### PR TITLE
Support structured index parts from Atlas HCL

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -418,6 +418,24 @@ func (n *ConstraintNode) Accept(visitor Visitor) error {
 	return visitor.VisitConstraint(n)
 }
 
+// IndexPart represents one column or expression inside a CREATE INDEX column list.
+type IndexPart struct {
+	// Name is the indexed column name.
+	Name string
+	// Expr is a raw indexed expression. It is mutually exclusive with Name.
+	Expr string
+	// Desc indicates DESC ordering for this index part.
+	Desc bool
+}
+
+// Reference returns the column name or expression represented by the index part.
+func (p IndexPart) Reference() string {
+	if p.Expr != "" {
+		return p.Expr
+	}
+	return p.Name
+}
+
 // IndexNode represents a CREATE INDEX statement.
 //
 // Indexes can be unique or non-unique and may specify an index type
@@ -430,6 +448,9 @@ type IndexNode struct {
 	Table string
 	// Columns contains the list of column names to include in the index
 	Columns []string
+	// Parts contains structured index elements. When empty, Columns remains
+	// the source of truth for legacy callers.
+	Parts []IndexPart
 	// Unique indicates whether this is a unique index
 	Unique bool
 	// Type specifies the index type (BTREE, HASH, GIN, GIST, etc. for
@@ -612,6 +633,24 @@ func NewIndex(name, table string, columns ...string) *IndexNode {
 // Accept implements the Node interface for IndexNode.
 func (n *IndexNode) Accept(visitor Visitor) error {
 	return visitor.VisitIndex(n)
+}
+
+// SetParts replaces the structured index parts and returns the index for chaining.
+func (n *IndexNode) SetParts(parts []IndexPart) *IndexNode {
+	n.Parts = slices.Clone(parts)
+	return n
+}
+
+// EffectiveParts returns structured index parts, falling back to Columns for legacy callers.
+func (n *IndexNode) EffectiveParts() []IndexPart {
+	if len(n.Parts) > 0 {
+		return slices.Clone(n.Parts)
+	}
+	parts := make([]IndexPart, 0, len(n.Columns))
+	for _, column := range n.Columns {
+		parts = append(parts, IndexPart{Name: column})
+	}
+	return parts
 }
 
 // SetUnique marks the index as unique and returns the index for chaining.

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -239,6 +239,22 @@ func TestNewIndex(t *testing.T) {
 	c.Assert(index.Unique, qt.IsFalse)
 }
 
+func TestIndexNode_EffectiveParts(t *testing.T) {
+	c := qt.New(t)
+
+	index := ast.NewIndex("idx_users_email", "users", "email")
+	c.Assert(index.EffectiveParts(), qt.DeepEquals, []ast.IndexPart{{Name: "email"}})
+
+	index.SetParts([]ast.IndexPart{
+		{Name: "email", Desc: true},
+		{Expr: "lower(name)"},
+	})
+	c.Assert(index.EffectiveParts(), qt.DeepEquals, []ast.IndexPart{
+		{Name: "email", Desc: true},
+		{Expr: "lower(name)"},
+	})
+}
+
 func TestIndexNode_Accept(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -188,12 +188,16 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if len(block.Labels) != 1 {
 		return goschema.Index{}, p.blockError(block, "index block requires exactly one label")
 	}
+	if block.Body.Attributes["columns"] != nil && len(block.Body.Blocks) > 0 {
+		return goschema.Index{}, p.blockError(block.Body.Blocks[0], "index cannot mix columns attribute with on blocks")
+	}
 	columns, err := p.parseColumnsAttr(block, "columns")
 	if err != nil {
 		return goschema.Index{}, err
 	}
+	var parts []goschema.IndexPart
 	if len(columns) == 0 {
-		columns, err = p.parseIndexParts(block)
+		columns, parts, err = p.parseIndexParts(block)
 		if err != nil {
 			return goschema.Index{}, err
 		}
@@ -208,6 +212,7 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		StructName: structName,
 		Name:       block.Labels[0],
 		Fields:     columns,
+		Parts:      parts,
 		Unique:     p.optionalBool(block.Body.Attributes["unique"], false),
 		Type:       p.optionalString(block.Body.Attributes["type"]),
 		Condition:  p.optionalString(block.Body.Attributes["where"]),
@@ -215,22 +220,39 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	}, nil
 }
 
-func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, error) {
+func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.IndexPart, error) {
 	var columns []string
+	var parts []goschema.IndexPart
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "on" {
-			return nil, p.blockError(nested, "unsupported index block %q", nested.Type)
+			return nil, nil, p.blockError(nested, "unsupported index block %q", nested.Type)
 		}
 		if err := p.rejectUnsupportedIndexOnAttrs(nested); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		attr := nested.Body.Attributes["column"]
-		if attr == nil {
-			return nil, p.blockError(nested, "index on block requires column")
+		columnAttr := nested.Body.Attributes["column"]
+		exprAttr := nested.Body.Attributes["expr"]
+		if columnAttr == nil && exprAttr == nil {
+			return nil, nil, p.blockError(nested, "index on block requires column or expr")
 		}
-		columns = append(columns, p.columnNameFromExpr(attr))
+		if columnAttr != nil && exprAttr != nil {
+			return nil, nil, p.blockError(nested, "index on block cannot set both column and expr")
+		}
+		desc, err := p.optionalIndexOnBool(nested, "desc", false)
+		if err != nil {
+			return nil, nil, err
+		}
+		if columnAttr != nil {
+			column := p.columnNameFromExpr(columnAttr)
+			columns = append(columns, column)
+			parts = append(parts, goschema.IndexPart{Name: column, Desc: desc})
+			continue
+		}
+		expr := p.exprString(exprAttr)
+		columns = append(columns, expr)
+		parts = append(parts, goschema.IndexPart{Expr: expr, Desc: desc})
 	}
-	return columns, nil
+	return columns, parts, nil
 }
 
 func (p *parser) parsePrimaryKey(block *hclsyntax.Block) ([]string, []goschema.PrimaryKeyPart, error) {
@@ -465,6 +487,8 @@ func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 func (p *parser) rejectUnsupportedIndexOnAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"column": true,
+		"expr":   true,
+		"desc":   true,
 	}, "index on")
 }
 
