### PR TITLE
Support Atlas HCL table auto_increment

### DIFF
--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -98,13 +98,14 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 
 	table := goschema.Table{
-		StructName:   block.Labels[0],
-		Name:         block.Labels[0],
-		Schema:       p.optionalRefName(block.Body.Attributes["schema"]),
-		Engine:       p.optionalString(block.Body.Attributes["engine"]),
-		Strict:       strict,
-		WithoutRowID: withoutRowID,
-		Comment:      p.optionalString(block.Body.Attributes["comment"]),
+		StructName:    block.Labels[0],
+		Name:          block.Labels[0],
+		Schema:        p.optionalRefName(block.Body.Attributes["schema"]),
+		Engine:        p.optionalString(block.Body.Attributes["engine"]),
+		AutoIncrement: p.optionalString(block.Body.Attributes["auto_increment"]),
+		Strict:        strict,
+		WithoutRowID:  withoutRowID,
+		Comment:       p.optionalString(block.Body.Attributes["comment"]),
 	}
 
 	fieldsStart := len(p.db.Fields)
@@ -489,11 +490,12 @@ func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
 
 func (p *parser) rejectUnsupportedTableAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"schema":        true,
-		"engine":        true,
-		"strict":        true,
-		"without_rowid": true,
-		"comment":       true,
+		"schema":         true,
+		"engine":         true,
+		"auto_increment": true,
+		"strict":         true,
+		"without_rowid":  true,
+		"comment":        true,
 	}, "table")
 }
 

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -118,6 +118,33 @@ table "events" {
 	c.Assert(db.Tables[0].WithoutRowID, qt.IsTrue)
 }
 
+func TestParseMySQLTableAutoIncrement(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "users" {
+  schema = schema.main
+  auto_increment = 1000
+  column "id" {
+    null = false
+    type = bigint
+    auto_increment = true
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].AutoIncrement, qt.Equals, "1000")
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, "AUTO_INCREMENT=1000")
+}
+
 func TestParseSQLiteTableOptionsRejectNonBool(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -421,6 +421,7 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	}
 	tableComment := table.Comment
 	tableEngine := table.Engine
+	tableAutoIncrement := table.AutoIncrement
 	tableStrict := table.Strict
 	tableWithoutRowID := table.WithoutRowID
 
@@ -437,6 +438,9 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	if engineOverride, ok := platformOverrides["engine"]; ok {
 		tableEngine = engineOverride
 	}
