### PR TITLE
Support Atlas template migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,13 @@ comments that look like `-- keep this comment --` remain comments, not txtar
 section boundaries. Ptah's txtar support is intentionally limited to Atlas SQL
 migration containers and is not a general-purpose txtar parser.
 
+Atlas-format SQL template migrations are rendered with Go `text/template`
+before execution and linting. Root versioned files such as `1.sql` and `2.sql`
+are executable migrations; shared template files in subdirectories can define
+helpers such as `{{ define "shared/users" }}` and are not executed as standalone
+migrations. The template data object exposes `.Env`; CLI commands set it with
+`--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
+
 If an Atlas migration has no embedded `down.sql`, `migrate-down` fails with a
 typed error explaining that Atlas dynamic down-plan synthesis is not implemented
 yet. This is different from transaction rollback: transaction rollback undoes a
@@ -695,6 +702,9 @@ Apply all pending migrations to bring database up to latest version:
 
 # Apply an Atlas-style versioned migration directory
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
+
+# Apply Atlas SQL template migrations with .Env set to dev
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
 ```
 
 Migration files can override the CLI defaults with top-of-file directives:
@@ -791,6 +801,9 @@ Show current migration status and pending migrations:
 
 # Check an Atlas-style versioned migration directory
 ./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
+
+# Check Atlas SQL template migrations with .Env set to dev
+./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
 ```
 
 **Output includes:**

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/lint"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 const (
@@ -35,6 +36,7 @@ func NewLintCommand() *cobra.Command {
 	var dialect string
 	var format string
 	var configPath string
+	var atlasEnv string
 	var disabled []string
 	var failOn string
 
@@ -60,6 +62,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 				dialect:    dialect,
 				format:     format,
 				configPath: configPath,
+				atlasEnv:   atlasEnv,
 				disabled:   disabled,
 				failOn:     failOn,
 				positional: args,
@@ -71,6 +74,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	cmd.Flags().StringVar(&dialect, "dialect", "", "Target dialect gating dialect-specific rules: postgres, mysql or mariadb (empty runs every rule)")
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
 	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+lint.ConfigFileName+" when present)")
+	cmd.Flags().StringVar(&atlasEnv, "atlas-env", "", "Value exposed as .Env when rendering Atlas SQL template migrations")
 	cmd.Flags().StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DS101 or MY (repeatable)")
 	cmd.Flags().StringVar(&failOn, "fail-on", failOnError, "Failure threshold controlling the exit code: error, any or none")
 
@@ -89,6 +93,7 @@ type runOptions struct {
 	dialect    string
 	format     string
 	configPath string
+	atlasEnv   string
 	disabled   []string
 	failOn     string
 	positional []string
@@ -141,9 +146,10 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 	disabled := append(append([]string{}, cfg.DisabledRules...), opts.disabled...)
 
 	findings, err := lint.LintFS(os.DirFS(opts.dir), lint.Options{
-		Dialect:    dialect,
-		Disabled:   disabled,
-		PathPrefix: filepath.ToSlash(opts.dir),
+		Dialect:           dialect,
+		Disabled:          disabled,
+		PathPrefix:        filepath.ToSlash(opts.dir),
+		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.atlasEnv},
 	})
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -37,6 +37,7 @@ const (
 	migrationsFlag       = "migrations-dir"
 	targetFlag           = "target"
 	dirFormatFlag        = "dir-format"
+	atlasEnvFlag         = "atlas-env"
 	dryRunFlag           = "dry-run"
 	verboseFlag          = "verbose"
 	confirmFlag          = "confirm"
@@ -65,6 +66,11 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Name:  dirFormatFlag,
 		Value: string(migrator.MigrationDirFormatAuto),
 		Usage: "Migration directory format: auto, ptah, or atlas",
+	},
+	atlasEnvFlag: &cobraflags.StringFlag{
+		Name:  atlasEnvFlag,
+		Value: "",
+		Usage: "Value exposed as .Env when rendering Atlas SQL template migrations",
 	},
 	dryRunFlag: &cobraflags.BoolFlag{
 		Name:  dryRunFlag,
@@ -112,6 +118,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	migrationsDir := migrateDownFlags[migrationsFlag].GetString()
 	targetVersionValue := migrateDownFlags[targetFlag].GetString()
 	dirFormatValue := migrateDownFlags[dirFormatFlag].GetString()
+	atlasEnv := migrateDownFlags[atlasEnvFlag].GetString()
 	dryRun := migrateDownFlags[dryRunFlag].GetBool()
 	verbose := migrateDownFlags[verboseFlag].GetBool()
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
@@ -200,7 +207,13 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
 
 	// Create migrator to access applied migrations
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor), migrator.WithMigrationDirFormat(dirFormat))
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		migrationsFS,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: atlasEnv}),
+	)
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -34,6 +34,7 @@ const (
 	dbURLFlag      = "db-url"
 	migrationsFlag = "migrations-dir"
 	dirFormatFlag  = "dir-format"
+	atlasEnvFlag   = "atlas-env"
 	verboseFlag    = "verbose"
 	jsonFlag       = "json"
 )
@@ -53,6 +54,11 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Name:  dirFormatFlag,
 		Value: string(migrator.MigrationDirFormatAuto),
 		Usage: "Migration directory format: auto, ptah, or atlas",
+	},
+	atlasEnvFlag: &cobraflags.StringFlag{
+		Name:  atlasEnvFlag,
+		Value: "",
+		Usage: "Value exposed as .Env when rendering Atlas SQL template migrations",
 	},
 	verboseFlag: &cobraflags.BoolFlag{
 		Name:  verboseFlag,
@@ -78,6 +84,7 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	dbURL := migrateStatusFlags[dbURLFlag].GetString()
 	migrationsDir := migrateStatusFlags[migrationsFlag].GetString()
 	dirFormatValue := migrateStatusFlags[dirFormatFlag].GetString()
+	atlasEnv := migrateStatusFlags[atlasEnvFlag].GetString()
 	verbose := migrateStatusFlags[verboseFlag].GetBool()
 	jsonOutput := migrateStatusFlags[jsonFlag].GetBool()
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
@@ -112,7 +119,12 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	// Create filesystem from migrations directory
 	migrationsFS := os.DirFS(migrationsDir)
 
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithMigrationDirFormat(dirFormat))
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		migrationsFS,
+		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: atlasEnv}),
+	)
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -39,6 +39,7 @@ const (
 	verboseFlag          = "verbose"
 	verifySumFlag        = "verify-sum"
 	dirFormatFlag        = "dir-format"
+	atlasEnvFlag         = "atlas-env"
 	execOrderFlag        = "exec-order"
 	lockTimeoutFlag      = "lock-timeout"
 	statementTimeoutFlag = "statement-timeout"
@@ -75,6 +76,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Name:  dirFormatFlag,
 		Value: string(migrator.MigrationDirFormatAuto),
 		Usage: "Migration directory format: auto, ptah, or atlas",
+	},
+	atlasEnvFlag: &cobraflags.StringFlag{
+		Name:  atlasEnvFlag,
+		Value: "",
+		Usage: "Value exposed as .Env when rendering Atlas SQL template migrations",
 	},
 	execOrderFlag: &cobraflags.StringFlag{
 		Name:  execOrderFlag,
@@ -114,6 +120,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	verbose := migrateUpFlags[verboseFlag].GetBool()
 	verifySum := migrateUpFlags[verifySumFlag].GetBool()
 	dirFormatValue := migrateUpFlags[dirFormatFlag].GetString()
+	atlasEnv := migrateUpFlags[atlasEnvFlag].GetString()
 	execOrderValue := migrateUpFlags[execOrderFlag].GetString()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
@@ -206,7 +213,13 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 	interceptor := onlineddl.New(*onlineCfg).WithDryRun(dryRun)
 
-	mig, err := migrator.NewFSMigrator(conn, migrationsFS, migrator.WithStatementInterceptor(interceptor), migrator.WithMigrationDirFormat(dirFormat))
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		migrationsFS,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: atlasEnv}),
+	)
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -154,6 +154,9 @@ type Options struct {
 	// Versions restricts linting to parsed migration versions. Empty means
 	// every migration file is linted.
 	Versions []int64
+	// AtlasTemplateData supplies data for Atlas SQL template migrations.
+	// When nil, templates render with migrator.AtlasTemplateData{}.
+	AtlasTemplateData any
 }
 
 // LintFS lints every *.sql file under fsys — recursively, because the
@@ -180,6 +183,10 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 	}
 	sort.Strings(names)
 	names = filterNamesByVersion(names, opts.Versions)
+	names, err = filterAtlasTemplateSupportNames(fsys, names)
+	if err != nil {
+		return nil, err
+	}
 	if len(names) == 0 {
 		return nil, nil
 	}
@@ -205,7 +212,7 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 	mode := modeForDialect(opts.Dialect)
 	var findings []Finding
 	for _, name := range names {
-		file, err := prepareFile(fsys, name, present, versionDirs, opts.PathPrefix, mode)
+		file, err := prepareFile(fsys, name, present, versionDirs, opts.PathPrefix, mode, opts.AtlasTemplateData)
 		if err != nil {
 			return nil, err
 		}
@@ -245,8 +252,65 @@ func filterNamesByVersion(names []string, versions []int64) []string {
 	return filtered
 }
 
+func filterAtlasTemplateSupportNames(fsys fs.FS, names []string) ([]string, error) {
+	hasAtlasTemplate, err := hasAtlasTemplateMigration(fsys, names)
+	if err != nil || !hasAtlasTemplate {
+		return names, err
+	}
+
+	filtered := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, err := parseKnownMigrationName(path.Base(name)); err == nil {
+			filtered = append(filtered, name)
+			continue
+		}
+		support, err := isAtlasTemplateSupportFile(fsys, name)
+		if err != nil {
+			return nil, err
+		}
+		if !support {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered, nil
+}
+
+func hasAtlasTemplateMigration(fsys fs.FS, names []string) (bool, error) {
+	for _, name := range names {
+		parsed, err := parseKnownMigrationName(path.Base(name))
+		if err != nil || parsed.Format != migrator.MigrationDirFormatAtlas {
+			continue
+		}
+		raw, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return false, fmt.Errorf("failed to read %s: %w", name, err)
+		}
+		if migrator.LooksAtlasTemplateSQL(string(raw)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isAtlasTemplateSupportFile(fsys fs.FS, name string) (bool, error) {
+	raw, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s: %w", name, err)
+	}
+	sql := string(raw)
+	return migrator.LooksAtlasTemplateSQL(sql) && strings.Contains(sql, "define "), nil
+}
+
 // prepareFile loads one migration file into the forms rules consume.
-func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDirs map[int64]map[string]bool, pathPrefix string, mode scanMode) (*File, error) {
+func prepareFile(
+	fsys fs.FS,
+	name string,
+	present map[string]struct{},
+	versionDirs map[int64]map[string]bool,
+	pathPrefix string,
+	mode scanMode,
+	atlasTemplateData any,
+) (*File, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", name, err)
@@ -292,7 +356,15 @@ func prepareFile(fsys fs.FS, name string, present map[string]struct{}, versionDi
 
 	// Statement rules apply to up migrations only.
 	if file.IsUp {
-		for _, rawStmt := range splitStatementsWithLines(string(raw), mode) {
+		sql := string(raw)
+		if atlasFormat && migrator.LooksAtlasTemplateSQL(sql) {
+			rendered, _, err := migrator.RenderAtlasTemplateSQL(fsys, name, atlasTemplateData)
+			if err != nil {
+				return nil, err
+			}
+			sql = rendered
+		}
+		for _, rawStmt := range splitStatementsWithLines(sql, mode) {
 			file.Statements = append(file.Statements, Statement{
 				SQL:       rawStmt.text,
 				Canonical: canonicalize(rawStmt.text, mode),

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -537,6 +537,30 @@ func TestLintFS_AtlasImportedMigrationNamesAreScanned(t *testing.T) {
 	c.Assert(findings[0].File, qt.Equals, "1_initial.up.sql")
 }
 
+func TestLintFS_AtlasTemplateMigrationsAreRendered(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"1.sql": `{{- if eq .Env "dev" }}
+CREATE TABLE dev1 (id INT);
+{{- else }}
+DROP TABLE prod1;
+{{- end }}
+`,
+		"2.sql": `{{ template "shared/users" "prod2" }}`,
+		"shared/users.sql": `{{- define "shared/users" }}
+CREATE TABLE users_{{ $ }} (id INT);
+{{- end }}
+`,
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"},
+		qt.Commentf("Atlas templates should be rendered before linting and shared definitions should not emit MF103; got %v", findings))
+	c.Assert(findings[0].File, qt.Equals, "1.sql")
+}
+
 func TestLintFS_CaseVariantSQLFilesGetNamingWarning(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -99,6 +99,13 @@ comments that look like `-- keep this comment --` remain comments, not txtar
 section boundaries. Ptah's txtar support is intentionally limited to Atlas SQL
 migration containers and is not a general-purpose txtar parser.
 
+Atlas-format SQL template migrations are rendered with Go `text/template`
+before execution and linting. Root versioned files such as `1.sql` and `2.sql`
+are executable migrations; shared template files in subdirectories can define
+helpers such as `{{ define "shared/users" }}` and are not executed as standalone
+migrations. The template data object exposes `.Env`; CLI commands set it with
+`--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
+
 If an Atlas migration does not provide `down.sql`, `migrate-down` returns a typed
 error explaining that Atlas dynamic down-plan synthesis is not implemented yet.
 This is distinct from transaction rollback on a failed migration: transaction
