### PR TITLE
Accept bare Atlas versioned migration names

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,10 +635,11 @@ Ptah provides a comprehensive migration system with versioning, rollback capabil
 Ptah migration directories use `--dir-format=auto` by default. Auto mode prefers
 Ptah's paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
-Atlas-style timestamp files such as `20220318104614_team_A.sql`. Short Atlas
-versions such as `1_initial.sql` are auto-detected when the directory contains
-`atlas.sum`; use `--dir-format=atlas` when you want to force Atlas parsing
-without an integrity file. Use
+Atlas-style timestamp files such as `20220318104614_team_A.sql` or
+`20240112070806.sql`. Short Atlas versions such as `1_initial.sql` and `2.sql`
+are auto-detected when the directory contains `atlas.sum`; use
+`--dir-format=atlas` when you want to force Atlas parsing without an integrity
+file. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when a directory should
 be interpreted explicitly. Ordinary Atlas files are forward migrations. Atlas

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -71,10 +71,11 @@ DROP TABLE IF EXISTS users;
 Migration directory commands use `--dir-format=auto` by default. Auto mode
 prefers Ptah paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
-Atlas-style timestamp files such as `20220318104614_team_A.sql`. Short Atlas
-versions such as `1_initial.sql` are auto-detected when the directory contains
-`atlas.sum`; use `--dir-format=atlas` when you want to force Atlas parsing
-without an integrity file. Use
+Atlas-style timestamp files such as `20220318104614_team_A.sql` or
+`20240112070806.sql`. Short Atlas versions such as `1_initial.sql` and `2.sql`
+are auto-detected when the directory contains `atlas.sum`; use
+`--dir-format=atlas` when you want to force Atlas parsing without an integrity
+file. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when detection should be
 explicit. Ordinary Atlas files are forward migrations. Atlas txtar files can also

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -73,6 +73,9 @@ func runAtlasFormatIntegration(t *testing.T, dbURL string) {
 		"20220318104615_add_users.sql": &fstest.MapFile{Data: []byte(
 			"CREATE TABLE ptah_issue_273_users (id INT PRIMARY KEY, team_id INT);\n",
 		)},
+		"20220318104616.sql": &fstest.MapFile{Data: []byte(
+			"CREATE TABLE ptah_issue_273_audit (id INT PRIMARY KEY);\n",
+		)},
 	}
 	mig, err := migrator.NewFSMigrator(conn, fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
 	c.Assert(err, qt.IsNil)
@@ -80,24 +83,24 @@ func runAtlasFormatIntegration(t *testing.T, dbURL string) {
 
 	status, err := mig.GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
-	c.Assert(status.TotalMigrations, qt.Equals, 2)
-	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{20220318104614, 20220318104615})
+	c.Assert(status.TotalMigrations, qt.Equals, 3)
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{20220318104614, 20220318104615, 20220318104616})
 
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(issue273UsersCount(t, conn), qt.Equals, 0)
-	c.Assert(issue273Versions(t, conn), qt.DeepEquals, []int64{20220318104614, 20220318104615})
+	c.Assert(issue273Versions(t, conn), qt.DeepEquals, []int64{20220318104614, 20220318104615, 20220318104616})
 
 	status, err = mig.GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
 	c.Assert(status.PendingMigrations, qt.HasLen, 0)
 	c.Assert(status.HasPendingChanges, qt.IsFalse)
 
-	err = mig.MigrateDownTo(ctx, 20220318104614)
-	c.Assert(err, qt.ErrorMatches, `.*migration 20220318104615 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet.*`)
+	err = mig.MigrateDownTo(ctx, 20220318104615)
+	c.Assert(err, qt.ErrorMatches, `.*migration 20220318104616 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet.*`)
 	var noDown *migrator.AtlasDownNotImplementedError
 	c.Assert(err, qt.ErrorAs, &noDown)