+	if autoIncrementOverride, ok := platformOverrides["auto_increment"]; ok {
+		tableAutoIncrement = autoIncrementOverride
+	}
 	if strictOverride, ok := platformOverrides["strict"]; ok {
 		if strict, err := strconv.ParseBool(strictOverride); err == nil {
 			tableStrict = strict
@@ -449,7 +453,7 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	}
 	// Apply any other platform-specific options
 	for key, value := range platformOverrides {
-		if key != "comment" && key != "engine" && key != "strict" && key != "without_rowid" {
+		if key != "comment" && key != "engine" && key != "auto_increment" && key != "strict" && key != "without_rowid" {
 			createTable.SetOption(strings.ToUpper(key), value)
 		}
 	}
@@ -457,6 +461,7 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	newTable := table
 	newTable.Comment = tableComment
 	newTable.Engine = tableEngine
+	newTable.AutoIncrement = tableAutoIncrement
 	newTable.Strict = tableStrict
 	newTable.WithoutRowID = tableWithoutRowID
 	return newTable
@@ -554,6 +559,9 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	// Set database-specific options (using potentially overridden value)
 	if tableEngine != "" {
 		createTable.SetOption("ENGINE", tableEngine)
+	}
+	if newTable.AutoIncrement != "" {
+		createTable.SetOption("AUTO_INCREMENT", newTable.AutoIncrement)
 	}
 	if targetPlatform == "sqlite" {
 		if newTable.WithoutRowID {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -449,6 +449,28 @@ func TestFromTable_BasicTable(t *testing.T) {
 					len(table.Columns) == 1
 			},
 		},
+		{
+			name: "table with auto increment option",
+			table: goschema.Table{
+				StructName:    "User",
+				Name:          "users",
+				AutoIncrement: "1000",
+			},
+			fields: []goschema.Field{
+				{
+					StructName: "User",
+					Name:       "id",
+					Type:       "BIGINT",
+					Primary:    true,
+					AutoInc:    true,
+				},
+			},
+			expected: func(table *ast.CreateTableNode) bool {
+				return table.Name == "users" &&
+					table.Options["AUTO_INCREMENT"] == "1000" &&
+					len(table.Columns) == 1
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1049,14 +1071,16 @@ func TestFromTable_PlatformOverrides(t *testing.T) {
 		{
 			name: "MySQL engine and comment override",
 			table: goschema.Table{
-				StructName: "Product",
-				Name:       "products",
-				Comment:    "Default comment",
-				Engine:     "MyISAM",
+				StructName:    "Product",
+				Name:          "products",
+				Comment:       "Default comment",
+				Engine:        "MyISAM",
+				AutoIncrement: "100",
 				Overrides: map[string]map[string]string{
 					"mysql": {
-						"engine":  "InnoDB",
-						"comment": "MySQL-specific comment",
+						"engine":         "InnoDB",
+						"comment":        "MySQL-specific comment",
+						"auto_increment": "1000",
 					},
 				},
 			},
@@ -1065,7 +1089,8 @@ func TestFromTable_PlatformOverrides(t *testing.T) {
 			expected: func(table *ast.CreateTableNode) bool {
 				return table.Name == "products" &&
 					table.Comment == "MySQL-specific comment" &&
-					table.Options["ENGINE"] == "InnoDB"
+					table.Options["ENGINE"] == "InnoDB" &&
+					table.Options["AUTO_INCREMENT"] == "1000"
 			},
 		},
 		{

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -346,14 +346,15 @@ type Extension struct {
 //	    RoleID int64
 //	}
 type Table struct {
-	StructName   string   // Name of the Go struct this table represents
-	Name         string   // Database table name
-	Schema       string   // Optional database schema/namespace (PostgreSQL-style)
-	Engine       string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
-	Strict       bool     // SQLite STRICT table option
-	WithoutRowID bool     // SQLite WITHOUT ROWID table option
-	Comment      string   // Table comment/description
-	PrimaryKey   []string // Composite primary key column names
+	StructName    string   // Name of the Go struct this table represents
+	Name          string   // Database table name
+	Schema        string   // Optional database schema/namespace (PostgreSQL-style)
+	Engine        string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
+	AutoIncrement string   // Initial AUTO_INCREMENT value (MySQL/MariaDB specific)
+	Strict        bool     // SQLite STRICT table option
+	WithoutRowID  bool     // SQLite WITHOUT ROWID table option
+	Comment       string   // Table comment/description
+	PrimaryKey    []string // Composite primary key column names
 	// PrimaryKeyParts carries dialect-specific metadata for composite primary
 	// key elements, such as MySQL prefix lengths and DESC ordering.
 	PrimaryKeyParts []PrimaryKeyPart


### PR DESCRIPTION
## Summary
- parse Atlas HCL table-level `auto_increment` into `goschema.Table`
- carry table AUTO_INCREMENT through fromschema into AST table options
- support platform-specific `auto_increment` table overrides

## Conformance impact
Validated against ptah-atlas-conformance with a temporary local replace:
- before this Ptah change: 115 unwaived non-OK observations
- with this Ptah change: 114 unwaived non-OK observations
- closes the remaining MySQL autoincrement apply blocker exposed by the conformance harness

## Validation
- go test ./core/atlashcl
- go test ./core/convert/fromschema
- go test ./core/goschema
- go test ./core/...
- go test ./...
- golangci-lint run ./...
- conformance local replace: go run ./cmd/gap-probe => 114 unwaived non-OK observations