### PR TITLE
Feat(lint): add `ptah lint` migration linter with rule-coded findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Provides command-line interface for all Ptah operations:
 - **`read-db`** - Read and display current database schema
 - **`compare`** - Compare Go entities with current database schema
 - **`drift`** - Check live database drift with CI-friendly exit codes
+- **`lint`** - Lint migration files for production-unsafe patterns (rule-coded, CI-friendly)
 - **`migrate`** - Generate migration SQL for schema differences
 - **`migrate-up`** - Apply migrations to bring database up to latest version
 - **`migrate-down`** - Roll back migrations to previous versions
@@ -488,6 +489,30 @@ jobs:
       - name: Fail workflow on drift
         if: steps.drift.outcome == 'failure'
         run: exit 1
+```
+
+#### Lint Migration Files
+Inspect a migrations directory for production-unsafe patterns, sqlcheck-style:
+
+```bash
+./package-migrator lint --dir ./migrations --dialect postgres
+```
+
+Findings carry stable rule codes grouped into families:
+
+- `DS` - data safety: `DS101` dropped table, `DS102` dropped column, `DS103` lossy column type change
+- `MF` - migration form: `MF101` missing down file, `MF102` empty migration, `MF103` non-conventional file name
+- `BC` - backwards compatibility: `BC101` rename breaking deployed code
+- `PG` - PostgreSQL: `PG101` `CREATE INDEX` without `CONCURRENTLY`, `PG102` `ALTER TYPE ... ADD VALUE` in a transaction
+- `MY` - MySQL/MariaDB: `MY101` lock-heavy `ALTER TABLE` forms
+
+Exit codes mirror `drift`: `0` clean (for the selected threshold), `1` findings above `--fail-on` (`error` by default; `any`, `none`), `2` command error. `--format text|json|github-actions` selects the output; the GitHub format annotates PR files inline. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
+
+```yaml
+dialect: postgres
+disabled-rules:
+  - MF103
+  - MY
 ```
 
 #### Generate Migration SQL

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ Findings carry stable rule codes grouped into families:
 - `PG` - PostgreSQL: `PG101` `CREATE INDEX` without `CONCURRENTLY`, `PG102` `ALTER TYPE ... ADD VALUE` in a transaction
 - `MY` - MySQL/MariaDB: `MY101` lock-heavy `ALTER TABLE` forms
 
+`--dialect` both gates the dialect-specific rule families and selects the dialect's SQL syntax for scanning (MySQL `#` comments, `/*!...*/` executable comments and backslash string escapes; PostgreSQL dollar quotes and nested block comments). With no dialect set, every rule runs under a hybrid scanner.
+
 Exit codes mirror `drift`: `0` clean (for the selected threshold), `1` findings above `--fail-on` (`error` by default; `any`, `none`), `2` command error. `--format text|json|github-actions` selects the output; the GitHub format annotates PR files inline. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
 
 ```yaml

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -1,0 +1,322 @@
+// Package lint implements the `ptah lint` command: a sqlcheck-style linter
+// for migration directories with rule-coded findings (issue #151).
+package lint
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/lint"
+)
+
+const (
+	formatText          = "text"
+	formatJSON          = "json"
+	formatGitHubActions = "github-actions"
+
+	failOnError = "error"
+	failOnAny   = "any"
+	failOnNone  = "none"
+)
+
+var errLintFindings = errors.New("lint findings exceed the failure threshold")
+
+// NewLintCommand returns the migration-linter command.
+func NewLintCommand() *cobra.Command {
+	var dir string
+	var dialect string
+	var format string
+	var configPath string
+	var disabled []string
+	var failOn string
+
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Lint migration files for production-unsafe patterns",
+		Long: `Lint inspects every *.sql file in a migrations directory and reports
+rule-coded findings, sqlcheck-style:
+
+  DS  data safety (dropped tables/columns, lossy type changes)
+  MF  migration form (missing down file, empty migration, naming)
+  BC  backwards compatibility (renames breaking deployed code)
+  PG  PostgreSQL-specific hazards (CREATE INDEX without CONCURRENTLY, ...)
+  MY  MySQL/MariaDB-specific hazards (lock-heavy ALTER TABLE forms)
+
+Statement rules run against up migrations; file-form rules cover every file.
+Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runLint(cmd, runOptions{
+				dir:        dir,
+				dialect:    dialect,
+				format:     format,
+				configPath: configPath,
+				disabled:   disabled,
+				failOn:     failOn,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	cmd.Flags().StringVar(&dialect, "dialect", "", "Target dialect gating dialect-specific rules: postgres, mysql or mariadb (empty runs every rule)")
+	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+lint.ConfigFileName+" when present)")
+	cmd.Flags().StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DS101 or MY (repeatable)")
+	cmd.Flags().StringVar(&failOn, "fail-on", failOnError, "Failure threshold controlling the exit code: error, any or none")
+
+	// Flag-parse errors (unknown flags and the like) must surface a message
+	// and exit 2 like every other usage error, not vanish under SilenceErrors.
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		fmt.Fprintf(c.ErrOrStderr(), "error: %s\n", err)
+		return exitcode.New(2, err)
+	})
+
+	return cmd
+}
+
+type runOptions struct {
+	dir        string
+	dialect    string
+	format     string
+	configPath string
+	disabled   []string
+	failOn     string
+}
+
+type lintReport struct {
+	Failed           bool           `json:"failed"`
+	FailureThreshold string         `json:"failure_threshold"`
+	Dialect          string         `json:"dialect,omitempty"`
+	Dir              string         `json:"dir,omitempty"`
+	DisabledRules    []string       `json:"disabled_rules,omitempty"`
+	Findings         []lint.Finding `json:"findings"`
+	Error            string         `json:"error,omitempty"`
+}
+
+func runLint(cmd *cobra.Command, opts runOptions) error {
+	if err := validateFormat(opts.format); err != nil {
+		return writeError(cmd.ErrOrStderr(), formatText, opts.failOn, err.Error())
+	}
+	if err := validateFailOn(opts.failOn); err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, failOnError, err.Error())
+	}
+	if err := validateDialect(opts.dialect); err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	if err := validateDir(opts.dir); err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+
+	cfg, err := loadConfig(opts)
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	if !isValidDialect(cfg.Dialect) {
+		msg := fmt.Sprintf("invalid dialect %q in lint config: expected postgres, mysql, or mariadb", cfg.Dialect)
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, msg)
+	}
+	// An explicitly passed --dialect wins even when set to "" (run every
+	// rule); an untouched flag defers to the config.
+	dialect := cfg.Dialect
+	if cmd.Flags().Changed("dialect") {
+		dialect = opts.dialect
+	}
+	disabled := append(append([]string{}, cfg.DisabledRules...), opts.disabled...)
+
+	findings, err := lint.LintFS(os.DirFS(opts.dir), lint.Options{
+		Dialect:    dialect,
+		Disabled:   disabled,
+		PathPrefix: filepath.ToSlash(opts.dir),
+	})
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	if findings == nil {
+		findings = []lint.Finding{}
+	}
+
+	failed := shouldFail(findings, opts.failOn)
+	report := lintReport{
+		Failed:           failed,
+		FailureThreshold: opts.failOn,
+		Dialect:          dialect,
+		Dir:              opts.dir,
+		DisabledRules:    disabled,
+		Findings:         findings,
+	}
+
+	writer := cmd.OutOrStdout()
+	if failed {
+		writer = cmd.ErrOrStderr()
+	}
+	if err := writeReport(writer, opts.format, report); err != nil {
+		return writeError(cmd.ErrOrStderr(), formatText, opts.failOn, err.Error())
+	}
+	if failed {
+		return exitcode.New(1, errLintFindings)
+	}
+	return nil
+}
+
+// loadConfig reads the explicit --config file, or the conventional
+// .ptah-lint.yaml inside the linted directory when present.
+func loadConfig(opts runOptions) (*lint.Config, error) {
+	if opts.configPath != "" {
+		if _, err := os.Stat(opts.configPath); err != nil {
+			return nil, fmt.Errorf("lint config %s: %w", opts.configPath, err)
+		}
+		return lint.LoadConfig(opts.configPath)
+	}
+	return lint.LoadConfig(filepath.Join(opts.dir, lint.ConfigFileName))
+}
+
+// shouldFail applies the --fail-on threshold to the findings.
+func shouldFail(findings []lint.Finding, failOn string) bool {
+	switch failOn {
+	case failOnNone:
+		return false
+	case failOnAny:
+		return len(findings) > 0
+	default: // failOnError
+		for _, f := range findings {
+			if f.Severity == lint.SeverityError {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func writeReport(w io.Writer, format string, report lintReport) error {
+	switch format {
+	case formatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	case formatGitHubActions:
+		writeGitHubActions(w, report)
+		return nil
+	default:
+		writeText(w, report)
+		return nil
+	}
+}
+
+func writeText(w io.Writer, report lintReport) {
+	if report.Error != "" {
+		fmt.Fprintf(w, "error: %s\n", report.Error)
+		return
+	}
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(w, "No lint findings.")
+		return
+	}
+	for _, f := range report.Findings {
+		fmt.Fprintln(w, lint.Describe(f))
+	}
+	fmt.Fprintf(w, "\n%d finding(s).\n", len(report.Findings))
+}
+
+func writeGitHubActions(w io.Writer, report lintReport) {
+	if report.Error != "" {
+		fmt.Fprintf(w, "::error::%s\n", escapeGHData(report.Error))
+		return
+	}
+	for _, f := range report.Findings {
+		level := "warning"
+		if f.Severity == lint.SeverityError {
+			level = "error"
+		}
+		file := escapeGHProperty(f.File)
+		message := escapeGHData(fmt.Sprintf("%s: %s", f.Rule, f.Message))
+		if f.Line > 0 {
+			fmt.Fprintf(w, "::%s file=%s,line=%d::%s\n", level, file, f.Line, message)
+			continue
+		}
+		fmt.Fprintf(w, "::%s file=%s::%s\n", level, file, message)
+	}
+}
+
+// escapeGHData escapes message text for GitHub Actions workflow commands.
+func escapeGHData(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+// escapeGHProperty escapes property values (file=...) for workflow commands,
+// which additionally reserve the separator characters.
+func escapeGHProperty(s string) string {
+	s = escapeGHData(s)
+	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
+	return s
+}
+
+func writeError(w io.Writer, format, failOn, msg string) error {
+	report := lintReport{
+		Failed:           true,
+		FailureThreshold: failOn,
+		Findings:         []lint.Finding{},
+		Error:            msg,
+	}
+	_ = writeReport(w, format, report)
+	return exitcode.New(2, errors.New(msg))
+}
+
+func validateFormat(format string) error {
+	switch format {
+	case formatText, formatJSON, formatGitHubActions:
+		return nil
+	default:
+		return fmt.Errorf("invalid --format value %q: expected text, json, or github-actions", format)
+	}
+}
+
+func validateFailOn(failOn string) error {
+	switch failOn {
+	case failOnError, failOnAny, failOnNone:
+		return nil
+	default:
+		return fmt.Errorf("invalid --fail-on value %q: expected error, any, or none", failOn)
+	}
+}
+
+func validateDialect(dialect string) error {
+	if isValidDialect(dialect) {
+		return nil
+	}
+	return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, or mariadb", dialect)
+}
+
+func isValidDialect(dialect string) bool {
+	switch dialect {
+	case "", "postgres", "mysql", "mariadb":
+		return true
+	default:
+		return false
+	}
+}
+
+// validateDir reports a usable error when the migrations directory itself is
+// missing, instead of the misleading "no *.sql migration files found".
+func validateDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("migrations directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("migrations directory %s: not a directory", dir)
+	}
+	return nil
+}

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -54,7 +54,7 @@ Statement rules run against up migrations; file-form rules cover every file.
 Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLint(cmd, runOptions{
 				dir:        dir,
 				dialect:    dialect,
@@ -62,6 +62,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 				configPath: configPath,
 				disabled:   disabled,
 				failOn:     failOn,
+				positional: args,
 			})
 		},
 	}
@@ -90,6 +91,7 @@ type runOptions struct {
 	configPath string
 	disabled   []string
 	failOn     string
+	positional []string
 }
 
 type lintReport struct {
@@ -111,6 +113,12 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 	}
 	if err := validateDialect(opts.dialect); err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	if len(opts.positional) > 0 {
+		// Silently linting the default --dir while the user pointed at
+		// another directory would be a silent false negative in CI.
+		msg := fmt.Sprintf("unexpected positional arguments %q: pass the migrations directory via --dir", opts.positional)
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, msg)
 	}
 	if err := validateDir(opts.dir); err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -143,6 +143,12 @@ func TestRunLint_InvalidFlagValuesExitCode2(t *testing.T) {
 	_, stderr, err = execute("--dir", "testdata/bad", "--no-such-flag")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(stderr, qt.Contains, "unknown flag")
+
+	// Positional arguments would silently lint the default --dir instead of
+	// what the user pointed at — a silent false negative in CI.
+	_, stderr, err = execute("testdata/bad")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "unexpected positional arguments")
 }
 
 func TestRunLint_ExplicitEmptyDialectOverridesConfig(t *testing.T) {
@@ -190,13 +196,13 @@ func TestWriteGitHubActions_EscapesWorkflowCommandCharacters(t *testing.T) {
 			Severity: lint.SeverityError,
 			File:     "dir/evil,file::name.sql",
 			Line:     3,
-			Message:  "50% data loss\nsecond line",
+			Message:  "50% data loss\r\nsecond line",
 		}},
 	})
 
 	out := buf.String()
 	c.Assert(out, qt.Contains, "::error file=dir/evil%2Cfile%3A%3Aname.sql,line=3::")
