### PR TITLE
Parse DROP TABLE statements

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -103,6 +103,8 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseAlterStatement()
 	case "COMMENT":
 		return p.parseCommentStatement()
+	case "DROP":
+		return p.parseDropStatement()
 	default:
 		return nil, fmt.Errorf("unsupported SQL statement: %s at position %d", keyword, p.current.Start)
 	}
@@ -185,6 +187,27 @@ func (p *Parser) expectIdentifier() (string, error) {
 	return value, nil
 }
 
+func (p *Parser) parseQualifiedIdentifier(label string) (string, error) {
+	first, err := p.expectIdentifier()
+	if err != nil {
+		return "", fmt.Errorf("expected %s: %w", label, err)
+	}
+
+	var name strings.Builder
+	name.WriteString(first)
+	for p.current.Type == lexer.TokenOperator && p.current.Value == "." {
+		name.WriteString(".")
+		p.advance()
+		p.skipWhitespace()
+		part, err := p.expectIdentifier()
+		if err != nil {
+			return "", fmt.Errorf("expected identifier after '.' in %s: %w", label, err)
+		}
+		name.WriteString(part)
+	}
+	return name.String(), nil
+}
+
 // skipWhitespace skips whitespace and comment tokens.
 func (p *Parser) skipWhitespace() {
 	for p.current.Type == lexer.TokenWhitespace || p.current.Type == lexer.TokenComment {
@@ -221,20 +244,9 @@ func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
 	p.skipWhitespace()
 
 	// Get table name (could be schema.table)
-	var tableName strings.Builder
-	tableName.WriteString(p.current.Value)
-	p.advance()
-
-	// Check for schema.table notation
-	if p.current.Type == lexer.TokenOperator && p.current.Value == "." {
-		tableName.WriteString(".")
-		p.advance()
-		p.skipWhitespace()
-		if p.current.Type != lexer.TokenIdentifier {
-			return nil, fmt.Errorf("expected table name after schema: got %s at position %d", p.current.Type, p.current.Start)
-		}
-		tableName.WriteString(p.current.Value)
-		p.advance()
+	tableName, err := p.parseQualifiedIdentifier("table name")
+	if err != nil {
+		return nil, err
 	}
 
 	p.skipWhitespace()
@@ -244,7 +256,7 @@ func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
 		return nil, fmt.Errorf("expected '(' after table name: %w", err)
 	}
 
-	table := ast.NewCreateTable(tableName.String())
+	table := ast.NewCreateTable(tableName)
 
 	// Parse column definitions and constraints
 	for {
@@ -1791,6 +1803,66 @@ func (p *Parser) parseAlterStatement() (*ast.AlterTableNode, error) {
 	}
 
 	return alterNode, nil
+}
+
+func (p *Parser) parseDropStatement() (ast.Node, error) {
+	if err := p.expect(lexer.TokenIdentifier, "DROP"); err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+
+	if p.current.Type != lexer.TokenIdentifier {
+		return nil, fmt.Errorf("expected DROP target, got %s at position %d", p.current.Type, p.current.Start)
+	}
+
+	target := strings.ToUpper(p.current.Value)
+	switch target {
+	case "TABLE":
+		return p.parseDropTable()
+	default:
+		return nil, fmt.Errorf("unsupported DROP target: %s at position %d", target, p.current.Start)
+	}
+}
+
+func (p *Parser) parseDropTable() (*ast.DropTableNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "TABLE"); err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+
+	ifExists := false
+	if p.current.MatchIdentifierValue("IF") {
+		p.advance()
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "EXISTS"); err != nil {
+			return nil, fmt.Errorf("expected EXISTS after DROP TABLE IF: %w", err)
+		}
+		p.skipWhitespace()
+		ifExists = true
+	}
+
+	tableName, err := p.parseQualifiedIdentifier("table name")
+	if err != nil {
+		return nil, err
+	}
+
+	dropTable := ast.NewDropTable(tableName)
+	if ifExists {
+		dropTable.SetIfExists()
+	}
+
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("CASCADE") {
+		dropTable.SetCascade()
+		p.advance()
+		return dropTable, nil
+	}
+	if p.current.MatchIdentifierValue("RESTRICT") {
+		p.advance()
+	}
+	return dropTable, nil
 }
 
 // parseAlterOperation parses individual ALTER TABLE operations.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/parser"
+	"github.com/stokaro/ptah/core/renderer"
 )
 
 func TestNewParser(t *testing.T) {
@@ -119,6 +120,71 @@ func TestParser_ParseAlterTable(t *testing.T) {
 	c.Assert(addOp.Column.Name, qt.Equals, "email")
 	c.Assert(addOp.Column.Type, qt.Equals, "VARCHAR(255)")
 	c.Assert(addOp.Column.Unique, qt.IsTrue)
+}
+
+func TestParser_ParseDropTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		table    string
+		ifExists bool
+		cascade  bool
+		rendered string
+	}{
+		{
+			name:     "basic",
+			sql:      "DROP TABLE users;",
+			table:    "users",
+			rendered: "DROP TABLE users;\n",
+		},
+		{
+			name:     "if exists",
+			sql:      "DROP TABLE IF EXISTS users;",
+			table:    "users",
+			ifExists: true,
+			rendered: "DROP TABLE IF EXISTS users;\n",
+		},
+		{
+			name:     "qualified cascade",
+			sql:      "DROP TABLE public.users CASCADE;",
+			table:    "public.users",
+			cascade:  true,
+			rendered: "DROP TABLE public.users CASCADE;\n",
+		},
+		{
+			name:     "restrict",
+			sql:      "DROP TABLE users RESTRICT;",
+			table:    "users",
+			rendered: "DROP TABLE users;\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := parser.NewParser(tt.sql).Parse()
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+
+			dropTable, ok := statements.Statements[0].(*ast.DropTableNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(dropTable.Name, qt.Equals, tt.table)
+			c.Assert(dropTable.IfExists, qt.Equals, tt.ifExists)
+			c.Assert(dropTable.Cascade, qt.Equals, tt.cascade)
+
+			rendered, err := renderer.RenderSQL("postgres", dropTable)
+			c.Assert(err, qt.IsNil)
+			c.Assert(rendered, qt.Equals, tt.rendered)
+		})
+	}
+}
+
+func TestParser_ParseDropTableRejectsUnsupportedTargets(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parser.NewParser("DROP VIEW users;").Parse()
+	c.Assert(err, qt.ErrorMatches, "unsupported DROP target: VIEW at position 5")
 }
 
 func TestParser_ParseCreateIndex(t *testing.T) {


### PR DESCRIPTION
## Summary

- Parse top-level `DROP TABLE` statements into the existing `ast.DropTableNode`.
- Support `IF EXISTS`, qualified table names, `CASCADE`, and `RESTRICT`.
- Keep unsupported `DROP` targets explicit instead of silently accepting them.
- Add parser tests that also render parsed drops through the PostgreSQL renderer.

Fixes #300.

## Validation

- `gopls go_diagnostics`: no diagnostics
- `gopls go_vulncheck ./...`: no reported vulnerabilities
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser ./core/renderer/...`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `git diff --check`
- `ptah-atlas-conformance` dry-run with local Ptah through `GOWORK`: `185 -> 177` unwaived gaps; all 8 baseline `unsupported SQL statement: DROP` rows are gone
