### PR TITLE
Accept Atlas primary key type

### DIFF
--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -322,6 +322,9 @@ func (p *parser) parsePrimaryKey(block *hclsyntax.Block) ([]string, []goschema.P
 	if err := p.rejectUnsupportedPrimaryKeyAttrs(block); err != nil {
 		return nil, nil, err
 	}
+	if err := p.validatePrimaryKeyType(block); err != nil {
+		return nil, nil, err
+	}
 	if block.Body.Attributes["columns"] != nil {
 		if len(block.Body.Blocks) > 0 {
 			return nil, nil, p.blockError(block.Body.Blocks[0], "primary_key cannot mix columns attribute with on blocks")
@@ -342,6 +345,16 @@ func (p *parser) parsePrimaryKey(block *hclsyntax.Block) ([]string, []goschema.P
 		columns = append(columns, part.Name)
 	}
 	return columns, parts, nil
+}
+
+func (p *parser) validatePrimaryKeyType(block *hclsyntax.Block) error {
+	primaryKeyType := strings.ToUpper(p.optionalString(block.Body.Attributes["type"]))
+	switch primaryKeyType {
+	case "", "BTREE", "HASH":
+		return nil
+	default:
+		return p.blockError(block, "unsupported primary_key type %q", primaryKeyType)
+	}
 }
 
 func (p *parser) parsePrimaryKeyParts(block *hclsyntax.Block) ([]goschema.PrimaryKeyPart, error) {
@@ -570,6 +583,7 @@ func (p *parser) rejectUnsupportedTableAttrs(block *hclsyntax.Block) error {
 func (p *parser) rejectUnsupportedPrimaryKeyAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"columns": true,
+		"type":    true,
 	}, "primary_key")
 }
 

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -93,6 +93,51 @@ table "tokens" {
 	c.Assert(sql, qt.Not(qt.Contains), "id tinytext PRIMARY KEY")
 }
 
+func TestParsePrimaryKeyType(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = varchar(128)
+  }
+  primary_key {
+    columns = [column.id]
+    type    = HASH
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].PrimaryKey, qt.DeepEquals, []string{"id"})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "mysql"), "\n")
+	c.Assert(sql, qt.Contains, "id varchar(128) PRIMARY KEY")
+}
+
+func TestParsePrimaryKeyTypeRejectsUnknownValue(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = varchar(128)
+  }
+  primary_key {
+    columns = [column.id]
+    type    = GIANT
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported primary_key type "GIANT".*`)
+}
+
 func TestParseSQLiteTableOptions(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- accept Atlas HCL primary_key.type for known BTREE/HASH values
- keep SQL rendering unchanged because MySQL SHOW output does not reflect HASH in the covered Atlas fixture
- reject unknown primary_key.type values instead of silently accepting arbitrary attributes

## Validation
- go test ./core/atlashcl -run 'TestParsePrimaryKeyType|TestParsePrimaryKeyParts|TestParseTablesColumnsPrimaryKeyAndIndexes' -count=1
- go test ./core/atlashcl ./core/convert/fromschema ./core/renderer/dialects/mysqllike ./migration/planner/dialects/mysql
- go test ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- git diff --check