### PR TITLE
fix(migrator): route SQL migrations through writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,20 @@ Migration files can override the CLI defaults with top-of-file directives:
 
 PostgreSQL uses `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB use `SET SESSION innodb_lock_wait_timeout`; statement timeouts use `max_execution_time` on MySQL and `max_statement_time` on MariaDB. Generated migrations that contain `ALTER TABLE` include the recommended `3s` lock timeout and `30s` statement timeout directives for supported dialects.
 
+Most migrations run inside the normal per-migration transaction. If the database
+rejects transactional execution, use an explicit file directive:
+
+```sql
+-- +ptah no_transaction
+ALTER TYPE status ADD VALUE 'archived';
+ALTER TABLE users ALTER COLUMN status SET DEFAULT 'archived';
+```
+
+Use this only for narrow database requirements such as PostgreSQL enum value
+additions that must be used later in the same migration. Ptah rejects migration
+timeouts on `no_transaction` migrations because those statements run as raw
+autocommit SQL instead of through the transaction-bound writer.
+
 Ptah detects out-of-order migrations from the applied version set. By default,
 `migrate-up` uses `--exec-order=linear` and fails if a pending migration version is
 below the current high-water mark, which catches ordinary branch merge races instead
@@ -670,7 +684,7 @@ a warning.
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
 - ✅ Detects out-of-order pending migrations below the current version
-- ✅ Each migration runs in its own transaction
+- ✅ Each migration runs in its own transaction unless explicitly marked `no_transaction`
 - ✅ Automatic rollback on failure
 - ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
 - ✅ Supports dry-run mode for preview

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -26,8 +26,9 @@ var migrateUpCmd = &cobra.Command{
 This command applies all migrations that haven't been applied yet, bringing
 the database schema up to the latest version defined in the migration files.
 
-Each migration is run in a transaction, so if any migration fails, it will
-be rolled back and the migration process will stop.`,
+Each migration is run in a transaction unless its file explicitly opts out with
+-- +ptah no_transaction, so ordinary migration failures are rolled back and the
+migration process stops.`,
 	RunE: migrateUpCommand,
 }
 

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -397,18 +397,18 @@ func (vem *VersionedEntityManager) GenerateSchemaFromEntities() (*goschema.Datab
 	return goschema.ParseDir(vem.entitiesDir)
 }
 
-// GenerateMigrationSQL compares current entities with database and generates migration SQL
-func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, conn *dbschema.DatabaseConnection) ([]string, error) {
+// GenerateMigrationSQL compares current entities with database and generates migration SQL.
+func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, conn *dbschema.DatabaseConnection) ([]string, bool, error) {
 	// Parse current entities
 	generated, err := vem.GenerateSchemaFromEntities()
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse entities: %w", err)
+		return nil, false, fmt.Errorf("failed to parse entities: %w", err)
 	}
 
 	// Read current database schema
 	dbSchema, err := conn.Reader().ReadSchema()
 	if err != nil {
-		return nil, fmt.Errorf("failed to read database schema: %w", err)
+		return nil, false, fmt.Errorf("failed to read database schema: %w", err)
 	}
 
 	// Compare schemas (dialect-aware so MySQL/MariaDB RESTRICT == NO ACTION)
@@ -416,15 +416,16 @@ func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, co
 
 	// Generate migration SQL
 	info := conn.Info()
+	nodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
 	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
 
-	return statements, nil
+	return statements, planner.RequiresNoTransaction(info.Dialect, nodes), nil
 }
 
 // ApplyMigrationFromEntities generates and applies a migration from current entities
 func (vem *VersionedEntityManager) ApplyMigrationFromEntities(ctx context.Context, conn *dbschema.DatabaseConnection, description string) error {
 	// Generate migration SQL
-	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	statements, noTransaction, err := vem.GenerateMigrationSQL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to generate migration SQL: %w", err)
 	}
@@ -450,6 +451,7 @@ func (vem *VersionedEntityManager) ApplyMigrationFromEntities(ctx context.Contex
 	downSQL := "-- Auto-generated down migration\n-- Manual review required\n"
 
 	migration := migrator.CreateMigrationFromSQL(vem.version, description, upSQL.String(), downSQL)
+	migration.NoTransaction = noTransaction
 
 	p := migrator.NewRegisteredMigrationProvider(migration)
 	m := migrator.NewMigrator(conn, p)

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -611,7 +611,7 @@ func rollbackToVersion(ctx context.Context, conn *dbschema.DatabaseConnection, v
 	}
 
 	// Generate migration SQL to reach target state
-	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to generate rollback migration SQL: %w", err)
 	}

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -566,7 +566,7 @@ func testDynamicSchemaDiff(ctx context.Context, conn *dbschema.DatabaseConnectio
 	}
 
 	// Generate migration SQL to see the diff
-	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to generate migration SQL: %w", err)
 	}
@@ -606,7 +606,7 @@ func testDynamicMigrationSQLGeneration(ctx context.Context, conn *dbschema.Datab
 	}
 
 	// Generate SQL for creating everything from scratch
-	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to generate migration SQL: %w", err)
 	}
@@ -3030,7 +3030,7 @@ func testDynamicRLSFunctionsDependencyOrder(ctx context.Context, conn *dbschema.
 			return fmt.Errorf("failed to load 000-initial entities: %w", err)
 		}
 
-		statements, err := vem.GenerateMigrationSQL(ctx, conn)
+		statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("failed to generate migration SQL: %w", err)
 		}

--- a/integration/scenarios_field_check_and_function_modify.go
+++ b/integration/scenarios_field_check_and_function_modify.go
@@ -200,7 +200,7 @@ func testDynamicFieldCheckConstraintEvolution(ctx context.Context, conn *dbschem
 	}
 
 	if err := recorder.RecordStep("Idempotency After Add", "Re-diff against 019 — no further changes expected", func() error {
-		statements, err := vem.GenerateMigrationSQL(ctx, conn)
+		statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("failed to regenerate migration SQL: %w", err)
 		}
@@ -241,7 +241,7 @@ func testDynamicFieldCheckConstraintEvolution(ctx context.Context, conn *dbschem
 	}
 
 	return recorder.RecordStep("Idempotency After Modify", "Re-diff against 020 — no further changes expected", func() error {
-		statements, err := vem.GenerateMigrationSQL(ctx, conn)
+		statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("failed to regenerate migration SQL: %w", err)
 		}

--- a/integration/scenarios_fk_action_evolution.go
+++ b/integration/scenarios_fk_action_evolution.go
@@ -122,7 +122,7 @@ func testDynamicFKActionEvolution(ctx context.Context, conn *dbschema.DatabaseCo
 // assertNoPendingChanges re-diffs the currently loaded fixture version against
 // the live database and fails on any non-comment statement.
 func assertNoPendingChanges(ctx context.Context, conn *dbschema.DatabaseConnection, vem *VersionedEntityManager, when string) error {
-	statements, err := vem.GenerateMigrationSQL(ctx, conn)
+	statements, _, err := vem.GenerateMigrationSQL(ctx, conn)
 	if err != nil {
 		return fmt.Errorf("failed to regenerate migration SQL %s: %w", when, err)
 	}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -165,6 +165,9 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		// No migration needed - this is a successful no-op operation
 		return nil, nil
 	}
+	if planner.RequiresNoTransaction(info.Dialect, upNodes) {
+		upSQL = withNoTransactionDirective(upSQL)
+	}
 
 	// 6. Generate down migration SQL
 	downSQL, err := generateDownMigrationSQL(diff, generated, dbSchema, info.Dialect, info.Capabilities)
@@ -808,6 +811,16 @@ func latestExistingMigrationVersion(outputDir string) int {
 func nonEmptyFileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.Size() > 0
+}
+
+func withNoTransactionDirective(sql string) string {
+	if strings.TrimSpace(sql) == "" {
+		return sql
+	}
+	if directive, ok := migrator.ParseFileDirectives(sql)[migrator.DirectiveNoTransaction]; ok && directive == "true" {
+		return sql
+	}
+	return "-- +ptah " + migrator.DirectiveNoTransaction + "\n" + sql
 }
 
 // createMigrationFiles creates the up and down migration files

--- a/migration/generator/no_transaction_test.go
+++ b/migration/generator/no_transaction_test.go
@@ -1,0 +1,23 @@
+package generator
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestWithNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "ALTER TYPE status ADD VALUE 'archived';\n"
+	got := withNoTransactionDirective(sql)
+
+	c.Assert(got, qt.Equals, "-- +ptah no_transaction\n"+sql)
+	c.Assert(migrator.ParseFileDirectives(got), qt.DeepEquals, map[string]string{
+		migrator.DirectiveNoTransaction: "true",
+	})
+	c.Assert(withNoTransactionDirective(got), qt.Equals, got)
+	c.Assert(withNoTransactionDirective(""), qt.Equals, "")
+}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -6,7 +6,7 @@ The Ptah Migrator provides versioned database migration capabilities with up/dow
 
 - **Versioned Migrations**: Each migration has a unique version number and description
 - **Up/Down Migrations**: Support for both applying and rolling back migrations
-- **Transaction Safety**: Each migration runs in its own transaction
+- **Transaction Safety**: Each migration runs in its own transaction unless it explicitly opts out with `no_transaction`
 - **SQL File Support**: Migrations can be defined as SQL files
 - **Go Function Support**: Migrations can also be defined as Go functions for complex logic
 - **Multiple Database Support**: Works with PostgreSQL and MySQL through Ptah's executor package
@@ -320,9 +320,27 @@ ALTER TABLE users ADD COLUMN email TEXT;
 
 PostgreSQL runs `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB run `SET SESSION innodb_lock_wait_timeout`; statement timeouts use MySQL `max_execution_time` and MariaDB `max_statement_time`.
 
+### Non-Transactional Migrations
+
+Most migrations should stay transactional. When the database rejects
+transactional execution, mark the migration explicitly:
+
+```sql
+-- +ptah no_transaction
+ALTER TYPE status ADD VALUE 'archived';
+ALTER TABLE users ALTER COLUMN status SET DEFAULT 'archived';
+```
+
+`no_transaction` executes the migration body and metadata update outside the
+normal per-migration transaction. This is intended for narrow database
+requirements such as PostgreSQL enum value additions that must be used by a
+later statement in the same migration. Migration timeouts are rejected for
+`no_transaction` migrations because Ptah cannot safely apply writer/session
+timeouts to raw autocommit statements.
+
 ## Safety Features
 
-- **Transaction Wrapping**: Each migration runs in its own transaction
+- **Transaction Wrapping**: Each migration runs in its own transaction unless marked `no_transaction`
 - **Rollback on Failure**: If a migration fails, the transaction is rolled back
 - **Confirmation Prompts**: Down migrations require confirmation (unless `--confirm` is used)
 - **Dry Run Mode**: Preview migrations without applying them

--- a/migration/migrator/directives.go
+++ b/migration/migrator/directives.go
@@ -9,13 +9,15 @@ import (
 // directivePrefix marks a ptah directive inside a SQL line comment:
 //
 //	-- +ptah key=value [key=value ...]
+//	-- +ptah no_transaction
 const directivePrefix = "+ptah"
 
 // ParseFileDirectives extracts `-- +ptah key=value` annotations from migration
 // SQL. Directives are file-scoped: every annotated line contributes to one
-// merged map (later lines win on duplicate keys). Tokens without an equals
-// sign and malformed lines are ignored — directives must never make a
-// migration file unreadable.
+// merged map (later lines win on duplicate keys). Bare no_transaction is a
+// boolean shorthand for no_transaction=true; other tokens without an equals
+// sign and malformed lines are ignored so directives never make a migration
+// file unreadable.
 //
 // The scan is lexer-driven, the same lexer SplitSQLStatements uses, so a
 // `-- +ptah` sequence inside a string literal or a block comment is never
@@ -47,8 +49,11 @@ func ParseFileDirectives(sql string) map[string]string {
 		}
 		for token := range strings.FieldsSeq(body) {
 			key, value, found := strings.Cut(token, "=")
-			if found && key != "" {
+			switch {
+			case found && key != "":
 				directives[key] = value
+			case token == DirectiveNoTransaction:
+				directives[token] = "true"
 			}
 		}
 	}

--- a/migration/migrator/directives_test.go
+++ b/migration/migrator/directives_test.go
@@ -53,6 +53,11 @@ func TestParseFileDirectives(t *testing.T) {
 			want: map[string]string{"online_ddl_tool": "ghost"},
 		},
 		{
+			name: "bare no transaction shorthand",
+			sql:  "-- +ptah no_transaction online_ddl_tool=ghost\n",
+			want: map[string]string{"no_transaction": "true", "online_ddl_tool": "ghost"},
+		},
+		{
 			name: "directive prefix must be a whole word",
 			sql:  "-- +ptahx key=value\n",
 			want: map[string]string{},

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -1,11 +1,14 @@
 package migrator
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"maps"
 	"slices"
 	"sort"
+
+	"github.com/stokaro/ptah/dbschema"
 )
 
 // MigrationProvider provides a list of migrations
@@ -126,21 +129,28 @@ func (p *FSMigrationProvider) load() error {
 		foundFiles[migrationFile.Version][migrationFile.Direction] = true
 
 		// Set the appropriate migration function based on direction
+		migration := migrationsMap[migrationFile.Version]
 		switch migrationFile.Direction {
 		case "up":
-			up, timeouts, err := MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(path, p.fsys, p.interceptor)
+			up, err := migrationFuncFromSQLFilenameWithMetadata(path, p.fsys, p.interceptor)
 			if err != nil {
 				return fmt.Errorf("failed to load up migration %s: %w", path, err)
 			}
-			migrationsMap[migrationFile.Version].Up = up
-			migrationsMap[migrationFile.Version].UpTimeouts = timeouts
+			migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+				return up.fn(ctx, conn, migration.executionMode())
+			}
+			migration.UpTimeouts = up.timeouts
+			migration.NoTransaction = migration.NoTransaction || up.noTransaction
 		case "down":
-			down, timeouts, err := MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(path, p.fsys, p.interceptor)
+			down, err := migrationFuncFromSQLFilenameWithMetadata(path, p.fsys, p.interceptor)
 			if err != nil {
 				return fmt.Errorf("failed to load down migration %s: %w", path, err)
 			}
-			migrationsMap[migrationFile.Version].Down = down
-			migrationsMap[migrationFile.Version].DownTimeouts = timeouts
+			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+				return down.fn(ctx, conn, migration.executionMode())
+			}
+			migration.DownTimeouts = down.timeouts
+			migration.NoTransaction = migration.NoTransaction || down.noTransaction
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"strconv"
 	"strings"
 
 	"github.com/stokaro/ptah/core/sqlutil"
@@ -39,6 +40,34 @@ type StatementInterceptor interface {
 	ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (handled bool, err error)
 }
 
+type migrationExecutionMode int
+
+const (
+	migrationExecutionTransactional migrationExecutionMode = iota
+	migrationExecutionNoTransaction
+)
+
+type sqlMigrationFunc func(context.Context, *dbschema.DatabaseConnection, migrationExecutionMode) error
+
+type sqlMigrationFile struct {
+	fn            sqlMigrationFunc
+	timeouts      MigrationTimeouts
+	noTransaction bool
+}
+
+func (f sqlMigrationFile) executionMode() migrationExecutionMode {
+	if f.noTransaction {
+		return migrationExecutionNoTransaction
+	}
+	return migrationExecutionTransactional
+}
+
+// DirectiveNoTransaction opts a SQL migration file out of the per-migration
+// transaction. It is intended for database operations that cannot run inside a
+// transaction, such as PostgreSQL enum value additions that are used by later
+// statements in the same migration.
+const DirectiveNoTransaction = "no_transaction"
+
 // MigrationFuncFromSQLFilename returns a migration function that reads SQL from a file
 // in the provided filesystem and executes it using the database connection
 func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
@@ -55,7 +84,16 @@ func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, in
 			return fmt.Errorf("failed to read migration file: %w", err)
 		}
 
