### PR TITLE
fix(dbschema): add context.Context to ConnectToDatabase (#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,11 +691,14 @@ func main() {
 package main
 
 import (
+    "context"
     "fmt"
+    "time"
+
     "github.com/stokaro/ptah/core/goschema"
-    "github.com/stokaro/ptah/migration/schemadiff"
-    "github.com/stokaro/ptah/migration/planner"
     "github.com/stokaro/ptah/dbschema"
+    "github.com/stokaro/ptah/migration/planner"
+    "github.com/stokaro/ptah/migration/schemadiff"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -489,7 +489,10 @@ func main() {
         OutputDir:     "./migrations",
     }
 
-    files, err := generator.GenerateMigration(opts)
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    files, err := generator.GenerateMigration(ctx, opts)
     if err != nil {
         log.Fatal(err)
     }
@@ -522,18 +525,24 @@ opts := generator.GenerateMigrationOptions{
     OutputDir:     "./migrations",
 }
 
-files, err := generator.GenerateMigration(opts)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+files, err := generator.GenerateMigration(ctx, opts)
 ```
 
 **Using Existing Database Connection:**
 
 ```go
-// Reuse existing connection
-conn, err := dbschema.ConnectToDatabase(dbURL)
+// Reuse existing connection. Supply a context so a stuck host cannot block
+// the initial Ping; defer dbschema.CloseAndWarn so close errors are surfaced.
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+defer cancel()
+conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 if err != nil {
     log.Fatal(err)
 }
-defer conn.Close()
+defer dbschema.CloseAndWarn(conn)
 
 opts := generator.GenerateMigrationOptions{
     GoEntitiesDir: "./models",
@@ -693,13 +702,16 @@ func main() {
         panic(err)
     }
 
-    // Connect to database and read schema
+    // Connect to database and read schema. Supply a context so the initial
+    // Ping cannot block indefinitely on a stuck host.
     dbURL := "postgres://user:pass@localhost:5432/database"
-    conn, err := dbschema.ConnectToDatabase(dbURL)
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
     if err != nil {
         panic(err)
     }
-    defer conn.Close()
+    defer dbschema.CloseAndWarn(conn)
 
     database, err := conn.Reader().ReadSchema()
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -476,8 +476,11 @@ Generate timestamped migration files from schema differences using the migration
 package main
 
 import (
+    "context"
     "fmt"
     "log"
+    "time"
+
     "github.com/stokaro/ptah/migration/generator"
 )
 

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -1,12 +1,14 @@
 package compare
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
@@ -39,6 +41,7 @@ var compareFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewCompareCommand() *cobra.Command {
@@ -70,11 +73,18 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	// 2. Connect to database and read schema
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(compareFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	dbSchema, err := conn.Reader().ReadSchema()
 	if err != nil {

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -84,7 +84,7 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	dbSchema, err := conn.Reader().ReadSchema()
 	if err != nil {

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -78,7 +78,7 @@ func dropAllCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	fmt.Printf("Connected to %s database successfully!\n", conn.Info().Dialect)
 	fmt.Println()

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -2,6 +2,7 @@ package dropall
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 )
 
@@ -39,6 +41,7 @@ var dropAllFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Show what would be executed without making actual changes",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewDropAllCommand() *cobra.Command {
@@ -64,11 +67,18 @@ func dropAllCommand(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 
 	// 1. Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(dropAllFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	fmt.Printf("Connected to %s database successfully!\n", conn.Info().Dialect)
 	fmt.Println()

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -1,12 +1,16 @@
 // Package dbcli holds small helpers shared by the CLI subcommands that connect
-// to a database. Centralising the connect-timeout flag, context construction
-// and the close-error log avoids inconsistent behaviour across commands.
+// to a database. Centralising the connect-timeout flag and context
+// construction keeps behaviour consistent across commands.
+//
+// For the close-with-warning idiom used after a successful Connect, prefer
+// [github.com/stokaro/ptah/dbschema.CloseAndWarn] — it lives next to the
+// DatabaseConnection type so non-CLI consumers (for example the migration
+// generator) can also use it.
 package dbcli
 
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/go-extras/cobraflags"
@@ -46,25 +50,13 @@ func ParseConnectTimeout(raw string) (time.Duration, error) {
 }
 
 // ConnectContext derives a context for the initial database connection from
-// the supplied parent. When timeout is zero, the parent is returned along with
-// a no-op cancel so callers can defer cancel unconditionally.
+// the supplied parent. When timeout is zero or negative, the parent is
+// returned unchanged together with a no-op CancelFunc so callers can `defer
+// cancel()` unconditionally; cancelling the returned function in that case
+// does not affect the parent context.
 func ConnectContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		return parent, func() {}
 	}
 	return context.WithTimeout(parent, timeout)
-}
-
-// WarnOnClose closes the given resource and logs a warning if Close returns an
-// error. It is intended to be used inside a deferred call so that CLI handlers
-// no longer silently discard errors from database connections.
-//
-//	defer dbcli.WarnOnClose("database connection", conn)
-func WarnOnClose(resource string, closer interface{ Close() error }) {
-	if closer == nil {
-		return
-	}
-	if err := closer.Close(); err != nil {
-		slog.Warn("failed to close "+resource, "error", err)
-	}
 }

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -1,0 +1,70 @@
+// Package dbcli holds small helpers shared by the CLI subcommands that connect
+// to a database. Centralising the connect-timeout flag, context construction
+// and the close-error log avoids inconsistent behaviour across commands.
+package dbcli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/go-extras/cobraflags"
+)
+
+// ConnectTimeoutFlagName is the CLI flag name exposed by [NewConnectTimeoutFlag].
+const ConnectTimeoutFlagName = "connect-timeout"
+
+// DefaultConnectTimeout is the default value for [ConnectTimeoutFlagName]. It
+// matches the value suggested by issue #139.
+const DefaultConnectTimeout = 10 * time.Second
+
+// NewConnectTimeoutFlag returns a string-valued flag definition that accepts a
+// [time.Duration] literal (for example "5s" or "2m"). The flag is intentionally
+// a string so a value of "0" disables the timeout, while still supporting the
+// usual duration suffixes.
+func NewConnectTimeoutFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  ConnectTimeoutFlagName,
+		Value: DefaultConnectTimeout.String(),
+		Usage: "Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
+	}
+}
+
+// ParseConnectTimeout parses the raw string value returned by the
+// [ConnectTimeoutFlagName] flag. A zero duration is accepted and signals that
+// callers should not wrap the parent context with a deadline.
+func ParseConnectTimeout(raw string) (time.Duration, error) {
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --%s value %q: %w", ConnectTimeoutFlagName, raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid --%s value %q: must not be negative", ConnectTimeoutFlagName, raw)
+	}
+	return d, nil
+}
+
+// ConnectContext derives a context for the initial database connection from
+// the supplied parent. When timeout is zero, the parent is returned along with
+// a no-op cancel so callers can defer cancel unconditionally.
+func ConnectContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return parent, func() {}
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+// WarnOnClose closes the given resource and logs a warning if Close returns an
+// error. It is intended to be used inside a deferred call so that CLI handlers
+// no longer silently discard errors from database connections.
+//
+//	defer dbcli.WarnOnClose("database connection", conn)
+func WarnOnClose(resource string, closer interface{ Close() error }) {
+	if closer == nil {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		slog.Warn("failed to close "+resource, "error", err)
+	}
+}