@@ -552,6 +576,18 @@ func (p *parser) optionalTableBool(block *hclsyntax.Block, name string, fallback
 	value, diags := attr.Expr.Value(nil)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return false, p.blockError(block, "table attribute %q must be a bool", name)
+	}
+	return value.True(), nil
+}
+
+func (p *parser) optionalIndexOnBool(block *hclsyntax.Block, name string, fallback bool) (bool, error) {
+	attr := block.Body.Attributes[name]
+	if attr == nil {
+		return fallback, nil
+	}
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.Bool {
+		return false, p.blockError(block, "index on attribute %q must be a bool", name)
 	}
 	return value.True(), nil
 }

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -132,6 +132,65 @@ table "events" {
 	c.Assert(err, qt.ErrorMatches, `.*table attribute "strict" must be a bool.*`)
 }
 
+func TestParseIndexParts(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "rank" {
+    type = int
+  }
+  column "score" {
+    type = int
+  }
+  index "rank_score_idx" {
+    on {
+      column = column.rank
+    }
+    on {
+      column = column.score
+      desc = true
+    }
+  }
+  index "full_name" {
+    on {
+      expr = "first_name || ' ' || last_name"
+    }
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 2)
+	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"rank", "score"})
+	c.Assert(db.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
+		{Name: "rank"},
+		{Name: "score", Desc: true},
+	})
+	c.Assert(db.Indexes[1].Fields, qt.DeepEquals, []string{"first_name || ' ' || last_name"})
+	c.Assert(db.Indexes[1].Parts, qt.DeepEquals, []goschema.IndexPart{
+		{Expr: "first_name || ' ' || last_name"},
+	})
+}
+
+func TestParseRejectsIndexColumnsAndOnBlocks(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "email" {
+    type = varchar(255)
+  }
+  index "idx_users_email" {
+    columns = [column.email]
+    on {
+      column = column.email
+    }
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*index cannot mix columns attribute with on blocks.*`)
+}
+
 func TestParseSchemaComment(t *testing.T) {
 	c := qt.New(t)
 
@@ -312,6 +371,57 @@ table "users" {
 }
 `), "schema.hcl")
 	c.Assert(err, qt.ErrorMatches, `.*unsupported index on attribute "prefix".*`)
