### PR TITLE
feat: Add migration generation command for empty migration files

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -11,24 +11,34 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/generator"
 )
 
 var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate schema from Go entities",
-	Long: `Generate database schema from Go entities in the specified directory.
-	
-This command scans the directory recursively for Go files with migrator directives
-and generates SQL schema for the specified database dialect(s).`,
-	RunE: generateCommand,
+	Use:   "generate [schema|migration]",
+	Short: "Generate schema from Go entities or create empty migration files",
+	Long: `Generate database schema from Go entities or create empty migration files for manual editing.
+
+Default behavior (no subcommand): Generate schema from Go entities (for backward compatibility)
+
+Available subcommands:
+  schema     - Generate database schema from Go entities  
+  migration  - Generate empty migration files for manual editing
+
+Examples:
+  ptah generate                                    # Generate schema (default)
+  ptah generate schema --dialect postgres         # Generate schema for specific dialect
+  ptah generate migration --name add_users        # Generate empty migration files`,
+	RunE: schemaCommand, // Default to schema generation for backward compatibility
 }
 
+// Schema generation flags
 const (
 	rootDirFlag = "root-dir"
 	dialectFlag = "dialect"
 )
 
-var generateFlags = map[string]cobraflags.Flag{
+var schemaFlags = map[string]cobraflags.Flag{
 	rootDirFlag: &cobraflags.StringFlag{
 		Name:  rootDirFlag,
 		Value: "./",
@@ -41,14 +51,72 @@ var generateFlags = map[string]cobraflags.Flag{
 	},
 }
 
+// Migration generation flags
+const (
+	nameFlag      = "name"
+	outputDirFlag = "output-dir"
+)
+
+var migrationFlags = map[string]cobraflags.Flag{
+	nameFlag: &cobraflags.StringFlag{
+		Name:  nameFlag,
+		Value: "",
+		Usage: "Name for the migration (required)",
+	},
+	outputDirFlag: &cobraflags.StringFlag{
+		Name:  outputDirFlag,
+		Value: "./migrations",
+		Usage: "Directory where migration files will be saved",
+	},
+}
+
 func NewGenerateCommand() *cobra.Command {
-	cobraflags.RegisterMap(generateCmd, generateFlags)
+	// Register schema flags on the main command for backward compatibility
+	cobraflags.RegisterMap(generateCmd, schemaFlags)
+	
+	// Add subcommands
+	generateCmd.AddCommand(newSchemaCommand())
+	generateCmd.AddCommand(newMigrationCommand())
 	return generateCmd
 }
 
-func generateCommand(_ *cobra.Command, _ []string) error {
-	rootDir := generateFlags[rootDirFlag].GetString()
-	dialect := generateFlags[dialectFlag].GetString()
+// newSchemaCommand creates the schema subcommand (existing functionality)
+func newSchemaCommand() *cobra.Command {
+	schemaCmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Generate database schema from Go entities",
+		Long: `Generate database schema from Go entities in the specified directory.
+	
+This command scans the directory recursively for Go files with migrator directives
+and generates SQL schema for the specified database dialect(s).`,
+		RunE: schemaCommand,
+	}
+
+	// Register flags on the subcommand as well for direct usage
+	cobraflags.RegisterMap(schemaCmd, schemaFlags)
+	return schemaCmd
+}
+
+// newMigrationCommand creates the migration subcommand for empty migration files
+func newMigrationCommand() *cobra.Command {
+	migrationCmd := &cobra.Command{
+		Use:   "migration",
+		Short: "Generate empty migration files for manual editing",
+		Long: `Generate empty skeleton migration files with proper timestamps and naming conventions.
+
+This command creates both up and down migration files that you can manually edit
+to add custom SQL operations, data migrations, or complex schema changes that
+can't be expressed through Go struct annotations.`,
+		RunE: migrationCommand,
+	}
+
+	cobraflags.RegisterMap(migrationCmd, migrationFlags)
+	return migrationCmd
+}
+
+func schemaCommand(_ *cobra.Command, _ []string) error {
+	rootDir := schemaFlags[rootDirFlag].GetString()
+	dialect := schemaFlags[dialectFlag].GetString()
 
 	// Convert to absolute path
 	absPath, err := filepath.Abs(rootDir)
@@ -122,6 +190,38 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 
 		fmt.Println()
 	}
+
+	return nil
+}
+
+func migrationCommand(_ *cobra.Command, _ []string) error {
+	migrationName := migrationFlags[nameFlag].GetString()
+	outputDir := migrationFlags[outputDirFlag].GetString()
+
+	if migrationName == "" {
+		return fmt.Errorf("migration name is required (use --name flag)")
+	}
+
+	fmt.Printf("Generating empty migration: %s\n", migrationName)
+	fmt.Printf("Output directory: %s\n", outputDir)
+	fmt.Println()
+
+	// Generate empty migration files
+	files, err := generator.GenerateEmptyMigration(generator.GenerateEmptyMigrationOptions{
+		MigrationName: migrationName,
+		OutputDir:     outputDir,
+	})
+	if err != nil {
+		return fmt.Errorf("error generating migration files: %w", err)
+	}
+
+	fmt.Printf("Generated migration files:\n")
+	fmt.Printf("  UP:   %s\n", files.UpFile)
+	fmt.Printf("  DOWN: %s\n", files.DownFile)
+	fmt.Printf("  Version: %d\n", files.Version)
+	fmt.Println()
+	fmt.Println("✅ Empty migration files created successfully!")
+	fmt.Println("You can now edit these files to add your custom SQL.")
 
 	return nil
 }

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -437,3 +437,52 @@ func createMigrationFiles(outputDir string, version int, migrationName, upSQL, d
 		Version:  version,
 	}, nil
 }
