### PR TITLE
Fix droping extensions on down migrations

### DIFF
--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -15,6 +15,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		Fields:       make([]goschema.Field, 0),
 		Indexes:      make([]goschema.Index, 0),
 		Enums:        make([]goschema.Enum, 0),
+		Extensions:   make([]goschema.Extension, 0),
 		Dependencies: make(map[string][]string),
 	}
 
@@ -74,6 +75,22 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 			Unique:     dbIndex.IsUnique,
 		}
 		database.Indexes = append(database.Indexes, index)
+	}
+
+	// Convert extensions
+	for _, dbExtension := range dbSchema.Extensions {
+		extension := goschema.Extension{
+			Name:        dbExtension.Name,
+			IfNotExists: true, // Default to true for down migrations for safety
+			Version:     dbExtension.Version,
+		}
+
+		// Set comment if available
+		if dbExtension.Comment != nil {
+			extension.Comment = *dbExtension.Comment
+		}
+
+		database.Extensions = append(database.Extensions, extension)
 	}
 
 	return database

--- a/core/convert/dbschematogo/dbschematogo_test.go
+++ b/core/convert/dbschematogo/dbschematogo_test.go
@@ -1,0 +1,202 @@
+package dbschematogo_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/convert/dbschematogo"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+)
+
+func TestConvertDBSchemaToGoSchema_Extensions(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbSchema *types.DBSchema
+		expected []goschema.Extension
+	}{
+		{
+			name: "single extension without comment",
+			dbSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{
+						Name:    "pg_trgm",
+						Version: "1.6",
+						Schema:  "public",
+					},
+				},
+			},
+			expected: []goschema.Extension{
+				{
+					Name:        "pg_trgm",
+					IfNotExists: true,
+					Version:     "1.6",
+					Comment:     "",
+				},
+			},
+		},
+		{
+			name: "single extension with comment",
+			dbSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{
+						Name:    "postgis",
+						Version: "3.0",
+						Schema:  "public",
+						Comment: stringPtr("Geographic data support"),
+					},
+				},
+			},
+			expected: []goschema.Extension{
+				{
+					Name:        "postgis",
+					IfNotExists: true,
+					Version:     "3.0",
+					Comment:     "Geographic data support",
+				},
+			},
+		},
+		{
+			name: "multiple extensions",
+			dbSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{
+						Name:    "pg_trgm",
+						Version: "1.6",
+						Schema:  "public",
+					},
+					{
+						Name:    "btree_gin",
+						Version: "1.3",
+						Schema:  "public",
+						Comment: stringPtr("Enable GIN indexes on btree types"),
+					},
+				},
+			},
+			expected: []goschema.Extension{
+				{
+					Name:        "pg_trgm",
+					IfNotExists: true,
+					Version:     "1.6",
+					Comment:     "",
+				},
+				{
+					Name:        "btree_gin",
+					IfNotExists: true,
+					Version:     "1.3",
+					Comment:     "Enable GIN indexes on btree types",
+				},
+			},
+		},
+		{
+			name: "no extensions",
+			dbSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{},
+			},
+			expected: []goschema.Extension{},
+		},
+		{
+			name: "nil extensions",
+			dbSchema: &types.DBSchema{
+				Extensions: nil,
+			},
+			expected: []goschema.Extension{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			result := dbschematogo.ConvertDBSchemaToGoSchema(tt.dbSchema)
+
+			c.Assert(len(result.Extensions), qt.Equals, len(tt.expected))
+			for i, expectedExt := range tt.expected {
+				actualExt := result.Extensions[i]
+				c.Assert(actualExt.Name, qt.Equals, expectedExt.Name)
+				c.Assert(actualExt.IfNotExists, qt.Equals, expectedExt.IfNotExists)
+				c.Assert(actualExt.Version, qt.Equals, expectedExt.Version)
+				c.Assert(actualExt.Comment, qt.Equals, expectedExt.Comment)
+			}
+		})
+	}
+}
+
+func TestConvertDBSchemaToGoSchema_ExtensionsWithOtherElements(t *testing.T) {
+	c := qt.New(t)
+
+	// Test that extensions are properly converted alongside other schema elements
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "users",
+				Columns: []types.DBColumn{
+					{
+						Name:     "id",
+						DataType: "integer",
+					},
+				},
+			},
+		},
+		Extensions: []types.DBExtension{
+			{
+				Name:    "pg_trgm",
+				Version: "1.6",
+				Schema:  "public",
+			},
+		},
+		Enums: []types.DBEnum{
+			{
+				Name:   "status_type",
+				Values: []string{"active", "inactive"},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	// Verify extensions are converted
+	c.Assert(len(result.Extensions), qt.Equals, 1)
+	c.Assert(result.Extensions[0].Name, qt.Equals, "pg_trgm")
+	c.Assert(result.Extensions[0].IfNotExists, qt.Equals, true)
+	c.Assert(result.Extensions[0].Version, qt.Equals, "1.6")
+
+	// Verify other elements are also converted
+	c.Assert(len(result.Tables), qt.Equals, 1)
+	c.Assert(result.Tables[0].Name, qt.Equals, "users")
+	c.Assert(len(result.Enums), qt.Equals, 1)
+	c.Assert(result.Enums[0].Name, qt.Equals, "status_type")
+}
+
+func TestConvertDBSchemaToGoSchema_ExtensionDefaultValues(t *testing.T) {
+	c := qt.New(t)
+
+	// Test that extensions get proper default values
+	dbSchema := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{
+				Name:    "test_extension",
+				Version: "1.0",
+				Schema:  "public",
+				// Comment is nil
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(len(result.Extensions), qt.Equals, 1)
+	ext := result.Extensions[0]
+
+	// Verify default values
+	c.Assert(ext.Name, qt.Equals, "test_extension")
+	c.Assert(ext.IfNotExists, qt.Equals, true) // Should default to true for safety
+	c.Assert(ext.Version, qt.Equals, "1.0")
+	c.Assert(ext.Comment, qt.Equals, "") // Should be empty string when nil
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/migration/generator/extension_integration_test.go
+++ b/migration/generator/extension_integration_test.go
@@ -1,0 +1,217 @@
+package generator_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestExtensionMigration_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name              string
+		generatedSchema   *goschema.Database
+		databaseSchema    *types.DBSchema
+		expectedUpSQL     []string
+		expectedDownSQL   []string
+		unexpectedUpSQL   []string
+		unexpectedDownSQL []string
+	}{
+		{
+			name: "add single extension",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "pg_trgm", IfNotExists: true, Comment: "Enable trigram similarity search"},
+				},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{},
+			},
+			expectedUpSQL: []string{
+				"-- Enable trigram similarity search",
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+			},
+			expectedDownSQL: []string{
+				"WARNING: Removing extension 'pg_trgm' may break existing functionality",
+				"DROP EXTENSION IF EXISTS pg_trgm;",
+			},
+			unexpectedUpSQL: []string{
+				"DROP EXTENSION",
+			},
+			unexpectedDownSQL: []string{
+				"CREATE EXTENSION",
+			},
+		},
+		{
+			name: "add multiple extensions",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "pg_trgm", IfNotExists: true, Comment: "Enable trigram similarity search"},
+					{Name: "btree_gin", IfNotExists: true, Comment: "Enable GIN indexes on btree types"},
+				},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{},
+			},
+			expectedUpSQL: []string{
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+				"CREATE EXTENSION IF NOT EXISTS btree_gin;",
+			},
+			expectedDownSQL: []string{
+				"DROP EXTENSION IF EXISTS pg_trgm;",
+				"DROP EXTENSION IF EXISTS btree_gin;",
+			},
+			unexpectedUpSQL: []string{
+				"DROP EXTENSION",
+			},
+			unexpectedDownSQL: []string{
+				"CREATE EXTENSION",
+			},
+		},
+		{
+			name: "remove extension",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+				},
+			},
+			expectedUpSQL: []string{
+				"DROP EXTENSION IF EXISTS pg_trgm;",
+			},
+			expectedDownSQL: []string{
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+			},
+			unexpectedUpSQL: []string{
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+			},
+			unexpectedDownSQL: []string{
+				"DROP EXTENSION",
+			},
+		},
+		{
+			name: "extension with version",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "postgis", Version: "3.0", IfNotExists: true, Comment: "Geographic data support"},
+				},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{},
+			},
+			expectedUpSQL: []string{
+				"-- Geographic data support",
+				"CREATE EXTENSION IF NOT EXISTS postgis VERSION '3.0';",
+			},
+			expectedDownSQL: []string{
+				"DROP EXTENSION IF EXISTS postgis;",
+			},
+			unexpectedUpSQL: []string{
+				"DROP EXTENSION",
+			},
+			unexpectedDownSQL: []string{
+				"CREATE EXTENSION",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// 1. Calculate schema diff
+			diff := schemadiff.Compare(tt.generatedSchema, tt.databaseSchema)
+			c.Assert(diff.HasChanges(), qt.IsTrue, qt.Commentf("Expected schema changes to be detected"))
+
+			// 2. Generate up migration SQL
+			upSQL := planner.GenerateSchemaDiffSQL(diff, tt.generatedSchema, "postgres")
+
+			// 3. Generate down migration SQL by reversing the diff
+			reverseDiff := &difftypes.SchemaDiff{
+				ExtensionsAdded:   diff.ExtensionsRemoved,
+				ExtensionsRemoved: diff.ExtensionsAdded,
+			}
+
+			// For down migrations, we need to convert database schema to go schema format
+			dbAsGoSchema := &goschema.Database{
+				Extensions: make([]goschema.Extension, len(tt.databaseSchema.Extensions)),
+			}
+			for i, ext := range tt.databaseSchema.Extensions {
+				dbAsGoSchema.Extensions[i] = goschema.Extension{
+					Name:        ext.Name,
+					IfNotExists: true, // Default for down migrations
+				}
+			}
+
+			downSQL := planner.GenerateSchemaDiffSQL(reverseDiff, dbAsGoSchema, "postgres")
+
+			// 4. Verify up migration SQL
+			for _, expected := range tt.expectedUpSQL {
+				c.Assert(strings.Contains(upSQL, expected), qt.IsTrue,
+					qt.Commentf("Expected up SQL to contain: %s\nActual up SQL:\n%s", expected, upSQL))
+			}
+
+			for _, unexpected := range tt.unexpectedUpSQL {
+				c.Assert(strings.Contains(upSQL, unexpected), qt.IsFalse,
+					qt.Commentf("Expected up SQL to NOT contain: %s\nActual up SQL:\n%s", unexpected, upSQL))
+			}
+
+			// 5. Verify down migration SQL
+			for _, expected := range tt.expectedDownSQL {
+				c.Assert(strings.Contains(downSQL, expected), qt.IsTrue,
+					qt.Commentf("Expected down SQL to contain: %s\nActual down SQL:\n%s", expected, downSQL))
+			}
+
+			for _, unexpected := range tt.unexpectedDownSQL {
+				c.Assert(strings.Contains(downSQL, unexpected), qt.IsFalse,
+					qt.Commentf("Expected down SQL to NOT contain: %s\nActual down SQL:\n%s", unexpected, downSQL))
+			}
+		})
+	}
+}
+
+func TestExtensionMigration_UpDownCycle(t *testing.T) {
+	c := qt.New(t)
+
+	// Test a complete up/down migration cycle
+	generatedSchema := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true, Comment: "Enable trigram similarity search"},
+			{Name: "btree_gin", IfNotExists: true, Comment: "Enable GIN indexes on btree types"},
+		},
+	}
+
+	databaseSchema := &types.DBSchema{
+		Extensions: []types.DBExtension{},
+	}
+
+	// 1. Calculate initial diff (should add extensions)
+	upDiff := schemadiff.Compare(generatedSchema, databaseSchema)
+	c.Assert(len(upDiff.ExtensionsAdded), qt.Equals, 2)
+	c.Assert(len(upDiff.ExtensionsRemoved), qt.Equals, 0)
+
+	// 2. Simulate applying the up migration (database now has extensions)
+	simulatedDatabaseAfterUp := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+			{Name: "btree_gin", Version: "1.3", Schema: "public"},
+		},
+	}
+
+	// 3. Calculate down diff (should remove extensions)
+	downDiff := schemadiff.Compare(&goschema.Database{Extensions: []goschema.Extension{}}, simulatedDatabaseAfterUp)
+	c.Assert(len(downDiff.ExtensionsAdded), qt.Equals, 0)
+	c.Assert(len(downDiff.ExtensionsRemoved), qt.Equals, 2)
+
+	// 4. Verify the cycle is complete
+	c.Assert(upDiff.ExtensionsAdded, qt.DeepEquals, downDiff.ExtensionsRemoved)
+	c.Assert(upDiff.ExtensionsRemoved, qt.DeepEquals, downDiff.ExtensionsAdded)
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -165,6 +165,10 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 		// Reverse index operations
 		IndexesAdded:   diff.IndexesRemoved, // Indexes to remove become indexes to add
 		IndexesRemoved: diff.IndexesAdded,   // Indexes to add become indexes to remove
