### PR TITLE
Parse CREATE FUNCTION statements

### DIFF
--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -30,6 +30,11 @@ The parser supports the following SQL DDL statements:
 - `CREATE VIEW ... AS SELECT ...`
 - `CREATE OR REPLACE VIEW ... AS SELECT ...`
 
+### CREATE FUNCTION
+- PostgreSQL-style `CREATE FUNCTION ... RETURNS ... AS $...$ LANGUAGE ...`
+- PostgreSQL-style `CREATE OR REPLACE FUNCTION ... AS '...' LANGUAGE ...`
+- Function parameters, return type, language, security, and volatility clauses
+
 ### CREATE TYPE (ENUM)
 - PostgreSQL-style enum type definitions
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -122,7 +122,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, INDEX, TYPE, DOMAIN), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
@@ -131,6 +131,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateTable()
 	case "VIEW":
 		return p.parseCreateView()
+	case "FUNCTION":
+		return p.parseCreateFunction()
 	case "INDEX":
 		return p.parseCreateIndex()
 	case "OR":
@@ -163,6 +165,9 @@ func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
 	p.skipWhitespace()
 	if p.current.MatchIdentifierValue("VIEW") {
 		return p.parseCreateOrReplaceView()
+	}
+	if p.current.MatchIdentifierValue("FUNCTION") {
+		return p.parseCreateOrReplaceFunction()
 	}
 	return nil, fmt.Errorf("unsupported CREATE OR REPLACE target: %s at position %d", p.current.Value, p.current.Start)
 }
@@ -278,6 +283,200 @@ func (p *Parser) parseCreateOrReplaceView() (*ast.CreateViewNode, error) {
 	}
 	view.SetReplace()
 	return view, nil