+
+// GenerateEmptyMigrationOptions contains options for empty migration generation
+type GenerateEmptyMigrationOptions struct {
+	// MigrationName is the name for the migration (required)
+	MigrationName string
+	// OutputDir is the directory where migration files will be saved (defaults to "./migrations")
+	OutputDir string
+}
+
+// GenerateEmptyMigration generates empty skeleton migration files for manual editing
+func GenerateEmptyMigration(opts GenerateEmptyMigrationOptions) (*MigrationFiles, error) {
+	// Validate migration name
+	if opts.MigrationName == "" {
+		return nil, fmt.Errorf("migration name is required")
+	}
+
+	// Set default output directory
+	if opts.OutputDir == "" {
+		opts.OutputDir = "./migrations"
+	}
+
+	// Generate migration version (timestamp)
+	version := migrator.GetNextMigrationVersion()
+	slog.Debug("Generated migration version", "version", version)
+
+	// Generate template SQL content
+	timestamp := time.Now().Format(time.RFC3339)
+	upSQL := fmt.Sprintf(`-- Migration: %s
+-- Generated on: %s
+-- Direction: UP
+
+-- Add your migration SQL here
+`, opts.MigrationName, timestamp)
+
+	downSQL := fmt.Sprintf(`-- Migration: %s
+-- Generated on: %s
+-- Direction: DOWN
+
+-- Add your rollback SQL here
+`, opts.MigrationName, timestamp)
+
+	// Create migration files
+	files, err := createMigrationFiles(opts.OutputDir, version, opts.MigrationName, upSQL, downSQL)
+	if err != nil {
+		return nil, fmt.Errorf("error creating empty migration files: %w", err)
+	}
+
+	return files, nil
+}


### PR DESCRIPTION
Implement 'ptah generate migration --name <name>' command to create skeleton migration files for manual editing. Addresses common use cases like data migrations, custom SQL operations, and advanced database features.

Features:
- Generate empty up/down migration files with proper timestamps
- Template comments with migration name, timestamp, and direction
- Configurable output directory (defaults to ./migrations)
- Full backward compatibility with existing 'ptah generate' command
- Follows existing migration file naming conventions

Fixes #41

🤖 Generated with [Claude Code](https://claude.ai/code)