### PR TITLE
fix(schemadiff): detect on_delete/on_update changes on field-level foreign keys (#189)

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -91,8 +91,8 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error reading database schema: %w", err)
 	}
 
-	// 3. Compare schemas
-	diff := schemadiff.Compare(result, dbSchema)
+	// 3. Compare schemas (dialect-aware: MySQL/MariaDB RESTRICT == NO ACTION)
+	diff := schemadiff.CompareWithDialect(result, dbSchema, conn.Info().Dialect)
 
 	// 4. Display differences
 	output := planner.GenerateSchemaDiffSQLStatements(diff, result, conn.Info().Dialect)

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -92,8 +92,8 @@ func migrateCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error reading database schema: %w", err)
 	}
 
-	// 3. Compare schemas
-	diff := schemadiff.Compare(result, dbSchema)
+	// 3. Compare schemas (dialect-aware: MySQL/MariaDB RESTRICT == NO ACTION)
+	diff := schemadiff.CompareWithDialect(result, dbSchema, conn.Info().Dialect)
 
 	// 4. Display differences summary
 	astNodes := planner.GenerateSchemaDiffAST(diff, result, conn.Info().Dialect)

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,17 @@ type CompareOptions struct {
 	// - plpgsql: Default procedural language, usually pre-installed
 	// - adminpack: Administrative functions, often pre-installed
 	IgnoredExtensions []string
+
+	// Dialect is the target database dialect ("postgres", "mysql", "mariadb",
+	// "clickhouse"). It is optional; when empty the comparison uses
+	// dialect-neutral rules. It is currently consulted only to fold
+	// referential-action reporting quirks: MariaDB reports an unspecified
+	// ON DELETE/ON UPDATE as RESTRICT (MySQL and PostgreSQL report NO ACTION),
+	// and InnoDB treats RESTRICT and NO ACTION identically, so for MySQL/MariaDB
+	// RESTRICT is folded to NO ACTION to avoid a perpetual drop+add loop on an
+	// unchanged foreign key. PostgreSQL distinguishes the two at DDL, so the
+	// fold is deliberately NOT applied there.
+	Dialect string
 }
 
 // DefaultCompareOptions returns the default comparison options with sensible defaults.

--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -102,6 +102,12 @@ type DropConstraintOperation struct {
 	ConstraintName string
 	// IfExists indicates whether to use IF EXISTS clause to avoid errors if constraint doesn't exist
 	IfExists bool
+	// ForeignKey marks the constraint as a FOREIGN KEY. MySQL/MariaDB require
+	// the dedicated `DROP FOREIGN KEY <name>` syntax for foreign keys rather
+	// than the generic `DROP CONSTRAINT <name>`; renderers that distinguish the
+	// two read this flag. Renderers where DROP CONSTRAINT already covers foreign
+	// keys (PostgreSQL) may ignore it.
+	ForeignKey bool
 }
 
 // Accept implements the Node interface for DropConstraintOperation.

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -31,6 +31,14 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		})
 	}
 
+	// Index single-column FOREIGN KEY constraints by table.column so the
+	// reconstructed fields can carry the foreign reference and its referential
+	// actions. This is what lets a down migration restore the prior ON DELETE /
+	// ON UPDATE action of a field-level FK (issue #189): the down path treats
+	// the introspected (pre-change) database as the target, so the old action
+	// must survive the round-trip into goschema.
+	fkByColumn := indexForeignKeysByColumn(dbSchema)
+
 	// Convert tables and their columns
 	for _, dbTable := range dbSchema.Tables {
 		// Generate struct name from table name (simple conversion)
@@ -59,6 +67,15 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 			// Set default value if present
 			if dbColumn.ColumnDefault != nil {
 				field.Default = *dbColumn.ColumnDefault
+			}
+
+			// Carry the field-level foreign key (reference + referential actions)
+			// so down migrations can reconstruct it with the prior action.
+			if fk, ok := fkByColumn[dbTable.Name+"."+dbColumn.Name]; ok {
+				field.Foreign = fk.foreign
+				field.ForeignKeyName = fk.name
+				field.OnDelete = fk.onDelete
+				field.OnUpdate = fk.onUpdate
 			}
 
 			database.Fields = append(database.Fields, field)
@@ -158,6 +175,52 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 	}
 
 	return database
+}
+
+// foreignKeyInfo holds the field-level pieces reconstructed from a database
+// FOREIGN KEY constraint.
+type foreignKeyInfo struct {
+	name     string // constraint name
+	foreign  string // "table(column)" reference
+	onDelete string // ON DELETE action (NO ACTION normalized away later)
+	onUpdate string // ON UPDATE action
+}
+
+// indexForeignKeysByColumn maps table.column -> reconstructed FK info for every
+// single-column FOREIGN KEY constraint in the database schema. Multi-column FKs
+// are not field-level and are skipped (they are represented as table-level
+// constraints, which this converter does not yet round-trip).
+func indexForeignKeysByColumn(dbSchema *dbschematypes.DBSchema) map[string]foreignKeyInfo {
+	result := make(map[string]foreignKeyInfo)
+	for _, c := range dbSchema.Constraints {
+		if c.Type != "FOREIGN KEY" || c.ColumnName == "" || c.ForeignTable == nil {
+			continue
+		}
+		foreignTable := *c.ForeignTable
+		foreignColumn := ""
+		if c.ForeignColumn != nil {
+			foreignColumn = *c.ForeignColumn
+		}
+		foreign := foreignTable
+		if foreignColumn != "" {
+			foreign = foreignTable + "(" + foreignColumn + ")"
+		}
+		result[c.TableName+"."+c.ColumnName] = foreignKeyInfo{
+			name:     c.Name,
+			foreign:  foreign,
+			onDelete: derefString(c.DeleteRule),
+			onUpdate: derefString(c.UpdateRule),
+		}
+	}
+	return result
+}
+
+// derefString returns the pointed-to string or "" when nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // generateStructName converts a table name to a Go struct name

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -67,9 +67,16 @@ func escapeSQLStringLiteral(value string) string {
 	return "'" + escaped + "'"
 }
 
-// generateForeignKeyName generates a consistent foreign key constraint name
-// following the convention: fk_{table_name}_{field_name}
-func generateForeignKeyName(tableName, fieldName string) string {
+// GenerateForeignKeyName generates a consistent foreign key constraint name
+// following the convention: fk_{table_name}_{field_name}.
+//
+// This is the single source of truth for the conventional FK name used when a
+// field-level foreign= annotation omits an explicit foreign_key_name. The
+// schemadiff comparator (when synthesizing a field-level FK for drift
+// comparison) and the dialect planners (when emitting the CREATE/ALTER) both
+// derive the name from here so the synthesized name always lines up with the
+// name actually written to the database.
+func GenerateForeignKeyName(tableName, fieldName string) string {
 	return "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(fieldName)
 }
 
@@ -1273,7 +1280,7 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 	}
 
 	// Generate automatic foreign key constraint name following convention
-	foreignKeyName := generateForeignKeyName(structName, embedded.Field)
+	foreignKeyName := GenerateForeignKeyName(structName, embedded.Field)
 
 	// Create platform-specific overrides for MySQL/MariaDB compatibility
 	// MySQL/MariaDB use INT for SERIAL types, so foreign keys should also use INT

--- a/core/goschema/field_order_integration_test.go
+++ b/core/goschema/field_order_integration_test.go
@@ -264,7 +264,12 @@ type Post struct {
 		// Generate migration AST
 		planner := postgres.New()
 		astNodes := planner.GenerateMigrationAST(diff, database)
-		c.Assert(len(astNodes), qt.Equals, 2) // Should have 2 CREATE TABLE statements
+		// 2 CREATE TABLE statements plus 1 ALTER TABLE ADD CONSTRAINT for the
+		// posts.user_id field-level foreign key. The FK has no explicit
+		// foreign_key_name, so the planner derives the conventional
+		// fk_posts_user_id name and emits the constraint (previously an
+		// anonymous field-level FK was silently dropped from the migration).
+		c.Assert(len(astNodes), qt.Equals, 3)
 
 		// Render to SQL
 		var sqlStatements []string

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -464,11 +464,19 @@ func (r *Renderer) visitAlterTableWithEnums(node *ast.AlterTableNode, enums map[
 
 		case *ast.DropConstraintOperation:
 			dropSQL := fmt.Sprintf("ALTER TABLE %s DROP", node.Name)
-			// MySQL uses different syntax for different constraint types
-			// For now, we'll use the generic DROP CONSTRAINT syntax
-			if op.IfExists {
+			// MySQL/MariaDB require a type-specific drop clause. Foreign keys
+			// must use DROP FOREIGN KEY (DROP CONSTRAINT is rejected for FKs on
+			// MySQL and on MariaDB <10.5); everything else uses DROP CONSTRAINT
+			// (CHECK and named constraints on MySQL 8.0.19+ / MariaDB).
+			switch {
+			case op.ForeignKey:
+				dropSQL += " FOREIGN KEY"
+				if op.IfExists {
+					dropSQL += " IF EXISTS"
+				}
+			case op.IfExists:
 				dropSQL += " CONSTRAINT IF EXISTS"
-			} else {
+			default:
 				dropSQL += " CONSTRAINT"
 			}
 			dropSQL += fmt.Sprintf(" %s", op.ConstraintName)

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -66,6 +66,17 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Constraints = constraints
 
+	// Reconcile per-column uniqueness against the authoritative index metadata.
+	// The DDL parser collapses every table-level KEY/INDEX clause to a UNIQUE
+	// constraint (it has no dedicated non-unique-index node), so a non-unique
+	// backing index — e.g. the index MySQL/MariaDB auto-creates for a FOREIGN
+	// KEY (`KEY fk_posts_user_id (user_id)`) — would otherwise mark its column
+	// as unique and produce a spurious `unique: true -> false` diff on an
+	// unchanged schema (issue #189 follow-up). information_schema.STATISTICS
+	// (NON_UNIQUE) is authoritative, so a column is unique only when a
+	// single-column unique index actually covers it.
+	reconcileColumnUniqueness(schema)
+
 	return schema, nil
 }
 
@@ -189,6 +200,33 @@ func (r *Reader) applyColumnConstraint(table *types.DBTable, constraint *ast.Con
 					}
 				}
 			}
+		}
+	}
+}
+
+// reconcileColumnUniqueness recomputes each column's IsUnique flag from the
+// authoritative index metadata (information_schema.STATISTICS, captured in
+// schema.Indexes with a correct NON_UNIQUE bit). A column is unique only when a
+// non-primary, single-column unique index covers exactly that column. This
+// overrides the DDL-parser heuristic, which cannot tell a plain non-unique
+// KEY/INDEX from a UNIQUE one and would over-report uniqueness for FK-backing
+// and other non-unique indexes.
+func reconcileColumnUniqueness(schema *types.DBSchema) {
+	// Set of table.column covered by a single-column unique (non-primary) index.
+	uniqueColumns := make(map[string]struct{})
+	for _, idx := range schema.Indexes {
+		if idx.IsPrimary || !idx.IsUnique || len(idx.Columns) != 1 {
+			continue
+		}
+		uniqueColumns[idx.TableName+"."+idx.Columns[0]] = struct{}{}
+	}
+
+	for ti := range schema.Tables {
+		table := &schema.Tables[ti]
+		for ci := range table.Columns {
+			col := &table.Columns[ci]
+			_, unique := uniqueColumns[table.Name+"."+col.Name]
+			col.IsUnique = unique
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stokaro/ptah
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -11,12 +11,23 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
+
+// dialectCompareOptions builds schemadiff comparison options carrying the
+// connection's dialect, so dialect-specific normalization (e.g. MySQL/MariaDB
+// RESTRICT == NO ACTION for foreign-key referential actions) is applied during
+// integration validation.
+func dialectCompareOptions(conn *dbschema.DatabaseConnection) *config.CompareOptions {
+	opts := config.DefaultCompareOptions()
+	opts.Dialect = conn.Info().Dialect
+	return opts
+}
 
 // TestStep represents a single step within a test scenario
 type TestStep struct {
@@ -364,8 +375,8 @@ func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, co
 		return nil, fmt.Errorf("failed to read database schema: %w", err)
 	}
 
-	// Compare schemas
-	diff := schemadiff.Compare(generated, dbSchema)
+	// Compare schemas (dialect-aware so MySQL/MariaDB RESTRICT == NO ACTION)
+	diff := schemadiff.CompareWithOptions(generated, dbSchema, dialectCompareOptions(conn))
 
 	// Generate migration SQL
 	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, conn.Info().Dialect)

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -589,8 +589,11 @@ func validateSchemaConsistency(ctx context.Context, conn *dbschema.DatabaseConne
 		return fmt.Errorf("failed to read database schema: %w", err)
 	}
 
-	// Compare schemas using schemadiff
-	diff := schemadiff.Compare(expectedSchema, actualSchema)
+	// Compare schemas using schemadiff. Thread the dialect so dialect-specific
+	// referential-action normalization (MySQL/MariaDB RESTRICT == NO ACTION) is
+	// applied — otherwise MariaDB reports a spurious FK action diff on an
+	// unchanged foreign key.
+	diff := schemadiff.CompareWithOptions(expectedSchema, actualSchema, dialectCompareOptions(conn))
 
 	// Check if there are any differences
 	if hasSchemaChanges(diff) {

--- a/integration/scenarios_field_check_and_function_modify.go
+++ b/integration/scenarios_field_check_and_function_modify.go
@@ -123,7 +123,7 @@ func testDynamicFunctionAttributeModification(ctx context.Context, conn *dbschem
 		if err != nil {
 			return fmt.Errorf("failed to read database schema: %w", err)
 		}
-		diff := schemadiff.Compare(generated, dbSchema)
+		diff := schemadiff.CompareWithOptions(generated, dbSchema, dialectCompareOptions(conn))
 		if len(diff.FunctionsModified) > 0 {
 			summary := make([]string, 0, len(diff.FunctionsModified))
 			for _, f := range diff.FunctionsModified {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/convert/dbschematogo"
+	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
@@ -104,8 +105,12 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		return nil, fmt.Errorf("error reading database schema: %w", err)
 	}
 
-	// 3. Calculate the diff between desired and current schema
-	diff := schemadiff.CompareWithOptions(generated, dbSchema, opts.CompareOptions)
+	// 3. Calculate the diff between desired and current schema.
+	// Thread the connection dialect into the compare options so dialect-specific
+	// normalization (e.g. MySQL/MariaDB RESTRICT == NO ACTION on foreign keys)
+	// is applied; without it MariaDB would loop drop+add on an unchanged FK.
+	compareOpts := withDialect(opts.CompareOptions, conn.Info().Dialect)
+	diff := schemadiff.CompareWithOptions(generated, dbSchema, compareOpts)
 
 	// Check if there are any changes
 	if !diff.HasChanges() {
@@ -142,6 +147,21 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	}
 
 	return files, nil
+}
+
+// withDialect returns a copy of opts with the Dialect set, allocating a default
+// options value when opts is nil. An explicit Dialect already present on opts is
+// preserved. The comparator consults Dialect only for dialect-specific
+// referential-action normalization (see config.CompareOptions.Dialect).
+func withDialect(opts *config.CompareOptions, dialect string) *config.CompareOptions {
+	if opts == nil {
+		opts = config.DefaultCompareOptions()
+	}
+	clone := *opts
+	if clone.Dialect == "" {
+		clone.Dialect = dialect
+	}
+	return &clone
 }
 
 // hasActualSQLStatements checks if the statements contain actual SQL operations (not just comments)
@@ -245,7 +265,73 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		RolesAdded:    diff.RolesRemoved, // Roles to remove become roles to add
 		RolesRemoved:  diff.RolesAdded,   // Roles to add become roles to remove
 		RolesModified: reverseRoleDiffs(diff.RolesModified),
+
+		// Reverse constraint operations. A modified constraint is expressed by
+		// the comparator as remove + add of the SAME name (e.g. an on_delete
+		// change on a field-level FK, issue #189). Swapping the two slices makes
+		// the down migration drop the new definition and re-add the old one — the
+		// down planner resolves the old definition from the introspected schema
+		// (see dbschematogo.ConvertDBSchemaToGoSchema, which now carries the
+		// FK action), so the prior action is faithfully restored.
+		ConstraintsAdded:             diff.ConstraintsRemoved,
+		ConstraintsRemoved:           diff.ConstraintsAdded,
+		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
 	}
+}
+
+// reverseConstraintRemovals builds the table-qualified removal info for the
+// down migration. In the down direction the constraints to remove are the ones
+// the up migration ADDED (diff.ConstraintsAdded); their owning table and type
+// are resolved from the generated schema, which is the source the up side
+// synthesized them from. This lets dialect planners that need the table and a
+// type-specific drop syntax (MySQL/MariaDB DROP FOREIGN KEY) emit a real drop in
+// the down migration. When the schema is unavailable (legacy callers) the names
+// still flow through ConstraintsRemoved; only the richer per-table info is
+// omitted.
+func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database) []types.ConstraintRemovalInfo {
+	if schema == nil || len(diff.ConstraintsAdded) == 0 {
+		return nil
+	}
+
+	// Index explicit table-level constraints by name.
+	tableConstraints := make(map[string]goschema.Constraint, len(schema.Constraints))
+	for _, c := range schema.Constraints {
+		tableConstraints[c.Name] = c
+	}
+
+	// Index field-level FK constraint names (foreign_key_name or the
+	// conventional fk_<table>_<column>) to their owning table.
+	structToTable := make(map[string]string, len(schema.Tables))
+	for _, t := range schema.Tables {
+		structToTable[t.StructName] = t.Name
+	}
+	fkTables := make(map[string]string, len(schema.Fields))
+	for _, f := range schema.Fields {
+		if f.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		name := f.ForeignKeyName
+		if name == "" {
+			name = fromschema.GenerateForeignKeyName(tableName, f.Name)
+		}
+		fkTables[name] = tableName
+	}
+
+	var infos []types.ConstraintRemovalInfo
+	for _, name := range diff.ConstraintsAdded {
+		switch {
+		case tableConstraints[name].Name != "":
+			c := tableConstraints[name]
+			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: c.Table, Type: c.Type})
+		case fkTables[name] != "":
+			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: fkTables[name], Type: "FOREIGN KEY"})
+		}
+	}
+	return infos
 }
 
 // reverseTableDiffs reverses table modifications for down migrations

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -572,4 +573,114 @@ func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 	// Tables should be removed in down migration (existing behavior)
 	c.Assert(downDiff.TablesRemoved, qt.DeepEquals, []string{"users"})
 	c.Assert(len(downDiff.TablesAdded), qt.Equals, 0)
