### PR TITLE
Add PostgreSQL multi-schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,17 @@ type Product struct {
 }
 ```
 
+PostgreSQL-family schemas can be set per table:
+
+```go
+//migrator:schema:table name="users" schema="auth"
+type User struct {
+    // fields...
+}
+```
+
+Migration generation emits `CREATE SCHEMA IF NOT EXISTS auth` before creating schema-qualified tables and renders references such as `auth.users`.
+
 ### Field Definition
 ```go
 //migrator:schema:field name="id" type="SERIAL" primary="true" platform.mysql.type="INT AUTO_INCREMENT"
@@ -411,6 +422,9 @@ validation rules, and examples.
 # Generate migration SQL
 ./package-migrator migrate --root-dir ./models --db-url postgres://user:pass@localhost/db
 
+# Generate migration SQL while introspecting specific PostgreSQL schemas
+./package-migrator migrate --root-dir ./models --db-url postgres://user:pass@localhost/db --schemas auth,billing,public
+
 # Apply migrations to database
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir ./migrations
 ```
@@ -443,6 +457,9 @@ Read and display the current database schema:
 
 ```bash
 ./package-migrator read-db --db-url postgres://user:pass@localhost:5432/database
+
+# Restrict PostgreSQL introspection to specific schemas
+./package-migrator read-db --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
 
 **Output:** Complete schema information including tables, columns, constraints, indexes, and enums
@@ -452,6 +469,7 @@ Compare your Go entities with the current database schema:
 
 ```bash
 ./package-migrator compare --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
+./package-migrator compare --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
 
 **Output:** Detailed differences showing what needs to be added, removed, or modified
@@ -461,6 +479,7 @@ Check whether the live database still matches the schema declared by Go entities
 
 ```bash
 ./package-migrator drift --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
+./package-migrator drift --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
 
 Exit codes are designed for scheduled CI checks:
@@ -543,6 +562,7 @@ Generate SQL migration statements to synchronize schemas:
 
 ```bash
 ./package-migrator migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
+./package-migrator migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
 
 **Output:** SQL statements to bring the database in sync with Go entities
@@ -589,6 +609,9 @@ Apply all pending migrations to bring database up to latest version:
 
 # Dry run to preview what would be applied
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dry-run
+
+# Store migration state in a dedicated schema/table
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
 ```
 
 Migration files can override the CLI defaults with top-of-file directives:
@@ -604,7 +627,7 @@ PostgreSQL uses `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` insid
 - ✅ Applies migrations in correct order based on version numbers
 - ✅ Each migration runs in its own transaction
 - ✅ Automatic rollback on failure
-- ✅ Tracks applied migrations in `schema_migrations` table
+- ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
 - ✅ Supports dry-run mode for preview
 - ✅ Supports per-migration lock and statement timeout directives
 - ✅ Online DDL for large MySQL/MariaDB tables via gh-ost / pt-online-schema-change
@@ -637,6 +660,9 @@ Roll back migrations to a specific version:
 
 # Dry run to preview rollback
 ./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --dry-run
+
+# Roll back using the same custom migration state table
+./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --migrations-schema infra --migrations-table ptah_migrations
 ```
 
 **Features:**
@@ -653,6 +679,9 @@ Show current migration status and pending migrations:
 
 # JSON output for automation
 ./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --json
+
+# Check status from a custom migration state table
+./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
 ```
 
 **Output includes:**
@@ -683,6 +712,7 @@ func main() {
         DatabaseURL:   "postgres://user:pass@localhost:5432/database",
         MigrationName: "add_user_table",
         OutputDir:     "./migrations",
+        Schemas:       []string{"auth", "billing", "public"},
     }
 
     ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -42,6 +42,7 @@ var compareFlags = map[string]cobraflags.Flag{
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
 
 func NewCompareCommand() *cobra.Command {
@@ -86,7 +87,8 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	dbSchema, err := conn.Reader().ReadSchema()
+	schemas := dbcli.ParseSchemas(compareFlags[dbcli.SchemasFlagName].GetString())
+	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading database schema: %w", err)
 	}

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -37,6 +37,7 @@ func NewDriftCommand() *cobra.Command {
 	var ignored []string
 	var useExitCode bool
 	var connectTimeoutRaw string
+	var schemasRaw string
 
 	cmd := &cobra.Command{
 		Use:           "drift",
@@ -52,6 +53,7 @@ func NewDriftCommand() *cobra.Command {
 				ignored:           ignored,
 				useExitCode:       useExitCode,
 				connectTimeoutRaw: connectTimeoutRaw,
+				schemasRaw:        schemasRaw,
 			})
 		},
 	}
@@ -60,7 +62,8 @@ func NewDriftCommand() *cobra.Command {
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
 	cmd.Flags().StringVar(&severity, "severity", severityAll, "Failing drift threshold: all or destructive")
-	cmd.Flags().StringArrayVar(&ignored, "ignore", nil, "Ignore drift for a scope, for example tables=audit_log,sessions")
+	cmd.Flags().StringArrayVar(&ignored, "ignore", nil, "Ignore drift for a scope, for example tables=audit_log,auth.users")
+	cmd.Flags().StringVar(&schemasRaw, dbcli.SchemasFlagName, "", "Comma-separated database schemas to introspect (PostgreSQL-family only). Empty uses the connection default schema.")
 	cmd.Flags().BoolVar(&useExitCode, "exit-code", true, "Return 1 when drift exceeds --severity; errors still return 2")
 	cmd.Flags().StringVar(
 		&connectTimeoutRaw,
@@ -80,6 +83,7 @@ type runOptions struct {
 	ignored           []string
 	useExitCode       bool
 	connectTimeoutRaw string
+	schemasRaw        string
 }
 
 type driftReport struct {
@@ -115,12 +119,14 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
 	}
+	schemas := dbcli.ParseSchemas(opts.schemasRaw)
 
 	result, err := schemaops.Compare(cmd.Context(), schemaops.CompareOptions{
 		RootDir:        opts.rootDir,
 		DatabaseURL:    opts.dbURL,
 		ConnectTimeout: connectTimeout,
 		IgnoredTables:  ignoredTables,
+		Schemas:        schemas,
 	})
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -11,13 +11,22 @@ package dbcli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-extras/cobraflags"
 )
 
-// ConnectTimeoutFlagName is the CLI flag name exposed by [NewConnectTimeoutFlag].
-const ConnectTimeoutFlagName = "connect-timeout"
+const (
+	// ConnectTimeoutFlagName is the CLI flag name exposed by [NewConnectTimeoutFlag].
+	ConnectTimeoutFlagName = "connect-timeout"
+	// SchemasFlagName is the CLI flag name exposed by [NewSchemasFlag].
+	SchemasFlagName = "schemas"
+	// MigrationsSchemaFlagName is the CLI flag name for the schema_migrations schema.
+	MigrationsSchemaFlagName = "migrations-schema"
+	// MigrationsTableFlagName is the CLI flag name for the schema_migrations table name.
+	MigrationsTableFlagName = "migrations-table"
+)
 
 // DefaultConnectTimeout is the default value for [ConnectTimeoutFlagName]. It
 // matches the value suggested by issue #139.
@@ -33,6 +42,52 @@ func NewConnectTimeoutFlag() cobraflags.Flag {
 		Value: DefaultConnectTimeout.String(),
 		Usage: "Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
 	}
+}
+
+// NewSchemasFlag returns a comma-separated schema allow-list flag.
+func NewSchemasFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  SchemasFlagName,
+		Value: "",
+		Usage: "Comma-separated database schemas to introspect (PostgreSQL-family only). Empty uses the connection default schema.",
+	}
+}
+
+// NewMigrationsSchemaFlag returns the migration tracking table schema flag.
+func NewMigrationsSchemaFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  MigrationsSchemaFlagName,
+		Value: "",
+		Usage: "Schema for Ptah's migration tracking table. Empty uses the connection default schema.",
+	}
+}
+
+// NewMigrationsTableFlag returns the migration tracking table name flag.
+func NewMigrationsTableFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  MigrationsTableFlagName,
+		Value: "schema_migrations",
+		Usage: "Table name for Ptah's migration tracking table.",
+	}
+}
+
+// ParseSchemas parses a comma-separated schema allow-list.
+func ParseSchemas(raw string) []string {
+	parts := strings.Split(raw, ",")
+	schemas := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		schema := strings.TrimSpace(part)
+		if schema == "" {
+			continue
+		}
+		if _, ok := seen[schema]; ok {
+			continue
+		}
+		seen[schema] = struct{}{}
+		schemas = append(schemas, schema)
+	}
+	return schemas
 }
 
 // ParseConnectTimeout parses the raw string value returned by the

--- a/cmd/internal/schemaops/schemaops.go
+++ b/cmd/internal/schemaops/schemaops.go
@@ -23,6 +23,7 @@ type CompareOptions struct {
 	DatabaseURL    string
 	ConnectTimeout time.Duration
 	IgnoredTables  []string
+	Schemas        []string
 }
 
 // CompareResult is the output of a live schema comparison.
@@ -63,7 +64,7 @@ func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	dbSchema, err := conn.Reader().ReadSchema()
+	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, opts.Schemas)
 	if err != nil {
 		return nil, fmt.Errorf("error reading database schema: %w", err)
 	}
@@ -101,7 +102,7 @@ func FilterGeneratedTables(db *goschema.Database, ignoredTables []string) *gosch
 	filtered := *db
 	ignoredStructs := make(map[string]struct{})
 	filtered.Tables = keep(db.Tables, func(table goschema.Table) bool {
-		if _, ignore := ignored[table.Name]; ignore {
+		if isIgnoredTable(ignored, table.QualifiedName(), table.Name) {
 			ignoredStructs[table.StructName] = struct{}{}
 			return false
 		}
@@ -120,8 +121,7 @@ func FilterGeneratedTables(db *goschema.Database, ignoredTables []string) *gosch
 			return false
 		}
 		if index.TableName != "" {
-			_, ignore := ignored[index.TableName]
-			return !ignore
+			return !isIgnoredTable(ignored, index.TableName)
 		}
 		return true
 	})
@@ -130,8 +130,7 @@ func FilterGeneratedTables(db *goschema.Database, ignoredTables []string) *gosch
 			return false
 		}
 		if constraint.Table != "" {
-			_, ignore := ignored[constraint.Table]
-			return !ignore
+			return !isIgnoredTable(ignored, constraint.Table)
 		}
 		return true
 	})
@@ -140,12 +139,10 @@ func FilterGeneratedTables(db *goschema.Database, ignoredTables []string) *gosch
 		return !ignore
 	})
 	filtered.RLSPolicies = keep(db.RLSPolicies, func(policy goschema.RLSPolicy) bool {
-		_, ignore := ignored[policy.Table]
-		return !ignore
+		return !isIgnoredTable(ignored, policy.Table)
 	})
 	filtered.RLSEnabledTables = keep(db.RLSEnabledTables, func(table goschema.RLSEnabledTable) bool {
-		_, ignore := ignored[table.Table]
-		return !ignore
+		return !isIgnoredTable(ignored, table.Table)
 	})
 	filtered.Dependencies = filterDependencies(db.Dependencies, ignored)
 	filtered.SelfReferencingForeignKeys = filterSelfReferencingForeignKeys(db.SelfReferencingForeignKeys, ignored)
@@ -168,23 +165,20 @@ func FilterDatabaseTables(db *dbschematypes.DBSchema, ignoredTables []string) *d
 	filtered := *db
 	ignoredEnumRefs := make(map[string]struct{})
 	filtered.Tables = keep(db.Tables, func(table dbschematypes.DBTable) bool {
-		_, ignore := ignored[table.Name]
+		ignore := isIgnoredTable(ignored, table.QualifiedName(), table.Name)
 		if ignore {
 			addDatabaseEnumRefs(ignoredEnumRefs, table.Columns)
 		}
 		return !ignore
 	})
 	filtered.Indexes = keep(db.Indexes, func(index dbschematypes.DBIndex) bool {
-		_, ignore := ignored[index.TableName]
-		return !ignore
+		return !isIgnoredTable(ignored, index.QualifiedTableName(), index.TableName)
 	})
 	filtered.Constraints = keep(db.Constraints, func(constraint dbschematypes.DBConstraint) bool {
-		_, ignore := ignored[constraint.TableName]
-		return !ignore
+		return !isIgnoredTable(ignored, constraint.QualifiedTableName(), constraint.TableName)
 	})
 	filtered.RLSPolicies = keep(db.RLSPolicies, func(policy dbschematypes.DBRLSPolicy) bool {
-		_, ignore := ignored[policy.Table]
-		return !ignore
+		return !isIgnoredTable(ignored, policy.Table)
 	})
 	filtered.Enums = keepDatabaseEnums(db.Enums, filtered.Tables, ignoredEnumRefs)
 
@@ -200,6 +194,24 @@ func tableSet(names []string) map[string]struct{} {
 		}
 	}
 	return set
