### PR TITLE
Parse create triggers

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -127,7 +127,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, TRIGGER, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
@@ -144,6 +144,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateView()
 	case "FUNCTION":
 		return p.parseCreateFunction()
+	case "TRIGGER":
+		return p.parseCreateTrigger()
 	case "INDEX":
 		return p.parseCreateIndex()
 	case "FULLTEXT", "SPATIAL":
@@ -155,6 +157,13 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateIndexAfterKeyword(target)
 	case "OR":
 		return p.parseCreateOrReplaceStatement()
+	case "TEMP", "TEMPORARY":
+		p.advance()
+		p.skipWhitespace()
+		if p.current.MatchIdentifierValue("TRIGGER") {
+			return p.parseCreateTrigger()
+		}
+		return nil, fmt.Errorf("unsupported CREATE %s target: %s at position %d", target, p.current.Value, p.current.Start)
 	case "UNIQUE":
 		// Handle CREATE UNIQUE INDEX
 		p.advance()
@@ -285,6 +294,13 @@ func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
 	}
 	if p.current.MatchIdentifierValue("FUNCTION") {
 		return p.parseCreateOrReplaceFunction()
+	}
+	if p.current.MatchIdentifierValue("TRIGGER") {
+		trigger, err := p.parseCreateTrigger()
+		if err != nil {
+			return nil, err
+		}
+		return trigger.SetReplace(), nil
 	}
 	return nil, fmt.Errorf("unsupported CREATE OR REPLACE target: %s at position %d", p.current.Value, p.current.Start)
 }
@@ -584,6 +600,196 @@ func (p *Parser) parseFunctionSecurity(function *ast.CreateFunctionNode) error {
 	}
 	function.SetSecurity(strings.ToUpper(security))
 	return nil
