### PR TITLE
Add schema object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The core package contains all fundamental components for parsing, transforming, 
 
 - **`yamlschema/`** - Language-agnostic YAML schema frontend
   - Parses `.yaml` / `.yml` schema files into the same `goschema.Database` IR used by Go annotations
-  - Supports tables, columns, indexes, constraints, enums, extensions, functions, RLS, roles, and dialect overrides
-  - Uses strict validation for unknown fields, duplicate ordered keys, unsupported objects, and invalid constraints
+  - Supports tables, columns, indexes, constraints, enums, extensions, functions, views, materialized views, triggers, RLS, roles, and dialect overrides
+  - Uses strict validation for unknown fields, duplicate ordered keys, and invalid constraints
 
 - **`parser/`** - SQL DDL token-to-AST parser
   - Converts SQL DDL tokens into Abstract Syntax Tree nodes
@@ -254,7 +254,7 @@ type Event struct {
 }
 ```
 
-Recognised keys: `engine`, `order_by`, `partition_by`, `primary_key`, `sample_by`, `settings`, `ttl`, `comment`. MergeTree-family engines require `order_by`; the renderer rejects a Nullable column that appears in the sorting key.
+Recognized keys: `engine`, `order_by`, `partition_by`, `primary_key`, `sample_by`, `settings`, `ttl`, `comment`. MergeTree-family engines require `order_by`; the renderer rejects a Nullable column that appears in the sorting key.
 
 ### PostgreSQL Extensions (PostgreSQL only)
 ```go
@@ -272,6 +272,19 @@ type User struct {
     // fields...
 }
 ```
+
+### Views, Materialized Views, And Triggers
+```go
+//migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" with_check="false"
+//migrator:schema:matview name="user_stats" body="SELECT id, COUNT(*) FROM users GROUP BY id" refresh_strategy="manual"
+//migrator:schema:trigger name="set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;"
+//migrator:schema:table name="users"
+type User struct {
+    // fields...
+}
+```
+
+Views are supported on PostgreSQL, MySQL, and MariaDB. Materialized views are PostgreSQL-only. Trigger bodies are dialect-specific: PostgreSQL trigger annotations provide the function body that returns `NEW`/`OLD`, while MySQL/MariaDB trigger bodies are emitted inline.
 
 ### Row-Level Security (PostgreSQL only)
 ```go

--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -42,6 +42,20 @@ type Visitor interface {
 	VisitCreateFunction(*CreateFunctionNode) error
 	// VisitDropFunction renders a DROP FUNCTION statement (PostgreSQL-specific)
 	VisitDropFunction(*DropFunctionNode) error
+	// VisitCreateView renders a CREATE VIEW statement
+	VisitCreateView(*CreateViewNode) error
+	// VisitDropView renders a DROP VIEW statement
+	VisitDropView(*DropViewNode) error
+	// VisitCreateMaterializedView renders a CREATE MATERIALIZED VIEW statement
+	VisitCreateMaterializedView(*CreateMaterializedViewNode) error
+	// VisitDropMaterializedView renders a DROP MATERIALIZED VIEW statement
+	VisitDropMaterializedView(*DropMaterializedViewNode) error
+	// VisitRefreshMaterializedView renders a REFRESH MATERIALIZED VIEW statement
+	VisitRefreshMaterializedView(*RefreshMaterializedViewNode) error
+	// VisitCreateTrigger renders a CREATE TRIGGER statement
+	VisitCreateTrigger(*CreateTriggerNode) error
+	// VisitDropTrigger renders a DROP TRIGGER statement
+	VisitDropTrigger(*DropTriggerNode) error
 	// VisitCreatePolicy renders a CREATE POLICY statement for RLS (PostgreSQL-specific)
 	VisitCreatePolicy(*CreatePolicyNode) error
 	// VisitDropPolicy renders a DROP POLICY statement for RLS (PostgreSQL-specific)

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -156,6 +156,62 @@ func (m *MockVisitor) VisitDropFunction(node *ast.DropFunctionNode) error {
 	return nil
 }
 
+func (m *MockVisitor) VisitCreateView(node *ast.CreateViewNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "CreateView:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitDropView(node *ast.DropViewNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "DropView:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "CreateMaterializedView:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "DropMaterializedView:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "RefreshMaterializedView:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "CreateTrigger:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "DropTrigger:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
 func (m *MockVisitor) VisitDropPolicy(node *ast.DropPolicyNode) error {
 	m.VisitedNodes = append(m.VisitedNodes, "DropPolicy:"+node.Name)
 	if m.ReturnError {

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -865,6 +865,255 @@ func (n *DropTypeNode) Accept(visitor Visitor) error {
 	return visitor.VisitDropType(n)
 }
 
+// CreateViewNode represents a CREATE VIEW statement.
+type CreateViewNode struct {
+	Name      string
+	Body      string
+	Replace   bool
+	WithCheck bool
+	Comment   string
+}
+
+func NewCreateView(name string) *CreateViewNode {
+	return &CreateViewNode{Name: name}
+}
+
+func (n *CreateViewNode) SetBody(body string) *CreateViewNode {
+	n.Body = body
+	return n
+}
+
+func (n *CreateViewNode) SetReplace() *CreateViewNode {
+	n.Replace = true
+	return n
+}
+
+func (n *CreateViewNode) SetWithCheck(withCheck bool) *CreateViewNode {
+	n.WithCheck = withCheck
+	return n
+}
+
+func (n *CreateViewNode) SetComment(comment string) *CreateViewNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *CreateViewNode) Accept(visitor Visitor) error {
+	return visitor.VisitCreateView(n)
+}
+
+// DropViewNode represents a DROP VIEW statement.
+type DropViewNode struct {
+	Name     string
+	IfExists bool
+	Cascade  bool
+	Comment  string
+}
+
+func NewDropView(name string) *DropViewNode {
+	return &DropViewNode{Name: name}
+}
+
+func (n *DropViewNode) SetIfExists() *DropViewNode {
+	n.IfExists = true
+	return n
+}
+
+func (n *DropViewNode) SetCascade() *DropViewNode {
+	n.Cascade = true
+	return n
+}
+
+func (n *DropViewNode) SetComment(comment string) *DropViewNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *DropViewNode) Accept(visitor Visitor) error {
+	return visitor.VisitDropView(n)
+}
+
+// CreateMaterializedViewNode represents a CREATE MATERIALIZED VIEW statement.
+type CreateMaterializedViewNode struct {
+	Name            string
+	Body            string
+	RefreshStrategy string
+	Comment         string
+}
+
+func NewCreateMaterializedView(name string) *CreateMaterializedViewNode {
+	return &CreateMaterializedViewNode{Name: name, RefreshStrategy: "manual"}
+}
+
+func (n *CreateMaterializedViewNode) SetBody(body string) *CreateMaterializedViewNode {
+	n.Body = body
+	return n
+}
+
+func (n *CreateMaterializedViewNode) SetRefreshStrategy(refreshStrategy string) *CreateMaterializedViewNode {
+	n.RefreshStrategy = refreshStrategy
+	return n
+}
+
+func (n *CreateMaterializedViewNode) SetComment(comment string) *CreateMaterializedViewNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *CreateMaterializedViewNode) Accept(visitor Visitor) error {
+	return visitor.VisitCreateMaterializedView(n)
+}
+
+// DropMaterializedViewNode represents a DROP MATERIALIZED VIEW statement.
+type DropMaterializedViewNode struct {
+	Name     string
+	IfExists bool
+	Cascade  bool
+	Comment  string
+}
+
+func NewDropMaterializedView(name string) *DropMaterializedViewNode {
+	return &DropMaterializedViewNode{Name: name}
+}
+
+func (n *DropMaterializedViewNode) SetIfExists() *DropMaterializedViewNode {
+	n.IfExists = true
+	return n
+}
+
+func (n *DropMaterializedViewNode) SetCascade() *DropMaterializedViewNode {
+	n.Cascade = true
+	return n
+}
+
+func (n *DropMaterializedViewNode) SetComment(comment string) *DropMaterializedViewNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *DropMaterializedViewNode) Accept(visitor Visitor) error {
+	return visitor.VisitDropMaterializedView(n)
+}
+
+// RefreshMaterializedViewNode represents a REFRESH MATERIALIZED VIEW statement.
+type RefreshMaterializedViewNode struct {
+	Name         string
+	Concurrently bool
+	Comment      string
+}
+
+func NewRefreshMaterializedView(name string) *RefreshMaterializedViewNode {
+	return &RefreshMaterializedViewNode{Name: name}
+}
+
+func (n *RefreshMaterializedViewNode) SetConcurrently() *RefreshMaterializedViewNode {
+	n.Concurrently = true
+	return n
+}
+
+func (n *RefreshMaterializedViewNode) SetComment(comment string) *RefreshMaterializedViewNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *RefreshMaterializedViewNode) Accept(visitor Visitor) error {
+	return visitor.VisitRefreshMaterializedView(n)
+}
+
+// CreateTriggerNode represents a CREATE TRIGGER statement.
+type CreateTriggerNode struct {
+	Name         string
+	Table        string
+	Timing       string
+	Event        string
+	ForEach      string
+	Body         string
+	FunctionName string
+	Replace      bool
+	Comment      string
+}
+
+func NewCreateTrigger(name, table string) *CreateTriggerNode {
+	return &CreateTriggerNode{Name: name, Table: table, ForEach: "ROW"}
+}
+
+func (n *CreateTriggerNode) SetTiming(timing string) *CreateTriggerNode {
+	n.Timing = timing
+	return n
+}
+
+func (n *CreateTriggerNode) SetEvent(event string) *CreateTriggerNode {
+	n.Event = event
+	return n
+}
+
+func (n *CreateTriggerNode) SetForEach(forEach string) *CreateTriggerNode {
+	n.ForEach = forEach
+	return n
+}
+
+func (n *CreateTriggerNode) SetBody(body string) *CreateTriggerNode {
+	n.Body = body
+	return n
+}
+
+func (n *CreateTriggerNode) SetFunctionName(functionName string) *CreateTriggerNode {
+	n.FunctionName = functionName
+	return n
+}
+
+func (n *CreateTriggerNode) SetReplace() *CreateTriggerNode {
+	n.Replace = true
+	return n
+}
+
+func (n *CreateTriggerNode) SetComment(comment string) *CreateTriggerNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *CreateTriggerNode) Accept(visitor Visitor) error {
+	return visitor.VisitCreateTrigger(n)
+}
+
+// DropTriggerNode represents a DROP TRIGGER statement.
+type DropTriggerNode struct {
+	Name         string
+	Table        string
+	FunctionName string
+	IfExists     bool
+	Cascade      bool
+	Comment      string
+}
+
+func NewDropTrigger(name, table string) *DropTriggerNode {
+	return &DropTriggerNode{Name: name, Table: table}
+}
+
+func (n *DropTriggerNode) SetIfExists() *DropTriggerNode {
+	n.IfExists = true
+	return n
+}
+
+func (n *DropTriggerNode) SetCascade() *DropTriggerNode {
+	n.Cascade = true
+	return n
+}
+
+func (n *DropTriggerNode) SetFunctionName(functionName string) *DropTriggerNode {
+	n.FunctionName = functionName
+	return n
+}
+
+func (n *DropTriggerNode) SetComment(comment string) *DropTriggerNode {
+	n.Comment = comment
+	return n
+}
+
+func (n *DropTriggerNode) Accept(visitor Visitor) error {
+	return visitor.VisitDropTrigger(n)
+}
+
 // CreateFunctionNode represents a CREATE FUNCTION statement for PostgreSQL custom functions.
 //
 // This node contains the complete definition of a PostgreSQL function including

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -11,16 +11,19 @@ import (
 // This is needed for down migrations where we use the current DB state as the target
 func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Database {
 	database := &goschema.Database{
-		Tables:           make([]goschema.Table, 0),
-		Fields:           make([]goschema.Field, 0),
-		Indexes:          make([]goschema.Index, 0),
-		Enums:            make([]goschema.Enum, 0),
-		Extensions:       make([]goschema.Extension, 0),
-		Functions:        make([]goschema.Function, 0),
-		RLSPolicies:      make([]goschema.RLSPolicy, 0),
-		RLSEnabledTables: make([]goschema.RLSEnabledTable, 0),
-		Roles:            make([]goschema.Role, 0),
-		Dependencies:     make(map[string][]string),
+		Tables:            make([]goschema.Table, 0),
+		Fields:            make([]goschema.Field, 0),
+		Indexes:           make([]goschema.Index, 0),
+		Enums:             make([]goschema.Enum, 0),
+		Extensions:        make([]goschema.Extension, 0),
+		Functions:         make([]goschema.Function, 0),
+		Views:             make([]goschema.View, 0),
+		MaterializedViews: make([]goschema.MaterializedView, 0),
+		Triggers:          make([]goschema.Trigger, 0),
+		RLSPolicies:       make([]goschema.RLSPolicy, 0),
+		RLSEnabledTables:  make([]goschema.RLSEnabledTable, 0),
+		Roles:             make([]goschema.Role, 0),
+		Dependencies:      make(map[string][]string),
 	}
 
 	// Convert enums
@@ -145,6 +148,40 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 			Comment:    dbFunction.Comment,
 		}
 		database.Functions = append(database.Functions, function)
+	}
+
+	for _, dbView := range dbSchema.Views {
+		database.Views = append(database.Views, goschema.View{
+			Name:      dbView.QualifiedName(),
+			Body:      dbView.Body,
+			WithCheck: strings.EqualFold(dbView.CheckOption, "LOCAL") || strings.EqualFold(dbView.CheckOption, "CASCADED"),
+			Comment:   dbView.Comment,
+		})
+	}
+
+	for _, dbView := range dbSchema.MatViews {
+		materializedView := goschema.MaterializedView{
+			Name:            dbView.QualifiedName(),
+			Body:            dbView.Body,
+			RefreshStrategy: dbView.RefreshStrategy,
+			Comment:         dbView.Comment,
+		}
+		materializedView.Canonicalize()
+		database.MaterializedViews = append(database.MaterializedViews, materializedView)
+	}
+
+	for _, dbTrigger := range dbSchema.Triggers {
+		trigger := goschema.Trigger{
+			Name:    dbTrigger.Name,
+			Table:   dbTrigger.QualifiedTable(),
+			Timing:  dbTrigger.Timing,
+			Event:   dbTrigger.Event,
+			ForEach: dbTrigger.ForEach,
+			Body:    dbTrigger.Body,
+			Comment: dbTrigger.Comment,
+		}
+		trigger.Canonicalize()
+		database.Triggers = append(database.Triggers, trigger)
 	}
 
 	// Convert roles

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -818,6 +818,39 @@ func FromFunction(function goschema.Function) *ast.CreateFunctionNode {
 	return functionNode
 }
 
+// FromView converts a goschema.View to an ast.CreateViewNode.
+func FromView(view goschema.View) *ast.CreateViewNode {
+	viewNode := ast.NewCreateView(view.Name).
+		SetBody(view.Body).
+		SetWithCheck(view.WithCheck).
+		SetComment(view.Comment)
+	return viewNode
+}
+
+// FromMaterializedView converts a goschema.MaterializedView to an
+// ast.CreateMaterializedViewNode.
+func FromMaterializedView(view goschema.MaterializedView) *ast.CreateMaterializedViewNode {
+	view.Canonicalize()
+	viewNode := ast.NewCreateMaterializedView(view.Name).
+		SetBody(view.Body).
+		SetRefreshStrategy(view.RefreshStrategy).
+		SetComment(view.Comment)
+	return viewNode
+}
+
+// FromTrigger converts a goschema.Trigger to an ast.CreateTriggerNode.
+func FromTrigger(trigger goschema.Trigger) *ast.CreateTriggerNode {
+	trigger.Canonicalize()
+	triggerNode := ast.NewCreateTrigger(trigger.Name, trigger.Table).
+		SetTiming(trigger.Timing).
+		SetEvent(trigger.Event).
+		SetForEach(trigger.ForEach).
+		SetBody(trigger.Body).
+		SetFunctionName(trigger.FunctionName()).
+		SetComment(trigger.Comment)
+	return triggerNode
+}
+
 // FromRLSPolicy converts a goschema.RLSPolicy to an ast.CreatePolicyNode.
 //
 // This function creates a PostgreSQL RLS policy definition from the parsed policy metadata.
