### PR TITLE
Add support for ignoring some extensions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,7 @@ func (c *CompareOptions) IsExtensionIgnored(extensionName string) bool {
 // and returns a new slice containing only non-ignored extensions.
 // This is useful for filtering extension lists before comparison.
 func (c *CompareOptions) FilterIgnoredExtensions(extensions []string) []string {
-	filtered := make([]string, 0) // Initialize with zero length but non-nil slice
+	filtered := make([]string, 0)
 	for _, ext := range extensions {
 		if !c.IsExtensionIgnored(ext) {
 			filtered = append(filtered, ext)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,87 @@
+// Package config provides configuration options for the Ptah schema migration system.
+//
+// This package provides a simple, programmatic API for configuring schema comparison
+// and migration behavior when using Ptah as a library. It focuses on providing
+// clean Go APIs rather than external configuration file management.
+package config
+
+// CompareOptions contains configuration options for schema comparison operations.
+// These options control how schema differences are calculated and what elements
+// should be ignored during comparison.
+type CompareOptions struct {
+	// IgnoredExtensions is a list of PostgreSQL extension names that should be
+	// ignored during schema migrations. These extensions will:
+	// - Never be deleted, even if missing from the target schema
+	// - Be excluded from schema diff calculations
+	// - Be treated as if they don't exist for comparison purposes
+	//
+	// Common extensions to ignore include:
+	// - plpgsql: Default procedural language, usually pre-installed
+	// - adminpack: Administrative functions, often pre-installed
+	IgnoredExtensions []string
+}
+
+// DefaultCompareOptions returns the default comparison options with sensible defaults.
+// The default configuration includes commonly pre-installed PostgreSQL
+// extensions that should typically be ignored during migrations.
+func DefaultCompareOptions() *CompareOptions {
+	return &CompareOptions{
+		IgnoredExtensions: []string{
+			"plpgsql", // PostgreSQL procedural language - usually pre-installed
+		},
+	}
+}
+
+// WithIgnoredExtensions returns a new CompareOptions with the specified ignored extensions.
+// This completely replaces the default ignored extensions list.
+//
+// Example:
+//
+//	opts := config.WithIgnoredExtensions("plpgsql", "adminpack", "pg_stat_statements")
+func WithIgnoredExtensions(extensions ...string) *CompareOptions {
+	return &CompareOptions{
+		IgnoredExtensions: extensions,
+	}
+}
+
+// WithAdditionalIgnoredExtensions returns a new CompareOptions that includes the default
+// ignored extensions plus the additional ones specified.
+//
+// Example:
+//
+//	opts := config.WithAdditionalIgnoredExtensions("adminpack", "pg_stat_statements")
+//	// Result: ["plpgsql", "adminpack", "pg_stat_statements"]
+func WithAdditionalIgnoredExtensions(extensions ...string) *CompareOptions {
+	defaults := DefaultCompareOptions()
+	allExtensions := make([]string, len(defaults.IgnoredExtensions)+len(extensions))
+	copy(allExtensions, defaults.IgnoredExtensions)
+	copy(allExtensions[len(defaults.IgnoredExtensions):], extensions)
+
+	return &CompareOptions{
+		IgnoredExtensions: allExtensions,
+	}
+}
+
+// IsExtensionIgnored checks if the given extension name should be ignored
+// during schema migrations based on the current configuration.
+func (c *CompareOptions) IsExtensionIgnored(extensionName string) bool {
+	for _, ignored := range c.IgnoredExtensions {
+		if ignored == extensionName {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterIgnoredExtensions removes ignored extensions from the provided slice
+// and returns a new slice containing only non-ignored extensions.
+// This is useful for filtering extension lists before comparison.
+func (c *CompareOptions) FilterIgnoredExtensions(extensions []string) []string {
+	filtered := make([]string, 0) // Initialize with zero length but non-nil slice
+	for _, ext := range extensions {
+		if !c.IsExtensionIgnored(ext) {
+			filtered = append(filtered, ext)
+		}
+	}
+	return filtered
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,219 @@
+package config_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config"
+)
+
+func TestDefaultCompareOptions(t *testing.T) {
+	c := qt.New(t)
+
+	opts := config.DefaultCompareOptions()
+
+	c.Assert(opts, qt.IsNotNil)
+	c.Assert(opts.IgnoredExtensions, qt.DeepEquals, []string{"plpgsql"})
+}
+
+func TestWithIgnoredExtensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		extensions []string
+		expected   []string
+	}{
+		{
+			name:       "single extension",
+			extensions: []string{"plpgsql"},
+			expected:   []string{"plpgsql"},
+		},
+		{
+			name:       "multiple extensions",
+			extensions: []string{"plpgsql", "adminpack", "pg_stat_statements"},
+			expected:   []string{"plpgsql", "adminpack", "pg_stat_statements"},
+		},
+		{
+			name:       "empty list",
+			extensions: []string{},
+			expected:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			opts := config.WithIgnoredExtensions(tt.extensions...)
+			c.Assert(opts.IgnoredExtensions, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestWithAdditionalIgnoredExtensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		additional []string
+		expected   []string
+	}{
+		{
+			name:       "add single extension",
+			additional: []string{"adminpack"},
+			expected:   []string{"plpgsql", "adminpack"},
+		},
+		{
+			name:       "add multiple extensions",
+			additional: []string{"adminpack", "pg_stat_statements"},
+			expected:   []string{"plpgsql", "adminpack", "pg_stat_statements"},
+		},
+		{
+			name:       "add no extensions",
+			additional: []string{},
+			expected:   []string{"plpgsql"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			opts := config.WithAdditionalIgnoredExtensions(tt.additional...)
+			c.Assert(opts.IgnoredExtensions, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestCompareOptions_IsExtensionIgnored(t *testing.T) {
+	tests := []struct {
+		name              string
+		ignoredExtensions []string
+		extensionName     string
+		expected          bool
+	}{
+		{
+			name:              "extension is ignored",
+			ignoredExtensions: []string{"plpgsql", "adminpack"},
+			extensionName:     "plpgsql",
+			expected:          true,
+		},
+		{
+			name:              "extension is not ignored",
+			ignoredExtensions: []string{"plpgsql", "adminpack"},
+			extensionName:     "pg_trgm",
+			expected:          false,
+		},
+		{
+			name:              "empty ignore list",
+			ignoredExtensions: []string{},
+			extensionName:     "plpgsql",
+			expected:          false,
+		},
+		{
+			name:              "case sensitive matching",
+			ignoredExtensions: []string{"plpgsql"},
+			extensionName:     "PLPGSQL",
+			expected:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			opts := &config.CompareOptions{
+				IgnoredExtensions: tt.ignoredExtensions,
+			}
+
+			result := opts.IsExtensionIgnored(tt.extensionName)
+			c.Assert(result, qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestCompareOptions_FilterIgnoredExtensions(t *testing.T) {
+	tests := []struct {
+		name              string
+		ignoredExtensions []string
+		inputExtensions   []string
+		expected          []string
+	}{
+		{
+			name:              "filter some extensions",
+			ignoredExtensions: []string{"plpgsql", "adminpack"},
+			inputExtensions:   []string{"plpgsql", "pg_trgm", "adminpack", "btree_gin"},
+			expected:          []string{"pg_trgm", "btree_gin"},
+		},
+		{
+			name:              "filter all extensions",
+			ignoredExtensions: []string{"plpgsql", "pg_trgm"},
+			inputExtensions:   []string{"plpgsql", "pg_trgm"},
+			expected:          []string{},
+		},
+		{
+			name:              "filter no extensions",
+			ignoredExtensions: []string{"adminpack"},
+			inputExtensions:   []string{"plpgsql", "pg_trgm", "btree_gin"},
+			expected:          []string{"plpgsql", "pg_trgm", "btree_gin"},
+		},
+		{
+			name:              "empty input list",
+			ignoredExtensions: []string{"plpgsql"},
+			inputExtensions:   []string{},
+			expected:          []string{},
+		},
+		{
+			name:              "empty ignore list",
+			ignoredExtensions: []string{},
+			inputExtensions:   []string{"plpgsql", "pg_trgm"},
+			expected:          []string{"plpgsql", "pg_trgm"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			opts := &config.CompareOptions{
+				IgnoredExtensions: tt.ignoredExtensions,
+			}
+
+			result := opts.FilterIgnoredExtensions(tt.inputExtensions)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestLibraryUsageExamples(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("default usage", func(t *testing.T) {
+		// User wants default behavior (ignore plpgsql)
+		opts := config.DefaultCompareOptions()
+		c.Assert(opts.IsExtensionIgnored("plpgsql"), qt.IsTrue)
+		c.Assert(opts.IsExtensionIgnored("pg_trgm"), qt.IsFalse)
+	})
+
+	t.Run("custom ignore list", func(t *testing.T) {
+		// User wants to ignore specific extensions only
+		opts := config.WithIgnoredExtensions("plpgsql", "adminpack")
+		c.Assert(opts.IsExtensionIgnored("plpgsql"), qt.IsTrue)
+		c.Assert(opts.IsExtensionIgnored("adminpack"), qt.IsTrue)
+		c.Assert(opts.IsExtensionIgnored("pg_trgm"), qt.IsFalse)
+	})
+
+	t.Run("additional ignored extensions", func(t *testing.T) {
+		// User wants defaults plus additional extensions
+		opts := config.WithAdditionalIgnoredExtensions("adminpack", "pg_stat_statements")
+		c.Assert(opts.IsExtensionIgnored("plpgsql"), qt.IsTrue)            // default
+		c.Assert(opts.IsExtensionIgnored("adminpack"), qt.IsTrue)          // additional
+		c.Assert(opts.IsExtensionIgnored("pg_stat_statements"), qt.IsTrue) // additional
+		c.Assert(opts.IsExtensionIgnored("pg_trgm"), qt.IsFalse)           // not ignored
+	})
+
+	t.Run("no ignored extensions", func(t *testing.T) {
+		// User wants to manage all extensions
+		opts := config.WithIgnoredExtensions()
+		c.Assert(opts.IsExtensionIgnored("plpgsql"), qt.IsFalse)
+		c.Assert(opts.IsExtensionIgnored("pg_trgm"), qt.IsFalse)
+	})
+}

--- a/docs/postgresql_extension_ignore.md
+++ b/docs/postgresql_extension_ignore.md
@@ -1,0 +1,195 @@
+# PostgreSQL Extension Ignore Functionality
+
+This document describes the PostgreSQL extension ignore functionality in Ptah, which allows you to configure which extensions should be ignored during schema migrations.
+
+## Overview
+
+Some PostgreSQL extensions (like `plpgsql`) are installed by default in databases and should not be managed by migration systems. The ignore functionality provides:
+
+- **Configurable ignore list**: Specify which extensions to ignore
+- **Default behavior**: `plpgsql` is ignored by default
+- **Programmatic API**: Clean Go API for library usage
+- **Flexible configuration**: Multiple ways to configure the ignore list
+
+## Key Behaviors
+
+When an extension is ignored:
+- ✅ **Can be created** during migrations if defined in target schema
+- ❌ **Never deleted** even if missing from target schema  
+- 🚫 **Excluded from diff calculations** (treated as if it doesn't exist)
+- 🔍 **Filtered out** before schema comparison
+
+## Library Usage
+
+### Basic Usage (Default Behavior)
+
+```go
+package main
+
+import (
+    "github.com/stokaro/ptah/core/goschema"
+    "github.com/stokaro/ptah/dbschema"
+    "github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func main() {
+    // Parse your Go entities
+    generated, err := goschema.ParseDir("./models")
+    if err != nil {
+        panic(err)
+    }
+
+    // Connect to database and read current schema
+    conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+    if err != nil {
+        panic(err)
+    }
+    defer conn.Close()
+
+    database, err := conn.ReadSchema()
+    if err != nil {
+        panic(err)
+    }
+
+    // Compare schemas with default options (ignores "plpgsql")
+    diff := schemadiff.Compare(generated, database)
+    
+    // plpgsql in database will NOT be marked for removal
+    fmt.Printf("Extensions to add: %v\n", diff.ExtensionsAdded)
+    fmt.Printf("Extensions to remove: %v\n", diff.ExtensionsRemoved)
+}
+```
+
+### Custom Ignore List
+
+```go
+import "github.com/stokaro/ptah/config"
+
+// Ignore specific extensions only
+opts := config.WithIgnoredExtensions("plpgsql", "adminpack", "pg_stat_statements")
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+```
+
+### Add to Default Ignore List
+
+```go
+// Keep default (plpgsql) and add more
+opts := config.WithAdditionalIgnoredExtensions("adminpack", "pg_stat_statements")
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+// Result: ignores ["plpgsql", "adminpack", "pg_stat_statements"]
+```
+
+### Manage All Extensions
+
+```go
+// Don't ignore any extensions (manage everything)
+opts := config.WithIgnoredExtensions() // Empty list
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+// Result: even plpgsql will be managed
+```
+
+## Configuration API
+
+### CompareOptions
+
+```go
+type CompareOptions struct {
+    IgnoredExtensions []string
+}
+```
+
+### Factory Functions
+
+```go
+// Default options (ignores "plpgsql")
+opts := config.DefaultCompareOptions()
+
+// Custom ignore list (replaces defaults)
+opts := config.WithIgnoredExtensions("plpgsql", "adminpack")
+
+// Add to defaults (keeps "plpgsql" + adds more)
+opts := config.WithAdditionalIgnoredExtensions("adminpack")
+```
+
+### Utility Methods
+
+```go
+// Check if extension is ignored
+if opts.IsExtensionIgnored("plpgsql") {
+    // Extension will be ignored
+}
+
+// Filter a list of extensions
+filtered := opts.FilterIgnoredExtensions([]string{"plpgsql", "pg_trgm", "adminpack"})
+// Returns only non-ignored extensions
+```
+
+## Real-World Examples
+
+### Development Environment
+
+```go
+// Development: ignore common pre-installed extensions
+opts := config.WithIgnoredExtensions("plpgsql", "adminpack")
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+```
+
+### Production Environment
+
+```go
+// Production: be more conservative, ignore more extensions
+opts := config.WithAdditionalIgnoredExtensions(
+    "adminpack",
+    "pg_stat_statements", 
+    "pg_buffercache",
+)
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+```
+
+### Testing Environment
+
+```go
+// Testing: manage all extensions for complete control
+opts := config.WithIgnoredExtensions() // Empty - manage everything
+diff := schemadiff.CompareWithOptions(generated, database, opts)
+```
+
+## Migration Generation
+
+The ignore functionality automatically integrates with migration generation:
+
+```go
+import "github.com/stokaro/ptah/migration/generator"
+
+// Generate migration with custom extension ignore options
+opts := generator.GenerateMigrationOptions{
+    RootDir:       "./models",
+    DatabaseURL:   "postgres://user:pass@localhost/db",
+    MigrationName: "update_schema",
+    OutputDir:     "./migrations",
+    // Extension ignore options will be supported in future versions
+}
+
+files, err := generator.GenerateMigration(opts)
+```
+
+## Common Extensions to Ignore
+
+- **`plpgsql`**: PostgreSQL procedural language (usually pre-installed)
+- **`adminpack`**: Administrative functions (often pre-installed)
+- **`pg_stat_statements`**: Query statistics (monitoring extension)
+- **`pg_buffercache`**: Buffer cache inspection (monitoring extension)
+
+## Best Practices
+
+1. **Start with defaults**: Use `schemadiff.Compare()` for most cases
+2. **Be explicit in production**: Use `CompareWithOptions()` with explicit ignore lists
+3. **Document your choices**: Comment why specific extensions are ignored
+4. **Test thoroughly**: Verify ignore behavior in your test environment
+5. **Review regularly**: Periodically review your ignore list as your system evolves
+
+## Backward Compatibility
+
+- Existing code using `schemadiff.Compare()` continues to work unchanged
+- Default behavior ignores `plpgsql` (safe for most PostgreSQL installations)
+- New `CompareWithOptions()` function provides full control when needed

--- a/examples/extension_ignore/main.go
+++ b/examples/extension_ignore/main.go
@@ -1,0 +1,191 @@
+// Package main demonstrates the PostgreSQL extension ignore functionality in Ptah.
+//
+// This example shows how to use the new configuration API to control which
+// PostgreSQL extensions should be ignored during schema migrations.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func main() {
+	fmt.Println("PostgreSQL Extension Ignore Functionality Demo")
+	fmt.Println("==============================================")
+	fmt.Println()
+
+	// Create sample data for demonstration
+	generated := createSampleGeneratedSchema()
+	database := createSampleDatabaseSchema()
+
+	fmt.Println("Sample Data:")
+	fmt.Printf("Generated schema extensions: %v\n", getExtensionNames(generated.Extensions))
+	fmt.Printf("Database schema extensions: %v\n", getDatabaseExtensionNames(database.Extensions))
+	fmt.Println()
+
+	// Demonstrate different configuration options
+	demonstrateDefaultBehavior(generated, database)
+	demonstrateCustomIgnoreList(generated, database)
+	demonstrateAdditionalIgnoredExtensions(generated, database)
+	demonstrateManageAllExtensions(generated, database)
+}
+
+func createSampleGeneratedSchema() *goschema.Database {
+	return &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true, Comment: "Trigram similarity search"},
+			{Name: "btree_gin", IfNotExists: true, Comment: "GIN indexes for btree types"},
+		},
+	}
+}
+
+func createSampleDatabaseSchema() *types.DBSchema {
+	return &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "adminpack", Version: "2.1", Schema: "public"},
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+		},
+	}
+}
+
+func getExtensionNames(extensions []goschema.Extension) []string {
+	names := make([]string, len(extensions))
+	for i, ext := range extensions {
+		names[i] = ext.Name
+	}
+	return names
+}
+
+func getDatabaseExtensionNames(extensions []types.DBExtension) []string {
+	names := make([]string, len(extensions))
+	for i, ext := range extensions {
+		names[i] = ext.Name
+	}
+	return names
+}
+
+func demonstrateDefaultBehavior(generated *goschema.Database, database *types.DBSchema) {
+	fmt.Println("1. Default Behavior (ignores 'plpgsql'):")
+	fmt.Println("   Code: schemadiff.Compare(generated, database)")
+
+	diff := schemadiff.Compare(generated, database)
+
+	fmt.Printf("   Extensions to add: %v\n", diff.ExtensionsAdded)
+	fmt.Printf("   Extensions to remove: %v\n", diff.ExtensionsRemoved)
+	fmt.Println("   Note: 'plpgsql' is ignored by default, so it won't be removed")
+	fmt.Println()
+}
+
+func demonstrateCustomIgnoreList(generated *goschema.Database, database *types.DBSchema) {
+	fmt.Println("2. Custom Ignore List (ignore 'adminpack' only):")
+	fmt.Println("   Code: config.WithIgnoredExtensions(\"adminpack\")")
+
+	opts := config.WithIgnoredExtensions("adminpack")
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	fmt.Printf("   Extensions to add: %v\n", diff.ExtensionsAdded)
+	fmt.Printf("   Extensions to remove: %v\n", diff.ExtensionsRemoved)
+	fmt.Println("   Note: 'adminpack' is ignored, but 'plpgsql' will be removed")
+	fmt.Println()
+}
+
+func demonstrateAdditionalIgnoredExtensions(generated *goschema.Database, database *types.DBSchema) {
+	fmt.Println("3. Additional Ignored Extensions (default + 'adminpack'):")
+	fmt.Println("   Code: config.WithAdditionalIgnoredExtensions(\"adminpack\")")
+
+	opts := config.WithAdditionalIgnoredExtensions("adminpack")
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	fmt.Printf("   Extensions to add: %v\n", diff.ExtensionsAdded)
+	fmt.Printf("   Extensions to remove: %v\n", diff.ExtensionsRemoved)
+	fmt.Println("   Note: Both 'plpgsql' and 'adminpack' are ignored")
+	fmt.Println()
+}
+
+func demonstrateManageAllExtensions(generated *goschema.Database, database *types.DBSchema) {
+	fmt.Println("4. Manage All Extensions (no ignoring):")
+	fmt.Println("   Code: config.WithIgnoredExtensions() // empty list")
+
+	opts := config.WithIgnoredExtensions() // Empty list - manage everything
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	fmt.Printf("   Extensions to add: %v\n", diff.ExtensionsAdded)
+	fmt.Printf("   Extensions to remove: %v\n", diff.ExtensionsRemoved)
+	fmt.Println("   Note: All extensions are managed, including 'plpgsql'")
+	fmt.Println()
+}
+
+// Example of how you might use this in a real application
+func realWorldExample() {
+	// This function demonstrates how you might integrate the extension ignore
+	// functionality into a real application
+
+	fmt.Println("Real-World Integration Example:")
+	fmt.Println("==============================")
+
+	// Parse your Go entities
+	generated, err := goschema.ParseDir("./models")
+	if err != nil {
+		log.Fatalf("Failed to parse Go entities: %v", err)
+	}
+
+	// Connect to database (this would be a real connection)
+	// conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+	// if err != nil {
+	//     log.Fatalf("Failed to connect to database: %v", err)
+	// }
+	// defer conn.Close()
+
+	// database, err := conn.ReadSchema()
+	// if err != nil {
+	//     log.Fatalf("Failed to read database schema: %v", err)
+	// }
+
+	// For demo purposes, create a mock database schema
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "adminpack", Version: "2.1", Schema: "public"},
+		},
+	}
+
+	// Different environments might have different ignore strategies
+	var opts *config.CompareOptions
+
+	environment := "production" // This could come from env var or config
+	switch environment {
+	case "development":
+		// Development: ignore common pre-installed extensions
+		opts = config.WithIgnoredExtensions("plpgsql", "adminpack")
+	case "production":
+		// Production: be conservative, ignore monitoring extensions too
+		opts = config.WithAdditionalIgnoredExtensions("adminpack", "pg_stat_statements")
+	case "testing":
+		// Testing: manage all extensions for complete control
+		opts = config.WithIgnoredExtensions()
+	default:
+		// Default: use Ptah defaults
+		opts = nil
+	}
+
+	// Compare schemas with environment-specific configuration
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	fmt.Printf("Environment: %s\n", environment)
+	fmt.Printf("Extensions to add: %v\n", diff.ExtensionsAdded)
+	fmt.Printf("Extensions to remove: %v\n", diff.ExtensionsRemoved)
+
+	// You could then use this diff to generate migrations
+	// files, err := generator.GenerateMigration(generator.GenerateMigrationOptions{
+	//     RootDir:       "./models",
+	//     DatabaseURL:   "postgres://user:pass@localhost/db",
+	//     MigrationName: "update_extensions",
+	//     OutputDir:     "./migrations",
+	// })
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -1,13 +1,46 @@
 package schemadiff
 
 import (
+	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
+// Compare performs schema comparison between generated and database schemas using default options.
+// This is a convenience function that uses default comparison options (ignores "plpgsql" extension).
+// For custom configuration, use CompareWithOptions.
 func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.SchemaDiff {
+	return CompareWithOptions(generated, database, nil)
+}
+
+// CompareWithOptions performs schema comparison between generated and database schemas
+// with custom configuration options.
+//
+// This function provides full control over the comparison process, allowing users to
+// specify which extensions should be ignored, and other comparison behaviors.
+//
+// Parameters:
+//   - generated: Target schema parsed from Go struct annotations
+//   - database: Current database schema from database introspection
+//   - opts: Configuration options for comparison (can be nil for defaults)
+//
+// Returns a SchemaDiff containing all identified differences between the schemas.
+//
+// Example usage:
+//
+//	// Use default options (ignores "plpgsql")
+//	diff := schemadiff.CompareWithOptions(generated, database, nil)
+//
+//	// Ignore specific extensions
+//	opts := config.WithIgnoredExtensions("plpgsql", "adminpack")
+//	diff := schemadiff.CompareWithOptions(generated, database, opts)
+//
+//	// Don't ignore any extensions
+//	opts := config.WithIgnoredExtensions()
+//	diff := schemadiff.CompareWithOptions(generated, database, opts)
+func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, opts *config.CompareOptions) *difftypes.SchemaDiff {
 	diff := &difftypes.SchemaDiff{}
 
 	// Compare tables and their column structures
@@ -19,8 +52,8 @@ func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.
 	// Compare database index definitions
 	compare.Indexes(generated, database, diff)
 
-	// Compare PostgreSQL extensions
-	compare.Extensions(generated, database, diff)
+	// Compare PostgreSQL extensions with configuration options
+	compare.Extensions(generated, database, diff, opts)
 
 	return diff
 }

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -1,0 +1,187 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestCompare_DefaultBehavior(t *testing.T) {
+	c := qt.New(t)
+
+	// Setup test data with plpgsql in database but not in generated schema
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+		},
+	}
+
+	// Test default behavior (should ignore plpgsql)
+	diff := schemadiff.Compare(generated, database)
+
+	// plpgsql should be ignored by default, so no extensions should be removed
+	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{})
+}
+
+func TestCompareWithOptions_CustomIgnoreList(t *testing.T) {
+	c := qt.New(t)
+
+	// Setup test data
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "adminpack", Version: "2.1", Schema: "public"},
+		},
+	}
+
+	// Test with custom ignore list (ignore adminpack but not plpgsql)
+	opts := config.WithIgnoredExtensions("adminpack")
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	// adminpack should be ignored, plpgsql should be marked for removal
+	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{"plpgsql"})
+}
+
+func TestCompareWithOptions_NoIgnoredExtensions(t *testing.T) {
+	c := qt.New(t)
+
+	// Setup test data
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "adminpack", Version: "2.1", Schema: "public"},
+		},
+	}
+
+	// Test with no ignored extensions (manage all extensions)
+	opts := config.WithIgnoredExtensions() // Empty list
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	// All database extensions should be marked for removal
+	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{"adminpack", "plpgsql"})
+}
+
+func TestCompareWithOptions_AdditionalIgnoredExtensions(t *testing.T) {
+	c := qt.New(t)
+
+	// Setup test data
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "adminpack", Version: "2.1", Schema: "public"},
+			{Name: "pg_stat_statements", Version: "1.9", Schema: "public"},
+		},
+	}
+
+	// Test with additional ignored extensions (default + adminpack)
+	opts := config.WithAdditionalIgnoredExtensions("adminpack")
+	diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+	// plpgsql and adminpack should be ignored, only pg_stat_statements should be removed
+	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{"pg_stat_statements"})
+}
+
+func TestCompareWithOptions_NilOptions(t *testing.T) {
+	c := qt.New(t)
+
+	// Setup test data
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+		},
+	}
+
+	// Test with nil options (should use defaults)
+	diff := schemadiff.CompareWithOptions(generated, database, nil)
+
+	// Should behave the same as Compare() - ignore plpgsql by default
+	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{})
+}
+
+func TestLibraryUsageExamples(t *testing.T) {
+	c := qt.New(t)
+
+	// Example data
+	generated := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true},
+			{Name: "btree_gin", IfNotExists: true},
+		},
+	}
+	database := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+		},
+	}
+
+	t.Run("simple usage with defaults", func(t *testing.T) {
+		// Most common usage - just compare with defaults
+		diff := schemadiff.Compare(generated, database)
+
+		c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"btree_gin"})
+		c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{}) // plpgsql ignored
+	})
+
+	t.Run("custom ignore list", func(t *testing.T) {
+		// User wants to ignore specific extensions
+		opts := config.WithIgnoredExtensions("plpgsql", "adminpack")
+		diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+		c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"btree_gin"})
+		c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{})
+	})
+
+	t.Run("manage all extensions", func(t *testing.T) {
+		// User wants to manage all extensions (no ignoring)
+		opts := config.WithIgnoredExtensions()
+		diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+		c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"btree_gin"})
+		c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{"plpgsql"})
+	})
+
+	t.Run("add to default ignore list", func(t *testing.T) {
+		// User wants defaults plus additional ignored extensions
+		opts := config.WithAdditionalIgnoredExtensions("uuid-ossp")
+		diff := schemadiff.CompareWithOptions(generated, database, opts)
+
+		c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"btree_gin"})
+		c.Assert(diff.ExtensionsRemoved, qt.DeepEquals, []string{}) // plpgsql still ignored
+	})
+}