-		return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor)
+		noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(string(sql)))
+		if err != nil {
+			return fmt.Errorf("invalid migration directives in %s: %w", filename, err)
+		}
+
+		mode := migrationExecutionTransactional
+		if noTransaction {
+			mode = migrationExecutionNoTransaction
+		}
+		return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor, mode)
 	}
 }
 
@@ -73,19 +111,42 @@ func MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(
 	fsys fs.FS,
 	interceptor StatementInterceptor,
 ) (MigrationFunc, MigrationTimeouts, error) {
+	migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor)
+	if err != nil {
+		return nil, MigrationTimeouts{}, err
+	}
+	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		return migrationFile.fn(ctx, conn, migrationFile.executionMode())
+	}, migrationFile.timeouts, nil
+}
+
+func migrationFuncFromSQLFilenameWithMetadata(
+	filename string,
+	fsys fs.FS,
+	interceptor StatementInterceptor,
+) (sqlMigrationFile, error) {
 	sql, err := fs.ReadFile(fsys, filename)
 	if err != nil {
-		return nil, MigrationTimeouts{}, fmt.Errorf("failed to read migration file: %w", err)
+		return sqlMigrationFile{}, fmt.Errorf("failed to read migration file: %w", err)
 	}
 
 	timeouts, err := parseMigrationTimeoutDirectives(string(sql))
 	if err != nil {
-		return nil, MigrationTimeouts{}, err
+		return sqlMigrationFile{}, err
 	}
 
-	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor)
-	}, timeouts, nil
+	noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(string(sql)))
+	if err != nil {
+		return sqlMigrationFile{}, fmt.Errorf("invalid migration directives in %s: %w", filename, err)
+	}
+
+	return sqlMigrationFile{
+		fn: func(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
+			return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor, mode)
+		},
+		timeouts:      timeouts,
+		noTransaction: noTransaction,
+	}, nil
 }
 
 // NoopMigrationFunc is a no-op migration function
