### PR TITLE
Parse named column check constraints

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -1735,6 +1735,8 @@ func (p *Parser) parseColumnConstraintOrAttribute(table *ast.CreateTableNode, co
 		return p.handleDefault(column)
 	case "CHECK":
 		return p.handleCheck(column)
+	case "CONSTRAINT":
+		return p.handleColumnConstraint(column)
 	case "REFERENCES":
 		return p.handleReferences(column)
 	case "AS":
@@ -1754,6 +1756,24 @@ func (p *Parser) parseColumnConstraintOrAttribute(table *ast.CreateTableNode, co
 	default:
 		return fmt.Errorf("unsupported column attribute: %s at position %d", keyword, p.current.Start)
 	}
+	return nil
+}
+
+func (p *Parser) handleColumnConstraint(column *ast.ColumnNode) error {
+	p.advance()
+	p.skipWhitespace()
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected column constraint name: %w", err)
+	}
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("CHECK") {
+		return fmt.Errorf("unsupported column constraint %q at position %d", p.current.Value, p.current.Start)
+	}
+	if err := p.handleCheck(column); err != nil {
+		return err
+	}
+	column.SetCheckName(name)
 	return nil
 }
 

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -3182,6 +3182,30 @@ func TestParser_MariaDBWithCheckConstraint(t *testing.T) {
 	c.Assert(createTable.Columns, qt.HasLen, 1)
 }
 
+func TestParser_ColumnLevelNamedCheckConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE test (
+		a int CONSTRAINT c1 CHECK (a > 0),
+		b int constraint c2 check (b > 0)
+	);`
+	p := parser.NewParser(sql)
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Columns, qt.HasLen, 2)
+
+	c.Assert(createTable.Columns[0].Name, qt.Equals, "a")
+	c.Assert(createTable.Columns[0].CheckName, qt.Equals, "c1")
+	c.Assert(createTable.Columns[0].Check, qt.Equals, "a > 0")
+
+	c.Assert(createTable.Columns[1].Name, qt.Equals, "b")
+	c.Assert(createTable.Columns[1].CheckName, qt.Equals, "c2")
+	c.Assert(createTable.Columns[1].Check, qt.Equals, "b > 0")
+}
+
 func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- support column-level named CHECK constraints in the SQL parser
- preserve the constraint name in ColumnNode.CheckName
- add parser coverage for upper/lower-case CONSTRAINT CHECK syntax

## Why
Atlas integration fixtures use column definitions such as `a int CONSTRAINT c1 CHECK (a > 0)`. Ptah previously treated `CONSTRAINT` as an unsupported column attribute, which blocks conformance work for schema inspect/diff fixtures that rely on named column checks.

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/parser
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
