### PR TITLE
Support PostgreSQL primary key include

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -460,6 +460,8 @@ type ConstraintNode struct {
 	// ColumnParts contains structured column references for dialect-specific
 	// attributes such as MySQL prefix lengths and DESC ordering.
 	ColumnParts []ConstraintColumn
+	// IncludeColumns contains PostgreSQL INCLUDE columns for primary key constraints.
+	IncludeColumns []string
 	// Reference contains foreign key reference information (only for FOREIGN KEY constraints)
 	Reference *ForeignKeyRef
 	// Expression contains the check expression (only for CHECK constraints)

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -120,12 +120,13 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 			}
 			p.db.Fields = append(p.db.Fields, field)
 		case "primary_key":
-			columns, parts, err := p.parsePrimaryKey(nested)
+			primaryKey, err := p.parsePrimaryKey(nested)
 			if err != nil {
 				return err
 			}
-			table.PrimaryKey = columns
-			table.PrimaryKeyParts = parts
+			table.PrimaryKey = primaryKey.columns
+			table.PrimaryKeyParts = primaryKey.parts
+			table.PrimaryKeyInclude = primaryKey.include
 		case "index":
 			index, err := p.parseIndex(table.StructName, table.Name, nested)
 			if err != nil {
@@ -376,33 +377,43 @@ func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.I
 	return columns, parts, nil
 }
 
-func (p *parser) parsePrimaryKey(block *hclsyntax.Block) ([]string, []goschema.PrimaryKeyPart, error) {
+type primaryKeySpec struct {
+	columns []string
+	parts   []goschema.PrimaryKeyPart
+	include []string
+}
+
+func (p *parser) parsePrimaryKey(block *hclsyntax.Block) (primaryKeySpec, error) {
 	if err := p.rejectUnsupportedPrimaryKeyAttrs(block); err != nil {
-		return nil, nil, err
+		return primaryKeySpec{}, err
 	}
 	if err := p.validatePrimaryKeyType(block); err != nil {
-		return nil, nil, err
+		return primaryKeySpec{}, err
+	}
+	include, err := p.parseColumnsAttr(block, "include")
+	if err != nil {
+		return primaryKeySpec{}, err
 	}
 	if block.Body.Attributes["columns"] != nil {
 		if len(block.Body.Blocks) > 0 {
-			return nil, nil, p.blockError(block.Body.Blocks[0], "primary_key cannot mix columns attribute with on blocks")
+			return primaryKeySpec{}, p.blockError(block.Body.Blocks[0], "primary_key cannot mix columns attribute with on blocks")
 		}
 		columns, err := p.parseColumnsAttr(block, "columns")
 		if err != nil {
-			return nil, nil, err
+			return primaryKeySpec{}, err
 		}
-		return columns, primaryKeyParts(columns), nil
+		return primaryKeySpec{columns: columns, parts: primaryKeyParts(columns), include: include}, nil
 	}
 
 	parts, err := p.parsePrimaryKeyParts(block)
 	if err != nil {
-		return nil, nil, err
+		return primaryKeySpec{}, err
 	}
 	columns := make([]string, 0, len(parts))
 	for _, part := range parts {
 		columns = append(columns, part.Name)
 	}
-	return columns, parts, nil
+	return primaryKeySpec{columns: columns, parts: parts, include: include}, nil
 }
 
 func (p *parser) validatePrimaryKeyType(block *hclsyntax.Block) error {
@@ -641,6 +652,7 @@ func (p *parser) rejectUnsupportedTableAttrs(block *hclsyntax.Block) error {
 func (p *parser) rejectUnsupportedPrimaryKeyAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"columns": true,
+		"include": true,
 		"type":    true,
 	}, "primary_key")
 }

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -93,6 +93,37 @@ table "tokens" {
 	c.Assert(sql, qt.Not(qt.Contains), "id tinytext PRIMARY KEY")
 }
 
