### PR TITLE
Add qtlint to lint pipeline (#192)

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: qtlint
+        run: go tool qtlint ./...
+
       - name: Golint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Ptah Migration Library Makefile
 
-.PHONY: help build test integration-test clean docker-build
+.PHONY: help build test integration-test clean docker-build lint lint-qtlint lint-fix install-hooks
 
 # Default target
 help:
@@ -11,6 +11,9 @@ help:
 	@echo "  build              Build all binaries"
 	@echo "  test               Run unit tests"
 	@echo "  integration-test   Run integration tests using Docker Compose"
+	@echo "  lint               Run golangci-lint and qtlint"
+	@echo "  lint-fix           Run auto-fixable linters"
+	@echo "  install-hooks      Install local Git hooks"
 	@echo "  docker-build       Build Docker images"
 	@echo "  clean              Clean build artifacts"
 	@echo "  help               Show this help message"
@@ -127,14 +130,29 @@ coverage:
 	@echo "Coverage report generated: coverage.html"
 
 # Lint code
-lint:
-	@echo "Running linters..."
+lint: lint-qtlint
+	@echo "Running golangci-lint..."
 	golangci-lint run ./...
+
+lint-qtlint:
+	@echo "Running qtlint..."
+	go tool qtlint ./...
+
+lint-fix:
+	@echo "Running auto-fixable linters..."
+	go tool qtlint -fix ./...
+	golangci-lint run --fix ./...
+	$(MAKE) lint
 
 # Format code
 fmt:
 	@echo "Formatting code..."
 	go fmt ./...
+
+# Install local Git hooks
+install-hooks:
+	@echo "Installing Git hooks..."
+	./scripts/install-hooks.sh
 
 # Run all checks (format, lint, test)
 check: fmt lint test

--- a/cmd/integration-test/main_test.go
+++ b/cmd/integration-test/main_test.go
@@ -49,7 +49,7 @@ func TestStaticScenarioNaming(t *testing.T) {
 
 	// Verify that static scenarios don't have "dynamic_" prefix
 	for _, scenario := range staticScenarios {
-		c.Assert(scenario.Name[:8] != "dynamic_", qt.IsTrue, qt.Commentf("Static scenario %s should not have 'dynamic_' prefix", scenario.Name))
+		c.Assert(scenario.Name[:8], qt.Not(qt.Equals), "dynamic_", qt.Commentf("Static scenario %s should not have 'dynamic_' prefix", scenario.Name))
 	}
 }
 

--- a/core/ast/nodes_role_test.go
+++ b/core/ast/nodes_role_test.go
@@ -121,7 +121,7 @@ func TestAlterRoleNode(t *testing.T) {
 		alterRole := ast.NewAlterRole("test_role")
 
 		c.Assert(alterRole.Name, qt.Equals, "test_role")
-		c.Assert(len(alterRole.Operations), qt.Equals, 0)
+		c.Assert(alterRole.Operations, qt.HasLen, 0)
 		c.Assert(alterRole.Comment, qt.Equals, "")
 	})
 
@@ -133,7 +133,7 @@ func TestAlterRoleNode(t *testing.T) {
 			SetComment("Update role attributes")
 
 		c.Assert(alterRole.Name, qt.Equals, "test_role")
-		c.Assert(len(alterRole.Operations), qt.Equals, 2)
+		c.Assert(alterRole.Operations, qt.HasLen, 2)
 		c.Assert(alterRole.Comment, qt.Equals, "Update role attributes")
 
 		// Check operation types

--- a/core/astbuilder/columnbuilder_test.go
+++ b/core/astbuilder/columnbuilder_test.go
@@ -16,7 +16,7 @@ func TestColumnBuilder_Primary(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Primary, qt.IsTrue)
 	c.Assert(column.Nullable, qt.IsFalse) // Primary keys are automatically NOT NULL
@@ -30,7 +30,7 @@ func TestColumnBuilder_NotNull(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Nullable, qt.IsFalse)
 }
@@ -43,7 +43,7 @@ func TestColumnBuilder_Nullable(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Nullable, qt.IsTrue)
 }
@@ -56,7 +56,7 @@ func TestColumnBuilder_Unique(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Unique, qt.IsTrue)
 }
@@ -69,7 +69,7 @@ func TestColumnBuilder_AutoIncrement(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.AutoInc, qt.IsTrue)
 }
@@ -82,7 +82,7 @@ func TestColumnBuilder_Default(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Default, qt.IsNotNil)
 	c.Assert(column.Default.Value, qt.Equals, "'active'")
@@ -97,7 +97,7 @@ func TestColumnBuilder_DefaultFunction(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Default, qt.IsNotNil)
 	c.Assert(column.Default.Expression, qt.Equals, "NOW()")
@@ -112,7 +112,7 @@ func TestColumnBuilder_Check(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Check, qt.Equals, "age >= 0 AND age <= 150")
 }
@@ -125,7 +125,7 @@ func TestColumnBuilder_Comment(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Comment, qt.Equals, "Auto-incrementing primary key")
 }
