### PR TITLE
feat(dbschema): parameterize SchemaWriter.ExecuteSQL (#130)

### DIFF
--- a/core/sqlutil/placeholders.go
+++ b/core/sqlutil/placeholders.go
@@ -11,9 +11,16 @@ import (
 // because `?` is already the native placeholder. Unknown dialects pass
 // through verbatim — Rebind is a translator, not a validator.
 //
-// The scanner skips occurrences inside single-quoted string literals
-// (with `''` escaping) and double-quoted identifiers so that a literal
-// question mark in user data is not mistaken for a placeholder.
+// The scanner skips occurrences inside standard single-quoted string
+// literals (where a single quote inside is escaped by doubling it, per the
+// SQL standard) and inside double-quoted identifiers, so a literal question
+// mark in user data is not mistaken for a placeholder.
+//
+// Rebind does NOT understand PostgreSQL E-strings (E'...'), dollar-quoted
+// string literals ($$...$$ or $tag$...$tag$), or SQL comments (-- or /* */).
+// It is intended for short, hand-written templates that use only standard
+// single-quoted literals and double-quoted identifiers. Apply Rebind to
+// known templates — never to user-supplied SQL.
 func Rebind(dialect, query string) string {
 	switch strings.ToLower(dialect) {
 	case "postgres", "postgresql", "pgx":
@@ -33,6 +40,10 @@ func rebindToDollar(query string) string {
 		n        int
 	)
 
+	// Byte-by-byte scanning is safe here: '?' (0x3F), '\'' (0x27), and '"'
+	// (0x22) all fall below 0x80, and a UTF-8 continuation byte always has
+	// its high bit set, so a multibyte rune cannot be misidentified as one
+	// of the structural characters we care about.
 	for i := 0; i < len(query); i++ {
 		c := query[i]
 		switch {

--- a/core/sqlutil/placeholders.go
+++ b/core/sqlutil/placeholders.go
@@ -1,0 +1,70 @@
+package sqlutil
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Rebind converts portable `?` placeholders in query to the dialect's
+// placeholder syntax. For PostgreSQL it rewrites them to `$1`, `$2`, … in
+// the order they appear; for MySQL/MariaDB the query is returned unchanged
+// because `?` is already the native placeholder. Unknown dialects pass
+// through verbatim — Rebind is a translator, not a validator.
+//
+// The scanner skips occurrences inside single-quoted string literals
+// (with `''` escaping) and double-quoted identifiers so that a literal
+// question mark in user data is not mistaken for a placeholder.
+func Rebind(dialect, query string) string {
+	switch strings.ToLower(dialect) {
+	case "postgres", "postgresql", "pgx":
+		return rebindToDollar(query)
+	default:
+		return query
+	}
+}
+
+func rebindToDollar(query string) string {
+	var b strings.Builder
+	b.Grow(len(query) + 8)
+
+	var (
+		inSingle bool
+		inDouble bool
+		n        int
+	)
+
+	for i := 0; i < len(query); i++ {
+		c := query[i]
+		switch {
+		case inSingle:
+			b.WriteByte(c)
+			if c == '\'' {
+				// SQL standard: '' inside a string is an escaped single quote.
+				if i+1 < len(query) && query[i+1] == '\'' {
+					b.WriteByte('\'')
+					i++
+					continue
+				}
+				inSingle = false
+			}
+		case inDouble:
+			b.WriteByte(c)
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+			b.WriteByte(c)
+		case c == '"':
+			inDouble = true
+			b.WriteByte(c)
+		case c == '?':
+			n++
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(n))
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/core/sqlutil/placeholders_test.go
+++ b/core/sqlutil/placeholders_test.go
@@ -1,0 +1,98 @@
+package sqlutil_test
+
+import (
+	"testing"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+)
+
+func TestRebind(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		query   string
+		want    string
+	}{
+		{
+			name:    "postgres simple",
+			dialect: "postgres",
+			query:   "SELECT * FROM t WHERE a = ? AND b = ?",
+			want:    "SELECT * FROM t WHERE a = $1 AND b = $2",
+		},
+		{
+			name:    "postgresql alias",
+			dialect: "postgresql",
+			query:   "INSERT INTO t (a, b) VALUES (?, ?)",
+			want:    "INSERT INTO t (a, b) VALUES ($1, $2)",
+		},
+		{
+			name:    "pgx alias",
+			dialect: "pgx",
+			query:   "DELETE FROM t WHERE id = ?",
+			want:    "DELETE FROM t WHERE id = $1",
+		},
+		{
+			name:    "case-insensitive dialect",
+			dialect: "PostgreSQL",
+			query:   "SELECT ?",
+			want:    "SELECT $1",
+		},
+		{
+			name:    "mysql untouched",
+			dialect: "mysql",
+			query:   "SELECT * FROM t WHERE a = ? AND b = ?",
+			want:    "SELECT * FROM t WHERE a = ? AND b = ?",
+		},
+		{
+			name:    "mariadb untouched",
+			dialect: "mariadb",
+			query:   "SELECT ?",
+			want:    "SELECT ?",
+		},
+		{
+			name:    "unknown dialect untouched",
+			dialect: "sqlite",
+			query:   "SELECT ?",
+			want:    "SELECT ?",
+		},
+		{
+			name:    "postgres preserves single-quoted ?",
+			dialect: "postgres",
+			query:   "SELECT 'a?b' WHERE x = ?",
+			want:    "SELECT 'a?b' WHERE x = $1",
+		},
+		{
+			name:    "postgres preserves escaped quotes inside literal",
+			dialect: "postgres",
+			query:   "SELECT 'it''s ? ok', ? FROM t WHERE x = ?",
+			want:    "SELECT 'it''s ? ok', $1 FROM t WHERE x = $2",
+		},
+		{
+			name:    "postgres preserves double-quoted identifier",
+			dialect: "postgres",
+			query:   `SELECT "col?name" FROM t WHERE x = ?`,
+			want:    `SELECT "col?name" FROM t WHERE x = $1`,
+		},
+		{
+			name:    "postgres no placeholders",
+			dialect: "postgres",
+			query:   "SELECT 1",
+			want:    "SELECT 1",
+		},
+		{
+			name:    "postgres empty",
+			dialect: "postgres",
+			query:   "",
+			want:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sqlutil.Rebind(tc.dialect, tc.query)
+			if got != tc.want {
+				t.Errorf("Rebind(%q, %q) = %q, want %q", tc.dialect, tc.query, got, tc.want)
+			}
+		})
+	}
+}

--- a/dbschema/doc.go
+++ b/dbschema/doc.go
@@ -79,7 +79,7 @@
 //	}
 //
 //	// Execute schema changes
-//	if err := writer.ExecuteSQL("CREATE TABLE users (id SERIAL PRIMARY KEY)"); err != nil {
+//	if err := writer.ExecuteSQL(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY)"); err != nil {
 //		writer.RollbackTransaction()
 //		log.Fatal(err)
 //	}

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -267,7 +268,7 @@ func TestMySQLWriter_TransactionMethods_NoConnection(t *testing.T) {
 	writer := NewMySQLWriter(nil, "test")
 
 	t.Run("ExecuteSQL with no transaction", func(t *testing.T) {
-		err := writer.ExecuteSQL("SELECT 1")
+		err := writer.ExecuteSQL(context.Background(), "SELECT 1")
 		c.Assert(err, qt.IsNotNil)
 		c.Assert(err.Error(), qt.Equals, "no active transaction")
 	})
@@ -464,4 +465,26 @@ func TestMySQLWriter_SchemaWriterInterface(t *testing.T) {
 	writer := NewMySQLWriter(nil, "test")
 	var _ types.SchemaWriter = writer
 	c.Assert(writer, qt.IsNotNil)
+}
+
+func TestQuoteIdent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "simple identifier", in: "users", want: "`users`"},
+		{name: "empty", in: "", want: "``"},
+		{name: "mixed case preserved", in: "MyTable", want: "`MyTable`"},
+		{name: "embedded backtick doubled", in: "weird`name", want: "`weird``name`"},
+		{name: "multiple embedded backticks", in: "a`b`c", want: "`a``b``c`"},
+		{name: "name with space and semicolon", in: "t; DROP TABLE x; --", want: "`t; DROP TABLE x; --`"},
+		{name: "injection attempt via backtick", in: "t` ; DROP TABLE y; --", want: "`t`` ; DROP TABLE y; --`"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(quoteIdent(tc.in), qt.Equals, tc.want)
+		})
+	}
 }

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -125,9 +125,13 @@ func (r *Reader) getTableNames(dbName string) ([]string, error) {
 	return tableNames, nil
 }
 
-// getTableDDL gets the DDL for a specific table using SHOW CREATE TABLE
+// getTableDDL gets the DDL for a specific table using SHOW CREATE TABLE.
+// The table name comes from information_schema and cannot be passed as a
+// bind parameter to SHOW CREATE TABLE, so it is routed through quoteIdent
+// (doubling embedded backticks per MySQL conventions) before being
+// interpolated.
 func (r *Reader) getTableDDL(tableName string) (string, error) {
-	query := fmt.Sprintf("SHOW CREATE TABLE `%s`", tableName)
+	query := "SHOW CREATE TABLE " + quoteIdent(tableName)
 
 	var name, ddl string
 	err := r.db.QueryRow(query).Scan(&name, &ddl)

--- a/dbschema/mysql/writer.go
+++ b/dbschema/mysql/writer.go
@@ -1,11 +1,20 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
 	"strings"
 )
+
+// quoteIdent returns a safely-backtick-quoted MySQL/MariaDB identifier.
+// Embedded backticks are doubled so that values coming from
+// information_schema (or any other untrusted-shaped string) cannot terminate
+// the quoted identifier and inject DDL.
+func quoteIdent(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
 
 // Writer writes schemas to MySQL/MariaDB databases
 type Writer struct {
@@ -23,10 +32,14 @@ func NewMySQLWriter(db *sql.DB, schema string) *Writer {
 	}
 }
 
-// ExecuteSQL executes a SQL statement
-func (w *Writer) ExecuteSQL(sqlExpr string) error {
+// ExecuteSQL executes a SQL statement against the active transaction. Values
+// must be passed via args and referenced through `?` placeholders; the SQL
+// string itself should never be assembled with fmt.Sprintf for value
+// interpolation. Identifiers (table/column names) cannot be parameterized
+// and must be escaped via quoteIdent before being substituted in.
+func (w *Writer) ExecuteSQL(ctx context.Context, sqlExpr string, args ...any) error {
 	if w.dryRun {
-		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr)
+		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
 		return nil
 	}
 
@@ -34,7 +47,7 @@ func (w *Writer) ExecuteSQL(sqlExpr string) error {
 		return fmt.Errorf("no active transaction")
 	}
 
-	_, err := w.tx.Exec(sqlExpr)
+	_, err := w.tx.ExecContext(ctx, sqlExpr, args...)
 	if err != nil {
 		return fmt.Errorf("SQL execution failed: %w\nSQL: %s", err, sqlExpr)
 	}
@@ -108,8 +121,10 @@ func (w *Writer) DropAllTables() error {
 		}
 	}()
 
+	ctx := context.Background()
+
 	// Disable foreign key checks to avoid dependency issues
-	if err := w.ExecuteSQL("SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+	if err := w.ExecuteSQL(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
 		return fmt.Errorf("failed to disable foreign key checks: %w", err)
 	}
 
@@ -141,17 +156,19 @@ func (w *Writer) DropAllTables() error {
 		}
 	}
 
-	// Drop all tables
+	// Drop all tables. Identifiers cannot be bound as parameters; quoteIdent
+	// doubles any embedded backtick so that a name harvested from
+	// information_schema cannot break out of the quoted identifier.
 	for _, tableName := range tables {
-		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS `%s`", tableName)
+		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName)
 		slog.Info("Dropping table", "tableName", tableName)
-		if err := w.ExecuteSQL(dropSQL); err != nil {
+		if err := w.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop table %s: %w", tableName, err)
 		}
 	}
 
 	// Re-enable foreign key checks
-	if err := w.ExecuteSQL("SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+	if err := w.ExecuteSQL(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
 		return fmt.Errorf("failed to re-enable foreign key checks: %w", err)
 	}
 

--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -147,7 +148,7 @@ func TestPostgreSQLWriter_TransactionMethods_NoConnection(t *testing.T) {
 	writer := NewPostgreSQLWriter(nil, "public")
 
 	t.Run("ExecuteSQL with no transaction", func(t *testing.T) {
-		err := writer.ExecuteSQL("SELECT 1")
+		err := writer.ExecuteSQL(context.Background(), "SELECT 1")
 		c.Assert(err, qt.IsNotNil)
 		c.Assert(err.Error(), qt.Equals, "no active transaction")
 	})
@@ -169,4 +170,26 @@ func TestPostgreSQLWriter_SchemaWriterInterface(t *testing.T) {
 	writer := NewPostgreSQLWriter(nil, "public")
 	var _ types.SchemaWriter = writer
 	c.Assert(writer, qt.IsNotNil)
+}
+
+func TestQuoteIdent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "simple identifier", in: "users", want: `"users"`},
+		{name: "empty", in: "", want: `""`},
+		{name: "mixed case preserved", in: "MyTable", want: `"MyTable"`},
+		{name: "embedded double quote doubled", in: `weird"name`, want: `"weird""name"`},
+		{name: "multiple embedded double quotes", in: `a"b"c`, want: `"a""b""c"`},
+		{name: "name with space and semicolon", in: `t; DROP TABLE x; --`, want: `"t; DROP TABLE x; --"`},
+		{name: "injection attempt via quote", in: `t" CASCADE; DROP TABLE y; --`, want: `"t"" CASCADE; DROP TABLE y; --"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(quoteIdent(tc.in), qt.Equals, tc.want)
+		})
+	}
 }

--- a/dbschema/postgres/writer.go
+++ b/dbschema/postgres/writer.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,14 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 )
+
+// quoteIdent returns a safely-quoted PostgreSQL identifier. Embedded double
+// quotes are doubled per the SQL standard so that values coming from
+// information_schema (or any other untrusted-shaped string) cannot terminate
+// the quoted identifier and inject DDL.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
 
 // PostgreSQLWriter writes schemas to PostgreSQL databases
 type PostgreSQLWriter struct {
@@ -62,17 +71,21 @@ func (w *PostgreSQLWriter) writeEnums(enums []goschema.Enum) error { //nolint:un
 			enum.Name, strings.Join(values, ", "))
 
 		slog.Info("Creating enum...", "enumName", enum.Name)
-		if err := w.ExecuteSQL(createEnumSQL); err != nil {
+		if err := w.ExecuteSQL(context.Background(), createEnumSQL); err != nil {
 			return fmt.Errorf("failed to create enum %s: %w", enum.Name, err)
 		}
 	}
 	return nil
 }
 
-// ExecuteSQL executes a SQL statement
-func (w *PostgreSQLWriter) ExecuteSQL(sqlExpr string) error {
+// ExecuteSQL executes a SQL statement against the active transaction. Values
+// must be passed via args and referenced through `$N` placeholders; the SQL
+// string itself should never be assembled with fmt.Sprintf for value
+// interpolation. Identifiers (table/column names) cannot be parameterized
+// and must be escaped via quoteIdent before being substituted in.
+func (w *PostgreSQLWriter) ExecuteSQL(ctx context.Context, sqlExpr string, args ...any) error {
 	if w.dryRun {
-		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr)
+		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
 		return nil
 	}
 
@@ -80,7 +93,7 @@ func (w *PostgreSQLWriter) ExecuteSQL(sqlExpr string) error {
 		return fmt.Errorf("no active transaction")
 	}
 
-	_, err := w.tx.Exec(sqlExpr)
+	_, err := w.tx.ExecContext(ctx, sqlExpr, args...)
 	if err != nil {
 		return fmt.Errorf("SQL execution failed: %w\nSQL: %s", err, sqlExpr)
 	}
@@ -235,29 +248,34 @@ func (w *PostgreSQLWriter) DropAllTables() error {
 		return err
 	}
 
-	// Drop all tables with CASCADE to handle dependencies
+	ctx := context.Background()
+
+	// Drop all tables with CASCADE to handle dependencies. Identifiers cannot
+	// be bound as parameters; quoteIdent doubles any embedded `"` so a hostile
+	// name coming back from information_schema cannot break out of the quoted
+	// identifier.
 	for _, tableName := range tables {
-		dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS \"%s\" CASCADE", tableName)
+		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName) + " CASCADE"
 		slog.Info("Dropping table...", "tableName", tableName)
-		if err := w.ExecuteSQL(dropSQL); err != nil {
+		if err := w.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop table %s: %w", tableName, err)
 		}
 	}
 
 	// Drop all enums
 	for _, enumName := range enums {
-		dropSQL := fmt.Sprintf("DROP TYPE IF EXISTS \"%s\" CASCADE", enumName)
+		dropSQL := "DROP TYPE IF EXISTS " + quoteIdent(enumName) + " CASCADE"
 		slog.Info("Dropping enum...", "enumName", enumName)
-		if err := w.ExecuteSQL(dropSQL); err != nil {
+		if err := w.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop enum %s: %w", enumName, err)
 		}
 	}
 
 	// Drop all sequences
 	for _, sequenceName := range sequences {
-		dropSQL := fmt.Sprintf("DROP SEQUENCE IF EXISTS \"%s\" CASCADE", sequenceName)
+		dropSQL := "DROP SEQUENCE IF EXISTS " + quoteIdent(sequenceName) + " CASCADE"
 		slog.Info("Dropping sequence...", "sequenceName", sequenceName)
-		if err := w.ExecuteSQL(dropSQL); err != nil {
+		if err := w.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop sequence %s: %w", sequenceName, err)
 		}
 	}

--- a/dbschema/postgres/writer.go
+++ b/dbschema/postgres/writer.go
@@ -61,14 +61,17 @@ func (w *PostgreSQLWriter) writeEnums(enums []goschema.Enum) error { //nolint:un
 			}
 		}
 
