### PR TITLE
Fix(planner): UNIQUE constraint removals use DROP INDEX on every MySQL-family target (#195)

### DIFF
--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -117,10 +117,10 @@ type DropConstraintOperation struct {
 	Check bool
 	// Unique requests the `DROP INDEX <name>` spelling for a UNIQUE
 	// constraint (dropping its backing index), which is valid across the
-	// entire MySQL/MariaDB family. Planners set it for UNIQUE removals on
-	// targets without the generic DROP CONSTRAINT clause (MySQL < 8.0.19),
-	// where the generic spelling would be invalid SQL. Ignored when
-	// ForeignKey or Check is set; PostgreSQL-style renderers may ignore it.
+	// entire MySQL/MariaDB family — unlike the generic DROP CONSTRAINT
+	// clause, which only exists from MySQL 8.0.19. The MySQL-family planner
+	// sets it for every UNIQUE removal (issue #195). Ignored when ForeignKey
+	// or Check is set; PostgreSQL-style renderers may ignore it.
 	Unique bool
 }
 

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -85,9 +85,10 @@ func TestMySQLFamilyRenderers_DropCheckSpelling(t *testing.T) {
 }
 
 // TestMySQLFamilyRenderers_DropUniqueIndexSpelling pins the DROP INDEX
-// spelling requested via DropConstraintOperation.Unique (UNIQUE removals on
-// targets without the generic clause). ALTER TABLE ... DROP INDEX is valid
-// across the entire family, so both renderers honor it as-is.
+// spelling requested via DropConstraintOperation.Unique (every UNIQUE
+// removal, issue #195). ALTER TABLE ... DROP INDEX is valid across the entire
+// family, so both renderers honor it as-is; the IF EXISTS guard on the
+// spelling is MariaDB-only (verified live), so the mysql renderer strips it.
 func TestMySQLFamilyRenderers_DropUniqueIndexSpelling(t *testing.T) {
 	c := qt.New(t)
 
@@ -104,6 +105,25 @@ func TestMySQLFamilyRenderers_DropUniqueIndexSpelling(t *testing.T) {
 		c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
 			qt.Commentf("%s: got:\n%s", dialect, sql))
 	}
+
+	guardedNode := &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: "uq_email",
+			Unique:         true,
+			IfExists:       true,
+		}},
+	}
+	sql, err := renderer.RenderSQL("mariadb", guardedNode)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX IF EXISTS uq_email;",
+		qt.Commentf("mariadb honors the guard on the DROP INDEX spelling; got:\n%s", sql))
+
+	sql, err = renderer.RenderSQL("mysql", guardedNode)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
+		qt.Commentf("mysql strips the guard it cannot parse; got:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS", qt.Commentf("got:\n%s", sql))
 }
 
 // TestMySQLFamilyRenderers_DropIndexGuardValidity pins the DROP INDEX guard

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -81,8 +81,14 @@ func (r *Renderer) dropConstraintSQL(table string, op *ast.DropConstraintOperati
 	case op.Unique:
 		// ALTER TABLE ... DROP INDEX drops a UNIQUE constraint's backing
 		// index and is valid across the entire MySQL/MariaDB family, so the
-		// planner-requested spelling needs no capability gate here.
+		// planner-requested spelling needs no capability gate here. The
+		// IF EXISTS guard on this spelling is MariaDB-only (verified live:
+		// MariaDB 10.11 accepts it, incl. on an absent index; MySQL 9.7
+		// rejects it), so it is gated on the index-drop guard capability.
 		dropSQL += " INDEX"
+		if op.IfExists && r.caps.Has(capability.DropIndexIfExists) {
+			dropSQL += " IF EXISTS"
+		}
 	case guarded:
 		dropSQL += " CONSTRAINT IF EXISTS"
 	default:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -120,11 +120,14 @@ planner := mysql.NewWithCapabilities(caps)
   `ALTER TABLE … DROP CHECK <name>` for CHECK removals; the renderer resolves
   the spelling against **its** target too, so the request degrades to the
   generic clause on MariaDB, which has no `DROP CHECK` at all (verified live).
-  On the same no-generic targets a UNIQUE removal uses
-  `ALTER TABLE … DROP INDEX <name>` (valid family-wide — verified live), and a
-  CHECK removal with no valid spelling at all (`MySQLLegacy`) degrades to a
-  loud WARNING comment. Universal `DROP INDEX` branching for modern versions
-  stays with #195.
+  A CHECK removal with no valid spelling at all (`MySQLLegacy`) degrades to a
+  loud WARNING comment.
+- **UNIQUE removals use `DROP INDEX`** (#195). Every MySQL-family preset
+  renders `ALTER TABLE … DROP INDEX <name>` for a UNIQUE constraint removal —
+  the one spelling valid on every version (verified live on MySQL 9.7 and
+  MariaDB 10.11), unlike the generic clause (8.0.19+ only). MariaDB guards it
+  with `IF EXISTS` (also verified live, idempotent on absent indexes); the
+  mysql renderer strips the guard.
 - **CHECK adds on non-enforcing targets.** A target without
   `check_constraints_enforced` gets a loud `WARNING` comment instead of an
   `ADD CONSTRAINT … CHECK` the server would silently ignore. This covers the
@@ -147,5 +150,4 @@ planner := mysql.NewWithCapabilities(caps)
 - `SELECT version()` → preset wiring at connect time (`ForServerVersion` is
   ready; the dbschema plumbing is tracked with #163/#152 work).
 - `create_or_replace_trigger` consumer lands with triggers (#158).
-- UNIQUE drop syntax selection (`DROP INDEX` vs generic clause) — #195.
 - Distributed-SQL presets (CockroachDB / Yugabyte / Spanner) — #171.

--- a/migration/planner/dialects/mysql/capability_gating_test.go
+++ b/migration/planner/dialects/mysql/capability_gating_test.go
@@ -384,7 +384,7 @@ func TestPlanner_UniqueConstraintRemoval_UsesDropIndex(t *testing.T) {
 			qt.Commentf("PK removals stay skipped; got:\n%s", sql))
 	})
 
-	t.Run("mariadb via GetPlanner preset", func(t *testing.T) {
+	t.Run("mariadb preset", func(t *testing.T) {
 		c := qt.New(t)
 
 		nodes := mysql.NewWithCapabilities(capability.MariaDB1011()).GenerateMigrationAST(diff, &goschema.Database{})
@@ -403,4 +403,48 @@ func TestPlanner_UniqueConstraintRemoval_UsesDropIndex(t *testing.T) {
 		c.Assert(sqlMySQL, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
 			qt.Commentf("got:\n%s", sqlMySQL))
 	})
+}
+
+// TestPlanner_UniqueDropGuard_FollowsIndexCapability pins the guard-source
+// decoupling: the UNIQUE removal spelling is an index drop, so its IF EXISTS
+// intent follows capability.DropIndexIfExists — independently of the
+// constraint-drop guard capability. Identical on shipped presets; a composed
+// set enabling the guards separately must guard each spelling per its own
+// capability.
+func TestPlanner_UniqueDropGuard_FollowsIndexCapability(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"uq_email", "fk_posts_user"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "uq_email", TableName: "users", Type: "UNIQUE"},
+			{Name: "fk_posts_user", TableName: "posts", Type: "FOREIGN KEY"},
+		},
+	}
+
+	// Index guards off, constraint guards on: FK guarded, UNIQUE not.
+	caps := capability.MariaDB1011().With(capability.DropIndexIfExists, false)
+	c.Assert(caps.Validate(), qt.IsNil)
+	nodes := mysql.NewWithCapabilities(caps).GenerateMigrationAST(diff, &goschema.Database{})
+	sql, err := renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
+		qt.Commentf("got:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "DROP INDEX IF EXISTS",
+		qt.Commentf("UNIQUE guard must follow the index-drop capability; got:\n%s", sql))
+	c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;",
+		qt.Commentf("got:\n%s", sql))
+
+	// Constraint guards off, index guards on: UNIQUE guarded, FK not.
+	caps = capability.MariaDB1011().With(capability.DropConstraintIfExists, false)
+	c.Assert(caps.Validate(), qt.IsNil)
+	nodes = mysql.NewWithCapabilities(caps).GenerateMigrationAST(diff, &goschema.Database{})
+	sql, err = renderer.RenderSQL("mariadb", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ALTER TABLE users DROP INDEX IF EXISTS uq_email;",
+		qt.Commentf("got:\n%s", sql))
+	c.Assert(sql, qt.Contains, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;",
+		qt.Commentf("got:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "DROP FOREIGN KEY IF EXISTS",
+		qt.Commentf("FK guard must follow the constraint-drop capability; got:\n%s", sql))
 }

--- a/migration/planner/dialects/mysql/capability_gating_test.go
+++ b/migration/planner/dialects/mysql/capability_gating_test.go
@@ -144,21 +144,18 @@ func TestPlanner_CapabilityGating_NoGenericClauseFallbacks(t *testing.T) {
 				{Name: "uq_email", TableName: "users", Type: "UNIQUE"},
 			},
 		}
