### PR TITLE
Support MySQL index prefix types

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -139,6 +139,13 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateFunction()
 	case "INDEX":
 		return p.parseCreateIndex()
+	case "FULLTEXT", "SPATIAL":
+		p.advance()
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "INDEX"); err != nil {
+			return nil, fmt.Errorf("expected INDEX after %s: %w", target, err)
+		}
+		return p.parseCreateIndexAfterKeyword(target)
 	case "OR":
 		return p.parseCreateOrReplaceStatement()
 	case "UNIQUE":
@@ -2552,70 +2559,14 @@ func (p *Parser) parseCreateIndex() (*ast.IndexNode, error) {
 		return nil, err
 	}
 
-	p.skipWhitespace()
-
-	// Get index name
-	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected index name, got %s at position %d", p.current.Type, p.current.Start)
-	}
-	indexName := p.current.Value
-	p.advance()
-
-	p.skipWhitespace()
-
-	if err := p.expect(lexer.TokenIdentifier, "ON"); err != nil {
-		return nil, fmt.Errorf("expected ON after index name: %w", err)
-	}
-
-	p.skipWhitespace()
-
-	// Get table name
-	tableName, err := p.expectIdentifier()
-	if err != nil {
-		return nil, fmt.Errorf("expected table name: %w", err)
-	}
-
-	p.skipWhitespace()
-
-	// Parse column list
-	if err := p.expect(lexer.TokenOperator, "("); err != nil {
-		return nil, fmt.Errorf("expected '(' for index columns: %w", err)
-	}
-
-	var columns []string
-	for {
-		p.skipWhitespace()
-
-		columnName, err := p.expectIdentifier()
-		if err != nil {
-			return nil, fmt.Errorf("expected column name: %w", err)
-		}
-		columns = append(columns, columnName)
-
-		p.skipWhitespace()
-
-		if p.current.MatchOperatorValue(",") {
-			p.advance()
-			continue
-		}
-
-		if p.current.MatchOperatorValue(")") {
-			break
-		}
-
-		return nil, fmt.Errorf("expected ',' or ')' in column list at position %d", p.current.Start)
-	}
-
-	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
-		return nil, err
-	}
-
-	return ast.NewIndex(indexName, tableName, columns...), nil
+	return p.parseCreateIndexAfterKeyword(regularIndexType)
 }
 
