### PR TITLE
Support explicit schema comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ type User struct {
 
 Migration generation emits `CREATE SCHEMA IF NOT EXISTS auth` before creating schema-qualified tables and renders references such as `auth.users`.
 
+Schema objects can also be declared explicitly when you need schema-level metadata such as PostgreSQL comments:
+
+```go
+//migrator:schema:schema name="auth" comment="Authentication objects"
+type AuthSchema struct{}
+```
+
 ### Field Definition
 ```go
 //migrator:schema:field name="id" type="SERIAL" primary="true" platform.mysql.type="INT AUTO_INCREMENT"

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -110,6 +110,8 @@ type CreateSchemaNode struct {
 	Name string
 	// IfNotExists preserves an IF NOT EXISTS guard when the dialect supports it.
 	IfNotExists bool
+	// Comment is an optional schema comment.
+	Comment string
 }
 
 // NewCreateSchema creates a new CREATE SCHEMA node.

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -63,6 +63,10 @@ func (p *parser) parseBody(body *hclsyntax.Body) error {
 			if err := p.rejectUnsupportedSchemaBody(block); err != nil {
 				return err
 			}
+			p.db.Schemas = append(p.db.Schemas, goschema.Schema{
+				Name:    block.Labels[0],
+				Comment: p.optionalString(block.Body.Attributes["comment"]),
+			})
 		case "table":
 			if err := p.parseTable(block); err != nil {
 				return err
@@ -337,7 +341,9 @@ func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
 	if len(block.Body.Blocks) > 0 {
 		return p.blockError(block.Body.Blocks[0], "unsupported schema block %q", block.Body.Blocks[0].Type)
 	}
-	return p.rejectUnsupportedAttrs(block, map[string]bool{}, "schema")
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"comment": true,
+	}, "schema")
 }
 
 func (p *parser) rejectUnsupportedTableAttrs(block *hclsyntax.Block) error {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -36,6 +36,7 @@ table "users" {
 }
 `), "schema.hcl")
 	c.Assert(err, qt.IsNil)
+	c.Assert(db.Schemas, qt.DeepEquals, []goschema.Schema{{Name: "main"}})
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
 	c.Assert(db.Tables[0].Schema, qt.Equals, "main")
@@ -50,6 +51,25 @@ table "users" {
 	c.Assert(sql, qt.Contains, `CREATE TABLE main.users`)
 	c.Assert(sql, qt.Contains, `id int PRIMARY KEY`)
 	c.Assert(sql, qt.Contains, `CREATE UNIQUE INDEX`)
+}
+
+func TestParseSchemaComment(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "public" {
+  comment = "This is a test schema"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Schemas, qt.DeepEquals, []goschema.Schema{{
+		Name:    "public",
+		Comment: "This is a test schema",
+	}})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n")
+	c.Assert(sql, qt.Contains, `CREATE SCHEMA IF NOT EXISTS public;`)
+	c.Assert(sql, qt.Contains, `COMMENT ON SCHEMA public IS 'This is a test schema';`)
 }
 
 func TestParseCompositePrimaryKeyAndForeignKey(t *testing.T) {

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -938,23 +938,27 @@ func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
 // FromDatabase converts a complete goschema.Database to an ast.StatementList containing all DDL statements.
 //
 // This function creates a comprehensive database schema by converting all schema elements
-// (enums, tables, indexes, embedded fields) into their corresponding AST nodes. The statements are ordered
+// (schemas, enums, tables, indexes, embedded fields) into their corresponding AST nodes. The statements are ordered
 // to ensure proper dependency resolution during SQL execution, with platform-specific
 // overrides applied throughout.
 //
 // # Parameters
 //
-//   - database: The complete database schema containing all tables, fields, indexes, enums, and embedded fields
+//   - database: The complete database schema containing all schemas, tables, fields, indexes, enums, and embedded fields
 //   - targetPlatform: Target database platform for applying platform-specific overrides
 //
 // # Statement Ordering
 //
 // The function generates statements in the following order to respect dependencies:
-//  1. Enum type definitions (CREATE TYPE statements)
-//  2. Table definitions (CREATE TABLE statements) with embedded fields processed
-//  3. Index definitions (CREATE INDEX statements)
+//  1. Schema definitions (CREATE SCHEMA statements)
+//  2. Enum type definitions (CREATE TYPE statements)
+//  3. Table definitions (CREATE TABLE statements) with embedded fields processed
+//  4. Extension definitions
+//  5. Dialect-specific objects such as roles, functions, views, RLS policies, grants, and triggers
+//  6. Index definitions (CREATE INDEX statements)
 //
 // This ordering ensures that:
+//   - Schemas are created before tables that reference them
 //   - Enum types are created before tables that reference them
 //   - Tables are created before indexes that reference them
 //   - Foreign key dependencies are handled by the table creation order
@@ -1010,13 +1014,16 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// Process embedded fields to generate additional fields for each table
 	allFields := ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
 
-	// 1. Add enum definitions first (they may be referenced by tables)
+	// 1. Add schema definitions first (they may be referenced by tables)
+	appendSchemaStatements(statements, database.Schemas)
+
+	// 2. Add enum definitions (they may be referenced by tables)
 	for _, enum := range database.Enums {
 		enumNode := FromEnum(enum)
 		statements.Statements = append(statements.Statements, enumNode)
 	}
 
-	// 2. Add table definitions (they may be referenced by indexes)
+	// 3. Add table definitions (they may be referenced by indexes)
 	// Use the combined field list that includes embedded field expansions
 	for _, table := range database.Tables {
 		tableNode := FromTable(table, allFields, database.Enums, targetPlatform)
@@ -1024,13 +1031,13 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		statements.Statements = append(statements.Statements, tableNode)
 	}
 
-	// 3. Add extension definitions (PostgreSQL-specific)
+	// 4. Add extension definitions (PostgreSQL-specific)
 	for _, extension := range database.Extensions {
 		extensionNode := FromExtension(extension)
 		statements.Statements = append(statements.Statements, extensionNode)
 	}
 
-	// 4. Add PostgreSQL-specific features (functions and RLS)
+	// 5. Add PostgreSQL-specific features (functions and RLS)
 	// These features are only supported by PostgreSQL, so we only generate them for PostgreSQL dialects
 	isPostgreSQL := strings.ToLower(targetPlatform) == "postgresql" || strings.ToLower(targetPlatform) == "postgres"
 
@@ -1100,6 +1107,16 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	}
 
 	return statements
