### PR TITLE
fix(schemadiff): resolve embedded inline-relation FKs to host tables in drift synthesis (#197)

### DIFF
--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -299,8 +299,29 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 		tableConstraints[c.Name] = c
 	}
 
+	// Prefer the table-qualified additions the comparator recorded. A
+	// field-level FK contributed by an embedded inline-relation mixin shares one
+	// name across every host table, so resolving the table from a field's Go
+	// struct name collapses every host onto the same (often non-table) name —
+	// the down migration would then drop the constraint from the wrong table or
+	// from a struct name that does not exist (issue #197). ConstraintsAddedWithTables
+	// carries the concrete table for each addition, so the down side drops the
+	// FK from exactly the table the up side added it to. Names present here are
+	// recorded so the legacy field-scan fallback below does not double-emit them.
+	var infos []types.ConstraintRemovalInfo
+	handled := make(map[string]struct{})
+	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.TableName == "" {
+			continue
+		}
+		infos = append(infos, types.ConstraintRemovalInfo{Name: add.Name, TableName: add.TableName, Type: add.Type})
+		handled[add.Name] = struct{}{}
+	}
+
 	// Index field-level FK constraint names (foreign_key_name or the
-	// conventional fk_<table>_<column>) to their owning table.
+	// conventional fk_<table>_<column>) to their owning table for the names that
+	// did not arrive with table-qualified info (legacy callers / explicit
+	// table-level constraints).
 	structToTable := make(map[string]string, len(schema.Tables))
 	for _, t := range schema.Tables {
 		structToTable[t.StructName] = t.Name
@@ -321,8 +342,10 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 		fkTables[name] = tableName
 	}
 
