### PR TITLE
Preserve empty literal defaults

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -91,8 +91,17 @@ type Visitor interface {
 type DefaultValue struct {
 	// Value contains literal default values like 'default_value', '42', 'true'
 	Value string
+	// ValueSet distinguishes an explicitly empty literal from no literal.
+	ValueSet bool
 	// Function contains function calls like NOW(), UUID()
 	Expression string
+}
+
+// HasLiteral reports whether the default is a literal value, including an
+// explicitly empty string. Non-empty Value is accepted for compatibility with
+// existing struct literals.
+func (d *DefaultValue) HasLiteral() bool {
+	return d != nil && (d.ValueSet || d.Value != "")
 }
 
 // ForeignKeyRef represents a foreign key reference with optional referential actions.

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -313,7 +313,7 @@ func (n *ColumnNode) SetAutoIncrement() *ColumnNode {
 //	column.SetDefault("'active'")
 //	column.SetDefault("0")
 func (n *ColumnNode) SetDefault(value string) *ColumnNode {
-	n.Default = &DefaultValue{Value: value}
+	n.Default = &DefaultValue{Value: value, ValueSet: true}
 	return n
 }
 

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -160,6 +160,20 @@ func TestColumnNode_SetDefault(t *testing.T) {
 
 	c.Assert(column.Default, qt.IsNotNil)
 	c.Assert(column.Default.Value, qt.Equals, "'active'")
+	c.Assert(column.Default.ValueSet, qt.IsTrue)
+	c.Assert(column.Default.HasLiteral(), qt.IsTrue)
+	c.Assert(column.Default.Expression, qt.Equals, "")
+}
+
+func TestColumnNode_SetDefaultEmptyLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	column := ast.NewColumn("name", "VARCHAR(50)").SetDefault("")
+
+	c.Assert(column.Default, qt.IsNotNil)
+	c.Assert(column.Default.Value, qt.Equals, "")
+	c.Assert(column.Default.ValueSet, qt.IsTrue)
+	c.Assert(column.Default.HasLiteral(), qt.IsTrue)
 	c.Assert(column.Default.Expression, qt.Equals, "")
 }
 

--- a/core/ast/types.go
+++ b/core/ast/types.go
@@ -128,7 +128,7 @@ func (td *DomainTypeDef) SetNotNull() *DomainTypeDef {
 
 // SetDefault sets a literal default value and returns the domain for chaining.
 func (td *DomainTypeDef) SetDefault(value string) *DomainTypeDef {
-	td.Default = &DefaultValue{Value: value}
+	td.Default = &DefaultValue{Value: value, ValueSet: true}
 	return td
 }
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -617,6 +617,7 @@ func (p *parser) setDefault(field *goschema.Field, attr *hclsyntax.Attribute) {
 		return
 	}
 	field.Default = p.exprString(attr)
+	field.DefaultSet = true
 }
 
 func (p *parser) optionalRefName(attr *hclsyntax.Attribute) string {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -400,8 +400,27 @@ table "accounts" {
 	c.Assert(db.Fields[0].AutoInc, qt.IsTrue)
 	c.Assert(db.Fields[1].DefaultExpr, qt.Equals, "CURRENT_TIMESTAMP")
 	c.Assert(db.Fields[2].Default, qt.Equals, "active")
+	c.Assert(db.Fields[2].DefaultSet, qt.IsTrue)
 	c.Assert(db.Constraints, qt.HasLen, 1)
 	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, "status IN ('active', 'disabled')")
+}
+
+func TestParseEmptyLiteralDefault(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "name" {
+    type = varchar(255)
+    default = ""
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].Default, qt.Equals, "")
+	c.Assert(db.Fields[0].DefaultSet, qt.IsTrue)
+	c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "")
 }
 
 func TestParseBracketQuotedColumnReferences(t *testing.T) {

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -88,6 +88,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	checkName := field.CheckName
 	comment := field.Comment
 	defaultValue := field.Default
+	defaultSet := field.DefaultSet
 	defaultExpr := field.DefaultExpr
 
 	// Apply built-in platform-specific type conversions for MySQL/MariaDB
@@ -110,6 +111,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField.CheckName = checkName
 		newField.Comment = comment
 		newField.Default = defaultValue
+		newField.DefaultSet = defaultSet
 		newField.DefaultExpr = defaultExpr
 		return newField
 	}
