### PR TITLE
Support MySQL hash line comments

### DIFF
--- a/core/lexer/lexer.go
+++ b/core/lexer/lexer.go
@@ -180,6 +180,8 @@ func (l *Lexer) NextToken() Token {
 			return l.scanOperator()
 		case ch == '-' && l.peekNext() == '-':
 			return l.scanLineComment()
+		case ch == '#' && !isHashOperatorContinuation(l.peekNext()):
+			return l.scanHashLineComment()
 		case ch == '/' && l.peekNext() == '*':
 			return l.scanBlockComment()
 		case isIdentifierStart(ch):
@@ -251,6 +253,30 @@ func (l *Lexer) scanLineComment() Token {
 	}
 
 	return l.emit(TokenComment)
+}
+
+// scanHashLineComment scans a MySQL-style line comment (# comment).
+func (l *Lexer) scanHashLineComment() Token {
+	l.advance() // consume #
+
+	for {
+		ch := l.peek()
+		if ch == 0 || ch == '\n' || ch == '\r' {
+			break
+		}
+		l.advance()
+	}
+
+	return l.emit(TokenComment)
+}
+
+func isHashOperatorContinuation(ch rune) bool {
+	switch ch {
+	case '!', '#', '%', '&', '*', '+', '-', '/', '<', '=', '>', '?', '@', '^', '|', '~':
+		return true
+	default:
+		return false
+	}
 }
 
 // scanBlockComment scans a block comment (/* comment */)

--- a/core/lexer/lexer_test.go
+++ b/core/lexer/lexer_test.go
@@ -89,6 +89,34 @@ func TestLexer_NextToken_HappyPath(t *testing.T) {
 			},
 		},
 		{
+			name:  "hash_line_comment",
+			input: "SELECT # this is a comment\nFROM users",
+			expected: []lexer.Token{
+				{Type: lexer.TokenIdentifier, Value: "SELECT", Start: 0, End: 6},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 6, End: 7},
+				{Type: lexer.TokenComment, Value: "# this is a comment", Start: 7, End: 26},
+				{Type: lexer.TokenWhitespace, Value: "\n", Start: 26, End: 27},
+				{Type: lexer.TokenIdentifier, Value: "FROM", Start: 27, End: 31},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 31, End: 32},
+				{Type: lexer.TokenIdentifier, Value: "users", Start: 32, End: 37},
+				{Type: lexer.TokenEOF, Value: "", Start: 37, End: 37},
+			},
+		},
+		{
+			name:  "postgres_hash_operator",
+			input: "c #>> '{a}'",
+			expected: []lexer.Token{
+				{Type: lexer.TokenIdentifier, Value: "c", Start: 0, End: 1},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 1, End: 2},
+				{Type: lexer.TokenOperator, Value: "#", Start: 2, End: 3},
+				{Type: lexer.TokenOperator, Value: ">", Start: 3, End: 4},
+				{Type: lexer.TokenOperator, Value: ">", Start: 4, End: 5},
+				{Type: lexer.TokenWhitespace, Value: " ", Start: 5, End: 6},
+				{Type: lexer.TokenString, Value: "'{a}'", Start: 6, End: 11},
+				{Type: lexer.TokenEOF, Value: "", Start: 11, End: 11},
+			},
+		},
+		{
 			name:  "block_comment",
 			input: "SELECT /* multi\nline comment */ FROM users",
 			expected: []lexer.Token{

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -136,6 +136,24 @@ GO
 	c.Assert(statements.Statements[1].(*ast.CreateTableNode).Name, qt.Equals, "second_table")
 }
 
+func TestParser_ParseMySQLHashLineComments(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `# CREATE TABLE skipped(id int);
+CREATE TABLE t1(id int);
+SELECT * FROM t1 # inline comment
+;
+# another skipped statement
+CREATE TABLE t2(id int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+	c.Assert(statements.Statements[0].(*ast.CreateTableNode).Name, qt.Equals, "t1")
+	c.Assert(statements.Statements[1].(*ast.CreateTableNode).Name, qt.Equals, "t2")
+}
+
 func TestParser_ParseDoesNotTreatGotoAsGoBatchSeparator(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- tokenize MySQL-style # line comments as comments
- preserve PostgreSQL hash-prefixed operators such as #>>
- add lexer and parser coverage for top-level and inline # comments

## Root cause
Atlas lex fixtures include MySQL # comments. Ptah's lexer treated # as an operator, so the parser failed before it could skip commented-out SQL. A naive # comment rule would break PostgreSQL expression operators, so the lexer keeps hash-prefixed operator continuations as operators.

## Validation
- env GOCACHE=/private/tmp/ptah-gocache go test ./core/lexer ./core/parser
- env GOCACHE=/private/tmp/ptah-gocache go test ./...
- env GOCACHE=/private/tmp/ptah-gocache go test ./dbschema (outside sandbox for local TCP bind)
- env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run --fix ./...
- env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- ptah-atlas-conformance local replace: make probe -> 737 unwaived non-OK; lex/6_skip_comment.sql ok; lex/13_delimiter_mysql_command.sql moves from parse fail to explicit DELIMITER gap
- ptah-atlas-conformance local replace: go test ./..., make verify, make budget green
- ptah-atlas-conformance local replace: make gate remains red at 737 as expected