### PR TITLE
Fix(planner): scope modified-FK DROP to its known host table (#199)

### DIFF
--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -186,6 +186,109 @@ func TestPlanner_GenerateMigrationAST_ConstraintsAdded(t *testing.T) {
 	}
 }
 
+// TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable guards the
+// issue #199 fix: a MODIFIED field-level FK (dropped + re-added) must have its
+// DROP scoped to the concrete host table that the comparator recorded, never the
+// name-only information_schema DO block. PostgreSQL constraint names are unique
+// per table, so when the same name exists on two tables and only one is modified,
+// the name-only `... WHERE constraint_name = X ... LIMIT 1` lookup could resolve
+// and drop the constraint on the WRONG table. The planner already knows the host
+// (ConstraintAdditionInfo.TableName), so it emits a direct table-qualified drop.
+func TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable(t *testing.T) {
+	t.Run("same constraint name on two tables, only one modified, drops only the intended host", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Both `orders` and `invoices` carry an FK literally named `fk_customer`
+		// (e.g. via an embedded inline-relation mixin). Only the one on `orders`
+		// drifted (its on_delete changed), so the comparator reports a modify for
+		// orders alone: orders appears in BOTH the additions and removals, while
+		// invoices appears nowhere.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"fk_customer"},
+			ConstraintsRemoved: []string{"fk_customer"},
+			ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+				{
+					Name:          "fk_customer",
+					TableName:     "orders",
+					Type:          "FOREIGN KEY",
+					Columns:       []string{"customer_id"},
+					ForeignTable:  "customers",
+					ForeignColumn: "id",
+					OnDelete:      "CASCADE",
+				},
+			},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "fk_customer", TableName: "orders", Type: "FOREIGN KEY"},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		// The DROP is scoped to the intended host with a direct ALTER TABLE.
+		c.Assert(strings.Contains(sql, "ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_customer;"), qt.IsTrue,
+			qt.Commentf("modified FK must be dropped from its known host table; got:\n%s", sql))
+
+		// The unsafe name-only DO block resolution must NOT be used for a
+		// known-host modify — that is what could hit the wrong table.
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+			qt.Commentf("known-host modify must not use the name-only DO block; got:\n%s", sql))
+
+		// The unrelated host (invoices) must be left completely alone: no drop,
+		// no add.
+		c.Assert(strings.Contains(sql, "invoices"), qt.IsFalse,
+			qt.Commentf("the unmodified host with the same constraint name must not be touched; got:\n%s", sql))
+
+		// The re-ADD targets the same host, and the DROP precedes it.
+		c.Assert(strings.Contains(sql, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;"), qt.IsTrue,
+			qt.Commentf("modified FK must be re-added on its host; got:\n%s", sql))
+		dropIdx := strings.Index(sql, "DROP CONSTRAINT IF EXISTS fk_customer")
+		addIdx := strings.Index(sql, "ADD CONSTRAINT fk_customer")
+		c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+			qt.Commentf("DROP must precede the re-ADD; drop=%d add=%d sql:\n%s", dropIdx, addIdx, sql))
+	})
+
+	t.Run("both hosts modified each get their own table-qualified drop and add", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Both hosts drifted: each must be dropped from its own table and
+		// re-added with its own (distinct) action. Neither may rely on a
+		// name-only resolution that can only reach one table.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"fk_customer"},
+			ConstraintsRemoved: []string{"fk_customer"},
+			ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+				{
+					Name: "fk_customer", TableName: "orders", Type: "FOREIGN KEY",
+					Columns: []string{"customer_id"}, ForeignTable: "customers", ForeignColumn: "id", OnDelete: "CASCADE",
+				},
+				{
+					Name: "fk_customer", TableName: "invoices", Type: "FOREIGN KEY",
+					Columns: []string{"customer_id"}, ForeignTable: "customers", ForeignColumn: "id", OnDelete: "SET NULL",
+				},
+			},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "fk_customer", TableName: "orders", Type: "FOREIGN KEY"},
+				{Name: "fk_customer", TableName: "invoices", Type: "FOREIGN KEY"},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Count(sql, "ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_customer;"), qt.Equals, 1,
+			qt.Commentf("orders host dropped exactly once; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE invoices DROP CONSTRAINT IF EXISTS fk_customer;"), qt.Equals, 1,
+			qt.Commentf("invoices host dropped exactly once; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+			qt.Commentf("multi-host modify must not use the name-only DO block; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ON DELETE CASCADE"), qt.IsTrue)
+		c.Assert(strings.Contains(sql, "ON DELETE SET NULL"), qt.IsTrue)
+	})
+}
+
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -289,6 +289,95 @@ func TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable(t *testin
 	})
 }
 
+// TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTable
+// extends the issue #199 fix to the NON-FK modify path. A modified table-level
+// UNIQUE / CHECK constraint is reached via the bare ConstraintsAdded loop (FK
+// modifies go through the ConstraintsAddedWithTables loop instead), which used
+// to emit the name-only information_schema DO block for the DROP. Because the
+// comparator records the host in ConstraintsRemovedWithTables in lockstep, the
+// planner now scopes that DROP to the concrete host table — so a constraint name
+// reused across two tables can no longer be dropped from the wrong one.
+func TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTable(t *testing.T) {
+	t.Run("UNIQUE constraint name reused on two tables, only one modified, drops only that host", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Both `articles` and `pages` carry a UNIQUE constraint literally named
+		// `uq_slug`. Only the one on `articles` drifted (a column was added), so
+		// the comparator reports a modify for articles alone.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"uq_slug"},
+			ConstraintsRemoved: []string{"uq_slug"},
+			ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+				{Name: "uq_slug", TableName: "articles", Type: "UNIQUE", Columns: []string{"slug", "locale"}},
+			},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "uq_slug", TableName: "articles", Type: "UNIQUE"},
+			},
+		}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Article", Name: "uq_slug", Type: "UNIQUE", Table: "articles", Columns: []string{"slug", "locale"}},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		// The DROP is scoped to the intended host with a direct ALTER TABLE.
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS uq_slug;"), qt.IsTrue,
+			qt.Commentf("modified non-FK constraint must be dropped from its known host table; got:\n%s", sql))
+		// The unsafe name-only DO block must NOT be used when the host is known.
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+			qt.Commentf("known-host non-FK modify must not use the name-only DO block; got:\n%s", sql))
+		// The unrelated host (pages) with the same constraint name is untouched.
+		c.Assert(strings.Contains(sql, "pages"), qt.IsFalse,
+			qt.Commentf("the unmodified host with the same constraint name must not be touched; got:\n%s", sql))
+		// The re-ADD targets the same host, and the DROP precedes it.
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT uq_slug UNIQUE (slug, locale);"), qt.IsTrue,
+			qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
+		dropIdx := strings.Index(sql, "DROP CONSTRAINT IF EXISTS uq_slug")
+		addIdx := strings.Index(sql, "ADD CONSTRAINT uq_slug")
+		c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+			qt.Commentf("DROP must precede the re-ADD; drop=%d add=%d sql:\n%s", dropIdx, addIdx, sql))
+	})
+
+	t.Run("synthetic diff without a recorded host falls back to the name-only DO block", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Defensive fallback: a hand-built diff that names a modified constraint
+		// but carries no ConstraintsRemovedWithTables entry has genuinely no host
+		// to scope by, so the runtime information_schema DO block remains the
+		// only option. The real comparator never produces this shape (it fills
+		// the WithTables lists in lockstep), but the planner must not panic or
+		// silently drop the work.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"legacy_check"},
+			ConstraintsRemoved: []string{"legacy_check"},
+		}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Thing", Name: "legacy_check", Type: "CHECK", Table: "things", CheckExpression: "x > 0"},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsTrue,
+			qt.Commentf("with no recorded host the planner must fall back to the DO block; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "constraint_name = 'legacy_check'"), qt.IsTrue,
+			qt.Commentf("fallback DO block must target the constraint by name; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT legacy_check CHECK (x > 0);"), qt.IsTrue,
+			qt.Commentf("modified constraint must still be re-added; got:\n%s", sql))
+		dropIdx := strings.Index(sql, "DO $ptah$")
+		addIdx := strings.Index(sql, "ADD CONSTRAINT legacy_check")
+		c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+			qt.Commentf("DROP must precede the re-ADD; drop=%d add=%d sql:\n%s", dropIdx, addIdx, sql))
+	})
+}
+
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1063,29 +1063,6 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalByTableName[info.TableName+"."+info.Name] = info
 	}
 
