### PR TITLE
Test(integration): live FK on_delete/on_update round-trip scenario (#196)

### DIFF
--- a/integration/fixtures/entities/021-fk-actions-initial/order.go
+++ b/integration/fixtures/entities/021-fk-actions-initial/order.go
@@ -1,0 +1,23 @@
+package entities
+
+// Order carries a FIELD-LEVEL foreign key (foreign= on the column annotation,
+// the issue #189 / PR #190 feature) with NO referential actions: the engine
+// default is NO ACTION (reported as RESTRICT by MariaDB — the two are
+// equivalent on the MySQL family). The 022-fk-actions-changed version of this
+// fixture changes on_delete/on_update on the SAME constraint name, which the
+// comparator expresses as a modification (drop + re-add).
+//
+// user_id is deliberately nullable: the changed version sets
+// on_delete="SET NULL", which requires a nullable referencing column.
+
+//migrator:schema:table name="orders"
+type Order struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="user_id" type="INTEGER" foreign="users(id)" foreign_key_name="fk_orders_user"
+	UserID *int64
+
+	//migrator:schema:field name="note" type="VARCHAR(255)"
+	Note string
+}

--- a/integration/fixtures/entities/021-fk-actions-initial/user.go
+++ b/integration/fixtures/entities/021-fk-actions-initial/user.go
@@ -1,0 +1,10 @@
+package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}

--- a/integration/fixtures/entities/022-fk-actions-changed/order.go
+++ b/integration/fixtures/entities/022-fk-actions-changed/order.go
@@ -1,0 +1,20 @@
+package entities
+
+// Same schema as 021-fk-actions-initial except for the referential actions on
+// fk_orders_user: on_delete gains SET NULL and on_update gains CASCADE. The
+// constraint name is unchanged, so the comparator reports a modification
+// (remove + add of the same name) and the generated UP must drop-and-re-add
+// the FK with the new actions; the generated DOWN must restore the prior
+// (default) actions from the introspected pre-change schema (PR #190).
+
+//migrator:schema:table name="orders"
+type Order struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="user_id" type="INTEGER" foreign="users(id)" foreign_key_name="fk_orders_user" on_delete="SET NULL" on_update="CASCADE"
+	UserID *int64
+
+	//migrator:schema:field name="note" type="VARCHAR(255)"
+	Note string
+}

