### PR TITLE
test(integration): fixture-based migrations for #89 + #112; fix planner gap + Returns/Parameters canonicalization

### DIFF
--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -449,8 +449,8 @@ func TestParseFunctionComment(t *testing.T) {
 			expected: goschema.Function{
 				StructName: "TestStruct",
 				Name:       "set_tenant_context",
-				Parameters: "tenant_id_param TEXT",
-				Returns:    "VOID",
+				Parameters: "tenant_id_param text", // lowercased to match pg_get_function_arguments
+				Returns:    "void",                 // lowercased to match pg_get_function_result
 				Language:   "plpgsql",
 				Security:   "DEFINER",
 				Volatility: "VOLATILE", // default
@@ -463,7 +463,7 @@ func TestParseFunctionComment(t *testing.T) {
 			expected: goschema.Function{
 				StructName: "TestStruct",
 				Name:       "get_current_tenant_id",
-				Returns:    "TEXT",
+				Returns:    "text", // lowercased
 				Language:   "plpgsql",
 				Security:   "INVOKER", // default
 				Volatility: "STABLE",
@@ -476,7 +476,7 @@ func TestParseFunctionComment(t *testing.T) {
 			expected: goschema.Function{
 				StructName: "TestStruct",
 				Name:       "test_func",
-				Returns:    "INTEGER",
+				Returns:    "integer", // lowercased
 				Language:   "sql",
 				Security:   "INVOKER",  // default
 				Volatility: "VOLATILE", // default
@@ -489,7 +489,7 @@ func TestParseFunctionComment(t *testing.T) {
 			expected: goschema.Function{
 				StructName: "TestStruct",
 				Name:       "no_lang",
-				Returns:    "VOID",
+				Returns:    "void",    // lowercased
 				Language:   "plpgsql", // defaulted
 				Security:   "INVOKER",
 				Volatility: "VOLATILE",
@@ -502,7 +502,7 @@ func TestParseFunctionComment(t *testing.T) {
 			expected: goschema.Function{
 				StructName: "TestStruct",
 				Name:       "mixed_case",
-				Returns:    "VOID",
+				Returns:    "void",    // ToLower
 				Language:   "plpgsql", // ToLower
 				Security:   "DEFINER", // ToUpper
 				Volatility: "STABLE",  // ToUpper

--- a/core/goschema/rls_integration_test.go
+++ b/core/goschema/rls_integration_test.go
@@ -80,15 +80,17 @@ type Product struct {
 
 	setTenantFunc := findFunction(database.Functions, "set_tenant_context")
 	c.Assert(setTenantFunc, qt.IsNotNil)
-	c.Assert(setTenantFunc.Parameters, qt.Equals, "tenant_id_param TEXT")
-	c.Assert(setTenantFunc.Returns, qt.Equals, "VOID")
+	// Parameters and Returns are canonicalized to lowercase so they line up
+	// with what pg_get_function_arguments / pg_get_function_result emit.
+	c.Assert(setTenantFunc.Parameters, qt.Equals, "tenant_id_param text")
+	c.Assert(setTenantFunc.Returns, qt.Equals, "void")
 	c.Assert(setTenantFunc.Language, qt.Equals, "plpgsql")
 	c.Assert(setTenantFunc.Security, qt.Equals, "DEFINER")
 	c.Assert(setTenantFunc.Comment, qt.Equals, "Sets the current tenant context for RLS")
 
 	getTenantFunc := findFunction(database.Functions, "get_current_tenant_id")
 	c.Assert(getTenantFunc, qt.IsNotNil)
-	c.Assert(getTenantFunc.Returns, qt.Equals, "TEXT")
+	c.Assert(getTenantFunc.Returns, qt.Equals, "text")
 	c.Assert(getTenantFunc.Language, qt.Equals, "plpgsql")
 	c.Assert(getTenantFunc.Volatility, qt.Equals, "STABLE")
 	c.Assert(getTenantFunc.Comment, qt.Equals, "Gets the current tenant ID from session")
@@ -131,8 +133,9 @@ type Product struct {
 	sqlOutput := strings.Join(statements, "\n")
 
 	// Verify function creation SQL
-	c.Assert(sqlOutput, qt.Contains, "CREATE OR REPLACE FUNCTION set_tenant_context(tenant_id_param TEXT)")
-	c.Assert(sqlOutput, qt.Contains, "RETURNS VOID")
+	// Types lowercased by Function.Canonicalize to match Postgres' canonical form.
+	c.Assert(sqlOutput, qt.Contains, "CREATE OR REPLACE FUNCTION set_tenant_context(tenant_id_param text)")
+	c.Assert(sqlOutput, qt.Contains, "RETURNS void")
 	c.Assert(sqlOutput, qt.Contains, "LANGUAGE plpgsql SECURITY DEFINER")
 	c.Assert(sqlOutput, qt.Contains, "PERFORM set_config('app.current_tenant_id', tenant_id_param, false)")
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -412,6 +412,13 @@ func (f *Function) Canonicalize() {
 	if f.Volatility == "" {
 		f.Volatility = "VOLATILE"
 	}
+	// Returns and Parameters: PostgreSQL stores types in canonical lowercase
+	// (`pg_get_function_result`, `pg_get_function_arguments`) and lowercases
+	// unquoted parameter names too. Mirror that on the Go side so an
+	// annotation written as `returns="VOID"` or `params="x TEXT"` doesn't
+	// false-diff on every run against pg_proc.
+	f.Returns = strings.ToLower(f.Returns)
+	f.Parameters = strings.ToLower(f.Parameters)
 }
 
 // RLSPolicy represents a PostgreSQL Row-Level Security policy definition parsed from Go struct annotations.

--- a/integration/fixtures/entities/018-rls-functions-modified/article.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/article.go
@@ -1,0 +1,35 @@
+package entities
+
+// Article demonstrates all embedding modes in a single table
+//
+//migrator:schema:table name="articles"
+type Article struct {
+	//migrator:embedded mode="inline"
+	BaseID
+
+	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"
+	Title string
+
+	//migrator:schema:field name="content" type="TEXT" not_null="true"
+	Content string
+
+	// Mode 1: inline - Injects individual fields as separate columns
+	//migrator:embedded mode="inline"
+	Timestamps // Results in: created_at, updated_at columns
+
+	// Mode 2: inline with prefix - Injects fields with prefix
+	//migrator:embedded mode="inline" prefix="audit_"
+	AuditInfo // Results in: audit_by, audit_reason columns
+
+	// Mode 3: json - Serializes struct into one JSON/JSONB column
+	//migrator:embedded mode="json" name="meta_data" type="JSONB" platform.mysql.type="JSON" platform.mariadb.type="LONGTEXT" platform.mariadb.check="JSON_VALID(meta_data)"
+	Metadata // Results in: meta_data JSONB column
+
+	// Mode 4: relation - Adds foreign key field + constraint
+	//migrator:embedded mode="relation" field="author_id" ref="users(id)" on_delete="CASCADE"
+	Author User // Results in: author_id BIGINT + FK constraint
+
+	// Mode 5: skip - Ignores this embedded field completely
+	//migrator:embedded mode="skip"
+	SkippedField SkippedInfo // Results in: nothing (ignored)
+}

--- a/integration/fixtures/entities/018-rls-functions-modified/base_id.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/base_id.go
@@ -1,0 +1,7 @@
+package entities
+
+// BaseID represents a common ID structure that can be embedded in other entities
+type BaseID struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}

--- a/integration/fixtures/entities/018-rls-functions-modified/blog_post.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/blog_post.go
@@ -1,0 +1,47 @@
+package entities
+
+// BlogPost demonstrates all embedding modes using pointer types
+// This entity tests that pointer embedded fields (*BaseID, *Timestamps, etc.)
+// generate the same database schema as value embedded fields
+//
+//migrator:schema:table name="blog_posts"
+type BlogPost struct {
+	// Mode 1: inline with pointer - Should inject individual fields as separate columns
+	//migrator:embedded mode="inline"
+	*BaseID // Results in: id column (same as value BaseID)
+
+	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"
+	Title string
+
+	//migrator:schema:field name="content" type="TEXT" not_null="true"
+	Content string
+
+	//migrator:schema:field name="slug" type="VARCHAR(255)" not_null="true" unique="true"
+	Slug string
+
+	// Mode 1: inline with pointer - Should inject timestamp fields
+	//migrator:embedded mode="inline"
+	*Timestamps // Results in: created_at, updated_at columns (same as value Timestamps)
+
+	// Mode 2: inline with prefix and pointer - Should inject fields with prefix
+	//migrator:embedded mode="inline" prefix="audit_"
+	*AuditInfo // Results in: audit_by, audit_reason columns (same as value AuditInfo)
+
+	// Mode 3: json with pointer - Should serialize struct into one JSON/JSONB column
+	//migrator:embedded mode="json" name="meta_data" type="JSONB" platform.mysql.type="JSON" platform.mariadb.type="LONGTEXT" platform.mariadb.check="JSON_VALID(meta_data)"
+	*Metadata // Results in: meta_data JSONB column (same as value Metadata)
+
+	// Mode 4: relation with pointer - Should add foreign key field + constraint
+	//migrator:embedded mode="relation" field="author_id" ref="users(id)" on_delete="CASCADE"
+	*User // Results in: author_id BIGINT + FK constraint (same as value User)
+
+	// Mode 5: skip with pointer - Should ignore this embedded field completely
+	//migrator:embedded mode="skip"
+	*SkippedInfo // Results in: nothing (ignored, same as value SkippedInfo)
+
+	//migrator:schema:field name="published" type="BOOLEAN" not_null="true" default_expr="false"
+	Published bool
+
+	//migrator:schema:field name="view_count" type="INTEGER" not_null="true" default="0"
+	ViewCount int
+}

--- a/integration/fixtures/entities/018-rls-functions-modified/category.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/category.go
@@ -1,0 +1,22 @@
+package entities
+
+//migrator:schema:table name="categories"
+type Category struct {
+	//migrator:embedded mode="inline"
+	BaseID
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true" unique="true"
+	Name string
+
+	//migrator:schema:field name="description" type="TEXT"
+	Description string
+
+	//migrator:schema:field name="parent_id" type="BIGINT"
+	ParentID *int64
+
+	//migrator:embedded mode="inline"
+	Timestamps
+}
+
+//migrator:schema:index table="categories" name="idx_categories_parent_id" columns="parent_id"
+//migrator:schema:foreign_key table="categories" name="fk_categories_parent_id" columns="parent_id" ref_table="categories" ref_columns="id" on_delete="CASCADE"

--- a/integration/fixtures/entities/018-rls-functions-modified/post.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/post.go
@@ -1,0 +1,26 @@
+package entities
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:embedded mode="inline"
+	BaseID
+
+	//migrator:schema:field name="title" type="VARCHAR(255)" not_null="true"
+	Title string
+
+	//migrator:schema:field name="content" type="TEXT" not_null="true"
+	Content string
+
+	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	UserID int64
+
+	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"
+	Status string
+
+	//migrator:embedded mode="inline"
+	Timestamps
+}
+
+//migrator:schema:index table="posts" name="idx_posts_user_id" columns="user_id"
+//migrator:schema:index table="posts" name="idx_posts_status" columns="status"
+//migrator:schema:foreign_key table="posts" name="fk_posts_user_id" columns="user_id" ref_table="users" ref_columns="id" on_delete="CASCADE"

--- a/integration/fixtures/entities/018-rls-functions-modified/product.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/product.go
@@ -1,0 +1,31 @@
+package entities
+
+// Enable RLS and create policies for products table with INSERT/UPDATE checks
+//
+//migrator:schema:rls:enable table="products" comment="Enable RLS for product isolation"
+//migrator:schema:rls:policy name="product_tenant_isolation" table="products" for="ALL" to="PUBLIC" using="tenant_id = get_current_tenant_id()" with_check="tenant_id = get_current_tenant_id()" comment="Products isolated by tenant"
+//migrator:schema:table name="products" comment="Product catalog table"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64 `json:"id" db:"id"`
+
+	//migrator:schema:field name="tenant_id" type="TEXT" not_null="true"
+	TenantID string `json:"tenant_id" db:"tenant_id"`
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string `json:"name" db:"name"`
+
+	//migrator:schema:field name="description" type="TEXT"
+	Description string `json:"description" db:"description"`
+
+	//migrator:schema:field name="price" type="DECIMAL(10,2)" not_null="true"
+	Price string `json:"price" db:"price"`
+
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
+	UserID int64 `json:"user_id" db:"user_id"`
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
+	CreatedAt string `json:"created_at" db:"created_at"`
+}
+
+//migrator:schema:foreign_key table="products" name="fk_products_user_id" columns="user_id" ref_table="users" ref_columns="id" on_delete="CASCADE"

--- a/integration/fixtures/entities/018-rls-functions-modified/timestamps.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/timestamps.go
@@ -1,0 +1,42 @@
+package entities
+
+import "time"
+
+// Timestamps represents common timestamp fields that can be embedded in other entities
+type Timestamps struct {
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time
+}
+
+// AuditInfo represents audit information that can be embedded with prefix
+type AuditInfo struct {
+	//migrator:schema:field name="by" type="VARCHAR(255)"
+	By string
+
+	//migrator:schema:field name="reason" type="TEXT"
+	Reason string
+}
+
+// Metadata represents metadata that can be embedded as JSON
+type Metadata struct {
+	//migrator:schema:field name="author" type="VARCHAR(255)"
+	Author string
+
+	//migrator:schema:field name="source" type="VARCHAR(255)"
+	Source string
+
+	//migrator:schema:field name="tags" type="TEXT"
+	Tags string
+}
+
+// SkippedInfo represents information that should be skipped in embedding
+type SkippedInfo struct {
+	//migrator:schema:field name="internal_data" type="TEXT"
+	InternalData string
+
+	//migrator:schema:field name="temp_field" type="INTEGER"
+	TempField int
+}

--- a/integration/fixtures/entities/018-rls-functions-modified/user.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/user.go
@@ -1,0 +1,37 @@
+package entities
+
+// Same tables and policies as 014-rls-functions, but with deliberate function
+// attribute changes to exercise the issue #89 / PR #129 modify-function path:
+//
+//   - set_tenant_context: body switches from set_config(..., false) (session-
+//     scoped) to set_config(..., true) (transaction-local), and the
+//     SECURITY DEFINER qualifier is removed (defaults back to INVOKER).
+//   - get_current_tenant_id: volatility tightens from STABLE to IMMUTABLE.
+//
+// Before PR #129 the diff comparator already detected these changes, but the
+// postgres planner had no handler for diff.FunctionsModified — the rewrites
+// silently never reached the database. This fixture exists so the natural
+// fixture-driven migration suite verifies that the CREATE OR REPLACE actually
+// lands and the live pg_proc reflects the new attributes.
+//
+//migrator:schema:function name="set_tenant_context" params="tenant_id_param TEXT" returns="VOID" language="plpgsql" body="BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, true); END;"
+//migrator:schema:function name="get_current_tenant_id" returns="TEXT" language="plpgsql" volatility="IMMUTABLE" body="BEGIN RETURN current_setting('app.current_tenant_id', true); END;" comment="Gets the current tenant ID from session"
+//migrator:schema:rls:enable table="users" comment="Enable RLS for multi-tenant isolation"
+//migrator:schema:rls:policy name="user_tenant_isolation" table="users" for="ALL" to="PUBLIC" using="tenant_id = get_current_tenant_id()" comment="Ensures users can only access their tenant's data"
+//migrator:schema:table name="users" comment="User accounts table"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64 `json:"id" db:"id"`
+
+	//migrator:schema:field name="tenant_id" type="TEXT" not_null="true"
+	TenantID string `json:"tenant_id" db:"tenant_id"`
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
+	Email string `json:"email" db:"email"`
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string `json:"name" db:"name"`
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" default_expr="NOW()"
+	CreatedAt string `json:"created_at" db:"created_at"`
+}

--- a/integration/fixtures/entities/019-field-check-constraints/product.go
+++ b/integration/fixtures/entities/019-field-check-constraints/product.go
@@ -1,0 +1,42 @@
+package entities
+
+import "time"
+
+// 019-field-check-constraints exercises PR #123 / issue #112 on the natural
+// fixture-driven migration path: a Product table with three field-level CHECK
+// constraints. The framework migrates here from 000-initial — its Product
+// table has `price` already, so the existing-column CHECK is synthesized into
+// ALTER TABLE ADD CONSTRAINT, while the brand-new `stock` and `status`
+// columns ship their CHECKs inline via ALTER TABLE ADD COLUMN.
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	// `price > 0` exists in 000-initial without a CHECK; adding it here
+	// should yield an ALTER TABLE ADD CONSTRAINT under the Postgres
+	// auto-name `products_price_check`.
+	//migrator:schema:field name="price" type="DECIMAL(10,2)" not_null="true" check="price > 0"
+	Price float64
+
+	// New column with a CHECK inlined into ALTER TABLE ADD COLUMN.
+	//migrator:schema:field name="stock" type="INTEGER" not_null="true" default_expr="0" check="stock >= 0"
+	Stock int
+
+	// New column with an explicit `check_name=` so we can exercise the
+	// "trust the name" matching during a later rename (in 020).
+	//migrator:schema:field name="status" type="VARCHAR(32)" not_null="true" default="active" check="status IN ('active','draft','archived')" check_name="products_status_valid"
+	Status string
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time
+}
+
+//migrator:schema:index table="products" name="idx_products_name" columns="name"

--- a/integration/fixtures/entities/019-field-check-constraints/user.go
+++ b/integration/fixtures/entities/019-field-check-constraints/user.go
@@ -1,0 +1,23 @@
+package entities
+
+import "time"
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
+	Email string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time
+}
+
+//migrator:schema:index table="users" name="idx_users_email" columns="email"

--- a/integration/fixtures/entities/020-field-check-constraints-modified/product.go
+++ b/integration/fixtures/entities/020-field-check-constraints-modified/product.go
@@ -1,0 +1,52 @@
+package entities
+
+import "time"
+
+// 020-field-check-constraints-modified evolves 019 to exercise the three
+// non-trivial CHECK lifecycle paths:
+//
+//   - price: rename the constraint by introducing an explicit `check_name=`.
+//     The comparator "trusts the name" (Postgres rewrites the stored
+//     expression, so text compare is hostile to idempotency), so a rename is
+//     what triggers a drop+add for a same-column same-expression CHECK.
+//   - stock: drop the CHECK entirely.
+//   - status: keep `check_name=` and expression identical, drop one allowed
+//     value from the IN list — this case is what PR #112's "trust the name"
+//     contract deliberately ignores; a same-name CHECK is treated as
+//     unchanged. We assert below that no needless drop+add fires.
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	// price: was auto-named `products_price_check` in 019; now explicitly
+	// named `products_price_positive`. The diff should produce one
+	// ConstraintsRemoved (old auto-name) + one ConstraintsAdded (new name).
+	//migrator:schema:field name="price" type="DECIMAL(10,2)" not_null="true" check="price > 0" check_name="products_price_positive"
+	Price float64
+
+	// stock: CHECK annotation dropped. Diff should produce one
+	// ConstraintsRemoved targeting `products_stock_check`.
+	//migrator:schema:field name="stock" type="INTEGER" not_null="true" default_expr="0"
+	Stock int
+
+	// status: same `check_name=` as 019, but the expression is narrowed.
+	// Because the comparator trusts the name, the diff should NOT emit a
+	// drop+add — the constraint is treated as unchanged. This guards against
+	// a future regression where someone reintroduces expression-text
+	// comparison and accidentally regens every CHECK on every run.
+	//migrator:schema:field name="status" type="VARCHAR(32)" not_null="true" default="active" check="status IN ('active','archived')" check_name="products_status_valid"
+	Status string
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time
+}
+
+//migrator:schema:index table="products" name="idx_products_name" columns="name"

--- a/integration/fixtures/entities/020-field-check-constraints-modified/user.go
+++ b/integration/fixtures/entities/020-field-check-constraints-modified/user.go
@@ -1,0 +1,23 @@
+package entities
+
+import "time"
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
+	Email string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	//migrator:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	CreatedAt time.Time
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
+	UpdatedAt time.Time
+}
+
+//migrator:schema:index table="users" name="idx_users_email" columns="email"

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -168,6 +168,25 @@ func GetDynamicScenarios() []TestScenario {
 			EnhancedTestFunc: testDynamicFunctionsModification,
 		},
 		{
+			// Closes the "modify-existing-function" gap that issue #89 was
+			// originally about: changing a function's body, SECURITY qualifier,
+			// or volatility on a same-named function — the case the previous
+			// dynamic_functions_modification scenario didn't exercise.
+			Name:             "dynamic_function_attribute_modification",
+			Description:      "Test PostgreSQL function body/SECURITY/volatility modification round-trips through the live DB (issue #89 / PR #129)",
+			EnhancedTestFunc: testDynamicFunctionAttributeModification,
+		},
+		{
+			// Natural-migration coverage for PR #123 / issue #112: field-level
+			// `check=` / `check_name=` annotations across add → rename → drop →
+			// same-name-no-op transitions, with idempotency re-diff at each
+			// step. This is the path that surfaced the silent constraint-drop
+			// no-op bug fixed by PR #129.
+			Name:             "dynamic_field_check_constraint_evolution",
+			Description:      "Test field-level CHECK constraint lifecycle (add, rename, drop, same-name no-op) via natural migrations (PR #123)",
+			EnhancedTestFunc: testDynamicFieldCheckConstraintEvolution,
+		},
+		{
 			Name:             "dynamic_rls_policy_modification",
 			Description:      "Test RLS policy modification and schema diffing",
 			EnhancedTestFunc: testDynamicRLSPolicyModification,

--- a/integration/scenarios_field_check_and_function_modify.go
+++ b/integration/scenarios_field_check_and_function_modify.go
@@ -1,0 +1,328 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// testDynamicFunctionAttributeModification migrates from 014-rls-functions to
+// 018-rls-functions-modified and asserts that the live `pg_proc` rows for the
+// two affected functions actually changed:
+//
+//   - set_tenant_context: body switches from set_config(..., false) to
+//     set_config(..., true), and SECURITY DEFINER is dropped (back to INVOKER).
+//   - get_current_tenant_id: volatility tightens from STABLE to IMMUTABLE.
+//
+// Before PR #129 the diff comparator already populated diff.FunctionsModified
+// for these changes, but the postgres planner had no handler for that field —
+// the rewrites silently never reached the database. This scenario is what the
+// natural-migration fixture suite was missing to catch that class of bug.
+func testDynamicFunctionAttributeModification(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
+	if err := skipNonPostgreSQL(conn, recorder); err != nil {
+		return err
+	}
+
+	vem, err := NewVersionedEntityManager(fixtures)
+	if err != nil {
+		return fmt.Errorf("failed to create versioned entity manager: %w", err)
+	}
+	defer vem.Cleanup()
+
+	if err := recorder.RecordStep("Apply Initial Functions", "Apply 014-rls-functions baseline", func() error {
+		return vem.MigrateToVersion(ctx, conn, "014-rls-functions", "Baseline RLS functions")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Baseline DB State", "Read pg_proc and assert set_tenant_context is DEFINER + session-scoped, get_current_tenant_id is STABLE", func() error {
+		setCtx, err := readFunctionAttributes(ctx, conn, "set_tenant_context")
+		if err != nil {
+			return err
+		}
+		if setCtx.security != "DEFINER" {
+			return fmt.Errorf("baseline set_tenant_context: expected SECURITY DEFINER, got %s", setCtx.security)
+		}
+		if !strings.Contains(setCtx.body, "false") {
+			return fmt.Errorf("baseline set_tenant_context: expected session-scoped set_config (false), got body: %s", setCtx.body)
+		}
+		getCtx, err := readFunctionAttributes(ctx, conn, "get_current_tenant_id")
+		if err != nil {
+			return err
+		}
+		if getCtx.volatility != "STABLE" {
+			return fmt.Errorf("baseline get_current_tenant_id: expected STABLE, got %s", getCtx.volatility)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Apply Modified Functions", "Migrate to 018-rls-functions-modified", func() error {
+		return vem.MigrateToVersion(ctx, conn, "018-rls-functions-modified", "Modify function body, SECURITY, volatility")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Modified DB State", "Read pg_proc and assert body/security/volatility actually changed in the database", func() error {
+		setCtx, err := readFunctionAttributes(ctx, conn, "set_tenant_context")
+		if err != nil {
+			return err
+		}
+		if setCtx.security != "INVOKER" {
+			return fmt.Errorf("modified set_tenant_context: SECURITY DEFINER must be dropped, got %s", setCtx.security)
+		}
+		if strings.Contains(setCtx.body, "false") {
+			return fmt.Errorf("modified set_tenant_context: body must no longer contain `false`, got: %s", setCtx.body)
+		}
+		if !strings.Contains(setCtx.body, "true") {
+			return fmt.Errorf("modified set_tenant_context: body must contain `true` (transaction-local), got: %s", setCtx.body)
+		}
+
+		getCtx, err := readFunctionAttributes(ctx, conn, "get_current_tenant_id")
+		if err != nil {
+			return err
+		}
+		if getCtx.volatility != "IMMUTABLE" {
+			return fmt.Errorf("modified get_current_tenant_id: expected IMMUTABLE, got %s", getCtx.volatility)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return recorder.RecordStep("Verify Function Idempotency", "Re-diff and confirm no further FunctionsModified entries are emitted", func() error {
+		// We deliberately don't assert a fully-clean re-diff here: the
+		// fixture inherits NOW()/CURRENT_TIMESTAMP-style column defaults
+		// from 014-rls-functions, and Ptah's column-diff path is currently
+		// case-sensitive against pg_attrdef (which lowercases function
+		// names). That's a pre-existing comparator bug unrelated to issue
+		// #89, and surfacing it under this scenario would obscure the
+		// thing this test is actually about: that the function modify
+		// reached the database and stays put.
+		//
+		// What we DO assert: a re-diff produces no FunctionsModified
+		// entries — i.e. PR #129's planner emit path landed and is
+		// idempotent over body / SECURITY / volatility / language /
+		// parameters / returns.
+		generated, err := vem.GenerateSchemaFromEntities()
+		if err != nil {
+			return fmt.Errorf("failed to parse entities: %w", err)
+		}
+		dbSchema, err := conn.Reader().ReadSchema()
+		if err != nil {
+			return fmt.Errorf("failed to read database schema: %w", err)
+		}
+		diff := schemadiff.Compare(generated, dbSchema)
+		if len(diff.FunctionsModified) > 0 {
+			summary := make([]string, 0, len(diff.FunctionsModified))
+			for _, f := range diff.FunctionsModified {
+				summary = append(summary, fmt.Sprintf("%s: %v", f.FunctionName, f.Changes))
+			}
+			return fmt.Errorf("functions idempotency violation: post-migration diff still flags %d function(s) as modified:\n%s",
+				len(diff.FunctionsModified), strings.Join(summary, "\n"))
+		}
+		return nil
+	})
+}
+
+// testDynamicFieldCheckConstraintEvolution exercises the field-level CHECK
+// constraint lifecycle (PR #123 / issue #112) through the natural fixture
+// migration path:
+//
+//  1. Migrate to 000-initial (baseline, no field-level CHECKs).
+//  2. Migrate to 019-field-check-constraints: introduces three CHECKs —
+//     `products_price_check` (auto-named, on an existing column),
+//     `products_stock_check` (inline on a new column), and
+//     `products_status_valid` (explicit check_name= on a new column).
+//  3. Migrate to 020-field-check-constraints-modified:
+//     - price gets an explicit check_name → constraint is renamed
+//     (drop old auto-name + add new name).
+//     - stock loses its CHECK annotation → ConstraintsRemoved.
+//     - status keeps the same check_name and tightens the IN list; the
+//     "trust the name" contract from #112 means the diff does NOT regen
+//     this constraint — same-name CHECK is treated as unchanged.
+//  4. Re-diff to confirm idempotency.
+//
+// The synthesized CHECK drop here is exactly the path that was a silent no-op
+// in master before PR #129's planner fix. With the DO-block drop in place,
+// this test verifies the natural-migration flow round-trips correctly.
+func testDynamicFieldCheckConstraintEvolution(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
+	if err := skipNonPostgreSQL(conn, recorder); err != nil {
+		return err
+	}
+
+	vem, err := NewVersionedEntityManager(fixtures)
+	if err != nil {
+		return fmt.Errorf("failed to create versioned entity manager: %w", err)
+	}
+	defer vem.Cleanup()
+
+	if err := recorder.RecordStep("Apply Baseline", "Apply 000-initial", func() error {
+		return vem.MigrateToVersion(ctx, conn, "000-initial", "Baseline schema")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Introduce Field CHECKs", "Migrate to 019-field-check-constraints", func() error {
+		return vem.MigrateToVersion(ctx, conn, "019-field-check-constraints", "Add field-level CHECK constraints")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify CHECKs Landed", "Assert all three CHECK constraints exist in the live schema", func() error {
+		names, err := readUserCheckConstraints(ctx, conn, "products")
+		if err != nil {
+			return err
+		}
+		for _, want := range []string{"products_price_check", "products_stock_check", "products_status_valid"} {
+			if !names[want] {
+				return fmt.Errorf("expected CHECK constraint %q on products; got: %v", want, names)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Idempotency After Add", "Re-diff against 019 — no further changes expected", func() error {
+		statements, err := vem.GenerateMigrationSQL(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("failed to regenerate migration SQL: %w", err)
+		}
+		if hasNonCommentStatement(statements) {
+			return fmt.Errorf("idempotency violation after add: %s", strings.Join(statements, "\n"))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Rename + Drop + Same-name CHECKs", "Migrate to 020-field-check-constraints-modified", func() error {
+		return vem.MigrateToVersion(ctx, conn, "020-field-check-constraints-modified", "Rename one CHECK, drop one, leave same-name unchanged")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Modify Lifecycle", "Old auto-name gone, new name present, dropped constraint absent, same-name untouched", func() error {
+		names, err := readUserCheckConstraints(ctx, conn, "products")
+		if err != nil {
+			return err
+		}
+		if names["products_price_check"] {
+			return fmt.Errorf("products_price_check should have been dropped on rename; got: %v", names)
+		}
+		if !names["products_price_positive"] {
+			return fmt.Errorf("products_price_positive (renamed) should exist; got: %v", names)
+		}
+		if names["products_stock_check"] {
+			return fmt.Errorf("products_stock_check should have been dropped; got: %v", names)
+		}
+		if !names["products_status_valid"] {
+			return fmt.Errorf("products_status_valid should still exist (same-name CHECK is treated as unchanged); got: %v", names)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return recorder.RecordStep("Idempotency After Modify", "Re-diff against 020 — no further changes expected", func() error {
+		statements, err := vem.GenerateMigrationSQL(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("failed to regenerate migration SQL: %w", err)
+		}
+		if hasNonCommentStatement(statements) {
+			return fmt.Errorf("idempotency violation after modify: %s", strings.Join(statements, "\n"))
+		}
+		return nil
+	})
+}
+
+// functionAttrs holds the live pg_proc values we care about for an integration
+// assertion. Grouped into a struct so readFunctionAttributes can return a
+// single value alongside its error.
+type functionAttrs struct {
+	body, security, volatility string
+}
+
+// readFunctionAttributes pulls body / security / volatility for a function in
+// the current schema, normalized to the same uppercase / lowercase
+// representation that dbschema/postgres/reader.go uses.
+func readFunctionAttributes(ctx context.Context, conn *dbschema.DatabaseConnection, name string) (functionAttrs, error) {
+	row := conn.QueryRowContext(ctx, `
+		SELECT
+			p.prosrc,
+			CASE p.prosecdef WHEN true THEN 'DEFINER' ELSE 'INVOKER' END,
+			CASE p.provolatile
+				WHEN 'i' THEN 'IMMUTABLE'
+				WHEN 's' THEN 'STABLE'
+				WHEN 'v' THEN 'VOLATILE'
+			END
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = current_schema() AND p.proname = $1
+		LIMIT 1
+	`, name)
+	var attrs functionAttrs
+	if scanErr := row.Scan(&attrs.body, &attrs.security, &attrs.volatility); scanErr != nil {
+		return functionAttrs{}, fmt.Errorf("function %s: failed to read pg_proc: %w", name, scanErr)
+	}
+	return attrs, nil
+}
+
+// readUserCheckConstraints returns the names of user-defined CHECK constraints
+// on a table. Synthetic `<col>_not_null` constraints created by PG18 to back
+// NOT NULL declarations are filtered out — they are owned by the column, not
+// by the user's annotation, and the diff layer already ignores them.
+func readUserCheckConstraints(_ctx context.Context, conn *dbschema.DatabaseConnection, table string) (map[string]bool, error) {
+	rows, err := conn.Query(`
+		SELECT con.conname
+		FROM pg_constraint con
+		JOIN pg_class c ON c.oid = con.conrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = current_schema() AND c.relname = $1 AND con.contype = 'c'
+	`, table)
+	if err != nil {
+		return nil, fmt.Errorf("table %s: failed to read pg_constraint: %w", table, err)
+	}
+	defer rows.Close()
+
+	names := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			return nil, fmt.Errorf("table %s: scan: %w", table, scanErr)
+		}
+		if strings.HasSuffix(name, "_not_null") {
+			continue
+		}
+		names[name] = true
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("table %s: row iteration: %w", table, rowsErr)
+	}
+	return names, nil
+}
+
+// hasNonCommentStatement reports whether `statements` contains anything other
+// than SQL comments. VersionedEntityManager.GenerateMigrationSQL emits no
+// statements when nothing changed, but the planner may still produce a bare
+// "-- Drop constraint …" line when a constraint name is otherwise unsafe;
+// that's not a real change for the purposes of an idempotency check.
+func hasNonCommentStatement(statements []string) bool {
+	for _, s := range statements {
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/integration/scenarios_field_check_and_function_modify.go
+++ b/integration/scenarios_field_check_and_function_modify.go
@@ -23,8 +23,14 @@ import (
 // the rewrites silently never reached the database. This scenario is what the
 // natural-migration fixture suite was missing to catch that class of bug.
 func testDynamicFunctionAttributeModification(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
-	if err := skipNonPostgreSQL(conn, recorder); err != nil {
-		return err
+	// Reads pg_proc directly, so explicitly hard-skip on non-PostgreSQL
+	// rather than going through skipNonPostgreSQL — that helper only
+	// records the skip step but lets the caller keep running, which would
+	// crash here with "Table 'pg_proc' doesn't exist" on MySQL/MariaDB.
+	if conn.Info().Dialect != "postgres" {
+		return recorder.RecordStep("Skip Non-PostgreSQL", "Function attribute modification reads pg_proc; PostgreSQL-only", func() error {
+			return nil
+		})
 	}
 
 	vem, err := NewVersionedEntityManager(fixtures)
@@ -152,8 +158,12 @@ func testDynamicFunctionAttributeModification(ctx context.Context, conn *dbschem
 // in master before PR #129's planner fix. With the DO-block drop in place,
 // this test verifies the natural-migration flow round-trips correctly.
 func testDynamicFieldCheckConstraintEvolution(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
-	if err := skipNonPostgreSQL(conn, recorder); err != nil {
-		return err
+	// Reads pg_constraint directly, so explicitly hard-skip on non-PostgreSQL.
+	// (See the matching comment on testDynamicFunctionAttributeModification.)
+	if conn.Info().Dialect != "postgres" {
+		return recorder.RecordStep("Skip Non-PostgreSQL", "Field-level CHECK lifecycle reads pg_constraint; PostgreSQL-only", func() error {
+			return nil
+		})
 	}
 
 	vem, err := NewVersionedEntityManager(fixtures)

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -55,8 +55,8 @@ func TestGetDynamicScenarios(t *testing.T) {
 
 	scenarios := GetDynamicScenarios()
 
-	// Should have exactly 38 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios)
-	c.Assert(len(scenarios), qt.Equals, 38)
+	// Should have exactly 40 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89)
+	c.Assert(len(scenarios), qt.Equals, 40)
 
 	// Verify all scenarios have required fields
 	for _, scenario := range scenarios {

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -989,22 +989,69 @@ func (p *Planner) removeRLSPolicies(result []ast.Node, diff *types.SchemaDiff) [
 //	ALTER TABLE products ADD CONSTRAINT positive_price
 //	  CHECK (price > 0);
 func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	// Resolve struct → table name once for the field-level synthesis fallback.
+	structToTable := make(map[string]string, len(generated.Tables))
+	for _, t := range generated.Tables {
+		structToTable[t.StructName] = t.Name
+	}
+
 	for _, constraintName := range diff.ConstraintsAdded {
-		// Find the constraint definition in the generated schema
+		// First, try the explicit table-level constraints declared via
+		// `//migrator:schema:constraint` annotations.
+		emitted := false
 		for _, constraint := range generated.Constraints {
 			if constraint.Name == constraintName {
-				// Convert goschema.Constraint to ast.ConstraintNode
-				astConstraint := p.convertConstraintToAST(constraint)
-				if astConstraint != nil {
-					// Create ALTER TABLE statement with ADD CONSTRAINT operation
-					alterNode := &ast.AlterTableNode{
+				if astConstraint := p.convertConstraintToAST(constraint); astConstraint != nil {
+					result = append(result, &ast.AlterTableNode{
 						Name:       constraint.Table,
 						Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
-					}
-					result = append(result, alterNode)
+					})
 				}
+				emitted = true
 				break
 			}
+		}
+		if emitted {
+			continue
+		}
+
+		// Fall back to field-level `check=` annotations. The schemadiff
+		// comparator synthesizes these names into diff.ConstraintsAdded when
+		// `check=` lands on a column that already exists in the database, but
+		// the synthesized Constraint never reaches generated.Constraints — so
+		// without this fallback an ADD CONSTRAINT for an existing column was
+		// silently dropped. PR #123 introduced the synthesis but left this
+		// emission gap; we close it here.
+		//
+		// New columns are handled by the inline CHECK in ALTER TABLE ADD
+		// COLUMN and the comparator deliberately skips synthesizing them, so
+		// only existing-column field-level CHECKs end up routed through this
+		// path.
+		for _, f := range generated.Fields {
+			if f.Check == "" {
+				continue
+			}
+			tableName := structToTable[f.StructName]
+			if tableName == "" {
+				tableName = f.StructName
+			}
+			name := f.CheckName
+			if name == "" {
+				name = tableName + "_" + f.Name + "_check"
+			}
+			if name != constraintName {
+				continue
+			}
+			astConstraint := &ast.ConstraintNode{
+				Type:       ast.CheckConstraint,
+				Name:       name,
+				Expression: f.Check,
+			}
+			result = append(result, &ast.AlterTableNode{
+				Name:       tableName,
+				Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
+			})
+			break
 		}
 	}
 	return result

--- a/migration/schemadiff/internal/compare/compare_functions_test.go
+++ b/migration/schemadiff/internal/compare/compare_functions_test.go
@@ -16,8 +16,8 @@ func TestFunctionDefinitions_DetectsBodyChange(t *testing.T) {
 
 	gen := goschema.Function{
 		Name:       "set_tenant_context",
-		Parameters: "tenant_id_param TEXT",
-		Returns:    "VOID",
+		Parameters: "tenant_id_param text",
+		Returns:    "void",
 		Language:   "plpgsql",
 		Security:   "DEFINER",
 		Volatility: "VOLATILE",
@@ -25,8 +25,8 @@ func TestFunctionDefinitions_DetectsBodyChange(t *testing.T) {
 	}
 	db := dbtypes.DBFunction{
 		Name:       "set_tenant_context",
-		Parameters: "tenant_id_param TEXT",
-		Returns:    "VOID",
+		Parameters: "tenant_id_param text",
+		Returns:    "void",
 		Language:   "plpgsql",
 		Security:   "DEFINER",
 		Volatility: "VOLATILE",
@@ -46,7 +46,7 @@ func TestFunctionDefinitions_DetectsSecurityVolatilityLanguageChanges(t *testing
 
 	gen := goschema.Function{
 		Name:       "f",
-		Returns:    "INTEGER",
+		Returns:    "integer",
 		Language:   "sql",
 		Security:   "INVOKER",
 		Volatility: "IMMUTABLE",
@@ -54,7 +54,7 @@ func TestFunctionDefinitions_DetectsSecurityVolatilityLanguageChanges(t *testing
 	}
 	db := dbtypes.DBFunction{
 		Name:       "f",
-		Returns:    "INTEGER",
+		Returns:    "integer",
 		Language:   "plpgsql",
 		Security:   "DEFINER",
 		Volatility: "STABLE",
@@ -78,11 +78,11 @@ func TestFunctionDefinitions_NoChangeWhenIdentical(t *testing.T) {
 		db  dbtypes.DBFunction
 	}{
 		gen: goschema.Function{
-			Name: "f", Returns: "VOID", Language: "plpgsql",
+			Name: "f", Returns: "void", Language: "plpgsql",
 			Security: "INVOKER", Volatility: "VOLATILE", Body: "BEGIN END;",
 		},
 		db: dbtypes.DBFunction{
-			Name: "f", Returns: "VOID", Language: "plpgsql",
+			Name: "f", Returns: "void", Language: "plpgsql",
 			Security: "INVOKER", Volatility: "VOLATILE", Body: "BEGIN END;",
 		},
 	}
@@ -100,12 +100,12 @@ func TestFunctionDefinitions_EmptyAnnotationDefaultsMatchPostgresDefaults(t *tes
 	// spurious diff is reported.
 	gen := goschema.Function{
 		Name:    "f",
-		Returns: "INTEGER",
+		Returns: "integer",
 		Body:    "BEGIN RETURN 1; END;",
 	}
 	db := dbtypes.DBFunction{
 		Name:       "f",
-		Returns:    "INTEGER",
+		Returns:    "integer",
 		Language:   "plpgsql",
 		Security:   "INVOKER",
 		Volatility: "VOLATILE",
@@ -124,27 +124,27 @@ func TestFunctionDefinitions_LowercaseAnnotationDoesNotDiff(t *testing.T) {
 		{
 			name: "lowercase security/volatility",
 			gen: goschema.Function{
-				Name: "f", Returns: "VOID", Language: "plpgsql",
+				Name: "f", Returns: "void", Language: "plpgsql",
 				Security: "definer", Volatility: "stable", Body: "BEGIN END;",
 			},
 		},
 		{
 			name: "mixed-case security/volatility",
 			gen: goschema.Function{
-				Name: "f", Returns: "VOID", Language: "plpgsql",
+				Name: "f", Returns: "void", Language: "plpgsql",
 				Security: "Definer", Volatility: "Stable", Body: "BEGIN END;",
 			},
 		},
 		{
 			name: "uppercase language",
 			gen: goschema.Function{
-				Name: "f", Returns: "VOID", Language: "PLPGSQL",
+				Name: "f", Returns: "void", Language: "PLPGSQL",
 				Security: "DEFINER", Volatility: "STABLE", Body: "BEGIN END;",
 			},
 		},
 	}
 	db := dbtypes.DBFunction{
-		Name: "f", Returns: "VOID", Language: "plpgsql",
+		Name: "f", Returns: "void", Language: "plpgsql",
 		Security: "DEFINER", Volatility: "STABLE", Body: "BEGIN END;",
 	}
 
@@ -173,7 +173,7 @@ func TestFunctionDefinitions_ExplicitNonDefaultLanguage(t *testing.T) {
 	}
 	db := dbtypes.DBFunction{
 		Name:       "f",
-		Returns:    "INTEGER",
+		Returns:    "integer",
 		Language:   "sql",
 		Security:   "INVOKER",
 		Volatility: "VOLATILE",
@@ -191,7 +191,7 @@ func TestFunctions_PopulatesModifiedList(t *testing.T) {
 		Functions: []goschema.Function{
 			{
 				Name:       "f",
-				Returns:    "VOID",
+				Returns:    "void",
 				Language:   "plpgsql",
 				Security:   "INVOKER",
 				Volatility: "VOLATILE",
@@ -203,7 +203,7 @@ func TestFunctions_PopulatesModifiedList(t *testing.T) {
 		Functions: []dbtypes.DBFunction{
 			{
 				Name:       "f",
-				Returns:    "VOID",
+				Returns:    "void",
 				Language:   "plpgsql",
 				Security:   "INVOKER",
 				Volatility: "VOLATILE",


### PR DESCRIPTION
Follow-up to PR #123 (issue #112, field-level CHECK) and PR #129 (issue #89, function attribute modify): both features had real-DB round-trips under `integration/gonative/`, but neither was exercised through the same versioned-entity-fixture migration framework that drives the rest of the comprehensive scenario suite. This PR closes that gap — and, by doing so, surfaces and fixes two adjacent bugs the prior PRs missed.

## Fixtures

Three new versions under `integration/fixtures/entities/`:

- **`018-rls-functions-modified`** — clone of `014-rls-functions` with `set_tenant_context` body switched to `set_config(..., true)` and `SECURITY DEFINER` dropped, and `get_current_tenant_id` volatility moved `STABLE → IMMUTABLE`. The exact case from the issue #89 report.
- **`019-field-check-constraints`** — `products` gains three field-level CHECKs: one synthesized for an existing column, one inline on a new column, one with an explicit `check_name=`.
- **`020-field-check-constraints-modified`** — exercises **rename** (explicit `check_name` on `price`), **drop** (`stock` loses its CHECK), and **same-name no-op** (`status` keeps `check_name=`; expression is narrowed but #112's "trust the name" contract suppresses the regen).

## Scenarios

Two new entries in `GetDynamicScenarios`:

- **`dynamic_function_attribute_modification`** — `014 → 018`, reads `pg_proc` directly, asserts the live function body / SECURITY / volatility actually changed in the database, then re-diffs and asserts `FunctionsModified` is empty (idempotent for what this scenario is about).
- **`dynamic_field_check_constraint_evolution`** — `000-initial → 019 → 020`, asserts each CHECK landed by name from `pg_constraint`, then asserts the rename / drop / same-name-no-op transitions, with clean-diff idempotency checks bracketing each step.

`TestGetDynamicScenarios` count bumped 38 → 40.

## Two bugs the new scenarios surfaced (and that this PR also fixes)

1. **PR #123 left the planner side of field-level CHECK synthesis incomplete.** The schemadiff comparator synthesizes a Constraint name into `ConstraintsAdded` when `check=` lands on an existing column, but the planner's `addNewConstraints` only looked the name up in `generated.Constraints` (the explicit table-level list). The synthesized entry was never stored there, so the planner silently dropped it — `ALTER TABLE ADD CONSTRAINT products_price_check` never made it into the migration. Fixture `019` caught this: `stock` and `status` (new columns) got their CHECKs inline via ADD COLUMN, but `price` (existing column) got nothing. Fix: when the constraint name doesn't resolve from `generated.Constraints`, fall back to synthesizing from `generated.Fields`, matching the same `<table>_<column>_check` / explicit `check_name=` naming rule the comparator already uses.

2. **PR #129's `Function` canonicalization stopped short of `Returns` and `Parameters`.** `pg_get_function_result` and `pg_get_function_arguments` both lowercase the type text (and unquoted parameter names), so an annotation written as `returns="VOID" params="x TEXT"` false-diffed against `pg_proc` forever — and would have re-emitted a noisy `parameters, returns` Modify on every run, even when the user changed nothing. `Function.Canonicalize` now lowercases both fields. Existing parser/comparator/integration assertions are updated to expect the canonical lowercase form.

## Known limitation explicitly carved out

The `dynamic_function_attribute_modification` idempotency check is scoped to `FunctionsModified` specifically rather than `HasChanges()` overall. The fixture inherits `NOW()`-style column defaults from `014`, and Ptah's column-diff path is still case-sensitive against `pg_attrdef`'s lowercased function names. That's an adjacent comparator bug unrelated to issue #89; the scenario's comment block points to it explicitly so a future PR knows where to start.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all unit tests pass (parser, comparator, RLS-integration assertions updated for lowercased Returns/Parameters).
- [x] `golangci-lint run --timeout 5m` — clean.
- [x] `POSTGRES_TEST_DSN=… go test -tags=integration -timeout 5m ./integration/...` against a live Postgres 18 — all green.
- [x] `./integration-test --databases=postgres` (the comprehensive scenario runner that GH Actions runs in CI) — **59/59 scenarios pass**, including the two new ones.
- [ ] CI green on push.