-		nodes := mysql.NewWithCapabilities(capability.MySQL8016()).GenerateMigrationAST(diff, &goschema.Database{})
-		sql, err := renderer.RenderSQL("mysql", nodes...)
-		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.Equals, 1,
-			qt.Commentf("without the generic clause a UNIQUE drop must use DROP INDEX; got:\n%s", sql))
-		c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT",
-			qt.Commentf("got:\n%s", sql))
-
-		// Modern targets keep the generic clause (the universal DROP INDEX
-		// branching for every version is issue #195).
-		nodes = mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
-		sql, err = renderer.RenderSQL("mysql", nodes...)
-		c.Assert(err, qt.IsNil)
-		c.Assert(strings.Count(sql, "ALTER TABLE users DROP CONSTRAINT uq_email;"), qt.Equals, 1,
-			qt.Commentf("got:\n%s", sql))
+		// The DROP INDEX spelling is version-universal (issue #195), so every
+		// preset uses it — including targets without the generic clause,
+		// where DROP CONSTRAINT would be invalid SQL.
+		for _, caps := range []capability.Capabilities{capability.MySQL8016(), capability.MySQL80()} {
+			nodes := mysql.NewWithCapabilities(caps).GenerateMigrationAST(diff, &goschema.Database{})
+			sql, err := renderer.RenderSQL("mysql", nodes...)
+			c.Assert(err, qt.IsNil)
+			c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.Equals, 1,
+				qt.Commentf("a UNIQUE drop must use DROP INDEX; got:\n%s", sql))
+			c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT",
+				qt.Commentf("got:\n%s", sql))
+		}
 	})
 
 	t.Run("check removal without any valid spelling warns", func(t *testing.T) {
@@ -350,4 +347,60 @@ func TestPlanner_CapabilityGating_DropIndexGuard(t *testing.T) {
 		qt.Commentf("got:\n%s", sqlMariaDB))
 	c.Assert(sqlMariaDB, qt.Not(qt.Contains), "IF EXISTS",
 		qt.Commentf("a MySQL-preset planner must not request the index-drop guard; got:\n%s", sqlMariaDB))
+}
+
+// TestPlanner_UniqueConstraintRemoval_UsesDropIndex is the issue #195
+// acceptance test: a table-level UNIQUE constraint removal renders the
+// version-universal ALTER TABLE ... DROP INDEX spelling on the MySQL family —
+// never the generic DROP CONSTRAINT clause, which is invalid SQL before MySQL
+// 8.0.19 (and empirically unnecessary on newer lines, where DROP INDEX works
+// too). FK and PK behavior is unchanged: FK keeps DROP FOREIGN KEY, PK
+// removals stay skipped. On MariaDB the spelling carries the IF EXISTS guard
+// (verified live: MariaDB 10.11 accepts it, MySQL 9.7 rejects it).
+func TestPlanner_UniqueConstraintRemoval_UsesDropIndex(t *testing.T) {
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"uq_email", "fk_posts_user", "pk_legacy"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "uq_email", TableName: "users", Type: "UNIQUE"},
+			{Name: "fk_posts_user", TableName: "posts", Type: "FOREIGN KEY"},
+			{Name: "pk_legacy", TableName: "legacy", Type: "PRIMARY KEY"},
+		},
+	}
+
+	t.Run("mysql", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := mysql.New().GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX uq_email;"), qt.Equals, 1,
+			qt.Commentf("UNIQUE removal must render DROP INDEX; got:\n%s", sql))
+		c.Assert(sql, qt.Not(qt.Contains), "DROP CONSTRAINT",
+			qt.Commentf("the generic clause must not be used for UNIQUE; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE posts DROP FOREIGN KEY fk_posts_user;"), qt.Equals, 1,
+			qt.Commentf("FK drops unchanged; got:\n%s", sql))
+		c.Assert(sql, qt.Not(qt.Contains), "pk_legacy",
+			qt.Commentf("PK removals stay skipped; got:\n%s", sql))
+	})
+
+	t.Run("mariadb via GetPlanner preset", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := mysql.NewWithCapabilities(capability.MariaDB1011()).GenerateMigrationAST(diff, &goschema.Database{})
+		sql, err := renderer.RenderSQL("mariadb", nodes...)
+		c.Assert(err, qt.IsNil)
+
+		c.Assert(strings.Count(sql, "ALTER TABLE users DROP INDEX IF EXISTS uq_email;"), qt.Equals, 1,
+			qt.Commentf("MariaDB guards the DROP INDEX spelling; got:\n%s", sql))
+		c.Assert(strings.Count(sql, "ALTER TABLE posts DROP FOREIGN KEY IF EXISTS fk_posts_user;"), qt.Equals, 1,
+			qt.Commentf("got:\n%s", sql))
+
+		// The same plan through the mysql renderer strips every guard.
+		sqlMySQL, err := renderer.RenderSQL("mysql", nodes...)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sqlMySQL, qt.Not(qt.Contains), "IF EXISTS", qt.Commentf("got:\n%s", sqlMySQL))
+		c.Assert(sqlMySQL, qt.Contains, "ALTER TABLE users DROP INDEX uq_email;",
+			qt.Commentf("got:\n%s", sqlMySQL))
+	})
 }

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -1059,6 +1059,12 @@ func (p *Planner) dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node 
 		// DROP FOREIGN KEY carries the type information already.
 	case strings.EqualFold(info.Type, "UNIQUE"):
 		op.Unique = true
