### PR TITLE
Improve PG extension support

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -36,6 +36,8 @@ type Visitor interface {
 	VisitDropType(*DropTypeNode) error
 	// VisitExtension renders a CREATE EXTENSION statement (PostgreSQL-specific)
 	VisitExtension(*ExtensionNode) error
+	// VisitDropExtension renders a DROP EXTENSION statement (PostgreSQL-specific)
+	VisitDropExtension(*DropExtensionNode) error
 }
 
 // DefaultValue represents different types of default values for table columns.

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -115,3 +115,11 @@ func (m *MockVisitor) VisitExtension(node *ast.ExtensionNode) error {
 	}
 	return nil
 }
+
+func (m *MockVisitor) VisitDropExtension(node *ast.DropExtensionNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "DropExtension:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -414,6 +414,78 @@ func (n *ExtensionNode) SetComment(comment string) *ExtensionNode {
 	return n
 }
 
+// DropExtensionNode represents a DROP EXTENSION statement for PostgreSQL.
+//
+// This node is used to remove PostgreSQL extensions from the database.
+// Extension removal can be dangerous as it may break existing functionality
+// that depends on the extension's features.
+type DropExtensionNode struct {
+	// Name is the extension name to drop (pg_trgm, postgis, etc.)
+	Name string
+	// IfExists indicates whether to use IF EXISTS clause
+	IfExists bool
+	// Cascade indicates whether to use CASCADE option (removes dependent objects)
+	Cascade bool
+	// Comment is an optional comment for the drop operation
+	Comment string
+}
+
+// NewDropExtension creates a new drop extension node with the specified name.
+//
+// Example:
+//
+//	dropExt := NewDropExtension("pg_trgm")
+//	dropExt := NewDropExtension("postgis").SetIfExists().SetCascade()
+func NewDropExtension(name string) *DropExtensionNode {
+	return &DropExtensionNode{
+		Name:     name,
+		IfExists: false,
+		Cascade:  false,
+	}
+}
+
+// SetIfExists marks the drop extension to use IF EXISTS clause.
+//
+// This prevents errors if the extension doesn't exist.
+//
+// Example:
+//
+//	dropExt.SetIfExists()
+func (n *DropExtensionNode) SetIfExists() *DropExtensionNode {
+	n.IfExists = true
+	return n
+}
+
+// SetCascade marks the drop extension to use CASCADE option.
+//
+// This removes all objects that depend on the extension.
+// Use with extreme caution as it can remove user data.
+//
+// Example:
+//
+//	dropExt.SetCascade()
+func (n *DropExtensionNode) SetCascade() *DropExtensionNode {
+	n.Cascade = true
+	return n
+}
+
+// SetComment sets a comment for the DROP EXTENSION operation.
+//
+// This comment can be used for documentation or warnings.
+//
+// Example:
+//
+//	dropExt.SetComment("Remove unused extension")
+func (n *DropExtensionNode) SetComment(comment string) *DropExtensionNode {
+	n.Comment = comment
+	return n
+}
+
+// Accept implements the Node interface for DropExtensionNode.
+func (n *DropExtensionNode) Accept(visitor Visitor) error {
+	return visitor.VisitDropExtension(n)
+}
+
 // NewIndex creates a new index node with the specified name, table, and columns.
 //
 // Example:

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -121,3 +121,15 @@ func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
 	}
 	return nil
 }
+
+// VisitDropExtension renders DROP EXTENSION statements for MariaDB (no-op)
+func (r *Renderer) VisitDropExtension(node *ast.DropExtensionNode) error {
+	// MariaDB doesn't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in MariaDB: %s", node.Name, node.Comment)
+	} else {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in MariaDB", node.Name)
+	}
+	return nil
+}

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -121,3 +121,15 @@ func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
 	}
 	return nil
 }
+
+// VisitDropExtension renders DROP EXTENSION statements for MySQL (no-op)
+func (r *Renderer) VisitDropExtension(node *ast.DropExtensionNode) error {
+	// MySQL doesn't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in MySQL: %s", node.Name, node.Comment)
+	} else {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in MySQL", node.Name)
+	}
+	return nil
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -477,3 +477,15 @@ func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
 	}
 	return nil
 }
