### PR TITLE
fix(integration): make live CI failures visible

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -147,27 +147,23 @@ jobs:
           done
           echo "YugabyteDB is ready!"
       
-      - name: Run executor integration tests with PostgreSQL
+      - name: Run executor integration tests with live databases
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+          POSTGRES_TEST_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
         run: |
-          go test -v  ./integration/... -tags=integration -timeout 15m
-
-      - name: Run executor integration tests with MySQL
-        env:
-          MYSQL_TEST_DSN: "ptah_user:ptah_password@tcp(mysql:3306)/ptah_test"
-        run: |
-          go test -v  ./integration/... -tags=integration -timeout 15m
-
-      - name: Run executor integration tests with MariaDB
-        env:
-          MARIADB_TEST_DSN: "ptah_user:ptah_password@tcp(mariadb:3307)/ptah_test"
-        run: |
-          go test -v  ./integration/... -tags=integration -timeout 15m
+          go test -v ./integration -tags=integration -timeout 15m
+          go test -v ./integration/gonative -tags=integration -timeout 15m
 
       - name: Build integration test binary
         run: |
-          go build -o ./integration-test ./cmd/integration-test
+          go build -race -o ./integration-test ./cmd/integration-test
 
       - name: Test integration binary help
         run: |
@@ -215,6 +211,11 @@ jobs:
       
       - name: Run dynamic integration tests
         env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+          POSTGRES_TEST_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
@@ -222,4 +223,4 @@ jobs:
           COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
         run: |
-          go test -v -race ./integration -timeout 30m
+          go test -v -race ./integration -tags=integration -timeout 30m

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -161,14 +161,14 @@ func runIntegrationTests(cmd *cobra.Command, args []string) error {
 	dbConnections := configuredDatabaseConnections()
 
 	// Filter databases based on command line arguments
-	for _, dbName := range databases {
-		if url, exists := dbConnections[dbName]; exists && url != "" {
-			runner.AddDatabase(dbName, url)
-			if verbose {
-				fmt.Printf("Added database: %s\n", dbName)
-			}
-		} else {
-			fmt.Printf("Warning: Database %s not available (missing URL)\n", dbName)
+	selectedConnections, err := requestedDatabaseConnections(databases, dbConnections)
+	if err != nil {
+		return err
+	}
+	for dbName, url := range selectedConnections {
+		runner.AddDatabase(dbName, url)
+		if verbose {
+			fmt.Printf("Added database: %s\n", dbName)
 		}
 	}
 
@@ -235,9 +235,11 @@ func runIntegrationTests(cmd *cobra.Command, args []string) error {
 	fmt.Printf("   Total Tests: %d\n", report.TotalTests)
 	fmt.Printf("   Passed: %d\n", report.PassedTests)
 	fmt.Printf("   Failed: %d\n", report.FailedTests)
+	fmt.Printf("   Skipped: %d\n", report.SkippedTests)
 
-	if report.TotalTests > 0 {
-		successRate := float64(report.PassedTests) / float64(report.TotalTests) * 100
+	executedTests := report.PassedTests + report.FailedTests
+	if executedTests > 0 {
+		successRate := float64(report.PassedTests) / float64(executedTests) * 100
 		fmt.Printf("   Success Rate: %.1f%%\n", successRate)
 	}
 
@@ -249,7 +251,14 @@ func runIntegrationTests(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	fmt.Printf("\n🎉 All tests passed!\n")
+	switch {
+	case executedTests == 0 && report.SkippedTests > 0:
+		fmt.Printf("\n⏭️  All requested tests were skipped.\n")
+	case report.SkippedTests > 0:
+		fmt.Printf("\n🎉 All executed tests passed; %d skipped.\n", report.SkippedTests)
+	default:
+		fmt.Printf("\n🎉 All tests passed!\n")
+	}
 	return nil
 }
 
@@ -262,6 +271,23 @@ func configuredDatabaseConnections() map[string]string {
 		"cockroachdb": os.Getenv("COCKROACHDB_URL"),
 		"yugabytedb":  os.Getenv("YUGABYTEDB_URL"),
 	}
+}
+
+func requestedDatabaseConnections(databases []string, dbConnections map[string]string) (map[string]string, error) {
+	selected := make(map[string]string, len(databases))
+	var missing []string
+	for _, dbName := range databases {
+		url, exists := dbConnections[dbName]
+		if !exists || url == "" {
+			missing = append(missing, dbName)
+			continue
+		}
+		selected[dbName] = url
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing database URL for requested database(s): %s", strings.Join(missing, ", "))
+	}
+	return selected, nil
 }
 
 func listScenarios(cmd *cobra.Command, args []string) error {

--- a/cmd/integration-test/main_test.go
+++ b/cmd/integration-test/main_test.go
@@ -85,6 +85,35 @@ func TestConfiguredDatabaseConnectionsIncludesDistributedSQL(t *testing.T) {
 	c.Assert(connections["yugabytedb"], qt.Equals, "yugabytedb://yugabyte.example/yugabyte")
 }
 
+func TestRequestedDatabaseConnectionsRejectsMissingRequestedURL(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := requestedDatabaseConnections(
+		[]string{"postgres", "mysql"},
+		map[string]string{"postgres": "postgres://postgres.example/db"},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `missing database URL for requested database\(s\): mysql`)
+}
+
+func TestRequestedDatabaseConnectionsKeepsConfiguredURLs(t *testing.T) {
+	c := qt.New(t)
+
+	selected, err := requestedDatabaseConnections(
+		[]string{"postgres", "mysql"},
+		map[string]string{
+			"postgres": "postgres://postgres.example/db",
+			"mysql":    "mysql://mysql.example/db",
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(selected, qt.DeepEquals, map[string]string{
+		"postgres": "postgres://postgres.example/db",
+		"mysql":    "mysql://mysql.example/db",
+	})
+}
+
 func TestDefaultDatabasesIncludeOSSDistributedSQL(t *testing.T) {
 	c := qt.New(t)
 

--- a/integration/dynamic_test.go
+++ b/integration/dynamic_test.go
@@ -135,9 +135,15 @@ func getTestDatabaseURL() string {
 	if url := getEnvVar("POSTGRES_TEST_URL"); url != "" {
 		return url
 	}
+	if url := getEnvVar("POSTGRES_URL"); url != "" {
+		return url
+	}
 
 	// Try MySQL
 	if url := getEnvVar("MYSQL_TEST_URL"); url != "" {
+		return url
+	}
+	if url := getEnvVar("MYSQL_URL"); url != "" {
 		return url
 	}
 

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -44,21 +44,24 @@ type TestResult struct {
 	Name        string        `json:"name"`
 	Database    string        `json:"database"`
 	Success     bool          `json:"success"`
+	Skipped     bool          `json:"skipped"`
 	Duration    time.Duration `json:"duration"`
 	Error       string        `json:"error,omitempty"`
+	SkipReason  string        `json:"skip_reason,omitempty"`
 	Description string        `json:"description"`
 	Steps       []TestStep    `json:"steps,omitempty"`
 }
 
 // TestReport represents the complete test report
 type TestReport struct {
-	StartTime   time.Time    `json:"start_time"`
-	EndTime     time.Time    `json:"end_time"`
-	TotalTests  int          `json:"total_tests"`
-	PassedTests int          `json:"passed_tests"`
-	FailedTests int          `json:"failed_tests"`
-	Results     []TestResult `json:"results"`
-	Summary     string       `json:"summary"`
+	StartTime    time.Time    `json:"start_time"`
+	EndTime      time.Time    `json:"end_time"`
+	TotalTests   int          `json:"total_tests"`
+	PassedTests  int          `json:"passed_tests"`
+	FailedTests  int          `json:"failed_tests"`
+	SkippedTests int          `json:"skipped_tests"`
+	Results      []TestResult `json:"results"`
+	Summary      string       `json:"summary"`
 }
 
 // StepRecorder allows test functions to record individual steps
@@ -165,9 +168,12 @@ func (tr *TestRunner) RunAll(ctx context.Context) error {
 			tr.mu.Lock()
 			tr.report.Results = append(tr.report.Results, result)
 			tr.report.TotalTests++
-			if result.Success {
+			switch {
+			case result.Skipped:
+				tr.report.SkippedTests++
+			case result.Success:
 				tr.report.PassedTests++
-			} else {
+			default:
 				tr.report.FailedTests++
 			}
 			tr.mu.Unlock()
@@ -222,7 +228,8 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 			"Scenario has not opted in via ClickHouseCompatible; skipping on ClickHouse",
 			func() error { return nil },
 		)
-		result.Success = true
+		result.Skipped = true
+		result.SkipReason = "Scenario has not opted in via ClickHouseCompatible; skipping on ClickHouse"
 		result.Steps = recorder.GetSteps()
 		result.Duration = time.Since(start)
 		return result
@@ -234,7 +241,8 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 			"Scenario has not opted in via PostgresDistributedCompatible; skipping on PostgreSQL-family distributed SQL",
 			func() error { return nil },
 		)
-		result.Success = true
+		result.Skipped = true
+		result.SkipReason = "Scenario has not opted in via PostgresDistributedCompatible; skipping on PostgreSQL-family distributed SQL"
 		result.Steps = recorder.GetSteps()
 		result.Duration = time.Since(start)
 		return result
@@ -463,14 +471,19 @@ func (vem *VersionedEntityManager) MigrateToVersion(ctx context.Context, conn *d
 // generateSummary creates a summary of the test results
 func (tr *TestRunner) generateSummary() {
 	duration := tr.report.EndTime.Sub(tr.report.StartTime)
-	successRate := float64(tr.report.PassedTests) / float64(tr.report.TotalTests) * 100
+	executedTests := tr.report.PassedTests + tr.report.FailedTests
+	successRate := 0.0
+	if executedTests > 0 {
+		successRate = float64(tr.report.PassedTests) / float64(executedTests) * 100
+	}
 
 	tr.report.Summary = fmt.Sprintf(
-		"Executed %d tests in %v. %d passed, %d failed (%.1f%% success rate)",
-		tr.report.TotalTests,
+		"Executed %d tests in %v. %d passed, %d failed, %d skipped (%.1f%% success rate)",
+		executedTests,
 		duration.Round(time.Millisecond),
 		tr.report.PassedTests,
 		tr.report.FailedTests,
+		tr.report.SkippedTests,
 		successRate,
 	)
 }

--- a/integration/gonative/check_constraint_integration_test.go
+++ b/integration/gonative/check_constraint_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema/postgres"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
@@ -77,9 +78,10 @@ func TestFieldLevelCheckConstraint_RoundTrip_Integration(t *testing.T) {
 	reader := postgres.NewPostgreSQLReader(db, "public")
 	dbSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
+	filteredSchema := filterCheckConstraintSchema(dbSchema, "ptah_test_files")
 
 	checks := map[string]bool{}
-	for _, cs := range dbSchema.Constraints {
+	for _, cs := range filteredSchema.Constraints {
 		if cs.Type == "CHECK" && cs.TableName == "ptah_test_files" {
 			checks[cs.Name] = true
 		}
@@ -94,7 +96,7 @@ func TestFieldLevelCheckConstraint_RoundTrip_Integration(t *testing.T) {
 	// off — Postgres rewrites the stored CHECK clause (parens, type casts,
 	// `IN (...)` → `= ANY (ARRAY[...])`) and a naive text compare would
 	// regen a migration on every run.
-	diff := schemadiff.Compare(target, dbSchema)
+	diff := schemadiff.Compare(target, filteredSchema)
 	c.Assert(diff.HasChanges(), qt.IsFalse,
 		qt.Commentf("round-trip diff must be clean; got added=%v removed=%v",
 			diff.ConstraintsAdded, diff.ConstraintsRemoved))
@@ -146,8 +148,9 @@ func TestFieldLevelCheckConstraint_Removal_Integration(t *testing.T) {
 	reader := postgres.NewPostgreSQLReader(db, "public")
 	dbSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
+	filteredSchema := filterCheckConstraintSchema(dbSchema, "ptah_test_check_drop")
 
-	diff := schemadiff.Compare(withoutCheck, dbSchema)
+	diff := schemadiff.Compare(withoutCheck, filteredSchema)
 	c.Assert(diff.HasChanges(), qt.IsTrue)
 	c.Assert(diff.ConstraintsRemoved, qt.Contains, "ptah_test_check_drop_score_check")
 
@@ -167,7 +170,8 @@ func TestFieldLevelCheckConstraint_Removal_Integration(t *testing.T) {
 	// part of this assertion.
 	afterSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
-	for _, cs := range afterSchema.Constraints {
+	filteredAfterSchema := filterCheckConstraintSchema(afterSchema, "ptah_test_check_drop")
+	for _, cs := range filteredAfterSchema.Constraints {
 		if cs.TableName != "ptah_test_check_drop" || cs.Type != "CHECK" {
 			continue
 		}
@@ -177,7 +181,17 @@ func TestFieldLevelCheckConstraint_Removal_Integration(t *testing.T) {
 		c.Errorf("CHECK constraint should have been dropped, still found: %s", cs.Name)
 	}
 
-	idempDiff := schemadiff.Compare(withoutCheck, afterSchema)
+	idempDiff := schemadiff.Compare(withoutCheck, filteredAfterSchema)
 	c.Assert(idempDiff.HasChanges(), qt.IsFalse,
 		qt.Commentf("post-drop diff must be clean"))
+}
+
+func filterCheckConstraintSchema(in *dbschematypes.DBSchema, tableName string) *dbschematypes.DBSchema {
+	keepTables := map[string]struct{}{tableName: {}}
+	out := *in
+	out.Tables = filterTables(in.Tables, keepTables)
+	out.Indexes = filterIndexes(in.Indexes, keepTables)
+	out.Constraints = filterConstraints(in.Constraints, keepTables)
+	out.RLSPolicies = filterRLSPolicies(in.RLSPolicies, keepTables)
+	return &out
 }

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -5,7 +5,6 @@ package gonative_test
 import (
 	"context"
 	"database/sql"
-	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -15,27 +14,10 @@ import (
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
-// skipIfNoMySQL checks if MySQL is available for testing and skips the test if not.
+// skipIfNoMySQL skips only when MYSQL_TEST_DSN is absent; a bad configured DSN fails.
 func skipIfNoMySQL(t *testing.T) string {
 	t.Helper()
-
-	dsn := os.Getenv("MYSQL_TEST_DSN")
-	if dsn == "" {
-		t.Skip("Skipping MySQL tests: MYSQL_TEST_DSN environment variable not set")
-	}
-
-	// Test connection
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		t.Skipf("Skipping MySQL tests: failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		t.Skipf("Skipping MySQL tests: failed to connect to database: %v", err)
-	}
-
-	return dsn
+	return requireReachableTestDSN(t, "MYSQL_TEST_DSN", "mysql", "MySQL")
 }
 
 // Helper function to find a column by name

--- a/integration/gonative/postgres_integration_test.go
+++ b/integration/gonative/postgres_integration_test.go
@@ -5,7 +5,6 @@ package gonative_test
 import (
 	"context"
 	"database/sql"
-	"os"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -16,27 +15,10 @@ import (
 	"github.com/stokaro/ptah/internal/testutils"
 )
 
-// skipIfNoPostgreSQL checks if PostgreSQL is available for testing and skips the test if not.
+// skipIfNoPostgreSQL skips only when POSTGRES_TEST_DSN is absent; a bad configured DSN fails.
 func skipIfNoPostgreSQL(t *testing.T) string {
 	t.Helper()
-
-	dsn := os.Getenv("POSTGRES_TEST_DSN")
-	if dsn == "" {
-		t.Skip("Skipping PostgreSQL tests: POSTGRES_TEST_DSN environment variable not set")
-	}
-
-	// Test connection
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		t.Skipf("Skipping PostgreSQL tests: failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		t.Skipf("Skipping PostgreSQL tests: failed to connect to database: %v", err)
-	}
-
-	return dsn
+	return requireReachableTestDSN(t, "POSTGRES_TEST_DSN", "pgx", "PostgreSQL")
 }
 
 func TestPostgreSQLReader_ReadSchema_Integration(t *testing.T) {

--- a/integration/gonative/renderer_integration_test.go
+++ b/integration/gonative/renderer_integration_test.go
@@ -5,7 +5,6 @@ package gonative_test
 import (
 	"database/sql"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -17,73 +16,22 @@ import (
 	"github.com/stokaro/ptah/core/renderer"
 )
 
-// skipIfNoPostgreSQLRenderer checks if PostgreSQL is available for testing and skips the test if not.
+// skipIfNoPostgreSQLRenderer skips only when POSTGRES_TEST_DSN is absent; a bad configured DSN fails.
 func skipIfNoPostgreSQLRenderer(t *testing.T) string {
 	t.Helper()
-
-	dsn := os.Getenv("POSTGRES_TEST_DSN")
-	if dsn == "" {
-		t.Skip("Skipping PostgreSQL tests: POSTGRES_TEST_DSN environment variable not set")
-	}
-
-	// Test connection
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		t.Skipf("Skipping PostgreSQL tests: failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		t.Skipf("Skipping PostgreSQL tests: failed to connect to database: %v", err)
-	}
-
-	return dsn
+	return requireReachableTestDSN(t, "POSTGRES_TEST_DSN", "pgx", "PostgreSQL")
 }
 
-// skipIfNoMySQLRenderer checks if MySQL is available for testing and skips the test if not.
+// skipIfNoMySQLRenderer skips only when MYSQL_TEST_DSN is absent; a bad configured DSN fails.
 func skipIfNoMySQLRenderer(t *testing.T) string {
 	t.Helper()
-
-	dsn := os.Getenv("MYSQL_TEST_DSN")
-	if dsn == "" {
-		t.Skip("Skipping MySQL tests: MYSQL_TEST_DSN environment variable not set")
-	}
-
-	// Test connection
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		t.Skipf("Skipping MySQL tests: failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		t.Skipf("Skipping MySQL tests: failed to connect to database: %v", err)
-	}
-
-	return dsn
+	return requireReachableTestDSN(t, "MYSQL_TEST_DSN", "mysql", "MySQL")
 }
 
-// skipIfNoMariaDBRenderer checks if MariaDB is available for testing and skips the test if not.
+// skipIfNoMariaDBRenderer skips only when MARIADB_TEST_DSN is absent; a bad configured DSN fails.
 func skipIfNoMariaDBRenderer(t *testing.T) string {
 	t.Helper()
-
-	dsn := os.Getenv("MARIADB_TEST_DSN")
-	if dsn == "" {
-		t.Skip("Skipping MariaDB tests: MARIADB_TEST_DSN environment variable not set")
-	}
-
-	// Test connection
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		t.Skipf("Skipping MariaDB tests: failed to open database: %v", err)
-	}
-	defer db.Close()
-
-	if err := db.Ping(); err != nil {
-		t.Skipf("Skipping MariaDB tests: failed to connect to database: %v", err)
-	}
-
-	return dsn
+	return requireReachableTestDSN(t, "MARIADB_TEST_DSN", "mysql", "MariaDB")
 }
 
 func TestPostgreSQLRenderer_Integration(t *testing.T) {

--- a/integration/gonative/testdb_test.go
+++ b/integration/gonative/testdb_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+)
+
+func requireReachableTestDSN(t *testing.T, envName, driverName, databaseName string) string {
+	t.Helper()
+
+	dsn := os.Getenv(envName)
+	if dsn == "" {
+		t.Skipf("Skipping %s tests: %s environment variable not set", databaseName, envName)
+	}
+
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		t.Fatalf("%s is set but %s database open failed: %v", envName, databaseName, err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Fatalf("%s is set but %s database connection failed: %v", envName, databaseName, err)
+	}
+
+	return dsn
+}

--- a/integration/reporter.go
+++ b/integration/reporter.go
@@ -73,8 +73,9 @@ func (r *Reporter) generateTextStreamReport(w io.Writer) error {
 	fmt.Fprintf(w, "Total Tests: %d\n", r.report.TotalTests)
 	fmt.Fprintf(w, "Passed: %d\n", r.report.PassedTests)
 	fmt.Fprintf(w, "Failed: %d\n", r.report.FailedTests)
-	if r.report.TotalTests > 0 {
-		successRate := float64(r.report.PassedTests) / float64(r.report.TotalTests) * 100
+	fmt.Fprintf(w, "Skipped: %d\n", r.report.SkippedTests)
+	if executedTests := r.report.PassedTests + r.report.FailedTests; executedTests > 0 {
+		successRate := float64(r.report.PassedTests) / float64(executedTests) * 100
 		fmt.Fprintf(w, "Success Rate: %.1f%%\n", successRate)
 	}
 	fmt.Fprintf(w, "\n")
@@ -85,7 +86,10 @@ func (r *Reporter) generateTextStreamReport(w io.Writer) error {
 
 	for _, result := range r.report.Results {
 		status := "✅ PASS"
-		if !result.Success {
+		switch {
+		case result.Skipped:
+			status = "⏭️ SKIP"
+		case !result.Success:
 			status = "❌ FAIL"
 		}
 
@@ -96,6 +100,9 @@ func (r *Reporter) generateTextStreamReport(w io.Writer) error {
 		if !result.Success && result.Error != "" {
 			fmt.Fprintf(w, "    Error: %s\n", result.Error)
 		}
+		if result.Skipped && result.SkipReason != "" {
+			fmt.Fprintf(w, "    Skip: %s\n", result.SkipReason)
+		}
 		fmt.Fprintf(w, "\n")
 	}
 
@@ -104,7 +111,7 @@ func (r *Reporter) generateTextStreamReport(w io.Writer) error {
 		fmt.Fprintf(w, "FAILED TESTS SUMMARY\n")
 		fmt.Fprintf(w, "--------------------\n")
 		for _, result := range r.report.Results {
-			if !result.Success {
+			if !result.Success && !result.Skipped {
 				fmt.Fprintf(w, "❌ %s (%s)\n", result.Name, result.Database)
 				fmt.Fprintf(w, "   Error: %s\n\n", result.Error)
 			}
@@ -154,19 +161,26 @@ func (r *Reporter) generateHTMLReport(fpath string) error {
 			return t.Format("2006-01-02 15:04:05")
 		},
 		"successRate": func() float64 {
-			if r.report.TotalTests == 0 {
+			executedTests := r.report.PassedTests + r.report.FailedTests
+			if executedTests == 0 {
 				return 0
 			}
-			return float64(r.report.PassedTests) / float64(r.report.TotalTests) * 100
+			return float64(r.report.PassedTests) / float64(executedTests) * 100
 		},
-		"statusIcon": func(success bool) string {
-			if success {
+		"statusIcon": func(result TestResult) string {
+			if result.Skipped {
+				return "⏭️"
+			}
+			if result.Success {
 				return "✅"
 			}
 			return "❌"
 		},
-		"statusClass": func(success bool) string {
-			if success {
+		"statusClass": func(result TestResult) string {
+			if result.Skipped {
+				return "skipped"
+			}
+			if result.Success {
 				return "success"
 			}
 			return "failure"
@@ -197,6 +211,7 @@ const htmlTemplate = `<!DOCTYPE html>
         th { background-color: #f8f9fa; font-weight: bold; }
         .success { color: #28a745; }
         .failure { color: #dc3545; }
+        .skipped { color: #6c757d; }
         .error-details { background: #f8d7da; padding: 10px; border-radius: 3px; margin-top: 5px; font-family: monospace; font-size: 0.9em; }
         .duration { color: #666; font-size: 0.9em; }
         .database-badge { background: #007acc; color: white; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; }
@@ -240,6 +255,10 @@ const htmlTemplate = `<!DOCTYPE html>
                 <div class="stat-label">Failed</div>
             </div>
             <div class="stat-card">
+                <div class="stat-value skipped">{{.SkippedTests}}</div>
+                <div class="stat-label">Skipped</div>
+            </div>
+            <div class="stat-card">
                 <div class="stat-value">{{printf "%.1f%%" successRate}}</div>
                 <div class="stat-label">Success Rate</div>
             </div>
@@ -263,17 +282,20 @@ const htmlTemplate = `<!DOCTYPE html>
             <tbody>
                 {{range .Results}}
                 <tr class="{{if .Steps}}expandable{{end}}" onclick="{{if .Steps}}toggleSteps('{{.Name}}_{{.Database}}'){{end}}">
-                    <td class="{{statusClass .Success}}">
+                    <td class="{{statusClass .}}">
                         {{if .Steps}}<span class="expand-icon">▶</span>{{end}}
-                        {{statusIcon .Success}}
+                        {{statusIcon .}}
                     </td>
                     <td>{{.Name}}</td>
                     <td><span class="database-badge">{{.Database}}</span></td>
                     <td class="duration">{{formatDuration .Duration}}</td>
                     <td>
                         {{.Description}}
-                        {{if not .Success}}
-                            <div class="error-details">{{.Error}}</div>
+						{{if and (not .Success) (not .Skipped)}}
+							<div class="error-details">{{.Error}}</div>
+						{{end}}
+                        {{if .Skipped}}
+                            <div class="step-description">{{.SkipReason}}</div>
                         {{end}}
                     </td>
                 </tr>

--- a/integration/reporting_test.go
+++ b/integration/reporting_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestGenerateSummaryExcludesSkippedFromSuccessRate(t *testing.T) {
+	c := qt.New(t)
+
+	runner := NewTestRunner(nil)
+	runner.report.StartTime = time.Now()
+	runner.report.EndTime = runner.report.StartTime.Add(time.Second)
+	runner.report.TotalTests = 3
+	runner.report.PassedTests = 1
+	runner.report.FailedTests = 0
+	runner.report.SkippedTests = 2
+
+	runner.generateSummary()
+
+	c.Assert(runner.report.Summary, qt.Contains, "Executed 1 tests")
+	c.Assert(runner.report.Summary, qt.Contains, "1 passed, 0 failed, 2 skipped")
+	c.Assert(runner.report.Summary, qt.Contains, "100.0% success rate")
+}
+
+func TestTextReportShowsSkippedAndExecutedSuccessRate(t *testing.T) {
+	c := qt.New(t)
+
+	now := time.Now()
+	report := &TestReport{
+		StartTime:    now,
+		EndTime:      now.Add(time.Second),
+		TotalTests:   3,
+		PassedTests:  1,
+		FailedTests:  0,
+		SkippedTests: 2,
+		Summary:      "Executed 1 tests in 1s. 1 passed, 0 failed, 2 skipped (100.0% success rate)",
+		Results: []TestResult{
+			{Name: "runs_postgres", Database: "postgres", Success: true},
+			{Name: "skips_clickhouse", Database: "clickhouse", Skipped: true, SkipReason: "not compatible"},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := NewReporter(report).generateTextStreamReport(&buf)
+	c.Assert(err, qt.IsNil)
+
+	out := buf.String()
+	c.Assert(out, qt.Contains, "Total Tests: 3")
+	c.Assert(out, qt.Contains, "Passed: 1")
+	c.Assert(out, qt.Contains, "Failed: 0")
+	c.Assert(out, qt.Contains, "Skipped: 2")
+	c.Assert(out, qt.Contains, "Success Rate: 100.0%")
+	c.Assert(out, qt.Contains, "SKIP skips_clickhouse")
+	c.Assert(out, qt.Contains, "Skip: not compatible")
+}


### PR DESCRIPTION
Fixes #260.

## Summary
- collapse live DB `go test` CI into one step with reachable localhost DSNs for PostgreSQL/MySQL/MariaDB
- fail integration-tagged DB tests when a configured DSN cannot connect; still skip only when the env var is absent
- make `integration-test` fail when a requested database has no URL
- report dialect-incompatible scenarios as skipped instead of passed, and compute success rate over executed tests only
- build the integration-test binary with `-race` and pass the env vars used by dynamic integration tests

## Validation
- `go test ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go build -race -o /private/tmp/ptah-integration-test-race ./cmd/integration-test`
- missing requested DB URL now exits non-zero
- configured-but-dead `MYSQL_TEST_DSN` now fails instead of skipping
- absent integration DSNs still skip`