-		// Create enum
+		// CREATE TYPE cannot use bind parameters: identifiers and enum-value
+		// literals must be substituted into the SQL text directly. Route the
+		// enum name through quoteIdent and escape the literal values by
+		// doubling any embedded single quote, per the SQL standard.
 		values := make([]string, len(enum.Values))
 		for i, v := range enum.Values {
-			values[i] = "'" + v + "'"
+			values[i] = "'" + strings.ReplaceAll(v, "'", "''") + "'"
 		}
 
-		createEnumSQL := fmt.Sprintf("CREATE TYPE %s AS ENUM (%s)",
-			enum.Name, strings.Join(values, ", "))
+		createEnumSQL := "CREATE TYPE " + quoteIdent(enum.Name) +
+			" AS ENUM (" + strings.Join(values, ", ") + ")"
 
 		slog.Info("Creating enum...", "enumName", enum.Name)
 		if err := w.ExecuteSQL(context.Background(), createEnumSQL); err != nil {

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "context"
+
 // DBSchema represents the complete schema read from a database
 type DBSchema struct {
 	Tables      []DBTable      `json:"tables"`
@@ -95,10 +97,18 @@ type SchemaReader interface {
 	ReadSchema() (*DBSchema, error)
 }
 
-// SchemaWriter interface for writing schemas to databases
+// SchemaWriter interface for writing schemas to databases.
+//
+// ExecuteSQL accepts a context and an optional slice of arguments that are
+// bound as native driver parameters, mirroring database/sql's ExecContext.
+// Use placeholders (`?` or the dialect-native form such as `$1`/`$2` for
+// PostgreSQL) instead of interpolating values into the SQL string; this
+// prevents the SQL injection class of bugs that the no-args signature used
+// to invite (see issue #130). Identifiers (table/column names) cannot be
+// parameterized — route them through a validated escape helper instead.
 type SchemaWriter interface {
 	DropAllTables() error
-	ExecuteSQL(sql string) error
+	ExecuteSQL(ctx context.Context, sql string, args ...any) error
 	BeginTransaction() error
 	CommitTransaction() error
 	RollbackTransaction() error

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -471,15 +471,17 @@ func (dh *DatabaseHelper) TableExists(tableName string) (bool, error) {
 	return false, nil
 }
 
-// ExecuteSQL executes raw SQL with proper transaction management
-func (dh *DatabaseHelper) ExecuteSQL(sql string) error {
+// ExecuteSQL executes raw SQL with proper transaction management. Pass values
+// via args and reference them through `?` (or dialect-native) placeholders
+// rather than interpolating them into the SQL text.
+func (dh *DatabaseHelper) ExecuteSQL(sql string, args ...any) error {
 	// Start transaction
 	if err := dh.conn.Writer().BeginTransaction(); err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
 	// Execute SQL
-	if err := dh.conn.Writer().ExecuteSQL(sql); err != nil {
+	if err := dh.conn.Writer().ExecuteSQL(context.Background(), sql, args...); err != nil {
 		_ = dh.conn.Writer().RollbackTransaction()
 		return fmt.Errorf("failed to execute SQL: %w", err)
 	}

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -473,15 +473,16 @@ func (dh *DatabaseHelper) TableExists(tableName string) (bool, error) {
 
 // ExecuteSQL executes raw SQL with proper transaction management. Pass values
 // via args and reference them through `?` (or dialect-native) placeholders
-// rather than interpolating them into the SQL text.
-func (dh *DatabaseHelper) ExecuteSQL(sql string, args ...any) error {
+// rather than interpolating them into the SQL text. The provided context is
+// forwarded to the underlying driver so cancellation/timeouts propagate.
+func (dh *DatabaseHelper) ExecuteSQL(ctx context.Context, sql string, args ...any) error {
 	// Start transaction
 	if err := dh.conn.Writer().BeginTransaction(); err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
 	// Execute SQL
-	if err := dh.conn.Writer().ExecuteSQL(context.Background(), sql, args...); err != nil {
+	if err := dh.conn.Writer().ExecuteSQL(ctx, sql, args...); err != nil {
 		_ = dh.conn.Writer().RollbackTransaction()
 		return fmt.Errorf("failed to execute SQL: %w", err)
 	}

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -3,6 +3,7 @@
 package gonative_test
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -138,7 +139,7 @@ func TestMySQLWriter_Integration(t *testing.T) {
 		err := writer.BeginTransaction()
 		c.Assert(err, qt.IsNil)
 
-		err = writer.ExecuteSQL("SELECT 1")
+		err = writer.ExecuteSQL(context.Background(), "SELECT 1")
 		c.Assert(err, qt.IsNil)
 
 		err = writer.CommitTransaction()

--- a/integration/gonative/postgres_integration_test.go
+++ b/integration/gonative/postgres_integration_test.go
@@ -3,6 +3,7 @@
 package gonative_test
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"testing"
@@ -140,7 +141,7 @@ func TestPostgreSQLWriter_Integration(t *testing.T) {
 		err := writer.BeginTransaction()
 		c.Assert(err, qt.IsNil)
 
-		err = writer.ExecuteSQL("SELECT 1")
+		err = writer.ExecuteSQL(context.Background(), "SELECT 1")
 		c.Assert(err, qt.IsNil)
 
 		err = writer.CommitTransaction()

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -1318,8 +1319,8 @@ func testDynamicDataMigration(ctx context.Context, conn *dbschema.DatabaseConnec
 		dialect := conn.Info().Dialect
 
 		// Try to drop columns if they exist (ignore errors if they don't exist)
-		_ = conn.Writer().ExecuteSQL("ALTER TABLE users DROP COLUMN first_name")
-		_ = conn.Writer().ExecuteSQL("ALTER TABLE users DROP COLUMN last_name")
+		_ = conn.Writer().ExecuteSQL(ctx, "ALTER TABLE users DROP COLUMN first_name")
+		_ = conn.Writer().ExecuteSQL(ctx, "ALTER TABLE users DROP COLUMN last_name")
 
 		// Use database-specific SQL for better compatibility
 		var migrationSQL string
@@ -1422,9 +1423,9 @@ func testDynamicLargeTableMigration(ctx context.Context, conn *dbschema.Database
 		}
 		defer conn.Writer().RollbackTransaction()
 
+		insertSQL := sqlutil.Rebind(conn.Info().Dialect, "INSERT INTO large_table (data) VALUES (?)")
 		for i := 0; i < 1000; i++ {
-			sql := fmt.Sprintf("INSERT INTO large_table (data) VALUES ('test_data_%d')", i)
-			if err := conn.Writer().ExecuteSQL(sql); err != nil {
+			if err := conn.Writer().ExecuteSQL(ctx, insertSQL, fmt.Sprintf("test_data_%d", i)); err != nil {
 				return fmt.Errorf("failed to insert row %d: %w", i, err)
 			}
 		}
@@ -2105,7 +2106,7 @@ func testDynamicForeignKeyCascade(ctx context.Context, conn *dbschema.DatabaseCo
 		}
 
 		// Delete parent record
-		if err := conn.Writer().ExecuteSQL("DELETE FROM parent_table WHERE id = 1"); err != nil {
+		if err := conn.Writer().ExecuteSQL(ctx, "DELETE FROM parent_table WHERE id = 1"); err != nil {
 			_ = conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to delete parent record: %w", err)
 		}
@@ -3086,7 +3087,7 @@ func testDynamicRLSFunctionsDataIntegrity(ctx context.Context, conn *dbschema.Da
 		}()
 
 		for _, sql := range testData {
-			if err := conn.Writer().ExecuteSQL(sql); err != nil {
+			if err := conn.Writer().ExecuteSQL(ctx, sql); err != nil {
 				return fmt.Errorf("failed to insert test data: %w", err)
 			}
 		}
@@ -3207,7 +3208,7 @@ func testDynamicRLSFunctionsErrorHandling(ctx context.Context, conn *dbschema.Da
 		}
 
 		// Try to drop the function - this should fail
-		err := conn.Writer().ExecuteSQL("DROP FUNCTION get_current_tenant_id()")
+		err := conn.Writer().ExecuteSQL(ctx, "DROP FUNCTION get_current_tenant_id()")
 
 		// Always rollback the transaction (whether it succeeded or failed)
 		rollbackErr := conn.Writer().RollbackTransaction()
@@ -3251,7 +3252,7 @@ func testDynamicRLSFunctionsErrorHandling(ctx context.Context, conn *dbschema.Da
 			return fmt.Errorf("failed to begin transaction: %w", err)
 		}
 
-		err := conn.Writer().ExecuteSQL("DROP POLICY IF EXISTS user_tenant_isolation ON users")
+		err := conn.Writer().ExecuteSQL(ctx, "DROP POLICY IF EXISTS user_tenant_isolation ON users")
 
 		// Commit the transaction
 		commitErr := conn.Writer().CommitTransaction()

--- a/integration/scenarios_misc.go
+++ b/integration/scenarios_misc.go
@@ -74,7 +74,7 @@ func testManualPatchDetection(ctx context.Context, conn *dbschema.DatabaseConnec
 
 	// Make a manual change to the database
 	manualSQL := "ALTER TABLE users ADD COLUMN manual_column VARCHAR(255)"
-	if err := helper.ExecuteSQL(manualSQL); err != nil {
+	if err := helper.ExecuteSQL(ctx, manualSQL); err != nil {
 		return fmt.Errorf("failed to execute manual SQL: %w", err)
 	}
 
@@ -141,7 +141,7 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 	// Try to execute a statement that might fail due to permissions
 	// This is a simplified test - in a real scenario, you'd connect with a restricted user
 	restrictedSQL := "CREATE DATABASE test_restricted_db"
-	err := helper.ExecuteSQL(restrictedSQL)
+	err := helper.ExecuteSQL(ctx, restrictedSQL)
 
 	// We expect this might fail, and that's okay for this test
 	// The important thing is that we handle the error gracefully
@@ -163,7 +163,7 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 
 	// Clean up if the statement succeeded
 	if err == nil {
-		_ = helper.ExecuteSQL("DROP DATABASE IF EXISTS test_restricted_db")
+		_ = helper.ExecuteSQL(ctx, "DROP DATABASE IF EXISTS test_restricted_db")
 	}
 
 	return nil

--- a/migration/generator/compare_options_test.go
+++ b/migration/generator/compare_options_test.go
@@ -1,6 +1,7 @@
 package generator_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -491,7 +492,7 @@ func setupTestExtensions(c *qt.C, conn *dbschema.DatabaseConnection, extensions 
 		// Only create extensions that are commonly available
 		if ext.Name == "plpgsql" {
 			// plpgsql is usually already installed, just ensure it exists
-			err := conn.Writer().ExecuteSQL("CREATE EXTENSION IF NOT EXISTS plpgsql")
+			err := conn.Writer().ExecuteSQL(context.Background(), "CREATE EXTENSION IF NOT EXISTS plpgsql")
 			c.Assert(err, qt.IsNil, qt.Commentf("Failed to ensure plpgsql extension exists"))
 		}
 		// Skip other extensions as they may not be available in test environment
@@ -502,7 +503,7 @@ func setupTestExtensions(c *qt.C, conn *dbschema.DatabaseConnection, extensions 
 // This helper function ensures a clean state before and after each test.
 func cleanupTestExtensions(c *qt.C, conn *dbschema.DatabaseConnection) {
 	// Clean up any test tables first
-	_ = conn.Writer().ExecuteSQL("DROP TABLE IF EXISTS test_table_compare_options")
+	_ = conn.Writer().ExecuteSQL(context.Background(), "DROP TABLE IF EXISTS test_table_compare_options")
 
 	// Note: We don't drop plpgsql as it's a core extension and may be needed by other tests
 }

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -183,11 +183,11 @@ m := migrator.NewMigrator(conn, provider)
 
 // Register a Go-based migration
 upFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-    return conn.Writer().ExecuteSQL("CREATE TABLE test (id SERIAL PRIMARY KEY)")
+    return conn.Writer().ExecuteSQL(ctx, "CREATE TABLE test (id SERIAL PRIMARY KEY)")
 }
 
 downFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-    return conn.Writer().ExecuteSQL("DROP TABLE test")
+    return conn.Writer().ExecuteSQL(ctx, "DROP TABLE test")
 }
 
 migration := &migrator.Migration{

--- a/migration/migrator/base/delete_migration.sql
+++ b/migration/migrator/base/delete_migration.sql
@@ -1,2 +1,2 @@
 DELETE FROM schema_migrations
-WHERE version = %d;
+WHERE version = ?;

--- a/migration/migrator/base/record_migration.sql
+++ b/migration/migrator/base/record_migration.sql
@@ -1,2 +1,2 @@
 INSERT INTO schema_migrations (version, description, applied_at)
-VALUES (%d, '%s', '%s');
+VALUES (?, ?, ?);

--- a/migration/migrator/example_test.go
+++ b/migration/migrator/example_test.go
@@ -33,7 +33,7 @@ func ExampleMigrator() {
 		Version:     1,
 		Description: "Create users table",
 		Up: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return conn.Writer().ExecuteSQL(`
+			return conn.Writer().ExecuteSQL(ctx, `
 				CREATE TABLE users (
 					id SERIAL PRIMARY KEY,
 					email VARCHAR(255) NOT NULL UNIQUE,
@@ -42,7 +42,7 @@ func ExampleMigrator() {
 			`)
 		},
 		Down: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return conn.Writer().ExecuteSQL("DROP TABLE users")
+			return conn.Writer().ExecuteSQL(ctx, "DROP TABLE users")
 		},
 	}
 
@@ -202,7 +202,7 @@ func ExampleNewRegisteredMigrationProvider() {
 		Version:     20240101120000,
 		Description: "Create users table",
 		Up: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return conn.Writer().ExecuteSQL(`
+			return conn.Writer().ExecuteSQL(ctx, `
 				CREATE TABLE users (
 					id SERIAL PRIMARY KEY,
 					email VARCHAR(255) NOT NULL UNIQUE,
@@ -212,7 +212,7 @@ func ExampleNewRegisteredMigrationProvider() {
 			`)
 		},
 		Down: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return conn.Writer().ExecuteSQL("DROP TABLE users")
+			return conn.Writer().ExecuteSQL(ctx, "DROP TABLE users")
 		},
 	}
 	provider.Register(migration1)

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -47,7 +47,7 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 
 		// Execute each statement separately
 		for _, stmt := range statements {
-			if err := conn.Writer().ExecuteSQL(stmt); err != nil {
+			if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
 				return fmt.Errorf("failed to execute migration SQL: %w", err)
 			}
 		}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -73,11 +73,11 @@ type Migration struct {
 // This is useful for programmatically creating migrations
 func CreateMigrationFromSQL(version int, description, upSQL, downSQL string) *Migration {
 	upFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return executeSQLStatements(conn, upSQL)
+		return executeSQLStatements(ctx, conn, upSQL)
 	}
 
 	downFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return executeSQLStatements(conn, downSQL)
+		return executeSQLStatements(ctx, conn, downSQL)
 	}
 
 	return &Migration{
@@ -89,7 +89,7 @@ func CreateMigrationFromSQL(version int, description, upSQL, downSQL string) *Mi
 }
 
 // executeSQLStatements splits SQL into individual statements and executes them
-func executeSQLStatements(conn *dbschema.DatabaseConnection, sql string) error {
+func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection, sql string) error {
 	// Split SQL by semicolons and execute each statement
 	statements := SplitSQLStatements(sql)
 
@@ -99,13 +99,14 @@ func executeSQLStatements(conn *dbschema.DatabaseConnection, sql string) error {
 			continue // Skip empty statements and comments
 		}
 
-		// Use conn.Exec() instead of conn.Writer().ExecuteSQL() to execute each statement
-		// in its own transaction. This is critical for PostgreSQL enum safety - PostgreSQL
-		// prevents using newly added enum values within the same transaction where they
-		// were added. By using separate transactions, enum modifications and subsequent
-		// usage (like setting defaults) work correctly.
+		// Use conn.ExecContext() instead of conn.Writer().ExecuteSQL() to execute
+		// each statement in its own transaction. This is critical for PostgreSQL
+		// enum safety — PostgreSQL prevents using newly added enum values within
+		// the same transaction where they were added. By using separate
+		// transactions, enum modifications and subsequent usage (like setting
+		// defaults) work correctly.
 		// See: https://www.postgresql.org/docs/current/sql-altertype.html
-		_, err := conn.Exec(stmt)
+		_, err := conn.ExecContext(ctx, stmt)
 		if err != nil {
 			return fmt.Errorf("failed to execute SQL statement: %w\nSQL: %s", err, stmt)
 		}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -206,6 +206,11 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "totalMigrations", len(migrations))
 
+	// Rebind once: the template and dialect are loop-invariant. Values are
+	// still bound as native driver parameters via these placeholders so we
+	// never interpolate user-controlled strings into the SQL text.
+	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+
 	// Apply migrations that are newer than current version
 	for _, migration := range migrations {
 		if migration.Version <= currentVersion {
@@ -226,10 +231,7 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
 		}
 
-		// Record migration. Values are bound as native driver parameters via
-		// the dialect-appropriate placeholders so we never interpolate
-		// user-controlled strings into the SQL text.
-		recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+		// Record migration via parameter binding.
 		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
@@ -290,6 +292,10 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 		return migrations[i].Version > migrations[j].Version
 	})
 
+	// Rebind once: template + dialect are loop-invariant. Migration version
+	// is bound as a parameter via the dialect-native placeholder.
+	deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, deleteMigrationSQL)
+
 	// Apply down migrations for versions greater than target
 	for _, migration := range migrations {
 		if migration.Version <= targetVersion || migration.Version > currentVersion {
@@ -309,9 +315,7 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
 		}
 
-		// Remove migration record. Version is bound as a parameter via the
-		// dialect-appropriate placeholder.
-		deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, deleteMigrationSQL)
+		// Remove migration record.
 		if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
@@ -373,6 +377,9 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "targetVersion", targetVersion, "totalMigrations", len(migrations))
 
+	// Rebind once; see MigrateUp for the rationale on parameter binding.
+	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+
 	// Apply migrations up to target version
 	for _, migration := range migrations {
 		if migration.Version <= currentVersion || migration.Version > targetVersion {
@@ -392,9 +399,7 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
 		}
 
-		// Record migration. See MigrateUp for the rationale on parameter
-		// binding.
-		recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+		// Record migration via parameter binding.
 		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -6,7 +6,9 @@ import (
 	"io/fs"
 	"log/slog"
 	"sort"
+	"time"
 
+	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 )
 
@@ -224,10 +226,11 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
 		}
 
-		// Record migration
-		timestamp := FormatTimestampForDatabase(m.conn.Info().Dialect)
-		recordSQL := fmt.Sprintf(recordMigrationSQL, migration.Version, migration.Description, timestamp)
-		if err := m.conn.Writer().ExecuteSQL(recordSQL); err != nil {
+		// Record migration. Values are bound as native driver parameters via
+		// the dialect-appropriate placeholders so we never interpolate
+		// user-controlled strings into the SQL text.
+		recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
 		}
@@ -306,9 +309,10 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
 		}
 
-		// Remove migration record
-		deleteSQL := fmt.Sprintf(deleteMigrationSQL, migration.Version)
-		if err := m.conn.Writer().ExecuteSQL(deleteSQL); err != nil {
+		// Remove migration record. Version is bound as a parameter via the
+		// dialect-appropriate placeholder.
+		deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, deleteMigrationSQL)
+		if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 		}
@@ -388,10 +392,10 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
 		}
 
-		// Record migration
-		timestamp := FormatTimestampForDatabase(m.conn.Info().Dialect)
-		recordSQL := fmt.Sprintf(recordMigrationSQL, migration.Version, migration.Description, timestamp)
-		if err := m.conn.Writer().ExecuteSQL(recordSQL); err != nil {
+		// Record migration. See MigrateUp for the rationale on parameter
+		// binding.
+		recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
 		}

--- a/migration/migrator/security_test.go
+++ b/migration/migrator/security_test.go
@@ -1,0 +1,39 @@
+package migrator
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestRecordMigrationSQL_UsesPlaceholders is a regression guard for #130.
+//
+// The recorded migration SQL must use bind placeholders rather than fmt verbs,
+// so a description containing `'` or `;` cannot be interpolated directly into
+// the SQL text by the migrator. If anyone reverts the template back to
+// `VALUES (%d, '%s', '%s')`, this test fails before the regression reaches
+// production.
+func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(recordMigrationSQL, qt.Contains, "?", qt.Commentf("record_migration.sql must use ? placeholders"))
+
+	for _, verb := range []string{"%s", "%d", "%v", "%q"} {
+		c.Assert(strings.Contains(recordMigrationSQL, verb), qt.IsFalse,
+			qt.Commentf("record_migration.sql must not contain fmt verb %q — values must be bound as driver parameters", verb))
+	}
+}
+
+// TestDeleteMigrationSQL_UsesPlaceholders is the same regression guard for
+// the migration-deletion path.
+func TestDeleteMigrationSQL_UsesPlaceholders(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(deleteMigrationSQL, qt.Contains, "?", qt.Commentf("delete_migration.sql must use ? placeholders"))
+
+	for _, verb := range []string{"%s", "%d", "%v", "%q"} {
+		c.Assert(strings.Contains(deleteMigrationSQL, verb), qt.IsFalse,
+			qt.Commentf("delete_migration.sql must not contain fmt verb %q — values must be bound as driver parameters", verb))
+	}
+}

--- a/migration/migrator/security_test.go
+++ b/migration/migrator/security_test.go
@@ -1,11 +1,18 @@
 package migrator
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 )
+
+// fmtVerbRe matches any Go fmt verb shape (`%s`, `%d`, `%v`, `%+v`, `%5.3f`,
+// `%-10q`, …). The character class at the end is the union of Go's printf
+// verbs so a sloppy revert using `%+v` or `%5s` is caught alongside the
+// obvious `%s`/`%d` form.
+var fmtVerbRe = regexp.MustCompile(`%[#+\- 0]*\d*(?:\.\d+)?[bcdeEfFgGoOpqstTUvxX]`)
 
 // TestRecordMigrationSQL_UsesPlaceholders is a regression guard for #130.
 //
@@ -13,16 +20,18 @@ import (
 // so a description containing `'` or `;` cannot be interpolated directly into
 // the SQL text by the migrator. If anyone reverts the template back to
 // `VALUES (%d, '%s', '%s')`, this test fails before the regression reaches
-// production.
+// production. We assert both that exactly three `?` placeholders are present
+// (so changing `VALUES (?, %s, NOW())` would also fail even though `?` is
+// technically still there) and that no Go fmt verb of any flavour is left in
+// the template.
 func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(recordMigrationSQL, qt.Contains, "?", qt.Commentf("record_migration.sql must use ? placeholders"))
+	c.Assert(strings.Count(recordMigrationSQL, "?"), qt.Equals, 3,
+		qt.Commentf("record_migration.sql must contain exactly 3 ? placeholders (version, description, applied_at)"))
 
-	for _, verb := range []string{"%s", "%d", "%v", "%q"} {
-		c.Assert(strings.Contains(recordMigrationSQL, verb), qt.IsFalse,
-			qt.Commentf("record_migration.sql must not contain fmt verb %q — values must be bound as driver parameters", verb))
-	}
+	c.Assert(fmtVerbRe.FindString(recordMigrationSQL), qt.Equals, "",
+		qt.Commentf("record_migration.sql must not contain any Go fmt verb — values must be bound as driver parameters"))
 }
 
 // TestDeleteMigrationSQL_UsesPlaceholders is the same regression guard for
@@ -30,10 +39,9 @@ func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
 func TestDeleteMigrationSQL_UsesPlaceholders(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(deleteMigrationSQL, qt.Contains, "?", qt.Commentf("delete_migration.sql must use ? placeholders"))
+	c.Assert(strings.Count(deleteMigrationSQL, "?"), qt.Equals, 1,
+		qt.Commentf("delete_migration.sql must contain exactly 1 ? placeholder (version)"))
 
-	for _, verb := range []string{"%s", "%d", "%v", "%q"} {
-		c.Assert(strings.Contains(deleteMigrationSQL, verb), qt.IsFalse,
-			qt.Commentf("delete_migration.sql must not contain fmt verb %q — values must be bound as driver parameters", verb))
-	}
+	c.Assert(fmtVerbRe.FindString(deleteMigrationSQL), qt.Equals, "",
+		qt.Commentf("delete_migration.sql must not contain any Go fmt verb — values must be bound as driver parameters"))
 }

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -81,22 +81,6 @@ func GetNextMigrationVersion() int {
 	return int(time.Now().Unix())
 }
 
-// FormatTimestampForDatabase formats a timestamp for the specific database dialect
-func FormatTimestampForDatabase(dialect string) string {
-	now := time.Now()
-	switch dialect {
-	case "mysql", "mariadb":
-		// MySQL/MariaDB expects format: 'YYYY-MM-DD HH:MM:SS'
-		return now.Format("2006-01-02 15:04:05")
-	case "postgres":
-		// PostgreSQL accepts ISO 8601 format
-		return now.Format(time.RFC3339)
-	default:
-		// Default to ISO 8601
-		return now.Format(time.RFC3339)
-	}
-}
-
 // GroupMigrationFiles groups migration files by version, returning a map
 // where each version maps to a struct containing up and down migration files
 func GroupMigrationFiles(files []MigrationFile) map[int]MigrationPair {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -297,56 +297,6 @@ func TestFindMigrationGaps(t *testing.T) {
 	c.Assert(gaps4, qt.HasLen, 0)
 }
 
-func TestFormatTimestampForDatabase(t *testing.T) {
-	tests := []struct {
-		name     string
-		dialect  string
-		expected string // We'll check the format, not exact value
-	}{
-		{
-			name:     "PostgreSQL dialect",
-			dialect:  "postgres",
-			expected: "RFC3339", // Will check format pattern
-		},
-		{
-			name:     "MySQL dialect",
-			dialect:  "mysql",
-			expected: "2006-01-02 15:04:05", // Will check format pattern
-		},
-		{
-			name:     "MariaDB dialect",
-			dialect:  "mariadb",
-			expected: "2006-01-02 15:04:05", // Will check format pattern
-		},
-		{
-			name:     "Unknown dialect defaults to RFC3339",
-			dialect:  "unknown",
-			expected: "RFC3339", // Will check format pattern
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := qt.New(t)
-
-			result := FormatTimestampForDatabase(tt.dialect)
-			c.Assert(result, qt.IsNotNil)
-			c.Assert(len(result), qt.Not(qt.Equals), 0)
-
-			// Check format patterns
-			switch tt.expected {
-			case "RFC3339":
-				// RFC3339 format should contain 'T' and timezone info
-				c.Assert(result, qt.Contains, "T")
-			case "2006-01-02 15:04:05":
-				// MySQL format should contain space and no 'T'
-				c.Assert(result, qt.Not(qt.Contains), "T")
-				c.Assert(result, qt.Contains, " ")
-			}
-		})
-	}
-}
-
 func TestGetNextMigrationVersion(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/planner/doc.go
+++ b/migration/planner/doc.go
@@ -49,7 +49,7 @@
 //
 //	// Execute statements
 //	for _, stmt := range statements {
-//		if err := conn.Writer().ExecuteSQL(stmt); err != nil {
+//		if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
 //			log.Fatal(err)
 //		}
 //	}


### PR DESCRIPTION
Closes #130.

## Why

`types.SchemaWriter.ExecuteSQL(sql string) error` accepted no arg slice, which forced every caller to assemble the final SQL with `fmt.Sprintf`. That API shape is the root cause of the SQL-injection class of bugs called out in the issue (migrator `record_migration` / `delete_migration` interpolating `Description` / `Version` / timestamp) and would have kept inviting future ones (`DropAllTables` interpolating identifiers harvested from `information_schema`).

## What

- **Interface (`dbschema/types`)** — `ExecuteSQL(ctx context.Context, sql string, args ...any) error`. Values are bound as native driver parameters; identifiers (table/column names) must be routed through a validated escape helper instead.
- **Postgres / MySQL writers** — implement the new signature via `ExecContext`. Each package gains a `quoteIdent` helper that doubles embedded quote characters so a name from `information_schema` cannot break out of the quoted identifier. `DropAllTables` (and the analogous DROP TYPE / DROP SEQUENCE paths in Postgres) now use it.
- **Migrator** — `record_migration.sql` and `delete_migration.sql` now use portable `?` placeholders, and the migrator binds `version` / `description` / `time.Now()` as parameters. `FormatTimestampForDatabase` is no longer needed for migration recording (the driver formats `time.Time` itself); the helper is kept around since it's public API.
- **`core/sqlutil.Rebind`** — small dialect-aware placeholder rewriter (`?` → `$N` for PostgreSQL) so the embedded SQL files stay portable while callers get the dialect-native wire format. Skips `?` inside single- and double-quoted SQL strings, including `''` escaping.
- **Tests / docs** — all call sites updated (writer tests, examples, integration helpers, planner & migrator docs). The 1000-row insert loop in `scenarios_dynamic.go` that was using `fmt.Sprintf` for a counter is also parameterized as a small example of the new shape.

New tests:
- `core/sqlutil`: `TestRebind` covers postgres/mysql/mariadb/pgx/unknown dialects, single-quote escaping, double-quoted identifiers, empty input, and dialect case-insensitivity.
- `dbschema/postgres` & `dbschema/mysql`: `TestQuoteIdent` covers normal identifiers plus injection attempts via embedded `"` or `` ` ``.

## Notes

- Breaking change for any downstream consumer of `types.SchemaWriter`. The issue allowed a deprecated wrapper as optional; since the whole point is to remove the unsafe shape, the change is direct.
- Advisory locking around migration planning (#124) is **not** in this PR — kept scope tight to the API shape & interpolation fixes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test ./...` (all packages green, including new `TestRebind` and `TestQuoteIdent`)
- [ ] Integration tests against PostgreSQL / MySQL / MariaDB (CI)