### PR TITLE
Support MySQL FULLTEXT index parsers

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -470,6 +470,8 @@ type IndexNode struct {
 	// PostgreSQL; "minmax", "set(N)", "bloom_filter(p)", "tokenbf_v1(...)"
 	// etc. for ClickHouse data-skipping indexes) - database-specific.
 	Type string
+	// Parser specifies the MySQL FULLTEXT parser name, for example ngram.
+	Parser string
 	// Comment is an optional index comment
 	Comment string
 	// IfNotExists indicates whether to use IF NOT EXISTS clause for idempotent migrations

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -258,13 +258,19 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if err := p.rejectUnsupportedIndexAttrs(block); err != nil {
 		return goschema.Index{}, err
 	}
+	indexType := p.optionalString(block.Body.Attributes["type"])
+	parserName := p.optionalString(block.Body.Attributes["parser"])
+	if parserName != "" && !strings.EqualFold(indexType, "FULLTEXT") {
+		return goschema.Index{}, p.blockError(block, "index parser requires FULLTEXT type")
+	}
 	return goschema.Index{
 		StructName: structName,
 		Name:       block.Labels[0],
 		Fields:     columns,
 		Parts:      parts,
 		Unique:     p.optionalBool(block.Body.Attributes["unique"], false),
-		Type:       p.optionalString(block.Body.Attributes["type"]),
+		Type:       indexType,
+		Parser:     parserName,
 		Condition:  p.optionalString(block.Body.Attributes["where"]),
 		TableName:  tableName,
 	}, nil
@@ -546,6 +552,7 @@ func (p *parser) rejectUnsupportedGeneratedColumnAttrs(block *hclsyntax.Block) e
 func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"columns": true,
+		"parser":  true,
 		"unique":  true,
 		"type":    true,
 		"where":   true,

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -226,6 +226,45 @@ table "users" {
 	})
 }
 
+func TestParseFulltextIndexParser(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "bio" {
+    type = text
+  }
+  index "idx_users_bio" {
+    type = FULLTEXT
+    parser = ngram
+    columns = [column.bio]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"bio"})
+	c.Assert(db.Indexes[0].Type, qt.Equals, "FULLTEXT")
+	c.Assert(db.Indexes[0].Parser, qt.Equals, "ngram")
+}
+
+func TestParseRejectsIndexParserWithoutFulltext(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "bio" {
+    type = text
+  }
+  index "idx_users_bio" {
+    parser = ngram
+    columns = [column.bio]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*index parser requires FULLTEXT type.*`)
+}
+
 func TestParseRejectsIndexColumnsAndOnBlocks(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -779,6 +779,10 @@ func FromIndex(index goschema.Index) *ast.IndexNode {
 		indexNode.Type = index.Type
 	}
 
+	if index.Parser != "" {
+		indexNode.Parser = index.Parser
+	}
+
 	if index.Condition != "" {
 		indexNode.Condition = index.Condition
 	}
@@ -1276,6 +1280,10 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 	// and CH (minmax/set/bloom_filter/...) — the renderer interprets it.
 	if index.Type != "" {
 		indexNode.Type = index.Type
+	}
+
+	if index.Parser != "" {
+		indexNode.Parser = index.Parser
 	}
 
 	if index.Condition != "" {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -728,6 +728,21 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 			},
 		},
 		{
+			name: "fulltext index with parser",
+			index: goschema.Index{
+				Name:       "idx_users_bio",
+				StructName: "users",
+				Fields:     []string{"bio"},
+				Type:       "FULLTEXT",
+				Parser:     "ngram",
+			},
+			expected: func(idx *ast.IndexNode) bool {
+				return idx.Name == "idx_users_bio" &&
+					idx.Type == "FULLTEXT" &&
+					idx.Parser == "ngram"
+			},
+		},
+		{
 			name: "structured index parts",
 			index: goschema.Index{
 				Name:       "idx_users_rank_name",

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -363,6 +363,7 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Comment:    index.Comment,
 		// PostgreSQL-specific features
 		Type:      index.Type,
+		Parser:    index.Parser,
 		Condition: index.Condition,
 		Operator:  index.Operator,
 		TableName: index.Table,

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -431,6 +431,20 @@ func TestToIndex_BasicIndex(t *testing.T) {
 			},
 		},
 		{
+			name: "fulltext index with parser",
+			index: func() *ast.IndexNode {
+				index := ast.NewIndex("idx_users_bio", "users", "bio")
+				index.Type = "FULLTEXT"
+				index.Parser = "ngram"
+				return index
+			}(),
+			expected: func(index goschema.Index) bool {
+				return index.Name == "idx_users_bio" &&
+					index.Type == "FULLTEXT" &&
+					index.Parser == "ngram"
+			},
+		},
+		{
 			name: "structured index parts",
 			index: ast.NewIndex("idx_users_rank_name", "users").
 				SetParts([]ast.IndexPart{

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -232,6 +232,8 @@ type Index struct {
 	// GIN/GIST/BTREE/HASH; for ClickHouse data-skipping indexes it is
 	// "minmax"/"set(N)"/"bloom_filter(p)"/"tokenbf_v1(...)"/etc.
 	Type string
+	// Parser carries a MySQL FULLTEXT parser name, for example ngram.
+	Parser string
 	// Condition is the WHERE clause for partial indexes (PostgreSQL only).
 	Condition string
 	// Operator is the operator class (PostgreSQL only, e.g. "gin_trgm_ops").

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -66,3 +66,15 @@ func TestMySQLRenderer_IndexParts(t *testing.T) {
 	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_name ON users (name (64));")
 	c.Assert(sql, qt.Contains, "CREATE INDEX idx_users_lower_name ON users ((lower(name)));")
 }
+
+func TestMySQLRenderer_FulltextIndexParser(t *testing.T) {
+	c := qt.New(t)
+
+	index := ast.NewIndex("idx_users_bio", "users", "bio")
+	index.Type = "FULLTEXT"
+	index.Parser = "ngram"
+
+	sql := renderMySQL(t, index)
+
+	c.Assert(sql, qt.Contains, "CREATE FULLTEXT INDEX idx_users_bio ON users (bio) /*!50100 WITH PARSER `ngram` */;")
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -335,7 +335,11 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	parts = append(parts, node.Name)
 	parts = append(parts, "ON")
 	parts = append(parts, node.Table)
-	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(renderIndexParts(node.EffectiveParts()), ", ")))
+	columnSpec := fmt.Sprintf("(%s)", strings.Join(renderIndexParts(node.EffectiveParts()), ", "))
+	if node.Parser != "" {
+		columnSpec += fmt.Sprintf(" /*!50100 WITH PARSER `%s` */", strings.ReplaceAll(node.Parser, "`", "``"))
+	}
+	parts = append(parts, columnSpec)
 
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 	return nil

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -57,6 +57,10 @@ table "users" {
     null = false
   }
 
+  column "bio" {
+    type = text
+  }
+
   primary_key {
     columns = [column.id]
   }
@@ -64,6 +68,12 @@ table "users" {
   index "idx_users_email" {
     unique = true
     columns = [column.email]
+  }
+
+  index "idx_users_bio" {
+    type = FULLTEXT
+    parser = ngram
+    columns = [column.bio]
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add MySQL FULLTEXT parser metadata to index schema/AST
- parse Atlas HCL `parser = ngram` for FULLTEXT indexes
- render MySQL/MariaDB `WITH PARSER` comments and document the HCL form

## Validation
- go test ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/renderer/dialects/mysql
- go test ./...
- golangci-lint run ./...

Part of the Atlas conformance work; this keeps expression/function parsing out of scope.