+}
+
+func isIgnoredTable(ignored map[string]struct{}, names ...string) bool {
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := ignored[name]; ok {
+			return true
+		}
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			if _, ok := ignored[name[idx+1:]]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func keep[T any](items []T, shouldKeep func(T) bool) []T {
@@ -218,12 +230,11 @@ func filterDependencies(in map[string][]string, ignored map[string]struct{}) map
 	}
 	out := make(map[string][]string, len(in))
 	for table, deps := range in {
-		if _, ignore := ignored[table]; ignore {
+		if isIgnoredTable(ignored, table) {
 			continue
 		}
 		out[table] = keep(deps, func(dep string) bool {
-			_, ignore := ignored[dep]
-			return !ignore
+			return !isIgnoredTable(ignored, dep)
 		})
 	}
 	return out
@@ -238,7 +249,7 @@ func filterSelfReferencingForeignKeys(
 	}
 	out := make(map[string][]goschema.SelfReferencingFK, len(in))
 	for table, refs := range in {
-		if _, ignore := ignored[table]; ignore {
+		if isIgnoredTable(ignored, table) {
 			continue
 		}
 		out[table] = refs

--- a/cmd/internal/schemaops/schemaops_test.go
+++ b/cmd/internal/schemaops/schemaops_test.go
@@ -52,6 +52,58 @@ func TestFilterGeneratedTables_RemovesTableScopedObjects(t *testing.T) {
 	c.Assert(filtered.Dependencies, qt.DeepEquals, map[string][]string{"users": {}})
 }
 
+func TestFilterGeneratedTables_RemovesSchemaQualifiedTableScopedObjects(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Schema: "auth", Name: "users"},
+			{StructName: "Invoice", Schema: "billing", Name: "invoices"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "status", Type: "enum_user_status"},
+			{StructName: "Invoice", Name: "id", Type: "INTEGER"},
+		},
+		Indexes: []goschema.Index{
+			{StructName: "User", Name: "idx_users_status", TableName: "auth.users"},
+			{StructName: "Invoice", Name: "idx_invoices_id", TableName: "billing.invoices"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "User", Name: "users_status_check", Table: "auth.users"},
+			{StructName: "Invoice", Name: "invoices_id_check", Table: "billing.invoices"},
+		},
+		Enums: []goschema.Enum{
+			{Name: "enum_user_status", Values: []string{"active"}},
+			{Name: "orphan_enum", Values: []string{"kept"}},
+		},
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "auth.users"},
+			{Table: "billing.invoices"},
+		},
+		Dependencies: map[string][]string{
+			"auth.users":       {"billing.invoices"},
+			"billing.invoices": {"auth.users"},
+		},
+		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{
+			"auth.users":       {{FieldName: "parent_id"}},
+			"billing.invoices": {{FieldName: "parent_id"}},
+		},
+	}
+
+	filtered := schemaops.FilterGeneratedTables(db, []string{"auth.users"})
+
+	c.Assert(filtered.Tables, qt.DeepEquals, []goschema.Table{{StructName: "Invoice", Schema: "billing", Name: "invoices"}})
+	c.Assert(filtered.Fields, qt.DeepEquals, []goschema.Field{{StructName: "Invoice", Name: "id", Type: "INTEGER"}})
+	c.Assert(filtered.Indexes, qt.DeepEquals, []goschema.Index{{StructName: "Invoice", Name: "idx_invoices_id", TableName: "billing.invoices"}})
+	c.Assert(filtered.Constraints, qt.DeepEquals, []goschema.Constraint{{StructName: "Invoice", Name: "invoices_id_check", Table: "billing.invoices"}})
+	c.Assert(filtered.Enums, qt.DeepEquals, []goschema.Enum{{Name: "orphan_enum", Values: []string{"kept"}}})
+	c.Assert(filtered.RLSEnabledTables, qt.DeepEquals, []goschema.RLSEnabledTable{{Table: "billing.invoices"}})
+	c.Assert(filtered.Dependencies, qt.DeepEquals, map[string][]string{"billing.invoices": {}})
+	c.Assert(filtered.SelfReferencingForeignKeys, qt.DeepEquals, map[string][]goschema.SelfReferencingFK{
+		"billing.invoices": {{FieldName: "parent_id"}},
+	})
+}
+
 func TestFilterDatabaseTables_RemovesOnlyIgnoredTableEnums(t *testing.T) {
 	c := qt.New(t)
 
@@ -95,6 +147,63 @@ func TestFilterDatabaseTables_RemovesOnlyIgnoredTableEnums(t *testing.T) {
 	c.Assert(filtered.RLSPolicies, qt.HasLen, 0)
 	c.Assert(filtered.Enums, qt.DeepEquals, []dbschematypes.DBEnum{
 		{Name: "enum_user_status", Values: []string{"active"}},
+		{Name: "orphan_enum", Values: []string{"kept"}},
+	})
+}
+
+func TestFilterDatabaseTables_RemovesSchemaQualifiedTableScopedObjects(t *testing.T) {
+	c := qt.New(t)
+
+	db := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Schema: "auth",
+				Name:   "users",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "status", DataType: "USER-DEFINED", UDTName: "enum_user_status"},
+				},
+			},
+			{
+				Schema: "billing",
+				Name:   "invoices",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "state", DataType: "USER-DEFINED", UDTName: "enum_invoice_state"},
+				},
+			},
+		},
+		Enums: []dbschematypes.DBEnum{
+			{Name: "enum_user_status", Values: []string{"active"}},
+			{Name: "enum_invoice_state", Values: []string{"open"}},
+			{Name: "orphan_enum", Values: []string{"kept"}},
+		},
+		Indexes: []dbschematypes.DBIndex{
+			{Name: "idx_users_status", Schema: "auth", TableName: "users"},
+			{Name: "idx_invoices_state", Schema: "billing", TableName: "invoices"},
+		},
+		Constraints: []dbschematypes.DBConstraint{
+			{Name: "users_status_check", Schema: "auth", TableName: "users"},
+			{Name: "invoices_state_check", Schema: "billing", TableName: "invoices"},
+		},
+		RLSPolicies: []dbschematypes.DBRLSPolicy{
+			{Name: "users_rls", Table: "auth.users"},
+			{Name: "invoices_rls", Table: "billing.invoices"},
+		},
+	}
+
+	filtered := schemaops.FilterDatabaseTables(db, []string{"auth.users"})
+
+	c.Assert(filtered.Tables, qt.DeepEquals, []dbschematypes.DBTable{{
+		Schema: "billing",
+		Name:   "invoices",
+		Columns: []dbschematypes.DBColumn{
+			{Name: "state", DataType: "USER-DEFINED", UDTName: "enum_invoice_state"},
+		},
+	}})
+	c.Assert(filtered.Indexes, qt.DeepEquals, []dbschematypes.DBIndex{{Name: "idx_invoices_state", Schema: "billing", TableName: "invoices"}})
+	c.Assert(filtered.Constraints, qt.DeepEquals, []dbschematypes.DBConstraint{{Name: "invoices_state_check", Schema: "billing", TableName: "invoices"}})
+	c.Assert(filtered.RLSPolicies, qt.DeepEquals, []dbschematypes.DBRLSPolicy{{Name: "invoices_rls", Table: "billing.invoices"}})
+	c.Assert(filtered.Enums, qt.DeepEquals, []dbschematypes.DBEnum{
+		{Name: "enum_invoice_state", Values: []string{"open"}},
 		{Name: "orphan_enum", Values: []string{"kept"}},
 	})
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -43,6 +43,7 @@ var migrateFlags = map[string]cobraflags.Flag{
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
 
 func NewMigrateCommand() *cobra.Command {
@@ -87,7 +88,8 @@ func migrateCommand(_ *cobra.Command, _ []string) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	dbSchema, err := conn.Reader().ReadSchema()
+	schemas := dbcli.ParseSchemas(migrateFlags[dbcli.SchemasFlagName].GetString())
+	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading database schema: %w", err)
 	}

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -83,8 +83,10 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Default per-migration statement timeout, such as 30s or 2m",
 	},
-	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
-	dbcli.ConfigFlagName:         dbcli.NewConfigFlag(),
+	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:           dbcli.NewConfigFlag(),
+	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
 }
 
 func NewMigrateDownCommand() *cobra.Command {
@@ -101,6 +103,8 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
 	lockTimeout := migrateDownFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
+	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
+	migrationsTable := migrateDownFlags[dbcli.MigrationsTableFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -171,7 +175,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithDefaultTimeouts(timeouts)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -57,7 +57,9 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Output status in JSON format",
 	},
-	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
+	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
 }
 
 func NewMigrateStatusCommand() *cobra.Command {
@@ -70,6 +72,8 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	migrationsDir := migrateStatusFlags[migrationsFlag].GetString()
 	verbose := migrateStatusFlags[verboseFlag].GetBool()
 	jsonOutput := migrateStatusFlags[jsonFlag].GetBool()
+	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
+	migrationsTable := migrateStatusFlags[dbcli.MigrationsTableFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -99,6 +103,7 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable)
 
 	// Get migration status
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migratestatus/migratestatus_test.go
+++ b/cmd/migratestatus/migratestatus_test.go
@@ -1,0 +1,22 @@
+package migratestatus_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/migratestatus"
+)
+
+func TestMigrateStatusCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migratestatus.NewMigrateStatusCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "migrate-status")
+	c.Assert(cmd.Short, qt.Contains, "Show current migration status")
+	c.Assert(cmd.Flag(dbcli.MigrationsSchemaFlagName), qt.IsNotNil)
+	c.Assert(cmd.Flag(dbcli.MigrationsTableFlagName), qt.IsNotNil)
+}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -67,8 +67,10 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Default per-migration statement timeout, such as 30s or 2m",
 	},
