### PR TITLE
Detect short Atlas versions with atlas.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,10 @@ Ptah provides a comprehensive migration system with versioning, rollback capabil
 Ptah migration directories use `--dir-format=auto` by default. Auto mode prefers
 Ptah's paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
-Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
+Atlas-style timestamp files such as `20220318104614_team_A.sql`. Short Atlas
+versions such as `1_initial.sql` are auto-detected when the directory contains
+`atlas.sum`; use `--dir-format=atlas` when you want to force Atlas parsing
+without an integrity file. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when a directory should
 be interpreted explicitly. Ordinary Atlas files are forward migrations. Atlas

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -71,7 +71,10 @@ DROP TABLE IF EXISTS users;
 Migration directory commands use `--dir-format=auto` by default. Auto mode
 prefers Ptah paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
-Atlas-style versioned files such as `20220318104614_team_A.sql`. Use
+Atlas-style timestamp files such as `20220318104614_team_A.sql`. Short Atlas
+versions such as `1_initial.sql` are auto-detected when the directory contains
+`atlas.sum`; use `--dir-format=atlas` when you want to force Atlas parsing
+without an integrity file. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when detection should be
 explicit. Ordinary Atlas files are forward migrations. Atlas txtar files can also

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -24,10 +24,10 @@ var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 // Atlas migration file naming pattern: version_description.sql.
 var atlasFileNameRe = regexp.MustCompile(`^(\d+)_(.+)(\.sql)$`)
 
-// Auto-detection stays stricter than explicit Atlas mode: Atlas versioned
-// directories commonly use 14-digit timestamp versions, and requiring more than
-// Ptah's 10-digit version width keeps legacy suffixless Ptah-looking files from
-// being auto-classified as Atlas migrations.
+// Auto-detection without atlas.sum stays stricter than explicit Atlas mode:
+// Atlas versioned directories commonly use 14-digit timestamp versions, and
+// requiring more than Ptah's 10-digit version width keeps legacy suffixless
+// Ptah-looking files from being auto-classified as Atlas migrations.
 var atlasAutoFileNameRe = regexp.MustCompile(`^(\d{11,})_(.+)(\.sql)$`)
 
 // MigrationDirFormat selects how a filesystem migration directory is parsed.
@@ -282,30 +282,51 @@ func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationF
 	}
 
 	var sqlFiles []string
-	var ptahFiles []MigrationFile
-	var atlasFiles []MigrationFile
+	hasAtlasSum := false
 	err = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if d.IsDir() || !strings.EqualFold(path.Ext(p), ".sql") {
+		if d.IsDir() {
 			return nil
 		}
 
+		if path.Base(p) == "atlas.sum" {
+			hasAtlasSum = true
+			return nil
+		}
+		if !strings.EqualFold(path.Ext(p), ".sql") {
+			return nil
+		}
 		sqlFiles = append(sqlFiles, p)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+
+	var ptahFiles []MigrationFile
+	var atlasFiles []MigrationFile
+	for _, p := range sqlFiles {
 		base := path.Base(p)
 		if migrationFile, err := ParseMigrationFileName(base); err == nil {
 			migrationFile.Path = p
 			ptahFiles = append(ptahFiles, *migrationFile)
 		}
-		if migrationFile, err := parseAtlasMigrationFileNameForFormat(base, format); err == nil {
+		if format == MigrationDirFormatPtah {
+			continue
+		}
+		if format == MigrationDirFormatAtlas || hasAtlasSum {
+			if migrationFile, err := ParseAtlasMigrationFileName(base); err == nil {
+				migrationFile.Path = p
+				atlasFiles = append(atlasFiles, *migrationFile)
+			}
+			continue
+		}
+		if migrationFile, err := ParseAtlasMigrationFileNameForAutoDetection(base); err == nil {
 			migrationFile.Path = p
 			atlasFiles = append(atlasFiles, *migrationFile)
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan migrations directory: %w", err)
 	}
 
 	files := selectMigrationFiles(format, ptahFiles, atlasFiles)
@@ -319,13 +340,6 @@ func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationF
 		return files[i].Path < files[j].Path
 	})
 	return files, nil
-}
-
-func parseAtlasMigrationFileNameForFormat(filename string, format MigrationDirFormat) (*MigrationFile, error) {
-	if format == MigrationDirFormatAtlas {
-		return ParseAtlasMigrationFileName(filename)
-	}
-	return ParseAtlasMigrationFileNameForAutoDetection(filename)
 }
 
 func normalizeMigrationDirFormat(format MigrationDirFormat) (MigrationDirFormat, error) {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -223,6 +223,26 @@ func TestDiscoverMigrationFilesAtlasExplicitAllowsShortVersions(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1_initial.sql`)
 }
 
+func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1_initial.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"2_second.sql":  &fstest.MapFile{Data: []byte("ALTER TABLE users ADD COLUMN name TEXT;\n")},
+		"atlas.sum":     &fstest.MapFile{Data: []byte("h1:fake\n1_initial.sql h1:fake\n2_second.sql h1:fake\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	c.Assert(files[0].Path, qt.Equals, "1_initial.sql")
+	c.Assert(files[0].Version, qt.Equals, int64(1))
+	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
+	c.Assert(files[1].Path, qt.Equals, "2_second.sql")
+	c.Assert(files[1].Version, qt.Equals, int64(2))
+	c.Assert(files[1].Format, qt.Equals, MigrationDirFormatAtlas)
+}
+
 func TestDiscoverMigrationFilesAutoPrefersPtahWhenPresent(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- auto-detect short Atlas versioned migration files when the directory carries `atlas.sum`
- keep suffixless short SQL files without `atlas.sum` as an error in auto mode
- document the auto-detection distinction between timestamp-style Atlas names and `atlas.sum`-backed short versions

## Why
The full Atlas conformance corpus includes real Atlas migration directories such as `1_initial.sql` plus `atlas.sum`. Explicit `--dir-format=atlas` already handled these, but `auto` still rejected them. Issue #273 calls for Atlas format auto-detection from directory contents, and `atlas.sum` is the directory-level signal that makes short versions safe to classify as Atlas.

## Validation
- `GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator -run 'TestDiscoverMigrationFiles|TestParseAtlasMigrationFileName|TestNewFSMigrationProvider_AtlasFormat|TestAtlasFormat' -count=1 -v`
- `GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator ./migration/migratesum ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./cmd/migratehash ./cmd/migratevalidate`
- `GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `git diff --check`
- `gopls go_diagnostics` on changed Go files
- conformance temp run with local Ptah replace: `make probe` drops from 275 to 270 unwaived gaps; `migdir-ingest` has 15 ok / 28 red, `sum-compat` has 22 ok / 22 red
