### PR TITLE
Harden Atlas txtar migration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,12 +652,24 @@ INSERT INTO users (id, name) VALUES (1, 'Alice');
 DELETE FROM users WHERE id = 1;
 ```
 
+For Atlas txtar migrations, Ptah executes only the `migration.sql` section for
+`migrate-up` and only the `down.sql` section for `migrate-down`. Other embedded
+txtar files, such as `schema.sql`, are ignored by the migrator; ordinary SQL
+comments that look like `-- keep this comment --` remain comments, not txtar
+section boundaries. Ptah's txtar support is intentionally limited to Atlas SQL
+migration containers and is not a general-purpose txtar parser.
+
 If an Atlas migration has no embedded `down.sql`, `migrate-down` fails with a
 typed error explaining that Atlas dynamic down-plan synthesis is not implemented
 yet. This is different from transaction rollback: transaction rollback undoes a
 failed in-progress migration automatically, while `migrate-down` reverts an
 already-recorded migration using an explicit Ptah `.down.sql` file or an Atlas
 txtar `down.sql` section.
+
+`-- +ptah` directives inside `migration.sql` and `down.sql` are parsed per
+section for timeout and validation purposes. The current `no_transaction` model
+is still migration-level: if either direction opts out of transactions, Ptah
+treats the migration as non-transactional.
 
 #### Apply Migrations
 Apply all pending migrations to bring database up to latest version:

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -87,12 +87,24 @@ INSERT INTO users (id, name) VALUES (1, 'Alice');
 DELETE FROM users WHERE id = 1;
 ```
 
+For Atlas txtar migrations, Ptah executes only the `migration.sql` section for
+`migrate-up` and only the `down.sql` section for `migrate-down`. Other embedded
+txtar files, such as `schema.sql`, are ignored by the migrator; ordinary SQL
+comments that look like `-- keep this comment --` remain comments, not txtar
+section boundaries. Ptah's txtar support is intentionally limited to Atlas SQL
+migration containers and is not a general-purpose txtar parser.
+
 If an Atlas migration does not provide `down.sql`, `migrate-down` returns a typed
 error explaining that Atlas dynamic down-plan synthesis is not implemented yet.
 This is distinct from transaction rollback on a failed migration: transaction
 rollback undoes an in-progress failure, Ptah paired `.down.sql` files and Atlas
 txtar `down.sql` sections revert already-applied migrations, and Atlas dynamic
 `migrate down` would synthesize a downgrade plan from database/dev state.
+
+`-- +ptah` directives inside `migration.sql` and `down.sql` are parsed per
+section for timeout and validation purposes. The current `no_transaction` model
+is still migration-level: if either direction opts out of transactions, Ptah
+treats the migration as non-transactional.
 
 ### Migrate Up
 Apply all pending migrations:

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -180,6 +181,106 @@ func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
 	c.Assert(err, qt.ErrorAs, &noDown)
 	c.Assert(noDown.Version, qt.Equals, int64(20220318104614))
 	c.Assert(noDown.Description, qt.Equals, "Team A")
+}
+
+func TestNewFSMigrationProvider_AtlasTxtarSectionsAndDirectives(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240305171147_section_boundary.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+-- +ptah lock_timeout=3s
+-- keep this marker-like SQL comment --
+CREATE TABLE users (id INT PRIMARY KEY);
+
+-- schema.sql --
+SELECT 'ptah_extra_section_sentinel';
+
+-- down.sql --
+-- +ptah statement_timeout=30s
+SELECT 'ptah_down_section_sentinel';
+DROP TABLE users;
+`)},
+	}
+	interceptor := &recordingInterceptor{}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementInterceptor(interceptor),
+	)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	migration := migrations[0]
+	c.Assert(migration.UpTimeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(migration.UpTimeouts.LockTimeout, qt.Equals, 3*time.Second)
+	c.Assert(migration.DownTimeouts.HasStatementTimeout, qt.IsTrue)
+	c.Assert(migration.DownTimeouts.StatementTimeout, qt.Equals, 30*time.Second)
+
+	err = migration.Up(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{
+		"CREATE TABLE users (id INT PRIMARY KEY)",
+	})
+	c.Assert(interceptor.directives, qt.DeepEquals, []map[string]string{
+		{"lock_timeout": "3s"},
+	})
+
+	interceptor.statements = nil
+	interceptor.directives = nil
+	err = migration.Down(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{
+		"SELECT 'ptah_down_section_sentinel'",
+		"DROP TABLE users",
+	})
+	c.Assert(interceptor.directives, qt.DeepEquals, []map[string]string{
+		{"statement_timeout": "30s"},
+		{"statement_timeout": "30s"},
+	})
+}
+
+func TestNewFSMigrationProvider_AtlasTxtarDownInvalidDirective(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240305171147_invalid_down_directive.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+CREATE TABLE users (id INT PRIMARY KEY);
+
+-- down.sql --
+-- +ptah no_transaction=maybe
+DROP TABLE users;
+`)},
+	}
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(provider, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `failed to load Atlas migration 20240305171147_invalid_down_directive.sql: invalid migration directives in 20240305171147_invalid_down_directive.sql#down.sql: invalid \+ptah no_transaction value "maybe": expected true or false`)
+}
+
+func TestNewFSMigrationProvider_AtlasTxtarDownNoTransactionIsMigrationLevel(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240305171147_down_no_transaction.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+CREATE TABLE users (id INT PRIMARY KEY);
+
+-- down.sql --
+-- +ptah no_transaction
+DROP TABLE users;
+`)},
+	}
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].NoTransaction, qt.IsTrue)
 }
 
 func TestNewFSMigrationProvider_UnknownOnlySQLFilesError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add provider-level Atlas txtar tests for section boundaries, per-section directives, invalid down directives, and migration-level no_transaction behavior
- document exact Atlas txtar semantics: only migration.sql and down.sql execute; unknown embedded files are ignored; marker-like SQL comments stay comments
- make the current txtar scope explicit: Ptah supports Atlas SQL migration containers, not general-purpose txtar archives

## Validation
- GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator -run 'TestNewFSMigrationProvider_AtlasTxtar|TestParseAtlasTxtarSQL' -count=1 -v
- GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator ./migration/migratesum ./migration/lint ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./cmd/migratehash ./cmd/migratevalidate
- GOCACHE=/private/tmp/ptah-go-cache go test ./...
- GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...
- GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...