### PR TITLE
Add distributed SQL adapters

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -91,6 +91,18 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Start distributed SQL databases
+        run: |
+          docker run --detach --name ptah-cockroachdb \
+            --publish 26257:26257 \
+            cockroachdb/cockroach:v23.2.5 \
+            start-single-node --insecure --advertise-addr=localhost:26257
+
+          docker run --detach --name ptah-yugabytedb \
+            --publish 5433:5433 \
+            yugabytedb/yugabyte:2026.1.0.0-b118 \
+            bash -lc 'ip=$(hostname -i); ip=${ip%% *}; exec bin/yugabyted start --daemon=false --advertise_address=$ip --ui=false'
+
       - name: Wait for databases to be ready
         run: |
           echo "Waiting for PostgreSQL..."
@@ -120,6 +132,20 @@ jobs:
             sleep 2
           done
           echo "ClickHouse is ready!"
+
+          echo "Waiting for CockroachDB..."
+          until docker exec ptah-cockroachdb /cockroach/cockroach sql --insecure --host=127.0.0.1:26257 --execute="SELECT 1"; do
+            echo "CockroachDB is unavailable - sleeping"
+            sleep 2
+          done
+          echo "CockroachDB is ready!"
+
+          echo "Waiting for YugabyteDB..."
+          until docker exec ptah-yugabytedb bash -lc 'ip=$(hostname -i); ip=${ip%% *}; bin/ysqlsh -h "$ip" -p 5433 -U yugabyte -d yugabyte -c "SELECT 1"'; do
+            echo "YugabyteDB is unavailable - sleeping"
+            sleep 5
+          done
+          echo "YugabyteDB is ready!"
       
       - name: Run executor integration tests with PostgreSQL
         env:
@@ -159,8 +185,18 @@ jobs:
           MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
           CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
         run: |
-          ./integration-test --databases=postgres,mysql,mariadb,clickhouse --report=stdout,txt,json,html --verbose --output=./reports
+          ./integration-test --databases=postgres,mysql,mariadb,clickhouse,cockroachdb,yugabytedb --report=stdout,txt,json,html --verbose --output=./reports
+
+      - name: Run distributed SQL live smoke tests
+        env:
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+        run: |
+          ./integration-test --databases=cockroachdb --scenarios=dynamic_cockroachdb_common_subset --report=stdout,txt,json,html --verbose --output=./reports
+          ./integration-test --databases=yugabytedb --scenarios=dynamic_yugabytedb_common_subset --report=stdout,txt,json,html --verbose --output=./reports
 
       - name: Upload integration test reports
         uses: actions/upload-artifact@v7
@@ -177,5 +213,7 @@ jobs:
           MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
           CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
         run: |
           go test -v -race ./integration -timeout 30m

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ integration-test-mariadb: docker-build
 	@echo "Running integration tests against MariaDB only..."
 	docker compose --profile test run --rm ptah-tester --databases=mariadb --report=html --verbose
 
+integration-test-cockroachdb: docker-build
+	@echo "Running integration tests against CockroachDB only..."
+	docker compose --profile test run --rm ptah-tester --databases=cockroachdb --scenarios=dynamic_cockroachdb_common_subset --report=html --verbose
+
+integration-test-yugabytedb: docker-build
+	@echo "Running integration tests against YugabyteDB only..."
+	docker compose --profile test run --rm ptah-tester --databases=yugabytedb --scenarios=dynamic_yugabytedb_common_subset --report=html --verbose
+
 # Run integration tests using Docker Compose with custom arguments
 integration-test-custom: docker-build
 	@echo "Running integration tests with custom arguments..."
@@ -83,7 +91,7 @@ integration-test-custom: docker-build
 # Start databases only (for development)
 db-start:
 	@echo "Starting databases..."
-	docker compose up -d postgres mysql mariadb
+	docker compose up -d postgres mysql mariadb cockroachdb yugabytedb
 
 # Stop databases
 db-stop:
@@ -93,7 +101,7 @@ db-stop:
 # View database logs
 db-logs:
 	@echo "Showing database logs..."
-	docker compose logs -f postgres mysql mariadb
+	docker compose logs -f postgres mysql mariadb cockroachdb yugabytedb
 
 # Clean up Docker resources
 docker-clean:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The core package contains all fundamental components for parsing, transforming, 
 
 - **`renderer/`** - Dialect-specific SQL generation from AST
   - Converts AST nodes to database-specific SQL statements
-  - Supports PostgreSQL, MySQL, MariaDB, and ClickHouse dialects
+  - Supports PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, YugabyteDB, and Spanner dialects
   - Implements visitor pattern for extensible rendering
 
 - **`platform/`** - Database platform constants and identifiers
@@ -113,7 +113,7 @@ Provides comprehensive database migration functionality:
 
 - **`planner/`** - Migration planning and SQL generation
   - Converts schema differences into executable SQL statements
-  - Dialect-specific planners for PostgreSQL, MySQL, MariaDB, and ClickHouse
+  - Dialect-specific planners for PostgreSQL, MySQL, MariaDB, ClickHouse, and PostgreSQL-family distributed SQL targets
   - Handles dependency ordering and safety checks
 
 - **`schemadiff/`** - Schema comparison and difference analysis
@@ -124,7 +124,7 @@ Provides comprehensive database migration functionality:
 #### `dbschema/` - Database Schema Operations
 Handles all database interactions and schema operations:
 
-- **Connection management** for PostgreSQL, MySQL, MariaDB, and ClickHouse
+- **Connection management** for PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, YugabyteDB, and Spanner
 - **Schema reading and introspection** from live databases (including ClickHouse `system.tables` / `system.columns` / `system.data_skipping_indices`)
 - **Schema writing and migration execution** with transaction support (transactions are no-ops on ClickHouse — see the package godoc)
 - **Database cleaning and schema dropping** capabilities
@@ -842,7 +842,7 @@ go test -v ./migration/...
 
 ### Integration Testing Framework
 
-Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL, MySQL, MariaDB, and ClickHouse.
+Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets.
 
 #### Run Integration Tests
 
@@ -959,6 +959,10 @@ docker run --name test-mysql \
 - **PostgreSQL** - Full support including enums, constraints (CHECK, UNIQUE, FOREIGN KEY, EXCLUDE), indexes, RLS policies, and extensions
 - **MySQL** - Full support with MySQL-specific optimizations
 - **MariaDB** - Full support with MariaDB-specific features
+- **ClickHouse** - Opt-in MergeTree-oriented support for compatible scenarios
+- **CockroachDB** - PostgreSQL-family common subset via `platform.CockroachDB`; no `CREATE INDEX CONCURRENTLY`, XML, advisory locks, or RLS
+- **YugabyteDB** - PostgreSQL-family common subset via `platform.YugabyteDB`; regular `CREATE INDEX` is used instead of PostgreSQL `CONCURRENTLY`
+- **Spanner** - Conservative PostgreSQL-interface routing via `platform.Spanner`; full Spanner-specific DDL is not yet implemented
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -685,11 +685,12 @@ Run comprehensive integration tests across multiple database platforms:
 ```
 
 **Features:**
-- ✅ Tests across PostgreSQL, MySQL, MariaDB, and ClickHouse
+- ✅ Tests across PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, and YugabyteDB
 - ✅ Comprehensive scenario coverage (basic, concurrency, idempotency, failure recovery)
 - ✅ Multiple report formats (TXT, JSON, HTML)
 - ✅ Automated database setup and cleanup
 - ✅ ClickHouse scenarios are opt-in per scenario (`ClickHouseCompatible`); incompatible scenarios skip cleanly against a ClickHouse connection
+- ✅ PostgreSQL-family distributed SQL scenarios are opt-in per scenario (`PostgresDistributedCompatible`), with live common-subset coverage for CockroachDB and YugabyteDB
 
 ---
 
@@ -842,7 +843,7 @@ go test -v ./migration/...
 
 ### Integration Testing Framework
 
-Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets.
+Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets. CockroachDB and YugabyteDB have live common-subset scenarios in CI; Spanner uses capability, planning, and rendering coverage only.
 
 #### Run Integration Tests
 
@@ -960,8 +961,8 @@ docker run --name test-mysql \
 - **MySQL** - Full support with MySQL-specific optimizations
 - **MariaDB** - Full support with MariaDB-specific features
 - **ClickHouse** - Opt-in MergeTree-oriented support for compatible scenarios
-- **CockroachDB** - PostgreSQL-family common subset via `platform.CockroachDB`; no `CREATE INDEX CONCURRENTLY`, XML, advisory locks, or RLS
-- **YugabyteDB** - PostgreSQL-family common subset via `platform.YugabyteDB`; regular `CREATE INDEX` is used instead of PostgreSQL `CONCURRENTLY`
+- **CockroachDB** - PostgreSQL-family common subset via `platform.CockroachDB`; no `CREATE INDEX CONCURRENTLY`, XML, advisory locks, or RLS; covered by a live common-subset integration scenario
+- **YugabyteDB** - PostgreSQL-family common subset via `platform.YugabyteDB`; regular `CREATE INDEX` is used instead of PostgreSQL `CONCURRENTLY`; covered by a live common-subset integration scenario
 - **Spanner** - Conservative PostgreSQL-interface routing via `platform.Spanner`; full Spanner-specific DDL is not yet implemented
 
 ---

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
 )
 
@@ -37,7 +38,7 @@ var generateFlags = map[string]cobraflags.Flag{
 	dialectFlag: &cobraflags.StringFlag{
 		Name:  dialectFlag,
 		Value: "",
-		Usage: "Database dialect (postgres, mysql, mariadb, clickhouse). If empty, generates for all dialects",
+		Usage: "Database dialect (postgres, mysql, mariadb, clickhouse, cockroachdb, yugabytedb, spanner). If empty, generates for all dialects",
 	},
 }
 
@@ -81,7 +82,7 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 
 	// Determine which dialects to generate
-	dialects := []string{"postgres", "mysql", "mariadb", "clickhouse"}
+	dialects := []string{"postgres", "mysql", "mariadb", "clickhouse", "cockroachdb", "yugabytedb", "spanner"}
 	if dialect != "" {
 		dialects = []string{dialect}
 	}
@@ -95,7 +96,8 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 		if len(result.Enums) > 0 {
 			fmt.Println("-- ENUMS --")
 			for _, enum := range result.Enums {
-				if d == "postgres" {
+				switch platform.NormalizeDialect(d) {
+				case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
 					fmt.Printf("CREATE TYPE %s AS ENUM (%s);\n", enum.Name,
 						strings.Join(func() []string {
 							quoted := make([]string, len(enum.Values))
@@ -104,7 +106,7 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 							}
 							return quoted
 						}(), ", "))
-				} else {
+				default:
 					fmt.Printf("-- Enum %s: %v (handled in table definitions)\n", enum.Name, enum.Values)
 				}
 			}

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -43,7 +43,7 @@ var rootFlags = map[string]cobraflags.Flag{
 	},
 	databasesFlag: &cobraflags.StringSliceFlag{
 		Name:  databasesFlag,
-		Value: []string{"postgres", "mysql", "mariadb"},
+		Value: []string{"postgres", "mysql", "mariadb", "cockroachdb", "yugabytedb"},
 		Usage: "Databases to test against",
 	},
 	scenariosFlag: &cobraflags.StringSliceFlag{
@@ -158,12 +158,7 @@ func runIntegrationTests(cmd *cobra.Command, args []string) error {
 	runner := integration.NewTestRunner(fixturesFS)
 
 	// Add database connections from environment variables
-	dbConnections := map[string]string{
-		"postgres":   os.Getenv("POSTGRES_URL"),
-		"mysql":      os.Getenv("MYSQL_URL"),
-		"mariadb":    os.Getenv("MARIADB_URL"),
-		"clickhouse": os.Getenv("CLICKHOUSE_URL"),
-	}
+	dbConnections := configuredDatabaseConnections()
 
 	// Filter databases based on command line arguments
 	for _, dbName := range databases {
@@ -256,6 +251,17 @@ func runIntegrationTests(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("\n🎉 All tests passed!\n")
 	return nil
+}
+
+func configuredDatabaseConnections() map[string]string {
+	return map[string]string{
+		"postgres":    os.Getenv("POSTGRES_URL"),
+		"mysql":       os.Getenv("MYSQL_URL"),
+		"mariadb":     os.Getenv("MARIADB_URL"),
+		"clickhouse":  os.Getenv("CLICKHOUSE_URL"),
+		"cockroachdb": os.Getenv("COCKROACHDB_URL"),
+		"yugabytedb":  os.Getenv("YUGABYTEDB_URL"),
+	}
 }
 
 func listScenarios(cmd *cobra.Command, args []string) error {

--- a/cmd/integration-test/main_test.go
+++ b/cmd/integration-test/main_test.go
@@ -68,3 +68,28 @@ func TestDynamicScenarioIdentification(t *testing.T) {
 		c.Assert(scenario.EnhancedTestFunc, qt.IsNotNil, qt.Commentf("Dynamic scenario %s should have EnhancedTestFunc", scenario.Name))
 	}
 }
+
+func TestConfiguredDatabaseConnectionsIncludesDistributedSQL(t *testing.T) {
+	c := qt.New(t)
+
+	t.Setenv("POSTGRES_URL", "postgres://postgres.example/db")
+	t.Setenv("MYSQL_URL", "mysql://mysql.example/db")
+	t.Setenv("MARIADB_URL", "mariadb://mariadb.example/db")
+	t.Setenv("CLICKHOUSE_URL", "clickhouse://clickhouse.example/db")
+	t.Setenv("COCKROACHDB_URL", "cockroachdb://cockroach.example/defaultdb")
+	t.Setenv("YUGABYTEDB_URL", "yugabytedb://yugabyte.example/yugabyte")
+
+	connections := configuredDatabaseConnections()
+
+	c.Assert(connections["cockroachdb"], qt.Equals, "cockroachdb://cockroach.example/defaultdb")
+	c.Assert(connections["yugabytedb"], qt.Equals, "yugabytedb://yugabyte.example/yugabyte")
+}
+
+func TestDefaultDatabasesIncludeOSSDistributedSQL(t *testing.T) {
+	c := qt.New(t)
+
+	defaultDatabases := rootFlags[databasesFlag].GetStringSlice()
+
+	c.Assert(defaultDatabases, qt.Contains, "cockroachdb")
+	c.Assert(defaultDatabases, qt.Contains, "yugabytedb")
+}

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -2,13 +2,14 @@
 // a version line) can accept, as a validated set of feature flags.
 //
 // Ptah maps several real targets onto one implementation: MySQL and MariaDB
-// share a planner and a renderer, and versions within one dialect differ in
-// what DDL they accept (MySQL gained generic DROP CONSTRAINT in 8.0.19,
-// enforced CHECK constraints in 8.0.16; IF EXISTS on constraint drops is
-// MariaDB-only; and so on). Encoding each variant as a separate dialect would
-// multiply planners and renderers; instead, planners and renderers consult a
-// capability set and restrict or enable individual emissions per target
-// (issues #225/#226).
+// share a planner and a renderer; CockroachDB, YugabyteDB, and Spanner use the
+// PostgreSQL family with target-specific restrictions; and versions within one
+// dialect differ in what DDL they accept (MySQL gained generic DROP CONSTRAINT
+// in 8.0.19, enforced CHECK constraints in 8.0.16; IF EXISTS on constraint
+// drops is MariaDB-only; and so on). Encoding each variant as a separate
+// dialect would multiply planners and renderers; instead, planners and
+// renderers consult a capability set and restrict or enable individual
+// emissions per target (issues #225/#226/#171).
 //
 // # Model
 //
@@ -114,6 +115,27 @@ const (
 	// RowLevelSecurity marks support for row-level security policies
 	// (PostgreSQL ALTER TABLE ... ENABLE ROW LEVEL SECURITY + CREATE POLICY).
 	RowLevelSecurity Capability = "row_level_security"
+
+	// ForeignKeys marks support for declarative FOREIGN KEY constraints.
+	// PostgreSQL, CockroachDB, YugabyteDB, MySQL, and MariaDB support them;
+	// Spanner's PostgreSQL interface has historically not supported the
+	// PostgreSQL FOREIGN KEY surface, so its conservative preset disables it.
+	ForeignKeys Capability = "foreign_keys"
+
+	// Sequences marks support for database sequence objects used by
+	// PostgreSQL SERIAL/BIGSERIAL or explicit CREATE SEQUENCE support.
+	Sequences Capability = "sequences"
+
+	// XMLType marks support for the PostgreSQL XML column type. CockroachDB
+	// and Spanner PostgreSQL disable it; callers should use platform-specific
+	// type overrides for those targets.
+	XMLType Capability = "xml_type"
+
+	// AdvisoryLocks marks support for PostgreSQL advisory locks such as
+	// pg_advisory_lock. Migration-level lock selection is outside this
+	// package, but the flag lets callers avoid assuming PostgreSQL lock
+	// functions exist on every PostgreSQL-wire engine.
+	AdvisoryLocks Capability = "advisory_locks"
 )
 
 // spec documents a registry entry and its implication edges.
@@ -159,6 +181,18 @@ var registry = map[Capability]spec{
 	},
 	RowLevelSecurity: {
 		doc: "row-level security policies (PostgreSQL)",
+	},
+	ForeignKeys: {
+		doc: "declarative FOREIGN KEY constraints",
+	},
+	Sequences: {
+		doc: "database sequence objects (SERIAL/BIGSERIAL or explicit CREATE SEQUENCE support)",
+	},
+	XMLType: {
+		doc: "PostgreSQL XML column type",
+	},
+	AdvisoryLocks: {
+		doc: "PostgreSQL advisory lock functions",
 	},
 }
 
@@ -275,6 +309,10 @@ func MySQL80() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   false,
 		RowLevelSecurity:         false,
+		ForeignKeys:              true,
+		Sequences:                false,
+		XMLType:                  false,
+		AdvisoryLocks:            false,
 	}
 }
 
@@ -309,6 +347,10 @@ func MariaDB1011() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   true,
 		RowLevelSecurity:         false,
+		ForeignKeys:              true,
+		Sequences:                true,
+		XMLType:                  false,
+		AdvisoryLocks:            false,
 	}
 }
 
@@ -339,6 +381,10 @@ func Postgres16() Capabilities {
 		CreateIndexConcurrently:  true,
 		CreateOrReplaceTrigger:   true,
 		RowLevelSecurity:         true,
+		ForeignKeys:              true,
+		Sequences:                true,
+		XMLType:                  true,
+		AdvisoryLocks:            true,
 	}
 }
 
@@ -364,7 +410,54 @@ func ClickHouse24() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   false,
 		RowLevelSecurity:         false,
+		ForeignKeys:              false,
+		Sequences:                false,
+		XMLType:                  false,
+		AdvisoryLocks:            false,
 	}
+}
+
+// CockroachDB23 is the preset for CockroachDB's PostgreSQL-compatible surface.
+// CockroachDB runs schema changes online by design, so PostgreSQL's
+// CONCURRENTLY keyword is not a meaningful or portable emission target. It
+// also lacks PostgreSQL's XML type and advisory-lock functions.
+func CockroachDB23() Capabilities {
+	return Postgres16().
+		With(CreateIndexConcurrently, false).
+		With(XMLType, false).
+		With(AdvisoryLocks, false).
+		With(RowLevelSecurity, false)
+}
+
+// YugabyteDB25 is the preset for YugabyteDB YSQL. It stays close to
+// PostgreSQL for the common DDL subset, but regular CREATE INDEX is already
+// asynchronous in YugabyteDB, so the PostgreSQL CONCURRENTLY keyword is not
+// emitted.
+func YugabyteDB25() Capabilities {
+	return Postgres16().
+		With(CreateIndexConcurrently, false).
+		With(AdvisoryLocks, false).
+		With(RowLevelSecurity, false)
+}
+
+// SpannerPostgres is the conservative preset for Cloud Spanner's PostgreSQL
+// interface. Spanner's SQL surface is sufficiently different that Ptah only
+// routes the simplest PostgreSQL-family statements through this preset; enums,
+// sequences, RLS, advisory locks, XML, and foreign keys are disabled.
+func SpannerPostgres() Capabilities {
+	return Postgres16().
+		With(DropConstraintGeneric, false).
+		With(DropConstraintIfExists, false).
+		With(DropIndexIfExists, false).
+		With(CheckConstraintsEnforced, false).
+		With(EnumCustomType, false).
+		With(CreateIndexConcurrently, false).
+		With(CreateOrReplaceTrigger, false).
+		With(RowLevelSecurity, false).
+		With(ForeignKeys, false).
+		With(Sequences, false).
+		With(XMLType, false).
+		With(AdvisoryLocks, false)
 }
 
 // ForDialect returns the default preset for a dialect name (normalized via
@@ -380,6 +473,12 @@ func ForDialect(dialect string) Capabilities {
 		return MariaDB1011()
 	case platform.ClickHouse:
 		return ClickHouse24()
+	case platform.CockroachDB:
+		return CockroachDB23()
+	case platform.YugabyteDB:
+		return YugabyteDB25()
+	case platform.Spanner:
+		return SpannerPostgres()
 	default:
 		return nil
 	}
@@ -394,10 +493,20 @@ func ForDialect(dialect string) Capabilities {
 // version cannot be parsed, the dialect's default preset is returned.
 func ForServerVersion(dialect, version string) Capabilities {
 	normalized := platform.NormalizeDialect(dialect)
+	versionLower := strings.ToLower(version)
+
+	switch {
+	case strings.Contains(versionLower, "cockroachdb"):
+		return CockroachDB23()
+	case strings.Contains(versionLower, "yugabytedb") || strings.Contains(versionLower, "yugabyte") || strings.Contains(versionLower, "-yb-"):
+		return YugabyteDB25()
+	case strings.Contains(versionLower, "spanner"):
+		return SpannerPostgres()
+	}
 
 	// MariaDB announces itself in the version string even when connected via
 	// the mysql dialect/driver; trust the string over the declared dialect.
-	if strings.Contains(strings.ToLower(version), "mariadb") {
+	if strings.Contains(versionLower, "mariadb") {
 		return mariaDBForVersion(version)
 	}
 

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -96,6 +96,9 @@ func TestPresets_AllValid_AndCoverEveryRegisteredCapability(t *testing.T) {
 		"Postgres16":    capability.Postgres16(),
 		"Postgres13":    capability.Postgres13(),
 		"ClickHouse24":  capability.ClickHouse24(),
+		"CockroachDB23": capability.CockroachDB23(),
+		"YugabyteDB25":  capability.YugabyteDB25(),
+		"Spanner":       capability.SpannerPostgres(),
 	}
 	for name, preset := range presets {
 		c.Assert(preset.Validate(), qt.IsNil, qt.Commentf("preset %s must validate", name))
@@ -150,6 +153,26 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(legacy.Has(capability.DropIndexIfExists), qt.IsFalse)
 	c.Assert(legacy.Has(capability.CheckConstraintsEnforced), qt.IsFalse)
 	c.Assert(legacy.Has(capability.EnumInlineColumn), qt.IsTrue)
+
+	// Distributed-SQL targets share the PostgreSQL family but not every
+	// PostgreSQL feature.
+	cockroach := capability.CockroachDB23()
+	c.Assert(cockroach.Has(capability.EnumCustomType), qt.IsTrue)
+	c.Assert(cockroach.Has(capability.ForeignKeys), qt.IsTrue)
+	c.Assert(cockroach.Has(capability.CreateIndexConcurrently), qt.IsFalse)
+	c.Assert(cockroach.Has(capability.XMLType), qt.IsFalse)
+	c.Assert(cockroach.Has(capability.AdvisoryLocks), qt.IsFalse)
+
+	yugabyte := capability.YugabyteDB25()
+	c.Assert(yugabyte.Has(capability.EnumCustomType), qt.IsTrue)
+	c.Assert(yugabyte.Has(capability.ForeignKeys), qt.IsTrue)
+	c.Assert(yugabyte.Has(capability.CreateIndexConcurrently), qt.IsFalse)
+
+	spanner := capability.SpannerPostgres()
+	c.Assert(spanner.Has(capability.EnumCustomType), qt.IsFalse)
+	c.Assert(spanner.Has(capability.ForeignKeys), qt.IsFalse)
+	c.Assert(spanner.Has(capability.Sequences), qt.IsFalse)
+	c.Assert(spanner.Has(capability.XMLType), qt.IsFalse)
 }
 
 func TestCapabilities_With_DoesNotMutateReceiver(t *testing.T) {
@@ -191,6 +214,9 @@ func TestForDialect(t *testing.T) {
 	c.Assert(capability.ForDialect("postgresql").Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(capability.ForDialect("pgx").Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(capability.ForDialect("ch").Has(capability.EnumInlineColumn), qt.IsTrue)
+	c.Assert(capability.ForDialect("crdb").Has(capability.CreateIndexConcurrently), qt.IsFalse)
+	c.Assert(capability.ForDialect("yugabyte").Has(capability.CreateIndexConcurrently), qt.IsFalse)
+	c.Assert(capability.ForDialect("spanner").Has(capability.ForeignKeys), qt.IsFalse)
 	// Unknown dialects get the conservative nil set.
 	c.Assert(capability.ForDialect("oracle"), qt.IsNil)
 }
@@ -227,6 +253,10 @@ func TestForServerVersion(t *testing.T) {
 		{"postgres 14 exact boundary", "postgres", "PostgreSQL 14.0", capability.CreateOrReplaceTrigger, true},
 		{"postgres 13 plain", "postgres", "13.14", capability.CreateOrReplaceTrigger, false},
 		{"postgres 13 still concurrent-capable", "postgres", "13.14", capability.CreateIndexConcurrently, true},
+		{"cockroach banner disables concurrent indexes", "postgres", "CockroachDB CCL v23.2.5 (x86_64-pc-linux-gnu)", capability.CreateIndexConcurrently, false},
+		{"cockroach banner disables XML", "postgres", "CockroachDB CCL v23.2.5 (x86_64-pc-linux-gnu)", capability.XMLType, false},
+		{"yugabytedb banner disables concurrent indexes", "postgres", "PostgreSQL 11.2-YB-2.25.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang", capability.CreateIndexConcurrently, false},
+		{"spanner banner disables foreign keys", "postgres", "Cloud Spanner PostgreSQL interface", capability.ForeignKeys, false},
 		{"unparseable falls back to dialect default", "mysql", "who knows", capability.DropConstraintGeneric, true},
 	}
 	for _, tt := range tests {

--- a/core/platform/constants.go
+++ b/core/platform/constants.go
@@ -5,14 +5,17 @@ import (
 )
 
 const (
-	Postgres   = "postgres"
-	MySQL      = "mysql"
-	MariaDB    = "mariadb"
-	ClickHouse = "clickhouse"
+	Postgres    = "postgres"
+	MySQL       = "mysql"
+	MariaDB     = "mariadb"
+	ClickHouse  = "clickhouse"
+	CockroachDB = "cockroachdb"
+	YugabyteDB  = "yugabytedb"
+	Spanner     = "spanner"
 )
 
 func NormalizeDialect(dialect string) string {
-	switch strings.ToLower(dialect) {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
 	case "pgx", "postgresql", "postgres":
 		return Postgres
 	case "mysql":
@@ -21,7 +24,22 @@ func NormalizeDialect(dialect string) string {
 		return MariaDB
 	case "clickhouse", "ch":
 		return ClickHouse
+	case "cockroach", "cockroachdb", "crdb":
+		return CockroachDB
+	case "yugabyte", "yugabytedb", "ysql":
+		return YugabyteDB
+	case "spanner", "cloudspanner", "google-spanner", "google_spanner":
+		return Spanner
 	default:
 		return ""
+	}
+}
+
+func IsPostgresFamily(dialect string) bool {
+	switch NormalizeDialect(dialect) {
+	case Postgres, CockroachDB, YugabyteDB, Spanner:
+		return true
+	default:
+		return false
 	}
 }

--- a/core/platform/constants_test.go
+++ b/core/platform/constants_test.go
@@ -1,0 +1,42 @@
+package platform_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+func TestNormalizeDialect_DistributedSQLAliases(t *testing.T) {
+	c := qt.New(t)
+
+	tests := map[string]string{
+		"cockroach":      platform.CockroachDB,
+		"cockroachdb":    platform.CockroachDB,
+		"crdb":           platform.CockroachDB,
+		"yugabyte":       platform.YugabyteDB,
+		"yugabytedb":     platform.YugabyteDB,
+		"ysql":           platform.YugabyteDB,
+		"spanner":        platform.Spanner,
+		"cloudspanner":   platform.Spanner,
+		"google-spanner": platform.Spanner,
+		"google_spanner": platform.Spanner,
+		" CockroachDB ":  platform.CockroachDB,
+	}
+
+	for input, expected := range tests {
+		c.Assert(platform.NormalizeDialect(input), qt.Equals, expected)
+	}
+}
+
+func TestIsPostgresFamily(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{"postgres", "pgx", "cockroachdb", "yugabytedb", "spanner"} {
+		c.Assert(platform.IsPostgresFamily(dialect), qt.IsTrue, qt.Commentf("dialect %q", dialect))
+	}
+	for _, dialect := range []string{"mysql", "mariadb", "clickhouse", "oracle"} {
+		c.Assert(platform.IsPostgresFamily(dialect), qt.IsFalse, qt.Commentf("dialect %q", dialect))
+	}
+}

--- a/core/platform/doc.go
+++ b/core/platform/doc.go
@@ -11,6 +11,10 @@
 //   - Postgres: PostgreSQL database platform identifier
 //   - MySQL: MySQL database platform identifier
 //   - MariaDB: MariaDB database platform identifier
+//   - ClickHouse: ClickHouse database platform identifier
+//   - CockroachDB: CockroachDB PostgreSQL-family platform identifier
+//   - YugabyteDB: YugabyteDB YSQL PostgreSQL-family platform identifier
+//   - Spanner: Cloud Spanner PostgreSQL-interface platform identifier
 //
 // # Usage
 //
@@ -33,6 +37,8 @@
 //			return generateMySQLSchema()
 //		case platform.MariaDB:
 //			return generateMariaDBSchema()
+//		case platform.CockroachDB:
+//			return generateCockroachDBSchema()
 //		default:
 //			return generateGenericSchema()
 //		}

--- a/core/renderer/dialects/postgres/capability_test.go
+++ b/core/renderer/dialects/postgres/capability_test.go
@@ -1,0 +1,29 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer/dialects/postgres"
+)
+
+func TestPostgreSQLRenderer_NilCapabilitiesAreConservative(t *testing.T) {
+	c := qt.New(t)
+
+	renderer := postgres.NewWithCapabilities(nil, platform.CockroachDB)
+
+	idx := ast.NewIndex("idx_users_email", "users", "email")
+	idx.Concurrently = true
+	sql, err := renderer.Render(idx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY")
+
+	xmlTable := ast.NewCreateTable("events").
+		AddColumn(ast.NewColumn("payload", "XML"))
+	_, err = renderer.Render(xmlTable)
+	c.Assert(err, qt.ErrorMatches, `error rendering column payload: cockroachdb does not support XML columns; use a platform-specific type override`)
+}

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/internal/bufwriter"
 	"github.com/stokaro/ptah/core/renderer/types"
 )
@@ -20,6 +22,7 @@ type Renderer struct {
 	currentEnums []string
 	dialect      string
 	dialectUpper string
+	caps         capability.Capabilities
 	w            bufwriter.Writer
 }
 
@@ -28,7 +31,7 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	var parts []string
 	parts = append(parts, "DROP INDEX")
 
-	if node.IfExists {
+	if node.IfExists && r.capabilities().Has(capability.DropIndexIfExists) {
 		parts = append(parts, "IF EXISTS")
 	}
 
@@ -140,15 +143,34 @@ func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 
 // New creates a new PostgreSQL renderer
 func New() *Renderer {
+	return NewWithCapabilities(capability.Postgres16(), platform.Postgres)
+}
+
+// NewWithCapabilities creates a PostgreSQL-family renderer configured for a
+// concrete target capability set. The dialect label controls diagnostics and
+// GetDialect output; SQL emission is controlled by caps.
+func NewWithCapabilities(caps capability.Capabilities, dialect string) *Renderer {
+	normalized := platform.NormalizeDialect(dialect)
+	if normalized == "" {
+		normalized = platform.Postgres
+	}
 	return &Renderer{
 		currentEnums: nil,
-		dialect:      "postgres",
-		dialectUpper: "POSTGRES",
+		dialect:      normalized,
+		dialectUpper: strings.ToUpper(normalized),
+		caps:         caps.Clone(),
 	}
 }
 
 func (r *Renderer) Dialect() string {
 	return r.dialect
+}
+
+func (r *Renderer) capabilities() capability.Capabilities {
+	if r.caps == nil {
+		return capability.Postgres16()
+	}
+	return r.caps
 }
 
 func (r *Renderer) Reset() {
@@ -294,6 +316,10 @@ func (r *Renderer) VisitAlterTable(node *ast.AlterTableNode) error {
 			if err != nil {
 				return fmt.Errorf("error rendering add constraint: %w", err)
 			}
+			if constraintLine == "" {
+				r.w.WriteLinef("-- %s: constraint %q is not supported by this target; skipped.", r.dialectUpper, op.Constraint.Name)
+				continue
+			}
 			// Remove the leading spaces from constraint rendering for ALTER
 			constraintLine = strings.TrimPrefix(constraintLine, "  ")
 			r.w.WriteLinef("ALTER TABLE %s ADD %s;", node.Name, constraintLine)
@@ -359,7 +385,7 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 
 	// CONCURRENTLY precedes IF NOT EXISTS in the PostgreSQL grammar:
 	// CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] name ...
-	if node.Concurrently {
+	if node.Concurrently && r.capabilities().Has(capability.CreateIndexConcurrently) {
 		parts = append(parts, "CONCURRENTLY")
 	}
 
@@ -427,6 +453,11 @@ func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {
 
 // VisitEnum renders CREATE TYPE ... AS ENUM for PostgreSQL
 func (r *Renderer) VisitEnum(node *ast.EnumNode) error {
+	if !r.capabilities().Has(capability.EnumCustomType) {
+		r.w.WriteLinef("-- %s: enum type %s is not supported by this target; skipped.", r.dialectUpper, node.Name)
+		return nil
+	}
+
 	values := make([]string, len(node.Values))
 	for i, value := range node.Values {
 		values[i] = fmt.Sprintf("'%s'", value)
@@ -500,7 +531,10 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	var parts []string
 
 	// Handle PostgreSQL-specific type conversions using current enum context
-	columnType := r.processFieldType(column.Type, r.currentEnums)
+	columnType, err := r.processFieldType(column.Type, r.currentEnums)
+	if err != nil {
+		return "", err
+	}
 
 	// Column name and type
 	parts = append(parts, fmt.Sprintf("  %s %s", column.Name, columnType))
@@ -549,21 +583,25 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 }
 
 // processFieldType processes field type for PostgreSQL, handling enums appropriately
-func (r *Renderer) processFieldType(fieldType string, enums []string) string {
+func (r *Renderer) processFieldType(fieldType string, enums []string) (string, error) {
 	// For PostgreSQL, enum types are used directly (they're defined separately)
 	// Check if this type is an enum using the helper method
 	if r.isEnumType(fieldType, enums) {
-		return fieldType // Use enum type directly
+		return fieldType, nil // Use enum type directly
+	}
+
+	if strings.EqualFold(fieldType, "XML") && !r.capabilities().Has(capability.XMLType) {
+		return "", fmt.Errorf("%s does not support XML columns; use a platform-specific type override", r.dialect)
 	}
 
 	// Handle other PostgreSQL-specific type mappings if needed
 	switch fieldType {
 	case "AUTO_INCREMENT":
-		return "SERIAL"
+		return "SERIAL", nil
 	case "BIGINT AUTO_INCREMENT":
-		return "BIGSERIAL"
+		return "BIGSERIAL", nil
 	default:
-		return fieldType
+		return fieldType, nil
 	}
 }
 
@@ -583,6 +621,9 @@ func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, err
 		}
 		return fmt.Sprintf("  UNIQUE (%s)", strings.Join(constraint.Columns, ", ")), nil
 	case ast.ForeignKeyConstraint:
+		if !r.capabilities().Has(capability.ForeignKeys) {
+			return "", nil
+		}
 		return r.renderForeignKeyConstraint(constraint)
 	case ast.CheckConstraint:
 		if constraint.Name != "" {
@@ -664,7 +705,11 @@ func (r *Renderer) renderPostgreSQLModifyColumn(tableName string, column *ast.Co
 	// PostgreSQL requires separate ALTER statements for different column properties
 
 	// Process the column type with enum support
-	columnType := r.processFieldType(column.Type, r.currentEnums)
+	columnType, err := r.processFieldType(column.Type, r.currentEnums)
+	if err != nil {
+		r.w.WriteLinef("-- %s: %s", r.dialectUpper, err.Error())
+		return
+	}
 
 	// Change column type (with USING clause for complex conversions if needed)
 	if columnType != column.Type {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -167,9 +167,6 @@ func (r *Renderer) Dialect() string {
 }
 
 func (r *Renderer) capabilities() capability.Capabilities {
-	if r.caps == nil {
-		return capability.Postgres16()
-	}
 	return r.caps
 }
 

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -32,11 +32,12 @@ package renderer
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/clickhouse"
 	"github.com/stokaro/ptah/core/renderer/dialects/mariadb"
 	"github.com/stokaro/ptah/core/renderer/dialects/mysql"
@@ -46,7 +47,7 @@ import (
 
 // SupportedDialects returns a list of all supported database dialects.
 func SupportedDialects() []string {
-	return []string{"postgresql", "postgres", "mysql", "mariadb", "clickhouse"}
+	return []string{"postgresql", "postgres", "mysql", "mariadb", "clickhouse", "cockroachdb", "yugabytedb", "spanner"}
 }
 
 // NewRenderer creates a new renderer for the specified database dialect.
@@ -57,17 +58,19 @@ func SupportedDialects() []string {
 //
 // Returns an error if the dialect is not supported.
 func NewRenderer(dialect string) types.RenderVisitor {
-	normalizedDialect := strings.ToLower(strings.TrimSpace(dialect))
+	normalizedDialect := platform.NormalizeDialect(dialect)
 
 	switch normalizedDialect {
-	case "postgresql", "postgres":
+	case platform.Postgres:
 		return postgres.New()
-	case "mysql":
+	case platform.MySQL:
 		return mysql.New()
-	case "mariadb":
+	case platform.MariaDB:
 		return mariadb.New()
-	case "clickhouse":
+	case platform.ClickHouse:
 		return clickhouse.New()
+	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return postgres.NewWithCapabilities(capability.ForDialect(normalizedDialect), normalizedDialect)
 	default:
 		panic(fmt.Sprintf("unsupported database dialect: %s", dialect))
 	}

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -15,7 +15,7 @@ func TestSupportedDialects(t *testing.T) {
 	c := qt.New(t)
 
 	dialects := renderer.SupportedDialects()
-	expected := []string{"postgresql", "postgres", "mysql", "mariadb", "clickhouse"}
+	expected := []string{"postgresql", "postgres", "mysql", "mariadb", "clickhouse", "cockroachdb", "yugabytedb", "spanner"}
 
 	c.Assert(dialects, qt.DeepEquals, expected)
 }
@@ -50,6 +50,26 @@ func TestNewRenderer_SupportedDialects(t *testing.T) {
 			name:     "ClickHouse",
 			dialect:  "clickhouse",
 			expected: "clickhouse",
+		},
+		{
+			name:     "CockroachDB",
+			dialect:  "cockroachdb",
+			expected: "cockroachdb",
+		},
+		{
+			name:     "CockroachDB alias",
+			dialect:  "crdb",
+			expected: "cockroachdb",
+		},
+		{
+			name:     "YugabyteDB",
+			dialect:  "yugabytedb",
+			expected: "yugabytedb",
+		},
+		{
+			name:     "Spanner",
+			dialect:  "spanner",
+			expected: "spanner",
 		},
 		{
 			name:     "Case insensitive PostgreSQL",
@@ -115,6 +135,25 @@ func TestNewRenderer_UnsupportedDialects(t *testing.T) {
 			}, qt.PanicMatches, "unsupported database dialect: "+tt.dialect)
 		})
 	}
+}
+
+func TestPostgresFamilyRenderer_CapabilityGates(t *testing.T) {
+	c := qt.New(t)
+
+	idx := ast.NewIndex("idx_users_email", "users", "email").SetIfNotExists()
+	idx.Concurrently = true
+
+	sql, err := renderer.RenderSQL("cockroachdb", idx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);")
+	c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY",
+		qt.Commentf("CockroachDB renderer must strip a stray CONCURRENTLY flag; got:\n%s", sql))
+
+	xmlTable := ast.NewCreateTable("documents").
+		AddColumn(ast.NewColumn("id", "INT8").SetPrimary()).
+		AddColumn(ast.NewColumn("payload", "XML"))
+	_, err = renderer.RenderSQL("cockroachdb", xmlTable)
+	c.Assert(err, qt.ErrorMatches, `error rendering column payload: cockroachdb does not support XML columns; use a platform-specific type override`)
 }
 
 func TestRenderSQL_Success(t *testing.T) {

--- a/core/sqlutil/placeholders.go
+++ b/core/sqlutil/placeholders.go
@@ -3,6 +3,8 @@ package sqlutil
 import (
 	"strconv"
 	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
 )
 
 // Rebind converts portable `?` placeholders in query to the dialect's
@@ -22,8 +24,8 @@ import (
 // single-quoted literals and double-quoted identifiers. Apply Rebind to
 // known templates — never to user-supplied SQL.
 func Rebind(dialect, query string) string {
-	switch strings.ToLower(dialect) {
-	case "postgres", "postgresql", "pgx":
+	switch platform.NormalizeDialect(strings.ToLower(dialect)) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
 		return rebindToDollar(query)
 	default:
 		return query

--- a/core/sqlutil/placeholders_test.go
+++ b/core/sqlutil/placeholders_test.go
@@ -32,6 +32,24 @@ func TestRebind(t *testing.T) {
 			want:    "DELETE FROM t WHERE id = $1",
 		},
 		{
+			name:    "cockroachdb postgres-family placeholders",
+			dialect: "cockroachdb",
+			query:   "INSERT INTO t (a, b) VALUES (?, ?)",
+			want:    "INSERT INTO t (a, b) VALUES ($1, $2)",
+		},
+		{
+			name:    "yugabytedb postgres-family placeholders",
+			dialect: "yugabytedb",
+			query:   "SELECT ?",
+			want:    "SELECT $1",
+		},
+		{
+			name:    "spanner postgres-family placeholders",
+			dialect: "spanner",
+			query:   "DELETE FROM t WHERE id = ?",
+			want:    "DELETE FROM t WHERE id = $1",
+		},
+		{
 			name:    "case-insensitive dialect",
 			dialect: "PostgreSQL",
 			query:   "SELECT ?",

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/clickhouse"
 	"github.com/stokaro/ptah/dbschema/mysql"
 	"github.com/stokaro/ptah/dbschema/postgres"
@@ -49,7 +50,11 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 	}
 
 	// Determine the dialect
-	dialect := strings.ToLower(parsedURL.Scheme)
+	rawDialect := strings.ToLower(parsedURL.Scheme)
+	dialect := platform.NormalizeDialect(rawDialect)
+	if dialect == "" {
+		return nil, fmt.Errorf("unsupported database dialect: %s", rawDialect)
+	}
 
 	// Connect to the database
 	// For MySQL/MariaDB, we need to convert the URL format
@@ -57,17 +62,15 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 
 	var dialectProtocol string
 	switch dialect {
-	case "postgres", "postgresql", "pgx":
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
 		dialectProtocol = "pgx"
-		connectionString = removePostgresPoolParams(dbURL)
-	case "mysql", "mariadb":
+		connectionString = convertPostgresWireURL(dbURL)
+	case platform.MySQL, platform.MariaDB:
 		dialectProtocol = "mysql"
 		connectionString = convertMySQLURL(dbURL)
-	case "clickhouse":
+	case platform.ClickHouse:
 		dialectProtocol = "clickhouse"
 		connectionString = convertClickHouseURL(dbURL)
-	default:
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
 	}
 
 	db, err := sql.Open(dialectProtocol, connectionString)
@@ -236,7 +239,7 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 	}
 
 	switch dialect {
-	case "postgres":
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
 		// Get PostgreSQL version
 		var version string
 		err := db.QueryRowContext(ctx, "SELECT version()").Scan(&version)
@@ -244,6 +247,7 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 			return info, fmt.Errorf("failed to get PostgreSQL version: %w", err)
 		}
 		info.Version = version
+		info.Dialect = detectPostgresWireDialect(dialect, version)
 
 		// Get schema name (default to 'public' if not specified in URL)
 		schema := "public"
@@ -254,7 +258,7 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 		}
 		info.Schema = schema
 
-	case "mysql", "mariadb":
+	case platform.MySQL, platform.MariaDB:
 		// Get MySQL/MariaDB version
 		var version string
 		err := db.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version)
@@ -275,7 +279,7 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 			}
 			info.Schema = dbName
 		}
-	case "clickhouse":
+	case platform.ClickHouse:
 		var version string
 		if err := db.QueryRow("SELECT version()").Scan(&version); err != nil {
 			return info, fmt.Errorf("failed to get ClickHouse version: %w", err)
@@ -294,6 +298,20 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 	}
 
 	return info, nil
+}
+
+func detectPostgresWireDialect(declaredDialect, version string) string {
+	versionLower := strings.ToLower(version)
+	switch {
+	case strings.Contains(versionLower, "cockroachdb"):
+		return platform.CockroachDB
+	case strings.Contains(versionLower, "yugabytedb") || strings.Contains(versionLower, "yugabyte") || strings.Contains(versionLower, "-yb-"):
+		return platform.YugabyteDB
+	case strings.Contains(versionLower, "spanner"):
+		return platform.Spanner
+	default:
+		return platform.NormalizeDialect(declaredDialect)
+	}
 }
 
 // convertMySQLURL converts a MySQL/MariaDB URL from standard format to Go driver format
@@ -330,6 +348,22 @@ func convertMySQLURL(dbURL string) string {
 	}
 
 	return connectionString
+}
+
+func convertPostgresWireURL(dbURL string) string {
+	cleaned := removePostgresPoolParams(dbURL)
+	parsedURL, err := url.Parse(cleaned)
+	if err != nil {
+		return cleaned
+	}
+
+	switch platform.NormalizeDialect(parsedURL.Scheme) {
+	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		parsedURL.Scheme = platform.Postgres
+		return parsedURL.String()
+	default:
+		return cleaned
+	}
 }
 
 // convertClickHouseURL normalises a ClickHouse connection URL into the form

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
 
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema/clickhouse"
 	"github.com/stokaro/ptah/dbschema/mysql"
 	"github.com/stokaro/ptah/dbschema/postgres"
@@ -97,7 +98,7 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 	var writer types.SchemaWriter
 	switch dialectProtocol {
 	case "pgx":
-		reader = postgres.NewPostgreSQLReader(db, info.Schema)
+		reader = postgres.NewPostgreSQLReaderWithCapabilities(db, info.Schema, capability.ForDialect(info.Dialect))
 		writer = postgres.NewPostgreSQLWriter(db, info.Schema)
 	case "mysql":
 		reader = mysql.NewMySQLReader(db, info.Schema)

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -70,6 +70,94 @@ func TestConvertClickHouseURL(t *testing.T) {
 	}
 }
 
+func TestConvertPostgresWireURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "postgres passthrough with pool params removed",
+			input:    "postgres://user:pass@localhost:5432/app?pool_max_conns=10&sslmode=disable",
+			expected: "postgres://user:pass@localhost:5432/app?sslmode=disable",
+		},
+		{
+			name:     "cockroachdb scheme rewrites to postgres for pgx",
+			input:    "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable",
+			expected: "postgres://root@localhost:26257/defaultdb?sslmode=disable",
+		},
+		{
+			name:     "yugabytedb scheme rewrites to postgres for pgx",
+			input:    "yugabytedb://yugabyte@localhost:5433/yugabyte",
+			expected: "postgres://yugabyte@localhost:5433/yugabyte",
+		},
+		{
+			name:     "spanner scheme rewrites to postgres for pgx",
+			input:    "spanner://user@localhost:5432/db",
+			expected: "postgres://user@localhost:5432/db",
+		},
+		{
+			name:     "malformed URL falls back to cleaned input",
+			input:    "::not-a-url::",
+			expected: "::not-a-url::",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(convertPostgresWireURL(tt.input), qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestDetectPostgresWireDialect(t *testing.T) {
+	tests := []struct {
+		name     string
+		declared string
+		version  string
+		expected string
+	}{
+		{
+			name:     "plain postgres",
+			declared: "postgres",
+			version:  "PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1)",
+			expected: "postgres",
+		},
+		{
+			name:     "cockroach detected from postgres URL",
+			declared: "postgres",
+			version:  "CockroachDB CCL v23.2.5 (x86_64-pc-linux-gnu)",
+			expected: "cockroachdb",
+		},
+		{
+			name:     "yugabyte detected from postgres URL",
+			declared: "postgres",
+			version:  "PostgreSQL 11.2-YB-2.25.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang, YugabyteDB",
+			expected: "yugabytedb",
+		},
+		{
+			name:     "spanner detected from postgres URL",
+			declared: "postgres",
+			version:  "Cloud Spanner PostgreSQL interface",
+			expected: "spanner",
+		},
+		{
+			name:     "explicit cockroach survives generic banner",
+			declared: "cockroachdb",
+			version:  "PostgreSQL-compatible server",
+			expected: "cockroachdb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(detectPostgresWireDialect(tt.declared, tt.version), qt.Equals, tt.expected)
+		})
+	}
+}
+
 func TestRemovePostgresPoolParams(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -6,6 +6,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/testutils"
 )
@@ -36,9 +37,20 @@ func TestNewPostgreSQLReader(t *testing.T) {
 				c.Assert(reader, qt.IsNotNil)
 				c.Assert(reader.schema, qt.Equals, test.expectedSchema)
 				c.Assert(reader.db, qt.IsNil) // We passed nil for testing
+				c.Assert(reader.caps.Has(capability.RowLevelSecurity), qt.IsTrue)
 			})
 		}
 	})
+}
+
+func TestNewPostgreSQLReaderWithCapabilities(t *testing.T) {
+	c := qt.New(t)
+
+	reader := NewPostgreSQLReaderWithCapabilities(nil, "", capability.CockroachDB23())
+
+	c.Assert(reader.schema, qt.Equals, "public")
+	c.Assert(reader.caps.Has(capability.RowLevelSecurity), qt.IsFalse)
+	c.Assert(reader.caps.Has(capability.XMLType), qt.IsFalse)
 }
 
 func TestPostgreSQLReader_ReadSchema_NoConnection(t *testing.T) {

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
@@ -12,16 +13,24 @@ import (
 type Reader struct {
 	db     *sql.DB
 	schema string
+	caps   capability.Capabilities
 }
 
 // NewPostgreSQLReader creates a new PostgreSQL schema reader
 func NewPostgreSQLReader(db *sql.DB, schema string) *Reader {
+	return NewPostgreSQLReaderWithCapabilities(db, schema, capability.Postgres16())
+}
+
+// NewPostgreSQLReaderWithCapabilities creates a PostgreSQL-family schema reader
+// whose PostgreSQL-specific catalog reads are gated by target capabilities.
+func NewPostgreSQLReaderWithCapabilities(db *sql.DB, schema string, caps capability.Capabilities) *Reader {
 	if schema == "" {
 		schema = "public"
 	}
 	return &Reader{
 		db:     db,
 		schema: schema,
+		caps:   caps,
 	}
 }
 
@@ -71,12 +80,14 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Functions = functions
 
-	// Read RLS policies (PostgreSQL-specific)
-	rlsPolicies, err := r.readRLSPolicies()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read RLS policies: %w", err)
+	if r.caps.Has(capability.RowLevelSecurity) {
+		// Read RLS policies (PostgreSQL-specific)
+		rlsPolicies, err := r.readRLSPolicies()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read RLS policies: %w", err)
+		}
+		schema.RLSPolicies = rlsPolicies
 	}
-	schema.RLSPolicies = rlsPolicies
 
 	// Read roles (PostgreSQL-specific)
 	roles, err := r.readRoles()

--- a/docker-compose.override.yaml.example
+++ b/docker-compose.override.yaml.example
@@ -61,6 +61,18 @@ services:
     #   MARIADB_PASSWORD: ptah_password
     #   MARIADB_ROOT_PASSWORD: root_password
 
+  # CockroachDB Database Configuration
+  cockroachdb:
+    # Customize the port mapping if 26257 conflicts with your local services
+    ports:
+      - "26257:26257"  # Default: CockroachDB SQL on localhost:26257
+
+  # YugabyteDB Database Configuration
+  yugabytedb:
+    # Customize the port mapping if 5434 conflicts with your local services
+    ports:
+      - "5434:5433"  # Default: YugabyteDB YSQL on localhost:5434
+
   # Test Runner Service Configuration
   ptah-tester:
     # Override environment variables for local testing
@@ -68,6 +80,8 @@ services:
     #   POSTGRES_URL: "postgres://ptah_user:ptah_password@postgres:5432/ptah_test?sslmode=disable"
     #   MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(mysql:3306)/ptah_test"
     #   MARIADB_URL: "mysql://ptah_user:ptah_password@tcp(mariadb:3306)/ptah_test"
+    #   COCKROACHDB_URL: "cockroachdb://root@cockroachdb:26257/defaultdb?sslmode=disable"
+    #   YUGABYTEDB_URL: "yugabytedb://yugabyte@yugabytedb:5433/yugabyte?sslmode=disable"
     
     # Add additional volumes for development
     # volumes:
@@ -105,3 +119,4 @@ services:
 #   local_postgres_data:
 #   local_mysql_data:
 #   local_mariadb_data:
+#   local_cockroachdb_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,6 +68,36 @@ services:
       timeout: 5s
       retries: 10
 
+  cockroachdb:
+    image: cockroachdb/cockroach:v23.2.5
+    command:
+      - start-single-node
+      - --insecure
+      - --advertise-addr=localhost:26257
+    ports:
+      - "26257:26257"
+    volumes:
+      - cockroachdb_data:/cockroach/cockroach-data
+    healthcheck:
+      test: ["CMD", "/cockroach/cockroach", "sql", "--insecure", "--host=localhost:26257", "--execute=SELECT 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  yugabytedb:
+    image: yugabytedb/yugabyte:2026.1.0.0-b118
+    command:
+      - bash
+      - -lc
+      - ip=$$(hostname -i); ip=$${ip%% *}; exec bin/yugabyted start --daemon=false --advertise_address=$$ip --ui=false
+    ports:
+      - "5434:5433"
+    healthcheck:
+      test: ["CMD-SHELL", "ip=$$(hostname -i); ip=$${ip%% *}; bin/ysqlsh -h $$ip -p 5433 -U yugabyte -d yugabyte -c 'SELECT 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+
   # Test runner service
   ptah-tester:
     build:
@@ -82,11 +112,17 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
+      cockroachdb:
+        condition: service_healthy
+      yugabytedb:
+        condition: service_healthy
     environment:
       POSTGRES_URL: "postgres://ptah_user:ptah_password@postgres:5432/ptah_test?sslmode=disable"
       MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(mysql:3306)/ptah_test"
       MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(mariadb:3306)/ptah_test"
       CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@clickhouse:9000/ptah_test"
+      COCKROACHDB_URL: "cockroachdb://root@cockroachdb:26257/defaultdb?sslmode=disable"
+      YUGABYTEDB_URL: "yugabytedb://yugabyte@yugabytedb:5433/yugabyte?sslmode=disable"
     volumes:
       - ./integration/reports:/app/reports
       - ./integration/fixtures:/app/fixtures
@@ -98,3 +134,4 @@ volumes:
   mysql_data:
   mariadb_data:
   clickhouse_data:
+  cockroachdb_data:

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,11 +1,13 @@
 # Dialect capabilities
 
 Ptah maps several real database targets onto shared implementations: MySQL and
-MariaDB share one planner and one renderer family, and versions within a single
-dialect differ in which DDL they accept. Instead of forking a new dialect for
-every variant, planners and renderers consult a **capability set** — a
-validated `map[Capability]bool` describing what the concrete target accepts —
-and restrict or enable individual emissions accordingly (issues #225/#226).
+MariaDB share one planner and one renderer family; CockroachDB, YugabyteDB, and
+Spanner share the PostgreSQL family with target-specific capability presets;
+and versions within a single dialect differ in which DDL they accept. Instead
+of forking a new dialect for every variant, planners and renderers consult a
+**capability set** — a validated `map[Capability]bool` describing what the
+concrete target accepts — and restrict or enable individual emissions
+accordingly (issues #225/#226/#171).
 
 Package: `core/platform/capability`.
 
@@ -48,6 +50,10 @@ so typos fail fast. Current registry:
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
 | `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Reserved for the trigger work (#158) |
 | `row_level_security` | Row-level security policies (PostgreSQL) |
+| `foreign_keys` | Declarative `FOREIGN KEY` constraints |
+| `sequences` | Database sequence objects (`SERIAL`/`BIGSERIAL` or explicit `CREATE SEQUENCE` support) |
+| `xml_type` | PostgreSQL `XML` column type |
+| `advisory_locks` | PostgreSQL advisory lock functions such as `pg_advisory_lock` |
 
 ### Validation rules
 
@@ -67,24 +73,31 @@ composed sets yourself.
 
 ## Presets
 
-| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres16 | Postgres13 | ClickHouse24 |
-|---|---|---|---|---|---|---|---|---|
-| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
-| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres16 | Postgres13 | ClickHouse24 | CockroachDB23 | YugabyteDB25 | SpannerPG |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
+| `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 Version lines: `MySQL80()` covers MySQL 8.0.19+ and 9.x; `MySQL8016()` covers
 8.0.16–8.0.18; `MySQLLegacy()` anything older. `MariaDB1011()` covers the
 supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
 floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres16()` covers
 PostgreSQL 14+; `Postgres13()` covers 12–13 (no `CREATE OR REPLACE TRIGGER`).
+`CockroachDB23()` and `YugabyteDB25()` are PostgreSQL-family presets for the
+common distributed-SQL subset; `SpannerPostgres()` is deliberately conservative
+because Spanner's PostgreSQL interface is not a drop-in PostgreSQL server.
 
 ### Composition
 
@@ -99,14 +112,17 @@ planner := mysql.NewWithCapabilities(caps)
 ### Resolving a preset
 
 - `capability.ForDialect("mariadb")` — default preset for a dialect name
-  (aliases like `pgx`/`postgresql` normalize first). Used by `GetPlanner` and
-  the renderers.
+  (aliases like `pgx`/`postgresql`, `crdb`/`cockroachdb`,
+  `ysql`/`yugabytedb`, and `cloudspanner`/`spanner` normalize first). Used by
+  `GetPlanner` and the renderers.
 - `capability.ForServerVersion("mysql", version)` — refine using a live
   `SELECT version()` string. Recognizes shapes like `8.0.42-log`,
   `10.11.6-MariaDB-…`, the `5.5.5-10.11.6-MariaDB` replication-protocol prefix
   (MariaDB over the mysql driver resolves to the MariaDB preset), and
-  `PostgreSQL 16.3 (…)`. Wiring this into live connections at `read-db` /
-  `migrate` time is a follow-up.
+  `PostgreSQL 16.3 (…)`. PostgreSQL-wire banners containing `CockroachDB`,
+  `YugabyteDB`/`Yugabyte`, or `Spanner` resolve to their distributed-SQL
+  presets. `dbschema.ConnectToDatabase` uses this when populating
+  `conn.Info().Dialect`.
 
 ## Current consumers
 
@@ -144,10 +160,20 @@ planner := mysql.NewWithCapabilities(caps)
   because concurrent builds cannot run inside a transaction block (#152 tracks
   migrator support); a capability-less target (CockroachDB-style preset, #171)
   keeps plain `CREATE INDEX` regardless of policy.
+- **Distributed-SQL PostgreSQL-family adapters (#171).**
+  `platform.CockroachDB`, `platform.YugabyteDB`, and `platform.Spanner`
+  normalize as distinct dialects but reuse the PostgreSQL planner, renderer,
+  reader, and writer with capability presets:
+  CockroachDB disables `CREATE INDEX CONCURRENTLY`, `XML`, advisory locks, and
+  RLS; YugabyteDB disables `CREATE INDEX CONCURRENTLY` because regular
+  `CREATE INDEX` is already asynchronous in YSQL; Spanner disables enums,
+  foreign keys, sequences, RLS, XML, advisory locks, and concurrent indexes.
+  CockroachDB integration coverage is an opt-in common-subset scenario that
+  avoids SERIAL, XML, foreign keys, and concurrent indexes.
 
 ## Follow-ups
 
-- `SELECT version()` → preset wiring at connect time (`ForServerVersion` is
-  ready; the dbschema plumbing is tracked with #163/#152 work).
 - `create_or_replace_trigger` consumer lands with triggers (#158).
-- Distributed-SQL presets (CockroachDB / Yugabyte / Spanner) — #171.
+- Spanner remains lowest priority: the preset exists so callers get explicit
+  routing and conservative rendering, but full Spanner-specific DDL such as
+  interleaved tables is outside the PostgreSQL-family adapter.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -168,8 +168,10 @@ planner := mysql.NewWithCapabilities(caps)
   RLS; YugabyteDB disables `CREATE INDEX CONCURRENTLY` because regular
   `CREATE INDEX` is already asynchronous in YSQL; Spanner disables enums,
   foreign keys, sequences, RLS, XML, advisory locks, and concurrent indexes.
-  CockroachDB integration coverage is an opt-in common-subset scenario that
-  avoids SERIAL, XML, foreign keys, and concurrent indexes.
+  CockroachDB and YugabyteDB integration coverage uses opt-in common-subset
+  scenarios that run against live OSS containers in CI. Spanner currently has
+  capability, planning, rendering, URL, and detection coverage only; there is
+  no OSS Spanner PostgreSQL-interface container in the integration suite.
 
 ## Follow-ups
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,6 +1,6 @@
 # Ptah Migration Library Integration Tests
 
-This directory contains comprehensive integration tests for the Ptah migration library. The tests validate migration functionality across multiple database backends including PostgreSQL, MySQL, and MariaDB.
+This directory contains comprehensive integration tests for the Ptah migration library. The tests validate migration functionality across multiple database backends including PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets.
 
 ## Overview
 
@@ -135,6 +135,9 @@ docker compose --profile test run --rm ptah-tester --databases=mariadb
 
 # Test against specific combination
 docker compose --profile test run --rm ptah-tester --databases=postgres,mysql
+
+# Test the CockroachDB common-subset scenario when a CockroachDB URL is configured
+docker compose --profile test run --rm ptah-tester --databases=cockroachdb --scenarios=dynamic_cockroachdb_common_subset
 ```
 
 ### Combined Options
@@ -191,6 +194,12 @@ Rich, interactive report with:
 - Version: 16+
 - Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
 - Default schema: `public`
+
+### CockroachDB
+- Version: 23+
+- Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
+- Coverage: opt-in common subset only (`dynamic_cockroachdb_common_subset`)
+- Limitations: no `CREATE INDEX CONCURRENTLY`, XML columns, advisory locks, RLS, or sequence-dependent schema in the CockroachDB scenario
 
 ### MySQL
 - Version: 8+

--- a/integration/README.md
+++ b/integration/README.md
@@ -138,6 +138,9 @@ docker compose --profile test run --rm ptah-tester --databases=postgres,mysql
 
 # Test the CockroachDB common-subset scenario when a CockroachDB URL is configured
 docker compose --profile test run --rm ptah-tester --databases=cockroachdb --scenarios=dynamic_cockroachdb_common_subset
+
+# Test the YugabyteDB common-subset scenario when a YugabyteDB URL is configured
+docker compose --profile test run --rm ptah-tester --databases=yugabytedb --scenarios=dynamic_yugabytedb_common_subset
 ```
 
 ### Combined Options
@@ -150,7 +153,7 @@ docker compose --profile test run --rm ptah-tester --report=html --verbose
 docker compose --profile test run --rm ptah-tester --scenarios=apply_incremental_migrations --databases=postgres --report=txt
 
 # CI/CD friendly execution
-docker compose --profile test run --rm ptah-tester --report=json --databases=postgres,mysql,mariadb
+docker compose --profile test run --rm ptah-tester --report=json --databases=postgres,mysql,mariadb,cockroachdb,yugabytedb
 ```
 
 ## Command Line Options
@@ -158,7 +161,7 @@ docker compose --profile test run --rm ptah-tester --report=json --databases=pos
 ### Main Test Command
 
 - `--report` - Report format: `txt`, `json`, or `html` (default: `txt`)
-- `--databases` - Comma-separated list of databases to test (default: `postgres,mysql,mariadb`)
+- `--databases` - Comma-separated list of databases to test (default: `postgres,mysql,mariadb,cockroachdb,yugabytedb`)
 - `--scenarios` - Comma-separated list of specific scenarios to run (default: all)
 - `--verbose` - Enable verbose output
 
@@ -200,6 +203,12 @@ Rich, interactive report with:
 - Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
 - Coverage: opt-in common subset only (`dynamic_cockroachdb_common_subset`)
 - Limitations: no `CREATE INDEX CONCURRENTLY`, XML columns, advisory locks, RLS, or sequence-dependent schema in the CockroachDB scenario
+
+### YugabyteDB
+- Version: 2.25+
+- Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
+- Coverage: opt-in common subset only (`dynamic_yugabytedb_common_subset`)
+- Limitations: no `CREATE INDEX CONCURRENTLY`, XML columns, RLS, or sequence-dependent schema in the YugabyteDB scenario
 
 ### MySQL
 - Version: 8+

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
@@ -115,6 +116,12 @@ type TestScenario struct {
 	// ClickHouse with a single recorded "Skip" step rather than running
 	// them and producing confusing failures.
 	ClickHouseCompatible bool
+	// PostgresDistributedCompatible opts a scenario in to running against
+	// PostgreSQL-family distributed-SQL targets. Default false because many
+	// existing scenarios exercise PostgreSQL features outside the common
+	// distributed-SQL subset (functions, RLS, roles, XML, and concurrent
+	// index policy).
+	PostgresDistributedCompatible bool
 }
 
 // TestRunner manages and executes integration tests
@@ -220,6 +227,18 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 		result.Duration = time.Since(start)
 		return result
 	}
+	if isPostgresDistributedSQL(conn.Info().Dialect) && !scenario.PostgresDistributedCompatible {
+		recorder := &StepRecorder{}
+		_ = recorder.RecordStep(
+			"Skip Non-Distributed-SQL-Compatible Scenario",
+			"Scenario has not opted in via PostgresDistributedCompatible; skipping on PostgreSQL-family distributed SQL",
+			func() error { return nil },
+		)
+		result.Success = true
+		result.Steps = recorder.GetSteps()
+		result.Duration = time.Since(start)
+		return result
+	}
 
 	// Clean database before test
 	if err := tr.cleanDatabase(ctx, conn); err != nil {
@@ -253,6 +272,15 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 
 	result.Duration = time.Since(start)
 	return result
+}
+
+func isPostgresDistributedSQL(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return true
+	default:
+		return false
+	}
 }
 
 // cleanDatabase drops all tables and resets the database to a clean state
@@ -562,9 +590,9 @@ func GetMigrationsFS(fixtures fs.FS, conn *dbschema.DatabaseConnection, migratio
 	// Try database-specific migrations first
 	var migrationPath string
 	switch dialect {
-	case "mysql", "mariadb":
+	case platform.MySQL, platform.MariaDB:
 		migrationPath = fmt.Sprintf("migrations/%s_mysql", migrationType)
-	case "postgres":
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
 		migrationPath = fmt.Sprintf("migrations/%s", migrationType) // PostgreSQL uses the default
 	default:
 		migrationPath = fmt.Sprintf("migrations/%s", migrationType) // Fallback to default

--- a/integration/scenarios_cockroachdb_common.go
+++ b/integration/scenarios_cockroachdb_common.go
@@ -1,0 +1,68 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema"
+)
+
+// testCockroachDBCommonSubset validates the PostgreSQL-family common subset
+// that CockroachDB accepts without relying on PostgreSQL-only features such as
+// SERIAL, XML, foreign keys, advisory locks, or CREATE INDEX CONCURRENTLY.
+func testCockroachDBCommonSubset(ctx context.Context, conn *dbschema.DatabaseConnection, _ fs.FS, recorder *StepRecorder) error {
+	if conn.Info().Dialect != platform.CockroachDB {
+		return recorder.RecordStep("Skip Non-CockroachDB", "Common subset scenario is CockroachDB-only", func() error {
+			return nil
+		})
+	}
+
+	createUsers := ast.NewCreateTable("crdb_common_users").
+		AddColumn(ast.NewColumn("id", "INT8").SetPrimary()).
+		AddColumn(ast.NewColumn("email", "STRING").SetNotNull()).
+		AddColumn(ast.NewColumn("profile", "JSONB"))
+	createEmailIndex := ast.NewIndex("idx_crdb_common_users_email", "crdb_common_users", "email").
+		SetIfNotExists()
+
+	var sqlText string
+	if err := recorder.RecordStep("Render CockroachDB DDL", "Render common-subset table and index through the CockroachDB renderer", func() error {
+		var err error
+		sqlText, err = renderer.RenderSQL(platform.CockroachDB, createUsers, createEmailIndex)
+		if err != nil {
+			return fmt.Errorf("render CockroachDB SQL: %w", err)
+		}
+		if strings.Contains(sqlText, "CONCURRENTLY") {
+			return fmt.Errorf("CockroachDB common-subset SQL must not contain CONCURRENTLY:\n%s", sqlText)
+		}
+		if strings.Contains(sqlText, "XML") {
+			return fmt.Errorf("CockroachDB common-subset SQL must not contain XML:\n%s", sqlText)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := recorder.RecordStep("Apply CockroachDB DDL", "Apply rendered common-subset SQL to the live CockroachDB connection", func() error {
+		return conn.Writer().ExecuteSQL(ctx, sqlText)
+	}); err != nil {
+		return err
+	}
+
+	return recorder.RecordStep("Read CockroachDB Schema", "Verify the created table is visible through the PostgreSQL-family reader", func() error {
+		schema, err := conn.Reader().ReadSchema()
+		if err != nil {
+			return fmt.Errorf("read CockroachDB schema: %w", err)
+		}
+		for _, table := range schema.Tables {
+			if table.Name == "crdb_common_users" {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected crdb_common_users table in CockroachDB schema")
+	})
+}

--- a/integration/scenarios_cockroachdb_common.go
+++ b/integration/scenarios_cockroachdb_common.go
@@ -22,47 +22,75 @@ func testCockroachDBCommonSubset(ctx context.Context, conn *dbschema.DatabaseCon
 		})
 	}
 
-	createUsers := ast.NewCreateTable("crdb_common_users").
-		AddColumn(ast.NewColumn("id", "INT8").SetPrimary()).
-		AddColumn(ast.NewColumn("email", "STRING").SetNotNull()).
+	return testPostgresDistributedCommonSubset(ctx, conn, recorder, "CockroachDB", "crdb_common_users")
+}
+
+// testYugabyteDBCommonSubset validates the same conservative PostgreSQL-family
+// common subset against a live YugabyteDB YSQL connection.
+func testYugabyteDBCommonSubset(ctx context.Context, conn *dbschema.DatabaseConnection, _ fs.FS, recorder *StepRecorder) error {
+	if conn.Info().Dialect != platform.YugabyteDB {
+		return recorder.RecordStep("Skip Non-YugabyteDB", "Common subset scenario is YugabyteDB-only", func() error {
+			return nil
+		})
+	}
+
+	return testPostgresDistributedCommonSubset(ctx, conn, recorder, "YugabyteDB", "yb_common_users")
+}
+
+func testPostgresDistributedCommonSubset(ctx context.Context, conn *dbschema.DatabaseConnection, recorder *StepRecorder, label, tableName string) error {
+	createUsers := ast.NewCreateTable(tableName).
+		AddColumn(ast.NewColumn("id", "BIGINT").SetPrimary()).
+		AddColumn(ast.NewColumn("email", "TEXT").SetNotNull()).
 		AddColumn(ast.NewColumn("profile", "JSONB"))
-	createEmailIndex := ast.NewIndex("idx_crdb_common_users_email", "crdb_common_users", "email").
-		SetIfNotExists()
+	createEmailIndex := ast.NewIndex("idx_"+tableName+"_email", tableName, "email").SetIfNotExists()
 
 	var sqlText string
-	if err := recorder.RecordStep("Render CockroachDB DDL", "Render common-subset table and index through the CockroachDB renderer", func() error {
+	if err := recorder.RecordStep("Render "+label+" DDL", "Render common-subset table and index through the distributed-SQL renderer", func() error {
 		var err error
-		sqlText, err = renderer.RenderSQL(platform.CockroachDB, createUsers, createEmailIndex)
+		sqlText, err = renderer.RenderSQL(conn.Info().Dialect, createUsers, createEmailIndex)
 		if err != nil {
-			return fmt.Errorf("render CockroachDB SQL: %w", err)
+			return fmt.Errorf("render %s SQL: %w", label, err)
 		}
 		if strings.Contains(sqlText, "CONCURRENTLY") {
-			return fmt.Errorf("CockroachDB common-subset SQL must not contain CONCURRENTLY:\n%s", sqlText)
+			return fmt.Errorf("%s common-subset SQL must not contain CONCURRENTLY:\n%s", label, sqlText)
 		}
 		if strings.Contains(sqlText, "XML") {
-			return fmt.Errorf("CockroachDB common-subset SQL must not contain XML:\n%s", sqlText)
+			return fmt.Errorf("%s common-subset SQL must not contain XML:\n%s", label, sqlText)
 		}
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	if err := recorder.RecordStep("Apply CockroachDB DDL", "Apply rendered common-subset SQL to the live CockroachDB connection", func() error {
-		return conn.Writer().ExecuteSQL(ctx, sqlText)
+	if err := recorder.RecordStep("Apply "+label+" DDL", "Apply rendered common-subset SQL to the live distributed-SQL connection", func() error {
+		writer := conn.Writer()
+		if err := writer.BeginTransaction(); err != nil {
+			return fmt.Errorf("begin %s transaction: %w", label, err)
+		}
+		defer func() {
+			_ = writer.RollbackTransaction()
+		}()
+		if err := writer.ExecuteSQL(ctx, sqlText); err != nil {
+			return fmt.Errorf("apply %s SQL: %w", label, err)
+		}
+		if err := writer.CommitTransaction(); err != nil {
+			return fmt.Errorf("commit %s transaction: %w", label, err)
+		}
+		return nil
 	}); err != nil {
 		return err
 	}
 
-	return recorder.RecordStep("Read CockroachDB Schema", "Verify the created table is visible through the PostgreSQL-family reader", func() error {
+	return recorder.RecordStep("Read "+label+" Schema", "Verify the created table is visible through the PostgreSQL-family reader", func() error {
 		schema, err := conn.Reader().ReadSchema()
 		if err != nil {
-			return fmt.Errorf("read CockroachDB schema: %w", err)
+			return fmt.Errorf("read %s schema: %w", label, err)
 		}
 		for _, table := range schema.Tables {
-			if table.Name == "crdb_common_users" {
+			if table.Name == tableName {
 				return nil
 			}
 		}
-		return fmt.Errorf("expected crdb_common_users table in CockroachDB schema")
+		return fmt.Errorf("expected %s table in %s schema", tableName, label)
 	})
 }

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -278,6 +278,12 @@ func GetDynamicScenarios() []TestScenario {
 			EnhancedTestFunc:              testCockroachDBCommonSubset,
 			PostgresDistributedCompatible: true,
 		},
+		{
+			Name:                          "dynamic_yugabytedb_common_subset",
+			Description:                   "Test YugabyteDB common PostgreSQL-compatible subset without SERIAL, XML, or concurrent indexes",
+			EnhancedTestFunc:              testYugabyteDBCommonSubset,
+			PostgresDistributedCompatible: true,
+		},
 	}
 }
 

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -272,6 +272,12 @@ func GetDynamicScenarios() []TestScenario {
 			EnhancedTestFunc:     testClickHouseMergeTreeEngine,
 			ClickHouseCompatible: true,
 		},
+		{
+			Name:                          "dynamic_cockroachdb_common_subset",
+			Description:                   "Test CockroachDB common PostgreSQL-compatible subset without SERIAL, XML, foreign keys, or concurrent indexes",
+			EnhancedTestFunc:              testCockroachDBCommonSubset,
+			PostgresDistributedCompatible: true,
+		},
 	}
 }
 

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -55,8 +55,8 @@ func TestGetDynamicScenarios(t *testing.T) {
 
 	scenarios := GetDynamicScenarios()
 
-	// Should have exactly 43 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169 + 1 FK action evolution scenario for issue #196 + 1 CockroachDB common-subset scenario for issue #171)
-	c.Assert(scenarios, qt.HasLen, 43)
+	// Should have exactly 44 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169 + 1 FK action evolution scenario for issue #196 + 2 distributed-SQL common-subset scenarios for issue #171)
+	c.Assert(scenarios, qt.HasLen, 44)
 
 	// Verify all scenarios have required fields
 	for _, scenario := range scenarios {

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -55,8 +55,8 @@ func TestGetDynamicScenarios(t *testing.T) {
 
 	scenarios := GetDynamicScenarios()
 
-	// Should have exactly 42 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169 + 1 FK action evolution scenario for issue #196)
-	c.Assert(scenarios, qt.HasLen, 42)
+	// Should have exactly 43 dynamic scenarios (28 original + 5 RLS down migration scenarios + 5 role scenarios + 2 fixture-coverage scenarios for PR #123 / issue #89 + 1 ClickHouse MergeTree scenario for issue #169 + 1 FK action evolution scenario for issue #196 + 1 CockroachDB common-subset scenario for issue #171)
+	c.Assert(scenarios, qt.HasLen, 43)
 
 	// Verify all scenarios have required fields
 	for _, scenario := range scenarios {

--- a/migration/planner/capability_wiring_test.go
+++ b/migration/planner/capability_wiring_test.go
@@ -6,6 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -45,4 +46,24 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 		c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 			qt.Commentf("MySQL output must be byte-identical to the pre-capability planner; got:\n%s", sql))
 	})
+}
+
+func TestGetPlanner_DistributedSQLCapabilityWiring(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{IndexesAdded: []string{"idx_users_email"}}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email"}},
+		},
+	}
+
+	nodes := planner.GenerateSchemaDiffAST(diff, generated, platform.CockroachDB)
+	sql, err := renderer.RenderSQL(platform.CockroachDB, nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);",
+		qt.Commentf("got:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY",
+		qt.Commentf("CockroachDB must stay on plain CREATE INDEX; got:\n%s", sql))
 }

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -204,6 +204,8 @@ func GetPlanner(dialect string) Planner {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
 		return postgres.New()
+	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return postgres.NewWithCapabilities(capability.ForDialect(dialect))
 	case platform.MySQL:
 		return mysql.New()
 	case platform.MariaDB:

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -33,6 +33,21 @@ func TestGetPlanner(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "cockroachdb planner",
+			dialect: platform.CockroachDB,
+			wantErr: false,
+		},
+		{
+			name:    "yugabytedb planner",
+			dialect: platform.YugabyteDB,
+			wantErr: false,
+		},
+		{
+			name:    "spanner planner",
+			dialect: platform.Spanner,
+			wantErr: false,
+		},
+		{
 			name:    "unknown dialect",
 			dialect: "unknown",
 			wantErr: true,


### PR DESCRIPTION
## What

- Add platform constants and aliases for CockroachDB, YugabyteDB, and Spanner.
- Add PostgreSQL-family capability presets and wire them into planner, renderer, placeholder rebinding, and connection version detection.
- Add an opt-in CockroachDB common-subset integration scenario and document distributed-SQL limitations.

## Validation

- env GOCACHE=/private/tmp/ptah-go-build go test ./...
- env GOCACHE=/private/tmp/ptah-go-build GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache make lint
- git diff --check

Closes #171