### PR TITLE
Fix(schemadiff,planner): deterministic migration generation

### DIFF
--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -52,6 +52,7 @@ package fromschema
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -1228,6 +1229,7 @@ func getUniqueStructNames(embeddedFields []goschema.EmbeddedField) []string {
 	for structName := range structNameMap {
 		structNames = append(structNames, structName)
 	}
+	sort.Strings(structNames)
 	return structNames
 }
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -52,7 +52,6 @@ package fromschema
 import (
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -1209,28 +1208,13 @@ func ProcessEmbeddedFields(embeddedFields []goschema.EmbeddedField, originalFiel
 	copy(allFields, originalFields)
 
 	// Process embedded fields for each struct
-	structNames := getUniqueStructNames(embeddedFields)
+	structNames := goschema.UniqueStructNames(embeddedFields)
 	for _, structName := range structNames {
 		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, originalFields, structName)
 		allFields = append(allFields, generatedFields...)
 	}
 
 	return allFields
-}
-
-// getUniqueStructNames extracts unique struct names from embedded fields.
-func getUniqueStructNames(embeddedFields []goschema.EmbeddedField) []string {
-	structNameMap := make(map[string]bool)
-	for _, embedded := range embeddedFields {
-		structNameMap[embedded.StructName] = true
-	}
-
-	var structNames []string
-	for structName := range structNameMap {
-		structNames = append(structNames, structName)
-	}
-	sort.Strings(structNames)
-	return structNames
 }
 
 func processEmbeddedInlineMode(generatedFields []goschema.Field, embedded goschema.EmbeddedField, allFields []goschema.Field, allEmbeddedFields []goschema.EmbeddedField, structName string) []goschema.Field {

--- a/core/goschema/dependency_fix_test.go
+++ b/core/goschema/dependency_fix_test.go
@@ -241,26 +241,13 @@ func processEmbeddedFields(embeddedFields []goschema.EmbeddedField, originalFiel
 	copy(allFields, originalFields)
 
 	// Process embedded fields for each struct
-	structNames := getUniqueStructNames(embeddedFields)
+	structNames := goschema.UniqueStructNames(embeddedFields)
 	for _, structName := range structNames {
 		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, originalFields, structName)
 		allFields = append(allFields, generatedFields...)
 	}
 
 	return allFields
-}
-
-func getUniqueStructNames(embeddedFields []goschema.EmbeddedField) []string {
-	structNameMap := make(map[string]bool)
-	for _, embedded := range embeddedFields {
-		structNameMap[embedded.StructName] = true
-	}
-
-	var structNames []string
-	for structName := range structNameMap {
-		structNames = append(structNames, structName)
-	}
-	return structNames
 }
 
 func processEmbeddedFieldsForStruct(embeddedFields []goschema.EmbeddedField, allFields []goschema.Field, structName string) []goschema.Field {

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -330,6 +330,7 @@ func getUniqueStructNames(embeddedFields []EmbeddedField) []string {
 	for structName := range structNameMap {
 		structNames = append(structNames, structName)
 	}
+	sort.Strings(structNames)
 	return structNames
 }
 
@@ -568,11 +569,12 @@ func buildFunctionDependencies(r *Database) {
 			}
 		}
 
-		// Convert depMap keys to a slice and assign to FunctionDependencies
+		// Convert depMap keys to a sorted slice and assign to FunctionDependencies
 		deps := make([]string, 0, len(depMap))
 		for dep := range depMap {
 			deps = append(deps, dep)
 		}
