### PR TITLE
Fix local Docker compose test env (#227)

### DIFF
--- a/INTEGRATION_TEST_IMPLEMENTATION.md
+++ b/INTEGRATION_TEST_IMPLEMENTATION.md
@@ -154,28 +154,28 @@ The integration test suite covers:
 make integration-test
 
 # Or directly with Docker Compose
-docker-compose --profile test run --rm ptah-tester --report=html
+docker compose --profile test run --rm ptah-tester --report=html
 ```
 
 ### Docker Compose Commands
 ```bash
 # Run all tests with default text report
-docker-compose --profile test run --rm ptah-tester
+docker compose --profile test run --rm ptah-tester
 
 # Run with HTML report (recommended)
-docker-compose --profile test run --rm ptah-tester --report=html --verbose
+docker compose --profile test run --rm ptah-tester --report=html --verbose
 
 # Run specific scenarios
-docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations
+docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations
 
 # Test specific database
-docker-compose --profile test run --rm ptah-tester --databases=postgres
+docker compose --profile test run --rm ptah-tester --databases=postgres
 
 # Generate JSON report for CI/CD
-docker-compose --profile test run --rm ptah-tester --report=json
+docker compose --profile test run --rm ptah-tester --report=json
 
 # Quick smoke test
-docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres
+docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres
 ```
 
 ### Makefile Shortcuts
@@ -252,8 +252,8 @@ Reports are automatically saved to `./integration/reports/` on the host system.
 The integration test suite is now complete and ready for use. To get started:
 
 1. **Review the documentation** in `integration/README.md`
-2. **Run a quick test**: `docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres`
-3. **Execute the full suite**: `docker-compose --profile test run --rm ptah-tester --report=html --verbose`
+2. **Run a quick test**: `docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres`
+3. **Execute the full suite**: `docker compose --profile test run --rm ptah-tester --report=html --verbose`
 4. **Examine the reports** in `integration/reports/`
 5. **Integrate into CI/CD** using Docker Compose commands
 6. **Get help**: `make docker-help` for all available commands

--- a/Makefile
+++ b/Makefile
@@ -29,73 +29,73 @@ test:
 # Build Docker image for integration tests
 docker-build:
 	@echo "Building Docker image for integration tests..."
-	docker-compose --profile test build ptah-tester
+	docker compose --profile test build ptah-tester
 
 # Run integration tests using Docker Compose
 integration-test: docker-build
 	@echo "Starting databases and running integration tests..."
-	docker-compose --profile test run --rm ptah-tester --report=html --verbose
+	docker compose --profile test run --rm ptah-tester --report=html --verbose
 
 # Run integration tests with specific format
 integration-test-json: docker-build
 	@echo "Running integration tests with JSON report..."
-	docker-compose --profile test run --rm ptah-tester --report=json --verbose
+	docker compose --profile test run --rm ptah-tester --report=json --verbose
 
 # Run integration tests with text report
 integration-test-txt: docker-build
 	@echo "Running integration tests with text report..."
-	docker-compose --profile test run --rm ptah-tester --report=txt --verbose
+	docker compose --profile test run --rm ptah-tester --report=txt --verbose
 
 # Run integration tests with stdout report
 integration-test-stdout: docker-build
 	@echo "Running integration tests with stdout report..."
-	docker-compose --profile test run --rm ptah-tester --report=stdout --verbose
+	docker compose --profile test run --rm ptah-tester --report=stdout --verbose
 
 # Run specific scenarios
 integration-test-basic: docker-build
 	@echo "Running basic integration tests..."
-	docker-compose --profile test run --rm ptah-tester \
+	docker compose --profile test run --rm ptah-tester \
 		--scenarios=apply_incremental_migrations,rollback_migrations,upgrade_to_specific_version \
 		--report=html --verbose
 
 # Run integration tests against specific database
 integration-test-postgres: docker-build
 	@echo "Running integration tests against PostgreSQL only..."
-	docker-compose --profile test run --rm ptah-tester --databases=postgres --report=html --verbose
+	docker compose --profile test run --rm ptah-tester --databases=postgres --report=html --verbose
 
 integration-test-mysql: docker-build
 	@echo "Running integration tests against MySQL only..."
-	docker-compose --profile test run --rm ptah-tester --databases=mysql --report=html --verbose
+	docker compose --profile test run --rm ptah-tester --databases=mysql --report=html --verbose
 
 integration-test-mariadb: docker-build
 	@echo "Running integration tests against MariaDB only..."
-	docker-compose --profile test run --rm ptah-tester --databases=mariadb --report=html --verbose
+	docker compose --profile test run --rm ptah-tester --databases=mariadb --report=html --verbose
 
 # Run integration tests using Docker Compose with custom arguments
 integration-test-custom: docker-build
 	@echo "Running integration tests with custom arguments..."
 	@echo "Usage: make integration-test-custom ARGS='--report=json --databases=postgres'"
-	docker-compose --profile test run --rm ptah-tester $(ARGS)
+	docker compose --profile test run --rm ptah-tester $(ARGS)
 
 # Start databases only (for development)
 db-start:
 	@echo "Starting databases..."
-	docker-compose up -d postgres mysql mariadb
+	docker compose up -d postgres mysql mariadb
 
 # Stop databases
 db-stop:
 	@echo "Stopping databases..."
-	docker-compose down
+	docker compose down
 
 # View database logs
 db-logs:
 	@echo "Showing database logs..."
-	docker-compose logs -f postgres mysql mariadb
+	docker compose logs -f postgres mysql mariadb
 
 # Clean up Docker resources
 docker-clean:
 	@echo "Cleaning up Docker resources..."
-	docker-compose down -v
+	docker compose down -v
 	docker system prune -f
 
 # Clean build artifacts
@@ -115,7 +115,7 @@ dev-setup: db-start
 # Run a quick smoke test
 smoke-test: docker-build
 	@echo "Running smoke test..."
-	docker-compose --profile test run --rm ptah-tester \
+	docker compose --profile test run --rm ptah-tester \
 		--scenarios=apply_incremental_migrations,check_current_version \
 		--databases=postgres --report=txt
 
@@ -150,23 +150,23 @@ docker-help:
 	@echo "============================================="
 	@echo ""
 	@echo "Basic usage:"
-	@echo "  docker-compose --profile test run --rm ptah-tester [OPTIONS]"
+	@echo "  docker compose --profile test run --rm ptah-tester [OPTIONS]"
 	@echo ""
 	@echo "Examples:"
 	@echo "  # Run all tests with HTML report"
-	@echo "  docker-compose --profile test run --rm ptah-tester --report=html"
+	@echo "  docker compose --profile test run --rm ptah-tester --report=html"
 	@echo ""
 	@echo "  # Run specific scenarios"
-	@echo "  docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations"
+	@echo "  docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations"
 	@echo ""
 	@echo "  # Test specific database"
-	@echo "  docker-compose --profile test run --rm ptah-tester --databases=postgres"
+	@echo "  docker compose --profile test run --rm ptah-tester --databases=postgres"
 	@echo ""
 	@echo "  # Generate JSON report"
-	@echo "  docker-compose --profile test run --rm ptah-tester --report=json"
+	@echo "  docker compose --profile test run --rm ptah-tester --report=json"
 	@echo ""
 	@echo "  # Verbose output"
-	@echo "  docker-compose --profile test run --rm ptah-tester --verbose"
+	@echo "  docker compose --profile test run --rm ptah-tester --verbose"
 	@echo ""
 	@echo "Available options:"
 	@echo "  --report FORMAT     Report format: txt, json, html (default: txt)"

--- a/README-TESTING.md
+++ b/README-TESTING.md
@@ -73,7 +73,7 @@ go test -C core/renderer -run "TestNewVisitorMethods_UnitTests" -v
    ```powershell
    # Check Docker status
    docker --version
-   docker-compose --version
+   docker compose --version
    ```
 
 2. **Tests not showing detailed output:**
@@ -88,10 +88,10 @@ go test -C core/renderer -run "TestNewVisitorMethods_UnitTests" -v
 3. **Database connection issues:**
    ```powershell
    # Check database health
-   docker-compose ps
+   docker compose ps
    
    # View database logs
-   docker-compose logs postgres mysql mariadb
+   docker compose logs postgres mysql mariadb
    ```
 
 4. **PowerShell coloring issues:**

--- a/TEST-RUNNER.md
+++ b/TEST-RUNNER.md
@@ -116,7 +116,7 @@ Timeout: 10 minutes
 
 [STEP] Checking prerequisites...
 [OK] Go found: go version go1.24.3 windows/amd64
-[OK] Docker and docker-compose found
+[OK] Docker and Docker Compose found
 
 [STEP] Starting databases (PostgreSQL, MySQL, MariaDB)...
 [STEP] Waiting for databases to be healthy...
@@ -163,7 +163,7 @@ Total duration: 02:30
    ```bash
    # Check Docker status
    docker --version
-   docker-compose --version
+   docker compose --version
    ```
 
 2. **Permission issues (Linux/macOS):**

--- a/TESTING.md
+++ b/TESTING.md
@@ -154,13 +154,13 @@ Connection details:
 ```powershell
 # Check Docker status
 docker --version
-docker-compose --version
+docker compose --version
 
 # View database logs
-docker-compose logs postgres mysql mariadb
+docker compose logs postgres mysql mariadb
 
 # Clean up containers
-docker-compose down -v
+docker compose down -v
 ```
 
 ### Test Failures

--- a/docker-compose.override.yaml.example
+++ b/docker-compose.override.yaml.example
@@ -12,7 +12,7 @@
 # Usage:
 #   1. Copy this file: cp docker-compose.override.yaml.example docker-compose.override.yaml
 #   2. Customize the settings below for your local environment
-#   3. Run: docker-compose up -d
+#   3. Run: docker compose up -d
 #
 # Note: docker-compose.override.yaml is ignored by git, so your local changes won't be committed.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ptah_user -d ptah_test"]
       interval: 5s
@@ -26,7 +26,6 @@ services:
       - "3310:3306"
     volumes:
       - mysql_data:/var/lib/mysql
-    command: --default-authentication-plugin=mysql_native_password
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "ptah_user", "-pptah_password"]
       interval: 5s
@@ -57,9 +56,6 @@ services:
       CLICKHOUSE_USER: ptah_user
       CLICKHOUSE_PASSWORD: ptah_password
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    ports:
-      - "8123:8123"
-      - "9000:9000"
     ulimits:
       nofile:
         soft: 262144

--- a/docs/POSTGRESQL_ROLES.md
+++ b/docs/POSTGRESQL_ROLES.md
@@ -234,10 +234,10 @@ Use the integration test framework to verify role functionality:
 
 ```bash
 # Test PostgreSQL role scenarios
-docker-compose --profile test run --rm ptah-tester --scenarios=dynamic_roles_basic,dynamic_roles_advanced --databases=postgres
+docker compose --profile test run --rm ptah-tester --scenarios=dynamic_roles_basic,dynamic_roles_advanced --databases=postgres
 
 # Test cross-database compatibility
-docker-compose --profile test run --rm ptah-tester --scenarios=dynamic_roles_cross_database
+docker compose --profile test run --rm ptah-tester --scenarios=dynamic_roles_cross_database
 ```
 
 ## Troubleshooting
@@ -254,7 +254,7 @@ Enable verbose logging to see generated SQL statements:
 
 ```bash
 # Run with verbose output to see role creation SQL
-docker-compose --profile test run --rm ptah-tester --verbose --scenarios=dynamic_roles_basic
+docker compose --profile test run --rm ptah-tester --verbose --scenarios=dynamic_roles_basic
 ```
 
 ## Examples

--- a/integration/DYNAMIC_TESTING.md
+++ b/integration/DYNAMIC_TESTING.md
@@ -123,13 +123,13 @@ The dynamic scenarios are automatically included in all test runs:
 
 ```bash
 # Run all tests (includes dynamic scenarios)
-docker-compose --profile test run --rm ptah-tester
+docker compose --profile test run --rm ptah-tester
 
 # Run only dynamic scenarios
-docker-compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution,dynamic_idempotency
+docker compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution,dynamic_idempotency
 
 # Run specific dynamic scenario
-docker-compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution --databases=postgres
+docker compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution --databases=postgres
 ```
 
 ## Benefits Over Static Migrations

--- a/integration/README.md
+++ b/integration/README.md
@@ -67,16 +67,16 @@ All integration tests are designed to run using Docker Compose, which provides i
 
 ```bash
 # Run all tests with default settings (text report)
-docker-compose --profile test run --rm ptah-tester
+docker compose --profile test run --rm ptah-tester
 
 # Run with HTML report (recommended for detailed analysis)
-docker-compose --profile test run --rm ptah-tester --report=html
+docker compose --profile test run --rm ptah-tester --report=html
 
 # Run with JSON report (good for CI/CD integration)
-docker-compose --profile test run --rm ptah-tester --report=json
+docker compose --profile test run --rm ptah-tester --report=json
 
 # Enable verbose output for debugging
-docker-compose --profile test run --rm ptah-tester --verbose
+docker compose --profile test run --rm ptah-tester --verbose
 ```
 
 ### Listing Available Scenarios
@@ -85,16 +85,16 @@ Before running tests, you can list all available scenarios to see what's availab
 
 ```bash
 # List all scenarios (both static and dynamic)
-docker-compose --profile test run --rm ptah-tester list
+docker compose --profile test run --rm ptah-tester list
 
 # List only static scenarios (basic functionality tests)
-docker-compose --profile test run --rm ptah-tester list --static
+docker compose --profile test run --rm ptah-tester list --static
 
 # List only dynamic scenarios (versioned entity evolution tests)
-docker-compose --profile test run --rm ptah-tester list --dynamic
+docker compose --profile test run --rm ptah-tester list --dynamic
 
 # Show help for the list command
-docker-compose --profile test run --rm ptah-tester list --help
+docker compose --profile test run --rm ptah-tester list --help
 ```
 
 The list command displays:
@@ -106,48 +106,48 @@ The list command displays:
 
 ```bash
 # Run specific scenarios only
-docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations
+docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,rollback_migrations
 
 # Run basic functionality tests
-docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,upgrade_to_specific_version,check_current_version
+docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations,upgrade_to_specific_version,check_current_version
 
 # Run idempotency tests
-docker-compose --profile test run --rm ptah-tester --scenarios=idempotency_reapply,idempotency_up_to_date
+docker compose --profile test run --rm ptah-tester --scenarios=idempotency_reapply,idempotency_up_to_date
 
 # Run failure recovery tests
-docker-compose --profile test run --rm ptah-tester --scenarios=failure_diagnostics,partial_failure_recovery
+docker compose --profile test run --rm ptah-tester --scenarios=failure_diagnostics,partial_failure_recovery
 
 # Run dynamic scenarios for schema evolution testing
-docker-compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution,dynamic_rollback_single
+docker compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution,dynamic_rollback_single
 ```
 
 ### Database Selection
 
 ```bash
 # Test against PostgreSQL only
-docker-compose --profile test run --rm ptah-tester --databases=postgres
+docker compose --profile test run --rm ptah-tester --databases=postgres
 
 # Test against MySQL only
-docker-compose --profile test run --rm ptah-tester --databases=mysql
+docker compose --profile test run --rm ptah-tester --databases=mysql
 
 # Test against MariaDB only
-docker-compose --profile test run --rm ptah-tester --databases=mariadb
+docker compose --profile test run --rm ptah-tester --databases=mariadb
 
 # Test against specific combination
-docker-compose --profile test run --rm ptah-tester --databases=postgres,mysql
+docker compose --profile test run --rm ptah-tester --databases=postgres,mysql
 ```
 
 ### Combined Options
 
 ```bash
 # Comprehensive test with detailed reporting
-docker-compose --profile test run --rm ptah-tester --report=html --verbose
+docker compose --profile test run --rm ptah-tester --report=html --verbose
 
 # Quick smoke test
-docker-compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres --report=txt
+docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres --report=txt
 
 # CI/CD friendly execution
-docker-compose --profile test run --rm ptah-tester --report=json --databases=postgres,mysql,mariadb
+docker compose --profile test run --rm ptah-tester --report=json --databases=postgres,mysql,mariadb
 ```
 
 ## Command Line Options
@@ -195,7 +195,7 @@ Rich, interactive report with:
 ### MySQL
 - Version: 8+
 - Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
-- Authentication: `mysql_native_password`
+- Authentication: default MySQL authentication (`caching_sha2_password` on current MySQL images)
 
 ### MariaDB
 - Version: 10.11+
@@ -226,12 +226,12 @@ The integration tests are designed to run in CI/CD environments using Docker Com
 # Example GitHub Actions workflow
 - name: Run Integration Tests
   run: |
-    docker-compose --profile test run --rm ptah-tester --report=json
+    docker compose --profile test run --rm ptah-tester --report=json
 
 # Example GitLab CI
 test:integration:
   script:
-    - docker-compose --profile test run --rm ptah-tester --report=json
+    - docker compose --profile test run --rm ptah-tester --report=json
   artifacts:
     reports:
       junit: integration/reports/*.json
@@ -239,7 +239,7 @@ test:integration:
 # Example with specific database testing
 test:postgres:
   script:
-    - docker-compose --profile test run --rm ptah-tester --databases=postgres --report=json
+    - docker compose --profile test run --rm ptah-tester --databases=postgres --report=json
 ```
 
 ## Troubleshooting

--- a/test-ptah.ps1
+++ b/test-ptah.ps1
@@ -550,10 +550,10 @@ function Test-Prerequisites {
     if (-not $UnitOnly) {
         try {
             docker --version | Out-Null
-            docker-compose --version | Out-Null
-            Write-Success "Docker and docker-compose found"
+            docker compose --version | Out-Null
+            Write-Success "Docker and Docker Compose found"
         } catch {
-            Write-Error "Docker or docker-compose not found. Please install Docker Desktop."
+            Write-Error "Docker or Docker Compose not found. Please install Docker Desktop."
             exit 1
         }
     }
@@ -566,7 +566,7 @@ function Start-Databases {
     }
 
     Write-Step "Starting databases (PostgreSQL, MySQL, MariaDB)..."
-    docker-compose up -d postgres mysql mariadb
+    docker compose up -d postgres mysql mariadb
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to start databases"
         exit 1
@@ -582,7 +582,7 @@ function Start-Databases {
         $waited += $interval
         
         try {
-            $status = docker-compose ps --format json | ConvertFrom-Json
+            $status = docker compose ps --format json | ConvertFrom-Json
             $healthy = $true
             
             foreach ($service in $status) {
@@ -608,7 +608,7 @@ function Start-Databases {
             Write-Host ""
             Write-Error "Timeout waiting for databases to be healthy"
             Write-Warning "Database logs:"
-            docker-compose logs --tail=20 postgres mysql mariadb
+            docker compose logs --tail=20 postgres mysql mariadb
             exit 1
         }
     } while ($true)
@@ -630,7 +630,7 @@ function Set-TestEnvironment {
 function Stop-Databases {
     if ($UnitOnly -or $KeepDatabases) {
         if ($KeepDatabases) {
-            Write-Warning "Keeping databases running (use 'docker-compose down' to stop them)"
+            Write-Warning "Keeping databases running (use 'docker compose down' to stop them)"
             Write-Host "Database connections:" -ForegroundColor Yellow
             foreach ($key in $DatabaseConnections.Keys) {
                 Write-Host "  $key = $($DatabaseConnections[$key])" -ForegroundColor Gray
@@ -640,7 +640,7 @@ function Stop-Databases {
     }
 
     Write-Step "Stopping and removing databases..."
-    docker-compose down
+    docker compose down
     if ($LASTEXITCODE -eq 0) {
         Write-Success "Databases stopped and removed"
     } else {

--- a/test-ptah.sh
+++ b/test-ptah.sh
@@ -233,11 +233,11 @@ function check_prerequisites() {
     
     # Check Docker (only if not unit-only)
     if [ "$UNIT_ONLY" != "true" ]; then
-        if ! command -v docker &> /dev/null || ! command -v docker-compose &> /dev/null; then
-            print_error "Docker or docker-compose not found. Please install Docker."
+        if ! command -v docker &> /dev/null || ! docker compose version &> /dev/null; then
+            print_error "Docker or Docker Compose not found. Please install Docker."
             exit 1
         fi
-        print_success "Docker and docker-compose found"
+        print_success "Docker and Docker Compose found"
     fi
 }
 
@@ -248,7 +248,7 @@ function start_databases() {
     fi
     
     print_step "Starting databases (PostgreSQL, MySQL, MariaDB)..."
-    docker-compose up -d postgres mysql mariadb
+    docker compose up -d postgres mysql mariadb
     
     print_step "Waiting for databases to be healthy..."
     local max_wait=60
@@ -260,7 +260,7 @@ function start_databases() {
         waited=$((waited + interval))
         
         # Check if all databases are healthy
-        local status=$(docker-compose ps --format json 2>/dev/null || echo "[]")
+        local status=$(docker compose ps --format json 2>/dev/null || echo "[]")
         
         if [ "$status" != "[]" ]; then
             # Simple check - if containers are running, assume healthy after initial wait
@@ -284,7 +284,7 @@ function start_databases() {
 function stop_databases() {
     if [ "$UNIT_ONLY" = "true" ] || [ "$KEEP_DATABASES" = "true" ]; then
         if [ "$KEEP_DATABASES" = "true" ]; then
-            print_warning "Keeping databases running (use 'docker-compose down' to stop them)"
+            print_warning "Keeping databases running (use 'docker compose down' to stop them)"
             echo -e "${YELLOW}Database connections:${NC}"
             echo "  POSTGRES_TEST_DSN = $POSTGRES_TEST_DSN"
             echo "  MYSQL_TEST_DSN = $MYSQL_TEST_DSN"
@@ -294,7 +294,7 @@ function stop_databases() {
     fi
     
     print_step "Stopping and removing databases..."
-    docker-compose down
+    docker compose down
     if [ $? -eq 0 ]; then
         print_success "Databases stopped and removed"
     else


### PR DESCRIPTION
Closes #227.

## What changed

- Removed the obsolete MySQL startup option `--default-authentication-plugin=mysql_native_password` from the local compose service. MySQL 9.7 rejects that removed variable and now boots with the image default authentication.
- Replaced local `docker-compose` v1 invocations with `docker compose` v2 across the Makefile, helper scripts, and related documentation.
- Updated the PostgreSQL 18 local volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`, matching the current Docker image layout.
- Stopped publishing the local ClickHouse `8123` and `9000` host ports. The integration runner connects to `clickhouse:9000` on the compose network, so host publishing only creates avoidable conflicts with other local ClickHouse stacks.
- Updated integration docs to stop referring to `mysql_native_password` as the expected MySQL authentication mode.

## Why

The local Docker test environment had drifted from the image/tooling versions it now uses:

- MySQL 9.x no longer accepts the old authentication plugin option.
- Compose v1 is EOL and fails on modern Python environments.
- PostgreSQL 18 Docker images expect data below `/var/lib/postgresql` so the image can manage versioned data directories.
- The ClickHouse service does not need host-published ports for the existing test runner.

## Verification

- `git diff --check`
- `docker compose config --quiet`
- `rg --pcre2 "docker-compose(?!\\.yaml|\\.override\\.yaml)|mysql_native_password|default-authentication-plugin" -S .` returns no command/config matches
- `docker compose down -v`
- `make db-start` with PostgreSQL, MySQL, and MariaDB all healthy
- `make integration-test-mysql` - 60/60 passed
- `make integration-test-mariadb` - 60/60 passed
- `make db-stop`