### PR TITLE
Feat(migrator): migration-directory integrity check via ptah.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Provides command-line interface for all Ptah operations:
 - **`migrate-up`** - Apply migrations to bring database up to latest version
 - **`migrate-down`** - Roll back migrations to previous versions
 - **`migrate-status`** - Show current migration status and history
+- **`migrate-hash`** - Write/update the `ptah.sum` migration-directory integrity file
+- **`migrate-validate`** - Verify a migrations directory against its committed `ptah.sum`
 - **`seed`** - Apply environment-scoped SQL seed files with replay tracking
 - **`drop-all`** - Drop ALL tables and enums in database (VERY DANGEROUS!) (supports `--dry-run`)
 - **`integration-test`** - Run comprehensive integration tests across database platforms
@@ -660,6 +662,35 @@ Show current migration status and pending migrations:
 - Total available migrations
 - List of pending migrations
 - Migration history and timestamps
+
+#### Migration Directory Integrity (`ptah.sum`)
+
+Once a migration is committed and applied somewhere, its content must never change.
+`ptah.sum` records the SHA-256 (`h1:`, base64) of every migration file plus a
+directory-level hash, so an out-of-band edit to an already-applied migration is
+caught in CI instead of silently breaking reproducibility.
+
+```bash
+# Write/update ptah.sum after adding or intentionally editing a migration
+./package-migrator migrate-hash --dir ./migrations
+
+# Verify the directory matches its committed ptah.sum (CI gate)
+./package-migrator migrate-validate --dir ./migrations
+```
+
+`migrate-validate` exits `0` when clean, `1` on drift (a file added, removed, or
+edited out of band — with a diff on stderr), and `2` when `ptah.sum` is missing or
+unreadable. `migrate-up --verify-sum` runs the same check before applying and
+aborts on drift.
+
+```yaml
+# CI (GitHub Actions)
+- name: Verify migration integrity
+  run: ./package-migrator migrate-validate --dir ./migrations
+```
+
+The file layout and `h1:` scheme mirror Atlas's `atlas.sum`; convergence on the
+exact Atlas format is tracked as part of the Atlas-compatibility research (#250).
 
 #### Migration File Generation
 Generate timestamped migration files from schema differences using the migration generator package:

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -27,6 +27,19 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 	return Fail(cmd, err)
 }
 
+// NoPositionalArgs is a cobra Args validator that rejects any positional
+// argument with a printed message and exit code 2. Unlike cobra.NoArgs, whose
+// error is swallowed under SilenceErrors and degrades to a bare exit 1, this
+// routes through Fail so the failure is visible and carries the usage exit
+// code (e.g. a stray path typed instead of --dir does not masquerade as a
+// success/drift).
+func NoPositionalArgs(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return Fail(cmd, fmt.Errorf("unexpected positional arguments %q: pass the directory via --dir", args))
+	}
+	return nil
+}
+
 // StatDir validates that dir exists and is a directory, returning an
 // actionable error (wrapping the underlying os.Stat error, and distinguishing
 // a path that exists but is a file) otherwise.

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -1,0 +1,42 @@
+// Package cmdutil holds small helpers shared by CLI subcommands: consistent
+// usage-error reporting (exit code 2 with a printed message) and directory
+// validation.
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+)
+
+// Fail prints err to the command's stderr and returns it as an exit-2 usage
+// error. Commands that set SilenceErrors must route their usage failures
+// through this so the message still reaches the user.
+func Fail(cmd *cobra.Command, err error) error {
+	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	return exitcode.New(2, err)
+}
+
+// FlagErrorFunc reports a cobra flag-parse error (unknown flag, bad value)
+// with a printed message and exit code 2, matching every other usage error.
+// Install it with cmd.SetFlagErrorFunc.
+func FlagErrorFunc(cmd *cobra.Command, err error) error {
+	return Fail(cmd, err)
+}
+
+// StatDir validates that dir exists and is a directory, returning an
+// actionable error (wrapping the underlying os.Stat error, and distinguishing
+// a path that exists but is a file) otherwise.
+func StatDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("migrations directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("migrations directory %s: not a directory", dir)
+	}
+	return nil
+}

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -4,11 +4,10 @@ package migratehash
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/migration/migratesum"
 )
 
@@ -33,27 +32,22 @@ an already-committed migration.`,
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	cmd.SetFlagErrorFunc(cmdutil.FlagErrorFunc)
 	return cmd
 }
 
 func runHash(cmd *cobra.Command, dir string) error {
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		return fail(cmd, fmt.Errorf("migrations directory %s is not accessible", dir))
+	if err := cmdutil.StatDir(dir); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 
 	sum, err := migratesum.Write(dir)
 	if err != nil {
-		return fail(cmd, err)
+		return cmdutil.Fail(cmd, err)
 	}
 
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Wrote %s/%s\n", dir, migratesum.FileName)
 	fmt.Fprintf(out, "%d migration file(s) hashed\n", len(sum.Entries))
 	return nil
-}
-
-// fail prints an error to stderr and returns it as an exit-2 error.
-func fail(cmd *cobra.Command, err error) error {
-	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
-	return exitcode.New(2, err)
 }

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -1,0 +1,59 @@
+// Package migratehash implements the `ptah migrate-hash` command: it writes
+// or updates the ptah.sum integrity file for a migrations directory (#161).
+package migratehash
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+// NewMigrateHashCommand returns the migrate-hash command.
+func NewMigrateHashCommand() *cobra.Command {
+	var dir string
+
+	cmd := &cobra.Command{
+		Use:   "migrate-hash",
+		Short: "Write or update the ptah.sum integrity file for a migrations directory",
+		Long: `migrate-hash recomputes the integrity hashes of every migration file in a
+directory and writes them to ptah.sum. Run it whenever you add, remove, or
+intentionally edit a migration file, and commit the updated ptah.sum.
+
+CI can then run 'ptah migrate-validate' to fail on any out-of-band change to
+an already-committed migration.`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runHash(cmd, dir)
+		},
+	}
+	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	return cmd
+}
+
+func runHash(cmd *cobra.Command, dir string) error {
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return fail(cmd, fmt.Errorf("migrations directory %s is not accessible", dir))
+	}
+
+	sum, err := migratesum.Write(dir)
+	if err != nil {
+		return fail(cmd, err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Wrote %s/%s\n", dir, migratesum.FileName)
+	fmt.Fprintf(out, "%d migration file(s) hashed\n", len(sum.Entries))
+	return nil
+}
+
+// fail prints an error to stderr and returns it as an exit-2 error.
+func fail(cmd *cobra.Command, err error) error {
+	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	return exitcode.New(2, err)
+}

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -24,7 +24,7 @@ intentionally edit a migration file, and commit the updated ptah.sum.
 
 CI can then run 'ptah migrate-validate' to fail on any out-of-band change to
 an already-committed migration.`,