+		sort.Strings(deps)
 		r.FunctionDependencies[function.Name] = deps
 	}
 }

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -2,6 +2,7 @@ package goschema
 
 import (
 	"log/slog"
+	"maps"
 	"regexp"
 	"slices"
 	"sort"
@@ -310,7 +311,7 @@ func processEmbeddedFields(embeddedFields []EmbeddedField, originalFields []Fiel
 	copy(allFields, originalFields)
 
 	// Process embedded fields for each struct
-	structNames := getUniqueStructNames(embeddedFields)
+	structNames := UniqueStructNames(embeddedFields)
 	for _, structName := range structNames {
 		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, originalFields, structName)
 		allFields = append(allFields, generatedFields...)
@@ -319,19 +320,15 @@ func processEmbeddedFields(embeddedFields []EmbeddedField, originalFields []Fiel
 	return allFields
 }
 
-// getUniqueStructNames extracts unique struct names from embedded fields.
-func getUniqueStructNames(embeddedFields []EmbeddedField) []string {
+// UniqueStructNames extracts the distinct StructName values from the given
+// embedded fields, sorted alphabetically so callers process embedded structs
+// in a deterministic order (issue #59).
+func UniqueStructNames(embeddedFields []EmbeddedField) []string {
 	structNameMap := make(map[string]bool)
 	for _, embedded := range embeddedFields {
 		structNameMap[embedded.StructName] = true
 	}
-
-	var structNames []string
-	for structName := range structNameMap {
-		structNames = append(structNames, structName)
-	}
-	sort.Strings(structNames)
-	return structNames
+	return slices.Sorted(maps.Keys(structNameMap))
 }
 
 // processEmbeddedFieldsForStruct processes embedded fields for a specific struct and generates corresponding schema fields.
@@ -570,12 +567,7 @@ func buildFunctionDependencies(r *Database) {
 		}
 
 		// Convert depMap keys to a sorted slice and assign to FunctionDependencies
-		deps := make([]string, 0, len(depMap))
-		for dep := range depMap {
-			deps = append(deps, dep)
-		}
-		sort.Strings(deps)
-		r.FunctionDependencies[function.Name] = deps
+		r.FunctionDependencies[function.Name] = slices.Sorted(maps.Keys(depMap))
 	}
 }
 

--- a/migration/planner/determinism_test.go
+++ b/migration/planner/determinism_test.go
@@ -1,0 +1,93 @@
+package planner_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	dbtypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// multiTenantRLSSchema builds an RLS-heavy schema of the shape reported in
+// issue #59: several tables, each with a row-level-security policy. Table
+// names are deliberately declared out of alphabetical order so that any
+// order-sensitive code path has to sort rather than rely on input order.
+func multiTenantRLSSchema() *goschema.Database {
+	tables := []struct {
+		table      string
+		structName string
+	}{
+		{"locations", "Location"},
+		{"users", "User"},
+		{"areas", "Area"},
+		{"tenants", "Tenant"},
+		{"files", "File"},
+		{"commodities", "Commodity"},
+	}
+
+	db := &goschema.Database{}
+	for _, tbl := range tables {
+		db.Tables = append(db.Tables, goschema.Table{Name: tbl.table, StructName: tbl.structName})
+		db.Fields = append(db.Fields,
+			goschema.Field{StructName: tbl.structName, Name: "id", Type: "TEXT", Primary: true},
+			goschema.Field{StructName: tbl.structName, Name: "tenant_id", Type: "TEXT"},
+		)
+		db.RLSPolicies = append(db.RLSPolicies, goschema.RLSPolicy{
+			StructName:      tbl.structName,
+			Name:            tbl.table + "_tenant_isolation",
+			Table:           tbl.table,
+			PolicyFor:       "ALL",
+			ToRoles:         "app_role",
+			UsingExpression: "tenant_id = get_current_tenant_id()",
+		})
+		db.RLSEnabledTables = append(db.RLSEnabledTables, goschema.RLSEnabledTable{
+			StructName: tbl.structName,
+			Table:      tbl.table,
+		})
+	}
+	return db
+}
+
+// TestGenerateSchemaDiffSQL_Deterministic guards against issue #59: planning
+// the same schema diff repeatedly must produce byte-identical SQL. Go
+// randomizes map iteration order, so any statement emitted while ranging over
+// a map (historically the ENABLE ROW LEVEL SECURITY statements in the
+// postgres planner) permutes between runs unless the keys are sorted first.
+func TestGenerateSchemaDiffSQL_Deterministic(t *testing.T) {
+	c := qt.New(t)
+
+	gen := multiTenantRLSSchema()
+
+	first := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
+	c.Assert(first, qt.Contains, "ENABLE ROW LEVEL SECURITY")
+
+	for i := range 100 {
+		sql := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
+		c.Assert(sql, qt.Equals, first, qt.Commentf("iteration %d produced different SQL", i))
+	}
+}
+
+// TestGenerateSchemaDiffSQL_EnableRLSSorted pins the ENABLE ROW LEVEL
+// SECURITY statements to alphabetical table order — a stronger guarantee than
+// run-to-run stability alone.
+func TestGenerateSchemaDiffSQL_EnableRLSSorted(t *testing.T) {
+	c := qt.New(t)
+
+	gen := multiTenantRLSSchema()
+	sql := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
+
+	var enableStmts []string
+	for line := range strings.SplitSeq(sql, "\n") {
+		if strings.Contains(line, "ENABLE ROW LEVEL SECURITY") {
+			enableStmts = append(enableStmts, line)
+		}
+	}
+	c.Assert(enableStmts, qt.HasLen, len(gen.Tables))
+	c.Assert(sort.StringsAreSorted(enableStmts), qt.IsTrue,
+		qt.Commentf("ENABLE RLS statements not in sorted table order:\n%s", strings.Join(enableStmts, "\n")))
+}

--- a/migration/planner/determinism_test.go
+++ b/migration/planner/determinism_test.go
@@ -50,26 +50,117 @@ func multiTenantRLSSchema() *goschema.Database {
 			Table:      tbl.table,
 		})
 	}