-	var infos []types.ConstraintRemovalInfo
 	for _, name := range diff.ConstraintsAdded {
+		if _, done := handled[name]; done {
+			continue
+		}
 		switch {
 		case tableConstraints[name].Name != "":
 			c := tableConstraints[name]

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -198,9 +198,12 @@ func generateDownMigrationSQL(diff *types.SchemaDiff, generated *goschema.Databa
 	// since we're reverting back to the current state
 	dbAsGoSchema := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
 
-	// Create a reverse diff to generate down migration
-	// We pass the original generated schema to resolve table names for RLS policies
-	reverseDiff := reverseSchemaDiffWithSchema(diff, generated)
+	// Create a reverse diff to generate down migration. We pass the original
+	// generated schema to resolve table names for RLS policies, and the
+	// introspected database schema so the reversed constraint additions can
+	// rebuild the FULL prior FK body (columns, target, on_delete/on_update) from
+	// the pre-change DB state — that is exactly the action the down must restore.
+	reverseDiff := reverseSchemaDiffWithSchema(diff, generated, dbSchema)
 
 	statements := planner.GenerateSchemaDiffSQLStatements(reverseDiff, dbAsGoSchema, dialect)
 
@@ -222,12 +225,17 @@ func generateDownMigrationSQL(diff *types.SchemaDiff, generated *goschema.Databa
 //
 // Deprecated: Use reverseSchemaDiffWithSchema for proper RLS policy table name resolution
 func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
-	return reverseSchemaDiffWithSchema(diff, nil)
+	return reverseSchemaDiffWithSchema(diff, nil, nil)
 }
 
-// reverseSchemaDiffWithSchema creates a reverse diff for generating down migrations with schema context
-// This version can properly resolve table names for RLS policies using the provided schema
-func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database) *types.SchemaDiff {
+// reverseSchemaDiffWithSchema creates a reverse diff for generating down migrations with schema context.
+//
+// schema is the generated (target) Go schema, used to resolve table names for
+// RLS policies. dbSchema is the introspected (pre-change) database schema, used
+// to rebuild the prior FK definition for the reversed constraint additions; it
+// may be nil for legacy callers that only have the generated schema (the
+// reversed additions then fall back to the name-only path).
+func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	return &types.SchemaDiff{
 		// Reverse table operations
 		TablesAdded:    diff.TablesRemoved, // Tables to remove become tables to add
@@ -273,10 +281,100 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		// down planner resolves the old definition from the introspected schema
 		// (see dbschematogo.ConvertDBSchemaToGoSchema, which now carries the
 		// FK action), so the prior action is faithfully restored.
+		//
+		// ConstraintsAddedWithTables carries the table-qualified prior FK body so
+		// the down add-path can fan a mixin-shared FK name out to every host
+		// table. Without it the down add-path falls back to the name-only field
+		// scan, which emits one ADD for a single host while the per-host DROP also
+		// resolves only one host — so the 2nd host's re-add collides with its
+		// still-present old constraint (Postgres 42710, MySQL 1826) and the
+		// rollback aborts half-applied. This is the DOWN mirror of the UP
+		// multi-host fix (issue #197).
 		ConstraintsAdded:             diff.ConstraintsRemoved,
 		ConstraintsRemoved:           diff.ConstraintsAdded,
 		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
+		ConstraintsAddedWithTables:   reverseConstraintAdditions(diff, dbSchema),
 	}
+}
+
+// reverseConstraintAdditions builds the table-qualified additions for the down
+// migration. In the down direction the constraints to add back are the ones the
+// up migration REMOVED (diff.ConstraintsRemovedWithTables) — restoring their
+// prior definition. The prior FK body (columns, foreign table/column,
+// on_delete/on_update) is read from the introspected (pre-change) database
+// schema, which is the authoritative source for what the down must restore.
+//
+// Carrying the full per-host body here lets both dialect planners' add-paths
+// (which already prefer ConstraintsAddedWithTables) emit one correct ALTER TABLE
+// per real host table. This is what makes the down of a multi-host mixin FK
+// modify apply cleanly: a name-only down re-adds only one host (and drops only
+// one host), so the others collide on re-add (issue #197 DOWN path). When
+// dbSchema is nil (legacy callers) the names still flow through ConstraintsAdded
+// and the planners fall back to the name-only field scan.
+func reverseConstraintAdditions(diff *types.SchemaDiff, dbSchema *dbschematypes.DBSchema) []types.ConstraintAdditionInfo {
+	if dbSchema == nil || len(diff.ConstraintsRemovedWithTables) == 0 {
+		return nil
+	}
+
+	// Index the introspected FOREIGN KEY constraints by (table, name) so each
+	// reversed addition restores the body from the exact host it was removed
+	// from. A mixin-shared FK name legitimately repeats across host tables, so a
+	// name-only key would collapse them onto one host.
+	dbFKByTableName := make(map[string]dbschematypes.DBConstraint)
+	for _, c := range dbSchema.Constraints {
+		if c.Type != "FOREIGN KEY" {
+			continue
+		}
+		dbFKByTableName[c.TableName+"."+c.Name] = c
+	}
+
+	var infos []types.ConstraintAdditionInfo
+	for _, removed := range diff.ConstraintsRemovedWithTables {
+		if removed.Type != "FOREIGN KEY" || removed.TableName == "" {
+			continue
+		}
+		dbFK, ok := dbFKByTableName[removed.TableName+"."+removed.Name]
+		if !ok {
+			// No introspected body to restore (e.g. the constraint was a
+			// pure-removal not present pre-change, or a non-FK). The name still
+			// rides in ConstraintsAdded for the name-only fallback.
+			continue
+		}
+		infos = append(infos, foreignKeyAdditionFromDBConstraint(removed.Name, removed.TableName, dbFK))
+	}
+	return infos
+}
+
+// foreignKeyAdditionFromDBConstraint builds a ConstraintAdditionInfo carrying the
+// full FK body from an introspected database FOREIGN KEY constraint. The
+// referential actions come straight from the pre-change DB, so the down
+// migration restores exactly the prior ON DELETE / ON UPDATE behavior.
+func foreignKeyAdditionFromDBConstraint(name, table string, dbFK dbschematypes.DBConstraint) types.ConstraintAdditionInfo {
+	info := types.ConstraintAdditionInfo{
+		Name:      name,
+		TableName: table,
+		Type:      "FOREIGN KEY",
+		OnDelete:  derefString(dbFK.DeleteRule),
+		OnUpdate:  derefString(dbFK.UpdateRule),
+	}
+	if dbFK.ColumnName != "" {
+		info.Columns = []string{dbFK.ColumnName}
+	}
+	if dbFK.ForeignTable != nil {
+		info.ForeignTable = *dbFK.ForeignTable
+	}
+	if dbFK.ForeignColumn != nil {
+		info.ForeignColumn = *dbFK.ForeignColumn
+	}
+	return info
+}
+
+// derefString returns the pointed-to string or "" when nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // reverseConstraintRemovals builds the table-qualified removal info for the

--- a/migration/generator/multihost_fk_down_integration_test.go
+++ b/migration/generator/multihost_fk_down_integration_test.go
@@ -1,0 +1,277 @@
+//go:build integration
+
+package generator
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/convert/fromschema"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// TestMultiHostMixinFKModify_DownRoundTrip_Integration is the live-database gate
+// for the issue #197 DOWN path. It drives the REAL generator (UP then the
+// generated DOWN) against a live PostgreSQL / MySQL / MariaDB and proves the
+// rollback applies cleanly and restores each host's PRIOR FK action per host.
+//
+// Scenario: an FK lives on several host tables at the prior ON DELETE NO ACTION.
+// The UP changes it to ON DELETE CASCADE on every host (a multi-host modify, the
+// shape an embedded inline-relation mixin produces). The generated DOWN must,
+// for EACH host, drop the CASCADE constraint and re-add it with the prior action.
+// Before the fix the reversed diff carried no ConstraintsAddedWithTables, so the
+// DOWN add-path fell back to the name-only field scan: it re-added a single host
+// and (on Postgres) dropped a single host via the information_schema LIMIT 1 DO
+// block, so the 2nd host's re-add collided ("constraint already exists",
+// SQLSTATE 42710) and the rollback aborted half-applied. With the fix the DOWN is
+// table-qualified per host and applies clean.
+//
+// FK naming is dialect-aware: Postgres scopes constraint names per table, so the
+// canonical mixin case shares ONE name (fk_entity_tenant) across all hosts — the
+// exact #197 reproduction. MySQL/MariaDB scope FK names schema-GLOBALLY (a shared
+// name is rejected at DDL time with errno 1826/121), so a representable
+// multi-host mixin there uses a distinct name per host; the DOWN still exercises
+// the same per-host DROP FOREIGN KEY + re-ADD generator path.
+//
+// Counterfactual (proven separately by neutering the fix): the pre-fix generator
+// produces a DOWN that re-adds/drops only one host, so on Postgres the
+// shared-name re-add errors 42710 at the "DOWN must apply cleanly" gate below.
+func TestMultiHostMixinFKModify_DownRoundTrip_Integration(t *testing.T) {
+	cases := []struct {
+		dialect string
+		envKey  string
+	}{
+		{"postgres", "POSTGRES_URL"},
+		{"mysql", "MYSQL_URL"},
+		{"mariadb", "MARIADB_URL"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			url := os.Getenv(tc.envKey)
+			if url == "" {
+				t.Skipf("skipping %s: %s not set", tc.dialect, tc.envKey)
+			}
+
+			c := qt.New(t)
+			ctx := context.Background()
+
+			conn, err := dbschema.ConnectToDatabase(ctx, url)
+			if err != nil {
+				t.Skipf("skipping %s: cannot connect: %v", tc.dialect, err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			dialect := conn.Info().Dialect
+			hosts := []string{"ptah_loc", "ptah_area", "ptah_comm"}
+
+			// Always start from a clean slate and tear down afterwards.
+			dropAll := func() {
+				for _, h := range hosts {
+					_, _ = conn.Exec(dropTableSQL(dialect, h))
+				}
+				_, _ = conn.Exec(dropTableSQL(dialect, "ptah_tenants"))
+			}
+			dropAll()
+			t.Cleanup(dropAll)
+
+			// 1. Install the PRIOR schema: parent table + host tables, then add the
+			//    tenant FK at the prior ON DELETE NO ACTION via explicit ALTER per
+			//    host. We add the FK explicitly (not via the renderer's inline
+			//    CREATE-TABLE FK) because the MySQL renderer omits field-level
+			//    inline FKs — the ALTER form is dialect-portable.
+			genPrior := roundTripSchema(dialect, "", hosts...)
+			applyTablesOnly(c, conn, dialect, genPrior)
+			for _, h := range hosts {
+				_, err := conn.Exec("ALTER TABLE " + h + " ADD CONSTRAINT " + tenantFKName(dialect, h) +
+					" FOREIGN KEY (tenant_id) REFERENCES ptah_tenants(id)")
+				c.Assert(err, qt.IsNil, qt.Commentf("setup: add prior FK on %s", h))
+			}
+
+			dbPrior, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			priorRules := tenantDeleteRules(dialect, dbPrior, hosts)
+			c.Assert(len(priorRules), qt.Equals, len(hosts),
+				qt.Commentf("prior FK must exist on every host, got %v", priorRules))
+
+			// 2. Target schema: the tenant FK now ON DELETE CASCADE.
+			genCascade := roundTripSchema(dialect, "CASCADE", hosts...)
+
+			upDiff := schemadiff.CompareWithDialect(genCascade, dbPrior, dialect)
+			c.Assert(upDiff.HasChanges(), qt.IsTrue, qt.Commentf("UP must have changes"))
+
+			// 3. Generate + apply the UP (the multi-host modify).
+			upSQL, err := generateUpMigrationSQL(upDiff, genCascade, dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(upSQL, qt.Not(qt.Equals), "")
+			execScript(c, conn, upSQL, "UP")
+
+			dbAfterUp, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			afterUp := tenantDeleteRules(dialect, dbAfterUp, hosts)
+			for _, h := range hosts {
+				c.Assert(strings.ToUpper(afterUp[h]), qt.Equals, "CASCADE",
+					qt.Commentf("after UP, %s tenant FK must be ON DELETE CASCADE, got %q", h, afterUp[h]))
+			}
+
+			// 4. Generate the DOWN from the original up diff + the PRIOR db schema
+			//    (exactly what the generator does), then apply it. THIS IS THE GATE:
+			//    the pre-fix DOWN errors with 42710 here on Postgres.
+			downSQL, err := generateDownMigrationSQL(upDiff, genCascade, dbPrior, dialect)
+			c.Assert(err, qt.IsNil)
+			t.Logf("[%s] generated DOWN:\n%s", dialect, downSQL)
+			execScript(c, conn, downSQL, "DOWN")
+
+			// 5. Per-host action restored to the prior value, on every host.
+			dbAfterDown, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			restored := tenantDeleteRules(dialect, dbAfterDown, hosts)
+			for _, h := range hosts {
+				c.Assert(restored[h], qt.Equals, priorRules[h],
+					qt.Commentf("after DOWN, %s tenant FK action must be restored to %q, got %q",
+						h, priorRules[h], restored[h]))
+			}
+
+			// 6. Idempotency: the DB now matches the prior schema again, so a fresh
+			//    diff against the prior generated schema is clean (no churn loop).
+			idemDiff := schemadiff.CompareWithDialect(genPrior, dbAfterDown, dialect)
+			c.Assert(idemDiff.HasChanges(), qt.IsFalse,
+				qt.Commentf("post-DOWN diff must be clean; added=%v removed=%v",
+					idemDiff.ConstraintsAdded, idemDiff.ConstraintsRemoved))
+		})
+	}
+}
+
+// tenantFKName returns the FK constraint name for the tenant_id FK on the given
+// host. Postgres scopes constraint names per table, so the canonical mixin case
+// reuses ONE shared name on every host (the #197 reproduction). MySQL/MariaDB
+// scope FK names schema-globally and reject a duplicate at DDL time, so there we
+// use a distinct name per host (the same multi-host modify shape, representable).
+func tenantFKName(dialect, host string) string {
+	if dialect == "postgres" {
+		return "fk_entity_tenant"
+	}
+	return "fk_" + host + "_tenant"
+}
+
+// roundTripSchema builds the generated schema for the round-trip: a parent
+// ptah_tenants table plus the given host tables, each carrying a tenant_id field
+// with the tenant FK (named per tenantFKName). onDelete sets the FK's ON DELETE
+// action ("" = leave default / NO ACTION).
+func roundTripSchema(dialect, onDelete string, hosts ...string) *goschema.Database {
+	// VARCHAR(36) (not TEXT) so MySQL/MariaDB can index the PK and back the FK —
+	// a TEXT column needs a key length there ("BLOB/TEXT used in key
+	// specification without a key length").
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "PtahTenants", Name: "ptah_tenants"}},
+		Fields: []goschema.Field{
+			{StructName: "PtahTenants", Name: "id", Type: "VARCHAR(36)", Primary: true},
+		},
+	}
+	for _, h := range hosts {
+		structName := structNameFor(h)
+		db.Tables = append(db.Tables, goschema.Table{StructName: structName, Name: h})
+		db.Fields = append(db.Fields,
+			goschema.Field{StructName: structName, Name: "id", Type: "VARCHAR(36)", Primary: true},
+			goschema.Field{
+				StructName:     structName,
+				Name:           "tenant_id",
+				Type:           "VARCHAR(36)",
+				Nullable:       true,
+				Foreign:        "ptah_tenants(id)",
+				ForeignKeyName: tenantFKName(dialect, h),
+				OnDelete:       onDelete,
+			},
+		)
+	}
+	return db
+}
+
+// tenantDeleteRules returns host -> ON DELETE rule for the host's tenant FK as
+// the database reports it.
+func tenantDeleteRules(dialect string, db *dbschematypes.DBSchema, hosts []string) map[string]string {
+	wantName := make(map[string]string, len(hosts)) // host -> expected FK name
+	for _, h := range hosts {
+		wantName[h] = tenantFKName(dialect, h)
+	}
+	rules := make(map[string]string)
+	for _, cs := range db.Constraints {
+		if cs.Type != "FOREIGN KEY" {
+			continue
+		}
+		if name, ok := wantName[cs.TableName]; !ok || name != cs.Name {
+			continue
+		}
+		rule := ""
+		if cs.DeleteRule != nil {
+			rule = *cs.DeleteRule
+		}
+		rules[cs.TableName] = rule
+	}
+	return rules
+}
+
+// applyTablesOnly renders + applies the CREATE TABLE statements for the schema
+// with all foreign= fields stripped, so the host tables exist with their columns
+// but no FK yet. The named prior FK is then added explicitly by the caller (the
+// renderer's inline FK emission is dialect-asymmetric — MySQL omits field-level
+// inline FKs — so we keep setup engine-agnostic).
+func applyTablesOnly(c *qt.C, conn *dbschema.DatabaseConnection, dialect string, gen *goschema.Database) {
+	c.Helper()
+	bare := *gen
+	bare.Fields = make([]goschema.Field, 0, len(gen.Fields))
+	for _, f := range gen.Fields {
+		f.Foreign = ""
+		f.ForeignKeyName = ""
+		f.OnDelete = ""
+		f.OnUpdate = ""
+		bare.Fields = append(bare.Fields, f)
+	}
+	stmts := fromschema.FromDatabase(bare, dialect)
+	sqlText, err := renderer.RenderSQL(dialect, stmts.Statements...)
+	c.Assert(err, qt.IsNil)
+	execScript(c, conn, sqlText, "SETUP")
+}
+
+// execScript splits a multi-statement SQL script the same way the migrator does
+// (DO-block / dollar-quote aware) and executes each statement, failing the test
+// on the first error. label names the phase for diagnostics — the DOWN phase is
+// the gate that errored on the pre-fix generator. We use conn.Exec (the raw
+// driver) rather than the Writer's transaction-scoped ExecuteSQL because DDL on
+// MySQL/MariaDB auto-commits and the round-trip applies statements directly.
+func execScript(c *qt.C, conn *dbschema.DatabaseConnection, sqlText, label string) {
+	c.Helper()
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		if strings.TrimSpace(stmt) == "" {
+			continue
+		}
+		_, err := conn.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("%s statement must apply cleanly:\n%s", label, stmt))
+	}
+}
+
+func structNameFor(table string) string {
+	parts := strings.Split(table, "_")
+	for i, p := range parts {
+		if p != "" {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func dropTableSQL(dialect, table string) string {
+	if dialect == "mysql" || dialect == "mariadb" {
+		return "DROP TABLE IF EXISTS " + table
+	}
+	return "DROP TABLE IF EXISTS " + table + " CASCADE"
+}

--- a/migration/generator/multihost_fk_down_test.go
+++ b/migration/generator/multihost_fk_down_test.go
@@ -1,0 +1,212 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// These tests pin the DOWN (rollback) half of issue #197: a mixin-shared FK name
+// whose on_delete action drifts on >=2 host tables. The UP fix (PR #198 commit
+// 894902d) emits a table-qualified per-host DROP+ADD, but the generated DOWN was
+// still name-only — it re-added only one host and dropped only one host, so the
+// 2nd host's re-add collided (Postgres 42710 / MySQL 1826) and the rollback
+// aborted half-applied. The fix repopulates the reversed
+// ConstraintsAddedWithTables from the introspected (pre-change) DB so the DOWN
+// add-path fans out per host and restores each host's PRIOR action.
+//
+// These run the REAL generator down-path (generateDownMigrationSQL ->
+// reverseSchemaDiffWithSchema -> reverseConstraintAdditions), not a hand-rolled
+// reversal, which is the gap that let the original bug ship.
+
+func strPtr(s string) *string { return &s }
+
+// multiHostMixinGenerated builds a generated schema with an "Ownable" inline
+// mixin carrying a shared tenant FK (fk_entity_tenant, ON DELETE = onDelete)
+// embedded into each host table.
+func multiHostMixinGenerated(onDelete string, hosts ...string) *goschema.Database {
+	db := &goschema.Database{
+		Fields: []goschema.Field{
+			{
+				StructName:     "Ownable",
+				Name:           "tenant_id",
+				Type:           "TEXT",
+				Foreign:        "tenants(id)",
+				ForeignKeyName: "fk_entity_tenant",
+				OnDelete:       onDelete,
+			},
+		},
+	}
+	for _, h := range hosts {
+		structName := strings.ToUpper(h[:1]) + h[1:]
+		db.Tables = append(db.Tables, goschema.Table{StructName: structName, Name: h})
+		db.Fields = append(db.Fields,
+			goschema.Field{StructName: structName, Name: "id", Type: "TEXT", Primary: true},
+		)
+		db.EmbeddedFields = append(db.EmbeddedFields, goschema.EmbeddedField{
+			StructName: structName, Mode: "inline", EmbeddedTypeName: "Ownable",
+		})
+	}
+	return db
+}
+
+// multiHostMixinDB builds the introspected (pre-change) DB: each host has the
+// tenant FK with the given delete rule.
+func multiHostMixinDB(deleteRule string, hosts ...string) *dbschematypes.DBSchema {
+	db := &dbschematypes.DBSchema{}
+	for _, h := range hosts {
+		db.Tables = append(db.Tables, dbschematypes.DBTable{
+			Name: h,
+			Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "tenant_id", DataType: "text", IsNullable: "NO"},
+			},
+		})
+		db.Constraints = append(db.Constraints, dbschematypes.DBConstraint{
+			Name: "fk_entity_tenant", TableName: h, Type: "FOREIGN KEY", ColumnName: "tenant_id",
+			ForeignTable: strPtr("tenants"), ForeignColumn: strPtr("id"),
+			DeleteRule: strPtr(deleteRule), UpdateRule: strPtr("NO ACTION"),
+		})
+	}
+	return db
+}
+
+// TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost is
+// the regression test for the issue #197 DOWN path. The UP changes the shared
+// tenant FK from the prior NO ACTION to ON DELETE CASCADE on every host; the
+// generated DOWN must, for EACH host, drop the (CASCADE) constraint and re-add
+// it with the prior NO ACTION — table-qualified so no host collides.
+func TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost(t *testing.T) {
+	hosts := []string{"locations", "areas", "commodities"}
+
+	for _, dialect := range []string{"postgres", "mysql"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			// Generated = CASCADE; DB (pre-change) = converged NO ACTION.
+			gen := multiHostMixinGenerated("CASCADE", hosts...)
+			dbSchema := multiHostMixinDB("NO ACTION", hosts...)
+
+			upDiff := schemadiff.CompareWithDialect(gen, dbSchema, dialect)
+			c.Assert(upDiff.HasChanges(), qt.IsTrue)
+			// The shared FK name is added + removed once per host (a modification).
+			c.Assert(countConstraint(upDiff.ConstraintsAdded, "fk_entity_tenant"), qt.Equals, len(hosts))
+			c.Assert(countConstraint(upDiff.ConstraintsRemoved, "fk_entity_tenant"), qt.Equals, len(hosts))
+
+			downSQL, err := generateDownMigrationSQL(upDiff, gen, dbSchema, dialect)
+			c.Assert(err, qt.IsNil)
+
+			for _, h := range hosts {
+				var dropStmt string
+				if dialect == "mysql" {
+					dropStmt = "ALTER TABLE " + h + " DROP FOREIGN KEY fk_entity_tenant;"
+				} else {
+					dropStmt = "ALTER TABLE " + h + " DROP CONSTRAINT IF EXISTS fk_entity_tenant;"
+				}
+				addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)"
+
+				c.Assert(strings.Count(downSQL, dropStmt), qt.Equals, 1,
+					qt.Commentf("host %s: expected exactly one table-qualified DROP in DOWN, got:\n%s", h, downSQL))
+				c.Assert(strings.Count(downSQL, addStmt), qt.Equals, 1,
+					qt.Commentf("host %s: expected exactly one re-ADD in DOWN, got:\n%s", h, downSQL))
+
+				dropIdx := strings.Index(downSQL, dropStmt)
+				addIdx := strings.Index(downSQL, addStmt)
+				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+					qt.Commentf("host %s: DOWN DROP must precede the re-ADD; drop@%d add@%d\n%s", h, dropIdx, addIdx, downSQL))
+			}
+
+			// The DOWN restores the PRIOR action (NO ACTION), never the new CASCADE.
+			c.Assert(strings.Contains(downSQL, "ON DELETE CASCADE"), qt.IsFalse,
+				qt.Commentf("DOWN must restore the prior action, not re-apply CASCADE:\n%s", downSQL))
+			// Never the mixin struct name.
+			c.Assert(strings.Contains(downSQL, "Ownable"), qt.IsFalse,
+				qt.Commentf("DOWN must not reference the mixin struct name:\n%s", downSQL))
+		})
+	}
+}
+
+// TestGenerateDownMigration_MultiHostMixinFKModify_NameOnlyCounterfactual proves
+// the bug is actually fixed by the table-qualified reversed additions: without
+// ConstraintsAddedWithTables on the reversed diff the DOWN add-path would emit a
+// single name-only re-ADD (one host) instead of one per host. We assert the
+// fixed DOWN re-adds the FK for ALL hosts — the property the old code violated.
+func TestGenerateDownMigration_MultiHostMixinFKModify_NameOnlyCounterfactual(t *testing.T) {
+	c := qt.New(t)
+	hosts := []string{"locations", "areas", "commodities"}
+
+	gen := multiHostMixinGenerated("CASCADE", hosts...)
+	dbSchema := multiHostMixinDB("NO ACTION", hosts...)
+	upDiff := schemadiff.CompareWithDialect(gen, dbSchema, "postgres")
+
+	downSQL, err := generateDownMigrationSQL(upDiff, gen, dbSchema, "postgres")
+	c.Assert(err, qt.IsNil)
+
+	// One re-ADD per host (the old name-only path produced exactly one total).
+	total := strings.Count(downSQL, "ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)")
+	c.Assert(total, qt.Equals, len(hosts),
+		qt.Commentf("DOWN must re-add the FK once per host (%d), got %d:\n%s", len(hosts), total, downSQL))
+}
+
+// TestReverseConstraintAdditions_RestoresPerHostBody unit-tests the new helper
+// directly: each up-removal becomes a down-addition carrying the FULL FK body
+// (columns, target, prior action) read from the introspected DB, keyed per host.
+func TestReverseConstraintAdditions_RestoresPerHostBody(t *testing.T) {
+	c := qt.New(t)
+	hosts := []string{"locations", "areas"}
+
+	dbSchema := multiHostMixinDB("NO ACTION", hosts...)
+	// Up diff: the shared FK was removed (then re-added) on each host.
+	upDiff := &types.SchemaDiff{}
+	for _, h := range hosts {
+		upDiff.ConstraintsRemovedWithTables = append(upDiff.ConstraintsRemovedWithTables,
+			types.ConstraintRemovalInfo{Name: "fk_entity_tenant", TableName: h, Type: "FOREIGN KEY"})
+	}
+
+	additions := reverseConstraintAdditions(upDiff, dbSchema)
+	c.Assert(len(additions), qt.Equals, len(hosts))
+
+	byTable := map[string]types.ConstraintAdditionInfo{}
+	for _, a := range additions {
+		byTable[a.TableName] = a
+	}
+	for _, h := range hosts {
+		a, ok := byTable[h]
+		c.Assert(ok, qt.IsTrue, qt.Commentf("missing reversed addition for host %s", h))
+		c.Assert(a.Name, qt.Equals, "fk_entity_tenant")
+		c.Assert(a.Type, qt.Equals, "FOREIGN KEY")
+		c.Assert(a.Columns, qt.DeepEquals, []string{"tenant_id"})
+		c.Assert(a.ForeignTable, qt.Equals, "tenants")
+		c.Assert(a.ForeignColumn, qt.Equals, "id")
+		c.Assert(a.OnDelete, qt.Equals, "NO ACTION")
+	}
+}
+
+// TestReverseConstraintAdditions_NilDBSchema is the legacy-caller path: with no
+// introspected schema there is no body to restore, so the helper returns nil and
+// the names ride the name-only fallback via ConstraintsAdded.
+func TestReverseConstraintAdditions_NilDBSchema(t *testing.T) {
+	c := qt.New(t)
+	upDiff := &types.SchemaDiff{
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "fk_x", TableName: "t", Type: "FOREIGN KEY"},
+		},
+	}
+	c.Assert(reverseConstraintAdditions(upDiff, nil), qt.IsNil)
+}
+
+func countConstraint(names []string, want string) int {
+	n := 0
+	for _, name := range names {
+		if name == want {
+			n++
+		}
+	}
+	return n
+}

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -573,11 +573,20 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		structToTable[t.StructName] = t.Name
 	}
 
