### PR TITLE
Parse CREATE EXTENSION statements

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -122,7 +122,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
@@ -131,6 +131,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateSchema()
 	case "DATABASE":
 		return p.parseCreateDatabase()
+	case "EXTENSION":
+		return p.parseCreateExtension()
 	case "TABLE":
 		return p.parseCreateTable()
 	case "VIEW":
@@ -185,6 +187,53 @@ func (p *Parser) parseCreateDatabase() (*ast.CreateDatabaseNode, error) {
 		return nil, err
 	}
 	return &ast.CreateDatabaseNode{Name: name, IfNotExists: ifNotExists}, nil
+}
+
+func (p *Parser) parseCreateExtension() (*ast.ExtensionNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "EXTENSION"); err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected extension name: %w", err)
+	}
+
+	extension := ast.NewExtension(name)
+	if ifNotExists {
+		extension.SetIfNotExists()
+	}
+
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("VERSION") {
+		version, err := p.parseCreateExtensionVersion()
+		if err != nil {
+			return nil, err
+		}
+		extension.SetVersion(version)
+	}
+
+	return extension, nil
+}
+
+func (p *Parser) parseCreateExtensionVersion() (string, error) {
+	p.advance()
+	p.skipWhitespace()
+
+	if p.current.Type != lexer.TokenString && p.current.Type != lexer.TokenIdentifier {
+		return "", fmt.Errorf("expected extension version, got %s at position %d", p.current.Type, p.current.Start)
+	}
+
+	version := strings.Trim(p.current.Value, "'\"")
+	p.advance()
+	return version, nil
 }
 
 func (p *Parser) parseCreateNamespaceName(label string) (string, bool, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -686,6 +686,51 @@ func TestParser_ParseCreateTypedIndex(t *testing.T) {
 	}
 }
 
+func TestParser_ParseCreateExtension(t *testing.T) {
+	tests := []struct {
+		name        string
+		sql         string
+		extension   string
+		ifNotExists bool
+		version     string
+	}{
+		{
+			name:      "plain",
+			sql:       "CREATE EXTENSION pg_trgm;",
+			extension: "pg_trgm",
+		},
+		{
+			name:        "if not exists",
+			sql:         "CREATE EXTENSION IF NOT EXISTS unaccent;",
+			extension:   "unaccent",
+			ifNotExists: true,
+		},
+		{
+			name:      "version",
+			sql:       "CREATE EXTENSION postgis VERSION '3.0';",
+			extension: "postgis",
+			version:   "3.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			p := parser.NewParser(tt.sql)
+			statements, err := p.Parse()
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+
+			extension, ok := statements.Statements[0].(*ast.ExtensionNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(extension.Name, qt.Equals, tt.extension)
+			c.Assert(extension.IfNotExists, qt.Equals, tt.ifNotExists)
+			c.Assert(extension.Version, qt.Equals, tt.version)
+		})
+	}
+}
+
 func TestParser_ParseCreateEnum(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What
- Parse CREATE EXTENSION statements into the existing ast.ExtensionNode.
- Preserve IF NOT EXISTS and optional VERSION values.
- Add parser coverage for plain, IF NOT EXISTS, and VERSION forms.

## Why
Atlas fixtures currently expose a real sql-parse gap for PostgreSQL CREATE EXTENSION statements. This closes that parser gap using Ptah's existing extension AST surface instead of changing the conformance harness.

## Validation
- gopls diagnostics: clean
- go test ./core/parser
- go test ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- ptah-atlas-conformance with temporary local replace: 744 -> 742 unwaived non-OK observations; lex/7_delimiter_2n.sql and lex/8_delimiter_3n.sql moved from gap to ok