### PR TITLE
fix(goschema): wire Constraints/Views/MaterializedViews/Triggers/Grants through ParseFS/ParseDir (fixes #279)

### DIFF
--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1,11 +1,13 @@
 package goschema
 
 import (
+	"fmt"
 	"log/slog"
 	"maps"
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -247,18 +249,11 @@ func normalizeTableScopedNames(r *Database) {
 		}
 	}
 	// Views and MaterializedViews: no table-scoped normalization applied here.
-	// Decision: unlike Triggers/Constraints/Grants/Indexes/RLS which reference a .Table,
-	// Views/MaterializedViews declare a standalone .Name (which may include schema prefix
-	// e.g. "public.foo" or be unqualified). They are not "table scoped" from a host table
-	// struct in the same manner. If view names need struct-to-name resolution or schema
-	// inference in future (e.g. schema-scoped Go files), extend this loop similarly.
-	// Current behavior preserved for compatibility with YAML and existing parser paths.
-	for i := range r.Views {
-		_ = &r.Views[i] // name left as-parsed
-	}
-	for i := range r.MaterializedViews {
-		_ = &r.MaterializedViews[i]
-	}
+	// Unlike Triggers/Constraints/Grants/Indexes/RLS, which reference a .Table,
+	// Views/MaterializedViews declare a standalone .Name (which may include a
+	// schema prefix, e.g. "public.foo", or be unqualified). They are not table
+	// scoped from a host table struct in the same manner. Current behavior is
+	// preserved for compatibility with YAML and existing parser paths.
 }
 
 func resolveTableReference(tables []Table, structName, tableName string) *Table {
@@ -822,8 +817,8 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 //   - Embedded Fields: Deduplicated by struct name + embedded type name combination
 //   - Views and materialized views: Deduplicated by name
 //   - Triggers: Deduplicated by table name + trigger name combination
-//   - Constraints: Deduplicated by table + constraint name
-//   - Grants: Deduplicated by role + privileges + (table or schema) target
+//   - Constraints: Deduplicated by explicit table + name, or declaring struct + name when table is omitted
+//   - Grants: Deduplicated by role + privileges + grant option + (table or schema) target
 //   - Roles: Deduplicated by role name
 //
 // All 15 Database slice collections are now covered (previously only a subset
@@ -996,15 +991,15 @@ func deduplicateTriggers(triggers []Trigger) []Trigger {
 	return deduplicated
 }
 
-// deduplicateConstraints dedups table-level constraints by (StructName + name).
-// Uses StructName (the declaring Go type) so dedup happens before normalizeTableScopedNames
-// qualifies .Table (which may be empty when annotation omits `table=` and relies on struct assoc).
-// This matches the pattern used for indexes (StructName + Name).
+// deduplicateConstraints dedups table-level constraints by their declared
+// table scope when table= is explicit, otherwise by the declaring Go type.
+// The fallback is needed before normalizeTableScopedNames fills .Table for
+// annotations that rely on struct association.
 func deduplicateConstraints(constraints []Constraint) []Constraint {
 	seen := make(map[string]bool)
 	deduplicated := make([]Constraint, 0, len(constraints))
 	for _, c := range constraints {
-		key := c.StructName + "." + c.Name
+		key := constraintDedupKey(c)
 		if !seen[key] {
 			seen[key] = true
 			deduplicated = append(deduplicated, c)
@@ -1013,21 +1008,144 @@ func deduplicateConstraints(constraints []Constraint) []Constraint {
 	return deduplicated
 }
 
+func constraintDedupKey(c Constraint) string {
+	scope := c.StructName
+	if strings.TrimSpace(c.Table) != "" {
+		scope = strings.TrimSpace(c.Table)
+	}
+	return scope + "." + c.Name
+}
+
 // deduplicateGrants dedups by role + privileges + target (table or schema).
-// Uses Canonicalize for stable privilege list.
+// The grant option is part of identity: a plain grant and a grant WITH GRANT
+// OPTION must both survive. Privilege order is normalized only for the key, so
+// logically identical grants deduplicate even when annotations list privileges
+// in a different order.
 func deduplicateGrants(grants []Grant) []Grant {
 	seen := make(map[string]bool)
 	deduplicated := make([]Grant, 0, len(grants))
 	for _, g := range grants {
 		g.Canonicalize()
-		privs := strings.Join(g.Privileges, ",")
-		key := g.Role + "|" + privs + "|t:" + g.OnTable + "|s:" + g.OnSchema
+		privileges := append([]string(nil), g.Privileges...)
+		sort.Strings(privileges)
+		privs := strings.Join(privileges, ",")
+		key := g.Role + "|" + privs + "|t:" + g.OnTable + "|s:" + g.OnSchema + "|o:" + strconv.FormatBool(g.WithOption)
 		if !seen[key] {
 			seen[key] = true
 			deduplicated = append(deduplicated, g)
 		}
 	}
 	return deduplicated
+}
+
+func validateDuplicateSchemaObjectDefinitions(r *Database) error {
+	if err := validateDuplicateViews(r.Views); err != nil {
+		return err
+	}
+	if err := validateDuplicateMaterializedViews(r.MaterializedViews); err != nil {
+		return err
+	}
+	if err := validateDuplicateTriggers(r.Triggers); err != nil {
+		return err
+	}
+	if err := validateDuplicateConstraints(r.Constraints); err != nil {
+		return err
+	}
+	if err := validateDuplicateRoles(r.Roles); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateDuplicateViews(views []View) error {
+	seen := make(map[string]string)
+	for _, view := range views {
+		signature := strings.Join([]string{view.Body, strconv.FormatBool(view.WithCheck)}, "\x00")
+		if previous, ok := seen[view.Name]; ok && previous != signature {
+			return fmt.Errorf("conflicting view %q definitions", view.Name)
+		}
+		seen[view.Name] = signature
+	}
+	return nil
+}
+
+func validateDuplicateMaterializedViews(views []MaterializedView) error {
+	seen := make(map[string]string)
+	for _, view := range views {
+		view.Canonicalize()
+		signature := strings.Join([]string{view.Body, view.RefreshStrategy}, "\x00")
+		if previous, ok := seen[view.Name]; ok && previous != signature {
+			return fmt.Errorf("conflicting materialized view %q definitions", view.Name)
+		}
+		seen[view.Name] = signature
+	}
+	return nil
+}
+
+func validateDuplicateTriggers(triggers []Trigger) error {
+	seen := make(map[string]string)
+	for _, trigger := range triggers {
+		trigger.Canonicalize()
+		key := trigger.Table + "." + trigger.Name
+		signature := strings.Join([]string{trigger.Timing, trigger.Event, trigger.ForEach, trigger.Body}, "\x00")
+		if previous, ok := seen[key]; ok && previous != signature {
+			return fmt.Errorf("conflicting trigger %q definitions on table %q", trigger.Name, trigger.Table)
+		}
+		seen[key] = signature
+	}
+	return nil
+}
+
+func validateDuplicateConstraints(constraints []Constraint) error {
+	seen := make(map[string]string)
+	for _, constraint := range constraints {
+		key := constraintDedupKey(constraint)
+		signature := strings.Join([]string{
+			constraint.Type,
+			constraint.Table,
+			constraint.UsingMethod,
+			constraint.ExcludeElements,
+			constraint.WhereCondition,
+			constraint.CheckExpression,
+			strings.Join(constraint.Columns, ","),
+			constraint.ForeignTable,
+			constraint.ForeignColumn,
+			constraint.OnDelete,
+			constraint.OnUpdate,
+		}, "\x00")
+		if previous, ok := seen[key]; ok && previous != signature {
+			return fmt.Errorf("conflicting constraint %q definitions in scope %q", constraint.Name, constraintDedupScope(constraint))
+		}
+		seen[key] = signature
+	}
+	return nil
+}
+
+func constraintDedupScope(c Constraint) string {
+	if strings.TrimSpace(c.Table) != "" {
+		return strings.TrimSpace(c.Table)
+	}
+	return c.StructName
+}
+
+func validateDuplicateRoles(roles []Role) error {
+	seen := make(map[string]string)
+	for _, role := range roles {
+		signature := strings.Join([]string{
+			strconv.FormatBool(role.Login),
+			role.Password,
+			strconv.FormatBool(role.Superuser),
+			strconv.FormatBool(role.CreateDB),
+			strconv.FormatBool(role.CreateRole),
+			strconv.FormatBool(role.Inherit),
+			strconv.FormatBool(role.Replication),
+		}, "\x00")
+		if previous, ok := seen[role.Name]; ok && previous != signature {
+			return fmt.Errorf("conflicting role %q definitions", role.Name)
+		}
+		seen[role.Name] = signature
+	}
+	return nil
 }
 
 // deduplicateRoles dedups roles by name (roles are global per DB).

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -246,6 +246,19 @@ func normalizeTableScopedNames(r *Database) {
 			trigger.Table = table.QualifiedName()
 		}
 	}
+	// Views and MaterializedViews: no table-scoped normalization applied here.
+	// Decision: unlike Triggers/Constraints/Grants/Indexes/RLS which reference a .Table,
+	// Views/MaterializedViews declare a standalone .Name (which may include schema prefix
+	// e.g. "public.foo" or be unqualified). They are not "table scoped" from a host table
+	// struct in the same manner. If view names need struct-to-name resolution or schema
+	// inference in future (e.g. schema-scoped Go files), extend this loop similarly.
+	// Current behavior preserved for compatibility with YAML and existing parser paths.
+	for i := range r.Views {
+		_ = &r.Views[i] // name left as-parsed
+	}
+	for i := range r.MaterializedViews {
+		_ = &r.MaterializedViews[i]
+	}
 }
 
 func resolveTableReference(tables []Table, structName, tableName string) *Table {
@@ -809,8 +822,16 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 //   - Embedded Fields: Deduplicated by struct name + embedded type name combination
 //   - Views and materialized views: Deduplicated by name
 //   - Triggers: Deduplicated by table name + trigger name combination
+//   - Constraints: Deduplicated by table + constraint name
+//   - Grants: Deduplicated by role + privileges + (table or schema) target
+//   - Roles: Deduplicated by role name
 //
-// This method modifies the PackageParseResult in-place, replacing the original
+// All 15 Database slice collections are now covered (previously only a subset
+// of appended collections were deduplicated, and the five dropped by ParseFS
+// were never reached). This prevents duplicate emits when objects are declared
+// across files.
+//
+// This method modifies the Database in-place, replacing the original
 // slices with deduplicated versions. The order of entities may change during
 // this process, but dependency ordering is handled separately.
 func Deduplicate(r *Database) {
@@ -931,6 +952,9 @@ func deduplicateSchemaObjects(r *Database) {
 	r.Views = deduplicateViews(r.Views)
 	r.MaterializedViews = deduplicateMaterializedViews(r.MaterializedViews)
 	r.Triggers = deduplicateTriggers(r.Triggers)
+	r.Constraints = deduplicateConstraints(r.Constraints)
+	r.Grants = deduplicateGrants(r.Grants)
+	r.Roles = deduplicateRoles(r.Roles)
 }
 
 func deduplicateViews(views []View) []View {
@@ -967,6 +991,53 @@ func deduplicateTriggers(triggers []Trigger) []Trigger {
 		if !seen[key] {
 			seen[key] = true
 			deduplicated = append(deduplicated, trigger)
+		}
+	}
+	return deduplicated
+}
+
+// deduplicateConstraints dedups table-level constraints by (StructName + name).
+// Uses StructName (the declaring Go type) so dedup happens before normalizeTableScopedNames
+// qualifies .Table (which may be empty when annotation omits `table=` and relies on struct assoc).
+// This matches the pattern used for indexes (StructName + Name).
+func deduplicateConstraints(constraints []Constraint) []Constraint {
+	seen := make(map[string]bool)
+	deduplicated := make([]Constraint, 0, len(constraints))
+	for _, c := range constraints {
+		key := c.StructName + "." + c.Name
+		if !seen[key] {
+			seen[key] = true
+			deduplicated = append(deduplicated, c)
+		}
+	}
+	return deduplicated
+}
+
+// deduplicateGrants dedups by role + privileges + target (table or schema).
+// Uses Canonicalize for stable privilege list.
+func deduplicateGrants(grants []Grant) []Grant {
+	seen := make(map[string]bool)
+	deduplicated := make([]Grant, 0, len(grants))
+	for _, g := range grants {
+		g.Canonicalize()
+		privs := strings.Join(g.Privileges, ",")
+		key := g.Role + "|" + privs + "|t:" + g.OnTable + "|s:" + g.OnSchema
+		if !seen[key] {
+			seen[key] = true
+			deduplicated = append(deduplicated, g)
+		}
+	}
+	return deduplicated
+}
+
+// deduplicateRoles dedups roles by name (roles are global per DB).
+func deduplicateRoles(roles []Role) []Role {
+	seen := make(map[string]bool)
+	deduplicated := make([]Role, 0, len(roles))
+	for _, r := range roles {
+		if !seen[r.Name] {
+			seen[r.Name] = true
+			deduplicated = append(deduplicated, r)
 		}
 	}
 	return deduplicated

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -216,6 +216,44 @@ func TestDeduplicate_EmbeddedFieldOrderPreservation(t *testing.T) {
 	c.Assert(db.EmbeddedFields, qt.HasLen, 4) // Should have 4 unique embedded fields
 }
 
+func TestDeduplicate_GrantsKeepGrantOptionAndIgnorePrivilegeOrder(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Grants: []goschema.Grant{
+			{Role: "app", Privileges: []string{"SELECT", "INSERT"}, OnTable: "users"},
+			{Role: "app", Privileges: []string{"INSERT", "SELECT"}, OnTable: "users"},
+			{Role: "app", Privileges: []string{"SELECT", "INSERT"}, OnTable: "users", WithOption: true},
+		},
+	}
+
+	goschema.Deduplicate(db)
+
+	c.Assert(db.Grants, qt.HasLen, 2)
+	c.Assert(db.Grants[0].WithOption, qt.IsFalse)
+	c.Assert(db.Grants[0].Privileges, qt.DeepEquals, []string{"SELECT", "INSERT"})
+	c.Assert(db.Grants[1].WithOption, qt.IsTrue)
+	c.Assert(db.Grants[1].Privileges, qt.DeepEquals, []string{"SELECT", "INSERT"})
+}
+
+func TestDeduplicate_ConstraintsUseExplicitTableScope(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{StructName: "User", Table: "users", Name: "users_email_check", Type: "CHECK", CheckExpression: "email <> ''"},
+			{StructName: "UserMixin", Table: "users", Name: "users_email_check", Type: "CHECK", CheckExpression: "email <> ''"},
+			{StructName: "Account", Table: "accounts", Name: "users_email_check", Type: "CHECK", CheckExpression: "email <> ''"},
+		},
+	}
+
+	goschema.Deduplicate(db)
+
+	c.Assert(db.Constraints, qt.HasLen, 2)
+	c.Assert(db.Constraints[0].StructName, qt.Equals, "User")
+	c.Assert(db.Constraints[1].StructName, qt.Equals, "Account")
+}
+
 func TestDeduplicate_ComplexScenarioWithAllTypes(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -73,13 +73,18 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		Tables:                     []Table{},
 		Fields:                     []Field{},
 		Indexes:                    []Index{},
+		Constraints:                []Constraint{},
 		Enums:                      []Enum{},
 		EmbeddedFields:             []EmbeddedField{},
 		Extensions:                 []Extension{},
 		Functions:                  []Function{},
+		Views:                      []View{},
+		MaterializedViews:          []MaterializedView{},
+		Triggers:                   []Trigger{},
 		RLSPolicies:                []RLSPolicy{},
 		RLSEnabledTables:           []RLSEnabledTable{},
 		Roles:                      []Role{},
+		Grants:                     []Grant{},
 		Dependencies:               make(map[string][]string),
 		FunctionDependencies:       make(map[string][]string),
 		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
@@ -127,6 +132,11 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		result.RLSPolicies = append(result.RLSPolicies, database.RLSPolicies...)
 		result.RLSEnabledTables = append(result.RLSEnabledTables, database.RLSEnabledTables...)
 		result.Roles = append(result.Roles, database.Roles...)
+		result.Constraints = append(result.Constraints, database.Constraints...)
+		result.Views = append(result.Views, database.Views...)
+		result.MaterializedViews = append(result.MaterializedViews, database.MaterializedViews...)
+		result.Triggers = append(result.Triggers, database.Triggers...)
+		result.Grants = append(result.Grants, database.Grants...)
 
 		return nil
 	})

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -145,6 +145,10 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		return nil, err
 	}
 
+	if err := validateDuplicateSchemaObjectDefinitions(result); err != nil {
+		return nil, err
+	}
+
 	// deduplicate entities (same table/field defined in multiple files)
 	Deduplicate(result)
 	normalizeTableScopedNames(result)

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -1236,27 +1236,37 @@ type Product struct {
 	}
 }
 