@@ -101,29 +162,53 @@ type Migration struct {
 	Down         MigrationFunc
 	UpTimeouts   MigrationTimeouts
 	DownTimeouts MigrationTimeouts
+	// NoTransaction runs the migration body and metadata update outside the
+	// normal per-migration transaction. Use this only for statements that cannot
+	// run transactionally; ordinary migrations should leave it false so dry-run,
+	// timeout, and rollback behavior all go through the dialect writer.
+	NoTransaction bool
+}
+
+func (m *Migration) executionMode() migrationExecutionMode {
+	if m.NoTransaction {
+		return migrationExecutionNoTransaction
+	}
+	return migrationExecutionTransactional
 }
 
 // CreateMigrationFromSQL creates a migration from SQL strings
 // This is useful for programmatically creating migrations
 func CreateMigrationFromSQL(version int, description, upSQL, downSQL string) *Migration {
+	upNoTransaction, upDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(upSQL))
+	downNoTransaction, downDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(downSQL))
+
+	migration := &Migration{
+		Version:       version,
+		Description:   description,
+		NoTransaction: upNoTransaction || downNoTransaction,
+	}
+
 	upFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return executeSQLStatements(ctx, conn, upSQL)
+		if upDirectiveErr != nil {
+			return fmt.Errorf("invalid up migration directives: %w", upDirectiveErr)
+		}
+		return executeSQLStatements(ctx, conn, upSQL, migration.executionMode())
 	}
 
 	downFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return executeSQLStatements(ctx, conn, downSQL)
+		if downDirectiveErr != nil {
+			return fmt.Errorf("invalid down migration directives: %w", downDirectiveErr)
+		}
+		return executeSQLStatements(ctx, conn, downSQL, migration.executionMode())
 	}
 
-	return &Migration{
-		Version:     version,
-		Description: description,
-		Up:          upFunc,
-		Down:        downFunc,
-	}
+	migration.Up = upFunc
+	migration.Down = downFunc
+	return migration
 }
 
 // executeSQLStatements splits SQL into individual statements and executes them
