### PR TITLE
Wire server-version capability detection

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -94,10 +94,11 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	// 3. Compare schemas (dialect-aware: MySQL/MariaDB RESTRICT == NO ACTION)
-	diff := schemadiff.CompareWithDialect(result, dbSchema, conn.Info().Dialect)
+	info := conn.Info()
+	diff := schemadiff.CompareWithDialect(result, dbSchema, info.Dialect)
 
 	// 4. Display differences
-	output := planner.GenerateSchemaDiffSQLStatements(diff, result, conn.Info().Dialect)
+	output := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, result, info.Dialect, info.Capabilities)
 	fmt.Print(output)
 
 	return nil

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -141,8 +141,9 @@ func migrateCommand(cmd *cobra.Command, _ []string) error {
 	diff := schemadiff.CompareWithDialect(result, dbSchema, conn.Info().Dialect)
 
 	// 4. Display differences summary
-	astNodes := planner.GenerateSchemaDiffAST(diff, result, conn.Info().Dialect)
-	assessments, err := safety.AssessRendered(astNodes, conn.Info().Dialect)
+	info := conn.Info()
+	astNodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, result, info.Dialect, info.Capabilities)
+	assessments, err := safety.AssessRenderedWithCapabilities(astNodes, info.Dialect, info.Capabilities)
 	if err != nil {
 		return fmt.Errorf("error assessing migration safety: %w", err)
 	}
@@ -171,7 +172,7 @@ func migrateCommand(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintln(out, "=== MIGRATION SQL ===")
 	fmt.Fprintln(out)
 
-	statements, err := renderer.RenderSQL(conn.Info().Dialect, astNodes...)
+	statements, err := renderer.RenderSQLWithCapabilities(info.Dialect, info.Capabilities, astNodes...)
 	if err != nil {
 		return fmt.Errorf("error rendering SQL: %w", err)
 	}

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -92,7 +92,8 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 
 	// Format and display the schema
 	dbsch := dbschematogo.ConvertDBSchemaToGoSchema(schema)
-	statements := renderer.GetOrderedCreateStatements(dbsch, conn.Info().Dialect)
+	info := conn.Info()
+	statements := renderer.GetOrderedCreateStatementsWithCapabilities(dbsch, info.Dialect, info.Capabilities)
 	output := strings.Join(statements, ";\n") + ";"
 	fmt.Print(output)
 

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -431,14 +431,16 @@ func ClickHouse24() Capabilities {
 // CockroachDB23 is the preset for CockroachDB's PostgreSQL-compatible surface.
 // CockroachDB runs schema changes online by design, so PostgreSQL's
 // CONCURRENTLY keyword is not a meaningful or portable emission target. It
-// also lacks PostgreSQL's XML type and advisory-lock functions.
+// also lacks PostgreSQL's SERIAL/sequence surface, XML type, and advisory-lock
+// functions in Ptah's portable subset.
 func CockroachDB23() Capabilities {
 	return Postgres16().
 		With(CreateIndexConcurrently, false).
 		With(XMLType, false).
 		With(AdvisoryLocks, false).
 		With(RowLevelSecurity, false).
-		With(RoleManagement, false)
+		With(RoleManagement, false).
+		With(Sequences, false)
 }
 
 // YugabyteDB25 is the preset for YugabyteDB YSQL. It stays close to
@@ -505,48 +507,57 @@ func ForDialect(dialect string) Capabilities {
 // over the MySQL protocol) and "PostgreSQL 16.3 (Debian ...)". When the
 // version cannot be parsed, the dialect's default preset is returned.
 func ForServerVersion(dialect, version string) Capabilities {
+	caps, _ := ForServerVersionResult(dialect, version)
+	return caps
+}
+
+// ForServerVersionResult is ForServerVersion plus an explicit fallback signal.
+// The boolean is false when no version-specific preset could be selected and
+// the dialect default was used instead. Callers with a live connection can log
+// that degradation while offline callers can keep using ForDialect.
+func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 	normalized := platform.NormalizeDialect(dialect)
 	versionLower := strings.ToLower(version)
 
 	switch {
 	case strings.Contains(versionLower, "cockroachdb"):
-		return CockroachDB23()
+		return CockroachDB23(), true
 	case strings.Contains(versionLower, "yugabytedb") || strings.Contains(versionLower, "yugabyte") || strings.Contains(versionLower, "-yb-"):
-		return YugabyteDB25()
+		return YugabyteDB25(), true
 	case strings.Contains(versionLower, "spanner"):
-		return SpannerPostgres()
+		return SpannerPostgres(), true
 	}
 
 	// MariaDB announces itself in the version string even when connected via
 	// the mysql dialect/driver; trust the string over the declared dialect.
 	if strings.Contains(versionLower, "mariadb") {
-		return mariaDBForVersion(version)
+		return mariaDBForVersion(version), parseableMariaDBVersion(version)
 	}
 
 	v, ok := parseVersion(version)
 	if !ok {
-		return ForDialect(dialect)
+		return ForDialect(dialect), false
 	}
 
 	switch normalized {
 	case platform.MySQL:
 		switch {
 		case v.major > 8 || (v.major == 8 && (v.minor > 0 || v.patch >= 19)):
-			return MySQL80()
+			return MySQL80(), true
 		case v.major == 8 && v.patch >= 16:
-			return MySQL8016()
+			return MySQL8016(), true
 		default:
-			return MySQLLegacy()
+			return MySQLLegacy(), true
 		}
 	case platform.MariaDB:
-		return mariaDBForVersion(version)
+		return mariaDBForVersion(version), parseableMariaDBVersion(version)
 	case platform.Postgres:
 		if v.major >= 14 {
-			return Postgres16()
+			return Postgres16(), true
 		}
-		return Postgres13()
+		return Postgres13(), true
 	default:
-		return ForDialect(dialect)
+		return ForDialect(dialect), false
 	}
 }
 
@@ -567,6 +578,11 @@ func mariaDBForVersion(version string) Capabilities {
 		return MariaDB1011()
 	}
 	return MariaDBLegacy()
+}
+
+func parseableMariaDBVersion(version string) bool {
+	_, ok := parseVersion(strings.TrimPrefix(version, "5.5.5-"))
+	return ok
 }
 
 // serverVersion is a parsed dotted server version.

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -165,12 +165,14 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(cockroach.Has(capability.XMLType), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.AdvisoryLocks), qt.IsFalse)
 	c.Assert(cockroach.Has(capability.RoleManagement), qt.IsFalse)
+	c.Assert(cockroach.Has(capability.Sequences), qt.IsFalse)
 
 	yugabyte := capability.YugabyteDB25()
 	c.Assert(yugabyte.Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.ForeignKeys), qt.IsTrue)
 	c.Assert(yugabyte.Has(capability.CreateIndexConcurrently), qt.IsFalse)
 	c.Assert(yugabyte.Has(capability.RoleManagement), qt.IsTrue)