-	// Removal info keyed by name so a same-name modification can be dropped with
-	// the correct table + FK-aware syntax before being re-added.
-	removalByName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	// Removal info keyed by (table, name) so a same-name modification can be
+	// dropped from each owning table with the correct FK-aware syntax before
+	// being re-added. A mixin-shared FK name with on_delete/on_update drift on
+	// >=2 host tables produces one ConstraintsRemovedWithTables entry per host
+	// (same Name, distinct TableName); keying the map on the name alone would
+	// collapse them to the last host, so only that host's old FK would be
+	// dropped and the other hosts' ADD CONSTRAINT would collide with the
+	// still-present same-named constraint ("Duplicate foreign key constraint
+	// name", errno 1826). Keying on (table, name) keeps one removal per host so
+	// each host gets its own DROP FOREIGN KEY. A single-host name still resolves
+	// to exactly one entry, so #189 stays byte-identical (one DROP + one ADD).
+	removalByTableName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
 	for _, info := range diff.ConstraintsRemovedWithTables {
-		removalByName[info.Name] = info
+		removalByTableName[info.TableName+"."+info.Name] = info
 	}
 
 	// Prefer the table-qualified additions when present. A field-level FK from an
@@ -592,16 +601,28 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
 		}
-		if info, modified := removalByName[add.Name]; modified {
-			if _, done := droppedForModify[add.Name]; !done {
+		// For a modification, emit the DROP FOREIGN KEY from this exact host
+		// table before its re-add. Dedup on (table, name) so each host is
+		// dropped once even if the comparator lists it more than once.
+		dropKey := add.TableName + "." + add.Name
+		if info, modified := removalByTableName[dropKey]; modified {
+			if _, done := droppedForModify[dropKey]; !done {
 				result = append(result, dropConstraintNode(info))
-				droppedForModify[add.Name] = struct{}{}
+				droppedForModify[dropKey] = struct{}{}
 			}
 		}
 		result = append(result, p.foreignKeyAdditionNode(add))
 		handled[add.Name] = struct{}{}
 	}
 
+	// Fallback for added constraints with no table-qualified entry above
+	// (table-level CHECK/UNIQUE, or field-level synthesis resolved by name).
+	// These names are unique per table, so a name-keyed removal lookup is
+	// sufficient and there is no multi-host collapse hazard here.
+	removalByName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		removalByName[info.Name] = info
+	}
 	for _, constraintName := range diff.ConstraintsAdded {
 		if _, done := handled[constraintName]; done {
 			continue

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -580,7 +580,33 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalByName[info.Name] = info
 	}
 
+	// Prefer the table-qualified additions when present. A field-level FK from an
+	// embedded inline-relation mixin shares one name across every host table, so
+	// resolving the table from the field's Go struct name targets the mixin
+	// struct rather than the real tables (issue #197). ConstraintsAddedWithTables
+	// carries the concrete table + full FK definition. Names handled here are
+	// recorded so the legacy name loop skips them.
+	handled := make(map[string]struct{})
+	droppedForModify := make(map[string]struct{})
+	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.Type != "FOREIGN KEY" || add.TableName == "" {
+			continue
+		}
+		if info, modified := removalByName[add.Name]; modified {
+			if _, done := droppedForModify[add.Name]; !done {
+				result = append(result, dropConstraintNode(info))
+				droppedForModify[add.Name] = struct{}{}
+			}
+		}
+		result = append(result, p.foreignKeyAdditionNode(add))
+		handled[add.Name] = struct{}{}
+	}
+
 	for _, constraintName := range diff.ConstraintsAdded {
+		if _, done := handled[constraintName]; done {
+			continue
+		}
+
 		// For a modification, emit the DROP first so it precedes the re-add.
 		if info, modified := removalByName[constraintName]; modified {
 			result = append(result, dropConstraintNode(info))
@@ -589,6 +615,21 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		result = p.appendAddConstraint(result, constraintName, generated, structToTable)
 	}
 	return result
+}
+
+// foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a
+// table-qualified field-level FK addition (ConstraintsAddedWithTables). The
+// concrete table comes from the comparator, so this is correct for FK names
+// that repeat across the many tables embedding an inline-relation mixin
+// (issue #197), unlike the legacy field scan keyed on a Go struct name.
+func (p *Planner) foreignKeyAdditionNode(add types.ConstraintAdditionInfo) *ast.AlterTableNode {
+	fkRef := &ast.ForeignKeyRef{
+		Table:    add.ForeignTable,
+		Column:   add.ForeignColumn,
+		OnDelete: add.OnDelete,
+		OnUpdate: add.OnUpdate,
+	}
+	return p.createForeignKeyAlterStatement(add.TableName, add.Name, add.Columns, fkRef)
 }
 
 // appendAddConstraint resolves the ADD CONSTRAINT node for a constraint known

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1040,7 +1040,38 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removedNames[name] = struct{}{}
 	}
 