-func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection, sql string) error {
+func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection, sql string, mode migrationExecutionMode) error {
 	// Split SQL by semicolons and execute each statement
 	statements := SplitSQLStatements(sql)
 
@@ -133,15 +218,7 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 			continue // Skip empty statements and comments
 		}
 
-		// Use conn.ExecContext() instead of conn.Writer().ExecuteSQL() to execute
-		// each statement in its own transaction. This is critical for PostgreSQL
-		// enum safety — PostgreSQL prevents using newly added enum values within
-		// the same transaction where they were added. By using separate
-		// transactions, enum modifications and subsequent usage (like setting
-		// defaults) work correctly.
-		// See: https://www.postgresql.org/docs/current/sql-altertype.html
-		_, err := conn.ExecContext(ctx, stmt)
-		if err != nil {
+		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
 			return fmt.Errorf("failed to execute SQL statement: %w\nSQL: %s", err, stmt)
 		}
 	}
@@ -155,6 +232,7 @@ func executeMigrationFileSQL(
 	filename string,
 	sql string,
 	interceptor StatementInterceptor,
+	mode migrationExecutionMode,
 ) error {
 	// Directives live in comments, so they must be read from the raw file
 	// before comment stripping, and validated before any statement runs so an
@@ -184,9 +262,40 @@ func executeMigrationFileSQL(
 			}
 		}
 
-		if err := conn.Writer().ExecuteSQL(ctx, stmt); err != nil {
+		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
 			return fmt.Errorf("failed to execute migration SQL: %w", err)
 		}
 	}
 	return nil