+func TestParsePrimaryKeyInclude(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  column "covering" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+    include = [column.covering]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].PrimaryKey, qt.DeepEquals, []string{"id"})
+	c.Assert(db.Tables[0].PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{{Name: "id"}})
+	c.Assert(db.Tables[0].PrimaryKeyInclude, qt.DeepEquals, []string{"covering"})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n")
+	c.Assert(sql, qt.Contains, "PRIMARY KEY (id) INCLUDE (covering)")
+	c.Assert(sql, qt.Not(qt.Contains), "id int PRIMARY KEY")
+}
+
 func TestParsePrimaryKeyType(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -670,6 +670,9 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 }
 
 func tableNeedsPrimaryKeyConstraint(table goschema.Table) bool {
+	if len(table.PrimaryKeyInclude) > 0 && (len(table.PrimaryKey) > 0 || len(table.PrimaryKeyParts) > 0) {
+		return true
+	}
 	if len(table.PrimaryKeyParts) > 0 {
 		return len(table.PrimaryKeyParts) > 1 || primaryKeyPartsHaveAttributes(table.PrimaryKeyParts)
 	}
@@ -687,7 +690,9 @@ func primaryKeyPartsHaveAttributes(parts []goschema.PrimaryKeyPart) bool {
 
 func newPrimaryKeyConstraint(table goschema.Table) *ast.ConstraintNode {
 	if len(table.PrimaryKeyParts) == 0 {
-		return ast.NewPrimaryKeyConstraint(table.PrimaryKey...)
+		constraint := ast.NewPrimaryKeyConstraint(table.PrimaryKey...)
+		constraint.IncludeColumns = table.PrimaryKeyInclude
+		return constraint
 	}
 	columns := make([]string, 0, len(table.PrimaryKeyParts))
 	columnParts := make([]ast.ConstraintColumn, 0, len(table.PrimaryKeyParts))
@@ -700,9 +705,10 @@ func newPrimaryKeyConstraint(table goschema.Table) *ast.ConstraintNode {
 		})
 	}
 	return &ast.ConstraintNode{
-		Type:        ast.PrimaryKeyConstraint,
-		Columns:     columns,
-		ColumnParts: columnParts,
+		Type:           ast.PrimaryKeyConstraint,
+		Columns:        columns,
+		ColumnParts:    columnParts,
+		IncludeColumns: table.PrimaryKeyInclude,
 	}
 }
 

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -627,6 +627,39 @@ func TestFromTable_PrimaryKeyParts(t *testing.T) {
 	}})
 }
 
+func TestFromTable_PrimaryKeyInclude(t *testing.T) {
+	c := qt.New(t)
+
+	table := goschema.Table{
+		StructName:        "User",
+		Name:              "users",
+		PrimaryKey:        []string{"id"},
+		PrimaryKeyInclude: []string{"covering"},
+	}
+	fields := []goschema.Field{
+		{
+			StructName: "User",
+			Name:       "id",
+			Type:       "INTEGER",
+			Primary:    true,
+		},
+		{
+			StructName: "User",
+			Name:       "covering",
+			Type:       "INTEGER",
+		},
+	}
+
+	result := fromschema.FromTable(table, fields, nil, "")
+
+	c.Assert(result.Columns, qt.HasLen, 2)
+	c.Assert(result.Columns[0].Primary, qt.IsFalse)
+	c.Assert(result.Constraints, qt.HasLen, 1)
+	c.Assert(result.Constraints[0].Type, qt.Equals, ast.PrimaryKeyConstraint)
+	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"id"})
+	c.Assert(result.Constraints[0].IncludeColumns, qt.DeepEquals, []string{"covering"})
+}
+
 func TestFromDatabase_TableLevelConstraints(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -264,6 +264,7 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 		if constraint.Type == ast.PrimaryKeyConstraint {
 			tableSchema.PrimaryKey = constraint.Columns
 			tableSchema.PrimaryKeyParts = toPrimaryKeyParts(constraint)
+			tableSchema.PrimaryKeyInclude = constraint.IncludeColumns
 			break // Only one primary key constraint per table
 		}
 	}

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -402,6 +402,24 @@ func TestToTable_PrimaryKeyParts(t *testing.T) {
 	}})
 }
 
