### PR TITLE
Fix(migrator): escape the dot before the direction in fileNameRe

### DIFF
--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -110,10 +110,9 @@ type File struct {
 	// up for down) exists in the same directory.
 	HasPair bool
 	// WellFormedName reports whether the name matches the documented
-	// NNNNNNNNNN_description.(up|down).sql convention. The migrator's own
-	// parser is more lenient (see Direction), so a name can be parseable
-	// yet not well-formed — 0000000001_cleanup.sql parses as an up
-	// migration with a truncated description.
+	// NNNNNNNNNN_description.(up|down).sql convention, checked
+	// independently of the migrator's parser as defense in depth (see the
+	// strictNameRe comment).
 	WellFormedName bool
 	// Statements holds the parsed statements of up migrations. Empty for
 	// down migrations (statement rules do not run there).
@@ -297,11 +296,12 @@ func ruleAppliesToDialect(rule Rule, dialect string) bool {
 	return slices.Contains(rule.Dialects, dialect)
 }
 
-// strictNameRe is the documented migration naming convention. The migrator's
-// own parser is more lenient — its regexp has an unescaped dot before the
-// direction, so 0000000001_cleanup.sql parses as an up migration — which is
-// why WellFormedName checks the strict form while Direction follows the
-// migrator.
+// strictNameRe is the documented migration naming convention, encoded
+// independently of the migrator's parser: WellFormedName checks this strict
+// form while Direction follows the migrator, so if the two ever diverge
+// again (as they did before #245, when the migrator's unescaped dot made
+// 0000000001_cleanup.sql run as an up migration) lint keeps scanning
+// whatever the migrator would execute and MF103 explains the ambiguity.
 var strictNameRe = regexp.MustCompile(`^\d{10}_.+\.(up|down)\.sql$`)
 
 // rawStatement is one raw SQL statement plus the line it starts on.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -384,12 +384,30 @@ func TestLintFS_NestedDirectoriesAreLinted(t *testing.T) {
 	c.Assert(findings[0].Line, qt.Equals, 1)
 }
 
