### PR TITLE
Add migration timeout directives

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -179,6 +179,12 @@ jobs:
         run: |
           ./integration-test --scenarios=apply_incremental_migrations,check_current_version --databases=postgres --report=stdout,txt,json,html --output=./reports
 
+      - name: Run migrator safety integration tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -v ./migration/migrator -run TestMigrateUp_PostgresLockTimeoutIntegration -timeout 2m
+
       - name: Run all databases comprehensive test
         env:
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/README.md
+++ b/README.md
@@ -509,9 +509,21 @@ Apply all pending migrations to bring database up to latest version:
 ```bash
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations
 
+# Production rollout defaults: fail fast on hot-table locks and runaway statements
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --lock-timeout 3s --statement-timeout 30s
+
 # Dry run to preview what would be applied
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dry-run
 ```
+
+Migration files can override the CLI defaults with top-of-file directives:
+
+```sql
+-- +ptah lock_timeout=3s
+-- +ptah statement_timeout=30s
+```
+
+PostgreSQL uses `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB use `SET SESSION innodb_lock_wait_timeout`; statement timeouts use `max_execution_time` on MySQL and `max_statement_time` on MariaDB. Generated migrations that contain `ALTER TABLE` include the recommended `3s` lock timeout and `30s` statement timeout directives for supported dialects.
 
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
@@ -519,12 +531,16 @@ Apply all pending migrations to bring database up to latest version:
 - ✅ Automatic rollback on failure
 - ✅ Tracks applied migrations in `schema_migrations` table
 - ✅ Supports dry-run mode for preview
+- ✅ Supports per-migration lock and statement timeout directives
 
 #### Roll Back Migrations
 Roll back migrations to a specific version:
 
 ```bash
 ./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5
+
+# Use the same production safety defaults for rollback DDL
+./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --lock-timeout 3s --statement-timeout 30s
 
 # Dry run to preview rollback
 ./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --dry-run

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -31,12 +31,14 @@ before running down migrations in production.`,
 }
 
 const (
-	dbURLFlag      = "db-url"
-	migrationsFlag = "migrations-dir"
-	targetFlag     = "target"
-	dryRunFlag     = "dry-run"
-	verboseFlag    = "verbose"
-	confirmFlag    = "confirm"
+	dbURLFlag            = "db-url"
+	migrationsFlag       = "migrations-dir"
+	targetFlag           = "target"
+	dryRunFlag           = "dry-run"
+	verboseFlag          = "verbose"
+	confirmFlag          = "confirm"
+	lockTimeoutFlag      = "lock-timeout"
+	statementTimeoutFlag = "statement-timeout"
 )
 
 var migrateDownFlags = map[string]cobraflags.Flag{
@@ -70,6 +72,16 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Skip confirmation prompt (use with caution!)",
 	},
+	lockTimeoutFlag: &cobraflags.StringFlag{
+		Name:  lockTimeoutFlag,
+		Value: "",
+		Usage: "Default per-migration lock timeout, such as 3s or 500ms",
+	},
+	statementTimeoutFlag: &cobraflags.StringFlag{
+		Name:  statementTimeoutFlag,
+		Value: "",
+		Usage: "Default per-migration statement timeout, such as 30s or 2m",
+	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
@@ -85,6 +97,8 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	dryRun := migrateDownFlags[dryRunFlag].GetBool()
 	verbose := migrateDownFlags[verboseFlag].GetBool()
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
+	lockTimeout := migrateDownFlags[lockTimeoutFlag].GetString()
+	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -100,6 +114,11 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 
 	if verbose {
 		fmt.Printf("Connecting to database: %s\n", dbschema.FormatDatabaseURL(dbURL))
+	}
+
+	timeouts, err := migrator.ParseMigrationTimeouts(lockTimeout, statementTimeout)
+	if err != nil {
+		return err
 	}
 
 	connectTimeout, err := dbcli.ParseConnectTimeout(migrateDownFlags[dbcli.ConnectTimeoutFlagName].GetString())
@@ -139,6 +158,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
+	mig = mig.WithDefaultTimeouts(timeouts)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -27,10 +27,12 @@ be rolled back and the migration process will stop.`,
 }
 
 const (
-	dbURLFlag      = "db-url"
-	migrationsFlag = "migrations-dir"
-	dryRunFlag     = "dry-run"
-	verboseFlag    = "verbose"
+	dbURLFlag            = "db-url"
+	migrationsFlag       = "migrations-dir"
+	dryRunFlag           = "dry-run"
+	verboseFlag          = "verbose"
+	lockTimeoutFlag      = "lock-timeout"
+	statementTimeoutFlag = "statement-timeout"
 )
 
 var migrateUpFlags = map[string]cobraflags.Flag{
@@ -54,6 +56,16 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Enable verbose output",
 	},
+	lockTimeoutFlag: &cobraflags.StringFlag{
+		Name:  lockTimeoutFlag,
+		Value: "",
+		Usage: "Default per-migration lock timeout, such as 3s or 500ms",
+	},
+	statementTimeoutFlag: &cobraflags.StringFlag{
+		Name:  statementTimeoutFlag,
+		Value: "",
+		Usage: "Default per-migration statement timeout, such as 30s or 2m",
+	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 }
 
