### PR TITLE
Recognize Atlas imported migration names

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,15 +636,15 @@ Ptah migration directories use `--dir-format=auto` by default. Auto mode prefers
 Ptah's paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
 Atlas-style timestamp files such as `20220318104614_team_A.sql` or
-`20240112070806.sql`. Short Atlas versions such as `1_initial.sql` and `2.sql`
-are auto-detected when the directory contains `atlas.sum`; use
-`--dir-format=atlas` when you want to force Atlas parsing without an integrity
-file. Use
+`20240112070806.sql`, plus numeric migration names produced by Atlas importers
+such as `1_initial.sql`, `2.sql`, `1_initial.up.sql`, `1_initial.down.sql`, and
+`1.my.sql`. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when a directory should
-be interpreted explicitly. Ordinary Atlas files are forward migrations. Atlas
-txtar files can also carry an embedded `down.sql` section that Ptah executes on
-rollback.
+be interpreted explicitly. Ordinary Atlas and imported single SQL files are
+forward migrations. Imported `.down.sql` files are paired with their matching
+`.up.sql` version for rollback. Atlas txtar files can also carry an embedded
+`down.sql` section that Ptah executes on rollback.
 
 ```sql
 -- atlas:txtar

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -460,8 +460,8 @@ func TestLintFS_UpSuffixFallbackScansMalformedVersions(t *testing.T) {
 	// hazard scanning via the IsUp suffix fallback — the author clearly
 	// meant it as an up migration, and MF103 explains why it will not run.
 	fsys := fixture(map[string]string{
-		"001_bad_version.up.sql":   "DROP TABLE users;\n",
-		"001_bad_version.down.sql": "-- restore\n",
+		"bad_version.up.sql":   "DROP TABLE users;\n",
+		"bad_version.down.sql": "-- restore\n",
 	})
 
 	findings, err := lint.LintFS(fsys, lint.Options{})
@@ -504,6 +504,22 @@ func TestLintFS_AtlasMigrationNamesAreScanned(t *testing.T) {
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"},
 		qt.Commentf("Atlas files should be treated as runnable up migrations, not MF103-only noise; got %v", findings))
 	c.Assert(findings[0].File, qt.Equals, "20220318104614_team_A.sql")
+}
+
+func TestLintFS_AtlasImportedMigrationNamesAreScanned(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"1_initial.up.sql":   "DROP TABLE users;\n",
+		"1_initial.down.sql": "DROP TABLE users;\n",
+		"2.10.x-20_next.sql": "CREATE TABLE next_step (id INT);\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"},
+		qt.Commentf("Atlas-imported files should be treated as runnable migrations, not MF-only noise; got %v", findings))
+	c.Assert(findings[0].File, qt.Equals, "1_initial.up.sql")
 }
 
 func TestLintFS_CaseVariantSQLFilesGetNamingWarning(t *testing.T) {

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -72,14 +72,15 @@ Migration directory commands use `--dir-format=auto` by default. Auto mode
 prefers Ptah paired files (`NNNNNNNNNN_description.up.sql` and
 `NNNNNNNNNN_description.down.sql`) when they are present, and otherwise accepts
 Atlas-style timestamp files such as `20220318104614_team_A.sql` or
-`20240112070806.sql`. Short Atlas versions such as `1_initial.sql` and `2.sql`
-are auto-detected when the directory contains `atlas.sum`; use
-`--dir-format=atlas` when you want to force Atlas parsing without an integrity
-file. Use
+`20240112070806.sql`, plus numeric migration names produced by Atlas importers
+such as `1_initial.sql`, `2.sql`, `1_initial.up.sql`, `1_initial.down.sql`, and
+`1.my.sql`. Use
 `--dir-format=ptah` or `--dir-format=atlas` on `migrate-up`, `migrate-down`,
 `migrate-status`, `migrate-hash`, and `migrate-validate` when detection should be
-explicit. Ordinary Atlas files are forward migrations. Atlas txtar files can also
-embed a `down.sql` section that Ptah executes during rollback:
+explicit. Ordinary Atlas and imported single SQL files are forward migrations.
+Imported `.down.sql` files are paired with their matching `.up.sql` version for
+rollback. Atlas txtar files can also embed a `down.sql` section that Ptah
+executes during rollback:
 
 ```sql
 -- atlas:txtar

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/fs"
 	"maps"