+	c.Assert(yugabyte.Has(capability.Sequences), qt.IsTrue)
 
 	spanner := capability.SpannerPostgres()
 	c.Assert(spanner.Has(capability.EnumCustomType), qt.IsFalse)
@@ -273,6 +275,23 @@ func TestForServerVersion(t *testing.T) {
 				qt.Commentf("dialect=%s version=%q probe=%s", tt.dialect, tt.version, tt.probe))
 		})
 	}
+}
+
+func TestForServerVersionResultReportsFallback(t *testing.T) {
+	c := qt.New(t)
+
+	caps, versionSpecific := capability.ForServerVersionResult("mysql", "8.0.17")
+	c.Assert(versionSpecific, qt.Equals, true)
+	c.Assert(caps.Has(capability.DropCheckClause), qt.Equals, true)
+	c.Assert(caps.Has(capability.DropConstraintGeneric), qt.Equals, false)
+
+	caps, versionSpecific = capability.ForServerVersionResult("mysql", "who knows")
+	c.Assert(versionSpecific, qt.Equals, false)
+	c.Assert(caps.Has(capability.DropConstraintGeneric), qt.Equals, true)
+
+	caps, versionSpecific = capability.ForServerVersionResult("mariadb", "MariaDB something")
+	c.Assert(versionSpecific, qt.Equals, false)
+	c.Assert(caps.Has(capability.DropConstraintIfExists), qt.Equals, true)
 }
 
 func TestDoc(t *testing.T) {

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -6,7 +6,9 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/core/renderer/dialects/mysql"
 )
 
 // TestMySQLFamilyRenderers_ConstraintDropGuardValidity pins the renderer-side
@@ -82,6 +84,36 @@ func TestMySQLFamilyRenderers_DropCheckSpelling(t *testing.T) {
 		qt.Commentf("mariadb must degrade DROP CHECK to the generic clause; got:\n%s", sql))
 	c.Assert(sql, qt.Not(qt.Contains), "DROP CHECK",
 		qt.Commentf("got:\n%s", sql))
