### PR TITLE
Fix MySQL field-level CHECK rollback (#194)

### DIFF
--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -416,28 +416,36 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 		handled[add.Name] = struct{}{}
 	}
 
-	// Index field-level FK constraint names (foreign_key_name or the
-	// conventional fk_<table>_<column>) to their owning table for the names that
-	// did not arrive with table-qualified info (legacy callers / explicit
+	// Index field-level constraint names to their owning table for the names
+	// that did not arrive with table-qualified info (legacy callers / explicit
 	// table-level constraints).
 	structToTable := make(map[string]string, len(schema.Tables))
 	for _, t := range schema.Tables {
 		structToTable[t.StructName] = t.Name
 	}
 	fkTables := make(map[string]string, len(schema.Fields))
+	checkTables := make(map[string]string, len(schema.Fields))
 	for _, f := range schema.Fields {
-		if f.Foreign == "" {
-			continue
-		}
 		tableName := structToTable[f.StructName]
 		if tableName == "" {
 			tableName = f.StructName
 		}
-		name := f.ForeignKeyName
-		if name == "" {
-			name = fromschema.GenerateForeignKeyName(tableName, f.Name)
+
+		if f.Foreign != "" {
+			name := f.ForeignKeyName
+			if name == "" {
+				name = fromschema.GenerateForeignKeyName(tableName, f.Name)
+			}
+			fkTables[name] = tableName
 		}
-		fkTables[name] = tableName
+
+		if f.Check != "" {
+			name := f.CheckName
+			if name == "" {
+				name = tableName + "_" + f.Name + "_check"
+			}
+			checkTables[name] = tableName
+		}
 	}
 
 	for _, name := range diff.ConstraintsAdded {
@@ -450,6 +458,8 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: c.Table, Type: c.Type})
 		case fkTables[name] != "":
 			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: fkTables[name], Type: "FOREIGN KEY"})
+		case checkTables[name] != "":
+			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: checkTables[name], Type: "CHECK"})
 		}
 	}
 	return infos

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -597,6 +598,44 @@ func TestReverseSchemaDiff_ConstraintReversal(t *testing.T) {
 	c.Assert(result.ConstraintsRemoved, qt.DeepEquals, []string{"fk_export_file"})
 }
 
+// TestReverseSchemaDiff_FieldLevelCheckRemovalsWithTables verifies that field-level
+// CHECK constraints added by an up migration are reversed into table-qualified
+// removals for the down migration. MySQL/MariaDB need the owning table to emit a
+// real DROP CONSTRAINT; the bare ConstraintsRemoved name list is not enough.
+func TestReverseSchemaDiff_FieldLevelCheckRemovalsWithTables(t *testing.T) {
+	c := qt.New(t)
+
+	generatedSchema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+		Fields: []goschema.Field{
+			{
+				StructName: "File",
+				Name:       "category",
+				Type:       "TEXT",
+				Check:      "category IN ('a','b')",
+			},
+			{
+				StructName: "File",
+				Name:       "status",
+				Type:       "TEXT",
+				Check:      "status IN ('new','done')",
+				CheckName:  "files_status_valid",
+			},
+		},
+	}
+	upDiff := &types.SchemaDiff{
+		ConstraintsAdded: []string{"files_category_check", "files_status_valid"},
+	}
+
+	result := reverseSchemaDiffWithSchema(upDiff, generatedSchema, nil)
+
+	c.Assert(result.ConstraintsRemoved, qt.DeepEquals, []string{"files_category_check", "files_status_valid"})
+	c.Assert(result.ConstraintsRemovedWithTables, qt.DeepEquals, []types.ConstraintRemovalInfo{
+		{Name: "files_category_check", TableName: "files", Type: "CHECK"},
+		{Name: "files_status_valid", TableName: "files", Type: "CHECK"},
+	})
+}
+
 // TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction is the
 // acceptance test for the down half of issue #189: when an up migration changes
 // a field-level FK's ON DELETE action, the generated down migration must DROP
@@ -683,4 +722,53 @@ func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *test
 		c.Assert(strings.Contains(downSQL, "ON DELETE SET NULL"), qt.IsFalse,
 			qt.Commentf("down must restore the prior action, not SET NULL:\n%s", downSQL))
 	})
+}
+
+// TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily is the
+// acceptance test for issue #194: adding a field-level CHECK on an existing
+// column must generate a non-empty MySQL/MariaDB DOWN that drops the CHECK.
+func TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily(t *testing.T) {
+	generatedSchema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "File", Name: "files"}},
+		Fields: []goschema.Field{
+			{
+				StructName: "File",
+				Name:       "category",
+				Type:       "TEXT",
+				Check:      "category IN ('a','b')",
+			},
+		},
+	}
+	dbSchema := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Name: "files",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "category", DataType: "text", IsNullable: "YES"},
+				},
+			},
+		},
+	}
+	upDiff := schemadiff.Compare(generatedSchema, dbSchema)
+	c := qt.New(t)
+	c.Assert(upDiff.ConstraintsAdded, qt.DeepEquals, []string{"files_category_check"})
+
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, dbSchema, dialect)
+			c.Assert(err, qt.IsNil)
+
+			wantDrop := "ALTER TABLE files DROP CONSTRAINT files_category_check;"
+			if dialect == "mariadb" {
+				wantDrop = "ALTER TABLE files DROP CONSTRAINT IF EXISTS files_category_check;"
+			}
+			c.Assert(downSQL, qt.Contains, wantDrop)
+			c.Assert(strings.Contains(downSQL, "No rollback operations needed"), qt.IsFalse,
+				qt.Commentf("field-level CHECK down migration must not be empty:\n%s", downSQL))
+			c.Assert(strings.Contains(downSQL, "TODO"), qt.IsFalse,
+				qt.Commentf("down must emit real SQL, not a TODO placeholder:\n%s", downSQL))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Fix the down migration path for field-level CHECK constraints added on existing columns for MySQL/MariaDB.
- Resolve generated field-level CHECK names, including explicit `check_name` and the default `<table>_<column>_check`, into `ConstraintsRemovedWithTables` during reverse diff generation.
- Add regression coverage for reverse mapping and generated MySQL/MariaDB DOWN SQL.

## Root cause
`reverseConstraintRemovals` only resolved table-level constraints and field-level foreign keys when reversing an UP diff. A field-level CHECK added in the UP became a bare `ConstraintsRemoved` name in the DOWN, but the MySQL family planner needs the owning table and constraint type to emit a real `ALTER TABLE ... DROP CONSTRAINT ...` statement.

## Impact
Rollback for field-level CHECK additions on MySQL/MariaDB now emits a non-empty, table-qualified CHECK drop instead of `No rollback operations needed`.

Closes #194.

## Verification
- `go test ./migration/generator`
- `go test ./migration/planner/dialects/mysql`
- `git diff --check`
- `golangci-lint run ./...`
- `go test ./...`
- `go test -count=1 ./...`