+func TestToTable_PrimaryKeyInclude(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddConstraint(&ast.ConstraintNode{
+			Type:           ast.PrimaryKeyConstraint,
+			Columns:        []string{"id"},
+			ColumnParts:    []ast.ConstraintColumn{{Name: "id"}},
+			IncludeColumns: []string{"covering"},
+		})
+
+	result := toschema.ToTable(table, "")
+
+	c.Assert(result.PrimaryKey, qt.DeepEquals, []string{"id"})
+	c.Assert(result.PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{{Name: "id"}})
+	c.Assert(result.PrimaryKeyInclude, qt.DeepEquals, []string{"covering"})
+}
+
 func TestToTable_PlatformSource(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -391,9 +391,12 @@ type Table struct {
 	// PrimaryKeyParts carries dialect-specific metadata for composite primary
 	// key elements, such as MySQL prefix lengths and DESC ordering.
 	PrimaryKeyParts []PrimaryKeyPart
-	Checks          []string                     // Table-level check constraints
-	CustomSQL       string                       // Custom SQL to append to CREATE TABLE
-	Overrides       map[string]map[string]string // Platform-specific overrides
+	// PrimaryKeyInclude carries PostgreSQL INCLUDE columns for table-level
+	// primary keys.
+	PrimaryKeyInclude []string
+	Checks            []string                     // Table-level check constraints
+	CustomSQL         string                       // Custom SQL to append to CREATE TABLE
+	Overrides         map[string]map[string]string // Platform-specific overrides
 }
 
 // PrimaryKeyPart represents one column reference inside a table primary key.

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2652,6 +2652,40 @@ func (p *Parser) parseTableColumnList(constraint *ast.ConstraintNode) error {
 	return nil
 }
 
+func (p *Parser) handleTablePrimaryKeyInclude(constraint *ast.ConstraintNode) error {
+	if constraint.Type != ast.PrimaryKeyConstraint {
+		return nil
+	}
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("INCLUDE") {
+		return nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return fmt.Errorf("expected '(' after PRIMARY KEY INCLUDE: %w", err)
+	}
+	p.skipWhitespace()
+	for {
+		column, err := p.expectIdentifier()
+		if err != nil {
+			return fmt.Errorf("expected PRIMARY KEY INCLUDE column name: %w", err)
+		}
+		constraint.IncludeColumns = append(constraint.IncludeColumns, column)
+		p.skipWhitespace()
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			p.skipWhitespace()
+			continue
+		}
+		if p.current.MatchOperatorValue(")") {
+			break
+		}
+		return fmt.Errorf("expected ',' or ')' in PRIMARY KEY INCLUDE list at position %d", p.current.Start)
+	}
+	return p.expect(lexer.TokenOperator, ")")
+}
+
 func (p *Parser) parseConstraintColumn() (ast.ConstraintColumn, error) {
 	columnName, err := p.expectIdentifier()
 	if err != nil {
@@ -2816,6 +2850,11 @@ func (p *Parser) parseTableConstraint() (*ast.ConstraintNode, error) {
 
 	// Parse column list for PRIMARY KEY, UNIQUE, FOREIGN KEY
 	err = p.parseTableColumnList(constraint)
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.handleTablePrimaryKeyInclude(constraint)
 	if err != nil {
 		return nil, err
 	}

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -3322,6 +3322,46 @@ func TestParser_TableConstraintColumnParts(t *testing.T) {
 	}})
 }
 
