### PR TITLE
Parse CREATE VIEW statements

### DIFF
--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -26,6 +26,10 @@ The parser supports the following SQL DDL statements:
 - Unique indexes
 - Multi-column indexes
 
+### CREATE VIEW
+- `CREATE VIEW ... AS SELECT ...`
+- `CREATE OR REPLACE VIEW ... AS SELECT ...`
+
 ### CREATE TYPE (ENUM)
 - PostgreSQL-style enum type definitions
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -122,15 +122,19 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, INDEX, TYPE), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, INDEX, TYPE, DOMAIN), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
 	switch target {
 	case "TABLE":
 		return p.parseCreateTable()
+	case "VIEW":
+		return p.parseCreateView()
 	case "INDEX":
 		return p.parseCreateIndex()
+	case "OR":
+		return p.parseCreateOrReplaceStatement()
 	case "UNIQUE":
 		// Handle CREATE UNIQUE INDEX
 		p.advance()
@@ -146,6 +150,21 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	default:
 		return nil, fmt.Errorf("unsupported CREATE target: %s at position %d", target, p.current.Start)
 	}
+}
+
+func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
+	if err := p.expect(lexer.TokenIdentifier, "OR"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "REPLACE"); err != nil {
+		return nil, fmt.Errorf("expected REPLACE after CREATE OR: %w", err)
+	}
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("VIEW") {
+		return p.parseCreateOrReplaceView()
+	}
+	return nil, fmt.Errorf("unsupported CREATE OR REPLACE target: %s at position %d", p.current.Value, p.current.Start)
 }
 
 // advance moves to the next token.
@@ -246,6 +265,52 @@ func isNumeric(s string) bool {
 		}
 	}
 	return true
+}
+
+func (p *Parser) parseCreateView() (*ast.CreateViewNode, error) {
+	return p.parseCreateViewNode()
+}
+
+func (p *Parser) parseCreateOrReplaceView() (*ast.CreateViewNode, error) {
+	view, err := p.parseCreateViewNode()
+	if err != nil {
+		return nil, err
+	}
+	view.SetReplace()
+	return view, nil
+}
+
+func (p *Parser) parseCreateViewNode() (*ast.CreateViewNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "VIEW"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	viewName, err := p.parseQualifiedIdentifier("view name")
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	if err := p.expect(lexer.TokenIdentifier, "AS"); err != nil {
+		return nil, fmt.Errorf("expected AS after view name: %w", err)
+	}
+
+	body := p.collectStatementBody()
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("expected view body after AS at position %d", p.current.Start)
+	}
+
+	return ast.NewCreateView(viewName).SetBody(body), nil
+}
+
+func (p *Parser) collectStatementBody() string {
+	var body strings.Builder
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+	return strings.TrimSpace(body.String())
 }
 
 // parseCreateTable parses CREATE TABLE statements.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -100,6 +100,47 @@ func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 	c.Assert(createTable.Comment, qt.Equals, "'Product catalog'")
 }
 
+func TestParser_ParseCreateView(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE VIEW active_users AS SELECT id, name FROM users WHERE active = true;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createView, ok := statements.Statements[0].(*ast.CreateViewNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createView.Name, qt.Equals, "active_users")
+	c.Assert(createView.Replace, qt.IsFalse)
+	c.Assert(createView.Body, qt.Equals, "SELECT id, name FROM users WHERE active = true")
+}
+
+func TestParser_ParseCreateOrReplaceView(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE OR REPLACE VIEW public.active_users AS SELECT * FROM users;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createView, ok := statements.Statements[0].(*ast.CreateViewNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createView.Name, qt.Equals, "public.active_users")
+	c.Assert(createView.Replace, qt.IsTrue)
+	c.Assert(createView.Body, qt.Equals, "SELECT * FROM users")
+}
+
+func TestParser_ParseRejectsUnsupportedCreateOrReplaceTarget(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parser.NewParser("CREATE OR REPLACE FUNCTION f() RETURNS int AS $$ SELECT 1 $$;").Parse()
+	c.Assert(err, qt.ErrorMatches, `unsupported CREATE OR REPLACE target: FUNCTION at position 18`)
+}
+
 func TestParser_ParseSkipsSchemaNeutralStatements(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What changed

- Added parser support for `CREATE VIEW ... AS ...`.
- Added parser support for `CREATE OR REPLACE VIEW ... AS ...`.
- Store the view SELECT body in the existing `ast.CreateViewNode` instead of trying to parse SELECT into a schema AST.
- Added parser tests for plain views, replace views, and unsupported `CREATE OR REPLACE FUNCTION`.
- Documented `CREATE VIEW` parser support.

## Why

Ptah already has structured view AST nodes and renderers, but the parser did not wire `CREATE VIEW` into the SQL round-trip path. Atlas import fixtures include view migrations, so this left avoidable `sql-parse` gaps.

This does not claim function/procedure support. `CREATE OR REPLACE FUNCTION` remains a parser gap.

## Conformance impact

Checked against local `ptah-atlas-conformance` using a temporary Go workspace pointing at this branch:

- Unwaived gaps: `160 -> 157`
- `sql-parse` red entries: `46 -> 43`
- No new red entries were introduced.

The removed gaps are the three Atlas `CREATE VIEW` fixtures:

- `cmd/atlas/internal/cmdapi/testdata/import/flyway/R__views.sql`
- `cmd/atlas/internal/cmdapi/testdata/import/flyway_gold/3R_views.sql`
- `sql/sqltool/testdata/flyway/R__views.sql`

## Validation

- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/... ./migration/...`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-conformance-go-cache GOWORK=/private/tmp/ptah-conformance-local-work/go.work go run ./cmd/gap-probe -md /private/tmp/ptah-view-gaps.md -json /private/tmp/ptah-view-gaps.json`
