### PR TITLE
Add shadow migration verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,11 +739,12 @@ import (
 
 func main() {
     opts := generator.GenerateMigrationOptions{
-        GoEntitiesDir: "./models",
-        DatabaseURL:   "postgres://user:pass@localhost:5432/database",
-        MigrationName: "add_user_table",
-        OutputDir:     "./migrations",
-        Schemas:       []string{"auth", "billing", "public"},
+        GoEntitiesDir:      "./models",
+        DatabaseURL:        "postgres://user:pass@localhost:5432/database",
+        MigrationName:      "add_user_table",
+        OutputDir:          "./migrations",
+        Schemas:            []string{"auth", "billing", "public"},
+        ShadowDatabaseURL:  "postgres://user:pass@localhost:5432/shadow_database",
     }
 
     ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -788,6 +789,23 @@ defer cancel()
 files, err := generator.GenerateMigration(ctx, opts)
 ```
 
+**CLI generation with shadow verification:**
+
+```bash
+package-migrator migrate generate \
+  --root-dir ./models \
+  --db-url postgres://user:pass@localhost:5432/database \
+  --migrations-dir ./migrations \
+  --name add_user_table \
+  --shadow-db postgres://user:pass@localhost:5432/shadow_database
+```
+
+`--shadow-db` is destructive for the shadow database: Ptah drops all objects in
+that database, replays existing migrations, applies the candidate migration,
+re-introspects the schema, and only writes files when the replayed schema
+matches the Go source. A mismatch aborts before writing files with a diagnostic
+such as `shadow check failed: missing column users.email`.
+
 **Using Existing Database Connection:**
 
 ```go
@@ -818,6 +836,7 @@ opts := generator.GenerateMigrationOptions{
 - ✅ Embedded filesystem support for Go modules
 - ✅ Connection reuse for better performance
 - ✅ No-op detection (returns nil when no changes needed)
+- ✅ Optional shadow database replay before files are written
 
 ### Dangerous Operations
 

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -1,0 +1,134 @@
+package migrate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+const (
+	generateRootDirFlag          = "root-dir"
+	generateDBURLFlag            = "db-url"
+	generateMigrationsDirFlag    = "migrations-dir"
+	generateNameFlag             = "name"
+	generateShadowDBFlag         = "shadow-db"
+	generateCheckDestructiveFlag = "check-destructive"
+	generateAllowDestructiveFlag = "allow-destructive"
+	generateReportFormatFlag     = "report"
+)
+
+func newMigrateGenerateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "generate",
+		Short: "Generate migration files from schema differences",
+		Long: `Generate migration files by comparing Go entities with the current database schema.
+
+When --shadow-db is set, Ptah verifies the generated candidate on the shadow database before writing files:
+it drops all shadow objects, replays existing migrations, applies the candidate, re-introspects the schema,
+and performs an up/down/up round-trip.`,
+		RunE: migrateGenerateCommand,
+	}
+
+	flags := cmd.Flags()
+	flags.String(generateRootDirFlag, "./", "Root directory to scan for Go entities")
+	flags.String(generateDBURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
+	flags.String(generateMigrationsDirFlag, "", "Directory containing existing migrations and receiving generated files (required)")
+	flags.String(generateNameFlag, "migration", "Migration name")
+	flags.String(generateShadowDBFlag, "", "Shadow database URL used to verify generated migrations before writing files")
+	flags.Bool(generateCheckDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
+	flags.Bool(generateAllowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
+	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "" or html`)
+	flags.String(dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String(), "Initial database connection timeout")
+	flags.String(dbcli.SchemasFlagName, "", "Comma-separated schemas to introspect when supported")
+
+	return cmd
+}
+
+func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
+	rootDir, err := cmd.Flags().GetString(generateRootDirFlag)
+	if err != nil {
+		return err
+	}
+	dbURL, err := cmd.Flags().GetString(generateDBURLFlag)
+	if err != nil {
+		return err
+	}
+	migrationsDir, err := cmd.Flags().GetString(generateMigrationsDirFlag)
+	if err != nil {
+		return err
+	}
+	name, err := cmd.Flags().GetString(generateNameFlag)
+	if err != nil {
+		return err
+	}
+	shadowDB, err := cmd.Flags().GetString(generateShadowDBFlag)
+	if err != nil {
+		return err
+	}
+	reportFormat, err := cmd.Flags().GetString(generateReportFormatFlag)
+	if err != nil {
+		return err
+	}
+	checkDestructive, err := cmd.Flags().GetBool(generateCheckDestructiveFlag)
+	if err != nil {
+		return err
+	}
+	allowDestructive, err := cmd.Flags().GetBool(generateAllowDestructiveFlag)
+	if err != nil {
+		return err
+	}
+	connectTimeoutValue, err := cmd.Flags().GetString(dbcli.ConnectTimeoutFlagName)
+	if err != nil {
+		return err
+	}
+	schemasValue, err := cmd.Flags().GetString(dbcli.SchemasFlagName)
+	if err != nil {
+		return err
+	}
+
+	if dbURL == "" {
+		return fmt.Errorf("database URL is required")
+	}
+	if migrationsDir == "" {
+		return fmt.Errorf("migrations directory is required")
+	}
+
+	connectTimeout, err := dbcli.ParseConnectTimeout(connectTimeoutValue)
+	if err != nil {
+		return err
+	}
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	defer cancelConnect()
+
+	files, err := generator.GenerateMigration(connectCtx, generator.GenerateMigrationOptions{
+		GoEntitiesDir:     rootDir,
+		DatabaseURL:       dbURL,
+		MigrationName:     name,
+		OutputDir:         migrationsDir,
+		Schemas:           dbcli.ParseSchemas(schemasValue),
+		CheckDestructive:  checkDestructive,
+		AllowDestructive:  allowDestructive,
+		ReportFormat:      reportFormat,
+		ShadowDatabaseURL: shadowDB,
+	})
+	if err != nil {
+		return err
+	}
+	if files == nil {
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Generated migration files for %s:\n", dbschema.FormatDatabaseURL(dbURL))
+	fmt.Fprintf(out, "UP:   %s\n", files.UpFile)
+	fmt.Fprintf(out, "DOWN: %s\n", files.DownFile)
+	if files.ReportFile != "" {
+		fmt.Fprintf(out, "REPORT: %s\n", files.ReportFile)
+	}
+	return nil
+}

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -1,0 +1,173 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+)
+
+func TestMigrateGenerateCommandExposesShadowDBFlag(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := newMigrateGenerateCommand()
+
+	c.Assert(cmd.Name(), qt.Equals, "generate")
+	c.Assert(cmd.Flags().Lookup(generateShadowDBFlag), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup(generateMigrationsDirFlag), qt.IsNotNil)
+}
+
+func TestAddMigrateGenerateCommandIsIdempotent(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrateCommand()
+	addMigrateGenerateCommand(cmd)
+	addMigrateGenerateCommand(cmd)
+
+	count := 0
+	for _, child := range cmd.Commands() {
+		if child.Name() == "generate" {
+			count++
+		}
+	}
+	c.Assert(count, qt.Equals, 1)
+}
+
+func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
+	dbURL := migrateGenerateTestDatabaseURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
+		t.Skipf("shadow CLI acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
+	}
+	releaseLock := acquireMigrateGenerateTestLock(c, ctx, conn)
+	defer releaseLock()
+	defer func() {
+		c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	}()
+
+	c.Run("broken prior migration aborts before writing candidate files", func(c *qt.C) {
+		dir := c.TempDir()
+		entitiesDir := writeMigrateGenerateShadowEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writeMigrateGeneratePriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY);\n")
+		prepareMigrateGenerateTargetDB(c, ctx, conn)
+
+		var out bytes.Buffer
+		cmd := NewMigrateCommand()
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{
+			"generate",
+			"--root-dir", entitiesDir,
+			"--db-url", dbURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "add_email",
+			"--shadow-db", dbURL,
+		})
+
+		err := cmd.Execute()
+
+		c.Assert(err, qt.ErrorMatches, `shadow check failed: missing column users\.name`)
+		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 2)
+	})
+
+	c.Run("correct prior migration writes candidate files", func(c *qt.C) {
+		dir := c.TempDir()
+		entitiesDir := writeMigrateGenerateShadowEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writeMigrateGeneratePriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\n")
+		prepareMigrateGenerateTargetDB(c, ctx, conn)
+
+		var out bytes.Buffer
+		cmd := NewMigrateCommand()
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{
+			"generate",
+			"--root-dir", entitiesDir,
+			"--db-url", dbURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "add_email",
+			"--shadow-db", dbURL,
+		})
+
+		err := cmd.Execute()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(out.String(), qt.Contains, "Generated migration files")
+		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 4)
+	})
+}
+
+func migrateGenerateTestDatabaseURL() string {
+	for _, name := range []string{"TEST_DATABASE_URL", "TEST_DB_URL", "POSTGRES_TEST_DSN", "POSTGRES_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func acquireMigrateGenerateTestLock(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) func() {
+	_, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock(156156156)")
+	c.Assert(err, qt.IsNil)
+
+	return func() {
+		_, unlockErr := conn.ExecContext(ctx, "SELECT pg_advisory_unlock(156156156)")
+		c.Assert(unlockErr, qt.IsNil)
+	}
+}
+
+func writeMigrateGenerateShadowEntities(c *qt.C, dir string) string {
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+
+	content := `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+
+	//migrator:schema:field name="email" type="TEXT"
+	Email string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0600), qt.IsNil)
+	return entitiesDir
+}
+
+func writeMigrateGeneratePriorMigration(c *qt.C, dir, upSQL string) {
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte(upSQL), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte("DROP TABLE IF EXISTS users;\n"), 0600), qt.IsNil)
+}
+
+func prepareMigrateGenerateTargetDB(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) {
+	c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	_, err := conn.ExecContext(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)")
+	c.Assert(err, qt.IsNil)
+}

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -28,6 +28,8 @@ the SQL statements needed to update the database to match your entities.`,
 	RunE: migrateCommand,
 }
 
+var migrateFlagsRegistered bool
+
 const (
 	rootDirFlag          = "root-dir"
 	dbURLFlag            = "db-url"
@@ -67,8 +69,21 @@ var migrateFlags = map[string]cobraflags.Flag{
 }
 
 func NewMigrateCommand() *cobra.Command {
-	cobraflags.RegisterMap(migrateCmd, migrateFlags)
+	if !migrateFlagsRegistered {
+		cobraflags.RegisterMap(migrateCmd, migrateFlags)
+		migrateFlagsRegistered = true
+	}
+	addMigrateGenerateCommand(migrateCmd)
 	return migrateCmd
+}
+
+func addMigrateGenerateCommand(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		if child.Name() == "generate" {
+			return
+		}
+	}
+	cmd.AddCommand(newMigrateGenerateCommand())
 }
 
 func migrateCommand(cmd *cobra.Command, _ []string) error {

--- a/integration/shadow_generate_e2e_test.go
+++ b/integration/shadow_generate_e2e_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
+	dbURL := postgresE2EDatabaseURL(t)
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN or POSTGRES_URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "package-migrator")
+	buildPackageMigrator(c, ctx, repoRoot, binaryPath)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_shadow_e2e_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	testDBURL := replaceDatabaseName(c, dbURL, testDBName)
+
+	t.Run("broken hand-edited migration aborts before writing candidate files", func(t *testing.T) {
+		c := qt.New(t)
+		dir := t.TempDir()
+		entitiesDir := writeShadowE2EEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writeShadowE2EPriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY);\n")
+		prepareShadowE2ETargetDB(c, ctx, testDBURL)
+
+		output, err := runPackageMigrator(
+			ctx,
+			repoRoot,
+			binaryPath,
+			"migrate", "generate",
+			"--root-dir", entitiesDir,
+			"--db-url", testDBURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "add_email",
+			"--shadow-db", testDBURL,
+		)
+
+		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(output, qt.Contains, "shadow check failed: missing column users.name")
+		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 2)
+	})
+
+	t.Run("correct migration chain writes candidate files", func(t *testing.T) {
+		c := qt.New(t)
+		dir := t.TempDir()
+		entitiesDir := writeShadowE2EEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writeShadowE2EPriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\n")
+		prepareShadowE2ETargetDB(c, ctx, testDBURL)
+
+		output, err := runPackageMigrator(
+			ctx,
+			repoRoot,
+			binaryPath,
+			"migrate", "generate",
+			"--root-dir", entitiesDir,
+			"--db-url", testDBURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "add_email",
+			"--shadow-db", testDBURL,
+		)
+
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+		c.Assert(output, qt.Contains, "Generated migration files")
+		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 4)
+		c.Assert(readFirstMatchingFile(c, migrationsDir, "*_add_email.up.sql"), qt.Contains, "email")
+	})
+}
+
+func postgresE2EDatabaseURL(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func e2eRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve test file path")
+	}
+	return filepath.Dir(filepath.Dir(file))
+}
+
+func buildPackageMigrator(c *qt.C, ctx context.Context, repoRoot, binaryPath string) {
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", binaryPath, "./cmd")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("go build output:\n%s", string(output)))
+}
+
+func runPackageMigrator(ctx context.Context, repoRoot, binaryPath string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func createE2EDatabase(c *qt.C, ctx context.Context, db *sql.DB, name string) {
+	_, err := db.ExecContext(ctx, "CREATE DATABASE "+quoteE2EIdent(name))
+	c.Assert(err, qt.IsNil)
+}
+
+func dropE2EDatabase(c *qt.C, ctx context.Context, db *sql.DB, name string) {
+	_, _ = db.ExecContext(ctx, "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()", name)
+	_, err := db.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteE2EIdent(name))
+	c.Assert(err, qt.IsNil)
+}
+
+func quoteE2EIdent(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func replaceDatabaseName(c *qt.C, dbURL, databaseName string) string {
+	parsed, err := url.Parse(dbURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + databaseName
+	return parsed.String()
+}
+
+func prepareShadowE2ETargetDB(c *qt.C, ctx context.Context, dbURL string) {
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS users CASCADE")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, "DROP TABLE IF EXISTS schema_migrations CASCADE")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)")
+	c.Assert(err, qt.IsNil)
+}
+
+func writeShadowE2EEntities(c *qt.C, dir string) string {
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+	content := `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+
+	//migrator:schema:field name="email" type="TEXT"
+	Email string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0600), qt.IsNil)
+	return entitiesDir
+}
+
+func writeShadowE2EPriorMigration(c *qt.C, dir, upSQL string) {
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte(upSQL), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte("DROP TABLE IF EXISTS users;\n"), 0600), qt.IsNil)
+}
+
+func readFirstMatchingFile(c *qt.C, dir, pattern string) string {
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.Not(qt.HasLen), 0)
+	content, err := os.ReadFile(matches[0])
+	c.Assert(err, qt.IsNil)
+	return string(content)
+}

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -34,6 +34,7 @@ func main() {
         MigrationName: "add_user_table",       // Optional: defaults to "migration"
         OutputDir:     "./migrations",         // Directory to save migration files
         Schemas:       []string{"auth", "billing", "public"}, // Optional PostgreSQL schema allow-list
+        ShadowDatabaseURL: "postgres://user:pass@localhost/shadow", // Optional pre-write verification DB
     }
 
     // Bound the initial database connection so a stuck host fails fast.
@@ -67,7 +68,34 @@ The generator follows this process:
 3. **Calculate Differences**: Compares the desired schema with the current database state
 4. **Generate UP Migration**: Creates SQL statements to transform current schema to desired schema
 5. **Generate DOWN Migration**: Creates SQL statements to reverse the changes (rollback)
-6. **Save Files**: Writes both migration files with proper naming convention
+6. **Shadow Verification (Optional)**: Replays prior migrations plus the candidate on a disposable database before files are written
+7. **Save Files**: Writes both migration files with proper naming convention
+
+### Shadow Database Verification
+
+Set `ShadowDatabaseURL` to verify generated migrations before they are written:
+
+```go
+opts := generator.GenerateMigrationOptions{
+    GoEntitiesDir:      "./entities",
+    DatabaseURL:        "postgres://localhost:5432/app_dev",
+    MigrationName:      "add_user_table",
+    OutputDir:          "./migrations",
+    ShadowDatabaseURL:  "postgres://localhost:5432/app_shadow",
+}
+```
+
+The shadow database is treated as disposable. The generator drops all objects in
+it, applies every existing migration from `OutputDir`, applies the candidate
+migration, re-introspects the database, and compares the result against the Go
+schema. If the replayed schema differs, generation aborts before writing files:
+
+```text
+shadow check failed: missing column users.email
+```
+
+Ptah also runs an `up -> down -> up` round-trip on the candidate migration and
+aborts if either direction fails.
 
 ### File Naming Convention
 
@@ -180,6 +208,9 @@ type GenerateMigrationOptions struct {
     // Schemas restricts database introspection to the listed schemas when the
     // connected dialect supports schema scoping.
     Schemas []string
+
+    // ShadowDatabaseURL enables pre-write verification on a disposable database.
+    ShadowDatabaseURL string
 }
 ```
 
@@ -192,6 +223,7 @@ type GenerateMigrationOptions struct {
 - `OutputDir`: Directory where migration files will be saved (required)
 - `CompareOptions`: Schema comparison options (optional)
 - `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
+- `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks (optional)
 
 ### Database URL Examples
 

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -53,6 +53,11 @@ type GenerateMigrationOptions struct {
 	// ReportFormat optionally writes a safety report next to generated files.
 	// Supported values: "", "html".
 	ReportFormat string
+	// ShadowDatabaseURL enables pre-write verification on an ephemeral database.
+	// The generator drops all objects in this database, replays existing
+	// migrations from OutputDir, applies the candidate migration, re-introspects
+	// the result, and aborts if it differs from the Go schema.
+	ShadowDatabaseURL string
 }
 
 // MigrationFiles represents the generated migration files
@@ -135,6 +140,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 
 	// 4. Generate migration version (timestamp)
 	version := migrator.GetNextMigrationVersion()
+	version = nextAvailableMigrationVersion(opts.OutputDir, version, opts.MigrationName)
 	slog.Debug("Generated migration version", "version", version)
 
 	upNodes := planner.GenerateSchemaDiffAST(diff, generated, conn.Info().Dialect)
@@ -162,6 +168,23 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	downSQL, err := generateDownMigrationSQL(diff, generated, dbSchema, conn.Info().Dialect)
 	if err != nil {
 		return nil, fmt.Errorf("error generating down migration SQL: %w", err)
+	}
+
+	if opts.ShadowDatabaseURL != "" {
+		if err := verifyShadowMigration(ctx, shadowMigrationOptions{
+			DatabaseURL:   opts.ShadowDatabaseURL,
+			MigrationsDir: opts.OutputDir,
+			Dialect:       conn.Info().Dialect,
+			Version:       version,
+			Name:          opts.MigrationName,
+			UpSQL:         upSQL,
+			DownSQL:       downSQL,
+			Generated:     generated,
+			CompareOpts:   compareOpts,
+			Schemas:       opts.Schemas,
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	// 7. Create migration files
@@ -721,6 +744,46 @@ func reverseRoleDiffs(roleDiffs []types.RoleDiff) []types.RoleDiff {
 	return reversed
 }
 
+func nextAvailableMigrationVersion(outputDir string, version int, migrationName string) int {
+	if latest := latestExistingMigrationVersion(outputDir); latest >= version {
+		version = latest + 1
+	}
+	for {
+		upFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "up"))
+		downFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "down"))
+		if !nonEmptyFileExists(upFilePath) && !nonEmptyFileExists(downFilePath) {
+			return version
+		}
+		version++
+	}
+}
+
+func latestExistingMigrationVersion(outputDir string) int {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return 0
+	}
+	latest := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		migrationFile, err := migrator.ParseMigrationFileName(entry.Name())
+		if err != nil {
+			continue
+		}
+		if migrationFile.Version > latest {
+			latest = migrationFile.Version
+		}
+	}
+	return latest
+}
+
+func nonEmptyFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Size() > 0
+}
+
 // createMigrationFiles creates the up and down migration files
 func createMigrationFiles(outputDir string, version int, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
 	// Ensure output directory exists
@@ -734,19 +797,6 @@ func createMigrationFiles(outputDir string, version int, migrationName, upSQL, d
 
 	upFilePath := filepath.Join(outputDir, upFileName)
 	downFilePath := filepath.Join(outputDir, downFileName)
-
-	for {
-		info, err := os.Stat(upFilePath)
-		if err != nil || info.Size() == 0 {
-			break
-		}
-
-		version++
-		upFileName = migrator.GenerateMigrationFileName(version, migrationName, "up")
-		downFileName = migrator.GenerateMigrationFileName(version, migrationName, "down")
-		upFilePath = filepath.Join(outputDir, upFileName)
-		downFilePath = filepath.Join(outputDir, downFileName)
-	}
 
 	// Write up migration file
 	if err := os.WriteFile(upFilePath, []byte(upSQL), 0644); err != nil { //nolint:gosec // 0644 is fine

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -1,0 +1,246 @@
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+var missingColumnErrorRe = regexp.MustCompile(`column "([^"]+)" of relation "([^"]+)" does not exist`)
+
+type shadowMigrationOptions struct {
+	DatabaseURL   string
+	MigrationsDir string
+	Dialect       string
+	Version       int
+	Name          string
+	UpSQL         string
+	DownSQL       string
+	Generated     *goschema.Database
+	CompareOpts   *config.CompareOptions
+	Schemas       []string
+}
+
+func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) error {
+	conn, err := dbschema.ConnectToDatabase(ctx, opts.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("shadow check failed: connect to shadow database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	if !sameDialect(opts.Dialect, conn.Info().Dialect) {
+		return fmt.Errorf("shadow check failed: shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect)
+	}
+
+	if err := conn.Writer().DropAllTables(); err != nil {
+		return fmt.Errorf("shadow check failed: drop all objects: %w", err)
+	}
+	replayCtx := context.Background()
+
+	prior, err := loadPriorMigrations(opts.MigrationsDir)
+	if err != nil {
+		return fmt.Errorf("shadow check failed: load prior migrations: %w", err)
+	}
+
+	candidate := migrator.CreateMigrationFromSQL(opts.Version, opts.Name, opts.UpSQL, opts.DownSQL)
+	migrations := make([]*migrator.Migration, 0, len(prior)+1)
+	migrations = append(migrations, prior...)
+	migrations = append(migrations, candidate)
+
+	mig := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...))
+	if err := mig.MigrateUp(replayCtx); err != nil {
+		if description := describeReplayError(err); description != "" {
+			return fmt.Errorf("shadow check failed: %s", description)
+		}
+		return fmt.Errorf("shadow check failed: replay migrations: %w", err)
+	}
+	if err := assertShadowSchemaMatches(conn, opts); err != nil {
+		return err
+	}
+
+	previousVersion := latestMigrationVersion(prior)
+	if err := mig.MigrateDownTo(replayCtx, previousVersion); err != nil {
+		return fmt.Errorf("shadow check failed: round-trip down: %w", err)
+	}
+	if err := mig.MigrateTo(replayCtx, opts.Version); err != nil {
+		return fmt.Errorf("shadow check failed: round-trip up: %w", err)
+	}
+	return assertShadowSchemaMatches(conn, opts)
+}
+
+func describeReplayError(err error) string {
+	match := missingColumnErrorRe.FindStringSubmatch(err.Error())
+	if match == nil {
+		return ""
+	}
+	return fmt.Sprintf("missing column %s.%s", match[2], match[1])
+}
+
+func sameDialect(left, right string) bool {
+	return platform.NormalizeDialect(left) == platform.NormalizeDialect(right)
+}
+
+func loadPriorMigrations(dir string) ([]*migrator.Migration, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(dir))
+	if err != nil {
+		return nil, err
+	}
+	migrations := provider.Migrations()
+	out := make([]*migrator.Migration, len(migrations))
+	copy(out, migrations)
+	return out, nil
+}
+
+func latestMigrationVersion(migrations []*migrator.Migration) int {
+	latest := 0
+	for _, migration := range migrations {
+		if migration.Version > latest {
+			latest = migration.Version
+		}
+	}
+	return latest
+}
+
+func assertShadowSchemaMatches(conn *dbschema.DatabaseConnection, opts shadowMigrationOptions) error {
+	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, opts.Schemas)
+	if err != nil {
+		return fmt.Errorf("shadow check failed: re-introspect shadow database: %w", err)
+	}
+
+	diff := schemadiff.CompareWithOptions(opts.Generated, dbSchema, opts.CompareOpts)
+	if !diff.HasChanges() {
+		return nil
+	}
+	return fmt.Errorf("shadow check failed: %s", describeShadowDiff(diff))
+}
+
+func describeShadowDiff(diff *types.SchemaDiff) string {
+	if diff == nil {
+		return "schema differs"
+	}
+
+	for _, tableName := range sortedStrings(diff.TablesAdded) {
+		return "missing table " + tableName
+	}
+	for _, table := range sortedTableDiffs(diff.TablesModified) {
+		for _, columnName := range sortedStrings(table.ColumnsAdded) {
+			return fmt.Sprintf("missing column %s.%s", table.TableName, columnName)
+		}
+		for _, constraintName := range sortedStrings(table.ConstraintsAdded) {
+			return fmt.Sprintf("missing constraint %s.%s", table.TableName, constraintName)
+		}
+		for _, column := range sortedColumnDiffs(table.ColumnsModified) {
+			return fmt.Sprintf("column mismatch %s.%s: %s", table.TableName, column.ColumnName, describeChanges(column.Changes))
+		}
+		for _, columnName := range sortedStrings(table.ColumnsRemoved) {
+			return fmt.Sprintf("extra column %s.%s", table.TableName, columnName)
+		}
+		for _, constraintName := range sortedStrings(table.ConstraintsRemoved) {
+			return fmt.Sprintf("extra constraint %s.%s", table.TableName, constraintName)
+		}
+	}
+	for _, enumName := range sortedStrings(diff.EnumsAdded) {
+		return "missing enum " + enumName
+	}
+	for _, enum := range sortedEnumDiffs(diff.EnumsModified) {
+		for _, value := range sortedStrings(enum.ValuesAdded) {
+			return fmt.Sprintf("missing enum value %s.%s", enum.EnumName, value)
+		}
+		for _, value := range sortedStrings(enum.ValuesRemoved) {
+			return fmt.Sprintf("extra enum value %s.%s", enum.EnumName, value)
+		}
+	}
+	for _, indexName := range sortedStrings(diff.IndexesAdded) {
+		return "missing index " + indexName
+	}
+	for _, extensionName := range sortedStrings(diff.ExtensionsAdded) {
+		return "missing extension " + extensionName
+	}
+	for _, functionName := range sortedStrings(diff.FunctionsAdded) {
+		return "missing function " + functionName
+	}
+	for _, policyName := range sortedStrings(diff.RLSPoliciesAdded) {
+		return "missing RLS policy " + policyName
+	}
+	for _, tableName := range sortedStrings(diff.RLSEnabledTablesAdded) {
+		return "missing RLS enablement " + tableName
+	}
+	for _, roleName := range sortedStrings(diff.RolesAdded) {
+		return "missing role " + roleName
+	}
+	for _, constraintName := range sortedStrings(diff.ConstraintsAdded) {
+		return "missing constraint " + constraintName
+	}
+
+	return "schema differs"
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}
+
+func sortedTableDiffs(values []types.TableDiff) []types.TableDiff {
+	out := append([]types.TableDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].TableName < out[j].TableName
+	})
+	return out
+}
+
+func sortedColumnDiffs(values []types.ColumnDiff) []types.ColumnDiff {
+	out := append([]types.ColumnDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ColumnName < out[j].ColumnName
+	})
+	return out
+}
+
+func sortedEnumDiffs(values []types.EnumDiff) []types.EnumDiff {
+	out := append([]types.EnumDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].EnumName < out[j].EnumName
+	})
+	return out
+}
+
+func describeChanges(changes map[string]string) string {
+	if len(changes) == 0 {
+		return "unknown change"
+	}
+
+	keys := make([]string, 0, len(changes))
+	for key := range changes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+" "+changes[key])
+	}
+	return strings.Join(parts, ", ")
+}

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -1,0 +1,188 @@
+package generator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestDescribeShadowDiffMissingColumn(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{
+				TableName:    "users",
+				ColumnsAdded: []string{"email", "name"},
+			},
+		},
+	}
+
+	c.Assert(describeShadowDiff(diff), qt.Equals, "missing column users.email")
+}
+
+func TestDescribeChangesIsDeterministic(t *testing.T) {
+	c := qt.New(t)
+
+	got := describeChanges(map[string]string{
+		"nullable": "true -> false",
+		"type":     "text -> varchar",
+	})
+
+	c.Assert(got, qt.Equals, "nullable true -> false, type text -> varchar")
+}
+
+func TestNextAvailableMigrationVersionChecksUpAndDownFiles(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, migrator.GenerateMigrationFileName(100, "add_email", "down")), []byte("SELECT 1;"), 0600)
+	c.Assert(err, qt.IsNil)
+	err = os.WriteFile(filepath.Join(dir, migrator.GenerateMigrationFileName(105, "future", "up")), []byte("SELECT 1;"), 0600)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(nextAvailableMigrationVersion(dir, 100, "add_email"), qt.Equals, 106)
+}
+
+func TestLoadPriorMigrationsMissingDir(t *testing.T) {
+	c := qt.New(t)
+
+	migrations, err := loadPriorMigrations(filepath.Join(t.TempDir(), "missing"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrations, qt.HasLen, 0)
+}
+
+func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
+	dbURL := shadowTestDatabaseURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
+		t.Skipf("shadow acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
+	}
+	releaseLock := acquireShadowTestLock(c, ctx, conn)
+	defer releaseLock()
+	defer func() {
+		c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	}()
+
+	c.Run("broken prior migration aborts with missing column", func(c *qt.C) {
+		dir := c.TempDir()
+		entitiesDir := writeShadowEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writePriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY);\n")
+
+		prepareShadowTargetDB(c, ctx, conn)
+
+		files, err := GenerateMigration(ctx, GenerateMigrationOptions{
+			GoEntitiesDir:     entitiesDir,
+			DatabaseURL:       dbURL,
+			MigrationName:     "add_email",
+			OutputDir:         migrationsDir,
+			ShadowDatabaseURL: dbURL,
+		})
+
+		c.Assert(files, qt.IsNil)
+		c.Assert(err, qt.ErrorMatches, `shadow check failed: missing column users\.name`)
+		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 2)
+	})
+
+	c.Run("correct prior migration passes and writes files", func(c *qt.C) {
+		dir := c.TempDir()
+		entitiesDir := writeShadowEntities(c, dir)
+		migrationsDir := filepath.Join(dir, "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+		writePriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\n")
+
+		prepareShadowTargetDB(c, ctx, conn)
+
+		files, err := GenerateMigration(ctx, GenerateMigrationOptions{
+			GoEntitiesDir:     entitiesDir,
+			DatabaseURL:       dbURL,
+			MigrationName:     "add_email",
+			OutputDir:         migrationsDir,
+			ShadowDatabaseURL: dbURL,
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(files, qt.IsNotNil)
+		c.Assert(files.UpFile, qt.Not(qt.Equals), "")
+		c.Assert(files.DownFile, qt.Not(qt.Equals), "")
+		upSQL, readErr := os.ReadFile(files.UpFile)
+		c.Assert(readErr, qt.IsNil)
+		c.Assert(string(upSQL), qt.Contains, "email")
+	})
+}
+
+func shadowTestDatabaseURL() string {
+	for _, name := range []string{"TEST_DATABASE_URL", "TEST_DB_URL", "POSTGRES_TEST_DSN", "POSTGRES_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func acquireShadowTestLock(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) func() {
+	_, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock(156156156)")
+	c.Assert(err, qt.IsNil)
+
+	return func() {
+		_, unlockErr := conn.ExecContext(ctx, "SELECT pg_advisory_unlock(156156156)")
+		c.Assert(unlockErr, qt.IsNil)
+	}
+}
+
+func writeShadowEntities(c *qt.C, dir string) string {
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+
+	content := `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+
+	//migrator:schema:field name="email" type="TEXT"
+	Email string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0600), qt.IsNil)
+	return entitiesDir
+}
+
+func writePriorMigration(c *qt.C, dir, upSQL string) {
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte(upSQL), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte("DROP TABLE IF EXISTS users;\n"), 0600), qt.IsNil)
+}
+
+func prepareShadowTargetDB(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) {
+	c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	_, err := conn.ExecContext(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)")
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
Closes #156.

## Summary
- add `migrate generate --shadow-db` and wire it to pre-write migration generation
- replay existing migrations plus the candidate on a disposable shadow DB, re-introspect, diff against Go schema, and run an up/down/up round-trip
- add API, CLI, docs, unit tests, and real PostgreSQL acceptance coverage

## Validation
- `go test -count=1 ./migration/generator ./cmd/migrate`
- `TEST_DATABASE_URL=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test ./migration/generator ./cmd/migrate -run 'Test.*ShadowVerificationWithRealDB' -count=1 -v`
- `go test -v -race ./... -timeout 10m`
- `golangci-lint run ./...`
- `git diff --check`