### PR TITLE
Support generated columns in schema IR

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -220,6 +220,10 @@ type ColumnNode struct {
 	// when matching against introspected constraints, a deterministic
 	// "<table>_<column>_check" identifier.
 	CheckName string
+	// GeneratedExpression stores the raw SQL expression for generated columns.
+	GeneratedExpression string
+	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
+	GeneratedKind string
 	// Comment is an optional column comment
 	Comment string
 	// ForeignKey contains foreign key reference information if this column references another table
@@ -346,6 +350,13 @@ func (n *ColumnNode) SetCheck(expression string) *ColumnNode {
 // required (e.g. for drift detection on field-level CHECKs).
 func (n *ColumnNode) SetCheckName(name string) *ColumnNode {
 	n.CheckName = name
+	return n
+}
+
+// SetGenerated marks the column as generated from the supplied raw SQL expression.
+func (n *ColumnNode) SetGenerated(expression, kind string) *ColumnNode {
+	n.GeneratedExpression = expression
+	n.GeneratedKind = kind
 	return n
 }
 

--- a/core/astbuilder/columnbuilder.go
+++ b/core/astbuilder/columnbuilder.go
@@ -172,6 +172,12 @@ func (cb *ColumnBuilder) Check(expression string) *ColumnBuilder {
 	return cb
 }
 
+// Generated marks the column as generated from the supplied raw SQL expression.
+func (cb *ColumnBuilder) Generated(expression, kind string) *ColumnBuilder {
+	cb.column.SetGenerated(expression, kind)
+	return cb
+}
+
 // Comment sets a descriptive comment for the column and returns the ColumnBuilder for chaining.
 //
 // Comments are useful for documenting the purpose, format, or constraints of a column.
@@ -394,6 +400,12 @@ func (scb *SchemaColumnBuilder) DefaultExpression(fn string) *SchemaColumnBuilde
 //	column := schema.Table("users").Column("email", "VARCHAR(255)").Check("email LIKE '%@%'")
 func (scb *SchemaColumnBuilder) Check(expression string) *SchemaColumnBuilder {
 	scb.column.SetCheck(expression)
+	return scb
+}
+
+// Generated marks the column as generated from the supplied raw SQL expression.
+func (scb *SchemaColumnBuilder) Generated(expression, kind string) *SchemaColumnBuilder {
+	scb.column.SetGenerated(expression, kind)
 	return scb
 }
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -167,21 +167,68 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 	if err := p.rejectUnsupportedColumnAttrs(block); err != nil {
 		return goschema.Field{}, err
 	}
+	generated, err := p.parseGeneratedColumn(block)
+	if err != nil {
+		return goschema.Field{}, err
+	}
 
 	field := goschema.Field{
-		StructName: structName,
-		FieldName:  name,
-		Name:       name,
-		Type:       p.rawExpr(typeAttr),
-		Nullable:   p.optionalBool(block.Body.Attributes["null"], false),
-		AutoInc:    p.optionalBool(block.Body.Attributes["auto_increment"], false),
-		Unique:     p.optionalBool(block.Body.Attributes["unique"], false),
-		Comment:    p.optionalString(block.Body.Attributes["comment"]),
+		StructName:          structName,
+		FieldName:           name,
+		Name:                name,
+		Type:                p.rawExpr(typeAttr),
+		Nullable:            p.optionalBool(block.Body.Attributes["null"], false),
+		AutoInc:             p.optionalBool(block.Body.Attributes["auto_increment"], false),
+		Unique:              p.optionalBool(block.Body.Attributes["unique"], false),
+		GeneratedExpression: generated.expression,
+		GeneratedKind:       generated.kind,
+		Comment:             p.optionalString(block.Body.Attributes["comment"]),
 	}
 	if attr := block.Body.Attributes["default"]; attr != nil {
 		p.setDefault(&field, attr)
 	}
 	return field, nil
+}
+
+type generatedColumnSpec struct {
+	expression string
+	kind       string
+}
+
+func (p *parser) parseGeneratedColumn(block *hclsyntax.Block) (generatedColumnSpec, error) {
+	attr := block.Body.Attributes["as"]
+	var asBlocks []*hclsyntax.Block
+	for _, nested := range block.Body.Blocks {
+		if nested.Type != "as" {
+			return generatedColumnSpec{}, p.blockError(nested, "unsupported column block %q", nested.Type)
+		}
+		asBlocks = append(asBlocks, nested)
+	}
+	if attr != nil && len(asBlocks) > 0 {
+		return generatedColumnSpec{}, p.blockError(asBlocks[0], "column cannot mix as attribute with as block")
+	}
+	if len(asBlocks) > 1 {
+		return generatedColumnSpec{}, p.blockError(asBlocks[1], "column can contain at most one as block")
+	}
+	if attr != nil {
+		return generatedColumnSpec{expression: p.exprString(attr), kind: "VIRTUAL"}, nil
+	}
+	if len(asBlocks) == 0 {
+		return generatedColumnSpec{}, nil
+	}
+
+	asBlock := asBlocks[0]
+	if err := p.rejectUnsupportedGeneratedColumnAttrs(asBlock); err != nil {
+		return generatedColumnSpec{}, err
+	}
+	exprAttr := asBlock.Body.Attributes["expr"]
+	if exprAttr == nil {
+		return generatedColumnSpec{}, p.blockError(asBlock, "column as block requires expr")
+	}
+	return generatedColumnSpec{
+		expression: p.exprString(exprAttr),
+		kind:       strings.ToUpper(p.optionalString(asBlock.Body.Attributes["type"])),
+	}, nil
 }
 
 func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block) (goschema.Index, error) {
@@ -471,8 +518,19 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 		"auto_increment": true,
 		"unique":         true,
 		"default":        true,
+		"as":             true,
 		"comment":        true,
 	}, "column")
+}
+
+func (p *parser) rejectUnsupportedGeneratedColumnAttrs(block *hclsyntax.Block) error {
+	if len(block.Body.Blocks) > 0 {
+		return p.blockError(block.Body.Blocks[0], "unsupported column as block %q", block.Body.Blocks[0].Type)
+	}
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"expr": true,
+		"type": true,
+	}, "column as")
 }
 
 func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -329,18 +329,105 @@ table "users" {
 	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"email,normalized"})
 }
 
-func TestParseRejectsUnsupportedSemanticColumnAttributes(t *testing.T) {
+func TestParseGeneratedColumns(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := atlashcl.Parse([]byte(`
+	db, err := atlashcl.Parse([]byte(`
 table "users" {
   column "slug" {
     type = text
     as = "lower(name)"
   }
+  column "name_key" {
+    type = text
+    as {
+      expr = "lower(name)"
+      type = STORED
+    }
+  }
 }
 `), "schema.hcl")
-	c.Assert(err, qt.ErrorMatches, `.*unsupported column attribute "as".*`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 2)
+	c.Assert(db.Fields[0].GeneratedExpression, qt.Equals, "lower(name)")
+	c.Assert(db.Fields[0].GeneratedKind, qt.Equals, "VIRTUAL")
+	c.Assert(db.Fields[1].GeneratedExpression, qt.Equals, "lower(name)")
+	c.Assert(db.Fields[1].GeneratedKind, qt.Equals, "STORED")
+}
+
+func TestParseRejectsInvalidGeneratedColumnForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		hcl   string
+		match string
+	}{
+		{
+			name: "as attribute and block",
+			hcl: `
+table "users" {
+  column "slug" {
+    type = text
+    as = "lower(name)"
+    as {
+      expr = "lower(name)"
+    }
+  }
+}
+`,
+			match: `.*column cannot mix as attribute with as block.*`,
+		},
+		{
+			name: "as block without expr",
+			hcl: `
+table "users" {
+  column "slug" {
+    type = text
+    as {
+      type = STORED
+    }
+  }
+}
+`,
+			match: `.*column as block requires expr.*`,
+		},
+		{
+			name: "unsupported as block attribute",
+			hcl: `
+table "users" {
+  column "slug" {
+    type = text
+    as {
+      expr = "lower(name)"
+      unknown = true
+    }
+  }
+}
+`,
+			match: `.*unsupported column as attribute "unknown".*`,
+		},
+		{
+			name: "unsupported column block",
+			hcl: `
+table "users" {
+  column "slug" {
+    type = text
+    generated {
+      expr = "lower(name)"
+    }
+  }
+}
+`,
+			match: `.*unsupported column block "generated".*`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
 }
 
 func TestParseRejectsUnsupportedSchemaAttributes(t *testing.T) {

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -59,14 +59,18 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 		// Convert columns to fields
 		for _, dbColumn := range dbTable.Columns {
 			field := goschema.Field{
-				StructName: structName,
-				FieldName:  generateFieldName(dbColumn.Name),
-				Name:       dbColumn.Name,
-				Type:       dbColumn.DataType,
-				Nullable:   dbColumn.IsNullable == "YES",
-				Primary:    dbColumn.IsPrimaryKey,
-				AutoInc:    dbColumn.IsAutoIncrement,
-				Unique:     dbColumn.IsUnique,
+				StructName:    structName,
+				FieldName:     generateFieldName(dbColumn.Name),
+				Name:          dbColumn.Name,
+				Type:          dbColumn.DataType,
+				Nullable:      dbColumn.IsNullable == "YES",
+				Primary:       dbColumn.IsPrimaryKey,
+				AutoInc:       dbColumn.IsAutoIncrement,
+				Unique:        dbColumn.IsUnique,
+				GeneratedKind: dbColumn.GeneratedKind,
+			}
+			if dbColumn.GeneratedExpression != nil {
+				field.GeneratedExpression = *dbColumn.GeneratedExpression
 			}
 
 			// Set default value if present

--- a/core/convert/dbschematogo/dbschematogo_test.go
+++ b/core/convert/dbschematogo/dbschematogo_test.go
@@ -169,6 +169,32 @@ func TestConvertDBSchemaToGoSchema_ExtensionsWithOtherElements(t *testing.T) {
 	c.Assert(result.Enums[0].Name, qt.Equals, "status_type")
 }
 
+func TestConvertDBSchemaToGoSchema_GeneratedColumns(t *testing.T) {
+	c := qt.New(t)
+	expression := "lower(name)"
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "users",
+				Columns: []types.DBColumn{
+					{
+						Name:                "slug",
+						DataType:            "text",
+						GeneratedExpression: &expression,
+						GeneratedKind:       "STORED",
+					},
+				},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Fields, qt.HasLen, 1)
+	c.Assert(result.Fields[0].GeneratedExpression, qt.Equals, "lower(name)")
+	c.Assert(result.Fields[0].GeneratedKind, qt.Equals, "STORED")
+}
+
 func TestConvertDBSchemaToGoSchema_ExtensionDefaultValues(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -322,6 +322,9 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 			column.SetCheckName(field.CheckName)
 		}
 	}
+	if field.GeneratedExpression != "" {
+		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
+	}
 
 	// Set comment (using potentially overridden value)
 	if field.Comment != "" {
@@ -395,6 +398,9 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 		if field.CheckName != "" {
 			column.SetCheckName(field.CheckName)
 		}
+	}
+	if field.GeneratedExpression != "" {
+		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
 	}
 
 	// Set comment (using potentially overridden value)

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -71,6 +71,18 @@ func TestFromField_BasicProperties(t *testing.T) {
 				return col.Name == "id" && col.AutoInc == true
 			},
 		},
+		{
+			name: "generated field",
+			field: goschema.Field{
+				Name:                "slug",
+				Type:                "TEXT",
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "STORED",
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.GeneratedExpression == "lower(name)" && col.GeneratedKind == "STORED"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -124,16 +124,18 @@ import (
 // The StructName is set to the provided structName parameter.
 func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema.Field {
 	field := goschema.Field{
-		StructName: structName,
-		FieldName:  "", // This would need to be set separately as it's not in the AST
-		Name:       column.Name,
-		Type:       column.Type,
-		Nullable:   column.Nullable,
-		Primary:    column.Primary,
-		AutoInc:    column.AutoInc,
-		Unique:     column.Unique,
-		Check:      column.Check,
-		Comment:    column.Comment,
+		StructName:          structName,
+		FieldName:           "", // This would need to be set separately as it's not in the AST
+		Name:                column.Name,
+		Type:                column.Type,
+		Nullable:            column.Nullable,
+		Primary:             column.Primary,
+		AutoInc:             column.AutoInc,
+		Unique:              column.Unique,
+		Check:               column.Check,
+		GeneratedExpression: column.GeneratedExpression,
+		GeneratedKind:       column.GeneratedKind,
+		Comment:             column.Comment,
 	}
 
 	// Mirror the fromschema guarding: only surface CheckName when there's

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -65,6 +65,15 @@ func TestToField_BasicProperties(t *testing.T) {
 					field.AutoInc == true
 			},
 		},
+		{
+			name:       "generated field",
+			column:     ast.NewColumn("slug", "TEXT").SetGenerated("lower(name)", "STORED"),
+			structName: "User",
+			expected: func(field goschema.Field) bool {
+				return field.GeneratedExpression == "lower(name)" &&
+					field.GeneratedKind == "STORED"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -126,26 +126,30 @@ type EmbeddedField struct {
 //	//migrator:schema:field name="id" type="SERIAL" platform.mysql.type="INT AUTO_INCREMENT"
 //	ID int64
 type Field struct {
-	StructName     string                       // Name of the Go struct this field belongs to
-	FieldName      string                       // Name of the Go struct field
-	Name           string                       // Database column name
-	Type           string                       // Database column type (e.g., "VARCHAR(255)", "INTEGER")
-	Nullable       bool                         // Whether the column allows NULL values
-	Primary        bool                         // Whether this is a primary key column
-	AutoInc        bool                         // Whether this column auto-increments
-	Unique         bool                         // Whether this column has a unique constraint
-	UniqueExpr     string                       // Custom unique constraint expression
-	Default        string                       // Default value for the column
-	DefaultExpr    string                       // Default expression (e.g., "NOW()", "UUID()", "CURRENT_TIMESTAMP", "1", "true")
-	Foreign        string                       // Foreign key reference (e.g., "users(id)")
-	ForeignKeyName string                       // Custom foreign key constraint name
-	OnDelete       string                       // Foreign key ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
-	OnUpdate       string                       // Foreign key ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
-	Enum           []string                     // Enum values for ENUM type fields
-	Check          string                       // Check constraint expression
-	CheckName      string                       // Optional constraint name for the column-level CHECK; defaults to "<table>_<column>_check"
-	Comment        string                       // Column comment
-	Overrides      map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
+	StructName     string   // Name of the Go struct this field belongs to
+	FieldName      string   // Name of the Go struct field
+	Name           string   // Database column name
+	Type           string   // Database column type (e.g., "VARCHAR(255)", "INTEGER")
+	Nullable       bool     // Whether the column allows NULL values
+	Primary        bool     // Whether this is a primary key column
+	AutoInc        bool     // Whether this column auto-increments
+	Unique         bool     // Whether this column has a unique constraint
+	UniqueExpr     string   // Custom unique constraint expression
+	Default        string   // Default value for the column
+	DefaultExpr    string   // Default expression (e.g., "NOW()", "UUID()", "CURRENT_TIMESTAMP", "1", "true")
+	Foreign        string   // Foreign key reference (e.g., "users(id)")
+	ForeignKeyName string   // Custom foreign key constraint name
+	OnDelete       string   // Foreign key ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+	OnUpdate       string   // Foreign key ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+	Enum           []string // Enum values for ENUM type fields
+	Check          string   // Check constraint expression
+	CheckName      string   // Optional constraint name for the column-level CHECK; defaults to "<table>_<column>_check"
+	// GeneratedExpression stores the raw SQL expression for generated columns.
+	GeneratedExpression string
+	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
+	GeneratedKind string
+	Comment       string                       // Column comment
+	Overrides     map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
 }
 
 // IndexPart represents one column or expression inside an index definition.

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -1521,17 +1521,17 @@ func (p *Parser) handleAs(column *ast.ColumnNode) error {
 		p.advance()
 	}
 
-	// Parse STORED/VIRTUAL keyword
+	generatedKind := ""
 	p.skipWhitespace()
 	if p.current.Type == lexer.TokenIdentifier {
 		storageType := strings.ToUpper(p.current.Value)
 		if storageType == "STORED" || storageType == "VIRTUAL" {
+			generatedKind = storageType
 			p.advance()
 		}
 	}
 
-	// Store as a check constraint for now (in a full implementation, add Generated field to ColumnNode)
-	column.SetCheck("AS (" + expr.String() + ") STORED")
+	column.SetGenerated(expr.String(), generatedKind)
 	return nil
 }
 
@@ -1571,14 +1571,14 @@ func (p *Parser) handleGenerated(column *ast.ColumnNode) error {
 		p.advance()
 	}
 
-	// Parse STORED keyword
+	generatedKind := ""
 	p.skipWhitespace()
 	if p.current.Type == lexer.TokenIdentifier && strings.ToUpper(p.current.Value) == "STORED" {
+		generatedKind = "STORED"
 		p.advance()
 	}
 
-	// Store as a check constraint for now (in a full implementation, add Generated field to ColumnNode)
-	column.SetCheck("GENERATED ALWAYS AS (" + expr.String() + ") STORED")
+	column.SetGenerated(expr.String(), generatedKind)
 
 	return nil
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -2077,8 +2077,9 @@ func TestParser_ParsePostgreSQLGeneratedColumn(t *testing.T) {
 	fullNameCol := createTable.Columns[2]
 	c.Assert(fullNameCol.Name, qt.Equals, "full_name")
 	c.Assert(fullNameCol.Type, qt.Equals, "TEXT")
-	c.Assert(fullNameCol.Check, qt.Contains, "GENERATED ALWAYS AS")
-	c.Assert(fullNameCol.Check, qt.Contains, "first_name || ' ' || last_name")
+	c.Assert(fullNameCol.GeneratedExpression, qt.Equals, "first_name || ' ' || last_name")
+	c.Assert(fullNameCol.GeneratedKind, qt.Equals, "STORED")
+	c.Assert(fullNameCol.Check, qt.Equals, "")
 }
 
 func TestParser_ParsePostgreSQLJSONTypes(t *testing.T) {
@@ -2971,6 +2972,8 @@ func TestParser_ParseMariaDBComprehensiveDemo(t *testing.T) {
 	fullnameCol := createTable.Columns[12]
 	c.Assert(fullnameCol.Name, qt.Equals, "`fullname`")
 	c.Assert(fullnameCol.Type, qt.Equals, "VARCHAR(100)")
+	c.Assert(fullnameCol.GeneratedExpression, qt.Equals, "CONCAT(`username`, ' ', 'User')")
+	c.Assert(fullnameCol.GeneratedKind, qt.Equals, "STORED")
 
 	// Test foreign key column
 	countryCol := createTable.Columns[13]
@@ -3128,6 +3131,8 @@ func TestParser_MariaDBVirtualColumn(t *testing.T) {
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Columns, qt.HasLen, 2)
 	c.Assert(createTable.Columns[1].Type, qt.Equals, "VARCHAR(100)")
+	c.Assert(createTable.Columns[1].GeneratedExpression, qt.Equals, "CONCAT(`name`, ' ', 'User')")
+	c.Assert(createTable.Columns[1].GeneratedKind, qt.Equals, "STORED")
 }
 
 func TestParser_MariaDBTableOptions(t *testing.T) {

--- a/core/renderer/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/dialects/mysql/alter_ops_test.go
@@ -79,6 +79,19 @@ func TestMySQL_CreateTableSelectTail(t *testing.T) {
 	c.Assert(out, qt.Not(qt.Contains), "CREATE TABLE IF NOT EXISTS t2 (")
 }
 
+func TestMySQL_CreateTableGeneratedColumn(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("id", "int").SetPrimary()).
+		AddColumn(ast.NewColumn("slug", "varchar(255)").
+			SetNotNull().
+			SetGenerated("lower(name)", "STORED"))
+
+	out := renderMySQL(t, table)
+
+	c.Assert(out, qt.Contains, "slug varchar(255) NOT NULL AS (lower(name)) STORED")
+}
+
 func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 	c := qt.New(t)
 	alter := &ast.AlterTableNode{

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -529,6 +529,9 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	if column.AutoInc {
 		parts = append(parts, r.renderAutoIncrement())
 	}
+	if column.GeneratedExpression != "" {
+		parts = append(parts, renderGeneratedColumn(column))
+	}
 
 	// Default value
 	switch {
@@ -554,6 +557,14 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	}
 
 	return strings.Join(parts, " "), nil
+}
+
+func renderGeneratedColumn(column *ast.ColumnNode) string {
+	sql := fmt.Sprintf("AS (%s)", column.GeneratedExpression)
+	if column.GeneratedKind != "" {
+		sql += " " + column.GeneratedKind
+	}
+	return sql
 }
 
 // renderAutoIncrement renders auto increment (dialect-specific, override in subclasses)
@@ -677,6 +688,9 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 		} else if column.Default.Value != "" {
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", column.Default.Value))
 		}
+	}
+	if column.GeneratedExpression != "" {
+		parts = append(parts, renderGeneratedColumn(column))
 	}
 
 	// Check constraints

--- a/core/renderer/dialects/postgres/check_constraint_test.go
+++ b/core/renderer/dialects/postgres/check_constraint_test.go
@@ -67,3 +67,18 @@ CREATE TABLE files (
 		})
 	}
 }
+
+func TestPostgreSQLRenderer_GeneratedColumn(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary()).
+		AddColumn(ast.NewColumn("slug", "TEXT").
+			SetNotNull().
+			SetGenerated("lower(name)", "STORED"))
+
+	renderer := postgres.New()
+	result, err := renderer.Render(table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Contains, "slug TEXT NOT NULL GENERATED ALWAYS AS (lower(name)) STORED")
+}

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -628,6 +628,12 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	case column.Default.Expression != "":
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 	}
+	if column.GeneratedExpression != "" {
+		if column.GeneratedKind != "" && !strings.EqualFold(column.GeneratedKind, "STORED") {
+			return "", fmt.Errorf("postgres does not support %s generated columns", column.GeneratedKind)
+		}
+		parts = append(parts, fmt.Sprintf("GENERATED ALWAYS AS (%s) STORED", column.GeneratedExpression))
+	}
 
 	// Check constraint. Emit `CONSTRAINT <name> CHECK (...)` only when an
 	// explicit name was provided via `check_name=` on the field annotation —

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -51,13 +51,10 @@ func QualifyTableName(schema, table string) string {
 
 // DBColumn represents a database column.
 //
-// GeneratedKind / GeneratedExpression are populated only by the ClickHouse
-// reader and capture columns declared with non-DEFAULT default kinds
-// (MATERIALIZED, ALIAS, EPHEMERAL). The planner currently ignores these
-// fields — round-trip support for generated columns is not yet wired through
-// the goschema-side annotation surface — but capturing the data here means
-// the schema read is lossless. See the renderer/planner comments for the
-// follow-up boundary.
+// GeneratedKind / GeneratedExpression are currently populated by the ClickHouse
+// reader for columns declared with non-DEFAULT default kinds (MATERIALIZED,
+// ALIAS, EPHEMERAL). Schema comparison can match these fields when the
+// goschema-side model also carries generated column metadata.
 type DBColumn struct {
 	Name               string  `json:"name"`
 	DataType           string  `json:"data_type"`

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -90,6 +90,17 @@ table "posts" {
     type = int
     null = true
   }
+  column "slug" {
+    type = text
+    as = "lower(name)"
+  }
+  column "name_key" {
+    type = text
+    as {
+      expr = "lower(name)"
+      type = STORED
+    }
+  }
 
   foreign_key "owner_id" {
     columns = [column.owner_id]
@@ -104,8 +115,6 @@ table "posts" {
 The Atlas HCL frontend is intentionally conservative. It does not yet model
 Atlas features that Ptah cannot represent without losing semantics, including:
 
-- schema-level charset and collation attributes
-- generated columns
 - composite foreign keys
 - index prefix parts
 - Atlas project `env` execution semantics

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -347,16 +347,10 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 		Changes:    make(map[string]string),
 	}
 
-	// ClickHouse-only: when the database side declares a MATERIALIZED /
-	// ALIAS / EPHEMERAL column there is currently no goschema-side
-	// annotation to express that, so the diff layer cannot tell whether a
-	// plain DEFAULT in the entity should become MATERIALIZED on the
-	// database (or vice-versa). Suppress per-column diffing entirely for
-	// generated columns so we don't emit a no-op ALTER on every migration.
-	// Round-trip support is tracked alongside the goschema annotation
-	// work; once that lands this guard can be tightened to compare
-	// GeneratedKind/Expression directly.
-	if dbCol.GeneratedKind != "" {
+	// Legacy ClickHouse-only guard: old goschema models cannot express
+	// MATERIALIZED / ALIAS / EPHEMERAL columns. Once the schema side carries a
+	// generated expression, compare it normally below.
+	if dbCol.GeneratedKind != "" && genCol.GeneratedExpression == "" {
 		return colDiff
 	}
 
@@ -394,6 +388,9 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 	if genUnique != dbUnique {
 		colDiff.Changes["unique"] = fmt.Sprintf("%t -> %t", dbUnique, genUnique)
 	}
+	if diff := generatedColumnDiff(genCol, dbCol); diff != "" {
+		colDiff.Changes["generated"] = diff
+	}
 
 	// Compare default values (simplified)
 	genDefault := genCol.Default
@@ -424,6 +421,20 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 	}
 
 	return colDiff
+}
+
+func generatedColumnDiff(genCol goschema.Field, dbCol types.DBColumn) string {
+	genExpr := strings.TrimSpace(genCol.GeneratedExpression)
+	dbExpr := ""
+	if dbCol.GeneratedExpression != nil {
+		dbExpr = strings.TrimSpace(*dbCol.GeneratedExpression)
+	}
+	genKind := strings.ToUpper(strings.TrimSpace(genCol.GeneratedKind))
+	dbKind := strings.ToUpper(strings.TrimSpace(dbCol.GeneratedKind))
+	if genExpr == dbExpr && genKind == dbKind {
+		return ""
+	}
+	return fmt.Sprintf("%s %s -> %s %s", dbKind, dbExpr, genKind, genExpr)
 }
 
 func rawDBColumnType(dbCol types.DBColumn) string {

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -262,6 +262,31 @@ func TestColumns_HappyPath(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "generated expression change",
+			genCol: goschema.Field{
+				Name:                "slug",
+				Type:                "TEXT",
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "STORED",
+			},
+			dbCol: types.DBColumn{
+				Name:          "slug",
+				DataType:      "TEXT",
+				IsNullable:    "NO",
+				GeneratedKind: "VIRTUAL",
+				GeneratedExpression: func() *string {
+					value := "upper(name)"
+					return &value
+				}(),
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "slug",
+				Changes: map[string]string{
+					"generated": "VIRTUAL upper(name) -> STORED lower(name)",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- add generated-column metadata to goschema and AST, with parser/converter/rendering support
- parse Atlas HCL column as attr/block forms without silently dropping unknown column blocks
- compare generated-column metadata in schema diff and carry DB introspection metadata into goschema
- document Atlas HCL generated columns

## Validation
- go test ./core/atlashcl ./core/parser ./core/convert/fromschema ./core/convert/toschema ./core/convert/dbschematogo ./core/renderer/dialects/mysql ./core/renderer/dialects/postgres ./migration/schemadiff/internal/compare
- go test ./core/...
- go test ./... (rerun outside sandbox because sandbox blocks localhost bind in dbschema context tests)
- golangci-lint run --fix ./...
- golangci-lint run ./...