+}
+
+// TestReverseSchemaDiff_ConstraintReversal verifies that a modified constraint
+// (expressed by the comparator as remove + add of the same name) is reversed so
+// the down migration drops the new definition and re-adds the old one. This is
+// the field-level FK on_delete/on_update drift case from issue #189: without the
+// reversal the down migration was empty and could not restore the prior action.
+func TestReverseSchemaDiff_ConstraintReversal(t *testing.T) {
+	c := qt.New(t)
+
+	input := &types.SchemaDiff{
+		// Up: change fk_export_file's action -> remove(old) + add(new) of the
+		// same name.
+		ConstraintsRemoved: []string{"fk_export_file"},
+		ConstraintsAdded:   []string{"fk_export_file"},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	// Down: the slices swap, so the down re-adds the old and drops the new.
+	c.Assert(result.ConstraintsAdded, qt.DeepEquals, []string{"fk_export_file"})
+	c.Assert(result.ConstraintsRemoved, qt.DeepEquals, []string{"fk_export_file"})
+}
+
+// TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction is the
+// acceptance test for the down half of issue #189: when an up migration changes
+// a field-level FK's ON DELETE action, the generated down migration must DROP
+// the new constraint and re-ADD it with the PRIOR action read back from the
+// (pre-change) database state. Previously the down migration was empty.
+func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *testing.T) {
+	noAction := "NO ACTION"
+	filesTable := "files"
+	idCol := "id"
+
+	// Generated (target) schema: file_id FK now uses ON DELETE SET NULL.
+	generatedSchema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+		Fields: []goschema.Field{
+			{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+			{
+				StructName:     "Export",
+				Name:           "file_id",
+				Type:           "TEXT",
+				Nullable:       true,
+				Foreign:        "files(id)",
+				ForeignKeyName: "fk_export_file",
+				OnDelete:       "SET NULL",
+			},
+		},
+	}
+
+	// Database (current, pre-change) schema: the FK still has the prior default
+	// NO ACTION. This is what the down migration must restore.
+	dbSchema := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Name: "exports",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+					{Name: "file_id", DataType: "text", IsNullable: "YES"},
+				},
+			},
+		},
+		Constraints: []dbschematypes.DBConstraint{
+			{
+				Name:          "fk_export_file",
+				TableName:     "exports",
+				Type:          "FOREIGN KEY",
+				ColumnName:    "file_id",
+				ForeignTable:  &filesTable,
+				ForeignColumn: &idCol,
+				DeleteRule:    &noAction,
+				UpdateRule:    &noAction,
+			},
+		},
+	}
+
+	// Up diff for the action change: remove(old) + add(new) of the same name.
+	upDiff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"fk_export_file"},
+		ConstraintsAdded:   []string{"fk_export_file"},
+	}
+
+	t.Run("postgres", func(t *testing.T) {
+		c := qt.New(t)
+		downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, dbSchema, "postgres")
+		c.Assert(err, qt.IsNil)
+
+		// The down must be non-empty and re-add the FK (restoring the prior
+		// action) plus drop the new definition first.
+		c.Assert(downSQL, qt.Contains, "ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id)")
+		c.Assert(downSQL, qt.Contains, "DROP CONSTRAINT IF EXISTS")
+		// The restored action must NOT be SET NULL (that was the new action).
+		c.Assert(strings.Contains(downSQL, "ON DELETE SET NULL"), qt.IsFalse,
+			qt.Commentf("down must restore the prior action, not SET NULL:\n%s", downSQL))
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		c := qt.New(t)
+		downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, dbSchema, "mysql")
+		c.Assert(err, qt.IsNil)
+
+		// Real DROP FOREIGN KEY + re-ADD with the prior action; never a TODO.
+		c.Assert(downSQL, qt.Contains, "ALTER TABLE exports DROP FOREIGN KEY fk_export_file;")
+		c.Assert(downSQL, qt.Contains, "ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id)")
+		c.Assert(strings.Contains(downSQL, "TODO"), qt.IsFalse,
+			qt.Commentf("down must not emit a TODO placeholder:\n%s", downSQL))
+		c.Assert(strings.Contains(downSQL, "ON DELETE SET NULL"), qt.IsFalse,
+			qt.Commentf("down must restore the prior action, not SET NULL:\n%s", downSQL))
+	})
 }

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -144,7 +144,7 @@ func (p *Planner) addRegularForeignKeys(result []ast.Node, generated *goschema.D
 		if fkRef != nil && fkRef.Table != table.Name {
 			fkRef.OnDelete = field.OnDelete
 			fkRef.OnUpdate = field.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, field.ForeignKeyName, []string{field.Name}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.Name, foreignKeyName(table.Name, field), []string{field.Name}, fkRef))
 		}
 	}
 	return result
@@ -162,16 +162,44 @@ func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *go
 		if fkRef != nil {
 			fkRef.OnDelete = selfRefFK.OnDelete
 			fkRef.OnUpdate = selfRefFK.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfRefFK.ForeignKeyName, []string{selfRefFK.FieldName}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfReferencingForeignKeyName(table.Name, selfRefFK), []string{selfRefFK.FieldName}, fkRef))
 		}
 	}
 
 	return result
 }
 
-// isRegularForeignKeyField checks if a field is a regular foreign key field for the given table
+// isRegularForeignKeyField checks if a field is a regular foreign key field for the given table.
+//
+// A field-level foreign= annotation is a foreign key whether or not an explicit
+// foreign_key_name= was supplied; when omitted the planner derives the
+// conventional fk_<table>_<column> name (see foreignKeyName) so the constraint
+// is actually created with a stable, named identity. MySQL in particular needs
+// a known name to later emit ALTER TABLE ... DROP FOREIGN KEY for action drift
+// (issue #189).
 func isRegularForeignKeyField(field goschema.Field, table goschema.Table) bool {
-	return field.StructName == table.StructName && field.Foreign != "" && field.ForeignKeyName != ""
+	return field.StructName == table.StructName && field.Foreign != ""
+}
+
+// foreignKeyName returns the constraint name to use for a field-level foreign
+// key: the explicit foreign_key_name= when set, otherwise the conventional
+// fk_<table>_<column> name shared with the schemadiff comparator and the down
+// path via fromschema.GenerateForeignKeyName.
+func foreignKeyName(tableName string, field goschema.Field) string {
+	if field.ForeignKeyName != "" {
+		return field.ForeignKeyName
+	}
+	return fromschema.GenerateForeignKeyName(tableName, field.Name)
+}
+
+// selfReferencingForeignKeyName returns the constraint name for a
+// self-referencing field-level foreign key, deriving the conventional
+// fk_<table>_<field> name when foreign_key_name= was omitted.
+func selfReferencingForeignKeyName(tableName string, fk goschema.SelfReferencingFK) string {
+	if fk.ForeignKeyName != "" {
+		return fk.ForeignKeyName
+	}
+	return fromschema.GenerateForeignKeyName(tableName, fk.FieldName)
 }
 
 // createForeignKeyAlterStatement creates an ALTER TABLE statement for adding a foreign key constraint