+}
+
+func (p *Parser) parseCreateTrigger() (*ast.CreateTriggerNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "TRIGGER"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	if p.current.MatchIdentifierValue("IF") {
+		if err := p.parseTriggerIfNotExists(); err != nil {
+			return nil, err
+		}
+		p.skipWhitespace()
+	}
+
+	triggerName, err := p.parseQualifiedIdentifier("trigger name")
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	timing, err := p.parseTriggerTiming()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	event, err := p.parseTriggerEvent()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	if err := p.expect(lexer.TokenIdentifier, "ON"); err != nil {
+		return nil, fmt.Errorf("expected ON after trigger event: %w", err)
+	}
+	p.skipWhitespace()
+
+	tableName, err := p.parseQualifiedIdentifier("trigger table name")
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	forEach, err := p.parseOptionalTriggerForEach()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	body, err := p.collectTriggerBody()
+	if err != nil {
+		return nil, err
+	}
+
+	return ast.NewCreateTrigger(triggerName, tableName).
+		SetTiming(timing).
+		SetEvent(event).
+		SetForEach(forEach).
+		SetBody(body), nil
+}
+
+func (p *Parser) parseTriggerIfNotExists() error {
+	if err := p.expect(lexer.TokenIdentifier, "IF"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "NOT"); err != nil {
+		return fmt.Errorf("expected NOT after IF: %w", err)
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "EXISTS"); err != nil {
+		return fmt.Errorf("expected EXISTS after IF NOT: %w", err)
+	}
+	return nil
+}
+
+func (p *Parser) parseTriggerTiming() (string, error) {
+	switch {
+	case p.current.MatchIdentifierValue("BEFORE"), p.current.MatchIdentifierValue("AFTER"):
+		timing := strings.ToUpper(p.current.Value)
+		p.advance()
+		return timing, nil
+	case p.current.MatchIdentifierValue("INSTEAD"):
+		p.advance()
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "OF"); err != nil {
+			return "", fmt.Errorf("expected OF after INSTEAD in trigger timing: %w", err)
+		}
+		return "INSTEAD OF", nil
+	default:
+		return "", fmt.Errorf("expected trigger timing, got %s at position %d", p.current.Type, p.current.Start)
+	}
+}
+
+func (p *Parser) parseTriggerEvent() (string, error) {
+	switch {
+	case p.current.MatchIdentifierValue("INSERT"), p.current.MatchIdentifierValue("DELETE"):
+		event := strings.ToUpper(p.current.Value)
+		p.advance()
+		return event, nil
+	case p.current.MatchIdentifierValue("UPDATE"):
+		return p.parseUpdateTriggerEvent(), nil
+	default:
+		return "", fmt.Errorf("expected trigger event, got %s at position %d", p.current.Type, p.current.Start)
+	}
+}
+
+func (p *Parser) parseUpdateTriggerEvent() string {
+	var event strings.Builder
+	event.WriteString(strings.ToUpper(p.current.Value))
+	p.advance()
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("OF") {
+		return event.String()
+	}
+
+	event.WriteString(" OF")
+	p.advance()
+	for !p.isAtEnd() && !p.current.MatchIdentifierValue("ON") {
+		event.WriteString(p.current.Value)
+		p.advance()
+	}
+	return strings.TrimSpace(event.String())
+}
+
+func (p *Parser) parseOptionalTriggerForEach() (string, error) {
+	if !p.current.MatchIdentifierValue("FOR") {
+		return "ROW", nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "EACH"); err != nil {
+		return "", fmt.Errorf("expected EACH after FOR in trigger clause: %w", err)
+	}
+	p.skipWhitespace()
+
+	forEach, err := p.expectIdentifier()
+	if err != nil {
+		return "", fmt.Errorf("expected trigger FOR EACH target: %w", err)
+	}
+	return strings.ToUpper(forEach), nil
+}
+
+func (p *Parser) collectTriggerBody() (string, error) {
+	var body strings.Builder
+	blockDepth := 0
+	caseDepth := 0
+	seenBegin := false
+
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+
+		if p.current.Type == lexer.TokenIdentifier {
+			keyword := strings.ToUpper(p.current.Value)
+			switch keyword {
+			case "BEGIN":
+				seenBegin = true
+				blockDepth++
+			case "CASE":
+				if seenBegin {
+					caseDepth++
+				}
+			case "END":
+				if caseDepth > 0 {
+					caseDepth--
+				} else if seenBegin {
+					blockDepth--
+				}
+			}
+
+			body.WriteString(p.current.Value)
+			p.advance()
+
+			if seenBegin && blockDepth == 0 {
+				return strings.TrimSpace(body.String()), nil
+			}
+			continue
+		}
+
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	if !seenBegin {
+		return "", fmt.Errorf("expected trigger body BEGIN at position %d", p.current.Start)
+	}
+	return "", fmt.Errorf("unterminated trigger body at position %d", p.current.Start)
 }
 
 func stripSQLStringDelimiters(value string) string {
@@ -1223,8 +1429,8 @@ func (p *Parser) parseColumnDefinition(table *ast.CreateTableNode) (*ast.ColumnN
 
 	p.skipWhitespace()
 
-	// Get column type
-	columnType, err := p.parseColumnType()
+	// Get column type. SQLite permits columns without an explicit type.
+	columnType, err := p.parseOptionalColumnType()
 	if err != nil {
 		return nil, fmt.Errorf("expected column type: %w", err)
 	}
@@ -1236,6 +1442,26 @@ func (p *Parser) parseColumnDefinition(table *ast.CreateTableNode) (*ast.ColumnN
 	}
 
 	return column, nil
+}
+
+func (p *Parser) parseOptionalColumnType() (string, error) {
+	switch {
+	case p.current.Type == lexer.TokenIdentifier && isColumnConstraintStart(p.current.Value):
+		return "", nil
+	case p.current.MatchOperatorValue(",") || p.current.MatchOperatorValue(")"):
+		return "", nil
+	default:
+		return p.parseColumnType()
+	}
+}
+
+func isColumnConstraintStart(value string) bool {
+	switch strings.ToUpper(value) {
+	case "NOT", "NULL", "PRIMARY", "UNIQUE", "AUTO_INCREMENT", "AUTOINCREMENT", "DEFAULT", "CHECK", "REFERENCES", "COMMENT", "COLLATE", "GENERATED", "AS":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *Parser) handleMultiWordType(typeName string) string {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -419,6 +419,77 @@ func TestParser_ParseCreateFunctionWithSingleQuotedBody(t *testing.T) {
 	c.Assert(createFunction.Volatility, qt.Equals, "STABLE")
 }
 
+func TestParser_ParseCreateTrigger(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE
+    WHEN (new.a = 4) THEN RAISE(IGNORE) END;
+END;
+
+CREATE TABLE t2(x,y,z);
+CREATE TRIGGER t2r3 AFTER UPDATE ON t2 BEGIN SELECT 1; END;
+CREATE TRIGGER trigItem_UNDO_AD AFTER DELETE ON Item FOR EACH ROW
+BEGIN
+  INSERT INTO Undo SELECT 'INSERT INTO Item (a,b,c) VALUES ('
+   || coalesce(old.a,'NULL') || ',' || quote(old.b) || ',' || old.c || ');';
+END;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 4)
+
+	firstTrigger, ok := statements.Statements[0].(*ast.CreateTriggerNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(firstTrigger.Name, qt.Equals, "before_tbl_insert")
+	c.Assert(firstTrigger.Table, qt.Equals, "tbl")
+	c.Assert(firstTrigger.Timing, qt.Equals, "BEFORE")
+	c.Assert(firstTrigger.Event, qt.Equals, "INSERT")
+	c.Assert(firstTrigger.ForEach, qt.Equals, "ROW")
+	c.Assert(firstTrigger.Body, qt.Contains, "RAISE(IGNORE) END;")
+
+	table, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(table.Name, qt.Equals, "t2")
+	c.Assert(table.Columns, qt.HasLen, 3)
+	c.Assert(table.Columns[0].Name, qt.Equals, "x")
+	c.Assert(table.Columns[0].Type, qt.Equals, "")
+
+	updateTrigger, ok := statements.Statements[2].(*ast.CreateTriggerNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(updateTrigger.Name, qt.Equals, "t2r3")
+	c.Assert(updateTrigger.Timing, qt.Equals, "AFTER")
+	c.Assert(updateTrigger.Event, qt.Equals, "UPDATE")
+	c.Assert(updateTrigger.Body, qt.Equals, "BEGIN SELECT 1; END")
+
+	deleteTrigger, ok := statements.Statements[3].(*ast.CreateTriggerNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(deleteTrigger.Name, qt.Equals, "trigItem_UNDO_AD")
+	c.Assert(deleteTrigger.Table, qt.Equals, "Item")
+	c.Assert(deleteTrigger.Event, qt.Equals, "DELETE")
+	c.Assert(deleteTrigger.ForEach, qt.Equals, "ROW")
+	c.Assert(deleteTrigger.Body, qt.Contains, "coalesce(old.a,'NULL')")
+}
+
+func TestParser_ParseCreateOrReplaceTrigger(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE OR REPLACE TRIGGER set_updated_at BEFORE UPDATE ON users BEGIN SELECT 1; END;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTrigger, ok := statements.Statements[0].(*ast.CreateTriggerNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTrigger.Name, qt.Equals, "set_updated_at")
+	c.Assert(createTrigger.Replace, qt.IsTrue)
+	c.Assert(createTrigger.Timing, qt.Equals, "BEFORE")
+	c.Assert(createTrigger.Event, qt.Equals, "UPDATE")
+	c.Assert(createTrigger.Table, qt.Equals, "users")
+}
+
 func TestParser_ParseRejectsUnsupportedCreateOrReplaceTarget(t *testing.T) {
 	c := qt.New(t)
 
@@ -2759,8 +2830,8 @@ func TestParser_ErrorHandling(t *testing.T) {
 			sql:  "CREATE TABLE users id INTEGER);",
 		},
 		{
-			name: "Missing column type",
-			sql:  "CREATE TABLE users (id);",
+			name: "Invalid column type token",
+			sql:  "CREATE TABLE users (id @);",
 		},
 		{
 			name: "Unterminated column list",


### PR DESCRIPTION
## Summary
- parse `CREATE TRIGGER` statements into existing `ast.CreateTriggerNode`
- preserve trigger bodies as opaque balanced `BEGIN ... END` text, including internal semicolons and `CASE ... END` blocks
- support `CREATE OR REPLACE TRIGGER`, optional `IF NOT EXISTS`, `INSTEAD OF`, `FOR EACH`, and `UPDATE OF` event text
- allow SQLite typeless columns without inventing a type

## Conformance
- With a temporary local replace in ptah-atlas-conformance, `make probe` moves `sql/migrate/testdata/lexgroup/1_trigger.sql` from gap to ok.
- Gap budget improves from 740 to 739 unwaived non-OK observations.
- Full conformance remains red, as expected.

## Validation
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser`
- `env GOCACHE=/private/tmp/ptah-go-cache go test ./...` outside sandbox for localhost bind tests
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-conformance-go-cache make probe` in ptah-atlas-conformance with `replace github.com/stokaro/ptah => ../ptah`
