### PR TITLE
Fix migration field order randomization in deduplicate function

### DIFF
--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -397,48 +397,52 @@ func deduplicate(r *Database) {
 		r.Tables = append(r.Tables, table)
 	}
 
-	// deduplicate fields by struct name and field name
-	fieldMap := make(map[string]Field)
+	// deduplicate fields by struct name and field name (preserving order)
+	fieldSeen := make(map[string]bool)
+	var deduplicatedFields []Field
 	for _, field := range r.Fields {
 		key := field.StructName + "." + field.Name
-		fieldMap[key] = field
+		if !fieldSeen[key] {
+			fieldSeen[key] = true
+			deduplicatedFields = append(deduplicatedFields, field)
+		}
 	}
-	r.Fields = make([]Field, 0, len(fieldMap))
-	for _, field := range fieldMap {
-		r.Fields = append(r.Fields, field)
-	}
+	r.Fields = deduplicatedFields
 
-	// deduplicate indexes by struct name and index name
-	indexMap := make(map[string]Index)
+	// deduplicate indexes by struct name and index name (preserving order)
+	indexSeen := make(map[string]bool)
+	var deduplicatedIndexes []Index
 	for _, index := range r.Indexes {
 		key := index.StructName + "." + index.Name
-		indexMap[key] = index
+		if !indexSeen[key] {
+			indexSeen[key] = true
+			deduplicatedIndexes = append(deduplicatedIndexes, index)
+		}
 	}
-	r.Indexes = make([]Index, 0, len(indexMap))
-	for _, index := range indexMap {
-		r.Indexes = append(r.Indexes, index)
-	}
+	r.Indexes = deduplicatedIndexes
 
-	// deduplicate enums by name
-	enumMap := make(map[string]Enum)
+	// deduplicate enums by name (preserving order)
+	enumSeen := make(map[string]bool)
+	var deduplicatedEnums []Enum
 	for _, enum := range r.Enums {
-		enumMap[enum.Name] = enum
+		if !enumSeen[enum.Name] {
+			enumSeen[enum.Name] = true
+			deduplicatedEnums = append(deduplicatedEnums, enum)
+		}
 	}
-	r.Enums = make([]Enum, 0, len(enumMap))
-	for _, enum := range enumMap {
-		r.Enums = append(r.Enums, enum)
-	}
+	r.Enums = deduplicatedEnums
 
-	// deduplicate embedded fields by struct name and embedded type name
-	embeddedMap := make(map[string]EmbeddedField)
+	// deduplicate embedded fields by struct name and embedded type name (preserving order)
+	embeddedSeen := make(map[string]bool)
+	var deduplicatedEmbedded []EmbeddedField
 	for _, embedded := range r.EmbeddedFields {
 		key := embedded.StructName + "." + embedded.EmbeddedTypeName
-		embeddedMap[key] = embedded
+		if !embeddedSeen[key] {
+			embeddedSeen[key] = true
+			deduplicatedEmbedded = append(deduplicatedEmbedded, embedded)
+		}
 	}
-	r.EmbeddedFields = make([]EmbeddedField, 0, len(embeddedMap))
-	for _, embedded := range embeddedMap {
-		r.EmbeddedFields = append(r.EmbeddedFields, embedded)
-	}
+	r.EmbeddedFields = deduplicatedEmbedded
 
 	// deduplicate extensions by name
 	extensionMap := make(map[string]Extension)
@@ -459,33 +463,36 @@ func deduplicate(r *Database) {
 		r.Extensions = append(r.Extensions, extensionMap[name])
 	}
 
-	// deduplicate functions by name
-	functionMap := make(map[string]Function)
+	// deduplicate functions by name (preserving order)
+	functionSeen := make(map[string]bool)
+	var deduplicatedFunctions []Function
 	for _, function := range r.Functions {
-		functionMap[function.Name] = function
+		if !functionSeen[function.Name] {
+			functionSeen[function.Name] = true
+			deduplicatedFunctions = append(deduplicatedFunctions, function)
+		}
 	}
-	r.Functions = make([]Function, 0, len(functionMap))
-	for _, function := range functionMap {
-		r.Functions = append(r.Functions, function)
-	}
+	r.Functions = deduplicatedFunctions
 
-	// deduplicate RLS policies by name
-	rlsPolicyMap := make(map[string]RLSPolicy)
+	// deduplicate RLS policies by name (preserving order)
+	rlsPolicySeen := make(map[string]bool)
+	var deduplicatedRLSPolicies []RLSPolicy
 	for _, policy := range r.RLSPolicies {
-		rlsPolicyMap[policy.Name] = policy
+		if !rlsPolicySeen[policy.Name] {
+			rlsPolicySeen[policy.Name] = true
+			deduplicatedRLSPolicies = append(deduplicatedRLSPolicies, policy)
+		}
 	}
