### PR TITLE
Add PostgreSQL grants support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ capabilities include:
 - 🧱 **Schema Generation (DDL)**
   Builds platform-specific `CREATE TABLE`, `CREATE INDEX`, and other DDL statements.
 
-- 🔐 **Row-Level Security (PostgreSQL)**
-  Supports PostgreSQL RLS policies and custom functions for multi-tenant data isolation.
+- 🔐 **Row-Level Security And Access Control (PostgreSQL)**
+  Supports PostgreSQL RLS policies, roles, grants, and custom functions for multi-tenant data isolation.
 
 - 🔍 **Database Introspection**
   Reads the current schema directly from PostgreSQL, MySQL, MariaDB, or ClickHouse for comparison and analysis.
@@ -347,6 +347,25 @@ type User struct {
 - `using` - USING clause expression for row filtering
 - `with_check` - WITH CHECK clause expression for INSERT/UPDATE validation
 - `comment` - Policy description
+
+#### Role Attributes (PostgreSQL only)
+- `name` - Role name
+- `login` - Whether the role can login
+- `password` - Encrypted password hash
+- `superuser` - Whether the role has superuser privileges
+- `createdb` or `create_db` - Whether the role can create databases
+- `createrole` or `create_role` - Whether the role can create roles
+- `inherit` - Whether the role inherits privileges
+- `replication` - Whether the role can initiate replication
+- `comment` - Role description
+
+#### Grant Attributes (PostgreSQL only)
+- `role` - Role receiving the privilege
+- `privilege` or `privileges` - One privilege or a comma-separated list such as `SELECT,INSERT,UPDATE,DELETE`
+- `on_table` - Target table for table privileges
+- `on_schema` - Target schema for schema privileges such as `USAGE`
+- `with_option` - Whether to emit `WITH GRANT OPTION`
+- `comment` - Grant description
 
 #### Constraint Attributes
 - `name` - Constraint name
@@ -1229,6 +1248,13 @@ package main
 //migrator:schema:function name="set_tenant_context" params="tenant_id_param TEXT" returns="VOID" language="plpgsql" security="DEFINER" body="BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;" comment="Sets the current tenant context for RLS"
 //migrator:schema:function name="get_current_tenant_id" returns="TEXT" language="plpgsql" volatility="STABLE" body="BEGIN RETURN current_setting('app.current_tenant_id', true); END;" comment="Gets the current tenant ID from session"
 
+// Define the application role and the privileges it needs.
+//migrator:schema:role name="app_role" inherit="true" comment="Application runtime role"
+//migrator:schema:grant role="app_role" privilege="USAGE" on_schema="public" comment="Allow app role to resolve public schema objects"
+//migrator:schema:grant role="app_role" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users" comment="Allow app role to use tenant-scoped users"
+//migrator:schema:grant role="app_role" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="products" comment="Allow app role to use tenant-scoped products"
+type AccessControl struct{}
+
 // Enable RLS and create policies for users table
 //migrator:schema:rls:enable table="users" comment="Enable RLS for multi-tenant isolation"
 //migrator:schema:rls:policy name="user_tenant_isolation" table="users" for="ALL" to="app_role" using="tenant_id = get_current_tenant_id()" comment="Ensures users can only access their tenant's data"
@@ -1269,6 +1295,12 @@ type Product struct {
 This generates the following PostgreSQL SQL:
 
 ```sql
+-- Create the runtime role and grant object privileges
+CREATE ROLE app_role WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
+GRANT USAGE ON SCHEMA public TO app_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO app_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE products TO app_role;
+
 -- Create helper functions
 CREATE OR REPLACE FUNCTION set_tenant_context(tenant_id_param TEXT) RETURNS VOID AS $$
 BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;
@@ -1291,7 +1323,7 @@ CREATE POLICY product_tenant_isolation ON products FOR ALL TO app_role
     WITH CHECK (tenant_id = get_current_tenant_id());
 ```
 
-**Note:** RLS and custom functions are PostgreSQL-specific features. For other databases, these annotations are ignored during SQL generation.
+**Note:** RLS, roles, grants, and custom functions are PostgreSQL-specific features. For other databases, these annotations are ignored during SQL generation.
 
 ### EXCLUDE Constraints (PostgreSQL)
 

--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -70,6 +70,10 @@ type Visitor interface {
 	VisitDropRole(*DropRoleNode) error
 	// VisitAlterRole renders an ALTER ROLE statement (PostgreSQL-specific)
 	VisitAlterRole(*AlterRoleNode) error
+	// VisitGrantPrivilege renders a GRANT statement (PostgreSQL-specific)
+	VisitGrantPrivilege(*GrantPrivilegeNode) error
+	// VisitRevokePrivilege renders a REVOKE statement (PostgreSQL-specific)
+	VisitRevokePrivilege(*RevokePrivilegeNode) error
 	// VisitRawSQL renders a literal SQL fragment verbatim. Use sparingly —
 	// reach for structured nodes first.
 	VisitRawSQL(*RawSQLNode) error

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -252,6 +252,22 @@ func (m *MockVisitor) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return nil
 }
 
+func (m *MockVisitor) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "GrantPrivilege:"+node.Role)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "RevokePrivilege:"+node.Role)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
 func (m *MockVisitor) VisitRawSQL(node *ast.RawSQLNode) error {
 	m.VisitedNodes = append(m.VisitedNodes, "RawSQL:"+node.SQL)
 	if m.ReturnError {

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1805,6 +1805,92 @@ func (n *AlterRoleNode) Accept(visitor Visitor) error {
 	return visitor.VisitAlterRole(n)
 }
 
+// GrantPrivilegeNode represents a PostgreSQL GRANT statement.
+type GrantPrivilegeNode struct {
+	// Role is the role receiving the privilege.
+	Role string
+	// Privileges contains one or more privileges, e.g. SELECT, INSERT, USAGE.
+	Privileges []string
+	// ObjectType is the target kind, currently TABLE or SCHEMA.
+	ObjectType string
+	// ObjectName is the target table or schema name.
+	ObjectName string
+	// WithOption controls WITH GRANT OPTION.
+	WithOption bool
+	// Comment is an optional comment for the grant operation.
+	Comment string
+}
+
+// NewGrantPrivilege creates a new GRANT node.
+func NewGrantPrivilege(role, objectType, objectName string, privileges []string) *GrantPrivilegeNode {
+	return &GrantPrivilegeNode{
+		Role:       role,
+		Privileges: privileges,
+		ObjectType: objectType,
+		ObjectName: objectName,
+	}
+}
+
+// SetWithOption enables or disables WITH GRANT OPTION.
+func (n *GrantPrivilegeNode) SetWithOption(withOption bool) *GrantPrivilegeNode {
+	n.WithOption = withOption
+	return n
+}
+
+// SetComment sets a comment for the GRANT operation.
+func (n *GrantPrivilegeNode) SetComment(comment string) *GrantPrivilegeNode {
+	n.Comment = comment
+	return n
+}
+
+// Accept implements the Node interface for GrantPrivilegeNode.
+func (n *GrantPrivilegeNode) Accept(visitor Visitor) error {
+	return visitor.VisitGrantPrivilege(n)
+}
+
+// RevokePrivilegeNode represents a PostgreSQL REVOKE statement.
+type RevokePrivilegeNode struct {
+	// Role is the role losing the privilege.
+	Role string
+	// Privileges contains one or more privileges, e.g. SELECT, INSERT, USAGE.
+	Privileges []string
+	// ObjectType is the target kind, currently TABLE or SCHEMA.
+	ObjectType string
+	// ObjectName is the target table or schema name.
+	ObjectName string
+	// GrantOptionFor controls REVOKE GRANT OPTION FOR.
+	GrantOptionFor bool
+	// Comment is an optional comment for the revoke operation.
+	Comment string
+}
+
+// NewRevokePrivilege creates a new REVOKE node.
+func NewRevokePrivilege(role, objectType, objectName string, privileges []string) *RevokePrivilegeNode {
+	return &RevokePrivilegeNode{
+		Role:       role,
+		Privileges: privileges,
+		ObjectType: objectType,
+		ObjectName: objectName,
+	}
+}
+
+// SetGrantOptionFor enables or disables REVOKE GRANT OPTION FOR.
+func (n *RevokePrivilegeNode) SetGrantOptionFor(grantOptionFor bool) *RevokePrivilegeNode {
+	n.GrantOptionFor = grantOptionFor
+	return n
+}
+
+// SetComment sets a comment for the REVOKE operation.
+func (n *RevokePrivilegeNode) SetComment(comment string) *RevokePrivilegeNode {
+	n.Comment = comment
+	return n
+}
+
+// Accept implements the Node interface for RevokePrivilegeNode.
+func (n *RevokePrivilegeNode) Accept(visitor Visitor) error {
+	return visitor.VisitRevokePrivilege(n)
+}
+
 // RoleOperation represents an operation that can be performed on a role during ALTER ROLE.
 //
 // This interface allows for different types of role modifications to be represented

--- a/core/ast/nodes_role_test.go
+++ b/core/ast/nodes_role_test.go
@@ -164,6 +164,82 @@ func TestAlterRoleNode(t *testing.T) {
 	})
 }
 
