### PR TITLE
Feat(capability): dialect capability sets — registry, validation, presets + planner/renderer adoption (#225, #226)

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -374,6 +374,12 @@ type IndexNode struct {
 	Condition string
 	// Operator specifies the operator class (gin_trgm_ops, etc.)
 	Operator string
+	// Concurrently requests CREATE INDEX CONCURRENTLY, PostgreSQL's
+	// non-locking index build. Set by planners only when the target
+	// capability set includes capability.CreateIndexConcurrently and the
+	// caller opted into concurrent builds (they cannot run inside a
+	// transaction block). Ignored by non-PostgreSQL renderers.
+	Concurrently bool
 
 	// ClickHouse-specific features
 	// Granularity is the GRANULARITY value for data-skipping indexes. Zero

--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -115,6 +115,13 @@ type DropConstraintOperation struct {
 	// constraints. Ignored when ForeignKey is set; renderers where the generic
 	// clause always exists (PostgreSQL) may ignore it entirely.
 	Check bool
+	// Unique requests the `DROP INDEX <name>` spelling for a UNIQUE
+	// constraint (dropping its backing index), which is valid across the
+	// entire MySQL/MariaDB family. Planners set it for UNIQUE removals on
+	// targets without the generic DROP CONSTRAINT clause (MySQL < 8.0.19),
+	// where the generic spelling would be invalid SQL. Ignored when
+	// ForeignKey or Check is set; PostgreSQL-style renderers may ignore it.
+	Unique bool
 }
 
 // Accept implements the Node interface for DropConstraintOperation.

--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -108,6 +108,13 @@ type DropConstraintOperation struct {
 	// two read this flag. Renderers where DROP CONSTRAINT already covers foreign
 	// keys (PostgreSQL) may ignore it.
 	ForeignKey bool
+	// Check requests the dedicated `DROP CHECK <name>` spelling instead of the
+	// generic `DROP CONSTRAINT <name>`. MySQL 8.0.16–8.0.18 accept only the
+	// former (the generic clause arrived in 8.0.19), so planners targeting a
+	// capability set without drop_constraint_generic set this for CHECK
+	// constraints. Ignored when ForeignKey is set; renderers where the generic
+	// clause always exists (PostgreSQL) may ignore it entirely.
+	Check bool
 }
 
 // Accept implements the Node interface for DropConstraintOperation.

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -1,0 +1,482 @@
+// Package capability models what a concrete database target (a dialect plus
+// a version line) can accept, as a validated set of feature flags.
+//
+// Ptah maps several real targets onto one implementation: MySQL and MariaDB
+// share a planner and a renderer, and versions within one dialect differ in
+// what DDL they accept (MySQL gained generic DROP CONSTRAINT in 8.0.19,
+// enforced CHECK constraints in 8.0.16; IF EXISTS on constraint drops is
+// MariaDB-only; and so on). Encoding each variant as a separate dialect would
+// multiply planners and renderers; instead, planners and renderers consult a
+// capability set and restrict or enable individual emissions per target
+// (issues #225/#226).
+//
+// # Model
+//
+// A Capability is a named feature flag from a curated registry — free-form
+// keys are rejected by Validate. A Capabilities value is a plain
+// map[Capability]bool set. The nil set is valid and behaves conservatively:
+// Has reports false for everything, so consumers fall back to the most
+// compatible emission.
+//
+// Some capabilities relate to each other: a capability may require another
+// (IF EXISTS on constraint drops presupposes the generic DROP CONSTRAINT
+// statement), and some are mutually exclusive by construction of the SQL
+// model (a dialect models enums either inline in the column type or as a
+// separate named type, never both). Validate enforces both rule kinds.
+//
+// # Presets
+//
+// Presets describe the current supported version lines. Compose from a preset
+// with With rather than building sets by hand:
+//
+//	caps := capability.MariaDB1011().With(capability.DropIndexIfExists, false)
+//	if err := caps.Validate(); err != nil { ... }
+//
+// ForDialect resolves the default preset for a normalized dialect name;
+// ForServerVersion refines that using a live server version string (e.g. the
+// result of SELECT version()).
+package capability
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+// Capability is a single named feature flag from the curated registry below.
+type Capability string
+
+const (
+	// DropConstraintGeneric marks support for the SQL-standard
+	// ALTER TABLE ... DROP CONSTRAINT <name> clause for non-FK constraints.
+	// MySQL gained it in 8.0.19; MariaDB has it on all supported lines.
+	// Without it, a CHECK constraint drop must use ALTER TABLE ... DROP CHECK
+	// (MySQL 8.0.16–8.0.18) and UNIQUE drops must use DROP INDEX.
+	DropConstraintGeneric Capability = "drop_constraint_generic"
+
+	// DropConstraintIfExists marks support for the IF EXISTS guard on
+	// constraint drops (ALTER TABLE ... DROP CONSTRAINT IF EXISTS ... and
+	// ALTER TABLE ... DROP FOREIGN KEY IF EXISTS ...). MariaDB-only within
+	// the MySQL family; MySQL 8/9 reject it. PostgreSQL supports it.
+	// Requires DropConstraintGeneric.
+	DropConstraintIfExists Capability = "drop_constraint_if_exists"
+
+	// DropIndexIfExists marks support for the IF EXISTS guard on DROP INDEX
+	// (MariaDB 10.1.4+: DROP INDEX IF EXISTS <name> ON <table>; PostgreSQL:
+	// DROP INDEX IF EXISTS <name>). MySQL has no such form.
+	DropIndexIfExists Capability = "drop_index_if_exists"
+
+	// CheckConstraintsEnforced marks targets that actually enforce CHECK
+	// constraints. MySQL parsed-and-ignored CHECK before 8.0.16; MariaDB
+	// enforces from 10.2.1; PostgreSQL always enforces. When absent, emitting
+	// an ADD CONSTRAINT ... CHECK would silently do nothing on the target, so
+	// planners surface a warning instead.
+	CheckConstraintsEnforced Capability = "check_constraints_enforced"
+
+	// DropCheckClause marks support for the dedicated
+	// ALTER TABLE ... DROP CHECK <name> spelling (MySQL 8.0.16+, including
+	// the 9.x line). MariaDB does NOT accept it (verified live on 10.11) —
+	// its CHECK drops go through the generic DROP CONSTRAINT clause.
+	// Planners request the spelling via DropConstraintOperation.Check for
+	// targets that lack DropConstraintGeneric; renderers resolve the final
+	// spelling against their own set, so a stray Check flag reaching a
+	// MariaDB renderer degrades safely to the generic clause. Requires
+	// CheckConstraintsEnforced (a server without enforced CHECKs has nothing
+	// to drop).
+	DropCheckClause Capability = "drop_check_clause"
+
+	// EnumInlineColumn marks dialects whose enums live inline in the column
+	// definition (MySQL/MariaDB ENUM(...), ClickHouse Enum8/Enum16).
+	// Mutually exclusive with EnumCustomType.
+	EnumInlineColumn Capability = "enum_inline_column"
+
+	// EnumCustomType marks dialects whose enums are separate named types
+	// (PostgreSQL CREATE TYPE ... AS ENUM). Mutually exclusive with
+	// EnumInlineColumn.
+	EnumCustomType Capability = "enum_custom_type"
+
+	// CreateIndexConcurrently marks support for PostgreSQL's non-locking
+	// CREATE [UNIQUE] INDEX CONCURRENTLY build. Postgres-compatible engines
+	// differ here: CockroachDB only parses the keyword as a compatibility
+	// no-op (its schema changes are online by design), so a future preset
+	// for it would disable this capability rather than pretend the keyword
+	// changes behavior (issue #171).
+	CreateIndexConcurrently Capability = "create_index_concurrently"
+
+	// CreateOrReplaceTrigger marks support for CREATE OR REPLACE TRIGGER
+	// (PostgreSQL 14+, MariaDB 10.1.4+; MySQL has no OR REPLACE for
+	// triggers). No in-tree consumer yet — reserved for the trigger work in
+	// issue #158; version presets already gate it.
+	CreateOrReplaceTrigger Capability = "create_or_replace_trigger"
+
+	// RowLevelSecurity marks support for row-level security policies
+	// (PostgreSQL ALTER TABLE ... ENABLE ROW LEVEL SECURITY + CREATE POLICY).
+	RowLevelSecurity Capability = "row_level_security"
+)
+
+// spec documents a registry entry and its implication edges.
+type spec struct {
+	doc string
+	// requires lists capabilities that must also be enabled whenever this
+	// one is enabled; Validate rejects sets that violate an edge.
+	requires []Capability
+}
+
+// registry is the curated set of known capabilities. Validate rejects any
+// key not present here, so typos fail fast instead of silently reading as
+// "capability absent".
+var registry = map[Capability]spec{
+	DropConstraintGeneric: {
+		doc: "SQL-standard ALTER TABLE ... DROP CONSTRAINT for non-FK constraints (MySQL 8.0.19+, MariaDB, PostgreSQL)",
+	},
+	DropConstraintIfExists: {
+		doc:      "IF EXISTS guard on constraint drops (MariaDB, PostgreSQL; rejected by MySQL)",
+		requires: []Capability{DropConstraintGeneric},
+	},
+	DropIndexIfExists: {
+		doc: "IF EXISTS guard on DROP INDEX (MariaDB 10.1.4+, PostgreSQL; rejected by MySQL)",
+	},
+	CheckConstraintsEnforced: {
+		doc: "CHECK constraints are enforced, not parsed-and-ignored (MySQL 8.0.16+, MariaDB 10.2.1+, PostgreSQL)",
+	},
+	DropCheckClause: {
+		doc:      "dedicated ALTER TABLE ... DROP CHECK spelling (MySQL 8.0.16+; NOT MariaDB — verified live)",
+		requires: []Capability{CheckConstraintsEnforced},
+	},
+	EnumInlineColumn: {
+		doc: "enums are inline column types (MySQL/MariaDB ENUM, ClickHouse Enum8/16)",
+	},
+	EnumCustomType: {
+		doc: "enums are separate named types (PostgreSQL CREATE TYPE ... AS ENUM)",
+	},
+	CreateIndexConcurrently: {
+		doc: "CREATE [UNIQUE] INDEX CONCURRENTLY (PostgreSQL; a compatibility no-op on CockroachDB)",
+	},
+	CreateOrReplaceTrigger: {
+		doc: "CREATE OR REPLACE TRIGGER (PostgreSQL 14+, MariaDB; not MySQL)",
+	},
+	RowLevelSecurity: {
+		doc: "row-level security policies (PostgreSQL)",
+	},
+}
+
+// mutexGroups lists capability groups in which AT MOST ONE member may be
+// enabled: they describe mutually exclusive modelings of the same concept.
+var mutexGroups = [][]Capability{
+	{EnumInlineColumn, EnumCustomType},
+}
+
+// Capabilities is a set of feature flags describing one concrete target, as
+// map[Capability]bool. The nil set is valid and conservative (Has always
+// reports false). Presets in this package enumerate every registry key
+// explicitly; hand-built sets should be checked with Validate.
+type Capabilities map[Capability]bool
+
+// Has reports whether the capability is present AND enabled. It is nil-safe:
+// a nil set has nothing, which is the conservative reading consumers rely on.
+func (c Capabilities) Has(key Capability) bool {
+	return c != nil && c[key]
+}
+
+// Clone returns an independent copy of the set (nil stays nil).
+func (c Capabilities) Clone() Capabilities {
+	if c == nil {
+		return nil
+	}
+	out := make(Capabilities, len(c))
+	maps.Copy(out, c)
+	return out
+}
+
+// With returns a copy of the set with one capability overridden. The receiver
+// is never mutated, so presets can be composed safely:
+//
+//	caps := capability.Postgres16().With(capability.CreateIndexConcurrently, false)
+func (c Capabilities) With(key Capability, enabled bool) Capabilities {
+	out := c.Clone()
+	if out == nil {
+		out = make(Capabilities, 1)
+	}
+	out[key] = enabled
+	return out
+}
+
+// Validate checks the set against the registry:
+//
+//   - every key must be a known, registered capability (typos fail fast);
+//   - every enabled capability's requirements must also be enabled (e.g.
+//     DropConstraintIfExists requires DropConstraintGeneric — an IF EXISTS
+//     variant of a statement the target does not have is a contradiction);
+//   - within each mutual-exclusion group at most one member may be enabled
+//     (e.g. a dialect models enums inline OR as custom types, never both).
+//
+// A nil or empty set is valid.
+func (c Capabilities) Validate() error {
+	for key := range c {
+		if _, known := registry[key]; !known {
+			return fmt.Errorf("unknown capability %q", key)
+		}
+	}
+	for key, enabled := range c {
+		if !enabled {
+			continue
+		}
+		for _, req := range registry[key].requires {
+			if !c.Has(req) {
+				return fmt.Errorf("capability %q requires %q, which is not enabled", key, req)
+			}
+		}
+	}
+	for _, group := range mutexGroups {
+		var enabled []string
+		for _, key := range group {
+			if c.Has(key) {
+				enabled = append(enabled, string(key))
+			}
+		}
+		if len(enabled) > 1 {
+			return fmt.Errorf("capabilities %s are mutually exclusive", strings.Join(enabled, " and "))
+		}
+	}
+	return nil
+}
+
+// Doc returns the registry documentation line for a capability (empty for
+// unknown keys).
+func Doc(key Capability) string {
+	return registry[key].doc
+}
+
+// All returns every registered capability. The order is unspecified; sort
+// before rendering user-facing output.
+func All() []Capability {
+	out := make([]Capability, 0, len(registry))
+	for key := range registry {
+		out = append(out, key)
+	}
+	return out
+}
+
+// MySQL80 is the preset for the current MySQL line: 8.0.19+ and the 9.x
+// releases, which share these capabilities. Notably NO IF EXISTS on
+// constraint or index drops — plans must be exactly-once by construction
+// (see the MySQL planner's constraint-drop ownership rules, issue #207).
+func MySQL80() Capabilities {
+	return Capabilities{
+		DropConstraintGeneric:    true,
+		DropConstraintIfExists:   false,
+		DropIndexIfExists:        false,
+		CheckConstraintsEnforced: true,
+		DropCheckClause:          true,
+		EnumInlineColumn:         true,
+		EnumCustomType:           false,
+		CreateIndexConcurrently:  false,
+		CreateOrReplaceTrigger:   false,
+		RowLevelSecurity:         false,
+	}
+}
+
+// MySQL8016 is the preset for MySQL 8.0.16–8.0.18: CHECK constraints are
+// enforced, but the generic DROP CONSTRAINT clause does not exist yet (CHECK
+// drops must use ALTER TABLE ... DROP CHECK).
+func MySQL8016() Capabilities {
+	return MySQL80().With(DropConstraintGeneric, false)
+}
+
+// MySQLLegacy is the preset for MySQL before 8.0.16: no generic
+// DROP CONSTRAINT, no DROP CHECK, and CHECK constraints are parsed but not
+// enforced.
+func MySQLLegacy() Capabilities {
+	return MySQL8016().
+		With(CheckConstraintsEnforced, false).
+		With(DropCheckClause, false)
+}
+
+// MariaDB1011 is the preset for the current MariaDB LTS line (10.6+ /
+// 10.11 / 11.x share these): IF EXISTS guards are available on both
+// constraint and index drops.
+func MariaDB1011() Capabilities {
+	return Capabilities{
+		DropConstraintGeneric:    true,
+		DropConstraintIfExists:   true,
+		DropIndexIfExists:        true,
+		CheckConstraintsEnforced: true,
+		DropCheckClause:          false,
+		EnumInlineColumn:         true,
+		EnumCustomType:           false,
+		CreateIndexConcurrently:  false,
+		CreateOrReplaceTrigger:   true,
+		RowLevelSecurity:         false,
+	}
+}
+
+// MariaDBLegacy is the conservative preset for MariaDB before 10.2 (EOL
+// lines): no generic DROP CONSTRAINT, no enforced CHECK constraints, and no
+// IF EXISTS guards are assumed (a floor, deliberately below what late 10.1
+// releases could do). ForServerVersion maps pre-10.2 version strings here so
+// a modern preset is never over-promised to an old server.
+func MariaDBLegacy() Capabilities {
+	return MariaDB1011().
+		With(DropConstraintGeneric, false).
+		With(DropConstraintIfExists, false).
+		With(DropIndexIfExists, false).
+		With(CheckConstraintsEnforced, false).
+		With(CreateOrReplaceTrigger, false)
+}
+
+// Postgres16 is the preset for PostgreSQL 14+ (14/15/16/17 share these).
+func Postgres16() Capabilities {
+	return Capabilities{
+		DropConstraintGeneric:    true,
+		DropConstraintIfExists:   true,
+		DropIndexIfExists:        true,
+		CheckConstraintsEnforced: true,
+		DropCheckClause:          false,
+		EnumInlineColumn:         false,
+		EnumCustomType:           true,
+		CreateIndexConcurrently:  true,
+		CreateOrReplaceTrigger:   true,
+		RowLevelSecurity:         true,
+	}
+}
+
+// Postgres13 is the preset for PostgreSQL 12–13: identical to Postgres16
+// except CREATE OR REPLACE TRIGGER, which arrived in PostgreSQL 14.
+func Postgres13() Capabilities {
+	return Postgres16().With(CreateOrReplaceTrigger, false)
+}
+
+// ClickHouse24 is the preset for the ClickHouse 24.x line. It is deliberately
+// minimal: ClickHouse models constraints and indexes so differently that the
+// shared capability gates mostly do not apply; enums are inline column types
+// (Enum8/Enum16).
+func ClickHouse24() Capabilities {
+	return Capabilities{
+		DropConstraintGeneric:    false,
+		DropConstraintIfExists:   false,
+		DropIndexIfExists:        false,
+		CheckConstraintsEnforced: false,
+		DropCheckClause:          false,
+		EnumInlineColumn:         true,
+		EnumCustomType:           false,
+		CreateIndexConcurrently:  false,
+		CreateOrReplaceTrigger:   false,
+		RowLevelSecurity:         false,
+	}
+}
+
+// ForDialect returns the default preset for a dialect name (normalized via
+// platform.NormalizeDialect): the current supported version line of that
+// dialect. Unknown dialects get nil — the conservative empty set.
+func ForDialect(dialect string) Capabilities {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres:
+		return Postgres16()
+	case platform.MySQL:
+		return MySQL80()
+	case platform.MariaDB:
+		return MariaDB1011()
+	case platform.ClickHouse:
+		return ClickHouse24()
+	default:
+		return nil
+	}
+}
+
+// ForServerVersion refines ForDialect using a live server version string —
+// typically the result of SELECT version() — so callers can map a concrete
+// server to the closest preset at connect time. Recognized shapes include
+// "8.0.42", "8.0.42-log", "10.11.6-MariaDB-1:10.11.6+maria~ubu2204",
+// "5.5.5-10.11.6-MariaDB" (the replication-protocol prefix MariaDB reports
+// over the MySQL protocol) and "PostgreSQL 16.3 (Debian ...)". When the
+// version cannot be parsed, the dialect's default preset is returned.
+func ForServerVersion(dialect, version string) Capabilities {
+	normalized := platform.NormalizeDialect(dialect)
+
+	// MariaDB announces itself in the version string even when connected via
+	// the mysql dialect/driver; trust the string over the declared dialect.
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return mariaDBForVersion(version)
+	}
+
+	v, ok := parseVersion(version)
+	if !ok {
+		return ForDialect(dialect)
+	}
+
+	switch normalized {
+	case platform.MySQL:
+		switch {
+		case v.major > 8 || (v.major == 8 && (v.minor > 0 || v.patch >= 19)):
+			return MySQL80()
+		case v.major == 8 && v.patch >= 16:
+			return MySQL8016()
+		default:
+			return MySQLLegacy()
+		}
+	case platform.MariaDB:
+		return mariaDBForVersion(version)
+	case platform.Postgres:
+		if v.major >= 14 {
+			return Postgres16()
+		}
+		return Postgres13()
+	default:
+		return ForDialect(dialect)
+	}
+}
+
+// mariaDBForVersion picks the MariaDB preset for a server version string.
+// MariaDB servers speaking the MySQL protocol prepend a fake "5.5.5-"
+// replication-compatibility prefix ("5.5.5-10.11.6-MariaDB"); that prefix is
+// stripped before parsing so the REAL version decides. 10.2+ gets the modern
+// preset (generic DROP CONSTRAINT, enforced CHECKs, IF EXISTS guards);
+// anything older — or an unparseable string — degrades to MariaDBLegacy /
+// the modern preset respectively.
+func mariaDBForVersion(version string) Capabilities {
+	trimmed := strings.TrimPrefix(version, "5.5.5-")
+	v, ok := parseVersion(trimmed)
+	if !ok {
+		return MariaDB1011()
+	}
+	if v.major > 10 || (v.major == 10 && v.minor >= 2) {
+		return MariaDB1011()
+	}
+	return MariaDBLegacy()
+}
+
+// serverVersion is a parsed dotted server version.
+type serverVersion struct {
+	major, minor, patch int
+}
+
+// parseVersion extracts the first dotted numeric version from a server
+// version string. It tolerates prefixes ("PostgreSQL 16.3") and suffixes
+// ("8.0.42-log"); missing minor/patch components default to zero.
+func parseVersion(s string) (serverVersion, bool) {
+	i := 0
+	for i < len(s) && (s[i] < '0' || s[i] > '9') {
+		i++
+	}
+	if i == len(s) {
+		return serverVersion{}, false
+	}
+	nums := [3]int{}
+	for n := range 3 {
+		start := i
+		for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+			nums[n] = nums[n]*10 + int(s[i]-'0')
+			i++
+		}
+		if start == i {
+			break
+		}
+		if i == len(s) || s[i] != '.' {
+			break
+		}
+		i++ // skip the dot
+	}
+	return serverVersion{major: nums[0], minor: nums[1], patch: nums[2]}, true
+}

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -1,0 +1,250 @@
+package capability_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform/capability"
+)
+
+func TestCapabilities_Has_NilSafe(t *testing.T) {
+	c := qt.New(t)
+
+	var caps capability.Capabilities
+	c.Assert(caps.Has(capability.DropConstraintIfExists), qt.IsFalse)
+	c.Assert(caps.Validate(), qt.IsNil)
+}
+
+func TestCapabilities_Has(t *testing.T) {
+	c := qt.New(t)
+
+	caps := capability.Capabilities{
+		capability.DropConstraintGeneric: true,
+		capability.DropIndexIfExists:     false,
+	}
+	c.Assert(caps.Has(capability.DropConstraintGeneric), qt.IsTrue)
+	c.Assert(caps.Has(capability.DropIndexIfExists), qt.IsFalse, qt.Commentf("present-but-disabled must read as absent"))
+	c.Assert(caps.Has(capability.RowLevelSecurity), qt.IsFalse, qt.Commentf("missing key must read as absent"))
+}
+
+func TestCapabilities_Validate_UnknownKey(t *testing.T) {
+	c := qt.New(t)
+
+	caps := capability.Capabilities{"definately_a_typo": true}
+	c.Assert(caps.Validate(), qt.ErrorMatches, `unknown capability "definately_a_typo"`)
+
+	// Disabled unknown keys are rejected too: a typo must never validate.
+	caps = capability.Capabilities{"another_typo": false}
+	c.Assert(caps.Validate(), qt.ErrorMatches, `unknown capability "another_typo"`)
+}
+
+func TestCapabilities_Validate_RequiresEdge(t *testing.T) {
+	c := qt.New(t)
+
+	// IF EXISTS on a statement the target does not have is a contradiction.
+	caps := capability.Capabilities{
+		capability.DropConstraintIfExists: true,
+		capability.DropConstraintGeneric:  false,
+	}
+	c.Assert(caps.Validate(), qt.ErrorMatches,
+		`capability "drop_constraint_if_exists" requires "drop_constraint_generic", which is not enabled`)
+
+	// A missing (rather than disabled) requirement is equally invalid.
+	caps = capability.Capabilities{capability.DropConstraintIfExists: true}
+	c.Assert(caps.Validate(), qt.ErrorMatches,
+		`capability "drop_constraint_if_exists" requires "drop_constraint_generic", which is not enabled`)
+
+	// Satisfying the edge fixes the set.
+	caps = capability.Capabilities{
+		capability.DropConstraintIfExists: true,
+		capability.DropConstraintGeneric:  true,
+	}
+	c.Assert(caps.Validate(), qt.IsNil)
+
+	// DROP CHECK presupposes enforced CHECK constraints.
+	caps = capability.Capabilities{capability.DropCheckClause: true}
+	c.Assert(caps.Validate(), qt.ErrorMatches,
+		`capability "drop_check_clause" requires "check_constraints_enforced", which is not enabled`)
+}
+
+func TestCapabilities_Validate_MutexGroup(t *testing.T) {
+	c := qt.New(t)
+
+	caps := capability.Capabilities{
+		capability.EnumInlineColumn: true,
+		capability.EnumCustomType:   true,
+	}
+	c.Assert(caps.Validate(), qt.ErrorMatches,
+		`capabilities enum_inline_column and enum_custom_type are mutually exclusive`)
+
+	// One of the two (or neither) is fine.
+	c.Assert(capability.Capabilities{capability.EnumInlineColumn: true}.Validate(), qt.IsNil)
+	c.Assert(capability.Capabilities{capability.EnumCustomType: true}.Validate(), qt.IsNil)
+	c.Assert(capability.Capabilities{}.Validate(), qt.IsNil)
+}
+
+func TestPresets_AllValid_AndCoverEveryRegisteredCapability(t *testing.T) {
+	c := qt.New(t)
+
+	presets := map[string]capability.Capabilities{
+		"MySQL80":       capability.MySQL80(),
+		"MySQL8016":     capability.MySQL8016(),
+		"MySQLLegacy":   capability.MySQLLegacy(),
+		"MariaDB1011":   capability.MariaDB1011(),
+		"MariaDBLegacy": capability.MariaDBLegacy(),
+		"Postgres16":    capability.Postgres16(),
+		"Postgres13":    capability.Postgres13(),
+		"ClickHouse24":  capability.ClickHouse24(),
+	}
+	for name, preset := range presets {
+		c.Assert(preset.Validate(), qt.IsNil, qt.Commentf("preset %s must validate", name))
+		// Presets enumerate every registered capability explicitly, so the
+		// docs matrix and the code never drift silently.
+		for _, key := range capability.All() {
+			_, present := preset[key]
+			c.Assert(present, qt.IsTrue, qt.Commentf("preset %s is missing registry key %q", name, key))
+		}
+		c.Assert(len(preset), qt.Equals, len(capability.All()), qt.Commentf("preset %s carries an extra key", name))
+	}
+}
+
+func TestPresets_KeyDifferences(t *testing.T) {
+	c := qt.New(t)
+
+	// The MySQL family never gets IF EXISTS guards; MariaDB does.
+	c.Assert(capability.MySQL80().Has(capability.DropConstraintIfExists), qt.IsFalse)
+	c.Assert(capability.MySQL80().Has(capability.DropIndexIfExists), qt.IsFalse)
+	c.Assert(capability.MariaDB1011().Has(capability.DropConstraintIfExists), qt.IsTrue)
+	c.Assert(capability.MariaDB1011().Has(capability.DropIndexIfExists), qt.IsTrue)
+
+	// Version ladder within MySQL.
+	c.Assert(capability.MySQL80().Has(capability.DropConstraintGeneric), qt.IsTrue)
+	c.Assert(capability.MySQL8016().Has(capability.DropConstraintGeneric), qt.IsFalse)
+	c.Assert(capability.MySQL8016().Has(capability.CheckConstraintsEnforced), qt.IsTrue)
+	c.Assert(capability.MySQLLegacy().Has(capability.CheckConstraintsEnforced), qt.IsFalse)
+
+	// Postgres version presets gate CREATE OR REPLACE TRIGGER (PG 14+).
+	c.Assert(capability.Postgres16().Has(capability.CreateOrReplaceTrigger), qt.IsTrue)
+	c.Assert(capability.Postgres13().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
+	c.Assert(capability.Postgres13().Has(capability.CreateIndexConcurrently), qt.IsTrue)
+
+	// Enum modeling is mutually exclusive and dialect-appropriate.
+	c.Assert(capability.MySQL80().Has(capability.EnumInlineColumn), qt.IsTrue)
+	c.Assert(capability.MySQL80().Has(capability.EnumCustomType), qt.IsFalse)
+	c.Assert(capability.Postgres16().Has(capability.EnumCustomType), qt.IsTrue)
+	c.Assert(capability.Postgres16().Has(capability.EnumInlineColumn), qt.IsFalse)
+
+	// DROP CHECK is a MySQL-only spelling (MariaDB rejects it — verified
+	// live), present exactly in the enforcing MySQL windows.
+	c.Assert(capability.MySQL80().Has(capability.DropCheckClause), qt.IsTrue)
+	c.Assert(capability.MySQL8016().Has(capability.DropCheckClause), qt.IsTrue)
+	c.Assert(capability.MySQLLegacy().Has(capability.DropCheckClause), qt.IsFalse)
+	c.Assert(capability.MariaDB1011().Has(capability.DropCheckClause), qt.IsFalse)
+	c.Assert(capability.Postgres16().Has(capability.DropCheckClause), qt.IsFalse)
+
+	// The legacy MariaDB floor drops every modern guarantee.
+	legacy := capability.MariaDBLegacy()
+	c.Assert(legacy.Has(capability.DropConstraintGeneric), qt.IsFalse)
+	c.Assert(legacy.Has(capability.DropConstraintIfExists), qt.IsFalse)
+	c.Assert(legacy.Has(capability.DropIndexIfExists), qt.IsFalse)
+	c.Assert(legacy.Has(capability.CheckConstraintsEnforced), qt.IsFalse)
+	c.Assert(legacy.Has(capability.EnumInlineColumn), qt.IsTrue)
+}
+
+func TestCapabilities_With_DoesNotMutateReceiver(t *testing.T) {
+	c := qt.New(t)
+
+	base := capability.MariaDB1011()
+	derived := base.With(capability.DropIndexIfExists, false)
+
+	c.Assert(base.Has(capability.DropIndexIfExists), qt.IsTrue, qt.Commentf("receiver must stay untouched"))
+	c.Assert(derived.Has(capability.DropIndexIfExists), qt.IsFalse)
+	c.Assert(derived.Validate(), qt.IsNil)
+
+	// With on a nil set allocates.
+	var empty capability.Capabilities
+	derived = empty.With(capability.DropConstraintGeneric, true)
+	c.Assert(derived.Has(capability.DropConstraintGeneric), qt.IsTrue)
+	c.Assert(empty.Has(capability.DropConstraintGeneric), qt.IsFalse)
+}
+
+func TestCapabilities_Clone(t *testing.T) {
+	c := qt.New(t)
+
+	var nilSet capability.Capabilities
+	c.Assert(nilSet.Clone(), qt.IsNil)
+
+	orig := capability.MySQL80()
+	cl := orig.Clone()
+	cl[capability.DropIndexIfExists] = true
+	c.Assert(orig.Has(capability.DropIndexIfExists), qt.IsFalse, qt.Commentf("clone must be independent"))
+}
+
+func TestForDialect(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(capability.ForDialect("mysql").Has(capability.DropConstraintIfExists), qt.IsFalse)
+	c.Assert(capability.ForDialect("mariadb").Has(capability.DropConstraintIfExists), qt.IsTrue)
+	c.Assert(capability.ForDialect("postgres").Has(capability.CreateIndexConcurrently), qt.IsTrue)
+	// Dialect aliases go through platform.NormalizeDialect.
+	c.Assert(capability.ForDialect("postgresql").Has(capability.EnumCustomType), qt.IsTrue)
+	c.Assert(capability.ForDialect("pgx").Has(capability.EnumCustomType), qt.IsTrue)
+	c.Assert(capability.ForDialect("ch").Has(capability.EnumInlineColumn), qt.IsTrue)
+	// Unknown dialects get the conservative nil set.
+	c.Assert(capability.ForDialect("oracle"), qt.IsNil)
+}
+
+func TestForServerVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		version string
+		// probe capability and its expected value pin the resolved preset
+		probe capability.Capability
+		want  bool
+	}{
+		{"mysql 8.0.19+ line", "mysql", "8.0.42", capability.DropConstraintGeneric, true},
+		{"mysql 8.0.42-log suffix", "mysql", "8.0.42-log", capability.DropConstraintGeneric, true},
+		{"mysql 9.x line", "mysql", "9.7.1", capability.DropConstraintGeneric, true},
+		{"mysql 8.1 minor above zero", "mysql", "8.1.0", capability.DropConstraintGeneric, true},
+		{"mysql 8.0.19 exact boundary", "mysql", "8.0.19", capability.DropConstraintGeneric, true},
+		{"mysql 8.0.18 upper edge of the DROP CHECK window", "mysql", "8.0.18", capability.DropConstraintGeneric, false},
+		{"mysql 8.0.16 exact boundary", "mysql", "8.0.16", capability.CheckConstraintsEnforced, true},
+		{"mysql 8.0.15 below the CHECK window", "mysql", "8.0.15", capability.CheckConstraintsEnforced, false},
+		{"mysql 8.0.16 window has checks", "mysql", "8.0.17", capability.CheckConstraintsEnforced, true},
+		{"mysql 8.0.16 window lacks generic drop", "mysql", "8.0.17", capability.DropConstraintGeneric, false},
+		{"mysql 8.0.16 window has DROP CHECK", "mysql", "8.0.17", capability.DropCheckClause, true},
+		{"mysql legacy lacks enforced checks", "mysql", "5.7.44", capability.CheckConstraintsEnforced, false},
+		{"mariadb via own dialect", "mariadb", "10.11.6-MariaDB-1:10.11.6+maria~ubu2204", capability.DropConstraintIfExists, true},
+		{"mariadb over mysql protocol prefix", "mysql", "5.5.5-10.11.6-MariaDB", capability.DropConstraintIfExists, true},
+		{"mariadb 10.2 exact boundary", "mariadb", "10.2.44-MariaDB", capability.DropConstraintIfExists, true},
+		{"mariadb 11.x line", "mariadb", "11.4.2-MariaDB", capability.DropConstraintIfExists, true},
+		{"mariadb pre-10.2 degrades to the legacy floor", "mariadb", "10.1.48-MariaDB", capability.DropConstraintIfExists, false},
+		{"mariadb pre-10.2 over mysql protocol prefix", "mysql", "5.5.5-10.1.48-MariaDB", capability.CheckConstraintsEnforced, false},
+		{"mariadb unparseable stays on the modern preset", "mariadb", "MariaDB something", capability.DropConstraintIfExists, true},
+		{"postgres 16 banner", "postgres", "PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1)", capability.CreateOrReplaceTrigger, true},
+		{"postgres 14 exact boundary", "postgres", "PostgreSQL 14.0", capability.CreateOrReplaceTrigger, true},
+		{"postgres 13 plain", "postgres", "13.14", capability.CreateOrReplaceTrigger, false},
+		{"postgres 13 still concurrent-capable", "postgres", "13.14", capability.CreateIndexConcurrently, true},
+		{"unparseable falls back to dialect default", "mysql", "who knows", capability.DropConstraintGeneric, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			caps := capability.ForServerVersion(tt.dialect, tt.version)
+			c.Assert(caps.Validate(), qt.IsNil)
+			c.Assert(caps.Has(tt.probe), qt.Equals, tt.want,
+				qt.Commentf("dialect=%s version=%q probe=%s", tt.dialect, tt.version, tt.probe))
+		})
+	}
+}
+
+func TestDoc(t *testing.T) {
+	c := qt.New(t)
+
+	for _, key := range capability.All() {
+		c.Assert(capability.Doc(key) != "", qt.IsTrue, qt.Commentf("registry entry %q must carry documentation", key))
+	}
+	c.Assert(capability.Doc("nope"), qt.Equals, "")
+}

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -1,0 +1,106 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+// TestMySQLFamilyRenderers_ConstraintDropGuardValidity pins the renderer-side
+// half of the capability model (issue #226) in isolation from any planner:
+// given the SAME AST carrying an IF EXISTS intent flag, the mysql renderer
+// strips the guard (MySQL rejects it on every constraint-drop spelling) while
+// the mariadb renderer honors it.
+func TestMySQLFamilyRenderers_ConstraintDropGuardValidity(t *testing.T) {
+	dropFK := &ast.AlterTableNode{
+		Name: "posts",
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: "fk_posts_user",
+			ForeignKey:     true,
+			IfExists:       true,
+		}},
+	}
+	dropCheck := &ast.AlterTableNode{
+		Name: "things",
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: "chk_qty",
+			IfExists:       true,
+		}},
+	}
+
+	t.Run("mysql strips the guard", func(t *testing.T) {
+		c := qt.New(t)
+
+		sql, err := renderer.RenderSQL("mysql", dropFK, dropCheck)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;"), qt.IsTrue,
+			qt.Commentf("got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+			qt.Commentf("got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+			qt.Commentf("MySQL accepts no IF EXISTS on constraint drops; got:\n%s", sql))
+	})
+
+	t.Run("mariadb honors the guard", func(t *testing.T) {
+		c := qt.New(t)
+
+		sql, err := renderer.RenderSQL("mariadb", dropFK, dropCheck)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;"), qt.IsTrue,
+			qt.Commentf("got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_qty;"), qt.IsTrue,
+			qt.Commentf("got:\n%s", sql))
+	})
+}
+
+// TestMySQLFamilyRenderers_DropCheckSpelling pins the dedicated DROP CHECK
+// spelling requested via DropConstraintOperation.Check (used by planners for
+// MySQL 8.0.16–8.0.18, which lack the generic DROP CONSTRAINT clause) — and
+// its validity resolution: MariaDB has no DROP CHECK clause at all (verified
+// live on 10.11), so its renderer degrades the request to the generic clause.
+func TestMySQLFamilyRenderers_DropCheckSpelling(t *testing.T) {
+	c := qt.New(t)
+
+	node := &ast.AlterTableNode{
+		Name: "things",
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: "chk_qty",
+			Check:          true,
+		}},
+	}
+	sql, err := renderer.RenderSQL("mysql", node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CHECK chk_qty;"), qt.IsTrue,
+		qt.Commentf("got:\n%s", sql))
+
+	sql, err = renderer.RenderSQL("mariadb", node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+		qt.Commentf("mariadb must degrade DROP CHECK to the generic clause; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "DROP CHECK"), qt.IsFalse,
+		qt.Commentf("got:\n%s", sql))
+}
+
+// TestMySQLFamilyRenderers_DropIndexGuardValidity pins the DROP INDEX guard
+// gating: same node, mysql strips IF EXISTS (no such form), mariadb renders
+// it (10.1.4+ syntax).
+func TestMySQLFamilyRenderers_DropIndexGuardValidity(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewDropIndex("idx_users_email").SetIfExists().SetTable("users")
+
+	sqlMySQL, err := renderer.RenderSQL("mysql", node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlMySQL, "DROP INDEX idx_users_email ON users;"), qt.IsTrue,
+		qt.Commentf("got:\n%s", sqlMySQL))
+	c.Assert(strings.Contains(sqlMySQL, "IF EXISTS"), qt.IsFalse)
+
+	sqlMariaDB, err := renderer.RenderSQL("mariadb", node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX IF EXISTS idx_users_email ON users;"), qt.IsTrue,
+		qt.Commentf("got:\n%s", sqlMariaDB))
+}

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -85,6 +85,28 @@ func TestMySQLFamilyRenderers_DropCheckSpelling(t *testing.T) {
 		qt.Commentf("got:\n%s", sql))
 }
 