--- a/integration/fixtures/entities/022-fk-actions-changed/user.go
+++ b/integration/fixtures/entities/022-fk-actions-changed/user.go
@@ -1,0 +1,10 @@
+package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -189,6 +189,16 @@ func GetDynamicScenarios() []TestScenario {
 			EnhancedTestFunc: testDynamicFieldCheckConstraintEvolution,
 		},
 		{
+			// Live coverage for issue #196: a field-level FK referential-action
+			// CHANGE (issue #189 / PR #190) round-trips through REAL generated
+			// up+down migration files on PG, MySQL and MariaDB, asserting the
+			// APPLIED actions via information_schema introspection — not just
+			// that a migration was emitted.
+			Name:             "dynamic_fk_action_evolution",
+			Description:      "Test FK on_delete/on_update change round-trip (real up + generated down) with live introspection (issue #196)",
+			EnhancedTestFunc: testDynamicFKActionEvolution,
+		},
+		{
 			Name:             "dynamic_rls_policy_modification",
 			Description:      "Test RLS policy modification and schema diffing",
 			EnhancedTestFunc: testDynamicRLSPolicyModification,

--- a/integration/scenarios_fk_action_evolution.go
+++ b/integration/scenarios_fk_action_evolution.go
@@ -1,0 +1,191 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+// testDynamicFKActionEvolution is the live versioned-fixture coverage for
+// issue #196: a field-level foreign key's on_delete/on_update CHANGE
+// round-trips through REAL generated migrations — up and down files produced
+// by migration/generator (the issue #189 / PR #190 machinery) and applied by
+// the real migrator — on PostgreSQL, MySQL and MariaDB alike. Unlike the
+// pre-existing unit coverage, every assertion here reads the LIVE applied
+// referential actions back from information_schema.referential_constraints,
+// so a migration that "runs fine" but leaves the wrong ON DELETE rule in the
+// database fails loudly.
+//
+// Flow (mirrors the testMigrationGeneratorValidation / PR #175 pattern):
+//
+//  1. 021-fk-actions-initial: users + orders with a field-level FK
+//     (fk_orders_user) carrying NO referential actions — the engine default,
+//     NO ACTION (MariaDB reports the equivalent RESTRICT).
+//  2. Assert the live default actions; re-diff for idempotency (this is also
+//     the spot where a missing RESTRICT==NO ACTION normalization would
+//     produce a spurious FK diff on MariaDB).
+//  3. 022-fk-actions-changed: the SAME constraint name gains
+//     on_delete="SET NULL" and on_update="CASCADE" — a modification
+//     (drop + re-add) in the comparator's terms. Apply the generated UP.
+//  4. Assert the live actions actually changed; re-diff for idempotency.
+//  5. Apply the generated DOWN (one MigrateDown step) and assert the PRIOR
+//     actions are restored — the #190 down path reconstructs the old FK body
+//     from the introspected pre-change schema.
+//  6. Full comparator consistency check against the 021 fixture.
+func testDynamicFKActionEvolution(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
+	vem, err := NewVersionedEntityManager(fixtures)
+	if err != nil {
+		return fmt.Errorf("failed to create versioned entity manager: %w", err)
+	}
+	defer vem.Cleanup()
+
+	migrationsDir, err := os.MkdirTemp("", "ptah_fk_action_evolution_*")
+	if err != nil {
+		return fmt.Errorf("failed to create migrations directory: %w", err)
+	}
+	defer os.RemoveAll(migrationsDir)
+	migrationsFs := os.DirFS(migrationsDir)
+	dh := NewDatabaseHelper(conn)
+
+	generateAndMigrateUp := func(versionDir string) error {
+		if loadErr := vem.LoadEntityVersion(versionDir); loadErr != nil {
+			return loadErr
+		}
+		if _, genErr := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+			GoEntitiesDir: vem.GetEntitiesDir(),
+			DBConn:        conn,
+			OutputDir:     migrationsDir,
+		}); genErr != nil {
+			return genErr
+		}
+		return dh.MigrateUp(ctx, migrationsFs)
+	}
+
+	if err := recorder.RecordStep("Apply FK Baseline", "Generate and apply real migration files for 021-fk-actions-initial", func() error {
+		return generateAndMigrateUp("021-fk-actions-initial")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Default FK Actions", "Live fk_orders_user must carry the engine-default referential actions", func() error {
+		return assertLiveFKActions(ctx, conn, "fk_orders_user", "NO ACTION", "NO ACTION")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Idempotency At Baseline", "Re-diff against 021 — no further changes expected", func() error {
+		return assertNoPendingChanges(ctx, conn, vem, "after baseline")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Apply FK Action Change", "Generate and apply real migration files for 022-fk-actions-changed", func() error {
+		return generateAndMigrateUp("022-fk-actions-changed")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Changed FK Actions", "Live fk_orders_user must now be ON UPDATE CASCADE / ON DELETE SET NULL", func() error {
+		return assertLiveFKActions(ctx, conn, "fk_orders_user", "CASCADE", "SET NULL")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Idempotency After Change", "Re-diff against 022 — no further changes expected", func() error {
+		return assertNoPendingChanges(ctx, conn, vem, "after action change")
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Rollback FK Action Change", "Apply the GENERATED down migration (issue #190 path)", func() error {
+		return dh.MigrateDown(ctx, migrationsFs)
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Verify Actions Restored", "Live fk_orders_user must be back to the engine-default actions", func() error {
+		return assertLiveFKActions(ctx, conn, "fk_orders_user", "NO ACTION", "NO ACTION")
+	}); err != nil {
+		return err
+	}
+
+	return recorder.RecordStep("Schema Consistency After Rollback", "Comparator must see no drift against 021-fk-actions-initial", func() error {
+		return validateSchemaConsistency(ctx, conn, vem, "021-fk-actions-initial")
+	})
+}
+
+// assertNoPendingChanges re-diffs the currently loaded fixture version against
+// the live database and fails on any non-comment statement.
+func assertNoPendingChanges(ctx context.Context, conn *dbschema.DatabaseConnection, vem *VersionedEntityManager, when string) error {
+	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("failed to regenerate migration SQL %s: %w", when, err)
+	}
+	if hasNonCommentStatement(statements) {
+		return fmt.Errorf("idempotency violation %s: %s", when, strings.Join(statements, "\n"))
+	}
+	return nil
+}
+
+// assertLiveFKActions reads the applied referential actions of a foreign key
+// straight from information_schema.referential_constraints and compares them
+// (normalized) against the expectation. NO ACTION and RESTRICT are equivalent
+// on the MySQL family — InnoDB even reports the default as RESTRICT on
+// MariaDB — so both are normalized to NO ACTION before comparing there.
+func assertLiveFKActions(ctx context.Context, conn *dbschema.DatabaseConnection, constraintName, wantUpdate, wantDelete string) error {
+	updateRule, deleteRule, err := readFKReferentialActions(ctx, conn, constraintName)
+	if err != nil {
+		return err
+	}
+
+	dialect := conn.Info().Dialect
+	gotUpdate := normalizeReferentialAction(dialect, updateRule)
+	gotDelete := normalizeReferentialAction(dialect, deleteRule)
+	wantUpdate = normalizeReferentialAction(dialect, wantUpdate)
+	wantDelete = normalizeReferentialAction(dialect, wantDelete)
+
+	if gotUpdate != wantUpdate || gotDelete != wantDelete {
+		return fmt.Errorf("constraint %s: live actions ON UPDATE %s / ON DELETE %s, want ON UPDATE %s / ON DELETE %s",
+			constraintName, updateRule, deleteRule, wantUpdate, wantDelete)
+	}
+	return nil
+}
+
+// readFKReferentialActions returns the update_rule / delete_rule of a named
+// foreign key in the current schema. information_schema.referential_constraints
+// exists on PostgreSQL, MySQL and MariaDB; only the schema scoping function
+// and the bind-parameter style differ.
+func readFKReferentialActions(ctx context.Context, conn *dbschema.DatabaseConnection, constraintName string) (updateRule, deleteRule string, err error) {
+	var query string
+	if conn.Info().Dialect == "postgres" {
+		query = `
+			SELECT update_rule, delete_rule
+			FROM information_schema.referential_constraints
+			WHERE constraint_schema = current_schema() AND constraint_name = $1`
+	} else {
+		query = `
+			SELECT update_rule, delete_rule
+			FROM information_schema.referential_constraints
+			WHERE constraint_schema = DATABASE() AND constraint_name = ?`
+	}
+	row := conn.QueryRowContext(ctx, query, constraintName)
+	if scanErr := row.Scan(&updateRule, &deleteRule); scanErr != nil {
+		return "", "", fmt.Errorf("constraint %s: failed to read referential_constraints: %w", constraintName, scanErr)
+	}
+	return updateRule, deleteRule, nil
+}
+
+// normalizeReferentialAction maps RESTRICT to NO ACTION on the MySQL family,
+// where the two are semantically identical and interchangeable in server
+// reporting (mirrors the comparator's dialect-aware normalization).
+func normalizeReferentialAction(dialect, action string) string {
+	if (dialect == "mysql" || dialect == "mariadb") && strings.EqualFold(action, "RESTRICT") {
+		return "NO ACTION"
+	}
+	return strings.ToUpper(action)
+}

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -55,8 +55,8 @@ func TestGetDynamicScenarios(t *testing.T) {
 
 	scenarios := GetDynamicScenarios()
 
-	// Should have exactly 41 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169)
-	c.Assert(scenarios, qt.HasLen, 41)
+	// Should have exactly 42 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169 + 1 FK action evolution scenario for issue #196)
+	c.Assert(scenarios, qt.HasLen, 42)
 
 	// Verify all scenarios have required fields
 	for _, scenario := range scenarios {


### PR DESCRIPTION
Closes #196.

Adds `dynamic_fk_action_evolution` — a versioned-fixture integration scenario that round-trips a **field-level FK referential-action change** through **real generated migration files** (`migration/generator` up+down, applied by the real migrator — the `testMigrationGeneratorValidation` / PR #175 pattern) on **PostgreSQL, MySQL and MariaDB**.

## Flow (per the issue's scope)

1. **`021-fk-actions-initial`**: `users` + `orders` with a field-level FK (`foreign=` on the column — the #189/#190 feature), constraint `fk_orders_user`, **no** referential actions (engine default `NO ACTION`). `user_id` is nullable so `SET NULL` is legal later.
2. Assert live defaults via `information_schema.referential_constraints`; idempotency re-diff — this leg also pins the `RESTRICT == NO ACTION` normalization on the MySQL family (MariaDB reports the default FK as `RESTRICT`; without the comparator's dialect normalization this exact spot would produce a spurious diff).
3. **`022-fk-actions-changed`**: same constraint name gains `on_delete="SET NULL"` + `on_update="CASCADE"` — a modification (drop + re-add). Generate + `MigrateUp`.
4. **Assert the APPLIED actions** — `update_rule=CASCADE`, `delete_rule=SET NULL` read back from the live schema, not just "a migration was emitted". Idempotency re-diff.
5. **`MigrateDown`** applies the **generated DOWN file** — the #190 path that reconstructs the prior FK body from the introspected pre-change schema — and the live actions are asserted back to the defaults.
6. Full comparator consistency check against `021`.

Every step reads the live rules; an empty down, a skipped modify, or a wrong applied rule fails on the spot (a missing constraint fails the row scan). Introspection is dialect-aware but uses the same `information_schema.referential_constraints` view on all three engines.

## Acceptance criteria

- [x] A versioned-fixture scenario round-trips an FK `on_delete`/`on_update` change up + down on PG, MySQL and MariaDB, asserting the applied action via introspection.
- [x] Runs in the existing integration matrix (registered in `GetDynamicScenarios`; scenario count 41 → 42).

## Verification

- Live scenario legs: **3/3** (postgres 140ms, mysql 131ms, mariadb 102ms).
- Full live integration suite: **183/183** across PostgreSQL 18 + MySQL 9.7 + MariaDB 10.11.
- `go test -count=1 ./...` green; `golangci-lint` + `qtlint` — 0 issues.