@@ -217,6 +224,7 @@ pending and out of order.
 - **`WithMigrationsTable(schema, table)`**: Configures the migration history table
 - **`WithExecOrder(policy)`**: Configures out-of-order migration handling
 - **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
+- **`WithAtlasTemplateData(data)`**: Supplies data, including `.Env`, for Atlas SQL template migrations
 
 ## Programmatic Usage
 

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -38,6 +38,10 @@ func TestAtlasTxtarDown_PostgresIntegration(t *testing.T) {
 	runAtlasTxtarDownIntegration(t, postgresTestURL(t))
 }
 
+func TestAtlasTemplate_PostgresIntegration(t *testing.T) {
+	runAtlasTemplateIntegration(t, postgresTestURL(t))
+}
+
 func TestAtlasTxtarDown_MySQLIntegration(t *testing.T) {
 	dbURL := os.Getenv("MYSQL_TEST_DSN")
 	if dbURL == "" {
@@ -141,6 +145,48 @@ DROP TABLE ptah_issue_290_widgets;
 	c.Assert(issue290WidgetTableExists(t, conn), qt.IsFalse)
 }
 
+func runAtlasTemplateIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	cleanupIssue299(t, conn)
+	defer cleanupIssue299(t, conn)
+
+	fsys := fstest.MapFS{
+		"1.sql": &fstest.MapFile{Data: []byte(`{{- if eq .Env "dev" }}
+CREATE TABLE ptah_issue_299_dev (id INT PRIMARY KEY);
+{{- else }}
+CREATE TABLE ptah_issue_299_prod (id INT PRIMARY KEY);
+{{- end }}
+`)},
+		"2.sql": &fstest.MapFile{Data: []byte(`{{ template "shared/users" "dev" }}`)},
+		"shared/users.sql": &fstest.MapFile{Data: []byte(`{{- define "shared/users" }}
+CREATE TABLE ptah_issue_299_users_{{ $ }} (id INT PRIMARY KEY);
+{{- end }}
+`)},
+	}
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: "dev"}),
+	)
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithMigrationsTable("", "schema_migrations_issue_299")
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_299_dev"), qt.IsTrue)
+	c.Assert(tableExists(t, conn, "ptah_issue_299_prod"), qt.IsFalse)
+	c.Assert(tableExists(t, conn, "ptah_issue_299_users_dev"), qt.IsTrue)
+	c.Assert(issue299Versions(t, conn), qt.DeepEquals, []int64{1, 2})
+}
+
 func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 	t.Helper()
 