@@ -141,7 +141,7 @@ func TestColumnBuilder_ForeignKey(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.Table, qt.Equals, "users")
@@ -165,7 +165,7 @@ func TestColumnBuilder_ComplexColumn(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 
 	c.Assert(column.Name, qt.Equals, "user_id")
@@ -237,7 +237,7 @@ func TestColumnBuilder_MultipleColumns(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 6)
+	c.Assert(result.Columns, qt.HasLen, 6)
 
 	// Check id column
 	idCol := result.Columns[0]
@@ -269,7 +269,7 @@ func TestColumnBuilder_PrimaryKeyOverridesNullable(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 
 	// Primary key should override nullable setting

--- a/core/astbuilder/foreignkeybuilder_test.go
+++ b/core/astbuilder/foreignkeybuilder_test.go
@@ -18,7 +18,7 @@ func TestForeignKeyBuilder_OnDelete(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "CASCADE")
@@ -34,7 +34,7 @@ func TestForeignKeyBuilder_OnUpdate(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnUpdate, qt.Equals, "RESTRICT")
@@ -51,7 +51,7 @@ func TestForeignKeyBuilder_OnDeleteAndUpdate(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "CASCADE")
@@ -88,7 +88,7 @@ func TestForeignKeyBuilder_SetNoAction(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "NO ACTION")
@@ -106,7 +106,7 @@ func TestForeignKeyBuilder_SetNull(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "SET NULL")
@@ -124,7 +124,7 @@ func TestForeignKeyBuilder_SetDefault(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "SET DEFAULT")
@@ -143,7 +143,7 @@ func TestForeignKeyBuilder_TableLevelConstraint(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Constraints), qt.Equals, 1)
+	c.Assert(result.Constraints, qt.HasLen, 1)
 	constraint := result.Constraints[0]
 	c.Assert(constraint.Reference, qt.IsNotNil)
 	c.Assert(constraint.Reference.OnDelete, qt.Equals, "CASCADE")
@@ -164,7 +164,7 @@ func TestForeignKeyBuilder_MultipleForeignKeys(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 2)
+	c.Assert(result.Columns, qt.HasLen, 2)
 
 	// Check first foreign key
 	userIDColumn := result.Columns[0]
@@ -195,7 +195,7 @@ func TestForeignKeyBuilder_ComplexForeignKey(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 2)
+	c.Assert(result.Columns, qt.HasLen, 2)
 
 	// Check order foreign key
 	orderColumn := result.Columns[0]
@@ -231,7 +231,7 @@ func TestForeignKeyBuilder_SelfReferencing(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 2)
+	c.Assert(result.Columns, qt.HasLen, 2)
 
 	parentColumn := result.Columns[1]
 	c.Assert(parentColumn.Name, qt.Equals, "parent_id")
@@ -250,7 +250,7 @@ func TestForeignKeyBuilder_NoActions(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.ForeignKey, qt.IsNotNil)
 	c.Assert(column.ForeignKey.OnDelete, qt.Equals, "") // Default empty

--- a/core/astbuilder/indexbuilder_test.go
+++ b/core/astbuilder/indexbuilder_test.go
@@ -128,7 +128,7 @@ func TestIndexBuilder_SingleColumn(t *testing.T) {
 
 	c.Assert(result.Name, qt.Equals, "idx_users_username")
 	c.Assert(result.Table, qt.Equals, "users")
-	c.Assert(len(result.Columns), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 1)
 	c.Assert(result.Columns[0], qt.Equals, "username")
 	c.Assert(result.Unique, qt.IsTrue)
 	c.Assert(result.Comment, qt.Equals, "Unique username index")
@@ -143,7 +143,7 @@ func TestIndexBuilder_NoColumns(t *testing.T) {
 
 	c.Assert(result.Name, qt.Equals, "idx_empty")
 	c.Assert(result.Table, qt.Equals, "test_table")
-	c.Assert(len(result.Columns), qt.Equals, 0)
+	c.Assert(result.Columns, qt.HasLen, 0)
 }
 
 func TestIndexBuilder_HashIndex(t *testing.T) {

--- a/core/astbuilder/schemabuilder_test.go
+++ b/core/astbuilder/schemabuilder_test.go
@@ -19,7 +19,7 @@ func TestNewSchema(t *testing.T) {
 	// Build should return empty statement list
 	result := schema.Build()
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(len(result.Statements), qt.Equals, 0)
+	c.Assert(result.Statements, qt.HasLen, 0)
 }
 
 func TestSchemaBuilder_Comment(t *testing.T) {
@@ -30,7 +30,7 @@ func TestSchemaBuilder_Comment(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	// Check that it's a comment node
 	commentNode, ok := result.Statements[0].(*ast.CommentNode)
@@ -46,7 +46,7 @@ func TestSchemaBuilder_Enum(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	// Check that it's an enum node
 	enumNode, ok := result.Statements[0].(*ast.EnumNode)
@@ -66,13 +66,13 @@ func TestSchemaBuilder_Table(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	// Check that it's a create table node
 	tableNode, ok := result.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(tableNode.Name, qt.Equals, "users")
-	c.Assert(len(tableNode.Columns), qt.Equals, 2)
+	c.Assert(tableNode.Columns, qt.HasLen, 2)
 
 	// Check first column
 	c.Assert(tableNode.Columns[0].Name, qt.Equals, "id")
@@ -97,7 +97,7 @@ func TestSchemaBuilder_Index(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	// Check that it's an index node
 	indexNode, ok := result.Statements[0].(*ast.IndexNode)
@@ -121,7 +121,7 @@ func TestSchemaBuilder_IndexWithIfNotExists(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	// Check that it's an index node with IfNotExists set
 	indexNode, ok := result.Statements[0].(*ast.IndexNode)
@@ -156,7 +156,7 @@ func TestSchemaBuilder_ComplexSchema(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 5) // comment + enum + 2 tables + 1 index
+	c.Assert(result.Statements, qt.HasLen, 5) // comment + enum + 2 tables + 1 index
 
 	// Check comment
 	commentNode, ok := result.Statements[0].(*ast.CommentNode)
@@ -172,7 +172,7 @@ func TestSchemaBuilder_ComplexSchema(t *testing.T) {
 	usersTable, ok := result.Statements[2].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(usersTable.Name, qt.Equals, "users")
-	c.Assert(len(usersTable.Columns), qt.Equals, 4)
+	c.Assert(usersTable.Columns, qt.HasLen, 4)
 
 	// Check index
 	indexNode, ok := result.Statements[3].(*ast.IndexNode)
@@ -183,7 +183,7 @@ func TestSchemaBuilder_ComplexSchema(t *testing.T) {
 	postsTable, ok := result.Statements[4].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(postsTable.Name, qt.Equals, "posts")
-	c.Assert(len(postsTable.Columns), qt.Equals, 4)
+	c.Assert(postsTable.Columns, qt.HasLen, 4)
 
 	// Check foreign key on user_id column
 	userIDColumn := postsTable.Columns[1]
@@ -229,7 +229,7 @@ func TestSchemaBuilder_MultipleComments(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 2)
+	c.Assert(result.Statements, qt.HasLen, 2)
 
 	comment1, ok := result.Statements[0].(*ast.CommentNode)
 	c.Assert(ok, qt.IsTrue)
@@ -249,7 +249,7 @@ func TestSchemaBuilder_MultipleEnums(t *testing.T) {
 
 	result := schema.Build()
 
-	c.Assert(len(result.Statements), qt.Equals, 2)
+	c.Assert(result.Statements, qt.HasLen, 2)
 
 	enum1, ok := result.Statements[0].(*ast.EnumNode)
 	c.Assert(ok, qt.IsTrue)

--- a/core/astbuilder/tablebuilder_test.go
+++ b/core/astbuilder/tablebuilder_test.go
@@ -19,8 +19,8 @@ func TestNewTable(t *testing.T) {
 	result := table.Build()
 	c.Assert(result, qt.IsNotNil)
 	c.Assert(result.Name, qt.Equals, "users")
-	c.Assert(len(result.Columns), qt.Equals, 0)
-	c.Assert(len(result.Constraints), qt.Equals, 0)
+	c.Assert(result.Columns, qt.HasLen, 0)
+	c.Assert(result.Constraints, qt.HasLen, 0)
 }
 
 func TestTableBuilder_Comment(t *testing.T) {
@@ -67,7 +67,7 @@ func TestTableBuilder_Column(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Columns), qt.Equals, 2)
+	c.Assert(result.Columns, qt.HasLen, 2)
 
 	// Check first column
 	c.Assert(result.Columns[0].Name, qt.Equals, "id")
@@ -91,7 +91,7 @@ func TestTableBuilder_PrimaryKey(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Constraints), qt.Equals, 1)
+	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id", "role_id"})
 }
@@ -106,7 +106,7 @@ func TestTableBuilder_Unique(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Constraints), qt.Equals, 1)
+	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Type, qt.Equals, ast.UniqueConstraint)
 	c.Assert(result.Constraints[0].Name, qt.Equals, "uk_users_email_username")
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"email", "username"})
@@ -124,7 +124,7 @@ func TestTableBuilder_ForeignKey(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Constraints), qt.Equals, 1)
+	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Type, qt.Equals, ast.ForeignKeyConstraint)
 	c.Assert(result.Constraints[0].Name, qt.Equals, "fk_posts_user")
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id"})
@@ -161,10 +161,10 @@ func TestTableBuilder_ComplexTable(t *testing.T) {
 	c.Assert(result.Options["CHARSET"], qt.Equals, "utf8mb4")
 
 	// Check columns
-	c.Assert(len(result.Columns), qt.Equals, 7)
+	c.Assert(result.Columns, qt.HasLen, 7)
 
 	// Check constraints
-	c.Assert(len(result.Constraints), qt.Equals, 2) // unique + primary key
+	c.Assert(result.Constraints, qt.HasLen, 2) // unique + primary key
 
 	// Check unique constraint
 	uniqueConstraint := result.Constraints[0]
@@ -226,7 +226,7 @@ func TestTableBuilder_MultipleConstraints(t *testing.T) {
 
 	result := table.Build()
 
-	c.Assert(len(result.Constraints), qt.Equals, 3)
+	c.Assert(result.Constraints, qt.HasLen, 3)
 
 	// Check primary key
 	c.Assert(result.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)

--- a/core/convert/dbschematogo/dbschematogo_test.go
+++ b/core/convert/dbschematogo/dbschematogo_test.go
@@ -111,7 +111,7 @@ func TestConvertDBSchemaToGoSchema_Extensions(t *testing.T) {
 
 			result := dbschematogo.ConvertDBSchemaToGoSchema(tt.dbSchema)
 
-			c.Assert(len(result.Extensions), qt.Equals, len(tt.expected))
+			c.Assert(result.Extensions, qt.HasLen, len(tt.expected))
 			for i, expectedExt := range tt.expected {
 				actualExt := result.Extensions[i]
 				c.Assert(actualExt.Name, qt.Equals, expectedExt.Name)
@@ -157,15 +157,15 @@ func TestConvertDBSchemaToGoSchema_ExtensionsWithOtherElements(t *testing.T) {
 	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
 
 	// Verify extensions are converted
-	c.Assert(len(result.Extensions), qt.Equals, 1)
+	c.Assert(result.Extensions, qt.HasLen, 1)
 	c.Assert(result.Extensions[0].Name, qt.Equals, "pg_trgm")
 	c.Assert(result.Extensions[0].IfNotExists, qt.Equals, true)
 	c.Assert(result.Extensions[0].Version, qt.Equals, "1.6")
 
 	// Verify other elements are also converted
-	c.Assert(len(result.Tables), qt.Equals, 1)
+	c.Assert(result.Tables, qt.HasLen, 1)
 	c.Assert(result.Tables[0].Name, qt.Equals, "users")
-	c.Assert(len(result.Enums), qt.Equals, 1)
+	c.Assert(result.Enums, qt.HasLen, 1)
 	c.Assert(result.Enums[0].Name, qt.Equals, "status_type")
 }
 
@@ -186,7 +186,7 @@ func TestConvertDBSchemaToGoSchema_ExtensionDefaultValues(t *testing.T) {
 
 	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
 
-	c.Assert(len(result.Extensions), qt.Equals, 1)
+	c.Assert(result.Extensions, qt.HasLen, 1)
 	ext := result.Extensions[0]
 
 	// Verify default values

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -477,8 +477,8 @@ func TestFromTable_CompositePrimaryKey(t *testing.T) {
 
 	c.Assert(result, qt.IsNotNil)
 	c.Assert(result.Name, qt.Equals, "user_roles")
-	c.Assert(len(result.Columns), qt.Equals, 2)
-	c.Assert(len(result.Constraints), qt.Equals, 1)
+	c.Assert(result.Columns, qt.HasLen, 2)
+	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id", "role_id"})
 }
@@ -513,7 +513,7 @@ func TestFromTable_FiltersByStructName(t *testing.T) {
 
 	c.Assert(result, qt.IsNotNil)
 	c.Assert(result.Name, qt.Equals, "users")
-	c.Assert(len(result.Columns), qt.Equals, 2) // Only User fields
+	c.Assert(result.Columns, qt.HasLen, 2) // Only User fields
 	c.Assert(result.Columns[0].Name, qt.Equals, "id")
 	c.Assert(result.Columns[1].Name, qt.Equals, "email")
 }
@@ -713,7 +713,7 @@ func TestFromDatabase_CompleteSchema(t *testing.T) {
 	result := fromschema.FromDatabase(database, "")
 
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(len(result.Statements), qt.Equals, 5) // 1 enum + 2 tables + 2 indexes
+	c.Assert(result.Statements, qt.HasLen, 5) // 1 enum + 2 tables + 2 indexes
 
 	// Check statement ordering: enums first, then tables, then indexes
 	enumNode, ok := result.Statements[0].(*ast.EnumNode)
@@ -750,7 +750,7 @@ func TestFromDatabase_EmptySchema(t *testing.T) {
 	result := fromschema.FromDatabase(database, "")
 
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(len(result.Statements), qt.Equals, 0)
+	c.Assert(result.Statements, qt.HasLen, 0)
 }
 
 func TestFromField_PlatformOverrides(t *testing.T) {
@@ -1012,25 +1012,25 @@ func TestFromDatabase_PlatformOverrides(t *testing.T) {
 	// Test MySQL platform
 	mysqlResult := fromschema.FromDatabase(database, "mysql")
 	c.Assert(mysqlResult, qt.IsNotNil)
-	c.Assert(len(mysqlResult.Statements), qt.Equals, 1)
+	c.Assert(mysqlResult.Statements, qt.HasLen, 1)
 
 	tableNode, ok := mysqlResult.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(tableNode.Name, qt.Equals, "products")
 	c.Assert(tableNode.Options["ENGINE"], qt.Equals, "InnoDB")
-	c.Assert(len(tableNode.Columns), qt.Equals, 1)
+	c.Assert(tableNode.Columns, qt.HasLen, 1)
 	c.Assert(tableNode.Columns[0].Type, qt.Equals, "JSON") // Overridden type
 
 	// Test PostgreSQL platform (no overrides)
 	postgresResult := fromschema.FromDatabase(database, "postgres")
 	c.Assert(postgresResult, qt.IsNotNil)
-	c.Assert(len(postgresResult.Statements), qt.Equals, 1)
+	c.Assert(postgresResult.Statements, qt.HasLen, 1)
 
 	tableNode2, ok := postgresResult.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(tableNode2.Name, qt.Equals, "products")
 	c.Assert(tableNode2.Options["ENGINE"], qt.Equals, "") // No engine for PostgreSQL
-	c.Assert(len(tableNode2.Columns), qt.Equals, 1)
+	c.Assert(tableNode2.Columns, qt.HasLen, 1)
 	c.Assert(tableNode2.Columns[0].Type, qt.Equals, "JSONB") // Default type
 }
 
@@ -1711,7 +1711,7 @@ func TestFromDatabase_EmbeddedFields_ComplexScenario(t *testing.T) {
 	result := fromschema.FromDatabase(database, "")
 
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(len(result.Statements), qt.Equals, 1)
+	c.Assert(result.Statements, qt.HasLen, 1)
 
 	tableNode, ok := result.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
@@ -1728,7 +1728,7 @@ func TestFromDatabase_EmbeddedFields_ComplexScenario(t *testing.T) {
 	// 7. meta_data (from Meta json mode)
 	// 8. author_id (from User relation mode)
 	// Note: Internal fields are skipped
-	c.Assert(len(tableNode.Columns), qt.Equals, 8)
+	c.Assert(tableNode.Columns, qt.HasLen, 8)
 
 	// Verify each column
 	columns := make(map[string]*ast.ColumnNode)

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -222,7 +222,7 @@ func TestToField_PlatformSource(t *testing.T) {
 	c.Assert(result.Type, qt.Equals, "JSON")
 	c.Assert(result.StructName, qt.Equals, "Product")
 	c.Assert(result.Overrides, qt.IsNotNil)
-	c.Assert(len(result.Overrides), qt.Equals, 0) // Empty until merged
+	c.Assert(result.Overrides, qt.HasLen, 0) // Empty until merged
 }
 
 func TestToTable_BasicTable(t *testing.T) {
@@ -299,7 +299,7 @@ func TestToTable_CompositePrimaryKey(t *testing.T) {
 
 	c.Assert(result.Name, qt.Equals, "user_roles")
 	c.Assert(result.StructName, qt.Equals, "UserRole")
-	c.Assert(len(result.PrimaryKey), qt.Equals, 2)
+	c.Assert(result.PrimaryKey, qt.HasLen, 2)
 	c.Assert(result.PrimaryKey[0], qt.Equals, "user_id")
 	c.Assert(result.PrimaryKey[1], qt.Equals, "role_id")
 }
@@ -318,7 +318,7 @@ func TestToTable_PlatformSource(t *testing.T) {
 	c.Assert(result.Engine, qt.Equals, "InnoDB")
 	c.Assert(result.Comment, qt.Equals, "Product catalog")
 	c.Assert(result.Overrides, qt.IsNotNil)
-	c.Assert(len(result.Overrides), qt.Equals, 1)
+	c.Assert(result.Overrides, qt.HasLen, 1)
 	c.Assert(result.Overrides["mysql"]["engine"], qt.Equals, "InnoDB")
 	c.Assert(result.Overrides["mysql"]["charset"], qt.Equals, "utf8mb4")
 	c.Assert(result.Overrides["mysql"]["comment"], qt.Equals, "Product catalog")
@@ -451,17 +451,17 @@ func TestToDatabase_CompleteSchema(t *testing.T) {
 
 	result := toschema.ToDatabase(statements)
 
-	c.Assert(len(result.Enums), qt.Equals, 1)
+	c.Assert(result.Enums, qt.HasLen, 1)
 	c.Assert(result.Enums[0].Name, qt.Equals, "user_status")
-	c.Assert(len(result.Enums[0].Values), qt.Equals, 2)
+	c.Assert(result.Enums[0].Values, qt.HasLen, 2)
 
-	c.Assert(len(result.Tables), qt.Equals, 2)
+	c.Assert(result.Tables, qt.HasLen, 2)
 	c.Assert(result.Tables[0].Name, qt.Equals, "users")
 	c.Assert(result.Tables[0].StructName, qt.Equals, "User")
 	c.Assert(result.Tables[1].Name, qt.Equals, "posts")
 	c.Assert(result.Tables[1].StructName, qt.Equals, "Post")
 
-	c.Assert(len(result.Fields), qt.Equals, 4) // 2 fields per table
+	c.Assert(result.Fields, qt.HasLen, 4) // 2 fields per table
 	c.Assert(result.Fields[0].Name, qt.Equals, "id")
 	c.Assert(result.Fields[0].StructName, qt.Equals, "User")
 	c.Assert(result.Fields[1].Name, qt.Equals, "status")
@@ -472,7 +472,7 @@ func TestToDatabase_CompleteSchema(t *testing.T) {
 	c.Assert(result.Fields[3].StructName, qt.Equals, "Post")
 	c.Assert(result.Fields[3].Foreign, qt.Equals, "users(id)")
 
-	c.Assert(len(result.Indexes), qt.Equals, 2)
+	c.Assert(result.Indexes, qt.HasLen, 2)
 	c.Assert(result.Indexes[0].Name, qt.Equals, "idx_users_status")
 	c.Assert(result.Indexes[1].Name, qt.Equals, "idx_posts_user")
 }
@@ -486,10 +486,10 @@ func TestToDatabase_EmptySchema(t *testing.T) {
 
 	result := toschema.ToDatabase(statements)
 
-	c.Assert(len(result.Enums), qt.Equals, 0)
-	c.Assert(len(result.Tables), qt.Equals, 0)
-	c.Assert(len(result.Fields), qt.Equals, 0)
-	c.Assert(len(result.Indexes), qt.Equals, 0)
+	c.Assert(result.Enums, qt.HasLen, 0)
+	c.Assert(result.Tables, qt.HasLen, 0)
+	c.Assert(result.Fields, qt.HasLen, 0)
+	c.Assert(result.Indexes, qt.HasLen, 0)
 }
 
 func TestMergeFieldOverrides_BasicMerging(t *testing.T) {
@@ -520,7 +520,7 @@ func TestMergeFieldOverrides_BasicMerging(t *testing.T) {
 	c.Assert(result.Name, qt.Equals, "data")
 	c.Assert(result.Type, qt.Equals, "JSONB") // Base type unchanged
 	c.Assert(result.Overrides, qt.IsNotNil)
-	c.Assert(len(result.Overrides), qt.Equals, 2)
+	c.Assert(result.Overrides, qt.HasLen, 2)
 
 	// Check MySQL overrides
 	c.Assert(result.Overrides["mysql"]["type"], qt.Equals, "JSON")
@@ -602,7 +602,7 @@ func TestMergeTableOverrides_BasicMerging(t *testing.T) {
 	c.Assert(result.Name, qt.Equals, "products")
 	c.Assert(result.Engine, qt.Equals, "InnoDB") // Base engine unchanged
 	c.Assert(result.Overrides, qt.IsNotNil)
-	c.Assert(len(result.Overrides), qt.Equals, 2)
+	c.Assert(result.Overrides, qt.HasLen, 2)
 
 	// Check MariaDB overrides
 	c.Assert(result.Overrides["mariadb"]["comment"], qt.Equals, "MariaDB product catalog")

--- a/core/goschema/dependency_fix_test.go
+++ b/core/goschema/dependency_fix_test.go
@@ -59,7 +59,7 @@ func TestDependencyOrderingWithEmbeddedFields(t *testing.T) {
 
 	// Verify that the dependency was correctly detected
 	usersDeps := database.Dependencies["users"]
-	c.Assert(len(usersDeps), qt.Equals, 1, qt.Commentf("Users table should have exactly one dependency"))
+	c.Assert(usersDeps, qt.HasLen, 1, qt.Commentf("Users table should have exactly one dependency"))
 	c.Assert(usersDeps[0], qt.Equals, "tenants", qt.Commentf("Users table should depend on tenants table"))
 
 	// Verify that tables are sorted in correct order
@@ -93,7 +93,7 @@ func TestDependencyOrderingWithEmbeddedFields(t *testing.T) {
 
 	// Should have: tenant_id (from TenantAwareEntityID), email (direct)
 	// Note: id field from EntityID is not included because TenantAwareEntityID doesn't directly embed EntityID in this test
-	c.Assert(len(userFields), qt.Equals, 2, qt.Commentf("User should have 2 fields after embedded processing"))
+	c.Assert(userFields, qt.HasLen, 2, qt.Commentf("User should have 2 fields after embedded processing"))
 
 	// Check that tenant_id field with foreign key is present
 	hasTenantIDWithFK := false
@@ -177,7 +177,7 @@ func TestEmbeddedFieldProcessingModes(t *testing.T) {
 
 	// Should have: title (direct), created_at, updated_at (inline), audit_by, audit_reason (inline with prefix),
 	// meta_data (json), author_id (relation) = 7 fields total
-	c.Assert(len(articleFields), qt.Equals, 7, qt.Commentf("Article should have 7 fields after processing"))
+	c.Assert(articleFields, qt.HasLen, 7, qt.Commentf("Article should have 7 fields after processing"))
 
 	// Check inline mode fields
 	hasCreatedAt := false

--- a/core/goschema/embedded_bug_reproduction_test.go
+++ b/core/goschema/embedded_bug_reproduction_test.go
@@ -81,7 +81,7 @@ func TestEmbeddedEntityIDBugReproduction(t *testing.T) {
 	allFields := processEmbeddedFields(database.EmbeddedFields, database.Fields)
 
 	// Check that we have the expected tables (users, tenants, areas, prefixed_test)
-	c.Assert(len(database.Tables), qt.Equals, 4)
+	c.Assert(database.Tables, qt.HasLen, 4)
 
 	// Find the users table
 	var usersTable Table
@@ -199,7 +199,7 @@ func TestEmbeddedFieldProcessingDebug(t *testing.T) {
 	}
 
 	// This test is just for debugging - we expect it to show the missing id field
-	c.Assert(len(userFields), qt.Not(qt.Equals), 0)
+	c.Assert(userFields, qt.Not(qt.HasLen), 0)
 }
 
 func TestNestedEmbeddedFieldsComprehensive(t *testing.T) {
@@ -369,7 +369,7 @@ func TestNestedEmbeddedFieldsWithPrefixes(t *testing.T) {
 	}
 
 	// Verify no unexpected fields
-	c.Assert(len(prefixedTestFields), qt.Equals, len(expectedFields), qt.Commentf("Expected %d fields, got %d. Actual fields: %v", len(expectedFields), len(prefixedTestFields), getFieldNames(prefixedTestFields)))
+	c.Assert(prefixedTestFields, qt.HasLen, len(expectedFields), qt.Commentf("Expected %d fields, got %d. Actual fields: %v", len(expectedFields), len(prefixedTestFields), getFieldNames(prefixedTestFields)))
 }
 
 // Helper function to get field names for debugging

--- a/core/goschema/field_order_integration_test.go
+++ b/core/goschema/field_order_integration_test.go
@@ -64,7 +64,7 @@ type User struct {
 		// Generate migration AST
 		planner := postgres.New()
 		astNodes := planner.GenerateMigrationAST(diff, database)
-		c.Assert(len(astNodes), qt.Equals, 1)
+		c.Assert(astNodes, qt.HasLen, 1)
 
 		// Render to SQL
 		sql, err := renderer.RenderSQL("postgresql", astNodes[0])
@@ -171,7 +171,7 @@ type Post struct {
 		// Generate migration AST
 		planner := postgres.New()
 		astNodes := planner.GenerateMigrationAST(diff, database)
-		c.Assert(len(astNodes), qt.Equals, 1)
+		c.Assert(astNodes, qt.HasLen, 1)
 
 		// Render to SQL
 		sql, err := renderer.RenderSQL("postgresql", astNodes[0])
@@ -269,7 +269,7 @@ type Post struct {
 		// foreign_key_name, so the planner derives the conventional
 		// fk_posts_user_id name and emits the constraint (previously an
 		// anonymous field-level FK was silently dropped from the migration).
-		c.Assert(len(astNodes), qt.Equals, 3)
+		c.Assert(astNodes, qt.HasLen, 3)
 
 		// Render to SQL
 		var sqlStatements []string
@@ -282,7 +282,7 @@ type Post struct {
 		if i == 0 {
 			previousSQL = sqlStatements
 		} else {
-			c.Assert(len(sqlStatements), qt.Equals, len(previousSQL))
+			c.Assert(sqlStatements, qt.HasLen, len(previousSQL))
 			for j, sql := range sqlStatements {
 				c.Assert(sql, qt.Equals, previousSQL[j],
 					qt.Commentf("Migration SQL for statement %d should be identical across runs (run %d)", j, i))

--- a/core/goschema/index_annotations_test.go
+++ b/core/goschema/index_annotations_test.go
@@ -56,7 +56,7 @@ type Event struct {
 	c := qt.New(t)
 	defer func() {
 		r := recover()
-		c.Assert(r, qt.Not(qt.IsNil), qt.Commentf("expected parser to panic on unknown index attribute"))
+		c.Assert(r, qt.IsNotNil, qt.Commentf("expected parser to panic on unknown index attribute"))
 	}()
 	_ = goschema.ParseSource("fixture.go", src)
 }

--- a/core/goschema/parser_role_test.go
+++ b/core/goschema/parser_role_test.go
@@ -20,7 +20,7 @@ type UserRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 1)
+		c.Assert(database.Roles, qt.HasLen, 1)
 		role := database.Roles[0]
 		c.Assert(role.StructName, qt.Equals, "UserRoles")
 		c.Assert(role.Name, qt.Equals, "app_user")
@@ -45,7 +45,7 @@ type AdminRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 1)
+		c.Assert(database.Roles, qt.HasLen, 1)
 		role := database.Roles[0]
 		c.Assert(role.StructName, qt.Equals, "AdminRoles")
 		c.Assert(role.Name, qt.Equals, "admin_user")
@@ -70,7 +70,7 @@ type ServiceRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 1)
+		c.Assert(database.Roles, qt.HasLen, 1)
 		role := database.Roles[0]
 		c.Assert(role.Name, qt.Equals, "service_user")
 		c.Assert(role.CreateDB, qt.Equals, true)
@@ -90,7 +90,7 @@ type UserRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 3)
+		c.Assert(database.Roles, qt.HasLen, 3)
 
 		// Check app_user
 		appUser := findRoleByName(database.Roles, "app_user")
@@ -129,7 +129,7 @@ type AdminRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 2)
+		c.Assert(database.Roles, qt.HasLen, 2)
 
 		appUser := findRoleByName(database.Roles, "app_user")
 		c.Assert(appUser, qt.IsNotNil)
@@ -151,7 +151,7 @@ type MinimalRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 1)
+		c.Assert(database.Roles, qt.HasLen, 1)
 		role := database.Roles[0]
 		c.Assert(role.Name, qt.Equals, "minimal_role")
 		c.Assert(role.Login, qt.Equals, false)
@@ -177,7 +177,7 @@ type InheritRoles struct {
 `
 		database := parseStringAsGoFile(c, goCode)
 
-		c.Assert(len(database.Roles), qt.Equals, 3)
+		c.Assert(database.Roles, qt.HasLen, 3)
 
 		defaultRole := findRoleByName(database.Roles, "inherit_default")
 		c.Assert(defaultRole.Inherit, qt.Equals, true)

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -280,7 +280,7 @@ func TestParsePackageRecursively(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Verify we found entities (includes all test files in stubs directory)
-	c.Assert(len(result.Tables), qt.Equals, 16) // All test tables from various test files
+	c.Assert(result.Tables, qt.HasLen, 16) // All test tables from various test files
 	c.Assert(len(result.Fields) > 0, qt.IsTrue)
 	c.Assert(len(result.EmbeddedFields) > 0, qt.IsTrue)
 
@@ -711,7 +711,7 @@ func TestParseConstraintComment(t *testing.T) {
 			comment := &ast.Comment{Text: tt.comment}
 			goschema.ParseConstraintComment(comment, "TestStruct", &constraints)
 
-			c.Assert(len(constraints), qt.Equals, 1)
+			c.Assert(constraints, qt.HasLen, 1)
 			constraint := constraints[0]
 
 			c.Assert(constraint.StructName, qt.Equals, tt.expected.StructName)
@@ -772,7 +772,7 @@ type Widget struct {
 
 			defer func() {
 				r := recover()
-				c.Assert(r, qt.Not(qt.IsNil), qt.Commentf("expected panic for unknown attribute"))
+				c.Assert(r, qt.IsNotNil, qt.Commentf("expected panic for unknown attribute"))
 				msg, _ := r.(string)
 				c.Assert(msg, qt.Contains, "unknown annotation attribute")
 				c.Assert(msg, qt.Contains, tt.mustContain)
@@ -851,7 +851,7 @@ type CommodityService struct {
 			break
 		}
 	}
-	c.Assert(fkField, qt.Not(qt.IsNil))
+	c.Assert(fkField, qt.IsNotNil)
 	c.Assert(fkField.Foreign, qt.Equals, "commodities(id)")
 	c.Assert(fkField.ForeignKeyName, qt.Equals, "fk_cs_commodity")
 	c.Assert(fkField.OnDelete, qt.Equals, "CASCADE")
@@ -900,7 +900,7 @@ type Post struct {
 			break
 		}
 	}
-	c.Assert(authorField, qt.Not(qt.IsNil),
+	c.Assert(authorField, qt.IsNotNil,
 		qt.Commentf("expected synthesized author_id field on Post; got fields: %+v", database.Fields))
 	c.Assert(authorField.Foreign, qt.Equals, "users(id)")
 	c.Assert(authorField.OnDelete, qt.Equals, "CASCADE")
@@ -945,11 +945,11 @@ type File struct {
 			typ = &database.Fields[i]
 		}
 	}
-	c.Assert(category, qt.Not(qt.IsNil))
+	c.Assert(category, qt.IsNotNil)
 	c.Assert(category.Check, qt.Equals, "category IN ('photos','invoices','documents','other')")
 	c.Assert(category.CheckName, qt.Equals, "")
 
-	c.Assert(typ, qt.Not(qt.IsNil))
+	c.Assert(typ, qt.IsNotNil)
 	c.Assert(typ.Check, qt.Equals, "type IN ('image','document','video','audio','archive','other')")
 	c.Assert(typ.CheckName, qt.Equals, "files_type_valid")
 }

--- a/core/goschema/pointer_embedded_integration_test.go
+++ b/core/goschema/pointer_embedded_integration_test.go
@@ -137,7 +137,7 @@ type BlogPost struct {
 	c.Assert(err, qt.IsNil)
 
 	// Should have 2 tables: users and blog_posts
-	c.Assert(len(database.Tables), qt.Equals, 2)
+	c.Assert(database.Tables, qt.HasLen, 2)
 
 	// Find the BlogPost table
 	var blogPostTable *goschema.Table

--- a/core/goschema/postgresql_features_test.go
+++ b/core/goschema/postgresql_features_test.go
@@ -71,7 +71,7 @@ type TestExtensions struct{}
 			// Write to a temporary file and parse it
 			database := parseStringAsGoFile(c, content)
 
-			c.Assert(len(database.Extensions), qt.Equals, 1)
+			c.Assert(database.Extensions, qt.HasLen, 1)
 			ext := database.Extensions[0]
 			c.Assert(ext.Name, qt.Equals, tt.expected.Name)
 			c.Assert(ext.IfNotExists, qt.Equals, tt.expected.IfNotExists)
@@ -165,7 +165,7 @@ type TestEntity struct {
 			// Write to a temporary file and parse it
 			database := parseStringAsGoFile(c, content)
 
-			c.Assert(len(database.Indexes), qt.Equals, 1)
+			c.Assert(database.Indexes, qt.HasLen, 1)
 			idx := database.Indexes[0]
 			c.Assert(idx.Name, qt.Equals, tt.expected.Name)
 			c.Assert(idx.Fields, qt.DeepEquals, tt.expected.Fields)
@@ -190,7 +190,7 @@ type DatabaseExtensions struct{}
 
 	database := parseStringAsGoFile(c, content)
 
-	c.Assert(len(database.Extensions), qt.Equals, 3)
+	c.Assert(database.Extensions, qt.HasLen, 3)
 
 	// Extensions are sorted alphabetically: btree_gin, pg_trgm, postgis
 
@@ -247,20 +247,20 @@ type Product struct {
 	database := parseStringAsGoFile(c, content)
 
 	// Check extensions (sorted alphabetically)
-	c.Assert(len(database.Extensions), qt.Equals, 2)
+	c.Assert(database.Extensions, qt.HasLen, 2)
 	c.Assert(database.Extensions[0].Name, qt.Equals, "btree_gin")
 	c.Assert(database.Extensions[1].Name, qt.Equals, "pg_trgm")
 
 	// Check tables
-	c.Assert(len(database.Tables), qt.Equals, 1)
+	c.Assert(database.Tables, qt.HasLen, 1)
 	c.Assert(database.Tables[0].Name, qt.Equals, "products")
 	c.Assert(database.Tables[0].StructName, qt.Equals, "Product")
 
 	// Check fields
-	c.Assert(len(database.Fields), qt.Equals, 4)
+	c.Assert(database.Fields, qt.HasLen, 4)
 
 	// Check indexes
-	c.Assert(len(database.Indexes), qt.Equals, 3)
+	c.Assert(database.Indexes, qt.HasLen, 3)
 
 	// Check GIN index
 	ginIndex := database.Indexes[0]

--- a/core/goschema/rls_edge_cases_test.go
+++ b/core/goschema/rls_edge_cases_test.go
@@ -133,11 +133,11 @@ type User struct {
 			database := goschema.ParseFile(tempFile)
 
 			// Check RLS policies
-			c.Assert(len(database.RLSPolicies), qt.Equals, tt.expectedPolicies,
+			c.Assert(database.RLSPolicies, qt.HasLen, tt.expectedPolicies,
 				qt.Commentf("Expected %d RLS policies, got %d. %s", tt.expectedPolicies, len(database.RLSPolicies), tt.description))
 
 			// Check RLS enabled tables
-			c.Assert(len(database.RLSEnabledTables), qt.Equals, tt.expectedEnabledTables,
+			c.Assert(database.RLSEnabledTables, qt.HasLen, tt.expectedEnabledTables,
 				qt.Commentf("Expected %d RLS enabled tables, got %d. %s", tt.expectedEnabledTables, len(database.RLSEnabledTables), tt.description))
 		})
 	}

--- a/core/goschema/rls_inventario_reproduction_test.go
+++ b/core/goschema/rls_inventario_reproduction_test.go
@@ -40,7 +40,7 @@ func TestRLSPolicyGenerationInventarioReproduction(t *testing.T) {
 		"location_tenant_isolation",
 	}
 
-	c.Assert(len(database.RLSPolicies), qt.Equals, len(expectedPolicies), qt.Commentf("Expected %d RLS policies, got %d", len(expectedPolicies), len(database.RLSPolicies)))
+	c.Assert(database.RLSPolicies, qt.HasLen, len(expectedPolicies), qt.Commentf("Expected %d RLS policies, got %d", len(expectedPolicies), len(database.RLSPolicies)))
 
 	// Check that all expected policies are present
 	policyNames := make(map[string]bool)
@@ -61,7 +61,7 @@ func TestRLSPolicyGenerationInventarioReproduction(t *testing.T) {
 		"locations",
 	}
 
-	c.Assert(len(database.RLSEnabledTables), qt.Equals, len(expectedTables), qt.Commentf("Expected %d RLS enabled tables, got %d", len(expectedTables), len(database.RLSEnabledTables)))
+	c.Assert(database.RLSEnabledTables, qt.HasLen, len(expectedTables), qt.Commentf("Expected %d RLS enabled tables, got %d", len(expectedTables), len(database.RLSEnabledTables)))
 
 	// Check that all expected tables are present
 	tableNames := make(map[string]bool)

--- a/core/goschema/rls_multiple_files_test.go
+++ b/core/goschema/rls_multiple_files_test.go
@@ -40,7 +40,7 @@ func TestRLSPolicyGenerationMultipleFiles(t *testing.T) {
 		"location_tenant_isolation",
 	}
 
-	c.Assert(len(database.RLSPolicies), qt.Equals, len(expectedPolicies), qt.Commentf("Expected %d RLS policies, got %d", len(expectedPolicies), len(database.RLSPolicies)))
+	c.Assert(database.RLSPolicies, qt.HasLen, len(expectedPolicies), qt.Commentf("Expected %d RLS policies, got %d", len(expectedPolicies), len(database.RLSPolicies)))
 
 	// Check that all expected policies are present
 	policyNames := make(map[string]bool)
@@ -61,7 +61,7 @@ func TestRLSPolicyGenerationMultipleFiles(t *testing.T) {
 		"locations",
 	}
 
-	c.Assert(len(database.RLSEnabledTables), qt.Equals, len(expectedTables), qt.Commentf("Expected %d RLS enabled tables, got %d", len(expectedTables), len(database.RLSEnabledTables)))
+	c.Assert(database.RLSEnabledTables, qt.HasLen, len(expectedTables), qt.Commentf("Expected %d RLS enabled tables, got %d", len(expectedTables), len(database.RLSEnabledTables)))
 
 	// Check that all expected tables are present
 	tableNames := make(map[string]bool)

--- a/core/goschema/rls_robust_parsing_test.go
+++ b/core/goschema/rls_robust_parsing_test.go
@@ -145,11 +145,11 @@ type User struct {
 			database := goschema.ParseFile(tempFile)
 
 			// Check RLS policies
-			c.Assert(len(database.RLSPolicies), qt.Equals, tt.expectedPolicies,
+			c.Assert(database.RLSPolicies, qt.HasLen, tt.expectedPolicies,
 				qt.Commentf("Expected %d RLS policies, got %d", tt.expectedPolicies, len(database.RLSPolicies)))
 
 			// Check RLS enabled tables
-			c.Assert(len(database.RLSEnabledTables), qt.Equals, tt.expectedEnabledTables,
+			c.Assert(database.RLSEnabledTables, qt.HasLen, tt.expectedEnabledTables,
 				qt.Commentf("Expected %d RLS enabled tables, got %d", tt.expectedEnabledTables, len(database.RLSEnabledTables)))
 
 			// Check policy names

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -42,7 +42,7 @@ func TestDeduplicate_FieldOrderPreservation(t *testing.T) {
 		}
 
 		// Should have exactly 4 unique fields
-		c.Assert(len(userFields), qt.Equals, 4)
+		c.Assert(userFields, qt.HasLen, 4)
 
 		// Order should be preserved: id, email, name, created_at
 		expectedOrder := []string{"id", "email", "name", "created_at"}
@@ -126,7 +126,7 @@ func TestDeduplicate_IndexOrderPreservation(t *testing.T) {
 	// Should preserve original order and remove duplicates
 	expectedOrder := []string{"idx_email", "idx_name", "idx_title", "idx_created_at"}
 	c.Assert(indexNames, qt.DeepEquals, expectedOrder)
-	c.Assert(len(db.Indexes), qt.Equals, 4) // Should have 4 unique indexes
+	c.Assert(db.Indexes, qt.HasLen, 4) // Should have 4 unique indexes
 }
 
 func TestDeduplicate_EnumOrderPreservation(t *testing.T) {
@@ -154,7 +154,7 @@ func TestDeduplicate_EnumOrderPreservation(t *testing.T) {
 	// Should preserve original order and remove duplicates
 	expectedOrder := []string{"user_status", "post_status", "priority"}
 	c.Assert(enumNames, qt.DeepEquals, expectedOrder)
-	c.Assert(len(db.Enums), qt.Equals, 3) // Should have 3 unique enums
+	c.Assert(db.Enums, qt.HasLen, 3) // Should have 3 unique enums
 }
 
 func TestDeduplicate_TableOrderPreservation(t *testing.T) {
@@ -183,7 +183,7 @@ func TestDeduplicate_TableOrderPreservation(t *testing.T) {
 	// Should preserve original order and remove duplicates
 	expectedOrder := []string{"users", "posts", "comments", "categories"}
 	c.Assert(tableNames, qt.DeepEquals, expectedOrder)
-	c.Assert(len(db.Tables), qt.Equals, 4) // Should have 4 unique tables
+	c.Assert(db.Tables, qt.HasLen, 4) // Should have 4 unique tables
 }
 
 func TestDeduplicate_EmbeddedFieldOrderPreservation(t *testing.T) {
@@ -213,7 +213,7 @@ func TestDeduplicate_EmbeddedFieldOrderPreservation(t *testing.T) {
 	// Should preserve original order and remove duplicates
 	expectedOrder := []string{"User.BaseEntity", "User.Timestamps", "Post.BaseEntity", "User.SoftDelete"}
 	c.Assert(embeddedKeys, qt.DeepEquals, expectedOrder)
-	c.Assert(len(db.EmbeddedFields), qt.Equals, 4) // Should have 4 unique embedded fields
+	c.Assert(db.EmbeddedFields, qt.HasLen, 4) // Should have 4 unique embedded fields
 }
 
 func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
@@ -263,7 +263,7 @@ func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 		tableNames = append(tableNames, table.Name)
 	}
 	c.Assert(tableNames, qt.DeepEquals, []string{"users", "posts"})
-	c.Assert(len(db.Tables), qt.Equals, 2)
+	c.Assert(db.Tables, qt.HasLen, 2)
 
 	// Fields - should maintain interleaved order
 	fieldKeys := make([]string, 0)
@@ -273,7 +273,7 @@ func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 	}
 	expectedFieldOrder := []string{"User.id", "Post.id", "User.email", "Post.title", "User.name", "Post.content"}
 	c.Assert(fieldKeys, qt.DeepEquals, expectedFieldOrder)
-	c.Assert(len(db.Fields), qt.Equals, 6)
+	c.Assert(db.Fields, qt.HasLen, 6)
 
 	// Indexes
 	indexNames := make([]string, 0)
@@ -281,7 +281,7 @@ func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 		indexNames = append(indexNames, index.Name)
 	}
 	c.Assert(indexNames, qt.DeepEquals, []string{"idx_email", "idx_title", "idx_name"})
-	c.Assert(len(db.Indexes), qt.Equals, 3)
+	c.Assert(db.Indexes, qt.HasLen, 3)
 
 	// Enums
 	enumNames := make([]string, 0)
@@ -289,7 +289,7 @@ func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 		enumNames = append(enumNames, enum.Name)
 	}
 	c.Assert(enumNames, qt.DeepEquals, []string{"status", "priority"})
-	c.Assert(len(db.Enums), qt.Equals, 2)
+	c.Assert(db.Enums, qt.HasLen, 2)
 
 	// Embedded Fields
 	embeddedKeys := make([]string, 0)
@@ -298,5 +298,5 @@ func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 		embeddedKeys = append(embeddedKeys, key)
 	}
 	c.Assert(embeddedKeys, qt.DeepEquals, []string{"User.BaseEntity", "Post.BaseEntity"})
-	c.Assert(len(db.EmbeddedFields), qt.Equals, 2)
+	c.Assert(db.EmbeddedFields, qt.HasLen, 2)
 }

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -68,7 +68,7 @@ type ProductIndexes struct {
 	c.Assert(err, qt.IsNil)
 
 	// Verify extensions are merged correctly (sorted alphabetically)
-	c.Assert(len(result.Extensions), qt.Equals, 2)
+	c.Assert(result.Extensions, qt.HasLen, 2)
 	c.Assert(result.Extensions[0].Name, qt.Equals, "btree_gin")
 	c.Assert(result.Extensions[0].IfNotExists, qt.Equals, true)
 	c.Assert(result.Extensions[0].Comment, qt.Equals, "Enable GIN indexes on btree types")
@@ -77,10 +77,10 @@ type ProductIndexes struct {
 	c.Assert(result.Extensions[1].Comment, qt.Equals, "Enable trigram similarity search")
 
 	// Verify other entities are also merged
-	c.Assert(len(result.Tables), qt.Equals, 1)
+	c.Assert(result.Tables, qt.HasLen, 1)
 	c.Assert(result.Tables[0].Name, qt.Equals, "products")
-	c.Assert(len(result.Indexes), qt.Equals, 2)
-	c.Assert(len(result.Fields), qt.Equals, 4)
+	c.Assert(result.Indexes, qt.HasLen, 2)
+	c.Assert(result.Fields, qt.HasLen, 4)
 }
 
 func TestParseDir_FileFiltering(t *testing.T) {
@@ -168,8 +168,8 @@ type User struct {
 			c.Assert(err, qt.IsNil)
 
 			// Verify filtering worked correctly
-			c.Assert(len(result.Tables), qt.Equals, tt.expectedTables)
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedFields)
+			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
 		})
 	}
 }
@@ -224,21 +224,21 @@ type Product struct {
 	c.Assert(err, qt.IsNil)
 
 	// Verify all entity types are merged correctly
-	c.Assert(len(result.Extensions), qt.Equals, 1)
+	c.Assert(result.Extensions, qt.HasLen, 1)
 	c.Assert(result.Extensions[0].Name, qt.Equals, "pg_trgm")
 
-	c.Assert(len(result.Enums), qt.Equals, 1)
+	c.Assert(result.Enums, qt.HasLen, 1)
 	c.Assert(result.Enums[0].Name, qt.Equals, "enum_user_status") // Auto-generated enum name
 
-	c.Assert(len(result.Tables), qt.Equals, 2)
+	c.Assert(result.Tables, qt.HasLen, 2)
 	tableNames := []string{result.Tables[0].Name, result.Tables[1].Name}
 	c.Assert(tableNames, qt.Contains, "users")
 	c.Assert(tableNames, qt.Contains, "products")
 
-	c.Assert(len(result.Indexes), qt.Equals, 1)
+	c.Assert(result.Indexes, qt.HasLen, 1)
 	c.Assert(result.Indexes[0].Name, qt.Equals, "idx_users_name")
 
-	c.Assert(len(result.Fields), qt.Equals, 4) // 3 from users, 1 from products
+	c.Assert(result.Fields, qt.HasLen, 4) // 3 from users, 1 from products
 }
 
 func TestParseDir_ErrorHandling(t *testing.T) {
@@ -277,8 +277,8 @@ func TestParseDir_ErrorHandling(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(result, qt.IsNotNil)
 				// Empty directory should return empty but valid result
-				c.Assert(len(result.Tables), qt.Equals, 0)
-				c.Assert(len(result.Extensions), qt.Equals, 0)
+				c.Assert(result.Tables, qt.HasLen, 0)
+				c.Assert(result.Extensions, qt.HasLen, 0)
 				c.Assert(result.Dependencies, qt.IsNotNil)
 			}
 		})
@@ -320,7 +320,7 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 
 	// Verify deduplication worked
-	c.Assert(len(result.Tables), qt.Equals, 1) // Should have only one "users" table
+	c.Assert(result.Tables, qt.HasLen, 1) // Should have only one "users" table
 
 	// Verify all fields are merged (should have id, name, email)
 	userFields := []goschema.Field{}
@@ -329,7 +329,7 @@ type User struct {
 			userFields = append(userFields, field)
 		}
 	}
-	c.Assert(len(userFields), qt.Equals, 3)
+	c.Assert(userFields, qt.HasLen, 3)
 
 	fieldNames := []string{}
 	for _, field := range userFields {
@@ -508,9 +508,9 @@ type Product struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check counts
-			c.Assert(len(result.Tables), qt.Equals, tt.expectedTables)
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedFields)
-			c.Assert(len(result.Enums), qt.Equals, tt.expectedEnums)
+			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
+			c.Assert(result.Enums, qt.HasLen, tt.expectedEnums)
 
 			// Check specific tables exist
 			tableNames := make(map[string]bool)
@@ -620,8 +620,8 @@ type User struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check counts
-			c.Assert(len(result.Tables), qt.Equals, tt.expectedTables)
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedFields)
+			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
 		})
 	}
 }
@@ -819,7 +819,7 @@ type Order struct {
 			// Check self-referencing foreign keys
 			for table, expectedCount := range tt.expectedSelfReferencing {
 				actualSelfRefs := result.SelfReferencingForeignKeys[table]
-				c.Assert(len(actualSelfRefs), qt.Equals, expectedCount, qt.Commentf("Self-referencing FKs for table %s", table))
+				c.Assert(actualSelfRefs, qt.HasLen, expectedCount, qt.Commentf("Self-referencing FKs for table %s", table))
 			}
 		})
 	}
@@ -874,8 +874,8 @@ type User struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check counts after deduplication
-			c.Assert(len(result.Tables), qt.Equals, tt.expectedTables)
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedFields)
+			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
 
 			// Verify no duplicate table names
 			tableNames := make(map[string]int)
@@ -940,10 +940,10 @@ type User struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check embedded fields
-			c.Assert(len(result.EmbeddedFields), qt.Equals, tt.expectedEmbeddedFields)
+			c.Assert(result.EmbeddedFields, qt.HasLen, tt.expectedEmbeddedFields)
 
 			// Check that embedded fields are processed into regular fields
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedProcessedFields)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedProcessedFields)
 		})
 	}
 }
@@ -1015,10 +1015,10 @@ type User struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check PostgreSQL features
-			c.Assert(len(result.Extensions), qt.Equals, tt.expectedExtensions)
-			c.Assert(len(result.Functions), qt.Equals, tt.expectedFunctions)
-			c.Assert(len(result.RLSPolicies), qt.Equals, tt.expectedRLSPolicies)
-			c.Assert(len(result.Roles), qt.Equals, tt.expectedRoles)
+			c.Assert(result.Extensions, qt.HasLen, tt.expectedExtensions)
+			c.Assert(result.Functions, qt.HasLen, tt.expectedFunctions)
+			c.Assert(result.RLSPolicies, qt.HasLen, tt.expectedRLSPolicies)
+			c.Assert(result.Roles, qt.HasLen, tt.expectedRoles)
 
 			// Verify specific content
 			if tt.expectedExtensions > 0 {
@@ -1156,8 +1156,8 @@ type OtherTable struct {
 			c.Assert(result, qt.IsNotNil)
 
 			// Check counts
-			c.Assert(len(result.Tables), qt.Equals, tt.expectedTables)
-			c.Assert(len(result.Fields), qt.Equals, tt.expectedFields)
+			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
+			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
 		})
 	}
 }
@@ -1175,11 +1175,11 @@ func TestParseFS_CompareWithParseDir(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Results should be identical
-	c.Assert(len(resultFS.Tables), qt.Equals, len(resultDir.Tables))
-	c.Assert(len(resultFS.Fields), qt.Equals, len(resultDir.Fields))
-	c.Assert(len(resultFS.Indexes), qt.Equals, len(resultDir.Indexes))
-	c.Assert(len(resultFS.Enums), qt.Equals, len(resultDir.Enums))
-	c.Assert(len(resultFS.EmbeddedFields), qt.Equals, len(resultDir.EmbeddedFields))
+	c.Assert(resultFS.Tables, qt.HasLen, len(resultDir.Tables))
+	c.Assert(resultFS.Fields, qt.HasLen, len(resultDir.Fields))
+	c.Assert(resultFS.Indexes, qt.HasLen, len(resultDir.Indexes))
+	c.Assert(resultFS.Enums, qt.HasLen, len(resultDir.Enums))
+	c.Assert(resultFS.EmbeddedFields, qt.HasLen, len(resultDir.EmbeddedFields))
 
 	// Compare table names
 	tableDirNames := make(map[string]bool)

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -25,13 +25,13 @@ func TestParser_ParseCreateTable_Basic(t *testing.T) {
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements, qt.IsNotNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	// Check that it's a CREATE TABLE statement
 	createTable, ok := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(createTable.Name, qt.Equals, "users")
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 
 	// Check first column (id)
 	idColumn := createTable.Columns[0]
@@ -57,12 +57,12 @@ func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "orders")
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check id column
 	idColumn := createTable.Columns[0]
@@ -90,7 +90,7 @@ func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "products")
@@ -107,12 +107,12 @@ func TestParser_ParseAlterTable(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(alterTable.Name, qt.Equals, "users")
-	c.Assert(len(alterTable.Operations), qt.Equals, 1)
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
 
 	addOp, ok := alterTable.Operations[0].(*ast.AddColumnOperation)
 	c.Assert(ok, qt.IsTrue)
@@ -129,7 +129,7 @@ func TestParser_ParseCreateIndex(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	index, ok := statements.Statements[0].(*ast.IndexNode)
 	c.Assert(ok, qt.IsTrue)
@@ -147,7 +147,7 @@ func TestParser_ParseCreateUniqueIndex(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	index, ok := statements.Statements[0].(*ast.IndexNode)
 	c.Assert(ok, qt.IsTrue)
@@ -165,7 +165,7 @@ func TestParser_ParseCreateEnum(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	enum, ok := statements.Statements[0].(*ast.EnumNode)
 	c.Assert(ok, qt.IsTrue)
@@ -185,7 +185,7 @@ func TestParser_ParseMultipleStatements(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 3)
+	c.Assert(statements.Statements, qt.HasLen, 3)
 
 	// Check first statement
 	createTable, ok := statements.Statements[0].(*ast.CreateTableNode)
@@ -211,10 +211,10 @@ func TestParser_ParseColumnWithForeignKey(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 
 	column := createTable.Columns[0]
 	c.Assert(column.Name, qt.Equals, "user_id")
@@ -232,7 +232,7 @@ func TestParser_ParseColumnWithDefaultFunction(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	column := createTable.Columns[0]
@@ -259,12 +259,12 @@ func TestParser_ParseComplexTable(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "complex_table")
-	c.Assert(len(createTable.Columns), qt.Equals, 7)
-	c.Assert(len(createTable.Constraints), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 7)
+	c.Assert(createTable.Constraints, qt.HasLen, 2)
 
 	// Check id column
 	idCol := createTable.Columns[0]
@@ -315,11 +315,11 @@ func TestParser_ParseAlterTableMultipleOperations(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	alterTable := statements.Statements[0].(*ast.AlterTableNode)
 	c.Assert(alterTable.Name, qt.Equals, "users")
-	c.Assert(len(alterTable.Operations), qt.Equals, 3)
+	c.Assert(alterTable.Operations, qt.HasLen, 3)
 
 	// Check ADD operation
 	addOp, ok := alterTable.Operations[0].(*ast.AddColumnOperation)
@@ -355,12 +355,12 @@ func TestParser_ParseMySQLStyleTable(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`sample`")
-	c.Assert(len(createTable.Columns), qt.Equals, 5)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 5)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check id column
 	idColumn := createTable.Columns[0]
@@ -417,11 +417,11 @@ func TestParser_ParseBacktickedIdentifiers(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`users`")
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 
 	// Check first column
 	userIDColumn := createTable.Columns[0]
@@ -444,12 +444,12 @@ func TestParser_ParseSimpleMySQLTable(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`sample`")
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check id column
 	idColumn := createTable.Columns[0]
@@ -467,10 +467,10 @@ func TestParser_ParseCurrentTimestamp(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 
 	column := createTable.Columns[0]
 	c.Assert(column.Name, qt.Equals, "`created_at`")
@@ -492,11 +492,11 @@ func TestParser_ParseMySQLTableStepByStep(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`sample`")
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 }
 
 func TestParser_ParseNumericDefault(t *testing.T) {
@@ -507,10 +507,10 @@ func TestParser_ParseNumericDefault(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 
 	column := createTable.Columns[0]
 	c.Assert(column.Name, qt.Equals, "`age`")
@@ -532,11 +532,11 @@ func TestParser_ParseMySQLTableWithTimestamp(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`sample`")
-	c.Assert(len(createTable.Columns), qt.Equals, 3)
+	c.Assert(createTable.Columns, qt.HasLen, 3)
 
 	// Check created_at column
 	createdColumn := createTable.Columns[1]
@@ -634,10 +634,10 @@ func TestParser_ParseMySQLDataTypes(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 			c.Assert(createTable.Columns[0].Type, qt.Equals, tt.expectedType)
 		})
 	}
@@ -656,7 +656,7 @@ func TestParser_ParseMySQLTableOptions(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Options["ENGINE"], qt.Equals, "MyISAM")
@@ -673,7 +673,7 @@ func TestParser_ParsePostgreSQLEnum(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	enum, ok := statements.Statements[0].(*ast.EnumNode)
 	c.Assert(ok, qt.IsTrue)
@@ -690,7 +690,7 @@ func TestParser_ParsePostgreSQLDomain(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	comment, ok := statements.Statements[0].(*ast.CommentNode)
 	c.Assert(ok, qt.IsTrue)
@@ -709,11 +709,11 @@ func TestParser_ParsePostgreSQLSerialTypes(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "test")
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 
 	// Check SERIAL column
 	serialCol := createTable.Columns[0]
@@ -739,10 +739,10 @@ func TestParser_ParsePostgreSQLArrayTypes(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 
 	// Check TEXT[] column with array default
 	tagsCol := createTable.Columns[0]
@@ -765,10 +765,10 @@ func TestParser_ParsePostgreSQLUUIDWithFunction(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 
 	uuidCol := createTable.Columns[0]
 	c.Assert(uuidCol.Name, qt.Equals, "uuid_id")
@@ -786,10 +786,10 @@ func TestParser_ParsePostgreSQLGeneratedColumn(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 3)
+	c.Assert(createTable.Columns, qt.HasLen, 3)
 
 	// Check generated column
 	fullNameCol := createTable.Columns[2]
@@ -810,10 +810,10 @@ func TestParser_ParsePostgreSQLJSONTypes(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 
 	// Check JSON column
 	jsonCol := createTable.Columns[0]
@@ -837,7 +837,7 @@ func TestParser_ParsePostgreSQLCommentStatements(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	comment, ok := statements.Statements[0].(*ast.CommentNode)
 	c.Assert(ok, qt.IsTrue)
@@ -853,11 +853,11 @@ func TestParser_ParsePostgreSQLSchemaTable(t *testing.T) {
 
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "public.test")
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 }
 
 func TestParser_ParsePostgreSQLFullDemo(t *testing.T) {
@@ -876,11 +876,11 @@ func TestParser_ParsePostgreSQLFullDemo(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "public.full_demo")
-	c.Assert(len(createTable.Columns), qt.Equals, 6)
+	c.Assert(createTable.Columns, qt.HasLen, 6)
 
 	// Test some key columns
 	serialCol := createTable.Columns[0]
@@ -925,7 +925,7 @@ func TestParser_ParsePostgreSQLMultipleStatements(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 4)
+	c.Assert(statements.Statements, qt.HasLen, 4)
 
 	// Check enum
 	enum, ok := statements.Statements[0].(*ast.EnumNode)
@@ -941,7 +941,7 @@ func TestParser_ParsePostgreSQLMultipleStatements(t *testing.T) {
 	table, ok := statements.Statements[2].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(table.Name, qt.Equals, "test")
-	c.Assert(len(table.Columns), qt.Equals, 3)
+	c.Assert(table.Columns, qt.HasLen, 3)
 
 	// Check comment
 	comment, ok := statements.Statements[3].(*ast.CommentNode)
@@ -983,13 +983,13 @@ func TestParser_ParsePostgreSQLComprehensiveDemo(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "public.full_demo")
 
 	// Test that we have the expected number of columns (now includes DOUBLE PRECISION)
-	c.Assert(len(createTable.Columns), qt.Equals, 20)
+	c.Assert(createTable.Columns, qt.HasLen, 20)
 
 	// Test key PostgreSQL features
 
@@ -1098,7 +1098,7 @@ func TestParser_ParsePostgreSQLComprehensiveDemo(t *testing.T) {
 	c.Assert(userIDCol.ForeignKey.OnUpdate, qt.Equals, "SET NULL")
 
 	// Test table-level constraints
-	c.Assert(len(createTable.Constraints), qt.Equals, 3)
+	c.Assert(createTable.Constraints, qt.HasLen, 3)
 
 	// Unique constraint
 	uniqueConstraint := createTable.Constraints[0]
@@ -1163,10 +1163,10 @@ func TestParser_ParseMultiWordTypes(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 
 			column := createTable.Columns[0]
 			c.Assert(column.Type, qt.Equals, tt.expectedType)
@@ -1209,10 +1209,10 @@ func TestParser_ParseParameterizedArrayTypes(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 
 			column := createTable.Columns[0]
 			c.Assert(column.Type, qt.Equals, tt.expectedType)
@@ -1233,11 +1233,11 @@ func TestParser_ParseOriginalProblematicSQL(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "public.full_demo")
-	c.Assert(len(createTable.Columns), qt.Equals, 3)
+	c.Assert(createTable.Columns, qt.HasLen, 3)
 
 	// Verify DOUBLE PRECISION column is parsed correctly
 	doubleCol := createTable.Columns[1]
@@ -1309,10 +1309,10 @@ func TestParser_ParsePostgreSQLTableOptions(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 
 			// Verify all expected options are present
 			for key, expectedValue := range tt.expectedOptions {
@@ -1461,7 +1461,7 @@ func TestParser_ParseExtendedPostgreSQLDemo(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "public.extended_demo")
@@ -1587,7 +1587,7 @@ func TestParser_ParseMariaDBComprehensiveDemo(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`full_demo`")
@@ -1603,7 +1603,7 @@ func TestParser_ParseMariaDBComprehensiveDemo(t *testing.T) {
 	}
 
 	// Test that we have the expected number of columns (14 total)
-	c.Assert(len(createTable.Columns), qt.Equals, 14)
+	c.Assert(createTable.Columns, qt.HasLen, 14)
 
 	// Test auto-increment unsigned primary key
 	idCol := createTable.Columns[0]
@@ -1714,7 +1714,7 @@ func TestParser_TimeoutProtection(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 }
 
 func TestParser_MariaDBMinimal(t *testing.T) {
@@ -1725,11 +1725,11 @@ func TestParser_MariaDBMinimal(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "`test`")
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 
 	// Test the id column
 	idCol := createTable.Columns[0]
@@ -1775,10 +1775,10 @@ func TestParser_MariaDBTypeModifiers(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 			c.Assert(createTable.Columns[0].Type, qt.Equals, tt.expectedType)
 		})
 	}
@@ -1792,10 +1792,10 @@ func TestParser_MariaDBCharacterSet(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 	c.Assert(createTable.Columns[0].Type, qt.Equals, "VARCHAR(50)")
 }
 
@@ -1824,10 +1824,10 @@ func TestParser_MariaDBEnumAndSet(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Columns), qt.Equals, 1)
+			c.Assert(createTable.Columns, qt.HasLen, 1)
 			c.Assert(createTable.Columns[0].Type, qt.Equals, tt.expectedType)
 		})
 	}
@@ -1841,10 +1841,10 @@ func TestParser_MariaDBVirtualColumn(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
 	c.Assert(createTable.Columns[1].Type, qt.Equals, "VARCHAR(100)")
 }
 
@@ -1862,10 +1862,10 @@ func TestParser_MariaDBTableOptions(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 }
 
 func TestParser_MariaDBFirstFewColumns(t *testing.T) {
@@ -1880,7 +1880,7 @@ func TestParser_MariaDBFirstFewColumns(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -1890,7 +1890,7 @@ func TestParser_MariaDBFirstFewColumns(t *testing.T) {
 		t.Logf("  %d: %s %s", i, col.Name, col.Type)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 3)
+	c.Assert(createTable.Columns, qt.HasLen, 3)
 }
 
 func TestParser_MariaDBWithCheckConstraint(t *testing.T) {
@@ -1903,7 +1903,7 @@ func TestParser_MariaDBWithCheckConstraint(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -1913,7 +1913,7 @@ func TestParser_MariaDBWithCheckConstraint(t *testing.T) {
 		t.Logf("  %d: %s %s", i, col.Name, col.Type)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 }
 
 func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
@@ -1926,7 +1926,7 @@ func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -1936,7 +1936,7 @@ func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 		t.Logf("  %d: %s %s", i, col.Name, col.Type)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
 }
 
 func TestParser_MariaDBFirst5Columns(t *testing.T) {
@@ -1958,7 +1958,7 @@ func TestParser_MariaDBFirst5Columns(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -1972,7 +1972,7 @@ func TestParser_MariaDBFirst5Columns(t *testing.T) {
 		t.Logf("  %d: %s %v", i, constraint.Type, constraint.Columns)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 5)
+	c.Assert(createTable.Columns, qt.HasLen, 5)
 }
 
 func TestParser_MariaDBFirst7Columns(t *testing.T) {
@@ -1993,7 +1993,7 @@ func TestParser_MariaDBFirst7Columns(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -2003,7 +2003,7 @@ func TestParser_MariaDBFirst7Columns(t *testing.T) {
 		t.Logf("  %d: %s %s", i, col.Name, col.Type)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 7)
+	c.Assert(createTable.Columns, qt.HasLen, 7)
 }
 
 func TestParser_MariaDBFirst10Columns(t *testing.T) {
@@ -2029,7 +2029,7 @@ func TestParser_MariaDBFirst10Columns(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
@@ -2039,7 +2039,7 @@ func TestParser_MariaDBFirst10Columns(t *testing.T) {
 		t.Logf("  %d: %s %s", i, col.Name, col.Type)
 	}
 
-	c.Assert(len(createTable.Columns), qt.Equals, 10)
+	c.Assert(createTable.Columns, qt.HasLen, 10)
 }
 
 func TestParser_ErrorHandling(t *testing.T) {
@@ -2121,12 +2121,12 @@ func TestParser_ParseExcludeConstraint_Basic(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Name, qt.Equals, "user_sessions")
-	c.Assert(len(createTable.Columns), qt.Equals, 2)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check EXCLUDE constraint
 	excludeConstraint := createTable.Constraints[0]
@@ -2149,10 +2149,10 @@ func TestParser_ParseExcludeConstraint_WithName(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check named EXCLUDE constraint
 	excludeConstraint := createTable.Constraints[0]
@@ -2175,10 +2175,10 @@ func TestParser_ParseExcludeConstraint_ComplexElements(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check EXCLUDE constraint with complex elements
 	excludeConstraint := createTable.Constraints[0]
@@ -2199,10 +2199,10 @@ func TestParser_ParseExcludeConstraint_WithoutWhere(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check EXCLUDE constraint without WHERE clause
 	excludeConstraint := createTable.Constraints[0]
@@ -2223,10 +2223,10 @@ func TestParser_ParseExcludeConstraint_BtreeMethod(t *testing.T) {
 	p := parser.NewParser(sql)
 	statements, err := p.Parse()
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(statements.Statements), qt.Equals, 1)
+	c.Assert(statements.Statements, qt.HasLen, 1)
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
-	c.Assert(len(createTable.Constraints), qt.Equals, 1)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 	// Check EXCLUDE constraint with btree method
 	excludeConstraint := createTable.Constraints[0]
@@ -2375,10 +2375,10 @@ func TestParser_ParseExcludeConstraint_EdgeCases(t *testing.T) {
 			p := parser.NewParser(tt.sql)
 			statements, err := p.Parse()
 			c.Assert(err, qt.IsNil)
-			c.Assert(len(statements.Statements), qt.Equals, 1)
+			c.Assert(statements.Statements, qt.HasLen, 1)
 
 			createTable := statements.Statements[0].(*ast.CreateTableNode)
-			c.Assert(len(createTable.Constraints), qt.Equals, 1)
+			c.Assert(createTable.Constraints, qt.HasLen, 1)
 
 			constraint := createTable.Constraints[0]
 			c.Assert(constraint.Type, qt.Equals, ast.ExcludeConstraint)

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -105,7 +105,7 @@ func TestPresets_AllValid_AndCoverEveryRegisteredCapability(t *testing.T) {
 			_, present := preset[key]
 			c.Assert(present, qt.IsTrue, qt.Commentf("preset %s is missing registry key %q", name, key))
 		}
-		c.Assert(len(preset), qt.Equals, len(capability.All()), qt.Commentf("preset %s carries an extra key", name))
+		c.Assert(preset, qt.HasLen, len(capability.All()), qt.Commentf("preset %s carries an extra key", name))
 	}
 }
 
@@ -244,7 +244,7 @@ func TestDoc(t *testing.T) {
 	c := qt.New(t)
 
 	for _, key := range capability.All() {
-		c.Assert(capability.Doc(key) != "", qt.IsTrue, qt.Commentf("registry entry %q must carry documentation", key))
+		c.Assert(capability.Doc(key), qt.Not(qt.Equals), "", qt.Commentf("registry entry %q must carry documentation", key))
 	}
 	c.Assert(capability.Doc("nope"), qt.Equals, "")
 }

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -1,7 +1,6 @@
 package renderer_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -37,11 +36,11 @@ func TestMySQLFamilyRenderers_ConstraintDropGuardValidity(t *testing.T) {
 
 		sql, err := renderer.RenderSQL("mysql", dropFK, dropCheck)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;",
 			qt.Commentf("got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_qty;",
 			qt.Commentf("got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 			qt.Commentf("MySQL accepts no IF EXISTS on constraint drops; got:\n%s", sql))
 	})
 
@@ -50,9 +49,9 @@ func TestMySQLFamilyRenderers_ConstraintDropGuardValidity(t *testing.T) {
 
 		sql, err := renderer.RenderSQL("mariadb", dropFK, dropCheck)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;",
 			qt.Commentf("got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_qty;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_qty;",
 			qt.Commentf("got:\n%s", sql))
 	})
 }
@@ -74,14 +73,14 @@ func TestMySQLFamilyRenderers_DropCheckSpelling(t *testing.T) {
 	}
 	sql, err := renderer.RenderSQL("mysql", node)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CHECK chk_qty;"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CHECK chk_qty;",
 		qt.Commentf("got:\n%s", sql))
 
 	sql, err = renderer.RenderSQL("mariadb", node)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_qty;",
 		qt.Commentf("mariadb must degrade DROP CHECK to the generic clause; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "DROP CHECK"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "DROP CHECK",
 		qt.Commentf("got:\n%s", sql))
 }
 
@@ -102,7 +101,7 @@ func TestMySQLFamilyRenderers_DropUniqueIndexSpelling(t *testing.T) {
 	for _, dialect := range []string{"mysql", "mariadb"} {
 		sql, err := renderer.RenderSQL(dialect, node)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
 			qt.Commentf("%s: got:\n%s", dialect, sql))
 	}
 }
@@ -117,12 +116,12 @@ func TestMySQLFamilyRenderers_DropIndexGuardValidity(t *testing.T) {
 
 	sqlMySQL, err := renderer.RenderSQL("mysql", node)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sqlMySQL, "DROP INDEX idx_users_email ON users;"), qt.IsTrue,
+	c.Assert(sqlMySQL, qt.Contains, "DROP INDEX idx_users_email ON users;",
 		qt.Commentf("got:\n%s", sqlMySQL))
-	c.Assert(strings.Contains(sqlMySQL, "IF EXISTS"), qt.IsFalse)
+	c.Assert(sqlMySQL, qt.Not(qt.Contains), "IF EXISTS")
 
 	sqlMariaDB, err := renderer.RenderSQL("mariadb", node)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX IF EXISTS idx_users_email ON users;"), qt.IsTrue,
+	c.Assert(sqlMariaDB, qt.Contains, "DROP INDEX IF EXISTS idx_users_email ON users;",
 		qt.Commentf("got:\n%s", sqlMariaDB))
 }

--- a/core/renderer/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/dialects/clickhouse/clickhouse_test.go
@@ -368,7 +368,7 @@ func TestUnsupportedFeaturesEmitCommentAndReturnNil(t *testing.T) {
 			err := renderErr(tc.node)
 			c.Assert(err, qt.IsNil)
 			out := render(t, tc.node)
-			c.Assert(strings.Contains(out, "-- CLICKHOUSE:"), qt.IsTrue, qt.Commentf("expected '-- CLICKHOUSE:' marker, got: %q", out))
+			c.Assert(out, qt.Contains, "-- CLICKHOUSE:", qt.Commentf("expected '-- CLICKHOUSE:' marker, got: %q", out))
 		})
 	}
 }

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -1,7 +1,6 @@
 package mysql_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -50,6 +49,6 @@ func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 
 	c.Assert(out, qt.Contains, "-- MYSQL: data-skipping indexes are ClickHouse-specific; ignored.")
 	c.Assert(out, qt.Contains, "-- MYSQL: table TTL is ClickHouse-specific; ignored.")
-	c.Assert(strings.Contains(out, "ADD INDEX"), qt.IsFalse)
-	c.Assert(strings.Contains(out, "MODIFY TTL"), qt.IsFalse)
+	c.Assert(out, qt.Not(qt.Contains), "ADD INDEX")
+	c.Assert(out, qt.Not(qt.Contains), "MODIFY TTL")
 }

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -1,7 +1,6 @@
 package postgres_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -53,8 +52,8 @@ func TestPostgres_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 	c.Assert(out, qt.Contains, "-- POSTGRES: data-skipping indexes are ClickHouse-specific; ignored.")
 	c.Assert(out, qt.Contains, "-- POSTGRES: table TTL is ClickHouse-specific; ignored.")
 	// No executable ALTER statement should have been emitted by these branches.
-	c.Assert(strings.Contains(out, "ADD INDEX"), qt.IsFalse,
+	c.Assert(out, qt.Not(qt.Contains), "ADD INDEX",
 		qt.Commentf("postgres must not emit ADD INDEX for an AddSkippingIndexOperation; got: %q", out))
-	c.Assert(strings.Contains(out, "MODIFY TTL"), qt.IsFalse,
+	c.Assert(out, qt.Not(qt.Contains), "MODIFY TTL",
 		qt.Commentf("postgres must not emit MODIFY TTL for a ModifyTTLOperation; got: %q", out))
 }

--- a/core/renderer/dialects/postgres/postgres_role_test.go
+++ b/core/renderer/dialects/postgres/postgres_role_test.go
@@ -145,7 +145,7 @@ func TestPostgreSQLRenderer_VisitAlterRole(t *testing.T) {
 
 		c.Assert(err, qt.IsNil)
 		lines := strings.Split(strings.TrimSpace(sql), "\n")
-		c.Assert(len(lines), qt.Equals, 3)
+		c.Assert(lines, qt.HasLen, 3)
 		c.Assert(lines[0], qt.Equals, "ALTER ROLE test_role LOGIN;")
 		c.Assert(lines[1], qt.Equals, "ALTER ROLE test_role PASSWORD 'md5a1b2c3d4e5f6789012345678901234';")
 		c.Assert(lines[2], qt.Equals, "ALTER ROLE test_role CREATEDB;")
@@ -167,7 +167,7 @@ func TestPostgreSQLRenderer_VisitAlterRole(t *testing.T) {
 
 		c.Assert(err, qt.IsNil)
 		lines := strings.Split(strings.TrimSpace(sql), "\n")
-		c.Assert(len(lines), qt.Equals, 7)
+		c.Assert(lines, qt.HasLen, 7)
 		c.Assert(lines[0], qt.Equals, "ALTER ROLE test_role NOLOGIN;")
 		c.Assert(lines[1], qt.Equals, "ALTER ROLE test_role PASSWORD 'SCRAM-SHA-256$4096:abcd1234$hash:signature';")
 		c.Assert(lines[2], qt.Equals, "ALTER ROLE test_role SUPERUSER;")

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -407,7 +407,7 @@ func TestGetOrderedCreateStatements(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	statements := renderer.GetOrderedCreateStatements(result, "postgres")
-	c.Assert(len(statements), qt.Equals, len(result.Tables)+3) // 1 type + 2 indexes
+	c.Assert(statements, qt.HasLen, len(result.Tables)+3) // 1 type + 2 indexes
 
 	c.Assert(statements[0], qt.Contains, "CREATE TYPE")
 	c.Assert(statements[17], qt.Contains, "CREATE INDEX")

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -2,7 +2,6 @@ package dbschema_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -182,7 +181,7 @@ func TestConnectToDatabase_CancelledContext(t *testing.T) {
 
 	c.Assert(conn, qt.IsNil)
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(errors.Is(err, context.Canceled), qt.IsTrue,
+	c.Assert(err, qt.ErrorIs, context.Canceled,
 		qt.Commentf("expected context.Canceled in error chain, got: %v", err))
 
 	// "Promptly" is intentionally loose to avoid flakiness on slow CI runners,
@@ -208,7 +207,7 @@ func TestConnectToDatabase_DeadlineExceeded(t *testing.T) {
 
 	c.Assert(conn, qt.IsNil)
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(errors.Is(err, context.DeadlineExceeded), qt.IsTrue,
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded,
 		qt.Commentf("expected context.DeadlineExceeded in error chain, got: %v", err))
 
 	// Generous upper bound — the deadline is 200ms; allow for handshake +

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -128,7 +128,7 @@ func TestMySQLReader_parseTableFromDDL(t *testing.T) {
 			validate: func(c *qt.C, table types.DBTable) {
 				c.Assert(table.Name, qt.Equals, "users")
 				c.Assert(table.Type, qt.Equals, "BASE TABLE")
-				c.Assert(len(table.Columns), qt.Equals, 3)
+				c.Assert(table.Columns, qt.HasLen, 3)
 
 				// Check id column
 				idCol := table.Columns[0]
@@ -166,7 +166,7 @@ func TestMySQLReader_parseTableFromDDL(t *testing.T) {
 			expectError: false,
 			validate: func(c *qt.C, table types.DBTable) {
 				c.Assert(table.Name, qt.Equals, "products")
-				c.Assert(len(table.Columns), qt.Equals, 2)
+				c.Assert(table.Columns, qt.HasLen, 2)
 
 				// Check sku column should be marked as unique
 				skuCol := table.Columns[1]
@@ -187,7 +187,7 @@ func TestMySQLReader_parseTableFromDDL(t *testing.T) {
 			expectError: false,
 			validate: func(c *qt.C, table types.DBTable) {
 				c.Assert(table.Name, qt.Equals, "test_table")
-				c.Assert(len(table.Columns), qt.Equals, 4)
+				c.Assert(table.Columns, qt.HasLen, 4)
 
 				// Check id column
 				idCol := table.Columns[0]

--- a/dbschema/postgres/exclude_constraints_test.go
+++ b/dbschema/postgres/exclude_constraints_test.go
@@ -221,7 +221,7 @@ func TestEnhanceExcludeConstraints(t *testing.T) {
 			// For now, we'll test the parsing logic separately
 			// In a full implementation, you would use a test database or mock the SQL queries
 
-			c.Assert(len(tt.expectedConstraints), qt.Equals, len(tt.basicConstraints))
+			c.Assert(tt.expectedConstraints, qt.HasLen, len(tt.basicConstraints))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
+	github.com/go-extras/qtlint v1.6.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
@@ -46,6 +47,10 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/tools v0.47.0 // indirect
 )
+
+tool github.com/go-extras/qtlint/cmd/qtlint

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/go-extras/cobraflags v0.0.0-20260116100222-f76efc9500d4 h1:V+pPX/Arkw
 github.com/go-extras/cobraflags v0.0.0-20260116100222-f76efc9500d4/go.mod h1:7/Lp0Dpz9+tTeHOat9fTxQxrLPuBJva/eSs/o76wGco=
 github.com/go-extras/go-kit v1.2.0 h1:Q0v8TIq8uEqTfAiE6VstKUhaiVrpiRLssQZA0qFE62o=
 github.com/go-extras/go-kit v1.2.0/go.mod h1:Fy+eKjteQ6nP6R3raMRXG9SuXQ67egS75OIMn0LgLUk=
+github.com/go-extras/qtlint v1.6.0 h1:TXKNWH6QDqW3trD1QnQkHsxA47EQje+ioC0bX8it4rI=
+github.com/go-extras/qtlint v1.6.0/go.mod h1:L+/3a6KjcV6jygzzGrgo0oYjLoX2pTahQiDMQ7Hzyeg=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
@@ -95,12 +97,16 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/integration/dynamic_test.go
+++ b/integration/dynamic_test.go
@@ -35,10 +35,10 @@ func TestVersionedEntityManager(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		// Should have 2 tables: users, products
-		c.Assert(len(schema.Tables), qt.Equals, 2)
+		c.Assert(schema.Tables, qt.HasLen, 2)
 
 		// Should have no enums in initial version
-		c.Assert(len(schema.Enums), qt.Equals, 0)
+		c.Assert(schema.Enums, qt.HasLen, 0)
 
 		// Check table names
 		tableNames := make(map[string]bool)
@@ -61,10 +61,10 @@ func TestVersionedEntityManager(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		// Should have 3 tables: users, products, posts
-		c.Assert(len(schema.Tables), qt.Equals, 3)
+		c.Assert(schema.Tables, qt.HasLen, 3)
 
 		// Should have 3 enums
-		c.Assert(len(schema.Enums), qt.Equals, 3)
+		c.Assert(schema.Enums, qt.HasLen, 3)
 
 		// Check enum names (parser adds "enum_" prefix)
 		enumNames := make(map[string]bool)

--- a/integration/rls_integration_test.go
+++ b/integration/rls_integration_test.go
@@ -59,11 +59,11 @@ func TestRLSIntegrationFixtures(t *testing.T) {
 			c.Assert(err, qt.IsNil, qt.Commentf("Failed to parse fixture directory: %s", tc.fixtureDir))
 
 			// Check that the expected number of RLS policies are parsed
-			c.Assert(len(generated.RLSPolicies), qt.Equals, tc.expectedPolicies,
+			c.Assert(generated.RLSPolicies, qt.HasLen, tc.expectedPolicies,
 				qt.Commentf("Expected %d RLS policies, got %d. %s", tc.expectedPolicies, len(generated.RLSPolicies), tc.description))
 
 			// Check that the expected number of RLS enabled tables are parsed
-			c.Assert(len(generated.RLSEnabledTables), qt.Equals, tc.expectedEnabledTables,
+			c.Assert(generated.RLSEnabledTables, qt.HasLen, tc.expectedEnabledTables,
 				qt.Commentf("Expected %d RLS enabled tables, got %d. %s", tc.expectedEnabledTables, len(generated.RLSEnabledTables), tc.description))
 
 			// Test migration generation

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -56,7 +56,7 @@ func TestGetDynamicScenarios(t *testing.T) {
 	scenarios := GetDynamicScenarios()
 
 	// Should have exactly 41 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169)
-	c.Assert(len(scenarios), qt.Equals, 41)
+	c.Assert(scenarios, qt.HasLen, 41)
 
 	// Verify all scenarios have required fields
 	for _, scenario := range scenarios {

--- a/migration/generator/compare_options_test.go
+++ b/migration/generator/compare_options_test.go
@@ -89,7 +89,7 @@ func TestGenerateMigrationOptions_CompareOptions_NilHandling_DefaultBehavior(t *
 
 	// With nil options, should use defaults (ignore plpgsql)
 	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
-	c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 1) // adminpack should be removed
+	c.Assert(diff.ExtensionsRemoved, qt.HasLen, 1) // adminpack should be removed
 	c.Assert(diff.ExtensionsRemoved, qt.Contains, "adminpack")
 }
 
@@ -118,7 +118,7 @@ func TestGenerateMigrationOptions_CompareOptions_NilHandling_CustomOptions(t *te
 
 	// With custom options ignoring both plpgsql and adminpack
 	c.Assert(diff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
-	c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 0) // both should be ignored
+	c.Assert(diff.ExtensionsRemoved, qt.HasLen, 0) // both should be ignored
 }
 
 // TestGenerateMigrationOptions_CompareOptions_ConfigurationValidation tests that
@@ -197,9 +197,9 @@ func TestGenerateMigrationOptions_CompareOptions_ConfigurationValidation(t *test
 
 			diff := schemadiff.CompareWithOptions(generated, database, tt.compareOptions)
 
-			c.Assert(len(diff.ExtensionsAdded), qt.Equals, tt.expectedAddedCount,
+			c.Assert(diff.ExtensionsAdded, qt.HasLen, tt.expectedAddedCount,
 				qt.Commentf("Expected %d extensions to be added", tt.expectedAddedCount))
-			c.Assert(len(diff.ExtensionsRemoved), qt.Equals, tt.expectedRemovedCount,
+			c.Assert(diff.ExtensionsRemoved, qt.HasLen, tt.expectedRemovedCount,
 				qt.Commentf("Expected %d extensions to be removed", tt.expectedRemovedCount))
 		})
 	}
@@ -379,7 +379,7 @@ func TestGenerateMigration_CompareOptions_Integration_NoIgnoredExtensions(t *tes
 	upContent, err := os.ReadFile(files.UpFile)
 	c.Assert(err, qt.IsNil)
 	upSQL := string(upContent)
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION"), qt.IsFalse,
+	c.Assert(upSQL, qt.Not(qt.Contains), "CREATE EXTENSION",
 		qt.Commentf("UP SQL should not contain CREATE EXTENSION when removing extensions"))
 
 	// Clean up test extensions
@@ -449,9 +449,9 @@ func TestGenerateMigration_CompareOptions_Integration_AddExtension(t *testing.T)
 	upContent, err := os.ReadFile(files.UpFile)
 	c.Assert(err, qt.IsNil)
 	upSQL := string(upContent)
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION IF NOT EXISTS pg_trgm"), qt.IsTrue,
+	c.Assert(upSQL, qt.Contains, "CREATE EXTENSION IF NOT EXISTS pg_trgm",
 		qt.Commentf("UP SQL should contain CREATE EXTENSION for pg_trgm"))
-	c.Assert(strings.Contains(upSQL, "DROP EXTENSION"), qt.IsFalse,
+	c.Assert(upSQL, qt.Not(qt.Contains), "DROP EXTENSION",
 		qt.Commentf("UP SQL should not contain DROP EXTENSION"))
 
 	// Clean up test extensions
@@ -551,7 +551,7 @@ type TestTable struct {
 
 	// Verify that the error is not related to CompareOptions
 	errMsg := err.Error()
-	c.Assert(strings.Contains(errMsg, "CompareOptions"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "CompareOptions",
 		qt.Commentf("Error should not be related to CompareOptions: %s", errMsg))
 }
 
@@ -598,7 +598,7 @@ type TestTable struct {
 
 	// Verify that the error is not related to CompareOptions
 	errMsg := err.Error()
-	c.Assert(strings.Contains(errMsg, "CompareOptions"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "CompareOptions",
 		qt.Commentf("Error should not be related to CompareOptions: %s", errMsg))
 }
 

--- a/migration/generator/extension_integration_test.go
+++ b/migration/generator/extension_integration_test.go
@@ -1,7 +1,6 @@
 package generator_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -155,23 +154,23 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 
 			// 4. Verify up migration SQL
 			for _, expected := range tt.expectedUpSQL {
-				c.Assert(strings.Contains(upSQL, expected), qt.IsTrue,
+				c.Assert(upSQL, qt.Contains, expected,
 					qt.Commentf("Expected up SQL to contain: %s\nActual up SQL:\n%s", expected, upSQL))
 			}
 
 			for _, unexpected := range tt.unexpectedUpSQL {
-				c.Assert(strings.Contains(upSQL, unexpected), qt.IsFalse,
+				c.Assert(upSQL, qt.Not(qt.Contains), unexpected,
 					qt.Commentf("Expected up SQL to NOT contain: %s\nActual up SQL:\n%s", unexpected, upSQL))
 			}
 
 			// 5. Verify down migration SQL
 			for _, expected := range tt.expectedDownSQL {
-				c.Assert(strings.Contains(downSQL, expected), qt.IsTrue,
+				c.Assert(downSQL, qt.Contains, expected,
 					qt.Commentf("Expected down SQL to contain: %s\nActual down SQL:\n%s", expected, downSQL))
 			}
 
 			for _, unexpected := range tt.unexpectedDownSQL {
-				c.Assert(strings.Contains(downSQL, unexpected), qt.IsFalse,
+				c.Assert(downSQL, qt.Not(qt.Contains), unexpected,
 					qt.Commentf("Expected down SQL to NOT contain: %s\nActual down SQL:\n%s", unexpected, downSQL))
 			}
 		})
@@ -195,8 +194,8 @@ func TestExtensionMigration_UpDownCycle(t *testing.T) {
 
 	// 1. Calculate initial diff (should add extensions)
 	upDiff := schemadiff.Compare(generatedSchema, databaseSchema)
-	c.Assert(len(upDiff.ExtensionsAdded), qt.Equals, 2)
-	c.Assert(len(upDiff.ExtensionsRemoved), qt.Equals, 0)
+	c.Assert(upDiff.ExtensionsAdded, qt.HasLen, 2)
+	c.Assert(upDiff.ExtensionsRemoved, qt.HasLen, 0)
 
 	// 2. Simulate applying the up migration (database now has extensions)
 	simulatedDatabaseAfterUp := &types.DBSchema{
@@ -208,8 +207,8 @@ func TestExtensionMigration_UpDownCycle(t *testing.T) {
 
 	// 3. Calculate down diff (should remove extensions)
 	downDiff := schemadiff.Compare(&goschema.Database{Extensions: []goschema.Extension{}}, simulatedDatabaseAfterUp)
-	c.Assert(len(downDiff.ExtensionsAdded), qt.Equals, 0)
-	c.Assert(len(downDiff.ExtensionsRemoved), qt.Equals, 2)
+	c.Assert(downDiff.ExtensionsAdded, qt.HasLen, 0)
+	c.Assert(downDiff.ExtensionsRemoved, qt.HasLen, 2)
 
 	// 4. Verify the cycle is complete
 	c.Assert(upDiff.ExtensionsAdded, qt.DeepEquals, downDiff.ExtensionsRemoved)

--- a/migration/generator/generator_test.go
+++ b/migration/generator/generator_test.go
@@ -116,8 +116,8 @@ func TestMigrationFileNaming(t *testing.T) {
 	expectedDownFile := "1234567890_create_users_table.down.sql"
 
 	// Verify the expected naming pattern
-	c.Assert(strings.Contains(expectedUpFile, "up.sql"), qt.IsTrue)
-	c.Assert(strings.Contains(expectedDownFile, "down.sql"), qt.IsTrue)
+	c.Assert(expectedUpFile, qt.Contains, "up.sql")
+	c.Assert(expectedDownFile, qt.Contains, "down.sql")
 	c.Assert(strings.HasPrefix(expectedUpFile, "1234567890"), qt.IsTrue)
 	c.Assert(strings.HasPrefix(expectedDownFile, "1234567890"), qt.IsTrue)
 }
@@ -221,11 +221,11 @@ type TestTable struct {
 	c.Assert(err, qt.IsNil)
 
 	upSQL := string(upContent)
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION IF NOT EXISTS pg_trgm"), qt.IsTrue,
+	c.Assert(upSQL, qt.Contains, "CREATE EXTENSION IF NOT EXISTS pg_trgm",
 		qt.Commentf("UP migration should contain CREATE EXTENSION for pg_trgm"))
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION IF NOT EXISTS btree_gin"), qt.IsTrue,
+	c.Assert(upSQL, qt.Contains, "CREATE EXTENSION IF NOT EXISTS btree_gin",
 		qt.Commentf("UP migration should contain CREATE EXTENSION for btree_gin"))
-	c.Assert(strings.Contains(upSQL, "CREATE TABLE test_table_generator"), qt.IsTrue,
+	c.Assert(upSQL, qt.Contains, "CREATE TABLE test_table_generator",
 		qt.Commentf("UP migration should contain CREATE TABLE"))
 
 	// Read and verify DOWN migration
@@ -233,17 +233,17 @@ type TestTable struct {
 	c.Assert(err, qt.IsNil)
 
 	downSQL := string(downContent)
-	c.Assert(strings.Contains(downSQL, "DROP EXTENSION IF EXISTS pg_trgm"), qt.IsTrue,
+	c.Assert(downSQL, qt.Contains, "DROP EXTENSION IF EXISTS pg_trgm",
 		qt.Commentf("DOWN migration should contain DROP EXTENSION for pg_trgm"))
-	c.Assert(strings.Contains(downSQL, "DROP EXTENSION IF EXISTS btree_gin"), qt.IsTrue,
+	c.Assert(downSQL, qt.Contains, "DROP EXTENSION IF EXISTS btree_gin",
 		qt.Commentf("DOWN migration should contain DROP EXTENSION for btree_gin"))
-	c.Assert(strings.Contains(downSQL, "DROP TABLE IF EXISTS test_table_generator"), qt.IsTrue,
+	c.Assert(downSQL, qt.Contains, "DROP TABLE IF EXISTS test_table_generator",
 		qt.Commentf("DOWN migration should contain DROP TABLE"))
 
 	// Verify symmetric extension handling
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION"), qt.IsTrue,
+	c.Assert(upSQL, qt.Contains, "CREATE EXTENSION",
 		qt.Commentf("UP migration should create extensions"))
-	c.Assert(strings.Contains(downSQL, "DROP EXTENSION"), qt.IsTrue,
+	c.Assert(downSQL, qt.Contains, "DROP EXTENSION",
 		qt.Commentf("DOWN migration should drop extensions"))
 }
 
@@ -351,9 +351,9 @@ type TestTable struct {
 
 	// The error should be about database connection or parsing, NOT about filesystem paths
 	errMsg := err.Error()
-	c.Assert(strings.Contains(errMsg, "invalid argument"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "invalid argument",
 		qt.Commentf("Should not have filesystem path resolution errors, got: %s", errMsg))
-	c.Assert(strings.Contains(errMsg, "stat"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "stat",
 		qt.Commentf("Should not have stat errors, got: %s", errMsg))
 
 	// The error should be about database or parsing issues instead
@@ -419,8 +419,8 @@ type TestTable struct {
 
 	// The error should be about database connection or parsing, NOT about filesystem paths
 	errMsg := err.Error()
-	c.Assert(strings.Contains(errMsg, "invalid argument"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "invalid argument",
 		qt.Commentf("Should not have filesystem path resolution errors, got: %s", errMsg))
-	c.Assert(strings.Contains(errMsg, "stat"), qt.IsFalse,
+	c.Assert(errMsg, qt.Not(qt.Contains), "stat",
 		qt.Commentf("Should not have stat errors, got: %s", errMsg))
 }

--- a/migration/generator/migration_file_generation_test.go
+++ b/migration/generator/migration_file_generation_test.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -100,23 +99,23 @@ func TestMigrationFileGeneration_ExtensionSQL(t *testing.T) {
 
 			// 4. Verify up migration SQL contains expected patterns
 			for _, expected := range tt.expectedUpSQL {
-				c.Assert(strings.Contains(upSQL, expected), qt.IsTrue,
+				c.Assert(upSQL, qt.Contains, expected,
 					qt.Commentf("Expected up SQL to contain: %s\nActual up SQL:\n%s", expected, upSQL))
 			}
 
 			for _, unexpected := range tt.unexpectedUpSQL {
-				c.Assert(strings.Contains(upSQL, unexpected), qt.IsFalse,
+				c.Assert(upSQL, qt.Not(qt.Contains), unexpected,
 					qt.Commentf("Expected up SQL to NOT contain: %s\nActual up SQL:\n%s", unexpected, upSQL))
 			}
 
 			// 5. Verify down migration SQL contains expected patterns
 			for _, expected := range tt.expectedDownSQL {
-				c.Assert(strings.Contains(downSQL, expected), qt.IsTrue,
+				c.Assert(downSQL, qt.Contains, expected,
 					qt.Commentf("Expected down SQL to contain: %s\nActual down SQL:\n%s", expected, downSQL))
 			}
 
 			for _, unexpected := range tt.unexpectedDownSQL {
-				c.Assert(strings.Contains(downSQL, unexpected), qt.IsFalse,
+				c.Assert(downSQL, qt.Not(qt.Contains), unexpected,
 					qt.Commentf("Expected down SQL to NOT contain: %s\nActual down SQL:\n%s", unexpected, downSQL))
 			}
 		})
@@ -161,7 +160,7 @@ func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
 	upDiff := schemadiff.Compare(generatedSchema, emptyDatabase)
 	upSQL, err := generateUpMigrationSQL(upDiff, generatedSchema, "postgres")
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(upSQL, "CREATE EXTENSION IF NOT EXISTS pg_trgm;"), qt.IsTrue)
+	c.Assert(upSQL, qt.Contains, "CREATE EXTENSION IF NOT EXISTS pg_trgm;")
 
 	// 2. Simulate database state after up migration
 	databaseAfterUp := &types.DBSchema{
@@ -174,11 +173,11 @@ func TestExtensionMigrationSQL_CompleteFlow(t *testing.T) {
 	// For down migration, we use the original upDiff and reverse it
 	downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, databaseAfterUp, "postgres")
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(downSQL, "DROP EXTENSION IF EXISTS pg_trgm;"), qt.IsTrue)
+	c.Assert(downSQL, qt.Contains, "DROP EXTENSION IF EXISTS pg_trgm;")
 
 	// 4. Verify the cycle is complete
 	c.Assert(upDiff.ExtensionsAdded, qt.DeepEquals, []string{"pg_trgm"})
-	c.Assert(len(upDiff.ExtensionsRemoved), qt.Equals, 0)
+	c.Assert(upDiff.ExtensionsRemoved, qt.HasLen, 0)
 }
 
 // TestMigrationFileGeneration_EmptyDiffPrevention tests the fix for issue #36

--- a/migration/generator/multihost_fk_down_test.go
+++ b/migration/generator/multihost_fk_down_test.go
@@ -121,10 +121,10 @@ func TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost
 			}
 
 			// The DOWN restores the PRIOR action (NO ACTION), never the new CASCADE.
-			c.Assert(strings.Contains(downSQL, "ON DELETE CASCADE"), qt.IsFalse,
+			c.Assert(downSQL, qt.Not(qt.Contains), "ON DELETE CASCADE",
 				qt.Commentf("DOWN must restore the prior action, not re-apply CASCADE:\n%s", downSQL))
 			// Never the mixin struct name.
-			c.Assert(strings.Contains(downSQL, "Ownable"), qt.IsFalse,
+			c.Assert(downSQL, qt.Not(qt.Contains), "Ownable",
 				qt.Commentf("DOWN must not reference the mixin struct name:\n%s", downSQL))
 		})
 	}
@@ -168,7 +168,7 @@ func TestReverseConstraintAdditions_RestoresPerHostBody(t *testing.T) {
 	}
 
 	additions := reverseConstraintAdditions(upDiff, dbSchema)
-	c.Assert(len(additions), qt.Equals, len(hosts))
+	c.Assert(additions, qt.HasLen, len(hosts))
 
 	byTable := map[string]types.ConstraintAdditionInfo{}
 	for _, a := range additions {

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -328,14 +327,14 @@ func TestReverseSchemaDiff_TableModifications(t *testing.T) {
 
 	result := reverseSchemaDiff(input)
 
-	c.Assert(len(result.TablesModified), qt.Equals, 1)
+	c.Assert(result.TablesModified, qt.HasLen, 1)
 
 	reversedTable := result.TablesModified[0]
 	c.Assert(reversedTable.TableName, qt.Equals, "users")
 	c.Assert(reversedTable.ColumnsAdded, qt.DeepEquals, []string{"legacy_field"})
 	c.Assert(reversedTable.ColumnsRemoved, qt.DeepEquals, []string{"email", "created_at"})
 
-	c.Assert(len(reversedTable.ColumnsModified), qt.Equals, 1)
+	c.Assert(reversedTable.ColumnsModified, qt.HasLen, 1)
 	reversedColumn := reversedTable.ColumnsModified[0]
 	c.Assert(reversedColumn.ColumnName, qt.Equals, "name")
 	c.Assert(reversedColumn.Changes["type"], qt.Equals, "VARCHAR(255) -> VARCHAR(100)")
@@ -357,7 +356,7 @@ func TestReverseSchemaDiff_EnumModifications(t *testing.T) {
 
 	result := reverseSchemaDiff(input)
 
-	c.Assert(len(result.EnumsModified), qt.Equals, 1)
+	c.Assert(result.EnumsModified, qt.HasLen, 1)
 
 	reversedEnum := result.EnumsModified[0]
 	c.Assert(reversedEnum.EnumName, qt.Equals, "status_type")
@@ -384,7 +383,7 @@ func TestReverseSchemaDiff_FunctionModifications(t *testing.T) {
 
 	result := reverseSchemaDiff(input)
 
-	c.Assert(len(result.FunctionsModified), qt.Equals, 1)
+	c.Assert(result.FunctionsModified, qt.HasLen, 1)
 
 	reversedFunction := result.FunctionsModified[0]
 	c.Assert(reversedFunction.FunctionName, qt.Equals, "get_tenant_id")
@@ -414,7 +413,7 @@ func TestReverseSchemaDiff_RLSPolicyModifications(t *testing.T) {
 
 	result := reverseSchemaDiff(input)
 
-	c.Assert(len(result.RLSPoliciesModified), qt.Equals, 1)
+	c.Assert(result.RLSPoliciesModified, qt.HasLen, 1)
 
 	reversedPolicy := result.RLSPoliciesModified[0]
 	c.Assert(reversedPolicy.PolicyName, qt.Equals, "user_tenant_isolation")
@@ -445,7 +444,7 @@ func TestReverseSchemaDiff_RoleModifications(t *testing.T) {
 
 	result := reverseSchemaDiff(input)
 
-	c.Assert(len(result.RolesModified), qt.Equals, 1)
+	c.Assert(result.RolesModified, qt.HasLen, 1)
 
 	reversedRole := result.RolesModified[0]
 	c.Assert(reversedRole.RoleName, qt.Equals, "app_user")
@@ -553,7 +552,7 @@ func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 
 	// Functions should be removed in down migration
 	c.Assert(downDiff.FunctionsRemoved, qt.DeepEquals, []string{"get_current_tenant_id", "set_tenant_context"})
-	c.Assert(len(downDiff.FunctionsAdded), qt.Equals, 0)
+	c.Assert(downDiff.FunctionsAdded, qt.HasLen, 0)
 
 	// RLS policies should be removed in down migration
 	expectedPolicyRefs := []types.RLSPolicyRef{
@@ -561,19 +560,19 @@ func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 		{PolicyName: "area_tenant_isolation", TableName: ""},
 	}
 	c.Assert(downDiff.RLSPoliciesRemoved, qt.DeepEquals, expectedPolicyRefs)
-	c.Assert(len(downDiff.RLSPoliciesAdded), qt.Equals, 0)
+	c.Assert(downDiff.RLSPoliciesAdded, qt.HasLen, 0)
 
 	// RLS should be disabled on tables in down migration
 	c.Assert(downDiff.RLSEnabledTablesRemoved, qt.DeepEquals, []string{"users", "areas"})
-	c.Assert(len(downDiff.RLSEnabledTablesAdded), qt.Equals, 0)
+	c.Assert(downDiff.RLSEnabledTablesAdded, qt.HasLen, 0)
 
 	// Roles should be removed in down migration
 	c.Assert(downDiff.RolesRemoved, qt.DeepEquals, []string{"inventario_app"})
-	c.Assert(len(downDiff.RolesAdded), qt.Equals, 0)
+	c.Assert(downDiff.RolesAdded, qt.HasLen, 0)
 
 	// Tables should be removed in down migration (existing behavior)
 	c.Assert(downDiff.TablesRemoved, qt.DeepEquals, []string{"users"})
-	c.Assert(len(downDiff.TablesAdded), qt.Equals, 0)
+	c.Assert(downDiff.TablesAdded, qt.HasLen, 0)
 }
 
 // TestReverseSchemaDiff_ConstraintReversal verifies that a modified constraint
@@ -705,7 +704,7 @@ func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *test
 		c.Assert(downSQL, qt.Contains, "ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id)")
 		c.Assert(downSQL, qt.Contains, "DROP CONSTRAINT IF EXISTS")
 		// The restored action must NOT be SET NULL (that was the new action).
-		c.Assert(strings.Contains(downSQL, "ON DELETE SET NULL"), qt.IsFalse,
+		c.Assert(downSQL, qt.Not(qt.Contains), "ON DELETE SET NULL",
 			qt.Commentf("down must restore the prior action, not SET NULL:\n%s", downSQL))
 	})
 
@@ -717,9 +716,9 @@ func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *test
 		// Real DROP FOREIGN KEY + re-ADD with the prior action; never a TODO.
 		c.Assert(downSQL, qt.Contains, "ALTER TABLE exports DROP FOREIGN KEY fk_export_file;")
 		c.Assert(downSQL, qt.Contains, "ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id)")
-		c.Assert(strings.Contains(downSQL, "TODO"), qt.IsFalse,
+		c.Assert(downSQL, qt.Not(qt.Contains), "TODO",
 			qt.Commentf("down must not emit a TODO placeholder:\n%s", downSQL))
-		c.Assert(strings.Contains(downSQL, "ON DELETE SET NULL"), qt.IsFalse,
+		c.Assert(downSQL, qt.Not(qt.Contains), "ON DELETE SET NULL",
 			qt.Commentf("down must restore the prior action, not SET NULL:\n%s", downSQL))
 	})
 }
@@ -765,9 +764,9 @@ func TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily(t *te
 				wantDrop = "ALTER TABLE files DROP CONSTRAINT IF EXISTS files_category_check;"
 			}
 			c.Assert(downSQL, qt.Contains, wantDrop)
-			c.Assert(strings.Contains(downSQL, "No rollback operations needed"), qt.IsFalse,
+			c.Assert(downSQL, qt.Not(qt.Contains), "No rollback operations needed",
 				qt.Commentf("field-level CHECK down migration must not be empty:\n%s", downSQL))
-			c.Assert(strings.Contains(downSQL, "TODO"), qt.IsFalse,
+			c.Assert(downSQL, qt.Not(qt.Contains), "TODO",
 				qt.Commentf("down must emit real SQL, not a TODO placeholder:\n%s", downSQL))
 		})
 	}

--- a/migration/generator/rls_migration_test.go
+++ b/migration/generator/rls_migration_test.go
@@ -1,7 +1,6 @@
 package generator_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -35,20 +34,20 @@ func TestRLSMigrationGeneration(t *testing.T) {
 	t.Logf("Generated SQL:\n%s", sql)
 
 	// Check that RLS enable statements are generated
-	c.Assert(strings.Contains(sql, "ALTER TABLE areas ENABLE ROW LEVEL SECURITY"), qt.IsTrue, qt.Commentf("Missing RLS enable for areas table"))
-	c.Assert(strings.Contains(sql, "ALTER TABLE commodities ENABLE ROW LEVEL SECURITY"), qt.IsTrue, qt.Commentf("Missing RLS enable for commodities table"))
-	c.Assert(strings.Contains(sql, "ALTER TABLE users ENABLE ROW LEVEL SECURITY"), qt.IsTrue, qt.Commentf("Missing RLS enable for users table"))
-	c.Assert(strings.Contains(sql, "ALTER TABLE files ENABLE ROW LEVEL SECURITY"), qt.IsTrue, qt.Commentf("Missing RLS enable for files table"))
-	c.Assert(strings.Contains(sql, "ALTER TABLE locations ENABLE ROW LEVEL SECURITY"), qt.IsTrue, qt.Commentf("Missing RLS enable for locations table"))
+	c.Assert(sql, qt.Contains, "ALTER TABLE areas ENABLE ROW LEVEL SECURITY", qt.Commentf("Missing RLS enable for areas table"))
+	c.Assert(sql, qt.Contains, "ALTER TABLE commodities ENABLE ROW LEVEL SECURITY", qt.Commentf("Missing RLS enable for commodities table"))
+	c.Assert(sql, qt.Contains, "ALTER TABLE users ENABLE ROW LEVEL SECURITY", qt.Commentf("Missing RLS enable for users table"))
+	c.Assert(sql, qt.Contains, "ALTER TABLE files ENABLE ROW LEVEL SECURITY", qt.Commentf("Missing RLS enable for files table"))
+	c.Assert(sql, qt.Contains, "ALTER TABLE locations ENABLE ROW LEVEL SECURITY", qt.Commentf("Missing RLS enable for locations table"))
 
 	// Check that RLS policies are generated
-	c.Assert(strings.Contains(sql, "CREATE POLICY area_tenant_isolation ON areas"), qt.IsTrue, qt.Commentf("Missing area RLS policy"))
-	c.Assert(strings.Contains(sql, "CREATE POLICY commodity_tenant_isolation ON commodities"), qt.IsTrue, qt.Commentf("Missing commodity RLS policy"))
-	c.Assert(strings.Contains(sql, "CREATE POLICY user_tenant_isolation ON users"), qt.IsTrue, qt.Commentf("Missing user RLS policy"))
-	c.Assert(strings.Contains(sql, "CREATE POLICY file_tenant_isolation ON files"), qt.IsTrue, qt.Commentf("Missing file RLS policy"))
-	c.Assert(strings.Contains(sql, "CREATE POLICY location_tenant_isolation ON locations"), qt.IsTrue, qt.Commentf("Missing location RLS policy"))
+	c.Assert(sql, qt.Contains, "CREATE POLICY area_tenant_isolation ON areas", qt.Commentf("Missing area RLS policy"))
+	c.Assert(sql, qt.Contains, "CREATE POLICY commodity_tenant_isolation ON commodities", qt.Commentf("Missing commodity RLS policy"))
+	c.Assert(sql, qt.Contains, "CREATE POLICY user_tenant_isolation ON users", qt.Commentf("Missing user RLS policy"))
+	c.Assert(sql, qt.Contains, "CREATE POLICY file_tenant_isolation ON files", qt.Commentf("Missing file RLS policy"))
+	c.Assert(sql, qt.Contains, "CREATE POLICY location_tenant_isolation ON locations", qt.Commentf("Missing location RLS policy"))
 
 	// Check that policies have correct attributes
-	c.Assert(strings.Contains(sql, "FOR ALL TO inventario_app"), qt.IsTrue, qt.Commentf("Missing policy attributes"))
-	c.Assert(strings.Contains(sql, "USING (tenant_id = get_current_tenant_id())"), qt.IsTrue, qt.Commentf("Missing USING clause"))
+	c.Assert(sql, qt.Contains, "FOR ALL TO inventario_app", qt.Commentf("Missing policy attributes"))
+	c.Assert(sql, qt.Contains, "USING (tenant_id = get_current_tenant_id())", qt.Commentf("Missing USING clause"))
 }

--- a/migration/planner/capability_wiring_test.go
+++ b/migration/planner/capability_wiring_test.go
@@ -1,7 +1,6 @@
 package planner_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -31,7 +30,7 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mariadb")
 		sql, err := renderer.RenderSQL("mariadb", nodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;",
 			qt.Commentf("GetPlanner(mariadb) must carry the MariaDB capability preset; got:\n%s", sql))
 	})
 
@@ -41,9 +40,9 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
 		sql, err := renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;",
 			qt.Commentf("got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 			qt.Commentf("MySQL output must be byte-identical to the pre-capability planner; got:\n%s", sql))
 	})
 }

--- a/migration/planner/dialects/clickhouse/clickhouse_test.go
+++ b/migration/planner/dialects/clickhouse/clickhouse_test.go
@@ -62,7 +62,7 @@ func TestGenerateMigrationAST_AddTableDropTableAndAlter(t *testing.T) {
 
 	// Expected order: CREATE events, ALTER existing (add), ALTER existing (modify),
 	// ALTER existing (drop), DROP legacy.
-	c.Assert(len(nodes), qt.Equals, 5)
+	c.Assert(nodes, qt.HasLen, 5)
 
 	ct, ok := nodes[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("first node should be CREATE TABLE, got %T", nodes[0]))
@@ -105,7 +105,7 @@ func TestGenerateMigrationAST_IndexAddRemove(t *testing.T) {
 
 	p := clickhouse.New()
 	nodes := p.GenerateMigrationAST(diff, gen)
-	c.Assert(len(nodes), qt.Equals, 2)
+	c.Assert(nodes, qt.HasLen, 2)
 	idx, ok := nodes[0].(*ast.IndexNode)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("expected IndexNode, got %T", nodes[0]))
 	c.Assert(idx.Table, qt.Equals, "events")
@@ -123,7 +123,7 @@ func TestGenerateMigrationAST_EnumChangesAreSurfacedAsComment(t *testing.T) {
 	}
 	p := clickhouse.New()
 	nodes := p.GenerateMigrationAST(diff, mkDB())
-	c.Assert(len(nodes), qt.Equals, 1)
+	c.Assert(nodes, qt.HasLen, 1)
 	comment, ok := nodes[0].(*ast.CommentNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(comment.Text, qt.Contains, "enum changes")

--- a/migration/planner/dialects/mysql/capability_gating_test.go
+++ b/migration/planner/dialects/mysql/capability_gating_test.go
@@ -76,7 +76,7 @@ func TestPlanner_CapabilityGating_RendererStripsGuardsForMySQL(t *testing.T) {
 	sql, err := renderer.RenderSQL("mysql", nodes...)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 		qt.Commentf("the mysql renderer must strip guards the target rejects; got:\n%s", sql))
 	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
 	c.Assert(strings.Count(sql, "ALTER TABLE pages DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
@@ -92,7 +92,7 @@ func TestPlanner_CapabilityGating_MySQLPlannerEmitsNoGuardIntent(t *testing.T) {
 	sql, err := renderer.RenderSQL("mariadb", nodes...)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(strings.Contains(sql, "DROP FOREIGN KEY IF EXISTS"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "DROP FOREIGN KEY IF EXISTS",
 		qt.Commentf("a MySQL-preset planner must not request guards; got:\n%s", sql))
 	c.Assert(strings.Count(sql, "ALTER TABLE articles DROP FOREIGN KEY shared_fk;"), qt.Equals, 1)
 }
@@ -117,7 +117,7 @@ func TestPlanner_CapabilityGating_DropCheckSpellingWithoutGenericClause(t *testi
 
 	c.Assert(strings.Count(sql, "ALTER TABLE things DROP CHECK chk_qty;"), qt.Equals, 1,
 		qt.Commentf("without drop_constraint_generic a CHECK drop must use DROP CHECK; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "DROP CONSTRAINT"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT",
 		qt.Commentf("the generic clause must not be emitted for this target; got:\n%s", sql))
 
 	// The current MySQL line keeps the generic clause.
@@ -149,7 +149,7 @@ func TestPlanner_CapabilityGating_NoGenericClauseFallbacks(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.Equals, 1,
 			qt.Commentf("without the generic clause a UNIQUE drop must use DROP INDEX; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "DROP CONSTRAINT"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT",
 			qt.Commentf("got:\n%s", sql))
 
 		// Modern targets keep the generic clause (the universal DROP INDEX
@@ -176,8 +176,8 @@ func TestPlanner_CapabilityGating_NoGenericClauseFallbacks(t *testing.T) {
 		// No statement may be emitted at all — only the warning comment
 		// (asserting on statement shape, not bare keywords, because the
 		// warning text itself names the missing clauses).
-		c.Assert(strings.Contains(sql, "ALTER TABLE"), qt.IsFalse, qt.Commentf("got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "WARNING: cannot drop CHECK constraint chk_qty"), qt.IsTrue,
+		c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE", qt.Commentf("got:\n%s", sql))
+		c.Assert(sql, qt.Contains, "WARNING: cannot drop CHECK constraint chk_qty",
 			qt.Commentf("the impossibility must be loud; got:\n%s", sql))
 	})
 }
@@ -203,16 +203,16 @@ func TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced(t *testing.T) {
 		sql, err := renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "ADD CONSTRAINT"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "ADD CONSTRAINT",
 			qt.Commentf("an unenforced CHECK must not be emitted; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "WARNING: CHECK constraint positive_price skipped"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "WARNING: CHECK constraint positive_price skipped",
 			qt.Commentf("the skip must be loud; got:\n%s", sql))
 
 		// The enforcing window (8.0.16+) emits the constraint as usual.
 		nodes = mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, generated)
 		sql, err = renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);",
 			qt.Commentf("enforcing targets keep the ADD; got:\n%s", sql))
 	})
 
@@ -234,9 +234,9 @@ func TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced(t *testing.T) {
 		sql, err := renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "ADD CONSTRAINT"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "ADD CONSTRAINT",
 			qt.Commentf("an unenforced field-level CHECK must not be emitted; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "WARNING: CHECK constraint things_qty_check skipped"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "WARNING: CHECK constraint things_qty_check skipped",
 			qt.Commentf("the skip must be loud; got:\n%s", sql))
 
 		// Positive control at the unit level: an enforcing target emits the
@@ -244,9 +244,9 @@ func TestPlanner_CapabilityGating_CheckAddSkippedWhenUnenforced(t *testing.T) {
 		nodes = mysql.New().GenerateMigrationAST(diff, generated)
 		sql, err = renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT things_qty_check CHECK (qty >= 0);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE things ADD CONSTRAINT things_qty_check CHECK (qty >= 0);",
 			qt.Commentf("enforcing targets keep the field-level ADD; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "WARNING"), qt.IsFalse)
+		c.Assert(sql, qt.Not(qt.Contains), "WARNING")
 	})
 }
 
@@ -280,9 +280,9 @@ func TestPlanner_CapabilityGating_ZeroValuePlannerBehavesLikeNew(t *testing.T) {
 
 	c.Assert(zeroSQL, qt.Equals, newSQL,
 		qt.Commentf("a zero-value planner must be byte-identical to New()"))
-	c.Assert(strings.Contains(zeroSQL, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);"), qt.IsTrue,
+	c.Assert(zeroSQL, qt.Contains, "ALTER TABLE products ADD CONSTRAINT positive_price CHECK (price > 0);",
 		qt.Commentf("the CHECK addition must be emitted, not downgraded to a warning; got:\n%s", zeroSQL))
-	c.Assert(strings.Contains(zeroSQL, "ALTER TABLE things DROP CONSTRAINT chk_old;"), qt.IsTrue,
+	c.Assert(zeroSQL, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_old;",
 		qt.Commentf("the CHECK removal must use the generic clause, not DROP CHECK; got:\n%s", zeroSQL))
 }
 
@@ -304,9 +304,9 @@ func TestPlanner_CapabilityGating_DropCheckDegradesOnMariaDBRenderer(t *testing.
 
 	sql, err := renderer.RenderSQL("mariadb", nodes...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_qty;",
 		qt.Commentf("the mariadb renderer must degrade DROP CHECK to the generic clause; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "DROP CHECK"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "DROP CHECK",
 		qt.Commentf("MariaDB has no DROP CHECK clause; got:\n%s", sql))
 }
 
@@ -332,22 +332,22 @@ func TestPlanner_CapabilityGating_DropIndexGuard(t *testing.T) {
 
 	sqlMariaDB, err := renderer.RenderSQL("mariadb", nodes...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX IF EXISTS idx_things_qty ON things;"), qt.IsTrue,
+	c.Assert(sqlMariaDB, qt.Contains, "DROP INDEX IF EXISTS idx_things_qty ON things;",
 		qt.Commentf("mariadb honors the guard intent; got:\n%s", sqlMariaDB))
 
 	sqlMySQL, err := renderer.RenderSQL("mysql", nodes...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sqlMySQL, "DROP INDEX idx_things_qty ON things;"), qt.IsTrue,
+	c.Assert(sqlMySQL, qt.Contains, "DROP INDEX idx_things_qty ON things;",
 		qt.Commentf("the mysql renderer strips the guard it cannot parse; got:\n%s", sqlMySQL))
-	c.Assert(strings.Contains(sqlMySQL, "IF EXISTS"), qt.IsFalse)
+	c.Assert(sqlMySQL, qt.Not(qt.Contains), "IF EXISTS")
 
 	// MySQL-preset planner: no intent, so even the guard-capable mariadb
 	// renderer emits the plain form — the capability is a real knob.
 	nodes = mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
 	sqlMariaDB, err = renderer.RenderSQL("mariadb", nodes...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sqlMariaDB, "DROP INDEX idx_things_qty ON things;"), qt.IsTrue,
+	c.Assert(sqlMariaDB, qt.Contains, "DROP INDEX idx_things_qty ON things;",
 		qt.Commentf("got:\n%s", sqlMariaDB))
-	c.Assert(strings.Contains(sqlMariaDB, "IF EXISTS"), qt.IsFalse,
+	c.Assert(sqlMariaDB, qt.Not(qt.Contains), "IF EXISTS",
 		qt.Commentf("a MySQL-preset planner must not request the index-drop guard; got:\n%s", sqlMariaDB))
 }

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -100,7 +100,7 @@ func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePur
 
 					// MySQL 8 accepts no IF EXISTS on constraint drops — the plan
 					// must be valid without it.
-					c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+					c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 						qt.Commentf("MySQL-family constraint scoping must not lean on IF EXISTS; got:\n%s", sql))
 
 					// Ordering: the modified host's drop precedes its re-add; the
@@ -165,7 +165,7 @@ func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePur
 						qt.Commentf("purely-removed host must be dropped exactly once; got:\n%s", sql))
 					c.Assert(strings.Count(sql, "DROP CONSTRAINT shared_check;"), qt.Equals, 2,
 						qt.Commentf("exactly one drop per host, no more; got:\n%s", sql))
-					c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse,
+					c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 						qt.Commentf("MySQL-family constraint scoping must not lean on IF EXISTS; got:\n%s", sql))
 
 					articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check")
@@ -218,11 +218,11 @@ func TestPlanner_GenerateMigrationAST_ModifiedFK_EveryHostDroppedAndReadded(t *t
 					qt.Commentf("orders host dropped exactly once; got:\n%s", sql))
 				c.Assert(strings.Count(sql, "ALTER TABLE invoices DROP FOREIGN KEY fk_customer;"), qt.Equals, 1,
 					qt.Commentf("invoices host dropped exactly once; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;"), qt.IsTrue,
+				c.Assert(sql, qt.Contains, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;",
 					qt.Commentf("orders re-added with its own action; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "ALTER TABLE invoices ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;"), qt.IsTrue,
+				c.Assert(sql, qt.Contains, "ALTER TABLE invoices ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;",
 					qt.Commentf("invoices re-added with its own action; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse)
+				c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS")
 
 				for _, host := range []string{"orders", "invoices"} {
 					dropIdx := strings.Index(sql, "ALTER TABLE "+host+" DROP FOREIGN KEY fk_customer")
@@ -302,7 +302,7 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(
 				// removeConstraints must not emit a second, unguarded one.
 				c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_down;"), qt.Equals, 1,
 					qt.Commentf("the drop must be emitted exactly once across both planner phases; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);"), qt.IsTrue,
+				c.Assert(sql, qt.Contains, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);",
 					qt.Commentf("modified constraint must still be re-added; got:\n%s", sql))
 				dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT chk_down")
 				addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_down")
@@ -354,7 +354,7 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(
 					qt.Commentf("second removal host must be dropped exactly once, not skipped and not doubled; got:\n%s", sql))
 				c.Assert(strings.Count(sql, "DROP CONSTRAINT shared_check;"), qt.Equals, 2,
 					qt.Commentf("exactly one drop per recorded host across BOTH planner phases; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "IF EXISTS"), qt.IsFalse)
+				c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS")
 
 				articlesDrop := strings.Index(sql, "ALTER TABLE articles DROP CONSTRAINT shared_check")
 				pagesDrop := strings.Index(sql, "ALTER TABLE pages DROP CONSTRAINT shared_check")
@@ -393,9 +393,9 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(
 
 				sql := renderMySQLFamily(c, dialect, diff, generated)
 
-				c.Assert(strings.Contains(sql, "DROP CONSTRAINT chk_hostless"), qt.IsFalse,
+				c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT chk_hostless",
 					qt.Commentf("a hostless removal entry must be skipped, not dropped; got:\n%s", sql))
-				c.Assert(strings.Contains(sql, "ALTER TABLE  DROP"), qt.IsFalse,
+				c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE  DROP",
 					qt.Commentf("no malformed empty-table ALTER may be emitted; got:\n%s", sql))
 				c.Assert(strings.Count(sql, "ALTER TABLE things ADD CONSTRAINT chk_hostless CHECK (qty >= 0);"), qt.Equals, 1,
 					qt.Commentf("the re-add still proceeds alone; got:\n%s", sql))
@@ -527,15 +527,15 @@ func TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified(t *t
 				qt.Commentf("FK removal must be dropped exactly once (deduped) with FK syntax; got:\n%s", sql))
 			c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT chk_qty;"), qt.Equals, 1,
 				qt.Commentf("CHECK removal must be dropped exactly once; got:\n%s", sql))
-			c.Assert(strings.Contains(sql, "pk_legacy"), qt.IsFalse,
+			c.Assert(sql, qt.Not(qt.Contains), "pk_legacy",
 				qt.Commentf("PRIMARY KEY removals must be skipped; got:\n%s", sql))
-			c.Assert(strings.Contains(sql, "DROP CONSTRAINT chk_on_obsolete"), qt.IsFalse,
+			c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT chk_on_obsolete",
 				qt.Commentf("constraints on dropped tables are cascaded by DROP TABLE, not dropped explicitly; got:\n%s", sql))
-			c.Assert(strings.Contains(sql, "DROP TABLE IF EXISTS obsolete"), qt.IsTrue,
+			c.Assert(sql, qt.Contains, "DROP TABLE IF EXISTS obsolete",
 				qt.Commentf("the dropped table itself is still removed; got:\n%s", sql))
-			c.Assert(strings.Contains(sql, "chk_orphan"), qt.IsFalse,
+			c.Assert(sql, qt.Not(qt.Contains), "chk_orphan",
 				qt.Commentf("a removal entry with no recorded host must be skipped silently; got:\n%s", sql))
-			c.Assert(strings.Contains(sql, "ALTER TABLE  DROP"), qt.IsFalse,
+			c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE  DROP",
 				qt.Commentf("no malformed empty-table ALTER may be emitted; got:\n%s", sql))
 		})
 	}

--- a/migration/planner/dialects/mysql/fk_actions_test.go
+++ b/migration/planner/dialects/mysql/fk_actions_test.go
@@ -165,13 +165,13 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 			sql, err := renderer.RenderSQL("mysql", nodes...)
 			c.Assert(err, qt.IsNil)
 
-			c.Assert(strings.Contains(sql, tt.mustEmit), qt.IsTrue,
+			c.Assert(sql, qt.Contains, tt.mustEmit,
 				qt.Commentf("expected SQL to contain:\n  %s\ngot:\n%s", tt.mustEmit, sql))
 
 			if tt.mustNotHit != "" {
 				for line := range strings.SplitSeq(sql, "\n") {
 					if strings.Contains(line, tt.constraintMarker) {
-						c.Assert(strings.Contains(line, tt.mustNotHit), qt.IsFalse,
+						c.Assert(line, qt.Not(qt.Contains), tt.mustNotHit,
 							qt.Commentf("FK line should not mention %q: %s", tt.mustNotHit, line))
 					}
 				}

--- a/migration/planner/dialects/mysql/mysql_test.go
+++ b/migration/planner/dialects/mysql/mysql_test.go
@@ -397,7 +397,7 @@ func TestPlanner_AddNewTables_WithEmbeddedFields(t *testing.T) {
 	planner := mysql.New()
 	result := planner.GenerateMigrationAST(diff, generated)
 
-	c.Assert(len(result), qt.Equals, 1)
+	c.Assert(result, qt.HasLen, 1)
 
 	// Convert AST to SQL to verify content
 	sql, err := renderer.RenderSQL("mysql", result[0])

--- a/migration/planner/dialects/postgres/concurrent_index_test.go
+++ b/migration/planner/dialects/postgres/concurrent_index_test.go
@@ -1,7 +1,6 @@
 package postgres_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -41,9 +40,9 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);",
 			qt.Commentf("default output must be byte-identical to the pre-capability planner; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse)
+		c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY")
 	})
 
 	t.Run("policy plus capability emits CONCURRENTLY", func(t *testing.T) {
@@ -53,7 +52,7 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);",
 			qt.Commentf("CONCURRENTLY must precede IF NOT EXISTS per the PostgreSQL grammar; got:\n%s", sql))
 	})
 
@@ -65,9 +64,9 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY",
 			qt.Commentf("the capability gate must win over the policy; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);"), qt.IsTrue)
+		c.Assert(sql, qt.Contains, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);")
 	})
 
 	t.Run("unique concurrent index", func(t *testing.T) {
@@ -84,7 +83,7 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_users_email ON users (email);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_users_email ON users (email);",
 			qt.Commentf("UNIQUE and CONCURRENTLY must compose; got:\n%s", sql))
 	})
 
@@ -97,7 +96,7 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 		nodes := base.GenerateMigrationAST(diff, generated)
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(sql, "CONCURRENTLY"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY",
 			qt.Commentf("the original planner must keep the default policy; got:\n%s", sql))
 	})
 }

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -178,7 +178,7 @@ func TestPlanner_GenerateMigrationAST_ConstraintsAdded(t *testing.T) {
 				}
 			}
 
-			c.Assert(len(sqlStatements), qt.Equals, len(tt.expectedSQL))
+			c.Assert(sqlStatements, qt.HasLen, len(tt.expectedSQL))
 			for i, expected := range tt.expectedSQL {
 				c.Assert(sqlStatements[i], qt.Equals, expected)
 			}
@@ -227,21 +227,21 @@ func TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable(t *testin
 		c.Assert(err, qt.IsNil)
 
 		// The DROP is scoped to the intended host with a direct ALTER TABLE.
-		c.Assert(strings.Contains(sql, "ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_customer;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE orders DROP CONSTRAINT IF EXISTS fk_customer;",
 			qt.Commentf("modified FK must be dropped from its known host table; got:\n%s", sql))
 
 		// The unsafe name-only DO block resolution must NOT be used for a
 		// known-host modify — that is what could hit the wrong table.
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 			qt.Commentf("known-host modify must not use the name-only DO block; got:\n%s", sql))
 
 		// The unrelated host (invoices) must be left completely alone: no drop,
 		// no add.
-		c.Assert(strings.Contains(sql, "invoices"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "invoices",
 			qt.Commentf("the unmodified host with the same constraint name must not be touched; got:\n%s", sql))
 
 		// The re-ADD targets the same host, and the DROP precedes it.
-		c.Assert(strings.Contains(sql, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE orders ADD CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;",
 			qt.Commentf("modified FK must be re-added on its host; got:\n%s", sql))
 		dropIdx := strings.Index(sql, "DROP CONSTRAINT IF EXISTS fk_customer")
 		addIdx := strings.Index(sql, "ADD CONSTRAINT fk_customer")
@@ -282,10 +282,10 @@ func TestPlanner_GenerateMigrationAST_ModifiedFK_ScopesDropToHostTable(t *testin
 			qt.Commentf("orders host dropped exactly once; got:\n%s", sql))
 		c.Assert(strings.Count(sql, "ALTER TABLE invoices DROP CONSTRAINT IF EXISTS fk_customer;"), qt.Equals, 1,
 			qt.Commentf("invoices host dropped exactly once; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 			qt.Commentf("multi-host modify must not use the name-only DO block; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ON DELETE CASCADE"), qt.IsTrue)
-		c.Assert(strings.Contains(sql, "ON DELETE SET NULL"), qt.IsTrue)
+		c.Assert(sql, qt.Contains, "ON DELETE CASCADE")
+		c.Assert(sql, qt.Contains, "ON DELETE SET NULL")
 	})
 }
 
@@ -325,16 +325,16 @@ func TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTa
 		c.Assert(err, qt.IsNil)
 
 		// The DROP is scoped to the intended host with a direct ALTER TABLE.
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS uq_slug;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS uq_slug;",
 			qt.Commentf("modified non-FK constraint must be dropped from its known host table; got:\n%s", sql))
 		// The unsafe name-only DO block must NOT be used when the host is known.
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 			qt.Commentf("known-host non-FK modify must not use the name-only DO block; got:\n%s", sql))
 		// The unrelated host (pages) with the same constraint name is untouched.
-		c.Assert(strings.Contains(sql, "pages"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "pages",
 			qt.Commentf("the unmodified host with the same constraint name must not be touched; got:\n%s", sql))
 		// The re-ADD targets the same host, and the DROP precedes it.
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT uq_slug UNIQUE (slug, locale);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles ADD CONSTRAINT uq_slug UNIQUE (slug, locale);",
 			qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
 		dropIdx := strings.Index(sql, "DROP CONSTRAINT IF EXISTS uq_slug")
 		addIdx := strings.Index(sql, "ADD CONSTRAINT uq_slug")
@@ -365,11 +365,11 @@ func TestPlanner_GenerateMigrationAST_ModifiedNonFKConstraint_ScopesDropToHostTa
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "information_schema.table_constraints",
 			qt.Commentf("with no recorded host the planner must fall back to the DO block; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "constraint_name = 'legacy_check'"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "constraint_name = 'legacy_check'",
 			qt.Commentf("fallback DO block must target the constraint by name; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT legacy_check CHECK (x > 0);"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE things ADD CONSTRAINT legacy_check CHECK (x > 0);",
 			qt.Commentf("modified constraint must still be re-added; got:\n%s", sql))
 		dropIdx := strings.Index(sql, "DO $ptah$")
 		addIdx := strings.Index(sql, "ADD CONSTRAINT legacy_check")
@@ -420,16 +420,16 @@ func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePur
 
 		// The pure removal on B (pages) is dropped table-qualified and NOT skipped.
 		// This is the assertion that fails against the pre-fix bare-name skip.
-		c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_fk;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_fk;",
 			qt.Commentf("purely-removed host must be dropped table-qualified, not skipped; got:\n%s", sql))
 		// The modify on A (articles) is dropped table-qualified and re-added once.
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk;",
 			qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_fk FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles ADD CONSTRAINT shared_fk FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE;",
 			qt.Commentf("modified FK must be re-added on its host; got:\n%s", sql))
 		c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_fk"), qt.Equals, 1,
 			qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 			qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
 		c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_fk;"), qt.Equals, 1)
 		c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_fk;"), qt.Equals, 1)
@@ -470,15 +470,15 @@ func TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePur
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;",
 			qt.Commentf("purely-removed host must be dropped table-qualified; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;",
 			qt.Commentf("modified host must be dropped from its known table; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));"), qt.IsTrue,
+		c.Assert(sql, qt.Contains, "ALTER TABLE articles ADD CONSTRAINT shared_check CHECK (status IN ('draft', 'published'));",
 			qt.Commentf("modified constraint must be re-added on its host; got:\n%s", sql))
 		c.Assert(strings.Count(sql, "ADD CONSTRAINT shared_check"), qt.Equals, 1,
 			qt.Commentf("only the modified host may be re-added; got:\n%s", sql))
-		c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 			qt.Commentf("must not use the name-only DO block when hosts are known; got:\n%s", sql))
 		c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1)
 
@@ -527,11 +527,11 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_ScopesToHostWhenAddedHostsAbsen
 	c.Assert(err, qt.IsNil)
 
 	// Table-scoped drop, not the name-only DO block.
-	c.Assert(strings.Contains(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;",
 		qt.Commentf("modify drop must be scoped to the known removal host even with no addedHosts; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 		qt.Commentf("must not regress to the name-only DO block when the removal host is known; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);",
 		qt.Commentf("modified constraint must be re-added; got:\n%s", sql))
 	dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down")
 	addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_down")
@@ -555,7 +555,7 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved(t *testing.T) {
 	// drop logic, leaving the constraint in place — see commit message for the
 	// full incident report. The DO block executes immediately on parse and
 	// leaves no temporary functions behind.
-	c.Assert(len(nodes), qt.Equals, 1)
+	c.Assert(nodes, qt.HasLen, 1)
 
 	sql, err := renderer.RenderSQL("postgres", nodes[0])
 	c.Assert(err, qt.IsNil)
@@ -584,11 +584,11 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_MultipleSplitCleanly(t 
 		ConstraintsRemoved: []string{"first_constraint", "second_constraint"},
 	}
 	statements := planner.GenerateSchemaDiffSQLStatements(diff, &goschema.Database{}, "postgres")
-	c.Assert(len(statements), qt.Equals, 2,
+	c.Assert(statements, qt.HasLen, 2,
 		qt.Commentf("each DO block must end up as its own statement after SQL splitting; got %d statements:\n%s",
 			len(statements), strings.Join(statements, "\n---\n")))
-	c.Assert(strings.Contains(statements[0], "first_constraint"), qt.IsTrue)
-	c.Assert(strings.Contains(statements[1], "second_constraint"), qt.IsTrue)
+	c.Assert(statements[0], qt.Contains, "first_constraint")
+	c.Assert(statements[1], qt.Contains, "second_constraint")
 }
 
 func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_EscapesSingleQuoteInName(t *testing.T) {
@@ -603,13 +603,13 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_EscapesSingleQuoteInNam
 	}
 
 	nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
-	c.Assert(len(nodes), qt.Equals, 1)
+	c.Assert(nodes, qt.HasLen, 1)
 
 	sql, err := renderer.RenderSQL("postgres", nodes[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(sql, qt.Contains, "'don''t_drop'", qt.Commentf("single quote in constraint name must be SQL-escaped"))
 	// The bare unescaped form must NOT appear in any SQL string literal.
-	c.Assert(strings.Contains(sql, "'don't_drop'"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "'don't_drop'",
 		qt.Commentf("unescaped name in a literal would break parsing; got: %s", sql))
 }
 
@@ -644,21 +644,21 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_RejectsUnsafeName(t *te
 			c := qt.New(t)
 			diff := &types.SchemaDiff{ConstraintsRemoved: []string{tc.input}}
 			nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
-			c.Assert(len(nodes), qt.Equals, 1)
+			c.Assert(nodes, qt.HasLen, 1)
 
 			sql, err := renderer.RenderSQL("postgres", nodes[0])
 			c.Assert(err, qt.IsNil)
-			c.Assert(strings.Contains(sql, "RAISE EXCEPTION"), qt.IsTrue,
+			c.Assert(sql, qt.Contains, "RAISE EXCEPTION",
 				qt.Commentf("planner must emit RAISE EXCEPTION for unsafe names; got: %s", sql))
-			c.Assert(strings.Contains(sql, "ALTER TABLE %I DROP CONSTRAINT"), qt.IsFalse,
+			c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE %I DROP CONSTRAINT",
 				qt.Commentf("unsafe name must NOT produce a drop statement; got: %s", sql))
 			// The rejected name must appear inside an embedded SQL single-
 			// quoted literal (not as a Postgres identifier), so the operator
 			// sees a clean exception message.
-			c.Assert(strings.Contains(sql, "''"+tc.expectVisible+"''"), qt.IsTrue,
+			c.Assert(sql, qt.Contains, "''"+tc.expectVisible+"''",
 				qt.Commentf("rejected name must appear escaped inside the exception message; got: %s", sql))
 			for _, forbidden := range tc.mustNotContain {
-				c.Assert(strings.Contains(sql, forbidden), qt.IsFalse,
+				c.Assert(sql, qt.Not(qt.Contains), forbidden,
 					qt.Commentf("escaped output must not contain raw substring %q; got: %s", forbidden, sql))
 			}
 		})

--- a/migration/planner/dialects/postgres/fk_actions_test.go
+++ b/migration/planner/dialects/postgres/fk_actions_test.go
@@ -172,7 +172,7 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 			sql, err := renderer.RenderSQL("postgres", nodes...)
 			c.Assert(err, qt.IsNil)
 
-			c.Assert(strings.Contains(sql, tt.mustEmit), qt.IsTrue,
+			c.Assert(sql, qt.Contains, tt.mustEmit,
 				qt.Commentf("expected SQL to contain:\n  %s\ngot:\n%s", tt.mustEmit, sql))
 
 			if tt.mustNotHit != "" {
@@ -180,7 +180,7 @@ func TestPlanner_FieldLevelForeignKeyActions(t *testing.T) {
 				// constraint so we don't accidentally match unrelated noise.
 				for line := range strings.SplitSeq(sql, "\n") {
 					if strings.Contains(line, tt.constraintMarker) {
-						c.Assert(strings.Contains(line, tt.mustNotHit), qt.IsFalse,
+						c.Assert(line, qt.Not(qt.Contains), tt.mustNotHit,
 							qt.Commentf("FK line should not mention %q: %s", tt.mustNotHit, line))
 					}
 				}

--- a/migration/planner/dialects/postgres/modify_functions_test.go
+++ b/migration/planner/dialects/postgres/modify_functions_test.go
@@ -1,7 +1,6 @@
 package postgres_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -42,7 +41,7 @@ func TestPlanner_GenerateMigrationAST_FunctionsModified_EmitsCreateOrReplace(t *
 
 	planner := postgres.New()
 	nodes := planner.GenerateMigrationAST(diff, generated)
-	c.Assert(len(nodes), qt.Not(qt.Equals), 0)
+	c.Assert(nodes, qt.Not(qt.HasLen), 0)
 
 	sql, err := renderer.RenderSQL("postgres", nodes...)
 	c.Assert(err, qt.IsNil)
@@ -77,6 +76,6 @@ func TestPlanner_GenerateMigrationAST_FunctionsModified_SkippedWhenTargetMissing
 
 	sql, err := renderer.RenderSQL("postgres", nodes...)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(sql, "ghost"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "ghost",
 		qt.Commentf("planner must not emit SQL for a modified function whose target definition is missing"))
 }

--- a/migration/planner/dialects/postgres/postgres_test.go
+++ b/migration/planner/dialects/postgres/postgres_test.go
@@ -558,8 +558,8 @@ func TestPlanner_ForeignKeyDependencyOrdering_SQLOutput(t *testing.T) {
 	}
 
 	// All ADD COLUMN operations should come before all ADD CONSTRAINT operations
-	c.Assert(len(addColumnLines), qt.Equals, 2)
-	c.Assert(len(addConstraintLines), qt.Equals, 1)
+	c.Assert(addColumnLines, qt.HasLen, 2)
+	c.Assert(addConstraintLines, qt.HasLen, 1)
 
 	// The last ADD COLUMN should come before the first ADD CONSTRAINT
 	lastAddColumn := addColumnLines[len(addColumnLines)-1]
@@ -1165,13 +1165,13 @@ func TestPlanner_ExtensionSQL_Generation(t *testing.T) {
 
 			// Check expected SQL patterns
 			for _, expected := range tt.expectedSQL {
-				c.Assert(strings.Contains(sql, expected), qt.IsTrue,
+				c.Assert(sql, qt.Contains, expected,
 					qt.Commentf("Expected SQL to contain: %s\nActual SQL:\n%s", expected, sql))
 			}
 
 			// Check unexpected SQL patterns
 			for _, unexpected := range tt.unexpectedSQL {
-				c.Assert(strings.Contains(sql, unexpected), qt.IsFalse,
+				c.Assert(sql, qt.Not(qt.Contains), unexpected,
 					qt.Commentf("Expected SQL to NOT contain: %s\nActual SQL:\n%s", unexpected, sql))
 			}
 		})
@@ -1210,7 +1210,7 @@ func TestPlanner_AddNewTables_WithEmbeddedFields(t *testing.T) {
 	planner := &postgres.Planner{}
 	result := planner.GenerateMigrationAST(diff, generated)
 
-	c.Assert(len(result), qt.Equals, 1)
+	c.Assert(result, qt.HasLen, 1)
 
 	// Convert AST to SQL to verify content
 	sql, err := renderer.RenderSQL("postgresql", result[0])

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -114,7 +114,7 @@ func TestGenerateMigrationAST(t *testing.T) {
 			} else {
 				nodes := planner.GenerateSchemaDiffAST(tt.diff, tt.generated, tt.dialect)
 				c.Assert(nodes, qt.IsNotNil)
-				c.Assert(len(nodes), qt.Equals, 1) // Should have one CREATE TABLE statement
+				c.Assert(nodes, qt.HasLen, 1) // Should have one CREATE TABLE statement
 			}
 		})
 	}

--- a/migration/schemadiff/embedded_fk_drift_test.go
+++ b/migration/schemadiff/embedded_fk_drift_test.go
@@ -142,7 +142,7 @@ func TestEmbeddedInlineMixinFK_NeverTargetsStructName(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 
 		// Never the mixin struct name.
-		c.Assert(strings.Contains(sql, "ALTER TABLE Ownable"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE Ownable",
 			qt.Commentf("must not target the mixin struct name, got:\n%s", sql))
 
 		// One correctly-targeted ADD per host table per FK, no duplication.
@@ -166,12 +166,12 @@ func TestEmbeddedInlineMixinFK_NeverTargetsStructName(t *testing.T) {
 		sql, err := renderer.RenderSQL("postgres", nodes...)
 		c.Assert(err, qt.IsNil)
 
-		c.Assert(strings.Contains(sql, "Ownable"), qt.IsFalse,
+		c.Assert(sql, qt.Not(qt.Contains), "Ownable",
 			qt.Commentf("down must not reference the mixin struct, got:\n%s", sql))
 		for _, h := range hosts {
-			c.Assert(strings.Contains(sql, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_tenant"), qt.IsTrue,
+			c.Assert(sql, qt.Contains, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_tenant",
 				qt.Commentf("down must drop tenant FK from %s, got:\n%s", h, sql))
-			c.Assert(strings.Contains(sql, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_created_by"), qt.IsTrue,
+			c.Assert(sql, qt.Contains, "ALTER TABLE "+h+" DROP CONSTRAINT IF EXISTS fk_entity_created_by",
 				qt.Commentf("down must drop created_by FK from %s, got:\n%s", h, sql))
 		}
 	})
@@ -234,7 +234,7 @@ func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
 		noopNodes := postgres.New().GenerateMigrationAST(converged, gen)
 		noopSQL, err := renderer.RenderSQL("postgres", noopNodes...)
 		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Contains(noopSQL, "fk_entity_tenant"), qt.IsFalse,
+		c.Assert(noopSQL, qt.Not(qt.Contains), "fk_entity_tenant",
 			qt.Commentf("converged tenant FK must produce no churn, got:\n%s", noopSQL))
 	})
 
@@ -310,9 +310,9 @@ func TestEmbeddedInlineMixinFK_MixedModifyAndAdd_NoPhantomDrop(t *testing.T) {
 			qt.Commentf("modify host %s must drop the old tenant FK once, got:\n%s", h, sql))
 	}
 	// The pure-add host gets the ADD but NO phantom DROP.
-	c.Assert(strings.Contains(sql, "ALTER TABLE "+addHost+" ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE"), qt.IsTrue,
+	c.Assert(sql, qt.Contains, "ALTER TABLE "+addHost+" ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE",
 		qt.Commentf("pure-add host %s must add the tenant FK, got:\n%s", addHost, sql))
-	c.Assert(strings.Contains(sql, "ALTER TABLE "+addHost+" DROP CONSTRAINT IF EXISTS fk_entity_tenant"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE "+addHost+" DROP CONSTRAINT IF EXISTS fk_entity_tenant",
 		qt.Commentf("pure-add host %s must NOT emit a phantom DROP, got:\n%s", addHost, sql))
 }
 

--- a/migration/schemadiff/fk_action_drift_mysql_test.go
+++ b/migration/schemadiff/fk_action_drift_mysql_test.go
@@ -39,9 +39,9 @@ func TestCompare_FieldLevelForeignKeyActionDrift_MySQL(t *testing.T) {
 	const dropStmt = "ALTER TABLE exports DROP FOREIGN KEY fk_export_file;"
 	const addStmt = "ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE SET NULL;"
 
-	c.Assert(strings.Contains(sql, dropStmt), qt.IsTrue,
+	c.Assert(sql, qt.Contains, dropStmt,
 		qt.Commentf("expected a real DROP FOREIGN KEY (not a TODO comment), got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "TODO"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "TODO",
 		qt.Commentf("must not emit a TODO placeholder, got:\n%s", sql))
 
 	// Ordering: the DROP must precede the ADD so the re-add does not collide
@@ -54,7 +54,7 @@ func TestCompare_FieldLevelForeignKeyActionDrift_MySQL(t *testing.T) {
 		qt.Commentf("DROP must come before ADD; drop@%d add@%d\n%s", dropIdx, addIdx, sql))
 
 	// The re-added FK carries the new ON DELETE action.
-	c.Assert(strings.Contains(sql, addStmt), qt.IsTrue,
+	c.Assert(sql, qt.Contains, addStmt,
 		qt.Commentf("expected the FK to be re-added with ON DELETE SET NULL, got:\n%s", sql))
 }
 

--- a/migration/schemadiff/fk_action_drift_test.go
+++ b/migration/schemadiff/fk_action_drift_test.go
@@ -148,7 +148,7 @@ func TestCompare_FieldLevelForeignKeyActionMigrationSQL(t *testing.T) {
 
 	// The new FK with the action clause is emitted.
 	const addStmt = "ALTER TABLE exports ADD CONSTRAINT fk_export_file FOREIGN KEY (file_id) REFERENCES files(id) ON DELETE SET NULL;"
-	c.Assert(strings.Contains(sql, addStmt), qt.IsTrue,
+	c.Assert(sql, qt.Contains, addStmt,
 		qt.Commentf("expected migration to ADD the FK with ON DELETE SET NULL, got:\n%s", sql))
 
 	// The old constraint is dropped first. The comparator records the concrete
@@ -157,9 +157,9 @@ func TestCompare_FieldLevelForeignKeyActionMigrationSQL(t *testing.T) {
 	// DO block — the latter resolves the owning table with LIMIT 1 and could drop a
 	// same-named constraint on the wrong table (issue #199).
 	const dropStmt = "ALTER TABLE exports DROP CONSTRAINT IF EXISTS fk_export_file;"
-	c.Assert(strings.Contains(sql, dropStmt), qt.IsTrue,
+	c.Assert(sql, qt.Contains, dropStmt,
 		qt.Commentf("expected migration to DROP the old FK from its known host table, got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+	c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 		qt.Commentf("a known-host modify must not fall back to the name-only DO block, got:\n%s", sql))
 
 	// Ordering: the DROP must precede the ADD so the re-add does not collide.

--- a/migration/schemadiff/internal/compare/compare_roles_test.go
+++ b/migration/schemadiff/internal/compare/compare_roles_test.go
@@ -20,9 +20,9 @@ func TestRolesComparison(t *testing.T) {
 
 		compare.Roles(generated, database, diff)
 
-		c.Assert(len(diff.RolesAdded), qt.Equals, 0)
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
-		c.Assert(len(diff.RolesModified), qt.Equals, 0)
+		c.Assert(diff.RolesAdded, qt.HasLen, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
+		c.Assert(diff.RolesModified, qt.HasLen, 0)
 	})
 
 	t.Run("roles added", func(t *testing.T) {
@@ -38,11 +38,11 @@ func TestRolesComparison(t *testing.T) {
 
 		compare.Roles(generated, database, diff)
 
-		c.Assert(len(diff.RolesAdded), qt.Equals, 2)
+		c.Assert(diff.RolesAdded, qt.HasLen, 2)
 		c.Assert(diff.RolesAdded, qt.Contains, "app_user")
 		c.Assert(diff.RolesAdded, qt.Contains, "admin_user")
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
-		c.Assert(len(diff.RolesModified), qt.Equals, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
+		c.Assert(diff.RolesModified, qt.HasLen, 0)
 	})
 
 	t.Run("roles not automatically removed", func(t *testing.T) {
@@ -59,9 +59,9 @@ func TestRolesComparison(t *testing.T) {
 		compare.Roles(generated, database, diff)
 
 		// Roles should not be automatically removed for safety
-		c.Assert(len(diff.RolesAdded), qt.Equals, 0)
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
-		c.Assert(len(diff.RolesModified), qt.Equals, 0)
+		c.Assert(diff.RolesAdded, qt.HasLen, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
+		c.Assert(diff.RolesModified, qt.HasLen, 0)
 	})
 
 	t.Run("roles modified", func(t *testing.T) {
@@ -80,11 +80,11 @@ func TestRolesComparison(t *testing.T) {
 
 		compare.Roles(generated, database, diff)
 
-		c.Assert(len(diff.RolesAdded), qt.Equals, 0)
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
-		c.Assert(len(diff.RolesModified), qt.Equals, 1)
+		c.Assert(diff.RolesAdded, qt.HasLen, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
+		c.Assert(diff.RolesModified, qt.HasLen, 1)
 		c.Assert(diff.RolesModified[0].RoleName, qt.Equals, "app_user")
-		c.Assert(len(diff.RolesModified[0].Changes), qt.Equals, 2)
+		c.Assert(diff.RolesModified[0].Changes, qt.HasLen, 2)
 		c.Assert(diff.RolesModified[0].Changes["login"], qt.Equals, "false -> true")
 		c.Assert(diff.RolesModified[0].Changes["createdb"], qt.Equals, "false -> true")
 	})
@@ -109,13 +109,13 @@ func TestRolesComparison(t *testing.T) {
 
 		compare.Roles(generated, database, diff)
 
-		c.Assert(len(diff.RolesAdded), qt.Equals, 1)
+		c.Assert(diff.RolesAdded, qt.HasLen, 1)
 		c.Assert(diff.RolesAdded[0], qt.Equals, "new_role")
 
 		// Roles are not automatically removed for safety
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
 
-		c.Assert(len(diff.RolesModified), qt.Equals, 1)
+		c.Assert(diff.RolesModified, qt.HasLen, 1)
 		c.Assert(diff.RolesModified[0].RoleName, qt.Equals, "app_user")
 		c.Assert(diff.RolesModified[0].Changes["login"], qt.Equals, "false -> true")
 	})
@@ -144,10 +144,10 @@ func TestRolesComparison(t *testing.T) {
 		c.Assert(diff.RolesAdded, qt.DeepEquals, []string{"a_role", "z_role"})
 
 		// Roles are not automatically removed for safety
-		c.Assert(len(diff.RolesRemoved), qt.Equals, 0)
+		c.Assert(diff.RolesRemoved, qt.HasLen, 0)
 
 		// Check modified roles are sorted
-		c.Assert(len(diff.RolesModified), qt.Equals, 1)
+		c.Assert(diff.RolesModified, qt.HasLen, 1)
 		c.Assert(diff.RolesModified[0].RoleName, qt.Equals, "m_role")
 	})
 }
@@ -177,7 +177,7 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		diff := compare.RoleDefinitions(generated, database)
 
 		c.Assert(diff.RoleName, qt.Equals, "test_role")
-		c.Assert(len(diff.Changes), qt.Equals, 0)
+		c.Assert(diff.Changes, qt.HasLen, 0)
 	})
 
 	t.Run("all attributes different", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		diff := compare.RoleDefinitions(generated, database)
 
 		c.Assert(diff.RoleName, qt.Equals, "test_role")
-		c.Assert(len(diff.Changes), qt.Equals, 7)
+		c.Assert(diff.Changes, qt.HasLen, 7)
 		c.Assert(diff.Changes["login"], qt.Equals, "false -> true")
 		c.Assert(diff.Changes["password"], qt.Equals, "password_update_required")
 		c.Assert(diff.Changes["superuser"], qt.Equals, "false -> true")
@@ -229,7 +229,7 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		diff := compare.RoleDefinitions(generated, database)
 
 		c.Assert(diff.RoleName, qt.Equals, "test_role")
-		c.Assert(len(diff.Changes), qt.Equals, 1)
+		c.Assert(diff.Changes, qt.HasLen, 1)
 		c.Assert(diff.Changes["login"], qt.Equals, "false -> true")
 	})
 
@@ -246,7 +246,7 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		diff := compare.RoleDefinitions(generated, database)
 
 		c.Assert(diff.RoleName, qt.Equals, "test_role")
-		c.Assert(len(diff.Changes), qt.Equals, 1)
+		c.Assert(diff.Changes, qt.HasLen, 1)
 		c.Assert(diff.Changes["password"], qt.Equals, "password_update_required")
 	})
 
@@ -264,6 +264,6 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		diff := compare.RoleDefinitions(generated, database)
 
 		c.Assert(diff.RoleName, qt.Equals, "test_role")
-		c.Assert(len(diff.Changes), qt.Equals, 0) // No password change detected
+		c.Assert(diff.Changes, qt.HasLen, 0) // No password change detected
 	})
 }

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -201,7 +201,7 @@ func TestColumns_HappyPath(t *testing.T) {
 			result := compare.Columns(tt.genCol, tt.dbCol)
 
 			c.Assert(result.ColumnName, qt.Equals, tt.expected.ColumnName)
-			c.Assert(len(result.Changes), qt.Equals, len(tt.expected.Changes))
+			c.Assert(result.Changes, qt.HasLen, len(tt.expected.Changes))
 			for key, expectedValue := range tt.expected.Changes {
 				c.Assert(result.Changes[key], qt.Equals, expectedValue)
 			}
@@ -283,7 +283,7 @@ func TestColumns_UnhappyPath(t *testing.T) {
 			result := compare.Columns(tt.genCol, tt.dbCol)
 
 			c.Assert(result.ColumnName, qt.Equals, tt.expected.ColumnName)
-			c.Assert(len(result.Changes), qt.Equals, len(tt.expected.Changes))
+			c.Assert(result.Changes, qt.HasLen, len(tt.expected.Changes))
 			for key, expectedValue := range tt.expected.Changes {
 				c.Assert(result.Changes[key], qt.Equals, expectedValue)
 			}
@@ -385,7 +385,7 @@ func TestEnums_HappyPath(t *testing.T) {
 
 			c.Assert(diff.EnumsAdded, qt.DeepEquals, tt.expected.EnumsAdded)
 			c.Assert(diff.EnumsRemoved, qt.DeepEquals, tt.expected.EnumsRemoved)
-			c.Assert(len(diff.EnumsModified), qt.Equals, len(tt.expected.EnumsModified))
+			c.Assert(diff.EnumsModified, qt.HasLen, len(tt.expected.EnumsModified))
 
 			for i, expectedEnumDiff := range tt.expected.EnumsModified {
 				c.Assert(diff.EnumsModified[i].EnumName, qt.Equals, expectedEnumDiff.EnumName)
@@ -434,7 +434,7 @@ func TestEnums_UnhappyPath(t *testing.T) {
 
 			c.Assert(diff.EnumsAdded, qt.DeepEquals, tt.expected.EnumsAdded)
 			c.Assert(diff.EnumsRemoved, qt.DeepEquals, tt.expected.EnumsRemoved)
-			c.Assert(len(diff.EnumsModified), qt.Equals, len(tt.expected.EnumsModified))
+			c.Assert(diff.EnumsModified, qt.HasLen, len(tt.expected.EnumsModified))
 		})
 	}
 }
@@ -856,7 +856,7 @@ func TestColumns_EdgeCases(t *testing.T) {
 			result := compare.Columns(tt.genCol, tt.dbCol)
 
 			c.Assert(result.ColumnName, qt.Equals, tt.expected.ColumnName)
-			c.Assert(len(result.Changes), qt.Equals, len(tt.expected.Changes))
+			c.Assert(result.Changes, qt.HasLen, len(tt.expected.Changes))
 			for key, expectedValue := range tt.expected.Changes {
 				c.Assert(result.Changes[key], qt.Equals, expectedValue)
 			}
@@ -888,9 +888,9 @@ func TestTableColumns_EdgeCases(t *testing.T) {
 	result := compare.TableColumns(genTable, dbTable, generated)
 
 	c.Assert(result.TableName, qt.Equals, "users")
-	c.Assert(len(result.ColumnsModified), qt.Equals, 1)
+	c.Assert(result.ColumnsModified, qt.HasLen, 1)
 	c.Assert(result.ColumnsModified[0].ColumnName, qt.Equals, "name")
-	c.Assert(len(result.ColumnsModified[0].Changes), qt.Equals, 1) // Only nullable should change (types are both varchar)
+	c.Assert(result.ColumnsModified[0].Changes, qt.HasLen, 1) // Only nullable should change (types are both varchar)
 	c.Assert(result.ColumnsModified[0].Changes["nullable"], qt.Equals, "true -> false")
 }
 
@@ -1050,7 +1050,7 @@ func TestColumnByName_HappyPath(t *testing.T) {
 
 			c.Assert(result, qt.IsNotNil)
 			c.Assert(result.ColumnName, qt.Equals, tt.expectedDiff.ColumnName)
-			c.Assert(len(result.Changes), qt.Equals, len(tt.expectedDiff.Changes))
+			c.Assert(result.Changes, qt.HasLen, len(tt.expectedDiff.Changes))
 			for key, expectedValue := range tt.expectedDiff.Changes {
 				c.Assert(result.Changes[key], qt.Equals, expectedValue)
 			}
@@ -1263,7 +1263,7 @@ func TestColumnByName_EdgeCases(t *testing.T) {
 			} else {
 				c.Assert(result, qt.IsNotNil)
 				c.Assert(result.ColumnName, qt.Equals, tt.expectedDiff.ColumnName)
-				c.Assert(len(result.Changes), qt.Equals, len(tt.expectedDiff.Changes))
+				c.Assert(result.Changes, qt.HasLen, len(tt.expectedDiff.Changes))
 				for key, expectedValue := range tt.expectedDiff.Changes {
 					c.Assert(result.Changes[key], qt.Equals, expectedValue)
 				}
@@ -1294,7 +1294,7 @@ func TestColumnByName_PointerBehavior(t *testing.T) {
 	result.Changes["new_change"] = "old -> new"
 
 	c.Assert(originalDiffs[0].Changes["new_change"], qt.Equals, "old -> new")
-	c.Assert(len(originalDiffs[0].Changes), qt.Equals, 2)
+	c.Assert(originalDiffs[0].Changes, qt.HasLen, 2)
 }
 
 func TestTablesAndColumns_HappyPath(t *testing.T) {
@@ -1416,7 +1416,7 @@ func TestTablesAndColumns_HappyPath(t *testing.T) {
 
 			c.Assert(diff.TablesAdded, qt.DeepEquals, tt.expected.TablesAdded)
 			c.Assert(diff.TablesRemoved, qt.DeepEquals, tt.expected.TablesRemoved)
-			c.Assert(len(diff.TablesModified), qt.Equals, len(tt.expected.TablesModified))
+			c.Assert(diff.TablesModified, qt.HasLen, len(tt.expected.TablesModified))
 
 			for i, expectedTableDiff := range tt.expected.TablesModified {
 				c.Assert(diff.TablesModified[i].TableName, qt.Equals, expectedTableDiff.TableName)
@@ -1475,7 +1475,7 @@ func TestTablesAndColumns_UnhappyPath(t *testing.T) {
 
 			c.Assert(diff.TablesAdded, qt.DeepEquals, tt.expected.TablesAdded)
 			c.Assert(diff.TablesRemoved, qt.DeepEquals, tt.expected.TablesRemoved)
-			c.Assert(len(diff.TablesModified), qt.Equals, len(tt.expected.TablesModified))
+			c.Assert(diff.TablesModified, qt.HasLen, len(tt.expected.TablesModified))
 		})
 	}
 }

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -161,14 +161,14 @@ func TestConstraints(t *testing.T) {
 			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			// Check constraints added
-			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded))
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, len(tt.expected.ConstraintsAdded))
 			// Check that all expected constraints are present (order doesn't matter)
 			for _, expected := range tt.expected.ConstraintsAdded {
 				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
 			}
 
 			// Check constraints removed
-			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved))
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, len(tt.expected.ConstraintsRemoved))
 			// Check that all expected constraints are present (order doesn't matter)
 			for _, expected := range tt.expected.ConstraintsRemoved {
 				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)
@@ -242,8 +242,8 @@ func TestConstraints_EdgeCases(t *testing.T) {
 
 	compare.Constraints(generated, database, diff, nil)
 
-	c.Assert(len(diff.ConstraintsAdded), qt.Equals, 0)
-	c.Assert(len(diff.ConstraintsRemoved), qt.Equals, 0)
+	c.Assert(diff.ConstraintsAdded, qt.HasLen, 0)
+	c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
 }
 
 func TestConstraints_ExcludeConstraintComparison(t *testing.T) {
@@ -429,13 +429,13 @@ func TestConstraints_ExcludeConstraintComparison(t *testing.T) {
 			compare.Constraints(tt.generated, tt.database, diff, nil)
 
 			// Check constraints added
-			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded))
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, len(tt.expected.ConstraintsAdded))
 			for _, expected := range tt.expected.ConstraintsAdded {
 				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
 			}
 
 			// Check constraints removed
-			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved))
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, len(tt.expected.ConstraintsRemoved))
 			for _, expected := range tt.expected.ConstraintsRemoved {
 				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)
 			}
@@ -674,13 +674,13 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 			diff := &difftypes.SchemaDiff{}
 			compare.Constraints(tt.generated, tt.database, diff, nil)
 
-			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, len(tt.expected.ConstraintsAdded),
 				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))
 			for _, expected := range tt.expected.ConstraintsAdded {
 				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
 			}
 
-			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved),
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, len(tt.expected.ConstraintsRemoved),
 				qt.Commentf("ConstraintsRemoved=%v", diff.ConstraintsRemoved))
 			for _, expected := range tt.expected.ConstraintsRemoved {
 				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)

--- a/migration/schemadiff/internal/compare/extensions_test.go
+++ b/migration/schemadiff/internal/compare/extensions_test.go
@@ -147,11 +147,11 @@ func TestExtensions_RealWorldScenarios(t *testing.T) {
 				return generated, database
 			},
 			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
-				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 3)
+				c.Assert(diff.ExtensionsAdded, qt.HasLen, 3)
 				c.Assert(diff.ExtensionsAdded, qt.Contains, "pg_trgm")
 				c.Assert(diff.ExtensionsAdded, qt.Contains, "btree_gin")
 				c.Assert(diff.ExtensionsAdded, qt.Contains, "postgis")
-				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 0)
+				c.Assert(diff.ExtensionsRemoved, qt.HasLen, 0)
 			},
 		},
 		{
@@ -174,8 +174,8 @@ func TestExtensions_RealWorldScenarios(t *testing.T) {
 				return generated, database
 			},
 			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
-				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 0)
-				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 3)
+				c.Assert(diff.ExtensionsAdded, qt.HasLen, 0)
+				c.Assert(diff.ExtensionsRemoved, qt.HasLen, 3)
 				c.Assert(diff.ExtensionsRemoved, qt.Contains, "uuid-ossp")
 				c.Assert(diff.ExtensionsRemoved, qt.Contains, "postgis")
 				c.Assert(diff.ExtensionsRemoved, qt.Contains, "btree_gin")
@@ -202,10 +202,10 @@ func TestExtensions_RealWorldScenarios(t *testing.T) {
 				return generated, database
 			},
 			verify: func(c *qt.C, diff *difftypes.SchemaDiff) {
-				c.Assert(len(diff.ExtensionsAdded), qt.Equals, 2)
+				c.Assert(diff.ExtensionsAdded, qt.HasLen, 2)
 				c.Assert(diff.ExtensionsAdded, qt.Contains, "postgis")
 				c.Assert(diff.ExtensionsAdded, qt.Contains, "uuid-ossp")
-				c.Assert(len(diff.ExtensionsRemoved), qt.Equals, 0)
+				c.Assert(diff.ExtensionsRemoved, qt.HasLen, 0)
 			},
 		},
 	}

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -323,13 +323,13 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 			diff := &difftypes.SchemaDiff{}
 			compare.Constraints(tt.generated, tt.database, diff, nil)
 
-			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expected.ConstraintsAdded),
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, len(tt.expected.ConstraintsAdded),
 				qt.Commentf("ConstraintsAdded=%v", diff.ConstraintsAdded))
 			for _, expected := range tt.expected.ConstraintsAdded {
 				c.Assert(diff.ConstraintsAdded, qt.Contains, expected)
 			}
 
-			c.Assert(len(diff.ConstraintsRemoved), qt.Equals, len(tt.expected.ConstraintsRemoved),
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, len(tt.expected.ConstraintsRemoved),
 				qt.Commentf("ConstraintsRemoved=%v", diff.ConstraintsRemoved))
 			for _, expected := range tt.expected.ConstraintsRemoved {
 				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+hooks_dir="$repo_root/.git/hooks"
+pre_commit="$hooks_dir/pre-commit"
+marker="# ptah-managed-pre-commit-hook"
+
+mkdir -p "$hooks_dir"
+
+if [ -f "$pre_commit" ] && ! grep -qF "$marker" "$pre_commit"; then
+	backup="$pre_commit.ptah-backup.$(date +%Y%m%d%H%M%S)"
+	mv "$pre_commit" "$backup"
+	echo "Backed up existing pre-commit hook to $backup"
+fi
+
+cat >"$pre_commit" <<'HOOK'
+#!/usr/bin/env sh
+set -eu
+# ptah-managed-pre-commit-hook
+
+echo "Running qtlint..."
+go tool qtlint ./...
+
+echo "Running golangci-lint..."
+golangci-lint run ./...
+HOOK
+
+chmod +x "$pre_commit"
+echo "Installed $pre_commit"


### PR DESCRIPTION
## Summary
- Add `github.com/go-extras/qtlint/cmd/qtlint` as a Go tool at the latest released version, `v1.6.0`.
- Wire `go tool qtlint ./...` into the Makefile lint path and Go lint workflow.
- Add `lint-qtlint`, `lint-fix`, and `install-hooks` Makefile targets plus a tracked `scripts/install-hooks.sh` pre-commit installer.
- Apply `go tool qtlint -fix ./...` across existing quicktest assertions so the new lint gate passes.

## Impact
The standard lint path now enforces qtlint locally, in CI, and through the optional installed pre-commit hook. Existing quicktest usage has been normalized to qtlint-preferred assertions.

Closes #192.

## Verification
- `go list -m -versions github.com/go-extras/qtlint`
- `go tool qtlint -h`
- `go tool qtlint -fix ./...`
- `go tool qtlint ./...`
- `sh -n scripts/install-hooks.sh`
- `make lint`
- `git diff --check`
- `go test ./...`
- `go test -count=1 ./...`

Note: `go mod tidy` was not run because it was rejected as broader dependency-manifest churn than this qtlint wiring change requires; `go get -tool github.com/go-extras/qtlint/cmd/qtlint@v1.6.0` produced the committed `go.mod`/`go.sum` updates.