### PR TITLE
Preserve SQL Server functions as raw SQL

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -500,6 +500,10 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	}
 	p.skipWhitespace()
 
+	if p.isSQLServerBracketedFunctionNameStart() {
+		return p.parseCreateRawSQLServerFunction(statementStart)
+	}
+
 	functionName, err := p.parseQualifiedIdentifier("function name")
 	if err != nil {
 		return nil, fmt.Errorf("unsupported CREATE FUNCTION syntax: %w", err)
@@ -520,6 +524,87 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 		return ast.NewRawSQL(p.rawStatement(statementStart)), nil
 	}
 	return function, nil
+}
+
+func (p *Parser) isSQLServerBracketedFunctionNameStart() bool {
+	// Bracketed function names enter T-SQL's routine-body sub-language. Until
+	// #323 adds a dialect-aware body parser, preserve the statement as raw SQL.
+	return p.current.MatchOperatorValue("[")
+}
+
+func (p *Parser) parseCreateRawSQLServerFunction(statementStart int) (ast.Node, error) {
+	sql, err := p.collectRawSQLServerFunction(statementStart)
+	if err != nil {
+		return nil, err
+	}
+	return ast.NewRawSQL(sql), nil
+}
+
+func (p *Parser) collectRawSQLServerFunction(statementStart int) (string, error) {
+	blockDepth := 0
+	caseDepth := 0
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+
+		if p.current.MatchOperatorValue("[") {
+			p.skipSQLServerBracketedIdentifier()
+			continue
+		}
+
+		if p.current.Type == lexer.TokenSemicolon && blockDepth == 0 {
+			sql := p.rawStatement(statementStart)
+			p.advance()
+			return sql, nil
+		}
+
+		if p.current.Type == lexer.TokenIdentifier {
+			if complete := trackSQLServerRawFunctionKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth); complete {
+				end := p.current.End
+				p.advance()
+				return p.rawStatementFragment(statementStart, end), nil
+			}
+		}
+		p.advance()
+	}
+
+	if blockDepth > 0 {
+		return "", fmt.Errorf("unterminated CREATE FUNCTION body at position %d", p.current.Start)
+	}
+	return p.rawStatementFragment(statementStart, p.previous.End), nil
+}
+
+func (p *Parser) skipSQLServerBracketedIdentifier() {
+	p.advance()
+	for !p.isAtEnd() {
+		if p.current.MatchOperatorValue("]") {
+			p.advance()
+			if p.current.MatchOperatorValue("]") {
+				p.advance()
+				continue
+			}
+			return
+		}
+		p.advance()
+	}
+}
+
+func trackSQLServerRawFunctionKeyword(keyword string, blockDepth, caseDepth *int) bool {
+	switch keyword {
+	case "BEGIN":
+		(*blockDepth)++
+	case "CASE":
+		(*caseDepth)++
+	case "END":
+		if *caseDepth > 0 {
+			(*caseDepth)--
+		} else if *blockDepth > 0 {
+			(*blockDepth)--
+			return *blockDepth == 0
+		}
+	}
+	return false
 }
 
 func (p *Parser) parseCreateRawRoutineStatement(statementStart int) (ast.Node, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -693,6 +693,135 @@ CALL gen_uuid();`
 	c.Assert(raw.SQL, qt.Contains, "date_format(NOW(6), '%Y%m%d%i%s%f')")
 }
 
+func TestParser_ParseSQLServerInlineTableFunctionAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f2](@a as INT, @b as INT = 1)
+RETURNS TABLE
+AS RETURN SELECT @a as [a], @b as [b], (@a+@b)*2 as [p], @a*@b as [s];
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION [f2](@a as INT, @b as INT = 1)")
+	c.Assert(raw.SQL, qt.Contains, "RETURNS TABLE")
+	c.Assert(raw.SQL, qt.Contains, "AS RETURN SELECT @a as [a]")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerMultiStatementTableFunctionAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f3] (@a int, @b int = 1) RETURNS @t1 TABLE ([c1] int NOT NULL, [c2] nvarchar(255) COLLATE SQL_Latin1_General_CP1_CI_AS NOT NULL, [c3] nvarchar(255) COLLATE SQL_Latin1_General_CP1_CI_AS DEFAULT N'G' NULL, [c4] int NOT NULL, PRIMARY KEY CLUSTERED ([c1] ASC), INDEX [idx] NONCLUSTERED ([c2] ASC), UNIQUE NONCLUSTERED ([c2] ASC, [c3] DESC), UNIQUE NONCLUSTERED ([c3] DESC, [c4] ASC), CHECK ([c4]>(0))) AS BEGIN
+  INSERT @t1
+  SELECT 1 AS [c1], 'A' AS [c2], NULL AS [c3], @a * @a + @b AS [c4];
+RETURN
+END;
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION [f3]")
+	c.Assert(raw.SQL, qt.Contains, "RETURNS @t1 TABLE")
+	c.Assert(raw.SQL, qt.Contains, "INSERT @t1")
+	c.Assert(raw.SQL, qt.Contains, "RETURN\nEND")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerGoDelimitedFunctionsAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `-- atlas:delimiter \nGO
+
+CREATE FUNCTION [f3] (@a int, @b int = 1) RETURNS @t1 TABLE ([c1] int NOT NULL) AS BEGIN
+  INSERT @t1
+  SELECT 1 AS [c1];
+RETURN
+END
+GO
+CREATE FUNCTION [f4] (@a int) RETURNS TABLE
+AS RETURN SELECT @a as [a];`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	first, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(first.SQL, qt.Contains, "CREATE FUNCTION [f3]")
+	c.Assert(first.SQL, qt.Contains, "SELECT 1 AS [c1];")
+	c.Assert(first.SQL, qt.Not(qt.Contains), "GO")
+
+	second, ok := statements.Statements[1].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(second.SQL, qt.Contains, "CREATE FUNCTION [f4]")
+	c.Assert(second.SQL, qt.Contains, "AS RETURN SELECT @a as [a];")
+}
+
+func TestParser_ParseSQLServerFunctionWithCaseExpressionAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f5] (@a int) RETURNS @t TABLE ([result] int NOT NULL) AS BEGIN
+  INSERT @t
+  SELECT CASE WHEN @a > 0 THEN @a ELSE 0 END AS [result];
+RETURN
+END
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CASE WHEN @a > 0 THEN @a ELSE 0 END")
+	c.Assert(raw.SQL, qt.Contains, "RETURN\nEND")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+}
+
+func TestParser_ParseSQLServerFunctionWithBracketedEndIdentifierAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f6] (@a int) RETURNS @t TABLE ([END]]value] int NOT NULL) AS BEGIN
+  INSERT @t
+  SELECT @a AS [END]]value];
+RETURN
+END
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "RETURNS @t TABLE ([END]]value] int NOT NULL)")
+	c.Assert(raw.SQL, qt.Contains, "SELECT @a AS [END]]value];")
+	c.Assert(raw.SQL, qt.Contains, "RETURN\nEND")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+}
+
 func TestParser_ParseCreateProcedureAsRawSQL(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- preserve SQL Server bracketed CREATE FUNCTION statements as RawSQL instead of entering the generic function-body parser
- handle inline table functions, multi-statement table functions, GO-delimited batches, CASE expressions, bracketed identifiers, and END; boundaries
- keep full dialect-aware T-SQL function parsing scoped to #323

## Validation
- gopls diagnostics: no diagnostics
- go vulncheck ./...: no findings in output
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser -run 'SQLServer|CreateFunction' -count=1
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/parser
- env GOCACHE=/private/tmp/ptah-go-cache go test ./core/...
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache go vet ./core/parser
- git diff --check
- local ptah-atlas-conformance replace probe: 726 -> 724 unwaived non-OK; sqlserver/1_return_table.sql and sqlserver/2_function.sql are ok

Note: local golangci-lint 2.12.2 still fails before analysis with "no go files to analyze"; CI lint is the authoritative check here.