-	c.Assert(noDown.Version, qt.Equals, int64(20220318104615))
+	c.Assert(noDown.Version, qt.Equals, int64(20220318104616))
 }
 
 func runAtlasTxtarDownIntegration(t *testing.T, dbURL string) {
@@ -142,6 +145,7 @@ func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 	t.Helper()
 
 	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ptah_issue_273_audit",
 		"DROP TABLE IF EXISTS ptah_issue_273_users",
 		"DROP TABLE IF EXISTS ptah_issue_273_teams",
 		"DROP TABLE IF EXISTS schema_migrations_issue_273",

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -21,14 +21,14 @@ import (
 // "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
 var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
-// Atlas migration file naming pattern: version_description.sql.
-var atlasFileNameRe = regexp.MustCompile(`^(\d+)_(.+)(\.sql)$`)
+// Atlas migration file naming pattern: version.sql or version_description.sql.
+var atlasFileNameRe = regexp.MustCompile(`^(\d+)(?:_(.+))?(\.sql)$`)
 
 // Auto-detection without atlas.sum stays stricter than explicit Atlas mode:
 // Atlas versioned directories commonly use 14-digit timestamp versions, and
 // requiring more than Ptah's 10-digit version width keeps legacy suffixless
 // Ptah-looking files from being auto-classified as Atlas migrations.
-var atlasAutoFileNameRe = regexp.MustCompile(`^(\d{11,})_(.+)(\.sql)$`)
+var atlasAutoFileNameRe = regexp.MustCompile(`^(\d{11,})(?:_(.+))?(\.sql)$`)
 
 // MigrationDirFormat selects how a filesystem migration directory is parsed.
 type MigrationDirFormat string
@@ -39,7 +39,7 @@ const (
 	MigrationDirFormatAuto MigrationDirFormat = "auto"
 	// MigrationDirFormatPtah parses NNNNNNNNNN_description.(up|down).sql pairs.
 	MigrationDirFormatPtah MigrationDirFormat = "ptah"
-	// MigrationDirFormatAtlas parses Atlas version_description.sql files.
+	// MigrationDirFormatAtlas parses Atlas version.sql or version_description.sql files.
 	MigrationDirFormatAtlas MigrationDirFormat = "atlas"
 )
 
@@ -104,8 +104,8 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 }
 
 // ParseAtlasMigrationFileName parses an Atlas versioned migration file name.
-// Expected format: version_description.sql. Atlas does not use paired .up.sql
-// and .down.sql files; these files are forward migrations.
+// Expected format: version.sql or version_description.sql. Atlas does not use
+// paired .up.sql and .down.sql files; these files are forward migrations.
 func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error) {
 	return parseAtlasMigrationFileName(filename, atlasFileNameRe)
 }
@@ -123,7 +123,8 @@ func parseAtlasMigrationFileName(filename string, pattern *regexp.Regexp) (*Migr
 		return nil, errors.New("invalid Atlas migration file name format")
 	}
 