+func TestGrantPrivilegeNode(t *testing.T) {
+	t.Run("fluent API methods work correctly", func(t *testing.T) {
+		c := qt.New(t)
+		grant := ast.NewGrantPrivilege("app_role", "TABLE", "users", []string{"SELECT"}).
+			SetWithOption(true).
+			SetComment("Grant read access")
+
+		c.Assert(grant.Role, qt.Equals, "app_role")
+		c.Assert(grant.ObjectType, qt.Equals, "TABLE")
+		c.Assert(grant.ObjectName, qt.Equals, "users")
+		c.Assert(grant.Privileges, qt.DeepEquals, []string{"SELECT"})
+		c.Assert(grant.WithOption, qt.IsTrue)
+		c.Assert(grant.Comment, qt.Equals, "Grant read access")
+	})
+
+	t.Run("Accept calls visitor correctly", func(t *testing.T) {
+		c := qt.New(t)
+		grant := ast.NewGrantPrivilege("app_role", "TABLE", "users", []string{"SELECT"})
+		visitor := &mocks.MockVisitor{}
+
+		err := grant.Accept(visitor)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(visitor.VisitedNodes, qt.Contains, "GrantPrivilege:app_role")
+	})
+
+	t.Run("Accept propagates visitor errors", func(t *testing.T) {
+		c := qt.New(t)
+		grant := ast.NewGrantPrivilege("app_role", "TABLE", "users", []string{"SELECT"})
+		visitor := &mocks.MockVisitor{ReturnError: true}
+
+		err := grant.Accept(visitor)
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "mock error")
+	})
+}
+
+func TestRevokePrivilegeNode(t *testing.T) {
+	t.Run("fluent API methods work correctly", func(t *testing.T) {
+		c := qt.New(t)
+		revoke := ast.NewRevokePrivilege("app_role", "SCHEMA", "public", []string{"USAGE"}).
+			SetGrantOptionFor(true).
+			SetComment("Remove schema access")
+
+		c.Assert(revoke.Role, qt.Equals, "app_role")
+		c.Assert(revoke.ObjectType, qt.Equals, "SCHEMA")
+		c.Assert(revoke.ObjectName, qt.Equals, "public")
+		c.Assert(revoke.Privileges, qt.DeepEquals, []string{"USAGE"})
+		c.Assert(revoke.GrantOptionFor, qt.IsTrue)
+		c.Assert(revoke.Comment, qt.Equals, "Remove schema access")
+	})
+
+	t.Run("Accept calls visitor correctly", func(t *testing.T) {
+		c := qt.New(t)
+		revoke := ast.NewRevokePrivilege("app_role", "SCHEMA", "public", []string{"USAGE"})
+		visitor := &mocks.MockVisitor{}
+
+		err := revoke.Accept(visitor)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(visitor.VisitedNodes, qt.Contains, "RevokePrivilege:app_role")
+	})
+
+	t.Run("Accept propagates visitor errors", func(t *testing.T) {
+		c := qt.New(t)
+		revoke := ast.NewRevokePrivilege("app_role", "SCHEMA", "public", []string{"USAGE"})
+		visitor := &mocks.MockVisitor{ReturnError: true}
+
+		err := revoke.Accept(visitor)
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "mock error")
+	})
+}
+
 func TestRoleOperations(t *testing.T) {
 	t.Run("SetPasswordOperation", func(t *testing.T) {
 		c := qt.New(t)

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -23,6 +23,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		RLSPolicies:       make([]goschema.RLSPolicy, 0),
 		RLSEnabledTables:  make([]goschema.RLSEnabledTable, 0),
 		Roles:             make([]goschema.Role, 0),
+		Grants:            make([]goschema.Grant, 0),
 		Dependencies:      make(map[string][]string),
 	}
 
@@ -201,6 +202,8 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		database.Roles = append(database.Roles, role)
 	}
 
+	database.Grants = convertGrants(dbSchema.Grants)
+
 	// Convert RLS enabled tables from tables that have RLS enabled
 	for _, dbTable := range dbSchema.Tables {
 		if dbTable.RLSEnabled {
@@ -214,6 +217,26 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 	}
 
 	return database
+}
+
+func convertGrants(dbGrants []dbschematypes.DBGrant) []goschema.Grant {
+	grants := make([]goschema.Grant, 0, len(dbGrants))
+	for _, dbGrant := range dbGrants {
+		grant := goschema.Grant{
+			Role:       dbGrant.Role,
+			Privileges: []string{dbGrant.Privilege},
+			WithOption: dbGrant.WithOption,
+			GrantedBy:  dbGrant.GrantedBy,
+		}
+		if strings.EqualFold(dbGrant.ObjectType, "SCHEMA") {
+			grant.OnSchema = dbGrant.ObjectName
+		} else {
+			grant.OnTable = dbGrant.QualifiedTarget()
+		}
+		grant.Canonicalize()
+		grants = append(grants, grant)
+	}
+	return grants
 }
 
 // foreignKeyInfo holds the field-level pieces reconstructed from a database

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -921,6 +921,20 @@ func FromRole(role goschema.Role) *ast.CreateRoleNode {
 	return roleNode
 }
 
+// FromGrant converts a goschema.Grant to an ast.GrantPrivilegeNode.
+func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
+	grant.Canonicalize()
+	objectType := "TABLE"
+	objectName := grant.OnTable
+	if grant.OnSchema != "" {
+		objectType = "SCHEMA"
+		objectName = grant.OnSchema
+	}
+	return ast.NewGrantPrivilege(grant.Role, objectType, objectName, grant.Privileges).
+		SetWithOption(grant.WithOption).
+		SetComment(grant.Comment)
+}
+
 // FromDatabase converts a complete goschema.Database to an ast.StatementList containing all DDL statements.
 //
 // This function creates a comprehensive database schema by converting all schema elements
@@ -1053,6 +1067,11 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		for _, rlsPolicy := range database.RLSPolicies {
 			policyNode := FromRLSPolicy(rlsPolicy)
 			statements.Statements = append(statements.Statements, policyNode)
+		}
+
+		for _, grant := range database.Grants {
+			grantNode := FromGrant(grant)
+			statements.Statements = append(statements.Statements, grantNode)
 		}
 
 		for _, trigger := range database.Triggers {

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -347,6 +347,7 @@ func parseComment(
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
+	grants *[]Grant,
 ) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
@@ -373,6 +374,8 @@ func parseComment(
 		parseRLSEnableComment(comment, structName, rlsEnabledTables)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
 		parseRoleComment(comment, structName, roles)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
+		parseGrantComment(comment, structName, grants)
 	}
 }
 
@@ -389,6 +392,7 @@ func processTableComments(
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
+	grants *[]Grant,
 ) {
 	if genDecl.Doc == nil {
 		return
@@ -416,6 +420,8 @@ func processTableComments(
 			parseRLSEnableComment(comment, structName, rlsEnabledTables)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
 			parseRoleComment(comment, structName, roles)
+		case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
+			parseGrantComment(comment, structName, grants)
 		}
 	}
 }
@@ -436,13 +442,14 @@ func processFieldComments(
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
+	grants *[]Grant,
 ) {
 	for _, field := range structType.Fields.List {
 		if field.Doc == nil {
 			continue
 		}
 		for _, comment := range field.Doc.List {
-			parseComment(comment, structName, field, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
+			parseComment(comment, structName, field, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
 		}
 	}
 }
@@ -485,6 +492,7 @@ func parseFileAST(f *ast.File) Database {
 	var rlsPolicies []RLSPolicy
 	var rlsEnabledTables []RLSEnabledTable
 	var roles []Role
+	var grants []Grant
 	globalEnumsMap := make(map[string]Enum)
 
 	// Single pass: collect table names and process all declarations and comments
@@ -506,6 +514,7 @@ func parseFileAST(f *ast.File) Database {
 		&rlsPolicies,
 		&rlsEnabledTables,
 		&roles,
+		&grants,
 	)
 
 	enums := make([]Enum, 0, len(globalEnumsMap))
@@ -538,6 +547,7 @@ func parseFileAST(f *ast.File) Database {
 		RLSPolicies:       rlsPolicies,
 		RLSEnabledTables:  rlsEnabledTables,
 		Roles:             roles,
+		Grants:            grants,
 		Dependencies:      make(map[string][]string),
 	}
 	normalizeTableScopedNames(&result)
@@ -563,6 +573,7 @@ func processFileAST(
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
+	grants *[]Grant,
 ) {
 	// First, collect table names from struct declarations
 	for _, decl := range f.Decls {
@@ -603,6 +614,7 @@ func processFileAST(
 		rlsPolicies,
 		rlsEnabledTables,
 		roles,
+		grants,
 	)
 
 	// Process all file comments for RLS annotations that might not be associated with struct declarations
@@ -647,6 +659,7 @@ func processDeclarations(
 	rlsPolicies *[]RLSPolicy,
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
+	grants *[]Grant,
 ) {
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
@@ -664,8 +677,8 @@ func processDeclarations(
 				continue
 			}
 
-			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
-			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles)
+			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
+			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
 		}
 	}
 }
@@ -853,6 +866,40 @@ func parseRoleComment(comment *ast.Comment, structName string, roles *[]Role) {
 		Replication: kv["replication"] == "true",
 		Comment:     kv["comment"],
 	})
+}
+
+func parseGrantComment(comment *ast.Comment, structName string, grants *[]Grant) {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	privileges := splitCommaList(kv["privilege"])
+	if len(privileges) == 0 {
+		privileges = splitCommaList(kv["privileges"])
+	}
+	grant := Grant{
+		StructName: structName,
+		Role:       kv["role"],
+		Privileges: privileges,
+		OnTable:    kv["on_table"],
+		OnSchema:   kv["on_schema"],
+		WithOption: kv["with_option"] == "true" || kv["grant_option"] == "true",
+		Comment:    kv["comment"],
+	}
+	grant.Canonicalize()
+	*grants = append(*grants, grant)
+}
+
+func splitCommaList(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 // ParseFileWithDependencies parses a Go file and automatically discovers and parses

--- a/core/goschema/parser_role_test.go
+++ b/core/goschema/parser_role_test.go
@@ -190,6 +190,67 @@ type InheritRoles struct {
 	})
 }
 