+func TestParser_TablePrimaryKeyInclude(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE users (id integer NOT NULL, covering integer, PRIMARY KEY (id) INCLUDE (covering));`
+	statements, err := parser.NewParser(sql).Parse()
+	c.Assert(err, qt.IsNil)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
+
+	pk := createTable.Constraints[0]
+	c.Assert(pk.Type, qt.Equals, ast.PrimaryKeyConstraint)
+	c.Assert(pk.Columns, qt.DeepEquals, []string{"id"})
+	c.Assert(pk.IncludeColumns, qt.DeepEquals, []string{"covering"})
+}
+
+func TestParser_PrimaryKeyIncludeRejectsInvalidLists(t *testing.T) {
+	tests := []string{
+		`CREATE TABLE users (id integer NOT NULL, covering integer, PRIMARY KEY (id) INCLUDE ());`,
+		`CREATE TABLE users (id integer NOT NULL, covering integer, PRIMARY KEY (id) INCLUDE (covering,));`,
+	}
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := parser.NewParser(sql).Parse()
+
+			c.Assert(err, qt.IsNotNil)
+		})
+	}
+}
+
+func TestParser_PrimaryKeyIncludeRejectsColumnConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parser.NewParser(`CREATE TABLE users (id integer PRIMARY KEY INCLUDE (covering), covering integer);`).Parse()
+
+	c.Assert(err, qt.IsNotNil)
+}
+
 func TestParser_MariaDBOnUpdateTimestamp(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -735,7 +735,15 @@ func (r *Renderer) isEnumType(fieldType string, enums []string) bool {
 func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, error) {
 	switch constraint.Type {
 	case ast.PrimaryKeyConstraint:
-		return fmt.Sprintf("  PRIMARY KEY (%s)", strings.Join(constraint.Columns, ", ")), nil
+		line := "  "
+		if constraint.Name != "" {
+			line += fmt.Sprintf("CONSTRAINT %s ", constraint.Name)
+		}
+		line += fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(constraint.Columns, ", "))
+		if len(constraint.IncludeColumns) > 0 {
+			line += fmt.Sprintf(" INCLUDE (%s)", strings.Join(constraint.IncludeColumns, ", "))
+		}
+		return line, nil
 	case ast.UniqueConstraint:
 		if constraint.Name != "" {
 			return fmt.Sprintf("  CONSTRAINT %s UNIQUE (%s)", constraint.Name, strings.Join(constraint.Columns, ", ")), nil

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -645,6 +645,26 @@ CREATE TABLE users (
 `)
 }
 
+func TestPostgreSQLRenderer_PrimaryKeyInclude(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("id", "INTEGER").SetNotNull()).
+		AddColumn(ast.NewColumn("covering", "INTEGER")).
+		AddConstraint(&ast.ConstraintNode{
+			Type:           ast.PrimaryKeyConstraint,
+			Name:           "users_pkey",
+			Columns:        []string{"id"},
+			IncludeColumns: []string{"covering"},
+		})
+
+	renderer := postgres.New()
+	result, err := renderer.Render(table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Contains, "  CONSTRAINT users_pkey PRIMARY KEY (id) INCLUDE (covering)")
+}
+
 func TestPostgreSQLRenderer_RejectsIdentityGeneratedColumnMix(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -29,7 +29,8 @@ current schema IR:
 - `table` blocks
 - `column` blocks with `type`, `null`, `auto_increment`, `unique`, `default`,
   `identity`, and `comment`
-- `primary_key` blocks with `columns`
+- `primary_key` blocks with `columns`; PostgreSQL primary keys also support
+  `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
   `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
@@ -74,6 +75,25 @@ table "users" {
     type = FULLTEXT
     parser = ngram
     columns = [column.bio]
+  }
+}
+```
+
+## PostgreSQL Primary Key Include Example
+
+```hcl
+table "users" {
+  column "id" {
+    type = int
+  }
+
+  column "covering" {
+    type = int
+  }
+
+  primary_key {
+    columns = [column.id]
+    include = [column.covering]
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add PostgreSQL primary key INCLUDE columns to the shared schema and AST models
- parse Atlas HCL primary_key.include and PostgreSQL table-level PRIMARY KEY (...) INCLUDE (...)
- render named PostgreSQL primary key constraints with INCLUDE columns
- document Atlas HCL primary_key.include support

## Validation
- gopls diagnostics: no diagnostics
- gopls vulncheck ./...: no findings returned
- go test ./core/ast ./core/goschema ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/parser ./core/renderer/dialects/postgres
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- live PostgreSQL smoke: CREATE TABLE with CONSTRAINT ... PRIMARY KEY (id) INCLUDE (covering)