-	r.RLSPolicies = make([]RLSPolicy, 0, len(rlsPolicyMap))
-	for _, policy := range rlsPolicyMap {
-		r.RLSPolicies = append(r.RLSPolicies, policy)
-	}
+	r.RLSPolicies = deduplicatedRLSPolicies
 
-	// deduplicate RLS enabled tables by table name
-	rlsEnabledMap := make(map[string]RLSEnabledTable)
+	// deduplicate RLS enabled tables by table name (preserving order)
+	rlsEnabledSeen := make(map[string]bool)
+	var deduplicatedRLSEnabled []RLSEnabledTable
 	for _, rlsTable := range r.RLSEnabledTables {
-		rlsEnabledMap[rlsTable.Table] = rlsTable
+		if !rlsEnabledSeen[rlsTable.Table] {
+			rlsEnabledSeen[rlsTable.Table] = true
+			deduplicatedRLSEnabled = append(deduplicatedRLSEnabled, rlsTable)
+		}
 	}
-	r.RLSEnabledTables = make([]RLSEnabledTable, 0, len(rlsEnabledMap))
-	for _, rlsTable := range rlsEnabledMap {
-		r.RLSEnabledTables = append(r.RLSEnabledTables, rlsTable)
-	}
+	r.RLSEnabledTables = deduplicatedRLSEnabled
 }

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -385,7 +385,7 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 // This method modifies the PackageParseResult in-place, replacing the original
 // slices with deduplicated versions. The order of entities may change during
 // this process, but dependency ordering is handled separately.
