### PR TITLE
Fix schema object post-merge review issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ type User struct {
 }
 ```
 
-Views are supported on PostgreSQL, MySQL, and MariaDB. Materialized views are PostgreSQL-only. Trigger bodies are dialect-specific: PostgreSQL trigger annotations provide the function body that returns `NEW`/`OLD`, while MySQL/MariaDB trigger bodies are emitted inline.
+Views are supported on PostgreSQL, MySQL, and MariaDB. Materialized views are PostgreSQL-only; `refresh_strategy` is authoring metadata for future refresh workflows and is not drift-compared because PostgreSQL does not persist that policy in the catalog. Trigger bodies are dialect-specific: PostgreSQL trigger annotations provide the function body that returns `NEW`/`OLD`, while MySQL/MariaDB trigger bodies are emitted inline.
 
 ### Row-Level Security (PostgreSQL only)
 ```go

--- a/core/sqlutil/splitter.go
+++ b/core/sqlutil/splitter.go
@@ -43,6 +43,7 @@ func SplitSQLStatements(sql string) []string {
 	lexr := lexer.NewLexer(sql)
 	var statements []string
 	var currentStatement strings.Builder
+	var state statementSplitState
 
 	for {
 		token := lexr.NextToken()
@@ -52,13 +53,20 @@ func SplitSQLStatements(sql string) []string {
 		}
 
 		if token.Type == lexer.TokenSemicolon {
+			if state.keepSemicolonInsideStatement() {
+				currentStatement.WriteString(token.Value)
+				continue
+			}
+
 			// Found a statement terminator - add current statement if not empty
 			stmt := strings.TrimSpace(currentStatement.String())
 			if stmt != "" {
 				statements = append(statements, stmt)
 			}
 			currentStatement.Reset()
+			state.reset()
 		} else {
+			state.observe(token)
 			// Add token to current statement
 			currentStatement.WriteString(token.Value)
 		}
@@ -76,4 +84,56 @@ func SplitSQLStatements(sql string) []string {
 	}
 
 	return statements
+}
+
+type statementSplitState struct {
+	afterCreate       bool
+	inCreateTrigger   bool
+	triggerCompound   bool
+	pendingTriggerEnd bool
+}
+
+func (s *statementSplitState) reset() {
+	*s = statementSplitState{}
+}
+
+func (s *statementSplitState) observe(token lexer.Token) {
+	if token.Type != lexer.TokenIdentifier {
+		return
+	}
+
+	value := strings.ToUpper(token.Value)
+	if !s.inCreateTrigger {
+		s.observeCreateTriggerPrefix(value)
+		return
+	}
+
+	if !s.triggerCompound {
+		s.triggerCompound = value == "BEGIN"
+		return
+	}
+
+	switch value {
+	case "END":
+		s.pendingTriggerEnd = true
+	default:
+		if s.pendingTriggerEnd {
+			s.pendingTriggerEnd = false
+		}
+	}
+}
+
+func (s *statementSplitState) observeCreateTriggerPrefix(value string) {
+	if value == "CREATE" {
+		s.afterCreate = true
+		return
+	}
+	if s.afterCreate && value == "TRIGGER" {
+		s.inCreateTrigger = true
+		return
+	}
+}
+
+func (s statementSplitState) keepSemicolonInsideStatement() bool {
+	return s.inCreateTrigger && s.triggerCompound && !s.pendingTriggerEnd
 }

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -160,6 +160,66 @@ func TestSplitSQLStatements_PostgreSQLDollarQuoted(t *testing.T) {
 	}
 }
 