-		Args:          cobra.NoArgs,
+		Args:          cmdutil.NoPositionalArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/migratehash/migratehash_test.go
+++ b/cmd/migratehash/migratehash_test.go
@@ -1,0 +1,76 @@
+package migratehash
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+func execute(args ...string) (stdout string, err error) {
+	cmd := NewMigrateHashCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), err
+}
+
+func TestHash_WritesSumFileForMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE t;\n"), 0o600), qt.IsNil)
+
+	stdout, err := execute("--dir", dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "2 migration file(s) hashed")
+
+	// The written sum file makes the directory validate clean.
+	raw, err := os.ReadFile(filepath.Join(dir, migratesum.FileName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(raw) > 0, qt.IsTrue)
+	res, err := migratesum.VerifyDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsTrue)
+}
+
+func TestHash_UpdatesSumFileAfterAddingAMigration(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+	_, err := execute("--dir", dir)
+	c.Assert(err, qt.IsNil)
+
+	// Add a migration; the directory now drifts from the recorded sum.
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000002_more.up.sql"),
+		[]byte("CREATE TABLE u (id INT);\n"), 0o600), qt.IsNil)
+	res, err := migratesum.VerifyDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsFalse)
+
+	// Re-hash: the sum file is updated and validation passes again.
+	_, err = execute("--dir", dir)
+	c.Assert(err, qt.IsNil)
+	res, err = migratesum.VerifyDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsTrue)
+}
+
+func TestHash_MissingDirectoryExitsTwo(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := execute("--dir", filepath.Join(t.TempDir(), "nope"))
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+}

--- a/cmd/migratehash/migratehash_test.go
+++ b/cmd/migratehash/migratehash_test.go
@@ -74,3 +74,19 @@ func TestHash_MissingDirectoryExitsTwo(t *testing.T) {
 	_, err := execute("--dir", filepath.Join(t.TempDir(), "nope"))
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 }
+
+func TestHash_PositionalArgExitsTwoWithoutWriting(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+
+	// A stray positional must fail (exit 2) with a message, not silently
+	// skip writing ptah.sum.
+	stdout, err := execute(dir, "stray")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stdout, qt.Contains, "unexpected positional arguments")
+	_, statErr := os.Stat(filepath.Join(dir, migratesum.FileName))
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue, qt.Commentf("ptah.sum must not be written on a usage error"))
+}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/onlineddl"
 )
@@ -32,6 +33,7 @@ const (
 	migrationsFlag       = "migrations-dir"
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
+	verifySumFlag        = "verify-sum"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
 )
@@ -57,6 +59,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Enable verbose output",
 	},