+}
+
+func (p *Parser) parseCreateFunction() (*ast.CreateFunctionNode, error) {
+	return p.parseCreateFunctionNode()
+}
+
+func (p *Parser) parseCreateOrReplaceFunction() (*ast.CreateFunctionNode, error) {
+	return p.parseCreateFunctionNode()
+}
+
+func (p *Parser) parseCreateFunctionNode() (*ast.CreateFunctionNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "FUNCTION"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	functionName, err := p.parseQualifiedIdentifier("function name")
+	if err != nil {
+		return nil, fmt.Errorf("unsupported CREATE FUNCTION syntax: %w", err)
+	}
+
+	p.skipWhitespace()
+	parameters, err := p.collectParenthesizedBody("function parameters")
+	if err != nil {
+		return nil, err
+	}
+
+	function := ast.NewCreateFunction(functionName).SetParameters(parameters)
+	if err := p.parseFunctionClauses(function); err != nil {
+		return nil, err
+	}
+	return function, nil
+}
+
+func (p *Parser) collectParenthesizedBody(label string) (string, error) {
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return "", fmt.Errorf("expected '(' for %s: %w", label, err)
+	}
+
+	var body strings.Builder
+	depth := 1
+	for depth > 0 && !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+
+		if p.current.Type == lexer.TokenOperator {
+			switch p.current.Value {
+			case "(":
+				depth++
+			case ")":
+				depth--
+				if depth == 0 {
+					p.advance()
+					return strings.TrimSpace(body.String()), nil
+				}
+			}
+		}
+
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	return "", fmt.Errorf("unterminated %s at position %d", label, p.current.Start)
+}
+
+func (p *Parser) parseFunctionClauses(function *ast.CreateFunctionNode) error {
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if err := p.checkTimeout(); err != nil {
+			return err
+		}
+
+		p.skipWhitespace()
+		if p.isAtEnd() || p.current.Type == lexer.TokenSemicolon {
+			return nil
+		}
+		if p.current.Type != lexer.TokenIdentifier {
+			return fmt.Errorf("unsupported CREATE FUNCTION syntax: expected function clause, got %s at position %d", p.current.Type, p.current.Start)
+		}
+
+		switch strings.ToUpper(p.current.Value) {
+		case "RETURNS":
+			if err := p.parseFunctionReturns(function); err != nil {
+				return err
+			}
+		case "AS":
+			if err := p.parseFunctionBody(function); err != nil {
+				return err
+			}
+		case "LANGUAGE":
+			if err := p.parseFunctionLanguage(function); err != nil {
+				return err
+			}
+		case "SECURITY":
+			if err := p.parseFunctionSecurity(function); err != nil {
+				return err
+			}
+		case "IMMUTABLE", "STABLE", "VOLATILE":
+			function.SetVolatility(strings.ToUpper(p.current.Value))
+			p.advance()
+		default:
+			return fmt.Errorf("unsupported CREATE FUNCTION clause: %s at position %d", p.current.Value, p.current.Start)
+		}
+	}
+	return nil
+}
+
+func (p *Parser) parseFunctionReturns(function *ast.CreateFunctionNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "RETURNS"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+
+	var returns strings.Builder
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if p.current.Type == lexer.TokenIdentifier {
+			switch strings.ToUpper(p.current.Value) {
+			case "AS", "LANGUAGE", "SECURITY", "IMMUTABLE", "STABLE", "VOLATILE":
+				function.SetReturns(strings.TrimSpace(returns.String()))
+				return nil
+			}
+		}
+		returns.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	function.SetReturns(strings.TrimSpace(returns.String()))
+	return nil
+}
+
+func (p *Parser) parseFunctionBody(function *ast.CreateFunctionNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "AS"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+
+	if p.current.Type != lexer.TokenString {
+		return fmt.Errorf("unsupported CREATE FUNCTION body: expected string literal after AS, got %s at position %d", p.current.Type, p.current.Start)
+	}
+
+	body := p.current.Value
+	function.SetBody(stripSQLStringDelimiters(body))
+	p.advance()
+	return nil
+}
+
+func (p *Parser) parseFunctionLanguage(function *ast.CreateFunctionNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "LANGUAGE"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+
+	language, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected function language: %w", err)
+	}
+	function.SetLanguage(language)
+	return nil
+}
+
+func (p *Parser) parseFunctionSecurity(function *ast.CreateFunctionNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "SECURITY"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+
+	security, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected function security mode: %w", err)
+	}
+	function.SetSecurity(strings.ToUpper(security))
+	return nil
+}
+
+func stripSQLStringDelimiters(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	if value[0] == '\'' && value[len(value)-1] == '\'' {
+		return value[1 : len(value)-1]
+	}
+	if value[0] != '$' {
+		return value
+	}
+
+	end := strings.Index(value[1:], "$")
+	if end < 0 {
+		return value
+	}
+	tag := value[:end+2]
+	if !strings.HasSuffix(value, tag) {
+		return value
+	}
+	return value[len(tag) : len(value)-len(tag)]
 }
 
 func (p *Parser) parseCreateViewNode() (*ast.CreateViewNode, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -134,11 +134,84 @@ func TestParser_ParseCreateOrReplaceView(t *testing.T) {
 	c.Assert(createView.Body, qt.Equals, "SELECT * FROM users")
 }
 
+func TestParser_ParseCreateFunction(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.add_one(value integer)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT value + 1; $$;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "public.add_one")
+	c.Assert(createFunction.Parameters, qt.Equals, "value integer")
+	c.Assert(createFunction.Returns, qt.Equals, "integer")
+	c.Assert(createFunction.Language, qt.Equals, "sql")
+	c.Assert(createFunction.Volatility, qt.Equals, "IMMUTABLE")
+	c.Assert(createFunction.Body, qt.Equals, " SELECT value + 1; ")
+}
+
+func TestParser_ParseCreateOrReplaceFunction(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE
+OR REPLACE FUNCTION histories_partition_creation( DATE, DATE )
+returns void AS $$
+DECLARE
+create_query text;
+BEGIN
+EXECUTE create_query;
+END;
+$$
+language plpgsql;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "histories_partition_creation")
+	c.Assert(createFunction.Parameters, qt.Equals, "DATE, DATE")
+	c.Assert(createFunction.Returns, qt.Equals, "void")
+	c.Assert(createFunction.Language, qt.Equals, "plpgsql")
+	c.Assert(createFunction.Body, qt.Contains, "EXECUTE create_query;")
+}
+
+func TestParser_ParseCreateFunctionWithSingleQuotedBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE FUNCTION public.read_value() RETURNS text AS 'SELECT current_user' LANGUAGE sql SECURITY DEFINER STABLE;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "public.read_value")
+	c.Assert(createFunction.Parameters, qt.Equals, "")
+	c.Assert(createFunction.Returns, qt.Equals, "text")
+	c.Assert(createFunction.Body, qt.Equals, "SELECT current_user")
+	c.Assert(createFunction.Language, qt.Equals, "sql")
+	c.Assert(createFunction.Security, qt.Equals, "DEFINER")
+	c.Assert(createFunction.Volatility, qt.Equals, "STABLE")
+}
+
 func TestParser_ParseRejectsUnsupportedCreateOrReplaceTarget(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := parser.NewParser("CREATE OR REPLACE FUNCTION f() RETURNS int AS $$ SELECT 1 $$;").Parse()
-	c.Assert(err, qt.ErrorMatches, `unsupported CREATE OR REPLACE target: FUNCTION at position 18`)
+	_, err := parser.NewParser("CREATE OR REPLACE PROCEDURE p() AS $$ SELECT 1 $$;").Parse()
+	c.Assert(err, qt.ErrorMatches, `unsupported CREATE OR REPLACE target: PROCEDURE at position 18`)
 }
 
 func TestParser_ParseSkipsSchemaNeutralStatements(t *testing.T) {


### PR DESCRIPTION
## What changed

- Added parser support for PostgreSQL-style `CREATE FUNCTION` and `CREATE OR REPLACE FUNCTION`.
- Captures function name, parameters, return type, language, security mode, volatility, and quoted function body into the existing `ast.CreateFunctionNode`.
- Documents the supported parser scope in `core/parser/README.md`.

## Conformance impact

Local `ptah-atlas-conformance` probe using this branch:

- Unwaived gaps: `157 -> 154`
- `sql-parse` red entries: `43 -> 40`
- Removed red keys:
  - `cmd/atlas/internal/cmdapi/testdata/import/goose/2_second_migration.sql`
  - `cmd/atlas/internal/cmdapi/testdata/import/goose_gold/2_second_migration.sql`
  - `sql/sqltool/testdata/goose/2_second_migration.sql`

No new red keys were added.

## Scope notes

This does not claim support for SQL-standard `RETURN` / `BEGIN ATOMIC` functions, procedures, triggers, MySQL delimiter routines, or SQL Server bracketed routine syntax. Those remain visible as conformance gaps.

## Validation

- `gopls` diagnostics on changed Go files
- `go test ./core/parser`
- `go test ./core/... ./migration/...`
- `go test ./...`
- `golangci-lint run ./...`
- Local conformance probe with `GOWORK=/private/tmp/ptah-function-work/go.work`
- `git diff --check`
