### PR TITLE
Support MySQL column charset and collate

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -224,6 +224,10 @@ type ColumnNode struct {
 	GeneratedExpression string
 	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
 	GeneratedKind string
+	// Charset is an optional column character set for MySQL-compatible dialects.
+	Charset string
+	// Collate is an optional column collation for MySQL-compatible dialects.
+	Collate string
 	// Comment is an optional column comment
 	Comment string
 	// ForeignKey contains foreign key reference information if this column references another table
@@ -357,6 +361,18 @@ func (n *ColumnNode) SetCheckName(name string) *ColumnNode {
 func (n *ColumnNode) SetGenerated(expression, kind string) *ColumnNode {
 	n.GeneratedExpression = expression
 	n.GeneratedKind = kind
+	return n
+}
+
+// SetCharset sets the column character set and returns the column for chaining.
+func (n *ColumnNode) SetCharset(charset string) *ColumnNode {
+	n.Charset = charset
+	return n
+}
+
+// SetCollate sets the column collation and returns the column for chaining.
+func (n *ColumnNode) SetCollate(collate string) *ColumnNode {
+	n.Collate = collate
 	return n
 }
 

--- a/core/astbuilder/columnbuilder.go
+++ b/core/astbuilder/columnbuilder.go
@@ -18,6 +18,7 @@ import (
 //   - Auto-increment behavior
 //   - Default values (literal and expressions)
 //   - Check constraints
+//   - MySQL-compatible character sets and collations
 //   - Comments
 //   - Foreign key references
 //
@@ -175,6 +176,18 @@ func (cb *ColumnBuilder) Check(expression string) *ColumnBuilder {
 // Generated marks the column as generated from the supplied raw SQL expression.
 func (cb *ColumnBuilder) Generated(expression, kind string) *ColumnBuilder {
 	cb.column.SetGenerated(expression, kind)
+	return cb
+}
+
+// Charset sets the column character set and returns the ColumnBuilder for chaining.
+func (cb *ColumnBuilder) Charset(charset string) *ColumnBuilder {
+	cb.column.SetCharset(charset)
+	return cb
+}
+
+// Collate sets the column collation and returns the ColumnBuilder for chaining.
+func (cb *ColumnBuilder) Collate(collate string) *ColumnBuilder {
+	cb.column.SetCollate(collate)
 	return cb
 }
 
@@ -406,6 +419,18 @@ func (scb *SchemaColumnBuilder) Check(expression string) *SchemaColumnBuilder {
 // Generated marks the column as generated from the supplied raw SQL expression.
 func (scb *SchemaColumnBuilder) Generated(expression, kind string) *SchemaColumnBuilder {
 	scb.column.SetGenerated(expression, kind)
+	return scb
+}
+
+// Charset sets the column character set and returns the SchemaColumnBuilder for chaining.
+func (scb *SchemaColumnBuilder) Charset(charset string) *SchemaColumnBuilder {
+	scb.column.SetCharset(charset)
+	return scb
+}
+
+// Collate sets the column collation and returns the SchemaColumnBuilder for chaining.
+func (scb *SchemaColumnBuilder) Collate(collate string) *SchemaColumnBuilder {
+	scb.column.SetCollate(collate)
 	return scb
 }
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -185,6 +185,8 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		Unique:              p.optionalBool(block.Body.Attributes["unique"], false),
 		GeneratedExpression: generated.expression,
 		GeneratedKind:       generated.kind,
+		Charset:             p.optionalString(block.Body.Attributes["charset"]),
+		Collate:             p.optionalString(block.Body.Attributes["collate"]),
 		Comment:             p.optionalString(block.Body.Attributes["comment"]),
 	}
 	if attr := block.Body.Attributes["default"]; attr != nil {
@@ -535,6 +537,8 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 		"unique":         true,
 		"default":        true,
 		"as":             true,
+		"charset":        true,
+		"collate":        true,
 		"comment":        true,
 	}, "column")
 }

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -171,6 +171,28 @@ table "users" {
 	c.Assert(sql, qt.Contains, "COLLATE=utf8mb4_bin")
 }
 
+func TestParseMySQLColumnCharsetCollate(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "name" {
+    null = false
+    type = varchar(255)
+    charset = "hebrew"
+    collate = "hebrew_general_ci"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].Charset, qt.Equals, "hebrew")
+	c.Assert(db.Fields[0].Collate, qt.Equals, "hebrew_general_ci")
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, "name varchar(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL")
+}
+
 func TestParseSQLiteTableOptionsRejectNonBool(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -67,6 +67,8 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 				Primary:       dbColumn.IsPrimaryKey,
 				AutoInc:       dbColumn.IsAutoIncrement,
 				Unique:        dbColumn.IsUnique,
+				Charset:       dbColumn.Charset,
+				Collate:       dbColumn.Collate,
 				GeneratedKind: dbColumn.GeneratedKind,
 			}
 			if dbColumn.GeneratedExpression != nil {

--- a/core/convert/dbschematogo/dbschematogo_test.go
+++ b/core/convert/dbschematogo/dbschematogo_test.go
@@ -195,6 +195,31 @@ func TestConvertDBSchemaToGoSchema_GeneratedColumns(t *testing.T) {
 	c.Assert(result.Fields[0].GeneratedKind, qt.Equals, "STORED")
 }
 
+func TestConvertDBSchemaToGoSchema_ColumnCharsetCollate(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "users",
+				Columns: []types.DBColumn{
+					{
+						Name:     "name",
+						DataType: "varchar(255)",
+						Charset:  "hebrew",
+						Collate:  "hebrew_general_ci",
+					},
+				},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Fields, qt.HasLen, 1)
+	c.Assert(result.Fields[0].Charset, qt.Equals, "hebrew")
+	c.Assert(result.Fields[0].Collate, qt.Equals, "hebrew_general_ci")
+}
+
 func TestConvertDBSchemaToGoSchema_ExtensionDefaultValues(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -87,6 +87,8 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	checkConstraint := field.Check
 	checkName := field.CheckName
 	comment := field.Comment
+	charset := field.Charset
+	collate := field.Collate
 	defaultValue := field.Default
 	defaultSet := field.DefaultSet
 	defaultExpr := field.DefaultExpr
@@ -110,6 +112,8 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField.Check = checkConstraint
 		newField.CheckName = checkName
 		newField.Comment = comment
+		newField.Charset = charset
+		newField.Collate = collate
 		newField.Default = defaultValue
 		newField.DefaultSet = defaultSet
 		newField.DefaultExpr = defaultExpr
@@ -123,6 +127,8 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		newField.Check = checkConstraint
 		newField.CheckName = checkName
 		newField.Comment = comment
+		newField.Charset = charset
+		newField.Collate = collate
 		newField.Default = defaultValue
 		newField.DefaultSet = defaultSet
 		newField.DefaultExpr = defaultExpr
@@ -145,6 +151,13 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	if commentOverride, ok := platformOverrides["comment"]; ok {
 		comment = commentOverride
 	}
+	// Override column charset/collation if specified.
+	if charsetOverride, ok := platformOverrides["charset"]; ok {
+		charset = charsetOverride
+	}
+	if collateOverride, ok := platformOverrides["collate"]; ok {
+		collate = collateOverride
+	}
 	// Override default value if specified
 	if defaultOverride, ok := platformOverrides["default"]; ok {
 		defaultValue = defaultOverride
@@ -163,6 +176,8 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 	newField.Check = checkConstraint
 	newField.CheckName = checkName
 	newField.Comment = comment
+	newField.Charset = charset
+	newField.Collate = collate
 	newField.Default = defaultValue
 	newField.DefaultSet = defaultSet
 	newField.DefaultExpr = defaultExpr
@@ -331,6 +346,12 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 	if field.GeneratedExpression != "" {
 		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
 	}
+	if field.Charset != "" {
+		column.SetCharset(field.Charset)
+	}
+	if field.Collate != "" {
+		column.SetCollate(field.Collate)
+	}
 
 	// Set comment (using potentially overridden value)
 	if field.Comment != "" {
@@ -407,6 +428,12 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 	}
 	if field.GeneratedExpression != "" {
 		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
+	}
+	if field.Charset != "" {
+		column.SetCharset(field.Charset)
+	}
+	if field.Collate != "" {
+		column.SetCollate(field.Collate)
 	}
 
 	// Set comment (using potentially overridden value)

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -83,6 +83,18 @@ func TestFromField_BasicProperties(t *testing.T) {
 				return col.GeneratedExpression == "lower(name)" && col.GeneratedKind == "STORED"
 			},
 		},
+		{
+			name: "column charset and collate",
+			field: goschema.Field{
+				Name:    "name",
+				Type:    "VARCHAR(255)",
+				Charset: "hebrew",
+				Collate: "hebrew_general_ci",
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.Charset == "hebrew" && col.Collate == "hebrew_general_ci"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -135,6 +135,8 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 		Check:               column.Check,
 		GeneratedExpression: column.GeneratedExpression,
 		GeneratedKind:       column.GeneratedKind,
+		Charset:             column.Charset,
+		Collate:             column.Collate,
 		Comment:             column.Comment,
 	}
 
@@ -651,6 +653,14 @@ func MergeFieldOverrides(baseField goschema.Field, platformFields map[string]gos
 		// Check for comment differences
 		if platformField.Comment != baseField.Comment {
 			platformOverrides["comment"] = platformField.Comment
+		}
+
+		// Check for column charset/collation differences
+		if platformField.Charset != baseField.Charset {
+			platformOverrides["charset"] = platformField.Charset
+		}
+		if platformField.Collate != baseField.Collate {
+			platformOverrides["collate"] = platformField.Collate
 		}
 
 		// Check for default value differences

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -74,6 +74,17 @@ func TestToField_BasicProperties(t *testing.T) {
 					field.GeneratedKind == "STORED"
 			},
 		},
+		{
+			name: "column charset and collate",
+			column: ast.NewColumn("name", "VARCHAR(255)").
+				SetCharset("hebrew").
+				SetCollate("hebrew_general_ci"),
+			structName: "User",
+			expected: func(field goschema.Field) bool {
+				return field.Charset == "hebrew" &&
+					field.Collate == "hebrew_general_ci"
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -628,6 +639,28 @@ func TestMergeFieldOverrides_BasicMerging(t *testing.T) {
 	// Check MariaDB overrides
 	c.Assert(result.Overrides["mariadb"]["type"], qt.Equals, "LONGTEXT")
 	c.Assert(result.Overrides["mariadb"]["check"], qt.Equals, "JSON_VALID(data)")
+}
+
+func TestMergeFieldOverrides_CharsetCollate(t *testing.T) {
+	c := qt.New(t)
+
+	baseField := goschema.Field{
+		Name: "name",
+		Type: "VARCHAR(255)",
+	}
+	platformFields := map[string]goschema.Field{
+		"mysql": {
+			Name:    "name",
+			Type:    "VARCHAR(255)",
+			Charset: "hebrew",
+			Collate: "hebrew_general_ci",
+		},
+	}
+
+	result := toschema.MergeFieldOverrides(baseField, platformFields)
+
+	c.Assert(result.Overrides["mysql"]["charset"], qt.Equals, "hebrew")
+	c.Assert(result.Overrides["mysql"]["collate"], qt.Equals, "hebrew_general_ci")
 }
 
 func TestMergeFieldOverrides_DefaultValues(t *testing.T) {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -149,8 +149,12 @@ type Field struct {
 	GeneratedExpression string
 	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
 	GeneratedKind string
-	Comment       string                       // Column comment
-	Overrides     map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
+	// Charset stores the column character set for MySQL-compatible dialects.
+	Charset string
+	// Collate stores the column collation for MySQL-compatible dialects.
+	Collate   string
+	Comment   string                       // Column comment
+	Overrides map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
 }
 
 // IndexPart represents one column or expression inside an index definition.

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -1598,7 +1598,7 @@ func (p *Parser) handleCharacter(column *ast.ColumnNode) {
 	p.advance()
 	p.skipWhitespace()
 	if p.current.Type == lexer.TokenIdentifier {
-		appendColumnComment(column, "CHARACTER SET "+p.current.Value)
+		column.Charset = p.current.Value
 		p.advance()
 	}
 }
@@ -1611,7 +1611,7 @@ func (p *Parser) handleCharset(column *ast.ColumnNode) error {
 	if err != nil {
 		return fmt.Errorf("expected charset name: %w", err)
 	}
-	appendColumnComment(column, "CHARSET "+value)
+	column.Charset = value
 	return nil
 }
 
@@ -1634,7 +1634,7 @@ func (p *Parser) handleCollate(column *ast.ColumnNode) error {
 		return fmt.Errorf("expected collation name: got %s at position %d", p.current.Type, p.current.Start)
 	}
 
-	appendColumnComment(column, "COLLATE "+collation)
+	column.Collate = collation
 
 	return nil
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -49,6 +49,23 @@ func TestParser_ParseCreateTable_Basic(t *testing.T) {
 	c.Assert(nameColumn.Nullable, qt.IsFalse) // NOT NULL specified
 }
 
+func TestParser_ParseCreateTable_ColumnCharsetCollate(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE TABLE users (name VARCHAR(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL);"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	createTable, ok := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].Charset, qt.Equals, "hebrew")
+	c.Assert(createTable.Columns[0].Collate, qt.Equals, "hebrew_general_ci")
+	c.Assert(createTable.Columns[0].Nullable, qt.IsFalse)
+}
+
 func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 	c := qt.New(t)
 
@@ -350,9 +367,10 @@ func TestParser_ParseCreateTable_MySQLColumnModifiers(t *testing.T) {
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 	c.Assert(createTable.Columns, qt.HasLen, 3)
 	c.Assert(createTable.Columns[0].Comment, qt.Equals, "COMMENT 'column1'")
-	c.Assert(createTable.Columns[1].Comment, qt.Equals, "CHARACTER SET utf8")
+	c.Assert(createTable.Columns[1].Charset, qt.Equals, "utf8")
 	c.Assert(createTable.Columns[1].Nullable, qt.IsFalse)
-	c.Assert(createTable.Columns[2].Comment, qt.Equals, "CHARSET utf8; COLLATE utf8_unicode_ci")
+	c.Assert(createTable.Columns[2].Charset, qt.Equals, "utf8")
+	c.Assert(createTable.Columns[2].Collate, qt.Equals, "utf8_unicode_ci")
 	c.Assert(createTable.Columns[2].Nullable, qt.IsTrue)
 }
 

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -61,6 +61,20 @@ func TestMySQLRenderer_EmptyLiteralDefault(t *testing.T) {
 	c.Assert(sql, qt.Contains, "name varchar(255) NOT NULL DEFAULT ''")
 }
 
+func TestMySQLRenderer_ColumnCharsetCollate(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("name", "varchar(255)").
+			SetCharset("hebrew").
+			SetCollate("hebrew_general_ci").
+			SetNotNull())
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "name varchar(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL")
+}
+
 func TestMySQLRenderer_IndexParts(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -520,6 +520,12 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 
 	// Column name and type
 	parts = append(parts, fmt.Sprintf("  %s %s", column.Name, column.Type))
+	if column.Charset != "" {
+		parts = append(parts, "CHARACTER SET", column.Charset)
+	}
+	if column.Collate != "" {
+		parts = append(parts, "COLLATE", column.Collate)
+	}
 
 	// Column constraints
 	if column.Primary {

--- a/core/yamlschema/yamlschema.go
+++ b/core/yamlschema/yamlschema.go
@@ -97,6 +97,8 @@ type fieldSpec struct {
 	Enum           stringList   `yaml:"enum"`
 	Check          stringScalar `yaml:"check"`
 	CheckName      stringScalar `yaml:"check_name"`
+	Charset        stringScalar `yaml:"charset"`
+	Collate        stringScalar `yaml:"collate"`
 	Comment        stringScalar `yaml:"comment"`
 	Platform       platformSpec `yaml:"platform"`
 	Overrides      platformSpec `yaml:"overrides"`
@@ -381,6 +383,8 @@ func buildField(structName, key string, spec fieldSpec, db *goschema.Database) g
 		Enum:           enumValues,
 		Check:          string(spec.Check),
 		CheckName:      string(spec.CheckName),
+		Charset:        string(spec.Charset),
+		Collate:        string(spec.Collate),
 		Comment:        string(spec.Comment),
 		Overrides:      mergePlatform(spec.Platform, spec.Overrides),
 	}

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -213,6 +213,21 @@ func TestMySQLReader_parseTableFromDDL(t *testing.T) {
 			},
 		},
 		{
+			name: "column charset and collate",
+			ddl: "CREATE TABLE `users` (\n" +
+				"  `name` varchar(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL\n" +
+				") ENGINE=InnoDB",
+			expectError: false,
+			validate: func(c *qt.C, table types.DBTable) {
+				c.Assert(table.Columns, qt.HasLen, 1)
+				nameCol := table.Columns[0]
+				c.Assert(nameCol.Name, qt.Equals, "name")
+				c.Assert(nameCol.Charset, qt.Equals, "hebrew")
+				c.Assert(nameCol.Collate, qt.Equals, "hebrew_general_ci")
+				c.Assert(nameCol.IsNullable, qt.Equals, "NO")
+			},
+		},
+		{
 			name:        "invalid DDL",
 			ddl:         "INVALID SQL STATEMENT",
 			expectError: true,

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -264,6 +264,8 @@ func (r *Reader) convertASTToTable(node *ast.CreateTableNode) types.DBTable {
 			DataType:        astCol.Type,
 			ColumnType:      astCol.Type, // For MySQL, these are often the same
 			IsNullable:      isNullable,
+			Charset:         astCol.Charset,
+			Collate:         astCol.Collate,
 			OrdinalPosition: len(table.Columns) + 1,
 			IsAutoIncrement: astCol.AutoInc,
 			IsPrimaryKey:    astCol.Primary,

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -63,6 +63,8 @@ type DBColumn struct {
 	IsNullable         string  `json:"is_nullable"`          // YES/NO
 	ColumnDefault      *string `json:"column_default"`       // Can be NULL
 	CharacterMaxLength *int    `json:"character_max_length"` // For VARCHAR, etc.
+	Charset            string  `json:"charset,omitempty"`    // MySQL/MariaDB column character set
+	Collate            string  `json:"collate,omitempty"`    // MySQL/MariaDB column collation
 	NumericPrecision   *int    `json:"numeric_precision"`    // For DECIMAL, etc.
 	NumericScale       *int    `json:"numeric_scale"`        // For DECIMAL, etc.
 	OrdinalPosition    int     `json:"ordinal_position"`


### PR DESCRIPTION
## Summary
- add column-level charset/collate fields to AST, goschema, YAML, and builders
- parse Atlas HCL and MySQL DDL column charset/collate as structured metadata
- render MySQL/MariaDB column charset/collate and preserve it through DB schema conversion

## Validation
- go test ./...
- golangci-lint run ./...
- git diff --check