### PR TITLE
Support Atlas HCL primary key parts

### DIFF
--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -104,14 +104,12 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 			}
 			p.db.Fields = append(p.db.Fields, field)
 		case "primary_key":
-			if err := p.rejectUnsupportedPrimaryKeyAttrs(nested); err != nil {
-				return err
-			}
-			columns, err := p.parseColumnsAttr(nested, "columns")
+			columns, parts, err := p.parsePrimaryKey(nested)
 			if err != nil {
 				return err
 			}
 			table.PrimaryKey = columns
+			table.PrimaryKeyParts = parts
 		case "index":
 			index, err := p.parseIndex(table.StructName, table.Name, nested)
 			if err != nil {
@@ -220,6 +218,65 @@ func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, error) {
 		columns = append(columns, p.columnNameFromExpr(attr))
 	}
 	return columns, nil
+}
+
+func (p *parser) parsePrimaryKey(block *hclsyntax.Block) ([]string, []goschema.PrimaryKeyPart, error) {
+	if err := p.rejectUnsupportedPrimaryKeyAttrs(block); err != nil {
+		return nil, nil, err
+	}
+	if block.Body.Attributes["columns"] != nil {
+		if len(block.Body.Blocks) > 0 {
+			return nil, nil, p.blockError(block.Body.Blocks[0], "primary_key cannot mix columns attribute with on blocks")
+		}
+		columns, err := p.parseColumnsAttr(block, "columns")
+		if err != nil {
+			return nil, nil, err
+		}
+		return columns, primaryKeyParts(columns), nil
+	}
+
+	parts, err := p.parsePrimaryKeyParts(block)
+	if err != nil {
+		return nil, nil, err
+	}
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		columns = append(columns, part.Name)
+	}
+	return columns, parts, nil
+}
+
+func (p *parser) parsePrimaryKeyParts(block *hclsyntax.Block) ([]goschema.PrimaryKeyPart, error) {
+	if len(block.Body.Blocks) == 0 {
+		return nil, p.blockError(block, "primary_key requires columns attribute or on blocks")
+	}
+	parts := make([]goschema.PrimaryKeyPart, 0, len(block.Body.Blocks))
+	for _, nested := range block.Body.Blocks {
+		if nested.Type != "on" {
+			return nil, p.blockError(nested, "unsupported primary_key block %q", nested.Type)
+		}
+		if err := p.rejectUnsupportedPrimaryKeyOnAttrs(nested); err != nil {
+			return nil, err
+		}
+		attr := nested.Body.Attributes["column"]
+		if attr == nil {
+			return nil, p.blockError(nested, "primary_key on block requires column")
+		}
+		parts = append(parts, goschema.PrimaryKeyPart{
+			Name:   p.columnNameFromExpr(attr),
+			Prefix: p.optionalRawExpr(nested.Body.Attributes["prefix"]),
+			Desc:   p.optionalBool(nested.Body.Attributes["desc"], false),
+		})
+	}
+	return parts, nil
+}
+
+func primaryKeyParts(columns []string) []goschema.PrimaryKeyPart {
+	parts := make([]goschema.PrimaryKeyPart, 0, len(columns))
+	for _, column := range columns {
+		parts = append(parts, goschema.PrimaryKeyPart{Name: column})
+	}
+	return parts
 }
 
 type foreignKeySpec struct {
@@ -360,6 +417,14 @@ func (p *parser) rejectUnsupportedPrimaryKeyAttrs(block *hclsyntax.Block) error 
 	}, "primary_key")
 }
 
+func (p *parser) rejectUnsupportedPrimaryKeyOnAttrs(block *hclsyntax.Block) error {
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"column": true,
+		"prefix": true,
+		"desc":   true,
+	}, "primary_key on")
+}
+
 func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"type":           true,
@@ -460,6 +525,13 @@ func (p *parser) optionalBool(attr *hclsyntax.Attribute, fallback bool) bool {
 		return fallback
 	}
 	return value.True()
