### PR TITLE
Parse CREATE SCHEMA and DATABASE

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -12,6 +12,10 @@ package ast
 type Visitor interface {
 	// VisitCreateTable renders a CREATE TABLE statement
 	VisitCreateTable(*CreateTableNode) error
+	// VisitCreateSchema renders a CREATE SCHEMA statement
+	VisitCreateSchema(*CreateSchemaNode) error
+	// VisitCreateDatabase renders a CREATE DATABASE statement
+	VisitCreateDatabase(*CreateDatabaseNode) error
 	// VisitAlterTable renders an ALTER TABLE statement
 	VisitAlterTable(*AlterTableNode) error
 	// VisitColumn renders a column definition (typically called from other visitors)

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -20,6 +20,22 @@ func (m *MockVisitor) VisitCreateTable(node *ast.CreateTableNode) error {
 	return nil
 }
 
+func (m *MockVisitor) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "CreateSchema:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
+func (m *MockVisitor) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "CreateDatabase:"+node.Name)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}
+
 func (m *MockVisitor) VisitAlterTable(node *ast.AlterTableNode) error {
 	m.VisitedNodes = append(m.VisitedNodes, "AlterTable:"+node.Name)
 	if m.ReturnError {

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -99,6 +99,42 @@ func (n *CreateTableNode) Accept(visitor Visitor) error {
 	return visitor.VisitCreateTable(n)
 }
 
+// CreateSchemaNode represents a CREATE SCHEMA statement.
+type CreateSchemaNode struct {
+	// Name is the schema name.
+	Name string
+	// IfNotExists preserves an IF NOT EXISTS guard when the dialect supports it.
+	IfNotExists bool
+}
+
+// NewCreateSchema creates a new CREATE SCHEMA node.
+func NewCreateSchema(name string) *CreateSchemaNode {
+	return &CreateSchemaNode{Name: name}
+}
+
+// Accept implements the Node interface for CreateSchemaNode.
+func (n *CreateSchemaNode) Accept(visitor Visitor) error {
+	return visitor.VisitCreateSchema(n)
+}
+
+// CreateDatabaseNode represents a CREATE DATABASE statement.
+type CreateDatabaseNode struct {
+	// Name is the database name.
+	Name string
+	// IfNotExists preserves an IF NOT EXISTS guard when the dialect supports it.
+	IfNotExists bool
+}
+
+// NewCreateDatabase creates a new CREATE DATABASE node.
+func NewCreateDatabase(name string) *CreateDatabaseNode {
+	return &CreateDatabaseNode{Name: name}
+}
+
+// Accept implements the Node interface for CreateDatabaseNode.
+func (n *CreateDatabaseNode) Accept(visitor Visitor) error {
+	return visitor.VisitCreateDatabase(n)
+}
+
 // AddColumn adds a column to the CREATE TABLE statement and returns the table node for chaining.
 //
 // Example:

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -54,6 +54,31 @@ func TestCreateTableNode_Accept(t *testing.T) {
 	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"CreateTable:users"})
 }
 
+func TestCreateSchemaNode_Accept(t *testing.T) {
+	c := qt.New(t)
+
+	visitor := &mocks.MockVisitor{}
+	node := ast.NewCreateSchema("public")
+	node.IfNotExists = true
+
+	err := node.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"CreateSchema:public"})
+}
+
+func TestCreateDatabaseNode_Accept(t *testing.T) {
+	c := qt.New(t)
+
+	visitor := &mocks.MockVisitor{}
+	node := ast.NewCreateDatabase("app")
+
+	err := node.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"CreateDatabase:app"})
+}
+
 func TestAlterTableNode_Accept(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -15,6 +15,9 @@ The parser supports the following SQL DDL statements:
 - Table-level constraints (PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK)
 - Table options (ENGINE, CHARSET, COLLATE, COMMENT)
 
+### CREATE SCHEMA / CREATE DATABASE
+- Namespace creation with optional `IF NOT EXISTS`
+
 ### ALTER TABLE
 - ADD COLUMN operations
 - DROP COLUMN operations  

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -122,11 +122,15 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
 	switch target {
+	case "SCHEMA":
+		return p.parseCreateSchema()
+	case "DATABASE":
+		return p.parseCreateDatabase()
 	case "TABLE":
 		return p.parseCreateTable()
 	case "VIEW":
@@ -152,6 +156,58 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	default:
 		return nil, fmt.Errorf("unsupported CREATE target: %s at position %d", target, p.current.Start)
 	}
+}
+
+func (p *Parser) parseCreateSchema() (*ast.CreateSchemaNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "SCHEMA"); err != nil {
+		return nil, err
+	}
+	name, ifNotExists, err := p.parseCreateNamespaceName("schema name")
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CreateSchemaNode{Name: name, IfNotExists: ifNotExists}, nil
+}
+
+func (p *Parser) parseCreateDatabase() (*ast.CreateDatabaseNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "DATABASE"); err != nil {
+		return nil, err
+	}
+	name, ifNotExists, err := p.parseCreateNamespaceName("database name")
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CreateDatabaseNode{Name: name, IfNotExists: ifNotExists}, nil
+}
+
+func (p *Parser) parseCreateNamespaceName(label string) (string, bool, error) {
+	p.skipWhitespace()
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return "", false, err
+	}
+	p.skipWhitespace()
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return "", false, fmt.Errorf("expected %s: %w", label, err)
+	}
+	return name, ifNotExists, nil
+}
+
+func (p *Parser) parseOptionalIfNotExists() (bool, error) {
+	if !p.current.MatchIdentifierValue("IF") {
+		return false, nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "NOT"); err != nil {
+		return false, fmt.Errorf("expected NOT after IF: %w", err)
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "EXISTS"); err != nil {
+		return false, fmt.Errorf("expected EXISTS after IF NOT: %w", err)
+	}
+	return true, nil
 }
 
 func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