-func TestLintFS_MigratorLenientNamesAreLinted(t *testing.T) {
+func TestLintFS_UpSuffixFallbackScansMalformedVersions(t *testing.T) {
 	c := qt.New(t)
 
-	// The migrator's lenient name parser runs 0000000001_cleanup.sql as an
-	// UP migration and 0000000002_teardown.sql as a DOWN one; lint must
-	// classify them the same way instead of skipping their statements.
+	// A .up.sql file whose version prefix the migrator rejects still gets
+	// hazard scanning via the IsUp suffix fallback — the author clearly
+	// meant it as an up migration, and MF103 explains why it will not run.
+	fsys := fixture(map[string]string{
+		"001_bad_version.up.sql":   "DROP TABLE users;\n",
+		"001_bad_version.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF103", "MF103", "DS101"},
+		qt.Commentf("naming warnings for both files plus the hazard in the up file; got %v", findings))
+}
+
+func TestLintFS_SuffixlessNamesFollowTheMigrator(t *testing.T) {
+	c := qt.New(t)
+
+	// Since the migrator's name regexp was fixed (#245), a description
+	// merely ending in up/down is not a migration: the migrator skips the
+	// file, so lint reports the naming problem instead of scanning
+	// statements that will never run.
 	fsys := fixture(map[string]string{
 		"0000000001_cleanup.sql":  "DROP TABLE users;\n",
 		"0000000002_teardown.sql": "DROP TABLE audit;\n",
@@ -398,12 +416,10 @@ func TestLintFS_MigratorLenientNamesAreLinted(t *testing.T) {
 	findings, err := lint.LintFS(fsys, lint.Options{})
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF101", "MF103", "DS101", "MF103"},
-		qt.Commentf("cleanup.sql is an up migration to the migrator: DS101 + missing down + ambiguous name; teardown.sql is a down migration: ambiguous name only; got %v", findings))
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF103", "MF103"},
+		qt.Commentf("both files are invisible to the migrator: naming warnings only; got %v", findings))
 	for _, f := range findings {
-		if f.Rule == "MF103" {
-			c.Assert(f.Message, qt.Contains, "ambiguous file name")
-		}
+		c.Assert(f.Message, qt.Contains, "the migrator will not pick it up")
 	}
 }
 

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -132,9 +132,11 @@ func migrationFormRules() []Rule {
 				}
 				message := "file name does not match NNNNNNNNNN_description.(up|down).sql; the migrator will not pick it up"
 				if file.Direction != "" {
-					// The migrator's lenient parser accepts this name — e.g.
-					// 0000000001_cleanup.sql runs as an UP migration — which
-					// is more surprising than being skipped.
+					// Defense in depth: unreachable while the migrator's
+					// parser matches the strict convention (#245 fixed its
+					// lenient regexp), but if they ever diverge again a name
+					// the migrator would RUN despite its odd spelling is more
+					// surprising than one it skips, so say so.
 					message = fmt.Sprintf("ambiguous file name: the migrator runs this as a %s migration even though it does not end in .%s.sql; rename it to NNNNNNNNNN_description.%s.sql", file.Direction, file.Direction, file.Direction)
 				}
 				return []Finding{{

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -169,6 +169,36 @@ func TestNewFSMigrationProvider_EmptyFilesystem(t *testing.T) {
 	c.Assert(migrations, qt.HasLen, 0)
 }
 
+func TestNewFSMigrationProvider_DescriptionEndingInUpIsNotAMigration(t *testing.T) {
+	c := qt.New(t)
+
+	// Regression for issue #245: with the unescaped dot in fileNameRe,
+	// 0000000003_cleanup.sql used to register as version 3's UP migration
+	// (description "Clea") and its SQL would run on migrate-up.
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+		"0000000003_cleanup.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+		"0000000004_teardown.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE audit;"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil, qt.Commentf("suffix-less files are skipped, not incomplete migrations"))
+	c.Assert(provider, qt.IsNotNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].Version, qt.Equals, 1)
+}
+
 func TestNewFSMigrationProvider_InvalidFiles(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -13,8 +13,10 @@ import (
 	"golang.org/x/text/language"
 )
 
-// Migration file naming pattern: NNNNNNNNNN_description.up.sql or NNNNNNNNNN_description.down.sql
-var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*).(down|up)(\.sql)$`)
+// Migration file naming pattern: NNNNNNNNNN_description.up.sql or NNNNNNNNNN_description.down.sql.
+// The dot before the direction is literal: a description merely ending in
+// "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
+var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
 // MigrationFile represents the parsed components of a migration file name
 type MigrationFile struct {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -42,6 +42,90 @@ func TestParseMigrationFileName(t *testing.T) {
 			expectError: true,
 		},
 		{
+			// Regression for issue #245: the unescaped dot in fileNameRe used
+			// to make any description ending in "up"/"down" parse as a
+			// migration (cleanup.sql ran as UP with description "Clea").
+			name:        "description ending in up is not a direction",
+			filename:    "0000000001_cleanup.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "description ending in down is not a direction",
+			filename:    "0000000001_teardown.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "setup without direction suffix",
+			filename:    "0000000001_setup.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:     "description ending in up with a proper direction suffix",
+			filename: "0000000003_cleanup.up.sql",
+			expected: &MigrationFile{
+				Version:   3,
+				Name:      "Cleanup",
+				Direction: "up",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			name:     "description ending in down with a proper direction suffix",
+			filename: "0000000004_teardown.down.sql",
+			expected: &MigrationFile{
+				Version:   4,
+				Name:      "Teardown",
+				Direction: "down",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// Pins the other half of the naming language: descriptions may
+			// contain dots, so an over-tightened pattern ((.*) -> ([^.]*))
+			// must fail here instead of silently skipping such migrations.
+			name:     "description containing dots",
+			filename: "0000000001_v2.0_schema.up.sql",
+			expected: &MigrationFile{
+				Version:   1,
+				Name:      "V2.0 Schema",
+				Direction: "up",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// The LAST direction token wins; everything before it is
+			// description (greedy match).
+			name:     "multiple direction tokens",
+			filename: "0000000001_foo.up.down.sql",
+			expected: &MigrationFile{
+				Version:   1,
+				Name:      "Foo.up",
+				Direction: "down",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// Only a literal dot separates description from direction: a
+			// lenient-separator pattern ([._]) must not sneak back in.
+			name:        "underscore before direction is not a separator",
+			filename:    "0000000001_add_users_up.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "dash before direction is not a separator",
+			filename:    "0000000001_migrate-up.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
 			name:        "invalid format - wrong extension",
 			filename:    "0000000001_create_users_table.up.txt",
 			expected:    nil,
@@ -101,6 +185,11 @@ func TestValidateMigrationFileName(t *testing.T) {
 		{
 			name:     "invalid format",
 			filename: "invalid_filename.sql",
+			expected: false,
+		},
+		{
+			name:     "description ending in up without direction suffix",
+			filename: "0000000001_cleanup.sql",
 			expected: false,
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #245: `fileNameRe` had an unescaped dot before `(down|up)`, so any description merely *ending* in `up`/`down` parsed as a migration:

| filename | before | after |
|---|---|---|
| `0000000001_cleanup.sql` | UP migration, description **"Clea"** — executed by `migrate-up` | skipped (not a migration) |
| `0000000001_teardown.sql` | DOWN migration, description "Tea" | skipped |
| `0000000003_cleanup.up.sql` | description truncated to "Clea" | description **"Cleanup"** |

```diff
-var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*).(down|up)(\.sql)$`)
+var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
```

`FSMigrationProvider` skips unparseable files (pre-existing behavior), so directories containing such names now load without registering them — and `ptah lint` flags them with MF103 ("the migrator will not pick it up").

### Behavior change note

A file like `0000000001_cleanup.sql` that previously **ran** as an up migration is now ignored by the migrator. That is the intent of the fix — such files were almost certainly never meant to be direction-suffixed migrations, and the old parse mangled their descriptions — but if anyone relied on it, `ptah lint` now points at every such file.

### Tests

The self-review fleet's mutation testing showed the old suite could not distinguish several plausible regressions of this exact line, so the naming language is now pinned from both sides:

- rejected: `cleanup.sql` / `setup.sql` / `teardown.sql` (suffix-less), `add_users_up.sql` / `migrate-up.sql` (non-dot separators);
- accepted: `v2.0_schema.up.sql` (dots in descriptions — kills the `([^.]*)` over-tightening mutant), `foo.up.down.sql` → direction `down`, description "Foo.up" (last direction token wins);
- provider-level: suffix-less files are skipped without an incomplete-pair error and never registered;
- lint-side: suffix-less names now yield MF103 naming warnings only (no statement scan for SQL that will never run), and a new test pins the `.up.sql` suffix fallback that keeps hazard scanning for files with malformed version prefixes.

`migration/lint` keeps its migrator-following classification (`Direction`, independent `strictNameRe`, the MF103 ambiguity branch) as defense in depth in case the two parsers ever diverge again; comments updated accordingly.

Self-reviewed by a compact adversarial fleet (15 agents: 3 lenses × 2 skeptics per finding, mutation-tested against a repo copy): 4 confirmed test gaps — all closed here; 2 findings rejected as pre-existing/out-of-scope.

`go test ./...`, `golangci-lint run`, `go tool qtlint ./...` — clean.

Closes #245

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB