### PR TITLE
Support Atlas HCL index prefix parts

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -435,6 +435,8 @@ type IndexPart struct {
 	Name string
 	// Expr is a raw indexed expression. It is mutually exclusive with Name.
 	Expr string
+	// Prefix stores the MySQL index prefix length for column parts.
+	Prefix string
 	// Desc indicates DESC ordering for this index part.
 	Desc bool
 }

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -292,11 +292,15 @@ func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.I
 		if err != nil {
 			return nil, nil, err
 		}
+		prefix := p.optionalRawExpr(nested.Body.Attributes["prefix"])
 		if columnAttr != nil {
 			column := p.columnNameFromExpr(columnAttr)
 			columns = append(columns, column)
-			parts = append(parts, goschema.IndexPart{Name: column, Desc: desc})
+			parts = append(parts, goschema.IndexPart{Name: column, Prefix: prefix, Desc: desc})
 			continue
+		}
+		if prefix != "" {
+			return nil, nil, p.blockError(nested, "index on prefix requires column")
 		}
 		expr := p.exprString(exprAttr)
 		columns = append(columns, expr)
@@ -552,6 +556,7 @@ func (p *parser) rejectUnsupportedIndexOnAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"column": true,
 		"expr":   true,
+		"prefix": true,
 		"desc":   true,
 	}, "index on")
 }

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -199,6 +199,7 @@ table "users" {
   index "rank_score_idx" {
     on {
       column = column.rank
+      prefix = 7
     }
     on {
       column = column.score
@@ -216,7 +217,7 @@ table "users" {
 	c.Assert(db.Indexes, qt.HasLen, 2)
 	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"rank", "score"})
 	c.Assert(db.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
-		{Name: "rank"},
+		{Name: "rank", Prefix: "7"},
 		{Name: "score", Desc: true},
 	})
 	c.Assert(db.Indexes[1].Fields, qt.DeepEquals, []string{"first_name || ' ' || last_name"})
@@ -494,7 +495,7 @@ schema "main" {
 	c.Assert(err, qt.ErrorMatches, `.*unsupported schema attribute "owner".*`)
 }
 
-func TestParseRejectsUnsupportedIndexPartAttributes(t *testing.T) {
+func TestParseRejectsIndexExprPrefix(t *testing.T) {
 	c := qt.New(t)
 
 	_, err := atlashcl.Parse([]byte(`
@@ -504,13 +505,13 @@ table "users" {
   }
   index "idx_users_email" {
     on {
-      column = column.email
+      expr = "lower(email)"
       prefix = 32
     }
   }
 }
 `), "schema.hcl")
-	c.Assert(err, qt.ErrorMatches, `.*unsupported index on attribute "prefix".*`)
+	c.Assert(err, qt.ErrorMatches, `.*index on prefix requires column.*`)
 }
 
 func TestParseRejectsInvalidIndexParts(t *testing.T) {

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1299,9 +1299,10 @@ func toASTIndexParts(parts []goschema.IndexPart) []ast.IndexPart {
 	astParts := make([]ast.IndexPart, 0, len(parts))
 	for _, part := range parts {
 		astParts = append(astParts, ast.IndexPart{
-			Name: part.Name,
-			Expr: part.Expr,
-			Desc: part.Desc,
+			Name:   part.Name,
+			Expr:   part.Expr,
+			Prefix: part.Prefix,
+			Desc:   part.Desc,
 		})
 	}
 	return astParts

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -734,7 +734,7 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 				StructName: "users",
 				Fields:     []string{"stale_rank", "stale_name"},
 				Parts: []goschema.IndexPart{
-					{Name: "rank", Desc: true},
+					{Name: "rank", Prefix: "7", Desc: true},
 					{Expr: "lower(name)"},
 				},
 			},
@@ -745,7 +745,7 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.Columns[0] == "rank" &&
 					idx.Columns[1] == "lower(name)" &&
 					len(idx.Parts) == 2 &&
-					idx.Parts[0] == (ast.IndexPart{Name: "rank", Desc: true}) &&
+					idx.Parts[0] == (ast.IndexPart{Name: "rank", Prefix: "7", Desc: true}) &&
 					idx.Parts[1] == (ast.IndexPart{Expr: "lower(name)"})
 			},
 		},

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -384,9 +384,10 @@ func toSchemaIndexParts(parts []ast.IndexPart) []goschema.IndexPart {
 	schemaParts := make([]goschema.IndexPart, 0, len(parts))
 	for _, part := range parts {
 		schemaParts = append(schemaParts, goschema.IndexPart{
-			Name: part.Name,
-			Expr: part.Expr,
-			Desc: part.Desc,
+			Name:   part.Name,
+			Expr:   part.Expr,
+			Prefix: part.Prefix,
+			Desc:   part.Desc,
 		})
 	}
 	return schemaParts

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -434,7 +434,7 @@ func TestToIndex_BasicIndex(t *testing.T) {
 			name: "structured index parts",
 			index: ast.NewIndex("idx_users_rank_name", "users").
 				SetParts([]ast.IndexPart{
-					{Name: "rank", Desc: true},
+					{Name: "rank", Prefix: "7", Desc: true},
 					{Expr: "lower(name)"},
 				}),
 			expected: func(index goschema.Index) bool {
@@ -444,7 +444,7 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.Fields[0] == "rank" &&
 					index.Fields[1] == "lower(name)" &&
 					len(index.Parts) == 2 &&
-					index.Parts[0] == (goschema.IndexPart{Name: "rank", Desc: true}) &&
+					index.Parts[0] == (goschema.IndexPart{Name: "rank", Prefix: "7", Desc: true}) &&
 					index.Parts[1] == (goschema.IndexPart{Expr: "lower(name)"})
 			},
 		},

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -154,9 +154,10 @@ type Field struct {
 
 // IndexPart represents one column or expression inside an index definition.
 type IndexPart struct {
-	Name string // Column name
-	Expr string // Raw index expression
-	Desc bool   // Whether this part is ordered DESC
+	Name   string // Column name
+	Expr   string // Raw index expression
+	Prefix string // MySQL index prefix length
+	Desc   bool   // Whether this part is ordered DESC
 }
 
 // Index represents a database index definition parsed from Go struct annotations.

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -56,10 +56,13 @@ func TestMySQLRenderer_IndexParts(t *testing.T) {
 	sql := renderMySQL(t,
 		ast.NewIndex("idx_users_rank", "users", "rank").
 			SetParts([]ast.IndexPart{{Name: "rank", Desc: true}}),
+		ast.NewIndex("idx_users_name", "users", "name").
+			SetParts([]ast.IndexPart{{Name: "name", Prefix: "64"}}),
 		ast.NewIndex("idx_users_lower_name", "users", "lower(name)").
 			SetParts([]ast.IndexPart{{Expr: "lower(name)"}}),
 	)
 
 	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_rank ON users (rank DESC);")
+	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_name ON users (name (64));")
 	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_lower_name ON users ((lower(name)));")
 }

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -348,6 +348,9 @@ func renderIndexParts(parts []ast.IndexPart) []string {
 		if part.Expr != "" {
 			spec = fmt.Sprintf("(%s)", part.Expr)
 		}
+		if part.Prefix != "" && part.Expr == "" {
+			spec += " (" + part.Prefix + ")"
+		}
 		if part.Desc {
 			spec += " DESC"
 		}

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -30,8 +30,8 @@ current schema IR:
 - `column` blocks with `type`, `null`, `auto_increment`, `unique`, `default`,
   and `comment`
 - `primary_key` blocks with `columns`
-- `index` blocks with `columns`, `on { column = ... }`, `on { expr = "..." }`,
-  `desc`, `unique`, `type`, and `where`
+- `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
+  `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
   `ref_columns` entry
 - `check` blocks with `expr`
@@ -116,7 +116,6 @@ The Atlas HCL frontend is intentionally conservative. It does not yet model
 Atlas features that Ptah cannot represent without losing semantics, including:
 
 - composite foreign keys
-- index prefix parts
 - Atlas project `env` execution semantics
 - Atlas HCL objects outside direct schema definitions, such as variables,
   realms, extensions, and other dialect-specific object types


### PR DESCRIPTION
## Summary
- add `Prefix` to structured index parts in the schema IR and SQL AST
- parse Atlas HCL `index { on { column = ..., prefix = ... } }` without allowing prefix on expression parts
- preserve prefix through schema converters and render MySQL/MariaDB index parts as `column (N)`
- document index part prefix support in the Atlas HCL frontend docs

## Validation
- go test ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/renderer/dialects/mysql
- go test ./... (outside sandbox; sandbox blocks dbschema localhost listen tests)
- golangci-lint run ./...
- git diff --check
- gopls diagnostics on touched Go files