### PR TITLE
Skip schema-neutral parser statements

### DIFF
--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -29,6 +29,14 @@ The parser supports the following SQL DDL statements:
 ### CREATE TYPE (ENUM)
 - PostgreSQL-style enum type definitions
 
+### Schema-neutral statements
+- DML and session-control statements such as `INSERT`, `UPDATE`, `DELETE`,
+  `SELECT`, `PRAGMA`, `SET`, `BEGIN`, `COMMIT`, and `ROLLBACK` are skipped.
+
+These statements are intentionally not represented in the schema AST. They can
+appear in migration files alongside DDL, but they do not describe the database
+schema that Ptah can diff or render.
+
 ## Usage
 
 ### Basic Usage
@@ -177,7 +185,9 @@ The parser integrates with other Ptah components:
 ## Limitations
 
 Current limitations include:
-- Limited to DDL statements (no DML like INSERT, UPDATE, DELETE)
+- Limited to schema DDL statements. DML like `INSERT`, `UPDATE`, and `DELETE`
+  is tolerated and skipped when it appears in a migration file, but it is not
+  modeled in the AST.
 - Basic expression parsing in CHECK constraints
 - Simplified handling of complex data types
 - No support for stored procedures or functions

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -105,6 +105,9 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseCommentStatement()
 	case "DROP":
 		return p.parseDropStatement()
+	case "ANALYZE", "BEGIN", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "UPDATE", "USE", "VACUUM", "WITH":
+		p.skipSchemaNeutralStatement()
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unsupported SQL statement: %s at position %d", keyword, p.current.Start)
 	}
@@ -211,6 +214,16 @@ func (p *Parser) parseQualifiedIdentifier(label string) (string, error) {
 // skipWhitespace skips whitespace and comment tokens.
 func (p *Parser) skipWhitespace() {
 	for p.current.Type == lexer.TokenWhitespace || p.current.Type == lexer.TokenComment {
+		p.advance()
+	}
+}
+
+func (p *Parser) skipSchemaNeutralStatement() {
+	for !p.isAtEnd() {
+		if p.current.Type == lexer.TokenSemicolon {
+			p.advance()
+			return
+		}
 		p.advance()
 	}
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -100,6 +100,41 @@ func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 	c.Assert(createTable.Comment, qt.Equals, "'Product catalog'")
 }
 
+func TestParser_ParseSkipsSchemaNeutralStatements(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `
+		INSERT INTO ignored_seed_data (id, name) VALUES (1, 'semi;colon');
+		CREATE TABLE users (id INTEGER PRIMARY KEY);
+		PRAGMA foreign_keys = off;
+		SELECT * FROM users;
+	`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable, ok := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "users")
+}
+
+func TestParser_ParseSchemaNeutralOnlyReturnsNoStatements(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := parser.NewParser("INSERT INTO seed_data (id) VALUES (1);").Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 0)
+}
+
+func TestParser_ParseRejectsUnknownStatement(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parser.NewParser("BROKEN STATEMENT;").Parse()
+	c.Assert(err, qt.ErrorMatches, `unsupported SQL statement: BROKEN at position 0`)
+}
+
 func TestParser_ParseAlterTable(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What changed

- Teach the DDL parser to skip schema-neutral DML/session statements such as `INSERT`, `SELECT`, `PRAGMA`, `SET`, `BEGIN`, and `COMMIT`.
- Keep those statements out of the schema AST rather than wrapping them as raw SQL.
- Add parser tests for mixed DDL plus seed data, pure schema-neutral input, and unknown statement rejection.
- Document the behavior in the parser README.

## Why

Atlas migration fixtures often contain schema DDL mixed with seed/utility SQL. Ptah's schema parser used to parse the DDL and then fail as soon as it reached `INSERT`, `SELECT`, or similar non-schema statements. Those statements do not describe the schema Ptah can diff or render, so they should not block parsing of nearby DDL.

This does not claim DML support. A file containing only schema-neutral statements still returns zero schema statements, and unknown junk such as `BROKEN STATEMENT` still fails.

## Conformance impact

Checked against local `ptah-atlas-conformance` using a temporary Go workspace pointing at this branch:

- Unwaived gaps: `177 -> 160`
- `sql-parse` red entries: `63 -> 46`
- No new red entries were introduced.

The 17 removed gaps are Atlas import/versioned migration fixtures where Ptah now parses the schema DDL instead of failing on seed or lock statements.

## Validation

- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/... ./migration/...`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-conformance-go-cache GOWORK=/private/tmp/ptah-conformance-local-work/go.work go run ./cmd/gap-probe -md /private/tmp/ptah-local-gaps.md -json /private/tmp/ptah-local-gaps.json`