+
+// VisitDropExtension renders DROP EXTENSION statements for MySQL-like databases (no-op)
+func (r *Renderer) VisitDropExtension(node *ast.DropExtensionNode) error {
+	// MySQL-like databases don't support extensions like PostgreSQL
+	// Add a comment to indicate this feature is not supported
+	if node.Comment != "" {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in %s: %s", node.Name, r.dialect, node.Comment)
+	} else {
+		r.w.WriteLinef("-- DROP EXTENSION %s not supported in %s", node.Name, r.dialect)
+	}
+	return nil
+}

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -618,3 +618,28 @@ func (r *Renderer) renderPostgreSQLModifyColumn(tableName string, column *ast.Co
 		r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;", tableName, column.Name, column.Default.Expression)
 	}
 }
+
+func (r *Renderer) VisitDropExtension(node *ast.DropExtensionNode) error {
+	var parts []string
+
+	parts = append(parts, "DROP EXTENSION")
+
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+
+	parts = append(parts, node.Name)
+
+	if node.Cascade {
+		parts = append(parts, "CASCADE")
+	}
+
+	// Add comment if provided
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+
+	return nil
+}

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -57,6 +57,13 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Constraints = constraints
 
+	// Read extensions (PostgreSQL-specific)
+	extensions, err := r.readExtensions()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read extensions: %w", err)
+	}
+	schema.Extensions = extensions
+
 	// Enhance tables with constraint information
 	r.enhanceTablesWithConstraints(schema.Tables, schema.Constraints)
 
@@ -342,6 +349,61 @@ func (r *Reader) readConstraints() ([]types.DBConstraint, error) {
 	}
 
 	return constraints, nil
+}
+
+// readExtensions reads all PostgreSQL extensions installed in the database
+func (r *Reader) readExtensions() ([]types.DBExtension, error) {
+	extensionsQuery := `
+		SELECT
+			e.extname AS extension_name,
+			e.extversion AS installed_version,
+			n.nspname AS schema_name,
+			e.extrelocatable AS relocatable,
+			obj_description(e.oid, 'pg_extension') AS comment,
+			av.version AS default_version
+		FROM pg_extension e
+		JOIN pg_namespace n ON n.oid = e.extnamespace
+		LEFT JOIN pg_available_extensions av ON av.name = e.extname
+		ORDER BY e.extname`
+
+	rows, err := r.db.Query(extensionsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query extensions: %w", err)
+	}
+	defer rows.Close()
+
+	var extensions []types.DBExtension
+	for rows.Next() {
+		var ext types.DBExtension
+		var comment, defaultVersion sql.NullString
+
+		err := rows.Scan(
+			&ext.Name,
+			&ext.Version,
+			&ext.Schema,
+			&ext.Relocatable,
+			&comment,
+			&defaultVersion,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan extension: %w", err)
+		}
+
+		// Set optional fields
+		if comment.Valid {
+			ext.Comment = &comment.String
+		}
+		if defaultVersion.Valid {
+			ext.DefaultVersion = &defaultVersion.String
+		}
+
+		// Set installed version (same as version for installed extensions)
+		ext.InstalledVersion = &ext.Version
+
+		extensions = append(extensions, ext)
+	}
+
+	return extensions, nil
 }
 
 // enhanceTablesWithConstraints adds constraint information to table columns

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -6,6 +6,7 @@ type DBSchema struct {
 	Enums       []DBEnum       `json:"enums"`
 	Indexes     []DBIndex      `json:"indexes"`
 	Constraints []DBConstraint `json:"constraints"`
+	Extensions  []DBExtension  `json:"extensions"` // PostgreSQL extensions
 }
 
 // DBTable represents a database table
@@ -60,6 +61,17 @@ type DBConstraint struct {
 	DeleteRule    *string `json:"delete_rule"`    // CASCADE, RESTRICT, etc.
 	UpdateRule    *string `json:"update_rule"`    // CASCADE, RESTRICT, etc.
 	CheckClause   *string `json:"check_clause"`   // For CHECK constraints
+}
+
+// DBExtension represents a PostgreSQL extension installed in the database
+type DBExtension struct {
+	Name             string  `json:"name"`              // Extension name (pg_trgm, postgis, etc.)
+	Version          string  `json:"version"`           // Installed version
+	Schema           string  `json:"schema"`            // Schema where extension is installed
+	Relocatable      bool    `json:"relocatable"`       // Whether extension can be moved between schemas
+	Comment          *string `json:"comment"`           // Extension comment/description
+	DefaultVersion   *string `json:"default_version"`   // Default version available
+	InstalledVersion *string `json:"installed_version"` // Currently installed version (may differ from default)
 }
 
 // DBInfo contains connection and metadata information

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -243,14 +243,15 @@ func (a *SchemaAnalyzer) VisitIndex(node *ast.IndexNode) error {
 	a.IndexCount++
 	return nil
 }