@@ -122,6 +124,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField.CheckName = checkName
 		newField.Comment = comment
 		newField.Default = defaultValue
+		newField.DefaultSet = defaultSet
 		newField.DefaultExpr = defaultExpr
 		return newField
 	}
@@ -145,12 +148,14 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	// Override default value if specified
 	if defaultOverride, ok := platformOverrides["default"]; ok {
 		defaultValue = defaultOverride
+		defaultSet = true
 		defaultExpr = "" // Clear expression if literal default is overridden
 	}
 	// Override default expression if specified
 	if defaultExprOverride, ok := platformOverrides["default_expr"]; ok {
 		defaultExpr = defaultExprOverride
 		defaultValue = "" // Clear literal if expression default is overridden
+		defaultSet = false
 	}
 
 	newField := field // Shallow copy to avoid modifying original field
@@ -159,6 +164,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	newField.CheckName = checkName
 	newField.Comment = comment
 	newField.Default = defaultValue
+	newField.DefaultSet = defaultSet
 	newField.DefaultExpr = defaultExpr
 
 	return newField
@@ -309,7 +315,7 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 
 	// Set default values (using potentially overridden values)
 	switch {
-	case field.Default != "":
+	case field.DefaultSet || field.Default != "":
 		column.SetDefault(field.Default)
 	case field.DefaultExpr != "":
 		column.SetDefaultExpression(field.DefaultExpr)
@@ -383,7 +389,7 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 	}
 
 	// Set default value (using potentially overridden value)