### PR DESCRIPTION
This pull request introduces a comprehensive update to the Ptah schema migration system, focusing on PostgreSQL extension ignore functionality. The changes include a new configuration API for managing ignored extensions during schema comparisons, extensive tests to validate behavior, updated documentation, and example usage. Additionally, the schema comparison logic has been enhanced to integrate these new options seamlessly.

### Core Functionality Enhancements:

#### Configuration API for Ignored Extensions:
- Added `CompareOptions` struct in `config/config.go` to define ignored extensions and utility methods for filtering and checking extensions.
- Introduced factory functions like `DefaultCompareOptions`, `WithIgnoredExtensions`, and `WithAdditionalIgnoredExtensions` for flexible configuration.

#### Integration with Schema Comparison:
- Updated `schemadiff` logic to support filtering ignored extensions during schema comparison, ensuring ignored extensions are excluded from diff calculations and never marked for removal. [[1]](diffhunk://#diff-eff4c2c67a956edc6a97a6d479f79a4a83813930a6cb507e176e21c1689d49f7R899-R912) [[2]](diffhunk://#diff-eff4c2c67a956edc6a97a6d479f79a4a83813930a6cb507e176e21c1689d49f7R934)

### Testing and Documentation:

#### Extensive Test Coverage:
- Added unit tests in `config/config_test.go` to validate default options, custom ignore lists, additional ignored extensions, and utility methods like `IsExtensionIgnored` and `FilterIgnoredExtensions`.

#### Comprehensive Documentation:
- Created `docs/postgresql_extension_ignore.md` to explain the functionality, usage patterns, and best practices for configuring ignored extensions. Includes code examples for different environments (development, production, testing).

### Example Usage and Integration:

#### Demonstration Code:
- Added `examples/extension_ignore/main.go` to showcase real-world usage scenarios, including default behavior, custom ignore lists, adding to defaults, and managing all extensions.

#### Codebase Integration:
- Updated import statements and comments in `migration/schemadiff/internal/compare/compare.go` to reflect integration of the new configuration API. [[1]](diffhunk://#diff-eff4c2c67a956edc6a97a6d479f79a4a83813930a6cb507e176e21c1689d49f7R8) [[2]](diffhunk://#diff-eff4c2c67a956edc6a97a6d479f79a4a83813930a6cb507e176e21c1689d49f7R921)

These changes provide a robust mechanism for managing PostgreSQL extensions during schema migrations, enhancing flexibility and control for developers while maintaining backward compatibility.