@@ -67,6 +79,8 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	migrationsDir := migrateUpFlags[migrationsFlag].GetString()
 	dryRun := migrateUpFlags[dryRunFlag].GetBool()
 	verbose := migrateUpFlags[verboseFlag].GetBool()
+	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
+	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -78,6 +92,11 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 
 	if verbose {
 		fmt.Printf("Connecting to database: %s\n", dbschema.FormatDatabaseURL(dbURL))
+	}
+
+	timeouts, err := migrator.ParseMigrationTimeouts(lockTimeout, statementTimeout)
+	if err != nil {
+		return err
 	}
 
 	connectTimeout, err := dbcli.ParseConnectTimeout(migrateUpFlags[dbcli.ConnectTimeoutFlagName].GetString())
@@ -115,6 +134,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
+	mig = mig.WithDefaultTimeouts(timeouts)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -132,8 +132,17 @@ The generator will return an error if:
 The generated files are compatible with the ptah migration system and can be executed using:
 
 ```bash
-go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir ./migrations
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir ./migrations --lock-timeout 3s --statement-timeout 30s
 ```
+
+For PostgreSQL, MySQL, and MariaDB targets, generated migrations containing `ALTER TABLE` automatically include:
+
+```sql
+-- +ptah lock_timeout=3s
+-- +ptah statement_timeout=30s
+```
+
+Review these defaults before production deployment and adjust them per migration when a longer rollout window is intentional.
 
 ## Configuration Options
 

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -242,7 +243,7 @@ func containsAlterTable(sql string) bool {
 
 func supportsGeneratedTimeoutDirectives(dialect string) bool {
 	normalized := platform.NormalizeDialect(dialect)
-	return normalized == platform.Postgres || normalized == platform.MySQL || normalized == platform.MariaDB
+	return slices.Contains([]string{platform.Postgres, platform.MySQL, platform.MariaDB}, normalized)
 }
 
 // reverseSchemaDiff creates a reverse diff for generating down migrations

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/core/convert/dbschematogo"
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
@@ -189,7 +190,7 @@ func generateUpMigrationSQL(diff *types.SchemaDiff, generated *goschema.Database
 	header := fmt.Sprintf("-- Migration generated from schema differences\n-- Generated on: %s\n-- Direction: UP\n\n",
 		time.Now().Format(time.RFC3339))
 
-	return header + strings.Join(statements, ";\n") + ";", nil
+	return withGeneratedTimeoutDirectives(header+strings.Join(statements, ";\n")+";", dialect), nil
 }
 
 // generateDownMigrationSQL generates the SQL for the down migration by reversing the diff
@@ -218,7 +219,30 @@ func generateDownMigrationSQL(diff *types.SchemaDiff, generated *goschema.Databa
 	header := fmt.Sprintf("-- Migration rollback\n-- Generated on: %s\n-- Direction: DOWN\n\n",
 		time.Now().Format(time.RFC3339))
 
-	return header + strings.Join(statements, ";\n") + ";", nil
+	return withGeneratedTimeoutDirectives(header+strings.Join(statements, ";\n")+";", dialect), nil
+}
+
+func withGeneratedTimeoutDirectives(sql, dialect string) string {
+	if !containsAlterTable(sql) || !supportsGeneratedTimeoutDirectives(dialect) {
+		return sql
+	}
+
+	directives := "-- +ptah lock_timeout=3s\n-- +ptah statement_timeout=30s\n"
+	separator := "\n\n"
+	if before, after, ok := strings.Cut(sql, separator); ok {
+		return before + "\n" + directives + "\n" + after
+	}
+	return directives + sql
+}
+
+func containsAlterTable(sql string) bool {
+	stripped := sqlutil.StripComments(sql)
+	return strings.Contains(strings.ToUpper(stripped), "ALTER TABLE")
+}
+
+func supportsGeneratedTimeoutDirectives(dialect string) bool {
+	normalized := platform.NormalizeDialect(dialect)
+	return normalized == platform.Postgres || normalized == platform.MySQL || normalized == platform.MariaDB
 }
 
 // reverseSchemaDiff creates a reverse diff for generating down migrations

--- a/migration/generator/migration_file_generation_test.go
+++ b/migration/generator/migration_file_generation_test.go
@@ -323,3 +323,35 @@ func TestHasActualSQLStatements(t *testing.T) {
 		})
 	}
 }
+
+func TestWithGeneratedTimeoutDirectives(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "-- Migration generated from schema differences\n-- Direction: UP\n\nALTER TABLE users ADD COLUMN email TEXT;"
+	got := withGeneratedTimeoutDirectives(sql, "postgres")
+
+	c.Assert(got, qt.Contains, "-- +ptah lock_timeout=3s")
+	c.Assert(got, qt.Contains, "-- +ptah statement_timeout=30s")
+	c.Assert(got, qt.Matches, "(?s).*-- Direction: UP\n-- \\+ptah lock_timeout=3s\n-- \\+ptah statement_timeout=30s\n\nALTER TABLE.*")
+}
+
+func TestWithGeneratedTimeoutDirectives_NoAlterTable(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "-- Direction: UP\n\nCREATE TABLE users (id INTEGER PRIMARY KEY);"
+	got := withGeneratedTimeoutDirectives(sql, "postgres")
+
+	c.Assert(got, qt.Equals, sql)
+}
+
+func TestWithGeneratedTimeoutDirectives_UnsupportedDialect(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "-- Direction: UP\n\nALTER TABLE events ADD COLUMN payload String;"
+	got := withGeneratedTimeoutDirectives(sql, "clickhouse")
+
+	c.Assert(got, qt.Equals, sql)
+
+	got = withGeneratedTimeoutDirectives(sql, "spanner")
+	c.Assert(got, qt.Equals, sql)
+}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -260,7 +260,27 @@ CREATE TABLE schema_migrations (
 4. **Test migrations**: Always test both up and down migrations before deploying
 5. **Use transactions**: The migrator automatically wraps migrations in transactions
 6. **Backup before rollbacks**: Down migrations can cause data loss
-7. **Version numbers**: Use sequential version numbers or timestamps
+7. **Use production timeouts**: Run production DDL with `--lock-timeout 3s --statement-timeout 30s` so hot-table locks and runaway statements fail fast
+8. **Version numbers**: Use sequential version numbers or timestamps
+
+### Per-Migration Timeouts
+
+Set CLI defaults for every pending migration:
+
+```bash
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --lock-timeout 3s --statement-timeout 30s
+```
+
+Override those defaults in a specific migration file with top-of-file directives:
+
+```sql
+-- +ptah lock_timeout=3s
+-- +ptah statement_timeout=30s
+
+ALTER TABLE users ADD COLUMN email TEXT;
+```
+
+PostgreSQL runs `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB run `SET SESSION innodb_lock_wait_timeout`; statement timeouts use MySQL `max_execution_time` and MariaDB `max_statement_time`.
 
 ## Safety Features
 
@@ -268,6 +288,7 @@ CREATE TABLE schema_migrations (
 - **Rollback on Failure**: If a migration fails, the transaction is rolled back
 - **Confirmation Prompts**: Down migrations require confirmation (unless `--confirm` is used)
 - **Dry Run Mode**: Preview migrations without applying them
+- **Migration Timeouts**: File-level directives and CLI defaults can cap lock waits and statement runtime for safer production rollouts
 - **Validation**: Migrations are validated before execution
 
 ## Limitations

--- a/migration/migrator/lock_timeout_integration_test.go
+++ b/migration/migrator/lock_timeout_integration_test.go
@@ -1,0 +1,76 @@
+package migrator_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMigrateUp_PostgresLockTimeoutIntegration(t *testing.T) {
+	dbURL := os.Getenv("POSTGRES_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN or TEST_DATABASE_URL not set")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		t.Skip("PostgreSQL URL required for lock timeout integration test")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS schema_migrations")
+	_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS ptah_lock_timeout_items")
+	_, err = conn.ExecContext(ctx, "CREATE TABLE ptah_lock_timeout_items (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS schema_migrations")
+		_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS ptah_lock_timeout_items")
+	}()
+
+	lockDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = lockDB.Close() }()
+
+	lockTx, err := lockDB.BeginTx(ctx, nil)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = lockTx.Rollback() }()
+
+	_, err = lockTx.ExecContext(ctx, "SELECT * FROM ptah_lock_timeout_items")
+	c.Assert(err, qt.IsNil)
+
+	fsys := fstest.MapFS{
+		"0000000001_add_blocked_column.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah lock_timeout=200ms\nALTER TABLE ptah_lock_timeout_items ADD COLUMN blocked_value TEXT;"),
+		},
+		"0000000001_add_blocked_column.down.sql": &fstest.MapFile{
+			Data: []byte("ALTER TABLE ptah_lock_timeout_items DROP COLUMN blocked_value;"),
+		},
+	}
+
+	mig, err := migrator.NewFSMigrator(conn, fsys)
+	c.Assert(err, qt.IsNil)
+
+	start := time.Now()
+	err = mig.MigrateUp(ctx)
+	elapsed := time.Since(start)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "lock timeout")
+	c.Assert(elapsed < 2*time.Second, qt.IsTrue, qt.Commentf("migration took %s", elapsed))
+}

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -112,9 +112,19 @@ func (p *FSMigrationProvider) load() error {
 		// Set the appropriate migration function based on direction
 		switch migrationFile.Direction {
 		case "up":
-			migrationsMap[migrationFile.Version].Up = MigrationFuncFromSQLFilename(path, p.fsys)
+			up, timeouts, err := MigrationFuncFromSQLFilenameWithTimeouts(path, p.fsys)
+			if err != nil {
+				return fmt.Errorf("failed to load up migration %s: %w", path, err)
+			}
+			migrationsMap[migrationFile.Version].Up = up
+			migrationsMap[migrationFile.Version].UpTimeouts = timeouts
 		case "down":
-			migrationsMap[migrationFile.Version].Down = MigrationFuncFromSQLFilename(path, p.fsys)
+			down, timeouts, err := MigrationFuncFromSQLFilenameWithTimeouts(path, p.fsys)
+			if err != nil {
+				return fmt.Errorf("failed to load down migration %s: %w", path, err)
+			}
+			migrationsMap[migrationFile.Version].Down = down
+			migrationsMap[migrationFile.Version].DownTimeouts = timeouts
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -42,18 +42,26 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 			return fmt.Errorf("failed to read migration file: %w", err)
 		}
 
-		// Split SQL into individual statements for better MySQL compatibility
-		statements := SplitSQLStatements(string(sql))
-
-		// Execute each statement separately
-		for _, stmt := range statements {
-			if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
-				return fmt.Errorf("failed to execute migration SQL: %w", err)
-			}
-		}
-
-		return nil
+		return executeMigrationFileSQL(ctx, conn, string(sql))
 	}
+}
+
+// MigrationFuncFromSQLFilenameWithTimeouts returns a migration function and any
+// file-level +ptah timeout directives parsed from the top of the SQL file.
+func MigrationFuncFromSQLFilenameWithTimeouts(filename string, fsys fs.FS) (MigrationFunc, MigrationTimeouts, error) {
+	sql, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return nil, MigrationTimeouts{}, fmt.Errorf("failed to read migration file: %w", err)
+	}
+
+	timeouts, err := parseMigrationTimeoutDirectives(string(sql))
+	if err != nil {
+		return nil, MigrationTimeouts{}, err
+	}
+
+	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		return executeMigrationFileSQL(ctx, conn, string(sql))
+	}, timeouts, nil
 }
 
 // NoopMigrationFunc is a no-op migration function
@@ -63,10 +71,12 @@ func NoopMigrationFunc(_ctx context.Context, _conn *dbschema.DatabaseConnection)
 
 // Migration represents a database migration
 type Migration struct {
-	Version     int
-	Description string
-	Up          MigrationFunc
-	Down        MigrationFunc
+	Version      int
+	Description  string
+	Up           MigrationFunc
+	Down         MigrationFunc
+	UpTimeouts   MigrationTimeouts
+	DownTimeouts MigrationTimeouts
 }
 
 // CreateMigrationFromSQL creates a migration from SQL strings
@@ -112,5 +122,20 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 		}
 	}
 
+	return nil
+}
+
+func executeMigrationFileSQL(ctx context.Context, conn *dbschema.DatabaseConnection, sql string) error {
+	statements := SplitSQLStatements(sql)
+	for _, stmt := range statements {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+
+		if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
+			return fmt.Errorf("failed to execute migration SQL: %w", err)
+		}
+	}
 	return nil
 }

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -164,4 +165,93 @@ func TestMigrationFuncFromSQLFilename_FileNotFound(t *testing.T) {
 	err := migrationFunc(context.Background(), nil)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "failed to read migration file")
+}
+
+func TestParseMigrationTimeoutDirectives(t *testing.T) {
+	tests := []struct {
+		name                    string
+		sql                     string
+		wantLockTimeout         time.Duration
+		wantStatementTimeout    time.Duration
+		wantHasLockTimeout      bool
+		wantHasStatementTimeout bool
+		wantErr                 string
+	}{
+		{
+			name: "directives at top of file",
+			sql: `-- Migration header
+-- +ptah lock_timeout=3s
+-- +ptah statement_timeout=30s
+
+ALTER TABLE users ADD COLUMN email TEXT;`,
+			wantLockTimeout:         3 * time.Second,
+			wantStatementTimeout:    30 * time.Second,
+			wantHasLockTimeout:      true,
+			wantHasStatementTimeout: true,
+		},
+		{
+			name: "multiple directives on one line",
+			sql: `-- +ptah lock_timeout=500ms statement_timeout=2m
+ALTER TABLE users ADD COLUMN email TEXT;`,
+			wantLockTimeout:         500 * time.Millisecond,
+			wantStatementTimeout:    2 * time.Minute,
+			wantHasLockTimeout:      true,
+			wantHasStatementTimeout: true,
+		},
+		{
+			name: "directive after SQL is ignored",
+			sql: `ALTER TABLE users ADD COLUMN email TEXT;
+-- +ptah lock_timeout=3s`,
+		},
+		{
+			name:    "unknown directive fails",
+			sql:     "-- +ptah unknown_timeout=3s\nALTER TABLE users ADD COLUMN email TEXT;",
+			wantErr: `unknown +ptah directive "unknown_timeout"`,
+		},
+		{
+			name:    "invalid duration fails",
+			sql:     "-- +ptah lock_timeout=soon\nALTER TABLE users ADD COLUMN email TEXT;",
+			wantErr: "invalid +ptah lock_timeout value",
+		},
+		{
+			name:    "zero duration fails",
+			sql:     "-- +ptah statement_timeout=0s\nALTER TABLE users ADD COLUMN email TEXT;",
+			wantErr: "must be greater than zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := parseMigrationTimeoutDirectives(tt.sql)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, tt.wantErr)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got.HasLockTimeout, qt.Equals, tt.wantHasLockTimeout)
+			c.Assert(got.HasStatementTimeout, qt.Equals, tt.wantHasStatementTimeout)
+			c.Assert(got.LockTimeout, qt.Equals, tt.wantLockTimeout)
+			c.Assert(got.StatementTimeout, qt.Equals, tt.wantStatementTimeout)
+		})
+	}
+}
+
+func TestMigrationFuncFromSQLFilenameWithTimeouts(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"test.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah lock_timeout=3s\nCREATE TABLE test (id SERIAL PRIMARY KEY);"),
+		},
+	}
+
+	migrationFunc, timeouts, err := MigrationFuncFromSQLFilenameWithTimeouts("test.sql", fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFunc, qt.IsNotNil)
+	c.Assert(timeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(timeouts.LockTimeout, qt.Equals, 3*time.Second)
 }

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -24,6 +24,7 @@ type MigrationStatus struct {
 type Migrator struct {
 	conn              *dbschema.DatabaseConnection
 	migrationProvider MigrationProvider
+	defaultTimeouts   MigrationTimeouts
 	initialized       bool
 	logger            *slog.Logger
 }
@@ -225,10 +226,22 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
 		}
 
+		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
+		if err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
+		}
+
 		// Apply migration
 		if err := migration.Up(ctx, m.conn); err != nil {
+			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
+		}
+
+		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return err
 		}
 
 		// Record migration via parameter binding.
@@ -309,10 +322,22 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
 		}
 
+		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts))
+		if err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
+		}
+
 		// Apply down migration
 		if err := migration.Down(ctx, m.conn); err != nil {
+			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
+		}
+
+		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return err
 		}
 
 		// Remove migration record.
@@ -393,10 +418,22 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
 		}
 
+		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
+		if err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
+		}
+
 		// Apply migration
 		if err := migration.Up(ctx, m.conn); err != nil {
+			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
 			_ = m.conn.Writer().RollbackTransaction()
 			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
+		}
+
+		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
+			_ = m.conn.Writer().RollbackTransaction()
+			return err
 		}
 
 		// Record migration via parameter binding.

--- a/migration/migrator/migrator_test.go
+++ b/migration/migrator/migrator_test.go
@@ -39,6 +39,43 @@ func TestNewFSMigrator_Success(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(m, qt.IsNotNil)
 	c.Assert(m.MigrationProvider().Migrations(), qt.HasLen, 1)
+	c.Assert(m.MigrationProvider().Migrations()[0].UpTimeouts.IsZero(), qt.IsTrue)
+}
+
+func TestNewFSMigrator_LoadsTimeoutDirectives(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah lock_timeout=3s\nCREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah statement_timeout=30s\nDROP TABLE users;"),
+		},
+	}
+
+	m, err := migrator.NewFSMigrator(nil, fsys)
+	c.Assert(err, qt.IsNil)
+	migration := m.MigrationProvider().Migrations()[0]
+	c.Assert(migration.UpTimeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(migration.DownTimeouts.HasStatementTimeout, qt.IsTrue)
+}
+
+func TestNewFSMigrator_InvalidTimeoutDirective(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah lock_timeout=0s\nCREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+	}
+
+	m, err := migrator.NewFSMigrator(nil, fsys)
+	c.Assert(err, qt.ErrorMatches, ".*failed to load up migration.*must be greater than zero.*")
+	c.Assert(m, qt.IsNil)
 }
 
 func TestNewFSMigrator_InvalidFilesystem(t *testing.T) {

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -3,7 +3,6 @@ package migrator
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -261,9 +260,13 @@ func durationMillisLiteral(duration time.Duration) string {
 }
 
 func durationMillis(duration time.Duration) int64 {
-	return int64(math.Ceil(float64(duration) / float64(time.Millisecond)))
+	return ceilDurationUnits(duration, time.Millisecond)
 }
 
 func durationSeconds(duration time.Duration) int64 {
-	return int64(math.Ceil(duration.Seconds()))
+	return ceilDurationUnits(duration, time.Second)
+}
+
+func ceilDurationUnits(duration, unit time.Duration) int64 {
+	return int64((duration-1)/unit) + 1
 }

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -64,11 +65,12 @@ func parseMigrationTimeoutDirectives(sql string) (MigrationTimeouts, error) {
 		if !strings.HasPrefix(trimmed, "--") {
 			break
 		}
-		if !strings.HasPrefix(trimmed, ptahDirectivePrefix) {
+		directive, ok := strings.CutPrefix(trimmed, ptahDirectivePrefix)
+		if !ok {
 			continue
 		}
 
-		directive := strings.TrimSpace(strings.TrimPrefix(trimmed, ptahDirectivePrefix))
+		directive = strings.TrimSpace(directive)
 		if directive == "" {
 			return MigrationTimeouts{}, fmt.Errorf("empty +ptah directive")
 		}
@@ -252,10 +254,8 @@ func mariaDBTimeoutStatements(timeouts MigrationTimeouts) (setupStatements, rest
 }
 
 func reverseStrings(values []string) []string {
-	reversed := make([]string, len(values))
-	for i, value := range values {
-		reversed[len(values)-1-i] = value
-	}
+	reversed := slices.Clone(values)
+	slices.Reverse(reversed)
 	return reversed
 }
 

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -1,0 +1,269 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+const ptahDirectivePrefix = "-- +ptah "
+
+// MigrationTimeouts configures per-migration database safety timeouts.
+// Empty values mean no timeout is configured.
+type MigrationTimeouts struct {
+	LockTimeout         time.Duration
+	StatementTimeout    time.Duration
+	HasLockTimeout      bool
+	HasStatementTimeout bool
+}
+
+type restoreTimeoutsFunc func(context.Context) error
+
+// ParseMigrationTimeouts parses CLI timeout values. Empty values are ignored.
+func ParseMigrationTimeouts(lockTimeout, statementTimeout string) (MigrationTimeouts, error) {
+	var timeouts MigrationTimeouts
+
+	if strings.TrimSpace(lockTimeout) != "" {
+		duration, err := parsePositiveDuration(lockTimeout)
+		if err != nil {
+			return MigrationTimeouts{}, fmt.Errorf("invalid lock timeout: %w", err)
+		}
+		timeouts.LockTimeout = duration
+		timeouts.HasLockTimeout = true
+	}
+
+	if strings.TrimSpace(statementTimeout) != "" {
+		duration, err := parsePositiveDuration(statementTimeout)
+		if err != nil {
+			return MigrationTimeouts{}, fmt.Errorf("invalid statement timeout: %w", err)
+		}
+		timeouts.StatementTimeout = duration
+		timeouts.HasStatementTimeout = true
+	}
+
+	return timeouts, nil
+}
+
+// IsZero reports whether no timeout is configured.
+func (t MigrationTimeouts) IsZero() bool {
+	return !t.HasLockTimeout && !t.HasStatementTimeout
+}
+
+func parseMigrationTimeoutDirectives(sql string) (MigrationTimeouts, error) {
+	var timeouts MigrationTimeouts
+
+	for line := range strings.SplitSeq(sql, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "--") {
+			break
+		}
+		if !strings.HasPrefix(trimmed, ptahDirectivePrefix) {
+			continue
+		}
+
+		directive := strings.TrimSpace(strings.TrimPrefix(trimmed, ptahDirectivePrefix))
+		if directive == "" {
+			return MigrationTimeouts{}, fmt.Errorf("empty +ptah directive")
+		}
+
+		for field := range strings.FieldsSeq(directive) {
+			key, value, ok := strings.Cut(field, "=")
+			if !ok {
+				return MigrationTimeouts{}, fmt.Errorf("invalid +ptah directive %q", field)
+			}
+			duration, err := parsePositiveDuration(value)
+			if err != nil {
+				return MigrationTimeouts{}, fmt.Errorf("invalid +ptah %s value: %w", key, err)
+			}
+
+			switch key {
+			case "lock_timeout", "lock-timeout":
+				timeouts.LockTimeout = duration
+				timeouts.HasLockTimeout = true
+			case "statement_timeout", "statement-timeout":
+				timeouts.StatementTimeout = duration
+				timeouts.HasStatementTimeout = true
+			default:
+				return MigrationTimeouts{}, fmt.Errorf("unknown +ptah directive %q", key)
+			}
+		}
+	}
+
+	return timeouts, nil
+}
+
+func parsePositiveDuration(value string) (time.Duration, error) {
+	duration, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil {
+		return 0, err
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("must be greater than zero")
+	}
+	return duration, nil
+}
+
+func mergeMigrationTimeouts(defaults, overrides MigrationTimeouts) MigrationTimeouts {
+	merged := defaults
+	if overrides.HasLockTimeout {
+		merged.LockTimeout = overrides.LockTimeout
+		merged.HasLockTimeout = true
+	}
+	if overrides.HasStatementTimeout {
+		merged.StatementTimeout = overrides.StatementTimeout
+		merged.HasStatementTimeout = true
+	}
+	return merged
+}
+
+// WithDefaultTimeouts returns a copy of the migrator that applies the provided
+// timeouts to migrations that do not override them with file-level directives.
+func (m *Migrator) WithDefaultTimeouts(timeouts MigrationTimeouts) *Migrator {
+	tmp := *m
+	tmp.defaultTimeouts = timeouts
+	return &tmp
+}
+
+func (m *Migrator) applyTimeoutsWithRestore(ctx context.Context, timeouts MigrationTimeouts) (restoreTimeoutsFunc, error) {
+	if timeouts.IsZero() {
+		return noopRestoreTimeouts, nil
+	}
+
+	setupStatements, restoreStatements, err := timeoutStatements(m.conn.Info().Dialect, timeouts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, statement := range setupStatements {
+		if err := m.conn.Writer().ExecuteSQL(ctx, statement); err != nil {
+			return nil, fmt.Errorf("failed to apply migration timeout: %w", err)
+		}
+	}
+
+	return func(ctx context.Context) error {
+		for _, statement := range restoreStatements {
+			if err := m.conn.Writer().ExecuteSQL(ctx, statement); err != nil {
+				return fmt.Errorf("failed to restore migration timeout: %w", err)
+			}
+		}
+		return nil
+	}, nil
+}
+
+func noopRestoreTimeouts(_ context.Context) error {
+	return nil
+}
+
+func (m *Migrator) restoreTimeouts(ctx context.Context, version int, restore restoreTimeoutsFunc) error {
+	if restore == nil {
+		return nil
+	}
+	if err := restore(ctx); err != nil {
+		return fmt.Errorf("failed to restore timeouts for migration %d: %w", version, err)
+	}
+	return nil
+}
+
+func (m *Migrator) restoreTimeoutsAfterFailure(ctx context.Context, version int, restore restoreTimeoutsFunc, failure error) error {
+	if restore == nil {
+		return failure
+	}
+	if err := restore(ctx); err != nil {
+		return fmt.Errorf("failed to restore timeouts after migration %d failed: %w (original error: %v)", version, err, failure)
+	}
+	return failure
+}
+
+func timeoutStatements(dialect string, timeouts MigrationTimeouts) (setupStatements, restoreStatements []string, err error) {
+	normalized := platform.NormalizeDialect(dialect)
+
+	switch normalized {
+	case platform.Postgres:
+		return postgresTimeoutStatements(timeouts), nil, nil
+	case platform.MySQL:
+		return mysqlTimeoutStatements(timeouts)
+	case platform.MariaDB:
+		return mariaDBTimeoutStatements(timeouts)
+	default:
+		return nil, nil, fmt.Errorf("migration timeouts are not supported for dialect %q", dialect)
+	}
+}
+
+func postgresTimeoutStatements(timeouts MigrationTimeouts) []string {
+	statements := make([]string, 0, 2)
+	if timeouts.HasLockTimeout {
+		statements = append(statements, "SET LOCAL lock_timeout = '"+durationMillisLiteral(timeouts.LockTimeout)+"'")
+	}
+	if timeouts.HasStatementTimeout {
+		statements = append(statements, "SET LOCAL statement_timeout = '"+durationMillisLiteral(timeouts.StatementTimeout)+"'")
+	}
+	return statements
+}
+
+func mysqlTimeoutStatements(timeouts MigrationTimeouts) (setupStatements, restoreStatements []string, err error) {
+	setup := make([]string, 0, 4)
+	restore := make([]string, 0, 2)
+	if timeouts.HasLockTimeout {
+		setup = append(setup,
+			"SET @ptah_prev_innodb_lock_wait_timeout = @@SESSION.innodb_lock_wait_timeout",
+			"SET SESSION innodb_lock_wait_timeout = "+strconv.FormatInt(durationSeconds(timeouts.LockTimeout), 10),
+		)
+		restore = append(restore, "SET SESSION innodb_lock_wait_timeout = @ptah_prev_innodb_lock_wait_timeout")
+	}
+	if timeouts.HasStatementTimeout {
+		setup = append(setup,
+			"SET @ptah_prev_max_execution_time = @@SESSION.max_execution_time",
+			"SET SESSION max_execution_time = "+strconv.FormatInt(durationMillis(timeouts.StatementTimeout), 10),
+		)
+		restore = append(restore, "SET SESSION max_execution_time = @ptah_prev_max_execution_time")
+	}
+	return setup, reverseStrings(restore), nil
+}
+
+func mariaDBTimeoutStatements(timeouts MigrationTimeouts) (setupStatements, restoreStatements []string, err error) {
+	setup := make([]string, 0, 4)
+	restore := make([]string, 0, 2)
+	if timeouts.HasLockTimeout {
+		setup = append(setup,
+			"SET @ptah_prev_innodb_lock_wait_timeout = @@SESSION.innodb_lock_wait_timeout",
+			"SET SESSION innodb_lock_wait_timeout = "+strconv.FormatInt(durationSeconds(timeouts.LockTimeout), 10),
+		)
+		restore = append(restore, "SET SESSION innodb_lock_wait_timeout = @ptah_prev_innodb_lock_wait_timeout")
+	}
+	if timeouts.HasStatementTimeout {
+		setup = append(setup,
+			"SET @ptah_prev_max_statement_time = @@SESSION.max_statement_time",
+			"SET SESSION max_statement_time = "+strconv.FormatFloat(timeouts.StatementTimeout.Seconds(), 'f', -1, 64),
+		)
+		restore = append(restore, "SET SESSION max_statement_time = @ptah_prev_max_statement_time")
+	}
+	return setup, reverseStrings(restore), nil
+}
+
+func reverseStrings(values []string) []string {
+	reversed := make([]string, len(values))
+	for i, value := range values {
+		reversed[len(values)-1-i] = value
+	}
+	return reversed
+}
+
+func durationMillisLiteral(duration time.Duration) string {
+	return strconv.FormatInt(durationMillis(duration), 10) + "ms"
+}
+
+func durationMillis(duration time.Duration) int64 {
+	return int64(math.Ceil(float64(duration) / float64(time.Millisecond)))
+}
+
+func durationSeconds(duration time.Duration) int64 {
+	return int64(math.Ceil(duration.Seconds()))
+}

--- a/migration/migrator/timeouts_test.go
+++ b/migration/migrator/timeouts_test.go
@@ -1,0 +1,147 @@
+package migrator
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseMigrationTimeouts(t *testing.T) {
+	c := qt.New(t)
+
+	timeouts, err := ParseMigrationTimeouts("3s", "30s")
+	c.Assert(err, qt.IsNil)
+	c.Assert(timeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(timeouts.LockTimeout, qt.Equals, 3*time.Second)
+	c.Assert(timeouts.HasStatementTimeout, qt.IsTrue)
+	c.Assert(timeouts.StatementTimeout, qt.Equals, 30*time.Second)
+}
+
+func TestParseMigrationTimeouts_Invalid(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := ParseMigrationTimeouts("0s", "")
+	c.Assert(err, qt.ErrorMatches, "invalid lock timeout: must be greater than zero")
+}
+
+func TestMergeMigrationTimeouts(t *testing.T) {
+	c := qt.New(t)
+
+	defaults := MigrationTimeouts{
+		LockTimeout:         3 * time.Second,
+		StatementTimeout:    30 * time.Second,
+		HasLockTimeout:      true,
+		HasStatementTimeout: true,
+	}
+	overrides := MigrationTimeouts{
+		LockTimeout:    500 * time.Millisecond,
+		HasLockTimeout: true,
+	}
+
+	got := mergeMigrationTimeouts(defaults, overrides)
+	c.Assert(got.LockTimeout, qt.Equals, 500*time.Millisecond)
+	c.Assert(got.StatementTimeout, qt.Equals, 30*time.Second)
+	c.Assert(got.HasLockTimeout, qt.IsTrue)
+	c.Assert(got.HasStatementTimeout, qt.IsTrue)
+}
+
+func TestTimeoutStatements(t *testing.T) {
+	tests := []struct {
+		name        string
+		dialect     string
+		timeouts    MigrationTimeouts
+		wantSetup   []string
+		wantRestore []string
+		wantErr     string
+	}{
+		{
+			name:    "postgres",
+			dialect: "postgres",
+			timeouts: MigrationTimeouts{
+				LockTimeout:         3 * time.Second,
+				StatementTimeout:    30 * time.Second,
+				HasLockTimeout:      true,
+				HasStatementTimeout: true,
+			},
+			wantSetup: []string{
+				"SET LOCAL lock_timeout = '3000ms'",
+				"SET LOCAL statement_timeout = '30000ms'",
+			},
+		},
+		{
+			name:    "mysql",
+			dialect: "mysql",
+			timeouts: MigrationTimeouts{
+				LockTimeout:         1500 * time.Millisecond,
+				StatementTimeout:    2500 * time.Millisecond,
+				HasLockTimeout:      true,
+				HasStatementTimeout: true,
+			},
+			wantSetup: []string{
+				"SET @ptah_prev_innodb_lock_wait_timeout = @@SESSION.innodb_lock_wait_timeout",
+				"SET SESSION innodb_lock_wait_timeout = 2",
+				"SET @ptah_prev_max_execution_time = @@SESSION.max_execution_time",
+				"SET SESSION max_execution_time = 2500",
+			},
+			wantRestore: []string{
+				"SET SESSION max_execution_time = @ptah_prev_max_execution_time",
+				"SET SESSION innodb_lock_wait_timeout = @ptah_prev_innodb_lock_wait_timeout",
+			},
+		},
+		{
+			name:    "mariadb",
+			dialect: "mariadb",
+			timeouts: MigrationTimeouts{
+				LockTimeout:         time.Second,
+				StatementTimeout:    1500 * time.Millisecond,
+				HasLockTimeout:      true,
+				HasStatementTimeout: true,
+			},
+			wantSetup: []string{
+				"SET @ptah_prev_innodb_lock_wait_timeout = @@SESSION.innodb_lock_wait_timeout",
+				"SET SESSION innodb_lock_wait_timeout = 1",
+				"SET @ptah_prev_max_statement_time = @@SESSION.max_statement_time",
+				"SET SESSION max_statement_time = 1.5",
+			},
+			wantRestore: []string{
+				"SET SESSION max_statement_time = @ptah_prev_max_statement_time",
+				"SET SESSION innodb_lock_wait_timeout = @ptah_prev_innodb_lock_wait_timeout",
+			},
+		},
+		{
+			name:    "clickhouse lock timeout",
+			dialect: "clickhouse",
+			timeouts: MigrationTimeouts{
+				LockTimeout:    time.Second,
+				HasLockTimeout: true,
+			},
+			wantErr: `migration timeouts are not supported for dialect "clickhouse"`,
+		},
+		{
+			name:    "spanner unsupported",
+			dialect: "spanner",
+			timeouts: MigrationTimeouts{
+				LockTimeout:    time.Second,
+				HasLockTimeout: true,
+			},
+			wantErr: `migration timeouts are not supported for dialect "spanner"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			gotSetup, gotRestore, err := timeoutStatements(tt.dialect, tt.timeouts)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(gotSetup, qt.DeepEquals, tt.wantSetup)
+			c.Assert(gotRestore, qt.DeepEquals, tt.wantRestore)
+		})
+	}
+}

