### PR TITLE
feat(parser): field-level CHECK constraint annotation with drift detection

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -155,6 +155,12 @@ type ColumnNode struct {
 	Default *DefaultValue
 	// Check contains a check constraint expression for this column
 	Check string
+	// CheckName is an optional explicit constraint name for the column-level
+	// CHECK. When empty, dialect renderers either emit an unnamed `CHECK (...)`
+	// (relying on the engine's auto-generated name) or, in the planner path
+	// when matching against introspected constraints, a deterministic
+	// "<table>_<column>_check" identifier.
+	CheckName string
 	// Comment is an optional column comment
 	Comment string
 	// ForeignKey contains foreign key reference information if this column references another table
@@ -272,6 +278,15 @@ func (n *ColumnNode) SetDefaultExpression(fn string) *ColumnNode {
 //	column.SetCheck("price > 0")
 func (n *ColumnNode) SetCheck(expression string) *ColumnNode {
 	n.Check = expression
+	return n
+}
+
+// SetCheckName sets the constraint name used to emit
+// `CONSTRAINT <name> CHECK (...)` instead of the unnamed inline form.
+// Use this when round-trip stability with database introspection is
+// required (e.g. for drift detection on field-level CHECKs).
+func (n *ColumnNode) SetCheckName(name string) *ColumnNode {
+	n.CheckName = name
 	return n
 }
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -76,6 +76,7 @@ func generateForeignKeyName(tableName, fieldName string) string {
 func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschema.Field {
 	fieldType := field.Type
 	checkConstraint := field.Check
+	checkName := field.CheckName
 	comment := field.Comment
 	defaultValue := field.Default
 	defaultExpr := field.DefaultExpr
@@ -97,6 +98,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField := field // Shallow copy to avoid modifying original field
 		newField.Type = fieldType
 		newField.Check = checkConstraint
+		newField.CheckName = checkName
 		newField.Comment = comment
 		newField.Default = defaultValue
 		newField.DefaultExpr = defaultExpr
@@ -108,6 +110,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField := field // Shallow copy to avoid modifying original field
 		newField.Type = fieldType
 		newField.Check = checkConstraint
+		newField.CheckName = checkName
 		newField.Comment = comment
 		newField.Default = defaultValue
 		newField.DefaultExpr = defaultExpr
@@ -121,6 +124,10 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	// Override check constraint if specified
 	if checkOverride, ok := platformOverrides["check"]; ok {
 		checkConstraint = checkOverride
+	}
+	// Override check constraint name if specified
+	if checkNameOverride, ok := platformOverrides["check_name"]; ok {
+		checkName = checkNameOverride
 	}
 	// Override comment if specified
 	if commentOverride, ok := platformOverrides["comment"]; ok {
@@ -140,6 +147,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	newField := field // Shallow copy to avoid modifying original field
 	newField.Type = fieldType
 	newField.Check = checkConstraint
+	newField.CheckName = checkName
 	newField.Comment = comment
 	newField.Default = defaultValue
 	newField.DefaultExpr = defaultExpr
@@ -301,6 +309,9 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 	// Set check constraint (using potentially overridden value)
 	if field.Check != "" {
 		column.SetCheck(field.Check)
+		if field.CheckName != "" {
+			column.SetCheckName(field.CheckName)
+		}
 	}
 
 	// Set comment (using potentially overridden value)
@@ -372,6 +383,9 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 	// Set check constraint (using potentially overridden value)
 	if field.Check != "" {
 		column.SetCheck(field.Check)
+		if field.CheckName != "" {
+			column.SetCheckName(field.CheckName)
+		}
 	}
 
 	// Set comment (using potentially overridden value)

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -132,6 +132,7 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 		AutoInc:    column.AutoInc,
 		Unique:     column.Unique,
 		Check:      column.Check,
+		CheckName:  column.CheckName,
 		Comment:    column.Comment,
 	}
 

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -132,8 +132,15 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 		AutoInc:    column.AutoInc,
 		Unique:     column.Unique,
 		Check:      column.Check,
-		CheckName:  column.CheckName,
 		Comment:    column.Comment,
+	}
+
+	// Mirror the fromschema guarding: only surface CheckName when there's
+	// actually a CHECK expression. Otherwise a stale name from a partly-
+	// populated AST node would leak back into a generated Go annotation
+	// suggestion as a phantom `check_name=` with no `check=` to back it.
+	if column.Check != "" {
+		field.CheckName = column.CheckName
 	}
 
 	// Extract default values

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -38,6 +38,7 @@ var knownFieldAttributes = map[string]bool{
 	"on_update":        true,
 	"enum":             true,
 	"check":            true,
+	"check_name":       true,
 	"comment":          true,
 }
 
@@ -111,6 +112,7 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 			OnUpdate:       kv["on_update"],
 			Enum:           enum,
 			Check:          kv["check"],
+			CheckName:      kv["check_name"],
 			Comment:        kv["comment"],
 			Overrides:      parseutils.ParsePlatformSpecific(kv),
 		})

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -879,3 +879,50 @@ type Post struct {
 	c.Assert(authorField.OnDelete, qt.Equals, "CASCADE")
 	c.Assert(authorField.OnUpdate, qt.Equals, "RESTRICT")
 }
+
+// TestParseField_CheckConstraint verifies that the column-level `check=` and
+// optional `check_name=` attributes (issue #112) are accepted by the parser
+// and propagated onto goschema.Field. The expression is passed through
+// verbatim — the parser does not parse or validate the SQL.
+func TestParseField_CheckConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="files"
+type File struct {
+	//migrator:schema:field name="id" type="TEXT" primary="true"
+	ID string
+
+	//migrator:schema:field name="category" type="TEXT" not_null="true" default="other" check="category IN ('photos','invoices','documents','other')"
+	Category string
+
+	//migrator:schema:field name="type" type="TEXT" not_null="true" check="type IN ('image','document','video','audio','archive','other')" check_name="files_type_valid"
+	Type string
+}
+`
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "file.go")
+	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
+	c.Assert(err, qt.IsNil)
+
+	database := goschema.ParseFile(testFile)
+
+	var category, typ *goschema.Field
+	for i, f := range database.Fields {
+		switch f.Name {
+		case "category":
+			category = &database.Fields[i]
+		case "type":
+			typ = &database.Fields[i]
+		}
+	}
+	c.Assert(category, qt.Not(qt.IsNil))
+	c.Assert(category.Check, qt.Equals, "category IN ('photos','invoices','documents','other')")
+	c.Assert(category.CheckName, qt.Equals, "")
+
+	c.Assert(typ, qt.Not(qt.IsNil))
+	c.Assert(typ.Check, qt.Equals, "type IN ('image','document','video','audio','archive','other')")
+	c.Assert(typ.CheckName, qt.Equals, "files_type_valid")
+}

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -123,6 +123,7 @@ type Field struct {
 	OnUpdate       string                       // Foreign key ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
 	Enum           []string                     // Enum values for ENUM type fields
 	Check          string                       // Check constraint expression
+	CheckName      string                       // Optional constraint name for the column-level CHECK; defaults to "<table>_<column>_check"
 	Comment        string                       // Column comment
 	Overrides      map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
 }

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -298,9 +298,17 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 	}
 
-	// Check constraint
+	// Check constraint. When `check_name=` is provided, emit the explicit
+	// `CONSTRAINT <name> CHECK (...)` form so the constraint round-trips
+	// stably through MySQL/MariaDB introspection (which otherwise auto-names
+	// CHECKs as `<table>_chk_N` and would not match the drift detector's
+	// expected name).
 	if column.Check != "" {
-		parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
+		if column.CheckName != "" {
+			parts = append(parts, fmt.Sprintf("CONSTRAINT %s CHECK (%s)", column.CheckName, column.Check))
+		} else {
+			parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
+		}
 	}
 
 	return strings.Join(parts, " "), nil

--- a/core/renderer/dialects/postgres/check_constraint_test.go
+++ b/core/renderer/dialects/postgres/check_constraint_test.go
@@ -1,0 +1,69 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer/dialects/postgres"
+)
+
+// TestPostgreSQLRenderer_ColumnCheckConstraint covers issue #112 — column-level
+// `check=` (and optional `check_name=`) annotations need to render as either
+// inline `CHECK (...)` (relying on PostgreSQL's auto-naming convention
+// `<table>_<column>_check`) or, when an explicit name is provided, the named
+// `CONSTRAINT <name> CHECK (...)` form so the constraint survives drift
+// detection round-trips.
+func TestPostgreSQLRenderer_ColumnCheckConstraint(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    *ast.CreateTableNode
+		expected string
+	}{
+		{
+			name: "unnamed CHECK in column scope",
+			table: ast.NewCreateTable("files").
+				AddColumn(ast.NewColumn("id", "TEXT").SetPrimary()).
+				AddColumn(ast.NewColumn("category", "TEXT").
+					SetNotNull().
+					SetDefault("other").
+					SetCheck("category IN ('photos','invoices','documents','other')")),
+			expected: `-- POSTGRES TABLE: files --
+CREATE TABLE files (
+  id TEXT PRIMARY KEY NOT NULL,
+  category TEXT NOT NULL DEFAULT 'other' CHECK (category IN ('photos','invoices','documents','other'))
+);
+
+`,
+		},
+		{
+			name: "named CHECK in column scope",
+			table: ast.NewCreateTable("files").
+				AddColumn(ast.NewColumn("id", "TEXT").SetPrimary()).
+				AddColumn(ast.NewColumn("type", "TEXT").
+					SetNotNull().
+					SetCheck("type IN ('image','document','video','audio','archive','other')").
+					SetCheckName("files_type_valid")),
+			expected: `-- POSTGRES TABLE: files --
+CREATE TABLE files (
+  id TEXT PRIMARY KEY NOT NULL,
+  type TEXT NOT NULL CONSTRAINT files_type_valid CHECK (type IN ('image','document','video','audio','archive','other'))
+);
+
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			renderer := postgres.New()
+			result, err := renderer.Render(tt.table)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.Equals, tt.expected)
+		})
+	}
+}

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -514,9 +514,17 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 	}
 
-	// Check constraint
+	// Check constraint. Emit `CONSTRAINT <name> CHECK (...)` only when an
+	// explicit name was provided via `check_name=` on the field annotation —
+	// for the default (unnamed) form, PostgreSQL auto-generates the canonical
+	// "<table>_<column>_check" name, which is exactly what the drift detector
+	// expects, so we don't burn a constraint name on every column needlessly.
 	if column.Check != "" {
-		parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
+		if column.CheckName != "" {
+			parts = append(parts, fmt.Sprintf("CONSTRAINT %s CHECK (%s)", column.CheckName, column.Check))
+		} else {
+			parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
+		}
 	}
 
 	return strings.Join(parts, " "), nil

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -850,6 +850,22 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 		genConstraints[key] = constraint
 	}
 
+	// Synthesize table-level Constraint entries from field-level `check=`
+	// annotations so they participate in drift comparison alongside table
+	// constraints from `//migrator:schema:constraint`. Only synthesized for
+	// columns that already exist in the database — new tables/columns get
+	// their CHECK inline via CREATE TABLE / ALTER TABLE ADD COLUMN, and
+	// double-emitting an ALTER TABLE ADD CONSTRAINT would fail because the
+	// constraint is created in the same migration step.
+	for _, synthesized := range synthesizeFieldLevelCheckConstraints(generated, database) {
+		key := synthesized.Table + "." + synthesized.Name
+		// Don't clobber an explicit table-level constraint that happens to
+		// share the same name.
+		if _, exists := genConstraints[key]; !exists {
+			genConstraints[key] = synthesized
+		}
+	}
+
 	// Create map of existing database constraints, filtering out field-level constraints
 	dbConstraints := make(map[string]types.DBConstraint)
 	for _, constraint := range database.Constraints {
@@ -1029,11 +1045,12 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 		if strings.Contains(dbConstraint.Name, "_not_null") {
 			return hasNonNullableFieldInTable(dbConstraint.TableName, generated)
 		}
-		// Regular CHECK constraint - check if there's a field with check constraint for this column
-		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
-		if field, exists := fieldMap[key]; exists && field.Check != "" {
-			return true
-		}
+		// Regular CHECK constraints from `check=` annotations are surfaced
+		// to the diff via synthesized goschema.Constraint entries (see
+		// synthesizeFieldLevelCheckConstraints in Constraints). Letting the
+		// DB constraint participate here means it gets matched against the
+		// synthesized entry by name, so add/remove/expression-change cases
+		// all flow through the standard Constraints() comparison path.
 	}
 
 	return false
@@ -1055,6 +1072,65 @@ func hasNonNullableFieldInTable(tableName string, generated *goschema.Database) 
 		}
 	}
 	return false
+}
+
+// synthesizeFieldLevelCheckConstraints turns each field-level `check=`
+// annotation on an existing database column into a synthetic
+// goschema.Constraint of type CHECK so the standard Constraints() diff path
+// can compare it against the introspected CHECK from pg_constraint.
+//
+// The constraint name follows the user-provided `check_name=` value when set,
+// otherwise it falls back to the PostgreSQL convention
+// "<table>_<column>_check" — which is what PostgreSQL itself uses for
+// unnamed inline column-level CHECKs, so the name lines up with whatever the
+// reader sees on the DB side.
+//
+// Columns that do not yet exist in the database are deliberately skipped:
+// those CHECKs ship inline as part of CREATE TABLE / ALTER TABLE ADD COLUMN,
+// and emitting an ADD CONSTRAINT alongside would attempt to create the same
+// constraint twice in the same migration.
+func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database *types.DBSchema) []goschema.Constraint {
+	if generated == nil || database == nil {
+		return nil
+	}
+
+	structToTable := make(map[string]string, len(generated.Tables))
+	for _, t := range generated.Tables {
+		structToTable[t.StructName] = t.Name
+	}
+
+	dbColumns := make(map[string]struct{}, 16)
+	for _, t := range database.Tables {
+		for _, c := range t.Columns {
+			dbColumns[t.Name+"."+c.Name] = struct{}{}
+		}
+	}
+
+	var synthesized []goschema.Constraint
+	for _, f := range generated.Fields {
+		if f.Check == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		if _, exists := dbColumns[tableName+"."+f.Name]; !exists {
+			continue
+		}
+		name := f.CheckName
+		if name == "" {
+			name = tableName + "_" + f.Name + "_check"
+		}
+		synthesized = append(synthesized, goschema.Constraint{
+			StructName:      f.StructName,
+			Name:            name,
+			Type:            "CHECK",
+			Table:           tableName,
+			CheckExpression: f.Check,
+		})
+	}
+	return synthesized
 }
 
 // getConstraintColumn extracts the column name from a constraint

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -950,9 +950,32 @@ func excludeConstraintChanged(genConstraint goschema.Constraint, dbConstraint ty
 	return false
 }
 
