### PR TITLE
Support PostgreSQL index storage params

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -534,6 +534,9 @@ type IndexNode struct {
 	Operator string
 	// IncludeColumns contains PostgreSQL INCLUDE columns for covering indexes.
 	IncludeColumns []string
+	// StorageParams contains PostgreSQL index storage parameters rendered as
+	// WITH (key='value'), for example pages_per_range for BRIN indexes.
+	StorageParams map[string]string
 	// Concurrently requests CREATE INDEX CONCURRENTLY, PostgreSQL's
 	// non-locking index build. Set by planners only when the target
 	// capability set includes capability.CreateIndexConcurrently and the

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -324,6 +324,10 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if err := p.rejectUnsupportedIndexAttrs(block); err != nil {
 		return goschema.Index{}, err
 	}
+	storageParams, err := p.parseIndexStorageParams(block)
+	if err != nil {
+		return goschema.Index{}, err
+	}
 	indexType := p.optionalString(block.Body.Attributes["type"])
 	parserName := p.optionalString(block.Body.Attributes["parser"])
 	if parserName != "" && !strings.EqualFold(indexType, "FULLTEXT") {
@@ -339,8 +343,28 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		Parser:         parserName,
 		Condition:      p.optionalString(block.Body.Attributes["where"]),
 		IncludeColumns: include,
+		StorageParams:  storageParams,
 		TableName:      tableName,
 	}, nil
+}
+
+func (p *parser) parseIndexStorageParams(block *hclsyntax.Block) (map[string]string, error) {
+	pagePerRange := block.Body.Attributes["page_per_range"]
+	pagesPerRange := block.Body.Attributes["pages_per_range"]
+	if pagePerRange != nil && pagesPerRange != nil {
+		return nil, p.blockError(block, "index cannot set both page_per_range and pages_per_range")
+	}
+	params := map[string]string{}
+	if pagePerRange != nil {
+		params["pages_per_range"] = p.exprString(pagePerRange)
+	}
+	if pagesPerRange != nil {
+		params["pages_per_range"] = p.exprString(pagesPerRange)
+	}
+	if len(params) == 0 {
+		return nil, nil
+	}
+	return params, nil
 }
 
 func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.IndexPart, error) {
@@ -708,12 +732,14 @@ func (p *parser) rejectUnsupportedIdentityColumnAttrs(block *hclsyntax.Block) er
 
 func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"columns": true,
-		"include": true,
-		"parser":  true,
-		"unique":  true,
-		"type":    true,
-		"where":   true,
+		"columns":         true,
+		"include":         true,
+		"parser":          true,
+		"page_per_range":  true,
+		"pages_per_range": true,
+		"unique":          true,
+		"type":            true,
+		"where":           true,
 	}, "index")
 }
 

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -347,6 +347,46 @@ table "users" {
 	c.Assert(db.Indexes[0].IncludeColumns, qt.DeepEquals, []string{"active"})
 }
 