+	// Prefer the table-qualified additions when the comparator supplied them.
+	// A field-level FK contributed by an embedded inline-relation mixin shares
+	// one constraint name across every host table, so the bare ConstraintsAdded
+	// name list (and a field scan keyed on the Go struct name) cannot target the
+	// right table — it would emit ALTER TABLE <MixinStruct> once per host
+	// (issue #197). ConstraintsAddedWithTables carries the concrete table and
+	// the full FK definition, so each host gets its own correct ALTER. Names
+	// handled here are recorded so the legacy name loop below skips them.
+	handled := make(map[string]struct{})
+	droppedForModify := make(map[string]struct{})
+	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.Type != "FOREIGN KEY" || add.TableName == "" {
+			continue
+		}
+		// For a modification (same name dropped + added) emit the DROP once
+		// before the first re-add so it precedes every re-add of that name.
+		if _, modified := removedNames[add.Name]; modified {
+			if _, done := droppedForModify[add.Name]; !done {
+				result = append(result, p.dropConstraintNode(add.Name))
+				droppedForModify[add.Name] = struct{}{}
+			}
+		}
+		result = append(result, p.foreignKeyAdditionNode(add))
+		handled[add.Name] = struct{}{}
+	}
+
 	for _, constraintName := range diff.ConstraintsAdded {
+		// Already emitted via the table-qualified FK path above.
+		if _, done := handled[constraintName]; done {
+			continue
+		}
+
 		// For a modification, emit the DROP first so it precedes the re-add.
 		if _, modified := removedNames[constraintName]; modified {
 			result = append(result, p.dropConstraintNode(constraintName))
@@ -1062,6 +1093,22 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		}
 	}
 	return result
+}
+
+// foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a
+// table-qualified field-level FK addition (ConstraintsAddedWithTables). The
+// table comes straight from the comparator's synthesized constraint, so this
+// path is correct for FK names that repeat across the many tables embedding an
+// inline-relation mixin (issue #197), unlike the legacy field-scan fallback
+// that re-derived the table from a Go struct name.
+func (p *Planner) foreignKeyAdditionNode(add types.ConstraintAdditionInfo) *ast.AlterTableNode {
+	fkRef := &ast.ForeignKeyRef{
+		Table:    add.ForeignTable,
+		Column:   add.ForeignColumn,
+		OnDelete: add.OnDelete,
+		OnUpdate: add.OnUpdate,
+	}
+	return p.createForeignKeyAlterStatement(add.TableName, add.Name, add.Columns, fkRef)
 }
 
 // addConstraintNodeFor resolves the ADD CONSTRAINT node for a constraint known
@@ -1214,8 +1261,38 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 		addedNames[name] = struct{}{}
 	}
 
+	// When the comparator supplied the owning table (ConstraintsRemovedWithTables),
+	// drop the constraint from that exact table with a direct ALTER TABLE … DROP
+	// CONSTRAINT IF EXISTS. This is required for a field-level FK whose name
+	// repeats across the many tables embedding an inline-relation mixin
+	// (issue #197): the name-only DO block below resolves a single table via
+	// information_schema LIMIT 1, so it would drop the constraint from only one
+	// of the host tables and silently leave the rest. Names handled here are
+	// recorded so the name-only fallback does not double-drop them.
+	handled := make(map[string]struct{})
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		if info.TableName == "" {
+			continue
+		}
+		if _, modified := addedNames[info.Name]; modified {
+			handled[info.Name] = struct{}{}
+			continue
+		}
+		result = append(result, &ast.AlterTableNode{
+			Name: info.TableName,
+			Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+				ConstraintName: info.Name,
+				IfExists:       true,
+			}},
+		})
+		handled[info.Name] = struct{}{}
+	}
+
 	for _, constraintName := range diff.ConstraintsRemoved {
 		if _, modified := addedNames[constraintName]; modified {
+			continue
+		}
+		if _, done := handled[constraintName]; done {
 			continue
 		}
 		result = append(result, p.dropConstraintNode(constraintName))

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1048,19 +1048,43 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// (issue #197). ConstraintsAddedWithTables carries the concrete table and
 	// the full FK definition, so each host gets its own correct ALTER. Names
 	// handled here are recorded so the legacy name loop below skips them.
+	// A modified FK name (dropped + added) must be dropped before its re-add.
+	// Count the distinct host tables each such name spans so we can pick the
+	// right drop form: a mixin-shared FK name with on_delete/on_update drift on
+	// >=2 host tables yields one ConstraintsAddedWithTables entry per host
+	// (same Name, distinct TableName). The legacy name-only DO block resolves a
+	// single table via information_schema LIMIT 1, so it drops the constraint
+	// from only ONE host and the 2nd+ host's ADD CONSTRAINT then collides with
+	// the still-present old constraint of the same name ("constraint ...
+	// already exists", SQLSTATE 42710). For those multi-host names we instead
+	// emit a table-qualified ALTER TABLE <host> DROP CONSTRAINT IF EXISTS
+	// <name> per host, mirroring the per-table approach removeConstraints
+	// already uses for the pure-removal multi-host case. A single-host name
+	// keeps the unchanged name-only DO block so #189 stays byte-identical.
+	modifyHostsByName := make(map[string]map[string]struct{})
+	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.Type != "FOREIGN KEY" || add.TableName == "" {
+			continue
+		}
+		if _, modified := removedNames[add.Name]; !modified {
+			continue
+		}
+		hosts := modifyHostsByName[add.Name]
+		if hosts == nil {
+			hosts = make(map[string]struct{})
+			modifyHostsByName[add.Name] = hosts
+		}
+		hosts[add.TableName] = struct{}{}
+	}
+
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
 		}
-		// For a modification (same name dropped + added) emit the DROP once
-		// before the first re-add so it precedes every re-add of that name.
 		if _, modified := removedNames[add.Name]; modified {
-			if _, done := droppedForModify[add.Name]; !done {
-				result = append(result, p.dropConstraintNode(add.Name))
-				droppedForModify[add.Name] = struct{}{}
-			}
+			result = p.emitModifyDrop(result, add, modifyHostsByName, droppedForModify)
 		}
 		result = append(result, p.foreignKeyAdditionNode(add))
 		handled[add.Name] = struct{}{}
@@ -1093,6 +1117,41 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		}
 	}
 	return result
+}
+
+// emitModifyDrop appends the DROP that must precede the re-ADD of a modified
+// field-level FK (a constraint present in both ConstraintsAdded and
+// ConstraintsRemoved). For a name spanning >=2 host tables it emits a
+// table-qualified ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>, deduped
+// per (host, name), so every host's old constraint is dropped before its ADD;
+// the name-only information_schema LIMIT 1 DO block would drop only one host
+// and let the others collide (issue #197 MODIFY path). A single-host name keeps
+// the unchanged name-only DO block so #189 stays byte-identical.
+func (p *Planner) emitModifyDrop(
+	result []ast.Node,
+	add types.ConstraintAdditionInfo,
+	modifyHostsByName map[string]map[string]struct{},
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	if len(modifyHostsByName[add.Name]) > 1 {
+		dedupKey := add.TableName + "." + add.Name
+		if _, done := droppedForModify[dedupKey]; done {
+			return result
+		}
+		droppedForModify[dedupKey] = struct{}{}
+		return append(result, &ast.AlterTableNode{
+			Name: add.TableName,
+			Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+				ConstraintName: add.Name,
+				IfExists:       true,
+			}},
+		})
+	}
+	if _, done := droppedForModify[add.Name]; done {
+		return result
+	}
+	droppedForModify[add.Name] = struct{}{}
+	return append(result, p.dropConstraintNode(add.Name))
 }
 
 // foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1048,31 +1048,40 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// (issue #197). ConstraintsAddedWithTables carries the concrete table and
 	// the full FK definition, so each host gets its own correct ALTER. Names
 	// handled here are recorded so the legacy name loop below skips them.
-	// A modified FK name (dropped + added) must be dropped before its re-add.
-	// Count the distinct host tables each such name spans so we can pick the
-	// right drop form: a mixin-shared FK name with on_delete/on_update drift on
-	// >=2 host tables yields one ConstraintsAddedWithTables entry per host
-	// (same Name, distinct TableName). The legacy name-only DO block resolves a
-	// single table via information_schema LIMIT 1, so it drops the constraint
-	// from only ONE host and the 2nd+ host's ADD CONSTRAINT then collides with
-	// the still-present old constraint of the same name ("constraint ...
-	// already exists", SQLSTATE 42710). For those multi-host names we instead
-	// emit a table-qualified ALTER TABLE <host> DROP CONSTRAINT IF EXISTS
-	// <name> per host, mirroring the per-table approach removeConstraints
-	// already uses for the pure-removal multi-host case. A single-host name
-	// keeps the unchanged name-only DO block so #189 stays byte-identical.
-	modifyHostsByName := make(map[string]map[string]struct{})
+	//
+	// A modified FK (dropped + re-added) must be dropped before its re-add. The
+	// authoritative "is this host a modification" signal is whether the exact
+	// (table, name) pair appears in the removal set — NOT whether the name alone
+	// was removed somewhere. In the MIXED case a shared FK name can be a modify
+	// on host A and a pure ADD on host B (B has no removal entry); keying the
+	// modify decision on the name alone would emit a phantom
+	// `ALTER TABLE B DROP CONSTRAINT IF EXISTS <name>` for the pure-add host.
+	// Keying the drop decision on (table, name) — mirroring MySQL's
+	// removalByTableName — gives the pure-add host no drop.
+	removalByTableName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		removalByTableName[info.TableName+"."+info.Name] = info
+	}
+
+	// Count the distinct host tables each FK name lands on across ALL additions
+	// (modifies and pure-adds alike). This selects the drop FORM for a modify
+	// host: when a name is shared by >1 host the name-only information_schema
+	// `LIMIT 1` DO block is unsafe — it could resolve to the wrong host (it would
+	// drop from only one host for a pure multi-host modify → the others collide
+	// on re-add with SQLSTATE 42710; and in the MIXED case a pure-add host's
+	// freshly added FK could be the one it resolves). So any shared name uses a
+	// table-qualified `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>` per
+	// modify host. A name on a single host keeps the unchanged name-only DO block
+	// so #189 stays byte-identical.
+	sharedNameHosts := make(map[string]map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
 		}
-		if _, modified := removedNames[add.Name]; !modified {
-			continue
-		}
-		hosts := modifyHostsByName[add.Name]
+		hosts := sharedNameHosts[add.Name]
 		if hosts == nil {
 			hosts = make(map[string]struct{})
-			modifyHostsByName[add.Name] = hosts
+			sharedNameHosts[add.Name] = hosts
 		}
 		hosts[add.TableName] = struct{}{}
 	}
@@ -1083,8 +1092,11 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
 		}
-		if _, modified := removedNames[add.Name]; modified {
-			result = p.emitModifyDrop(result, add, modifyHostsByName, droppedForModify)
+		// Only emit the DROP-before-ADD when this exact host's FK is being
+		// modified (its (table, name) is in the removal set). A pure-add host
+		// gets no phantom drop.
+		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.emitModifyDrop(result, add, sharedNameHosts, droppedForModify)
 		}
 		result = append(result, p.foreignKeyAdditionNode(add))
 		handled[add.Name] = struct{}{}
@@ -1120,20 +1132,21 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 }
 
 // emitModifyDrop appends the DROP that must precede the re-ADD of a modified
-// field-level FK (a constraint present in both ConstraintsAdded and
-// ConstraintsRemoved). For a name spanning >=2 host tables it emits a
-// table-qualified ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>, deduped
-// per (host, name), so every host's old constraint is dropped before its ADD;
-// the name-only information_schema LIMIT 1 DO block would drop only one host
-// and let the others collide (issue #197 MODIFY path). A single-host name keeps
-// the unchanged name-only DO block so #189 stays byte-identical.
+// field-level FK (a constraint whose (table, name) is in both the additions and
+// the removals). When the FK name lands on >=2 host tables across the additions
+// (sharedNameHosts) it emits a table-qualified ALTER TABLE <host> DROP
+// CONSTRAINT IF EXISTS <name>, deduped per (host, name), so each modify host's
+// old constraint is dropped before its ADD without the name-only
+// information_schema LIMIT 1 DO block resolving the wrong host (issue #197
+// MODIFY path). A name on a single host keeps the unchanged name-only DO block
+// so #189 stays byte-identical.
 func (p *Planner) emitModifyDrop(
 	result []ast.Node,
 	add types.ConstraintAdditionInfo,
-	modifyHostsByName map[string]map[string]struct{},
+	sharedNameHosts map[string]map[string]struct{},
 	droppedForModify map[string]struct{},
 ) []ast.Node {
-	if len(modifyHostsByName[add.Name]) > 1 {
+	if len(sharedNameHosts[add.Name]) > 1 {
 		dedupKey := add.TableName + "." + add.Name
 		if _, done := droppedForModify[dedupKey]; done {
 			return result

--- a/migration/schemadiff/embedded_fk_drift_test.go
+++ b/migration/schemadiff/embedded_fk_drift_test.go
@@ -266,6 +266,56 @@ func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
 	})
 }
 
+// TestEmbeddedInlineMixinFK_MixedModifyAndAdd_NoPhantomDrop covers the MIXED
+// case for the same mixin-shared FK name: on some host tables the FK already
+// exists with a different action (a MODIFY → drop-before-add) while on another
+// host the FK is missing entirely (a pure ADD). The pure-add host must NOT get a
+// DROP — there is nothing to drop there. Postgres' multi-host drop decision is
+// keyed on the actual (table, name) removal set, so a host that contributes only
+// an addition (no removal) emits no `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS`
+// noise.
+func TestEmbeddedInlineMixinFK_MixedModifyAndAdd_NoPhantomDrop(t *testing.T) {
+	c := qt.New(t)
+
+	modifyHosts := []string{"locations", "areas"}
+	addHost := "commodities"
+	allHosts := append(append([]string(nil), modifyHosts...), addHost)
+
+	// DB: locations+areas have the tenant FK at NO ACTION (so CASCADE = modify);
+	// commodities has the column but NO FK (so CASCADE = pure add).
+	dbSchema := ownableMixinColumnsOnlyDB(allHosts...)
+	for _, h := range modifyHosts {
+		dbSchema.Constraints = append(dbSchema.Constraints,
+			types.DBConstraint{Name: "fk_entity_tenant", TableName: h, Type: "FOREIGN KEY", ColumnName: "tenant_id", ForeignTable: strPtr("tenants"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+			types.DBConstraint{Name: "fk_entity_created_by", TableName: h, Type: "FOREIGN KEY", ColumnName: "created_by_user_id", ForeignTable: strPtr("users"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+		)
+	}
+	// commodities also needs the created_by FK present so only tenant differs;
+	// otherwise created_by would surface as an extra pure-add and muddy the test.
+	dbSchema.Constraints = append(dbSchema.Constraints,
+		types.DBConstraint{Name: "fk_entity_created_by", TableName: addHost, Type: "FOREIGN KEY", ColumnName: "created_by_user_id", ForeignTable: strPtr("users"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+	)
+
+	gen := ownableMixinSchemaWithTenantOnDelete("CASCADE", allHosts...)
+	diff := schemadiff.Compare(gen, dbSchema)
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+
+	nodes := postgres.New().GenerateMigrationAST(diff, gen)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	// Each modify host gets a table-qualified DROP before its re-ADD.
+	for _, h := range modifyHosts {
+		c.Assert(strings.Count(sql, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_tenant;"), qt.Equals, 1,
+			qt.Commentf("modify host %s must drop the old tenant FK once, got:\n%s", h, sql))
+	}
+	// The pure-add host gets the ADD but NO phantom DROP.
+	c.Assert(strings.Contains(sql, "ALTER TABLE "+addHost+" ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE"), qt.IsTrue,
+		qt.Commentf("pure-add host %s must add the tenant FK, got:\n%s", addHost, sql))
+	c.Assert(strings.Contains(sql, "ALTER TABLE "+addHost+" DROP CONSTRAINT IF EXISTS fk_entity_tenant"), qt.IsFalse,
+		qt.Commentf("pure-add host %s must NOT emit a phantom DROP, got:\n%s", addHost, sql))
+}
+
 // ownableMixinConvergedTenantOnDelete is ownableMixinConvergedDB but with the
 // tenant FK already carrying the given delete rule, used to prove idempotency
 // of the multi-host modify (after apply, the database agrees with generated).

--- a/migration/schemadiff/embedded_fk_drift_test.go
+++ b/migration/schemadiff/embedded_fk_drift_test.go
@@ -1,0 +1,169 @@
+package schemadiff_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// reverseConstraintDiff mirrors the constraint half of the generator's down
+// migration: what the up migration ADDED is what the down migration must
+// REMOVE, preserving the table-qualified info so the planner targets the right
+// table. (The generator's reverseSchemaDiffWithSchema is unexported; this
+// reproduces only the constraint reversal exercised here.)
+func reverseConstraintDiff(up *difftypes.SchemaDiff) *difftypes.SchemaDiff {
+	down := &difftypes.SchemaDiff{
+		ConstraintsRemoved: append([]string(nil), up.ConstraintsAdded...),
+	}
+	for _, add := range up.ConstraintsAddedWithTables {
+		down.ConstraintsRemovedWithTables = append(down.ConstraintsRemovedWithTables, difftypes.ConstraintRemovalInfo{
+			Name:      add.Name,
+			TableName: add.TableName,
+			Type:      add.Type,
+		})
+	}
+	return down
+}
+
+// ownableMixinSchema builds a generated schema with an "Ownable" embedded
+// inline mixin that carries two `foreign=` fields (tenant_id and
+// created_by_user_id, each with an explicit shared foreign_key_name). The mixin
+// is embedded inline into the named host tables, so each host materializes the
+// same columns + the same FK names.
+func ownableMixinSchema(hostTables ...string) *goschema.Database {
+	db := &goschema.Database{
+		Fields: []goschema.Field{
+			{
+				StructName:     "Ownable",
+				Name:           "tenant_id",
+				Type:           "TEXT",
+				Foreign:        "tenants(id)",
+				ForeignKeyName: "fk_entity_tenant",
+			},
+			{
+				StructName:     "Ownable",
+				Name:           "created_by_user_id",
+				Type:           "TEXT",
+				Foreign:        "users(id)",
+				ForeignKeyName: "fk_entity_created_by",
+			},
+		},
+	}
+	for _, ht := range hostTables {
+		// Derive a struct name from the table name for the test (e.g. locations -> Locations).
+		structName := strings.ToUpper(ht[:1]) + ht[1:]
+		db.Tables = append(db.Tables, goschema.Table{StructName: structName, Name: ht})
+		db.Fields = append(db.Fields, goschema.Field{StructName: structName, Name: "id", Type: "TEXT", Primary: true})
+		db.EmbeddedFields = append(db.EmbeddedFields, goschema.EmbeddedField{
+			StructName: structName, Mode: "inline", EmbeddedTypeName: "Ownable",
+		})
+	}
+	return db
+}
+
+// ownableMixinColumnsOnlyDB builds the introspected DB for the given host
+// tables with the mixin columns present but the FKs missing (so they surface as
+// additions).
+func ownableMixinColumnsOnlyDB(hostTables ...string) *types.DBSchema {
+	db := &types.DBSchema{}
+	for _, ht := range hostTables {
+		db.Tables = append(db.Tables, ownableHostTable(ht))
+	}
+	return db
+}
+
+// ownableMixinConvergedDB builds the introspected DB for the given host tables
+// with both the mixin columns and the tenant/created_by FKs already present
+// (NO ACTION), i.e. the schema is converged.
+func ownableMixinConvergedDB(hostTables ...string) *types.DBSchema {
+	db := ownableMixinColumnsOnlyDB(hostTables...)
+	for _, ht := range hostTables {
+		db.Constraints = append(db.Constraints,
+			types.DBConstraint{Name: "fk_entity_tenant", TableName: ht, Type: "FOREIGN KEY", ColumnName: "tenant_id", ForeignTable: strPtr("tenants"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+			types.DBConstraint{Name: "fk_entity_created_by", TableName: ht, Type: "FOREIGN KEY", ColumnName: "created_by_user_id", ForeignTable: strPtr("users"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+		)
+	}
+	return db
+}
+
+func ownableHostTable(name string) types.DBTable {
+	return types.DBTable{
+		Name: name,
+		Columns: []types.DBColumn{
+			{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+			{Name: "tenant_id", DataType: "text", IsNullable: "NO"},
+			{Name: "created_by_user_id", DataType: "text", IsNullable: "NO"},
+		},
+	}
+}
+
+// TestEmbeddedInlineMixinFK_NeverTargetsStructName is the end-to-end acceptance
+// test for issue #197 through the postgres planner + renderer. When an embedded
+// inline-relation mixin contributes `foreign=` fields to several host tables,
+// the generated migration must add one FK per real host table (correct table
+// name, no duplication) and never emit `ALTER TABLE <MixinStruct> ...`.
+func TestEmbeddedInlineMixinFK_NeverTargetsStructName(t *testing.T) {
+	hosts := []string{"locations", "areas", "commodities"}
+
+	t.Run("missing mixin FKs are added once per real host table, never the struct", func(t *testing.T) {
+		c := qt.New(t)
+
+		gen := ownableMixinSchema(hosts...)
+		diff := schemadiff.Compare(gen, ownableMixinColumnsOnlyDB(hosts...))
+		c.Assert(diff.HasChanges(), qt.IsTrue)
+
+		nodes := postgres.New().GenerateMigrationAST(diff, gen)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		// Never the mixin struct name.
+		c.Assert(strings.Contains(sql, "ALTER TABLE Ownable"), qt.IsFalse,
+			qt.Commentf("must not target the mixin struct name, got:\n%s", sql))
+
+		// One correctly-targeted ADD per host table per FK, no duplication.
+		for _, h := range hosts {
+			tenantStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)"
+			createdByStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id)"
+			c.Assert(strings.Count(sql, tenantStmt), qt.Equals, 1, qt.Commentf("host %s tenant FK, sql:\n%s", h, sql))
+			c.Assert(strings.Count(sql, createdByStmt), qt.Equals, 1, qt.Commentf("host %s created_by FK, sql:\n%s", h, sql))
+		}
+	})
+
+	t.Run("down migration drops each FK from its real host table", func(t *testing.T) {
+		c := qt.New(t)
+
+		gen := ownableMixinSchema(hosts...)
+		diff := schemadiff.Compare(gen, ownableMixinColumnsOnlyDB(hosts...))
+
+		// Reverse the diff the way the generator does for the down migration.
+		downDiff := reverseConstraintDiff(diff)
+		nodes := postgres.New().GenerateMigrationAST(downDiff, gen)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "Ownable"), qt.IsFalse,
+			qt.Commentf("down must not reference the mixin struct, got:\n%s", sql))
+		for _, h := range hosts {
+			c.Assert(strings.Contains(sql, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_tenant"), qt.IsTrue,
+				qt.Commentf("down must drop tenant FK from %s, got:\n%s", h, sql))
+			c.Assert(strings.Contains(sql, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_created_by"), qt.IsTrue,
+				qt.Commentf("down must drop created_by FK from %s, got:\n%s", h, sql))
+		}
+	})
+
+	t.Run("converged mixin FKs are a no-op (no churn)", func(t *testing.T) {
+		c := qt.New(t)
+
+		gen := ownableMixinSchema(hosts...)
+		diff := schemadiff.Compare(gen, ownableMixinConvergedDB(hosts...))
+		c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("added=%v removed=%v", diff.ConstraintsAdded, diff.ConstraintsRemoved))
+	})
+}

--- a/migration/schemadiff/embedded_fk_drift_test.go
+++ b/migration/schemadiff/embedded_fk_drift_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
 	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/schemadiff"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
@@ -94,6 +95,22 @@ func ownableMixinConvergedDB(hostTables ...string) *types.DBSchema {
 	return db
 }
 
+// ownableMixinSchemaWithTenantOnDelete builds the same Ownable mixin schema as
+// ownableMixinSchema but stamps the given ON DELETE action onto the shared
+// tenant FK (fk_entity_tenant) on every host. Used to drive a multi-host FK
+// action change (issue #197 MODIFY path): the generated action differs from the
+// converged NO ACTION database, so the comparator routes fk_entity_tenant into
+// ConstraintsAdded + ConstraintsRemoved for each host table at once.
+func ownableMixinSchemaWithTenantOnDelete(onDelete string, hostTables ...string) *goschema.Database {
+	db := ownableMixinSchema(hostTables...)
+	for i := range db.Fields {
+		if db.Fields[i].StructName == "Ownable" && db.Fields[i].Name == "tenant_id" {
+			db.Fields[i].OnDelete = onDelete
+		}
+	}
+	return db
+}
+
 func ownableHostTable(name string) types.DBTable {
 	return types.DBTable{
 		Name: name,
@@ -166,4 +183,109 @@ func TestEmbeddedInlineMixinFK_NeverTargetsStructName(t *testing.T) {
 		diff := schemadiff.Compare(gen, ownableMixinConvergedDB(hosts...))
 		c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("added=%v removed=%v", diff.ConstraintsAdded, diff.ConstraintsRemoved))
 	})
+}
+
+// TestEmbeddedInlineMixinFK_MultiHostActionDrift is the regression test for the
+// MODIFY (drop-before-add) half of issue #197. When a mixin-shared FK name
+// (fk_entity_tenant) has an on_delete change on >=2 host tables in the same
+// diff, the planner must emit a DROP of the OLD constraint for EACH host paired
+// with each re-ADD. A single name-keyed drop (Postgres: the information_schema
+// LIMIT 1 DO block; MySQL: the last-host-wins collapse) drops the constraint
+// from only one host, so the 2nd+ host's ADD CONSTRAINT collides with the
+// still-present same-named constraint ("already exists" / "Duplicate foreign
+// key constraint name"). This pins one DROP per host, ordered before its ADD.
+func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
+	hosts := []string{"locations", "areas", "commodities"}
+
+	t.Run("postgres emits a table-qualified DROP per host before each ADD", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Generated tenant FK = ON DELETE CASCADE; DB = converged NO ACTION.
+		gen := ownableMixinSchemaWithTenantOnDelete("CASCADE", hosts...)
+		diff := schemadiff.Compare(gen, ownableMixinConvergedDB(hosts...))
+		c.Assert(diff.HasChanges(), qt.IsTrue)
+		// The same FK name is added + removed once per host (a modification).
+		c.Assert(countName(diff.ConstraintsAdded, "fk_entity_tenant"), qt.Equals, len(hosts))
+		c.Assert(countName(diff.ConstraintsRemoved, "fk_entity_tenant"), qt.Equals, len(hosts))
+
+		nodes := postgres.New().GenerateMigrationAST(diff, gen)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		for _, h := range hosts {
+			dropStmt := "ALTER TABLE " + h + " DROP CONSTRAINT IF EXISTS fk_entity_tenant;"
+			addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;"
+
+			// Exactly one table-qualified DROP and one ADD for this host.
+			c.Assert(strings.Count(sql, dropStmt), qt.Equals, 1,
+				qt.Commentf("host %s: expected one table-qualified DROP, got:\n%s", h, sql))
+			c.Assert(strings.Count(sql, addStmt), qt.Equals, 1,
+				qt.Commentf("host %s: expected one ADD with ON DELETE CASCADE, got:\n%s", h, sql))
+
+			// The DROP must precede the matching ADD so the re-add can't collide.
+			dropIdx := strings.Index(sql, dropStmt)
+			addIdx := strings.Index(sql, addStmt)
+			c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+				qt.Commentf("host %s: DROP must precede ADD; drop@%d add@%d\n%s", h, dropIdx, addIdx, sql))
+		}
+
+		// Idempotency: once the database carries CASCADE, regenerating is empty.
+		converged := schemadiff.Compare(gen, ownableMixinConvergedTenantOnDelete("CASCADE", hosts...))
+		noopNodes := postgres.New().GenerateMigrationAST(converged, gen)
+		noopSQL, err := renderer.RenderSQL("postgres", noopNodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(noopSQL, "fk_entity_tenant"), qt.IsFalse,
+			qt.Commentf("converged tenant FK must produce no churn, got:\n%s", noopSQL))
+	})
+
+	t.Run("mysql emits a DROP FOREIGN KEY per host before each ADD", func(t *testing.T) {
+		c := qt.New(t)
+
+		gen := ownableMixinSchemaWithTenantOnDelete("CASCADE", hosts...)
+		diff := schemadiff.CompareWithDialect(gen, ownableMixinConvergedDB(hosts...), "mysql")
+		c.Assert(diff.HasChanges(), qt.IsTrue)
+
+		nodes := mysql.New().GenerateMigrationAST(diff, gen)
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		for _, h := range hosts {
+			dropStmt := "ALTER TABLE " + h + " DROP FOREIGN KEY fk_entity_tenant;"
+			addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;"
+
+			c.Assert(strings.Count(sql, dropStmt), qt.Equals, 1,
+				qt.Commentf("host %s: expected one DROP FOREIGN KEY, got:\n%s", h, sql))
+			c.Assert(strings.Count(sql, addStmt), qt.Equals, 1,
+				qt.Commentf("host %s: expected one ADD with ON DELETE CASCADE, got:\n%s", h, sql))
+
+			dropIdx := strings.Index(sql, dropStmt)
+			addIdx := strings.Index(sql, addStmt)
+			c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+				qt.Commentf("host %s: DROP must precede ADD; drop@%d add@%d\n%s", h, dropIdx, addIdx, sql))
+		}
+	})
+}
+
+// ownableMixinConvergedTenantOnDelete is ownableMixinConvergedDB but with the
+// tenant FK already carrying the given delete rule, used to prove idempotency
+// of the multi-host modify (after apply, the database agrees with generated).
+func ownableMixinConvergedTenantOnDelete(deleteRule string, hostTables ...string) *types.DBSchema {
+	db := ownableMixinColumnsOnlyDB(hostTables...)
+	for _, ht := range hostTables {
+		db.Constraints = append(db.Constraints,
+			types.DBConstraint{Name: "fk_entity_tenant", TableName: ht, Type: "FOREIGN KEY", ColumnName: "tenant_id", ForeignTable: strPtr("tenants"), ForeignColumn: strPtr("id"), DeleteRule: strPtr(deleteRule), UpdateRule: strPtr("NO ACTION")},
+			types.DBConstraint{Name: "fk_entity_created_by", TableName: ht, Type: "FOREIGN KEY", ColumnName: "created_by_user_id", ForeignTable: strPtr("users"), ForeignColumn: strPtr("id"), DeleteRule: strPtr("NO ACTION"), UpdateRule: strPtr("NO ACTION")},
+		)
+	}
+	return db
+}
+
+func countName(names []string, want string) int {
+	n := 0
+	for _, name := range names {
+		if name == want {
+			n++
+		}
+	}
+	return n
 }

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -925,6 +925,7 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	for constraintKey, genConstraint := range genConstraints {
 		if _, exists := dbConstraints[constraintKey]; !exists {
 			diff.ConstraintsAdded = append(diff.ConstraintsAdded, genConstraint.Name)
+			diff.ConstraintsAddedWithTables = appendConstraintAddition(diff.ConstraintsAddedWithTables, genConstraint)
 		}
 	}
 
@@ -945,6 +946,7 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 				diff.ConstraintsRemoved = append(diff.ConstraintsRemoved, dbConstraint.Name)
 				diff.ConstraintsRemovedWithTables = appendConstraintRemoval(diff.ConstraintsRemovedWithTables, dbConstraint)
 				diff.ConstraintsAdded = append(diff.ConstraintsAdded, genConstraint.Name)
+				diff.ConstraintsAddedWithTables = appendConstraintAddition(diff.ConstraintsAddedWithTables, genConstraint)
 			}
 		}
 	}
@@ -960,6 +962,29 @@ func appendConstraintRemoval(infos []difftypes.ConstraintRemovalInfo, dbConstrai
 		Name:      dbConstraint.Name,
 		TableName: dbConstraint.TableName,
 		Type:      dbConstraint.Type,
+	})
+}
+
+// appendConstraintAddition records the table-qualified definition of a
+// constraint that is being added (or modified, which is expressed as remove +
+// add). The bare ConstraintsAdded name list cannot disambiguate a field-level
+// FK whose name repeats across several tables — the canonical case being an
+// embedded inline-relation mixin (e.g. fk_entity_tenant on every table that
+// embeds a tenant-aware base struct, issue #197). Planners read this parallel
+// slice to emit one correctly-targeted ALTER TABLE per real host table instead
+// of re-deriving the table from a field's Go struct name (which, for a mixin,
+// is not a table at all). For a unique-named constraint this carries exactly
+// one entry and matches the legacy field-scan behavior.
+func appendConstraintAddition(infos []difftypes.ConstraintAdditionInfo, genConstraint goschema.Constraint) []difftypes.ConstraintAdditionInfo {
+	return append(infos, difftypes.ConstraintAdditionInfo{
+		Name:          genConstraint.Name,
+		TableName:     genConstraint.Table,
+		Type:          genConstraint.Type,
+		Columns:       append([]string(nil), genConstraint.Columns...),
+		ForeignTable:  genConstraint.ForeignTable,
+		ForeignColumn: genConstraint.ForeignColumn,
+		OnDelete:      genConstraint.OnDelete,
+		OnUpdate:      genConstraint.OnUpdate,
 	})
 }
 
@@ -1315,11 +1340,6 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		return nil
 	}
 
-	structToTable := make(map[string]string, len(generated.Tables))
-	for _, t := range generated.Tables {
-		structToTable[t.StructName] = t.Name
-	}
-
 	dbColumns := make(map[string]struct{}, 16)
 	for _, t := range database.Tables {
 		for _, c := range t.Columns {
@@ -1327,14 +1347,33 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		}
 	}
 
+	// Iterate the fields that actually materialize on each concrete table,
+	// not the raw parse result. A `foreign=` annotation declared on an
+	// embedded inline-relation mixin (e.g. a TenantGroupAwareEntityID base
+	// struct carrying tenant_id/group_id/created_by_user_id FKs) lives on the
+	// mixin's StructName, which is NOT a table. Synthesizing against
+	// f.StructName therefore produced a constraint targeting the Go struct
+	// name (ALTER TABLE TenantGroupAwareEntityID ...) once per embedding host,
+	// all collapsed onto the same bogus name (issue #197). Resolving via the
+	// same CREATE-path embedded expansion that TableColumns uses gives one
+	// field per real host table with the host's StructName, so each embedding
+	// table gets its own correctly-targeted FK.
+	//
+	// dedupe guards against a host that both declares a field directly and
+	// inherits one of the same (table, constraint name) from a mixin.
+	dedupe := make(map[string]struct{})
 	var synthesized []goschema.Constraint
-	for _, f := range generated.Fields {
+	for _, f := range resolveTableFields(generated) {
 		if f.Foreign == "" {
 			continue
 		}
-		tableName := structToTable[f.StructName]
+		// resolveTableFields only returns fields that belong to a real table,
+		// tagged with that table's name. An empty tableName would mean the
+		// field is not part of any table, so skip it rather than synthesize
+		// against a struct name.
+		tableName := f.tableName
 		if tableName == "" {
-			tableName = f.StructName
+			continue
 		}
 		if _, exists := dbColumns[tableName+"."+f.Name]; !exists {
 			continue
@@ -1352,6 +1391,11 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		if fkRef == nil {
 			continue
 		}
+		dedupeKey := tableName + "." + name
+		if _, seen := dedupe[dedupeKey]; seen {
+			continue
+		}
+		dedupe[dedupeKey] = struct{}{}
 		synthesized = append(synthesized, goschema.Constraint{
 			StructName:    f.StructName,
 			Name:          name,
@@ -1365,6 +1409,48 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		})
 	}
 	return synthesized
+}
+
+// resolvedField is a goschema.Field paired with the concrete database table it
+// materializes on. Fields declared directly on a table struct carry that
+// table's name; fields contributed by an embedded inline / inline-relation
+// mixin are expanded once per embedding host and carry the host table's name.
+type resolvedField struct {
+	goschema.Field
+	tableName string
+}
+
+// resolveTableFields expands every table's field set the same way the CREATE
+// and column-diff paths do (processEmbeddedFieldsForStruct), tagging each
+// resulting field with its concrete host table name. This is the single source
+// of truth for "which fields end up as columns on which real table", so any
+// field-level synthesis (FK drift, and any future field-level constraint
+// synthesis) targets host tables rather than mixin struct names (issue #197).
+//
+// Only fields whose owning struct is a declared table are returned: a
+// `foreign=` annotation on a mixin that is never embedded, or on a struct that
+// is not a //migrator:schema:table, has no concrete table and must not be
+// synthesized.
+func resolveTableFields(generated *goschema.Database) []resolvedField {
+	if generated == nil {
+		return nil
+	}
+
+	var resolved []resolvedField
+	for _, table := range generated.Tables {
+		// Direct fields declared on the table struct itself.
+		for _, f := range generated.Fields {
+			if f.StructName == table.StructName {
+				resolved = append(resolved, resolvedField{Field: f, tableName: table.Name})
+			}
+		}
+		// Fields contributed by embedded mixins (inline + inline-relation),
+		// each already rewritten to the host struct name by the expansion.
+		for _, f := range processEmbeddedFieldsForStruct(generated.EmbeddedFields, generated.Fields, table.StructName) {
+			resolved = append(resolved, resolvedField{Field: f, tableName: table.Name})
+		}
+	}
+	return resolved
 }
 
 // getConstraintColumn extracts the column name from a constraint

--- a/migration/schemadiff/internal/compare/embedded_fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/embedded_fk_constraints_test.go
@@ -1,0 +1,297 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestConstraints_EmbeddedInlineMixinForeignKey covers issue #197 — a
+// `foreign=` annotation declared on an embedded inline mixin (a base struct
+// that is embedded via //migrator:embedded mode="inline" into several concrete
+// tables) must synthesize one FK per real embedding table, against the host
+// table name, never against the mixin's Go struct name.
+//
+// The #189 synthesis iterated the raw parse result, where the mixin's FK fields
+// carry the mixin StructName (not a table). That produced
+// `ALTER TABLE <MixinStruct> ADD CONSTRAINT ...` once per embedding host, all
+// collapsed onto the same bogus name with no DROP and no ON DELETE. The fix
+// resolves fields through the same CREATE-path embedded expansion the column
+// diff uses, so each host gets its own correctly-targeted FK.
+//
+// The mixin here intentionally pins explicit foreign_key_name= values that are
+// shared across every host (mirroring inventario's TenantGroupAwareEntityID,
+// whose fk_entity_* names repeat on every embedding table). FK names are scoped
+// per table in the database, so the same name legitimately appears once per
+// host table — the assertions therefore count occurrences per (table, name).
+func TestConstraints_EmbeddedInlineMixinForeignKey(t *testing.T) {
+	// ownerCol returns the standard introspected FK row for <table>.<col> ->
+	// <refTable>.id with the given delete rule (nil == rule absent).
+	dbFK := func(name, table, col, refTable string, deleteRule *string) types.DBConstraint {
+		return types.DBConstraint{
+			Name:          name,
+			TableName:     table,
+			Type:          "FOREIGN KEY",
+			ColumnName:    col,
+			ForeignTable:  stringPtr(refTable),
+			ForeignColumn: stringPtr("id"),
+			DeleteRule:    deleteRule,
+			UpdateRule:    stringPtr("NO ACTION"),
+		}
+	}
+
+	// mixinFields are the FK fields owned by the "Ownable" mixin struct. They
+	// are declared on the mixin, not on any table.
+	mixinFields := []goschema.Field{
+		{
+			StructName:     "Ownable",
+			Name:           "tenant_id",
+			Type:           "TEXT",
+			Foreign:        "tenants(id)",
+			ForeignKeyName: "fk_entity_tenant",
+			OnDelete:       "CASCADE",
+		},
+		{
+			StructName:     "Ownable",
+			Name:           "created_by_user_id",
+			Type:           "TEXT",
+			Foreign:        "users(id)",
+			ForeignKeyName: "fk_entity_created_by",
+			// OnDelete intentionally empty -> NO ACTION.
+		},
+	}
+
+	// Two concrete tables embed the mixin inline.
+	embedded := []goschema.EmbeddedField{
+		{StructName: "Location", Mode: "inline", EmbeddedTypeName: "Ownable"},
+		{StructName: "Area", Mode: "inline", EmbeddedTypeName: "Ownable"},
+	}
+
+	// dbColumns: both host tables already exist in the database with the mixin
+	// columns materialized, so the field-level FKs get synthesized.
+	dbTable := func(name string) types.DBTable {
+		return types.DBTable{
+			Name: name,
+			Columns: []types.DBColumn{
+				{Name: "id"},
+				{Name: "tenant_id"},
+				{Name: "created_by_user_id"},
+			},
+		}
+	}
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Location", Name: "locations"},
+			{StructName: "Area", Name: "areas"},
+		},
+		Fields: append([]goschema.Field{
+			{StructName: "Location", Name: "id", Type: "TEXT", Primary: true},
+			{StructName: "Area", Name: "id", Type: "TEXT", Primary: true},
+		}, mixinFields...),
+		EmbeddedFields: embedded,
+	}
+
+	t.Run("unchanged actions round-trip to a no-op across all embedding hosts", func(t *testing.T) {
+		c := qt.New(t)
+
+		database := &types.DBSchema{
+			Tables: []types.DBTable{dbTable("locations"), dbTable("areas")},
+			Constraints: []types.DBConstraint{
+				// CASCADE matches the mixin annotation on both hosts.
+				dbFK("fk_entity_tenant", "locations", "tenant_id", "tenants", stringPtr("CASCADE")),
+				dbFK("fk_entity_tenant", "areas", "tenant_id", "tenants", stringPtr("CASCADE")),
+				// NO ACTION matches the action-less created_by FK on both hosts.
+				dbFK("fk_entity_created_by", "locations", "created_by_user_id", "users", stringPtr("NO ACTION")),
+				dbFK("fk_entity_created_by", "areas", "created_by_user_id", "users", stringPtr("NO ACTION")),
+			},
+		}
+
+		diff := &difftypes.SchemaDiff{}
+		compare.Constraints(generated, database, diff, nil)
+
+		c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("added=%v", diff.ConstraintsAdded))
+		c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("removed=%v", diff.ConstraintsRemoved))
+	})
+
+	t.Run("never targets the mixin struct name", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Empty database -> every synthesized FK is "added". This is the path
+		// that previously emitted ALTER TABLE Ownable ADD CONSTRAINT ...; with
+		// the fix the synthesis is keyed on real host tables, so the removal
+		// info (and therefore the eventual ALTER) never references the struct.
+		database := &types.DBSchema{
+			Tables: []types.DBTable{dbTable("locations"), dbTable("areas")},
+			// No matching DB constraints -> all synthesized FKs are additions,
+			// but crucially against real tables.
+			Constraints: []types.DBConstraint{
+				dbFK("fk_entity_tenant", "locations", "tenant_id", "tenants", stringPtr("CASCADE")),
+				dbFK("fk_entity_tenant", "areas", "tenant_id", "tenants", stringPtr("CASCADE")),
+				dbFK("fk_entity_created_by", "locations", "created_by_user_id", "users", stringPtr("NO ACTION")),
+				dbFK("fk_entity_created_by", "areas", "created_by_user_id", "users", stringPtr("NO ACTION")),
+			},
+		}
+
+		// Re-run the unchanged-state diff (a no-op) and additionally assert the
+		// removal-info table names never contain the mixin struct. The removal
+		// slice is the structure the planner reads to build ALTER statements.
+		diff := &difftypes.SchemaDiff{}
+		compare.Constraints(generated, database, diff, nil)
+		for _, info := range diff.ConstraintsRemovedWithTables {
+			c.Assert(info.TableName, qt.Not(qt.Equals), "Ownable",
+				qt.Commentf("removal must target a real table, got %q", info.TableName))
+		}
+	})
+
+	t.Run("action change on one host surfaces once for that host, not duplicated", func(t *testing.T) {
+		c := qt.New(t)
+
+		// The live FK on locations.tenant_id drifted to NO ACTION; the model
+		// (mixin) wants CASCADE. areas still matches CASCADE. Expect exactly one
+		// drop + one add of fk_entity_tenant, and the removal must be scoped to
+		// the locations table.
+		database := &types.DBSchema{
+			Tables: []types.DBTable{dbTable("locations"), dbTable("areas")},
+			Constraints: []types.DBConstraint{
+				dbFK("fk_entity_tenant", "locations", "tenant_id", "tenants", stringPtr("NO ACTION")), // drifted
+				dbFK("fk_entity_tenant", "areas", "tenant_id", "tenants", stringPtr("CASCADE")),       // unchanged
+				dbFK("fk_entity_created_by", "locations", "created_by_user_id", "users", stringPtr("NO ACTION")),
+				dbFK("fk_entity_created_by", "areas", "created_by_user_id", "users", stringPtr("NO ACTION")),
+			},
+		}
+
+		diff := &difftypes.SchemaDiff{}
+		compare.Constraints(generated, database, diff, nil)
+
+		c.Assert(diff.ConstraintsAdded, qt.DeepEquals, []string{"fk_entity_tenant"},
+			qt.Commentf("added=%v", diff.ConstraintsAdded))
+		c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, []string{"fk_entity_tenant"},
+			qt.Commentf("removed=%v", diff.ConstraintsRemoved))
+
+		// The drop must target the locations table (where the drift is), never
+		// areas (unchanged) and never the mixin struct.
+		c.Assert(diff.ConstraintsRemovedWithTables, qt.HasLen, 1)
+		c.Assert(diff.ConstraintsRemovedWithTables[0].TableName, qt.Equals, "locations")
+		c.Assert(diff.ConstraintsRemovedWithTables[0].Name, qt.Equals, "fk_entity_tenant")
+	})
+
+	t.Run("no diff and no host-collapse when the whole mixin is unchanged on three hosts", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Add a third embedding host to prove the per-host de-duplication does
+		// not accidentally drop legitimate distinct (table,name) pairs.
+		gen3 := &goschema.Database{
+			Tables: []goschema.Table{
+				{StructName: "Location", Name: "locations"},
+				{StructName: "Area", Name: "areas"},
+				{StructName: "Commodity", Name: "commodities"},
+			},
+			Fields: append([]goschema.Field{
+				{StructName: "Location", Name: "id", Type: "TEXT", Primary: true},
+				{StructName: "Area", Name: "id", Type: "TEXT", Primary: true},
+				{StructName: "Commodity", Name: "id", Type: "TEXT", Primary: true},
+			}, mixinFields...),
+			EmbeddedFields: []goschema.EmbeddedField{
+				{StructName: "Location", Mode: "inline", EmbeddedTypeName: "Ownable"},
+				{StructName: "Area", Mode: "inline", EmbeddedTypeName: "Ownable"},
+				{StructName: "Commodity", Mode: "inline", EmbeddedTypeName: "Ownable"},
+			},
+		}
+
+		hosts := []string{"locations", "areas", "commodities"}
+		var dbTables []types.DBTable
+		var dbConstraints []types.DBConstraint
+		for _, h := range hosts {
+			dbTables = append(dbTables, dbTable(h))
+			dbConstraints = append(dbConstraints,
+				dbFK("fk_entity_tenant", h, "tenant_id", "tenants", stringPtr("CASCADE")),
+				dbFK("fk_entity_created_by", h, "created_by_user_id", "users", stringPtr("NO ACTION")),
+			)
+		}
+
+		diff := &difftypes.SchemaDiff{}
+		compare.Constraints(gen3, &types.DBSchema{Tables: dbTables, Constraints: dbConstraints}, diff, nil)
+
+		c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("added=%v", diff.ConstraintsAdded))
+		c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("removed=%v", diff.ConstraintsRemoved))
+	})
+
+	t.Run("mixin column missing from DB on one host is not synthesized for that host", func(t *testing.T) {
+		c := qt.New(t)
+
+		// areas has not yet materialized the mixin columns (fresh table mid-add):
+		// its FKs ship inline with the column add, so they must NOT be
+		// synthesized here. locations is fully migrated and matches -> no-op.
+		database := &types.DBSchema{
+			Tables: []types.DBTable{
+				dbTable("locations"),
+				{Name: "areas", Columns: []types.DBColumn{{Name: "id"}}}, // mixin cols absent
+			},
+			Constraints: []types.DBConstraint{
+				dbFK("fk_entity_tenant", "locations", "tenant_id", "tenants", stringPtr("CASCADE")),
+				dbFK("fk_entity_created_by", "locations", "created_by_user_id", "users", stringPtr("NO ACTION")),
+			},
+		}
+
+		diff := &difftypes.SchemaDiff{}
+		compare.Constraints(generated, database, diff, nil)
+
+		c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("added=%v", diff.ConstraintsAdded))
+		c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("removed=%v", diff.ConstraintsRemoved))
+	})
+}
+
+// TestConstraints_FieldLevelForeignKeyOnDeleteNotStripped covers the
+// SYMPTOM 2 facet of issue #197 in isolation: a single-column field-level FK
+// whose ON DELETE is declared via the field annotation, with a matching live
+// DB action, must round-trip to a no-op — the synthesized constraint must carry
+// the field's OnDelete so foreignKeyConstraintChanged sees CASCADE == CASCADE
+// rather than reading the desired side as action-less (which would strip the
+// existing ON DELETE on every generate).
+func TestConstraints_FieldLevelForeignKeyOnDeleteNotStripped(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "AuditRow", Name: "audit_rows"}},
+		Fields: []goschema.Field{
+			{StructName: "AuditRow", Name: "id", Type: "TEXT", Primary: true},
+			{
+				StructName:     "AuditRow",
+				Name:           "migration_id",
+				Type:           "TEXT",
+				Foreign:        "migrations(id)",
+				ForeignKeyName: "fk_audit_migration",
+				OnDelete:       "CASCADE",
+			},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{Name: "audit_rows", Columns: []types.DBColumn{{Name: "id"}, {Name: "migration_id"}}},
+		},
+		Constraints: []types.DBConstraint{
+			{
+				Name:          "fk_audit_migration",
+				TableName:     "audit_rows",
+				Type:          "FOREIGN KEY",
+				ColumnName:    "migration_id",
+				ForeignTable:  stringPtr("migrations"),
+				ForeignColumn: stringPtr("id"),
+				DeleteRule:    stringPtr("CASCADE"),
+				UpdateRule:    stringPtr("NO ACTION"),
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.Constraints(generated, database, diff, nil)
+
+	c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("CASCADE must not be stripped, added=%v", diff.ConstraintsAdded))
+	c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("CASCADE must not be stripped, removed=%v", diff.ConstraintsRemoved))
+}

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -32,6 +32,42 @@ type ConstraintRemovalInfo struct {
 	Type string `json:"type"`
 }
 
+// ConstraintAdditionInfo contains the table-qualified definition of a
+// constraint that needs to be added, in parallel to the bare ConstraintsAdded
+// name list (mirroring ConstraintsRemovedWithTables).
+//
+// This exists because a field-level FOREIGN KEY whose constraint name repeats
+// across several tables cannot be resolved from the name alone. The canonical
+// case is an embedded inline-relation mixin: a shared base struct that carries
+// `foreign=` fields (e.g. tenant_id with foreign_key_name="fk_entity_tenant")
+// and is embedded into many concrete tables, so the same FK name legitimately
+// lands on every host table. The mixin's Go struct name is not a table, so a
+// planner that re-derives the table from the field's StructName emits
+// `ALTER TABLE <MixinStruct> ...` once per host, all collapsed onto the bogus
+// name (issue #197). Carrying the concrete table (and the full FK definition)
+// here lets the planner emit one correct ALTER TABLE per real host table.
+type ConstraintAdditionInfo struct {
+	// Name is the name of the constraint to be added.
+	Name string `json:"name"`
+
+	// TableName is the concrete database table the constraint is added to.
+	TableName string `json:"table_name"`
+
+	// Type is the constraint type (FOREIGN KEY, CHECK, UNIQUE, ...).
+	Type string `json:"type"`
+
+	// Columns are the local columns the constraint covers (FK source columns).
+	Columns []string `json:"columns,omitempty"`
+
+	// ForeignTable / ForeignColumn describe the FK target (FOREIGN KEY only).
+	ForeignTable  string `json:"foreign_table,omitempty"`
+	ForeignColumn string `json:"foreign_column,omitempty"`
+
+	// OnDelete / OnUpdate are the referential actions (FOREIGN KEY only).
+	OnDelete string `json:"on_delete,omitempty"`
+	OnUpdate string `json:"on_update,omitempty"`
+}
+
 // SchemaDiff represents comprehensive differences between two database schemas.
 //
 // This structure captures all types of schema changes that can occur between a target
@@ -156,6 +192,14 @@ type SchemaDiff struct {
 	// ConstraintsAdded contains names of constraints that exist in the target schema
 	// but not in the current database schema
 	ConstraintsAdded []string `json:"constraints_added"`
+
+	// ConstraintsAddedWithTables contains the table-qualified definitions of the
+	// constraints in ConstraintsAdded, in parallel (mirroring
+	// ConstraintsRemovedWithTables). Planners read this to add a field-level FK
+	// to its concrete host table rather than re-deriving the table from a Go
+	// struct name — which breaks for FK names shared across the many tables that
+	// embed an inline-relation mixin (issue #197).
+	ConstraintsAddedWithTables []ConstraintAdditionInfo `json:"constraints_added_with_tables"`
 
 	// ConstraintsRemoved contains names of constraints that exist in the current database
 	// but not in the target schema (potentially dangerous - may affect data integrity)


### PR DESCRIPTION
## Problem

The #189/#190 field-level FK drift synthesis produced broken migrations against model sets that use **embedded inline-relation mixins** — base structs embedded via `//migrator:embedded mode="inline"` that carry `foreign=` fields and are embedded into several concrete tables (e.g. a tenant/group-aware base struct contributing `tenant_id` / `group_id` / `created_by_user_id` FKs to every data table).

Two symptoms, both surfaced by bumping downstream `denisvmedia/inventario` to this ptah and running `generate-migration`:

1. **Mixin struct name emitted as a table, duplicated.** The synthesis iterated the raw `generated.Fields`, where the mixin's FK field keeps the *mixin* `StructName`. Resolving the table via `structToTable[f.StructName]` (with an `f.StructName` fallback) produced `ALTER TABLE TenantGroupAwareEntityID ADD CONSTRAINT fk_entity_created_by ...` — an invalid statement, emitted once per embedding host, all collapsed onto the same bogus name, re-ADD with no DROP and no `ON DELETE`.
2. **ON DELETE stripped on a field-annotated FK** — appeared to drop+re-add a `fk_currency_migration_audit_migration` without its `ON DELETE CASCADE`.

## Root cause

`goschema.ParseFS` does **not** pre-expand embedded fields. The mixin's FK field keeps `StructName=<MixinStruct>`; host-table expansion happens at consumption time via `processEmbeddedFieldsForStruct` (used by `compare.TableColumns` and `fromschema.FromDatabase`). **Three** sites independently iterated the raw field list and resolved the table via `structToTable[f.StructName]` with a struct-name fallback — so for a mixin field (whose struct is not a table) they all targeted the struct name:

1. comparator `synthesizeFieldLevelForeignKeyConstraints`
2. planner `fieldLevelForeignKeyConstraintNode` (postgres **and** mysql) — the ADD emission
3. generator `reverseConstraintRemovals` — the DOWN drop info

A complication: the bare `ConstraintsAdded` name list is **lossy** for a mixin FK whose name repeats across many tables (one name → N tables), so a name-keyed field scan cannot fan out to the right tables.

On symptom 2: the field-level vs table-level reconciliation **already** honors the field `on_delete`. A field-level FK whose `on_delete` matches the live action round-trips to a no-op (the synthesized constraint carries `f.OnDelete`, `foreignKeyConstraintChanged` sees the actions equal). The observed strip only occurs when the model **genuinely omits** `on_delete` while the database has `CASCADE` — which is real drift, not a bug. Verified e2e both with and without the annotation.

## Fix

**Symptom 1 (the three sites):**

- Comparator `synthesizeFieldLevelForeignKeyConstraints` now iterates a new `resolveTableFields` helper that expands embedded fields per host table (mirroring `TableColumns`) and tags each field with its concrete host table, plus a `(table, name)` de-dupe. Fields that belong to no real table are never synthesized.
- New parallel `SchemaDiff.ConstraintsAddedWithTables []ConstraintAdditionInfo` (mirrors `ConstraintsRemovedWithTables`) carries the concrete table + full FK definition. The postgres and mysql planners' `addNewConstraints` emit one correctly-targeted `ALTER TABLE <host>` per entry (`foreignKeyAdditionNode`) and record handled names so the legacy field-scan path skips them.
- Generator `reverseConstraintRemovals` and postgres `removeConstraints` prefer the table-qualified info, so the **down** migration drops each FK from its real host table (direct `ALTER TABLE <t> DROP CONSTRAINT IF EXISTS <name>` per host) instead of a name-only DO block that resolves a single table via `information_schema ... LIMIT 1`.

**Symptom 2:** no reconciliation change needed — an unchanged `CASCADE` already round-trips to a no-op once the model declares it. The fix to symptom 1 removes the diff corruption; the no-op behavior is covered by a dedicated test.

The single-column non-mixin path (e.g. `exports.file_id -> ON DELETE SET NULL`, #189) is unchanged — it flows through the same table-qualified path with exactly one entry.

## Tests

- `internal/compare/embedded_fk_constraints_test.go` — an inline mixin embedded into ≥2 tables: synthesis targets the real host tables (not the mixin), no duplication, no spurious strip on a same-named field+table FK, single-host action-change fan-out, three-host no-op, per-host column-presence gating; plus a focused `OnDeleteNotStripped` case.
- `embedded_fk_drift_test.go` — end-to-end through the postgres planner + renderer: the up adds one FK per real host table (never `ALTER TABLE <MixinStruct>`, no duplication), the down drops each from its real table, converged mixin FKs are a no-op.
- The existing #189 field-level FK action-drift scenarios stay green.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — green (33/33 packages).
- `golangci-lint run ./...` @ v2.12.2 — 0 issues.
- Full integration scenario matrix on postgres + mysql + mariadb — **180/180**; `TestMigrationGeneratorValidation` + dynamic scenarios green.
- **End-to-end downstream proof** (`denisvmedia/inventario` on the bumped ptah via a temporary `replace`): the generated UP/DOWN now contains **zero** `ALTER TABLE TenantGroupAwareEntityID/TenantUserAwareEntityID`, no duplicated `fk_entity_*` re-adds (each `fk_entity_*` adds/drops exactly once per **real** host table — `locations`, `areas`, `commodities`, `files`, `exports`, `restore_operations`, `restore_steps`, `user_mfa_secrets`), and the clean `ALTER TABLE exports ADD CONSTRAINT fk_export_file ... ON DELETE SET NULL` (DROP-then-ADD) is intact. With the model declaring `on_delete="CASCADE"` on the audit FK, `fk_currency_migration_audit_migration` is a clean no-op (no CASCADE drop in either direction). The downstream worktree was restored to its exact prior state and nothing was committed there.

Closes #197