+}
+
+func appendSchemaStatements(statements *ast.StatementList, schemas []goschema.Schema) {
+	for _, schema := range schemas {
+		statements.Statements = append(statements.Statements, &ast.CreateSchemaNode{
+			Name:        schema.Name,
+			IfNotExists: true,
+			Comment:     schema.Comment,
+		})
+	}
 }
 
 // createStructToTableMap creates a mapping from struct names to table names.

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -515,6 +515,31 @@ func TestFromDatabase_TableLevelConstraints(t *testing.T) {
 	c.Assert(table.Constraints[0].Expression, qt.Equals, "position('@' in email) > 1")
 }
 
+func TestFromDatabase_Schemas(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Schemas: []goschema.Schema{{
+			Name:    "public",
+			Comment: "Application schema",
+		}},
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+			Schema:     "public",
+		}},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+
+	c.Assert(result.Statements, qt.HasLen, 2)
+	schema, ok := result.Statements[0].(*ast.CreateSchemaNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(schema.Name, qt.Equals, "public")
+	c.Assert(schema.IfNotExists, qt.IsTrue)
+	c.Assert(schema.Comment, qt.Equals, "Application schema")
+}
+
 func TestFromTable_FiltersByStructName(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -484,6 +484,7 @@ func ToEnum(enum *ast.EnumNode) goschema.Enum {
 // properly categorized from the AST statement list.
 func ToDatabase(statements *ast.StatementList) goschema.Database {
 	database := goschema.Database{
+		Schemas: []goschema.Schema{},
 		Tables:  []goschema.Table{},
 		Fields:  []goschema.Field{},
 		Indexes: []goschema.Index{},
@@ -493,6 +494,12 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 	// Process all statements and categorize them
 	for _, stmt := range statements.Statements {
 		switch node := stmt.(type) {
+		case *ast.CreateSchemaNode:
+			database.Schemas = append(database.Schemas, goschema.Schema{
+				Name:    node.Name,
+				Comment: node.Comment,
+			})
+
 		case *ast.EnumNode:
 			// Convert enum definitions
 			enumSchema := ToEnum(node)

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -88,6 +88,11 @@ var knownTriggerAttributes = map[string]bool{
 	"comment": true,
 }
 
+var knownSchemaAttributes = map[string]bool{
+	"name":    true,
+	"comment": true,
+}
+
 // validateAttributes panics if kv contains any key the directive does not
 // recognize. Platform-specific overrides (platform.*) are always allowed.
 // This catches typos like default_fn-vs-default_expr at parse time instead of
@@ -315,6 +320,17 @@ func parseExtensionComment(comment *ast.Comment, extensions *[]Extension) {
 	})
 }
 
+func parseSchemaComment(comment *ast.Comment, schemas *[]Schema) {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	validateAttributes(kv, knownSchemaAttributes, "//migrator:schema:schema", kv["name"])
+	requireAttributes(kv, []string{"name"}, "//migrator:schema:schema", kv["name"])
+
+	*schemas = append(*schemas, Schema{
+		Name:    kv["name"],
+		Comment: kv["comment"],
+	})
+}
+
 func parseTableComment(comment *ast.Comment, structName string, tableDirectives *[]Table) {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	*tableDirectives = append(*tableDirectives, Table{
@@ -393,6 +409,7 @@ func processTableComments(
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
 	grants *[]Grant,
+	schemas *[]Schema,
 ) {
 	if genDecl.Doc == nil {
 		return
@@ -422,6 +439,8 @@ func processTableComments(
 			parseRoleComment(comment, structName, roles)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
 			parseGrantComment(comment, structName, grants)
+		case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
+			parseSchemaComment(comment, schemas)
 		}
 	}
 }
@@ -493,6 +512,7 @@ func parseFileAST(f *ast.File) Database {
 	var rlsEnabledTables []RLSEnabledTable
 	var roles []Role
 	var grants []Grant
+	var schemas []Schema
 	globalEnumsMap := make(map[string]Enum)
 
 	// Single pass: collect table names and process all declarations and comments
@@ -515,6 +535,7 @@ func parseFileAST(f *ast.File) Database {
 		&rlsEnabledTables,
 		&roles,
 		&grants,
+		&schemas,
 	)
 
 	enums := make([]Enum, 0, len(globalEnumsMap))
@@ -533,6 +554,7 @@ func parseFileAST(f *ast.File) Database {
 	})
 
 	result := Database{
+		Schemas:           schemas,
 		Tables:            tableDirectives,
 		Fields:            schemaFields,
 		Indexes:           schemaIndexes,
@@ -574,6 +596,7 @@ func processFileAST(
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
 	grants *[]Grant,
+	schemas *[]Schema,
 ) {
 	// First, collect table names from struct declarations
 	for _, decl := range f.Decls {
@@ -615,6 +638,7 @@ func processFileAST(
 		rlsEnabledTables,
 		roles,
 		grants,
+		schemas,
 	)
 
 	// Process all file comments for RLS annotations that might not be associated with struct declarations
@@ -660,6 +684,7 @@ func processDeclarations(
 	rlsEnabledTables *[]RLSEnabledTable,
 	roles *[]Role,
 	grants *[]Grant,
+	schemas *[]Schema,
 ) {
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
@@ -677,7 +702,7 @@ func processDeclarations(
 				continue
 			}
 
-			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
+			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants, schemas)
 			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
 		}
 	}

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -131,6 +131,7 @@ package test
 //migrator:schema:view name="active_users" body="SELECT id FROM users WHERE deleted_at IS NULL" with_check="true" comment="Active users"
 //migrator:schema:matview name="user_stats" body="SELECT id, COUNT(*) FROM users GROUP BY id"
 //migrator:schema:trigger name="set_updated_at" table="users" timing="before" event="update" body="NEW.updated_at = NOW(); RETURN NEW;"
+//migrator:schema:schema name="auth" comment="Authentication schema"
 //migrator:schema:table name="users"
 type User struct {
 	//migrator:schema:field name="id" type="SERIAL" primary="true"
@@ -150,6 +151,10 @@ type User struct {
 	c.Assert(db.Triggers[0].Timing, qt.Equals, "BEFORE")
 	c.Assert(db.Triggers[0].Event, qt.Equals, "UPDATE")
 	c.Assert(db.Triggers[0].ForEach, qt.Equals, "ROW")
+	c.Assert(db.Schemas, qt.DeepEquals, []goschema.Schema{{
+		Name:    "auth",
+		Comment: "Authentication schema",
+	}})
 }
 
 func TestParseSchemaObjectAnnotations_RejectsInvalidAttributes(t *testing.T) {
@@ -174,6 +179,11 @@ func TestParseSchemaObjectAnnotations_RejectsInvalidAttributes(t *testing.T) {
 			name:       "missing trigger table",
 			annotation: `//migrator:schema:trigger name="set_updated_at" timing="before" event="update" body="RETURN NEW;"`,
 			want:       `missing required annotation attribute "table"`,
+		},
+		{
+			name:       "missing schema name",
+			annotation: `//migrator:schema:schema comment="missing name"`,
+			want:       `missing required annotation attribute "name"`,
 		},
 	}
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -21,6 +21,7 @@ import (
 //   - Sort tables in topological order to ensure proper creation sequence
 //
 // Fields:
+//   - Schemas: All explicit database schema/namespace directives
 //   - Tables: All table directives found in the project
 //   - Fields: All field definitions with their database mappings
 //   - Indexes: All index definitions for database optimization
@@ -28,6 +29,7 @@ import (
 //   - EmbeddedFields: Fields from embedded structs with their relation modes
 //   - Dependencies: Dependency graph mapping table names to their dependencies
 type Database struct {
+	Schemas                    []Schema
 	Tables                     []Table
 	Fields                     []Field
 	Indexes                    []Index
@@ -46,6 +48,12 @@ type Database struct {
 	Dependencies               map[string][]string            // table -> list of tables it depends on
 	FunctionDependencies       map[string][]string            // function -> list of functions it depends on
 	SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
+}
+
+// Schema represents a database schema/namespace.
+type Schema struct {
+	Name    string // Schema name, e.g. "public"
+	Comment string // Optional schema comment/description
 }
 
 // EmbeddedField represents an embedded field in a Go struct that should be handled specially

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -820,8 +820,9 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 //   - Constraints: Deduplicated by explicit table + name, or declaring struct + name when table is omitted
 //   - Grants: Deduplicated by role + privileges + grant option + (table or schema) target
 //   - Roles: Deduplicated by role name
+//   - Schemas: Deduplicated by schema name
 //
-// All 15 Database slice collections are now covered (previously only a subset
+// All 16 Database slice collections are now covered (previously only a subset
 // of appended collections were deduplicated, and the five dropped by ParseFS
 // were never reached). This prevents duplicate emits when objects are declared
 // across files.
@@ -830,6 +831,8 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 // slices with deduplicated versions. The order of entities may change during
 // this process, but dependency ordering is handled separately.
 func Deduplicate(r *Database) {
+	r.Schemas = deduplicateSchemas(r.Schemas)
+
 	// Deduplicate tables by schema-qualified name - preserve order
 	tableSeen := make(map[string]bool)
 	var deduplicatedTables []Table
@@ -952,6 +955,18 @@ func deduplicateSchemaObjects(r *Database) {
 	r.Roles = deduplicateRoles(r.Roles)
 }
 
+func deduplicateSchemas(schemas []Schema) []Schema {
+	seen := make(map[string]bool)
+	deduplicated := make([]Schema, 0, len(schemas))
+	for _, schema := range schemas {
+		if !seen[schema.Name] {
+			seen[schema.Name] = true
+			deduplicated = append(deduplicated, schema)
+		}
+	}
+	return deduplicated
+}
+
 func deduplicateViews(views []View) []View {
 	seen := make(map[string]bool)
 	deduplicated := make([]View, 0, len(views))
@@ -1039,6 +1054,9 @@ func deduplicateGrants(grants []Grant) []Grant {
 }
 
 func validateDuplicateSchemaObjectDefinitions(r *Database) error {
+	if err := validateDuplicateSchemas(r.Schemas); err != nil {
+		return err
+	}
 	if err := validateDuplicateViews(r.Views); err != nil {
 		return err
 	}
@@ -1053,6 +1071,17 @@ func validateDuplicateSchemaObjectDefinitions(r *Database) error {
 	}
 	if err := validateDuplicateRoles(r.Roles); err != nil {
 		return err
+	}
+	return nil
+}
+
+func validateDuplicateSchemas(schemas []Schema) error {
+	seen := make(map[string]string)
+	for _, schema := range schemas {
+		if previous, ok := seen[schema.Name]; ok && previous != schema.Comment {
+			return fmt.Errorf("conflicting schema %q definitions", schema.Name)
+		}
+		seen[schema.Name] = schema.Comment
 	}
 	return nil
 }

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -70,6 +70,7 @@ func ParseDir(rootDir string) (*Database, error) {
 //	statements := GetOrderedCreateStatements(result, "postgresql")
 func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 	result := &Database{
+		Schemas:                    []Schema{},
 		Tables:                     []Table{},
 		Fields:                     []Field{},
 		Indexes:                    []Index{},
@@ -122,6 +123,7 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		database := ParseSource(path, reader)
 
 		// Add to result
+		result.Schemas = append(result.Schemas, database.Schemas...)
 		result.EmbeddedFields = append(result.EmbeddedFields, database.EmbeddedFields...)
 		result.Fields = append(result.Fields, database.Fields...)
 		result.Indexes = append(result.Indexes, database.Indexes...)

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -1394,6 +1394,12 @@ func TestParseFS_ConflictingDuplicateSchemaObjectsFail(t *testing.T) {
 			sourceB: `//migrator:schema:role name="app_user" login="true" inherit="true"`,
 			err:     `conflicting role "app_user" definitions`,
 		},
+		{
+			name:    "schema comment",
+			sourceA: `//migrator:schema:schema name="auth" comment="Authentication schema"`,
+			sourceB: `//migrator:schema:schema name="auth" comment="Identity schema"`,
+			err:     `conflicting schema "auth" definitions`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1439,6 +1445,31 @@ type Second struct{}
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.Views, qt.HasLen, 1)
 	c.Assert(result.Views[0].Comment, qt.Equals, "first")
+}
+
+func TestParseFS_IdenticalDuplicateSchemasAreNoOp(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"a.go": {Data: []byte(`package fixtures
+
+//migrator:schema:schema name="auth" comment="Authentication schema"
+type First struct{}
+`)},
+		"b.go": {Data: []byte(`package fixtures
+
+//migrator:schema:schema name="auth" comment="Authentication schema"
+type Second struct{}
+`)},
+	}
+
+	result, err := goschema.ParseFS(fsys, ".")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Schemas, qt.DeepEquals, []goschema.Schema{{
+		Name:    "auth",
+		Comment: "Authentication schema",
+	}})
 }
 
 // BenchmarkParseFS_LargeProject benchmarks ParseFS performance on a larger project

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -50,8 +50,9 @@ func TestPostgres_AlterTable_RenameTable(t *testing.T) {
 
 func TestPostgres_CreateSchema(t *testing.T) {
 	c := qt.New(t)
-	out := renderPG(t, &ast.CreateSchemaNode{Name: "auth", IfNotExists: true})
+	out := renderPG(t, &ast.CreateSchemaNode{Name: "auth", IfNotExists: true, Comment: "Auth user's schema"})
 	c.Assert(out, qt.Contains, "CREATE SCHEMA IF NOT EXISTS auth;")
+	c.Assert(out, qt.Contains, "COMMENT ON SCHEMA auth IS 'Auth user''s schema';")
 }
 
 func TestPostgres_CreateDatabase(t *testing.T) {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -60,6 +60,9 @@ func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
 		guard = " IF NOT EXISTS"
 	}
 	r.w.WriteLinef("CREATE SCHEMA%s %s;", guard, node.Name)
+	if node.Comment != "" {
+		r.w.WriteLinef("COMMENT ON SCHEMA %s IS %s;", node.Name, r.escapeValue(node.Comment))
+	}
 	return nil
 }
 

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -24,7 +24,8 @@ go run ./cmd generate --schema-file schema.hcl --dialect postgres
 The parser supports the schema-object subset that maps directly to Ptah's
 current schema IR:
 
-- `schema` labels, for table namespace references such as `schema = schema.main`
+- `schema` labels and `comment`, for table namespace references such as
+  `schema = schema.main`
 - `table` blocks
 - `column` blocks with `type`, `null`, `auto_increment`, `unique`, `default`,
   and `comment`

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -155,6 +155,7 @@ For a detailed view of the migration workflow, see the [Migration Architecture D
 ```go
 // Core schema representation from Go annotations
 type Database struct {
+    Schemas       []Schema
     Tables         []Table
     Fields         []Field
     Indexes        []Index

--- a/integration/fixtures/entities/023-go-annotations-objects/users.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/users.go
@@ -1,5 +1,8 @@
 package entities
 
+//migrator:schema:schema name="public" comment="Fixture public schema"
+type SchemaMarker struct{}
+
 //migrator:schema:extension name="pg_trgm" if_not_exists="true" comment="Fixture extension"
 type ExtensionsMarker struct{}
 


### PR DESCRIPTION
## Summary

- Add explicit schema objects to the Go schema IR and Atlas HCL parser, including schema comments.
- Render PostgreSQL `COMMENT ON SCHEMA` statements and preserve schema objects through AST conversion.
- Add Go annotation support for `//migrator:schema:schema`, duplicate conflict validation, tests, fixtures, and docs.

## Validation

- `go test -count=1 ./core/convert/fromschema ./core/goschema ./core/atlashcl ./core/renderer/dialects/postgres ./core/renderer ./integration/gonative`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test -count=1 ./...` outside sandbox because `dbschema` connection tests need a local listener on `127.0.0.1:0`