+// TestMySQLFamilyRenderers_DropUniqueIndexSpelling pins the DROP INDEX
+// spelling requested via DropConstraintOperation.Unique (UNIQUE removals on
+// targets without the generic clause). ALTER TABLE ... DROP INDEX is valid
+// across the entire family, so both renderers honor it as-is.
+func TestMySQLFamilyRenderers_DropUniqueIndexSpelling(t *testing.T) {
+	c := qt.New(t)
+
+	node := &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: "uq_email",
+			Unique:         true,
+		}},
+	}
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		sql, err := renderer.RenderSQL(dialect, node)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.IsTrue,
+			qt.Commentf("%s: got:\n%s", dialect, sql))
+	}
+}
+
 // TestMySQLFamilyRenderers_DropIndexGuardValidity pins the DROP INDEX guard
 // gating: same node, mysql strips IF EXISTS (no such form), mariadb renders
 // it (10.1.4+ syntax).

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -78,6 +78,11 @@ func (r *Renderer) dropConstraintSQL(table string, op *ast.DropConstraintOperati
 		}
 	case op.Check && r.caps.Has(capability.DropCheckClause):
 		dropSQL += " CHECK"
+	case op.Unique:
+		// ALTER TABLE ... DROP INDEX drops a UNIQUE constraint's backing
+		// index and is valid across the entire MySQL/MariaDB family, so the
+		// planner-requested spelling needs no capability gate here.
+		dropSQL += " INDEX"
 	case guarded:
 		dropSQL += " CONSTRAINT IF EXISTS"
 	default:
