### PR TITLE
Refactor database connection logic and add PostgreSQL URL cleanup

### DIFF
--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -49,7 +49,7 @@ func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
 	switch dialect {
 	case "postgres", "postgresql", "pgx":
 		dialectProtocol = "pgx"
-		connectionString = cleanPostgresURL(dbURL)
+		connectionString = removePostgresPoolParams(dbURL)
 	case "mysql", "mariadb":
 		dialectProtocol = "mysql"
 		connectionString = convertMySQLURL(dbURL)
@@ -267,9 +267,12 @@ func convertMySQLURL(dbURL string) string {
 	return connectionString
 }
 
-func cleanPostgresURL(dbURL string) string {
-	// remove pool_max_conns=?&pool_min_conns=?
-	// parse url, remove these query params, reconstruct and return
+// removePostgresPoolParams removes PostgreSQL connection pool parameters from a database URL.
+// These parameters (pool_max_conns and pool_min_conns) are specific to pgx driver configuration
+// and may interfere with standard database connections. This function ensures compatibility
+// by removing them while preserving all other query parameters.
+// If the URL cannot be parsed, it returns the original URL unchanged.
+func removePostgresPoolParams(dbURL string) string {
 	parsedURL, err := url.Parse(dbURL)
 	if err != nil {
 		return dbURL

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -43,7 +43,7 @@ func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
 
 	// Connect to the database
 	// For MySQL/MariaDB, we need to convert the URL format
-	connectionString := dbURL
+	var connectionString string
 
 	var dialectProtocol string
 	switch dialect {

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -40,21 +40,21 @@ func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
 
 	// Determine the dialect
 	dialect := strings.ToLower(parsedURL.Scheme)
-	var dialectProtocol string
-	switch dialect {
-	case "postgres", "postgresql", "pgx":
-		dialectProtocol = "pgx"
-	case "mysql", "mariadb":
-		dialectProtocol = "mysql"
-	default:
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
-	}
 
 	// Connect to the database
 	// For MySQL/MariaDB, we need to convert the URL format
 	connectionString := dbURL
-	if dialectProtocol == "mysql" {
+
+	var dialectProtocol string
+	switch dialect {
+	case "postgres", "postgresql", "pgx":
+		dialectProtocol = "pgx"
+		connectionString = cleanPostgresURL(dbURL)
+	case "mysql", "mariadb":
+		dialectProtocol = "mysql"
 		connectionString = convertMySQLURL(dbURL)
+	default:
+		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
 	}
 
 	db, err := sql.Open(dialectProtocol, connectionString)
@@ -265,4 +265,18 @@ func convertMySQLURL(dbURL string) string {
 	}
 
 	return connectionString
+}
+
+func cleanPostgresURL(dbURL string) string {
+	// remove pool_max_conns=?&pool_min_conns=?
+	// parse url, remove these query params, reconstruct and return
+	parsedURL, err := url.Parse(dbURL)
+	if err != nil {
+		return dbURL
+	}
+	q := parsedURL.Query()
+	q.Del("pool_max_conns")
+	q.Del("pool_min_conns")
+	parsedURL.RawQuery = q.Encode()
+	return parsedURL.String()
 }

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -1,0 +1,144 @@
+package dbschema
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestRemovePostgresPoolParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with both pool params",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conns=10&pool_min_conns=2&other=value",
+			expected: "postgres://user:pass@localhost:5432/db?other=value",
+		},
+		{
+			name:     "URL with only max_conns",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conns=10&other=value",
+			expected: "postgres://user:pass@localhost:5432/db?other=value",
+		},
+		{
+			name:     "URL with only min_conns",
+			input:    "postgres://user:pass@localhost:5432/db?pool_min_conns=2&other=value",
+			expected: "postgres://user:pass@localhost:5432/db?other=value",
+		},
+		{
+			name:     "URL without pool params",
+			input:    "postgres://user:pass@localhost:5432/db?other=value",
+			expected: "postgres://user:pass@localhost:5432/db?other=value",
+		},
+		{
+			name:     "URL with no query params",
+			input:    "postgres://user:pass@localhost:5432/db",
+			expected: "postgres://user:pass@localhost:5432/db",
+		},
+		{
+			name:     "URL with pool params and multiple other params",
+			input:    "postgres://user:pass@localhost:5432/db?sslmode=disable&pool_max_conns=20&timeout=30&pool_min_conns=5&application_name=myapp",
+			expected: "postgres://user:pass@localhost:5432/db?application_name=myapp&sslmode=disable&timeout=30",
+		},
+		{
+			name:     "URL with pool params at different positions",
+			input:    "postgres://user:pass@localhost:5432/db?first=1&pool_max_conns=10&middle=2&pool_min_conns=3&last=4",
+			expected: "postgres://user:pass@localhost:5432/db?first=1&last=4&middle=2",
+		},
+		{
+			name:     "URL with only pool params (should result in no query string)",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conns=10&pool_min_conns=2",
+			expected: "postgres://user:pass@localhost:5432/db",
+		},
+		{
+			name:     "Invalid URL fallback",
+			input:    "not-a-url",
+			expected: "not-a-url",
+		},
+		{
+			name:     "URL with special characters in pool params",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conns=10&other=special%20value&pool_min_conns=2",
+			expected: "postgres://user:pass@localhost:5432/db?other=special+value",
+		},
+		{
+			name:     "Empty URL",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "URL with case variations (should not match)",
+			input:    "postgres://user:pass@localhost:5432/db?POOL_MAX_CONNS=10&Pool_Min_Conns=2&other=value",
+			expected: "postgres://user:pass@localhost:5432/db?POOL_MAX_CONNS=10&Pool_Min_Conns=2&other=value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := removePostgresPoolParams(tt.input)
+			c.Assert(result, qt.Equals, tt.expected, qt.Commentf("removePostgresPoolParams(%q) = %q, want %q", tt.input, result, tt.expected))
+		})
+	}
+}
+
+func TestRemovePostgresPoolParams_ParameterOrdering(t *testing.T) {
+	c := qt.New(t)
+
+	// Test that the function produces consistent results regardless of input parameter order
+	input1 := "postgres://user:pass@localhost:5432/db?pool_max_conns=10&other=value&pool_min_conns=2"
+	input2 := "postgres://user:pass@localhost:5432/db?pool_min_conns=2&pool_max_conns=10&other=value"
+	input3 := "postgres://user:pass@localhost:5432/db?other=value&pool_max_conns=10&pool_min_conns=2"
+
+	result1 := removePostgresPoolParams(input1)
+	result2 := removePostgresPoolParams(input2)
+	result3 := removePostgresPoolParams(input3)
+	
+	// All should result in the same cleaned URL
+	expected := "postgres://user:pass@localhost:5432/db?other=value"
+	c.Assert(result1, qt.Equals, expected)
+	c.Assert(result2, qt.Equals, expected)
+	c.Assert(result3, qt.Equals, expected)
+	
+	// All results should be identical
+	c.Assert(result1, qt.Equals, result2)
+	c.Assert(result2, qt.Equals, result3)
+}
+
+func TestRemovePostgresPoolParams_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with fragment",
+			input:    "postgres://user:pass@localhost:5432/db?pool_max_conns=10#fragment",
+			expected: "postgres://user:pass@localhost:5432/db#fragment",
+		},
+		{
+			name:     "URL with port and path",
+			input:    "postgres://user:pass@localhost:5432/path/to/db?pool_max_conns=10&pool_min_conns=2",
+			expected: "postgres://user:pass@localhost:5432/path/to/db",
+		},
+		{
+			name:     "URL with encoded characters",
+			input:    "postgres://user:pass%40word@localhost:5432/db?pool_max_conns=10&other=value%20with%20spaces",
+			expected: "postgres://user:pass%40word@localhost:5432/db?other=value+with+spaces",
+		},
+		{
+			name:     "URL with duplicate non-pool params (should preserve all)",
+			input:    "postgres://user:pass@localhost:5432/db?other=value1&pool_max_conns=10&other=value2",
+			expected: "postgres://user:pass@localhost:5432/db?other=value1&other=value2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := removePostgresPoolParams(tt.input)
+			c.Assert(result, qt.Equals, tt.expected, qt.Commentf("removePostgresPoolParams(%q) = %q, want %q", tt.input, result, tt.expected))
+		})
+	}
+}

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -94,13 +94,13 @@ func TestRemovePostgresPoolParams_ParameterOrdering(t *testing.T) {
 	result1 := removePostgresPoolParams(input1)
 	result2 := removePostgresPoolParams(input2)
 	result3 := removePostgresPoolParams(input3)
-	
+
 	// All should result in the same cleaned URL
 	expected := "postgres://user:pass@localhost:5432/db?other=value"
 	c.Assert(result1, qt.Equals, expected)
 	c.Assert(result2, qt.Equals, expected)
 	c.Assert(result3, qt.Equals, expected)
-	
+
 	// All results should be identical
 	c.Assert(result1, qt.Equals, result2)
 	c.Assert(result2, qt.Equals, result3)


### PR DESCRIPTION
## Summary

This PR refactors the database connection logic in `dbschema/connection.go` to improve code organization and adds support for cleaning PostgreSQL connection URLs.

## Changes

- **Reorganized connection string handling**: Moved the connection string preparation logic to be more readable and consistent
- **Added `cleanPostgresURL` function**: New function to remove pool connection parameters (`pool_max_conns` and `pool_min_conns`) from PostgreSQL URLs
- **Consistent URL processing**: Both PostgreSQL and MySQL connections now follow the same pattern for URL cleanup

## Technical Details

- The `cleanPostgresURL` function parses the URL, removes specific query parameters that might interfere with the connection, and reconstructs the URL
- Connection string handling is now done before the dialect switch statement for better code flow
- Error handling is preserved and the function gracefully falls back to the original URL if parsing fails

## Testing

Please ensure that:
- [ ] Database connections work correctly with both PostgreSQL and MySQL
- [ ] Pool parameters are properly removed from PostgreSQL URLs
- [ ] Existing functionality remains unchanged

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author