+	"path"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -65,6 +67,12 @@ type FSMigrationProvider struct {
 // FSProviderOption configures a FSMigrationProvider before it loads
 // migrations.
 type FSProviderOption func(*FSMigrationProvider)
+
+type atlasParts struct {
+	migration *Migration
+	hasUp     bool
+	hasDown   bool
+}
 
 // WithStatementInterceptor makes every loaded migration consult the given
 // interceptor for each statement (see StatementInterceptor).
@@ -184,44 +192,119 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 }
 
 func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
-	migrations := make([]*Migration, 0, len(files))
+	partsByVersion := make(map[int64]*atlasParts)
 	for i := range files {
 		migrationFile := files[i]
-		atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
-		if err != nil {
-			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
-		}
-
-		migration := &Migration{
-			Version:       migrationFile.Version,
-			Description:   migrationFile.Name,
-			UpTimeouts:    atlasFile.up.timeouts,
-			NoTransaction: atlasFile.up.noTransaction,
-		}
-		migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-			return atlasFile.up.fn(ctx, conn, migration.executionMode())
-		}
-		if atlasFile.hasDown {
-			migration.DownTimeouts = atlasFile.down.timeouts
-			migration.NoTransaction = migration.NoTransaction || atlasFile.down.noTransaction
-			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-				return atlasFile.down.fn(ctx, conn, migration.executionMode())
+		parts := partsByVersion[migrationFile.Version]
+		if parts == nil {
+			parts = &atlasParts{
+				migration: &Migration{
+					Version:     migrationFile.Version,
+					Description: migrationFile.Name,
+				},
 			}
-		} else {
-			migration.downUnavailable = true
-			migration.Down = func(_ context.Context, _ *dbschema.DatabaseConnection) error {
+			partsByVersion[migrationFile.Version] = parts
+		}
+		if err := p.loadAtlasFile(parts, migrationFile); err != nil {
+			return err
+		}
+	}
+
+	migrations := make([]*Migration, 0, len(partsByVersion))
+	for _, parts := range partsByVersion {
+		if !parts.hasUp {
+			return fmt.Errorf("Atlas migration version %d has down migration but no up migration", parts.migration.Version)
+		}
+		if !parts.hasDown {
+			parts.migration.downUnavailable = true
+			parts.migration.Down = func(_ context.Context, _ *dbschema.DatabaseConnection) error {
 				return &AtlasDownNotImplementedError{
-					Version:     migration.Version,
-					Description: migration.Description,
+					Version:     parts.migration.Version,
+					Description: parts.migration.Description,
 				}
 			}
 		}
-		migrations = append(migrations, migration)
+		migrations = append(migrations, parts.migration)
 	}
 
 	p.migrations = migrations
 	sortMigrations(p.migrations)
 	return nil
+}
+
+func (p *FSMigrationProvider) loadAtlasFile(parts *atlasParts, migrationFile MigrationFile) error {
+	switch migrationFile.Direction {
+	case "up":
+		if parts.hasUp {
+			return fmt.Errorf("duplicate Atlas up migration for version %d", migrationFile.Version)
+		}
+		return p.loadAtlasUp(parts, migrationFile)
+	case "down":
+		if parts.hasDown {
+			return fmt.Errorf("duplicate Atlas down migration for version %d", migrationFile.Version)
+		}
+		return p.loadAtlasDown(parts, migrationFile)
+	default:
+		return fmt.Errorf("invalid Atlas migration direction: %s", migrationFile.Direction)
+	}
+}
+
+func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile MigrationFile) error {
+	if isAtlasDirectionalMigrationFile(migrationFile) {
+		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+		if err != nil {
+			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
+		}
+		setAtlasUp(parts, up)
+		return nil
+	}
+
+	atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+	if err != nil {
+		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
+	}
+	setAtlasUp(parts, atlasFile.up)
+	if atlasFile.hasDown {
+		if parts.hasDown {
+			return fmt.Errorf("duplicate Atlas down migration for version %d", migrationFile.Version)
+		}
+		setAtlasDown(parts, atlasFile.down)
+	}
+	return nil
+}
+
+func (p *FSMigrationProvider) loadAtlasDown(parts *atlasParts, migrationFile MigrationFile) error {
+	down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+	if err != nil {
+		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
+	}
+	setAtlasDown(parts, down)
+	return nil
+}
+
+func setAtlasUp(parts *atlasParts, up sqlMigrationFile) {
+	migration := parts.migration
+	migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		return up.fn(ctx, conn, migration.executionMode())
+	}
+	migration.UpTimeouts = up.timeouts
+	migration.NoTransaction = migration.NoTransaction || up.noTransaction
+	parts.hasUp = true
+}
+
+func setAtlasDown(parts *atlasParts, down sqlMigrationFile) {
+	migration := parts.migration
+	migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		return down.fn(ctx, conn, migration.executionMode())
+	}
+	migration.DownTimeouts = down.timeouts
+	migration.NoTransaction = migration.NoTransaction || down.noTransaction
+	parts.hasDown = true
+}
+
+func isAtlasDirectionalMigrationFile(file MigrationFile) bool {
+	base := path.Base(file.Path)
+	return strings.HasSuffix(base, ".up.sql") || strings.HasSuffix(base, ".down.sql")
 }
 
 func sortMigrations(migrations []*Migration) {

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -183,6 +183,50 @@ func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
 	c.Assert(noDown.Description, qt.Equals, "Team A")
 }
 
