### PR TITLE
Preserve MySQL routines opaquely

### DIFF
--- a/core/parser/client_delimiters.go
+++ b/core/parser/client_delimiters.go
@@ -79,6 +79,9 @@ func rewriteClientDelimitedStatements(input, delimiter string) string {
 			pos = writeUntilLineEnd(&output, input, pos)
 		case input[pos] == '\'' || input[pos] == '"' || input[pos] == '`':
 			pos = writeQuotedSQL(&output, input, pos, input[pos])
+		case strings.HasPrefix(input[pos:], delimiter):
+			output.WriteString(replacement)
+			pos += len(delimiter)
 		case input[pos] == '$':
 			if nextPos, ok := writeDollarQuotedSQL(&output, input, pos); ok {
 				pos = nextPos
@@ -86,9 +89,6 @@ func rewriteClientDelimitedStatements(input, delimiter string) string {
 			}
 			output.WriteByte(input[pos])
 			pos++
-		case strings.HasPrefix(input[pos:], delimiter):
-			output.WriteString(replacement)
-			pos += len(delimiter)
 		default:
 			output.WriteByte(input[pos])
 			pos++

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -18,6 +18,7 @@ import (
 // and other DDL operations.
 type Parser struct {
 	lexer     *lexer.Lexer
+	input     string
 	current   lexer.Token
 	previous  lexer.Token
 	startTime time.Time
@@ -32,9 +33,11 @@ type Parser struct {
 //
 //	parser := NewParser("CREATE TABLE users (id INTEGER PRIMARY KEY);")
 func NewParser(input string) *Parser {
-	l := lexer.NewLexer(normalizeClientDelimiters(input))
+	normalized := normalizeClientDelimiters(input)
+	l := lexer.NewLexer(normalized)
 	p := &Parser{
 		lexer:     l,
+		input:     normalized,
 		startTime: time.Now(),
 		timeout:   30 * time.Second, // 30 second timeout to prevent infinite loops
 	}
@@ -120,6 +123,7 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 
 // parseCreateStatement parses CREATE statements (TABLE, INDEX, TYPE).
 func (p *Parser) parseCreateStatement() (ast.Node, error) {
+	statementStart := p.current.Start
 	if err := p.expect(lexer.TokenIdentifier, "CREATE"); err != nil {
 		return nil, err
 	}
@@ -142,8 +146,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateTable()
 	case "VIEW":
 		return p.parseCreateView()
-	case "FUNCTION":
-		return p.parseCreateFunction()
+	case "FUNCTION", "PROCEDURE":
+		return p.parseCreateRoutine(target, statementStart)
 	case "TRIGGER":
 		return p.parseCreateTrigger()
 	case "INDEX":
@@ -156,14 +160,9 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		}
 		return p.parseCreateIndexAfterKeyword(target)
 	case "OR":
-		return p.parseCreateOrReplaceStatement()
+		return p.parseCreateOrReplaceStatement(statementStart)
 	case "TEMP", "TEMPORARY":
-		p.advance()
-		p.skipWhitespace()
-		if p.current.MatchIdentifierValue("TRIGGER") {
-			return p.parseCreateTrigger()
-		}
-		return nil, fmt.Errorf("unsupported CREATE %s target: %s at position %d", target, p.current.Value, p.current.Start)
+		return p.parseCreateTemporary(target)
 	case "UNIQUE":
 		// Handle CREATE UNIQUE INDEX
 		p.advance()
@@ -179,6 +178,22 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	default:
 		return nil, fmt.Errorf("unsupported CREATE target: %s at position %d", target, p.current.Start)
 	}
+}
+
+func (p *Parser) parseCreateRoutine(target string, statementStart int) (ast.Node, error) {
+	if target == "PROCEDURE" {
+		return p.parseCreateRawRoutine("CREATE ")
+	}
+	return p.parseCreateFunction(statementStart)
+}
+
+func (p *Parser) parseCreateTemporary(target string) (ast.Node, error) {
+	p.advance()
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("TRIGGER") {
+		return p.parseCreateTrigger()
+	}
+	return nil, fmt.Errorf("unsupported CREATE %s target: %s at position %d", target, p.current.Value, p.current.Start)
 }
 
 func (p *Parser) parseCreateSchema() (*ast.CreateSchemaNode, error) {
@@ -280,7 +295,7 @@ func (p *Parser) parseOptionalIfNotExists() (bool, error) {
 	return true, nil
 }
 
-func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
+func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, error) {
 	if err := p.expect(lexer.TokenIdentifier, "OR"); err != nil {
 		return nil, err
 	}
@@ -293,7 +308,10 @@ func (p *Parser) parseCreateOrReplaceStatement() (ast.Node, error) {
 		return p.parseCreateOrReplaceView()
 	}
 	if p.current.MatchIdentifierValue("FUNCTION") {
-		return p.parseCreateOrReplaceFunction()
+		return p.parseCreateFunction(statementStart)
+	}
+	if p.current.MatchIdentifierValue("PROCEDURE") {
+		return p.parseCreateRawRoutine("CREATE OR REPLACE ")
 	}
 	if p.current.MatchIdentifierValue("TRIGGER") {
 		trigger, err := p.parseCreateTrigger()
@@ -430,15 +448,7 @@ func (p *Parser) parseCreateOrReplaceView() (*ast.CreateViewNode, error) {
 	return view, nil
 }
 
-func (p *Parser) parseCreateFunction() (*ast.CreateFunctionNode, error) {
-	return p.parseCreateFunctionNode()
-}
-
-func (p *Parser) parseCreateOrReplaceFunction() (*ast.CreateFunctionNode, error) {
-	return p.parseCreateFunctionNode()
-}
-
-func (p *Parser) parseCreateFunctionNode() (*ast.CreateFunctionNode, error) {
+func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	if err := p.expect(lexer.TokenIdentifier, "FUNCTION"); err != nil {
 		return nil, err
 	}
@@ -456,10 +466,56 @@ func (p *Parser) parseCreateFunctionNode() (*ast.CreateFunctionNode, error) {
 	}
 
 	function := ast.NewCreateFunction(functionName).SetParameters(parameters)
-	if err := p.parseFunctionClauses(function); err != nil {
+	raw, err := p.parseFunctionClauses(function)
+	if err != nil {
 		return nil, err
 	}
+	if raw {
+		return ast.NewRawSQL(p.rawStatement(statementStart)), nil
+	}
 	return function, nil
+}
+
+func (p *Parser) parseCreateRawRoutine(prefix string) (ast.Node, error) {
+	sql, err := p.collectRawRoutine(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return ast.NewRawSQL(sql), nil
+}
+
+func (p *Parser) collectRawRoutine(prefix string) (string, error) {
+	var sql strings.Builder
+	sql.WriteString(prefix)
+
+	blockDepth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+
+		if p.current.Type == lexer.TokenSemicolon && blockDepth == 0 {
+			p.advance()
+			return strings.TrimSpace(sql.String()), nil
+		}
+
+		if p.current.Type == lexer.TokenIdentifier {
+			trackRoutineCompoundKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth, &pendingEndTrailer)
+		}
+		if p.current.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+		}
+
+		sql.WriteString(p.current.Value)
+		p.advance()
+	}
+
+	if blockDepth > 0 {
+		return "", fmt.Errorf("unterminated CREATE routine body at position %d", p.current.Start)
+	}
+	return strings.TrimSpace(sql.String()), nil
 }
 
 func (p *Parser) collectParenthesizedBody(label string) (string, error) {
@@ -494,53 +550,93 @@ func (p *Parser) collectParenthesizedBody(label string) (string, error) {
 	return "", fmt.Errorf("unterminated %s at position %d", label, p.current.Start)
 }
 
-func (p *Parser) parseFunctionClauses(function *ast.CreateFunctionNode) error {
+func (p *Parser) parseFunctionClauses(function *ast.CreateFunctionNode) (bool, error) {
 	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
 		if err := p.checkTimeout(); err != nil {
-			return err
+			return false, err
 		}
 
 		p.skipWhitespace()
 		if p.isAtEnd() || p.current.Type == lexer.TokenSemicolon {
-			return nil
+			return false, nil
 		}
 		if p.current.Type != lexer.TokenIdentifier {
-			return fmt.Errorf("unsupported CREATE FUNCTION syntax: expected function clause, got %s at position %d", p.current.Type, p.current.Start)
+			return false, fmt.Errorf("unsupported CREATE FUNCTION syntax: expected function clause, got %s at position %d", p.current.Type, p.current.Start)
 		}
 
-		switch strings.ToUpper(p.current.Value) {
-		case "RETURNS":
-			if err := p.parseFunctionReturns(function); err != nil {
-				return err
-			}
-		case "RETURN":
-			if err := p.parseFunctionReturnBody(function); err != nil {
-				return err
-			}
-		case "BEGIN":
-			if err := p.parseFunctionAtomicBody(function); err != nil {
-				return err
-			}
-		case "AS":
-			if err := p.parseFunctionBody(function); err != nil {
-				return err
-			}
-		case "LANGUAGE":
-			if err := p.parseFunctionLanguage(function); err != nil {
-				return err
-			}
-		case "SECURITY":
-			if err := p.parseFunctionSecurity(function); err != nil {
-				return err
-			}
-		case "IMMUTABLE", "STABLE", "VOLATILE":
-			function.SetVolatility(strings.ToUpper(p.current.Value))
-			p.advance()
-		default:
-			return fmt.Errorf("unsupported CREATE FUNCTION clause: %s at position %d", p.current.Value, p.current.Start)
+		raw, err := p.parseFunctionClause(function)
+		if err != nil {
+			return false, err
+		}
+		if raw {
+			return true, nil
 		}
 	}
-	return nil
+	return false, nil
+}
+
+func (p *Parser) parseFunctionClause(function *ast.CreateFunctionNode) (bool, error) {
+	keyword := strings.ToUpper(p.current.Value)
+	switch keyword {
+	case "RETURNS":
+		return false, p.parseFunctionReturns(function)
+	case "RETURN":
+		return false, p.parseFunctionReturnBody(function)
+	case "BEGIN":
+		return p.parseFunctionBeginBody(function)
+	case "AS":
+		return false, p.parseFunctionBody(function)
+	case "LANGUAGE":
+		return false, p.parseFunctionLanguage(function)
+	case "SECURITY":
+		return false, p.parseFunctionSecurity(function)
+	case "IMMUTABLE", "STABLE", "VOLATILE":
+		function.SetVolatility(keyword)
+		p.advance()
+		return false, nil
+	default:
+		if p.skipMySQLFunctionAttribute(keyword) {
+			return false, nil
+		}
+		return false, fmt.Errorf("unsupported CREATE FUNCTION clause: %s at position %d", p.current.Value, p.current.Start)
+	}
+}
+
+func (p *Parser) skipMySQLFunctionAttribute(keyword string) bool {
+	switch keyword {
+	case "DETERMINISTIC":
+		p.advance()
+		return true
+	case "NOT":
+		return p.skipOptionalFollowingKeyword("DETERMINISTIC")
+	case "NO", "CONTAINS":
+		return p.skipOptionalFollowingKeyword("SQL")
+	case "READS", "MODIFIES":
+		p.advance()
+		p.skipWhitespace()
+		if p.current.MatchIdentifierValue("SQL") {
+			p.advance()
+			p.skipWhitespace()
+		}
+		if p.current.MatchIdentifierValue("DATA") {
+			p.advance()
+		}
+		return true
+	case "SQL":
+		p.advance()
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) skipOptionalFollowingKeyword(keyword string) bool {
+	p.advance()
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue(keyword) {
+		p.advance()
+	}
+	return true
 }
 
 func (p *Parser) parseFunctionReturns(function *ast.CreateFunctionNode) error {
@@ -553,7 +649,7 @@ func (p *Parser) parseFunctionReturns(function *ast.CreateFunctionNode) error {
 	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
 		if p.current.Type == lexer.TokenIdentifier {
 			switch strings.ToUpper(p.current.Value) {
-			case "AS", "BEGIN", "LANGUAGE", "RETURN", "SECURITY", "IMMUTABLE", "STABLE", "VOLATILE":
+			case "AS", "BEGIN", "CONTAINS", "DETERMINISTIC", "LANGUAGE", "MODIFIES", "NO", "NOT", "READS", "RETURN", "SECURITY", "SQL", "IMMUTABLE", "STABLE", "VOLATILE":
 				function.SetReturns(strings.TrimSpace(returns.String()))
 				return nil
 			}
@@ -602,65 +698,106 @@ func (p *Parser) parseFunctionReturnBody(function *ast.CreateFunctionNode) error
 	return nil
 }
 
-func (p *Parser) parseFunctionAtomicBody(function *ast.CreateFunctionNode) error {
-	body, err := p.collectAtomicFunctionBody()
+func (p *Parser) parseFunctionBeginBody(function *ast.CreateFunctionNode) (bool, error) {
+	body, atomic, err := p.collectFunctionBeginBody()
 	if err != nil {
-		return err
+		return false, err
 	}
-	function.SetAtomicBody(body)
-	return nil
+	if atomic {
+		function.SetAtomicBody(body)
+		return false, nil
+	}
+	return true, nil
 }
 
-func (p *Parser) collectAtomicFunctionBody() (string, error) {
+func (p *Parser) collectFunctionBeginBody() (string, bool, error) {
 	if err := p.expect(lexer.TokenIdentifier, "BEGIN"); err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	var body strings.Builder
 	body.WriteString("BEGIN")
 
 	p.skipWhitespace()
-	if err := p.expect(lexer.TokenIdentifier, "ATOMIC"); err != nil {
-		return "", fmt.Errorf("unsupported CREATE FUNCTION body: BEGIN without ATOMIC at position %d", p.current.Start)
+	atomic := false
+	if p.current.MatchIdentifierValue("ATOMIC") {
+		atomic = true
+		body.WriteString(" ATOMIC")
+		p.advance()
 	}
-	body.WriteString(" ATOMIC")
 
 	blockDepth := 1
 	caseDepth := 0
+	pendingEndTrailer := false
 	for !p.isAtEnd() {
 		if err := p.checkTimeout(); err != nil {
-			return "", err
+			return "", false, err
 		}
 
 		if p.current.Type == lexer.TokenIdentifier {
 			keyword := strings.ToUpper(p.current.Value)
-			switch keyword {
-			case "BEGIN":
-				blockDepth++
-			case "CASE":
-				caseDepth++
-			case "END":
-				if caseDepth > 0 {
-					caseDepth--
-				} else {
-					blockDepth--
-				}
-			}
+			trackRoutineCompoundKeyword(keyword, &blockDepth, &caseDepth, &pendingEndTrailer)
 
 			body.WriteString(p.current.Value)
 			p.advance()
 
 			if blockDepth == 0 {
-				return strings.TrimSpace(body.String()), nil
+				return strings.TrimSpace(body.String()), atomic, nil
 			}
 			continue
 		}
 
+		if p.current.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+		}
 		body.WriteString(p.current.Value)
 		p.advance()
 	}
 
-	return "", fmt.Errorf("unterminated SQL function body at position %d", p.current.Start)
+	return "", false, fmt.Errorf("unterminated SQL function body at position %d", p.current.Start)
+}
+
+func trackRoutineCompoundKeyword(keyword string, blockDepth, caseDepth *int, pendingEndTrailer *bool) {
+	if *pendingEndTrailer {
+		*pendingEndTrailer = false
+		if isRoutineEndTrailerKeyword(keyword) {
+			return
+		}
+	}
+
+	switch keyword {
+	case "BEGIN", "IF", "LOOP", "REPEAT", "WHILE":
+		(*blockDepth)++
+	case "CASE":
+		(*caseDepth)++
+	case "END":
+		if *caseDepth > 0 {
+			(*caseDepth)--
+		} else if *blockDepth > 0 {
+			(*blockDepth)--
+		}
+		*pendingEndTrailer = true
+	}
+}
+
+func isRoutineEndTrailerKeyword(keyword string) bool {
+	switch keyword {
+	case "CASE", "IF", "LOOP", "REPEAT", "WHILE":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) rawStatement(start int) string {
+	end := p.previous.End
+	if p.current.Type == lexer.TokenSemicolon {
+		end = p.current.End
+	}
+	if start < 0 || start > end || end > len(p.input) {
+		return ""
+	}
+	return strings.TrimSpace(p.input[start:end])
 }
 
 func (p *Parser) parseFunctionLanguage(function *ast.CreateFunctionNode) error {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -538,6 +538,134 @@ END;`
 	c.Assert(createFunction.Body, qt.Contains, "END")
 }
 
+func TestParser_ParseMySQLCreateFunctionWithReturnBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE FUNCTION `add2` (a int, b int) RETURNS int DETERMINISTIC NO SQL RETURN a + b;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Name, qt.Equals, "`add2`")
+	c.Assert(createFunction.Parameters, qt.Equals, "a int, b int")
+	c.Assert(createFunction.Returns, qt.Equals, "int")
+	c.Assert(createFunction.BodyKind, qt.Equals, ast.FunctionBodyReturn)
+	c.Assert(createFunction.Body, qt.Equals, "a + b")
+}
+
+func TestParser_ParseMySQLCreateFunctionWithCompoundBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DELIMITER |
+CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC
+BEGIN
+       INSERT INTO t1 VALUES (x);
+       RETURN x+2;
+END|
+DELIMITER ;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC")
+	c.Assert(raw.SQL, qt.Contains, "INSERT INTO t1 VALUES (x);")
+	c.Assert(raw.SQL, qt.Contains, "RETURN x+2;")
+}
+
+func TestParser_ParseMySQLCreateFunctionWithNestedCompoundBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION CompFunc(eID INT) RETURNS INT
+BEGIN
+    DECLARE ts INT;
+    DECLARE b INT;
+
+    BEGIN
+        SELECT SUM(s) INTO ts FROM sales WHERE e = eID;
+    END;
+
+    BEGIN
+        IF ts > 10000 THEN
+            SET b = 500;
+        ELSEIF ts BETWEEN 5000 AND 10000 THEN
+            SET b = 300;
+        ELSE
+            SET b = 0;
+        END IF;
+    END;
+
+    RETURN b;
+END;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION CompFunc(eID INT) RETURNS INT")
+	c.Assert(raw.SQL, qt.Contains, "END IF;")
+	c.Assert(raw.SQL, qt.Contains, "RETURN b;")
+}
+
+func TestParser_ParseMySQLCreateFunctionWithDollarDelimiter(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DELIMITER $$
+CREATE OR REPLACE FUNCTION gen_uuid() RETURNS VARCHAR(22)
+BEGIN
+    RETURN concat(
+        date_format(NOW(6), '%Y%m%d%i%s%f'),
+        ROUND(1 + RAND() * (100 - 2))
+    );
+END;$$
+DELIMITER ;
+CALL gen_uuid();`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE OR REPLACE FUNCTION gen_uuid() RETURNS VARCHAR(22)")
+	c.Assert(raw.SQL, qt.Contains, "date_format(NOW(6), '%Y%m%d%i%s%f')")
+}
+
+func TestParser_ParseCreateProcedureAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DELIMITER //
+CREATE PROCEDURE dorepeat(p1 INT)
+BEGIN
+    SET @x = 0;
+    REPEAT SET @x = @x + 1; UNTIL @x > p1 END REPEAT;
+END
+//
+DELIMITER ;
+CALL dorepeat(100);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE PROCEDURE dorepeat(p1 INT)")
+	c.Assert(raw.SQL, qt.Contains, "REPEAT SET @x = @x + 1; UNTIL @x > p1 END REPEAT;")
+}
+
 func TestParser_ParseCreateTrigger(t *testing.T) {
 	c := qt.New(t)
 
@@ -609,11 +737,16 @@ func TestParser_ParseCreateOrReplaceTrigger(t *testing.T) {
 	c.Assert(createTrigger.Table, qt.Equals, "users")
 }
 
-func TestParser_ParseRejectsUnsupportedCreateOrReplaceTarget(t *testing.T) {
+func TestParser_ParseCreateOrReplaceProcedureAsRawSQL(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := parser.NewParser("CREATE OR REPLACE PROCEDURE p() AS $$ SELECT 1 $$;").Parse()
-	c.Assert(err, qt.ErrorMatches, `unsupported CREATE OR REPLACE target: PROCEDURE at position 18`)
+	statements, err := parser.NewParser("CREATE OR REPLACE PROCEDURE p() AS BEGIN SELECT 1; END;").Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE OR REPLACE PROCEDURE p()")
 }
 
 func TestParser_ParseSkipsSchemaNeutralStatements(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve MySQL/MariaDB-style `CREATE PROCEDURE` statements as opaque raw SQL instead of rejecting them
- preserve compound `CREATE FUNCTION ... BEGIN ... END` bodies opaquely, while keeping existing SQL-standard/PostgreSQL function parsing intact
- fix `DELIMITER $$` handling so MySQL client delimiters win over PostgreSQL dollar-quote detection when they are the active delimiter

## Rationale

Routine bodies are a dialect-specific sub-language. The generic parser should not pretend to understand MySQL compound routine control flow until Ptah has a dialect-aware routine parser. This PR only finds the routine boundary and preserves the statement.

Follow-up design issue: #318.

## Validation

- `env GOCACHE=/private/tmp/ptah-gocache go test ./core/parser -run 'TestParser_Parse(MySQLCreateFunctionWith(ReturnBody|CompoundBody|NestedCompoundBody|DollarDelimiter)|CreateProcedureAsRawSQL|CreateOrReplaceProcedureAsRawSQL)|TestParser_ParseSQLStandardCreateFunction|TestParser_ParseCreateFunction'`
- `env GOCACHE=/private/tmp/ptah-gocache go test ./...`
- `env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run --fix ./...`
- `env GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- local ptah-atlas-conformance probe with local Ptah replace: 728 unwaived non-OK observations, 390 ok, 721 gap, 7 fail, 0 panic
- local conformance budget: green at 728/735
- local full conformance gate: red as expected until all gaps close