+func TestParsePostgreSQLIndexStorageParams(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "c" {
+    type = int
+  }
+  index "idx_users_c" {
+    type = BRIN
+    columns = [column.c]
+    page_per_range = 2
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Type, qt.Equals, "BRIN")
+	c.Assert(db.Indexes[0].StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
+}
+
+func TestParsePostgreSQLIndexStorageParamsRejectsDuplicateAliases(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "c" {
+    type = int
+  }
+  index "idx_users_c" {
+    type = BRIN
+    columns = [column.c]
+    page_per_range = 2
+    pages_per_range = 3
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*index cannot set both page_per_range and pages_per_range`)
+}
+
 func TestParseFulltextIndexParser(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -52,6 +52,7 @@ package fromschema
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -817,6 +818,7 @@ func FromIndex(index goschema.Index) *ast.IndexNode {
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
 	indexNode.IncludeColumns = index.IncludeColumns
+	indexNode.StorageParams = maps.Clone(index.StorageParams)
 
 	// Set unique constraint
 	if index.Unique {
@@ -1321,6 +1323,7 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
 	indexNode.IncludeColumns = index.IncludeColumns
+	indexNode.StorageParams = maps.Clone(index.StorageParams)
 
 	// Set unique constraint
 	if index.Unique {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -866,6 +866,23 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.IncludeColumns[0] == "active"
 			},
 		},
+		{
+			name: "index storage params",
+			index: goschema.Index{
+				Name:          "idx_users_c",
+				StructName:    "users",
+				Fields:        []string{"c"},
+				Type:          "BRIN",
+				StorageParams: map[string]string{"pages_per_range": "2"},
+			},
+			expected: func(idx *ast.IndexNode) bool {
+				return idx.Name == "idx_users_c" &&
+					idx.Table == "users" &&
+					idx.Columns[0] == "c" &&
+					idx.Type == "BRIN" &&
+					idx.StorageParams["pages_per_range"] == "2"
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -895,6 +912,7 @@ func TestFromDatabase_IndexIncludeColumns(t *testing.T) {
 				Fields:         []string{"name"},
 				Condition:      "active",
 				IncludeColumns: []string{"active"},
+				StorageParams:  map[string]string{"pages_per_range": "2"},
 			},
 		},
 	}
@@ -908,6 +926,7 @@ func TestFromDatabase_IndexIncludeColumns(t *testing.T) {
 	c.Assert(index.Columns, qt.DeepEquals, []string{"name"})
 	c.Assert(index.Condition, qt.Equals, "active")
 	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active"})
+	c.Assert(index.StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
 }
 
 func TestFromEnum_BasicEnum(t *testing.T) {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -42,6 +42,7 @@
 package toschema
 
 import (
+	"maps"
 	"strconv"
 	"strings"
 
@@ -376,6 +377,7 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Condition:      index.Condition,
 		Operator:       index.Operator,
 		IncludeColumns: index.IncludeColumns,
+		StorageParams:  maps.Clone(index.StorageParams),
 		TableName:      index.Table,
 	}
 }

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -534,6 +534,22 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.IncludeColumns[0] == "active"
 			},
 		},
+		{
+			name: "index storage params",
+			index: func() *ast.IndexNode {
+				index := ast.NewIndex("idx_users_c", "users", "c")
+				index.Type = "BRIN"
+				index.StorageParams = map[string]string{"pages_per_range": "2"}
+				return index
+			}(),
+			expected: func(index goschema.Index) bool {
+				return index.Name == "idx_users_c" &&
+					index.StructName == "users" &&
+					index.Fields[0] == "c" &&
+					index.Type == "BRIN" &&
+					index.StorageParams["pages_per_range"] == "2"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -255,6 +255,9 @@ type Index struct {
 	Operator string
 	// IncludeColumns carries PostgreSQL INCLUDE columns for covering indexes.
 	IncludeColumns []string
+	// StorageParams carries PostgreSQL index storage parameters rendered as
+	// WITH (key='value'), for example pages_per_range for BRIN indexes.
+	StorageParams map[string]string
 	// TableName is the cross-table association (overrides StructName-based
 	// resolution when set).
 	TableName string

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -4,6 +4,7 @@ package parser
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -3523,6 +3524,16 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	}
 
 	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("USING") {
+		p.advance()
+		p.skipWhitespace()
+		usingType, err := p.expectIdentifier()
+		if err != nil {
+			return nil, fmt.Errorf("expected index method after USING: %w", err)
+		}
+		indexType = usingType
+		p.skipWhitespace()
+	}
 
 	columns, err := p.parseCreateIndexColumns()
 	if err != nil {
@@ -3533,10 +3544,16 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	if err != nil {
 		return nil, err
 	}
+	p.skipWhitespace()
+	storageParams, err := p.parseCreateIndexStorageParams()
+	if err != nil {
+		return nil, err
+	}
 
 	index := ast.NewIndex(indexName, tableName, columns...)
 	index.Type = indexType
 	index.IncludeColumns = includeColumns
+	index.StorageParams = storageParams
 	return index, nil
 }
 
@@ -3569,6 +3586,67 @@ func (p *Parser) parseCreateIndexIncludeColumns() ([]string, error) {
 		return nil, fmt.Errorf("expected ',' or ')' in index INCLUDE list at position %d", p.current.Start)
 	}
 	return columns, p.expect(lexer.TokenOperator, ")")
+}
+
+func (p *Parser) parseCreateIndexStorageParams() (map[string]string, error) {
+	if !p.current.MatchIdentifierValue("WITH") {
+		return nil, nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return nil, fmt.Errorf("expected '(' after index WITH: %w", err)
+	}
+	p.skipWhitespace()
+
+	params := map[string]string{}
+	for {
+		key, err := p.expectIdentifier()
+		if err != nil {
+			return nil, fmt.Errorf("expected index storage parameter name: %w", err)
+		}
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenOperator, "="); err != nil {
+			return nil, fmt.Errorf("expected '=' after index storage parameter %q: %w", key, err)
+		}
+		p.skipWhitespace()
+		value, err := p.parseCreateIndexStorageParamValue()
+		if err != nil {
+			return nil, err
+		}
+		params[key] = value
+		p.skipWhitespace()
+
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			p.skipWhitespace()
+			continue
+		}
+		if p.current.MatchOperatorValue(")") {
+			break
+		}
+		return nil, fmt.Errorf("expected ',' or ')' in index WITH parameter list at position %d", p.current.Start)
+	}
+	if err := p.expect(lexer.TokenOperator, ")"); err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+func (p *Parser) parseCreateIndexStorageParamValue() (string, error) {
+	if p.current.Type == lexer.TokenEOF || p.current.MatchOperatorValue(",") || p.current.MatchOperatorValue(")") {
+		return "", fmt.Errorf("expected index storage parameter value at position %d", p.current.Start)
+	}
+	value := p.current.Value
+	p.advance()
+	if unquoted, err := strconv.Unquote(value); err == nil {
+		return unquoted, nil
+	}
+	if len(value) >= 2 && strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
+		value = strings.TrimSuffix(strings.TrimPrefix(value, "'"), "'")
+		return strings.ReplaceAll(value, "''", "'"), nil
+	}
+	return value, nil
 }
 
 func (p *Parser) parseCreateIndexColumns() ([]string, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -1321,6 +1321,25 @@ func TestParser_ParseCreateIndexInclude(t *testing.T) {
 	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active", "version"})
 }
 
+func TestParser_ParseCreateIndexUsingAndStorageParams(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE INDEX idx_users_c ON users USING BRIN (c) WITH (pages_per_range='2');"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_c")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Type, qt.Equals, "BRIN")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"c"})
+	c.Assert(index.StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
+}
+
 func TestParser_ParseCreateIndexIncludeRejectsInvalidLists(t *testing.T) {
 	tests := []string{
 		"CREATE INDEX idx_users_name ON users (name) INCLUDE ();",

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -474,6 +474,14 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 		parts = append(parts, fmt.Sprintf("INCLUDE (%s)", strings.Join(node.IncludeColumns, ", ")))
 	}
 
+	if len(node.StorageParams) > 0 {
+		storageParams, err := r.renderIndexStorageParams(node.StorageParams)
+		if err != nil {
+			return err
+		}
+		parts = append(parts, storageParams)
+	}
+
 	// Add WHERE condition for partial indexes
 	if node.Condition != "" {
 		parts = append(parts, "WHERE")
@@ -483,6 +491,39 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 
 	return nil
+}
+
+func (r *Renderer) renderIndexStorageParams(params map[string]string) (string, error) {
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		if !validIndexStorageParamName(key) {
+			return "", fmt.Errorf("invalid PostgreSQL index storage parameter %q", key)
+		}
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	rendered := make([]string, 0, len(keys))
+	for _, key := range keys {
+		rendered = append(rendered, fmt.Sprintf("%s=%s", key, r.escapeValue(params[key])))
+	}
+	return fmt.Sprintf("WITH (%s)", strings.Join(rendered, ", ")), nil
+}
+
+func validIndexStorageParamName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, ch := range name {
+		switch {
+		case ch >= 'a' && ch <= 'z':
+		case ch == '_':
+		case i > 0 && ch >= '0' && ch <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func renderIndexPart(part ast.IndexPart) string {

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -79,6 +79,17 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			expected: "CREATE INDEX idx_users_name ON users (name) INCLUDE (active) WHERE active;\n",
 		},
 		{
+			name: "BRIN index with storage params",
+			index: &ast.IndexNode{
+				Name:          "idx_users_c",
+				Table:         "users",
+				Columns:       []string{"c"},
+				Type:          "BRIN",
+				StorageParams: map[string]string{"pages_per_range": "2"},
+			},
+			expected: "CREATE INDEX idx_users_c ON users USING BRIN (c) WITH (pages_per_range='2');\n",
+		},
+		{
 			name: "trigram index",
 			index: &ast.IndexNode{
 				Name:     "idx_users_name_trgm",
@@ -159,6 +170,21 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			c.Assert(sql, qt.Equals, tt.expected)
 		})
 	}
+}
+
+func TestPostgreSQLRenderer_RejectsUnsafeIndexStorageParamName(t *testing.T) {
+	c := qt.New(t)
+	renderer := postgres.New()
+	index := &ast.IndexNode{
+		Name:          "idx_users_c",
+		Table:         "users",
+		Columns:       []string{"c"},
+		Type:          "BRIN",
+		StorageParams: map[string]string{"pages_per_range) = 2; DROP TABLE users; --": "2"},
+	}
+
+	_, err := renderer.Render(index)
+	c.Assert(err, qt.ErrorMatches, `invalid PostgreSQL index storage parameter .*`)
 }
 
 func TestPostgreSQLRenderer_VisitExtension(t *testing.T) {

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -33,7 +33,7 @@ current schema IR:
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
   `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`; PostgreSQL
-  indexes also support `include`
+  indexes also support `include` and BRIN `page_per_range`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
   `ref_columns` entry
 - `check` blocks with `expr`
@@ -114,6 +114,22 @@ table "users" {
   index "idx_users_name" {
     columns = [column.name]
     include = [column.active]
+  }
+}
+```
+
+## PostgreSQL BRIN Storage Parameter Example
+
+```hcl
+table "users" {
+  column "c" {
+    type = int
+  }
+
+  index "idx_users_c" {
+    type = BRIN
+    columns = [column.c]
+    page_per_range = 2
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add PostgreSQL index storage params to goschema/AST and preserve them through schema converters
- parse Atlas HCL BRIN page_per_range/pages_per_range into pages_per_range
- parse and render CREATE INDEX ... USING ... WITH (...) for PostgreSQL BRIN-style storage params
- document the Atlas HCL BRIN page_per_range shape

## Validation
- go test ./...
- go tool qtlint ./... outside sandbox after sandbox-only package discovery failure
- golangci-lint run --fix ./...
- golangci-lint run ./...
- live PostgreSQL smoke: CREATE INDEX ... USING BRIN ... WITH (pages_per_range=2)