### PR TITLE
Fix issue #57: Missing table names in DROP POLICY statements

### DIFF
--- a/migration/generator/migration_file_generation_test.go
+++ b/migration/generator/migration_file_generation_test.go
@@ -95,7 +95,7 @@ func TestMigrationFileGeneration_ExtensionSQL(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 
 			// 3. Generate down migration SQL using the fixed reverseSchemaDiff function
-			downSQL, err := generateDownMigrationSQL(diff, tt.databaseSchema, "postgres")
+			downSQL, err := generateDownMigrationSQL(diff, tt.generatedSchema, tt.databaseSchema, "postgres")
 			c.Assert(err, qt.IsNil)
 
 			// 4. Verify up migration SQL contains expected patterns
@@ -172,7 +172,7 @@ func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
 
 	// 3. Generate down migration (should drop extension)
 	// For down migration, we use the original upDiff and reverse it
-	downSQL, err := generateDownMigrationSQL(upDiff, databaseAfterUp, "postgres")
+	downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, databaseAfterUp, "postgres")
 	c.Assert(err, qt.IsNil)
 	c.Assert(strings.Contains(downSQL, "DROP EXTENSION IF EXISTS pg_trgm;"), qt.IsTrue)
 


### PR DESCRIPTION
## Summary

Fixes #57 - Resolves the bug where DROP POLICY statements in generated down migration files were missing table names after the "ON" keyword, resulting in SQL syntax errors.

## Problem

The issue occurred when generating down migrations because:
1. The `generateDownMigrationSQL` function only had access to the database schema
2. The database schema didn't contain the RLS policies that were just added in the up migration
3. The `convertRLSPolicyNamesToRefsWithSchema` function couldn't resolve table names for policies
4. This resulted in malformed DROP POLICY statements like `DROP POLICY IF EXISTS policy_name ON;`

## Solution

- **Modified `generateDownMigrationSQL`** to accept the original generated schema as a parameter
- **Updated `reverseSchemaDiffWithSchema`** to use the original generated schema for RLS policy table resolution
- **Fixed table name resolution** in `convertRLSPolicyNamesToRefsWithSchema` by using the correct schema context
- **Added comprehensive test** `TestGenerateDownMigrationSQL_Issue57_MissingTableNames` to reproduce and verify the fix
- **Updated existing tests** to work with the new function signature

## Changes Made

### Core Fix
- `migration/generator/generator.go`: Modified `generateDownMigrationSQL` function signature and implementation
- Updated function call in `GenerateMigration` to pass the original generated schema

### Tests
- `migration/generator/reverse_diff_test.go`: Added new test case and updated existing test
- `migration/generator/migration_file_generation_test.go`: Updated test calls to match new signature

## Testing

✅ **New test case** reproduces the exact bug scenario and verifies the fix
✅ **All existing tests pass** - no regressions introduced
✅ **Generated SQL now correct**:

**Before (broken):**
```sql
-- Drop RLS policy area_tenant_isolation from table 
DROP POLICY IF EXISTS area_tenant_isolation ON;
```

**After (fixed):**
```sql
-- Drop RLS policy area_tenant_isolation from table areas
DROP POLICY IF EXISTS area_tenant_isolation ON areas;
```

## Impact

- ✅ Down migrations now work correctly
- ✅ Database rollback operations are functional
- ✅ No manual intervention required to fix migration files
- ✅ Development and deployment workflows restored

## Verification

Ran full test suite:
```bash
go test ./...
# All tests pass
```

Specific test for this issue:
```bash
go test -v ./migration/generator -run TestGenerateDownMigrationSQL_Issue57_MissingTableNames
# PASS
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author