+}
+
+func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {
+	if attr == nil {
+		return ""
+	}
+	return p.rawExpr(attr)
 }
 
 func (p *parser) exprString(attr *hclsyntax.Attribute) string {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -53,6 +53,46 @@ table "users" {
 	c.Assert(sql, qt.Contains, `CREATE UNIQUE INDEX`)
 }
 
+func TestParsePrimaryKeyParts(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "tokens" {
+  schema = schema.main
+  column "id" {
+    type = tinytext
+  }
+  column "tenant_id" {
+    type = tinytext
+  }
+  primary_key {
+    on {
+      column = column.id
+      prefix = 7
+    }
+    on {
+      desc   = true
+      column = column.tenant_id
+      prefix = 1
+    }
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].PrimaryKey, qt.DeepEquals, []string{"id", "tenant_id"})
+	c.Assert(db.Tables[0].PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{
+		{Name: "id", Prefix: "7"},
+		{Name: "tenant_id", Prefix: "1", Desc: true},
+	})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, "PRIMARY KEY (id (7), tenant_id (1) DESC)")
+	c.Assert(sql, qt.Not(qt.Contains), "id tinytext PRIMARY KEY")
+}
+
 func TestParseSchemaComment(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -52,6 +52,7 @@ package fromschema
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -535,20 +536,61 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	}
 
 	// Add columns for fields that belong to this table
+	tableLevelPK := tableNeedsPrimaryKeyConstraint(newTable)
 	for _, field := range fields {
 		if field.StructName == table.StructName {
+			if tableLevelPK && slices.Contains(newTable.PrimaryKey, field.Name) {
+				field.Primary = false
+			}
 			column := FromField(field, enums, targetPlatform)
 			createTable.AddColumn(column)
 		}
 	}
 
 	// Add composite primary key constraint if specified
-	if len(table.PrimaryKey) > 1 {
-		constraint := ast.NewPrimaryKeyConstraint(table.PrimaryKey...)
+	if tableLevelPK {
+		constraint := newPrimaryKeyConstraint(newTable)
 		createTable.AddConstraint(constraint)
 	}
 
 	return createTable
+}
+
+func tableNeedsPrimaryKeyConstraint(table goschema.Table) bool {
+	if len(table.PrimaryKeyParts) > 0 {
+		return len(table.PrimaryKeyParts) > 1 || primaryKeyPartsHaveAttributes(table.PrimaryKeyParts)
+	}
+	return len(table.PrimaryKey) > 1
+}
+
+func primaryKeyPartsHaveAttributes(parts []goschema.PrimaryKeyPart) bool {
+	for _, part := range parts {
+		if part.Prefix != "" || part.Desc {
+			return true
+		}
+	}
+	return false
+}
+
+func newPrimaryKeyConstraint(table goschema.Table) *ast.ConstraintNode {
+	if len(table.PrimaryKeyParts) == 0 {
+		return ast.NewPrimaryKeyConstraint(table.PrimaryKey...)
+	}
+	columns := make([]string, 0, len(table.PrimaryKeyParts))
+	columnParts := make([]ast.ConstraintColumn, 0, len(table.PrimaryKeyParts))
+	for _, part := range table.PrimaryKeyParts {
+		columns = append(columns, part.Name)
+		columnParts = append(columnParts, ast.ConstraintColumn{
+			Name:   part.Name,
+			Prefix: part.Prefix,
+			Desc:   part.Desc,
+		})
+	}
+	return &ast.ConstraintNode{
+		Type:        ast.PrimaryKeyConstraint,
+		Columns:     columns,
+		ColumnParts: columnParts,
+	}
 }
 
 // FromConstraint converts a goschema.Constraint to an AST table constraint.

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -483,6 +483,40 @@ func TestFromTable_CompositePrimaryKey(t *testing.T) {
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id", "role_id"})
 }
 
+func TestFromTable_PrimaryKeyParts(t *testing.T) {
+	c := qt.New(t)
+
+	table := goschema.Table{
+		StructName: "Token",
+		Name:       "tokens",
+		PrimaryKey: []string{"id"},
+		PrimaryKeyParts: []goschema.PrimaryKeyPart{{
+			Name:   "id",
+			Prefix: "7",
+			Desc:   true,
+		}},
+	}
+	fields := []goschema.Field{{
+		StructName: "Token",
+		Name:       "id",
+		Type:       "tinytext",
+		Primary:    true,
+	}}
+
+	result := fromschema.FromTable(table, fields, nil, "")
+
+	c.Assert(result.Columns, qt.HasLen, 1)
+	c.Assert(result.Columns[0].Primary, qt.IsFalse)
+	c.Assert(result.Constraints, qt.HasLen, 1)
+	c.Assert(result.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)
+	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"id"})
+	c.Assert(result.Constraints[0].ColumnParts, qt.DeepEquals, []ast.ConstraintColumn{{
+		Name:   "id",
+		Prefix: "7",
+		Desc:   true,
+	}})
+}
+
 func TestFromDatabase_TableLevelConstraints(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -246,6 +246,7 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 	for _, constraint := range table.Constraints {
 		if constraint.Type == ast.PrimaryKeyConstraint {
 			tableSchema.PrimaryKey = constraint.Columns
+			tableSchema.PrimaryKeyParts = toPrimaryKeyParts(constraint)
 			break // Only one primary key constraint per table
 		}
 	}
@@ -278,6 +279,25 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 	}
 
 	return tableSchema