@@ -1000,6 +1033,16 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 			statements.Statements = append(statements.Statements, functionNode)
 		}
 
+		for _, view := range database.Views {
+			viewNode := FromView(view)
+			statements.Statements = append(statements.Statements, viewNode)
+		}
+
+		for _, view := range database.MaterializedViews {
+			viewNode := FromMaterializedView(view)
+			statements.Statements = append(statements.Statements, viewNode)
+		}
+
 		// Add RLS enablement statements (must come before policies)
 		for _, rlsEnabled := range database.RLSEnabledTables {
 			rlsNode := FromRLSEnabledTable(rlsEnabled)
@@ -1010,6 +1053,22 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		for _, rlsPolicy := range database.RLSPolicies {
 			policyNode := FromRLSPolicy(rlsPolicy)
 			statements.Statements = append(statements.Statements, policyNode)
+		}
+
+		for _, trigger := range database.Triggers {
+			triggerNode := FromTrigger(trigger)
+			statements.Statements = append(statements.Statements, triggerNode)
+		}
+	}
+
+	if !isPostgreSQL && (strings.EqualFold(targetPlatform, "mysql") || strings.EqualFold(targetPlatform, "mariadb")) {
+		for _, view := range database.Views {
+			viewNode := FromView(view)
+			statements.Statements = append(statements.Statements, viewNode)
+		}
+		for _, trigger := range database.Triggers {
+			triggerNode := FromTrigger(trigger)
+			statements.Statements = append(statements.Statements, triggerNode)
 		}
 	}
 

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -785,6 +785,35 @@ func TestFromDatabase_EmptySchema(t *testing.T) {
 	c.Assert(result.Statements, qt.HasLen, 0)
 }
 
