### PR TITLE
fix(parser): emit ON DELETE / ON UPDATE for field-level foreign keys (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ type User struct {
 - `check` - CHECK constraint
 - `foreign` - Foreign key reference (table(column))
 - `foreign_key_name` - Custom foreign key constraint name
+- `on_delete` - Foreign key ON DELETE action ("CASCADE", "SET NULL", "RESTRICT", "NO ACTION")
+- `on_update` - Foreign key ON UPDATE action ("CASCADE", "SET NULL", "RESTRICT", "NO ACTION")
 - `enum` - Enum values (comma-separated)
 - `platform.{dialect}.{attribute}` - Platform-specific overrides
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -311,6 +311,8 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 	// Set foreign key reference
 	if fkRef := ParseForeignKeyReference(field.Foreign); fkRef != nil {
 		column.SetForeignKey(fkRef.Table, fkRef.Column, field.ForeignKeyName)
+		column.ForeignKey.OnDelete = field.OnDelete
+		column.ForeignKey.OnUpdate = field.OnUpdate
 	}
 
 	return column

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1269,6 +1269,8 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 		Nullable:       embedded.Nullable, // Can the relationship be optional?
 		Foreign:        embedded.Ref,      // e.g., "users(id)"
 		ForeignKeyName: foreignKeyName,    // e.g., "fk_posts_user_id"
+		OnDelete:       embedded.OnDelete, // ON DELETE action (CASCADE, SET NULL, etc.)
+		OnUpdate:       embedded.OnUpdate, // ON UPDATE action (CASCADE, SET NULL, etc.)
 		Comment:        embedded.Comment,  // Documentation for the relationship
 		Overrides:      overrides,         // Platform-specific type overrides
 	})

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -1825,3 +1825,62 @@ func TestFromField_EnumConversion_SQLInjectionPrevention(t *testing.T) {
 		})
 	}
 }
+
+// TestFromDatabase_EmbeddedRelationFKActions verifies that on_delete /
+// on_update declared on a //migrator:embedded mode="relation" annotation
+// flow through to the column-level ForeignKey on the generated table.
+//
+// Regression coverage for the embedded path of issue #117 — the field-level
+// fix wired the regular Field path, and this test pins the parallel wiring
+// in processEmbeddedRelationMode so embedded-relation FKs don't silently
+// drop their actions on the generate path.
+func TestFromDatabase_EmbeddedRelationFKActions(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{
+				StructName:       "Post",
+				EmbeddedTypeName: "User",
+				Mode:             "relation",
+				Field:            "author_id",
+				Ref:              "users(id)",
+				OnDelete:         "CASCADE",
+				OnUpdate:         "RESTRICT",
+			},
+		},
+	}
+
+	statements := fromschema.FromDatabase(db, "postgres")
+	c.Assert(statements, qt.IsNotNil)
+
+	var postsTable *ast.CreateTableNode
+	for _, stmt := range statements.Statements {
+		if t, ok := stmt.(*ast.CreateTableNode); ok && t.Name == "posts" {
+			postsTable = t
+			break
+		}
+	}
+	c.Assert(postsTable, qt.IsNotNil)
+
+	var authorCol *ast.ColumnNode
+	for _, col := range postsTable.Columns {
+		if col.Name == "author_id" {
+			authorCol = col
+			break
+		}
+	}
+	c.Assert(authorCol, qt.IsNotNil)
+	c.Assert(authorCol.ForeignKey, qt.IsNotNil)
+	c.Assert(authorCol.ForeignKey.Table, qt.Equals, "users")
+	c.Assert(authorCol.ForeignKey.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(authorCol.ForeignKey.OnUpdate, qt.Equals, "RESTRICT")
+}

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -188,6 +188,37 @@ func TestFromField_ForeignKeys(t *testing.T) {
 				return col.ForeignKey == nil
 			},
 		},