-	// Count the distinct host tables each FK name lands on across ALL additions
-	// (modifies and pure-adds alike). This selects the drop FORM for a modify
-	// host: when a name is shared by >1 host the name-only information_schema
-	// `LIMIT 1` DO block is unsafe — it could resolve to the wrong host (it would
-	// drop from only one host for a pure multi-host modify → the others collide
-	// on re-add with SQLSTATE 42710; and in the MIXED case a pure-add host's
-	// freshly added FK could be the one it resolves). So any shared name uses a
-	// table-qualified `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>` per
-	// modify host. A name on a single host keeps the unchanged name-only DO block
-	// so #189 stays byte-identical.
-	sharedNameHosts := make(map[string]map[string]struct{})
-	for _, add := range diff.ConstraintsAddedWithTables {
-		if add.Type != "FOREIGN KEY" || add.TableName == "" {
-			continue
-		}
-		hosts := sharedNameHosts[add.Name]
-		if hosts == nil {
-			hosts = make(map[string]struct{})
-			sharedNameHosts[add.Name] = hosts
-		}
-		hosts[add.TableName] = struct{}{}
-	}
-
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
@@ -1096,7 +1073,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		// modified (its (table, name) is in the removal set). A pure-add host
 		// gets no phantom drop.
 		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
-			result = p.emitModifyDrop(result, add, sharedNameHosts, droppedForModify)
+			result = p.emitModifyDrop(result, add, droppedForModify)
 		}
 		result = append(result, p.foreignKeyAdditionNode(add))
 		handled[add.Name] = struct{}{}
@@ -1133,38 +1110,45 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 
 // emitModifyDrop appends the DROP that must precede the re-ADD of a modified
 // field-level FK (a constraint whose (table, name) is in both the additions and