@@ -215,17 +243,18 @@ func (p *Planner) addNewTableColumns(result []ast.Node, tableDiff *types.TableDi
 			operations := []ast.AlterOperation{&ast.AddColumnOperation{Column: columnNode}}
 
 			// If the column has a foreign key, add a separate ADD CONSTRAINT operation
-			if targetField.Foreign != "" && targetField.ForeignKeyName != "" {
+			if targetField.Foreign != "" {
 				// Parse the foreign key reference
 				fkRef := fromschema.ParseForeignKeyReference(targetField.Foreign)
 				if fkRef != nil {
-					fkRef.Name = targetField.ForeignKeyName
+					fkName := foreignKeyName(tableDiff.TableName, *targetField)
+					fkRef.Name = fkName
 					fkRef.OnDelete = targetField.OnDelete
 					fkRef.OnUpdate = targetField.OnUpdate
 
 					// Create foreign key constraint
 					fkConstraint := ast.NewForeignKeyConstraint(
-						targetField.ForeignKeyName,
+						fkName,
 						[]string{targetField.Name},
 						fkRef,
 					)
@@ -514,61 +543,220 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 //   - PRIMARY KEY: Composite primary key constraints
 //   - FOREIGN KEY: Table-level foreign key constraints
 //
+// # Field-Level Fallbacks
+//
+// The schemadiff comparator synthesizes field-level check= and foreign= drift
+// into diff.ConstraintsAdded by name only — those constraints never reach
+// generated.Constraints. addNewConstraints therefore falls back to resolving
+// the constraint from the field annotations (mirroring the PostgreSQL planner)
+// so an existing-column CHECK/FK drift is actually re-emitted instead of being
+// silently dropped.
+//
+// # Modifications (DROP-before-ADD)
+//
+// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved is
+// a modification (the comparator expresses a changed constraint as remove + add
+// of the same name — e.g. an on_delete change on a field-level FK, issue #189).
+// The DROP is emitted here, immediately before the re-ADD, so it precedes the
+// re-add and removeConstraints (which runs later) skips it.
+//
 // # Example Generated SQL
 //
 //	ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);
 //	ALTER TABLE users ADD CONSTRAINT uk_users_email_name UNIQUE (email, name);
+//	ALTER TABLE posts DROP FOREIGN KEY fk_posts_user_id;
+//	ALTER TABLE posts ADD CONSTRAINT fk_posts_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
 func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	// Resolve struct → table name once for the field-level synthesis fallbacks.
+	structToTable := make(map[string]string, len(generated.Tables))
+	for _, t := range generated.Tables {
+		structToTable[t.StructName] = t.Name
+	}
+
+	// Removal info keyed by name so a same-name modification can be dropped with
+	// the correct table + FK-aware syntax before being re-added.
+	removalByName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		removalByName[info.Name] = info
+	}
+
 	for _, constraintName := range diff.ConstraintsAdded {
-		// Find the constraint definition in the generated schema
-		for _, constraint := range generated.Constraints {
-			if constraint.Name == constraintName {
-				// Convert goschema.Constraint to ast.ConstraintNode
-				astConstraint := p.convertConstraintToAST(constraint)
-				if astConstraint != nil {
-					// Create ALTER TABLE statement with ADD CONSTRAINT operation
-					alterNode := &ast.AlterTableNode{
-						Name:       constraint.Table,
-						Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
-					}
-					result = append(result, alterNode)
-				} else if constraint.Type == "EXCLUDE" {
-					// Add warning for unsupported EXCLUDE constraints
-					commentNode := ast.NewComment(fmt.Sprintf("WARNING: EXCLUDE constraint %s not supported in MySQL (PostgreSQL-specific feature)", constraint.Name))
-					result = append(result, commentNode)
-				}
-				break
-			}
+		// For a modification, emit the DROP first so it precedes the re-add.
+		if info, modified := removalByName[constraintName]; modified {
+			result = append(result, dropConstraintNode(info))
+		}
+
+		result = p.appendAddConstraint(result, constraintName, generated, structToTable)
+	}
+	return result
+}
+
+// appendAddConstraint resolves the ADD CONSTRAINT node for a constraint known
+// only by name, trying the explicit table-level constraints first and then the
+// synthesized field-level check= / foreign= fallbacks, mirroring the PostgreSQL
+// planner.
+func (p *Planner) appendAddConstraint(result []ast.Node, constraintName string, generated *goschema.Database, structToTable map[string]string) []ast.Node {
+	for _, constraint := range generated.Constraints {
+		if constraint.Name != constraintName {
+			continue
+		}
+		if astConstraint := p.convertConstraintToAST(constraint); astConstraint != nil {
+			return append(result, &ast.AlterTableNode{
+				Name:       constraint.Table,
+				Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
+			})
+		}
+		if constraint.Type == "EXCLUDE" {
+			return append(result, ast.NewComment(fmt.Sprintf("WARNING: EXCLUDE constraint %s not supported in MySQL (PostgreSQL-specific feature)", constraint.Name)))
+		}
+		return result
+	}
+
+	if node, ok := p.fieldLevelCheckConstraintNode(constraintName, generated, structToTable); ok {
+		if node != nil {
+			result = append(result, node)
+		}
+		return result
+	}
+
+	if node, ok := p.fieldLevelForeignKeyConstraintNode(constraintName, generated, structToTable); ok {
+		if node != nil {
+			result = append(result, node)
 		}
 	}
 	return result
 }
 
+// fieldLevelCheckConstraintNode builds the ADD CONSTRAINT node for a synthesized
+// field-level check= constraint. Mirrors the PostgreSQL planner. New columns are
+// handled by the inline CHECK in ALTER TABLE ADD COLUMN and the comparator
+// deliberately skips synthesizing those, so only existing-column field-level
+// CHECKs reach here.
+func (p *Planner) fieldLevelCheckConstraintNode(constraintName string, generated *goschema.Database, structToTable map[string]string) (ast.Node, bool) {
+	for _, f := range generated.Fields {
+		if f.Check == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		name := f.CheckName
+		if name == "" {
+			name = tableName + "_" + f.Name + "_check"
+		}
+		if name != constraintName {
+			continue
+		}
+		return &ast.AlterTableNode{
+			Name: tableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: &ast.ConstraintNode{
+				Type:       ast.CheckConstraint,
+				Name:       name,
+				Expression: f.Check,
+			}}},
+		}, true
+	}
+	return nil, false
+}
+
+// fieldLevelForeignKeyConstraintNode builds the ADD CONSTRAINT node for a
+// synthesized field-level foreign= constraint whose on_delete / on_update action
+// changed (issue #189). Without this the FK would be dropped (via
+// removeConstraints) but never re-added with the new action — a destructive,
+// silently-broken migration. New columns/tables are handled by the inline FK in
+// CREATE TABLE / ALTER TABLE ADD COLUMN and the comparator deliberately skips
+// synthesizing those, so only existing-column FK action changes reach here.
+func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, generated *goschema.Database, structToTable map[string]string) (ast.Node, bool) {
+	for _, f := range generated.Fields {
+		if f.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		name := foreignKeyName(tableName, f)
+		if name != constraintName {
+			continue
+		}
+		fkRef := fromschema.ParseForeignKeyReference(f.Foreign)
+		if fkRef == nil {
+			continue
+		}
+		fkRef.OnDelete = f.OnDelete
+		fkRef.OnUpdate = f.OnUpdate
+		return p.createForeignKeyAlterStatement(tableName, name, []string{f.Name}, fkRef), true
+	}
+	return nil, false
+}
+
 // removeConstraints removes table-level constraints via ALTER TABLE statements.
 //
-// This method generates ALTER TABLE DROP CONSTRAINT statements for constraints
-// that exist in the database but not in the generated schema.
+// This method generates ALTER TABLE DROP statements for constraints that exist
+// in the database but not in the generated schema.
 //
 // # MySQL Constraint Removal
 //
-// MySQL uses different syntax for dropping different constraint types:
-//   - DROP CONSTRAINT for named constraints (MySQL 8.0.19+)
-//   - DROP INDEX for unique constraints in older versions
-//   - DROP FOREIGN KEY for foreign key constraints
+// MySQL/MariaDB use a type-specific drop syntax:
+//   - DROP FOREIGN KEY <name> for foreign key constraints (DROP CONSTRAINT is
+//     not accepted for FKs on MySQL/MariaDB)
+//   - DROP CONSTRAINT <name> for CHECK constraints (MySQL 8.0.16+ / MariaDB)
+//   - DROP INDEX <name> for UNIQUE constraints
 //
-// # Example Generated SQL
-//
-//	ALTER TABLE products DROP CONSTRAINT positive_price;
-//	ALTER TABLE users DROP CONSTRAINT uk_users_email_name;
+// The owning table is carried on diff.ConstraintsRemovedWithTables (the bare
+// ConstraintsRemoved name list does not retain it). Constraints that appear in
+// BOTH ConstraintsAdded and ConstraintsRemoved are modifications (the
+// comparator expresses a changed constraint as remove + add of the same name —
+// e.g. an on_delete change on a field-level FK, issue #189). Those are emitted
+// as DROP-then-ADD by addNewConstraints, which runs earlier in the pipeline so
+// the drop precedes the re-add; dropping them again here would remove the
+// freshly added constraint, so they are skipped.
 func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
-	for _, constraintName := range diff.ConstraintsRemoved {
-		// For constraint removal, we need to determine which table the constraint belongs to
-		// This is a limitation of the current approach - we don't track table names for removed constraints
-		// For now, we'll add a comment indicating manual intervention may be needed
-		commentNode := ast.NewComment(fmt.Sprintf("TODO: Remove constraint %s (table name unknown - manual intervention required)", constraintName))
-		result = append(result, commentNode)
+	addedNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
+	for _, name := range diff.ConstraintsAdded {
+		addedNames[name] = struct{}{}
+	}
+
+	// Constraints owned by a table that is itself being dropped do not need an
+	// explicit drop — the DROP TABLE cascades them. Emitting one is at best
+	// redundant and at worst invalid (MySQL/MariaDB reject DROP CONSTRAINT for a
+	// PRIMARY KEY; PRIMARY KEY uses DROP PRIMARY KEY), so skip them.
+	droppedTables := make(map[string]struct{}, len(diff.TablesRemoved))
+	for _, t := range diff.TablesRemoved {
+		droppedTables[t] = struct{}{}
+	}
+
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		if _, modified := addedNames[info.Name]; modified {
+			continue
+		}
+		if _, dropped := droppedTables[info.TableName]; dropped {
+			continue
+		}
+		// PRIMARY KEY uses a dedicated syntax and is owned by the column/table
+		// lifecycle; ptah never emits a standalone PK drop here.
+		if strings.EqualFold(info.Type, "PRIMARY KEY") {
+			continue
+		}
+		result = append(result, dropConstraintNode(info))
 	}
 	return result