@@ -149,6 +195,19 @@ func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 		"DROP TABLE IF EXISTS ptah_issue_273_users",
 		"DROP TABLE IF EXISTS ptah_issue_273_teams",
 		"DROP TABLE IF EXISTS schema_migrations_issue_273",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func cleanupIssue299(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ptah_issue_299_users_dev",
+		"DROP TABLE IF EXISTS ptah_issue_299_prod",
+		"DROP TABLE IF EXISTS ptah_issue_299_dev",
+		"DROP TABLE IF EXISTS schema_migrations_issue_299",
 	} {
 		_, _ = conn.ExecContext(context.Background(), statement)
 	}
@@ -218,6 +277,23 @@ func issue290Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
 	t.Helper()
 
 	rows, err := conn.Query("SELECT version FROM schema_migrations_issue_290 ORDER BY version")
+	qt.Assert(t, err, qt.IsNil)
+	defer rows.Close()
+
+	var versions []int64
+	for rows.Next() {
+		var version int64
+		qt.Assert(t, rows.Scan(&version), qt.IsNil)
+		versions = append(versions, version)
+	}
+	qt.Assert(t, rows.Err(), qt.IsNil)
+	return versions
+}
+
+func issue299Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
+	t.Helper()
+
+	rows, err := conn.Query("SELECT version FROM schema_migrations_issue_299 ORDER BY version")
 	qt.Assert(t, err, qt.IsNil)
 	defer rows.Close()
 