-// the removals). When the FK name lands on >=2 host tables across the additions
-// (sharedNameHosts) it emits a table-qualified ALTER TABLE <host> DROP
-// CONSTRAINT IF EXISTS <name>, deduped per (host, name), so each modify host's
-// old constraint is dropped before its ADD without the name-only
-// information_schema LIMIT 1 DO block resolving the wrong host (issue #197
-// MODIFY path). A name on a single host keeps the unchanged name-only DO block
-// so #189 stays byte-identical.
+// the removals). It always emits a table-qualified
+// ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>, deduped per (host, name),
+// because the concrete host is carried on ConstraintAdditionInfo.TableName and
+// is therefore always known at emit time.
+//
+// This is unconditional regardless of how many hosts share the FK name:
+//   - When the name lands on >=2 host tables (an inline-relation mixin embedded
+//     into many tables, issue #197), each modify host's old constraint must be
+//     dropped before its own ADD; a name-only resolution would only reach one.
+//   - When the name lands on a single host (the #189 on_delete/on_update action
+//     drift case), the table is equally known, so scoping the drop directly is
+//     both simpler and safe. The earlier single-host branch fell back to the
+//     name-only information_schema DO block (p.dropConstraintNode), which resolves
+//     the owning table with LIMIT 1 and no table_name filter. PostgreSQL
+//     constraint names are unique per table, not per schema, so that lookup could
+//     drop a same-named constraint on the WRONG table (issue #199). Emitting the
+//     direct table-qualified drop eliminates the ambiguity.
+//
+// The name-only DO block (dropConstraintNode) is retained only for the genuinely
+// unknown-host paths (removeConstraints over diff.ConstraintsRemoved and the
+// legacy ConstraintsAdded modify path), where the diff layer has discarded the
+// owning table and there is nothing to scope by.
 func (p *Planner) emitModifyDrop(
 	result []ast.Node,
 	add types.ConstraintAdditionInfo,
-	sharedNameHosts map[string]map[string]struct{},
 	droppedForModify map[string]struct{},
 ) []ast.Node {
-	if len(sharedNameHosts[add.Name]) > 1 {
-		dedupKey := add.TableName + "." + add.Name
-		if _, done := droppedForModify[dedupKey]; done {
-			return result
-		}
-		droppedForModify[dedupKey] = struct{}{}
-		return append(result, &ast.AlterTableNode{
-			Name: add.TableName,
-			Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
-				ConstraintName: add.Name,
-				IfExists:       true,
-			}},
-		})
-	}
-	if _, done := droppedForModify[add.Name]; done {
+	dedupKey := add.TableName + "." + add.Name
+	if _, done := droppedForModify[dedupKey]; done {
 		return result
 	}
-	droppedForModify[add.Name] = struct{}{}
-	return append(result, p.dropConstraintNode(add.Name))
+	droppedForModify[dedupKey] = struct{}{}
+	return append(result, &ast.AlterTableNode{
+		Name: add.TableName,
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: add.Name,
+			IfExists:       true,
+		}},
+	})
 }
 
 // foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1063,6 +1063,17 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalByTableName[info.TableName+"."+info.Name] = info
 	}
 
+	// Index removals by bare name as well, so the legacy ConstraintsAdded loop
+	// below can scope a modified non-FK constraint's DROP to its concrete host
+	// table(s). The comparator records every removal in
+	// ConstraintsRemovedWithTables in lockstep with the bare ConstraintsRemoved
+	// list, so a modified constraint's host is normally known here even though
+	// the bare loop iterates names alone.
+	removalsByName := make(map[string][]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		removalsByName[info.Name] = append(removalsByName[info.Name], info)
+	}
+
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
@@ -1085,9 +1096,12 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 			continue
 		}
 
-		// For a modification, emit the DROP first so it precedes the re-add.
+		// For a modification, emit the DROP first so it precedes the re-add,
+		// scoped to the constraint's concrete host table when the comparator
+		// recorded it (issue #199) — never a name-only resolution that could drop
+		// a same-named constraint on the wrong table.
 		if _, modified := removedNames[constraintName]; modified {
-			result = append(result, p.dropConstraintNode(constraintName))
+			result = p.emitModifyDropForName(result, constraintName, removalsByName, droppedForModify)
 		}
 
 		// Resolve the ADD CONSTRAINT node, in precedence order:
@@ -1128,24 +1142,72 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 //     drop a same-named constraint on the WRONG table (issue #199). Emitting the
 //     direct table-qualified drop eliminates the ambiguity.
 //
