### PR TITLE
Support MariaDB JSON column rendering

### DIFF
--- a/core/renderer/dialects/mariadb/schema_objects_test.go
+++ b/core/renderer/dialects/mariadb/schema_objects_test.go
@@ -1,0 +1,37 @@
+package mariadb_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestMariaDBRenderer_JSONColumnUsesLongtextCheck(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("id", "int").SetNotNull()).
+		AddColumn(ast.NewColumn("name", "json").SetNotNull())
+
+	sql, err := renderer.RenderSQL("mariadb", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "name longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(name))")
+}
+
+func TestMariaDBRenderer_JSONColumnPreservesExplicitCharsetCollate(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("payload", "json").
+			SetCharset("utf8").
+			SetCollate("utf8_bin"))
+
+	sql, err := renderer.RenderSQL("mariadb", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "payload longtext CHARACTER SET utf8 COLLATE utf8_bin CHECK (json_valid(payload))")
+}

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -75,6 +75,18 @@ func TestMySQLRenderer_ColumnCharsetCollate(t *testing.T) {
 	c.Assert(sql, qt.Contains, "name varchar(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL")
 }
 
+func TestMySQLRenderer_JSONColumnRemainsNativeJSON(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("payload", "json").SetNotNull())
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "payload json NOT NULL")
+	c.Assert(sql, qt.Not(qt.Contains), "json_valid")
+}
+
 func TestMySQLRenderer_IndexParts(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -519,13 +519,9 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	var parts []string
 
 	// Column name and type
-	parts = append(parts, fmt.Sprintf("  %s %s", column.Name, column.Type))
-	if column.Charset != "" {
-		parts = append(parts, "CHARACTER SET", column.Charset)
-	}
-	if column.Collate != "" {
-		parts = append(parts, "COLLATE", column.Collate)
-	}
+	columnType := r.renderColumnType(column, column.Type)
+	parts = append(parts, fmt.Sprintf("  %s %s", column.Name, columnType))
+	parts = r.appendColumnCharsetCollate(parts, column)
 
 	// Column constraints
 	if column.Primary {
@@ -569,8 +565,46 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 			parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
 		}
 	}
+	if r.needsMariaDBJSONCheck(column) {
+		parts = append(parts, fmt.Sprintf("CHECK (json_valid(%s))", column.Name))
+	}
 
 	return strings.Join(parts, " "), nil
+}
+
+func (r *Renderer) renderColumnType(column *ast.ColumnNode, columnType string) string {
+	if r.isMariaDBJSONColumn(column) {
+		return "longtext"
+	}
+	return columnType
+}
+
+func (r *Renderer) appendColumnCharsetCollate(parts []string, column *ast.ColumnNode) []string {
+	charset := column.Charset
+	collate := column.Collate
+	if r.isMariaDBJSONColumn(column) {
+		if charset == "" {
+			charset = "utf8mb4"
+		}
+		if collate == "" {
+			collate = "utf8mb4_bin"
+		}
+	}
+	if charset != "" {
+		parts = append(parts, "CHARACTER SET", charset)
+	}
+	if collate != "" {
+		parts = append(parts, "COLLATE", collate)
+	}
+	return parts
+}
+
+func (r *Renderer) isMariaDBJSONColumn(column *ast.ColumnNode) bool {
+	return r.dialect == "mariadb" && strings.EqualFold(column.Type, "json")
+}
+
+func (r *Renderer) needsMariaDBJSONCheck(column *ast.ColumnNode) bool {
+	return r.isMariaDBJSONColumn(column) && !strings.Contains(strings.ToLower(column.Check), "json_valid(")
 }
 
 func renderGeneratedColumn(column *ast.ColumnNode) string {
@@ -693,7 +727,9 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 	}
 
 	// Column name and type
+	columnType = r.renderColumnType(column, columnType)
 	parts = append(parts, fmt.Sprintf("  %s %s", column.Name, columnType))
+	parts = r.appendColumnCharsetCollate(parts, column)
 
 	// Column constraints - MariaDB order: PRIMARY KEY, then NOT NULL, then UNIQUE
 	if column.Primary {
@@ -728,6 +764,9 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 	// Check constraints
 	if column.Check != "" {
 		parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
+	}
+	if r.needsMariaDBJSONCheck(column) {
+		parts = append(parts, fmt.Sprintf("CHECK (json_valid(%s))", column.Name))
 	}
 
 	// Comments


### PR DESCRIPTION
## Summary
- render MariaDB `json` columns as `longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`
- add implicit `CHECK (json_valid(...))` for MariaDB JSON aliases
- keep MySQL `json` rendering unchanged

## Validation
- `go test ./core/renderer/dialects/mariadb ./core/renderer/dialects/mysql ./core/renderer/dialects/mysqllike ./core/renderer -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`