+	db.Roles = append(db.Roles,
+		goschema.Role{Name: "app_role", Login: true, CreateDB: true, Inherit: true},
+		goschema.Role{Name: "readonly_role", Login: true, CreateRole: true, Inherit: true},
+	)
+	return db
+}
+
+// driftedDatabase builds a database-side schema that has drifted from the
+// generated one in every order-sensitive way at once: columns with 2+ changed
+// properties (the "Modify column" comment ranges over the Changes map), roles
+// with 2+ changed attributes (ALTER ROLE operation order), removed policies
+// (the disable-RLS warning comments) and removed constraints.
+func driftedDatabase(gen *goschema.Database) *dbtypes.DBSchema {
+	db := &dbtypes.DBSchema{}
+	for _, tbl := range gen.Tables {
+		db.Tables = append(db.Tables, dbtypes.DBTable{
+			Name: tbl.Name,
+			Columns: []dbtypes.DBColumn{
+				{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+				// Generated side declares TEXT NOT NULL -> both a type and a
+				// nullability change on the same column.
+				{Name: "tenant_id", DataType: "varchar", IsNullable: "YES"},
+			},
+		})
+		// Present only in the database -> ConstraintsRemoved.
+		db.Constraints = append(db.Constraints, dbtypes.DBConstraint{
+			Name:      "obsolete_" + tbl.Name + "_check",
+			TableName: tbl.Name,
+			Type:      "CHECK",
+		})
+		// Present only in the database -> RLSPoliciesRemoved (drives the
+		// disable-RLS warning comments in the postgres planner).
+		db.RLSPolicies = append(db.RLSPolicies, dbtypes.DBRLSPolicy{
+			Name:  tbl.Name + "_zombie_policy",
+			Table: tbl.Name,
+		})
+	}
+	// Both roles drift in 2+ attributes -> multi-entry RoleDiff.Changes.
+	db.Roles = append(db.Roles,
+		dbtypes.DBRole{Name: "app_role", Login: false, CreateDB: false, Inherit: true},
+		dbtypes.DBRole{Name: "readonly_role", Login: false, CreateRole: false, Inherit: true},
+	)
 	return db
 }
 
 // TestGenerateSchemaDiffSQL_Deterministic guards against issue #59: planning
 // the same schema diff repeatedly must produce byte-identical SQL. Go
 // randomizes map iteration order, so any statement emitted while ranging over
-// a map (historically the ENABLE ROW LEVEL SECURITY statements in the
-// postgres planner) permutes between runs unless the keys are sorted first.
+// a map (the ENABLE ROW LEVEL SECURITY statements, the "Modify column"
+// comments built from colDiff.Changes, the ALTER ROLE operations built from
+// roleDiff.Changes) permutes between runs unless the keys are sorted first.
 func TestGenerateSchemaDiffSQL_Deterministic(t *testing.T) {
+	gen := multiTenantRLSSchema()
+
+	scenarios := []struct {
+		name string
+		db   *dbtypes.DBSchema
+	}{
+		{name: "fresh database", db: &dbtypes.DBSchema{}},
+		{name: "drifted database", db: driftedDatabase(gen)},
+	}
+
+	for _, dialect := range []string{"postgres", "mysql", "mariadb"} {
+		for _, scenario := range scenarios {
+			t.Run(dialect+"/"+scenario.name, func(t *testing.T) {
+				c := qt.New(t)
+
+				first := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+				c.Assert(first, qt.Not(qt.Equals), "")
+
+				for i := range 100 {
+					sql := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+					c.Assert(sql, qt.Equals, first, qt.Commentf("iteration %d produced different SQL", i))
+				}
+			})
+		}
+	}
+}
+
+// TestGenerateSchemaDiffSQL_DriftedFixtureCoverage pins that the drifted
+// fixture really exercises the order-sensitive paths the determinism test is
+// guarding: a multi-property column change and multi-attribute role changes.
+// Without this, a fixture regression could hollow the test out silently.
+func TestGenerateSchemaDiffSQL_DriftedFixtureCoverage(t *testing.T) {
 	c := qt.New(t)
 
 	gen := multiTenantRLSSchema()
+	diff := schemadiff.CompareWithDialect(gen, driftedDatabase(gen), "postgres")
 
-	first := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
-	c.Assert(first, qt.Contains, "ENABLE ROW LEVEL SECURITY")
-
-	for i := range 100 {
-		sql := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
-		c.Assert(sql, qt.Equals, first, qt.Commentf("iteration %d produced different SQL", i))
+	multiChangeColumns := 0
+	for _, tableDiff := range diff.TablesModified {
+		for _, colDiff := range tableDiff.ColumnsModified {
+			if len(colDiff.Changes) >= 2 {
+				multiChangeColumns++
+			}
+		}
 	}
+	c.Assert(multiChangeColumns > 1, qt.IsTrue,
+		qt.Commentf("fixture must produce 2+ columns with 2+ changes each, got %d", multiChangeColumns))
+
+	multiChangeRoles := 0
+	for _, roleDiff := range diff.RolesModified {
+		if len(roleDiff.Changes) >= 2 {
+			multiChangeRoles++
+		}
+	}
+	c.Assert(multiChangeRoles > 1, qt.IsTrue,
+		qt.Commentf("fixture must produce 2+ roles with 2+ changes each, got %d", multiChangeRoles))
+
+	c.Assert(len(diff.RLSPoliciesRemoved) > 1, qt.IsTrue)
+	c.Assert(len(diff.ConstraintsRemoved) > 1, qt.IsTrue)
 }
 
 // TestGenerateSchemaDiffSQL_EnableRLSSorted pins the ENABLE ROW LEVEL

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -2,6 +2,8 @@ package mysql
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -350,10 +352,12 @@ func (p *Planner) modifyExistingColumns(result []ast.Node, tableDiff *types.Tabl
 		}
 		result = append(result, alterNode)
 
-		// Add a comment showing what changes are being made
+		// Add a comment showing what changes are being made. Iterate the
+		// changes in sorted key order so migration output is deterministic
+		// (issue #59).
 		changesList := make([]string, 0, len(colDiff.Changes))
-		for changeType, change := range colDiff.Changes {
-			changesList = append(changesList, fmt.Sprintf("%s: %s", changeType, change))
+		for _, changeType := range slices.Sorted(maps.Keys(colDiff.Changes)) {
+			changesList = append(changesList, fmt.Sprintf("%s: %s", changeType, colDiff.Changes[changeType]))
 		}
 		astCommentNode := ast.NewComment(fmt.Sprintf("Modify column %s.%s: %s", tableDiff.TableName, colDiff.ColumnName, strings.Join(changesList, ", ")))
 		result = append(result, astCommentNode)

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -991,6 +991,18 @@ func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []a
 	return result
 }
 
+// sortedKeys returns the keys of a string-keyed set in sorted order. Map
+// iteration order is randomized in Go, so any SQL emitted while ranging over a
+// map must go through this to keep migration output deterministic (issue #59).
+func sortedKeys(set map[string]bool) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	// Create a set of tables that need RLS enabled
 	tablesNeedingRLS := make(map[string]bool)
@@ -998,8 +1010,9 @@ func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, g
 		tablesNeedingRLS[policy.Table] = true
 	}
 
-	// Enable RLS on tables that have policies but don't have RLS enabled yet
-	for tableName := range tablesNeedingRLS {
+	// Enable RLS on tables that have policies but don't have RLS enabled yet.
+	// Iterate in sorted order so migration output is deterministic (issue #59).
+	for _, tableName := range sortedKeys(tablesNeedingRLS) {
 		// Check if this table is being added or if RLS is being enabled
 		tableIsNew := slices.Contains(diff.TablesAdded, tableName)
 
@@ -1022,7 +1035,7 @@ func (p *Planner) disableRLSOnTables(result []ast.Node, diff *types.SchemaDiff) 
 
 	// For each table that had policies removed, add a comment about potentially disabling RLS
 	// Note: We don't automatically disable RLS because there might be other policies on the table
-	for tableName := range tablesWithRemovedPolicies {
+	for _, tableName := range sortedKeys(tablesWithRemovedPolicies) {
 		warningComment := ast.NewComment(fmt.Sprintf("NOTE: RLS policies were removed from table %s - verify if RLS should be disabled", tableName))
 		result = append(result, warningComment)
 	}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -2,8 +2,8 @@ package postgres
 
 import (
 	"fmt"
+	"maps"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -422,10 +422,12 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 		}
 		result = append(result, alterNode)
 
-		// Add a comment showing what changes are being made
+		// Add a comment showing what changes are being made. Iterate the
+		// changes in sorted key order so migration output is deterministic
+		// (issue #59).
 		changesList := make([]string, 0, len(colDiff.Changes))
-		for changeType, change := range colDiff.Changes {
-			changesList = append(changesList, fmt.Sprintf("%s: %s", changeType, change))
+		for _, changeType := range slices.Sorted(maps.Keys(colDiff.Changes)) {
+			changesList = append(changesList, fmt.Sprintf("%s: %s", changeType, colDiff.Changes[changeType]))
 		}
 		astCommentNode := ast.NewComment(fmt.Sprintf("Modify column %s.%s: %s", tableDiff.TableName, colDiff.ColumnName, strings.Join(changesList, ", ")))
 		result = append(result, astCommentNode)
@@ -789,8 +791,10 @@ func (p *Planner) findTargetRole(roleName string, generated *goschema.Database) 
 func (p *Planner) buildAlterRoleNode(roleDiff types.RoleDiff, targetRole *goschema.Role) *ast.AlterRoleNode {
 	alterRoleNode := ast.NewAlterRole(roleDiff.RoleName)
 
-	for changeType, changeValue := range roleDiff.Changes {
-		p.addRoleOperation(alterRoleNode, changeType, changeValue, targetRole)
+	// Sorted key order keeps the ALTER ROLE operation order deterministic
+	// across runs (issue #59).
+	for _, changeType := range slices.Sorted(maps.Keys(roleDiff.Changes)) {
+		p.addRoleOperation(alterRoleNode, changeType, roleDiff.Changes[changeType], targetRole)
 	}
 
 	return alterRoleNode
@@ -973,12 +977,7 @@ func (p *Planner) modifyExistingFunctions(result []ast.Node, diff *types.SchemaD
 // summarizeFunctionChanges produces a deterministic one-line summary of the
 // changed attributes for use as a SQL comment.
 func summarizeFunctionChanges(fnDiff types.FunctionDiff) string {
-	keys := make([]string, 0, len(fnDiff.Changes))
-	for k := range fnDiff.Changes {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return strings.Join(keys, ", ")
+	return strings.Join(slices.Sorted(maps.Keys(fnDiff.Changes)), ", ")
 }
 
 func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
@@ -991,18 +990,6 @@ func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []a
 	return result
 }
 
-// sortedKeys returns the keys of a string-keyed set in sorted order. Map
-// iteration order is randomized in Go, so any SQL emitted while ranging over a
-// map must go through this to keep migration output deterministic (issue #59).
-func sortedKeys(set map[string]bool) []string {
-	keys := make([]string, 0, len(set))
-	for k := range set {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	// Create a set of tables that need RLS enabled
 	tablesNeedingRLS := make(map[string]bool)
@@ -1012,7 +999,7 @@ func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, g
 
 	// Enable RLS on tables that have policies but don't have RLS enabled yet.
 	// Iterate in sorted order so migration output is deterministic (issue #59).
-	for _, tableName := range sortedKeys(tablesNeedingRLS) {
+	for _, tableName := range slices.Sorted(maps.Keys(tablesNeedingRLS)) {
 		// Check if this table is being added or if RLS is being enabled
 		tableIsNew := slices.Contains(diff.TablesAdded, tableName)
 
@@ -1035,7 +1022,7 @@ func (p *Planner) disableRLSOnTables(result []ast.Node, diff *types.SchemaDiff) 
 
 	// For each table that had policies removed, add a comment about potentially disabling RLS
 	// Note: We don't automatically disable RLS because there might be other policies on the table
-	for _, tableName := range sortedKeys(tablesWithRemovedPolicies) {
+	for _, tableName := range slices.Sorted(maps.Keys(tablesWithRemovedPolicies)) {
 		warningComment := ast.NewComment(fmt.Sprintf("NOTE: RLS policies were removed from table %s - verify if RLS should be disabled", tableName))
 		result = append(result, warningComment)
 	}

--- a/migration/schemadiff/determinism_test.go
+++ b/migration/schemadiff/determinism_test.go
@@ -1,0 +1,152 @@
+package schemadiff_test
+
+import (
+	"sort"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// driftedSchemas builds a generated/database schema pair where every
+// "modified" diff category has at least two entries: modified tables (with
+// both added and modified columns), modified enums, modified functions,
+// modified RLS policies, and added constraints. All source collections are
+// declared out of alphabetical order so ordering must come from sorting, not
+// from input order.
+func driftedSchemas() (*goschema.Database, *types.DBSchema) {
+	tableNames := []struct {
+		table      string
+		structName string
+	}{
+		{"locations", "Location"},
+		{"users", "User"},
+		{"areas", "Area"},
+		{"tenants", "Tenant"},
+	}
+
+	gen := &goschema.Database{}
+	db := &types.DBSchema{}
+
+	for _, tbl := range tableNames {
+		gen.Tables = append(gen.Tables, goschema.Table{Name: tbl.table, StructName: tbl.structName})
+		gen.Fields = append(gen.Fields,
+			goschema.Field{StructName: tbl.structName, Name: "id", Type: "TEXT", Primary: true},
+			// Nullable in the database but NOT NULL in the generated schema -> ColumnsModified.
+			goschema.Field{StructName: tbl.structName, Name: "flag", Type: "TEXT"},
+			// Missing from the database -> ColumnsAdded.
+			goschema.Field{StructName: tbl.structName, Name: "extra", Type: "TEXT", Nullable: true},
+		)
+		db.Tables = append(db.Tables, types.DBTable{
+			Name: tbl.table,
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "flag", DataType: "text", IsNullable: "YES"},
+			},
+		})
+		// Present only in the generated schema -> ConstraintsAdded.
+		gen.Constraints = append(gen.Constraints, goschema.Constraint{
+			StructName:      tbl.structName,
+			Name:            tbl.table + "_flag_check",
+			Type:            "CHECK",
+			Table:           tbl.table,
+			CheckExpression: "flag <> ''",
+		})
+	}
+
+	for _, enumName := range []string{"enum_status", "enum_kind", "enum_area_type"} {
+		gen.Enums = append(gen.Enums, goschema.Enum{Name: enumName, Values: []string{"a", "b", "c"}})
+		// Missing value "c" -> EnumsModified.
+		db.Enums = append(db.Enums, types.DBEnum{Name: enumName, Values: []string{"a", "b"}})
+	}
+
+	for _, fnName := range []string{"set_tenant_context", "get_current_tenant_id", "audit_row"} {
+		gen.Functions = append(gen.Functions, goschema.Function{
+			Name: fnName, Returns: "TEXT", Language: "plpgsql", Body: "BEGIN RETURN 'x'; END;",
+		})
+		// Different return type -> FunctionsModified.
+		db.Functions = append(db.Functions, types.DBFunction{
+			Name: fnName, Returns: "VOID", Language: "plpgsql", Body: "BEGIN RETURN 'x'; END;",
+		})
+	}
+
+	for _, tbl := range []string{"users", "tenants", "areas"} {
+		policyName := tbl + "_tenant_isolation"
+		gen.RLSPolicies = append(gen.RLSPolicies, goschema.RLSPolicy{
+			Name: policyName, Table: tbl, PolicyFor: "ALL", ToRoles: "app_role",
+			UsingExpression: "tenant_id = get_current_tenant_id()",
+		})
+		// Different FOR clause -> RLSPoliciesModified.
+		db.RLSPolicies = append(db.RLSPolicies, types.DBRLSPolicy{
+			Name: policyName, Table: tbl, PolicyFor: "SELECT", ToRoles: "app_role",
+			UsingExpression: "tenant_id = get_current_tenant_id()",
+		})
+	}
+
+	return gen, db
+}
+
+// TestCompare_Deterministic guards against issue #59: comparing the same
+// schema pair repeatedly must produce an identical diff. The compare layer
+// builds its lists while ranging over maps, so every list — including the
+// *Modified ones — must be sorted before being returned.
+func TestCompare_Deterministic(t *testing.T) {
+	c := qt.New(t)
+
+	gen, db := driftedSchemas()
+	first := schemadiff.Compare(gen, db)
+
+	// Sanity-check that the fixtures actually exercise every category this
+	// test is guarding, so a fixture regression can't silently hollow it out.
+	c.Assert(len(first.TablesModified) > 1, qt.IsTrue)
+	c.Assert(len(first.TablesModified[0].ColumnsModified) > 0, qt.IsTrue)
+	c.Assert(len(first.EnumsModified) > 1, qt.IsTrue)
+	c.Assert(len(first.FunctionsModified) > 1, qt.IsTrue)
+	c.Assert(len(first.RLSPoliciesModified) > 1, qt.IsTrue)
+	c.Assert(len(first.ConstraintsAdded) > 1, qt.IsTrue)
+	c.Assert(len(first.ConstraintsAddedWithTables) > 1, qt.IsTrue)
+
+	for i := range 100 {
+		c.Assert(schemadiff.Compare(gen, db), qt.DeepEquals, first,
+			qt.Commentf("iteration %d produced a different diff", i))
+	}
+}
+
+// TestCompare_ModifiedListsSorted pins the ordering contract: all diff lists
+// come out sorted by their natural key, not merely stable.
+func TestCompare_ModifiedListsSorted(t *testing.T) {
+	c := qt.New(t)
+
+	gen, db := driftedSchemas()
+	diff := schemadiff.Compare(gen, db)
+
+	c.Assert(sort.SliceIsSorted(diff.TablesModified, func(i, j int) bool {
+		return diff.TablesModified[i].TableName < diff.TablesModified[j].TableName
+	}), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.EnumsModified, func(i, j int) bool {
+		return diff.EnumsModified[i].EnumName < diff.EnumsModified[j].EnumName
+	}), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.FunctionsModified, func(i, j int) bool {
+		return diff.FunctionsModified[i].FunctionName < diff.FunctionsModified[j].FunctionName
+	}), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.RLSPoliciesModified, func(i, j int) bool {
+		return diff.RLSPoliciesModified[i].PolicyName < diff.RLSPoliciesModified[j].PolicyName
+	}), qt.IsTrue)
+	c.Assert(sort.StringsAreSorted(diff.ConstraintsAdded), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.ConstraintsAddedWithTables, func(i, j int) bool {
+		a, b := diff.ConstraintsAddedWithTables[i], diff.ConstraintsAddedWithTables[j]
+		if a.TableName != b.TableName {
+			return a.TableName < b.TableName
+		}
+		return a.Name < b.Name
+	}), qt.IsTrue)
+
+	for _, tableDiff := range diff.TablesModified {
+		c.Assert(sort.SliceIsSorted(tableDiff.ColumnsModified, func(i, j int) bool {
+			return tableDiff.ColumnsModified[i].ColumnName < tableDiff.ColumnsModified[j].ColumnName
+		}), qt.IsTrue)
+	}
+}

--- a/migration/schemadiff/determinism_test.go
+++ b/migration/schemadiff/determinism_test.go
@@ -12,11 +12,13 @@ import (
 )
 
 // driftedSchemas builds a generated/database schema pair where every
-// "modified" diff category has at least two entries: modified tables (with
-// both added and modified columns), modified enums, modified functions,
-// modified RLS policies, and added constraints. All source collections are
-// declared out of alphabetical order so ordering must come from sorting, not
-// from input order.
+// "modified" and "removed" diff category has at least two entries: modified
+// tables (with added and multi-property-modified columns), modified enums,
+// modified functions, modified RLS policies, modified roles, plus added AND
+// removed constraints. All source collections are declared out of
+// alphabetical order so ordering must come from sorting, not from input
+// order, and multi-entry Changes maps catch consumers that range over them
+// unsorted.
 func driftedSchemas() (*goschema.Database, *types.DBSchema) {
 	tableNames := []struct {
 		table      string
@@ -35,7 +37,8 @@ func driftedSchemas() (*goschema.Database, *types.DBSchema) {
 		gen.Tables = append(gen.Tables, goschema.Table{Name: tbl.table, StructName: tbl.structName})
 		gen.Fields = append(gen.Fields,
 			goschema.Field{StructName: tbl.structName, Name: "id", Type: "TEXT", Primary: true},
-			// Nullable in the database but NOT NULL in the generated schema -> ColumnsModified.
+			// Database side is nullable varchar -> both a type change and a
+			// nullability change on the same column (multi-entry Changes map).
 			goschema.Field{StructName: tbl.structName, Name: "flag", Type: "TEXT"},
 			// Missing from the database -> ColumnsAdded.
 			goschema.Field{StructName: tbl.structName, Name: "extra", Type: "TEXT", Nullable: true},
@@ -44,7 +47,7 @@ func driftedSchemas() (*goschema.Database, *types.DBSchema) {
 			Name: tbl.table,
 			Columns: []types.DBColumn{
 				{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
-				{Name: "flag", DataType: "text", IsNullable: "YES"},
+				{Name: "flag", DataType: "varchar", IsNullable: "YES"},
 			},
 		})
 		// Present only in the generated schema -> ConstraintsAdded.
@@ -55,12 +58,25 @@ func driftedSchemas() (*goschema.Database, *types.DBSchema) {
 			Table:           tbl.table,
 			CheckExpression: "flag <> ''",
 		})
+		// Present only in the database -> ConstraintsRemoved.
+		db.Constraints = append(db.Constraints, types.DBConstraint{
+			Name:      "obsolete_" + tbl.table + "_check",
+			TableName: tbl.table,
+			Type:      "CHECK",
+		})
 	}
 
 	for _, enumName := range []string{"enum_status", "enum_kind", "enum_area_type"} {
 		gen.Enums = append(gen.Enums, goschema.Enum{Name: enumName, Values: []string{"a", "b", "c"}})
 		// Missing value "c" -> EnumsModified.
 		db.Enums = append(db.Enums, types.DBEnum{Name: enumName, Values: []string{"a", "b"}})
+	}
+
+	// Both roles drift in 2+ attributes -> RolesModified with multi-entry
+	// Changes maps.
+	for _, roleName := range []string{"app_role", "admin_role"} {
+		gen.Roles = append(gen.Roles, goschema.Role{Name: roleName, Login: true, CreateDB: true, Inherit: true})
+		db.Roles = append(db.Roles, types.DBRole{Name: roleName, Login: false, CreateDB: false, Inherit: true})
 	}
 
 	for _, fnName := range []string{"set_tenant_context", "get_current_tenant_id", "audit_row"} {
@@ -103,11 +119,18 @@ func TestCompare_Deterministic(t *testing.T) {
 	// test is guarding, so a fixture regression can't silently hollow it out.
 	c.Assert(len(first.TablesModified) > 1, qt.IsTrue)
 	c.Assert(len(first.TablesModified[0].ColumnsModified) > 0, qt.IsTrue)
+	c.Assert(len(first.TablesModified[0].ColumnsModified[0].Changes) > 1, qt.IsTrue,
+		qt.Commentf("modified columns must carry 2+ changes to catch unsorted Changes-map consumers"))
 	c.Assert(len(first.EnumsModified) > 1, qt.IsTrue)
 	c.Assert(len(first.FunctionsModified) > 1, qt.IsTrue)
 	c.Assert(len(first.RLSPoliciesModified) > 1, qt.IsTrue)
+	c.Assert(len(first.RolesModified) > 1, qt.IsTrue)
+	c.Assert(len(first.RolesModified[0].Changes) > 1, qt.IsTrue,
+		qt.Commentf("modified roles must carry 2+ changes to catch unsorted Changes-map consumers"))
 	c.Assert(len(first.ConstraintsAdded) > 1, qt.IsTrue)
 	c.Assert(len(first.ConstraintsAddedWithTables) > 1, qt.IsTrue)
+	c.Assert(len(first.ConstraintsRemoved) > 1, qt.IsTrue)
+	c.Assert(len(first.ConstraintsRemovedWithTables) > 1, qt.IsTrue)
 
 	for i := range 100 {
 		c.Assert(schemadiff.Compare(gen, db), qt.DeepEquals, first,
@@ -142,6 +165,17 @@ func TestCompare_ModifiedListsSorted(t *testing.T) {
 			return a.TableName < b.TableName
 		}
 		return a.Name < b.Name
+	}), qt.IsTrue)
+	c.Assert(sort.StringsAreSorted(diff.ConstraintsRemoved), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.ConstraintsRemovedWithTables, func(i, j int) bool {
+		a, b := diff.ConstraintsRemovedWithTables[i], diff.ConstraintsRemovedWithTables[j]
+		if a.TableName != b.TableName {
+			return a.TableName < b.TableName
+		}
+		return a.Name < b.Name
+	}), qt.IsTrue)
+	c.Assert(sort.SliceIsSorted(diff.RolesModified, func(i, j int) bool {
+		return diff.RolesModified[i].RoleName < diff.RolesModified[j].RoleName
 	}), qt.IsTrue)
 
 	for _, tableDiff := range diff.TablesModified {

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -125,6 +125,9 @@ func TablesAndColumns(generated *goschema.Database, database *types.DBSchema, di
 	// Sort for consistent output
 	sort.Strings(diff.TablesAdded)
 	sort.Strings(diff.TablesRemoved)
+	sort.Slice(diff.TablesModified, func(i, j int) bool {
+		return diff.TablesModified[i].TableName < diff.TablesModified[j].TableName
+	})
 }
 
 // TableColumns performs detailed column-level comparison within a specific table.
@@ -244,6 +247,9 @@ func TableColumns(genTable goschema.Table, dbTable types.DBTable, generated *gos
 	// Sort for consistent output
 	sort.Strings(tableDiff.ColumnsAdded)
 	sort.Strings(tableDiff.ColumnsRemoved)
+	sort.Slice(tableDiff.ColumnsModified, func(i, j int) bool {
+		return tableDiff.ColumnsModified[i].ColumnName < tableDiff.ColumnsModified[j].ColumnName
+	})
 
 	return tableDiff
 }
@@ -627,6 +633,9 @@ func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 	// Sort for consistent output
 	sort.Strings(diff.EnumsAdded)
 	sort.Strings(diff.EnumsRemoved)
+	sort.Slice(diff.EnumsModified, func(i, j int) bool {
+		return diff.EnumsModified[i].EnumName < diff.EnumsModified[j].EnumName
+	})
 }
 
 // EnumValues performs detailed value-level comparison between generated and database enum types.
@@ -950,6 +959,26 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 			}
 		}
 	}
+
+	// Sort for consistent output. Planners pair the bare name lists with the
+	// *WithTables slices through name-keyed maps, not by index, so each list
+	// can be sorted independently.
+	sort.Strings(diff.ConstraintsAdded)
+	sort.Strings(diff.ConstraintsRemoved)
+	sort.Slice(diff.ConstraintsAddedWithTables, func(i, j int) bool {
+		a, b := diff.ConstraintsAddedWithTables[i], diff.ConstraintsAddedWithTables[j]
+		if a.TableName != b.TableName {
+			return a.TableName < b.TableName
+		}
+		return a.Name < b.Name
+	})
+	sort.Slice(diff.ConstraintsRemovedWithTables, func(i, j int) bool {
+		a, b := diff.ConstraintsRemovedWithTables[i], diff.ConstraintsRemovedWithTables[j]
+		if a.TableName != b.TableName {
+			return a.TableName < b.TableName
+		}
+		return a.Name < b.Name
+	})
 }
 
 // appendConstraintRemoval records the table-qualified removal info for a
@@ -1834,6 +1863,9 @@ func Functions(generated *goschema.Database, database *types.DBSchema, diff *dif
 	// Ensure consistent ordering of results
 	sort.Strings(diff.FunctionsAdded)
 	sort.Strings(diff.FunctionsRemoved)
+	sort.Slice(diff.FunctionsModified, func(i, j int) bool {
+		return diff.FunctionsModified[i].FunctionName < diff.FunctionsModified[j].FunctionName
+	})
 }
 
 // RLSPolicies performs PostgreSQL RLS policy comparison between generated and database schemas.
@@ -1937,6 +1969,9 @@ func RLSPolicies(generated *goschema.Database, database *types.DBSchema, diff *d
 	sort.Strings(diff.RLSPoliciesAdded)
 	sort.Slice(diff.RLSPoliciesRemoved, func(i, j int) bool {
 		return diff.RLSPoliciesRemoved[i].PolicyName < diff.RLSPoliciesRemoved[j].PolicyName
+	})
+	sort.Slice(diff.RLSPoliciesModified, func(i, j int) bool {
+		return diff.RLSPoliciesModified[i].PolicyName < diff.RLSPoliciesModified[j].PolicyName
 	})
 }
 

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -194,11 +194,13 @@ type SchemaDiff struct {
 	ConstraintsAdded []string `json:"constraints_added"`
 
 	// ConstraintsAddedWithTables contains the table-qualified definitions of the
-	// constraints in ConstraintsAdded, in parallel (mirroring
-	// ConstraintsRemovedWithTables). Planners read this to add a field-level FK
-	// to its concrete host table rather than re-deriving the table from a Go
-	// struct name — which breaks for FK names shared across the many tables that
-	// embed an inline-relation mixin (issue #197).
+	// constraints in ConstraintsAdded. It is NOT index-aligned with
+	// ConstraintsAdded — each list is sorted independently (ConstraintsAdded by
+	// name, this one by table then name), so consumers must correlate entries
+	// by constraint name, never by position. Planners read this to add a
+	// field-level FK to its concrete host table rather than re-deriving the
+	// table from a Go struct name — which breaks for FK names shared across
+	// the many tables that embed an inline-relation mixin (issue #197).
 	ConstraintsAddedWithTables []ConstraintAdditionInfo `json:"constraints_added_with_tables"`
 
 	// ConstraintsRemoved contains names of constraints that exist in the current database
@@ -208,8 +210,10 @@ type SchemaDiff struct {
 	// ConstraintsRemovedWithTables contains detailed information about constraints that
 	// need to be removed, including the constraint name, owning table, and type. This is
 	// used by database dialects that require the table name and a type-specific drop
-	// syntax (e.g. MySQL/MariaDB FOREIGN KEY constraints use DROP FOREIGN KEY). It runs
-	// in parallel to ConstraintsRemoved (mirroring IndexesRemovedWithTables).
+	// syntax (e.g. MySQL/MariaDB FOREIGN KEY constraints use DROP FOREIGN KEY). It is
+	// NOT index-aligned with ConstraintsRemoved — each list is sorted independently
+	// (ConstraintsRemoved by name, this one by table then name), so consumers must
+	// correlate entries by constraint name, never by position.
 	ConstraintsRemovedWithTables []ConstraintRemovalInfo `json:"constraints_removed_with_tables"`
 }
 


### PR DESCRIPTION
## Summary

Closes #59 — the remaining sources of non-deterministic migration generation. All of them are the same bug class: SQL-affecting lists built while ranging over a Go map (iteration order is randomized) without sorting afterwards.

## Reproduction

Running parse → `schemadiff.Compare` (vs empty DB) → `planner.GenerateSchemaDiffSQL` on `integration/fixtures/entities/016-rls-multiple-files` diverged **at iteration 1 in 3/3 attempts** — the `ALTER TABLE … ENABLE ROW LEVEL SECURITY` statements permute between runs. Notably, #59 was filed 12 days *after* PR #20 fixed the `deduplicate()` map randomization; the reporter's RLS-heavy schema was hitting exactly this planner path. Since #251 landed, this also breaks the `ptah.sum` integrity workflow: regenerating an identical schema produced a different hash.

## Fixes

- **postgres planner** (the reproducible bug): `enableRLSOnTables` / `disableRLSOnTables` iterated `map[string]bool` directly; they now go through a `sortedKeys` helper.
- **compare**: `ConstraintsAdded`/`ConstraintsRemoved` and the `*WithTables` parallel slices were never sorted; neither were any of the `*Modified` lists (`TablesModified`, `ColumnsModified`, `EnumsModified`, `FunctionsModified`, `RLSPoliciesModified`). All sorted by their natural key now. Planners pair the bare name lists with the `*WithTables` slices via name-keyed maps, not by index, so independent sorts are safe.
- **goschema / fromschema** (latent): `getUniqueStructNames` (both copies) and `FunctionDependencies` entries returned map keys unsorted. Today's consumers are order-independent, but they're one refactor away from not being.

Verified untouched because already deterministic: table/function topological sorts (sorted Kahn queue + `insertSortedString`), the Added/Removed lists in compare, enum value lists, extension ordering.

## Testing

- `migration/planner/determinism_test.go` — runs the full compare→plan pipeline 100× over an RLS-heavy schema, asserts byte-identical SQL, and pins ENABLE RLS statements to sorted table order.
- `migration/schemadiff/determinism_test.go` — drifted-schema pair exercising every `*Modified` category plus constraint additions; 100× `Compare` asserted `DeepEquals`, plus explicit sorted-order assertions. Fixture self-checks guard against the test silently going hollow.
- **Both tests verified to FAIL against the unfixed code** (planner fix reverted → sorted-order test fails; `TablesModified` sort removed → compare test fails).
- End-to-end: the original reproducer is now deterministic — 5 processes × 50 in-process iterations, byte-identical output (postgres and mysql dialects).
- `go test ./...`, `golangci-lint run ./...` (0 issues), `go tool qtlint ./...` — clean.

https://claude.ai/code/session_01BheoCghDrNMowdZjChA5RB