@@ -92,9 +97,10 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	parts = append(parts, "DROP INDEX")
 
 	// The IF EXISTS guard on DROP INDEX is MariaDB-only (10.1.4+); MySQL has
-	// no such form and rejects it. The planner sets the intent flag
-	// unconditionally, so the renderer honors it only when the target's
-	// capability set allows (capability.DropIndexIfExists, issue #226).
+	// no such form and rejects it. Planners record the guard intent per THEIR
+	// capability set (capability.DropIndexIfExists); the renderer validates
+	// it again against its own target set, so the guard reaches the SQL only
+	// when both layers agree (issue #226).
 	if node.IfExists && r.caps.Has(capability.DropIndexIfExists) {
 		parts = append(parts, "IF EXISTS")
 	}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/internal/bufwriter"
 	"github.com/stokaro/ptah/core/renderer/types"
 )
@@ -18,14 +19,23 @@ type Renderer struct {
 	dialect      string
 	dialectUpper string
 	w            *bufwriter.Writer
+	// caps describes what the target dialect line actually accepts. The
+	// renderer is the VALIDITY layer of the capability model (issue #226): a
+	// planner records intent on AST nodes (e.g. IfExists), and the renderer
+	// drops any modifier the concrete target would reject — MySQL 8/9 reject
+	// IF EXISTS on constraint and index drops, MariaDB accepts both.
+	caps capability.Capabilities
 }
 