--- a/migration/migrator/atlas_template.go
+++ b/migration/migrator/atlas_template.go
@@ -1,0 +1,95 @@
+package migrator
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+var atlasTemplateActionRe = regexp.MustCompile(`{{-?\s*(define|template|if|else|end|range|with|block|\$|\.)\b?`)
+
+// AtlasTemplateData is the default data object used for Atlas SQL templates.
+type AtlasTemplateData struct {
+	Env string
+}
+
+// LooksAtlasTemplateSQL reports whether sql contains Go template actions.
+func LooksAtlasTemplateSQL(sql string) bool {
+	return atlasTemplateActionRe.MatchString(sql)
+}
+
+// RenderAtlasTemplateSQL renders an Atlas SQL template migration file.
+//
+// The root file is executed after parsing every *.sql file in the same
+// filesystem, so shared templates such as {{ template "shared/users" . }} can be
+// defined in subdirectories. Non-template files are returned unchanged with
+// rendered=false.
+func RenderAtlasTemplateSQL(fsys fs.FS, filename string, data any) (sql string, rendered bool, err error) {
+	raw, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read migration file: %w", err)
+	}
+	if !LooksAtlasTemplateSQL(string(raw)) {
+		return string(raw), false, nil
+	}
+
+	renderedSQL, err := renderAtlasTemplateSQL(fsys, filename, data)
+	if err != nil {
+		return "", false, err
+	}
+	return renderedSQL, true, nil
+}
+
+func renderAtlasTemplateSQL(fsys fs.FS, filename string, data any) (string, error) {
+	rootName := path.Clean(filename)
+	tmpl := template.New(rootName).Option("missingkey=zero")
+
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.EqualFold(path.Ext(p), ".sql") {
+			return nil
+		}
+		raw, err := fs.ReadFile(fsys, p)
+		if err != nil {
+			return fmt.Errorf("failed to read SQL template %s: %w", p, err)
+		}
+		if path.Clean(p) != rootName && !LooksAtlasTemplateSQL(string(raw)) {
+			return nil
+		}
+
+		name := path.Clean(p)
+		if name != rootName {
+			name = atlasTemplateReferenceName(name)
+		}
+		if _, err := tmpl.New(name).Parse(string(raw)); err != nil {
+			return fmt.Errorf("failed to parse SQL template %s: %w", p, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, rootName, atlasTemplateData(data)); err != nil {
+		return "", fmt.Errorf("failed to render SQL template %s: %w", filename, err)
+	}
+	return out.String(), nil
+}
+
+func atlasTemplateReferenceName(filename string) string {
+	return strings.TrimSuffix(filename, path.Ext(filename))
+}
+
+func atlasTemplateData(data any) any {
+	if data != nil {
+		return data
+	}
+	return AtlasTemplateData{}
+}

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -58,10 +58,11 @@ func (p *RegisteredMigrationProvider) maybeSort() {
 // It scans the filesystem for migration files following the naming convention and
 // automatically creates Migration instances from the SQL files.
 type FSMigrationProvider struct {
-	fsys        fs.FS
-	migrations  []*Migration
-	interceptor StatementInterceptor
-	format      MigrationDirFormat
+	fsys              fs.FS
+	migrations        []*Migration
+	interceptor       StatementInterceptor
+	format            MigrationDirFormat
+	atlasTemplateData any
 }
 
 // FSProviderOption configures a FSMigrationProvider before it loads
@@ -88,6 +89,14 @@ func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
 func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption {
 	return func(p *FSMigrationProvider) {
 		p.format = format
+	}
+}
+
+// WithAtlasTemplateData supplies the data object used to render Atlas SQL
+// template migrations. When omitted, templates render with AtlasTemplateData{}.
+func WithAtlasTemplateData(data any) FSProviderOption {
+	return func(p *FSMigrationProvider) {
+		p.atlasTemplateData = data
 	}
 }
 
@@ -147,7 +156,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 		migration := migrationsMap[migrationFile.Version]
 		switch migrationFile.Direction {
 		case "up":
-			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)
 			if err != nil {
 				return fmt.Errorf("failed to load up migration %s: %w", migrationFile.Path, err)
 			}
@@ -157,7 +166,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.UpTimeouts = up.timeouts
 			migration.NoTransaction = migration.NoTransaction || up.noTransaction
 		case "down":
-			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)
 			if err != nil {
 				return fmt.Errorf("failed to load down migration %s: %w", migrationFile.Path, err)
 			}
@@ -254,7 +263,7 @@ func (p *FSMigrationProvider) loadAtlasFile(parts *atlasParts, migrationFile Mig
 
 func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile MigrationFile) error {
 	if isAtlasDirectionalMigrationFile(migrationFile) {
-		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
 		if err != nil {
 			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 		}
@@ -262,7 +271,7 @@ func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile Migra
 		return nil
 	}
 
-	atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+	atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
 	if err != nil {
 		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 	}
@@ -277,7 +286,7 @@ func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile Migra
 }
 
 func (p *FSMigrationProvider) loadAtlasDown(parts *atlasParts, migrationFile MigrationFile) error {
-	down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor)
+	down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
 	if err != nil {
 		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 	}

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -249,6 +249,51 @@ func TestNewFSMigrationProvider_AtlasRepeatableFilesAreDiscoveryOnly(t *testing.
 	c.Assert(migrations[0].Description, qt.Equals, "Baseline")
 }
 
+func TestNewFSMigrationProvider_AtlasTemplateMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"1.sql": &fstest.MapFile{Data: []byte(`{{- if eq .Env "dev" }}
+CREATE TABLE dev1 (id INT);
+{{- else }}
+CREATE TABLE prod1 (id INT);
+{{- end }}
+`)},
+		"2.sql": &fstest.MapFile{Data: []byte(`{{- if eq .Env "dev" }}
+{{ template "shared/users" "dev2" }}
+{{- else }}
+{{ template "shared/users" "prod2" }}
+{{- end }}
+`)},
+		"shared/users.sql": &fstest.MapFile{Data: []byte(`{{- define "shared/users" }}
+CREATE TABLE users_{{ $ }} (id INT);
+{{- end }}
+`)},
+	}
+	interceptor := &recordingInterceptor{}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: "dev"}),
+	)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 2)
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
+	c.Assert(migrations[1].Version, qt.Equals, int64(2))
+
+	err = migrations[0].Up(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"CREATE TABLE dev1 (id INT)"})
+
+	interceptor.statements = nil
+	err = migrations[1].Up(context.Background(), nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"CREATE TABLE users_dev2 (id INT)"})
+}
+
 func TestNewFSMigrationProvider_AtlasTxtarSectionsAndDirectives(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -112,7 +112,7 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 // behaves exactly like MigrationFuncFromSQLFilename.
 func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc {
 	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor)
+		migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor, nil)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(
 	fsys fs.FS,
 	interceptor StatementInterceptor,
 ) (MigrationFunc, MigrationTimeouts, error) {
-	migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor)
+	migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor, nil)
 	if err != nil {
 		return nil, MigrationTimeouts{}, err
 	}
