### PR TITLE
Avoid SQL builder concatenation

### DIFF
--- a/integration/framework.go
+++ b/integration/framework.go
@@ -404,7 +404,8 @@ func (vem *VersionedEntityManager) ApplyMigrationFromEntities(ctx context.Contex
 	vem.version++
 	var upSQL strings.Builder
 	for _, stmt := range statements {
-		upSQL.WriteString(stmt + ";\n")
+		upSQL.WriteString(stmt)
+		upSQL.WriteString(";\n")
 	}
 
 	// For simplicity, we'll create a basic down migration that drops everything


### PR DESCRIPTION
## Summary
- Address Copilot review feedback from PR #231 by avoiding per-statement string concatenation while writing migration SQL.
- Write statement text and terminator separately to keep strings.Builder effective.

## Verification
- git diff --check
- golangci-lint run ./...
- go test ./...

Follow-up to https://github.com/stokaro/ptah/pull/231#discussion_r3564061227