### PR TITLE
Support SQL-standard function bodies

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1183,6 +1183,8 @@ type CreateFunctionNode struct {
 	Language string
 	// Body contains the function implementation code
 	Body string
+	// BodyKind specifies how Body should be rendered.
+	BodyKind FunctionBodyKind
 	// Security specifies security attributes (e.g., "DEFINER", "INVOKER")
 	Security string
 	// Volatility specifies function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
@@ -1190,6 +1192,18 @@ type CreateFunctionNode struct {
 	// Comment is an optional comment for the function
 	Comment string
 }
+
+// FunctionBodyKind specifies the PostgreSQL CREATE FUNCTION body syntax.
+type FunctionBodyKind string
+
+const (
+	// FunctionBodyQuoted renders AS $$ body $$.
+	FunctionBodyQuoted FunctionBodyKind = "quoted"
+	// FunctionBodyReturn renders a SQL-standard RETURN body.
+	FunctionBodyReturn FunctionBodyKind = "return"
+	// FunctionBodyAtomic renders a SQL-standard BEGIN ATOMIC body.
+	FunctionBodyAtomic FunctionBodyKind = "atomic"
+)
 
 // NewCreateFunction creates a new CREATE FUNCTION node with the specified name.
 //
@@ -1203,7 +1217,8 @@ type CreateFunctionNode struct {
 //		SetBody("BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;")
 func NewCreateFunction(name string) *CreateFunctionNode {
 	return &CreateFunctionNode{
-		Name: name,
+		Name:     name,
+		BodyKind: FunctionBodyQuoted,
 	}
 }
 
@@ -1244,6 +1259,21 @@ func (n *CreateFunctionNode) SetLanguage(language string) *CreateFunctionNode {
 //	createFunc.SetBody("BEGIN RETURN current_setting('app.current_tenant_id', true); END;")
 func (n *CreateFunctionNode) SetBody(body string) *CreateFunctionNode {
 	n.Body = body
+	n.BodyKind = FunctionBodyQuoted
+	return n
+}
+
+// SetReturnBody sets a SQL-standard RETURN function body.
+func (n *CreateFunctionNode) SetReturnBody(body string) *CreateFunctionNode {
+	n.Body = body
+	n.BodyKind = FunctionBodyReturn
+	return n
+}
+
+// SetAtomicBody sets a SQL-standard BEGIN ATOMIC function body.
+func (n *CreateFunctionNode) SetAtomicBody(body string) *CreateFunctionNode {
+	n.Body = body
+	n.BodyKind = FunctionBodyAtomic
 	return n
 }
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -513,6 +513,14 @@ func (p *Parser) parseFunctionClauses(function *ast.CreateFunctionNode) error {
 			if err := p.parseFunctionReturns(function); err != nil {
 				return err
 			}
+		case "RETURN":
+			if err := p.parseFunctionReturnBody(function); err != nil {
+				return err
+			}
+		case "BEGIN":
+			if err := p.parseFunctionAtomicBody(function); err != nil {
+				return err
+			}
 		case "AS":
 			if err := p.parseFunctionBody(function); err != nil {
 				return err
@@ -545,7 +553,7 @@ func (p *Parser) parseFunctionReturns(function *ast.CreateFunctionNode) error {
 	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
 		if p.current.Type == lexer.TokenIdentifier {
 			switch strings.ToUpper(p.current.Value) {
-			case "AS", "LANGUAGE", "SECURITY", "IMMUTABLE", "STABLE", "VOLATILE":
+			case "AS", "BEGIN", "LANGUAGE", "RETURN", "SECURITY", "IMMUTABLE", "STABLE", "VOLATILE":
 				function.SetReturns(strings.TrimSpace(returns.String()))
 				return nil
 			}
@@ -572,6 +580,87 @@ func (p *Parser) parseFunctionBody(function *ast.CreateFunctionNode) error {
 	function.SetBody(stripSQLStringDelimiters(body))
 	p.advance()
 	return nil
+}
+
+func (p *Parser) parseFunctionReturnBody(function *ast.CreateFunctionNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "RETURN"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+
+	var body strings.Builder
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if err := p.checkTimeout(); err != nil {
+			return err
+		}
+
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	function.SetReturnBody(strings.TrimSpace(body.String()))
+	return nil
+}
+
+func (p *Parser) parseFunctionAtomicBody(function *ast.CreateFunctionNode) error {
+	body, err := p.collectAtomicFunctionBody()
+	if err != nil {
+		return err
+	}
+	function.SetAtomicBody(body)
+	return nil
+}
+
+func (p *Parser) collectAtomicFunctionBody() (string, error) {
+	if err := p.expect(lexer.TokenIdentifier, "BEGIN"); err != nil {
+		return "", err
+	}
+
+	var body strings.Builder
+	body.WriteString("BEGIN")
+
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "ATOMIC"); err != nil {
+		return "", fmt.Errorf("expected ATOMIC after BEGIN in SQL function body: %w", err)
+	}
+	body.WriteString(" ATOMIC")
+
+	blockDepth := 1
+	caseDepth := 0
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+
+		if p.current.Type == lexer.TokenIdentifier {
+			keyword := strings.ToUpper(p.current.Value)
+			switch keyword {
+			case "BEGIN":
+				blockDepth++
+			case "CASE":
+				caseDepth++
+			case "END":
+				if caseDepth > 0 {
+					caseDepth--
+				} else {
+					blockDepth--
+				}
+			}
+
+			body.WriteString(p.current.Value)
+			p.advance()
+
+			if blockDepth == 0 {
+				return strings.TrimSpace(body.String()), nil
+			}
+			continue
+		}
+
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	return "", fmt.Errorf("unterminated SQL function body at position %d", p.current.Start)
 }
 
 func (p *Parser) parseFunctionLanguage(function *ast.CreateFunctionNode) error {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -419,6 +419,53 @@ func TestParser_ParseCreateFunctionWithSingleQuotedBody(t *testing.T) {
 	c.Assert(createFunction.Volatility, qt.Equals, "STABLE")
 }
 
+func TestParser_ParseCreateFunctionWithReturnBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE FUNCTION public.first_int(value text[]) RETURNS int RETURN value[1]::int;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "public.first_int")
+	c.Assert(createFunction.Parameters, qt.Equals, "value text[]")
+	c.Assert(createFunction.Returns, qt.Equals, "int")
+	c.Assert(createFunction.BodyKind, qt.Equals, ast.FunctionBodyReturn)
+	c.Assert(createFunction.Body, qt.Equals, "value[1]::int")
+}
+
+func TestParser_ParseCreateFunctionWithAtomicBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.is_even(x int) RETURNS boolean
+LANGUAGE SQL
+STABLE
+BEGIN ATOMIC
+SELECT CASE WHEN x % 2 = 0 THEN true ELSE false END;
+END;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "public.is_even")
+	c.Assert(createFunction.Parameters, qt.Equals, "x int")
+	c.Assert(createFunction.Returns, qt.Equals, "boolean")
+	c.Assert(createFunction.Language, qt.Equals, "SQL")
+	c.Assert(createFunction.Volatility, qt.Equals, "STABLE")
+	c.Assert(createFunction.BodyKind, qt.Equals, ast.FunctionBodyAtomic)
+	c.Assert(createFunction.Body, qt.Contains, "BEGIN ATOMIC")
+	c.Assert(createFunction.Body, qt.Contains, "SELECT CASE WHEN x % 2 = 0 THEN true ELSE false END;")
+	c.Assert(createFunction.Body, qt.Contains, "END")
+}
+
 func TestParser_ParseCreateTrigger(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -907,10 +907,6 @@ func (r *Renderer) VisitCreateFunction(node *ast.CreateFunctionNode) error {
 		parts = append(parts, "RETURNS", node.Returns)
 	}
 
-	// Function body with dollar quoting
-	r.w.WriteLinef("%s AS $$", strings.Join(parts, " "))
-	r.w.WriteLinef("%s", node.Body)
-
 	// Language specification and other attributes
 	var attributes []string
 	if node.Language != "" {
@@ -927,13 +923,28 @@ func (r *Renderer) VisitCreateFunction(node *ast.CreateFunctionNode) error {
 		attributes = append(attributes, node.Volatility)
 	}
 
+	if node.BodyKind == ast.FunctionBodyReturn || node.BodyKind == ast.FunctionBodyAtomic {
+		parts = append(parts, attributes...)
+		switch node.BodyKind {
+		case ast.FunctionBodyReturn:
+			r.w.WriteLinef("%s RETURN %s;", strings.Join(parts, " "), node.Body)
+		case ast.FunctionBodyAtomic:
+			r.w.WriteLinef("%s %s;", strings.Join(parts, " "), node.Body)
+		}
+		return nil
+	}
+
+	// Function body with dollar quoting
+	r.w.WriteLinef("%s AS $$", strings.Join(parts, " "))
+	r.w.WriteLinef("%s", node.Body)
+
 	// Close the function with attributes
 	if len(attributes) > 0 {
 		r.w.WriteLinef("$$")
 		r.w.WriteLinef("%s;", strings.Join(attributes, " "))
-	} else {
-		r.w.WriteLinef("$$;")
+		return nil
 	}
+	r.w.WriteLinef("$$;")
 
 	return nil
 }

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -395,6 +395,31 @@ $$
 LANGUAGE sql;
 `,
 		},
+		{
+			name: "function with return body",
+			function: ast.NewCreateFunction("first_int").
+				SetParameters("value text[]").
+				SetReturns("int").
+				SetLanguage("sql").
+				SetReturnBody("value[1]::int"),
+			expected: `CREATE OR REPLACE FUNCTION first_int(value text[]) RETURNS int LANGUAGE sql RETURN value[1]::int;
+`,
+		},
+		{
+			name: "function with atomic body",
+			function: ast.NewCreateFunction("is_even").
+				SetParameters("x int").
+				SetReturns("boolean").
+				SetLanguage("SQL").
+				SetVolatility("STABLE").
+				SetAtomicBody(`BEGIN ATOMIC
+SELECT CASE WHEN x % 2 = 0 THEN true ELSE false END;
+END`),
+			expected: `CREATE OR REPLACE FUNCTION is_even(x int) RETURNS boolean LANGUAGE SQL STABLE BEGIN ATOMIC
+SELECT CASE WHEN x % 2 = 0 THEN true ELSE false END;
+END;
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add explicit CREATE FUNCTION body kinds for quoted, RETURN, and BEGIN ATOMIC forms
- parse PostgreSQL SQL-standard function bodies without folding RETURN into the return type
- render SQL-standard function bodies without wrapping them in dollar-quoted AS bodies

## Root cause
Ptah only modeled CREATE FUNCTION bodies provided through AS string literals. Atlas includes PostgreSQL fixtures using SQL-standard RETURN expressions and BEGIN ATOMIC blocks, so the parser stopped at RETURN as an unsupported function clause or treated body tokens as part of RETURNS.

## Validation
- env GOCACHE=/private/tmp/ptah-gocache go test ./core/parser ./core/renderer/dialects/postgres ./core/ast
- env GOCACHE=/private/tmp/ptah-gocache go test ./...
- env GOCACHE=/private/tmp/ptah-gocache go test ./dbschema (outside sandbox for local TCP bind)
- env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- ptah-atlas-conformance local replace: make probe -> 738 unwaived non-OK, lex/16_begin_atomic.sql ok
- ptah-atlas-conformance local replace: go test ./..., make verify, make budget green
- ptah-atlas-conformance local replace: make gate remains red at 738 as expected