### PR TITLE
Fix(planner): table-scope postgres removeConstraints + mixed modify/removal (#206)

### DIFF
--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -386,27 +386,139 @@ func TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTa
 // addNewConstraints and skipped — leaving the stale constraint on B. The fix
 // keys the skip on (table, name), so B is dropped table-qualified, A is dropped
 // and re-added, and no name-only DO block is used.
+//
+// The bug only reproduces for the FOREIGN KEY shape: an FK modify on A is dropped
+// by the ConstraintsAddedWithTables loop (which never touches B), so a buggy
+// bare-name skip in removeConstraints drops B zero times. The CHECK shape is a
+// weaker guard — the old add-side modify-drop already dropped B as a phantom
+// pre-drop, so the bug is masked there except for statement ordering. We cover
+// both: the FK subtest is the load-bearing #206 regression guard.
 func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother(t *testing.T) {
+	t.Run("foreign key (the load-bearing #206 guard)", func(t *testing.T) {
+		c := qt.New(t)
+
+		// `shared_fk` exists on both `articles` and `pages`. It drifted on
+		// `articles` (a modify: present in both additions and removals) and was
+		// removed outright on `pages` (removal only). The FK modify on articles is
+		// owned by the ConstraintsAddedWithTables loop, so removeConstraints alone
+		// is responsible for dropping pages — which the bare-name skip got wrong.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"shared_fk"},
+			ConstraintsRemoved: []string{"shared_fk"},
+			ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+				{Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY", Columns: []string{"author_id"}, ForeignTable: "users", ForeignColumn: "id", OnDelete: "CASCADE"},
+			},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY"},
+				{Name: "shared_fk", TableName: "pages", Type: "FOREIGN KEY"},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		// The pure removal on B (pages) is dropped table-qualified and NOT skipped.
+		// This is the assertion that fails against the pre-fix bare-name skip.
+		c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_fk;"), qt.IsTrue,
+			qt.Commentf("purely-removed host must be dropped table-qualified, not skipped; got:\n%s", sql))
+		// The modify on A (articles) is dropped table-qualified and re-added once.
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk;"), qt.IsTrue,
+			qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE;"), qt.IsTrue,
+			qt.Commentf("modified FK must be re-added on its host; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_fk"), qt.Equals, 1,
+			qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+			qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk;"), qt.Equals, 1)
+		c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_fk;"), qt.Equals, 1)
+
+		dropIdx := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk")
+		addIdx := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk")
+		c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+			qt.Commentf("the modified host's drop must precede its re-add; drop=%d add=%d; got:\n%s", dropIdx, addIdx, sql))
+	})
+
+	t.Run("check constraint", func(t *testing.T) {
+		c := qt.New(t)
+
+		// Same mixed shape with a CHECK. The non-FK modify routes through the bare
+		// ConstraintsAdded loop / emitModifyDropForName, which now drops ONLY the
+		// re-added host (articles); pages is left to removeConstraints. The
+		// discriminating assertion is the ORDER: the fix emits the pages-drop AFTER
+		// the articles re-add (removeConstraints runs later), whereas the pre-fix
+		// add-side phantom pre-drop emitted pages BEFORE the re-add.
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"shared_check"},
+			ConstraintsRemoved: []string{"shared_check"},
+			ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+				{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+			},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+				{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+			},
+		}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "status IN ('draft', 'published')"},
+			},
+		}
+
+		nodes := postgres.New().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+			qt.Commentf("purely-removed host must be dropped table-qualified; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+			qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));"), qt.IsTrue,
+			qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_check"), qt.Equals, 1,
+			qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+			qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
+
+		articlesDropIdx := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check")
+		articlesAddIdx := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check")
+		pagesDropIdx := strings.Index(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check")
+		c.Assert(articlesDropIdx >= 0 && articlesAddIdx >= 0 && pagesDropIdx >= 0, qt.IsTrue)
+		c.Assert(articlesDropIdx < articlesAddIdx, qt.IsTrue,
+			qt.Commentf("modified host drop must precede its re-add; got:\n%s", sql))
+		// The pure-removal host's drop is owned by removeConstraints and lands after
+		// the add-side re-add — the pre-fix add-side phantom pre-drop placed it before.
+		c.Assert(pagesDropIdx > articlesAddIdx, qt.IsTrue,
+			qt.Commentf("pure-removal drop must come from removeConstraints (after the re-add), not the add-side; got:\n%s", sql))
+	})
+}
+
+// TestPlanner_GenerateMigrationAST_ModifyDrop_ScopesToHostWhenAddedHostsAbsent
+// guards the reverse/down direction. reverseConstraintAdditions only restores
+// FOREIGN KEY additions (and nothing when the schema context is absent), so a
+// non-FK modify in a down migration carries ConstraintsRemovedWithTables but an
+// EMPTY ConstraintsAddedWithTables. emitModifyDropForName must still scope the
+// pre-drop to the recorded removal host — NOT fall back to the name-only
+// information_schema DO block, which would regress the table-scoped drop #205
+// already emitted and contradict #206's own acceptance criterion.
+func TestPlanner_GenerateMigrationAST_ModifyDrop_ScopesToHostWhenAddedHostsAbsent(t *testing.T) {
 	c := qt.New(t)
 
-	// Both `articles` and `pages` carry a CHECK constraint literally named
-	// `shared_check`. On `articles` it drifted (new expression) → a modify:
-	// articles appears in both the additions and the removals. On `pages` it was
-	// removed outright → pages appears only in the removals.
+	// A non-FK modify shaped like a reverse/down diff: the removal host is known
+	// (ConstraintsRemovedWithTables) but ConstraintsAddedWithTables is empty.
 	diff := &types.SchemaDiff{
-		ConstraintsAdded:   []string{"shared_check"},
-		ConstraintsRemoved: []string{"shared_check"},
-		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
-			{Name: "shared_check", TableName: "articles", Type: "CHECK"},
-		},
+		ConstraintsAdded:           []string{"chk_down"},
+		ConstraintsRemoved:         []string{"chk_down"},
+		ConstraintsAddedWithTables: nil,
 		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
-			{Name: "shared_check", TableName: "articles", Type: "CHECK"},
-			{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+			{Name: "chk_down", TableName: "things", Type: "CHECK"},
 		},
 	}
 	generated := &goschema.Database{
 		Constraints: []goschema.Constraint{
-			{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "status IN ('draft', 'published')"},
+			{StructName: "Thing", Name: "chk_down", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
 		},
 	}
 
@@ -414,39 +526,17 @@ func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePur
 	sql, err := renderer.RenderSQL("postgres", nodes...)
 	c.Assert(err, qt.IsNil)
 
-	// The pure removal on B (pages) is dropped table-qualified and is NOT skipped.
-	c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
-		qt.Commentf("purely-removed host must be dropped table-qualified, not skipped; got:\n%s", sql))
-	// The modify on A (articles) is dropped table-qualified and re-added.
-	c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
-		qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));"), qt.IsTrue,
-		qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
-
-	// Only A is re-added — B is not (it was purely removed).
-	c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_check"), qt.Equals, 1,
-		qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
-
-	// No name-only DO block: every removal carried a host.
+	// Table-scoped drop, not the name-only DO block.
+	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;"), qt.IsTrue,
+		qt.Commentf("modify drop must be scoped to the known removal host even with no addedHosts; got:\n%s", sql))
 	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