-	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
-	dbcli.ConfigFlagName:         dbcli.NewConfigFlag(),
+	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:           dbcli.NewConfigFlag(),
+	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
 }
 
 func NewMigrateUpCommand() *cobra.Command {
@@ -83,6 +85,8 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	verbose := migrateUpFlags[verboseFlag].GetBool()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
+	migrationsSchema := migrateUpFlags[dbcli.MigrationsSchemaFlagName].GetString()
+	migrationsTable := migrateUpFlags[dbcli.MigrationsTableFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -148,7 +152,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithDefaultTimeouts(timeouts)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -35,6 +35,7 @@ var readDBFlags = map[string]cobraflags.Flag{
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
 
 func NewReadDBCommand() *cobra.Command {
@@ -83,7 +84,8 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 
 	// Read the schema
-	schema, err := conn.Reader().ReadSchema()
+	schemas := dbcli.ParseSchemas(readDBFlags[dbcli.SchemasFlagName].GetString())
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading schema: %w", err)
 	}

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -47,6 +47,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		table := goschema.Table{
 			StructName: structName,
 			Name:       dbTable.Name,
+			Schema:     dbTable.Schema,
 			Comment:    dbTable.Comment,
 		}
 		database.Tables = append(database.Tables, table)
@@ -71,7 +72,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 
 			// Carry the field-level foreign key (reference + referential actions)
 			// so down migrations can reconstruct it with the prior action.
-			if fk, ok := fkByColumn[dbTable.Name+"."+dbColumn.Name]; ok {
+			if fk, ok := fkByColumn[dbTable.QualifiedName()+"."+dbColumn.Name]; ok {
 				field.Foreign = fk.foreign
 				field.ForeignKeyName = fk.name
 				field.OnDelete = fk.onDelete
@@ -92,6 +93,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		index := goschema.Index{
 			StructName: generateStructName(dbIndex.TableName),
 			Name:       dbIndex.Name,
+			TableName:  dbIndex.QualifiedTableName(),
 			Fields:     dbIndex.Columns,
 			Unique:     dbIndex.IsUnique,
 		}
@@ -196,7 +198,7 @@ func indexForeignKeysByColumn(dbSchema *dbschematypes.DBSchema) map[string]forei
 		if c.Type != "FOREIGN KEY" || c.ColumnName == "" || c.ForeignTable == nil {
 			continue
 		}
-		foreignTable := *c.ForeignTable
+		foreignTable := c.QualifiedForeignTableName()
 		foreignColumn := ""
 		if c.ForeignColumn != nil {
 			foreignColumn = *c.ForeignColumn
@@ -205,7 +207,7 @@ func indexForeignKeysByColumn(dbSchema *dbschematypes.DBSchema) map[string]forei
 		if foreignColumn != "" {
 			foreign = foreignTable + "(" + foreignColumn + ")"
 		}
-		result[c.TableName+"."+c.ColumnName] = foreignKeyInfo{
+		result[c.QualifiedTableName()+"."+c.ColumnName] = foreignKeyInfo{
 			name:     c.Name,
 			foreign:  foreign,
 			onDelete: derefString(c.DeleteRule),

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -516,7 +516,7 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 // Returns a fully configured *ast.CreateTableNode ready for SQL generation.
 // The node contains the table definition with all columns, constraints, and platform-specific options.
 func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.CreateTableNode {
-	createTable := ast.NewCreateTable(table.Name)
+	createTable := ast.NewCreateTable(table.QualifiedName())
 
 	newTable := applyTablePlatformOverrides(createTable, table, targetPlatform)
 
@@ -594,7 +594,7 @@ func addTableConstraints(createTable *ast.CreateTableNode, table goschema.Table,
 
 func constraintBelongsToTable(constraint goschema.Constraint, table goschema.Table) bool {
 	if constraint.Table != "" {
-		return constraint.Table == table.Name
+		return constraint.Table == table.Name || constraint.Table == table.QualifiedName()
 	}
 	return constraint.StructName == table.StructName
 }
@@ -1029,7 +1029,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 func createStructToTableMap(tables []goschema.Table) map[string]string {
 	structToTableMap := make(map[string]string)
 	for _, table := range tables {
-		structToTableMap[table.StructName] = table.Name
+		structToTableMap[table.StructName] = table.QualifiedName()
 	}
 	return structToTableMap
 }

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -282,6 +282,7 @@ func parseTableComment(comment *ast.Comment, structName string, tableDirectives 
 	*tableDirectives = append(*tableDirectives, Table{
 		StructName: structName,
 		Name:       kv["name"],
+		Schema:     kv["schema"],
 		Engine:     kv["engine"],
 		Comment:    kv["comment"],
 		PrimaryKey: strings.Split(kv["primary_key"], ","),
@@ -471,6 +472,7 @@ func parseFileAST(f *ast.File) Database {
 		Roles:            roles,
 		Dependencies:     make(map[string][]string),
 	}
+	normalizeTableScopedNames(&result)
 	buildDependencyGraph(&result)
 	return result
 }
@@ -508,17 +510,7 @@ func processFileAST(
 				continue
 			}
 
-			// Extract table name from table directive
-			if genDecl.Doc != nil {
-				for _, comment := range genDecl.Doc.List {
-					if strings.HasPrefix(comment.Text, "//migrator:schema:table") {
-						kv := parseutils.ParseKeyValueComment(comment.Text)
-						if tableName := kv["name"]; tableName != "" {
-							tableNameToStructName[tableName] = structName
-						}
-					}
-				}
-			}
+			mapTableDirectiveStructNames(genDecl.Doc, structName, tableNameToStructName)
 		}
 	}
 
@@ -541,6 +533,26 @@ func processFileAST(
 
 	// Process all file comments for RLS annotations that might not be associated with struct declarations
 	processAllFileComments(f, tableNameToStructName, rlsPolicies, rlsEnabledTables)
+}
+
+func mapTableDirectiveStructNames(doc *ast.CommentGroup, structName string, tableNameToStructName map[string]string) {
+	if doc == nil {
+		return
+	}
+	for _, comment := range doc.List {
+		if !strings.HasPrefix(comment.Text, "//migrator:schema:table") {
+			continue
+		}
+		kv := parseutils.ParseKeyValueComment(comment.Text)
+		tableName := kv["name"]
+		if tableName == "" {
+			continue
+		}
+		tableNameToStructName[tableName] = structName
+		if schemaName := kv["schema"]; schemaName != "" {
+			tableNameToStructName[QualifyTableName(schemaName, tableName)] = structName
+		}
+	}
 }
 
 // processDeclarations processes all struct declarations in the file

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -272,6 +272,78 @@ type Product struct {
 	c.Assert(database.Enums[0].Values, qt.DeepEquals, []string{"draft", "active", "discontinued"})
 }
 
+func TestParseFile_TableSchemaAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="users" schema="auth"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary
+	ID int64
+}
+`
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "user.go")
+	err := os.WriteFile(testFile, []byte(content), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	database := goschema.ParseFile(testFile)
+	c.Assert(database.Tables, qt.HasLen, 1)
+	c.Assert(database.Tables[0].Name, qt.Equals, "users")
+	c.Assert(database.Tables[0].Schema, qt.Equals, "auth")
+	c.Assert(database.Tables[0].QualifiedName(), qt.Equals, "auth.users")
+}
+
+func TestParseFile_TableLevelConstraintsUseSchemaQualifiedTables(t *testing.T) {
+	c := qt.New(t)
+
+	content := `package entities
+
+//migrator:schema:table name="accounts" schema="auth"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary
+	ID int64
+}
+
+//migrator:schema:table name="users" schema="auth"
+//migrator:schema:constraint name="users_status_check" type="CHECK" table="users" check="status <> ''"
+//migrator:schema:constraint name="users_account_fk" type="FOREIGN KEY" table="users" columns="account_id" foreign_table="accounts" foreign_column="id"
+//migrator:schema:rls:enable table="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary
+	ID int64
+	//migrator:schema:field name="account_id" type="INTEGER"
+	AccountID int64
+	//migrator:schema:field name="status" type="TEXT"
+	//migrator:schema:index name="idx_users_status" fields="status" table="users"
+	Status string
+}
+
+//migrator:schema:rls:policy name="users_rls" table="auth.users" for="ALL" using="account_id IS NOT NULL"
+`
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "user.go")
+	err := os.WriteFile(testFile, []byte(content), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	database := goschema.ParseFile(testFile)
+	c.Assert(database.Constraints, qt.HasLen, 2)
+	c.Assert(database.Constraints[0].Table, qt.Equals, "auth.users")
+	c.Assert(database.Constraints[1].Table, qt.Equals, "auth.users")
+	c.Assert(database.Constraints[1].ForeignTable, qt.Equals, "auth.accounts")
+	c.Assert(database.Indexes, qt.HasLen, 1)
+	c.Assert(database.Indexes[0].TableName, qt.Equals, "auth.users")
+	c.Assert(database.RLSEnabledTables, qt.DeepEquals, []goschema.RLSEnabledTable{
+		{StructName: "User", Table: "auth.users"},
+	})
+	c.Assert(database.RLSPolicies, qt.DeepEquals, []goschema.RLSPolicy{
+		{StructName: "User", Name: "users_rls", Table: "auth.users", PolicyFor: "ALL", UsingExpression: "account_id IS NOT NULL"},
+	})
+}
+
 func TestParsePackageRecursively(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -315,12 +315,30 @@ type Extension struct {
 type Table struct {
 	StructName string                       // Name of the Go struct this table represents
 	Name       string                       // Database table name
+	Schema     string                       // Optional database schema/namespace (PostgreSQL-style)
 	Engine     string                       // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
 	Comment    string                       // Table comment/description
 	PrimaryKey []string                     // Composite primary key column names
 	Checks     []string                     // Table-level check constraints
 	CustomSQL  string                       // Custom SQL to append to CREATE TABLE
 	Overrides  map[string]map[string]string // Platform-specific overrides
+}
+
+// QualifiedName returns the schema-qualified database table name when a schema
+// is configured, or the plain table name otherwise.
+func (t Table) QualifiedName() string {
+	return QualifyTableName(t.Schema, t.Name)
+}
+
+// QualifyTableName joins schema and table without quoting. Renderers remain
+// responsible for dialect-specific identifier escaping.
+func QualifyTableName(schema, table string) string {
+	schema = strings.TrimSpace(schema)
+	table = strings.TrimSpace(table)
+	if schema == "" {
+		return table
+	}
+	return schema + "." + table
 }
 
 // Enum represents a global enumeration type definition that can be shared across

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -76,7 +76,7 @@ func checkForCircularDependencies(r *Database, sorted *[]Table) {
 	for _, table := range r.Tables {
 		found := false
 		for _, sortedTable := range *sorted {
-			if sortedTable.Name == table.Name {
+			if sortedTable.QualifiedName() == table.QualifiedName() {
 				found = true
 				break
 			}
@@ -112,7 +112,7 @@ func sortTablesByDependencies(r *Database) {
 	// Create a map for quick table lookup
 	tableMap := make(map[string]Table)
 	for _, table := range r.Tables {
-		tableMap[table.Name] = table
+		tableMap[table.QualifiedName()] = table
 	}
 
 	// Perform topological sort using Kahn's algorithm
@@ -190,16 +190,80 @@ func Finalize(r *Database) {
 	}
 
 	Deduplicate(r)
+	normalizeTableScopedNames(r)
 	buildDependencyGraph(r)
 	sortTablesByDependencies(r)
 	sortFunctionsByDependencies(r)
+}
+
+func normalizeTableScopedNames(r *Database) {
+	if r == nil {
+		return
+	}
+	for i := range r.Constraints {
+		constraint := &r.Constraints[i]
+		table := resolveTableReference(r.Tables, constraint.StructName, constraint.Table)
+		if table == nil {
+			continue
+		}
+		constraint.Table = table.QualifiedName()
+		if constraint.ForeignTable != "" {
+			constraint.ForeignTable = resolveReferenceTableName(r.Tables, *table, constraint.ForeignTable)
+		}
+	}
+	for i := range r.Indexes {
+		index := &r.Indexes[i]
+		if table := resolveTableReference(r.Tables, index.StructName, index.TableName); table != nil {
+			index.TableName = table.QualifiedName()
+		}
+	}
+	for i := range r.RLSPolicies {
+		policy := &r.RLSPolicies[i]
+		if table := resolveTableReference(r.Tables, policy.StructName, policy.Table); table != nil {
+			policy.Table = table.QualifiedName()
+		}
+	}
+	for i := range r.RLSEnabledTables {
+		rlsEnabled := &r.RLSEnabledTables[i]
+		if table := resolveTableReference(r.Tables, rlsEnabled.StructName, rlsEnabled.Table); table != nil {
+			rlsEnabled.Table = table.QualifiedName()
+		}
+	}
+}
+
+func resolveTableReference(tables []Table, structName, tableName string) *Table {
+	tableName = strings.TrimSpace(tableName)
+	for i := range tables {
+		table := &tables[i]
+		if tableName == "" && table.StructName == structName {
+			return table
+		}
+		if tableName != "" && table.StructName == structName && (table.Name == tableName || table.QualifiedName() == tableName) {
+			return table
+		}
+	}
+	if tableName == "" || strings.Contains(tableName, ".") {
+		return nil
+	}
+	var match *Table
+	for i := range tables {
+		table := &tables[i]
+		if table.Name != tableName {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = table
+	}
+	return match
 }
 
 // initializeDependencyMaps initializes the dependency tracking maps
 func initializeDependencyMaps(r *Database) {
 	// Initialize dependencies map for all tables
 	for _, table := range r.Tables {
-		r.Dependencies[table.Name] = []string{}
+		r.Dependencies[table.QualifiedName()] = []string{}
 	}
 
 	// Initialize self-referencing foreign keys tracking
@@ -221,7 +285,7 @@ func analyzeFieldForeignKeys(r *Database) {
 			continue
 		}
 
-		processForeignKeyDependency(r, table.Name, refTable, SelfReferencingFK{
+		processForeignKeyDependency(r, *table, refTable, SelfReferencingFK{
 			FieldName:      field.Name,
 			Foreign:        field.Foreign,
 			ForeignKeyName: field.ForeignKeyName,
@@ -244,7 +308,7 @@ func analyzeEmbeddedFieldRelations(r *Database) {
 			continue
 		}
 
-		processForeignKeyDependency(r, table.Name, refTable, SelfReferencingFK{
+		processForeignKeyDependency(r, *table, refTable, SelfReferencingFK{
 			FieldName:      embedded.Field,
 			Foreign:        embedded.Ref,
 			ForeignKeyName: generateForeignKeyName(table.Name, embedded.Field),
@@ -265,7 +329,9 @@ func findTableByStructName(tables []Table, structName string) *Table {
 }
 
 // processForeignKeyDependency processes a foreign key dependency, handling self-references appropriately
-func processForeignKeyDependency(r *Database, tableName, refTable string, selfRefFK SelfReferencingFK) {
+func processForeignKeyDependency(r *Database, table Table, refTable string, selfRefFK SelfReferencingFK) {
+	tableName := table.QualifiedName()
+	refTable = resolveReferenceTableName(r.Tables, table, refTable)
 	if tableName == refTable {
 		// Track self-referencing foreign key for deferred constraint creation
 		r.SelfReferencingForeignKeys[tableName] = append(r.SelfReferencingForeignKeys[tableName], selfRefFK)
@@ -273,6 +339,31 @@ func processForeignKeyDependency(r *Database, tableName, refTable string, selfRe
 		// Add dependency: table depends on refTable (only for non-self-referencing FKs)
 		r.Dependencies[tableName] = append(r.Dependencies[tableName], refTable)
 	}
+}
+
+func resolveReferenceTableName(tables []Table, current Table, refTable string) string {
+	if strings.Contains(refTable, ".") {
+		return refTable
+	}
+	for _, table := range tables {
+		if table.Schema == current.Schema && table.Name == refTable {
+			return table.QualifiedName()
+		}
+	}
+	var match string
+	for _, table := range tables {
+		if table.Name != refTable {
+			continue
+		}
+		if match != "" {
+			return refTable
+		}
+		match = table.QualifiedName()
+	}
+	if match != "" {
+		return match
+	}
+	return refTable
 }
 
 // generateForeignKeyName generates a consistent foreign key constraint name
@@ -711,12 +802,12 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 // slices with deduplicated versions. The order of entities may change during
 // this process, but dependency ordering is handled separately.
 func Deduplicate(r *Database) {
-	// Deduplicate tables by name - preserve order
+	// Deduplicate tables by schema-qualified name - preserve order
 	tableSeen := make(map[string]bool)
 	var deduplicatedTables []Table
 	for _, table := range r.Tables {
-		if !tableSeen[table.Name] {
-			tableSeen[table.Name] = true
+		if !tableSeen[table.QualifiedName()] {
+			tableSeen[table.QualifiedName()] = true
 			deduplicatedTables = append(deduplicatedTables, table)
 		}
 	}

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -137,6 +137,7 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 
 	// deduplicate entities (same table/field defined in multiple files)
 	Deduplicate(result)
+	normalizeTableScopedNames(result)
 
 	// Process embedded fields BEFORE building dependency graph
 	// This ensures that foreign keys from embedded fields are included in dependency analysis

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -127,6 +127,22 @@ type DatabaseConnection struct {
 	writer types.SchemaWriter
 }
 
+type schemaScopedReader interface {
+	SetSchemas([]string)
+}
+
+// ReadSchemaWithSchemas reads a database schema, applying a schema allow-list
+// when the underlying dialect reader supports schema scoping.
+func ReadSchemaWithSchemas(conn *DatabaseConnection, schemas []string) (*types.DBSchema, error) {
+	reader := conn.Reader()
+	scoped, ok := reader.(schemaScopedReader)
+	if ok {
+		scoped.SetSchemas(schemas)
+		defer scoped.SetSchemas(nil)
+	}
+	return reader.ReadSchema()
+}
+
 // Info returns the database connection information
 func (dc *DatabaseConnection) Info() types.DBInfo {
 	return dc.info

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -11,9 +11,11 @@ import (
 
 // Reader reads schema from PostgreSQL databases
 type Reader struct {
-	db     *sql.DB
-	schema string
-	caps   capability.Capabilities
+	db      *sql.DB
+	schema  string
+	schemas []string
+	scoped  bool
+	caps    capability.Capabilities
 }
 
 // NewPostgreSQLReader creates a new PostgreSQL schema reader
@@ -28,10 +30,51 @@ func NewPostgreSQLReaderWithCapabilities(db *sql.DB, schema string, caps capabil
 		schema = "public"
 	}
 	return &Reader{
-		db:     db,
-		schema: schema,
-		caps:   caps,
+		db:      db,
+		schema:  schema,
+		schemas: []string{schema},
+		caps:    caps,
 	}
+}
+
+// SetSchemas restricts schema introspection to the provided allow-list.
+func (r *Reader) SetSchemas(schemas []string) {
+	r.schemas = normalizeSchemas(schemas, r.schema)
+	r.scoped = len(schemas) > 0
+}
+
+func (r *Reader) schemasToRead() []string {
+	return normalizeSchemas(r.schemas, r.schema)
+}
+
+func normalizeSchemas(schemas []string, fallback string) []string {
+	seen := make(map[string]struct{}, len(schemas)+1)
+	out := make([]string, 0, len(schemas)+1)
+	for _, schema := range schemas {
+		schema = strings.TrimSpace(schema)
+		if schema == "" {
+			continue
+		}
+		if _, ok := seen[schema]; ok {
+			continue
+		}
+		seen[schema] = struct{}{}
+		out = append(out, schema)
+	}
+	if len(out) > 0 {
+		return out
+	}
+	if fallback == "" {
+		fallback = "public"
+	}
+	return []string{fallback}
+}
+
+func (r *Reader) outputSchema(schemaName string) string {
+	if r.scoped && schemaName != r.schema {
+		return schemaName
+	}
+	return ""
 }
 
 // ReadSchema reads the complete database schema
@@ -107,18 +150,30 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 
 // readTables reads all tables and their columns
 func (r *Reader) readTables() ([]types.DBTable, error) {
+	var tables []types.DBTable
+	for _, schemaName := range r.schemasToRead() {
+		schemaTables, err := r.readTablesForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, schemaTables...)
+	}
+	return tables, nil
+}
+
+func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error) {
 	// Read tables, excluding system tables like schema_migrations
 	tablesQuery := `
-		SELECT table_name, table_type,
-		       COALESCE(obj_description(c.oid), '') as table_comment
-		FROM information_schema.tables t
-		LEFT JOIN pg_class c ON c.relname = t.table_name
+			SELECT table_schema, table_name, table_type,
+			       COALESCE(obj_description(c.oid), '') as table_comment
+			FROM information_schema.tables t
+			LEFT JOIN pg_class c ON c.relname = t.table_name
 		LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-		WHERE t.table_schema = $1 AND (n.nspname = $1 OR n.nspname IS NULL)
-		AND t.table_name NOT IN ('schema_migrations')
-		ORDER BY table_name`
+			WHERE t.table_schema = $1 AND (n.nspname = $1 OR n.nspname IS NULL)
+			AND t.table_name NOT IN ('schema_migrations')
+			ORDER BY table_schema, table_name`
 
-	rows, err := r.db.Query(tablesQuery, r.schema)
+	rows, err := r.db.Query(tablesQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tables: %w", err)
 	}
@@ -127,15 +182,16 @@ func (r *Reader) readTables() ([]types.DBTable, error) {
 	var tables []types.DBTable
 	for rows.Next() {
 		var table types.DBTable
-		err := rows.Scan(&table.Name, &table.Type, &table.Comment)
+		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
+		table.Schema = r.outputSchema(table.Schema)
 
 		// Read columns for this table
-		columns, err := r.readColumns(table.Name)
+		columns, err := r.readColumns(schemaName, table.Name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read columns for table %s: %w", table.Name, err)
+			return nil, fmt.Errorf("failed to read columns for table %s: %w", table.QualifiedName(), err)
 		}
 		table.Columns = columns
 
@@ -146,7 +202,7 @@ func (r *Reader) readTables() ([]types.DBTable, error) {
 }
 
 // readColumns reads all columns for a specific table
-func (r *Reader) readColumns(tableName string) ([]types.DBColumn, error) {
+func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, error) {
 	columnsQuery := `
 		SELECT
 			column_name,
@@ -162,7 +218,7 @@ func (r *Reader) readColumns(tableName string) ([]types.DBColumn, error) {
 		WHERE table_schema = $1 AND table_name = $2
 		ORDER BY ordinal_position`
 
-	rows, err := r.db.Query(columnsQuery, r.schema, tableName)
+	rows, err := r.db.Query(columnsQuery, schemaName, tableName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query columns: %w", err)
 	}
@@ -201,6 +257,18 @@ func (r *Reader) readColumns(tableName string) ([]types.DBColumn, error) {
 
 // readEnums reads all enum types
 func (r *Reader) readEnums() ([]types.DBEnum, error) {
+	var enums []types.DBEnum
+	for _, schemaName := range r.schemasToRead() {
+		schemaEnums, err := r.readEnumsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		enums = append(enums, schemaEnums...)
+	}
+	return enums, nil
+}
+
+func (r *Reader) readEnumsForSchema(schemaName string) ([]types.DBEnum, error) {
 	enumsQuery := `
 		SELECT
 			t.typname AS enum_name,
@@ -212,7 +280,7 @@ func (r *Reader) readEnums() ([]types.DBEnum, error) {
 		WHERE n.nspname = $1
 		ORDER BY t.typname, e.enumsortorder`
 
-	rows, err := r.db.Query(enumsQuery, r.schema)
+	rows, err := r.db.Query(enumsQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query enums: %w", err)
 	}
@@ -243,6 +311,18 @@ func (r *Reader) readEnums() ([]types.DBEnum, error) {
 
 // readIndexes reads all indexes
 func (r *Reader) readIndexes() ([]types.DBIndex, error) {
+	var indexes []types.DBIndex
+	for _, schemaName := range r.schemasToRead() {
+		schemaIndexes, err := r.readIndexesForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		indexes = append(indexes, schemaIndexes...)
+	}
+	return indexes, nil
+}
+
+func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error) {
 	indexesQuery := `
 		SELECT
 			n.nspname as schemaname,
@@ -259,7 +339,7 @@ func (r *Reader) readIndexes() ([]types.DBIndex, error) {
 		AND t.relname NOT IN ('schema_migrations')
 		ORDER BY t.relname, i.relname`
 
-	rows, err := r.db.Query(indexesQuery, r.schema)
+	rows, err := r.db.Query(indexesQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query indexes: %w", err)
 	}
@@ -278,6 +358,7 @@ func (r *Reader) readIndexes() ([]types.DBIndex, error) {
 		index := types.DBIndex{
 			Name:       indexName,
 			TableName:  tableName,
+			Schema:     r.outputSchema(schemaName),
 			Definition: indexDef,
 			IsUnique:   isUnique,
 			IsPrimary:  isPrimary,
@@ -325,15 +406,29 @@ func (r *Reader) readConstraints() ([]types.DBConstraint, error) {
 
 // readBasicConstraints reads basic constraint information from information_schema
 func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
+	var constraints []types.DBConstraint
+	for _, schemaName := range r.schemasToRead() {
+		schemaConstraints, err := r.readBasicConstraintsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, schemaConstraints...)
+	}
+	return constraints, nil
+}
+
+func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBConstraint, error) {
 	constraintsQuery := `
-		SELECT
-			tc.table_name,
-			tc.constraint_name,
-			tc.constraint_type,
-			COALESCE(kcu.column_name, ''),
-			COALESCE(ccu.table_name, ''),
-			COALESCE(ccu.column_name, ''),
-			COALESCE(rc.delete_rule, ''),
+			SELECT
+				tc.table_schema,
+				tc.table_name,
+				tc.constraint_name,
+				tc.constraint_type,
+				COALESCE(kcu.column_name, ''),
+				COALESCE(ccu.table_schema, ''),
+				COALESCE(ccu.table_name, ''),
+				COALESCE(ccu.column_name, ''),
+				COALESCE(rc.delete_rule, ''),
 			COALESCE(rc.update_rule, ''),
 			COALESCE(cc.check_clause, '')
 		FROM information_schema.table_constraints AS tc
@@ -341,9 +436,9 @@ func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
 			ON tc.constraint_name = kcu.constraint_name
 			AND tc.table_schema = kcu.table_schema
 			AND tc.table_name = kcu.table_name
-		LEFT JOIN information_schema.constraint_column_usage AS ccu
-			ON ccu.constraint_name = tc.constraint_name
-			AND ccu.table_schema = tc.table_schema
+			LEFT JOIN information_schema.constraint_column_usage AS ccu
+				ON ccu.constraint_name = tc.constraint_name
+				AND ccu.constraint_schema = tc.constraint_schema
 		LEFT JOIN information_schema.referential_constraints AS rc
 			ON tc.constraint_name = rc.constraint_name
 			AND tc.table_schema = rc.constraint_schema
@@ -354,7 +449,7 @@ func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
 		AND tc.table_name NOT IN ('schema_migrations')
 		ORDER BY tc.table_name, tc.constraint_type, tc.constraint_name`
 
-	rows, err := r.db.Query(constraintsQuery, r.schema)
+	rows, err := r.db.Query(constraintsQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query constraints: %w", err)
 	}
@@ -363,13 +458,15 @@ func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
 	var constraints []types.DBConstraint
 	for rows.Next() {
 		var constraint types.DBConstraint
-		var foreignTable, foreignColumn, deleteRule, updateRule, checkClause string
+		var foreignSchema, foreignTable, foreignColumn, deleteRule, updateRule, checkClause string
 
 		err := rows.Scan(
+			&constraint.Schema,
 			&constraint.TableName,
 			&constraint.Name,
 			&constraint.Type,
 			&constraint.ColumnName,
+			&foreignSchema,
 			&foreignTable,
 			&foreignColumn,
 			&deleteRule,
@@ -384,6 +481,8 @@ func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
 		if foreignTable != "" {
 			constraint.ForeignTable = &foreignTable
 		}
+		constraint.Schema = r.outputSchema(constraint.Schema)
+		constraint.ForeignSchema = r.outputSchema(foreignSchema)
 		if foreignColumn != "" {
 			constraint.ForeignColumn = &foreignColumn
 		}
@@ -405,12 +504,25 @@ func (r *Reader) readBasicConstraints() ([]types.DBConstraint, error) {
 
 // readPostgreSQLConstraints reads PostgreSQL-specific constraints from pg_constraint
 func (r *Reader) readPostgreSQLConstraints() ([]types.DBConstraint, error) {
+	var constraints []types.DBConstraint
+	for _, schemaName := range r.schemasToRead() {
+		schemaConstraints, err := r.readPostgreSQLConstraintsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, schemaConstraints...)
+	}
+	return constraints, nil
+}
+
+func (r *Reader) readPostgreSQLConstraintsForSchema(schemaName string) ([]types.DBConstraint, error) {
 	// Query PostgreSQL system catalogs for PostgreSQL-specific constraints
 	pgQuery := `
-		SELECT
-			c.conname AS constraint_name,
-			cl.relname AS table_name,
-			c.contype AS constraint_type,
+			SELECT
+				n.nspname AS schema_name,
+				c.conname AS constraint_name,
+				cl.relname AS table_name,
+				c.contype AS constraint_type,
 			pg_get_constraintdef(c.oid) AS constraint_definition
 		FROM pg_constraint c
 		JOIN pg_class cl ON c.conrelid = cl.oid
@@ -420,7 +532,7 @@ func (r *Reader) readPostgreSQLConstraints() ([]types.DBConstraint, error) {
 		AND cl.relname NOT IN ('schema_migrations')
 		ORDER BY cl.relname, c.conname`
 
-	rows, err := r.db.Query(pgQuery, r.schema)
+	rows, err := r.db.Query(pgQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query PostgreSQL constraints: %w", err)
 	}
@@ -428,8 +540,8 @@ func (r *Reader) readPostgreSQLConstraints() ([]types.DBConstraint, error) {
 
 	var constraints []types.DBConstraint
 	for rows.Next() {
-		var constraintName, tableName, constraintType, definition string
-		err := rows.Scan(&constraintName, &tableName, &constraintType, &definition)
+		var schemaName, constraintName, tableName, constraintType, definition string
+		err := rows.Scan(&schemaName, &constraintName, &tableName, &constraintType, &definition)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan PostgreSQL constraint: %w", err)
 		}
@@ -446,6 +558,7 @@ func (r *Reader) readPostgreSQLConstraints() ([]types.DBConstraint, error) {
 		constraint := types.DBConstraint{
 			Name:      constraintName,
 			TableName: tableName,
+			Schema:    r.outputSchema(schemaName),
 			Type:      stdType,
 		}
 
@@ -607,25 +720,26 @@ func (r *Reader) enhanceTablesWithConstraints(tables []types.DBTable, constraint
 	uniqueKeys := make(map[string]map[string]bool)
 
 	for _, constraint := range constraints {
+		tableName := constraint.QualifiedTableName()
 		if constraint.Type == "PRIMARY KEY" {
-			if primaryKeys[constraint.TableName] == nil {
-				primaryKeys[constraint.TableName] = make(map[string]bool)
+			if primaryKeys[tableName] == nil {
+				primaryKeys[tableName] = make(map[string]bool)
 			}
-			primaryKeys[constraint.TableName][constraint.ColumnName] = true
+			primaryKeys[tableName][constraint.ColumnName] = true
 		}
 		if constraint.Type == "UNIQUE" {
-			if uniqueKeys[constraint.TableName] == nil {
-				uniqueKeys[constraint.TableName] = make(map[string]bool)
+			if uniqueKeys[tableName] == nil {
+				uniqueKeys[tableName] = make(map[string]bool)
 			}
-			uniqueKeys[constraint.TableName][constraint.ColumnName] = true
+			uniqueKeys[tableName][constraint.ColumnName] = true
 		}
 	}
 
 	// Update table columns with constraint information
 	for i := range tables {
 		for j := range tables[i].Columns {
-			col := &tables[i].Columns[j] //nolint:gosec // G602: index bounded by `range tables[i].Columns`
-			tableName := tables[i].Name  //nolint:gosec // G602: index bounded by `range tables`
+			col := &tables[i].Columns[j]           //nolint:gosec // G602: index bounded by `range tables[i].Columns`
+			tableName := tables[i].QualifiedName() //nolint:gosec // G602: index bounded by `range tables`
 
 			if primaryKeys[tableName] != nil && primaryKeys[tableName][col.Name] {
 				col.IsPrimaryKey = true
@@ -671,6 +785,18 @@ func (r *Reader) enhanceTablesWithIndexes(tables []types.DBTable, indexes []type
 // This approach is more robust than maintaining a manual list of problematic
 // extensions because it automatically handles any extension that creates functions.
 func (r *Reader) readFunctions() ([]types.DBFunction, error) {
+	var functions []types.DBFunction
+	for _, schemaName := range r.schemasToRead() {
+		schemaFunctions, err := r.readFunctionsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		functions = append(functions, schemaFunctions...)
+	}
+	return functions, nil
+}
+
+func (r *Reader) readFunctionsForSchema(schemaName string) ([]types.DBFunction, error) {
 	functionsQuery := `
 		SELECT
 			p.proname AS function_name,
@@ -700,7 +826,7 @@ func (r *Reader) readFunctions() ([]types.DBFunction, error) {
 		)
 		ORDER BY p.proname`
 
-	rows, err := r.db.Query(functionsQuery, r.schema)
+	rows, err := r.db.Query(functionsQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query functions: %w", err)
 	}
@@ -731,8 +857,21 @@ func (r *Reader) readFunctions() ([]types.DBFunction, error) {
 
 // readRLSPolicies reads all PostgreSQL RLS policies from the database
 func (r *Reader) readRLSPolicies() ([]types.DBRLSPolicy, error) {
+	var policies []types.DBRLSPolicy
+	for _, schemaName := range r.schemasToRead() {
+		schemaPolicies, err := r.readRLSPoliciesForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		policies = append(policies, schemaPolicies...)
+	}
+	return policies, nil
+}
+
+func (r *Reader) readRLSPoliciesForSchema(schemaName string) ([]types.DBRLSPolicy, error) {
 	rlsPoliciesQuery := `
 		SELECT
+			n.nspname AS schema_name,
 			pol.polname AS policy_name,
 			c.relname AS table_name,
 			CASE pol.polcmd
@@ -757,7 +896,7 @@ func (r *Reader) readRLSPolicies() ([]types.DBRLSPolicy, error) {
 		WHERE n.nspname = $1
 		ORDER BY c.relname, pol.polname`
 
-	rows, err := r.db.Query(rlsPoliciesQuery, r.schema)
+	rows, err := r.db.Query(rlsPoliciesQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query RLS policies: %w", err)
 	}
@@ -766,7 +905,9 @@ func (r *Reader) readRLSPolicies() ([]types.DBRLSPolicy, error) {
 	var policies []types.DBRLSPolicy
 	for rows.Next() {
 		var policy types.DBRLSPolicy
+		var schemaName string
 		err := rows.Scan(
+			&schemaName,
 			&policy.Name,
 			&policy.Table,
 			&policy.PolicyFor,
@@ -778,6 +919,7 @@ func (r *Reader) readRLSPolicies() ([]types.DBRLSPolicy, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan RLS policy: %w", err)
 		}
+		policy.Table = types.QualifyTableName(r.outputSchema(schemaName), policy.Table)
 
 		policies = append(policies, policy)
 	}

--- a/dbschema/schema_scope_test.go
+++ b/dbschema/schema_scope_test.go
@@ -1,0 +1,38 @@
+package dbschema
+
+import (
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+)
+
+type scopedReaderStub struct {
+	scopes [][]string
+}
+
+func (r *scopedReaderStub) SetSchemas(schemas []string) {
+	r.scopes = append(r.scopes, slices.Clone(schemas))
+}
+
+func (r *scopedReaderStub) ReadSchema() (*dbschematypes.DBSchema, error) {
+	return &dbschematypes.DBSchema{}, nil
+}
+
+func TestReadSchemaWithSchemas_ResetsScopedReader(t *testing.T) {
+	c := qt.New(t)
+
+	reader := &scopedReaderStub{}
+	conn := &DatabaseConnection{reader: reader}
+
+	schema, err := ReadSchemaWithSchemas(conn, []string{"auth", "billing"})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(schema, qt.IsNotNil)
+	c.Assert(reader.scopes, qt.DeepEquals, [][]string{
+		{"auth", "billing"},
+		nil,
+	})
+}

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // DBSchema represents the complete schema read from a database
 type DBSchema struct {
@@ -17,10 +20,27 @@ type DBSchema struct {
 // DBTable represents a database table
 type DBTable struct {
 	Name       string     `json:"name"`
+	Schema     string     `json:"schema,omitempty"`
 	Type       string     `json:"type"` // TABLE, VIEW, etc.
 	Comment    string     `json:"comment"`
 	Columns    []DBColumn `json:"columns"`
 	RLSEnabled bool       `json:"rls_enabled"` // Whether RLS is enabled on this table (PostgreSQL)
+}
+
+// QualifiedName returns schema.table when Schema is set, or Name otherwise.
+func (t DBTable) QualifiedName() string {
+	return QualifyTableName(t.Schema, t.Name)
+}
+
+// QualifyTableName joins schema and table without quoting. Dialect renderers
+// remain responsible for escaping identifiers.
+func QualifyTableName(schema, table string) string {
+	schema = strings.TrimSpace(schema)
+	table = strings.TrimSpace(table)
+	if schema == "" {
+		return table
+	}
+	return schema + "." + table
 }
 
 // DBColumn represents a database column.
@@ -73,6 +93,7 @@ type DBEnum struct {
 type DBIndex struct {
 	Name       string   `json:"name"`
 	TableName  string   `json:"table_name"`
+	Schema     string   `json:"schema,omitempty"`
 	Columns    []string `json:"columns"`
 	IsUnique   bool     `json:"is_unique"`
 	IsPrimary  bool     `json:"is_primary"`
@@ -94,13 +115,20 @@ type DBIndex struct {
 	Granularity int `json:"granularity,omitempty"`
 }
 
+// QualifiedTableName returns schema.table when Schema is set, or TableName otherwise.
+func (i DBIndex) QualifiedTableName() string {
+	return QualifyTableName(i.Schema, i.TableName)
+}
+
 // DBConstraint represents a database constraint
 type DBConstraint struct {
 	Name          string  `json:"name"`
 	TableName     string  `json:"table_name"`
+	Schema        string  `json:"schema,omitempty"`
 	Type          string  `json:"type"` // PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK, EXCLUDE
 	ColumnName    string  `json:"column_name"`
-	ForeignTable  *string `json:"foreign_table"`  // For foreign keys
+	ForeignTable  *string `json:"foreign_table"` // For foreign keys
+	ForeignSchema string  `json:"foreign_schema,omitempty"`
 	ForeignColumn *string `json:"foreign_column"` // For foreign keys
 	DeleteRule    *string `json:"delete_rule"`    // CASCADE, RESTRICT, etc.
 	UpdateRule    *string `json:"update_rule"`    // CASCADE, RESTRICT, etc.
@@ -109,6 +137,19 @@ type DBConstraint struct {
 	UsingMethod     *string `json:"using_method"`     // Index method: gist, btree, etc.
 	ExcludeElements *string `json:"exclude_elements"` // Elements with operators: "room_id WITH =, during WITH &&"
 	WhereCondition  *string `json:"where_condition"`  // Optional WHERE clause for EXCLUDE constraints
+}
+
+// QualifiedTableName returns schema.table when Schema is set, or TableName otherwise.
+func (c DBConstraint) QualifiedTableName() string {
+	return QualifyTableName(c.Schema, c.TableName)
+}
+
+// QualifiedForeignTableName returns schema.table for a foreign key target.
+func (c DBConstraint) QualifiedForeignTableName() string {
+	if c.ForeignTable == nil {
+		return ""
+	}
+	return QualifyTableName(c.ForeignSchema, *c.ForeignTable)
 }
 
 // DBExtension represents a PostgreSQL extension installed in the database

--- a/integration/gonative/multi_schema_postgres_test.go
+++ b/integration/gonative/multi_schema_postgres_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPostgreSQLMultiSchemaGenerateApplyReadDiffIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupMultiSchemaIntegration(t, db)
+	defer cleanupMultiSchemaIntegration(t, db)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Account", Name: "ptah_ms_accounts"},
+			{StructName: "User", Name: "ptah_ms_users", Schema: "ptah_ms_auth"},
+			{StructName: "Invoice", Name: "ptah_ms_invoices", Schema: "ptah_ms_billing"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Account", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "user_id", Type: "INTEGER", Foreign: "ptah_ms_auth.ptah_ms_users(id)"},
+			{StructName: "Invoice", Name: "account_id", Type: "INTEGER", Foreign: "ptah_ms_accounts(id)"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "ptah_ms_users_visible", Table: "ptah_ms_auth.ptah_ms_users", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "id IS NOT NULL"},
+		},
+		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{},
+	}
+
+	diff := &difftypes.SchemaDiff{
+		TablesAdded:      []string{"ptah_ms_accounts", "ptah_ms_auth.ptah_ms_users", "ptah_ms_billing.ptah_ms_invoices"},
+		RLSPoliciesAdded: []string{"ptah_ms_users_visible"},
+	}
+	nodes := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+	migrationSQL, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationSQL, qt.Contains, "CREATE SCHEMA IF NOT EXISTS ptah_ms_auth;")
+	c.Assert(migrationSQL, qt.Contains, "CREATE SCHEMA IF NOT EXISTS ptah_ms_billing;")
+	c.Assert(migrationSQL, qt.Contains, "REFERENCES ptah_ms_auth.ptah_ms_users(id);")
+
+	for _, stmt := range migrator.SplitSQLStatements(migrationSQL) {
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", stmt))
+	}
+
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dsn)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	live, err := dbschema.ReadSchemaWithSchemas(conn, []string{"ptah_ms_auth", "ptah_ms_billing", "public"})
+	c.Assert(err, qt.IsNil)
+	live = filterMultiSchemaIntegrationTables(live)
+
+	roundTripDiff := schemadiff.CompareWithDialect(generated, live, "postgres")
+	c.Assert(roundTripDiff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", roundTripDiff))
+}
+
+func cleanupMultiSchemaIntegration(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, _ = db.Exec("DROP SCHEMA IF EXISTS ptah_ms_billing CASCADE")
+	_, _ = db.Exec("DROP SCHEMA IF EXISTS ptah_ms_auth CASCADE")
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_ms_accounts CASCADE")
+}
+
+func filterMultiSchemaIntegrationTables(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	keepTables := map[string]struct{}{
+		"ptah_ms_accounts":                 {},
+		"ptah_ms_auth.ptah_ms_users":       {},
+		"ptah_ms_billing.ptah_ms_invoices": {},
+	}
+	out := *in
+	out.Tables = filterTables(in.Tables, keepTables)
+	out.Indexes = filterIndexes(in.Indexes, keepTables)
+	out.Constraints = filterConstraints(in.Constraints, keepTables)
+	out.RLSPolicies = filterRLSPolicies(in.RLSPolicies, keepTables)
+	return &out
+}
+
+func filterTables(in []dbschematypes.DBTable, keep map[string]struct{}) []dbschematypes.DBTable {
+	out := make([]dbschematypes.DBTable, 0, len(in))
+	for _, table := range in {
+		if _, ok := keep[table.QualifiedName()]; ok {
+			out = append(out, table)
+		}
+	}
+	return out
+}
+
+func filterIndexes(in []dbschematypes.DBIndex, keep map[string]struct{}) []dbschematypes.DBIndex {
+	out := make([]dbschematypes.DBIndex, 0, len(in))
+	for _, index := range in {
+		if _, ok := keep[index.QualifiedTableName()]; ok {
+			out = append(out, index)
+		}
+	}
+	return out
+}
+
+func filterConstraints(in []dbschematypes.DBConstraint, keep map[string]struct{}) []dbschematypes.DBConstraint {
+	out := make([]dbschematypes.DBConstraint, 0, len(in))
+	for _, constraint := range in {
+		if _, ok := keep[constraint.QualifiedTableName()]; ok {
+			out = append(out, constraint)
+		}
+	}
+	return out
+}
+
+func filterRLSPolicies(in []dbschematypes.DBRLSPolicy, keep map[string]struct{}) []dbschematypes.DBRLSPolicy {
+	out := make([]dbschematypes.DBRLSPolicy, 0, len(in))
+	for _, policy := range in {
+		if _, ok := keep[policy.Table]; ok {
+			out = append(out, policy)
+		}
+	}
+	return out
+}

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -7,6 +7,7 @@ The migration generator package provides functionality to automatically generate
 - **Automatic Schema Comparison**: Compares Go entity definitions with current database schema
 - **Bidirectional Migrations**: Generates both UP and DOWN migration files
 - **Multiple Database Support**: Works with PostgreSQL, MySQL, and MariaDB
+- **Schema-Scoped Introspection**: Restricts PostgreSQL reads to selected schemas
 - **Proper File Naming**: Uses timestamp-based naming convention for migration files
 - **Embedded Field Support**: Handles embedded structs in Go entities
 
@@ -32,6 +33,7 @@ func main() {
         DatabaseURL:   "postgres://user:pass@localhost/db", // Database connection
         MigrationName: "add_user_table",       // Optional: defaults to "migration"
         OutputDir:     "./migrations",         // Directory to save migration files
+        Schemas:       []string{"auth", "billing", "public"}, // Optional PostgreSQL schema allow-list
     }
 
     // Bound the initial database connection so a stuck host fails fast.
@@ -171,6 +173,13 @@ type GenerateMigrationOptions struct {
 
     // OutputDir is the directory where migration files will be saved (always real filesystem)
     OutputDir string
+
+    // CompareOptions are the options to use when comparing schemas
+    CompareOptions *config.CompareOptions
+
+    // Schemas restricts database introspection to the listed schemas when the
+    // connected dialect supports schema scoping.
+    Schemas []string
 }
 ```
 
@@ -178,8 +187,11 @@ type GenerateMigrationOptions struct {
 
 - `GoEntitiesDir`: Directory to scan for Go entities (required)
 - `DatabaseURL`: Database connection string (required)
+- `DBConn`: Existing database connection (optional; used instead of `DatabaseURL` when set)
 - `MigrationName`: Name for the migration (optional, defaults to "migration")
 - `OutputDir`: Directory where migration files will be saved (required)
+- `CompareOptions`: Schema comparison options (optional)
+- `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
 
 ### Database URL Examples
 

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -41,6 +41,9 @@ type GenerateMigrationOptions struct {
 	OutputDir string
 	// CompareOptions are the options to use when comparing schemas
 	CompareOptions *config.CompareOptions
+	// Schemas restricts database introspection to the listed schemas when the
+	// connected dialect supports schema scoping.
+	Schemas []string
 }
 
 // MigrationFiles represents the generated migration files
@@ -102,7 +105,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		defer dbschema.CloseAndWarn(conn)
 	}
 
-	dbSchema, err := conn.Reader().ReadSchema()
+	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, opts.Schemas)
 	if err != nil {
 		return nil, fmt.Errorf("error reading database schema: %w", err)
 	}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -12,6 +12,7 @@ The Ptah Migrator provides versioned database migration capabilities with up/dow
 - **Multiple Database Support**: Works with PostgreSQL and MySQL through Ptah's executor package
 - **Dry Run Mode**: Preview what migrations would do without actually applying them
 - **Migration Status**: Check current migration state and pending migrations
+- **Configurable Migration State**: Store migration history in a custom schema/table
 
 ## Migration File Structure
 
@@ -78,6 +79,11 @@ With dry run:
 go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dry-run
 ```
 
+With a custom migration state table:
+```bash
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --migrations-schema infra --migrations-table ptah_migrations
+```
+
 ### Migrate Down
 Roll back to a specific version:
 ```bash
@@ -87,6 +93,11 @@ go run ./cmd migrate-down --db-url postgres://user:pass@localhost/db --migration
 With confirmation skip (dangerous!):
 ```bash
 go run ./cmd migrate-down --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --target 5 --confirm
+```
+
+With a custom migration state table:
+```bash
+go run ./cmd migrate-down --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --target 5 --migrations-schema infra --migrations-table ptah_migrations
 ```
 
 ### Migration Status
@@ -103,6 +114,11 @@ go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrati
 JSON output:
 ```bash
 go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --json
+```
+
+With a custom migration state table:
+```bash
+go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --migrations-schema infra --migrations-table ptah_migrations
 ```
 
 ## API Overview
@@ -127,6 +143,7 @@ The migrator package provides a clean, modular API with the following key compon
 - **`NewMigrator(conn, provider)`**: Creates a migrator with a custom provider
 - **`NewFSMigrator(conn, fsys)`**: Creates a migrator that loads migrations from a filesystem
 - **`NewRegisteredMigrationProvider(migrations...)`**: Creates an in-memory migration provider
+- **`WithMigrationsTable(schema, table)`**: Configures the migration history table
 
 ## Programmatic Usage
 

--- a/migration/migrator/base/delete_migration.sql
+++ b/migration/migrator/base/delete_migration.sql
@@ -1,2 +1,0 @@
-DELETE FROM schema_migrations
-WHERE version = ?;

--- a/migration/migrator/base/get_version.sql
+++ b/migration/migrator/base/get_version.sql
@@ -1,1 +1,0 @@
-SELECT COALESCE(MAX(version), 0) FROM schema_migrations;

--- a/migration/migrator/base/record_migration.sql
+++ b/migration/migrator/base/record_migration.sql
@@ -1,2 +1,0 @@
-INSERT INTO schema_migrations (version, description, applied_at)
-VALUES (?, ?, ?);

--- a/migration/migrator/base/schema.sql
+++ b/migration/migrator/base/schema.sql
@@ -1,5 +1,0 @@
-CREATE TABLE IF NOT EXISTS schema_migrations (
-    version INTEGER PRIMARY KEY,
-    description TEXT NOT NULL,
-    applied_at TIMESTAMP NOT NULL
-);

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -83,7 +83,9 @@
 //		applied_at TIMESTAMP NOT NULL
 //	);
 //
-// This table tracks which migrations have been applied and when.
+// This table tracks which migrations have been applied and when. Use
+// WithMigrationsTable(schema, table) to store migration history in a custom
+// schema or table, for example an `infra.ptah_migrations` table in PostgreSQL.
 //
 // # Migration Operations
 //

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -2,7 +2,6 @@ package migrator
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"io/fs"
 	"strings"
@@ -10,18 +9,6 @@ import (
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 )
-
-//go:embed base/schema.sql
-var migrationsSchemaSQL string
-
-//go:embed base/get_version.sql
-var getVersionSQL string
-
-//go:embed base/record_migration.sql
-var recordMigrationSQL string
-
-//go:embed base/delete_migration.sql
-var deleteMigrationSQL string
 
 // MigrationFunc represents a migration function that operates on a database connection
 type MigrationFunc func(context.Context, *dbschema.DatabaseConnection) error

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/stokaro/ptah/core/sqlutil"
@@ -25,6 +26,8 @@ type Migrator struct {
 	conn              *dbschema.DatabaseConnection
 	migrationProvider MigrationProvider
 	defaultTimeouts   MigrationTimeouts
+	migrationsTable   string
+	migrationsSchema  string
 	initialized       bool
 	logger            *slog.Logger
 }
@@ -47,6 +50,7 @@ func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) 
 	return &Migrator{
 		conn:              conn,
 		migrationProvider: provider,
+		migrationsTable:   "schema_migrations",
 		logger:            slog.Default(),
 	}
 }
@@ -58,6 +62,72 @@ func (m *Migrator) WithLogger(l *slog.Logger) *Migrator {
 	return &tmp
 }
 
+// WithMigrationsTable sets the table used to record applied migrations.
+func (m *Migrator) WithMigrationsTable(schema, table string) *Migrator {
+	tmp := *m
+	tmp.migrationsSchema = strings.TrimSpace(schema)
+	tmp.migrationsTable = strings.TrimSpace(table)
+	if tmp.migrationsTable == "" {
+		tmp.migrationsTable = "schema_migrations"
+	}
+	tmp.initialized = false
+	return &tmp
+}
+
+func (m *Migrator) qualifiedMigrationsTable() string {
+	table := m.migrationsTable
+	if table == "" {
+		table = "schema_migrations"
+	}
+	if m.migrationsSchema == "" {
+		return m.quoteIdentifier(table)
+	}
+	return m.quoteIdentifier(m.migrationsSchema) + "." + m.quoteIdentifier(table)
+}
+
+func (m *Migrator) migrationsSchemaStatement() string {
+	if m.migrationsSchema == "" {
+		return ""
+	}
+	return "CREATE SCHEMA IF NOT EXISTS " + m.quoteIdentifier(m.migrationsSchema)
+}
+
+func (m *Migrator) quoteIdentifier(identifier string) string {
+	if m.conn == nil {
+		return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+	}
+	switch m.conn.Info().Dialect {
+	case "mysql", "mariadb", "clickhouse":
+		return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+	default:
+		return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+	}
+}
+
+func (m *Migrator) createMigrationsTableSQL() string {
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+    version INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    applied_at TIMESTAMP NOT NULL
+)`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) getVersionSQL() string {
+	return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s", m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) getAppliedMigrationsSQL() string {
+	return fmt.Sprintf("SELECT version FROM %s ORDER BY version", m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) recordMigrationSQL() string {
+	return fmt.Sprintf("INSERT INTO %s (version, description, applied_at) VALUES (?, ?, ?)", m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) deleteMigrationSQL() string {
+	return fmt.Sprintf("DELETE FROM %s WHERE version = ?", m.qualifiedMigrationsTable())
+}
+
 // Initialize creates the migrations table if it doesn't exist
 func (m *Migrator) Initialize(ctx context.Context) error {
 	// Skip if already initialized
@@ -65,9 +135,15 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 		return nil
 	}
 
+	if schemaSQL := m.migrationsSchemaStatement(); schemaSQL != "" {
+		if _, err := m.conn.ExecContext(ctx, schemaSQL); err != nil {
+			return fmt.Errorf("failed to create migrations schema: %w", err)
+		}
+	}
+
 	// Execute the schema creation SQL directly on the database connection
 	// This avoids transaction conflicts with the PostgreSQL writer
-	_, err := m.conn.ExecContext(ctx, migrationsSchemaSQL)
+	_, err := m.conn.ExecContext(ctx, m.createMigrationsTableSQL())
 	if err != nil {
 		return fmt.Errorf("failed to create migrations table: %w", err)
 	}
@@ -86,7 +162,7 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int, error) {
 
 	// Query the current version
 	var version int
-	row := m.conn.QueryRowContext(ctx, getVersionSQL)
+	row := m.conn.QueryRowContext(ctx, m.getVersionSQL())
 	if err := row.Scan(&version); err != nil {
 		return 0, fmt.Errorf("failed to get current version: %w", err)
 	}
@@ -102,7 +178,7 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 	}
 
 	// Query all applied migration versions
-	rows, err := m.conn.Query("SELECT version FROM schema_migrations ORDER BY version")
+	rows, err := m.conn.Query(m.getAppliedMigrationsSQL())
 	if err != nil {
 		return nil, fmt.Errorf("failed to query applied migrations: %w", err)
 	}
@@ -210,7 +286,7 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 	// Rebind once: the template and dialect are loop-invariant. Values are
 	// still bound as native driver parameters via these placeholders so we
 	// never interpolate user-controlled strings into the SQL text.
-	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.recordMigrationSQL())
 
 	// Apply migrations that are newer than current version
 	for _, migration := range migrations {
@@ -307,7 +383,7 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 
 	// Rebind once: template + dialect are loop-invariant. Migration version
 	// is bound as a parameter via the dialect-native placeholder.
-	deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, deleteMigrationSQL)
+	deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
 
 	// Apply down migrations for versions greater than target
 	for _, migration := range migrations {
@@ -403,7 +479,7 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "targetVersion", targetVersion, "totalMigrations", len(migrations))
 
 	// Rebind once; see MigrateUp for the rationale on parameter binding.
-	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, recordMigrationSQL)
+	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.recordMigrationSQL())
 
 	// Apply migrations up to target version
 	for _, migration := range migrations {

--- a/migration/migrator/security_test.go
+++ b/migration/migrator/security_test.go
@@ -18,20 +18,22 @@ var fmtVerbRe = regexp.MustCompile(`%[#+\- 0]*\d*(?:\.\d+)?[bcdeEfFgGoOpqstTUvxX
 //
 // The recorded migration SQL must use bind placeholders rather than fmt verbs,
 // so a description containing `'` or `;` cannot be interpolated directly into
-// the SQL text by the migrator. If anyone reverts the template back to
+// the SQL text by the migrator. If anyone reverts the generated SQL back to
 // `VALUES (%d, '%s', '%s')`, this test fails before the regression reaches
 // production. We assert both that exactly three `?` placeholders are present
 // (so changing `VALUES (?, %s, NOW())` would also fail even though `?` is
-// technically still there) and that no Go fmt verb of any flavour is left in
-// the template.
+// technically still there) and that no Go fmt verb of any flavor is left in
+// the SQL that the migrator actually executes.
 func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(strings.Count(recordMigrationSQL, "?"), qt.Equals, 3,
-		qt.Commentf("record_migration.sql must contain exactly 3 ? placeholders (version, description, applied_at)"))
+	sql := (&Migrator{}).recordMigrationSQL()
 
-	c.Assert(fmtVerbRe.FindString(recordMigrationSQL), qt.Equals, "",
-		qt.Commentf("record_migration.sql must not contain any Go fmt verb — values must be bound as driver parameters"))
+	c.Assert(strings.Count(sql, "?"), qt.Equals, 3,
+		qt.Commentf("record migration SQL must contain exactly 3 ? placeholders (version, description, applied_at)"))
+
+	c.Assert(fmtVerbRe.FindString(sql), qt.Equals, "",
+		qt.Commentf("record migration SQL must not contain any Go fmt verb - values must be bound as driver parameters"))
 }
 
 // TestDeleteMigrationSQL_UsesPlaceholders is the same regression guard for
@@ -39,9 +41,23 @@ func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
 func TestDeleteMigrationSQL_UsesPlaceholders(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(strings.Count(deleteMigrationSQL, "?"), qt.Equals, 1,
-		qt.Commentf("delete_migration.sql must contain exactly 1 ? placeholder (version)"))
+	sql := (&Migrator{}).deleteMigrationSQL()
 
-	c.Assert(fmtVerbRe.FindString(deleteMigrationSQL), qt.Equals, "",
-		qt.Commentf("delete_migration.sql must not contain any Go fmt verb — values must be bound as driver parameters"))
+	c.Assert(strings.Count(sql, "?"), qt.Equals, 1,
+		qt.Commentf("delete migration SQL must contain exactly 1 ? placeholder (version)"))
+
+	c.Assert(fmtVerbRe.FindString(sql), qt.Equals, "",
+		qt.Commentf("delete migration SQL must not contain any Go fmt verb - values must be bound as driver parameters"))
+}
+
+func TestMigrator_CustomMigrationsTableSQL(t *testing.T) {
+	c := qt.New(t)
+
+	m := (&Migrator{}).WithMigrationsTable("infra", "ptah_migrations")
+
+	c.Assert(m.migrationsSchemaStatement(), qt.Equals, `CREATE SCHEMA IF NOT EXISTS "infra"`)
+	c.Assert(m.createMigrationsTableSQL(), qt.Contains, `CREATE TABLE IF NOT EXISTS "infra"."ptah_migrations"`)
+	c.Assert(m.getVersionSQL(), qt.Equals, `SELECT COALESCE(MAX(version), 0) FROM "infra"."ptah_migrations"`)
+	c.Assert(m.recordMigrationSQL(), qt.Equals, `INSERT INTO "infra"."ptah_migrations" (version, description, applied_at) VALUES (?, ?, ?)`)
+	c.Assert(m.deleteMigrationSQL(), qt.Equals, `DELETE FROM "infra"."ptah_migrations" WHERE version = ?`)
 }

--- a/migration/planner/dialects/postgres/multi_schema_test.go
+++ b/migration/planner/dialects/postgres/multi_schema_test.go
@@ -1,0 +1,113 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_MultiSchemaTablesAndFKs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users", Schema: "auth"},
+			{StructName: "Invoice", Name: "invoices", Schema: "billing"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "user_id", Type: "INTEGER", Foreign: "auth.users(id)"},
+		},
+		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{},
+	}
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{"auth.users", "billing.invoices"},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(sql, qt.Contains, "CREATE SCHEMA IF NOT EXISTS auth;")
+	c.Assert(sql, qt.Contains, "CREATE SCHEMA IF NOT EXISTS billing;")
+	c.Assert(sql, qt.Contains, "CREATE TABLE auth.users")
+	c.Assert(sql, qt.Contains, "CREATE TABLE billing.invoices")
+	c.Assert(sql, qt.Contains, "ALTER TABLE billing.invoices ADD CONSTRAINT fk_invoices_user_id FOREIGN KEY (user_id) REFERENCES auth.users(id);")
+}
+
+func TestPlanner_GenerateMigrationAST_TrimsSchemaPreconditions(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users", Schema: " auth "},
+			{StructName: "Account", Name: "accounts", Schema: "auth"},
+			{StructName: "Blank", Name: "blank", Schema: "   "},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Account", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Blank", Name: "id", Type: "SERIAL", Primary: true},
+		},
+		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{},
+	}
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{"auth.users", "auth.accounts", "blank"},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(sql, qt.Contains, "CREATE SCHEMA IF NOT EXISTS auth;")
+	c.Assert(sql, qt.Not(qt.Contains), "CREATE SCHEMA IF NOT EXISTS  auth ;")
+	c.Assert(sql, qt.Not(qt.Contains), "CREATE SCHEMA IF NOT EXISTS    ;")
+	c.Assert(countSQLLine(sql, "CREATE SCHEMA IF NOT EXISTS auth;"), qt.Equals, 1)
+}
+
+func TestPlanner_GenerateMigrationAST_DoesNotQualifyAmbiguousLeafFK(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "AuthUser", Name: "users", Schema: "auth"},
+			{StructName: "CrmUser", Name: "users", Schema: "crm"},
+			{StructName: "Invoice", Name: "invoices", Schema: "billing"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "AuthUser", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "CrmUser", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "user_id", Type: "INTEGER", Foreign: "users(id)"},
+		},
+		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{},
+	}
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{"auth.users", "crm.users", "billing.invoices"},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(sql, qt.Contains, "ALTER TABLE billing.invoices ADD CONSTRAINT fk_invoices_user_id FOREIGN KEY (user_id) REFERENCES users(id);")
+	c.Assert(sql, qt.Not(qt.Contains), "REFERENCES auth.users(id)")
+	c.Assert(sql, qt.Not(qt.Contains), "REFERENCES crm.users(id)")
+}
+
+func countSQLLine(sql, line string) int {
+	count := 0
+	for sqlLine := range strings.SplitSeq(sql, "\n") {
+		if sqlLine == line {
+			count++
+		}
+	}
+	return count
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -152,12 +152,30 @@ func (p *Planner) modifyExistingEnums(result []ast.Node, diff *types.SchemaDiff)
 func (p *Planner) addNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	tablesToAdd := createTableLookupMap(diff.TablesAdded)
 
+	result = p.addSchemaPreconditions(result, generated, tablesToAdd)
+
 	// Phase 1: Create tables without foreign key constraints
 	result = p.createTablesWithoutForeignKeys(result, generated, tablesToAdd)
 
 	// Phase 2: Add foreign key constraints via ALTER TABLE statements
 	result = p.addForeignKeyConstraints(result, generated, tablesToAdd)
 
+	return result
+}
+
+func (p *Planner) addSchemaPreconditions(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
+	seen := make(map[string]struct{})
+	for _, table := range generated.Tables {
+		schema := strings.TrimSpace(table.Schema)
+		if schema == "" || !tablesToAdd[table.QualifiedName()] {
+			continue
+		}
+		if _, ok := seen[schema]; ok {
+			continue
+		}
+		seen[schema] = struct{}{}
+		result = append(result, ast.NewRawSQL("CREATE SCHEMA IF NOT EXISTS "+schema))
+	}
 	return result
 }
 
@@ -175,11 +193,11 @@ func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *g
 	allFields := generated.Fields
 
 	for _, table := range generated.Tables {
-		if !tablesToAdd[table.Name] {
+		if !tablesToAdd[table.QualifiedName()] {
 			continue
 		}
 
-		astNode := ast.NewCreateTable(table.Name)
+		astNode := ast.NewCreateTable(table.QualifiedName())
 		for _, field := range allFields {
 			if field.StructName == table.StructName {
 				columnNode := fromschema.FromFieldWithoutForeignKeys(field, generated.Enums, DialectName)
@@ -195,7 +213,7 @@ func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *g
 // addForeignKeyConstraints adds foreign key constraints via ALTER TABLE statements
 func (p *Planner) addForeignKeyConstraints(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
 	for _, table := range generated.Tables {
-		if !tablesToAdd[table.Name] {
+		if !tablesToAdd[table.QualifiedName()] {
 			continue
 		}
 
@@ -214,18 +232,49 @@ func (p *Planner) addRegularForeignKeys(result []ast.Node, generated *goschema.D
 		}
 
 		fkRef := fromschema.ParseForeignKeyReference(field.Foreign)
-		if fkRef != nil && fkRef.Table != table.Name {
+		if fkRef != nil && !foreignKeyTargetsTable(fkRef, table) {
+			qualifyForeignKeyRef(generated, table, fkRef)
 			fkRef.OnDelete = field.OnDelete
 			fkRef.OnUpdate = field.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, foreignKeyName(table.Name, field), []string{field.Name}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.QualifiedName(), foreignKeyName(table.Name, field), []string{field.Name}, fkRef))
 		}
 	}
 	return result
 }
 
+func foreignKeyTargetsTable(fkRef *ast.ForeignKeyRef, table goschema.Table) bool {
+	return fkRef.Table == table.Name || fkRef.Table == table.QualifiedName()
+}
+
+func qualifyForeignKeyRef(generated *goschema.Database, current goschema.Table, fkRef *ast.ForeignKeyRef) {
+	if strings.Contains(fkRef.Table, ".") {
+		return
+	}
+	currentSchema := strings.TrimSpace(current.Schema)
+	for _, table := range generated.Tables {
+		if strings.TrimSpace(table.Schema) == currentSchema && table.Name == fkRef.Table {
+			fkRef.Table = table.QualifiedName()
+			return
+		}
+	}
+	matchedName := ""
+	for _, table := range generated.Tables {
+		if table.Name != fkRef.Table {
+			continue
+		}
+		if matchedName != "" {
+			return
+		}
+		matchedName = table.QualifiedName()
+	}
+	if matchedName != "" {
+		fkRef.Table = matchedName
+	}
+}
+
 // addSelfReferencingForeignKeys adds self-referencing foreign key constraints
 func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *goschema.Database, table goschema.Table) []ast.Node {
-	selfRefFKs, exists := generated.SelfReferencingForeignKeys[table.Name]
+	selfRefFKs, exists := generated.SelfReferencingForeignKeys[table.QualifiedName()]
 	if !exists {
 		return result
 	}
@@ -233,9 +282,10 @@ func (p *Planner) addSelfReferencingForeignKeys(result []ast.Node, generated *go
 	for _, selfRefFK := range selfRefFKs {
 		fkRef := fromschema.ParseForeignKeyReference(selfRefFK.Foreign)
 		if fkRef != nil {
+			qualifyForeignKeyRef(generated, table, fkRef)
 			fkRef.OnDelete = selfRefFK.OnDelete
 			fkRef.OnUpdate = selfRefFK.OnUpdate
-			result = append(result, p.createForeignKeyAlterStatement(table.Name, selfReferencingForeignKeyName(table.Name, selfRefFK), []string{selfRefFK.FieldName}, fkRef))
+			result = append(result, p.createForeignKeyAlterStatement(table.QualifiedName(), selfReferencingForeignKeyName(table.Name, selfRefFK), []string{selfRefFK.FieldName}, fkRef))
 		}
 	}
 
@@ -297,11 +347,8 @@ func (p *Planner) addNewTableColumns(result []ast.Node, tableDiff types.TableDif
 		var targetStructName string
 
 		// First, find the struct name for this table
-		for _, table := range generated.Tables {
-			if table.Name == tableDiff.TableName {
-				targetStructName = table.StructName
-				break
-			}
+		if table := findGeneratedTableByDiffName(generated, tableDiff.TableName); table != nil {
+			targetStructName = table.StructName
 		}
 
 		// Now find the field using the correct struct name
@@ -313,7 +360,7 @@ func (p *Planner) addNewTableColumns(result []ast.Node, tableDiff types.TableDif
 		}
 
 		if targetField != nil {
-			columnNode := fromschema.FromField(*targetField, generated.Enums, "postgres")
+			columnNode := fromschema.FromFieldWithoutForeignKeys(*targetField, generated.Enums, "postgres")
 
 			// Only add the column - foreign key constraints will be added separately
 			// to ensure proper dependency ordering (columns must exist before FK constraints)
@@ -337,13 +384,14 @@ func (p *Planner) addForeignKeyConstraintsForNewColumns(result []ast.Node, table
 		// Find the field definition for this column
 		var targetField *goschema.Field
 		var targetStructName string
+		var targetTableName string
+		var targetTable *goschema.Table
 
 		// First, find the struct name for this table
-		for _, table := range generated.Tables {
-			if table.Name == tableDiff.TableName {
-				targetStructName = table.StructName
-				break
-			}
+		if table := findGeneratedTableByDiffName(generated, tableDiff.TableName); table != nil {
+			targetTable = table
+			targetStructName = table.StructName
+			targetTableName = table.Name
 		}
 
 		// Now find the field using the correct struct name
@@ -359,7 +407,10 @@ func (p *Planner) addForeignKeyConstraintsForNewColumns(result []ast.Node, table
 			// Parse the foreign key reference
 			fkRef := fromschema.ParseForeignKeyReference(targetField.Foreign)
 			if fkRef != nil {
-				fkName := foreignKeyName(tableDiff.TableName, *targetField)
+				if targetTable != nil {
+					qualifyForeignKeyRef(generated, *targetTable, fkRef)
+				}
+				fkName := foreignKeyName(targetTableName, *targetField)
 				fkRef.Name = fkName
 				fkRef.OnDelete = targetField.OnDelete
 				fkRef.OnUpdate = targetField.OnUpdate
@@ -391,11 +442,8 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 		var targetStructName string
 
 		// First, find the struct name for this table
-		for _, table := range generated.Tables {
-			if table.Name == tableDiff.TableName {
-				targetStructName = table.StructName
-				break
-			}
+		if table := findGeneratedTableByDiffName(generated, tableDiff.TableName); table != nil {
+			targetStructName = table.StructName
 		}
 
 		// Now find the field using the correct struct name
@@ -431,6 +479,16 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 		result = append(result, astCommentNode)
 	}
 	return result
+}
+
+func findGeneratedTableByDiffName(generated *goschema.Database, tableName string) *goschema.Table {
+	for i := range generated.Tables {
+		table := &generated.Tables[i]
+		if table.Name == tableName || table.QualifiedName() == tableName {
+			return table
+		}
+	}
+	return nil
 }
 
 func (p *Planner) removeTableColumnsFromDiff(result []ast.Node, tableDiff types.TableDiff) []ast.Node {
@@ -524,7 +582,7 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 	// Create a mapping from struct names to table names for proper index table resolution
 	structToTableMap := make(map[string]string)
 	for _, table := range generated.Tables {
-		structToTableMap[table.StructName] = table.Name
+		structToTableMap[table.StructName] = table.QualifiedName()
 	}
 
 	for _, indexName := range diff.IndexesAdded {
@@ -1086,7 +1144,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// Resolve struct → table name once for the field-level synthesis fallbacks.
 	structToTable := make(map[string]string, len(generated.Tables))
 	for _, t := range generated.Tables {
-		structToTable[t.StructName] = t.Name
+		structToTable[t.StructName] = t.QualifiedName()
 	}
 
 	// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved
@@ -1395,7 +1453,7 @@ func (p *Planner) fieldLevelCheckConstraintNode(constraintName string, generated
 		}
 		name := f.CheckName
 		if name == "" {
-			name = tableName + "_" + f.Name + "_check"
+			name = unqualifiedTableName(tableName) + "_" + f.Name + "_check"
 		}
 		if name != constraintName {
 			continue
@@ -1428,7 +1486,7 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 		if tableName == "" {
 			tableName = f.StructName
 		}
-		name := foreignKeyName(tableName, f)
+		name := foreignKeyName(unqualifiedTableName(tableName), f)
 		if name != constraintName {
 			continue
 		}
@@ -1436,11 +1494,21 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 		if fkRef == nil {
 			continue
 		}
+		if table := findGeneratedTableByDiffName(generated, tableName); table != nil {
+			qualifyForeignKeyRef(generated, *table, fkRef)
+		}
 		fkRef.OnDelete = f.OnDelete
 		fkRef.OnUpdate = f.OnUpdate
 		return p.createForeignKeyAlterStatement(tableName, name, []string{f.Name}, fkRef), true
 	}
 	return nil, false
+}
+
+func unqualifiedTableName(tableName string) string {
+	if idx := strings.LastIndex(tableName, "."); idx >= 0 {
+		return tableName[idx+1:]
+	}
+	return tableName
 }
 
 // removeConstraints removes table-level constraints via ALTER TABLE statements.

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -91,12 +91,12 @@ func TablesAndColumns(generated *goschema.Database, database *types.DBSchema, di
 	// Create maps for quick lookup
 	genTables := make(map[string]goschema.Table)
 	for _, table := range generated.Tables {
-		genTables[table.Name] = table
+		genTables[table.QualifiedName()] = table
 	}
 
 	dbTables := make(map[string]types.DBTable)
 	for _, table := range database.Tables {
-		dbTables[table.Name] = table
+		dbTables[table.QualifiedName()] = table
 	}
 
 	// Find added and removed tables
@@ -196,7 +196,7 @@ func TablesAndColumns(generated *goschema.Database, database *types.DBSchema, di
 //
 // Column lists are sorted alphabetically for deterministic output and reliable testing.
 func TableColumns(genTable goschema.Table, dbTable types.DBTable, generated *goschema.Database) difftypes.TableDiff {
-	tableDiff := difftypes.TableDiff{TableName: genTable.Name}
+	tableDiff := difftypes.TableDiff{TableName: genTable.QualifiedName()}
 
 	// Process embedded fields to get the complete field list (same as generators do)
 	embeddedGeneratedFields := processEmbeddedFieldsForStruct(generated.EmbeddedFields, generated.Fields, genTable.StructName)
@@ -917,7 +917,7 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 		}
 
 		// Use table.constraint_name as the key for comparison
-		key := constraint.TableName + "." + constraint.Name
+		key := constraint.QualifiedTableName() + "." + constraint.Name
 		dbConstraints[key] = constraint
 	}
 
@@ -960,7 +960,7 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 func appendConstraintRemoval(infos []difftypes.ConstraintRemovalInfo, dbConstraint types.DBConstraint) []difftypes.ConstraintRemovalInfo {
 	return append(infos, difftypes.ConstraintRemovalInfo{
 		Name:      dbConstraint.Name,
-		TableName: dbConstraint.TableName,
+		TableName: dbConstraint.QualifiedTableName(),
 		Type:      dbConstraint.Type,
 	})
 }
@@ -1080,7 +1080,7 @@ func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint typ
 // (the same hazard checkConstraintChanged guards against for CHECK clauses).
 func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint, dialect string) bool {
 	// Compare referenced table
-	if genConstraint.ForeignTable != getStringValue(dbConstraint.ForeignTable) {
+	if !foreignTableRefMatches(genConstraint.ForeignTable, dbConstraint) {
 		return true
 	}
 
@@ -1100,6 +1100,17 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 	}
 
 	return false
+}
+
+func foreignTableRefMatches(generated string, dbConstraint types.DBConstraint) bool {
+	generated = strings.TrimSpace(generated)
+	if generated == "" {
+		return dbConstraint.ForeignTable == nil
+	}
+	if strings.Contains(generated, ".") {
+		return generated == dbConstraint.QualifiedForeignTableName()
+	}
+	return generated == getStringValue(dbConstraint.ForeignTable)
 }
 
 // normalizeReferentialAction canonicalizes an ON DELETE / ON UPDATE action so
@@ -1169,7 +1180,7 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 		tableName := field.StructName // default to struct name
 		for _, table := range generated.Tables {
 			if table.StructName == field.StructName {
-				tableName = table.Name
+				tableName = table.QualifiedName()
 				break
 			}
 		}
@@ -1181,19 +1192,19 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 	switch dbConstraint.Type {
 	case "NOT NULL":
 		// Check if there's a field with not_null=true for this column
-		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
+		key := dbConstraint.QualifiedTableName() + "." + getConstraintColumn(dbConstraint)
 		if field, exists := fieldMap[key]; exists && !field.Nullable {
 			return true
 		}
 	case "PRIMARY KEY":
 		// Check if there's a field with primary=true for this column
-		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
+		key := dbConstraint.QualifiedTableName() + "." + getConstraintColumn(dbConstraint)
 		if field, exists := fieldMap[key]; exists && field.Primary {
 			return true
 		}
 	case "UNIQUE":
 		// Check if there's a field with unique=true for this column
-		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
+		key := dbConstraint.QualifiedTableName() + "." + getConstraintColumn(dbConstraint)
 		if field, exists := fieldMap[key]; exists && field.Unique {
 			return true
 		}
@@ -1207,14 +1218,14 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 		// the constraint name rather than the column, because the synthesized
 		// name is keyed on table.constraint_name and getConstraintColumn does
 		// not always resolve the FK column.
-		if _, synthesized := synthesizedFKKeys[dbConstraint.TableName+"."+dbConstraint.Name]; synthesized {
+		if _, synthesized := synthesizedFKKeys[dbConstraint.QualifiedTableName()+"."+dbConstraint.Name]; synthesized {
 			return false
 		}
 		// Check if there's a field with foreign key reference for this column.
 		// No synthesized counterpart (e.g. the column is not yet in the
 		// database): keep the historical behavior and treat it as field-level
 		// so it is owned by the column/table lifecycle.
-		key := dbConstraint.TableName + "." + getConstraintColumn(dbConstraint)
+		key := dbConstraint.QualifiedTableName() + "." + getConstraintColumn(dbConstraint)
 		if field, exists := fieldMap[key]; exists && field.Foreign != "" {
 			return true
 		}
@@ -1274,15 +1285,15 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 		return nil
 	}
 
-	structToTable := make(map[string]string, len(generated.Tables))
+	structToTable := make(map[string]goschema.Table, len(generated.Tables))
 	for _, t := range generated.Tables {
-		structToTable[t.StructName] = t.Name
+		structToTable[t.StructName] = t
 	}
 
 	dbColumns := make(map[string]struct{}, 16)
 	for _, t := range database.Tables {
 		for _, c := range t.Columns {
-			dbColumns[t.Name+"."+c.Name] = struct{}{}
+			dbColumns[t.QualifiedName()+"."+c.Name] = struct{}{}
 		}
 	}
 
@@ -1291,16 +1302,19 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 		if f.Check == "" {
 			continue
 		}
-		tableName := structToTable[f.StructName]
-		if tableName == "" {
+		table, ok := structToTable[f.StructName]
+		tableName := table.QualifiedName()
+		tableLeafName := table.Name
+		if !ok || tableName == "" {
 			tableName = f.StructName
+			tableLeafName = f.StructName
 		}
 		if _, exists := dbColumns[tableName+"."+f.Name]; !exists {
 			continue
 		}
 		name := f.CheckName
 		if name == "" {
-			name = tableName + "_" + f.Name + "_check"
+			name = tableLeafName + "_" + f.Name + "_check"
 		}
 		synthesized = append(synthesized, goschema.Constraint{
 			StructName:      f.StructName,
@@ -1343,7 +1357,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 	dbColumns := make(map[string]struct{}, 16)
 	for _, t := range database.Tables {
 		for _, c := range t.Columns {
-			dbColumns[t.Name+"."+c.Name] = struct{}{}
+			dbColumns[t.QualifiedName()+"."+c.Name] = struct{}{}
 		}
 	}
 
@@ -1371,7 +1385,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		// tagged with that table's name. An empty tableName would mean the
 		// field is not part of any table, so skip it rather than synthesize
 		// against a struct name.
-		tableName := f.tableName
+		tableName := f.qualifiedTableName
 		if tableName == "" {
 			continue
 		}
@@ -1380,7 +1394,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		}
 		name := f.ForeignKeyName
 		if name == "" {
-			name = fromschema.GenerateForeignKeyName(tableName, f.Name)
+			name = fromschema.GenerateForeignKeyName(f.tableName, f.Name)
 		}
 		// Reuse the canonical generate-path parser so the synthesized table /
 		// column always match exactly what the planner emits (issue #189
@@ -1417,7 +1431,8 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 // mixin are expanded once per embedding host and carry the host table's name.
 type resolvedField struct {
 	goschema.Field
-	tableName string
+	tableName          string
+	qualifiedTableName string
 }
 
 // resolveTableFields expands every table's field set the same way the CREATE
@@ -1441,13 +1456,13 @@ func resolveTableFields(generated *goschema.Database) []resolvedField {
 		// Direct fields declared on the table struct itself.
 		for _, f := range generated.Fields {
 			if f.StructName == table.StructName {
-				resolved = append(resolved, resolvedField{Field: f, tableName: table.Name})
+				resolved = append(resolved, resolvedField{Field: f, tableName: table.Name, qualifiedTableName: table.QualifiedName()})
 			}
 		}
 		// Fields contributed by embedded mixins (inline + inline-relation),
 		// each already rewritten to the host struct name by the expansion.
 		for _, f := range processEmbeddedFieldsForStruct(generated.EmbeddedFields, generated.Fields, table.StructName) {
-			resolved = append(resolved, resolvedField{Field: f, tableName: table.Name})
+			resolved = append(resolved, resolvedField{Field: f, tableName: table.Name, qualifiedTableName: table.QualifiedName()})
 		}
 	}
 	return resolved
@@ -1653,7 +1668,7 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 	fkBackedIndexes := make(map[string]struct{}, len(database.Constraints))
 	for _, c := range database.Constraints {
 		if c.Type == "FOREIGN KEY" {
-			fkBackedIndexes[c.TableName+"."+c.Name] = struct{}{}
+			fkBackedIndexes[c.QualifiedTableName()+"."+c.Name] = struct{}{}
 		}
 	}
 
@@ -1672,7 +1687,7 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 
 		// Skip MySQL/MariaDB FK-backing indexes (named after the FK constraint
 		// on the same table). They are auto-managed by the foreign key.
-		if _, ok := fkBackedIndexes[index.TableName+"."+index.Name]; ok {
+		if _, ok := fkBackedIndexes[index.QualifiedTableName()+"."+index.Name]; ok {
 			continue
 		}
 
@@ -1695,7 +1710,7 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 				if index.Name == indexName {
 					diff.IndexesRemovedWithTables = append(diff.IndexesRemovedWithTables, difftypes.IndexRemovalInfo{
 						Name:      indexName,
-						TableName: index.TableName,
+						TableName: index.QualifiedTableName(),
 					})
 					break
 				}
@@ -2605,12 +2620,12 @@ func RLSPolicyDefinitions(genPolicy goschema.RLSPolicy, dbPolicy types.DBRLSPoli
 	}
 
 	// Compare USING expression
-	if genPolicy.UsingExpression != dbPolicy.UsingExpression {
+	if normalize.Expression(genPolicy.UsingExpression) != normalize.Expression(dbPolicy.UsingExpression) {
 		policyDiff.Changes["using_expression"] = fmt.Sprintf("%s -> %s", dbPolicy.UsingExpression, genPolicy.UsingExpression)
 	}
 
 	// Compare WITH CHECK expression
-	if genPolicy.WithCheckExpression != dbPolicy.WithCheckExpression {
+	if normalize.Expression(genPolicy.WithCheckExpression) != normalize.Expression(dbPolicy.WithCheckExpression) {
 		policyDiff.Changes["with_check_expression"] = fmt.Sprintf("%s -> %s", dbPolicy.WithCheckExpression, genPolicy.WithCheckExpression)
 	}
 

--- a/migration/schemadiff/internal/compare/compare_rls_test.go
+++ b/migration/schemadiff/internal/compare/compare_rls_test.go
@@ -1,0 +1,64 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+)
+
+func TestRLSPolicyDefinitions_NormalizesRedundantExpressionParentheses(t *testing.T) {
+	c := qt.New(t)
+
+	gen := goschema.RLSPolicy{
+		Name:                "users_visible",
+		Table:               "auth.users",
+		PolicyFor:           "ALL",
+		ToRoles:             "PUBLIC",
+		UsingExpression:     "id IS NOT NULL",
+		WithCheckExpression: "account_id IS NOT NULL",
+	}
+	db := types.DBRLSPolicy{
+		Name:                "users_visible",
+		Table:               "auth.users",
+		PolicyFor:           "ALL",
+		ToRoles:             "PUBLIC",
+		UsingExpression:     "(id IS NOT NULL)",
+		WithCheckExpression: "((account_id IS NOT NULL))",
+	}
+
+	diff := compare.RLSPolicyDefinitions(gen, db)
+
+	c.Assert(diff.Changes, qt.HasLen, 0)
+}
+
+func TestRLSPolicyDefinitions_DetectsExpressionChangesAfterNormalization(t *testing.T) {
+	c := qt.New(t)
+
+	gen := goschema.RLSPolicy{
+		Name:                "users_visible",
+		Table:               "auth.users",
+		PolicyFor:           "ALL",
+		ToRoles:             "PUBLIC",
+		UsingExpression:     "id IS NOT NULL",
+		WithCheckExpression: "account_id IS NOT NULL",
+	}
+	db := types.DBRLSPolicy{
+		Name:                "users_visible",
+		Table:               "auth.users",
+		PolicyFor:           "ALL",
+		ToRoles:             "PUBLIC",
+		UsingExpression:     "(id > 0)",
+		WithCheckExpression: "(account_id > 0)",
+	}
+
+	diff := compare.RLSPolicyDefinitions(gen, db)
+
+	c.Assert(diff.Changes, qt.DeepEquals, map[string]string{
+		"using_expression":      "(id > 0) -> id IS NOT NULL",
+		"with_check_expression": "(account_id > 0) -> account_id IS NOT NULL",
+	})
+}

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -921,6 +921,40 @@ func TestTablesAndColumns_SortingConsistency(t *testing.T) {
 	c.Assert(diff.TablesRemoved, qt.DeepEquals, []string{"alpha_old_table", "zebra_old_table"})
 }
 
+func TestTablesAndColumns_UsesSchemaQualifiedTableIdentity(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "AuthUser", Name: "users", Schema: "auth"},
+			{StructName: "BillingUser", Name: "users", Schema: "billing"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "AuthUser", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "BillingUser", Name: "id", Type: "INTEGER", Primary: true},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name:   "users",
+				Schema: "auth",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "integer", UDTName: "int4", IsNullable: "NO", IsPrimaryKey: true},
+				},
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.TablesAndColumns(generated, database, diff)
+
+	c.Assert(diff.TablesAdded, qt.DeepEquals, []string{"billing.users"})
+	c.Assert(diff.TablesRemoved, qt.HasLen, 0)
+	c.Assert(diff.TablesModified, qt.HasLen, 0)
+}
+
 func TestColumnByName_HappyPath(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/migration/schemadiff/internal/normalize/normalize.go
+++ b/migration/schemadiff/internal/normalize/normalize.go
@@ -177,3 +177,56 @@ func IsDefaultExpr(value string) bool {
 	}
 	return true
 }
+
+// Expression normalizes SQL expressions for schema comparison.
+func Expression(value string) string {
+	cleanValue := strings.TrimSpace(value)
+	for hasRedundantOuterParentheses(cleanValue) {
+		cleanValue = strings.TrimSpace(cleanValue[1 : len(cleanValue)-1])
+	}
+	return cleanValue
+}
+
+func hasRedundantOuterParentheses(value string) bool {
+	if len(value) < 2 || value[0] != '(' || value[len(value)-1] != ')' {
+		return false
+	}
+
+	depth := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '\'', '"':
+			next, ok := skipQuotedSQL(value, i, value[i])
+			if !ok {
+				return false
+			}
+			i = next
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+			if depth == 0 && i != len(value)-1 {
+				return false
+			}
+		}
+	}
+
+	return depth == 0
+}
+
+func skipQuotedSQL(value string, start int, quote byte) (int, bool) {
+	for i := start + 1; i < len(value); i++ {
+		if value[i] != quote {
+			continue
+		}
+		if i+1 < len(value) && value[i+1] == quote {
+			i++
+			continue
+		}
+		return i, true
+	}
+	return 0, false
+}


### PR DESCRIPTION
## Summary
- add table-level `schema` annotations and schema-qualified table identity across parsing, diffing, planning, and conversion
- add PostgreSQL schema-scoped introspection via `--schemas` and `GenerateMigrationOptions.Schemas`
- support custom migration state tables with `--migrations-schema` / `--migrations-table` for up/down/status
- document the new multi-schema and migration-state options

Closes #160

## Validation
- `GOCACHE=/private/tmp/ptah-go-build-cache go test ./...`
- `GOCACHE=/private/tmp/ptah-go-build-cache go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-go-build-cache POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test -tags=integration ./integration/gonative -run TestPostgreSQLMultiSchemaGenerateApplyReadDiffIntegration -count=1`

## Self-review notes
- verified schema-qualified table keys are used for generated and introspected table identity
- verified cross-schema FK introspection joins by constraint schema, not only owning table schema
- verified migration state SQL quotes configured schema/table identifiers while keeping version values parameterized
- verified `ReadSchemaWithSchemas(conn, nil)` resets scoped PostgreSQL readers back to the default schema scope
