### PR TITLE
Add Atlas migration directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,15 @@ the target database already contains production-marker tables unless
 
 Ptah provides a comprehensive migration system with versioning, rollback capabilities, and transaction safety.
 
+Ptah migration directories use `--dir-format=auto` by default. Auto mode prefers
+Ptah's paired files (`NNNNNNNNNN_description.up.sql` and
+`NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
+Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
+`--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
+`migrate-status`, `migrate-hash`, and `migrate-validate` when a directory should
+be interpreted explicitly. Atlas-style files are forward migrations only;
+`migrate-down` reports a clear "no down migration" error for them.
+
 #### Apply Migrations
 Apply all pending migrations to bring database up to latest version:
 
@@ -649,6 +658,9 @@ Apply all pending migrations to bring database up to latest version:
 
 # Store migration state in a dedicated schema/table
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
+
+# Apply an Atlas-style versioned migration directory
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
 ```
 
 Migration files can override the CLI defaults with top-of-file directives:
@@ -741,6 +753,9 @@ Show current migration status and pending migrations:
 
 # Check status from a custom migration state table
 ./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
+
+# Check an Atlas-style versioned migration directory
+./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
 ```
 
 **Output includes:**
@@ -764,6 +779,10 @@ caught in CI instead of silently breaking reproducibility.
 
 # Verify the directory matches its committed ptah.sum (CI gate)
 ./package-migrator migrate-validate --dir ./migrations
+
+# Hash or validate an Atlas-style migration directory
+./package-migrator migrate-hash --dir ./migrations --dir-format atlas
+./package-migrator migrate-validate --dir ./migrations --dir-format atlas
 ```
 
 `migrate-validate` exits `0` when clean, `1` on drift (a file added, removed, or

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ const (
 	dbURLFlag            = "db-url"
 	migrationsFlag       = "migrations-dir"
 	targetFlag           = "target"
+	dirFormatFlag        = "dir-format"
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
 	confirmFlag          = "confirm"
@@ -54,10 +56,15 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Directory containing migration files (required)",
 	},
-	targetFlag: &cobraflags.IntFlag{
+	targetFlag: &cobraflags.StringFlag{
 		Name:  targetFlag,
-		Value: 0,
+		Value: "0",
 		Usage: "Target version to migrate down to (required)",
+	},
+	dirFormatFlag: &cobraflags.StringFlag{
+		Name:  dirFormatFlag,
+		Value: string(migrator.MigrationDirFormatAuto),
+		Usage: "Migration directory format: auto, ptah, or atlas",
 	},
 	dryRunFlag: &cobraflags.BoolFlag{
 		Name:  dryRunFlag,
@@ -103,7 +110,8 @@ func NewMigrateDownCommand() *cobra.Command {
 func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	dbURL := migrateDownFlags[dbURLFlag].GetString()
 	migrationsDir := migrateDownFlags[migrationsFlag].GetString()
-	targetVersion := migrateDownFlags[targetFlag].GetInt()
+	targetVersionValue := migrateDownFlags[targetFlag].GetString()
+	dirFormatValue := migrateDownFlags[dirFormatFlag].GetString()
 	dryRun := migrateDownFlags[dryRunFlag].GetBool()
 	verbose := migrateDownFlags[verboseFlag].GetBool()
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
@@ -121,8 +129,17 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("migrations directory is required")
 	}
 
+	targetVersion, err := strconv.ParseInt(targetVersionValue, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid target version %q: %w", targetVersionValue, err)
+	}
 	if targetVersion < 0 {
 		return fmt.Errorf("target version must be >= 0")
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
 	}
 
 	if verbose {
@@ -164,6 +181,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	fmt.Printf("Database: %s\n", dbschema.FormatDatabaseURL(dbURL))
 	fmt.Printf("Dialect: %s\n", conn.Info().Dialect)
 	fmt.Printf("Migrations directory: %s\n", migrationsDir)
+	fmt.Printf("Migration directory format: %s\n", dirFormat)
 	fmt.Printf("Target version: %d\n", targetVersion)
 	fmt.Println()
 
@@ -182,7 +200,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
 
 	// Create migrator to access applied migrations
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor))
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor), migrator.WithMigrationDirFormat(dirFormat))
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
@@ -209,7 +227,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	// Calculate which migrations will be rolled back
-	var migrationsToRollback []int
+	var migrationsToRollback []int64
 	for _, version := range appliedMigrations {
 		if version > targetVersion {
 			migrationsToRollback = append(migrationsToRollback, version)

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/migration/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // NewMigrateHashCommand returns the migrate-hash command.
 func NewMigrateHashCommand() *cobra.Command {
 	var dir string
+	var dirFormatValue string
 
 	cmd := &cobra.Command{
 		Use:   "migrate-hash",
@@ -28,20 +30,26 @@ an already-committed migration.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runHash(cmd, dir)
+			return runHash(cmd, dir, dirFormatValue)
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	cmd.Flags().StringVar(&dirFormatValue, "dir-format", string(migrator.MigrationDirFormatAuto), "Migration directory format: auto, ptah, or atlas")
 	cmd.SetFlagErrorFunc(cmdutil.FlagErrorFunc)
 	return cmd
 }
 
-func runHash(cmd *cobra.Command, dir string) error {
+func runHash(cmd *cobra.Command, dir, dirFormatValue string) error {
 	if err := cmdutil.StatDir(dir); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 
-	sum, err := migratesum.Write(dir)
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
+	sum, err := migratesum.WriteWithFormat(dir, dirFormat)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -33,6 +33,7 @@ migrations or for debugging migration issues.`,
 const (
 	dbURLFlag      = "db-url"
 	migrationsFlag = "migrations-dir"
+	dirFormatFlag  = "dir-format"
 	verboseFlag    = "verbose"
 	jsonFlag       = "json"
 )
@@ -47,6 +48,11 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Name:  migrationsFlag,
 		Value: "",
 		Usage: "Directory containing migration files (required)",
+	},
+	dirFormatFlag: &cobraflags.StringFlag{
+		Name:  dirFormatFlag,
+		Value: string(migrator.MigrationDirFormatAuto),
+		Usage: "Migration directory format: auto, ptah, or atlas",
 	},
 	verboseFlag: &cobraflags.BoolFlag{
 		Name:  verboseFlag,
@@ -71,6 +77,7 @@ func NewMigrateStatusCommand() *cobra.Command {
 func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	dbURL := migrateStatusFlags[dbURLFlag].GetString()
 	migrationsDir := migrateStatusFlags[migrationsFlag].GetString()
+	dirFormatValue := migrateStatusFlags[dirFormatFlag].GetString()
 	verbose := migrateStatusFlags[verboseFlag].GetBool()
 	jsonOutput := migrateStatusFlags[jsonFlag].GetBool()
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
@@ -82,6 +89,11 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
 	}
 
 	connectTimeout, err := dbcli.ParseConnectTimeout(migrateStatusFlags[dbcli.ConnectTimeoutFlagName].GetString())
@@ -100,7 +112,7 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)
 
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS)
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithMigrationDirFormat(dirFormat))
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -38,6 +38,7 @@ const (
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
 	verifySumFlag        = "verify-sum"
+	dirFormatFlag        = "dir-format"
 	execOrderFlag        = "exec-order"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
@@ -69,6 +70,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Name:  verifySumFlag,
 		Value: false,
 		Usage: "Verify the migrations directory against its committed ptah.sum before applying; abort on drift",
+	},
+	dirFormatFlag: &cobraflags.StringFlag{
+		Name:  dirFormatFlag,
+		Value: string(migrator.MigrationDirFormatAuto),
+		Usage: "Migration directory format: auto, ptah, or atlas",
 	},
 	execOrderFlag: &cobraflags.StringFlag{
 		Name:  execOrderFlag,
@@ -107,6 +113,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	dryRun := migrateUpFlags[dryRunFlag].GetBool()
 	verbose := migrateUpFlags[verboseFlag].GetBool()
 	verifySum := migrateUpFlags[verifySumFlag].GetBool()
+	dirFormatValue := migrateUpFlags[dirFormatFlag].GetString()
 	execOrderValue := migrateUpFlags[execOrderFlag].GetString()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
@@ -122,10 +129,15 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("migrations directory is required")
 	}
 
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+
 	// Integrity gate: refuse to apply if a committed migration was edited
 	// out of band. Runs before connecting so a tampered directory fails fast.
 	if verifySum {
-		result, err := migratesum.VerifyDir(migrationsDir)
+		result, err := migratesum.VerifyDirWithFormat(migrationsDir, dirFormat)
 		if err != nil {
 			return fmt.Errorf("ptah.sum verification failed: %w", err)
 		}
@@ -176,6 +188,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	fmt.Printf("Database: %s\n", dbschema.FormatDatabaseURL(dbURL))
 	fmt.Printf("Dialect: %s\n", conn.Info().Dialect)
 	fmt.Printf("Migrations directory: %s\n", migrationsDir)
+	fmt.Printf("Migration directory format: %s\n", dirFormat)
 	fmt.Println()
 
 	// Create filesystem from migrations directory
@@ -193,7 +206,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
 
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor))
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor), migrator.WithMigrationDirFormat(dirFormat))
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
@@ -263,17 +276,17 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int {
+func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int64 {
 	if execOrder != migrator.ExecOrderLinearSkip {
 		return status.PendingMigrations
 	}
 
-	outOfOrder := make(map[int]struct{}, len(status.OutOfOrderMigrations))
+	outOfOrder := make(map[int64]struct{}, len(status.OutOfOrderMigrations))
 	for _, version := range status.OutOfOrderMigrations {
 		outOfOrder[version] = struct{}{}
 	}
 
-	pending := make([]int, 0, len(status.PendingMigrations))
+	pending := make([]int64, 0, len(status.PendingMigrations))
 	for _, version := range status.PendingMigrations {
 		if _, ok := outOfOrder[version]; ok {
 			continue
@@ -283,7 +296,7 @@ func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder
 	return pending
 }
 
-func lintPendingDestructive(fsys fs.FS, pending []int, dialect string) ([]lint.Finding, error) {
+func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint.Finding, error) {
 	findings, err := lint.LintFS(fsys, lint.Options{
 		Dialect:  dialect,
 		Disabled: []string{"MF", "BC", "PG", "MY"},

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -69,7 +69,7 @@ ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
 		},
 	}
 
-	findings, err := lintPendingDestructive(fsys, []int{2}, "postgres")
+	findings, err := lintPendingDestructive(fsys, []int64{2}, "postgres")
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 5)
 	c.Assert([]string{findings[0].Rule, findings[1].Rule, findings[2].Rule, findings[3].Rule, findings[4].Rule}, qt.DeepEquals, []string{"DS102", "DS107", "DS107", "DS108", "DS109"})
@@ -80,23 +80,23 @@ func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing
 	c := qt.New(t)
 
 	status := &migrator.MigrationStatus{
-		PendingMigrations:    []int{3, 6},
-		OutOfOrderMigrations: []int{3},
+		PendingMigrations:    []int64{3, 6},
+		OutOfOrderMigrations: []int64{3},
 	}
 
 	c.Assert(
 		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinear),
 		qt.DeepEquals,
-		[]int{3, 6},
+		[]int64{3, 6},
 	)
 	c.Assert(
 		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderNonLinear),
 		qt.DeepEquals,
-		[]int{3, 6},
+		[]int64{3, 6},
 	)
 	c.Assert(
 		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinearSkip),
 		qt.DeepEquals,
-		[]int{6},
+		[]int64{6},
 	)
 }

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -12,11 +12,13 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // NewMigrateValidateCommand returns the migrate-validate command.
 func NewMigrateValidateCommand() *cobra.Command {
 	var dir string
+	var dirFormatValue string
 
 	cmd := &cobra.Command{
 		Use:   "migrate-validate",
@@ -33,16 +35,22 @@ Run it in CI to guarantee already-committed migrations are never changed.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runValidate(cmd, dir)
+			return runValidate(cmd, dir, dirFormatValue)
 		},
 	}
 	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
+	cmd.Flags().StringVar(&dirFormatValue, "dir-format", string(migrator.MigrationDirFormatAuto), "Migration directory format: auto, ptah, or atlas")
 	cmd.SetFlagErrorFunc(cmdutil.FlagErrorFunc)
 	return cmd
 }
 
-func runValidate(cmd *cobra.Command, dir string) error {
+func runValidate(cmd *cobra.Command, dir, dirFormatValue string) error {
 	if err := cmdutil.StatDir(dir); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 
@@ -51,7 +59,7 @@ func runValidate(cmd *cobra.Command, dir string) error {
 	// message — including the actionable "run ptah migrate-hash" for a
 	// missing sum — must reach the user, so print it here (the command
 	// silences cobra's own error output).
-	result, err := migratesum.VerifyDir(dir)
+	result, err := migratesum.VerifyDirWithFormat(dir, dirFormat)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -450,7 +450,7 @@ func (vem *VersionedEntityManager) ApplyMigrationFromEntities(ctx context.Contex
 	// In a real scenario, you'd want more sophisticated down migrations
 	downSQL := "-- Auto-generated down migration\n-- Manual review required\n"
 
-	migration := migrator.CreateMigrationFromSQL(vem.version, description, upSQL.String(), downSQL)
+	migration := migrator.CreateMigrationFromSQL(int64(vem.version), description, upSQL.String(), downSQL)
 	migration.NoTransaction = noTransaction
 
 	p := migrator.NewRegisteredMigrationProvider(migration)
@@ -515,7 +515,7 @@ func (dh *DatabaseHelper) ApplyMigrations(ctx context.Context, migrationsFS fs.F
 }
 
 // GetCurrentVersion returns the current migration version
-func (dh *DatabaseHelper) GetCurrentVersion(ctx context.Context, migrationsFS fs.FS) (int, error) {
+func (dh *DatabaseHelper) GetCurrentVersion(ctx context.Context, migrationsFS fs.FS) (int64, error) {
 	m, err := migrator.NewFSMigrator(dh.conn, migrationsFS)
 	if err != nil {
 		return 0, err
@@ -524,7 +524,7 @@ func (dh *DatabaseHelper) GetCurrentVersion(ctx context.Context, migrationsFS fs
 }
 
 // RollbackToVersion rolls back migrations to a specific version
-func (dh *DatabaseHelper) RollbackToVersion(ctx context.Context, migrationsFS fs.FS, targetVersion int) error {
+func (dh *DatabaseHelper) RollbackToVersion(ctx context.Context, migrationsFS fs.FS, targetVersion int64) error {
 	m, err := migrator.NewFSMigrator(dh.conn, migrationsFS)
 	if err != nil {
 		return err

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -640,12 +640,12 @@ func testDynamicMigrationSQLGeneration(ctx context.Context, conn *dbschema.Datab
 }
 
 // getCurrentMigrationVersion gets the current migration version from the database
-func getCurrentMigrationVersion(ctx context.Context, conn *dbschema.DatabaseConnection) (int, error) {
+func getCurrentMigrationVersion(ctx context.Context, conn *dbschema.DatabaseConnection) (int64, error) {
 	// Query the schema_migrations table to get the highest version
 	query := "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
 	row := conn.QueryRow(query)
 
-	var version int
+	var version int64
 	if err := row.Scan(&version); err != nil {
 		return 0, fmt.Errorf("failed to scan migration version: %w", err)
 	}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -66,7 +66,7 @@ type MigrationFiles struct {
 	UpFile     string // Path to the up migration file
 	DownFile   string // Path to the down migration file
 	ReportFile string // Path to the safety report file, when requested
-	Version    int    // Migration version (timestamp)
+	Version    int64  // Migration version (timestamp)
 }
 
 // GenerateMigration generates both up and down migration files by comparing
@@ -773,7 +773,7 @@ func reverseRoleDiffs(roleDiffs []types.RoleDiff) []types.RoleDiff {
 	return reversed
 }
 
-func nextAvailableMigrationVersion(outputDir string, version int, migrationName string) int {
+func nextAvailableMigrationVersion(outputDir string, version int64, migrationName string) int64 {
 	if latest := latestExistingMigrationVersion(outputDir); latest >= version {
 		version = latest + 1
 	}
@@ -787,12 +787,12 @@ func nextAvailableMigrationVersion(outputDir string, version int, migrationName 
 	}
 }
 
-func latestExistingMigrationVersion(outputDir string) int {
+func latestExistingMigrationVersion(outputDir string) int64 {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return 0
 	}
-	latest := 0
+	var latest int64
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -824,7 +824,7 @@ func withNoTransactionDirective(sql string) string {
 }
 
 // createMigrationFiles creates the up and down migration files
-func createMigrationFiles(outputDir string, version int, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
+func createMigrationFiles(outputDir string, version int64, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
 	// Ensure output directory exists
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -27,7 +27,7 @@ type shadowMigrationOptions struct {
 	MigrationsDir string
 	Dialect       string
 	Capabilities  capability.Capabilities
-	Version       int
+	Version       int64
 	Name          string
 	UpSQL         string
 	DownSQL       string
@@ -119,8 +119,8 @@ func loadPriorMigrations(dir string) ([]*migrator.Migration, error) {
 	return out, nil
 }
 
-func latestMigrationVersion(migrations []*migrator.Migration) int {
-	latest := 0
+func latestMigrationVersion(migrations []*migrator.Migration) int64 {
+	var latest int64
 	for _, migration := range migrations {
 		if migration.Version > latest {
 			latest = migration.Version

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -49,7 +49,7 @@ func TestNextAvailableMigrationVersionChecksUpAndDownFiles(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, migrator.GenerateMigrationFileName(105, "future", "up")), []byte("SELECT 1;"), 0600)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(nextAvailableMigrationVersion(dir, 100, "add_email"), qt.Equals, 106)
+	c.Assert(nextAvailableMigrationVersion(dir, 100, "add_email"), qt.Equals, int64(106))
 }
 
 func TestLoadPriorMigrationsMissingDir(t *testing.T) {

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -309,7 +309,7 @@ func parseKnownMigrationName(name string) (*migrator.MigrationFile, error) {
 	if parsed, err := migrator.ParseMigrationFileName(name); err == nil {
 		return parsed, nil
 	}
-	return migrator.ParseAtlasMigrationFileName(name)
+	return migrator.ParseAtlasMigrationFileNameForAutoDetection(name)
 }
 
 // runRules applies every enabled rule to one prepared file.

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -153,7 +153,7 @@ type Options struct {
 	PathPrefix string
 	// Versions restricts linting to parsed migration versions. Empty means
 	// every migration file is linted.
-	Versions []int
+	Versions []int64
 }
 
 // LintFS lints every *.sql file under fsys — recursively, because the
@@ -192,9 +192,9 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 	// Directions present per version, so pairing matches the migrator, which
 	// pairs an up and a down by their shared version prefix regardless of
 	// description — not by an identical file-name stem.
-	versionDirs := map[int]map[string]bool{}
+	versionDirs := map[int64]map[string]bool{}
 	for _, name := range names {
-		if parsed, err := migrator.ParseMigrationFileName(path.Base(name)); err == nil {
+		if parsed, err := parseKnownMigrationName(path.Base(name)); err == nil {
 			if versionDirs[parsed.Version] == nil {
 				versionDirs[parsed.Version] = map[string]bool{}
 			}
@@ -224,17 +224,17 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 	return findings, nil
 }
 
-func filterNamesByVersion(names []string, versions []int) []string {
+func filterNamesByVersion(names []string, versions []int64) []string {
 	if len(versions) == 0 {
 		return names
 	}
-	allowed := make(map[int]struct{}, len(versions))
+	allowed := make(map[int64]struct{}, len(versions))
 	for _, version := range versions {
 		allowed[version] = struct{}{}
 	}
 	var filtered []string
 	for _, name := range names {
-		parsed, err := migrator.ParseMigrationFileName(path.Base(name))
+		parsed, err := parseKnownMigrationName(path.Base(name))
 		if err != nil {
 			continue
 		}
@@ -246,7 +246,7 @@ func filterNamesByVersion(names []string, versions []int) []string {
 }
 
 // prepareFile loads one migration file into the forms rules consume.
-func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDirs map[int]map[string]bool, pathPrefix string, mode scanMode) (*File, error) {
+func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDirs map[int64]map[string]bool, pathPrefix string, mode scanMode) (*File, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", name, err)
@@ -254,10 +254,14 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDi
 
 	base := path.Base(name)
 	direction := ""
-	version := -1
-	if parsed, parseErr := migrator.ParseMigrationFileName(base); parseErr == nil {
+	var version int64
+	hasVersion := false
+	atlasFormat := false
+	if parsed, parseErr := parseKnownMigrationName(base); parseErr == nil {
 		direction = parsed.Direction
 		version = parsed.Version
+		hasVersion = true
+		atlasFormat = parsed.Format == migrator.MigrationDirFormatAtlas
 	}
 	file := &File{
 		Path:      path.Join(pathPrefix, name),
@@ -267,10 +271,12 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDi
 		// lint must follow it; the suffix check keeps hazard scanning for
 		// .up.sql files whose version prefix is malformed.
 		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
-		WellFormedName: strictNameRe.MatchString(base),
+		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
 	}
 	switch {
-	case version >= 0:
+	case atlasFormat:
+		file.HasPair = true
+	case hasVersion:
 		// Pair by version, matching the migrator: the counterpart is any
 		// file of the same version in the opposite direction.
 		counterpart := "down"
@@ -297,6 +303,13 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDi
 		}
 	}
 	return file, nil
+}
+
+func parseKnownMigrationName(name string) (*migrator.MigrationFile, error) {
+	if parsed, err := migrator.ParseMigrationFileName(name); err == nil {
+		return parsed, nil
+	}
+	return migrator.ParseAtlasMigrationFileName(name)
 }
 
 // runRules applies every enabled rule to one prepared file.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -83,7 +83,7 @@ func TestLintFS_VersionsRestrictsFindings(t *testing.T) {
 
 	findings, err := lint.LintFS(fsys, lint.Options{
 		Disabled: []string{"MF", "BC", "PG", "MY"},
-		Versions: []int{2},
+		Versions: []int64{2},
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS102"})
@@ -490,6 +490,20 @@ func TestLintFS_SuffixlessNamesFollowTheMigrator(t *testing.T) {
 	for _, f := range findings {
 		c.Assert(f.Message, qt.Contains, "the migrator will not pick it up")
 	}
+}
+
+func TestLintFS_AtlasMigrationNamesAreScanned(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"20220318104614_team_A.sql": "DROP TABLE users;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"},
+		qt.Commentf("Atlas files should be treated as runnable up migrations, not MF103-only noise; got %v", findings))
+	c.Assert(findings[0].File, qt.Equals, "20220318104614_team_A.sql")
 }
 
 func TestLintFS_CaseVariantSQLFilesGetNamingWarning(t *testing.T) {

--- a/migration/migratesum/io.go
+++ b/migration/migratesum/io.go
@@ -4,13 +4,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // Write computes the sum of the migrations directory at dir and writes it to
 // dir/ptah.sum, returning the computed sum. The ptah.sum file is excluded
 // from its own hash because it is not a migration file.
 func Write(dir string) (*SumFile, error) {
-	sum, err := Compute(os.DirFS(dir))
+	return WriteWithFormat(dir, migrator.MigrationDirFormatAuto)
+}
+
+// WriteWithFormat computes the sum of the migrations directory at dir using
+// format and writes it to dir/ptah.sum.
+func WriteWithFormat(dir string, format migrator.MigrationDirFormat) (*SumFile, error) {
+	sum, err := ComputeWithFormat(os.DirFS(dir), format)
 	if err != nil {
 		return nil, err
 	}
@@ -25,5 +33,11 @@ func Write(dir string) (*SumFile, error) {
 
 // VerifyDir verifies the migrations directory at dir against its ptah.sum.
 func VerifyDir(dir string) (*Result, error) {
-	return Verify(os.DirFS(dir))
+	return VerifyDirWithFormat(dir, migrator.MigrationDirFormatAuto)
+}
+
+// VerifyDirWithFormat verifies the migrations directory at dir against its
+// ptah.sum using the selected migration directory format.
+func VerifyDirWithFormat(dir string, format migrator.MigrationDirFormat) (*Result, error) {
+	return VerifyWithFormat(os.DirFS(dir), format)
 }

--- a/migration/migratesum/sum.go
+++ b/migration/migratesum/sum.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
-	"path"
 	"sort"
 	"strings"
 
@@ -58,23 +57,24 @@ type SumFile struct {
 // covers exactly what migrate-up/down would execute. The ptah.sum file itself
 // and any non-migration file are excluded.
 func Compute(fsys fs.FS) (*SumFile, error) {
-	var entries []Entry
-	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() || !migrator.ValidateMigrationFileName(path.Base(p)) {
-			return nil
-		}
-		data, err := fs.ReadFile(fsys, p)
-		if err != nil {
-			return fmt.Errorf("failed to read %s: %w", p, err)
-		}
-		entries = append(entries, Entry{Name: p, Hash: hashContent(data)})
-		return nil
-	})
+	return ComputeWithFormat(fsys, migrator.MigrationDirFormatAuto)
+}
+
+// ComputeWithFormat walks fsys and builds the sum over every migration file
+// recognized by the selected directory format.
+func ComputeWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error) {
+	files, err := migrator.DiscoverMigrationFiles(fsys, format)
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan migrations directory: %w", err)
+		return nil, err
+	}
+
+	entries := make([]Entry, 0, len(files))
+	for _, file := range files {
+		data, err := fs.ReadFile(fsys, file.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", file.Path, err)
+		}
+		entries = append(entries, Entry{Name: file.Path, Hash: hashContent(data)})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
 

--- a/migration/migratesum/sum_test.go
+++ b/migration/migratesum/sum_test.go
@@ -10,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/migration/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 func fixture(files map[string]string) fstest.MapFS {
@@ -50,6 +51,26 @@ func TestCompute_HashesOnlyMigrationFilesSortedByName(t *testing.T) {
 		"nested/0000000004_x.up.sql",
 	}, qt.Commentf("only recognized migration files, sorted; README/ptah.sum/.txt excluded"))
 	c.Assert(sum.DirHash, qt.Matches, "h1:.+")
+}
+
+func TestComputeWithFormat_HashesAtlasMigrationFiles(t *testing.T) {
+	c := qt.New(t)
+
+	sum, err := migratesum.ComputeWithFormat(fixture(map[string]string{
+		"20220318104615_add_users.sql": "CREATE TABLE users (id INT);\n",
+		"20220318104614_team_A.sql":    "CREATE TABLE teams (id INT);\n",
+		"atlas.sum":                    "ignored\n",
+	}), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	var names []string
+	for _, entry := range sum.Entries {
+		names = append(names, entry.Name)
+	}
+	c.Assert(names, qt.DeepEquals, []string{
+		"20220318104614_team_A.sql",
+		"20220318104615_add_users.sql",
+	})
 }
 
 func TestCompute_IsDeterministicAndContentSensitive(t *testing.T) {

--- a/migration/migratesum/verify.go
+++ b/migration/migratesum/verify.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // ErrSumFileMissing is returned when the migrations directory has no ptah.sum.
@@ -36,6 +38,13 @@ func (r *Result) OK() bool {
 // ErrSumFileMissing; a read/parse failure returns a wrapped error. A drift is
 // reported in the Result (not as an error) so callers choose the exit code.
 func Verify(fsys fs.FS) (*Result, error) {
+	return VerifyWithFormat(fsys, migrator.MigrationDirFormatAuto)
+}
+
+// VerifyWithFormat recomputes the sum of fsys using the selected migration
+// directory format and compares it against the ptah.sum recorded in the same
+// directory.
+func VerifyWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*Result, error) {
 	recordedRaw, err := fs.ReadFile(fsys, FileName)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, ErrSumFileMissing
@@ -48,7 +57,7 @@ func Verify(fsys fs.FS) (*Result, error) {
 		return nil, fmt.Errorf("failed to parse %s: %w", FileName, err)
 	}
 
-	current, err := Compute(fsys)
+	current, err := ComputeWithFormat(fsys, format)
 	if err != nil {
 		return nil, err
 	}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -68,6 +68,15 @@ DROP TABLE IF EXISTS users;
 
 ## Command Line Interface
 
+Migration directory commands use `--dir-format=auto` by default. Auto mode
+prefers Ptah paired files (`NNNNNNNNNN_description.up.sql` and
+`NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
+Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
+`--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
+`migrate-status`, `migrate-hash`, and `migrate-validate` when detection should be
+explicit. Atlas-style files are forward migrations only; `migrate-down` returns a
+clear no-down-migration error for them.
+
 ### Migrate Up
 Apply all pending migrations:
 ```bash
@@ -87,6 +96,11 @@ go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-
 With a custom migration state table:
 ```bash
 go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --migrations-schema infra --migrations-table ptah_migrations
+```
+
+With an Atlas-style versioned migration directory:
+```bash
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas
 ```
 
 ### Migrate Down
@@ -126,6 +140,11 @@ With a custom migration state table:
 go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --migrations-schema infra --migrations-table ptah_migrations
 ```
 
+With an Atlas-style versioned migration directory:
+```bash
+go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas
+```
+
 ## API Overview
 
 The migrator package provides a clean, modular API with the following key components:
@@ -163,6 +182,7 @@ pending and out of order.
 - **`NewRegisteredMigrationProvider(migrations...)`**: Creates an in-memory migration provider
 - **`WithMigrationsTable(schema, table)`**: Configures the migration history table
 - **`WithExecOrder(policy)`**: Configures out-of-order migration handling
+- **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
 
 ## Programmatic Usage
 

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -1,0 +1,114 @@
+package migrator_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestAtlasFormat_PostgresIntegration(t *testing.T) {
+	runAtlasFormatIntegration(t, postgresTestURL(t))
+}
+
+func TestAtlasFormat_MySQLIntegration(t *testing.T) {
+	dbURL := os.Getenv("MYSQL_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("MYSQL_TEST_URL")
+	}
+	if dbURL == "" {
+		t.Skip("MYSQL_TEST_DSN or MYSQL_TEST_URL not set")
+	}
+	if strings.Contains(dbURL, "@tcp(") && !strings.HasPrefix(dbURL, "mysql://") {
+		dbURL = "mysql://" + dbURL
+	}
+	if !strings.HasPrefix(dbURL, "mysql://") {
+		t.Skip("MySQL URL required for Atlas migration integration test")
+	}
+	runAtlasFormatIntegration(t, dbURL)
+}
+
+func runAtlasFormatIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	cleanupIssue273(t, conn)
+	defer cleanupIssue273(t, conn)
+
+	fsys := fstest.MapFS{
+		"20220318104614_team_A.sql": &fstest.MapFile{Data: []byte("CREATE TABLE ptah_issue_273_teams (id INT PRIMARY KEY);\n")},
+		"20220318104615_add_users.sql": &fstest.MapFile{Data: []byte(
+			"CREATE TABLE ptah_issue_273_users (id INT PRIMARY KEY, team_id INT);\n",
+		)},
+	}
+	mig, err := migrator.NewFSMigrator(conn, fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithMigrationsTable("", "schema_migrations_issue_273")
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.TotalMigrations, qt.Equals, 2)
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{20220318104614, 20220318104615})
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue273UsersCount(t, conn), qt.Equals, 0)
+	c.Assert(issue273Versions(t, conn), qt.DeepEquals, []int64{20220318104614, 20220318104615})
+
+	status, err = mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+	c.Assert(status.HasPendingChanges, qt.IsFalse)
+
+	err = mig.MigrateDownTo(ctx, 20220318104614)
+	c.Assert(err, qt.ErrorMatches, `.*migration 20220318104615 has no down migration; directory format atlas does not support down migrations.*`)
+}
+
+func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ptah_issue_273_users",
+		"DROP TABLE IF EXISTS ptah_issue_273_teams",
+		"DROP TABLE IF EXISTS schema_migrations_issue_273",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func issue273UsersCount(t *testing.T, conn *dbschema.DatabaseConnection) int {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM ptah_issue_273_users").Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func issue273Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
+	t.Helper()
+
+	rows, err := conn.Query("SELECT version FROM schema_migrations_issue_273 ORDER BY version")
+	qt.Assert(t, err, qt.IsNil)
+	defer rows.Close()
+
+	var versions []int64
+	for rows.Next() {
+		var version int64
+		qt.Assert(t, rows.Scan(&version), qt.IsNil)
+		versions = append(versions, version)
+	}
+	qt.Assert(t, rows.Err(), qt.IsNil)
+	return versions
+}

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -45,6 +45,7 @@ func runAtlasFormatIntegration(t *testing.T, dbURL string) {
 
 	cleanupIssue273(t, conn)
 	defer cleanupIssue273(t, conn)
+	createLegacyIssue273MetadataTable(t, conn)
 
 	fsys := fstest.MapFS{
 		"20220318104614_team_A.sql": &fstest.MapFile{Data: []byte("CREATE TABLE ptah_issue_273_teams (id INT PRIMARY KEY);\n")},
@@ -85,6 +86,20 @@ func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 	} {
 		_, _ = conn.ExecContext(context.Background(), statement)
 	}
+}
+
+func createLegacyIssue273MetadataTable(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	_, err := conn.ExecContext(
+		context.Background(),
+		`CREATE TABLE schema_migrations_issue_273 (
+			version INTEGER PRIMARY KEY,
+			description TEXT NOT NULL,
+			applied_at TIMESTAMP NOT NULL
+		)`,
+	)
+	qt.Assert(t, err, qt.IsNil)
 }
 
 func issue273UsersCount(t *testing.T, conn *dbschema.DatabaseConnection) int {

--- a/migration/migrator/example_test.go
+++ b/migration/migrator/example_test.go
@@ -416,7 +416,7 @@ func ExampleParseMigrationFileName() {
 // Example demonstrates generating migration filenames
 func ExampleGenerateMigrationFileName() {
 	// Generate filenames for a new migration
-	version := 20240101120000
+	var version int64 = 20240101120000
 	description := "Add User Preferences Table"
 
 	upFilename := migrator.GenerateMigrationFileName(version, description, "up")

--- a/migration/migrator/exec_order.go
+++ b/migration/migrator/exec_order.go
@@ -47,8 +47,8 @@ func normalizeExecOrder(value ExecOrder) ExecOrder {
 // OutOfOrderError reports pending migrations that are below the current
 // high-water mark while linear execution is required.
 type OutOfOrderError struct {
-	CurrentVersion int
-	Versions       []int
+	CurrentVersion int64
+	Versions       []int64
 }
 
 func (e *OutOfOrderError) Error() string {
@@ -61,7 +61,7 @@ func (e *OutOfOrderError) Error() string {
 
 // NewOutOfOrderError builds the typed error returned for linear execution when
 // lower-version pending migrations are present.
-func NewOutOfOrderError(currentVersion int, versions []int) *OutOfOrderError {
+func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError {
 	return &OutOfOrderError{
 		CurrentVersion: currentVersion,
 		Versions:       slices.Clone(versions),

--- a/migration/migrator/exec_order_test.go
+++ b/migration/migrator/exec_order_test.go
@@ -40,55 +40,55 @@ func TestPendingMigrationVersionsUsesAppliedSet(t *testing.T) {
 	c := qt.New(t)
 
 	migrations := testMigrations(1, 2, 3, 5)
-	pending := pendingMigrationVersions(migrations, []int{1, 2, 5})
+	pending := pendingMigrationVersions(migrations, []int64{1, 2, 5})
 
-	c.Assert(pending, qt.DeepEquals, []int{3})
-	c.Assert(outOfOrderMigrationVersions(pending, 5), qt.DeepEquals, []int{3})
+	c.Assert(pending, qt.DeepEquals, []int64{3})
+	c.Assert(outOfOrderMigrationVersions(pending, 5), qt.DeepEquals, []int64{3})
 }
 
 func TestMigrationsToApplyExecOrderPolicies(t *testing.T) {
 	c := qt.New(t)
 
 	migrations := testMigrations(1, 2, 3, 5)
-	applied := []int{1, 2, 5}
+	applied := []int64{1, 2, 5}
 
 	linear := NewMigrator(nil, NewRegisteredMigrationProvider(migrations...))
 	_, err := linear.migrationsToApply(migrations, applied, 0)
 	c.Assert(err, qt.IsNotNil)
 	var outOfOrderErr *OutOfOrderError
 	c.Assert(err, qt.ErrorAs, &outOfOrderErr)
-	c.Assert(outOfOrderErr.CurrentVersion, qt.Equals, 5)
-	c.Assert(outOfOrderErr.Versions, qt.DeepEquals, []int{3})
+	c.Assert(outOfOrderErr.CurrentVersion, qt.Equals, int64(5))
+	c.Assert(outOfOrderErr.Versions, qt.DeepEquals, []int64{3})
 
 	linearSkip := linear.WithExecOrder(ExecOrderLinearSkip)
 	got, err := linearSkip.migrationsToApply(migrations, applied, 0)
 	c.Assert(err, qt.IsNil)
-	c.Assert(migrationVersions(got), qt.DeepEquals, []int{})
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int64{})
 
 	nonLinear := linear.WithExecOrder(ExecOrderNonLinear)
 	got, err = nonLinear.migrationsToApply(migrations, applied, 0)
 	c.Assert(err, qt.IsNil)
-	c.Assert(migrationVersions(got), qt.DeepEquals, []int{3})
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int64{3})
 }
 
 func TestMigrationsToRollbackUsesAppliedSet(t *testing.T) {
 	c := qt.New(t)
 
 	migrationMap := migrationsByVersion(testMigrations(1, 2, 3, 5))
-	got, err := migrationsToRollback(migrationMap, []int{1, 2, 5}, 2)
+	got, err := migrationsToRollback(migrationMap, []int64{1, 2, 5}, 2)
 	c.Assert(err, qt.IsNil)
-	c.Assert(migrationVersions(got), qt.DeepEquals, []int{5})
+	c.Assert(migrationVersions(got), qt.DeepEquals, []int64{5})
 }
 
 func TestMigrationsToRollbackRequiresAppliedMigrationFile(t *testing.T) {
 	c := qt.New(t)
 
 	migrationMap := migrationsByVersion(testMigrations(1, 2))
-	_, err := migrationsToRollback(migrationMap, []int{1, 2, 5}, 2)
+	_, err := migrationsToRollback(migrationMap, []int64{1, 2, 5}, 2)
 	c.Assert(err, qt.ErrorMatches, `applied migration 5 is above target version 2 but is missing from the migration provider`)
 }
 
-func testMigrations(versions ...int) []*Migration {
+func testMigrations(versions ...int64) []*Migration {
 	migrations := make([]*Migration, 0, len(versions))
 	for _, version := range versions {
 		migrations = append(migrations, &Migration{
@@ -101,8 +101,8 @@ func testMigrations(versions ...int) []*Migration {
 	return migrations
 }
 
-func migrationVersions(migrations []*Migration) []int {
-	versions := make([]int, 0, len(migrations))
+func migrationVersions(migrations []*Migration) []int64 {
+	versions := make([]int64, 0, len(migrations))
 	for _, migration := range migrations {
 		versions = append(versions, migration.Version)
 	}

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -59,6 +59,7 @@ type FSMigrationProvider struct {
 	fsys        fs.FS
 	migrations  []*Migration
 	interceptor StatementInterceptor
+	format      MigrationDirFormat
 }
 
 // FSProviderOption configures a FSMigrationProvider before it loads
@@ -70,6 +71,15 @@ type FSProviderOption func(*FSMigrationProvider)
 func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption {
 	return func(p *FSMigrationProvider) {
 		p.interceptor = interceptor
+	}
+}
+
+// WithMigrationDirFormat selects how filesystem migrations are discovered.
+// The default auto mode keeps existing Ptah-pair behavior when Ptah files are
+// present and otherwise accepts Atlas single-file migrations.
+func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption {
+	return func(p *FSMigrationProvider) {
+		p.format = format
 	}
 }
 
@@ -94,27 +104,26 @@ func (p *FSMigrationProvider) Migrations() []*Migration {
 }
 
 func (p *FSMigrationProvider) load() error {
-	migrationsMap := make(map[int]*Migration) // version -> migration
-	// Track which files were found for validation
-	foundFiles := make(map[int]map[string]bool) // version -> direction -> found
+	files, err := DiscoverMigrationFiles(p.fsys, p.format)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		p.migrations = []*Migration{}
+		return nil
+	}
+	if files[0].Format == MigrationDirFormatAtlas {
+		return p.loadAtlas(files)
+	}
+	return p.loadPtah(files)
+}
 
-	err := fs.WalkDir(p.fsys, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
+	migrationsMap := make(map[int64]*Migration)
+	foundFiles := make(map[int64]map[string]bool)
 
-		if d.IsDir() {
-			return nil
-		}
-
-		// Parse migration filename
-		migrationFile, err := ParseMigrationFileName(d.Name())
-		if err != nil {
-			// Skip files that don't match migration pattern
-			return nil
-		}
-
-		// Initialize migration if it doesn't exist
+	for i := range files {
+		migrationFile := files[i]
 		if _, exists := migrationsMap[migrationFile.Version]; !exists {
 			migrationsMap[migrationFile.Version] = &Migration{
 				Version:     migrationFile.Version,
@@ -125,16 +134,14 @@ func (p *FSMigrationProvider) load() error {
 			foundFiles[migrationFile.Version] = make(map[string]bool)
 		}
 
-		// Track that we found this file
 		foundFiles[migrationFile.Version][migrationFile.Direction] = true
 
-		// Set the appropriate migration function based on direction
 		migration := migrationsMap[migrationFile.Version]
 		switch migrationFile.Direction {
 		case "up":
-			up, err := migrationFuncFromSQLFilenameWithMetadata(path, p.fsys, p.interceptor)
+			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
 			if err != nil {
-				return fmt.Errorf("failed to load up migration %s: %w", path, err)
+				return fmt.Errorf("failed to load up migration %s: %w", migrationFile.Path, err)
 			}
 			migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 				return up.fn(ctx, conn, migration.executionMode())
@@ -142,9 +149,9 @@ func (p *FSMigrationProvider) load() error {
 			migration.UpTimeouts = up.timeouts
 			migration.NoTransaction = migration.NoTransaction || up.noTransaction
 		case "down":
-			down, err := migrationFuncFromSQLFilenameWithMetadata(path, p.fsys, p.interceptor)
+			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
 			if err != nil {
-				return fmt.Errorf("failed to load down migration %s: %w", path, err)
+				return fmt.Errorf("failed to load down migration %s: %w", migrationFile.Path, err)
 			}
 			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 				return down.fn(ctx, conn, migration.executionMode())
@@ -154,16 +161,10 @@ func (p *FSMigrationProvider) load() error {
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}
-
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to scan migrations directory: %w", err)
 	}
 
 	// Validate that all migrations have both up and down files
-	var incompleteMigrations []int
+	var incompleteMigrations []int64
 	for version := range migrationsMap {
 		files := foundFiles[version]
 		if !files["up"] || !files["down"] {
@@ -179,6 +180,35 @@ func (p *FSMigrationProvider) load() error {
 
 	sortMigrations(p.migrations)
 
+	return nil
+}
+
+func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
+	migrations := make([]*Migration, 0, len(files))
+	for i := range files {
+		migrationFile := files[i]
+		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+		if err != nil {
+			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
+		}
+
+		migration := &Migration{
+			Version:       migrationFile.Version,
+			Description:   migrationFile.Name,
+			UpTimeouts:    up.timeouts,
+			NoTransaction: up.noTransaction,
+		}
+		migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+			return up.fn(ctx, conn, migration.executionMode())
+		}
+		migration.Down = func(_ context.Context, _ *dbschema.DatabaseConnection) error {
+			return fmt.Errorf("migration %d has no down migration; directory format atlas does not support down migrations without %s", migration.Version, "atlas txtar down.sql")
+		}
+		migrations = append(migrations, migration)
+	}
+
+	p.migrations = migrations
+	sortMigrations(p.migrations)
 	return nil
 }
 

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -1,6 +1,7 @@
 package migrator_test
 
 import (
+	"context"
 	"io/fs"
 	"testing"
 	"testing/fstest"
@@ -53,7 +54,7 @@ func TestRegisteredMigrationProvider_Register(t *testing.T) {
 	provider.Register(migration1)
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1)
-	c.Assert(migrations[0].Version, qt.Equals, 1)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
 
 	migration2 := &migrator.Migration{
 		Version:     2,
@@ -66,8 +67,8 @@ func TestRegisteredMigrationProvider_Register(t *testing.T) {
 	provider.Register(migration2)
 	migrations = provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 2)
-	c.Assert(migrations[0].Version, qt.Equals, 1)
-	c.Assert(migrations[1].Version, qt.Equals, 2)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
+	c.Assert(migrations[1].Version, qt.Equals, int64(2))
 }
 
 func TestRegisteredMigrationProvider_Sorting(t *testing.T) {
@@ -102,9 +103,9 @@ func TestRegisteredMigrationProvider_Sorting(t *testing.T) {
 	// Should be sorted by version
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 3)
-	c.Assert(migrations[0].Version, qt.Equals, 1)
-	c.Assert(migrations[1].Version, qt.Equals, 2)
-	c.Assert(migrations[2].Version, qt.Equals, 3)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
+	c.Assert(migrations[1].Version, qt.Equals, int64(2))
+	c.Assert(migrations[2].Version, qt.Equals, int64(3))
 }
 
 func TestNewFSMigrationProvider_Success(t *testing.T) {
@@ -132,9 +133,9 @@ func TestNewFSMigrationProvider_Success(t *testing.T) {
 
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 2)
-	c.Assert(migrations[0].Version, qt.Equals, 1)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
 	c.Assert(migrations[0].Description, qt.Equals, "Create Users")
-	c.Assert(migrations[1].Version, qt.Equals, 2)
+	c.Assert(migrations[1].Version, qt.Equals, int64(2))
 	c.Assert(migrations[1].Description, qt.Equals, "Add Index")
 }
 
@@ -153,6 +154,40 @@ func TestNewFSMigrationProvider_IncompleteMigrations(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(provider, qt.IsNil)
 	c.Assert(err.Error(), qt.Contains, "incomplete migrations found")
+}
+
+func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20220318104615_add_users.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"20220318104614_team_A.sql":    &fstest.MapFile{Data: []byte("CREATE TABLE teams (id INT);\n")},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 2)
+	c.Assert(migrations[0].Version, qt.Equals, int64(20220318104614))
+	c.Assert(migrations[0].Description, qt.Equals, "Team A")
+	c.Assert(migrations[1].Version, qt.Equals, int64(20220318104615))
+	c.Assert(migrations[1].Description, qt.Equals, "Add Users")
+
+	err = migrations[0].Down(context.Background(), nil)
+	c.Assert(err, qt.ErrorMatches, `migration 20220318104614 has no down migration; directory format atlas does not support down migrations.*`)
+}
+
+func TestNewFSMigrationProvider_UnknownOnlySQLFilesError(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"cleanup.sql": &fstest.MapFile{Data: []byte("DROP TABLE users;\n")},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(provider, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: cleanup.sql`)
 }
 
 func TestNewFSMigrationProvider_EmptyFilesystem(t *testing.T) {
@@ -196,7 +231,7 @@ func TestNewFSMigrationProvider_DescriptionEndingInUpIsNotAMigration(t *testing.
 
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1)
-	c.Assert(migrations[0].Version, qt.Equals, 1)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
 }
 
 func TestNewFSMigrationProvider_InvalidFiles(t *testing.T) {
@@ -224,7 +259,7 @@ func TestNewFSMigrationProvider_InvalidFiles(t *testing.T) {
 
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1) // Only the valid migration should be loaded
-	c.Assert(migrations[0].Version, qt.Equals, 1)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
 }
 
 func TestFSMigrationProvider_FilesystemError(t *testing.T) {

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -156,7 +156,7 @@ func NoopMigrationFunc(_ctx context.Context, _conn *dbschema.DatabaseConnection)
 
 // Migration represents a database migration
 type Migration struct {
-	Version      int
+	Version      int64
 	Description  string
 	Up           MigrationFunc
 	Down         MigrationFunc
@@ -178,7 +178,7 @@ func (m *Migration) executionMode() migrationExecutionMode {
 
 // CreateMigrationFromSQL creates a migration from SQL strings
 // This is useful for programmatically creating migrations
-func CreateMigrationFromSQL(version int, description, upSQL, downSQL string) *Migration {
+func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration {
 	upNoTransaction, upDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(upSQL))
 	downNoTransaction, downDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(downSQL))
 

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -20,7 +20,7 @@ func TestMigration_Basic(t *testing.T) {
 		Down:        NoopMigrationFunc,
 	}
 
-	c.Assert(migration.Version, qt.Equals, 1)
+	c.Assert(migration.Version, qt.Equals, int64(1))
 	c.Assert(migration.Description, qt.Equals, "Test migration")
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
@@ -42,7 +42,7 @@ func TestCreateMigrationFromSQL(t *testing.T) {
 
 	migration := CreateMigrationFromSQL(1, "Create test table", upSQL, downSQL)
 
-	c.Assert(migration.Version, qt.Equals, 1)
+	c.Assert(migration.Version, qt.Equals, int64(1))
 	c.Assert(migration.Description, qt.Equals, "Create test table")
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
@@ -81,12 +81,12 @@ func TestMigrationStatus(t *testing.T) {
 
 	status := &MigrationStatus{
 		CurrentVersion:    5,
-		PendingMigrations: []int{6, 7, 8},
+		PendingMigrations: []int64{6, 7, 8},
 		TotalMigrations:   8,
 		HasPendingChanges: true,
 	}
 
-	c.Assert(status.CurrentVersion, qt.Equals, 5)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(5))
 	c.Assert(status.PendingMigrations, qt.HasLen, 3)
 	c.Assert(status.TotalMigrations, qt.Equals, 8)
 	c.Assert(status.HasPendingChanges, qt.IsTrue)
@@ -97,12 +97,12 @@ func TestMigrationStatus_NoPending(t *testing.T) {
 
 	status := &MigrationStatus{
 		CurrentVersion:    5,
-		PendingMigrations: []int{},
+		PendingMigrations: []int64{},
 		TotalMigrations:   5,
 		HasPendingChanges: false,
 	}
 
-	c.Assert(status.CurrentVersion, qt.Equals, 5)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(5))
 	c.Assert(status.PendingMigrations, qt.HasLen, 0)
 	c.Assert(status.TotalMigrations, qt.Equals, 5)
 	c.Assert(status.HasPendingChanges, qt.IsFalse)

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -16,12 +16,12 @@ import (
 
 // MigrationStatus represents the current state of migrations
 type MigrationStatus struct {
-	CurrentVersion       int   `json:"current_version"`
-	AppliedMigrations    []int `json:"applied_migrations"`
-	PendingMigrations    []int `json:"pending_migrations"`
-	OutOfOrderMigrations []int `json:"out_of_order_migrations"`
-	TotalMigrations      int   `json:"total_migrations"`
-	HasPendingChanges    bool  `json:"has_pending_changes"`
+	CurrentVersion       int64   `json:"current_version"`
+	AppliedMigrations    []int64 `json:"applied_migrations"`
+	PendingMigrations    []int64 `json:"pending_migrations"`
+	OutOfOrderMigrations []int64 `json:"out_of_order_migrations"`
+	TotalMigrations      int     `json:"total_migrations"`
+	HasPendingChanges    bool    `json:"has_pending_changes"`
 }
 
 // Migrator handles database migrations for ptah
@@ -119,7 +119,7 @@ func (m *Migrator) quoteIdentifier(identifier string) string {
 
 func (m *Migrator) createMigrationsTableSQL() string {
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-    version INTEGER PRIMARY KEY,
+    version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
     applied_at TIMESTAMP NOT NULL
 )`, m.qualifiedMigrationsTable())
@@ -175,7 +175,7 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 }
 
 // GetCurrentVersion returns the current migration version from the database
-func (m *Migrator) GetCurrentVersion(ctx context.Context) (int, error) {
+func (m *Migrator) GetCurrentVersion(ctx context.Context) (int64, error) {
 	// First ensure the migrations table exists
 	if err := m.Initialize(ctx); err != nil {
 		return 0, fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -185,7 +185,7 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int, error) {
 	}
 
 	// Query the current version
-	var version int
+	var version int64
 	row := m.conn.QueryRowContext(ctx, m.getVersionSQL())
 	if err := row.Scan(&version); err != nil {
 		return 0, fmt.Errorf("failed to get current version: %w", err)
@@ -195,13 +195,13 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int, error) {
 }
 
 // GetAppliedMigrations returns a list of applied migration versions
-func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
+func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error) {
 	// First ensure the migrations table exists
 	if err := m.Initialize(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
 	if m.conn.Writer().IsDryRun() {
-		return []int{}, nil
+		return []int64{}, nil
 	}
 
 	// Query all applied migration versions
@@ -211,9 +211,9 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 	}
 	defer rows.Close()
 
-	applied := make([]int, 0)
+	applied := make([]int64, 0)
 	for rows.Next() {
-		var version int
+		var version int64
 		if err := rows.Scan(&version); err != nil {
 			return nil, fmt.Errorf("failed to scan migration version: %w", err)
 		}
@@ -228,7 +228,7 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int, error) {
 }
 
 // GetPendingMigrations returns a list of pending migration versions
-func (m *Migrator) GetPendingMigrations(ctx context.Context) ([]int, error) {
+func (m *Migrator) GetPendingMigrations(ctx context.Context) ([]int64, error) {
 	applied, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
 		return nil, err
@@ -239,7 +239,7 @@ func (m *Migrator) GetPendingMigrations(ctx context.Context) ([]int, error) {
 
 // GetPreviousMigrationVersion finds the previous migration version compared to the current one.
 // Returns an error and -1 if no previous migrations exist.
-func (m *Migrator) GetPreviousMigrationVersion(ctx context.Context) (int, error) {
+func (m *Migrator) GetPreviousMigrationVersion(ctx context.Context) (int64, error) {
 	applied, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
 		return -1, fmt.Errorf("failed to get applied migrations: %w", err)
@@ -318,7 +318,7 @@ func (m *Migrator) MigrateDown(ctx context.Context) error {
 }
 
 // MigrateDownTo migrates the database down to the specified target version
-func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
+func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -399,7 +399,7 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int) error {
 }
 
 // MigrateTo migrates the database to a specific version (up or down)
-func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int) error {
+func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int64) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -435,7 +435,7 @@ func (m *Migrator) MigrationProvider() MigrationProvider {
 }
 
 // migrateUpTo migrates the database up to a specific version
-func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int) error {
+func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int64) error {
 	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get applied migrations: %w", err)
@@ -540,14 +540,14 @@ func (m *Migrator) rollbackMigrationNoTransaction(ctx context.Context, migration
 	return nil
 }
 
-func ensureNoTransactionHasNoTimeouts(version int, timeouts MigrationTimeouts) error {
+func ensureNoTransactionHasNoTimeouts(version int64, timeouts MigrationTimeouts) error {
 	if timeouts.IsZero() {
 		return nil
 	}
 	return fmt.Errorf("migration %d is marked no_transaction, so migration timeouts cannot be applied safely", version)
 }
 
-func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int, targetVersion int) ([]*Migration, error) {
+func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, targetVersion int64) ([]*Migration, error) {
 	currentVersion := maxAppliedVersion(applied)
 	pendingVersions := pendingMigrationVersions(migrations, applied)
 	outOfOrderVersions := outOfOrderMigrationVersions(pendingVersions, currentVersion)
@@ -576,21 +576,21 @@ func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int, tar
 	return migrationsToApply, nil
 }
 
-func pendingMigrationVersions(migrations []*Migration, applied []int) []int {
+func pendingMigrationVersions(migrations []*Migration, applied []int64) []int64 {
 	appliedSet := versionSet(applied)
-	pending := make([]int, 0, len(migrations))
+	pending := make([]int64, 0, len(migrations))
 	for _, migration := range migrations {
 		if _, ok := appliedSet[migration.Version]; ok {
 			continue
 		}
 		pending = append(pending, migration.Version)
 	}
-	sort.Ints(pending)
+	slices.Sort(pending)
 	return pending
 }
 
-func outOfOrderMigrationVersions(pending []int, currentVersion int) []int {
-	outOfOrder := make([]int, 0)
+func outOfOrderMigrationVersions(pending []int64, currentVersion int64) []int64 {
+	outOfOrder := make([]int64, 0)
 	for _, version := range pending {
 		if version < currentVersion {
 			outOfOrder = append(outOfOrder, version)
@@ -599,37 +599,37 @@ func outOfOrderMigrationVersions(pending []int, currentVersion int) []int {
 	return outOfOrder
 }
 
-func maxAppliedVersion(applied []int) int {
+func maxAppliedVersion(applied []int64) int64 {
 	if len(applied) == 0 {
 		return 0
 	}
 	return slices.Max(applied)
 }
 
-func versionSet(versions []int) map[int]struct{} {
-	set := make(map[int]struct{}, len(versions))
+func versionSet(versions []int64) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(versions))
 	for _, version := range versions {
 		set[version] = struct{}{}
 	}
 	return set
 }
 
-func migrationsByVersion(migrations []*Migration) map[int]*Migration {
-	result := make(map[int]*Migration, len(migrations))
+func migrationsByVersion(migrations []*Migration) map[int64]*Migration {
+	result := make(map[int64]*Migration, len(migrations))
 	for _, migration := range migrations {
 		result[migration.Version] = migration
 	}
 	return result
 }
 
-func migrationsToRollback(migrationsByVersion map[int]*Migration, applied []int, targetVersion int) ([]*Migration, error) {
-	rollbackVersions := make([]int, 0, len(applied))
+func migrationsToRollback(migrationsByVersion map[int64]*Migration, applied []int64, targetVersion int64) ([]*Migration, error) {
+	rollbackVersions := make([]int64, 0, len(applied))
 	for _, version := range applied {
 		if version > targetVersion {
 			rollbackVersions = append(rollbackVersions, version)
 		}
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(rollbackVersions)))
+	sort.Slice(rollbackVersions, func(i, j int) bool { return rollbackVersions[i] > rollbackVersions[j] })
 
 	rollbackMigrations := make([]*Migration, 0, len(rollbackVersions))
 	for _, version := range rollbackVersions {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -168,10 +168,104 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create migrations table: %w", err)
 	}
+	if err := m.ensureMigrationsVersionColumn(ctx); err != nil {
+		return fmt.Errorf("failed to prepare migrations version column: %w", err)
+	}
 
 	// Mark as initialized
 	m.initialized = true
 	return nil
+}
+
+func (m *Migrator) ensureMigrationsVersionColumn(ctx context.Context) error {
+	switch m.conn.Info().Dialect {
+	case "postgres", "cockroachdb", "yugabytedb":
+		return m.ensurePostgresMigrationsVersionColumn(ctx)
+	case "mysql", "mariadb":
+		return m.ensureMySQLMigrationsVersionColumn(ctx)
+	default:
+		return nil
+	}
+}
+
+func (m *Migrator) ensurePostgresMigrationsVersionColumn(ctx context.Context) error {
+	dataType, err := m.migrationsVersionColumnType(
+		ctx,
+		sqlutil.Rebind(m.conn.Info().Dialect, `
+SELECT data_type
+FROM information_schema.columns
+WHERE table_schema = ? AND table_name = ? AND column_name = 'version'`),
+	)
+	if err != nil {
+		return err
+	}
+	if dataType == "bigint" {
+		return nil
+	}
+	_, err = m.conn.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE %s ALTER COLUMN %s TYPE BIGINT",
+		m.qualifiedMigrationsTable(),
+		m.quoteIdentifier("version"),
+	))
+	if err != nil {
+		return fmt.Errorf("failed to widen version column from %s to BIGINT: %w", dataType, err)
+	}
+	return nil
+}
+
+func (m *Migrator) ensureMySQLMigrationsVersionColumn(ctx context.Context) error {
+	dataType, err := m.migrationsVersionColumnType(
+		ctx,
+		`SELECT data_type
+FROM information_schema.columns
+WHERE table_schema = ? AND table_name = ? AND column_name = 'version'`,
+	)
+	if err != nil {
+		return err
+	}
+	if dataType == "bigint" {
+		return nil
+	}
+	_, err = m.conn.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE %s MODIFY COLUMN %s BIGINT NOT NULL",
+		m.qualifiedMigrationsTable(),
+		m.quoteIdentifier("version"),
+	))
+	if err != nil {
+		return fmt.Errorf("failed to widen version column from %s to BIGINT: %w", dataType, err)
+	}
+	return nil
+}
+
+func (m *Migrator) migrationsVersionColumnType(ctx context.Context, query string) (string, error) {
+	var dataType string
+	err := m.conn.QueryRowContext(ctx, query, m.metadataSchemaName(), m.migrationsTableName()).Scan(&dataType)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect migrations version column: %w", err)
+	}
+	return strings.ToLower(dataType), nil
+}
+
+func (m *Migrator) metadataSchemaName() string {
+	if m.migrationsSchema != "" {
+		return m.migrationsSchema
+	}
+	if m.conn != nil {
+		if schema := strings.TrimSpace(m.conn.Info().Schema); schema != "" {
+			return schema
+		}
+	}
+	if m.conn != nil && m.conn.Info().Dialect == "postgres" {
+		return "public"
+	}
+	return ""
+}
+
+func (m *Migrator) migrationsTableName() string {
+	if m.migrationsTable == "" {
+		return "schema_migrations"
+	}
+	return m.migrationsTable
 }
 
 // GetCurrentVersion returns the current migration version from the database

--- a/migration/migrator/out_of_order_integration_test.go
+++ b/migration/migrator/out_of_order_integration_test.go
@@ -28,10 +28,10 @@ func TestOutOfOrderMigrationsPostgresIntegration(t *testing.T) {
 	mig := issue261Migrator(conn, issue261AllMigrations()...)
 	status, err := mig.GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(status.CurrentVersion, qt.Equals, 5)
-	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int{1, 2, 5})
-	c.Assert(status.PendingMigrations, qt.DeepEquals, []int{3})
-	c.Assert(status.OutOfOrderMigrations, qt.DeepEquals, []int{3})
+	c.Assert(status.CurrentVersion, qt.Equals, int64(5))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1, 2, 5})
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{3})
+	c.Assert(status.OutOfOrderMigrations, qt.DeepEquals, []int64{3})
 
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNotNil)
@@ -64,7 +64,7 @@ func TestOutOfOrderMigrationsPostgresIntegration(t *testing.T) {
 
 	finalStatus, err := issue261Migrator(conn, issue261AllMigrations()...).GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(finalStatus.AppliedMigrations, qt.DeepEquals, []int{1, 2, 3, 5})
+	c.Assert(finalStatus.AppliedMigrations, qt.DeepEquals, []int64{1, 2, 3, 5})
 	c.Assert(finalStatus.PendingMigrations, qt.HasLen, 0)
 }
 
@@ -113,7 +113,7 @@ func issue261AllMigrations() []*migrator.Migration {
 	}
 }
 
-func issue261Migration(version int, description, upSQL, downSQL string) *migrator.Migration {
+func issue261Migration(version int64, description, upSQL, downSQL string) *migrator.Migration {
 	return migrator.CreateMigrationFromSQL(version, description, upSQL, downSQL)
 }
 

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -170,7 +170,7 @@ func noopRestoreTimeouts(_ context.Context) error {
 	return nil
 }
 
-func (m *Migrator) restoreTimeouts(ctx context.Context, version int, restore restoreTimeoutsFunc) error {
+func (m *Migrator) restoreTimeouts(ctx context.Context, version int64, restore restoreTimeoutsFunc) error {
 	if restore == nil {
 		return nil
 	}
@@ -180,7 +180,7 @@ func (m *Migrator) restoreTimeouts(ctx context.Context, version int, restore res
 	return nil
 }
 
-func (m *Migrator) restoreTimeoutsAfterFailure(ctx context.Context, version int, restore restoreTimeoutsFunc, failure error) error {
+func (m *Migrator) restoreTimeoutsAfterFailure(ctx context.Context, version int64, restore restoreTimeoutsFunc, failure error) error {
 	if restore == nil {
 		return failure
 	}

--- a/migration/migrator/transaction_integration_test.go
+++ b/migration/migrator/transaction_integration_test.go
@@ -34,7 +34,7 @@ func TestCreateMigrationFromSQL_PostgresFailureRollsBackStatements(t *testing.T)
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(columnExists(t, conn, "ptah_issue_262_users", "status"), qt.IsFalse)
-	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 0)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, int64(0))
 
 	fixedMigration := migrator.CreateMigrationFromSQL(1, "add status",
 		`ALTER TABLE ptah_issue_262_users ADD COLUMN status TEXT;
@@ -43,7 +43,7 @@ func TestCreateMigrationFromSQL_PostgresFailureRollsBackStatements(t *testing.T)
 	err = issue262Migrator(conn, fixedMigration).MigrateUp(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(columnExists(t, conn, "ptah_issue_262_users", "status"), qt.IsTrue)
-	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 1)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, int64(1))
 }
 
 func TestMigratorDryRun_PostgresDoesNotCreateMetadataOrMigrationObjects(t *testing.T) {
@@ -65,8 +65,8 @@ func TestMigratorDryRun_PostgresDoesNotCreateMetadataOrMigrationObjects(t *testi
 
 	status, err := mig.GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(status.CurrentVersion, qt.Equals, 0)
-	c.Assert(status.PendingMigrations, qt.DeepEquals, []int{1})
+	c.Assert(status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{1})
 
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNil)
@@ -117,7 +117,7 @@ ALTER TABLE ptah_issue_262_enum_items DROP COLUMN mood;`),
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(columnExists(t, conn, "ptah_issue_262_enum_items", "mood"), qt.IsTrue)
-	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, 2)
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, int64(2))
 }
 
 func issue262Migrator(conn *dbschema.DatabaseConnection, migrations ...*migrator.Migration) *migrator.Migrator {

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -21,11 +21,14 @@ import (
 // "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
 var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
-// Atlas migration file naming pattern: version_description.sql. Atlas
-// versioned directories commonly use 14-digit timestamp versions. Requiring
-// more than Ptah's 10-digit version width keeps legacy suffixless Ptah-looking
-// files from being auto-classified as Atlas migrations.
-var atlasFileNameRe = regexp.MustCompile(`^(\d{11,})_(.+)(\.sql)$`)
+// Atlas migration file naming pattern: version_description.sql.
+var atlasFileNameRe = regexp.MustCompile(`^(\d+)_(.+)(\.sql)$`)
+
+// Auto-detection stays stricter than explicit Atlas mode: Atlas versioned
+// directories commonly use 14-digit timestamp versions, and requiring more than
+// Ptah's 10-digit version width keeps legacy suffixless Ptah-looking files from
+// being auto-classified as Atlas migrations.
+var atlasAutoFileNameRe = regexp.MustCompile(`^(\d{11,})_(.+)(\.sql)$`)
 
 // MigrationDirFormat selects how a filesystem migration directory is parsed.
 type MigrationDirFormat string
@@ -104,7 +107,18 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 // Expected format: version_description.sql. Atlas does not use paired .up.sql
 // and .down.sql files; these files are forward migrations.
 func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error) {
-	matches := atlasFileNameRe.FindStringSubmatch(filename)
+	return parseAtlasMigrationFileName(filename, atlasFileNameRe)
+}
+
+// ParseAtlasMigrationFileNameForAutoDetection parses Atlas names accepted by
+// auto-detection. It is stricter than explicit Atlas parsing so legacy
+// suffixless Ptah-looking files keep surfacing as unrecognized in auto mode.
+func ParseAtlasMigrationFileNameForAutoDetection(filename string) (*MigrationFile, error) {
+	return parseAtlasMigrationFileName(filename, atlasAutoFileNameRe)
+}
+
+func parseAtlasMigrationFileName(filename string, pattern *regexp.Regexp) (*MigrationFile, error) {
+	matches := pattern.FindStringSubmatch(filename)
 	if matches == nil || len(matches) != 4 {
 		return nil, errors.New("invalid Atlas migration file name format")
 	}
@@ -284,7 +298,7 @@ func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationF
 			migrationFile.Path = p
 			ptahFiles = append(ptahFiles, *migrationFile)
 		}
-		if migrationFile, err := ParseAtlasMigrationFileName(base); err == nil {
+		if migrationFile, err := parseAtlasMigrationFileNameForFormat(base, format); err == nil {
 			migrationFile.Path = p
 			atlasFiles = append(atlasFiles, *migrationFile)
 		}
@@ -305,6 +319,13 @@ func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationF
 		return files[i].Path < files[j].Path
 	})
 	return files, nil
+}
+
+func parseAtlasMigrationFileNameForFormat(filename string, format MigrationDirFormat) (*MigrationFile, error) {
+	if format == MigrationDirFormatAtlas {
+		return ParseAtlasMigrationFileName(filename)
+	}
+	return ParseAtlasMigrationFileNameForAutoDetection(filename)
 }
 
 func normalizeMigrationDirFormat(format MigrationDirFormat) (MigrationDirFormat, error) {

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -3,7 +3,10 @@ package migrator
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,12 +21,47 @@ import (
 // "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
 var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
+// Atlas migration file naming pattern: version_description.sql. Atlas
+// versioned directories commonly use 14-digit timestamp versions. Requiring
+// more than Ptah's 10-digit version width keeps legacy suffixless Ptah-looking
+// files from being auto-classified as Atlas migrations.
+var atlasFileNameRe = regexp.MustCompile(`^(\d{11,})_(.+)(\.sql)$`)
+
+// MigrationDirFormat selects how a filesystem migration directory is parsed.
+type MigrationDirFormat string
+
+const (
+	// MigrationDirFormatAuto prefers Ptah files when present and otherwise
+	// falls back to Atlas single-file migrations.
+	MigrationDirFormatAuto MigrationDirFormat = "auto"
+	// MigrationDirFormatPtah parses NNNNNNNNNN_description.(up|down).sql pairs.
+	MigrationDirFormatPtah MigrationDirFormat = "ptah"
+	// MigrationDirFormatAtlas parses Atlas version_description.sql files.
+	MigrationDirFormatAtlas MigrationDirFormat = "atlas"
+)
+
+// ParseMigrationDirFormat normalizes a migration directory format value.
+func ParseMigrationDirFormat(value string) (MigrationDirFormat, error) {
+	switch MigrationDirFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case "", MigrationDirFormatAuto:
+		return MigrationDirFormatAuto, nil
+	case MigrationDirFormatPtah:
+		return MigrationDirFormatPtah, nil
+	case MigrationDirFormatAtlas:
+		return MigrationDirFormatAtlas, nil
+	default:
+		return "", fmt.Errorf("unknown migration directory format %q: expected auto, ptah, or atlas", value)
+	}
+}
+
 // MigrationFile represents the parsed components of a migration file name
 type MigrationFile struct {
-	Version   int
+	Path      string
+	Version   int64
 	Name      string
 	Direction string
 	Extension string
+	Format    MigrationDirFormat
 }
 
 // ParseMigrationFileName parses a migration filename into its components
@@ -36,7 +74,7 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 		return nil, errors.New("invalid migration file name format")
 	}
 
-	version, err := strconv.Atoi(matches[1])
+	version, err := strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +96,40 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 		Name:      name,
 		Direction: direction,
 		Extension: extension,
+		Format:    MigrationDirFormatPtah,
+	}, nil
+}
+
+// ParseAtlasMigrationFileName parses an Atlas versioned migration file name.
+// Expected format: version_description.sql. Atlas does not use paired .up.sql
+// and .down.sql files; these files are forward migrations.
+func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error) {
+	matches := atlasFileNameRe.FindStringSubmatch(filename)
+	if matches == nil || len(matches) != 4 {
+		return nil, errors.New("invalid Atlas migration file name format")
+	}
+
+	if strings.HasSuffix(matches[2], ".up") || strings.HasSuffix(matches[2], ".down") {
+		return nil, errors.New("Atlas migration file name must not use Ptah direction suffixes")
+	}
+
+	version, err := strconv.ParseInt(matches[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	if version <= 0 {
+		return nil, errors.New("migration version must be greater than zero")
+	}
+
+	name := strings.ReplaceAll(matches[2], "_", " ")
+	name = cases.Title(language.English).String(name)
+
+	return &MigrationFile{
+		Version:   version,
+		Name:      name,
+		Direction: "up",
+		Extension: matches[3],
+		Format:    MigrationDirFormatAtlas,
 	}, nil
 }
 
@@ -68,7 +140,7 @@ func ValidateMigrationFileName(filename string) bool {
 }
 
 // GenerateMigrationFileName generates a migration filename from components
-func GenerateMigrationFileName(version int, description, direction string) string {
+func GenerateMigrationFileName(version int64, description, direction string) string {
 	// Convert description to snake_case
 	desc := strings.ToLower(description)
 	desc = strings.ReplaceAll(desc, " ", "_")
@@ -79,14 +151,14 @@ func GenerateMigrationFileName(version int, description, direction string) strin
 
 // GetNextMigrationVersion generates the next migration version number
 // This is a simple implementation that uses the current timestamp
-func GetNextMigrationVersion() int {
-	return int(time.Now().Unix())
+func GetNextMigrationVersion() int64 {
+	return time.Now().Unix()
 }
 
 // GroupMigrationFiles groups migration files by version, returning a map
 // where each version maps to a struct containing up and down migration files
-func GroupMigrationFiles(files []MigrationFile) map[int]MigrationPair {
-	groups := make(map[int]MigrationPair)
+func GroupMigrationFiles(files []MigrationFile) map[int64]MigrationPair {
+	groups := make(map[int64]MigrationPair)
 
 	for _, file := range files {
 		pair := groups[file.Version]
@@ -124,7 +196,7 @@ func (mp MigrationPair) HasDown() bool {
 }
 
 // GetVersion returns the version number (assumes both up and down have same version)
-func (mp MigrationPair) GetVersion() int {
+func (mp MigrationPair) GetVersion() int64 {
 	if mp.Up != nil {
 		return mp.Up.Version
 	}
@@ -147,8 +219,8 @@ func (mp MigrationPair) GetDescription() string {
 
 // ValidateMigrationPairs validates that all migration pairs are complete
 // Returns a list of versions that are missing either up or down migrations
-func ValidateMigrationPairs(pairs map[int]MigrationPair) []int {
-	var incomplete []int
+func ValidateMigrationPairs(pairs map[int64]MigrationPair) []int64 {
+	var incomplete []int64
 
 	for version, pair := range pairs {
 		if !pair.IsComplete() {
@@ -156,19 +228,19 @@ func ValidateMigrationPairs(pairs map[int]MigrationPair) []int {
 		}
 	}
 
-	sort.Ints(incomplete)
+	slicesSort(incomplete)
 	return incomplete
 }
 
 // FindMigrationGaps finds gaps in migration version sequences
 // Returns a list of missing version numbers in the sequence
-func FindMigrationGaps(versions []int) []int {
+func FindMigrationGaps(versions []int64) []int64 {
 	if len(versions) == 0 {
 		return nil
 	}
 
-	sort.Ints(versions)
-	var gaps []int
+	slicesSort(versions)
+	var gaps []int64
 
 	for i := 1; i < len(versions); i++ {
 		current := versions[i]
@@ -184,4 +256,78 @@ func FindMigrationGaps(versions []int) []int {
 	}
 
 	return gaps
+}
+
+// DiscoverMigrationFiles walks fsys and returns files matching the requested
+// migration directory format. In auto mode Ptah files win when present, so
+// existing directories with stray single .sql files keep their old behavior.
+func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationFile, error) {
+	format, err := normalizeMigrationDirFormat(format)
+	if err != nil {
+		return nil, err
+	}
+
+	var sqlFiles []string
+	var ptahFiles []MigrationFile
+	var atlasFiles []MigrationFile
+	err = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.EqualFold(path.Ext(p), ".sql") {
+			return nil
+		}
+
+		sqlFiles = append(sqlFiles, p)
+		base := path.Base(p)
+		if migrationFile, err := ParseMigrationFileName(base); err == nil {
+			migrationFile.Path = p
+			ptahFiles = append(ptahFiles, *migrationFile)
+		}
+		if migrationFile, err := ParseAtlasMigrationFileName(base); err == nil {
+			migrationFile.Path = p
+			atlasFiles = append(atlasFiles, *migrationFile)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+
+	files := selectMigrationFiles(format, ptahFiles, atlasFiles)
+	if len(files) == 0 && len(sqlFiles) > 0 {
+		return nil, fmt.Errorf("no migration files matched format %q; unrecognized SQL files: %s", format, strings.Join(sqlFiles, ", "))
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Version != files[j].Version {
+			return files[i].Version < files[j].Version
+		}
+		return files[i].Path < files[j].Path
+	})
+	return files, nil
+}
+
+func normalizeMigrationDirFormat(format MigrationDirFormat) (MigrationDirFormat, error) {
+	if format == "" {
+		return MigrationDirFormatAuto, nil
+	}
+	return ParseMigrationDirFormat(string(format))
+}
+
+func selectMigrationFiles(format MigrationDirFormat, ptahFiles, atlasFiles []MigrationFile) []MigrationFile {
+	switch format {
+	case MigrationDirFormatPtah:
+		return ptahFiles
+	case MigrationDirFormatAtlas:
+		return atlasFiles
+	default:
+		if len(ptahFiles) > 0 {
+			return ptahFiles
+		}
+		return atlasFiles
+	}
+}
+
+func slicesSort(values []int64) {
+	slices.Sort(values)
 }

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -178,8 +178,10 @@ func TestParseAtlasMigrationFileName(t *testing.T) {
 	c.Assert(migrationFile.Extension, qt.Equals, ".sql")
 	c.Assert(migrationFile.Format, qt.Equals, MigrationDirFormatAtlas)
 
-	_, err = ParseAtlasMigrationFileName("0000000001_cleanup.sql")
-	c.Assert(err, qt.ErrorMatches, "invalid Atlas migration file name format")
+	migrationFile, err = ParseAtlasMigrationFileName("1_initial.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(1))
+	c.Assert(migrationFile.Name, qt.Equals, "Initial")
 	_, err = ParseAtlasMigrationFileName("20220318104614_team_A.up.sql")
 	c.Assert(err, qt.ErrorMatches, "Atlas migration file name must not use Ptah direction suffixes")
 }
@@ -200,6 +202,25 @@ func TestDiscoverMigrationFilesAtlasAuto(t *testing.T) {
 	c.Assert(files[0].Version, qt.Equals, int64(20220318104614))
 	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
 	c.Assert(files[1].Path, qt.Equals, "20220318104615_add_users.sql")
+}
+
+func TestDiscoverMigrationFilesAtlasExplicitAllowsShortVersions(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1_initial.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(files[0].Path, qt.Equals, "1_initial.sql")
+	c.Assert(files[0].Version, qt.Equals, int64(1))
+	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
+
+	files, err = DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(files, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1_initial.sql`)
 }
 
 func TestDiscoverMigrationFilesAutoPrefersPtahWhenPresent(t *testing.T) {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -2,6 +2,7 @@ package migrator
 
 import (
 	"testing"
+	"testing/fstest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -166,6 +167,73 @@ func TestParseMigrationFileName(t *testing.T) {
 	}
 }
 
+func TestParseAtlasMigrationFileName(t *testing.T) {
+	c := qt.New(t)
+
+	migrationFile, err := ParseAtlasMigrationFileName("20220318104614_team_A.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(20220318104614))
+	c.Assert(migrationFile.Name, qt.Equals, "Team A")
+	c.Assert(migrationFile.Direction, qt.Equals, "up")
+	c.Assert(migrationFile.Extension, qt.Equals, ".sql")
+	c.Assert(migrationFile.Format, qt.Equals, MigrationDirFormatAtlas)
+
+	_, err = ParseAtlasMigrationFileName("0000000001_cleanup.sql")
+	c.Assert(err, qt.ErrorMatches, "invalid Atlas migration file name format")
+	_, err = ParseAtlasMigrationFileName("20220318104614_team_A.up.sql")
+	c.Assert(err, qt.ErrorMatches, "Atlas migration file name must not use Ptah direction suffixes")
+}
+
+func TestDiscoverMigrationFilesAtlasAuto(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20220318104615_add_users.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"20220318104614_team_A.sql":    &fstest.MapFile{Data: []byte("CREATE TABLE teams (id INT);\n")},
+		"atlas.sum":                    &fstest.MapFile{Data: []byte("ignored\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	c.Assert(files[0].Path, qt.Equals, "20220318104614_team_A.sql")
+	c.Assert(files[0].Version, qt.Equals, int64(20220318104614))
+	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
+	c.Assert(files[1].Path, qt.Equals, "20220318104615_add_users.sql")
+}
+
+func TestDiscoverMigrationFilesAutoPrefersPtahWhenPresent(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_init.up.sql":       &fstest.MapFile{Data: []byte("CREATE TABLE t (id INT);\n")},
+		"0000000001_init.down.sql":     &fstest.MapFile{Data: []byte("DROP TABLE t;\n")},
+		"20220318104614_atlas_way.sql": &fstest.MapFile{Data: []byte("CREATE TABLE atlas_t (id INT);\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	for _, file := range files {
+		c.Assert(file.Format, qt.Equals, MigrationDirFormatPtah)
+	}
+}
+
+func TestDiscoverMigrationFilesUnknownOnlySQLErrors(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"cleanup.sql":           &fstest.MapFile{Data: []byte("DROP TABLE users;\n")},
+		"0000000001_legacy.sql": &fstest.MapFile{Data: []byte("DROP TABLE audit;\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(files, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: .*`)
+	c.Assert(err.Error(), qt.Contains, "cleanup.sql")
+	c.Assert(err.Error(), qt.Contains, "0000000001_legacy.sql")
+}
+
 func TestValidateMigrationFileName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -207,7 +275,7 @@ func TestValidateMigrationFileName(t *testing.T) {
 func TestGenerateMigrationFileName(t *testing.T) {
 	tests := []struct {
 		name        string
-		version     int
+		version     int64
 		description string
 		direction   string
 		expected    string
@@ -264,7 +332,7 @@ func TestMigrationPair(t *testing.T) {
 	c.Assert(completePair.IsComplete(), qt.IsTrue)
 	c.Assert(completePair.HasUp(), qt.IsTrue)
 	c.Assert(completePair.HasDown(), qt.IsTrue)
-	c.Assert(completePair.GetVersion(), qt.Equals, 1)
+	c.Assert(completePair.GetVersion(), qt.Equals, int64(1))
 	c.Assert(completePair.GetDescription(), qt.Equals, "Create Users Table")
 
 	// Test incomplete pair (only up)
@@ -276,7 +344,7 @@ func TestMigrationPair(t *testing.T) {
 	c.Assert(upOnlyPair.IsComplete(), qt.IsFalse)
 	c.Assert(upOnlyPair.HasUp(), qt.IsTrue)
 	c.Assert(upOnlyPair.HasDown(), qt.IsFalse)
-	c.Assert(upOnlyPair.GetVersion(), qt.Equals, 1)
+	c.Assert(upOnlyPair.GetVersion(), qt.Equals, int64(1))
 	c.Assert(upOnlyPair.GetDescription(), qt.Equals, "Create Users Table")
 
 	// Test incomplete pair (only down)
@@ -288,7 +356,7 @@ func TestMigrationPair(t *testing.T) {
 	c.Assert(downOnlyPair.IsComplete(), qt.IsFalse)
 	c.Assert(downOnlyPair.HasUp(), qt.IsFalse)
 	c.Assert(downOnlyPair.HasDown(), qt.IsTrue)
-	c.Assert(downOnlyPair.GetVersion(), qt.Equals, 1)
+	c.Assert(downOnlyPair.GetVersion(), qt.Equals, int64(1))
 	c.Assert(downOnlyPair.GetDescription(), qt.Equals, "Create Users Table")
 
 	// Test empty pair
@@ -297,7 +365,7 @@ func TestMigrationPair(t *testing.T) {
 	c.Assert(emptyPair.IsComplete(), qt.IsFalse)
 	c.Assert(emptyPair.HasUp(), qt.IsFalse)
 	c.Assert(emptyPair.HasDown(), qt.IsFalse)
-	c.Assert(emptyPair.GetVersion(), qt.Equals, 0)
+	c.Assert(emptyPair.GetVersion(), qt.Equals, int64(0))
 	c.Assert(emptyPair.GetDescription(), qt.Equals, "")
 }
 
@@ -318,7 +386,7 @@ func TestGroupMigrationFiles(t *testing.T) {
 	// Check version 1 (complete pair)
 	pair1 := groups[1]
 	c.Assert(pair1.IsComplete(), qt.IsTrue)
-	c.Assert(pair1.GetVersion(), qt.Equals, 1)
+	c.Assert(pair1.GetVersion(), qt.Equals, int64(1))
 
 	// Check version 2 (only up)
 	pair2 := groups[2]
@@ -336,7 +404,7 @@ func TestGroupMigrationFiles(t *testing.T) {
 func TestValidateMigrationPairs(t *testing.T) {
 	c := qt.New(t)
 
-	pairs := map[int]MigrationPair{
+	pairs := map[int64]MigrationPair{
 		1: {
 			Up:   &MigrationFile{Version: 1, Direction: "up"},
 			Down: &MigrationFile{Version: 1, Direction: "down"},
@@ -354,34 +422,34 @@ func TestValidateMigrationPairs(t *testing.T) {
 	incomplete := ValidateMigrationPairs(pairs)
 
 	c.Assert(incomplete, qt.HasLen, 2)
-	c.Assert(incomplete, qt.Contains, 2)
-	c.Assert(incomplete, qt.Contains, 3)
+	c.Assert(incomplete, qt.Contains, int64(2))
+	c.Assert(incomplete, qt.Contains, int64(3))
 }
 
 func TestFindMigrationGaps(t *testing.T) {
 	c := qt.New(t)
 
 	// Test with no gaps
-	versions1 := []int{1, 2, 3, 4, 5}
+	versions1 := []int64{1, 2, 3, 4, 5}
 	gaps1 := FindMigrationGaps(versions1)
 	c.Assert(gaps1, qt.HasLen, 0)
 
 	// Test with gaps
-	versions2 := []int{1, 3, 6, 8}
+	versions2 := []int64{1, 3, 6, 8}
 	gaps2 := FindMigrationGaps(versions2)
 	c.Assert(gaps2, qt.HasLen, 4) // Should be 4: gaps at 2, 4, 5, 7
-	c.Assert(gaps2, qt.Contains, 2)
-	c.Assert(gaps2, qt.Contains, 4)
-	c.Assert(gaps2, qt.Contains, 5)
-	c.Assert(gaps2, qt.Contains, 7)
+	c.Assert(gaps2, qt.Contains, int64(2))
+	c.Assert(gaps2, qt.Contains, int64(4))
+	c.Assert(gaps2, qt.Contains, int64(5))
+	c.Assert(gaps2, qt.Contains, int64(7))
 
 	// Test with empty slice
-	versions3 := []int{}
+	versions3 := []int64{}
 	gaps3 := FindMigrationGaps(versions3)
 	c.Assert(gaps3, qt.IsNil)
 
 	// Test with single version
-	versions4 := []int{1}
+	versions4 := []int64{1}
 	gaps4 := FindMigrationGaps(versions4)
 	c.Assert(gaps4, qt.HasLen, 0)
 }


### PR DESCRIPTION
## Summary

- Add migration directory format discovery for `auto`, `ptah`, and `atlas`, including explicit CLI flags for migrate up/down/status/hash/validate.
- Load Atlas-style `YYYYMMDDHHMMSS_description.sql` files as forward migrations, reject unknown-only SQL directories instead of silently loading zero migrations, and make Atlas rollback fail with an explicit no-down-migration error.
- Move migration versions and revision table storage to `int64`/`BIGINT` so 14-digit Atlas versions apply on Postgres/MySQL without overflow.
- Route migratesum, lint filtering, destructive pending checks, and shadow prior-migration loading through the same format-aware behavior.
- Document `--dir-format` usage and Atlas up-only limitations.

Fixes #273.

## Validation

- `go test ./migration/migrator ./migration/migratesum ./migration/lint ./migration/generator ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./cmd/migratehash ./cmd/migratevalidate ./integration`
- `go test ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable MYSQL_TEST_DSN=ptah_user:ptah_password@tcp(127.0.0.1:3310)/ptah_test go test ./migration/migrator -run 'TestAtlasFormat_(Postgres|MySQL)Integration' -count=1 -v`
