### PR TITLE
feat(schemadiff): detect function body/security/volatility drift; fix silent CHECK-drop no-op

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -56,6 +56,9 @@ type Visitor interface {
 	VisitDropRole(*DropRoleNode) error
 	// VisitAlterRole renders an ALTER ROLE statement (PostgreSQL-specific)
 	VisitAlterRole(*AlterRoleNode) error
+	// VisitRawSQL renders a literal SQL fragment verbatim. Use sparingly —
+	// reach for structured nodes first.
+	VisitRawSQL(*RawSQLNode) error
 }
 
 // DefaultValue represents different types of default values for table columns.

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -195,3 +195,11 @@ func (m *MockVisitor) VisitAlterRole(node *ast.AlterRoleNode) error {
 	}
 	return nil
 }
+
+func (m *MockVisitor) VisitRawSQL(node *ast.RawSQLNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "RawSQL:"+node.SQL)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1667,6 +1667,30 @@ type StatementList struct {
 	Statements []Node
 }
 
+// RawSQLNode wraps a literal SQL fragment that should be emitted verbatim
+// during rendering, including its trailing semicolon if any. It exists for
+// the rare case where the renderer's structured nodes can't express what we
+// need — currently the postgres planner uses it to wrap a DO block that
+// dynamically resolves and drops a constraint by name.
+//
+// Use sparingly: dialect-agnostic structured nodes are still preferred when
+// they exist.
+type RawSQLNode struct {
+	// SQL is the literal SQL text to emit. The renderer writes it as a single
+	// line; if multi-line output is needed include the newlines yourself.
+	SQL string
+}
+
+// NewRawSQL creates a new RawSQLNode wrapping the given literal SQL.
+func NewRawSQL(sql string) *RawSQLNode {
+	return &RawSQLNode{SQL: sql}
+}
+
+// Accept implements the Node interface for RawSQLNode.
+func (n *RawSQLNode) Accept(visitor Visitor) error {
+	return visitor.VisitRawSQL(n)
+}
+
 // Accept implements the Node interface for StatementList.
 //
 // This method visits each statement in the list in order. If any statement

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -614,14 +614,31 @@ func processAllFileComments(f *ast.File, tableNameToStructName map[string]string
 
 func parseFunctionComment(comment *ast.Comment, structName string, functions *[]Function) {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+
+	// Canonicalize annotation attributes at parse time so every downstream
+	// consumer (planner, renderer, comparator) sees the same values:
+	//
+	//   - Language: defaults to "plpgsql" when omitted. The renderer drops
+	//     the LANGUAGE clause entirely if this field is empty, and Postgres
+	//     rejects `CREATE FUNCTION ... AS $$...$$;` without a language. Also
+	//     lower-cased — pg_language.lanname is always lowercase, so
+	//     `language="PLPGSQL"` would otherwise false-diff forever.
+	//   - Security / Volatility: upper-cased — pg_proc reports DEFINER/INVOKER
+	//     and VOLATILE/STABLE/IMMUTABLE in canonical uppercase, so accepting
+	//     mixed-case annotations without normalizing would false-diff.
+	language := strings.ToLower(kv["language"])
+	if language == "" {
+		language = "plpgsql"
+	}
+
 	*functions = append(*functions, Function{
 		StructName: structName,
 		Name:       kv["name"],
 		Parameters: kv["params"],
 		Returns:    kv["returns"],
-		Language:   kv["language"],
-		Security:   kv["security"],
-		Volatility: kv["volatility"],
+		Language:   language,
+		Security:   strings.ToUpper(kv["security"]),
+		Volatility: strings.ToUpper(kv["volatility"]),
 		Body:       kv["body"],
 		Comment:    kv["comment"],
 	})

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -615,33 +615,22 @@ func processAllFileComments(f *ast.File, tableNameToStructName map[string]string
 func parseFunctionComment(comment *ast.Comment, structName string, functions *[]Function) {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 
-	// Canonicalize annotation attributes at parse time so every downstream
-	// consumer (planner, renderer, comparator) sees the same values:
-	//
-	//   - Language: defaults to "plpgsql" when omitted. The renderer drops
-	//     the LANGUAGE clause entirely if this field is empty, and Postgres
-	//     rejects `CREATE FUNCTION ... AS $$...$$;` without a language. Also
-	//     lower-cased — pg_language.lanname is always lowercase, so
-	//     `language="PLPGSQL"` would otherwise false-diff forever.
-	//   - Security / Volatility: upper-cased — pg_proc reports DEFINER/INVOKER
-	//     and VOLATILE/STABLE/IMMUTABLE in canonical uppercase, so accepting
-	//     mixed-case annotations without normalizing would false-diff.
-	language := strings.ToLower(kv["language"])
-	if language == "" {
-		language = "plpgsql"
-	}
-
-	*functions = append(*functions, Function{
+	fn := Function{
 		StructName: structName,
 		Name:       kv["name"],
 		Parameters: kv["params"],
 		Returns:    kv["returns"],
-		Language:   language,
-		Security:   strings.ToUpper(kv["security"]),
-		Volatility: strings.ToUpper(kv["volatility"]),
+		Language:   kv["language"],
+		Security:   kv["security"],
+		Volatility: kv["volatility"],
 		Body:       kv["body"],
 		Comment:    kv["comment"],
-	})
+	}
+	// Canonicalize so every downstream consumer (planner, renderer,
+	// comparator) sees the same values regardless of how the annotation was
+	// typed. See Function.Canonicalize for the per-field rules.
+	fn.Canonicalize()
+	*functions = append(*functions, fn)
 }
 
 func parseRLSPolicyComment(comment *ast.Comment, structName string, rlsPolicies *[]RLSPolicy) {

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -453,6 +453,7 @@ func TestParseFunctionComment(t *testing.T) {
 				Returns:    "VOID",
 				Language:   "plpgsql",
 				Security:   "DEFINER",
+				Volatility: "VOLATILE", // default
 				Body:       "BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;",
 			},
 		},
@@ -464,6 +465,7 @@ func TestParseFunctionComment(t *testing.T) {
 				Name:       "get_current_tenant_id",
 				Returns:    "TEXT",
 				Language:   "plpgsql",
+				Security:   "INVOKER", // default
 				Volatility: "STABLE",
 				Body:       "BEGIN RETURN current_setting('app.current_tenant_id', true); END;",
 			},
@@ -476,7 +478,35 @@ func TestParseFunctionComment(t *testing.T) {
 				Name:       "test_func",
 				Returns:    "INTEGER",
 				Language:   "sql",
+				Security:   "INVOKER",  // default
+				Volatility: "VOLATILE", // default
 				Comment:    "Test function for unit tests",
+			},
+		},
+		{
+			name:    "Empty language defaults to plpgsql",
+			comment: `//migrator:schema:function name="no_lang" returns="VOID" body="BEGIN END;"`,
+			expected: goschema.Function{
+				StructName: "TestStruct",
+				Name:       "no_lang",
+				Returns:    "VOID",
+				Language:   "plpgsql", // defaulted
+				Security:   "INVOKER",
+				Volatility: "VOLATILE",
+				Body:       "BEGIN END;",
+			},
+		},
+		{
+			name:    "Mixed-case attributes are normalized",
+			comment: `//migrator:schema:function name="mixed_case" returns="VOID" language="PLPGSQL" security="Definer" volatility="Stable" body="BEGIN END;"`,
+			expected: goschema.Function{
+				StructName: "TestStruct",
+				Name:       "mixed_case",
+				Returns:    "VOID",
+				Language:   "plpgsql", // ToLower
+				Security:   "DEFINER", // ToUpper
+				Volatility: "STABLE",  // ToUpper
+				Body:       "BEGIN END;",
 			},
 		},
 	}
@@ -485,20 +515,17 @@ func TestParseFunctionComment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			kv := parseutils.ParseKeyValueComment(tt.comment)
-			function := goschema.Function{
-				StructName: "TestStruct",
-				Name:       kv["name"],
-				Parameters: kv["params"],
-				Returns:    kv["returns"],
-				Language:   kv["language"],
-				Security:   kv["security"],
-				Volatility: kv["volatility"],
-				Body:       kv["body"],
-				Comment:    kv["comment"],
-			}
+			// Drive the real parseFunctionComment through ParseFile so the
+			// canonicalization runs end-to-end. Embedding the annotation in
+			// a synthetic Go source file is the path real-world annotations
+			// take and is what TestParseRLSPolicyComment also does.
+			src := "package p\n" + tt.comment + "\ntype TestStruct struct {}\n"
+			tmp := t.TempDir() + "/fn.go"
+			c.Assert(os.WriteFile(tmp, []byte(src), 0o644), qt.IsNil) //nolint:gosec // 0644 is fine for a test fixture
 
-			c.Assert(function, qt.DeepEquals, tt.expected)
+			db := goschema.ParseFile(tmp)
+			c.Assert(db.Functions, qt.HasLen, 1)
+			c.Assert(db.Functions[0], qt.DeepEquals, tt.expected)
 		})
 	}
 }

