### PR TITLE
Preserve PostgreSQL index include in database conversion

### DIFF
--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1320,6 +1320,7 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 	if len(index.Parts) > 0 {
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
+	indexNode.IncludeColumns = index.IncludeColumns
 
 	// Set unique constraint
 	if index.Unique {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -878,6 +878,38 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 	}
 }
 
+func TestFromDatabase_IndexIncludeColumns(t *testing.T) {
+	c := qt.New(t)
+	db := goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "users", StructName: "User"},
+		},
+		Fields: []goschema.Field{
+			{Name: "name", Type: "text", StructName: "User"},
+			{Name: "active", Type: "boolean", StructName: "User"},
+		},
+		Indexes: []goschema.Index{
+			{
+				Name:           "users_name",
+				StructName:     "User",
+				Fields:         []string{"name"},
+				Condition:      "active",
+				IncludeColumns: []string{"active"},
+			},
+		},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+	c.Assert(result.Statements, qt.HasLen, 2)
+	index, ok := result.Statements[1].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "users_name")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"name"})
+	c.Assert(index.Condition, qt.Equals, "active")
+	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active"})
+}
+
 func TestFromEnum_BasicEnum(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- preserve goschema index IncludeColumns in FromIndexWithTableMapping
- add a FromDatabase regression test covering include + where through the aggregate conversion path

## Validation
- go test ./core/convert/fromschema
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...