### PR TITLE
Add destructive migration safety gate

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/safety"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
@@ -27,8 +29,11 @@ the SQL statements needed to update the database to match your entities.`,
 }
 
 const (
-	rootDirFlag = "root-dir"
-	dbURLFlag   = "db-url"
+	rootDirFlag          = "root-dir"
+	dbURLFlag            = "db-url"
+	checkDestructiveFlag = "check-destructive"
+	allowDestructiveFlag = "allow-destructive"
+	reportFormatFlag     = "report"
 )
 
 var migrateFlags = map[string]cobraflags.Flag{
@@ -42,6 +47,21 @@ var migrateFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
+	checkDestructiveFlag: &cobraflags.BoolFlag{
+		Name:  checkDestructiveFlag,
+		Value: false,
+		Usage: "Fail when generated migration SQL contains destructive statements",
+	},
+	allowDestructiveFlag: &cobraflags.BoolFlag{
+		Name:  allowDestructiveFlag,
+		Value: false,
+		Usage: "Allow destructive statements when --check-destructive is set",
+	},
+	reportFormatFlag: &cobraflags.StringFlag{
+		Name:  reportFormatFlag,
+		Value: "text",
+		Usage: "Safety report format: text or html",
+	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
@@ -51,17 +71,25 @@ func NewMigrateCommand() *cobra.Command {
 	return migrateCmd
 }
 
-func migrateCommand(_ *cobra.Command, _ []string) error {
+func migrateCommand(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
 	rootDir := migrateFlags[rootDirFlag].GetString()
 	dbURL := migrateFlags[dbURLFlag].GetString()
+	checkDestructive := migrateFlags[checkDestructiveFlag].GetBool()
+	allowDestructive := migrateFlags[allowDestructiveFlag].GetBool()
+	reportFormat := strings.ToLower(strings.TrimSpace(migrateFlags[reportFormatFlag].GetString()))
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
-
-	fmt.Printf("Generating migration from %s to database %s\n", rootDir, dbschema.FormatDatabaseURL(dbURL))
-	fmt.Println("=== GENERATE MIGRATION SQL ===")
-	fmt.Println()
+	if reportFormat != "text" && reportFormat != "html" {
+		return fmt.Errorf("unsupported report format %q", reportFormat)
+	}
+	if reportFormat != "html" {
+		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootDir, dbschema.FormatDatabaseURL(dbURL))
+		fmt.Fprintln(out, "=== GENERATE MIGRATION SQL ===")
+		fmt.Fprintln(out)
+	}
 
 	// 1. Parse Go entities
 	absPath, err := filepath.Abs(rootDir)
@@ -99,34 +127,53 @@ func migrateCommand(_ *cobra.Command, _ []string) error {
 
 	// 4. Display differences summary
 	astNodes := planner.GenerateSchemaDiffAST(diff, result, conn.Info().Dialect)
-	fmt.Print(astNodes)
+	assessments, err := safety.AssessRendered(astNodes, conn.Info().Dialect)
+	if err != nil {
+		return fmt.Errorf("error assessing migration safety: %w", err)
+	}
+	if reportFormat == "html" {
+		if err := safety.RenderHTML(out, assessments); err != nil {
+			return fmt.Errorf("error rendering safety report: %w", err)
+		}
+		if checkDestructive && safety.HasDestructiveAssessment(assessments) && !allowDestructive {
+			return fmt.Errorf("destructive migration statements require --allow-destructive")
+		}
+		return nil
+	}
+	fmt.Fprint(out, astNodes)
+	if err := safety.RenderText(out, assessments); err != nil {
+		return fmt.Errorf("error rendering safety report: %w", err)
+	}
+	if checkDestructive && safety.HasDestructiveAssessment(assessments) && !allowDestructive {
+		return fmt.Errorf("destructive migration statements require --allow-destructive")
+	}
 
 	if !diff.HasChanges() {
 		return nil
 	}
 
 	// 5. Generate migration SQL
-	fmt.Println("=== MIGRATION SQL ===")
-	fmt.Println()
+	fmt.Fprintln(out, "=== MIGRATION SQL ===")
+	fmt.Fprintln(out)
 
 	statements, err := renderer.RenderSQL(conn.Info().Dialect, astNodes...)
 	if err != nil {
 		return fmt.Errorf("error rendering SQL: %w", err)
 	}
 
-	fmt.Println("-- Migration generated from schema differences")
-	fmt.Printf("-- Generated on: %s\n", "now") // You could add actual timestamp
-	fmt.Printf("-- Source: %s\n", rootDir)
-	fmt.Printf("-- Target: %s\n", dbschema.FormatDatabaseURL(dbURL))
-	fmt.Println()
+	fmt.Fprintln(out, "-- Migration generated from schema differences")
+	fmt.Fprintf(out, "-- Generated on: %s\n", "now") // You could add actual timestamp
+	fmt.Fprintf(out, "-- Source: %s\n", rootDir)
+	fmt.Fprintf(out, "-- Target: %s\n", dbschema.FormatDatabaseURL(dbURL))
+	fmt.Fprintln(out)
 
 	for _, statement := range statements {
-		fmt.Println(statement)
+		fmt.Fprintln(out, statement)
 	}
 
-	fmt.Println()
-	fmt.Printf("Generated %d migration statements.\n", len(statements))
-	fmt.Println("⚠️  Review the SQL carefully before executing!")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Generated %d migration statements.\n", len(statements))
+	fmt.Fprintln(out, "⚠️  Review the SQL carefully before executing!")
 
 	return nil
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -3,13 +3,16 @@ package migrateup
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/onlineddl"
@@ -36,6 +39,7 @@ const (
 	verifySumFlag        = "verify-sum"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
+	allowDestructiveFlag = "allow-destructive"
 )
 
 var migrateUpFlags = map[string]cobraflags.Flag{
@@ -74,6 +78,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Default per-migration statement timeout, such as 30s or 2m",
 	},
+	allowDestructiveFlag: &cobraflags.BoolFlag{
+		Name:  allowDestructiveFlag,
+		Value: false,
+		Usage: "Allow pending migrations that contain destructive statements",
+	},
 	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:           dbcli.NewConfigFlag(),
 	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
@@ -93,6 +102,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	verifySum := migrateUpFlags[verifySumFlag].GetBool()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
+	allowDestructive := migrateUpFlags[allowDestructiveFlag].GetBool()
 	migrationsSchema := migrateUpFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateUpFlags[dbcli.MigrationsTableFlagName].GetString()
 
@@ -196,6 +206,16 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 		fmt.Printf("Pending migration versions: %v\n", status.PendingMigrations)
 	}
 
+	if !allowDestructive {
+		findings, err := lintPendingDestructive(migrationsFS, status.PendingMigrations, conn.Info().Dialect)
+		if err != nil {
+			return fmt.Errorf("error checking pending migration safety: %w", err)
+		}
+		if len(findings) > 0 {
+			return fmt.Errorf("pending migrations contain destructive statements; rerun with --allow-destructive after review:\n%s", formatDestructiveFindings(findings))
+		}
+	}
+
 	fmt.Println()
 
 	// Run migrations
@@ -220,4 +240,34 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func lintPendingDestructive(fsys fs.FS, pending []int, dialect string) ([]lint.Finding, error) {
+	findings, err := lint.LintFS(fsys, lint.Options{
+		Dialect:  dialect,
+		Disabled: []string{"MF", "BC", "PG", "MY"},
+		Versions: pending,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var destructive []lint.Finding
+	for _, finding := range findings {
+		if strings.HasPrefix(finding.Rule, "DS") {
+			destructive = append(destructive, finding)
+		}
+	}
+	return destructive, nil
+}
+
+func formatDestructiveFindings(findings []lint.Finding) string {
+	var b strings.Builder
+	for _, finding := range findings {
+		if finding.Line > 0 {
+			fmt.Fprintf(&b, "- %s:%d %s %s: %s\n", finding.File, finding.Line, finding.Rule, finding.Severity, finding.Message)
+			continue
+		}
+		fmt.Fprintf(&b, "- %s %s %s: %s\n", finding.File, finding.Rule, finding.Severity, finding.Message)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	qt "github.com/frankban/quicktest"
 
@@ -48,4 +49,28 @@ func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "(?s).*ptah.sum verification failed.*")
 	c.Assert(err, qt.ErrorMatches, "(?s).*changed: 0000000001_init.up.sql.*",
 		qt.Commentf("the drift diagnostic identifies the tampered file"))
+}
+
+func TestLintPendingDestructiveScansOnlyPendingVersions(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_old.up.sql":   &fstest.MapFile{Data: []byte("DROP TABLE old_data;\n")},
+		"0000000001_old.down.sql": &fstest.MapFile{Data: []byte("CREATE TABLE old_data (id INT);\n")},
+		"0000000002_next.up.sql": &fstest.MapFile{Data: []byte(`ALTER TABLE users DROP COLUMN legacy;
+DROP TYPE old_status;
+DROP POLICY tenant_isolation ON accounts;
+TRUNCATE TABLE audit_log;
+ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
+`)},
+		"0000000002_next.down.sql": &fstest.MapFile{
+			Data: []byte("ALTER TABLE users ADD COLUMN legacy TEXT;\n"),
+		},
+	}
+
+	findings, err := lintPendingDestructive(fsys, []int{2}, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 5)
+	c.Assert([]string{findings[0].Rule, findings[1].Rule, findings[2].Rule, findings[3].Rule, findings[4].Rule}, qt.DeepEquals, []string{"DS102", "DS107", "DS107", "DS108", "DS109"})
+	c.Assert(findings[0].File, qt.Equals, "0000000002_next.up.sql")
 }

--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -60,6 +60,16 @@ func (op *DropColumnOperation) alterOperation() {}
 type ModifyColumnOperation struct {
 	// Column contains the new column definition
 	Column *ColumnNode
+	// PreviousType is the best-known existing database type before the
+	// modification. Renderers ignore this metadata; safety analysis uses it to
+	// distinguish narrowing changes from other column modifications.
+	PreviousType string
+	// PreviousNullable is the best-known existing database nullability before
+	// the modification. Renderers ignore this metadata; safety analysis uses it
+	// to distinguish DROP NOT NULL from SET NOT NULL.
+	PreviousNullable bool
+	// HasPreviousNullable reports whether PreviousNullable was populated.
+	HasPreviousNullable bool
 }
 
 // Accept implements the Node interface for ModifyColumnOperation.

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -21,6 +21,7 @@ import (
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/safety"
 	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -44,13 +45,22 @@ type GenerateMigrationOptions struct {
 	// Schemas restricts database introspection to the listed schemas when the
 	// connected dialect supports schema scoping.
 	Schemas []string
+	// CheckDestructive refuses to generate destructive up migrations unless
+	// AllowDestructive is set.
+	CheckDestructive bool
+	// AllowDestructive permits destructive up migrations when CheckDestructive is set.
+	AllowDestructive bool
+	// ReportFormat optionally writes a safety report next to generated files.
+	// Supported values: "", "html".
+	ReportFormat string
 }
 
 // MigrationFiles represents the generated migration files
 type MigrationFiles struct {
-	UpFile   string // Path to the up migration file
-	DownFile string // Path to the down migration file
-	Version  int    // Migration version (timestamp)
+	UpFile     string // Path to the up migration file
+	DownFile   string // Path to the down migration file
+	ReportFile string // Path to the safety report file, when requested
+	Version    int    // Migration version (timestamp)
 }
 
 // GenerateMigration generates both up and down migration files by comparing
@@ -127,6 +137,15 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	version := migrator.GetNextMigrationVersion()
 	slog.Debug("Generated migration version", "version", version)
 
+	upNodes := planner.GenerateSchemaDiffAST(diff, generated, conn.Info().Dialect)
+	assessments, err := safety.AssessRendered(upNodes, conn.Info().Dialect)
+	if err != nil {
+		return nil, fmt.Errorf("error assessing migration safety: %w", err)
+	}
+	if err := checkDestructiveAllowed(opts, assessments); err != nil {
+		return nil, err
+	}
+
 	// 5. Generate up migration SQL
 	upSQL, err := generateUpMigrationSQL(diff, generated, conn.Info().Dialect)
 	if err != nil {
@@ -150,6 +169,13 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	if err != nil {
 		return nil, fmt.Errorf("error creating migration files: %w", err)
 	}
+	if opts.ReportFormat != "" {
+		reportFile, err := createSafetyReportFile(files.UpFile, opts.ReportFormat, assessments)
+		if err != nil {
+			return nil, fmt.Errorf("error creating safety report: %w", err)
+		}
+		files.ReportFile = reportFile
+	}
 
 	return files, nil
 }
@@ -167,6 +193,33 @@ func withDialect(opts *config.CompareOptions, dialect string) *config.CompareOpt
 		clone.Dialect = dialect
 	}
 	return &clone
+}
+
+func checkDestructiveAllowed(opts GenerateMigrationOptions, assessments []safety.StatementAssessment) error {
+	if opts.CheckDestructive && safety.HasDestructiveAssessment(assessments) && !opts.AllowDestructive {
+		return fmt.Errorf("destructive migration statements require AllowDestructive")
+	}
+	return nil
+}
+
+func createSafetyReportFile(upFile, format string, assessments []safety.StatementAssessment) (string, error) {
+	if !strings.EqualFold(format, "html") {
+		return "", fmt.Errorf("unsupported safety report format %q", format)
+	}
+	reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.html"
+	file, err := os.Create(reportFile)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			slog.Warn("failed to close safety report", "path", reportFile, "error", closeErr)
+		}
+	}()
+	if err := safety.RenderHTML(file, assessments); err != nil {
+		return "", err
+	}
+	return reportFile, nil
 }
 
 // hasActualSQLStatements checks if the statements contain actual SQL operations (not just comments)

--- a/migration/generator/safety_test.go
+++ b/migration/generator/safety_test.go
@@ -1,0 +1,65 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+func TestCheckDestructiveAllowed(t *testing.T) {
+	c := qt.New(t)
+
+	destructive := []safety.StatementAssessment{
+		{Severity: safety.Destructive, Reason: "DROP TABLE removes the table and all rows"},
+	}
+	warning := []safety.StatementAssessment{
+		{Severity: safety.Warning, Reason: "CREATE UNIQUE INDEX can fail on existing duplicate values"},
+	}
+
+	err := checkDestructiveAllowed(GenerateMigrationOptions{CheckDestructive: true}, destructive)
+	c.Assert(err, qt.ErrorMatches, "destructive migration statements require AllowDestructive")
+
+	err = checkDestructiveAllowed(GenerateMigrationOptions{CheckDestructive: true, AllowDestructive: true}, destructive)
+	c.Assert(err, qt.IsNil)
+
+	err = checkDestructiveAllowed(GenerateMigrationOptions{CheckDestructive: false}, destructive)
+	c.Assert(err, qt.IsNil)
+
+	err = checkDestructiveAllowed(GenerateMigrationOptions{CheckDestructive: true}, warning)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestCreateSafetyReportFile(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	upFile := filepath.Join(dir, "1234567890_drop_legacy.up.sql")
+	err := os.WriteFile(upFile, []byte("DROP TABLE legacy;\n"), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	reportFile, err := createSafetyReportFile(upFile, "html", []safety.StatementAssessment{
+		{
+			Index:     1,
+			NodeType:  "sql",
+			Subject:   "legacy",
+			Statement: "DROP TABLE legacy;",
+			Severity:  safety.Destructive,
+			Reason:    "DROP TABLE removes the table and all rows",
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(reportFile, qt.Equals, filepath.Join(dir, "1234567890_drop_legacy.safety.html"))
+
+	content, err := os.ReadFile(reportFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Contains, "Ptah migration safety report")
+	c.Assert(string(content), qt.Contains, "DROP TABLE legacy;")
+	c.Assert(string(content), qt.Contains, "destructive")
+
+	_, err = createSafetyReportFile(upFile, "json", nil)
+	c.Assert(err, qt.ErrorMatches, `unsupported safety report format "json"`)
+}

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -151,6 +151,9 @@ type Options struct {
 	// PathPrefix is prepended (with /) to file names in findings so they
 	// point at real repository paths in CI annotations.
 	PathPrefix string
+	// Versions restricts linting to parsed migration versions. Empty means
+	// every migration file is linted.
+	Versions []int
 }
 
 // LintFS lints every *.sql file under fsys — recursively, because the
@@ -176,6 +179,10 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 		return nil, fmt.Errorf("no *.sql migration files found")
 	}
 	sort.Strings(names)
+	names = filterNamesByVersion(names, opts.Versions)
+	if len(names) == 0 {
+		return nil, nil
+	}
 
 	present := make(map[string]struct{}, len(names))
 	for _, name := range names {
@@ -215,6 +222,27 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 		return findings[i].Rule < findings[j].Rule
 	})
 	return findings, nil
+}
+
+func filterNamesByVersion(names []string, versions []int) []string {
+	if len(versions) == 0 {
+		return names
+	}
+	allowed := make(map[int]struct{}, len(versions))
+	for _, version := range versions {
+		allowed[version] = struct{}{}
+	}
+	var filtered []string
+	for _, name := range names {
+		parsed, err := migrator.ParseMigrationFileName(path.Base(name))
+		if err != nil {
+			continue
+		}
+		if _, ok := allowed[parsed.Version]; ok {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
 }
 
 // prepareFile loads one migration file into the forms rules consume.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -71,6 +71,25 @@ ALTER TYPE mood ADD VALUE 'ambivalent';
 	c.Assert(byRule["PG101"].Severity, qt.Equals, lint.SeverityWarning)
 }
 
+func TestLintFS_VersionsRestrictsFindings(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_old.up.sql":    "DROP TABLE old_data;\n",
+		"0000000001_old.down.sql":  "CREATE TABLE old_data (id INT);\n",
+		"0000000002_next.up.sql":   "ALTER TABLE users DROP COLUMN legacy;\n",
+		"0000000002_next.down.sql": "ALTER TABLE users ADD COLUMN legacy TEXT;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{
+		Disabled: []string{"MF", "BC", "PG", "MY"},
+		Versions: []int{2},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS102"})
+	c.Assert(findings[0].File, qt.Equals, "0000000002_next.up.sql")
+}
+
 func TestLintFS_CleanMigrationHasNoFindings(t *testing.T) {
 	c := qt.New(t)
 
@@ -183,14 +202,14 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		{"convert to character set", "ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4;", []string{"MY101"}},
 		{"convert to charset synonym", "ALTER TABLE users CONVERT TO CHARSET utf8mb4;", []string{"MY101"}},
 
-		// Non-column DROP clauses and column attributes must stay silent.
-		{"drop constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", nil},
-		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", nil},
-		{"drop primary key", "ALTER TABLE users DROP PRIMARY KEY;", nil},
+		// Data-protection drops are destructive; storage-only drops stay silent.
+		{"drop constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", []string{"DS105"}},
+		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", []string{"DS105"}},
+		{"drop primary key", "ALTER TABLE users DROP PRIMARY KEY;", []string{"DS105"}},
 		{"drop index", "ALTER TABLE users DROP INDEX idx_users_email;", nil},
-		{"drop check", "ALTER TABLE users DROP CHECK chk_age;", nil},
+		{"drop check", "ALTER TABLE users DROP CHECK chk_age;", []string{"DS105"}},
 		{"drop default attribute", "ALTER TABLE users ALTER COLUMN a DROP DEFAULT;", nil},
-		{"drop not null attribute", "ALTER TABLE users ALTER COLUMN a DROP NOT NULL;", nil},
+		{"drop not null attribute", "ALTER TABLE users ALTER COLUMN a DROP NOT NULL;", []string{"DS104"}},
 		{"drop identity attribute", "ALTER TABLE users ALTER COLUMN a DROP IDENTITY IF EXISTS;", nil},
 		{"drop key", "ALTER TABLE users DROP KEY idx_email;", nil},
 		{"drop partition", "ALTER TABLE metrics DROP PARTITION p2024;", nil},
@@ -199,12 +218,23 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		// Columns that happen to be named like keywords are not hazards.
 		{"column named type set not null", "ALTER TABLE users ALTER COLUMN type SET NOT NULL;", nil},
 		{"quoted column named type", `ALTER TABLE users ALTER COLUMN "type" SET NOT NULL;`, nil},
+		{"column named not drop default", "ALTER TABLE users ALTER COLUMN not DROP DEFAULT;", nil},
 		{"added column named modify", "ALTER TABLE users ADD COLUMN modify TEXT;", nil},
 		{"added column named rename", "ALTER TABLE users ADD COLUMN rename TEXT;", nil},
 
 		// Renames invisible to application code are not BC breaks.
 		{"rename index", "ALTER TABLE users RENAME INDEX i1 TO i2;", nil},
 		{"rename constraint", "ALTER TABLE users RENAME CONSTRAINT c1 TO c2;", nil},
+		{"enum value catalog delete", "DELETE FROM pg_enum WHERE enumlabel = 'archived';", []string{"DS106"}},
+		{"enum value drop syntax", "ALTER TYPE status DROP VALUE 'archived';", []string{"DS106"}},
+		{"drop type", "DROP TYPE IF EXISTS status;", []string{"DS107"}},
+		{"drop extension", "DROP EXTENSION IF EXISTS hstore;", []string{"DS107"}},
+		{"drop function", "DROP FUNCTION IF EXISTS refresh_user();", []string{"DS107"}},
+		{"drop role", "DROP ROLE old_role;", []string{"DS107"}},
+		{"drop policy", "DROP POLICY IF EXISTS tenant_isolation ON accounts;", []string{"DS107"}},
+		{"truncate table keyword", "TRUNCATE TABLE audit_log;", []string{"DS108"}},
+		{"truncate without table keyword", "TRUNCATE audit_log;", []string{"DS108"}},
+		{"disable row level security", "ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;", []string{"DS109"}},
 
 		// Top-level commas separate clauses; commas in parens do not.
 		{"comma-adjacent drop clause", "ALTER TABLE t ADD COLUMN a NUMERIC(10,2),DROP COLUMN b;", []string{"DS102"}},

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -23,64 +23,166 @@ func Rules() []Rule {
 // dataSafetyRules covers the DS family: statements that destroy data.
 func dataSafetyRules() []Rule {
 	return []Rule{
-		{
-			Code:     "DS101",
-			Title:    "table dropped",
-			Severity: SeverityError,
-			// File-level: dropping a table this same migration created (the
-			// create-staging/backfill/drop pattern) destroys no pre-existing
-			// data and is exempt.
-			CheckFile: func(file *File) []Finding {
-				if !file.IsUp {
-					return nil
+		tableDroppedRule(),
+		columnDroppedRule(),
+		columnTypeChangedRule(),
+		notNullDroppedRule(),
+		constraintDroppedRule(),
+		enumValueRemovedRule(),
+		databaseObjectDroppedRule(),
+		tableTruncatedRule(),
+		rlsDisabledRule(),
+	}
+}
+
+func tableDroppedRule() Rule {
+	return Rule{
+		Code:     "DS101",
+		Title:    "table dropped",
+		Severity: SeverityError,
+		// File-level: dropping a table this same migration created (the
+		// create-staging/backfill/drop pattern) destroys no pre-existing
+		// data and is exempt.
+		CheckFile: func(file *File) []Finding {
+			if !file.IsUp {
+				return nil
+			}
+			var findings []Finding
+			created := map[string]bool{}
+			for i := range file.Statements {
+				stmt := &file.Statements[i]
+				if ref := createdTableRef(stmt.Words); ref != "" {
+					created[ref] = true
+					continue
 				}
-				var findings []Finding
-				created := map[string]bool{}
-				for i := range file.Statements {
-					stmt := &file.Statements[i]
-					if ref := createdTableRef(stmt.Words); ref != "" {
-						created[ref] = true
-						continue
-					}
-					if !hasWordPrefix(stmt.Words, "DROP", "TABLE") || dropsOnlyCreatedTables(stmt.Words, created) {
-						continue
-					}
-					findings = append(findings, Finding{
-						Rule:     "DS101",
-						Title:    "table dropped",
-						Severity: SeverityError,
-						File:     file.Path,
-						Line:     stmt.Line,
-						Message:  "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead",
-					})
+				if !hasWordPrefix(stmt.Words, "DROP", "TABLE") || dropsOnlyCreatedTables(stmt.Words, created) {
+					continue
 				}
-				return findings
-			},
+				findings = append(findings, Finding{
+					Rule:     "DS101",
+					Title:    "table dropped",
+					Severity: SeverityError,
+					File:     file.Path,
+					Line:     stmt.Line,
+					Message:  "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead",
+				})
+			}
+			return findings
 		},
-		{
-			Code:     "DS102",
-			Title:    "column dropped",
-			Severity: SeverityError,
-			CheckStatement: func(stmt *Statement) (bool, string) {
-				if !isAlterTable(stmt.Words) || !scanDropColumn(stmt.Words) {
-					return false, ""
-				}
-				return true, "DROP COLUMN permanently deletes the column's data; deploy readers that no longer use the column first, then drop it in a later release"
-			},
+	}
+}
+
+func columnDroppedRule() Rule {
+	return Rule{
+		Code:     "DS102",
+		Title:    "column dropped",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) || !scanDropColumn(stmt.Words) {
+				return false, ""
+			}
+			return true, "DROP COLUMN permanently deletes the column's data; deploy readers that no longer use the column first, then drop it in a later release"
 		},
-		{
-			Code:     "DS103",
-			Title:    "column type changed",
-			Severity: SeverityWarning,
-			CheckStatement: func(stmt *Statement) (bool, string) {
-				if !isAlterTable(stmt.Words) {
-					return false, ""
-				}
-				if !scanModifyChange(stmt.Words) && !scanAlterColumnType(stmt.Words) {
-					return false, ""
-				}
-				return true, "changing a column type can truncate or reject existing values and may rewrite the table under a lock; verify the old-to-new value mapping on production data first"
-			},
+	}
+}
+
+func columnTypeChangedRule() Rule {
+	return Rule{
+		Code:     "DS103",
+		Title:    "column type changed",
+		Severity: SeverityWarning,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) {
+				return false, ""
+			}
+			if !scanModifyChange(stmt.Words) && !scanAlterColumnType(stmt.Words) {
+				return false, ""
+			}
+			return true, "changing a column type can truncate or reject existing values and may rewrite the table under a lock; verify the old-to-new value mapping on production data first"
+		},
+	}
+}
+
+func notNullDroppedRule() Rule {
+	return Rule{
+		Code:     "DS104",
+		Title:    "not-null constraint dropped",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) || !scanDropNotNull(stmt.Words) {
+				return false, ""
+			}
+			return true, "DROP NOT NULL removes a column-level data protection; verify nullable values are accepted by every deployed reader and writer first"
+		},
+	}
+}
+
+func constraintDroppedRule() Rule {
+	return Rule{
+		Code:     "DS105",
+		Title:    "constraint dropped",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) || !scanDropConstraint(stmt.Words) {
+				return false, ""
+			}
+			return true, "dropping a constraint removes an existing data protection; verify the replacement safety invariant before applying"
+		},
+	}
+}
+
+func enumValueRemovedRule() Rule {
+	return Rule{
+		Code:     "DS106",
+		Title:    "enum value removed",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !scanEnumValueRemoval(stmt.Words) {
+				return false, ""
+			}
+			return true, "removing an enum value can invalidate existing rows; backfill rows away from the value before changing the enum"
+		},
+	}
+}
+
+func databaseObjectDroppedRule() Rule {
+	return Rule{
+		Code:     "DS107",
+		Title:    "database object dropped",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !scanDestructiveObjectDrop(stmt.Words) {
+				return false, ""
+			}
+			return true, "dropping a database object removes existing schema behavior or principals; verify all dependent code and data paths are retired first"
+		},
+	}
+}
+
+func tableTruncatedRule() Rule {
+	return Rule{
+		Code:     "DS108",
+		Title:    "table truncated",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !hasWordPrefix(stmt.Words, "TRUNCATE") {
+				return false, ""
+			}
+			return true, "TRUNCATE deletes all rows from the table; take a verified backup first and require an explicit destructive apply"
+		},
+	}
+}
+
+func rlsDisabledRule() Rule {
+	return Rule{
+		Code:     "DS109",
+		Title:    "row-level security disabled",
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) || !hasWordSeq(stmt.Words, "DISABLE", "ROW", "LEVEL", "SECURITY") {
+				return false, ""
+			}
+			return true, "DISABLE ROW LEVEL SECURITY removes an access-control protection; verify replacement authorization before applying"
 		},
 	}
 }
@@ -457,6 +559,66 @@ func scanAlterColumnType(w []string) bool {
 		}
 	}
 	return false
+}
+
+// scanDropNotNull reports whether an ALTER TABLE statement removes a column's
+// NOT NULL attribute via ALTER [COLUMN] name DROP NOT NULL.
+func scanDropNotNull(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || w[i] != "ALTER" {
+			continue
+		}
+		j := i + 1
+		if j < len(w) && w[j] == "COLUMN" {
+			j++
+		}
+		j = skipIfExists(w, j)
+		if j >= len(w) || !identLike(w[j]) {
+			continue
+		}
+		if hasWordPrefix(w[j+1:], "DROP", "NOT", "NULL") {
+			return true
+		}
+	}
+	return false
+}
+
+// scanDropConstraint reports whether an ALTER TABLE statement removes a data
+// protection constraint. Index/key/partition drops stay out of this rule.
+func scanDropConstraint(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if i >= len(w) || w[i] != "DROP" {
+			continue
+		}
+		switch {
+		case hasWordPrefix(w[i:], "DROP", "CONSTRAINT"):
+			return true
+		case hasWordPrefix(w[i:], "DROP", "FOREIGN", "KEY"):
+			return true
+		case hasWordPrefix(w[i:], "DROP", "PRIMARY", "KEY"):
+			return true
+		case hasWordPrefix(w[i:], "DROP", "CHECK"):
+			return true
+		}
+	}
+	return false
+}
+
+func scanEnumValueRemoval(w []string) bool {
+	return hasWordSeq(w, "DELETE", "FROM", "PG_ENUM") ||
+		hasWordSeq(w, "DROP", "VALUE")
+}
+
+func scanDestructiveObjectDrop(w []string) bool {
+	if len(w) < 2 || w[0] != "DROP" {
+		return false
+	}
+	switch w[1] {
+	case "TYPE", "EXTENSION", "FUNCTION", "ROLE", "POLICY":
+		return true
+	default:
+		return false
+	}
 }
 
 // scanConvertCharset reports whether an ALTER TABLE statement converts the

--- a/migration/planner/dialects/clickhouse/clickhouse.go
+++ b/migration/planner/dialects/clickhouse/clickhouse.go
@@ -16,6 +16,7 @@ package clickhouse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/convert/fromschema"
@@ -119,8 +120,13 @@ func (p *Planner) modifyExistingTables(result []ast.Node, diff *types.SchemaDiff
 			}
 			col := fromschema.FromField(*field, generated.Enums, platform.ClickHouse)
 			result = append(result, &ast.AlterTableNode{
-				Name:       td.TableName,
-				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: col}},
+				Name: td.TableName,
+				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{
+					Column:              col,
+					PreviousType:        previousColumnType(colDiff.Changes["type"]),
+					PreviousNullable:    previousColumnNullable(colDiff.Changes["nullable"]),
+					HasPreviousNullable: colDiff.Changes["nullable"] != "",
+				}},
 			})
 		}
 
@@ -216,4 +222,17 @@ func lookupField(generated *goschema.Database, structName, columnName string) *g
 		}
 	}
 	return nil
+}
+
+func previousColumnType(change string) string {
+	before, _, ok := strings.Cut(change, " -> ")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(before)
+}
+
+func previousColumnNullable(change string) bool {
+	before, _, ok := strings.Cut(change, " -> ")
+	return ok && strings.TrimSpace(before) == "true"
 }

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -345,8 +345,13 @@ func (p *Planner) modifyExistingColumns(result []ast.Node, tableDiff *types.Tabl
 
 		// Generate ALTER COLUMN statements using AST
 		alterNode := &ast.AlterTableNode{
-			Name:       tableDiff.TableName,
-			Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: columnNode}},
+			Name: tableDiff.TableName,
+			Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{
+				Column:              columnNode,
+				PreviousType:        previousColumnType(colDiff.Changes["type"]),
+				PreviousNullable:    previousColumnNullable(colDiff.Changes["nullable"]),
+				HasPreviousNullable: colDiff.Changes["nullable"] != "",
+			}},
 		}
 		result = append(result, alterNode)
 
@@ -1129,4 +1134,17 @@ func (p *Planner) convertConstraintToAST(constraint goschema.Constraint) *ast.Co
 	default:
 		return nil // Unsupported constraint type
 	}
+}
+
+func previousColumnType(change string) string {
+	before, _, ok := strings.Cut(change, " -> ")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(before)
+}
+
+func previousColumnNullable(change string) bool {
+	before, _, ok := strings.Cut(change, " -> ")
+	return ok && strings.TrimSpace(before) == "true"
 }

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -465,8 +465,13 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 
 		// Generate ALTER COLUMN statements using AST
 		alterNode := &ast.AlterTableNode{
-			Name:       tableDiff.TableName,
-			Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: columnNode}},
+			Name: tableDiff.TableName,
+			Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{
+				Column:              columnNode,
+				PreviousType:        previousColumnType(colDiff.Changes["type"]),
+				PreviousNullable:    previousColumnNullable(colDiff.Changes["nullable"]),
+				HasPreviousNullable: colDiff.Changes["nullable"] != "",
+			}},
 		}
 		result = append(result, alterNode)
 
@@ -489,6 +494,19 @@ func findGeneratedTableByDiffName(generated *goschema.Database, tableName string
 		}
 	}
 	return nil
+}
+
+func previousColumnType(change string) string {
+	before, _, ok := strings.Cut(change, " -> ")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(before)
+}
+
+func previousColumnNullable(change string) bool {
+	before, _, ok := strings.Cut(change, " -> ")
+	return ok && strings.TrimSpace(before) == "true"
 }
 
 func (p *Planner) removeTableColumnsFromDiff(result []ast.Node, tableDiff types.TableDiff) []ast.Node {

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	dbtypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/safety"
+	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -71,6 +74,56 @@ func TestGetPlanner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGeneratedNarrowingTypeChangeIsDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "users", StructName: "User"},
+		},
+		Fields: []goschema.Field{
+			{Name: "name", Type: "VARCHAR(100)", StructName: "User"},
+		},
+	}
+	database := &dbtypes.DBSchema{
+		Tables: []dbtypes.DBTable{
+			{
+				Name: "users",
+				Columns: []dbtypes.DBColumn{
+					{Name: "name", DataType: "VARCHAR(255)", IsNullable: "NO"},
+				},
+			},
+		},
+	}
+
+	diff := schemadiff.Compare(generated, database)
+	c.Assert(diff.TablesModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["type"], qt.Equals, "VARCHAR(255) -> VARCHAR(100)")
+
+	nodes := planner.GenerateSchemaDiffAST(diff, generated, platform.Postgres)
+	assessments, err := safety.AssessRendered(nodes, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsTrue)
+}
+
+func TestGeneratedRLSPolicyRemovalIsDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		RLSPoliciesRemoved: []types.RLSPolicyRef{
+			{PolicyName: "tenant_isolation", TableName: "accounts"},
+		},
+	}
+
+	nodes := planner.GenerateSchemaDiffAST(diff, &goschema.Database{}, platform.Postgres)
+	assessments, err := safety.AssessRendered(nodes, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsTrue)
+	c.Assert(assessments[0].Severity, qt.Equals, safety.Destructive)
+	c.Assert(assessments[0].Statement, qt.Contains, "DROP POLICY IF EXISTS tenant_isolation ON accounts")
 }
 
 func TestGenerateMigrationAST(t *testing.T) {

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -2,9 +2,17 @@
 package safety
 
 import (
+	"fmt"
+	"html/template"
+	"io"
 	"sort"
+	"strings"
 
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
+	"github.com/stokaro/ptah/migration/typechange"
 )
 
 // Severity is the operational risk level for a schema change.
@@ -24,6 +32,16 @@ type Finding struct {
 	Category string   `json:"category"`
 	Count    int      `json:"count"`
 	Severity Severity `json:"severity"`
+}
+
+// StatementAssessment classifies one generated migration statement.
+type StatementAssessment struct {
+	Index     int      `json:"index"`
+	NodeType  string   `json:"node_type"`
+	Subject   string   `json:"subject,omitempty"`
+	Statement string   `json:"statement,omitempty"`
+	Severity  Severity `json:"severity"`
+	Reason    string   `json:"reason"`
 }
 
 // ClassifySchemaDiff returns severity findings for every non-empty diff
@@ -46,7 +64,7 @@ func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding {
 	add(&findings, "functions_removed", len(diff.FunctionsRemoved), Destructive)
 	add(&findings, "functions_modified", len(diff.FunctionsModified), Warning)
 	add(&findings, "rls_policies_added", len(diff.RLSPoliciesAdded), Safe)
-	add(&findings, "rls_policies_removed", len(diff.RLSPoliciesRemoved), Warning)
+	add(&findings, "rls_policies_removed", len(diff.RLSPoliciesRemoved), Destructive)
 	add(&findings, "rls_policies_modified", len(diff.RLSPoliciesModified), Warning)
 	add(&findings, "rls_enabled_tables_added", len(diff.RLSEnabledTablesAdded), Safe)
 	add(&findings, "rls_enabled_tables_removed", len(diff.RLSEnabledTablesRemoved), Destructive)
@@ -94,6 +112,355 @@ func HasDestructive(findings []Finding) bool {
 	return Highest(findings) == Destructive
 }
 
+// Classify returns the highest operational risk for a migration AST node.
+func Classify(node ast.Node) Severity {
+	return assessNode(node).Severity
+}
+
+// Assess returns per-statement risk classifications for generated AST nodes.
+func Assess(nodes []ast.Node) []StatementAssessment {
+	assessments := make([]StatementAssessment, 0, len(nodes))
+	for i, node := range nodes {
+		assessment := assessNode(node)
+		assessment.Index = i + 1
+		assessments = append(assessments, assessment)
+	}
+	return assessments
+}
+
+// AssessRendered returns per-rendered-SQL-statement risk classifications for
+// generated AST nodes.
+func AssessRendered(nodes []ast.Node, dialect string) ([]StatementAssessment, error) {
+	var assessments []StatementAssessment
+	for _, node := range nodes {
+		nodeAssessment := assessNode(node)
+		rendered, err := renderer.RenderSQL(dialect, node)
+		if err != nil {
+			return nil, err
+		}
+		statements := sqlutil.SplitSQLStatements(rendered)
+		if len(statements) == 0 && strings.TrimSpace(rendered) != "" {
+			statements = []string{strings.TrimSpace(rendered)}
+		}
+		for _, statement := range statements {
+			assessment := AssessSQL(statement)
+			assessment.NodeType = nodeAssessment.NodeType
+			if assessment.Subject == "" {
+				assessment.Subject = nodeAssessment.Subject
+			}
+			if len(statements) == 1 || isTypeChangeSQL(statement) {
+				raiseAssessment(&assessment, nodeAssessment)
+			}
+			assessment.Index = len(assessments) + 1
+			assessments = append(assessments, assessment)
+		}
+	}
+	return assessments, nil
+}
+
+// AssessSQL returns a best-effort classification for one rendered SQL
+// statement.
+func AssessSQL(statement string) StatementAssessment {
+	assessment := StatementAssessment{
+		NodeType:  "sql",
+		Statement: strings.TrimSpace(statement),
+		Severity:  Safe,
+		Reason:    "does not remove data or tighten constraints",
+	}
+	return assessRawSQL(statement, assessment)
+}
+
+// HighestAssessment returns the highest severity from statement assessments.
+func HighestAssessment(assessments []StatementAssessment) Severity {
+	highest := Safe
+	for _, assessment := range assessments {
+		if severityRank(assessment.Severity) > severityRank(highest) {
+			highest = assessment.Severity
+		}
+	}
+	return highest
+}
+
+// HasDestructiveAssessment returns true when any statement is destructive.
+func HasDestructiveAssessment(assessments []StatementAssessment) bool {
+	return HighestAssessment(assessments) == Destructive
+}
+
+// RenderText writes a compact text table for statement assessments.
+func RenderText(w io.Writer, assessments []StatementAssessment) error {
+	if len(assessments) == 0 {
+		_, err := fmt.Fprintln(w, "Safety: no executable migration statements")
+		return err
+	}
+	_, err := fmt.Fprintln(w, "Safety classification:")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, "  #  severity      subject                  reason")
+	if err != nil {
+		return err
+	}
+	for _, assessment := range assessments {
+		subject := assessment.Subject
+		if subject == "" {
+			subject = assessment.NodeType
+		}
+		if _, err := fmt.Fprintf(w, "  %-2d %-12s %-24s %s\n", assessment.Index, assessment.Severity, subject, assessment.Reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RenderHTML writes a standalone HTML safety report.
+func RenderHTML(w io.Writer, assessments []StatementAssessment) error {
+	const report = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Ptah migration safety report</title>
+<style>
+body { font-family: system-ui, sans-serif; margin: 2rem; color: #1f2937; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #d1d5db; padding: 0.5rem; text-align: left; vertical-align: top; }
+th { background: #f3f4f6; }
+.safe { color: #047857; font-weight: 700; }
+.warning { color: #b45309; font-weight: 700; }
+.destructive { color: #b91c1c; font-weight: 700; }
+pre { margin: 0; white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+</style>
+</head>
+<body>
+<h1>Ptah migration safety report</h1>
+<table>
+<thead><tr><th>#</th><th>Severity</th><th>Subject</th><th>Reason</th><th>Statement</th></tr></thead>
+<tbody>
+{{range .}}
+<tr>
+<td>{{.Index}}</td>
+<td class="{{.Severity}}">{{.Severity}}</td>
+<td>{{if .Subject}}{{.Subject}}{{else}}{{.NodeType}}{{end}}</td>
+<td>{{.Reason}}</td>
+<td><pre>{{.Statement}}</pre></td>
+</tr>
+{{end}}
+</tbody>
+</table>
+</body>
+</html>`
+	tmpl, err := template.New("safety-report").Parse(report)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(w, assessments)
+}
+
+func assessNode(node ast.Node) StatementAssessment {
+	assessment := StatementAssessment{
+		NodeType: fmt.Sprintf("%T", node),
+		Severity: Safe,
+		Reason:   "does not remove data or tighten constraints",
+	}
+
+	switch n := node.(type) {
+	case *ast.AlterTableNode:
+		assessment.Subject = n.Name
+		return assessAlterTable(n, assessment)
+	case *ast.DropTableNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP TABLE removes the table and all rows"
+	case *ast.DropTypeNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP TYPE removes an existing database type"
+	case *ast.DropExtensionNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP EXTENSION removes database objects owned by the extension"
+	case *ast.DropFunctionNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP FUNCTION removes executable database behavior"
+	case *ast.DropRoleNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP ROLE removes an existing database principal"
+	case *ast.DropPolicyNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP POLICY removes an access-control protection"
+	case *ast.AlterTableDisableRLSNode:
+		assessment.Subject = n.Table
+		assessment.Severity = Destructive
+		assessment.Reason = "DISABLE ROW LEVEL SECURITY removes an access-control protection"
+	case *ast.IndexNode:
+		assessment.Subject = n.Name
+		if n.Unique {
+			assessment.Severity = Warning
+			assessment.Reason = "CREATE UNIQUE INDEX can fail on existing duplicate values"
+		}
+	case *ast.DropIndexNode:
+		assessment.Subject = n.Name
+		assessment.Severity = Warning
+		assessment.Reason = "DROP INDEX can affect query plans and constraints"
+	case *ast.AlterTypeNode:
+		assessment.Subject = n.Name
+		return assessAlterType(n, assessment)
+	case *ast.RawSQLNode:
+		assessment.Statement = n.SQL
+		return assessRawSQL(n.SQL, assessment)
+	}
+	return assessment
+}
+
+func assessAlterTable(n *ast.AlterTableNode, assessment StatementAssessment) StatementAssessment {
+	for _, op := range n.Operations {
+		severity, reason := classifyAlterOperation(op)
+		if severityRank(severity) > severityRank(assessment.Severity) {
+			assessment.Severity = severity
+			assessment.Reason = reason
+		}
+	}
+	return assessment
+}
+
+func assessAlterType(n *ast.AlterTypeNode, assessment StatementAssessment) StatementAssessment {
+	for _, op := range n.Operations {
+		severity, reason := classifyTypeOperation(op)
+		if severityRank(severity) > severityRank(assessment.Severity) {
+			assessment.Severity = severity
+			assessment.Reason = reason
+		}
+	}
+	return assessment
+}
+
+func classifyAlterOperation(op ast.AlterOperation) (Severity, string) {
+	switch o := op.(type) {
+	case *ast.DropColumnOperation:
+		return Destructive, "DROP COLUMN removes existing column data"
+	case *ast.DropConstraintOperation:
+		return Destructive, "DROP CONSTRAINT removes an existing data protection"
+	case *ast.RenameColumnOperation:
+		return Warning, "RENAME COLUMN can break deployed readers and writers"
+	case *ast.AddConstraintOperation:
+		return Warning, "ADD CONSTRAINT can fail on existing rows"
+	case *ast.AddColumnOperation:
+		if o.Column != nil && !o.Column.Nullable {
+			return Warning, "ADD COLUMN with NOT NULL can fail on existing rows"
+		}
+		return Safe, "ADD COLUMN is additive"
+	case *ast.ModifyColumnOperation:
+		return classifyModifyColumn(o)
+	case *ast.AddSkippingIndexOperation:
+		return Warning, "ADD INDEX can affect write workload during build"
+	case *ast.ModifyTTLOperation:
+		return Warning, "MODIFY TTL can delete or move existing rows"
+	default:
+		return Safe, "does not remove data or tighten constraints"
+	}
+}
+
+func classifyModifyColumn(op *ast.ModifyColumnOperation) (Severity, string) {
+	if op == nil || op.Column == nil {
+		return Warning, "column modification needs manual review"
+	}
+	if IsTypeNarrowing(op.PreviousType, op.Column.Type) {
+		return Destructive, fmt.Sprintf("column type narrows from %s to %s", op.PreviousType, op.Column.Type)
+	}
+	if op.HasPreviousNullable && !op.PreviousNullable && op.Column.Nullable {
+		return Destructive, "DROP NOT NULL removes a column-level data protection"
+	}
+	if op.PreviousType != "" && !sameType(op.PreviousType, op.Column.Type) {
+		return Warning, fmt.Sprintf("column type changes from %s to %s", op.PreviousType, op.Column.Type)
+	}
+	if !op.Column.Nullable {
+		return Warning, "SET NOT NULL can fail when existing rows contain NULL"
+	}
+	return Warning, "column modification needs manual review"
+}
+
+func classifyTypeOperation(op ast.TypeOperation) (Severity, string) {
+	switch op.(type) {
+	case *ast.RenameEnumValueOperation:
+		return Warning, "RENAME VALUE can break deployed readers and writers"
+	case *ast.RenameTypeOperation:
+		return Warning, "RENAME TYPE can break deployed readers and writers"
+	case *ast.AddEnumValueOperation:
+		return Warning, "ADD VALUE can affect cross-version enum compatibility"
+	default:
+		return Safe, "type change is additive"
+	}
+}
+
+func assessRawSQL(sql string, assessment StatementAssessment) StatementAssessment {
+	words := rawWords(sql)
+	switch {
+	case hasWordPrefix(words, "DROP", "TABLE"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP TABLE removes the table and all rows"
+	case hasWordPrefix(words, "DROP", "TYPE"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP TYPE removes an existing database type"
+	case hasWordPrefix(words, "DROP", "EXTENSION"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP EXTENSION removes database objects owned by the extension"
+	case hasWordPrefix(words, "DROP", "FUNCTION"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP FUNCTION removes executable database behavior"
+	case hasWordPrefix(words, "DROP", "ROLE"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP ROLE removes an existing database principal"
+	case hasWordPrefix(words, "DROP", "POLICY"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP POLICY removes an access-control protection"
+	case hasWordPrefix(words, "TRUNCATE"):
+		assessment.Severity = Destructive
+		assessment.Reason = "TRUNCATE removes all rows from a table"
+	case hasWordSequence(words, "DISABLE", "ROW", "LEVEL", "SECURITY"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DISABLE ROW LEVEL SECURITY removes an access-control protection"
+	case hasWordSequence(words, "DROP", "COLUMN"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP COLUMN removes existing column data"
+	case hasWordSequence(words, "DROP", "CONSTRAINT"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP CONSTRAINT removes an existing data protection"
+	case hasWordSequence(words, "DROP", "NOT", "NULL"):
+		assessment.Severity = Destructive
+		assessment.Reason = "DROP NOT NULL removes an existing data protection"
+	case hasWordSequence(words, "DROP", "VALUE"), hasWordSequence(words, "DELETE", "FROM", "PG_ENUM"):
+		assessment.Severity = Destructive
+		assessment.Reason = "removing an enum value can invalidate existing rows"
+	case hasWordSequence(words, "RENAME", "COLUMN"), hasWordSequence(words, "RENAME", "TO"):
+		assessment.Severity = Warning
+		assessment.Reason = "rename can break deployed readers and writers"
+	case hasWordSequence(words, "SET", "NOT", "NULL"):
+		assessment.Severity = Warning
+		assessment.Reason = "SET NOT NULL can fail when existing rows contain NULL"
+	case hasWordPrefix(words, "CREATE", "UNIQUE", "INDEX"):
+		assessment.Severity = Warning
+		assessment.Reason = "CREATE UNIQUE INDEX can fail on existing duplicate values"
+	}
+	return assessment
+}
+
+func raiseAssessment(target *StatementAssessment, source StatementAssessment) {
+	if severityRank(source.Severity) <= severityRank(target.Severity) {
+		return
+	}
+	target.Severity = source.Severity
+	target.Reason = source.Reason
+}
+
+func isTypeChangeSQL(statement string) bool {
+	words := rawWords(statement)
+	return hasWordSequence(words, "ALTER", "COLUMN") && hasWordSequence(words, "TYPE") ||
+		hasWordSequence(words, "MODIFY", "COLUMN") ||
+		hasWordSequence(words, "CHANGE", "COLUMN")
+}
+
 func add(findings *[]Finding, category string, count int, severity Severity) {
 	if count == 0 {
 		return
@@ -136,4 +503,51 @@ func severityRank(severity Severity) int {
 	default:
 		return 1
 	}
+}
+
+// IsTypeNarrowing reports whether changing from oldType to newType can lose
+// data by reducing the representable range or length.
+func IsTypeNarrowing(oldType, newType string) bool {
+	return typechange.IsNarrowing(oldType, newType)
+}
+
+func sameType(left, right string) bool {
+	return typechange.Same(left, right)
+}
+
+func rawWords(sql string) []string {
+	replacer := strings.NewReplacer("(", " ", ")", " ", ",", " ", ";", " ", "\n", " ", "\t", " ")
+	clean := replacer.Replace(strings.ToUpper(sql))
+	return strings.Fields(clean)
+}
+
+func hasWordPrefix(words []string, prefix ...string) bool {
+	if len(words) < len(prefix) {
+		return false
+	}
+	for i, word := range prefix {
+		if words[i] != word {
+			return false
+		}
+	}
+	return true
+}
+
+func hasWordSequence(words []string, sequence ...string) bool {
+	if len(sequence) == 0 || len(words) < len(sequence) {
+		return false
+	}
+	for i := 0; i <= len(words)-len(sequence); i++ {
+		matched := true
+		for j, word := range sequence {
+			if words[i+j] != word {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
 }

--- a/migration/safety/safety_test.go
+++ b/migration/safety/safety_test.go
@@ -1,10 +1,12 @@
 package safety_test
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/migration/safety"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -22,12 +24,20 @@ func TestClassifySchemaDiff_HighestSeverity(t *testing.T) {
 			},
 		},
 		IndexesRemoved: []string{"idx_products_old"},
+		RLSPoliciesRemoved: []types.RLSPolicyRef{
+			{PolicyName: "tenant_isolation", TableName: "accounts"},
+		},
 	}
 
 	findings := safety.ClassifySchemaDiff(diff)
 
 	c.Assert(findings, qt.Contains, safety.Finding{
 		Category: "columns_removed",
+		Count:    1,
+		Severity: safety.Destructive,
+	})
+	c.Assert(findings, qt.Contains, safety.Finding{
+		Category: "rls_policies_removed",
 		Count:    1,
 		Severity: safety.Destructive,
 	})
@@ -60,4 +70,117 @@ func TestClassifySchemaDiff_AggregatesRepeatedCategories(t *testing.T) {
 		},
 	})
 	c.Assert(safety.Highest(findings), qt.Equals, safety.Warning)
+}
+
+func TestClassifyASTStatements(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(safety.Classify(ast.NewDropTable("users")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(&ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.DropColumnOperation{ColumnName: "legacy_name"},
+		},
+	}), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(&ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.ModifyColumnOperation{
+				Column:       ast.NewColumn("name", "varchar(100)"),
+				PreviousType: "varchar(255)",
+			},
+		},
+	}), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(&ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.ModifyColumnOperation{
+				Column:       ast.NewColumn("count", "bigint"),
+				PreviousType: "integer",
+			},
+		},
+	}), qt.Equals, safety.Warning)
+	c.Assert(safety.Classify(&ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.ModifyColumnOperation{
+				Column:              ast.NewColumn("nickname", "text"),
+				PreviousNullable:    false,
+				HasPreviousNullable: true,
+			},
+		},
+	}), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewIndex("users_email_key", "users", "email").SetUnique()), qt.Equals, safety.Warning)
+	c.Assert(safety.Classify(ast.NewRawSQL("DELETE FROM pg_enum WHERE enumlabel = 'archived'")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("DROP TYPE status")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("DROP EXTENSION hstore")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("DROP FUNCTION refresh_user()")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("DROP ROLE old_role")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("DROP POLICY tenant_isolation ON accounts")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("TRUNCATE TABLE audit_log")), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(ast.NewRawSQL("ALTER TABLE accounts DISABLE ROW LEVEL SECURITY")), qt.Equals, safety.Destructive)
+}
+
+func TestAssessHighestSeverity(t *testing.T) {
+	c := qt.New(t)
+
+	assessments := safety.Assess([]ast.Node{
+		ast.NewIndex("idx_users_email", "users", "email"),
+		&ast.AlterTableNode{
+			Name: "users",
+			Operations: []ast.AlterOperation{
+				&ast.RenameColumnOperation{OldName: "name", NewName: "display_name"},
+			},
+		},
+	})
+
+	c.Assert(assessments, qt.HasLen, 2)
+	c.Assert(assessments[0].Index, qt.Equals, 1)
+	c.Assert(safety.HighestAssessment(assessments), qt.Equals, safety.Warning)
+	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsFalse)
+}
+
+func TestAssessRenderedSplitsPostgresModifyColumnStatements(t *testing.T) {
+	c := qt.New(t)
+
+	assessments, err := safety.AssessRendered([]ast.Node{
+		&ast.AlterTableNode{
+			Name: "users",
+			Operations: []ast.AlterOperation{
+				&ast.ModifyColumnOperation{
+					Column:              ast.NewColumn("nickname", "varchar(100)"),
+					PreviousType:        "varchar(255)",
+					PreviousNullable:    false,
+					HasPreviousNullable: true,
+				},
+			},
+		},
+	}, "postgres")
+	c.Assert(err, qt.IsNil)
+
+	byStatement := make(map[string]safety.Severity)
+	for _, assessment := range assessments {
+		switch {
+		case strings.Contains(assessment.Statement, " TYPE "):
+			byStatement["type"] = assessment.Severity
+		case strings.Contains(assessment.Statement, " DROP NOT NULL"):
+			byStatement["drop_not_null"] = assessment.Severity
+		case strings.Contains(assessment.Statement, " DROP DEFAULT"):
+			byStatement["drop_default"] = assessment.Severity
+		}
+	}
+	c.Assert(byStatement["type"], qt.Equals, safety.Destructive)
+	c.Assert(byStatement["drop_not_null"], qt.Equals, safety.Destructive)
+	c.Assert(byStatement["drop_default"], qt.Equals, safety.Safe)
+}
+
+func TestIsTypeNarrowing(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(safety.IsTypeNarrowing("varchar(255)", "varchar(100)"), qt.IsTrue)
+	c.Assert(safety.IsTypeNarrowing("text", "varchar(255)"), qt.IsTrue)
+	c.Assert(safety.IsTypeNarrowing("bigint", "integer"), qt.IsTrue)
+	c.Assert(safety.IsTypeNarrowing("integer", "bigint"), qt.IsFalse)
+	c.Assert(safety.IsTypeNarrowing("numeric(12,2)", "numeric(10,2)"), qt.IsTrue)
+	c.Assert(safety.IsTypeNarrowing("numeric(12,2)", "numeric(12,4)"), qt.IsTrue)
 }

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff/internal/normalize"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+	"github.com/stokaro/ptah/migration/typechange"
 )
 
 // Regular expressions for constraint-based index detection