-// New creates a new MySQL-like renderer
+// New creates a new MySQL-like renderer. The target capabilities are resolved
+// from the dialect name (capability.ForDialect), so "mysql" gets the strict
+// MySQL preset and "mariadb" the MariaDB one.
 func New(dialect string, buf *bufwriter.Writer) *Renderer {
 	return &Renderer{
 		w:            buf,
 		dialect:      dialect,
 		dialectUpper: strings.ToUpper(dialect),
+		caps:         capability.ForDialect(dialect),
 	}
 }
 
@@ -36,16 +46,58 @@ func (r *Renderer) escapeValue(value string) string {
 	return "'" + escaped + "'"
 }
 
+// dropConstraintSQL renders a single ALTER TABLE constraint drop.
+//
+// MySQL/MariaDB constraint drops are type-specific. Foreign keys use the
+// dedicated DROP FOREIGN KEY spelling — the one form valid across the entire
+// family, including servers that predate the generic DROP CONSTRAINT clause
+// (current lines happen to accept the generic clause for FKs too — verified
+// live on MySQL 9.7 and MariaDB 10.11 — but there is no reason to give up the
+// universal spelling). CHECK constraints on a target without the generic
+// clause use DROP CHECK; everything else uses DROP CONSTRAINT.
+//
+// This is the VALIDITY half of the capability model (issue #226): the planner
+// records intent, and the renderer resolves modifiers and spellings against
+// ITS target set —
+//   - the IF EXISTS guard is MariaDB-only within this family (MySQL rejects
+//     it on every constraint-drop spelling), so it renders only when
+//     capability.DropConstraintIfExists is present;
+//   - the DROP CHECK spelling (op.Check, requested by planners for MySQL
+//     8.0.16–8.0.18) exists only on MySQL (capability.DropCheckClause) —
+//     MariaDB rejects it (verified live on 10.11), so a stray Check flag
+//     reaching a MariaDB renderer degrades to the generic clause, which every
+//     CHECK-capable MariaDB accepts.
+func (r *Renderer) dropConstraintSQL(table string, op *ast.DropConstraintOperation) string {
+	dropSQL := fmt.Sprintf("ALTER TABLE %s DROP", table)
+	guarded := op.IfExists && r.caps.Has(capability.DropConstraintIfExists)
+	switch {
+	case op.ForeignKey:
+		dropSQL += " FOREIGN KEY"
+		if guarded {
+			dropSQL += " IF EXISTS"
+		}
+	case op.Check && r.caps.Has(capability.DropCheckClause):
+		dropSQL += " CHECK"
+	case guarded:
+		dropSQL += " CONSTRAINT IF EXISTS"
+	default:
+		dropSQL += " CONSTRAINT"
+	}
+	return dropSQL + " " + op.ConstraintName
+}
+
 func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	// Build DROP INDEX statement for MySQL/MariaDB
 	var parts []string
 	parts = append(parts, "DROP INDEX")
 
-	// Note: MySQL 8.0.1+ and MariaDB 10.1.4+ support IF EXISTS with DROP INDEX
-	// For compatibility with older versions, we'll skip IF EXISTS for now
-	// if node.IfExists {
-	//     parts = append(parts, "IF EXISTS")
-	// }
+	// The IF EXISTS guard on DROP INDEX is MariaDB-only (10.1.4+); MySQL has
+	// no such form and rejects it. The planner sets the intent flag
+	// unconditionally, so the renderer honors it only when the target's
+	// capability set allows (capability.DropIndexIfExists, issue #226).
+	if node.IfExists && r.caps.Has(capability.DropIndexIfExists) {
+		parts = append(parts, "IF EXISTS")
+	}
 
 	parts = append(parts, node.Name)
 
