### PR TITLE
Support MySQL client delimiters

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"slices"
 )
 
 // Node represents any SQL AST node that can be visited by a Visitor.
@@ -724,6 +725,8 @@ func (n *CommentNode) Accept(visitor Visitor) error {
 type DropTableNode struct {
 	// Name is the name of the table to drop
 	Name string
+	// Names contains all tables to drop. Name is kept as the first table for compatibility.
+	Names []string
 	// IfExists indicates whether to use IF EXISTS clause
 	IfExists bool
 	// Cascade indicates whether to use CASCADE option (PostgreSQL)
@@ -743,9 +746,32 @@ type DropTableNode struct {
 func NewDropTable(name string) *DropTableNode {
 	return &DropTableNode{
 		Name:     name,
+		Names:    []string{name},
 		IfExists: false,
 		Cascade:  false,
 	}
+}
+
+// SetNames sets the table names to drop and keeps Name aligned with the first table.
+func (n *DropTableNode) SetNames(names []string) *DropTableNode {
+	n.Names = slices.Clone(names)
+	if len(names) == 0 {
+		n.Name = ""
+		return n
+	}
+	n.Name = names[0]
+	return n
+}
+
+// TableNames returns every table targeted by the DROP TABLE statement.
+func (n *DropTableNode) TableNames() []string {
+	if len(n.Names) > 0 {
+		return slices.Clone(n.Names)
+	}
+	if n.Name == "" {
+		return nil
+	}
+	return []string{n.Name}
 }
 
 // SetIfExists sets the IF EXISTS option for the DROP TABLE statement.

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -487,6 +487,7 @@ func TestDropTableNode_Constructor(t *testing.T) {
 	dropTable := ast.NewDropTable("users")
 
 	c.Assert(dropTable.Name, qt.Equals, "users")
+	c.Assert(dropTable.TableNames(), qt.DeepEquals, []string{"users"})
 	c.Assert(dropTable.IfExists, qt.IsFalse)
 	c.Assert(dropTable.Cascade, qt.IsFalse)
 	c.Assert(dropTable.Comment, qt.Equals, "")
@@ -501,9 +502,19 @@ func TestDropTableNode_FluentAPI(t *testing.T) {
 		SetComment("Dangerous operation")
 
 	c.Assert(dropTable.Name, qt.Equals, "users")
+	c.Assert(dropTable.TableNames(), qt.DeepEquals, []string{"users"})
 	c.Assert(dropTable.IfExists, qt.IsTrue)
 	c.Assert(dropTable.Cascade, qt.IsTrue)
 	c.Assert(dropTable.Comment, qt.Equals, "Dangerous operation")
+}
+
+func TestDropTableNode_SetNames(t *testing.T) {
+	c := qt.New(t)
+
+	dropTable := ast.NewDropTable("users").SetNames([]string{"users", "archived_users"})
+
+	c.Assert(dropTable.Name, qt.Equals, "users")
+	c.Assert(dropTable.TableNames(), qt.DeepEquals, []string{"users", "archived_users"})
 }
 
 func TestDropTableNode_Accept(t *testing.T) {

--- a/core/parser/client_delimiters.go
+++ b/core/parser/client_delimiters.go
@@ -1,0 +1,181 @@
+package parser
+
+import "strings"
+
+func normalizeClientDelimiters(input string) string {
+	delimiter := ";"
+	var output strings.Builder
+	var pending strings.Builder
+
+	for line := range strings.SplitAfterSeq(input, "\n") {
+		if nextDelimiter, ok := parseClientDelimiterDirective(line); ok {
+			output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter))
+			pending.Reset()
+			delimiter = nextDelimiter
+			continue
+		}
+		pending.WriteString(line)
+	}
+
+	output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter))
+	return output.String()
+}
+
+func parseClientDelimiterDirective(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < len("DELIMITER") || !strings.EqualFold(trimmed[:len("DELIMITER")], "DELIMITER") {
+		return "", false
+	}
+	if len(trimmed) > len("DELIMITER") && !isClientDelimiterBoundary(trimmed[len("DELIMITER")]) {
+		return "", false
+	}
+
+	delimiter := strings.TrimSpace(trimmed[len("DELIMITER"):])
+	if delimiter == "" {
+		return "", false
+	}
+	delimiter = stripClientDelimiterQuotes(delimiter)
+	delimiter = strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t").Replace(delimiter)
+	return delimiter, true
+}
+
+func isClientDelimiterBoundary(ch byte) bool {
+	switch ch {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+func stripClientDelimiterQuotes(delimiter string) string {
+	if len(delimiter) < 2 {
+		return delimiter
+	}
+	if delimiter[0] == delimiter[len(delimiter)-1] && (delimiter[0] == '\'' || delimiter[0] == '"') {
+		return delimiter[1 : len(delimiter)-1]
+	}
+	return delimiter
+}
+
+func rewriteClientDelimitedStatements(input, delimiter string) string {
+	if delimiter == "" || delimiter == ";" {
+		return input
+	}
+
+	replacement := ";"
+	if strings.ContainsAny(delimiter, "\r\n") {
+		replacement = ";\n"
+	}
+
+	var output strings.Builder
+	for pos := 0; pos < len(input); {
+		switch {
+		case strings.HasPrefix(input[pos:], "--"):
+			pos = writeUntilLineEnd(&output, input, pos)
+		case strings.HasPrefix(input[pos:], "/*"):
+			pos = writeUntilBlockCommentEnd(&output, input, pos)
+		case input[pos] == '#' && !isClientHashOperatorContinuation(input, pos):
+			pos = writeUntilLineEnd(&output, input, pos)
+		case input[pos] == '\'' || input[pos] == '"' || input[pos] == '`':
+			pos = writeQuotedSQL(&output, input, pos, input[pos])
+		case input[pos] == '$':
+			if nextPos, ok := writeDollarQuotedSQL(&output, input, pos); ok {
+				pos = nextPos
+				continue
+			}
+			output.WriteByte(input[pos])
+			pos++
+		case strings.HasPrefix(input[pos:], delimiter):
+			output.WriteString(replacement)
+			pos += len(delimiter)
+		default:
+			output.WriteByte(input[pos])
+			pos++
+		}
+	}
+	return output.String()
+}
+
+func isClientHashOperatorContinuation(input string, pos int) bool {
+	if pos+1 >= len(input) {
+		return false
+	}
+	switch input[pos+1] {
+	case '!', '#', '%', '&', '*', '+', '-', '/', '<', '=', '>', '?', '@', '^', '|', '~':
+		return true
+	default:
+		return false
+	}
+}
+
+func writeUntilLineEnd(output *strings.Builder, input string, pos int) int {
+	for pos < len(input) {
+		output.WriteByte(input[pos])
+		pos++
+		if input[pos-1] == '\n' {
+			return pos
+		}
+	}
+	return pos
+}
+
+func writeUntilBlockCommentEnd(output *strings.Builder, input string, pos int) int {
+	for pos < len(input) {
+		if pos+1 < len(input) && input[pos] == '*' && input[pos+1] == '/' {
+			output.WriteString("*/")
+			return pos + 2
+		}
+		output.WriteByte(input[pos])
+		pos++
+	}
+	return pos
+}
+
+func writeQuotedSQL(output *strings.Builder, input string, pos int, quote byte) int {
+	output.WriteByte(input[pos])
+	pos++
+	for pos < len(input) {
+		output.WriteByte(input[pos])
+		if input[pos] == '\\' && pos+1 < len(input) {
+			pos++
+			output.WriteByte(input[pos])
+			pos++
+			continue
+		}
+		if input[pos] == quote {
+			if pos+1 < len(input) && input[pos+1] == quote {
+				pos++
+				output.WriteByte(input[pos])
+				pos++
+				continue
+			}
+			return pos + 1
+		}
+		pos++
+	}
+	return pos
+}
+
+func writeDollarQuotedSQL(output *strings.Builder, input string, pos int) (int, bool) {
+	tagEnd := pos + 1
+	for tagEnd < len(input) && input[tagEnd] != '$' {
+		ch := input[tagEnd]
+		if ch != '_' && (ch < '0' || ch > '9') && (ch < 'A' || ch > 'Z') && (ch < 'a' || ch > 'z') {
+			return pos, false
+		}
+		tagEnd++
+	}
+	if tagEnd >= len(input) {
+		return pos, false
+	}
+
+	tag := input[pos : tagEnd+1]
+	closeStart := strings.Index(input[tagEnd+1:], tag)
+	if closeStart < 0 {
+		return pos, false
+	}
+	nextPos := tagEnd + 1 + closeStart + len(tag)
+	output.WriteString(input[pos:nextPos])
+	return nextPos, true
+}

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -32,7 +32,7 @@ type Parser struct {
 //
 //	parser := NewParser("CREATE TABLE users (id INTEGER PRIMARY KEY);")
 func NewParser(input string) *Parser {
-	l := lexer.NewLexer(input)
+	l := lexer.NewLexer(normalizeClientDelimiters(input))
 	p := &Parser{
 		lexer:     l,
 		startTime: time.Now(),
@@ -110,7 +110,7 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		// SQL Server tooling uses GO as a batch separator, not as schema DDL.
 		p.skipGoBatchSeparator()
 		return nil, nil
-	case "ANALYZE", "BEGIN", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "UPDATE", "USE", "VACUUM", "WITH":
+	case "ANALYZE", "BEGIN", "CALL", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "SHOW", "UPDATE", "USE", "VACUUM", "WITH":
 		p.skipSchemaNeutralStatement()
 		return nil, nil
 	default:
@@ -621,7 +621,7 @@ func (p *Parser) collectAtomicFunctionBody() (string, error) {
 
 	p.skipWhitespace()
 	if err := p.expect(lexer.TokenIdentifier, "ATOMIC"); err != nil {
-		return "", fmt.Errorf("expected ATOMIC after BEGIN in SQL function body: %w", err)
+		return "", fmt.Errorf("unsupported CREATE FUNCTION body: BEGIN without ATOMIC at position %d", p.current.Start)
 	}
 	body.WriteString(" ATOMIC")
 
@@ -1537,7 +1537,7 @@ func (p *Parser) parseOptionalColumnType() (string, error) {
 	switch {
 	case p.current.Type == lexer.TokenIdentifier && isColumnConstraintStart(p.current.Value):
 		return "", nil
-	case p.current.MatchOperatorValue(",") || p.current.MatchOperatorValue(")"):
+	case p.current.Type == lexer.TokenSemicolon || p.current.MatchOperatorValue(",") || p.current.MatchOperatorValue(")"):
 		return "", nil
 	default:
 		return p.parseColumnType()
@@ -2767,12 +2767,12 @@ func (p *Parser) parseDropTable() (*ast.DropTableNode, error) {
 		ifExists = true
 	}
 
-	tableName, err := p.parseQualifiedIdentifier("table name")
+	tableNames, err := p.parseDropTableNames()
 	if err != nil {
 		return nil, err
 	}
 
-	dropTable := ast.NewDropTable(tableName)
+	dropTable := ast.NewDropTable(tableNames[0]).SetNames(tableNames)
 	if ifExists {
 		dropTable.SetIfExists()
 	}
@@ -2787,6 +2787,24 @@ func (p *Parser) parseDropTable() (*ast.DropTableNode, error) {
 		p.advance()
 	}
 	return dropTable, nil
+}
+
+func (p *Parser) parseDropTableNames() ([]string, error) {
+	var names []string
+	for {
+		tableName, err := p.parseQualifiedIdentifier("table name")
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, tableName)
+
+		p.skipWhitespace()
+		if !p.current.MatchOperatorValue(",") {
+			return names, nil
+		}
+		p.advance()
+		p.skipWhitespace()
+	}
 }
 
 // parseAlterOperation parses individual ALTER TABLE operations.

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -154,6 +154,60 @@ CREATE TABLE t2(id int);`
 	c.Assert(statements.Statements[1].(*ast.CreateTableNode).Name, qt.Equals, "t2")
 }
 
+func TestParser_ParseMySQLClientDelimiters(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `delimiter //
+CREATE TABLE t2 (a int) //
+delimiter 'DONE'
+CREATE TABLE t3 (a int) DONE
+delimiter //
+CREATE TABLE t4 (a text DEFAULT 'a//b')//
+delimiter \n\n
+CREATE TABLE t5 (a int)
+
+delimiter ;
+SHOW TABLES;
+DROP TABLE t2, t3;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 5)
+	c.Assert(statements.Statements[0].(*ast.CreateTableNode).Name, qt.Equals, "t2")
+	c.Assert(statements.Statements[1].(*ast.CreateTableNode).Name, qt.Equals, "t3")
+	createWithDefault := statements.Statements[2].(*ast.CreateTableNode)
+	c.Assert(createWithDefault.Name, qt.Equals, "t4")
+	c.Assert(createWithDefault.Columns[0].Default.Value, qt.Equals, "'a//b'")
+	c.Assert(statements.Statements[3].(*ast.CreateTableNode).Name, qt.Equals, "t5")
+	c.Assert(statements.Statements[4].(*ast.DropTableNode).Name, qt.Equals, "t2")
+	c.Assert(statements.Statements[4].(*ast.DropTableNode).TableNames(), qt.DeepEquals, []string{"t2", "t3"})
+}
+
+func TestParser_ParseMySQLClientDelimiterVariants(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `delimiter delimiter
+SELECT * FROM t1delimiter
+delimiter @@
+ALTER TABLE t ADD COLUMN c@@
+delimiter ;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Name, qt.Equals, "t")
+
+	addOp, ok := alterTable.Operations[0].(*ast.AddColumnOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(addOp.Column.Name, qt.Equals, "c")
+	c.Assert(addOp.Column.Type, qt.Equals, "")
+}
+
 func TestParser_ParseDoesNotTreatGotoAsGoBatchSeparator(t *testing.T) {
 	c := qt.New(t)
 
@@ -670,6 +724,23 @@ func TestParser_ParseAlterTableQualifiedName(t *testing.T) {
 	c.Assert(addOp.Column.Type, qt.Equals, "TEXT")
 }
 
+func TestParser_ParseAlterTableAddTypelessColumn(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := parser.NewParser("ALTER TABLE t ADD COLUMN c;").Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	alterTable, ok := statements.Statements[0].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(alterTable.Operations, qt.HasLen, 1)
+
+	addOp, ok := alterTable.Operations[0].(*ast.AddColumnOperation)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(addOp.Column.Name, qt.Equals, "c")
+	c.Assert(addOp.Column.Type, qt.Equals, "")
+}
+
 func TestParser_ParseAlterTableRenameTable(t *testing.T) {
 	c := qt.New(t)
 
@@ -736,6 +807,7 @@ func TestParser_ParseDropTable(t *testing.T) {
 		name     string
 		sql      string
 		table    string
+		tables   []string
 		ifExists bool
 		cascade  bool
 		rendered string
@@ -745,6 +817,13 @@ func TestParser_ParseDropTable(t *testing.T) {
 			sql:      "DROP TABLE users;",
 			table:    "users",
 			rendered: "DROP TABLE users;\n",
+		},
+		{
+			name:     "multiple tables",
+			sql:      "DROP TABLE users, archived_users;",
+			table:    "users",
+			tables:   []string{"users", "archived_users"},
+			rendered: "DROP TABLE users, archived_users;\n",
 		},
 		{
 			name:     "if exists",
@@ -779,6 +858,9 @@ func TestParser_ParseDropTable(t *testing.T) {
 			dropTable, ok := statements.Statements[0].(*ast.DropTableNode)
 			c.Assert(ok, qt.IsTrue)
 			c.Assert(dropTable.Name, qt.Equals, tt.table)
+			if tt.tables != nil {
+				c.Assert(dropTable.TableNames(), qt.DeepEquals, tt.tables)
+			}
 			c.Assert(dropTable.IfExists, qt.Equals, tt.ifExists)
 			c.Assert(dropTable.Cascade, qt.Equals, tt.cascade)
 

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -776,9 +776,9 @@ func (r *Renderer) VisitDropTable(node *ast.DropTableNode) error {
 		r.w.WriteLinef("-- %s", node.Comment)
 	}
 	if node.IfExists {
-		r.w.WriteLinef("DROP TABLE IF EXISTS %s;", node.Name)
+		r.w.WriteLinef("DROP TABLE IF EXISTS %s;", strings.Join(node.TableNames(), ", "))
 	} else {
-		r.w.WriteLinef("DROP TABLE %s;", node.Name)
+		r.w.WriteLinef("DROP TABLE %s;", strings.Join(node.TableNames(), ", "))
 	}
 	return nil
 }

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -366,7 +366,7 @@ func (r *Renderer) VisitDropTable(node *ast.DropTableNode) error {
 		parts = append(parts, "IF EXISTS")
 	}
 
-	parts = append(parts, node.Name)
+	parts = append(parts, strings.Join(node.TableNames(), ", "))
 
 	// MariaDB doesn't support CASCADE for DROP TABLE like PostgreSQL
 	// Ignore the Cascade flag for MariaDB

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -532,7 +532,7 @@ func (r *Renderer) VisitDropTable(node *ast.DropTableNode) error {
 		parts = append(parts, "IF EXISTS")
 	}
 
-	parts = append(parts, node.Name)
+	parts = append(parts, strings.Join(node.TableNames(), ", "))
 
 	if node.Cascade {
 		parts = append(parts, "CASCADE")


### PR DESCRIPTION
## What Changed

Adds parser preprocessing for MySQL client `DELIMITER` directives so Atlas-style migration lexer fixtures can be ingested before normal SQL parsing.

This also adds the parser/AST support needed by those fixtures:

- `DROP TABLE t1, t2` keeps all table names in `DropTableNode.Names` while preserving `Name` as the first table for compatibility.
- `ALTER TABLE ... ADD COLUMN c;` can represent an existing typeless-column AST case when the column definition ends at `;`.
- Non-atomic `CREATE FUNCTION ... BEGIN ...` bodies now remain an explicit unsupported gap instead of surfacing as a generic parse failure.
- `CALL` and `SHOW` are treated as schema-neutral statements like `SELECT`.

## Why

Atlas has MySQL lexer fixtures that use client-side delimiter commands around ordinary DDL. Ptah previously failed these at the first `DELIMITER` token, so the conformance report could not distinguish real routine support gaps from client delimiter preprocessing gaps.

The implementation rewrites delimiters only outside SQL quotes, comments, and dollar-quoted bodies, so delimiter-like text inside literals is preserved.

## Validation

- `env GOCACHE=/private/tmp/ptah-gocache go test ./...`
- `env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run --fix ./...`
- `env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- Local ptah-atlas-conformance probe with a replace to this branch: `737 -> 735` unwaived non-OK observations, outcomes `383 ok`, `728 gap`, `7 fail`, `0 panic`.

Full conformance remains red as expected; this PR only closes the client delimiter slice.
