### PR TITLE
Support Atlas txtar down migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,8 +638,26 @@ Ptah's paired files (`NNNNNNNNNN_description.up.sql` and
 Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when a directory should
-be interpreted explicitly. Atlas-style files are forward migrations only;
-`migrate-down` reports a clear "no down migration" error for them.
+be interpreted explicitly. Ordinary Atlas files are forward migrations. Atlas
+txtar files can also carry an embedded `down.sql` section that Ptah executes on
+rollback.
+
+```sql
+-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+```
+
+If an Atlas migration has no embedded `down.sql`, `migrate-down` fails with a
+typed error explaining that Atlas dynamic down-plan synthesis is not implemented
+yet. This is different from transaction rollback: transaction rollback undoes a
+failed in-progress migration automatically, while `migrate-down` reverts an
+already-recorded migration using an explicit Ptah `.down.sql` file or an Atlas
+txtar `down.sql` section.
 
 #### Apply Migrations
 Apply all pending migrations to bring database up to latest version:
@@ -698,6 +716,7 @@ a warning.
 - ✅ Detects out-of-order pending migrations below the current version
 - ✅ Each migration runs in its own transaction unless explicitly marked `no_transaction`
 - ✅ Automatic rollback on failure
+- ✅ Executes Ptah paired down files and Atlas txtar `down.sql` sections
 - ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
 - ✅ Supports dry-run mode for preview
 - ✅ Supports per-migration lock and statement timeout directives

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -74,8 +74,25 @@ prefers Ptah paired files (`NNNNNNNNNN_description.up.sql` and
 Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when detection should be
-explicit. Atlas-style files are forward migrations only; `migrate-down` returns a
-clear no-down-migration error for them.
+explicit. Ordinary Atlas files are forward migrations. Atlas txtar files can also
+embed a `down.sql` section that Ptah executes during rollback:
+
+```sql
+-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+```
+
+If an Atlas migration does not provide `down.sql`, `migrate-down` returns a typed
+error explaining that Atlas dynamic down-plan synthesis is not implemented yet.
+This is distinct from transaction rollback on a failed migration: transaction
+rollback undoes an in-progress failure, Ptah paired `.down.sql` files and Atlas
+txtar `down.sql` sections revert already-applied migrations, and Atlas dynamic
+`migrate down` would synthesize a downgrade plan from database/dev state.
 
 ### Migrate Up
 Apply all pending migrations:

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -34,6 +34,27 @@ func TestAtlasFormat_MySQLIntegration(t *testing.T) {
 	runAtlasFormatIntegration(t, dbURL)
 }
 
+func TestAtlasTxtarDown_PostgresIntegration(t *testing.T) {
+	runAtlasTxtarDownIntegration(t, postgresTestURL(t))
+}
+
+func TestAtlasTxtarDown_MySQLIntegration(t *testing.T) {
+	dbURL := os.Getenv("MYSQL_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("MYSQL_TEST_URL")
+	}
+	if dbURL == "" {
+		t.Skip("MYSQL_TEST_DSN or MYSQL_TEST_URL not set")
+	}
+	if strings.Contains(dbURL, "@tcp(") && !strings.HasPrefix(dbURL, "mysql://") {
+		dbURL = "mysql://" + dbURL
+	}
+	if !strings.HasPrefix(dbURL, "mysql://") {
+		t.Skip("MySQL URL required for Atlas migration integration test")
+	}
+	runAtlasTxtarDownIntegration(t, dbURL)
+}
+
 func runAtlasFormatIntegration(t *testing.T, dbURL string) {
 	t.Helper()
 
@@ -73,7 +94,48 @@ func runAtlasFormatIntegration(t *testing.T, dbURL string) {
 	c.Assert(status.HasPendingChanges, qt.IsFalse)
 
 	err = mig.MigrateDownTo(ctx, 20220318104614)
-	c.Assert(err, qt.ErrorMatches, `.*migration 20220318104615 has no down migration; directory format atlas does not support down migrations.*`)
+	c.Assert(err, qt.ErrorMatches, `.*migration 20220318104615 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet.*`)
+	var noDown *migrator.AtlasDownNotImplementedError
+	c.Assert(err, qt.ErrorAs, &noDown)
+	c.Assert(noDown.Version, qt.Equals, int64(20220318104615))
+}
+
+func runAtlasTxtarDownIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	cleanupIssue290(t, conn)
+	defer cleanupIssue290(t, conn)
+
+	fsys := fstest.MapFS{
+		"20240305171146_seed_widget.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+CREATE TABLE ptah_issue_290_widgets (id INT PRIMARY KEY, name VARCHAR(64) NOT NULL);
+INSERT INTO ptah_issue_290_widgets (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DROP TABLE ptah_issue_290_widgets;
+`)},
+	}
+	mig, err := migrator.NewFSMigrator(conn, fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithMigrationsTable("", "schema_migrations_issue_290")
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue290WidgetsCount(t, conn), qt.Equals, 1)
+	c.Assert(issue290Versions(t, conn), qt.DeepEquals, []int64{20240305171146})
+
+	err = mig.MigrateDownTo(ctx, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue290Versions(t, conn), qt.HasLen, 0)
+	c.Assert(issue290WidgetTableExists(t, conn), qt.IsFalse)
 }
 
 func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
@@ -83,6 +145,17 @@ func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 		"DROP TABLE IF EXISTS ptah_issue_273_users",
 		"DROP TABLE IF EXISTS ptah_issue_273_teams",
 		"DROP TABLE IF EXISTS schema_migrations_issue_273",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func cleanupIssue290(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ptah_issue_290_widgets",
+		"DROP TABLE IF EXISTS schema_migrations_issue_290",
 	} {
 		_, _ = conn.ExecContext(context.Background(), statement)
 	}
@@ -126,4 +199,38 @@ func issue273Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
 	}
 	qt.Assert(t, rows.Err(), qt.IsNil)
 	return versions
+}
+
+func issue290WidgetsCount(t *testing.T, conn *dbschema.DatabaseConnection) int {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM ptah_issue_290_widgets").Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func issue290Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
+	t.Helper()
+
+	rows, err := conn.Query("SELECT version FROM schema_migrations_issue_290 ORDER BY version")
+	qt.Assert(t, err, qt.IsNil)
+	defer rows.Close()
+
+	var versions []int64
+	for rows.Next() {
+		var version int64
+		qt.Assert(t, rows.Scan(&version), qt.IsNil)
+		versions = append(versions, version)
+	}
+	qt.Assert(t, rows.Err(), qt.IsNil)
+	return versions
+}
+
+func issue290WidgetTableExists(t *testing.T, conn *dbschema.DatabaseConnection) bool {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM ptah_issue_290_widgets").Scan(&count)
+	return err == nil
 }

--- a/migration/migrator/interceptor_test.go
+++ b/migration/migrator/interceptor_test.go
@@ -88,6 +88,29 @@ func TestMigrationFuncFromSQLFilenameWithInterceptor_ErrorAbortsMigration(t *tes
 	c.Assert(err, qt.ErrorMatches, "failed to execute migration SQL: .*")
 }
 
+func TestMigrationFuncFromSQLFilenameWithInterceptor_AtlasTxtarExecutesMigrationSectionOnly(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240305171146_seed.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+`)},
+	}
+	interceptor := &recordingInterceptor{}
+
+	fn := migrator.MigrationFuncFromSQLFilenameWithInterceptor("20240305171146_seed.sql", fsys, interceptor)
+	err := fn(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{
+		"INSERT INTO users (id, name) VALUES (1, 'Alice')",
+	})
+}
+
 func TestMigrationFuncFromSQLFilenameWithInterceptor_ValidateDirectivesRunsBeforeAnyStatement(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -187,7 +187,7 @@ func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
 	migrations := make([]*Migration, 0, len(files))
 	for i := range files {
 		migrationFile := files[i]
-		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+		atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
 		if err != nil {
 			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 		}
@@ -195,14 +195,26 @@ func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
 		migration := &Migration{
 			Version:       migrationFile.Version,
 			Description:   migrationFile.Name,
-			UpTimeouts:    up.timeouts,
-			NoTransaction: up.noTransaction,
+			UpTimeouts:    atlasFile.up.timeouts,
+			NoTransaction: atlasFile.up.noTransaction,
 		}
 		migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return up.fn(ctx, conn, migration.executionMode())
+			return atlasFile.up.fn(ctx, conn, migration.executionMode())
 		}
-		migration.Down = func(_ context.Context, _ *dbschema.DatabaseConnection) error {
-			return fmt.Errorf("migration %d has no down migration; directory format atlas does not support down migrations without %s", migration.Version, "atlas txtar down.sql")
+		if atlasFile.hasDown {
+			migration.DownTimeouts = atlasFile.down.timeouts
+			migration.NoTransaction = migration.NoTransaction || atlasFile.down.noTransaction
+			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+				return atlasFile.down.fn(ctx, conn, migration.executionMode())
+			}
+		} else {
+			migration.downUnavailable = true
+			migration.Down = func(_ context.Context, _ *dbschema.DatabaseConnection) error {
+				return &AtlasDownNotImplementedError{
+					Version:     migration.Version,
+					Description: migration.Description,
+				}
+			}
 		}
 		migrations = append(migrations, migration)
 	}

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -175,7 +175,11 @@ func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
 	c.Assert(migrations[1].Description, qt.Equals, "Add Users")
 
 	err = migrations[0].Down(context.Background(), nil)
