### PR TITLE
Fix(planner): postgres hostless-re-add ownership + hostless-addition guard (#229)

### DIFF
--- a/migration/planner/dialects/postgres/hostless_constraints_test.go
+++ b/migration/planner/dialects/postgres/hostless_constraints_test.go
@@ -1,0 +1,146 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestPlanner_GenerateMigrationAST_HostlessReAdd_DropsExactlyOnce guards the
+// hostless-re-add ownership rule (issue #229). When a name is re-added with NO
+// recorded addition hosts (ConstraintsAdded carries it but
+// ConstraintsAddedWithTables has no entry — the shape of every reverse/down
+// diff of a non-FK constraint modify, since reverseConstraintAdditions
+// restores FOREIGN KEYs only), the add side drops every recorded removal host
+// BEFORE the re-add, and removeConstraints must skip the name entirely.
+//
+// Before the fix removeConstraints emitted a second guarded drop AFTER the
+// re-add — and IF EXISTS is no protection against dropping a constraint that
+// exists again: the down migration silently deleted the constraint it had
+// just restored (DROP → ADD → DROP). The exactly-once counts below fail
+// against that behavior.
+func TestPlanner_GenerateMigrationAST_HostlessReAdd_DropsExactlyOnce(t *testing.T) {
+	t.Run("single removal host", func(t *testing.T) {
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"chk_down"},
+			ConstraintsRemoved: []string{"chk_down"},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "chk_down", TableName: "things", Type: "CHECK"},
+			},
+		}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Thing", Name: "chk_down", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
+			},
+		}
+
+		sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(diff, generated)...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;"), qt.Equals, 1,
+			qt.Commentf("the drop must be emitted exactly once across both planner phases; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);"), qt.Equals, 1,
+			qt.Commentf("got:\n%s", sql))
+
+		dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down")
+		addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_down")
+		c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+			qt.Commentf("the single drop must precede the re-add; got:\n%s", sql))
+		lastDrop := strings.LastIndex(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down")
+		c.Assert(lastDrop < addIdx, qt.IsTrue,
+			qt.Commentf("no drop may follow the re-add — it would delete the restored constraint; got:\n%s", sql))
+	})
+
+	t.Run("two removal hosts", func(t *testing.T) {
+		// The down migration of a multi-host non-FK constraint modify: the
+		// bare name arrives duplicated, every host sits in
+		// ConstraintsRemovedWithTables, ConstraintsAddedWithTables is empty.
+		// Every recorded host must be dropped exactly once, all before the
+		// re-add, and removeConstraints must add nothing on top.
+		c := qt.New(t)
+
+		diff := &types.SchemaDiff{
+			ConstraintsAdded:   []string{"shared_check", "shared_check"},
+			ConstraintsRemoved: []string{"shared_check", "shared_check"},
+			ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+				{Name: "shared_check", TableName: "articles", Type: "CHECK"},
+				{Name: "shared_check", TableName: "pages", Type: "CHECK"},
+			},
+		}
+		generated := &goschema.Database{
+			Constraints: []goschema.Constraint{
+				{StructName: "Article", Name: "shared_check", Type: "CHECK", Table: "articles", CheckExpression: "qty >= 0"},
+			},
+		}
+
+		sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(diff, generated)...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Count(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1,
+			qt.Commentf("first removal host dropped exactly once; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check;"), qt.Equals, 1,
+			qt.Commentf("second removal host dropped exactly once; got:\n%s", sql))
+
+		firstAdd := strings.Index(sql, "ADD CONSTRAINT shared_check")
+		c.Assert(firstAdd >= 0, qt.IsTrue)
+		c.Assert(strings.LastIndex(sql, "ALTER TABLE articles DROP CONSTRAINT IF EXISTS shared_check") < firstAdd, qt.IsTrue,
+			qt.Commentf("all drops must precede the re-add; got:\n%s", sql))
+		c.Assert(strings.LastIndex(sql, "ALTER TABLE pages DROP CONSTRAINT IF EXISTS shared_check") < firstAdd, qt.IsTrue,
+			qt.Commentf("all drops must precede the re-add; got:\n%s", sql))
+	})
+}
+
+// TestPlanner_GenerateMigrationAST_EmptyTableNameAdditionTreatedAsHostless is
+// the postgres port of the MySQL guard from PR #228 (the literal issue #229
+// trigger). A ConstraintsAddedWithTables entry with an empty TableName must
+// not count as a recorded addition host: if it did, addedHostsByName would
+// contain only "" (matching no real removal host), the required pre-drop
+// would be skipped, and the re-ADD would collide with the still-present
+// constraint (42710) — IF EXISTS cannot help with a drop that is never
+// emitted. With the guard the name degrades to hostless-re-add semantics: one
+// pre-drop per recorded removal host, then the re-add, nothing after it.
+func TestPlanner_GenerateMigrationAST_EmptyTableNameAdditionTreatedAsHostless(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsAdded:   []string{"chk_ghost"},
+		ConstraintsRemoved: []string{"chk_ghost"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+			{Name: "chk_ghost", TableName: "", Type: "CHECK"},
+		},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "chk_ghost", TableName: "things", Type: "CHECK"},
+		},
+	}
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{StructName: "Thing", Name: "chk_ghost", Type: "CHECK", Table: "things", CheckExpression: "qty >= 0"},
+		},
+	}
+
+	sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(diff, generated)...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Count(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_ghost;"), qt.Equals, 1,
+		qt.Commentf("the recorded removal host must be dropped exactly once; got:\n%s", sql))
+	c.Assert(strings.Count(sql, "ALTER TABLE things ADD CONSTRAINT chk_ghost CHECK (qty >= 0);"), qt.Equals, 1,
+		qt.Commentf("the re-add must still be emitted; got:\n%s", sql))
+
+	dropIdx := strings.Index(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_ghost")
+	addIdx := strings.Index(sql, "ALTER TABLE things ADD CONSTRAINT chk_ghost")
+	c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+		qt.Commentf("the drop must be the add-side pre-drop, before the re-add; got:\n%s", sql))
+	lastDrop := strings.LastIndex(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_ghost")
+	c.Assert(lastDrop < addIdx, qt.IsTrue,
+		qt.Commentf("no drop may follow the re-add; got:\n%s", sql))
+	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
+		qt.Commentf("the name-only DO block must not be used when removal hosts are known; got:\n%s", sql))
+}