+}
+
+// dropConstraintNode builds the ALTER TABLE drop statement for a single removed
+// constraint, choosing the MySQL/MariaDB type-specific syntax. FOREIGN KEY uses
+// DROP FOREIGN KEY; everything else falls back to DROP CONSTRAINT (MySQL
+// 8.0.19+ / MariaDB) which covers CHECK and named constraints.
+func dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node {
+	op := &ast.DropConstraintOperation{
+		ConstraintName: info.Name,
+		ForeignKey:     strings.EqualFold(info.Type, "FOREIGN KEY"),
+	}
+	return &ast.AlterTableNode{
+		Name:       info.TableName,
+		Operations: []ast.AlterOperation{op},
+	}
 }
 
 // convertConstraintToAST converts a goschema.Constraint to an ast.ConstraintNode for MySQL.

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -989,72 +989,141 @@ func (p *Planner) removeRLSPolicies(result []ast.Node, diff *types.SchemaDiff) [
 //	ALTER TABLE products ADD CONSTRAINT positive_price
 //	  CHECK (price > 0);
 func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	// Resolve struct → table name once for the field-level synthesis fallback.
+	// Resolve struct → table name once for the field-level synthesis fallbacks.
 	structToTable := make(map[string]string, len(generated.Tables))
 	for _, t := range generated.Tables {
 		structToTable[t.StructName] = t.Name
 	}
 
+	// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved
+	// is a modification (the comparator expresses a changed constraint as
+	// remove + add of the same name — e.g. an on_delete change on a field-level
+	// FK, issue #189). For those we must DROP the old definition before adding
+	// the new one, otherwise the ADD CONSTRAINT collides with the still-present
+	// constraint of the same name. removeConstraints runs later in the pipeline
+	// and deliberately skips these names, so the drop+add is owned here and
+	// ordered correctly.
+	removedNames := make(map[string]struct{}, len(diff.ConstraintsRemoved))
+	for _, name := range diff.ConstraintsRemoved {
+		removedNames[name] = struct{}{}
+	}
+
 	for _, constraintName := range diff.ConstraintsAdded {
-		// First, try the explicit table-level constraints declared via
-		// `//migrator:schema:constraint` annotations.
-		emitted := false
-		for _, constraint := range generated.Constraints {
-			if constraint.Name == constraintName {
-				if astConstraint := p.convertConstraintToAST(constraint); astConstraint != nil {
-					result = append(result, &ast.AlterTableNode{
-						Name:       constraint.Table,
-						Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
-					})
-				}
-				emitted = true
-				break
-			}
-		}
-		if emitted {
-			continue
+		// For a modification, emit the DROP first so it precedes the re-add.
+		if _, modified := removedNames[constraintName]; modified {
+			result = append(result, p.dropConstraintNode(constraintName))
 		}
 
-		// Fall back to field-level `check=` annotations. The schemadiff
-		// comparator synthesizes these names into diff.ConstraintsAdded when
-		// `check=` lands on a column that already exists in the database, but
-		// the synthesized Constraint never reaches generated.Constraints — so
-		// without this fallback an ADD CONSTRAINT for an existing column was
-		// silently dropped. PR #123 introduced the synthesis but left this
-		// emission gap; we close it here.
-		//
-		// New columns are handled by the inline CHECK in ALTER TABLE ADD
-		// COLUMN and the comparator deliberately skips synthesizing them, so
-		// only existing-column field-level CHECKs end up routed through this
-		// path.
-		for _, f := range generated.Fields {
-			if f.Check == "" {
-				continue
+		// Resolve the ADD CONSTRAINT node, in precedence order:
+		//  1. explicit table-level //migrator:schema:constraint
+		//  2. synthesized field-level check= (issue #112 / PR #123)
+		//  3. synthesized field-level foreign= action drift (issue #189)
+		// The two field-level fallbacks exist because the comparator
+		// synthesizes those constraints into diff.ConstraintsAdded by name only
+		// — they never reach generated.Constraints, so without the fallbacks an
+		// ADD CONSTRAINT for an existing column would be silently dropped.
+		if node, ok := p.addConstraintNodeFor(constraintName, generated, structToTable); ok {
+			if node != nil {
+				result = append(result, node)
 			}
-			tableName := structToTable[f.StructName]
-			if tableName == "" {
-				tableName = f.StructName
-			}
-			name := f.CheckName
-			if name == "" {
-				name = tableName + "_" + f.Name + "_check"
-			}
-			if name != constraintName {
-				continue
-			}
-			astConstraint := &ast.ConstraintNode{
-				Type:       ast.CheckConstraint,
-				Name:       name,
-				Expression: f.Check,
-			}
-			result = append(result, &ast.AlterTableNode{
-				Name:       tableName,
-				Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
-			})
-			break
+			continue
 		}
 	}
 	return result
+}
+
+// addConstraintNodeFor resolves the ADD CONSTRAINT node for a constraint known
+// only by name, trying the explicit table-level constraints first and then the
+// synthesized field-level check= / foreign= fallbacks (see addNewConstraints).
+// The returned bool reports whether a matching definition was found; the node
+// may still be nil when a match exists but produces no valid AST (e.g. an
+// EXCLUDE constraint, which convertConstraintToAST cannot represent).
+func (p *Planner) addConstraintNodeFor(constraintName string, generated *goschema.Database, structToTable map[string]string) (ast.Node, bool) {
+	for _, constraint := range generated.Constraints {
+		if constraint.Name != constraintName {
+			continue
+		}
+		if astConstraint := p.convertConstraintToAST(constraint); astConstraint != nil {
+			return &ast.AlterTableNode{
+				Name:       constraint.Table,
+				Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: astConstraint}},
+			}, true
+		}
+		return nil, true
+	}
+
+	if node, ok := p.fieldLevelCheckConstraintNode(constraintName, generated, structToTable); ok {
+		return node, true
+	}
+
+	return p.fieldLevelForeignKeyConstraintNode(constraintName, generated, structToTable)
+}
+
+// fieldLevelCheckConstraintNode builds the ADD CONSTRAINT node for a synthesized
+// field-level check= constraint (issue #112 / PR #123). New columns are handled
+// by the inline CHECK in ALTER TABLE ADD COLUMN, and the comparator deliberately
+// skips synthesizing those, so only existing-column field-level CHECKs reach
+// here.
+func (p *Planner) fieldLevelCheckConstraintNode(constraintName string, generated *goschema.Database, structToTable map[string]string) (ast.Node, bool) {
+	for _, f := range generated.Fields {
+		if f.Check == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		name := f.CheckName
+		if name == "" {
+			name = tableName + "_" + f.Name + "_check"
+		}
+		if name != constraintName {
+			continue
+		}
+		return &ast.AlterTableNode{
+			Name: tableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: &ast.ConstraintNode{
+				Type:       ast.CheckConstraint,
+				Name:       name,
+				Expression: f.Check,
+			}}},
+		}, true
+	}
+	return nil, false
+}
+
+// fieldLevelForeignKeyConstraintNode builds the ADD CONSTRAINT node for a
+// synthesized field-level foreign= constraint whose on_delete / on_update action
+// changed (issue #189). Without this the FK would be dropped (via
+// removeConstraints) but never re-added with the new action — a destructive,
+// silently-broken migration. New columns/tables are handled by the inline FK in
+// CREATE TABLE / ALTER TABLE ADD COLUMN and the comparator deliberately skips
+// synthesizing those, so only existing-column FK action changes reach here.
+func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, generated *goschema.Database, structToTable map[string]string) (ast.Node, bool) {
+	for _, f := range generated.Fields {
+		if f.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		name := f.ForeignKeyName
+		if name == "" {
+			name = "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(f.Name)
+		}
+		if name != constraintName {
+			continue
+		}
+		fkRef := fromschema.ParseForeignKeyReference(f.Foreign)
+		if fkRef == nil {
+			continue
+		}
+		fkRef.OnDelete = f.OnDelete
+		fkRef.OnUpdate = f.OnUpdate
+		return p.createForeignKeyAlterStatement(tableName, name, []string{f.Name}, fkRef), true
+	}
+	return nil, false
 }
 
 // removeConstraints removes table-level constraints via ALTER TABLE statements.
@@ -1105,34 +1174,70 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	// Unsafe names trigger a DO block whose only action is RAISE EXCEPTION,
 	// so the migration fails loudly with the operator's attention — better
 	// than a silent comment that would loop forever on subsequent runs.
-	for _, constraintName := range diff.ConstraintsRemoved {
-		escaped := strings.ReplaceAll(constraintName, "'", "''")
-		if strings.ContainsAny(constraintName, "$\n\r") {
-			// Build a printable, single-quoted SQL string literal of the
-			// rejected name so the operator's error output shows what was
-			// rejected. `$` is rendered as `\$` so the surrounding `$ptah$`
-			// dollar quoting can't be prematurely terminated; `\n` / `\r` /
-			// `\t` are rendered as their printable escapes; apostrophes are
-			// SQL-escaped via `''`. The result is plain ASCII inside `'…'`.
-			visible := strings.NewReplacer(
-				"\n", `\n`,
-				"\r", `\r`,
-				"\t", `\t`,
-				"$", `\$`,
-			).Replace(constraintName)
-			visible = strings.ReplaceAll(visible, "'", "''")
+	// Constraints that appear in BOTH ConstraintsAdded and ConstraintsRemoved
+	// are modifications (the comparator expresses a changed constraint as
+	// remove + add of the same name). Those are emitted as DROP-then-ADD by
+	// addNewConstraints, which runs earlier in the pipeline so the drop
+	// precedes the re-add. Dropping them again here would remove the freshly
+	// added constraint, so skip them.
+	addedNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
+	for _, name := range diff.ConstraintsAdded {
+		addedNames[name] = struct{}{}
+	}
 
-			failBlock := fmt.Sprintf(`-- Unsafe constraint name rejected by the migration generator; the
+	for _, constraintName := range diff.ConstraintsRemoved {
+		if _, modified := addedNames[constraintName]; modified {
+			continue
+		}
+		result = append(result, p.dropConstraintNode(constraintName))
+	}
+	return result
+}
+
+// dropConstraintNode builds a self-contained DROP CONSTRAINT statement for a
+// constraint known only by name. The diff layer discards the table name for
+// removed constraints (field-level CHECK / FK constraints are synthesized and
+// presented by name alone), so the table is resolved at execution time from
+// information_schema via a DO block.
+//
+// Constraint-name safety. Postgres constraint names should be plain ASCII
+// alnum + underscore; we reject only the chars that would actually break our
+// specific DO-block template:
+//   - `$` would collide with the `$ptah$` dollar-quote tag and terminate the
+//     body early.
+//   - newline / carriage return would terminate the leading `--` comment line
+//     and dump whatever follows as bare SQL.
+//
+// Anything else (apostrophe) is handled by SQL-literal escaping. Unsafe names
+// produce a DO block whose only action is RAISE EXCEPTION, so the migration
+// fails loudly rather than silently looping forever on subsequent runs.
+func (p *Planner) dropConstraintNode(constraintName string) ast.Node {
+	escaped := strings.ReplaceAll(constraintName, "'", "''")
+	if strings.ContainsAny(constraintName, "$\n\r") {
+		// Build a printable, single-quoted SQL string literal of the
+		// rejected name so the operator's error output shows what was
+		// rejected. `$` is rendered as `\$` so the surrounding `$ptah$`
+		// dollar quoting can't be prematurely terminated; `\n` / `\r` /
+		// `\t` are rendered as their printable escapes; apostrophes are
+		// SQL-escaped via `''`. The result is plain ASCII inside `'…'`.
+		visible := strings.NewReplacer(
+			"\n", `\n`,
+			"\r", `\r`,
+			"\t", `\t`,
+			"$", `\$`,
+		).Replace(constraintName)
+		visible = strings.ReplaceAll(visible, "'", "''")
+
+		failBlock := fmt.Sprintf(`-- Unsafe constraint name rejected by the migration generator; the
 -- following DO block raises an exception so the migration fails loudly.
 DO $ptah$
 BEGIN
     RAISE EXCEPTION 'refusing to drop constraint with unsafe name ''%s''; rename the constraint and regenerate the migration';
 END
 $ptah$`, visible)
-			result = append(result, ast.NewRawSQL(failBlock))
-			continue
-		}
-		doBlock := fmt.Sprintf(`-- Drop constraint %s (table resolved at runtime from information_schema)
+		return ast.NewRawSQL(failBlock)
+	}
+	doBlock := fmt.Sprintf(`-- Drop constraint %s (table resolved at runtime from information_schema)
 DO $ptah$
 DECLARE
     target_table TEXT;
@@ -1152,9 +1257,7 @@ BEGIN
 END
 $ptah$`, constraintName, escaped, escaped, escaped, escaped)
 
-		result = append(result, ast.NewRawSQL(doBlock))
-	}
-	return result
+	return ast.NewRawSQL(doBlock)
 }
 
 // convertConstraintToAST converts a goschema.Constraint to an ast.ConstraintNode.

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -163,7 +163,7 @@ func (p *Planner) addRegularForeignKeys(result []ast.Node, generated *goschema.D
 		if fkRef != nil && fkRef.Table != table.Name {
 			fkRef.OnDelete = field.OnDelete
 			fkRef.OnUpdate = field.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, field.ForeignKeyName, []string{field.Name}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.Name, foreignKeyName(table.Name, field), []string{field.Name}, fkRef))
 		}
 	}
 	return result
@@ -181,16 +181,47 @@ func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *go
 		if fkRef != nil {
 			fkRef.OnDelete = selfRefFK.OnDelete
 			fkRef.OnUpdate = selfRefFK.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfRefFK.ForeignKeyName, []string{selfRefFK.FieldName}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfReferencingForeignKeyName(table.Name, selfRefFK), []string{selfRefFK.FieldName}, fkRef))
 		}
 	}
 
 	return result
 }
 
-// isRegularForeignKeyField checks if a field is a regular foreign key field for the given table
+// selfReferencingForeignKeyName returns the constraint name for a
+// self-referencing field-level foreign key, deriving the conventional
+// fk_<table>_<field> name when foreign_key_name= was omitted (same rule as the
+// regular field path in foreignKeyName).
+func selfReferencingForeignKeyName(tableName string, fk goschema.SelfReferencingFK) string {
+	if fk.ForeignKeyName != "" {
+		return fk.ForeignKeyName
+	}
+	return fromschema.GenerateForeignKeyName(tableName, fk.FieldName)
+}
+
+// isRegularForeignKeyField checks if a field is a regular foreign key field for the given table.
+//
+// A field-level foreign= annotation is a foreign key regardless of whether the
+// author supplied an explicit foreign_key_name=. When the name is omitted the
+// planner derives the conventional fk_<table>_<column> name (see
+// foreignKeyName) so the constraint is actually created in the database with a
+// stable, named identity. Without this an anonymous field-level FK on a newly
+// created table was silently dropped from the migration, which made the
+// schemadiff comparator (which synthesizes the FK under the conventional name)
+// re-report it as missing forever (issue #189 round-trip failure).
 func isRegularForeignKeyField(field goschema.Field, table goschema.Table) bool {
-	return field.StructName == table.StructName && field.Foreign != "" && field.ForeignKeyName != ""
+	return field.StructName == table.StructName && field.Foreign != ""
+}
+
+// foreignKeyName returns the constraint name to use for a field-level foreign
+// key: the explicit foreign_key_name= when set, otherwise the conventional
+// fk_<table>_<column> name shared with the schemadiff comparator and the down
+// path via fromschema.GenerateForeignKeyName.
+func foreignKeyName(tableName string, field goschema.Field) string {
+	if field.ForeignKeyName != "" {
+		return field.ForeignKeyName
+	}
+	return fromschema.GenerateForeignKeyName(tableName, field.Name)
 }
 
 // createForeignKeyAlterStatement creates an ALTER TABLE statement for adding a foreign key constraint
@@ -270,17 +301,18 @@ func (p *Planner) addForeignKeyConstraintsForNewColumns(result []ast.Node, table
 		}
 
 		// Only process fields that have foreign key constraints
