### PR TITLE
Support Atlas comment delimiters

### DIFF
--- a/core/parser/client_delimiters.go
+++ b/core/parser/client_delimiters.go
@@ -4,21 +4,33 @@ import "strings"
 
 func normalizeClientDelimiters(input string) string {
 	delimiter := ";"
+	allowCommentDelimiter := false
 	var output strings.Builder
 	var pending strings.Builder
 
 	for line := range strings.SplitAfterSeq(input, "\n") {
-		if nextDelimiter, ok := parseClientDelimiterDirective(line); ok {
-			output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter))
+		if nextDelimiter, commentDelimiter, ok := parseDelimiterDirective(line); ok {
+			output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter, allowCommentDelimiter))
 			pending.Reset()
 			delimiter = nextDelimiter
+			allowCommentDelimiter = commentDelimiter
 			continue
 		}
 		pending.WriteString(line)
 	}
 
-	output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter))
+	output.WriteString(rewriteClientDelimitedStatements(pending.String(), delimiter, allowCommentDelimiter))
 	return output.String()
+}
+
+func parseDelimiterDirective(line string) (delimiter string, allowCommentDelimiter bool, ok bool) {
+	if delimiter, ok := parseClientDelimiterDirective(line); ok {
+		return delimiter, false, true
+	}
+	if delimiter, ok := parseAtlasDelimiterDirective(line); ok {
+		return delimiter, true, true
+	}
+	return "", false, false
 }
 
 func parseClientDelimiterDirective(line string) (string, bool) {
@@ -31,6 +43,26 @@ func parseClientDelimiterDirective(line string) (string, bool) {
 	}
 
 	delimiter := strings.TrimSpace(trimmed[len("DELIMITER"):])
+	if delimiter == "" {
+		return "", false
+	}
+	delimiter = stripClientDelimiterQuotes(delimiter)
+	delimiter = strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t").Replace(delimiter)
+	return delimiter, true
+}
+
+func parseAtlasDelimiterDirective(line string) (string, bool) {
+	const prefix = "-- atlas:delimiter"
+
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < len(prefix) || !strings.EqualFold(trimmed[:len(prefix)], prefix) {
+		return "", false
+	}
+	if len(trimmed) > len(prefix) && !isClientDelimiterBoundary(trimmed[len(prefix)]) {
+		return "", false
+	}
+
+	delimiter := strings.TrimSpace(trimmed[len(prefix):])
 	if delimiter == "" {
 		return "", false
 	}
@@ -58,7 +90,7 @@ func stripClientDelimiterQuotes(delimiter string) string {
 	return delimiter
 }
 
-func rewriteClientDelimitedStatements(input, delimiter string) string {
+func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelimiter bool) string {
 	if delimiter == "" || delimiter == ";" {
 		return input
 	}
@@ -71,6 +103,9 @@ func rewriteClientDelimitedStatements(input, delimiter string) string {
 	var output strings.Builder
 	for pos := 0; pos < len(input); {
 		switch {
+		case allowCommentDelimiter && strings.HasPrefix(input[pos:], delimiter):
+			output.WriteString(replacement)
+			pos += len(delimiter)
 		case strings.HasPrefix(input[pos:], "--"):
 			pos = writeUntilLineEnd(&output, input, pos)
 		case strings.HasPrefix(input[pos:], "/*"):

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -148,6 +148,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateView()
 	case "FUNCTION", "PROCEDURE":
 		return p.parseCreateRoutine(target, statementStart)
+	case "DEFINER":
+		return p.parseCreateDefinerRoutine(statementStart)
 	case "TRIGGER":
 		return p.parseCreateTrigger()
 	case "INDEX":
@@ -182,9 +184,22 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 
 func (p *Parser) parseCreateRoutine(target string, statementStart int) (ast.Node, error) {
 	if target == "PROCEDURE" {
-		return p.parseCreateRawRoutine("CREATE ")
+		return p.parseCreateRawRoutineStatement(statementStart)
 	}
 	return p.parseCreateFunction(statementStart)
+}
+
+func (p *Parser) parseCreateDefinerRoutine(statementStart int) (ast.Node, error) {
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if err := p.checkTimeout(); err != nil {
+			return nil, err
+		}
+		if p.current.MatchIdentifierValue("FUNCTION") || p.current.MatchIdentifierValue("PROCEDURE") {
+			return p.parseCreateRawRoutineStatement(statementStart)
+		}
+		p.advance()
+	}
+	return nil, fmt.Errorf("unsupported CREATE DEFINER target at position %d", p.current.Start)
 }
 
 func (p *Parser) parseCreateTemporary(target string) (ast.Node, error) {
@@ -311,7 +326,7 @@ func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, er
 		return p.parseCreateFunction(statementStart)
 	}
 	if p.current.MatchIdentifierValue("PROCEDURE") {
-		return p.parseCreateRawRoutine("CREATE OR REPLACE ")
+		return p.parseCreateRawRoutineStatement(statementStart)
 	}
 	if p.current.MatchIdentifierValue("TRIGGER") {
 		trigger, err := p.parseCreateTrigger()
@@ -476,18 +491,15 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	return function, nil
 }
 
-func (p *Parser) parseCreateRawRoutine(prefix string) (ast.Node, error) {
-	sql, err := p.collectRawRoutine(prefix)
+func (p *Parser) parseCreateRawRoutineStatement(statementStart int) (ast.Node, error) {
+	sql, err := p.collectRawRoutineStatement(statementStart)
 	if err != nil {
 		return nil, err
 	}
 	return ast.NewRawSQL(sql), nil
 }
 
-func (p *Parser) collectRawRoutine(prefix string) (string, error) {
-	var sql strings.Builder
-	sql.WriteString(prefix)
-
+func (p *Parser) collectRawRoutineStatement(statementStart int) (string, error) {
 	blockDepth := 0
 	caseDepth := 0
 	pendingEndTrailer := false
@@ -497,25 +509,25 @@ func (p *Parser) collectRawRoutine(prefix string) (string, error) {
 		}
 
 		if p.current.Type == lexer.TokenSemicolon && blockDepth == 0 {
+			sql := p.rawStatementFragment(statementStart, p.current.Start)
 			p.advance()
-			return strings.TrimSpace(sql.String()), nil
+			return sql, nil
 		}
 
 		if p.current.Type == lexer.TokenIdentifier {
-			trackRoutineCompoundKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth, &pendingEndTrailer)
+			p.trackCurrentRoutineCompoundKeyword(&blockDepth, &caseDepth, &pendingEndTrailer)
 		}
 		if p.current.Type == lexer.TokenSemicolon {
 			pendingEndTrailer = false
 		}
 
-		sql.WriteString(p.current.Value)
 		p.advance()
 	}
 
 	if blockDepth > 0 {
 		return "", fmt.Errorf("unterminated CREATE routine body at position %d", p.current.Start)
 	}
-	return strings.TrimSpace(sql.String()), nil
+	return p.rawStatementFragment(statementStart, p.previous.End), nil
 }
 
 func (p *Parser) collectParenthesizedBody(label string) (string, error) {
@@ -735,8 +747,7 @@ func (p *Parser) collectFunctionBeginBody() (string, bool, error) {
 		}
 
 		if p.current.Type == lexer.TokenIdentifier {
-			keyword := strings.ToUpper(p.current.Value)
-			trackRoutineCompoundKeyword(keyword, &blockDepth, &caseDepth, &pendingEndTrailer)
+			p.trackCurrentRoutineCompoundKeyword(&blockDepth, &caseDepth, &pendingEndTrailer)
 
 			body.WriteString(p.current.Value)
 			p.advance()
@@ -755,6 +766,15 @@ func (p *Parser) collectFunctionBeginBody() (string, bool, error) {
 	}
 
 	return "", false, fmt.Errorf("unterminated SQL function body at position %d", p.current.Start)
+}
+
+func (p *Parser) trackCurrentRoutineCompoundKeyword(blockDepth, caseDepth *int, pendingEndTrailer *bool) {
+	keyword := strings.ToUpper(p.current.Value)
+	if keyword == "IF" && p.current.End < len(p.input) && p.input[p.current.End] == '(' {
+		// MySQL scalar IF(...) calls are not compound IF ... END IF blocks.
+		return
+	}
+	trackRoutineCompoundKeyword(keyword, blockDepth, caseDepth, pendingEndTrailer)
 }
 
 func trackRoutineCompoundKeyword(keyword string, blockDepth, caseDepth *int, pendingEndTrailer *bool) {
@@ -794,6 +814,10 @@ func (p *Parser) rawStatement(start int) string {
 	if p.current.Type == lexer.TokenSemicolon {
 		end = p.current.End
 	}
+	return p.rawStatementFragment(start, end)
+}
+
+func (p *Parser) rawStatementFragment(start, end int) string {
 	if start < 0 || start > end || end > len(p.input) {
 		return ""
 	}

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -666,6 +666,42 @@ CALL dorepeat(100);`
 	c.Assert(raw.SQL, qt.Contains, "REPEAT SET @x = @x + 1; UNTIL @x > p1 END REPEAT;")
 }
 
+func TestParser_ParseCreateDefinerProcedureWithAtlasDelimiter(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `-- atlas:delimiter \n-- end --\n
+
+CREATE DEFINER='boring' PROCEDURE proc ()
+    COMMENT 'ATLAS_DELIMITER'
+    SQL SECURITY INVOKER
+    NOT DETERMINISTIC
+    MODIFIES SQL DATA
+BEGIN
+    UPDATE performance_schema.threads
+    SET instrumented = 'YES'
+    WHERE type = 'BACKGROUND';
+
+    SELECT CONCAT('Enabled ', @rows := ROW_COUNT(), ' background thread', IF(@rows != 1, 's', '')) AS summary;
+END
+
+-- end --
+
+CALL proc();`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE DEFINER='boring' PROCEDURE proc ()")
+	c.Assert(raw.SQL, qt.Contains, "SQL SECURITY INVOKER")
+	c.Assert(raw.SQL, qt.Contains, "IF(@rows != 1, 's', '')")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CALL proc")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "-- end --")
+}
+
 func TestParser_ParseCreateTrigger(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

- add parser support for Atlas `-- atlas:delimiter ...` directives, including comment delimiters such as `-- end --`
- preserve `CREATE DEFINER ... FUNCTION/PROCEDURE` as bounded raw routine SQL instead of rejecting the `DEFINER` target
- avoid treating MySQL scalar `IF(...)` calls inside routine bodies as compound `IF ... END IF` blocks

## Validation

- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./core/parser`
- `go test ./...`
- `make budget` in `ptah-atlas-conformance` with a local Ptah replace: green, 727 unwaived non-OK observations against budget 728
- `make gate` in `ptah-atlas-conformance` with a local Ptah replace: red as expected, 727 unwaived non-OK observations remain

## Conformance Impact

- `sql/migrate/testdata/lex/5_delimiter.sql` now parses successfully.
- The Atlas conformance report moves from 728 to 727 unwaived non-OK observations.
