### PR TITLE
Support composite Atlas foreign keys

### DIFF
--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -106,20 +106,39 @@ func (d *DefaultValue) HasLiteral() bool {
 
 // ForeignKeyRef represents a foreign key reference with optional referential actions.
 //
-// This structure defines the target table and column for a foreign key constraint,
+// This structure defines the target table and columns for a foreign key constraint,
 // along with optional ON DELETE and ON UPDATE actions that specify what should
 // happen when the referenced row is deleted or updated.
 type ForeignKeyRef struct {
 	// Table is the name of the referenced table
 	Table string
-	// Column is the name of the referenced column
+	// Column is the name of the referenced column. It is kept for single-column
+	// foreign keys and compatibility with existing struct literals.
 	Column string
+	// Columns contains the referenced columns for composite foreign keys. When
+	// empty, Column remains the source of truth.
+	Columns []string
 	// OnDelete specifies the action when the referenced row is deleted (CASCADE, SET NULL, etc.)
 	OnDelete string
 	// OnUpdate specifies the action when the referenced row is updated (CASCADE, SET NULL, etc.)
 	OnUpdate string
 	// Name is the constraint name for the foreign key
 	Name string
+}
+
+// ReferencedColumns returns the referenced column list, falling back to Column
+// for legacy single-column foreign key references.
+func (f *ForeignKeyRef) ReferencedColumns() []string {
+	if f == nil {
+		return nil
+	}
+	if len(f.Columns) > 0 {
+		return f.Columns
+	}
+	if f.Column != "" {
+		return []string{f.Column}
+	}
+	return nil
 }
 
 // ConstraintType represents the different types of table constraints.

--- a/core/ast/ast_test.go
+++ b/core/ast/ast_test.go
@@ -317,6 +317,22 @@ func TestForeignKeyRef_EmptyFields(t *testing.T) {
 	c.Assert(fkRef.Name, qt.Equals, "")
 }
 
+func TestForeignKeyRef_ReferencedColumns(t *testing.T) {
+	c := qt.New(t)
+
+	single := &ast.ForeignKeyRef{Column: "id"}
+	c.Assert(single.ReferencedColumns(), qt.DeepEquals, []string{"id"})
+
+	composite := &ast.ForeignKeyRef{
+		Column:  "tenant_id",
+		Columns: []string{"tenant_id", "id"},
+	}
+	c.Assert(composite.ReferencedColumns(), qt.DeepEquals, []string{"tenant_id", "id"})
+
+	var nilRef *ast.ForeignKeyRef
+	c.Assert(nilRef.ReferencedColumns(), qt.IsNil)
+}
+
 // Test foreign key reference with all fields through column
 func TestForeignKeyRef_ThroughColumn(t *testing.T) {
 	c := qt.New(t)

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -137,7 +137,7 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 			if err != nil {
 				return err
 			}
-			if err := p.applyForeignKey(fieldsStart, nested, spec); err != nil {
+			if err := p.applyForeignKey(table, fieldsStart, nested, spec); err != nil {
 				return err
 			}
 		case "check":
@@ -378,12 +378,12 @@ func primaryKeyParts(columns []string) []goschema.PrimaryKeyPart {
 }
 
 type foreignKeySpec struct {
-	name          string
-	column        string
-	foreignTable  string
-	foreignColumn string
-	onDelete      string
-	onUpdate      string
+	name           string
+	columns        []string
+	foreignTable   string
+	foreignColumns []string
+	onDelete       string
+	onUpdate       string
 }
 
 func (p *parser) parseForeignKey(block *hclsyntax.Block) (foreignKeySpec, error) {
@@ -401,36 +401,87 @@ func (p *parser) parseForeignKey(block *hclsyntax.Block) (foreignKeySpec, error)
 	if err != nil {
 		return foreignKeySpec{}, err
 	}
-	if len(columns) != 1 || len(refColumns) != 1 {
-		return foreignKeySpec{}, p.blockError(block, "foreign_key %q currently requires one column and one ref_column", block.Labels[0])
+	if len(columns) == 0 || len(refColumns) == 0 {
+		return foreignKeySpec{}, p.blockError(block, "foreign_key %q requires columns and ref_columns", block.Labels[0])
 	}
-	if refColumns[0].table == "" || refColumns[0].column == "" {
-		return foreignKeySpec{}, p.blockError(block, "foreign_key %q requires table-qualified ref_columns", block.Labels[0])
+	if len(columns) != len(refColumns) {
+		return foreignKeySpec{}, p.blockError(block, "foreign_key %q requires matching columns and ref_columns counts", block.Labels[0])
+	}
+
+	localColumns := make([]string, 0, len(columns))
+	foreignColumns := make([]string, 0, len(refColumns))
+	foreignTable := refColumns[0].table
+	for _, refColumn := range refColumns {
+		if refColumn.table == "" || refColumn.column == "" {
+			return foreignKeySpec{}, p.blockError(block, "foreign_key %q requires table-qualified ref_columns", block.Labels[0])
+		}
+		if refColumn.table != foreignTable {
+			return foreignKeySpec{}, p.blockError(block, "foreign_key %q ref_columns must target one table", block.Labels[0])
+		}
+		foreignColumns = append(foreignColumns, refColumn.column)
+	}
+	for _, column := range columns {
+		if column.column == "" {
+			return foreignKeySpec{}, p.blockError(block, "foreign_key %q requires column refs", block.Labels[0])
+		}
+		localColumns = append(localColumns, column.column)
 	}
 
 	return foreignKeySpec{
-		name:          block.Labels[0],
-		column:        columns[0].column,
-		foreignTable:  refColumns[0].table,
-		foreignColumn: refColumns[0].column,
-		onDelete:      p.optionalString(block.Body.Attributes["on_delete"]),
-		onUpdate:      p.optionalString(block.Body.Attributes["on_update"]),
+		name:           block.Labels[0],
+		columns:        localColumns,
+		foreignTable:   foreignTable,
+		foreignColumns: foreignColumns,
+		onDelete:       p.optionalString(block.Body.Attributes["on_delete"]),
+		onUpdate:       p.optionalString(block.Body.Attributes["on_update"]),
 	}, nil
 }
 
-func (p *parser) applyForeignKey(fieldsStart int, block *hclsyntax.Block, spec foreignKeySpec) error {
+func (p *parser) applyForeignKey(table goschema.Table, fieldsStart int, block *hclsyntax.Block, spec foreignKeySpec) error {
+	if err := p.requireForeignKeyLocalColumns(fieldsStart, block, spec); err != nil {
+		return err
+	}
+	if len(spec.columns) > 1 {
+		p.db.Constraints = append(p.db.Constraints, goschema.Constraint{
+			StructName:     table.StructName,
+			Name:           spec.name,
+			Type:           "FOREIGN KEY",
+			Table:          table.Name,
+			Columns:        spec.columns,
+			ForeignTable:   spec.foreignTable,
+			ForeignColumn:  spec.foreignColumns[0],
+			ForeignColumns: spec.foreignColumns,
+			OnDelete:       spec.onDelete,
+			OnUpdate:       spec.onUpdate,
+		})
+		return nil
+	}
+
 	for i := fieldsStart; i < len(p.db.Fields); i++ {
 		field := &p.db.Fields[i]
-		if field.Name != spec.column {
+		if field.Name != spec.columns[0] {
 			continue
 		}
-		field.Foreign = spec.foreignTable + "(" + spec.foreignColumn + ")"
+		field.Foreign = spec.foreignTable + "(" + spec.foreignColumns[0] + ")"
 		field.ForeignKeyName = spec.name
 		field.OnDelete = spec.onDelete
 		field.OnUpdate = spec.onUpdate
 		return nil
 	}
-	return p.blockError(block, "foreign_key %q references unknown local column %q", spec.name, spec.column)
+	return nil
+}
+
+func (p *parser) requireForeignKeyLocalColumns(fieldsStart int, block *hclsyntax.Block, spec foreignKeySpec) error {
+	seen := make(map[string]bool, len(spec.columns))
+	for i := fieldsStart; i < len(p.db.Fields); i++ {
+		seen[p.db.Fields[i].Name] = true
+	}
+	for _, column := range spec.columns {
+		if !seen[column] {
+			return p.blockError(block, "foreign_key %q references unknown local column %q", spec.name, column)
+		}
+	}
+	return nil
 }
 
 func (p *parser) parseCheck(structName, tableName string, block *hclsyntax.Block) (goschema.Constraint, error) {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -393,6 +393,54 @@ table "posts" {
 	c.Assert(db.Dependencies["main.posts"], qt.DeepEquals, []string{"main.users"})
 }
 
+func TestParseCompositeForeignKey(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "accounts" {
+  column "tenant_id" {
+    type = int
+  }
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.tenant_id, column.id]
+  }
+}
+
+table "posts" {
+  column "tenant_id" {
+    type = int
+  }
+  column "owner_id" {
+    type = int
+  }
+  foreign_key "owner_ref" {
+    columns = [column.tenant_id, column.owner_id]
+    ref_columns = [table.accounts.column.tenant_id, table.accounts.column.id]
+    on_delete = CASCADE
+    on_update = NO_ACTION
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+
+	constraint := constraintByName(db.Constraints, "owner_ref")
+	c.Assert(constraint.Type, qt.Equals, "FOREIGN KEY")
+	c.Assert(constraint.Table, qt.Equals, "posts")
+	c.Assert(constraint.Columns, qt.DeepEquals, []string{"tenant_id", "owner_id"})
+	c.Assert(constraint.ForeignTable, qt.Equals, "accounts")
+	c.Assert(constraint.ForeignColumn, qt.Equals, "tenant_id")
+	c.Assert(constraint.ForeignColumns, qt.DeepEquals, []string{"tenant_id", "id"})
+	c.Assert(constraint.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(constraint.OnUpdate, qt.Equals, "NO_ACTION")
+	c.Assert(db.Dependencies["posts"], qt.DeepEquals, []string{"accounts"})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, `CONSTRAINT owner_ref FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE ON UPDATE NO_ACTION`)
+}
+
 func TestParseDefaultsAndChecks(t *testing.T) {
 	c := qt.New(t)
 
@@ -703,4 +751,13 @@ func fieldByName(fields []goschema.Field, structName, name string) goschema.Fiel
 		}
 	}
 	return goschema.Field{}
+}
+
+func constraintByName(constraints []goschema.Constraint, name string) goschema.Constraint {
+	for _, constraint := range constraints {
+		if constraint.Name == name {
+			return constraint
+		}
+	}
+	return goschema.Constraint{}
 }

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -261,13 +261,13 @@ type foreignKeyInfo struct {
 func indexForeignKeysByColumn(dbSchema *dbschematypes.DBSchema) map[string]foreignKeyInfo {
 	result := make(map[string]foreignKeyInfo)
 	for _, c := range dbSchema.Constraints {
-		if c.Type != "FOREIGN KEY" || c.ColumnName == "" || c.ForeignTable == nil {
+		if c.Type != "FOREIGN KEY" || c.ColumnName == "" || c.ForeignTable == nil || len(c.ColumnNamesOrDefault()) != 1 {
 			continue
 		}
 		foreignTable := c.QualifiedForeignTableName()
 		foreignColumn := ""
-		if c.ForeignColumn != nil {
-			foreignColumn = *c.ForeignColumn
+		if foreignColumns := c.ForeignColumnsOrDefault(); len(foreignColumns) == 1 {
+			foreignColumn = foreignColumns[0]
 		}
 		foreign := foreignTable
 		if foreignColumn != "" {

--- a/core/convert/dbschematogo/dbschematogo_test.go
+++ b/core/convert/dbschematogo/dbschematogo_test.go
@@ -195,6 +195,41 @@ func TestConvertDBSchemaToGoSchema_GeneratedColumns(t *testing.T) {
 	c.Assert(result.Fields[0].GeneratedKind, qt.Equals, "STORED")
 }
 
+func TestConvertDBSchemaToGoSchema_SkipsCompositeForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "orders",
+				Columns: []types.DBColumn{
+					{Name: "tenant_id", DataType: "integer"},
+					{Name: "owner_id", DataType: "integer"},
+				},
+			},
+		},
+		Constraints: []types.DBConstraint{
+			{
+				Name:           "fk_orders_accounts",
+				TableName:      "orders",
+				Type:           "FOREIGN KEY",
+				ColumnName:     "tenant_id",
+				ColumnNames:    []string{"tenant_id", "owner_id"},
+				ForeignTable:   new("accounts"),
+				ForeignColumn:  new("tenant_id"),
+				ForeignColumns: []string{"tenant_id", "id"},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Fields, qt.HasLen, 2)
+	for _, field := range result.Fields {
+		c.Assert(field.Foreign, qt.Equals, "")
+		c.Assert(field.ForeignKeyName, qt.Equals, "")
+	}
+}
+
 func TestConvertDBSchemaToGoSchema_ColumnCharsetCollate(t *testing.T) {
 	c := qt.New(t)
 	dbSchema := &types.DBSchema{

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -709,6 +709,7 @@ func FromConstraint(constraint goschema.Constraint) *ast.ConstraintNode {
 		return ast.NewForeignKeyConstraint(constraint.Name, constraint.Columns, &ast.ForeignKeyRef{
 			Table:    constraint.ForeignTable,
 			Column:   constraint.ForeignColumn,
+			Columns:  constraint.ForeignColumns,
 			OnDelete: constraint.OnDelete,
 			OnUpdate: constraint.OnUpdate,
 		})

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -296,12 +296,25 @@ type Constraint struct {
 	Columns []string // Column names for UNIQUE/PRIMARY KEY constraints
 
 	// FOREIGN KEY constraint specific fields
-	ForeignTable  string // Referenced table name
-	ForeignColumn string // Referenced column name
-	OnDelete      string // ON DELETE action
-	OnUpdate      string // ON UPDATE action
+	ForeignTable   string   // Referenced table name
+	ForeignColumn  string   // Referenced column name for single-column foreign keys
+	ForeignColumns []string // Referenced column names for composite foreign keys
+	OnDelete       string   // ON DELETE action
+	OnUpdate       string   // ON UPDATE action
 
 	Comment string // Constraint comment/description
+}
+
+// ForeignColumnsOrDefault returns the referenced column list for FOREIGN KEY
+// constraints, falling back to ForeignColumn for legacy single-column callers.
+func (c Constraint) ForeignColumnsOrDefault() []string {
+	if len(c.ForeignColumns) > 0 {
+		return c.ForeignColumns
+	}
+	if c.ForeignColumn != "" {
+		return []string{c.ForeignColumn}
+	}
+	return nil
 }
 
 // Extension represents a PostgreSQL extension definition parsed from Go struct annotations.

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -160,8 +160,9 @@ func sortTablesByDependencies(r *Database) {
 //  1. Initializes empty dependency lists for all tables
 //  2. Scans all fields for foreign key references (field.Foreign attribute)
 //  3. Scans embedded fields with relation mode for references (embedded.Ref attribute)
-//  4. Extracts referenced table names from foreign key specifications
-//  5. Maps each table to its list of dependencies
+//  4. Scans table-level FOREIGN KEY constraints
+//  5. Extracts referenced table names from foreign key specifications
+//  6. Maps each table to its list of dependencies
 //
 // Foreign key format examples:
 //   - "users(id)" -> depends on "users" table
@@ -173,6 +174,7 @@ func buildDependencyGraph(r *Database) {
 	initializeDependencyMaps(r)
 	analyzeFieldForeignKeys(r)
 	analyzeEmbeddedFieldRelations(r)
+	analyzeConstraintForeignKeys(r)
 	buildFunctionDependencies(r)
 }
 
@@ -341,6 +343,32 @@ func analyzeEmbeddedFieldRelations(r *Database) {
 			OnUpdate:       embedded.OnUpdate,
 		})
 	}
+}
+
+func analyzeConstraintForeignKeys(r *Database) {
+	for _, constraint := range r.Constraints {
+		if constraint.ForeignTable == "" || strings.ToUpper(constraint.Type) != "FOREIGN KEY" {
+			continue
+		}
+		table := resolveTableReference(r.Tables, constraint.StructName, constraint.Table)
+		if table == nil {
+			continue
+		}
+		processForeignKeyDependency(r, *table, constraint.ForeignTable, SelfReferencingFK{
+			FieldName:      strings.Join(constraint.Columns, ","),
+			Foreign:        foreignKeyReferenceString(constraint.ForeignTable, constraint.ForeignColumnsOrDefault()),
+			ForeignKeyName: constraint.Name,
+			OnDelete:       constraint.OnDelete,
+			OnUpdate:       constraint.OnUpdate,
+		})
+	}
+}
+
+func foreignKeyReferenceString(table string, columns []string) string {
+	if len(columns) == 0 {
+		return table
+	}
+	return table + "(" + strings.Join(columns, ",") + ")"
 }
 
 // findTableByStructName finds a table by its struct name
@@ -1138,7 +1166,7 @@ func validateDuplicateConstraints(constraints []Constraint) error {
 			constraint.CheckExpression,
 			strings.Join(constraint.Columns, ","),
 			constraint.ForeignTable,
-			constraint.ForeignColumn,
+			strings.Join(constraint.ForeignColumnsOrDefault(), ","),
 			constraint.OnDelete,
 			constraint.OnUpdate,
 		}, "\x00")

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2300,10 +2300,21 @@ func (p *Parser) parseForeignKeyReference() (*ast.ForeignKeyRef, error) {
 
 	p.skipWhitespace()
 
-	// Get referenced column name
-	columnName, err := p.expectIdentifier()
-	if err != nil {
-		return nil, fmt.Errorf("expected column name in REFERENCES: %w", err)
+	// Get referenced column names
+	var columnNames []string
+	for {
+		columnName, err := p.expectIdentifier()
+		if err != nil {
+			return nil, fmt.Errorf("expected column name in REFERENCES: %w", err)
+		}
+		columnNames = append(columnNames, columnName)
+
+		p.skipWhitespace()
+		if !p.current.MatchOperatorValue(",") {
+			break
+		}
+		p.advance()
+		p.skipWhitespace()
 	}
 
 	p.skipWhitespace()
@@ -2315,7 +2326,10 @@ func (p *Parser) parseForeignKeyReference() (*ast.ForeignKeyRef, error) {
 
 	fkRef := &ast.ForeignKeyRef{
 		Table:  tableName,
-		Column: columnName,
+		Column: columnNames[0],
+	}
+	if len(columnNames) > 1 {
+		fkRef.Columns = columnNames
 	}
 
 	// Parse optional ON DELETE/UPDATE actions

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -97,6 +97,30 @@ func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 	c.Assert(fkConstraint.Reference.Column, qt.Equals, "id")
 }
 
+func TestParser_ParseCreateTable_WithCompositeForeignKey(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE orders (
+		tenant_id INTEGER,
+		customer_id INTEGER,
+		CONSTRAINT fk_orders_customer FOREIGN KEY (tenant_id, customer_id) REFERENCES customers (tenant_id, id)
+	);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
+	constraint := createTable.Constraints[0]
+	c.Assert(constraint.Type, qt.Equals, ast.ForeignKeyConstraint)
+	c.Assert(constraint.Columns, qt.DeepEquals, []string{"tenant_id", "customer_id"})
+	c.Assert(constraint.Reference.Table, qt.Equals, "customers")
+	c.Assert(constraint.Reference.Column, qt.Equals, "tenant_id")
+	c.Assert(constraint.Reference.Columns, qt.DeepEquals, []string{"tenant_id", "id"})
+}
+
 func TestParser_ParseCreateTable_WithTableOptions(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -701,7 +701,7 @@ func (r *Renderer) renderForeignKeyConstraint(constraint *ast.ConstraintNode) (s
 		constraint.Name,
 		strings.Join(constraint.Columns, ", "),
 		ref.Table,
-		ref.Column)
+		strings.Join(ref.ReferencedColumns(), ", "))
 
 	if ref.OnDelete != "" {
 		result += fmt.Sprintf(" ON DELETE %s", ref.OnDelete)

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -729,7 +729,7 @@ func (r *Renderer) renderForeignKeyConstraint(constraint *ast.ConstraintNode) (s
 		constraint.Name,
 		strings.Join(constraint.Columns, ", "),
 		ref.Table,
-		ref.Column)
+		strings.Join(ref.ReferencedColumns(), ", "))
 
 	if ref.OnDelete != "" {
 		result += fmt.Sprintf(" ON DELETE %s", ref.OnDelete)

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -550,9 +550,16 @@ func (r *Reader) readConstraints(dbName string) ([]types.DBConstraint, error) {
 		}
 
 		// For multi-column constraints, we only store the first column name
-		// This matches the existing behavior and avoids duplicates
+		// in the legacy scalar field. ColumnNames / ForeignColumns retain the
+		// full ordered list for composite keys.
 		if constraint.ColumnName == "" && columnName != "" {
 			constraint.ColumnName = columnName
+		}
+		if columnName != "" {
+			constraint.ColumnNames = append(constraint.ColumnNames, columnName)
+		}
+		if referencedColumn != "" {
+			constraint.ForeignColumns = append(constraint.ForeignColumns, referencedColumn)
 		}
 	}
 

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -452,10 +452,10 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 				tc.table_name,
 				tc.constraint_name,
 				tc.constraint_type,
-				COALESCE(kcu.column_name, ''),
-				COALESCE(ccu.table_schema, ''),
-				COALESCE(ccu.table_name, ''),
-				COALESCE(ccu.column_name, ''),
+				COALESCE(string_agg(kcu.column_name, ',' ORDER BY kcu.ordinal_position) FILTER (WHERE kcu.column_name IS NOT NULL), ''),
+				COALESCE(max(ukcu.table_schema), ''),
+				COALESCE(max(ukcu.table_name), ''),
+				COALESCE(string_agg(ukcu.column_name, ',' ORDER BY kcu.ordinal_position) FILTER (WHERE ukcu.column_name IS NOT NULL), ''),
 				COALESCE(rc.delete_rule, ''),
 			COALESCE(rc.update_rule, ''),
 			COALESCE(cc.check_clause, '')
@@ -464,17 +464,26 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 			ON tc.constraint_name = kcu.constraint_name
 			AND tc.table_schema = kcu.table_schema
 			AND tc.table_name = kcu.table_name
-			LEFT JOIN information_schema.constraint_column_usage AS ccu
-				ON ccu.constraint_name = tc.constraint_name
-				AND ccu.constraint_schema = tc.constraint_schema
 		LEFT JOIN information_schema.referential_constraints AS rc
 			ON tc.constraint_name = rc.constraint_name
 			AND tc.table_schema = rc.constraint_schema
+		LEFT JOIN information_schema.key_column_usage AS ukcu
+			ON ukcu.constraint_schema = rc.unique_constraint_schema
+			AND ukcu.constraint_name = rc.unique_constraint_name
+			AND ukcu.ordinal_position = kcu.position_in_unique_constraint
 		LEFT JOIN information_schema.check_constraints AS cc
 			ON tc.constraint_name = cc.constraint_name
 			AND tc.table_schema = cc.constraint_schema
 		WHERE tc.table_schema = $1
 		AND tc.table_name NOT IN ('schema_migrations')
+		GROUP BY
+			tc.table_schema,
+			tc.table_name,
+			tc.constraint_name,
+			tc.constraint_type,
+			rc.delete_rule,
+			rc.update_rule,
+			cc.check_clause
 		ORDER BY tc.table_name, tc.constraint_type, tc.constraint_name`
 
 	rows, err := r.db.Query(constraintsQuery, schemaName)
@@ -486,17 +495,17 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 	var constraints []types.DBConstraint
 	for rows.Next() {
 		var constraint types.DBConstraint
-		var foreignSchema, foreignTable, foreignColumn, deleteRule, updateRule, checkClause string
+		var columnNames, foreignSchema, foreignTable, foreignColumns, deleteRule, updateRule, checkClause string
 
 		err := rows.Scan(
 			&constraint.Schema,
 			&constraint.TableName,
 			&constraint.Name,
 			&constraint.Type,
-			&constraint.ColumnName,
+			&columnNames,
 			&foreignSchema,
 			&foreignTable,
-			&foreignColumn,
+			&foreignColumns,
 			&deleteRule,
 			&updateRule,
 			&checkClause,
@@ -506,13 +515,18 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 		}
 
 		// Set optional fields
+		if columnNames != "" {
+			constraint.ColumnNames = strings.Split(columnNames, ",")
+			constraint.ColumnName = constraint.ColumnNames[0]
+		}
 		if foreignTable != "" {
 			constraint.ForeignTable = &foreignTable
 		}
 		constraint.Schema = r.outputSchema(constraint.Schema)
 		constraint.ForeignSchema = r.outputSchema(foreignSchema)
-		if foreignColumn != "" {
-			constraint.ForeignColumn = &foreignColumn
+		if foreignColumns != "" {
+			constraint.ForeignColumns = strings.Split(foreignColumns, ",")
+			constraint.ForeignColumn = &constraint.ForeignColumns[0]
 		}
 		if deleteRule != "" {
 			constraint.DeleteRule = &deleteRule

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -127,17 +127,19 @@ func (i DBIndex) QualifiedTableName() string {
 
 // DBConstraint represents a database constraint
 type DBConstraint struct {
-	Name          string  `json:"name"`
-	TableName     string  `json:"table_name"`
-	Schema        string  `json:"schema,omitempty"`
-	Type          string  `json:"type"` // PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK, EXCLUDE
-	ColumnName    string  `json:"column_name"`
-	ForeignTable  *string `json:"foreign_table"` // For foreign keys
-	ForeignSchema string  `json:"foreign_schema,omitempty"`
-	ForeignColumn *string `json:"foreign_column"` // For foreign keys
-	DeleteRule    *string `json:"delete_rule"`    // CASCADE, RESTRICT, etc.
-	UpdateRule    *string `json:"update_rule"`    // CASCADE, RESTRICT, etc.
-	CheckClause   *string `json:"check_clause"`   // For CHECK constraints
+	Name           string   `json:"name"`
+	TableName      string   `json:"table_name"`
+	Schema         string   `json:"schema,omitempty"`
+	Type           string   `json:"type"` // PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK, EXCLUDE
+	ColumnName     string   `json:"column_name"`
+	ColumnNames    []string `json:"column_names,omitempty"`
+	ForeignTable   *string  `json:"foreign_table"` // For foreign keys
+	ForeignSchema  string   `json:"foreign_schema,omitempty"`
+	ForeignColumn  *string  `json:"foreign_column"` // For foreign keys
+	ForeignColumns []string `json:"foreign_columns,omitempty"`
+	DeleteRule     *string  `json:"delete_rule"`  // CASCADE, RESTRICT, etc.
+	UpdateRule     *string  `json:"update_rule"`  // CASCADE, RESTRICT, etc.
+	CheckClause    *string  `json:"check_clause"` // For CHECK constraints
 	// EXCLUDE constraint specific fields (PostgreSQL only)
 	UsingMethod     *string `json:"using_method"`     // Index method: gist, btree, etc.
 	ExcludeElements *string `json:"exclude_elements"` // Elements with operators: "room_id WITH =, during WITH &&"
@@ -155,6 +157,30 @@ func (c DBConstraint) QualifiedForeignTableName() string {
 		return ""
 	}
 	return QualifyTableName(c.ForeignSchema, *c.ForeignTable)
+}
+
+// ColumnNamesOrDefault returns all local constraint columns, falling back to
+// the legacy single-column field for callers that have not populated slices.
+func (c DBConstraint) ColumnNamesOrDefault() []string {
+	if len(c.ColumnNames) > 0 {
+		return c.ColumnNames
+	}
+	if c.ColumnName != "" {
+		return []string{c.ColumnName}
+	}
+	return nil
+}
+
+// ForeignColumnsOrDefault returns all referenced FK columns, falling back to
+// the legacy single-column field for older readers and test fixtures.
+func (c DBConstraint) ForeignColumnsOrDefault() []string {
+	if len(c.ForeignColumns) > 0 {
+		return c.ForeignColumns
+	}
+	if c.ForeignColumn != nil && *c.ForeignColumn != "" {
+		return []string{*c.ForeignColumn}
+	}
+	return nil
 }
 
 // DBExtension represents a PostgreSQL extension installed in the database

--- a/dbschema/types/types_test.go
+++ b/dbschema/types/types_test.go
@@ -1,0 +1,29 @@
+package types_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema/types"
+)
+
+func TestDBConstraint_ColumnSlicesFallbackToLegacyFields(t *testing.T) {
+	c := qt.New(t)
+
+	legacy := types.DBConstraint{
+		ColumnName:    "tenant_id",
+		ForeignColumn: new("id"),
+	}
+	c.Assert(legacy.ColumnNamesOrDefault(), qt.DeepEquals, []string{"tenant_id"})
+	c.Assert(legacy.ForeignColumnsOrDefault(), qt.DeepEquals, []string{"id"})
+
+	composite := types.DBConstraint{
+		ColumnName:     "tenant_id",
+		ColumnNames:    []string{"tenant_id", "owner_id"},
+		ForeignColumn:  new("tenant_id"),
+		ForeignColumns: []string{"tenant_id", "id"},
+	}
+	c.Assert(composite.ColumnNamesOrDefault(), qt.DeepEquals, []string{"tenant_id", "owner_id"})
+	c.Assert(composite.ForeignColumnsOrDefault(), qt.DeepEquals, []string{"tenant_id", "id"})
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -490,14 +490,15 @@ func foreignKeyAdditionFromDBConstraint(name, table string, dbFK dbschematypes.D
 		OnDelete:  derefString(dbFK.DeleteRule),
 		OnUpdate:  derefString(dbFK.UpdateRule),
 	}
-	if dbFK.ColumnName != "" {
-		info.Columns = []string{dbFK.ColumnName}
+	if columns := dbFK.ColumnNamesOrDefault(); len(columns) > 0 {
+		info.Columns = append([]string(nil), columns...)
 	}
 	if dbFK.ForeignTable != nil {
 		info.ForeignTable = *dbFK.ForeignTable
 	}
-	if dbFK.ForeignColumn != nil {
-		info.ForeignColumn = *dbFK.ForeignColumn
+	if foreignColumns := dbFK.ForeignColumnsOrDefault(); len(foreignColumns) > 0 {
+		info.ForeignColumn = foreignColumns[0]
+		info.ForeignColumns = append([]string(nil), foreignColumns...)
 	}
 	return info
 }

--- a/migration/generator/multihost_fk_down_test.go
+++ b/migration/generator/multihost_fk_down_test.go
@@ -182,8 +182,50 @@ func TestReverseConstraintAdditions_RestoresPerHostBody(t *testing.T) {
 		c.Assert(a.Columns, qt.DeepEquals, []string{"tenant_id"})
 		c.Assert(a.ForeignTable, qt.Equals, "tenants")
 		c.Assert(a.ForeignColumn, qt.Equals, "id")
+		c.Assert(a.ForeignColumns, qt.DeepEquals, []string{"id"})
 		c.Assert(a.OnDelete, qt.Equals, "NO ACTION")
 	}
+}
+
+func TestReverseConstraintAdditions_RestoresCompositeForeignKeyBody(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &dbschematypes.DBSchema{
+		Constraints: []dbschematypes.DBConstraint{
+			{
+				Name:           "fk_orders_accounts",
+				TableName:      "orders",
+				Type:           "FOREIGN KEY",
+				ColumnName:     "tenant_id",
+				ColumnNames:    []string{"tenant_id", "owner_id"},
+				ForeignTable:   new("accounts"),
+				ForeignColumn:  new("tenant_id"),
+				ForeignColumns: []string{"tenant_id", "id"},
+				DeleteRule:     new("CASCADE"),
+				UpdateRule:     new("NO ACTION"),
+			},
+		},
+	}
+	upDiff := &types.SchemaDiff{
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "fk_orders_accounts", TableName: "orders", Type: "FOREIGN KEY"},
+		},
+	}
+
+	additions := reverseConstraintAdditions(upDiff, dbSchema)
+
+	c.Assert(additions, qt.DeepEquals, []types.ConstraintAdditionInfo{
+		{
+			Name:           "fk_orders_accounts",
+			TableName:      "orders",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "owner_id"},
+			ForeignTable:   "accounts",
+			ForeignColumn:  "tenant_id",
+			ForeignColumns: []string{"tenant_id", "id"},
+			OnDelete:       "CASCADE",
+			OnUpdate:       "NO ACTION",
+		},
+	})
 }
 
 // TestReverseConstraintAdditions_NilDBSchema is the legacy-caller path: with no

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -31,6 +31,35 @@ func renderMySQLFamily(c *qt.C, dialect string, diff *types.SchemaDiff, generate
 	return sql
 }
 
+func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &types.SchemaDiff{
+				ConstraintsAdded: []string{"fk_orders_accounts"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+					{
+						Name:           "fk_orders_accounts",
+						TableName:      "orders",
+						Type:           "FOREIGN KEY",
+						Columns:        []string{"tenant_id", "owner_id"},
+						ForeignTable:   "accounts",
+						ForeignColumn:  "tenant_id",
+						ForeignColumns: []string{"tenant_id", "id"},
+						OnDelete:       "CASCADE",
+					},
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+			c.Assert(sql, qt.Contains, "ALTER TABLE orders ADD CONSTRAINT fk_orders_accounts FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE;",
+				qt.Commentf("composite FK addition must preserve all referenced columns; got:\n%s", sql))
+		})
+	}
+}
+
 // TestPlanner_GenerateMigrationAST_SharedConstraintName_ModifiedOnOneTablePurelyRemovedOnAnother
 // guards issue #207 — the MySQL-family sibling of the postgres issue #206. A
 // single constraint name is shared across two tables: it is MODIFIED on table

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -903,6 +903,7 @@ func (p *Planner) foreignKeyAdditionNode(add types.ConstraintAdditionInfo) *ast.
 	fkRef := &ast.ForeignKeyRef{
 		Table:    add.ForeignTable,
 		Column:   add.ForeignColumn,
+		Columns:  add.ForeignColumns,
 		OnDelete: add.OnDelete,
 		OnUpdate: add.OnUpdate,
 	}
@@ -1211,12 +1212,13 @@ func (p *Planner) convertConstraintToAST(constraint goschema.Constraint) *ast.Co
 		return ast.NewPrimaryKeyConstraint(constraint.Columns...)
 
 	case "FOREIGN KEY":
-		if len(constraint.Columns) == 0 || constraint.ForeignTable == "" || constraint.ForeignColumn == "" {
+		if len(constraint.Columns) == 0 || constraint.ForeignTable == "" || len(constraint.ForeignColumnsOrDefault()) == 0 {
 			return nil // Invalid FOREIGN KEY constraint
 		}
 		ref := &ast.ForeignKeyRef{
 			Table:    constraint.ForeignTable,
 			Column:   constraint.ForeignColumn,
+			Columns:  constraint.ForeignColumns,
 			OnDelete: constraint.OnDelete,
 			OnUpdate: constraint.OnUpdate,
 			Name:     constraint.Name,

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -13,6 +13,33 @@ import (
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
+func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsAdded: []string{"fk_orders_accounts"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+			{
+				Name:           "fk_orders_accounts",
+				TableName:      "orders",
+				Type:           "FOREIGN KEY",
+				Columns:        []string{"tenant_id", "owner_id"},
+				ForeignTable:   "accounts",
+				ForeignColumn:  "tenant_id",
+				ForeignColumns: []string{"tenant_id", "id"},
+				OnDelete:       "CASCADE",
+			},
+		},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, &goschema.Database{})
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(sql, qt.Contains, "ALTER TABLE orders ADD CONSTRAINT fk_orders_accounts FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE;",
+		qt.Commentf("composite FK addition must preserve all referenced columns; got:\n%s", sql))
+}
+
 func TestPlanner_GenerateMigrationAST_ConstraintsAdded(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1598,6 +1598,7 @@ func (p *Planner) foreignKeyAdditionNode(add types.ConstraintAdditionInfo) *ast.
 	fkRef := &ast.ForeignKeyRef{
 		Table:    add.ForeignTable,
 		Column:   add.ForeignColumn,
+		Columns:  add.ForeignColumns,
 		OnDelete: add.OnDelete,
 		OnUpdate: add.OnUpdate,
 	}
@@ -1943,12 +1944,13 @@ func (p *Planner) convertConstraintToAST(constraint goschema.Constraint) *ast.Co
 		return ast.NewPrimaryKeyConstraint(constraint.Columns...)
 
 	case "FOREIGN KEY":
-		if len(constraint.Columns) == 0 || constraint.ForeignTable == "" || constraint.ForeignColumn == "" {
+		if len(constraint.Columns) == 0 || constraint.ForeignTable == "" || len(constraint.ForeignColumnsOrDefault()) == 0 {
 			return nil // Invalid FOREIGN KEY constraint
 		}
 		ref := &ast.ForeignKeyRef{
 			Table:    constraint.ForeignTable,
 			Column:   constraint.ForeignColumn,
+			Columns:  constraint.ForeignColumns,
 			OnDelete: constraint.OnDelete,
 			OnUpdate: constraint.OnUpdate,
 			Name:     constraint.Name,

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -3,6 +3,7 @@ package compare
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -1050,14 +1051,15 @@ func appendConstraintRemoval(infos []difftypes.ConstraintRemovalInfo, dbConstrai
 // one entry and matches the legacy field-scan behavior.
 func appendConstraintAddition(infos []difftypes.ConstraintAdditionInfo, genConstraint goschema.Constraint) []difftypes.ConstraintAdditionInfo {
 	return append(infos, difftypes.ConstraintAdditionInfo{
-		Name:          genConstraint.Name,
-		TableName:     genConstraint.Table,
-		Type:          genConstraint.Type,
-		Columns:       append([]string(nil), genConstraint.Columns...),
-		ForeignTable:  genConstraint.ForeignTable,
-		ForeignColumn: genConstraint.ForeignColumn,
-		OnDelete:      genConstraint.OnDelete,
-		OnUpdate:      genConstraint.OnUpdate,
+		Name:           genConstraint.Name,
+		TableName:      genConstraint.Table,
+		Type:           genConstraint.Type,
+		Columns:        append([]string(nil), genConstraint.Columns...),
+		ForeignTable:   genConstraint.ForeignTable,
+		ForeignColumn:  genConstraint.ForeignColumn,
+		ForeignColumns: append([]string(nil), genConstraint.ForeignColumnsOrDefault()...),
+		OnDelete:       genConstraint.OnDelete,
+		OnUpdate:       genConstraint.OnUpdate,
 	})
 }
 
@@ -1152,13 +1154,18 @@ func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint typ
 // explicit action, producing a perpetual drop+add loop on every `generate`
 // (the same hazard checkConstraintChanged guards against for CHECK clauses).
 func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint, dialect string) bool {
+	// Compare local columns.
+	if !slices.Equal(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault()) {
+		return true
+	}
+
 	// Compare referenced table
 	if !foreignTableRefMatches(genConstraint.ForeignTable, dbConstraint) {
 		return true
 	}
 
-	// Compare referenced column
-	if genConstraint.ForeignColumn != getStringValue(dbConstraint.ForeignColumn) {
+	// Compare referenced columns.
+	if !slices.Equal(genConstraint.ForeignColumnsOrDefault(), dbConstraint.ForeignColumnsOrDefault()) {
 		return true
 	}
 
@@ -1484,15 +1491,16 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		}
 		dedupe[dedupeKey] = struct{}{}
 		synthesized = append(synthesized, goschema.Constraint{
-			StructName:    f.StructName,
-			Name:          name,
-			Type:          "FOREIGN KEY",
-			Table:         tableName,
-			Columns:       []string{f.Name},
-			ForeignTable:  fkRef.Table,
-			ForeignColumn: fkRef.Column,
-			OnDelete:      f.OnDelete,
-			OnUpdate:      f.OnUpdate,
+			StructName:     f.StructName,
+			Name:           name,
+			Type:           "FOREIGN KEY",
+			Table:          tableName,
+			Columns:        []string{f.Name},
+			ForeignTable:   fkRef.Table,
+			ForeignColumn:  fkRef.Column,
+			ForeignColumns: fkRef.ReferencedColumns(),
+			OnDelete:       f.OnDelete,
+			OnUpdate:       f.OnUpdate,
 		})
 	}
 	return synthesized

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -230,6 +230,149 @@ func TestConstraints_HasChanges(t *testing.T) {
 	}
 }
 
+func TestConstraints_CompositeForeignKeyAdditionCarriesReferencedColumns(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Order",
+				Name:           "fk_orders_accounts",
+				Type:           "FOREIGN KEY",
+				Table:          "orders",
+				Columns:        []string{"tenant_id", "owner_id"},
+				ForeignTable:   "accounts",
+				ForeignColumn:  "tenant_id",
+				ForeignColumns: []string{"tenant_id", "id"},
+				OnDelete:       "CASCADE",
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.Constraints(generated, &types.DBSchema{}, diff, nil)
+
+	c.Assert(diff.ConstraintsAdded, qt.DeepEquals, []string{"fk_orders_accounts"})
+	c.Assert(diff.ConstraintsAddedWithTables, qt.DeepEquals, []difftypes.ConstraintAdditionInfo{
+		{
+			Name:           "fk_orders_accounts",
+			TableName:      "orders",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "owner_id"},
+			ForeignTable:   "accounts",
+			ForeignColumn:  "tenant_id",
+			ForeignColumns: []string{"tenant_id", "id"},
+			OnDelete:       "CASCADE",
+		},
+	})
+}
+
+func TestConstraints_CompositeForeignKeyReferencedColumnDrift(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Order",
+				Name:           "fk_orders_accounts",
+				Type:           "FOREIGN KEY",
+				Table:          "orders",
+				Columns:        []string{"tenant_id", "owner_id"},
+				ForeignTable:   "accounts",
+				ForeignColumn:  "tenant_id",
+				ForeignColumns: []string{"tenant_id", "id"},
+			},
+		},
+	}
+	database := &types.DBSchema{
+		Constraints: []types.DBConstraint{
+			{
+				Name:           "fk_orders_accounts",
+				TableName:      "orders",
+				Type:           "FOREIGN KEY",
+				ColumnName:     "tenant_id",
+				ColumnNames:    []string{"tenant_id", "owner_id"},
+				ForeignTable:   new("accounts"),
+				ForeignColumn:  new("tenant_id"),
+				ForeignColumns: []string{"tenant_id", "account_id"},
+				DeleteRule:     new("NO ACTION"),
+				UpdateRule:     new("NO ACTION"),
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.Constraints(generated, database, diff, nil)
+
+	c.Assert(diff.ConstraintsRemovedWithTables, qt.DeepEquals, []difftypes.ConstraintRemovalInfo{
+		{Name: "fk_orders_accounts", TableName: "orders", Type: "FOREIGN KEY"},
+	})
+	c.Assert(diff.ConstraintsAddedWithTables, qt.DeepEquals, []difftypes.ConstraintAdditionInfo{
+		{
+			Name:           "fk_orders_accounts",
+			TableName:      "orders",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "owner_id"},
+			ForeignTable:   "accounts",
+			ForeignColumn:  "tenant_id",
+			ForeignColumns: []string{"tenant_id", "id"},
+		},
+	})
+}
+
+func TestConstraints_CompositeForeignKeyLocalColumnDrift(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Order",
+				Name:           "fk_orders_accounts",
+				Type:           "FOREIGN KEY",
+				Table:          "orders",
+				Columns:        []string{"tenant_id", "owner_id"},
+				ForeignTable:   "accounts",
+				ForeignColumn:  "tenant_id",
+				ForeignColumns: []string{"tenant_id", "id"},
+			},
+		},
+	}
+	database := &types.DBSchema{
+		Constraints: []types.DBConstraint{
+			{
+				Name:           "fk_orders_accounts",
+				TableName:      "orders",
+				Type:           "FOREIGN KEY",
+				ColumnName:     "tenant_id",
+				ColumnNames:    []string{"tenant_id", "account_owner_id"},
+				ForeignTable:   new("accounts"),
+				ForeignColumn:  new("tenant_id"),
+				ForeignColumns: []string{"tenant_id", "id"},
+				DeleteRule:     new("NO ACTION"),
+				UpdateRule:     new("NO ACTION"),
+			},
+		},
+	}
+
+	diff := &difftypes.SchemaDiff{}
+	compare.Constraints(generated, database, diff, nil)
+
+	c.Assert(diff.ConstraintsRemovedWithTables, qt.DeepEquals, []difftypes.ConstraintRemovalInfo{
+		{Name: "fk_orders_accounts", TableName: "orders", Type: "FOREIGN KEY"},
+	})
+	c.Assert(diff.ConstraintsAddedWithTables, qt.DeepEquals, []difftypes.ConstraintAdditionInfo{
+		{
+			Name:           "fk_orders_accounts",
+			TableName:      "orders",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "owner_id"},
+			ForeignTable:   "accounts",
+			ForeignColumn:  "tenant_id",
+			ForeignColumns: []string{"tenant_id", "id"},
+		},
+	})
+}
+
 func TestConstraints_EdgeCases(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -59,9 +59,13 @@ type ConstraintAdditionInfo struct {
 	// Columns are the local columns the constraint covers (FK source columns).
 	Columns []string `json:"columns,omitempty"`
 
-	// ForeignTable / ForeignColumn describe the FK target (FOREIGN KEY only).
-	ForeignTable  string `json:"foreign_table,omitempty"`
-	ForeignColumn string `json:"foreign_column,omitempty"`
+	// ForeignTable / ForeignColumn / ForeignColumns describe the FK target
+	// (FOREIGN KEY only). ForeignColumn is kept for compatibility with older
+	// single-column callers; ForeignColumns carries the full referenced column
+	// list for composite keys.
+	ForeignTable   string   `json:"foreign_table,omitempty"`
+	ForeignColumn  string   `json:"foreign_column,omitempty"`
+	ForeignColumns []string `json:"foreign_columns,omitempty"`
 
 	// OnDelete / OnUpdate are the referential actions (FOREIGN KEY only).
 	OnDelete string `json:"on_delete,omitempty"`


### PR DESCRIPTION
## Summary
- add composite foreign-key support across Atlas HCL parsing, SQL parsing, AST/renderers, schema conversion, schemadiff, planners, and down-migration restoration
- preserve legacy single-column fields while carrying full local/referenced column lists for composite constraints
- harden DB introspection/conversion so composite FKs do not collapse to the first column

## Validation
- go test ./dbschema/types ./dbschema/mysql ./dbschema/postgres ./migration/schemadiff/types ./migration/schemadiff/internal/compare ./migration/planner/dialects/mysql ./migration/planner/dialects/postgres
- go test ./core/convert/dbschematogo ./migration/generator ./dbschema/types ./migration/schemadiff/internal/compare ./migration/planner/dialects/mysql ./migration/planner/dialects/postgres
- go test ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- git diff --check