### PR TITLE
Preserve Postgres DO blocks

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -109,6 +109,8 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseCommentStatement()
 	case "DROP":
 		return p.parseDropStatement()
+	case "DO":
+		return p.parseDoStatement()
 	case "GO":
 		// SQL Server tooling uses GO as a batch separator, not as schema DDL.
 		p.skipGoBatchSeparator()
@@ -119,6 +121,31 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 	default:
 		return nil, fmt.Errorf("unsupported SQL statement: %s at position %d", keyword, p.current.Start)
 	}
+}
+
+func (p *Parser) parseDoStatement() (ast.Node, error) {
+	statementStart := p.current.Start
+	p.advance()
+	sql, err := p.collectRawStatement(statementStart, "DO statement")
+	if err != nil {
+		return nil, err
+	}
+	return ast.NewRawSQL(sql), nil
+}
+
+func (p *Parser) collectRawStatement(statementStart int, label string) (string, error) {
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+		if p.current.Type == lexer.TokenSemicolon {
+			sql := p.rawStatement(statementStart)
+			p.advance()
+			return sql, nil
+		}
+		p.advance()
+	}
+	return "", fmt.Errorf("unterminated %s at position %d", label, p.current.Start)
 }
 
 // parseCreateStatement parses CREATE statements (TABLE, INDEX, TYPE).
@@ -151,7 +178,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	case "DEFINER":
 		return p.parseCreateDefinerRoutine(statementStart)
 	case "TRIGGER":
-		return p.parseCreateTrigger()
+		return p.parseCreateTrigger(statementStart)
 	case "INDEX":
 		return p.parseCreateIndex()
 	case "FULLTEXT", "SPATIAL":
@@ -164,7 +191,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	case "OR":
 		return p.parseCreateOrReplaceStatement(statementStart)
 	case "TEMP", "TEMPORARY":
-		return p.parseCreateTemporary(target)
+		return p.parseCreateTemporary(target, statementStart)
 	case "UNIQUE":
 		// Handle CREATE UNIQUE INDEX
 		p.advance()
@@ -202,11 +229,11 @@ func (p *Parser) parseCreateDefinerRoutine(statementStart int) (ast.Node, error)
 	return nil, fmt.Errorf("unsupported CREATE DEFINER target at position %d", p.current.Start)
 }
 
-func (p *Parser) parseCreateTemporary(target string) (ast.Node, error) {
+func (p *Parser) parseCreateTemporary(target string, statementStart int) (ast.Node, error) {
 	p.advance()
 	p.skipWhitespace()
 	if p.current.MatchIdentifierValue("TRIGGER") {
-		return p.parseCreateTrigger()
+		return p.parseCreateTrigger(statementStart)
 	}
 	return nil, fmt.Errorf("unsupported CREATE %s target: %s at position %d", target, p.current.Value, p.current.Start)
 }
@@ -329,9 +356,13 @@ func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, er
 		return p.parseCreateRawRoutineStatement(statementStart)
 	}
 	if p.current.MatchIdentifierValue("TRIGGER") {
-		trigger, err := p.parseCreateTrigger()
+		node, err := p.parseCreateTrigger(statementStart)
 		if err != nil {
 			return nil, err
+		}
+		trigger, ok := node.(*ast.CreateTriggerNode)
+		if !ok {
+			return node, nil
 		}
 		return trigger.SetReplace(), nil
 	}
@@ -852,7 +883,7 @@ func (p *Parser) parseFunctionSecurity(function *ast.CreateFunctionNode) error {
 	return nil
 }
 
-func (p *Parser) parseCreateTrigger() (*ast.CreateTriggerNode, error) {
+func (p *Parser) parseCreateTrigger(statementStart int) (ast.Node, error) {
 	if err := p.expect(lexer.TokenIdentifier, "TRIGGER"); err != nil {
 		return nil, err
 	}
@@ -899,6 +930,14 @@ func (p *Parser) parseCreateTrigger() (*ast.CreateTriggerNode, error) {
 		return nil, err
 	}
 	p.skipWhitespace()
+
+	if p.current.MatchIdentifierValue("EXECUTE") {
+		sql, err := p.collectRawStatement(statementStart, "CREATE TRIGGER statement")
+		if err != nil {
+			return nil, err
+		}
+		return ast.NewRawSQL(sql), nil
+	}
 
 	body, err := p.collectTriggerBody()
 	if err != nil {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -216,6 +216,57 @@ func TestParser_ParseDoesNotTreatGotoAsGoBatchSeparator(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `unsupported SQL statement: GOTO at position 0`)
 }
 
+func TestParser_ParsePostgresDoBlockAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DO $$
+BEGIN
+    CREATE TYPE some_type AS ENUM ('one', 'two');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END;
+$$;
+CREATE INDEX idx_users_name ON users (name);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "DO $$")
+	c.Assert(raw.SQL, qt.Contains, "CREATE TYPE some_type AS ENUM ('one', 'two');")
+	c.Assert(raw.SQL, qt.Contains, "END;")
+
+	index, ok := statements.Statements[1].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_name")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"name"})
+}
+
+func TestParser_ParsePostgresExecuteFunctionTriggerAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION touch_updated_at('updated_at');
+CREATE TABLE audit_log (id INTEGER);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE TRIGGER set_updated_at")
+	c.Assert(raw.SQL, qt.Contains, "EXECUTE FUNCTION touch_updated_at('updated_at')")
+
+	table, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(table.Name, qt.Equals, "audit_log")
+}
+
 func TestParser_ParseCreateTable_TablePrimaryKeyWithoutComma(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

- preserve top-level PostgreSQL `DO ...` blocks as raw SQL instead of rejecting the `DO` statement
- preserve `CREATE TRIGGER ... EXECUTE FUNCTION/PROCEDURE ...` trigger references as raw SQL, avoiding synthetic trigger-function rendering
- add parser tests covering dollar-quoted DO bodies, internal semicolons, and following statements

## Validation

- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./core/parser`
- `go test ./...`
- `make budget` in `ptah-atlas-conformance` with a local Ptah replace: green, 727 unwaived non-OK observations against budget 728
- `make gate` in `ptah-atlas-conformance` with a local Ptah replace: red as expected, 727 unwaived non-OK observations remain

## Conformance Impact

- `sql/migrate/testdata/lex/15_dollar_quote.sql` now parses successfully.
- The Atlas conformance report moves from 728 to 727 unwaived non-OK observations for this independent slice.
