### PR TITLE
Support PostgreSQL index include

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -532,6 +532,8 @@ type IndexNode struct {
 	Condition string
 	// Operator specifies the operator class (gin_trgm_ops, etc.)
 	Operator string
+	// IncludeColumns contains PostgreSQL INCLUDE columns for covering indexes.
+	IncludeColumns []string
 	// Concurrently requests CREATE INDEX CONCURRENTLY, PostgreSQL's
 	// non-locking index build. Set by planners only when the target
 	// capability set includes capability.CreateIndexConcurrently and the

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -307,6 +307,10 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if err != nil {
 		return goschema.Index{}, err
 	}
+	include, err := p.parseColumnsAttr(block, "include")
+	if err != nil {
+		return goschema.Index{}, err
+	}
 	var parts []goschema.IndexPart
 	if len(columns) == 0 {
 		columns, parts, err = p.parseIndexParts(block)
@@ -326,15 +330,16 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		return goschema.Index{}, p.blockError(block, "index parser requires FULLTEXT type")
 	}
 	return goschema.Index{
-		StructName: structName,
-		Name:       block.Labels[0],
-		Fields:     columns,
-		Parts:      parts,
-		Unique:     p.optionalBool(block.Body.Attributes["unique"], false),
-		Type:       indexType,
-		Parser:     parserName,
-		Condition:  p.optionalString(block.Body.Attributes["where"]),
-		TableName:  tableName,
+		StructName:     structName,
+		Name:           block.Labels[0],
+		Fields:         columns,
+		Parts:          parts,
+		Unique:         p.optionalBool(block.Body.Attributes["unique"], false),
+		Type:           indexType,
+		Parser:         parserName,
+		Condition:      p.optionalString(block.Body.Attributes["where"]),
+		IncludeColumns: include,
+		TableName:      tableName,
 	}, nil
 }
 
@@ -704,6 +709,7 @@ func (p *parser) rejectUnsupportedIdentityColumnAttrs(block *hclsyntax.Block) er
 func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"columns": true,
+		"include": true,
 		"parser":  true,
 		"unique":  true,
 		"type":    true,

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -324,6 +324,29 @@ table "users" {
 	})
 }
 
+func TestParseIndexInclude(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "name" {
+    type = text
+  }
+  column "active" {
+    type = bool
+  }
+  index "idx_users_name" {
+    columns = [column.name]
+    include = [column.active]
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"name"})
+	c.Assert(db.Indexes[0].IncludeColumns, qt.DeepEquals, []string{"active"})
+}
+
 func TestParseFulltextIndexParser(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -816,6 +816,7 @@ func FromIndex(index goschema.Index) *ast.IndexNode {
 	if len(index.Parts) > 0 {
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
+	indexNode.IncludeColumns = index.IncludeColumns
 
 	// Set unique constraint
 	if index.Unique {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -851,6 +851,21 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.Parts[1] == (ast.IndexPart{Expr: "lower(name)"})
 			},
 		},
+		{
+			name: "index include columns",
+			index: goschema.Index{
+				Name:           "idx_users_name",
+				StructName:     "users",
+				Fields:         []string{"name"},
+				IncludeColumns: []string{"active"},
+			},
+			expected: func(idx *ast.IndexNode) bool {
+				return idx.Name == "idx_users_name" &&
+					idx.Table == "users" &&
+					idx.Columns[0] == "name" &&
+					idx.IncludeColumns[0] == "active"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -371,11 +371,12 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Unique:     index.Unique,
 		Comment:    index.Comment,
 		// PostgreSQL-specific features
-		Type:      index.Type,
-		Parser:    index.Parser,
-		Condition: index.Condition,
-		Operator:  index.Operator,
-		TableName: index.Table,
+		Type:           index.Type,
+		Parser:         index.Parser,
+		Condition:      index.Condition,
+		Operator:       index.Operator,
+		IncludeColumns: index.IncludeColumns,
+		TableName:      index.Table,
 	}
 }
 

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -520,6 +520,20 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.Parts[1] == (goschema.IndexPart{Expr: "lower(name)"})
 			},
 		},
+		{
+			name: "index include columns",
+			index: func() *ast.IndexNode {
+				index := ast.NewIndex("idx_users_name", "users", "name")
+				index.IncludeColumns = []string{"active"}
+				return index
+			}(),
+			expected: func(index goschema.Index) bool {
+				return index.Name == "idx_users_name" &&
+					index.StructName == "users" &&
+					index.Fields[0] == "name" &&
+					index.IncludeColumns[0] == "active"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -253,6 +253,8 @@ type Index struct {
 	Condition string
 	// Operator is the operator class (PostgreSQL only, e.g. "gin_trgm_ops").
 	Operator string
+	// IncludeColumns carries PostgreSQL INCLUDE columns for covering indexes.
+	IncludeColumns []string
 	// TableName is the cross-table association (overrides StructName-based
 	// resolution when set).
 	TableName string

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -3528,10 +3528,47 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	if err != nil {
 		return nil, err
 	}
+	p.skipWhitespace()
+	includeColumns, err := p.parseCreateIndexIncludeColumns()
+	if err != nil {
+		return nil, err
+	}
 
 	index := ast.NewIndex(indexName, tableName, columns...)
 	index.Type = indexType
+	index.IncludeColumns = includeColumns
 	return index, nil
+}
+
+func (p *Parser) parseCreateIndexIncludeColumns() ([]string, error) {
+	if !p.current.MatchIdentifierValue("INCLUDE") {
+		return nil, nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return nil, fmt.Errorf("expected '(' after index INCLUDE: %w", err)
+	}
+	p.skipWhitespace()
+	var columns []string
+	for {
+		column, err := p.expectIdentifier()
+		if err != nil {
+			return nil, fmt.Errorf("expected index INCLUDE column name: %w", err)
+		}
+		columns = append(columns, column)
+		p.skipWhitespace()
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			p.skipWhitespace()
+			continue
+		}
+		if p.current.MatchOperatorValue(")") {
+			break
+		}
+		return nil, fmt.Errorf("expected ',' or ')' in index INCLUDE list at position %d", p.current.Start)
+	}
+	return columns, p.expect(lexer.TokenOperator, ")")
 }
 
 func (p *Parser) parseCreateIndexColumns() ([]string, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -1303,6 +1303,40 @@ func TestParser_ParseCreateIndex(t *testing.T) {
 	c.Assert(index.Unique, qt.IsFalse)
 }
 
+func TestParser_ParseCreateIndexInclude(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE INDEX idx_users_name ON users (name) INCLUDE (active, version);"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_name")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"name"})
+	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active", "version"})
+}
+
+func TestParser_ParseCreateIndexIncludeRejectsInvalidLists(t *testing.T) {
+	tests := []string{
+		"CREATE INDEX idx_users_name ON users (name) INCLUDE ();",
+		"CREATE INDEX idx_users_name ON users (name) INCLUDE (active,);",
+	}
+	for _, sql := range tests {
+		t.Run(sql, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := parser.NewParser(sql).Parse()
+
+			c.Assert(err, qt.IsNotNil)
+		})
+	}
+}
+
 func TestParser_ParseCreateIndexExpressions(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -470,6 +470,10 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	}
 	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(columnSpecs, ", ")))
 
+	if len(node.IncludeColumns) > 0 {
+		parts = append(parts, fmt.Sprintf("INCLUDE (%s)", strings.Join(node.IncludeColumns, ", ")))
+	}
+
 	// Add WHERE condition for partial indexes
 	if node.Condition != "" {
 		parts = append(parts, "WHERE")

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -68,6 +68,17 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			expected: "CREATE INDEX idx_active_users ON users (status) WHERE deleted_at IS NULL;\n",
 		},
 		{
+			name: "covering index",
+			index: &ast.IndexNode{
+				Name:           "idx_users_name",
+				Table:          "users",
+				Columns:        []string{"name"},
+				IncludeColumns: []string{"active"},
+				Condition:      "active",
+			},
+			expected: "CREATE INDEX idx_users_name ON users (name) INCLUDE (active) WHERE active;\n",
+		},
+		{
 			name: "trigram index",
 			index: &ast.IndexNode{
 				Name:     "idx_users_name_trgm",

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -32,7 +32,8 @@ current schema IR:
 - `primary_key` blocks with `columns`; PostgreSQL primary keys also support
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
-  `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`
+  `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`; PostgreSQL
+  indexes also support `include`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
   `ref_columns` entry
 - `check` blocks with `expr`
@@ -94,6 +95,25 @@ table "users" {
   primary_key {
     columns = [column.id]
     include = [column.covering]
+  }
+}
+```
+
+## PostgreSQL Index Include Example
+
+```hcl
+table "users" {
+  column "name" {
+    type = text
+  }
+
+  column "active" {
+    type = bool
+  }
+
+  index "idx_users_name" {
+    columns = [column.name]
+    include = [column.active]
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add PostgreSQL index INCLUDE columns to the shared schema and AST models
- parse Atlas HCL index.include and SQL CREATE INDEX ... INCLUDE (...)
- render PostgreSQL covering indexes as CREATE INDEX ... INCLUDE (...) before WHERE
- document Atlas HCL index.include support

## Validation
- gopls diagnostics: no diagnostics
- gopls vulncheck ./...: no findings returned
- go test ./core/ast ./core/goschema ./core/atlashcl ./core/convert/fromschema ./core/convert/toschema ./core/parser ./core/renderer/dialects/postgres
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- live PostgreSQL smoke: CREATE INDEX ... INCLUDE (...) WHERE active