### PR TITLE
Support SQLite table options from Atlas HCL

### DIFF
--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -89,11 +89,13 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 
 	table := goschema.Table{
-		StructName: block.Labels[0],
-		Name:       block.Labels[0],
-		Schema:     p.optionalRefName(block.Body.Attributes["schema"]),
-		Engine:     p.optionalString(block.Body.Attributes["engine"]),
-		Comment:    p.optionalString(block.Body.Attributes["comment"]),
+		StructName:   block.Labels[0],
+		Name:         block.Labels[0],
+		Schema:       p.optionalRefName(block.Body.Attributes["schema"]),
+		Engine:       p.optionalString(block.Body.Attributes["engine"]),
+		Strict:       p.optionalBool(block.Body.Attributes["strict"], false),
+		WithoutRowID: p.optionalBool(block.Body.Attributes["without_rowid"], false),
+		Comment:      p.optionalString(block.Body.Attributes["comment"]),
 	}
 
 	fieldsStart := len(p.db.Fields)
@@ -409,9 +411,11 @@ func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
 
 func (p *parser) rejectUnsupportedTableAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"schema":  true,
-		"engine":  true,
-		"comment": true,
+		"schema":        true,
+		"engine":        true,
+		"strict":        true,
+		"without_rowid": true,
+		"comment":       true,
 	}, "table")
 }
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -88,13 +88,22 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 		return p.blockError(block, "table block requires exactly one label")
 	}
 
+	strict, err := p.optionalTableBool(block, "strict", false)
+	if err != nil {
+		return err
+	}
+	withoutRowID, err := p.optionalTableBool(block, "without_rowid", false)
+	if err != nil {
+		return err
+	}
+
 	table := goschema.Table{
 		StructName:   block.Labels[0],
 		Name:         block.Labels[0],
 		Schema:       p.optionalRefName(block.Body.Attributes["schema"]),
 		Engine:       p.optionalString(block.Body.Attributes["engine"]),
-		Strict:       p.optionalBool(block.Body.Attributes["strict"], false),
-		WithoutRowID: p.optionalBool(block.Body.Attributes["without_rowid"], false),
+		Strict:       strict,
+		WithoutRowID: withoutRowID,
 		Comment:      p.optionalString(block.Body.Attributes["comment"]),
 	}
 
@@ -533,6 +542,18 @@ func (p *parser) optionalBool(attr *hclsyntax.Attribute, fallback bool) bool {
 		return fallback
 	}
 	return value.True()
+}
+
+func (p *parser) optionalTableBool(block *hclsyntax.Block, name string, fallback bool) (bool, error) {
+	attr := block.Body.Attributes[name]
+	if attr == nil {
+		return fallback, nil
+	}
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.Bool {
+		return false, p.blockError(block, "table attribute %q must be a bool", name)
+	}
+	return value.True(), nil
 }
 
 func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -93,6 +93,31 @@ table "tokens" {
 	c.Assert(sql, qt.Not(qt.Contains), "id tinytext PRIMARY KEY")
 }
 