+func TestFromDatabase_MySQLIncludesViewsAndTriggers(t *testing.T) {
+	c := qt.New(t)
+
+	database := goschema.Database{
+		Views: []goschema.View{{
+			Name: "active_users",
+			Body: "SELECT id FROM users WHERE deleted_at IS NULL",
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:   "set_updated_at",
+			Table:  "users",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "SET NEW.updated_at = NOW()",
+		}},
+	}
+
+	result := fromschema.FromDatabase(database, "mysql")
+
+	c.Assert(result.Statements, qt.HasLen, 2)
+	viewNode, ok := result.Statements[0].(*ast.CreateViewNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(viewNode.Name, qt.Equals, "active_users")
+	triggerNode, ok := result.Statements[1].(*ast.CreateTriggerNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(triggerNode.Name, qt.Equals, "set_updated_at")
+	c.Assert(triggerNode.Table, qt.Equals, "users")
+}
+
 func TestFromField_PlatformOverrides(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -64,6 +64,30 @@ var knownFieldAttributes = map[string]bool{
 	"comment":          true,
 }
 
+var knownViewAttributes = map[string]bool{
+	"name":       true,
+	"body":       true,
+	"with_check": true,
+	"comment":    true,
+}
+
+var knownMaterializedViewAttributes = map[string]bool{
+	"name":             true,
+	"body":             true,
+	"refresh_strategy": true,
+	"comment":          true,
+}
+
+var knownTriggerAttributes = map[string]bool{
+	"name":    true,
+	"table":   true,
+	"timing":  true,
+	"event":   true,
+	"for":     true,
+	"body":    true,
+	"comment": true,
+}
+
 // validateAttributes panics if kv contains any key the directive does not
 // recognize. Platform-specific overrides (platform.*) are always allowed.
 // This catches typos like default_fn-vs-default_expr at parse time instead of
@@ -79,6 +103,20 @@ func validateAttributes(kv map[string]string, known map[string]bool, directive, 
 			"location", location,
 		)
 		panic(fmt.Sprintf("unknown annotation attribute %q on %s at %s", k, directive, location))
+	}
+}
+
+func requireAttributes(kv map[string]string, required []string, directive, location string) {
+	for _, key := range required {
+		if strings.TrimSpace(kv[key]) != "" {
+			continue
+		}
+		slog.Error("missing required annotation attribute",
+			"directive", directive,
+			"attribute", key,
+			"location", location,
+		)
+		panic(fmt.Sprintf("missing required annotation attribute %q on %s at %s", key, directive, location))
 	}
 }
 
@@ -303,6 +341,9 @@ func parseComment(
 	schemaConstraints *[]Constraint,
 	extensions *[]Extension,
 	functions *[]Function,
+	views *[]View,
+	materializedViews *[]MaterializedView,
+	triggers *[]Trigger,
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
@@ -320,6 +361,12 @@ func parseComment(
 		parseExtensionComment(comment, extensions)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
 		parseFunctionComment(comment, structName, functions)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
+		parseViewComment(comment, structName, views)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
+		parseMaterializedViewComment(comment, structName, materializedViews)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
+		parseTriggerComment(comment, structName, triggers)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
 		parseRLSPolicyComment(comment, structName, rlsPolicies)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
@@ -336,6 +383,9 @@ func processTableComments(
 	schemaConstraints *[]Constraint,
 	extensions *[]Extension,
 	functions *[]Function,
+	views *[]View,
+	materializedViews *[]MaterializedView,
+	triggers *[]Trigger,
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
@@ -354,6 +404,12 @@ func processTableComments(
 			parseExtensionComment(comment, extensions)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
 			parseFunctionComment(comment, structName, functions)
+		case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
+			parseViewComment(comment, structName, views)
+		case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
+			parseMaterializedViewComment(comment, structName, materializedViews)
+		case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
+			parseTriggerComment(comment, structName, triggers)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
 			parseRLSPolicyComment(comment, structName, rlsPolicies)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
@@ -374,6 +430,9 @@ func processFieldComments(
 	schemaConstraints *[]Constraint,
 	extensions *[]Extension,
 	functions *[]Function,
+	views *[]View,
+	materializedViews *[]MaterializedView,
+	triggers *[]Trigger,
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
@@ -383,7 +442,7 @@ func processFieldComments(
 			continue
 		}
 		for _, comment := range field.Doc.List {
-			parseComment(comment, structName, field, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, rlsPolicies, rlsEnabledTables, roles)
+			parseComment(comment, structName, field, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
 		}
 	}
 }
@@ -420,6 +479,9 @@ func parseFileAST(f *ast.File) Database {
 	var tableDirectives []Table
 	var extensions []Extension
 	var functions []Function
+	var views []View
+	var materializedViews []MaterializedView
+	var triggers []Trigger
 	var rlsPolicies []RLSPolicy
 	var rlsEnabledTables []RLSEnabledTable
 	var roles []Role
@@ -438,6 +500,9 @@ func parseFileAST(f *ast.File) Database {
 		&tableDirectives,
 		&extensions,
 		&functions,
+		&views,
+		&materializedViews,
+		&triggers,
 		&rlsPolicies,
 		&rlsEnabledTables,
 		&roles,
@@ -459,18 +524,21 @@ func parseFileAST(f *ast.File) Database {
 	})
 
 	result := Database{
-		Tables:           tableDirectives,
-		Fields:           schemaFields,
-		Indexes:          schemaIndexes,
-		Constraints:      schemaConstraints,
-		Enums:            enums,
-		EmbeddedFields:   embeddedFields,
-		Extensions:       extensions,
-		Functions:        functions,
-		RLSPolicies:      rlsPolicies,
-		RLSEnabledTables: rlsEnabledTables,
-		Roles:            roles,
-		Dependencies:     make(map[string][]string),
+		Tables:            tableDirectives,
+		Fields:            schemaFields,
+		Indexes:           schemaIndexes,
+		Constraints:       schemaConstraints,
+		Enums:             enums,
+		EmbeddedFields:    embeddedFields,
+		Extensions:        extensions,
+		Functions:         functions,
+		Views:             views,
+		MaterializedViews: materializedViews,
+		Triggers:          triggers,
+		RLSPolicies:       rlsPolicies,
+		RLSEnabledTables:  rlsEnabledTables,
+		Roles:             roles,
+		Dependencies:      make(map[string][]string),
 	}
 	normalizeTableScopedNames(&result)
 	buildDependencyGraph(&result)
@@ -489,6 +557,9 @@ func processFileAST(
 	tableDirectives *[]Table,
 	extensions *[]Extension,
 	functions *[]Function,
+	views *[]View,
+	materializedViews *[]MaterializedView,
+	triggers *[]Trigger,
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
@@ -526,6 +597,9 @@ func processFileAST(
 		tableDirectives,
 		extensions,
 		functions,
+		views,
+		materializedViews,
+		triggers,
 		rlsPolicies,
 		rlsEnabledTables,
 		roles,
@@ -567,6 +641,9 @@ func processDeclarations(
 	tableDirectives *[]Table,
 	extensions *[]Extension,
 	functions *[]Function,
+	views *[]View,
+	materializedViews *[]MaterializedView,
+	triggers *[]Trigger,
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
@@ -587,8 +664,8 @@ func processDeclarations(
 				continue
 			}
 
-			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, rlsPolicies, rlsEnabledTables, roles)
-			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, rlsPolicies, rlsEnabledTables, roles)
+			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
+			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
 		}
 	}
 }
@@ -687,6 +764,56 @@ func parseFunctionComment(comment *ast.Comment, structName string, functions *[]
 	// typed. See Function.Canonicalize for the per-field rules.
 	fn.Canonicalize()
 	*functions = append(*functions, fn)
+}
+
+func parseViewComment(comment *ast.Comment, structName string, views *[]View) {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	validateAttributes(kv, knownViewAttributes, "//migrator:schema:view", structName)
+	requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:view", structName)
+	*views = append(*views, View{
+		StructName: structName,
+		Name:       kv["name"],
+		Body:       kv["body"],
+		WithCheck:  kv["with_check"] == "true",
+		Comment:    kv["comment"],
+	})
+}
+
+func parseMaterializedViewComment(comment *ast.Comment, structName string, materializedViews *[]MaterializedView) {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	validateAttributes(kv, knownMaterializedViewAttributes, "//migrator:schema:matview", structName)
+	requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:matview", structName)
+	refreshStrategy := kv["refresh_strategy"]
+	if refreshStrategy == "" {
+		refreshStrategy = "manual"
+	}
+	matView := MaterializedView{
+		StructName:      structName,
+		Name:            kv["name"],
+		Body:            kv["body"],
+		RefreshStrategy: strings.ToLower(refreshStrategy),
+		Comment:         kv["comment"],
+	}
+	matView.Canonicalize()
+	*materializedViews = append(*materializedViews, matView)
+}
+
+func parseTriggerComment(comment *ast.Comment, structName string, triggers *[]Trigger) {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	validateAttributes(kv, knownTriggerAttributes, "//migrator:schema:trigger", structName)
+	requireAttributes(kv, []string{"name", "table", "timing", "event", "body"}, "//migrator:schema:trigger", structName)
+	trigger := Trigger{
+		StructName: structName,
+		Name:       kv["name"],
+		Table:      kv["table"],
+		Timing:     kv["timing"],
+		Event:      kv["event"],
+		ForEach:    kv["for"],
+		Body:       kv["body"],
+		Comment:    kv["comment"],
+	}
+	trigger.Canonicalize()
+	*triggers = append(*triggers, trigger)
 }
 
 func parseRLSPolicyComment(comment *ast.Comment, structName string, rlsPolicies *[]RLSPolicy) {

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -122,6 +122,85 @@ func TestParseKeyValueComment_SimplifiedSyntax(t *testing.T) {
 	}
 }
 
+func TestParseSchemaObjectAnnotations(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.ParseSource("schema_objects.go", `
+package test
+
+//migrator:schema:view name="active_users" body="SELECT id FROM users WHERE deleted_at IS NULL" with_check="true" comment="Active users"
+//migrator:schema:matview name="user_stats" body="SELECT id, COUNT(*) FROM users GROUP BY id"
+//migrator:schema:trigger name="set_updated_at" table="users" timing="before" event="update" body="NEW.updated_at = NOW(); RETURN NEW;"
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`)
+
+	c.Assert(db.Views, qt.HasLen, 1)
+	c.Assert(db.Views[0].Name, qt.Equals, "active_users")
+	c.Assert(db.Views[0].WithCheck, qt.IsTrue)
+	c.Assert(db.MaterializedViews, qt.HasLen, 1)
+	c.Assert(db.MaterializedViews[0].Name, qt.Equals, "user_stats")
+	c.Assert(db.MaterializedViews[0].RefreshStrategy, qt.Equals, "manual")
+	c.Assert(db.Triggers, qt.HasLen, 1)
+	c.Assert(db.Triggers[0].Name, qt.Equals, "set_updated_at")
+	c.Assert(db.Triggers[0].Table, qt.Equals, "users")
+	c.Assert(db.Triggers[0].Timing, qt.Equals, "BEFORE")
+	c.Assert(db.Triggers[0].Event, qt.Equals, "UPDATE")
+	c.Assert(db.Triggers[0].ForEach, qt.Equals, "ROW")
+}
+
+func TestParseSchemaObjectAnnotations_RejectsInvalidAttributes(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		annotation string
+		want       string
+	}{
+		{
+			name:       "unknown view attribute",
+			annotation: `//migrator:schema:view name="active_users" body="SELECT id FROM users" boddy="typo"`,
+			want:       "boddy",
+		},
+		{
+			name:       "missing materialized view body",
+			annotation: `//migrator:schema:matview name="user_stats"`,
+			want:       `missing required annotation attribute "body"`,
+		},
+		{
+			name:       "missing trigger table",
+			annotation: `//migrator:schema:trigger name="set_updated_at" timing="before" event="update" body="RETURN NEW;"`,
+			want:       `missing required annotation attribute "table"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c.Assert(func() {
+				goschema.ParseSource("schema_object_invalid.go", `
+package test
+`+tt.annotation+`
+type User struct{}
+`)
+			}, qt.PanicMatches, ".*"+tt.want+".*")
+		})
+	}
+}
+
+func TestTrigger_FunctionNameIsTableScoped(t *testing.T) {
+	c := qt.New(t)
+
+	userTrigger := goschema.Trigger{Name: "set_updated_at", Table: "public.users"}
+	postTrigger := goschema.Trigger{Name: "set_updated_at", Table: "public.posts"}
+
+	c.Assert(userTrigger.FunctionName(), qt.Equals, "ptah_trigger_public_users_set_updated_at")
+	c.Assert(postTrigger.FunctionName(), qt.Equals, "ptah_trigger_public_posts_set_updated_at")
+	c.Assert(userTrigger.FunctionName(), qt.Not(qt.Equals), postTrigger.FunctionName())
+}
+
 func TestParseKeyValueComment_BooleanPatterns(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -3,7 +3,11 @@
 // Go struct annotations and used for generating database-specific migration SQL.
 package goschema
 
-import "strings"
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
 
 // Database represents the complete database schema derived from Go struct annotations.
 //
@@ -32,6 +36,9 @@ type Database struct {
 	EmbeddedFields             []EmbeddedField
 	Extensions                 []Extension                    // PostgreSQL extensions (pg_trgm, postgis, etc.)
 	Functions                  []Function                     // PostgreSQL custom functions
+	Views                      []View                         // Database views
+	MaterializedViews          []MaterializedView             // Database materialized views
+	Triggers                   []Trigger                      // Database triggers
 	RLSPolicies                []RLSPolicy                    // PostgreSQL Row-Level Security policies
 	RLSEnabledTables           []RLSEnabledTable              // Tables with RLS enabled
 	Roles                      []Role                         // PostgreSQL roles
@@ -423,6 +430,125 @@ type Function struct {
 	Volatility string // Function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
 	Body       string // Function body/implementation
 	Comment    string // Optional comment for documentation
+}
+
+// View represents a database view definition parsed from Go annotations.
+//
+// View is created by parsing //migrator:schema:view annotations:
+//
+//	//migrator:schema:view name="active_users" body="SELECT * FROM users WHERE deleted_at IS NULL" with_check="false"
+//	type User struct{}
+type View struct {
+	StructName string // Name of the Go struct this view is associated with
+	Name       string // View name
+	Body       string // SELECT query used as the view body
+	WithCheck  bool   // Whether to add WITH CHECK OPTION where supported
+	Comment    string // Optional comment for documentation
+}
+
+// MaterializedView represents a database materialized view definition parsed
+// from Go annotations.
+//
+// MaterializedView is created by parsing //migrator:schema:matview annotations:
+//
+//	//migrator:schema:matview name="user_stats" body="SELECT user_id, COUNT(*) FROM users GROUP BY user_id" refresh_strategy="manual"
+//	type UserStats struct{}
+type MaterializedView struct {
+	StructName      string // Name of the Go struct this materialized view is associated with
+	Name            string // Materialized view name
+	Body            string // SELECT query used as the materialized view body
+	RefreshStrategy string // manual, concurrently, or future scheduled variants
+	Comment         string // Optional comment for documentation
+}
+
+// Canonicalize fills in materialized-view defaults used by the planner and
+// comparator.
+func (v *MaterializedView) Canonicalize() {
+	v.RefreshStrategy = strings.ToLower(strings.TrimSpace(v.RefreshStrategy))
+	if v.RefreshStrategy == "" {
+		v.RefreshStrategy = "manual"
+	}
+}
+
+// Trigger represents a database trigger definition parsed from Go annotations.
+//
+// Trigger is created by parsing //migrator:schema:trigger annotations:
+//
+//	//migrator:schema:trigger name="set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;"
+//	type User struct{}
+type Trigger struct {
+	StructName string // Name of the Go struct this trigger is associated with
+	Name       string // Trigger name
+	Table      string // Target table
+	Timing     string // BEFORE, AFTER, or INSTEAD OF
+	Event      string // INSERT, UPDATE, DELETE, or TRUNCATE
+	ForEach    string // ROW or STATEMENT
+	Body       string // Trigger body
+	Comment    string // Optional comment for documentation
+}
+
+// Canonicalize fills in trigger defaults and case-folds attributes reported in
+// canonical uppercase by database catalogs.
+func (t *Trigger) Canonicalize() {
+	t.Timing = strings.ToUpper(strings.TrimSpace(t.Timing))
+	t.Event = strings.ToUpper(strings.TrimSpace(t.Event))
+	t.ForEach = strings.ToUpper(strings.TrimSpace(t.ForEach))
+	if t.ForEach == "" {
+		t.ForEach = "ROW"
+	}
+}
+
+// FunctionName returns the deterministic PostgreSQL trigger function name used
+// for this trigger. PostgreSQL stores executable trigger code in a function, so
+// Ptah manages that linked function as part of the trigger definition.
+func (t Trigger) FunctionName() string {
+	name := "ptah_trigger_" + sanitizeTriggerFunctionPart(t.Table) + "_" + sanitizeTriggerFunctionPart(t.Name)
+	if len(name) <= maxPostgreSQLIdentifierLength {
+		return name
+	}
+
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(t.Table))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(t.Name))
+	suffix := fmt.Sprintf("_%08x", hash.Sum32())
+	return name[:maxPostgreSQLIdentifierLength-len(suffix)] + suffix
+}
+
+const maxPostgreSQLIdentifierLength = 63
+
+func sanitizeTriggerFunctionPart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	builder.Grow(len(value))
+	lastUnderscore := false
+	for i := range len(value) {
+		character := value[i]
+		if isIdentifierPart(character) {
+			builder.WriteByte(character)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+
+	result := strings.Trim(builder.String(), "_")
+	if result == "" {
+		return "object"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		return "_" + result
+	}
+	return result
+}
+
+func isIdentifierPart(character byte) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= '0' && character <= '9' ||
+		character == '_'
 }
 
 // Canonicalize fills in PostgreSQL's implicit defaults and case-folds the

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -230,6 +230,12 @@ func normalizeTableScopedNames(r *Database) {
 			rlsEnabled.Table = table.QualifiedName()
 		}
 	}
+	for i := range r.Triggers {
+		trigger := &r.Triggers[i]
+		if table := resolveTableReference(r.Tables, trigger.StructName, trigger.Table); table != nil {
+			trigger.Table = table.QualifiedName()
+		}
+	}
 }
 
 func resolveTableReference(tables []Table, structName, tableName string) *Table {
@@ -791,6 +797,8 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 //   - Indexes: Deduplicated by struct name + index name combination
 //   - Enums: Deduplicated by enum name
 //   - Embedded Fields: Deduplicated by struct name + embedded type name combination
+//   - Views and materialized views: Deduplicated by name
+//   - Triggers: Deduplicated by table name + trigger name combination
 //
 // This method modifies the PackageParseResult in-place, replacing the original
 // slices with deduplicated versions. The order of entities may change during
@@ -884,6 +892,8 @@ func Deduplicate(r *Database) {
 	}
 	r.Functions = deduplicatedFunctions
 
+	deduplicateSchemaObjects(r)
+
 	// Deduplicate RLS policies by name - preserve order
 	rlsPolicySeen := make(map[string]bool)
 	var deduplicatedRLSPolicies []RLSPolicy
@@ -905,4 +915,49 @@ func Deduplicate(r *Database) {
 		}
 	}
 	r.RLSEnabledTables = deduplicatedRLSEnabled
+}
+
+func deduplicateSchemaObjects(r *Database) {
+	r.Views = deduplicateViews(r.Views)
+	r.MaterializedViews = deduplicateMaterializedViews(r.MaterializedViews)
+	r.Triggers = deduplicateTriggers(r.Triggers)
+}
+
+func deduplicateViews(views []View) []View {
+	seen := make(map[string]bool)
+	deduplicated := make([]View, 0, len(views))
+	for _, view := range views {
+		if !seen[view.Name] {
+			seen[view.Name] = true
+			deduplicated = append(deduplicated, view)
+		}
+	}
+	return deduplicated
+}
+
+func deduplicateMaterializedViews(views []MaterializedView) []MaterializedView {
+	seen := make(map[string]bool)
+	deduplicated := make([]MaterializedView, 0, len(views))
+	for _, view := range views {
+		view.Canonicalize()
+		if !seen[view.Name] {
+			seen[view.Name] = true
+			deduplicated = append(deduplicated, view)
+		}
+	}
+	return deduplicated
+}
+
+func deduplicateTriggers(triggers []Trigger) []Trigger {
+	seen := make(map[string]bool)
+	deduplicated := make([]Trigger, 0, len(triggers))
+	for _, trigger := range triggers {
+		trigger.Canonicalize()
+		key := trigger.Table + "." + trigger.Name
+		if !seen[key] {
+			seen[key] = true
+			deduplicated = append(deduplicated, trigger)
+		}
+	}
+	return deduplicated
 }

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -108,8 +108,8 @@ const (
 
 	// CreateOrReplaceTrigger marks support for CREATE OR REPLACE TRIGGER
 	// (PostgreSQL 14+, MariaDB 10.1.4+; MySQL has no OR REPLACE for
-	// triggers). No in-tree consumer yet — reserved for the trigger work in
-	// issue #158; version presets already gate it.
+	// triggers). Trigger renderers use this to choose between
+	// CREATE OR REPLACE TRIGGER and an explicit drop/create sequence.
 	CreateOrReplaceTrigger Capability = "create_or_replace_trigger"
 
 	// RowLevelSecurity marks support for row-level security policies

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -805,6 +805,41 @@ func (r *Renderer) VisitDropFunction(node *ast.DropFunctionNode) error {
 	return nil
 }
 
+func (r *Renderer) VisitCreateView(node *ast.CreateViewNode) error {
+	r.notSupported("CREATE VIEW", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitDropView(node *ast.DropViewNode) error {
+	r.notSupported("DROP VIEW", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	r.notSupported("CREATE MATERIALIZED VIEW", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	r.notSupported("DROP MATERIALIZED VIEW", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	r.notSupported("REFRESH MATERIALIZED VIEW", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	r.notSupported("CREATE TRIGGER", node.Name)
+	return nil
+}
+
+func (r *Renderer) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	r.notSupported("DROP TRIGGER", node.Name)
+	return nil
+}
+
 // VisitCreatePolicy is a no-op for ClickHouse. ClickHouse has row policies
 // but with a different syntax that the PG-shaped node cannot describe.
 func (r *Renderer) VisitCreatePolicy(node *ast.CreatePolicyNode) error {

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -175,6 +175,34 @@ func (r *Renderer) VisitDropFunction(node *ast.DropFunctionNode) error {
 	return r.r.VisitDropFunction(node)
 }
 
+func (r *Renderer) VisitCreateView(node *ast.CreateViewNode) error {
+	return r.r.VisitCreateView(node)
+}
+
+func (r *Renderer) VisitDropView(node *ast.DropViewNode) error {
+	return r.r.VisitDropView(node)
+}
+
+func (r *Renderer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	return r.r.VisitCreateMaterializedView(node)
+}
+
+func (r *Renderer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	return r.r.VisitDropMaterializedView(node)
+}
+
+func (r *Renderer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	return r.r.VisitRefreshMaterializedView(node)
+}
+
+func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	return r.r.VisitCreateTrigger(node)
+}
+
+func (r *Renderer) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	return r.r.VisitDropTrigger(node)
+}
+
 // VisitDropPolicy delegates to the mysqllike renderer
 func (r *Renderer) VisitDropPolicy(node *ast.DropPolicyNode) error {
 	return r.r.VisitDropPolicy(node)

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -175,6 +175,34 @@ func (r *Renderer) VisitDropFunction(node *ast.DropFunctionNode) error {
 	return r.r.VisitDropFunction(node)
 }
 
+func (r *Renderer) VisitCreateView(node *ast.CreateViewNode) error {
+	return r.r.VisitCreateView(node)
+}
+
+func (r *Renderer) VisitDropView(node *ast.DropViewNode) error {
+	return r.r.VisitDropView(node)
+}
+
+func (r *Renderer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	return r.r.VisitCreateMaterializedView(node)
+}
+
+func (r *Renderer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	return r.r.VisitDropMaterializedView(node)
+}
+
+func (r *Renderer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	return r.r.VisitRefreshMaterializedView(node)
+}
+
+func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	return r.r.VisitCreateTrigger(node)
+}
+
+func (r *Renderer) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	return r.r.VisitDropTrigger(node)
+}
+
 // VisitDropPolicy delegates to the mysqllike renderer
 func (r *Renderer) VisitDropPolicy(node *ast.DropPolicyNode) error {
 	return r.r.VisitDropPolicy(node)

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -1,0 +1,31 @@
+package mysql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+)
+
+func TestMySQLRenderer_ViewsAndTriggers(t *testing.T) {
+	c := qt.New(t)
+
+	sql := renderMySQL(t,
+		ast.NewCreateView("active_users").
+			SetReplace().
+			SetBody("SELECT id FROM users WHERE deleted_at IS NULL"),
+		ast.NewCreateTrigger("set_updated_at", "users").
+			SetTiming("BEFORE").
+			SetEvent("UPDATE").
+			SetBody("SET NEW.updated_at = NOW()").
+			SetReplace(),
+		ast.NewCreateMaterializedView("user_stats").
+			SetBody("SELECT id, COUNT(*) FROM users GROUP BY id"),
+	)
+
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users AS")
+	c.Assert(sql, qt.Contains, "DROP TRIGGER IF EXISTS set_updated_at;")
+	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW SET NEW.updated_at = NOW();")
+	c.Assert(sql, qt.Contains, "-- MYSQL does not support CREATE MATERIALIZED VIEW user_stats")
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -328,6 +328,96 @@ func (r *Renderer) VisitDropType(node *ast.DropTypeNode) error {
 	return nil
 }
 
+// VisitCreateView renders a CREATE VIEW statement for MySQL/MariaDB.
+func (r *Renderer) VisitCreateView(node *ast.CreateViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	create := "CREATE VIEW"
+	if node.Replace {
+		create = "CREATE OR REPLACE VIEW"
+	}
+	r.w.WriteLinef("%s %s AS", create, node.Name)
+	r.w.WriteLine(strings.TrimSpace(node.Body))
+	if node.WithCheck {
+		r.w.WriteLine("WITH CHECK OPTION")
+	}
+	r.w.WriteLine(";")
+	return nil
+}
+
+// VisitDropView renders a DROP VIEW statement for MySQL/MariaDB.
+func (r *Renderer) VisitDropView(node *ast.DropViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	parts := []string{"DROP VIEW"}
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+	parts = append(parts, node.Name)
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	return nil
+}
+
+// VisitCreateMaterializedView renders an explicit unsupported warning.
+func (r *Renderer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	r.w.WriteLinef("-- %s does not support CREATE MATERIALIZED VIEW %s", r.dialectUpper, node.Name)
+	return nil
+}
+
+// VisitDropMaterializedView renders an explicit unsupported warning.
+func (r *Renderer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	r.w.WriteLinef("-- %s does not support DROP MATERIALIZED VIEW %s", r.dialectUpper, node.Name)
+	return nil
+}
+
+// VisitRefreshMaterializedView renders an explicit unsupported warning.
+func (r *Renderer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	r.w.WriteLinef("-- %s does not support REFRESH MATERIALIZED VIEW %s", r.dialectUpper, node.Name)
+	return nil
+}
+
+// VisitCreateTrigger renders a CREATE TRIGGER statement for MySQL/MariaDB.
+func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	if node.Replace && !r.caps.Has(capability.CreateOrReplaceTrigger) {
+		r.w.WriteLinef("DROP TRIGGER IF EXISTS %s;", node.Name)
+	}
+	create := "CREATE TRIGGER"
+	if node.Replace && r.caps.Has(capability.CreateOrReplaceTrigger) {
+		create = "CREATE OR REPLACE TRIGGER"
+	}
+	r.w.WriteLinef("%s %s %s %s ON %s FOR EACH ROW %s;",
+		create, node.Name, node.Timing, node.Event, node.Table, strings.TrimSpace(node.Body))
+	return nil
+}
+
+// VisitDropTrigger renders a DROP TRIGGER statement for MySQL/MariaDB.
+func (r *Renderer) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	parts := []string{"DROP TRIGGER"}
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+	parts = append(parts, node.Name)
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	return nil
+}
+
 // RenderColumn renders a column definition
 func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	var parts []string

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"fmt"
+	"hash/fnv"
 	"slices"
 	"strings"
 
@@ -958,6 +959,207 @@ func (r *Renderer) VisitDropFunction(node *ast.DropFunctionNode) error {
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 
 	return nil
+}
+
+// VisitCreateView renders a CREATE VIEW statement.
+func (r *Renderer) VisitCreateView(node *ast.CreateViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	create := "CREATE VIEW"
+	if node.Replace {
+		create = "CREATE OR REPLACE VIEW"
+	}
+	r.w.WriteLinef("%s %s AS", create, node.Name)
+	r.w.WriteLine(strings.TrimSpace(node.Body))
+	if node.WithCheck {
+		r.w.WriteLine("WITH CHECK OPTION")
+	}
+	r.w.WriteLine(";")
+	return nil
+}
+
+// VisitDropView renders a DROP VIEW statement.
+func (r *Renderer) VisitDropView(node *ast.DropViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	parts := []string{"DROP VIEW"}
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+	parts = append(parts, node.Name)
+	if node.Cascade {
+		parts = append(parts, "CASCADE")
+	}
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	return nil
+}
+
+// VisitCreateMaterializedView renders a CREATE MATERIALIZED VIEW statement.
+func (r *Renderer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	r.w.WriteLinef("CREATE MATERIALIZED VIEW %s AS", node.Name)
+	r.w.WriteLine(strings.TrimSpace(node.Body))
+	r.w.WriteLine(";")
+	return nil
+}
+
+// VisitDropMaterializedView renders a DROP MATERIALIZED VIEW statement.
+func (r *Renderer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	parts := []string{"DROP MATERIALIZED VIEW"}
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+	parts = append(parts, node.Name)
+	if node.Cascade {
+		parts = append(parts, "CASCADE")
+	}
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	return nil
+}
+
+// VisitRefreshMaterializedView renders a REFRESH MATERIALIZED VIEW statement.
+func (r *Renderer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	parts := []string{"REFRESH MATERIALIZED VIEW"}
+	if node.Concurrently {
+		parts = append(parts, "CONCURRENTLY")
+	}
+	parts = append(parts, node.Name)
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	return nil
+}
+
+// VisitCreateTrigger renders PostgreSQL trigger creation plus its linked
+// trigger function.
+func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	functionName := node.FunctionName
+	if functionName == "" {
+		functionName = postgresTriggerFunctionName(node.Table, node.Name)
+	}
+
+	r.w.WriteLinef("CREATE OR REPLACE FUNCTION %s()", functionName)
+	r.w.WriteLine("RETURNS trigger AS $$")
+	r.w.WriteLine(renderPostgreSQLTriggerFunctionBody(node.Body))
+	r.w.WriteLine("$$ LANGUAGE plpgsql;")
+
+	if node.Replace && !r.capabilities().Has(capability.CreateOrReplaceTrigger) {
+		r.w.WriteLinef("DROP TRIGGER IF EXISTS %s ON %s;", node.Name, node.Table)
+	}
+
+	create := "CREATE TRIGGER"
+	if node.Replace && r.capabilities().Has(capability.CreateOrReplaceTrigger) {
+		create = "CREATE OR REPLACE TRIGGER"
+	}
+
+	forEach := node.ForEach
+	if forEach == "" {
+		forEach = "ROW"
+	}
+	r.w.WriteLinef("%s %s %s %s ON %s FOR EACH %s EXECUTE FUNCTION %s();",
+		create, node.Name, node.Timing, node.Event, node.Table, forEach, functionName)
+	return nil
+}
+
+func renderPostgreSQLTriggerFunctionBody(body string) string {
+	body = strings.TrimSpace(body)
+	upperBody := strings.ToUpper(body)
+	if strings.HasPrefix(upperBody, "BEGIN") {
+		return body
+	}
+	return "BEGIN\n" + body + "\nEND;"
+}
+
+// VisitDropTrigger renders a DROP TRIGGER statement and drops the linked Ptah
+// trigger function when its deterministic name is known.
+func (r *Renderer) VisitDropTrigger(node *ast.DropTriggerNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+
+	parts := []string{"DROP TRIGGER"}
+	if node.IfExists {
+		parts = append(parts, "IF EXISTS")
+	}
+	parts = append(parts, node.Name, "ON", node.Table)
+	if node.Cascade {
+		parts = append(parts, "CASCADE")
+	}
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+
+	functionName := node.FunctionName
+	if functionName == "" {
+		functionName = postgresTriggerFunctionName(node.Table, node.Name)
+	}
+	r.w.WriteLinef("DROP FUNCTION IF EXISTS %s();", functionName)
+	return nil
+}
+
+func postgresTriggerFunctionName(tableName, triggerName string) string {
+	name := "ptah_trigger_" + sanitizeTriggerFunctionPart(tableName) + "_" + sanitizeTriggerFunctionPart(triggerName)
+	if len(name) <= maxPostgreSQLIdentifierLength {
+		return name
+	}
+
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(tableName))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(triggerName))
+	suffix := fmt.Sprintf("_%08x", hash.Sum32())
+	return name[:maxPostgreSQLIdentifierLength-len(suffix)] + suffix
+}
+
+const maxPostgreSQLIdentifierLength = 63
+
+func sanitizeTriggerFunctionPart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	builder.Grow(len(value))
+	lastUnderscore := false
+	for i := range len(value) {
+		character := value[i]
+		if isIdentifierPart(character) {
+			builder.WriteByte(character)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+
+	result := strings.Trim(builder.String(), "_")
+	if result == "" {
+		return "object"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		return "_" + result
+	}
+	return result
+}
+
+func isIdentifierPart(character byte) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= '0' && character <= '9' ||
+		character == '_'
 }
 
 // VisitDropPolicy renders a DROP POLICY statement

--- a/core/renderer/dialects/postgres/schema_objects_test.go
+++ b/core/renderer/dialects/postgres/schema_objects_test.go
@@ -1,0 +1,67 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestPostgreSQLRenderer_ViewsMaterializedViewsAndTriggers(t *testing.T) {
+	c := qt.New(t)
+
+	sql, err := renderer.RenderSQL("postgres",
+		ast.NewCreateView("active_users").
+			SetReplace().
+			SetBody("SELECT id FROM users WHERE deleted_at IS NULL").
+			SetWithCheck(true),
+		ast.NewCreateMaterializedView("user_stats").
+			SetBody("SELECT id, COUNT(*) FROM users GROUP BY id"),
+		ast.NewCreateTrigger("set_updated_at", "users").
+			SetTiming("BEFORE").
+			SetEvent("UPDATE").
+			SetBody("NEW.updated_at = NOW(); RETURN NEW;").
+			SetFunctionName("ptah_trigger_set_updated_at").
+			SetReplace(),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users AS")
+	c.Assert(sql, qt.Contains, "WITH CHECK OPTION")
+	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW user_stats AS")
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE FUNCTION ptah_trigger_set_updated_at()")
+	c.Assert(sql, qt.Contains, "RETURNS trigger AS $$")
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION ptah_trigger_set_updated_at();")
+}
+
+func TestPostgreSQLRenderer_DropTriggerUsesConfiguredFunctionName(t *testing.T) {
+	c := qt.New(t)
+
+	sql, err := renderer.RenderSQL("postgres",
+		ast.NewDropTrigger("set_updated_at", "users").
+			SetIfExists().
+			SetFunctionName("ptah_trigger_custom_set_updated_at"),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "DROP TRIGGER IF EXISTS set_updated_at ON users;")
+	c.Assert(sql, qt.Contains, "DROP FUNCTION IF EXISTS ptah_trigger_custom_set_updated_at();")
+}
+
+func TestPostgreSQLRenderer_DefaultTriggerFunctionNameIsTableScoped(t *testing.T) {
+	c := qt.New(t)
+
+	sql, err := renderer.RenderSQL("postgres",
+		ast.NewCreateTrigger("set_updated_at", "public.users").
+			SetTiming("BEFORE").
+			SetEvent("UPDATE").
+			SetBody("NEW.updated_at = NOW(); RETURN NEW;"),
+		ast.NewDropTrigger("set_updated_at", "public.users").SetIfExists(),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE FUNCTION ptah_trigger_public_users_set_updated_at()")
+	c.Assert(sql, qt.Contains, "EXECUTE FUNCTION ptah_trigger_public_users_set_updated_at();")
+	c.Assert(sql, qt.Contains, "DROP FUNCTION IF EXISTS ptah_trigger_public_users_set_updated_at();")
+}

--- a/core/yamlschema/yamlschema.go
+++ b/core/yamlschema/yamlschema.go
@@ -39,29 +39,23 @@ func Parse(data []byte) (*goschema.Database, error) {
 		return nil, fmt.Errorf("parse YAML schema: %w", err)
 	}
 
-	if len(doc.Views) > 0 {
-		return nil, fmt.Errorf("yaml views are not supported by the current goschema IR")
-	}
-	if len(doc.Triggers) > 0 {
-		return nil, fmt.Errorf("yaml triggers are not supported by the current goschema IR")
-	}
-
 	return doc.toDatabase()
 }
 
 type document struct {
-	Tables           map[string]tableSpec      `yaml:"tables"`
-	Indexes          map[string]indexSpec      `yaml:"indexes"`
-	Constraints      map[string]constraintSpec `yaml:"constraints"`
-	Enums            map[string]enumSpec       `yaml:"enums"`
-	Extensions       map[string]extensionSpec  `yaml:"extensions"`
-	Functions        map[string]functionSpec   `yaml:"functions"`
-	RLSPolicies      map[string]rlsPolicySpec  `yaml:"rls_policies"`
-	RLSEnabledTables map[string]rlsEnableSpec  `yaml:"rls_enabled_tables"`
-	RLSEnabled       map[string]rlsEnableSpec  `yaml:"rls_enabled"`
-	Roles            map[string]roleSpec       `yaml:"roles"`
-	Views            map[string]any            `yaml:"views"`
-	Triggers         map[string]any            `yaml:"triggers"`
+	Tables            map[string]tableSpec      `yaml:"tables"`
+	Indexes           map[string]indexSpec      `yaml:"indexes"`
+	Constraints       map[string]constraintSpec `yaml:"constraints"`
+	Enums             map[string]enumSpec       `yaml:"enums"`
+	Extensions        map[string]extensionSpec  `yaml:"extensions"`
+	Functions         map[string]functionSpec   `yaml:"functions"`
+	RLSPolicies       map[string]rlsPolicySpec  `yaml:"rls_policies"`
+	RLSEnabledTables  map[string]rlsEnableSpec  `yaml:"rls_enabled_tables"`
+	RLSEnabled        map[string]rlsEnableSpec  `yaml:"rls_enabled"`
+	Roles             map[string]roleSpec       `yaml:"roles"`
+	Views             map[string]viewSpec       `yaml:"views"`
+	MaterializedViews map[string]matViewSpec    `yaml:"matviews"`
+	Triggers          map[string]triggerSpec    `yaml:"triggers"`
 }
 
 type tableSpec struct {
@@ -179,6 +173,33 @@ type functionSpec struct {
 	Comment    stringScalar `yaml:"comment"`
 }
 
+type viewSpec struct {
+	StructName stringScalar `yaml:"struct_name"`
+	Name       stringScalar `yaml:"name"`
+	Body       stringScalar `yaml:"body"`
+	WithCheck  bool         `yaml:"with_check"`
+	Comment    stringScalar `yaml:"comment"`
+}
+
+type matViewSpec struct {
+	StructName      stringScalar `yaml:"struct_name"`
+	Name            stringScalar `yaml:"name"`
+	Body            stringScalar `yaml:"body"`
+	RefreshStrategy stringScalar `yaml:"refresh_strategy"`
+	Comment         stringScalar `yaml:"comment"`
+}
+
+type triggerSpec struct {
+	StructName stringScalar `yaml:"struct_name"`
+	Name       stringScalar `yaml:"name"`
+	Table      stringScalar `yaml:"table"`
+	Timing     stringScalar `yaml:"timing"`
+	Event      stringScalar `yaml:"event"`
+	ForEach    stringScalar `yaml:"for"`
+	Body       stringScalar `yaml:"body"`
+	Comment    stringScalar `yaml:"comment"`
+}
+
 type rlsPolicySpec struct {
 	StructName          stringScalar `yaml:"struct_name"`
 	Name                stringScalar `yaml:"name"`
@@ -230,6 +251,15 @@ func (d document) toDatabase() (*goschema.Database, error) {
 	}
 	d.addExtensions(db)
 	d.addFunctions(db)
+	if err := d.addViews(db); err != nil {
+		return nil, err
+	}
+	if err := d.addMaterializedViews(db); err != nil {
+		return nil, err
+	}
+	if err := d.addTriggers(db); err != nil {
+		return nil, err
+	}
 	d.addRLS(db)
 	d.addRoles(db)
 
@@ -509,6 +539,73 @@ func (d document) addFunctions(db *goschema.Database) {
 		fn.Canonicalize()
 		db.Functions = append(db.Functions, fn)
 	}
+}
+
+func (d document) addViews(db *goschema.Database) error {
+	for _, key := range sortedKeys(d.Views) {
+		spec := d.Views[key]
+		if string(spec.Body) == "" {
+			return fmt.Errorf("view %q requires body", key)
+		}
+		db.Views = append(db.Views, goschema.View{
+			StructName: string(spec.StructName),
+			Name:       valueOrDefault(spec.Name, key),
+			Body:       string(spec.Body),
+			WithCheck:  spec.WithCheck,
+			Comment:    string(spec.Comment),
+		})
+	}
+	return nil
+}
+
+func (d document) addMaterializedViews(db *goschema.Database) error {
+	for _, key := range sortedKeys(d.MaterializedViews) {
+		spec := d.MaterializedViews[key]
+		if string(spec.Body) == "" {
+			return fmt.Errorf("materialized view %q requires body", key)
+		}
+		view := goschema.MaterializedView{
+			StructName:      string(spec.StructName),
+			Name:            valueOrDefault(spec.Name, key),
+			Body:            string(spec.Body),
+			RefreshStrategy: string(spec.RefreshStrategy),
+			Comment:         string(spec.Comment),
+		}
+		view.Canonicalize()
+		db.MaterializedViews = append(db.MaterializedViews, view)
+	}
+	return nil
+}
+
+func (d document) addTriggers(db *goschema.Database) error {
+	for _, key := range sortedKeys(d.Triggers) {
+		spec := d.Triggers[key]
+		if string(spec.Table) == "" {
+			return fmt.Errorf("trigger %q requires table", key)
+		}
+		if string(spec.Timing) == "" {
+			return fmt.Errorf("trigger %q requires timing", key)
+		}
+		if string(spec.Event) == "" {
+			return fmt.Errorf("trigger %q requires event", key)
+		}
+		if string(spec.Body) == "" {
+			return fmt.Errorf("trigger %q requires body", key)
+		}
+		trigger := goschema.Trigger{
+			StructName: string(spec.StructName),
+			Name:       valueOrDefault(spec.Name, key),
+			Table:      string(spec.Table),
+			Timing:     string(spec.Timing),
+			Event:      string(spec.Event),
+			ForEach:    string(spec.ForEach),
+			Body:       string(spec.Body),
+			Comment:    string(spec.Comment),
+		}
+		trigger.Canonicalize()
+		db.Triggers = append(db.Triggers, trigger)
+	}
+	return nil
 }
 
 func (d document) addRLS(db *goschema.Database) {

--- a/core/yamlschema/yamlschema_test.go
+++ b/core/yamlschema/yamlschema_test.go
@@ -220,20 +220,84 @@ tables:
 	c.Assert(err, qt.ErrorMatches, `parse YAML schema: multiple YAML documents are not supported`)
 }
 
-func TestParse_RejectsUnsupportedViewsAndTriggers(t *testing.T) {
+func TestParse_ViewsMaterializedViewsAndTriggers(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := yamlschema.Parse([]byte(`
+	db, err := yamlschema.Parse([]byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+views:
+  active_users:
+    body: SELECT id FROM users WHERE deleted_at IS NULL
+    with_check: true
+matviews:
+  user_stats:
+    body: SELECT id, COUNT(*) FROM users GROUP BY id
+    refresh_strategy: concurrently
+triggers:
+  set_updated_at:
+    table: users
+    timing: before
+    event: update
+    body: NEW.updated_at = NOW(); RETURN NEW;
+`))
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Views, qt.HasLen, 1)
+	c.Assert(db.Views[0].Name, qt.Equals, "active_users")
+	c.Assert(db.Views[0].WithCheck, qt.IsTrue)
+	c.Assert(db.MaterializedViews, qt.HasLen, 1)
+	c.Assert(db.MaterializedViews[0].RefreshStrategy, qt.Equals, "concurrently")
+	c.Assert(db.Triggers, qt.HasLen, 1)
+	c.Assert(db.Triggers[0].Table, qt.Equals, "users")
+	c.Assert(db.Triggers[0].Timing, qt.Equals, "BEFORE")
+	c.Assert(db.Triggers[0].Event, qt.Equals, "UPDATE")
+	c.Assert(db.Triggers[0].ForEach, qt.Equals, "ROW")
+}
+
+func TestParse_RejectsIncompleteSchemaObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "view missing body",
+			yaml: `
 views:
   active_users: {}
-`))
-	c.Assert(err, qt.ErrorMatches, `yaml views are not supported by the current goschema IR`)
-
-	_, err = yamlschema.Parse([]byte(`
+`,
+			want: `view "active_users" requires body`,
+		},
+		{
+			name: "materialized view missing body",
+			yaml: `
+matviews:
+  user_stats: {}
+`,
+			want: `materialized view "user_stats" requires body`,
+		},
+		{
+			name: "trigger missing table",
+			yaml: `
 triggers:
-  update_timestamp: {}
-`))
-	c.Assert(err, qt.ErrorMatches, `yaml triggers are not supported by the current goschema IR`)
+  set_updated_at:
+    timing: before
+    event: update
+    body: RETURN NEW;
+`,
+			want: `trigger "set_updated_at" requires table`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := yamlschema.Parse([]byte(tt.yaml))
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
 }
 
 func TestParse_RejectsUnknownColumnAttributes(t *testing.T) {

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -66,6 +66,18 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Constraints = constraints
 
+	views, err := r.readViews(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read views: %w", err)
+	}
+	schema.Views = views
+
+	triggers, err := r.readTriggers(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read triggers: %w", err)
+	}
+	schema.Triggers = triggers
+
 	// Reconcile per-column uniqueness against the authoritative index metadata.
 	// The DDL parser collapses every table-level KEY/INDEX clause to a UNIQUE
 	// constraint (it has no dedicated non-unique-index node), so a non-unique
@@ -114,7 +126,7 @@ func (r *Reader) getTableNames(dbName string) ([]string, error) {
 		SELECT TABLE_NAME
 		FROM information_schema.TABLES
 		WHERE TABLE_SCHEMA = ?
-		AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+		AND TABLE_TYPE = 'BASE TABLE'
 		AND TABLE_NAME NOT IN ('schema_migrations')
 		ORDER BY TABLE_NAME`
 
@@ -301,6 +313,70 @@ func (r *Reader) convertASTToTable(node *ast.CreateTableNode) types.DBTable {
 	}
 
 	return table
+}
+
+func (r *Reader) readViews(dbName string) ([]types.DBView, error) {
+	query := `
+		SELECT TABLE_NAME, VIEW_DEFINITION, CHECK_OPTION
+		FROM information_schema.VIEWS
+		WHERE TABLE_SCHEMA = ?
+		AND TABLE_NAME NOT IN ('schema_migrations')
+		ORDER BY TABLE_NAME`
+
+	rows, err := r.db.Query(query, dbName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var views []types.DBView
+	for rows.Next() {
+		var view types.DBView
+		err := rows.Scan(&view.Name, &view.Body, &view.CheckOption)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (r *Reader) readTriggers(dbName string) ([]types.DBTrigger, error) {
+	query := `
+		SELECT
+			TRIGGER_NAME,
+			EVENT_OBJECT_TABLE,
+			ACTION_TIMING,
+			EVENT_MANIPULATION,
+			ACTION_ORIENTATION,
+			ACTION_STATEMENT
+		FROM information_schema.TRIGGERS
+		WHERE TRIGGER_SCHEMA = ?
+		ORDER BY EVENT_OBJECT_TABLE, TRIGGER_NAME`
+
+	rows, err := r.db.Query(query, dbName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var triggers []types.DBTrigger
+	for rows.Next() {
+		var trigger types.DBTrigger
+		err := rows.Scan(
+			&trigger.Name,
+			&trigger.Table,
+			&trigger.Timing,
+			&trigger.Event,
+			&trigger.ForEach,
+			&trigger.Body,
+		)
+		if err != nil {
+			return nil, err
+		}
+		triggers = append(triggers, trigger)
+	}
+	return triggers, nil
 }
 
 // readEnums reads enum types from MySQL (stored as column types)

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -123,6 +123,24 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Functions = functions
 
+	views, err := r.readViews()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read views: %w", err)
+	}
+	schema.Views = views
+
+	matViews, err := r.readMaterializedViews()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read materialized views: %w", err)
+	}
+	schema.MatViews = matViews
+
+	triggers, err := r.readTriggers()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read triggers: %w", err)
+	}
+	schema.Triggers = triggers
+
 	if r.caps.Has(capability.RowLevelSecurity) {
 		// Read RLS policies (PostgreSQL-specific)
 		rlsPolicies, err := r.readRLSPolicies()
@@ -170,6 +188,7 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 			LEFT JOIN pg_class c ON c.relname = t.table_name
 		LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
 			WHERE t.table_schema = $1 AND (n.nspname = $1 OR n.nspname IS NULL)
+			AND t.table_type = 'BASE TABLE'
 			AND t.table_name NOT IN ('schema_migrations')
 			ORDER BY table_schema, table_name`
 
@@ -796,6 +815,167 @@ func (r *Reader) readFunctions() ([]types.DBFunction, error) {
 	return functions, nil
 }
 
+func (r *Reader) readViews() ([]types.DBView, error) {
+	var views []types.DBView
+	for _, schemaName := range r.schemasToRead() {
+		schemaViews, err := r.readViewsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, schemaViews...)
+	}
+	return views, nil
+}
+
+func (r *Reader) readViewsForSchema(schemaName string) ([]types.DBView, error) {
+	viewsQuery := `
+		SELECT
+			n.nspname AS schema_name,
+			c.relname AS view_name,
+			pg_get_viewdef(c.oid, true) AS view_definition,
+			COALESCE(v.check_option, 'NONE') AS check_option,
+			COALESCE(obj_description(c.oid, 'pg_class'), '') AS comment
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		LEFT JOIN information_schema.views v
+			ON v.table_schema = n.nspname AND v.table_name = c.relname
+		WHERE n.nspname = $1
+		AND c.relkind = 'v'
+		AND c.relname NOT IN ('schema_migrations')
+		ORDER BY c.relname`
+
+	rows, err := r.db.Query(viewsQuery, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query views: %w", err)
+	}
+	defer rows.Close()
+
+	var views []types.DBView
+	for rows.Next() {
+		var view types.DBView
+		err := rows.Scan(&view.Schema, &view.Name, &view.Body, &view.CheckOption, &view.Comment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan view: %w", err)
+		}
+		view.Schema = r.outputSchema(view.Schema)
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (r *Reader) readMaterializedViews() ([]types.DBMatView, error) {
+	var views []types.DBMatView
+	for _, schemaName := range r.schemasToRead() {
+		schemaViews, err := r.readMaterializedViewsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		views = append(views, schemaViews...)
+	}
+	return views, nil
+}
+
+func (r *Reader) readMaterializedViewsForSchema(schemaName string) ([]types.DBMatView, error) {
+	viewsQuery := `
+		SELECT
+			n.nspname AS schema_name,
+			c.relname AS view_name,
+			pg_get_viewdef(c.oid, true) AS view_definition,
+			COALESCE(obj_description(c.oid, 'pg_class'), '') AS comment
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1
+		AND c.relkind = 'm'
+		ORDER BY c.relname`
+
+	rows, err := r.db.Query(viewsQuery, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query materialized views: %w", err)
+	}
+	defer rows.Close()
+
+	var views []types.DBMatView
+	for rows.Next() {
+		var view types.DBMatView
+		err := rows.Scan(&view.Schema, &view.Name, &view.Body, &view.Comment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan materialized view: %w", err)
+		}
+		view.Schema = r.outputSchema(view.Schema)
+		view.RefreshStrategy = "manual"
+		views = append(views, view)
+	}
+	return views, nil
+}
+
+func (r *Reader) readTriggers() ([]types.DBTrigger, error) {
+	var triggers []types.DBTrigger
+	for _, schemaName := range r.schemasToRead() {
+		schemaTriggers, err := r.readTriggersForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		triggers = append(triggers, schemaTriggers...)
+	}
+	return triggers, nil
+}
+
+func (r *Reader) readTriggersForSchema(schemaName string) ([]types.DBTrigger, error) {
+	triggersQuery := `
+		SELECT
+			n.nspname AS schema_name,
+			tbl.relname AS table_name,
+			trg.tgname AS trigger_name,
+			CASE
+				WHEN (trg.tgtype & 2) <> 0 THEN 'BEFORE'
+				WHEN (trg.tgtype & 64) <> 0 THEN 'INSTEAD OF'
+				ELSE 'AFTER'
+			END AS timing,
+			concat_ws(' OR ',
+				CASE WHEN (trg.tgtype & 4) <> 0 THEN 'INSERT' END,
+				CASE WHEN (trg.tgtype & 8) <> 0 THEN 'DELETE' END,
+				CASE WHEN (trg.tgtype & 16) <> 0 THEN 'UPDATE' END,
+				CASE WHEN (trg.tgtype & 32) <> 0 THEN 'TRUNCATE' END
+			) AS event,
+			CASE WHEN (trg.tgtype & 1) <> 0 THEN 'ROW' ELSE 'STATEMENT' END AS for_each,
+			p.prosrc AS body,
+			COALESCE(obj_description(trg.oid, 'pg_trigger'), '') AS comment
+		FROM pg_trigger trg
+		JOIN pg_class tbl ON tbl.oid = trg.tgrelid
+		JOIN pg_namespace n ON n.oid = tbl.relnamespace
+		JOIN pg_proc p ON p.oid = trg.tgfoid
+		WHERE n.nspname = $1
+		AND NOT trg.tgisinternal
+		ORDER BY tbl.relname, trg.tgname`
+
+	rows, err := r.db.Query(triggersQuery, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query triggers: %w", err)
+	}
+	defer rows.Close()
+
+	var triggers []types.DBTrigger
+	for rows.Next() {
+		var trigger types.DBTrigger
+		err := rows.Scan(
+			&trigger.Schema,
+			&trigger.Table,
+			&trigger.Name,
+			&trigger.Timing,
+			&trigger.Event,
+			&trigger.ForEach,
+			&trigger.Body,
+			&trigger.Comment,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan trigger: %w", err)
+		}
+		trigger.Schema = r.outputSchema(trigger.Schema)
+		triggers = append(triggers, trigger)
+	}
+	return triggers, nil
+}
+
 func (r *Reader) readFunctionsForSchema(schemaName string) ([]types.DBFunction, error) {
 	functionsQuery := `
 		SELECT
@@ -817,6 +997,7 @@ func (r *Reader) readFunctionsForSchema(schemaName string) ([]types.DBFunction, 
 		WHERE n.nspname = $1
 		AND p.prokind = 'f'  -- Only functions, not procedures
 		AND l.lanname != 'internal'  -- Exclude internal functions
+		AND p.proname NOT LIKE 'ptah_trigger_%'
 		-- Exclude extension-owned functions to prevent migration issues
 		-- Extension functions cannot be dropped independently and should be managed by the extension
 		AND NOT EXISTS (

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -13,6 +13,9 @@ type DBSchema struct {
 	Constraints []DBConstraint `json:"constraints"`
 	Extensions  []DBExtension  `json:"extensions"`   // PostgreSQL extensions
 	Functions   []DBFunction   `json:"functions"`    // PostgreSQL custom functions
+	Views       []DBView       `json:"views"`        // Database views
+	MatViews    []DBMatView    `json:"matviews"`     // Database materialized views
+	Triggers    []DBTrigger    `json:"triggers"`     // Database triggers
 	RLSPolicies []DBRLSPolicy  `json:"rls_policies"` // PostgreSQL RLS policies
 	Roles       []DBRole       `json:"roles"`        // PostgreSQL roles
 }
@@ -205,6 +208,51 @@ type DBFunction struct {
 	Volatility string `json:"volatility"` // Function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
 	Body       string `json:"body"`       // Function body/implementation
 	Comment    string `json:"comment"`    // Function comment/description
+}
+
+// DBView represents a database view read from the database.
+type DBView struct {
+	Name        string `json:"name"`         // View name
+	Schema      string `json:"schema"`       // Schema where the view is defined
+	Body        string `json:"body"`         // SELECT query used as the view definition
+	CheckOption string `json:"check_option"` // NONE, LOCAL, CASCADED, or dialect equivalent
+	Comment     string `json:"comment"`      // View comment/description
+}
+
+// QualifiedName returns schema.view when Schema is set, or Name otherwise.
+func (v DBView) QualifiedName() string {
+	return QualifyTableName(v.Schema, v.Name)
+}
+
+// DBMatView represents a PostgreSQL materialized view read from the database.
+type DBMatView struct {
+	Name            string `json:"name"`             // Materialized view name
+	Schema          string `json:"schema"`           // Schema where the materialized view is defined
+	Body            string `json:"body"`             // SELECT query used as the materialized view definition
+	RefreshStrategy string `json:"refresh_strategy"` // Ptah-managed refresh policy; database introspection defaults to manual
+	Comment         string `json:"comment"`          // Materialized view comment/description
+}
+
+// QualifiedName returns schema.materialized_view when Schema is set, or Name otherwise.
+func (v DBMatView) QualifiedName() string {
+	return QualifyTableName(v.Schema, v.Name)
+}
+
+// DBTrigger represents a database trigger read from the database.
+type DBTrigger struct {
+	Name    string `json:"name"`    // Trigger name
+	Schema  string `json:"schema"`  // Schema where the trigger is defined
+	Table   string `json:"table"`   // Target table
+	Timing  string `json:"timing"`  // BEFORE, AFTER, or INSTEAD OF
+	Event   string `json:"event"`   // INSERT, UPDATE, DELETE, or TRUNCATE
+	ForEach string `json:"for"`     // ROW or STATEMENT
+	Body    string `json:"body"`    // Trigger body
+	Comment string `json:"comment"` // Trigger comment/description
+}
+
+// QualifiedTable returns schema.table when Schema is set, or Table otherwise.
+func (t DBTrigger) QualifiedTable() string {
+	return QualifyTableName(t.Schema, t.Table)
 }
 
 // DBRLSPolicy represents a PostgreSQL RLS policy read from the database

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -48,7 +48,7 @@ so typos fail fast. Current registry:
 | `enum_inline_column` | Enums are inline column types (MySQL/MariaDB `ENUM`, ClickHouse `Enum8/16`) |
 | `enum_custom_type` | Enums are separate named types (PostgreSQL `CREATE TYPE … AS ENUM`) |
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
-| `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Reserved for the trigger work (#158) |
+| `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Trigger renderers use this to choose replace vs. drop/create |
 | `row_level_security` | Row-level security policies (PostgreSQL) |
 | `foreign_keys` | Declarative `FOREIGN KEY` constraints |
 | `sequences` | Database sequence objects (`SERIAL`/`BIGSERIAL` or explicit `CREATE SEQUENCE` support) |
@@ -172,10 +172,13 @@ planner := mysql.NewWithCapabilities(caps)
   scenarios that run against live OSS containers in CI. Spanner currently has
   capability, planning, rendering, URL, and detection coverage only; there is
   no OSS Spanner PostgreSQL-interface container in the integration suite.
+- **Trigger replacement (#158).** Planners mark modified triggers as replacement
+  intent. Renderers emit `CREATE OR REPLACE TRIGGER` only when
+  `create_or_replace_trigger` is present (PostgreSQL 14+ and MariaDB); targets
+  without it use an explicit drop/create sequence.
 
 ## Follow-ups
 
-- `create_or_replace_trigger` consumer lands with triggers (#158).
 - Spanner remains lowest priority: the preset exists so callers get explicit
   routing and conservative rendering, but full Spanner-specific DDL such as
   interleaved tables is outside the PostgreSQL-family adapter.

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -56,9 +56,9 @@ The system operates through four main layers:
 - **Purpose**: Parses language-agnostic YAML schema files into the same `goschema.Database` IR used by Go annotations
 - **Input**: `.yaml` and `.yml` files passed to `ptah generate --schema-file`
 - **Functionality**:
-  - Supports tables, columns, indexes, constraints, enums, extensions, functions, row-level security, roles, and dialect overrides
+  - Supports tables, columns, indexes, constraints, enums, extensions, functions, views, materialized views, triggers, row-level security, roles, and dialect overrides
   - Preserves author order for table-local columns, indexes, and constraints while keeping top-level maps deterministic
-  - Applies strict validation for unknown fields, duplicate ordered keys, invalid indexes and constraints, multiple YAML documents, and currently unsupported views/triggers
+  - Applies strict validation for unknown fields, duplicate ordered keys, invalid indexes and constraints, and multiple YAML documents
 
 #### lexer Package
 - **Purpose**: Tokenizes SQL statements into structured tokens

--- a/docs/yaml_schema.md
+++ b/docs/yaml_schema.md
@@ -228,13 +228,18 @@ and `EXCLUDE`.
 Top-level constraints also require `table`. `condition` is supported for
 `EXCLUDE` constraints.
 
-## PostgreSQL Objects
+## Schema Objects
 
-YAML input supports the current PostgreSQL-specific goschema objects:
+YAML input supports these schema objects. Extensions, functions, materialized
+views, RLS, and roles are PostgreSQL-specific; views and triggers are also
+rendered for MySQL/MariaDB with dialect-specific trigger bodies.
 
 - `extensions`: `name`, `if_not_exists`, `version`, `comment`
 - `functions`: `name`, `params` or `parameters`, `returns`, `language`,
   `security`, `volatility`, `body`, `comment`
+- `views`: `name`, `body`, `with_check`, `comment`
+- `matviews`: `name`, `body`, `refresh_strategy`, `comment`
+- `triggers`: `name`, `table`, `timing`, `event`, `for`, `body`, `comment`
 - `rls_enabled_tables` or `rls_enabled`: map of tables with optional `table`,
   `struct_name`, and `comment`
 - `rls_policies`: `name`, `table`, `for`, `to`, `using`, `with_check`,
@@ -252,7 +257,3 @@ The parser is intentionally strict:
 - Top-level indexes and constraints must name their target table.
 - Constraint types and required semantic fields are validated before SQL
   generation.
-
-`views` and `triggers` are explicitly rejected for now because the current
-`goschema` IR and renderers do not model them yet. They can be added later on
-the same frontend path when backend support exists.

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -51,7 +51,7 @@ func DemonstrateASTApproach() {
 
 	schema := astbuilder.NewSchema().
 		Comment("E-commerce database schema").
-		Enum("order_status", "pending", "processing", "shipped", "delivered", "cancelled").
+		Enum("order_status", "pending", "processing", "shipped", "delivered", "canceled").
 		Table("categories").
 		Column("id", "SERIAL").Primary().End().
 		Column("name", "VARCHAR(100)").NotNull().Unique().End().
@@ -260,6 +260,19 @@ func (a *SchemaAnalyzer) VisitAlterTableEnableRLS(node *ast.AlterTableEnableRLSN
 func (a *SchemaAnalyzer) VisitDropFunction(node *ast.DropFunctionNode) error {
 	return nil
 }
+func (a *SchemaAnalyzer) VisitCreateView(node *ast.CreateViewNode) error { return nil }
+func (a *SchemaAnalyzer) VisitDropView(node *ast.DropViewNode) error     { return nil }
+func (a *SchemaAnalyzer) VisitCreateMaterializedView(node *ast.CreateMaterializedViewNode) error {
+	return nil
+}
+func (a *SchemaAnalyzer) VisitDropMaterializedView(node *ast.DropMaterializedViewNode) error {
+	return nil
+}
+func (a *SchemaAnalyzer) VisitRefreshMaterializedView(node *ast.RefreshMaterializedViewNode) error {
+	return nil
+}
+func (a *SchemaAnalyzer) VisitCreateTrigger(node *ast.CreateTriggerNode) error { return nil }
+func (a *SchemaAnalyzer) VisitDropTrigger(node *ast.DropTriggerNode) error     { return nil }
 func (a *SchemaAnalyzer) VisitDropPolicy(node *ast.DropPolicyNode) error {
 	return nil
 }

--- a/integration/gonative/schema_objects_integration_test.go
+++ b/integration/gonative/schema_objects_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/postgres"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupSchemaObjects(t, db)
+	defer cleanupSchemaObjects(t, db)
+
+	target := schemaObjectsTarget()
+	diff := schemadiff.Compare(target, &dbschematypes.DBSchema{})
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+
+	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	sqlText := strings.Join(statements, ";\n") + ";"
+	_, err = db.Exec(sqlText)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated migration SQL must execute: %s", sqlText))
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	read, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	filtered := filterSchemaObjects(read)
+
+	roundTrip := schemadiff.Compare(target, filtered)
+	c.Assert(roundTrip.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", roundTrip))
+
+	modified := schemaObjectsTarget()
+	modified.Views[0].Body = "SELECT id, updated_at FROM ptah_schema_objects_users WHERE deleted_at IS NULL AND updated_at IS NOT NULL"
+	modified.MaterializedViews[0].Body = "SELECT id, COUNT(updated_at) FROM ptah_schema_objects_users GROUP BY id"
+	modified.Triggers[0].Body = "NEW.updated_at = clock_timestamp(); RETURN NEW;"
+
+	bodyDiff := schemadiff.Compare(modified, filtered)
+	c.Assert(bodyDiff.ViewsModified, qt.HasLen, 1)
+	c.Assert(bodyDiff.MaterializedViewsModified, qt.HasLen, 1)
+	c.Assert(bodyDiff.TriggersModified, qt.HasLen, 1)
+
+	modifiedStatements := planner.GenerateSchemaDiffSQLStatements(bodyDiff, modified, "postgres")
+	modifiedSQL := strings.Join(modifiedStatements, ";\n") + ";"
+	_, err = db.Exec(modifiedSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("modified migration SQL must execute: %s", modifiedSQL))
+
+	read, err = reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	modifiedFiltered := filterSchemaObjects(read)
+	modifiedRoundTrip := schemadiff.Compare(modified, modifiedFiltered)
+	c.Assert(modifiedRoundTrip.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", modifiedRoundTrip))
+
+	tableOnly := schemaObjectsTableOnly()
+	removalDiff := schemadiff.Compare(tableOnly, modifiedFiltered)
+	c.Assert(removalDiff.ViewsRemoved, qt.DeepEquals, []string{"ptah_schema_objects_active_users"})
+	c.Assert(removalDiff.MaterializedViewsRemoved, qt.DeepEquals, []string{"ptah_schema_objects_user_stats"})
+	c.Assert(removalDiff.TriggersRemoved, qt.DeepEquals, []difftypes.TriggerRef{{
+		TriggerName: "ptah_schema_objects_set_updated_at",
+		TableName:   "ptah_schema_objects_users",
+	}})
+
+	removalStatements := planner.GenerateSchemaDiffSQLStatements(removalDiff, tableOnly, "postgres")
+	removalSQL := strings.Join(removalStatements, ";\n") + ";"
+	_, err = db.Exec(removalSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("removal migration SQL must execute: %s", removalSQL))
+
+	read, err = reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	removedFiltered := filterSchemaObjects(read)
+	removedRoundTrip := schemadiff.Compare(tableOnly, removedFiltered)
+	c.Assert(removedRoundTrip.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", removedRoundTrip))
+}
+
+func schemaObjectsTarget() *goschema.Database {
+	db := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "SchemaObjectUser",
+			Name:       "ptah_schema_objects_users",
+		}},
+		Fields: []goschema.Field{
+			{StructName: "SchemaObjectUser", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "SchemaObjectUser", Name: "deleted_at", Type: "TIMESTAMP"},
+			{StructName: "SchemaObjectUser", Name: "updated_at", Type: "TIMESTAMP"},
+		},
+		Views: []goschema.View{{
+			Name: "ptah_schema_objects_active_users",
+			Body: "SELECT id, updated_at FROM ptah_schema_objects_users WHERE deleted_at IS NULL",
+		}},
+		MaterializedViews: []goschema.MaterializedView{{
+			Name:            "ptah_schema_objects_user_stats",
+			Body:            "SELECT id, COUNT(*) FROM ptah_schema_objects_users GROUP BY id",
+			RefreshStrategy: "manual",
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:   "ptah_schema_objects_set_updated_at",
+			Table:  "ptah_schema_objects_users",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "NEW.updated_at = NOW(); RETURN NEW;",
+		}},
+	}
+	goschema.Finalize(db)
+	return db
+}
+
+func schemaObjectsTableOnly() *goschema.Database {
+	db := schemaObjectsTarget()
+	db.Views = nil
+	db.MaterializedViews = nil
+	db.Triggers = nil
+	return db
+}
+
+func cleanupSchemaObjects(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, _ = db.Exec("DROP MATERIALIZED VIEW IF EXISTS ptah_schema_objects_user_stats CASCADE")
+	_, _ = db.Exec("DROP VIEW IF EXISTS ptah_schema_objects_active_users CASCADE")
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_schema_objects_users CASCADE")
+	_, _ = db.Exec("DROP FUNCTION IF EXISTS ptah_trigger_ptah_schema_objects_users_ptah_schema_objects_set_updated_at()")
+}
+
+func filterSchemaObjects(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	out := &dbschematypes.DBSchema{}
+	for _, table := range in.Tables {
+		if table.Name == "ptah_schema_objects_users" {
+			out.Tables = append(out.Tables, table)
+		}
+	}
+	for _, view := range in.Views {
+		if view.Name == "ptah_schema_objects_active_users" {
+			out.Views = append(out.Views, view)
+		}
+	}
+	for _, view := range in.MatViews {
+		if view.Name == "ptah_schema_objects_user_stats" {
+			out.MatViews = append(out.MatViews, view)
+		}
+	}
+	for _, trigger := range in.Triggers {
+		if trigger.Name == "ptah_schema_objects_set_updated_at" {
+			out.Triggers = append(out.Triggers, trigger)
+		}
+	}
+	return out
+}

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -560,6 +560,13 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 4. Modify existing tables
 	result = p.modifyExistingTables(result, diff, generated)
 
+	// 4.5. Add and modify views/triggers after tables exist.
+	result = p.addNewViews(result, diff, generated)
+	result = p.modifyExistingViews(result, diff, generated)
+	p.rejectMaterializedViews(diff)
+	result = p.addNewTriggers(result, diff, generated)
+	result = p.modifyExistingTriggers(result, diff, generated)
+
 	// 5. Add new indexes
 	result = p.addNewIndexes(result, diff, generated)
 
@@ -572,6 +579,10 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 6.5. Remove constraints (must be done before removing tables)
 	result = p.removeConstraints(result, diff)
 
+	// 6.6. Remove triggers and view-like objects before dependent tables.
+	result = p.removeTriggers(result, diff)
+	result = p.removeViews(result, diff)
+
 	// 7. Remove tables (dangerous!)
 	result = p.removeTables(result, diff)
 
@@ -579,6 +590,83 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.handleEnumRemovals(result, diff)
 
 	return result
+}
+
+func (p *Planner) rejectMaterializedViews(diff *types.SchemaDiff) {
+	if len(diff.MaterializedViewsAdded) == 0 &&
+		len(diff.MaterializedViewsModified) == 0 &&
+		len(diff.MaterializedViewsRemoved) == 0 {
+		return
+	}
+	panic("materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target")
+}
+
+func (p *Planner) addNewViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewName := range diff.ViewsAdded {
+		if view := findView(generated.Views, viewName); view != nil {
+			result = append(result, fromschema.FromView(*view))
+		}
+	}
+	return result
+}
+
+func (p *Planner) modifyExistingViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewDiff := range diff.ViewsModified {
+		if view := findView(generated.Views, viewDiff.ViewName); view != nil {
+			result = append(result, fromschema.FromView(*view).SetReplace())
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeViews(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, viewName := range diff.ViewsRemoved {
+		result = append(result, ast.NewDropView(viewName).SetIfExists())
+	}
+	return result
+}
+
+func (p *Planner) addNewTriggers(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, triggerRef := range diff.TriggersAdded {
+		if trigger := findTrigger(generated.Triggers, triggerRef.TableName, triggerRef.TriggerName); trigger != nil {
+			result = append(result, fromschema.FromTrigger(*trigger))
+		}
+	}
+	return result
+}
+
+func (p *Planner) modifyExistingTriggers(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, triggerDiff := range diff.TriggersModified {
+		if trigger := findTrigger(generated.Triggers, triggerDiff.TableName, triggerDiff.TriggerName); trigger != nil {
+			result = append(result, fromschema.FromTrigger(*trigger).SetReplace())
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeTriggers(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, triggerRef := range diff.TriggersRemoved {
+		result = append(result, ast.NewDropTrigger(triggerRef.TriggerName, triggerRef.TableName).SetIfExists())
+	}
+	return result
+}
+
+func findView(views []goschema.View, name string) *goschema.View {
+	for i := range views {
+		if views[i].Name == name {
+			return &views[i]
+		}
+	}
+	return nil
+}
+
+func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
+	for i := range triggers {
+		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
+			return &triggers[i]
+		}
+	}
+	return nil
 }
 
 // addNewConstraints adds new table-level constraints via ALTER TABLE statements.

--- a/migration/planner/dialects/mysql/schema_objects_test.go
+++ b/migration/planner/dialects/mysql/schema_objects_test.go
@@ -1,0 +1,61 @@
+package mysql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_ViewsAndTriggersModified(t *testing.T) {
+	c := qt.New(t)
+	planner := mysql.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "active_users",
+			Body: "SELECT id FROM users WHERE deleted_at IS NULL",
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:   "set_updated_at",
+			Table:  "users",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "SET NEW.updated_at = NOW()",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsModified:    []difftypes.ViewDiff{{ViewName: "active_users", Changes: map[string]string{"body": "old -> new"}}},
+		TriggersModified: []difftypes.TriggerDiff{{TriggerName: "set_updated_at", TableName: "users", Changes: map[string]string{"body": "old -> new"}}},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("mysql", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users")
+	c.Assert(sql, qt.Contains, "DROP TRIGGER IF EXISTS set_updated_at;")
+	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW SET NEW.updated_at = NOW();")
+}
+
+func TestPlanner_GenerateMigrationAST_RejectsMaterializedViews(t *testing.T) {
+	c := qt.New(t)
+	planner := mysql.New()
+
+	diff := &difftypes.SchemaDiff{
+		MaterializedViewsAdded: []string{"user_stats"},
+	}
+	generated := &goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name: "user_stats",
+			Body: "SELECT id, COUNT(*) FROM users GROUP BY id",
+		}},
+	}
+
+	c.Assert(func() {
+		planner.GenerateMigrationAST(diff, generated)
+	}, qt.PanicMatches, "materialized views are not supported by MySQL or MariaDB.*")
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -775,6 +775,14 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 6.5. Add foreign key constraints for newly added columns (must be done after all columns exist)
 	result = p.addForeignKeyConstraintsForModifiedTables(result, diff, generated)
 
+	// 6.6. Add and modify views, materialized views, and triggers after their tables/functions exist.
+	result = p.addNewViews(result, diff, generated)
+	result = p.modifyExistingViews(result, diff, generated)
+	result = p.addNewMaterializedViews(result, diff, generated)
+	result = p.modifyExistingMaterializedViews(result, diff, generated)
+	result = p.addNewTriggers(result, diff, generated)
+	result = p.modifyExistingTriggers(result, diff, generated)
+
 	// 7. Modify existing roles (must be done before RLS policies that reference them)
 	result = p.modifyExistingRoles(result, diff, generated)
 
@@ -804,6 +812,11 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 
 	// 12.5. Remove constraints (must be done before removing tables)
 	result = p.removeConstraints(result, diff)
+
+	// 12.6. Remove triggers and view-like objects before dropping tables/functions they depend on.
+	result = p.removeTriggers(result, diff)
+	result = p.removeMaterializedViews(result, diff)
+	result = p.removeViews(result, diff)
 
 	// 13. Remove tables (dangerous!)
 	result = p.removeTables(result, diff)
@@ -1064,6 +1077,116 @@ func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []a
 		result = append(result, dropFunctionNode)
 	}
 	return result
+}
+
+func (p *Planner) addNewViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewName := range diff.ViewsAdded {
+		if view := findView(generated.Views, viewName); view != nil {
+			result = append(result, fromschema.FromView(*view))
+		}
+	}
+	return result
+}
+
+func (p *Planner) modifyExistingViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewDiff := range diff.ViewsModified {
+		if view := findView(generated.Views, viewDiff.ViewName); view != nil {
+			result = append(result, fromschema.FromView(*view).SetReplace())
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeViews(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, viewName := range diff.ViewsRemoved {
+		result = append(result, ast.NewDropView(viewName).SetIfExists().SetCascade())
+	}
+	return result
+}
+
+func (p *Planner) addNewMaterializedViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewName := range diff.MaterializedViewsAdded {
+		if view := findMaterializedView(generated.MaterializedViews, viewName); view != nil {
+			result = append(result, fromschema.FromMaterializedView(*view))
+			if strings.EqualFold(view.RefreshStrategy, "concurrently") {
+				result = append(result, ast.NewRefreshMaterializedView(view.Name).SetConcurrently())
+			}
+		}
+	}
+	return result
+}
+
+func (p *Planner) modifyExistingMaterializedViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, viewDiff := range diff.MaterializedViewsModified {
+		if view := findMaterializedView(generated.MaterializedViews, viewDiff.ViewName); view != nil {
+			result = append(result, ast.NewDropMaterializedView(view.Name).SetIfExists().SetCascade())
+			result = append(result, fromschema.FromMaterializedView(*view))
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeMaterializedViews(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, viewName := range diff.MaterializedViewsRemoved {
+		result = append(result, ast.NewDropMaterializedView(viewName).SetIfExists().SetCascade())
+	}
+	return result
+}
+
+func (p *Planner) addNewTriggers(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, triggerRef := range diff.TriggersAdded {
+		if trigger := findTrigger(generated.Triggers, triggerRef.TableName, triggerRef.TriggerName); trigger != nil {
+			result = append(result, fromschema.FromTrigger(*trigger))
+		}
+	}
+	return result
+}
+
+func (p *Planner) modifyExistingTriggers(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, triggerDiff := range diff.TriggersModified {
+		if trigger := findTrigger(generated.Triggers, triggerDiff.TableName, triggerDiff.TriggerName); trigger != nil {
+			result = append(result, fromschema.FromTrigger(*trigger).SetReplace())
+		}
+	}
+	return result
+}
+
+func (p *Planner) removeTriggers(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, triggerRef := range diff.TriggersRemoved {
+		functionName := goschema.Trigger{Name: triggerRef.TriggerName, Table: triggerRef.TableName}.FunctionName()
+		result = append(result, ast.NewDropTrigger(triggerRef.TriggerName, triggerRef.TableName).
+			SetIfExists().
+			SetCascade().
+			SetFunctionName(functionName))
+	}
+	return result
+}
+
+func findView(views []goschema.View, name string) *goschema.View {
+	for i := range views {
+		if views[i].Name == name {
+			return &views[i]
+		}
+	}
+	return nil
+}
+
+func findMaterializedView(views []goschema.MaterializedView, name string) *goschema.MaterializedView {
+	for i := range views {
+		if views[i].Name == name {
+			return &views[i]
+		}
+	}
+	return nil
+}
+
+func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
+	for i := range triggers {
+		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
+			return &triggers[i]
+		}
+	}
+	return nil
 }
 
 func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {

--- a/migration/planner/dialects/postgres/schema_objects_test.go
+++ b/migration/planner/dialects/postgres/schema_objects_test.go
@@ -1,0 +1,86 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_SchemaObjectsModified(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "active_users",
+			Body: "SELECT id FROM users WHERE deleted_at IS NULL",
+		}},
+		MaterializedViews: []goschema.MaterializedView{{
+			Name: "user_stats",
+			Body: "SELECT id, COUNT(*) FROM users GROUP BY id",
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:   "set_updated_at",
+			Table:  "users",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "NEW.updated_at = NOW(); RETURN NEW;",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsModified:             []difftypes.ViewDiff{{ViewName: "active_users", Changes: map[string]string{"body": "old -> new"}}},
+		MaterializedViewsModified: []difftypes.MaterializedViewDiff{{ViewName: "user_stats", Changes: map[string]string{"body": "old -> new"}}},
+		TriggersModified:          []difftypes.TriggerDiff{{TriggerName: "set_updated_at", TableName: "users", Changes: map[string]string{"body": "old -> new"}}},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users")
+	c.Assert(sql, qt.Contains, "DROP MATERIALIZED VIEW IF EXISTS user_stats CASCADE;")
+	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW user_stats AS")
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION ptah_trigger_users_set_updated_at();")
+}
+
+func TestPlanner_GenerateMigrationAST_DuplicateTriggerNamesUseDistinctFunctions(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Triggers: []goschema.Trigger{
+			{
+				Name:   "set_updated_at",
+				Table:  "users",
+				Timing: "BEFORE",
+				Event:  "UPDATE",
+				Body:   "NEW.updated_at = NOW(); RETURN NEW;",
+			},
+			{
+				Name:   "set_updated_at",
+				Table:  "posts",
+				Timing: "BEFORE",
+				Event:  "UPDATE",
+				Body:   "NEW.updated_at = clock_timestamp(); RETURN NEW;",
+			},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		TriggersAdded: []difftypes.TriggerRef{
+			{TriggerName: "set_updated_at", TableName: "users"},
+			{TriggerName: "set_updated_at", TableName: "posts"},
+		},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE FUNCTION ptah_trigger_users_set_updated_at()")
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE FUNCTION ptah_trigger_posts_set_updated_at()")
+	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION ptah_trigger_users_set_updated_at();")
+	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON posts FOR EACH ROW EXECUTE FUNCTION ptah_trigger_posts_set_updated_at();")
+}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -27,6 +27,8 @@ var (
 	// Custom index patterns (these should NOT be considered constraint-based)
 	// Match indexes that start with "idx_" or "index_", or end with "_idx" or "_index"
 	customIndexPattern = regexp.MustCompile(`(?i)(^(idx|index)_|_(idx|index)$)`)
+
+	defaultAggregateAliasPattern = regexp.MustCompile(`\b(count|sum|avg|min|max)\(([^)]*)\)\s+as\s+([a-z_][a-z0-9_]*)\b`)
 )
 
 // TablesAndColumns performs comprehensive table and column comparison between generated and database schemas.
@@ -703,9 +705,9 @@ func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 // **Mixed changes**:
 //
 //	```
-//	Generated: ["pending", "approved", "rejected", "cancelled"]
+//	Generated: ["pending", "approved", "rejected", "canceled"]
 //	Database:  ["pending", "approved", "denied"]
-//	Result:    ValuesAdded=["rejected", "cancelled"], ValuesRemoved=["denied"]
+//	Result:    ValuesAdded=["rejected", "canceled"], ValuesRemoved=["denied"]
 //	```
 //
 // # Performance Characteristics
@@ -1913,6 +1915,133 @@ func Functions(generated *goschema.Database, database *types.DBSchema, diff *dif
 	})
 }
 
+// Views compares view definitions between generated and database schemas.
+func Views(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	generatedViews := make(map[string]goschema.View)
+	for _, view := range generated.Views {
+		generatedViews[view.Name] = view
+	}
+
+	databaseViews := make(map[string]types.DBView)
+	for _, view := range database.Views {
+		databaseViews[view.QualifiedName()] = view
+	}
+
+	addedViews, removedViews := compareNamedItems(generatedViews, databaseViews)
+	diff.ViewsAdded = append(diff.ViewsAdded, addedViews...)
+	diff.ViewsRemoved = append(diff.ViewsRemoved, removedViews...)
+
+	for viewName, generatedView := range generatedViews {
+		if databaseView, exists := databaseViews[viewName]; exists {
+			viewDiff := ViewDefinitions(generatedView, databaseView)
+			if len(viewDiff.Changes) > 0 {
+				diff.ViewsModified = append(diff.ViewsModified, viewDiff)
+			}
+		}
+	}
+
+	sort.Strings(diff.ViewsAdded)
+	sort.Strings(diff.ViewsRemoved)
+	sort.Slice(diff.ViewsModified, func(i, j int) bool {
+		return diff.ViewsModified[i].ViewName < diff.ViewsModified[j].ViewName
+	})
+}
+
+// MaterializedViews compares materialized view definitions between generated
+// and database schemas.
+func MaterializedViews(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	generatedViews := make(map[string]goschema.MaterializedView)
+	for _, view := range generated.MaterializedViews {
+		view.Canonicalize()
+		generatedViews[view.Name] = view
+	}
+
+	databaseViews := make(map[string]types.DBMatView)
+	for _, view := range database.MatViews {
+		databaseViews[view.QualifiedName()] = view
+	}
+
+	addedViews, removedViews := compareNamedItems(generatedViews, databaseViews)
+	diff.MaterializedViewsAdded = append(diff.MaterializedViewsAdded, addedViews...)
+	diff.MaterializedViewsRemoved = append(diff.MaterializedViewsRemoved, removedViews...)
+
+	for viewName, generatedView := range generatedViews {
+		if databaseView, exists := databaseViews[viewName]; exists {
+			viewDiff := MaterializedViewDefinitions(generatedView, databaseView)
+			if len(viewDiff.Changes) > 0 {
+				diff.MaterializedViewsModified = append(diff.MaterializedViewsModified, viewDiff)
+			}
+		}
+	}
+
+	sort.Strings(diff.MaterializedViewsAdded)
+	sort.Strings(diff.MaterializedViewsRemoved)
+	sort.Slice(diff.MaterializedViewsModified, func(i, j int) bool {
+		return diff.MaterializedViewsModified[i].ViewName < diff.MaterializedViewsModified[j].ViewName
+	})
+}
+
+// Triggers compares trigger definitions between generated and database schemas.
+func Triggers(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	generatedTriggers := make(map[string]goschema.Trigger)
+	for _, trigger := range generated.Triggers {
+		trigger.Canonicalize()
+		generatedTriggers[triggerKey(trigger.Table, trigger.Name)] = trigger
+	}
+
+	databaseTriggers := make(map[string]types.DBTrigger)
+	for _, trigger := range database.Triggers {
+		databaseTriggers[triggerKey(trigger.QualifiedTable(), trigger.Name)] = trigger
+	}
+
+	for key, trigger := range generatedTriggers {
+		if _, exists := databaseTriggers[key]; !exists {
+			diff.TriggersAdded = append(diff.TriggersAdded, difftypes.TriggerRef{
+				TriggerName: trigger.Name,
+				TableName:   trigger.Table,
+			})
+		}
+	}
+	for key, trigger := range databaseTriggers {
+		if _, exists := generatedTriggers[key]; !exists {
+			diff.TriggersRemoved = append(diff.TriggersRemoved, difftypes.TriggerRef{
+				TriggerName: trigger.Name,
+				TableName:   trigger.QualifiedTable(),
+			})
+		}
+	}
+	for key, generatedTrigger := range generatedTriggers {
+		if databaseTrigger, exists := databaseTriggers[key]; exists {
+			triggerDiff := TriggerDefinitions(generatedTrigger, databaseTrigger)
+			if len(triggerDiff.Changes) > 0 {
+				diff.TriggersModified = append(diff.TriggersModified, triggerDiff)
+			}
+		}
+	}
+
+	sortTriggerRefs(diff.TriggersAdded)
+	sortTriggerRefs(diff.TriggersRemoved)
+	sort.Slice(diff.TriggersModified, func(i, j int) bool {
+		if diff.TriggersModified[i].TableName == diff.TriggersModified[j].TableName {
+			return diff.TriggersModified[i].TriggerName < diff.TriggersModified[j].TriggerName
+		}
+		return diff.TriggersModified[i].TableName < diff.TriggersModified[j].TableName
+	})
+}
+
+func triggerKey(tableName, triggerName string) string {
+	return tableName + "." + triggerName
+}
+
+func sortTriggerRefs(refs []difftypes.TriggerRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].TableName == refs[j].TableName {
+			return refs[i].TriggerName < refs[j].TriggerName
+		}
+		return refs[i].TableName < refs[j].TableName
+	})
+}
+
 // RLSPolicies performs PostgreSQL RLS policy comparison between generated and database schemas.
 //
 // This function handles the comparison of Row-Level Security policies, which are
@@ -2617,6 +2746,121 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 	}
 
 	return functionDiff
+}
+
+// ViewDefinitions performs detailed comparison between generated and database view definitions.
+func ViewDefinitions(genView goschema.View, dbView types.DBView) difftypes.ViewDiff {
+	viewDiff := difftypes.ViewDiff{
+		ViewName: genView.Name,
+		Changes:  make(map[string]string),
+	}
+
+	genBody := normalizeSchemaObjectBody(genView.Body)
+	dbBody := normalizeSchemaObjectBody(dbView.Body)
+	if genBody != dbBody {
+		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
+	}
+
+	dbWithCheck := !strings.EqualFold(dbView.CheckOption, "") && !strings.EqualFold(dbView.CheckOption, "NONE")
+	if genView.WithCheck != dbWithCheck {
+		viewDiff.Changes["with_check"] = fmt.Sprintf("%t -> %t", dbWithCheck, genView.WithCheck)
+	}
+
+	return viewDiff
+}
+
+// MaterializedViewDefinitions performs detailed comparison between generated
+// and database materialized view definitions.
+func MaterializedViewDefinitions(genView goschema.MaterializedView, dbView types.DBMatView) difftypes.MaterializedViewDiff {
+	genView.Canonicalize()
+	if dbView.RefreshStrategy == "" {
+		dbView.RefreshStrategy = "manual"
+	}
+	dbView.RefreshStrategy = strings.ToLower(strings.TrimSpace(dbView.RefreshStrategy))
+
+	viewDiff := difftypes.MaterializedViewDiff{
+		ViewName: genView.Name,
+		Changes:  make(map[string]string),
+	}
+
+	genBody := normalizeSchemaObjectBody(genView.Body)
+	dbBody := normalizeSchemaObjectBody(dbView.Body)
+	if genBody != dbBody {
+		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
+	}
+	if genView.RefreshStrategy != dbView.RefreshStrategy {
+		viewDiff.Changes["refresh_strategy"] = fmt.Sprintf("%s -> %s", dbView.RefreshStrategy, genView.RefreshStrategy)
+	}
+
+	return viewDiff
+}
+
+// TriggerDefinitions performs detailed comparison between generated and database trigger definitions.
+func TriggerDefinitions(genTrigger goschema.Trigger, dbTrigger types.DBTrigger) difftypes.TriggerDiff {
+	genTrigger.Canonicalize()
+
+	triggerDiff := difftypes.TriggerDiff{
+		TriggerName: genTrigger.Name,
+		TableName:   genTrigger.Table,
+		Changes:     make(map[string]string),
+	}
+
+	if genTrigger.Timing != strings.ToUpper(dbTrigger.Timing) {
+		triggerDiff.Changes["timing"] = fmt.Sprintf("%s -> %s", dbTrigger.Timing, genTrigger.Timing)
+	}
+	if genTrigger.Event != strings.ToUpper(dbTrigger.Event) {
+		triggerDiff.Changes["event"] = fmt.Sprintf("%s -> %s", dbTrigger.Event, genTrigger.Event)
+	}
+	dbForEach := strings.ToUpper(strings.TrimSpace(dbTrigger.ForEach))
+	if dbForEach == "" {
+		dbForEach = "ROW"
+	}
+	if genTrigger.ForEach != dbForEach {
+		triggerDiff.Changes["for"] = fmt.Sprintf("%s -> %s", dbForEach, genTrigger.ForEach)
+	}
+
+	genBody := normalizeTriggerBody(genTrigger.Body)
+	dbBody := normalizeTriggerBody(dbTrigger.Body)
+	if genBody != dbBody {
+		triggerDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbTrigger.Body), strings.TrimSpace(genTrigger.Body))
+	}
+
+	return triggerDiff
+}
+
+func normalizeSchemaObjectBody(body string) string {
+	body = strings.TrimSpace(body)
+	body = strings.TrimSuffix(body, ";")
+	body = strings.TrimSpace(body)
+	body = strings.ReplaceAll(body, "\"", "")
+	body = strings.ReplaceAll(body, "`", "")
+	body = strings.ToLower(body)
+	body = stripDefaultAggregateAliases(body)
+	body = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`).ReplaceAllString(body, "")
+	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
+	return strings.TrimSpace(body)
+}
+
+func stripDefaultAggregateAliases(body string) string {
+	return defaultAggregateAliasPattern.ReplaceAllStringFunc(body, func(match string) string {
+		parts := defaultAggregateAliasPattern.FindStringSubmatch(match)
+		if len(parts) != 4 || parts[1] != parts[3] {
+			return match
+		}
+		return parts[1] + "(" + parts[2] + ")"
+	})
+}
+
+func normalizeTriggerBody(body string) string {
+	body = normalizeSchemaObjectBody(body)
+	body = strings.TrimPrefix(body, "begin ")
+	body = strings.TrimPrefix(body, "begin")
+	body = strings.TrimSpace(body)
+	body = strings.TrimSuffix(body, " end")
+	body = strings.TrimSuffix(body, "end")
+	body = strings.TrimSpace(body)
+	body = strings.TrimSuffix(body, ";")
+	return strings.TrimSpace(body)
 }
 
 // RLSPolicyDefinitions performs detailed comparison between generated and database RLS policy definitions.

--- a/migration/schemadiff/internal/compare/compare_schema_objects_test.go
+++ b/migration/schemadiff/internal/compare/compare_schema_objects_test.go
@@ -1,0 +1,97 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestViews_DetectsBodyChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "active_users", Body: "SELECT id FROM users WHERE deleted_at IS NULL"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{Name: "active_users", Body: "SELECT id FROM users WHERE deleted_at IS NULL AND enabled = true"}},
+	}, diff)
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestMaterializedViews_DetectsBodyAndRefreshStrategyChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.MaterializedViews(&goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name:            "user_stats",
+			Body:            "SELECT id, COUNT(*) FROM users GROUP BY id",
+			RefreshStrategy: "concurrently",
+		}},
+	}, &dbschematypes.DBSchema{
+		MatViews: []dbschematypes.DBMatView{{
+			Name:            "user_stats",
+			Body:            "SELECT id, COUNT(*) FROM users WHERE enabled GROUP BY id",
+			RefreshStrategy: "manual",
+		}},
+	}, diff)
+
+	c.Assert(diff.MaterializedViewsModified, qt.HasLen, 1)
+	c.Assert(diff.MaterializedViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+	c.Assert(diff.MaterializedViewsModified[0].Changes["refresh_strategy"], qt.Equals, "manual -> concurrently")
+}
+
+func TestMaterializedViews_IgnoresPostgreSQLDefaultAggregateAlias(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.MaterializedViews(&goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name: "user_stats",
+			Body: "SELECT id, COUNT(*) FROM users GROUP BY id",
+		}},
+	}, &dbschematypes.DBSchema{
+		MatViews: []dbschematypes.DBMatView{{
+			Name: "user_stats",
+			Body: "SELECT id,\n    count(*) AS count\n   FROM users\n  GROUP BY id;",
+		}},
+	}, diff)
+
+	c.Assert(diff.MaterializedViewsModified, qt.HasLen, 0)
+}
+
+func TestTriggers_KeyedByTableAndDetectsBodyChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Triggers(&goschema.Database{
+		Triggers: []goschema.Trigger{{
+			Name:    "set_updated_at",
+			Table:   "users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "NEW.updated_at = NOW(); RETURN NEW;",
+		}},
+	}, &dbschematypes.DBSchema{
+		Triggers: []dbschematypes.DBTrigger{{
+			Name:    "set_updated_at",
+			Table:   "users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "BEGIN NEW.updated_at = clock_timestamp(); RETURN NEW; END;",
+		}},
+	}, diff)
+
+	c.Assert(diff.TriggersModified, qt.HasLen, 1)
+	c.Assert(diff.TriggersModified[0].TableName, qt.Equals, "users")
+	c.Assert(diff.TriggersModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -69,6 +69,11 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	// Compare PostgreSQL functions (PostgreSQL-specific feature)
 	compare.Functions(generated, database, diff)
 
+	// Compare views, materialized views, and triggers
+	compare.Views(generated, database, diff)
+	compare.MaterializedViews(generated, database, diff)
+	compare.Triggers(generated, database, diff)
+
 	// Compare RLS policies (PostgreSQL-specific feature)
 	compare.RLSPolicies(generated, database, diff)
 

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -158,6 +158,39 @@ type SchemaDiff struct {
 	// schemas but have different definitions (parameters, body, attributes, etc.)
 	FunctionsModified []FunctionDiff `json:"functions_modified"`
 
+	// ViewsAdded contains names of views that exist in the target schema
+	// but not in the current database schema.
+	ViewsAdded []string `json:"views_added"`
+
+	// ViewsRemoved contains names of views that exist in the current database
+	// but not in the target schema.
+	ViewsRemoved []string `json:"views_removed"`
+
+	// ViewsModified contains detailed information about views with changed definitions.
+	ViewsModified []ViewDiff `json:"views_modified"`
+
+	// MaterializedViewsAdded contains names of materialized views that exist in the target schema
+	// but not in the current database schema.
+	MaterializedViewsAdded []string `json:"materialized_views_added"`
+
+	// MaterializedViewsRemoved contains names of materialized views that exist in the current database
+	// but not in the target schema.
+	MaterializedViewsRemoved []string `json:"materialized_views_removed"`
+
+	// MaterializedViewsModified contains detailed information about changed materialized views.
+	MaterializedViewsModified []MaterializedViewDiff `json:"materialized_views_modified"`
+
+	// TriggersAdded contains table-qualified trigger refs that exist in the target schema
+	// but not in the current database schema.
+	TriggersAdded []TriggerRef `json:"triggers_added"`
+
+	// TriggersRemoved contains table-qualified trigger refs that exist in the current database
+	// but not in the target schema.
+	TriggersRemoved []TriggerRef `json:"triggers_removed"`
+
+	// TriggersModified contains detailed information about changed triggers.
+	TriggersModified []TriggerDiff `json:"triggers_modified"`
+
 	// RLSPoliciesAdded contains names of RLS policies that exist in the target schema
 	// but not in the current database schema
 	RLSPoliciesAdded []string `json:"rls_policies_added"`
@@ -252,6 +285,9 @@ func (d *SchemaDiff) HasChanges() bool {
 		d.hasIndexChanges() ||
 		d.hasExtensionChanges() ||
 		d.hasFunctionChanges() ||
+		d.hasViewChanges() ||
+		d.hasMaterializedViewChanges() ||
+		d.hasTriggerChanges() ||
 		d.hasRLSChanges() ||
 		d.hasRoleChanges() ||
 		d.hasConstraintChanges()
@@ -288,6 +324,24 @@ func (d *SchemaDiff) hasFunctionChanges() bool {
 	return len(d.FunctionsAdded) > 0 ||
 		len(d.FunctionsRemoved) > 0 ||
 		len(d.FunctionsModified) > 0
+}
+
+func (d *SchemaDiff) hasViewChanges() bool {
+	return len(d.ViewsAdded) > 0 ||
+		len(d.ViewsRemoved) > 0 ||
+		len(d.ViewsModified) > 0
+}
+
+func (d *SchemaDiff) hasMaterializedViewChanges() bool {
+	return len(d.MaterializedViewsAdded) > 0 ||
+		len(d.MaterializedViewsRemoved) > 0 ||
+		len(d.MaterializedViewsModified) > 0
+}
+
+func (d *SchemaDiff) hasTriggerChanges() bool {
+	return len(d.TriggersAdded) > 0 ||
+		len(d.TriggersRemoved) > 0 ||
+		len(d.TriggersModified) > 0
 }
 
 // hasRLSChanges returns true if there are any RLS-related changes
@@ -450,6 +504,31 @@ type FunctionDiff struct {
 	// Changes maps change types to their old->new value transitions
 	// Format: "change_type" -> "old_value -> new_value"
 	Changes map[string]string `json:"changes"`
+}
+
+// ViewDiff represents changes to a view definition.
+type ViewDiff struct {
+	ViewName string            `json:"view_name"`
+	Changes  map[string]string `json:"changes"`
+}
+
+// MaterializedViewDiff represents changes to a materialized view definition.
+type MaterializedViewDiff struct {
+	ViewName string            `json:"view_name"`
+	Changes  map[string]string `json:"changes"`
+}
+
+// TriggerRef identifies a trigger by table and trigger name.
+type TriggerRef struct {
+	TriggerName string `json:"trigger_name"`
+	TableName   string `json:"table_name"`
+}
+
+// TriggerDiff represents changes to a trigger definition.
+type TriggerDiff struct {
+	TriggerName string            `json:"trigger_name"`
+	TableName   string            `json:"table_name"`
+	Changes     map[string]string `json:"changes"`
 }
 
 // RLSPolicyRef represents a reference to an RLS policy with its table information.


### PR DESCRIPTION
## Summary

Closes #158.

Adds first-class schema object support for:
- views
- PostgreSQL materialized views
- PostgreSQL/MySQL/MariaDB triggers

This wires the feature through Go annotations, YAML schema input, goschema/dbschema models, AST nodes, renderers, database readers, schema diff, planners, and docs.

## Notes from self-review

- PostgreSQL trigger helper functions are table-scoped and sanitized to avoid collisions for same-named triggers on different tables.
- MySQL/MariaDB triggers are included in full-schema conversion, not just renderer tests.
- MySQL/MariaDB materialized views now fail during planning instead of producing comment-only migrations that can never converge.
- PostgreSQL integration coverage exercises create, introspect, empty diff, body-change diff, apply replacement SQL, and removal SQL.

## Validation

- 0 issues.
- 0 issues.
- ?   	github.com/stokaro/ptah/cmd	[no test files]
?   	github.com/stokaro/ptah/cmd/compare	[no test files]
ok  	github.com/stokaro/ptah/cmd/drift	0.451s
?   	github.com/stokaro/ptah/cmd/dropall	[no test files]
ok  	github.com/stokaro/ptah/cmd/generate	0.624s
ok  	github.com/stokaro/ptah/cmd/integration-test	0.537s
?   	github.com/stokaro/ptah/cmd/internal/cmdutil	[no test files]
ok  	github.com/stokaro/ptah/cmd/internal/dbcli	1.133s
ok  	github.com/stokaro/ptah/cmd/internal/exitcode	(cached)
ok  	github.com/stokaro/ptah/cmd/internal/schemaops	0.822s
ok  	github.com/stokaro/ptah/cmd/lint	1.425s
ok  	github.com/stokaro/ptah/cmd/migrate	1.754s
ok  	github.com/stokaro/ptah/cmd/migratedown	2.052s
ok  	github.com/stokaro/ptah/cmd/migratehash	2.288s
ok  	github.com/stokaro/ptah/cmd/migratestatus	2.572s
ok  	github.com/stokaro/ptah/cmd/migrateup	2.795s
ok  	github.com/stokaro/ptah/cmd/migratevalidate	2.827s
?   	github.com/stokaro/ptah/cmd/packagemigrator	[no test files]
?   	github.com/stokaro/ptah/cmd/readdb	[no test files]
ok  	github.com/stokaro/ptah/cmd/seed	2.978s
ok  	github.com/stokaro/ptah/config	(cached)
ok  	github.com/stokaro/ptah/core/ast	3.070s
?   	github.com/stokaro/ptah/core/ast/mocks	[no test files]
ok  	github.com/stokaro/ptah/core/astbuilder	3.275s
ok  	github.com/stokaro/ptah/core/convert/dbschematogo	3.370s
ok  	github.com/stokaro/ptah/core/convert/fromschema	3.334s
ok  	github.com/stokaro/ptah/core/convert/toschema	3.163s
ok  	github.com/stokaro/ptah/core/goschema	2.985s
?   	github.com/stokaro/ptah/core/goschema/internal/parseutils	[no test files]
?   	github.com/stokaro/ptah/core/goschema/testutil	[no test files]
ok  	github.com/stokaro/ptah/core/lexer	(cached)
ok  	github.com/stokaro/ptah/core/parser	2.843s
ok  	github.com/stokaro/ptah/core/platform	(cached)
ok  	github.com/stokaro/ptah/core/platform/capability	(cached)
ok  	github.com/stokaro/ptah/core/renderer	2.743s
ok  	github.com/stokaro/ptah/core/renderer/dialects/clickhouse	2.753s
?   	github.com/stokaro/ptah/core/renderer/dialects/internal/bufwriter	[no test files]
?   	github.com/stokaro/ptah/core/renderer/dialects/mariadb	[no test files]
ok  	github.com/stokaro/ptah/core/renderer/dialects/mysql	2.801s
?   	github.com/stokaro/ptah/core/renderer/dialects/mysqllike	[no test files]
ok  	github.com/stokaro/ptah/core/renderer/dialects/postgres	2.773s
?   	github.com/stokaro/ptah/core/renderer/types	[no test files]
ok  	github.com/stokaro/ptah/core/sqlutil	(cached)
ok  	github.com/stokaro/ptah/core/yamlschema	2.715s
ok  	github.com/stokaro/ptah/dbschema	2.257s
ok  	github.com/stokaro/ptah/dbschema/clickhouse	(cached)
ok  	github.com/stokaro/ptah/dbschema/mysql	2.136s
ok  	github.com/stokaro/ptah/dbschema/postgres	2.097s
?   	github.com/stokaro/ptah/dbschema/types	[no test files]
?   	github.com/stokaro/ptah/examples/ast_demo	[no test files]
?   	github.com/stokaro/ptah/examples/extension_ignore	[no test files]
?   	github.com/stokaro/ptah/examples/migrator	[no test files]
?   	github.com/stokaro/ptah/examples/migrator_parser	[no test files]
?   	github.com/stokaro/ptah/examples/migrator_parser/models	[no test files]
?   	github.com/stokaro/ptah/examples/mysql_demo	[no test files]
?   	github.com/stokaro/ptah/examples/parser_demo	[no test files]
?   	github.com/stokaro/ptah/examples/postgresql_demo	[no test files]
ok  	github.com/stokaro/ptah/integration	1.978s
?   	github.com/stokaro/ptah/integration/fixtures/entities/000-initial	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/001-add-fields	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/002-add-posts	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/003-add-enums	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/004-field-rename	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/005-field-type-change	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/006-field-drop	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/007-index-add	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/008-index-remove	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/009-add-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/010-drop-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/011-add-entity	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/012-drop-entity	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/013-embedded-fields	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/014-rls-functions	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/015-rls-advanced	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/016-rls-multiple-files	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/016-roles	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/017-rls-inventario-reproduction	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/017-roles-advanced	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/018-rls-functions-modified	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/019-field-check-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/020-field-check-constraints-modified	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/021-fk-actions-initial	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/022-fk-actions-changed	[no test files]
ok  	github.com/stokaro/ptah/integration/gonative	1.997s
?   	github.com/stokaro/ptah/internal/testutils	[no test files]
ok  	github.com/stokaro/ptah/migration/generator	2.227s
?   	github.com/stokaro/ptah/migration/generator/example	[no test files]
ok  	github.com/stokaro/ptah/migration/lint	2.402s
ok  	github.com/stokaro/ptah/migration/migratesum	2.585s
ok  	github.com/stokaro/ptah/migration/migrator	2.462s
ok  	github.com/stokaro/ptah/migration/onlineddl	4.383s
ok  	github.com/stokaro/ptah/migration/planner	2.483s
ok  	github.com/stokaro/ptah/migration/planner/dialects/clickhouse	2.474s
ok  	github.com/stokaro/ptah/migration/planner/dialects/mysql	2.414s
ok  	github.com/stokaro/ptah/migration/planner/dialects/postgres	2.348s
ok  	github.com/stokaro/ptah/migration/safety	2.239s
ok  	github.com/stokaro/ptah/migration/schemadiff	2.261s
ok  	github.com/stokaro/ptah/migration/schemadiff/internal/compare	2.067s
ok  	github.com/stokaro/ptah/migration/schemadiff/internal/normalize	(cached)
ok  	github.com/stokaro/ptah/migration/schemadiff/types	2.104s
ok  	github.com/stokaro/ptah/migration/seeder	1.978s
?   	github.com/stokaro/ptah/migration/typechange	[no test files]
?   	github.com/stokaro/ptah/stubs	[no test files]
- ok  	github.com/stokaro/ptah/integration/gonative	0.424s
- 
- 
- Live PostgreSQL 18 Docker run: === RUN   TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration
    schema_objects_integration_test.go:22: Skipping PostgreSQL tests: failed to connect to database: failed to connect to `user=postgres database=ptah`: 127.0.0.1:32770 (127.0.0.1): dial error: dial tcp 127.0.0.1:32770: connect: connection refused
--- SKIP: TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration (0.01s)
PASS
ok  	github.com/stokaro/ptah/integration/gonative	0.347s