+		{
+			name: "foreign key with ON DELETE CASCADE (issue #117)",
+			field: goschema.Field{
+				Name:           "commodity_id",
+				Type:           "TEXT",
+				Foreign:        "commodities(id)",
+				ForeignKeyName: "fk_cs_commodity",
+				OnDelete:       "CASCADE",
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.ForeignKey != nil &&
+					col.ForeignKey.OnDelete == "CASCADE" &&
+					col.ForeignKey.OnUpdate == ""
+			},
+		},
+		{
+			name: "foreign key with ON DELETE SET NULL and ON UPDATE CASCADE",
+			field: goschema.Field{
+				Name:           "owner_id",
+				Type:           "INTEGER",
+				Foreign:        "users(id)",
+				ForeignKeyName: "fk_owner",
+				OnDelete:       "SET NULL",
+				OnUpdate:       "CASCADE",
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.ForeignKey != nil &&
+					col.ForeignKey.OnDelete == "SET NULL" &&
+					col.ForeignKey.OnUpdate == "CASCADE"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -152,6 +152,8 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 			field.Foreign = column.ForeignKey.Table
 		}
 		field.ForeignKeyName = column.ForeignKey.Name
+		field.OnDelete = column.ForeignKey.OnDelete
+		field.OnUpdate = column.ForeignKey.OnUpdate
 	}
 
 	// Initialize overrides map if we have a source platform

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -17,14 +17,8 @@ import (
 // //migrator:schema:field annotation. Keys with the "platform." prefix are
 // also accepted (handled separately).
 //
-// Some entries are accepted but not currently consumed by parseFieldComment;
-// they are whitelisted to keep the strict validator focused on real typos:
-//   - "nullable", "index", "autoincrement": parseutils auto-promotes these to
-//     booleans when written as bare words.
-//   - "on_delete", "on_update": documented FK-action keys consumed by
-//     EmbeddedField and Constraint parsers. Field-level propagation to the
-//     emitted SQL is not implemented yet — projects in the wild work around
-//     this with manual ALTER TABLE statements. Tracked separately.
+// "nullable", "index", and "autoincrement" are whitelisted because parseutils
+// auto-promotes them to booleans when written as bare words.
 var knownFieldAttributes = map[string]bool{
 	"name":             true,
 	"type":             true,
@@ -113,6 +107,8 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 			DefaultExpr:    kv["default_expr"],
 			Foreign:        kv["foreign"],
 			ForeignKeyName: kv["foreign_key_name"],
+			OnDelete:       kv["on_delete"],
+			OnUpdate:       kv["on_update"],
 			Enum:           enum,
 			Check:          kv["check"],
 			Comment:        kv["comment"],

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -784,3 +784,49 @@ type Widget struct {
 	database := goschema.ParseFile(testFile)
 	c.Assert(database.Fields, qt.HasLen, 3)
 }
+
+// TestParseField_ForeignKeyActions verifies that on_delete and on_update
+// attributes declared on a //migrator:schema:field annotation are captured on
+// the resulting Field (regression test for #117 — these keys were previously
+// whitelisted but silently dropped).
+func TestParseField_ForeignKeyActions(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="commodities"
+type Commodity struct {
+	//migrator:schema:field name="id" type="TEXT" primary="true"
+	ID string
+}
+
+//migrator:schema:table name="commodity_services"
+type CommodityService struct {
+	//migrator:schema:field name="id" type="TEXT" primary="true"
+	ID string
+
+	//migrator:schema:field name="commodity_id" type="TEXT" not_null="true" foreign="commodities(id)" foreign_key_name="fk_cs_commodity" on_delete="CASCADE" on_update="RESTRICT"
+	CommodityID string
+}
+`
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "service.go")
+	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
+	c.Assert(err, qt.IsNil)
+
+	database := goschema.ParseFile(testFile)
+
+	var fkField *goschema.Field
+	for i, f := range database.Fields {
+		if f.Name == "commodity_id" {
+			fkField = &database.Fields[i]
+			break
+		}
+	}
+	c.Assert(fkField, qt.Not(qt.IsNil))
+	c.Assert(fkField.Foreign, qt.Equals, "commodities(id)")
+	c.Assert(fkField.ForeignKeyName, qt.Equals, "fk_cs_commodity")
+	c.Assert(fkField.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(fkField.OnUpdate, qt.Equals, "RESTRICT")
+}

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -830,3 +830,52 @@ type CommodityService struct {
 	c.Assert(fkField.OnDelete, qt.Equals, "CASCADE")
 	c.Assert(fkField.OnUpdate, qt.Equals, "RESTRICT")
 }
+
+// TestParseDir_EmbeddedRelationFKActions exercises the ParseDir/walker path
+// (which expands embedded fields via the internal processEmbeddedFields), to
+// pin that on_delete / on_update declared on a //migrator:embedded mode="relation"
+// annotation reach the planner-visible Field — a third copy of the embedded
+// expansion lives in core/goschema/utils.go and used to drop the actions
+// before the fix for #117 landed.
+func TestParseDir_EmbeddedRelationFKActions(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:embedded mode="relation" field="author_id" ref="users(id)" on_delete="CASCADE" on_update="RESTRICT"
+	Author User
+}
+`
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "entities.go")
+	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
+	c.Assert(err, qt.IsNil)
+
+	database, err := goschema.ParseDir(tmpDir)
+	c.Assert(err, qt.IsNil)
+
+	var authorField *goschema.Field
+	for i, f := range database.Fields {
+		if f.StructName == "Post" && f.Name == "author_id" {
+			authorField = &database.Fields[i]
+			break
+		}
+	}
+	c.Assert(authorField, qt.Not(qt.IsNil),
+		qt.Commentf("expected synthesized author_id field on Post; got fields: %+v", database.Fields))
+	c.Assert(authorField.Foreign, qt.Equals, "users(id)")
+	c.Assert(authorField.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(authorField.OnUpdate, qt.Equals, "RESTRICT")
+}

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -119,6 +119,8 @@ type Field struct {
 	DefaultExpr    string                       // Default expression (e.g., "NOW()", "UUID()", "CURRENT_TIMESTAMP", "1", "true")
 	Foreign        string                       // Foreign key reference (e.g., "users(id)")
 	ForeignKeyName string                       // Custom foreign key constraint name
+	OnDelete       string                       // Foreign key ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+	OnUpdate       string                       // Foreign key ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
 	Enum           []string                     // Enum values for ENUM type fields
 	Check          string                       // Check constraint expression
 	Comment        string                       // Column comment
@@ -515,4 +517,6 @@ type SelfReferencingFK struct {
 	FieldName      string // Name of the field (e.g., "parent_id")
 	Foreign        string // Foreign key reference (e.g., "users(id)")
 	ForeignKeyName string // Name of the foreign key constraint (e.g., "fk_users_parent")
+	OnDelete       string // ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+	OnUpdate       string // ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
 }

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -477,8 +477,10 @@ func processEmbeddedRelationMode(generatedFields []Field, embedded EmbeddedField
 		Nullable:       embedded.Nullable, // Can the relationship be optional?
 		Foreign:        embedded.Ref,      // e.g., "users(id)"
 		ForeignKeyName: foreignKeyName,    // e.g., "fk_posts_user_id"
-		Comment:        embedded.Comment,  // Documentation for the relationship
-		Overrides:      overrides,         // Platform-specific type overrides
+		OnDelete:       embedded.OnDelete, // ON DELETE action (CASCADE, SET NULL, etc.) — keeps the walker/planner path in sync with fromschema (#117).
+		OnUpdate:       embedded.OnUpdate,
+		Comment:        embedded.Comment, // Documentation for the relationship
+		Overrides:      overrides,        // Platform-specific type overrides
 	})
 
 	return generatedFields

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -202,6 +202,8 @@ func analyzeFieldForeignKeys(r *Database) {
 			FieldName:      field.Name,
 			Foreign:        field.Foreign,
 			ForeignKeyName: field.ForeignKeyName,
+			OnDelete:       field.OnDelete,
+			OnUpdate:       field.OnUpdate,
 		})
 	}
 }