--- a/cmd/internal/dbcli/dbcli_test.go
+++ b/cmd/internal/dbcli/dbcli_test.go
@@ -2,7 +2,6 @@ package dbcli_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -46,12 +45,23 @@ func TestParseConnectTimeout(t *testing.T) {
 func TestConnectContext_PositiveTimeout(t *testing.T) {
 	c := qt.New(t)
 	parent := context.Background()
-	ctx, cancel := dbcli.ConnectContext(parent, 50*time.Millisecond)
+
+	const timeout = 250 * time.Millisecond
+	before := time.Now()
+	ctx, cancel := dbcli.ConnectContext(parent, timeout)
 	defer cancel()
 
 	deadline, ok := ctx.Deadline()
 	c.Assert(ok, qt.IsTrue, qt.Commentf("expected a deadline when timeout > 0"))
-	c.Assert(time.Until(deadline) <= 50*time.Millisecond, qt.IsTrue)
+
+	remaining := time.Until(deadline)
+	c.Assert(remaining > 0, qt.IsTrue, qt.Commentf("deadline must be in the future, got %s", remaining))
+	// Deadline = before + timeout (within scheduling jitter). Allow a generous
+	// upper bound so CI's noisy clocks don't flake.
+	c.Assert(deadline.Sub(before) <= timeout+50*time.Millisecond, qt.IsTrue,
+		qt.Commentf("deadline %s exceeds expected %s + slack", deadline.Sub(before), timeout))
+	c.Assert(remaining <= timeout, qt.IsTrue,
+		qt.Commentf("remaining %s exceeds requested timeout %s", remaining, timeout))
 }
 
 func TestConnectContext_ZeroTimeout(t *testing.T) {
@@ -66,25 +76,14 @@ func TestConnectContext_ZeroTimeout(t *testing.T) {
 	c.Assert(ctx, qt.Equals, parent)
 }
 
-// nopCloser is a stub that returns a fixed error from Close so the helper's
-// log path is exercised. We can't easily assert on slog output without a custom
-// handler, so we just verify the helper doesn't panic on either branch.
-type nopCloser struct{ err error }
-
-func (n nopCloser) Close() error { return n.err }
-
-func TestWarnOnClose(t *testing.T) {
+func TestConnectContext_NegativeTimeout(t *testing.T) {
 	c := qt.New(t)
+	parent := context.Background()
+	ctx, cancel := dbcli.ConnectContext(parent, -1*time.Second)
+	defer cancel()
 
-	// Nil closer is a no-op.
-	dbcli.WarnOnClose("nothing", nil)
-
-	// Successful close is silent.
-	dbcli.WarnOnClose("ok", nopCloser{})
-
-	// Failing close logs (and must not panic).
-	dbcli.WarnOnClose("fail", nopCloser{err: errors.New("boom")})
-
-	// If we got here without panicking, the helper behaved correctly.
-	c.Assert(true, qt.IsTrue)
+	// Negative timeouts are treated the same as zero — no deadline imposed.
+	_, ok := ctx.Deadline()
+	c.Assert(ok, qt.IsFalse)
+	c.Assert(ctx, qt.Equals, parent)
 }

--- a/cmd/internal/dbcli/dbcli_test.go
+++ b/cmd/internal/dbcli/dbcli_test.go
@@ -1,0 +1,90 @@
+package dbcli_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+)
+
+func TestParseConnectTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+		errSub  string
+	}{
+		{name: "default value", raw: "10s", want: 10 * time.Second},
+		{name: "zero disables timeout", raw: "0", want: 0},
+		{name: "minutes", raw: "2m", want: 2 * time.Minute},
+		{name: "fractional", raw: "1500ms", want: 1500 * time.Millisecond},
+		{name: "empty", raw: "", wantErr: true, errSub: "invalid --connect-timeout"},
+		{name: "garbage", raw: "soon", wantErr: true, errSub: "invalid --connect-timeout"},
+		{name: "negative", raw: "-1s", wantErr: true, errSub: "must not be negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got, err := dbcli.ParseConnectTimeout(tt.raw)
+			if tt.wantErr {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, tt.errSub)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestConnectContext_PositiveTimeout(t *testing.T) {
+	c := qt.New(t)
+	parent := context.Background()
+	ctx, cancel := dbcli.ConnectContext(parent, 50*time.Millisecond)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, qt.IsTrue, qt.Commentf("expected a deadline when timeout > 0"))
+	c.Assert(time.Until(deadline) <= 50*time.Millisecond, qt.IsTrue)
+}
+
+func TestConnectContext_ZeroTimeout(t *testing.T) {
+	c := qt.New(t)
+	parent := context.Background()
+	ctx, cancel := dbcli.ConnectContext(parent, 0)
+	defer cancel()
+
+	// A zero timeout should not impose a deadline; the parent context is returned.
+	_, ok := ctx.Deadline()
+	c.Assert(ok, qt.IsFalse)
+	c.Assert(ctx, qt.Equals, parent)
+}
+
+// nopCloser is a stub that returns a fixed error from Close so the helper's
+// log path is exercised. We can't easily assert on slog output without a custom
+// handler, so we just verify the helper doesn't panic on either branch.
+type nopCloser struct{ err error }
+
+func (n nopCloser) Close() error { return n.err }
+
+func TestWarnOnClose(t *testing.T) {
+	c := qt.New(t)
+
+	// Nil closer is a no-op.
+	dbcli.WarnOnClose("nothing", nil)
+
+	// Successful close is silent.
+	dbcli.WarnOnClose("ok", nopCloser{})
+
+	// Failing close logs (and must not panic).
+	dbcli.WarnOnClose("fail", nopCloser{err: errors.New("boom")})
+
+	// If we got here without panicking, the helper behaved correctly.
+	c.Assert(true, qt.IsTrue)
+}

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -85,7 +85,7 @@ func migrateCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	dbSchema, err := conn.Reader().ReadSchema()
 	if err != nil {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -1,12 +1,14 @@
 package migrate
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
@@ -40,6 +42,7 @@ var migrateFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewMigrateCommand() *cobra.Command {
@@ -71,11 +74,18 @@ func migrateCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	// 2. Connect to database and read schema
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(migrateFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	dbSchema, err := conn.Reader().ReadSchema()
 	if err != nil {

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -69,6 +70,7 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Skip confirmation prompt (use with caution!)",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewMigrateDownCommand() *cobra.Command {
@@ -100,12 +102,18 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 		fmt.Printf("Connecting to database: %s\n", dbschema.FormatDatabaseURL(dbURL))
 	}
 
-	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(migrateDownFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	// Set dry run mode if requested
 	conn.Writer().SetDryRun(dryRun)

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -113,7 +113,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	// Set dry run mode if requested
 	conn.Writer().SetDryRun(dryRun)

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -45,9 +45,9 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Apply migration first
 	migrationsFS := os.DirFS(tempDir)

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -56,6 +57,7 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Output status in JSON format",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewMigrateStatusCommand() *cobra.Command {
@@ -77,12 +79,18 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("migrations directory is required")
 	}
 
-	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(migrateStatusFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -90,7 +90,7 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -53,6 +54,7 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Enable verbose output",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewMigrateUpCommand() *cobra.Command {
@@ -78,12 +80,18 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 		fmt.Printf("Connecting to database: %s\n", dbschema.FormatDatabaseURL(dbURL))
 	}
 
-	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectTimeout, err := dbcli.ParseConnectTimeout(migrateUpFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	// Set dry run mode if requested
 	conn.Writer().SetDryRun(dryRun)

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -91,7 +91,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	// Set dry run mode if requested
 	conn.Writer().SetDryRun(dryRun)

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -1,12 +1,14 @@
 package readdb
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/convert/dbschematogo"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
@@ -32,6 +34,7 @@ var readDBFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
+	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
 func NewReadDBCommand() *cobra.Command {
@@ -50,8 +53,15 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 	fmt.Println("=== DATABASE SCHEMA ===")
 	fmt.Println()
 
+	connectTimeout, err := dbcli.ParseConnectTimeout(readDBFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
 	// Connect to the database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
 	if err != nil {
 		fmt.Printf("Error connecting to database: %v\n", err)
 		fmt.Println()
@@ -60,9 +70,10 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 		fmt.Println("2. The database server is running")
 		fmt.Println("3. You have the correct permissions")
 		fmt.Println("4. The database exists")
+		fmt.Println("5. The connection completes within --connect-timeout (currently " + connectTimeout.String() + ")")
 		return err
 	}
-	defer conn.Close()
+	defer dbcli.WarnOnClose("database connection", conn)
 
 	fmt.Printf("Connected to %s database successfully!\n", conn.Info().Dialect)
 	fmt.Println()

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -70,10 +70,14 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 		fmt.Println("2. The database server is running")
 		fmt.Println("3. You have the correct permissions")
 		fmt.Println("4. The database exists")
-		fmt.Println("5. The connection completes within --connect-timeout (currently " + connectTimeout.String() + ")")
+		if connectTimeout > 0 {
+			fmt.Printf("5. The connection completes within --connect-timeout (currently %s)\n", connectTimeout)
+		} else {
+			fmt.Println("5. --connect-timeout is disabled; the call will not time out at the application layer")
+		}
 		return err
 	}
-	defer dbcli.WarnOnClose("database connection", conn)
+	defer dbschema.CloseAndWarn(conn)
 
 	fmt.Printf("Connected to %s database successfully!\n", conn.Info().Dialect)
 	fmt.Println()

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"strings"
@@ -161,6 +162,28 @@ func (dc *DatabaseConnection) Close() error {
 		return dc.db.Close()
 	}
 	return nil
+}
+
+// CloseAndWarn closes the connection and logs a warning at slog.LevelWarn if
+// Close returns an error. It is intended for `defer` use in CLI handlers and
+// library code that does not have a natural error channel for cleanup
+// failures, so that close errors are surfaced rather than silently dropped.
+//
+// Calling CloseAndWarn on a nil *DatabaseConnection is a no-op, allowing the
+// idiom:
+//
+//	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+//	if err != nil {
+//	    return err
+//	}
+//	defer dbschema.CloseAndWarn(conn)
+func CloseAndWarn(conn *DatabaseConnection) {
+	if conn == nil {
+		return
+	}
+	if err := conn.Close(); err != nil {
+		slog.Warn("failed to close database connection", "error", err)
+	}
 }
 
 // FormatDatabaseURL formats a database URL for display (hiding password)

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -15,8 +15,15 @@ import (
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
-// ConnectToDatabase creates a database connection from a URL
-func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
+// ConnectToDatabase creates a database connection from a URL.
+//
+// The provided context governs the initial Ping used to verify the connection
+// and the metadata queries issued to populate [DBInfo]. Cancelling the context
+// before or during the call causes ConnectToDatabase to return promptly with
+// the context error wrapped in a descriptive message. The context does not
+// affect the lifetime of the returned *DatabaseConnection; callers are
+// responsible for closing it.
+func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, error) {
 	// Handle MySQL URLs specially since they have a different format
 	var parsedURL *url.URL
 	var err error
@@ -63,16 +70,17 @@ func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
 
-	// Test the connection
-	if err := db.Ping(); err != nil {
-		db.Close()
+	// Test the connection — honour the caller-supplied context so a stuck or
+	// slow host cannot block ConnectToDatabase indefinitely.
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
 	// Get database info
-	info, err := getDatabaseInfo(db, dialect, parsedURL, dbURL)
+	info, err := getDatabaseInfo(ctx, db, dialect, parsedURL, dbURL)
 	if err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("failed to get database info: %w", err)
 	}
 
@@ -87,7 +95,7 @@ func ConnectToDatabase(dbURL string) (*DatabaseConnection, error) {
 		reader = mysql.NewMySQLReader(db, info.Schema)
 		writer = mysql.NewMySQLWriter(db, info.Schema)
 	default:
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("no schema reader available for dialect: %s", dialect)
 	}
 
@@ -191,7 +199,7 @@ func FormatDatabaseURL(dbURL string) string {
 }
 
 // getDatabaseInfo retrieves database metadata
-func getDatabaseInfo(db *sql.DB, dialect string, parsedURL *url.URL, originalURL string) (types.DBInfo, error) {
+func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL *url.URL, originalURL string) (types.DBInfo, error) {
 	info := types.DBInfo{
 		Dialect: dialect,
 		URL:     originalURL,
@@ -201,7 +209,7 @@ func getDatabaseInfo(db *sql.DB, dialect string, parsedURL *url.URL, originalURL
 	case "postgres":
 		// Get PostgreSQL version
 		var version string
-		err := db.QueryRow("SELECT version()").Scan(&version)
+		err := db.QueryRowContext(ctx, "SELECT version()").Scan(&version)
 		if err != nil {
 			return info, fmt.Errorf("failed to get PostgreSQL version: %w", err)
 		}
@@ -219,7 +227,7 @@ func getDatabaseInfo(db *sql.DB, dialect string, parsedURL *url.URL, originalURL
 	case "mysql", "mariadb":
 		// Get MySQL/MariaDB version
 		var version string
-		err := db.QueryRow("SELECT VERSION()").Scan(&version)
+		err := db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version)
 		if err != nil {
 			return info, fmt.Errorf("failed to get MySQL/MariaDB version: %w", err)
 		}
@@ -231,7 +239,7 @@ func getDatabaseInfo(db *sql.DB, dialect string, parsedURL *url.URL, originalURL
 		} else {
 			// Get current database
 			var dbName string
-			err := db.QueryRow("SELECT DATABASE()").Scan(&dbName)
+			err := db.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&dbName)
 			if err != nil {
 				return info, fmt.Errorf("failed to get current database name: %w", err)
 			}

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -1,7 +1,10 @@
 package dbschema_test
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -71,7 +74,7 @@ func TestConnectToDatabase_InvalidURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			conn, err := dbschema.ConnectToDatabase(tt.dbURL)
+			conn, err := dbschema.ConnectToDatabase(context.Background(), tt.dbURL)
 			c.Assert(err, qt.ErrorMatches, ".*"+tt.errMsg+".*")
 			c.Assert(conn, qt.IsNil)
 		})
@@ -94,7 +97,7 @@ func TestConnectToDatabase_UnsupportedDialects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			conn, err := dbschema.ConnectToDatabase(tt.dbURL)
+			conn, err := dbschema.ConnectToDatabase(context.Background(), tt.dbURL)
 			c.Assert(err, qt.ErrorMatches, ".*"+tt.expected+".*")
 			c.Assert(conn, qt.IsNil)
 		})
@@ -107,7 +110,7 @@ func TestPostgreSQLConnection_NoServer(t *testing.T) {
 
 	// This test expects to fail since we don't have a PostgreSQL server running
 	// It's mainly to test that the connection logic works correctly
-	conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost:5432/testdb")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "postgres://user:pass@localhost:5432/testdb")
 
 	// We expect an error because no PostgreSQL server is running
 	c.Assert(err, qt.IsNotNil)
@@ -116,4 +119,60 @@ func TestPostgreSQLConnection_NoServer(t *testing.T) {
 	// The error should be about connection failure, not about invalid URL or unsupported dialect
 	c.Assert(err.Error(), qt.Not(qt.Contains), "unsupported database dialect")
 	c.Assert(err.Error(), qt.Not(qt.Contains), "invalid database URL")
+}
+
+// TestConnectToDatabase_CancelledContext is the acceptance test for issue #139.
+// It points ConnectToDatabase at a routable but quiet TCP endpoint, which would
+// otherwise block on the initial Ping indefinitely. A pre-cancelled context
+// must short-circuit the call so that ConnectToDatabase returns promptly with
+// context.Canceled.
+func TestConnectToDatabase_CancelledContext(t *testing.T) {
+	c := qt.New(t)
+
+	// The TEST-NET-1 block (192.0.2.0/24) is reserved for documentation and
+	// never routes anywhere — connections sit until the TCP timeout. Pairing
+	// it with a port the kernel will silently drop makes for a reliable "slow
+	// host" surrogate that doesn't depend on the local environment.
+	const stuckURL = "postgres://user:pass@192.0.2.1:65535/db"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before the call to guarantee the ping never starts.
+
+	start := time.Now()
+	conn, err := dbschema.ConnectToDatabase(ctx, stuckURL)
+	elapsed := time.Since(start)
+
+	c.Assert(conn, qt.IsNil)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, context.Canceled), qt.IsTrue,
+		qt.Commentf("expected context.Canceled in error chain, got: %v", err))
+
+	// "Promptly" is intentionally loose to avoid flakiness on slow CI runners,
+	// but well below the 30-60s TCP timeout that the bug describes.
+	c.Assert(elapsed < 2*time.Second, qt.IsTrue,
+		qt.Commentf("ConnectToDatabase took %s with a cancelled context, want <2s", elapsed))
+}
+
+// TestConnectToDatabase_DeadlineExceeded covers the typical --connect-timeout
+// case: a context that expires while the connection attempt is pending must
+// surface context.DeadlineExceeded instead of hanging.
+func TestConnectToDatabase_DeadlineExceeded(t *testing.T) {
+	c := qt.New(t)
+
+	const stuckURL = "postgres://user:pass@192.0.2.1:65535/db"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := dbschema.ConnectToDatabase(ctx, stuckURL)
+	elapsed := time.Since(start)
+
+	c.Assert(conn, qt.IsNil)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, context.DeadlineExceeded), qt.IsTrue,
+		qt.Commentf("expected context.DeadlineExceeded in error chain, got: %v", err))
+
+	c.Assert(elapsed < 5*time.Second, qt.IsTrue,
+		qt.Commentf("ConnectToDatabase took %s with a 100ms deadline, want <5s", elapsed))
 }

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -3,6 +3,8 @@ package dbschema_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -121,25 +123,61 @@ func TestPostgreSQLConnection_NoServer(t *testing.T) {
 	c.Assert(err.Error(), qt.Not(qt.Contains), "invalid database URL")
 }
 
+// stuckPostgresURL spins up a local TCP listener that completes the TCP
+// handshake but never reads from the socket, so the PostgreSQL protocol
+// handshake stalls indefinitely. This is the most portable way to simulate
+// "host accepts but never answers" without depending on routing tables or
+// reserved IP blocks (those behave differently on offline/restricted hosts).
+//
+// The listener and a sentinel "drainer" goroutine are wired to a cancellable
+// context so the test can guarantee the goroutine exits even if the call
+// under test races ahead.
+func stuckPostgresURL(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	stop := make(chan struct{})
+	go func() {
+		// Accept and hold connections until the test ends. Holding the conn
+		// stops the kernel from sending an RST, so the Postgres handshake
+		// hangs waiting for server bytes instead of failing fast.
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				<-stop
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	t.Cleanup(func() {
+		close(stop)
+		_ = ln.Close()
+	})
+
+	return fmt.Sprintf("postgres://user:pass@%s/db", ln.Addr())
+}
+
 // TestConnectToDatabase_CancelledContext is the acceptance test for issue #139.
-// It points ConnectToDatabase at a routable but quiet TCP endpoint, which would
-// otherwise block on the initial Ping indefinitely. A pre-cancelled context
-// must short-circuit the call so that ConnectToDatabase returns promptly with
-// context.Canceled.
+// A pre-cancelled context must short-circuit the call so that
+// ConnectToDatabase returns promptly with context.Canceled.
 func TestConnectToDatabase_CancelledContext(t *testing.T) {
 	c := qt.New(t)
 
-	// The TEST-NET-1 block (192.0.2.0/24) is reserved for documentation and
-	// never routes anywhere — connections sit until the TCP timeout. Pairing
-	// it with a port the kernel will silently drop makes for a reliable "slow
-	// host" surrogate that doesn't depend on the local environment.
-	const stuckURL = "postgres://user:pass@192.0.2.1:65535/db"
+	dbURL := stuckPostgresURL(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel before the call to guarantee the ping never starts.
 
 	start := time.Now()
-	conn, err := dbschema.ConnectToDatabase(ctx, stuckURL)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	elapsed := time.Since(start)
 
 	c.Assert(conn, qt.IsNil)
@@ -148,7 +186,7 @@ func TestConnectToDatabase_CancelledContext(t *testing.T) {
 		qt.Commentf("expected context.Canceled in error chain, got: %v", err))
 
 	// "Promptly" is intentionally loose to avoid flakiness on slow CI runners,
-	// but well below the 30-60s TCP timeout that the bug describes.
+	// but well below the multi-second TCP timeout the bug describes.
 	c.Assert(elapsed < 2*time.Second, qt.IsTrue,
 		qt.Commentf("ConnectToDatabase took %s with a cancelled context, want <2s", elapsed))
 }
@@ -159,13 +197,13 @@ func TestConnectToDatabase_CancelledContext(t *testing.T) {
 func TestConnectToDatabase_DeadlineExceeded(t *testing.T) {
 	c := qt.New(t)
 
-	const stuckURL = "postgres://user:pass@192.0.2.1:65535/db"
+	dbURL := stuckPostgresURL(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	start := time.Now()
-	conn, err := dbschema.ConnectToDatabase(ctx, stuckURL)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	elapsed := time.Since(start)
 
 	c.Assert(conn, qt.IsNil)
@@ -173,6 +211,8 @@ func TestConnectToDatabase_DeadlineExceeded(t *testing.T) {
 	c.Assert(errors.Is(err, context.DeadlineExceeded), qt.IsTrue,
 		qt.Commentf("expected context.DeadlineExceeded in error chain, got: %v", err))
 
+	// Generous upper bound — the deadline is 200ms; allow for handshake +
+	// scheduling slack without flaking on slow CI runners.
 	c.Assert(elapsed < 5*time.Second, qt.IsTrue,
-		qt.Commentf("ConnectToDatabase took %s with a 100ms deadline, want <5s", elapsed))
+		qt.Commentf("ConnectToDatabase took %s with a 200ms deadline, want <5s", elapsed))
 }

--- a/dbschema/doc.go
+++ b/dbschema/doc.go
@@ -41,14 +41,17 @@
 //
 // Database connections are established using standard database URLs:
 //
+//	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+//	defer cancel()
+//
 //	// PostgreSQL
-//	conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost:5432/database")
+//	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost:5432/database")
 //
 //	// MySQL
-//	conn, err := dbschema.ConnectToDatabase("mysql://user:pass@tcp(localhost:3306)/database")
+//	conn, err := dbschema.ConnectToDatabase(ctx, "mysql://user:pass@tcp(localhost:3306)/database")
 //
 //	// MariaDB
-//	conn, err := dbschema.ConnectToDatabase("mariadb://user:pass@tcp(localhost:3307)/database")
+//	conn, err := dbschema.ConnectToDatabase(ctx, "mariadb://user:pass@tcp(localhost:3307)/database")
 //
 // # Schema Reading
 //

--- a/docs/postgresql_extension_ignore.md
+++ b/docs/postgresql_extension_ignore.md
@@ -39,12 +39,15 @@ func main() {
         panic(err)
     }
 
-    // Connect to database and read current schema
-    conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+    // Connect to database and read current schema. Supply a context so the
+    // initial Ping cannot block indefinitely on a stuck host.
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
     if err != nil {
         panic(err)
     }
-    defer conn.Close()
+    defer dbschema.CloseAndWarn(conn)
 
     database, err := conn.ReadSchema()
     if err != nil {
@@ -170,7 +173,10 @@ opts := generator.GenerateMigrationOptions{
     // Extension ignore options will be supported in future versions
 }
 
-files, err := generator.GenerateMigration(opts)
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+files, err := generator.GenerateMigration(ctx, opts)
 ```
 
 ## Common Extensions to Ignore

--- a/docs/postgresql_extension_ignore.md
+++ b/docs/postgresql_extension_ignore.md
@@ -166,7 +166,12 @@ diff := schemadiff.CompareWithOptions(generated, database, opts)
 The ignore functionality automatically integrates with migration generation:
 
 ```go
-import "github.com/stokaro/ptah/migration/generator"
+import (
+    "context"
+    "time"
+
+    "github.com/stokaro/ptah/migration/generator"
+)
 
 // Generate migration with custom extension ignore options
 opts := generator.GenerateMigrationOptions{

--- a/docs/postgresql_extension_ignore.md
+++ b/docs/postgresql_extension_ignore.md
@@ -27,6 +27,10 @@ When an extension is ignored:
 package main
 
 import (
+    "context"
+    "fmt"
+    "time"
+
     "github.com/stokaro/ptah/core/goschema"
     "github.com/stokaro/ptah/dbschema"
     "github.com/stokaro/ptah/migration/schemadiff"

--- a/examples/extension_ignore/main.go
+++ b/examples/extension_ignore/main.go
@@ -11,12 +11,14 @@
 //		log.Fatalf("Failed to parse Go entities: %v", err)
 //	}
 //
-//	// Connect to database (supply a context so the call can be cancelled)
+//	// Connect to database (supply a context so the call can be cancelled).
+//	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+//	defer cancel()
 //	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
 //	if err != nil {
 //		log.Fatalf("Failed to connect to database: %v", err)
 //	}
-//	defer conn.Close()
+//	defer dbschema.CloseAndWarn(conn)
 //
 //	database, err := conn.ReadSchema()
 //	if err != nil {

--- a/examples/extension_ignore/main.go
+++ b/examples/extension_ignore/main.go
@@ -11,8 +11,8 @@
 //		log.Fatalf("Failed to parse Go entities: %v", err)
 //	}
 //
-//	// Connect to database
-//	conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+//	// Connect to database (supply a context so the call can be cancelled)
+//	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
 //	if err != nil {
 //		log.Fatalf("Failed to connect to database: %v", err)
 //	}
@@ -40,7 +40,7 @@
 //	diff := schemadiff.CompareWithOptions(generated, database, opts)
 //
 //	// Generate migrations based on the differences
-//	files, err := generator.GenerateMigration(generator.GenerateMigrationOptions{
+//	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
 //		GoEntitiesDir: "./models",
 //		DatabaseURL:   "postgres://user:pass@localhost/db",
 //		MigrationName: "update_extensions",

--- a/integration/dynamic_test.go
+++ b/integration/dynamic_test.go
@@ -89,9 +89,9 @@ func TestDynamicScenariosBasic(t *testing.T) {
 	ctx := context.Background()
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Clean database
 	err = conn.Writer().DropAllTables()

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -163,14 +163,23 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 	}
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	if err != nil {
 		result.Success = false
 		result.Error = fmt.Sprintf("Failed to connect to database: %v", err)
 		result.Duration = time.Since(start)
 		return result
 	}
-	defer conn.Close()
+	defer func() {
+		if cerr := conn.Close(); cerr != nil {
+			// Surface close failures in the test result so a leaked connection
+			// doesn't pass silently. The scenario error (if any) takes priority.
+			if result.Success {
+				result.Success = false
+				result.Error = fmt.Sprintf("Failed to close database connection: %v", cerr)
+			}
+		}
+	}()
 
 	// Clean database before test
 	if err := tr.cleanDatabase(ctx, conn); err != nil {

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -152,11 +152,15 @@ func (tr *TestRunner) RunAll(ctx context.Context) error {
 	return nil
 }
 
-// runSingleTest executes a single test scenario against a specific database
-func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, dbName, dbURL string) TestResult {
+// runSingleTest executes a single test scenario against a specific database.
+//
+// The return value is named so the deferred Close handler can promote a
+// connection-close failure into a test failure when the scenario itself
+// succeeded — otherwise the close error would be silently lost.
+func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, dbName, dbURL string) (result TestResult) {
 	start := time.Now()
 
-	result := TestResult{
+	result = TestResult{
 		Name:        fmt.Sprintf("%s_%s", scenario.Name, dbName),
 		Database:    dbName,
 		Description: scenario.Description,
@@ -171,13 +175,9 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 		return result
 	}
 	defer func() {
-		if cerr := conn.Close(); cerr != nil {
-			// Surface close failures in the test result so a leaked connection
-			// doesn't pass silently. The scenario error (if any) takes priority.
-			if result.Success {
-				result.Success = false
-				result.Error = fmt.Sprintf("Failed to close database connection: %v", cerr)
-			}
+		if cerr := conn.Close(); cerr != nil && result.Success {
+			result.Success = false
+			result.Error = fmt.Sprintf("Failed to close database connection: %v", cerr)
 		}
 	}()
 

--- a/integration/gonative/driver_validation_test.go
+++ b/integration/gonative/driver_validation_test.go
@@ -47,9 +47,9 @@ func TestPgxDriverValidation(t *testing.T) {
 		c := qt.New(t)
 
 		// Test that dbschema.ConnectToDatabase uses pgx for PostgreSQL URLs
-		conn, err := dbschema.ConnectToDatabase(dsn)
+		conn, err := dbschema.ConnectToDatabase(t.Context(), dsn)
 		c.Assert(err, qt.IsNil)
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		// Test that we can query the database through the connection
 		var version string
@@ -116,9 +116,9 @@ func TestPgxDriverValidation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				c := qt.New(t)
 
-				conn, err := dbschema.ConnectToDatabase(tc.dsn)
+				conn, err := dbschema.ConnectToDatabase(t.Context(), tc.dsn)
 				c.Assert(err, qt.IsNil)
-				defer conn.Close()
+				defer func() { _ = conn.Close() }()
 
 				// Test that we can query the database
 				var version string

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 
@@ -221,17 +222,25 @@ func testConcurrencyParallelMigrate(ctx context.Context, conn *dbschema.Database
 	}
 
 	// Create two separate connections for parallel execution
-	conn1, err := dbschema.ConnectToDatabase(conn.Info().URL)
+	conn1, err := dbschema.ConnectToDatabase(ctx, conn.Info().URL)
 	if err != nil {
 		return fmt.Errorf("failed to create first connection: %w", err)
 	}
-	defer conn1.Close()
+	defer func() {
+		if cerr := conn1.Close(); cerr != nil {
+			slog.Warn("failed to close first parallel connection", "error", cerr)
+		}
+	}()
 
-	conn2, err := dbschema.ConnectToDatabase(conn.Info().URL)
+	conn2, err := dbschema.ConnectToDatabase(ctx, conn.Info().URL)
 	if err != nil {
 		return fmt.Errorf("failed to create second connection: %w", err)
 	}
-	defer conn2.Close()
+	defer func() {
+		if cerr := conn2.Close(); cerr != nil {
+			slog.Warn("failed to close second parallel connection", "error", cerr)
+		}
+	}()
 
 	// Use channels to collect results from goroutines (race-safe)
 	const numParallelMigrations = 2
@@ -345,7 +354,7 @@ func testMigrationGeneratorValidation(ctx context.Context, conn *dbschema.Databa
 			return err
 		}
 
-		_, err := generator.GenerateMigration(generator.GenerateMigrationOptions{
+		_, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
 			GoEntitiesDir: vem.GetEntitiesDir(),
 			DBConn:        conn,
 			OutputDir:     migrationsDir,
@@ -379,7 +388,7 @@ func testMigrationGeneratorValidation(ctx context.Context, conn *dbschema.Databa
 			return err
 		}
 
-		_, err = generator.GenerateMigration(generator.GenerateMigrationOptions{
+		_, err = generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
 			GoEntitiesDir: vem.GetEntitiesDir(),
 			DBConn:        conn,
 			OutputDir:     migrationsDir,
@@ -412,7 +421,7 @@ func testMigrationGeneratorValidation(ctx context.Context, conn *dbschema.Databa
 		if err := vem.LoadEntityVersion("002-add-posts"); err != nil {
 			return err
 		}
-		_, err = generator.GenerateMigration(generator.GenerateMigrationOptions{
+		_, err = generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
 			GoEntitiesDir: vem.GetEntitiesDir(),
 			DBConn:        conn,
 			OutputDir:     migrationsDir,

--- a/integration/scenarios_advanced_test.go
+++ b/integration/scenarios_advanced_test.go
@@ -20,16 +20,16 @@ func TestMigrationGeneratorValidation(t *testing.T) {
 	}
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
 	err = conn.Writer().DropAllTables()
 	c.Assert(err, qt.IsNil)
 
 	// Run the migration generator validation test
-	ctx := context.Background()
 	recorder := &StepRecorder{}
 	err = testMigrationGeneratorValidation(ctx, conn, testFixtures, recorder)
 	c.Assert(err, qt.IsNil)
@@ -46,9 +46,10 @@ func TestValidateSchemaConsistency(t *testing.T) {
 	}
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
 	err = conn.Writer().DropAllTables()
@@ -60,7 +61,6 @@ func TestValidateSchemaConsistency(t *testing.T) {
 	defer vem.Cleanup()
 
 	// Apply initial migration
-	ctx := context.Background()
 	err = vem.MigrateToVersion(ctx, conn, "000-initial", "Create initial tables")
 	c.Assert(err, qt.IsNil)
 
@@ -80,16 +80,16 @@ func TestValidateEmptySchema(t *testing.T) {
 	}
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
 	err = conn.Writer().DropAllTables()
 	c.Assert(err, qt.IsNil)
 
 	// Validate empty schema - should pass
-	ctx := context.Background()
 	err = validateEmptySchema(ctx, conn)
 	c.Assert(err, qt.IsNil)
 

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"time"
 
 	"github.com/stokaro/ptah/core/goschema"
@@ -1132,11 +1133,15 @@ func testDynamicConcurrentMigrations(ctx context.Context, conn *dbschema.Databas
 
 	return recorder.RecordStep("Test Concurrent Migration Attempts", "Simulate concurrent migration attempts", func() error {
 		// Create two separate database connections to simulate concurrency
-		conn2, err := dbschema.ConnectToDatabase(conn.Info().URL)
+		conn2, err := dbschema.ConnectToDatabase(ctx, conn.Info().URL)
 		if err != nil {
 			return fmt.Errorf("failed to create second connection: %w", err)
 		}
-		defer conn2.Close()
+		defer func() {
+			if cerr := conn2.Close(); cerr != nil {
+				slog.Warn("failed to close concurrent migration connection", "error", cerr)
+			}
+		}()
 
 		// Create channels for synchronization
 		startCh := make(chan struct{})

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -18,9 +18,11 @@ The migration generator package provides functionality to automatically generate
 package main
 
 import (
+    "context"
     "fmt"
     "log"
-    
+    "time"
+
     "github.com/stokaro/ptah/migration/generator"
 )
 
@@ -32,7 +34,11 @@ func main() {
         OutputDir:     "./migrations",         // Directory to save migration files
     }
 
-    files, err := generator.GenerateMigration(opts)
+    // Bound the initial database connection so a stuck host fails fast.
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    files, err := generator.GenerateMigration(ctx, opts)
     if err != nil {
         log.Fatal(err)
     }

--- a/migration/generator/compare_options_test.go
+++ b/migration/generator/compare_options_test.go
@@ -233,7 +233,7 @@ func TestGenerateMigration_CompareOptions_Integration_NilOptions(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Create database connection and set up test extensions
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to connect to database: %v", err))
 	defer conn.Close()
 
@@ -254,7 +254,7 @@ func TestGenerateMigration_CompareOptions_Integration_NilOptions(t *testing.T) {
 		CompareOptions: nil,
 	}
 
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNil, qt.Commentf("Migration generation failed: %v", err))
 
 	// With nil options, plpgsql should be ignored, so no migration should be generated
@@ -292,7 +292,7 @@ func TestGenerateMigration_CompareOptions_Integration_CustomIgnoreList(t *testin
 	c.Assert(err, qt.IsNil)
 
 	// Create database connection
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to connect to database: %v", err))
 	defer conn.Close()
 
@@ -308,7 +308,7 @@ func TestGenerateMigration_CompareOptions_Integration_CustomIgnoreList(t *testin
 		CompareOptions: config.WithIgnoredExtensions("plpgsql", "adminpack"),
 	}
 
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNil, qt.Commentf("Migration generation failed: %v", err))
 
 	// With custom options ignoring adminpack, no migration should be generated
@@ -346,7 +346,7 @@ func TestGenerateMigration_CompareOptions_Integration_NoIgnoredExtensions(t *tes
 	c.Assert(err, qt.IsNil)
 
 	// Create database connection and set up test extensions
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to connect to database: %v", err))
 	defer conn.Close()
 
@@ -367,7 +367,7 @@ func TestGenerateMigration_CompareOptions_Integration_NoIgnoredExtensions(t *tes
 		CompareOptions: config.WithIgnoredExtensions(),
 	}
 
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNil, qt.Commentf("Migration generation failed: %v", err))
 
 	// With no ignored extensions, plpgsql should be managed and migration should be generated
@@ -416,7 +416,7 @@ func TestGenerateMigration_CompareOptions_Integration_AddExtension(t *testing.T)
 	c.Assert(err, qt.IsNil)
 
 	// Create database connection and set up test extensions
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	c.Assert(err, qt.IsNil, qt.Commentf("Failed to connect to database: %v", err))
 	defer conn.Close()
 
@@ -437,7 +437,7 @@ func TestGenerateMigration_CompareOptions_Integration_AddExtension(t *testing.T)
 		CompareOptions: config.WithIgnoredExtensions("plpgsql"),
 	}
 
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNil, qt.Commentf("Migration generation failed: %v", err))
 
 	// Migration should be generated to add pg_trgm
@@ -546,7 +546,7 @@ type TestTable struct {
 	}
 
 	// This should fail due to memory database limitations, but not due to CompareOptions
-	_, err = generator.GenerateMigration(opts)
+	_, err = generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNotNil)
 
 	// Verify that the error is not related to CompareOptions
@@ -593,7 +593,7 @@ type TestTable struct {
 	}
 
 	// This should fail due to memory database limitations, but not due to CompareOptions
-	_, err = generator.GenerateMigration(opts)
+	_, err = generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNotNil)
 
 	// Verify that the error is not related to CompareOptions

--- a/migration/generator/doc.go
+++ b/migration/generator/doc.go
@@ -49,7 +49,10 @@
 //		OutputDir:     "./migrations",
 //	}
 //
-//	files, err := generator.GenerateMigration(opts)
+//	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+//	defer cancel()
+//
+//	files, err := generator.GenerateMigration(ctx, opts)
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/migration/generator/example/main.go
+++ b/migration/generator/example/main.go
@@ -53,6 +53,10 @@ func main() {
 	// Bound the initial database connection so a stuck host fails fast.
 	// The schema-reading work inside GenerateMigration is not yet
 	// context-aware — see its docstring.
+	//
+	// We cancel synchronously rather than via `defer` because the failure
+	// path below uses log.Fatalf, which calls os.Exit and skips deferreds.
+	// The OS reclaims the timer when the process exits, so this is safe.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	files, err := generator.GenerateMigration(ctx, opts)
 	cancel()

--- a/migration/generator/example/main.go
+++ b/migration/generator/example/main.go
@@ -50,8 +50,9 @@ func main() {
 	fmt.Printf("  Migration name: %s\n", migrationName)
 	fmt.Println()
 
-	// Generate the migration. Wrap with a generous timeout so a stuck DB
-	// fails fast instead of hanging the CLI.
+	// Bound the initial database connection so a stuck host fails fast.
+	// The schema-reading work inside GenerateMigration is not yet
+	// context-aware — see its docstring.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	files, err := generator.GenerateMigration(ctx, opts)
 	cancel()

--- a/migration/generator/example/main.go
+++ b/migration/generator/example/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/stokaro/ptah/migration/generator"
 )
@@ -48,8 +50,11 @@ func main() {
 	fmt.Printf("  Migration name: %s\n", migrationName)
 	fmt.Println()
 
-	// Generate the migration
-	files, err := generator.GenerateMigration(opts)
+	// Generate the migration. Wrap with a generous timeout so a stuck DB
+	// fails fast instead of hanging the CLI.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	files, err := generator.GenerateMigration(ctx, opts)
+	cancel()
 	if err != nil {
 		log.Fatalf("Error generating migration: %v", err)
 	}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -47,8 +48,13 @@ type MigrationFiles struct {
 }
 
 // GenerateMigration generates both up and down migration files by comparing
-// the desired schema (from Go entities) with the current database state
-func GenerateMigration(opts GenerateMigrationOptions) (*MigrationFiles, error) {
+// the desired schema (from Go entities) with the current database state.
+//
+// The provided context is used when opening a new database connection (so a
+// stuck host cannot block the call indefinitely). When opts.DBConn is already
+// set, the caller controls connection lifetime and the context only governs
+// the work performed inside this function.
+func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error) {
 	// Set default migration name if not provided
 	if opts.MigrationName == "" {
 		opts.MigrationName = "migration"
@@ -85,11 +91,15 @@ func GenerateMigration(opts GenerateMigrationOptions) (*MigrationFiles, error) {
 	if opts.DBConn != nil {
 		conn = opts.DBConn
 	} else {
-		conn, err = dbschema.ConnectToDatabase(opts.DatabaseURL)
+		conn, err = dbschema.ConnectToDatabase(ctx, opts.DatabaseURL)
 		if err != nil {
 			return nil, fmt.Errorf("error connecting to database: %w", err)
 		}
-		defer conn.Close()
+		defer func() {
+			if cerr := conn.Close(); cerr != nil {
+				slog.Warn("failed to close database connection", "error", cerr)
+			}
+		}()
 	}
 
 	dbSchema, err := conn.Reader().ReadSchema()

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -50,10 +50,11 @@ type MigrationFiles struct {
 // GenerateMigration generates both up and down migration files by comparing
 // the desired schema (from Go entities) with the current database state.
 //
-// The provided context is used when opening a new database connection (so a
-// stuck host cannot block the call indefinitely). When opts.DBConn is already
-// set, the caller controls connection lifetime and the context only governs
-// the work performed inside this function.
+// The context bounds only the initial database connection attempt performed
+// when opts.DBConn is nil (so a stuck host cannot block the call
+// indefinitely). The schema-reading and migration-writing work below does not
+// yet propagate the context; future work may thread it through there too.
+// When opts.DBConn is supplied the context is currently unused.
 func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error) {
 	// Set default migration name if not provided
 	if opts.MigrationName == "" {
@@ -95,11 +96,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		if err != nil {
 			return nil, fmt.Errorf("error connecting to database: %w", err)
 		}
-		defer func() {
-			if cerr := conn.Close(); cerr != nil {
-				slog.Warn("failed to close database connection", "error", cerr)
-			}
-		}()
+		defer dbschema.CloseAndWarn(conn)
 	}
 
 	dbSchema, err := conn.Reader().ReadSchema()

--- a/migration/generator/generator_test.go
+++ b/migration/generator/generator_test.go
@@ -1,6 +1,7 @@
 package generator_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +28,7 @@ func TestGenerateMigration_HappyPath(t *testing.T) {
 
 	// This test will fail if there's no testdata directory with Go entities
 	// and no memory database connection, but it tests the basic structure
-	_, err := generator.GenerateMigration(opts)
+	_, err := generator.GenerateMigration(context.Background(), opts)
 
 	// We expect this to fail because we don't have test data set up
 	// but we can verify the error is reasonable
@@ -101,7 +102,7 @@ func TestCreateMigrationFiles_FileCreation(t *testing.T) {
 	}
 
 	// This will fail due to missing testdata, but we can check the structure
-	_, err := generator.GenerateMigration(opts)
+	_, err := generator.GenerateMigration(context.Background(), opts)
 	c.Assert(err, qt.IsNotNil) // Expected to fail without proper setup
 }
 
@@ -150,7 +151,7 @@ func TestGenerateMigrationOptions_ErrorCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			_, err := generator.GenerateMigration(tt.opts)
+			_, err := generator.GenerateMigration(context.Background(), tt.opts)
 			c.Assert(err, qt.IsNotNil)
 		})
 	}
@@ -202,7 +203,7 @@ type TestTable struct {
 		OutputDir:     migrationsDir,
 	}
 
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	if err != nil {
 		// Skip test if database is not available
 		t.Skipf("Skipping test due to database connection error: %v", err)
@@ -286,7 +287,7 @@ type SimpleTable struct {
 	}
 
 	// This should not panic with nil pointer dereference
-	files, err := generator.GenerateMigration(opts)
+	files, err := generator.GenerateMigration(context.Background(), opts)
 	if err != nil {
 		// Skip test if database is not available
 		t.Skipf("Skipping test due to database connection error: %v", err)
@@ -343,7 +344,7 @@ type TestTable struct {
 	}
 
 	// This should not fail with filesystem path resolution errors
-	_, err = generator.GenerateMigration(opts)
+	_, err = generator.GenerateMigration(context.Background(), opts)
 
 	// We expect this to fail due to memory database limitations, but NOT due to filesystem path issues
 	c.Assert(err, qt.IsNotNil)
@@ -411,7 +412,7 @@ type TestTable struct {
 	}
 
 	// This should not fail with filesystem path resolution errors
-	_, err = generator.GenerateMigration(opts)
+	_, err = generator.GenerateMigration(context.Background(), opts)
 
 	// We expect this to fail due to memory database limitations, but NOT due to filesystem path issues
 	c.Assert(err, qt.IsNotNil)

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -138,6 +138,8 @@ package main
 import (
     "context"
     "os"
+    "time"
+
     "github.com/stokaro/ptah/dbschema"
     "github.com/stokaro/ptah/migration/migrator"
 )

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -143,12 +143,15 @@ import (
 )
 
 func main() {
-    // Connect to database
-    conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+    // Connect to database. Supply a context so the initial Ping cannot block
+    // indefinitely on a stuck host.
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    defer cancel()
+    conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
     if err != nil {
         panic(err)
     }
-    defer conn.Close()
+    defer dbschema.CloseAndWarn(conn)
 
     // Create filesystem from migrations directory
     migrationsFS := os.DirFS("/path/to/migrations")

--- a/migration/migrator/debug_test.go
+++ b/migration/migrator/debug_test.go
@@ -16,14 +16,14 @@ func TestInitializeDebug(t *testing.T) {
 	dbURL := "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	if err != nil {
 		t.Skipf("Skipping test: failed to connect to database: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Clean up any existing schema_migrations table to ensure a clean test
-	ctx := context.Background()
 	_, _ = conn.Exec("DROP TABLE IF EXISTS schema_migrations")
 
 	// Create a migrator

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -50,7 +50,7 @@
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//	defer conn.Close()
+//	defer dbschema.CloseAndWarn(conn)
 //
 //	// Option 1: Create migrator from filesystem
 //	m, err := migrator.NewFSMigrator(conn, os.DirFS("/path/to/migrations"))

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -45,8 +45,8 @@
 //
 // Basic migration setup and execution:
 //
-//	// Create database connection
-//	conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+//	// Create database connection (supply a context to bound the initial Ping)
+//	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/migration/migrator/example_test.go
+++ b/migration/migrator/example_test.go
@@ -21,7 +21,7 @@ func ExampleMigrator() {
 	dbURL := "postgres://user:pass@localhost/db"
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -65,7 +65,7 @@ func ExampleNewFSMigrator() {
 	dbURL := "postgres://user:pass@localhost/db"
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -98,7 +98,7 @@ func ExampleMigrator_GetMigrationStatus() {
 	dbURL := "postgres://user:pass@localhost/db"
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -165,7 +165,7 @@ func Example_registerMigrationsCustomFilesystem() {
 	dbURL := "postgres://user:pass@localhost/db"
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -241,7 +241,7 @@ func ExampleMigrator_MigrateDown() {
 	// This is a demonstration - in real usage you would have a valid database URL
 	dbURL := "postgres://user:pass@localhost/db"
 
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -278,7 +278,7 @@ func ExampleMigrator_MigrateTo() {
 	// This is a demonstration - in real usage you would have a valid database URL
 	dbURL := "postgres://user:pass@localhost/db"
 
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -345,7 +345,7 @@ func ExampleMigrator_GetPendingMigrations() {
 	// This is a demonstration - in real usage you would have a valid database URL
 	dbURL := "postgres://user:pass@localhost/db"
 
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return
@@ -458,7 +458,7 @@ func Example_completeWorkflow() {
 	// This is a demonstration - in real usage you would have a valid database URL
 	dbURL := "postgres://user:pass@localhost/db"
 
-	conn, err := dbschema.ConnectToDatabase(dbURL)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
 	if err != nil {
 		fmt.Printf("Failed to connect: %v\n", err)
 		return

--- a/migration/schemadiff/doc.go
+++ b/migration/schemadiff/doc.go
@@ -53,7 +53,7 @@
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//	defer conn.Close()
+//	defer dbschema.CloseAndWarn(conn)
 //
 //	database, err := conn.Reader().ReadSchema()
 //	if err != nil {

--- a/migration/schemadiff/doc.go
+++ b/migration/schemadiff/doc.go
@@ -48,8 +48,8 @@
 //		log.Fatal(err)
 //	}
 //
-//	// Connect to database and read current schema
-//	conn, err := dbschema.ConnectToDatabase("postgres://user:pass@localhost/db")
+//	// Connect to database and read current schema (supply a context)
+//	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")
 //	if err != nil {
 //		log.Fatal(err)
 //	}


### PR DESCRIPTION
## Summary

Resolves #139.

`dbschema.ConnectToDatabase` was untyped against cancellation: it accepted only a URL, called `db.Ping()` with no deadline, and silently swallowed close errors at the call sites. Against a slow or dead host the function blocked indefinitely.

This PR changes the signature to `ConnectToDatabase(ctx context.Context, dbURL string)` and threads the context through to `PingContext` and the metadata `QueryRowContext` calls. The seven CLI subcommands (`compare`, `dropall`, `migrate`, `migrate-down`, `migrate-status`, `migrate-up`, `read-db`) all grow a new `--connect-timeout` flag (default `10s`, `0` disables) that builds the connection context. The new `dbschema.CloseAndWarn(*DatabaseConnection)` helper lives next to the type and is used by every CLI handler and the migration generator so close errors are logged via `slog.Warn` instead of dropped.

`generator.GenerateMigration` also takes a `context.Context` so the connection it opens internally inherits the same cancellation guarantee. All callers (tests, examples, scenarios, doc comments) are updated.

Flag bookkeeping (registration / parsing / context derivation) lives in a small `cmd/internal/dbcli` package to keep the 7 commands consistent.

### Behaviour changes worth highlighting
- `--connect-timeout` is opt-out (default 10s). Users with healthy databases see no change; users with a stuck DB get a fast, informative error.
- Close errors are now logged at warn level via `slog`, not returned.
- `integration.TestRunner.runSingleTest` now promotes a `conn.Close()` failure into a test failure when the scenario itself passed (previously the close error was silently dropped). Driver-level flakes on Close that used to be invisible will now turn the affected integration test red — if you prefer a warning-only approach in that hot path, swap the defer body for `slog.Warn` instead of mutating `result`.

## Acceptance criteria (from #139)
- ✅ Signature is `ConnectToDatabase(ctx context.Context, dbURL string)`.
- ✅ `db.PingContext(ctx)` replaces `db.Ping()`; `getDatabaseInfo` uses `QueryRowContext`.
- ✅ CLI commands wrap `conn.Close()` via `dbschema.CloseAndWarn` so failures surface as `slog.Warn`.
- ✅ `--connect-timeout` flag (default 10s, "0" disables) drives the context.
- ✅ Unit test `TestConnectToDatabase_CancelledContext` asserts the call returns `context.Canceled` promptly when the context is cancelled before invocation. A companion `TestConnectToDatabase_DeadlineExceeded` covers the typical `--connect-timeout` case using a 200 ms deadline against a local TCP listener that completes the handshake but never replies (portable, no dependency on routing tables / reserved IP blocks).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race`
- [x] `golangci-lint run --timeout 5m ./...` (0 issues)
- [x] New cancellation tests (`TestConnectToDatabase_CancelledContext`, `TestConnectToDatabase_DeadlineExceeded`) execute in <0.3s combined; verified across 5 race-enabled runs without flakes.
- [x] Two self-review iterations against an independent reviewer agent; all blockers, mediums, and most lows addressed.
- [ ] CI integration tests (depend on Docker; not exercised locally) — relying on GitHub Actions.