@@ -206,12 +262,16 @@ func (p *Parser) expect(tokenType lexer.TokenType, value string) error {
 
 // expectIdentifier consumes an identifier token and returns its value.
 func (p *Parser) expectIdentifier() (string, error) {
-	if p.current.Type != lexer.TokenIdentifier {
+	if p.current.Type != lexer.TokenIdentifier && !isDoubleQuotedIdentifierToken(p.current) {
 		return "", fmt.Errorf("expected identifier, got %s at position %d", p.current.Type, p.current.Start)
 	}
 	value := p.current.Value
 	p.advance()
 	return value, nil
+}
+
+func isDoubleQuotedIdentifierToken(tok lexer.Token) bool {
+	return tok.Type == lexer.TokenString && strings.HasPrefix(tok.Value, `"`)
 }
 
 func (p *Parser) parseQualifiedIdentifier(label string) (string, error) {
@@ -1774,10 +1834,10 @@ func (p *Parser) handleTableCharset(table *ast.CreateTableNode, option string) e
 		}
 		p.skipWhitespace()
 	}
-	if err := p.expect(lexer.TokenOperator, "="); err != nil {
-		return fmt.Errorf("expected '=' after CHARSET: %w", err)
+	if p.current.MatchOperatorValue("=") {
+		p.advance()
+		p.skipWhitespace()
 	}
-	p.skipWhitespace()
 	value, err := p.expectIdentifier()
 	if err != nil {
 		return fmt.Errorf("expected charset value: %w", err)
@@ -1790,10 +1850,10 @@ func (p *Parser) handleTableCollate(table *ast.CreateTableNode) error {
 	// Handle COLLATE
 	p.advance()
 	p.skipWhitespace()
-	if err := p.expect(lexer.TokenOperator, "="); err != nil {
-		return fmt.Errorf("expected '=' after COLLATE: %w", err)
+	if p.current.MatchOperatorValue("=") {
+		p.advance()
+		p.skipWhitespace()
 	}
-	p.skipWhitespace()
 	value, err := p.expectIdentifier()
 	if err != nil {
 		return fmt.Errorf("expected collate value: %w", err)

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -134,6 +134,59 @@ func TestParser_ParseCreateOrReplaceView(t *testing.T) {
 	c.Assert(createView.Body, qt.Equals, "SELECT * FROM users")
 }
 
+func TestParser_ParseCreateSchema(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE SCHEMA IF NOT EXISTS "bc_test";`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createSchema, ok := statements.Statements[0].(*ast.CreateSchemaNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createSchema.Name, qt.Equals, `"bc_test"`)
+	c.Assert(createSchema.IfNotExists, qt.IsTrue)
+}
+
+func TestParser_ParseCreateDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE DATABASE `atlantis`;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createDatabase, ok := statements.Statements[0].(*ast.CreateDatabaseNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createDatabase.Name, qt.Equals, "`atlantis`")
+	c.Assert(createDatabase.IfNotExists, qt.IsFalse)
+}
+
+func TestParser_ParseCreateDatabaseWithQualifiedTableAndMySQLOptions(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE DATABASE `atlantis`; CREATE TABLE `atlantis`.`tbl` (`col` int NOT NULL) CHARSET utf8mb4 COLLATE utf8mb4_general_ci;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	createDatabase, ok := statements.Statements[0].(*ast.CreateDatabaseNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createDatabase.Name, qt.Equals, "`atlantis`")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "`atlantis`.`tbl`")
+	c.Assert(createTable.Options["CHARSET"], qt.Equals, "utf8mb4")
+	c.Assert(createTable.Options["COLLATE"], qt.Equals, "utf8mb4_general_ci")
+}
+
 func TestParser_ParseCreateFunction(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -87,6 +87,26 @@ func (r *Renderer) notSupported(feature, name string) {
 	r.w.WriteLinef("-- CLICKHOUSE: %s %q is not supported", feature, name)
 }
 
+// VisitCreateSchema renders schema creation as ClickHouse database creation.
+func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+	r.w.WriteLinef("CREATE DATABASE%s %s;", guard, node.Name)
+	return nil
+}
+
+// VisitCreateDatabase renders a CREATE DATABASE statement.
+func (r *Renderer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+	r.w.WriteLinef("CREATE DATABASE%s %s;", guard, node.Name)
+	return nil
+}
+
 // escapeStringLiteral doubles single quotes for safe embedding in a SQL
 // string literal.
 func escapeStringLiteral(s string) string {

--- a/core/renderer/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/dialects/clickhouse/clickhouse_test.go
@@ -589,6 +589,17 @@ func TestAlterTable_RenameTable(t *testing.T) {
 	c.Assert(out, qt.Contains, "RENAME TABLE old_events TO events;")
 }
 
+func TestCreateNamespaceStatements(t *testing.T) {
+	c := qt.New(t)
+	out := render(t,
+		&ast.CreateSchemaNode{Name: "events", IfNotExists: true},
+		&ast.CreateDatabaseNode{Name: "analytics"},
+	)
+
+	c.Assert(out, qt.Contains, "CREATE DATABASE IF NOT EXISTS events;")
+	c.Assert(out, qt.Contains, "CREATE DATABASE analytics;")
+}
+
 func TestAlterTable_AddSkippingIndex(t *testing.T) {
 	cases := []struct {
 		name string

--- a/core/renderer/dialects/mariadb/mariadb.go
+++ b/core/renderer/dialects/mariadb/mariadb.go
@@ -41,6 +41,16 @@ func (r *Renderer) VisitCreateType(node *ast.CreateTypeNode) error {
 	return r.r.VisitCreateType(node)
 }
 
+// VisitCreateSchema delegates to the mysqllike renderer
+func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	return r.r.VisitCreateSchema(node)
+}
+
+// VisitCreateDatabase delegates to the mysqllike renderer
+func (r *Renderer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	return r.r.VisitCreateDatabase(node)
+}
+
 func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 	return r.r.VisitAlterType(node)
 }

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -48,6 +48,17 @@ func TestMySQL_AlterTable_RenameTable(t *testing.T) {
 	c.Assert(out, qt.Contains, "ALTER TABLE old_users RENAME TO users;")
 }
 
+func TestMySQL_CreateNamespaceStatements(t *testing.T) {
+	c := qt.New(t)
+	out := renderMySQL(t,
+		&ast.CreateSchemaNode{Name: "`bc_test`", IfNotExists: true},
+		&ast.CreateDatabaseNode{Name: "`atlantis`"},
+	)
+
+	c.Assert(out, qt.Contains, "CREATE SCHEMA IF NOT EXISTS `bc_test`;")
+	c.Assert(out, qt.Contains, "CREATE DATABASE `atlantis`;")
+}
+
 func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 	c := qt.New(t)
 	alter := &ast.AlterTableNode{

--- a/core/renderer/dialects/mysql/mysql.go
+++ b/core/renderer/dialects/mysql/mysql.go
@@ -41,6 +41,16 @@ func (r *Renderer) VisitCreateType(node *ast.CreateTypeNode) error {
 	return r.r.VisitCreateType(node)
 }
 
+// VisitCreateSchema delegates to the mysqllike renderer
+func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	return r.r.VisitCreateSchema(node)
+}
+
+// VisitCreateDatabase delegates to the mysqllike renderer
+func (r *Renderer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	return r.r.VisitCreateDatabase(node)
+}
+
 func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 	return r.r.VisitAlterType(node)
 }

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -146,6 +146,26 @@ func (r *Renderer) VisitCreateType(node *ast.CreateTypeNode) error {
 	return nil
 }
 
+// VisitCreateSchema renders a CREATE SCHEMA statement.
+func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+	r.w.WriteLinef("CREATE SCHEMA%s %s;", guard, node.Name)
+	return nil
+}
+
+// VisitCreateDatabase renders a CREATE DATABASE statement.
+func (r *Renderer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+	r.w.WriteLinef("CREATE DATABASE%s %s;", guard, node.Name)
+	return nil
+}
+
 func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 	// MySQL/MariaDB doesn't support ALTER TYPE operations
 	// Type changes are handled through ALTER TABLE MODIFY COLUMN

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -48,6 +48,27 @@ func TestPostgres_AlterTable_RenameTable(t *testing.T) {
 	c.Assert(out, qt.Contains, "ALTER TABLE old_users RENAME TO users;")
 }
 
+func TestPostgres_CreateSchema(t *testing.T) {
+	c := qt.New(t)
+	out := renderPG(t, &ast.CreateSchemaNode{Name: "auth", IfNotExists: true})
+	c.Assert(out, qt.Contains, "CREATE SCHEMA IF NOT EXISTS auth;")
+}
+
+func TestPostgres_CreateDatabase(t *testing.T) {
+	c := qt.New(t)
+	out := renderPG(t, &ast.CreateDatabaseNode{Name: "appdb"})
+	c.Assert(out, qt.Contains, "CREATE DATABASE appdb;")
+}
+
+func TestPostgres_CreateDatabaseIfNotExistsUnsupported(t *testing.T) {
+	c := qt.New(t)
+	r := postgres.New()
+
+	err := (&ast.CreateDatabaseNode{Name: "appdb", IfNotExists: true}).Accept(r)
+
+	c.Assert(err, qt.ErrorMatches, "create database if not exists is not supported in PostgreSQL")
+}
+
 // AddSkippingIndex and ModifyTTL are ClickHouse-only; postgres emits an
 // explanatory comment and otherwise treats the operation as a no-op.
 func TestPostgres_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -53,6 +53,25 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	return nil
 }
 
+// VisitCreateSchema renders a CREATE SCHEMA statement.
+func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+	r.w.WriteLinef("CREATE SCHEMA%s %s;", guard, node.Name)
+	return nil
+}
+
+// VisitCreateDatabase renders a CREATE DATABASE statement.
+func (r *Renderer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error {
+	if node.IfNotExists {
+		return fmt.Errorf("create database if not exists is not supported in PostgreSQL")
+	}
+	r.w.WriteLinef("CREATE DATABASE %s;", node.Name)
+	return nil
+}
+
 func (r *Renderer) VisitCreateType(node *ast.CreateTypeNode) error {
 	// Add comment if provided
 	if node.Comment != "" {

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -236,9 +236,11 @@ func (a *SchemaAnalyzer) VisitCreateTable(node *ast.CreateTableNode) error {
 	return nil
 }
 
-func (a *SchemaAnalyzer) VisitAlterTable(node *ast.AlterTableNode) error { return nil }
-func (a *SchemaAnalyzer) VisitColumn(node *ast.ColumnNode) error         { return nil }
-func (a *SchemaAnalyzer) VisitConstraint(node *ast.ConstraintNode) error { return nil }
+func (a *SchemaAnalyzer) VisitCreateSchema(node *ast.CreateSchemaNode) error     { return nil }
+func (a *SchemaAnalyzer) VisitCreateDatabase(node *ast.CreateDatabaseNode) error { return nil }
+func (a *SchemaAnalyzer) VisitAlterTable(node *ast.AlterTableNode) error         { return nil }
+func (a *SchemaAnalyzer) VisitColumn(node *ast.ColumnNode) error                 { return nil }
+func (a *SchemaAnalyzer) VisitConstraint(node *ast.ConstraintNode) error         { return nil }
 func (a *SchemaAnalyzer) VisitIndex(node *ast.IndexNode) error {
 	a.IndexCount++
 	return nil


### PR DESCRIPTION
## Summary
- add typed AST nodes for CREATE SCHEMA and CREATE DATABASE
- parse namespace creation with optional IF NOT EXISTS, including double-quoted identifiers
- render namespace creation for PostgreSQL, MySQL/MariaDB, and ClickHouse
- accept MySQL table CHARSET/COLLATE options with or without '='

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser ./core/ast ./core/renderer/dialects/postgres ./core/renderer/dialects/mysql ./core/renderer/dialects/mariadb ./core/renderer/dialects/clickhouse
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/... ./migration/...
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- conformance probe through temporary go.work: 151 -> 148 unwaived gaps, no new red keys

## Conformance keys removed
- sql-parse cmd/atlas/internal/cmdapi/testdata/mysql/20220318104614_initial.sql round-trip
- sql-parse internal/integration/testdata/migrations/mysql/1_initial.sql round-trip
- sql-parse internal/integration/testdata/migrations/postgres/1_initial.sql round-trip