-		if targetField != nil && targetField.Foreign != "" && targetField.ForeignKeyName != "" {
+		if targetField != nil && targetField.Foreign != "" {
 			// Parse the foreign key reference
 			fkRef := fromschema.ParseForeignKeyReference(targetField.Foreign)
 			if fkRef != nil {
-				fkRef.Name = targetField.ForeignKeyName
+				fkName := foreignKeyName(tableDiff.TableName, *targetField)
+				fkRef.Name = fkName
 				fkRef.OnDelete = targetField.OnDelete
 				fkRef.OnUpdate = targetField.OnUpdate
 
 				// Create foreign key constraint
 				fkConstraint := ast.NewForeignKeyConstraint(
-					targetField.ForeignKeyName,
+					fkName,
 					[]string{targetField.Name},
 					fkRef,
 				)
@@ -1108,10 +1140,7 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 		if tableName == "" {
 			tableName = f.StructName
 		}
-		name := f.ForeignKeyName
-		if name == "" {
-			name = "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(f.Name)
-		}
+		name := foreignKeyName(tableName, f)
 		if name != constraintName {
 			continue
 		}

--- a/migration/schemadiff/fk_action_drift_mysql_test.go
+++ b/migration/schemadiff/fk_action_drift_mysql_test.go
@@ -1,0 +1,111 @@
+package schemadiff_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// TestCompare_FieldLevelForeignKeyActionDrift_MySQL is the MySQL/MariaDB
+// counterpart of the PostgreSQL end-to-end acceptance test for issue #189. The
+// comparator is dialect-agnostic, so it detects the same field-level FK action
+// drift; this test pins that the MySQL planner now renders a real
+// `ALTER TABLE ... DROP FOREIGN KEY` followed by a re-ADD carrying the new
+// action (previously it emitted only a non-actionable TODO comment, producing a
+// perpetually re-firing, non-functional migration).
+func TestCompare_FieldLevelForeignKeyActionDrift_MySQL(t *testing.T) {
+	c := qt.New(t)
+
+	gen := exportsSchema("SET NULL")
+	diff := schemadiff.CompareWithDialect(gen, exportsDBSchema("NO ACTION"), "mysql")
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+	c.Assert(diff.ConstraintsAdded, qt.Contains, "fk_export_file")
+	c.Assert(diff.ConstraintsRemoved, qt.Contains, "fk_export_file")
+	// The removal info must carry the owning table and the FK type so the
+	// planner can pick the DROP FOREIGN KEY syntax.
+	c.Assert(diff.ConstraintsRemovedWithTables, qt.HasLen, 1)
+	c.Assert(diff.ConstraintsRemovedWithTables[0].TableName, qt.Equals, "exports")
+	c.Assert(diff.ConstraintsRemovedWithTables[0].Type, qt.Equals, "FOREIGN KEY")
+
+	nodes := mysql.New().GenerateMigrationAST(diff, gen)
+	sql, err := renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	const dropStmt = "ALTER TABLE exports DROP FOREIGN KEY fk_export_file;"
+	const addStmt = "ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE SET NULL;"
+
+	c.Assert(strings.Contains(sql, dropStmt), qt.IsTrue,
+		qt.Commentf("expected a real DROP FOREIGN KEY (not a TODO comment), got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "TODO"), qt.IsFalse,
+		qt.Commentf("must not emit a TODO placeholder, got:\n%s", sql))
+
+	// Ordering: the DROP must precede the ADD so the re-add does not collide
+	// with the still-present same-named constraint.
+	dropIdx := strings.Index(sql, dropStmt)
+	addIdx := strings.Index(sql, "ADD CONSTRAINT fk_export_file")
+	c.Assert(dropIdx >= 0, qt.IsTrue)
+	c.Assert(addIdx >= 0, qt.IsTrue)
+	c.Assert(dropIdx < addIdx, qt.IsTrue,
+		qt.Commentf("DROP must come before ADD; drop@%d add@%d\n%s", dropIdx, addIdx, sql))
+
+	// The re-added FK carries the new ON DELETE action.
+	c.Assert(strings.Contains(sql, addStmt), qt.IsTrue,
+		qt.Commentf("expected the FK to be re-added with ON DELETE SET NULL, got:\n%s", sql))
+}
+
+// TestCompare_FieldLevelForeignKeyActionIdempotency_MySQL proves the MySQL path
+// does not loop drop+add. SET NULL == SET NULL is a no-op, and crucially the
+// MariaDB RESTRICT-as-default fold makes "" / NO ACTION == RESTRICT a no-op too
+// (MariaDB reports an unspecified action as RESTRICT). Without the dialect fold
+// MariaDB would re-fire the migration on every generate.
+func TestCompare_FieldLevelForeignKeyActionIdempotency_MySQL(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect+" SET NULL is a no-op", func(t *testing.T) {
+			cc := qt.New(t)
+			diff := schemadiff.CompareWithDialect(exportsSchema("SET NULL"), exportsDBSchema("SET NULL"), dialect)
+			cc.Assert(diff.HasChanges(), qt.IsFalse)
+		})
+
+		t.Run(dialect+" empty action vs NO ACTION default is a no-op", func(t *testing.T) {
+			cc := qt.New(t)
+			diff := schemadiff.CompareWithDialect(exportsSchema(""), exportsDBSchema("NO ACTION"), dialect)
+			cc.Assert(diff.HasChanges(), qt.IsFalse)
+		})
+	}
+
+	// MariaDB reports the default action as RESTRICT; InnoDB treats RESTRICT and
+	// NO ACTION identically, so an FK declared without an action must round-trip
+	// to no change against a RESTRICT-reporting database.
+	mariaDiff := schemadiff.CompareWithDialect(exportsSchema(""), exportsDBSchema("RESTRICT"), "mariadb")
+	c.Assert(mariaDiff.HasChanges(), qt.IsFalse,
+		qt.Commentf("MariaDB RESTRICT default must fold to NO ACTION; got %+v", mariaDiff))
+}
+
+// TestCompare_ForeignKeyRestrictIsRealOnPostgres guards the dialect-scoping of
+// the RESTRICT fold: on PostgreSQL RESTRICT and NO ACTION are genuinely
+// different (RESTRICT is checked immediately, NO ACTION is deferrable), so a
+// change between them MUST still be detected. Folding them globally would mask
+// this real change.
+func TestCompare_ForeignKeyRestrictIsRealOnPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	// Entity declares ON DELETE RESTRICT, database has the default NO ACTION:
+	// this is a genuine change on PostgreSQL and must be detected.
+	diff := schemadiff.CompareWithDialect(exportsSchema("RESTRICT"), exportsDBSchema("NO ACTION"), "postgres")
+	c.Assert(diff.HasChanges(), qt.IsTrue,
+		qt.Commentf("PostgreSQL RESTRICT != NO ACTION must be detected; got %+v", diff))
+
+	// On MySQL/MariaDB the same pair is intentionally a no-op.
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		mysqlDiff := schemadiff.CompareWithDialect(exportsSchema("RESTRICT"), exportsDBSchema("NO ACTION"), dialect)
+		c.Assert(mysqlDiff.HasChanges(), qt.IsFalse,
+			qt.Commentf("%s RESTRICT == NO ACTION must be a no-op; got %+v", dialect, mysqlDiff))
+	}
+}

--- a/migration/schemadiff/fk_action_drift_test.go
+++ b/migration/schemadiff/fk_action_drift_test.go
@@ -1,0 +1,175 @@
+package schemadiff_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func strPtr(s string) *string { return &s }
+
+// exportsSchema returns a generated schema with an exports.file_id field-level
+// FK whose ON DELETE action is set to onDelete (empty string == no action).
+func exportsSchema(onDelete string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+		Fields: []goschema.Field{
+			{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+			{
+				StructName:     "Export",
+				Name:           "file_id",
+				Type:           "TEXT",
+				Nullable:       true,
+				Foreign:        "files(id)",
+				ForeignKeyName: "fk_export_file",
+				OnDelete:       onDelete,
+			},
+		},
+	}
+}
+
+// exportsDBSchema returns an introspected DB schema for the exports table whose
+// existing FK carries the given delete rule (empty string == NO ACTION default).
+func exportsDBSchema(deleteRule string) *types.DBSchema {
+	if deleteRule == "" {
+		deleteRule = "NO ACTION"
+	}
+	return &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "exports",
+				// Realistic column shapes so the column comparator is silent
+				// and the FK action is the only variable under test. id is the
+				// applied TEXT primary key; file_id is a nullable TEXT FK column.
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+					{Name: "file_id", DataType: "text", IsNullable: "YES"},
+				},
+			},
+		},
+		Constraints: []types.DBConstraint{
+			{
+				Name:          "fk_export_file",
+				TableName:     "exports",
+				Type:          "FOREIGN KEY",
+				ColumnName:    "file_id",
+				ForeignTable:  strPtr("files"),
+				ForeignColumn: strPtr("id"),
+				DeleteRule:    strPtr(deleteRule),
+				UpdateRule:    strPtr("NO ACTION"),
+			},
+		},
+	}
+}
+
+// TestCompare_FieldLevelForeignKeyActionDrift is the end-to-end acceptance test
+// for issue #189: an on_delete change on an existing field-level FK must be a
+// real, non-empty change through the public schemadiff.Compare API, while an
+// unchanged FK (including "" == NO ACTION) must be a no-op.
+func TestCompare_FieldLevelForeignKeyActionDrift(t *testing.T) {
+	t.Run("NO ACTION -> SET NULL is detected as a change", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := schemadiff.Compare(exportsSchema("SET NULL"), exportsDBSchema("NO ACTION"))
+
+		c.Assert(diff.HasChanges(), qt.IsTrue)
+		// Drop + add of the same FK name (modified constraints are expressed as
+		// removed + added today).
+		c.Assert(diff.ConstraintsAdded, qt.Contains, "fk_export_file")
+		c.Assert(diff.ConstraintsRemoved, qt.Contains, "fk_export_file")
+	})
+
+	t.Run("unchanged SET NULL FK is a no-op", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := schemadiff.Compare(exportsSchema("SET NULL"), exportsDBSchema("SET NULL"))
+
+		c.Assert(diff.HasChanges(), qt.IsFalse)
+	})
+
+	t.Run("empty action vs NO ACTION default is a no-op", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := schemadiff.Compare(exportsSchema(""), exportsDBSchema("NO ACTION"))
+
+		c.Assert(diff.HasChanges(), qt.IsFalse)
+	})
+}
+
+// TestCompare_FieldLevelForeignKeyActionIdempotency proves the fix does not
+// introduce a perpetual drop+add loop: once the schema and the database agree
+// on the FK action, repeated Compare runs keep reporting no changes. This is
+// the explicit idempotency proof called for by the issue acceptance criteria.
+func TestCompare_FieldLevelForeignKeyActionIdempotency(t *testing.T) {
+	c := qt.New(t)
+
+	generated := exportsSchema("SET NULL")
+	// The database now reflects the applied SET NULL action.
+	database := exportsDBSchema("SET NULL")
+
+	// Run Compare twice against the same (already-converged) inputs. Both runs
+	// must report no changes — no churn on repeated `generate`.
+	first := schemadiff.Compare(generated, database)
+	c.Assert(first.HasChanges(), qt.IsFalse, qt.Commentf("first run should be a no-op"))
+
+	second := schemadiff.Compare(generated, database)
+	c.Assert(second.HasChanges(), qt.IsFalse, qt.Commentf("second run should remain a no-op"))
+
+	// And the empty-action default likewise converges and stays converged.
+	noActionGen := exportsSchema("")
+	noActionDB := exportsDBSchema("NO ACTION")
+	c.Assert(schemadiff.Compare(noActionGen, noActionDB).HasChanges(), qt.IsFalse)
+	c.Assert(schemadiff.Compare(noActionGen, noActionDB).HasChanges(), qt.IsFalse)
+}
+
+// TestCompare_FieldLevelForeignKeyActionMigrationSQL pins the emitted migration
+// for a field-level FK action change end-to-end through the postgres planner +
+// renderer. The comparator routes the synthesized FK into ConstraintsAdded /
+// ConstraintsRemoved (a modification), so the planner must emit a DROP of the
+// old constraint BEFORE the ADD of the new one — otherwise the ADD CONSTRAINT
+// collides with the still-present same-named constraint. Without the planner
+// fallback that re-synthesizes the field-level FK, the migration would drop the
+// FK and never re-add it (a destructive, silently-broken migration).
+func TestCompare_FieldLevelForeignKeyActionMigrationSQL(t *testing.T) {
+	c := qt.New(t)
+
+	gen := exportsSchema("SET NULL")
+	diff := schemadiff.Compare(gen, exportsDBSchema("NO ACTION"))
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+
+	nodes := postgres.New().GenerateMigrationAST(diff, gen)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	// The new FK with the action clause is emitted.
+	const addStmt = "ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE SET NULL;"
+	c.Assert(strings.Contains(sql, addStmt), qt.IsTrue,
+		qt.Commentf("expected migration to ADD the FK with ON DELETE SET NULL, got:\n%s", sql))
+
+	// The old constraint is dropped first (resolved at runtime via a DO block).
+	c.Assert(strings.Contains(sql, "DROP CONSTRAINT IF EXISTS"), qt.IsTrue,
+		qt.Commentf("expected migration to DROP the old FK, got:\n%s", sql))
+
+	// Ordering: the DROP must precede the ADD so the re-add does not collide.
+	dropIdx := strings.Index(sql, "Drop constraint fk_export_file")
+	addIdx := strings.Index(sql, addStmt)
+	c.Assert(dropIdx >= 0, qt.IsTrue)
+	c.Assert(addIdx >= 0, qt.IsTrue)
+	c.Assert(dropIdx < addIdx, qt.IsTrue,
+		qt.Commentf("DROP must come before ADD; drop@%d add@%d\n%s", dropIdx, addIdx, sql))
+
+	// Idempotency: once applied, regenerating produces no statements.
+	converged := schemadiff.Compare(exportsSchema("SET NULL"), exportsDBSchema("SET NULL"))
+	noopNodes := postgres.New().GenerateMigrationAST(converged, exportsSchema("SET NULL"))
+	noopSQL, err := renderer.RenderSQL("postgres", noopNodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.TrimSpace(noopSQL), qt.Equals, "",
+		qt.Commentf("converged schema must produce an empty migration, got:\n%s", noopSQL))
+}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -879,11 +879,34 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 		}
 	}
 
