### PR TITLE
Fix(lint): default mode must not treat '#' as a comment; pair by version

### DIFF
--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -182,10 +182,23 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 		present[name] = struct{}{}
 	}
 
+	// Directions present per version, so pairing matches the migrator, which
+	// pairs an up and a down by their shared version prefix regardless of
+	// description — not by an identical file-name stem.
+	versionDirs := map[int]map[string]bool{}
+	for _, name := range names {
+		if parsed, err := migrator.ParseMigrationFileName(path.Base(name)); err == nil {
+			if versionDirs[parsed.Version] == nil {
+				versionDirs[parsed.Version] = map[string]bool{}
+			}
+			versionDirs[parsed.Version][parsed.Direction] = true
+		}
+	}
+
 	mode := modeForDialect(opts.Dialect)
 	var findings []Finding
 	for _, name := range names {
-		file, err := prepareFile(fsys, name, present, opts.PathPrefix, mode)
+		file, err := prepareFile(fsys, name, present, versionDirs, opts.PathPrefix, mode)
 		if err != nil {
 			return nil, err
 		}
@@ -205,7 +218,7 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 }
 
 // prepareFile loads one migration file into the forms rules consume.
-func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefix string, mode scanMode) (*File, error) {
+func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDirs map[int]map[string]bool, pathPrefix string, mode scanMode) (*File, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", name, err)
@@ -213,8 +226,10 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefi
 
 	base := path.Base(name)
 	direction := ""
+	version := -1
 	if parsed, parseErr := migrator.ParseMigrationFileName(base); parseErr == nil {
 		direction = parsed.Direction
+		version = parsed.Version
 	}
 	file := &File{
 		Path:      path.Join(pathPrefix, name),
@@ -227,6 +242,14 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, pathPrefi
 		WellFormedName: strictNameRe.MatchString(base),
 	}
 	switch {
+	case version >= 0:
+		// Pair by version, matching the migrator: the counterpart is any
+		// file of the same version in the opposite direction.
+		counterpart := "down"
+		if direction == "down" {
+			counterpart = "up"
+		}
+		file.HasPair = versionDirs[version][counterpart]
 	case file.IsUp:
 		_, file.HasPair = present[strings.TrimSuffix(name, ".up.sql")+".down.sql"]
 	case strings.HasSuffix(name, ".down.sql"):

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -117,6 +117,24 @@ func TestLintFS_MigrationFormRules(t *testing.T) {
 	}
 }
 
+func TestLintFS_PairsByVersionLikeMigrator(t *testing.T) {
+	c := qt.New(t)
+
+	// The migrator pairs an up and a down by their shared version prefix,
+	// regardless of description, so lint must not raise MF101 (missing down)
+	// when the counterpart down exists for the same version under a
+	// different description.
+	fsys := fixture(map[string]string{
+		"0000000001_create_users.up.sql":         "CREATE TABLE users (id INT);\n",
+		"0000000001_create_users_table.down.sql": "DROP TABLE users;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0,
+		qt.Commentf("version 1 has both an up and a down; no MF101 expected; got %v", findings))
+}
+
 // lintOne lints a single-statement up migration (with a paired down file)
 // and returns the rule codes that fired.
 func lintOne(c *qt.C, sql string) []string {
@@ -258,6 +276,18 @@ func TestLintFS_DialectAwareScanning(t *testing.T) {
 		// In PostgreSQL # is an operator, not a comment starter.
 		{"postgres hash operator in index expression", "postgres",
 			"CREATE INDEX idx ON t ((data #>> '{a}'));", []string{"PG101"}},
+		// The default (no --dialect) hybrid must NOT treat # as a comment:
+		// # is a PostgreSQL operator (jsonb #>>, bitwise XOR), and swallowing
+		// the rest of the line would merge statements and hide the following
+		// DROP TABLE (a DS101 false negative in the default CI invocation).
+		{"default dialect jsonb operator does not hide drop table", "",
+			"UPDATE cfg SET v = data #>> '{key}';\nDROP TABLE legacy_audit;", []string{"DS101"}},
+		{"default dialect xor operator does not hide drop table", "",
+			"UPDATE flags SET mask = mask # 1;\nDROP TABLE audit_log;", []string{"DS101"}},
+		// Mirror false positive: the # merge used to bury a same-file CREATE,
+		// so the later DROP of that created table wrongly fired DS101.
+		{"default dialect xor does not manufacture same-file drop false positive", "",
+			"UPDATE flags SET mask = mask # 1;\nCREATE TABLE tmp_backfill (id INT);\nDROP TABLE tmp_backfill;", nil},
 
 		// MySQL executable comments are real SQL to the server.
 		{"mysql executable comment hides real ddl", "mysql",

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -288,6 +288,15 @@ func TestLintFS_DialectAwareScanning(t *testing.T) {
 		// so the later DROP of that created table wrongly fired DS101.
 		{"default dialect xor does not manufacture same-file drop false positive", "",
 			"UPDATE flags SET mask = mask # 1;\nCREATE TABLE tmp_backfill (id INT);\nDROP TABLE tmp_backfill;", nil},
+		// Block comments do not nest in MySQL/MariaDB, so the default hybrid
+		// must close at the first '*/' — otherwise it keeps scanning for a
+		// second '*/' and swallows the DROP that MySQL would execute.
+		{"default dialect non-nesting comment does not hide drop table", "",
+			"/* note /* inner */\nDROP TABLE t;", []string{"DS101"}},
+		// Under an explicit postgres dialect, block comments DO nest, so the
+		// same input is one comment and nothing fires.
+		{"postgres nesting comment hides nothing real", "postgres",
+			"/* note /* inner */ still comment */\nSELECT 1;", nil},
 
 		// MySQL executable comments are real SQL to the server.
 		{"mysql executable comment hides real ddl", "mysql",

--- a/migration/lint/scan.go
+++ b/migration/lint/scan.go
@@ -26,16 +26,25 @@ type scanMode struct {
 
 // modeForDialect maps a lint target dialect to its lexing behavior. An empty
 // or unknown dialect gets a hybrid whose overriding goal is to never HIDE a
-// hazard: it recognizes strings and dollar-quoted bodies (so literal content
-// is not mis-scanned as code) but deliberately omits the dialect-specific
-// lexing rules that would swallow a statement — backslash escapes (a trailing
-// backslash in a standard-conforming literal would hide everything after it)
-// and, critically, MySQL '#' line comments. '#' is a PostgreSQL operator
-// (bitwise XOR, and the ubiquitous jsonb '#>' / '#>>'); treating it as a
-// comment in the dialect-agnostic mode would eat the rest of the line
-// including its terminating ';', merging statements and hiding a following
-// DROP TABLE. MySQL '#' line comments therefore require an explicit
-// --dialect mysql/mariadb.
+// hazard: every lexing rule it omits is one that could swallow a statement in
+// one of the supported dialects. It recognizes strings and PostgreSQL
+// dollar-quoted bodies (so literal / function-body content is not mis-scanned
+// as code), and it scans the content of MySQL executable comments (which only
+// makes more visible), but it deliberately omits:
+//
+//   - backslash escapes — a trailing backslash in a standard-conforming
+//     PostgreSQL literal would hide everything after it;
+//   - MySQL '#' line comments — '#' is a PostgreSQL operator (bitwise XOR,
+//     and the ubiquitous jsonb '#>' / '#>>'), so treating it as a comment
+//     would eat the rest of the line including its ';' and hide a following
+//     DROP TABLE;
+//   - nested block comments — PostgreSQL nests them but MySQL/MariaDB do
+//     not, so a '*/' must always close a comment; otherwise
+//     "/* a /* b */ DROP TABLE t;" would keep scanning for a second '*/'
+//     and swallow the DROP that MySQL would actually execute.
+//
+// The dialect-specific behaviors (MySQL '#' comments, PostgreSQL nested
+// comments) require an explicit --dialect.
 func modeForDialect(dialect string) scanMode {
 	switch dialect {
 	case "mysql", "mariadb":
@@ -43,7 +52,7 @@ func modeForDialect(dialect string) scanMode {
 	case "postgres":
 		return scanMode{dollarQuotes: true, nestedComments: true}
 	default:
-		return scanMode{execComments: true, dollarQuotes: true, nestedComments: true}
+		return scanMode{execComments: true, dollarQuotes: true}
 	}
 }
 

--- a/migration/lint/scan.go
+++ b/migration/lint/scan.go
@@ -25,10 +25,17 @@ type scanMode struct {
 }
 
 // modeForDialect maps a lint target dialect to its lexing behavior. An empty
-// or unknown dialect gets a hybrid that keeps hazards visible for every
-// supported dialect: the MySQL comment forms are honored, but backslash
-// escapes stay off because a trailing backslash in a standard-conforming
-// literal would otherwise hide every statement after it.
+// or unknown dialect gets a hybrid whose overriding goal is to never HIDE a
+// hazard: it recognizes strings and dollar-quoted bodies (so literal content
+// is not mis-scanned as code) but deliberately omits the dialect-specific
+// lexing rules that would swallow a statement — backslash escapes (a trailing
+// backslash in a standard-conforming literal would hide everything after it)
+// and, critically, MySQL '#' line comments. '#' is a PostgreSQL operator
+// (bitwise XOR, and the ubiquitous jsonb '#>' / '#>>'); treating it as a
+// comment in the dialect-agnostic mode would eat the rest of the line
+// including its terminating ';', merging statements and hiding a following
+// DROP TABLE. MySQL '#' line comments therefore require an explicit
+// --dialect mysql/mariadb.
 func modeForDialect(dialect string) scanMode {
 	switch dialect {
 	case "mysql", "mariadb":
@@ -36,7 +43,7 @@ func modeForDialect(dialect string) scanMode {
 	case "postgres":
 		return scanMode{dollarQuotes: true, nestedComments: true}
 	default:
-		return scanMode{hashComments: true, execComments: true, dollarQuotes: true, nestedComments: true}
+		return scanMode{execComments: true, dollarQuotes: true, nestedComments: true}
 	}
 }
 


### PR DESCRIPTION
Two lint defects surfaced by a cross-contour self-validation fleet over everything shipped this session.

## HIGH — default (no `--dialect`) mode hid `DROP TABLE` on PostgreSQL

The dialect-agnostic hybrid scanner enabled MySQL `#` line comments. But `#` is a **PostgreSQL operator** — bitwise XOR, and the ubiquitous jsonb `#>` / `#>>`. A postgres migration using it before a destructive statement had the `#` swallow the rest of the line (including its `;`), merging the statements and hiding the following `DROP TABLE`:

```sql
UPDATE cfg SET v = data #>> '{key}';
DROP TABLE legacy_audit;
```

`ptah lint --dir X` (default, the natural CI invocation — the flag help even advertises empty as "runs every rule") → **`No lint findings.` exit 0**, silently passing a destructive migration. `--dialect postgres` correctly reported DS101. There was a mirror **false positive** too: the `#` merge buried a same-file `CREATE`, so the later `DROP` of that created table wrongly fired DS101.

**Fix:** the default hybrid no longer treats `#` as a comment (it is scanned as an operator, so it can never swallow a statement), restoring the mode's documented "never hide a hazard" intent. MySQL `#` line comments require an explicit `--dialect mysql`/`mariadb` (which still enables them). No change to the postgres/mysql/mariadb explicit modes.

## LOW — MF101 paired by name stem, not version

The migrator pairs an up and a down by their shared 10-digit **version** prefix regardless of description; MF101 (missing down) compared exact name stems. So a valid pair with differing descriptions on the same version —

```
0000000001_create_users.up.sql
0000000001_create_users_table.down.sql
```

— drew a false MF101. lint now pairs by version like the migrator (stem fallback retained for files whose version prefix is malformed).

## Testing

- New cases in `TestLintFS_DialectAwareScanning`: default-dialect `#>>` and `#` XOR must not hide a following `DROP TABLE`, and must not manufacture a same-file-drop false positive.
- New `TestLintFS_PairsByVersionLikeMigrator`.
- Verified live: the `#>>`-then-`DROP TABLE` migration now reports DS101 (error) under the default dialect.
- `go test ./...`, `golangci-lint run`, `go tool qtlint ./...` — clean.

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB