### PR TITLE
Fix: Resolve linting issues in extension function tests

### DIFF
--- a/migration/generator/extension_integration_test.go
+++ b/migration/generator/extension_integration_test.go
@@ -32,9 +32,9 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 			},
 			databaseSchema: &types.DBSchema{
 				Extensions: []types.DBExtension{
-					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-					{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-					{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+					{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 				},
 			},
 			expectedUpSQL: []string{
@@ -62,9 +62,9 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 			},
 			databaseSchema: &types.DBSchema{
 				Extensions: []types.DBExtension{
-					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-					{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-					{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+					{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 				},
 			},
 			expectedUpSQL: []string{
@@ -89,9 +89,9 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 			},
 			databaseSchema: &types.DBSchema{
 				Extensions: []types.DBExtension{
-					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-					{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-					{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+					{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 					{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
 				},
 			},
@@ -202,9 +202,9 @@ func TestExtensionMigration_UpDownCycle(t *testing.T) {
 
 	databaseSchema := &types.DBSchema{
 		Extensions: []types.DBExtension{
-			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-			{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-			{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+			{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 		},
 	}
 
@@ -216,9 +216,9 @@ func TestExtensionMigration_UpDownCycle(t *testing.T) {
 	// 2. Simulate applying the up migration (database now has extensions)
 	simulatedDatabaseAfterUp := &types.DBSchema{
 		Extensions: []types.DBExtension{
-			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-			{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-			{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+			{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 			{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
 			{Name: "hstore", Version: "1.8", Schema: "public"},
 		},

--- a/migration/generator/migration_file_generation_test.go
+++ b/migration/generator/migration_file_generation_test.go
@@ -32,9 +32,9 @@ func TestMigrationFileGeneration_ExtensionSQL(t *testing.T) {
 			},
 			databaseSchema: &types.DBSchema{
 				Extensions: []types.DBExtension{
-					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-					{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-					{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+					{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 				},
 			},
 			expectedUpSQL: []string{
@@ -65,9 +65,9 @@ func TestMigrationFileGeneration_ExtensionSQL(t *testing.T) {
 			},
 			databaseSchema: &types.DBSchema{
 				Extensions: []types.DBExtension{
-					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-					{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-					{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+					{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+					{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+					{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 					{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
 				},
 			},
@@ -162,9 +162,9 @@ func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
 
 	databaseWithIgnoredExtensions := &types.DBSchema{
 		Extensions: []types.DBExtension{
-			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-			{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-			{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+			{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 		},
 	}
 
@@ -177,9 +177,9 @@ func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
 	// 2. Simulate database state after up migration
 	databaseAfterUp := &types.DBSchema{
 		Extensions: []types.DBExtension{
-			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-			{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-			{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+			{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+			{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+			{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 			{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
 		},
 	}

--- a/migration/schemadiff/internal/compare/extensions_test.go
+++ b/migration/schemadiff/internal/compare/extensions_test.go
@@ -143,9 +143,9 @@ func TestExtensions_RealWorldScenarios(t *testing.T) {
 				}
 				database := &types.DBSchema{
 					Extensions: []types.DBExtension{
-						{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-						{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-						{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+						{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+						{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+						{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 					},
 				}
 				return generated, database
@@ -169,9 +169,9 @@ func TestExtensions_RealWorldScenarios(t *testing.T) {
 				}
 				database := &types.DBSchema{
 					Extensions: []types.DBExtension{
-						{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"},    // ignored by default
-						{Name: "btree_gin", Version: "1.3", Schema: "public"},     // ignored by default
-						{Name: "pg_trgm", Version: "1.6", Schema: "public"},       // ignored by default
+						{Name: "plpgsql", Version: "1.0", Schema: "pg_catalog"}, // ignored by default
+						{Name: "btree_gin", Version: "1.3", Schema: "public"},   // ignored by default
+						{Name: "pg_trgm", Version: "1.6", Schema: "public"},     // ignored by default
 						{Name: "uuid-ossp", Version: "1.1", Schema: "public"},
 						{Name: "postgis", Version: "3.0", Schema: "public"},
 						{Name: "hstore", Version: "1.8", Schema: "public"},


### PR DESCRIPTION
## Summary

This PR fixes linting issues that were introduced in the previous direct push to master (commit 0245174). The CI was failing due to `gci` formatting violations in test files.

## Changes Made

- **Fixed gci formatting issues** in 3 test files:
  - `migration/generator/extension_integration_test.go`
  - `migration/generator/migration_file_generation_test.go`
  - `migration/schemadiff/internal/compare/extensions_test.go`

- **Aligned comment spacing** to meet linter requirements
- **Verified all tests continue to pass** after formatting fixes

## Root Cause

The linting issues were caused by inconsistent spacing in struct literal comments. The `gci` linter requires specific formatting for inline comments in struct definitions.

## Verification

✅ **Linting**: `golangci-lint run` passes with 0 issues  
✅ **Tests**: All unit and integration tests pass  
✅ **Formatting**: Code follows project formatting standards  

## Workflow Improvement

This PR also establishes the correct development workflow going forward:
- ✅ Created feature branch (`fix/linting-issues`)
- ✅ Made targeted fixes
- ✅ Verified changes locally
- ✅ Created proper pull request
- ❌ **Never push directly to master again**

## Impact

This is a pure formatting fix with no functional changes. The extension function filtering feature implemented in the previous commit remains fully functional and tested.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author