-	c.Assert(out, qt.Contains, "DS101: 50%25 data loss%0Asecond line")
+	c.Assert(out, qt.Contains, "DS101: 50%25 data loss%0D%0Asecond line")
 	c.Assert(out, qt.Not(qt.Contains), "evil,file::name")
 
 	buf.Reset()

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -1,0 +1,218 @@
+package lint
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/lint"
+)
+
+func execute(args ...string) (stdout, stderr string, err error) {
+	cmd := NewLintCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestNewLintCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewLintCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "lint")
+	c.Assert(cmd.Short, qt.Contains, "Lint")
+}
+
+func TestRunLint_CuratedFixtureProducesExpectedRuleHits(t *testing.T) {
+	c := qt.New(t)
+
+	_, stderr, err := execute("--dir", "testdata/bad", "--format", "json")
+
+	// The fixture contains DS errors, so the default --fail-on=error exits 1.
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	var report struct {
+		Failed   bool           `json:"failed"`
+		Findings []lint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stderr), &report), qt.IsNil)
+	c.Assert(report.Failed, qt.IsTrue)
+
+	rules := map[string]int{}
+	for _, f := range report.Findings {
+		rules[f.Rule]++
+	}
+	for _, want := range []string{"DS101", "DS102", "DS103", "BC101", "MF101", "MF102", "MF103", "PG101", "PG102", "MY101"} {
+		c.Assert(rules[want] >= 1, qt.IsTrue,
+			qt.Commentf("expected at least one %s hit; got rule tally %v", want, rules))
+	}
+}
+
+func TestRunLint_GitHubActionsFormatAnnotatesFileAndLine(t *testing.T) {
+	c := qt.New(t)
+
+	_, stderr, err := execute("--dir", "testdata/bad", "--format", "github-actions")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr, qt.Contains, "::error file=testdata/bad/0000000002_bad_stuff.up.sql,line=2::DS101:")
+	c.Assert(stderr, qt.Contains, "::warning file=testdata/bad/0000000002_bad_stuff.up.sql,line=10::PG101:")
+	c.Assert(stderr, qt.Contains, "::warning file=testdata/bad/misnamed.sql::MF103:")
+}
+
+func TestRunLint_ConfigFileDisablesRulesAndSetsDialect(t *testing.T) {
+	c := qt.New(t)
+
+	_, stderr, err := execute("--dir", "testdata/with-config", "--format", "json")
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf("DS errors remain, so the run still fails"))
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	var report struct {
+		Dialect  string         `json:"dialect"`
+		Findings []lint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stderr), &report), qt.IsNil)
+	c.Assert(report.Dialect, qt.Equals, "postgres")
+
+	for _, f := range report.Findings {
+		c.Assert(f.Rule, qt.Not(qt.Contains), "MF",
+			qt.Commentf("the MF family is disabled by .ptah-lint.yaml; got %v", f))
+		c.Assert(f.Rule, qt.Not(qt.Equals), "BC101")
+		c.Assert(f.Rule, qt.Not(qt.Equals), "MY101",
+			qt.Commentf("dialect: postgres from the config must gate MY rules; got %v", f))
+	}
+}
+
+func TestRunLint_FailOnThresholds(t *testing.T) {
+	c := qt.New(t)
+
+	// none: findings are reported but the exit code stays zero.
+	stdout, _, err := execute("--dir", "testdata/bad", "--fail-on", "none")
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "DS101")
+
+	// any: even warning-only runs fail. Disable the DS error rules and keep
+	// warnings; the exit code must still be 1.
+	_, _, err = execute("--dir", "testdata/bad", "--fail-on", "any", "--disable", "DS")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	// error (default): warnings alone do not fail.
+	stdout, _, err = execute("--dir", "testdata/bad", "--disable", "DS")
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "PG101")
+}
+
+func TestRunLint_InvalidFlagValuesExitCode2(t *testing.T) {
+	c := qt.New(t)
+
+	_, stderr, err := execute("--dir", "testdata/bad", "--format", "yaml")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "invalid --format")
+
+	_, stderr, err = execute("--dir", "testdata/bad", "--fail-on", "sometimes")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "invalid --fail-on")
+
+	_, stderr, err = execute("--dir", "testdata/bad", "--dialect", "oracle")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "invalid --dialect")
+
+	_, stderr, err = execute("--dir", "testdata/does-not-exist")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "migrations directory testdata/does-not-exist")
+
+	_, stderr, err = execute("--dir", "testdata/bad", "--config", "testdata/nope.yaml")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "lint config")
+
+	_, stderr, err = execute("--dir", "testdata/bad", "--config", "testdata/invalid-dialect.yaml")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, `invalid dialect "oracle" in lint config`)
+
+	_, stderr, err = execute("--dir", "testdata/bad", "--no-such-flag")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "unknown flag")
+}
+
+func TestRunLint_ExplicitEmptyDialectOverridesConfig(t *testing.T) {
+	c := qt.New(t)
+
+	// The config sets dialect: postgres; an explicit --dialect "" must win
+	// and re-enable the MY family.
+	_, stderr, err := execute("--dir", "testdata/with-config", "--format", "json", "--dialect", "")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	var report struct {
+		Dialect  string         `json:"dialect"`
+		Findings []lint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stderr), &report), qt.IsNil)
+	c.Assert(report.Dialect, qt.Equals, "")
+
+	rules := map[string]int{}
+	for _, f := range report.Findings {
+		rules[f.Rule]++
+	}
+	c.Assert(rules["MY101"] >= 1, qt.IsTrue,
+		qt.Commentf("explicit empty --dialect runs every rule; got tally %v", rules))
+}
+
+func TestRunLint_JSONReportsEmptyFindingsAsArray(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, _, err := execute("--dir", "testdata/clean", "--format", "json")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, `"findings": []`,
+		qt.Commentf("an empty findings list must serialize as [], not null; got: %s", stdout))
+}
+
+func TestWriteGitHubActions_EscapesWorkflowCommandCharacters(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	writeGitHubActions(&buf, lintReport{
+		Findings: []lint.Finding{{
+			Rule:     "DS101",
+			Severity: lint.SeverityError,
+			File:     "dir/evil,file::name.sql",
+			Line:     3,
+			Message:  "50% data loss\nsecond line",
+		}},
+	})
+
+	out := buf.String()
+	c.Assert(out, qt.Contains, "::error file=dir/evil%2Cfile%3A%3Aname.sql,line=3::")
+	c.Assert(out, qt.Contains, "DS101: 50%25 data loss%0Asecond line")
+	c.Assert(out, qt.Not(qt.Contains), "evil,file::name")
+
+	buf.Reset()
+	writeGitHubActions(&buf, lintReport{Error: "bad\nnews: 100%"})
+	c.Assert(buf.String(), qt.Equals, "::error::bad%0Anews: 100%25\n")
+}
+
+func TestShouldFail(t *testing.T) {
+	c := qt.New(t)
+
+	warning := []lint.Finding{{Severity: lint.SeverityWarning}}
+	fatal := []lint.Finding{{Severity: lint.SeverityError}}
+
+	c.Assert(shouldFail(nil, failOnError), qt.IsFalse)
+	c.Assert(shouldFail(warning, failOnError), qt.IsFalse)
+	c.Assert(shouldFail(fatal, failOnError), qt.IsTrue)
+	c.Assert(shouldFail(warning, failOnAny), qt.IsTrue)
+	c.Assert(shouldFail(fatal, failOnNone), qt.IsFalse)
+}

--- a/cmd/lint/testdata/bad/0000000001_create_users.down.sql
+++ b/cmd/lint/testdata/bad/0000000001_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/cmd/lint/testdata/bad/0000000001_create_users.up.sql
+++ b/cmd/lint/testdata/bad/0000000001_create_users.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL
+);

--- a/cmd/lint/testdata/bad/0000000002_bad_stuff.up.sql
+++ b/cmd/lint/testdata/bad/0000000002_bad_stuff.up.sql
@@ -1,0 +1,12 @@
+-- A curated pile of production hazards; -- semicolons in comments must not split statements.
+DROP TABLE audit_log;
+
+ALTER TABLE users DROP COLUMN legacy_flags;
+
+ALTER TABLE users RENAME COLUMN email TO email_address;
+
+ALTER TABLE users MODIFY COLUMN email VARCHAR(64) NOT NULL;
+
+CREATE INDEX idx_users_email ON users (email);
+
+ALTER TYPE mood ADD VALUE 'ambivalent';

--- a/cmd/lint/testdata/bad/0000000003_noop.down.sql
+++ b/cmd/lint/testdata/bad/0000000003_noop.down.sql
@@ -1,0 +1,1 @@
+-- nothing to undo

--- a/cmd/lint/testdata/bad/0000000003_noop.up.sql
+++ b/cmd/lint/testdata/bad/0000000003_noop.up.sql
@@ -1,0 +1,2 @@
+-- placeholder migration
+-- nothing here yet

--- a/cmd/lint/testdata/bad/misnamed.sql
+++ b/cmd/lint/testdata/bad/misnamed.sql
@@ -1,0 +1,1 @@
+CREATE TABLE stray (id INT);

--- a/cmd/lint/testdata/clean/0000000001_create_users.down.sql
+++ b/cmd/lint/testdata/clean/0000000001_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/cmd/lint/testdata/clean/0000000001_create_users.up.sql
+++ b/cmd/lint/testdata/clean/0000000001_create_users.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL
+);

--- a/cmd/lint/testdata/invalid-dialect.yaml
+++ b/cmd/lint/testdata/invalid-dialect.yaml
@@ -1,0 +1,1 @@
+dialect: oracle

--- a/cmd/lint/testdata/with-config/.ptah-lint.yaml
+++ b/cmd/lint/testdata/with-config/.ptah-lint.yaml
@@ -1,0 +1,4 @@
+dialect: postgres
+disabled-rules:
+  - MF
+  - BC101

--- a/cmd/lint/testdata/with-config/0000000001_create_users.down.sql
+++ b/cmd/lint/testdata/with-config/0000000001_create_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS users;

--- a/cmd/lint/testdata/with-config/0000000001_create_users.up.sql
+++ b/cmd/lint/testdata/with-config/0000000001_create_users.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL
+);

--- a/cmd/lint/testdata/with-config/0000000002_bad_stuff.up.sql
+++ b/cmd/lint/testdata/with-config/0000000002_bad_stuff.up.sql
@@ -1,0 +1,12 @@
+-- A curated pile of production hazards; -- semicolons in comments must not split statements.
+DROP TABLE audit_log;
+
+ALTER TABLE users DROP COLUMN legacy_flags;
+
+ALTER TABLE users RENAME COLUMN email TO email_address;
+
+ALTER TABLE users MODIFY COLUMN email VARCHAR(64) NOT NULL;
+
+CREATE INDEX idx_users_email ON users (email);
+
+ALTER TYPE mood ADD VALUE 'ambivalent';

--- a/cmd/lint/testdata/with-config/0000000003_noop.down.sql
+++ b/cmd/lint/testdata/with-config/0000000003_noop.down.sql
@@ -1,0 +1,1 @@
+-- nothing to undo

--- a/cmd/lint/testdata/with-config/0000000003_noop.up.sql
+++ b/cmd/lint/testdata/with-config/0000000003_noop.up.sql
@@ -1,0 +1,2 @@
+-- placeholder migration
+-- nothing here yet

--- a/cmd/lint/testdata/with-config/misnamed.sql
+++ b/cmd/lint/testdata/with-config/misnamed.sql
@@ -1,0 +1,1 @@
+CREATE TABLE stray (id INT);

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/cmd/dropall"
 	"github.com/stokaro/ptah/cmd/generate"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migratestatus"
@@ -52,6 +53,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
 	rootCmd.AddCommand(migratestatus.NewMigrateStatusCommand())
 	rootCmd.AddCommand(dropall.NewDropAllCommand())
+	rootCmd.AddCommand(lint.NewLintCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/text v0.40.0
 )
 
@@ -46,7 +47,6 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -1,0 +1,50 @@
+package lint
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// ConfigFileName is the conventional per-project lint configuration file,
+// looked up inside the linted migrations directory when no explicit config
+// path is given.
+const ConfigFileName = ".ptah-lint.yaml"
+
+// Config is the on-disk lint configuration.
+//
+// Example .ptah-lint.yaml:
+//
+//	dialect: postgres
+//	disabled-rules:
+//	  - MF103
+//	  - MY
+type Config struct {
+	// Dialect is the target dialect used to gate dialect-specific rules;
+	// the --dialect flag overrides it.
+	Dialect string `yaml:"dialect"`
+	// DisabledRules lists rule codes or family prefixes to skip; merged
+	// with --disable flags.
+	DisabledRules []string `yaml:"disabled-rules"`
+}
+
+// LoadConfig reads a lint configuration file. A missing file at the
+// conventional location is not an error — callers get an empty config — but
+// an unreadable or malformed file is.
+func LoadConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read lint config %s: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse lint config %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -12,14 +12,17 @@
 //
 // # How statements are matched
 //
-// Each *.up.sql file is split into statements with ptah's SQL lexer (so
-// dollar-quoted bodies and comments never confuse the splitter) and every
-// statement is checked in two complementary forms:
+// Each *.up.sql file is split into statements by a dialect-aware scanner:
+// string literals, quoted identifiers, comments (including the MySQL-family
+// # line comments and /*!...*/ executable comments) and PostgreSQL
+// dollar-quoted bodies never confuse the splitter, and Options.Dialect
+// selects which of those syntaxes apply. Every statement is then checked in
+// two complementary forms:
 //
-//   - a canonical text form — comments stripped, whitespace collapsed,
-//     keywords uppercased — that pattern rules match against, which keeps the
-//     rules robust for statements outside the DDL subset ptah's parser
-//     understands (DROP TABLE, ALTER TYPE, ...);
+//   - Statement.Words — the token-word sequence the built-in rules scan,
+//     anchored at ALTER TABLE clause boundaries; string literals and quoted
+//     identifiers stay opaque single words, so data or a column named like a
+//     keyword can neither trigger nor mask a rule;
 //   - a best-effort AST (Statement.Node) parsed with core/parser for the
 //     statements it supports, available to rules that want structural
 //     precision.
@@ -33,12 +36,12 @@ import (
 	"fmt"
 	"io/fs"
 	"path"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
-	"github.com/stokaro/ptah/core/lexer"
 	"github.com/stokaro/ptah/core/parser"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -93,15 +96,24 @@ type File struct {
 	// Path is the file path as it should appear in findings (reporting
 	// prefix included).
 	Path string
-	// Name is the bare file name inside the linted directory.
+	// Name is the slash-separated path of the file relative to the linted
+	// directory (bare file name for root-level files).
 	Name string
-	// IsUp reports whether this is an up migration (*.up.sql).
+	// Direction is the migration direction ("up"/"down") exactly as the
+	// migrator's name parser classifies this file; empty when the migrator
+	// cannot parse the name at all.
+	Direction string
+	// IsUp reports whether statement rules treat this as an up migration:
+	// the migrator parses it as up, or its name carries the .up.sql suffix.
 	IsUp bool
 	// HasPair reports whether the matching counterpart file (down for up,
 	// up for down) exists in the same directory.
 	HasPair bool
-	// WellFormedName reports whether the name matches the migrator's
-	// NNNNNNNNNN_description.(up|down).sql convention.
+	// WellFormedName reports whether the name matches the documented
+	// NNNNNNNNNN_description.(up|down).sql convention. The migrator's own
+	// parser is more lenient (see Direction), so a name can be parseable
+	// yet not well-formed — 0000000001_cleanup.sql parses as an up
+	// migration with a truncated description.
 	WellFormedName bool
 	// Statements holds the parsed statements of up migrations. Empty for
 	// down migrations (statement rules do not run there).
@@ -128,9 +140,11 @@ type Rule struct {
 
 // Options configures a lint run.
 type Options struct {
-	// Dialect gates dialect-specific rules: "postgres" enables PG rules,
-	// "mysql"/"mariadb" enable MY rules. Empty runs every rule — maximum
-	// visibility when the target is unknown.
+	// Dialect gates dialect-specific rules — "postgres" enables PG rules,
+	// "mysql"/"mariadb" enable MY rules — and selects the dialect's lexing
+	// behavior (comment forms, string escape rules, dollar quotes). Empty
+	// runs every rule under a hybrid lexer — maximum visibility when the
+	// target is unknown.
 	Dialect string
 	// Disabled lists rule codes or code prefixes to skip: "DS101" disables
 	// one rule, "DS" the whole data-safety family.
@@ -140,10 +154,22 @@ type Options struct {
 	PathPrefix string
 }
 
-// LintFS lints every *.sql file at the root of fsys and returns the findings
-// ordered by file, line and rule code.
+// LintFS lints every *.sql file under fsys — recursively, because the
+// migrator's FSMigrationProvider discovers migrations in subdirectories too —
+// and returns the findings ordered by file, line and rule code. The .sql
+// suffix is matched case-insensitively so that stray case variants (x.UP.SQL)
+// at least earn a naming warning instead of vanishing.
 func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
-	names, err := fs.Glob(fsys, "*.sql")
+	var names []string
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && strings.EqualFold(path.Ext(p), ".sql") {
+			names = append(names, p)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list migration files: %w", err)
 	}
@@ -157,9 +183,10 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 		present[name] = struct{}{}
 	}
 
+	mode := modeForDialect(opts.Dialect)
 	var findings []Finding
 	for _, name := range names {
-		file, err := prepareFile(fsys, name, present, opts.PathPrefix)
+		file, err := prepareFile(fsys, name, present, opts.PathPrefix, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -179,17 +206,26 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 }
 
 // prepareFile loads one migration file into the forms rules consume.
-func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefix string) (*File, error) {
+func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefix string, mode scanMode) (*File, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", name, err)
 	}
 
+	base := path.Base(name)
+	direction := ""
+	if parsed, parseErr := migrator.ParseMigrationFileName(base); parseErr == nil {
+		direction = parsed.Direction
+	}
 	file := &File{
-		Path:           path.Join(pathPrefix, name),
-		Name:           name,
-		IsUp:           strings.HasSuffix(name, ".up.sql"),
-		WellFormedName: migrator.ValidateMigrationFileName(name),
+		Path:      path.Join(pathPrefix, name),
+		Name:      name,
+		Direction: direction,
+		// The migrator executes whatever its parser classifies as up, so
+		// lint must follow it; the suffix check keeps hazard scanning for
+		// .up.sql files whose version prefix is malformed.
+		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
+		WellFormedName: strictNameRe.MatchString(base),
 	}
 	switch {
 	case file.IsUp:
@@ -200,11 +236,11 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefi
 
 	// Statement rules apply to up migrations only.
 	if file.IsUp {
-		for _, rawStmt := range splitStatementsWithLines(string(raw)) {
+		for _, rawStmt := range splitStatementsWithLines(string(raw), mode) {
 			file.Statements = append(file.Statements, Statement{
 				SQL:       rawStmt.text,
-				Canonical: canonicalize(rawStmt.text),
-				Words:     tokenizeWords(rawStmt.text),
+				Canonical: canonicalize(rawStmt.text, mode),
+				Words:     tokenizeWords(rawStmt.text, mode),
 				Node:      parseBestEffort(rawStmt.text),
 				Line:      rawStmt.line,
 			})
@@ -261,110 +297,94 @@ func ruleAppliesToDialect(rule Rule, dialect string) bool {
 	return slices.Contains(rule.Dialects, dialect)
 }
 
+// strictNameRe is the documented migration naming convention. The migrator's
+// own parser is more lenient — its regexp has an unescaped dot before the
+// direction, so 0000000001_cleanup.sql parses as an up migration — which is
+// why WellFormedName checks the strict form while Direction follows the
+// migrator.
+var strictNameRe = regexp.MustCompile(`^\d{10}_.+\.(up|down)\.sql$`)
+
 // rawStatement is one raw SQL statement plus the line it starts on.
 type rawStatement struct {
 	text string
 	line int
 }
 
-// splitStatementsWithLines splits SQL into statements using the lexer (so
-// semicolons inside strings, comments and dollar-quoted bodies do not
-// terminate statements) while tracking each statement's starting line.
-func splitStatementsWithLines(raw string) []rawStatement {
-	lexr := lexer.NewLexer(raw)
+// splitStatementsWithLines splits SQL into statements using the dialect-aware
+// scanner (so semicolons inside strings, comments, executable comments and
+// dollar-quoted bodies do not terminate statements) while tracking each
+// statement's starting line.
+func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
 	var statements []rawStatement
 	start := -1
 	end := 0
-	for {
-		tok := lexr.NextToken()
-		if tok.Type == lexer.TokenEOF {
-			break
-		}
-		switch tok.Type {
-		case lexer.TokenSemicolon:
+	startLine := 0
+	for _, tok := range scanSQL(raw, mode) {
+		switch tok.kind {
+		case tokSemicolon:
 			if start >= 0 {
-				statements = append(statements, rawStatement{
-					text: raw[start:end],
-					line: 1 + strings.Count(raw[:start], "\n"),
-				})
+				statements = append(statements, rawStatement{text: raw[start:end], line: startLine})
 				start = -1
 			}
-		case lexer.TokenWhitespace, lexer.TokenComment:
+		case tokWhitespace, tokComment:
 			// Never starts a statement; keep end untouched so trailing
 			// comments/whitespace are not included in the statement text.
 		default:
 			if start < 0 {
-				start = tok.Start
+				start = tok.start
+				startLine = tok.line
 			}
-			end = tok.End
+			end = tok.end
 		}
 	}
 	if start >= 0 {
-		statements = append(statements, rawStatement{
-			text: raw[start:end],
-			line: 1 + strings.Count(raw[:start], "\n"),
-		})
+		statements = append(statements, rawStatement{text: raw[start:end], line: startLine})
 	}
 	return statements
 }
 
-// canonicalize renders a statement in the form pattern rules match against:
-// comments removed, every whitespace run collapsed to one space, everything
-// except string literals uppercased.
-func canonicalize(sql string) string {
-	lexr := lexer.NewLexer(sql)
+// canonicalize renders a statement in its display form: comments removed,
+// every whitespace run collapsed to one space, everything except string
+// literals and quoted identifiers uppercased.
+func canonicalize(sql string, mode scanMode) string {
 	var b strings.Builder
 	pendingSpace := false
-	for {
-		tok := lexr.NextToken()
-		if tok.Type == lexer.TokenEOF {
-			break
-		}
-		switch tok.Type {
-		case lexer.TokenComment, lexer.TokenWhitespace:
+	for _, tok := range scanSQL(sql, mode) {
+		switch tok.kind {
+		case tokComment, tokWhitespace:
 			// A comment separates tokens exactly like whitespace does
 			// (DROP/*x*/TABLE must not canonicalize to DROPTABLE).
 			pendingSpace = b.Len() > 0
-		case lexer.TokenString:
+		case tokString, tokQuotedIdent:
 			if pendingSpace {
 				b.WriteByte(' ')
 				pendingSpace = false
 			}
-			b.WriteString(tok.Value)
+			b.WriteString(tok.text)
 		default:
 			if pendingSpace {
 				b.WriteByte(' ')
 				pendingSpace = false
 			}
-			b.WriteString(strings.ToUpper(tok.Value))
+			b.WriteString(strings.ToUpper(tok.text))
 		}
 	}
 	return b.String()
 }
 
 // tokenizeWords renders a statement as the word sequence rules scan (see
-// Statement.Words). Double-quoted identifiers arrive from the lexer as string
-// tokens and backtick-quoted ones as identifiers; both keep their quotes and
-// case, so quoted names never collide with SQL keywords in the scans.
-func tokenizeWords(sql string) []string {
-	lexr := lexer.NewLexer(sql)
+// Statement.Words). String literals and quoted identifiers keep their quotes
+// and case, so quoted names never collide with SQL keywords in the scans.
+func tokenizeWords(sql string, mode scanMode) []string {
 	var words []string
-	for {
-		tok := lexr.NextToken()
-		if tok.Type == lexer.TokenEOF {
-			break
-		}
-		switch tok.Type {
-		case lexer.TokenComment, lexer.TokenWhitespace:
+	for _, tok := range scanSQL(sql, mode) {
+		switch tok.kind {
+		case tokComment, tokWhitespace:
 			continue
-		case lexer.TokenString:
-			words = append(words, tok.Value)
+		case tokString, tokQuotedIdent:
+			words = append(words, tok.text)
 		default:
-			if strings.HasPrefix(tok.Value, "`") || strings.HasPrefix(tok.Value, `"`) {
-				words = append(words, tok.Value)
-				continue
-			}
-			words = append(words, strings.ToUpper(tok.Value))
+			words = append(words, strings.ToUpper(tok.text))
 		}
 	}
 	return words

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -1,0 +1,381 @@
+// Package lint inspects migration files for production-unsafe patterns and
+// emits rule-coded findings, in the spirit of sqlcheck and `atlas migrate
+// lint` (issue #151).
+//
+// # Rule codes
+//
+//   - DS — data safety (dropping tables/columns, lossy type changes)
+//   - MF — migration form (missing down file, empty migration, naming)
+//   - BC — backwards compatibility (renames breaking deployed readers)
+//   - PG — PostgreSQL-specific hazards
+//   - MY — MySQL/MariaDB-specific hazards
+//
+// # How statements are matched
+//
+// Each *.up.sql file is split into statements with ptah's SQL lexer (so
+// dollar-quoted bodies and comments never confuse the splitter) and every
+// statement is checked in two complementary forms:
+//
+//   - a canonical text form — comments stripped, whitespace collapsed,
+//     keywords uppercased — that pattern rules match against, which keeps the
+//     rules robust for statements outside the DDL subset ptah's parser
+//     understands (DROP TABLE, ALTER TYPE, ...);
+//   - a best-effort AST (Statement.Node) parsed with core/parser for the
+//     statements it supports, available to rules that want structural
+//     precision.
+//
+// Statement-level rules run on up migrations only: a down migration dropping
+// what its up created is the expected shape, not a hazard. File-level form
+// rules (naming, pairing) look at every *.sql file.
+package lint
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/parser"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// Severity is the urgency of a finding.
+type Severity string
+
+const (
+	// SeverityWarning marks patterns that deserve review before a prod
+	// rollout but are not necessarily destructive.
+	SeverityWarning Severity = "warning"
+	// SeverityError marks patterns that destroy data or database objects.
+	SeverityError Severity = "error"
+)
+
+// Finding is one rule hit in one migration file.
+type Finding struct {
+	Rule     string   `json:"rule"`
+	Title    string   `json:"title"`
+	Severity Severity `json:"severity"`
+	File     string   `json:"file"`
+	// Line is the 1-based line of the offending statement's first token;
+	// zero for file-level findings (naming, pairing).
+	Line    int    `json:"line,omitempty"`
+	Message string `json:"message"`
+}
+
+// Statement is one SQL statement of a migration file, in the forms rules
+// consume.
+type Statement struct {
+	// SQL is the raw statement text as written (comments included).
+	SQL string
+	// Canonical is the comment-stripped, whitespace-collapsed, uppercased
+	// display form. String literals keep their original case.
+	Canonical string
+	// Words is the token-word sequence the built-in rules scan: comments and
+	// whitespace dropped, bare keywords/identifiers uppercased, punctuation
+	// as its own entry, string literals and quoted identifiers kept verbatim
+	// as single opaque words (so a literal containing "DROP COLUMN" or a
+	// column named "type" can never impersonate a keyword).
+	Words []string
+	// Node is the best-effort parse of the statement into ptah's DDL AST;
+	// nil when the statement is outside the parser's supported subset.
+	// Word-scan rules must not rely on it.
+	Node ast.Node
+	// Line is the 1-based line number of the statement's first token.
+	Line int
+}
+
+// File is one migration file prepared for linting.
+type File struct {
+	// Path is the file path as it should appear in findings (reporting
+	// prefix included).
+	Path string
+	// Name is the bare file name inside the linted directory.
+	Name string
+	// IsUp reports whether this is an up migration (*.up.sql).
+	IsUp bool
+	// HasPair reports whether the matching counterpart file (down for up,
+	// up for down) exists in the same directory.
+	HasPair bool
+	// WellFormedName reports whether the name matches the migrator's
+	// NNNNNNNNNN_description.(up|down).sql convention.
+	WellFormedName bool
+	// Statements holds the parsed statements of up migrations. Empty for
+	// down migrations (statement rules do not run there).
+	Statements []Statement
+}
+
+// Rule is one lint check. Exactly one of CheckStatement / CheckFile is set.
+type Rule struct {
+	// Code is the stable identifier (DS101, PG101, ...).
+	Code string
+	// Title is the short human-readable name of the hazard.
+	Title string
+	// Severity is the default severity of findings from this rule.
+	Severity Severity
+	// Dialects restricts the rule to specific target dialects; empty means
+	// every dialect.
+	Dialects []string
+	// CheckStatement inspects one statement of an up migration and reports
+	// whether the rule fires, with a specific message.
+	CheckStatement func(stmt *Statement) (bool, string)
+	// CheckFile inspects file-level form and returns full findings.
+	CheckFile func(file *File) []Finding
+}
+
+// Options configures a lint run.
+type Options struct {
+	// Dialect gates dialect-specific rules: "postgres" enables PG rules,
+	// "mysql"/"mariadb" enable MY rules. Empty runs every rule — maximum
+	// visibility when the target is unknown.
+	Dialect string
+	// Disabled lists rule codes or code prefixes to skip: "DS101" disables
+	// one rule, "DS" the whole data-safety family.
+	Disabled []string
+	// PathPrefix is prepended (with /) to file names in findings so they
+	// point at real repository paths in CI annotations.
+	PathPrefix string
+}
+
+// LintFS lints every *.sql file at the root of fsys and returns the findings
+// ordered by file, line and rule code.
+func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
+	names, err := fs.Glob(fsys, "*.sql")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list migration files: %w", err)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no *.sql migration files found")
+	}
+	sort.Strings(names)
+
+	present := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		present[name] = struct{}{}
+	}
+
+	var findings []Finding
+	for _, name := range names {
+		file, err := prepareFile(fsys, name, present, opts.PathPrefix)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, runRules(file, opts)...)
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Rule < findings[j].Rule
+	})
+	return findings, nil
+}
+
+// prepareFile loads one migration file into the forms rules consume.
+func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefix string) (*File, error) {
+	raw, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", name, err)
+	}
+
+	file := &File{
+		Path:           path.Join(pathPrefix, name),
+		Name:           name,
+		IsUp:           strings.HasSuffix(name, ".up.sql"),
+		WellFormedName: migrator.ValidateMigrationFileName(name),
+	}
+	switch {
+	case file.IsUp:
+		_, file.HasPair = present[strings.TrimSuffix(name, ".up.sql")+".down.sql"]
+	case strings.HasSuffix(name, ".down.sql"):
+		_, file.HasPair = present[strings.TrimSuffix(name, ".down.sql")+".up.sql"]
+	}
+
+	// Statement rules apply to up migrations only.
+	if file.IsUp {
+		for _, rawStmt := range splitStatementsWithLines(string(raw)) {
+			file.Statements = append(file.Statements, Statement{
+				SQL:       rawStmt.text,
+				Canonical: canonicalize(rawStmt.text),
+				Words:     tokenizeWords(rawStmt.text),
+				Node:      parseBestEffort(rawStmt.text),
+				Line:      rawStmt.line,
+			})
+		}
+	}
+	return file, nil
+}
+
+// runRules applies every enabled rule to one prepared file.
+func runRules(file *File, opts Options) []Finding {
+	var findings []Finding
+	for _, rule := range Rules() {
+		if ruleDisabled(rule.Code, opts.Disabled) || !ruleAppliesToDialect(rule, opts.Dialect) {
+			continue
+		}
+		if rule.CheckFile != nil {
+			findings = append(findings, rule.CheckFile(file)...)
+			continue
+		}
+		for i := range file.Statements {
+			if hit, message := rule.CheckStatement(&file.Statements[i]); hit {
+				findings = append(findings, Finding{
+					Rule:     rule.Code,
+					Title:    rule.Title,
+					Severity: rule.Severity,
+					File:     file.Path,
+					Line:     file.Statements[i].Line,
+					Message:  message,
+				})
+			}
+		}
+	}
+	return findings
+}
+
+// ruleDisabled reports whether code matches any disabled entry — exact code
+// or family prefix ("DS" disables every DS rule).
+func ruleDisabled(code string, disabled []string) bool {
+	for _, entry := range disabled {
+		entry = strings.TrimSpace(entry)
+		if entry != "" && strings.HasPrefix(code, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleAppliesToDialect reports whether a rule runs for the configured target
+// dialect. An empty configured dialect runs everything.
+func ruleAppliesToDialect(rule Rule, dialect string) bool {
+	if len(rule.Dialects) == 0 || dialect == "" {
+		return true
+	}
+	return slices.Contains(rule.Dialects, dialect)
+}
+
+// rawStatement is one raw SQL statement plus the line it starts on.
+type rawStatement struct {
+	text string
+	line int
+}
+
+// splitStatementsWithLines splits SQL into statements using the lexer (so
+// semicolons inside strings, comments and dollar-quoted bodies do not
+// terminate statements) while tracking each statement's starting line.
+func splitStatementsWithLines(raw string) []rawStatement {
+	lexr := lexer.NewLexer(raw)
+	var statements []rawStatement
+	start := -1
+	end := 0
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		switch tok.Type {
+		case lexer.TokenSemicolon:
+			if start >= 0 {
+				statements = append(statements, rawStatement{
+					text: raw[start:end],
+					line: 1 + strings.Count(raw[:start], "\n"),
+				})
+				start = -1
+			}
+		case lexer.TokenWhitespace, lexer.TokenComment:
+			// Never starts a statement; keep end untouched so trailing
+			// comments/whitespace are not included in the statement text.
+		default:
+			if start < 0 {
+				start = tok.Start
+			}
+			end = tok.End
+		}
+	}
+	if start >= 0 {
+		statements = append(statements, rawStatement{
+			text: raw[start:end],
+			line: 1 + strings.Count(raw[:start], "\n"),
+		})
+	}
+	return statements
+}
+
+// canonicalize renders a statement in the form pattern rules match against:
+// comments removed, every whitespace run collapsed to one space, everything
+// except string literals uppercased.
+func canonicalize(sql string) string {
+	lexr := lexer.NewLexer(sql)
+	var b strings.Builder
+	pendingSpace := false
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		switch tok.Type {
+		case lexer.TokenComment, lexer.TokenWhitespace:
+			// A comment separates tokens exactly like whitespace does
+			// (DROP/*x*/TABLE must not canonicalize to DROPTABLE).
+			pendingSpace = b.Len() > 0
+		case lexer.TokenString:
+			if pendingSpace {
+				b.WriteByte(' ')
+				pendingSpace = false
+			}
+			b.WriteString(tok.Value)
+		default:
+			if pendingSpace {
+				b.WriteByte(' ')
+				pendingSpace = false
+			}
+			b.WriteString(strings.ToUpper(tok.Value))
+		}
+	}
+	return b.String()
+}
+
+// tokenizeWords renders a statement as the word sequence rules scan (see
+// Statement.Words). Double-quoted identifiers arrive from the lexer as string
+// tokens and backtick-quoted ones as identifiers; both keep their quotes and
+// case, so quoted names never collide with SQL keywords in the scans.
+func tokenizeWords(sql string) []string {
+	lexr := lexer.NewLexer(sql)
+	var words []string
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		switch tok.Type {
+		case lexer.TokenComment, lexer.TokenWhitespace:
+			continue
+		case lexer.TokenString:
+			words = append(words, tok.Value)
+		default:
+			if strings.HasPrefix(tok.Value, "`") || strings.HasPrefix(tok.Value, `"`) {
+				words = append(words, tok.Value)
+				continue
+			}
+			words = append(words, strings.ToUpper(tok.Value))
+		}
+	}
+	return words
+}
+
+// parseBestEffort parses a statement into ptah's DDL AST when it falls inside
+// the parser's supported subset, and returns nil otherwise.
+func parseBestEffort(sql string) ast.Node {
+	statements, err := parser.NewParser(sql).Parse()
+	if err != nil || statements == nil || len(statements.Statements) != 1 {
+		return nil
+	}
+	return statements.Statements[0]
+}

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -120,12 +120,17 @@ func TestLintFS_MigrationFormRules(t *testing.T) {
 // lintOne lints a single-statement up migration (with a paired down file)
 // and returns the rule codes that fired.
 func lintOne(c *qt.C, sql string) []string {
+	return lintOneDialect(c, "", sql)
+}
+
+// lintOneDialect is lintOne with an explicit target dialect.
+func lintOneDialect(c *qt.C, dialect, sql string) []string {
 	c.Helper()
 	fsys := fixture(map[string]string{
 		"0000000001_x.up.sql":   sql + "\n",
 		"0000000001_x.down.sql": "-- restore\n",
 	})
-	findings, err := lint.LintFS(fsys, lint.Options{})
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: dialect})
 	c.Assert(err, qt.IsNil)
 	return rulesOf(findings)
 }
@@ -149,6 +154,17 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		{"standalone rename table", "RENAME TABLE users TO users_archive;", []string{"BC101"}},
 		{"mysql rename table without TO", "ALTER TABLE users RENAME users_archive;", []string{"BC101"}},
 
+		// PostgreSQL: ALTER TABLE [ IF EXISTS ] [ ONLY ] name [ * ] — every
+		// modifier combination must still anchor the clause scan.
+		{"if exists only drop", "ALTER TABLE IF EXISTS ONLY users DROP COLUMN email;", []string{"DS102"}},
+		{"if exists only alter type", "ALTER TABLE IF EXISTS ONLY users ALTER COLUMN age TYPE BIGINT;", []string{"DS103"}},
+		{"if exists only rename", "ALTER TABLE IF EXISTS ONLY users RENAME COLUMN email TO email_old;", []string{"BC101"}},
+		{"descendant asterisk form", "ALTER TABLE users * DROP COLUMN email;", []string{"DS102"}},
+
+		// CONVERT TO CHARACTER SET and its CHARSET synonym rebuild the table.
+		{"convert to character set", "ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4;", []string{"MY101"}},
+		{"convert to charset synonym", "ALTER TABLE users CONVERT TO CHARSET utf8mb4;", []string{"MY101"}},
+
 		// Non-column DROP clauses and column attributes must stay silent.
 		{"drop constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", nil},
 		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", nil},
@@ -158,6 +174,9 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		{"drop default attribute", "ALTER TABLE users ALTER COLUMN a DROP DEFAULT;", nil},
 		{"drop not null attribute", "ALTER TABLE users ALTER COLUMN a DROP NOT NULL;", nil},
 		{"drop identity attribute", "ALTER TABLE users ALTER COLUMN a DROP IDENTITY IF EXISTS;", nil},
+		{"drop key", "ALTER TABLE users DROP KEY idx_email;", nil},
+		{"drop partition", "ALTER TABLE metrics DROP PARTITION p2024;", nil},
+		{"drop system versioning", "ALTER TABLE users DROP SYSTEM VERSIONING;", nil},
 
 		// Columns that happen to be named like keywords are not hazards.
 		{"column named type set not null", "ALTER TABLE users ALTER COLUMN type SET NOT NULL;", nil},
@@ -210,6 +229,199 @@ func TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards(t *testing.T) {
 	}
 }
 
+func TestLintFS_DialectAwareScanning(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		want    []string
+	}{
+		// Under standard_conforming_strings (the PostgreSQL default since
+		// 9.1) a backslash is a literal character, so a trailing backslash
+		// must not swallow the closing quote and everything after it.
+		{"postgres trailing backslash literal", "postgres",
+			"INSERT INTO paths (prefix) VALUES ('C:\\');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+		{"postgres like escape literal", "postgres",
+			"ALTER TABLE t ADD CONSTRAINT chk CHECK (code NOT LIKE '%\\_%' ESCAPE '\\');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+		// MySQL treats backslash as an escape: \' stays inside the literal.
+		{"mysql backslash-escaped quote", "mysql",
+			"INSERT INTO notes (t) VALUES ('it\\'s; fine');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+
+		// # line comments are MySQL/MariaDB syntax and must neither hide
+		// hazards nor leak decoy text into statements.
+		{"mysql hash comment before statement", "mysql",
+			"# drop unused column\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+		{"mysql hash comment inside statement", "mysql",
+			"ALTER TABLE users\n# remove the legacy column\nDROP COLUMN email;", []string{"DS102"}},
+		{"mysql hash comment decoys are inert", "mysql",
+			"# decoy; DROP TABLE x;\nCREATE TABLE t (id INT);", nil},
+		// In PostgreSQL # is an operator, not a comment starter.
+		{"postgres hash operator in index expression", "postgres",
+			"CREATE INDEX idx ON t ((data #>> '{a}'));", []string{"PG101"}},
+
+		// MySQL executable comments are real SQL to the server.
+		{"mysql executable comment hides real ddl", "mysql",
+			"/*!50003 ALTER TABLE users DROP COLUMN email */;", []string{"DS102"}},
+
+		// PostgreSQL block comments nest.
+		{"postgres nested block comment", "postgres",
+			"/* cleanup /* legacy */ block */\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+
+		// Encoding and termination edge cases.
+		{"utf8 bom before first statement", "", "\uFEFFDROP TABLE users;", []string{"DS101"}},
+		{"final statement without semicolon", "", "DROP TABLE users", []string{"DS101"}},
+		{"unicode table name", "", "ALTER TABLE пользователи DROP COLUMN email;", []string{"DS102"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := lintOneDialect(c, tt.dialect, tt.sql)
+			if len(tt.want) == 0 {
+				c.Assert(got, qt.HasLen, 0, qt.Commentf("%s must be clean", tt.sql))
+			} else {
+				c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
+			}
+		})
+	}
+}
+
+func TestLintFS_ScanningKeepsLineNumbers(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_x.up.sql": "# leading comment with a decoy; DROP TABLE decoy;\n" +
+			"CREATE TABLE t (id INT);\n" +
+			"ALTER TABLE users\n" +
+			"# mid-statement comment\n" +
+			"DROP COLUMN email;\n",
+		"0000000001_x.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "mysql"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(findings[0].Line, qt.Equals, 3,
+		qt.Commentf("the finding points at the ALTER TABLE start, not the comment"))
+}
+
+func TestLintFS_SameFileCreatedTablesAreExempt(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		want    []string
+	}{
+		// The create-staging/backfill/drop pattern destroys no existing data.
+		{"drop of table created in same file", "postgres",
+			"CREATE TEMPORARY TABLE tmp_backfill AS SELECT id FROM users;\nDROP TABLE tmp_backfill;", nil},
+		{"drop if exists of created table", "postgres",
+			"CREATE TABLE staging (id INT);\nDROP TABLE IF EXISTS staging;", nil},
+		{"drop of pre-existing table still fires", "postgres",
+			"CREATE TABLE staging (id INT);\nDROP TABLE users;", []string{"DS101"}},
+		{"drop before create still fires", "postgres",
+			"DROP TABLE staging;\nCREATE TABLE staging (id INT);", []string{"DS101"}},
+		{"multi-table drop with one pre-existing fires", "postgres",
+			"CREATE TABLE staging (id INT);\nDROP TABLE staging, users;", []string{"DS101"}},
+
+		// An index on a table created two statements earlier is built on an
+		// empty table — no lock hazard.
+		{"index on table created in same file", "postgres",
+			"CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, user_id BIGINT);\nCREATE INDEX idx_orders_user ON orders (user_id);", nil},
+		{"index on schema-qualified created table", "postgres",
+			"CREATE TABLE app.orders (id INT);\nCREATE UNIQUE INDEX uq ON app.orders (id);", nil},
+		{"index on pre-existing table still fires", "postgres",
+			"CREATE TABLE orders (id INT);\nCREATE INDEX idx_users_email ON users (email);", []string{"PG101"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := lintOneDialect(c, tt.dialect, tt.sql)
+			if len(tt.want) == 0 {
+				c.Assert(got, qt.HasLen, 0, qt.Commentf("%s must be clean", tt.sql))
+			} else {
+				c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
+			}
+		})
+	}
+}
+
+func TestLintFS_MY101PinnedOnlineDDLIsExempt(t *testing.T) {
+	c := qt.New(t)
+
+	// Pinned ALGORITHM/LOCK make the server refuse a blocking rebuild, so
+	// the lock hazard cannot occur; the lossy-type-change warning stays.
+	got := lintOneDialect(c, "mysql",
+		"ALTER TABLE users MODIFY COLUMN bio VARCHAR(500) NOT NULL, ALGORITHM=INPLACE, LOCK=NONE;")
+	c.Assert(got, qt.DeepEquals, []string{"DS103"})
+
+	// The = is optional in the MySQL grammar.
+	got = lintOneDialect(c, "mysql",
+		"ALTER TABLE users MODIFY COLUMN bio VARCHAR(500), ALGORITHM INPLACE;")
+	c.Assert(got, qt.DeepEquals, []string{"DS103"})
+
+	// ALGORITHM=COPY pins the blocking path; MY101 must still fire.
+	got = lintOneDialect(c, "mysql",
+		"ALTER TABLE users MODIFY COLUMN bio VARCHAR(500), ALGORITHM=COPY;")
+	c.Assert(got, qt.DeepEquals, []string{"DS103", "MY101"})
+}
+
+func TestLintFS_NestedDirectoriesAreLinted(t *testing.T) {
+	c := qt.New(t)
+
+	// The migrator's FSMigrationProvider discovers migrations recursively,
+	// so lint must walk subdirectories too.
+	fsys := fixture(map[string]string{
+		"sub/0000000001_a.up.sql":   "DROP TABLE users;\n",
+		"sub/0000000001_a.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{PathPrefix: "db/migrations"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+	c.Assert(findings[0].File, qt.Equals, "db/migrations/sub/0000000001_a.up.sql")
+	c.Assert(findings[0].Line, qt.Equals, 1)
+}
+
+func TestLintFS_MigratorLenientNamesAreLinted(t *testing.T) {
+	c := qt.New(t)
+
+	// The migrator's lenient name parser runs 0000000001_cleanup.sql as an
+	// UP migration and 0000000002_teardown.sql as a DOWN one; lint must
+	// classify them the same way instead of skipping their statements.
+	fsys := fixture(map[string]string{
+		"0000000001_cleanup.sql":  "DROP TABLE users;\n",
+		"0000000002_teardown.sql": "DROP TABLE audit;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF101", "MF103", "DS101", "MF103"},
+		qt.Commentf("cleanup.sql is an up migration to the migrator: DS101 + missing down + ambiguous name; teardown.sql is a down migration: ambiguous name only; got %v", findings))
+	for _, f := range findings {
+		if f.Rule == "MF103" {
+			c.Assert(f.Message, qt.Contains, "ambiguous file name")
+		}
+	}
+}
+
+func TestLintFS_CaseVariantSQLFilesGetNamingWarning(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_x.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_x.down.sql": "DROP TABLE t;\n",
+		"0000000002_y.UP.SQL":   "DROP TABLE users;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF103"},
+		qt.Commentf("a case-variant file the migrator will not run earns a naming warning instead of vanishing"))
+}
+
 func TestLintFS_DialectGating(t *testing.T) {
 	c := qt.New(t)
 
@@ -227,6 +439,11 @@ ALTER TABLE users MODIFY COLUMN email VARCHAR(64);
 
 	// mariadb: MY rules fire, PG rules do not.
 	findings, err = lint.LintFS(fsys, lint.Options{Dialect: "mariadb"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS103", "MY101"})
+
+	// mysql gates identically to mariadb.
+	findings, err = lint.LintFS(fsys, lint.Options{Dialect: "mysql"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS103", "MY101"})
 
@@ -256,6 +473,11 @@ CREATE INDEX i ON b (c);
 	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{"DS"}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101"})
+
+	// A stray empty entry must not disable everything.
+	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{""}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101", "DS102", "PG101"})
 }
 
 func TestLintFS_DollarQuotedBodiesDoNotSplitStatements(t *testing.T) {

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -1,0 +1,342 @@
+package lint_test
+
+import (
+	"os"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/lint"
+)
+
+// fixture builds an in-memory migrations directory.
+func fixture(files map[string]string) fstest.MapFS {
+	fsys := fstest.MapFS{}
+	for name, content := range files {
+		fsys[name] = &fstest.MapFile{Data: []byte(content)}
+	}
+	return fsys
+}
+
+// rulesOf collects the rule codes of findings, with duplicates.
+func rulesOf(findings []lint.Finding) []string {
+	codes := make([]string, 0, len(findings))
+	for _, f := range findings {
+		codes = append(codes, f.Rule)
+	}
+	return codes
+}
+
+func TestLintFS_CuratedHazardsProduceExpectedRuleHits(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_bad.up.sql": `-- hazards ahead; note the semicolon in this comment: DROP TABLE decoy;
+DROP TABLE audit_log;
+ALTER TABLE users DROP COLUMN legacy;
+ALTER TABLE users RENAME COLUMN email TO email_address;
+ALTER TABLE users MODIFY COLUMN email VARCHAR(64);
+CREATE UNIQUE INDEX uq_users_email ON users (email);
+ALTER TYPE mood ADD VALUE 'ambivalent';
+`,
+		"0000000001_bad.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{
+		"DS101", // DROP TABLE audit_log
+		"DS102", // DROP COLUMN legacy
+		"BC101", // RENAME COLUMN
+		"DS103", // MODIFY COLUMN (lossy)
+		"MY101", // MODIFY COLUMN (lock-heavy)
+		"PG101", // CREATE UNIQUE INDEX without CONCURRENTLY
+		"PG102", // ALTER TYPE ADD VALUE
+	})
+
+	// Line numbers point at the offending statements, not the file head:
+	// the comment on line 1 (with its decoy semicolon) shifts DROP TABLE to
+	// line 2 and everything after accordingly.
+	byRule := map[string]lint.Finding{}
+	for _, f := range findings {
+		byRule[f.Rule] = f
+	}
+	c.Assert(byRule["DS101"].Line, qt.Equals, 2)
+	c.Assert(byRule["DS102"].Line, qt.Equals, 3)
+	c.Assert(byRule["BC101"].Line, qt.Equals, 4)
+	c.Assert(byRule["PG102"].Line, qt.Equals, 7)
+	c.Assert(byRule["DS101"].Severity, qt.Equals, lint.SeverityError)
+	c.Assert(byRule["PG101"].Severity, qt.Equals, lint.SeverityWarning)
+}
+
+func TestLintFS_CleanMigrationHasNoFindings(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_create_users.up.sql":   "CREATE TABLE users (id SERIAL PRIMARY KEY, email VARCHAR(255) NOT NULL);\n",
+		"0000000001_create_users.down.sql": "DROP TABLE IF EXISTS users;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "mysql"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0,
+		qt.Commentf("a plain CREATE TABLE with a paired down file is clean; got: %v", findings))
+}
+
+func TestLintFS_DownMigrationStatementsAreNotLinted(t *testing.T) {
+	c := qt.New(t)
+
+	// A down migration dropping what its up created is the expected shape.
+	fsys := fixture(map[string]string{
+		"0000000001_create_users.up.sql":   "CREATE TABLE users (id SERIAL PRIMARY KEY);\n",
+		"0000000001_create_users.down.sql": "DROP TABLE users;\nALTER TABLE audit DROP COLUMN old;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0, qt.Commentf("got: %v", findings))
+}
+
+func TestLintFS_MigrationFormRules(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_orphan.up.sql":  "CREATE TABLE t (id INT);\n",         // MF101: no down
+		"0000000002_empty.up.sql":   "-- only comments; nothing to run\n", // MF102
+		"0000000002_empty.down.sql": "-- nothing\n",
+		"misnamed.sql":              "CREATE TABLE stray (id INT);\n", // MF103
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF101", "MF102", "MF103"})
+	for _, f := range findings {
+		c.Assert(f.Line, qt.Equals, 0, qt.Commentf("file-level findings carry no line: %v", f))
+	}
+}
+
+// lintOne lints a single-statement up migration (with a paired down file)
+// and returns the rule codes that fired.
+func lintOne(c *qt.C, sql string) []string {
+	c.Helper()
+	fsys := fixture(map[string]string{
+		"0000000001_x.up.sql":   sql + "\n",
+		"0000000001_x.down.sql": "-- restore\n",
+	})
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	return rulesOf(findings)
+}
+
+func TestLintFS_OptionalKeywordForms(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		// The COLUMN keyword is optional in PostgreSQL and the MySQL family.
+		{"drop without COLUMN keyword", "ALTER TABLE users DROP email;", []string{"DS102"}},
+		{"drop column if exists", "ALTER TABLE users DROP COLUMN IF EXISTS email;", []string{"DS102"}},
+		{"drop if exists without COLUMN", "ALTER TABLE users DROP IF EXISTS email;", []string{"DS102"}},
+		{"drop on schema-qualified table", "ALTER TABLE public.users DROP email;", []string{"DS102"}},
+		{"modify without COLUMN keyword", "ALTER TABLE users MODIFY name VARCHAR(500);", []string{"DS103", "MY101"}},
+		{"change without COLUMN keyword", "ALTER TABLE users CHANGE old_name new_name TEXT;", []string{"DS103", "MY101"}},
+		{"alter type without COLUMN keyword", "ALTER TABLE users ALTER email TYPE TEXT;", []string{"DS103"}},
+		{"set data type spelling", "ALTER TABLE users ALTER COLUMN price SET DATA TYPE NUMERIC(12,2);", []string{"DS103"}},
+		{"rename without COLUMN keyword", "ALTER TABLE users RENAME email TO email_address;", []string{"BC101"}},
+		{"standalone rename table", "RENAME TABLE users TO users_archive;", []string{"BC101"}},
+		{"mysql rename table without TO", "ALTER TABLE users RENAME users_archive;", []string{"BC101"}},
+
+		// Non-column DROP clauses and column attributes must stay silent.
+		{"drop constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", nil},
+		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", nil},
+		{"drop primary key", "ALTER TABLE users DROP PRIMARY KEY;", nil},
+		{"drop index", "ALTER TABLE users DROP INDEX idx_users_email;", nil},
+		{"drop check", "ALTER TABLE users DROP CHECK chk_age;", nil},
+		{"drop default attribute", "ALTER TABLE users ALTER COLUMN a DROP DEFAULT;", nil},
+		{"drop not null attribute", "ALTER TABLE users ALTER COLUMN a DROP NOT NULL;", nil},
+		{"drop identity attribute", "ALTER TABLE users ALTER COLUMN a DROP IDENTITY IF EXISTS;", nil},
+
+		// Columns that happen to be named like keywords are not hazards.
+		{"column named type set not null", "ALTER TABLE users ALTER COLUMN type SET NOT NULL;", nil},
+		{"quoted column named type", `ALTER TABLE users ALTER COLUMN "type" SET NOT NULL;`, nil},
+		{"added column named modify", "ALTER TABLE users ADD COLUMN modify TEXT;", nil},
+		{"added column named rename", "ALTER TABLE users ADD COLUMN rename TEXT;", nil},
+
+		// Renames invisible to application code are not BC breaks.
+		{"rename index", "ALTER TABLE users RENAME INDEX i1 TO i2;", nil},
+		{"rename constraint", "ALTER TABLE users RENAME CONSTRAINT c1 TO c2;", nil},
+
+		// Top-level commas separate clauses; commas in parens do not.
+		{"comma-adjacent drop clause", "ALTER TABLE t ADD COLUMN a NUMERIC(10,2),DROP COLUMN b;", []string{"DS102"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := lintOne(c, tt.sql)
+			if len(tt.want) == 0 {
+				c.Assert(got, qt.HasLen, 0, qt.Commentf("%s must be clean", tt.sql))
+			} else {
+				c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
+			}
+		})
+	}
+}
+
+func TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{"comment glued between keywords", "DROP/*hidden*/TABLE users;", []string{"DS101"}},
+		{"comment inside alter clause", "ALTER TABLE users DROP/*hidden*/COLUMN email;", []string{"DS102"}},
+		{"hazard text inside a string literal", "ALTER TABLE t ADD COLUMN note TEXT DEFAULT 'use DROP COLUMN x';", nil},
+		{"concurrently in a literal is no guard", "CREATE INDEX i ON t (a) WHERE b = 'CONCURRENTLY';", []string{"PG101"}},
+		{"create index concurrently is safe", "CREATE UNIQUE INDEX CONCURRENTLY uq ON t (a);", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := lintOne(c, tt.sql)
+			if len(tt.want) == 0 {
+				c.Assert(got, qt.HasLen, 0, qt.Commentf("%s must be clean", tt.sql))
+			} else {
+				c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
+			}
+		})
+	}
+}
+
+func TestLintFS_DialectGating(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_mixed.up.sql": `CREATE INDEX idx ON users (email);
+ALTER TABLE users MODIFY COLUMN email VARCHAR(64);
+`,
+		"0000000001_mixed.down.sql": "-- restore\n",
+	})
+
+	// postgres: PG rules fire, MY rules do not (DS103 is generic and stays).
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101", "DS103"})
+
+	// mariadb: MY rules fire, PG rules do not.
+	findings, err = lint.LintFS(fsys, lint.Options{Dialect: "mariadb"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS103", "MY101"})
+
+	// empty dialect: everything fires.
+	findings, err = lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101", "DS103", "MY101"})
+}
+
+func TestLintFS_DisabledRulesAndFamilies(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_bad.up.sql": `DROP TABLE a;
+ALTER TABLE b DROP COLUMN c;
+CREATE INDEX i ON b (c);
+`,
+		"0000000001_bad.down.sql": "-- restore\n",
+	})
+
+	// Disable one exact code.
+	findings, err := lint.LintFS(fsys, lint.Options{Disabled: []string{"DS101"}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS102", "PG101"})
+
+	// Disable a whole family by prefix.
+	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{"DS"}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101"})
+}
+
+func TestLintFS_DollarQuotedBodiesDoNotSplitStatements(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_fn.up.sql": `CREATE FUNCTION noop() RETURNS void AS $ptah$
+BEGIN
+    -- DROP TABLE decoy; inside a dollar-quoted body and a comment
+    PERFORM 1;
+END;
+$ptah$ LANGUAGE plpgsql;
+`,
+		"0000000001_fn.down.sql": "DROP FUNCTION noop();\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0,
+		qt.Commentf("statements inside dollar-quoted bodies must not trigger rules; got: %v", findings))
+}
+
+func TestLintFS_PathPrefixAppearsInFindings(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_bad.up.sql":   "DROP TABLE a;\n",
+		"0000000001_bad.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{PathPrefix: "db/migrations"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].File, qt.Equals, "db/migrations/0000000001_bad.up.sql")
+}
+
+func TestLintFS_NoMigrationFilesIsAnError(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{"README.md": "not sql"}), lint.Options{})
+	c.Assert(err, qt.ErrorMatches, "no \\*\\.sql migration files found")
+}
+
+func TestLoadConfig(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(writeFile(dir+"/.ptah-lint.yaml", "dialect: postgres\ndisabled-rules:\n  - MF\n  - BC101\n"), qt.IsNil)
+
+	cfg, err := lint.LoadConfig(dir + "/.ptah-lint.yaml")
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Dialect, qt.Equals, "postgres")
+	c.Assert(cfg.DisabledRules, qt.DeepEquals, []string{"MF", "BC101"})
+
+	// A missing file at the conventional location is not an error.
+	cfg, err = lint.LoadConfig(dir + "/nope.yaml")
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Dialect, qt.Equals, "")
+	c.Assert(cfg.DisabledRules, qt.HasLen, 0)
+
+	// A malformed file is.
+	c.Assert(writeFile(dir+"/broken.yaml", "dialect: [not, a, string"), qt.IsNil)
+	_, err = lint.LoadConfig(dir + "/broken.yaml")
+	c.Assert(err, qt.ErrorMatches, "failed to parse lint config .*")
+}
+
+func TestRules_EveryRuleHasCodeTitleAndOneChecker(t *testing.T) {
+	c := qt.New(t)
+
+	seen := map[string]bool{}
+	for _, rule := range lint.Rules() {
+		c.Assert(rule.Code, qt.Not(qt.Equals), "")
+		c.Assert(rule.Title, qt.Not(qt.Equals), "")
+		c.Assert(seen[rule.Code], qt.IsFalse, qt.Commentf("duplicate rule code %s", rule.Code))
+		seen[rule.Code] = true
+		oneChecker := (rule.CheckStatement != nil) != (rule.CheckFile != nil)
+		c.Assert(oneChecker, qt.IsTrue, qt.Commentf("rule %s must set exactly one checker", rule.Code))
+		c.Assert(rule.Severity == lint.SeverityWarning || rule.Severity == lint.SeverityError, qt.IsTrue)
+	}
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -26,11 +27,34 @@ func dataSafetyRules() []Rule {
 			Code:     "DS101",
 			Title:    "table dropped",
 			Severity: SeverityError,
-			CheckStatement: func(stmt *Statement) (bool, string) {
-				if !hasWordPrefix(stmt.Words, "DROP", "TABLE") {
-					return false, ""
+			// File-level: dropping a table this same migration created (the
+			// create-staging/backfill/drop pattern) destroys no pre-existing
+			// data and is exempt.
+			CheckFile: func(file *File) []Finding {
+				if !file.IsUp {
+					return nil
 				}
-				return true, "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead"
+				var findings []Finding
+				created := map[string]bool{}
+				for i := range file.Statements {
+					stmt := &file.Statements[i]
+					if ref := createdTableRef(stmt.Words); ref != "" {
+						created[ref] = true
+						continue
+					}
+					if !hasWordPrefix(stmt.Words, "DROP", "TABLE") || dropsOnlyCreatedTables(stmt.Words, created) {
+						continue
+					}
+					findings = append(findings, Finding{
+						Rule:     "DS101",
+						Title:    "table dropped",
+						Severity: SeverityError,
+						File:     file.Path,
+						Line:     stmt.Line,
+						Message:  "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead",
+					})
+				}
+				return findings
 			},
 		},
 		{
@@ -106,12 +130,19 @@ func migrationFormRules() []Rule {
 				if file.WellFormedName {
 					return nil
 				}
+				message := "file name does not match NNNNNNNNNN_description.(up|down).sql; the migrator will not pick it up"
+				if file.Direction != "" {
+					// The migrator's lenient parser accepts this name — e.g.
+					// 0000000001_cleanup.sql runs as an UP migration — which
+					// is more surprising than being skipped.
+					message = fmt.Sprintf("ambiguous file name: the migrator runs this as a %s migration even though it does not end in .%s.sql; rename it to NNNNNNNNNN_description.%s.sql", file.Direction, file.Direction, file.Direction)
+				}
 				return []Finding{{
 					Rule:     "MF103",
 					Title:    "non-conventional file name",
 					Severity: SeverityWarning,
 					File:     file.Path,
-					Message:  "file name does not match NNNNNNNNNN_description.(up|down).sql; the migrator will not pick it up",
+					Message:  message,
 				}}
 			},
 		},
@@ -144,11 +175,37 @@ func postgresRules() []Rule {
 			Title:    "index built with a table lock",
 			Severity: SeverityWarning,
 			Dialects: []string{"postgres"},
-			CheckStatement: func(stmt *Statement) (bool, string) {
-				if !isCreateIndex(stmt.Words) || slices.Contains(stmt.Words, "CONCURRENTLY") {
-					return false, ""
+			// File-level: an index on a table this same migration created is
+			// built on an empty table — no lock hazard, and CONCURRENTLY
+			// would be impossible inside the transactional migration anyway.
+			CheckFile: func(file *File) []Finding {
+				if !file.IsUp {
+					return nil
 				}
-				return true, "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction"
+				var findings []Finding
+				created := map[string]bool{}
+				for i := range file.Statements {
+					stmt := &file.Statements[i]
+					if ref := createdTableRef(stmt.Words); ref != "" {
+						created[ref] = true
+						continue
+					}
+					if !isCreateIndex(stmt.Words) || slices.Contains(stmt.Words, "CONCURRENTLY") {
+						continue
+					}
+					if refersToCreated(created, indexTargetRef(stmt.Words)) {
+						continue
+					}
+					findings = append(findings, Finding{
+						Rule:     "PG101",
+						Title:    "index built with a table lock",
+						Severity: SeverityWarning,
+						File:     file.Path,
+						Line:     stmt.Line,
+						Message:  "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction",
+					})
+				}
+				return findings
 			},
 		},
 		{
@@ -179,10 +236,12 @@ func mysqlRules() []Rule {
 					return false, ""
 				}
 				heavy := scanModifyChange(stmt.Words) || scanConvertCharset(stmt.Words)
-				if !heavy {
+				if !heavy || scanPinnedOnlineDDL(stmt.Words) {
 					return false, ""
 				}
-				return true, "this ALTER TABLE form usually rebuilds the table and blocks writes for the duration on MySQL/MariaDB; for large tables use an online-DDL tool (gh-ost, pt-online-schema-change) or verify ALGORITHM=INPLACE applies"
+				return true, "this ALTER TABLE form usually rebuilds the table and blocks writes for the duration on MySQL/MariaDB; " +
+					"for large tables use an online-DDL tool (gh-ost, pt-online-schema-change), or pin ALGORITHM=INPLACE/LOCK=NONE " +
+					"so the server refuses a blocking rebuild instead of performing it"
 			},
 		},
 	}
@@ -281,14 +340,26 @@ func skipIfExists(w []string, j int) int {
 // column names appearing mid-clause, e.g. ADD COLUMN modify TEXT.
 func clauseStarts(w []string) []int {
 	j := 2
-	if j < len(w) && w[j] == "ONLY" {
-		j++ // postgres: ALTER TABLE ONLY tbl
+	// PostgreSQL grammar: ALTER TABLE [ IF EXISTS ] [ ONLY ] name [ * ].
+	// Skip the modifiers in any order to stay robust.
+	for j < len(w) {
+		if w[j] == "ONLY" {
+			j++
+			continue
+		}
+		if next := skipIfExists(w, j); next != j {
+			j = next
+			continue
+		}
+		break
 	}
-	j = skipIfExists(w, j) // postgres: ALTER TABLE IF EXISTS tbl
 	if j < len(w) && identLike(w[j]) {
 		j++
 		for j+1 < len(w) && w[j] == "." && identLike(w[j+1]) {
 			j += 2 // schema-qualified reference: schema.tbl
+		}
+		if j < len(w) && w[j] == "*" {
+			j++ // postgres: name * (include descendant tables)
 		}
 	}
 	starts := []int{j}
@@ -388,9 +459,137 @@ func scanAlterColumnType(w []string) bool {
 
 // scanConvertCharset reports whether an ALTER TABLE statement converts the
 // table to another character set (a full-table rewrite on MySQL/MariaDB).
+// CHARSET is the accepted synonym of CHARACTER SET.
 func scanConvertCharset(w []string) bool {
 	for _, i := range clauseStarts(w) {
-		if hasWordPrefix(w[i:], "CONVERT", "TO", "CHARACTER", "SET") {
+		if hasWordPrefix(w[i:], "CONVERT", "TO", "CHARACTER", "SET") ||
+			hasWordPrefix(w[i:], "CONVERT", "TO", "CHARSET") {
+			return true
+		}
+	}
+	return false
+}
+
+// createdTableRef returns the normalized reference of the table a CREATE
+// TABLE statement creates, or "" for any other statement. Temporary-table
+// modifiers and IF NOT EXISTS are skipped.
+func createdTableRef(w []string) string {
+	if len(w) == 0 || w[0] != "CREATE" {
+		return ""
+	}
+	j := 1
+	for j < len(w) {
+		switch w[j] {
+		case "GLOBAL", "LOCAL", "TEMPORARY", "TEMP", "UNLOGGED":
+			j++
+			continue
+		}
+		break
+	}
+	if j >= len(w) || w[j] != "TABLE" {
+		return ""
+	}
+	j++
+	if j+2 < len(w) && w[j] == "IF" && w[j+1] == "NOT" && w[j+2] == "EXISTS" {
+		j += 3
+	}
+	ref, _ := tableRefAt(w, j)
+	return ref
+}
+
+// tableRefAt reads a possibly schema-qualified table reference at w[j] and
+// returns it normalized plus the index past its end; "" when w[j] does not
+// start a reference.
+func tableRefAt(w []string, j int) (string, int) {
+	if j >= len(w) || !identLike(w[j]) {
+		return "", j
+	}
+	parts := []string{normalizeIdent(w[j])}
+	j++
+	for j+1 < len(w) && w[j] == "." && identLike(w[j+1]) {
+		parts = append(parts, normalizeIdent(w[j+1]))
+		j += 2
+	}
+	return strings.Join(parts, "."), j
+}
+
+// normalizeIdent strips identifier quoting and uppercases for comparison.
+func normalizeIdent(word string) string {
+	return strings.ToUpper(strings.Trim(word, "`\""))
+}
+
+// refersToCreated reports whether ref names one of the created tables,
+// comparing full references when both sides are schema-qualified and last
+// components otherwise.
+func refersToCreated(created map[string]bool, ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if created[ref] {
+		return true
+	}
+	last := ref[strings.LastIndex(ref, ".")+1:]
+	for c := range created {
+		if c[strings.LastIndex(c, ".")+1:] != last {
+			continue
+		}
+		if !strings.Contains(ref, ".") || !strings.Contains(c, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+// dropsOnlyCreatedTables reports whether every table named by a DROP TABLE
+// statement was created earlier in the same file.
+func dropsOnlyCreatedTables(w []string, created map[string]bool) bool {
+	j := skipIfExists(w, 2)
+	for {
+		ref, next := tableRefAt(w, j)
+		if ref == "" || !refersToCreated(created, ref) {
+			return false
+		}
+		if next < len(w) && w[next] == "," {
+			j = next + 1
+			continue
+		}
+		return true
+	}
+}
+
+// indexTargetRef extracts the table a CREATE INDEX statement builds on (the
+// reference after ON).
+func indexTargetRef(w []string) string {
+	for k := range w {
+		if w[k] == "ON" {
+			ref, _ := tableRefAt(w, k+1)
+			return ref
+		}
+	}
+	return ""
+}
+
+// scanPinnedOnlineDDL reports whether an ALTER TABLE statement pins a
+// non-blocking online-DDL path: with ALGORITHM=INPLACE/INSTANT or LOCK=NONE
+// the server errors out instead of silently falling back to a locking
+// rebuild, so the lock hazard cannot occur. The = is optional in the MySQL
+// grammar.
+func scanPinnedOnlineDDL(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || (w[i] != "ALGORITHM" && w[i] != "LOCK") {
+			continue
+		}
+		j := i + 1
+		if j < len(w) && w[j] == "=" {
+			j++
+		}
+		if j >= len(w) {
+			continue
+		}
+		if w[i] == "ALGORITHM" && (w[j] == "INPLACE" || w[j] == "INSTANT") {
+			return true
+		}
+		if w[i] == "LOCK" && w[j] == "NONE" {
 			return true
 		}
 	}

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -1,0 +1,430 @@
+package lint
+
+import (
+	"fmt"
+	"slices"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Rules returns the built-in rule set. The slice is rebuilt on every call so
+// callers can never corrupt the registry.
+func Rules() []Rule {
+	var rules []Rule
+	rules = append(rules, dataSafetyRules()...)
+	rules = append(rules, migrationFormRules()...)
+	rules = append(rules, compatibilityRules()...)
+	rules = append(rules, postgresRules()...)
+	rules = append(rules, mysqlRules()...)
+	return rules
+}
+
+// dataSafetyRules covers the DS family: statements that destroy data.
+func dataSafetyRules() []Rule {
+	return []Rule{
+		{
+			Code:     "DS101",
+			Title:    "table dropped",
+			Severity: SeverityError,
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !hasWordPrefix(stmt.Words, "DROP", "TABLE") {
+					return false, ""
+				}
+				return true, "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead"
+			},
+		},
+		{
+			Code:     "DS102",
+			Title:    "column dropped",
+			Severity: SeverityError,
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanDropColumn(stmt.Words) {
+					return false, ""
+				}
+				return true, "DROP COLUMN permanently deletes the column's data; deploy readers that no longer use the column first, then drop it in a later release"
+			},
+		},
+		{
+			Code:     "DS103",
+			Title:    "column type changed",
+			Severity: SeverityWarning,
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) {
+					return false, ""
+				}
+				if !scanModifyChange(stmt.Words) && !scanAlterColumnType(stmt.Words) {
+					return false, ""
+				}
+				return true, "changing a column type can truncate or reject existing values and may rewrite the table under a lock; verify the old-to-new value mapping on production data first"
+			},
+		},
+	}
+}
+
+// migrationFormRules covers the MF family: file-level migration hygiene.
+func migrationFormRules() []Rule {
+	return []Rule{
+		{
+			Code:     "MF101",
+			Title:    "missing down migration",
+			Severity: SeverityWarning,
+			CheckFile: func(file *File) []Finding {
+				if !file.IsUp || file.HasPair {
+					return nil
+				}
+				return []Finding{{
+					Rule:     "MF101",
+					Title:    "missing down migration",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Message:  "no matching .down.sql exists; a failed deploy cannot be rolled back mechanically",
+				}}
+			},
+		},
+		{
+			Code:     "MF102",
+			Title:    "empty migration",
+			Severity: SeverityWarning,
+			CheckFile: func(file *File) []Finding {
+				if !file.IsUp || len(file.Statements) > 0 {
+					return nil
+				}
+				return []Finding{{
+					Rule:     "MF102",
+					Title:    "empty migration",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Message:  "the migration contains no executable statements; delete it or fill it in",
+				}}
+			},
+		},
+		{
+			Code:     "MF103",
+			Title:    "non-conventional file name",
+			Severity: SeverityWarning,
+			CheckFile: func(file *File) []Finding {
+				if file.WellFormedName {
+					return nil
+				}
+				return []Finding{{
+					Rule:     "MF103",
+					Title:    "non-conventional file name",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Message:  "file name does not match NNNNNNNNNN_description.(up|down).sql; the migrator will not pick it up",
+				}}
+			},
+		},
+	}
+}
+
+// compatibilityRules covers the BC family: changes that break deployed code.
+func compatibilityRules() []Rule {
+	return []Rule{
+		{
+			Code:     "BC101",
+			Title:    "rename breaks deployed code",
+			Severity: SeverityWarning,
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				standalone := hasWordPrefix(stmt.Words, "RENAME", "TABLE")
+				if !standalone && (!isAlterTable(stmt.Words) || !scanAlterRename(stmt.Words)) {
+					return false, ""
+				}
+				return true, "renames are not backwards compatible: application versions deployed against the old name fail instantly; prefer add-new/backfill/drop-old across releases"
+			},
+		},
+	}
+}
+
+// postgresRules covers the PG family: PostgreSQL-specific hazards.
+func postgresRules() []Rule {
+	return []Rule{
+		{
+			Code:     "PG101",
+			Title:    "index built with a table lock",
+			Severity: SeverityWarning,
+			Dialects: []string{"postgres"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isCreateIndex(stmt.Words) || slices.Contains(stmt.Words, "CONCURRENTLY") {
+					return false, ""
+				}
+				return true, "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction"
+			},
+		},
+		{
+			Code:     "PG102",
+			Title:    "enum value added inside a transaction",
+			Severity: SeverityWarning,
+			Dialects: []string{"postgres"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !hasWordPrefix(stmt.Words, "ALTER", "TYPE") || !hasWordSeq(stmt.Words, "ADD", "VALUE") {
+					return false, ""
+				}
+				return true, "ALTER TYPE ... ADD VALUE cannot run inside a transaction block before PostgreSQL 12, and the new value stays unusable within the same transaction on newer versions; run it in its own non-transactional migration"
+			},
+		},
+	}
+}
+
+// mysqlRules covers the MY family: MySQL/MariaDB-specific hazards.
+func mysqlRules() []Rule {
+	return []Rule{
+		{
+			Code:     "MY101",
+			Title:    "lock-heavy ALTER TABLE",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) {
+					return false, ""
+				}
+				heavy := scanModifyChange(stmt.Words) || scanConvertCharset(stmt.Words)
+				if !heavy {
+					return false, ""
+				}
+				return true, "this ALTER TABLE form usually rebuilds the table and blocks writes for the duration on MySQL/MariaDB; for large tables use an online-DDL tool (gh-ost, pt-online-schema-change) or verify ALGORITHM=INPLACE applies"
+			},
+		},
+	}
+}
+
+// dropTargets are the keywords that can follow ALTER TABLE ... DROP when the
+// clause drops something other than a column: constraints, the key family,
+// partitioning, system versioning. A column with one of these names must be
+// quoted to be valid SQL, and quoted identifiers keep their quotes in Words,
+// so real columns never collide with this set.
+var dropTargets = map[string]bool{
+	"CONSTRAINT":   true,
+	"INDEX":        true,
+	"KEY":          true,
+	"FOREIGN":      true,
+	"PRIMARY":      true,
+	"UNIQUE":       true,
+	"CHECK":        true,
+	"PARTITION":    true,
+	"PARTITIONING": true,
+	"SYSTEM":       true,
+}
+
+// isAlterTable reports whether the statement's words begin with ALTER TABLE.
+func isAlterTable(w []string) bool {
+	return hasWordPrefix(w, "ALTER", "TABLE")
+}
+
+// isCreateIndex reports whether the statement's words begin with
+// CREATE [UNIQUE] INDEX.
+func isCreateIndex(w []string) bool {
+	if len(w) == 0 || w[0] != "CREATE" {
+		return false
+	}
+	j := 1
+	if j < len(w) && w[j] == "UNIQUE" {
+		j++
+	}
+	return j < len(w) && w[j] == "INDEX"
+}
+
+// hasWordPrefix reports whether the word sequence starts with the given words.
+func hasWordPrefix(w []string, prefix ...string) bool {
+	if len(w) < len(prefix) {
+		return false
+	}
+	for i, p := range prefix {
+		if w[i] != p {
+			return false
+		}
+	}
+	return true
+}
+
+// hasWordSeq reports whether the given words appear consecutively anywhere in
+// the sequence.
+func hasWordSeq(w []string, seq ...string) bool {
+	for i := 0; i+len(seq) <= len(w); i++ {
+		if hasWordPrefix(w[i:], seq...) {
+			return true
+		}
+	}
+	return false
+}
+
+// identLike reports whether a word can name a column or table: a quoted
+// identifier, or a bare word starting with a letter, underscore, or digit.
+// Single-quoted string literals are values, never identifiers.
+func identLike(word string) bool {
+	if word == "" {
+		return false
+	}
+	switch word[0] {
+	case '`', '"':
+		return true
+	case '\'':
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(word)
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// skipIfExists advances past an optional IF EXISTS at w[j].
+func skipIfExists(w []string, j int) int {
+	if j+1 < len(w) && w[j] == "IF" && w[j+1] == "EXISTS" {
+		return j + 2
+	}
+	return j
+}
+
+// clauseStarts returns the word indices where the clauses of an ALTER TABLE
+// statement begin: the first word after the table reference and each word
+// after a top-level comma. Commas inside parentheses (type parameters,
+// expressions) do not start a clause. Anchoring scans to clause heads keeps
+// clause keywords (DROP, MODIFY, RENAME, ...) from being confused with
+// column names appearing mid-clause, e.g. ADD COLUMN modify TEXT.
+func clauseStarts(w []string) []int {
+	j := 2
+	if j < len(w) && w[j] == "ONLY" {
+		j++ // postgres: ALTER TABLE ONLY tbl
+	}
+	j = skipIfExists(w, j) // postgres: ALTER TABLE IF EXISTS tbl
+	if j < len(w) && identLike(w[j]) {
+		j++
+		for j+1 < len(w) && w[j] == "." && identLike(w[j+1]) {
+			j += 2 // schema-qualified reference: schema.tbl
+		}
+	}
+	starts := []int{j}
+	depth := 0
+	for k := j; k < len(w); k++ {
+		switch w[k] {
+		case "(":
+			depth++
+		case ")":
+			if depth > 0 {
+				depth--
+			}
+		case ",":
+			if depth == 0 {
+				starts = append(starts, k+1)
+			}
+		}
+	}
+	return starts
+}
+
+// scanDropColumn reports whether an ALTER TABLE statement drops a column.
+// The COLUMN keyword is optional in PostgreSQL and the MySQL family, so a
+// clause-head DROP followed by an identifier counts unless the identifier is
+// a known non-column DROP target (DROP CONSTRAINT, DROP PRIMARY KEY, ...).
+func scanDropColumn(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || w[i] != "DROP" {
+			continue
+		}
+		j := i + 1
+		explicit := false
+		if j < len(w) && w[j] == "COLUMN" {
+			explicit = true
+			j++
+		}
+		j = skipIfExists(w, j)
+		if j >= len(w) {
+			continue
+		}
+		if !explicit && dropTargets[w[j]] {
+			continue
+		}
+		if identLike(w[j]) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanModifyChange reports whether an ALTER TABLE statement rewrites a column
+// via the MySQL-family MODIFY/CHANGE clauses (COLUMN keyword optional).
+func scanModifyChange(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || (w[i] != "MODIFY" && w[i] != "CHANGE") {
+			continue
+		}
+		j := i + 1
+		if j < len(w) && w[j] == "COLUMN" {
+			j++
+		}
+		j = skipIfExists(w, j)
+		if j < len(w) && identLike(w[j]) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanAlterColumnType reports whether an ALTER TABLE statement changes a
+// column's type via ALTER [COLUMN] name [SET DATA] TYPE. The ordered scan
+// keeps a column merely named "type" (e.g. ALTER COLUMN type SET NOT NULL)
+// from matching.
+func scanAlterColumnType(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || w[i] != "ALTER" {
+			continue
+		}
+		j := i + 1
+		if j < len(w) && w[j] == "COLUMN" {
+			j++
+		}
+		j = skipIfExists(w, j)
+		if j >= len(w) || !identLike(w[j]) {
+			continue
+		}
+		k := j + 1
+		if k+1 < len(w) && w[k] == "SET" && w[k+1] == "DATA" {
+			k += 2
+		}
+		if k < len(w) && w[k] == "TYPE" {
+			return true
+		}
+	}
+	return false
+}
+
+// scanConvertCharset reports whether an ALTER TABLE statement converts the
+// table to another character set (a full-table rewrite on MySQL/MariaDB).
+func scanConvertCharset(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if hasWordPrefix(w[i:], "CONVERT", "TO", "CHARACTER", "SET") {
+			return true
+		}
+	}
+	return false
+}
+
+// scanAlterRename reports whether an ALTER TABLE statement renames the table
+// or a column. Handles RENAME TO/AS (table), RENAME COLUMN a TO b, the
+// PostgreSQL form without the COLUMN keyword, and MySQL's bare RENAME
+// new_name. Index, key, and constraint renames are invisible to applications
+// and are deliberately skipped.
+func scanAlterRename(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i+1 >= len(w) || w[i] != "RENAME" {
+			continue
+		}
+		switch w[i+1] {
+		case "INDEX", "KEY", "CONSTRAINT":
+			continue
+		case "TO", "AS", "COLUMN":
+			return true
+		}
+		if identLike(w[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// Describe renders one finding as a single human-readable line.
+func Describe(f Finding) string {
+	location := f.File
+	if f.Line > 0 {
+		location = fmt.Sprintf("%s:%d", f.File, f.Line)
+	}
+	return fmt.Sprintf("%s [%s] %s: %s (%s)", location, f.Severity, f.Rule, f.Message, f.Title)
+}

--- a/migration/lint/scan.go
+++ b/migration/lint/scan.go
@@ -1,0 +1,248 @@
+package lint
+
+import "strings"
+
+// scanMode selects dialect-specific lexing behavior for the lint scanner.
+// SQL comment and string syntax differ between the supported dialects in
+// ways that change where statements begin and end, so the scanner cannot be
+// dialect-blind: under PostgreSQL's standard_conforming_strings a backslash
+// is a literal character (treating it as an escape lets 'C:\' swallow the
+// rest of the file), while MySQL treats backslash as an escape and adds the
+// # line-comment and /*!...*/ executable-comment forms.
+type scanMode struct {
+	// hashComments makes # start a line comment (MySQL/MariaDB).
+	hashComments bool
+	// backslashEscapes makes a backslash escape the next character inside
+	// quoted strings (MySQL/MariaDB default; wrong for PostgreSQL).
+	backslashEscapes bool
+	// execComments treats MySQL executable comments /*!...*/ as real SQL:
+	// the server executes their content, so the linter must scan it.
+	execComments bool
+	// dollarQuotes recognizes $tag$...$tag$ string bodies (PostgreSQL).
+	dollarQuotes bool
+	// nestedComments lets block comments nest (PostgreSQL).
+	nestedComments bool
+}
+
+// modeForDialect maps a lint target dialect to its lexing behavior. An empty
+// or unknown dialect gets a hybrid that keeps hazards visible for every
+// supported dialect: the MySQL comment forms are honored, but backslash
+// escapes stay off because a trailing backslash in a standard-conforming
+// literal would otherwise hide every statement after it.
+func modeForDialect(dialect string) scanMode {
+	switch dialect {
+	case "mysql", "mariadb":
+		return scanMode{hashComments: true, backslashEscapes: true, execComments: true}
+	case "postgres":
+		return scanMode{dollarQuotes: true, nestedComments: true}
+	default:
+		return scanMode{hashComments: true, execComments: true, dollarQuotes: true, nestedComments: true}
+	}
+}
+
+// lintTokenKind classifies scanner tokens.
+type lintTokenKind int
+
+const (
+	tokWhitespace lintTokenKind = iota
+	tokComment
+	// tokString is a single-quoted or dollar-quoted literal, kept verbatim.
+	tokString
+	// tokQuotedIdent is a double-quoted or backtick-quoted identifier (or a
+	// MySQL double-quoted string), kept verbatim including the quotes.
+	tokQuotedIdent
+	tokWord
+	tokSemicolon
+	tokOp
+)
+
+// lintToken is one lexical token of a migration file.
+type lintToken struct {
+	kind lintTokenKind
+	text string
+	// start/end are byte offsets into the scanned input.
+	start int
+	end   int
+	// line is the 1-based line the token starts on.
+	line int
+}
+
+// scanSQL tokenizes SQL under the given dialect mode. It never fails: an
+// unterminated string or comment consumes the rest of the input.
+func scanSQL(input string, mode scanMode) []lintToken {
+	var toks []lintToken
+	n := len(input)
+	i := 0
+	if strings.HasPrefix(input, "\uFEFF") {
+		i = len("\uFEFF") // a UTF-8 BOM must not become part of the first word
+	}
+	line := 1
+	execDepth := 0
+	for i < n {
+		start := i
+		startLine := line
+		var kind lintTokenKind
+		kind, i, execDepth = nextLintToken(input, i, mode, execDepth)
+		toks = append(toks, lintToken{kind: kind, text: input[start:i], start: start, end: i, line: startLine})
+		line += strings.Count(input[start:i], "\n")
+	}
+	return toks
+}
+
+// nextLintToken scans one token starting at input[i] and returns its kind,
+// the offset past its end, and the updated executable-comment depth.
+func nextLintToken(input string, i int, mode scanMode, execDepth int) (kind lintTokenKind, end int, depth int) {
+	c := input[i]
+	switch {
+	case isSpaceByte(c):
+		return tokWhitespace, whitespaceEnd(input, i), execDepth
+	case isWordByte(c):
+		return tokWord, wordEnd(input, i), execDepth
+	case c == '\'':
+		return tokString, quotedEnd(input, i+1, '\'', mode.backslashEscapes), execDepth
+	case c == '"':
+		return tokQuotedIdent, quotedEnd(input, i+1, '"', mode.backslashEscapes), execDepth
+	case c == '`':
+		return tokQuotedIdent, quotedEnd(input, i+1, '`', false), execDepth
+	case c == ';':
+		return tokSemicolon, i + 1, execDepth
+	default:
+		return nextPunctToken(input, i, mode, execDepth)
+	}
+}
+
+// nextPunctToken handles the punctuation-led tokens: comment forms, dollar
+// quotes and bare operator characters.
+func nextPunctToken(input string, i int, mode scanMode, execDepth int) (kind lintTokenKind, end int, depth int) {
+	n := len(input)
+	c := input[i]
+	switch {
+	case c == '-' && i+1 < n && input[i+1] == '-':
+		return tokComment, lineCommentEnd(input, i+2), execDepth
+	case c == '#' && mode.hashComments:
+		return tokComment, lineCommentEnd(input, i+1), execDepth
+	case c == '/' && i+1 < n && input[i+1] == '*':
+		if mode.execComments && i+2 < n && input[i+2] == '!' {
+			// The /*!NNNNN marker is comment syntax, but its content is SQL
+			// the MySQL family executes; scan it as code until the */.
+			return tokComment, execCommentMarkerEnd(input, i+3), execDepth + 1
+		}
+		return tokComment, blockCommentEnd(input, i+2, mode.nestedComments), execDepth
+	case c == '*' && execDepth > 0 && i+1 < n && input[i+1] == '/':
+		return tokComment, i + 2, execDepth - 1
+	case c == '$' && mode.dollarQuotes:
+		if end, ok := dollarQuoteEnd(input, i); ok {
+			return tokString, end, execDepth
+		}
+		return tokOp, i + 1, execDepth
+	default:
+		return tokOp, i + 1, execDepth
+	}
+}
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
+// isWordByte reports whether a byte continues a bare word. Bytes >= 0x80 are
+// UTF-8 continuation or lead bytes, so non-ASCII identifiers stay one word.
+func isWordByte(c byte) bool {
+	return c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0x80
+}
+
+func whitespaceEnd(input string, i int) int {
+	for i < len(input) && isSpaceByte(input[i]) {
+		i++
+	}
+	return i
+}
+
+func wordEnd(input string, i int) int {
+	for i < len(input) && isWordByte(input[i]) {
+		i++
+	}
+	return i
+}
+
+func lineCommentEnd(input string, i int) int {
+	for i < len(input) && input[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+// execCommentMarkerEnd consumes the optional version digits of a /*!NNNNN
+// executable-comment marker.
+func execCommentMarkerEnd(input string, i int) int {
+	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
+		i++
+	}
+	return i
+}
+
+func blockCommentEnd(input string, i int, nested bool) int {
+	depth := 1
+	n := len(input)
+	for i < n {
+		switch {
+		case nested && input[i] == '/' && i+1 < n && input[i+1] == '*':
+			depth++
+			i += 2
+		case input[i] == '*' && i+1 < n && input[i+1] == '/':
+			i += 2
+			depth--
+			if depth == 0 {
+				return i
+			}
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// quotedEnd scans a quoted region opened before input[i] until its closing
+// quote, honoring doubled-quote escapes (two consecutive quote characters
+// stay inside the region) and, when enabled, backslash escapes.
+func quotedEnd(input string, i int, quote byte, backslashEscapes bool) int {
+	n := len(input)
+	for i < n {
+		switch {
+		case backslashEscapes && input[i] == '\\' && i+1 < n:
+			i += 2
+		case input[i] == quote:
+			if i+1 < n && input[i+1] == quote {
+				i += 2 // doubled quote stays inside the region
+				continue
+			}
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// dollarQuoteEnd matches a PostgreSQL dollar-quoted body $tag$...$tag$
+// starting at input[i] == '$' and returns the offset past its end. The tag
+// follows identifier rules (it must not start with a digit: $1 is a
+// positional parameter, not a delimiter).
+func dollarQuoteEnd(input string, i int) (int, bool) {
+	n := len(input)
+	j := i + 1
+	if j < n && input[j] >= '0' && input[j] <= '9' {
+		return 0, false
+	}
+	for j < n && isWordByte(input[j]) {
+		j++
+	}
+	if j >= n || input[j] != '$' {
+		return 0, false
+	}
+	delim := input[i : j+1]
+	rest := strings.Index(input[j+1:], delim)
+	if rest < 0 {
+		return n, true // unterminated: consume the rest of the input
+	}
+	return j + 1 + rest + len(delim), true
+}


### PR DESCRIPTION
## Summary

Implements #151: a sqlcheck-style linter for migration directories, exposed as `ptah lint` and as an importable `migration/lint` package.

```
$ ptah lint --dir ./migrations --dialect postgres --format github-actions
::error file=migrations/0000000002_bad.up.sql,line=2::DS101: DROP TABLE permanently deletes ...
```

### Rule families

| Code | Severity | Fires on |
|------|----------|----------|
| DS101 | error | `DROP TABLE` — except tables created earlier in the same migration (staging/backfill pattern) |
| DS102 | error | `ALTER TABLE ... DROP [COLUMN] [IF EXISTS] col` (excludes `DROP CONSTRAINT/INDEX/KEY/FOREIGN/PRIMARY/CHECK/...`) |
| DS103 | warning | `MODIFY`/`CHANGE [COLUMN]`, `ALTER [COLUMN] col [SET DATA] TYPE` |
| MF101 | warning | missing `.down.sql` pair |
| MF102 | warning | migration with no executable statements |
| MF103 | warning | file name the migrator will not pick up — or one it *ambiguously* runs (see below) |
| BC101 | warning | column/table renames incl. `RENAME TABLE a TO b` and MySQL's bare `RENAME new_name` (index/key/constraint renames exempt) |
| PG101 | warning | `CREATE [UNIQUE] INDEX` without `CONCURRENTLY` (postgres only) — except indexes on tables created in the same migration (empty table, no lock hazard) |
| PG102 | warning | `ALTER TYPE ... ADD VALUE` (postgres only) |
| MY101 | warning | lock-heavy ALTERs: `MODIFY`/`CHANGE`, `CONVERT TO CHARACTER SET`/`CHARSET` (mysql/mariadb only) — except statements pinning `ALGORITHM=INPLACE`/`INSTANT` or `LOCK=NONE`, where the server refuses a blocking rebuild |

Statement rules run on up migrations only — a down migration dropping what its up created is the expected shape.

### Matching engine

Rules scan a **token-word sequence** anchored at ALTER TABLE **clause boundaries** (after the table reference — `IF EXISTS`/`ONLY`/`*` modifiers handled in any order — and after top-level commas, paren-depth aware):

- optional keywords: `DROP email`, `MODIFY name VARCHAR(500)`, `ALTER email TYPE text`, `RENAME email TO e2` all match without `COLUMN`;
- quoted identifiers and string literals stay verbatim/opaque: a column named `"type"` never fakes DS103, a literal `'use DROP COLUMN x'` never fakes DS102, `WHERE b = 'CONCURRENTLY'` never masks PG101;
- a column named `modify`/`rename` in an `ADD COLUMN` clause does not fire (clause-head anchoring).

### Dialect-aware scanning

The scanner is dialect-aware because SQL comment/string syntax changes where statements begin and end. `--dialect` selects it (empty dialect = safe hybrid):

- **postgres**: `standard_conforming_strings` (a trailing `\` in a literal no longer swallows the rest of the file), dollar quotes, nested block comments; `#` stays an operator (`data #>> '{a}'`);
- **mysql/mariadb**: `#` line comments, backslash string escapes, `/*!...*/` executable comments are scanned as the real SQL they are;
- UTF-8 BOM and unicode identifiers handled everywhere.

### Migrator-consistent discovery

- Discovery recurses into subdirectories, exactly like `FSMigrationProvider`; `.sql` matched case-insensitively so `x.UP.SQL` earns MF103 instead of vanishing.
- The migrator's name regexp has an unescaped dot (#245), so `0000000001_cleanup.sql` actually *runs* as an up migration — lint classifies files exactly as the migrator does, scans their statements, and MF103 explains the ambiguity ("the migrator runs this as an up migration ... rename it"). Fixing the migrator regexp itself is tracked in #245.

### CLI

- `--dir`, `--dialect` (empty = all rules; explicit `--dialect ""` overrides the config), `--format text|json|github-actions`, `--config`, `--disable DS101|DS` (repeatable, unions with config), `--fail-on error|any|none`.
- Exit codes: 0 clean/below threshold, 1 findings at threshold, 2 usage/config errors — including unknown flags, stray positional arguments (previously they silently linted the default `--dir` — a silent CI false negative), missing migrations directory, and an invalid config dialect.
- GitHub annotations escape workflow-command characters (`%`, CR/LF; `:`/`,` in properties); JSON always emits a `findings` array, never `null`.

### Review

Self-reviewed by an adversarial agent fleet (2 rounds, ~90 agents): finders per lens (false positives, false negatives, engine mechanics, CLI semantics, test quality) with 2–3 adversarial skeptics verifying every finding empirically against the built CLI. 10 confirmed findings — all fixed and covered by tests (backslash literals, `#` comments, nested comments, `IF EXISTS ONLY` ordering — also caught by Copilot — cleanup.sql classification, nested dirs, positional args, same-file DS101/PG101 suppression, MY101 `ALGORITHM` pinning, `CONVERT TO CHARSET`); 3 rejected as documented behavior.

### Testing

- Engine: curated hazards with exact rule order and line numbers, optional-keyword matrix (35+ cases incl. negatives), dialect-aware scanning matrix (12 cases), same-file suppression matrix, migrator-lenient names, nested dirs, comment/literal opacity, dollar-quoted bodies, dialect gating, family disabling, config loading.
- CLI: fixture rule hits for all 10 codes, GH annotation format + escaping (incl. CR), config merge and explicit-empty-dialect override, fail-on thresholds, exit-code-2 matrix, JSON empty-array shape.
- `go test -count=1 ./...`, `golangci-lint run`, `go tool qtlint ./...` — all clean.

Closes #151

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB