### PR TITLE
Add YAML schema frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ capabilities include:
 - 📘 **Go Struct Parsing**
   Extracts tables, columns, indexes, foreign keys, and constraints from structured comments in Go code.
 
+- 🧾 **YAML Schema Input**
+  Generates SQL from language-agnostic `.yaml` / `.yml` schema files using the same internal schema model as Go annotations.
+
 - 🧱 **Schema Generation (DDL)**
   Builds platform-specific `CREATE TABLE`, `CREATE INDEX`, and other DDL statements.
 
@@ -70,6 +73,11 @@ The core package contains all fundamental components for parsing, transforming, 
   - Recursively parses Go source files to discover entity definitions
   - Extracts table directives, field mappings, indexes, enums, and embedded fields
   - Handles dependency analysis and topological sorting for proper table creation order
+
+- **`yamlschema/`** - Language-agnostic YAML schema frontend
+  - Parses `.yaml` / `.yml` schema files into the same `goschema.Database` IR used by Go annotations
+  - Supports tables, columns, indexes, constraints, enums, extensions, functions, RLS, roles, and dialect overrides
+  - Uses strict validation for unknown fields, duplicate ordered keys, unsupported objects, and invalid constraints
 
 - **`parser/`** - SQL DDL token-to-AST parser
   - Converts SQL DDL tokens into Abstract Syntax Tree nodes