+}
+
+func TestMySQLRendererWithCapabilities_UsesPassedCapabilitySet(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewDropIndex("idx_users_email").SetIfExists().SetTable("users")
+
+	sql, err := renderer.RenderSQLWithCapabilities("mysql", capability.MySQL80(), node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "DROP INDEX idx_users_email ON users;")
+	c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS")
+
+	sql, err = renderer.RenderSQLWithCapabilities("mysql", capability.MariaDB1011(), node)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "DROP INDEX IF EXISTS idx_users_email ON users;")
+}
+
+func TestMySQLRendererWithCapabilities_ClonesCapabilitySet(t *testing.T) {
+	c := qt.New(t)
+
+	caps := capability.MySQL80()
+	mysqlRenderer := mysql.NewWithCapabilities(caps)
+	caps[capability.DropIndexIfExists] = true
+
+	node := ast.NewDropIndex("idx_users_email").SetIfExists().SetTable("users")
+	sql, err := mysqlRenderer.Render(node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "DROP INDEX idx_users_email ON users;")
+	c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS")
 }
 
 // TestMySQLFamilyRenderers_DropUniqueIndexSpelling pins the DROP INDEX

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -2,6 +2,7 @@ package mariadb
 
 import (
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/internal/bufwriter"
 	"github.com/stokaro/ptah/core/renderer/dialects/mysqllike"
 	"github.com/stokaro/ptah/core/renderer/types"
@@ -19,9 +20,15 @@ type Renderer struct {
 
 // New creates a new MariaDB renderer
 func New() *Renderer {
+	return NewWithCapabilities(capability.MariaDB1011())
+}
+
+// NewWithCapabilities creates a MariaDB renderer for a concrete server
+// capability set. Use New for offline/default rendering.
+func NewWithCapabilities(caps capability.Capabilities) *Renderer {
 	var w bufwriter.Writer
 	return &Renderer{
-		r: mysqllike.New("mariadb", &w),
+		r: mysqllike.NewWithCapabilities("mariadb", &w, caps),
 		w: w,
 	}
 }

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/internal/bufwriter"
 	"github.com/stokaro/ptah/core/renderer/dialects/mysqllike"
 	"github.com/stokaro/ptah/core/renderer/types"
@@ -19,9 +20,15 @@ type Renderer struct {
 
 // New creates a new MySQL renderer
 func New() *Renderer {
+	return NewWithCapabilities(capability.MySQL80())
+}
+
+// NewWithCapabilities creates a MySQL renderer for a concrete server
+// capability set. Use New for offline/default rendering.
+func NewWithCapabilities(caps capability.Capabilities) *Renderer {
 	var w bufwriter.Writer
 	return &Renderer{
-		r: mysqllike.New("mysql", &w),
+		r: mysqllike.NewWithCapabilities("mysql", &w, caps),
 		w: w,
 	}
 }

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -31,11 +31,18 @@ type Renderer struct {
 // from the dialect name (capability.ForDialect), so "mysql" gets the strict
 // MySQL preset and "mariadb" the MariaDB one.
 func New(dialect string, buf *bufwriter.Writer) *Renderer {
+	return NewWithCapabilities(dialect, buf, capability.ForDialect(dialect))
+}
+
+// NewWithCapabilities creates a new MySQL-like renderer for a concrete target
+// capability set. Live database paths should pass the set resolved from the
+// server version; offline paths use New and therefore the dialect default.
+func NewWithCapabilities(dialect string, buf *bufwriter.Writer, caps capability.Capabilities) *Renderer {
 	return &Renderer{
 		w:            buf,
 		dialect:      dialect,
 		dialectUpper: strings.ToUpper(dialect),
-		caps:         capability.ForDialect(dialect),
+		caps:         caps.Clone(),
 	}
 }
 

--- a/core/renderer/dialects/postgres/capability_test.go
+++ b/core/renderer/dialects/postgres/capability_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/postgres"
 )
 
@@ -26,4 +27,119 @@ func TestPostgreSQLRenderer_NilCapabilitiesAreConservative(t *testing.T) {
 		AddColumn(ast.NewColumn("payload", "XML"))
 	_, err = renderer.Render(xmlTable)
 	c.Assert(err, qt.ErrorMatches, `error rendering column payload: cockroachdb does not support XML columns; use a platform-specific type override`)
+}
+
+func TestPostgreSQLRenderer_SequenceCapability(t *testing.T) {
+	t.Run("postgres keeps SERIAL", func(t *testing.T) {
+		c := qt.New(t)
+
+		renderer := postgres.NewWithCapabilities(capability.Postgres16(), platform.Postgres)
+		table := ast.NewCreateTable("users").
+			AddColumn(ast.NewColumn("id", "SERIAL").SetPrimary())
+
+		sql, err := renderer.Render(table)
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Contains, "id SERIAL PRIMARY KEY NOT NULL")
+	})
+
+	t.Run("cockroach rejects explicit SERIAL", func(t *testing.T) {
+		c := qt.New(t)
+
+		renderer := postgres.NewWithCapabilities(capability.CockroachDB23(), platform.CockroachDB)
+		table := ast.NewCreateTable("users").
+			AddColumn(ast.NewColumn("id", "SERIAL").SetPrimary())
+
+		_, err := renderer.Render(table)
+
+		c.Assert(err, qt.ErrorMatches, `error rendering column id: cockroachdb does not support sequence-backed type SERIAL; use a platform-specific type override`)
+	})
+
+	t.Run("spanner rejects auto increment mapping", func(t *testing.T) {
+		c := qt.New(t)
+
+		renderer := postgres.NewWithCapabilities(capability.SpannerPostgres(), platform.Spanner)
+		table := ast.NewCreateTable("users").
+			AddColumn(ast.NewColumn("id", "BIGINT AUTO_INCREMENT").SetPrimary())
+
+		_, err := renderer.Render(table)
+
+		c.Assert(err, qt.ErrorMatches, `error rendering column id: spanner does not support sequence-backed type BIGINT AUTO_INCREMENT; use a platform-specific type override`)
+	})
+}
+
+func TestPostgreSQLRenderer_RowLevelSecurityCapability(t *testing.T) {
+	tests := []struct {
+		name string
+		node ast.Node
+	}{
+		{
+			name: "create policy",
+			node: ast.NewCreatePolicy("tenant_policy", "users").
+				SetPolicyFor("SELECT").
+				SetUsingExpression("tenant_id = current_setting('app.tenant_id')::uuid"),
+		},
+		{
+			name: "drop policy",
+			node: ast.NewDropPolicy("tenant_policy", "users").SetIfExists(),
+		},
+		{
+			name: "enable RLS",
+			node: ast.NewAlterTableEnableRLS("users"),
+		},
+		{
+			name: "disable RLS",
+			node: ast.NewAlterTableDisableRLS("users"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			renderer := postgres.NewWithCapabilities(capability.CockroachDB23(), platform.CockroachDB)
+			_, err := renderer.Render(tt.node)
+
+			c.Assert(err, qt.ErrorMatches, `cockroachdb does not support row-level security`)
+		})
+	}
+}
+
+func TestPostgreSQLRenderer_RoleManagementCapability(t *testing.T) {
+	tests := []struct {
+		name string
+		node ast.Node
+	}{
+		{
+			name: "create role",
+			node: ast.NewCreateRole("app_role"),
+		},
+		{
+			name: "drop role",
+			node: ast.NewDropRole("app_role").SetIfExists(),
+		},
+		{
+			name: "alter role",
+			node: ast.NewAlterRole("app_role").AddOperation(ast.NewSetLoginOperation(true)),
+		},
+		{
+			name: "grant",
+			node: ast.NewGrantPrivilege("app_role", "TABLE", "users", []string{"SELECT"}),
+		},
+		{
+			name: "revoke",
+			node: ast.NewRevokePrivilege("app_role", "TABLE", "users", []string{"SELECT"}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			renderer := postgres.NewWithCapabilities(capability.CockroachDB23(), platform.CockroachDB)
+			_, err := renderer.Render(tt.node)
+
+			c.Assert(err, qt.ErrorMatches, `cockroachdb does not support role management`)
+		})
+	}
 }

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -591,6 +591,9 @@ func (r *Renderer) processFieldType(fieldType string, enums []string) (string, e
 	if strings.EqualFold(fieldType, "XML") && !r.capabilities().Has(capability.XMLType) {
 		return "", fmt.Errorf("%s does not support XML columns; use a platform-specific type override", r.dialect)
 	}
+	if sequenceBackedType(fieldType) && !r.capabilities().Has(capability.Sequences) {
+		return "", fmt.Errorf("%s does not support sequence-backed type %s; use a platform-specific type override", r.dialect, fieldType)
+	}
 
 	// Handle other PostgreSQL-specific type mappings if needed
 	switch fieldType {
@@ -600,6 +603,15 @@ func (r *Renderer) processFieldType(fieldType string, enums []string) (string, e
 		return "BIGSERIAL", nil
 	default:
 		return fieldType, nil
+	}
+}
+
+func sequenceBackedType(fieldType string) bool {
+	switch strings.ToUpper(strings.TrimSpace(fieldType)) {
+	case "SMALLSERIAL", "SERIAL", "BIGSERIAL", "AUTO_INCREMENT", "BIGINT AUTO_INCREMENT":
+		return true
+	default:
+		return strings.Contains(strings.ToUpper(fieldType), "AUTO_INCREMENT")
 	}
 }
 
@@ -876,6 +888,10 @@ func (r *Renderer) VisitCreateFunction(node *ast.CreateFunctionNode) error {
 
 // VisitCreatePolicy renders a CREATE POLICY statement for PostgreSQL RLS
 func (r *Renderer) VisitCreatePolicy(node *ast.CreatePolicyNode) error {
+	if err := r.requireRowLevelSecurityCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -919,6 +935,10 @@ func (r *Renderer) VisitCreatePolicy(node *ast.CreatePolicyNode) error {
 
 // VisitAlterTableEnableRLS renders an ALTER TABLE ENABLE ROW LEVEL SECURITY statement
 func (r *Renderer) VisitAlterTableEnableRLS(node *ast.AlterTableEnableRLSNode) error {
+	if err := r.requireRowLevelSecurityCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1164,6 +1184,10 @@ func isIdentifierPart(character byte) bool {
 
 // VisitDropPolicy renders a DROP POLICY statement
 func (r *Renderer) VisitDropPolicy(node *ast.DropPolicyNode) error {
+	if err := r.requireRowLevelSecurityCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1186,6 +1210,10 @@ func (r *Renderer) VisitDropPolicy(node *ast.DropPolicyNode) error {
 
 // VisitAlterTableDisableRLS renders an ALTER TABLE DISABLE ROW LEVEL SECURITY statement
 func (r *Renderer) VisitAlterTableDisableRLS(node *ast.AlterTableDisableRLSNode) error {
+	if err := r.requireRowLevelSecurityCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1199,6 +1227,10 @@ func (r *Renderer) VisitAlterTableDisableRLS(node *ast.AlterTableDisableRLSNode)
 
 // VisitCreateRole renders a CREATE ROLE statement for PostgreSQL
 func (r *Renderer) VisitCreateRole(node *ast.CreateRoleNode) error {
+	if err := r.requireRoleManagementCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1268,6 +1300,10 @@ func (r *Renderer) VisitCreateRole(node *ast.CreateRoleNode) error {
 
 // VisitDropRole renders a DROP ROLE statement for PostgreSQL
 func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
+	if err := r.requireRoleManagementCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1290,6 +1326,10 @@ func (r *Renderer) VisitDropRole(node *ast.DropRoleNode) error {
 
 // VisitGrantPrivilege renders a GRANT statement for PostgreSQL.
 func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
+	if err := r.requireRoleManagementCapability(); err != nil {
+		return err
+	}
+
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
 	}
@@ -1314,6 +1354,10 @@ func (r *Renderer) VisitGrantPrivilege(node *ast.GrantPrivilegeNode) error {
 
 // VisitRevokePrivilege renders a REVOKE statement for PostgreSQL.
 func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
+	if err := r.requireRoleManagementCapability(); err != nil {
+		return err
+	}
+
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
 	}
@@ -1354,6 +1398,10 @@ func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
 
 // VisitAlterRole renders an ALTER ROLE statement for PostgreSQL
 func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
+	if err := r.requireRoleManagementCapability(); err != nil {
+		return err
+	}
+
 	// Add comment if provided
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
@@ -1367,6 +1415,20 @@ func (r *Renderer) VisitAlterRole(node *ast.AlterRoleNode) error {
 	}
 
 	return nil
+}
+
+func (r *Renderer) requireRowLevelSecurityCapability() error {
+	if r.capabilities().Has(capability.RowLevelSecurity) {
+		return nil
+	}
+	return fmt.Errorf("%s does not support row-level security", r.dialect)
+}
+
+func (r *Renderer) requireRoleManagementCapability() error {
+	if r.capabilities().Has(capability.RoleManagement) {
+		return nil
+	}
+	return fmt.Errorf("%s does not support role management", r.dialect)
 }
 
 // renderRoleOperation renders a single role operation as an ALTER ROLE statement

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -58,19 +58,26 @@ func SupportedDialects() []string {
 //
 // Returns an error if the dialect is not supported.
 func NewRenderer(dialect string) types.RenderVisitor {
+	return NewRendererWithCapabilities(dialect, capability.ForDialect(dialect))
+}
+
+// NewRendererWithCapabilities creates a renderer for a concrete server
+// capability set. Use this on live database paths where capabilities were
+// resolved from DBInfo.Version; NewRenderer remains the offline default.
+func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) types.RenderVisitor {
 	normalizedDialect := platform.NormalizeDialect(dialect)
 
 	switch normalizedDialect {
 	case platform.Postgres:
-		return postgres.New()
+		return postgres.NewWithCapabilities(caps, normalizedDialect)
 	case platform.MySQL:
-		return mysql.New()
+		return mysql.NewWithCapabilities(caps)
 	case platform.MariaDB:
-		return mariadb.New()
+		return mariadb.NewWithCapabilities(caps)
 	case platform.ClickHouse:
 		return clickhouse.New()
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(capability.ForDialect(normalizedDialect), normalizedDialect)
+		return postgres.NewWithCapabilities(caps, normalizedDialect)
 	default:
 		panic(fmt.Sprintf("unsupported database dialect: %s", dialect))
 	}
@@ -85,6 +92,12 @@ func RenderSQL(dialect string, nodes ...ast.Node) (string, error) {
 	return VisitorRenderSQL(r, nodes...)
 }
 
+// RenderSQLWithCapabilities renders SQL for a concrete server capability set.
+func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nodes ...ast.Node) (string, error) {
+	r := NewRendererWithCapabilities(dialect, caps)
+	return VisitorRenderSQL(r, nodes...)
+}
+
 func VisitorRenderSQL(r types.RenderVisitor, nodes ...ast.Node) (string, error) {
 	r.Reset()
 	for _, node := range nodes {
@@ -96,11 +109,21 @@ func VisitorRenderSQL(r types.RenderVisitor, nodes ...ast.Node) (string, error) 
 }
 
 func GetOrderedCreateStatements(r *goschema.Database, dialect string) []string {
+	return GetOrderedCreateStatementsWithCapabilities(r, dialect, capability.ForDialect(dialect))
+}
+
+// GetOrderedCreateStatementsWithCapabilities renders ordered create statements
+// for a concrete server capability set.
+func GetOrderedCreateStatementsWithCapabilities(
+	r *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) []string {
 	var statements []string
 
 	astNodes := fromschema.FromDatabase(*r, dialect)
 	for _, node := range astNodes.Statements {
-		sql, err := RenderSQL(dialect, node)
+		sql, err := RenderSQLWithCapabilities(dialect, caps, node)
 		if err != nil {
 			panic(err)
 		}

--- a/dbschema/capability_wiring_test.go
+++ b/dbschema/capability_wiring_test.go
@@ -1,0 +1,53 @@
+package dbschema_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestLiveCapabilityPathsAvoidVersionBlindFactories(t *testing.T) {
+	forbidden := map[string][]string{
+		"connection.go": {
+			`NewPostgreSQLReaderWithCapabilities\([^)]*capability\.ForDialect\(info\.Dialect\)`,
+			`capability\.ForDialect\(info\.Dialect\)`,
+		},
+		filepath.Join("..", "migration", "generator", "generator.go"): {
+			`planner\.GenerateSchemaDiff(AST|SQL|SQLStatements)\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+			`safety\.AssessRendered\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+			`generateUpMigrationSQL\([^)]*(conn\.Info\(\)|info)\.Dialect\)`,
+			`generateDownMigrationSQL\([^)]*(conn\.Info\(\)|info)\.Dialect\)`,
+		},
+		filepath.Join("..", "cmd", "migrate", "migrate.go"): {
+			`planner\.GenerateSchemaDiff(AST|SQL|SQLStatements)\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+			`safety\.AssessRendered\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+			`renderer\.RenderSQL\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+		},
+		filepath.Join("..", "cmd", "compare", "compare.go"): {
+			`planner\.GenerateSchemaDiff(AST|SQL|SQLStatements)\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+		},
+		filepath.Join("..", "cmd", "readdb", "readdb.go"): {
+			`renderer\.GetOrderedCreateStatements\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+		},
+		filepath.Join("..", "integration", "framework.go"): {
+			`planner\.GenerateSchemaDiff(AST|SQL|SQLStatements)\([^)]*(conn\.Info\(\)|info)\.Dialect`,
+		},
+	}
+
+	for path, snippets := range forbidden {
+		t.Run(path, func(t *testing.T) {
+			c := qt.New(t)
+			content, err := os.ReadFile(path)
+			c.Assert(err, qt.IsNil)
+			source := string(content)
+			for _, pattern := range snippets {
+				matched, err := regexp.MatchString(pattern, source)
+				c.Assert(err, qt.IsNil)
+				c.Assert(matched, qt.IsFalse, qt.Commentf("matched forbidden live capability pattern %q", pattern))
+			}
+		})
+	}
+}

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -92,13 +92,22 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to get database info: %w", err)
 	}
+	caps, versionSpecific := capability.ForServerVersionResult(info.Dialect, info.Version)
+	info.Capabilities = caps
+	if !versionSpecific {
+		slog.Debug(
+			"falling back to dialect default capabilities",
+			"dialect", info.Dialect,
+			"version", info.Version,
+		)
+	}
 
 	// Create appropriate schema reader and writer
 	var reader types.SchemaReader
 	var writer types.SchemaWriter
 	switch dialectProtocol {
 	case "pgx":
-		reader = postgres.NewPostgreSQLReaderWithCapabilities(db, info.Schema, capability.ForDialect(info.Dialect))
+		reader = postgres.NewPostgreSQLReaderWithCapabilities(db, info.Schema, info.Capabilities)
 		writer = postgres.NewPostgreSQLWriter(db, info.Schema)
 	case "mysql":
 		reader = mysql.NewMySQLReader(db, info.Schema)
@@ -145,7 +154,9 @@ func ReadSchemaWithSchemas(conn *DatabaseConnection, schemas []string) (*types.D
 
 // Info returns the database connection information
 func (dc *DatabaseConnection) Info() types.DBInfo {
-	return dc.info
+	info := dc.info
+	info.Capabilities = info.Capabilities.Clone()
+	return info
 }
 
 // Reader returns the schema reader

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/dbschema/types"
 )
 
 func TestConvertClickHouseURL(t *testing.T) {
@@ -156,6 +159,22 @@ func TestDetectPostgresWireDialect(t *testing.T) {
 			c.Assert(detectPostgresWireDialect(tt.declared, tt.version), qt.Equals, tt.expected)
 		})
 	}
+}
+
+func TestDatabaseConnectionInfoClonesCapabilities(t *testing.T) {
+	c := qt.New(t)
+
+	conn := &DatabaseConnection{
+		info: types.DBInfo{
+			Dialect:      "cockroachdb",
+			Capabilities: capability.CockroachDB23(),
+		},
+	}
+
+	info := conn.Info()
+	info.Capabilities[capability.RowLevelSecurity] = true
+
+	c.Assert(conn.Info().Capabilities.Has(capability.RowLevelSecurity), qt.IsFalse)
 }
 
 func TestRemovePostgresPoolParams(t *testing.T) {

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 	"strings"
+
+	"github.com/stokaro/ptah/core/platform/capability"
 )
 
 // DBSchema represents the complete schema read from a database
@@ -169,10 +171,11 @@ type DBExtension struct {
 
 // DBInfo contains connection and metadata information
 type DBInfo struct {
-	Dialect string `json:"dialect"` // postgres, mysql, mariadb
-	Version string `json:"version"`
-	Schema  string `json:"schema"` // public, database name, etc.
-	URL     string `json:"url"`    // database connection URL (for reference)
+	Dialect      string                  `json:"dialect"` // postgres, mysql, mariadb
+	Version      string                  `json:"version"`
+	Schema       string                  `json:"schema"`       // public, database name, etc.
+	URL          string                  `json:"url"`          // database connection URL (for reference)
+	Capabilities capability.Capabilities `json:"capabilities"` // resolved from Dialect + Version for live connections
 }
 
 // SchemaReader interface for reading database schemas

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -50,6 +50,7 @@ so typos fail fast. Current registry:
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
 | `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Trigger renderers use this to choose replace vs. drop/create |
 | `row_level_security` | Row-level security policies (PostgreSQL) |
+| `role_management` | PostgreSQL role and object privilege management (`CREATE/ALTER ROLE`, `GRANT`, `REVOKE`) |
 | `foreign_keys` | Declarative `FOREIGN KEY` constraints |
 | `sequences` | Database sequence objects (`SERIAL`/`BIGSERIAL` or explicit `CREATE SEQUENCE` support) |
 | `xml_type` | PostgreSQL `XML` column type |
@@ -85,8 +86,9 @@ composed sets yourself.
 | `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
 | `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `role_management` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
 | `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
 | `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
 | `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
@@ -121,8 +123,16 @@ planner := mysql.NewWithCapabilities(caps)
   (MariaDB over the mysql driver resolves to the MariaDB preset), and
   `PostgreSQL 16.3 (…)`. PostgreSQL-wire banners containing `CockroachDB`,
   `YugabyteDB`/`Yugabyte`, or `Spanner` resolve to their distributed-SQL
-  presets. `dbschema.ConnectToDatabase` uses this when populating
-  `conn.Info().Dialect`.
+  presets. `dbschema.ConnectToDatabase` stores this resolved set in
+  `conn.Info().Capabilities`, and live migration generation passes that same
+  set through planning, rendering, and safety assessment.
+
+Offline SQL generation has no server banner to inspect. Factories such as
+`planner.GetPlanner`, `renderer.NewRenderer`, and
+`planner.GenerateSchemaDiffSQLStatements` therefore use `ForDialect`, which is
+the current-version default for the normalized dialect. Use the
+`...WithCapabilities` variants when a caller has a live `DBInfo.Capabilities`
+value or wants to pin a specific server version in tests/CI.
 
 ## Current consumers
 
@@ -164,10 +174,11 @@ planner := mysql.NewWithCapabilities(caps)
   `platform.CockroachDB`, `platform.YugabyteDB`, and `platform.Spanner`
   normalize as distinct dialects but reuse the PostgreSQL planner, renderer,
   reader, and writer with capability presets:
-  CockroachDB disables `CREATE INDEX CONCURRENTLY`, `XML`, advisory locks, and
-  RLS; YugabyteDB disables `CREATE INDEX CONCURRENTLY` because regular
-  `CREATE INDEX` is already asynchronous in YSQL; Spanner disables enums,
-  foreign keys, sequences, RLS, XML, advisory locks, and concurrent indexes.
+  CockroachDB disables `CREATE INDEX CONCURRENTLY`, sequences, `XML`,
+  advisory locks, role management, and RLS; YugabyteDB disables
+  `CREATE INDEX CONCURRENTLY` because regular `CREATE INDEX` is already
+  asynchronous in YSQL; Spanner disables enums, foreign keys, sequences, RLS,
+  XML, advisory locks, and concurrent indexes.
   CockroachDB and YugabyteDB integration coverage uses opt-in common-subset
   scenarios that run against live OSS containers in CI. Spanner currently has
   capability, planning, rendering, URL, and detection coverage only; there is

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -407,7 +407,8 @@ func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, co
 	diff := schemadiff.CompareWithOptions(generated, dbSchema, dialectCompareOptions(conn))
 
 	// Generate migration SQL
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, conn.Info().Dialect)
+	info := conn.Info()
+	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
 
 	return statements, nil
 }

--- a/integration/gonative/driver_validation_test.go
+++ b/integration/gonative/driver_validation_test.go
@@ -12,6 +12,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	_ "github.com/jackc/pgx/v5/stdlib"
 
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema"
 )
 
@@ -61,6 +62,9 @@ func TestPgxDriverValidation(t *testing.T) {
 		// Verify connection info shows correct dialect
 		info := conn.Info()
 		c.Assert(info.Dialect, qt.Matches, "postgres|postgresql|pgx")
+		c.Assert(info.Capabilities, qt.Not(qt.IsNil))
+		c.Assert(info.Capabilities.Validate(), qt.IsNil)
+		c.Assert(info.Capabilities.Has(capability.EnumCustomType), qt.IsTrue)
 	})
 
 	t.Run("pgx specific features work", func(t *testing.T) {
@@ -129,6 +133,9 @@ func TestPgxDriverValidation(t *testing.T) {
 				// Verify connection info shows correct dialect
 				info := conn.Info()
 				c.Assert(info.Dialect, qt.Matches, "postgres|postgresql|pgx")
+				c.Assert(info.Capabilities, qt.Not(qt.IsNil))
+				c.Assert(info.Capabilities.Validate(), qt.IsNil)
+				c.Assert(info.Capabilities.Has(capability.EnumCustomType), qt.IsTrue)
 			})
 		}
 	})

--- a/integration/scenarios_cockroachdb_common.go
+++ b/integration/scenarios_cockroachdb_common.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -22,7 +24,14 @@ func testCockroachDBCommonSubset(ctx context.Context, conn *dbschema.DatabaseCon
 		})
 	}
 
-	return testPostgresDistributedCommonSubset(ctx, conn, recorder, "CockroachDB", "crdb_common_users")
+	return testPostgresDistributedCommonSubset(
+		ctx,
+		conn,
+		recorder,
+		"CockroachDB",
+		"crdb_common_users",
+		capability.CockroachDB23(),
+	)
 }
 
 // testYugabyteDBCommonSubset validates the same conservative PostgreSQL-family
@@ -34,10 +43,24 @@ func testYugabyteDBCommonSubset(ctx context.Context, conn *dbschema.DatabaseConn
 		})
 	}
 
-	return testPostgresDistributedCommonSubset(ctx, conn, recorder, "YugabyteDB", "yb_common_users")
+	return testPostgresDistributedCommonSubset(
+		ctx,
+		conn,
+		recorder,
+		"YugabyteDB",
+		"yb_common_users",
+		capability.YugabyteDB25(),
+	)
 }
 
-func testPostgresDistributedCommonSubset(ctx context.Context, conn *dbschema.DatabaseConnection, recorder *StepRecorder, label, tableName string) error {
+func testPostgresDistributedCommonSubset(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	recorder *StepRecorder,
+	label string,
+	tableName string,
+	expectedCapabilities capability.Capabilities,
+) error {
 	createUsers := ast.NewCreateTable(tableName).
 		AddColumn(ast.NewColumn("id", "BIGINT").SetPrimary()).
 		AddColumn(ast.NewColumn("email", "TEXT").SetNotNull()).
@@ -47,7 +70,20 @@ func testPostgresDistributedCommonSubset(ctx context.Context, conn *dbschema.Dat
 	var sqlText string
 	if err := recorder.RecordStep("Render "+label+" DDL", "Render common-subset table and index through the distributed-SQL renderer", func() error {
 		var err error
-		sqlText, err = renderer.RenderSQL(conn.Info().Dialect, createUsers, createEmailIndex)
+		info := conn.Info()
+		if !maps.Equal(info.Capabilities, expectedCapabilities) {
+			return fmt.Errorf("%s connection capabilities must match the expected preset", label)
+		}
+		if info.Capabilities.Has(capability.RowLevelSecurity) {
+			return fmt.Errorf("%s connection capabilities must disable RLS", label)
+		}
+		if !expectedCapabilities.Has(capability.Sequences) && info.Capabilities.Has(capability.Sequences) {
+			return fmt.Errorf("%s connection capabilities must disable sequences", label)
+		}
+		if info.Capabilities.Has(capability.CreateIndexConcurrently) {
+			return fmt.Errorf("%s connection capabilities must disable concurrent indexes", label)
+		}
+		sqlText, err = renderer.RenderSQLWithCapabilities(info.Dialect, info.Capabilities, createUsers, createEmailIndex)
 		if err != nil {
 			return fmt.Errorf("render %s SQL: %w", label, err)
 		}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
@@ -143,8 +144,9 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	version = nextAvailableMigrationVersion(opts.OutputDir, version, opts.MigrationName)
 	slog.Debug("Generated migration version", "version", version)
 
-	upNodes := planner.GenerateSchemaDiffAST(diff, generated, conn.Info().Dialect)
-	assessments, err := safety.AssessRendered(upNodes, conn.Info().Dialect)
+	info := conn.Info()
+	upNodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
+	assessments, err := safety.AssessRenderedWithCapabilities(upNodes, info.Dialect, info.Capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("error assessing migration safety: %w", err)
 	}
@@ -153,7 +155,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	}
 
 	// 5. Generate up migration SQL
-	upSQL, err := generateUpMigrationSQL(diff, generated, conn.Info().Dialect)
+	upSQL, err := generateUpMigrationSQL(diff, generated, info.Dialect, info.Capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("error generating up migration SQL: %w", err)
 	}
@@ -165,7 +167,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	}
 
 	// 6. Generate down migration SQL
-	downSQL, err := generateDownMigrationSQL(diff, generated, dbSchema, conn.Info().Dialect)
+	downSQL, err := generateDownMigrationSQL(diff, generated, dbSchema, info.Dialect, info.Capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("error generating down migration SQL: %w", err)
 	}
@@ -174,7 +176,8 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		if err := verifyShadowMigration(ctx, shadowMigrationOptions{
 			DatabaseURL:   opts.ShadowDatabaseURL,
 			MigrationsDir: opts.OutputDir,
-			Dialect:       conn.Info().Dialect,
+			Dialect:       info.Dialect,
+			Capabilities:  info.Capabilities,
 			Version:       version,
 			Name:          opts.MigrationName,
 			UpSQL:         upSQL,
@@ -257,9 +260,18 @@ func hasActualSQLStatements(statements []string) bool {
 	return false
 }
 
-// generateUpMigrationSQL generates the SQL for the up migration
-func generateUpMigrationSQL(diff *types.SchemaDiff, generated *goschema.Database, dialect string) (string, error) {
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, dialect)
+// generateUpMigrationSQL generates the SQL for the up migration.
+func generateUpMigrationSQL(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	capsOverride ...capability.Capabilities,
+) (string, error) {
+	caps := capability.ForDialect(dialect)
+	if len(capsOverride) > 0 {
+		caps = capsOverride[0]
+	}
+	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, dialect, caps)
 
 	if len(statements) == 0 || !hasActualSQLStatements(statements) {
 		// No actual SQL statements generated - this is a successful no-op operation
@@ -273,8 +285,14 @@ func generateUpMigrationSQL(diff *types.SchemaDiff, generated *goschema.Database
 	return withGeneratedTimeoutDirectives(header+strings.Join(statements, ";\n")+";", dialect), nil
 }
 
-// generateDownMigrationSQL generates the SQL for the down migration by reversing the diff
-func generateDownMigrationSQL(diff *types.SchemaDiff, generated *goschema.Database, dbSchema *dbschematypes.DBSchema, dialect string) (string, error) {
+// generateDownMigrationSQL generates the SQL for the down migration by reversing the diff.
+func generateDownMigrationSQL(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dbSchema *dbschematypes.DBSchema,
+	dialect string,
+	capsOverride ...capability.Capabilities,
+) (string, error) {
 	// For down migrations, we need to use the current database schema as the "generated" schema
 	// since we're reverting back to the current state
 	dbAsGoSchema := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
@@ -286,7 +304,11 @@ func generateDownMigrationSQL(diff *types.SchemaDiff, generated *goschema.Databa
 	// the pre-change DB state — that is exactly the action the down must restore.
 	reverseDiff := reverseSchemaDiffWithSchema(diff, generated, dbSchema)
 
-	statements := planner.GenerateSchemaDiffSQLStatements(reverseDiff, dbAsGoSchema, dialect)
+	caps := capability.ForDialect(dialect)
+	if len(capsOverride) > 0 {
+		caps = capsOverride[0]
+	}
+	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(reverseDiff, dbAsGoSchema, dialect, caps)
 
 	if len(statements) == 0 {
 		// If no statements generated, create a simple comment

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -24,6 +26,7 @@ type shadowMigrationOptions struct {
 	DatabaseURL   string
 	MigrationsDir string
 	Dialect       string
+	Capabilities  capability.Capabilities
 	Version       int
 	Name          string
 	UpSQL         string
@@ -42,6 +45,9 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 
 	if !sameDialect(opts.Dialect, conn.Info().Dialect) {
 		return fmt.Errorf("shadow check failed: shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect)
+	}
+	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, conn.Info().Capabilities) {
+		return fmt.Errorf("shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
 	}
 
 	if err := conn.Writer().DropAllTables(); err != nil {

--- a/migration/planner/capability_wiring_test.go
+++ b/migration/planner/capability_wiring_test.go
@@ -1,12 +1,14 @@
 package planner_test
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -45,6 +47,47 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 			qt.Commentf("got:\n%s", sql))
 		c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS",
 			qt.Commentf("MySQL output must be byte-identical to the pre-capability planner; got:\n%s", sql))
+	})
+}
+
+func TestGenerateSchemaDiffSQLStatementsWithCapabilities_UsesServerVersionPreset(t *testing.T) {
+	diff := &types.SchemaDiff{
+		ConstraintsRemoved: []string{"chk_qty"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "chk_qty", TableName: "things", Type: "CHECK"},
+		},
+	}
+	generated := &goschema.Database{}
+
+	t.Run("mysql 5.7 emits warning instead of invalid drop", func(t *testing.T) {
+		c := qt.New(t)
+		caps := capability.ForServerVersion("mysql", "5.7.44")
+
+		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		sql := strings.Join(statements, "\n")
+
+		c.Assert(sql, qt.Contains, "WARNING: cannot drop CHECK constraint chk_qty")
+		c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE")
+	})
+
+	t.Run("mysql 8.0.17 uses DROP CHECK", func(t *testing.T) {
+		c := qt.New(t)
+		caps := capability.ForServerVersion("mysql", "8.0.17")
+
+		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		sql := strings.Join(statements, "\n")
+
+		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CHECK chk_qty")
+	})
+
+	t.Run("mysql 8.0.19 uses generic DROP CONSTRAINT", func(t *testing.T) {
+		c := qt.New(t)
+		caps := capability.ForServerVersion("mysql", "8.0.19")
+
+		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		sql := strings.Join(statements, "\n")
+
+		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_qty")
 	})
 }
 

--- a/migration/planner/dialects/postgres/capability_gating_test.go
+++ b/migration/planner/dialects/postgres/capability_gating_test.go
@@ -1,0 +1,68 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_CapabilityGatesRLSAndRoleManagement(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		RolesAdded: []string{"app_role"},
+		RolesModified: []types.RoleDiff{
+			{RoleName: "existing_role", Changes: map[string]string{"login": "false -> true"}},
+		},
+		RolesRemoved: []string{"old_role"},
+		GrantsRemoved: []types.GrantRef{
+			{Role: "app_role", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		GrantOptionsRevoked: []types.GrantRef{
+			{Role: "app_role", Privilege: "UPDATE", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		GrantOptionsAdded: []types.GrantRef{
+			{Role: "app_role", Privilege: "REFERENCES", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		GrantsAdded: []types.GrantRef{
+			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
+		},
+		RLSPoliciesAdded: []string{"tenant_policy"},
+		RLSPoliciesRemoved: []types.RLSPolicyRef{
+			{PolicyName: "old_policy", TableName: "users"},
+		},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Roles: []goschema.Role{
+			{Name: "app_role", Inherit: true},
+			{Name: "existing_role", Login: true, Inherit: true},
+		},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "tenant_policy",
+			Table:           "users",
+			PolicyFor:       "SELECT",
+			ToRoles:         "app_role",
+			UsingExpression: "tenant_id = current_setting('app.tenant_id')::uuid",
+		}},
+	}
+
+	nodes := postgres.NewWithCapabilities(capability.CockroachDB23()).GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQLWithCapabilities("cockroachdb", capability.CockroachDB23(), nodes...)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Not(qt.Contains), "CREATE ROLE")
+	c.Assert(sql, qt.Not(qt.Contains), "ALTER ROLE")
+	c.Assert(sql, qt.Not(qt.Contains), "DROP ROLE")
+	c.Assert(sql, qt.Not(qt.Contains), "GRANT ")
+	c.Assert(sql, qt.Not(qt.Contains), "REVOKE ")
+	c.Assert(sql, qt.Not(qt.Contains), "ROW LEVEL SECURITY")
+	c.Assert(sql, qt.Not(qt.Contains), "CREATE POLICY")
+	c.Assert(sql, qt.Not(qt.Contains), "DROP POLICY")
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -750,7 +750,9 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.addNewExtensions(result, diff, generated)
 
 	// 1. Add new roles (roles may be referenced by RLS policies and functions)
-	result = p.addNewRoles(result, diff, generated)
+	if p.capabilities().Has(capability.RoleManagement) {
+		result = p.addNewRoles(result, diff, generated)
+	}
 
 	// 2. Add new functions (functions may be used by RLS policies)
 	result = p.addNewFunctions(result, diff, generated)
@@ -784,20 +786,30 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.modifyExistingTriggers(result, diff, generated)
 
 	// 7. Modify existing roles (must be done before RLS policies that reference them)
-	result = p.modifyExistingRoles(result, diff, generated)
+	if p.capabilities().Has(capability.RoleManagement) {
+		result = p.modifyExistingRoles(result, diff, generated)
+	}
 
 	// 7.5. Revoke removed grants before adding replacement grants.
-	result = p.removeGrants(result, diff)
-	result = p.revokeGrantOptions(result, diff)
+	if p.capabilities().Has(capability.RoleManagement) {
+		result = p.removeGrants(result, diff)
+		result = p.revokeGrantOptions(result, diff)
+	}
 
 	// 8. Enable RLS on tables (must be done after table creation and modification)
-	result = p.enableRLSOnTables(result, diff, generated)
+	if p.capabilities().Has(capability.RowLevelSecurity) {
+		result = p.enableRLSOnTables(result, diff, generated)
+	}
 
 	// 9. Add RLS policies (must be done after RLS is enabled and columns exist)
-	result = p.addNewRLSPolicies(result, diff, generated)
+	if p.capabilities().Has(capability.RowLevelSecurity) {
+		result = p.addNewRLSPolicies(result, diff, generated)
+	}
 
 	// 9.5. Add role privilege grants after roles and target objects exist.
-	result = p.addNewGrants(result, diff)
+	if p.capabilities().Has(capability.RoleManagement) {
+		result = p.addNewGrants(result, diff)
+	}
 
 	// 10. Add new indexes
 	result = p.addNewIndexes(result, diff, generated)
@@ -809,10 +821,14 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.removeIndexes(result, diff)
 
 	// 12. Remove RLS policies (must be done before disabling RLS and before dropping columns)
-	result = p.removeRLSPolicies(result, diff)
+	if p.capabilities().Has(capability.RowLevelSecurity) {
+		result = p.removeRLSPolicies(result, diff)
+	}
 
 	// 11. Disable RLS on tables (must be done after removing policies)
-	result = p.disableRLSOnTables(result, diff)
+	if p.capabilities().Has(capability.RowLevelSecurity) {
+		result = p.disableRLSOnTables(result, diff)
+	}
 
 	// 12. Remove table columns (must be done after removing RLS policies that depend on columns)
 	result = p.removeTableColumns(result, diff)
@@ -832,7 +848,9 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.removeFunctions(result, diff)
 
 	// 14. Remove roles (must be done after removing functions and policies that depend on them)
-	result = p.removeRoles(result, diff)
+	if p.capabilities().Has(capability.RoleManagement) {
+		result = p.removeRoles(result, diff)
+	}
 
 	// 15. Remove enums (dangerous!)
 	result = p.removeEnums(result, diff)

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -201,15 +201,23 @@ type Planner interface {
 //   - Centralize dialect validation and error handling
 //   - Enable dependency injection and testing scenarios
 func GetPlanner(dialect string) Planner {
+	return GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
+}
+
+// GetPlannerWithCapabilities returns a dialect-specific migration planner for
+// a concrete target capability set. Live database paths should pass
+// DBInfo.Capabilities so planning uses the same server-version preset as
+// readers and renderers. Offline callers should use GetPlanner.
+func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) Planner {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
-		return postgres.New()
+		return postgres.NewWithCapabilities(caps)
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(capability.ForDialect(dialect))
+		return postgres.NewWithCapabilities(caps)
 	case platform.MySQL:
-		return mysql.New()
+		return mysql.NewWithCapabilities(caps)
 	case platform.MariaDB:
-		return mysql.NewWithCapabilities(capability.MariaDB1011())
+		return mysql.NewWithCapabilities(caps)
 	case platform.ClickHouse:
 		return clickhouse.New()
 	default:
@@ -259,7 +267,19 @@ func GetPlanner(dialect string) Planner {
 //   - GenerateSchemaDiffSQLStatements: For individual SQL statements
 //   - GetPlanner: For direct planner access
 func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) []ast.Node {
-	planner := GetPlanner(dialect)
+	planner := GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
+	return planner.GenerateMigrationAST(diff, generated)
+}
+
+// GenerateSchemaDiffASTWithCapabilities generates AST nodes for a concrete
+// target capability set resolved from a live server version.
+func GenerateSchemaDiffASTWithCapabilities(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) []ast.Node {
+	planner := GetPlannerWithCapabilities(dialect, caps)
 	return planner.GenerateMigrationAST(diff, generated)
 }
 
@@ -316,7 +336,20 @@ func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database,
 //   - GenerateSchemaDiffSQL: For complete SQL string without splitting
 //   - GenerateSchemaDiffAST: For AST nodes without rendering
 func GenerateSchemaDiffSQLStatements(diff *types.SchemaDiff, generated *goschema.Database, dialect string) []string {
-	output := GenerateSchemaDiffSQL(diff, generated, dialect)
+	output := GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, capability.ForDialect(dialect))
+	statements := sqlutil.SplitSQLStatements(output)
+	return statements
+}
+
+// GenerateSchemaDiffSQLStatementsWithCapabilities generates individual SQL
+// statements using a concrete server capability set.
+func GenerateSchemaDiffSQLStatementsWithCapabilities(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) []string {
+	output := GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, caps)
 	statements := sqlutil.SplitSQLStatements(output)
 	return statements
 }
@@ -382,8 +415,19 @@ func GenerateSchemaDiffSQLStatements(diff *types.SchemaDiff, generated *goschema
 //   - GenerateSchemaDiffSQLStatements: For individual SQL statements
 //   - GenerateSchemaDiffAST: For AST nodes without rendering
 func GenerateSchemaDiffSQL(diff *types.SchemaDiff, generated *goschema.Database, dialect string) string {
-	astNodes := GenerateSchemaDiffAST(diff, generated, dialect)
-	output, err := renderer.RenderSQL(dialect, astNodes...)
+	return GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, capability.ForDialect(dialect))
+}
+
+// GenerateSchemaDiffSQLWithCapabilities generates complete SQL using a
+// concrete server capability set.
+func GenerateSchemaDiffSQLWithCapabilities(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) string {
+	astNodes := GenerateSchemaDiffASTWithCapabilities(diff, generated, dialect, caps)
+	output, err := renderer.RenderSQLWithCapabilities(dialect, caps, astNodes...)
 	if err != nil {
 		panic(err)
 	}

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -131,10 +132,21 @@ func Assess(nodes []ast.Node) []StatementAssessment {
 // AssessRendered returns per-rendered-SQL-statement risk classifications for
 // generated AST nodes.
 func AssessRendered(nodes []ast.Node, dialect string) ([]StatementAssessment, error) {
+	return AssessRenderedWithCapabilities(nodes, dialect, capability.ForDialect(dialect))
+}
+
+// AssessRenderedWithCapabilities returns per-rendered-SQL-statement risk
+// classifications using the same server-version capability set as planning and
+// rendering on live database paths.
+func AssessRenderedWithCapabilities(
+	nodes []ast.Node,
+	dialect string,
+	caps capability.Capabilities,
+) ([]StatementAssessment, error) {
 	var assessments []StatementAssessment
 	for _, node := range nodes {
 		nodeAssessment := assessNode(node)
-		rendered, err := renderer.RenderSQL(dialect, node)
+		rendered, err := renderer.RenderSQLWithCapabilities(dialect, caps, node)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Resolve live database capabilities from `Dialect` + `Version` once in `ConnectToDatabase` and expose them as `DBInfo.Capabilities`.
- Thread that concrete capability set through live schema reading, planning, rendering, safety assessment, migration generation, shadow checks, and integration helpers.
- Keep offline helpers on dialect defaults while adding `...WithCapabilities` APIs for callers that have a live target or pinned server version.
- Add regression coverage for MySQL 5.7 / 8.0.17 / 8.0.19 behavior, PostgreSQL live capability population, Cockroach-style capability assertions in integration flows, and static checks against version-blind live factories.
- Document the live vs offline capability contract.

Closes #280

## Validation

- `GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `POSTGRES_TEST_DSN="postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable" GOCACHE=/private/tmp/ptah-go-cache go test -tags integration ./integration/gonative -count=1`
- `GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache GOCACHE=/private/tmp/ptah-go-cache golangci-lint run --fix ./...`
- `GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache GOCACHE=/private/tmp/ptah-go-cache golangci-lint run ./...`
- `git diff --check`