### PR TITLE
Recognize Flyway repeatable migrations

### DIFF
--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -154,6 +154,21 @@ func TestLintFS_PairsByVersionLikeMigrator(t *testing.T) {
 		qt.Commentf("version 1 has both an up and a down; no MF101 expected; got %v", findings))
 }
 
+func TestLintFS_AtlasImportedFlywayRepeatableIsContentLinted(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"2_baseline.sql": "CREATE TABLE users (id INT);\n",
+		"3R_views.sql":   "DROP TABLE users;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"})
+	c.Assert(findings[0].File, qt.Equals, "3R_views.sql")
+	c.Assert(findings[0].Line, qt.Equals, 1)
+}
+
 // lintOne lints a single-statement up migration (with a paired down file)
 // and returns the rule codes that fired.
 func lintOne(c *qt.C, sql string) []string {

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -195,6 +195,9 @@ func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
 	partsByVersion := make(map[int64]*atlasParts)
 	for i := range files {
 		migrationFile := files[i]
+		if migrationFile.Repeatable {
+			continue
+		}
 		parts := partsByVersion[migrationFile.Version]
 		if parts == nil {
 			parts = &atlasParts{

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -227,6 +227,28 @@ func TestNewFSMigrationProvider_AtlasImportedDirectionalFiles(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `migration 2 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet; add an atlas txtar down.sql section or migrate down manually`)
 }
 
+func TestNewFSMigrationProvider_AtlasRepeatableFilesAreDiscoveryOnly(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"2_baseline.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
+		"3R_views.sql":   &fstest.MapFile{Data: []byte("CREATE VIEW active_users AS SELECT * FROM users;\n")},
+	}
+
+	files, err := migrator.DiscoverMigrationFiles(fsys, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	c.Assert(files[0].Path, qt.Equals, "3R_views.sql")
+	c.Assert(files[0].Repeatable, qt.IsTrue)
+
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].Version, qt.Equals, int64(2))
+	c.Assert(migrations[0].Description, qt.Equals, "Baseline")
+}
+
 func TestNewFSMigrationProvider_AtlasTxtarSectionsAndDirectives(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -63,6 +63,10 @@ type MigrationFile struct {
 	Direction string
 	Extension string
 	Format    MigrationDirFormat
+	// Repeatable marks Flyway-style repeatable migrations imported by Atlas.
+	// They are visible to discovery and linting, but they are not part of
+	// Ptah's ordered versioned execution model.
+	Repeatable bool
 }
 
 // ParseMigrationFileName parses a migration filename into its components
@@ -123,6 +127,10 @@ func parseAtlasMigrationFileName(filename string, mode atlasParseMode) (*Migrati
 		return nil, errors.New("invalid Atlas migration file name format")
 	}
 
+	if migrationFile, ok := parseAtlasRepeatableMigrationStem(stem); ok {
+		return migrationFile, nil
+	}
+
 	direction := "up"
 	for _, suffix := range []string{".up", ".down"} {
 		if strings.HasSuffix(stem, suffix) {
@@ -162,6 +170,56 @@ func parseAtlasMigrationFileName(filename string, mode atlasParseMode) (*Migrati
 		Extension: ".sql",
 		Format:    MigrationDirFormatAtlas,
 	}, nil
+}
+
+func parseAtlasRepeatableMigrationStem(stem string) (*MigrationFile, bool) {
+	repeatableName, ok := atlasRepeatableName(stem)
+	if !ok {
+		return nil, false
+	}
+	return &MigrationFile{
+		Name:       repeatableName,
+		Direction:  "up",
+		Extension:  ".sql",
+		Format:     MigrationDirFormatAtlas,
+		Repeatable: true,
+	}, true
+}
+
+func atlasRepeatableName(stem string) (string, bool) {
+	if strings.HasSuffix(stem, ".up") || strings.HasSuffix(stem, ".down") {
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(stem, "R__"):
+		rawName := strings.TrimPrefix(stem, "R__")
+		if rawName == "" {
+			return "", false
+		}
+		return titleAtlasName(rawName), true
+	case strings.Contains(stem, "R_"):
+		prefix, rawName, _ := strings.Cut(stem, "R_")
+		if prefix == "" || !allDigits(prefix) || rawName == "" {
+			return "", false
+		}
+		return titleAtlasName(rawName), true
+	default:
+		return "", false
+	}
+}
+
+func titleAtlasName(name string) string {
+	name = strings.NewReplacer("_", " ", ".", " ").Replace(name)
+	return cases.Title(language.English).String(name)
+}
+
+func allDigits(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return value != ""
 }
 
 func splitAtlasMigrationStem(stem string) (versionDigits, rawName string, ok bool) {

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -205,7 +205,23 @@ func TestParseAtlasMigrationFileName(t *testing.T) {
 	c.Assert(migrationFile.Version, qt.Equals, int64(2))
 	c.Assert(migrationFile.Name, qt.Equals, "10 X-20 Description")
 
-	_, err = ParseAtlasMigrationFileName("3R_views.sql")
+	migrationFile, err = ParseAtlasMigrationFileName("3R_views.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Version, qt.Equals, int64(0))
+	c.Assert(migrationFile.Name, qt.Equals, "Views")
+	c.Assert(migrationFile.Direction, qt.Equals, "up")
+	c.Assert(migrationFile.Format, qt.Equals, MigrationDirFormatAtlas)
+	c.Assert(migrationFile.Repeatable, qt.IsTrue)
+
+	migrationFile, err = ParseAtlasMigrationFileName("R__refresh_views.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFile.Name, qt.Equals, "Refresh Views")
+	c.Assert(migrationFile.Repeatable, qt.IsTrue)
+
+	_, err = ParseAtlasMigrationFileName("R__.sql")
+	c.Assert(err, qt.ErrorMatches, "invalid Atlas migration file name format")
+
+	_, err = ParseAtlasMigrationFileName("3R_views.down.sql")
 	c.Assert(err, qt.ErrorMatches, "invalid Atlas migration file name format")
 }
 
@@ -300,6 +316,30 @@ func TestDiscoverMigrationFilesAutoDetectsShortAtlasVersionsWithSum(t *testing.T
 	c.Assert(files[1].Version, qt.Equals, int64(2))
 	c.Assert(files[1].Name, qt.Equals, "2")
 	c.Assert(files[1].Format, qt.Equals, MigrationDirFormatAtlas)
+}
+
+func TestDiscoverMigrationFilesRecognizesAtlasImportedFlywayRepeatables(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"2_baseline.sql":        &fstest.MapFile{Data: []byte("CREATE TABLE post (id INT);\n")},
+		"3R_views.sql":          &fstest.MapFile{Data: []byte("CREATE VIEW my_view AS SELECT * FROM post;\n")},
+		"3_third_migration.sql": &fstest.MapFile{Data: []byte("ALTER TABLE post ADD COLUMN title TEXT;\n")},
+		"not_a_repeatable.sql":  &fstest.MapFile{Data: []byte("SELECT 1;\n")},
+		"also_not_R_views.sql":  &fstest.MapFile{Data: []byte("SELECT 2;\n")},
+		"atlas.sum":             &fstest.MapFile{Data: []byte("ignored\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatAuto)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 3)
+	c.Assert(files[0].Path, qt.Equals, "3R_views.sql")
+	c.Assert(files[0].Repeatable, qt.IsTrue)
+	c.Assert(files[0].Version, qt.Equals, int64(0))
+	c.Assert(files[1].Path, qt.Equals, "2_baseline.sql")
+	c.Assert(files[1].Version, qt.Equals, int64(2))
+	c.Assert(files[2].Path, qt.Equals, "3_third_migration.sql")
+	c.Assert(files[2].Version, qt.Equals, int64(3))
 }
 
 func TestDiscoverMigrationFilesAutoDetectsAtlasImportedNames(t *testing.T) {


### PR DESCRIPTION
## Summary

- recognize Atlas-imported Flyway repeatable migration files such as 3R_views.sql without assigning them a fake version
- expose repeatables to migration discovery and linting, while keeping them out of the ordered filesystem migration execution model
- add regression coverage for discovery, provider loading, lint content scanning, and negative repeatable filename cases

## Validation

- env GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator ./migration/lint ./cmd/lint ./cmd/migratevalidate ./cmd/migratehash
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- conformance preview with local Ptah via temporary go.work: 664 -> 662 unwaived non-OK observations; flyway_gold migdir/lint rows become OK