-	if strings.HasSuffix(matches[2], ".up") || strings.HasSuffix(matches[2], ".down") {
+	rawName := matches[2]
+	if strings.HasSuffix(rawName, ".up") || strings.HasSuffix(rawName, ".down") {
 		return nil, errors.New("Atlas migration file name must not use Ptah direction suffixes")
 	}
 
@@ -135,7 +136,11 @@ func parseAtlasMigrationFileName(filename string, pattern *regexp.Regexp) (*Migr
 		return nil, errors.New("migration version must be greater than zero")
 	}
 
-	name := strings.ReplaceAll(matches[2], "_", " ")
+	name := rawName
+	if name == "" {
+		name = matches[1]
+	}
+	name = strings.ReplaceAll(name, "_", " ")
 	name = cases.Title(language.English).String(name)
 
 	return &MigrationFile{

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -182,6 +182,11 @@ func TestParseAtlasMigrationFileName(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(migrationFile.Version, qt.Equals, int64(1))
 	c.Assert(migrationFile.Name, qt.Equals, "Initial")
+
+	migrationFile, err = ParseAtlasMigrationFileName("20240112070806.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(20240112070806))
+	c.Assert(migrationFile.Name, qt.Equals, "20240112070806")
 	_, err = ParseAtlasMigrationFileName("20220318104614_team_A.up.sql")
 	c.Assert(err, qt.ErrorMatches, "Atlas migration file name must not use Ptah direction suffixes")
 }
@@ -204,6 +209,24 @@ func TestDiscoverMigrationFilesAtlasAuto(t *testing.T) {
 	c.Assert(files[1].Path, qt.Equals, "20220318104615_add_users.sql")
 }
 
+func TestDiscoverMigrationFilesAutoDetectsTimestampAtlasVersionsWithoutSum(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240112070806.sql":        &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"20240116003831_second.sql": &fstest.MapFile{Data: []byte("ALTER TABLE users ADD COLUMN name TEXT;\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	c.Assert(files[0].Path, qt.Equals, "20240112070806.sql")
+	c.Assert(files[0].Name, qt.Equals, "20240112070806")
+	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
+	c.Assert(files[1].Path, qt.Equals, "20240116003831_second.sql")
+	c.Assert(files[1].Name, qt.Equals, "Second")
+}
+
 func TestDiscoverMigrationFilesAtlasExplicitAllowsShortVersions(t *testing.T) {
 	c := qt.New(t)
 
@@ -223,13 +246,25 @@ func TestDiscoverMigrationFilesAtlasExplicitAllowsShortVersions(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1_initial.sql`)
 }
 
+func TestDiscoverMigrationFilesAutoRejectsShortBareVersionWithoutSum(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(files, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1.sql`)
+}
+
 func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fstest.MapFS{
 		"1_initial.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
-		"2_second.sql":  &fstest.MapFile{Data: []byte("ALTER TABLE users ADD COLUMN name TEXT;\n")},
-		"atlas.sum":     &fstest.MapFile{Data: []byte("h1:fake\n1_initial.sql h1:fake\n2_second.sql h1:fake\n")},
+		"2.sql":         &fstest.MapFile{Data: []byte("ALTER TABLE users ADD COLUMN name TEXT;\n")},
+		"atlas.sum":     &fstest.MapFile{Data: []byte("h1:fake\n1_initial.sql h1:fake\n2.sql h1:fake\n")},
 	}
 
 	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
@@ -238,8 +273,9 @@ func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T
 	c.Assert(files[0].Path, qt.Equals, "1_initial.sql")
 	c.Assert(files[0].Version, qt.Equals, int64(1))
 	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
-	c.Assert(files[1].Path, qt.Equals, "2_second.sql")
+	c.Assert(files[1].Path, qt.Equals, "2.sql")
 	c.Assert(files[1].Version, qt.Equals, int64(2))
+	c.Assert(files[1].Name, qt.Equals, "2")
 	c.Assert(files[1].Format, qt.Equals, MigrationDirFormatAtlas)
 }
 


### PR DESCRIPTION
## Summary

- accept Atlas migration file names with no description, such as `20240112070806.sql`
- keep auto-detection conservative: short bare names like `1.sql` still require `atlas.sum` or explicit `--dir-format=atlas`
- extend the Atlas live DB integration fixture to apply a bare `version.sql` migration
- update README docs for the supported Atlas naming forms

Fixes #273.

## Conformance Impact

Checked against `stokaro/ptah-atlas-conformance` with a local replace to this branch:

- Before: 270 unwaived, 145 ok, 250 gap, 20 fail
- After: 262 unwaived, 153 ok, 249 gap, 13 fail
- #273 findings drop from 66 to 58
- Remaining moved rows are classified as #274 hash compatibility rather than migration discovery failures.

## Validation

- GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator -run 'TestParseAtlasMigrationFileName|TestDiscoverMigrationFiles|TestAtlasFormat' -count=1 -v
- GOCACHE=/private/tmp/ptah-go-cache go test ./...
- GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- git diff --check
- Local conformance: GOCACHE=/private/tmp/ptah-conformance-go-cache make probe (262 unwaived)

Note: local Postgres/MySQL Atlas integration tests skipped because DSNs are not set in this sandbox; the test now includes the bare `version.sql` fixture for CI/live DB runs.
