### PR TITLE
Parse ALTER EXCLUDE constraints and GO batches

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -105,6 +105,9 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseCommentStatement()
 	case "DROP":
 		return p.parseDropStatement()
+	case "GO":
+		p.skipGoBatchSeparator()
+		return nil, nil
 	case "ANALYZE", "BEGIN", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "UPDATE", "USE", "VACUUM", "WITH":
 		p.skipSchemaNeutralStatement()
 		return nil, nil
@@ -364,6 +367,14 @@ func (p *Parser) skipSchemaNeutralStatement() {
 			p.advance()
 			return
 		}
+		p.advance()
+	}
+}
+
+func (p *Parser) skipGoBatchSeparator() {
+	p.advance()
+	p.skipWhitespace()
+	if p.current.Type == lexer.TokenIdentifier && isNumeric(p.current.Value) {
 		p.advance()
 	}
 }
@@ -2223,7 +2234,7 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 
 		var err error
 		option := strings.ToUpper(p.current.Value)
-		if option == "AS" || option == "SELECT" {
+		if option == "AS" || option == "SELECT" || option == "GO" {
 			return nil
 		}
 		switch option {
@@ -2353,6 +2364,11 @@ func (p *Parser) parseAlterStatement() (*ast.AlterTableNode, error) {
 	}
 
 	p.skipWhitespace()
+
+	if p.current.MatchIdentifierValue("ONLY") {
+		p.advance()
+		p.skipWhitespace()
+	}
 
 	// Get table name
 	tableName, err := p.parseQualifiedIdentifier("table name")
@@ -2525,13 +2541,21 @@ func (p *Parser) parseRenameColumnOperation() (*ast.RenameColumnOperation, error
 	return &ast.RenameColumnOperation{OldName: oldName, NewName: newName}, nil
 }
 
-// parseAddOperation parses ADD COLUMN operations.
-func (p *Parser) parseAddOperation() (*ast.AddColumnOperation, error) {
+// parseAddOperation parses ADD COLUMN and ADD CONSTRAINT operations.
+func (p *Parser) parseAddOperation() (ast.AlterOperation, error) {
 	if err := p.expect(lexer.TokenIdentifier, "ADD"); err != nil {
 		return nil, err
 	}
 
 	p.skipWhitespace()
+
+	if p.isAlterAddConstraintStart() {
+		constraint, err := p.parseTableConstraint()
+		if err != nil {
+			return nil, err
+		}
+		return &ast.AddConstraintOperation{Constraint: constraint}, nil
+	}
 
 	// Optional COLUMN keyword
 	if p.current.Type == lexer.TokenIdentifier && strings.ToUpper(p.current.Value) == "COLUMN" {
@@ -2546,6 +2570,18 @@ func (p *Parser) parseAddOperation() (*ast.AddColumnOperation, error) {
 	}
 
 	return &ast.AddColumnOperation{Column: column}, nil
+}
+
+func (p *Parser) isAlterAddConstraintStart() bool {
+	if p.current.Type != lexer.TokenIdentifier {
+		return false
+	}
+	switch strings.ToUpper(p.current.Value) {
+	case "CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "EXCLUDE":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseDropOperation parses DROP COLUMN operations.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -117,6 +117,33 @@ func TestParser_ParseCreateTable_IfNotExists(t *testing.T) {
 	c.Assert(createTable.Columns[0].Primary, qt.IsTrue)
 }
 
+func TestParser_ParseSQLServerGoBatchSeparators(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `
+GO
+CREATE TABLE first_table (id INTEGER)
+gO 11
+CREATE TABLE second_table (id INTEGER)
+GO
+`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+	c.Assert(statements.Statements[0].(*ast.CreateTableNode).Name, qt.Equals, "first_table")
+	c.Assert(statements.Statements[1].(*ast.CreateTableNode).Name, qt.Equals, "second_table")
+}
+
+func TestParser_ParseDoesNotTreatGotoAsGoBatchSeparator(t *testing.T) {
+	c := qt.New(t)
+
+	p := parser.NewParser("GOTO label;")
+	_, err := p.Parse()
+	c.Assert(err, qt.ErrorMatches, `unsupported SQL statement: GOTO at position 0`)
+}
+
 func TestParser_ParseCreateTable_TablePrimaryKeyWithoutComma(t *testing.T) {
 	c := qt.New(t)
 
@@ -454,6 +481,36 @@ func TestParser_ParseAlterTable(t *testing.T) {
 	c.Assert(addOp.Column.Name, qt.Equals, "email")
 	c.Assert(addOp.Column.Type, qt.Equals, "VARCHAR(255)")
 	c.Assert(addOp.Column.Unique, qt.IsTrue)
+}
+
+func TestParser_ParseAlterTableOnlyAddExcludeConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `ALTER TABLE ONLY t
+    ADD CONSTRAINT name3 EXCLUDE USING gist (id WITH =, cid WITH -|-),
+    ADD CONSTRAINT name4 EXCLUDE USING gist (id WITH =, cid WITH -|-);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "t")
+	c.Assert(alterTable.Operations, qt.HasLen, 2)
+
+	firstOp, ok := alterTable.Operations[0].(*ast.AddConstraintOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(firstOp.Constraint.Name, qt.Equals, "name3")
+	c.Assert(firstOp.Constraint.Type, qt.Equals, ast.ExcludeConstraint)
+	c.Assert(firstOp.Constraint.UsingMethod, qt.Equals, "gist")
+	c.Assert(firstOp.Constraint.ExcludeElements, qt.Equals, "id WITH =, cid WITH -|-")
+
+	secondOp, ok := alterTable.Operations[1].(*ast.AddConstraintOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(secondOp.Constraint.Name, qt.Equals, "name4")
+	c.Assert(secondOp.Constraint.Type, qt.Equals, ast.ExcludeConstraint)
 }
 
 func TestParser_ParseAlterTableQualifiedName(t *testing.T) {


### PR DESCRIPTION
## What
- Parse SQL Server-style GO batch separators as schema-neutral statement boundaries, including optional numeric repeat counts.
- Parse PostgreSQL ALTER TABLE ONLY ... ADD CONSTRAINT ... EXCLUDE USING ... statements through the existing AddConstraintOperation and ExcludeConstraint AST types.
- Add parser tests for GO separators, GOTO not being treated as GO, and ALTER TABLE ONLY ADD EXCLUDE constraints.

## Why
The Atlas conformance corpus exposes real parser gaps around PostgreSQL EXCLUDE constraints added via ALTER TABLE. Supporting the existing AST surface closes that gap without changing the conformance harness.

GO handling improves parser correctness for SQL Server batch separators, but SELECT-only GO fixtures still remain red because Ptah intentionally returns zero AST statements for schema-neutral-only input.

## Validation
- gopls diagnostics: clean
- go test ./core/parser
- go test ./... outside sandbox after localhost bind was blocked inside sandbox
- golangci-lint run --fix ./...
- golangci-lint run ./...
- ptah-atlas-conformance with temporary local replace: 742 -> 741 unwaived non-OK observations; sql/migrate/testdata/lex/17_paren.sql moved from gap to ok