### PR TITLE
Fix #39: Add missing RLS policies, functions, and roles to down migrations

### DIFF
--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -96,6 +96,16 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 		IndexesRemoved:    []string{"idx_old"},
 		ExtensionsAdded:   []string{"pg_trgm", "btree_gin"},
 		ExtensionsRemoved: []string{"postgis"},
+		FunctionsAdded:    []string{"get_tenant_id", "set_tenant_context"},
+		FunctionsRemoved:  []string{"old_function"},
+		RLSPoliciesAdded:  []string{"user_policy", "tenant_policy"},
+		RLSPoliciesRemoved: []types.RLSPolicyRef{
+			{PolicyName: "old_policy", TableName: "old_table"},
+		},
+		RLSEnabledTablesAdded:   []string{"users", "posts"},
+		RLSEnabledTablesRemoved: []string{"old_table"},
+		RolesAdded:              []string{"app_user", "admin_user"},
+		RolesRemoved:            []string{"old_role"},
 	}
 
 	result := reverseSchemaDiff(input)
@@ -109,6 +119,28 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 	c.Assert(result.IndexesRemoved, qt.DeepEquals, input.IndexesAdded)
 	c.Assert(result.ExtensionsAdded, qt.DeepEquals, input.ExtensionsRemoved)
 	c.Assert(result.ExtensionsRemoved, qt.DeepEquals, input.ExtensionsAdded)