+	verifySumFlag: &cobraflags.BoolFlag{
+		Name:  verifySumFlag,
+		Value: false,
+		Usage: "Verify the migrations directory against its committed ptah.sum before applying; abort on drift",
+	},
 	lockTimeoutFlag: &cobraflags.StringFlag{
 		Name:  lockTimeoutFlag,
 		Value: "",
@@ -81,6 +88,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	migrationsDir := migrateUpFlags[migrationsFlag].GetString()
 	dryRun := migrateUpFlags[dryRunFlag].GetBool()
 	verbose := migrateUpFlags[verboseFlag].GetBool()
+	verifySum := migrateUpFlags[verifySumFlag].GetBool()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
 
@@ -90,6 +98,21 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
+	}
+
+	// Integrity gate: refuse to apply if a committed migration was edited
+	// out of band. Runs before connecting so a tampered directory fails fast.
+	if verifySum {
+		result, err := migratesum.VerifyDir(migrationsDir)
+		if err != nil {
+			return fmt.Errorf("ptah.sum verification failed: %w", err)
+		}
+		if !result.OK() {
+			return fmt.Errorf("ptah.sum verification failed:\n%s", result.Describe())
+		}
+		if verbose {
+			fmt.Printf("ptah.sum verified: migrations directory is intact\n")
+		}
 	}
 
 	if verbose {

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -1,0 +1,51 @@
+package migrateup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+// TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting exercises the
+// --verify-sum gate: on a drifted migrations directory the command must fail
+// on the integrity check before ever touching the database, so a bogus,
+// unreachable --db-url is never dialed.
+//
+// The command uses package-global flag state, so this package keeps a single
+// command-level test to avoid re-registering flags.
+func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	write := func(name, content string) {
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	write("0000000001_init.up.sql", "CREATE TABLE t (id INT);\n")
+	write("0000000001_init.down.sql", "DROP TABLE t;\n")
+	_, err := migratesum.Write(dir)
+	c.Assert(err, qt.IsNil)
+
+	// Tamper with an already-hashed migration so the directory drifts.
+	write("0000000001_init.up.sql", "CREATE TABLE t (id BIGINT);\n")
+
+	cmd := NewMigrateUpCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--db-url", "mysql://u@tcp(127.0.0.1:1)/db", // unreachable; must never be dialed
+		"--migrations-dir", dir,
+		"--verify-sum",
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, "(?s).*ptah.sum verification failed.*")
+	c.Assert(err, qt.ErrorMatches, "(?s).*changed: 0000000001_init.up.sql.*",
+		qt.Commentf("the drift diagnostic identifies the tampered file"))
+}

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -29,7 +29,7 @@ and compares them against the committed ptah.sum. It exits:
   2  ptah.sum is missing or unreadable, or the directory is inaccessible
 
 Run it in CI to guarantee already-committed migrations are never changed.`,
-		Args:          cobra.NoArgs,
+		Args:          cmdutil.NoPositionalArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -6,10 +6,10 @@ package migratevalidate
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/migratesum"
 )
@@ -37,12 +37,13 @@ Run it in CI to guarantee already-committed migrations are never changed.`,
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	cmd.SetFlagErrorFunc(cmdutil.FlagErrorFunc)
 	return cmd
 }
 
 func runValidate(cmd *cobra.Command, dir string) error {
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		return fail(cmd, fmt.Errorf("migrations directory %s is not accessible", dir))
+	if err := cmdutil.StatDir(dir); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 
 	// A missing or unreadable ptah.sum, and any other verify error, is a
@@ -52,7 +53,7 @@ func runValidate(cmd *cobra.Command, dir string) error {
 	// silences cobra's own error output).
 	result, err := migratesum.VerifyDir(dir)
 	if err != nil {
-		return fail(cmd, err)
+		return cmdutil.Fail(cmd, err)
 	}
 
 	if !result.OK() {
@@ -62,10 +63,4 @@ func runValidate(cmd *cobra.Command, dir string) error {
 
 	fmt.Fprintf(cmd.OutOrStdout(), "OK: migrations directory matches %s\n", migratesum.FileName)
 	return nil
-}
-
-// fail prints an error to stderr and returns it as an exit-2 error.
-func fail(cmd *cobra.Command, err error) error {
-	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
-	return exitcode.New(2, err)
 }

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -1,0 +1,71 @@
+// Package migratevalidate implements the `ptah migrate-validate` command: it
+// verifies a migrations directory against its committed ptah.sum and exits
+// non-zero on any drift (#161).
+package migratevalidate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+// NewMigrateValidateCommand returns the migrate-validate command.
+func NewMigrateValidateCommand() *cobra.Command {
+	var dir string
+
+	cmd := &cobra.Command{
+		Use:   "migrate-validate",
+		Short: "Verify a migrations directory against its committed ptah.sum",
+		Long: `migrate-validate recomputes the integrity hashes of a migrations directory
+and compares them against the committed ptah.sum. It exits:
+
+  0  the directory matches ptah.sum
+  1  a migration file was added, removed, or edited out of band (drift)
+  2  ptah.sum is missing or unreadable, or the directory is inaccessible
+
+Run it in CI to guarantee already-committed migrations are never changed.`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runValidate(cmd, dir)
+		},
+	}
+	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	return cmd
+}
+
+func runValidate(cmd *cobra.Command, dir string) error {
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return fail(cmd, fmt.Errorf("migrations directory %s is not accessible", dir))
+	}
+
+	// A missing or unreadable ptah.sum, and any other verify error, is a
+	// usage failure (exit 2) distinct from a content drift (exit 1). Its
+	// message — including the actionable "run ptah migrate-hash" for a
+	// missing sum — must reach the user, so print it here (the command
+	// silences cobra's own error output).
+	result, err := migratesum.VerifyDir(dir)
+	if err != nil {
+		return fail(cmd, err)
+	}
+
+	if !result.OK() {
+		fmt.Fprintln(cmd.ErrOrStderr(), result.Describe())
+		return exitcode.New(1, errors.New("migration directory integrity check failed"))
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "OK: migrations directory matches %s\n", migratesum.FileName)
+	return nil
+}
+
+// fail prints an error to stderr and returns it as an exit-2 error.
+func fail(cmd *cobra.Command, err error) error {
+	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	return exitcode.New(2, err)
+}

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -1,0 +1,83 @@
+package migratevalidate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+func execute(args ...string) (stdout, stderr string, err error) {
+	cmd := NewMigrateValidateCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// migrationsDir writes a clean pair plus a matching ptah.sum and returns the dir.
+func migrationsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("0000000001_init.up.sql", "CREATE TABLE t (id INT);\n")
+	write("0000000001_init.down.sql", "DROP TABLE t;\n")
+	if _, err := migratesum.Write(dir); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestValidate_CleanDirectoryExitsZero(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, _, err := execute("--dir", migrationsDir(t))
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "OK: migrations directory matches ptah.sum")
+}
+
+func TestValidate_EditedMigrationExitsOneWithDiff(t *testing.T) {
+	c := qt.New(t)
+
+	dir := migrationsDir(t)
+	// Tamper with an already-hashed migration.
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE t (id BIGINT);\n"), 0o600), qt.IsNil)
+
+	_, stderr, err := execute("--dir", dir)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr, qt.Contains, "changed: 0000000001_init.up.sql")
+}
+
+func TestValidate_MissingSumFileExitsTwo(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+
+	_, stderr, err := execute("--dir", dir)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(err, qt.ErrorMatches, ".*ptah.sum not found.*")
+	// The actionable guidance must reach the user, not be swallowed.
+	c.Assert(stderr, qt.Contains, "run `ptah migrate-hash`")
+}
+
+func TestValidate_MissingDirectoryExitsTwo(t *testing.T) {
+	c := qt.New(t)
+
+	_, _, err := execute("--dir", filepath.Join(t.TempDir(), "does-not-exist"))
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(err, qt.ErrorMatches, ".*not accessible.*")
+}

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -84,6 +84,17 @@ func TestValidate_MissingDirectoryExitsTwo(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*does-not-exist.*")
 }
 
