### PR TITLE
Support Atlas-compatible migration sums

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ Show current migration status and pending migrations:
 - Out-of-order pending migrations
 - Migration history and timestamps
 
-#### Migration Directory Integrity (`ptah.sum`)
+#### Migration Directory Integrity (`ptah.sum` / `atlas.sum`)
 
 Once a migration is committed and applied somewhere, its content must never change.
 `ptah.sum` records the SHA-256 (`h1:`, base64) of every migration file plus a
@@ -820,10 +820,18 @@ caught in CI instead of silently breaking reproducibility.
 ./package-migrator migrate-validate --dir ./migrations --dir-format atlas
 ```
 
+Ptah-format integrity writes `ptah.sum` and hashes the Ptah migration files that
+would be executed. Atlas-format integrity writes `atlas.sum` and uses Atlas's
+byte-compatible checksum algorithm: top-level `*.sql` files sorted
+lexicographically, chained per-file hashes, directory hashes without separators,
+and `-- atlas:sum ignore` support. Auto validation reads `atlas.sum` when it is
+the only integrity file present, reads `ptah.sum` otherwise, and errors if both
+files exist so CI does not silently choose the wrong format.
+
 `migrate-validate` exits `0` when clean, `1` on drift (a file added, removed, or
-edited out of band — with a diff on stderr), and `2` when `ptah.sum` is missing or
-unreadable. `migrate-up --verify-sum` runs the same check before applying and
-aborts on drift.
+edited out of band — with a diff on stderr), and `2` when the expected integrity
+file is missing or unreadable. `migrate-up --verify-sum` runs the same check
+before applying and aborts on drift.
 
 ```yaml
 # CI (GitHub Actions)