+
+	// Verify function reversals
+	c.Assert(result.FunctionsAdded, qt.DeepEquals, input.FunctionsRemoved)
+	c.Assert(result.FunctionsRemoved, qt.DeepEquals, input.FunctionsAdded)
+
+	// Verify RLS policy reversals
+	expectedRLSPoliciesAdded := []string{"old_policy"}
+	c.Assert(result.RLSPoliciesAdded, qt.DeepEquals, expectedRLSPoliciesAdded)
+
+	expectedRLSPoliciesRemoved := []types.RLSPolicyRef{
+		{PolicyName: "user_policy", TableName: ""},
+		{PolicyName: "tenant_policy", TableName: ""},
+	}
+	c.Assert(result.RLSPoliciesRemoved, qt.DeepEquals, expectedRLSPoliciesRemoved)
+
+	// Verify RLS table enablement reversals
+	c.Assert(result.RLSEnabledTablesAdded, qt.DeepEquals, input.RLSEnabledTablesRemoved)
+	c.Assert(result.RLSEnabledTablesRemoved, qt.DeepEquals, input.RLSEnabledTablesAdded)
+
+	// Verify role reversals
+	c.Assert(result.RolesAdded, qt.DeepEquals, input.RolesRemoved)
+	c.Assert(result.RolesRemoved, qt.DeepEquals, input.RolesAdded)
 }
 
 func TestReverseSchemaDiff_TableModifications(t *testing.T) {
@@ -168,4 +200,177 @@ func TestReverseSchemaDiff_EnumModifications(t *testing.T) {
 	c.Assert(reversedEnum.EnumName, qt.Equals, "status_type")
 	c.Assert(reversedEnum.ValuesAdded, qt.DeepEquals, []string{"deprecated"})
 	c.Assert(reversedEnum.ValuesRemoved, qt.DeepEquals, []string{"pending", "archived"})
+}
+
+func TestReverseSchemaDiff_FunctionModifications(t *testing.T) {
+	c := qt.New(t)
+
+	// Test function modifications reversal
+	input := &types.SchemaDiff{
+		FunctionsModified: []types.FunctionDiff{
+			{
+				FunctionName: "get_tenant_id",
+				Changes: map[string]string{
+					"parameters": "() -> (tenant_id TEXT)",
+					"body":       "SELECT current_user -> SELECT current_setting('app.tenant_id')",
+					"volatility": "VOLATILE -> STABLE",
+				},
+			},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Assert(len(result.FunctionsModified), qt.Equals, 1)
+
+	reversedFunction := result.FunctionsModified[0]
+	c.Assert(reversedFunction.FunctionName, qt.Equals, "get_tenant_id")
+	c.Assert(reversedFunction.Changes["parameters"], qt.Equals, "(tenant_id TEXT) -> ()")
+	c.Assert(reversedFunction.Changes["body"], qt.Equals, "SELECT current_setting('app.tenant_id') -> SELECT current_user")
+	c.Assert(reversedFunction.Changes["volatility"], qt.Equals, "STABLE -> VOLATILE")
+}
+
+func TestReverseSchemaDiff_RLSPolicyModifications(t *testing.T) {
+	c := qt.New(t)
+
+	// Test RLS policy modifications reversal
+	input := &types.SchemaDiff{
+		RLSPoliciesModified: []types.RLSPolicyDiff{
+			{
+				PolicyName: "user_tenant_isolation",
+				TableName:  "users",
+				Changes: map[string]string{
+					"using_expression":       "tenant_id = current_user -> tenant_id = get_current_tenant_id()",
+					"with_check_expression":  "tenant_id = current_user -> tenant_id = get_current_tenant_id()",
+					"to_roles":               "app_user -> app_user,admin_user",
+					"policy_for":             "SELECT -> ALL",
+				},
+			},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Assert(len(result.RLSPoliciesModified), qt.Equals, 1)
+
+	reversedPolicy := result.RLSPoliciesModified[0]
+	c.Assert(reversedPolicy.PolicyName, qt.Equals, "user_tenant_isolation")
+	c.Assert(reversedPolicy.TableName, qt.Equals, "users")
+	c.Assert(reversedPolicy.Changes["using_expression"], qt.Equals, "tenant_id = get_current_tenant_id() -> tenant_id = current_user")
+	c.Assert(reversedPolicy.Changes["with_check_expression"], qt.Equals, "tenant_id = get_current_tenant_id() -> tenant_id = current_user")
+	c.Assert(reversedPolicy.Changes["to_roles"], qt.Equals, "app_user,admin_user -> app_user")
+	c.Assert(reversedPolicy.Changes["policy_for"], qt.Equals, "ALL -> SELECT")
+}
+
+func TestReverseSchemaDiff_RoleModifications(t *testing.T) {
+	c := qt.New(t)
+
+	// Test role modifications reversal
+	input := &types.SchemaDiff{
+		RolesModified: []types.RoleDiff{
+			{
+				RoleName: "app_user",
+				Changes: map[string]string{
+					"login":      "false -> true",
+					"superuser":  "false -> true",
+					"createdb":   "false -> true",
+					"password":   "old_hash -> new_hash",
+				},
+			},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Assert(len(result.RolesModified), qt.Equals, 1)
+
+	reversedRole := result.RolesModified[0]
+	c.Assert(reversedRole.RoleName, qt.Equals, "app_user")
+	c.Assert(reversedRole.Changes["login"], qt.Equals, "true -> false")
+	c.Assert(reversedRole.Changes["superuser"], qt.Equals, "true -> false")
+	c.Assert(reversedRole.Changes["createdb"], qt.Equals, "true -> false")
+	c.Assert(reversedRole.Changes["password"], qt.Equals, "new_hash -> old_hash")
+}
+
+func TestConvertRLSPolicyRefsToNames(t *testing.T) {
+	c := qt.New(t)
+
+	input := []types.RLSPolicyRef{
+		{PolicyName: "user_policy", TableName: "users"},
+		{PolicyName: "tenant_policy", TableName: "tenants"},
+	}
+
+	result := convertRLSPolicyRefsToNames(input)
+
+	expected := []string{"user_policy", "tenant_policy"}
+	c.Assert(result, qt.DeepEquals, expected)
+}
+
+func TestConvertRLSPolicyNamesToRefs(t *testing.T) {
+	c := qt.New(t)
+
+	input := []string{"user_policy", "tenant_policy"}
+
+	result := convertRLSPolicyNamesToRefs(input)
+
+	expected := []types.RLSPolicyRef{
+		{PolicyName: "user_policy", TableName: ""},
+		{PolicyName: "tenant_policy", TableName: ""},
+	}
+	c.Assert(result, qt.DeepEquals, expected)
+}
+
+func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
+	c := qt.New(t)
+
+	// This test demonstrates the fix for GitHub issue #39:
+	// Migration generator creates incomplete down migrations - missing RLS policies, functions, and roles
+
+	// Create a schema diff that includes RLS policies, functions, and roles being added
+	// (simulating a migration that creates these objects)
+	upDiff := &types.SchemaDiff{
+		// Add some functions
+		FunctionsAdded: []string{"get_current_tenant_id", "set_tenant_context"},
+
+		// Add some RLS policies
+		RLSPoliciesAdded: []string{"user_tenant_isolation", "area_tenant_isolation"},
+
+		// Enable RLS on tables
+		RLSEnabledTablesAdded: []string{"users", "areas"},
+
+		// Add some roles
+		RolesAdded: []string{"inventario_app"},
+
+		// Also add a table to make it a realistic scenario
+		TablesAdded: []string{"users"},
+	}
+
+	// Generate the reverse diff (for down migration)
+	downDiff := reverseSchemaDiff(upDiff)
+
+	// Verify that the down migration includes removal of all the objects that were added
+
+	// Functions should be removed in down migration
+	c.Assert(downDiff.FunctionsRemoved, qt.DeepEquals, []string{"get_current_tenant_id", "set_tenant_context"})
+	c.Assert(len(downDiff.FunctionsAdded), qt.Equals, 0)
+
+	// RLS policies should be removed in down migration
+	expectedPolicyRefs := []types.RLSPolicyRef{
+		{PolicyName: "user_tenant_isolation", TableName: ""},
+		{PolicyName: "area_tenant_isolation", TableName: ""},
+	}
+	c.Assert(downDiff.RLSPoliciesRemoved, qt.DeepEquals, expectedPolicyRefs)
+	c.Assert(len(downDiff.RLSPoliciesAdded), qt.Equals, 0)
+
+	// RLS should be disabled on tables in down migration
+	c.Assert(downDiff.RLSEnabledTablesRemoved, qt.DeepEquals, []string{"users", "areas"})
+	c.Assert(len(downDiff.RLSEnabledTablesAdded), qt.Equals, 0)
+
+	// Roles should be removed in down migration
+	c.Assert(downDiff.RolesRemoved, qt.DeepEquals, []string{"inventario_app"})
+	c.Assert(len(downDiff.RolesAdded), qt.Equals, 0)
+
+	// Tables should be removed in down migration (existing behavior)
+	c.Assert(downDiff.TablesRemoved, qt.DeepEquals, []string{"users"})
+	c.Assert(len(downDiff.TablesAdded), qt.Equals, 0)
 }


### PR DESCRIPTION
## Problem

Fixes #39 - The migration generator was creating incomplete down migrations that failed to include rollback statements for:

- Row Level Security (RLS) policies (`DROP POLICY` statements)
- RLS enablement (`ALTER TABLE ... DISABLE ROW LEVEL SECURITY` statements)
- Functions (`DROP FUNCTION` statements)
- Database roles (`DROP ROLE` statements)

This caused incomplete rollbacks when migrations were reverted, leaving behind security policies, functions, and roles that should be cleaned up.

## Solution

This PR fixes the issue by:

1. **Enhanced `reverseSchemaDiff()` function**: Added missing reversal logic for RLS policies, functions, and roles
2. **New helper functions**: Created specialized reversal functions for complex diff types:
   - `reverseFunctionDiffs()` - reverses function modifications
   - `reverseRLSPolicyDiffs()` - reverses RLS policy modifications
   - `reverseRoleDiffs()` - reverses role modifications
   - `convertRLSPolicyRefsToNames()` and `convertRLSPolicyNamesToRefs()` - handle RLS policy reference conversions

3. **Comprehensive test coverage**: Added extensive unit tests and an integration test demonstrating the fix works end-to-end

## Changes Made

### Core Fix
- **`migration/generator/generator.go`**: Enhanced `reverseSchemaDiff()` to include all missing object types
- Added helper functions for reversing complex diff structures

### Tests
- **`migration/generator/reverse_diff_test.go`**: Added comprehensive test coverage including:
  - Function modification reversal tests
  - RLS policy modification reversal tests
  - Role modification reversal tests
  - Integration test demonstrating the complete fix

## Testing

- ✅ All existing tests pass
- ✅ New unit tests verify correct reversal logic for all object types
- ✅ Integration test demonstrates end-to-end functionality
- ✅ No breaking changes to existing functionality

## Impact

After this fix, down migrations will properly include:

```sql
-- Drop all RLS policies
DROP POLICY IF EXISTS area_tenant_isolation ON areas;
DROP POLICY IF EXISTS commodity_tenant_isolation ON commodities;
-- ... (all other policies)

-- Disable RLS
ALTER TABLE users DISABLE ROW LEVEL SECURITY;
-- ... (all other RLS-enabled tables)

-- Drop functions
DROP FUNCTION IF EXISTS get_current_tenant_id();
DROP FUNCTION IF EXISTS set_tenant_context(TEXT);

-- Drop roles
DROP ROLE IF EXISTS inventario_app;
```

This ensures complete migration reversals that truly restore the previous database state.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author