+func TestValidate_PositionalArgExitsTwoWithMessage(t *testing.T) {
+	c := qt.New(t)
+
+	// A stray positional (e.g. the path typed without --dir) is a usage
+	// error (exit 2 with a message), not a silent exit 1 that would look
+	// like drift.
+	_, stderr, err := execute(migrationsDir(t), "stray")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "unexpected positional arguments")
+}
+
 func TestValidate_CorruptSumFileExitsTwoNotOne(t *testing.T) {
 	c := qt.New(t)
 

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -77,7 +77,23 @@ func TestValidate_MissingSumFileExitsTwo(t *testing.T) {
 func TestValidate_MissingDirectoryExitsTwo(t *testing.T) {
 	c := qt.New(t)
 
-	_, _, err := execute("--dir", filepath.Join(t.TempDir(), "does-not-exist"))
+	_, stderr, err := execute("--dir", filepath.Join(t.TempDir(), "does-not-exist"))
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
-	c.Assert(err, qt.ErrorMatches, ".*not accessible.*")
+	// The message surfaces the directory and the underlying stat error.
+	c.Assert(stderr, qt.Contains, "migrations directory")
+	c.Assert(err, qt.ErrorMatches, ".*does-not-exist.*")
+}
+
+func TestValidate_CorruptSumFileExitsTwoNotOne(t *testing.T) {
+	c := qt.New(t)
+
+	dir := migrationsDir(t)
+	// A structurally broken ptah.sum (an h1: hash that is not valid base64)
+	// is a usage failure (exit 2), not content drift (exit 1).
+	c.Assert(os.WriteFile(filepath.Join(dir, "ptah.sum"),
+		[]byte("h1:not-valid-base64!!\n"), 0o600), qt.IsNil)
+
+	_, stderr, err := execute("--dir", dir)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, "malformed directory hash line")
 }

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -14,8 +14,10 @@ import (
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratedown"
+	"github.com/stokaro/ptah/cmd/migratehash"
 	"github.com/stokaro/ptah/cmd/migratestatus"
 	"github.com/stokaro/ptah/cmd/migrateup"
+	"github.com/stokaro/ptah/cmd/migratevalidate"
 	"github.com/stokaro/ptah/cmd/readdb"
 	"github.com/stokaro/ptah/cmd/seed"
 )
@@ -53,6 +55,8 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(migrateup.NewMigrateUpCommand())
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
 	rootCmd.AddCommand(migratestatus.NewMigrateStatusCommand())
+	rootCmd.AddCommand(migratehash.NewMigrateHashCommand())
+	rootCmd.AddCommand(migratevalidate.NewMigrateValidateCommand())
 	rootCmd.AddCommand(seed.NewSeedCommand())
 	rootCmd.AddCommand(dropall.NewDropAllCommand())
 	rootCmd.AddCommand(lint.NewLintCommand())

--- a/migration/migratesum/io.go
+++ b/migration/migratesum/io.go
@@ -14,7 +14,10 @@ func Write(dir string) (*SumFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(filepath.Join(dir, FileName), sum.Bytes(), 0o600); err != nil {
+	// ptah.sum is committed alongside the migrations and read by everyone who
+	// checks out the repo, so it uses the same 0644 as generated migration
+	// files rather than a private 0600.
+	if err := os.WriteFile(filepath.Join(dir, FileName), sum.Bytes(), 0644); err != nil { //nolint:gosec // 0644 is fine
 		return nil, fmt.Errorf("failed to write %s: %w", FileName, err)
 	}
 	return sum, nil

--- a/migration/migratesum/io.go
+++ b/migration/migratesum/io.go
@@ -1,0 +1,26 @@
+package migratesum
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Write computes the sum of the migrations directory at dir and writes it to
+// dir/ptah.sum, returning the computed sum. The ptah.sum file is excluded
+// from its own hash because it is not a migration file.
+func Write(dir string) (*SumFile, error) {
+	sum, err := Compute(os.DirFS(dir))
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, FileName), sum.Bytes(), 0o600); err != nil {
+		return nil, fmt.Errorf("failed to write %s: %w", FileName, err)
+	}
+	return sum, nil
+}
+
+// VerifyDir verifies the migrations directory at dir against its ptah.sum.
+func VerifyDir(dir string) (*Result, error) {
+	return Verify(os.DirFS(dir))
+}

--- a/migration/migratesum/sum.go
+++ b/migration/migratesum/sum.go
@@ -105,7 +105,7 @@ func Parse(data []byte) (*SumFile, error) {
 	if dirLine == "" {
 		return nil, fmt.Errorf("empty or missing directory hash line")
 	}
-	if !strings.HasPrefix(dirLine, hashPrefix) {
+	if !validHash(dirLine) {
 		return nil, fmt.Errorf("malformed directory hash line: %q", dirLine)
 	}
 	sum := &SumFile{DirHash: dirLine}
@@ -123,12 +123,25 @@ func Parse(data []byte) (*SumFile, error) {
 			return nil, fmt.Errorf("malformed entry line: %q", line)
 		}
 		name, hash := line[:idx], line[idx+1:]
-		if !strings.HasPrefix(hash, hashPrefix) {
+		if !validHash(hash) {
 			return nil, fmt.Errorf("malformed entry line: %q", line)
 		}
 		sum.Entries = append(sum.Entries, Entry{Name: name, Hash: hash})
 	}
 	return sum, nil
+}
+
+// validHash reports whether s is a well-formed h1: hash: the prefix plus a
+// standard-base64 SHA-256 digest. Rejecting a syntactically broken hash at
+// parse time keeps a corrupt ptah.sum a usage error (exit 2) rather than
+// masquerading as content drift (exit 1).
+func validHash(s string) bool {
+	rest, ok := strings.CutPrefix(s, hashPrefix)
+	if !ok {
+		return false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rest)
+	return err == nil && len(decoded) == sha256.Size
 }
 
 // hashContent returns the h1: content hash of a migration file.

--- a/migration/migratesum/sum.go
+++ b/migration/migratesum/sum.go
@@ -1,0 +1,148 @@
+// Package migratesum provides a migration-directory integrity check: a
+// committed checksum file (ptah.sum) records the hash of every migration file
+// plus a directory-level hash, so an out-of-band edit to an already-applied
+// migration is caught in CI instead of silently breaking reproducibility
+// (issue #161).
+//
+// # File format
+//
+// The sum file is line-oriented. The first line is the directory hash; each
+// following line is a migration file and its hash:
+//
+//	h1:<base64 sha256 over the entries below>
+//	0000000001_init.up.sql h1:<base64 sha256 of file contents>
+//	0000000001_init.down.sql h1:<base64 sha256 of file contents>
+//
+// The layout and the h1: (base64-encoded SHA-256) scheme mirror Atlas's
+// atlas.sum so a future "atlas mode" (issue #250) can converge on it; the
+// file is named ptah.sum and its exact byte-compatibility with Atlas is
+// intentionally out of scope until that decision lands.
+package migratesum
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// FileName is the conventional integrity file inside a migrations directory.
+const FileName = "ptah.sum"
+
+// hashPrefix marks a base64-encoded SHA-256 hash, matching Atlas's h1 scheme.
+const hashPrefix = "h1:"
+
+// Entry is one migration file and its content hash.
+type Entry struct {
+	// Name is the slash-separated path of the file relative to the
+	// migrations directory.
+	Name string
+	// Hash is the h1: content hash of the file.
+	Hash string
+}
+
+// SumFile is the parsed integrity file: a directory hash over all entries and
+// the per-file entries themselves (sorted by name).
+type SumFile struct {
+	DirHash string
+	Entries []Entry
+}
+
+// Compute walks fsys and builds the sum over every migration file the
+// migrator recognizes (NNNNNNNNNN_description.(up|down).sql), so the checksum
+// covers exactly what migrate-up/down would execute. The ptah.sum file itself
+// and any non-migration file are excluded.
+func Compute(fsys fs.FS) (*SumFile, error) {
+	var entries []Entry
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !migrator.ValidateMigrationFileName(path.Base(p)) {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", p, err)
+		}
+		entries = append(entries, Entry{Name: p, Hash: hashContent(data)})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	return &SumFile{DirHash: dirHash(entries), Entries: entries}, nil
+}
+
+// Bytes renders the sum file in its on-disk form.
+func (s *SumFile) Bytes() []byte {
+	var b strings.Builder
+	b.WriteString(s.DirHash)
+	b.WriteByte('\n')
+	for _, e := range s.Entries {
+		b.WriteString(e.Name)
+		b.WriteByte(' ')
+		b.WriteString(e.Hash)
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+// Parse reads a sum file. It tolerates a trailing newline and CRLF line
+// endings (a checkout on Windows, or git autocrlf, must not report false
+// drift) but rejects structurally malformed content so a corrupt sum file is
+// an explicit error rather than a silent mismatch.
+func Parse(data []byte) (*SumFile, error) {
+	lines := strings.Split(strings.TrimRight(string(data), "\r\n"), "\n")
+	dirLine := strings.TrimRight(lines[0], "\r")
+	if dirLine == "" {
+		return nil, fmt.Errorf("empty or missing directory hash line")
+	}
+	if !strings.HasPrefix(dirLine, hashPrefix) {
+		return nil, fmt.Errorf("malformed directory hash line: %q", dirLine)
+	}
+	sum := &SumFile{DirHash: dirLine}
+	for _, line := range lines[1:] {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		// Split on the LAST space: a migration description may legally
+		// contain spaces (the migrator's name regex allows any character),
+		// but an h1: base64 hash never does, so the trailing token is the
+		// hash and everything before it is the file name.
+		idx := strings.LastIndex(line, " ")
+		if idx <= 0 {
+			return nil, fmt.Errorf("malformed entry line: %q", line)
+		}
+		name, hash := line[:idx], line[idx+1:]
+		if !strings.HasPrefix(hash, hashPrefix) {
+			return nil, fmt.Errorf("malformed entry line: %q", line)
+		}
+		sum.Entries = append(sum.Entries, Entry{Name: name, Hash: hash})
+	}
+	return sum, nil
+}
+
+// hashContent returns the h1: content hash of a migration file.
+func hashContent(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hashPrefix + base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// dirHash returns the h1: hash over the (sorted) entries, binding every file
+// name and content hash into a single directory-level checksum.
+func dirHash(entries []Entry) string {
+	h := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintf(h, "%s %s\n", e.Name, e.Hash)
+	}
+	return hashPrefix + base64.StdEncoding.EncodeToString(h.Sum(nil))
+}

--- a/migration/migratesum/sum_test.go
+++ b/migration/migratesum/sum_test.go
@@ -1,6 +1,8 @@
 package migratesum_test
 
 import (
+	"bytes"
+	"encoding/base64"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -93,19 +95,34 @@ func TestBytesParseRoundTrip(t *testing.T) {
 func TestParse_Malformed(t *testing.T) {
 	c := qt.New(t)
 
+	// A syntactically valid h1: hash (prefix + base64 of 32 bytes) for the
+	// directory line, so the entry-line cases below are not short-circuited
+	// by a bad dir line.
+	validH := "h1:" + base64.StdEncoding.EncodeToString(make([]byte, 32))
+
 	_, err := migratesum.Parse([]byte(""))
 	c.Assert(err, qt.ErrorMatches, "empty or missing directory hash line")
 
-	_, err = migratesum.Parse([]byte("not-a-hash\n0000000001_x.up.sql h1:abc\n"))
+	// Directory line without the h1: prefix.
+	_, err = migratesum.Parse([]byte("not-a-hash\n0000000001_x.up.sql " + validH + "\n"))
+	c.Assert(err, qt.ErrorMatches, "malformed directory hash line.*")
+
+	// Directory line with the h1: prefix but a non-base64 / wrong-length
+	// digest — a corrupt sum must be a usage error, not silent drift.
+	_, err = migratesum.Parse([]byte("h1:not-valid-base64!!\n"))
 	c.Assert(err, qt.ErrorMatches, "malformed directory hash line.*")
 
 	// No space between name and hash.
-	_, err = migratesum.Parse([]byte("h1:dir\nnohashhere\n"))
+	_, err = migratesum.Parse([]byte(validH + "\nnohashhere\n"))
 	c.Assert(err, qt.ErrorMatches, "malformed entry line.*")
 
 	// A space is present (so the field split succeeds) but the trailing
-	// token is not an h1: hash — this pins the hash-prefix validation.
-	_, err = migratesum.Parse([]byte("h1:dir\n0000000001_x.up.sql garbagehash\n"))
+	// token is not an h1: hash.
+	_, err = migratesum.Parse([]byte(validH + "\n0000000001_x.up.sql garbagehash\n"))
+	c.Assert(err, qt.ErrorMatches, "malformed entry line.*")
+
+	// h1: prefix present but the digest is not valid base64/32 bytes.
+	_, err = migratesum.Parse([]byte(validH + "\n0000000001_x.up.sql h1:short\n"))
 	c.Assert(err, qt.ErrorMatches, "malformed entry line.*")
 }
 
@@ -215,9 +232,12 @@ func TestVerify_HandEditedSumFileDirHashMismatch(t *testing.T) {
 	sum, err := migratesum.Compute(fsys)
 	c.Assert(err, qt.IsNil)
 
-	// Corrupt only the directory-hash line; the per-file entries still match
-	// their files, so this is detectable only via the dir hash.
-	tampered := append([]byte("h1:AAAAtampered\n"), sum.Bytes()[len(sum.DirHash)+1:]...)
+	// Replace only the directory-hash line with a different but still
+	// well-formed h1 hash; the per-file entries still match their files, so
+	// this is detectable only via the dir hash. (A syntactically broken hash
+	// would instead be rejected at parse time — see TestParse_Malformed.)
+	wrongDirHash := "h1:" + base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0xFF}, 32))
+	tampered := append([]byte(wrongDirHash+"\n"), sum.Bytes()[len(sum.DirHash)+1:]...)
 	fsys["ptah.sum"] = &fstest.MapFile{Data: tampered}
 
 	res, err := migratesum.Verify(fsys)

--- a/migration/migratesum/sum_test.go
+++ b/migration/migratesum/sum_test.go
@@ -1,0 +1,228 @@
+package migratesum_test
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migratesum"
+)
+
+func fixture(files map[string]string) fstest.MapFS {
+	fsys := fstest.MapFS{}
+	for name, content := range files {
+		fsys[name] = &fstest.MapFile{Data: []byte(content)}
+	}
+	return fsys
+}
+
+func TestCompute_HashesOnlyMigrationFilesSortedByName(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000002_add.up.sql":      "ALTER TABLE t ADD COLUMN a INT;\n",
+		"0000000002_add.down.sql":    "ALTER TABLE t DROP COLUMN a;\n",
+		"0000000001_init.up.sql":     "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql":   "DROP TABLE t;\n",
+		"README.md":                  "not a migration\n",
+		"ptah.sum":                   "stale\n",
+		"0000000003_bad_name.txt":    "ignored\n",
+		"nested/0000000004_x.up.sql": "CREATE TABLE u (id INT);\n",
+	})
+
+	sum, err := migratesum.Compute(fsys)
+	c.Assert(err, qt.IsNil)
+
+	var names []string
+	for _, e := range sum.Entries {
+		names = append(names, e.Name)
+		c.Assert(e.Hash, qt.Matches, "h1:.+")
+	}
+	c.Assert(names, qt.DeepEquals, []string{
+		"0000000001_init.down.sql",
+		"0000000001_init.up.sql",
+		"0000000002_add.down.sql",
+		"0000000002_add.up.sql",
+		"nested/0000000004_x.up.sql",
+	}, qt.Commentf("only recognized migration files, sorted; README/ptah.sum/.txt excluded"))
+	c.Assert(sum.DirHash, qt.Matches, "h1:.+")
+}
+
+func TestCompute_IsDeterministicAndContentSensitive(t *testing.T) {
+	c := qt.New(t)
+
+	base := map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}
+	a, err := migratesum.Compute(fixture(base))
+	c.Assert(err, qt.IsNil)
+	b, err := migratesum.Compute(fixture(base))
+	c.Assert(err, qt.IsNil)
+	c.Assert(a.DirHash, qt.Equals, b.DirHash)
+	c.Assert(a.Bytes(), qt.DeepEquals, b.Bytes())
+
+	changed := map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id BIGINT);\n", // one byte differs
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}
+	d, err := migratesum.Compute(fixture(changed))
+	c.Assert(err, qt.IsNil)
+	c.Assert(d.DirHash, qt.Not(qt.Equals), a.DirHash)
+	c.Assert(d.Entries[1].Hash, qt.Not(qt.Equals), a.Entries[1].Hash,
+		qt.Commentf("the up file hash reflects its content"))
+}
+
+func TestBytesParseRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	sum, err := migratesum.Compute(fixture(map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}))
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := migratesum.Parse(sum.Bytes())
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.DirHash, qt.Equals, sum.DirHash)
+	c.Assert(parsed.Entries, qt.DeepEquals, sum.Entries)
+}
+
+func TestParse_Malformed(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := migratesum.Parse([]byte(""))
+	c.Assert(err, qt.ErrorMatches, "empty or missing directory hash line")
+
+	_, err = migratesum.Parse([]byte("not-a-hash\n0000000001_x.up.sql h1:abc\n"))
+	c.Assert(err, qt.ErrorMatches, "malformed directory hash line.*")
+
+	// No space between name and hash.
+	_, err = migratesum.Parse([]byte("h1:dir\nnohashhere\n"))
+	c.Assert(err, qt.ErrorMatches, "malformed entry line.*")
+
+	// A space is present (so the field split succeeds) but the trailing
+	// token is not an h1: hash — this pins the hash-prefix validation.
+	_, err = migratesum.Parse([]byte("h1:dir\n0000000001_x.up.sql garbagehash\n"))
+	c.Assert(err, qt.ErrorMatches, "malformed entry line.*")
+}
+
+func TestBytesParseRoundTrip_NameWithSpaces(t *testing.T) {
+	c := qt.New(t)
+
+	// The migrator's name regex allows any character in the description, so
+	// "0000000002_add user.up.sql" is a valid, runnable migration. Its name
+	// contains a space, which is also the sum-file field separator: the
+	// round-trip must recover the full name.
+	sum, err := migratesum.Compute(fixture(map[string]string{
+		"0000000002_add user.up.sql":   "ALTER TABLE t ADD COLUMN u INT;\n",
+		"0000000002_add user.down.sql": "ALTER TABLE t DROP COLUMN u;\n",
+	}))
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := migratesum.Parse(sum.Bytes())
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Entries, qt.DeepEquals, sum.Entries)
+	c.Assert(parsed.Entries[0].Name, qt.Equals, "0000000002_add user.down.sql")
+}
+
+func TestParse_ToleratesCRLFLineEndings(t *testing.T) {
+	c := qt.New(t)
+
+	files := map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}
+	fsys := fixture(files)
+	sum, err := migratesum.Compute(fsys)
+	c.Assert(err, qt.IsNil)
+
+	// A git checkout with autocrlf, or editing ptah.sum on Windows, yields
+	// CRLF line endings. That must not be read as drift: the parsed hashes
+	// must match, so a clean directory still verifies clean.
+	crlf := strings.ReplaceAll(string(sum.Bytes()), "\n", "\r\n")
+	parsed, err := migratesum.Parse([]byte(crlf))
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.DirHash, qt.Equals, sum.DirHash)
+	c.Assert(parsed.Entries, qt.DeepEquals, sum.Entries)
+
+	fsys["ptah.sum"] = &fstest.MapFile{Data: []byte(crlf)}
+	res, err := migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsTrue, qt.Commentf("CRLF ptah.sum on an unchanged dir must not report drift; got %s", res.Describe()))
+}
+
+func TestVerify_CleanAddedRemovedChanged(t *testing.T) {
+	c := qt.New(t)
+
+	files := map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}
+	fsys := fixture(files)
+	sum, err := migratesum.Compute(fsys)
+	c.Assert(err, qt.IsNil)
+	fsys["ptah.sum"] = &fstest.MapFile{Data: sum.Bytes()}
+
+	// Clean.
+	res, err := migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsTrue)
+
+	// Changed: edit a file's content.
+	fsys["0000000001_init.up.sql"] = &fstest.MapFile{Data: []byte("CREATE TABLE t (id BIGINT);\n")}
+	res, err = migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsFalse)
+	c.Assert(res.Changed, qt.DeepEquals, []string{"0000000001_init.up.sql"})
+	c.Assert(res.Describe(), qt.Contains, "changed: 0000000001_init.up.sql")
+
+	// Added: a new migration not yet hashed.
+	fsys["0000000001_init.up.sql"] = &fstest.MapFile{Data: []byte(files["0000000001_init.up.sql"])}
+	fsys["0000000002_more.up.sql"] = &fstest.MapFile{Data: []byte("CREATE TABLE u (id INT);\n")}
+	res, err = migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Added, qt.DeepEquals, []string{"0000000002_more.up.sql"})
+
+	// Removed: delete a hashed file.
+	delete(fsys, "0000000002_more.up.sql")
+	delete(fsys, "0000000001_init.down.sql")
+	res, err = migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.Removed, qt.DeepEquals, []string{"0000000001_init.down.sql"})
+}
+
+func TestVerify_MissingSumFile(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := migratesum.Verify(fixture(map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}))
+	c.Assert(err, qt.ErrorIs, migratesum.ErrSumFileMissing)
+}
+
+func TestVerify_HandEditedSumFileDirHashMismatch(t *testing.T) {
+	c := qt.New(t)
+
+	files := map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql": "DROP TABLE t;\n",
+	}
+	fsys := fixture(files)
+	sum, err := migratesum.Compute(fsys)
+	c.Assert(err, qt.IsNil)
+
+	// Corrupt only the directory-hash line; the per-file entries still match
+	// their files, so this is detectable only via the dir hash.
+	tampered := append([]byte("h1:AAAAtampered\n"), sum.Bytes()[len(sum.DirHash)+1:]...)
+	fsys["ptah.sum"] = &fstest.MapFile{Data: tampered}
+
+	res, err := migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsFalse)
+	c.Assert(res.DirHashMismatch, qt.IsTrue)
+	c.Assert(res.Describe(), qt.Contains, "directory hash mismatch")
+}