-func (a *SchemaAnalyzer) VisitDropIndex(node *ast.DropIndexNode) error   { return nil }
-func (a *SchemaAnalyzer) VisitEnum(node *ast.EnumNode) error             { return nil }
-func (a *SchemaAnalyzer) VisitCreateType(node *ast.CreateTypeNode) error { return nil }
-func (a *SchemaAnalyzer) VisitAlterType(node *ast.AlterTypeNode) error   { return nil }
-func (a *SchemaAnalyzer) VisitComment(node *ast.CommentNode) error       { return nil }
-func (a *SchemaAnalyzer) VisitDropTable(node *ast.DropTableNode) error   { return nil }
-func (a *SchemaAnalyzer) VisitDropType(node *ast.DropTypeNode) error     { return nil }
-func (a *SchemaAnalyzer) VisitExtension(node *ast.ExtensionNode) error   { return nil }
+func (a *SchemaAnalyzer) VisitDropIndex(node *ast.DropIndexNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitEnum(node *ast.EnumNode) error                   { return nil }
+func (a *SchemaAnalyzer) VisitCreateType(node *ast.CreateTypeNode) error       { return nil }
+func (a *SchemaAnalyzer) VisitAlterType(node *ast.AlterTypeNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitComment(node *ast.CommentNode) error             { return nil }
+func (a *SchemaAnalyzer) VisitDropTable(node *ast.DropTableNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitDropType(node *ast.DropTypeNode) error           { return nil }
+func (a *SchemaAnalyzer) VisitExtension(node *ast.ExtensionNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitDropExtension(node *ast.DropExtensionNode) error { return nil }
 
 // AuditTransformer adds audit columns to all tables
 type AuditTransformer struct{}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -227,17 +227,18 @@ func (p *Planner) modifyExistingTables(result []ast.Node, diff *types.SchemaDiff
 }
 
 func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	// Create a mapping from struct names to table names for proper index table resolution
+	structToTableMap := make(map[string]string)
+	for _, table := range generated.Tables {
+		structToTableMap[table.StructName] = table.Name
+	}
+
 	for _, indexName := range diff.IndexesAdded {
 		// Find the index definition
 		for _, idx := range generated.Indexes {
 			if idx.Name == indexName {
-				indexNode := ast.NewIndex(idx.Name, idx.StructName, idx.Fields...)
-				if idx.Unique {
-					indexNode.Unique = true
-				}
-				if idx.Comment != "" {
-					indexNode.Comment = idx.Comment
-				}
+				// Use enhanced index creation with PostgreSQL features
+				indexNode := fromschema.FromIndexWithTableMapping(idx, structToTableMap)
 				result = append(result, indexNode)
 				break
 			}
@@ -359,7 +360,10 @@ func (p *Planner) removeEnums(result []ast.Node, diff *types.SchemaDiff) []ast.N
 func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	var result []ast.Node
 
-	// 1. Add new enums first (PostgreSQL requires enum types to exist before tables use them)
+	// 0. Add new extensions first (PostgreSQL extensions should be created before other objects)
+	result = p.addNewExtensions(result, diff, generated)
+
+	// 1. Add new enums (PostgreSQL requires enum types to exist before tables use them)
 	result = p.addNewEnums(result, diff, generated)
 
 	// 2. Modify existing enums (add values only - PostgreSQL doesn't support removing enum values easily)
@@ -383,5 +387,51 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 8. Remove enums (dangerous!)
 	result = p.removeEnums(result, diff)
 
+	// 9. Remove extensions (dangerous!)
+	result = p.removeExtensions(result, diff)
+
+	return result
+}
+
+func (p *Planner) addNewExtensions(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, extensionName := range diff.ExtensionsAdded {
+		// Find the extension definition
+		for _, ext := range generated.Extensions {
+			if ext.Name == extensionName {
+				extensionNode := fromschema.FromExtension(ext)
+				result = append(result, extensionNode)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeExtensions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	// Generate DROP EXTENSION statements with comprehensive safety warnings
+	// Extension removal is potentially dangerous and requires careful consideration
+	for _, extensionName := range diff.ExtensionsRemoved {
+		// Add comprehensive warning comments before each DROP EXTENSION statement
+		warningComment1 := ast.NewComment(fmt.Sprintf("WARNING: Removing extension '%s' may break existing functionality that depends on it", extensionName))
+		warningComment2 := ast.NewComment("Consider reviewing all database objects that use this extension before proceeding")
+		warningComment3 := ast.NewComment("Extension removal may cascade to dependent objects - review carefully")
+
+		result = append(result, warningComment1)
+		result = append(result, warningComment2)
+		result = append(result, warningComment3)
+
+		// Create DROP EXTENSION statement with IF EXISTS for safety
+		dropExtension := ast.NewDropExtension(extensionName).
+			SetIfExists().
+			SetComment(fmt.Sprintf("Remove extension '%s' as it's no longer required by the schema", extensionName))
+
+		result = append(result, dropExtension)
+
+		// Add blank line for readability between extension removals
+		if len(diff.ExtensionsRemoved) > 1 {
+			blankLine := ast.NewComment("")
+			result = append(result, blankLine)
+		}
+	}
 	return result
 }

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -410,7 +410,7 @@ func (p *Planner) addNewExtensions(result []ast.Node, diff *types.SchemaDiff, ge
 func (p *Planner) removeExtensions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	// Generate DROP EXTENSION statements with comprehensive safety warnings
 	// Extension removal is potentially dangerous and requires careful consideration
-	for _, extensionName := range diff.ExtensionsRemoved {
+	for i, extensionName := range diff.ExtensionsRemoved {
 		// Add comprehensive warning comments before each DROP EXTENSION statement
 		warningComment1 := ast.NewComment(fmt.Sprintf("WARNING: Removing extension '%s' may break existing functionality that depends on it", extensionName))
 		warningComment2 := ast.NewComment("Consider reviewing all database objects that use this extension before proceeding")
@@ -427,8 +427,8 @@ func (p *Planner) removeExtensions(result []ast.Node, diff *types.SchemaDiff) []
 
 		result = append(result, dropExtension)
 
-		// Add blank line for readability between extension removals
-		if len(diff.ExtensionsRemoved) > 1 {
+		// Add blank line for readability between extension removals (not after the last one)
+		if i < len(diff.ExtensionsRemoved)-1 {
 			blankLine := ast.NewComment("")
 			result = append(result, blankLine)
 		}

--- a/migration/schemadiff/internal/compare/extensions_test.go
+++ b/migration/schemadiff/internal/compare/extensions_test.go
@@ -1,0 +1,303 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestExtensions(t *testing.T) {
+	tests := []struct {
+		name                string
+		generatedExtensions []goschema.Extension
+		databaseExtensions  []types.DBExtension
+		expectedAdded       []string
+		expectedRemoved     []string
+	}{
+		{
+			name:                "no extensions in either schema",
+			generatedExtensions: []goschema.Extension{},
+			databaseExtensions:  []types.DBExtension{},
+			expectedAdded:       []string{},
+			expectedRemoved:     []string{},
+		},
+		{
+			name: "extension needs to be added",
+			generatedExtensions: []goschema.Extension{
+				{Name: "pg_trgm", IfNotExists: true},
+			},
+			databaseExtensions: []types.DBExtension{},
+			expectedAdded:      []string{"pg_trgm"},
+			expectedRemoved:    []string{},
+		},
+		{
+			name:                "extension needs to be removed",
+			generatedExtensions: []goschema.Extension{},
+			databaseExtensions: []types.DBExtension{
+				{Name: "btree_gin", Version: "1.3", Schema: "public"},
+			},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{"btree_gin"},
+		},
+		{
+			name: "extension already exists - no changes",
+			generatedExtensions: []goschema.Extension{
+				{Name: "pg_trgm", IfNotExists: true},
+			},
+			databaseExtensions: []types.DBExtension{
+				{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+			},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{},
+		},
+		{
+			name: "multiple extensions - mixed operations",
+			generatedExtensions: []goschema.Extension{
+				{Name: "pg_trgm", IfNotExists: true},
+				{Name: "btree_gin", IfNotExists: true},
+				{Name: "postgis", Version: "3.0"},
+			},
+			databaseExtensions: []types.DBExtension{
+				{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+				{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
+			},
+			expectedAdded:   []string{"btree_gin", "postgis"},
+			expectedRemoved: []string{"uuid-ossp"},
+		},
+		{
+			name: "extensions with different versions - no version comparison",
+			generatedExtensions: []goschema.Extension{
+				{Name: "postgis", Version: "3.1"},
+			},
+			databaseExtensions: []types.DBExtension{
+				{Name: "postgis", Version: "3.0", Schema: "public"},
+			},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{},
+		},
+		{
+			name: "sorted output verification",
+			generatedExtensions: []goschema.Extension{
+				{Name: "z_extension", IfNotExists: true},
+				{Name: "a_extension", IfNotExists: true},
+				{Name: "m_extension", IfNotExists: true},
+			},
+			databaseExtensions: []types.DBExtension{
+				{Name: "z_old_ext", Version: "1.0", Schema: "public"},
+				{Name: "a_old_ext", Version: "1.0", Schema: "public"},
+			},
+			expectedAdded:   []string{"a_extension", "m_extension", "z_extension"},
+			expectedRemoved: []string{"a_old_ext", "z_old_ext"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Create test schemas
+			generated := &goschema.Database{
+				Extensions: tt.generatedExtensions,
+			}
+
+			database := &types.DBSchema{
+				Extensions: tt.databaseExtensions,
+			}
+
+			// Create empty diff to populate
+			diff := &difftypes.SchemaDiff{}
+
+			// Run the comparison
+			compare.Extensions(generated, database, diff)
+
+			// Verify results
+			c.Assert(diff.ExtensionsAdded, qt.DeepEquals, tt.expectedAdded)
+			c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, tt.expectedRemoved)
+		})
+	}
+}
+
+func TestExtensions_RealWorldScenarios(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		setup       func() (*goschema.Database, *types.DBSchema)
+		verify      func(c *qt.C, diff *difftypes.SchemaDiff)
+	}{
+		{
+			name:        "fresh database setup",
+			description: "Setting up PostgreSQL extensions on a fresh database",
+			setup: func() (*goschema.Database, *types.DBSchema) {
+				generated := &goschema.Database{
+					Extensions: []goschema.Extension{
+						{Name: "pg_trgm", IfNotExists: true, Comment: "Trigram similarity"},
+						{Name: "btree_gin", IfNotExists: true, Comment: "GIN indexes for btree"},
+						{Name: "postgis", Version: "3.0", Comment: "Geographic data"},
+					},
+				}
+				database := &types.DBSchema{
+					Extensions: []types.DBExtension{}, // Fresh database
+				}
+				return generated, database
+			},
+			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 3)
+				c.Assert(diff.ExtensionsAdded, qt.Contains, "pg_trgm")
+				c.Assert(diff.ExtensionsAdded, qt.Contains, "btree_gin")
+				c.Assert(diff.ExtensionsAdded, qt.Contains, "postgis")
+				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 0)
+			},
+		},
+		{
+			name:        "production database cleanup",
+			description: "Removing unused extensions from production database",
+			setup: func() (*goschema.Database, *types.DBSchema) {
+				generated := &goschema.Database{
+					Extensions: []goschema.Extension{
+						{Name: "pg_trgm", IfNotExists: true},
+					},
+				}
+				database := &types.DBSchema{
+					Extensions: []types.DBExtension{
+						{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+						{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
+						{Name: "postgis", Version: "3.0", Schema: "public"},
+						{Name: "btree_gin", Version: "1.3", Schema: "public"},
+					},
+				}
+				return generated, database
+			},
+			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 0)
+				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 3)
+				c.Assert(diff.ExtensionsRemoved, qt.Contains, "uuid-ossp")
+				c.Assert(diff.ExtensionsRemoved, qt.Contains, "postgis")
+				c.Assert(diff.ExtensionsRemoved, qt.Contains, "btree_gin")
+			},
+		},
+		{
+			name:        "incremental extension addition",
+			description: "Adding new extensions to existing setup",
+			setup: func() (*goschema.Database, *types.DBSchema) {
+				generated := &goschema.Database{
+					Extensions: []goschema.Extension{
+						{Name: "pg_trgm", IfNotExists: true},
+						{Name: "btree_gin", IfNotExists: true},
+						{Name: "postgis", Version: "3.1"},
+						{Name: "uuid-ossp", IfNotExists: true},
+					},
+				}
+				database := &types.DBSchema{
+					Extensions: []types.DBExtension{
+						{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+						{Name: "btree_gin", Version: "1.3", Schema: "public"},
+					},
+				}
+				return generated, database
+			},
+			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 2)
+				c.Assert(diff.ExtensionsAdded, qt.Contains, "postgis")
+				c.Assert(diff.ExtensionsAdded, qt.Contains, "uuid-ossp")
+				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Setup test scenario
+			generated, database := tt.setup()
+
+			// Create empty diff to populate
+			diff := &difftypes.SchemaDiff{}
+
+			// Run the comparison
+			compare.Extensions(generated, database, diff)
+
+			// Verify results using custom verification function
+			tt.verify(c, diff)
+		})
+	}
+}
+
+func TestExtensions_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		generated   *goschema.Database
+		database    *types.DBSchema
+		expectPanic bool
+	}{
+		{
+			name:        "nil generated extensions",
+			description: "Handle nil extensions slice in generated schema",
+			generated: &goschema.Database{
+				Extensions: nil,
+			},
+			database: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+				},
+			},
+			expectPanic: false,
+		},
+		{
+			name:        "nil database extensions",
+			description: "Handle nil extensions slice in database schema",
+			generated: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "pg_trgm", IfNotExists: true},
+				},
+			},
+			database: &types.DBSchema{
+				Extensions: nil,
+			},
+			expectPanic: false,
+		},
+		{
+			name:        "empty extension names",
+			description: "Handle extensions with empty names gracefully",
+			generated: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "", IfNotExists: true},
+					{Name: "pg_trgm", IfNotExists: true},
+				},
+			},
+			database: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{Name: "", Version: "1.0", Schema: "public"},
+				},
+			},
+			expectPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Create empty diff to populate
+			diff := &difftypes.SchemaDiff{}
+
+			// Run the comparison and check for panics
+			if tt.expectPanic {
+				c.Assert(func() {
+					compare.Extensions(tt.generated, tt.database, diff)
+				}, qt.PanicMatches, ".*")
+			} else {
+				// Should not panic
+				compare.Extensions(tt.generated, tt.database, diff)
+				// Basic sanity check - diff should be populated
+				c.Assert(diff, qt.IsNotNil)
+			}
+		})
+	}
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -19,5 +19,8 @@ func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.
 	// Compare database index definitions
 	compare.Indexes(generated, database, diff)
 
+	// Compare PostgreSQL extensions
+	compare.Extensions(generated, database, diff)
+
 	return diff
 }

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -64,6 +64,14 @@ type SchemaDiff struct {
 	// IndexesRemoved contains names of indexes that exist in the current database
 	// but not in the target schema (safe operation - no data loss)
 	IndexesRemoved []string `json:"indexes_removed"`
+
+	// ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
+	// but not in the current database schema
+	ExtensionsAdded []string `json:"extensions_added"`
+
+	// ExtensionsRemoved contains names of PostgreSQL extensions that exist in the current database
+	// but not in the target schema (potentially dangerous - may break existing functionality)
+	ExtensionsRemoved []string `json:"extensions_removed"`
 }
 
 // HasChanges returns true if the diff contains any schema changes requiring migration.
@@ -103,7 +111,9 @@ func (d *SchemaDiff) HasChanges() bool {
 		len(d.EnumsRemoved) > 0 ||
 		len(d.EnumsModified) > 0 ||
 		len(d.IndexesAdded) > 0 ||
-		len(d.IndexesRemoved) > 0
+		len(d.IndexesRemoved) > 0 ||
+		len(d.ExtensionsAdded) > 0 ||
+		len(d.ExtensionsRemoved) > 0
 }
 
 // TableDiff represents structural differences within a specific database table.

--- a/migration/schemadiff/types/types_test.go
+++ b/migration/schemadiff/types/types_test.go
@@ -79,6 +79,20 @@ func TestSchemaDiff_HasChanges(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "extensions added",
+			diff: &types.SchemaDiff{
+				ExtensionsAdded: []string{"pg_trgm"},
+			},
+			expected: true,
+		},
+		{
+			name: "extensions removed",
+			diff: &types.SchemaDiff{
+				ExtensionsRemoved: []string{"btree_gin"},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request introduces comprehensive support for PostgreSQL extensions, including the ability to manage extensions through schema comparison, migration generation, and rendering. It adds functionality to handle `DROP EXTENSION` statements, supports extension lifecycle management, and ensures compatibility across different database dialects. Below is a breakdown of the most important changes grouped by theme.

### PostgreSQL Extension Management

* Added a new `DropExtensionNode` type in `core/ast/nodes.go` to represent `DROP EXTENSION` statements, with methods for setting options like `IF EXISTS`, `CASCADE`, and comments.
* Implemented extension comparison logic in `migration/schemadiff/internal/compare/compare.go` to identify extensions that need to be added or removed during schema migration.
* Enhanced the PostgreSQL schema reader in `dbschema/postgres/reader.go` to read installed extensions and populate the schema with extension details. [[1]](diffhunk://#diff-d8eb9b6eb0ee056f1cd885805a7857c2cac40f4d1623c00ab953b1b5549bb7a9R60-R66) [[2]](diffhunk://#diff-d8eb9b6eb0ee056f1cd885805a7857c2cac40f4d1623c00ab953b1b5549bb7a9R354-R408)
* Updated the schema type in `dbschema/types/types.go` to include a new `DBExtension` struct for representing extensions and added an `Extensions` field to `DBSchema`. [[1]](diffhunk://#diff-6d95768243e4a4469b5ac8ba81ee8cd2eaff7a805a046d36eb759369db56a119R9) [[2]](diffhunk://#diff-6d95768243e4a4469b5ac8ba81ee8cd2eaff7a805a046d36eb759369db56a119R66-R76)

### Migration and Rendering Enhancements

* Modified the PostgreSQL migration planner in `migration/planner/dialects/postgres/postgres.go` to handle extension addition and removal during migration generation. Added safety warnings for `DROP EXTENSION` operations. [[1]](diffhunk://#diff-728f4c6299737fce06f5fded07720b5b46b120b6de3386bbf57a4532daf214e6R230-R241) [[2]](diffhunk://#diff-728f4c6299737fce06f5fded07720b5b46b120b6de3386bbf57a4532daf214e6L362-R366) [[3]](diffhunk://#diff-728f4c6299737fce06f5fded07720b5b46b120b6de3386bbf57a4532daf214e6R390-R435)
* Added rendering support for `DROP EXTENSION` statements across PostgreSQL, MySQL-like, MySQL, and MariaDB dialects, including comments for unsupported dialects. [[1]](diffhunk://#diff-91eaaa72375b30ad1d49505d5de800f9d6de539723af3931a927760600240771R621-R645) [[2]](diffhunk://#diff-2db95cd2a46bf32c0c295fd97e19fb17fa73aa2b08b25cb6d4af648e8e7c8097R480-R491) [[3]](diffhunk://#diff-5897d0629f8e49ccc4d2f909379a4d1bd447a660dc4f61096b412a502fb18657R124-R135) [[4]](diffhunk://#diff-444c121acee04df6d8dffa7db0c9f9623eff2a8857b4e8a4d2a93c7eabefb6e8R124-R135)

### Testing and Mocking

* Added unit tests for `VisitDropExtension` rendering in PostgreSQL in `core/renderer/dialects/postgres/postgresql_features_test.go`. Tests cover various scenarios including `IF EXISTS`, `CASCADE`, and comments.
* Updated the mock visitor in `core/ast/mocks/visitor.go` to include a `VisitDropExtension` method for testing purposes.

### Codebase Integration

* Extended the `Visitor` interface in `core/ast/ast.go` to include the `VisitDropExtension` method for handling `DROP EXTENSION` nodes.
* Updated example code in `examples/ast_demo/ast_example.go` to include support for `VisitDropExtension`.

These changes collectively enhance the system's ability to manage PostgreSQL extensions, ensuring robust schema migration and compatibility across supported database dialects.