### PR TITLE
Parse Atlas CREATE TABLE syntax variants

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -67,12 +67,16 @@ func (n *EnumNode) Accept(visitor Visitor) error {
 type CreateTableNode struct {
 	// Name is the name of the table to create
 	Name string
+	// IfNotExists preserves an IF NOT EXISTS guard when present.
+	IfNotExists bool
 	// Columns contains all column definitions for the table
 	Columns []*ColumnNode
 	// Constraints contains table-level constraints (PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK)
 	Constraints []*ConstraintNode
 	// Options contains dialect-specific table options like ENGINE for MySQL
 	Options map[string]string
+	// SelectBody stores the SELECT tail for CREATE TABLE ... SELECT statements.
+	SelectBody string
 	// Comment is an optional table comment
 	Comment string
 }
@@ -142,6 +146,18 @@ func (n *CreateDatabaseNode) Accept(visitor Visitor) error {
 //	table.AddColumn(NewColumn("id", "INTEGER").SetPrimary())
 func (n *CreateTableNode) AddColumn(column *ColumnNode) *CreateTableNode {
 	n.Columns = append(n.Columns, column)
+	return n
+}
+
+// SetIfNotExists marks the CREATE TABLE statement as conditional.
+func (n *CreateTableNode) SetIfNotExists() *CreateTableNode {
+	n.IfNotExists = true
+	return n
+}
+
+// SetSelectBody stores the SELECT tail for CREATE TABLE ... SELECT statements.
+func (n *CreateTableNode) SetSelectBody(body string) *CreateTableNode {
+	n.SelectBody = body
 	return n
 }
 

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -30,16 +30,20 @@ func TestCreateTableNode_FluentAPI(t *testing.T) {
 	constraint := ast.NewPrimaryKeyConstraint("id")
 
 	table := ast.NewCreateTable("users").
+		SetIfNotExists().
 		AddColumn(column).
 		AddConstraint(constraint).
-		SetOption("ENGINE", "InnoDB")
+		SetOption("ENGINE", "InnoDB").
+		SetSelectBody("SELECT * FROM seed_users")
 
 	c.Assert(table.Name, qt.Equals, "users")
+	c.Assert(table.IfNotExists, qt.IsTrue)
 	c.Assert(table.Columns, qt.HasLen, 1)
 	c.Assert(table.Columns[0], qt.Equals, column)
 	c.Assert(table.Constraints, qt.HasLen, 1)
 	c.Assert(table.Constraints[0], qt.Equals, constraint)
 	c.Assert(table.Options["ENGINE"], qt.Equals, "InnoDB")
+	c.Assert(table.SelectBody, qt.Equals, "SELECT * FROM seed_users")
 }
 
 func TestCreateTableNode_Accept(t *testing.T) {

--- a/core/lexer/lexer.go
+++ b/core/lexer/lexer.go
@@ -3,6 +3,7 @@ package lexer
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // TokenType represents the type of SQL token
@@ -85,15 +86,41 @@ func (l *Lexer) peek() rune {
 	if l.pos >= len(l.input) {
 		return 0
 	}
-	return rune(l.input[l.pos])
+	ch, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+	return ch
 }
 
 // peekNext returns the character at the next position without advancing
 func (l *Lexer) peekNext() rune {
-	if l.pos+1 >= len(l.input) {
+	if l.pos >= len(l.input) {
 		return 0
 	}
-	return rune(l.input[l.pos+1])
+	_, size := utf8.DecodeRuneInString(l.input[l.pos:])
+	next := l.pos + size
+	if next >= len(l.input) {
+		return 0
+	}
+	ch, _ := utf8.DecodeRuneInString(l.input[next:])
+	return ch
+}
+
+// peekAfterNext returns the rune after peekNext without advancing.
+func (l *Lexer) peekAfterNext() rune {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	_, size := utf8.DecodeRuneInString(l.input[l.pos:])
+	next := l.pos + size
+	if next >= len(l.input) {
+		return 0
+	}
+	_, nextSize := utf8.DecodeRuneInString(l.input[next:])
+	afterNext := next + nextSize
+	if afterNext >= len(l.input) {
+		return 0
+	}
+	ch, _ := utf8.DecodeRuneInString(l.input[afterNext:])
+	return ch
 }
 
 // advance moves to the next character and returns it
@@ -101,8 +128,8 @@ func (l *Lexer) advance() rune {
 	if l.pos >= len(l.input) {
 		return 0
 	}
-	ch := rune(l.input[l.pos])
-	l.pos++
+	ch, size := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += size
 	return ch
 }
 
@@ -147,12 +174,15 @@ func (l *Lexer) NextToken() Token {
 			if l.isDollarQuotedString() {
 				return l.scanDollarQuotedString()
 			}
+			if isIdentifierPart(l.peekNext()) {
+				return l.scanIdentifier()
+			}
 			return l.scanOperator()
 		case ch == '-' && l.peekNext() == '-':
 			return l.scanLineComment()
 		case ch == '/' && l.peekNext() == '*':
 			return l.scanBlockComment()
-		case unicode.IsLetter(ch) || ch == '_':
+		case isIdentifierStart(ch):
 			return l.scanIdentifier()
 		case unicode.IsDigit(ch):
 			return l.scanNumber()
@@ -187,6 +217,10 @@ func (l *Lexer) scanString() Token {
 		}
 
 		if ch == '\\' {
+			if quote == '\'' && l.peekNext() == quote && isStringTerminator(l.peekAfterNext()) {
+				l.advance()
+				continue
+			}
 			l.advance() // consume backslash
 			if l.peek() != 0 {
 				l.advance() // consume escaped character
@@ -197,6 +231,10 @@ func (l *Lexer) scanString() Token {
 	}
 
 	return l.emit(TokenString)
+}
+
+func isStringTerminator(ch rune) bool {
+	return ch == 0 || ch == ';' || ch == ',' || ch == ')'
 }
 
 // scanLineComment scans a line comment (-- comment)
@@ -243,12 +281,20 @@ func (l *Lexer) scanBlockComment() Token {
 func (l *Lexer) scanIdentifier() Token {
 	for {
 		ch := l.peek()
-		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' {
+		if !isIdentifierPart(ch) {
 			break
 		}
 		l.advance()
 	}
 	return l.emit(TokenIdentifier)
+}
+
+func isIdentifierStart(ch rune) bool {
+	return unicode.IsLetter(ch) || ch == '_' || ch == '$'
+}
+
+func isIdentifierPart(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || ch == '$'
 }
 
 // scanBacktickedIdentifier scans a backtick-quoted identifier (MySQL style)

--- a/core/lexer/lexer_test.go
+++ b/core/lexer/lexer_test.go
@@ -113,6 +113,27 @@ func TestLexer_NextToken_HappyPath(t *testing.T) {
 			},
 		},
 		{
+			name:  "dollar_identifier",
+			input: "mysqltest.$test1 ($b int, c$ int)",
+			expected: []lexer.Token{
+				{Type: lexer.TokenIdentifier, Value: "mysqltest", Start: 0, End: 9},
+				{Type: lexer.TokenOperator, Value: ".", Start: 9, End: 10},
+				{Type: lexer.TokenIdentifier, Value: "$test1", Start: 10, End: 16},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 16, End: 17},
+				{Type: lexer.TokenOperator, Value: "(", Start: 17, End: 18},
+				{Type: lexer.TokenIdentifier, Value: "$b", Start: 18, End: 20},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 20, End: 21},
+				{Type: lexer.TokenIdentifier, Value: "int", Start: 21, End: 24},
+				{Type: lexer.TokenOperator, Value: ",", Start: 24, End: 25},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 25, End: 26},
+				{Type: lexer.TokenIdentifier, Value: "c$", Start: 26, End: 28},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 28, End: 29},
+				{Type: lexer.TokenIdentifier, Value: "int", Start: 29, End: 32},
+				{Type: lexer.TokenOperator, Value: ")", Start: 32, End: 33},
+				{Type: lexer.TokenEOF, Value: "", Start: 33, End: 33},
+			},
+		},
+		{
 			name:  "numbers",
 			input: "123 45.67 89",
 			expected: []lexer.Token{

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -14,6 +14,9 @@ The parser supports the following SQL DDL statements:
 - Foreign key references with ON DELETE/UPDATE actions
 - Table-level constraints (PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK)
 - Table options (ENGINE, CHARSET, COLLATE, COMMENT)
+- Optional `IF NOT EXISTS`
+- MySQL-style `CREATE TABLE ... SELECT ...` tails, preserved as raw SELECT SQL
+- Unicode identifiers and MySQL identifiers containing `$`
 
 ### CREATE SCHEMA / CREATE DATABASE
 - Namespace creation with optional `IF NOT EXISTS`
@@ -143,6 +146,18 @@ for _, stmt := range statements.Statements {
 - `CHARSET=utf8mb4` / `CHARACTER SET=utf8mb4`
 - `COLLATE=utf8mb4_unicode_ci`
 - `COMMENT='table description'`
+
+### CREATE TABLE ... SELECT
+
+The parser can represent MySQL-style `CREATE TABLE ... SELECT ...` statements by
+storing the SELECT tail on the `CreateTableNode`. The SELECT body is preserved
+as SQL text; Ptah does not infer schema columns from SELECT expressions.
+
+Supported forms include:
+
+- `CREATE TABLE IF NOT EXISTS users_copy SELECT * FROM users`
+- `CREATE TABLE users_copy ENGINE=heap SELECT * FROM users`
+- `CREATE TABLE users_copy (id INT) SELECT id FROM users`
 
 ## Architecture
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -574,10 +574,46 @@ func (p *Parser) collectStatementBody() string {
 
 // parseCreateTable parses CREATE TABLE statements.
 func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
+	table, err := p.parseCreateTableHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	done, err := p.parseCreateTableBeforeColumnList(table)
+	if err != nil || done {
+		return table, err
+	}
+
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return nil, fmt.Errorf("expected '(' after table name: %w", err)
+	}
+
+	if err := p.parseCreateTableElements(table); err != nil {
+		return nil, err
+	}
+
+	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
+		return nil, err
+	}
+
+	if err := p.parseCreateTableSuffix(table); err != nil {
+		return nil, err
+	}
+
+	return table, nil
+}
+
+func (p *Parser) parseCreateTableHeader() (*ast.CreateTableNode, error) {
 	if err := p.expect(lexer.TokenIdentifier, "TABLE"); err != nil {
 		return nil, err
 	}
 
+	p.skipWhitespace()
+
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
 	p.skipWhitespace()
 
 	// Get table name (could be schema.table)
@@ -586,20 +622,44 @@ func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
 		return nil, err
 	}
 
-	p.skipWhitespace()
-
-	// Expect opening parenthesis
-	if err := p.expect(lexer.TokenOperator, "("); err != nil {
-		return nil, fmt.Errorf("expected '(' after table name: %w", err)
+	table := ast.NewCreateTable(tableName)
+	if ifNotExists {
+		table.SetIfNotExists()
 	}
 
-	table := ast.NewCreateTable(tableName)
+	return table, nil
+}
 
+func (p *Parser) parseCreateTableBeforeColumnList(table *ast.CreateTableNode) (bool, error) {
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("AS") || p.current.MatchIdentifierValue("SELECT") {
+		if err := p.parseCreateTableSelectBody(table); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if !p.current.MatchOperatorValue("(") && p.current.Type == lexer.TokenIdentifier {
+		if err := p.parseTableOptions(table); err != nil {
+			return false, err
+		}
+		p.skipWhitespace()
+		if p.current.MatchIdentifierValue("AS") || p.current.MatchIdentifierValue("SELECT") {
+			if err := p.parseCreateTableSelectBody(table); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (p *Parser) parseCreateTableElements(table *ast.CreateTableNode) error {
 	// Parse column definitions and constraints
 	for {
 		// Check for timeout to prevent infinite loops
 		if err := p.checkTimeout(); err != nil {
-			return nil, err
+			return err
 		}
 
 		p.skipWhitespace()
@@ -611,7 +671,7 @@ func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
 
 		// Parse column or constraint
 		if err := p.parseTableElement(table); err != nil {
-			return nil, err
+			return err
 		}
 
 		p.skipWhitespace()
@@ -644,20 +704,36 @@ func (p *Parser) parseCreateTable() (*ast.CreateTableNode, error) {
 			continue
 		}
 
-		return nil, fmt.Errorf("expected ',' or ')' after table element at position %d", p.current.Start)
+		return fmt.Errorf("expected ',' or ')' after table element at position %d", p.current.Start)
 	}
 
-	// Consume closing parenthesis
-	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
-		return nil, err
-	}
+	return nil
+}
 
+func (p *Parser) parseCreateTableSuffix(table *ast.CreateTableNode) error {
 	// Parse optional table options (ENGINE, etc.)
 	if err := p.parseTableOptions(table); err != nil {
-		return nil, err
+		return err
 	}
+	if p.current.MatchIdentifierValue("AS") || p.current.MatchIdentifierValue("SELECT") {
+		if err := p.parseCreateTableSelectBody(table); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	return table, nil
+func (p *Parser) parseCreateTableSelectBody(table *ast.CreateTableNode) error {
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("AS") {
+		p.advance()
+		p.skipWhitespace()
+	}
+	if !p.current.MatchIdentifierValue("SELECT") {
+		return fmt.Errorf("expected SELECT in CREATE TABLE SELECT body, got %s at position %d", p.current.Type, p.current.Start)
+	}
+	table.SetSelectBody(p.collectStatementBody())
+	return nil
 }
 
 // parseTableElement parses a column definition or table constraint.
@@ -679,7 +755,7 @@ func (p *Parser) parseTableElement(table *ast.CreateTableNode) error {
 	}
 
 	// Otherwise, parse as column definition
-	column, err := p.parseColumnDefinition()
+	column, err := p.parseColumnDefinition(table)
 	if err != nil {
 		return err
 	}
@@ -873,10 +949,21 @@ func (p *Parser) handleCharacter(column *ast.ColumnNode) {
 	p.advance()
 	p.skipWhitespace()
 	if p.current.Type == lexer.TokenIdentifier {
-		// Store charset as comment for now
-		column.SetComment("CHARACTER SET " + p.current.Value)
+		appendColumnComment(column, "CHARACTER SET "+p.current.Value)
 		p.advance()
 	}
+}
+
+func (p *Parser) handleCharset(column *ast.ColumnNode) error {
+	p.advance()
+	p.skipWhitespace()
+
+	value, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected charset name: %w", err)
+	}
+	appendColumnComment(column, "CHARSET "+value)
+	return nil
 }
 
 func (p *Parser) handleCollate(column *ast.ColumnNode) error {
@@ -898,10 +985,28 @@ func (p *Parser) handleCollate(column *ast.ColumnNode) error {
 		return fmt.Errorf("expected collation name: got %s at position %d", p.current.Type, p.current.Start)
 	}
 
-	// Store as comment for now (in a full implementation, add Collation field to ColumnNode)
-	column.SetComment("COLLATE " + collation)
+	appendColumnComment(column, "COLLATE "+collation)
 
 	return nil
+}
+
+func (p *Parser) handleColumnComment(column *ast.ColumnNode) error {
+	p.advance()
+	p.skipWhitespace()
+	if p.current.Type != lexer.TokenString {
+		return fmt.Errorf("expected column comment string, got %s at position %d", p.current.Type, p.current.Start)
+	}
+	appendColumnComment(column, "COMMENT "+p.current.Value)
+	p.advance()
+	return nil
+}
+
+func appendColumnComment(column *ast.ColumnNode, text string) {
+	if column.Comment == "" {
+		column.SetComment(text)
+		return
+	}
+	column.SetComment(column.Comment + "; " + text)
 }
 
 func (p *Parser) handleOn(column *ast.ColumnNode) {
@@ -941,7 +1046,7 @@ func (p *Parser) handleOn(column *ast.ColumnNode) {
 	column.SetComment("ON UPDATE " + updateExpr)
 }
 
-func (p *Parser) parseColumnConstraintsAndAttributes(column *ast.ColumnNode) error {
+func (p *Parser) parseColumnConstraintsAndAttributes(table *ast.CreateTableNode, column *ast.ColumnNode) error {
 	var err error
 	for {
 		// Check for timeout to prevent infinite loops
@@ -956,38 +1061,7 @@ func (p *Parser) parseColumnConstraintsAndAttributes(column *ast.ColumnNode) err
 		}
 
 		keyword := strings.ToUpper(p.current.Value)
-		switch keyword {
-		case "NOT":
-			err = p.handleNotNull(column)
-		case "NULL":
-			p.handleNull(column)
-		case "PRIMARY":
-			err = p.handlePrimaryKey(column)
-		case "UNIQUE":
-			p.handleUnique(column)
-		case "AUTO_INCREMENT", "AUTOINCREMENT":
-			p.handleAutoIncrement(column)
-		case "DEFAULT":
-			err = p.handleDefault(column)
-		case "CHECK":
-			err = p.handleCheck(column)
-		case "REFERENCES":
-			err = p.handleReferences(column)
-		case "AS":
-			err = p.handleAs(column)
-		case "GENERATED":
-			err = p.handleGenerated(column)
-		case "CHARACTER":
-			p.handleCharacter(column)
-		case "COLLATE":
-			err = p.handleCollate(column)
-		case "ON":
-			p.handleOn(column)
-		default:
-			// Unknown keyword, stop parsing column attributes
-			err = fmt.Errorf("unsupported column attribute: %s at position %d", keyword, p.current.Start)
-		}
-
+		err = p.parseColumnConstraintOrAttribute(table, column, keyword)
 		if err != nil {
 			return err
 		}
@@ -996,8 +1070,80 @@ func (p *Parser) parseColumnConstraintsAndAttributes(column *ast.ColumnNode) err
 	return nil
 }
 
+func (p *Parser) parseColumnConstraintOrAttribute(table *ast.CreateTableNode, column *ast.ColumnNode, keyword string) error {
+	switch keyword {
+	case "NOT":
+		return p.handleNotNull(column)
+	case "NULL":
+		p.handleNull(column)
+	case "PRIMARY":
+		return p.handlePrimaryKeyAttribute(table, column)
+	case "UNIQUE":
+		p.handleUnique(column)
+	case "AUTO_INCREMENT", "AUTOINCREMENT":
+		p.handleAutoIncrement(column)
+	case "DEFAULT":
+		return p.handleDefault(column)
+	case "CHECK":
+		return p.handleCheck(column)
+	case "REFERENCES":
+		return p.handleReferences(column)
+	case "AS":
+		return p.handleAs(column)
+	case "GENERATED":
+		return p.handleGenerated(column)
+	case "CHARACTER":
+		p.handleCharacter(column)
+	case "CHARSET":
+		return p.handleCharset(column)
+	case "COLLATE":
+		return p.handleCollate(column)
+	case "COMMENT":
+		return p.handleColumnComment(column)
+	case "ON":
+		p.handleOn(column)
+	default:
+		return fmt.Errorf("unsupported column attribute: %s at position %d", keyword, p.current.Start)
+	}
+	return nil
+}
+
+func (p *Parser) handlePrimaryKeyAttribute(table *ast.CreateTableNode, column *ast.ColumnNode) error {
+	if table == nil {
+		return p.handlePrimaryKey(column)
+	}
+	handled, err := p.handlePrimaryKeyOrInlineTableConstraint(table, column)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+	return p.handlePrimaryKey(column)
+}
+
+func (p *Parser) handlePrimaryKeyOrInlineTableConstraint(table *ast.CreateTableNode, column *ast.ColumnNode) (bool, error) {
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "KEY"); err != nil {
+		return false, fmt.Errorf("expected KEY after PRIMARY: %w", err)
+	}
+	p.skipWhitespace()
+	if !p.current.MatchOperatorValue("(") {
+		column.SetPrimary()
+		return true, nil
+	}
+
+	constraint := &ast.ConstraintNode{Type: ast.PrimaryKeyConstraint}
+	if err := p.parseTableColumnList(constraint); err != nil {
+		return false, err
+	}
+	table.AddConstraint(constraint)
+	return true, nil
+}
+
 // parseColumnDefinition parses a column definition.
-func (p *Parser) parseColumnDefinition() (*ast.ColumnNode, error) {
+func (p *Parser) parseColumnDefinition(table *ast.CreateTableNode) (*ast.ColumnNode, error) {
 	p.skipWhitespace()
 
 	// Get column name
@@ -1015,7 +1161,7 @@ func (p *Parser) parseColumnDefinition() (*ast.ColumnNode, error) {
 	}
 
 	column := ast.NewColumn(columnName, columnType)
-	err = p.parseColumnConstraintsAndAttributes(column)
+	err = p.parseColumnConstraintsAndAttributes(table, column)
 	if err != nil {
 		return nil, err
 	}
@@ -1264,6 +1410,13 @@ func (p *Parser) handleFunctionCallOrKeyword() (*ast.DefaultValue, error) {
 	value := p.current.Value
 	p.advance()
 
+	upperValue := strings.ToUpper(value)
+	if upperValue == "E" && p.current.Type == lexer.TokenString {
+		value += p.current.Value
+		p.advance()
+		return &ast.DefaultValue{Value: value}, nil
+	}
+
 	// Check if it's a function call
 	if p.current.Type == lexer.TokenOperator && p.current.Value == "(" {
 		// Parse function call
@@ -1279,7 +1432,6 @@ func (p *Parser) handleFunctionCallOrKeyword() (*ast.DefaultValue, error) {
 	}
 
 	// Handle MySQL/PostgreSQL functions that can be used without parentheses
-	upperValue := strings.ToUpper(value)
 	if upperValue == "CURRENT_TIMESTAMP" || upperValue == "NOW" || upperValue == "CURRENT_DATE" || upperValue == "CURRENT_TIME" {
 		return &ast.DefaultValue{Expression: value + "()"}, nil
 	}
@@ -1330,19 +1482,62 @@ func (p *Parser) handleNumber() (*ast.DefaultValue, error) {
 func (p *Parser) parseDefaultValue() (*ast.DefaultValue, error) {
 	p.skipWhitespace()
 
+	var value *ast.DefaultValue
+	var err error
 	switch p.current.Type {
 	case lexer.TokenString:
 		// String literal
-		return p.handleStringLiteral()
+		value, err = p.handleStringLiteral()
 	case lexer.TokenIdentifier:
 		// Could be a function call or keyword like NULL, TRUE, FALSE
-		return p.handleFunctionCallOrKeyword()
+		value, err = p.handleFunctionCallOrKeyword()
 	case lexer.TokenOperator:
 		// Could be a number (positive or negative) or just a number
-		return p.handleNumber()
+		value, err = p.handleNumber()
 	default:
 		return nil, fmt.Errorf("expected default value, got %s at position %d", p.current.Type, p.current.Start)
 	}
+	if err != nil {
+		return nil, err
+	}
+	return p.extendDefaultExpression(value), nil
+}
+
+func (p *Parser) extendDefaultExpression(value *ast.DefaultValue) *ast.DefaultValue {
+	p.skipWhitespace()
+	if !p.current.MatchOperatorValue("+") {
+		return value
+	}
+
+	var expr strings.Builder
+	if value.Expression != "" {
+		expr.WriteString(value.Expression)
+	} else {
+		expr.WriteString(value.Value)
+	}
+
+	depth := 0
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if p.current.Type == lexer.TokenOperator {
+			switch p.current.Value {
+			case "(":
+				depth++
+			case ")":
+				if depth == 0 {
+					return &ast.DefaultValue{Expression: strings.TrimSpace(expr.String())}
+				}
+				depth--
+			case ",":
+				if depth == 0 {
+					return &ast.DefaultValue{Expression: strings.TrimSpace(expr.String())}
+				}
+			}
+		}
+
+		expr.WriteString(p.current.Value)
+		p.advance()
+	}
+	return &ast.DefaultValue{Expression: strings.TrimSpace(expr.String())}
 }
 
 // parseCheckExpression parses a CHECK constraint expression.
@@ -1972,6 +2167,9 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 
 		var err error
 		option := strings.ToUpper(p.current.Value)
+		if option == "AS" || option == "SELECT" {
+			return nil
+		}
 		switch option {
 		case "ENGINE":
 			err = p.handleTableEngine(table)
@@ -2286,7 +2484,7 @@ func (p *Parser) parseAddOperation() (*ast.AddColumnOperation, error) {
 	}
 
 	// Parse column definition
-	column, err := p.parseColumnDefinition()
+	column, err := p.parseColumnDefinition(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2340,7 +2538,7 @@ func (p *Parser) parseModifyOperation() (*ast.ModifyColumnOperation, error) {
 	}
 
 	// Parse column definition
-	column, err := p.parseColumnDefinition()
+	column, err := p.parseColumnDefinition(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -100,6 +100,138 @@ func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 	c.Assert(createTable.Comment, qt.Equals, "'Product catalog'")
 }
 
+func TestParser_ParseCreateTable_IfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY);"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Name, qt.Equals, "users")
+	c.Assert(createTable.IfNotExists, qt.IsTrue)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].Primary, qt.IsTrue)
+}
+
+func TestParser_ParseCreateTable_TablePrimaryKeyWithoutComma(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE post
+(
+    id int NOT NULL,
+    created_at TIMESTAMP NOT NULL
+    PRIMARY KEY (id)
+);
+
+INSERT INTO post (id, created_at) VALUES (1, NOW());`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
+	c.Assert(createTable.Columns[1].Name, qt.Equals, "created_at")
+	c.Assert(createTable.Columns[1].Nullable, qt.IsFalse)
+	c.Assert(createTable.Columns[1].Primary, qt.IsFalse)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
+	c.Assert(createTable.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)
+	c.Assert(createTable.Constraints[0].Columns, qt.DeepEquals, []string{"id"})
+}
+
+func TestParser_ParseCreateTable_SelectTail(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE t2 ENGINE=heap SELECT * FROM t1;
+CREATE TABLE t3 (b int) SELECT a AS b FROM t1;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	noColumns := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(noColumns.Name, qt.Equals, "t2")
+	c.Assert(noColumns.Columns, qt.HasLen, 0)
+	c.Assert(noColumns.Options["ENGINE"], qt.Equals, "heap")
+	c.Assert(noColumns.SelectBody, qt.Equals, "SELECT * FROM t1")
+
+	withColumns := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(withColumns.Name, qt.Equals, "t3")
+	c.Assert(withColumns.Columns, qt.HasLen, 1)
+	c.Assert(withColumns.SelectBody, qt.Equals, "SELECT a AS b FROM t1")
+}
+
+func TestParser_ParseCreateTable_MySQLColumnModifiers(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE t1(
+    c1 INT DEFAULT 12 COMMENT 'column1',
+    c2 VARCHAR(255) CHARACTER SET utf8 NOT NULL DEFAULT 'a',
+    c3 VARCHAR(255) CHARSET utf8 COLLATE utf8_unicode_ci NULL DEFAULT 'b'
+);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Columns, qt.HasLen, 3)
+	c.Assert(createTable.Columns[0].Comment, qt.Equals, "COMMENT 'column1'")
+	c.Assert(createTable.Columns[1].Comment, qt.Equals, "CHARACTER SET utf8")
+	c.Assert(createTable.Columns[1].Nullable, qt.IsFalse)
+	c.Assert(createTable.Columns[2].Comment, qt.Equals, "CHARSET utf8; COLLATE utf8_unicode_ci")
+	c.Assert(createTable.Columns[2].Nullable, qt.IsTrue)
+}
+
+func TestParser_ParseCreateTable_UnicodeIdentifiers(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE טבלה_של_אריאל (כמות int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Name, qt.Equals, "טבלה_של_אריאל")
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].Name, qt.Equals, "כמות")
+	c.Assert(createTable.Columns[0].Type, qt.Equals, "int")
+}
+
+func TestParser_ParseCreateTable_EscapedDefaultStrings(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE mysql_defaults (c text default "\"" + '\'');
+CREATE TABLE pg_plain_defaults (c text default '\');
+CREATE TABLE pg_escaped_defaults (c text default E'\\A\\');`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 3)
+
+	mysqlTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(mysqlTable.Columns, qt.HasLen, 1)
+	c.Assert(mysqlTable.Columns[0].Default.Expression, qt.Equals, `"\""+ '\''`)
+
+	pgPlainTable := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(pgPlainTable.Columns, qt.HasLen, 1)
+	c.Assert(pgPlainTable.Columns[0].Default.Value, qt.Equals, "'\\'")
+
+	pgEscapedTable := statements.Statements[2].(*ast.CreateTableNode)
+	c.Assert(pgEscapedTable.Columns, qt.HasLen, 1)
+	c.Assert(pgEscapedTable.Columns[0].Default.Value, qt.Equals, `E'\\A\\'`)
+}
+
 func TestParser_ParseCreateView(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -472,6 +472,25 @@ func splitColumns(expr string) []string {
 // thread it through r.forceNotNullSet so the per-column renderer can return
 // a precise error rather than silently stripping Nullable.
 func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+
+	if len(node.Columns) == 0 && len(node.Constraints) == 0 && node.SelectBody != "" {
+		spec, err := r.resolveAndValidateTableEngine(node)
+		if err != nil {
+			return err
+		}
+		r.w.Writef("CREATE TABLE%s %s", guard, node.Name)
+		r.writeEngineSpec(spec)
+		r.w.WriteLine(" AS")
+		r.w.WriteLine(strings.TrimSpace(node.SelectBody))
+		r.w.WriteLine(";")
+		r.w.WriteLine("")
+		return nil
+	}
+
 	spec, err := r.resolveAndValidateTableEngine(node)
 	if err != nil {
 		return err
@@ -480,7 +499,7 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 	r.forceNotNullSet = sortKeyColumnSet(spec)
 	defer func() { r.forceNotNullSet = nil }()
 
-	r.w.WriteLinef("CREATE TABLE %s (", node.Name)
+	r.w.WriteLinef("CREATE TABLE%s %s (", guard, node.Name)
 	lines, err := r.renderTableBody(node)
 	if err != nil {
 		return err
@@ -495,6 +514,10 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 	r.writeEngineClause(spec)
 	if node.Comment != "" {
 		r.w.Writef(" COMMENT %s", escapeStringLiteral(node.Comment))
+	}
+	if node.SelectBody != "" {
+		r.w.Write(" AS ")
+		r.w.Write(strings.TrimSpace(node.SelectBody))
 	}
 	r.w.WriteLine(";")
 	r.w.WriteLine("")
@@ -578,7 +601,12 @@ func (r *Renderer) renderTableBody(node *ast.CreateTableNode) ([]string, error) 
 // writeEngineClause emits the trailing ENGINE/PARTITION BY/... clause for a
 // CREATE TABLE statement, in the order ClickHouse expects.
 func (r *Renderer) writeEngineClause(spec tableEngineSpec) {
-	r.w.Writef(") ENGINE = %s", spec.engine)
+	r.w.Write(")")
+	r.writeEngineSpec(spec)
+}
+
+func (r *Renderer) writeEngineSpec(spec tableEngineSpec) {
+	r.w.Writef(" ENGINE = %s", spec.engine)
 	if spec.partitionBy != "" {
 		r.w.Writef(" PARTITION BY %s", spec.partitionBy)
 	}

--- a/core/renderer/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/dialects/clickhouse/clickhouse_test.go
@@ -600,6 +600,28 @@ func TestCreateNamespaceStatements(t *testing.T) {
 	c.Assert(out, qt.Contains, "CREATE DATABASE analytics;")
 }
 
+func TestCreateTableSelectTailWithEngine(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("copied_events").
+		SetIfNotExists().
+		SetOption("ENGINE", "Memory").
+		SetSelectBody("SELECT * FROM events")
+
+	out := render(t, table)
+
+	c.Assert(out, qt.Contains, "CREATE TABLE IF NOT EXISTS copied_events ENGINE = Memory AS\nSELECT * FROM events\n;")
+}
+
+func TestCreateTableSelectTailRequiresValidEngine(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("copied_events").
+		SetSelectBody("SELECT * FROM events")
+
+	err := renderErr(table)
+
+	c.Assert(err, qt.ErrorMatches, `clickhouse: table "copied_events" uses engine MergeTree which requires ORDER BY; set platform.clickhouse.order_by or declare a primary key`)
+}
+
 func TestAlterTable_AddSkippingIndex(t *testing.T) {
 	cases := []struct {
 		name string

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -59,6 +59,19 @@ func TestMySQL_CreateNamespaceStatements(t *testing.T) {
 	c.Assert(out, qt.Contains, "CREATE DATABASE `atlantis`;")
 }
 
+func TestMySQL_CreateTableSelectTail(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("t2").
+		SetIfNotExists().
+		SetOption("ENGINE", "heap").
+		SetSelectBody("SELECT * FROM t1")
+
+	out := renderMySQL(t, table)
+
+	c.Assert(out, qt.Contains, "CREATE TABLE IF NOT EXISTS t2 ENGINE=heap SELECT * FROM t1;")
+	c.Assert(out, qt.Not(qt.Contains), "CREATE TABLE IF NOT EXISTS t2 (")
+}
+
 func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 	c := qt.New(t)
 	alter := &ast.AlterTableNode{

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -213,8 +213,27 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 		r.w.WriteLinef("-- %s TABLE: %s --", r.dialectUpper, node.Name)
 	}
 
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
+	}
+
+	if len(node.Columns) == 0 && len(node.Constraints) == 0 && node.SelectBody != "" {
+		r.w.Writef("CREATE TABLE%s %s", guard, node.Name)
+		if len(node.Options) > 0 {
+			options := r.renderTableOptions(node.Options)
+			if options != "" {
+				r.w.Write(" ")
+				r.w.Write(options)
+			}
+		}
+		r.w.WriteLinef(" %s;", strings.TrimSpace(node.SelectBody))
+		r.w.WriteLine("")
+		return nil
+	}
+
 	// CREATE TABLE statement
-	r.w.WriteLinef("CREATE TABLE %s (", node.Name)
+	r.w.WriteLinef("CREATE TABLE%s %s (", guard, node.Name)
 
 	var lines []string
 
@@ -256,6 +275,11 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 			r.w.Write(" ")
 			r.w.Write(options)
 		}
+	}
+
+	if node.SelectBody != "" {
+		r.w.Write(" ")
+		r.w.Write(strings.TrimSpace(node.SelectBody))
 	}
 
 	r.w.WriteLine(";")

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -69,6 +69,18 @@ func TestPostgres_CreateDatabaseIfNotExistsUnsupported(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "create database if not exists is not supported in PostgreSQL")
 }
 
+func TestPostgres_CreateTableSelectWithTypedColumnsUnsupported(t *testing.T) {
+	c := qt.New(t)
+	r := postgres.New()
+	table := ast.NewCreateTable("copied_users").
+		AddColumn(ast.NewColumn("id", "INTEGER")).
+		SetSelectBody("SELECT id FROM users")
+
+	err := table.Accept(r)
+
+	c.Assert(err, qt.ErrorMatches, "postgres: create table as select with explicit column definitions is not supported")
+}
+
 // AddSkippingIndex and ModifyTTL are ClickHouse-only; postgres emits an
 // explanatory comment and otherwise treats the operation as a no-op.
 func TestPostgres_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -233,65 +233,26 @@ func (r *Renderer) GetOutput() string {
 
 // VisitCreateTable renders CREATE TABLE with PostgreSQL-specific handling
 func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
-	// Table comment
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s TABLE: %s (%s) --", r.dialectUpper, node.Name, node.Comment)
 	} else {
 		r.w.WriteLinef("-- %s TABLE: %s --", r.dialectUpper, node.Name)
 	}
 
-	// CREATE TABLE statement
-	r.w.WriteLinef("CREATE TABLE %s (", node.Name)
-
-	var lines []string
-
-	// Render columns using PostgreSQL-specific column rendering
-	for _, column := range node.Columns {
-		line, err := r.renderColumn(column)
-		if err != nil {
-			return fmt.Errorf("error rendering column %s: %w", column.Name, err)
-		}
-		lines = append(lines, line)
+	guard := ""
+	if node.IfNotExists {
+		guard = " IF NOT EXISTS"
 	}
 
-	// Render table-level constraints
-	for _, constraint := range node.Constraints {
-		line, err := r.renderConstraint(constraint)
-		if err != nil {
-			return fmt.Errorf("error rendering constraint: %w", err)
-		}
-		if line != "" {
-			lines = append(lines, line)
-		}
+	if node.SelectBody != "" {
+		return r.visitCreateTableAsSelect(node, guard)
 	}
 
-	// Convert column-level foreign keys to table-level constraints
-	for _, column := range node.Columns {
-		if column.ForeignKey != nil {
-			fk := column.ForeignKey
-			constraint := &ast.ConstraintNode{
-				Type:    ast.ForeignKeyConstraint,
-				Name:    fk.Name,
-				Columns: []string{column.Name},
-				Reference: &ast.ForeignKeyRef{
-					Table:    fk.Table,
-					Column:   fk.Column,
-					OnDelete: fk.OnDelete,
-					OnUpdate: fk.OnUpdate,
-					Name:     fk.Name,
-				},
-			}
-			line, err := r.renderConstraint(constraint)
-			if err != nil {
-				return fmt.Errorf("error rendering foreign key constraint: %w", err)
-			}
-			if line != "" {
-				lines = append(lines, line)
-			}
-		}
+	r.w.WriteLinef("CREATE TABLE%s %s (", guard, node.Name)
+	lines, err := r.renderCreateTableLines(node)
+	if err != nil {
+		return err
 	}
-
-	// Join all lines
 	for i, line := range lines {
 		if i == len(lines)-1 {
 			r.w.WriteLine(line) // Last line without comma
@@ -312,6 +273,76 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 	r.w.WriteLine("")
 
 	return nil
+}
+
+func (r *Renderer) visitCreateTableAsSelect(node *ast.CreateTableNode, guard string) error {
+	if len(node.Columns) > 0 || len(node.Constraints) > 0 {
+		return fmt.Errorf("postgres: create table as select with explicit column definitions is not supported")
+	}
+
+	r.w.WriteLinef("CREATE TABLE%s %s AS", guard, node.Name)
+	r.w.WriteLine(strings.TrimSpace(node.SelectBody))
+	r.w.WriteLine(";")
+	r.w.WriteLine("")
+	return nil
+}
+
+func (r *Renderer) renderCreateTableLines(node *ast.CreateTableNode) ([]string, error) {
+	lines := make([]string, 0, len(node.Columns)+len(node.Constraints))
+	for _, column := range node.Columns {
+		line, err := r.renderColumn(column)
+		if err != nil {
+			return nil, fmt.Errorf("error rendering column %s: %w", column.Name, err)
+		}
+		lines = append(lines, line)
+	}
+
+	for _, constraint := range node.Constraints {
+		line, err := r.renderConstraint(constraint)
+		if err != nil {
+			return nil, fmt.Errorf("error rendering constraint: %w", err)
+		}
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return r.appendColumnForeignKeyLines(lines, node.Columns)
+}
+
+func (r *Renderer) appendColumnForeignKeyLines(lines []string, columns []*ast.ColumnNode) ([]string, error) {
+	for _, column := range columns {
+		if column.ForeignKey == nil {
+			continue
+		}
+		line, err := r.renderColumnForeignKey(column)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, line)
+	}
+	return lines, nil
+}
+
+func (r *Renderer) renderColumnForeignKey(column *ast.ColumnNode) (string, error) {
+	fk := column.ForeignKey
+	constraint := &ast.ConstraintNode{
+		Type:    ast.ForeignKeyConstraint,
+		Name:    fk.Name,
+		Columns: []string{column.Name},
+		Reference: &ast.ForeignKeyRef{
+			Table:    fk.Table,
+			Column:   fk.Column,
+			OnDelete: fk.OnDelete,
+			OnUpdate: fk.OnUpdate,
+			Name:     fk.Name,
+		},
+	}
+	line, err := r.renderConstraint(constraint)
+	if err != nil {
+		return "", fmt.Errorf("error rendering foreign key constraint: %w", err)
+	}
+	return line, nil
 }
 
 // VisitAlterTable renders PostgreSQL-specific ALTER TABLE statements


### PR DESCRIPTION
## Summary
- support CREATE TABLE IF NOT EXISTS, MySQL CREATE TABLE ... SELECT tails, and Atlas/Flyway inline PRIMARY KEY syntax without a comma
- teach the lexer UTF-8 identifiers, MySQL dollar identifiers, and escaped default string cases from Atlas fixtures
- preserve CTAS tails in AST/renderers, with dialect validity checks for PostgreSQL and ClickHouse

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOCACHE=/private/tmp/ptah-conformance-go-cache GOWORK=/private/tmp/ptah-rename-work/go.work go run ./cmd/gap-probe -md /private/tmp/ptah-mysql-ctas-gaps.md -json /private/tmp/ptah-mysql-ctas-gaps.json

Conformance result with local Ptah: 158 fixtures, 516 observations, 142 unwaived gaps. Removed 6 sql-parse red keys and introduced no new red keys.