+	// Synthesize table-level Constraint entries from field-level `foreign=`
+	// annotations so on_delete / on_update drift on an existing field-level
+	// FK participates in comparison (issue #189), mirroring the field-level
+	// CHECK synthesis above. Only synthesized for columns that already exist
+	// in the database — new tables/columns get their FK inline via CREATE
+	// TABLE / ALTER TABLE ADD CONSTRAINT, so emitting an ADD CONSTRAINT here
+	// would double-create it in the same migration step.
+	//
+	// synthesizedFKKeys records the table.constraint_name of every synthesized
+	// field-level FK so isFieldLevelConstraint can let the matching DB-side FK
+	// through to the comparison instead of filtering it out — otherwise
+	// foreignKeyConstraintChanged would never run for field-level FKs.
+	synthesizedFKKeys := make(map[string]struct{})
+	for _, synthesized := range synthesizeFieldLevelForeignKeyConstraints(generated, database) {
+		key := synthesized.Table + "." + synthesized.Name
+		synthesizedFKKeys[key] = struct{}{}
+		// Don't clobber an explicit table-level constraint that happens to
+		// share the same name.
+		if _, exists := genConstraints[key]; !exists {
+			genConstraints[key] = synthesized
+		}
+	}
+
 	// Create map of existing database constraints, filtering out field-level constraints
 	dbConstraints := make(map[string]types.DBConstraint)
 	for _, constraint := range database.Constraints {
 		// Skip field-level constraints that are represented in field definitions
-		if isFieldLevelConstraint(constraint, generated) {
+		if isFieldLevelConstraint(constraint, generated, synthesizedFKKeys) {
 			continue
 		}
 
@@ -1000,7 +1023,15 @@ func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint typ
 	return false // For now, assume UNIQUE constraints don't change
 }
 
-// foreignKeyConstraintChanged compares FOREIGN KEY constraint definitions
+// foreignKeyConstraintChanged compares FOREIGN KEY constraint definitions.
+//
+// Referential actions are normalized before comparison (see
+// normalizeReferentialAction): databases report the default action as
+// "NO ACTION" via information_schema.referential_constraints, whereas a Go
+// annotation that omits on_delete/on_update leaves the value empty. Without
+// the normalization the two would never match for FKs declared without an
+// explicit action, producing a perpetual drop+add loop on every `generate`
+// (the same hazard checkConstraintChanged guards against for CHECK clauses).
 func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
 	// Compare referenced table
 	if genConstraint.ForeignTable != getStringValue(dbConstraint.ForeignTable) {
@@ -1013,16 +1044,34 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 	}
 
 	// Compare delete rule
-	if genConstraint.OnDelete != getStringValue(dbConstraint.DeleteRule) {
+	if normalizeReferentialAction(genConstraint.OnDelete) != normalizeReferentialAction(getStringValue(dbConstraint.DeleteRule)) {
 		return true
 	}
 
 	// Compare update rule
-	if genConstraint.OnUpdate != getStringValue(dbConstraint.UpdateRule) {
+	if normalizeReferentialAction(genConstraint.OnUpdate) != normalizeReferentialAction(getStringValue(dbConstraint.UpdateRule)) {
 		return true
 	}
 
 	return false
+}
+
+// normalizeReferentialAction canonicalizes an ON DELETE / ON UPDATE action so
+// that semantically identical values compare equal across the generated and
+// introspected sides.
+//
+// SQL treats an omitted referential action as NO ACTION. PostgreSQL and
+// MySQL/MariaDB both report it as the literal "NO ACTION" through
+// information_schema.referential_constraints, while a Go field annotation that
+// simply omits on_delete/on_update yields an empty string. Trimming,
+// upper-casing, and folding "" into "NO ACTION" makes those equivalent and
+// keeps an unchanged FK a no-op on repeated runs.
+func normalizeReferentialAction(action string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(action))
+	if normalized == "" {
+		return "NO ACTION"
+	}
+	return normalized
 }
 
 // getStringValue safely extracts string value from a pointer, returning empty string if nil
@@ -1034,8 +1083,17 @@ func getStringValue(ptr *string) string {
 }
 
 // isFieldLevelConstraint determines if a database constraint represents a field-level constraint
-// that is already represented in the field definitions (NOT NULL, PRIMARY KEY, UNIQUE, FOREIGN KEY)
-func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema.Database) bool {
+// that is already represented in the field definitions (NOT NULL, PRIMARY KEY, UNIQUE, FOREIGN KEY).
+//
+// synthesizedFKKeys holds the table.constraint_name of every field-level FK that
+// Constraints() synthesized into the generated set (see
+// synthesizeFieldLevelForeignKeyConstraints). When a DB-side FK has a synthesized
+// counterpart it is NOT treated as field-level here, so it stays in the
+// comparison and on_delete / on_update drift flows through
+// foreignKeyConstraintChanged (issue #189). FKs without a synthesized
+// counterpart (e.g. a column that is not yet in the database, which never gets
+// synthesized) keep the previous filter-out behavior.
+func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema.Database, synthesizedFKKeys map[string]struct{}) bool {
 	// Create a map of table.column -> field for quick lookup
 	fieldMap := make(map[string]goschema.Field)
 	for _, field := range generated.Fields {
@@ -1072,7 +1130,22 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 			return true
 		}
 	case "FOREIGN KEY":
-		// Check if there's a field with foreign key reference for this column
+		// A field-level FK that was synthesized into the generated set (see
+		// synthesizeFieldLevelForeignKeyConstraints) must participate in the
+		// comparison so on_delete / on_update drift is detected (issue #189).
+		// Letting the DB-side FK through means it gets matched by name against
+		// the synthesized entry, so add / remove / action-change cases all
+		// flow through the standard Constraints() comparison path. Match on
+		// the constraint name rather than the column, because the synthesized
+		// name is keyed on table.constraint_name and getConstraintColumn does
+		// not always resolve the FK column.
+		if _, synthesized := synthesizedFKKeys[dbConstraint.TableName+"."+dbConstraint.Name]; synthesized {
+			return false
+		}
+		// Check if there's a field with foreign key reference for this column.
+		// No synthesized counterpart (e.g. the column is not yet in the
+		// database): keep the historical behavior and treat it as field-level
+		// so it is owned by the column/table lifecycle.
 		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
 		if field, exists := fieldMap[key]; exists && field.Foreign != "" {
 			return true
@@ -1170,6 +1243,102 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 		})
 	}
 	return synthesized
+}
+
+// synthesizeFieldLevelForeignKeyConstraints turns each field-level `foreign=`
+// annotation on an existing database column into a synthetic
+// goschema.Constraint of type FOREIGN KEY so the standard Constraints() diff
+// path can compare it against the introspected FK from
+// information_schema.referential_constraints. This is what makes on_delete /
+// on_update drift on a pre-existing field-level FK observable (issue #189).
+//
+// The constraint name follows the user-provided `foreign_key_name=` value when
+// set, otherwise it falls back to the conventional generated name
+// "fk_<table>_<column>" — matching generateForeignKeyName in
+// core/convert/fromschema, which is the name the planner emits when it creates
+// the FK, so the synthesized name lines up with whatever the reader sees on the
+// DB side.
+//
+// Columns that do not yet exist in the database are deliberately skipped: those
+// FKs ship inline as part of CREATE TABLE / ALTER TABLE ADD COLUMN, and emitting
+// an ADD CONSTRAINT alongside would attempt to create the same constraint twice
+// in the same migration. This mirrors synthesizeFieldLevelCheckConstraints
+// exactly and is what keeps added-table generation untouched.
+//
+// Precedence: an explicit table-level constraint declared via
+// `//migrator:schema:constraint` that happens to share the synthesized name
+// wins — synthesis never clobbers it (see the guard in Constraints()).
+func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, database *types.DBSchema) []goschema.Constraint {
+	if generated == nil || database == nil {
+		return nil
+	}
+
+	structToTable := make(map[string]string, len(generated.Tables))
+	for _, t := range generated.Tables {
+		structToTable[t.StructName] = t.Name
+	}
+
+	dbColumns := make(map[string]struct{}, 16)
+	for _, t := range database.Tables {
+		for _, c := range t.Columns {
+			dbColumns[t.Name+"."+c.Name] = struct{}{}
+		}
+	}
+
+	var synthesized []goschema.Constraint
+	for _, f := range generated.Fields {
+		if f.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[f.StructName]
+		if tableName == "" {
+			tableName = f.StructName
+		}
+		if _, exists := dbColumns[tableName+"."+f.Name]; !exists {
+			continue
+		}
+		name := f.ForeignKeyName
+		if name == "" {
+			name = "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(f.Name)
+		}
+		foreignTable, foreignColumn := parseForeignReference(f.Foreign)
+		synthesized = append(synthesized, goschema.Constraint{
+			StructName:    f.StructName,
+			Name:          name,
+			Type:          "FOREIGN KEY",
+			Table:         tableName,
+			Columns:       []string{f.Name},
+			ForeignTable:  foreignTable,
+			ForeignColumn: foreignColumn,
+			OnDelete:      f.OnDelete,
+			OnUpdate:      f.OnUpdate,
+		})
+	}
+	return synthesized
+}
+
+// parseForeignReference splits a field-level `foreign=` reference into its
+// referenced table and column. It accepts the "table(column)" form and the
+// bare "table" form, which defaults to referencing the "id" column — the same
+// rules core/convert/fromschema.ParseForeignKeyReference uses on the generate
+// path, kept in agreement here so the synthesized FK matches what the planner
+// emits. A malformed reference yields the trimmed input as the table and an
+// empty column.
+func parseForeignReference(foreign string) (table, column string) {
+	foreign = strings.TrimSpace(foreign)
+	if foreign == "" {
+		return "", ""
+	}
+
+	open := strings.Index(foreign, "(")
+	if open == -1 || !strings.HasSuffix(foreign, ")") {
+		// Bare "table" form references the conventional "id" column.
+		return foreign, "id"
+	}
+
+	table = strings.TrimSpace(foreign[:open])
+	column = strings.TrimSpace(foreign[open+1 : len(foreign)-1])
+	return table, column
 }
 
 // getConstraintColumn extracts the column name from a constraint

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff/internal/normalize"
@@ -854,7 +855,12 @@ func isConstraintBasedUniqueIndex(indexName, tableName string, columns []string)
 //   - Database constraint introspection is not yet fully implemented
 //   - Currently focuses on constraint additions from generated schema
 //   - Constraint modifications are not yet detected