+}
+
+func toPrimaryKeyParts(constraint *ast.ConstraintNode) []goschema.PrimaryKeyPart {
+	if len(constraint.ColumnParts) == 0 {
+		parts := make([]goschema.PrimaryKeyPart, 0, len(constraint.Columns))
+		for _, column := range constraint.Columns {
+			parts = append(parts, goschema.PrimaryKeyPart{Name: column})
+		}
+		return parts
+	}
+	parts := make([]goschema.PrimaryKeyPart, 0, len(constraint.ColumnParts))
+	for _, column := range constraint.ColumnParts {
+		parts = append(parts, goschema.PrimaryKeyPart{
+			Name:   column.Name,
+			Prefix: column.Prefix,
+			Desc:   column.Desc,
+		})
+	}
+	return parts
 }
 
 // ToIndex converts an ast.IndexNode to a goschema.Index for database index definitions.

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -304,6 +304,30 @@ func TestToTable_CompositePrimaryKey(t *testing.T) {
 	c.Assert(result.PrimaryKey[1], qt.Equals, "role_id")
 }
 
+func TestToTable_PrimaryKeyParts(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("tokens").
+		AddConstraint(&ast.ConstraintNode{
+			Type:    ast.PrimaryKeyConstraint,
+			Columns: []string{"id"},
+			ColumnParts: []ast.ConstraintColumn{{
+				Name:   "id",
+				Prefix: "7",
+				Desc:   true,
+			}},
+		})
+
+	result := toschema.ToTable(table, "")
+
+	c.Assert(result.PrimaryKey, qt.DeepEquals, []string{"id"})
+	c.Assert(result.PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{{
+		Name:   "id",
+		Prefix: "7",
+		Desc:   true,
+	}})
+}
+
 func TestToTable_PlatformSource(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -329,15 +329,25 @@ type Extension struct {
 //	    RoleID int64
 //	}
 type Table struct {
-	StructName string                       // Name of the Go struct this table represents
-	Name       string                       // Database table name
-	Schema     string                       // Optional database schema/namespace (PostgreSQL-style)
-	Engine     string                       // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
-	Comment    string                       // Table comment/description
-	PrimaryKey []string                     // Composite primary key column names
-	Checks     []string                     // Table-level check constraints
-	CustomSQL  string                       // Custom SQL to append to CREATE TABLE
-	Overrides  map[string]map[string]string // Platform-specific overrides
+	StructName string   // Name of the Go struct this table represents
+	Name       string   // Database table name
+	Schema     string   // Optional database schema/namespace (PostgreSQL-style)
+	Engine     string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
+	Comment    string   // Table comment/description
+	PrimaryKey []string // Composite primary key column names
+	// PrimaryKeyParts carries dialect-specific metadata for composite primary
+	// key elements, such as MySQL prefix lengths and DESC ordering.
+	PrimaryKeyParts []PrimaryKeyPart
+	Checks          []string                     // Table-level check constraints
+	CustomSQL       string                       // Custom SQL to append to CREATE TABLE
+	Overrides       map[string]map[string]string // Platform-specific overrides
+}
+
+// PrimaryKeyPart represents one column reference inside a table primary key.
+type PrimaryKeyPart struct {
+	Name   string // Column name
+	Prefix string // MySQL index prefix length
+	Desc   bool   // Whether the column is ordered DESC
 }
 
 // QualifiedName returns the schema-qualified database table name when a schema


### PR DESCRIPTION
## Summary
- parse Atlas HCL primary_key on blocks with column, prefix, and desc metadata
- carry primary key part metadata through goschema and AST conversion
- render prefix/DESC primary keys as table-level constraints without duplicate inline primary keys

## Validation
- gopls diagnostics on touched files
- gopls vulncheck ./...
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/atlashcl
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/convert/fromschema
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/convert/toschema
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/...
- env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./... (escalated because sandbox blocks local TCP listen in dbschema tests)