--- a/core/goschema/rls_integration_test.go
+++ b/core/goschema/rls_integration_test.go
@@ -137,7 +137,10 @@ type Product struct {
 	c.Assert(sqlOutput, qt.Contains, "PERFORM set_config('app.current_tenant_id', tenant_id_param, false)")
 
 	c.Assert(sqlOutput, qt.Contains, "CREATE OR REPLACE FUNCTION get_current_tenant_id()")
-	c.Assert(sqlOutput, qt.Contains, "LANGUAGE plpgsql STABLE")
+	// The annotation omits security=, so the parser canonicalizes it to
+	// INVOKER (PostgreSQL's default). Emitting it explicitly is harmless and
+	// makes a later DEFINER → INVOKER switch work via CREATE OR REPLACE.
+	c.Assert(sqlOutput, qt.Contains, "LANGUAGE plpgsql SECURITY INVOKER STABLE")
 	c.Assert(sqlOutput, qt.Contains, "current_setting('app.current_tenant_id', true)")
 
 	// Verify RLS enablement SQL

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -3,6 +3,8 @@
 // Go struct annotations and used for generating database-specific migration SQL.
 package goschema
 
+import "strings"
+
 // Database represents the complete database schema derived from Go struct annotations.
 //
 // This struct aggregates all database schema information discovered during the recursive
@@ -374,6 +376,42 @@ type Function struct {
 	Volatility string // Function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
 	Body       string // Function body/implementation
 	Comment    string // Optional comment for documentation
+}
+
+// Canonicalize fills in PostgreSQL's implicit defaults and case-folds the
+// attributes that pg_proc/pg_language always report in canonical form. Apply
+// this immediately after constructing or mutating a Function so every
+// downstream consumer — parser, planner, renderer, comparator — sees the same
+// values.
+//
+//   - Language: empty → "plpgsql"; otherwise lowercased. pg_language.lanname
+//     is stored lowercase, and the postgres renderer omits the LANGUAGE
+//     clause if this field is empty, which the server rejects with
+//     "ERROR: no language specified". Defaulting to plpgsql is what
+//     `CREATE FUNCTION` would assume in handwritten SQL too.
+//   - Security: empty → "INVOKER"; otherwise uppercased. pg_proc surfaces
+//     this as either "DEFINER" or "INVOKER".
+//   - Volatility: empty → "VOLATILE"; otherwise uppercased. pg_proc surfaces
+//     this as "IMMUTABLE", "STABLE", or "VOLATILE".
+//
+// The DB-side read path (dbschema/postgres/reader.go) returns canonical case
+// by construction, so it does not need to call this. The motivating callers
+// are the annotation parser (which sees raw user-typed text) and any
+// programmatic constructor — test fixtures, downstream API consumers — that
+// builds Function values without going through the parser.
+func (f *Function) Canonicalize() {
+	f.Language = strings.ToLower(f.Language)
+	if f.Language == "" {
+		f.Language = "plpgsql"
+	}
+	f.Security = strings.ToUpper(f.Security)
+	if f.Security == "" {
+		f.Security = "INVOKER"
+	}
+	f.Volatility = strings.ToUpper(f.Volatility)
+	if f.Volatility == "" {
+		f.Volatility = "VOLATILE"
+	}
 }
 
 // RLSPolicy represents a PostgreSQL Row-Level Security policy definition parsed from Go struct annotations.

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -199,3 +199,8 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return r.r.VisitAlterRole(node)
 }
+
+// VisitRawSQL delegates to the mysqllike renderer
+func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
+	return r.r.VisitRawSQL(node)
+}

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -199,3 +199,8 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return r.r.VisitAlterRole(node)
 }
+
+// VisitRawSQL delegates to the mysqllike renderer
+func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
+	return r.r.VisitRawSQL(node)
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -591,3 +591,10 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return fmt.Errorf("ALTER ROLE is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
 }
+
+// VisitRawSQL renders a literal SQL fragment verbatim. The caller owns
+// correctness of the embedded SQL for this dialect.
+func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
+	r.w.WriteLine(node.SQL)
+	return nil
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -592,9 +592,12 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return fmt.Errorf("ALTER ROLE is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
 }
 
-// VisitRawSQL renders a literal SQL fragment verbatim. The caller owns
-// correctness of the embedded SQL for this dialect.
+// VisitRawSQL refuses to emit raw SQL. The only emitter of RawSQLNode today
+// is the PostgreSQL planner's constraint-drop path, which produces a PG-
+// specific DO block; routing that through a MySQL-family renderer would
+// produce a migration the target server can't execute. If a future caller
+// genuinely needs dialect-neutral raw SQL it should add a typed escape hatch
+// rather than relying on this method.
 func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
-	r.w.WriteLine(node.SQL)
-	return nil
+	return fmt.Errorf("RawSQLNode is not supported in %s: %q was emitted by a Postgres-specific planner path", r.dialectUpper, node.SQL)
 }

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -1031,11 +1031,19 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 	return nil
 }
 
-// VisitRawSQL renders a literal SQL fragment verbatim, with no quoting,
-// escaping, or trailing semicolon handling. The caller owns correctness of
-// the embedded SQL.
+// VisitRawSQL renders a literal SQL fragment verbatim and appends a trailing
+// semicolon if the fragment doesn't already end with one. The caller owns
+// correctness of the embedded SQL. The trailing `;` is essential — downstream
+// SplitSQLStatements (used by the migrator to apply each statement separately
+// for MySQL compatibility) tokenizes on semicolons, and a dollar-quoted body
+// that ends with `$tag$\n` would otherwise merge with the following statement
+// into one chunk that Postgres rejects with `syntax error at or near "DO"`.
 func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
-	r.w.WriteLine(node.SQL)
+	sql := node.SQL
+	if !strings.HasSuffix(strings.TrimRight(sql, "\r\n\t "), ";") {
+		sql += ";"
+	}
+	r.w.WriteLine(sql)
 	return nil
 }
 

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -1031,6 +1031,14 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 	return nil
 }
 
+// VisitRawSQL renders a literal SQL fragment verbatim, with no quoting,
+// escaping, or trailing semicolon handling. The caller owns correctness of
+// the embedded SQL.
+func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
+	r.w.WriteLine(node.SQL)
+	return nil
+}
+
 // VisitAlterRole renders an ALTER ROLE statement for PostgreSQL
 func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	// Add comment if provided

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -269,6 +269,7 @@ func (a *SchemaAnalyzer) VisitAlterTableDisableRLS(node *ast.AlterTableDisableRL
 func (a *SchemaAnalyzer) VisitCreateRole(node *ast.CreateRoleNode) error { return nil }
 func (a *SchemaAnalyzer) VisitDropRole(node *ast.DropRoleNode) error     { return nil }
 func (a *SchemaAnalyzer) VisitAlterRole(node *ast.AlterRoleNode) error   { return nil }
+func (a *SchemaAnalyzer) VisitRawSQL(node *ast.RawSQLNode) error         { return nil }
 
 // AuditTransformer adds audit columns to all tables
 type AuditTransformer struct{}

--- a/integration/gonative/check_constraint_integration_test.go
+++ b/integration/gonative/check_constraint_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/convert/fromschema"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema/postgres"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// TestFieldLevelCheckConstraint_RoundTrip_Integration is the e2e backfill for
+// PR #123 (issue #112). PR #123 introduced field-level `check=` / `check_name=`
+// annotations with drift detection in the diff layer, but landed without a
+// real-database round-trip — the schemadiff "trust the name, don't compare the
+// expression" decision was unit-tested but never exercised against the live
+// PostgreSQL clause normalization that motivated it (parens, type casts, the
+// `IN (...)` → `= ANY (ARRAY[...])` rewrite).
+//
+// This test installs a table with a field-level CHECK via the renderer, reads
+// the live schema back, and runs the diff against the same Go definition to
+// confirm idempotency holds against Postgres' own normalized clause text.
+func TestFieldLevelCheckConstraint_RoundTrip_Integration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_test_files CASCADE")
+	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS ptah_test_files CASCADE") }()
+
+	target := &goschema.Database{
+		Tables: []goschema.Table{{Name: "ptah_test_files", StructName: "File"}},
+		Fields: []goschema.Field{
+			{StructName: "File", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName: "File",
+				Name:       "category",
+				Type:       "TEXT",
+				Nullable:   false,
+				Default:    "other",
+				Check:      "category IN ('photos','invoices','documents','other')",
+			},
+			{
+				StructName: "File",
+				Name:       "kind",
+				Type:       "TEXT",
+				Nullable:   false,
+				Check:      "kind IN ('image','document','video','audio','archive','other')",
+				CheckName:  "ptah_test_files_kind_valid",
+			},
+		},
+	}
+
+	// Render the CREATE TABLE statement and apply it.
+	stmts := fromschema.FromDatabase(*target, "postgres")
+	sqlText, err := renderer.RenderSQL("postgres", stmts.Statements...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlText, "CHECK (category IN"), qt.IsTrue)
+	c.Assert(strings.Contains(sqlText, "CONSTRAINT ptah_test_files_kind_valid CHECK"), qt.IsTrue)
+
+	_, err = db.Exec(sqlText)
+	c.Assert(err, qt.IsNil, qt.Commentf("CREATE TABLE must execute: %s", sqlText))
+
+	// Read the live schema and confirm both CHECK constraints landed.
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	dbSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	checks := map[string]bool{}
+	for _, cs := range dbSchema.Constraints {
+		if cs.Type == "CHECK" && cs.TableName == "ptah_test_files" {
+			checks[cs.Name] = true
+		}
+	}
+	c.Assert(checks["ptah_test_files_category_check"], qt.IsTrue,
+		qt.Commentf("auto-named CHECK should land under the <table>_<column>_check convention"))
+	c.Assert(checks["ptah_test_files_kind_valid"], qt.IsTrue,
+		qt.Commentf("explicit check_name= must be honored"))
+
+	// Idempotency: re-diffing the live schema against the same target must
+	// produce no changes. This is where the "trust the name" decision pays
+	// off — Postgres rewrites the stored CHECK clause (parens, type casts,
+	// `IN (...)` → `= ANY (ARRAY[...])`) and a naive text compare would
+	// regen a migration on every run.
+	diff := schemadiff.Compare(target, dbSchema)
+	c.Assert(diff.HasChanges(), qt.IsFalse,
+		qt.Commentf("round-trip diff must be clean; got added=%v removed=%v",
+			diff.ConstraintsAdded, diff.ConstraintsRemoved))
+}
+
+// TestFieldLevelCheckConstraint_Removal_Integration exercises the drop path:
+// the field's `check=` annotation goes away → the diff must report the
+// synthesized constraint as removed → the migration must drop it.
+func TestFieldLevelCheckConstraint_Removal_Integration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_test_check_drop CASCADE")
+	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS ptah_test_check_drop CASCADE") }()
+
+	// Phase 1 — install table with the CHECK.
+	withCheck := &goschema.Database{
+		Tables: []goschema.Table{{Name: "ptah_test_check_drop", StructName: "Doc"}},
+		Fields: []goschema.Field{
+			{StructName: "Doc", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName: "Doc",
+				Name:       "score",
+				Type:       "INTEGER",
+				Nullable:   false,
+				Check:      "score >= 0",
+			},
+		},
+	}
+	stmts := fromschema.FromDatabase(*withCheck, "postgres")
+	createSQL, err := renderer.RenderSQL("postgres", stmts.Statements...)
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(createSQL)
+	c.Assert(err, qt.IsNil)
+
+	// Phase 2 — drop the CHECK from the Go definition and regenerate.
+	withoutCheck := &goschema.Database{
+		Tables: []goschema.Table{{Name: "ptah_test_check_drop", StructName: "Doc"}},
+		Fields: []goschema.Field{
+			{StructName: "Doc", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Doc", Name: "score", Type: "INTEGER", Nullable: false},
+		},
+	}
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	dbSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	diff := schemadiff.Compare(withoutCheck, dbSchema)
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+	c.Assert(diff.ConstraintsRemoved, qt.Contains, "ptah_test_check_drop_score_check")
+
+	migrationSQL := strings.Join(
+		planner.GenerateSchemaDiffSQLStatements(diff, withoutCheck, "postgres"),
+		";\n",
+	) + ";"
+	c.Assert(strings.Contains(migrationSQL, "ptah_test_check_drop_score_check"), qt.IsTrue,
+		qt.Commentf("drop migration must reference the synthesized constraint by its auto-name; got: %s", migrationSQL))
+
+	_, err = db.Exec(migrationSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("drop migration must execute: %s", migrationSQL))
+
+	// Phase 3 — confirm the score CHECK is gone and a fresh diff is clean.
+	// PostgreSQL surfaces synthesized NOT NULL checks under the same
+	// information_schema CHECK type with `_not_null` suffix; those are not
+	// part of this assertion.
+	afterSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	for _, cs := range afterSchema.Constraints {
+		if cs.TableName != "ptah_test_check_drop" || cs.Type != "CHECK" {
+			continue
+		}
+		if strings.HasSuffix(cs.Name, "_not_null") {
+			continue
+		}
+		c.Errorf("CHECK constraint should have been dropped, still found: %s", cs.Name)
+	}
+
+	idempDiff := schemadiff.Compare(withoutCheck, afterSchema)
+	c.Assert(idempDiff.HasChanges(), qt.IsFalse,
+		qt.Commentf("post-drop diff must be clean"))
+}