+}
+
+func TestParseRejectsInvalidIndexParts(t *testing.T) {
+	tests := []struct {
+		name  string
+		part  string
+		match string
+	}{
+		{
+			name: "missing column and expr",
+			part: `
+    on {
+      desc = true
+    }`,
+			match: `.*index on block requires column or expr.*`,
+		},
+		{
+			name: "column and expr together",
+			part: `
+    on {
+      column = column.email
+      expr = "lower(email)"
+    }`,
+			match: `.*index on block cannot set both column and expr.*`,
+		},
+		{
+			name: "non-bool desc",
+			part: `
+    on {
+      column = column.email
+      desc = "true"
+    }`,
+			match: `.*index on attribute "desc" must be a bool.*`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "email" {
+    type = varchar(255)
+  }
+  index "idx_users_email" {`+test.part+`
+  }
+}
+`), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
 }
 
 func TestParseRejectsForeignKeyWithUnknownLocalColumn(t *testing.T) {

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -715,7 +715,10 @@ func FromIndex(index goschema.Index) *ast.IndexNode {
 		tableName = index.StructName
 	}
 
-	indexNode := ast.NewIndex(index.Name, tableName, index.Fields...)
+	indexNode := ast.NewIndex(index.Name, tableName, indexFields(index)...)
+	if len(index.Parts) > 0 {
+		indexNode.SetParts(toASTIndexParts(index.Parts))
+	}
 
 	// Set unique constraint
 	if index.Unique {
@@ -1211,7 +1214,10 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 		}
 	}
 
-	indexNode := ast.NewIndex(index.Name, tableName, index.Fields...)
+	indexNode := ast.NewIndex(index.Name, tableName, indexFields(index)...)
+	if len(index.Parts) > 0 {
+		indexNode.SetParts(toASTIndexParts(index.Parts))
+	}
 
 	// Set unique constraint
 	if index.Unique {
@@ -1244,6 +1250,33 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 	indexNode.IfNotExists = true
 
 	return indexNode
+}
+
+func toASTIndexParts(parts []goschema.IndexPart) []ast.IndexPart {
+	astParts := make([]ast.IndexPart, 0, len(parts))
+	for _, part := range parts {
+		astParts = append(astParts, ast.IndexPart{
+			Name: part.Name,
+			Expr: part.Expr,
+			Desc: part.Desc,
+		})
+	}
+	return astParts
+}
+
+func indexFields(index goschema.Index) []string {
+	if len(index.Parts) == 0 {
+		return index.Fields
+	}
+	fields := make([]string, 0, len(index.Parts))
+	for _, part := range index.Parts {
+		if part.Expr != "" {
+			fields = append(fields, part.Expr)
+			continue
+		}
+		fields = append(fields, part.Name)
+	}
+	return fields
 }
 
 // ParseForeignKeyReference parses a foreign key reference string into an ast.ForeignKeyRef.

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -671,6 +671,28 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.Comment == "Index for price range queries"
 			},
 		},
+		{
+			name: "structured index parts",
+			index: goschema.Index{
+				Name:       "idx_users_rank_name",
+				StructName: "users",
+				Fields:     []string{"stale_rank", "stale_name"},
+				Parts: []goschema.IndexPart{
+					{Name: "rank", Desc: true},
+					{Expr: "lower(name)"},
+				},
+			},
+			expected: func(idx *ast.IndexNode) bool {
+				return idx.Name == "idx_users_rank_name" &&
+					idx.Table == "users" &&
+					len(idx.Columns) == 2 &&
+					idx.Columns[0] == "rank" &&
+					idx.Columns[1] == "lower(name)" &&
+					len(idx.Parts) == 2 &&
+					idx.Parts[0] == (ast.IndexPart{Name: "rank", Desc: true}) &&
+					idx.Parts[1] == (ast.IndexPart{Expr: "lower(name)"})
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -355,7 +355,8 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 	return goschema.Index{
 		Name:       index.Name,
 		StructName: index.Table, // Use table name as struct name
-		Fields:     index.Columns,
+		Fields:     indexFieldNames(index),
+		Parts:      toSchemaIndexParts(index.Parts),
 		Unique:     index.Unique,
 		Comment:    index.Comment,
 		// PostgreSQL-specific features
@@ -364,6 +365,29 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Operator:  index.Operator,
 		TableName: index.Table,
 	}
+}
+
+func indexFieldNames(index *ast.IndexNode) []string {
+	if len(index.Parts) == 0 {
+		return index.Columns
+	}
+	fields := make([]string, 0, len(index.Parts))
+	for _, part := range index.Parts {
+		fields = append(fields, part.Reference())
+	}
+	return fields
+}
+
+func toSchemaIndexParts(parts []ast.IndexPart) []goschema.IndexPart {
+	schemaParts := make([]goschema.IndexPart, 0, len(parts))
+	for _, part := range parts {
+		schemaParts = append(schemaParts, goschema.IndexPart{
+			Name: part.Name,
+			Expr: part.Expr,
+			Desc: part.Desc,
+		})
+	}
+	return schemaParts
 }
 
 // ToExtension converts an ast.ExtensionNode to a goschema.Extension for database extension definitions.

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -421,6 +421,24 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.Comment == "Index for price range queries"
 			},
 		},
+		{
+			name: "structured index parts",
+			index: ast.NewIndex("idx_users_rank_name", "users").
+				SetParts([]ast.IndexPart{
+					{Name: "rank", Desc: true},
+					{Expr: "lower(name)"},
+				}),
+			expected: func(index goschema.Index) bool {
+				return index.Name == "idx_users_rank_name" &&
+					index.StructName == "users" &&
+					len(index.Fields) == 2 &&
+					index.Fields[0] == "rank" &&
+					index.Fields[1] == "lower(name)" &&
+					len(index.Parts) == 2 &&
+					index.Parts[0] == (goschema.IndexPart{Name: "rank", Desc: true}) &&
+					index.Parts[1] == (goschema.IndexPart{Expr: "lower(name)"})
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -148,6 +148,13 @@ type Field struct {
 	Overrides      map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
 }
 
+// IndexPart represents one column or expression inside an index definition.
+type IndexPart struct {
+	Name string // Column name
+	Expr string // Raw index expression
+	Desc bool   // Whether this part is ordered DESC
+}
+
 // Index represents a database index definition parsed from Go struct annotations.
 // Indexes are used to improve query performance and enforce uniqueness constraints
 // on one or more columns.
@@ -209,8 +216,12 @@ type Index struct {
 	StructName string   // Name of the Go struct this index belongs to
 	Name       string   // Index name (e.g., "idx_users_email")
 	Fields     []string // Column names included in the index
-	Unique     bool     // Whether this is a unique index
-	Comment    string   // Index comment/description
+	// Parts carries structured index elements for dialect-specific metadata,
+	// such as DESC ordering and expression indexes. Fields remains the legacy
+	// column/expression list for compatibility.
+	Parts   []IndexPart
+	Unique  bool   // Whether this is a unique index
+	Comment string // Index comment/description
 
 	// Type carries the dialect-specific index type. For PostgreSQL this is
 	// GIN/GIST/BTREE/HASH; for ClickHouse data-skipping indexes it is

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -49,3 +49,17 @@ func TestMySQLRenderer_ConstraintColumnParts(t *testing.T) {
 
 	c.Assert(sql, qt.Contains, "PRIMARY KEY (`id` (7) DESC)")
 }
+
+func TestMySQLRenderer_IndexParts(t *testing.T) {
+	c := qt.New(t)
+
+	sql := renderMySQL(t,
+		ast.NewIndex("idx_users_rank", "users", "rank").
+			SetParts([]ast.IndexPart{{Name: "rank", Desc: true}}),
+		ast.NewIndex("idx_users_lower_name", "users", "lower(name)").
+			SetParts([]ast.IndexPart{{Expr: "lower(name)"}}),
+	)
+
+	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_rank ON users (rank DESC);")
+	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_lower_name ON users ((lower(name)));")
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -334,10 +334,25 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	parts = append(parts, node.Name)
 	parts = append(parts, "ON")
 	parts = append(parts, node.Table)
-	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(node.Columns, ", ")))
+	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(renderIndexParts(node.EffectiveParts()), ", ")))
 
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 	return nil
+}
+
+func renderIndexParts(parts []ast.IndexPart) []string {
+	specs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		spec := part.Reference()
+		if part.Expr != "" {
+			spec = fmt.Sprintf("(%s)", part.Expr)
+		}
+		if part.Desc {
+			spec += " DESC"
+		}
+		specs = append(specs, spec)
+	}
+	return specs
 }
 
 func mysqlIndexPrefixType(indexType string) string {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -458,10 +458,13 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 
 	// Add columns with optional operator class
 	var columnSpecs []string
-	for _, column := range node.Columns {
-		columnSpec := column
+	for _, part := range node.EffectiveParts() {
+		columnSpec := renderIndexPart(part)
 		if node.Operator != "" {
-			columnSpec = fmt.Sprintf("%s %s", column, node.Operator)
+			columnSpec = fmt.Sprintf("%s %s", columnSpec, node.Operator)
+		}
+		if part.Desc {
+			columnSpec += " DESC"
 		}
 		columnSpecs = append(columnSpecs, columnSpec)
 	}
@@ -476,6 +479,13 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 
 	return nil
+}
+
+func renderIndexPart(part ast.IndexPart) string {
+	if part.Expr != "" {
+		return fmt.Sprintf("(%s)", part.Expr)
+	}
+	return part.Name
 }
 
 func (r *Renderer) VisitExtension(node *ast.ExtensionNode) error {

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -46,6 +46,18 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			expected: "CREATE INDEX idx_products_tags ON products USING GIN (tags);\n",
 		},
 		{
+			name: "descending index part",
+			index: ast.NewIndex("idx_users_rank", "users", "rank").
+				SetParts([]ast.IndexPart{{Name: "rank", Desc: true}}),
+			expected: "CREATE INDEX idx_users_rank ON users (rank DESC);\n",
+		},
+		{
+			name: "expression index part",
+			index: ast.NewIndex("idx_users_full_name", "users", "first_name || ' ' || last_name").
+				SetParts([]ast.IndexPart{{Expr: "first_name || ' ' || last_name"}}),
+			expected: "CREATE INDEX idx_users_full_name ON users ((first_name || ' ' || last_name));\n",
+		},
+		{
 			name: "partial index",
 			index: &ast.IndexNode{
 				Name:      "idx_active_users",

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -30,8 +30,8 @@ current schema IR:
 - `column` blocks with `type`, `null`, `auto_increment`, `unique`, `default`,
   and `comment`
 - `primary_key` blocks with `columns`
-- `index` blocks with `columns`, `on { column = ... }`, `unique`, `type`, and
-  `where`
+- `index` blocks with `columns`, `on { column = ... }`, `on { expr = "..." }`,
+  `desc`, `unique`, `type`, and `where`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
   `ref_columns` entry
 - `check` blocks with `expr`


### PR DESCRIPTION
## Summary
- add structured index parts to goschema and AST while preserving legacy Fields/Columns compatibility
- parse Atlas HCL index on blocks with column or expr plus desc metadata
- render structured index parts in PostgreSQL and MySQL-family index SQL, and document the Atlas HCL shape

## Validation
- go test ./core/...
- go test ./... (outside sandbox for dbschema localhost bind)
- golangci-lint run --fix ./...
- golangci-lint run ./...

Full Atlas conformance remains intentionally red; this PR only adds the Ptah core support needed for the next SQLite index-part conformance slice.