@@ -147,13 +147,14 @@ func migrationFuncFromSQLFilenameWithMetadata(
 	filename string,
 	fsys fs.FS,
 	interceptor StatementInterceptor,
+	atlasTemplateData any,
 ) (sqlMigrationFile, error) {
-	sql, err := fs.ReadFile(fsys, filename)
+	sql, err := readSQLMigrationFile(fsys, filename, atlasTemplateData)
 	if err != nil {
-		return sqlMigrationFile{}, fmt.Errorf("failed to read migration file: %w", err)
+		return sqlMigrationFile{}, err
 	}
 
-	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, string(sql), interceptor)
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, interceptor)
 	if err != nil {
 		return sqlMigrationFile{}, err
 	}
@@ -161,20 +162,21 @@ func migrationFuncFromSQLFilenameWithMetadata(
 		return atlasMigrationFile.up, nil
 	}
 
-	return migrationFuncFromSQLStringWithMetadata(filename, string(sql), interceptor)
+	return migrationFuncFromSQLStringWithMetadata(filename, sql, interceptor)
 }
 
 func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
 	filename string,
 	fsys fs.FS,
 	interceptor StatementInterceptor,
+	atlasTemplateData any,
 ) (atlasSQLMigrationFile, error) {
-	sql, err := fs.ReadFile(fsys, filename)
+	sql, err := readSQLMigrationFile(fsys, filename, atlasTemplateData)
 	if err != nil {
-		return atlasSQLMigrationFile{}, fmt.Errorf("failed to read migration file: %w", err)
+		return atlasSQLMigrationFile{}, err
 	}
 
-	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, string(sql), interceptor)
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, interceptor)
 	if err != nil {
 		return atlasSQLMigrationFile{}, err
 	}