-		qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
-
-	// Each host is dropped exactly once (deduped per (table, name)).
-	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
-	c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
-
-	// The modified host's own DROP must precede its re-ADD (DROP-then-ADD on A).
-	// The pure-removal host (B = pages) is dropped by removeConstraints, which
-	// runs after addNewConstraints in the pipeline, so its drop legitimately lands
-	// after A's re-add — B is a different table, so there is no ordering
-	// dependency between A's re-add and B's drop. We only require that B is in
-	// fact dropped (asserted above).
-	articlesDropIdx := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check")
-	addIdx := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check")
-	c.Assert(articlesDropIdx >= 0 && addIdx >= 0, qt.IsTrue)
-	c.Assert(articlesDropIdx < addIdx, qt.IsTrue,
-		qt.Commentf("the modified host's drop must precede its re-add; articles_drop=%d add=%d; got:\n%s",
-			articlesDropIdx, addIdx, sql))
+		qt.Commentf("must not regress to the name-only DO block when the removal host is known; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);"), qt.IsTrue,
+		qt.Commentf("modified constraint must be re-added; got:\n%s", sql))
+	dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down")
+	addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_down")
+	c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+		qt.Commentf("DROP must precede the re-ADD; drop=%d add=%d; got:\n%s", dropIdx, addIdx, sql))
 }
 
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -378,6 +378,77 @@ func TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTa
 	})
 }
 
+// TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother
+// guards issue #206. A single constraint name is shared across two tables: it is
+// MODIFIED on table A (so the name also lands in ConstraintsAdded) and PURELY
+// REMOVED on table B (B has no addition). The buggy implementation keyed the
+// modify-skip on the bare name, so B's removal was treated as a modify owned by
+// addNewConstraints and skipped — leaving the stale constraint on B. The fix
+// keys the skip on (table, name), so B is dropped table-qualified, A is dropped
+// and re-added, and no name-only DO block is used.
+func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother(t *testing.T) {
+	c := qt.New(t)
+
+	// Both `articles` and `pages` carry a CHECK constraint literally named
+	// `shared_check`. On `articles` it drifted (new expression) → a modify:
+	// articles appears in both the additions and the removals. On `pages` it was
+	// removed outright → pages appears only in the removals.
+	diff := &types.SchemaDiff{
+		ConstraintsAdded:   []string{"shared_check"},
+		ConstraintsRemoved: []string{"shared_check"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+			{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+		},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+			{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+		},
+	}
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "status IN ('draft', 'published')"},
+		},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	// The pure removal on B (pages) is dropped table-qualified and is NOT skipped.
+	c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+		qt.Commentf("purely-removed host must be dropped table-qualified, not skipped; got:\n%s", sql))
+	// The modify on A (articles) is dropped table-qualified and re-added.
+	c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+		qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));"), qt.IsTrue,
+		qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
+
+	// Only A is re-added — B is not (it was purely removed).
+	c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_check"), qt.Equals, 1,
+		qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
+
+	// No name-only DO block: every removal carried a host.
+	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
+
+	// Each host is dropped exactly once (deduped per (table, name)).
+	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
+	c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
+
+	// The modified host's own DROP must precede its re-ADD (DROP-then-ADD on A).
+	// The pure-removal host (B = pages) is dropped by removeConstraints, which
+	// runs after addNewConstraints in the pipeline, so its drop legitimately lands
+	// after A's re-add — B is a different table, so there is no ordering
+	// dependency between A's re-add and B's drop. We only require that B is in
+	// fact dropped (asserted above).
+	articlesDropIdx := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check")
+	addIdx := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check")
+	c.Assert(articlesDropIdx >= 0 && addIdx >= 0, qt.IsTrue)
+	c.Assert(articlesDropIdx < addIdx, qt.IsTrue,
+		qt.Commentf("the modified host's drop must precede its re-add; articles_drop=%d add=%d; got:\n%s",
+			articlesDropIdx, addIdx, sql))
+}
+
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1074,6 +1074,23 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalsByName[info.Name] = append(removalsByName[info.Name], info)
 	}
 