+}
+
+func executeMigrationStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, mode migrationExecutionMode) error {
+	if mode == migrationExecutionTransactional {
+		return conn.Writer().ExecuteSQL(ctx, stmt)
+	}
+	return executeSQLOutsideTransaction(ctx, conn, stmt)
+}
+
+func executeSQLOutsideTransaction(ctx context.Context, conn *dbschema.DatabaseConnection, sql string, args ...any) error {
+	if conn.Writer().IsDryRun() {
+		return conn.Writer().ExecuteSQL(ctx, sql, args...)
+	}
+
+	// Deliberate transaction escape hatch. This is used only for migrations
+	// marked no_transaction, where the database rejects transactional execution
+	// (for example PostgreSQL ALTER TYPE ADD VALUE followed by using that value).
+	_, err := conn.ExecContext(ctx, sql, args...)
+	return err
+}
+
+func parseNoTransactionDirective(directives map[string]string) (bool, error) {
+	value, ok := directives[DirectiveNoTransaction]
+	if !ok {
+		return false, nil
+	}
+	noTransaction, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid +ptah %s value %q: expected true or false", DirectiveNoTransaction, value)
+	}
+	return noTransaction, nil
 }

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -46,10 +46,34 @@ func TestCreateMigrationFromSQL(t *testing.T) {
 	c.Assert(migration.Description, qt.Equals, "Create test table")
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
+	c.Assert(migration.NoTransaction, qt.IsFalse)
 
 	// Test that the functions don't panic (we can't test execution without a real DB)
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
+}
+
+func TestCreateMigrationFromSQL_NoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	migration := CreateMigrationFromSQL(1, "Add enum value",
+		"-- +ptah no_transaction\nALTER TYPE mood ADD VALUE 'ok';",
+		"-- manual down migration required",
+	)
+
+	c.Assert(migration.NoTransaction, qt.IsTrue)
+}
+
+func TestCreateMigrationFromSQL_InvalidNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	migration := CreateMigrationFromSQL(1, "Invalid directive",
+		"-- +ptah no_transaction=maybe\nSELECT 1;",
+		"",
+	)
+
+	err := migration.Up(context.Background(), nil)
+	c.Assert(err, qt.ErrorMatches, `invalid up migration directives: invalid \+ptah no_transaction value "maybe": expected true or false`)
 }
 
 func TestMigrationStatus(t *testing.T) {
@@ -210,6 +234,10 @@ ALTER TABLE users ADD COLUMN email TEXT;`,
 		{
 			name: "online ddl directive is ignored by timeout parser",
 			sql:  "-- +ptah online_ddl_tool=ghost\nALTER TABLE users ADD COLUMN email TEXT;",
+		},
+		{
+			name: "no transaction directive is ignored by timeout parser",
+			sql:  "-- +ptah no_transaction\nALTER TABLE users ADD COLUMN email TEXT;",
 		},
 		{
 			name:    "invalid duration fails",

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -148,14 +148,22 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 		return nil
 	}
 
+	if m.conn.Writer().IsDryRun() {
+		m.logger.Info("[DRY RUN] Would initialize migrations metadata", "table", m.qualifiedMigrationsTable())
+		return nil
+	}
+
 	if schemaSQL := m.migrationsSchemaStatement(); schemaSQL != "" {
+		// Deliberately outside the migration writer: Initialize runs before any
+		// per-migration transaction exists. Dry-run returns above so metadata DDL
+		// is never written when callers asked for a simulation.
 		if _, err := m.conn.ExecContext(ctx, schemaSQL); err != nil {
 			return fmt.Errorf("failed to create migrations schema: %w", err)
 		}
 	}
 
-	// Execute the schema creation SQL directly on the database connection
-	// This avoids transaction conflicts with the PostgreSQL writer
+	// Deliberately outside the migration writer for the same reason as schema
+	// creation: there is no active migration transaction yet.
 	_, err := m.conn.ExecContext(ctx, m.createMigrationsTableSQL())
 	if err != nil {
 		return fmt.Errorf("failed to create migrations table: %w", err)
@@ -171,6 +179,9 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int, error) {
 	// First ensure the migrations table exists
 	if err := m.Initialize(ctx); err != nil {
 		return 0, fmt.Errorf("failed to initialize migrations table: %w", err)
+	}
+	if m.conn.Writer().IsDryRun() {
+		return 0, nil
 	}
 
 	// Query the current version
@@ -188,6 +199,9 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 	// First ensure the migrations table exists
 	if err := m.Initialize(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize migrations table: %w", err)
+	}
+	if m.conn.Writer().IsDryRun() {
+		return []int{}, nil
 	}
 
 	// Query all applied migration versions
@@ -336,6 +350,12 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 
 	for _, migration := range migrationsToRollback {
 		m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
+		if migration.NoTransaction {
+			if err := m.rollbackMigrationNoTransaction(ctx, migration, deleteSQL); err != nil {
+				return err
+			}
+			continue
+		}
 
 		// Begin transaction for this migration rollback
 		if err := m.conn.Writer().BeginTransaction(); err != nil {
@@ -445,6 +465,12 @@ func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migratio
 
 	for _, migration := range migrations {
 		m.logger.Info("Applying migration", "version", migration.Version, "description", migration.Description)
+		if migration.NoTransaction {
+			if err := m.applyUpMigrationNoTransaction(ctx, migration, recordSQL); err != nil {
+				return err
+			}
+			continue
+		}
 
 		// Begin transaction for this migration
 		if err := m.conn.Writer().BeginTransaction(); err != nil {
@@ -484,6 +510,41 @@ func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migratio
 	}
 
 	return nil
+}
+
+func (m *Migrator) applyUpMigrationNoTransaction(ctx context.Context, migration *Migration, recordSQL string) error {
+	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts)); err != nil {
+		return err
+	}
+	if err := migration.Up(ctx, m.conn); err != nil {
+		return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
+	}
+	if err := executeSQLOutsideTransaction(ctx, m.conn, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
+	}
+	m.logger.Info("Applied non-transactional migration", "version", migration.Version, "description", migration.Description)
+	return nil
+}
+
+func (m *Migrator) rollbackMigrationNoTransaction(ctx context.Context, migration *Migration, deleteSQL string) error {
+	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts)); err != nil {
+		return err
+	}
+	if err := migration.Down(ctx, m.conn); err != nil {
+		return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
+	}
+	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
+	}
+	m.logger.Info("Rolled back non-transactional migration", "version", migration.Version, "description", migration.Description)
+	return nil
+}
+
+func ensureNoTransactionHasNoTimeouts(version int, timeouts MigrationTimeouts) error {
+	if timeouts.IsZero() {
+		return nil
+	}
+	return fmt.Errorf("migration %d is marked no_transaction, so migration timeouts cannot be applied safely", version)
 }
 
 func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int, targetVersion int) ([]*Migration, error) {

--- a/migration/migrator/migrator_test.go
+++ b/migration/migrator/migrator_test.go
@@ -61,6 +61,41 @@ func TestNewFSMigrator_LoadsTimeoutDirectives(t *testing.T) {
 	c.Assert(migration.DownTimeouts.HasStatementTimeout, qt.IsTrue)
 }
 
+func TestNewFSMigrator_LoadsNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_add_enum_value.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah no_transaction\nALTER TYPE mood ADD VALUE 'ok';"),
+		},
+		"0000000001_add_enum_value.down.sql": &fstest.MapFile{
+			Data: []byte("-- no-op"),
+		},
+	}
+
+	m, err := migrator.NewFSMigrator(nil, fsys)
+	c.Assert(err, qt.IsNil)
+	migration := m.MigrationProvider().Migrations()[0]
+	c.Assert(migration.NoTransaction, qt.IsTrue)
+}
+
+func TestNewFSMigrator_InvalidNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah no_transaction=maybe\nCREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+	}
+
+	m, err := migrator.NewFSMigrator(nil, fsys)
+	c.Assert(err, qt.ErrorMatches, `.*failed to load up migration.*invalid \+ptah no_transaction value "maybe".*`)
+	c.Assert(m, qt.IsNil)
+}
+
 func TestNewFSMigrator_InvalidTimeoutDirective(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -78,6 +78,9 @@ func parseMigrationTimeoutDirectives(sql string) (MigrationTimeouts, error) {
 		for field := range strings.FieldsSeq(directive) {
 			key, value, ok := strings.Cut(field, "=")
 			if !ok {
+				if field == DirectiveNoTransaction {
+					continue
+				}
 				return MigrationTimeouts{}, fmt.Errorf("invalid +ptah directive %q", field)
 			}
 

--- a/migration/migrator/transaction_integration_test.go
+++ b/migration/migrator/transaction_integration_test.go
@@ -1,0 +1,186 @@
+package migrator_test
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestCreateMigrationFromSQL_PostgresFailureRollsBackStatements(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+	cleanupIssue262(t, conn)
+	defer cleanupIssue262(t, conn)
+
+	_, err = conn.ExecContext(ctx, "CREATE TABLE ptah_issue_262_users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+
+	badMigration := migrator.CreateMigrationFromSQL(1, "add status",
+		`ALTER TABLE ptah_issue_262_users ADD COLUMN status TEXT;
+		 ALTER TABLE ptah_issue_262_users ADD CONSTRAINT ptah_issue_262_status_ck CHECK (missing_column > 0);`,
+		`ALTER TABLE ptah_issue_262_users DROP COLUMN status;`)
+	mig := issue262Migrator(conn, badMigration)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(columnExists(t, conn, "ptah_issue_262_users", "status"), qt.IsFalse)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 0)
+
+	fixedMigration := migrator.CreateMigrationFromSQL(1, "add status",
+		`ALTER TABLE ptah_issue_262_users ADD COLUMN status TEXT;
+		 ALTER TABLE ptah_issue_262_users ADD CONSTRAINT ptah_issue_262_status_ck CHECK (status IS NULL OR status <> '');`,
+		`ALTER TABLE ptah_issue_262_users DROP COLUMN status;`)
+	err = issue262Migrator(conn, fixedMigration).MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(columnExists(t, conn, "ptah_issue_262_users", "status"), qt.IsTrue)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 1)
+}
+
+func TestMigratorDryRun_PostgresDoesNotCreateMetadataOrMigrationObjects(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+	cleanupIssue262(t, conn)
+	defer cleanupIssue262(t, conn)
+
+	conn.Writer().SetDryRun(true)
+	migration := migrator.CreateMigrationFromSQL(1, "create dry run table",
+		`CREATE TABLE ptah_issue_262_dry_run (id INTEGER PRIMARY KEY);`,
+		`DROP TABLE ptah_issue_262_dry_run;`)
+	mig := issue262Migrator(conn, migration).WithMigrationsTable("ptah_issue_262", "schema_migrations")
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, 0)
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int{1})
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemaExists(t, conn, "ptah_issue_262"), qt.IsFalse)
+	c.Assert(tableExists(t, conn, "ptah_issue_262_dry_run"), qt.IsFalse)
+
+	err = mig.MigrateDownTo(ctx, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemaExists(t, conn, "ptah_issue_262"), qt.IsFalse)
+	c.Assert(tableExists(t, conn, "ptah_issue_262_dry_run"), qt.IsFalse)
+}
+
+func TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+	cleanupIssue262(t, conn)
+	defer cleanupIssue262(t, conn)
+
+	fsys := fstest.MapFS{
+		"0000000001_initial_enum.up.sql": &fstest.MapFile{
+			Data: []byte(`CREATE TYPE ptah_issue_262_mood AS ENUM ('sad');
+CREATE TABLE ptah_issue_262_enum_items (id INTEGER PRIMARY KEY);`),
+		},
+		"0000000001_initial_enum.down.sql": &fstest.MapFile{
+			Data: []byte(`DROP TABLE ptah_issue_262_enum_items;
+DROP TYPE ptah_issue_262_mood;`),
+		},
+		"0000000002_add_enum_value.up.sql": &fstest.MapFile{
+			Data: []byte(`-- +ptah no_transaction
+ALTER TYPE ptah_issue_262_mood ADD VALUE 'ok';
+ALTER TABLE ptah_issue_262_enum_items ADD COLUMN mood ptah_issue_262_mood NOT NULL DEFAULT 'ok';`),
+		},
+		"0000000002_add_enum_value.down.sql": &fstest.MapFile{
+			Data: []byte(`-- +ptah no_transaction
+ALTER TABLE ptah_issue_262_enum_items DROP COLUMN mood;`),
+		},
+	}
+
+	mig, err := migrator.NewFSMigrator(conn, fsys)
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithMigrationsTable("", "schema_migrations_issue_262")
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(columnExists(t, conn, "ptah_issue_262_enum_items", "mood"), qt.IsTrue)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 2)
+}
+
+func issue262Migrator(conn *dbschema.DatabaseConnection, migrations ...*migrator.Migration) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationsTable("", "schema_migrations_issue_262")
+}
+
+func cleanupIssue262(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP SCHEMA IF EXISTS ptah_issue_262 CASCADE",
+		"DROP TABLE IF EXISTS schema_migrations_issue_262",
+		"DROP TABLE IF EXISTS ptah_issue_262_dry_run",
+		"DROP TABLE IF EXISTS ptah_issue_262_enum_items",
+		"DROP TABLE IF EXISTS ptah_issue_262_users",
+		"DROP TYPE IF EXISTS ptah_issue_262_mood",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func columnExists(t *testing.T, conn *dbschema.DatabaseConnection, tableName, columnName string) bool {
+	t.Helper()
+
+	var exists bool
+	err := conn.QueryRowContext(
+		context.Background(),
+		`SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = 'public'
+			  AND table_name = $1
+			  AND column_name = $2
+		)`,
+		tableName,
+		columnName,
+	).Scan(&exists)
+	qt.Assert(t, err, qt.IsNil)
+	return exists
+}
+
+func issue262MigrationRecordCount(t *testing.T, conn *dbschema.DatabaseConnection) int {
+	t.Helper()
+
+	if !tableExists(t, conn, "schema_migrations_issue_262") {
+		return 0
+	}
+	var count int
+	err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM schema_migrations_issue_262").Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func schemaExists(t *testing.T, conn *dbschema.DatabaseConnection, schemaName string) bool {
+	t.Helper()
+
+	var exists bool
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)",
+		schemaName,
+	).Scan(&exists)
+	qt.Assert(t, err, qt.IsNil)
+	return exists
+}

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -283,6 +283,28 @@ func GenerateSchemaDiffASTWithCapabilities(
 	return planner.GenerateMigrationAST(diff, generated)
 }
 
+// RequiresNoTransaction reports whether the planned migration contains
+// statements that must be applied outside the migrator's per-migration
+// transaction. Keep this conservative: it should only return true for DDL that
+// is known to be rejected or unusable in a PostgreSQL-family transaction.
+func RequiresNoTransaction(dialect string, nodes []ast.Node) bool {
+	if !platform.IsPostgresFamily(dialect) {
+		return false
+	}
+	for _, node := range nodes {
+		alterType, ok := node.(*ast.AlterTypeNode)
+		if !ok {
+			continue
+		}
+		for _, op := range alterType.Operations {
+			if _, ok := op.(*ast.AddEnumValueOperation); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // GenerateSchemaDiffSQLStatements generates individual SQL statements for schema differences.
 //
 // This high-level convenience function provides the most commonly used output format:

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -5,6 +5,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	dbtypes "github.com/stokaro/ptah/dbschema/types"
@@ -74,6 +75,19 @@ func TestGetPlanner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequiresNoTransaction(t *testing.T) {
+	c := qt.New(t)
+
+	enumAdd := ast.NewAlterType("status").AddOperation(ast.NewAddEnumValueOperation("archived"))
+	enumRename := ast.NewAlterType("status").AddOperation(ast.NewRenameEnumValueOperation("old", "new"))
+
+	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{enumAdd}), qt.IsTrue)
+	c.Assert(planner.RequiresNoTransaction(platform.YugabyteDB, []ast.Node{enumAdd}), qt.IsTrue)
+	c.Assert(planner.RequiresNoTransaction(platform.MySQL, []ast.Node{enumAdd}), qt.IsFalse)
+	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{enumRename}), qt.IsFalse)
+	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{ast.NewComment("noop")}), qt.IsFalse)
 }
 
 func TestGeneratedNarrowingTypeChangeIsDestructive(t *testing.T) {

--- a/migration/seeder/seeder.go
+++ b/migration/seeder/seeder.go
@@ -274,6 +274,9 @@ func executeStatements(ctx context.Context, conn *dbschema.DatabaseConnection, s
 }
 
 func ensureTracker(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	// Deliberately outside the seed writer: the tracker table is metadata that
+	// must exist before either transactional or no-transaction seed execution
+	// starts, and this statement is not user-provided SQL.
 	_, err := conn.ExecContext(ctx, trackerDDL(conn.Info().Dialect))
 	if err != nil {
 		return fmt.Errorf("create %s table: %w", trackerName, err)


### PR DESCRIPTION
## What

Fixes #262.

- Route `CreateMigrationFromSQL` and SQL-file migration statements through the dialect writer by default, so they participate in the active migration transaction, dry-run handling, and writer-scoped timeouts.
- Add explicit `no_transaction` support via `Migration.NoTransaction` and `-- +ptah no_transaction` for cases such as PostgreSQL enum value additions that must be used later in the same migration.
- Make migrator metadata initialization dry-run aware so `migrate-up --dry-run --migrations-schema ...` does not create schemas or migration tables.
- Document remaining deliberate raw `ExecContext` call sites and update migrator docs for the transaction opt-out.

## Why

Programmatic migrations used `conn.ExecContext`, bypassing the writer transaction. A failing second statement could leave the first statement committed while `schema_migrations` stayed empty. `Initialize` also wrote metadata objects during dry-run.

## Validation

- `go test ./migration/migrator ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./migration/generator ./migration/seeder`
- `POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test -tags=integration ./migration/migrator -run 'Test(CreateMigrationFromSQL_PostgresFailureRollsBackStatements|MigratorDryRun_PostgresDoesNotCreateMetadataOrMigrationObjects|NoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration)' -v`
- `POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test -tags=integration ./migration/migrator`
- `go test ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `git diff --check`