--- a/migration/migrator/timeouts_test.go
+++ b/migration/migrator/timeouts_test.go
@@ -145,3 +145,14 @@ func TestTimeoutStatements(t *testing.T) {
 		})
 	}
 }
+
+func TestDurationUnitCeilUsesIntegerMath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(durationMillis(1500*time.Microsecond), qt.Equals, int64(2))
+	c.Assert(durationSeconds(1500*time.Millisecond), qt.Equals, int64(2))
+
+	maxDuration := time.Duration(1<<63 - 1)
+	c.Assert(durationMillis(maxDuration), qt.Equals, int64(maxDuration/time.Millisecond)+1)
+	c.Assert(durationSeconds(maxDuration), qt.Equals, int64(maxDuration/time.Second)+1)
+}


### PR DESCRIPTION
## Summary

Closes #165.

- add top-of-file `-- +ptah lock_timeout=...` and `-- +ptah statement_timeout=...` directive parsing for filesystem migrations
- apply per-migration timeouts before up/down SQL and restore MySQL/MariaDB session settings after each migration
- add `migrate-up` / `migrate-down` defaults via `--lock-timeout` and `--statement-timeout`
- emit recommended `3s` / `30s` directives from the generator for supported `ALTER TABLE` migrations
- document production defaults and add CI coverage for the PostgreSQL lock-timeout acceptance case

## Validation

- `go test ./migration/migrator ./migration/generator ./cmd/migrateup ./cmd/migratedown`
- `go test ./...`
- `go test -race ./... -timeout 10m`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go build -o /private/tmp/package-migrator-issue165 ./cmd/packagemigrator`
- `POSTGRES_TEST_DSN='postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' go test ./migration/migrator -run TestMigrateUp_PostgresLockTimeoutIntegration -count=1 -v`