--- a/migration/migratesum/verify.go
+++ b/migration/migratesum/verify.go
@@ -86,8 +86,11 @@ func diff(recorded, current *SumFile) *Result {
 	sort.Strings(res.Removed)
 	sort.Strings(res.Changed)
 
-	// A directory-hash mismatch with no per-file diff means the sum file's
-	// own dir line was tampered with (or an entry was reordered/edited).
+	// Per-file entries match, yet the recorded directory-hash line does not
+	// equal the hash recomputed over those entries: the dir line was
+	// hand-edited (or the sum file was assembled inconsistently). Reordering
+	// entry lines is not flagged here and need not be — the diff is
+	// name-keyed and Compute always re-sorts, so order carries no meaning.
 	if res.OK() && recorded.DirHash != current.DirHash {
 		res.DirHashMismatch = true
 	}

--- a/migration/migratesum/verify.go
+++ b/migration/migratesum/verify.go
@@ -1,0 +1,117 @@
+package migratesum
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// ErrSumFileMissing is returned when the migrations directory has no ptah.sum.
+// It is distinct so callers can tell "never hashed" apart from "tampered".
+var ErrSumFileMissing = errors.New("ptah.sum not found; run `ptah migrate-hash` to create it")
+
+// Result is the outcome of Verify: the lists are empty when the directory
+// matches its recorded sum.
+type Result struct {
+	// Added are migration files present on disk but absent from ptah.sum.
+	Added []string
+	// Removed are files recorded in ptah.sum but missing on disk.
+	Removed []string
+	// Changed are files whose content hash no longer matches ptah.sum.
+	Changed []string
+	// DirHashMismatch is set when the directory hash differs even though the
+	// per-file diff is empty (a corrupted or hand-edited sum file).
+	DirHashMismatch bool
+}
+
+// OK reports whether the directory matches its recorded sum exactly.
+func (r *Result) OK() bool {
+	return len(r.Added) == 0 && len(r.Removed) == 0 && len(r.Changed) == 0 && !r.DirHashMismatch
+}
+
+// Verify recomputes the sum of fsys and compares it against the ptah.sum
+// recorded in the same directory. A missing ptah.sum returns
+// ErrSumFileMissing; a read/parse failure returns a wrapped error. A drift is
+// reported in the Result (not as an error) so callers choose the exit code.
+func Verify(fsys fs.FS) (*Result, error) {
+	recordedRaw, err := fs.ReadFile(fsys, FileName)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrSumFileMissing
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", FileName, err)
+	}
+	recorded, err := Parse(recordedRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", FileName, err)
+	}
+
+	current, err := Compute(fsys)
+	if err != nil {
+		return nil, err
+	}
+
+	return diff(recorded, current), nil
+}
+
+// diff compares the recorded sum against the freshly computed one.
+func diff(recorded, current *SumFile) *Result {
+	recordedByName := make(map[string]string, len(recorded.Entries))
+	for _, e := range recorded.Entries {
+		recordedByName[e.Name] = e.Hash
+	}
+	currentByName := make(map[string]string, len(current.Entries))
+	for _, e := range current.Entries {
+		currentByName[e.Name] = e.Hash
+	}
+
+	var res Result
+	for _, e := range current.Entries {
+		recordedHash, ok := recordedByName[e.Name]
+		switch {
+		case !ok:
+			res.Added = append(res.Added, e.Name)
+		case recordedHash != e.Hash:
+			res.Changed = append(res.Changed, e.Name)
+		}
+	}
+	for _, e := range recorded.Entries {
+		if _, ok := currentByName[e.Name]; !ok {
+			res.Removed = append(res.Removed, e.Name)
+		}
+	}
+	sort.Strings(res.Added)
+	sort.Strings(res.Removed)
+	sort.Strings(res.Changed)
+
+	// A directory-hash mismatch with no per-file diff means the sum file's
+	// own dir line was tampered with (or an entry was reordered/edited).
+	if res.OK() && recorded.DirHash != current.DirHash {
+		res.DirHashMismatch = true
+	}
+	return &res
+}
+
+// Describe renders a drift Result as human-readable lines. It returns "" when
+// the result is OK.
+func (r *Result) Describe() string {
+	if r.OK() {
+		return ""
+	}
+	lines := []string{"migration directory does not match ptah.sum:"}
+	for _, n := range r.Changed {
+		lines = append(lines, "  changed: "+n)
+	}
+	for _, n := range r.Added {
+		lines = append(lines, "  added (not in ptah.sum): "+n)
+	}
+	for _, n := range r.Removed {
+		lines = append(lines, "  removed (still in ptah.sum): "+n)
+	}
+	if r.DirHashMismatch {
+		lines = append(lines, "  directory hash mismatch (ptah.sum was hand-edited)")
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary

Implements #161: a committed integrity file (`ptah.sum`) records the SHA-256 (`h1:`, base64) of every migration file plus a directory-level hash, so an out-of-band edit to an already-applied migration is caught in CI instead of silently breaking reproducibility.

```bash
# after adding or intentionally editing a migration
ptah migrate-hash --dir ./migrations

# CI gate
ptah migrate-validate --dir ./migrations
```

```
h1:aThO8xfh8Bp08YHaFPQCk9zpiIlWIlvlR+5ScAFKNMM=
0000000001_init.down.sql h1:3hAVcH5B1mghhsNEDFiyIlGOdernvs+6dDRkaO79/F0=
0000000001_init.up.sql h1:ibFuiLnjNXnxOpFq76++GmXv+bIWoSnDZy8y+YLA1FY=
```

## What's included (issue scope)

1. **`ptah migrate-hash --dir`** — writes/updates `ptah.sum`.
2. **`ptah migrate-validate --dir`** — verifies every file against its recorded hash and the directory hash; exit `0` clean, `1` on drift (a diff on stderr), `2` when `ptah.sum` is missing/unreadable or the dir is inaccessible.
3. **`ptah migrate-up --verify-sum`** — runs the same gate before connecting and aborts on drift.
4. **CI snippet** in the README.

`ptah.sum` covers exactly the files the migrator runs (recursive, `ValidateMigrationFileName`); non-migration files (README, the sum file itself) are not hashed. The layout and `h1:` scheme mirror Atlas's `atlas.sum`; exact Atlas-format convergence is deferred to the Atlas-compatibility research (#250).

## Design

- `migration/migratesum`: `Compute` (sorted, deterministic per-file + directory hashes), `Parse`/`Bytes` round-trip, `Verify` classifying `Added`/`Removed`/`Changed` and a directory-hash mismatch (a hand-edited sum). Drift is returned as data, not an error — the CLI maps it to exit 1; a missing/unreadable sum is exit 2.
- Commands mirror the existing `cmd/*` + `cmd/internal/exitcode` pattern.

## Adversarial self-review

Reviewed by an agent fleet (3 lenses × 2 skeptics, ~23 agents). 8 confirmed findings — all fixed and covered by tests; the load-bearing ones verified live with the built CLI:

- **HIGH — space in a migration name broke the round-trip.** The migrator's name regex allows any character, so `0000000002_add user.up.sql` is a valid, runnable migration; but `Parse` split the entry line on the *first* space, so `migrate-hash` wrote a `ptah.sum` that `migrate-validate` could never accept (clean dir → exit 2 forever, and `--verify-sum` aborting a clean dir). Fixed: split on the **last** space (an h1: hash never contains one). New round-trip test with a spaced name.
- **MEDIUM — CRLF `ptah.sum` reported false drift.** A Windows checkout / `autocrlf` left a `\r` on every recorded hash. Fixed: `Parse` tolerates CRLF. New test.
- **MEDIUM — silent exit-2.** Missing/corrupt sum or inaccessible dir exited 2 with no output, so the actionable "run `ptah migrate-hash`" never reached the user. Both commands now print the error. New assertion.
- Test gaps closed: `migrate-up --verify-sum` gate (new command test proving it aborts before dialing an unreachable DB), and `Parse`'s hash-prefix validation.

Rejected as non-issues: a claimed 32-bit/64-bit non-determinism (the version int never enters the hash — names are hashed as strings) and a README exit-code nitpick.

## Testing

- `migration/migratesum`: hashing (only migration files, sorted, recursive), determinism + content-sensitivity, `Bytes`↔`Parse` round-trip incl. spaced names and CRLF, malformed-input rejection, `Verify` clean/added/removed/changed and dir-hash mismatch, missing-sum sentinel.
- CLI: `migrate-hash` writes and updates; `migrate-validate` clean/drift/missing/inaccessible exit codes and the printed guidance; `migrate-up --verify-sum` abort-on-drift.
- Live: hash → validate clean → tamper → validate exit 1 with diff; spaced-name round-trip; missing-sum prints guidance.
- `go test ./...`, `golangci-lint run`, `go tool qtlint ./...` — clean.

Closes #161

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB