### PR TITLE
fix(migrator): detect out-of-order pending migrations

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -179,7 +179,7 @@ jobs:
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
         run: |
-          go test -v ./migration/migrator -run TestMigrateUp_PostgresLockTimeoutIntegration -timeout 2m
+          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration' -timeout 2m
 
       - name: Run all databases comprehensive test
         env:

--- a/README.md
+++ b/README.md
@@ -644,6 +644,9 @@ Apply all pending migrations to bring database up to latest version:
 # Dry run to preview what would be applied
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dry-run
 
+# Apply a migration that was merged below the current high-water mark
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --exec-order non-linear
+
 # Store migration state in a dedicated schema/table
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
 ```
@@ -657,8 +660,16 @@ Migration files can override the CLI defaults with top-of-file directives:
 
 PostgreSQL uses `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB use `SET SESSION innodb_lock_wait_timeout`; statement timeouts use `max_execution_time` on MySQL and `max_statement_time` on MariaDB. Generated migrations that contain `ALTER TABLE` include the recommended `3s` lock timeout and `30s` statement timeout directives for supported dialects.
 
+Ptah detects out-of-order migrations from the applied version set. By default,
+`migrate-up` uses `--exec-order=linear` and fails if a pending migration version is
+below the current high-water mark, which catches ordinary branch merge races instead
+of silently reporting "up to date". Use `--exec-order=non-linear` to apply those
+pending lower versions, or `--exec-order=linear-skip` to leave them unapplied with
+a warning.
+
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
+- ✅ Detects out-of-order pending migrations below the current version
 - ✅ Each migration runs in its own transaction
 - ✅ Automatic rollback on failure
 - ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
@@ -720,8 +731,10 @@ Show current migration status and pending migrations:
 
 **Output includes:**
 - Current database version
+- Applied migration versions
 - Total available migrations
 - List of pending migrations
+- Out-of-order pending migrations
 - Migration history and timestamps
 
 #### Migration Directory Integrity (`ptah.sum`)

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -38,6 +38,7 @@ const (
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
 	confirmFlag          = "confirm"
+	execOrderFlag        = "exec-order"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
 )
@@ -73,6 +74,11 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Skip confirmation prompt (use with caution!)",
 	},
+	execOrderFlag: &cobraflags.StringFlag{
+		Name:  execOrderFlag,
+		Value: string(migrator.ExecOrderLinear),
+		Usage: "Execution order policy for pending migrations below the current version: linear, linear-skip, or non-linear",
+	},
 	lockTimeoutFlag: &cobraflags.StringFlag{
 		Name:  lockTimeoutFlag,
 		Value: "",
@@ -101,6 +107,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	dryRun := migrateDownFlags[dryRunFlag].GetBool()
 	verbose := migrateDownFlags[verboseFlag].GetBool()
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
+	execOrderValue := migrateDownFlags[execOrderFlag].GetString()
 	lockTimeout := migrateDownFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
 	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
@@ -123,6 +130,10 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	timeouts, err := migrator.ParseMigrationTimeouts(lockTimeout, statementTimeout)
+	if err != nil {
+		return err
+	}
+	execOrder, err := migrator.ParseExecOrder(execOrderValue)
 	if err != nil {
 		return err
 	}
@@ -175,7 +186,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts).WithExecOrder(execOrder)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -2,6 +2,7 @@ package migratestatus
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -119,16 +120,9 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 }
 
 func outputJSON(status *migrator.MigrationStatus) error {
-	// Simple JSON output - in a real implementation you might want to use
-	// a proper JSON marshaling library
-	fmt.Printf(`{
-  "current_version": %d,
-  "total_migrations": %d,
-  "pending_migrations": %v,
-  "has_pending_changes": %t
-}
-`, status.CurrentVersion, status.TotalMigrations, status.PendingMigrations, status.HasPendingChanges)
-	return nil
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(status)
 }
 
 func outputHuman(status *migrator.MigrationStatus, conn *dbschema.DatabaseConnection, verbose bool) error { //revive:disable-line:flag-parameter // it's ok here
@@ -140,7 +134,9 @@ func outputHuman(status *migrator.MigrationStatus, conn *dbschema.DatabaseConnec
 
 	fmt.Printf("Current Version: %d\n", status.CurrentVersion)
 	fmt.Printf("Total Migrations: %d\n", status.TotalMigrations)
+	fmt.Printf("Applied Migrations: %d\n", len(status.AppliedMigrations))
 	fmt.Printf("Pending Migrations: %d\n", len(status.PendingMigrations))
+	fmt.Printf("Out-of-order Migrations: %d\n", len(status.OutOfOrderMigrations))
 
 	if status.HasPendingChanges {
 		fmt.Println("Status: ⚠️  Pending migrations available")
@@ -148,6 +144,12 @@ func outputHuman(status *migrator.MigrationStatus, conn *dbschema.DatabaseConnec
 		if verbose && len(status.PendingMigrations) > 0 {
 			fmt.Println("\nPending migration versions:")
 			for _, version := range status.PendingMigrations {
+				fmt.Printf("  - %d\n", version)
+			}
+		}
+		if verbose && len(status.OutOfOrderMigrations) > 0 {
+			fmt.Println("\nOut-of-order migration versions:")
+			for _, version := range status.OutOfOrderMigrations {
 				fmt.Printf("  - %d\n", version)
 			}
 		}
@@ -163,8 +165,7 @@ func outputHuman(status *migrator.MigrationStatus, conn *dbschema.DatabaseConnec
 		if status.TotalMigrations == 0 {
 			fmt.Println("No migrations found in the migrations directory.")
 		} else {
-			appliedCount := status.TotalMigrations - len(status.PendingMigrations)
-			fmt.Printf("Applied migrations: %d\n", appliedCount)
+			fmt.Printf("Applied migrations: %d\n", len(status.AppliedMigrations))
 
 			if len(status.PendingMigrations) > 0 {
 				fmt.Printf("Next migration to apply: %d\n", status.PendingMigrations[0])

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -37,6 +37,7 @@ const (
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
 	verifySumFlag        = "verify-sum"
+	execOrderFlag        = "exec-order"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
 	allowDestructiveFlag = "allow-destructive"
@@ -67,6 +68,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Name:  verifySumFlag,
 		Value: false,
 		Usage: "Verify the migrations directory against its committed ptah.sum before applying; abort on drift",
+	},
+	execOrderFlag: &cobraflags.StringFlag{
+		Name:  execOrderFlag,
+		Value: string(migrator.ExecOrderLinear),
+		Usage: "Execution order policy for pending migrations below the current version: linear, linear-skip, or non-linear",
 	},
 	lockTimeoutFlag: &cobraflags.StringFlag{
 		Name:  lockTimeoutFlag,
@@ -100,6 +106,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	dryRun := migrateUpFlags[dryRunFlag].GetBool()
 	verbose := migrateUpFlags[verboseFlag].GetBool()
 	verifySum := migrateUpFlags[verifySumFlag].GetBool()
+	execOrderValue := migrateUpFlags[execOrderFlag].GetString()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
 	allowDestructive := migrateUpFlags[allowDestructiveFlag].GetBool()
@@ -134,6 +141,10 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	timeouts, err := migrator.ParseMigrationTimeouts(lockTimeout, statementTimeout)
+	if err != nil {
+		return err
+	}
+	execOrder, err := migrator.ParseExecOrder(execOrderValue)
 	if err != nil {
 		return err
 	}
@@ -185,7 +196,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts).WithExecOrder(execOrder)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())
@@ -196,6 +207,9 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	fmt.Printf("Current version: %d\n", status.CurrentVersion)
 	fmt.Printf("Total migrations: %d\n", status.TotalMigrations)
 	fmt.Printf("Pending migrations: %d\n", len(status.PendingMigrations))
+	if len(status.OutOfOrderMigrations) > 0 {
+		fmt.Printf("Out-of-order migrations: %v\n", status.OutOfOrderMigrations)
+	}
 
 	if !status.HasPendingChanges {
 		fmt.Println("✅ Database is already up to date!")
@@ -204,10 +218,16 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 
 	if verbose {
 		fmt.Printf("Pending migration versions: %v\n", status.PendingMigrations)
+		if len(status.OutOfOrderMigrations) > 0 {
+			fmt.Printf("Out-of-order migration versions: %v\n", status.OutOfOrderMigrations)
+		}
+	}
+	if execOrder == migrator.ExecOrderLinear && len(status.OutOfOrderMigrations) > 0 {
+		return migrator.NewOutOfOrderError(status.CurrentVersion, status.OutOfOrderMigrations)
 	}
 
 	if !allowDestructive {
-		findings, err := lintPendingDestructive(migrationsFS, status.PendingMigrations, conn.Info().Dialect)
+		findings, err := lintPendingDestructive(migrationsFS, pendingMigrationsForSafetyCheck(status, execOrder), conn.Info().Dialect)
 		if err != nil {
 			return fmt.Errorf("error checking pending migration safety: %w", err)
 		}
@@ -240,6 +260,26 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int {
+	if execOrder != migrator.ExecOrderLinearSkip {
+		return status.PendingMigrations
+	}
+
+	outOfOrder := make(map[int]struct{}, len(status.OutOfOrderMigrations))
+	for _, version := range status.OutOfOrderMigrations {
+		outOfOrder[version] = struct{}{}
+	}
+
+	pending := make([]int, 0, len(status.PendingMigrations))
+	for _, version := range status.PendingMigrations {
+		if _, ok := outOfOrder[version]; ok {
+			continue
+		}
+		pending = append(pending, version)
+	}
+	return pending
 }
 
 func lintPendingDestructive(fsys fs.FS, pending []int, dialect string) ([]lint.Finding, error) {

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -10,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/migration/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting exercises the
@@ -73,4 +74,29 @@ ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
 	c.Assert(findings, qt.HasLen, 5)
 	c.Assert([]string{findings[0].Rule, findings[1].Rule, findings[2].Rule, findings[3].Rule, findings[4].Rule}, qt.DeepEquals, []string{"DS102", "DS107", "DS107", "DS108", "DS109"})
 	c.Assert(findings[0].File, qt.Equals, "0000000002_next.up.sql")
+}
+
+func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing.T) {
+	c := qt.New(t)
+
+	status := &migrator.MigrationStatus{
+		PendingMigrations:    []int{3, 6},
+		OutOfOrderMigrations: []int{3},
+	}
+
+	c.Assert(
+		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinear),
+		qt.DeepEquals,
+		[]int{3, 6},
+	)
+	c.Assert(
+		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderNonLinear),
+		qt.DeepEquals,
+		[]int{3, 6},
+	)
+	c.Assert(
+		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinearSkip),
+		qt.DeepEquals,
+		[]int{6},
+	)
 }

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -79,6 +79,11 @@ With dry run:
 go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dry-run
 ```
 
+Allow applying a migration whose version is below the current high-water mark:
+```bash
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --exec-order non-linear
+```
+
 With a custom migration state table:
 ```bash
 go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --migrations-schema infra --migrations-table ptah_migrations
@@ -133,6 +138,19 @@ The migrator package provides a clean, modular API with the following key compon
 - **`MigrationFunc`**: Function type for migration operations
 - **`MigrationStatus`**: Represents the current state of migrations
 
+### Execution Order Policy
+
+Ptah derives pending migrations from the applied version set, not from `MAX(version)`.
+This catches an ordinary branch merge race: migration `5` may already be applied while
+a later-merged migration `3` is present on disk but missing from the database.
+
+The default policy is `linear`, which fails loudly when a pending version is below the
+current high-water mark. Use `WithExecOrder(migrator.ExecOrderNonLinear)` or
+`--exec-order=non-linear` to apply the missing migration in version order. Use
+`linear-skip` only when you intentionally want to leave those versions unapplied; Ptah
+logs a warning for each skipped version and `migrate-status` continues to report it as
+pending and out of order.
+
 ### Migration Providers
 
 - **`RegisteredMigrationProvider`**: In-memory provider for programmatically registered migrations
@@ -144,6 +162,7 @@ The migrator package provides a clean, modular API with the following key compon
 - **`NewFSMigrator(conn, fsys)`**: Creates a migrator that loads migrations from a filesystem
 - **`NewRegisteredMigrationProvider(migrations...)`**: Creates an in-memory migration provider
 - **`WithMigrationsTable(schema, table)`**: Configures the migration history table
+- **`WithExecOrder(policy)`**: Configures out-of-order migration handling
 
 ## Programmatic Usage
 
@@ -277,8 +296,10 @@ CREATE TABLE schema_migrations (
 4. **Test migrations**: Always test both up and down migrations before deploying
 5. **Use transactions**: The migrator automatically wraps migrations in transactions
 6. **Backup before rollbacks**: Down migrations can cause data loss
-7. **Use production timeouts**: Run production DDL with `--lock-timeout 3s --statement-timeout 30s` so hot-table locks and runaway statements fail fast
-8. **Version numbers**: Use sequential version numbers or timestamps
+7. **Handle out-of-order files deliberately**: Use the default `linear` policy in CI so
+   a migration merged below the current version cannot be skipped silently
+8. **Use production timeouts**: Run production DDL with `--lock-timeout 3s --statement-timeout 30s` so hot-table locks and runaway statements fail fast
+9. **Version numbers**: Use sequential version numbers or timestamps
 
 ### Per-Migration Timeouts
 

--- a/migration/migrator/exec_order.go
+++ b/migration/migrator/exec_order.go
@@ -1,0 +1,69 @@
+package migrator
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// ExecOrder controls how the migrator handles unapplied migrations whose
+// version is below the current high-water mark.
+type ExecOrder string
+
+const (
+	// ExecOrderLinear rejects out-of-order pending migrations.
+	ExecOrderLinear ExecOrder = "linear"
+	// ExecOrderLinearSkip leaves out-of-order pending migrations unapplied.
+	ExecOrderLinearSkip ExecOrder = "linear-skip"
+	// ExecOrderNonLinear applies every pending migration in version order.
+	ExecOrderNonLinear ExecOrder = "non-linear"
+)
+
+// ParseExecOrder parses a CLI/API exec-order value.
+func ParseExecOrder(value string) (ExecOrder, error) {
+	switch ExecOrder(strings.ToLower(strings.TrimSpace(value))) {
+	case "", ExecOrderLinear:
+		return ExecOrderLinear, nil
+	case ExecOrderLinearSkip:
+		return ExecOrderLinearSkip, nil
+	case ExecOrderNonLinear:
+		return ExecOrderNonLinear, nil
+	default:
+		return "", fmt.Errorf("invalid exec-order %q: expected linear, linear-skip, or non-linear", value)
+	}
+}
+
+func normalizeExecOrder(value ExecOrder) ExecOrder {
+	switch value {
+	case "", ExecOrderLinear:
+		return ExecOrderLinear
+	case ExecOrderLinearSkip, ExecOrderNonLinear:
+		return value
+	default:
+		return ExecOrderLinear
+	}
+}
+
+// OutOfOrderError reports pending migrations that are below the current
+// high-water mark while linear execution is required.
+type OutOfOrderError struct {
+	CurrentVersion int
+	Versions       []int
+}
+
+func (e *OutOfOrderError) Error() string {
+	return fmt.Sprintf(
+		"out-of-order pending migrations below current version %d: %v (use --exec-order=non-linear to apply or --exec-order=linear-skip to ignore)",
+		e.CurrentVersion,
+		e.Versions,
+	)
+}
+
+// NewOutOfOrderError builds the typed error returned for linear execution when
+// lower-version pending migrations are present.
+func NewOutOfOrderError(currentVersion int, versions []int) *OutOfOrderError {
+	return &OutOfOrderError{
+		CurrentVersion: currentVersion,
+		Versions:       slices.Clone(versions),
+	}
+}

--- a/migration/migrator/exec_order_test.go
+++ b/migration/migrator/exec_order_test.go
@@ -1,0 +1,110 @@
+package migrator
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseExecOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want ExecOrder
+	}{
+		{name: "default", in: "", want: ExecOrderLinear},
+		{name: "linear", in: "linear", want: ExecOrderLinear},
+		{name: "linear skip", in: "linear-skip", want: ExecOrderLinearSkip},
+		{name: "non linear", in: "non-linear", want: ExecOrderNonLinear},
+		{name: "trim and case", in: " Non-Linear ", want: ExecOrderNonLinear},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got, err := ParseExecOrder(tt.in)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestParseExecOrderRejectsUnknownValue(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := ParseExecOrder("latest")
+	c.Assert(err, qt.ErrorMatches, `invalid exec-order "latest": expected linear, linear-skip, or non-linear`)
+}
+
+func TestPendingMigrationVersionsUsesAppliedSet(t *testing.T) {
+	c := qt.New(t)
+
+	migrations := testMigrations(1, 2, 3, 5)
+	pending := pendingMigrationVersions(migrations, []int{1, 2, 5})
+
+	c.Assert(pending, qt.DeepEquals, []int{3})
+	c.Assert(outOfOrderMigrationVersions(pending, 5), qt.DeepEquals, []int{3})
+}
+
+func TestMigrationsToApplyExecOrderPolicies(t *testing.T) {
+	c := qt.New(t)
+
+	migrations := testMigrations(1, 2, 3, 5)
+	applied := []int{1, 2, 5}
+
+	linear := NewMigrator(nil, NewRegisteredMigrationProvider(migrations...))
+	_, err := linear.migrationsToApply(migrations, applied, 0)
+	c.Assert(err, qt.IsNotNil)
+	var outOfOrderErr *OutOfOrderError
+	c.Assert(err, qt.ErrorAs, &outOfOrderErr)
+	c.Assert(outOfOrderErr.CurrentVersion, qt.Equals, 5)
+	c.Assert(outOfOrderErr.Versions, qt.DeepEquals, []int{3})
+
+	linearSkip := linear.WithExecOrder(ExecOrderLinearSkip)
+	got, err := linearSkip.migrationsToApply(migrations, applied, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int{})
+
+	nonLinear := linear.WithExecOrder(ExecOrderNonLinear)
+	got, err = nonLinear.migrationsToApply(migrations, applied, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int{3})
+}
+
+func TestMigrationsToRollbackUsesAppliedSet(t *testing.T) {
+	c := qt.New(t)
+
+	migrationMap := migrationsByVersion(testMigrations(1, 2, 3, 5))
+	got, err := migrationsToRollback(migrationMap, []int{1, 2, 5}, 2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int{5})
+}
+
+func TestMigrationsToRollbackRequiresAppliedMigrationFile(t *testing.T) {
+	c := qt.New(t)
+
+	migrationMap := migrationsByVersion(testMigrations(1, 2))
+	_, err := migrationsToRollback(migrationMap, []int{1, 2, 5}, 2)
+	c.Assert(err, qt.ErrorMatches, `applied migration 5 is above target version 2 but is missing from the migration provider`)
+}
+
+func testMigrations(versions ...int) []*Migration {
+	migrations := make([]*Migration, 0, len(versions))
+	for _, version := range versions {
+		migrations = append(migrations, &Migration{
+			Version:     version,
+			Description: "test",
+			Up:          NoopMigrationFunc,
+			Down:        NoopMigrationFunc,
+		})
+	}
+	return migrations
+}
+
+func migrationVersions(migrations []*Migration) []int {
+	versions := make([]int, 0, len(migrations))
+	for _, migration := range migrations {
+		versions = append(versions, migration.Version)
+	}
+	return versions
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -15,10 +16,12 @@ import (
 
 // MigrationStatus represents the current state of migrations
 type MigrationStatus struct {
-	CurrentVersion    int   `json:"current_version"`
-	PendingMigrations []int `json:"pending_migrations"`
-	TotalMigrations   int   `json:"total_migrations"`
-	HasPendingChanges bool  `json:"has_pending_changes"`
+	CurrentVersion       int   `json:"current_version"`
+	AppliedMigrations    []int `json:"applied_migrations"`
+	PendingMigrations    []int `json:"pending_migrations"`
+	OutOfOrderMigrations []int `json:"out_of_order_migrations"`
+	TotalMigrations      int   `json:"total_migrations"`
+	HasPendingChanges    bool  `json:"has_pending_changes"`
 }
 
 // Migrator handles database migrations for ptah
@@ -28,6 +31,7 @@ type Migrator struct {
 	defaultTimeouts   MigrationTimeouts
 	migrationsTable   string
 	migrationsSchema  string
+	execOrder         ExecOrder
 	initialized       bool
 	logger            *slog.Logger
 }
@@ -51,6 +55,7 @@ func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) 
 		conn:              conn,
 		migrationProvider: provider,
 		migrationsTable:   "schema_migrations",
+		execOrder:         ExecOrderLinear,
 		logger:            slog.Default(),
 	}
 }
@@ -59,6 +64,14 @@ func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) 
 func (m *Migrator) WithLogger(l *slog.Logger) *Migrator {
 	tmp := *m
 	tmp.logger = l
+	return &tmp
+}
+
+// WithExecOrder sets how this migrator handles pending migrations whose
+// version is below the current high-water mark.
+func (m *Migrator) WithExecOrder(execOrder ExecOrder) *Migrator {
+	tmp := *m
+	tmp.execOrder = normalizeExecOrder(execOrder)
 	return &tmp
 }
 
@@ -184,7 +197,7 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 	}
 	defer rows.Close()
 
-	var applied []int
+	applied := make([]int, 0)
 	for rows.Next() {
 		var version int
 		if err := rows.Scan(&version); err != nil {
@@ -202,67 +215,48 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 
 // GetPendingMigrations returns a list of pending migration versions
 func (m *Migrator) GetPendingMigrations(ctx context.Context) ([]int, error) {
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	applied, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	migrations := m.migrationProvider.Migrations()
-
-	var pending []int
-	for _, migration := range migrations {
-		if migration.Version > currentVersion {
-			pending = append(pending, migration.Version)
-		}
-	}
-
-	sort.Ints(pending)
-	return pending, nil
+	return pendingMigrationVersions(m.migrationProvider.Migrations(), applied), nil
 }
 
 // GetPreviousMigrationVersion finds the previous migration version compared to the current one.
 // Returns an error and -1 if no previous migrations exist.
 func (m *Migrator) GetPreviousMigrationVersion(ctx context.Context) (int, error) {
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	applied, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return -1, fmt.Errorf("failed to get current version: %w", err)
+		return -1, fmt.Errorf("failed to get applied migrations: %w", err)
 	}
-
-	// If current version is 0, there are no previous migrations
-	if currentVersion == 0 {
+	if len(applied) == 0 {
 		return -1, fmt.Errorf("no previous migrations exist")
 	}
-
-	migrations := m.migrationProvider.Migrations()
-
-	previousVersion := -1
-	for _, migration := range migrations {
-		if migration.Version >= currentVersion {
-			break
-		}
-		previousVersion = migration.Version
+	if len(applied) == 1 {
+		return 0, nil
 	}
 
-	return previousVersion, nil
+	return applied[len(applied)-2], nil
 }
 
 // GetMigrationStatus returns information about the current migration status using the provided filesystem
 func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, error) {
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get current version: %w", err)
+		return nil, fmt.Errorf("failed to get applied migrations: %w", err)
 	}
-
-	pendingMigrations, err := m.GetPendingMigrations(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get pending migrations: %w", err)
-	}
+	currentVersion := maxAppliedVersion(appliedMigrations)
+	pendingMigrations := pendingMigrationVersions(m.MigrationProvider().Migrations(), appliedMigrations)
+	outOfOrderMigrations := outOfOrderMigrationVersions(pendingMigrations, currentVersion)
 
 	return &MigrationStatus{
-		CurrentVersion:    currentVersion,
-		PendingMigrations: pendingMigrations,
-		TotalMigrations:   len(m.MigrationProvider().Migrations()),
-		HasPendingChanges: len(pendingMigrations) > 0,
+		CurrentVersion:       currentVersion,
+		AppliedMigrations:    appliedMigrations,
+		PendingMigrations:    pendingMigrations,
+		OutOfOrderMigrations: outOfOrderMigrations,
+		TotalMigrations:      len(m.MigrationProvider().Migrations()),
+		HasPendingChanges:    len(pendingMigrations) > 0,
 	}, nil
 }
 
@@ -273,65 +267,21 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
 
-	// Get the current version
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current version: %w", err)
+		return fmt.Errorf("failed to get applied migrations: %w", err)
 	}
+	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	migrations := m.migrationProvider.Migrations()
+	migrationsToApply, err := m.migrationsToApply(migrations, appliedMigrations, 0)
+	if err != nil {
+		return err
+	}
 
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "totalMigrations", len(migrations))
-
-	// Rebind once: the template and dialect are loop-invariant. Values are
-	// still bound as native driver parameters via these placeholders so we
-	// never interpolate user-controlled strings into the SQL text.
-	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.recordMigrationSQL())
-
-	// Apply migrations that are newer than current version
-	for _, migration := range migrations {
-		if migration.Version <= currentVersion {
-			m.logger.Info("Skipping migration", "version", migration.Version, "description", migration.Description)
-			continue
-		}
-
-		m.logger.Info("Applying migration", "version", migration.Version, "description", migration.Description)
-
-		// Begin transaction for this migration
-		if err := m.conn.Writer().BeginTransaction(); err != nil {
-			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
-		}
-
-		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
-		if err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
-		}
-
-		// Apply migration
-		if err := migration.Up(ctx, m.conn); err != nil {
-			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
-		}
-
-		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return err
-		}
-
-		// Record migration via parameter binding.
-		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
-		}
-
-		// Commit transaction
-		if err := m.conn.Writer().CommitTransaction(); err != nil {
-			return fmt.Errorf("failed to commit transaction for migration %d: %w", migration.Version, err)
-		}
-
-		m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
+	if err := m.applyUpMigrations(ctx, migrationsToApply); err != nil {
+		return err
 	}
 
 	m.logger.Info("All migrations applied successfully")
@@ -360,11 +310,11 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
 
-	// Get the current version
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current version: %w", err)
+		return fmt.Errorf("failed to get applied migrations: %w", err)
 	}
+	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	// Skip if already at or below target version (shouldn't happen)
 	if targetVersion >= currentVersion {
@@ -372,25 +322,19 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 		return nil
 	}
 
-	migrations := m.migrationProvider.Migrations()
+	migrationMap := migrationsByVersion(m.migrationProvider.Migrations())
+	migrationsToRollback, err := migrationsToRollback(migrationMap, appliedMigrations, targetVersion)
+	if err != nil {
+		return err
+	}
 
-	m.logger.Info("Migrating down", "targetVersion", targetVersion, "currentVersion", currentVersion, "totalMigrations", len(migrations))
-
-	// Sort migrations by version in descending order for rollback
-	sort.Slice(migrations, func(i, j int) bool {
-		return migrations[i].Version > migrations[j].Version
-	})
+	m.logger.Info("Migrating down", "targetVersion", targetVersion, "currentVersion", currentVersion, "totalMigrations", len(m.migrationProvider.Migrations()))
 
 	// Rebind once: template + dialect are loop-invariant. Migration version
 	// is bound as a parameter via the dialect-native placeholder.
 	deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
 
-	// Apply down migrations for versions greater than target
-	for _, migration := range migrations {
-		if migration.Version <= targetVersion || migration.Version > currentVersion {
-			continue
-		}
-
+	for _, migration := range migrationsToRollback {
 		m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
 
 		// Begin transaction for this migration rollback
@@ -441,11 +385,11 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int) error {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
 
-	// Get the current version
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current version: %w", err)
+		return fmt.Errorf("failed to get applied migrations: %w", err)
 	}
+	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	if targetVersion == currentVersion {
 		m.logger.Info("Already at target version", "version", targetVersion)
@@ -455,6 +399,10 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int) error {
 	if targetVersion > currentVersion {
 		// Migrate up to target version
 		return m.migrateUpTo(ctx, targetVersion)
+	}
+
+	if targetVersion > 0 && !slices.Contains(appliedMigrations, targetVersion) {
+		return fmt.Errorf("target version %d is below current version %d but is not applied", targetVersion, currentVersion)
 	}
 
 	// Migrate down to target version
@@ -468,25 +416,34 @@ func (m *Migrator) MigrationProvider() MigrationProvider {
 
 // migrateUpTo migrates the database up to a specific version
 func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
-	// Get the current version
-	currentVersion, err := m.GetCurrentVersion(ctx)
+	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current version: %w", err)
+		return fmt.Errorf("failed to get applied migrations: %w", err)
 	}
+	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	migrations := m.migrationProvider.Migrations()
+	migrationsToApply, err := m.migrationsToApply(migrations, appliedMigrations, targetVersion)
+	if err != nil {
+		return err
+	}
 
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "targetVersion", targetVersion, "totalMigrations", len(migrations))
+	if err := m.applyUpMigrations(ctx, migrationsToApply); err != nil {
+		return err
+	}
 
-	// Rebind once; see MigrateUp for the rationale on parameter binding.
+	m.logger.Info("Migrated successfully", "targetVersion", targetVersion)
+	return nil
+}
+
+func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migration) error {
+	// Rebind once: the template and dialect are loop-invariant. Values are
+	// still bound as native driver parameters via these placeholders so we
+	// never interpolate user-controlled strings into the SQL text.
 	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.recordMigrationSQL())
 
-	// Apply migrations up to target version
 	for _, migration := range migrations {
-		if migration.Version <= currentVersion || migration.Version > targetVersion {
-			continue
-		}
-
 		m.logger.Info("Applying migration", "version", migration.Version, "description", migration.Description)
 
 		// Begin transaction for this migration
@@ -526,6 +483,100 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
 		m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
 	}
 
-	m.logger.Info("Migrated successfully", "targetVersion", targetVersion)
 	return nil
+}
+
+func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int, targetVersion int) ([]*Migration, error) {
+	currentVersion := maxAppliedVersion(applied)
+	pendingVersions := pendingMigrationVersions(migrations, applied)
+	outOfOrderVersions := outOfOrderMigrationVersions(pendingVersions, currentVersion)
+	execOrder := normalizeExecOrder(m.execOrder)
+
+	if execOrder == ExecOrderLinear && len(outOfOrderVersions) > 0 {
+		return nil, NewOutOfOrderError(currentVersion, outOfOrderVersions)
+	}
+
+	appliedSet := versionSet(applied)
+	migrationsToApply := make([]*Migration, 0, len(pendingVersions))
+	for _, migration := range migrations {
+		if _, ok := appliedSet[migration.Version]; ok {
+			continue
+		}
+		if targetVersion > 0 && migration.Version > targetVersion {
+			continue
+		}
+		if execOrder == ExecOrderLinearSkip && migration.Version < currentVersion {
+			m.logger.Warn("Skipping out-of-order migration", "version", migration.Version, "currentVersion", currentVersion)
+			continue
+		}
+		migrationsToApply = append(migrationsToApply, migration)
+	}
+
+	return migrationsToApply, nil
+}
+
+func pendingMigrationVersions(migrations []*Migration, applied []int) []int {
+	appliedSet := versionSet(applied)
+	pending := make([]int, 0, len(migrations))
+	for _, migration := range migrations {
+		if _, ok := appliedSet[migration.Version]; ok {
+			continue
+		}
+		pending = append(pending, migration.Version)
+	}
+	sort.Ints(pending)
+	return pending
+}
+
+func outOfOrderMigrationVersions(pending []int, currentVersion int) []int {
+	outOfOrder := make([]int, 0)
+	for _, version := range pending {
+		if version < currentVersion {
+			outOfOrder = append(outOfOrder, version)
+		}
+	}
+	return outOfOrder
+}
+
+func maxAppliedVersion(applied []int) int {
+	if len(applied) == 0 {
+		return 0
+	}
+	return slices.Max(applied)
+}
+
+func versionSet(versions []int) map[int]struct{} {
+	set := make(map[int]struct{}, len(versions))
+	for _, version := range versions {
+		set[version] = struct{}{}
+	}
+	return set
+}
+
+func migrationsByVersion(migrations []*Migration) map[int]*Migration {
+	result := make(map[int]*Migration, len(migrations))
+	for _, migration := range migrations {
+		result[migration.Version] = migration
+	}
+	return result
+}
+
+func migrationsToRollback(migrationsByVersion map[int]*Migration, applied []int, targetVersion int) ([]*Migration, error) {
+	rollbackVersions := make([]int, 0, len(applied))
+	for _, version := range applied {
+		if version > targetVersion {
+			rollbackVersions = append(rollbackVersions, version)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(rollbackVersions)))
+
+	rollbackMigrations := make([]*Migration, 0, len(rollbackVersions))
+	for _, version := range rollbackVersions {
+		migration, ok := migrationsByVersion[version]
+		if !ok {
+			return nil, fmt.Errorf("applied migration %d is above target version %d but is missing from the migration provider", version, targetVersion)
+		}
+		rollbackMigrations = append(rollbackMigrations, migration)
+	}
+	return rollbackMigrations, nil
 }

--- a/migration/migrator/out_of_order_integration_test.go
+++ b/migration/migrator/out_of_order_integration_test.go
@@ -1,0 +1,145 @@
+package migrator_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestOutOfOrderMigrationsPostgresIntegration(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+	cleanupIssue261(t, conn)
+	defer cleanupIssue261(t, conn)
+
+	applyIssue261Migrations(t, conn)
+
+	mig := issue261Migrator(conn, issue261AllMigrations()...)
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, 5)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int{1, 2, 5})
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int{3})
+	c.Assert(status.OutOfOrderMigrations, qt.DeepEquals, []int{3})
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	var outOfOrderErr *migrator.OutOfOrderError
+	c.Assert(err, qt.ErrorAs, &outOfOrderErr)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v3"), qt.IsFalse)
+
+	err = mig.MigrateTo(ctx, 3)
+	c.Assert(err, qt.ErrorMatches, `target version 3 is below current version 5 but is not applied`)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v5"), qt.IsTrue)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v3"), qt.IsFalse)
+
+	err = mig.WithExecOrder(migrator.ExecOrderLinearSkip).MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v3"), qt.IsFalse)
+
+	err = mig.MigrateDownTo(ctx, 2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v5"), qt.IsFalse)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v3"), qt.IsFalse)
+
+	cleanupIssue261(t, conn)
+	applyIssue261Migrations(t, conn)
+
+	err = issue261Migrator(conn, issue261AllMigrations()...).
+		WithExecOrder(migrator.ExecOrderNonLinear).
+		MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_261_v3"), qt.IsTrue)
+
+	finalStatus, err := issue261Migrator(conn, issue261AllMigrations()...).GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(finalStatus.AppliedMigrations, qt.DeepEquals, []int{1, 2, 3, 5})
+	c.Assert(finalStatus.PendingMigrations, qt.HasLen, 0)
+}
+
+func postgresTestURL(t *testing.T) string {
+	t.Helper()
+
+	dbURL := os.Getenv("POSTGRES_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN or TEST_DATABASE_URL not set")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		t.Skip("PostgreSQL URL required for out-of-order migration integration test")
+	}
+	return dbURL
+}
+
+func issue261Migrator(conn *dbschema.DatabaseConnection, migrations ...*migrator.Migration) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationsTable("", "schema_migrations_issue_261")
+}
+
+func applyIssue261Migrations(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	err := issue261Migrator(conn, issue261AppliedMigrations()...).MigrateUp(context.Background())
+	qt.Assert(t, err, qt.IsNil)
+}
+
+func issue261AppliedMigrations() []*migrator.Migration {
+	return []*migrator.Migration{
+		issue261Migration(1, "v1", "CREATE TABLE ptah_issue_261_v1 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v1"),
+		issue261Migration(2, "v2", "CREATE TABLE ptah_issue_261_v2 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v2"),
+		issue261Migration(5, "v5", "CREATE TABLE ptah_issue_261_v5 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v5"),
+	}
+}
+
+func issue261AllMigrations() []*migrator.Migration {
+	return []*migrator.Migration{
+		issue261Migration(1, "v1", "CREATE TABLE ptah_issue_261_v1 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v1"),
+		issue261Migration(2, "v2", "CREATE TABLE ptah_issue_261_v2 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v2"),
+		issue261Migration(3, "v3", "CREATE TABLE ptah_issue_261_v3 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_never_applied_must_not_exist"),
+		issue261Migration(5, "v5", "CREATE TABLE ptah_issue_261_v5 (id INTEGER PRIMARY KEY)", "DROP TABLE ptah_issue_261_v5"),
+	}
+}
+
+func issue261Migration(version int, description, upSQL, downSQL string) *migrator.Migration {
+	return migrator.CreateMigrationFromSQL(version, description, upSQL, downSQL)
+}
+
+func cleanupIssue261(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS schema_migrations_issue_261",
+		"DROP TABLE IF EXISTS ptah_issue_261_v5",
+		"DROP TABLE IF EXISTS ptah_issue_261_v3",
+		"DROP TABLE IF EXISTS ptah_issue_261_v2",
+		"DROP TABLE IF EXISTS ptah_issue_261_v1",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func tableExists(t *testing.T, conn *dbschema.DatabaseConnection, tableName string) bool {
+	t.Helper()
+
+	var exists bool
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = $1)",
+		tableName,
+	).Scan(&exists)
+	qt.Assert(t, err, qt.IsNil)
+	return exists
+}


### PR DESCRIPTION
## Summary
- derive pending migrations from the applied version set instead of the high-water mark
- add exec-order policy support: linear, linear-skip, and non-linear
- make rollback select only applied versions, so never-applied down migrations are not executed
- expose applied/out-of-order status in CLI human and JSON output
- document out-of-order merge-race handling and run the Postgres regression in integration CI

## Validation
- go test ./migration/migrator ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus
- go test ./...
- go test -tags=integration ./migration/migrator
- golangci-lint run ./...

Fixes #261