@@ -831,8 +839,9 @@ aborts on drift.
   run: ./package-migrator migrate-validate --dir ./migrations
 ```
 
-The file layout and `h1:` scheme mirror Atlas's `atlas.sum`; convergence on the
-exact Atlas format is tracked as part of the Atlas-compatibility research (#250).
+The line-oriented file layout and `h1:` scheme are shared by both formats, but
+the hash algorithm differs. Recompute the integrity file with the selected
+format instead of renaming or hand-editing an existing sum file.
 
 #### Migration File Generation
 Generate timestamped migration files from schema differences using the migration generator package:

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -53,9 +53,13 @@ func runHash(cmd *cobra.Command, dir, dirFormatValue string) error {
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	sumFileName, err := migratesum.FileNameForFormat(dirFormat)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Wrote %s/%s\n", dir, migratesum.FileName)
+	fmt.Fprintf(out, "Wrote %s/%s\n", dir, sumFileName)
 	fmt.Fprintf(out, "%d migration file(s) hashed\n", len(sum.Entries))
 	return nil
 }

--- a/cmd/migratehash/migratehash_test.go
+++ b/cmd/migratehash/migratehash_test.go
@@ -44,6 +44,24 @@ func TestHash_WritesSumFileForMigrations(t *testing.T) {
 	c.Assert(res.OK(), qt.IsTrue)
 }
 
+func TestHash_AtlasFormatWritesAtlasSum(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+
+	stdout, err := execute("--dir", dir, "--dir-format", "atlas")
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "atlas.sum")
+	c.Assert(stdout, qt.Contains, "1 migration file(s) hashed")
+
+	_, err = os.Stat(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(filepath.Join(dir, migratesum.FileName))
+	c.Assert(os.IsNotExist(err), qt.IsTrue)
+}
+
 func TestHash_UpdatesSumFileAfterAddingAMigration(t *testing.T) {
 	c := qt.New(t)
 

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -139,13 +139,13 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if verifySum {
 		result, err := migratesum.VerifyDirWithFormat(migrationsDir, dirFormat)
 		if err != nil {
-			return fmt.Errorf("ptah.sum verification failed: %w", err)
+			return fmt.Errorf("migration sum verification failed: %w", err)
 		}
 		if !result.OK() {
-			return fmt.Errorf("ptah.sum verification failed:\n%s", result.Describe())
+			return fmt.Errorf("migration sum verification failed:\n%s", result.Describe())
 		}
 		if verbose {
-			fmt.Printf("ptah.sum verified: migrations directory is intact\n")
+			fmt.Printf("%s verified: migrations directory is intact\n", result.SumFileName)
 		}
 	}
 

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -47,7 +47,7 @@ func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
 
 	err = cmd.Execute()
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err, qt.ErrorMatches, "(?s).*ptah.sum verification failed.*")
+	c.Assert(err, qt.ErrorMatches, "(?s).*migration sum verification failed.*")
 	c.Assert(err, qt.ErrorMatches, "(?s).*changed: 0000000001_init.up.sql.*",
 		qt.Commentf("the drift diagnostic identifies the tampered file"))
 }

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -69,6 +69,6 @@ func runValidate(cmd *cobra.Command, dir, dirFormatValue string) error {
 		return exitcode.New(1, errors.New("migration directory integrity check failed"))
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "OK: migrations directory matches %s\n", migratesum.FileName)
+	fmt.Fprintf(cmd.OutOrStdout(), "OK: migrations directory matches %s\n", result.SumFileName)
 	return nil
 }

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 func execute(args ...string) (stdout, stderr string, err error) {
@@ -45,6 +46,20 @@ func TestValidate_CleanDirectoryExitsZero(t *testing.T) {
 	stdout, _, err := execute("--dir", migrationsDir(t))
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Contains, "OK: migrations directory matches ptah.sum")
+}
+
+func TestValidate_AutoReadsAtlasSum(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"),
+		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	stdout, _, err := execute("--dir", dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "OK: migrations directory matches atlas.sum")
 }
 
 func TestValidate_EditedMigrationExitsOneWithDiff(t *testing.T) {

--- a/migration/migratesum/io.go
+++ b/migration/migratesum/io.go
@@ -9,24 +9,28 @@ import (
 )
 
 // Write computes the sum of the migrations directory at dir and writes it to
-// dir/ptah.sum, returning the computed sum. The ptah.sum file is excluded
-// from its own hash because it is not a migration file.
+// dir/ptah.sum, returning the computed sum. The ptah.sum file is excluded from
+// its own hash because it is not a migration file.
 func Write(dir string) (*SumFile, error) {
 	return WriteWithFormat(dir, migrator.MigrationDirFormatAuto)
 }
 
 // WriteWithFormat computes the sum of the migrations directory at dir using
-// format and writes it to dir/ptah.sum.
+// format and writes it to the format's integrity file.
 func WriteWithFormat(dir string, format migrator.MigrationDirFormat) (*SumFile, error) {
 	sum, err := ComputeWithFormat(os.DirFS(dir), format)
 	if err != nil {
 		return nil, err
 	}
-	// ptah.sum is committed alongside the migrations and read by everyone who
-	// checks out the repo, so it uses the same 0644 as generated migration
+	name, err := FileNameForFormat(format)
+	if err != nil {
+		return nil, err
+	}
+	// The sum file is committed alongside the migrations and read by everyone
+	// who checks out the repo, so it uses the same 0644 as generated migration
 	// files rather than a private 0600.
-	if err := os.WriteFile(filepath.Join(dir, FileName), sum.Bytes(), 0644); err != nil { //nolint:gosec // 0644 is fine
-		return nil, fmt.Errorf("failed to write %s: %w", FileName, err)
+	if err := os.WriteFile(filepath.Join(dir, name), sum.Bytes(), 0644); err != nil { //nolint:gosec // 0644 is fine
+		return nil, fmt.Errorf("failed to write %s: %w", name, err)
 	}
 	return sum, nil
 }
@@ -36,8 +40,8 @@ func VerifyDir(dir string) (*Result, error) {
 	return VerifyDirWithFormat(dir, migrator.MigrationDirFormatAuto)
 }
 
-// VerifyDirWithFormat verifies the migrations directory at dir against its
-// ptah.sum using the selected migration directory format.
+// VerifyDirWithFormat verifies the migrations directory at dir against the
+// selected format's integrity file.
 func VerifyDirWithFormat(dir string, format migrator.MigrationDirFormat) (*Result, error) {
 	return VerifyWithFormat(os.DirFS(dir), format)
 }

--- a/migration/migratesum/sum.go
+++ b/migration/migratesum/sum.go
@@ -1,8 +1,7 @@
 // Package migratesum provides a migration-directory integrity check: a
-// committed checksum file (ptah.sum) records the hash of every migration file
-// plus a directory-level hash, so an out-of-band edit to an already-applied
-// migration is caught in CI instead of silently breaking reproducibility
-// (issue #161).
+// committed checksum file records the hash of every migration file plus a
+// directory-level hash, so an out-of-band edit to an already-applied migration
+// is caught in CI instead of silently breaking reproducibility (issue #161).
 //
 // # File format
 //
@@ -13,15 +12,15 @@
 //	0000000001_init.up.sql h1:<base64 sha256 of file contents>
 //	0000000001_init.down.sql h1:<base64 sha256 of file contents>
 //
-// The layout and the h1: (base64-encoded SHA-256) scheme mirror Atlas's
-// atlas.sum so a future "atlas mode" (issue #250) can converge on it; the
-// file is named ptah.sum and its exact byte-compatibility with Atlas is
-// intentionally out of scope until that decision lands.
+// Ptah-format integrity uses ptah.sum and hashes each file independently.
+// Atlas-format integrity uses atlas.sum-compatible chained hashes, matching
+// Atlas's migration directory integrity file byte for byte.
 package migratesum
 
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/fs"
 	"sort"
@@ -32,6 +31,10 @@ import (
 
 // FileName is the conventional integrity file inside a migrations directory.
 const FileName = "ptah.sum"
+
+// AtlasFileName is the conventional Atlas integrity file inside a migrations
+// directory.
+const AtlasFileName = "atlas.sum"
 
 // hashPrefix marks a base64-encoded SHA-256 hash, matching Atlas's h1 scheme.
 const hashPrefix = "h1:"
@@ -63,7 +66,20 @@ func Compute(fsys fs.FS) (*SumFile, error) {
 // ComputeWithFormat walks fsys and builds the sum over every migration file
 // recognized by the selected directory format.
 func ComputeWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error) {
-	files, err := migrator.DiscoverMigrationFiles(fsys, format)
+	normalized, err := migrator.ParseMigrationDirFormat(string(format))
+	if err != nil {
+		return nil, err
+	}
+
+	useAtlasHash, err := shouldUseAtlasHash(fsys, normalized)
+	if err != nil {
+		return nil, err
+	}
+	if useAtlasHash {
+		return computeAtlas(fsys)
+	}
+
+	files, err := migrator.DiscoverMigrationFiles(fsys, normalized)
 	if err != nil {
 		return nil, err
 	}
@@ -79,6 +95,19 @@ func ComputeWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
 
 	return &SumFile{DirHash: dirHash(entries), Entries: entries}, nil
+}
+
+// FileNameForFormat returns the integrity file written by the selected
+// explicit format. Auto mode preserves Ptah's default ptah.sum output.
+func FileNameForFormat(format migrator.MigrationDirFormat) (string, error) {
+	normalized, err := migrator.ParseMigrationDirFormat(string(format))
+	if err != nil {
+		return "", err
+	}
+	if normalized == migrator.MigrationDirFormatAtlas {
+		return AtlasFileName, nil
+	}
+	return FileName, nil
 }
 
 // Bytes renders the sum file in its on-disk form.
@@ -156,6 +185,96 @@ func dirHash(entries []Entry) string {
 	h := sha256.New()
 	for _, e := range entries {
 		fmt.Fprintf(h, "%s %s\n", e.Name, e.Hash)
+	}
+	return hashPrefix + base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func shouldUseAtlasHash(fsys fs.FS, format migrator.MigrationDirFormat) (bool, error) {
+	switch format {
+	case migrator.MigrationDirFormatAtlas:
+		return true, nil
+	case migrator.MigrationDirFormatPtah:
+		return false, nil
+	}
+	return hasFile(fsys, AtlasFileName)
+}
+
+func hasFile(fsys fs.FS, name string) (bool, error) {
+	_, err := fs.Stat(fsys, name)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func computeAtlas(fsys fs.FS) (*SumFile, error) {
+	names, err := fs.Glob(fsys, "*.sql")
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+
+	entries := make([]Entry, 0, len(names))
+	h := sha256.New()
+	for _, name := range names {
+		data, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", name, err)
+		}
+		_, _ = h.Write([]byte(name))
+		if atlasSumIgnored(data) {
+			continue
+		}
+		_, _ = h.Write(data)
+		entries = append(entries, Entry{Name: name, Hash: hashPrefix + base64.StdEncoding.EncodeToString(h.Sum(nil))})
+	}
+
+	return &SumFile{DirHash: atlasDirHash(entries), Entries: entries}, nil
+}
+
+func atlasSumIgnored(data []byte) bool {
+	name, args, ok := atlasDirective(data)
+	return ok && name == "sum" && args == "ignore"
+}
+
+func atlasDirective(data []byte) (name, args string, ok bool) {
+	content := string(data)
+	prefix, rest, ok := strings.Cut(content, "atlas:")
+	if !ok {
+		return "", "", false
+	}
+	for _, r := range prefix {
+		if r < ' ' || r > '~' {
+			return "", "", false
+		}
+	}
+
+	line, _, _ := strings.Cut(rest, "\n")
+	nameEnd := 0
+	for nameEnd < len(line) && isDirectiveNameChar(line[nameEnd]) {
+		nameEnd++
+	}
+	if nameEnd == 0 {
+		return "", "", false
+	}
+	if nameEnd < len(line) && line[nameEnd] == ' ' {
+		args = strings.TrimLeft(line[nameEnd+1:], " ")
+	}
+	return line[:nameEnd], args, true
+}
+
+func isDirectiveNameChar(b byte) bool {
+	return b == '_' || ('0' <= b && b <= '9') || ('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z')
+}
+
+func atlasDirHash(entries []Entry) string {
+	h := sha256.New()
+	for _, entry := range entries {
+		_, _ = h.Write([]byte(entry.Name))
+		_, _ = h.Write([]byte(strings.TrimPrefix(entry.Hash, hashPrefix)))
 	}
 	return hashPrefix + base64.StdEncoding.EncodeToString(h.Sum(nil))
 }

--- a/migration/migratesum/sum_test.go
+++ b/migration/migratesum/sum_test.go
@@ -73,6 +73,76 @@ func TestComputeWithFormat_HashesAtlasMigrationFiles(t *testing.T) {
 	})
 }
 
+func TestComputeWithFormat_AtlasGoldenBytes(t *testing.T) {
+	c := qt.New(t)
+
+	sum, err := migratesum.ComputeWithFormat(fixture(map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE users (id SERIAL PRIMARY KEY);\n",
+		"0000000001_init.down.sql": "DROP TABLE users;\n",
+	}), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	const expected = `h1:dV4b2tjr5jLyPdgrKp+m/NTaWTKMVgV80o5ps0Ew/GE=
+0000000001_init.down.sql h1:b4afj7upDcaQPh2KA7KdMZl7PEqNfrt1lEui6Gw5lHA=
+0000000001_init.up.sql h1:5pdFXxDzI9YASZoApjzSlatn7yMRKqTZ/pSe714fz0w=
+`
+	c.Assert(string(sum.Bytes()), qt.Equals, expected)
+}
+
+func TestComputeWithFormat_AtlasHashIsChained(t *testing.T) {
+	c := qt.New(t)
+
+	base := fixture(map[string]string{
+		"1_first.sql":  "SELECT 1;\n",
+		"2_second.sql": "SELECT 2;\n",
+	})
+	changedFirst := fixture(map[string]string{
+		"1_first.sql":  "SELECT 10;\n",
+		"2_second.sql": "SELECT 2;\n",
+	})
+	baseSum, err := migratesum.ComputeWithFormat(base, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	changedSum, err := migratesum.ComputeWithFormat(changedFirst, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(changedSum.Entries[0].Hash, qt.Not(qt.Equals), baseSum.Entries[0].Hash)
+	c.Assert(changedSum.Entries[1].Hash, qt.Not(qt.Equals), baseSum.Entries[1].Hash,
+		qt.Commentf("Atlas hashes are chained: editing the first file changes later entry hashes too"))
+}
+
+func TestComputeWithFormat_AtlasSumIgnore(t *testing.T) {
+	c := qt.New(t)
+
+	withIgnored, err := migratesum.ComputeWithFormat(fixture(map[string]string{
+		"1_ignore.sql": "-- atlas:sum ignore\nSELECT ignored;\n",
+		"2_keep.sql":   "SELECT kept;\n",
+	}), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	withoutIgnored, err := migratesum.ComputeWithFormat(fixture(map[string]string{
+		"2_keep.sql": "SELECT kept;\n",
+	}), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(withIgnored.Entries, qt.HasLen, 1)
+	c.Assert(withIgnored.Entries[0].Name, qt.Equals, "2_keep.sql")
+	c.Assert(withIgnored.Entries[0].Hash, qt.Not(qt.Equals), withoutIgnored.Entries[0].Hash,
+		qt.Commentf("ignored Atlas files are omitted from atlas.sum but their names still feed the chain"))
+}
+
+func TestCompute_AutoUsesAtlasHashWhenAtlasSumPresent(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"1_initial.sql": "CREATE TABLE users (id INT);\n",
+		"atlas.sum":     "stale\n",
+	})
+	autoSum, err := migratesum.Compute(fsys)
+	c.Assert(err, qt.IsNil)
+	atlasSum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(autoSum.Bytes(), qt.DeepEquals, atlasSum.Bytes())
+}
+
 func TestCompute_IsDeterministicAndContentSensitive(t *testing.T) {
 	c := qt.New(t)
 
@@ -240,6 +310,43 @@ func TestVerify_MissingSumFile(t *testing.T) {
 		"0000000001_init.down.sql": "DROP TABLE t;\n",
 	}))
 	c.Assert(err, qt.ErrorIs, migratesum.ErrSumFileMissing)
+}
+
+func TestVerify_MissingAtlasSumFile(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := migratesum.VerifyWithFormat(fixture(map[string]string{
+		"1_initial.sql": "CREATE TABLE users (id INT);\n",
+	}), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.ErrorIs, migratesum.ErrSumFileMissing)
+	c.Assert(err, qt.ErrorMatches, "atlas.sum not found; run `ptah migrate-hash --dir-format atlas` to create it")
+}
+
+func TestVerify_AutoReadsAtlasSum(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"1_initial.sql": "CREATE TABLE users (id INT);\n",
+	})
+	sum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	fsys[migratesum.AtlasFileName] = &fstest.MapFile{Data: sum.Bytes()}
+
+	res, err := migratesum.Verify(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(res.OK(), qt.IsTrue)
+	c.Assert(res.SumFileName, qt.Equals, migratesum.AtlasFileName)
+}
+
+func TestVerify_AutoRejectsAmbiguousSumFiles(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := migratesum.Verify(fixture(map[string]string{
+		"1_initial.sql": "CREATE TABLE users (id INT);\n",
+		"atlas.sum":     "h1:fake\n",
+		"ptah.sum":      "h1:fake\n",
+	}))
+	c.Assert(err, qt.ErrorMatches, "both ptah.sum and atlas.sum exist.*")
 }
 
 func TestVerify_HandEditedSumFileDirHashMismatch(t *testing.T) {

--- a/migration/migratesum/verify.go
+++ b/migration/migratesum/verify.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
-// ErrSumFileMissing is returned when the migrations directory has no ptah.sum.
-// It is distinct so callers can tell "never hashed" apart from "tampered".
+// ErrSumFileMissing is returned when the migrations directory has no expected
+// integrity file. It is distinct so callers can tell "never hashed" apart from
+// "tampered".
 var ErrSumFileMissing = errors.New("ptah.sum not found; run `ptah migrate-hash` to create it")
 
 // Result is the outcome of Verify: the lists are empty when the directory
@@ -26,6 +27,8 @@ type Result struct {
 	// DirHashMismatch is set when the directory hash differs even though the
 	// per-file diff is empty (a corrupted or hand-edited sum file).
 	DirHashMismatch bool
+	// SumFileName is the integrity file this result was compared against.
+	SumFileName string
 }
 
 // OK reports whether the directory matches its recorded sum exactly.
@@ -42,27 +45,90 @@ func Verify(fsys fs.FS) (*Result, error) {
 }
 
 // VerifyWithFormat recomputes the sum of fsys using the selected migration
-// directory format and compares it against the ptah.sum recorded in the same
-// directory.
+// directory format and compares it against the selected integrity file.
 func VerifyWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*Result, error) {
-	recordedRaw, err := fs.ReadFile(fsys, FileName)
+	name, err := fileNameForVerify(fsys, format)
+	if err != nil {
+		return nil, err
+	}
+	recordedRaw, err := fs.ReadFile(fsys, name)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil, ErrSumFileMissing
+		return nil, missingSumFileError(name, format)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read %s: %w", FileName, err)
+		return nil, fmt.Errorf("failed to read %s: %w", name, err)
 	}
 	recorded, err := Parse(recordedRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %w", FileName, err)
+		return nil, fmt.Errorf("failed to parse %s: %w", name, err)
 	}
 
-	current, err := ComputeWithFormat(fsys, format)
+	computeFormat := formatForSumFile(format, name)
+	current, err := ComputeWithFormat(fsys, computeFormat)
 	if err != nil {
 		return nil, err
 	}
 
-	return diff(recorded, current), nil
+	result := diff(recorded, current)
+	result.SumFileName = name
+	return result, nil
+}
+
+func formatForSumFile(format migrator.MigrationDirFormat, name string) migrator.MigrationDirFormat {
+	if format != migrator.MigrationDirFormatAuto && format != "" {
+		return format
+	}
+	if name == AtlasFileName {
+		return migrator.MigrationDirFormatAtlas
+	}
+	return migrator.MigrationDirFormatPtah
+}
+
+func fileNameForVerify(fsys fs.FS, format migrator.MigrationDirFormat) (string, error) {
+	normalized, err := migrator.ParseMigrationDirFormat(string(format))
+	if err != nil {
+		return "", err
+	}
+	if normalized != migrator.MigrationDirFormatAuto {
+		return FileNameForFormat(normalized)
+	}
+
+	hasPtahSum, err := hasFile(fsys, FileName)
+	if err != nil {
+		return "", err
+	}
+	hasAtlasSum, err := hasFile(fsys, AtlasFileName)
+	if err != nil {
+		return "", err
+	}
+	switch {
+	case hasPtahSum && hasAtlasSum:
+		return "", fmt.Errorf("both %s and %s exist; choose --dir-format ptah or --dir-format atlas", FileName, AtlasFileName)
+	case hasAtlasSum:
+		return AtlasFileName, nil
+	default:
+		return FileName, nil
+	}
+}
+
+func missingSumFileError(name string, format migrator.MigrationDirFormat) error {
+	if name == FileName {
+		return ErrSumFileMissing
+	}
+	return sumFileMissingError{name: name, format: format}
+}
+
+type sumFileMissingError struct {
+	name   string
+	format migrator.MigrationDirFormat
+}
+
+func (e sumFileMissingError) Error() string {
+	return fmt.Sprintf("%s not found; run `ptah migrate-hash --dir-format %s` to create it", e.name, e.format)
+}
+
+func (e sumFileMissingError) Is(target error) bool {
+	return target == ErrSumFileMissing
 }
 
 // diff compares the recorded sum against the freshly computed one.
@@ -112,18 +178,22 @@ func (r *Result) Describe() string {
 	if r.OK() {
 		return ""
 	}
-	lines := []string{"migration directory does not match ptah.sum:"}
+	name := r.SumFileName
+	if name == "" {
+		name = FileName
+	}
+	lines := []string{"migration directory does not match " + name + ":"}
 	for _, n := range r.Changed {
 		lines = append(lines, "  changed: "+n)
 	}
 	for _, n := range r.Added {
-		lines = append(lines, "  added (not in ptah.sum): "+n)
+		lines = append(lines, "  added (not in "+name+"): "+n)
 	}
 	for _, n := range r.Removed {
-		lines = append(lines, "  removed (still in ptah.sum): "+n)
+		lines = append(lines, "  removed (still in "+name+"): "+n)
 	}
 	if r.DirHashMismatch {
-		lines = append(lines, "  directory hash mismatch (ptah.sum was hand-edited)")
+		lines = append(lines, "  directory hash mismatch ("+name+" was hand-edited)")
 	}
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

- add Atlas-compatible migration sum computation for Atlas-format directories
- write/read atlas.sum for explicit Atlas integrity mode and auto-read atlas.sum when it is the only sum file present
- cover Atlas golden bytes, chained hashes, atlas:sum ignore, CLI behavior, missing-file errors, and ambiguous sum files
- update migration integrity docs for ptah.sum vs atlas.sum

Closes #274.

## Validation

- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./migration/migratesum
- env GOCACHE=/private/tmp/ptah-go-cache go tool qtlint github.com/stokaro/ptah/cmd/migratehash
- env GOCACHE=/private/tmp/ptah-go-cache go tool qtlint github.com/stokaro/ptah/cmd/migratevalidate
- env GOCACHE=/private/tmp/ptah-go-cache go tool qtlint github.com/stokaro/ptah/cmd/migrateup
- git diff --check
- ptah-atlas-conformance temp run with local replace: 158 fixtures, 415 observations, 240 unwaived gaps; prior baseline was 262, so this clears 22 sum-compat gaps