### PR TITLE
Add Postgres extensions support

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -34,6 +34,8 @@ type Visitor interface {
 	VisitDropTable(*DropTableNode) error
 	// VisitDropType renders a DROP TYPE statement (PostgreSQL-specific)
 	VisitDropType(*DropTypeNode) error
+	// VisitExtension renders a CREATE EXTENSION statement (PostgreSQL-specific)
+	VisitExtension(*ExtensionNode) error
 }
 
 // DefaultValue represents different types of default values for table columns.

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -107,3 +107,11 @@ func (m *MockVisitor) VisitDropType(node *ast.DropTypeNode) error {
 	}
 	return nil
 }
+
+func (m *MockVisitor) VisitExtension(node *ast.ExtensionNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "Extension:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -321,6 +321,60 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Fields:     index.Columns,
 		Unique:     index.Unique,
 		Comment:    index.Comment,
+		// PostgreSQL-specific features
+		Type:      index.Type,
+		Condition: index.Condition,
+		Operator:  index.Operator,
+		TableName: index.Table,
+	}
+}
+
+// ToExtension converts an ast.ExtensionNode to a goschema.Extension for database extension definitions.
+//
+// This function extracts extension metadata from an AST node, including the extension name,
+// version requirements, and configuration options.
+//
+// # Parameters
+//
+//   - extension: The AST extension node containing extension metadata
+//
+// # Extension Features
+//
+//   - Extension name extraction (pg_trgm, postgis, etc.)
+//   - IF NOT EXISTS clause handling
+//   - Version specification support
+//   - Extension comments for documentation
+//
+// # Examples
+//
+// Basic extension:
+//
+//	extension := ast.NewExtension("pg_trgm").SetIfNotExists()
+//	extensionSchema := ToExtension(extension)
+//	// Results in: goschema.Extension{
+//	//   Name: "pg_trgm", IfNotExists: true
+//	// }
+//
+// Extension with version:
+//
+//	extension := ast.NewExtension("postgis").
+//		SetVersion("3.0").
+//		SetComment("Geographic data support")
+//	extensionSchema := ToExtension(extension)
+//	// Results in: goschema.Extension{
+//	//   Name: "postgis", Version: "3.0",
+//	//   Comment: "Geographic data support"
+//	// }
+//
+// # Return Value
+//
+// Returns a goschema.Extension with all extension attributes extracted from the AST node.
+func ToExtension(extension *ast.ExtensionNode) goschema.Extension {
+	return goschema.Extension{
+		Name:        extension.Name,
+		IfNotExists: extension.IfNotExists,
+		Version:     extension.Version,
+		Comment:     extension.Comment,
 	}
 }
 