@@ -182,11 +184,16 @@ func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
 		return atlasMigrationFile, nil
 	}
 
-	up, err := migrationFuncFromSQLStringWithMetadata(filename, string(sql), interceptor)
+	up, err := migrationFuncFromSQLStringWithMetadata(filename, sql, interceptor)
 	if err != nil {
 		return atlasSQLMigrationFile{}, err
 	}
 	return atlasSQLMigrationFile{up: up}, nil
+}
+
+func readSQLMigrationFile(fsys fs.FS, filename string, atlasTemplateData any) (string, error) {
+	sql, _, err := RenderAtlasTemplateSQL(fsys, filename, atlasTemplateData)
+	return sql, err
 }
 
 func atlasSQLMigrationFileFromSQL(filename, sql string, interceptor StatementInterceptor) (atlasSQLMigrationFile, bool, error) {


### PR DESCRIPTION
## Summary
- render Atlas SQL template migrations with Go text/template before execution and linting
- add WithAtlasTemplateData plus --atlas-env for migrate-up, migrate-down, migrate-status, and lint
- treat shared template definition files as support files when an Atlas template migration is present
- document Atlas template behavior and add unit plus Postgres integration coverage

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator ./migration/lint ./cmd/lint ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus
- env 'POSTGRES_TEST_DSN=postgres://postgres:ptah@127.0.0.1:55438/ptah?sslmode=disable' GOCACHE=/private/tmp/ptah-go-cache go test ./migration/migrator -run TestAtlasTemplate_PostgresIntegration -count=1 -v
- env GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=/private/tmp/ptah-conformance-go.work GOCACHE=/private/tmp/ptah-go-cache make probe in ptah-atlas-conformance: 662 -> 661 before harness rendering updates