+func TestGrantAnnotationParsing(t *testing.T) {
+	t.Run("table grant with comma privileges", func(t *testing.T) {
+		c := qt.New(t)
+		goCode := `
+package test
+
+//migrator:schema:grant role="app_role" privilege="SELECT,INSERT, UPDATE,DELETE" on_table="users" comment="Application DML"
+type AccessControl struct {
+}
+`
+		database := parseStringAsGoFile(c, goCode)
+
+		c.Assert(database.Grants, qt.HasLen, 1)
+		grant := database.Grants[0]
+		c.Assert(grant.StructName, qt.Equals, "AccessControl")
+		c.Assert(grant.Role, qt.Equals, "app_role")
+		c.Assert(grant.Privileges, qt.DeepEquals, []string{"SELECT", "INSERT", "UPDATE", "DELETE"})
+		c.Assert(grant.OnTable, qt.Equals, "users")
+		c.Assert(grant.OnSchema, qt.Equals, "")
+		c.Assert(grant.Comment, qt.Equals, "Application DML")
+	})
+
+	t.Run("schema grant with privileges alias and grant option", func(t *testing.T) {
+		c := qt.New(t)
+		goCode := `
+package test
+
+//migrator:schema:grant role="app_role" privileges="usage" on_schema="public" with_option="true"
+type AccessControl struct {
+}
+`
+		database := parseStringAsGoFile(c, goCode)
+
+		c.Assert(database.Grants, qt.HasLen, 1)
+		grant := database.Grants[0]
+		c.Assert(grant.Role, qt.Equals, "app_role")
+		c.Assert(grant.Privileges, qt.DeepEquals, []string{"USAGE"})
+		c.Assert(grant.OnTable, qt.Equals, "")
+		c.Assert(grant.OnSchema, qt.Equals, "public")
+		c.Assert(grant.WithOption, qt.IsTrue)
+	})
+
+	t.Run("grant table reference is schema qualified by finalize", func(t *testing.T) {
+		c := qt.New(t)
+		goCode := `
+package test
+
+//migrator:schema:table name="app.users"
+//migrator:schema:grant role="app_role" privilege="SELECT" on_table="app.users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`
+		database := parseStringAsGoFile(c, goCode)
+
+		c.Assert(database.Grants, qt.HasLen, 1)
+		c.Assert(database.Grants[0].OnTable, qt.Equals, "app.users")
+	})
+}
+
 // Helper function to find a role by name in a slice of roles
 func findRoleByName(roles []goschema.Role, name string) *goschema.Role {
 	for _, role := range roles {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -42,6 +42,7 @@ type Database struct {
 	RLSPolicies                []RLSPolicy                    // PostgreSQL Row-Level Security policies
 	RLSEnabledTables           []RLSEnabledTable              // Tables with RLS enabled
 	Roles                      []Role                         // PostgreSQL roles
+	Grants                     []Grant                        // PostgreSQL privilege grants
 	Dependencies               map[string][]string            // table -> list of tables it depends on
 	FunctionDependencies       map[string][]string            // function -> list of functions it depends on
 	SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
@@ -701,6 +702,50 @@ type Role struct {
 	Inherit     bool   // Whether role inherits privileges (default: true)
 	Replication bool   // Whether role can initiate replication (default: false)
 	Comment     string // Optional comment for documentation
+}
+
+// Grant represents a PostgreSQL privilege grant parsed from Go annotations.
+//
+// Grants are defined using //migrator:schema:grant annotations and are used to
+// manage access-control privileges for roles that Ptah manages as first-class
+// schema objects.
+//
+// Example:
+//
+//	//migrator:schema:grant role="app_user" privilege="USAGE" on_schema="public"
+//	//migrator:schema:grant role="app_user" privilege="SELECT,INSERT" on_table="users"
+//	type AccessControl struct{}
+type Grant struct {
+	StructName string   // Name of the Go struct this grant is associated with
+	Role       string   // Role receiving the privilege
+	Privileges []string // Privileges to grant, e.g. SELECT, INSERT, USAGE
+	OnTable    string   // Target table, mutually exclusive with OnSchema
+	OnSchema   string   // Target schema, mutually exclusive with OnTable
+	WithOption bool     // Whether the grant includes WITH GRANT OPTION
+	GrantedBy  string   // Grantor reported by database introspection, if available
+	Comment    string   // Optional comment for documentation
+}
+
+// Canonicalize fills in normalized privilege and object names used by renderers
+// and comparators.
+func (g *Grant) Canonicalize() {
+	seen := make(map[string]bool)
+	privileges := make([]string, 0, len(g.Privileges))
+	for _, privilege := range g.Privileges {
+		trimmed := strings.TrimSpace(privilege)
+		if trimmed == "" {
+			continue
+		}
+		normalized := strings.ToUpper(trimmed)
+		if !seen[normalized] {
+			seen[normalized] = true
+			privileges = append(privileges, normalized)
+		}
+	}
+	g.Privileges = privileges
+	g.Role = strings.TrimSpace(g.Role)
+	g.OnTable = strings.TrimSpace(g.OnTable)
+	g.OnSchema = strings.TrimSpace(g.OnSchema)
 }
 
 // SelfReferencingFK represents a self-referencing foreign key that needs to be

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -230,6 +230,16 @@ func normalizeTableScopedNames(r *Database) {
 			rlsEnabled.Table = table.QualifiedName()
 		}
 	}
+	for i := range r.Grants {
+		grant := &r.Grants[i]
+		grant.Canonicalize()
+		if grant.OnTable == "" {
+			continue
+		}
+		if table := resolveTableReference(r.Tables, grant.StructName, grant.OnTable); table != nil {
+			grant.OnTable = table.QualifiedName()
+		}
+	}
 	for i := range r.Triggers {
 		trigger := &r.Triggers[i]
 		if table := resolveTableReference(r.Tables, trigger.StructName, trigger.Table); table != nil {

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -116,6 +116,10 @@ const (
 	// (PostgreSQL ALTER TABLE ... ENABLE ROW LEVEL SECURITY + CREATE POLICY).
 	RowLevelSecurity Capability = "row_level_security"
 
+	// RoleManagement marks support for PostgreSQL role and object privilege
+	// management (CREATE/ALTER ROLE plus GRANT/REVOKE).
+	RoleManagement Capability = "role_management"
+
 	// ForeignKeys marks support for declarative FOREIGN KEY constraints.
 	// PostgreSQL, CockroachDB, YugabyteDB, MySQL, and MariaDB support them;
 	// Spanner's PostgreSQL interface has historically not supported the
@@ -181,6 +185,9 @@ var registry = map[Capability]spec{
 	},
 	RowLevelSecurity: {
 		doc: "row-level security policies (PostgreSQL)",
+	},
+	RoleManagement: {
+		doc: "PostgreSQL role and object privilege management",
 	},
 	ForeignKeys: {
 		doc: "declarative FOREIGN KEY constraints",
@@ -309,6 +316,7 @@ func MySQL80() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   false,
 		RowLevelSecurity:         false,
+		RoleManagement:           false,
 		ForeignKeys:              true,
 		Sequences:                false,
 		XMLType:                  false,
@@ -347,6 +355,7 @@ func MariaDB1011() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   true,
 		RowLevelSecurity:         false,
+		RoleManagement:           false,
 		ForeignKeys:              true,
 		Sequences:                true,
 		XMLType:                  false,
@@ -381,6 +390,7 @@ func Postgres16() Capabilities {
 		CreateIndexConcurrently:  true,
 		CreateOrReplaceTrigger:   true,
 		RowLevelSecurity:         true,
+		RoleManagement:           true,
 		ForeignKeys:              true,
 		Sequences:                true,
 		XMLType:                  true,
@@ -410,6 +420,7 @@ func ClickHouse24() Capabilities {
 		CreateIndexConcurrently:  false,
 		CreateOrReplaceTrigger:   false,
 		RowLevelSecurity:         false,
+		RoleManagement:           false,
 		ForeignKeys:              false,
 		Sequences:                false,
 		XMLType:                  false,
@@ -426,7 +437,8 @@ func CockroachDB23() Capabilities {
 		With(CreateIndexConcurrently, false).
 		With(XMLType, false).
 		With(AdvisoryLocks, false).
-		With(RowLevelSecurity, false)
+		With(RowLevelSecurity, false).
+		With(RoleManagement, false)
 }
 
 // YugabyteDB25 is the preset for YugabyteDB YSQL. It stays close to
@@ -454,6 +466,7 @@ func SpannerPostgres() Capabilities {
 		With(CreateIndexConcurrently, false).
 		With(CreateOrReplaceTrigger, false).
 		With(RowLevelSecurity, false).
+		With(RoleManagement, false).
 		With(ForeignKeys, false).
 		With(Sequences, false).
 		With(XMLType, false).

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -131,10 +131,12 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(capability.Postgres16().Has(capability.CreateOrReplaceTrigger), qt.IsTrue)
 	c.Assert(capability.Postgres13().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
 	c.Assert(capability.Postgres13().Has(capability.CreateIndexConcurrently), qt.IsTrue)
+	c.Assert(capability.Postgres16().Has(capability.RoleManagement), qt.IsTrue)
 
 	// Enum modeling is mutually exclusive and dialect-appropriate.
 	c.Assert(capability.MySQL80().Has(capability.EnumInlineColumn), qt.IsTrue)
 	c.Assert(capability.MySQL80().Has(capability.EnumCustomType), qt.IsFalse)
+	c.Assert(capability.MySQL80().Has(capability.RoleManagement), qt.IsFalse)
 	c.Assert(capability.Postgres16().Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(capability.Postgres16().Has(capability.EnumInlineColumn), qt.IsFalse)
 
@@ -162,17 +164,20 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(cockroach.Has(capability.CreateIndexConcurrently), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.XMLType), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.AdvisoryLocks), qt.IsFalse)
+	c.Assert(cockroach.Has(capability.RoleManagement), qt.IsFalse)
 
 	yugabyte := capability.YugabyteDB25()
 	c.Assert(yugabyte.Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.ForeignKeys), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.CreateIndexConcurrently), qt.IsFalse)
+	c.Assert(yugabyte.Has(capability.RoleManagement), qt.IsTrue)
 
 	spanner := capability.SpannerPostgres()
 	c.Assert(spanner.Has(capability.EnumCustomType), qt.IsFalse)
 	c.Assert(spanner.Has(capability.ForeignKeys), qt.IsFalse)
 	c.Assert(spanner.Has(capability.Sequences), qt.IsFalse)
 	c.Assert(spanner.Has(capability.XMLType), qt.IsFalse)
+	c.Assert(spanner.Has(capability.RoleManagement), qt.IsFalse)
 }
 
 func TestCapabilities_With_DoesNotMutateReceiver(t *testing.T) {

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -883,3 +883,15 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	r.notSupported("ALTER ROLE", node.Name)
 	return nil
 }
+
+// VisitGrantPrivilege mirrors VisitCreateRole.
+func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	r.notSupported("GRANT", node.Role)
+	return nil
+}
+
+// VisitRevokePrivilege mirrors VisitCreateRole.
+func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	r.notSupported("REVOKE", node.Role)
+	return nil
+}

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -228,6 +228,16 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return r.r.VisitAlterRole(node)
 }
 
+// VisitGrantPrivilege delegates to the mysqllike renderer
+func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	return r.r.VisitGrantPrivilege(node)
+}
+
+// VisitRevokePrivilege delegates to the mysqllike renderer
+func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	return r.r.VisitRevokePrivilege(node)
+}
+
 // VisitRawSQL delegates to the mysqllike renderer
 func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
 	return r.r.VisitRawSQL(node)

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -228,6 +228,16 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return r.r.VisitAlterRole(node)
 }
 
+// VisitGrantPrivilege delegates to the mysqllike renderer
+func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	return r.r.VisitGrantPrivilege(node)
+}
+
+// VisitRevokePrivilege delegates to the mysqllike renderer
+func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	return r.r.VisitRevokePrivilege(node)
+}
+
 // VisitRawSQL delegates to the mysqllike renderer
 func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
 	return r.r.VisitRawSQL(node)

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -754,6 +754,16 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	return fmt.Errorf("ALTER ROLE is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
 }
 
+// VisitGrantPrivilege returns an error since PostgreSQL grants are not supported in MySQL
+func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	return fmt.Errorf("GRANT privilege management is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
+}
+
+// VisitRevokePrivilege returns an error since PostgreSQL grants are not supported in MySQL
+func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	return fmt.Errorf("REVOKE privilege management is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
+}
+
 // VisitRawSQL refuses to emit raw SQL. The only emitter of RawSQLNode today
 // is the PostgreSQL planner's constraint-drop path, which produces a PG-
 // specific DO block; routing that through a MySQL-family renderer would

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -1288,6 +1288,54 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 	return nil
 }
 
+// VisitGrantPrivilege renders a GRANT statement for PostgreSQL.
+func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	privileges := strings.Join(node.Privileges, ", ")
+	if privileges == "" {
+		return fmt.Errorf("GRANT requires at least one privilege")
+	}
+	if node.Role == "" {
+		return fmt.Errorf("GRANT requires a role")
+	}
+	if node.ObjectType == "" || node.ObjectName == "" {
+		return fmt.Errorf("GRANT requires an object type and object name")
+	}
+
+	grantOption := ""
+	if node.WithOption {
+		grantOption = " WITH GRANT OPTION"
+	}
+	r.w.WriteLinef("GRANT %s ON %s %s TO %s%s;", privileges, node.ObjectType, node.ObjectName, node.Role, grantOption)
+	return nil
+}
+
+// VisitRevokePrivilege renders a REVOKE statement for PostgreSQL.
+func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	if node.Comment != "" {
+		r.w.WriteLinef("-- %s", node.Comment)
+	}
+	privileges := strings.Join(node.Privileges, ", ")
+	if privileges == "" {
+		return fmt.Errorf("REVOKE requires at least one privilege")
+	}
+	if node.Role == "" {
+		return fmt.Errorf("REVOKE requires a role")
+	}
+	if node.ObjectType == "" || node.ObjectName == "" {
+		return fmt.Errorf("REVOKE requires an object type and object name")
+	}
+
+	prefix := "REVOKE"
+	if node.GrantOptionFor {
+		prefix = "REVOKE GRANT OPTION FOR"
+	}
+	r.w.WriteLinef("%s %s ON %s %s FROM %s;", prefix, privileges, node.ObjectType, node.ObjectName, node.Role)
+	return nil
+}
+
 // VisitRawSQL renders a literal SQL fragment verbatim and appends a trailing
 // semicolon if the fragment doesn't already end with one. The caller owns
 // correctness of the embedded SQL. The trailing `;` is essential — downstream

--- a/core/renderer/dialects/postgres/postgres_role_test.go
+++ b/core/renderer/dialects/postgres/postgres_role_test.go
@@ -203,3 +203,54 @@ func TestPostgreSQLRenderer_VisitAlterRole(t *testing.T) {
 		c.Assert(sql, qt.Equals, "")
 	})
 }
+
+func TestPostgreSQLRenderer_VisitGrantPrivilege(t *testing.T) {
+	t.Run("table grant with multiple privileges", func(t *testing.T) {
+		c := qt.New(t)
+		renderer := postgres.New()
+
+		grant := ast.NewGrantPrivilege("app_role", "TABLE", "users", []string{"SELECT", "INSERT"}).
+			SetComment("Grant application DML")
+		sql, err := renderer.Render(grant)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, "-- Grant application DML\nGRANT SELECT, INSERT ON TABLE users TO app_role;\n")
+	})
+
+	t.Run("schema grant with grant option", func(t *testing.T) {
+		c := qt.New(t)
+		renderer := postgres.New()
+
+		grant := ast.NewGrantPrivilege("app_role", "SCHEMA", "public", []string{"USAGE"}).
+			SetWithOption(true)
+		sql, err := renderer.Render(grant)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, "GRANT USAGE ON SCHEMA public TO app_role WITH GRANT OPTION;\n")
+	})
+}
+
+func TestPostgreSQLRenderer_VisitRevokePrivilege(t *testing.T) {
+	t.Run("table revoke", func(t *testing.T) {
+		c := qt.New(t)
+		renderer := postgres.New()
+
+		revoke := ast.NewRevokePrivilege("app_role", "TABLE", "users", []string{"DELETE"})
+		sql, err := renderer.Render(revoke)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, "REVOKE DELETE ON TABLE users FROM app_role;\n")
+	})
+
+	t.Run("grant option revoke", func(t *testing.T) {
+		c := qt.New(t)
+		renderer := postgres.New()
+
+		revoke := ast.NewRevokePrivilege("app_role", "SCHEMA", "public", []string{"USAGE"}).
+			SetGrantOptionFor(true)
+		sql, err := renderer.Render(revoke)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, "REVOKE GRANT OPTION FOR USAGE ON SCHEMA public FROM app_role;\n")
+	})
+}

--- a/core/yamlschema/yamlschema.go
+++ b/core/yamlschema/yamlschema.go
@@ -53,6 +53,7 @@ type document struct {
 	RLSEnabledTables  map[string]rlsEnableSpec  `yaml:"rls_enabled_tables"`
 	RLSEnabled        map[string]rlsEnableSpec  `yaml:"rls_enabled"`
 	Roles             map[string]roleSpec       `yaml:"roles"`
+	Grants            map[string]grantSpec      `yaml:"grants"`
 	Views             map[string]viewSpec       `yaml:"views"`
 	MaterializedViews map[string]matViewSpec    `yaml:"matviews"`
 	Triggers          map[string]triggerSpec    `yaml:"triggers"`
@@ -230,6 +231,17 @@ type roleSpec struct {
 	Comment     stringScalar `yaml:"comment"`
 }
 
+type grantSpec struct {
+	StructName stringScalar `yaml:"struct_name"`
+	Role       stringScalar `yaml:"role"`
+	Privilege  stringList   `yaml:"privilege"`
+	Privileges stringList   `yaml:"privileges"`
+	OnTable    stringScalar `yaml:"on_table"`
+	OnSchema   stringScalar `yaml:"on_schema"`
+	WithOption bool         `yaml:"with_option"`
+	Comment    stringScalar `yaml:"comment"`
+}
+
 type platformSpec map[string]map[string]stringScalar
 
 func (d document) toDatabase() (*goschema.Database, error) {
@@ -262,6 +274,7 @@ func (d document) toDatabase() (*goschema.Database, error) {
 	}
 	d.addRLS(db)
 	d.addRoles(db)
+	d.addGrants(db)
 
 	goschema.Finalize(db)
 	return db, nil
@@ -658,6 +671,27 @@ func (d document) addRoles(db *goschema.Database) {
 			Replication: spec.Replication,
 			Comment:     string(spec.Comment),
 		})
+	}
+}
+
+func (d document) addGrants(db *goschema.Database) {
+	for _, key := range sortedKeys(d.Grants) {
+		spec := d.Grants[key]
+		privileges := cleanStrings(spec.Privilege)
+		if len(privileges) == 0 {
+			privileges = cleanStrings(spec.Privileges)
+		}
+		grant := goschema.Grant{
+			StructName: string(spec.StructName),
+			Role:       string(spec.Role),
+			Privileges: privileges,
+			OnTable:    string(spec.OnTable),
+			OnSchema:   string(spec.OnSchema),
+			WithOption: spec.WithOption,
+			Comment:    string(spec.Comment),
+		}
+		grant.Canonicalize()
+		db.Grants = append(db.Grants, grant)
 	}
 }
 

--- a/core/yamlschema/yamlschema_test.go
+++ b/core/yamlschema/yamlschema_test.go
@@ -67,6 +67,15 @@ roles:
   app_user:
     login: true
     inherit: false
+grants:
+  app_user_schema:
+    role: app_user
+    privilege: USAGE
+    on_schema: public
+  app_user_users:
+    role: app_user
+    privileges: [SELECT, INSERT]
+    on_table: users
 tables:
   tenants:
     columns:
@@ -120,6 +129,10 @@ rls_policies:
 	c.Assert(db.Functions[0].Language, qt.Equals, "sql")
 	c.Assert(db.Roles, qt.HasLen, 1)
 	c.Assert(db.Roles[0].Inherit, qt.IsFalse)
+	c.Assert(db.Grants, qt.HasLen, 2)
+	c.Assert(db.Grants[0].Privileges, qt.DeepEquals, []string{"USAGE"})
+	c.Assert(db.Grants[1].Privileges, qt.DeepEquals, []string{"SELECT", "INSERT"})
+	c.Assert(db.Grants[1].OnTable, qt.Equals, "users")
 	c.Assert(db.RLSEnabledTables, qt.HasLen, 1)
 	c.Assert(db.RLSPolicies, qt.HasLen, 1)
 	c.Assert(db.Constraints, qt.HasLen, 1)
@@ -129,6 +142,8 @@ rls_policies:
 	c.Assert(sql, qt.Contains, `CONSTRAINT chk_users_email CHECK (position('@' in email) > 1)`)
 	c.Assert(sql, qt.Contains, `ALTER TABLE users ENABLE ROW LEVEL SECURITY;`)
 	c.Assert(sql, qt.Contains, `CREATE POLICY users_tenant_isolation ON users`)
+	c.Assert(sql, qt.Contains, `GRANT USAGE ON SCHEMA public TO app_user;`)
+	c.Assert(sql, qt.Contains, `GRANT SELECT, INSERT ON TABLE users TO app_user;`)
 }
 
 func TestParse_TrimsScalarEnumValues(t *testing.T) {

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -150,12 +150,20 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 		schema.RLSPolicies = rlsPolicies
 	}
 
-	// Read roles (PostgreSQL-specific)
-	roles, err := r.readRoles()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read roles: %w", err)
+	if r.caps.Has(capability.RoleManagement) {
+		// Read roles and grants (PostgreSQL-specific)
+		roles, err := r.readRoles()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read roles: %w", err)
+		}
+		schema.Roles = roles
+
+		grants, err := r.readGrants()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read grants: %w", err)
+		}
+		schema.Grants = grants
 	}
-	schema.Roles = roles
 
 	// Enhance tables with constraint information
 	r.enhanceTablesWithConstraints(schema.Tables, schema.Constraints)
@@ -182,8 +190,9 @@ func (r *Reader) readTables() ([]types.DBTable, error) {
 func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error) {
 	// Read tables, excluding system tables like schema_migrations
 	tablesQuery := `
-			SELECT table_schema, table_name, table_type,
-			       COALESCE(obj_description(c.oid), '') as table_comment
+		SELECT table_schema, table_name, table_type,
+		       COALESCE(obj_description(c.oid), '') as table_comment,
+		       COALESCE(c.relrowsecurity, false) AS rls_enabled
 			FROM information_schema.tables t
 			LEFT JOIN pg_class c ON c.relname = t.table_name
 		LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -201,7 +210,7 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	var tables []types.DBTable
 	for rows.Next() {
 		var table types.DBTable
-		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment)
+		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment, &table.RLSEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
@@ -1155,4 +1164,95 @@ func (r *Reader) readRoles() ([]types.DBRole, error) {
 	}
 
 	return roles, nil
+}
+
+func (r *Reader) readGrants() ([]types.DBGrant, error) {
+	var grants []types.DBGrant
+	for _, schemaName := range r.schemasToRead() {
+		tableGrants, err := r.readTableGrantsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, tableGrants...)
+
+		schemaGrants, err := r.readSchemaGrantsForSchema(schemaName)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, schemaGrants...)
+	}
+	return grants, nil
+}
+
+func (r *Reader) readTableGrantsForSchema(schemaName string) ([]types.DBGrant, error) {
+	const query = `
+		SELECT
+			grantee,
+			privilege_type,
+			table_schema,
+			table_name,
+			is_grantable = 'YES' AS with_option,
+			grantor
+		FROM information_schema.role_table_grants
+		WHERE table_schema = $1
+		AND grantee NOT LIKE 'pg_%'
+		AND grantee != 'postgres'
+		ORDER BY table_schema, table_name, grantee, privilege_type`
+
+	rows, err := r.db.Query(query, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query table grants for schema %s: %w", schemaName, err)
+	}
+	defer rows.Close()
+
+	var grants []types.DBGrant
+	for rows.Next() {
+		grant := types.DBGrant{ObjectType: "TABLE"}
+		if err := rows.Scan(&grant.Role, &grant.Privilege, &grant.Schema, &grant.ObjectName, &grant.WithOption, &grant.GrantedBy); err != nil {
+			return nil, fmt.Errorf("failed to scan table grant for schema %s: %w", schemaName, err)
+		}
+		grant.Schema = r.outputSchema(grant.Schema)
+		grants = append(grants, grant)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read table grants for schema %s: %w", schemaName, err)
+	}
+	return grants, nil
+}
+
+func (r *Reader) readSchemaGrantsForSchema(schemaName string) ([]types.DBGrant, error) {
+	const query = `
+		SELECT
+			COALESCE(grantee.rolname, 'PUBLIC') AS grantee,
+			acl.privilege_type,
+			n.nspname AS schema_name,
+			acl.is_grantable AS with_option,
+			grantor.rolname AS grantor
+		FROM pg_namespace n
+		CROSS JOIN LATERAL aclexplode(n.nspacl) acl
+		LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
+		JOIN pg_roles grantor ON grantor.oid = acl.grantor
+		WHERE n.nspname = $1
+		AND COALESCE(grantee.rolname, 'PUBLIC') NOT LIKE 'pg_%'
+		AND COALESCE(grantee.rolname, 'PUBLIC') != 'postgres'
+		ORDER BY n.nspname, COALESCE(grantee.rolname, 'PUBLIC'), acl.privilege_type`
+
+	rows, err := r.db.Query(query, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query schema grants for schema %s: %w", schemaName, err)
+	}
+	defer rows.Close()
+
+	var grants []types.DBGrant
+	for rows.Next() {
+		grant := types.DBGrant{ObjectType: "SCHEMA"}
+		if err := rows.Scan(&grant.Role, &grant.Privilege, &grant.ObjectName, &grant.WithOption, &grant.GrantedBy); err != nil {
+			return nil, fmt.Errorf("failed to scan schema grant for schema %s: %w", schemaName, err)
+		}
+		grants = append(grants, grant)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read schema grants for schema %s: %w", schemaName, err)
+	}
+	return grants, nil
 }

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -18,6 +18,7 @@ type DBSchema struct {
 	Triggers    []DBTrigger    `json:"triggers"`     // Database triggers
 	RLSPolicies []DBRLSPolicy  `json:"rls_policies"` // PostgreSQL RLS policies
 	Roles       []DBRole       `json:"roles"`        // PostgreSQL roles
+	Grants      []DBGrant      `json:"grants"`       // PostgreSQL privilege grants
 }
 
 // DBTable represents a database table
@@ -277,4 +278,24 @@ type DBRole struct {
 	Replication bool   `json:"replication"`  // Whether role can initiate replication
 	HasPassword bool   `json:"has_password"` // Whether role has a password set
 	Comment     string `json:"comment"`      // Role comment/description
+}
+
+// DBGrant represents a PostgreSQL privilege grant read from the database.
+type DBGrant struct {
+	Role       string `json:"role"`                 // Role receiving the privilege
+	Privilege  string `json:"privilege"`            // Granted privilege, e.g. SELECT or USAGE
+	ObjectType string `json:"object_type"`          // TABLE or SCHEMA
+	Schema     string `json:"schema,omitempty"`     // Schema containing the target object
+	ObjectName string `json:"object_name"`          // Target table or schema name
+	WithOption bool   `json:"with_option"`          // Whether the grant has WITH GRANT OPTION
+	GrantedBy  string `json:"granted_by,omitempty"` // Grantor role
+}
+
+// QualifiedTarget returns schema.object for table grants and the schema name
+// itself for schema grants.
+func (g DBGrant) QualifiedTarget() string {
+	if strings.EqualFold(g.ObjectType, "SCHEMA") {
+		return g.ObjectName
+	}
+	return QualifyTableName(g.Schema, g.ObjectName)
 }

--- a/docs/POSTGRESQL_ROLES.md
+++ b/docs/POSTGRESQL_ROLES.md
@@ -1,10 +1,10 @@
 # PostgreSQL Role Management with Ptah
 
-This document describes how to use Ptah's PostgreSQL role management features to create and manage database roles through Go struct annotations.
+This document describes how to use Ptah's PostgreSQL role and privilege management features to create roles and manage object grants through Go struct annotations.
 
 ## Overview
 
-Ptah supports PostgreSQL role creation and management through the `//migrator:schema:role` annotation. This allows you to define database roles alongside your entity definitions, ensuring that roles are created and managed as part of your schema migrations.
+Ptah supports PostgreSQL role creation and privilege management through the `//migrator:schema:role` and `//migrator:schema:grant` annotations. This allows you to define database roles and the privileges they need alongside your entity definitions, ensuring that access control is managed as part of your schema migrations.
 
 ## Basic Role Definition
 
@@ -40,6 +40,33 @@ The following attributes are supported for PostgreSQL roles:
 - `inherit`: Whether the role inherits privileges from granted roles (default: `true`)
 - `replication`: Whether the role can initiate streaming replication (default: `false`)
 - `comment`: Optional comment describing the role
+
+## Grant Definition
+
+Define table and schema privileges using the `//migrator:schema:grant` annotation:
+
+```go
+package entities
+
+//migrator:schema:role name="app_reader" inherit="true" comment="Application read-only role"
+//migrator:schema:role name="app_writer" inherit="true" comment="Application write role"
+//migrator:schema:grant role="app_reader" privilege="USAGE" on_schema="public"
+//migrator:schema:grant role="app_writer" privilege="USAGE" on_schema="public"
+//migrator:schema:grant role="app_reader" privilege="SELECT" on_table="users"
+//migrator:schema:grant role="app_writer" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users"
+type AccessControl struct{}
+```
+
+### Grant Attributes
+
+- `role`: Role receiving the privilege
+- `privilege` or `privileges`: One privilege or a comma-separated privilege list
+- `on_table`: Target table for table privileges
+- `on_schema`: Target schema for schema privileges such as `USAGE`
+- `with_option`: Whether to emit `WITH GRANT OPTION` (default: `false`)
+- `comment`: Optional comment describing the grant
+
+`on_table` and `on_schema` are mutually exclusive. Table grants are compared at the individual privilege level, so `privilege="SELECT,INSERT"` round-trips with PostgreSQL introspection, which reports one row per privilege.
 
 ## Advanced Role Configurations
 
@@ -98,14 +125,21 @@ ALTER ROLE api_user NOLOGIN;
 ALTER ROLE app_user PASSWORD 'new_encrypted_password';
 ```
 
-### Role Removal
+### GRANT and REVOKE Statements
 
-When roles are removed from the schema, Ptah generates DROP ROLE statements:
+When grants are added or removed for managed roles, Ptah generates `GRANT` and `REVOKE` statements:
 
 ```sql
--- Remove unused role (with safety check)
-DROP ROLE IF EXISTS old_service_role;
+GRANT USAGE ON SCHEMA public TO app_reader;
+GRANT SELECT ON TABLE users TO app_reader;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE users TO app_writer;
+
+REVOKE DELETE ON TABLE users FROM app_writer;
 ```
+
+### Role Removal
+
+Roles are not automatically dropped when they disappear from the target schema. Role removal is deliberately manual because roles may be shared with DBAs, infrastructure, or other applications. Grant removal is narrower: Ptah only emits `REVOKE` for privileges attached to roles that are still declared in the target schema.
 
 ## Integration with RLS Policies
 
@@ -115,6 +149,8 @@ Roles can be referenced in Row-Level Security policies:
 // Define roles first
 //migrator:schema:role name="tenant_user" login="true" comment="Multi-tenant user role"
 //migrator:schema:role name="admin_user" login="true" superuser="true" comment="Administrator role"
+//migrator:schema:grant role="tenant_user" privilege="USAGE" on_schema="public"
+//migrator:schema:grant role="tenant_user" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users"
 
 // Use roles in RLS policies
 //migrator:schema:rls:policy name="tenant_isolation" table="users" for="ALL" to="tenant_user" using="tenant_id = current_user_tenant_id()" comment="Tenant isolation policy"
@@ -140,6 +176,7 @@ Grant only the minimum privileges required:
 ```go
 // Good: Specific privileges for specific purposes
 //migrator:schema:role name="backup_service" login="true" replication="true" comment="Backup service role"
+//migrator:schema:grant role="analytics_reader" privilege="SELECT" on_table="events"
 
 // Avoid: Unnecessary superuser privileges
 //migrator:schema:role name="backup_service" login="true" superuser="true" comment="Backup service role"
@@ -194,7 +231,9 @@ Ptah automatically handles dependencies between roles and other database objects
 
 1. Roles are created before functions and policies that reference them
 2. Role attributes are modified when changes are detected
-3. Roles are never automatically dropped (manual removal required for safety)
+3. Grants are emitted after roles and target objects exist
+4. Removed grants for managed roles are revoked before replacement grants are added
+5. Roles are never automatically dropped (manual removal required for safety)
 
 ## Password Security
 

--- a/docs/yaml_schema.md
+++ b/docs/yaml_schema.md
@@ -78,6 +78,16 @@ roles:
     login: true
     inherit: false
 
+grants:
+  app_user_schema:
+    role: app_user
+    privilege: USAGE
+    on_schema: public
+  app_user_users:
+    role: app_user
+    privileges: [SELECT, INSERT, UPDATE, DELETE]
+    on_table: users
+
 tables:
   tenants:
     columns:
@@ -231,8 +241,8 @@ Top-level constraints also require `table`. `condition` is supported for
 ## Schema Objects
 
 YAML input supports these schema objects. Extensions, functions, materialized
-views, RLS, and roles are PostgreSQL-specific; views and triggers are also
-rendered for MySQL/MariaDB with dialect-specific trigger bodies.
+views, RLS, roles, and grants are PostgreSQL-specific; views and triggers are
+also rendered for MySQL/MariaDB with dialect-specific trigger bodies.
 
 - `extensions`: `name`, `if_not_exists`, `version`, `comment`
 - `functions`: `name`, `params` or `parameters`, `returns`, `language`,
@@ -246,6 +256,8 @@ rendered for MySQL/MariaDB with dialect-specific trigger bodies.
   `comment`
 - `roles`: `name`, `login`, `password`, `superuser`, `create_db`,
   `create_role`, `inherit`, `replication`, `comment`
+- `grants`: `role`, `privilege` or `privileges`, `on_table`, `on_schema`,
+  `with_option`, `comment`
 
 `matviews.refresh_strategy` is retained as authoring metadata for future
 refresh workflows. It is not drift-compared because PostgreSQL does not persist

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -282,7 +282,13 @@ func (a *SchemaAnalyzer) VisitAlterTableDisableRLS(node *ast.AlterTableDisableRL
 func (a *SchemaAnalyzer) VisitCreateRole(node *ast.CreateRoleNode) error { return nil }
 func (a *SchemaAnalyzer) VisitDropRole(node *ast.DropRoleNode) error     { return nil }
 func (a *SchemaAnalyzer) VisitAlterRole(node *ast.AlterRoleNode) error   { return nil }
-func (a *SchemaAnalyzer) VisitRawSQL(node *ast.RawSQLNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	return nil
+}
+func (a *SchemaAnalyzer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	return nil
+}
+func (a *SchemaAnalyzer) VisitRawSQL(node *ast.RawSQLNode) error { return nil }
 
 // AuditTransformer adds audit columns to all tables
 type AuditTransformer struct{}

--- a/integration/gonative/multi_schema_postgres_test.go
+++ b/integration/gonative/multi_schema_postgres_test.go
@@ -45,12 +45,16 @@ func TestPostgreSQLMultiSchemaGenerateApplyReadDiffIntegration(t *testing.T) {
 		RLSPolicies: []goschema.RLSPolicy{
 			{Name: "ptah_ms_users_visible", Table: "ptah_ms_auth.ptah_ms_users", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "id IS NOT NULL"},
 		},
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "ptah_ms_auth.ptah_ms_users"},
+		},
 		SelfReferencingForeignKeys: map[string][]goschema.SelfReferencingFK{},
 	}
 
 	diff := &difftypes.SchemaDiff{
-		TablesAdded:      []string{"ptah_ms_accounts", "ptah_ms_auth.ptah_ms_users", "ptah_ms_billing.ptah_ms_invoices"},
-		RLSPoliciesAdded: []string{"ptah_ms_users_visible"},
+		TablesAdded:           []string{"ptah_ms_accounts", "ptah_ms_auth.ptah_ms_users", "ptah_ms_billing.ptah_ms_invoices"},
+		RLSPoliciesAdded:      []string{"ptah_ms_users_visible"},
+		RLSEnabledTablesAdded: []string{"ptah_ms_auth.ptah_ms_users"},
 	}
 	nodes := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
 	migrationSQL, err := renderer.RenderSQL("postgres", nodes...)

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema/postgres"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupRolesGrantsIntegration(t, db)
+	defer cleanupRolesGrantsIntegration(t, db)
+
+	target := rolesGrantsTarget()
+	diff := schemadiff.Compare(target, &dbschematypes.DBSchema{})
+	c.Assert(diff.HasChanges(), qt.IsTrue)
+
+	nodes := planner.GenerateSchemaDiffAST(diff, target, "postgres")
+	migrationSQL, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	for _, stmt := range migrator.SplitSQLStatements(migrationSQL) {
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", stmt))
+	}
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	live, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	filtered := filterRolesGrantsIntegrationSchema(live)
+
+	roundTrip := schemadiff.Compare(target, filtered)
+	c.Assert(roundTrip.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", roundTrip))
+
+	_, err = db.Exec("GRANT ptah_grants_reader TO CURRENT_USER")
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec("GRANT ptah_grants_writer TO CURRENT_USER")
+	c.Assert(err, qt.IsNil)
+
+	_, err = db.Exec(`
+		INSERT INTO ptah_grants_users (id, tenant_id, email)
+		VALUES (1, 1, 'reader-visible@example.test'), (2, 2, 'reader-hidden@example.test')
+	`)
+	c.Assert(err, qt.IsNil)
+
+	assertReaderRoleBehavior(t, db)
+	assertWriterRoleBehavior(t, db)
+}
+
+func rolesGrantsTarget() *goschema.Database {
+	target := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "RolesGrantUser", Name: "ptah_grants_users"},
+			{StructName: "RolesGrantAuditLog", Name: "ptah_grants_audit_log"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "RolesGrantUser", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "RolesGrantUser", Name: "tenant_id", Type: "INTEGER", Nullable: false},
+			{StructName: "RolesGrantUser", Name: "email", Type: "TEXT", Nullable: false},
+			{StructName: "RolesGrantAuditLog", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "RolesGrantAuditLog", Name: "message", Type: "TEXT", Nullable: false},
+		},
+		Roles: []goschema.Role{
+			{Name: "ptah_grants_reader", Inherit: true},
+			{Name: "ptah_grants_writer", Inherit: true},
+		},
+		Grants: []goschema.Grant{
+			{Role: "ptah_grants_reader", Privileges: []string{"USAGE"}, OnSchema: "public"},
+			{Role: "ptah_grants_writer", Privileges: []string{"USAGE"}, OnSchema: "public"},
+			{Role: "ptah_grants_reader", Privileges: []string{"SELECT"}, OnTable: "ptah_grants_users"},
+			{Role: "ptah_grants_writer", Privileges: []string{"SELECT", "INSERT", "UPDATE", "DELETE"}, OnTable: "ptah_grants_users"},
+			{Role: "ptah_grants_writer", Privileges: []string{"INSERT"}, OnTable: "ptah_grants_audit_log"},
+		},
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "ptah_grants_users"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{
+				Name:                "ptah_grants_tenant_isolation",
+				Table:               "ptah_grants_users",
+				PolicyFor:           "ALL",
+				ToRoles:             "ptah_grants_reader,ptah_grants_writer",
+				UsingExpression:     "(tenant_id = (current_setting('app.tenant_id'::text))::integer)",
+				WithCheckExpression: "(tenant_id = (current_setting('app.tenant_id'::text))::integer)",
+			},
+		},
+	}
+	goschema.Finalize(target)
+	return target
+}
+
+func assertReaderRoleBehavior(t *testing.T, db *sql.DB) {
+	t.Helper()
+	c := qt.New(t)
+
+	tx, err := db.Begin()
+	c.Assert(err, qt.IsNil)
+	defer tx.Rollback()
+
+	_, err = tx.Exec("SET LOCAL ROLE ptah_grants_reader")
+	c.Assert(err, qt.IsNil)
+	_, err = tx.Exec("SET LOCAL app.tenant_id = '1'")
+	c.Assert(err, qt.IsNil)
+
+	var count int
+	err = tx.QueryRow("SELECT count(*) FROM ptah_grants_users").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+
+	_, err = tx.Exec("INSERT INTO ptah_grants_users (id, tenant_id, email) VALUES (3, 1, 'reader-write@example.test')")
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func assertWriterRoleBehavior(t *testing.T, db *sql.DB) {
+	t.Helper()
+	c := qt.New(t)
+
+	tx, err := db.Begin()
+	c.Assert(err, qt.IsNil)
+	defer tx.Rollback()
+
+	_, err = tx.Exec("SET LOCAL ROLE ptah_grants_writer")
+	c.Assert(err, qt.IsNil)
+	_, err = tx.Exec("SET LOCAL app.tenant_id = '1'")
+	c.Assert(err, qt.IsNil)
+
+	_, err = tx.Exec("INSERT INTO ptah_grants_users (id, tenant_id, email) VALUES (4, 1, 'writer-ok@example.test')")
+	c.Assert(err, qt.IsNil)
+	_, err = tx.Exec("INSERT INTO ptah_grants_audit_log (id, message) VALUES (1, 'writer inserted a user')")
+	c.Assert(err, qt.IsNil)
+
+	_, err = tx.Exec("INSERT INTO ptah_grants_users (id, tenant_id, email) VALUES (5, 2, 'writer-rls-blocked@example.test')")
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func cleanupRolesGrantsIntegration(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_grants_audit_log CASCADE")
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_grants_users CASCADE")
+	for _, roleName := range []string{"ptah_grants_reader", "ptah_grants_writer"} {
+		_, _ = db.Exec("REVOKE ALL PRIVILEGES ON SCHEMA public FROM " + roleName)
+		_, _ = db.Exec("DROP OWNED BY " + roleName)
+		_, _ = db.Exec("DROP ROLE IF EXISTS " + roleName)
+	}
+}
+
+func filterRolesGrantsIntegrationSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	keepTables := map[string]struct{}{
+		"ptah_grants_users":     {},
+		"ptah_grants_audit_log": {},
+	}
+	keepRoles := map[string]struct{}{
+		"ptah_grants_reader": {},
+		"ptah_grants_writer": {},
+	}
+
+	out := &dbschematypes.DBSchema{
+		Tables:      filterTables(in.Tables, keepTables),
+		Indexes:     filterIndexes(in.Indexes, keepTables),
+		Constraints: filterConstraints(in.Constraints, keepTables),
+		RLSPolicies: filterRLSPolicies(in.RLSPolicies, keepTables),
+		Roles:       filterRoles(in.Roles, keepRoles),
+		Grants:      filterGrants(in.Grants, keepRoles),
+	}
+	return out
+}
+
+func filterRoles(in []dbschematypes.DBRole, keep map[string]struct{}) []dbschematypes.DBRole {
+	out := make([]dbschematypes.DBRole, 0, len(in))
+	for _, role := range in {
+		if _, ok := keep[role.Name]; ok {
+			out = append(out, role)
+		}
+	}
+	return out
+}
+
+func filterGrants(in []dbschematypes.DBGrant, keepRoles map[string]struct{}) []dbschematypes.DBGrant {
+	out := make([]dbschematypes.DBGrant, 0, len(in))
+	for _, grant := range in {
+		if _, ok := keepRoles[grant.Role]; !ok {
+			continue
+		}
+		if strings.HasPrefix(grant.ObjectName, "ptah_grants_") || grant.ObjectName == "public" {
+			out = append(out, grant)
+		}
+	}
+	return out
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -374,9 +374,13 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		RLSEnabledTablesRemoved: diff.RLSEnabledTablesAdded,   // Tables to enable RLS become tables to disable RLS
 
 		// Reverse role operations
-		RolesAdded:    diff.RolesRemoved, // Roles to remove become roles to add
-		RolesRemoved:  diff.RolesAdded,   // Roles to add become roles to remove
-		RolesModified: reverseRoleDiffs(diff.RolesModified),
+		RolesAdded:          diff.RolesRemoved, // Roles to remove become roles to add
+		RolesRemoved:        diff.RolesAdded,   // Roles to add become roles to remove
+		RolesModified:       reverseRoleDiffs(diff.RolesModified),
+		GrantsAdded:         diff.GrantsRemoved,       // Grants to remove become grants to add
+		GrantsRemoved:       diff.GrantsAdded,         // Grants to add become grants to revoke
+		GrantOptionsAdded:   diff.GrantOptionsRevoked, // Revoked grant options become grant-option additions
+		GrantOptionsRevoked: diff.GrantOptionsAdded,   // Grant-option additions become grant-option revocations
 
 		// Reverse constraint operations. A modified constraint is expressed by
 		// the comparator as remove + add of the SAME name (e.g. an on_delete

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -1,12 +1,15 @@
 package generator
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -268,6 +271,18 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 		RLSEnabledTablesRemoved: []string{"old_table"},
 		RolesAdded:              []string{"app_user", "admin_user"},
 		RolesRemoved:            []string{"old_role"},
+		GrantsAdded: []types.GrantRef{
+			{Role: "app_user", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		GrantsRemoved: []types.GrantRef{
+			{Role: "old_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		GrantOptionsAdded: []types.GrantRef{
+			{Role: "app_user", Privilege: "UPDATE", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+		GrantOptionsRevoked: []types.GrantRef{
+			{Role: "old_role", Privilege: "INSERT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
 	}
 
 	result := reverseSchemaDiff(input)
@@ -303,6 +318,26 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 	// Verify role reversals
 	c.Assert(result.RolesAdded, qt.DeepEquals, input.RolesRemoved)
 	c.Assert(result.RolesRemoved, qt.DeepEquals, input.RolesAdded)
+	c.Assert(result.GrantsAdded, qt.DeepEquals, input.GrantsRemoved)
+	c.Assert(result.GrantsRemoved, qt.DeepEquals, input.GrantsAdded)
+	c.Assert(result.GrantOptionsAdded, qt.DeepEquals, input.GrantOptionsRevoked)
+	c.Assert(result.GrantOptionsRevoked, qt.DeepEquals, input.GrantOptionsAdded)
+}
+
+func TestReverseSchemaDiff_GrantOptionUpgradeDownRevokesOnlyOption(t *testing.T) {
+	c := qt.New(t)
+	upDiff := &types.SchemaDiff{
+		GrantOptionsAdded: []types.GrantRef{
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+	}
+
+	downDiff := reverseSchemaDiff(upDiff)
+	downSQL, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(downDiff, &goschema.Database{})...)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(downSQL, qt.Contains, "REVOKE GRANT OPTION FOR SELECT ON TABLE users FROM app_role;")
+	c.Assert(strings.Contains(downSQL, "REVOKE SELECT ON TABLE users FROM app_role;"), qt.Equals, false)
 }
 
 func TestReverseSchemaDiff_TableModifications(t *testing.T) {

--- a/migration/planner/dialects/postgres/grants_test.go
+++ b/migration/planner/dialects/postgres/grants_test.go
@@ -1,0 +1,44 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_Grants(t *testing.T) {
+	c := qt.New(t)
+	diff := &types.SchemaDiff{
+		GrantsRemoved: []types.GrantRef{
+			{Role: "app_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+		GrantOptionsRevoked: []types.GrantRef{
+			{Role: "app_role", Privilege: "UPDATE", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+		GrantOptionsAdded: []types.GrantRef{
+			{Role: "app_role", Privilege: "REFERENCES", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+		GrantsAdded: []types.GrantRef{
+			{Role: "app_role", Privilege: "USAGE", ObjectType: "SCHEMA", ObjectName: "public"},
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		},
+	}
+
+	sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(diff, &goschema.Database{})...)
+
+	c.Assert(err, qt.IsNil)
+	lines := strings.Split(strings.TrimSpace(sql), "\n")
+	c.Assert(lines, qt.DeepEquals, []string{
+		"REVOKE DELETE ON TABLE users FROM app_role;",
+		"REVOKE GRANT OPTION FOR UPDATE ON TABLE users FROM app_role;",
+		"GRANT USAGE ON SCHEMA public TO app_role;",
+		"GRANT SELECT ON TABLE users TO app_role WITH GRANT OPTION;",
+		"GRANT REFERENCES ON TABLE users TO app_role WITH GRANT OPTION;",
+	})
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -786,11 +786,18 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 7. Modify existing roles (must be done before RLS policies that reference them)
 	result = p.modifyExistingRoles(result, diff, generated)
 
+	// 7.5. Revoke removed grants before adding replacement grants.
+	result = p.removeGrants(result, diff)
+	result = p.revokeGrantOptions(result, diff)
+
 	// 8. Enable RLS on tables (must be done after table creation and modification)
 	result = p.enableRLSOnTables(result, diff, generated)
 
 	// 9. Add RLS policies (must be done after RLS is enabled and columns exist)
 	result = p.addNewRLSPolicies(result, diff, generated)
+
+	// 9.5. Add role privilege grants after roles and target objects exist.
+	result = p.addNewGrants(result, diff)
 
 	// 10. Add new indexes
 	result = p.addNewIndexes(result, diff, generated)
@@ -979,6 +986,37 @@ func (p *Planner) removeRoles(result []ast.Node, diff *types.SchemaDiff) []ast.N
 			SetIfExists().
 			SetComment("WARNING: Ensure no other objects depend on this role")
 		result = append(result, dropRoleNode)
+	}
+	return result
+}
+
+func (p *Planner) addNewGrants(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, grant := range diff.GrantsAdded {
+		node := ast.NewGrantPrivilege(grant.Role, grant.ObjectType, grant.ObjectName, []string{grant.Privilege}).
+			SetWithOption(grant.WithOption)
+		result = append(result, node)
+	}
+	for _, grant := range diff.GrantOptionsAdded {
+		node := ast.NewGrantPrivilege(grant.Role, grant.ObjectType, grant.ObjectName, []string{grant.Privilege}).
+			SetWithOption(true)
+		result = append(result, node)
+	}
+	return result
+}
+
+func (p *Planner) removeGrants(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, grant := range diff.GrantsRemoved {
+		node := ast.NewRevokePrivilege(grant.Role, grant.ObjectType, grant.ObjectName, []string{grant.Privilege})
+		result = append(result, node)
+	}
+	return result
+}
+
+func (p *Planner) revokeGrantOptions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	for _, grant := range diff.GrantOptionsRevoked {
+		node := ast.NewRevokePrivilege(grant.Role, grant.ObjectType, grant.ObjectName, []string{grant.Privilege}).
+			SetGrantOptionFor(true)
+		result = append(result, node)
 	}
 	return result
 }

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2202,7 +2202,7 @@ func RLSEnabledTables(generated *goschema.Database, database *types.DBSchema, di
 	dbRLSTables := make(map[string]bool)
 	for _, table := range database.Tables {
 		if table.RLSEnabled {
-			dbRLSTables[table.Name] = true
+			dbRLSTables[table.QualifiedName()] = true
 		}
 	}
 
@@ -2325,6 +2325,123 @@ func Roles(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 	sort.Strings(diff.RolesRemoved)
 	sort.Slice(diff.RolesModified, func(i, j int) bool {
 		return diff.RolesModified[i].RoleName < diff.RolesModified[j].RoleName
+	})
+}
+
+// Grants compares PostgreSQL role privilege grants.
+func Grants(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	generatedGrantMap := make(map[string]difftypes.GrantRef)
+	generatedGrantRoles := make(map[string]bool)
+	for _, grant := range generated.Grants {
+		generatedGrantRoles[grant.Role] = true
+		for _, ref := range grantRefsFromGenerated(grant) {
+			generatedGrantMap[grantRefIdentityKey(ref)] = ref
+		}
+	}
+
+	managedRoles := make(map[string]bool)
+	for _, role := range generated.Roles {
+		managedRoles[role.Name] = true
+	}
+
+	databaseGrantMapForAdditions := make(map[string]difftypes.GrantRef)
+	databaseGrantMapForRemovals := make(map[string]difftypes.GrantRef)
+	for _, grant := range database.Grants {
+		ref := grantRefFromDatabase(grant)
+		key := grantRefIdentityKey(ref)
+		if managedRoles[ref.Role] || generatedGrantRoles[ref.Role] {
+			databaseGrantMapForAdditions[key] = ref
+		}
+		if managedRoles[ref.Role] {
+			databaseGrantMapForRemovals[key] = ref
+		}
+	}
+
+	for key, ref := range generatedGrantMap {
+		databaseRef, exists := databaseGrantMapForAdditions[key]
+		if !exists {
+			diff.GrantsAdded = append(diff.GrantsAdded, ref)
+			continue
+		}
+		if ref.WithOption && !databaseRef.WithOption {
+			diff.GrantOptionsAdded = append(diff.GrantOptionsAdded, ref)
+		}
+		if !ref.WithOption && databaseRef.WithOption && managedRoles[ref.Role] {
+			diff.GrantOptionsRevoked = append(diff.GrantOptionsRevoked, databaseRef)
+		}
+	}
+	for key, ref := range databaseGrantMapForRemovals {
+		if _, exists := generatedGrantMap[key]; !exists {
+			diff.GrantsRemoved = append(diff.GrantsRemoved, ref)
+		}
+	}
+
+	sortGrantRefs(diff.GrantsAdded)
+	sortGrantRefs(diff.GrantsRemoved)
+	sortGrantRefs(diff.GrantOptionsAdded)
+	sortGrantRefs(diff.GrantOptionsRevoked)
+}
+
+func grantRefsFromGenerated(grant goschema.Grant) []difftypes.GrantRef {
+	grant.Canonicalize()
+	objectType := "TABLE"
+	objectName := grant.OnTable
+	if grant.OnSchema != "" {
+		objectType = "SCHEMA"
+		objectName = grant.OnSchema
+	}
+	refs := make([]difftypes.GrantRef, 0, len(grant.Privileges))
+	for _, privilege := range grant.Privileges {
+		refs = append(refs, difftypes.GrantRef{
+			Role:       grant.Role,
+			Privilege:  strings.ToUpper(strings.TrimSpace(privilege)),
+			ObjectType: objectType,
+			ObjectName: objectName,
+			WithOption: grant.WithOption,
+		})
+	}
+	return refs
+}
+
+func grantRefFromDatabase(grant types.DBGrant) difftypes.GrantRef {
+	objectType := strings.ToUpper(strings.TrimSpace(grant.ObjectType))
+	objectName := grant.QualifiedTarget()
+	if objectType == "SCHEMA" {
+		objectName = grant.ObjectName
+	}
+	return difftypes.GrantRef{
+		Role:       strings.TrimSpace(grant.Role),
+		Privilege:  strings.ToUpper(strings.TrimSpace(grant.Privilege)),
+		ObjectType: objectType,
+		ObjectName: objectName,
+		WithOption: grant.WithOption,
+	}
+}
+
+func grantRefIdentityKey(ref difftypes.GrantRef) string {
+	return strings.Join([]string{
+		strings.TrimSpace(ref.Role),
+		strings.ToUpper(strings.TrimSpace(ref.ObjectType)),
+		strings.TrimSpace(ref.ObjectName),
+		strings.ToUpper(strings.TrimSpace(ref.Privilege)),
+	}, "\x00")
+}
+
+func sortGrantRefs(refs []difftypes.GrantRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].ObjectType != refs[j].ObjectType {
+			return refs[i].ObjectType < refs[j].ObjectType
+		}
+		if refs[i].ObjectName != refs[j].ObjectName {
+			return refs[i].ObjectName < refs[j].ObjectName
+		}
+		if refs[i].Role != refs[j].Role {
+			return refs[i].Role < refs[j].Role
+		}
+		if refs[i].Privilege != refs[j].Privilege {
+			return refs[i].Privilege < refs[j].Privilege
+		}
+		return !refs[i].WithOption && refs[j].WithOption
 	})
 }
 

--- a/migration/schemadiff/internal/compare/compare_rls_test.go
+++ b/migration/schemadiff/internal/compare/compare_rls_test.go
@@ -8,57 +8,25 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
-func TestRLSPolicyDefinitions_NormalizesRedundantExpressionParentheses(t *testing.T) {
+func TestRLSEnabledTables_MatchesSchemaQualifiedTables(t *testing.T) {
 	c := qt.New(t)
-
-	gen := goschema.RLSPolicy{
-		Name:                "users_visible",
-		Table:               "auth.users",
-		PolicyFor:           "ALL",
-		ToRoles:             "PUBLIC",
-		UsingExpression:     "id IS NOT NULL",
-		WithCheckExpression: "account_id IS NOT NULL",
+	generated := &goschema.Database{
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "auth.users"},
+		},
 	}
-	db := types.DBRLSPolicy{
-		Name:                "users_visible",
-		Table:               "auth.users",
-		PolicyFor:           "ALL",
-		ToRoles:             "PUBLIC",
-		UsingExpression:     "(id IS NOT NULL)",
-		WithCheckExpression: "((account_id IS NOT NULL))",
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{Schema: "auth", Name: "users", RLSEnabled: true},
+		},
 	}
+	diff := &difftypes.SchemaDiff{}
 
-	diff := compare.RLSPolicyDefinitions(gen, db)
+	compare.RLSEnabledTables(generated, database, diff)
 
-	c.Assert(diff.Changes, qt.HasLen, 0)
-}
-
-func TestRLSPolicyDefinitions_DetectsExpressionChangesAfterNormalization(t *testing.T) {
-	c := qt.New(t)
-
-	gen := goschema.RLSPolicy{
-		Name:                "users_visible",
-		Table:               "auth.users",
-		PolicyFor:           "ALL",
-		ToRoles:             "PUBLIC",
-		UsingExpression:     "id IS NOT NULL",
-		WithCheckExpression: "account_id IS NOT NULL",
-	}
-	db := types.DBRLSPolicy{
-		Name:                "users_visible",
-		Table:               "auth.users",
-		PolicyFor:           "ALL",
-		ToRoles:             "PUBLIC",
-		UsingExpression:     "(id > 0)",
-		WithCheckExpression: "(account_id > 0)",
-	}
-
-	diff := compare.RLSPolicyDefinitions(gen, db)
-
-	c.Assert(diff.Changes, qt.DeepEquals, map[string]string{
-		"using_expression":      "(id > 0) -> id IS NOT NULL",
-		"with_check_expression": "(account_id > 0) -> account_id IS NOT NULL",
-	})
+	c.Assert(diff.RLSEnabledTablesAdded, qt.HasLen, 0)
+	c.Assert(diff.RLSEnabledTablesRemoved, qt.HasLen, 0)
 }

--- a/migration/schemadiff/internal/compare/compare_roles_test.go
+++ b/migration/schemadiff/internal/compare/compare_roles_test.go
@@ -267,3 +267,156 @@ func TestRoleDefinitionsComparison(t *testing.T) {
 		c.Assert(diff.Changes, qt.HasLen, 0) // No password change detected
 	})
 }
+
+func TestGrantsComparison(t *testing.T) {
+	t.Run("adds table and schema grants", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Roles: []goschema.Role{{Name: "app_role"}},
+			Grants: []goschema.Grant{
+				{Role: "app_role", Privileges: []string{"SELECT", "INSERT"}, OnTable: "users"},
+				{Role: "app_role", Privileges: []string{"USAGE"}, OnSchema: "public"},
+			},
+		}
+		database := &types.DBSchema{}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.DeepEquals, []difftypes.GrantRef{
+			{Role: "app_role", Privilege: "USAGE", ObjectType: "SCHEMA", ObjectName: "public"},
+			{Role: "app_role", Privilege: "INSERT", ObjectType: "TABLE", ObjectName: "users"},
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+		})
+		c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+	})
+
+	t.Run("matches PostgreSQL row per privilege introspection", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Roles: []goschema.Role{{Name: "app_role"}},
+			Grants: []goschema.Grant{
+				{Role: "app_role", Privileges: []string{"select", "insert"}, OnTable: "public.users"},
+			},
+		}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "app_role", Privilege: "INSERT", ObjectType: "TABLE", Schema: "public", ObjectName: "users"},
+				{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", Schema: "public", ObjectName: "users"},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+		c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+	})
+
+	t.Run("removes grants only for managed roles", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Roles:  []goschema.Role{{Name: "app_role"}},
+			Grants: []goschema.Grant{{Role: "app_role", Privileges: []string{"SELECT"}, OnTable: "users"}},
+		}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "app_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"},
+				{Role: "external_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsRemoved, qt.DeepEquals, []difftypes.GrantRef{
+			{Role: "app_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"},
+		})
+		c.Assert(diff.GrantOptionsRevoked, qt.HasLen, 0)
+	})
+
+	t.Run("matches explicit grants to external roles without revoking their other privileges", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Grants: []goschema.Grant{{Role: "external_role", Privileges: []string{"SELECT"}, OnTable: "users"}},
+		}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "external_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+				{Role: "external_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+		c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+	})
+
+	t.Run("downgrades grant option without revoking the privilege", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Roles:  []goschema.Role{{Name: "app_role"}},
+			Grants: []goschema.Grant{{Role: "app_role", Privileges: []string{"SELECT"}, OnTable: "users"}},
+		}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+		c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+		c.Assert(diff.GrantOptionsRevoked, qt.DeepEquals, []difftypes.GrantRef{
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		})
+	})
+
+	t.Run("upgrades grant option without re-adding the privilege", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{
+			Roles: []goschema.Role{{Name: "app_role"}},
+			Grants: []goschema.Grant{
+				{Role: "app_role", Privileges: []string{"SELECT"}, OnTable: "users", WithOption: true},
+			},
+		}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+		c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+		c.Assert(diff.GrantOptionsAdded, qt.DeepEquals, []difftypes.GrantRef{
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		})
+		c.Assert(diff.GrantOptionsRevoked, qt.HasLen, 0)
+	})
+
+	t.Run("removing a grant with grant option still revokes the full privilege", func(t *testing.T) {
+		c := qt.New(t)
+		generated := &goschema.Database{Roles: []goschema.Role{{Name: "app_role"}}}
+		database := &types.DBSchema{
+			Grants: []types.DBGrant{
+				{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+			},
+		}
+		diff := &difftypes.SchemaDiff{}
+
+		compare.Grants(generated, database, diff)
+
+		c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+		c.Assert(diff.GrantsRemoved, qt.DeepEquals, []difftypes.GrantRef{
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users", WithOption: true},
+		})
+		c.Assert(diff.GrantOptionsRevoked, qt.HasLen, 0)
+	})
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -83,6 +83,9 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	// Compare roles (PostgreSQL-specific feature)
 	compare.Roles(generated, database, diff)
 
+	// Compare role privilege grants (PostgreSQL-specific feature)
+	compare.Grants(generated, database, diff)
+
 	// Compare table-level constraints (EXCLUDE, CHECK, UNIQUE, etc.)
 	compare.Constraints(generated, database, diff, opts)
 

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -222,6 +222,22 @@ type SchemaDiff struct {
 	// schemas but have different definitions (attributes, passwords, etc.)
 	RolesModified []RoleDiff `json:"roles_modified"`
 
+	// GrantsAdded contains PostgreSQL privilege grants that exist in the target
+	// schema but not in the current database schema.
+	GrantsAdded []GrantRef `json:"grants_added"`
+
+	// GrantsRemoved contains PostgreSQL privilege grants that exist in the current
+	// database schema for managed roles but not in the target schema.
+	GrantsRemoved []GrantRef `json:"grants_removed"`
+
+	// GrantOptionsAdded contains PostgreSQL privileges whose WITH GRANT OPTION
+	// flag exists in the target schema but not in the current database schema.
+	GrantOptionsAdded []GrantRef `json:"grant_options_added"`
+
+	// GrantOptionsRevoked contains PostgreSQL privileges whose WITH GRANT OPTION
+	// flag exists in the database but not in the target schema.
+	GrantOptionsRevoked []GrantRef `json:"grant_options_revoked"`
+
 	// ConstraintsAdded contains names of constraints that exist in the target schema
 	// but not in the current database schema
 	ConstraintsAdded []string `json:"constraints_added"`
@@ -357,7 +373,11 @@ func (d *SchemaDiff) hasRLSChanges() bool {
 func (d *SchemaDiff) hasRoleChanges() bool {
 	return len(d.RolesAdded) > 0 ||
 		len(d.RolesRemoved) > 0 ||
-		len(d.RolesModified) > 0
+		len(d.RolesModified) > 0 ||
+		len(d.GrantsAdded) > 0 ||
+		len(d.GrantsRemoved) > 0 ||
+		len(d.GrantOptionsAdded) > 0 ||
+		len(d.GrantOptionsRevoked) > 0
 }
 
 // hasConstraintChanges returns true if there are any constraint-related changes
@@ -621,4 +641,22 @@ type RoleDiff struct {
 	// Changes maps change types to their old->new value transitions
 	// Format: "change_type" -> "old_value -> new_value"
 	Changes map[string]string `json:"changes"`
+}
+
+// GrantRef identifies one PostgreSQL privilege grant.
+type GrantRef struct {
+	// Role is the role receiving or losing the privilege.
+	Role string `json:"role"`
+
+	// Privilege is the individual privilege, e.g. SELECT, INSERT, or USAGE.
+	Privilege string `json:"privilege"`
+
+	// ObjectType is the target kind, currently TABLE or SCHEMA.
+	ObjectType string `json:"object_type"`
+
+	// ObjectName is the target table or schema name.
+	ObjectName string `json:"object_name"`
+
+	// WithOption records whether the grant has WITH GRANT OPTION.
+	WithOption bool `json:"with_option"`
 }


### PR DESCRIPTION
## Summary
- Add first-class PostgreSQL grant IR, parsing, YAML support, AST nodes, rendering, schema conversion, and diff/planner support.
- Introspect table and schema grants from PostgreSQL catalogs and gate role/grant reads behind RoleManagement capabilities.
- Add safe grant diff semantics for managed roles, including grant-option upgrades/downgrades without accidental privilege revocation.
- Document roles/grants and the multi-tenant RLS recipe in README and PostgreSQL docs.

## Validation
- go test ./...
- POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test -tags integration ./integration/gonative -run TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration -count=1 -v
- golangci-lint run --fix ./...
- golangci-lint run ./...
- git diff --check

Closes #164