--- a/core/goschema/postgresql_features_test.go
+++ b/core/goschema/postgresql_features_test.go
@@ -1,0 +1,302 @@
+package goschema_test
+
+import (
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+func TestParseExtensionComment(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected goschema.Extension
+	}{
+		{
+			name:    "basic extension",
+			comment: "//migrator:schema:extension name=\"pg_trgm\"",
+			expected: goschema.Extension{
+				Name:        "pg_trgm",
+				IfNotExists: false,
+				Version:     "",
+				Comment:     "",
+			},
+		},
+		{
+			name:    "extension with if_not_exists",
+			comment: "//migrator:schema:extension name=\"pg_trgm\" if_not_exists=\"true\"",
+			expected: goschema.Extension{
+				Name:        "pg_trgm",
+				IfNotExists: true,
+				Version:     "",
+				Comment:     "",
+			},
+		},
+		{
+			name:    "extension with version",
+			comment: "//migrator:schema:extension name=\"postgis\" version=\"3.0\" if_not_exists=\"true\"",
+			expected: goschema.Extension{
+				Name:        "postgis",
+				IfNotExists: true,
+				Version:     "3.0",
+				Comment:     "",
+			},
+		},
+		{
+			name:    "extension with comment",
+			comment: "//migrator:schema:extension name=\"btree_gin\" comment=\"Enable GIN indexes on btree types\"",
+			expected: goschema.Extension{
+				Name:        "btree_gin",
+				IfNotExists: false,
+				Version:     "",
+				Comment:     "Enable GIN indexes on btree types",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Create a temporary Go file with the extension annotation
+			content := `package test
+
+` + tt.comment + `
+type TestExtensions struct{}
+`
+
+			// Write to a temporary file and parse it
+			database := parseStringAsGoFile(c, content)
+
+			c.Assert(len(database.Extensions), qt.Equals, 1)
+			ext := database.Extensions[0]
+			c.Assert(ext.Name, qt.Equals, tt.expected.Name)
+			c.Assert(ext.IfNotExists, qt.Equals, tt.expected.IfNotExists)
+			c.Assert(ext.Version, qt.Equals, tt.expected.Version)
+			c.Assert(ext.Comment, qt.Equals, tt.expected.Comment)
+		})
+	}
+}
+
+func TestParseIndexWithPostgreSQLFeatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected goschema.Index
+	}{
+		{
+			name:    "GIN index",
+			comment: "//migrator:schema:index name=\"idx_tags\" fields=\"tags\" type=\"GIN\"",
+			expected: goschema.Index{
+				Name:      "idx_tags",
+				Fields:    []string{"tags"},
+				Type:      "GIN",
+				Condition: "",
+				Operator:  "",
+				TableName: "",
+			},
+		},
+		{
+			name:    "partial index",
+			comment: "//migrator:schema:index name=\"idx_active\" fields=\"status\" condition=\"deleted_at IS NULL\"",
+			expected: goschema.Index{
+				Name:      "idx_active",
+				Fields:    []string{"status"},
+				Type:      "",
+				Condition: "deleted_at IS NULL",
+				Operator:  "",
+				TableName: "",
+			},
+		},
+		{
+			name:    "trigram index",
+			comment: "//migrator:schema:index name=\"idx_name_trgm\" fields=\"name\" type=\"GIN\" ops=\"gin_trgm_ops\"",
+			expected: goschema.Index{
+				Name:      "idx_name_trgm",
+				Fields:    []string{"name"},
+				Type:      "GIN",
+				Condition: "",
+				Operator:  "gin_trgm_ops",
+				TableName: "",
+			},
+		},
+		{
+			name:    "cross-table index",
+			comment: "//migrator:schema:index name=\"idx_external\" fields=\"name,status\" table=\"products\"",
+			expected: goschema.Index{
+				Name:      "idx_external",
+				Fields:    []string{"name", "status"},
+				Type:      "",
+				Condition: "",
+				Operator:  "",
+				TableName: "products",
+			},
+		},
+		{
+			name:    "complex index with all features",
+			comment: "//migrator:schema:index name=\"idx_complex\" fields=\"name,tags\" type=\"GIN\" condition=\"status = 'active'\" table=\"products\"",
+			expected: goschema.Index{
+				Name:      "idx_complex",
+				Fields:    []string{"name", "tags"},
+				Type:      "GIN",
+				Condition: "status = 'active'",
+				Operator:  "",
+				TableName: "products",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Create a temporary Go file with the index annotation
+			content := `package test
+
+type TestEntity struct {
+	` + tt.comment + `
+	_ int
+}
+`
+
+			// Write to a temporary file and parse it
+			database := parseStringAsGoFile(c, content)
+
+			c.Assert(len(database.Indexes), qt.Equals, 1)
+			idx := database.Indexes[0]
+			c.Assert(idx.Name, qt.Equals, tt.expected.Name)
+			c.Assert(idx.Fields, qt.DeepEquals, tt.expected.Fields)
+			c.Assert(idx.Type, qt.Equals, tt.expected.Type)
+			c.Assert(idx.Condition, qt.Equals, tt.expected.Condition)
+			c.Assert(idx.Operator, qt.Equals, tt.expected.Operator)
+			c.Assert(idx.TableName, qt.Equals, tt.expected.TableName)
+		})
+	}
+}
+
+func TestParseMultipleExtensions(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package test
+
+//migrator:schema:extension name="pg_trgm" if_not_exists="true"
+//migrator:schema:extension name="btree_gin" if_not_exists="true"
+//migrator:schema:extension name="postgis" version="3.0"
+type DatabaseExtensions struct{}
+`
+
+	database := parseStringAsGoFile(c, content)
+
+	c.Assert(len(database.Extensions), qt.Equals, 3)
+
+	// Check pg_trgm
+	c.Assert(database.Extensions[0].Name, qt.Equals, "pg_trgm")
+	c.Assert(database.Extensions[0].IfNotExists, qt.IsTrue)
+
+	// Check btree_gin
+	c.Assert(database.Extensions[1].Name, qt.Equals, "btree_gin")
+	c.Assert(database.Extensions[1].IfNotExists, qt.IsTrue)
+
+	// Check postgis
+	c.Assert(database.Extensions[2].Name, qt.Equals, "postgis")
+	c.Assert(database.Extensions[2].Version, qt.Equals, "3.0")
+}
+
+func TestParseCompletePostgreSQLSchema(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package test
+
+//migrator:schema:extension name="pg_trgm" if_not_exists="true"
+//migrator:schema:extension name="btree_gin" if_not_exists="true"
+type DatabaseExtensions struct{}
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	//migrator:schema:field name="tags" type="JSONB"
+	Tags []string
+
+	//migrator:schema:field name="status" type="VARCHAR(50)"
+	Status string
+
+	// GIN index for JSONB field
+	//migrator:schema:index name="idx_product_tags" fields="tags" type="GIN"
+	_ int
+
+	// Partial index with condition
+	//migrator:schema:index name="idx_active_products" fields="status" condition="deleted_at IS NULL"
+	_ int
+
+	// Trigram similarity index
+	//migrator:schema:index name="idx_product_name_trgm" fields="name" type="GIN" ops="gin_trgm_ops"
+	_ int
+}
+`
+
+	database := parseStringAsGoFile(c, content)
+
+	// Check extensions
+	c.Assert(len(database.Extensions), qt.Equals, 2)
+	c.Assert(database.Extensions[0].Name, qt.Equals, "pg_trgm")
+	c.Assert(database.Extensions[1].Name, qt.Equals, "btree_gin")
+
+	// Check tables
+	c.Assert(len(database.Tables), qt.Equals, 1)
+	c.Assert(database.Tables[0].Name, qt.Equals, "products")
+	c.Assert(database.Tables[0].StructName, qt.Equals, "Product")
+
+	// Check fields
+	c.Assert(len(database.Fields), qt.Equals, 4)
+
+	// Check indexes
+	c.Assert(len(database.Indexes), qt.Equals, 3)
+
+	// Check GIN index
+	ginIndex := database.Indexes[0]
+	c.Assert(ginIndex.Name, qt.Equals, "idx_product_tags")
+	c.Assert(ginIndex.Type, qt.Equals, "GIN")
+	c.Assert(ginIndex.Fields, qt.DeepEquals, []string{"tags"})
+
+	// Check partial index
+	partialIndex := database.Indexes[1]
+	c.Assert(partialIndex.Name, qt.Equals, "idx_active_products")
+	c.Assert(partialIndex.Condition, qt.Equals, "deleted_at IS NULL")
+
+	// Check trigram index
+	trigramIndex := database.Indexes[2]
+	c.Assert(trigramIndex.Name, qt.Equals, "idx_product_name_trgm")
+	c.Assert(trigramIndex.Type, qt.Equals, "GIN")
+	c.Assert(trigramIndex.Operator, qt.Equals, "gin_trgm_ops")
+}
+
+// Helper function to parse a string as a Go file
+func parseStringAsGoFile(c *qt.C, content string) goschema.Database {
+	// Write content to a temporary file
+	tmpFile := c.TempDir() + "/test.go"
+	err := writeFile(tmpFile, content)
+	c.Assert(err, qt.IsNil)
+
+	// Parse the file
+	return goschema.ParseFile(tmpFile)
+}
+
+// Helper function to write content to a file
+func writeFile(filename, content string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	return err
+}

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -27,6 +27,7 @@ type Database struct {
 	Indexes        []Index
 	Enums          []Enum
 	EmbeddedFields []EmbeddedField
+	Extensions     []Extension         // PostgreSQL extensions (pg_trgm, postgis, etc.)
 	Dependencies   map[string][]string // table -> list of tables it depends on
 }
 
@@ -140,6 +141,22 @@ type Field struct {
 //	    // Multi-column index
 //	    //migrator:schema:index name="idx_users_email_status" fields="email,status"
 //	    _ int
+//
+//	    // PostgreSQL GIN index for JSONB fields
+//	    //migrator:schema:index name="idx_users_tags" fields="tags" type="GIN"
+//	    _ int
+//
+//	    // Partial index with WHERE condition
+//	    //migrator:schema:index name="idx_active_users" fields="status" condition="deleted_at IS NULL"
+//	    _ int
+//
+//	    // Trigram similarity index
+//	    //migrator:schema:index name="idx_users_name_trgm" fields="name" type="GIN" ops="gin_trgm_ops"
+//	    _ int
+//
+//	    // Cross-table index targeting specific table
+//	    //migrator:schema:index name="idx_products_name" fields="name" table="products"
+//	    _ int
 //	}
 type Index struct {
 	StructName string   // Name of the Go struct this index belongs to
@@ -147,6 +164,31 @@ type Index struct {
 	Fields     []string // Column names included in the index
 	Unique     bool     // Whether this is a unique index
 	Comment    string   // Index comment/description
+
+	// PostgreSQL-specific features
+	Type      string   // Index type: GIN, GIST, BTREE, HASH, etc.
+	Condition string   // WHERE clause for partial indexes
+	Operator  string   // Operator class (gin_trgm_ops, etc.)
+	TableName string   // Target table name (for cross-table association)
+}
+
+// Extension represents a PostgreSQL extension definition parsed from Go struct annotations.
+// Extensions enable additional functionality in PostgreSQL databases.
+//
+// Extension is created by parsing //migrator:schema:extension annotations:
+//
+//	// Enable trigram similarity search
+//	//migrator:schema:extension name="pg_trgm" if_not_exists="true"
+//	type DatabaseExtensions struct{}
+//
+//	// Enable PostGIS for geographic data
+//	//migrator:schema:extension name="postgis" version="3.0" if_not_exists="true"
+//	type GeoExtensions struct{}
+type Extension struct {
+	Name        string // Extension name (pg_trgm, postgis, etc.)
+	IfNotExists bool   // Whether to use IF NOT EXISTS clause
+	Version     string // Specific version requirement (optional)
+	Comment     string // Extension comment/description
 }
 
 // Table represents a database table configuration parsed from Go struct annotations.

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -166,10 +166,10 @@ type Index struct {
 	Comment    string   // Index comment/description
 
 	// PostgreSQL-specific features
-	Type      string   // Index type: GIN, GIST, BTREE, HASH, etc.
-	Condition string   // WHERE clause for partial indexes
-	Operator  string   // Operator class (gin_trgm_ops, etc.)
-	TableName string   // Target table name (for cross-table association)
+	Type      string // Index type: GIN, GIST, BTREE, HASH, etc.
+	Condition string // WHERE clause for partial indexes
+	Operator  string // Operator class (gin_trgm_ops, etc.)
+	TableName string // Target table name (for cross-table association)
 }
 
 // Extension represents a PostgreSQL extension definition parsed from Go struct annotations.

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -109,3 +109,15 @@ func (r *Renderer) VisitDropTable(node *ast.DropTableNode) error {
 func (r *Renderer) VisitDropType(node *ast.DropTypeNode) error {
 	return r.r.VisitDropType(node)
 }
+
+// VisitExtension renders CREATE EXTENSION statements for MariaDB (no-op)
+func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
+	// MariaDB doesn't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- Extension %s not supported in MariaDB: %s", node.Name, node.Comment)
+	} else {
+		r.w.WriteLinef("-- Extension %s not supported in MariaDB", node.Name)
+	}
+	return nil
+}

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -109,3 +109,15 @@ func (r *Renderer) VisitDropTable(node *ast.DropTableNode) error {
 func (r *Renderer) VisitDropType(node *ast.DropTypeNode) error {
 	return r.r.VisitDropType(node)
 }
+
+// VisitExtension renders CREATE EXTENSION statements for MySQL (no-op)
+func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
+	// MySQL doesn't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- Extension %s not supported in MySQL: %s", node.Name, node.Comment)
+	} else {
+		r.w.WriteLinef("-- Extension %s not supported in MySQL", node.Name)
+	}
+	return nil
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -465,3 +465,15 @@ func (r *Renderer) visitAlterTableWithEnums(node *ast.AlterTableNode, enums map[
 	r.w.WriteLine("")
 	return nil
 }
+
+// VisitExtension renders CREATE EXTENSION statements for MySQL-like databases (no-op)
+func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
+	// MySQL-like databases don't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- Extension %s not supported in %s: %s", node.Name, r.dialect, node.Comment)
+	} else {
+		r.w.WriteLinef("-- Extension %s not supported in %s", node.Name, r.dialect)
+	}
+	return nil
+}

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -1,0 +1,254 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer/dialects/postgres"
+)
+
+func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		index    *ast.IndexNode
+		expected string
+	}{
+		{
+			name: "basic BTREE index",
+			index: &ast.IndexNode{
+				Name:    "idx_users_email",
+				Table:   "users",
+				Columns: []string{"email"},
+				Unique:  false,
+			},
+			expected: "CREATE INDEX idx_users_email ON users (email);\n",
+		},
+		{
+			name: "unique index",
+			index: &ast.IndexNode{
+				Name:    "idx_users_username",
+				Table:   "users",
+				Columns: []string{"username"},
+				Unique:  true,
+			},
+			expected: "CREATE UNIQUE INDEX idx_users_username ON users (username);\n",
+		},
+		{
+			name: "GIN index",
+			index: &ast.IndexNode{
+				Name:    "idx_products_tags",
+				Table:   "products",
+				Columns: []string{"tags"},
+				Type:    "GIN",
+			},
+			expected: "CREATE INDEX idx_products_tags ON products USING GIN (tags);\n",
+		},
+		{
+			name: "partial index",
+			index: &ast.IndexNode{
+				Name:      "idx_active_users",
+				Table:     "users",
+				Columns:   []string{"status"},
+				Condition: "deleted_at IS NULL",
+			},
+			expected: "CREATE INDEX idx_active_users ON users (status) WHERE deleted_at IS NULL;\n",
+		},
+		{
+			name: "trigram index",
+			index: &ast.IndexNode{
+				Name:     "idx_users_name_trgm",
+				Table:    "users",
+				Columns:  []string{"name"},
+				Type:     "GIN",
+				Operator: "gin_trgm_ops",
+			},
+			expected: "CREATE INDEX idx_users_name_trgm ON users USING GIN (name gin_trgm_ops);\n",
+		},
+		{
+			name: "composite GIN index with condition",
+			index: &ast.IndexNode{
+				Name:      "idx_products_search",
+				Table:     "products",
+				Columns:   []string{"name", "tags"},
+				Type:      "GIN",
+				Condition: "status = 'active'",
+			},
+			expected: "CREATE INDEX idx_products_search ON products USING GIN (name, tags) WHERE status = 'active';\n",
+		},
+		{
+			name: "complex index with all features",
+			index: &ast.IndexNode{
+				Name:      "idx_complex",
+				Table:     "products",
+				Columns:   []string{"name", "description"},
+				Type:      "GIN",
+				Operator:  "gin_trgm_ops",
+				Condition: "status = 'published' AND deleted_at IS NULL",
+				Unique:    false,
+			},
+			expected: "CREATE INDEX idx_complex ON products USING GIN (name gin_trgm_ops, description gin_trgm_ops) WHERE status = 'published' AND deleted_at IS NULL;\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			renderer := postgres.New()
+			sql, err := renderer.Render(tt.index)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestPostgreSQLRenderer_VisitExtension(t *testing.T) {
+	tests := []struct {
+		name      string
+		extension *ast.ExtensionNode
+		expected  string
+	}{
+		{
+			name: "basic extension",
+			extension: &ast.ExtensionNode{
+				Name: "pg_trgm",
+			},
+			expected: "CREATE EXTENSION pg_trgm;\n",
+		},
+		{
+			name: "extension with IF NOT EXISTS",
+			extension: &ast.ExtensionNode{
+				Name:        "pg_trgm",
+				IfNotExists: true,
+			},
+			expected: "CREATE EXTENSION IF NOT EXISTS pg_trgm;\n",
+		},
+		{
+			name: "extension with version",
+			extension: &ast.ExtensionNode{
+				Name:    "postgis",
+				Version: "3.0",
+			},
+			expected: "CREATE EXTENSION postgis VERSION '3.0';\n",
+		},
+		{
+			name: "extension with comment",
+			extension: &ast.ExtensionNode{
+				Name:    "btree_gin",
+				Comment: "Enable GIN indexes on btree types",
+			},
+			expected: "-- Enable GIN indexes on btree types\nCREATE EXTENSION btree_gin;\n",
+		},
+		{
+			name: "extension with all features",
+			extension: &ast.ExtensionNode{
+				Name:        "postgis",
+				IfNotExists: true,
+				Version:     "3.0",
+				Comment:     "Geographic data support",
+			},
+			expected: "-- Geographic data support\nCREATE EXTENSION IF NOT EXISTS postgis VERSION '3.0';\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			renderer := postgres.New()
+			sql, err := renderer.Render(tt.extension)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestPostgreSQLRenderer_CompleteSchema(t *testing.T) {
+	c := qt.New(t)
+
+	// Create a complete schema with extensions, tables, and indexes
+	renderer := postgres.New()
+
+	// Extension
+	extension := &ast.ExtensionNode{
+		Name:        "pg_trgm",
+		IfNotExists: true,
+		Comment:     "Enable trigram similarity search",
+	}
+
+	// Table
+	table := ast.NewCreateTable("products").
+		AddColumn(
+			ast.NewColumn("id", "SERIAL").
+				SetPrimary().
+				SetNotNull(),
+		).
+		AddColumn(
+			ast.NewColumn("name", "VARCHAR(255)").
+				SetNotNull(),
+		).
+		AddColumn(
+			ast.NewColumn("tags", "JSONB"),
+		).
+		AddColumn(
+			ast.NewColumn("status", "VARCHAR(50)"),
+		).
+		AddColumn(
+			ast.NewColumn("deleted_at", "TIMESTAMP"),
+		)
+
+	// Indexes
+	ginIndex := &ast.IndexNode{
+		Name:    "idx_products_tags",
+		Table:   "products",
+		Columns: []string{"tags"},
+		Type:    "GIN",
+	}
+
+	partialIndex := &ast.IndexNode{
+		Name:      "idx_active_products",
+		Table:     "products",
+		Columns:   []string{"status"},
+		Condition: "deleted_at IS NULL",
+	}
+
+	trigramIndex := &ast.IndexNode{
+		Name:     "idx_products_name_trgm",
+		Table:    "products",
+		Columns:  []string{"name"},
+		Type:     "GIN",
+		Operator: "gin_trgm_ops",
+	}
+
+	// Render each component
+	extensionSQL, err := renderer.Render(extension)
+	c.Assert(err, qt.IsNil)
+
+	tableSQL, err := renderer.Render(table)
+	c.Assert(err, qt.IsNil)
+
+	ginIndexSQL, err := renderer.Render(ginIndex)
+	c.Assert(err, qt.IsNil)
+
+	partialIndexSQL, err := renderer.Render(partialIndex)
+	c.Assert(err, qt.IsNil)
+
+	trigramIndexSQL, err := renderer.Render(trigramIndex)
+	c.Assert(err, qt.IsNil)
+
+	// Verify the generated SQL
+	c.Assert(extensionSQL, qt.Contains, "CREATE EXTENSION IF NOT EXISTS pg_trgm")
+	c.Assert(extensionSQL, qt.Contains, "-- Enable trigram similarity search")
+
+	c.Assert(tableSQL, qt.Contains, "CREATE TABLE products")
+	c.Assert(tableSQL, qt.Contains, "id SERIAL PRIMARY KEY NOT NULL")
+	c.Assert(tableSQL, qt.Contains, "tags JSONB")
+
+	c.Assert(ginIndexSQL, qt.Equals, "CREATE INDEX idx_products_tags ON products USING GIN (tags);\n")
+	c.Assert(partialIndexSQL, qt.Equals, "CREATE INDEX idx_active_products ON products (status) WHERE deleted_at IS NULL;\n")
+	c.Assert(trigramIndexSQL, qt.Equals, "CREATE INDEX idx_products_name_trgm ON products USING GIN (name gin_trgm_ops);\n")
+}

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -250,6 +250,7 @@ func (a *SchemaAnalyzer) VisitAlterType(node *ast.AlterTypeNode) error   { retur
 func (a *SchemaAnalyzer) VisitComment(node *ast.CommentNode) error       { return nil }
 func (a *SchemaAnalyzer) VisitDropTable(node *ast.DropTableNode) error   { return nil }
 func (a *SchemaAnalyzer) VisitDropType(node *ast.DropTypeNode) error     { return nil }
+func (a *SchemaAnalyzer) VisitExtension(node *ast.ExtensionNode) error   { return nil }
 
 // AuditTransformer adds audit columns to all tables
 type AuditTransformer struct{}


### PR DESCRIPTION
This pull request introduces support for PostgreSQL-specific features, including extensions and advanced index capabilities, across the codebase. It adds new functionality for handling PostgreSQL extensions and enhances the handling of PostgreSQL-specific index attributes like partial indexes and operator classes. The changes span multiple files, including AST nodes, schema conversion, and schema parsing.

### PostgreSQL Extension Support:

* Added `ExtensionNode` to represent PostgreSQL extensions, including attributes for name, version, comments, and `IF NOT EXISTS` clause. (`core/ast/nodes.go`, [core/ast/nodes.goL341-R414](diffhunk://#diff-6345406bdad7771029ad037f386402a28137b93f661892154fc7c215bc7bab7eL341-R414))
* Implemented `VisitExtension` in the `Visitor` interface and its mock counterpart for AST traversal. (`core/ast/ast.go`, [[1]](diffhunk://#diff-189ad5c839ba9b79f291b26aed6691d0a20141e3e478e1c12b14a52f1f4700a8R37-R38); `core/ast/mocks/visitor.go`, [[2]](diffhunk://#diff-9becd4fa6c267200d5e88662a4e6b798ba638c6bc13225c6b14cf79cd25d71ecR110-R117)
* Added conversion functions `FromExtension` and `ToExtension` to translate between schema definitions and AST nodes for extensions. (`core/convert/fromschema/fromschema.go`, [[1]](diffhunk://#diff-6a0b921863e9d8f3d9debb16b77a1194744f773ee39a7a4e1d8df4ed94596478R492-R569); `core/convert/toschema/toschema.go`, [[2]](diffhunk://#diff-a45ffcbdd343e2b0b5d103f975f841055efb37bf358cbf3326b3da898330609fR324-R377)
* Extended schema parsing to handle extension comments and directives. (`core/goschema/parser.go`, [[1]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9R95-R120) [[2]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9L118-R172) [[3]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9R189)

### Enhanced Index Handling:

* Updated `IndexNode` to include PostgreSQL-specific attributes like `Condition` (partial indexes) and `Operator` (operator classes). (`core/ast/nodes.go`, [core/ast/nodes.goL341-R414](diffhunk://#diff-6345406bdad7771029ad037f386402a28137b93f661892154fc7c215bc7bab7eL341-R414))
* Enhanced `FromIndex` and `ToIndex` functions to handle PostgreSQL-specific index attributes. (`core/convert/fromschema/fromschema.go`, [[1]](diffhunk://#diff-6a0b921863e9d8f3d9debb16b77a1194744f773ee39a7a4e1d8df4ed94596478R492-R569); `core/convert/toschema/toschema.go`, [[2]](diffhunk://#diff-a45ffcbdd343e2b0b5d103f975f841055efb37bf358cbf3326b3da898330609fR324-R377)
* Added `FromIndexWithTableMapping` for resolving table names in index definitions using a struct-to-table mapping. (`core/convert/fromschema/fromschema.go`, [core/convert/fromschema/fromschema.goL621-R771](diffhunk://#diff-6a0b921863e9d8f3d9debb16b77a1194744f773ee39a7a4e1d8df4ed94596478L621-R771))

### Schema Parsing Enhancements:

* Modified schema parsing logic to include PostgreSQL-specific features for indexes and extensions. (`core/goschema/parser.go`, [[1]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9R95-R120) [[2]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9L118-R172) [[3]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9R189) [[4]](diffhunk://#diff-6fd01fdcc13c40633ca2ee41d243d193410a223853073c7b4bb9c8bd7342bfc9R228)
* Introduced `createStructToTableMap` for resolving table names during schema parsing. (`core/convert/fromschema/fromschema.go`, [core/convert/fromschema/fromschema.goL621-R771](diffhunk://#diff-6a0b921863e9d8f3d9debb16b77a1194744f773ee39a7a4e1d8df4ed94596478L621-R771))

These changes collectively improve support for PostgreSQL features, enabling more advanced database schema generation and parsing capabilities.