+func TestSplitSQLStatements_MySQLCompoundTrigger(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name: "trigger compound body",
+			input: `DROP TRIGGER IF EXISTS set_updated_at;
+CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW BEGIN
+  SET NEW.updated_at = NOW();
+  SET NEW.name = TRIM(NEW.name);
+END;
+CREATE VIEW active_users AS SELECT id FROM users;`,
+			expected: []string{
+				"DROP TRIGGER IF EXISTS set_updated_at",
+				`CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW BEGIN
+  SET NEW.updated_at = NOW();
+  SET NEW.name = TRIM(NEW.name);
+END`,
+				"CREATE VIEW active_users AS SELECT id FROM users",
+			},
+		},
+		{
+			name: "trigger compound body with nested if",
+			input: `CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW BEGIN
+  IF NEW.name <> OLD.name THEN
+    SET NEW.updated_at = NOW();
+  END IF;
+  SET NEW.touched = 1;
+END;`,
+			expected: []string{
+				`CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW BEGIN
+  IF NEW.name <> OLD.name THEN
+    SET NEW.updated_at = NOW();
+  END IF;
+  SET NEW.touched = 1;
+END`,
+			},
+		},
+		{
+			name:  "transaction begin still splits normally",
+			input: "BEGIN; INSERT INTO users (id) VALUES (1); COMMIT;",
+			expected: []string{
+				"BEGIN",
+				"INSERT INTO users (id) VALUES (1)",
+				"COMMIT",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := sqlutil.SplitSQLStatements(tt.input)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
 func TestSplitSQLStatements_Comments(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/docs/yaml_schema.md
+++ b/docs/yaml_schema.md
@@ -247,6 +247,10 @@ rendered for MySQL/MariaDB with dialect-specific trigger bodies.
 - `roles`: `name`, `login`, `password`, `superuser`, `create_db`,
   `create_role`, `inherit`, `replication`, `comment`
 
+`matviews.refresh_strategy` is retained as authoring metadata for future
+refresh workflows. It is not drift-compared because PostgreSQL does not persist
+that policy in `pg_class`/`information_schema`.
+
 ## Validation
 
 The parser is intentionally strict:

--- a/migration/planner/dialects/mysql/schema_objects_test.go
+++ b/migration/planner/dialects/mysql/schema_objects_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
+	migrationplanner "github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -39,6 +40,36 @@ func TestPlanner_GenerateMigrationAST_ViewsAndTriggersModified(t *testing.T) {
 	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users")
 	c.Assert(sql, qt.Contains, "DROP TRIGGER IF EXISTS set_updated_at;")
 	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW SET NEW.updated_at = NOW();")
+}
+
+func TestPlanner_GenerateSchemaDiffSQLStatements_CompoundTriggerBody(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Triggers: []goschema.Trigger{{
+			Name:   "set_updated_at",
+			Table:  "users",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "BEGIN SET NEW.updated_at = NOW(); SET NEW.name = TRIM(NEW.name); END",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		TriggersModified: []difftypes.TriggerDiff{{
+			TriggerName: "set_updated_at",
+			TableName:   "users",
+			Changes:     map[string]string{"body": "old -> new"},
+		}},
+	}
+
+	statements := migrationplanner.GenerateSchemaDiffSQLStatements(diff, generated, "mysql")
+
+	c.Assert(statements, qt.HasLen, 2)
+	c.Assert(statements[0], qt.Equals, "DROP TRIGGER IF EXISTS set_updated_at")
+	c.Assert(statements[1], qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW BEGIN")
+	c.Assert(statements[1], qt.Contains, "SET NEW.updated_at = NOW();")
+	c.Assert(statements[1], qt.Contains, "SET NEW.name = TRIM(NEW.name);")
+	c.Assert(statements[1], qt.Contains, "END")
 }
 
 func TestPlanner_GenerateMigrationAST_RejectsMaterializedViews(t *testing.T) {

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1108,9 +1108,6 @@ func (p *Planner) addNewMaterializedViews(result []ast.Node, diff *types.SchemaD
 	for _, viewName := range diff.MaterializedViewsAdded {
 		if view := findMaterializedView(generated.MaterializedViews, viewName); view != nil {
 			result = append(result, fromschema.FromMaterializedView(*view))
-			if strings.EqualFold(view.RefreshStrategy, "concurrently") {
-				result = append(result, ast.NewRefreshMaterializedView(view.Name).SetConcurrently())
-			}
 		}
 	}
 	return result

--- a/migration/planner/dialects/postgres/schema_objects_test.go
+++ b/migration/planner/dialects/postgres/schema_objects_test.go
@@ -84,3 +84,25 @@ func TestPlanner_GenerateMigrationAST_DuplicateTriggerNamesUseDistinctFunctions(
 	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION ptah_trigger_users_set_updated_at();")
 	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON posts FOR EACH ROW EXECUTE FUNCTION ptah_trigger_posts_set_updated_at();")
 }
+
+func TestPlanner_GenerateMigrationAST_MaterializedViewRefreshStrategyDoesNotAutoRefresh(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name:            "user_stats",
+			Body:            "SELECT id, COUNT(*) FROM users GROUP BY id",
+			RefreshStrategy: "concurrently",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		MaterializedViewsAdded: []string{"user_stats"},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW user_stats AS")
+	c.Assert(sql, qt.Not(qt.Contains), "REFRESH MATERIALIZED VIEW CONCURRENTLY")
+}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -29,6 +29,7 @@ var (
 	customIndexPattern = regexp.MustCompile(`(?i)(^(idx|index)_|_(idx|index)$)`)
 
 	defaultAggregateAliasPattern = regexp.MustCompile(`\b(count|sum|avg|min|max)\(([^)]*)\)\s+as\s+([a-z_][a-z0-9_]*)\b`)
+	schemaQualifierPattern       = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`)
 )
 
 // TablesAndColumns performs comprehensive table and column comparison between generated and database schemas.
@@ -2755,9 +2756,7 @@ func ViewDefinitions(genView goschema.View, dbView types.DBView) difftypes.ViewD
 		Changes:  make(map[string]string),
 	}
 
-	genBody := normalizeSchemaObjectBody(genView.Body)
-	dbBody := normalizeSchemaObjectBody(dbView.Body)
-	if genBody != dbBody {
+	if !schemaObjectBodiesEqual(genView.Body, dbView.Body) {
 		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
 	}
 
@@ -2772,24 +2771,13 @@ func ViewDefinitions(genView goschema.View, dbView types.DBView) difftypes.ViewD
 // MaterializedViewDefinitions performs detailed comparison between generated
 // and database materialized view definitions.
 func MaterializedViewDefinitions(genView goschema.MaterializedView, dbView types.DBMatView) difftypes.MaterializedViewDiff {
-	genView.Canonicalize()
-	if dbView.RefreshStrategy == "" {
-		dbView.RefreshStrategy = "manual"
-	}
-	dbView.RefreshStrategy = strings.ToLower(strings.TrimSpace(dbView.RefreshStrategy))
-
 	viewDiff := difftypes.MaterializedViewDiff{
 		ViewName: genView.Name,
 		Changes:  make(map[string]string),
 	}
 
-	genBody := normalizeSchemaObjectBody(genView.Body)
-	dbBody := normalizeSchemaObjectBody(dbView.Body)
-	if genBody != dbBody {
+	if !schemaObjectBodiesEqual(genView.Body, dbView.Body) {
 		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
-	}
-	if genView.RefreshStrategy != dbView.RefreshStrategy {
-		viewDiff.Changes["refresh_strategy"] = fmt.Sprintf("%s -> %s", dbView.RefreshStrategy, genView.RefreshStrategy)
 	}
 
 	return viewDiff
@@ -2828,7 +2816,38 @@ func TriggerDefinitions(genTrigger goschema.Trigger, dbTrigger types.DBTrigger) 
 	return triggerDiff
 }
 
-func normalizeSchemaObjectBody(body string) string {
+func schemaObjectBodiesEqual(generatedBody, databaseBody string) bool {
+	if normalizeSQLBodyPreservingQualifiers(generatedBody) == normalizeSQLBodyPreservingQualifiers(databaseBody) {
+		return true
+	}
+
+	if schemaQualifierPattern.MatchString(strings.ToLower(generatedBody)) {
+		return false
+	}
+	return normalizeSQLBodyPreservingQualifiers(generatedBody) == normalizeSQLBodyStrippingQualifiers(databaseBody)
+}
+
+func normalizeTriggerBody(body string) string {
+	body = normalizeSQLBodyPreservingQualifiers(body)
+	body = strings.TrimPrefix(body, "begin ")
+	body = strings.TrimPrefix(body, "begin")
+	body = strings.TrimSpace(body)
+	body = strings.TrimSuffix(body, " end")
+	body = strings.TrimSuffix(body, "end")
+	body = strings.TrimSpace(body)
+	body = strings.TrimSuffix(body, ";")
+	return strings.TrimSpace(body)
+}
+
+func normalizeSQLBodyPreservingQualifiers(body string) string {
+	return normalizeSQLBody(body)
+}
+
+func normalizeSQLBodyStrippingQualifiers(body string) string {
+	return schemaQualifierPattern.ReplaceAllString(normalizeSQLBody(body), "")
+}
+
+func normalizeSQLBody(body string) string {
 	body = strings.TrimSpace(body)
 	body = strings.TrimSuffix(body, ";")
 	body = strings.TrimSpace(body)
@@ -2836,7 +2855,6 @@ func normalizeSchemaObjectBody(body string) string {
 	body = strings.ReplaceAll(body, "`", "")
 	body = strings.ToLower(body)
 	body = stripDefaultAggregateAliases(body)
-	body = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`).ReplaceAllString(body, "")
 	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
 	return strings.TrimSpace(body)
 }
@@ -2849,18 +2867,6 @@ func stripDefaultAggregateAliases(body string) string {
 		}
 		return parts[1] + "(" + parts[2] + ")"
 	})
-}
-
-func normalizeTriggerBody(body string) string {
-	body = normalizeSchemaObjectBody(body)
-	body = strings.TrimPrefix(body, "begin ")
-	body = strings.TrimPrefix(body, "begin")
-	body = strings.TrimSpace(body)
-	body = strings.TrimSuffix(body, " end")
-	body = strings.TrimSuffix(body, "end")
-	body = strings.TrimSpace(body)
-	body = strings.TrimSuffix(body, ";")
-	return strings.TrimSpace(body)
 }
 
 // RLSPolicyDefinitions performs detailed comparison between generated and database RLS policy definitions.

--- a/migration/schemadiff/internal/compare/compare_schema_objects_test.go
+++ b/migration/schemadiff/internal/compare/compare_schema_objects_test.go
@@ -25,7 +25,34 @@ func TestViews_DetectsBodyChange(t *testing.T) {
 	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
 }
 
-func TestMaterializedViews_DetectsBodyAndRefreshStrategyChange(t *testing.T) {
+func TestViews_IgnoresDatabaseOnlyQualification(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "active_users", Body: "SELECT id FROM users WHERE deleted_at IS NULL"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{Name: "active_users", Body: "SELECT users.id FROM users WHERE users.deleted_at IS NULL"}},
+	}, diff)
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 0)
+}
+
+func TestViews_DetectsExplicitQualifierChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "active_users", Body: "SELECT users.id FROM users JOIN posts ON posts.user_id = users.id"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{Name: "active_users", Body: "SELECT posts.id FROM users JOIN posts ON posts.user_id = users.id"}},
+	}, diff)
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestMaterializedViews_DetectsBodyChange(t *testing.T) {
 	c := qt.New(t)
 	diff := &difftypes.SchemaDiff{}
 
@@ -45,7 +72,28 @@ func TestMaterializedViews_DetectsBodyAndRefreshStrategyChange(t *testing.T) {
 
 	c.Assert(diff.MaterializedViewsModified, qt.HasLen, 1)
 	c.Assert(diff.MaterializedViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
-	c.Assert(diff.MaterializedViewsModified[0].Changes["refresh_strategy"], qt.Equals, "manual -> concurrently")
+	c.Assert(diff.MaterializedViewsModified[0].Changes["refresh_strategy"], qt.Equals, "")
+}
+
+func TestMaterializedViews_IgnoresRefreshStrategyDrift(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.MaterializedViews(&goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name:            "user_stats",
+			Body:            "SELECT id, COUNT(*) FROM users GROUP BY id",
+			RefreshStrategy: "concurrently",
+		}},
+	}, &dbschematypes.DBSchema{
+		MatViews: []dbschematypes.DBMatView{{
+			Name:            "user_stats",
+			Body:            "SELECT id, COUNT(*) FROM users GROUP BY id",
+			RefreshStrategy: "manual",
+		}},
+	}, diff)
+
+	c.Assert(diff.MaterializedViewsModified, qt.HasLen, 0)
 }
 
 func TestMaterializedViews_IgnoresPostgreSQLDefaultAggregateAlias(t *testing.T) {
@@ -93,5 +141,33 @@ func TestTriggers_KeyedByTableAndDetectsBodyChange(t *testing.T) {
 
 	c.Assert(diff.TriggersModified, qt.HasLen, 1)
 	c.Assert(diff.TriggersModified[0].TableName, qt.Equals, "users")
+	c.Assert(diff.TriggersModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestTriggers_DetectsNewOldQualifierChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Triggers(&goschema.Database{
+		Triggers: []goschema.Trigger{{
+			Name:    "set_updated_at",
+			Table:   "users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "NEW.updated_at = NOW(); RETURN NEW;",
+		}},
+	}, &dbschematypes.DBSchema{
+		Triggers: []dbschematypes.DBTrigger{{
+			Name:    "set_updated_at",
+			Table:   "users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "BEGIN OLD.updated_at = NOW(); RETURN OLD; END;",
+		}},
+	}, diff)
+
+	c.Assert(diff.TriggersModified, qt.HasLen, 1)
 	c.Assert(diff.TriggersModified[0].Changes["body"], qt.Not(qt.Equals), "")
 }


### PR DESCRIPTION
## Summary

Follow-up from post-merge self-review of #257.

Fixes three correctness/convergence issues:
- Preserve MySQL/MariaDB compound trigger bodies as one executable SQL statement when splitting rendered migrations.
- Preserve `NEW.`/`OLD.` trigger qualifiers and explicit view qualifiers during schema-object diff normalization so meaningful body changes are not hidden.
- Treat materialized-view `refresh_strategy` as authoring metadata, not database drift, and stop auto-emitting `REFRESH MATERIALIZED VIEW CONCURRENTLY` after creation.

## Validation

- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go test -tags integration ./integration/gonative`
- `go tool qtlint ./...`
- `git diff --check`
- Live PostgreSQL 18 schema-object integration test against Docker
- Live MySQL 9.7 view + compound trigger smoke against Docker
- Live MariaDB 10.11 view + `CREATE OR REPLACE TRIGGER` compound trigger smoke against Docker