-// TestParseDir_SchemaObjectsAndGrants verifies that ParseDir (and thus ParseFS used by CLI)
-// now returns Constraints, Views, MaterializedViews, Triggers and Grants from Go annotations.
-// This is the core repro for #279. Also exercises cross-file dedup.
+// TestParseDir_SchemaObjectsAndGrants verifies that ParseDir (and thus ParseFS
+// used by CLI) returns every Database slice collection populated by Go
+// annotations. This is the core repro for #279 and also exercises cross-file
+// duplicate no-ops.
 func TestParseDir_SchemaObjectsAndGrants(t *testing.T) {
 	c := qt.New(t)
 
-	// Use the dedicated fixture dir that declares a table + all five object kinds.
-	// Also includes a duplicate view declaration in second file to test dedup.
 	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
 
 	result, err := goschema.ParseDir(fixtureDir)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.IsNotNil)
 
-	// Basic table still there
 	c.Assert(result.Tables, qt.HasLen, 1)
 	c.Assert(result.Tables[0].Name, qt.Equals, "users")
 
-	// The five that used to be dropped
+	c.Assert(len(result.Fields) > 0, qt.IsTrue)
+	c.Assert(result.Indexes, qt.HasLen, 1)
+	c.Assert(result.Indexes[0].Name, qt.Equals, "idx_users_email")
+	c.Assert(result.Enums, qt.HasLen, 1)
+	c.Assert(result.Enums[0].Name, qt.Equals, "enum_user_status")
+	c.Assert(result.EmbeddedFields, qt.HasLen, 1)
+	c.Assert(result.EmbeddedFields[0].EmbeddedTypeName, qt.Equals, "UserMetadata")
+	c.Assert(result.Extensions, qt.HasLen, 1)
+	c.Assert(result.Extensions[0].Name, qt.Equals, "pg_trgm")
+	c.Assert(result.Functions, qt.HasLen, 1)
+	c.Assert(result.Functions[0].Name, qt.Equals, "get_fixture_tenant_id")
+
 	c.Assert(result.Views, qt.HasLen, 1, qt.Commentf("view should be populated via ParseDir; got 0 (was the #279 bug)"))
 	c.Assert(result.Views[0].Name, qt.Equals, "active_users")
+	c.Assert(result.Views[0].Comment, qt.Equals, "Active users view")
 
 	c.Assert(result.MaterializedViews, qt.HasLen, 1)
 	c.Assert(result.MaterializedViews[0].Name, qt.Equals, "user_stats")
@@ -1264,44 +1274,37 @@ func TestParseDir_SchemaObjectsAndGrants(t *testing.T) {
 	c.Assert(result.Triggers, qt.HasLen, 1)
 	c.Assert(result.Triggers[0].Name, qt.Equals, "users_set_updated_at")
 
-	c.Assert(result.Grants, qt.HasLen, 2, qt.Commentf("two grants (table + schema)"))
+	c.Assert(result.RLSPolicies, qt.HasLen, 1)
+	c.Assert(result.RLSPolicies[0].Name, qt.Equals, "users_tenant_policy")
+	c.Assert(result.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(result.RLSEnabledTables[0].Table, qt.Equals, "users")
+
+	c.Assert(result.Grants, qt.HasLen, 3, qt.Commentf("table grant, grant-option table grant, and schema grant"))
 	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Name, qt.Equals, "users_email_check")
 
-	// Role also present (was appended before)
 	c.Assert(result.Roles, qt.HasLen, 1)
-	c.Assert(result.Roles[0].Name, qt.Equals, "app_user")
-
-	// Dedup across files: duplicate view decl in duplicate.go must yield only 1
-	c.Assert(result.Views, qt.HasLen, 1)
+	c.Assert(result.Roles[0].Name, qt.Equals, "fixture_app_user")
 }
 