+func TestParseSQLiteTableOptions(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "events" {
+  schema = schema.main
+  strict = true
+  without_rowid = true
+  column "id" {
+    null = false
+    type = integer
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Strict, qt.IsTrue)
+	c.Assert(db.Tables[0].WithoutRowID, qt.IsTrue)
+}
+
 func TestParseSchemaComment(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -118,6 +118,20 @@ table "events" {
 	c.Assert(db.Tables[0].WithoutRowID, qt.IsTrue)
 }
 
+func TestParseSQLiteTableOptionsRejectNonBool(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "events" {
+  strict = "true"
+  column "id" {
+    type = integer
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*table attribute "strict" must be a bool.*`)
+}
+
 func TestParseSchemaComment(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -53,6 +53,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -414,6 +415,8 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	}
 	tableComment := table.Comment
 	tableEngine := table.Engine
+	tableStrict := table.Strict
+	tableWithoutRowID := table.WithoutRowID
 
 	platformOverrides, exists := table.Overrides[targetPlatform]
 	if !exists {
@@ -428,9 +431,19 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	if engineOverride, ok := platformOverrides["engine"]; ok {
 		tableEngine = engineOverride
 	}
+	if strictOverride, ok := platformOverrides["strict"]; ok {
+		if strict, err := strconv.ParseBool(strictOverride); err == nil {
+			tableStrict = strict
+		}
+	}
+	if withoutRowIDOverride, ok := platformOverrides["without_rowid"]; ok {
+		if withoutRowID, err := strconv.ParseBool(withoutRowIDOverride); err == nil {
+			tableWithoutRowID = withoutRowID
+		}
+	}
 	// Apply any other platform-specific options
 	for key, value := range platformOverrides {
-		if key != "comment" && key != "engine" {
+		if key != "comment" && key != "engine" && key != "strict" && key != "without_rowid" {
 			createTable.SetOption(strings.ToUpper(key), value)
 		}
 	}
@@ -438,6 +451,8 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	newTable := table
 	newTable.Comment = tableComment
 	newTable.Engine = tableEngine
+	newTable.Strict = tableStrict
+	newTable.WithoutRowID = tableWithoutRowID
 	return newTable
 }
 
@@ -533,6 +548,14 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	// Set database-specific options (using potentially overridden value)
 	if tableEngine != "" {
 		createTable.SetOption("ENGINE", tableEngine)
+	}
+	if targetPlatform == "sqlite" {
+		if newTable.WithoutRowID {
+			createTable.SetOption("WITHOUT_ROWID", "true")
+		}
+		if newTable.Strict {
+			createTable.SetOption("STRICT", "true")
+		}
 	}
 
 	// Add columns for fields that belong to this table

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -1090,6 +1090,44 @@ func TestFromTable_PlatformOverrides(t *testing.T) {
 					table.Comment == "Default comment" // Uses default
 			},
 		},
+		{
+			name: "SQLite strict and without rowid options",
+			table: goschema.Table{
+				StructName:   "Event",
+				Name:         "events",
+				Strict:       true,
+				WithoutRowID: true,
+			},
+			fields:         []goschema.Field{},
+			targetPlatform: "sqlite",
+			expected: func(table *ast.CreateTableNode) bool {
+				return table.Name == "events" &&
+					table.Options["STRICT"] == "true" &&
+					table.Options["WITHOUT_ROWID"] == "true"
+			},
+		},
+		{
+			name: "SQLite table options use platform overrides",
+			table: goschema.Table{
+				StructName:   "Event",
+				Name:         "events",
+				Strict:       true,
+				WithoutRowID: true,
+				Overrides: map[string]map[string]string{
+					"sqlite": {
+						"strict":        "false",
+						"without_rowid": "false",
+					},
+				},
+			},
+			fields:         []goschema.Field{},
+			targetPlatform: "sqlite",
+			expected: func(table *ast.CreateTableNode) bool {
+				_, strict := table.Options["STRICT"]
+				_, withoutRowID := table.Options["WITHOUT_ROWID"]
+				return table.Name == "events" && !strict && !withoutRowID
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -42,6 +42,7 @@
 package toschema
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -241,6 +242,8 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 	if engine, exists := table.Options["ENGINE"]; exists {
 		tableSchema.Engine = engine
 	}
+	_, tableSchema.Strict = table.Options["STRICT"]
+	_, tableSchema.WithoutRowID = table.Options["WITHOUT_ROWID"]
 
 	// Extract composite primary key from constraints
 	for _, constraint := range table.Constraints {
@@ -258,7 +261,7 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 		// Store platform-specific options as overrides
 		platformOverrides := make(map[string]string)
 		for key, value := range table.Options {
-			if key != "ENGINE" { // ENGINE is handled separately
+			if key != "ENGINE" && key != "STRICT" && key != "WITHOUT_ROWID" {
 				platformOverrides[strings.ToLower(key)] = value
 			}
 		}
@@ -694,6 +697,12 @@ func MergeTableOverrides(baseTable goschema.Table, platformTables map[string]gos
 		// Check for comment differences
 		if platformTable.Comment != baseTable.Comment {
 			platformOverrides["comment"] = platformTable.Comment
+		}
+		if platformTable.Strict != baseTable.Strict {
+			platformOverrides["strict"] = strconv.FormatBool(platformTable.Strict)
+		}
+		if platformTable.WithoutRowID != baseTable.WithoutRowID {
+			platformOverrides["without_rowid"] = strconv.FormatBool(platformTable.WithoutRowID)
 		}
 
 		// Store platform overrides if any differences were found

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -242,8 +242,12 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 	if engine, exists := table.Options["ENGINE"]; exists {
 		tableSchema.Engine = engine
 	}
-	_, tableSchema.Strict = table.Options["STRICT"]
-	_, tableSchema.WithoutRowID = table.Options["WITHOUT_ROWID"]
+	if strict, exists := table.Options["STRICT"]; exists {
+		tableSchema.Strict, _ = strconv.ParseBool(strict)
+	}
+	if withoutRowID, exists := table.Options["WITHOUT_ROWID"]; exists {
+		tableSchema.WithoutRowID, _ = strconv.ParseBool(withoutRowID)
+	}
 
 	// Extract composite primary key from constraints
 	for _, constraint := range table.Constraints {

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -291,6 +291,18 @@ func TestToTable_BasicTable(t *testing.T) {
 					table.WithoutRowID
 			},
 		},
+		{
+			name: "SQLite false table options",
+			table: ast.NewCreateTable("events").
+				SetOption("STRICT", "false").
+				SetOption("WITHOUT_ROWID", "false"),
+			sourcePlatform: "sqlite",
+			expected: func(table goschema.Table) bool {
+				return table.Name == "events" &&
+					!table.Strict &&
+					!table.WithoutRowID
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -227,9 +227,10 @@ func TestToField_PlatformSource(t *testing.T) {
 
 func TestToTable_BasicTable(t *testing.T) {
 	tests := []struct {
-		name     string
-		table    *ast.CreateTableNode
-		expected func(goschema.Table) bool
+		name           string
+		table          *ast.CreateTableNode
+		sourcePlatform string
+		expected       func(goschema.Table) bool
 	}{
 		{
 			name:  "basic table",
@@ -278,12 +279,24 @@ func TestToTable_BasicTable(t *testing.T) {
 					table.Comment == "Product catalog"
 			},
 		},
+		{
+			name: "SQLite table options",
+			table: ast.NewCreateTable("events").
+				SetOption("STRICT", "true").
+				SetOption("WITHOUT_ROWID", "true"),
+			sourcePlatform: "sqlite",
+			expected: func(table goschema.Table) bool {
+				return table.Name == "events" &&
+					table.Strict &&
+					table.WithoutRowID
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			result := toschema.ToTable(test.table, "")
+			result := toschema.ToTable(test.table, test.sourcePlatform)
 			c.Assert(test.expected(result), qt.IsTrue)
 		})
 	}
@@ -619,6 +632,13 @@ func TestMergeTableOverrides_BasicMerging(t *testing.T) {
 			Engine:  "MyISAM",
 			Comment: "Product catalog",
 		},
+		"sqlite": {
+			Name:         "products",
+			Engine:       "InnoDB",
+			Comment:      "Product catalog",
+			Strict:       true,
+			WithoutRowID: true,
+		},
 	}
 
 	result := toschema.MergeTableOverrides(baseTable, platformTables)
@@ -626,7 +646,7 @@ func TestMergeTableOverrides_BasicMerging(t *testing.T) {
 	c.Assert(result.Name, qt.Equals, "products")
 	c.Assert(result.Engine, qt.Equals, "InnoDB") // Base engine unchanged
 	c.Assert(result.Overrides, qt.IsNotNil)
-	c.Assert(result.Overrides, qt.HasLen, 2)
+	c.Assert(result.Overrides, qt.HasLen, 3)
 
 	// Check MariaDB overrides
 	c.Assert(result.Overrides["mariadb"]["comment"], qt.Equals, "MariaDB product catalog")
@@ -635,6 +655,10 @@ func TestMergeTableOverrides_BasicMerging(t *testing.T) {
 	// Check MySQL overrides
 	c.Assert(result.Overrides["mysql"]["engine"], qt.Equals, "MyISAM")
 	c.Assert(result.Overrides["mysql"]["comment"], qt.Equals, "") // Same as base
+
+	// Check SQLite overrides
+	c.Assert(result.Overrides["sqlite"]["strict"], qt.Equals, "true")
+	c.Assert(result.Overrides["sqlite"]["without_rowid"], qt.Equals, "true")
 }
 
 func TestGenerateStructName_BasicConversions(t *testing.T) {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -331,12 +331,14 @@ type Extension struct {
 //	    RoleID int64
 //	}
 type Table struct {
-	StructName string   // Name of the Go struct this table represents
-	Name       string   // Database table name
-	Schema     string   // Optional database schema/namespace (PostgreSQL-style)
-	Engine     string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
-	Comment    string   // Table comment/description
-	PrimaryKey []string // Composite primary key column names
+	StructName   string   // Name of the Go struct this table represents
+	Name         string   // Database table name
+	Schema       string   // Optional database schema/namespace (PostgreSQL-style)
+	Engine       string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
+	Strict       bool     // SQLite STRICT table option
+	WithoutRowID bool     // SQLite WITHOUT ROWID table option
+	Comment      string   // Table comment/description
+	PrimaryKey   []string // Composite primary key column names
 	// PrimaryKeyParts carries dialect-specific metadata for composite primary
 	// key elements, such as MySQL prefix lengths and DESC ordering.
 	PrimaryKeyParts []PrimaryKeyPart

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -146,6 +146,8 @@ for _, stmt := range statements.Statements {
 - `CHARSET=utf8mb4` / `CHARACTER SET=utf8mb4`
 - `COLLATE=utf8mb4_unicode_ci`
 - `COMMENT='table description'`
+- SQLite `WITHOUT ROWID`
+- SQLite `STRICT`
 
 ### CREATE TABLE ... SELECT
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2885,6 +2885,10 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 		}
 
 		p.skipWhitespace()
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			continue
+		}
 
 		if p.current.Type != lexer.TokenIdentifier {
 			break
@@ -2917,6 +2921,11 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 		case "TABLESPACE":
 			// Handle PostgreSQL TABLESPACE
 			err = p.handleTablespace(table)
+		case "WITHOUT":
+			err = p.handleSQLiteWithoutRowID(table)
+		case "STRICT":
+			table.SetOption("STRICT", "true")
+			p.advance()
 		default:
 			// Unknown option, stop parsing
 			err = fmt.Errorf("unsupported table option: %s at position %d", option, p.current.Start)
@@ -2927,6 +2936,17 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 		}
 	}
 
+	return nil
+}
+
+func (p *Parser) handleSQLiteWithoutRowID(table *ast.CreateTableNode) error {
+	if err := p.expect(lexer.TokenIdentifier, "WITHOUT"); err != nil {
+		return err
+	}
+	if err := p.expect(lexer.TokenIdentifier, "ROWID"); err != nil {
+		return fmt.Errorf("expected ROWID after WITHOUT: %w", err)
+	}
+	table.SetOption("WITHOUT_ROWID", "true")
 	return nil
 }
 

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -100,6 +100,22 @@ func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 	c.Assert(createTable.Comment, qt.Equals, "'Product catalog'")
 }
 
+func TestParser_ParseCreateTable_WithSQLiteTableOptions(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE TABLE events (id integer NOT NULL, PRIMARY KEY (id)) WITHOUT ROWID, STRICT;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Name, qt.Equals, "events")
+	c.Assert(createTable.Options["WITHOUT_ROWID"], qt.Equals, "true")
+	c.Assert(createTable.Options["STRICT"], qt.Equals, "true")
+}
+
 func TestParser_ParseCreateTable_IfNotExists(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- parse Atlas HCL table `strict` and `without_rowid` attributes into schema metadata
- carry SQLite table options through schema-to-AST and AST-to-schema conversion
- parse SQLite `CREATE TABLE ... WITHOUT ROWID, STRICT` suffixes
- document the SQLite table options accepted by the SQL parser

## Validation
- `go test ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/parser ./core/goschema`
- `go test ./core/...`
- `go test ./...` (escalated because dbschema tests bind 127.0.0.1)
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`

## Conformance
- enables the Atlas SQLite `table-options.txtar` fixture when the conformance harness is updated
- local conformance check with temporary local Ptah replace reduced unwaived gaps from 144 to 143; full gate remains red as expected