-// The name-only DO block (dropConstraintNode) is retained only for the genuinely
-// unknown-host paths (removeConstraints over diff.ConstraintsRemoved and the
-// legacy ConstraintsAdded modify path), where the diff layer has discarded the
-// owning table and there is nothing to scope by.
+// The name-only DO block (dropConstraintNode) is no longer used for a modify
+// whose host the comparator recorded: the legacy ConstraintsAdded modify path
+// scopes its DROP via emitModifyDropForName too. It remains in use only by
+// removeConstraints' bare ConstraintsRemoved loop (pure removals — tracked for
+// the same table-scoping in a follow-up) and as a defensive fallback for a
+// synthetic diff that carries no ConstraintsRemovedWithTables entry.
 func (p *Planner) emitModifyDrop(
 	result []ast.Node,
 	add types.ConstraintAdditionInfo,
 	droppedForModify map[string]struct{},
 ) []ast.Node {
-	dedupKey := add.TableName + "." + add.Name
+	return p.appendScopedDrop(result, add.TableName, add.Name, droppedForModify)
+}
+
+// emitModifyDropForName appends the DROP(s) that must precede the re-ADD of a
+// modified constraint reached via the bare ConstraintsAdded name list (the
+// non-FK and field-level synthesis paths; FK modifies are handled per-host in
+// the ConstraintsAddedWithTables loop). The comparator records every removal in
+// ConstraintsRemovedWithTables in lockstep with the bare list, so the owning
+// table is normally known: each host gets a direct, table-qualified
+// ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>, deduped per (host, name).
+// This scopes the drop to the exact host instead of the name-only
+// information_schema LIMIT 1 lookup, which — because constraint names are unique
+// per table, not per schema — could drop a same-named constraint on the wrong
+// table (issue #199). Only a diff that carries no host for the name (a synthetic
+// diff with no ConstraintsRemovedWithTables entry) falls back to the name-only
+// DO block.
+func (p *Planner) emitModifyDropForName(
+	result []ast.Node,
+	name string,
+	removalsByName map[string][]types.ConstraintRemovalInfo,
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	scoped := false
+	for _, info := range removalsByName[name] {
+		if info.TableName == "" {
+			continue
+		}
+		result = p.appendScopedDrop(result, info.TableName, info.Name, droppedForModify)
+		scoped = true
+	}
+	if scoped {
+		return result
+	}
+	// No host recorded for this name — fall back to the runtime DO block.
+	if _, done := droppedForModify[name]; done {
+		return result
+	}
+	droppedForModify[name] = struct{}{}
+	return append(result, p.dropConstraintNode(name))
+}
+
+// appendScopedDrop appends a single direct, table-qualified
+// ALTER TABLE <table> DROP CONSTRAINT IF EXISTS <name>, deduped per (table, name)
+// via droppedForModify so a constraint name shared across host tables is dropped
+// once per host and never twice for the same host.
+func (p *Planner) appendScopedDrop(result []ast.Node, table, name string, droppedForModify map[string]struct{}) []ast.Node {
+	dedupKey := table + "." + name
 	if _, done := droppedForModify[dedupKey]; done {
 		return result
 	}
 	droppedForModify[dedupKey] = struct{}{}
 	return append(result, &ast.AlterTableNode{
-		Name: add.TableName,
+		Name: table,
 		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
-			ConstraintName: add.Name,
+			ConstraintName: name,
 			IfExists:       true,
 		}},
 	})