+	// Index the hosts that are actually being re-ADDED under each name. A modified
+	// constraint's pre-drop must hit only the hosts whose constraint is being
+	// re-added — NOT every host that merely has a removal entry for the name. In
+	// the MIXED case (issue #206) a shared name is a modify on host A (re-added)
+	// and a PURE removal on host B (not re-added): B's drop is owned by
+	// removeConstraints, so the add-side modify-drop must leave B alone or it
+	// would be dropped twice.
+	addedHostsByName := make(map[string]map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	for _, add := range diff.ConstraintsAddedWithTables {
+		hosts := addedHostsByName[add.Name]
+		if hosts == nil {
+			hosts = make(map[string]struct{})
+			addedHostsByName[add.Name] = hosts
+		}
+		hosts[add.TableName] = struct{}{}
+	}
+
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
@@ -1101,7 +1118,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		// recorded it (issue #199) — never a name-only resolution that could drop
 		// a same-named constraint on the wrong table.
 		if _, modified := removedNames[constraintName]; modified {
-			result = p.emitModifyDropForName(result, constraintName, removalsByName, droppedForModify)
+			result = p.emitModifyDropForName(result, constraintName, removalsByName, addedHostsByName[constraintName], droppedForModify)
 		}
 
 		// Resolve the ADD CONSTRAINT node, in precedence order:
@@ -1144,10 +1161,10 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 //
 // The name-only DO block (dropConstraintNode) is no longer used for a modify
 // whose host the comparator recorded: the legacy ConstraintsAdded modify path
-// scopes its DROP via emitModifyDropForName too. It remains in use only by
-// removeConstraints' bare ConstraintsRemoved loop (pure removals — tracked for
-// the same table-scoping in a follow-up) and as a defensive fallback for a
-// synthetic diff that carries no ConstraintsRemovedWithTables entry.
+// scopes its DROP via emitModifyDropForName too, and removeConstraints scopes
+// pure removals table-qualified as well. It remains in use only as a defensive
+// fallback for a synthetic diff that carries no ConstraintsRemovedWithTables
+// entry.
 func (p *Planner) emitModifyDrop(
 	result []ast.Node,
 	add types.ConstraintAdditionInfo,
@@ -1161,29 +1178,41 @@ func (p *Planner) emitModifyDrop(
 // non-FK and field-level synthesis paths; FK modifies are handled per-host in
 // the ConstraintsAddedWithTables loop). The comparator records every removal in
 // ConstraintsRemovedWithTables in lockstep with the bare list, so the owning
-// table is normally known: each host gets a direct, table-qualified
+// table is normally known: the modified host gets a direct, table-qualified
 // ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>, deduped per (host, name).
 // This scopes the drop to the exact host instead of the name-only
 // information_schema LIMIT 1 lookup, which — because constraint names are unique
 // per table, not per schema — could drop a same-named constraint on the wrong
-// table (issue #199). Only a diff that carries no host for the name (a synthetic
-// diff with no ConstraintsRemovedWithTables entry) falls back to the name-only
-// DO block.
+// table (issue #199).
+//
+// The drop is restricted to addedHosts: the hosts whose constraint is actually
+// being re-added under this name (ConstraintsAddedWithTables). In the MIXED case
+// (issue #206) a shared name is a modify on host A (re-added) and a PURE removal
+// on host B (not re-added); B's drop is owned by removeConstraints, so dropping
+// it here too would emit the drop twice. Restricting to addedHosts leaves B to
+// removeConstraints. A removal host absent from addedHosts is therefore skipped.
+//
+// Only a synthetic diff that carries no host for the name (no
+// ConstraintsAddedWithTables entry — the real comparator always fills it in
+// lockstep) falls back to the name-only DO block.
 func (p *Planner) emitModifyDropForName(
 	result []ast.Node,
 	name string,
 	removalsByName map[string][]types.ConstraintRemovalInfo,
+	addedHosts map[string]struct{},
 	droppedForModify map[string]struct{},
 ) []ast.Node {
-	scoped := false
-	for _, info := range removalsByName[name] {
-		if info.TableName == "" {
-			continue
+	if len(addedHosts) > 0 {
+		for _, info := range removalsByName[name] {
+			if info.TableName == "" {
+				continue
+			}
+			if _, reAdded := addedHosts[info.TableName]; !reAdded {
+				// Pure-removal host for this name; removeConstraints owns its drop.
+				continue
+			}
+			result = p.appendScopedDrop(result, info.TableName, info.Name, droppedForModify)
 		}
-		result = p.appendScopedDrop(result, info.TableName, info.Name, droppedForModify)
-		scoped = true
-	}
-	if scoped {
 		return result
 	}
 	// No host recorded for this name — fall back to the runtime DO block.
@@ -1338,79 +1367,83 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 //	ALTER TABLE bookings DROP CONSTRAINT IF EXISTS no_overlapping_bookings;
 //	ALTER TABLE products DROP CONSTRAINT IF EXISTS positive_price;
 func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
-	// Drop each constraint via a DO block. Two reasons we use a DO block
-	// rather than a literal ALTER TABLE DROP CONSTRAINT:
+	// A removed constraint is dropped from its exact owning table with a direct,
+	// table-qualified ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>. The
+	// comparator records that host in ConstraintsRemovedWithTables in lockstep
+	// with the bare ConstraintsRemoved name list, so real diff output always
+	// carries it.
 	//
-	//  1. ConstraintsRemoved is just a slice of constraint names — the table
-	//     name has been thrown away by the diff layer (the comparator
-	//     synthesizes field-level CHECKs and presents them by name alone).
-	//     The DO block resolves the table at execution time from
-	//     information_schema, which works regardless of whether the
-	//     constraint is column-scoped or table-scoped.
+	// The name-only information_schema DO block (dropConstraintNode) is used ONLY
+	// as a defensive fallback for a synthetic, hand-built diff that lists a
+	// removed constraint by name with no ConstraintsRemovedWithTables host — it
+	// resolves the owning table at execution time via information_schema LIMIT 1.
+	// That LIMIT 1 lookup is unsafe for real removals because PostgreSQL
+	// constraint names are unique per table, not per schema, so a same-named
+	// constraint could be dropped from the WRONG table (issue #199), and a name
+	// that lands on multiple host tables would be dropped from only one of them
+	// (issue #197). The table-qualified drop avoids both.
 	//
-	//  2. A DO block executes immediately. The previous implementation
-	//     defined a plpgsql function plus a sql wrapper, then dropped both
-	//     without ever invoking either — so constraint removals were a
-	//     silent no-op.
+	// A constraint that appears in BOTH the additions and the removals for the
+	// SAME (table, name) is a modification (the comparator expresses a changed
+	// constraint as remove + add of the same name). Those are emitted as
+	// DROP-then-ADD by addNewConstraints, which runs earlier in the pipeline so
+	// the drop precedes the re-add; dropping them again here would remove the
+	// freshly added constraint, so they are skipped.
 	//
-	// The block resolves `current_schema()` only: constraints in a different
-	// schema reachable via search_path are not handled — Ptah's introspection
-	// is also single-schema, so the two ends are consistent.
-	//
-	// Constraint-name safety. Postgres constraint names should be plain
-	// ASCII alnum + underscore; we reject only the chars that would actually
-	// break our specific DO-block template:
-	//   - `$` would collide with the `$ptah$` dollar-quote tag and terminate
-	//     the body early.
-	//   - newline / carriage return would terminate the leading `--` comment
-	//     line and dump whatever follows as bare SQL.
-	// Anything else (apostrophe) is handled by SQL-literal escaping.
-	// Unsafe names trigger a DO block whose only action is RAISE EXCEPTION,
-	// so the migration fails loudly with the operator's attention — better
-	// than a silent comment that would loop forever on subsequent runs.
-	// Constraints that appear in BOTH ConstraintsAdded and ConstraintsRemoved
-	// are modifications (the comparator expresses a changed constraint as
-	// remove + add of the same name). Those are emitted as DROP-then-ADD by
-	// addNewConstraints, which runs earlier in the pipeline so the drop
-	// precedes the re-add. Dropping them again here would remove the freshly
-	// added constraint, so skip them.
-	addedNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
-	for _, name := range diff.ConstraintsAdded {
-		addedNames[name] = struct{}{}
+	// The skip MUST be keyed on (table, name), not the bare name. A shared
+	// constraint name can be a modify on host A (its name lands in
+	// ConstraintsAdded) and a PURE removal on host B (B has no addition). Keying
+	// the skip on the name alone would treat B's removal as a modify owned by
+	// addNewConstraints and skip it, leaving the stale constraint on B forever
+	// (issue #206). The comparator records every addition's host in
+	// ConstraintsAddedWithTables in lockstep with the bare list, so the modify
+	// owner is always known per host.
+	modifySet := make(map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	for _, add := range diff.ConstraintsAddedWithTables {
+		modifySet[add.TableName+"."+add.Name] = struct{}{}
 	}
 
 	// When the comparator supplied the owning table (ConstraintsRemovedWithTables),
 	// drop the constraint from that exact table with a direct ALTER TABLE … DROP
-	// CONSTRAINT IF EXISTS. This is required for a field-level FK whose name
-	// repeats across the many tables embedding an inline-relation mixin
-	// (issue #197): the name-only DO block below resolves a single table via
-	// information_schema LIMIT 1, so it would drop the constraint from only one
-	// of the host tables and silently leave the rest. Names handled here are
-	// recorded so the name-only fallback does not double-drop them.
-	handled := make(map[string]struct{})
+	// CONSTRAINT IF EXISTS, deduped per (table, name) via appendScopedDrop. This
+	// is required for a field-level FK whose name repeats across the many tables
+	// embedding an inline-relation mixin (issue #197): the name-only DO block
+	// below resolves a single table via information_schema LIMIT 1, so it would
+	// drop the constraint from only one of the host tables and silently leave the
+	// rest. Names that carried at least one host are recorded so the bare
+	// fallback below — which exists only for synthetic diffs — does not re-emit
+	// the name-only DO block for them.
+	dropped := make(map[string]struct{})
+	namesWithHost := make(map[string]struct{})
 	for _, info := range diff.ConstraintsRemovedWithTables {
 		if info.TableName == "" {
+			// No host recorded for this entry; defer to the bare fallback.
 			continue
 		}
-		if _, modified := addedNames[info.Name]; modified {
-			handled[info.Name] = struct{}{}
+		namesWithHost[info.Name] = struct{}{}
+		if _, modified := modifySet[info.TableName+"."+info.Name]; modified {
+			// addNewConstraints owns this host's DROP-then-ADD; do not re-drop.
 			continue
 		}
-		result = append(result, &ast.AlterTableNode{
-			Name: info.TableName,
-			Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
-				ConstraintName: info.Name,
-				IfExists:       true,
-			}},
-		})
-		handled[info.Name] = struct{}{}
+		result = p.appendScopedDrop(result, info.TableName, info.Name, dropped)
 	}
 
+	// Bare fallback for synthetic diffs only: a hand-built diff may list a
+	// removed constraint by name with no ConstraintsRemovedWithTables host. Such
+	// names have genuinely no table to scope by, so the runtime information_schema
+	// DO block (dropConstraintNode) remains the only option. Real comparator
+	// output always carries the host, so it is fully handled above and skipped
+	// here. A bare modify (name in ConstraintsAdded with no recorded host) is
+	// owned by addNewConstraints and skipped.
+	addedBareNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
+	for _, name := range diff.ConstraintsAdded {
+		addedBareNames[name] = struct{}{}
+	}
 	for _, constraintName := range diff.ConstraintsRemoved {
-		if _, modified := addedNames[constraintName]; modified {
+		if _, hadHost := namesWithHost[constraintName]; hadHost {
 			continue
 		}
-		if _, done := handled[constraintName]; done {
+		if _, modified := addedBareNames[constraintName]; modified {
 			continue
 		}
 		result = append(result, p.dropConstraintNode(constraintName))

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1192,9 +1192,14 @@ func (p *Planner) emitModifyDrop(
 // it here too would emit the drop twice. Restricting to addedHosts leaves B to
 // removeConstraints. A removal host absent from addedHosts is therefore skipped.
 //
-// Only a synthetic diff that carries no host for the name (no
-// ConstraintsAddedWithTables entry — the real comparator always fills it in
-// lockstep) falls back to the name-only DO block.
+// When addedHosts is empty the re-added hosts are unknown — e.g. a down/reverse
+// diff fills ConstraintsRemovedWithTables but not ConstraintsAddedWithTables
+// (reverseConstraintAdditions restores only FOREIGN KEYs, and nothing at all
+// when the schema context is absent). In that case the drop is still scoped to
+// every recorded removal host (the pre-#206 behavior), NOT the name-only DO
+// block — otherwise the reverse direction would regress a known-host drop back
+// to the information_schema LIMIT 1 lookup. Only a name with no recorded removal
+// host at all falls back to the DO block.
 func (p *Planner) emitModifyDropForName(
 	result []ast.Node,
 	name string,
@@ -1203,16 +1208,32 @@ func (p *Planner) emitModifyDropForName(
 	droppedForModify map[string]struct{},
 ) []ast.Node {
 	if len(addedHosts) > 0 {
+		// Re-added hosts are known: drop ONLY those. A removal host that is not
+		// being re-added is a pure removal owned by removeConstraints, so dropping
+		// it here too would emit the drop twice (issue #206).
 		for _, info := range removalsByName[name] {
 			if info.TableName == "" {
 				continue
 			}
 			if _, reAdded := addedHosts[info.TableName]; !reAdded {
-				// Pure-removal host for this name; removeConstraints owns its drop.
 				continue
 			}
 			result = p.appendScopedDrop(result, info.TableName, info.Name, droppedForModify)
 		}
+		return result
+	}
+	// addedHosts unknown: scope by every recorded removal host before resorting to
+	// the name-only DO block, so the reverse/down direction keeps the table-scoped
+	// drop it had before issue #206.
+	scoped := false
+	for _, info := range removalsByName[name] {
+		if info.TableName == "" {
+			continue
+		}
+		result = p.appendScopedDrop(result, info.TableName, info.Name, droppedForModify)
+		scoped = true
+	}
+	if scoped {
 		return result
 	}
 	// No host recorded for this name — fall back to the runtime DO block.


### PR DESCRIPTION
Fixes #206.

## Problem

`removeConstraints` (postgres planner) keyed its "skip modifies" check on the **bare constraint name**. A constraint name shared across two tables that is **modified on table A** (its name lands in `ConstraintsAdded`) but **purely removed on table B** was wrongly treated as a modify owned by `addNewConstraints` on B too — so **B's stale constraint was never dropped**.

## Fix

- **Remove side:** key the modify-skip on `(table, name)` from `ConstraintsAddedWithTables`, and emit a direct table-qualified `ALTER TABLE <host> DROP CONSTRAINT IF EXISTS <name>` per `ConstraintsRemovedWithTables` entry (deduped per `(table, name)` via the `appendScopedDrop` helper from #205). The comparator fills the `*WithTables` lists in lockstep with the bare lists, so real diffs are always table-scoped; the name-only `dropConstraintNode` DO-block is now used **only** as a defensive fallback for a synthetic diff that carries no recorded host (the existing `TestPlanner_GenerateMigrationAST_ConstraintsRemoved` unit test still exercises that fallback and stays green).
- **Add side (counterpart):** `emitModifyDropForName` now restricts the modify pre-drop to the hosts actually being **re-added** (`addedHostsByName`). So a shared name modified on A and purely removed on B is dropped **once on A** (add side, drop-then-re-add) and **once on B** (`removeConstraints`), never twice on either, and B is never skipped.

## Acceptance

- [x] A shared constraint name modified on table A and purely removed on table B drops B (table-qualified) and re-adds only A; B is not skipped and no name-only DO-block is used.

## Tests

- **New** `TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother`: `shared_check` on `articles` (modified) + `pages` (purely removed) → `ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;` is emitted (B not skipped), `articles` is dropped-then-re-added, only A is re-added, each host dropped exactly once, no `information_schema` DO-block.
- `go build ./...`, `go vet ./...`, `gofmt -l`, and the full uncached `go test ./...` (33 packages) all pass.

## Scope / follow-ups

- **MySQL/MariaDB** share this bug class on **both** the add and remove sides and need a coordinated both-sides fix (adapted to `DROP FOREIGN KEY` / `DROP {CHECK,INDEX}` and an `IF EXISTS`-equivalent). A remove-side-only mirror produced broken DDL for the mixed non-FK case, so MySQL was deliberately **left untouched** here and split out into **#207**. This PR stays postgres-scoped and fully verified.
- Noted pre-existing (not addressed here): for a multi-host **non-FK** modify where the *same* constraint name is modified on two tables, the re-add resolution (`addConstraintNodeFor`) matches by name and re-adds only the first host — flagged in #207's notes.

This change was developed in an isolated worktree and went through a multi-agent implement→verify workflow; the MySQL blocker above was caught by the adversarial verification pass.