### PR TITLE
Support Atlas HCL schema attributes

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -112,6 +112,10 @@ type CreateSchemaNode struct {
 	IfNotExists bool
 	// Comment is an optional schema comment.
 	Comment string
+	// Charset is an optional default character set for MySQL-compatible dialects.
+	Charset string
+	// Collate is an optional default collation for MySQL-compatible dialects.
+	Collate string
 }
 
 // NewCreateSchema creates a new CREATE SCHEMA node.

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -66,6 +66,8 @@ func (p *parser) parseBody(body *hclsyntax.Body) error {
 			p.db.Schemas = append(p.db.Schemas, goschema.Schema{
 				Name:    block.Labels[0],
 				Comment: p.optionalString(block.Body.Attributes["comment"]),
+				Charset: p.optionalString(block.Body.Attributes["charset"]),
+				Collate: p.optionalString(block.Body.Attributes["collate"]),
 			})
 		case "table":
 			if err := p.parseTable(block); err != nil {
@@ -400,6 +402,8 @@ func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"comment": true,
+		"charset": true,
+		"collate": true,
 	}, "schema")
 }
 

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -112,6 +112,26 @@ schema "public" {
 	c.Assert(sql, qt.Contains, `COMMENT ON SCHEMA public IS 'This is a test schema';`)
 }
 
+func TestParseSchemaCharsetAndCollate(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "app" {
+  charset = "utf8mb4"
+  collate = "utf8mb4_0900_ai_ci"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Schemas, qt.DeepEquals, []goschema.Schema{{
+		Name:    "app",
+		Charset: "utf8mb4",
+		Collate: "utf8mb4_0900_ai_ci",
+	}})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, `CREATE SCHEMA IF NOT EXISTS app DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;`)
+}
+
 func TestParseCompositePrimaryKeyAndForeignKey(t *testing.T) {
 	c := qt.New(t)
 
@@ -230,10 +250,10 @@ func TestParseRejectsUnsupportedSchemaAttributes(t *testing.T) {
 
 	_, err := atlashcl.Parse([]byte(`
 schema "main" {
-  charset = "utf8mb4"
+  owner = "app"
 }
 `), "schema.hcl")
-	c.Assert(err, qt.ErrorMatches, `.*unsupported schema attribute "charset".*`)
+	c.Assert(err, qt.ErrorMatches, `.*unsupported schema attribute "owner".*`)
 }
 
 func TestParseRejectsUnsupportedIndexPartAttributes(t *testing.T) {

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1157,6 +1157,8 @@ func appendSchemaStatements(statements *ast.StatementList, schemas []goschema.Sc
 			Name:        schema.Name,
 			IfNotExists: true,
 			Comment:     schema.Comment,
+			Charset:     schema.Charset,
+			Collate:     schema.Collate,
 		})
 	}
 }

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -518,6 +518,8 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 			database.Schemas = append(database.Schemas, goschema.Schema{
 				Name:    node.Name,
 				Comment: node.Comment,
+				Charset: node.Charset,
+				Collate: node.Collate,
 			})
 
 		case *ast.EnumNode:

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -54,6 +54,8 @@ type Database struct {
 type Schema struct {
 	Name    string // Schema name, e.g. "public"
 	Comment string // Optional schema comment/description
+	Charset string // Optional default character set (MySQL/MariaDB)
+	Collate string // Optional default collation (MySQL/MariaDB)
 }
 
 // EmbeddedField represents an embedded field in a Go struct that should be handled specially

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -52,10 +52,17 @@ func TestMySQL_CreateNamespaceStatements(t *testing.T) {
 	c := qt.New(t)
 	out := renderMySQL(t,
 		&ast.CreateSchemaNode{Name: "`bc_test`", IfNotExists: true},
+		&ast.CreateSchemaNode{
+			Name:        "`tenant`",
+			IfNotExists: true,
+			Charset:     "utf8mb4",
+			Collate:     "utf8mb4_0900_ai_ci",
+		},
 		&ast.CreateDatabaseNode{Name: "`atlantis`"},
 	)
 
 	c.Assert(out, qt.Contains, "CREATE SCHEMA IF NOT EXISTS `bc_test`;")
+	c.Assert(out, qt.Contains, "CREATE SCHEMA IF NOT EXISTS `tenant` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;")
 	c.Assert(out, qt.Contains, "CREATE DATABASE `atlantis`;")
 }
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -152,7 +152,15 @@ func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
 	if node.IfNotExists {
 		guard = " IF NOT EXISTS"
 	}
-	r.w.WriteLinef("CREATE SCHEMA%s %s;", guard, node.Name)
+	var parts []string
+	parts = append(parts, "CREATE SCHEMA"+guard, node.Name)
+	if node.Charset != "" {
+		parts = append(parts, "DEFAULT CHARACTER SET", node.Charset)
+	}
+	if node.Collate != "" {
+		parts = append(parts, "COLLATE", node.Collate)
+	}
+	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- preserve Atlas HCL schema `charset` and `collate` attributes in `goschema`
- carry those attributes through AST conversion both ways
- render MySQL-compatible `CREATE SCHEMA` statements with default character set and collation

## Why

Atlas HCL fixtures can define MySQL schema-level charset/collation. Ptah parsed the schema block but rejected those attributes, which blocked real HCL-source conformance fixtures before reaching table rendering.

## Validation

- `go_vulncheck ./...` via gopls
- `go_diagnostics` via gopls on touched files
- `env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/renderer/dialects/mysql`
- `env GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...`
