### PR TITLE
Parse ALTER TABLE RENAME TO

### DIFF
--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -168,6 +168,26 @@ func (op *RenameColumnOperation) Accept(_visitor Visitor) error { return nil }
 // alterOperation implements the marker method for type safety.
 func (op *RenameColumnOperation) alterOperation() {}
 
+// RenameTableOperation represents a RENAME TO operation in ALTER TABLE statements.
+//
+// It is modeled separately from RenameColumnOperation because it changes the
+// relation name itself rather than a column inside the relation. Dialects may
+// render this as `ALTER TABLE old_name RENAME TO new_name` or as an equivalent
+// standalone table-rename statement.
+type RenameTableOperation struct {
+	// NewName is the new table name.
+	NewName string
+}
+
+// Accept implements the Node interface for RenameTableOperation.
+//
+// The actual rendering is handled by the dialect's VisitAlterTable method;
+// this stub exists to satisfy the Node interface.
+func (op *RenameTableOperation) Accept(_visitor Visitor) error { return nil }
+
+// alterOperation implements the marker method for type safety.
+func (op *RenameTableOperation) alterOperation() {}
+
 // AddSkippingIndexOperation represents ClickHouse's
 // `ALTER TABLE x ADD INDEX name expression TYPE indexType GRANULARITY n`.
 //