-func deduplicate(r *Database) {
+func Deduplicate(r *Database) {
 	// deduplicate tables by name
 	tableMap := make(map[string]Table)
 	for _, table := range r.Tables {

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 )
 

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -444,24 +444,16 @@ func deduplicate(r *Database) {
 	}
 	r.EmbeddedFields = deduplicatedEmbedded
 
-	// deduplicate extensions by name
-	extensionMap := make(map[string]Extension)
+	// deduplicate extensions by name (preserving order)
+	extensionSeen := make(map[string]bool)
+	var deduplicatedExtensions []Extension
 	for _, extension := range r.Extensions {
-		extensionMap[extension.Name] = extension
+		if !extensionSeen[extension.Name] {
+			extensionSeen[extension.Name] = true
+			deduplicatedExtensions = append(deduplicatedExtensions, extension)
+		}
 	}
-	r.Extensions = make([]Extension, 0, len(extensionMap))
-
-	// Sort extension names for consistent ordering
-	extensionNames := make([]string, 0, len(extensionMap))
-	for name := range extensionMap {
-		extensionNames = append(extensionNames, name)
-	}
-	sort.Strings(extensionNames)
-
-	// Add extensions in sorted order
-	for _, name := range extensionNames {
-		r.Extensions = append(r.Extensions, extensionMap[name])
-	}
+	r.Extensions = deduplicatedExtensions
 
 	// deduplicate functions by name (preserving order)
 	functionSeen := make(map[string]bool)

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -9,7 +9,6 @@ import (
 // TestDeduplicatePreservesFieldOrder tests that the deduplicate function preserves the original order of fields
 func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	c := qt.New(t)
-	
 	// Create a database with fields in a specific order
 	db := &Database{
 		Fields: []Field{

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -1,0 +1,338 @@
+package goschema
+
+import (
+	"testing"
+)
+
+// TestDeduplicatePreservesFieldOrder tests that the deduplicate function preserves the original order of fields
+func TestDeduplicatePreservesFieldOrder(t *testing.T) {
+	// Create a database with fields in a specific order
+	db := &Database{
+		Fields: []Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
+			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
+			{StructName: "User", Name: "created_at", Type: "TIMESTAMP"},
+			{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "Profile", Name: "bio", Type: "TEXT"},
+		},
+		Indexes:           []Index{},
+		Enums:             []Enum{},
+		EmbeddedFields:    []EmbeddedField{},
+		Functions:         []Function{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Extensions:        []Extension{},
+		Tables:            []Table{},
+	}
+
+	// Record original field order
+	originalOrder := make([]string, len(db.Fields))
+	for i, field := range db.Fields {
+		originalOrder[i] = field.StructName + "." + field.Name
+	}
+
+	// Run deduplication
+	deduplicate(db)
+
+	// Verify field order is preserved
+	if len(db.Fields) != len(originalOrder) {
+		t.Fatalf("Expected %d fields after deduplication, got %d", len(originalOrder), len(db.Fields))
+	}
+
+	for i, field := range db.Fields {
+		expectedKey := originalOrder[i]
+		actualKey := field.StructName + "." + field.Name
+		if actualKey != expectedKey {
+			t.Errorf("Field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+}
+
+// TestDeduplicateFieldOrderConsistency tests that multiple runs produce identical field order
+func TestDeduplicateFieldOrderConsistency(t *testing.T) {
+	createDatabase := func() *Database {
+		return &Database{
+			Fields: []Field{
+				{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+				{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
+				{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
+				{StructName: "User", Name: "created_at", Type: "TIMESTAMP"},
+				{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: "true"},
+				{StructName: "Profile", Name: "bio", Type: "TEXT"},
+			},
+			Indexes:           []Index{},
+			Enums:             []Enum{},
+			EmbeddedFields:    []EmbeddedField{},
+			Functions:         []Function{},
+			RLSPolicies:       []RLSPolicy{},
+			RLSEnabledTables:  []RLSEnabledTable{},
+			Extensions:        []Extension{},
+			Tables:            []Table{},
+		}
+	}
+
+	// Run deduplication multiple times and compare results
+	runs := 10
+	var results [][]string
+
+	for run := 0; run < runs; run++ {
+		db := createDatabase()
+		deduplicate(db)
+
+		// Record field order for this run
+		fieldOrder := make([]string, len(db.Fields))
+		for i, field := range db.Fields {
+			fieldOrder[i] = field.StructName + "." + field.Name
+		}
+		results = append(results, fieldOrder)
+	}
+
+	// Compare all runs to the first run
+	firstRunOrder := results[0]
+	for run := 1; run < runs; run++ {
+		currentRunOrder := results[run]
+		
+		if len(currentRunOrder) != len(firstRunOrder) {
+			t.Fatalf("Run %d produced different number of fields: expected %d, got %d", 
+				run, len(firstRunOrder), len(currentRunOrder))
+		}
+
+		for i, field := range currentRunOrder {
+			if field != firstRunOrder[i] {
+				t.Errorf("Inconsistent field order between runs: run 0 position %d = %s, run %d position %d = %s", 
+					i, firstRunOrder[i], run, i, field)
+			}
+		}
+	}
+}
+
+// TestDeduplicateRemovesDuplicateFields tests that duplicate fields are properly removed
+func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
+	db := &Database{
+		Fields: []Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"}, // Duplicate
+			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
+			{StructName: "User", Name: "email", Type: "VARCHAR(255)"}, // Duplicate
+		},
+		Indexes:           []Index{},
+		Enums:             []Enum{},
+		EmbeddedFields:    []EmbeddedField{},
+		Functions:         []Function{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Extensions:        []Extension{},
+		Tables:            []Table{},
+	}
+
+	deduplicate(db)
+
+	// Should have 3 unique fields
+	if len(db.Fields) != 3 {
+		t.Fatalf("Expected 3 unique fields after deduplication, got %d", len(db.Fields))
+	}
+
+	// Check that we have the expected fields in order
+	expectedFields := []string{
+		"User.id",
+		"User.email", 
+		"User.name",
+	}
+
+	for i, field := range db.Fields {
+		expectedKey := expectedFields[i]
+		actualKey := field.StructName + "." + field.Name
+		if actualKey != expectedKey {
+			t.Errorf("Unexpected field at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+}
+
+// TestDeduplicatePreservesIndexOrder tests that index deduplication preserves order
+func TestDeduplicatePreservesIndexOrder(t *testing.T) {
+	db := &Database{
+		Fields: []Field{},
+		Indexes: []Index{
+			{StructName: "User", Name: "idx_email", Type: "btree"},
+			{StructName: "User", Name: "idx_name", Type: "btree"},
+			{StructName: "Profile", Name: "idx_bio", Type: "gin"},
+		},
+		Enums:             []Enum{},
+		EmbeddedFields:    []EmbeddedField{},
+		Functions:         []Function{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Extensions:        []Extension{},
+		Tables:            []Table{},
+	}
+
+	originalOrder := make([]string, len(db.Indexes))
+	for i, index := range db.Indexes {
+		originalOrder[i] = index.StructName + "." + index.Name
+	}
+
+	deduplicate(db)
+
+	if len(db.Indexes) != len(originalOrder) {
+		t.Fatalf("Expected %d indexes after deduplication, got %d", len(originalOrder), len(db.Indexes))
+	}
+
+	for i, index := range db.Indexes {
+		expectedKey := originalOrder[i]
+		actualKey := index.StructName + "." + index.Name
+		if actualKey != expectedKey {
+			t.Errorf("Index order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+}
+
+// TestDeduplicatePreservesEnumOrder tests that enum deduplication preserves order
+func TestDeduplicatePreservesEnumOrder(t *testing.T) {
+	db := &Database{
+		Fields:  []Field{},
+		Indexes: []Index{},
+		Enums: []Enum{
+			{Name: "user_status", Values: []string{"active", "inactive"}},
+			{Name: "priority_level", Values: []string{"high", "medium", "low"}},
+			{Name: "permission_type", Values: []string{"read", "write", "admin"}},
+		},
+		EmbeddedFields:    []EmbeddedField{},
+		Functions:         []Function{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Extensions:        []Extension{},
+		Tables:            []Table{},
+	}
+
+	originalOrder := make([]string, len(db.Enums))
+	for i, enum := range db.Enums {
+		originalOrder[i] = enum.Name
+	}
+
+	deduplicate(db)
+
+	if len(db.Enums) != len(originalOrder) {
+		t.Fatalf("Expected %d enums after deduplication, got %d", len(originalOrder), len(db.Enums))
+	}
+
+	for i, enum := range db.Enums {
+		if enum.Name != originalOrder[i] {
+			t.Errorf("Enum order not preserved at position %d: expected %s, got %s", i, originalOrder[i], enum.Name)
+		}
+	}
+}
+
+// TestDeduplicatePreservesEmbeddedFieldOrder tests that embedded field deduplication preserves order
+func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
+	db := &Database{
+		Fields:  []Field{},
+		Indexes: []Index{},
+		Enums:   []Enum{},
+		EmbeddedFields: []EmbeddedField{
+			{StructName: "User", EmbeddedTypeName: "BaseModel", Mode: "inline"},
+			{StructName: "User", EmbeddedTypeName: "Timestamps", Mode: "inline"},
+			{StructName: "Profile", EmbeddedTypeName: "BaseModel", Mode: "inline"},
+		},
+		Functions:         []Function{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Extensions:        []Extension{},
+		Tables:            []Table{},
+	}
+
+	originalOrder := make([]string, len(db.EmbeddedFields))
+	for i, embedded := range db.EmbeddedFields {
+		originalOrder[i] = embedded.StructName + "." + embedded.EmbeddedTypeName
+	}
+
+	deduplicate(db)
+
+	if len(db.EmbeddedFields) != len(originalOrder) {
+		t.Fatalf("Expected %d embedded fields after deduplication, got %d", len(originalOrder), len(db.EmbeddedFields))
+	}
+
+	for i, embedded := range db.EmbeddedFields {
+		expectedKey := originalOrder[i]
+		actualKey := embedded.StructName + "." + embedded.EmbeddedTypeName
+		if actualKey != expectedKey {
+			t.Errorf("Embedded field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+}
+
+// TestDeduplicateAllCollections tests order preservation across all collections
+func TestDeduplicateAllCollections(t *testing.T) {
+	db := &Database{
+		Fields: []Field{
+			{StructName: "User", Name: "id", Type: "SERIAL"},
+			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
+		},
+		Indexes: []Index{
+			{StructName: "User", Name: "idx_email", Type: "btree"},
+		},
+		Enums: []Enum{
+			{Name: "user_status", Values: []string{"active", "inactive"}},
+		},
+		EmbeddedFields: []EmbeddedField{
+			{StructName: "User", EmbeddedTypeName: "BaseModel", Mode: "inline"},
+		},
+		Functions: []Function{
+			{Name: "get_user_count", Body: "SELECT COUNT(*) FROM users;"},
+		},
+		RLSPolicies: []RLSPolicy{
+			{Name: "user_policy", Table: "users"},
+		},
+		RLSEnabledTables: []RLSEnabledTable{
+			{Table: "users"},
+		},
+		Extensions: []Extension{
+			{Name: "uuid-ossp"},
+		},
+		Tables: []Table{
+			{Name: "users", StructName: "User"},
+		},
+	}
+
+	// Record original orders
+	originalFieldOrder := make([]string, len(db.Fields))
+	for i, field := range db.Fields {
+		originalFieldOrder[i] = field.StructName + "." + field.Name
+	}
+
+	originalIndexOrder := make([]string, len(db.Indexes))
+	for i, index := range db.Indexes {
+		originalIndexOrder[i] = index.StructName + "." + index.Name
+	}
+
+	originalEnumOrder := make([]string, len(db.Enums))
+	for i, enum := range db.Enums {
+		originalEnumOrder[i] = enum.Name
+	}
+
+	deduplicate(db)
+
+	// Verify all orders are preserved
+	for i, field := range db.Fields {
+		expectedKey := originalFieldOrder[i]
+		actualKey := field.StructName + "." + field.Name
+		if actualKey != expectedKey {
+			t.Errorf("Field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+
+	for i, index := range db.Indexes {
+		expectedKey := originalIndexOrder[i]
+		actualKey := index.StructName + "." + index.Name
+		if actualKey != expectedKey {
+			t.Errorf("Index order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
+		}
+	}
+
+	for i, enum := range db.Enums {
+		if enum.Name != originalEnumOrder[i] {
+			t.Errorf("Enum order not preserved at position %d: expected %s, got %s", i, originalEnumOrder[i], enum.Name)
+		}
+	}
+}

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -40,7 +40,7 @@ func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	deduplicate(db)
 
 	// Verify field order is preserved
-	c.Assert(len(db.Fields), qt.Equals, len(originalOrder))
+	c.Assert(db.Fields, qt.HasLen, len(originalOrder))
 
 	for i, field := range db.Fields {
 		expectedKey := originalOrder[i]
@@ -95,7 +95,7 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 	for run := 1; run < runs; run++ {
 		currentRunOrder := results[run]
 		
-		c.Assert(len(currentRunOrder), qt.Equals, len(firstRunOrder), 
+		c.Assert(currentRunOrder, qt.HasLen, len(firstRunOrder), 
 			qt.Commentf("Run %d produced different number of fields", run))
 
 		for i, field := range currentRunOrder {
@@ -131,7 +131,7 @@ func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 	deduplicate(db)
 
 	// Should have 3 unique fields
-	c.Assert(len(db.Fields), qt.Equals, 3)
+	c.Assert(db.Fields, qt.HasLen, 3)
 
 	// Check that we have the expected fields in order
 	expectedFields := []string{
@@ -174,7 +174,7 @@ func TestDeduplicatePreservesIndexOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	c.Assert(len(db.Indexes), qt.Equals, len(originalOrder))
+	c.Assert(db.Indexes, qt.HasLen, len(originalOrder))
 
 	for i, index := range db.Indexes {
 		expectedKey := originalOrder[i]
@@ -210,7 +210,7 @@ func TestDeduplicatePreservesEnumOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	c.Assert(len(db.Enums), qt.Equals, len(originalOrder))
+	c.Assert(db.Enums, qt.HasLen, len(originalOrder))
 
 	for i, enum := range db.Enums {
 		c.Assert(enum.Name, qt.Equals, originalOrder[i], qt.Commentf("Enum order not preserved at position %d", i))
@@ -244,7 +244,7 @@ func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	c.Assert(len(db.EmbeddedFields), qt.Equals, len(originalOrder))
+	c.Assert(db.EmbeddedFields, qt.HasLen, len(originalOrder))
 
 	for i, embedded := range db.EmbeddedFields {
 		expectedKey := originalOrder[i]

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -2,10 +2,14 @@ package goschema
 
 import (
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 // TestDeduplicatePreservesFieldOrder tests that the deduplicate function preserves the original order of fields
 func TestDeduplicatePreservesFieldOrder(t *testing.T) {
+	c := qt.New(t)
+	
 	// Create a database with fields in a specific order
 	db := &Database{
 		Fields: []Field{
@@ -36,21 +40,19 @@ func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	deduplicate(db)
 
 	// Verify field order is preserved
-	if len(db.Fields) != len(originalOrder) {
-		t.Fatalf("Expected %d fields after deduplication, got %d", len(originalOrder), len(db.Fields))
-	}
+	c.Assert(len(db.Fields), qt.Equals, len(originalOrder))
 
 	for i, field := range db.Fields {
 		expectedKey := originalOrder[i]
 		actualKey := field.StructName + "." + field.Name
-		if actualKey != expectedKey {
-			t.Errorf("Field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Field order not preserved at position %d", i))
 	}
 }
 
 // TestDeduplicateFieldOrderConsistency tests that multiple runs produce identical field order
 func TestDeduplicateFieldOrderConsistency(t *testing.T) {
+	c := qt.New(t)
+	
 	createDatabase := func() *Database {
 		return &Database{
 			Fields: []Field{
@@ -93,22 +95,21 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 	for run := 1; run < runs; run++ {
 		currentRunOrder := results[run]
 		
-		if len(currentRunOrder) != len(firstRunOrder) {
-			t.Fatalf("Run %d produced different number of fields: expected %d, got %d", 
-				run, len(firstRunOrder), len(currentRunOrder))
-		}
+		c.Assert(len(currentRunOrder), qt.Equals, len(firstRunOrder), 
+			qt.Commentf("Run %d produced different number of fields", run))
 
 		for i, field := range currentRunOrder {
-			if field != firstRunOrder[i] {
-				t.Errorf("Inconsistent field order between runs: run 0 position %d = %s, run %d position %d = %s", 
-					i, firstRunOrder[i], run, i, field)
-			}
+			c.Assert(field, qt.Equals, firstRunOrder[i], 
+				qt.Commentf("Inconsistent field order between runs: run 0 position %d = %s, run %d position %d = %s", 
+					i, firstRunOrder[i], run, i, field))
 		}
 	}
 }
 
 // TestDeduplicateRemovesDuplicateFields tests that duplicate fields are properly removed
 func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
+	c := qt.New(t)
+	
 	db := &Database{
 		Fields: []Field{
 			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
@@ -130,9 +131,7 @@ func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 	deduplicate(db)
 
 	// Should have 3 unique fields
-	if len(db.Fields) != 3 {
-		t.Fatalf("Expected 3 unique fields after deduplication, got %d", len(db.Fields))
-	}
+	c.Assert(len(db.Fields), qt.Equals, 3)
 
 	// Check that we have the expected fields in order
 	expectedFields := []string{
@@ -144,14 +143,14 @@ func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 	for i, field := range db.Fields {
 		expectedKey := expectedFields[i]
 		actualKey := field.StructName + "." + field.Name
-		if actualKey != expectedKey {
-			t.Errorf("Unexpected field at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Unexpected field at position %d", i))
 	}
 }
 
 // TestDeduplicatePreservesIndexOrder tests that index deduplication preserves order
 func TestDeduplicatePreservesIndexOrder(t *testing.T) {
+	c := qt.New(t)
+	
 	db := &Database{
 		Fields: []Field{},
 		Indexes: []Index{
@@ -175,21 +174,19 @@ func TestDeduplicatePreservesIndexOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	if len(db.Indexes) != len(originalOrder) {
-		t.Fatalf("Expected %d indexes after deduplication, got %d", len(originalOrder), len(db.Indexes))
-	}
+	c.Assert(len(db.Indexes), qt.Equals, len(originalOrder))
 
 	for i, index := range db.Indexes {
 		expectedKey := originalOrder[i]
 		actualKey := index.StructName + "." + index.Name
-		if actualKey != expectedKey {
-			t.Errorf("Index order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Index order not preserved at position %d", i))
 	}
 }
 
 // TestDeduplicatePreservesEnumOrder tests that enum deduplication preserves order
 func TestDeduplicatePreservesEnumOrder(t *testing.T) {
+	c := qt.New(t)
+	
 	db := &Database{
 		Fields:  []Field{},
 		Indexes: []Index{},
@@ -213,19 +210,17 @@ func TestDeduplicatePreservesEnumOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	if len(db.Enums) != len(originalOrder) {
-		t.Fatalf("Expected %d enums after deduplication, got %d", len(originalOrder), len(db.Enums))
-	}
+	c.Assert(len(db.Enums), qt.Equals, len(originalOrder))
 
 	for i, enum := range db.Enums {
-		if enum.Name != originalOrder[i] {
-			t.Errorf("Enum order not preserved at position %d: expected %s, got %s", i, originalOrder[i], enum.Name)
-		}
+		c.Assert(enum.Name, qt.Equals, originalOrder[i], qt.Commentf("Enum order not preserved at position %d", i))
 	}
 }
 
 // TestDeduplicatePreservesEmbeddedFieldOrder tests that embedded field deduplication preserves order
 func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
+	c := qt.New(t)
+	
 	db := &Database{
 		Fields:  []Field{},
 		Indexes: []Index{},
@@ -249,21 +244,19 @@ func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
 
 	deduplicate(db)
 
-	if len(db.EmbeddedFields) != len(originalOrder) {
-		t.Fatalf("Expected %d embedded fields after deduplication, got %d", len(originalOrder), len(db.EmbeddedFields))
-	}
+	c.Assert(len(db.EmbeddedFields), qt.Equals, len(originalOrder))
 
 	for i, embedded := range db.EmbeddedFields {
 		expectedKey := originalOrder[i]
 		actualKey := embedded.StructName + "." + embedded.EmbeddedTypeName
-		if actualKey != expectedKey {
-			t.Errorf("Embedded field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Embedded field order not preserved at position %d", i))
 	}
 }
 
 // TestDeduplicateAllCollections tests order preservation across all collections
 func TestDeduplicateAllCollections(t *testing.T) {
+	c := qt.New(t)
+	
 	db := &Database{
 		Fields: []Field{
 			{StructName: "User", Name: "id", Type: "SERIAL"},
@@ -317,22 +310,16 @@ func TestDeduplicateAllCollections(t *testing.T) {
 	for i, field := range db.Fields {
 		expectedKey := originalFieldOrder[i]
 		actualKey := field.StructName + "." + field.Name
-		if actualKey != expectedKey {
-			t.Errorf("Field order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Field order not preserved at position %d", i))
 	}
 
 	for i, index := range db.Indexes {
 		expectedKey := originalIndexOrder[i]
 		actualKey := index.StructName + "." + index.Name
-		if actualKey != expectedKey {
-			t.Errorf("Index order not preserved at position %d: expected %s, got %s", i, expectedKey, actualKey)
-		}
+		c.Assert(actualKey, qt.Equals, expectedKey, qt.Commentf("Index order not preserved at position %d", i))
 	}
 
 	for i, enum := range db.Enums {
-		if enum.Name != originalEnumOrder[i] {
-			t.Errorf("Enum order not preserved at position %d: expected %s, got %s", i, originalEnumOrder[i], enum.Name)
-		}
+		c.Assert(enum.Name, qt.Equals, originalEnumOrder[i], qt.Commentf("Enum order not preserved at position %d", i))
 	}
 }

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -13,11 +13,11 @@ func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	// Create a database with fields in a specific order
 	db := &Database{
 		Fields: []Field{
-			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "created_at", Type: "TIMESTAMP"},
-			{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "Profile", Name: "bio", Type: "TEXT"},
 		},
 		Indexes:           []Index{},
@@ -56,11 +56,11 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 	createDatabase := func() *Database {
 		return &Database{
 			Fields: []Field{
-				{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+				{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 				{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 				{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
 				{StructName: "User", Name: "created_at", Type: "TIMESTAMP"},
-				{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: "true"},
+				{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: true},
 				{StructName: "Profile", Name: "bio", Type: "TEXT"},
 			},
 			Indexes:           []Index{},
@@ -112,9 +112,9 @@ func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 	
 	db := &Database{
 		Fields: []Field{
-			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"},
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
-			{StructName: "User", Name: "id", Type: "SERIAL", Primary: "true"}, // Duplicate
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true}, // Duplicate
 			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"}, // Duplicate
 		},

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -1,8 +1,9 @@
-package goschema
+package goschema_test
 
 import (
 	"testing"
 
+	"github.com/stokaro/ptah/core/goschema"
 	qt "github.com/frankban/quicktest"
 )
 
@@ -10,8 +11,8 @@ import (
 func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	c := qt.New(t)
 	// Create a database with fields in a specific order
-	db := &Database{
-		Fields: []Field{
+	db := &goschema.Database{
+		Fields: []goschema.Field{
 			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
@@ -19,14 +20,14 @@ func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 			{StructName: "Profile", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "Profile", Name: "bio", Type: "TEXT"},
 		},
-		Indexes:           []Index{},
-		Enums:             []Enum{},
-		EmbeddedFields:    []EmbeddedField{},
-		Functions:         []Function{},
-		RLSPolicies:       []RLSPolicy{},
-		RLSEnabledTables:  []RLSEnabledTable{},
-		Extensions:        []Extension{},
-		Tables:            []Table{},
+		Indexes:           []goschema.Index{},
+		Enums:             []goschema.Enum{},
+		EmbeddedFields:    []goschema.EmbeddedField{},
+		Functions:         []goschema.Function{},
+		RLSPolicies:       []goschema.RLSPolicy{},
+		RLSEnabledTables:  []goschema.RLSEnabledTable{},
+		Extensions:        []goschema.Extension{},
+		Tables:            []goschema.Table{},
 	}
 
 	// Record original field order
@@ -36,7 +37,7 @@ func TestDeduplicatePreservesFieldOrder(t *testing.T) {
 	}
 
 	// Run deduplication
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	// Verify field order is preserved
 	c.Assert(db.Fields, qt.HasLen, len(originalOrder))
@@ -53,8 +54,8 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 	c := qt.New(t)
 	
 	createDatabase := func() *Database {
-		return &Database{
-			Fields: []Field{
+		return &goschema.Database{
+			Fields: []goschema.Field{
 				{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 				{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 				{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
@@ -79,7 +80,7 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 
 	for run := 0; run < runs; run++ {
 		db := createDatabase()
-		deduplicate(db)
+		goschema.Deduplicate(db)
 
 		// Record field order for this run
 		fieldOrder := make([]string, len(db.Fields))
@@ -109,25 +110,25 @@ func TestDeduplicateFieldOrderConsistency(t *testing.T) {
 func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 	c := qt.New(t)
 	
-	db := &Database{
-		Fields: []Field{
+	db := &goschema.Database{
+		Fields: []goschema.Field{
 			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true}, // Duplicate
 			{StructName: "User", Name: "name", Type: "VARCHAR(255)"},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"}, // Duplicate
 		},
-		Indexes:           []Index{},
-		Enums:             []Enum{},
-		EmbeddedFields:    []EmbeddedField{},
-		Functions:         []Function{},
-		RLSPolicies:       []RLSPolicy{},
-		RLSEnabledTables:  []RLSEnabledTable{},
-		Extensions:        []Extension{},
-		Tables:            []Table{},
+		Indexes:           []goschema.Index{},
+		Enums:             []goschema.Enum{},
+		EmbeddedFields:    []goschema.EmbeddedField{},
+		Functions:         []goschema.Function{},
+		RLSPolicies:       []goschema.RLSPolicy{},
+		RLSEnabledTables:  []goschema.RLSEnabledTable{},
+		Extensions:        []goschema.Extension{},
+		Tables:            []goschema.Table{},
 	}
 
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	// Should have 3 unique fields
 	c.Assert(db.Fields, qt.HasLen, 3)
@@ -150,9 +151,9 @@ func TestDeduplicateRemovesDuplicateFields(t *testing.T) {
 func TestDeduplicatePreservesIndexOrder(t *testing.T) {
 	c := qt.New(t)
 	
-	db := &Database{
-		Fields: []Field{},
-		Indexes: []Index{
+	db := &goschema.Database{
+		Fields: []goschema.Field{},
+		Indexes: []goschema.Index{
 			{StructName: "User", Name: "idx_email", Type: "btree"},
 			{StructName: "User", Name: "idx_name", Type: "btree"},
 			{StructName: "Profile", Name: "idx_bio", Type: "gin"},
@@ -171,7 +172,7 @@ func TestDeduplicatePreservesIndexOrder(t *testing.T) {
 		originalOrder[i] = index.StructName + "." + index.Name
 	}
 
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	c.Assert(db.Indexes, qt.HasLen, len(originalOrder))
 
@@ -186,10 +187,10 @@ func TestDeduplicatePreservesIndexOrder(t *testing.T) {
 func TestDeduplicatePreservesEnumOrder(t *testing.T) {
 	c := qt.New(t)
 	
-	db := &Database{
+	db := &goschema.Database{
 		Fields:  []Field{},
-		Indexes: []Index{},
-		Enums: []Enum{
+		Indexes: []goschema.Index{},
+		Enums: []goschema.Enum{
 			{Name: "user_status", Values: []string{"active", "inactive"}},
 			{Name: "priority_level", Values: []string{"high", "medium", "low"}},
 			{Name: "permission_type", Values: []string{"read", "write", "admin"}},
@@ -207,7 +208,7 @@ func TestDeduplicatePreservesEnumOrder(t *testing.T) {
 		originalOrder[i] = enum.Name
 	}
 
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	c.Assert(db.Enums, qt.HasLen, len(originalOrder))
 
@@ -220,11 +221,11 @@ func TestDeduplicatePreservesEnumOrder(t *testing.T) {
 func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
 	c := qt.New(t)
 	
-	db := &Database{
+	db := &goschema.Database{
 		Fields:  []Field{},
-		Indexes: []Index{},
+		Indexes: []goschema.Index{},
 		Enums:   []Enum{},
-		EmbeddedFields: []EmbeddedField{
+		EmbeddedFields: []goschema.EmbeddedField{
 			{StructName: "User", EmbeddedTypeName: "BaseModel", Mode: "inline"},
 			{StructName: "User", EmbeddedTypeName: "Timestamps", Mode: "inline"},
 			{StructName: "Profile", EmbeddedTypeName: "BaseModel", Mode: "inline"},
@@ -241,7 +242,7 @@ func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
 		originalOrder[i] = embedded.StructName + "." + embedded.EmbeddedTypeName
 	}
 
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	c.Assert(db.EmbeddedFields, qt.HasLen, len(originalOrder))
 
@@ -256,33 +257,33 @@ func TestDeduplicatePreservesEmbeddedFieldOrder(t *testing.T) {
 func TestDeduplicateAllCollections(t *testing.T) {
 	c := qt.New(t)
 	
-	db := &Database{
-		Fields: []Field{
+	db := &goschema.Database{
+		Fields: []goschema.Field{
 			{StructName: "User", Name: "id", Type: "SERIAL"},
 			{StructName: "User", Name: "email", Type: "VARCHAR(255)"},
 		},
-		Indexes: []Index{
+		Indexes: []goschema.Index{
 			{StructName: "User", Name: "idx_email", Type: "btree"},
 		},
-		Enums: []Enum{
+		Enums: []goschema.Enum{
 			{Name: "user_status", Values: []string{"active", "inactive"}},
 		},
-		EmbeddedFields: []EmbeddedField{
+		EmbeddedFields: []goschema.EmbeddedField{
 			{StructName: "User", EmbeddedTypeName: "BaseModel", Mode: "inline"},
 		},
-		Functions: []Function{
+		Functions: []goschema.Function{
 			{Name: "get_user_count", Body: "SELECT COUNT(*) FROM users;"},
 		},
-		RLSPolicies: []RLSPolicy{
+		RLSPolicies: []goschema.RLSPolicy{
 			{Name: "user_policy", Table: "users"},
 		},
-		RLSEnabledTables: []RLSEnabledTable{
+		RLSEnabledTables: []goschema.RLSEnabledTable{
 			{Table: "users"},
 		},
-		Extensions: []Extension{
+		Extensions: []goschema.Extension{
 			{Name: "uuid-ossp"},
 		},
-		Tables: []Table{
+		Tables: []goschema.Table{
 			{Name: "users", StructName: "User"},
 		},
 	}
@@ -303,7 +304,7 @@ func TestDeduplicateAllCollections(t *testing.T) {
 		originalEnumOrder[i] = enum.Name
 	}
 
-	deduplicate(db)
+	goschema.Deduplicate(db)
 
 	// Verify all orders are preserved
 	for i, field := range db.Fields {

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -96,7 +96,7 @@ func ParseDir(rootDir string) (*Database, error) {
 	}
 
 	// deduplicate entities (same table/field defined in multiple files)
-	deduplicate(result)
+	Deduplicate(result)
 
 	// Build dependency graph for foreign key ordering
 	buildDependencyGraph(result)


### PR DESCRIPTION
Fixes #17

This PR resolves the critical issue where the migration generator scrambled field order due to Go's map iteration randomization.

## Changes
- Replace map-based deduplication with order-preserving logic in `core/goschema/utils.go`
- Fix applies to all affected collections: fields, indexes, enums, embedded fields, functions, RLS policies
- Add comprehensive tests in `core/goschema/utils_test.go` for field order consistency

## Impact
- Migration generation is now deterministic across multiple runs
- Field order matches struct declaration order
- Consistent SQL generation for better team collaboration

Generated with [Claude Code](https://claude.ai/code)