@@ -352,13 +353,13 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 
 	// Compare data types (simplified)
 	genType := normalize.Type(genCol.Type)
-	dbType := normalize.Type(dbCol.DataType)
-	if dbCol.UDTName != "" {
-		dbType = normalize.Type(dbCol.UDTName)
-	}
+	dbRawType := rawDBColumnType(dbCol)
+	dbType := normalize.Type(dbRawType)
 
 	if genType != dbType {
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbType, genType)
+	} else if typechange.IsNarrowing(dbRawType, genCol.Type) {
+		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
 	}
 
 	// Compare nullable (primary keys are always NOT NULL regardless of the field definition)
@@ -414,6 +415,35 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 	}
 
 	return colDiff
+}
+
+func rawDBColumnType(dbCol types.DBColumn) string {
+	rawType := strings.TrimSpace(dbCol.ColumnType)
+	if rawType == "" && dbCol.UDTName != "" {
+		rawType = strings.TrimSpace(dbCol.UDTName)
+	}
+	if rawType == "" {
+		rawType = strings.TrimSpace(dbCol.DataType)
+	}
+
+	if strings.Contains(rawType, "(") {
+		return rawType
+	}
+	switch normalize.Type(rawType) {
+	case "varchar":
+		if dbCol.CharacterMaxLength != nil {
+			return fmt.Sprintf("%s(%d)", rawType, *dbCol.CharacterMaxLength)
+		}
+	case "decimal":
+		if dbCol.NumericPrecision == nil {
+			return rawType
+		}
+		if dbCol.NumericScale != nil {
+			return fmt.Sprintf("%s(%d,%d)", rawType, *dbCol.NumericPrecision, *dbCol.NumericScale)
+		}
+		return fmt.Sprintf("%s(%d)", rawType, *dbCol.NumericPrecision)
+	}
+	return rawType
 }
 
 // SearchColumnByName searches for a specific column difference by name within a slice of column diffs.

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -113,6 +113,76 @@ func TestColumns_HappyPath(t *testing.T) {
 			},
 		},
 		{
+			name: "varchar narrowing preserves raw type",
+			genCol: goschema.Field{
+				Name: "name",
+				Type: "VARCHAR(100)",
+			},
+			dbCol: types.DBColumn{
+				Name:     "name",
+				DataType: "VARCHAR(255)",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "name",
+				Changes: map[string]string{
+					"type": "VARCHAR(255) -> VARCHAR(100)",
+				},
+			},
+		},
+		{
+			name: "postgres varchar narrowing uses length metadata",
+			genCol: goschema.Field{
+				Name: "name",
+				Type: "VARCHAR(100)",
+			},
+			dbCol: types.DBColumn{
+				Name:               "name",
+				DataType:           "character varying",
+				UDTName:            "varchar",
+				CharacterMaxLength: func() *int { value := 255; return &value }(),
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "name",
+				Changes: map[string]string{
+					"type": "varchar(255) -> VARCHAR(100)",
+				},
+			},
+		},
+		{
+			name: "integer narrowing preserves raw type",
+			genCol: goschema.Field{
+				Name: "count",
+				Type: "integer",
+			},
+			dbCol: types.DBColumn{
+				Name:     "count",
+				DataType: "bigint",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "count",
+				Changes: map[string]string{
+					"type": "bigint -> integer",
+				},
+			},
+		},
+		{
+			name: "decimal narrowing preserves raw type",
+			genCol: goschema.Field{
+				Name: "price",
+				Type: "NUMERIC(10,2)",
+			},
+			dbCol: types.DBColumn{
+				Name:     "price",
+				DataType: "NUMERIC(12,2)",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "price",
+				Changes: map[string]string{
+					"type": "NUMERIC(12,2) -> NUMERIC(10,2)",
+				},
+			},
+		},
+		{
 			name: "primary key change",
 			genCol: goschema.Field{
 				Name:    "id",

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -130,7 +130,7 @@ type SchemaDiff struct {
 	IndexesAdded []string `json:"indexes_added"`
 
 	// IndexesRemoved contains names of indexes that exist in the current database
-	// but not in the target schema (safe operation - no data loss)
+	// but not in the target schema (may affect query plans or uniqueness protections)
 	IndexesRemoved []string `json:"indexes_removed"`
 
 	// IndexesRemovedWithTables contains detailed information about indexes that need to be removed,
@@ -163,7 +163,7 @@ type SchemaDiff struct {
 	RLSPoliciesAdded []string `json:"rls_policies_added"`
 
 	// RLSPoliciesRemoved contains RLS policies that exist in the current database
-	// but not in the target schema (safe operation - no data loss)
+	// but not in the target schema (may remove an access-control protection)
 	RLSPoliciesRemoved []RLSPolicyRef `json:"rls_policies_removed"`
 
 	// RLSPoliciesModified contains detailed information about RLS policies that exist in both

--- a/migration/typechange/typechange.go
+++ b/migration/typechange/typechange.go
@@ -1,0 +1,127 @@
+// Package typechange compares SQL type transitions.
+package typechange
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var typeArgRe = regexp.MustCompile(`^([a-zA-Z0-9_ ]+)\(([^)]*)\)$`)
+
+// IsNarrowing reports whether changing from oldType to newType can lose data
+// by reducing the representable range or length.
+func IsNarrowing(oldType, newType string) bool {
+	oldSpec := parseSpec(oldType)
+	newSpec := parseSpec(newType)
+	if oldSpec.name == "" || newSpec.name == "" || oldSpec.name == newSpec.name && oldSpec.arg == 0 && newSpec.arg == 0 {
+		return false
+	}
+	if isTextType(oldSpec.name) && isSizedString(newSpec.name) {
+		return true
+	}
+	if oldSpec.kind == "string" && newSpec.kind == "string" && oldSpec.arg > 0 && newSpec.arg > 0 {
+		return newSpec.arg < oldSpec.arg
+	}
+	if oldSpec.kind == "integer" && newSpec.kind == "integer" {
+		return integerRank(newSpec.name) < integerRank(oldSpec.name)
+	}
+	if oldSpec.kind == "decimal" && newSpec.kind == "decimal" {
+		return decimalNarrows(oldSpec.args, newSpec.args)
+	}
+	return false
+}
+
+// Same reports whether two type names normalize to the same semantic type.
+func Same(left, right string) bool {
+	return normalizeName(left) == normalizeName(right)
+}
+
+type spec struct {
+	name string
+	kind string
+	arg  int
+	args []int
+}
+
+func parseSpec(raw string) spec {
+	clean := normalizeName(raw)
+	if clean == "" {
+		return spec{}
+	}
+	name := clean
+	var args []int
+	if match := typeArgRe.FindStringSubmatch(clean); match != nil {
+		name = strings.TrimSpace(match[1])
+		for token := range strings.SplitSeq(match[2], ",") {
+			value, err := strconv.Atoi(strings.TrimSpace(token))
+			if err == nil {
+				args = append(args, value)
+			}
+		}
+	}
+	parsed := spec{name: name, args: args}
+	if len(args) > 0 {
+		parsed.arg = args[0]
+	}
+	switch {
+	case isSizedString(name), isTextType(name):
+		parsed.kind = "string"
+	case integerRank(name) > 0:
+		parsed.kind = "integer"
+	case name == "numeric" || name == "decimal" || name == "number":
+		parsed.kind = "decimal"
+	}
+	return parsed
+}
+
+func normalizeName(raw string) string {
+	clean := strings.ToLower(strings.TrimSpace(raw))
+	clean = strings.TrimPrefix(clean, "pg_catalog.")
+	clean = strings.ReplaceAll(clean, "character varying", "varchar")
+	clean = strings.ReplaceAll(clean, "double precision", "double")
+	clean = strings.ReplaceAll(clean, "unsigned", "")
+	return strings.Join(strings.Fields(clean), " ")
+}
+
+func isSizedString(name string) bool {
+	return name == "varchar" || name == "char" || name == "character"
+}
+
+func isTextType(name string) bool {
+	return name == "text" || name == "tinytext" || name == "mediumtext" || name == "longtext"
+}
+
+func integerRank(name string) int {
+	switch name {
+	case "tinyint":
+		return 1
+	case "smallint", "int2":
+		return 2
+	case "mediumint":
+		return 3
+	case "int", "integer", "int4":
+		return 4
+	case "bigint", "int8":
+		return 5
+	default:
+		return 0
+	}
+}
+
+func decimalNarrows(oldArgs, newArgs []int) bool {
+	if len(oldArgs) == 0 || len(newArgs) == 0 {
+		return false
+	}
+	if newArgs[0] < oldArgs[0] {
+		return true
+	}
+	if len(oldArgs) < 2 || len(newArgs) < 2 {
+		return false
+	}
+	oldScale := oldArgs[1]
+	newScale := newArgs[1]
+	oldIntegerDigits := oldArgs[0] - oldScale
+	newIntegerDigits := newArgs[0] - newScale
+	return newScale < oldScale || newIntegerDigits < oldIntegerDigits
+}


### PR DESCRIPTION
## Summary

- Add statement-level migration safety classification in migration/safety, including destructive, warning, and safe assessments for AST nodes.
- Track previous column types in generated modify-column AST operations so narrowing changes such as varchar(255) to varchar(100) and bigint to integer are classified as destructive.
- Add destructive safety checks to migration generation and migrate --check-destructive, plus HTML/text safety reports.
- Add migrate-up --allow-destructive and block pending destructive migrations by default using pending-version-scoped linting.

## Validation

- GOCACHE=/private/tmp/ptah-go-build-cache go test ./migration/safety ./migration/lint ./cmd/migrateup ./cmd/migrate ./migration/generator ./migration/planner/...
- GOCACHE=/private/tmp/ptah-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOCACHE=/private/tmp/ptah-go-build-cache go test ./...

Closes #150