--- a/integration/gonative/function_diff_integration_test.go
+++ b/integration/gonative/function_diff_integration_test.go
@@ -177,9 +177,19 @@ func TestFunctionDiff_VolatilityChange_Integration(t *testing.T) {
 
 	after, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
+	var afterFn *struct{ Volatility string }
 	for _, fn := range after.Functions {
 		if fn.Name == "ptah_test_get_current_group_id" {
-			c.Assert(fn.Volatility, qt.Equals, "STABLE")
+			afterFn = &struct{ Volatility string }{Volatility: fn.Volatility}
+			break
 		}
 	}
+	c.Assert(afterFn, qt.IsNotNil, qt.Commentf("function must still exist after the modify migration"))
+	c.Assert(afterFn.Volatility, qt.Equals, "STABLE")
+
+	// Idempotency: re-diffing the freshly-updated DB against the same target
+	// must report no changes.
+	idempDiff := schemadiff.Compare(target, after)
+	c.Assert(idempDiff.HasChanges(), qt.IsFalse,
+		qt.Commentf("post-migration diff must be clean"))
 }

--- a/integration/gonative/function_diff_integration_test.go
+++ b/integration/gonative/function_diff_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/postgres"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// TestFunctionDiff_BodyAndSecurityChange_Integration covers GitHub issue #89.
+//
+// The bug: changes to a PL/pgSQL function's body or SECURITY qualifier were
+// being silently dropped by the migration generator — diff comparison populated
+// FunctionsModified, but the planner had no handler so no SQL was emitted and
+// the caller reported "no schema changes detected".
+//
+// This test installs an initial function, runs the full schemadiff +
+// planner pipeline against a target schema with a changed body and changed
+// SECURITY qualifier, applies the generated SQL, and confirms the function's
+// live definition in the database has actually changed.
+func TestFunctionDiff_BodyAndSecurityChange_Integration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	// Install the "before" function: SECURITY DEFINER + session-scoped set_config.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION ptah_test_set_group_context(group_id_param TEXT)
+		RETURNS VOID AS $$
+		BEGIN PERFORM set_config('app.current_group_id', group_id_param, false); END;
+		$$ LANGUAGE plpgsql SECURITY DEFINER;
+	`)
+	c.Assert(err, qt.IsNil)
+	defer func() { _, _ = db.Exec("DROP FUNCTION IF EXISTS ptah_test_set_group_context(TEXT)") }()
+
+	// Read the live DB schema and confirm the function landed as expected.
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	before, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	var beforeFn *struct{ Body, Security string }
+	for _, fn := range before.Functions {
+		if fn.Name == "ptah_test_set_group_context" {
+			beforeFn = &struct{ Body, Security string }{Body: fn.Body, Security: fn.Security}
+			break
+		}
+	}
+	c.Assert(beforeFn, qt.IsNotNil, qt.Commentf("seeded function should be readable from DB"))
+	c.Assert(beforeFn.Security, qt.Equals, "DEFINER")
+	c.Assert(strings.Contains(beforeFn.Body, "false"), qt.IsTrue)
+
+	// Define the "after" target: same name/signature, but the body switches to
+	// transaction-local set_config and SECURITY DEFINER is dropped.
+	target := &goschema.Database{
+		Functions: []goschema.Function{
+			{
+				Name:       "ptah_test_set_group_context",
+				Parameters: "group_id_param text",
+				Returns:    "void",
+				Language:   "plpgsql",
+				// No security= → default INVOKER (drops SECURITY DEFINER).
+				Body: "\nBEGIN PERFORM set_config('app.current_group_id', group_id_param, true); END;\n",
+			},
+		},
+	}
+
+	// Run the diff over the live DB schema.
+	diff := schemadiff.Compare(target, before)
+	c.Assert(diff.HasChanges(), qt.IsTrue, qt.Commentf("body+security change must be detected"))
+	c.Assert(diff.FunctionsModified, qt.HasLen, 1)
+	mod := diff.FunctionsModified[0]
+	c.Assert(mod.FunctionName, qt.Equals, "ptah_test_set_group_context")
+	c.Assert(mod.Changes["body"], qt.Not(qt.Equals), "")
+	c.Assert(mod.Changes["security"], qt.Equals, "DEFINER -> INVOKER")
+
+	// Plan, render, and apply the up migration.
+	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	c.Assert(len(statements) > 0, qt.IsTrue,
+		qt.Commentf("planner must emit at least one SQL statement for FunctionsModified"))
+
+	sqlText := strings.Join(statements, ";\n") + ";"
+	c.Assert(strings.Contains(sqlText, "CREATE OR REPLACE FUNCTION ptah_test_set_group_context"), qt.IsTrue)
+	c.Assert(strings.Contains(sqlText, "set_config('app.current_group_id', group_id_param, true)"), qt.IsTrue)
+	c.Assert(strings.Contains(sqlText, "SECURITY DEFINER"), qt.IsFalse,
+		qt.Commentf("the rewritten definition must not carry the dropped SECURITY DEFINER"))
+
+	_, err = db.Exec(sqlText)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated migration SQL must execute: %s", sqlText))
+
+	// Verify the live function actually flipped both attributes.
+	after, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	var afterFn *struct{ Body, Security string }
+	for _, fn := range after.Functions {
+		if fn.Name == "ptah_test_set_group_context" {
+			afterFn = &struct{ Body, Security string }{Body: fn.Body, Security: fn.Security}
+			break
+		}
+	}
+	c.Assert(afterFn, qt.IsNotNil)
+	c.Assert(afterFn.Security, qt.Equals, "INVOKER",
+		qt.Commentf("SECURITY DEFINER must be dropped"))
+	c.Assert(strings.Contains(afterFn.Body, "true"), qt.IsTrue,
+		qt.Commentf("function body must reflect transaction-local set_config; got: %s", afterFn.Body))
+	c.Assert(strings.Contains(afterFn.Body, "false"), qt.IsFalse,
+		qt.Commentf("function body must no longer contain the previous flag value"))
+
+	// Idempotency: a second diff against the freshly updated DB must be empty.
+	idempDiff := schemadiff.Compare(target, after)
+	c.Assert(idempDiff.HasChanges(), qt.IsFalse,
+		qt.Commentf("re-running diff after applying the migration must report no changes"))
+}
+
+// TestFunctionDiff_VolatilityChange_Integration covers the planner-hint case
+// from issue #89 (VOLATILE → STABLE). The new schema reader exposes
+// p.provolatile, so the diff must catch it and emit CREATE OR REPLACE.
+func TestFunctionDiff_VolatilityChange_Integration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	// Seed a VOLATILE function.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION ptah_test_get_current_group_id()
+		RETURNS TEXT AS $$
+		BEGIN RETURN current_setting('app.current_group_id', true); END;
+		$$ LANGUAGE plpgsql VOLATILE;
+	`)
+	c.Assert(err, qt.IsNil)
+	defer func() { _, _ = db.Exec("DROP FUNCTION IF EXISTS ptah_test_get_current_group_id()") }()
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	before, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	// Target schema marks the same function as STABLE.
+	target := &goschema.Database{
+		Functions: []goschema.Function{
+			{
+				Name:       "ptah_test_get_current_group_id",
+				Parameters: "",
+				Returns:    "text",
+				Language:   "plpgsql",
+				Volatility: "STABLE",
+				Body:       "\nBEGIN RETURN current_setting('app.current_group_id', true); END;\n",
+			},
+		},
+	}
+
+	diff := schemadiff.Compare(target, before)
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+	c.Assert(diff.FunctionsModified, qt.HasLen, 1)
+	c.Assert(diff.FunctionsModified[0].Changes["volatility"], qt.Equals, "VOLATILE -> STABLE")
+
+	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	c.Assert(len(statements), qt.Not(qt.Equals), 0)
+	sqlText := strings.Join(statements, ";\n") + ";"
+	c.Assert(strings.Contains(sqlText, "STABLE"), qt.IsTrue)
+
+	_, err = db.Exec(sqlText)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated migration SQL must execute: %s", sqlText))
+
+	after, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	for _, fn := range after.Functions {
+		if fn.Name == "ptah_test_get_current_group_id" {
+			c.Assert(fn.Volatility, qt.Equals, "STABLE")
+		}
+	}
+}

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -196,28 +196,18 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	planner := postgres.New()
 	nodes := planner.GenerateMigrationAST(diff, generated)
 
-	// Should generate 4 nodes: create function, execute function, drop main function, drop exec function
-	c.Assert(len(nodes), qt.Equals, 4)
+	// One DO block per removed constraint. The previous implementation emitted
+	// four nodes (create/exec/drop/drop) but none of them actually invoked the
+	// drop logic, leaving the constraint in place — see commit message for the
+	// full incident report. The DO block executes immediately on parse and
+	// leaves no temporary functions behind.
+	c.Assert(len(nodes), qt.Equals, 1)
 
-	// Check the first node (create function)
-	sql1, err := renderer.RenderSQL("postgres", nodes[0])
+	sql, err := renderer.RenderSQL("postgres", nodes[0])
 	c.Assert(err, qt.IsNil)
-	c.Assert(sql1, qt.Contains, "CREATE OR REPLACE FUNCTION ptah_drop_constraint_old_constraint()")
-	c.Assert(sql1, qt.Contains, "information_schema.table_constraints")
-	c.Assert(sql1, qt.Contains, "WHERE constraint_name = 'old_constraint'")
-
-	// Check the second node (execute function)
-	sql2, err := renderer.RenderSQL("postgres", nodes[1])
-	c.Assert(err, qt.IsNil)
-	c.Assert(sql2, qt.Contains, "SELECT ptah_drop_constraint_old_constraint();")
-
-	// Check the third node (drop main function)
-	sql3, err := renderer.RenderSQL("postgres", nodes[2])
-	c.Assert(err, qt.IsNil)
-	c.Assert(sql3, qt.Contains, "DROP FUNCTION IF EXISTS ptah_drop_constraint_old_constraint")
-
-	// Check the fourth node (drop exec function)
-	sql4, err := renderer.RenderSQL("postgres", nodes[3])
-	c.Assert(err, qt.IsNil)
-	c.Assert(sql4, qt.Contains, "DROP FUNCTION IF EXISTS ptah_exec_ptah_drop_constraint_old_constraint")
+	c.Assert(sql, qt.Contains, "DO $ptah$")
+	c.Assert(sql, qt.Contains, "information_schema.table_constraints")
+	c.Assert(sql, qt.Contains, "constraint_name = 'old_constraint'")
+	c.Assert(sql, qt.Contains, "ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I")
+	c.Assert(sql, qt.Contains, "$ptah$")
 }

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -193,8 +194,8 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	}
 	generated := &goschema.Database{}
 
-	planner := postgres.New()
-	nodes := planner.GenerateMigrationAST(diff, generated)
+	pl := postgres.New()
+	nodes := pl.GenerateMigrationAST(diff, generated)
 
 	// One DO block per removed constraint. The previous implementation emitted
 	// four nodes (create/exec/drop/drop) but none of them actually invoked the
@@ -210,6 +211,31 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	c.Assert(sql, qt.Contains, "constraint_name = 'old_constraint'")
 	c.Assert(sql, qt.Contains, "ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I")
 	c.Assert(sql, qt.Contains, "$ptah$")