+func TestNewFSMigrationProvider_AtlasImportedDirectionalFiles(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1_initial.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah statement_timeout=7s\n" +
+				"CREATE TABLE users (id INT);\n",
+		)},
+		"1_initial.down.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah lock_timeout=2s\n" +
+				"DROP TABLE users;\n",
+		)},
+		"2_second.sql": &fstest.MapFile{Data: []byte("CREATE TABLE teams (id INT);\n")},
+	}
+	interceptor := &recordingInterceptor{}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementInterceptor(interceptor),
+	)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 2)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
+	c.Assert(migrations[0].Description, qt.Equals, "Initial")
+	c.Assert(migrations[0].UpTimeouts.HasStatementTimeout, qt.IsTrue)
+	c.Assert(migrations[0].UpTimeouts.StatementTimeout, qt.Equals, 7*time.Second)
+	c.Assert(migrations[0].DownTimeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(migrations[0].DownTimeouts.LockTimeout, qt.Equals, 2*time.Second)
+
+	err = migrations[0].Up(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"CREATE TABLE users (id INT)"})
+
+	interceptor.statements = nil
+	err = migrations[0].Down(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"DROP TABLE users"})
+
+	err = migrations[1].Down(context.Background(), nil)
+	c.Assert(err, qt.ErrorMatches, `migration 2 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet; add an atlas txtar down.sql section or migrate down manually`)
+}
+
 func TestNewFSMigrationProvider_AtlasTxtarSectionsAndDirectives(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -21,14 +21,12 @@ import (
 // "up"/"down" (cleanup, setup, teardown, ...) is not a migration file.
 var fileNameRe = regexp.MustCompile(`^(\d{10})_(.*)\.(down|up)(\.sql)$`)
 
-// Atlas migration file naming pattern: version.sql or version_description.sql.
-var atlasFileNameRe = regexp.MustCompile(`^(\d+)(?:_(.+))?(\.sql)$`)
+type atlasParseMode int
 
-// Auto-detection without atlas.sum stays stricter than explicit Atlas mode:
-// Atlas versioned directories commonly use 14-digit timestamp versions, and
-// requiring more than Ptah's 10-digit version width keeps legacy suffixless
-// Ptah-looking files from being auto-classified as Atlas migrations.
-var atlasAutoFileNameRe = regexp.MustCompile(`^(\d{11,})(?:_(.+))?(\.sql)$`)
+const (
+	atlasParseExplicit atlasParseMode = iota
+	atlasParseAuto
+)
 
 // MigrationDirFormat selects how a filesystem migration directory is parsed.
 type MigrationDirFormat string
@@ -104,31 +102,45 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 }
 
 // ParseAtlasMigrationFileName parses an Atlas versioned migration file name.
-// Expected format: version.sql or version_description.sql. Atlas does not use
-// paired .up.sql and .down.sql files; these files are forward migrations.
+// Expected format: version.sql, version_description.sql, or numeric migration
+// names emitted by Atlas importers such as version_description.up.sql,
+// version_description.down.sql, and version.tool.sql.
 func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error) {
-	return parseAtlasMigrationFileName(filename, atlasFileNameRe)
+	return parseAtlasMigrationFileName(filename, atlasParseExplicit)
 }
 
 // ParseAtlasMigrationFileNameForAutoDetection parses Atlas names accepted by
 // auto-detection. It is stricter than explicit Atlas parsing so legacy
-// suffixless Ptah-looking files keep surfacing as unrecognized in auto mode.
+// suffixless Ptah-looking files keep surfacing as unrecognized in auto mode,
+// while accepting short numeric names used by Atlas-imported migration tools.
 func ParseAtlasMigrationFileNameForAutoDetection(filename string) (*MigrationFile, error) {
-	return parseAtlasMigrationFileName(filename, atlasAutoFileNameRe)
+	return parseAtlasMigrationFileName(filename, atlasParseAuto)
 }
 
-func parseAtlasMigrationFileName(filename string, pattern *regexp.Regexp) (*MigrationFile, error) {
-	matches := pattern.FindStringSubmatch(filename)
-	if matches == nil || len(matches) != 4 {
+func parseAtlasMigrationFileName(filename string, mode atlasParseMode) (*MigrationFile, error) {
+	stem, ok := strings.CutSuffix(filename, ".sql")
+	if !ok {
 		return nil, errors.New("invalid Atlas migration file name format")
 	}
 
-	rawName := matches[2]
-	if strings.HasSuffix(rawName, ".up") || strings.HasSuffix(rawName, ".down") {
-		return nil, errors.New("Atlas migration file name must not use Ptah direction suffixes")
+	direction := "up"
+	for _, suffix := range []string{".up", ".down"} {
+		if strings.HasSuffix(stem, suffix) {
+			direction = strings.TrimPrefix(suffix, ".")
+			stem = strings.TrimSuffix(stem, suffix)
+			break
+		}
 	}
 
-	version, err := strconv.ParseInt(matches[1], 10, 64)
+	versionDigits, rawName, ok := splitAtlasMigrationStem(stem)
+	if !ok {
+		return nil, errors.New("invalid Atlas migration file name format")
+	}
+	if mode == atlasParseAuto && len(versionDigits) == 10 && direction == "up" {
+		return nil, errors.New("Atlas auto-detection rejects Ptah-width suffixless migration names")
+	}
+
+	version, err := strconv.ParseInt(versionDigits, 10, 64)
 	if err != nil {
 		return nil, err
 	}
@@ -138,18 +150,35 @@ func parseAtlasMigrationFileName(filename string, pattern *regexp.Regexp) (*Migr
 
 	name := rawName
 	if name == "" {
-		name = matches[1]
+		name = versionDigits
 	}
-	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.NewReplacer("_", " ", ".", " ").Replace(name)
 	name = cases.Title(language.English).String(name)
 
 	return &MigrationFile{
 		Version:   version,
 		Name:      name,
-		Direction: "up",
-		Extension: matches[3],
+		Direction: direction,
+		Extension: ".sql",
 		Format:    MigrationDirFormatAtlas,
 	}, nil
+}
+
+func splitAtlasMigrationStem(stem string) (versionDigits, rawName string, ok bool) {
+	i := 0
+	for i < len(stem) && stem[i] >= '0' && stem[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return "", "", false
+	}
+	if i == len(stem) {
+		return stem, "", true
+	}
+	if stem[i] != '_' && stem[i] != '.' {
+		return "", "", false
+	}
+	return stem[:i], strings.TrimLeft(stem[i:], "_."), true
 }
 
 // ValidateMigrationFileName validates that a filename follows the expected migration pattern

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -187,8 +187,26 @@ func TestParseAtlasMigrationFileName(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(migrationFile.Version, qt.Equals, int64(20240112070806))
 	c.Assert(migrationFile.Name, qt.Equals, "20240112070806")
-	_, err = ParseAtlasMigrationFileName("20220318104614_team_A.up.sql")
-	c.Assert(err, qt.ErrorMatches, "Atlas migration file name must not use Ptah direction suffixes")
+
+	migrationFile, err = ParseAtlasMigrationFileName("1_initial.up.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(1))
+	c.Assert(migrationFile.Name, qt.Equals, "Initial")
+	c.Assert(migrationFile.Direction, qt.Equals, "up")
+
+	migrationFile, err = ParseAtlasMigrationFileName("1_initial.down.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(1))
+	c.Assert(migrationFile.Name, qt.Equals, "Initial")
+	c.Assert(migrationFile.Direction, qt.Equals, "down")
+
+	migrationFile, err = ParseAtlasMigrationFileName("2.10.x-20_description.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(2))
+	c.Assert(migrationFile.Name, qt.Equals, "10 X-20 Description")
+
+	_, err = ParseAtlasMigrationFileName("3R_views.sql")
+	c.Assert(err, qt.ErrorMatches, "invalid Atlas migration file name format")
 }
 
 func TestDiscoverMigrationFilesAtlasAuto(t *testing.T) {
@@ -242,11 +260,13 @@ func TestDiscoverMigrationFilesAtlasExplicitAllowsShortVersions(t *testing.T) {
 	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
 
 	files, err = DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
-	c.Assert(files, qt.IsNil)
-	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1_initial.sql`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(files[0].Path, qt.Equals, "1_initial.sql")
+	c.Assert(files[0].Version, qt.Equals, int64(1))
 }
 
-func TestDiscoverMigrationFilesAutoRejectsShortBareVersionWithoutSum(t *testing.T) {
+func TestDiscoverMigrationFilesAutoDetectsShortBareVersionWithoutSum(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fstest.MapFS{
@@ -254,8 +274,11 @@ func TestDiscoverMigrationFilesAutoRejectsShortBareVersionWithoutSum(t *testing.
 	}
 
 	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
-	c.Assert(files, qt.IsNil)
-	c.Assert(err, qt.ErrorMatches, `no migration files matched format "auto"; unrecognized SQL files: 1.sql`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(files[0].Path, qt.Equals, "1.sql")
+	c.Assert(files[0].Version, qt.Equals, int64(1))
+	c.Assert(files[0].Format, qt.Equals, MigrationDirFormatAtlas)
 }
 
 func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T) {
@@ -277,6 +300,31 @@ func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T
 	c.Assert(files[1].Version, qt.Equals, int64(2))
 	c.Assert(files[1].Name, qt.Equals, "2")
 	c.Assert(files[1].Format, qt.Equals, MigrationDirFormatAtlas)
+}
+
+func TestDiscoverMigrationFilesAutoDetectsAtlasImportedNames(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1_initial.down.sql":               &fstest.MapFile{Data: []byte("DROP TABLE users;\n")},
+		"1_initial.up.sql":                 &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"2.10.x-20_description.sql":        &fstest.MapFile{Data: []byte("CREATE TABLE audit (id INT);\n")},
+		"sub/3_partly.sql":                 &fstest.MapFile{Data: []byte("CREATE TABLE logs (id INT);\n")},
+		"sub/4.a_sub.up.sql":               &fstest.MapFile{Data: []byte("CREATE TABLE nested (id INT);\n")},
+		"sub/4.a_sub.down.sql":             &fstest.MapFile{Data: []byte("DROP TABLE nested;\n")},
+		"0000000001_ptah_width_legacy.sql": &fstest.MapFile{Data: []byte("DROP TABLE legacy;\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 6)
+	c.Assert(files[0].Path, qt.Equals, "1_initial.down.sql")
+	c.Assert(files[0].Direction, qt.Equals, "down")
+	c.Assert(files[1].Path, qt.Equals, "1_initial.up.sql")
+	c.Assert(files[1].Direction, qt.Equals, "up")
+	c.Assert(files[2].Path, qt.Equals, "2.10.x-20_description.sql")
+	c.Assert(files[2].Name, qt.Equals, "10 X-20 Description")
+	c.Assert(files[5].Path, qt.Equals, "sub/4.a_sub.up.sql")
 }
 
 func TestDiscoverMigrationFilesAutoPrefersPtahWhenPresent(t *testing.T) {


### PR DESCRIPTION
## Summary

- Recognize numeric migration names produced by Atlas importers in auto/atlas mode, including `1_initial.sql`, `2.sql`, `1_initial.up.sql`, `1_initial.down.sql`, and dotted variants like `1.my.sql`.
- Group imported `.up.sql` / `.down.sql` files into a single Atlas-format filesystem migration so rollback uses the imported down file instead of treating it as a separate migration.
- Keep Ptah paired files preferred in auto mode and keep Ptah-width suffixless legacy names such as `0000000001_legacy.sql` out of auto-detection.
- Document the expanded auto-detection and imported down-file behavior.

Closes #297.
Refs #273.

## Validation

- `gopls` diagnostics: no diagnostics
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator ./migration/lint`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./migration/migrator ./migration/lint`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `git diff --check`
- Temp conformance run with local Ptah replace:
  - before: 240 unwaived gaps
  - after: 219 unwaived gaps
  - command: `env GOCACHE=/private/tmp/ptah-conformance-go-cache make probe`

## Self-Review Notes

- This intentionally does not map Flyway repeatable-style `3R_views.sql` into an int64 Ptah revision. That would either collide with `3_third_migration.sql` or require inventing fake revision numbers. A proper fix needs a repeatable/undo migration model rather than a filename-only parser hack.
- The expanded auto-detection only runs after Ptah-format files are checked, so existing paired Ptah migrations still win in mixed directories.
