### PR TITLE
fix(parser): reject unknown attributes on schema:field annotations (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ type User struct {
 - `not_null` - NOT NULL constraint
 - `unique` - UNIQUE constraint
 - `default` - Default value
-- `default_fn` - Default function (e.g., "NOW()")
+- `default_expr` - Default expression or function call (e.g., `"NOW()"`, `"CURRENT_TIMESTAMP"`, `"gen_random_uuid()"`)
 - `check` - CHECK constraint
 - `foreign` - Foreign key reference (table(column))
 - `foreign_key_name` - Custom foreign key constraint name
@@ -325,7 +325,7 @@ type User struct {
     //migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
     Email string
 
-    //migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_fn="NOW()"
+    //migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="NOW()"
     CreatedAt time.Time
 }
 

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -67,9 +67,17 @@ func validateAttributes(kv map[string]string, known map[string]bool, directive, 
 
 func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string, globalEnumsMap map[string]Enum, schemaFields *[]Field) {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	for _, name := range field.Names {
-		validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", structName+"."+name.Name)
 
+	// Validate the directive itself, not each named carrier. For anonymous /
+	// embedded fields field.Names is nil and the loop below would never run,
+	// so doing this inside the loop would let unknown keys slip through.
+	location := structName
+	if len(field.Names) > 0 {
+		location = structName + "." + field.Names[0].Name
+	}
+	validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", location)
+
+	for _, name := range field.Names {
 		enumRaw := kv["enum"]
 		var enum []string
 		if enumRaw != "" {

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -1,6 +1,7 @@
 package goschema
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -12,9 +13,63 @@ import (
 	"github.com/stokaro/ptah/core/goschema/internal/parseutils"
 )
 
+// knownFieldAttributes lists every attribute key recognized on a
+// //migrator:schema:field annotation. Keys with the "platform." prefix are
+// also accepted (handled separately).
+//
+// Some entries are accepted but not currently consumed by parseFieldComment;
+// they are whitelisted to keep the strict validator focused on real typos:
+//   - "nullable", "index", "autoincrement": parseutils auto-promotes these to
+//     booleans when written as bare words.
+//   - "on_delete", "on_update": documented FK-action keys consumed by
+//     EmbeddedField and Constraint parsers. Field-level propagation to the
+//     emitted SQL is not implemented yet — projects in the wild work around
+//     this with manual ALTER TABLE statements. Tracked separately.
+var knownFieldAttributes = map[string]bool{
+	"name":             true,
+	"type":             true,
+	"not_null":         true,
+	"nullable":         true,
+	"primary":          true,
+	"auto_increment":   true,
+	"autoincrement":    true,
+	"unique":           true,
+	"unique_expr":      true,
+	"index":            true,
+	"default":          true,
+	"default_expr":     true,
+	"foreign":          true,
+	"foreign_key_name": true,
+	"on_delete":        true,
+	"on_update":        true,
+	"enum":             true,
+	"check":            true,
+	"comment":          true,
+}
+
+// validateAttributes panics if kv contains any key the directive does not
+// recognize. Platform-specific overrides (platform.*) are always allowed.
+// This catches typos like default_fn-vs-default_expr at parse time instead of
+// silently dropping them and producing wrong SQL.
+func validateAttributes(kv map[string]string, known map[string]bool, directive, location string) {
+	for k := range kv {
+		if known[k] || strings.HasPrefix(k, "platform.") {
+			continue
+		}
+		slog.Error("unknown annotation attribute",
+			"directive", directive,
+			"attribute", k,
+			"location", location,
+		)
+		panic(fmt.Sprintf("unknown annotation attribute %q on %s at %s", k, directive, location))
+	}
+}
+
 func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string, globalEnumsMap map[string]Enum, schemaFields *[]Field) {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	for _, name := range field.Names {
+		validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", structName+"."+name.Name)
+
 		enumRaw := kv["enum"]
 		var enum []string
 		if enumRaw != "" {

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -702,3 +702,85 @@ func TestParseConstraintComment(t *testing.T) {
 		})
 	}
 }
+
+// TestParseField_UnknownAttributePanics verifies that field annotations
+// containing an unrecognized attribute key cause the parser to panic with a
+// clear message. This is the safety net that surfaces typos like
+// `default_fn`-vs-`default_expr` at parse time instead of silently dropping
+// them and producing wrong SQL.
+func TestParseField_UnknownAttributePanics(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		annotation  string
+		mustContain string
+	}{
+		{
+			name:        "removed default_fn key",
+			annotation:  `name="created_at" type="TIMESTAMP" default_fn="NOW()"`,
+			mustContain: "default_fn",
+		},
+		{
+			name:        "arbitrary typo",
+			annotation:  `name="id" type="SERIAL" primary="true" totally_made_up_attr="oops"`,
+			mustContain: "totally_made_up_attr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := `package entities
+
+//migrator:schema:table name="widgets"
+type Widget struct {
+	//migrator:schema:field ` + tt.annotation + `
+	ID int64
+}
+`
+			tmpDir := t.TempDir()
+			testFile := filepath.Join(tmpDir, "widget.go")
+			err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
+			c.Assert(err, qt.IsNil)
+
+			defer func() {
+				r := recover()
+				c.Assert(r, qt.Not(qt.IsNil), qt.Commentf("expected panic for unknown attribute"))
+				msg, _ := r.(string)
+				c.Assert(msg, qt.Contains, "unknown annotation attribute")
+				c.Assert(msg, qt.Contains, tt.mustContain)
+			}()
+
+			_ = goschema.ParseFile(testFile)
+		})
+	}
+}
+
+// TestParseField_KnownAttributesDoNotPanic verifies that the canonical
+// attribute set, including platform.* overrides, parses cleanly without
+// triggering the unknown-attribute panic.
+func TestParseField_KnownAttributesDoNotPanic(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="widgets"
+type Widget struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true" auto_increment="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true" unique="true" default="x" comment="widget name" platform.mysql.type="VARCHAR(191)"
+	Name string
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
+	CreatedAt string
+}
+`
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "widget.go")
+	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
+	c.Assert(err, qt.IsNil)
+
+	database := goschema.ParseFile(testFile)
+	c.Assert(database.Fields, qt.HasLen, 3)
+}

--- a/examples/postgresql_demo/exclude_constraints_example.go
+++ b/examples/postgresql_demo/exclude_constraints_example.go
@@ -21,7 +21,7 @@ type Booking struct {
 	//migrator:schema:field name="during" type="TSRANGE" not_null="true"
 	During string // PostgreSQL range type for time periods
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="NOW()"
 	CreatedAt string
 }
 
@@ -39,7 +39,7 @@ type UserSession struct {
 	//migrator:schema:field name="is_active" type="BOOLEAN" not_null="true" default="false"
 	IsActive bool
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="NOW()"
 	CreatedAt string
 }
 

--- a/integration/entity_templates.go
+++ b/integration/entity_templates.go
@@ -243,11 +243,11 @@ func (et *EntityTemplate) CustomEntity(tableName, structName string, fields []En
 		if field.Default != "" {
 			fmt.Fprintf(&sb, " default=\"%s\"", field.Default)
 		}
-		if field.DefaultFn != "" {
-			fmt.Fprintf(&sb, " default_expr=\"%s\"", field.DefaultFn)
+		if field.DefaultExpr != "" {
+			fmt.Fprintf(&sb, " default_expr=\"%s\"", field.DefaultExpr)
 		}
-		if field.ForeignKey != "" {
-			fmt.Fprintf(&sb, " foreign=\"%s\"", field.ForeignKey)
+		if field.Foreign != "" {
+			fmt.Fprintf(&sb, " foreign=\"%s\"", field.Foreign)
 		}
 
 		sb.WriteString("\n")
@@ -260,14 +260,14 @@ func (et *EntityTemplate) CustomEntity(tableName, structName string, fields []En
 
 // EntityField represents a field in a custom entity
 type EntityField struct {
-	Name       string // Database column name
-	GoName     string // Go field name
-	Type       string // Database type
-	GoType     string // Go type
-	Primary    bool
-	NotNull    bool
-	Unique     bool
-	Default    string
-	DefaultFn  string
-	ForeignKey string
+	Name        string // Database column name
+	GoName      string // Go field name
+	Type        string // Database type
+	GoType      string // Go type
+	Primary     bool
+	NotNull     bool
+	Unique      bool
+	Default     string
+	DefaultExpr string // Default expression / function call (rendered as default_expr=...)
+	Foreign     string // Foreign-key target, e.g. "users(id)" (rendered as foreign=...)
 }

--- a/integration/entity_templates.go
+++ b/integration/entity_templates.go
@@ -50,7 +50,7 @@ type Post struct {
 	//migrator:schema:field name="id" type="SERIAL" primary="true"
 	ID int64
 
-	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign_key="users(id)"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)"
 	UserID int64
 
 	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"
@@ -85,10 +85,10 @@ type Comment struct {
 	//migrator:schema:field name="id" type="SERIAL" primary="true"
 	ID int64
 
-	//migrator:schema:field name="post_id" type="INTEGER" not_null="true" foreign_key="posts(id)"
+	//migrator:schema:field name="post_id" type="INTEGER" not_null="true" foreign="posts(id)"
 	PostID int64
 
-	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign_key="users(id)"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)"
 	UserID int64
 
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
@@ -247,7 +247,7 @@ func (et *EntityTemplate) CustomEntity(tableName, structName string, fields []En
 			fmt.Fprintf(&sb, " default_expr=\"%s\"", field.DefaultFn)
 		}
 		if field.ForeignKey != "" {
-			fmt.Fprintf(&sb, " foreign_key=\"%s\"", field.ForeignKey)
+			fmt.Fprintf(&sb, " foreign=\"%s\"", field.ForeignKey)
 		}
 
 		sb.WriteString("\n")

--- a/integration/fixtures/entities/002-add-posts/post.go
+++ b/integration/fixtures/entities/002-add-posts/post.go
@@ -7,7 +7,7 @@ type Post struct {
 	//migrator:schema:field name="id" type="SERIAL" primary="true"
 	ID int64
 
-	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign_key="users(id)"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)"
 	UserID int64
 
 	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"

--- a/integration/fixtures/entities/003-add-enums/post.go
+++ b/integration/fixtures/entities/003-add-enums/post.go
@@ -7,7 +7,7 @@ type Post struct {
 	//migrator:schema:field name="id" type="SERIAL" primary="true"
 	ID int64
 
-	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign_key="users(id)"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)"
 	UserID int64
 
 	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"

--- a/integration/fixtures/entities/014-rls-functions/product.go
+++ b/integration/fixtures/entities/014-rls-functions/product.go
@@ -24,7 +24,7 @@ type Product struct {
 	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64 `json:"user_id" db:"user_id"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }
 

--- a/integration/fixtures/entities/014-rls-functions/user.go
+++ b/integration/fixtures/entities/014-rls-functions/user.go
@@ -21,6 +21,6 @@ type User struct {
 	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
 	Name string `json:"name" db:"name"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }

--- a/integration/fixtures/entities/015-rls-advanced/product.go
+++ b/integration/fixtures/entities/015-rls-advanced/product.go
@@ -28,10 +28,10 @@ type Product struct {
 	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64 `json:"user_id" db:"user_id"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 
-	//migrator:schema:field name="updated_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" default_expr="NOW()"
 	UpdatedAt string `json:"updated_at" db:"updated_at"`
 }
 

--- a/integration/fixtures/entities/015-rls-advanced/user.go
+++ b/integration/fixtures/entities/015-rls-advanced/user.go
@@ -27,6 +27,6 @@ type User struct {
 	//migrator:schema:field name="role" type="VARCHAR(50)" not_null="true" default="user"
 	Role string `json:"role" db:"role"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }

--- a/integration/fixtures/entities/016-roles/product.go
+++ b/integration/fixtures/entities/016-roles/product.go
@@ -11,6 +11,6 @@ type Product struct {
 	//migrator:schema:field name="price" type="DECIMAL(10,2)" not_null="true"
 	Price float64 `json:"price" db:"price"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }

--- a/integration/fixtures/entities/016-roles/user.go
+++ b/integration/fixtures/entities/016-roles/user.go
@@ -16,6 +16,6 @@ type User struct {
 	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
 	Name string `json:"name" db:"name"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }

--- a/integration/fixtures/entities/017-roles-advanced/product.go
+++ b/integration/fixtures/entities/017-roles-advanced/product.go
@@ -14,6 +14,6 @@ type Product struct {
 	//migrator:schema:field name="created_by_role" type="VARCHAR(50)" default="'app_user'"
 	CreatedByRole string `json:"created_by_role" db:"created_by_role"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }

--- a/integration/fixtures/entities/017-roles-advanced/user.go
+++ b/integration/fixtures/entities/017-roles-advanced/user.go
@@ -22,6 +22,6 @@ type User struct {
 	//migrator:schema:field name="role_type" type="VARCHAR(50)" default="'app_user'"
 	RoleType string `json:"role_type" db:"role_type"`
 
-	//migrator:schema:field name="created_at" type="TIMESTAMP" default_fn="NOW()"
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
 	CreatedAt string `json:"created_at" db:"created_at"`
 }


### PR DESCRIPTION
Closes #82.

## Summary

The annotation parser silently dropped unrecognized attribute keys on `//migrator:schema:field`. That made `default_fn="NOW()"` (the parser only reads `default_expr`) produce a migration with **no `DEFAULT` clause** — discoverable only at migration-apply time against a non-empty table:

```sql
-- generated, wrong:
ALTER TABLE tenants ADD COLUMN uuid TEXT NOT NULL;
-- → SQLSTATE 23502 on apply
```

`parseFieldComment` now **panics with a clear message** on any unrecognized key. No warn-only fallback, no deprecated alias — typos fail at parse time.

## What changed

### Parser (`core/goschema/parser.go`)

- New `knownFieldAttributes` whitelist + `validateAttributes()` helper. Panics with `slog.Error` + `panic(fmt.Sprintf(...))` on unknown keys, consistent with the existing `panic("Failed to parse file")` style on bad input.
- `platform.*` overrides accepted via prefix check.
- The whitelist intentionally includes some keys that aren't currently consumed by `parseFieldComment` so we don't break valid existing annotations:
  - `nullable`, `index`, `autoincrement` — `parseutils` auto-promotes these to standalone booleans; they appear in `stubs/all_booleans_demo.go` and similar.
  - `on_delete`, `on_update` — documented FK action keys, used in real downstream models (`denisvmedia/inventario/go/models`). The Field-level propagation to emitted SQL is **not implemented yet** — tracked separately in #117. Whitelisting keeps consumers parsing while the actual fix lands.

### Repo cleanup the new validator surfaced

These were latent silent-drop bugs in ptah's own examples and fixtures:

- `default_fn` → `default_expr`
  - `README.md`
  - `examples/postgresql_demo/exclude_constraints_example.go`
  - `integration/fixtures/entities/{014-rls-functions, 015-rls-advanced, 016-roles, 017-roles-advanced}/{user,product}.go`
- `foreign_key` → `foreign`
  - `integration/entity_templates.go` (both the inline templates and the `EntityField.ForeignKey` emitter)
  - `integration/fixtures/entities/{002-add-posts, 003-add-enums}/post.go`

### Tests (`core/goschema/parser_test.go`)

- `TestParseField_UnknownAttributePanics` — table-driven; locks in panic on `default_fn` and on an arbitrary typo.
- `TestParseField_KnownAttributesDoNotPanic` — smoke test for the canonical attribute set + `platform.*` override.

## Why panic, not error/warn

The author of #82 explicitly preferred hard rejection over warn. The parser already panics on bad input (`ParseFile` / `ParseSource` use `panic("Failed to parse file")` rather than returning errors), so a panic on unknown attribute is consistent with the existing API surface. Plumbing proper error returns through the parser is a larger refactor and out of scope here.

## Compatibility check

Ran the patched parser against [`denisvmedia/inventario/go/models`](https://github.com/denisvmedia/inventario) (a real downstream consumer that uses ptah heavily): 26 tables, 343 fields, no panics. Their existing `on_delete=`-on-Field usage continues to parse — proper end-to-end support is the follow-up in #117.

## Test plan

- [x] `go test ./...` — green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Cross-repo: `goschema.ParseDir("inventario/go/models")` parses without panic
- [ ] CI integration tests (Docker-based, run on PR)

## Out of scope (tracked separately)

- #117 — Field-level `on_delete` / `on_update` are accepted by the parser but not propagated into the emitted SQL. `Field` needs `OnDelete`/`OnUpdate` members and `fromschema.FromField` needs to wire them through `ColumnNode.ForeignKey`. Once shipped, the placeholder comment in `knownFieldAttributes` should be removed.
- Strict validation on other directives (`//migrator:schema:{table,index,constraint,embedded,function,rls:*,role}`) — same pattern can be extended; this PR only fixes the directive named in #82.