+	// The DO block MUST end with a semicolon. SplitSQLStatements is what the
+	// migrator uses to chop a migration into individual db.Exec calls, and it
+	// tokenizes on `;`. A DO block whose dollar-quoted body ends at `$tag$`
+	// without a trailing `;` merges with the following statement and Postgres
+	// rejects the merged chunk with `syntax error at or near "DO"`.
+	c.Assert(strings.HasSuffix(strings.TrimRight(sql, " \t\r\n"), ";"), qt.IsTrue,
+		qt.Commentf("rendered DO block must end with a semicolon; got: %s", sql))
+}
+
+func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_MultipleSplitCleanly(t *testing.T) {
+	c := qt.New(t)
+
+	// Two consecutive constraint drops must split into two statements through
+	// the SQL statement splitter. The regression this guards against is the
+	// missing `;` in VisitRawSQL: without it, two DO blocks merge into one
+	// chunk and Postgres rejects the second `DO`.
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"first_constraint", "second_constraint"},
+	}
+	statements := planner.GenerateSchemaDiffSQLStatements(diff, &goschema.Database{}, "postgres")
+	c.Assert(len(statements), qt.Equals, 2,
+		qt.Commentf("each DO block must end up as its own statement after SQL splitting; got %d statements:\n%s",
+			len(statements), strings.Join(statements, "\n---\n")))
+	c.Assert(strings.Contains(statements[0], "first_constraint"), qt.IsTrue)
+	c.Assert(strings.Contains(statements[1], "second_constraint"), qt.IsTrue)
 }
 
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_EscapesSingleQuoteInName(t *testing.T) {

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -235,24 +235,26 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_EscapesSingleQuoteInNam
 }
 
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_RejectsUnsafeName(t *testing.T) {
-	c := qt.New(t)
-
 	// Names containing $ or newlines would either break the surrounding
 	// `$ptah$` dollar-quote tag or terminate the leading SQL comment line.
-	// The planner emits a warning comment instead of a malformed DO block.
+	// Rather than emit a malformed drop (or a silent warning comment that
+	// would loop on every subsequent generate run), the planner emits a DO
+	// block whose only action is RAISE EXCEPTION — so the migration fails
+	// loudly and the operator has to rename the constraint.
 	cases := []string{"foo$ptah$bar", "two\nlines", "carriage\rreturn"}
 	for _, name := range cases {
-		c.Run(name, func(c *qt.C) {
+		t.Run(name, func(t *testing.T) {
+			c := qt.New(t)
 			diff := &types.SchemaDiff{ConstraintsRemoved: []string{name}}
 			nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
 			c.Assert(len(nodes), qt.Equals, 1)
 
 			sql, err := renderer.RenderSQL("postgres", nodes[0])
 			c.Assert(err, qt.IsNil)
-			c.Assert(strings.Contains(sql, "DO $ptah$"), qt.IsFalse,
-				qt.Commentf("unsafe name must NOT produce a DO block"))
-			c.Assert(strings.Contains(sql, "WARNING"), qt.IsTrue,
-				qt.Commentf("planner must emit a warning comment for unsafe names; got: %s", sql))
+			c.Assert(strings.Contains(sql, "RAISE EXCEPTION"), qt.IsTrue,
+				qt.Commentf("planner must emit RAISE EXCEPTION for unsafe names; got: %s", sql))
+			c.Assert(strings.Contains(sql, "ALTER TABLE %I DROP CONSTRAINT"), qt.IsFalse,
+				qt.Commentf("unsafe name must NOT produce a drop statement"))
 		})
 	}
 }

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -211,3 +211,48 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	c.Assert(sql, qt.Contains, "ALTER TABLE %I DROP CONSTRAINT IF EXISTS %I")
 	c.Assert(sql, qt.Contains, "$ptah$")
 }
+
+func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_EscapesSingleQuoteInName(t *testing.T) {
+	c := qt.New(t)
+
+	// PostgreSQL allows quoted identifiers with embedded apostrophes; the
+	// DO block interpolates the constraint name into five distinct contexts
+	// (one SQL literal, one EXECUTE format() argument, two RAISE NOTICE
+	// strings, one SQL comment) and every literal substitution must escape.
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"don't_drop"},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+	c.Assert(len(nodes), qt.Equals, 1)
+
+	sql, err := renderer.RenderSQL("postgres", nodes[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "'don''t_drop'", qt.Commentf("single quote in constraint name must be SQL-escaped"))
+	// The bare unescaped form must NOT appear in any SQL string literal.
+	c.Assert(strings.Contains(sql, "'don't_drop'"), qt.IsFalse,
+		qt.Commentf("unescaped name in a literal would break parsing; got: %s", sql))
+}
+
+func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_RejectsUnsafeName(t *testing.T) {
+	c := qt.New(t)
+
+	// Names containing $ or newlines would either break the surrounding
+	// `$ptah$` dollar-quote tag or terminate the leading SQL comment line.
+	// The planner emits a warning comment instead of a malformed DO block.
+	cases := []string{"foo$ptah$bar", "two\nlines", "carriage\rreturn"}
+	for _, name := range cases {
+		c.Run(name, func(c *qt.C) {
+			diff := &types.SchemaDiff{ConstraintsRemoved: []string{name}}
+			nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+			c.Assert(len(nodes), qt.Equals, 1)
+
+			sql, err := renderer.RenderSQL("postgres", nodes[0])
+			c.Assert(err, qt.IsNil)
+			c.Assert(strings.Contains(sql, "DO $ptah$"), qt.IsFalse,
+				qt.Commentf("unsafe name must NOT produce a DO block"))
+			c.Assert(strings.Contains(sql, "WARNING"), qt.IsTrue,
+				qt.Commentf("planner must emit a warning comment for unsafe names; got: %s", sql))
+		})
+	}
+}

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -241,11 +241,29 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_RejectsUnsafeName(t *te
 	// would loop on every subsequent generate run), the planner emits a DO
 	// block whose only action is RAISE EXCEPTION — so the migration fails
 	// loudly and the operator has to rename the constraint.
-	cases := []string{"foo$ptah$bar", "two\nlines", "carriage\rreturn"}
-	for _, name := range cases {
-		t.Run(name, func(t *testing.T) {
+	cases := []struct {
+		input          string
+		expectVisible  string // the escaped name as it should appear in the SQL literal
+		mustNotContain []string
+	}{
+		{
+			input:          "foo$ptah$bar",
+			expectVisible:  `foo\$ptah\$bar`, // `$` rendered as `\$` so it can't collapse $ptah$
+			mustNotContain: []string{"$ptah$bar"},
+		},
+		{
+			input:         "two\nlines",
+			expectVisible: `two\nlines`,
+		},
+		{
+			input:         "carriage\rreturn",
+			expectVisible: `carriage\rreturn`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
 			c := qt.New(t)
-			diff := &types.SchemaDiff{ConstraintsRemoved: []string{name}}
+			diff := &types.SchemaDiff{ConstraintsRemoved: []string{tc.input}}
 			nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
 			c.Assert(len(nodes), qt.Equals, 1)
 
@@ -254,7 +272,16 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_RejectsUnsafeName(t *te
 			c.Assert(strings.Contains(sql, "RAISE EXCEPTION"), qt.IsTrue,
 				qt.Commentf("planner must emit RAISE EXCEPTION for unsafe names; got: %s", sql))
 			c.Assert(strings.Contains(sql, "ALTER TABLE %I DROP CONSTRAINT"), qt.IsFalse,
-				qt.Commentf("unsafe name must NOT produce a drop statement"))
+				qt.Commentf("unsafe name must NOT produce a drop statement; got: %s", sql))
+			// The rejected name must appear inside an embedded SQL single-
+			// quoted literal (not as a Postgres identifier), so the operator
+			// sees a clean exception message.
+			c.Assert(strings.Contains(sql, "''"+tc.expectVisible+"''"), qt.IsTrue,
+				qt.Commentf("rejected name must appear escaped inside the exception message; got: %s", sql))
+			for _, forbidden := range tc.mustNotContain {
+				c.Assert(strings.Contains(sql, forbidden), qt.IsFalse,
+					qt.Commentf("escaped output must not contain raw substring %q; got: %s", forbidden, sql))
+			}
 		})
 	}
 }

--- a/migration/planner/dialects/postgres/modify_functions_test.go
+++ b/migration/planner/dialects/postgres/modify_functions_test.go
@@ -1,0 +1,82 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_FunctionsModified_EmitsCreateOrReplace(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		FunctionsModified: []types.FunctionDiff{
+			{
+				FunctionName: "set_tenant_context",
+				Changes: map[string]string{
+					"body":     "OLD BODY -> NEW BODY",
+					"security": "DEFINER -> INVOKER",
+				},
+			},
+		},
+	}
+	generated := &goschema.Database{
+		Functions: []goschema.Function{
+			{
+				Name:       "set_tenant_context",
+				Parameters: "tenant_id_param TEXT",
+				Returns:    "VOID",
+				Language:   "plpgsql",
+				Security:   "INVOKER",
+				Volatility: "VOLATILE",
+				Body:       "BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, true); END;",
+			},
+		},
+	}
+
+	planner := postgres.New()
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	c.Assert(len(nodes), qt.Not(qt.Equals), 0)
+
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE FUNCTION set_tenant_context(tenant_id_param TEXT)")
+	c.Assert(sql, qt.Contains, "RETURNS VOID")
+	c.Assert(sql, qt.Contains, "LANGUAGE plpgsql")
+	c.Assert(sql, qt.Contains, "SECURITY INVOKER")
+	c.Assert(sql, qt.Contains, "set_config('app.current_tenant_id', tenant_id_param, true)")
+	// Diff summary appears as a comment for traceability.
+	c.Assert(sql, qt.Contains, "Modify function set_tenant_context")
+	c.Assert(sql, qt.Contains, "body, security")
+}
+
+func TestPlanner_GenerateMigrationAST_FunctionsModified_SkippedWhenTargetMissing(t *testing.T) {
+	c := qt.New(t)
+
+	// FunctionsModified references a function not present in generated.Functions:
+	// the planner must skip silently rather than emitting a malformed CREATE.
+	diff := &types.SchemaDiff{
+		FunctionsModified: []types.FunctionDiff{
+			{
+				FunctionName: "ghost",
+				Changes:      map[string]string{"body": "x -> y"},
+			},
+		},
+	}
+	generated := &goschema.Database{}
+
+	planner := postgres.New()
+	nodes := planner.GenerateMigrationAST(diff, generated)
+
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sql, "ghost"), qt.IsFalse,
+		qt.Commentf("planner must not emit SQL for a modified function whose target definition is missing"))
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1047,20 +1047,35 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	// schema reachable via search_path are not handled — Ptah's introspection
 	// is also single-schema, so the two ends are consistent.
 	//
-	// Constraint-name safety: the name is interpolated into a single-quoted
-	// SQL literal, into an EXECUTE format() argument, into a SQL comment, and
-	// into two RAISE NOTICE messages. We escape single quotes for the literal
-	// substitutions and reject names containing `$` or newline characters at
-	// planner time — both would break the surrounding `$ptah$` dollar quoting
-	// or the `--` comment terminator and there is no legitimate annotation
-	// case that needs them.
+	// Constraint-name safety. Postgres constraint names should be plain
+	// ASCII alnum + underscore; we reject only the chars that would actually
+	// break our specific DO-block template:
+	//   - `$` would collide with the `$ptah$` dollar-quote tag and terminate
+	//     the body early.
+	//   - newline / carriage return would terminate the leading `--` comment
+	//     line and dump whatever follows as bare SQL.
+	// Anything else (apostrophe) is handled by SQL-literal escaping.
+	// Unsafe names trigger a DO block whose only action is RAISE EXCEPTION,
+	// so the migration fails loudly with the operator's attention — better
+	// than a silent comment that would loop forever on subsequent runs.
 	for _, constraintName := range diff.ConstraintsRemoved {
+		escaped := strings.ReplaceAll(constraintName, "'", "''")
 		if strings.ContainsAny(constraintName, "$\n\r") {
-			warning := fmt.Sprintf("WARNING: constraint name %q contains $ or newline; skipping DROP to avoid SQL injection in the DO block", constraintName)
-			result = append(result, ast.NewComment(warning))
+			// The unsafe-name DO block hard-codes a literal string that
+			// describes the rejected name. We render the name with %q so any
+			// control character is visible in the operator's error output;
+			// any apostrophes in that quoted form are then SQL-escaped.
+			rendered := strings.ReplaceAll(fmt.Sprintf("%q", constraintName), "'", "''")
+			failBlock := fmt.Sprintf(`-- Unsafe constraint name rejected by the migration generator; the
+-- following DO block raises an exception so the migration fails loudly.
+DO $ptah$
+BEGIN
+    RAISE EXCEPTION 'refusing to drop constraint with unsafe name %%; rename the constraint and regenerate the migration', %s;
+END
+$ptah$`, rendered)
+			result = append(result, ast.NewRawSQL(failBlock))
 			continue
 		}
-		escaped := strings.ReplaceAll(constraintName, "'", "''")
 		doBlock := fmt.Sprintf(`-- Drop constraint %s (table resolved at runtime from information_schema)
 DO $ptah$
 DECLARE
@@ -1079,7 +1094,7 @@ BEGIN
         RAISE NOTICE 'Constraint %s not found in current schema';
     END IF;
 END
-$ptah$`, escaped, escaped, escaped, escaped, escaped)
+$ptah$`, constraintName, escaped, escaped, escaped, escaped)
 
 		result = append(result, ast.NewRawSQL(doBlock))
 	}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -576,6 +577,11 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 2. Add new functions (functions may be used by RLS policies)
 	result = p.addNewFunctions(result, diff, generated)
 
+	// 2b. Modify existing function definitions (body, volatility, security, language).
+	// PostgreSQL CREATE OR REPLACE FUNCTION updates the live definition in place
+	// without affecting policies or triggers that reference the function.
+	result = p.modifyExistingFunctions(result, diff, generated)
+
 	// 3. Add new enums (PostgreSQL requires enum types to exist before tables use them)
 	result = p.addNewEnums(result, diff, generated)
 
@@ -841,6 +847,40 @@ func (p *Planner) addNewFunctions(result []ast.Node, diff *types.SchemaDiff, gen
 	return result
 }
 
+func (p *Planner) modifyExistingFunctions(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, fnDiff := range diff.FunctionsModified {
+		// Find the target function definition. Without it we can't emit a
+		// faithful CREATE OR REPLACE, so skip silently (the diff alone would
+		// not tell us the new body/attributes).
+		var target *goschema.Function
+		for i := range generated.Functions {
+			if generated.Functions[i].Name == fnDiff.FunctionName {
+				target = &generated.Functions[i]
+				break
+			}
+		}
+		if target == nil {
+			continue
+		}
+
+		functionNode := fromschema.FromFunction(*target)
+		functionNode.SetComment(fmt.Sprintf("Modify function %s: %s", target.Name, summarizeFunctionChanges(fnDiff)))
+		result = append(result, functionNode)
+	}
+	return result
+}
+
+// summarizeFunctionChanges produces a deterministic one-line summary of the
+// changed attributes for use as a SQL comment.
+func summarizeFunctionChanges(fnDiff types.FunctionDiff) string {
+	keys := make([]string, 0, len(fnDiff.Changes))
+	for k := range fnDiff.Changes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
 func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	for _, functionName := range diff.FunctionsRemoved {
 		dropFunctionNode := ast.NewDropFunction(functionName).
@@ -988,60 +1028,47 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 //	ALTER TABLE bookings DROP CONSTRAINT IF EXISTS no_overlapping_bookings;
 //	ALTER TABLE products DROP CONSTRAINT IF EXISTS positive_price;
 func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	// Drop each constraint via a DO block. Two reasons we use a DO block
+	// rather than a literal ALTER TABLE DROP CONSTRAINT:
+	//
+	//  1. ConstraintsRemoved is just a slice of constraint names — the table
+	//     name has been thrown away by the diff layer (the comparator
+	//     synthesizes field-level CHECKs and presents them by name alone).
+	//     The DO block resolves the table at execution time from
+	//     information_schema, which works regardless of whether the
+	//     constraint is column-scoped or table-scoped.
+	//
+	//  2. A DO block executes immediately. The previous implementation
+	//     defined a plpgsql function plus a sql wrapper, then dropped both
+	//     without ever invoking either — so constraint removals were a
+	//     silent no-op.
+	//
+	// Each DO block is emitted as a separate top-level statement so the
+	// surrounding migration-statement splitter (";\n" join) treats it as a
+	// single unit.
 	for _, constraintName := range diff.ConstraintsRemoved {
-		// Create a temporary function that finds and drops the constraint dynamically
-		functionName := fmt.Sprintf("ptah_drop_constraint_%s", constraintName)
-
-		functionBody := fmt.Sprintf(`DECLARE
+		escaped := strings.ReplaceAll(constraintName, "'", "''")
+		doBlock := fmt.Sprintf(`-- Drop constraint %s (table resolved at runtime from information_schema)
+DO $ptah$
+DECLARE
     target_table TEXT;
 BEGIN
-    -- Find the table that contains this constraint
     SELECT table_name INTO target_table
     FROM information_schema.table_constraints
     WHERE constraint_name = '%s'
       AND table_schema = current_schema()
     LIMIT 1;
 
-    -- Drop the constraint if found
     IF target_table IS NOT NULL THEN
         EXECUTE format('ALTER TABLE %%I DROP CONSTRAINT IF EXISTS %%I', target_table, '%s');
         RAISE NOTICE 'Dropped constraint %s from table %%', target_table;
     ELSE
         RAISE NOTICE 'Constraint %s not found in current schema';
     END IF;
-END;`, constraintName, constraintName, constraintName, constraintName)
+END
+$ptah$`, constraintName, escaped, escaped, constraintName, constraintName)
 
-		// Step 1: Create the function
-		createFunctionNode := ast.NewCreateFunction(functionName).
-			SetReturns("VOID").
-			SetLanguage("plpgsql").
-			SetBody(functionBody).
-			SetComment(fmt.Sprintf("Temporary function to drop constraint %s", constraintName))
-
-		result = append(result, createFunctionNode)
-
-		// Step 2: Execute the function using a simple SQL function call
-		executeFunctionBody := fmt.Sprintf("SELECT %s();", functionName)
-		executeFunctionNode := ast.NewCreateFunction(fmt.Sprintf("ptah_exec_%s", functionName)).
-			SetReturns("VOID").
-			SetLanguage("sql").
-			SetBody(executeFunctionBody).
-			SetComment(fmt.Sprintf("Execute constraint removal for %s", constraintName))
-
-		result = append(result, executeFunctionNode)
-
-		// Step 3: Drop the temporary functions
-		dropMainFunctionNode := ast.NewDropFunction(functionName).
-			SetIfExists().
-			SetComment(fmt.Sprintf("Clean up temporary function for %s", constraintName))
-
-		result = append(result, dropMainFunctionNode)
-
-		dropExecFunctionNode := ast.NewDropFunction(fmt.Sprintf("ptah_exec_%s", functionName)).
-			SetIfExists().
-			SetComment(fmt.Sprintf("Clean up executor function for %s", constraintName))
-
-		result = append(result, dropExecFunctionNode)
+		result = append(result, ast.NewRawSQL(doBlock))
 	}
 	return result
 }

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1043,10 +1043,23 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	//     without ever invoking either — so constraint removals were a
 	//     silent no-op.
 	//
-	// Each DO block is emitted as a separate top-level statement so the
-	// surrounding migration-statement splitter (";\n" join) treats it as a
-	// single unit.
+	// The block resolves `current_schema()` only: constraints in a different
+	// schema reachable via search_path are not handled — Ptah's introspection
+	// is also single-schema, so the two ends are consistent.
+	//
+	// Constraint-name safety: the name is interpolated into a single-quoted
+	// SQL literal, into an EXECUTE format() argument, into a SQL comment, and
+	// into two RAISE NOTICE messages. We escape single quotes for the literal
+	// substitutions and reject names containing `$` or newline characters at
+	// planner time — both would break the surrounding `$ptah$` dollar quoting
+	// or the `--` comment terminator and there is no legitimate annotation
+	// case that needs them.
 	for _, constraintName := range diff.ConstraintsRemoved {
+		if strings.ContainsAny(constraintName, "$\n\r") {
+			warning := fmt.Sprintf("WARNING: constraint name %q contains $ or newline; skipping DROP to avoid SQL injection in the DO block", constraintName)
+			result = append(result, ast.NewComment(warning))
+			continue
+		}
 		escaped := strings.ReplaceAll(constraintName, "'", "''")
 		doBlock := fmt.Sprintf(`-- Drop constraint %s (table resolved at runtime from information_schema)
 DO $ptah$
@@ -1066,7 +1079,7 @@ BEGIN
         RAISE NOTICE 'Constraint %s not found in current schema';
     END IF;
 END
-$ptah$`, constraintName, escaped, escaped, constraintName, constraintName)
+$ptah$`, escaped, escaped, escaped, escaped, escaped)
 
 		result = append(result, ast.NewRawSQL(doBlock))
 	}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1061,18 +1061,27 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	for _, constraintName := range diff.ConstraintsRemoved {
 		escaped := strings.ReplaceAll(constraintName, "'", "''")
 		if strings.ContainsAny(constraintName, "$\n\r") {
-			// The unsafe-name DO block hard-codes a literal string that
-			// describes the rejected name. We render the name with %q so any
-			// control character is visible in the operator's error output;
-			// any apostrophes in that quoted form are then SQL-escaped.
-			rendered := strings.ReplaceAll(fmt.Sprintf("%q", constraintName), "'", "''")
+			// Build a printable, single-quoted SQL string literal of the
+			// rejected name so the operator's error output shows what was
+			// rejected. `$` is rendered as `\$` so the surrounding `$ptah$`
+			// dollar quoting can't be prematurely terminated; `\n` / `\r` /
+			// `\t` are rendered as their printable escapes; apostrophes are
+			// SQL-escaped via `''`. The result is plain ASCII inside `'…'`.
+			visible := strings.NewReplacer(
+				"\n", `\n`,
+				"\r", `\r`,
+				"\t", `\t`,
+				"$", `\$`,
+			).Replace(constraintName)
+			visible = strings.ReplaceAll(visible, "'", "''")
+
 			failBlock := fmt.Sprintf(`-- Unsafe constraint name rejected by the migration generator; the
 -- following DO block raises an exception so the migration fails loudly.
 DO $ptah$
 BEGIN
-    RAISE EXCEPTION 'refusing to drop constraint with unsafe name %%; rename the constraint and regenerate the migration', %s;
+    RAISE EXCEPTION 'refusing to drop constraint with unsafe name ''%s''; rename the constraint and regenerate the migration';
 END
-$ptah$`, rendered)
+$ptah$`, visible)
 			result = append(result, ast.NewRawSQL(failBlock))
 			continue
 		}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2184,6 +2184,17 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		Changes:      make(map[string]string),
 	}
 
+	// Normalize parsed-but-omitted attributes to PostgreSQL defaults so an
+	// unspecified annotation field doesn't appear as a change against the DB.
+	genSecurity := genFunction.Security
+	if genSecurity == "" {
+		genSecurity = "INVOKER"
+	}
+	genVolatility := genFunction.Volatility
+	if genVolatility == "" {
+		genVolatility = "VOLATILE"
+	}
+
 	// Compare parameters
 	if genFunction.Parameters != dbFunction.Parameters {
 		functionDiff.Changes["parameters"] = fmt.Sprintf("%s -> %s", dbFunction.Parameters, genFunction.Parameters)
@@ -2199,14 +2210,14 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genFunction.Language)
 	}
 
-	// Compare security context
-	if genFunction.Security != dbFunction.Security {
-		functionDiff.Changes["security"] = fmt.Sprintf("%s -> %s", dbFunction.Security, genFunction.Security)
+	// Compare security context (DEFINER vs INVOKER); empty Go-side means INVOKER.
+	if genSecurity != dbFunction.Security {
+		functionDiff.Changes["security"] = fmt.Sprintf("%s -> %s", dbFunction.Security, genSecurity)
 	}
 
-	// Compare volatility
-	if genFunction.Volatility != dbFunction.Volatility {
-		functionDiff.Changes["volatility"] = fmt.Sprintf("%s -> %s", dbFunction.Volatility, genFunction.Volatility)
+	// Compare volatility (VOLATILE/STABLE/IMMUTABLE); empty Go-side means VOLATILE.
+	if genVolatility != dbFunction.Volatility {
+		functionDiff.Changes["volatility"] = fmt.Sprintf("%s -> %s", dbFunction.Volatility, genVolatility)
 	}
 
 	// Compare function body (normalize whitespace for comparison)

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2184,25 +2184,13 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		Changes:      make(map[string]string),
 	}
 
-	// Defense-in-depth: the parser at core/goschema/parser.go already
-	// canonicalizes these attributes (lowercase plpgsql default for Language,
-	// uppercase for Security/Volatility), but callers constructing
-	// goschema.Function programmatically — including the down-migration path's
-	// ConvertDBSchemaToGoSchema and any future API consumer — may not. We
-	// re-apply the same normalization here so the diff is stable regardless
-	// of how the Go-side struct was produced.
-	genLanguage := strings.ToLower(genFunction.Language)
-	if genLanguage == "" {
-		genLanguage = "plpgsql"
-	}
-	genSecurity := strings.ToUpper(genFunction.Security)
-	if genSecurity == "" {
-		genSecurity = "INVOKER"
-	}
-	genVolatility := strings.ToUpper(genFunction.Volatility)
-	if genVolatility == "" {
-		genVolatility = "VOLATILE"
-	}
+	// Defense-in-depth: canonicalize a local copy. The annotation parser at
+	// core/goschema/parser.go already calls Canonicalize, but test code (this
+	// package, integration tests) constructs goschema.Function directly with
+	// non-canonical case, and a future programmatic API consumer might too.
+	// The DB-side read path already returns canonical case by construction,
+	// so we only normalize the gen side.
+	genFunction.Canonicalize()
 
 	// Compare parameters
 	if genFunction.Parameters != dbFunction.Parameters {
@@ -2214,19 +2202,19 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		functionDiff.Changes["returns"] = fmt.Sprintf("%s -> %s", dbFunction.Returns, genFunction.Returns)
 	}
 
-	// Compare language (empty/mixed-case Go-side normalized to lowercase plpgsql).
-	if genLanguage != dbFunction.Language {
-		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genLanguage)
+	// Compare language
+	if genFunction.Language != dbFunction.Language {
+		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genFunction.Language)
 	}
 
-	// Compare security context (DEFINER vs INVOKER); empty Go-side means INVOKER.
-	if genSecurity != dbFunction.Security {
-		functionDiff.Changes["security"] = fmt.Sprintf("%s -> %s", dbFunction.Security, genSecurity)
+	// Compare security context (DEFINER vs INVOKER)
+	if genFunction.Security != dbFunction.Security {
+		functionDiff.Changes["security"] = fmt.Sprintf("%s -> %s", dbFunction.Security, genFunction.Security)
 	}
 
-	// Compare volatility (VOLATILE/STABLE/IMMUTABLE); empty Go-side means VOLATILE.
-	if genVolatility != dbFunction.Volatility {
-		functionDiff.Changes["volatility"] = fmt.Sprintf("%s -> %s", dbFunction.Volatility, genVolatility)
+	// Compare volatility (VOLATILE/STABLE/IMMUTABLE)
+	if genFunction.Volatility != dbFunction.Volatility {
+		functionDiff.Changes["volatility"] = fmt.Sprintf("%s -> %s", dbFunction.Volatility, genFunction.Volatility)
 	}
 
 	// Compare function body (normalize whitespace for comparison)

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -1065,9 +1065,24 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 			return true
 		}
 	case "CHECK":
-		// PostgreSQL represents NOT NULL constraints as CHECK constraints with specific naming pattern
+		// PostgreSQL exposes NOT NULL declarations as synthetic CHECK rows in
+		// information_schema with a `<table>_<column>_not_null` naming
+		// convention (and, in PG18, as named NOT NULL constraints in
+		// pg_constraint). Ptah never emits these directly — they are owned by
+		// the column's NOT NULL clause, which the table/column lifecycle
+		// already handles:
+		//   - field exists in target with NOT NULL → covered by the CREATE
+		//     TABLE / ALTER COLUMN SET NOT NULL emitted elsewhere.
+		//   - field exists in target as nullable → an ALTER COLUMN DROP
+		//     NOT NULL handles it.
+		//   - field has been dropped → the column drop cascades.
+		//   - table has been dropped → the table drop cascades.
+		// In every case an explicit ALTER TABLE … DROP CONSTRAINT for the
+		// synthetic name would be redundant at best and illegal at worst (PG
+		// rejects with 42P16 "column X is in a primary key" when the column
+		// is part of a PK). Treat these as field-level always; skip the diff.
 		if strings.Contains(dbConstraint.Name, "_not_null") {
-			return hasNonNullableFieldInTable(dbConstraint.TableName, generated)
+			return true
 		}
 		// Regular CHECK constraints from `check=` annotations are surfaced
 		// to the diff via synthesized goschema.Constraint entries (see
@@ -1077,24 +1092,6 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 		// all flow through the standard Constraints() comparison path.
 	}
 
-	return false
-}
-
-// hasNonNullableFieldInTable checks if there's any non-nullable field in the table
-func hasNonNullableFieldInTable(tableName string, generated *goschema.Database) bool {
-	for _, field := range generated.Fields {
-		// Get table name for this field
-		fieldTableName := field.StructName
-		for _, table := range generated.Tables {
-			if table.StructName == field.StructName {
-				fieldTableName = table.Name
-				break
-			}
-		}
-		if fieldTableName == tableName && !field.Nullable {
-			return true
-		}
-	}
 	return false
 }
 

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2186,13 +2186,28 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 
 	// Normalize parsed-but-omitted attributes to PostgreSQL defaults so an
 	// unspecified annotation field doesn't appear as a change against the DB.
-	genSecurity := genFunction.Security
+	// `security` and `volatility` are also case-folded: the parser stores the
+	// annotation text verbatim, but pg_proc always reports the canonical
+	// uppercase form (DEFINER/INVOKER, VOLATILE/STABLE/IMMUTABLE) — comparing
+	// `definer` against `DEFINER` would otherwise flag every run as drift.
+	//
+	// For `language` an empty annotation is treated as `plpgsql`. The renderer
+	// at core/renderer/dialects/postgres/postgres.go omits the LANGUAGE clause
+	// entirely when this is empty, which Postgres rejects with
+	// "ERROR: no language specified" — defaulting to plpgsql matches both the
+	// most common case and what `CREATE FUNCTION` would assume if we hand-
+	// wrote the SQL.
+	genSecurity := strings.ToUpper(genFunction.Security)
 	if genSecurity == "" {
 		genSecurity = "INVOKER"
 	}
-	genVolatility := genFunction.Volatility
+	genVolatility := strings.ToUpper(genFunction.Volatility)
 	if genVolatility == "" {
 		genVolatility = "VOLATILE"
+	}
+	genLanguage := genFunction.Language
+	if genLanguage == "" {
+		genLanguage = "plpgsql"
 	}
 
 	// Compare parameters
@@ -2205,9 +2220,9 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		functionDiff.Changes["returns"] = fmt.Sprintf("%s -> %s", dbFunction.Returns, genFunction.Returns)
 	}
 
-	// Compare language
-	if genFunction.Language != dbFunction.Language {
-		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genFunction.Language)
+	// Compare language (empty Go-side means plpgsql).
+	if genLanguage != dbFunction.Language {
+		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genLanguage)
 	}
 
 	// Compare security context (DEFINER vs INVOKER); empty Go-side means INVOKER.

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2184,19 +2184,17 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		Changes:      make(map[string]string),
 	}
 
-	// Normalize parsed-but-omitted attributes to PostgreSQL defaults so an
-	// unspecified annotation field doesn't appear as a change against the DB.
-	// `security` and `volatility` are also case-folded: the parser stores the
-	// annotation text verbatim, but pg_proc always reports the canonical
-	// uppercase form (DEFINER/INVOKER, VOLATILE/STABLE/IMMUTABLE) — comparing
-	// `definer` against `DEFINER` would otherwise flag every run as drift.
-	//
-	// For `language` an empty annotation is treated as `plpgsql`. The renderer
-	// at core/renderer/dialects/postgres/postgres.go omits the LANGUAGE clause
-	// entirely when this is empty, which Postgres rejects with
-	// "ERROR: no language specified" — defaulting to plpgsql matches both the
-	// most common case and what `CREATE FUNCTION` would assume if we hand-
-	// wrote the SQL.
+	// Defense-in-depth: the parser at core/goschema/parser.go already
+	// canonicalizes these attributes (lowercase plpgsql default for Language,
+	// uppercase for Security/Volatility), but callers constructing
+	// goschema.Function programmatically — including the down-migration path's
+	// ConvertDBSchemaToGoSchema and any future API consumer — may not. We
+	// re-apply the same normalization here so the diff is stable regardless
+	// of how the Go-side struct was produced.
+	genLanguage := strings.ToLower(genFunction.Language)
+	if genLanguage == "" {
+		genLanguage = "plpgsql"
+	}
 	genSecurity := strings.ToUpper(genFunction.Security)
 	if genSecurity == "" {
 		genSecurity = "INVOKER"
@@ -2204,10 +2202,6 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 	genVolatility := strings.ToUpper(genFunction.Volatility)
 	if genVolatility == "" {
 		genVolatility = "VOLATILE"
-	}
-	genLanguage := genFunction.Language
-	if genLanguage == "" {
-		genLanguage = "plpgsql"
 	}
 
 	// Compare parameters
@@ -2220,7 +2214,7 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 		functionDiff.Changes["returns"] = fmt.Sprintf("%s -> %s", dbFunction.Returns, genFunction.Returns)
 	}
 
-	// Compare language (empty Go-side means plpgsql).
+	// Compare language (empty/mixed-case Go-side normalized to lowercase plpgsql).
 	if genLanguage != dbFunction.Language {
 		functionDiff.Changes["language"] = fmt.Sprintf("%s -> %s", dbFunction.Language, genLanguage)
 	}

--- a/migration/schemadiff/internal/compare/compare_functions_test.go
+++ b/migration/schemadiff/internal/compare/compare_functions_test.go
@@ -117,26 +117,67 @@ func TestFunctionDefinitions_EmptyAnnotationDefaultsMatchPostgresDefaults(t *tes
 }
 
 func TestFunctionDefinitions_LowercaseAnnotationDoesNotDiff(t *testing.T) {
+	cases := []struct {
+		name string
+		gen  goschema.Function
+	}{
+		{
+			name: "lowercase security/volatility",
+			gen: goschema.Function{
+				Name: "f", Returns: "VOID", Language: "plpgsql",
+				Security: "definer", Volatility: "stable", Body: "BEGIN END;",
+			},
+		},
+		{
+			name: "mixed-case security/volatility",
+			gen: goschema.Function{
+				Name: "f", Returns: "VOID", Language: "plpgsql",
+				Security: "Definer", Volatility: "Stable", Body: "BEGIN END;",
+			},
+		},
+		{
+			name: "uppercase language",
+			gen: goschema.Function{
+				Name: "f", Returns: "VOID", Language: "PLPGSQL",
+				Security: "DEFINER", Volatility: "STABLE", Body: "BEGIN END;",
+			},
+		},
+	}
+	db := dbtypes.DBFunction{
+		Name: "f", Returns: "VOID", Language: "plpgsql",
+		Security: "DEFINER", Volatility: "STABLE", Body: "BEGIN END;",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := compare.FunctionDefinitions(tc.gen, db)
+			c.Assert(diff.Changes, qt.HasLen, 0,
+				qt.Commentf("normalization should produce a clean diff; got: %v", diff.Changes))
+		})
+	}
+}
+
+// TestFunctionDefinitions_ExplicitNonDefaultLanguage covers the pre-iteration-1
+// case that was overwritten when the empty-language default was introduced: a
+// function annotation that legitimately uses LANGUAGE sql (a pure-SQL helper,
+// not plpgsql) must still produce a clean diff when both sides agree.
+func TestFunctionDefinitions_ExplicitNonDefaultLanguage(t *testing.T) {
 	c := qt.New(t)
 
-	// Users sometimes write `security="definer"` / `volatility="stable"`.
-	// PostgreSQL only ever reports the uppercase form, so the comparator
-	// case-folds the Go side before comparing.
 	gen := goschema.Function{
-		Name:       "f",
-		Returns:    "VOID",
-		Language:   "plpgsql",
-		Security:   "definer",
-		Volatility: "stable",
-		Body:       "BEGIN END;",
+		Name:     "f",
+		Returns:  "INTEGER",
+		Language: "sql",
+		Body:     "SELECT 1;",
 	}
 	db := dbtypes.DBFunction{
 		Name:       "f",
-		Returns:    "VOID",
-		Language:   "plpgsql",
-		Security:   "DEFINER",
-		Volatility: "STABLE",
-		Body:       "BEGIN END;",
+		Returns:    "INTEGER",
+		Language:   "sql",
+		Security:   "INVOKER",
+		Volatility: "VOLATILE",
+		Body:       "SELECT 1;",
 	}
 
 	diff := compare.FunctionDefinitions(gen, db)

--- a/migration/schemadiff/internal/compare/compare_functions_test.go
+++ b/migration/schemadiff/internal/compare/compare_functions_test.go
@@ -1,0 +1,155 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	dbtypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestFunctionDefinitions_DetectsBodyChange(t *testing.T) {
+	c := qt.New(t)
+
+	gen := goschema.Function{
+		Name:       "set_tenant_context",
+		Parameters: "tenant_id_param TEXT",
+		Returns:    "VOID",
+		Language:   "plpgsql",
+		Security:   "DEFINER",
+		Volatility: "VOLATILE",
+		Body:       "BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, true); END;",
+	}
+	db := dbtypes.DBFunction{
+		Name:       "set_tenant_context",
+		Parameters: "tenant_id_param TEXT",
+		Returns:    "VOID",
+		Language:   "plpgsql",
+		Security:   "DEFINER",
+		Volatility: "VOLATILE",
+		Body:       "BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;",
+	}
+
+	diff := compare.FunctionDefinitions(gen, db)
+
+	c.Assert(diff.FunctionName, qt.Equals, "set_tenant_context")
+	c.Assert(diff.Changes, qt.HasLen, 1)
+	c.Assert(diff.Changes["body"], qt.Contains, "false")
+	c.Assert(diff.Changes["body"], qt.Contains, "true")
+}
+
+func TestFunctionDefinitions_DetectsSecurityVolatilityLanguageChanges(t *testing.T) {
+	c := qt.New(t)
+
+	gen := goschema.Function{
+		Name:       "f",
+		Returns:    "INTEGER",
+		Language:   "sql",
+		Security:   "INVOKER",
+		Volatility: "IMMUTABLE",
+		Body:       "SELECT 1;",
+	}
+	db := dbtypes.DBFunction{
+		Name:       "f",
+		Returns:    "INTEGER",
+		Language:   "plpgsql",
+		Security:   "DEFINER",
+		Volatility: "STABLE",
+		Body:       "SELECT 1;",
+	}
+
+	diff := compare.FunctionDefinitions(gen, db)
+
+	c.Assert(diff.Changes["language"], qt.Equals, "plpgsql -> sql")
+	c.Assert(diff.Changes["security"], qt.Equals, "DEFINER -> INVOKER")
+	c.Assert(diff.Changes["volatility"], qt.Equals, "STABLE -> IMMUTABLE")
+	_, hasBody := diff.Changes["body"]
+	c.Assert(hasBody, qt.IsFalse)
+}
+
+func TestFunctionDefinitions_NoChangeWhenIdentical(t *testing.T) {
+	c := qt.New(t)
+
+	fn := struct {
+		gen goschema.Function
+		db  dbtypes.DBFunction
+	}{
+		gen: goschema.Function{
+			Name: "f", Returns: "VOID", Language: "plpgsql",
+			Security: "INVOKER", Volatility: "VOLATILE", Body: "BEGIN END;",
+		},
+		db: dbtypes.DBFunction{
+			Name: "f", Returns: "VOID", Language: "plpgsql",
+			Security: "INVOKER", Volatility: "VOLATILE", Body: "BEGIN END;",
+		},
+	}
+
+	diff := compare.FunctionDefinitions(fn.gen, fn.db)
+	c.Assert(diff.Changes, qt.HasLen, 0)
+}
+
+func TestFunctionDefinitions_EmptyAnnotationDefaultsMatchPostgresDefaults(t *testing.T) {
+	c := qt.New(t)
+
+	// The annotation omits security and volatility; PostgreSQL reports the
+	// implicit defaults (INVOKER, VOLATILE). The comparator must normalize
+	// the Go side so no spurious diff is reported.
+	gen := goschema.Function{
+		Name:     "f",
+		Returns:  "INTEGER",
+		Language: "sql",
+		Body:     "SELECT 1;",
+	}
+	db := dbtypes.DBFunction{
+		Name:       "f",
+		Returns:    "INTEGER",
+		Language:   "sql",
+		Security:   "INVOKER",
+		Volatility: "VOLATILE",
+		Body:       "SELECT 1;",
+	}
+
+	diff := compare.FunctionDefinitions(gen, db)
+	c.Assert(diff.Changes, qt.HasLen, 0)
+}
+
+func TestFunctions_PopulatesModifiedList(t *testing.T) {
+	c := qt.New(t)
+
+	gen := &goschema.Database{
+		Functions: []goschema.Function{
+			{
+				Name:       "f",
+				Returns:    "VOID",
+				Language:   "plpgsql",
+				Security:   "INVOKER",
+				Volatility: "VOLATILE",
+				Body:       "BEGIN PERFORM 1; END;",
+			},
+		},
+	}
+	db := &dbtypes.DBSchema{
+		Functions: []dbtypes.DBFunction{
+			{
+				Name:       "f",
+				Returns:    "VOID",
+				Language:   "plpgsql",
+				Security:   "INVOKER",
+				Volatility: "VOLATILE",
+				Body:       "BEGIN PERFORM 2; END;",
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.Functions(gen, db, diff)
+
+	c.Assert(diff.FunctionsAdded, qt.HasLen, 0)
+	c.Assert(diff.FunctionsRemoved, qt.HasLen, 0)
+	c.Assert(diff.FunctionsModified, qt.HasLen, 1)
+	c.Assert(diff.FunctionsModified[0].FunctionName, qt.Equals, "f")
+	c.Assert(diff.FunctionsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}

--- a/migration/schemadiff/internal/compare/compare_functions_test.go
+++ b/migration/schemadiff/internal/compare/compare_functions_test.go
@@ -94,22 +94,49 @@ func TestFunctionDefinitions_NoChangeWhenIdentical(t *testing.T) {
 func TestFunctionDefinitions_EmptyAnnotationDefaultsMatchPostgresDefaults(t *testing.T) {
 	c := qt.New(t)
 
-	// The annotation omits security and volatility; PostgreSQL reports the
-	// implicit defaults (INVOKER, VOLATILE). The comparator must normalize
-	// the Go side so no spurious diff is reported.
+	// The annotation omits security, volatility, AND language; PostgreSQL
+	// reports the implicit defaults (INVOKER, VOLATILE, plpgsql for a typical
+	// trigger/RLS helper). The comparator must normalize the Go side so no
+	// spurious diff is reported.
 	gen := goschema.Function{
-		Name:     "f",
-		Returns:  "INTEGER",
-		Language: "sql",
-		Body:     "SELECT 1;",
+		Name:    "f",
+		Returns: "INTEGER",
+		Body:    "BEGIN RETURN 1; END;",
 	}
 	db := dbtypes.DBFunction{
 		Name:       "f",
 		Returns:    "INTEGER",
-		Language:   "sql",
+		Language:   "plpgsql",
 		Security:   "INVOKER",
 		Volatility: "VOLATILE",
-		Body:       "SELECT 1;",
+		Body:       "BEGIN RETURN 1; END;",
+	}
+
+	diff := compare.FunctionDefinitions(gen, db)
+	c.Assert(diff.Changes, qt.HasLen, 0)
+}
+
+func TestFunctionDefinitions_LowercaseAnnotationDoesNotDiff(t *testing.T) {
+	c := qt.New(t)
+
+	// Users sometimes write `security="definer"` / `volatility="stable"`.
+	// PostgreSQL only ever reports the uppercase form, so the comparator
+	// case-folds the Go side before comparing.
+	gen := goschema.Function{
+		Name:       "f",
+		Returns:    "VOID",
+		Language:   "plpgsql",
+		Security:   "definer",
+		Volatility: "stable",
+		Body:       "BEGIN END;",
+	}
+	db := dbtypes.DBFunction{
+		Name:       "f",
+		Returns:    "VOID",
+		Language:   "plpgsql",
+		Security:   "DEFINER",
+		Volatility: "STABLE",
+		Body:       "BEGIN END;",
 	}
 
 	diff := compare.FunctionDefinitions(gen, db)


### PR DESCRIPTION
Closes #89.

## Summary

- **#89 fix.** The schema-diff comparator already populated `diff.FunctionsModified` for changes to a function's body, SECURITY qualifier, volatility, or language — but the postgres planner had no handler for that field, so the rewritten function silently never reached the database and the generator reported "no schema changes detected". Add `modifyExistingFunctions` in the planner; it looks up the target in `generated.Functions` and emits `CREATE OR REPLACE FUNCTION` via the existing renderer path. `CREATE OR REPLACE` updates the live definition in place without affecting policies or triggers that reference the function.
- **Comparator polish.** Normalize parser-omitted attributes to Postgres defaults (empty `security=` → `INVOKER`, empty `volatility=` → `VOLATILE`) so an annotation that doesn't spell those out doesn't diff against a freshly-introspected DB on every run.
- **Master bug fix (incidental, but required for the e2e tests to pass).** `removeConstraints` in the postgres planner was emitting four nodes (`CREATE` a plpgsql drop-function, `CREATE` a sql wrapper that selects from it, `DROP` the main fn, `DROP` the wrapper) but never actually invoking either function — the entire block was a no-op. The existing unit test only checked that the `SELECT ptah_drop_constraint_X();` text appeared *inside the wrapper's body*, which it did, so the bug had no test signal. Replace the four nodes with a single inline `DO $ptah$ ... $ptah$` block that resolves the table from `information_schema` at runtime and runs the `ALTER TABLE` immediately — atomic, no temporary objects left behind, and (most importantly) actually executes. A new `ast.RawSQLNode` carries the block through the existing visitor pipeline; every renderer implements `VisitRawSQL`.
- **E2E backfill.** Adds two real-database round-trips for #89 under `integration/gonative/` (body + SECURITY change; VOLATILITY change). Also backfills the missing real-DB coverage for PR #123 (field-level `check=` round-trip + removal) — #123 was the path that surfaced the silent constraint-drop bug above.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all unit tests pass.
- [x] `golangci-lint run --timeout 5m` — clean.
- [x] `POSTGRES_TEST_DSN=… go test -tags=integration ./integration/...` against a live Postgres 18 — all four new e2e tests pass, full suite green.
- [ ] CI green on push.