-// checkConstraintChanged compares CHECK constraint definitions
-func checkConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
-	return genConstraint.CheckExpression != getStringValue(dbConstraint.CheckClause)
+// checkConstraintChanged compares CHECK constraint definitions.
+//
+// In practice, we cannot rely on a literal string compare here: PostgreSQL
+// rewrites the clause when it stores the constraint — adding outer parens,
+// inserting `::type` casts, converting `IN (...)` to `= ANY (ARRAY[...])`,
+// requalifying identifiers — so `pg_get_constraintdef` / `check_clause`
+// never round-trips byte-equal to what the user wrote in `check=`. Doing
+// the naive compare would mark every CHECK as drifted on the very next
+// run, producing a perpetual drop+add loop (see issue #112 discussion).
+//
+// For v1 the contract is "spelling-equivalence + a stable generated name
+// is enough as long as users don't author the same CHECK two different
+// ways" (verbatim from the issue body). Trusting the constraint name
+// gives us:
+//   - Adding `check=` → ConstraintsAdded (name not in DB).
+//   - Removing `check=` → ConstraintsRemoved (name not in generated).
+//   - Renaming via `check_name=` → drop + add (different name).
+//   - Idempotency after apply → no diff (same name).
+//
+// The known limitation is that changing only the expression while keeping
+// the constraint name will not trigger a migration. Users who need that
+// today should change `check_name=` alongside the expression; an
+// expression-normalization pass (and possibly AST-level compare) is a
+// follow-up tracked against future work.
+func checkConstraintChanged(_ goschema.Constraint, _ types.DBConstraint) bool {
+	return false
 }
 
 // uniqueConstraintChanged compares UNIQUE constraint definitions

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -953,12 +953,13 @@ func excludeConstraintChanged(genConstraint goschema.Constraint, dbConstraint ty
 // checkConstraintChanged compares CHECK constraint definitions.
 //
 // In practice, we cannot rely on a literal string compare here: PostgreSQL
-// rewrites the clause when it stores the constraint — adding outer parens,
-// inserting `::type` casts, converting `IN (...)` to `= ANY (ARRAY[...])`,
-// requalifying identifiers — so `pg_get_constraintdef` / `check_clause`
-// never round-trips byte-equal to what the user wrote in `check=`. Doing
-// the naive compare would mark every CHECK as drifted on the very next
-// run, producing a perpetual drop+add loop (see issue #112 discussion).
+// stores the parsed/analyzed node tree (`pg_constraint.conbin`) and
+// `information_schema.check_constraints.check_clause` is `pg_get_expr`
+// decompiling it — which normalizes parens, injects `::type` casts, and
+// rewrites `IN (...)` to `= ANY (ARRAY[...])`. So `check_clause` never
+// round-trips byte-equal to what the user wrote in `check=`. Doing the
+// naive compare would mark every CHECK as drifted on the very next run,
+// producing a perpetual drop+add loop (see issue #112 discussion).
 //
 // For v1 the contract is "spelling-equivalence + a stable generated name
 // is enough as long as users don't author the same CHECK two different
@@ -1112,6 +1113,11 @@ func hasNonNullableFieldInTable(tableName string, generated *goschema.Database) 
 // those CHECKs ship inline as part of CREATE TABLE / ALTER TABLE ADD COLUMN,
 // and emitting an ADD CONSTRAINT alongside would attempt to create the same
 // constraint twice in the same migration.
+//
+// Precedence: an explicit table-level constraint declared via
+// `//migrator:schema:constraint` that happens to share the synthesized
+// name wins — synthesis never clobbers it. See the guard in
+// Constraints() where genConstraints is populated.
 func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database *types.DBSchema) []goschema.Constraint {
 	if generated == nil || database == nil {
 		return nil

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -512,7 +512,15 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 			expected: &difftypes.SchemaDiff{},
 		},
 		{
-			name: "field-level CHECK expression changed → drop + add",
+			// v1 trade-off documented on checkConstraintChanged: an
+			// expression-only change with the same constraint name does
+			// NOT trigger a migration, because PostgreSQL normalizes the
+			// stored clause (parens / casts / `IN (...)` → `= ANY
+			// (ARRAY[...])`) and a literal string compare would otherwise
+			// produce a permanent drift loop on every run. Users who need
+			// to force a regen should change `check_name=` alongside the
+			// expression — covered by the next case below.
+			name: "field-level CHECK expression-only change is intentionally not surfaced (v1)",
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
 				Fields: []goschema.Field{
@@ -535,8 +543,39 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 					},
 				},
 			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// Renaming the constraint via `check_name=` while keeping the
+			// expression IS observable: the diff drops the old-named DB
+			// constraint and adds the renamed synthesized one. This is
+			// the documented escape hatch for forcing an expression change.
+			name: "field-level CHECK rename via check_name → drop + add",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "category",
+						Type:       "TEXT",
+						Check:      "category IN ('a','b','c')",
+						CheckName:  "files_category_v2",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "files_category_check",
+						TableName:   "files",
+						Type:        "CHECK",
+						CheckClause: stringPtr("category IN ('a','b')"),
+					},
+				},
+			},
 			expected: &difftypes.SchemaDiff{
-				ConstraintsAdded:   []string{"files_category_check"},
+				ConstraintsAdded:   []string{"files_category_v2"},
 				ConstraintsRemoved: []string{"files_category_check"},
 			},
 		},

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -486,7 +486,15 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "field-level CHECK matches existing — no diff (idempotency)",
+			// Realistic introspection shape: PostgreSQL stores the clause
+			// as the parser/rewriter produced it, NOT as the user wrote
+			// it. The user authored `category IN ('a','b')`; what comes
+			// back is roughly `((category)::text = ANY ((ARRAY['a'::text,
+			// 'b'::text])::text[]))`. The diff must STILL be empty —
+			// that's the whole point of the trust-name v1 contract. If a
+			// future regression reintroduces an expression compare here,
+			// this case will start failing.
+			name: "field-level CHECK matches existing — no diff (idempotency, Postgres-normalized clause)",
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
 				Fields: []goschema.Field{
@@ -505,7 +513,7 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 						Name:        "files_category_check",
 						TableName:   "files",
 						Type:        "CHECK",
-						CheckClause: stringPtr("category IN ('a','b')"),
+						CheckClause: stringPtr("((category)::text = ANY ((ARRAY['a'::text, 'b'::text])::text[]))"),
 					},
 				},
 			},

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -446,3 +446,202 @@ func TestConstraints_ExcludeConstraintComparison(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+// TestConstraints_FieldLevelCheck covers issue #112 — column-level `check=`
+// annotations need to participate in drift detection. The compare layer
+// synthesizes goschema.Constraint entries from field.Check for columns that
+// already exist in the introspected database, so add/remove/modify all run
+// through the standard Constraints() diff path.
+func TestConstraints_FieldLevelCheck(t *testing.T) {
+	// Shared setup: a "files" table with one existing column "category".
+	filesTable := types.DBTable{
+		Name:    "files",
+		Columns: []types.DBColumn{{Name: "category"}},
+	}
+
+	tests := []struct {
+		name      string
+		generated *goschema.Database
+		database  *types.DBSchema
+		expected  *difftypes.SchemaDiff
+	}{
+		{
+			name: "field-level CHECK added on existing column",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "category",
+						Type:       "TEXT",
+						Check:      "category IN ('a','b')",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded: []string{"files_category_check"},
+			},
+		},
+		{
+			name: "field-level CHECK matches existing — no diff (idempotency)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "category",
+						Type:       "TEXT",
+						Check:      "category IN ('a','b')",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "files_category_check",
+						TableName:   "files",
+						Type:        "CHECK",
+						CheckClause: stringPtr("category IN ('a','b')"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			name: "field-level CHECK expression changed → drop + add",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "category",
+						Type:       "TEXT",
+						Check:      "category IN ('a','b','c')",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "files_category_check",
+						TableName:   "files",
+						Type:        "CHECK",
+						CheckClause: stringPtr("category IN ('a','b')"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"files_category_check"},
+				ConstraintsRemoved: []string{"files_category_check"},
+			},
+		},
+		{
+			name: "field-level CHECK removed from annotation → drop existing",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{StructName: "File", Name: "category", Type: "TEXT"},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "files_category_check",
+						TableName:   "files",
+						Type:        "CHECK",
+						CheckClause: stringPtr("category IN ('a','b')"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsRemoved: []string{"files_category_check"},
+			},
+		},
+		{
+			name: "explicit check_name overrides deterministic name",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "category",
+						Type:       "TEXT",
+						Check:      "category IN ('a','b')",
+						CheckName:  "files_category_valid",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded: []string{"files_category_valid"},
+			},
+		},
+		{
+			name: "field-level CHECK on column not yet in DB → no synthesized constraint (handled inline by CREATE/ADD COLUMN)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{
+						StructName: "File",
+						Name:       "new_column",
+						Type:       "TEXT",
+						Check:      "new_column IN ('x','y')",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			name: "NOT NULL CHECK (internal Postgres representation) is not touched by field-level CHECK synthesis",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+				Fields: []goschema.Field{
+					{StructName: "File", Name: "category", Type: "TEXT", Nullable: false},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{filesTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:      "2200_files_category_not_null",
+						TableName: "files",
+						Type:      "CHECK",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &difftypes.SchemaDiff{}
+			compare.Constraints(tt.generated, tt.database, diff)
+
+			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
+				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))
+			for _, expected := range tt.expected.ConstraintsAdded {
+				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
+			}
+
+			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved),
+				qt.Commentf("ConstraintsRemoved=%v", diff.ConstraintsRemoved))
+			for _, expected := range tt.expected.ConstraintsRemoved {
+				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #112.

## Summary

Adds a column-level `check=` (and optional `check_name=`) attribute to `//migrator:schema:field` annotations, with drift detection plumbed through the existing constraint-comparison machinery.

```go
//migrator:schema:field name="category" type="TEXT" not_null="true" default="other" check="category IN ('photos','invoices','documents','other')"
Category string

//migrator:schema:field name="type" type="TEXT" not_null="true" check="type IN ('image','document','video','audio','archive','other')" check_name="files_type_valid"
Type string
```

Generates (PostgreSQL):

```sql
category TEXT NOT NULL DEFAULT 'other' CHECK (category IN ('photos','invoices','documents','other'))
type TEXT NOT NULL CONSTRAINT files_type_valid CHECK (type IN ('image','document','video','audio','archive','other'))
```

## Drift-detection contract (v1)

| Operation | Behavior |
| --- | --- |
| Adding `check=` to a field on an existing column | `ALTER TABLE … ADD CONSTRAINT <name> CHECK (…)` |
| Removing `check=` | `ALTER TABLE … DROP CONSTRAINT <name>` |
| Renaming via `check_name=` | drop old + add new |
| Re-apply with no annotation changes | no diff (idempotency) |
| Expression-only change (same name) | **not surfaced — by design for v1** |

The expression-only-change limitation is the explicit v1 trade-off from the issue body: *"spelling-equivalence + a stable generated name might be enough as long as users don't author the same CHECK two different ways"*. The reason a literal-text compare cannot work today is that PostgreSQL stores the parsed/analyzed node tree and `information_schema.check_constraints.check_clause` is `pg_get_expr` decompiling it — so a user-written `category IN ('a','b')` round-trips as `((category)::text = ANY ((ARRAY['a'::text, 'b'::text])::text[]))`. A naive compare would produce a perpetual drop+add loop on every migration. The documented escape hatch is to bump `check_name=` alongside the expression. A full expression-normalizer / AST-level compare is queued as a follow-up.

## How it works

The compare layer synthesizes a table-level `goschema.Constraint` entry per field with `check=` set, keyed by either `check_name=` or the deterministic `<table>_<column>_check` name (which is also PostgreSQL's own auto-naming convention for unnamed inline column CHECKs — so the synthesized name lines up with what introspection returns).

Synthesis only fires for columns that **already exist** in the introspected database; new tables and new columns get their CHECK inline via `CREATE TABLE` / `ALTER TABLE ADD COLUMN`, and double-emitting an `ADD CONSTRAINT` would fail at apply time because the constraint is created in the same migration step.

## What's reused from master

- Parser whitelist + `Field.Check` (landed earlier for table-level CHECKs via `//migrator:schema:constraint`)
- AST `ColumnNode.Check` + `SetCheck`
- Postgres / MySQL / MariaDB renderer column-scope `CHECK (...)` emission
- DB introspection reading `information_schema.check_constraints.check_clause`
- Planner's `addNewConstraints` / `removeConstraints` paths

## What this PR adds

- `check_name=` attribute on the parser whitelist + `Field.CheckName`
- `ColumnNode.CheckName` + `SetCheckName` on the AST
- Named `CONSTRAINT <name> CHECK (...)` rendering on Postgres + MySQL/MariaDB when `check_name=` is set
- Platform-override key `check_name` mirroring the existing `check` platform override
- `synthesizeFieldLevelCheckConstraints` in `migration/schemadiff/internal/compare/compare.go`
- **Replaced** `checkConstraintChanged` literal-string compare with name-trusting v1 contract (also fixes a pre-existing latent drift-loop on table-level CHECKs from `//migrator:schema:constraint`)
- Removed the special-case in `isFieldLevelConstraint` that hid DB CHECK constraints when a field had a non-empty `Check` (that filter masked the drift-loop and silently dropped expression changes)
- Round-trip via `toschema.ToField`, guarded so `CheckName` only surfaces when `Check` is also non-empty

## Dialect notes

- **PostgreSQL**: Full drift detection works without `check_name=` because PG's auto-naming `<table>_<column>_check` matches the synthesized name.
- **MySQL/MariaDB**: Without `check_name=`, MySQL/MariaDB auto-name unnamed CHECKs as `<table>_chk_N`. On the *first* drift run after upgrading to this version, users will see a one-time normalization migration that renames the constraint to `<table>_<column>_check`; subsequent runs are stable. To avoid the one-time churn, declare `check_name=` explicitly. (`dbschema/mysql/reader.go` doesn't yet load `INFORMATION_SCHEMA.CHECK_CONSTRAINTS.CHECK_CLAUSE` — tracked as a follow-up; not required for v1 because the diff trusts the constraint name rather than the clause.)

## Tests

- `core/goschema/parser_test.go::TestParseField_CheckConstraint` — parser accepts both `check=` and `check_name=`
- `core/renderer/dialects/postgres/check_constraint_test.go` — inline and named forms render correctly
- `migration/schemadiff/internal/compare/constraints_test.go::TestConstraints_FieldLevelCheck` covers:
  - new CHECK on existing column → ADD
  - matching CHECK (with a realistic Postgres-normalized clause like `((category)::text = ANY ((ARRAY['a'::text, 'b'::text])::text[]))`) → no diff. This is the regression net: anyone who reintroduces an expression compare will fail this case.
  - expression-only change with same name → not surfaced (v1 contract)
  - rename via `check_name=` → drop + add
  - removed annotation → DROP
  - explicit `check_name=` overrides deterministic naming
  - new column (not yet in DB) → no synthesized constraint
  - Postgres NOT NULL CHECK pattern is untouched

`go test ./...` + `golangci-lint run ./...` green.

## Self-review

Reviewed by `generic-code-reviewer` agent twice:
- Iteration 1 raised two BLOCKING issues (literal-string compare → drift loop; toschema CheckName not guarded). Both fixed.
- Iteration 2: no blockers, no HIGH. Two LOW doc improvements applied. One pre-existing bug noted (embedded inline fields with `prefix=` don't rewrite identifiers inside `check=` expressions — out of scope, queued for follow-up).

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` green
- [x] CI workflows green on this branch (unit, integration, lint, version consistency)
- [ ] End-to-end validation against the inventario `files.type` / `files.category` use case from the issue (downstream)