-	if field.Default != "" {
+	if field.DefaultSet || field.Default != "" {
 		column.SetDefault(field.Default)
 	}
 

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -109,7 +109,20 @@ func TestFromField_DefaultValues(t *testing.T) {
 				Default: "'active'",
 			},
 			expected: func(col *ast.ColumnNode) bool {
-				return col.Default != nil && col.Default.Value == "'active'" && col.Default.Expression == ""
+				return col.Default != nil && col.Default.Value == "'active'" &&
+					col.Default.HasLiteral() && col.Default.Expression == ""
+			},
+		},
+		{
+			name: "empty literal default value",
+			field: goschema.Field{
+				Name:       "status",
+				Type:       "VARCHAR(20)",
+				DefaultSet: true,
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.Default != nil && col.Default.Value == "" &&
+					col.Default.HasLiteral() && col.Default.Expression == ""
 			},
 		},
 		{

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -148,8 +148,9 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 
 	// Extract default values
 	if column.Default != nil {
-		if column.Default.Value != "" {
+		if column.Default.HasLiteral() {
 			field.Default = column.Default.Value
+			field.DefaultSet = true
 		} else if column.Default.Expression != "" {
 			field.DefaultExpr = column.Default.Expression
 		}
@@ -653,7 +654,7 @@ func MergeFieldOverrides(baseField goschema.Field, platformFields map[string]gos
 		}
 
 		// Check for default value differences
-		if platformField.Default != baseField.Default {
+		if platformField.Default != baseField.Default || platformField.DefaultSet != baseField.DefaultSet {
 			platformOverrides["default"] = platformField.Default
 		}
 

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -97,7 +97,15 @@ func TestToField_DefaultValues(t *testing.T) {
 			column:     ast.NewColumn("status", "VARCHAR(20)").SetDefault("'active'"),
 			structName: "User",
 			expected: func(field goschema.Field) bool {
-				return field.Default == "'active'" && field.DefaultExpr == ""
+				return field.Default == "'active'" && field.DefaultSet && field.DefaultExpr == ""
+			},
+		},
+		{
+			name:       "empty literal default value",
+			column:     ast.NewColumn("status", "VARCHAR(20)").SetDefault(""),
+			structName: "User",
+			expected: func(field goschema.Field) bool {
+				return field.Default == "" && field.DefaultSet && field.DefaultExpr == ""
 			},
 		},
 		{
@@ -113,7 +121,7 @@ func TestToField_DefaultValues(t *testing.T) {
 			column:     ast.NewColumn("description", "TEXT"),
 			structName: "User",
 			expected: func(field goschema.Field) bool {
-				return field.Default == "" && field.DefaultExpr == ""
+				return field.Default == "" && !field.DefaultSet && field.DefaultExpr == ""
 			},
 		},
 	}

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -159,6 +159,7 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 			fieldType = enumName
 		}
 
+		_, defaultSet := kv["default"]
 		*schemaFields = append(*schemaFields, Field{
 			StructName:     structName,
 			FieldName:      name.Name,
@@ -170,6 +171,7 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 			Unique:         kv["unique"] == "true",
 			UniqueExpr:     kv["unique_expr"],
 			Default:        kv["default"],
+			DefaultSet:     defaultSet,
 			DefaultExpr:    kv["default_expr"],
 			Foreign:        kv["foreign"],
 			ForeignKeyName: kv["foreign_key_name"],

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -136,6 +136,7 @@ type Field struct {
 	Unique         bool     // Whether this column has a unique constraint
 	UniqueExpr     string   // Custom unique constraint expression
 	Default        string   // Default value for the column
+	DefaultSet     bool     // Whether Default is set, including an empty string literal
 	DefaultExpr    string   // Default expression (e.g., "NOW()", "UUID()", "CURRENT_TIMESTAMP", "1", "true")
 	Foreign        string   // Foreign key reference (e.g., "users(id)")
 	ForeignKeyName string   // Custom foreign key constraint name

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2029,7 +2029,7 @@ func (p *Parser) handleStringLiteral() (*ast.DefaultValue, error) {
 		}
 	}
 
-	return &ast.DefaultValue{Value: value}, nil
+	return &ast.DefaultValue{Value: value, ValueSet: true}, nil
 }
 
 func (p *Parser) parseArrayLiteral(value string) (*string, error) {
@@ -2103,7 +2103,7 @@ func (p *Parser) handleFunctionCallOrKeyword() (*ast.DefaultValue, error) {
 	if upperValue == "E" && p.current.Type == lexer.TokenString {
 		value += p.current.Value
 		p.advance()
-		return &ast.DefaultValue{Value: value}, nil
+		return &ast.DefaultValue{Value: value, ValueSet: true}, nil
 	}
 
 	// Check if it's a function call
@@ -2141,7 +2141,7 @@ func (p *Parser) handleFunctionCallOrKeyword() (*ast.DefaultValue, error) {
 	}
 
 	// Regular identifier/keyword
-	return &ast.DefaultValue{Value: value}, nil
+	return &ast.DefaultValue{Value: value, ValueSet: true}, nil
 }
 
 func (p *Parser) handleNumber() (*ast.DefaultValue, error) {
@@ -2152,7 +2152,7 @@ func (p *Parser) handleNumber() (*ast.DefaultValue, error) {
 		if p.current.Type == lexer.TokenIdentifier || p.current.Type == lexer.TokenOperator {
 			value := sign + p.current.Value
 			p.advance()
-			return &ast.DefaultValue{Value: value}, nil
+			return &ast.DefaultValue{Value: value, ValueSet: true}, nil
 		}
 	}
 	// Check if it's a number that the lexer tokenized as an operator (like "0", "1", etc.)
@@ -2161,7 +2161,7 @@ func (p *Parser) handleNumber() (*ast.DefaultValue, error) {
 	// Check if this looks like a number
 	if isNumeric(value) {
 		p.advance()
-		return &ast.DefaultValue{Value: value}, nil
+		return &ast.DefaultValue{Value: value, ValueSet: true}, nil
 	}
 
 	return nil, fmt.Errorf("unexpected token for default value: %s at position %d", p.current.Value, p.current.Start)

--- a/core/renderer/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/dialects/clickhouse/clickhouse.go
@@ -295,7 +295,7 @@ func (r *Renderer) renderColumn(col *ast.ColumnNode) (string, error) {
 		switch {
 		case col.Default.Expression != "":
 			parts = append(parts, "DEFAULT "+col.Default.Expression)
-		case col.Default.Value != "":
+		case col.Default.HasLiteral():
 			parts = append(parts, "DEFAULT "+escapeStringLiteral(col.Default.Value))
 		}
 	}

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -50,6 +50,17 @@ func TestMySQLRenderer_ConstraintColumnParts(t *testing.T) {
 	c.Assert(sql, qt.Contains, "PRIMARY KEY (`id` (7) DESC)")
 }
 
+func TestMySQLRenderer_EmptyLiteralDefault(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("name", "varchar(255)").SetNotNull().SetDefault(""))
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "name varchar(255) NOT NULL DEFAULT ''")
+}
+
 func TestMySQLRenderer_IndexParts(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -545,7 +545,7 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	switch {
 	case column.Default == nil:
 		// No default value
-	case column.Default.Value != "":
+	case column.Default.HasLiteral():
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", r.escapeValue(column.Default.Value)))
 	case column.Default.Expression != "":
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
@@ -711,7 +711,7 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 	if column.Default != nil {
 		if column.Default.Expression != "" {
 			parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
-		} else if column.Default.Value != "" {
+		} else if column.Default.HasLiteral() {
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", column.Default.Value))
 		}
 	}

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -110,7 +110,7 @@ func (r *Renderer) VisitCreateType(node *ast.CreateTypeNode) error {
 
 		// Add DEFAULT if specified
 		if typeDef.Default != nil {
-			if typeDef.Default.Value != "" {
+			if typeDef.Default.HasLiteral() {
 				sql += fmt.Sprintf(" DEFAULT '%s'", typeDef.Default.Value)
 			} else if typeDef.Default.Expression != "" {
 				sql += fmt.Sprintf(" DEFAULT %s", typeDef.Default.Expression)
@@ -623,7 +623,7 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	switch {
 	case column.Default == nil:
 		// No default value
-	case column.Default.Value != "":
+	case column.Default.HasLiteral():
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", r.escapeValue(column.Default.Value)))
 	case column.Default.Expression != "":
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
@@ -822,7 +822,7 @@ func (r *Renderer) renderPostgreSQLModifyColumn(tableName string, column *ast.Co
 	switch {
 	case column.Default == nil:
 		r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT;", tableName, column.Name)
-	case column.Default.Value != "":
+	case column.Default.HasLiteral():
 		r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;", tableName, column.Name, r.escapeValue(column.Default.Value))
 	case column.Default.Expression != "":
 		r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;", tableName, column.Name, column.Default.Expression)
@@ -862,7 +862,7 @@ func (r *Renderer) updateNullValuesBeforeNotNull(tableName string, column *ast.C
 	if column.Default != nil {
 		if column.Default.Expression != "" {
 			r.w.WriteLinef("        UPDATE %s SET %s = %s WHERE %s IS NULL;", r.escapeIdentifier(tableName), r.escapeIdentifier(column.Name), column.Default.Expression, r.escapeIdentifier(column.Name))
-		} else if column.Default.Value != "" {
+		} else if column.Default.HasLiteral() {
 			r.w.WriteLinef("        UPDATE %s SET %s = %s WHERE %s IS NULL;", r.escapeIdentifier(tableName), r.escapeIdentifier(column.Name), r.escapeValue(column.Default.Value), r.escapeIdentifier(column.Name))
 		}
 	} else {


### PR DESCRIPTION
## Summary
- distinguish explicit empty literal defaults from missing defaults in goschema and AST
- preserve empty defaults across Atlas HCL parsing, Go annotations, converters, SQL parsing, and renderers
- add focused tests for empty literal defaults and MySQL rendering

## Validation
- go test ./core/ast ./core/atlashcl ./core/goschema ./core/convert/fromschema ./core/convert/toschema ./core/parser ./core/renderer/dialects/mysql ./core/renderer/dialects/postgres ./core/renderer/dialects/clickhouse
- go test ./...
- golangci-lint run ./...

Needed for the Atlas MySQL column-default-expr conformance fixture.