### PR TITLE
Feat(migrator): online-DDL helpers for MySQL/MariaDB (gh-ost / pt-online-schema-change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,24 @@ Apply all pending migrations to bring database up to latest version:
 - ✅ Automatic rollback on failure
 - ✅ Tracks applied migrations in `schema_migrations` table
 - ✅ Supports dry-run mode for preview
+- ✅ Online DDL for large MySQL/MariaDB tables via gh-ost / pt-online-schema-change
+
+**Online DDL (MySQL/MariaDB):** route lock-heavy `ALTER TABLE` statements through
+[gh-ost](https://github.com/github/gh-ost) or
+[pt-online-schema-change](https://docs.percona.com/percona-toolkit/pt-online-schema-change.html) —
+either per migration with a `-- +ptah online_ddl_tool=ghost` directive, or automatically for
+tables above a row threshold via `ptah.yaml` (`--config`):
+
+```yaml
+online_ddl:
+  tool: ghost            # or pt-osc
+  threshold_rows: 1000000
+  args: ["--allow-on-master"]
+```
+
+If the tool is not on PATH, ptah warns and falls back to a plain `ALTER TABLE`.
+See [docs/online-ddl.md](docs/online-ddl.md) for prerequisites (binlog ROW format,
+privileges, topology flags) and invocation details.
 
 #### Roll Back Migrations
 Roll back migrations to a specific version:

--- a/cmd/internal/dbcli/onlineddl.go
+++ b/cmd/internal/dbcli/onlineddl.go
@@ -1,0 +1,38 @@
+package dbcli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-extras/cobraflags"
+
+	"github.com/stokaro/ptah/migration/onlineddl"
+)
+
+// ConfigFlagName is the CLI flag name exposed by [NewConfigFlag].
+const ConfigFlagName = "config"
+
+// NewConfigFlag returns the flag definition for the ptah.yaml config path
+// used by the migration commands. Its online_ddl section routes ALTER TABLE
+// statements on large MySQL/MariaDB tables through gh-ost or
+// pt-online-schema-change (issue #173).
+func NewConfigFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  ConfigFlagName,
+		Value: "",
+		Usage: "Path to a ptah.yaml config file (default: ./" + onlineddl.ConfigFileName + " when present)",
+	}
+}
+
+// LoadOnlineDDLConfig loads the online_ddl section for a migration command.
+// An explicitly passed path must exist; the conventional ./ptah.yaml is
+// optional and yields a disabled config when absent.
+func LoadOnlineDDLConfig(path string) (*onlineddl.Config, error) {
+	if path == "" {
+		return onlineddl.LoadConfig(onlineddl.ConfigFileName)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("ptah config %s: %w", path, err)
+	}
+	return onlineddl.LoadConfig(path)
+}

--- a/cmd/internal/dbcli/onlineddl_test.go
+++ b/cmd/internal/dbcli/onlineddl_test.go
@@ -1,0 +1,34 @@
+package dbcli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+)
+
+func TestLoadOnlineDDLConfig(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ptah.yaml")
+	c.Assert(os.WriteFile(path, []byte("online_ddl:\n  tool: ghost\n  threshold_rows: 500\n"), 0o600), qt.IsNil)
+
+	cfg, err := dbcli.LoadOnlineDDLConfig(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, "ghost")
+	c.Assert(cfg.ThresholdRows, qt.Equals, int64(500))
+}
+
+func TestLoadOnlineDDLConfig_ExplicitMissingPathIsAnError(t *testing.T) {
+	c := qt.New(t)
+
+	// An explicit --config path that does not exist is a usage error — unlike
+	// the conventional ./ptah.yaml, whose absence is fine (covered by
+	// onlineddl.TestLoadConfig_MissingFileYieldsDisabledConfig).
+	_, err := dbcli.LoadOnlineDDLConfig(filepath.Join(t.TempDir(), "absent.yaml"))
+	c.Assert(err, qt.ErrorMatches, "ptah config .*absent.yaml.*")
+}

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/onlineddl"
 )
 
 var migrateDownCmd = &cobra.Command{
@@ -71,6 +72,7 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Usage: "Skip confirmation prompt (use with caution!)",
 	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:         dbcli.NewConfigFlag(),
 }
 
 func NewMigrateDownCommand() *cobra.Command {
@@ -134,8 +136,19 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)
 
