### PR TITLE
Add environment-scoped seed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Provides command-line interface for all Ptah operations:
 - **`migrate-up`** - Apply migrations to bring database up to latest version
 - **`migrate-down`** - Roll back migrations to previous versions
 - **`migrate-status`** - Show current migration status and history
+- **`seed`** - Apply environment-scoped SQL seed files with replay tracking
 - **`drop-all`** - Drop ALL tables and enums in database (VERY DANGEROUS!) (supports `--dry-run`)
 - **`integration-test`** - Run comprehensive integration tests across database platforms
 
@@ -498,6 +499,33 @@ Generate SQL migration statements to synchronize schemas:
 ```
 
 **Output:** SQL statements to bring the database in sync with Go entities
+
+#### Apply Seed Data
+Apply environment-scoped SQL seeds from a `seeds/` directory:
+
+```bash
+./package-migrator seed --db-url postgres://user:pass@localhost:5432/database --env test
+```
+
+Seed files use `NNN_description.env.sql` names. Files matching `--env` and
+`.all.sql` files are applied in version order:
+
+```text
+seeds/
+  010_countries.all.sql
+  020_demo_users.dev.sql
+  020_test_users.test.sql
+```
+
+Successful files are recorded in `schema_seeds`, so re-running `seed --env test`
+is a no-op unless `--force` is set. `--idempotent` uses a per-file savepoint to
+treat duplicate-key conflicts as already-applied data; it is rejected on
+ClickHouse because ClickHouse does not provide the transactions/savepoints this
+mode depends on. Production-like environments (`prod`, `production` by default)
+require `--allow-prod`; use `--protected-env name` to configure additional
+protected environment names. Use `--protected-table name` to refuse seeding when
+the target database already contains production-marker tables unless
+`--allow-prod` is explicit.
 
 ### Migration Management
 

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migratestatus"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/cmd/readdb"
+	"github.com/stokaro/ptah/cmd/seed"
 )
 
 const (
@@ -51,6 +52,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(migrateup.NewMigrateUpCommand())
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
 	rootCmd.AddCommand(migratestatus.NewMigrateStatusCommand())
+	rootCmd.AddCommand(seed.NewSeedCommand())
 	rootCmd.AddCommand(dropall.NewDropAllCommand())
 
 	err := rootCmd.Execute()

--- a/cmd/seed/seed.go
+++ b/cmd/seed/seed.go
@@ -1,0 +1,157 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/seeder"
+)
+
+// NewSeedCommand returns the seed command.
+func NewSeedCommand() *cobra.Command {
+	var dbURL string
+	var seedsDir string
+	var env string
+	var protectedEnvs []string
+	var protectedTables []string
+	var force bool
+	var idempotent bool
+	var allowProd bool
+	var verbose bool
+	var connectTimeoutRaw string
+
+	cmd := &cobra.Command{
+		Use:          "seed",
+		Short:        "Apply environment-scoped SQL seed files",
+		SilenceUsage: true,
+		Long: `Apply SQL seed files from a seeds directory.
+
+Seed files use the NNN_description.env.sql naming convention. Files matching
+the requested --env and files ending in .all.sql are applied in version order.
+Successful seeds are recorded in schema_seeds, so re-running the command is a
+no-op unless --force is set.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSeed(cmd.Context(), runOptions{
+				dbURL:             dbURL,
+				seedsDir:          seedsDir,
+				env:               env,
+				protectedEnvs:     protectedEnvs,
+				protectedTables:   protectedTables,
+				force:             force,
+				idempotent:        idempotent,
+				allowProd:         allowProd,
+				verbose:           verbose,
+				connectTimeoutRaw: connectTimeoutRaw,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL (required). Example: postgres://localhost:5432/dbname")
+	cmd.Flags().StringVar(&seedsDir, "seeds-dir", "seeds", "Directory containing seed files")
+	cmd.Flags().StringVar(&env, "env", "", "Seed environment to apply (required), for example dev, test, or prod")
+	cmd.Flags().StringArrayVar(&protectedEnvs, "protected-env", seeder.DefaultProtectedEnvs(), "Environment name that requires --allow-prod; repeat to add more")
+	cmd.Flags().StringArrayVar(&protectedTables, "protected-table", nil, "Existing target table name that requires --allow-prod; repeat to add more")
+	cmd.Flags().BoolVar(&force, "force", false, "Re-run seeds even when they are already recorded in schema_seeds")
+	cmd.Flags().BoolVar(&idempotent, "idempotent", false, "Treat duplicate-key conflicts as already-applied seed data using a per-file savepoint")
+	cmd.Flags().BoolVar(&allowProd, "allow-prod", false, "Allow seeding a protected production-like environment")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose output")
+	cmd.Flags().StringVar(
+		&connectTimeoutRaw,
+		dbcli.ConnectTimeoutFlagName,
+		dbcli.DefaultConnectTimeout.String(),
+		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
+	)
+
+	return cmd
+}
+
+type runOptions struct {
+	dbURL             string
+	seedsDir          string
+	env               string
+	protectedEnvs     []string
+	protectedTables   []string
+	force             bool
+	idempotent        bool
+	allowProd         bool
+	verbose           bool
+	connectTimeoutRaw string
+}
+
+func runSeed(ctx context.Context, opts runOptions) error {
+	if opts.dbURL == "" {
+		return fmt.Errorf("database URL is required")
+	}
+	if opts.seedsDir == "" {
+		return fmt.Errorf("seeds directory is required")
+	}
+
+	seedOpts := seeder.Options{
+		Env:             opts.env,
+		ProtectedEnvs:   opts.protectedEnvs,
+		ProtectedTables: opts.protectedTables,
+		Force:           opts.force,
+		Idempotent:      opts.idempotent,
+		AllowProd:       opts.allowProd,
+	}
+	if err := seeder.ValidateOptions(seedOpts); err != nil {
+		return err
+	}
+	connectTimeout, err := dbcli.ParseConnectTimeout(opts.connectTimeoutRaw)
+	if err != nil {
+		return err
+	}
+
+	if opts.verbose {
+		fmt.Printf("Connecting to database: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
+	}
+	connectCtx, cancelConnect := dbcli.ConnectContext(ctx, connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.dbURL)
+	cancelConnect()
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	fmt.Println("=== SEED ===")
+	fmt.Printf("Database: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
+	fmt.Printf("Dialect: %s\n", conn.Info().Dialect)
+	fmt.Printf("Seeds directory: %s\n", opts.seedsDir)
+	fmt.Printf("Environment: %s\n", strings.TrimSpace(opts.env))
+	if opts.force {
+		fmt.Println("Force: true")
+	}
+	if opts.idempotent {
+		fmt.Println("Idempotent: true")
+	}
+	fmt.Println()
+
+	result, err := seeder.Apply(ctx, conn, os.DirFS(opts.seedsDir), seedOpts)
+	if err != nil {
+		return fmt.Errorf("error applying seeds: %w", err)
+	}
+
+	fmt.Printf("Matching seeds: %d\n", result.Total)
+	fmt.Printf("Applied seeds: %d\n", len(result.Applied))
+	fmt.Printf("Skipped seeds: %d\n", len(result.Skipped))
+	if opts.verbose {
+		for _, seed := range result.Applied {
+			fmt.Printf("Applied: %s\n", seed.Path)
+		}
+		for _, seed := range result.Skipped {
+			fmt.Printf("Skipped: %s\n", seed.Path)
+		}
+	}
+	if len(result.Applied) == 0 {
+		fmt.Println("Database seed data is already up to date.")
+	} else {
+		fmt.Println("Seeds completed successfully.")
+	}
+	return nil
+}

--- a/cmd/seed/seed_test.go
+++ b/cmd/seed/seed_test.go
@@ -1,0 +1,37 @@
+package seed
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewSeedCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewSeedCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "seed")
+	c.Assert(cmd.Short, qt.Contains, "seed")
+}
+
+func TestRunSeedRequiresDatabaseURL(t *testing.T) {
+	c := qt.New(t)
+
+	err := runSeed(t.Context(), runOptions{env: "test", seedsDir: "seeds"})
+
+	c.Assert(err, qt.ErrorMatches, `database URL is required`)
+}
+
+func TestRunSeedValidatesProtectedEnvBeforeConnecting(t *testing.T) {
+	c := qt.New(t)
+
+	err := runSeed(t.Context(), runOptions{
+		dbURL:    "postgres://localhost/db",
+		seedsDir: "seeds",
+		env:      "prod",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `refusing to seed protected environment "prod" without --allow-prod`)
+}

--- a/migration/seeder/seeder.go
+++ b/migration/seeder/seeder.go
@@ -1,0 +1,436 @@
+// Package seeder applies environment-scoped SQL seed files and records which
+// files have already run.
+package seeder
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const (
+	allEnv      = "all"
+	trackerName = "schema_seeds"
+)
+
+var seedFilenameRE = regexp.MustCompile(`^([0-9]+)_(.+)\.([A-Za-z0-9_-]+)\.sql$`)
+
+// SeedFile is one discovered seed SQL file.
+type SeedFile struct {
+	Path        string
+	Filename    string
+	Version     int
+	Description string
+	Env         string
+	Checksum    string
+}
+
+// Options controls seed execution.
+type Options struct {
+	Env             string
+	ProtectedEnvs   []string
+	ProtectedTables []string
+	Force           bool
+	Idempotent      bool
+	AllowProd       bool
+}
+
+// Result summarizes one seed command run.
+type Result struct {
+	Env     string
+	Total   int
+	Applied []SeedFile
+	Skipped []SeedFile
+}
+
+// Discover scans fsys for seed files matching NNN_description.env.sql.
+func Discover(fsys fs.FS) ([]SeedFile, error) {
+	var seeds []SeedFile
+	err := fs.WalkDir(fsys, ".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), ".sql") {
+			return nil
+		}
+
+		seed, ok, err := parseSeedPath(fsys, path)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("invalid seed filename %q: expected NNN_description.env.sql", path)
+		}
+		seeds = append(seeds, seed)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan seeds: %w", err)
+	}
+
+	slices.SortFunc(seeds, func(a, b SeedFile) int {
+		if a.Version != b.Version {
+			return a.Version - b.Version
+		}
+		return strings.Compare(a.Path, b.Path)
+	})
+	return seeds, nil
+}
+
+// Select filters seed files for the requested environment.
+func Select(seeds []SeedFile, env string) []SeedFile {
+	env = normalizeEnv(env)
+	selected := make([]SeedFile, 0, len(seeds))
+	for _, seed := range seeds {
+		if seed.Env == allEnv || seed.Env == env {
+			selected = append(selected, seed)
+		}
+	}
+	return selected
+}
+
+func parseSeedPath(fsys fs.FS, path string) (SeedFile, bool, error) {
+	filename := filepath.Base(path)
+	matches := seedFilenameRE.FindStringSubmatch(filename)
+	if matches == nil {
+		return SeedFile{}, false, nil
+	}
+
+	version, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return SeedFile{}, false, fmt.Errorf("parse seed version from %q: %w", path, err)
+	}
+
+	data, err := fs.ReadFile(fsys, path)
+	if err != nil {
+		return SeedFile{}, false, fmt.Errorf("read seed file %q: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return SeedFile{
+		Path:        path,
+		Filename:    filename,
+		Version:     version,
+		Description: matches[2],
+		Env:         normalizeEnv(matches[3]),
+		Checksum:    hex.EncodeToString(sum[:]),
+	}, true, nil
+}
+
+// ValidateOptions returns an error if the command options would be unsafe.
+func ValidateOptions(opts Options) error {
+	if normalizeEnv(opts.Env) == "" {
+		return fmt.Errorf("environment is required")
+	}
+	if len(opts.ProtectedEnvs) == 0 {
+		opts.ProtectedEnvs = DefaultProtectedEnvs()
+	}
+	if isProtectedEnv(opts.Env, opts.ProtectedEnvs) && !opts.AllowProd {
+		return fmt.Errorf("refusing to seed protected environment %q without --allow-prod", opts.Env)
+	}
+	return nil
+}
+
+// Apply applies all matching seed files and records successful runs.
+func Apply(ctx context.Context, conn *dbschema.DatabaseConnection, fsys fs.FS, opts Options) (*Result, error) {
+	opts.Env = normalizeEnv(opts.Env)
+	if len(opts.ProtectedEnvs) == 0 {
+		opts.ProtectedEnvs = DefaultProtectedEnvs()
+	}
+	if err := ValidateOptions(opts); err != nil {
+		return nil, err
+	}
+	if opts.Idempotent && platform.NormalizeDialect(conn.Info().Dialect) == platform.ClickHouse {
+		return nil, fmt.Errorf("--idempotent is not supported for clickhouse seeds because transactions and savepoints are unavailable")
+	}
+	if err := ensureSafeTarget(ctx, conn, opts); err != nil {
+		return nil, err
+	}
+
+	seeds, err := Discover(fsys)
+	if err != nil {
+		return nil, err
+	}
+	selected := Select(seeds, opts.Env)
+	result := &Result{Env: opts.Env, Total: len(selected)}
+	if len(selected) == 0 {
+		return result, nil
+	}
+
+	if err := ensureTracker(ctx, conn); err != nil {
+		return nil, err
+	}
+	applied, err := appliedSeeds(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, seed := range selected {
+		if !opts.Force && applied[seed.Path] {
+			result.Skipped = append(result.Skipped, seed)
+			continue
+		}
+		if err := applySeed(ctx, conn, fsys, seed, opts); err != nil {
+			return result, err
+		}
+		result.Applied = append(result.Applied, seed)
+	}
+
+	return result, nil
+}
+
+func applySeed(ctx context.Context, conn *dbschema.DatabaseConnection, fsys fs.FS, seed SeedFile, opts Options) error {
+	data, err := fs.ReadFile(fsys, seed.Path)
+	if err != nil {
+		return fmt.Errorf("read seed file %q: %w", seed.Path, err)
+	}
+	statements := migrator.SplitSQLStatements(string(data))
+
+	dialect := platform.NormalizeDialect(conn.Info().Dialect)
+	if dialect == platform.ClickHouse {
+		return applySeedWithoutTransaction(ctx, conn, seed, statements, opts)
+	}
+
+	if err := conn.Writer().BeginTransaction(); err != nil {
+		return fmt.Errorf("begin seed transaction %s: %w", seed.Filename, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = conn.Writer().RollbackTransaction()
+		}
+	}()
+
+	if opts.Idempotent {
+		if err := conn.Writer().ExecuteSQL(ctx, "SAVEPOINT ptah_seed_file"); err != nil {
+			return fmt.Errorf("create seed savepoint %s: %w", seed.Filename, err)
+		}
+	}
+
+	if err := executeStatements(ctx, conn, statements); err != nil {
+		if !opts.Idempotent || !IsConflictError(err) {
+			return fmt.Errorf("apply seed %s: %w", seed.Filename, err)
+		}
+		if rbErr := conn.Writer().ExecuteSQL(ctx, "ROLLBACK TO SAVEPOINT ptah_seed_file"); rbErr != nil {
+			return fmt.Errorf("rollback idempotent seed %s: %w", seed.Filename, rbErr)
+		}
+	} else if opts.Idempotent {
+		if err := conn.Writer().ExecuteSQL(ctx, "RELEASE SAVEPOINT ptah_seed_file"); err != nil {
+			return fmt.Errorf("release seed savepoint %s: %w", seed.Filename, err)
+		}
+	}
+
+	if err := recordSeed(ctx, conn, seed, opts); err != nil {
+		return fmt.Errorf("record seed %s: %w", seed.Filename, err)
+	}
+	if err := conn.Writer().CommitTransaction(); err != nil {
+		return fmt.Errorf("commit seed %s: %w", seed.Filename, err)
+	}
+	committed = true
+	return nil
+}
+
+func applySeedWithoutTransaction(ctx context.Context, conn *dbschema.DatabaseConnection, seed SeedFile, statements []string, opts Options) error {
+	if err := executeStatements(ctx, conn, statements); err != nil {
+		return fmt.Errorf("apply seed %s: %w", seed.Filename, err)
+	}
+	if err := recordSeed(ctx, conn, seed, opts); err != nil {
+		return fmt.Errorf("record seed %s: %w", seed.Filename, err)
+	}
+	return nil
+}
+
+func executeStatements(ctx context.Context, conn *dbschema.DatabaseConnection, statements []string) error {
+	for _, stmt := range statements {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureTracker(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	_, err := conn.ExecContext(ctx, trackerDDL(conn.Info().Dialect))
+	if err != nil {
+		return fmt.Errorf("create %s table: %w", trackerName, err)
+	}
+	return nil
+}
+
+func trackerDDL(dialect string) string {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.ClickHouse:
+		return `CREATE TABLE IF NOT EXISTS schema_seeds (
+    seed_path String,
+    env String,
+    checksum String,
+    applied_at DateTime
+) ENGINE = MergeTree ORDER BY seed_path`
+	default:
+		return `CREATE TABLE IF NOT EXISTS schema_seeds (
+    seed_path VARCHAR(512) PRIMARY KEY,
+    env VARCHAR(128) NOT NULL,
+    checksum CHAR(64) NOT NULL,
+    applied_at TIMESTAMP NOT NULL
+)`
+	}
+}
+
+func appliedSeeds(ctx context.Context, conn *dbschema.DatabaseConnection) (map[string]bool, error) {
+	rows, err := conn.Query("SELECT seed_path FROM schema_seeds")
+	if err != nil {
+		return nil, fmt.Errorf("query applied seeds: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var filename string
+		if err := rows.Scan(&filename); err != nil {
+			return nil, fmt.Errorf("scan applied seed: %w", err)
+		}
+		applied[filename] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate applied seeds: %w", err)
+	}
+	return applied, nil
+}
+
+func recordSeed(ctx context.Context, conn *dbschema.DatabaseConnection, seed SeedFile, opts Options) error {
+	deleteSQL := sqlutil.Rebind(conn.Info().Dialect, "DELETE FROM schema_seeds WHERE seed_path = ?")
+	if err := conn.Writer().ExecuteSQL(ctx, deleteSQL, seed.Path); err != nil {
+		return err
+	}
+
+	insertSQL := sqlutil.Rebind(conn.Info().Dialect, "INSERT INTO schema_seeds (seed_path, env, checksum, applied_at) VALUES (?, ?, ?, ?)")
+	return conn.Writer().ExecuteSQL(ctx, insertSQL, seed.Path, opts.Env, seed.Checksum, time.Now())
+}
+
+func ensureSafeTarget(ctx context.Context, conn *dbschema.DatabaseConnection, opts Options) error {
+	if opts.AllowProd || len(opts.ProtectedTables) == 0 {
+		return nil
+	}
+
+	existing, err := existingTables(ctx, conn)
+	if err != nil {
+		return err
+	}
+	protected := make(map[string]string, len(opts.ProtectedTables))
+	for _, table := range opts.ProtectedTables {
+		table = strings.TrimSpace(table)
+		if table != "" {
+			protected[strings.ToLower(table)] = table
+		}
+	}
+
+	var matches []string
+	for _, table := range existing {
+		if original, ok := protected[strings.ToLower(table)]; ok {
+			matches = append(matches, original)
+		}
+	}
+	slices.Sort(matches)
+	if len(matches) > 0 {
+		return fmt.Errorf("refusing to seed target database because protected tables exist: %s; pass --allow-prod to override", strings.Join(matches, ", "))
+	}
+	return nil
+}
+
+func existingTables(ctx context.Context, conn *dbschema.DatabaseConnection) ([]string, error) {
+	var query string
+	var args []any
+	switch platform.NormalizeDialect(conn.Info().Dialect) {
+	case platform.MySQL, platform.MariaDB:
+		query = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'"
+	case platform.ClickHouse:
+		query = "SELECT name FROM system.tables WHERE database = currentDatabase() AND is_temporary = 0"
+	default:
+		query = sqlutil.Rebind(conn.Info().Dialect, "SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_type = 'BASE TABLE'")
+		args = append(args, conn.Info().Schema)
+	}
+
+	rows, err := conn.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query target tables: %w", err)
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			return nil, fmt.Errorf("scan target table: %w", err)
+		}
+		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate target tables: %w", err)
+	}
+	return tables, nil
+}
+
+// DefaultProtectedEnvs returns environment names that require --allow-prod.
+func DefaultProtectedEnvs() []string {
+	return []string{"prod", "production"}
+}
+
+func isProtectedEnv(env string, protected []string) bool {
+	env = normalizeEnv(env)
+	for _, value := range protected {
+		if normalizeEnv(value) == env {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeEnv(env string) string {
+	return strings.ToLower(strings.TrimSpace(env))
+}
+
+// IsConflictError reports whether err looks like a duplicate-key conflict.
+func IsConflictError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return true
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+		return true
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "duplicate entry") ||
+		strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "unique violation")
+}

--- a/migration/seeder/seeder_integration_test.go
+++ b/migration/seeder/seeder_integration_test.go
@@ -1,0 +1,61 @@
+package seeder
+
+import (
+	"os"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+)
+
+func TestApply_Integration(t *testing.T) {
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("TEST_DATABASE_URL not set, skipping seed integration test")
+	}
+
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	_, err = conn.ExecContext(t.Context(), "DROP TABLE IF EXISTS schema_seeds")
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), "DROP TABLE IF EXISTS seed_countries")
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE seed_countries (code VARCHAR(8) PRIMARY KEY, name VARCHAR(255) NOT NULL)")
+	c.Assert(err, qt.IsNil)
+
+	fsys := fstest.MapFS{
+		"010_countries.all.sql":       {Data: []byte("INSERT INTO seed_countries (code, name) VALUES ('CZ', 'Czechia');")},
+		"020_test_countries.test.sql": {Data: []byte("INSERT INTO seed_countries (code, name) VALUES ('US', 'United States');")},
+		"020_dev_countries.dev.sql":   {Data: []byte("INSERT INTO seed_countries (code, name) VALUES ('DE', 'Germany');")},
+	}
+
+	_, err = Apply(t.Context(), conn, fsys, Options{Env: "test", ProtectedTables: []string{"seed_countries"}})
+	c.Assert(err, qt.ErrorMatches, `refusing to seed target database because protected tables exist: seed_countries; pass --allow-prod to override`)
+
+	result, err := Apply(t.Context(), conn, fsys, Options{Env: "test"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Total, qt.Equals, 2)
+	c.Assert(seedNames(result.Applied), qt.DeepEquals, []string{"010_countries.all.sql", "020_test_countries.test.sql"})
+
+	result, err = Apply(t.Context(), conn, fsys, Options{Env: "test"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.HasLen, 0)
+	c.Assert(seedNames(result.Skipped), qt.DeepEquals, []string{"010_countries.all.sql", "020_test_countries.test.sql"})
+
+	result, err = Apply(t.Context(), conn, fsys, Options{Env: "test", Force: true, Idempotent: true})
+	c.Assert(err, qt.IsNil)
+	c.Assert(seedNames(result.Applied), qt.DeepEquals, []string{"010_countries.all.sql", "020_test_countries.test.sql"})
+
+	var rowCount int
+	c.Assert(conn.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM seed_countries").Scan(&rowCount), qt.IsNil)
+	c.Assert(rowCount, qt.Equals, 2)
+
+	var seedCount int
+	c.Assert(conn.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM schema_seeds").Scan(&seedCount), qt.IsNil)
+	c.Assert(seedCount, qt.Equals, 2)
+}

--- a/migration/seeder/seeder_test.go
+++ b/migration/seeder/seeder_test.go
@@ -1,0 +1,124 @@
+package seeder
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestDiscoverSortsSeedFiles(t *testing.T) {
+	c := qt.New(t)
+
+	seeds, err := Discover(fstest.MapFS{
+		"020_states.test.sql":        {Data: []byte("INSERT INTO states VALUES (1);")},
+		"010_countries.all.sql":      {Data: []byte("INSERT INTO countries VALUES (1);")},
+		"030_cities.dev.sql":         {Data: []byte("INSERT INTO cities VALUES (1);")},
+		"README.md":                  {Data: []byte("ignored")},
+		"020_states.dev.sql":         {Data: []byte("INSERT INTO states VALUES (2);")},
+		"nested/015_regions.all.sql": {Data: []byte("INSERT INTO regions VALUES (1);")},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(seedNames(seeds), qt.DeepEquals, []string{
+		"010_countries.all.sql",
+		"015_regions.all.sql",
+		"020_states.dev.sql",
+		"020_states.test.sql",
+		"030_cities.dev.sql",
+	})
+	c.Assert(seeds[0].Checksum, qt.Not(qt.Equals), "")
+}
+
+func TestDiscoverRejectsInvalidSQLFilename(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := Discover(fstest.MapFS{
+		"010_countries.sql": {Data: []byte("INSERT INTO countries VALUES (1);")},
+	})
+
+	c.Assert(err, qt.ErrorMatches, `scan seeds: invalid seed filename "010_countries.sql": expected NNN_description.env.sql`)
+}
+
+func TestDiscoverKeepsRelativePathIdentity(t *testing.T) {
+	c := qt.New(t)
+
+	seeds, err := Discover(fstest.MapFS{
+		"countries/010_reference.test.sql": {Data: []byte("INSERT INTO countries VALUES (1);")},
+		"regions/010_reference.test.sql":   {Data: []byte("INSERT INTO regions VALUES (1);")},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(seedPaths(seeds), qt.DeepEquals, []string{
+		"countries/010_reference.test.sql",
+		"regions/010_reference.test.sql",
+	})
+	c.Assert(seedNames(seeds), qt.DeepEquals, []string{
+		"010_reference.test.sql",
+		"010_reference.test.sql",
+	})
+}
+
+func TestSelectIncludesAllAndRequestedEnv(t *testing.T) {
+	c := qt.New(t)
+
+	seeds := []SeedFile{
+		{Filename: "010_common.all.sql", Env: "all"},
+		{Filename: "020_dev.dev.sql", Env: "dev"},
+		{Filename: "020_test.test.sql", Env: "test"},
+	}
+
+	selected := Select(seeds, "DEV")
+
+	c.Assert(seedNames(selected), qt.DeepEquals, []string{"010_common.all.sql", "020_dev.dev.sql"})
+}
+
+func TestValidateOptionsRequiresAllowProdForProtectedEnv(t *testing.T) {
+	c := qt.New(t)
+
+	err := ValidateOptions(Options{Env: "prod", ProtectedEnvs: DefaultProtectedEnvs()})
+	c.Assert(err, qt.ErrorMatches, `refusing to seed protected environment "prod" without --allow-prod`)
+
+	err = ValidateOptions(Options{Env: "prod", ProtectedEnvs: DefaultProtectedEnvs(), AllowProd: true})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestDiscoverReturnsReadErrors(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := Discover(errorFS{})
+
+	c.Assert(err, qt.ErrorMatches, `scan seeds: boom`)
+}
+
+func TestIsConflictErrorMatchesPortableMessages(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(IsConflictError(errors.New(`SQL execution failed: ERROR: duplicate key value violates unique constraint "users_email_key"`)), qt.IsTrue)
+	c.Assert(IsConflictError(errors.New(`Error 1062: Duplicate entry 'a@example.com' for key 'users.email'`)), qt.IsTrue)
+	c.Assert(IsConflictError(errors.New("syntax error near INSERT")), qt.IsFalse)
+}
+
+func seedNames(seeds []SeedFile) []string {
+	names := make([]string, 0, len(seeds))
+	for _, seed := range seeds {
+		names = append(names, seed.Filename)
+	}
+	return names
+}
+
+func seedPaths(seeds []SeedFile) []string {
+	paths := make([]string, 0, len(seeds))
+	for _, seed := range seeds {
+		paths = append(paths, seed.Path)
+	}
+	return paths
+}
+
+type errorFS struct{}
+
+func (errorFS) Open(string) (fs.File, error) {
+	return nil, errors.New("boom")
+}


### PR DESCRIPTION
## Summary

Fixes #167 with a first-class `package-migrator seed` command for environment-scoped SQL seed files.

## Changes

- Add `migration/seeder` to discover `NNN_description.env.sql` files, select `.all.sql` plus the requested environment, apply them in version/path order, and record successful runs in `schema_seeds.seed_path`.
- Add `cmd/seed` with `--env`, `--seeds-dir`, `--force`, `--idempotent`, `--allow-prod`, `--protected-env`, `--protected-table`, and `--connect-timeout`.
- Protect production-like environments (`prod`, `production` by default) and configured existing target tables unless `--allow-prod` is explicit.
- Use per-file transactions and savepoints for `--idempotent` duplicate-key handling on transactional dialects.
- Document the seed workflow in `README.md`.

## Validation

- `GOCACHE=/private/tmp/ptah-go-build go test ./...`
- `GOCACHE=/private/tmp/ptah-go-build go test -count=1 ./...`
- `GOCACHE=/private/tmp/ptah-go-build go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-go-build GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-go-build go test -race ./migration/seeder ./cmd/seed ./cmd/packagemigrator`
- `GOCACHE=/private/tmp/ptah-go-build go build -o /private/tmp/ptah-seed-smoke/package-migrator ./cmd`
- `GOCACHE=/private/tmp/ptah-go-build TEST_DATABASE_URL='postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' go test ./migration/seeder -run TestApply_Integration -count=1 -v`
- Real CLI smoke against local Docker Compose PostgreSQL 18, MySQL 9.7, and MariaDB 10.11:
  - initial `seed --env test` applies `.all.sql` + `.test.sql`
  - rerun skips both files
  - `--force --idempotent` handles duplicate-key reruns through savepoints
  - `--protected-table seed_countries` rejects a target DB even with `--env dev`
  - row counts remain stable
  - `--env prod` is rejected without `--allow-prod`