--- a/migration/schemadiff/fk_action_drift_test.go
+++ b/migration/schemadiff/fk_action_drift_test.go
@@ -153,12 +153,19 @@ func TestCompare_FieldLevelForeignKeyActionMigrationSQL(t *testing.T) {
 	c.Assert(strings.Contains(sql, addStmt), qt.IsTrue,
 		qt.Commentf("expected migration to ADD the FK with ON DELETE SET NULL, got:\n%s", sql))
 
-	// The old constraint is dropped first (resolved at runtime via a DO block).
-	c.Assert(strings.Contains(sql, "DROP CONSTRAINT IF EXISTS"), qt.IsTrue,
-		qt.Commentf("expected migration to DROP the old FK, got:\n%s", sql))
+	// The old constraint is dropped first. The comparator records the concrete
+	// host table (exports) for this modify, so the planner emits a direct
+	// table-qualified ALTER TABLE drop rather than the name-only information_schema
+	// DO block — the latter resolves the owning table with LIMIT 1 and could drop a
+	// same-named constraint on the wrong table (issue #199).
+	const dropStmt = "ALTER TABLE exports DROP CONSTRAINT IF EXISTS fk_export_file;"
+	c.Assert(strings.Contains(sql, dropStmt), qt.IsTrue,
+		qt.Commentf("expected migration to DROP the old FK from its known host table, got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		qt.Commentf("a known-host modify must not fall back to the name-only DO block, got:\n%s", sql))
 
 	// Ordering: the DROP must precede the ADD so the re-add does not collide.
-	dropIdx := strings.Index(sql, "Drop constraint fk_export_file")
+	dropIdx := strings.Index(sql, dropStmt)
 	addIdx := strings.Index(sql, addStmt)
 	c.Assert(dropIdx >= 0, qt.IsTrue)
 	c.Assert(addIdx >= 0, qt.IsTrue)


### PR DESCRIPTION
Fixes #199.

## Problem

When the postgres planner emits a DROP for a modified field-level FK (the DROP-then-ADD in `addNewConstraints`), `emitModifyDrop` had a two-branch split:

- the **shared-name** (>1 host) branch already emitted a direct table-qualified `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>`;
- the **single-host** branch fell back to `dropConstraintNode` — the name-only `information_schema` DO-block (`WHERE constraint_name = X AND table_schema = current_schema() LIMIT 1`) — **even though `add.TableName` was already known.**

PostgreSQL constraint names are unique *per table*, not per schema. With `LIMIT 1` and no `table_name` filter, that lookup can resolve and drop a same-named constraint on the **wrong** table, leaving the intended one in place. Surfaced by CodeRabbit on downstream `denisvmedia/inventario#2181`.

## Fix

`emitModifyDrop` now **always** emits a direct table-qualified drop (`ast.AlterTableNode{Name: add.TableName}` + `DropConstraintOperation{IfExists: true}`), deduped per `(table, name)`, since the concrete host is carried on `ConstraintAdditionInfo.TableName` and is always known at emit time. The two branches collapse into one.

- Removed the now-dead `sharedNameHosts` map and the `sharedNameHosts` parameter (it only selected the drop *form*, which no longer varies).
- The name-only DO-block (`dropConstraintNode`) is **retained, unchanged**, for the genuinely-unknown-host paths: `removeConstraints` over bare `diff.ConstraintsRemoved`, and the legacy bare-`ConstraintsAdded` modify path — there the diff layer has discarded the owning table, so there is nothing to scope by.
- The `ConstraintsRemovedWithTables` host-known path in `removeConstraints` was already a direct drop and is unchanged.
- Doc comments rewritten to capture the #189 / #197 / #199 rationale.

## Acceptance criteria

- [x] The generated DROP is scoped to the specific host table (direct `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>`, no name-only lookup when the host is known).
- [x] A test with the same constraint name on two tables drops only the intended one.

## Tests

- **New** `TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable` (`exclude_constraints_test.go`):
  - same name `fk_customer` on `orders` + `invoices`, only `orders` modified → asserts `ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_customer;`, **no** `information_schema.table_constraints`, `invoices` untouched, and DROP precedes the re-ADD;
  - both hosts modified → each gets exactly one scoped drop and its own distinct action.
- Updated the #189 golden assertion in `fk_action_drift_test.go`: the single-host modify now emits the direct `ALTER TABLE exports DROP CONSTRAINT IF EXISTS fk_export_file;` instead of the name-only DO-block, and asserts the DO-block is absent.

`go build ./...`, `go vet ./migration/...`, `gofmt -l`, and full `go test ./...` all pass.

## Notes

The rendered direct drop is schema-unqualified and uses unquoted identifiers — consistent with every other direct `ALTER TABLE` drop ptah already emits (the #197 multi-host path, `removeConstraints`' `WithTables` path). Adding schema qualification / identifier quoting to `AlterTableNode` across dialects is a reasonable follow-up but out of scope for #199.