+
+		// Reverse extension operations
+		ExtensionsAdded:   diff.ExtensionsRemoved, // Extensions to remove become extensions to add
+		ExtensionsRemoved: diff.ExtensionsAdded,   // Extensions to add become extensions to remove
 	}
 }
 

--- a/migration/generator/migration_file_generation_test.go
+++ b/migration/generator/migration_file_generation_test.go
@@ -1,0 +1,182 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestMigrationFileGeneration_ExtensionSQL(t *testing.T) {
+	tests := []struct {
+		name              string
+		generatedSchema   *goschema.Database
+		databaseSchema    *types.DBSchema
+		expectedUpSQL     []string
+		expectedDownSQL   []string
+		unexpectedUpSQL   []string
+		unexpectedDownSQL []string
+	}{
+		{
+			name: "extension addition generates correct up and down SQL",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{
+					{Name: "pg_trgm", IfNotExists: true, Comment: "Enable trigram similarity search"},
+					{Name: "btree_gin", IfNotExists: true, Comment: "Enable GIN indexes on btree types"},
+				},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{},
+			},
+			expectedUpSQL: []string{
+				"-- Direction: UP",
+				"-- Enable trigram similarity search",
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+				"-- Enable GIN indexes on btree types",
+				"CREATE EXTENSION IF NOT EXISTS btree_gin;",
+			},
+			expectedDownSQL: []string{
+				"-- Direction: DOWN",
+				"WARNING: Removing extension 'pg_trgm' may break existing functionality",
+				"DROP EXTENSION IF EXISTS pg_trgm;",
+				"WARNING: Removing extension 'btree_gin' may break existing functionality",
+				"DROP EXTENSION IF EXISTS btree_gin;",
+			},
+			unexpectedUpSQL: []string{
+				"DROP EXTENSION",
+			},
+			unexpectedDownSQL: []string{
+				"CREATE EXTENSION",
+			},
+		},
+		{
+			name: "extension removal generates correct up and down SQL",
+			generatedSchema: &goschema.Database{
+				Extensions: []goschema.Extension{},
+			},
+			databaseSchema: &types.DBSchema{
+				Extensions: []types.DBExtension{
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+				},
+			},
+			expectedUpSQL: []string{
+				"-- Direction: UP",
+				"WARNING: Removing extension 'pg_trgm' may break existing functionality",
+				"DROP EXTENSION IF EXISTS pg_trgm;",
+			},
+			expectedDownSQL: []string{
+				"-- Direction: DOWN",
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm",
+			},
+			unexpectedUpSQL: []string{
+				"CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+			},
+			unexpectedDownSQL: []string{
+				"DROP EXTENSION",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// 1. Calculate schema diff
+			diff := schemadiff.Compare(tt.generatedSchema, tt.databaseSchema)
+			c.Assert(diff.HasChanges(), qt.IsTrue)
+
+			// 2. Generate up migration SQL
+			upSQL, err := generateUpMigrationSQL(diff, tt.generatedSchema, "postgres")
+			c.Assert(err, qt.IsNil)
+
+			// 3. Generate down migration SQL using the fixed reverseSchemaDiff function
+			downSQL, err := generateDownMigrationSQL(diff, tt.databaseSchema, "postgres")
+			c.Assert(err, qt.IsNil)
+
+			// 4. Verify up migration SQL contains expected patterns
+			for _, expected := range tt.expectedUpSQL {
+				c.Assert(strings.Contains(upSQL, expected), qt.IsTrue,
+					qt.Commentf("Expected up SQL to contain: %s\nActual up SQL:\n%s", expected, upSQL))
+			}
+
+			for _, unexpected := range tt.unexpectedUpSQL {
+				c.Assert(strings.Contains(upSQL, unexpected), qt.IsFalse,
+					qt.Commentf("Expected up SQL to NOT contain: %s\nActual up SQL:\n%s", unexpected, upSQL))
+			}
+
+			// 5. Verify down migration SQL contains expected patterns
+			for _, expected := range tt.expectedDownSQL {
+				c.Assert(strings.Contains(downSQL, expected), qt.IsTrue,
+					qt.Commentf("Expected down SQL to contain: %s\nActual down SQL:\n%s", expected, downSQL))
+			}
+
+			for _, unexpected := range tt.unexpectedDownSQL {
+				c.Assert(strings.Contains(downSQL, unexpected), qt.IsFalse,
+					qt.Commentf("Expected down SQL to NOT contain: %s\nActual down SQL:\n%s", unexpected, downSQL))
+			}
+		})
+	}
+}
+
+func TestReverseSchemaDiff_ExtensionFieldsPresent(t *testing.T) {
+	c := qt.New(t)
+
+	// Test that the reverseSchemaDiff function properly handles extension fields
+	originalDiff := &difftypes.SchemaDiff{
+		ExtensionsAdded:   []string{"pg_trgm", "btree_gin"},
+		ExtensionsRemoved: []string{"postgis"},
+	}
+
+	reversedDiff := reverseSchemaDiff(originalDiff)
+
+	// Verify that extension fields are properly reversed
+	c.Assert(reversedDiff.ExtensionsAdded, qt.DeepEquals, originalDiff.ExtensionsRemoved)
+	c.Assert(reversedDiff.ExtensionsRemoved, qt.DeepEquals, originalDiff.ExtensionsAdded)
+
+	// Verify the specific values
+	c.Assert(reversedDiff.ExtensionsAdded, qt.DeepEquals, []string{"postgis"})
+	c.Assert(reversedDiff.ExtensionsRemoved, qt.DeepEquals, []string{"pg_trgm", "btree_gin"})
+}
+
+func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
+	c := qt.New(t)
+
+	// Test the complete flow: schema with extensions -> empty database -> up migration -> down migration
+	generatedSchema := &goschema.Database{
+		Extensions: []goschema.Extension{
+			{Name: "pg_trgm", IfNotExists: true, Comment: "Enable trigram similarity search"},
+		},
+	}
+
+	emptyDatabase := &types.DBSchema{
+		Extensions: []types.DBExtension{},
+	}
+
+	// 1. Generate up migration (should create extension)
+	upDiff := schemadiff.Compare(generatedSchema, emptyDatabase)
+	upSQL, err := generateUpMigrationSQL(upDiff, generatedSchema, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION IF NOT EXISTS pg_trgm;"), qt.IsTrue)
+
+	// 2. Simulate database state after up migration
+	databaseAfterUp := &types.DBSchema{
+		Extensions: []types.DBExtension{
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},
+		},
+	}
+
+	// 3. Generate down migration (should drop extension)
+	// For down migration, we use the original upDiff and reverse it
+	downSQL, err := generateDownMigrationSQL(upDiff, databaseAfterUp, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(downSQL, "DROP EXTENSION IF EXISTS pg_trgm;"), qt.IsTrue)
+
+	// 4. Verify the cycle is complete
+	c.Assert(upDiff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
+	c.Assert(len(upDiff.ExtensionsRemoved), qt.Equals, 0)
+}

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -1,0 +1,171 @@
+package generator
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestReverseSchemaDiff_Extensions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *types.SchemaDiff
+		expected *types.SchemaDiff
+	}{
+		{
+			name: "reverse extensions added and removed",
+			input: &types.SchemaDiff{
+				ExtensionsAdded:   []string{"pg_trgm", "btree_gin"},
+				ExtensionsRemoved: []string{"postgis", "uuid-ossp"},
+			},
+			expected: &types.SchemaDiff{
+				ExtensionsAdded:   []string{"postgis", "uuid-ossp"},
+				ExtensionsRemoved: []string{"pg_trgm", "btree_gin"},
+			},
+		},
+		{
+			name: "reverse only extensions added",
+			input: &types.SchemaDiff{
+				ExtensionsAdded:   []string{"pg_trgm"},
+				ExtensionsRemoved: []string{},
+			},
+			expected: &types.SchemaDiff{
+				ExtensionsAdded:   []string{},
+				ExtensionsRemoved: []string{"pg_trgm"},
+			},
+		},
+		{
+			name: "reverse only extensions removed",
+			input: &types.SchemaDiff{
+				ExtensionsAdded:   []string{},
+				ExtensionsRemoved: []string{"postgis"},
+			},
+			expected: &types.SchemaDiff{
+				ExtensionsAdded:   []string{"postgis"},
+				ExtensionsRemoved: []string{},
+			},
+		},
+		{
+			name: "no extensions to reverse",
+			input: &types.SchemaDiff{
+				ExtensionsAdded:   []string{},
+				ExtensionsRemoved: []string{},
+			},
+			expected: &types.SchemaDiff{
+				ExtensionsAdded:   []string{},
+				ExtensionsRemoved: []string{},
+			},
+		},
+		{
+			name: "nil extension slices",
+			input: &types.SchemaDiff{
+				ExtensionsAdded:   nil,
+				ExtensionsRemoved: nil,
+			},
+			expected: &types.SchemaDiff{
+				ExtensionsAdded:   nil,
+				ExtensionsRemoved: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			result := reverseSchemaDiff(tt.input)
+
+			c.Assert(result.ExtensionsAdded, qt.DeepEquals, tt.expected.ExtensionsAdded)
+			c.Assert(result.ExtensionsRemoved, qt.DeepEquals, tt.expected.ExtensionsRemoved)
+		})
+	}
+}
+
+func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
+	c := qt.New(t)
+
+	// Test that all fields are properly reversed
+	input := &types.SchemaDiff{
+		TablesAdded:       []string{"users", "posts"},
+		TablesRemoved:     []string{"old_table"},
+		EnumsAdded:        []string{"status_type"},
+		EnumsRemoved:      []string{"old_enum"},
+		IndexesAdded:      []string{"idx_users_email"},
+		IndexesRemoved:    []string{"idx_old"},
+		ExtensionsAdded:   []string{"pg_trgm", "btree_gin"},
+		ExtensionsRemoved: []string{"postgis"},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	// Verify all reversals
+	c.Assert(result.TablesAdded, qt.DeepEquals, input.TablesRemoved)
+	c.Assert(result.TablesRemoved, qt.DeepEquals, input.TablesAdded)
+	c.Assert(result.EnumsAdded, qt.DeepEquals, input.EnumsRemoved)
+	c.Assert(result.EnumsRemoved, qt.DeepEquals, input.EnumsAdded)
+	c.Assert(result.IndexesAdded, qt.DeepEquals, input.IndexesRemoved)
+	c.Assert(result.IndexesRemoved, qt.DeepEquals, input.IndexesAdded)
+	c.Assert(result.ExtensionsAdded, qt.DeepEquals, input.ExtensionsRemoved)
+	c.Assert(result.ExtensionsRemoved, qt.DeepEquals, input.ExtensionsAdded)
+}
+
+func TestReverseSchemaDiff_TableModifications(t *testing.T) {
+	c := qt.New(t)
+
+	// Test table modifications reversal
+	input := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{
+				TableName:      "users",
+				ColumnsAdded:   []string{"email", "created_at"},
+				ColumnsRemoved: []string{"legacy_field"},
+				ColumnsModified: []types.ColumnDiff{
+					{
+						ColumnName: "name",
+						Changes:    map[string]string{"type": "VARCHAR(100) -> VARCHAR(255)"},
+					},
+				},
+			},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Assert(len(result.TablesModified), qt.Equals, 1)
+
+	reversedTable := result.TablesModified[0]
+	c.Assert(reversedTable.TableName, qt.Equals, "users")
+	c.Assert(reversedTable.ColumnsAdded, qt.DeepEquals, []string{"legacy_field"})
+	c.Assert(reversedTable.ColumnsRemoved, qt.DeepEquals, []string{"email", "created_at"})
+
+	c.Assert(len(reversedTable.ColumnsModified), qt.Equals, 1)
+	reversedColumn := reversedTable.ColumnsModified[0]
+	c.Assert(reversedColumn.ColumnName, qt.Equals, "name")
+	c.Assert(reversedColumn.Changes["type"], qt.Equals, "VARCHAR(255) -> VARCHAR(100)")
+}
+
+func TestReverseSchemaDiff_EnumModifications(t *testing.T) {
+	c := qt.New(t)
+
+	// Test enum modifications reversal
+	input := &types.SchemaDiff{
+		EnumsModified: []types.EnumDiff{
+			{
+				EnumName:      "status_type",
+				ValuesAdded:   []string{"pending", "archived"},
+				ValuesRemoved: []string{"deprecated"},
+			},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Assert(len(result.EnumsModified), qt.Equals, 1)
+
+	reversedEnum := result.EnumsModified[0]
+	c.Assert(reversedEnum.EnumName, qt.Equals, "status_type")
+	c.Assert(reversedEnum.ValuesAdded, qt.DeepEquals, []string{"deprecated"})
+	c.Assert(reversedEnum.ValuesRemoved, qt.DeepEquals, []string{"pending", "archived"})
+}


### PR DESCRIPTION
This pull request introduces support for database extensions in the schema conversion and migration process. It includes changes to handle extensions in schema conversion, schema diff reversal, migration file generation, and testing. The most important changes are grouped by theme below.

### Schema Conversion Enhancements:
* Added handling of extensions in the `ConvertDBSchemaToGoSchema` function to convert database extensions into Go schema extensions, including support for comments and default values. (`core/convert/dbschematogo/dbschematogo.go`, [[1]](diffhunk://#diff-3fb2a4f21faf06df8546fdf2efd8c6fc546bcff9b3e8b7617c61e77824bf8fc9R18) [[2]](diffhunk://#diff-3fb2a4f21faf06df8546fdf2efd8c6fc546bcff9b3e8b7617c61e77824bf8fc9R80-R95)

### Testing Enhancements:
* Added unit tests for converting database extensions to Go schema extensions, covering scenarios such as single/multiple extensions, extensions with comments, and nil/empty extensions. (`core/convert/dbschematogo/dbschematogo_test.go`, [core/convert/dbschematogo/dbschematogo_test.goR1-R202](diffhunk://#diff-c7e4f6ecfe9aa2c512b8b13430a4c89ee55be7fe7b3e60e1f3b88754928de755R1-R202))
* Added integration tests for extension migrations, verifying correct SQL generation for adding, removing, and versioning extensions. (`migration/generator/extension_integration_test.go`, [migration/generator/extension_integration_test.goR1-R217](diffhunk://#diff-716b72b7deef65f429762459bf25c4b0c68dd57b90d41481a6b8b983613305a1R1-R217))
* Added tests for the `reverseSchemaDiff` function to ensure proper reversal of extension-related schema changes. (`migration/generator/reverse_diff_test.go`, [migration/generator/reverse_diff_test.goR1-R171](diffhunk://#diff-8d0850777a024921bff8bc0900a69bb27a5b13c39f76111fdbf30c4685977557R1-R171))

### Migration Enhancements:
* Modified the `reverseSchemaDiff` function to include reversal of extension operations, ensuring extensions added are reversed to extensions removed, and vice versa. (`migration/generator/generator.go`, [migration/generator/generator.goR168-R171](diffhunk://#diff-cadd777c44e249ccd30d9efce34975fb467c94ffc21fbabcf2b8f68dd97c675eR168-R171))
* Added tests for migration file generation to verify correct SQL for adding and removing extensions in both up and down migrations. (`migration/generator/migration_file_generation_test.go`, [migration/generator/migration_file_generation_test.goR1-R182](diffhunk://#diff-016c12af94b33c58384760b3b23ff1db1c50bd0d8906285084fa8e8f32eb416eR1-R182))