+		// The UNIQUE spelling is an index drop, so its guard intent follows
+		// the index-drop guard capability rather than the constraint-drop
+		// one. Identical on the shipped presets (MariaDB has both, MySQL
+		// neither), but a composed set may enable them independently and the
+		// intent must match the chosen spelling.
+		op.IfExists = caps.Has(capability.DropIndexIfExists)
 	case strings.EqualFold(info.Type, "CHECK") && !caps.Has(capability.DropConstraintGeneric):
 		if !caps.Has(capability.DropCheckClause) {
 			// No generic clause and no DROP CHECK either (MySQLLegacy):

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -1031,14 +1031,15 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 // planner's capability-derived intent (issue #226):
 //
 //   - FOREIGN KEY uses DROP FOREIGN KEY (never the generic clause);
+//   - UNIQUE uses DROP INDEX on EVERY target (issue #195): a UNIQUE
+//     constraint is backed by an index, and ALTER TABLE ... DROP INDEX is the
+//     one spelling valid across the entire MySQL/MariaDB family (verified
+//     live on MySQL 9.7 and MariaDB 10.11) — the generic clause would be
+//     invalid SQL before MySQL 8.0.19;
 //   - CHECK uses DROP CHECK when the target lacks the generic DROP CONSTRAINT
 //     clause (capability.DropConstraintGeneric absent — MySQL 8.0.16–8.0.18);
 //     a target with NEITHER spelling (capability.MySQLLegacy) gets a loud
 //     WARNING comment instead of invalid SQL;
-//   - UNIQUE uses DROP INDEX (dropping the backing index — valid across the
-//     whole family) when the generic clause is absent; on modern targets it
-//     keeps the generic clause for now, and the universal DROP INDEX
-//     branching for every version is tracked separately (issue #195);
 //   - everything else uses DROP CONSTRAINT (MySQL 8.0.19+ / MariaDB);
 //   - the IF EXISTS guard is requested when the target accepts guarded drops
 //     (capability.DropConstraintIfExists — MariaDB; MySQL rejects it). The
@@ -1053,19 +1054,19 @@ func (p *Planner) dropConstraintNode(info types.ConstraintRemovalInfo) ast.Node 
 		ForeignKey:     strings.EqualFold(info.Type, "FOREIGN KEY"),
 		IfExists:       caps.Has(capability.DropConstraintIfExists),
 	}
