### PR TITLE
Parse expression indexes

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -106,6 +107,7 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 	case "DROP":
 		return p.parseDropStatement()
 	case "GO":
+		// SQL Server tooling uses GO as a batch separator, not as schema DDL.
 		p.skipGoBatchSeparator()
 		return nil, nil
 	case "ANALYZE", "BEGIN", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "UPDATE", "USE", "VACUUM", "WITH":
@@ -2655,11 +2657,10 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	p.skipWhitespace()
 
 	// Get index name
-	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected index name, got %s at position %d", p.current.Type, p.current.Start)
+	indexName, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected index name: %w", err)
 	}
-	indexName := p.current.Value
-	p.advance()
 
 	p.skipWhitespace()
 
@@ -2670,49 +2671,90 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	p.skipWhitespace()
 
 	// Get table name
-	tableName, err := p.expectIdentifier()
+	tableName, err := p.parseQualifiedIdentifier("table name")
 	if err != nil {
-		return nil, fmt.Errorf("expected table name: %w", err)
+		return nil, err
 	}
 
 	p.skipWhitespace()
 
-	// Parse column list
-	if err := p.expect(lexer.TokenOperator, "("); err != nil {
-		return nil, fmt.Errorf("expected '(' for index columns: %w", err)
-	}
-
-	var columns []string
-	for {
-		p.skipWhitespace()
-
-		columnName, err := p.expectIdentifier()
-		if err != nil {
-			return nil, fmt.Errorf("expected column name: %w", err)
-		}
-		columns = append(columns, columnName)
-
-		p.skipWhitespace()
-
-		if p.current.MatchOperatorValue(",") {
-			p.advance()
-			continue
-		}
-
-		if p.current.MatchOperatorValue(")") {
-			break
-		}
-
-		return nil, fmt.Errorf("expected ',' or ')' in column list at position %d", p.current.Start)
-	}
-
-	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
+	columns, err := p.parseCreateIndexColumns()
+	if err != nil {
 		return nil, err
 	}
 
 	index := ast.NewIndex(indexName, tableName, columns...)
 	index.Type = indexType
 	return index, nil
+}
+
+func (p *Parser) parseCreateIndexColumns() ([]string, error) {
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return nil, fmt.Errorf("expected '(' for index columns: %w", err)
+	}
+
+	var columns []string
+	var column strings.Builder
+	parenDepth := 0
+	lastWasSpace := false
+
+columnList:
+	for !p.isAtEnd() {
+		if p.current.Type == lexer.TokenOperator {
+			switch p.current.Value {
+			case "(":
+				parenDepth++
+			case ")":
+				if parenDepth == 0 {
+					break columnList
+				}
+				parenDepth--
+			case ",":
+				if parenDepth == 0 {
+					columnText := strings.TrimSpace(column.String())
+					if columnText == "" {
+						return nil, fmt.Errorf("expected column or expression before ',' in index column list at position %d", p.current.Start)
+					}
+					columns = append(columns, columnText)
+					column.Reset()
+					lastWasSpace = false
+					p.advance()
+					p.skipWhitespace()
+					continue
+				}
+			}
+		}
+
+		appendTokenValue(&column, p.current, &lastWasSpace)
+		p.advance()
+	}
+
+	if p.isAtEnd() {
+		return nil, fmt.Errorf("expected ')' for index columns before end of input")
+	}
+
+	columns = append(columns, strings.TrimSpace(column.String()))
+	if slices.Contains(columns, "") {
+		return nil, fmt.Errorf("expected column or expression in index column list at position %d", p.current.Start)
+	}
+
+	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
+		return nil, err
+	}
+	return columns, nil
+}
+
+func appendTokenValue(builder *strings.Builder, token lexer.Token, lastWasSpace *bool) {
+	if token.Type == lexer.TokenWhitespace {
+		if builder.Len() > 0 && !*lastWasSpace {
+			builder.WriteString(" ")
+			*lastWasSpace = true
+		}
+		return
+	}
+
+	builder.WriteString(token.Value)
+	*lastWasSpace = false
 }
 
 // parseCreateUniqueIndex parses CREATE UNIQUE INDEX statements.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -678,6 +678,74 @@ func TestParser_ParseCreateIndex(t *testing.T) {
 	c.Assert(index.Unique, qt.IsFalse)
 }
 
+func TestParser_ParseCreateIndexExpressions(t *testing.T) {
+	tests := []struct {
+		name      string
+		sql       string
+		indexName string
+		tableName string
+		columns   []string
+	}{
+		{
+			name:      "quoted qualified table and nested expression",
+			sql:       `CREATE INDEX "i" ON "s"."t" (((c #>> '{a,b,c}'::text[])));`,
+			indexName: `"i"`,
+			tableName: `"s"."t"`,
+			columns:   []string{"((c #>> '{a,b,c}'::text[]))"},
+		},
+		{
+			name:      "function expression",
+			sql:       `CREATE INDEX "idx_emp_contact" ON "company"."employees" (LOWER(info #>> '{contact, email}'));`,
+			indexName: `"idx_emp_contact"`,
+			tableName: `"company"."employees"`,
+			columns:   []string{"LOWER(info #>> '{contact, email}')"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			p := parser.NewParser(tt.sql)
+			statements, err := p.Parse()
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+
+			index, ok := statements.Statements[0].(*ast.IndexNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(index.Name, qt.Equals, tt.indexName)
+			c.Assert(index.Table, qt.Equals, tt.tableName)
+			c.Assert(index.Columns, qt.DeepEquals, tt.columns)
+			c.Assert(index.Unique, qt.IsFalse)
+		})
+	}
+}
+
+func TestParser_ParseCreateIndexRejectsEmptyColumnExpressions(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "empty first expression",
+			sql:  "CREATE INDEX idx_users_email ON users (, email);",
+		},
+		{
+			name: "empty trailing expression",
+			sql:  "CREATE INDEX idx_users_email ON users (email,);",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := parser.NewParser(tt.sql).Parse()
+			c.Assert(err, qt.ErrorMatches, "expected column or expression.*")
+		})
+	}
+}
+
 func TestParser_ParseCreateUniqueIndex(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- parse quoted CREATE INDEX names and qualified table names
- parse PostgreSQL expression index column lists with balanced parentheses and string-literal commas
- reject empty index column/expression entries
- document why standalone GO is skipped as a SQL Server batch separator

## Conformance
- With a temporary local replace in ptah-atlas-conformance, `make probe` moves `sql/migrate/testdata/lex/18_pg_expr.sql` from fail to ok.
- Gap budget improves from 741 to 740 unwaived non-OK observations.
- Full conformance remains red, as expected.

## Validation
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...` outside sandbox for localhost bind tests
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-conformance-go-cache make probe` in ptah-atlas-conformance with `replace github.com/stokaro/ptah => ../ptah`
