### PR TITLE
Fix(planner): scope MySQL/MariaDB constraint drops to their (table,name) hosts (#207)

### DIFF
--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -1,0 +1,493 @@
+package mysql_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// mysqlFamilyDialects renders the same planner output through both renderers
+// that consume the MySQL planner (GetPlanner maps mysql AND mariadb to it), so
+// every scenario is asserted for the full MySQL family.
+var mysqlFamilyDialects = []string{"mysql", "mariadb"}
+
+// renderMySQLFamily generates the migration AST once per invocation and
+// renders it with the given dialect.
+func renderMySQLFamily(c *qt.C, dialect string, diff *types.SchemaDiff, generated *goschema.Database) string {
+	nodes := mysql.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL(dialect, nodes...)
+	c.Assert(err, qt.IsNil)
+	return sql
+}
+
+// TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother
+// guards issue #207 — the MySQL-family sibling of the postgres issue #206. A
+// single constraint name is shared across two tables: it is MODIFIED on table
+// A (the name lands in ConstraintsAdded) and PURELY REMOVED on table B (B has
+// no addition).
+//
+// The buggy implementation failed on BOTH sides:
+//   - add side: the modify pre-drop resolved its host via a name-keyed
+//     single-winner map (last removal entry wins), so with two removal hosts it
+//     could drop B (the wrong, pure-removal host) and leave A's stale
+//     constraint in place — A's re-ADD then collides (errno 1826/3822);
+//   - remove side: the modify-skip was keyed on the bare name, so B's pure
+//     removal was treated as "owned by addNewConstraints" and skipped — B's
+//     stale constraint would survive forever.
+//
+// The fix keys both sides on (table, name): A is dropped-then-re-added by the
+// add side, B is dropped exactly once by removeConstraints, and no statement
+// needs the (MySQL-unsupported) IF EXISTS guard. Removal-entry order must not
+// matter, so every subtest runs with both orderings.
+func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother(t *testing.T) {
+	t.Run("foreign key", func(t *testing.T) {
+		orderings := map[string][]types.ConstraintRemovalInfo{
+			"modified host listed first": {
+				{Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY"},
+				{Name: "shared_fk", TableName: "pages", Type: "FOREIGN KEY"},
+			},
+			"purely-removed host listed first": {
+				{Name: "shared_fk", TableName: "pages", Type: "FOREIGN KEY"},
+				{Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY"},
+			},
+		}
+		for orderName, removals := range orderings {
+			for _, dialect := range mysqlFamilyDialects {
+				t.Run(dialect+"/"+orderName, func(t *testing.T) {
+					c := qt.New(t)
+
+					diff := &types.SchemaDiff{
+						ConstraintsAdded:   []string{"shared_fk"},
+						ConstraintsRemoved: []string{"shared_fk"},
+						ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+							{
+								Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY",
+								Columns: []string{"author_id"}, ForeignTable: "users", ForeignColumn: "id", OnDelete: "CASCADE",
+							},
+						},
+						ConstraintsRemovedWithTables: removals,
+					}
+
+					sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+					// The modified host is dropped exactly once with FK syntax and
+					// re-added exactly once, drop before add.
+					c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk;"), qt.Equals, 1,
+						qt.Commentf("modified host must be dropped exactly once from its own table; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE;"), qt.Equals, 1,
+						qt.Commentf("modified FK must be re-added on its host; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_fk"), qt.Equals, 1,
+						qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
+
+					// The purely-removed host is dropped exactly once and never
+					// re-added. This is the assertion that fails against the
+					// bare-name remove-side skip.
+					c.Assert(strings.Count(sql, "ALTER TABLE pages DROP FOREIGN KEY shared_fk;"), qt.Equals, 1,
+						qt.Commentf("purely-removed host must be dropped exactly once, not skipped; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "DROP FOREIGN KEY shared_fk;"), qt.Equals, 2,
+						qt.Commentf("exactly one drop per host, no more; got:\n%s", sql))
+
+					// MySQL 8 accepts no IF EXISTS on constraint drops — the plan
+					// must be valid without it.
+					c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+						qt.Commentf("MySQL-family constraint scoping must not lean on IF EXISTS; got:\n%s", sql))
+
+					// Ordering: the modified host's drop precedes its re-add; the
+					// pure removal is owned by removeConstraints and lands after.
+					articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk")
+					articlesAdd := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk")
+					pagesDrop := strings.Index(sql, "ALTER TABLE pages DROP FOREIGN KEY shared_fk")
+					c.Assert(articlesDrop >= 0 && articlesAdd >= 0 && pagesDrop >= 0, qt.IsTrue)
+					c.Assert(articlesDrop < articlesAdd, qt.IsTrue,
+						qt.Commentf("modified host's drop must precede its re-add; got:\n%s", sql))
+					c.Assert(pagesDrop > articlesAdd, qt.IsTrue,
+						qt.Commentf("pure removal must come from removeConstraints (after the re-add); got:\n%s", sql))
+				})
+			}
+		}
+	})
+
+	t.Run("check constraint", func(t *testing.T) {
+		orderings := map[string][]types.ConstraintRemovalInfo{
+			"modified host listed first": {
+				{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+				{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+			},
+			"purely-removed host listed first": {
+				{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+				{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+			},
+		}
+		for orderName, removals := range orderings {
+			for _, dialect := range mysqlFamilyDialects {
+				t.Run(dialect+"/"+orderName, func(t *testing.T) {
+					c := qt.New(t)
+
+					diff := &types.SchemaDiff{
+						ConstraintsAdded:   []string{"shared_check"},
+						ConstraintsRemoved: []string{"shared_check"},
+						ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+							{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+						},
+						ConstraintsRemovedWithTables: removals,
+					}
+					generated := &goschema.Database{
+						Constraints: []goschema.Constraint{
+							{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "status IN ('draft', 'published')"},
+						},
+					}
+
+					sql := renderMySQLFamily(c, dialect, diff, generated)
+
+					// Modified host: dropped exactly once from ITS table (the
+					// name-keyed single-winner map could drop pages instead and
+					// leave this collision in place), re-added exactly once.
+					c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check;"), qt.Equals, 1,
+						qt.Commentf("modified host must be dropped exactly once from its own table; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));"), qt.Equals, 1,
+						qt.Commentf("modified CHECK must be re-added on its host; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_check"), qt.Equals, 1,
+						qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
+
+					// Pure removal: dropped exactly once, by removeConstraints.
+					c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT shared_check;"), qt.Equals, 1,
+						qt.Commentf("purely-removed host must be dropped exactly once; got:\n%s", sql))
+					c.Assert(strings.Count(sql, "DROP CONSTRAINT shared_check;"), qt.Equals, 2,
+						qt.Commentf("exactly one drop per host, no more; got:\n%s", sql))
+					c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+						qt.Commentf("MySQL-family constraint scoping must not lean on IF EXISTS; got:\n%s", sql))
+
+					articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check")
+					articlesAdd := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check")
+					pagesDrop := strings.Index(sql, "ALTER TABLE pages DROP CONSTRAINT shared_check")
+					c.Assert(articlesDrop >= 0 && articlesAdd >= 0 && pagesDrop >= 0, qt.IsTrue)
+					c.Assert(articlesDrop < articlesAdd, qt.IsTrue,
+						qt.Commentf("modified host's drop must precede its re-add; got:\n%s", sql))
+					c.Assert(pagesDrop > articlesAdd, qt.IsTrue,
+						qt.Commentf("pure removal must come from removeConstraints (after the re-add); got:\n%s", sql))
+				})
+			}
+		}
+	})
+}
+
+// TestPlanner_GenerateMigrationAST_ModifiedFK_EveryHostDroppedAndReadded covers
+// the multi-host modify (the issue #197 mixin shape, both hosts drifted): each
+// host must get its own table-qualified DROP FOREIGN KEY + re-ADD pair, with
+// each drop preceding its own re-add. A single-host modify (the issue #189
+// action-drift shape) is the degenerate case and is asserted too.
+func TestPlanner_GenerateMigrationAST_ModifiedFK_EveryHostDroppedAndReadded(t *testing.T) {
+	t.Run("two hosts, distinct actions", func(t *testing.T) {
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"fk_customer"},
+					ConstraintsRemoved: []string{"fk_customer"},
+					ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+						{
+							Name: "fk_customer", TableName: "orders", Type: "FOREIGN KEY",
+							Columns: []string{"customer_id"}, ForeignTable: "customers", ForeignColumn: "id", OnDelete: "CASCADE",
+						},
+						{
+							Name: "fk_customer", TableName: "invoices", Type: "FOREIGN KEY",
+							Columns: []string{"customer_id"}, ForeignTable: "customers", ForeignColumn: "id", OnDelete: "SET NULL",
+						},
+					},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "fk_customer", TableName: "orders", Type: "FOREIGN KEY"},
+						{Name: "fk_customer", TableName: "invoices", Type: "FOREIGN KEY"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+				c.Assert(strings.Count(sql, "ALTER TABLE orders DROP FOREIGN KEY fk_customer;"), qt.Equals, 1,
+					qt.Commentf("orders host dropped exactly once; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE invoices DROP FOREIGN KEY fk_customer;"), qt.Equals, 1,
+					qt.Commentf("invoices host dropped exactly once; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;"), qt.IsTrue,
+					qt.Commentf("orders re-added with its own action; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "ALTER TABLE invoices ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;"), qt.IsTrue,
+					qt.Commentf("invoices re-added with its own action; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse)
+
+				for _, host := range []string{"orders", "invoices"} {
+					dropIdx := strings.Index(sql, "ALTER TABLE "+host+" DROP FOREIGN KEY fk_customer")
+					addIdx := strings.Index(sql, "ALTER TABLE "+host+" ADD CONSTRAINT fk_customer")
+					c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+						qt.Commentf("%s: drop must precede its re-add; drop=%d add=%d; got:\n%s", host, dropIdx, addIdx, sql))
+				}
+			})
+		}
+	})
+
+	t.Run("single host (issue #189 parity)", func(t *testing.T) {
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"fk_post_owner"},
+					ConstraintsRemoved: []string{"fk_post_owner"},
+					ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+						{
+							Name: "fk_post_owner", TableName: "posts", Type: "FOREIGN KEY",
+							Columns: []string{"owner_id"}, ForeignTable: "users", ForeignColumn: "id", OnDelete: "SET NULL",
+						},
+					},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "fk_post_owner", TableName: "posts", Type: "FOREIGN KEY"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+				c.Assert(strings.Count(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_post_owner;"), qt.Equals, 1,
+					qt.Commentf("exactly one drop; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE SET NULL;"), qt.Equals, 1,
+					qt.Commentf("exactly one re-add; got:\n%s", sql))
+				dropIdx := strings.Index(sql, "DROP FOREIGN KEY fk_post_owner")
+				addIdx := strings.Index(sql, "ADD CONSTRAINT fk_post_owner")
+				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+					qt.Commentf("drop must precede re-add; got:\n%s", sql))
+			})
+		}
+	})
+}
+
+// TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent
+// guards the reverse/down shape: ConstraintsAdded carries the name but
+// ConstraintsAddedWithTables is EMPTY (reverseConstraintAdditions restores only
+// FOREIGN KEYs, and nothing at all when the introspected schema is absent). The
+// add side must drop every recorded removal host, and removeConstraints must
+// then skip the name entirely — MySQL has no IF EXISTS on constraint drops, so
+// a second drop of the same (table, name) would abort the whole migration.
+// This is exactly the failure mode that sank the naive remove-side-only port of
+// the postgres #206 fix (see issue #207).
+func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(t *testing.T) {
+	t.Run("check constraint", func(t *testing.T) {
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"chk_down"},
+					ConstraintsRemoved: []string{"chk_down"},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "chk_down", TableName: "things", Type: "CHECK"},
+					},
+				}
+				generated := &goschema.Database{
+					Constraints: []goschema.Constraint{
+						{StructName: "Thing", Name: "chk_down", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, generated)
+
+				// Exactly ONE drop in the whole plan: the add side owns it and
+				// removeConstraints must not emit a second, unguarded one.
+				c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_down;"), qt.Equals, 1,
+					qt.Commentf("the drop must be emitted exactly once across both planner phases; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);"), qt.IsTrue,
+					qt.Commentf("modified constraint must still be re-added; got:\n%s", sql))
+				dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT chk_down")
+				addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_down")
+				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+					qt.Commentf("drop must precede the re-add; got:\n%s", sql))
+			})
+		}
+	})
+
+	t.Run("check constraint, two removal hosts", func(t *testing.T) {
+		// The down migration of a multi-host non-FK constraint modify arrives
+		// exactly in this shape: reverseSchemaDiffWithSchema copies the bare
+		// name into ConstraintsAdded once per host (duplicated), fills
+		// ConstraintsRemovedWithTables with EVERY host, and leaves
+		// ConstraintsAddedWithTables empty (reverseConstraintAdditions
+		// restores FOREIGN KEYs only). emitModifyDropForName must then drop
+		// every recorded host exactly once — deduped across the duplicated
+		// bare names — and removeConstraints must emit nothing (hostless
+		// re-add rule). A regression that drops only the first host would
+		// leave the second host's stale constraint in place with the whole
+		// suite green, which is why the per-host counts below are load-bearing.
+		//
+		// The ADD side is deliberately NOT count-asserted: the multi-host
+		// non-FK re-add resolves by name to a single definition (a
+		// pre-existing limitation explicitly deferred in issue #207 notes).
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"shared_check", "shared_check"},
+					ConstraintsRemoved: []string{"shared_check", "shared_check"},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+						{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+					},
+				}
+				generated := &goschema.Database{
+					Constraints: []goschema.Constraint{
+						{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "qty >= 0"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, generated)
+
+				c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check;"), qt.Equals, 1,
+					qt.Commentf("first removal host must be dropped exactly once; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT shared_check;"), qt.Equals, 1,
+					qt.Commentf("second removal host must be dropped exactly once, not skipped and not doubled; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "DROP CONSTRAINT shared_check;"), qt.Equals, 2,
+					qt.Commentf("exactly one drop per recorded host across BOTH planner phases; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse)
+
+				articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check")
+				pagesDrop := strings.Index(sql, "ALTER TABLE pages DROP CONSTRAINT shared_check")
+				firstAdd := strings.Index(sql, "ADD CONSTRAINT shared_check")
+				c.Assert(articlesDrop >= 0 && pagesDrop >= 0 && firstAdd >= 0, qt.IsTrue)
+				c.Assert(articlesDrop < firstAdd && pagesDrop < firstAdd, qt.IsTrue,
+					qt.Commentf("both host drops are owned by the add side and must precede the re-add; got:\n%s", sql))
+			})
+		}
+	})
+
+	t.Run("empty-TableName removal entry emits nothing", func(t *testing.T) {
+		// Design decision: a removal entry with no recorded host cannot be
+		// dropped on MySQL — there is no valid table-qualified ALTER TABLE to
+		// emit and no runtime name-only fallback (no anonymous-block
+		// equivalent of the postgres information_schema DO block). Both new
+		// guards (emitModifyDropForName and removeConstraints) must skip the
+		// entry silently: no malformed statement with an empty table name, no
+		// abort. The re-add still proceeds alone.
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"chk_hostless"},
+					ConstraintsRemoved: []string{"chk_hostless"},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "chk_hostless", TableName: "", Type: "CHECK"},
+					},
+				}
+				generated := &goschema.Database{
+					Constraints: []goschema.Constraint{
+						{StructName: "Thing", Name: "chk_hostless", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, generated)
+
+				c.Assert(strings.Contains(sql, "DROP CONSTRAINT chk_hostless"), qt.IsFalse,
+					qt.Commentf("a hostless removal entry must be skipped, not dropped; got:\n%s", sql))
+				c.Assert(strings.Contains(sql, "ALTER TABLE  DROP"), qt.IsFalse,
+					qt.Commentf("no malformed empty-table ALTER may be emitted; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE things ADD CONSTRAINT chk_hostless CHECK (qty >= 0);"), qt.Equals, 1,
+					qt.Commentf("the re-add still proceeds alone; got:\n%s", sql))
+			})
+		}
+	})
+
+	t.Run("field-level foreign key", func(t *testing.T) {
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"fk_post_owner"},
+					ConstraintsRemoved: []string{"fk_post_owner"},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "fk_post_owner", TableName: "posts", Type: "FOREIGN KEY"},
+					},
+				}
+				generated := &goschema.Database{
+					Tables: []goschema.Table{
+						{StructName: "User", Name: "users"},
+						{StructName: "Post", Name: "posts"},
+					},
+					Fields: []goschema.Field{
+						{
+							StructName:     "Post",
+							Name:           "owner_id",
+							Type:           "INT",
+							Foreign:        "users(id)",
+							ForeignKeyName: "fk_post_owner",
+							OnDelete:       "CASCADE",
+						},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, generated)
+
+				c.Assert(strings.Count(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_post_owner;"), qt.Equals, 1,
+					qt.Commentf("the drop must be emitted exactly once across both planner phases; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE posts ADD CONSTRAINT fk_post_owner FOREIGN KEY (owner_id) REFERENCES users(id) ON DELETE CASCADE;"), qt.Equals, 1,
+					qt.Commentf("field-level FK must be re-added via the synthesis fallback; got:\n%s", sql))
+				dropIdx := strings.Index(sql, "DROP FOREIGN KEY fk_post_owner")
+				addIdx := strings.Index(sql, "ADD CONSTRAINT fk_post_owner")
+				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+					qt.Commentf("drop must precede the re-add; got:\n%s", sql))
+			})
+		}
+	})
+}
+
+// TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified locks
+// the pure-removal path: every removal with a known host is dropped exactly
+// once with the type-correct syntax; PRIMARY KEY removals and constraints on
+// tables that are themselves being dropped are skipped; a duplicate removal
+// entry for the same (table, name) is deduped — MySQL would abort on the
+// second, unguarded drop otherwise.
+func TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &types.SchemaDiff{
+				TablesRemoved: []string{"obsolete"},
+				ConstraintsRemoved: []string{
+					"fk_orders_customer", "chk_qty", "pk_legacy", "chk_on_obsolete", "fk_orders_customer", "chk_orphan",
+				},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+					{Name: "fk_orders_customer", TableName: "orders", Type: "FOREIGN KEY"},
+					{Name: "chk_qty", TableName: "things", Type: "CHECK"},
+					{Name: "pk_legacy", TableName: "legacy", Type: "PRIMARY KEY"},
+					{Name: "chk_on_obsolete", TableName: "obsolete", Type: "CHECK"},
+					// Duplicate entry for an already-listed host: must be deduped.
+					{Name: "fk_orders_customer", TableName: "orders", Type: "FOREIGN KEY"},
+					// Entry with no recorded host: must be skipped silently —
+					// MySQL has no name-only runtime fallback, and an empty
+					// table name would render a malformed ALTER.
+					{Name: "chk_orphan", TableName: "", Type: "CHECK"},
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+			c.Assert(strings.Count(sql, "ALTER TABLE orders DROP FOREIGN KEY fk_orders_customer;"), qt.Equals, 1,
+				qt.Commentf("FK removal must be dropped exactly once (deduped) with FK syntax; got:\n%s", sql))
+			c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.Equals, 1,
+				qt.Commentf("CHECK removal must be dropped exactly once; got:\n%s", sql))
+			c.Assert(strings.Contains(sql, "pk_legacy"), qt.IsFalse,
+				qt.Commentf("PRIMARY KEY removals must be skipped; got:\n%s", sql))
+			c.Assert(strings.Contains(sql, "DROP CONSTRAINT chk_on_obsolete"), qt.IsFalse,
+				qt.Commentf("constraints on dropped tables are cascaded by DROP TABLE, not dropped explicitly; got:\n%s", sql))
+			c.Assert(strings.Contains(sql, "DROP TABLE IF EXISTS obsolete"), qt.IsTrue,
+				qt.Commentf("the dropped table itself is still removed; got:\n%s", sql))
+			c.Assert(strings.Contains(sql, "chk_orphan"), qt.IsFalse,
+				qt.Commentf("a removal entry with no recorded host must be skipped silently; got:\n%s", sql))
+			c.Assert(strings.Contains(sql, "ALTER TABLE  DROP"), qt.IsFalse,
+				qt.Commentf("no malformed empty-table ALTER may be emitted; got:\n%s", sql))
+		})
+	}
+}

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -398,6 +398,50 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(
 		}
 	})
 
