### PR TITLE
Add drift check command (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Provides command-line interface for all Ptah operations:
 - **`generate`** - Generate SQL schema from Go entities without touching database
 - **`read-db`** - Read and display current database schema
 - **`compare`** - Compare Go entities with current database schema
+- **`drift`** - Check live database drift with CI-friendly exit codes
 - **`migrate`** - Generate migration SQL for schema differences
 - **`migrate-up`** - Apply migrations to bring database up to latest version
 - **`migrate-down`** - Roll back migrations to previous versions
@@ -432,6 +433,62 @@ Compare your Go entities with the current database schema:
 ```
 
 **Output:** Detailed differences showing what needs to be added, removed, or modified
+
+#### Check Schema Drift
+Check whether the live database still matches the schema declared by Go entities:
+
+```bash
+./package-migrator drift --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
+```
+
+Exit codes are designed for scheduled CI checks:
+
+- `0` - no failing drift for the selected threshold
+- `1` - drift detected
+- `2` - command error, such as a connection or parse failure
+
+Use `--format text|json|github-actions` to choose output, and `--ignore tables=audit_log,sessions` to suppress intentionally unmanaged tables. By default any drift returns `1`; use `--severity destructive` to return `1` only for destructive drift such as dropped tables, dropped columns, removed constraints, disabled RLS, or removed database objects.
+
+Nightly GitHub Actions example with Slack notification on drift:
+
+```yaml
+name: Nightly schema drift
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build ptah
+        run: go build -o ptah ./cmd
+      - name: Check schema drift
+        id: drift
+        continue-on-error: true
+        run: |
+          ./ptah drift \
+            --root-dir ./models \
+            --db-url "${{ secrets.STAGING_DATABASE_URL }}" \
+            --format github-actions
+      - name: Alert Slack on drift
+        if: steps.drift.outcome == 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Ptah schema drift detected on staging. Check the nightly drift workflow."}' \
+            "$SLACK_WEBHOOK_URL"
+      - name: Fail workflow on drift
+        if: steps.drift.outcome == 'failure'
+        run: exit 1
+```
 
 #### Generate Migration SQL
 Generate SQL migration statements to synchronize schemas:

--- a/README.md
+++ b/README.md
@@ -467,13 +467,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Build ptah
-        run: go build -o ptah ./cmd
+      - name: Build package-migrator
+        run: go build -o package-migrator ./cmd
       - name: Check schema drift
         id: drift
         continue-on-error: true
         run: |
-          ./ptah drift \
+          ./package-migrator drift \
             --root-dir ./models \
             --db-url "${{ secrets.STAGING_DATABASE_URL }}" \
             --format github-actions

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -1,7 +1,6 @@
 package drift
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -117,7 +116,7 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
 	}
 
-	result, err := schemaops.Compare(context.Background(), schemaops.CompareOptions{
+	result, err := schemaops.Compare(cmd.Context(), schemaops.CompareOptions{
 		RootDir:        opts.rootDir,
 		DatabaseURL:    opts.dbURL,
 		ConnectTimeout: connectTimeout,

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -1,0 +1,313 @@
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/internal/schemaops"
+	"github.com/stokaro/ptah/migration/safety"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+const (
+	formatText          = "text"
+	formatJSON          = "json"
+	formatGitHubActions = "github-actions"
+
+	severityAll         = "all"
+	severityDestructive = "destructive"
+)
+
+var errDriftDetected = errors.New("schema drift detected")
+
+// NewDriftCommand returns the drift-check command.
+func NewDriftCommand() *cobra.Command {
+	var rootDir string
+	var dbURL string
+	var format string
+	var severity string
+	var ignored []string
+	var useExitCode bool
+	var connectTimeoutRaw string
+
+	cmd := &cobra.Command{
+		Use:           "drift",
+		Short:         "Check live database drift against Go entities",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDrift(cmd, runOptions{
+				rootDir:           rootDir,
+				dbURL:             dbURL,
+				format:            format,
+				severity:          severity,
+				ignored:           ignored,
+				useExitCode:       useExitCode,
+				connectTimeoutRaw: connectTimeoutRaw,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&rootDir, "root-dir", "./", "Root directory to scan for Go entities")
+	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL (required). Example: postgres://localhost:5432/dbname")
+	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
+	cmd.Flags().StringVar(&severity, "severity", severityAll, "Failing drift threshold: all or destructive")
+	cmd.Flags().StringArrayVar(&ignored, "ignore", nil, "Ignore drift for a scope, for example tables=audit_log,sessions")
+	cmd.Flags().BoolVar(&useExitCode, "exit-code", true, "Return 1 when drift exceeds --severity; errors still return 2")
+	cmd.Flags().StringVar(
+		&connectTimeoutRaw,
+		dbcli.ConnectTimeoutFlagName,
+		dbcli.DefaultConnectTimeout.String(),
+		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
+	)
+
+	return cmd
+}
+
+type runOptions struct {
+	rootDir           string
+	dbURL             string
+	format            string
+	severity          string
+	ignored           []string
+	useExitCode       bool
+	connectTimeoutRaw string
+}
+
+type driftReport struct {
+	Drift            bool                  `json:"drift"`
+	Failed           bool                  `json:"failed"`
+	FailureThreshold string                `json:"failure_threshold"`
+	HighestSeverity  safety.Severity       `json:"highest_severity"`
+	Dialect          string                `json:"dialect,omitempty"`
+	RootDir          string                `json:"root_dir,omitempty"`
+	DatabaseURL      string                `json:"database_url,omitempty"`
+	IgnoredTables    []string              `json:"ignored_tables,omitempty"`
+	Findings         []safety.Finding      `json:"findings,omitempty"`
+	Diff             *difftypes.SchemaDiff `json:"diff,omitempty"`
+	Error            string                `json:"error,omitempty"`
+}
+
+func runDrift(cmd *cobra.Command, opts runOptions) error {
+	if opts.dbURL == "" {
+		return writeError(cmd.ErrOrStderr(), opts.format, "database URL is required")
+	}
+	if err := validateFormat(opts.format); err != nil {
+		return writeError(cmd.ErrOrStderr(), formatText, err.Error())
+	}
+	if err := validateSeverity(opts.severity); err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	ignoredTables, err := parseIgnoredTables(opts.ignored)
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+	connectTimeout, err := dbcli.ParseConnectTimeout(opts.connectTimeoutRaw)
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	result, err := schemaops.Compare(context.Background(), schemaops.CompareOptions{
+		RootDir:        opts.rootDir,
+		DatabaseURL:    opts.dbURL,
+		ConnectTimeout: connectTimeout,
+		IgnoredTables:  ignoredTables,
+	})
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	findings := safety.ClassifySchemaDiff(result.Diff)
+	highest := safety.Highest(findings)
+	hasDrift := result.Diff.HasChanges()
+	failed := opts.useExitCode && hasDrift && shouldFailDrift(highest, opts.severity)
+	report := driftReport{
+		Drift:            hasDrift,
+		Failed:           failed,
+		FailureThreshold: opts.severity,
+		HighestSeverity:  highest,
+		Dialect:          result.Dialect,
+		RootDir:          result.RootDir,
+		DatabaseURL:      result.DatabaseURL,
+		IgnoredTables:    ignoredTables,
+		Findings:         findings,
+		Diff:             result.Diff,
+	}
+
+	writer := cmd.OutOrStdout()
+	if hasDrift {
+		writer = cmd.ErrOrStderr()
+	}
+	if err := writeReport(writer, opts.format, report); err != nil {
+		return writeError(cmd.ErrOrStderr(), formatText, err.Error())
+	}
+	if failed {
+		return exitcode.New(1, errDriftDetected)
+	}
+	return nil
+}
+
+func writeError(w io.Writer, format string, msg string) error {
+	report := driftReport{
+		Failed:           true,
+		FailureThreshold: severityAll,
+		HighestSeverity:  safety.Safe,
+		Error:            msg,
+	}
+	_ = writeReport(w, format, report)
+	return exitcode.New(2, errors.New(msg))
+}
+
+func validateFormat(format string) error {
+	switch format {
+	case formatText, formatJSON, formatGitHubActions:
+		return nil
+	default:
+		return fmt.Errorf("invalid --format value %q: expected text, json, or github-actions", format)
+	}
+}
+
+func validateSeverity(severity string) error {
+	switch severity {
+	case severityAll, severityDestructive:
+		return nil
+	default:
+		return fmt.Errorf("invalid --severity value %q: expected all or destructive", severity)
+	}
+}
+
+func parseIgnoredTables(values []string) ([]string, error) {
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		key, raw, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(key) != "tables" {
+			return nil, fmt.Errorf("invalid --ignore value %q: expected tables=name[,name...]", value)
+		}
+		for name := range strings.SplitSeq(raw, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				seen[name] = struct{}{}
+			}
+		}
+	}
+
+	tables := make([]string, 0, len(seen))
+	for table := range seen {
+		tables = append(tables, table)
+	}
+	slices.Sort(tables)
+	return tables, nil
+}
+
+func shouldFailDrift(highest safety.Severity, severity string) bool {
+	switch severity {
+	case severityDestructive:
+		return highest == safety.Destructive
+	default:
+		return true
+	}
+}
+
+func writeReport(w io.Writer, format string, report driftReport) error {
+	switch format {
+	case formatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	case formatGitHubActions:
+		return writeGitHubActionsReport(w, report)
+	default:
+		return writeTextReport(w, report)
+	}
+}
+
+func writeTextReport(w io.Writer, report driftReport) error {
+	if report.Error != "" {
+		_, err := fmt.Fprintf(w, "Error: %s\n", report.Error)
+		return err
+	}
+	if !report.Drift {
+		_, err := fmt.Fprintln(w, "No schema drift detected.")
+		return err
+	}
+
+	if _, err := fmt.Fprintf(w, "Schema drift detected (highest severity: %s).\n", report.HighestSeverity); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Failure threshold: %s. Failing: %t.\n", report.FailureThreshold, report.Failed); err != nil {
+		return err
+	}
+	if report.DatabaseURL != "" {
+		if _, err := fmt.Fprintf(w, "Database: %s\n", report.DatabaseURL); err != nil {
+			return err
+		}
+	}
+	if len(report.IgnoredTables) > 0 {
+		if _, err := fmt.Fprintf(w, "Ignored tables: %s\n", strings.Join(report.IgnoredTables, ", ")); err != nil {
+			return err
+		}
+	}
+	if len(report.Findings) == 0 {
+		return nil
+	}
+	_, err := fmt.Fprintln(w, "\nFindings:")
+	if err != nil {
+		return err
+	}
+	for _, finding := range report.Findings {
+		if _, err := fmt.Fprintf(w, "- %s: %d (%s)\n", finding.Category, finding.Count, finding.Severity); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeGitHubActionsReport(w io.Writer, report driftReport) error {
+	if report.Error != "" {
+		_, err := fmt.Fprintf(w, "::error title=Ptah drift check failed::%s\n", escapeWorkflowCommand(report.Error))
+		return err
+	}
+	if !report.Drift {
+		_, err := fmt.Fprintln(w, "::notice title=Ptah drift check::No schema drift detected")
+		return err
+	}
+
+	level := "warning"
+	if report.Failed || report.HighestSeverity == safety.Destructive {
+		level = "error"
+	}
+	message := fmt.Sprintf(
+		"Schema drift detected; highest severity: %s; failure threshold: %s",
+		report.HighestSeverity,
+		report.FailureThreshold,
+	)
+	if _, err := fmt.Fprintf(w, "::%s title=Ptah schema drift::%s\n", level, escapeWorkflowCommand(message)); err != nil {
+		return err
+	}
+	for _, finding := range report.Findings {
+		message := fmt.Sprintf("%s: %d (%s)", finding.Category, finding.Count, finding.Severity)
+		if _, err := fmt.Fprintf(w, "::%s title=Ptah drift finding::%s\n", level, escapeWorkflowCommand(message)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func escapeWorkflowCommand(s string) string {
+	replacer := strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+	)
+	return replacer.Replace(s)
+}

--- a/cmd/drift/drift_test.go
+++ b/cmd/drift/drift_test.go
@@ -1,0 +1,97 @@
+package drift
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+func TestNewDriftCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDriftCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "drift")
+	c.Assert(cmd.Short, qt.Contains, "drift")
+}
+
+func TestRunDrift_MissingDatabaseURLReturnsCode2(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDriftCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--root-dir", "."})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr.String(), qt.Contains, "database URL is required")
+}
+
+func TestParseIgnoredTables(t *testing.T) {
+	c := qt.New(t)
+
+	tables, err := parseIgnoredTables([]string{"tables=audit_log,sessions", "tables= audit_log , events "})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(tables, qt.DeepEquals, []string{"audit_log", "events", "sessions"})
+}
+
+func TestParseIgnoredTablesRejectsUnknownScope(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parseIgnoredTables([]string{"views=audit_view"})
+
+	c.Assert(err, qt.ErrorMatches, `invalid --ignore value "views=audit_view": expected tables=name\[,name\.\.\.\]`)
+}
+
+func TestShouldFailDrift(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(shouldFailDrift(safety.Warning, severityAll), qt.IsTrue)
+	c.Assert(shouldFailDrift(safety.Warning, severityDestructive), qt.IsFalse)
+	c.Assert(shouldFailDrift(safety.Destructive, severityDestructive), qt.IsTrue)
+}
+
+func TestWriteGitHubActionsReport(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	err := writeGitHubActionsReport(&buf, driftReport{
+		Drift:            true,
+		Failed:           true,
+		FailureThreshold: severityDestructive,
+		HighestSeverity:  safety.Destructive,
+		Findings: []safety.Finding{
+			{Category: "tables_removed", Count: 1, Severity: safety.Destructive},
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "::error title=Ptah schema drift::")
+	c.Assert(buf.String(), qt.Contains, "tables_removed: 1")
+}
+
+func TestWriteJSONReport(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	err := writeReport(&buf, formatJSON, driftReport{
+		Drift:            true,
+		Failed:           false,
+		FailureThreshold: severityDestructive,
+		HighestSeverity:  safety.Warning,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, `"drift": true`)
+	c.Assert(buf.String(), qt.Contains, `"highest_severity": "warning"`)
+}

--- a/cmd/internal/exitcode/exitcode.go
+++ b/cmd/internal/exitcode/exitcode.go
@@ -1,0 +1,36 @@
+// Package exitcode carries explicit process exit codes through cobra command
+// execution without making every command know about os.Exit.
+package exitcode
+
+import "errors"
+
+// Error wraps an error message with a process exit code.
+type Error struct {
+	code int
+	err  error
+}
+
+// New returns an error that should make the CLI exit with code.
+func New(code int, err error) error {
+	return &Error{code: code, err: err}
+}
+
+// Error returns the wrapped error text.
+func (e *Error) Error() string {
+	return e.err.Error()
+}
+
+// Unwrap returns the wrapped error.
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+// Code returns the explicit process exit code carried by err, or fallback when
+// err is not an exit-code error.
+func Code(err error, fallback int) int {
+	var exitErr *Error
+	if errors.As(err, &exitErr) {
+		return exitErr.code
+	}
+	return fallback
+}

--- a/cmd/internal/exitcode/exitcode_test.go
+++ b/cmd/internal/exitcode/exitcode_test.go
@@ -1,0 +1,24 @@
+package exitcode_test
+
+import (
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+)
+
+func TestCodeReturnsWrappedExitCode(t *testing.T) {
+	c := qt.New(t)
+
+	err := fmt.Errorf("wrapped: %w", exitcode.New(2, fmt.Errorf("boom")))
+
+	c.Assert(exitcode.Code(err, 1), qt.Equals, 2)
+}
+
+func TestCodeReturnsFallback(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(exitcode.Code(fmt.Errorf("boom"), 1), qt.Equals, 1)
+}

--- a/cmd/internal/schemaops/schemaops.go
+++ b/cmd/internal/schemaops/schemaops.go
@@ -1,0 +1,289 @@
+// Package schemaops contains shared command-line schema comparison helpers.
+package schemaops
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// CompareOptions configures a live schema comparison.
+type CompareOptions struct {
+	RootDir        string
+	DatabaseURL    string
+	ConnectTimeout time.Duration
+	IgnoredTables  []string
+}
+
+// CompareResult is the output of a live schema comparison.
+type CompareResult struct {
+	RootDir     string
+	DatabaseURL string
+	Dialect     string
+	Generated   *goschema.Database
+	Database    *dbschematypes.DBSchema
+	Diff        *difftypes.SchemaDiff
+}
+
+// Compare parses Go entities, reads the live database schema, applies command
+// filters, and returns a dialect-aware schema diff.
+func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
+	if opts.RootDir == "" {
+		opts.RootDir = "."
+	}
+	if opts.DatabaseURL == "" {
+		return nil, fmt.Errorf("database URL is required")
+	}
+
+	absPath, err := filepath.Abs(opts.RootDir)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving path: %w", err)
+	}
+
+	generated, err := goschema.ParseDir(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Go entities: %w", err)
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(ctx, opts.ConnectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.DatabaseURL)
+	cancelConnect()
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	dbSchema, err := conn.Reader().ReadSchema()
+	if err != nil {
+		return nil, fmt.Errorf("error reading database schema: %w", err)
+	}
+
+	if len(opts.IgnoredTables) > 0 {
+		generated = FilterGeneratedTables(generated, opts.IgnoredTables)
+		dbSchema = FilterDatabaseTables(dbSchema, opts.IgnoredTables)
+	}
+
+	compareOpts := config.DefaultCompareOptions()
+	compareOpts.Dialect = conn.Info().Dialect
+	diff := schemadiff.CompareWithOptions(generated, dbSchema, compareOpts)
+
+	return &CompareResult{
+		RootDir:     absPath,
+		DatabaseURL: dbschema.FormatDatabaseURL(opts.DatabaseURL),
+		Dialect:     conn.Info().Dialect,
+		Generated:   generated,
+		Database:    dbSchema,
+		Diff:        diff,
+	}, nil
+}
+
+// FilterGeneratedTables returns a shallow copy of db without ignored tables and
+// their table-scoped schema objects.
+func FilterGeneratedTables(db *goschema.Database, ignoredTables []string) *goschema.Database {
+	if db == nil {
+		return nil
+	}
+	ignored := tableSet(ignoredTables)
+	if len(ignored) == 0 {
+		return db
+	}
+
+	filtered := *db
+	ignoredStructs := make(map[string]struct{})
+	filtered.Tables = keep(db.Tables, func(table goschema.Table) bool {
+		if _, ignore := ignored[table.Name]; ignore {
+			ignoredStructs[table.StructName] = struct{}{}
+			return false
+		}
+		return true
+	})
+	ignoredEnumRefs := make(map[string]struct{})
+	filtered.Fields = keep(db.Fields, func(field goschema.Field) bool {
+		_, ignore := ignoredStructs[field.StructName]
+		if ignore && strings.HasPrefix(field.Type, "enum_") {
+			ignoredEnumRefs[field.Type] = struct{}{}
+		}
+		return !ignore
+	})
+	filtered.Indexes = keep(db.Indexes, func(index goschema.Index) bool {
+		if _, ignore := ignoredStructs[index.StructName]; ignore {
+			return false
+		}
+		if index.TableName != "" {
+			_, ignore := ignored[index.TableName]
+			return !ignore
+		}
+		return true
+	})
+	filtered.Constraints = keep(db.Constraints, func(constraint goschema.Constraint) bool {
+		if _, ignore := ignoredStructs[constraint.StructName]; ignore {
+			return false
+		}
+		if constraint.Table != "" {
+			_, ignore := ignored[constraint.Table]
+			return !ignore
+		}
+		return true
+	})
+	filtered.EmbeddedFields = keep(db.EmbeddedFields, func(field goschema.EmbeddedField) bool {
+		_, ignore := ignoredStructs[field.StructName]
+		return !ignore
+	})
+	filtered.RLSPolicies = keep(db.RLSPolicies, func(policy goschema.RLSPolicy) bool {
+		_, ignore := ignored[policy.Table]
+		return !ignore
+	})
+	filtered.RLSEnabledTables = keep(db.RLSEnabledTables, func(table goschema.RLSEnabledTable) bool {
+		_, ignore := ignored[table.Table]
+		return !ignore
+	})
+	filtered.Dependencies = filterDependencies(db.Dependencies, ignored)
+	filtered.SelfReferencingForeignKeys = filterSelfReferencingForeignKeys(db.SelfReferencingForeignKeys, ignored)
+	filtered.Enums = keepGeneratedEnums(db.Enums, filtered.Fields, ignoredEnumRefs)
+
+	return &filtered
+}
+
+// FilterDatabaseTables returns a shallow copy of db without ignored tables and
+// their table-scoped schema objects.
+func FilterDatabaseTables(db *dbschematypes.DBSchema, ignoredTables []string) *dbschematypes.DBSchema {
+	if db == nil {
+		return nil
+	}
+	ignored := tableSet(ignoredTables)
+	if len(ignored) == 0 {
+		return db
+	}
+
+	filtered := *db
+	ignoredEnumRefs := make(map[string]struct{})
+	filtered.Tables = keep(db.Tables, func(table dbschematypes.DBTable) bool {
+		_, ignore := ignored[table.Name]
+		if ignore {
+			addDatabaseEnumRefs(ignoredEnumRefs, table.Columns)
+		}
+		return !ignore
+	})
+	filtered.Indexes = keep(db.Indexes, func(index dbschematypes.DBIndex) bool {
+		_, ignore := ignored[index.TableName]
+		return !ignore
+	})
+	filtered.Constraints = keep(db.Constraints, func(constraint dbschematypes.DBConstraint) bool {
+		_, ignore := ignored[constraint.TableName]
+		return !ignore
+	})
+	filtered.RLSPolicies = keep(db.RLSPolicies, func(policy dbschematypes.DBRLSPolicy) bool {
+		_, ignore := ignored[policy.Table]
+		return !ignore
+	})
+	filtered.Enums = keepDatabaseEnums(db.Enums, filtered.Tables, ignoredEnumRefs)
+
+	return &filtered
+}
+
+func tableSet(names []string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			set[name] = struct{}{}
+		}
+	}
+	return set
+}
+
+func keep[T any](items []T, shouldKeep func(T) bool) []T {
+	out := make([]T, 0, len(items))
+	for _, item := range items {
+		if shouldKeep(item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func filterDependencies(in map[string][]string, ignored map[string]struct{}) map[string][]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for table, deps := range in {
+		if _, ignore := ignored[table]; ignore {
+			continue
+		}
+		out[table] = keep(deps, func(dep string) bool {
+			_, ignore := ignored[dep]
+			return !ignore
+		})
+	}
+	return out
+}
+
+func filterSelfReferencingForeignKeys(
+	in map[string][]goschema.SelfReferencingFK,
+	ignored map[string]struct{},
+) map[string][]goschema.SelfReferencingFK {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]goschema.SelfReferencingFK, len(in))
+	for table, refs := range in {
+		if _, ignore := ignored[table]; ignore {
+			continue
+		}
+		out[table] = refs
+	}
+	return out
+}
+
+func keepGeneratedEnums(enums []goschema.Enum, fields []goschema.Field, ignoredEnumRefs map[string]struct{}) []goschema.Enum {
+	referenced := make(map[string]struct{})
+	for _, field := range fields {
+		if strings.HasPrefix(field.Type, "enum_") {
+			referenced[field.Type] = struct{}{}
+		}
+	}
+	return keep(enums, func(enum goschema.Enum) bool {
+		if _, stillReferenced := referenced[enum.Name]; stillReferenced {
+			return true
+		}
+		_, wasIgnored := ignoredEnumRefs[enum.Name]
+		return !wasIgnored
+	})
+}
+
+func keepDatabaseEnums(
+	enums []dbschematypes.DBEnum,
+	tables []dbschematypes.DBTable,
+	ignoredEnumRefs map[string]struct{},
+) []dbschematypes.DBEnum {
+	referenced := make(map[string]struct{})
+	for _, table := range tables {
+		addDatabaseEnumRefs(referenced, table.Columns)
+	}
+	return keep(enums, func(enum dbschematypes.DBEnum) bool {
+		if _, stillReferenced := referenced[enum.Name]; stillReferenced {
+			return true
+		}
+		_, wasIgnored := ignoredEnumRefs[enum.Name]
+		return !wasIgnored
+	})
+}
+
+func addDatabaseEnumRefs(out map[string]struct{}, columns []dbschematypes.DBColumn) {
+	for _, column := range columns {
+		if column.UDTName != "" {
+			out[column.UDTName] = struct{}{}
+		}
+	}
+}

--- a/cmd/internal/schemaops/schemaops.go
+++ b/cmd/internal/schemaops/schemaops.go
@@ -282,8 +282,27 @@ func keepDatabaseEnums(
 
 func addDatabaseEnumRefs(out map[string]struct{}, columns []dbschematypes.DBColumn) {
 	for _, column := range columns {
-		if column.UDTName != "" {
-			out[column.UDTName] = struct{}{}
+		ref, ok := databaseEnumRef(column)
+		if ok {
+			out[ref] = struct{}{}
 		}
+	}
+}
+
+func databaseEnumRef(column dbschematypes.DBColumn) (string, bool) {
+	if column.UDTName == "" {
+		return "", false
+	}
+
+	switch strings.ToUpper(column.DataType) {
+	case "USER-DEFINED":
+		return column.UDTName, true
+	case "ARRAY":
+		ref := strings.TrimPrefix(column.UDTName, "_")
+		return ref, ref != ""
+	case "":
+		return column.UDTName, true
+	default:
+		return "", false
 	}
 }

--- a/cmd/internal/schemaops/schemaops_test.go
+++ b/cmd/internal/schemaops/schemaops_test.go
@@ -60,13 +60,13 @@ func TestFilterDatabaseTables_RemovesOnlyIgnoredTableEnums(t *testing.T) {
 			{
 				Name: "users",
 				Columns: []dbschematypes.DBColumn{
-					{Name: "status", UDTName: "enum_user_status"},
+					{Name: "status", DataType: "USER-DEFINED", UDTName: "enum_user_status"},
 				},
 			},
 			{
 				Name: "audit_log",
 				Columns: []dbschematypes.DBColumn{
-					{Name: "status", UDTName: "enum_auditlog_status"},
+					{Name: "statuses", DataType: "ARRAY", UDTName: "_enum_auditlog_status"},
 				},
 			},
 		},
@@ -97,4 +97,26 @@ func TestFilterDatabaseTables_RemovesOnlyIgnoredTableEnums(t *testing.T) {
 		{Name: "enum_user_status", Values: []string{"active"}},
 		{Name: "orphan_enum", Values: []string{"kept"}},
 	})
+}
+
+func TestFilterDatabaseTables_IgnoresNonEnumUDTNames(t *testing.T) {
+	c := qt.New(t)
+
+	db := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Name: "audit_log",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "status_text", DataType: "text", UDTName: "enum_auditlog_status"},
+				},
+			},
+		},
+		Enums: []dbschematypes.DBEnum{
+			{Name: "enum_auditlog_status", Values: []string{"kept"}},
+		},
+	}
+
+	filtered := schemaops.FilterDatabaseTables(db, []string{"audit_log"})
+
+	c.Assert(filtered.Enums, qt.DeepEquals, db.Enums)
 }

--- a/cmd/internal/schemaops/schemaops_test.go
+++ b/cmd/internal/schemaops/schemaops_test.go
@@ -1,0 +1,100 @@
+package schemaops_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/schemaops"
+	"github.com/stokaro/ptah/core/goschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+)
+
+func TestFilterGeneratedTables_RemovesTableScopedObjects(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "AuditLog", Name: "audit_log"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER"},
+			{StructName: "AuditLog", Name: "status", Type: "enum_auditlog_status"},
+		},
+		Indexes: []goschema.Index{
+			{StructName: "AuditLog", Name: "idx_audit_log_status"},
+			{StructName: "User", Name: "idx_users_id"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "AuditLog", Name: "audit_log_status_check"},
+		},
+		Enums: []goschema.Enum{
+			{Name: "enum_auditlog_status", Values: []string{"ok", "failed"}},
+		},
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "audit_log"},
+		},
+		Dependencies: map[string][]string{
+			"audit_log": {"users"},
+			"users":     {"audit_log"},
+		},
+	}
+
+	filtered := schemaops.FilterGeneratedTables(db, []string{"audit_log"})
+
+	c.Assert(filtered.Tables, qt.DeepEquals, []goschema.Table{{StructName: "User", Name: "users"}})
+	c.Assert(filtered.Fields, qt.DeepEquals, []goschema.Field{{StructName: "User", Name: "id", Type: "INTEGER"}})
+	c.Assert(filtered.Indexes, qt.DeepEquals, []goschema.Index{{StructName: "User", Name: "idx_users_id"}})
+	c.Assert(filtered.Constraints, qt.HasLen, 0)
+	c.Assert(filtered.Enums, qt.HasLen, 0)
+	c.Assert(filtered.RLSEnabledTables, qt.HasLen, 0)
+	c.Assert(filtered.Dependencies, qt.DeepEquals, map[string][]string{"users": {}})
+}
+
+func TestFilterDatabaseTables_RemovesOnlyIgnoredTableEnums(t *testing.T) {
+	c := qt.New(t)
+
+	db := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Name: "users",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "status", UDTName: "enum_user_status"},
+				},
+			},
+			{
+				Name: "audit_log",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "status", UDTName: "enum_auditlog_status"},
+				},
+			},
+		},
+		Enums: []dbschematypes.DBEnum{
+			{Name: "enum_user_status", Values: []string{"active"}},
+			{Name: "enum_auditlog_status", Values: []string{"ok"}},
+			{Name: "orphan_enum", Values: []string{"kept"}},
+		},
+		Indexes: []dbschematypes.DBIndex{
+			{Name: "idx_audit_log_status", TableName: "audit_log"},
+		},
+		Constraints: []dbschematypes.DBConstraint{
+			{Name: "audit_log_status_check", TableName: "audit_log"},
+		},
+		RLSPolicies: []dbschematypes.DBRLSPolicy{
+			{Name: "audit_rls", Table: "audit_log"},
+		},
+	}
+
+	filtered := schemaops.FilterDatabaseTables(db, []string{"audit_log"})
+
+	c.Assert(filtered.Tables, qt.HasLen, 1)
+	c.Assert(filtered.Tables[0].Name, qt.Equals, "users")
+	c.Assert(filtered.Indexes, qt.HasLen, 0)
+	c.Assert(filtered.Constraints, qt.HasLen, 0)
+	c.Assert(filtered.RLSPolicies, qt.HasLen, 0)
+	c.Assert(filtered.Enums, qt.DeepEquals, []dbschematypes.DBEnum{
+		{Name: "enum_user_status", Values: []string{"active"}},
+		{Name: "orphan_enum", Values: []string{"kept"}},
+	})
+}

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -7,8 +7,10 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/stokaro/ptah/cmd/compare"
+	"github.com/stokaro/ptah/cmd/drift"
 	"github.com/stokaro/ptah/cmd/dropall"
 	"github.com/stokaro/ptah/cmd/generate"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migratestatus"
@@ -44,6 +46,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(generate.NewGenerateCommand())
 	rootCmd.AddCommand(readdb.NewReadDBCommand())
 	rootCmd.AddCommand(compare.NewCompareCommand())
+	rootCmd.AddCommand(drift.NewDriftCommand())
 	rootCmd.AddCommand(migrate.NewMigrateCommand())
 	rootCmd.AddCommand(migrateup.NewMigrateUpCommand())
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
@@ -52,6 +55,6 @@ func Execute(args ...string) {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		os.Exit(1) //revive:disable-line:deep-exit
+		os.Exit(exitcode.Code(err, 1)) //revive:disable-line:deep-exit
 	}
 }

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -1,0 +1,139 @@
+// Package safety classifies schema changes by operational risk.
+package safety
+
+import (
+	"sort"
+
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// Severity is the operational risk level for a schema change.
+type Severity string
+
+const (
+	// Safe changes should not remove data or tighten existing constraints.
+	Safe Severity = "safe"
+	// Warning changes are data-dependent or may affect runtime behavior.
+	Warning Severity = "warning"
+	// Destructive changes remove data, database objects, or protections.
+	Destructive Severity = "destructive"
+)
+
+// Finding summarizes one non-empty schema-diff category.
+type Finding struct {
+	Category string   `json:"category"`
+	Count    int      `json:"count"`
+	Severity Severity `json:"severity"`
+}
+
+// ClassifySchemaDiff returns severity findings for every non-empty diff
+// category.
+func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding {
+	if diff == nil {
+		return nil
+	}
+
+	var findings []Finding
+	add(&findings, "tables_added", len(diff.TablesAdded), Safe)
+	add(&findings, "tables_removed", len(diff.TablesRemoved), Destructive)
+	add(&findings, "enums_added", len(diff.EnumsAdded), Safe)
+	add(&findings, "enums_removed", len(diff.EnumsRemoved), Destructive)
+	add(&findings, "indexes_added", len(diff.IndexesAdded), Warning)
+	add(&findings, "indexes_removed", len(diff.IndexesRemoved), Warning)
+	add(&findings, "extensions_added", len(diff.ExtensionsAdded), Safe)
+	add(&findings, "extensions_removed", len(diff.ExtensionsRemoved), Destructive)
+	add(&findings, "functions_added", len(diff.FunctionsAdded), Safe)
+	add(&findings, "functions_removed", len(diff.FunctionsRemoved), Destructive)
+	add(&findings, "functions_modified", len(diff.FunctionsModified), Warning)
+	add(&findings, "rls_policies_added", len(diff.RLSPoliciesAdded), Safe)
+	add(&findings, "rls_policies_removed", len(diff.RLSPoliciesRemoved), Warning)
+	add(&findings, "rls_policies_modified", len(diff.RLSPoliciesModified), Warning)
+	add(&findings, "rls_enabled_tables_added", len(diff.RLSEnabledTablesAdded), Safe)
+	add(&findings, "rls_enabled_tables_removed", len(diff.RLSEnabledTablesRemoved), Destructive)
+	add(&findings, "roles_added", len(diff.RolesAdded), Safe)
+	add(&findings, "roles_removed", len(diff.RolesRemoved), Destructive)
+	add(&findings, "roles_modified", len(diff.RolesModified), Warning)
+	add(&findings, "constraints_added", len(diff.ConstraintsAdded), Warning)
+	add(&findings, "constraints_removed", len(diff.ConstraintsRemoved), Destructive)
+
+	for _, table := range diff.TablesModified {
+		add(&findings, "columns_added", len(table.ColumnsAdded), Warning)
+		add(&findings, "columns_removed", len(table.ColumnsRemoved), Destructive)
+		add(&findings, "columns_modified", len(table.ColumnsModified), Warning)
+		add(&findings, "table_constraints_added", len(table.ConstraintsAdded), Warning)
+		add(&findings, "table_constraints_removed", len(table.ConstraintsRemoved), Destructive)
+	}
+	for _, enum := range diff.EnumsModified {
+		add(&findings, "enum_values_added", len(enum.ValuesAdded), Warning)
+		add(&findings, "enum_values_removed", len(enum.ValuesRemoved), Destructive)
+	}
+
+	findings = aggregate(findings)
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Severity != findings[j].Severity {
+			return severityRank(findings[i].Severity) > severityRank(findings[j].Severity)
+		}
+		return findings[i].Category < findings[j].Category
+	})
+	return findings
+}
+
+// Highest returns the highest severity from findings.
+func Highest(findings []Finding) Severity {
+	highest := Safe
+	for _, finding := range findings {
+		if severityRank(finding.Severity) > severityRank(highest) {
+			highest = finding.Severity
+		}
+	}
+	return highest
+}
+
+// HasDestructive returns true when any finding is destructive.
+func HasDestructive(findings []Finding) bool {
+	return Highest(findings) == Destructive
+}
+
+func add(findings *[]Finding, category string, count int, severity Severity) {
+	if count == 0 {
+		return
+	}
+	*findings = append(*findings, Finding{
+		Category: category,
+		Count:    count,
+		Severity: severity,
+	})
+}
+
+func aggregate(findings []Finding) []Finding {
+	byCategory := make(map[string]Finding, len(findings))
+	for _, finding := range findings {
+		existing, ok := byCategory[finding.Category]
+		if !ok {
+			byCategory[finding.Category] = finding
+			continue
+		}
+		existing.Count += finding.Count
+		if severityRank(finding.Severity) > severityRank(existing.Severity) {
+			existing.Severity = finding.Severity
+		}
+		byCategory[finding.Category] = existing
+	}
+
+	out := make([]Finding, 0, len(byCategory))
+	for _, finding := range byCategory {
+		out = append(out, finding)
+	}
+	return out
+}
+
+func severityRank(severity Severity) int {
+	switch severity {
+	case Destructive:
+		return 3
+	case Warning:
+		return 2
+	default:
+		return 1
+	}
+}

--- a/migration/safety/safety_test.go
+++ b/migration/safety/safety_test.go
@@ -1,0 +1,63 @@
+package safety_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/safety"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestClassifySchemaDiff_HighestSeverity(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{"users"},
+		TablesModified: []types.TableDiff{
+			{
+				TableName:      "products",
+				ColumnsAdded:   []string{"sku"},
+				ColumnsRemoved: []string{"legacy_code"},
+			},
+		},
+		IndexesRemoved: []string{"idx_products_old"},
+	}
+
+	findings := safety.ClassifySchemaDiff(diff)
+
+	c.Assert(findings, qt.Contains, safety.Finding{
+		Category: "columns_removed",
+		Count:    1,
+		Severity: safety.Destructive,
+	})
+	c.Assert(findings, qt.Contains, safety.Finding{
+		Category: "indexes_removed",
+		Count:    1,
+		Severity: safety.Warning,
+	})
+	c.Assert(safety.Highest(findings), qt.Equals, safety.Destructive)
+	c.Assert(safety.HasDestructive(findings), qt.IsTrue)
+}
+
+func TestClassifySchemaDiff_AggregatesRepeatedCategories(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{TableName: "users", ColumnsAdded: []string{"email"}},
+			{TableName: "posts", ColumnsAdded: []string{"slug", "status"}},
+		},
+	}
+
+	findings := safety.ClassifySchemaDiff(diff)
+
+	c.Assert(findings, qt.DeepEquals, []safety.Finding{
+		{
+			Category: "columns_added",
+			Count:    3,
+			Severity: safety.Warning,
+		},
+	})
+	c.Assert(safety.Highest(findings), qt.Equals, safety.Warning)
+}


### PR DESCRIPTION
## Summary
- add `package-migrator drift` for live database drift checks with CI-oriented exit codes
- support text, JSON, and GitHub Actions annotation output
- add `--severity all|destructive`, `--ignore tables=...`, `--exit-code`, and shared connect-timeout handling
- add diff severity classification and pre-compare table filtering for ignored tables
- document nightly GitHub Actions + Slack usage

Closes #163.

## Self-review
- verified drift output writes drift summaries to stderr and no-drift output to stdout
- verified error paths return explicit exit code 2 without cobra usage noise
- checked that `--severity destructive` only fails on destructive findings while still reporting non-destructive drift
- checked that ignored tables are removed before comparison so table-scoped columns, indexes, constraints, RLS policies, and table-only enums do not leak into the diff
- checked that database URLs are masked in reports

## Validation
- `go test ./...`
- `make lint`
- `go test -count=1 ./...`
- `git diff --check`
- `go build -o /tmp/ptah-drift-check ./cmd`
- `/tmp/ptah-drift-check drift --format json` returns exit code 2 with a JSON error when `--db-url` is missing