-func Constraints(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+func Constraints(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, opts *config.CompareOptions) {
+	dialect := ""
+	if opts != nil {
+		dialect = opts.Dialect
+	}
+
 	// Create maps for detailed constraint comparison
 	genConstraints := make(map[string]goschema.Constraint)
 	for _, constraint := range generated.Constraints {
@@ -926,25 +932,40 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	for constraintKey, dbConstraint := range dbConstraints {
 		if _, exists := genConstraints[constraintKey]; !exists {
 			diff.ConstraintsRemoved = append(diff.ConstraintsRemoved, dbConstraint.Name)
+			diff.ConstraintsRemovedWithTables = appendConstraintRemoval(diff.ConstraintsRemovedWithTables, dbConstraint)
 		}
 	}
 
 	// Find modified constraints (constraints that exist in both but have different definitions)
 	for constraintKey, genConstraint := range genConstraints {
 		if dbConstraint, exists := dbConstraints[constraintKey]; exists {
-			if constraintDefinitionsChanged(genConstraint, dbConstraint) {
+			if constraintDefinitionsChanged(genConstraint, dbConstraint, dialect) {
 				// For now, treat modified constraints as removed + added
 				// In the future, we could add a ConstraintsModified field to SchemaDiff
 				diff.ConstraintsRemoved = append(diff.ConstraintsRemoved, dbConstraint.Name)
+				diff.ConstraintsRemovedWithTables = appendConstraintRemoval(diff.ConstraintsRemovedWithTables, dbConstraint)
 				diff.ConstraintsAdded = append(diff.ConstraintsAdded, genConstraint.Name)
 			}
 		}
 	}
 }
 
+// appendConstraintRemoval records the table-qualified removal info for a
+// database constraint that is being dropped (or modified, which is expressed as
+// remove + add). Dialects that need the owning table and a type-specific drop
+// syntax — MySQL/MariaDB FOREIGN KEY uses DROP FOREIGN KEY rather than DROP
+// CONSTRAINT — read this parallel slice instead of the bare name list.
+func appendConstraintRemoval(infos []difftypes.ConstraintRemovalInfo, dbConstraint types.DBConstraint) []difftypes.ConstraintRemovalInfo {
+	return append(infos, difftypes.ConstraintRemovalInfo{
+		Name:      dbConstraint.Name,
+		TableName: dbConstraint.TableName,
+		Type:      dbConstraint.Type,
+	})
+}
+
 // constraintDefinitionsChanged compares constraint definitions between generated and database schemas
 // to detect if a constraint needs to be recreated due to definition changes.
-func constraintDefinitionsChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
+func constraintDefinitionsChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint, dialect string) bool {
 	// Basic constraint type comparison
 	if genConstraint.Type != dbConstraint.Type {
 		return true
@@ -959,7 +980,7 @@ func constraintDefinitionsChanged(genConstraint goschema.Constraint, dbConstrain
 	case "UNIQUE":
 		return uniqueConstraintChanged(genConstraint, dbConstraint)
 	case "FOREIGN KEY":
-		return foreignKeyConstraintChanged(genConstraint, dbConstraint)
+		return foreignKeyConstraintChanged(genConstraint, dbConstraint, dialect)
 	default:
 		// For unknown constraint types, assume no change
 		return false
@@ -1032,7 +1053,7 @@ func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint typ
 // the normalization the two would never match for FKs declared without an
 // explicit action, producing a perpetual drop+add loop on every `generate`
 // (the same hazard checkConstraintChanged guards against for CHECK clauses).
-func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
+func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint, dialect string) bool {
 	// Compare referenced table
 	if genConstraint.ForeignTable != getStringValue(dbConstraint.ForeignTable) {
 		return true
@@ -1044,12 +1065,12 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 	}
 
 	// Compare delete rule
-	if normalizeReferentialAction(genConstraint.OnDelete) != normalizeReferentialAction(getStringValue(dbConstraint.DeleteRule)) {
+	if normalizeReferentialAction(genConstraint.OnDelete, dialect) != normalizeReferentialAction(getStringValue(dbConstraint.DeleteRule), dialect) {
 		return true
 	}
 
 	// Compare update rule
-	if normalizeReferentialAction(genConstraint.OnUpdate) != normalizeReferentialAction(getStringValue(dbConstraint.UpdateRule)) {
+	if normalizeReferentialAction(genConstraint.OnUpdate, dialect) != normalizeReferentialAction(getStringValue(dbConstraint.UpdateRule), dialect) {
 		return true
 	}
 
@@ -1060,18 +1081,40 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 // that semantically identical values compare equal across the generated and
 // introspected sides.
 //
-// SQL treats an omitted referential action as NO ACTION. PostgreSQL and
-// MySQL/MariaDB both report it as the literal "NO ACTION" through
+// SQL treats an omitted referential action as NO ACTION. PostgreSQL, MySQL and
+// MariaDB all report the default through
 // information_schema.referential_constraints, while a Go field annotation that
 // simply omits on_delete/on_update yields an empty string. Trimming,
 // upper-casing, and folding "" into "NO ACTION" makes those equivalent and
 // keeps an unchanged FK a no-op on repeated runs.
-func normalizeReferentialAction(action string) string {
+//
+// Dialect-specific RESTRICT handling: MariaDB reports an unspecified action as
+// RESTRICT (PostgreSQL and MySQL report NO ACTION), and InnoDB treats RESTRICT
+// and NO ACTION identically. For the MySQL family RESTRICT is therefore folded
+// to NO ACTION so an unchanged FK does not loop drop+add forever. PostgreSQL
+// distinguishes RESTRICT (checked immediately) from NO ACTION (deferrable) at
+// DDL level, so the fold is NOT applied there — doing so would mask a genuine
+// RESTRICT <-> NO ACTION change the user intended.
+func normalizeReferentialAction(action, dialect string) string {
 	normalized := strings.ToUpper(strings.TrimSpace(action))
 	if normalized == "" {
 		return "NO ACTION"
 	}
+	if normalized == "RESTRICT" && isMySQLFamily(dialect) {
+		return "NO ACTION"
+	}
 	return normalized
+}
+
+// isMySQLFamily reports whether the dialect is MySQL or MariaDB, which share the
+// InnoDB referential-action semantics (RESTRICT == NO ACTION).
+func isMySQLFamily(dialect string) bool {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mysql", "mariadb":
+		return true
+	default:
+		return false
+	}
 }
 
 // getStringValue safely extracts string value from a pointer, returning empty string if nil
@@ -1253,11 +1296,10 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 // on_update drift on a pre-existing field-level FK observable (issue #189).
 //
 // The constraint name follows the user-provided `foreign_key_name=` value when
-// set, otherwise it falls back to the conventional generated name
-// "fk_<table>_<column>" — matching generateForeignKeyName in
-// core/convert/fromschema, which is the name the planner emits when it creates
-// the FK, so the synthesized name lines up with whatever the reader sees on the
-// DB side.
+// set, otherwise it falls back to the conventional generated name from
+// fromschema.GenerateForeignKeyName ("fk_<table>_<column>"), which is the name
+// the planner emits when it creates the FK, so the synthesized name lines up
+// with whatever the reader sees on the DB side.
 //
 // Columns that do not yet exist in the database are deliberately skipped: those
 // FKs ship inline as part of CREATE TABLE / ALTER TABLE ADD COLUMN, and emitting
@@ -1299,46 +1341,30 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		}
 		name := f.ForeignKeyName
 		if name == "" {
-			name = "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(f.Name)
+			name = fromschema.GenerateForeignKeyName(tableName, f.Name)
 		}
-		foreignTable, foreignColumn := parseForeignReference(f.Foreign)
+		// Reuse the canonical generate-path parser so the synthesized table /
+		// column always match exactly what the planner emits (issue #189
+		// follow-up: a single source of truth removes the latent two-parser
+		// divergence). A malformed foreign= reference yields nil and is skipped
+		// rather than synthesizing a garbage constraint.
+		fkRef := fromschema.ParseForeignKeyReference(f.Foreign)
+		if fkRef == nil {
+			continue
+		}
 		synthesized = append(synthesized, goschema.Constraint{
 			StructName:    f.StructName,
 			Name:          name,
 			Type:          "FOREIGN KEY",
 			Table:         tableName,
 			Columns:       []string{f.Name},
-			ForeignTable:  foreignTable,
-			ForeignColumn: foreignColumn,
+			ForeignTable:  fkRef.Table,
+			ForeignColumn: fkRef.Column,
 			OnDelete:      f.OnDelete,
 			OnUpdate:      f.OnUpdate,
 		})
 	}
 	return synthesized
-}
-
-// parseForeignReference splits a field-level `foreign=` reference into its
-// referenced table and column. It accepts the "table(column)" form and the
-// bare "table" form, which defaults to referencing the "id" column — the same
-// rules core/convert/fromschema.ParseForeignKeyReference uses on the generate
-// path, kept in agreement here so the synthesized FK matches what the planner
-// emits. A malformed reference yields the trimmed input as the table and an
-// empty column.
-func parseForeignReference(foreign string) (table, column string) {
-	foreign = strings.TrimSpace(foreign)
-	if foreign == "" {
-		return "", ""
-	}
-
-	open := strings.Index(foreign, "(")
-	if open == -1 || !strings.HasSuffix(foreign, ")") {
-		// Bare "table" form references the conventional "id" column.
-		return foreign, "id"
-	}
-
-	table = strings.TrimSpace(foreign[:open])
-	column = strings.TrimSpace(foreign[open+1 : len(foreign)-1])
-	return table, column
 }
 
 // getConstraintColumn extracts the column name from a constraint
@@ -1530,6 +1556,21 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 		genIndexes[index.Name] = true
 	}
 
+	// MySQL/MariaDB transparently create a backing index for every FOREIGN KEY,
+	// named after the constraint, when no usable index already exists on the
+	// referencing column. That index is owned by the FK, not by the user's
+	// schema, so it must not be reported as a removable index — otherwise an
+	// unchanged field-level FK round-trips to a spurious DROP INDEX (issue #189
+	// follow-up). PostgreSQL does not auto-create FK indexes, so this set is
+	// naturally empty there and the filter is a no-op. Keyed by table.index so a
+	// constraint name only suppresses the index on its own table.
+	fkBackedIndexes := make(map[string]struct{}, len(database.Constraints))
+	for _, c := range database.Constraints {
+		if c.Type == "FOREIGN KEY" {
+			fkBackedIndexes[c.TableName+"."+c.Name] = struct{}{}
+		}
+	}
+
 	dbIndexes := make(map[string]bool)
 	for _, index := range database.Indexes {
 		// Skip primary key indexes as they're handled with tables
@@ -1540,6 +1581,12 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 		// Skip constraint-based unique indexes (automatically created by UNIQUE constraints)
 		// but allow explicitly defined unique indexes (created via schema annotations)
 		if index.IsUnique && isConstraintBasedUniqueIndex(index.Name, index.TableName, index.Columns) {
+			continue
+		}
+
+		// Skip MySQL/MariaDB FK-backing indexes (named after the FK constraint
+		// on the same table). They are auto-managed by the foreign key.
+		if _, ok := fkBackedIndexes[index.TableName+"."+index.Name]; ok {
 			continue
 		}
 

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -158,7 +158,7 @@ func TestConstraints(t *testing.T) {
 			c := qt.New(t)
 
 			diff := &difftypes.SchemaDiff{}
-			compare.Constraints(tt.generated, tt.database, diff)
+			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			// Check constraints added
 			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded))
@@ -240,7 +240,7 @@ func TestConstraints_EdgeCases(t *testing.T) {
 	database := &types.DBSchema{}
 	diff := &difftypes.SchemaDiff{}
 
-	compare.Constraints(generated, database, diff)
+	compare.Constraints(generated, database, diff, nil)
 
 	c.Assert(len(diff.ConstraintsAdded), qt.Equals, 0)
 	c.Assert(len(diff.ConstraintsRemoved), qt.Equals, 0)
@@ -426,7 +426,7 @@ func TestConstraints_ExcludeConstraintComparison(t *testing.T) {
 			c := qt.New(t)
 
 			diff := &difftypes.SchemaDiff{}
-			compare.Constraints(tt.generated, tt.database, diff)
+			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			// Check constraints added
 			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded))
@@ -676,7 +676,7 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 			c := qt.New(t)
 
 			diff := &difftypes.SchemaDiff{}
-			compare.Constraints(tt.generated, tt.database, diff)
+			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
 				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -1,0 +1,339 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestConstraints_FieldLevelForeignKey covers issue #189 — on_delete /
+// on_update drift on a field-level `foreign=` annotation against an
+// already-applied schema must surface as a migration. The compare layer
+// synthesizes a goschema.Constraint of type FOREIGN KEY from the field (for
+// columns that already exist in the introspected database) and lets the
+// matching DB-side FK through, so an action change runs through the standard
+// Constraints() → foreignKeyConstraintChanged path as a drop+add. An unchanged
+// FK — including the "" == NO ACTION default — stays a no-op.
+//
+// This is the diff/drift counterpart to the CREATE/ALTER-time emission fixed by
+// #117 / PR #122; see TestConstraints_FieldLevelCheck for the analogous CHECK
+// coverage that this mirrors.
+func TestConstraints_FieldLevelForeignKey(t *testing.T) {
+	// Shared setup: an "exports" table whose "file_id" column already exists in
+	// the database, so the field-level FK gets synthesized.
+	exportsTable := types.DBTable{
+		Name:    "exports",
+		Columns: []types.DBColumn{{Name: "id"}, {Name: "file_id"}},
+	}
+
+	// dbFK builds the introspected FK row for exports.file_id -> files.id with
+	// the given delete/update rules (nil pointer == rule absent).
+	dbFK := func(deleteRule, updateRule *string) types.DBConstraint {
+		return types.DBConstraint{
+			Name:          "fk_export_file",
+			TableName:     "exports",
+			Type:          "FOREIGN KEY",
+			ColumnName:    "file_id",
+			ForeignTable:  stringPtr("files"),
+			ForeignColumn: stringPtr("id"),
+			DeleteRule:    deleteRule,
+			UpdateRule:    updateRule,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		generated *goschema.Database
+		database  *types.DBSchema
+		expected  *difftypes.SchemaDiff
+	}{
+		{
+			// The headline bug: model says SET NULL, the live FK is NO ACTION.
+			// Expect a drop + add so a non-empty up/down migration is produced.
+			name: "on_delete NO ACTION -> SET NULL surfaces as drop + add",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnDelete:       "SET NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("NO ACTION"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"fk_export_file"},
+				ConstraintsRemoved: []string{"fk_export_file"},
+			},
+		},
+		{
+			// Idempotency #1: SET NULL == SET NULL is a no-op.
+			name: "on_delete SET NULL matches existing — no diff (idempotent)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnDelete:       "SET NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("SET NULL"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// Idempotency #2: the model leaves the action empty while Postgres
+			// reports the default as NO ACTION. The normalization ("" == NO
+			// ACTION, trim + upper-case) must make this a no-op, otherwise every
+			// `generate` would churn the same FK forever.
+			name: "empty action == NO ACTION — no diff (idempotent)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						// OnDelete / OnUpdate intentionally empty.
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("NO ACTION"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// Casing / whitespace differences between the model and the
+			// introspected rule must not register as drift.
+			name: "case-insensitive action match — no diff (idempotent)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnDelete:       "cascade",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("CASCADE"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// on_update drift is detected independently of on_delete.
+			name: "on_update CASCADE drift surfaces as drop + add",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnUpdate:       "CASCADE",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("NO ACTION"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"fk_export_file"},
+				ConstraintsRemoved: []string{"fk_export_file"},
+			},
+		},
+		{
+			// Fallback name: no foreign_key_name= on the annotation, so the
+			// synthesized constraint uses the conventional fk_<table>_<column>
+			// name. The DB FK is introspected under that same generated name, so
+			// the action change still matches and surfaces.
+			name: "fallback fk_<table>_<column> name still matches and detects drift",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName: "Export",
+						Name:       "file_id",
+						Type:       "TEXT",
+						Foreign:    "files(id)",
+						OnDelete:   "SET NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{
+					{
+						Name:          "fk_exports_file_id",
+						TableName:     "exports",
+						Type:          "FOREIGN KEY",
+						ColumnName:    "file_id",
+						ForeignTable:  stringPtr("files"),
+						ForeignColumn: stringPtr("id"),
+						DeleteRule:    stringPtr("NO ACTION"),
+						UpdateRule:    stringPtr("NO ACTION"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"fk_exports_file_id"},
+				ConstraintsRemoved: []string{"fk_exports_file_id"},
+			},
+		},
+		{
+			// Self-referencing FK declared at the field level: parent_id -> the
+			// same table. Changing on_delete must surface just like any other
+			// field-level FK.
+			name: "self-referencing field-level FK action drift surfaces",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Category", Name: "categories"}},
+				Fields: []goschema.Field{
+					{StructName: "Category", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Category",
+						Name:           "parent_id",
+						Type:           "TEXT",
+						Nullable:       true,
+						Foreign:        "categories(id)",
+						ForeignKeyName: "fk_categories_parent",
+						OnDelete:       "SET NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: []types.DBTable{
+					{
+						Name:    "categories",
+						Columns: []types.DBColumn{{Name: "id"}, {Name: "parent_id"}},
+					},
+				},
+				Constraints: []types.DBConstraint{
+					{
+						Name:          "fk_categories_parent",
+						TableName:     "categories",
+						Type:          "FOREIGN KEY",
+						ColumnName:    "parent_id",
+						ForeignTable:  stringPtr("categories"),
+						ForeignColumn: stringPtr("id"),
+						DeleteRule:    stringPtr("NO ACTION"),
+						UpdateRule:    stringPtr("NO ACTION"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"fk_categories_parent"},
+				ConstraintsRemoved: []string{"fk_categories_parent"},
+			},
+		},
+		{
+			// Non-regression: a field-level FK on a column that does NOT yet
+			// exist in the database must not be synthesized — the FK ships
+			// inline with the CREATE TABLE / ADD COLUMN, so emitting an ADD
+			// CONSTRAINT here would double-create it. No diff expected.
+			name: "field-level FK on column not yet in DB → no synthesized constraint",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "new_file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_new_file",
+						OnDelete:       "SET NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				// exports exists but new_file_id column does not yet.
+				Tables: []types.DBTable{{Name: "exports", Columns: []types.DBColumn{{Name: "id"}}}},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// Changing the referenced column (files(id) -> files(uuid)) is a
+			// definitional change and must also surface as drop + add.
+			name: "referenced column change surfaces as drop + add",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(uuid)",
+						ForeignKeyName: "fk_export_file",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(stringPtr("NO ACTION"), stringPtr("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"fk_export_file"},
+				ConstraintsRemoved: []string{"fk_export_file"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &difftypes.SchemaDiff{}
+			compare.Constraints(tt.generated, tt.database, diff)
+
+			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
+				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))
+			for _, expected := range tt.expected.ConstraintsAdded {
+				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
+			}
+
+			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved),
+				qt.Commentf("ConstraintsRemoved=%v", diff.ConstraintsRemoved))
+			for _, expected := range tt.expected.ConstraintsRemoved {
+				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)
+			}
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -321,7 +321,7 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 			c := qt.New(t)
 
 			diff := &difftypes.SchemaDiff{}
-			compare.Constraints(tt.generated, tt.database, diff)
+			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
 				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -15,6 +15,17 @@ func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.
 	return CompareWithOptions(generated, database, nil)
 }
 
+// CompareWithDialect performs schema comparison using default options plus the
+// supplied target dialect. The dialect drives dialect-specific normalization —
+// currently the MySQL/MariaDB RESTRICT == NO ACTION fold for foreign-key
+// referential actions (see config.CompareOptions.Dialect). Pass an empty
+// dialect for dialect-neutral comparison (equivalent to Compare).
+func CompareWithDialect(generated *goschema.Database, database *types.DBSchema, dialect string) *difftypes.SchemaDiff {
+	opts := config.DefaultCompareOptions()
+	opts.Dialect = dialect
+	return CompareWithOptions(generated, database, opts)
+}
+
 // CompareWithOptions performs schema comparison between generated and database schemas
 // with custom configuration options.
 //
@@ -68,7 +79,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.Roles(generated, database, diff)
 
 	// Compare table-level constraints (EXCLUDE, CHECK, UNIQUE, etc.)
-	compare.Constraints(generated, database, diff)
+	compare.Constraints(generated, database, diff, opts)
 
 	return diff
 }

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -12,6 +12,26 @@ type IndexRemovalInfo struct {
 	TableName string `json:"table_name"`
 }
 
+// ConstraintRemovalInfo contains information about a constraint that needs to be
+// removed, including the constraint name, the table it belongs to, and its type.
+//
+// This is needed for databases like MySQL/MariaDB that require both the table
+// name and a type-specific drop syntax — e.g. FOREIGN KEY constraints are
+// dropped with `ALTER TABLE <table> DROP FOREIGN KEY <name>` rather than
+// `DROP CONSTRAINT`. The plain ConstraintsRemoved name list discards the table
+// name, which the comparator does know at diff time, so it is preserved here in
+// parallel (mirroring IndexesRemovedWithTables).
+type ConstraintRemovalInfo struct {
+	// Name is the name of the constraint to be removed
+	Name string `json:"name"`
+
+	// TableName is the name of the table that the constraint belongs to
+	TableName string `json:"table_name"`
+
+	// Type is the constraint type (FOREIGN KEY, CHECK, UNIQUE, PRIMARY KEY, ...)
+	Type string `json:"type"`
+}
+
 // SchemaDiff represents comprehensive differences between two database schemas.
 //
 // This structure captures all types of schema changes that can occur between a target
@@ -140,6 +160,13 @@ type SchemaDiff struct {
 	// ConstraintsRemoved contains names of constraints that exist in the current database
 	// but not in the target schema (potentially dangerous - may affect data integrity)
 	ConstraintsRemoved []string `json:"constraints_removed"`
+
+	// ConstraintsRemovedWithTables contains detailed information about constraints that
+	// need to be removed, including the constraint name, owning table, and type. This is
+	// used by database dialects that require the table name and a type-specific drop
+	// syntax (e.g. MySQL/MariaDB FOREIGN KEY constraints use DROP FOREIGN KEY). It runs
+	// in parallel to ConstraintsRemoved (mirroring IndexesRemovedWithTables).
+	ConstraintsRemovedWithTables []ConstraintRemovalInfo `json:"constraints_removed_with_tables"`
 }
 
 // HasChanges returns true if the diff contains any schema changes requiring migration.


### PR DESCRIPTION
Closes #189.

## Summary

The schema-diff comparator detects `on_delete` / `on_update` changes on **existing** foreign keys declared on a `//migrator:schema:field` annotation (`foreign=... on_delete=...`), and the change is now rendered into a working, idempotent migration on **PostgreSQL, MySQL and MariaDB**, with a **down** migration that restores the prior action. Before this PR, changing the referential action on an already-applied field-level FK produced "No schema changes detected" and emitted no migration.

This is **distinct from #117 / PR #122**, which fixed CREATE/ALTER-time *emission* of field-level FK actions. That path is untouched here; what was missing is the **drift/diff detection** of a *change* on a pre-existing field-level FK — exactly the gap PR #122 deferred.

## Problem

Model carries `on_delete="SET NULL"`; the live DB FK is `NO ACTION`:

```go
//migrator:schema:field name="file_id" type="TEXT" foreign="files(id)" foreign_key_name="fk_export_file" on_delete="SET NULL"
FileID *string
```

`schemadiff.Compare(generated, dbSchema)` → `HasChanges() == false`, no constraints added/removed. The only way to change the action downstream was to hand-edit the SQL.

## Root cause

In `migration/schemadiff/internal/compare/compare.go`, two suppressions kept field-level FKs out of the comparison: the generated side never synthesized a comparable FK constraint, and the DB side was filtered out by `isFieldLevelConstraint`. So neither side reached `foreignKeyConstraintChanged`, even though the introspector already reads `referential_constraints.delete_rule/update_rule`.

A second, deeper cause surfaced once the comparator started synthesizing the FK: a field-level `foreign=` annotation **without** an explicit `foreign_key_name` was silently dropped from added-table / added-column migrations (the planners gated FK emission on a non-empty `ForeignKeyName`). The FK was therefore never created in the database, so the synthesized constraint re-appeared as a spurious `ConstraintsAdded` on every dialect and the schema never round-tripped to zero diff (the red `integration-tests` leg on `002-add-posts`).

## Fix

**Comparator** (`compare.go`):

- `synthesizeFieldLevelForeignKeyConstraints` turns each existing-column field-level FK into a comparable `goschema.Constraint`; `isFieldLevelConstraint` lets the matching DB FK through; `normalizeReferentialAction` folds `"" == NO ACTION`.
- The conventional name fallback and the `foreign=` parse are consolidated onto the now-exported `fromschema.GenerateForeignKeyName` and `fromschema.ParseForeignKeyReference`, so the synthesized name/refs stay in lockstep with the planner.
- **Dialect-scoped RESTRICT normalization.** MariaDB reports an unspecified action as `RESTRICT`, and InnoDB treats `RESTRICT` and `NO ACTION` identically, so for MySQL/MariaDB `RESTRICT` is folded to `NO ACTION` to avoid a perpetual drop+add loop. PostgreSQL distinguishes the two at DDL level, so a genuine `RESTRICT <-> NO ACTION` change is still detected there. The dialect is threaded via `config.CompareOptions.Dialect` / `schemadiff.CompareWithDialect`.
- MySQL/MariaDB FK-backing indexes (auto-created and named after the FK constraint) are filtered out so an unchanged FK does not round-trip to a spurious `DROP INDEX`.

**Planners** (`postgres` + `mysql`):

- When `foreign_key_name` is omitted the planner derives the conventional `fk_<table>_<column>` name and **actually creates the FK** (regular, self-referencing and `ADD COLUMN` paths), so the DB constraint matches the comparator's synthesized name.
- A changed constraint is expressed as remove + add of the **same name**: both planners emit the `DROP` before the re-`ADD` and the remove pass skips names also present in `ConstraintsAdded`.
- **MySQL/MariaDB emission** is now real, not a TODO comment: `removeConstraints` emits `ALTER TABLE <t> DROP FOREIGN KEY <name>` (the owning table + type are carried on the new `SchemaDiff.ConstraintsRemovedWithTables`), and `addNewConstraints` gained the field-level `foreign=` fallback so the FK is re-added with its new action. Constraints owned by a dropped table, and PRIMARY KEY, are skipped (the table drop cascades; PK uses dedicated syntax).

**Down migrations** (`generator` + `dbschematogo`):

- `reverseSchemaDiffWithSchema` now reverses `ConstraintsAdded <-> ConstraintsRemoved` (a modified constraint is remove + add of the same name, so the down drops the new definition and re-adds the old one), rebuilding `ConstraintsRemovedWithTables` from the generated schema for the MySQL DROP FOREIGN KEY.
- `ConvertDBSchemaToGoSchema` reconstructs each single-column field-level FK (reference + `ON DELETE`/`ON UPDATE`) from the introspected constraints, so the down planner — which targets the pre-change database state — renders the FK with its **prior** action.

**Reader** (`dbschema/mysql`): column uniqueness is reconciled against the authoritative index metadata (the DDL parser collapses every `KEY`/`INDEX` to a unique constraint, which over-reported uniqueness for the non-unique FK-backing index).

## Tests

- `migration/schemadiff/internal/compare/fk_constraints_test.go` — comparator drift/idempotency/fallback-name/self-ref/referenced-column cases.
- `migration/schemadiff/fk_action_drift_test.go` — end-to-end PostgreSQL drop+add, DROP-before-ADD ordering, idempotency.
- `migration/schemadiff/fk_action_drift_mysql_test.go` — **MySQL/MariaDB** emission: real `ALTER TABLE ... DROP FOREIGN KEY` + re-ADD with the action, DROP-before-ADD ordering, no TODO; idempotency incl. the MariaDB `RESTRICT == NO ACTION` fold; and a guard that PostgreSQL `RESTRICT != NO ACTION` is still a real change.
- `migration/generator/reverse_diff_test.go` — constraint reversal, and a **down**-direction test proving the down restores the prior FK action (non-empty, correct SQL) on PostgreSQL and MySQL.

## Test plan

- [x] `go build ./...` / `go vet ./...` — green
- [x] `go test ./...` — green (whole module)
- [x] `golangci-lint run ./...` (v2.12.2) — 0 issues
- [x] Go version consistency: `go.mod`, workflows and `.golangci.yml` all at `1.26.4`
- [x] Integration scenarios (180/180) on **postgres, mysql, mariadb** — incl. `migration_generator_validation` (`002-add-posts` round-trip) and `rollback_migrations`
- [x] Tagged integration tests (`go test -tags=integration ./integration/...`) on postgres, mysql, mariadb

## Acceptance (from #189)

- [x] `on_delete` change on an existing field-level FK produces a drop+add and a non-empty up/down migration
- [x] Unchanged field-level FK is a no-op (idempotent) on every dialect
- [x] Regression tests under `migration/schemadiff` covering the action change + idempotency
- [x] Comparator is dialect-agnostic; PostgreSQL **and** MySQL/MariaDB planners render the change into a working migration
- [x] Down migration restores the prior referential action