-	if !op.ForeignKey && !caps.Has(capability.DropConstraintGeneric) {
-		switch {
-		case strings.EqualFold(info.Type, "CHECK"):
-			if !caps.Has(capability.DropCheckClause) {
-				// No generic clause and no DROP CHECK either (MySQLLegacy):
-				// there is no valid spelling, so fail loudly instead of
-				// emitting SQL the server rejects.
-				return ast.NewComment(fmt.Sprintf("WARNING: cannot drop CHECK constraint %s on %s - the target supports neither DROP CONSTRAINT nor DROP CHECK", info.Name, info.TableName))
-			}
-			op.Check = true
-		case strings.EqualFold(info.Type, "UNIQUE"):
-			op.Unique = true
+	switch {
+	case op.ForeignKey:
+		// DROP FOREIGN KEY carries the type information already.
+	case strings.EqualFold(info.Type, "UNIQUE"):
+		op.Unique = true
+	case strings.EqualFold(info.Type, "CHECK") && !caps.Has(capability.DropConstraintGeneric):
+		if !caps.Has(capability.DropCheckClause) {
+			// No generic clause and no DROP CHECK either (MySQLLegacy):
+			// there is no valid spelling, so fail loudly instead of
+			// emitting SQL the server rejects.
+			return ast.NewComment(fmt.Sprintf("WARNING: cannot drop CHECK constraint %s on %s - the target supports neither DROP CONSTRAINT nor DROP CHECK", info.Name, info.TableName))
 		}
+		op.Check = true
 	}
 	return &ast.AlterTableNode{
 		Name:       info.TableName,


### PR DESCRIPTION
Closes #195.

A UNIQUE constraint is backed by an index, and `ALTER TABLE … DROP INDEX <name>` is the one spelling valid across the **entire** MySQL/MariaDB family — the generic `DROP CONSTRAINT` clause is invalid SQL before MySQL 8.0.19. The planner now requests the `DROP INDEX` spelling (`DropConstraintOperation.Unique`, introduced in #232) for **every** UNIQUE removal, not just on no-generic-clause targets — matching the convention `removeConstraints`' docstring has always promised.

## Guard interplay (capabilities, #225/#226)

`ALTER TABLE … DROP INDEX IF EXISTS` is MariaDB-only — **verified live**: MariaDB 10.11 accepts it (idempotently, including on an absent index), MySQL 9.7 rejects it (errno 1064). So the same two-layer split as the other constraint drops applies: the MariaDB-preset planner records `IfExists` intent, the mariadb renderer emits `DROP INDEX IF EXISTS`, and the mysql renderer strips the guard (gated on `capability.DropIndexIfExists`).

## Per the issue's acceptance criteria

- [x] A table-level UNIQUE constraint removal renders `DROP INDEX` on MySQL/MariaDB — planner-level (`TestPlanner_UniqueConstraintRemoval_UsesDropIndex`, every preset) and renderer-level (`TestMySQLFamilyRenderers_DropUniqueIndexSpelling`, incl. the guarded MariaDB variant) tests.
- [x] FK drops unchanged (`DROP FOREIGN KEY`), PK removals stay skipped — asserted in the same test.

Note on the issue's premise: current MySQL (8.0.19+/9.x) actually accepts the generic clause for UNIQUE too (empirical data posted on the issue earlier), so on modern lines this is a convention/robustness change rather than a live-break fix — but on the `MySQL8016`/`MySQLLegacy` capability presets introduced in #232 the generic clause *is* invalid, and `DROP INDEX` closes that hole for real.

## Verification

- `go test -count=1 ./...` green; `golangci-lint run ./...` 0 issues (qtlint-clean).
- Live integration suites: **120/120** scenarios on MySQL 9.7 + MariaDB 10.11.
- Live DDL checks: `ALTER TABLE … DROP INDEX` drops a named UNIQUE constraint on both engines; the `IF EXISTS` variant accepted by MariaDB only.