-// parseCreateUniqueIndex parses CREATE UNIQUE INDEX statements.
-// Note: The INDEX token has already been consumed by parseCreateStatement
-func (p *Parser) parseCreateUniqueIndex() (*ast.IndexNode, error) {
+// regularIndexType is the zero value for IndexNode.Type: a plain CREATE INDEX
+// without a MySQL-family FULLTEXT or SPATIAL prefix.
+const regularIndexType = ""
+
+func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode, error) {
 	p.skipWhitespace()
 
 	// Get index name
@@ -2675,6 +2626,17 @@ func (p *Parser) parseCreateUniqueIndex() (*ast.IndexNode, error) {
 	}
 
 	index := ast.NewIndex(indexName, tableName, columns...)
+	index.Type = indexType
+	return index, nil
+}
+
+// parseCreateUniqueIndex parses CREATE UNIQUE INDEX statements.
+// Note: The INDEX token has already been consumed by parseCreateStatement
+func (p *Parser) parseCreateUniqueIndex() (*ast.IndexNode, error) {
+	index, err := p.parseCreateIndexAfterKeyword(regularIndexType)
+	if err != nil {
+		return nil, err
+	}
 	index.SetUnique()
 	return index, nil
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -639,6 +639,53 @@ func TestParser_ParseCreateUniqueIndex(t *testing.T) {
 	c.Assert(index.Unique, qt.IsTrue)
 }
 
+func TestParser_ParseCreateTypedIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		indexName string
+		tableName string
+		columns   []string
+		indexType string
+	}{
+		{
+			name:      "fulltext",
+			sql:       "CREATE FULLTEXT INDEX idx_users_bio ON users (bio);",
+			indexName: "idx_users_bio",
+			tableName: "users",
+			columns:   []string{"bio"},
+			indexType: "FULLTEXT",
+		},
+		{
+			name:      "spatial",
+			sql:       "CREATE SPATIAL INDEX idx_geom_g ON geom (g);",
+			indexName: "idx_geom_g",
+			tableName: "geom",
+			columns:   []string{"g"},
+			indexType: "SPATIAL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			p := parser.NewParser(tt.sql)
+			statements, err := p.Parse()
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+
+			index, ok := statements.Statements[0].(*ast.IndexNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(index.Name, qt.Equals, tt.indexName)
+			c.Assert(index.Table, qt.Equals, tt.tableName)
+			c.Assert(index.Columns, qt.DeepEquals, tt.columns)
+			c.Assert(index.Type, qt.Equals, tt.indexType)
+			c.Assert(index.Unique, qt.IsFalse)
+		})
+	}
+}
+
 func TestParser_ParseCreateEnum(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -116,6 +116,35 @@ func TestMySQLRendererWithCapabilities_ClonesCapabilitySet(t *testing.T) {
 	c.Assert(sql, qt.Not(qt.Contains), "IF EXISTS")
 }
 
+func TestMySQLFamilyRenderers_IndexPrefixTypes(t *testing.T) {
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql, err := renderer.RenderSQL(dialect,
+				&ast.IndexNode{
+					Name:    "idx_users_bio",
+					Table:   "users",
+					Columns: []string{"bio"},
+					Type:    "FULLTEXT",
+				},
+				&ast.IndexNode{
+					Name:    "idx_geom_g",
+					Table:   "geom",
+					Columns: []string{"g"},
+					Type:    "SPATIAL",
+				},
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, "CREATE FULLTEXT INDEX idx_users_bio ON users (bio);",
+				qt.Commentf("got:\n%s", sql))
+			c.Assert(sql, qt.Contains, "CREATE SPATIAL INDEX idx_geom_g ON geom (g);",
+				qt.Commentf("got:\n%s", sql))
+		})
+	}
+}
+
 // TestMySQLFamilyRenderers_DropUniqueIndexSpelling pins the DROP INDEX
 // spelling requested via DropConstraintOperation.Unique (every UNIQUE
 // removal, issue #195). ALTER TABLE ... DROP INDEX is valid across the entire

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -318,6 +318,10 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 		parts = append(parts, "UNIQUE")
 	}
 
+	if indexType := mysqlIndexPrefixType(node.Type); indexType != "" {
+		parts = append(parts, indexType)
+	}
+
 	parts = append(parts, "INDEX")
 	parts = append(parts, node.Name)
 	parts = append(parts, "ON")
@@ -326,6 +330,16 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 	return nil
+}
+
+func mysqlIndexPrefixType(indexType string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(indexType))
+	switch normalized {
+	case "FULLTEXT", "SPATIAL":
+		return normalized
+	default:
+		return ""
+	}
 }
 
 // VisitEnum renders enum handling for MariaDB (inline ENUM types like MySQL)


### PR DESCRIPTION
## What changed

- Parse `CREATE FULLTEXT INDEX` and `CREATE SPATIAL INDEX` as `IndexNode` statements.
- Preserve MySQL-family prefix index types when rendering MySQL and MariaDB SQL.
- Share the regular and unique `CREATE INDEX` parser body to avoid duplicated parsing logic.

## Why

Atlas MySQL fixtures include `CREATE SPATIAL INDEX ...` in file-backed schema inspection. Ptah previously rejected that as an unsupported `CREATE` target, which kept one conformance runtime observation red.

## Validation

- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- Local ptah-atlas-conformance probe with temporary `replace github.com/stokaro/ptah => ../ptah`: `1119 observations / 745 non-OK` becomes `1118 observations / 744 non-OK`.