@@ -383,6 +391,15 @@ type Booking struct {
 ./package-migrator generate --root-dir ./models --dialect mysql
 ```
 
+You can also generate from a language-agnostic YAML schema file:
+
+```bash
+./package-migrator generate --schema-file schema.yaml --dialect postgres
+```
+
+See [YAML Schema Input](docs/yaml_schema.md) for the supported file format,
+validation rules, and examples.
+
 3. **Compare and migrate**:
 
 ```bash
@@ -412,6 +429,9 @@ Generate SQL DDL statements from Go entities without touching the database:
 ./package-migrator generate --root-dir ./models --dialect mysql
 ./package-migrator generate --root-dir ./models --dialect mariadb
 ./package-migrator generate --root-dir ./models --dialect clickhouse
+
+# Generate from a YAML schema file instead of Go annotations
+./package-migrator generate --schema-file schema.yaml --dialect postgres
 ```
 
 ### Database Operations

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -12,21 +12,23 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/core/yamlschema"
 )
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "Generate schema from Go entities",
-	Long: `Generate database schema from Go entities in the specified directory.
+	Short: "Generate schema from Go entities or YAML schema files",
+	Long: `Generate database schema from Go entities in the specified directory or from a schema file.
 	
-This command scans the directory recursively for Go files with migrator directives
-and generates SQL schema for the specified database dialect(s).`,
+By default, this command scans the directory recursively for Go files with migrator directives.
+When --schema-file is set, it reads a language-agnostic YAML schema instead.`,
 	RunE: generateCommand,
 }
 
 const (
-	rootDirFlag = "root-dir"
-	dialectFlag = "dialect"
+	rootDirFlag    = "root-dir"
+	schemaFileFlag = "schema-file"
+	dialectFlag    = "dialect"
 )
 
 var generateFlags = map[string]cobraflags.Flag{
@@ -34,6 +36,11 @@ var generateFlags = map[string]cobraflags.Flag{
 		Name:  rootDirFlag,
 		Value: "./",
 		Usage: "Root directory to scan for Go entities",
+	},
+	schemaFileFlag: &cobraflags.StringFlag{
+		Name:  schemaFileFlag,
+		Value: "",
+		Usage: "YAML schema file to generate from instead of scanning Go entities",
 	},
 	dialectFlag: &cobraflags.StringFlag{
 		Name:  dialectFlag,
@@ -49,27 +56,12 @@ func NewGenerateCommand() *cobra.Command {
 
 func generateCommand(_ *cobra.Command, _ []string) error {
 	rootDir := generateFlags[rootDirFlag].GetString()
+	schemaFile := generateFlags[schemaFileFlag].GetString()
 	dialect := generateFlags[dialectFlag].GetString()
 
-	// Convert to absolute path
-	absPath, err := filepath.Abs(rootDir)
+	result, err := loadSchema(rootDir, schemaFile)
 	if err != nil {
-		return fmt.Errorf("error resolving path: %w", err)
-	}
-
-	// Check if directory exists
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return fmt.Errorf("directory does not exist: %s", absPath)
-	}
-
-	fmt.Printf("Scanning directory: %s\n", absPath)
-	fmt.Println("=" + strings.Repeat("=", len(absPath)+19))
-	fmt.Println()
-
-	// Parse the entire package recursively
-	result, err := goschema.ParseDir(absPath)
-	if err != nil {
-		return fmt.Errorf("error parsing package: %w", err)
+		return err
 	}
 
 	// Print summary
@@ -117,7 +109,7 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 		statements := renderer.GetOrderedCreateStatements(result, d)
 
 		for i, statement := range statements {
-			fmt.Printf("-- Table %d/%d\n", i+1, len(result.Tables))
+			fmt.Printf("-- Statement %d/%d\n", i+1, len(statements))
 			fmt.Println(statement)
 			fmt.Println()
 		}
@@ -126,4 +118,66 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func loadSchema(rootDir, schemaFile string) (*goschema.Database, error) {
+	if schemaFile != "" {
+		return loadSchemaFile(schemaFile)
+	}
+
+	// Convert to absolute path
+	absPath, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving path: %w", err)
+	}
+
+	// Check if directory exists
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("directory does not exist: %s", absPath)
+	}
+
+	fmt.Printf("Scanning directory: %s\n", absPath)
+	fmt.Println("=" + strings.Repeat("=", len(absPath)+19))
+	fmt.Println()
+
+	// Parse the entire package recursively
+	result, err := goschema.ParseDir(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing package: %w", err)
+	}
+	return result, nil
+}
+
+func loadSchemaFile(schemaFile string) (*goschema.Database, error) {
+	absPath, err := filepath.Abs(schemaFile)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving schema file: %w", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("schema file does not exist: %s", absPath)
+		}
+		return nil, fmt.Errorf("stat schema file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("schema file is a directory: %s", absPath)
+	}
+
+	switch strings.ToLower(filepath.Ext(absPath)) {
+	case ".yaml", ".yml":
+	default:
+		return nil, fmt.Errorf("unsupported schema file extension %q: only .yaml and .yml are supported", filepath.Ext(absPath))
+	}
+
+	fmt.Printf("Reading schema file: %s\n", absPath)
+	fmt.Println("=" + strings.Repeat("=", len(absPath)+21))
+	fmt.Println()
+
+	result, err := yamlschema.ParseFile(absPath)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing schema file: %w", err)
+	}
+	return result, nil
 }

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -1,0 +1,39 @@
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestLoadSchemaFile_YAML(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.yaml")
+	c.Assert(
+		os.WriteFile(path, []byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+`), 0o600),
+		qt.IsNil,
+	)
+
+	db, err := loadSchema("", path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "users")
+}
+
+func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.hcl")
+	c.Assert(os.WriteFile(path, []byte(`schema "users" {}`), 0o600), qt.IsNil)
+
+	_, err := loadSchema("", path)
+	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".hcl": only .yaml and .yml are supported`)
+}

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -551,6 +551,54 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	return createTable
 }
 
+// FromConstraint converts a goschema.Constraint to an AST table constraint.
+func FromConstraint(constraint goschema.Constraint) *ast.ConstraintNode {
+	switch strings.ToUpper(constraint.Type) {
+	case "PRIMARY KEY":
+		return ast.NewPrimaryKeyConstraint(constraint.Columns...)
+	case "UNIQUE":
+		return ast.NewUniqueConstraint(constraint.Name, constraint.Columns...)
+	case "FOREIGN KEY":
+		return ast.NewForeignKeyConstraint(constraint.Name, constraint.Columns, &ast.ForeignKeyRef{
+			Table:    constraint.ForeignTable,
+			Column:   constraint.ForeignColumn,
+			OnDelete: constraint.OnDelete,
+			OnUpdate: constraint.OnUpdate,
+		})
+	case "CHECK":
+		return &ast.ConstraintNode{
+			Type:       ast.CheckConstraint,
+			Name:       constraint.Name,
+			Expression: constraint.CheckExpression,
+		}
+	case "EXCLUDE":
+		return ast.NewExcludeConstraint(constraint.Name, constraint.UsingMethod, constraint.ExcludeElements).
+			SetWhereCondition(constraint.WhereCondition)
+	default:
+		return nil
+	}
+}
+
+func addTableConstraints(createTable *ast.CreateTableNode, table goschema.Table, constraints []goschema.Constraint) {
+	for _, constraint := range constraints {
+		if !constraintBelongsToTable(constraint, table) {
+			continue
+		}
+
+		node := FromConstraint(constraint)
+		if node != nil {
+			createTable.AddConstraint(node)
+		}
+	}
+}
+
+func constraintBelongsToTable(constraint goschema.Constraint, table goschema.Table) bool {
+	if constraint.Table != "" {
+		return constraint.Table == table.Name
+	}
+	return constraint.StructName == table.StructName
+}
+
 // FromIndex converts a goschema.Index to an ast.IndexNode for database index creation.
 //
 // This function transforms index metadata into an AST node that can be rendered
@@ -925,6 +973,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// Use the combined field list that includes embedded field expansions
 	for _, table := range database.Tables {
 		tableNode := FromTable(table, allFields, database.Enums, targetPlatform)
+		addTableConstraints(tableNode, table, database.Constraints)
 		statements.Statements = append(statements.Statements, tableNode)
 	}
 

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -483,6 +483,38 @@ func TestFromTable_CompositePrimaryKey(t *testing.T) {
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id", "role_id"})
 }
 
+func TestFromDatabase_TableLevelConstraints(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+		}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			Name:       "email",
+			Type:       "VARCHAR(255)",
+		}},
+		Constraints: []goschema.Constraint{{
+			StructName:      "User",
+			Name:            "chk_users_email",
+			Type:            "CHECK",
+			CheckExpression: "position('@' in email) > 1",
+		}},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+
+	c.Assert(result.Statements, qt.HasLen, 1)
+	table, ok := result.Statements[0].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(table.Constraints, qt.HasLen, 1)
+	c.Assert(table.Constraints[0].Type, qt.Equals, ast.CheckConstraint)
+	c.Assert(table.Constraints[0].Name, qt.Equals, "chk_users_email")
+	c.Assert(table.Constraints[0].Expression, qt.Equals, "position('@' in email) > 1")
+}
+
 func TestFromTable_FiltersByStructName(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -58,7 +58,7 @@ func sortTablesProcessQueue(queue *[]string, sorted *[]Table, dependencies map[s
 				}
 				inDegree[tableName]--
 				if inDegree[tableName] == 0 {
-					*queue = append(*queue, tableName)
+					*queue = insertSortedString(*queue, tableName)
 				}
 			}
 		}
@@ -134,6 +134,7 @@ func sortTablesByDependencies(r *Database) {
 			queue = append(queue, tableName)
 		}
 	}
+	sort.Strings(queue)
 
 	// Process queue
 	sortTablesProcessQueue(&queue, &sorted, r.Dependencies, inDegree, tableMap)
@@ -170,6 +171,28 @@ func buildDependencyGraph(r *Database) {
 	analyzeFieldForeignKeys(r)
 	analyzeEmbeddedFieldRelations(r)
 	buildFunctionDependencies(r)
+}
+
+// Finalize prepares a programmatically constructed Database for rendering.
+//
+// Parsers that do not go through ParseDir still need the same derived metadata
+// as Go annotations: deduplicated declarations, dependency maps, self-referencing
+// foreign keys, and dependency-ordered tables/functions.
+func Finalize(r *Database) {
+	if r.Dependencies == nil {
+		r.Dependencies = make(map[string][]string)
+	}
+	if r.FunctionDependencies == nil {
+		r.FunctionDependencies = make(map[string][]string)
+	}
+	if r.SelfReferencingForeignKeys == nil {
+		r.SelfReferencingForeignKeys = make(map[string][]SelfReferencingFK)
+	}
+
+	Deduplicate(r)
+	buildDependencyGraph(r)
+	sortTablesByDependencies(r)
+	sortFunctionsByDependencies(r)
 }
 
 // initializeDependencyMaps initializes the dependency tracking maps
@@ -617,6 +640,7 @@ func findZeroDegreeNodes(inDegree map[string]int) []string {
 			queue = append(queue, functionName)
 		}
 	}
+	sort.Strings(queue)
 	return queue
 }
 
@@ -627,12 +651,20 @@ func updateInDegreesAndQueue(current string, dependencies map[string][]string, i
 			if dep == current {
 				inDegree[functionName]--
 				if inDegree[functionName] == 0 {
-					queue = append(queue, functionName)
+					queue = insertSortedString(queue, functionName)
 				}
 			}
 		}
 	}
 	return queue
+}
+
+func insertSortedString(values []string, value string) []string {
+	index, _ := slices.BinarySearch(values, value)
+	values = append(values, "")
+	copy(values[index+1:], values[index:])
+	values[index] = value
+	return values
 }
 
 // handleCircularDependencies detects and handles circular dependencies in function relationships.

--- a/core/yamlschema/yamlschema.go
+++ b/core/yamlschema/yamlschema.go
@@ -1,0 +1,710 @@
+// Package yamlschema parses language-agnostic YAML schema files into goschema.
+package yamlschema
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+// ParseFile parses a YAML schema file into the same Database IR used by Go annotations.
+func ParseFile(path string) (*goschema.Database, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read schema file: %w", err)
+	}
+
+	return Parse(data)
+}
+
+// Parse parses a YAML schema document into the same Database IR used by Go annotations.
+func Parse(data []byte) (*goschema.Database, error) {
+	var doc document
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parse YAML schema: %w", err)
+	}
+	var extraDoc document
+	if err := decoder.Decode(&extraDoc); err == nil {
+		return nil, fmt.Errorf("parse YAML schema: multiple YAML documents are not supported")
+	} else if err != io.EOF {
+		return nil, fmt.Errorf("parse YAML schema: %w", err)
+	}
+
+	if len(doc.Views) > 0 {
+		return nil, fmt.Errorf("yaml views are not supported by the current goschema IR")
+	}
+	if len(doc.Triggers) > 0 {
+		return nil, fmt.Errorf("yaml triggers are not supported by the current goschema IR")
+	}
+
+	return doc.toDatabase()
+}
+
+type document struct {
+	Tables           map[string]tableSpec      `yaml:"tables"`
+	Indexes          map[string]indexSpec      `yaml:"indexes"`
+	Constraints      map[string]constraintSpec `yaml:"constraints"`
+	Enums            map[string]enumSpec       `yaml:"enums"`
+	Extensions       map[string]extensionSpec  `yaml:"extensions"`
+	Functions        map[string]functionSpec   `yaml:"functions"`
+	RLSPolicies      map[string]rlsPolicySpec  `yaml:"rls_policies"`
+	RLSEnabledTables map[string]rlsEnableSpec  `yaml:"rls_enabled_tables"`
+	RLSEnabled       map[string]rlsEnableSpec  `yaml:"rls_enabled"`
+	Roles            map[string]roleSpec       `yaml:"roles"`
+	Views            map[string]any            `yaml:"views"`
+	Triggers         map[string]any            `yaml:"triggers"`
+}
+
+type tableSpec struct {
+	StructName  stringScalar               `yaml:"struct_name"`
+	Name        stringScalar               `yaml:"name"`
+	Engine      stringScalar               `yaml:"engine"`
+	Comment     stringScalar               `yaml:"comment"`
+	PrimaryKey  stringList                 `yaml:"primary_key"`
+	Checks      stringList                 `yaml:"checks"`
+	CustomSQL   stringScalar               `yaml:"custom_sql"`
+	Columns     orderedMap[fieldSpec]      `yaml:"columns"`
+	Fields      orderedMap[fieldSpec]      `yaml:"fields"`
+	Indexes     orderedMap[indexSpec]      `yaml:"indexes"`
+	Constraints orderedMap[constraintSpec] `yaml:"constraints"`
+	RLSEnabled  bool                       `yaml:"rls_enabled"`
+	Platform    platformSpec               `yaml:"platform"`
+	Overrides   platformSpec               `yaml:"overrides"`
+}
+
+type fieldSpec struct {
+	FieldName      stringScalar `yaml:"field_name"`
+	Name           stringScalar `yaml:"name"`
+	Type           stringScalar `yaml:"type"`
+	Nullable       *bool        `yaml:"nullable"`
+	NotNull        bool         `yaml:"not_null"`
+	Primary        bool         `yaml:"primary"`
+	AutoIncrement  bool         `yaml:"auto_increment"`
+	AutoInc        bool         `yaml:"auto_inc"`
+	Unique         bool         `yaml:"unique"`
+	UniqueExpr     stringScalar `yaml:"unique_expr"`
+	Index          bool         `yaml:"index"`
+	Default        stringScalar `yaml:"default"`
+	DefaultExpr    stringScalar `yaml:"default_expr"`
+	Foreign        stringScalar `yaml:"foreign"`
+	ForeignKeyName stringScalar `yaml:"foreign_key_name"`
+	OnDelete       stringScalar `yaml:"on_delete"`
+	OnUpdate       stringScalar `yaml:"on_update"`
+	Enum           stringList   `yaml:"enum"`
+	Check          stringScalar `yaml:"check"`
+	CheckName      stringScalar `yaml:"check_name"`
+	Comment        stringScalar `yaml:"comment"`
+	Platform       platformSpec `yaml:"platform"`
+	Overrides      platformSpec `yaml:"overrides"`
+}
+
+type indexSpec struct {
+	Name        stringScalar `yaml:"name"`
+	Fields      stringList   `yaml:"fields"`
+	Columns     stringList   `yaml:"columns"`
+	Unique      bool         `yaml:"unique"`
+	Comment     stringScalar `yaml:"comment"`
+	Type        stringScalar `yaml:"type"`
+	Condition   stringScalar `yaml:"condition"`
+	Operator    stringScalar `yaml:"ops"`
+	TableName   stringScalar `yaml:"table"`
+	Granularity int          `yaml:"granularity"`
+}
+
+type constraintSpec struct {
+	Name            stringScalar `yaml:"name"`
+	Type            stringScalar `yaml:"type"`
+	Table           stringScalar `yaml:"table"`
+	UsingMethod     stringScalar `yaml:"using"`
+	ExcludeElements stringScalar `yaml:"elements"`
+	WhereCondition  stringScalar `yaml:"condition"`
+	CheckExpression stringScalar `yaml:"check"`
+	Columns         stringList   `yaml:"columns"`
+	ForeignTable    stringScalar `yaml:"foreign_table"`
+	ForeignColumn   stringScalar `yaml:"foreign_column"`
+	OnDelete        stringScalar `yaml:"on_delete"`
+	OnUpdate        stringScalar `yaml:"on_update"`
+	Comment         stringScalar `yaml:"comment"`
+}
+
+type enumSpec struct {
+	Values stringList `yaml:"values"`
+}
+
+func (s *enumSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode || value.Kind == yaml.ScalarNode {
+		var values stringList
+		if err := value.Decode(&values); err != nil {
+			return err
+		}
+		s.Values = values
+		return nil
+	}
+
+	type rawEnumSpec enumSpec
+	var raw rawEnumSpec
+	if err := decodeKnownFields(value, &raw); err != nil {
+		return err
+	}
+	*s = enumSpec(raw)
+	return nil
+}
+
+type extensionSpec struct {
+	Name        stringScalar `yaml:"name"`
+	IfNotExists bool         `yaml:"if_not_exists"`
+	Version     stringScalar `yaml:"version"`
+	Comment     stringScalar `yaml:"comment"`
+}
+
+type functionSpec struct {
+	StructName stringScalar `yaml:"struct_name"`
+	Name       stringScalar `yaml:"name"`
+	Parameters stringScalar `yaml:"parameters"`
+	Params     stringScalar `yaml:"params"`
+	Returns    stringScalar `yaml:"returns"`
+	Language   stringScalar `yaml:"language"`
+	Security   stringScalar `yaml:"security"`
+	Volatility stringScalar `yaml:"volatility"`
+	Body       stringScalar `yaml:"body"`
+	Comment    stringScalar `yaml:"comment"`
+}
+
+type rlsPolicySpec struct {
+	StructName          stringScalar `yaml:"struct_name"`
+	Name                stringScalar `yaml:"name"`
+	Table               stringScalar `yaml:"table"`
+	PolicyFor           stringScalar `yaml:"for"`
+	ToRoles             stringScalar `yaml:"to"`
+	UsingExpression     stringScalar `yaml:"using"`
+	WithCheckExpression stringScalar `yaml:"with_check"`
+	Comment             stringScalar `yaml:"comment"`
+}
+
+type rlsEnableSpec struct {
+	StructName stringScalar `yaml:"struct_name"`
+	Table      stringScalar `yaml:"table"`
+	Comment    stringScalar `yaml:"comment"`
+}
+
+type roleSpec struct {
+	StructName  stringScalar `yaml:"struct_name"`
+	Name        stringScalar `yaml:"name"`
+	Login       bool         `yaml:"login"`
+	Password    stringScalar `yaml:"password"`
+	Superuser   bool         `yaml:"superuser"`
+	CreateDB    bool         `yaml:"create_db"`
+	CreateRole  bool         `yaml:"create_role"`
+	Inherit     *bool        `yaml:"inherit"`
+	Replication bool         `yaml:"replication"`
+	Comment     stringScalar `yaml:"comment"`
+}
+
+type platformSpec map[string]map[string]stringScalar
+
+func (d document) toDatabase() (*goschema.Database, error) {
+	db := &goschema.Database{
+		Dependencies:               make(map[string][]string),
+		FunctionDependencies:       make(map[string][]string),
+		SelfReferencingForeignKeys: make(map[string][]goschema.SelfReferencingFK),
+	}
+
+	d.addEnums(db)
+	if err := d.addTables(db); err != nil {
+		return nil, err
+	}
+	if err := d.addIndexes(db); err != nil {
+		return nil, err
+	}
+	if err := d.addConstraints(db); err != nil {
+		return nil, err
+	}
+	d.addExtensions(db)
+	d.addFunctions(db)
+	d.addRLS(db)
+	d.addRoles(db)
+
+	goschema.Finalize(db)
+	return db, nil
+}
+
+func (d document) addEnums(db *goschema.Database) {
+	for _, name := range sortedKeys(d.Enums) {
+		db.Enums = append(db.Enums, goschema.Enum{
+			Name:   name,
+			Values: cleanStrings(d.Enums[name].Values),
+		})
+	}
+}
+
+func (d document) addTables(db *goschema.Database) error {
+	for _, tableKey := range sortedKeys(d.Tables) {
+		table := d.Tables[tableKey]
+		structName := valueOrDefault(table.StructName, tableKey)
+		tableName := valueOrDefault(table.Name, tableKey)
+
+		db.Tables = append(db.Tables, goschema.Table{
+			StructName: structName,
+			Name:       tableName,
+			Engine:     string(table.Engine),
+			Comment:    string(table.Comment),
+			PrimaryKey: cleanStrings(table.PrimaryKey),
+			Checks:     cleanStrings(table.Checks),
+			CustomSQL:  string(table.CustomSQL),
+			Overrides:  mergePlatform(table.Platform, table.Overrides),
+		})
+
+		if err := addFields(db, structName, table.Columns, table.Fields); err != nil {
+			return err
+		}
+		if err := addTableIndexes(db, structName, table.Indexes); err != nil {
+			return err
+		}
+		if err := addTableConstraints(db, structName, tableName, table.Constraints); err != nil {
+			return err
+		}
+		if table.RLSEnabled {
+			db.RLSEnabledTables = append(db.RLSEnabledTables, goschema.RLSEnabledTable{
+				StructName: structName,
+				Table:      tableName,
+			})
+		}
+	}
+
+	return nil
+}
+
+func addFields(db *goschema.Database, structName string, columns, fields orderedMap[fieldSpec]) error {
+	seen := make(map[string]bool)
+	for _, column := range columns {
+		seen[column.Name] = true
+		db.Fields = append(db.Fields, buildField(structName, column.Name, column.Value, db))
+	}
+
+	for _, field := range fields {
+		if seen[field.Name] {
+			return fmt.Errorf("duplicate column %q in columns and fields", field.Name)
+		}
+		db.Fields = append(db.Fields, buildField(structName, field.Name, field.Value, db))
+	}
+
+	return nil
+}
+
+func buildField(structName, key string, spec fieldSpec, db *goschema.Database) goschema.Field {
+	fieldName := valueOrDefault(spec.FieldName, key)
+	columnName := valueOrDefault(spec.Name, key)
+	fieldType := string(spec.Type)
+	enumValues := cleanStrings(spec.Enum)
+	if len(enumValues) > 0 && (fieldType == "" || fieldType == "ENUM") {
+		enumName := "enum_" + strings.ToLower(structName) + "_" + strings.ToLower(fieldName)
+		db.Enums = append(db.Enums, goschema.Enum{Name: enumName, Values: enumValues})
+		fieldType = enumName
+	}
+
+	nullable := true
+	if spec.Nullable != nil {
+		nullable = *spec.Nullable
+	}
+	if spec.NotNull {
+		nullable = false
+	}
+
+	return goschema.Field{
+		StructName:     structName,
+		FieldName:      fieldName,
+		Name:           columnName,
+		Type:           fieldType,
+		Nullable:       nullable,
+		Primary:        spec.Primary,
+		AutoInc:        spec.AutoIncrement || spec.AutoInc,
+		Unique:         spec.Unique,
+		UniqueExpr:     string(spec.UniqueExpr),
+		Default:        string(spec.Default),
+		DefaultExpr:    string(spec.DefaultExpr),
+		Foreign:        string(spec.Foreign),
+		ForeignKeyName: string(spec.ForeignKeyName),
+		OnDelete:       string(spec.OnDelete),
+		OnUpdate:       string(spec.OnUpdate),
+		Enum:           enumValues,
+		Check:          string(spec.Check),
+		CheckName:      string(spec.CheckName),
+		Comment:        string(spec.Comment),
+		Overrides:      mergePlatform(spec.Platform, spec.Overrides),
+	}
+}
+
+func addTableIndexes(db *goschema.Database, structName string, indexes orderedMap[indexSpec]) error {
+	for _, index := range indexes {
+		value, err := buildIndex(index.Name, structName, index.Value)
+		if err != nil {
+			return err
+		}
+		db.Indexes = append(db.Indexes, value)
+	}
+	return nil
+}
+
+func (d document) addIndexes(db *goschema.Database) error {
+	for _, key := range sortedKeys(d.Indexes) {
+		index, err := buildIndex(key, "", d.Indexes[key])
+		if err != nil {
+			return err
+		}
+		db.Indexes = append(db.Indexes, index)
+	}
+	return nil
+}
+
+func buildIndex(key, structName string, spec indexSpec) (goschema.Index, error) {
+	fields := cleanStrings(spec.Fields)
+	if len(fields) == 0 {
+		fields = cleanStrings(spec.Columns)
+	}
+	if len(fields) == 0 {
+		return goschema.Index{}, fmt.Errorf("index %q requires fields", key)
+	}
+	if structName == "" && string(spec.TableName) == "" {
+		return goschema.Index{}, fmt.Errorf("top-level index %q requires table", key)
+	}
+
+	return goschema.Index{
+		StructName:  structName,
+		Name:        valueOrDefault(spec.Name, key),
+		Fields:      fields,
+		Unique:      spec.Unique,
+		Comment:     string(spec.Comment),
+		Type:        string(spec.Type),
+		Condition:   string(spec.Condition),
+		Operator:    string(spec.Operator),
+		TableName:   string(spec.TableName),
+		Granularity: spec.Granularity,
+	}, nil
+}
+
+func addTableConstraints(db *goschema.Database, structName, tableName string, constraints orderedMap[constraintSpec]) error {
+	for _, constraint := range constraints {
+		value, err := buildConstraint(constraint.Name, structName, tableName, constraint.Value)
+		if err != nil {
+			return err
+		}
+		db.Constraints = append(db.Constraints, value)
+	}
+	return nil
+}
+
+func (d document) addConstraints(db *goschema.Database) error {
+	for _, key := range sortedKeys(d.Constraints) {
+		constraint, err := buildConstraint(key, "", "", d.Constraints[key])
+		if err != nil {
+			return err
+		}
+		db.Constraints = append(db.Constraints, constraint)
+	}
+	return nil
+}
+
+func buildConstraint(key, structName, tableName string, spec constraintSpec) (goschema.Constraint, error) {
+	constraintTable := string(spec.Table)
+	if constraintTable == "" && structName == "" {
+		constraintTable = tableName
+	}
+	constraintType := strings.ToUpper(string(spec.Type))
+	columns := cleanStrings(spec.Columns)
+	if err := validateConstraint(key, structName, constraintTable, constraintType, columns, spec); err != nil {
+		return goschema.Constraint{}, err
+	}
+
+	return goschema.Constraint{
+		StructName:      structName,
+		Name:            valueOrDefault(spec.Name, key),
+		Type:            constraintType,
+		Table:           constraintTable,
+		UsingMethod:     string(spec.UsingMethod),
+		ExcludeElements: string(spec.ExcludeElements),
+		WhereCondition:  string(spec.WhereCondition),
+		CheckExpression: string(spec.CheckExpression),
+		Columns:         columns,
+		ForeignTable:    string(spec.ForeignTable),
+		ForeignColumn:   string(spec.ForeignColumn),
+		OnDelete:        string(spec.OnDelete),
+		OnUpdate:        string(spec.OnUpdate),
+		Comment:         string(spec.Comment),
+	}, nil
+}
+
+func validateConstraint(key, structName, tableName, constraintType string, columns []string, spec constraintSpec) error {
+	if structName == "" && tableName == "" {
+		return fmt.Errorf("top-level constraint %q requires table", key)
+	}
+
+	switch constraintType {
+	case "PRIMARY KEY", "UNIQUE":
+		if len(columns) == 0 {
+			return fmt.Errorf("constraint %q requires columns", key)
+		}
+	case "FOREIGN KEY":
+		if len(columns) == 0 {
+			return fmt.Errorf("constraint %q requires columns", key)
+		}
+		if spec.ForeignTable == "" || spec.ForeignColumn == "" {
+			return fmt.Errorf("constraint %q requires foreign_table and foreign_column", key)
+		}
+	case "CHECK":
+		if spec.CheckExpression == "" {
+			return fmt.Errorf("constraint %q requires check", key)
+		}
+	case "EXCLUDE":
+		if spec.UsingMethod == "" || spec.ExcludeElements == "" {
+			return fmt.Errorf("constraint %q requires using and elements", key)
+		}
+	case "":
+		return fmt.Errorf("constraint %q requires type", key)
+	default:
+		return fmt.Errorf("constraint %q has unsupported type %q", key, constraintType)
+	}
+	return nil
+}
+
+func (d document) addExtensions(db *goschema.Database) {
+	for _, key := range sortedKeys(d.Extensions) {
+		spec := d.Extensions[key]
+		db.Extensions = append(db.Extensions, goschema.Extension{
+			Name:        valueOrDefault(spec.Name, key),
+			IfNotExists: spec.IfNotExists,
+			Version:     string(spec.Version),
+			Comment:     string(spec.Comment),
+		})
+	}
+}
+
+func (d document) addFunctions(db *goschema.Database) {
+	for _, key := range sortedKeys(d.Functions) {
+		spec := d.Functions[key]
+		parameters := string(spec.Parameters)
+		if parameters == "" {
+			parameters = string(spec.Params)
+		}
+
+		fn := goschema.Function{
+			StructName: string(spec.StructName),
+			Name:       valueOrDefault(spec.Name, key),
+			Parameters: parameters,
+			Returns:    string(spec.Returns),
+			Language:   string(spec.Language),
+			Security:   string(spec.Security),
+			Volatility: string(spec.Volatility),
+			Body:       string(spec.Body),
+			Comment:    string(spec.Comment),
+		}
+		fn.Canonicalize()
+		db.Functions = append(db.Functions, fn)
+	}
+}
+
+func (d document) addRLS(db *goschema.Database) {
+	for _, key := range sortedKeys(d.RLSEnabledTables) {
+		db.RLSEnabledTables = append(db.RLSEnabledTables, buildRLSEnabledTable(key, d.RLSEnabledTables[key]))
+	}
+	for _, key := range sortedKeys(d.RLSEnabled) {
+		db.RLSEnabledTables = append(db.RLSEnabledTables, buildRLSEnabledTable(key, d.RLSEnabled[key]))
+	}
+
+	for _, key := range sortedKeys(d.RLSPolicies) {
+		spec := d.RLSPolicies[key]
+		db.RLSPolicies = append(db.RLSPolicies, goschema.RLSPolicy{
+			StructName:          string(spec.StructName),
+			Name:                valueOrDefault(spec.Name, key),
+			Table:               string(spec.Table),
+			PolicyFor:           string(spec.PolicyFor),
+			ToRoles:             string(spec.ToRoles),
+			UsingExpression:     string(spec.UsingExpression),
+			WithCheckExpression: string(spec.WithCheckExpression),
+			Comment:             string(spec.Comment),
+		})
+	}
+}
+
+func buildRLSEnabledTable(key string, spec rlsEnableSpec) goschema.RLSEnabledTable {
+	return goschema.RLSEnabledTable{
+		StructName: string(spec.StructName),
+		Table:      valueOrDefault(spec.Table, key),
+		Comment:    string(spec.Comment),
+	}
+}
+
+func (d document) addRoles(db *goschema.Database) {
+	for _, key := range sortedKeys(d.Roles) {
+		spec := d.Roles[key]
+		inherit := true
+		if spec.Inherit != nil {
+			inherit = *spec.Inherit
+		}
+		db.Roles = append(db.Roles, goschema.Role{
+			StructName:  string(spec.StructName),
+			Name:        valueOrDefault(spec.Name, key),
+			Login:       spec.Login,
+			Password:    string(spec.Password),
+			Superuser:   spec.Superuser,
+			CreateDB:    spec.CreateDB,
+			CreateRole:  spec.CreateRole,
+			Inherit:     inherit,
+			Replication: spec.Replication,
+			Comment:     string(spec.Comment),
+		})
+	}
+}
+
+func sortedKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func valueOrDefault(value stringScalar, fallback string) string {
+	if string(value) != "" {
+		return string(value)
+	}
+	return fallback
+}
+
+func cleanStrings(values stringList) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func mergePlatform(primary, secondary platformSpec) map[string]map[string]string {
+	if len(primary) == 0 && len(secondary) == 0 {
+		return nil
+	}
+
+	result := make(map[string]map[string]string)
+	copyPlatform(result, primary)
+	copyPlatform(result, secondary)
+	return result
+}
+
+func copyPlatform(target map[string]map[string]string, source platformSpec) {
+	for platform, values := range source {
+		if target[platform] == nil {
+			target[platform] = make(map[string]string)
+		}
+		for key, value := range values {
+			target[platform][key] = string(value)
+		}
+	}
+}
+
+type stringScalar string
+
+func (s *stringScalar) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("expected scalar, got %s", value.ShortTag())
+	}
+	if value.Tag == "!!null" {
+		*s = ""
+		return nil
+	}
+	*s = stringScalar(value.Value)
+	return nil
+}
+
+type stringList []string
+
+func (s *stringList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.SequenceNode:
+		values := make([]string, 0, len(value.Content))
+		for _, item := range value.Content {
+			var scalar stringScalar
+			if err := item.Decode(&scalar); err != nil {
+				return err
+			}
+			values = append(values, string(scalar))
+		}
+		*s = values
+	case yaml.ScalarNode:
+		if value.Tag == "!!null" || value.Value == "" {
+			*s = nil
+			return nil
+		}
+		*s = strings.Split(value.Value, ",")
+	default:
+		return fmt.Errorf("expected scalar or sequence, got %s", value.ShortTag())
+	}
+	return nil
+}
+
+type orderedMap[V any] []orderedEntry[V]
+
+type orderedEntry[V any] struct {
+	Name  string
+	Value V
+}
+
+func (m *orderedMap[V]) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode && value.Tag == "!!null" {
+		*m = nil
+		return nil
+	}
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping, got %s", value.ShortTag())
+	}
+
+	entries := make([]orderedEntry[V], 0, len(value.Content)/2)
+	seen := make(map[string]bool, len(value.Content)/2)
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+
+		if seen[keyNode.Value] {
+			return fmt.Errorf("duplicate key %q", keyNode.Value)
+		}
+		seen[keyNode.Value] = true
+
+		var entryValue V
+		if err := decodeKnownFields(valueNode, &entryValue); err != nil {
+			return err
+		}
+		entries = append(entries, orderedEntry[V]{
+			Name:  keyNode.Value,
+			Value: entryValue,
+		})
+	}
+
+	*m = entries
+	return nil
+}
+
+func decodeKnownFields[V any](node *yaml.Node, target *V) error {
+	var buffer bytes.Buffer
+	encoder := yaml.NewEncoder(&buffer)
+	if err := encoder.Encode(node); err != nil {
+		return err
+	}
+	if err := encoder.Close(); err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecoder(&buffer)
+	decoder.KnownFields(true)
+	return decoder.Decode(target)
+}

--- a/core/yamlschema/yamlschema_test.go
+++ b/core/yamlschema/yamlschema_test.go
@@ -1,0 +1,251 @@
+package yamlschema_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/core/yamlschema"
+)
+
+func TestParse_IssueExampleMatchesGoAnnotations(t *testing.T) {
+	c := qt.New(t)
+
+	yamlDB, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+      email: { type: VARCHAR(255), not_null: true, unique: true }
+    indexes:
+      idx_users_email: { fields: [email] }
+`))
+	c.Assert(err, qt.IsNil)
+
+	goDB := goschema.ParseSource("schema.go", `
+package test
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
+	Email string
+
+	//migrator:schema:index name="idx_users_email" fields="email"
+	_ int
+}
+`)
+
+	yamlSQL := strings.Join(renderer.GetOrderedCreateStatements(yamlDB, "postgres"), "\n")
+	goSQL := strings.Join(renderer.GetOrderedCreateStatements(&goDB, "postgres"), "\n")
+	c.Assert(yamlSQL, qt.Equals, goSQL)
+}
+
+func TestParse_CoversCurrentSchemaIR(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := yamlschema.Parse([]byte(`
+enums:
+  account_status: [active, suspended]
+extensions:
+  pg_trgm:
+    if_not_exists: true
+functions:
+  current_tenant:
+    params: ""
+    returns: TEXT
+    language: SQL
+    security: DEFINER
+    volatility: STABLE
+    body: SELECT current_setting('app.current_tenant_id')
+roles:
+  app_user:
+    login: true
+    inherit: false
+tables:
+  tenants:
+    columns:
+      id: { type: SERIAL, primary: true }
+  users:
+    rls_enabled: true
+    columns:
+      id: { type: SERIAL, primary: true }
+      tenant_id:
+        type: INTEGER
+        not_null: true
+        foreign: tenants(id)
+        foreign_key_name: fk_users_tenant
+        on_delete: CASCADE
+      status:
+        type: account_status
+        not_null: true
+        default: active
+      email:
+        type: VARCHAR(255)
+        not_null: true
+        unique: true
+        platform:
+          mysql:
+            type: VARCHAR(191)
+    indexes:
+      idx_users_email:
+        fields: [email]
+        unique: true
+    constraints:
+      chk_users_email:
+        type: CHECK
+        check: "position('@' in email) > 1"
+rls_policies:
+  users_tenant_isolation:
+    table: users
+    for: ALL
+    to: app_user
+    using: tenant_id = current_tenant()::INTEGER
+`))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(db.Tables, qt.HasLen, 2)
+	c.Assert(db.Tables[0].Name, qt.Equals, "tenants")
+	c.Assert(db.Tables[1].Name, qt.Equals, "users")
+	c.Assert(db.Fields, qt.HasLen, 5)
+	c.Assert(db.Enums, qt.DeepEquals, []goschema.Enum{{Name: "account_status", Values: []string{"active", "suspended"}}})
+	c.Assert(db.Extensions, qt.HasLen, 1)
+	c.Assert(db.Functions, qt.HasLen, 1)
+	c.Assert(db.Functions[0].Returns, qt.Equals, "text")
+	c.Assert(db.Functions[0].Language, qt.Equals, "sql")
+	c.Assert(db.Roles, qt.HasLen, 1)
+	c.Assert(db.Roles[0].Inherit, qt.IsFalse)
+	c.Assert(db.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(db.RLSPolicies, qt.HasLen, 1)
+	c.Assert(db.Constraints, qt.HasLen, 1)
+	c.Assert(db.Dependencies["users"], qt.DeepEquals, []string{"tenants"})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n")
+	c.Assert(sql, qt.Contains, `CONSTRAINT chk_users_email CHECK (position('@' in email) > 1)`)
+	c.Assert(sql, qt.Contains, `ALTER TABLE users ENABLE ROW LEVEL SECURITY;`)
+	c.Assert(sql, qt.Contains, `CREATE POLICY users_tenant_isolation ON users`)
+}
+
+func TestParse_TrimsScalarEnumValues(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := yamlschema.Parse([]byte(`
+enums:
+  account_status: active, suspended
+`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Enums, qt.DeepEquals, []goschema.Enum{{
+		Name:   "account_status",
+		Values: []string{"active", "suspended"},
+	}})
+}
+
+func TestParse_RejectsDuplicateOrderedMappingKeys(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+      id: { type: BIGSERIAL, primary: true }
+`))
+	c.Assert(err, qt.ErrorMatches, `parse YAML schema: duplicate key "id"`)
+}
+
+func TestParse_RejectsDuplicateTopLevelMappingKeys(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+  users:
+    columns:
+      id: { type: BIGSERIAL, primary: true }
+`))
+	c.Assert(err, qt.ErrorMatches, `(?s)parse YAML schema: .*mapping key "users" already defined.*`)
+}
+
+func TestParse_RejectsInvalidIndexesAndConstraints(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+indexes:
+  idx_users_email:
+    fields: [email]
+`))
+	c.Assert(err, qt.ErrorMatches, `top-level index "idx_users_email" requires table`)
+
+	_, err = yamlschema.Parse([]byte(`
+constraints:
+  chk_users_email:
+    type: CHECK
+    check: "position('@' in email) > 1"
+`))
+	c.Assert(err, qt.ErrorMatches, `top-level constraint "chk_users_email" requires table`)
+
+	_, err = yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      email: { type: VARCHAR(255), not_null: true }
+    constraints:
+      chk_users_email:
+        check: "position('@' in email) > 1"
+`))
+	c.Assert(err, qt.ErrorMatches, `constraint "chk_users_email" requires type`)
+}
+
+func TestParse_RejectsMultipleDocuments(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+---
+tables:
+  posts:
+    columns:
+      id: { type: SERIAL, primary: true }
+`))
+	c.Assert(err, qt.ErrorMatches, `parse YAML schema: multiple YAML documents are not supported`)
+}
+
+func TestParse_RejectsUnsupportedViewsAndTriggers(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+views:
+  active_users: {}
+`))
+	c.Assert(err, qt.ErrorMatches, `yaml views are not supported by the current goschema IR`)
+
+	_, err = yamlschema.Parse([]byte(`
+triggers:
+  update_timestamp: {}
+`))
+	c.Assert(err, qt.ErrorMatches, `yaml triggers are not supported by the current goschema IR`)
+}
+
+func TestParse_RejectsUnknownColumnAttributes(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id:
+        type: SERIAL
+        primarry: true
+`))
+	c.Assert(err, qt.ErrorMatches, `(?s)parse YAML schema: .*field primarry not found.*`)
+}

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -18,6 +18,7 @@ For a detailed visual representation of the system architecture, see the [Top-Le
 
 ```
 Go Code (Annotations) ──┐
+YAML Schema Files ──────┤
                         ├─► Parsing Layer ──► Core Processing ──► Migration System ──► Database
 SQL Statements ─────────┘                                                                  │
                                                                                            │
@@ -26,7 +27,7 @@ Live Database ──────────────────────
 
 The system operates through four main layers:
 
-1. **Input Sources**: Go code with annotations, SQL statements, and live database connections
+1. **Input Sources**: Go code with annotations, YAML schema files, SQL statements, and live database connections
 2. **Parsing Layer**: Tokenization, AST construction, and entity extraction
 3. **Core Processing**: Schema representation, comparison, and SQL generation
 4. **Migration System**: Planning, generation, and execution of database changes
@@ -50,6 +51,14 @@ The system operates through four main layers:
   - Recursively parses Go source files
   - Discovers entity definitions and dependencies
   - Handles embedded structs and topological sorting
+
+#### yamlschema Package
+- **Purpose**: Parses language-agnostic YAML schema files into the same `goschema.Database` IR used by Go annotations
+- **Input**: `.yaml` and `.yml` files passed to `ptah generate --schema-file`
+- **Functionality**:
+  - Supports tables, columns, indexes, constraints, enums, extensions, functions, row-level security, roles, and dialect overrides
+  - Preserves author order for table-local columns, indexes, and constraints while keeping top-level maps deterministic
+  - Applies strict validation for unknown fields, duplicate ordered keys, invalid indexes and constraints, multiple YAML documents, and currently unsupported views/triggers
 
 #### lexer Package
 - **Purpose**: Tokenizes SQL statements into structured tokens

--- a/docs/yaml_schema.md
+++ b/docs/yaml_schema.md
@@ -1,0 +1,258 @@
+# YAML Schema Input
+
+Ptah can generate SQL from a language-agnostic YAML schema file instead of
+scanning Go source annotations. The YAML frontend builds the same
+`goschema.Database` intermediate representation as Go annotations, then runs the
+normal finalization, dependency ordering, AST conversion, and dialect renderers.
+
+Use YAML input when schema ownership should not depend on Go structs or when a
+tool needs to generate a Ptah schema from another language.
+
+## Generate SQL
+
+```bash
+go run ./cmd generate --schema-file schema.yaml --dialect postgres
+```
+
+`--schema-file` accepts `.yaml` and `.yml` files. When it is set, `--root-dir`
+is ignored. If `--dialect` is omitted, Ptah renders every supported dialect.
+
+## Minimal Example
+
+```yaml
+tables:
+  users:
+    columns:
+      id:
+        type: SERIAL
+        primary: true
+      email:
+        type: VARCHAR(255)
+        not_null: true
+        unique: true
+    indexes:
+      idx_users_email:
+        fields: [email]
+```
+
+This is equivalent to:
+
+```go
+//migrator:schema:table name="users"
+type User struct {
+    //migrator:schema:field name="id" type="SERIAL" primary="true"
+    ID int64
+
+    //migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
+    Email string
+
+    //migrator:schema:index name="idx_users_email" fields="email"
+    _ int
+}
+```
+
+## Complete Shape
+
+Top-level objects are maps. Their keys are used as default object names when a
+`name` field is not provided.
+
+```yaml
+enums:
+  account_status: [active, suspended]
+
+extensions:
+  pg_trgm:
+    if_not_exists: true
+
+functions:
+  current_tenant:
+    params: ""
+    returns: TEXT
+    language: SQL
+    security: DEFINER
+    volatility: STABLE
+    body: SELECT current_setting('app.current_tenant_id')
+
+roles:
+  app_user:
+    login: true
+    inherit: false
+
+tables:
+  tenants:
+    columns:
+      id: { type: SERIAL, primary: true }
+
+  users:
+    rls_enabled: true
+    columns:
+      id: { type: SERIAL, primary: true }
+      tenant_id:
+        type: INTEGER
+        not_null: true
+        foreign: tenants(id)
+        foreign_key_name: fk_users_tenant
+        on_delete: CASCADE
+      status:
+        type: account_status
+        not_null: true
+        default: active
+      email:
+        type: VARCHAR(255)
+        not_null: true
+        unique: true
+        platform:
+          mysql:
+            type: VARCHAR(191)
+    indexes:
+      idx_users_email:
+        fields: [email]
+        unique: true
+    constraints:
+      chk_users_email:
+        type: CHECK
+        check: "position('@' in email) > 1"
+
+rls_policies:
+  users_tenant_isolation:
+    table: users
+    for: ALL
+    to: app_user
+    using: tenant_id = current_tenant()::INTEGER
+```
+
+## Tables
+
+Each entry under `tables` declares one table.
+
+| Key | Meaning |
+|---|---|
+| `name` | Database table name. Defaults to the map key. |
+| `struct_name` | Internal goschema owner name. Defaults to the map key. |
+| `engine` | Table engine value used by dialects that support it. |
+| `comment` | Table comment. |
+| `primary_key` | Table-level primary key column list. Scalar comma-separated values and YAML sequences are both accepted. |
+| `checks` | Table-level check expressions. |
+| `custom_sql` | Custom SQL attached to the table. |
+| `columns` / `fields` | Ordered column map. Use one or the other; duplicate names across both are rejected. |
+| `indexes` | Ordered table-local index map. |
+| `constraints` | Ordered table-local constraint map. |
+| `rls_enabled` | Adds row-level security enablement for this table. |
+| `platform` / `overrides` | Dialect-specific override map, for example `platform.mysql.type`. |
+
+Table-local `columns`, `fields`, `indexes`, and `constraints` preserve YAML
+author order. Top-level maps render deterministically by sorted key.
+
+## Columns
+
+Columns support the same information as field annotations:
+
+| Key | Meaning |
+|---|---|
+| `name` | Database column name. Defaults to the column map key. |
+| `field_name` | Internal goschema field name. Defaults to the column map key. |
+| `type` | SQL type or enum type name. |
+| `nullable` | Explicit nullability. Defaults to nullable unless `not_null` is true. |
+| `not_null` | Marks the column `NOT NULL`. |
+| `primary` | Marks the column as a primary key. |
+| `auto_increment` / `auto_inc` | Marks the column as auto-incrementing. |
+| `unique` | Marks the column unique. |
+| `unique_expr` | Unique expression. |
+| `index` | Requests an index for the column. |
+| `default` | Literal default value. |
+| `default_expr` | Default SQL expression, such as `NOW()`. |
+| `foreign` | Foreign key reference in `table(column)` form. |
+| `foreign_key_name` | Explicit foreign key constraint name. |
+| `on_delete` / `on_update` | Foreign key actions. |
+| `enum` | Inline enum values. Scalar comma-separated values and sequences are accepted. |
+| `check` | Column check expression. |
+| `check_name` | Explicit column check constraint name. |
+| `comment` | Column comment. |
+| `platform` / `overrides` | Dialect-specific overrides. |
+
+If `enum` is provided and `type` is empty or `ENUM`, Ptah creates an enum named
+`enum_<struct_name>_<field_name>` and uses that generated type for the column.
+
+## Indexes
+
+Indexes can be table-local under `tables.<table>.indexes` or top-level under
+`indexes`.
+
+```yaml
+indexes:
+  idx_users_email:
+    table: users
+    fields: [email]
+    unique: true
+```
+
+| Key | Meaning |
+|---|---|
+| `name` | Index name. Defaults to the map key. |
+| `table` | Target table. Required for top-level indexes. |
+| `fields` / `columns` | Indexed columns. Required. |
+| `unique` | Emits a unique index. |
+| `comment` | Index comment. |
+| `type` | Dialect-specific index type. |
+| `condition` | Partial-index condition where supported. |
+| `ops` | Operator or operator class string. |
+| `granularity` | ClickHouse data-skipping index granularity. |
+
+## Constraints
+
+Constraints can be table-local under `tables.<table>.constraints` or top-level
+under `constraints`.
+
+```yaml
+constraints:
+  fk_users_tenant:
+    table: users
+    type: FOREIGN KEY
+    columns: [tenant_id]
+    foreign_table: tenants
+    foreign_column: id
+    on_delete: CASCADE
+```
+
+Supported `type` values are `PRIMARY KEY`, `UNIQUE`, `FOREIGN KEY`, `CHECK`,
+and `EXCLUDE`.
+
+| Type | Required keys |
+|---|---|
+| `PRIMARY KEY` | `columns` |
+| `UNIQUE` | `columns` |
+| `FOREIGN KEY` | `columns`, `foreign_table`, `foreign_column` |
+| `CHECK` | `check` |
+| `EXCLUDE` | `using`, `elements` |
+
+Top-level constraints also require `table`. `condition` is supported for
+`EXCLUDE` constraints.
+
+## PostgreSQL Objects
+
+YAML input supports the current PostgreSQL-specific goschema objects:
+
+- `extensions`: `name`, `if_not_exists`, `version`, `comment`
+- `functions`: `name`, `params` or `parameters`, `returns`, `language`,
+  `security`, `volatility`, `body`, `comment`
+- `rls_enabled_tables` or `rls_enabled`: map of tables with optional `table`,
+  `struct_name`, and `comment`
+- `rls_policies`: `name`, `table`, `for`, `to`, `using`, `with_check`,
+  `comment`
+- `roles`: `name`, `login`, `password`, `superuser`, `create_db`,
+  `create_role`, `inherit`, `replication`, `comment`
+
+## Validation
+
+The parser is intentionally strict:
+
+- Unknown YAML fields are rejected.
+- Duplicate keys in ordered maps are rejected.
+- Multiple YAML documents in one file are rejected.
+- Top-level indexes and constraints must name their target table.
+- Constraint types and required semantic fields are validated before SQL
+  generation.
+
+`views` and `triggers` are explicitly rejected for now because the current
+`goschema` IR and renderers do not model them yet. They can be added later on
+the same frontend path when backend support exists.


### PR DESCRIPTION
## Summary

- Add `core/yamlschema` to parse YAML schema files into `goschema.Database`.
- Add `ptah generate --schema-file schema.yaml --dialect postgres`.
- Preserve YAML column/index/constraint author order while keeping strict unknown-field validation.
- Route programmatic schemas through shared `goschema.Finalize` dependency ordering.
- Render existing `goschema.Database.Constraints` in `fromschema` so table-level constraints work for YAML and Go annotation inputs.

## Validation

- `GOCACHE=/private/tmp/ptah-go-build go test ./...`
- `GOCACHE=/private/tmp/ptah-go-build go test -race ./... -timeout 10m`
- `GOCACHE=/private/tmp/ptah-go-build go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-go-build GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-go-build go run ./cmd generate --schema-file /private/tmp/ptah-issue170-schema.yaml --dialect postgres`

Closes #170.
