### PR TITLE
Support MySQL column ON UPDATE expressions

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -224,6 +224,8 @@ type ColumnNode struct {
 	GeneratedExpression string
 	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
 	GeneratedKind string
+	// UpdateExpression stores MySQL/MariaDB ON UPDATE expressions such as CURRENT_TIMESTAMP(6).
+	UpdateExpression string
 	// Charset is an optional column character set for MySQL-compatible dialects.
 	Charset string
 	// Collate is an optional column collation for MySQL-compatible dialects.
@@ -361,6 +363,12 @@ func (n *ColumnNode) SetCheckName(name string) *ColumnNode {
 func (n *ColumnNode) SetGenerated(expression, kind string) *ColumnNode {
 	n.GeneratedExpression = expression
 	n.GeneratedKind = kind
+	return n
+}
+
+// SetUpdateExpression sets the MySQL/MariaDB ON UPDATE expression for the column.
+func (n *ColumnNode) SetUpdateExpression(expression string) *ColumnNode {
+	n.UpdateExpression = expression
 	return n
 }
 

--- a/core/astbuilder/columnbuilder.go
+++ b/core/astbuilder/columnbuilder.go
@@ -179,6 +179,12 @@ func (cb *ColumnBuilder) Generated(expression, kind string) *ColumnBuilder {
 	return cb
 }
 
+// UpdateExpression sets the MySQL/MariaDB ON UPDATE expression and returns the ColumnBuilder for chaining.
+func (cb *ColumnBuilder) UpdateExpression(expression string) *ColumnBuilder {
+	cb.column.SetUpdateExpression(expression)
+	return cb
+}
+
 // Charset sets the column character set and returns the ColumnBuilder for chaining.
 func (cb *ColumnBuilder) Charset(charset string) *ColumnBuilder {
 	cb.column.SetCharset(charset)
@@ -419,6 +425,12 @@ func (scb *SchemaColumnBuilder) Check(expression string) *SchemaColumnBuilder {
 // Generated marks the column as generated from the supplied raw SQL expression.
 func (scb *SchemaColumnBuilder) Generated(expression, kind string) *SchemaColumnBuilder {
 	scb.column.SetGenerated(expression, kind)
+	return scb
+}
+
+// UpdateExpression sets the MySQL/MariaDB ON UPDATE expression and returns the SchemaColumnBuilder for chaining.
+func (scb *SchemaColumnBuilder) UpdateExpression(expression string) *SchemaColumnBuilder {
+	scb.column.SetUpdateExpression(expression)
 	return scb
 }
 

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -185,6 +185,7 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		Unique:              p.optionalBool(block.Body.Attributes["unique"], false),
 		GeneratedExpression: generated.expression,
 		GeneratedKind:       generated.kind,
+		UpdateExpression:    p.optionalSQLExpression(block.Body.Attributes["on_update"]),
 		Charset:             p.optionalString(block.Body.Attributes["charset"]),
 		Collate:             p.optionalString(block.Body.Attributes["collate"]),
 		Comment:             p.optionalString(block.Body.Attributes["comment"]),
@@ -536,6 +537,7 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 		"auto_increment": true,
 		"unique":         true,
 		"default":        true,
+		"on_update":      true,
 		"as":             true,
 		"charset":        true,
 		"collate":        true,
@@ -610,13 +612,7 @@ func markPrimaryFields(fields []goschema.Field, columns []string) {
 }
 
 func (p *parser) setDefault(field *goschema.Field, attr *hclsyntax.Attribute) {
-	raw := p.rawExpr(attr)
-	if value, ok := strings.CutPrefix(raw, "sql("); ok && strings.HasSuffix(value, ")") {
-		value = strings.TrimSuffix(value, ")")
-		if unquoted, err := strconv.Unquote(value); err == nil {
-			field.DefaultExpr = unquoted
-			return
-		}
+	if value, ok := p.sqlExpression(attr); ok {
 		field.DefaultExpr = value
 		return
 	}
@@ -678,6 +674,28 @@ func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {
 		return ""
 	}
 	return p.rawExpr(attr)
+}
+
+func (p *parser) optionalSQLExpression(attr *hclsyntax.Attribute) string {
+	if attr == nil {
+		return ""
+	}
+	if value, ok := p.sqlExpression(attr); ok {
+		return value
+	}
+	return p.exprString(attr)
+}
+
+func (p *parser) sqlExpression(attr *hclsyntax.Attribute) (string, bool) {
+	raw := p.rawExpr(attr)
+	if value, ok := strings.CutPrefix(raw, "sql("); ok && strings.HasSuffix(value, ")") {
+		value = strings.TrimSuffix(value, ")")
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			return unquoted, true
+		}
+		return value, true
+	}
+	return "", false
 }
 
 func (p *parser) exprString(attr *hclsyntax.Attribute) string {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -489,6 +489,25 @@ table "users" {
 	c.Assert(db.Fields[1].GeneratedKind, qt.Equals, "STORED")
 }
 
+func TestParseColumnOnUpdateExpression(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "updated_at" {
+    null      = false
+    type      = timestamp(6)
+    default   = sql("CURRENT_TIMESTAMP(6)")
+    on_update = sql("CURRENT_TIMESTAMP(6)")
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "CURRENT_TIMESTAMP(6)")
+	c.Assert(db.Fields[0].UpdateExpression, qt.Equals, "CURRENT_TIMESTAMP(6)")
+}
+
 func TestParseRejectsInvalidGeneratedColumnForms(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -346,6 +346,9 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 	if field.GeneratedExpression != "" {
 		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
 	}
+	if field.UpdateExpression != "" {
+		column.SetUpdateExpression(field.UpdateExpression)
+	}
 	if field.Charset != "" {
 		column.SetCharset(field.Charset)
 	}
@@ -428,6 +431,9 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 	}
 	if field.GeneratedExpression != "" {
 		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
+	}
+	if field.UpdateExpression != "" {
+		column.SetUpdateExpression(field.UpdateExpression)
 	}
 	if field.Charset != "" {
 		column.SetCharset(field.Charset)

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -84,6 +84,17 @@ func TestFromField_BasicProperties(t *testing.T) {
 			},
 		},
 		{
+			name: "column update expression",
+			field: goschema.Field{
+				Name:             "updated_at",
+				Type:             "TIMESTAMP",
+				UpdateExpression: "CURRENT_TIMESTAMP",
+			},
+			expected: func(col *ast.ColumnNode) bool {
+				return col.UpdateExpression == "CURRENT_TIMESTAMP"
+			},
+		},
+		{
 			name: "column charset and collate",
 			field: goschema.Field{
 				Name:    "name",

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -135,6 +135,7 @@ func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema
 		Check:               column.Check,
 		GeneratedExpression: column.GeneratedExpression,
 		GeneratedKind:       column.GeneratedKind,
+		UpdateExpression:    column.UpdateExpression,
 		Charset:             column.Charset,
 		Collate:             column.Collate,
 		Comment:             column.Comment,

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -75,6 +75,15 @@ func TestToField_BasicProperties(t *testing.T) {
 			},
 		},
 		{
+			name: "column update expression",
+			column: ast.NewColumn("updated_at", "TIMESTAMP").
+				SetUpdateExpression("CURRENT_TIMESTAMP"),
+			structName: "User",
+			expected: func(field goschema.Field) bool {
+				return field.UpdateExpression == "CURRENT_TIMESTAMP"
+			},
+		},
+		{
 			name: "column charset and collate",
 			column: ast.NewColumn("name", "VARCHAR(255)").
 				SetCharset("hebrew").

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -149,6 +149,8 @@ type Field struct {
 	GeneratedExpression string
 	// GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
 	GeneratedKind string
+	// UpdateExpression stores MySQL/MariaDB ON UPDATE expressions such as CURRENT_TIMESTAMP(6).
+	UpdateExpression string
 	// Charset stores the column character set for MySQL-compatible dialects.
 	Charset string
 	// Collate stores the column collation for MySQL-compatible dialects.

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -1669,30 +1669,50 @@ func (p *Parser) handleOn(column *ast.ColumnNode) {
 	p.advance()
 	p.skipWhitespace()
 
-	// Parse the update expression (usually CURRENT_TIMESTAMP)
-
-	if p.current.Type != lexer.TokenIdentifier {
+	updateExpr := p.parseOnUpdateExpression()
+	if updateExpr == "" {
 		return
 	}
+	column.SetUpdateExpression(updateExpr)
+}
 
-	updateExpr := p.current.Value
-	p.advance()
-
-	// Handle function calls like CURRENT_TIMESTAMP()
-
-	if !p.current.MatchOperatorValue("(") {
-		return
+func (p *Parser) parseOnUpdateExpression() string {
+	var expr strings.Builder
+	depth := 0
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		if depth == 0 && expr.Len() > 0 && p.current.Type == lexer.TokenIdentifier &&
+			isOnUpdateExpressionTerminator(p.current.Value) {
+			return strings.TrimSpace(expr.String())
+		}
+		if p.current.Type == lexer.TokenOperator {
+			switch p.current.Value {
+			case "(":
+				depth++
+			case ")":
+				if depth == 0 {
+					return strings.TrimSpace(expr.String())
+				}
+				depth--
+			case ",":
+				if depth == 0 {
+					return strings.TrimSpace(expr.String())
+				}
+			}
+		}
+		expr.WriteString(p.current.Value)
+		p.advance()
 	}
-	p.advance()
-	if !p.current.MatchOperatorValue(")") {
-		return
+	return strings.TrimSpace(expr.String())
+}
+
+func isOnUpdateExpressionTerminator(value string) bool {
+	switch strings.ToUpper(value) {
+	case "NOT", "NULL", "PRIMARY", "UNIQUE", "AUTO_INCREMENT", "AUTOINCREMENT", "DEFAULT", "CHECK",
+		"CONSTRAINT", "REFERENCES", "AS", "GENERATED", "CHARACTER", "CHARSET", "COLLATE", "COMMENT", "ON":
+		return true
+	default:
+		return false
 	}
-
-	updateExpr += "()"
-	p.advance()
-
-	// Store as comment for now
-	column.SetComment("ON UPDATE " + updateExpr)
 }
 
 func (p *Parser) parseColumnConstraintsAndAttributes(table *ast.CreateTableNode, column *ast.ColumnNode) error {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -3212,13 +3212,8 @@ func TestParser_MariaDBWithCheckConstraint(t *testing.T) {
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
-	// Debug: Print actual columns found
-	t.Logf("Found %d columns:", len(createTable.Columns))
-	for i, col := range createTable.Columns {
-		t.Logf("  %d: %s %s", i, col.Name, col.Type)
-	}
-
 	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].Check, qt.Equals, "`balance` >= 0")
 }
 
 func TestParser_ColumnLevelNamedCheckConstraint(t *testing.T) {
@@ -3279,13 +3274,24 @@ func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 
 	createTable := statements.Statements[0].(*ast.CreateTableNode)
 
-	// Debug: Print actual columns found
-	t.Logf("Found %d columns:", len(createTable.Columns))
-	for i, col := range createTable.Columns {
-		t.Logf("  %d: %s %s", i, col.Name, col.Type)
-	}
-
 	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].UpdateExpression, qt.Equals, "CURRENT_TIMESTAMP")
+	c.Assert(createTable.Columns[0].Comment, qt.Equals, "")
+}
+
+func TestParser_MariaDBOnUpdateBeforeComment(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE test (
+		` + "`updated_at`" + ` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Updated timestamp'
+	);`
+	statements, err := parser.NewParser(sql).Parse()
+	c.Assert(err, qt.IsNil)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Columns, qt.HasLen, 1)
+	c.Assert(createTable.Columns[0].UpdateExpression, qt.Equals, "CURRENT_TIMESTAMP")
+	c.Assert(createTable.Columns[0].Comment, qt.Equals, "COMMENT 'Updated timestamp'")
 }
 
 func TestParser_MariaDBFirst5Columns(t *testing.T) {

--- a/core/renderer/dialects/mariadb/schema_objects_test.go
+++ b/core/renderer/dialects/mariadb/schema_objects_test.go
@@ -35,3 +35,18 @@ func TestMariaDBRenderer_JSONColumnPreservesExplicitCharsetCollate(t *testing.T)
 	c.Assert(err, qt.IsNil)
 	c.Assert(sql, qt.Contains, "payload longtext CHARACTER SET utf8 COLLATE utf8_bin CHECK (json_valid(payload))")
 }
+
+func TestMariaDBRenderer_ColumnOnUpdateExpression(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("updated_at", "datetime(6)").
+			SetNotNull().
+			SetDefaultExpression("CURRENT_TIMESTAMP(6)").
+			SetUpdateExpression("CURRENT_TIMESTAMP(6)"))
+
+	sql, err := renderer.RenderSQL("mariadb", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "updated_at datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)")
+}

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -552,6 +552,9 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	case column.Default.Expression != "":
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 	}
+	if column.UpdateExpression != "" {
+		parts = append(parts, "ON UPDATE", column.UpdateExpression)
+	}
 
 	// Check constraint. When `check_name=` is provided, emit the explicit
 	// `CONSTRAINT <name> CHECK (...)` form so the constraint round-trips
@@ -756,6 +759,9 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 		} else if column.Default.HasLiteral() {
 			parts = append(parts, fmt.Sprintf("DEFAULT '%s'", column.Default.Value))
 		}
+	}
+	if column.UpdateExpression != "" {
+		parts = append(parts, "ON UPDATE", column.UpdateExpression)
 	}
 	if column.GeneratedExpression != "" {
 		parts = append(parts, renderGeneratedColumn(column))


### PR DESCRIPTION
## Summary
- add structured column-level `UpdateExpression` support for MySQL/MariaDB `ON UPDATE`
- parse Atlas HCL `on_update = sql(...)` without overloading foreign-key `OnUpdate`
- preserve `ON UPDATE` from SQL parser instead of storing it as a comment
- render `ON UPDATE <expr>` in MySQL-family column definitions

## Validation
- `go test ./core/parser ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/renderer/dialects/mariadb ./core/renderer/dialects/mysql -count=1`
- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`