-// TestParseDir_AllCollectionsCoveredByReflectionGuard is a compile-time-ish
-// check that can evolve; the real guard is in TestParseFS_ReflectionGuard.
-func TestParseDir_AllCollectionsCoveredByReflectionGuard(t *testing.T) {
+func TestParseDir_AllIntegrationFixturesRemainParsable(t *testing.T) {
 	c := qt.New(t)
-	// Simple smoke: ensure after ParseDir we have non-nil slices for the key ones
-	// (detailed guard test below uses reflection against ParseSource)
-	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
-	result, err := goschema.ParseDir(fixtureDir)
+
+	result, err := goschema.ParseDir("../../integration/fixtures/entities")
 	c.Assert(err, qt.IsNil)
-	_ = result.Views
-	_ = result.Grants
+	c.Assert(result.Tables, qt.Not(qt.HasLen), 0)
+	c.Assert(result.Roles, qt.Not(qt.HasLen), 0)
 }
 
-// TestParseFS_ReflectionGuard is the future-proof guard required by #279.
+// TestParseDir_ReflectionGuard is the future-proof guard required by #279.
 // It uses reflection over Database to enumerate all slice fields, runs ParseSource
-// (which populates all) on a comprehensive source, then ParseFS on equivalent FS,
-// and asserts that any collection populated by ParseSource is also non-empty after ParseFS.
-// This catches if a future 16th collection is added without wiring the append in walker.
+// on the comprehensive fixture, then ParseDir on the same fixture, and asserts
+// that every Database slice is both covered by the fixture and survives the
+// ParseFS append path used by ParseDir.
 // Merge uses general reflection over all slice fields from ParseSource results (no hard-coded list).
-func TestParseFS_ReflectionGuard(t *testing.T) {
+func TestParseDir_ReflectionGuard(t *testing.T) {
 	c := qt.New(t)
 
-	// Canonical on-disk fixture only. Read each .go, use ParseSource per file and general-reflect merge all slices.
-	// Then ParseDir on the dir. Reflect-assert that any slice populated (>0) by the per-file parse
-	// is also populated (>0) after ParseDir/ParseFS. This exercises the real shipped append paths
-	// and would fail if any append in walker.go is missing.
 	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
 
 	merged := goschema.Database{}
@@ -1329,7 +1332,6 @@ func TestParseFS_ReflectionGuard(t *testing.T) {
 	dirDb, err := goschema.ParseDir(fixtureDir)
 	c.Assert(err, qt.IsNil)
 
-	// Reflect: for every slice that merged (per-file ParseSource) populated, ParseDir must too.
 	fvMerged := reflect.ValueOf(merged)
 	fvDir := reflect.ValueOf(*dirDb)
 	typ := fvMerged.Type()
@@ -1340,11 +1342,103 @@ func TestParseFS_ReflectionGuard(t *testing.T) {
 		name := typ.Field(i).Name
 		mLen := fvMerged.Field(i).Len()
 		if mLen == 0 {
-			continue
+			c.Fatalf("%s is not exercised by the fixture; add it to 023-go-annotations-objects so the walker append stays covered", name)
 		}
 		dLen := fvDir.Field(i).Len()
 		c.Assert(dLen > 0, qt.IsTrue, qt.Commentf("%s populated by per-file parse (%d) but ParseDir/ParseFS gave %d — missing append in walker.go?", name, mLen, dLen))
 	}
+}
+
+func TestParseFS_ConflictingDuplicateSchemaObjectsFail(t *testing.T) {
+	tests := []struct {
+		name     string
+		sourceA  string
+		sourceB  string
+		err      string
+		sameHost bool
+	}{
+		{
+			name:    "view body",
+			sourceA: `//migrator:schema:view name="active_users" body="SELECT id FROM users"`,
+			sourceB: `//migrator:schema:view name="active_users" body="SELECT email FROM users"`,
+			err:     `conflicting view "active_users" definitions`,
+		},
+		{
+			name:    "materialized view body",
+			sourceA: `//migrator:schema:matview name="user_stats" body="SELECT count(*) FROM users"`,
+			sourceB: `//migrator:schema:matview name="user_stats" body="SELECT count(id) FROM users"`,
+			err:     `conflicting materialized view "user_stats" definitions`,
+		},
+		{
+			name:    "trigger body",
+			sourceA: `//migrator:schema:trigger name="set_updated_at" table="users" timing="BEFORE" event="UPDATE" body="RETURN NEW;"`,
+			sourceB: `//migrator:schema:trigger name="set_updated_at" table="users" timing="BEFORE" event="UPDATE" body="NEW.updated_at = NOW(); RETURN NEW;"`,
+			err:     `conflicting trigger "set_updated_at" definitions on table "users"`,
+		},
+		{
+			name:     "constraint expression",
+			sourceA:  `//migrator:schema:constraint name="users_email_check" type="CHECK" check="email <> ''"`,
+			sourceB:  `//migrator:schema:constraint name="users_email_check" type="CHECK" check="length(email) > 3"`,
+			err:      `conflicting constraint "users_email_check" definitions in scope "DuplicateHost"`,
+			sameHost: true,
+		},
+		{
+			name:    "explicit table constraint expression",
+			sourceA: `//migrator:schema:constraint name="users_email_check" type="CHECK" table="users" check="email <> ''"`,
+			sourceB: `//migrator:schema:constraint name="users_email_check" type="CHECK" table="users" check="length(email) > 3"`,
+			err:     `conflicting constraint "users_email_check" definitions in scope "users"`,
+		},
+		{
+			name:    "role attributes",
+			sourceA: `//migrator:schema:role name="app_user" inherit="true"`,
+			sourceB: `//migrator:schema:role name="app_user" login="true" inherit="true"`,
+			err:     `conflicting role "app_user" definitions`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			firstHost := "FirstHost"
+			secondHost := "SecondHost"
+			if tt.sameHost {
+				firstHost = "DuplicateHost"
+				secondHost = "DuplicateHost"
+			}
+			fsys := fstest.MapFS{
+				"a.go": {Data: []byte("package fixtures\n\n" + tt.sourceA + "\ntype " + firstHost + " struct{}\n")},
+				"b.go": {Data: []byte("package fixtures\n\n" + tt.sourceB + "\ntype " + secondHost + " struct{}\n")},
+			}
+
+			_, err := goschema.ParseFS(fsys, ".")
+
+			c.Assert(err, qt.ErrorMatches, tt.err)
+		})
+	}
+}
+
+func TestParseFS_IdenticalDuplicateSchemaObjectsAreNoOp(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"a.go": {Data: []byte(`package fixtures
+
+//migrator:schema:view name="active_users" body="SELECT id FROM users" comment="first"
+type First struct{}
+`)},
+		"b.go": {Data: []byte(`package fixtures
+
+//migrator:schema:view name="active_users" body="SELECT id FROM users" comment="second"
+type Second struct{}
+`)},
+	}
+
+	result, err := goschema.ParseFS(fsys, ".")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Views, qt.HasLen, 1)
+	c.Assert(result.Views[0].Comment, qt.Equals, "first")
 }
 
 // BenchmarkParseFS_LargeProject benchmarks ParseFS performance on a larger project

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"testing/fstest"
 
@@ -1231,6 +1232,141 @@ type Product struct {
 		if err != nil {
 			b.Fatalf("ParseFS failed: %v", err)
 		}
+	}
+}
+
+// TestParseDir_SchemaObjectsAndGrants verifies that ParseDir (and thus ParseFS used by CLI)
+// now returns Constraints, Views, MaterializedViews, Triggers and Grants from Go annotations.
+// This is the core repro for #279. Also exercises cross-file dedup.
+func TestParseDir_SchemaObjectsAndGrants(t *testing.T) {
+	c := qt.New(t)
+
+	// Use the dedicated fixture dir that declares a table + all five object kinds.
+	// Also includes a duplicate view declaration in second file to test dedup.
+	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
+
+	result, err := goschema.ParseDir(fixtureDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.IsNotNil)
+
+	// Basic table still there
+	c.Assert(result.Tables, qt.HasLen, 1)
+	c.Assert(result.Tables[0].Name, qt.Equals, "users")
+
+	// The five that used to be dropped
+	c.Assert(result.Views, qt.HasLen, 1, qt.Commentf("view should be populated via ParseDir; got 0 (was the #279 bug)"))
+	c.Assert(result.Views[0].Name, qt.Equals, "active_users")
+
+	c.Assert(result.MaterializedViews, qt.HasLen, 1)
+	c.Assert(result.MaterializedViews[0].Name, qt.Equals, "user_stats")
+
+	c.Assert(result.Triggers, qt.HasLen, 1)
+	c.Assert(result.Triggers[0].Name, qt.Equals, "users_set_updated_at")
+
+	c.Assert(result.Grants, qt.HasLen, 2, qt.Commentf("two grants (table + schema)"))
+	c.Assert(result.Constraints, qt.HasLen, 1)
+	c.Assert(result.Constraints[0].Name, qt.Equals, "users_email_check")
+
+	// Role also present (was appended before)
+	c.Assert(result.Roles, qt.HasLen, 1)
+	c.Assert(result.Roles[0].Name, qt.Equals, "app_user")
+
+	// Dedup across files: duplicate view decl in duplicate.go must yield only 1
+	c.Assert(result.Views, qt.HasLen, 1)
+}
+
+// TestParseDir_AllCollectionsCoveredByReflectionGuard is a compile-time-ish
+// check that can evolve; the real guard is in TestParseFS_ReflectionGuard.
+func TestParseDir_AllCollectionsCoveredByReflectionGuard(t *testing.T) {
+	c := qt.New(t)
+	// Simple smoke: ensure after ParseDir we have non-nil slices for the key ones
+	// (detailed guard test below uses reflection against ParseSource)
+	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
+	result, err := goschema.ParseDir(fixtureDir)
+	c.Assert(err, qt.IsNil)
+	_ = result.Views
+	_ = result.Grants
+}
+
+// TestParseFS_ReflectionGuard is the future-proof guard required by #279.
+// It uses reflection over Database to enumerate all slice fields, runs ParseSource
+// (which populates all) on a comprehensive source, then ParseFS on equivalent FS,
+// and asserts that any collection populated by ParseSource is also non-empty after ParseFS.
+// This catches if a future 16th collection is added without wiring the append in walker.
+func TestParseFS_ReflectionGuard(t *testing.T) {
+	c := qt.New(t)
+
+	// Comprehensive source that exercises table + the five + roles + more.
+	// Uses ParseSource directly (bypasses FS merge).
+	src := `package test
+
+//migrator:schema:role name="g_role" login="false"
+
+//migrator:schema:table name="g_users"
+type GUser struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+}
+
+// Table constraint
+//migrator:schema:constraint name="g_users_email_nn" type="CHECK" check="email <> ''" table="g_users"
+
+// View
+type GActiveView struct{}
+//migrator:schema:view name="g_active_users" body="SELECT id FROM g_users"
+
+// Mat view
+type GStatsView struct{}
+//migrator:schema:matview name="g_user_stats" body="SELECT COUNT(*) FROM g_users"
+
+// Trigger
+type GTrig struct{}
+//migrator:schema:trigger name="g_set_ts" table="g_users" timing="BEFORE" event="UPDATE" for="ROW" body="RETURN NEW;"
+
+// Grants
+type GPerm struct{}
+//migrator:schema:grant role="g_role" privilege="SELECT" on_table="g_users"
+//migrator:schema:grant role="g_role" privilege="USAGE" on_schema="public"
+`
+
+	dbSource := goschema.ParseSource("guard.go", src)
+
+	// Reflect to find all slice fields that were populated (>0 len) by ParseSource
+	populated := map[string]int{}
+	v := reflect.ValueOf(dbSource)
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		sf := typ.Field(i)
+		if f.Kind() == reflect.Slice {
+			n := f.Len()
+			if n > 0 {
+				populated[sf.Name] = n
+			}
+		}
+	}
+	c.Assert(len(populated) > 0, qt.IsTrue, qt.Commentf("source must populate some slices for guard to be meaningful"))
+
+	// Now write equivalent to a temp dir and use ParseFS (the path under test)
+	tmpDir := c.TempDir()
+	err := os.WriteFile(filepath.Join(tmpDir, "guard.go"), []byte(src), 0600)
+	c.Assert(err, qt.IsNil)
+
+	dbFS, err := goschema.ParseDir(tmpDir)
+	c.Assert(err, qt.IsNil)
+
+	// For every populated collection name, assert ParseFS also has >0
+	fv := reflect.ValueOf(*dbFS) // value of the struct
+	for name, want := range populated {
+		f := fv.FieldByName(name)
+		c.Assert(f.IsValid(), qt.IsTrue, qt.Commentf("field %s must exist on Database", name))
+		c.Assert(f.Kind(), qt.Equals, reflect.Slice)
+		got := f.Len()
+		c.Assert(got > 0, qt.IsTrue, qt.Commentf("ParseFS/ParseDir must populate %s (source had %d); this is the drift guard for #279", name, want))
+		// loose >= to allow multiples but we dedup later
+		_ = want
 	}
 }
 

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -1294,13 +1294,14 @@ func TestParseDir_AllCollectionsCoveredByReflectionGuard(t *testing.T) {
 // (which populates all) on a comprehensive source, then ParseFS on equivalent FS,
 // and asserts that any collection populated by ParseSource is also non-empty after ParseFS.
 // This catches if a future 16th collection is added without wiring the append in walker.
+// Merge uses general reflection over all slice fields from ParseSource results (no hard-coded list).
 func TestParseFS_ReflectionGuard(t *testing.T) {
 	c := qt.New(t)
 
-	// Canonical on-disk fixture only. Read each .go, use ParseSource (or ParseFile) per file and merge.
-	// Then ParseDir on the dir. Reflect-assert that any slice populated by the per-file parse
+	// Canonical on-disk fixture only. Read each .go, use ParseSource per file and general-reflect merge all slices.
+	// Then ParseDir on the dir. Reflect-assert that any slice populated (>0) by the per-file parse
 	// is also populated (>0) after ParseDir/ParseFS. This exercises the real shipped append paths
-	// and would fail if any of the five appends in walker.go were missing.
+	// and would fail if any append in walker.go is missing.
 	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
 
 	merged := goschema.Database{}
@@ -1314,12 +1315,15 @@ func TestParseFS_ReflectionGuard(t *testing.T) {
 		content, err := os.ReadFile(full)
 		c.Assert(err, qt.IsNil)
 		db := goschema.ParseSource(e.Name(), string(content))
-		merged.Constraints = append(merged.Constraints, db.Constraints...)
-		merged.Views = append(merged.Views, db.Views...)
-		merged.MaterializedViews = append(merged.MaterializedViews, db.MaterializedViews...)
-		merged.Triggers = append(merged.Triggers, db.Triggers...)
-		merged.Grants = append(merged.Grants, db.Grants...)
-		merged.Roles = append(merged.Roles, db.Roles...)
+		// General reflection merge over ALL slice fields from ParseSource (future-proof, no hard-coded list of 6)
+		fvSrc := reflect.ValueOf(db)
+		fvDst := reflect.ValueOf(&merged).Elem()
+		for j := 0; j < fvSrc.NumField(); j++ {
+			if fvSrc.Field(j).Kind() == reflect.Slice {
+				dstField := fvDst.Field(j)
+				dstField.Set(reflect.AppendSlice(dstField, fvSrc.Field(j)))
+			}
+		}
 	}
 
 	dirDb, err := goschema.ParseDir(fixtureDir)

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -1296,77 +1297,49 @@ func TestParseDir_AllCollectionsCoveredByReflectionGuard(t *testing.T) {
 func TestParseFS_ReflectionGuard(t *testing.T) {
 	c := qt.New(t)
 
-	// Comprehensive source that exercises table + the five + roles + more.
-	// Uses ParseSource directly (bypasses FS merge).
-	src := `package test
+	// Canonical on-disk fixture only. Read each .go, use ParseSource (or ParseFile) per file and merge.
+	// Then ParseDir on the dir. Reflect-assert that any slice populated by the per-file parse
+	// is also populated (>0) after ParseDir/ParseFS. This exercises the real shipped append paths
+	// and would fail if any of the five appends in walker.go were missing.
+	fixtureDir := "../../integration/fixtures/entities/023-go-annotations-objects"
 
-//migrator:schema:role name="g_role" login="false"
-
-//migrator:schema:table name="g_users"
-type GUser struct {
-	//migrator:schema:field name="id" type="SERIAL" primary="true"
-	ID int64
-	//migrator:schema:field name="email" type="TEXT" not_null="true"
-	Email string
-}
-
-// Table constraint
-//migrator:schema:constraint name="g_users_email_nn" type="CHECK" check="email <> ''" table="g_users"
-
-// View
-type GActiveView struct{}
-//migrator:schema:view name="g_active_users" body="SELECT id FROM g_users"
-
-// Mat view
-type GStatsView struct{}
-//migrator:schema:matview name="g_user_stats" body="SELECT COUNT(*) FROM g_users"
-
-// Trigger
-type GTrig struct{}
-//migrator:schema:trigger name="g_set_ts" table="g_users" timing="BEFORE" event="UPDATE" for="ROW" body="RETURN NEW;"
-
-// Grants
-type GPerm struct{}
-//migrator:schema:grant role="g_role" privilege="SELECT" on_table="g_users"
-//migrator:schema:grant role="g_role" privilege="USAGE" on_schema="public"
-`
-
-	dbSource := goschema.ParseSource("guard.go", src)
-
-	// Reflect to find all slice fields that were populated (>0 len) by ParseSource
-	populated := map[string]int{}
-	v := reflect.ValueOf(dbSource)
-	typ := v.Type()
-	for i := 0; i < v.NumField(); i++ {
-		f := v.Field(i)
-		sf := typ.Field(i)
-		if f.Kind() == reflect.Slice {
-			n := f.Len()
-			if n > 0 {
-				populated[sf.Name] = n
-			}
+	merged := goschema.Database{}
+	entries, err := os.ReadDir(fixtureDir)
+	c.Assert(err, qt.IsNil)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
 		}
+		full := filepath.Join(fixtureDir, e.Name())
+		content, err := os.ReadFile(full)
+		c.Assert(err, qt.IsNil)
+		db := goschema.ParseSource(e.Name(), string(content))
+		merged.Constraints = append(merged.Constraints, db.Constraints...)
+		merged.Views = append(merged.Views, db.Views...)
+		merged.MaterializedViews = append(merged.MaterializedViews, db.MaterializedViews...)
+		merged.Triggers = append(merged.Triggers, db.Triggers...)
+		merged.Grants = append(merged.Grants, db.Grants...)
+		merged.Roles = append(merged.Roles, db.Roles...)
 	}
-	c.Assert(len(populated) > 0, qt.IsTrue, qt.Commentf("source must populate some slices for guard to be meaningful"))
 
-	// Now write equivalent to a temp dir and use ParseFS (the path under test)
-	tmpDir := c.TempDir()
-	err := os.WriteFile(filepath.Join(tmpDir, "guard.go"), []byte(src), 0600)
+	dirDb, err := goschema.ParseDir(fixtureDir)
 	c.Assert(err, qt.IsNil)
 
-	dbFS, err := goschema.ParseDir(tmpDir)
-	c.Assert(err, qt.IsNil)
-
-	// For every populated collection name, assert ParseFS also has >0
-	fv := reflect.ValueOf(*dbFS) // value of the struct
-	for name, want := range populated {
-		f := fv.FieldByName(name)
-		c.Assert(f.IsValid(), qt.IsTrue, qt.Commentf("field %s must exist on Database", name))
-		c.Assert(f.Kind(), qt.Equals, reflect.Slice)
-		got := f.Len()
-		c.Assert(got > 0, qt.IsTrue, qt.Commentf("ParseFS/ParseDir must populate %s (source had %d); this is the drift guard for #279", name, want))
-		// loose >= to allow multiples but we dedup later
-		_ = want
+	// Reflect: for every slice that merged (per-file ParseSource) populated, ParseDir must too.
+	fvMerged := reflect.ValueOf(merged)
+	fvDir := reflect.ValueOf(*dirDb)
+	typ := fvMerged.Type()
+	for i := 0; i < fvMerged.NumField(); i++ {
+		if fvMerged.Field(i).Kind() != reflect.Slice {
+			continue
+		}
+		name := typ.Field(i).Name
+		mLen := fvMerged.Field(i).Len()
+		if mLen == 0 {
+			continue
+		}
+		dLen := fvDir.Field(i).Len()
+		c.Assert(dLen > 0, qt.IsTrue, qt.Commentf("%s populated by per-file parse (%d) but ParseDir/ParseFS gave %d — missing append in walker.go?", name, mLen, dLen))
 	}
 }
 

--- a/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
@@ -1,0 +1,6 @@
+package entities
+
+// Duplicate view decl (comment immediately before type) — identical body
+//
+//migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" comment="Duplicate should be ignored by dedup"
+type DuplicateViewHost struct{}

--- a/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
@@ -1,4 +1,0 @@
-package entities
-
-//migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" comment="Duplicate should be ignored by dedup"
-type DuplicateViewHost struct{}

--- a/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/duplicate.go
@@ -1,6 +1,4 @@
 package entities
 
-// Duplicate view decl (comment immediately before type) — identical body
-//
 //migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" comment="Duplicate should be ignored by dedup"
 type DuplicateViewHost struct{}

--- a/integration/fixtures/entities/023-go-annotations-objects/users.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/users.go
@@ -19,28 +19,18 @@ type User struct {
 	UpdatedAt *string
 }
 
-// Role uses its own marker type with doc comment immediately preceding
-//
 //migrator:schema:role name="app_user" login="false" inherit="true" comment="App role for grants demo"
 type AppRoleMarker struct{}
 
-// View
-//
 //migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" with_check="false" comment="Active users view"
 type ActiveUsersView struct{}
 
-// Materialized view
-//
 //migrator:schema:matview name="user_stats" body="SELECT COUNT(*) as cnt FROM users" refresh_strategy="manual" comment="User count matview"
 type UserStatsMatView struct{}
 
-// Trigger
-//
 //migrator:schema:trigger name="users_set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;" comment="Auto update"
 type UserTrigger struct{}
 
-// Grants use marker, comments immediately before
-//
 //migrator:schema:grant role="app_user" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users" comment="DML grants to app_user"
 //migrator:schema:grant role="app_user" privilege="USAGE" on_schema="public" comment="Schema usage"
 type AccessControlMarker struct{}

--- a/integration/fixtures/entities/023-go-annotations-objects/users.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/users.go
@@ -1,5 +1,8 @@
 package entities
 
+//migrator:schema:extension name="pg_trgm" if_not_exists="true" comment="Fixture extension"
+type ExtensionsMarker struct{}
+
 //migrator:schema:table name="users"
 //migrator:schema:constraint name="users_email_check" type="CHECK" check="email <> ''" comment="Email must not be empty"
 type User struct {
@@ -9,6 +12,9 @@ type User struct {
 	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
 	Email string
 
+	//migrator:schema:field name="status" type="ENUM" enum="active,disabled" default="active"
+	Status string
+
 	//migrator:schema:field name="name" type="VARCHAR(255)"
 	Name string
 
@@ -17,10 +23,21 @@ type User struct {
 
 	//migrator:schema:field name="updated_at" type="TIMESTAMP" default_expr="NOW()"
 	UpdatedAt *string
+
+	//migrator:schema:index name="idx_users_email" fields="email"
+	_ int
+
+	//migrator:embedded mode="json" name="metadata" type="JSONB"
+	Metadata UserMetadata
 }
 
-//migrator:schema:role name="app_user" login="false" inherit="true" comment="App role for grants demo"
+//migrator:schema:role name="fixture_app_user" login="false" inherit="true" comment="App role for grants demo"
 type AppRoleMarker struct{}
+
+//migrator:schema:function name="get_fixture_tenant_id" returns="TEXT" language="sql" body="SELECT current_setting('app.tenant_id', true)" comment="Fixture RLS helper"
+//migrator:schema:rls:enable table="users" comment="Enable RLS for fixture users"
+//migrator:schema:rls:policy name="users_tenant_policy" table="users" for="SELECT" to="fixture_app_user" using="get_fixture_tenant_id() IS NOT NULL" comment="Fixture RLS policy"
+type SecurityMarker struct{}
 
 //migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" with_check="false" comment="Active users view"
 type ActiveUsersView struct{}
@@ -31,6 +48,11 @@ type UserStatsMatView struct{}
 //migrator:schema:trigger name="users_set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;" comment="Auto update"
 type UserTrigger struct{}
 
-//migrator:schema:grant role="app_user" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users" comment="DML grants to app_user"
-//migrator:schema:grant role="app_user" privilege="USAGE" on_schema="public" comment="Schema usage"
+//migrator:schema:grant role="fixture_app_user" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users" comment="DML grants to fixture_app_user"
+//migrator:schema:grant role="fixture_app_user" privileges="SELECT, INSERT" on_table="users" with_option="true" comment="Grant option fixture"
+//migrator:schema:grant role="fixture_app_user" privilege="USAGE" on_schema="public" comment="Schema usage"
 type AccessControlMarker struct{}
+
+type UserMetadata struct {
+	TraceID string
+}

--- a/integration/fixtures/entities/023-go-annotations-objects/users.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/users.go
@@ -1,0 +1,46 @@
+package entities
+
+//migrator:schema:table name="users"
+//migrator:schema:constraint name="users_email_check" type="CHECK" check="email <> ''" comment="Email must not be empty"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)"
+	Name string
+
+	//migrator:schema:field name="deleted_at" type="TIMESTAMP"
+	DeletedAt *string
+
+	//migrator:schema:field name="updated_at" type="TIMESTAMP" default_expr="NOW()"
+	UpdatedAt *string
+}
+
+// Role uses its own marker type with doc comment immediately preceding
+//
+//migrator:schema:role name="app_user" login="false" inherit="true" comment="App role for grants demo"
+type AppRoleMarker struct{}
+
+// View
+//
+//migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" with_check="false" comment="Active users view"
+type ActiveUsersView struct{}
+
+// Materialized view
+//
+//migrator:schema:matview name="user_stats" body="SELECT COUNT(*) as cnt FROM users" refresh_strategy="manual" comment="User count matview"
+type UserStatsMatView struct{}
+
+// Trigger
+//
+//migrator:schema:trigger name="users_set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;" comment="Auto update"
+type UserTrigger struct{}
+
+// Grants use marker, comments immediately before
+//
+//migrator:schema:grant role="app_user" privilege="SELECT,INSERT,UPDATE,DELETE" on_table="users" comment="DML grants to app_user"
+//migrator:schema:grant role="app_user" privilege="USAGE" on_schema="public" comment="Schema usage"
+type AccessControlMarker struct{}

--- a/integration/fixtures/entities/023-go-annotations-objects/z_duplicate.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/z_duplicate.go
@@ -1,0 +1,4 @@
+package entities
+
+//migrator:schema:view name="active_users" body="SELECT id, email FROM users WHERE deleted_at IS NULL" comment="Active users view"
+type DuplicateViewHost struct{}

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -217,9 +217,9 @@ func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 
 	// Compute root and abs fixture from this source file's location (robust to test cwd)
 	_, filename, _, _ := runtime.Caller(0)
-	srcDir := filepath.Dir(filename)                 // .../integration/gonative
-	integrationDir := filepath.Dir(srcDir)           // .../integration
-	rootDir := filepath.Dir(integrationDir)          // module root
+	srcDir := filepath.Dir(filename)        // .../integration/gonative
+	integrationDir := filepath.Dir(srcDir)  // .../integration
+	rootDir := filepath.Dir(integrationDir) // module root
 	absFixture := filepath.Join(rootDir, "integration/fixtures/entities/023-go-annotations-objects")
 	result, err := goschema.ParseDir(absFixture)
 	c.Assert(err, qt.IsNil, qt.Commentf("ParseDir on new objects fixture must succeed"))
@@ -233,11 +233,12 @@ func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 	c.Assert(result.Triggers, qt.HasLen, 1)
 	c.Assert(result.Triggers[0].Name, qt.Equals, "users_set_updated_at")
 
-	c.Assert(result.Grants, qt.HasLen, 2)
+	c.Assert(result.Grants, qt.HasLen, 3)
 	c.Assert(result.Constraints, qt.HasLen, 1)
 	c.Assert(result.Constraints[0].Name, qt.Equals, "users_email_check")
 
 	c.Assert(result.Roles, qt.HasLen, 1)
+	c.Assert(result.Roles[0].Name, qt.Equals, "fixture_app_user")
 
 	// Exercise CLI generate entry point against the fixture (drives real ParseDir path in cmd/generate, per AC3)
 	goMain := filepath.Join(rootDir, "cmd/main.go")
@@ -249,6 +250,7 @@ func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 	c.Assert(outStr, qt.Contains, "CREATE MATERIALIZED VIEW user_stats")
 	c.Assert(outStr, qt.Contains, "CREATE TRIGGER")
 	c.Assert(outStr, qt.Contains, "GRANT ")
-	c.Assert(outStr, qt.Contains, "CREATE ROLE")
+	c.Assert(outStr, qt.Contains, "WITH GRANT OPTION")
+	c.Assert(outStr, qt.Contains, "CREATE ROLE fixture_app_user")
 	c.Assert(outStr, qt.Contains, "CONSTRAINT users_email_check")
 }

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -204,3 +204,31 @@ func filterGrants(in []dbschematypes.DBGrant, keepRoles map[string]struct{}) []d
 	}
 	return out
 }
+
+// TestGoFixtures_ParseDirForSchemaObjects exercises ParseDir on the Go annotation
+// fixtures added for #279 (views, grants, constraints, triggers, matviews).
+// This drives the real ParseDir path used by CLI in an integration-tagged test file.
+// Does not require live DB.
+func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
+	c := qt.New(t)
+
+	// Robust relative path from this test file location (integration/gonative -> integration/fixtures)
+	fixture := "../fixtures/entities/023-go-annotations-objects"
+	result, err := goschema.ParseDir(fixture)
+	c.Assert(err, qt.IsNil, qt.Commentf("ParseDir on new objects fixture must succeed"))
+
+	c.Assert(result.Views, qt.HasLen, 1)
+	c.Assert(result.Views[0].Name, qt.Equals, "active_users")
+
+	c.Assert(result.MaterializedViews, qt.HasLen, 1)
+	c.Assert(result.MaterializedViews[0].Name, qt.Equals, "user_stats")
+
+	c.Assert(result.Triggers, qt.HasLen, 1)
+	c.Assert(result.Triggers[0].Name, qt.Equals, "users_set_updated_at")
+
+	c.Assert(result.Grants, qt.HasLen, 2)
+	c.Assert(result.Constraints, qt.HasLen, 1)
+	c.Assert(result.Constraints[0].Name, qt.Equals, "users_email_check")
+
+	c.Assert(result.Roles, qt.HasLen, 1)
+}

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -4,6 +4,9 @@ package gonative_test
 
 import (
 	"database/sql"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -212,9 +215,13 @@ func filterGrants(in []dbschematypes.DBGrant, keepRoles map[string]struct{}) []d
 func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 	c := qt.New(t)
 
-	// Robust relative path from this test file location (integration/gonative -> integration/fixtures)
-	fixture := "../fixtures/entities/023-go-annotations-objects"
-	result, err := goschema.ParseDir(fixture)
+	// Compute root and abs fixture from this source file's location (robust to test cwd)
+	_, filename, _, _ := runtime.Caller(0)
+	srcDir := filepath.Dir(filename)                 // .../integration/gonative
+	integrationDir := filepath.Dir(srcDir)           // .../integration
+	rootDir := filepath.Dir(integrationDir)          // module root
+	absFixture := filepath.Join(rootDir, "integration/fixtures/entities/023-go-annotations-objects")
+	result, err := goschema.ParseDir(absFixture)
 	c.Assert(err, qt.IsNil, qt.Commentf("ParseDir on new objects fixture must succeed"))
 
 	c.Assert(result.Views, qt.HasLen, 1)
@@ -231,4 +238,17 @@ func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 	c.Assert(result.Constraints[0].Name, qt.Equals, "users_email_check")
 
 	c.Assert(result.Roles, qt.HasLen, 1)
+
+	// Exercise CLI generate entry point against the fixture (drives real ParseDir path in cmd/generate, per AC3)
+	goMain := filepath.Join(rootDir, "cmd/main.go")
+	genCmd := exec.Command("go", "run", goMain, "generate", "--root-dir", absFixture, "--dialect", "postgres")
+	genOut, err := genCmd.CombinedOutput()
+	c.Assert(err, qt.IsNil)
+	outStr := string(genOut)
+	c.Assert(outStr, qt.Contains, "CREATE VIEW active_users")
+	c.Assert(outStr, qt.Contains, "CREATE MATERIALIZED VIEW user_stats")
+	c.Assert(outStr, qt.Contains, "CREATE TRIGGER")
+	c.Assert(outStr, qt.Contains, "GRANT ")
+	c.Assert(outStr, qt.Contains, "CREATE ROLE")
+	c.Assert(outStr, qt.Contains, "CONSTRAINT users_email_check")
 }


### PR DESCRIPTION
## Summary

Fixes #279 (isolated clean PR).

`ParseFS`/`ParseDir` (CLI + generator path) was dropping 5 collections from Go annotations.

## Scope (minimal, 6 files)
- walker.go: inits + appends for Constraints/Views/MaterializedViews/Triggers/Grants
- utils.go: full dedup coverage + normalize decision doc
- walker_test.go: ParseDir test + reflection guard
- new fixture 023-go-annotations-objects (with columns for valid SQL) + dup for dedup test
- gonative subtest driving ParseDir

## Verification
- All unit/race/lint pass.
- generate emits the CREATE statements for all 5 + role + constraint.
- Guard + dedup tests pass.
- 3 detailed multi-agent review rounds executed and captured.

Refs #279. This PR is clean (only the 279 delta vs master).