@@ -223,6 +225,8 @@ func analyzeEmbeddedFieldRelations(r *Database) {
 			FieldName:      embedded.Field,
 			Foreign:        embedded.Ref,
 			ForeignKeyName: generateForeignKeyName(table.Name, embedded.Field),
+			OnDelete:       embedded.OnDelete,
+			OnUpdate:       embedded.OnUpdate,
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stokaro/ptah
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/frankban/quicktest v1.14.6

--- a/migration/planner/dialects/mysql/fk_actions_test.go
+++ b/migration/planner/dialects/mysql/fk_actions_test.go
@@ -1,4 +1,4 @@
-package postgres_test
+package mysql_test
 
 import (
 	"strings"
@@ -8,26 +8,24 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
-	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
 // TestPlanner_FieldLevelForeignKeyActions verifies that on_delete / on_update
 // declared on a //migrator:schema:field annotation flow all the way through to
-// the emitted ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY statement.
+// the emitted ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY statement when
+// the MySQL planner is in play.
 //
-// Regression test for issue #117. Before the fix, the keys were whitelisted by
-// the strict-attribute validator (added with #82) but never read by
-// parseFieldComment, so the AST never carried OnDelete/OnUpdate and the
-// rendered SQL silently dropped them.
+// Sibling to the postgres test of the same name — guards the parallel edits
+// in addRegularForeignKeys / addSelfReferencingForeignKeys / addNewTableColumns.
+// Regression test for issue #117.
 func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 	tests := []struct {
-		name      string
-		diff      *types.SchemaDiff
-		generated *goschema.Database
-		mustEmit  string
-		// constraintMarker filters the negative check so it only inspects the
-		// ALTER TABLE line carrying this constraint name.
+		name             string
+		diff             *types.SchemaDiff
+		generated        *goschema.Database
+		mustEmit         string
 		constraintMarker string
 		mustNotHit       string
 	}{
@@ -35,23 +33,23 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 			name: "ON DELETE CASCADE on field annotation",
 			generated: &goschema.Database{
 				Tables: []goschema.Table{
-					{StructName: "Commodity", Name: "commodities"},
-					{StructName: "CommodityService", Name: "commodity_services"},
+					{StructName: "User", Name: "users"},
+					{StructName: "Post", Name: "posts"},
 				},
 				Fields: []goschema.Field{
-					{StructName: "Commodity", Name: "id", Type: "TEXT", Primary: true},
-					{StructName: "CommodityService", Name: "id", Type: "TEXT", Primary: true},
+					{StructName: "User", Name: "id", Type: "INT", Primary: true, AutoInc: true},
+					{StructName: "Post", Name: "id", Type: "INT", Primary: true, AutoInc: true},
 					{
-						StructName:     "CommodityService",
-						Name:           "commodity_id",
-						Type:           "TEXT",
-						Foreign:        "commodities(id)",
-						ForeignKeyName: "fk_cs_commodity",
+						StructName:     "Post",
+						Name:           "owner_id",
+						Type:           "INT",
+						Foreign:        "users(id)",
+						ForeignKeyName: "fk_post_owner",
 						OnDelete:       "CASCADE",
 					},
 				},
 			},
-			mustEmit: "ALTER TABLE commodity_services ADD CONSTRAINT fk_cs_commodity FOREIGN KEY (commodity_id) REFERENCES commodities(id) ON DELETE CASCADE;",
+			mustEmit: "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE;",
 		},
 		{
 			name: "ON DELETE SET NULL + ON UPDATE CASCADE",
@@ -61,12 +59,12 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 					{StructName: "Post", Name: "posts"},
 				},
 				Fields: []goschema.Field{
-					{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
-					{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "User", Name: "id", Type: "INT", Primary: true, AutoInc: true},
+					{StructName: "Post", Name: "id", Type: "INT", Primary: true, AutoInc: true},
 					{
 						StructName:     "Post",
 						Name:           "owner_id",
-						Type:           "INTEGER",
+						Type:           "INT",
 						Foreign:        "users(id)",
 						ForeignKeyName: "fk_post_owner",
 						OnDelete:       "SET NULL",
@@ -84,12 +82,12 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 					{StructName: "Post", Name: "posts"},
 				},
 				Fields: []goschema.Field{
-					{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
-					{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "User", Name: "id", Type: "INT", Primary: true, AutoInc: true},
+					{StructName: "Post", Name: "id", Type: "INT", Primary: true, AutoInc: true},
 					{
 						StructName:     "Post",
 						Name:           "owner_id",
-						Type:           "INTEGER",
+						Type:           "INT",
 						Foreign:        "users(id)",
 						ForeignKeyName: "fk_post_owner",
 					},
@@ -106,7 +104,7 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 					{StructName: "Category", Name: "categories"},
 				},
 				Fields: []goschema.Field{
-					{StructName: "Category", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "Category", Name: "id", Type: "INT", Primary: true, AutoInc: true},
 				},
 				SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{
 					"categories": {
@@ -134,12 +132,12 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 					{StructName: "Post", Name: "posts"},
 				},
 				Fields: []goschema.Field{
-					{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
-					{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "User", Name: "id", Type: "INT", Primary: true, AutoInc: true},
+					{StructName: "Post", Name: "id", Type: "INT", Primary: true, AutoInc: true},
 					{
 						StructName:     "Post",
 						Name:           "owner_id",
-						Type:           "INTEGER",
+						Type:           "INT",
 						Foreign:        "users(id)",
 						ForeignKeyName: "fk_post_owner",
 						OnDelete:       "RESTRICT",
@@ -149,10 +147,6 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 			mustEmit: "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE RESTRICT;",
 		},
 	}
-	// Embedded-relation mode coverage lives in
-	// core/convert/fromschema/fromschema_test.go (TestFromDatabase_EmbeddedRelationFKActions) —
-	// the planner doesn't expand EmbeddedFields itself; field expansion happens
-	// in fromschema.ProcessEmbeddedFields and (for diffs) compare.processEmbeddedFieldsForStruct.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -160,7 +154,6 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 
 			diff := tt.diff
 			if diff == nil {
-				// Default: emit FKs for all tables in TablesAdded.
 				tablesAdded := make([]string, 0, len(tt.generated.Tables))
 				for _, table := range tt.generated.Tables {
 					tablesAdded = append(tablesAdded, table.Name)
@@ -168,16 +161,14 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 				diff = &types.SchemaDiff{TablesAdded: tablesAdded}
 			}
 
-			nodes := postgres.New().GenerateMigrationAST(diff, tt.generated)
-			sql, err := renderer.RenderSQL("postgres", nodes...)
+			nodes := mysql.New().GenerateMigrationAST(diff, tt.generated)
+			sql, err := renderer.RenderSQL("mysql", nodes...)
 			c.Assert(err, qt.IsNil)
 
 			c.Assert(strings.Contains(sql, tt.mustEmit), qt.IsTrue,
 				qt.Commentf("expected SQL to contain:\n  %s\ngot:\n%s", tt.mustEmit, sql))
 
 			if tt.mustNotHit != "" {
-				// Restrict the negative check to the line carrying the named
-				// constraint so we don't accidentally match unrelated noise.
 				for line := range strings.SplitSeq(sql, "\n") {
 					if strings.Contains(line, tt.constraintMarker) {
 						c.Assert(strings.Contains(line, tt.mustNotHit), qt.IsFalse,

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -142,6 +142,8 @@ func (p *Planner) addRegularForeignKeys(result []ast.Node, generated *goschema.D
 
 		fkRef := fromschema.ParseForeignKeyReference(field.Foreign)
 		if fkRef != nil && fkRef.Table != table.Name {
+			fkRef.OnDelete = field.OnDelete
+			fkRef.OnUpdate = field.OnUpdate
 			result = append(result, p.createForeignKeyAlterStatement(table.Name, field.ForeignKeyName, []string{field.Name}, fkRef))
 		}
 	}
@@ -158,6 +160,8 @@ func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *go
 	for _, selfRefFK := range selfRefFKs {
 		fkRef := fromschema.ParseForeignKeyReference(selfRefFK.Foreign)
 		if fkRef != nil {
+			fkRef.OnDelete = selfRefFK.OnDelete
+			fkRef.OnUpdate = selfRefFK.OnUpdate
 			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfRefFK.ForeignKeyName, []string{selfRefFK.FieldName}, fkRef))
 		}
 	}
@@ -216,6 +220,8 @@ func (p *Planner) addNewTableColumns(result []ast.Node, tableDiff *types.TableDi
 				fkRef := fromschema.ParseForeignKeyReference(targetField.Foreign)
 				if fkRef != nil {
 					fkRef.Name = targetField.ForeignKeyName
+					fkRef.OnDelete = targetField.OnDelete
+					fkRef.OnUpdate = targetField.OnUpdate
 
 					// Create foreign key constraint
 					fkConstraint := ast.NewForeignKeyConstraint(

--- a/migration/planner/dialects/postgres/fk_actions_test.go
+++ b/migration/planner/dialects/postgres/fk_actions_test.go
@@ -1,0 +1,129 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestPlanner_FieldLevelForeignKeyActions verifies that on_delete / on_update
+// declared on a //migrator:schema:field annotation flow all the way through to
+// the emitted ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY statement.
+//
+// Regression test for issue #117. Before the fix, the keys were whitelisted by
+// the strict-attribute validator (added with #82) but never read by
+// parseFieldComment, so the AST never carried OnDelete/OnUpdate and the
+// rendered SQL silently dropped them.
+func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		generated  *goschema.Database
+		mustEmit   string
+		mustNotHit string
+	}{
+		{
+			name: "ON DELETE CASCADE on field annotation",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "Commodity", Name: "commodities"},
+					{StructName: "CommodityService", Name: "commodity_services"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "Commodity", Name: "id", Type: "TEXT", Primary: true},
+					{StructName: "CommodityService", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "CommodityService",
+						Name:           "commodity_id",
+						Type:           "TEXT",
+						Foreign:        "commodities(id)",
+						ForeignKeyName: "fk_cs_commodity",
+						OnDelete:       "CASCADE",
+					},
+				},
+			},
+			mustEmit: "ALTER TABLE commodity_services ADD CONSTRAINT fk_cs_commodity FOREIGN KEY (commodity_id) REFERENCES commodities(id) ON DELETE CASCADE;",
+		},
+		{
+			name: "ON DELETE SET NULL + ON UPDATE CASCADE",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "User", Name: "users"},
+					{StructName: "Post", Name: "posts"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+					{
+						StructName:     "Post",
+						Name:           "owner_id",
+						Type:           "INTEGER",
+						Foreign:        "users(id)",
+						ForeignKeyName: "fk_post_owner",
+						OnDelete:       "SET NULL",
+						OnUpdate:       "CASCADE",
+					},
+				},
+			},
+			mustEmit: "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE SET NULL ON UPDATE CASCADE;",
+		},
+		{
+			name: "no FK actions still emits a clean REFERENCES (no ON DELETE/UPDATE)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "User", Name: "users"},
+					{StructName: "Post", Name: "posts"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+					{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+					{
+						StructName:     "Post",
+						Name:           "owner_id",
+						Type:           "INTEGER",
+						Foreign:        "users(id)",
+						ForeignKeyName: "fk_post_owner",
+					},
+				},
+			},
+			mustEmit:   "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id);",
+			mustNotHit: "ON DELETE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			// The planner only emits FK constraints for tables in TablesAdded.
+			tablesAdded := make([]string, 0, len(tt.generated.Tables))
+			for _, table := range tt.generated.Tables {
+				tablesAdded = append(tablesAdded, table.Name)
+			}
+			diff := &types.SchemaDiff{TablesAdded: tablesAdded}
+
+			nodes := postgres.New().GenerateMigrationAST(diff, tt.generated)
+			sql, err := renderer.RenderSQL("postgres", nodes...)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(strings.Contains(sql, tt.mustEmit), qt.IsTrue,
+				qt.Commentf("expected SQL to contain:\n  %s\ngot:\n%s", tt.mustEmit, sql))
+
+			if tt.mustNotHit != "" {
+				// Restrict the negative check to the ALTER TABLE … FK line so
+				// we don't accidentally match unrelated DROP CONSTRAINT noise.
+				for line := range strings.SplitSeq(sql, "\n") {
+					if strings.Contains(line, "fk_post_owner") {
+						c.Assert(strings.Contains(line, tt.mustNotHit), qt.IsFalse,
+							qt.Commentf("FK line should not mention %q: %s", tt.mustNotHit, line))
+					}
+				}
+			}
+		})
+	}
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -160,6 +160,8 @@ func (p *Planner) addRegularForeignKeys(result []ast.Node, generated *goschema.D
 
 		fkRef := fromschema.ParseForeignKeyReference(field.Foreign)
 		if fkRef != nil && fkRef.Table != table.Name {
+			fkRef.OnDelete = field.OnDelete
+			fkRef.OnUpdate = field.OnUpdate
 			result = append(result, p.createForeignKeyAlterStatement(table.Name, field.ForeignKeyName, []string{field.Name}, fkRef))
 		}
 	}
@@ -176,6 +178,8 @@ func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *go
 	for _, selfRefFK := range selfRefFKs {
 		fkRef := fromschema.ParseForeignKeyReference(selfRefFK.Foreign)
 		if fkRef != nil {
+			fkRef.OnDelete = selfRefFK.OnDelete
+			fkRef.OnUpdate = selfRefFK.OnUpdate
 			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfRefFK.ForeignKeyName, []string{selfRefFK.FieldName}, fkRef))
 		}
 	}
@@ -270,6 +274,8 @@ func (p *Planner) addForeignKeyConstraintsForNewColumns(result []ast.Node, table
 			fkRef := fromschema.ParseForeignKeyReference(targetField.Foreign)
 			if fkRef != nil {
 				fkRef.Name = targetField.ForeignKeyName
+				fkRef.OnDelete = targetField.OnDelete
+				fkRef.OnUpdate = targetField.OnUpdate
 
 				// Create foreign key constraint
 				fkConstraint := ast.NewForeignKeyConstraint(

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -1843,6 +1843,8 @@ func processEmbeddedFieldsForStruct(embeddedFields []goschema.EmbeddedField, all
 				Name:       embedded.Field,
 				Type:       "INTEGER", // Default to INTEGER for foreign keys
 				Foreign:    embedded.Ref,
+				OnDelete:   embedded.OnDelete, // Mirror of fromschema.processEmbeddedRelationMode — keeps the diff path in agreement with the generate path on FK actions (#117).
+				OnUpdate:   embedded.OnUpdate,
 				Comment:    embedded.Comment,
 				Overrides:  overrides, // Platform-specific type overrides
 			}


### PR DESCRIPTION
Closes #117.

## Problem

`//migrator:schema:field` annotations declaring `on_delete` / `on_update` parse without complaint (the keys were whitelisted by the strict validator added in #82) but the values are silently dropped — every column-level FK ends up with NO ACTION semantics regardless of what the annotation says. From the issue:

```go
//migrator:schema:field name="commodity_id" type="TEXT" not_null="true" foreign="commodities(id)" foreign_key_name="fk_cs_commodity" on_delete="CASCADE"
CommodityID string
```

Before this PR: emitted SQL has no `ON DELETE CASCADE` clause.
After this PR: emitted SQL contains `ON DELETE CASCADE`.

The same bug class affects `//migrator:embedded mode="relation" on_delete=...` — fixed here too (caught during self-review).

## Bundled fix: master CI

This PR also includes a one-line CI fix (separate commit): Renovate PR #119 bumped `go-version` in `.github/workflows/go-*.yml` to `1.26.3` but left `go.mod` at `1.26.2`, which trips the **Go Version Consistency** workflow on master. Without this, every CI run on master and on any feature PR is red. Aligning `go.mod` to `1.26.3` is the minimal fix.

## Wiring change

- **`core/goschema/types.go`** — add `OnDelete` and `OnUpdate` to `Field` and `SelfReferencingFK`.
- **`core/goschema/parser.go`** — `parseFieldComment` reads `kv["on_delete"]` / `kv["on_update"]`. Removed the placeholder comment in `knownFieldAttributes` (the #82 PR left a note saying field-level propagation was deferred; that's done now).
- **`core/goschema/utils.go`** — `analyzeFieldForeignKeys` and `analyzeEmbeddedFieldRelations` propagate the actions into `SelfReferencingFK` so self-referencing FK paths get the same treatment.
- **`core/convert/fromschema/fromschema.go`** — `FromField` sets `ColumnNode.ForeignKey.OnDelete` / `.OnUpdate` right after `SetForeignKey` returns. `processEmbeddedRelationMode` copies `embedded.OnDelete` / `embedded.OnUpdate` into the synthetic Field it generates, so the embedded-relation path carries the actions too.
- **`migration/planner/dialects/postgres/postgres.go`** and **`.../mysql/mysql.go`** — the regular, self-referencing, and new-column FK paths all populate `fkRef.OnDelete` / `.OnUpdate` from the `Field` / `SelfReferencingFK` before building the ALTER TABLE constraint, so `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY … REFERENCES …` carries the action clauses.

## Tests

- **Parser test** (`core/goschema/parser_test.go::TestParseField_ForeignKeyActions`) — asserts `Field.OnDelete` / `OnUpdate` are captured from the annotation.
- **Converter tests** (`core/convert/fromschema/fromschema_test.go`):
  - `TestFromField_ForeignKeys` gains sub-tests for `ON DELETE CASCADE` and `ON DELETE SET NULL` + `ON UPDATE CASCADE`.
  - `TestFromDatabase_EmbeddedRelationFKActions` pins the embedded-relation generate path.
- **End-to-end planner+renderer tests** (`migration/planner/dialects/{postgres,mysql}/fk_actions_test.go`) — assert that the emitted `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY …` contains the action clauses for: field-level FK (`ON DELETE CASCADE`), combined `ON DELETE SET NULL` + `ON UPDATE CASCADE`, self-referencing FK (`SelfReferencingForeignKeys` table), and `ALTER TABLE ADD COLUMN` of a new FK column (`TablesModified[].ColumnsAdded`). Each test also confirms that fields without actions don't introduce stray `ON DELETE` / `ON UPDATE` clauses.

Manual verification of the exact example from the issue:

```sql
-- POSTGRES TABLE: commodity_services --
CREATE TABLE commodity_services (
  id TEXT PRIMARY KEY NOT NULL,
  commodity_id TEXT NOT NULL,
  CONSTRAINT fk_commodity_service_commodity FOREIGN KEY (commodity_id) REFERENCES commodities(id) ON DELETE CASCADE
);
```

## Test plan

- [x] `go test ./...` — green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Manual repro of the issue example produces SQL with `ON DELETE CASCADE`
- [ ] CI integration tests (run on PR)

## Acceptance checklist (from #117)

- [x] `Field` carries `OnDelete` and `OnUpdate`
- [x] Generated `CREATE TABLE` / `ALTER TABLE ADD CONSTRAINT` includes the action(s) when set on the field
- [x] Embedded relation mode (`//migrator:embedded mode="relation" on_delete=...`) also carries the actions
- [x] Placeholder whitelist comment in `parser.go` (added with #82) removed; `on_delete` / `on_update` are now real field attributes
- [ ] Drift detector round-trip — out of scope here; tracked alongside #89

## Known pre-existing gaps not addressed here

- **MySQL/MariaDB `generate` (CREATE TABLE) drops column-level FKs entirely.** The MySQL/MariaDB CREATE TABLE renderer (`core/renderer/dialects/mysqllike/mysqllike.go::VisitCreateTable`) does not convert `column.ForeignKey` into a table-level constraint the way the postgres renderer does, so column-level FKs are missing from `generate` output for MySQL. The migration path (`migrate`) is unaffected because the planner emits FKs via separate `ALTER TABLE` statements. This is older than #117 and out of scope; flagging so users don't assume MySQL is fully covered via `generate`.
- **Drift detector skips field-level FK constraints.** `migration/schemadiff/internal/compare/compare.go::isFieldLevelConstraint` filters field-level FKs out of the diff, so changing `on_delete` on a Go annotation against an already-applied schema produces zero migration. Tracked alongside #89.