+	t.Run("empty-TableName addition entry is treated as hostless", func(t *testing.T) {
+		// A ConstraintsAddedWithTables entry with no recorded host must not
+		// count as a recorded addition host on either side. If it did, the
+		// add side would see a non-empty addedHosts set containing only ""
+		// (matching no real removal host) and skip the required pre-drop,
+		// while removeConstraints would see addedHostCounts > 0, disengage
+		// its hostless-re-add rule, and emit the drop AFTER the re-add —
+		// killing the freshly added constraint. With the guard, the name
+		// behaves exactly like a hostless re-add: one pre-drop from the add
+		// side, then the re-add, nothing from removeConstraints.
+		for _, dialect := range mysqlFamilyDialects {
+			t.Run(dialect, func(t *testing.T) {
+				c := qt.New(t)
+
+				diff := &types.SchemaDiff{
+					ConstraintsAdded:   []string{"chk_ghost"},
+					ConstraintsRemoved: []string{"chk_ghost"},
+					ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+						{Name: "chk_ghost", TableName: "", Type: "CHECK"},
+					},
+					ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+						{Name: "chk_ghost", TableName: "things", Type: "CHECK"},
+					},
+				}
+				generated := &goschema.Database{
+					Constraints: []goschema.Constraint{
+						{StructName: "Thing", Name: "chk_ghost", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
+					},
+				}
+
+				sql := renderMySQLFamily(c, dialect, diff, generated)
+
+				c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_ghost;"), qt.Equals, 1,
+					qt.Commentf("the recorded removal host must be dropped exactly once; got:\n%s", sql))
+				c.Assert(strings.Count(sql, "ALTER TABLE things ADD CONSTRAINT chk_ghost CHECK (qty >= 0);"), qt.Equals, 1,
+					qt.Commentf("the re-add must still be emitted; got:\n%s", sql))
+				dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT chk_ghost")
+				addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_ghost")
+				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+					qt.Commentf("the drop must be the add-side pre-drop (before the re-add), not a removeConstraints drop after it; got:\n%s", sql))
+			})
+		}
+	})
+
 	t.Run("field-level foreign key", func(t *testing.T) {
 		for _, dialect := range mysqlFamilyDialects {
 			t.Run(dialect, func(t *testing.T) {

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -557,8 +557,12 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 // A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved is
 // a modification (the comparator expresses a changed constraint as remove + add
 // of the same name — e.g. an on_delete change on a field-level FK, issue #189).
-// The DROP is emitted here, immediately before the re-ADD, so it precedes the
-// re-add and removeConstraints (which runs later) skips it.
+// The DROP is emitted here, immediately before the re-ADD, scoped to the exact
+// host table(s) being re-added (issue #207); removeConstraints (which runs
+// later) skips those (table, name) pairs and owns every remaining pure
+// removal. MySQL accepts no IF EXISTS on constraint drops, so this
+// exactly-once split between the two functions is what keeps a migration from
+// aborting on a duplicate drop or colliding on a missing one.
 //
 // # Example Generated SQL
 //
@@ -571,6 +575,17 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	structToTable := make(map[string]string, len(generated.Tables))
 	for _, t := range generated.Tables {
 		structToTable[t.StructName] = t.Name
+	}
+
+	// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved
+	// is a modification (the comparator expresses a changed constraint as
+	// remove + add of the same name — e.g. an on_delete change on a field-level
+	// FK, issue #189). Its old definition must be dropped before the re-add or
+	// the ADD CONSTRAINT collides with the still-present constraint of the same
+	// name (errno 1826 for FKs / 3822 for CHECKs).
+	removedNames := make(map[string]struct{}, len(diff.ConstraintsRemoved))
+	for _, name := range diff.ConstraintsRemoved {
+		removedNames[name] = struct{}{}
 	}
 
 	// Removal info keyed by (table, name) so a same-name modification can be
@@ -589,6 +604,34 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalByTableName[info.TableName+"."+info.Name] = info
 	}
 
+	// Removal info grouped by bare name, so the legacy ConstraintsAdded loop
+	// below can scope a modified non-FK constraint's DROP to its concrete host
+	// table(s). The comparator records every removal in
+	// ConstraintsRemovedWithTables in lockstep with the bare ConstraintsRemoved
+	// list, so a modified constraint's host is normally known here even though
+	// the bare loop iterates names alone.
+	removalsByName := make(map[string][]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
+	for _, info := range diff.ConstraintsRemovedWithTables {
+		removalsByName[info.Name] = append(removalsByName[info.Name], info)
+	}
+
+	// Hosts actually being re-ADDED under each name. A modified constraint's
+	// pre-drop must hit only those hosts — NOT every host that merely has a
+	// removal entry for the name. In the MIXED case (issue #207; postgres
+	// sibling #206) a shared name is a modify on host A (re-added) and a PURE
+	// removal on host B (not re-added): B's drop is owned by removeConstraints,
+	// and MySQL has no IF EXISTS on constraint drops to absorb a duplicate, so
+	// dropping B here as well would abort the migration on the second drop.
+	addedHostsByName := make(map[string]map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	for _, add := range diff.ConstraintsAddedWithTables {
+		hosts := addedHostsByName[add.Name]
+		if hosts == nil {
+			hosts = make(map[string]struct{})
+			addedHostsByName[add.Name] = hosts
+		}
+		hosts[add.TableName] = struct{}{}
+	}
+
 	// Prefer the table-qualified additions when present. A field-level FK from an
 	// embedded inline-relation mixin shares one name across every host table, so
 	// resolving the table from the field's Go struct name targets the mixin
@@ -602,40 +645,100 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 			continue
 		}
 		// For a modification, emit the DROP FOREIGN KEY from this exact host
-		// table before its re-add. Dedup on (table, name) so each host is
-		// dropped once even if the comparator lists it more than once.
-		dropKey := add.TableName + "." + add.Name
-		if info, modified := removalByTableName[dropKey]; modified {
-			if _, done := droppedForModify[dropKey]; !done {
-				result = append(result, dropConstraintNode(info))
-				droppedForModify[dropKey] = struct{}{}
-			}
+		// table before its re-add — only when this host's (table, name) is in
+		// the removal set; a pure-add host gets no phantom drop.
+		if info, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.appendScopedDrop(result, info, droppedForModify)
 		}
 		result = append(result, p.foreignKeyAdditionNode(add))
 		handled[add.Name] = struct{}{}
 	}
 
-	// Fallback for added constraints with no table-qualified entry above
+	// Fallback for added constraints with no table-qualified FK entry above
 	// (table-level CHECK/UNIQUE, or field-level synthesis resolved by name).
-	// These names are unique per table, so a name-keyed removal lookup is
-	// sufficient and there is no multi-host collapse hazard here.
-	removalByName := make(map[string]types.ConstraintRemovalInfo, len(diff.ConstraintsRemovedWithTables))
-	for _, info := range diff.ConstraintsRemovedWithTables {
-		removalByName[info.Name] = info
-	}
 	for _, constraintName := range diff.ConstraintsAdded {
 		if _, done := handled[constraintName]; done {
 			continue
 		}
 
-		// For a modification, emit the DROP first so it precedes the re-add.
-		if info, modified := removalByName[constraintName]; modified {
-			result = append(result, dropConstraintNode(info))
+		// For a modification, emit the DROP(s) first so they precede the
+		// re-add, scoped to the constraint's concrete host table(s) — never a
+		// name-keyed single-winner lookup, which collapses multiple removal
+		// hosts onto one arbitrary table (issue #207).
+		if _, modified := removedNames[constraintName]; modified {
+			result = p.emitModifyDropForName(result, constraintName, removalsByName, addedHostsByName[constraintName], droppedForModify)
 		}
 
 		result = p.appendAddConstraint(result, constraintName, generated, structToTable)
 	}
 	return result
+}
+
+// emitModifyDropForName appends the DROP(s) that must precede the re-ADD of a
+// modified constraint reached via the bare ConstraintsAdded name list (the
+// non-FK and field-level synthesis paths; FK modifies are handled per-host in
+// the ConstraintsAddedWithTables loop). The comparator records every removal
+// in ConstraintsRemovedWithTables in lockstep with the bare list, so the
+// owning table and constraint type are normally known: each re-added host gets
+// a direct, table-qualified, type-aware drop (DROP FOREIGN KEY /
+// DROP CONSTRAINT), deduped per (host, name). A name-keyed single-winner
+// lookup must never be used here: with >=2 removal hosts it collapses onto one
+// arbitrary host, so the wrong table's constraint is dropped while the
+// re-added host's ADD collides with its still-present old constraint
+// (errno 1826/3822, issue #207).
+//
+// The drop is restricted to addedHosts — the hosts actually being re-added
+// under this name (ConstraintsAddedWithTables). In the MIXED case a shared
+// name is a modify on host A (re-added) and a PURE removal on host B (not
+// re-added); B's drop is owned by removeConstraints. MySQL accepts no
+// IF EXISTS on constraint drops (only MariaDB does), so — unlike postgres,
+// where a duplicate guarded drop degrades to a no-op — dropping B here as well
+// would abort the migration on removeConstraints' second drop.
+//
+// When addedHosts is empty the re-added hosts are unknown — e.g. a
+// reverse/down diff fills ConstraintsRemovedWithTables but not
+// ConstraintsAddedWithTables (reverseConstraintAdditions restores only
+// FOREIGN KEYs, and nothing at all when the introspected schema is absent). In
+// that case every recorded removal host is dropped here and removeConstraints
+// skips the name entirely (its hostless-re-add rule), so each host is still
+// dropped exactly once. A name with no recorded removal host at all emits no
+// drop: MySQL has no anonymous-block equivalent of the postgres
+// information_schema DO fallback to resolve the owner at runtime, so the
+// re-add proceeds alone (pre-existing behavior for hand-built diffs).
+func (p *Planner) emitModifyDropForName(
+	result []ast.Node,
+	name string,
+	removalsByName map[string][]types.ConstraintRemovalInfo,
+	addedHosts map[string]struct{},
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	for _, info := range removalsByName[name] {
+		if info.TableName == "" {
+			continue
+		}
+		if len(addedHosts) > 0 {
+			if _, reAdded := addedHosts[info.TableName]; !reAdded {
+				continue
+			}
+		}
+		result = p.appendScopedDrop(result, info, droppedForModify)
+	}
+	return result
+}
+
+// appendScopedDrop appends a single table-qualified, type-aware constraint
+// drop (ALTER TABLE <host> DROP FOREIGN KEY <name> / DROP CONSTRAINT <name>),
+// deduped per (table, name) via dropped so a constraint name shared across
+// host tables is dropped once per host and never twice for the same host.
+// MySQL accepts no IF EXISTS on these drops, so exactly-once emission is what
+// keeps a duplicate drop from aborting the migration.
+func (p *Planner) appendScopedDrop(result []ast.Node, info types.ConstraintRemovalInfo, dropped map[string]struct{}) []ast.Node {
+	dedupKey := info.TableName + "." + info.Name
+	if _, done := dropped[dedupKey]; done {
+		return result
+	}
+	dropped[dedupKey] = struct{}{}
+	return append(result, dropConstraintNode(info))
 }
 
 // foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a
@@ -763,21 +866,48 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 // MySQL/MariaDB use a type-specific drop syntax:
 //   - DROP FOREIGN KEY <name> for foreign key constraints (DROP CONSTRAINT is
 //     not accepted for FKs on MySQL/MariaDB)
-//   - DROP CONSTRAINT <name> for CHECK constraints (MySQL 8.0.16+ / MariaDB)
+//   - DROP CONSTRAINT <name> for CHECK constraints (MySQL 8.0.19+ / MariaDB)
 //   - DROP INDEX <name> for UNIQUE constraints
 //
 // The owning table is carried on diff.ConstraintsRemovedWithTables (the bare
-// ConstraintsRemoved name list does not retain it). Constraints that appear in
-// BOTH ConstraintsAdded and ConstraintsRemoved are modifications (the
-// comparator expresses a changed constraint as remove + add of the same name —
-// e.g. an on_delete change on a field-level FK, issue #189). Those are emitted
-// as DROP-then-ADD by addNewConstraints, which runs earlier in the pipeline so
-// the drop precedes the re-add; dropping them again here would remove the
-// freshly added constraint, so they are skipped.
+// ConstraintsRemoved name list does not retain it, and MySQL has no runtime
+// name-only fallback like the postgres information_schema DO block).
+//
+// # Modification skip — keyed on (table, name), not the bare name
+//
+// A constraint whose (table, name) appears in BOTH the additions
+// (ConstraintsAddedWithTables) and the removals is a modification: the
+// comparator expresses a changed constraint as remove + add of the same name
+// (e.g. an on_delete change on a field-level FK, issue #189). Those hosts are
+// emitted as DROP-then-ADD by addNewConstraints, which runs earlier in the
+// pipeline so the drop precedes the re-add; dropping them again here would
+// remove the freshly added constraint.
+//
+// The skip MUST be keyed on (table, name): a shared constraint name can be a
+// modify on host A and a PURE removal on host B. A bare-name skip treats B's
+// removal as a modify owned by addNewConstraints and skips it, leaving B's
+// stale constraint in place forever (issue #207; postgres sibling #206).
+//
+// A name that is re-added with NO recorded host (ConstraintsAdded carries the
+// name but ConstraintsAddedWithTables has no entry — reverse/down and
+// hand-built diffs) is skipped entirely: addNewConstraints already dropped
+// every recorded removal host for it (see emitModifyDropForName), and MySQL
+// accepts no DROP ... IF EXISTS to absorb a duplicate drop, so a second drop
+// here would abort the migration. Exactly-once emission per (table, name) —
+// split between the two functions and deduped inside each — is what stands in
+// for postgres's IF EXISTS idempotency guard.
 func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
-	addedNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
+	// (table, name) pairs being re-added — modifications owned by
+	// addNewConstraints — plus, per name, how many hosts were recorded at all.
+	modifyHosts := make(map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	addedHostCounts := make(map[string]int, len(diff.ConstraintsAddedWithTables))
+	for _, add := range diff.ConstraintsAddedWithTables {
+		modifyHosts[add.TableName+"."+add.Name] = struct{}{}
+		addedHostCounts[add.Name]++
+	}
+	addedBareNames := make(map[string]struct{}, len(diff.ConstraintsAdded))
 	for _, name := range diff.ConstraintsAdded {
-		addedNames[name] = struct{}{}
+		addedBareNames[name] = struct{}{}
 	}
 
 	// Constraints owned by a table that is itself being dropped do not need an
@@ -789,11 +919,24 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 		droppedTables[t] = struct{}{}
 	}
 
+	dropped := make(map[string]struct{})
 	for _, info := range diff.ConstraintsRemovedWithTables {
-		if _, modified := addedNames[info.Name]; modified {
+		if info.TableName == "" {
+			// No host recorded: there is no valid table-qualified ALTER TABLE
+			// to emit and no runtime fallback on MySQL. Real comparator output
+			// always carries the host.
 			continue
 		}
-		if _, dropped := droppedTables[info.TableName]; dropped {
+		if _, modified := modifyHosts[info.TableName+"."+info.Name]; modified {
+			// addNewConstraints owns this host's DROP-then-ADD; do not re-drop.
+			continue
+		}
+		if _, added := addedBareNames[info.Name]; added && addedHostCounts[info.Name] == 0 {
+			// Hostless re-add: addNewConstraints already dropped every
+			// recorded removal host for this name.
+			continue
+		}
+		if _, droppedTable := droppedTables[info.TableName]; droppedTable {
 			continue
 		}
 		// PRIMARY KEY uses a dedicated syntax and is owned by the column/table
@@ -801,7 +944,7 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 		if strings.EqualFold(info.Type, "PRIMARY KEY") {
 			continue
 		}
-		result = append(result, dropConstraintNode(info))
+		result = p.appendScopedDrop(result, info, dropped)
 	}
 	return result
 }

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -624,6 +624,14 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// dropping B here as well would abort the migration on the second drop.
 	addedHostsByName := make(map[string]map[string]struct{}, len(diff.ConstraintsAddedWithTables))
 	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.TableName == "" {
+			// An addition entry with no recorded host is hostless: a "" host
+			// would match no removal entry, so keeping it here would make
+			// emitModifyDropForName filter out every REAL removal host and
+			// skip a required pre-drop. Treat the name as if it had no
+			// recorded addition hosts at all.
+			continue
+		}
 		hosts := addedHostsByName[add.Name]
 		if hosts == nil {
 			hosts = make(map[string]struct{})
@@ -902,6 +910,13 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	modifyHosts := make(map[string]struct{}, len(diff.ConstraintsAddedWithTables))
 	addedHostCounts := make(map[string]int, len(diff.ConstraintsAddedWithTables))
 	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.TableName == "" {
+			// Hostless addition entries do not count as recorded hosts —
+			// mirroring addedHostsByName in addNewConstraints — so the
+			// hostless-re-add rule below still engages and this side keeps
+			// skipping the hosts the add side already dropped.
+			continue
+		}
 		modifyHosts[add.TableName+"."+add.Name] = struct{}{}
 		addedHostCounts[add.Name]++
 	}


### PR DESCRIPTION
Closes #207.

Mirrors the postgres constraint-scoping fixes (#199 / PR #205, #206) into the MySQL/MariaDB planner — both sides together, as #207 requires (a remove-side-only port emits a second unguarded drop and aborts the migration).

## What changed

**Add side — `addNewConstraints`:**
- The legacy `ConstraintsAdded` loop no longer resolves a modified constraint's host via the bare-name `removalByName` map (last-write-wins across removal hosts). It calls the new `emitModifyDropForName`, which drops exactly the removal hosts that are actually being **re-added** (`addedHostsByName` built from `ConstraintsAddedWithTables`) — a pure-removal host is left to `removeConstraints` and never dropped twice.
- When the re-added hosts are unknown (`ConstraintsAdded` carries the name but `ConstraintsAddedWithTables` has no entry — reverse/down and hand-built diffs), every recorded removal host is dropped here, and `removeConstraints` skips the name (see below), so each host is still dropped exactly once.
- The FK loop keeps its (table,name) keying and now routes through the shared `appendScopedDrop` dedup.

**Remove side — `removeConstraints`:**
- The modify-skip is keyed on **(table, name)** from `ConstraintsAddedWithTables`, not the bare name — a pure removal of a shared name is no longer mistaken for a modification and skipped (the exact remove-side bug of #207/#206).
- Hostless-re-add rule: a name re-added with zero recorded hosts is skipped entirely (the add side owns all its recorded removal hosts).
- Every emitted drop is table-qualified and type-aware (`DROP FOREIGN KEY` / `DROP CONSTRAINT`), deduped per (table,name) — duplicate comparator entries no longer emit a second unguarded drop.
- Entries with an empty `TableName` are skipped: MySQL has no runtime name-only fallback (no anonymous-block equivalent of the postgres information_schema DO block).

**Idempotency decision (issue checkbox 3):** MySQL 8 rejects `IF EXISTS` on `DROP CONSTRAINT`/`DROP FOREIGN KEY` (MariaDB-only syntax), so instead of a guard the plan guarantees **exactly-once emission by construction**: the add side and the remove side own disjoint (table,name) sets, and both dedup internally. Documented in the function doc comments. (Emitting `IF EXISTS` selectively for MariaDB is the first consumer candidate for the capability-set proposal, #225.)

## Failure scenario fixed

Shared constraint name `shared_check` on `articles` (modified) and `pages` (purely removed):

- **Before, add side:** the bare-name lookup could resolve the modify-drop to `pages` (wrong host) — `articles` was never dropped, so its re-ADD collided (errno 3822/1826); or resolve to `articles` and leave `pages` never dropped at all.
- **Before, remove side:** the bare-name skip treated `pages`'s pure removal as "owned by the add side" and emitted nothing — stale constraint forever.
- **After:** `articles` is dropped-then-re-added by the add side; `pages` is dropped exactly once by the remove side; no statement needs `IF EXISTS`.

## Tests (`migration/planner/dialects/mysql/constraint_scope_test.go`)

Every scenario rendered through **both** `mysql` and `mariadb` renderers (both dialects consume this planner):

- Mixed modify+pure-removal for **FK** and **CHECK**, each in **both removal-entry orderings** — kills any last-write-wins resolution. Asserts: modified host dropped exactly once before its re-add, pure host dropped exactly once after it (removeConstraints ordering), exactly one ADD, no `IF EXISTS` anywhere.
- Multi-host FK modify (both hosts re-added with distinct actions) + single-host #189 parity.
- Hostless re-add (reverse/down-diff shape) for CHECK and field-level FK — the anti-double-drop guard: exactly ONE drop across both planner phases; plus the **two-host** hostless variant (the production down-diff of a multi-host non-FK modify: every recorded host dropped exactly once, deduped across the duplicated bare names).
- Empty-`TableName` removal entries: skipped silently on both the modify path and the pure-removal path — no malformed `ALTER TABLE  DROP …`.
- Pure removals: type-aware syntax, PRIMARY KEY skip, dropped-table skip, duplicate-entry dedup.

Verified load-bearing: `TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother` and `TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified` **fail against master** (checked by swapping in master's `mysql.go`); the rest are parity locks.

## Verification

- `go test -count=1 ./...` — green.
- `golangci-lint run ./...` — 0 issues.
- Live integration suites against Docker **MySQL 9.7 + MariaDB 10.11**: **120/120 scenarios passed** (run natively; note the repo's local compose setup is currently broken independently of this change — see #227).
- Multi-agent adversarial self-review (5 independent lenses: exactly-once ownership logic, postgres parity, SQL validity per dialect, test quality, blast radius; every finding cross-examined by 3 skeptics): the four code lenses returned **zero findings**; the test lens produced 2 confirmed coverage gaps (two-host hostless invariant, empty-TableName guard), both addressed in this PR's final test set.

## Acceptance criteria from #207

- [x] Mixed modify-on-A + pure-removal-on-B planner test (FK **and** non-FK) emits valid DDL: A dropped-then-re-added, B dropped exactly once, no duplicate-name ADD, no drop of a non-existent constraint.
- [x] No remaining bare-name constraint-owner resolution on either side where the host is known.
- [x] MySQL idempotency-guard decision made and documented (exactly-once by construction; no `IF EXISTS` on MySQL 8 — MariaDB-conditional guards deferred to #225).