### PR TITLE
Support constraint column parts

### DIFF
--- a/core/ast/constraints.go
+++ b/core/ast/constraints.go
@@ -14,8 +14,9 @@ package ast
 //	pk := NewPrimaryKeyConstraint("user_id", "role_id")
 func NewPrimaryKeyConstraint(columns ...string) *ConstraintNode {
 	return &ConstraintNode{
-		Type:    PrimaryKeyConstraint,
-		Columns: columns,
+		Type:        PrimaryKeyConstraint,
+		Columns:     columns,
+		ColumnParts: constraintColumnParts(columns),
 	}
 }
 
@@ -33,9 +34,10 @@ func NewPrimaryKeyConstraint(columns ...string) *ConstraintNode {
 //	unique := NewUniqueConstraint("uk_users_name_company", "name", "company_id")
 func NewUniqueConstraint(name string, columns ...string) *ConstraintNode {
 	return &ConstraintNode{
-		Type:    UniqueConstraint,
-		Name:    name,
-		Columns: columns,
+		Type:        UniqueConstraint,
+		Name:        name,
+		Columns:     columns,
+		ColumnParts: constraintColumnParts(columns),
 	}
 }
 
@@ -56,11 +58,20 @@ func NewUniqueConstraint(name string, columns ...string) *ConstraintNode {
 //	fk := NewForeignKeyConstraint("fk_orders_user", []string{"user_id"}, ref)
 func NewForeignKeyConstraint(name string, columns []string, ref *ForeignKeyRef) *ConstraintNode {
 	return &ConstraintNode{
-		Type:      ForeignKeyConstraint,
-		Name:      name,
-		Columns:   columns,
-		Reference: ref,
+		Type:        ForeignKeyConstraint,
+		Name:        name,
+		Columns:     columns,
+		ColumnParts: constraintColumnParts(columns),
+		Reference:   ref,
 	}
+}
+
+func constraintColumnParts(columns []string) []ConstraintColumn {
+	parts := make([]ConstraintColumn, 0, len(columns))
+	for _, column := range columns {
+		parts = append(parts, ConstraintColumn{Name: column})
+	}
+	return parts
 }
 
 // NewExcludeConstraint creates a table-level exclude constraint with a name, using method, and elements.

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -372,6 +372,16 @@ func (n *ColumnNode) SetForeignKey(table, column, name string) *ColumnNode {
 	return n
 }
 
+// ConstraintColumn represents a column reference inside a table-level constraint.
+type ConstraintColumn struct {
+	// Name is the referenced column name.
+	Name string
+	// Prefix stores MySQL index prefix length, as in PRIMARY KEY (`name` (7)).
+	Prefix string
+	// Desc is true when the constraint column is declared with DESC ordering.
+	Desc bool
+}
+
 // ConstraintNode represents table-level constraints (PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK, EXCLUDE).
 //
 // Table-level constraints can span multiple columns and are defined separately
@@ -384,6 +394,9 @@ type ConstraintNode struct {
 	Name string
 	// Columns contains the list of column names involved in the constraint
 	Columns []string
+	// ColumnParts contains structured column references for dialect-specific
+	// attributes such as MySQL prefix lengths and DESC ordering.
+	ColumnParts []ConstraintColumn
 	// Reference contains foreign key reference information (only for FOREIGN KEY constraints)
 	Reference *ForeignKeyRef
 	// Expression contains the check expression (only for CHECK constraints)

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2510,11 +2510,12 @@ func (p *Parser) parseTableColumnList(constraint *ast.ConstraintNode) error {
 
 	// Parse column names
 	for {
-		columnName, err := p.expectIdentifier()
+		column, err := p.parseConstraintColumn()
 		if err != nil {
-			return fmt.Errorf("expected column name: %w", err)
+			return err
 		}
-		constraint.Columns = append(constraint.Columns, columnName)
+		constraint.Columns = append(constraint.Columns, column.Name)
+		constraint.ColumnParts = append(constraint.ColumnParts, column)
 
 		p.skipWhitespace()
 
@@ -2536,6 +2537,41 @@ func (p *Parser) parseTableColumnList(constraint *ast.ConstraintNode) error {
 	}
 
 	return nil
+}
+
+func (p *Parser) parseConstraintColumn() (ast.ConstraintColumn, error) {
+	columnName, err := p.expectIdentifier()
+	if err != nil {
+		return ast.ConstraintColumn{}, fmt.Errorf("expected column name: %w", err)
+	}
+	column := ast.ConstraintColumn{Name: columnName}
+
+	p.skipWhitespace()
+	if p.current.MatchOperatorValue("(") {
+		p.advance()
+		p.skipWhitespace()
+		prefix, err := p.expectIdentifier()
+		if err != nil {
+			return ast.ConstraintColumn{}, fmt.Errorf("expected column prefix length: %w", err)
+		}
+		column.Prefix = prefix
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenOperator, ")"); err != nil {
+			return ast.ConstraintColumn{}, fmt.Errorf("expected ')' after column prefix length: %w", err)
+		}
+		p.skipWhitespace()
+	}
+
+	if p.current.MatchIdentifierValue("DESC") {
+		column.Desc = true
+		p.advance()
+		p.skipWhitespace()
+	} else if p.current.MatchIdentifierValue("ASC") {
+		p.advance()
+		p.skipWhitespace()
+	}
+
+	return column, nil
 }
 
 func (p *Parser) handleTableForeignKey(constraint *ast.ConstraintNode) error {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -3206,6 +3206,26 @@ func TestParser_ColumnLevelNamedCheckConstraint(t *testing.T) {
 	c.Assert(createTable.Columns[1].Check, qt.Equals, "b > 0")
 }
 
+func TestParser_TableConstraintColumnParts(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE TABLE t (`id` tinytext NOT NULL, PRIMARY KEY (`id` (7) DESC));"
+	statements, err := parser.NewParser(sql).Parse()
+	c.Assert(err, qt.IsNil)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
+
+	pk := createTable.Constraints[0]
+	c.Assert(pk.Type, qt.Equals, ast.PrimaryKeyConstraint)
+	c.Assert(pk.Columns, qt.DeepEquals, []string{"`id`"})
+	c.Assert(pk.ColumnParts, qt.DeepEquals, []ast.ConstraintColumn{{
+		Name:   "`id`",
+		Prefix: "7",
+		Desc:   true,
+	}})
+}
+
 func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -29,3 +29,23 @@ func TestMySQLRenderer_ViewsAndTriggers(t *testing.T) {
 	c.Assert(sql, qt.Contains, "CREATE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW SET NEW.updated_at = NOW();")
 	c.Assert(sql, qt.Contains, "-- MYSQL does not support CREATE MATERIALIZED VIEW user_stats")
 }
+
+func TestMySQLRenderer_ConstraintColumnParts(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("t1").
+		AddColumn(ast.NewColumn("`id`", "tinytext").SetNotNull()).
+		AddConstraint(&ast.ConstraintNode{
+			Type:    ast.PrimaryKeyConstraint,
+			Columns: []string{"`id`"},
+			ColumnParts: []ast.ConstraintColumn{{
+				Name:   "`id`",
+				Prefix: "7",
+				Desc:   true,
+			}},
+		})
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "PRIMARY KEY (`id` (7) DESC)")
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -551,12 +551,12 @@ func (r *Renderer) renderTableOptions(options map[string]string) string {
 func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, error) {
 	switch constraint.Type {
 	case ast.PrimaryKeyConstraint:
-		return fmt.Sprintf("  PRIMARY KEY (%s)", strings.Join(constraint.Columns, ", ")), nil
+		return fmt.Sprintf("  PRIMARY KEY (%s)", renderMySQLConstraintColumns(constraint)), nil
 	case ast.UniqueConstraint:
 		if constraint.Name != "" {
-			return fmt.Sprintf("  CONSTRAINT %s UNIQUE (%s)", constraint.Name, strings.Join(constraint.Columns, ", ")), nil
+			return fmt.Sprintf("  CONSTRAINT %s UNIQUE (%s)", constraint.Name, renderMySQLConstraintColumns(constraint)), nil
 		}
-		return fmt.Sprintf("  UNIQUE (%s)", strings.Join(constraint.Columns, ", ")), nil
+		return fmt.Sprintf("  UNIQUE (%s)", renderMySQLConstraintColumns(constraint)), nil
 	case ast.ForeignKeyConstraint:
 		return r.renderForeignKeyConstraint(constraint)
 	case ast.CheckConstraint:
@@ -567,6 +567,24 @@ func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, err
 	default:
 		return "", fmt.Errorf("unknown constraint type: %v", constraint.Type)
 	}
+}
+
+func renderMySQLConstraintColumns(constraint *ast.ConstraintNode) string {
+	if len(constraint.ColumnParts) == 0 {
+		return strings.Join(constraint.Columns, ", ")
+	}
+	parts := make([]string, 0, len(constraint.ColumnParts))
+	for _, column := range constraint.ColumnParts {
+		part := column.Name
+		if column.Prefix != "" {
+			part += " (" + column.Prefix + ")"
+		}
+		if column.Desc {
+			part += " DESC"
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // renderForeignKeyConstraint renders a foreign key constraint


### PR DESCRIPTION
## Summary
- add structured constraint column parts for table-level constraints while preserving the existing Columns field
- parse MySQL-style prefix lengths and DESC/ASC ordering in PRIMARY/UNIQUE/FOREIGN column lists
- render MySQL primary/unique constraints with prefix and DESC metadata

## Validation
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/parser
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/ast
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/renderer/dialects/mysql
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./... (escalated because sandbox blocks local TCP listen in dbschema tests)