@@ -463,24 +515,7 @@ func (r *Renderer) visitAlterTableWithEnums(node *ast.AlterTableNode, enums map[
 			r.w.WriteLinef("ALTER TABLE %s ADD %s;", node.Name, constraintLine)
 
 		case *ast.DropConstraintOperation:
-			dropSQL := fmt.Sprintf("ALTER TABLE %s DROP", node.Name)
-			// MySQL/MariaDB require a type-specific drop clause. Foreign keys
-			// must use DROP FOREIGN KEY (DROP CONSTRAINT is rejected for FKs on
-			// MySQL and on MariaDB <10.5); everything else uses DROP CONSTRAINT
-			// (CHECK and named constraints on MySQL 8.0.19+ / MariaDB).
-			switch {
-			case op.ForeignKey:
-				dropSQL += " FOREIGN KEY"
-				if op.IfExists {
-					dropSQL += " IF EXISTS"
-				}
-			case op.IfExists:
-				dropSQL += " CONSTRAINT IF EXISTS"
-			default:
-				dropSQL += " CONSTRAINT"
-			}
-			dropSQL += fmt.Sprintf(" %s", op.ConstraintName)
-			r.w.WriteLinef("%s;", dropSQL)
+			r.w.WriteLinef("%s;", r.dropConstraintSQL(node.Name, op))
 
 		case *ast.DropColumnOperation:
 			r.w.WriteLinef("ALTER TABLE %s DROP COLUMN %s;", node.Name, op.ColumnName)

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -356,6 +356,12 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 
 	parts = append(parts, "INDEX")
 
+	// CONCURRENTLY precedes IF NOT EXISTS in the PostgreSQL grammar:
+	// CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] name ...
+	if node.Concurrently {
+		parts = append(parts, "CONCURRENTLY")
+	}
+
 	if node.IfNotExists {
 		parts = append(parts, "IF NOT EXISTS")
 	}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,146 @@
+# Dialect capabilities
+
+Ptah maps several real database targets onto shared implementations: MySQL and
+MariaDB share one planner and one renderer family, and versions within a single
+dialect differ in which DDL they accept. Instead of forking a new dialect for
+every variant, planners and renderers consult a **capability set** — a
+validated `map[Capability]bool` describing what the concrete target accepts —
+and restrict or enable individual emissions accordingly (issues #225/#226).
+
+Package: `core/platform/capability`.
+
+## The model
+
+Two layers cooperate:
+
+- **Intent (planner).** A planner configured with a capability set records
+  intent on AST nodes — e.g. a MariaDB-preset planner sets `IfExists` on
+  constraint drops because MariaDB accepts guarded drops.
+- **Validity (renderer).** A renderer checks modifiers against *its own*
+  capability set for the target dialect and drops anything the target would
+  reject — the `mysql` renderer strips `IF EXISTS` from constraint and index
+  drops even if a stray intent flag reaches it.
+
+At the `Capabilities` type level the nil/empty set is valid and reads as
+"everything absent" (`Has` is nil-safe). The **planners** deliberately do NOT
+treat nil as assume-nothing, though: a zero-value planner (`&mysql.Planner{}`,
+`&postgres.Planner{}`) defaults to its dialect's current-line preset, so it
+behaves exactly like `New()`. An assume-nothing planner would be a trap — it
+would silently downgrade CHECK additions to warnings (turning a CHECK
+modification into a destructive drop-without-re-add) and re-spell CHECK drops.
+Restricting emissions is always an explicit choice: pass a legacy preset or a
+composed set to `NewWithCapabilities` (which clones its argument).
+
+## Registry
+
+Capability keys are a **curated registry** — `Validate()` rejects unknown keys,
+so typos fail fast. Current registry:
+
+| Capability | Meaning |
+|---|---|
+| `drop_constraint_generic` | SQL-standard `ALTER TABLE … DROP CONSTRAINT` for non-FK constraints (MySQL 8.0.19+, MariaDB, PostgreSQL) |
+| `drop_constraint_if_exists` | `IF EXISTS` guard on constraint drops (MariaDB, PostgreSQL; **rejected by MySQL**). Requires `drop_constraint_generic` |
+| `drop_index_if_exists` | `IF EXISTS` guard on `DROP INDEX` (MariaDB 10.1.4+, PostgreSQL; **rejected by MySQL**) |
+| `check_constraints_enforced` | CHECK constraints are enforced, not parsed-and-ignored (MySQL 8.0.16+, MariaDB 10.2.1+, PostgreSQL) |
+| `drop_check_clause` | Dedicated `ALTER TABLE … DROP CHECK` spelling (MySQL 8.0.16+ only; **MariaDB rejects it** — verified live). Requires `check_constraints_enforced` |
+| `enum_inline_column` | Enums are inline column types (MySQL/MariaDB `ENUM`, ClickHouse `Enum8/16`) |
+| `enum_custom_type` | Enums are separate named types (PostgreSQL `CREATE TYPE … AS ENUM`) |
+| `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
+| `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Reserved for the trigger work (#158) |
+| `row_level_security` | Row-level security policies (PostgreSQL) |
+
+### Validation rules
+
+`Capabilities.Validate()` enforces:
+
+1. **Known keys only** — anything outside the registry is an error.
+2. **Requirement edges** — an enabled capability with a disabled prerequisite
+   is a contradiction (`drop_constraint_if_exists` without
+   `drop_constraint_generic`: an `IF EXISTS` variant of a statement the target
+   does not have).
+3. **Mutual exclusion groups** — at most one member of a group may be enabled
+   (`enum_inline_column` vs `enum_custom_type`: a dialect models enums one way
+   or the other).
+
+Presets are valid by construction (unit-tested); validate hand-built or
+composed sets yourself.
+
+## Presets
+
+| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres16 | Postgres13 | ClickHouse24 |
+|---|---|---|---|---|---|---|---|---|
+| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+
+Version lines: `MySQL80()` covers MySQL 8.0.19+ and 9.x; `MySQL8016()` covers
+8.0.16–8.0.18; `MySQLLegacy()` anything older. `MariaDB1011()` covers the
+supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
+floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres16()` covers
+PostgreSQL 14+; `Postgres13()` covers 12–13 (no `CREATE OR REPLACE TRIGGER`).
+
+### Composition
+
+```go
+caps := capability.MariaDB1011().With(capability.DropIndexIfExists, false)
+if err := caps.Validate(); err != nil { /* reject configuration */ }
+planner := mysql.NewWithCapabilities(caps)
+```
+
+`With` copies — presets are never mutated.
+
+### Resolving a preset
+
+- `capability.ForDialect("mariadb")` — default preset for a dialect name
+  (aliases like `pgx`/`postgresql` normalize first). Used by `GetPlanner` and
+  the renderers.
+- `capability.ForServerVersion("mysql", version)` — refine using a live
+  `SELECT version()` string. Recognizes shapes like `8.0.42-log`,
+  `10.11.6-MariaDB-…`, the `5.5.5-10.11.6-MariaDB` replication-protocol prefix
+  (MariaDB over the mysql driver resolves to the MariaDB preset), and
+  `PostgreSQL 16.3 (…)`. Wiring this into live connections at `read-db` /
+  `migrate` time is a follow-up.
+
+## Current consumers
+
+- **Constraint drops (MySQL family).** The MariaDB-preset planner requests
+  `IF EXISTS` on `DROP CONSTRAINT` / `DROP FOREIGN KEY`; the mariadb renderer
+  honors it, the mysql renderer strips it. On MySQL the exactly-once drop
+  ownership from #207 remains the only idempotency mechanism — the guard is
+  belt-and-braces on MariaDB, never a substitute.
+- **`DROP CHECK` spelling.** A planner whose target lacks
+  `drop_constraint_generic` (MySQL 8.0.16–8.0.18) requests
+  `ALTER TABLE … DROP CHECK <name>` for CHECK removals; the renderer resolves
+  the spelling against **its** target too, so the request degrades to the
+  generic clause on MariaDB, which has no `DROP CHECK` at all (verified live).
+- **CHECK adds on non-enforcing targets.** A target without
+  `check_constraints_enforced` gets a loud `WARNING` comment instead of an
+  `ADD CONSTRAINT … CHECK` the server would silently ignore. This covers the
+  ALTER-time constraint paths (table-level and synthesized field-level);
+  column-level `CHECK` clauses inside `CREATE TABLE` / `ADD COLUMN` remain
+  emitted — they are valid, parsed-and-ignored syntax on such targets, exactly
+  MySQL's own historical behavior.
+- **`DROP INDEX` guard.** Intent is planner-side and capability-gated (the
+  MariaDB preset requests it, the MySQL preset does not), and the renderer
+  validates it again — so the capability is a real knob on both layers.
+- **`CREATE INDEX CONCURRENTLY` (postgres).**
+  `postgres.New().WithConcurrentIndexes()` emits `CONCURRENTLY` for new
+  indexes **only** when the capability is present. It is a policy opt-in
+  because concurrent builds cannot run inside a transaction block (#152 tracks
+  migrator support); a capability-less target (CockroachDB-style preset, #171)
+  keeps plain `CREATE INDEX` regardless of policy.
+
+## Follow-ups
+
+- `SELECT version()` → preset wiring at connect time (`ForServerVersion` is
+  ready; the dbschema plumbing is tracked with #163/#152 work).
+- `create_or_replace_trigger` consumer lands with triggers (#158).
+- UNIQUE drop syntax selection (`DROP INDEX` vs generic clause) — #195.
+- Distributed-SQL presets (CockroachDB / Yugabyte / Spanner) — #171.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -120,6 +120,11 @@ planner := mysql.NewWithCapabilities(caps)
   `ALTER TABLE … DROP CHECK <name>` for CHECK removals; the renderer resolves
   the spelling against **its** target too, so the request degrades to the
   generic clause on MariaDB, which has no `DROP CHECK` at all (verified live).
+  On the same no-generic targets a UNIQUE removal uses
+  `ALTER TABLE … DROP INDEX <name>` (valid family-wide — verified live), and a
+  CHECK removal with no valid spelling at all (`MySQLLegacy`) degrades to a
+  loud WARNING comment. Universal `DROP INDEX` branching for modern versions
+  stays with #195.
 - **CHECK adds on non-enforcing targets.** A target without
   `check_constraints_enforced` gets a loud `WARNING` comment instead of an
   `ADD CONSTRAINT … CHECK` the server would silently ignore. This covers the

--- a/migration/planner/capability_wiring_test.go
+++ b/migration/planner/capability_wiring_test.go
@@ -1,0 +1,49 @@
+package planner_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestGetPlanner_CapabilityWiring proves the factory wires the right
+// capability preset per dialect (issue #226): the SAME schema diff produces
+// guarded constraint drops for mariadb and unguarded ones for mysql, end to
+// end through GenerateSchemaDiffAST + the dialect renderer.
+func TestGetPlanner_CapabilityWiring(t *testing.T) {
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"fk_posts_user"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "fk_posts_user", TableName: "posts", Type: "FOREIGN KEY"},
+		},
+	}
+	generated := &goschema.Database{}
+
+	t.Run("mariadb gets guarded drops", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mariadb")
+		sql, err := renderer.RenderSQL("mariadb", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;"), qt.IsTrue,
+			qt.Commentf("GetPlanner(mariadb) must carry the MariaDB capability preset; got:\n%s", sql))
+	})
+
+	t.Run("mysql stays unguarded", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;"), qt.IsTrue,
+			qt.Commentf("got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+			qt.Commentf("MySQL output must be byte-identical to the pre-capability planner; got:\n%s", sql))
+	})
+}

--- a/migration/planner/dialects/mysql/capability_gating_test.go
+++ b/migration/planner/dialects/mysql/capability_gating_test.go
@@ -1,0 +1,299 @@
+package mysql_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// mixedSharedFKDiff is the issue #207 mixed scenario (shared_fk modified on
+// articles, purely removed from pages), reused here to prove the capability
+// gating composes with the exactly-once drop discipline instead of replacing
+// it.
+func mixedSharedFKDiff() *types.SchemaDiff {
+	return &types.SchemaDiff{
+		ConstraintsAdded:   []string{"shared_fk"},
+		ConstraintsRemoved: []string{"shared_fk"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+			{
+				Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY",
+				Columns: []string{"author_id"}, ForeignTable: "users", ForeignColumn: "id", OnDelete: "CASCADE",
+			},
+		},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "shared_fk", TableName: "articles", Type: "FOREIGN KEY"},
+			{Name: "shared_fk", TableName: "pages", Type: "FOREIGN KEY"},
+		},
+	}
+}
+
+// TestPlanner_CapabilityGating_MariaDBGuardedConstraintDrops covers the
+// issue #226 improvement: a planner configured with the MariaDB preset
+// requests the IF EXISTS guard on constraint drops, and the mariadb renderer
+// accepts it. Drops stay exactly-once per (table, name) — the guard is
+// belt-and-braces on top of the #207 ownership discipline, not a replacement.
+func TestPlanner_CapabilityGating_MariaDBGuardedConstraintDrops(t *testing.T) {
+	c := qt.New(t)
+
+	nodes := mysql.NewWithCapabilities(capability.MariaDB1011()).GenerateMigrationAST(mixedSharedFKDiff(), &goschema.Database{})
+	sql, err := renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY IF EXISTS shared_fk;"), qt.Equals, 1,
+		qt.Commentf("modified host drop must carry the MariaDB IF EXISTS guard; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "ALTER TABLE pages DROP FOREIGN KEY IF EXISTS shared_fk;"), qt.Equals, 1,
+		qt.Commentf("pure-removal drop must carry the guard too; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "DROP FOREIGN KEY IF EXISTS shared_fk;"), qt.Equals, 2,
+		qt.Commentf("guards must not change the exactly-once discipline; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE;"), qt.Equals, 1,
+		qt.Commentf("the re-add is unaffected by drop guarding; got:\n%s", sql))
+
+	// Ordering discipline is intact.
+	articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP FOREIGN KEY IF EXISTS shared_fk")
+	articlesAdd := strings.Index(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk")
+	pagesDrop := strings.Index(sql, "ALTER TABLE pages DROP FOREIGN KEY IF EXISTS shared_fk")
+	c.Assert(articlesDrop >= 0 && articlesAdd >= 0 && pagesDrop >= 0, qt.IsTrue)
+	c.Assert(articlesDrop < articlesAdd, qt.IsTrue)
+	c.Assert(pagesDrop > articlesAdd, qt.IsTrue)
+}
+
+// TestPlanner_CapabilityGating_RendererStripsGuardsForMySQL pins the validity
+// layer: even when a planner records the IF EXISTS intent (MariaDB preset),
+// the mysql renderer must strip it — MySQL 8/9 reject the guard on every
+// constraint-drop spelling, so a stray intent flag must never reach a MySQL
+// server (issue #226).
+func TestPlanner_CapabilityGating_RendererStripsGuardsForMySQL(t *testing.T) {
+	c := qt.New(t)
+
+	nodes := mysql.NewWithCapabilities(capability.MariaDB1011()).GenerateMigrationAST(mixedSharedFKDiff(), &goschema.Database{})
+	sql, err := renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+		qt.Commentf("the mysql renderer must strip guards the target rejects; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
+	c.Assert(strings.Count(sql, "ALTER TABLE pages DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
+}
+
+// TestPlanner_CapabilityGating_MySQLPlannerEmitsNoGuardIntent pins the intent
+// layer from the opposite side: a MySQL-preset planner records no IF EXISTS
+// intent, so even the guard-capable mariadb renderer has nothing to render.
+func TestPlanner_CapabilityGating_MySQLPlannerEmitsNoGuardIntent(t *testing.T) {
+	c := qt.New(t)
+
+	nodes := mysql.New().GenerateMigrationAST(mixedSharedFKDiff(), &goschema.Database{})
+	sql, err := renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Contains(sql, "DROP FOREIGN KEY IF EXISTS"), qt.IsFalse,
+		qt.Commentf("a MySQL-preset planner must not request guards; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
+}
+
+// TestPlanner_CapabilityGating_DropCheckSpellingWithoutGenericClause covers
+// the MySQL 8.0.16–8.0.18 window (capability.MySQL8016): the generic
+// DROP CONSTRAINT clause does not exist there, so a CHECK removal must use
+// the dedicated ALTER TABLE ... DROP CHECK spelling.
+func TestPlanner_CapabilityGating_DropCheckSpellingWithoutGenericClause(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"chk_qty"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "chk_qty", TableName: "things", Type: "CHECK"},
+		},
+	}
+
+	nodes := mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, &goschema.Database{})
+	sql, err := renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Count(sql, "ALTER TABLE things DROP CHECK chk_qty;"), qt.Equals, 1,
+		qt.Commentf("without drop_constraint_generic a CHECK drop must use DROP CHECK; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "DROP CONSTRAINT"), qt.IsFalse,
+		qt.Commentf("the generic clause must not be emitted for this target; got:\n%s", sql))
+
+	// The current MySQL line keeps the generic clause.
+	nodes = mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
+	sql, err = renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.Equals, 1,
+		qt.Commentf("modern MySQL keeps DROP CONSTRAINT; got:\n%s", sql))
+}
+
+// TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced covers the
+// capability.MySQLLegacy window (before 8.0.16): the server parses CHECK
+// constraints and silently ignores them, so emitting ADD CONSTRAINT ... CHECK
+// would leave ptah believing a constraint exists that the server never
+// enforces. The planner surfaces a warning comment instead — for both the
+// table-level and the synthesized field-level CHECK paths.
+func TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced(t *testing.T) {
+	t.Run("table-level constraint", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{ConstraintsAdded: []string{"positive_price"}}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Product", Name: "positive_price", Type: "CHECK", Table: "products", CheckExpression: "price > 0"},
+			},
+		}
+
+		nodes := mysql.NewWithCapabilities(capability.MySQLLegacy()).GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "ADD CONSTRAINT"), qt.IsFalse,
+			qt.Commentf("an unenforced CHECK must not be emitted; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "WARNING: CHECK constraint positive_price skipped"), qt.IsTrue,
+			qt.Commentf("the skip must be loud; got:\n%s", sql))
+
+		// The enforcing window (8.0.16+) emits the constraint as usual.
+		nodes = mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, generated)
+		sql, err = renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);"), qt.IsTrue,
+			qt.Commentf("enforcing targets keep the ADD; got:\n%s", sql))
+	})
+
+	t.Run("field-level synthesized constraint", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"things_qty_check"},
+			ConstraintsRemoved: []string{},
+		}
+		generated := &goschema.Database{
+			Tables: []goschema.Table{{StructName: "Thing", Name: "things"}},
+			Fields: []goschema.Field{
+				{StructName: "Thing", Name: "qty", Type: "INT", Check: "qty >= 0"},
+			},
+		}
+
+		nodes := mysql.NewWithCapabilities(capability.MySQLLegacy()).GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "ADD CONSTRAINT"), qt.IsFalse,
+			qt.Commentf("an unenforced field-level CHECK must not be emitted; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "WARNING: CHECK constraint things_qty_check skipped"), qt.IsTrue,
+			qt.Commentf("the skip must be loud; got:\n%s", sql))
+
+		// Positive control at the unit level: an enforcing target emits the
+		// field-level ADD as before.
+		nodes = mysql.New().GenerateMigrationAST(diff, generated)
+		sql, err = renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT things_qty_check CHECK (qty >= 0);"), qt.IsTrue,
+			qt.Commentf("enforcing targets keep the field-level ADD; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "WARNING"), qt.IsFalse)
+	})
+}
+
+// TestPlanner_CapabilityGating_ZeroValuePlannerBehavesLikeNew guards the
+// documented construction `planner := &mysql.Planner{}` (the type's own usage
+// example): the nil capability set must default to the modern MySQL preset,
+// NOT to an assume-nothing set — otherwise a zero-value planner would
+// silently skip CHECK additions (turning a CHECK modification into a
+// destructive drop-without-re-add) and re-spell CHECK drops as DROP CHECK.
+func TestPlanner_CapabilityGating_ZeroValuePlannerBehavesLikeNew(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsAdded:   []string{"positive_price"},
+		ConstraintsRemoved: []string{"chk_old"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "chk_old", TableName: "things", Type: "CHECK"},
+		},
+	}
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{StructName: "Product", Name: "positive_price", Type: "CHECK", Table: "products", CheckExpression: "price > 0"},
+		},
+	}
+
+	zero := &mysql.Planner{}
+	zeroSQL, err := renderer.RenderSQL("mysql", zero.GenerateMigrationAST(diff, generated)...)
+	c.Assert(err, qt.IsNil)
+	newSQL, err := renderer.RenderSQL("mysql", mysql.New().GenerateMigrationAST(diff, generated)...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(zeroSQL, qt.Equals, newSQL,
+		qt.Commentf("a zero-value planner must be byte-identical to New()"))
+	c.Assert(strings.Contains(zeroSQL, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);"), qt.IsTrue,
+		qt.Commentf("the CHECK addition must be emitted, not downgraded to a warning; got:\n%s", zeroSQL))
+	c.Assert(strings.Contains(zeroSQL, "ALTER TABLE things DROP CONSTRAINT chk_old;"), qt.IsTrue,
+		qt.Commentf("the CHECK removal must use the generic clause, not DROP CHECK; got:\n%s", zeroSQL))
+}
+
+// TestPlanner_CapabilityGating_DropCheckDegradesOnMariaDBRenderer pins the
+// renderer-side spelling resolution: DROP CHECK is a MySQL-only clause
+// (MariaDB 10.11 rejects it — verified live), so a plan built for the MySQL
+// 8.0.16–8.0.18 window rendered through the mariadb renderer must degrade to
+// the generic DROP CONSTRAINT clause rather than emit SQL MariaDB rejects.
+func TestPlanner_CapabilityGating_DropCheckDegradesOnMariaDBRenderer(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"chk_qty"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "chk_qty", TableName: "things", Type: "CHECK"},
+		},
+	}
+	nodes := mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, &goschema.Database{})
+
+	sql, err := renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+		qt.Commentf("the mariadb renderer must degrade DROP CHECK to the generic clause; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "DROP CHECK"), qt.IsFalse,
+		qt.Commentf("MariaDB has no DROP CHECK clause; got:\n%s", sql))
+}
+
+// TestPlanner_CapabilityGating_DropIndexGuard covers the DROP INDEX guard
+// through both capability layers: the guard is emitted only when the PLANNER
+// records the intent (its capability set includes DropIndexIfExists — the
+// MariaDB preset) AND the RENDERER accepts it (mariadb; the mysql renderer
+// strips the guard because MySQL has no such form). This also makes the
+// capability a live knob: a MySQL-preset planner produces no guard even for
+// the guard-capable mariadb renderer.
+func TestPlanner_CapabilityGating_DropIndexGuard(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		IndexesRemoved: []string{"idx_things_qty"},
+		IndexesRemovedWithTables: []types.IndexRemovalInfo{
+			{Name: "idx_things_qty", TableName: "things"},
+		},
+	}
+
+	// MariaDB-preset planner: intent recorded.
+	nodes := mysql.NewWithCapabilities(capability.MariaDB1011()).GenerateMigrationAST(diff, &goschema.Database{})
+
+	sqlMariaDB, err := renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX IF EXISTS idx_things_qty ON things;"), qt.IsTrue,
+		qt.Commentf("mariadb honors the guard intent; got:\n%s", sqlMariaDB))
+
+	sqlMySQL, err := renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlMySQL, "DROP INDEX idx_things_qty ON things;"), qt.IsTrue,
+		qt.Commentf("the mysql renderer strips the guard it cannot parse; got:\n%s", sqlMySQL))
+	c.Assert(strings.Contains(sqlMySQL, "IF EXISTS"), qt.IsFalse)
+
+	// MySQL-preset planner: no intent, so even the guard-capable mariadb
+	// renderer emits the plain form — the capability is a real knob.
+	nodes = mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
+	sqlMariaDB, err = renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX idx_things_qty ON things;"), qt.IsTrue,
+		qt.Commentf("got:\n%s", sqlMariaDB))
+	c.Assert(strings.Contains(sqlMariaDB, "IF EXISTS"), qt.IsFalse,
+		qt.Commentf("a MySQL-preset planner must not request the index-drop guard; got:\n%s", sqlMariaDB))
+}

--- a/migration/planner/dialects/mysql/capability_gating_test.go
+++ b/migration/planner/dialects/mysql/capability_gating_test.go
@@ -128,6 +128,60 @@ func TestPlanner_CapabilityGating_DropCheckSpellingWithoutGenericClause(t *testi
 		qt.Commentf("modern MySQL keeps DROP CONSTRAINT; got:\n%s", sql))
 }
 
+// TestPlanner_CapabilityGating_NoGenericClauseFallbacks covers the remaining
+// constraint types on targets without the generic DROP CONSTRAINT clause
+// (MySQL before 8.0.19): a UNIQUE removal must use DROP INDEX (dropping the
+// backing index — valid across the whole family), and a CHECK removal on a
+// target with NEITHER spelling (MySQLLegacy) must degrade to a loud WARNING
+// instead of emitting SQL the server rejects.
+func TestPlanner_CapabilityGating_NoGenericClauseFallbacks(t *testing.T) {
+	t.Run("unique removal uses DROP INDEX", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{
+			ConstraintsRemoved: []string{"uq_email"},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "uq_email", TableName: "users", Type: "UNIQUE"},
+			},
+		}
+		nodes := mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.Equals, 1,
+			qt.Commentf("without the generic clause a UNIQUE drop must use DROP INDEX; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "DROP CONSTRAINT"), qt.IsFalse,
+			qt.Commentf("got:\n%s", sql))
+
+		// Modern targets keep the generic clause (the universal DROP INDEX
+		// branching for every version is issue #195).
+		nodes = mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err = renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Count(sql, "ALTER TABLE users DROP CONSTRAINT uq_email;"), qt.Equals, 1,
+			qt.Commentf("got:\n%s", sql))
+	})
+
+	t.Run("check removal without any valid spelling warns", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{
+			ConstraintsRemoved: []string{"chk_qty"},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "chk_qty", TableName: "things", Type: "CHECK"},
+			},
+		}
+		nodes := mysql.NewWithCapabilities(capability.MySQLLegacy()).GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		// No statement may be emitted at all — only the warning comment
+		// (asserting on statement shape, not bare keywords, because the
+		// warning text itself names the missing clauses).
+		c.Assert(strings.Contains(sql, "ALTER TABLE"), qt.IsFalse, qt.Commentf("got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "WARNING: cannot drop CHECK constraint chk_qty"), qt.IsTrue,
+			qt.Commentf("the impossibility must be loud; got:\n%s", sql))
+	})
+}
+
 // TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced covers the
 // capability.MySQLLegacy window (before 8.0.16): the server parses CHECK
 // constraints and silently ignores them, so emitting ADD CONSTRAINT ... CHECK

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -13,8 +13,13 @@ import (
 )
 
 // mysqlFamilyDialects renders the same planner output through both renderers
-// that consume the MySQL planner (GetPlanner maps mysql AND mariadb to it), so
-// every scenario is asserted for the full MySQL family.
+// that consume the MySQL planner, so every scenario is asserted for the full
+// MySQL family. The suite deliberately uses the strict MySQL capability
+// preset (mysql.New()) for BOTH renderers: the (table,name) ownership
+// discipline it pins (issue #207) is capability-independent and must hold
+// even without IF EXISTS guards. The production mariadb configuration —
+// GetPlanner("mariadb"), which adds guard intent via the MariaDB preset — is
+// covered in capability_gating_test.go and the planner-level wiring test.
 var mysqlFamilyDialects = []string{"mysql", "mariadb"}
 
 // renderMySQLFamily generates the migration AST once per invocation and

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -1033,9 +1033,13 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 //   - FOREIGN KEY uses DROP FOREIGN KEY (never the generic clause);
 //   - CHECK uses DROP CHECK when the target lacks the generic DROP CONSTRAINT
 //     clause (capability.DropConstraintGeneric absent — MySQL 8.0.16–8.0.18);
-//   - everything else uses DROP CONSTRAINT (MySQL 8.0.19+ / MariaDB). A
-//     UNIQUE removal keeps the generic clause for now — the DROP INDEX
-//     branching for old targets is tracked separately (issue #195);
+//     a target with NEITHER spelling (capability.MySQLLegacy) gets a loud
+//     WARNING comment instead of invalid SQL;
+//   - UNIQUE uses DROP INDEX (dropping the backing index — valid across the
+//     whole family) when the generic clause is absent; on modern targets it
+//     keeps the generic clause for now, and the universal DROP INDEX
+//     branching for every version is tracked separately (issue #195);
+//   - everything else uses DROP CONSTRAINT (MySQL 8.0.19+ / MariaDB);
 //   - the IF EXISTS guard is requested when the target accepts guarded drops
 //     (capability.DropConstraintIfExists — MariaDB; MySQL rejects it). The
 //     renderer validates the flag against its own capability set too, so a
@@ -1043,13 +1047,25 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 //     discipline from issue #207 therefore stays load-bearing on MySQL, where
 //     no guard exists; on MariaDB the guard is belt-and-braces on top of it.
 func (p *Planner) dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node {
+	caps := p.capabilities()
 	op := &ast.DropConstraintOperation{
 		ConstraintName: info.Name,
 		ForeignKey:     strings.EqualFold(info.Type, "FOREIGN KEY"),
-		IfExists:       p.capabilities().Has(capability.DropConstraintIfExists),
+		IfExists:       caps.Has(capability.DropConstraintIfExists),
 	}
-	if !op.ForeignKey && strings.EqualFold(info.Type, "CHECK") && !p.capabilities().Has(capability.DropConstraintGeneric) {
-		op.Check = true
+	if !op.ForeignKey && !caps.Has(capability.DropConstraintGeneric) {
+		switch {
+		case strings.EqualFold(info.Type, "CHECK"):
+			if !caps.Has(capability.DropCheckClause) {
+				// No generic clause and no DROP CHECK either (MySQLLegacy):
+				// there is no valid spelling, so fail loudly instead of
+				// emitting SQL the server rejects.
+				return ast.NewComment(fmt.Sprintf("WARNING: cannot drop CHECK constraint %s on %s - the target supports neither DROP CONSTRAINT nor DROP CHECK", info.Name, info.TableName))
+			}
+			op.Check = true
+		case strings.EqualFold(info.Type, "UNIQUE"):
+			op.Unique = true
+		}
 	}
 	return &ast.AlterTableNode{
 		Name:       info.TableName,

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -45,13 +46,48 @@ const (
 //
 // # Thread Safety
 //
-// The Planner is stateless and safe for concurrent use across multiple goroutines.
-// Each call to GenerateMigrationSQL operates independently without shared state.
+// The Planner carries only an immutable capability set and is safe for
+// concurrent use across multiple goroutines. Each call to
+// GenerateMigrationSQL operates independently without shared state.
 type Planner struct {
+	// caps describes what the concrete target accepts (issue #225/#226). The
+	// MySQL planner serves both MySQL and MariaDB (GetPlanner maps both here);
+	// the capability set is what tells them apart — e.g. MariaDB accepts the
+	// IF EXISTS guard on constraint drops, MySQL does not. The nil zero value
+	// defaults to the current MySQL line preset (capability.MySQL80) via the
+	// capabilities accessor, so a bare &Planner{} — the construction shown in
+	// this type's own example — behaves exactly like New(). Pass an explicit
+	// preset (e.g. capability.MySQLLegacy()) to restrict emissions.
+	caps capability.Capabilities
 }
 
+// New returns a planner configured with the current MySQL line preset
+// (capability.MySQL80: 8.0.19+ and 9.x).
 func New() *Planner {
-	return &Planner{}
+	return NewWithCapabilities(capability.MySQL80())
+}
+
+// NewWithCapabilities returns a planner for a specific capability set — e.g.
+// capability.MariaDB1011() for MariaDB targets, or a preset composed with
+// Capabilities.With for a concrete server version (capability.ForServerVersion).
+// The set is expected to be valid (capability.Capabilities.Validate); presets
+// from the capability package always are. The set is cloned, so later
+// mutations by the caller cannot affect the planner. A nil set defaults to
+// the capability.MySQL80 preset.
+func NewWithCapabilities(caps capability.Capabilities) *Planner {
+	return &Planner{caps: caps.Clone()}
+}
+
+// capabilities returns the planner's capability set, defaulting the nil zero
+// value to the current MySQL line preset. nil deliberately does NOT mean
+// "assume nothing": an assume-nothing set would silently downgrade CHECK
+// additions to warnings and re-spell CHECK drops as DROP CHECK — destructive
+// surprises for a zero-value planner. Restriction must be an explicit choice.
+func (p *Planner) capabilities() capability.Capabilities {
+	if p.caps == nil {
+		return capability.MySQL80()
+	}
+	return p.caps
 }
 
 func (p *Planner) addEnumChangeWarnings(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
@@ -377,19 +413,31 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 }
 
 func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	// The IF EXISTS guard on DROP INDEX is capability-gated INTENT (issue
+	// #226): MariaDB accepts it, MySQL has no such form. The renderer
+	// additionally validates the flag against its own target set, so the
+	// guard is emitted only when both layers agree. Gating here (rather than
+	// always setting the flag) keeps the capability composable — disabling
+	// capability.DropIndexIfExists on a planner actually changes the plan.
+	guarded := p.capabilities().Has(capability.DropIndexIfExists)
+
 	// Use the detailed removal info if available (includes table names for MySQL/MariaDB)
 	if len(diff.IndexesRemovedWithTables) > 0 {
 		for _, indexInfo := range diff.IndexesRemovedWithTables {
 			dropIndexNode := ast.NewDropIndex(indexInfo.Name).
-				SetIfExists().
 				SetTable(indexInfo.TableName)
+			if guarded {
+				dropIndexNode.SetIfExists()
+			}
 			result = append(result, dropIndexNode)
 		}
 	} else {
 		// Fallback to the basic removal list (for backward compatibility)
 		for _, indexName := range diff.IndexesRemoved {
-			dropIndexNode := ast.NewDropIndex(indexName).
-				SetIfExists()
+			dropIndexNode := ast.NewDropIndex(indexName)
+			if guarded {
+				dropIndexNode.SetIfExists()
+			}
 			result = append(result, dropIndexNode)
 		}
 	}
@@ -746,7 +794,7 @@ func (p *Planner) appendScopedDrop(result []ast.Node, info types.ConstraintRemov
 		return result
 	}
 	dropped[dedupKey] = struct{}{}
-	return append(result, dropConstraintNode(info))
+	return append(result, p.dropConstraintNode(info))
 }
 
 // foreignKeyAdditionNode builds the ALTER TABLE ADD CONSTRAINT node for a
@@ -772,6 +820,14 @@ func (p *Planner) appendAddConstraint(result []ast.Node, constraintName string, 
 	for _, constraint := range generated.Constraints {
 		if constraint.Name != constraintName {
 			continue
+		}
+		// A CHECK constraint on a target that parses but does not enforce
+		// CHECK (capability.CheckConstraintsEnforced absent — MySQL before
+		// 8.0.16) would be a silent no-op in the live schema while ptah
+		// believes it applied; surface that loudly instead of emitting it
+		// (issue #226).
+		if constraint.Type == "CHECK" && !p.capabilities().Has(capability.CheckConstraintsEnforced) {
+			return append(result, ast.NewComment(fmt.Sprintf("WARNING: CHECK constraint %s skipped - the target parses but does not enforce CHECK constraints (MySQL < 8.0.16)", constraint.Name)))
 		}
 		if astConstraint := p.convertConstraintToAST(constraint); astConstraint != nil {
 			return append(result, &ast.AlterTableNode{
@@ -820,6 +876,12 @@ func (p *Planner) fieldLevelCheckConstraintNode(constraintName string, generated
 		}
 		if name != constraintName {
 			continue
+		}
+		// Same enforcement gate as the table-level path in
+		// appendAddConstraint: never emit a CHECK the target would silently
+		// ignore (issue #226).
+		if !p.capabilities().Has(capability.CheckConstraintsEnforced) {
+			return ast.NewComment(fmt.Sprintf("WARNING: CHECK constraint %s skipped - the target parses but does not enforce CHECK constraints (MySQL < 8.0.16)", name)), true
 		}
 		return &ast.AlterTableNode{
 			Name: tableName,
@@ -965,13 +1027,29 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 }
 
 // dropConstraintNode builds the ALTER TABLE drop statement for a single removed
-// constraint, choosing the MySQL/MariaDB type-specific syntax. FOREIGN KEY uses
-// DROP FOREIGN KEY; everything else falls back to DROP CONSTRAINT (MySQL
-// 8.0.19+ / MariaDB) which covers CHECK and named constraints.
-func dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node {
+// constraint, choosing the MySQL/MariaDB type-specific syntax and recording the
+// planner's capability-derived intent (issue #226):
+//
+//   - FOREIGN KEY uses DROP FOREIGN KEY (never the generic clause);
+//   - CHECK uses DROP CHECK when the target lacks the generic DROP CONSTRAINT
+//     clause (capability.DropConstraintGeneric absent — MySQL 8.0.16–8.0.18);
+//   - everything else uses DROP CONSTRAINT (MySQL 8.0.19+ / MariaDB). A
+//     UNIQUE removal keeps the generic clause for now — the DROP INDEX
+//     branching for old targets is tracked separately (issue #195);
+//   - the IF EXISTS guard is requested when the target accepts guarded drops
+//     (capability.DropConstraintIfExists — MariaDB; MySQL rejects it). The
+//     renderer validates the flag against its own capability set too, so a
+//     stray intent flag can never reach a MySQL server. The exactly-once drop
+//     discipline from issue #207 therefore stays load-bearing on MySQL, where
+//     no guard exists; on MariaDB the guard is belt-and-braces on top of it.
+func (p *Planner) dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node {
 	op := &ast.DropConstraintOperation{
 		ConstraintName: info.Name,
 		ForeignKey:     strings.EqualFold(info.Type, "FOREIGN KEY"),
+		IfExists:       p.capabilities().Has(capability.DropConstraintIfExists),
+	}
+	if !op.ForeignKey && strings.EqualFold(info.Type, "CHECK") && !p.capabilities().Has(capability.DropConstraintGeneric) {
+		op.Check = true
 	}
 	return &ast.AlterTableNode{
 		Name:       info.TableName,

--- a/migration/planner/dialects/postgres/concurrent_index_test.go
+++ b/migration/planner/dialects/postgres/concurrent_index_test.go
@@ -1,0 +1,103 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func indexAdditionFixture() (*types.SchemaDiff, *goschema.Database) {
+	diff := &types.SchemaDiff{IndexesAdded: []string{"idx_users_email"}}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email"}},
+		},
+	}
+	return diff, generated
+}
+
+// TestPlanner_ConcurrentIndexes covers the postgres consumer of the
+// capability set (issues #225/#226): CREATE INDEX CONCURRENTLY is emitted
+// only when BOTH the policy is opted into (WithConcurrentIndexes — the
+// statement cannot run inside a transaction block, so it must be a caller
+// choice, issue #152) AND the target capability set includes
+// capability.CreateIndexConcurrently (a postgres-compatible engine without
+// it, e.g. CockroachDB in issue #171, keeps plain CREATE INDEX).
+func TestPlanner_ConcurrentIndexes(t *testing.T) {
+	diff, generated := indexAdditionFixture()
+
+	t.Run("default policy stays non-concurrent", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := postgres.New().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue,
+			qt.Commentf("default output must be byte-identical to the pre-capability planner; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse)
+	})
+
+	t.Run("policy plus capability emits CONCURRENTLY", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := postgres.New().WithConcurrentIndexes().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue,
+			qt.Commentf("CONCURRENTLY must precede IF NOT EXISTS per the PostgreSQL grammar; got:\n%s", sql))
+	})
+
+	t.Run("policy without capability keeps plain CREATE INDEX", func(t *testing.T) {
+		c := qt.New(t)
+
+		caps := capability.Postgres16().With(capability.CreateIndexConcurrently, false)
+		nodes := postgres.NewWithCapabilities(caps).WithConcurrentIndexes().GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse,
+			qt.Commentf("the capability gate must win over the policy; got:\n%s", sql))
+		c.Assert(strings.Contains(sql, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue)
+	})
+
+	t.Run("unique concurrent index", func(t *testing.T) {
+		c := qt.New(t)
+
+		uniqueDiff := &types.SchemaDiff{IndexesAdded: []string{"uq_users_email"}}
+		uniqueGenerated := &goschema.Database{
+			Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+			Indexes: []goschema.Index{
+				{Name: "uq_users_email", StructName: "User", Fields: []string{"email"}, Unique: true},
+			},
+		}
+		nodes := postgres.New().WithConcurrentIndexes().GenerateMigrationAST(uniqueDiff, uniqueGenerated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Contains(sql, "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_users_email ON users (email);"), qt.IsTrue,
+			qt.Commentf("UNIQUE and CONCURRENTLY must compose; got:\n%s", sql))
+	})
+
+	t.Run("WithConcurrentIndexes does not mutate the receiver", func(t *testing.T) {
+		c := qt.New(t)
+
+		base := postgres.New()
+		_ = base.WithConcurrentIndexes()
+
+		nodes := base.GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse,
+			qt.Commentf("the original planner must keep the default policy; got:\n%s", sql))
+	})
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -50,13 +51,65 @@ const (
 //
 // # Thread Safety
 //
-// The Planner is stateless and safe for concurrent use across multiple goroutines.
-// Each call to GenerateMigrationSQL operates independently without shared state.
+// The Planner carries only immutable configuration (a capability set and
+// emission policy flags) and is safe for concurrent use across multiple
+// goroutines. Each call to GenerateMigrationSQL operates independently
+// without shared state.
 type Planner struct {
+	// caps describes what the concrete target accepts (issue #225/#226); the
+	// nil zero value defaults to the current PostgreSQL line preset
+	// (capability.Postgres16) via the capabilities accessor, so a bare
+	// &Planner{} behaves exactly like New(). Version presets live in the
+	// capability package — capability.Postgres16 for PostgreSQL 14+,
+	// capability.Postgres13 for 12–13.
+	caps capability.Capabilities
+	// concurrentIndexes requests CREATE INDEX CONCURRENTLY for new indexes.
+	// It is a POLICY choice (concurrent builds cannot run inside a
+	// transaction, so callers must arrange no-transaction execution — issue
+	// #152), and it only takes effect when the target also has the
+	// capability.CreateIndexConcurrently capability — a future
+	// postgres-compatible preset without it (CockroachDB, issue #171) keeps
+	// plain CREATE INDEX no matter the policy.
+	concurrentIndexes bool
 }
 
+// New returns a planner configured with the current PostgreSQL line preset
+// (capability.Postgres16: PostgreSQL 14+).
 func New() *Planner {
-	return &Planner{}
+	return NewWithCapabilities(capability.Postgres16())
+}
+
+// NewWithCapabilities returns a planner for a specific capability set — e.g.
+// capability.Postgres13() for a PostgreSQL 12/13 target, or a set resolved
+// from a live server via capability.ForServerVersion. The set is expected to
+// be valid (capability.Capabilities.Validate); presets always are. The set is
+// cloned, so later mutations by the caller cannot affect the planner. A nil
+// set defaults to the capability.Postgres16 preset.
+func NewWithCapabilities(caps capability.Capabilities) *Planner {
+	return &Planner{caps: caps.Clone()}
+}
+
+// capabilities returns the planner's capability set, defaulting the nil zero
+// value to the current PostgreSQL line preset so a bare &Planner{} behaves
+// exactly like New(). Restriction must be an explicit choice, never a
+// zero-value surprise.
+func (p *Planner) capabilities() capability.Capabilities {
+	if p.caps == nil {
+		return capability.Postgres16()
+	}
+	return p.caps
+}
+
+// WithConcurrentIndexes returns a copy of the planner that emits
+// CREATE [UNIQUE] INDEX CONCURRENTLY for newly added indexes, provided the
+// target capability set includes capability.CreateIndexConcurrently. The
+// receiver is not modified. Concurrent index builds cannot run inside a
+// transaction block; the caller owns arranging no-transaction execution for
+// such statements (issue #152 tracks first-class support in the migrator).
+func (p *Planner) WithConcurrentIndexes() *Planner {
+	cp := *p
+	cp.concurrentIndexes = true
+	return &cp
 }
 
 func (p *Planner) addNewEnums(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
@@ -479,6 +532,13 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 			if idx.Name == indexName {
 				// Use enhanced index creation with PostgreSQL features
 				indexNode := fromschema.FromIndexWithTableMapping(idx, structToTableMap)
+				// CONCURRENTLY is opt-in policy AND capability-gated: the
+				// planner never emits it for a target that rejects it
+				// (issue #226; CockroachDB-style presets keep plain
+				// CREATE INDEX even when the policy is on).
+				if p.concurrentIndexes && p.capabilities().Has(capability.CreateIndexConcurrently) {
+					indexNode.Concurrently = true
+				}
 				result = append(result, indexNode)
 				break
 			}
@@ -488,9 +548,16 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 }
 
 func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	// IF EXISTS on DROP INDEX is capability-gated intent, mirroring the MySQL
+	// planner (issue #226). Every supported PostgreSQL line has the guard, so
+	// the default preset keeps today's output; a preset without it (or a
+	// composed set) actually changes the plan.
+	guarded := p.capabilities().Has(capability.DropIndexIfExists)
 	for _, indexName := range diff.IndexesRemoved {
-		dropIndexNode := ast.NewDropIndex(indexName).
-			SetIfExists()
+		dropIndexNode := ast.NewDropIndex(indexName)
+		if guarded {
+			dropIndexNode.SetIfExists()
+		}
 		result = append(result, dropIndexNode)
 	}
 	return result

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -35,7 +35,9 @@
 // Currently supported database platforms:
 //   - PostgreSQL: Full support with ENUM types, SERIAL columns, and advanced constraints
 //   - MySQL: Complete support with AUTO_INCREMENT, ENGINE specifications, and charset handling
-//   - MariaDB: Planned support (currently panics with "not implemented")
+//   - MariaDB: Served by the MySQL planner configured with the MariaDB
+//     capability preset (capability.MariaDB1011), which unlocks
+//     MariaDB-only SQL such as IF EXISTS guards on constraint drops
 //
 // # Usage Patterns
 //
@@ -65,6 +67,7 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/migration/planner/dialects/clickhouse"
@@ -157,8 +160,11 @@ type Planner interface {
 //   - "postgres": Returns a PostgreSQL-specific planner with support for ENUM types,
 //     SERIAL columns, and PostgreSQL-specific constraints
 //   - "mysql": Returns a MySQL-specific planner with support for AUTO_INCREMENT,
-//     ENGINE specifications, and MySQL-specific features
-//   - "mariadb": Currently not implemented (panics with "not implemented")
+//     ENGINE specifications, and MySQL-specific features, configured with the
+//     capability.MySQL80 preset (no IF EXISTS guards — exactly-once drops)
+//   - "mariadb": Returns the same MySQL planner configured with the
+//     capability.MariaDB1011 preset, which additionally requests IF EXISTS
+//     guards on constraint drops (issue #226)
 //
 // # Parameters
 //
@@ -198,8 +204,10 @@ func GetPlanner(dialect string) Planner {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
 		return postgres.New()
-	case platform.MySQL, platform.MariaDB:
+	case platform.MySQL:
 		return mysql.New()
+	case platform.MariaDB:
+		return mysql.NewWithCapabilities(capability.MariaDB1011())
 	case platform.ClickHouse:
 		return clickhouse.New()
 	default:


### PR DESCRIPTION
Closes #225. Closes #226.

Introduces the **dialect capability system**: instead of forking a new dialect (or planner/renderer) for every engine variant and version line, planners and renderers consult a validated set of feature flags describing what the concrete target accepts, and restrict or enable individual emissions accordingly.

## Part 1 — the core (#225): `core/platform/capability`

- `Capability` + a **curated registry** with doc comments (unknown keys are rejected — typos fail fast).
- `Capabilities map[Capability]bool` — the set type, with nil-safe `Has`, copy-on-write `With`/`Clone`.
- `Validate()` enforces three rule kinds:
  - unknown keys;
  - **requirement edges** — `drop_constraint_if_exists` without `drop_constraint_generic` is a contradiction (an IF EXISTS variant of a statement the target does not have); same for `drop_check_clause` without enforced CHECKs;
  - **mutual-exclusion groups** — `enum_inline_column` vs `enum_custom_type` (a dialect models enums one way or the other).
- **Presets** for the supported lines: `MySQL80` (8.0.19+/9.x), `MySQL8016` (8.0.16–18), `MySQLLegacy`, `MariaDB1011`, `MariaDBLegacy` (pre-10.2 floor), `Postgres16` (14+), `Postgres13` (12–13), `ClickHouse24`. Every preset enumerates every registry key explicitly (unit-enforced).
- `ForDialect(name)` — default preset per dialect; `ForServerVersion(dialect, version)` — maps a live `SELECT version()` string to the closest preset, including the `5.5.5-…-MariaDB` replication-protocol prefix MariaDB reports over the mysql driver, with boundary tests at every cutoff (8.0.16 / 8.0.19 / MariaDB 10.2 / PG 14). Wiring detection into live connections is the one deliberately deferred item — the mapping is ready; dbschema plumbing belongs with #163/#152.

## Part 2 — adoption (#226): intent + validity layers

**The model:** a planner records capability-derived *intent* on AST nodes; a renderer enforces *validity* against its own capability set and drops modifiers (or re-resolves spellings) the target would reject. Mismatched combinations degrade to compatible SQL.

- **MariaDB gains guarded drops** — `GetPlanner("mariadb")` wires the MariaDB preset: constraint drops emit `DROP CONSTRAINT IF EXISTS` / `DROP FOREIGN KEY IF EXISTS`, index drops emit `DROP INDEX IF EXISTS … ON …`. The #207 exactly-once ownership stays untouched and load-bearing — the guards are belt-and-braces.
- **MySQL output is byte-identical** — the MySQL preset requests no guards, and the mysql renderer strips any stray guard (MySQL 8/9 reject `IF EXISTS` on every constraint/index-drop spelling — verified live, errno 1064). All pre-existing tests pass unmodified.
- **`DROP CHECK` spelling** for targets without the generic clause (MySQL 8.0.16–8.0.18) via `DropConstraintOperation.Check` — and the reverse validity gate: MariaDB has **no** `DROP CHECK` clause (verified live), so its renderer degrades the request to the generic clause.
- **CHECK adds on non-enforcing targets** (pre-8.0.16) become loud WARNING comments instead of statements the server silently ignores — on both the table-level and synthesized field-level paths. (Column-level `CHECK` clauses inside `CREATE TABLE` remain emitted: valid, parsed-and-ignored syntax — documented.)
- **Zero-value safety** — `&mysql.Planner{}` / `&postgres.Planner{}` (the construction shown in the type docs) default to their dialect preset and stay byte-identical to `New()`; an assume-nothing nil would have silently turned a CHECK modification into a destructive drop-without-re-add. `NewWithCapabilities` clones its argument.
- **Postgres `CREATE INDEX CONCURRENTLY`** — `postgres.New().WithConcurrentIndexes()` (copy-on-write policy opt-in; concurrent builds cannot run inside transactions — #152) emits `CONCURRENTLY` only when the capability is present; a CockroachDB-style preset (#171) keeps plain `CREATE INDEX` regardless of policy. `IndexNode.Concurrently` + renderer support (`CONCURRENTLY` precedes `IF NOT EXISTS`).
- **Docs**: `docs/capabilities.md` — model, registry, validation rules, capability × preset matrix, composition, version mapping, consumers, follow-ups.
- Fixes the #144 doc drift on the way (MariaDB is the MySQL planner with the MariaDB preset — now stated, not implied).

## Verification

- `go test -count=1 ./...` green; `golangci-lint run ./...` 0 issues.
- **Empirical, live servers** (every capability claim tested): MariaDB 10.11 accepts all guarded drop forms including repeats on absent objects, and **rejects `DROP CHECK`**; MySQL 9.7 rejects all three guarded forms (errno 1064), accepts `DROP CHECK`, and accepts generic `DROP CONSTRAINT` on FK/UNIQUE; PostgreSQL 18 accepts `CREATE [UNIQUE] INDEX CONCURRENTLY IF NOT EXISTS`.
- **Integration: 180/180 scenarios** across live PostgreSQL 18 + MySQL 9.7 + MariaDB 10.11, re-run after the review fixes (the mariadb leg exercises the new guarded drops in real migrations). Local compose is broken independently of this change (#227, incl. the postgres:18 mount issue noted there); run natively.
- **Multi-agent adversarial self-review** (5 lenses: gating correctness, API design, factual claims, tests, blast radius; 3 skeptics per finding): 15 raw findings — all addressed before this PR: nil-caps semantics reworked to zero-value-safe defaults, `DropIndexIfExists` made a live knob on the planner side, `NewWithCapabilities` clone, MariaDB version ladder + `MariaDBLegacy`, `drop_check_clause` capability with MariaDB degradation, CockroachDB wording corrected, boundary tests, and the FK drop-clause comment rewritten to match live behavior. Final confirmed/rejected tally will be posted as a comment when the verification pass completes.

## Acceptance criteria

#225:
- [x] Capability registry with predefined constants and doc comments.
- [x] `Capabilities` set (map[capability]bool) with `Validate()` covering unknown keys and declared conflicts.
- [x] Presets for the current MySQL / MariaDB lines (+ legacy floors, postgres, clickhouse).
- [x] `IF EXISTS` constraint-drop emission gated on a capability as the first real consumer.
- [x] Unit tests for validation, conflict rules, and preset composition.

#226:
- [x] No remaining hardcoded version-note compromises in mysqllike / mysql planner where a registry capability exists.
- [x] MariaDB preset emits guarded (`IF EXISTS`) constraint drops; MySQL preset output unchanged.
- [x] Postgres version presets exist and gate versioned features (`create_or_replace_trigger` differs 13→16; `create_index_concurrently` consumed by the planner).
- [x] Capability matrix documented in `docs/`.