--- a/migration/planner/dialects/postgres/hostless_constraints_test.go
+++ b/migration/planner/dialects/postgres/hostless_constraints_test.go
@@ -141,6 +141,6 @@ func TestPlanner_GenerateMigrationAST_EmptyTableNameAdditionTreatedAsHostless(t 
 	lastDrop := strings.LastIndex(sql, "ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_ghost")
 	c.Assert(lastDrop < addIdx, qt.IsTrue,
 		qt.Commentf("no drop may follow the re-add; got:\n%s", sql))
-	c.Assert(strings.Contains(sql, "information_schema.table_constraints"), qt.IsFalse,
-		qt.Commentf("the name-only DO block must not be used when removal hosts are known; got:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
+		qt.Commentf("the name-only DO block must not be used when removal hosts are known"))
 }

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1145,6 +1145,17 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// would be dropped twice.
 	addedHostsByName := make(map[string]map[string]struct{}, len(diff.ConstraintsAddedWithTables))
 	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.TableName == "" {
+			// An addition entry with no recorded host is hostless: a "" host
+			// would match no removal entry, so keeping it here would make
+			// emitModifyDropForName filter out every REAL removal host and
+			// skip a required pre-drop — the re-ADD then collides with the
+			// still-present constraint (42710; IF EXISTS on the drop cannot
+			// help because the drop was never emitted). Treat the name as if
+			// it had no recorded addition hosts at all (issue #229, mirroring
+			// the MySQL planner).
+			continue
+		}
 		hosts := addedHostsByName[add.Name]
 		if hosts == nil {
 			hosts = make(map[string]struct{})
@@ -1482,8 +1493,31 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 	// ConstraintsAddedWithTables in lockstep with the bare list, so the modify
 	// owner is always known per host.
 	modifySet := make(map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	addedHostCounts := make(map[string]int, len(diff.ConstraintsAddedWithTables))
 	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.TableName == "" {
+			// Hostless addition entries do not count as recorded hosts —
+			// mirroring addedHostsByName in addNewConstraints — so the
+			// hostless-re-add rule below still engages (issue #229).
+			continue
+		}
 		modifySet[add.TableName+"."+add.Name] = struct{}{}
+		addedHostCounts[add.Name]++
+	}
+
+	// Bare added names, for re-adds whose hosts were NOT recorded
+	// (ConstraintsAdded carries the name but ConstraintsAddedWithTables has no
+	// entry for it — reverse/down diffs of non-FK modifies, legacy callers
+	// without an introspected schema, and hand-built diffs). For those,
+	// emitModifyDropForName cannot restrict its pre-drop to the re-added
+	// hosts, so it drops EVERY recorded removal host BEFORE the re-add;
+	// dropping any of them again here would land AFTER the re-add and delete
+	// the freshly restored constraint — IF EXISTS is no protection against
+	// dropping a constraint that now exists again. This silently destroyed
+	// the constraint on every non-FK down migration (issue #229).
+	addedBareNamesHosted := make(map[string]struct{}, len(diff.ConstraintsAdded))
+	for _, name := range diff.ConstraintsAdded {
+		addedBareNamesHosted[name] = struct{}{}
 	}
 
 	// When the comparator supplied the owning table (ConstraintsRemovedWithTables),
@@ -1506,6 +1540,14 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 		namesWithHost[info.Name] = struct{}{}
 		if _, modified := modifySet[info.TableName+"."+info.Name]; modified {
 			// addNewConstraints owns this host's DROP-then-ADD; do not re-drop.
+			continue
+		}
+		if _, added := addedBareNamesHosted[info.Name]; added && addedHostCounts[info.Name] == 0 {
+			// Hostless re-add: addNewConstraints already dropped every
+			// recorded removal host for this name before the re-add
+			// (emitModifyDropForName with unknown addedHosts). A second drop
+			// here would follow the re-add and delete the fresh constraint
+			// (issue #229).
 			continue
 		}
 		result = p.appendScopedDrop(result, info.TableName, info.Name, dropped)


### PR DESCRIPTION
Closes #229.

Ports the PR #228 hostless-entry guards to the postgres planner — and fixes a **bigger live bug** the porting probe exposed on the way.

## The bigger bug: down migrations silently deleted restored constraints

Probing the down-diff shape through the real planner + renderer (no hand-built weirdness — this is what `reverseSchemaDiffWithSchema` produces for **every non-FK constraint modify**, because `reverseConstraintAdditions` restores FOREIGN KEYs only) showed postgres emitting:

```sql
ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;  -- add side, correct
ALTER TABLE things ADD CONSTRAINT chk_down CHECK (qty >= 0);
ALTER TABLE things DROP CONSTRAINT IF EXISTS chk_down;  -- removeConstraints, AFTER the re-add
```

The trailing drop deletes the constraint the down migration just restored — `IF EXISTS` is no protection against dropping a constraint that exists again. Net effect: **rolling back a CHECK/UNIQUE modify left the table with no constraint at all**, silently.

Fix: `removeConstraints` now skips names that are re-added with **zero recorded addition hosts** — the add side (`emitModifyDropForName` with unknown `addedHosts`) already owns every recorded removal host's pre-drop. This is the exact ownership rule the MySQL planner got in #207/#228 (where it was mandatory because MySQL has no `IF EXISTS`); it turns out postgres needed it just as much, for the opposite reason — its guarded drop absorbs *duplicate* drops, not *post-re-add* drops.

## The literal #229 trigger

`ConstraintsAddedWithTables` entries with an empty `TableName` counted as recorded hosts, so `addedHostsByName` could contain only `""`, `emitModifyDropForName` filtered every REAL removal host against `{""}`, the required pre-drop was skipped, and the re-`ADD` collided (42710). Hostless entries are now skipped when building `addedHostsByName` and `modifySet` (mirror of #228's `e56f4c1`).

## Tests (`hostless_constraints_test.go`)

- **Single-host down-shape**: exactly ONE `DROP CONSTRAINT IF EXISTS` across both planner phases, strictly before the re-add, nothing after (the `LastIndex < addIdx` assertion is what catches the deleted-restored-constraint bug).
- **Two-host down-shape** (multi-host non-FK modify rollback, duplicated bare names): each host dropped exactly once, all drops before the re-add.
- **Empty-TableName addition entry** (the #229 trigger): degrades to hostless-re-add semantics — one pre-drop, re-add, nothing after, no DO-block fallback.

All three **fail against master** (verified via a master worktree file swap) and pass with the fix.

## Verification

- `go test -count=1 ./...` green; `golangci-lint run ./...` 0 issues.
- Live integration suite against Docker **PostgreSQL 18: 60/60 scenarios**.
- Before/after probe output through the real planner + renderer confirms `DROP → ADD → DROP` became `DROP → ADD` for both failure shapes.