--- a/core/ast/operations_test.go
+++ b/core/ast/operations_test.go
@@ -98,8 +98,10 @@ func TestAlterOperations_ImplementInterface(t *testing.T) {
 	ops = append(ops, &ast.ModifyColumnOperation{Column: ast.NewColumn("test", "INTEGER")})
 	ops = append(ops, &ast.AddConstraintOperation{Constraint: ast.NewUniqueConstraint("uk_test", "test")})
 	ops = append(ops, &ast.DropConstraintOperation{ConstraintName: "test_constraint"})
+	ops = append(ops, &ast.RenameColumnOperation{OldName: "old_test", NewName: "test"})
+	ops = append(ops, &ast.RenameTableOperation{NewName: "renamed_test"})
 
-	c.Assert(ops, qt.HasLen, 5)
+	c.Assert(ops, qt.HasLen, 7)
 
 	// Test that they all implement the Node interface as well (since AlterOperation embeds Node)
 	for _, op := range ops {
@@ -120,6 +122,8 @@ func TestAlterOperations_InterfaceCompliance(t *testing.T) {
 	var _ ast.AlterOperation = &ast.ModifyColumnOperation{}
 	var _ ast.AlterOperation = &ast.AddConstraintOperation{}
 	var _ ast.AlterOperation = &ast.DropConstraintOperation{}
+	var _ ast.AlterOperation = &ast.RenameColumnOperation{}
+	var _ ast.AlterOperation = &ast.RenameTableOperation{}
 
 	// Test that they also implement Node interface
 	var _ ast.Node = &ast.AddColumnOperation{}
@@ -127,6 +131,8 @@ func TestAlterOperations_InterfaceCompliance(t *testing.T) {
 	var _ ast.Node = &ast.ModifyColumnOperation{}
 	var _ ast.Node = &ast.AddConstraintOperation{}
 	var _ ast.Node = &ast.DropConstraintOperation{}
+	var _ ast.Node = &ast.RenameColumnOperation{}
+	var _ ast.Node = &ast.RenameTableOperation{}
 
 	// If we get here, all interfaces are implemented correctly
 	c.Assert(true, qt.IsTrue)

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -19,6 +19,9 @@ The parser supports the following SQL DDL statements:
 - ADD COLUMN operations
 - DROP COLUMN operations  
 - MODIFY/ALTER COLUMN operations
+- RENAME COLUMN operations
+- RENAME TO table operations
+- Schema-qualified table names
 - Multiple operations in a single statement
 
 ### CREATE INDEX

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2041,9 +2041,9 @@ func (p *Parser) parseAlterStatement() (*ast.AlterTableNode, error) {
 	p.skipWhitespace()
 
 	// Get table name
-	tableName, err := p.expectIdentifier()
+	tableName, err := p.parseQualifiedIdentifier("table name")
 	if err != nil {
-		return nil, fmt.Errorf("expected table name: %w", err)
+		return nil, err
 	}
 
 	alterNode := &ast.AlterTableNode{
@@ -2158,9 +2158,57 @@ func (p *Parser) parseAlterOperation() (ast.AlterOperation, error) {
 		return p.parseDropOperation()
 	case "MODIFY", "ALTER":
 		return p.parseModifyOperation()
+	case "RENAME":
+		return p.parseRenameOperation()
 	default:
 		return nil, fmt.Errorf("unsupported ALTER operation: %s at position %d", operation, p.current.Start)
 	}
+}
+
+func (p *Parser) parseRenameOperation() (ast.AlterOperation, error) {
+	if err := p.expect(lexer.TokenIdentifier, "RENAME"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	if p.current.MatchIdentifierValue("COLUMN") {
+		return p.parseRenameColumnOperation()
+	}
+	if !p.current.MatchIdentifierValue("TO") {
+		return nil, fmt.Errorf("expected TO or COLUMN after RENAME at position %d", p.current.Start)
+	}
+
+	p.advance()
+	p.skipWhitespace()
+	newName, err := p.parseQualifiedIdentifier("new table name")
+	if err != nil {
+		return nil, err
+	}
+	return &ast.RenameTableOperation{NewName: newName}, nil
+}
+
+func (p *Parser) parseRenameColumnOperation() (*ast.RenameColumnOperation, error) {
+	if err := p.expect(lexer.TokenIdentifier, "COLUMN"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	oldName, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected old column name: %w", err)
+	}
+	p.skipWhitespace()
+
+	if err := p.expect(lexer.TokenIdentifier, "TO"); err != nil {
+		return nil, fmt.Errorf("expected TO after old column name: %w", err)
+	}
+	p.skipWhitespace()
+
+	newName, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected new column name: %w", err)
+	}
+	return &ast.RenameColumnOperation{OldName: oldName, NewName: newName}, nil
 }
 
 // parseAddOperation parses ADD COLUMN operations.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -271,6 +271,88 @@ func TestParser_ParseAlterTable(t *testing.T) {
 	c.Assert(addOp.Column.Unique, qt.IsTrue)
 }
 
+func TestParser_ParseAlterTableQualifiedName(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "ALTER TABLE `atlantis`.`tbl` ADD `col_2` TEXT;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "`atlantis`.`tbl`")
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
+
+	addOp, ok := alterTable.Operations[0].(*ast.AddColumnOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(addOp.Column.Name, qt.Equals, "`col_2`")
+	c.Assert(addOp.Column.Type, qt.Equals, "TEXT")
+}
+
+func TestParser_ParseAlterTableRenameTable(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "ALTER TABLE `new_users` RENAME TO `users`;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "`new_users`")
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
+
+	renameOp, ok := alterTable.Operations[0].(*ast.RenameTableOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(renameOp.NewName, qt.Equals, "`users`")
+}
+
+func TestParser_ParseAlterTableRenameQualifiedTable(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "ALTER TABLE public.old_users RENAME TO archive.users;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "public.old_users")
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
+
+	renameOp, ok := alterTable.Operations[0].(*ast.RenameTableOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(renameOp.NewName, qt.Equals, "archive.users")
+}
+
+func TestParser_ParseAlterTableRenameColumn(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "ALTER TABLE users RENAME COLUMN old_name TO new_name;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "users")
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
+
+	renameOp, ok := alterTable.Operations[0].(*ast.RenameColumnOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(renameOp.OldName, qt.Equals, "old_name")
+	c.Assert(renameOp.NewName, qt.Equals, "new_name")
+}
+
 func TestParser_ParseDropTable(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -623,6 +623,8 @@ func (r *Renderer) VisitAlterTable(node *ast.AlterTableNode) error {
 			// on MergeTree-family engines. The runtime DB version is the
 			// user's problem; we emit the canonical spelling unconditionally.
 			r.w.WriteLinef("ALTER TABLE %s RENAME COLUMN %s TO %s;", node.Name, op.OldName, op.NewName)
+		case *ast.RenameTableOperation:
+			r.w.WriteLinef("RENAME TABLE %s TO %s;", node.Name, op.NewName)
 		case *ast.AddSkippingIndexOperation:
 			if err := r.renderAddSkippingIndex(node.Name, op); err != nil {
 				return err

--- a/core/renderer/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/dialects/clickhouse/clickhouse_test.go
@@ -577,6 +577,18 @@ func TestAlterTable_RenameColumn(t *testing.T) {
 	c.Assert(out, qt.Contains, "ALTER TABLE events RENAME COLUMN payload_old TO payload;")
 }
 
+func TestAlterTable_RenameTable(t *testing.T) {
+	c := qt.New(t)
+	alter := &ast.AlterTableNode{
+		Name: "old_events",
+		Operations: []ast.AlterOperation{
+			&ast.RenameTableOperation{NewName: "events"},
+		},
+	}
+	out := render(t, alter)
+	c.Assert(out, qt.Contains, "RENAME TABLE old_events TO events;")
+}
+
 func TestAlterTable_AddSkippingIndex(t *testing.T) {
 	cases := []struct {
 		name string

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -36,6 +36,18 @@ func TestMySQL_AlterTable_RenameColumn(t *testing.T) {
 	c.Assert(out, qt.Contains, "ALTER TABLE users RENAME COLUMN email_old TO email;")
 }
 
+func TestMySQL_AlterTable_RenameTable(t *testing.T) {
+	c := qt.New(t)
+	alter := &ast.AlterTableNode{
+		Name: "old_users",
+		Operations: []ast.AlterOperation{
+			&ast.RenameTableOperation{NewName: "users"},
+		},
+	}
+	out := renderMySQL(t, alter)
+	c.Assert(out, qt.Contains, "ALTER TABLE old_users RENAME TO users;")
+}
+
 func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 	c := qt.New(t)
 	alter := &ast.AlterTableNode{

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -651,6 +651,8 @@ func (r *Renderer) visitAlterTableWithEnums(node *ast.AlterTableNode, enums map[
 			// version is the caller's concern; older servers will fail at
 			// migration apply time rather than at SQL generation time.
 			r.w.WriteLinef("ALTER TABLE %s RENAME COLUMN %s TO %s;", node.Name, op.OldName, op.NewName)
+		case *ast.RenameTableOperation:
+			r.w.WriteLinef("ALTER TABLE %s RENAME TO %s;", node.Name, op.NewName)
 
 		case *ast.AddSkippingIndexOperation:
 			// Data-skipping indexes are a ClickHouse-specific construct; no

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -36,6 +36,18 @@ func TestPostgres_AlterTable_RenameColumn(t *testing.T) {
 	c.Assert(out, qt.Contains, "ALTER TABLE users RENAME COLUMN email_old TO email;")
 }
 
+func TestPostgres_AlterTable_RenameTable(t *testing.T) {
+	c := qt.New(t)
+	alter := &ast.AlterTableNode{
+		Name: "old_users",
+		Operations: []ast.AlterOperation{
+			&ast.RenameTableOperation{NewName: "users"},
+		},
+	}
+	out := renderPG(t, alter)
+	c.Assert(out, qt.Contains, "ALTER TABLE old_users RENAME TO users;")
+}
+
 // AddSkippingIndex and ModifyTTL are ClickHouse-only; postgres emits an
 // explanatory comment and otherwise treats the operation as a no-op.
 func TestPostgres_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -341,6 +341,8 @@ func (r *Renderer) VisitAlterTable(node *ast.AlterTableNode) error {
 			// PostgreSQL has supported `ALTER TABLE x RENAME COLUMN old TO new`
 			// for a long time; emit it unconditionally.
 			r.w.WriteLinef("ALTER TABLE %s RENAME COLUMN %s TO %s;", node.Name, op.OldName, op.NewName)
+		case *ast.RenameTableOperation:
+			r.w.WriteLinef("ALTER TABLE %s RENAME TO %s;", node.Name, op.NewName)
 		case *ast.AddSkippingIndexOperation:
 			// Data-skipping indexes are a ClickHouse-specific construct; no
 			// PostgreSQL equivalent exists. Emit a self-explanatory comment.

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -356,6 +356,8 @@ func classifyAlterOperation(op ast.AlterOperation) (Severity, string) {
 		return Destructive, "DROP CONSTRAINT removes an existing data protection"
 	case *ast.RenameColumnOperation:
 		return Warning, "RENAME COLUMN can break deployed readers and writers"
+	case *ast.RenameTableOperation:
+		return Warning, "RENAME TABLE can break deployed readers and writers"
 	case *ast.AddConstraintOperation:
 		return Warning, "ADD CONSTRAINT can fail on existing rows"
 	case *ast.AddColumnOperation:

--- a/migration/safety/safety_test.go
+++ b/migration/safety/safety_test.go
@@ -110,6 +110,12 @@ func TestClassifyASTStatements(t *testing.T) {
 			},
 		},
 	}), qt.Equals, safety.Destructive)
+	c.Assert(safety.Classify(&ast.AlterTableNode{
+		Name: "old_users",
+		Operations: []ast.AlterOperation{
+			&ast.RenameTableOperation{NewName: "users"},
+		},
+	}), qt.Equals, safety.Warning)
 	c.Assert(safety.Classify(ast.NewIndex("users_email_key", "users", "email").SetUnique()), qt.Equals, safety.Warning)
 	c.Assert(safety.Classify(ast.NewRawSQL("DELETE FROM pg_enum WHERE enumlabel = 'archived'")), qt.Equals, safety.Destructive)
 	c.Assert(safety.Classify(ast.NewRawSQL("DROP TYPE status")), qt.Equals, safety.Destructive)


### PR DESCRIPTION
## Summary
- add a dedicated AST operation for ALTER TABLE table renames
- parse ALTER TABLE ... RENAME TO, keep RENAME COLUMN on its own operation, and allow schema-qualified ALTER TABLE targets
- render table renames for PostgreSQL/MySQL/MariaDB and ClickHouse, and classify table renames as a safety warning

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser ./core/ast ./core/renderer/dialects/postgres ./core/renderer/dialects/mysql ./core/renderer/dialects/clickhouse ./migration/safety
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/... ./migration/...
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- conformance probe through temporary go.work: 154 -> 151 unwaived gaps, no new red keys

## Conformance keys removed
- sql-parse cmd/atlas/internal/cmdapi/testdata/mysql/20220420213403_second.sql round-trip
- sql-parse cmd/atlas/internal/cmdapi/testdata/sqlitetx/20220925094437_third.sql round-trip
- sql-parse cmd/atlas/internal/cmdapi/testdata/sqlitetx2/20220925094437_third.sql round-trip