-	c.Assert(err, qt.ErrorMatches, `migration 20220318104614 has no down migration; directory format atlas does not support down migrations.*`)
+	c.Assert(err, qt.ErrorMatches, `migration 20220318104614 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet; add an atlas txtar down.sql section or migrate down manually`)
+	var noDown *migrator.AtlasDownNotImplementedError
+	c.Assert(err, qt.ErrorAs, &noDown)
+	c.Assert(noDown.Version, qt.Equals, int64(20220318104614))
+	c.Assert(noDown.Description, qt.Equals, "Team A")
 }
 
 func TestNewFSMigrationProvider_UnknownOnlySQLFilesError(t *testing.T) {

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -241,11 +241,15 @@ func parseAtlasTxtarSQL(filename, sql string) (atlasTxtarSQL, bool, error) {
 	for _, line := range strings.SplitAfter(sql, "\n") {
 		section, isMarker := parseAtlasTxtarSectionMarker(line)
 		if isMarker {
-			if _, exists := sections[section]; exists {
-				return atlasTxtarSQL{}, true, fmt.Errorf("invalid Atlas txtar migration %s: duplicate %s section", filename, section)
+			if isAtlasTxtarSQLSection(section) {
+				if _, exists := sections[section]; exists {
+					return atlasTxtarSQL{}, true, fmt.Errorf("invalid Atlas txtar migration %s: duplicate %s section", filename, section)
+				}
+				sections[section] = &strings.Builder{}
+				currentSection = section
+			} else {
+				currentSection = ""
 			}
-			sections[section] = &strings.Builder{}
-			currentSection = section
 			sawSection = true
 			continue
 		}
@@ -295,7 +299,21 @@ func parseAtlasTxtarSectionMarker(line string) (string, bool) {
 		return "", false
 	}
 	section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "-- "), " --"))
-	return section, section != ""
+	if isAtlasTxtarSQLSection(section) || looksAtlasTxtarFileSection(section) {
+		return section, true
+	}
+	return "", false
+}
+
+func isAtlasTxtarSQLSection(section string) bool {
+	return section == atlasTxtarMigrationSection || section == atlasTxtarDownSection
+}
+
+func looksAtlasTxtarFileSection(section string) bool {
+	if len(strings.Fields(section)) != 1 {
+		return false
+	}
+	return strings.ContainsAny(section, `./\`)
 }
 
 // NoopMigrationFunc is a no-op migration function

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -55,6 +55,18 @@ type sqlMigrationFile struct {
 	noTransaction bool
 }
 
+type atlasSQLMigrationFile struct {
+	up      sqlMigrationFile
+	down    sqlMigrationFile
+	hasDown bool
+}
+
+type atlasTxtarSQL struct {
+	migrationSQL string
+	downSQL      string
+	hasDown      bool
+}
+
 func (f sqlMigrationFile) executionMode() migrationExecutionMode {
 	if f.noTransaction {
 		return migrationExecutionNoTransaction
@@ -68,6 +80,27 @@ func (f sqlMigrationFile) executionMode() migrationExecutionMode {
 // statements in the same migration.
 const DirectiveNoTransaction = "no_transaction"
 
+const (
+	atlasTxtarDirective        = "-- atlas:txtar"
+	atlasTxtarMigrationSection = "migration.sql"
+	atlasTxtarDownSection      = "down.sql"
+)
+
+// AtlasDownNotImplementedError reports an Atlas migration that lacks an
+// embedded down.sql section. Ptah does not yet synthesize Atlas dynamic down
+// plans from the current database state and a dev database.
+type AtlasDownNotImplementedError struct {
+	Version     int64
+	Description string
+}
+
+func (e *AtlasDownNotImplementedError) Error() string {
+	return fmt.Sprintf(
+		"migration %d has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet; add an atlas txtar down.sql section or migrate down manually",
+		e.Version,
+	)
+}
+
 // MigrationFuncFromSQLFilename returns a migration function that reads SQL from a file
 // in the provided filesystem and executes it using the database connection
 func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
@@ -79,21 +112,11 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 // behaves exactly like MigrationFuncFromSQLFilename.
 func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc {
 	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		sql, err := fs.ReadFile(fsys, filename)
+		migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor)
 		if err != nil {
-			return fmt.Errorf("failed to read migration file: %w", err)
+			return err
 		}
-
-		noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(string(sql)))
-		if err != nil {
-			return fmt.Errorf("invalid migration directives in %s: %w", filename, err)
-		}
-
-		mode := migrationExecutionTransactional
-		if noTransaction {
-			mode = migrationExecutionNoTransaction
-		}
-		return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor, mode)
+		return migrationFile.fn(ctx, conn, migrationFile.executionMode())
 	}
 }
 
@@ -130,23 +153,149 @@ func migrationFuncFromSQLFilenameWithMetadata(
 		return sqlMigrationFile{}, fmt.Errorf("failed to read migration file: %w", err)
 	}
 
-	timeouts, err := parseMigrationTimeoutDirectives(string(sql))
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, string(sql), interceptor)
+	if err != nil {
+		return sqlMigrationFile{}, err
+	}
+	if ok {
+		return atlasMigrationFile.up, nil
+	}
+
+	return migrationFuncFromSQLStringWithMetadata(filename, string(sql), interceptor)
+}
+
+func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
+	filename string,
+	fsys fs.FS,
+	interceptor StatementInterceptor,
+) (atlasSQLMigrationFile, error) {
+	sql, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return atlasSQLMigrationFile{}, fmt.Errorf("failed to read migration file: %w", err)
+	}
+
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, string(sql), interceptor)
+	if err != nil {
+		return atlasSQLMigrationFile{}, err
+	}
+	if ok {
+		return atlasMigrationFile, nil
+	}
+
+	up, err := migrationFuncFromSQLStringWithMetadata(filename, string(sql), interceptor)
+	if err != nil {
+		return atlasSQLMigrationFile{}, err
+	}
+	return atlasSQLMigrationFile{up: up}, nil
+}
+
+func atlasSQLMigrationFileFromSQL(filename, sql string, interceptor StatementInterceptor) (atlasSQLMigrationFile, bool, error) {
+	parsed, ok, err := parseAtlasTxtarSQL(filename, sql)
+	if err != nil || !ok {
+		return atlasSQLMigrationFile{}, ok, err
+	}
+
+	up, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarMigrationSection, parsed.migrationSQL, interceptor)
+	if err != nil {
+		return atlasSQLMigrationFile{}, true, err
+	}
+	atlasMigrationFile := atlasSQLMigrationFile{up: up}
+	if parsed.hasDown {
+		down, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarDownSection, parsed.downSQL, interceptor)
+		if err != nil {
+			return atlasSQLMigrationFile{}, true, err
+		}
+		atlasMigrationFile.down = down
+		atlasMigrationFile.hasDown = true
+	}
+	return atlasMigrationFile, true, nil
+}
+
+func migrationFuncFromSQLStringWithMetadata(filename, sql string, interceptor StatementInterceptor) (sqlMigrationFile, error) {
+	timeouts, err := parseMigrationTimeoutDirectives(sql)
 	if err != nil {
 		return sqlMigrationFile{}, err
 	}
 
-	noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(string(sql)))
+	noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(sql))
 	if err != nil {
 		return sqlMigrationFile{}, fmt.Errorf("invalid migration directives in %s: %w", filename, err)
 	}
-
 	return sqlMigrationFile{
 		fn: func(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
-			return executeMigrationFileSQL(ctx, conn, filename, string(sql), interceptor, mode)
+			return executeMigrationFileSQL(ctx, conn, filename, sql, interceptor, mode)
 		},
 		timeouts:      timeouts,
 		noTransaction: noTransaction,
 	}, nil
+}
+
+func parseAtlasTxtarSQL(filename, sql string) (atlasTxtarSQL, bool, error) {
+	if !hasAtlasTxtarDirective(sql) {
+		return atlasTxtarSQL{}, false, nil
+	}
+
+	sections := make(map[string]*strings.Builder)
+	var currentSection string
+	sawSection := false
+	for _, line := range strings.SplitAfter(sql, "\n") {
+		section, isMarker := parseAtlasTxtarSectionMarker(line)
+		if isMarker {
+			if _, exists := sections[section]; exists {
+				return atlasTxtarSQL{}, true, fmt.Errorf("invalid Atlas txtar migration %s: duplicate %s section", filename, section)
+			}
+			sections[section] = &strings.Builder{}
+			currentSection = section
+			sawSection = true
+			continue
+		}
+
+		if !sawSection {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+				continue
+			}
+			return atlasTxtarSQL{}, true, fmt.Errorf("invalid Atlas txtar migration %s: SQL appears before the first txtar section", filename)
+		}
+
+		if builder := sections[currentSection]; builder != nil {
+			builder.WriteString(line)
+		}
+	}
+
+	migrationSection := sections[atlasTxtarMigrationSection]
+	if migrationSection == nil {
+		return atlasTxtarSQL{}, true, fmt.Errorf("invalid Atlas txtar migration %s: missing migration.sql section", filename)
+	}
+	downSection := sections[atlasTxtarDownSection]
+	if downSection == nil {
+		return atlasTxtarSQL{migrationSQL: migrationSection.String()}, true, nil
+	}
+	return atlasTxtarSQL{
+		migrationSQL: migrationSection.String(),
+		downSQL:      downSection.String(),
+		hasDown:      true,
+	}, true, nil
+}
+
+func hasAtlasTxtarDirective(sql string) bool {
+	for line := range strings.SplitSeq(sql, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		return trimmed == atlasTxtarDirective
+	}
+	return false
+}
+
+func parseAtlasTxtarSectionMarker(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "-- ") || !strings.HasSuffix(trimmed, " --") {
+		return "", false
+	}
+	section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "-- "), " --"))
+	return section, section != ""
 }
 
 // NoopMigrationFunc is a no-op migration function
@@ -156,12 +305,13 @@ func NoopMigrationFunc(_ctx context.Context, _conn *dbschema.DatabaseConnection)
 
 // Migration represents a database migration
 type Migration struct {
-	Version      int64
-	Description  string
-	Up           MigrationFunc
-	Down         MigrationFunc
-	UpTimeouts   MigrationTimeouts
-	DownTimeouts MigrationTimeouts
+	Version         int64
+	Description     string
+	Up              MigrationFunc
+	Down            MigrationFunc
+	UpTimeouts      MigrationTimeouts
+	DownTimeouts    MigrationTimeouts
+	downUnavailable bool
 	// NoTransaction runs the migration body and metadata update outside the
 	// normal per-migration transaction. Use this only for statements that cannot
 	// run transactionally; ordinary migrations should leave it false so dry-run,

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -249,6 +249,46 @@ SELECT 1;
 	c.Assert(err, qt.ErrorMatches, `invalid Atlas txtar migration 20240305171146_seed.sql: SQL appears before the first txtar section`)
 }
 
+func TestParseAtlasTxtarSQLIgnoresUnknownCommentMarkers(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+
+-- migration.sql --
+-- keep this comment --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(parsed.migrationSQL, qt.Contains, "-- keep this comment --")
+	c.Assert(parsed.migrationSQL, qt.Contains, "INSERT INTO users")
+	c.Assert(parsed.hasDown, qt.IsTrue)
+}
+
+func TestParseAtlasTxtarSQLIgnoresUnknownFileSections(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- schema.sql --
+THIS IS NOT MIGRATION SQL;
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(parsed.migrationSQL, qt.Contains, "INSERT INTO users")
+	c.Assert(parsed.migrationSQL, qt.Not(qt.Contains), "THIS IS NOT MIGRATION SQL")
+	c.Assert(parsed.downSQL, qt.Contains, "DELETE FROM users")
+}
+
 func TestParseMigrationTimeoutDirectives(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -191,6 +191,64 @@ func TestMigrationFuncFromSQLFilename_FileNotFound(t *testing.T) {
 	c.Assert(err.Error(), qt.Contains, "failed to read migration file")
 }
 
+func TestParseAtlasTxtarSQL(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(parsed.hasDown, qt.IsTrue)
+	c.Assert(parsed.migrationSQL, qt.Contains, "INSERT INTO users")
+	c.Assert(parsed.downSQL, qt.Contains, "DELETE FROM users")
+}
+
+func TestParseAtlasTxtarSQLWithoutDown(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+
+-- migration.sql --
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(parsed.hasDown, qt.IsFalse)
+	c.Assert(parsed.migrationSQL, qt.Contains, "INSERT INTO users")
+	c.Assert(parsed.downSQL, qt.Equals, "")
+}
+
+func TestParseAtlasTxtarSQLRequiresMigrationSection(t *testing.T) {
+	c := qt.New(t)
+
+	_, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+
+-- down.sql --
+DELETE FROM users WHERE id = 1;
+`)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(err, qt.ErrorMatches, `invalid Atlas txtar migration 20240305171146_seed.sql: missing migration.sql section`)
+}
+
+func TestParseAtlasTxtarSQLRejectsSQLBeforeSection(t *testing.T) {
+	c := qt.New(t)
+
+	_, ok, err := parseAtlasTxtarSQL("20240305171146_seed.sql", `-- atlas:txtar
+INSERT INTO users (id, name) VALUES (1, 'Alice');
+
+-- migration.sql --
+SELECT 1;
+`)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(err, qt.ErrorMatches, `invalid Atlas txtar migration 20240305171146_seed.sql: SQL appears before the first txtar section`)
+}
+
 func TestParseMigrationTimeoutDirectives(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -444,6 +444,12 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error
 
 	for _, migration := range migrationsToRollback {
 		m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
+		if migration.downUnavailable {
+			if err := migration.Down(ctx, m.conn); err != nil {
+				return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
+			}
+			continue
+		}
 		if migration.NoTransaction {
 			if err := m.rollbackMigrationNoTransaction(ctx, migration, deleteSQL); err != nil {
 				return err


### PR DESCRIPTION
## Summary
- parse Atlas txtar migration files and execute the embedded migration.sql section on migrate-up
- execute embedded down.sql sections on migrate-down, while ordinary Atlas files return a typed dynamic-down-not-implemented error
- document Ptah down files, Atlas txtar down.sql, transaction rollback, and the dynamic Atlas down boundary

## Tests
- go test ./migration/migrator ./migration/migratesum ./migration/lint ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./cmd/migratehash ./cmd/migratevalidate
- POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable MYSQL_TEST_DSN=ptah_user:ptah_password@tcp(127.0.0.1:3310)/ptah_test GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator -run 'TestAtlas(Format|TxtarDown)_(Postgres|MySQL)Integration' -count=1 -v
- go test ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- go tool qtlint ./...

Closes #290