+	// Online-DDL routing works for down migrations too: a rollback ALTER on
+	// a large table is just as lock-heavy as the forward one.
+	onlineCfg, err := dbcli.LoadOnlineDDLConfig(migrateDownFlags[dbcli.ConfigFlagName].GetString())
+	if err != nil {
+		return err
+	}
+	if onlineCfg.Enabled() {
+		fmt.Printf("Online DDL: tool=%s threshold_rows=%d\n", onlineCfg.Tool, onlineCfg.ThresholdRows)
+	}
+	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
+
 	// Create migrator to access applied migrations
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS)
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor))
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/onlineddl"
 )
 
 var migrateUpCmd = &cobra.Command{
@@ -55,6 +56,7 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Usage: "Enable verbose output",
 	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:         dbcli.NewConfigFlag(),
 }
 
 func NewMigrateUpCommand() *cobra.Command {
@@ -111,7 +113,19 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)
 
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS)
+	// Online-DDL routing: `-- +ptah online_ddl_tool=...` directives always
+	// work; the ptah.yaml online_ddl section adds automatic routing of
+	// ALTERs on tables above the configured row threshold.
+	onlineCfg, err := dbcli.LoadOnlineDDLConfig(migrateUpFlags[dbcli.ConfigFlagName].GetString())
+	if err != nil {
+		return err
+	}
+	if onlineCfg.Enabled() {
+		fmt.Printf("Online DDL: tool=%s threshold_rows=%d\n", onlineCfg.Tool, onlineCfg.ThresholdRows)
+	}
+	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
+
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor))
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/docs/online-ddl.md
+++ b/docs/online-ddl.md
@@ -1,0 +1,109 @@
+# Online DDL for MySQL/MariaDB (gh-ost / pt-online-schema-change)
+
+`ALTER TABLE` on a large MySQL or MariaDB table can block writes for minutes
+to hours. Production teams route such changes through
+[gh-ost](https://github.com/github/gh-ost) or
+[pt-online-schema-change](https://docs.percona.com/percona-toolkit/pt-online-schema-change.html),
+which rebuild the table as a shadow copy with row-level catch-up and swap it
+in with a near-instant rename.
+
+`ptah migrate-up` / `ptah migrate-down` can invoke these tools for you
+(issue #173). Routing happens two ways.
+
+## Per-migration directive
+
+Annotate a migration file with a ptah directive comment:
+
+```sql
+-- +ptah online_ddl_tool=ghost
+ALTER TABLE users ADD COLUMN bio TEXT;
+```
+
+Every `ALTER TABLE` statement in that migration is routed through the chosen
+tool (`ghost` or `pt-osc`); non-ALTER statements run normally on the
+migration connection. `online_ddl_tool=none` opts the migration out of
+automatic threshold routing (see below).
+
+Directives work without any configuration file.
+
+## Automatic routing via ptah.yaml
+
+Create a `ptah.yaml` next to where you run the CLI (or pass `--config`):
+
+```yaml
+online_ddl:
+  tool: ghost            # or pt-osc
+  threshold_rows: 1000000
+  args:
+    - --allow-on-master
+    - --max-load=Threads_running=25
+```
+
+With this config, any `ALTER TABLE` whose target table has an estimated row
+count (from `information_schema.TABLES`) at or above `threshold_rows` is
+routed through the tool automatically. Smaller tables get a plain `ALTER`.
+`args` are appended verbatim to every tool invocation — this is where
+deployment-specific switches belong.
+
+## Fallback behavior
+
+The routing degrades safely — the plain `ALTER TABLE` on the migration
+connection is always the fallback:
+
+- the tool binary is not on `PATH` → warning + plain ALTER;
+- the row-count estimate fails → warning + plain ALTER;
+- the dialect is not MySQL/MariaDB → directives are ignored with a warning;
+- the tool itself exits non-zero → the migration **fails** (no silent
+  fallback once the tool has started: it may have left a shadow table
+  behind, and rerunning a plain ALTER on top could double-apply).
+
+`--dry-run` logs the tool invocation that would run without executing it.
+
+## Invocation details
+
+For `ALTER TABLE <tbl> <clause>` with database URL
+`mysql://user:pass@host:port/db`, ptah runs:
+
+```text
+gh-ost --host=host --port=port --user=user --database=db --table=tbl \
+       --alter="<clause>" [--password=pass] [args...] --execute
+
+pt-online-schema-change --alter "<clause>" [args...] --execute \
+       h=host,P=port,u=user,D=db,t=tbl,p=pass
+```
+
+A schema-qualified table (`ALTER TABLE shop.users ...`) overrides the
+database from the URL. The alter clause is passed through verbatim, so
+multi-part alters (`ADD COLUMN a INT, ADD INDEX idx (a)`) work.
+
+## Prerequisites you must provide
+
+ptah shells out to the tools; it does not configure your topology. Before
+enabling:
+
+- **binlog in ROW format** (`binlog_format=ROW`) — required by gh-ost, which
+  reads the binary log to replay ongoing writes onto the shadow table.
+- **gh-ost topology flags**: by default gh-ost expects to connect to a
+  replica. On a single-node/master-only setup add `--allow-on-master` to
+  `online_ddl.args`. For reading from a specific replica, put the replica
+  DSN switches (`--assume-master-host`, throttling flags, ...) there too.
+- **pt-online-schema-change** uses triggers for catch-up: the table must not
+  already have conflicting triggers, and foreign-key handling needs an
+  explicit strategy (`--alter-foreign-keys-method`) when children reference
+  the table.
+- **Privileges**: both tools need more than plain ALTER — gh-ost needs
+  REPLICATION SLAVE/CLIENT plus DDL/DML on the schema; pt-osc needs
+  CREATE/DROP/TRIGGER.
+- **Credentials on the command line** are visible in the process list. For
+  shared hosts prefer the tools' own config mechanisms (gh-ost `--conf`,
+  pt-osc `/etc/percona-toolkit/`), passing them via `online_ddl.args`, and a
+  database URL without an inline password.
+
+## Interaction with migration transactions
+
+The migrator wraps each migration in a transaction, but MySQL DDL commits
+implicitly anyway, and the online tools run on their own connections. A
+tool-routed migration is therefore **not atomic**: if it fails halfway, fix
+the underlying issue (and clean up the tool's shadow/ghost tables if any)
+before re-running. Keep online-DDL migrations minimal — ideally one ALTER
+per migration, with unrelated statements in separate migrations.

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -110,10 +110,9 @@ type File struct {
 	// up for down) exists in the same directory.
 	HasPair bool
 	// WellFormedName reports whether the name matches the documented
-	// NNNNNNNNNN_description.(up|down).sql convention. The migrator's own
-	// parser is more lenient (see Direction), so a name can be parseable
-	// yet not well-formed — 0000000001_cleanup.sql parses as an up
-	// migration with a truncated description.
+	// NNNNNNNNNN_description.(up|down).sql convention, checked
+	// independently of the migrator's parser as defense in depth (see the
+	// strictNameRe comment).
 	WellFormedName bool
 	// Statements holds the parsed statements of up migrations. Empty for
 	// down migrations (statement rules do not run there).
@@ -297,11 +296,12 @@ func ruleAppliesToDialect(rule Rule, dialect string) bool {
 	return slices.Contains(rule.Dialects, dialect)
 }
 
-// strictNameRe is the documented migration naming convention. The migrator's
-// own parser is more lenient — its regexp has an unescaped dot before the
-// direction, so 0000000001_cleanup.sql parses as an up migration — which is
-// why WellFormedName checks the strict form while Direction follows the
-// migrator.
+// strictNameRe is the documented migration naming convention, encoded
+// independently of the migrator's parser: WellFormedName checks this strict
+// form while Direction follows the migrator, so if the two ever diverge
+// again (as they did before #245, when the migrator's unescaped dot made
+// 0000000001_cleanup.sql run as an up migration) lint keeps scanning
+// whatever the migrator would execute and MF103 explains the ambiguity.
 var strictNameRe = regexp.MustCompile(`^\d{10}_.+\.(up|down)\.sql$`)
 
 // rawStatement is one raw SQL statement plus the line it starts on.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -384,12 +384,30 @@ func TestLintFS_NestedDirectoriesAreLinted(t *testing.T) {
 	c.Assert(findings[0].Line, qt.Equals, 1)
 }
 
-func TestLintFS_MigratorLenientNamesAreLinted(t *testing.T) {
+func TestLintFS_UpSuffixFallbackScansMalformedVersions(t *testing.T) {
 	c := qt.New(t)
 
-	// The migrator's lenient name parser runs 0000000001_cleanup.sql as an
-	// UP migration and 0000000002_teardown.sql as a DOWN one; lint must
-	// classify them the same way instead of skipping their statements.
+	// A .up.sql file whose version prefix the migrator rejects still gets
+	// hazard scanning via the IsUp suffix fallback — the author clearly
+	// meant it as an up migration, and MF103 explains why it will not run.
+	fsys := fixture(map[string]string{
+		"001_bad_version.up.sql":   "DROP TABLE users;\n",
+		"001_bad_version.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF103", "MF103", "DS101"},
+		qt.Commentf("naming warnings for both files plus the hazard in the up file; got %v", findings))
+}
+
+func TestLintFS_SuffixlessNamesFollowTheMigrator(t *testing.T) {
+	c := qt.New(t)
+
+	// Since the migrator's name regexp was fixed (#245), a description
+	// merely ending in up/down is not a migration: the migrator skips the
+	// file, so lint reports the naming problem instead of scanning
+	// statements that will never run.
 	fsys := fixture(map[string]string{
 		"0000000001_cleanup.sql":  "DROP TABLE users;\n",
 		"0000000002_teardown.sql": "DROP TABLE audit;\n",
@@ -398,12 +416,10 @@ func TestLintFS_MigratorLenientNamesAreLinted(t *testing.T) {
 	findings, err := lint.LintFS(fsys, lint.Options{})
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF101", "MF103", "DS101", "MF103"},
-		qt.Commentf("cleanup.sql is an up migration to the migrator: DS101 + missing down + ambiguous name; teardown.sql is a down migration: ambiguous name only; got %v", findings))
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"MF103", "MF103"},
+		qt.Commentf("both files are invisible to the migrator: naming warnings only; got %v", findings))
 	for _, f := range findings {
-		if f.Rule == "MF103" {
-			c.Assert(f.Message, qt.Contains, "ambiguous file name")
-		}
+		c.Assert(f.Message, qt.Contains, "the migrator will not pick it up")
 	}
 }
 

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -132,9 +132,11 @@ func migrationFormRules() []Rule {
 				}
 				message := "file name does not match NNNNNNNNNN_description.(up|down).sql; the migrator will not pick it up"
 				if file.Direction != "" {
-					// The migrator's lenient parser accepts this name — e.g.
-					// 0000000001_cleanup.sql runs as an UP migration — which
-					// is more surprising than being skipped.
+					// Defense in depth: unreachable while the migrator's
+					// parser matches the strict convention (#245 fixed its
+					// lenient regexp), but if they ever diverge again a name
+					// the migrator would RUN despite its odd spelling is more
+					// surprising than one it skips, so say so.
 					message = fmt.Sprintf("ambiguous file name: the migrator runs this as a %s migration even though it does not end in .%s.sql; rename it to NNNNNNNNNN_description.%s.sql", file.Direction, file.Direction, file.Direction)
 				}
 				return []Finding{{

--- a/migration/migrator/directives.go
+++ b/migration/migrator/directives.go
@@ -1,0 +1,72 @@
+package migrator
+
+import (
+	"strings"
+
+	"github.com/stokaro/ptah/core/lexer"
+)
+
+// directivePrefix marks a ptah directive inside a SQL line comment:
+//
+//	-- +ptah key=value [key=value ...]
+const directivePrefix = "+ptah"
+
+// ParseFileDirectives extracts `-- +ptah key=value` annotations from migration
+// SQL. Directives are file-scoped: every annotated line contributes to one
+// merged map (later lines win on duplicate keys). Tokens without an equals
+// sign and malformed lines are ignored — directives must never make a
+// migration file unreadable.
+//
+// The scan is lexer-driven, the same lexer SplitSQLStatements uses, so a
+// `-- +ptah` sequence inside a string literal or a block comment is never
+// mistaken for a directive; the two views of the file cannot disagree. A
+// directive must additionally be a line comment that begins its physical line
+// (leading whitespace allowed), so an ordinary trailing comment after a
+// statement is not treated as a directive either.
+func ParseFileDirectives(sql string) map[string]string {
+	directives := map[string]string{}
+	lexr := lexer.NewLexer(sql)
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		if tok.Type != lexer.TokenComment {
+			continue
+		}
+		body, ok := strings.CutPrefix(tok.Value, "--")
+		if !ok {
+			continue // block comment: not a directive carrier
+		}
+		if !commentStartsLine(sql, tok.Start) {
+			continue // trailing comment: not a directive
+		}
+		body, ok = strings.CutPrefix(strings.TrimSpace(body), directivePrefix)
+		if !ok || (body != "" && body[0] != ' ' && body[0] != '\t') {
+			continue
+		}
+		for token := range strings.FieldsSeq(body) {
+			key, value, found := strings.Cut(token, "=")
+			if found && key != "" {
+				directives[key] = value
+			}
+		}
+	}
+	return directives
+}
+
+// commentStartsLine reports whether only whitespace precedes the byte at pos
+// on its physical line.
+func commentStartsLine(sql string, pos int) bool {
+	for i := pos - 1; i >= 0; i-- {
+		switch sql[i] {
+		case '\n':
+			return true
+		case ' ', '\t', '\r':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/migration/migrator/directives_test.go
+++ b/migration/migrator/directives_test.go
@@ -1,0 +1,72 @@
+package migrator
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseFileDirectives(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want map[string]string
+	}{
+		{
+			name: "single directive",
+			sql:  "-- +ptah online_ddl_tool=ghost\nALTER TABLE users ADD COLUMN bio TEXT;\n",
+			want: map[string]string{"online_ddl_tool": "ghost"},
+		},
+		{
+			name: "leading whitespace and multiple pairs on one line",
+			sql:  "   --  +ptah online_ddl_tool=pt-osc foo=bar\nSELECT 1;\n",
+			want: map[string]string{"online_ddl_tool": "pt-osc", "foo": "bar"},
+		},
+		{
+			name: "multiple directive lines merge with later lines winning",
+			sql:  "-- +ptah a=1\n-- +ptah b=2\n-- +ptah a=3\n",
+			want: map[string]string{"a": "3", "b": "2"},
+		},
+		{
+			name: "regular comments are not directives",
+			sql:  "-- ordinary comment with ptah in it\n-- ptah key=value (no plus)\nSELECT 1; -- +ptah trailing=nope is fine because the line does not start with the comment\n",
+			want: map[string]string{},
+		},
+		{
+			name: "directive-looking text inside a string literal is not a directive",
+			sql:  "INSERT INTO notes (body) VALUES ('runbook:\n-- +ptah online_ddl_tool=ghost\ndone');\nALTER TABLE users ADD COLUMN a INT;\n",
+			want: map[string]string{},
+		},
+		{
+			name: "directive-looking text inside a block comment is not a directive",
+			sql:  "/*\n-- +ptah online_ddl_tool=ghost\n*/\nALTER TABLE users ADD COLUMN a INT;\n",
+			want: map[string]string{},
+		},
+		{
+			name: "real directive alongside a decoy inside a string still parses",
+			sql:  "-- +ptah online_ddl_tool=pt-osc\nINSERT INTO notes (body) VALUES ('-- +ptah online_ddl_tool=ghost');\n",
+			want: map[string]string{"online_ddl_tool": "pt-osc"},
+		},
+		{
+			name: "tokens without an equals sign are ignored",
+			sql:  "-- +ptah standalone online_ddl_tool=ghost =orphan\n",
+			want: map[string]string{"online_ddl_tool": "ghost"},
+		},
+		{
+			name: "directive prefix must be a whole word",
+			sql:  "-- +ptahx key=value\n",
+			want: map[string]string{},
+		},
+		{
+			name: "empty input",
+			sql:  "",
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(ParseFileDirectives(tt.sql), qt.DeepEquals, tt.want)
+		})
+	}
+}

--- a/migration/migrator/interceptor_test.go
+++ b/migration/migrator/interceptor_test.go
@@ -1,0 +1,124 @@
+package migrator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// recordingInterceptor handles every statement and records what it saw.
+type recordingInterceptor struct {
+	statements   []string
+	directives   []map[string]string
+	err          error
+	validateErr  error
+	handled      bool // whether ExecuteStatement claims to have handled statements
+	handledSetup bool
+}
+
+func (r *recordingInterceptor) ValidateDirectives(map[string]string) error {
+	return r.validateErr
+}
+
+func (r *recordingInterceptor) ExecuteStatement(_ context.Context, _ *dbschema.DatabaseConnection, stmt string, directives map[string]string) (bool, error) {
+	if r.err != nil {
+		return false, r.err
+	}
+	r.statements = append(r.statements, stmt)
+	r.directives = append(r.directives, directives)
+	if r.handledSetup {
+		return r.handled, nil
+	}
+	return true, nil
+}
+
+func TestFSMigrationProvider_StatementInterceptorSeesStatementsAndDirectives(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_widen.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah online_ddl_tool=ghost\n" +
+				"ALTER TABLE users ADD COLUMN bio TEXT;\n" +
+				"ALTER TABLE users ADD COLUMN age INT;\n",
+		)},
+		"0000000001_widen.down.sql": &fstest.MapFile{Data: []byte(
+			"ALTER TABLE users DROP COLUMN age;\n",
+		)},
+	}
+
+	interceptor := &recordingInterceptor{}
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithStatementInterceptor(interceptor))
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	// The interceptor handles every statement, so a nil connection is never
+	// touched.
+	c.Assert(migrations[0].Up(context.Background(), nil), qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		"ALTER TABLE users ADD COLUMN age INT",
+	})
+	c.Assert(interceptor.directives, qt.HasLen, 2)
+	c.Assert(interceptor.directives[0], qt.DeepEquals, map[string]string{"online_ddl_tool": "ghost"})
+
+	// Down migrations carry their own (here: empty) directive set.
+	c.Assert(migrations[0].Down(context.Background(), nil), qt.IsNil)
+	c.Assert(interceptor.statements[2], qt.Equals, "ALTER TABLE users DROP COLUMN age")
+	c.Assert(interceptor.directives[2], qt.DeepEquals, map[string]string{})
+}
+
+func TestMigrationFuncFromSQLFilenameWithInterceptor_ErrorAbortsMigration(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"m.sql": &fstest.MapFile{Data: []byte("ALTER TABLE users ADD COLUMN bio TEXT;")},
+	}
+	interceptor := &recordingInterceptor{err: context.DeadlineExceeded}
+
+	fn := migrator.MigrationFuncFromSQLFilenameWithInterceptor("m.sql", fsys, interceptor)
+	err := fn(context.Background(), nil)
+	c.Assert(err, qt.ErrorMatches, "failed to execute migration SQL: .*")
+}
+
+func TestMigrationFuncFromSQLFilenameWithInterceptor_ValidateDirectivesRunsBeforeAnyStatement(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"m.sql": &fstest.MapFile{Data: []byte(
+			"CREATE TABLE t (id INT);\nALTER TABLE t ADD COLUMN a INT;\n")},
+	}
+	interceptor := &recordingInterceptor{validateErr: errors.New("bad directive value")}
+
+	fn := migrator.MigrationFuncFromSQLFilenameWithInterceptor("m.sql", fsys, interceptor)
+	err := fn(context.Background(), nil)
+
+	c.Assert(err, qt.ErrorMatches, "invalid migration directives in m.sql: bad directive value")
+	c.Assert(interceptor.statements, qt.HasLen, 0,
+		qt.Commentf("no statement may execute once directive validation fails"))
+}
+
+func TestMigrationFuncFromSQLFilenameWithInterceptor_DeclinedStatementReachesWriter(t *testing.T) {
+	c := qt.New(t)
+
+	// When the interceptor declines a statement (handled=false), the
+	// migrator must run it on the connection. With a nil connection that
+	// dispatch panics — which is exactly what proves the writer path is
+	// taken (a regression that skipped declined statements would not panic).
+	fsys := fstest.MapFS{
+		"m.sql": &fstest.MapFile{Data: []byte("ALTER TABLE t ADD COLUMN a INT;")},
+	}
+	interceptor := &recordingInterceptor{handledSetup: true, handled: false}
+
+	fn := migrator.MigrationFuncFromSQLFilenameWithInterceptor("m.sql", fsys, interceptor)
+	c.Assert(func() { _ = fn(context.Background(), nil) }, qt.PanicMatches, ".*")
+	c.Assert(interceptor.statements, qt.HasLen, 1,
+		qt.Commentf("the interceptor was still consulted before the writer dispatch"))
+}

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -53,16 +53,32 @@ func (p *RegisteredMigrationProvider) maybeSort() {
 // It scans the filesystem for migration files following the naming convention and
 // automatically creates Migration instances from the SQL files.
 type FSMigrationProvider struct {
-	fsys       fs.FS
-	migrations []*Migration
+	fsys        fs.FS
+	migrations  []*Migration
+	interceptor StatementInterceptor
+}
+
+// FSProviderOption configures a FSMigrationProvider before it loads
+// migrations.
+type FSProviderOption func(*FSMigrationProvider)
+
+// WithStatementInterceptor makes every loaded migration consult the given
+// interceptor for each statement (see StatementInterceptor).
+func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption {
+	return func(p *FSMigrationProvider) {
+		p.interceptor = interceptor
+	}
 }
 
 // NewFSMigrationProvider creates a new filesystem-based migration provider.
 // It scans the provided filesystem for migration files and validates that all migrations
 // have both up and down files. Returns an error if the filesystem cannot be scanned
 // or if any migrations are incomplete.
-func NewFSMigrationProvider(fsys fs.FS) (*FSMigrationProvider, error) {
+func NewFSMigrationProvider(fsys fs.FS, opts ...FSProviderOption) (*FSMigrationProvider, error) {
 	p := &FSMigrationProvider{fsys: fsys}
+	for _, opt := range opts {
+		opt(p)
+	}
 	if err := p.load(); err != nil {
 		return nil, err
 	}
@@ -112,9 +128,9 @@ func (p *FSMigrationProvider) load() error {
 		// Set the appropriate migration function based on direction
 		switch migrationFile.Direction {
 		case "up":
-			migrationsMap[migrationFile.Version].Up = MigrationFuncFromSQLFilename(path, p.fsys)
+			migrationsMap[migrationFile.Version].Up = MigrationFuncFromSQLFilenameWithInterceptor(path, p.fsys, p.interceptor)
 		case "down":
-			migrationsMap[migrationFile.Version].Down = MigrationFuncFromSQLFilename(path, p.fsys)
+			migrationsMap[migrationFile.Version].Down = MigrationFuncFromSQLFilenameWithInterceptor(path, p.fsys, p.interceptor)
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -169,6 +169,36 @@ func TestNewFSMigrationProvider_EmptyFilesystem(t *testing.T) {
 	c.Assert(migrations, qt.HasLen, 0)
 }
 
+func TestNewFSMigrationProvider_DescriptionEndingInUpIsNotAMigration(t *testing.T) {
+	c := qt.New(t)
+
+	// Regression for issue #245: with the unescaped dot in fileNameRe,
+	// 0000000003_cleanup.sql used to register as version 3's UP migration
+	// (description "Clea") and its SQL would run on migrate-up.
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+		"0000000003_cleanup.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+		"0000000004_teardown.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE audit;"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil, qt.Commentf("suffix-less files are skipped, not incomplete migrations"))
+	c.Assert(provider, qt.IsNotNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].Version, qt.Equals, 1)
+}
+
 func TestNewFSMigrationProvider_InvalidFiles(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -33,13 +33,50 @@ func SplitSQLStatements(sql string) []string {
 	return sqlutil.SplitSQLStatements(sqlutil.StripComments(sql))
 }
 
+// StatementInterceptor lets an external executor take over individual
+// migration statements — for example, routing ALTER TABLE statements through
+// an online-DDL tool (gh-ost, pt-online-schema-change) instead of executing
+// them on the migration connection.
+//
+// ValidateDirectives is called once per migration, before any statement runs,
+// so a bad directive fails the migration cleanly with nothing applied instead
+// of surfacing only when the first affected statement is reached.
+//
+// ExecuteStatement receives one statement (comments stripped) together with
+// the file-level directives of the migration it came from (see
+// ParseFileDirectives). It returns handled=true when it fully executed the
+// statement itself; on handled=false the migrator executes the statement
+// normally. A non-nil error aborts the migration.
+type StatementInterceptor interface {
+	ValidateDirectives(directives map[string]string) error
+	ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (handled bool, err error)
+}
+
 // MigrationFuncFromSQLFilename returns a migration function that reads SQL from a file
 // in the provided filesystem and executes it using the database connection
 func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
+	return MigrationFuncFromSQLFilenameWithInterceptor(filename, fsys, nil)
+}
+
+// MigrationFuncFromSQLFilenameWithInterceptor is MigrationFuncFromSQLFilename
+// with an optional StatementInterceptor consulted for every statement; nil
+// behaves exactly like MigrationFuncFromSQLFilename.
+func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc {
 	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 		sql, err := fs.ReadFile(fsys, filename)
 		if err != nil {
 			return fmt.Errorf("failed to read migration file: %w", err)
+		}
+
+		// Directives live in comments, so they must be read from the raw
+		// file before comment stripping, and validated before any statement
+		// runs so an invalid directive leaves nothing half-applied.
+		var directives map[string]string
+		if interceptor != nil {
+			directives = ParseFileDirectives(string(sql))
+			if err := interceptor.ValidateDirectives(directives); err != nil {
+				return fmt.Errorf("invalid migration directives in %s: %w", filename, err)
+			}
 		}
 
 		// Split SQL into individual statements for better MySQL compatibility
@@ -47,6 +84,15 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 
 		// Execute each statement separately
 		for _, stmt := range statements {
+			if interceptor != nil {
+				handled, err := interceptor.ExecuteStatement(ctx, conn, stmt, directives)
+				if err != nil {
+					return fmt.Errorf("failed to execute migration SQL: %w", err)
+				}
+				if handled {
+					continue
+				}
+			}
 			if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
 				return fmt.Errorf("failed to execute migration SQL: %w", err)
 			}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -33,8 +33,8 @@ type Migrator struct {
 // NNNNNNNNNN_description.up.sql and NNNNNNNNNN_description.down.sql and automatically
 // registers them with the migrator. Returns an error if the filesystem cannot be scanned
 // or if any migrations are incomplete (missing up or down files).
-func NewFSMigrator(conn *dbschema.DatabaseConnection, fsys fs.FS) (*Migrator, error) {
-	provider, err := NewFSMigrationProvider(fsys)
+func NewFSMigrator(conn *dbschema.DatabaseConnection, fsys fs.FS, opts ...FSProviderOption) (*Migrator, error) {
+	provider, err := NewFSMigrationProvider(fsys, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -13,8 +13,10 @@ import (
 	"golang.org/x/text/language"
 )
 
-// Migration file naming pattern: NNNNNNNNNN_description.up.sql or NNNNNNNNNN_description.down.sql
-var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*).(down|up)(\.sql)$`)
+// Migration file naming pattern: NNNNNNNNNN_description.up.sql or NNNNNNNNNN_description.down.sql.
+// The dot before the direction is literal: a description merely ending in
+// "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
+var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
 // MigrationFile represents the parsed components of a migration file name
 type MigrationFile struct {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -42,6 +42,90 @@ func TestParseMigrationFileName(t *testing.T) {
 			expectError: true,
 		},
 		{
+			// Regression for issue #245: the unescaped dot in fileNameRe used
+			// to make any description ending in "up"/"down" parse as a
+			// migration (cleanup.sql ran as UP with description "Clea").
+			name:        "description ending in up is not a direction",
+			filename:    "0000000001_cleanup.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "description ending in down is not a direction",
+			filename:    "0000000001_teardown.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "setup without direction suffix",
+			filename:    "0000000001_setup.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:     "description ending in up with a proper direction suffix",
+			filename: "0000000003_cleanup.up.sql",
+			expected: &MigrationFile{
+				Version:   3,
+				Name:      "Cleanup",
+				Direction: "up",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			name:     "description ending in down with a proper direction suffix",
+			filename: "0000000004_teardown.down.sql",
+			expected: &MigrationFile{
+				Version:   4,
+				Name:      "Teardown",
+				Direction: "down",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// Pins the other half of the naming language: descriptions may
+			// contain dots, so an over-tightened pattern ((.*) -> ([^.]*))
+			// must fail here instead of silently skipping such migrations.
+			name:     "description containing dots",
+			filename: "0000000001_v2.0_schema.up.sql",
+			expected: &MigrationFile{
+				Version:   1,
+				Name:      "V2.0 Schema",
+				Direction: "up",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// The LAST direction token wins; everything before it is
+			// description (greedy match).
+			name:     "multiple direction tokens",
+			filename: "0000000001_foo.up.down.sql",
+			expected: &MigrationFile{
+				Version:   1,
+				Name:      "Foo.up",
+				Direction: "down",
+				Extension: ".sql",
+			},
+			expectError: false,
+		},
+		{
+			// Only a literal dot separates description from direction: a
+			// lenient-separator pattern ([._]) must not sneak back in.
+			name:        "underscore before direction is not a separator",
+			filename:    "0000000001_add_users_up.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "dash before direction is not a separator",
+			filename:    "0000000001_migrate-up.sql",
+			expected:    nil,
+			expectError: true,
+		},
+		{
 			name:        "invalid format - wrong extension",
 			filename:    "0000000001_create_users_table.up.txt",
 			expected:    nil,
@@ -101,6 +185,11 @@ func TestValidateMigrationFileName(t *testing.T) {
 		{
 			name:     "invalid format",
 			filename: "invalid_filename.sql",
+			expected: false,
+		},
+		{
+			name:     "description ending in up without direction suffix",
+			filename: "0000000001_cleanup.sql",
 			expected: false,
 		},
 	}

--- a/migration/onlineddl/config.go
+++ b/migration/onlineddl/config.go
@@ -1,0 +1,101 @@
+// Package onlineddl routes ALTER TABLE migration statements through external
+// online-DDL tools — gh-ost or pt-online-schema-change — so large MySQL and
+// MariaDB tables can be altered without holding a long table lock (issue
+// #173).
+//
+// Routing happens two ways:
+//
+//   - a per-migration directive `-- +ptah online_ddl_tool=ghost` (or pt-osc,
+//     or none) forces the choice for every ALTER TABLE in that migration;
+//   - a ptah.yaml config with online_ddl.tool and online_ddl.threshold_rows
+//     routes any ALTER TABLE automatically when the target table's estimated
+//     row count reaches the threshold.
+//
+// When the selected tool is not on PATH the executor logs a warning and the
+// statement falls back to a plain ALTER TABLE on the migration connection.
+package onlineddl
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ConfigFileName is the conventional ptah configuration file looked up in the
+// working directory when no explicit path is given.
+const ConfigFileName = "ptah.yaml"
+
+// Canonical tool names accepted in configuration and directives.
+const (
+	// ToolGhost routes ALTERs through GitHub's gh-ost.
+	ToolGhost = "ghost"
+	// ToolPTOSC routes ALTERs through Percona's pt-online-schema-change.
+	ToolPTOSC = "pt-osc"
+)
+
+// Config is the online_ddl section of ptah.yaml.
+type Config struct {
+	// Tool selects the online-DDL tool used for automatic routing: "ghost"
+	// or "pt-osc". Empty disables automatic routing (per-migration
+	// directives keep working).
+	Tool string `yaml:"tool"`
+	// ThresholdRows enables automatic routing: any ALTER TABLE on a table
+	// whose estimated row count (information_schema) is at or above this
+	// value goes through Tool. Zero disables automatic routing.
+	ThresholdRows int64 `yaml:"threshold_rows"`
+	// Args are extra arguments appended to every tool invocation — e.g.
+	// gh-ost's --allow-on-master or --max-load, pt-osc's --max-lag.
+	Args []string `yaml:"args"`
+}
+
+// ptahConfig is the ptah.yaml envelope.
+type ptahConfig struct {
+	OnlineDDL Config `yaml:"online_ddl"`
+}
+
+// Enabled reports whether automatic threshold routing is configured.
+// Directive-based routing works regardless.
+func (c Config) Enabled() bool {
+	return c.Tool != "" && c.ThresholdRows > 0
+}
+
+// Validate checks the configuration values.
+func (c Config) Validate() error {
+	switch c.Tool {
+	case "", ToolGhost, ToolPTOSC:
+	default:
+		return fmt.Errorf("unknown online_ddl tool %q: expected %s or %s", c.Tool, ToolGhost, ToolPTOSC)
+	}
+	if c.ThresholdRows < 0 {
+		return fmt.Errorf("online_ddl threshold_rows must not be negative, got %d", c.ThresholdRows)
+	}
+	if c.ThresholdRows > 0 && c.Tool == "" {
+		return fmt.Errorf("online_ddl threshold_rows is set but no tool is configured")
+	}
+	return nil
+}
+
+// LoadConfig reads the online_ddl section of a ptah.yaml file. A missing file
+// at the conventional location is not an error — it yields a zero Config
+// (automatic routing disabled); an unreadable, malformed or invalid file is.
+func LoadConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return &Config{}, nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to read ptah config %s: %w", path, err)
+	}
+
+	var cfg ptahConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse ptah config %s: %w", path, err)
+	}
+	if err := cfg.OnlineDDL.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid online_ddl config in %s: %w", path, err)
+	}
+	return &cfg.OnlineDDL, nil
+}

--- a/migration/onlineddl/config_test.go
+++ b/migration/onlineddl/config_test.go
@@ -1,0 +1,66 @@
+package onlineddl_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/onlineddl"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ptah.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadConfig(t *testing.T) {
+	c := qt.New(t)
+
+	path := writeConfig(t, "online_ddl:\n  tool: ghost\n  threshold_rows: 1000000\n  args:\n    - --allow-on-master\n    - --max-load=Threads_running=25\n")
+	cfg, err := onlineddl.LoadConfig(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
+	c.Assert(cfg.ThresholdRows, qt.Equals, int64(1000000))
+	c.Assert(cfg.Args, qt.DeepEquals, []string{"--allow-on-master", "--max-load=Threads_running=25"})
+	c.Assert(cfg.Enabled(), qt.IsTrue)
+}
+
+func TestLoadConfig_MissingFileYieldsDisabledConfig(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := onlineddl.LoadConfig(filepath.Join(t.TempDir(), "nope.yaml"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, "")
+	c.Assert(cfg.Enabled(), qt.IsFalse)
+}
+
+func TestLoadConfig_Invalid(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := onlineddl.LoadConfig(writeConfig(t, "online_ddl: [broken"))
+	c.Assert(err, qt.ErrorMatches, "failed to parse ptah config .*")
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  tool: liquibase\n"))
+	c.Assert(err, qt.ErrorMatches, `invalid online_ddl config .*unknown online_ddl tool "liquibase".*`)
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  tool: ghost\n  threshold_rows: -5\n"))
+	c.Assert(err, qt.ErrorMatches, ".*threshold_rows must not be negative.*")
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  threshold_rows: 100\n"))
+	c.Assert(err, qt.ErrorMatches, ".*threshold_rows is set but no tool is configured.*")
+}
+
+func TestConfig_Enabled(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(onlineddl.Config{}.Enabled(), qt.IsFalse)
+	c.Assert(onlineddl.Config{Tool: onlineddl.ToolGhost}.Enabled(), qt.IsFalse,
+		qt.Commentf("a tool without a threshold cannot auto-route"))
+	c.Assert(onlineddl.Config{Tool: onlineddl.ToolGhost, ThresholdRows: 1}.Enabled(), qt.IsTrue)
+}

--- a/migration/onlineddl/dsn.go
+++ b/migration/onlineddl/dsn.go
@@ -1,0 +1,109 @@
+package onlineddl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// DSN carries the connection endpoints an external online-DDL tool needs.
+type DSN struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	Database string
+}
+
+// ParseDatabaseURL extracts tool connection endpoints from the database URLs
+// ptah accepts for the MySQL family:
+//
+//	mysql://user:pass@host:port/dbname
+//	mysql://user:pass@tcp(host:port)/dbname
+//
+// (and the mariadb:// spellings of both). It mirrors how
+// dbschema.ConnectToDatabase treats each form so the tool receives the same
+// credentials ptah connects with: the go-sql-driver @tcp(...) form is passed
+// to the driver verbatim, so its user/password are NOT percent-decoded, while
+// the plain URL form is decoded by net/url. Host defaults to 127.0.0.1 and
+// port to 3306 when absent; a missing database name is an error because both
+// gh-ost and pt-online-schema-change require one.
+func ParseDatabaseURL(dbURL string) (DSN, error) {
+	var dsn DSN
+	if strings.Contains(dbURL, "@tcp(") {
+		dsn = parseTCPForm(dbURL)
+	} else {
+		var err error
+		if dsn, err = parseURLForm(dbURL); err != nil {
+			return DSN{}, err
+		}
+	}
+
+	if dsn.Host == "" {
+		dsn.Host = "127.0.0.1"
+	}
+	if dsn.Port == "" {
+		dsn.Port = "3306"
+	}
+	if dsn.Database == "" {
+		// The raw URL is deliberately not echoed: it may carry credentials.
+		return DSN{}, fmt.Errorf("database URL carries no database name; online-DDL tools require one")
+	}
+	return dsn, nil
+}
+
+// parseURLForm parses the plain mysql://user:pass@host:port/db form, which
+// net/url percent-decodes exactly as dbschema.convertMySQLURL does.
+func parseURLForm(dbURL string) (DSN, error) {
+	parsed, err := url.Parse(dbURL)
+	if err != nil {
+		return DSN{}, fmt.Errorf("failed to parse database URL: %w", err)
+	}
+	dsn := DSN{
+		Host:     parsed.Hostname(),
+		Port:     parsed.Port(),
+		Database: strings.TrimPrefix(parsed.Path, "/"),
+	}
+	if parsed.User != nil {
+		dsn.User = parsed.User.Username()
+		dsn.Password, _ = parsed.User.Password()
+	}
+	return dsn, nil
+}
+
+// parseTCPForm parses mysql://user:pass@tcp(host:port)/db without
+// percent-decoding, matching what ptah hands go-sql-driver for this form.
+func parseTCPForm(dbURL string) DSN {
+	body := dbURL
+	for _, scheme := range []string{"mysql://", "mariadb://"} {
+		if after, ok := strings.CutPrefix(body, scheme); ok {
+			body = after
+			break
+		}
+	}
+
+	var dsn DSN
+	if creds, rest, ok := strings.Cut(body, "@tcp("); ok {
+		if user, pass, hasPass := strings.Cut(creds, ":"); hasPass {
+			dsn.User, dsn.Password = user, pass
+		} else {
+			dsn.User = creds
+		}
+		body = rest
+	}
+
+	hostPort, rest, _ := strings.Cut(body, ")")
+	if host, port, ok := strings.Cut(hostPort, ":"); ok {
+		dsn.Host, dsn.Port = host, port
+	} else {
+		dsn.Host = hostPort
+	}
+
+	rest = strings.TrimPrefix(rest, "/")
+	if db, _, ok := strings.Cut(rest, "?"); ok {
+		dsn.Database = db
+	} else {
+		dsn.Database = rest
+	}
+	return dsn
+}

--- a/migration/onlineddl/dsn_test.go
+++ b/migration/onlineddl/dsn_test.go
@@ -1,0 +1,80 @@
+package onlineddl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/onlineddl"
+)
+
+func TestParseDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		want    onlineddl.DSN
+		wantErr string
+	}{
+		//nolint:gosec // fixture URL with a made-up password, not a credential
+		{
+			name: "plain mysql url",
+			url:  "mysql://app:secret@db.internal:3307/shop",
+			want: onlineddl.DSN{Host: "db.internal", Port: "3307", User: "app", Password: "secret", Database: "shop"},
+		},
+		{
+			name: "tcp form",
+			url:  "mysql://app:secret@tcp(127.0.0.1:3310)/shop",
+			want: onlineddl.DSN{Host: "127.0.0.1", Port: "3310", User: "app", Password: "secret", Database: "shop"},
+		},
+		{
+			// The @tcp() form is handed to go-sql-driver verbatim, which does
+			// not percent-decode, so ptah connects with the literal value —
+			// the tool must receive the same literal, not a decoded one.
+			name: "tcp form is not percent-decoded",
+			url:  "mysql://app:p%40ss@tcp(db:3306)/shop",
+			want: onlineddl.DSN{Host: "db", Port: "3306", User: "app", Password: "p%40ss", Database: "shop"},
+		},
+		{
+			name: "tcp form with query params",
+			url:  "mariadb://root:pw@tcp(127.0.0.1:3307)/inventory?parseTime=true",
+			want: onlineddl.DSN{Host: "127.0.0.1", Port: "3307", User: "root", Password: "pw", Database: "inventory"},
+		},
+		{
+			name: "mariadb scheme with defaults",
+			url:  "mariadb://root@localhost/inventory",
+			want: onlineddl.DSN{Host: "localhost", Port: "3306", User: "root", Database: "inventory"},
+		},
+		//nolint:gosec // fixture URL with a made-up password, not a credential
+		{
+			name: "url-encoded password",
+			url:  "mysql://app:p%40ss%2Fword@db:3306/shop",
+			want: onlineddl.DSN{Host: "db", Port: "3306", User: "app", Password: "p@ss/word", Database: "shop"},
+		},
+		//nolint:gosec // fixture URL with a made-up password, not a credential
+		{
+			name:    "missing database name",
+			url:     "mysql://app:secret@db:3306/",
+			wantErr: ".*no database name.*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dsn, err := onlineddl.ParseDatabaseURL(tt.url)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(dsn, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestParseDatabaseURL_ErrorNeverEchoesCredentials(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := onlineddl.ParseDatabaseURL("mysql://app:supersecret@db:3306/")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "supersecret")
+}

--- a/migration/onlineddl/executor.go
+++ b/migration/onlineddl/executor.go
@@ -131,8 +131,10 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 
 	binary := binaryFor(tool)
 	if _, err := e.lookPath(binary); err != nil {
-		e.logger.Warn("online-DDL tool not found on PATH; falling back to a plain ALTER TABLE",
-			"tool", tool, "binary", binary, "table", target.Table)
+		// Not just ErrNotFound: a non-executable binary or a permission
+		// error also lands here, so surface the underlying cause.
+		e.logger.Warn("online-DDL tool unavailable on PATH; falling back to a plain ALTER TABLE",
+			"tool", tool, "binary", binary, "table", target.Table, "error", err)
 		return false, nil
 	}
 

--- a/migration/onlineddl/executor.go
+++ b/migration/onlineddl/executor.go
@@ -1,0 +1,274 @@
+package onlineddl
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/dbschema/types"
+)
+
+// DirectiveTool is the per-migration directive key selecting the online-DDL
+// tool, written as `-- +ptah online_ddl_tool=ghost` in a migration file.
+const DirectiveTool = "online_ddl_tool"
+
+// DirectiveNone is the DirectiveTool value that opts a migration out of
+// automatic threshold routing.
+const DirectiveNone = "none"
+
+// Tool binary names on PATH.
+const (
+	ghostBinary = "gh-ost"
+	ptoscBinary = "pt-online-schema-change"
+)
+
+// Conn is the slice of dbschema.DatabaseConnection the executor consumes,
+// narrow so tests can fake it.
+type Conn interface {
+	Info() types.DBInfo
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// CommandRunner executes an external tool invocation.
+type CommandRunner func(ctx context.Context, binary string, args []string) error
+
+// Executor routes ALTER TABLE migration statements through an online-DDL
+// tool. It implements migrator.StatementInterceptor.
+type Executor struct {
+	cfg    Config
+	dryRun bool
+	logger *slog.Logger
+
+	// Swappable seams for tests.
+	run      CommandRunner
+	lookPath func(file string) (string, error)
+	rowCount func(ctx context.Context, conn Conn, schema, table string) (int64, error)
+}
+
+// New creates an executor for the given configuration. A zero Config is
+// valid: automatic routing stays off, per-migration directives keep working.
+func New(cfg Config) *Executor {
+	return &Executor{
+		cfg:      cfg,
+		logger:   slog.Default(),
+		run:      runCommand,
+		lookPath: exec.LookPath,
+		rowCount: tableRows,
+	}
+}
+
+// WithLogger returns a copy of the executor using the given logger.
+func (e *Executor) WithLogger(logger *slog.Logger) *Executor {
+	tmp := *e
+	tmp.logger = logger
+	return &tmp
+}
+
+// WithDryRun returns a copy of the executor that logs the tool invocation it
+// would perform instead of running it (the statement still counts as
+// handled, mirroring the writer's dry-run treatment of plain statements).
+func (e *Executor) WithDryRun(dryRun bool) *Executor {
+	tmp := *e
+	tmp.dryRun = dryRun
+	return &tmp
+}
+
+// ValidateDirectives implements migrator.StatementInterceptor: it rejects an
+// unknown online_ddl_tool directive value before any statement runs, so a
+// typo fails the migration cleanly instead of aborting midway (after earlier,
+// implicitly committed DDL) when the first ALTER is reached.
+func (e *Executor) ValidateDirectives(directives map[string]string) error {
+	tool, ok := directives[DirectiveTool]
+	if !ok {
+		return nil
+	}
+	switch tool {
+	case ToolGhost, ToolPTOSC, DirectiveNone:
+		return nil
+	default:
+		return fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
+			DirectiveTool, tool, ToolGhost, ToolPTOSC, DirectiveNone)
+	}
+}
+
+// ExecuteStatement implements migrator.StatementInterceptor: it returns
+// handled=true when the statement was routed through (or, in dry-run mode,
+// attributed to) an online-DDL tool, and handled=false when the migrator
+// should execute the statement itself — including every fallback path.
+func (e *Executor) ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (bool, error) {
+	return e.executeStatement(ctx, conn, stmt, directives)
+}
+
+func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string, directives map[string]string) (bool, error) {
+	directiveTool, hasDirective := directives[DirectiveTool]
+	if hasDirective && directiveTool == DirectiveNone {
+		return false, nil
+	}
+
+	info := conn.Info()
+	if info.Dialect != "mysql" && info.Dialect != "mariadb" {
+		if hasDirective {
+			e.logger.Warn("online_ddl_tool directive ignored: online-DDL tools support only the MySQL family",
+				"dialect", info.Dialect)
+		}
+		return false, nil
+	}
+
+	target, ok := ParseAlterTable(stmt)
+	if !ok {
+		return false, nil
+	}
+
+	tool, err := e.pickTool(ctx, conn, target, directives)
+	if err != nil || tool == "" {
+		return false, err
+	}
+
+	binary := binaryFor(tool)
+	if _, err := e.lookPath(binary); err != nil {
+		e.logger.Warn("online-DDL tool not found on PATH; falling back to a plain ALTER TABLE",
+			"tool", tool, "binary", binary, "table", target.Table)
+		return false, nil
+	}
+
+	dsn, err := ParseDatabaseURL(info.URL)
+	if err != nil {
+		return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
+	}
+	if target.Schema != "" {
+		dsn.Database = target.Schema
+	}
+
+	args, err := buildArgs(tool, dsn, target, e.cfg.Args)
+	if err != nil {
+		return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
+	}
+	if e.dryRun {
+		e.logger.Info("DRY RUN: would run online-DDL tool",
+			"tool", binary, "table", target.Table, "alter", target.Clause)
+		return true, nil
+	}
+
+	e.logger.Info("Running online-DDL tool", "tool", binary, "table", target.Table, "alter", target.Clause)
+	if err := e.run(ctx, binary, args); err != nil {
+		return false, fmt.Errorf("online-DDL tool %s failed for table %s: %w", binary, target.Table, err)
+	}
+	e.logger.Info("Online-DDL tool finished", "tool", binary, "table", target.Table)
+	return true, nil
+}
+
+// pickTool decides which tool (if any) handles the statement: an explicit
+// directive wins; otherwise the configured tool applies when the table's
+// estimated row count reaches the threshold. Empty means "not routed".
+func (e *Executor) pickTool(ctx context.Context, conn Conn, target AlterTarget, directives map[string]string) (string, error) {
+	if directiveTool, ok := directives[DirectiveTool]; ok {
+		if directiveTool != ToolGhost && directiveTool != ToolPTOSC {
+			return "", fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
+				DirectiveTool, directiveTool, ToolGhost, ToolPTOSC, DirectiveNone)
+		}
+		return directiveTool, nil
+	}
+
+	if !e.cfg.Enabled() {
+		return "", nil
+	}
+	rows, err := e.rowCount(ctx, conn, target.Schema, target.Table)
+	if err != nil {
+		// Fail open: the plain ALTER is the pre-feature behavior, and a
+		// broken estimate must not block a migration.
+		e.logger.Warn("online-DDL row-count check failed; executing a plain ALTER TABLE",
+			"table", target.Table, "error", err)
+		return "", nil
+	}
+	if rows < e.cfg.ThresholdRows {
+		return "", nil
+	}
+	e.logger.Info("Routing ALTER TABLE through the online-DDL tool: table exceeds the row threshold",
+		"table", target.Table, "rows", rows, "threshold", e.cfg.ThresholdRows, "tool", e.cfg.Tool)
+	return e.cfg.Tool, nil
+}
+
+// binaryFor maps a canonical tool name to its binary on PATH.
+func binaryFor(tool string) string {
+	if tool == ToolPTOSC {
+		return ptoscBinary
+	}
+	return ghostBinary
+}
+
+// buildArgs assembles the tool invocation. User-configured args go before
+// the final --execute so they can never be overridden by it.
+func buildArgs(tool string, dsn DSN, target AlterTarget, extra []string) ([]string, error) {
+	switch tool {
+	case ToolPTOSC:
+		return buildPTOSCArgs(dsn, target, extra)
+	default: // ToolGhost
+		// gh-ost takes each endpoint as its own --flag=value argv element, so
+		// values are passed literally with no delimiter to escape.
+		args := []string{
+			"--host=" + dsn.Host,
+			"--port=" + dsn.Port,
+			"--user=" + dsn.User,
+			"--database=" + dsn.Database,
+			"--table=" + target.Table,
+			"--alter=" + target.Clause,
+		}
+		if dsn.Password != "" {
+			args = append(args, "--password="+dsn.Password)
+		}
+		args = append(args, extra...)
+		return append(args, "--execute"), nil
+	}
+}
+
+// buildPTOSCArgs assembles the pt-online-schema-change invocation. Its DSN is
+// a single comma-delimited argv element (h=,P=,u=,D=,t=[,p=]) that Percona's
+// DSN parser splits on literal commas with no un-escaping, so a comma in any
+// endpoint would silently smuggle extra DSN keys (host redirect, F= defaults
+// file). Rather than emit a corrupt or injectable DSN, refuse to build it.
+func buildPTOSCArgs(dsn DSN, target AlterTarget, extra []string) ([]string, error) {
+	fields := map[string]string{
+		"host": dsn.Host, "port": dsn.Port, "user": dsn.User,
+		"database": dsn.Database, "table": target.Table, "password": dsn.Password,
+	}
+	for name, value := range fields {
+		if strings.Contains(value, ",") {
+			return nil, fmt.Errorf("pt-online-schema-change cannot receive a %s containing a comma (%q); "+
+				"pass it via online_ddl.args (for example a --defaults-file) instead", name, value)
+		}
+	}
+
+	spec := fmt.Sprintf("h=%s,P=%s,u=%s,D=%s,t=%s", dsn.Host, dsn.Port, dsn.User, dsn.Database, target.Table)
+	if dsn.Password != "" {
+		spec += ",p=" + dsn.Password
+	}
+	args := []string{"--alter", target.Clause}
+	args = append(args, extra...)
+	return append(args, "--execute", spec), nil
+}
+
+// runCommand is the production CommandRunner: it streams the tool's output
+// to the migrator's stdout/stderr so progress is visible.
+func runCommand(ctx context.Context, binary string, args []string) error {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// tableRows estimates a table's row count from information_schema. The
+// estimate is approximate on InnoDB, which is fine for a routing threshold.
+func tableRows(ctx context.Context, conn Conn, schema, table string) (int64, error) {
+	const query = "SELECT COALESCE(TABLE_ROWS, 0) FROM information_schema.TABLES " +
+		"WHERE TABLE_SCHEMA = COALESCE(NULLIF(?, ''), DATABASE()) AND TABLE_NAME = ?"
+	var rows int64
+	if err := conn.QueryRowContext(ctx, query, schema, table).Scan(&rows); err != nil {
+		return 0, err
+	}
+	return rows, nil
+}

--- a/migration/onlineddl/executor_test.go
+++ b/migration/onlineddl/executor_test.go
@@ -191,7 +191,8 @@ func TestExecuteStatement_FallbackPathsWarn(t *testing.T) {
 		"ALTER TABLE users ADD COLUMN a INT", map[string]string{DirectiveTool: ToolGhost})
 	c.Assert(err, qt.IsNil)
 	c.Assert(handled, qt.IsFalse)
-	c.Assert(buf.String(), qt.Contains, "not found on PATH")
+	c.Assert(buf.String(), qt.Contains, "unavailable on PATH")
+	c.Assert(buf.String(), qt.Contains, "not found", qt.Commentf("the underlying lookPath error is surfaced"))
 
 	// Row-count estimate failure warns then falls through.
 	buf.Reset()
@@ -394,7 +395,8 @@ func TestExecuteStatement_RunsRealFakeBinary(t *testing.T) {
 
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "args.txt")
-	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %s\n", argsFile)
+	// Quote the redirection target: t.TempDir() paths can contain spaces.
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > \"%s\"\n", argsFile)
 	binPath := filepath.Join(dir, "gh-ost")
 	c.Assert(os.WriteFile(binPath, []byte(script), 0o600), qt.IsNil)
 	c.Assert(os.Chmod(binPath, 0o700), qt.IsNil)

--- a/migration/onlineddl/executor_test.go
+++ b/migration/onlineddl/executor_test.go
@@ -1,0 +1,415 @@
+package onlineddl
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema/types"
+)
+
+// fakeConn satisfies Conn without a database. QueryRowContext must never be
+// reached: tests stub the executor's rowCount seam instead.
+type fakeConn struct {
+	info types.DBInfo
+}
+
+func (f fakeConn) Info() types.DBInfo { return f.info }
+
+func (f fakeConn) QueryRowContext(_ context.Context, _ string, _ ...any) *sql.Row {
+	panic("QueryRowContext must not be called in unit tests")
+}
+
+func mysqlConn() fakeConn {
+	//nolint:gosec // fixture URL with a made-up password, not a credential
+	return fakeConn{info: types.DBInfo{Dialect: "mysql", URL: "mysql://app:secret@db.internal:3307/shop"}}
+}
+
+// testExecutor returns an executor with recording seams: *ran captures the
+// invocation, lookPathErr simulates a missing binary, rows/rowsErr stub the
+// row-count estimate.
+type invocation struct {
+	binary string
+	args   []string
+}
+
+func testExecutor(cfg Config, ran *[]invocation, lookPathErr error, rows int64, rowsErr error) *Executor {
+	e := New(cfg)
+	e.run = func(_ context.Context, binary string, args []string) error {
+		*ran = append(*ran, invocation{binary: binary, args: args})
+		return nil
+	}
+	e.lookPath = func(file string) (string, error) {
+		if lookPathErr != nil {
+			return "", lookPathErr
+		}
+		return "/usr/local/bin/" + file, nil
+	}
+	e.rowCount = func(_ context.Context, _ Conn, _, _ string) (int64, error) {
+		return rows, rowsErr
+	}
+	return e
+}
+
+func TestExecuteStatement_DirectiveRoutesThroughGhost(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+	c.Assert(ran[0].binary, qt.Equals, "gh-ost")
+	c.Assert(ran[0].args, qt.DeepEquals, []string{
+		"--host=db.internal",
+		"--port=3307",
+		"--user=app",
+		"--database=shop",
+		"--table=users",
+		"--alter=ADD COLUMN bio TEXT",
+		"--password=secret",
+		"--execute",
+	})
+}
+
+func TestExecuteStatement_GhostAppendsConfigArgsBeforeExecute(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{Args: []string{"--allow-on-master", "--max-load=Threads_running=25"}}, &ran, nil, 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran[0].args, qt.DeepEquals, []string{
+		"--host=db.internal",
+		"--port=3307",
+		"--user=app",
+		"--database=shop",
+		"--table=users",
+		"--alter=ADD COLUMN bio TEXT",
+		"--password=secret",
+		"--allow-on-master",
+		"--max-load=Threads_running=25",
+		"--execute",
+	})
+}
+
+func TestExecuteStatement_DirectiveWinsOverThreshold(t *testing.T) {
+	c := qt.New(t)
+
+	// Config would route through pt-osc on a huge table, but the migration's
+	// explicit ghost directive must win, and the row count must not even be
+	// consulted.
+	var ran []invocation
+	e := testExecutor(Config{Tool: ToolPTOSC, ThresholdRows: 10}, &ran, nil, 0, nil)
+	e.rowCount = func(context.Context, Conn, string, string) (int64, error) {
+		c.Fatal("row count must not be consulted when a directive is present")
+		return 0, nil
+	}
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+	c.Assert(ran[0].binary, qt.Equals, "gh-ost")
+}
+
+func TestExecuteStatement_PTOSCRejectsCommaInIdentifier(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+
+	// A backtick-quoted table name with a comma would smuggle extra DSN keys
+	// into pt-osc's comma-delimited --execute spec; refuse instead.
+	_, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE `evil,u=attacker,F=/tmp/x.cnf` ADD COLUMN a INT",
+		map[string]string{DirectiveTool: ToolPTOSC})
+
+	c.Assert(err, qt.ErrorMatches, ".*cannot receive a table containing a comma.*")
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_PTOSCRejectsCommaInPassword(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+	conn := fakeConn{info: types.DBInfo{Dialect: "mysql", URL: "mysql://app:se,cret@db:3306/shop"}}
+
+	_, err := e.executeStatement(context.Background(), conn,
+		"ALTER TABLE users ADD COLUMN a INT",
+		map[string]string{DirectiveTool: ToolPTOSC})
+
+	c.Assert(err, qt.ErrorMatches, ".*cannot receive a password containing a comma.*")
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestValidateDirectives(t *testing.T) {
+	c := qt.New(t)
+
+	e := New(Config{})
+	c.Assert(e.ValidateDirectives(nil), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: ToolGhost}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: ToolPTOSC}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: DirectiveNone}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{"unrelated": "x"}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: "goste"}),
+		qt.ErrorMatches, `unknown online_ddl_tool directive value "goste".*`)
+}
+
+func TestExecuteStatement_FallbackPathsWarn(t *testing.T) {
+	c := qt.New(t)
+
+	// Missing binary warns then falls through.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, errors.New("not found"), 0, nil).WithLogger(logger)
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN a INT", map[string]string{DirectiveTool: ToolGhost})
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+	c.Assert(buf.String(), qt.Contains, "not found on PATH")
+
+	// Row-count estimate failure warns then falls through.
+	buf.Reset()
+	e = testExecutor(Config{Tool: ToolGhost, ThresholdRows: 1}, &ran, nil, 0, errors.New("boom")).WithLogger(logger)
+	handled, err = e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN a INT", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+	c.Assert(buf.String(), qt.Contains, "row-count check failed")
+}
+
+func TestExecuteStatement_DirectiveRoutesThroughPTOSC(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{Args: []string{"--max-lag=5"}}, &ran, nil, 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users MODIFY COLUMN bio VARCHAR(500)",
+		map[string]string{DirectiveTool: ToolPTOSC})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+	c.Assert(ran[0].binary, qt.Equals, "pt-online-schema-change")
+	c.Assert(ran[0].args, qt.DeepEquals, []string{
+		"--alter", "MODIFY COLUMN bio VARCHAR(500)",
+		"--max-lag=5",
+		"--execute", "h=db.internal,P=3307,u=app,D=shop,t=users,p=secret",
+	})
+}
+
+func TestExecuteStatement_DirectiveNoneOptsOutOfAutoRouting(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{Tool: ToolGhost, ThresholdRows: 10}, &ran, nil, 1_000_000, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: DirectiveNone})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_UnknownDirectiveValueIsAnError(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+
+	_, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: "goose"})
+
+	c.Assert(err, qt.ErrorMatches, `unknown online_ddl_tool directive value "goose".*`)
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_ThresholdAutoRouting(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := Config{Tool: ToolGhost, ThresholdRows: 1000}
+
+	// At/above the threshold: routed.
+	var ran []invocation
+	e := testExecutor(cfg, &ran, nil, 1000, nil)
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+
+	// Below the threshold: plain ALTER.
+	ran = nil
+	e = testExecutor(cfg, &ran, nil, 999, nil)
+	handled, err = e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+	c.Assert(ran, qt.HasLen, 0)
+
+	// Row-count estimate broken: fail open to the plain ALTER.
+	ran = nil
+	e = testExecutor(cfg, &ran, nil, 0, errors.New("information_schema unavailable"))
+	handled, err = e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_NonAlterAndNonMySQLPassThrough(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{Tool: ToolGhost, ThresholdRows: 1}, &ran, nil, 1_000_000, nil)
+
+	// Non-ALTER statements never route.
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"CREATE TABLE t (id INT)", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+
+	// Non-MySQL dialects never route, even with an explicit directive.
+	pg := fakeConn{info: types.DBInfo{Dialect: "postgres", URL: "postgres://app@db/shop"}}
+	handled, err = e.executeStatement(context.Background(), pg,
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse)
+
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_MissingBinaryFallsBackToPlainAlter(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, errors.New("executable file not found in $PATH"), 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsFalse, qt.Commentf("the migrator must execute the plain ALTER instead"))
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_SchemaQualifiedTableOverridesDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE analytics.events ADD COLUMN a INT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran[0].args, qt.Contains, "--database=analytics")
+	c.Assert(ran[0].args, qt.Contains, "--table=events")
+}
+
+func TestExecuteStatement_ToolFailureAbortsMigration(t *testing.T) {
+	c := qt.New(t)
+
+	e := New(Config{})
+	e.lookPath = func(string) (string, error) { return "/bin/gh-ost", nil }
+	e.run = func(context.Context, string, []string) error { return errors.New("exit status 1") }
+
+	_, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.ErrorMatches, "online-DDL tool gh-ost failed for table users: exit status 1")
+}
+
+func TestExecuteStatement_DryRunHandlesWithoutRunning(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil).WithDryRun(true)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue, qt.Commentf("dry-run must not fall through to the writer either"))
+	c.Assert(ran, qt.HasLen, 0)
+}
+
+func TestExecuteStatement_EmptyPasswordOmitsPasswordArg(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{}, &ran, nil, 0, nil)
+	conn := fakeConn{info: types.DBInfo{Dialect: "mariadb", URL: "mariadb://root@localhost:3306/shop"}}
+
+	handled, err := e.executeStatement(context.Background(), conn,
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	for _, arg := range ran[0].args {
+		c.Assert(strings.HasPrefix(arg, "--password"), qt.IsFalse)
+	}
+}
+
+// TestExecuteStatement_RunsRealFakeBinary exercises the production LookPath
+// and CommandRunner against a fake gh-ost on PATH that records its argv.
+func TestExecuteStatement_RunsRealFakeBinary(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %s\n", argsFile)
+	binPath := filepath.Join(dir, "gh-ost")
+	c.Assert(os.WriteFile(binPath, []byte(script), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(binPath, 0o700), qt.IsNil)
+	t.Setenv("PATH", dir)
+
+	e := New(Config{})
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+
+	recorded, err := os.ReadFile(argsFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(recorded), qt.Equals,
+		"--host=db.internal\n--port=3307\n--user=app\n--database=shop\n--table=users\n--alter=ADD COLUMN bio TEXT\n--password=secret\n--execute\n")
+}

--- a/migration/onlineddl/statement.go
+++ b/migration/onlineddl/statement.go
@@ -1,0 +1,122 @@
+package onlineddl
+
+import (
+	"strings"
+)
+
+// AlterTarget is the parsed target of an ALTER TABLE statement.
+type AlterTarget struct {
+	// Schema is the explicit schema qualifier, empty when the table
+	// reference is unqualified.
+	Schema string
+	// Table is the bare table name, quoting stripped.
+	Table string
+	// Clause is everything after the table reference — the value passed to
+	// the tool's --alter flag.
+	Clause string
+}
+
+// ParseAlterTable splits an ALTER TABLE statement (comments already
+// stripped) into its target table and alter clause. ok is false for any
+// other statement, and for a bare ALTER TABLE with no clause. The optional
+// MariaDB IF EXISTS modifier and backtick-quoted or schema-qualified table
+// references are handled.
+func ParseAlterTable(stmt string) (AlterTarget, bool) {
+	rest, ok := eatKeyword(strings.TrimSpace(stmt), "ALTER")
+	if !ok {
+		return AlterTarget{}, false
+	}
+	// MariaDB accepts ALTER [ONLINE] [IGNORE] TABLE ...; skip those modifiers.
+	if after, ok := eatKeyword(rest, "ONLINE"); ok {
+		rest = after
+	}
+	if after, ok := eatKeyword(rest, "IGNORE"); ok {
+		rest = after
+	}
+	rest, ok = eatKeyword(rest, "TABLE")
+	if !ok {
+		return AlterTarget{}, false
+	}
+	if afterIf, ok := eatKeyword(rest, "IF"); ok {
+		if afterExists, ok := eatKeyword(afterIf, "EXISTS"); ok {
+			rest = afterExists
+		}
+	}
+
+	name, rest, ok := eatIdentifier(rest)
+	if !ok {
+		return AlterTarget{}, false
+	}
+	target := AlterTarget{Table: name}
+
+	rest = strings.TrimLeft(rest, " \t\r\n")
+	if strings.HasPrefix(rest, ".") {
+		second, afterSecond, ok := eatIdentifier(strings.TrimLeft(rest[1:], " \t\r\n"))
+		if !ok {
+			return AlterTarget{}, false
+		}
+		target.Schema, target.Table = name, second
+		rest = afterSecond
+	}
+
+	target.Clause = strings.TrimSpace(rest)
+	if target.Clause == "" {
+		return AlterTarget{}, false
+	}
+	return target, true
+}
+
+// eatKeyword consumes a case-insensitive keyword followed by whitespace and
+// returns the remainder with leading whitespace trimmed.
+func eatKeyword(s, keyword string) (string, bool) {
+	if len(s) <= len(keyword) || !strings.EqualFold(s[:len(keyword)], keyword) {
+		return s, false
+	}
+	rest := s[len(keyword):]
+	if !isSpaceByte(rest[0]) {
+		return s, false
+	}
+	return strings.TrimLeft(rest, " \t\r\n"), true
+}
+
+// eatIdentifier consumes one identifier, backtick-quoted (doubled backticks
+// stay inside, quotes stripped) or bare, and returns it plus the remainder.
+func eatIdentifier(s string) (name, rest string, ok bool) {
+	if s == "" {
+		return "", s, false
+	}
+	if s[0] == '`' {
+		var b strings.Builder
+		i := 1
+		for i < len(s) {
+			if s[i] != '`' {
+				b.WriteByte(s[i])
+				i++
+				continue
+			}
+			if i+1 < len(s) && s[i+1] == '`' {
+				b.WriteByte('`')
+				i += 2
+				continue
+			}
+			if b.Len() == 0 {
+				return "", s, false // empty identifier ``
+			}
+			return b.String(), s[i+1:], true
+		}
+		return "", s, false // unterminated quote
+	}
+
+	i := 0
+	for i < len(s) && !isSpaceByte(s[i]) && s[i] != '.' && s[i] != '(' && s[i] != ',' && s[i] != ';' {
+		i++
+	}
+	if i == 0 {
+		return "", s, false
+	}
+	return s[:i], s[i:], true
+}
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}

--- a/migration/onlineddl/statement_test.go
+++ b/migration/onlineddl/statement_test.go
@@ -1,0 +1,82 @@
+package onlineddl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/onlineddl"
+)
+
+func TestParseAlterTable(t *testing.T) {
+	tests := []struct {
+		name string
+		stmt string
+		want onlineddl.AlterTarget
+		ok   bool
+	}{
+		{
+			name: "plain alter",
+			stmt: "ALTER TABLE users ADD COLUMN bio TEXT",
+			want: onlineddl.AlterTarget{Table: "users", Clause: "ADD COLUMN bio TEXT"},
+			ok:   true,
+		},
+		{
+			name: "lowercase keywords and multiline clause",
+			stmt: "alter table users\n  modify column bio VARCHAR(500)\n  NOT NULL",
+			want: onlineddl.AlterTarget{Table: "users", Clause: "modify column bio VARCHAR(500)\n  NOT NULL"},
+			ok:   true,
+		},
+		{
+			name: "backtick-quoted table",
+			stmt: "ALTER TABLE `order``s` ADD INDEX idx (a)",
+			want: onlineddl.AlterTarget{Table: "order`s", Clause: "ADD INDEX idx (a)"},
+			ok:   true,
+		},
+		{
+			name: "schema-qualified reference",
+			stmt: "ALTER TABLE shop.users DROP COLUMN legacy",
+			want: onlineddl.AlterTarget{Schema: "shop", Table: "users", Clause: "DROP COLUMN legacy"},
+			ok:   true,
+		},
+		{
+			name: "quoted schema-qualified reference with spaces",
+			stmt: "ALTER TABLE `shop` . `users` ADD COLUMN a INT",
+			want: onlineddl.AlterTarget{Schema: "shop", Table: "users", Clause: "ADD COLUMN a INT"},
+			ok:   true,
+		},
+		{
+			name: "mariadb if exists",
+			stmt: "ALTER TABLE IF EXISTS users ADD COLUMN a INT",
+			want: onlineddl.AlterTarget{Table: "users", Clause: "ADD COLUMN a INT"},
+			ok:   true,
+		},
+		{
+			name: "mariadb alter online table",
+			stmt: "ALTER ONLINE TABLE users ADD COLUMN a INT",
+			want: onlineddl.AlterTarget{Table: "users", Clause: "ADD COLUMN a INT"},
+			ok:   true,
+		},
+		{
+			name: "mariadb alter ignore table",
+			stmt: "ALTER IGNORE TABLE users DROP COLUMN legacy",
+			want: onlineddl.AlterTarget{Table: "users", Clause: "DROP COLUMN legacy"},
+			ok:   true,
+		},
+		{name: "not an alter", stmt: "CREATE TABLE users (id INT)", ok: false},
+		{name: "alter of a non-table object", stmt: "ALTER VIEW v AS SELECT 1", ok: false},
+		{name: "bare alter table without clause", stmt: "ALTER TABLE users", ok: false},
+		{name: "unterminated quoted identifier", stmt: "ALTER TABLE `users ADD COLUMN a INT", ok: false},
+		{name: "empty statement", stmt: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got, ok := onlineddl.ParseAlterTable(tt.stmt)
+			c.Assert(ok, qt.Equals, tt.ok, qt.Commentf("stmt: %s", tt.stmt))
+			if tt.ok {
+				c.Assert(got, qt.DeepEquals, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements #173: route lock-heavy `ALTER TABLE` migration statements through [gh-ost](https://github.com/github/gh-ost) or [pt-online-schema-change](https://docs.percona.com/percona-toolkit/pt-online-schema-change.html) so large MySQL/MariaDB tables can be altered without holding a long table lock.

```sql
-- +ptah online_ddl_tool=ghost
ALTER TABLE users ADD COLUMN bio TEXT;
```

```yaml
# ptah.yaml (--config), automatic routing above a row threshold
online_ddl:
  tool: ghost            # or pt-osc
  threshold_rows: 1000000
  args: ["--allow-on-master"]
```

## What's included (issue scope)

1. **Per-migration directive** `-- +ptah online_ddl_tool=ghost|pt-osc|none` — routes every `ALTER TABLE` in that migration through the tool. Works with no config file.
2. **Migrator shells out** to gh-ost / pt-osc with the right args (endpoints derived from the migration's own DB URL; the alter clause passed through; schema-qualified tables override the database).
3. **`ptah.yaml` config** — `online_ddl: { tool, threshold_rows, args }`. Any `ALTER TABLE` on a table whose `information_schema` row estimate is at/above `threshold_rows` routes automatically; a directive always overrides the threshold.
4. **Fallback** — tool missing on PATH or row-count estimate fails → warning + plain `ALTER TABLE`. `--dry-run` logs the invocation without running it.

Fail-**open** on the pre-feature-equivalent paths (missing binary, broken estimate); fail-**closed** on tool failure and on an unknown directive value.

## Design

- The migrator gains a generic `-- +ptah key=value` directive mechanism and a `StatementInterceptor` seam (`WithStatementInterceptor`); the online-DDL logic lives in a separate `migration/onlineddl` package and is not hard-wired into the migrator.
- `migrate-up` / `migrate-down` both gain `--config` and attach the interceptor unconditionally (zero config = directives only).

## Adversarial self-review

Reviewed by an agent fleet (4 lenses × 2 skeptics, with live MySQL access; ~36 agents). 10 confirmed findings — all fixed and covered by tests; the load-bearing ones verified end-to-end against MySQL 9.7:

- **Directive parsing is now lexer-driven** (the same lexer the statement splitter uses), so a `-- +ptah` line inside a **string literal** or block comment can no longer be mistaken for a directive — it previously silently rerouted or aborted a data-seeding migration.
- **Up-front directive validation**: a typo (`online_ddl_tool=goste`) now fails the migration before any statement runs, instead of midway after earlier DDL had implicitly committed.
- **pt-osc DSN injection closed**: the comma-delimited `--execute` DSN refuses any endpoint containing a comma, closing an argument-smuggling vector (host redirect / `F=` defaults-file via a backtick-quoted table name) and the matching correctness bug for comma-bearing passwords. (gh-ost is unaffected — it takes each endpoint as its own `--flag=value` argv element.)
- **`@tcp()` URL form is not percent-decoded**, matching the literal credentials ptah hands go-sql-driver.
- MariaDB `ALTER ONLINE/IGNORE TABLE` spellings route; config `args` land before `--execute`.

Plus test gaps closed: interceptor `handled=false`→writer dispatch, directive-wins-over-threshold precedence, gh-ost with config args, `LoadOnlineDDLConfig`, and the documented fallback warnings.

## Testing

- `migration/onlineddl`: config load/validate, DSN parsing (URL + `@tcp()`, percent-decode semantics, missing db, credential-safe errors), ALTER parsing (quoting, schema-qualified, `IF EXISTS`, `ONLINE`/`IGNORE`), executor decision matrix (directive/threshold/fallback/dry-run/injection guard) via seams **and** a real fake-binary-on-PATH test.
- `migration/migrator`: directive extraction (string-literal/comment safety), interceptor contract, up-front validation, declined-statement dispatch.
- Live end-to-end against MySQL 9.7: directive routing, missing-binary fallback, threshold auto-routing, and all three fixed defects.
- `go test ./...`, `golangci-lint run`, `go tool qtlint ./...` — clean.

## Documentation

`docs/online-ddl.md` covers prerequisites (binlog ROW, gh-ost topology / `--allow-on-master`, pt-osc triggers/FK strategy, privileges, credential visibility in argv) and invocation details; README has a short section.

Closes #173

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB