### PR TITLE
Support PostgreSQL NULLS NOT DISTINCT

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -462,6 +462,9 @@ type ConstraintNode struct {
 	ColumnParts []ConstraintColumn
 	// IncludeColumns contains PostgreSQL INCLUDE columns for primary key constraints.
 	IncludeColumns []string
+	// NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+	// Nil means the clause was not specified.
+	NullsDistinct *bool
 	// Reference contains foreign key reference information (only for FOREIGN KEY constraints)
 	Reference *ForeignKeyRef
 	// Expression contains the check expression (only for CHECK constraints)
@@ -516,6 +519,9 @@ type IndexNode struct {
 	Parts []IndexPart
 	// Unique indicates whether this is a unique index
 	Unique bool
+	// NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT state.
+	// Nil means the clause was not specified.
+	NullsDistinct *bool
 	// Type specifies the index type (BTREE, HASH, GIN, GIST, etc. for
 	// PostgreSQL; "minmax", "set(N)", "bloom_filter(p)", "tokenbf_v1(...)"
 	// etc. for ClickHouse data-skipping indexes) - database-specific.

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -133,6 +133,12 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 				return err
 			}
 			p.db.Indexes = append(p.db.Indexes, index)
+		case "unique":
+			constraint, err := p.parseUnique(table.StructName, table.Name, nested)
+			if err != nil {
+				return err
+			}
+			p.db.Constraints = append(p.db.Constraints, constraint)
 		case "foreign_key":
 			spec, err := p.parseForeignKey(nested)
 			if err != nil {
@@ -329,22 +335,59 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		return goschema.Index{}, err
 	}
 	indexType := p.optionalString(block.Body.Attributes["type"])
+	nullsDistinct, err := p.optionalBlockBoolPtr(block, "nulls_distinct", "index")
+	if err != nil {
+		return goschema.Index{}, err
+	}
 	parserName := p.optionalString(block.Body.Attributes["parser"])
 	if parserName != "" && !strings.EqualFold(indexType, "FULLTEXT") {
 		return goschema.Index{}, p.blockError(block, "index parser requires FULLTEXT type")
+	}
+	unique := p.optionalBool(block.Body.Attributes["unique"], false)
+	if nullsDistinct != nil && !unique {
+		return goschema.Index{}, p.blockError(block, "index nulls_distinct requires unique = true")
 	}
 	return goschema.Index{
 		StructName:     structName,
 		Name:           block.Labels[0],
 		Fields:         columns,
 		Parts:          parts,
-		Unique:         p.optionalBool(block.Body.Attributes["unique"], false),
+		Unique:         unique,
+		NullsDistinct:  nullsDistinct,
 		Type:           indexType,
 		Parser:         parserName,
 		Condition:      p.optionalString(block.Body.Attributes["where"]),
 		IncludeColumns: include,
 		StorageParams:  storageParams,
 		TableName:      tableName,
+	}, nil
+}
+
+func (p *parser) parseUnique(structName, tableName string, block *hclsyntax.Block) (goschema.Constraint, error) {
+	if len(block.Labels) != 1 {
+		return goschema.Constraint{}, p.blockError(block, "unique block requires exactly one label")
+	}
+	if err := p.rejectUnsupportedUniqueAttrs(block); err != nil {
+		return goschema.Constraint{}, err
+	}
+	columns, err := p.parseColumnsAttr(block, "columns")
+	if err != nil {
+		return goschema.Constraint{}, err
+	}
+	if len(columns) == 0 {
+		return goschema.Constraint{}, p.blockError(block, "unique %q requires columns", block.Labels[0])
+	}
+	nullsDistinct, err := p.optionalBlockBoolPtr(block, "nulls_distinct", "unique")
+	if err != nil {
+		return goschema.Constraint{}, err
+	}
+	return goschema.Constraint{
+		StructName:    structName,
+		Name:          block.Labels[0],
+		Type:          "UNIQUE",
+		Table:         tableName,
+		Columns:       columns,
+		NullsDistinct: nullsDistinct,
 	}, nil
 }
 
@@ -737,10 +780,18 @@ func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 		"parser":          true,
 		"page_per_range":  true,
 		"pages_per_range": true,
+		"nulls_distinct":  true,
 		"unique":          true,
 		"type":            true,
 		"where":           true,
 	}, "index")
+}
+
+func (p *parser) rejectUnsupportedUniqueAttrs(block *hclsyntax.Block) error {
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"columns":        true,
+		"nulls_distinct": true,
+	}, "unique")
 }
 
 func (p *parser) rejectUnsupportedIndexOnAttrs(block *hclsyntax.Block) error {
@@ -845,6 +896,19 @@ func (p *parser) optionalIndexOnBool(block *hclsyntax.Block, name string, fallba
 		return false, p.blockError(block, "index on attribute %q must be a bool", name)
 	}
 	return value.True(), nil
+}
+
+func (p *parser) optionalBlockBoolPtr(block *hclsyntax.Block, name, label string) (*bool, error) {
+	attr := block.Body.Attributes[name]
+	if attr == nil {
+		return nil, nil
+	}
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.Bool {
+		return nil, p.blockError(block, "%s attribute %q must be a bool", label, name)
+	}
+	result := value.True()
+	return &result, nil
 }
 
 func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -387,6 +387,58 @@ table "users" {
 	c.Assert(err, qt.ErrorMatches, `.*index cannot set both page_per_range and pages_per_range`)
 }
 
+func TestParsePostgreSQLNullsDistinctIndexAndUnique(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "c" {
+    type = int
+  }
+  index "nulls_not_distinct" {
+    unique = true
+    columns = [column.c]
+    nulls_distinct = false
+  }
+  unique "nulls_not_distinct2" {
+    columns = [column.c]
+    nulls_distinct = false
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Unique, qt.IsTrue)
+	c.Assert(db.Indexes[0].NullsDistinct, qt.IsNotNil)
+	c.Assert(*db.Indexes[0].NullsDistinct, qt.IsFalse)
+	c.Assert(db.Constraints, qt.HasLen, 1)
+	c.Assert(db.Constraints[0].Type, qt.Equals, "UNIQUE")
+	c.Assert(db.Constraints[0].Columns, qt.DeepEquals, []string{"c"})
+	c.Assert(db.Constraints[0].NullsDistinct, qt.IsNotNil)
+	c.Assert(*db.Constraints[0].NullsDistinct, qt.IsFalse)
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n")
+	c.Assert(sql, qt.Contains, "CREATE UNIQUE INDEX IF NOT EXISTS nulls_not_distinct ON users (c) NULLS NOT DISTINCT")
+	c.Assert(sql, qt.Contains, "CONSTRAINT nulls_not_distinct2 UNIQUE NULLS NOT DISTINCT (c)")
+}
+
+func TestParsePostgreSQLIndexNullsDistinctRequiresUnique(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "c" {
+    type = int
+  }
+  index "idx_users_c" {
+    columns = [column.c]
+    nulls_distinct = false
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*index nulls_distinct requires unique = true`)
+}
+
 func TestParseFulltextIndexParser(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -719,7 +719,9 @@ func FromConstraint(constraint goschema.Constraint) *ast.ConstraintNode {
 	case "PRIMARY KEY":
 		return ast.NewPrimaryKeyConstraint(constraint.Columns...)
 	case "UNIQUE":
-		return ast.NewUniqueConstraint(constraint.Name, constraint.Columns...)
+		node := ast.NewUniqueConstraint(constraint.Name, constraint.Columns...)
+		node.NullsDistinct = cloneBoolPtr(constraint.NullsDistinct)
+		return node
 	case "FOREIGN KEY":
 		return ast.NewForeignKeyConstraint(constraint.Name, constraint.Columns, &ast.ForeignKeyRef{
 			Table:    constraint.ForeignTable,
@@ -818,6 +820,7 @@ func FromIndex(index goschema.Index) *ast.IndexNode {
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
 	indexNode.IncludeColumns = index.IncludeColumns
+	indexNode.NullsDistinct = cloneBoolPtr(index.NullsDistinct)
 	indexNode.StorageParams = maps.Clone(index.StorageParams)
 
 	// Set unique constraint
@@ -1323,6 +1326,7 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 		indexNode.SetParts(toASTIndexParts(index.Parts))
 	}
 	indexNode.IncludeColumns = index.IncludeColumns
+	indexNode.NullsDistinct = cloneBoolPtr(index.NullsDistinct)
 	indexNode.StorageParams = maps.Clone(index.StorageParams)
 
 	// Set unique constraint
@@ -1360,6 +1364,14 @@ func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string
 	indexNode.IfNotExists = true
 
 	return indexNode
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 func toASTIndexParts(parts []goschema.IndexPart) []ast.IndexPart {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -883,6 +883,25 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.StorageParams["pages_per_range"] == "2"
 			},
 		},
+		{
+			name: "index nulls not distinct",
+			index: func() goschema.Index {
+				nullsDistinct := false
+				return goschema.Index{
+					Name:          "idx_users_c",
+					StructName:    "users",
+					Fields:        []string{"c"},
+					Unique:        true,
+					NullsDistinct: &nullsDistinct,
+				}
+			}(),
+			expected: func(idx *ast.IndexNode) bool {
+				return idx.Name == "idx_users_c" &&
+					idx.Unique &&
+					idx.NullsDistinct != nil &&
+					!*idx.NullsDistinct
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -927,6 +946,22 @@ func TestFromDatabase_IndexIncludeColumns(t *testing.T) {
 	c.Assert(index.Condition, qt.Equals, "active")
 	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active"})
 	c.Assert(index.StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
+}
+
+func TestFromConstraint_UniqueNullsNotDistinct(t *testing.T) {
+	c := qt.New(t)
+	nullsDistinct := false
+
+	node := fromschema.FromConstraint(goschema.Constraint{
+		Name:          "users_c_key",
+		Type:          "UNIQUE",
+		Columns:       []string{"c"},
+		NullsDistinct: &nullsDistinct,
+	})
+
+	c.Assert(node.Type, qt.Equals, ast.UniqueConstraint)
+	c.Assert(node.NullsDistinct, qt.IsNotNil)
+	c.Assert(*node.NullsDistinct, qt.IsFalse)
 }
 
 func TestFromEnum_BasicEnum(t *testing.T) {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -377,6 +377,7 @@ func ToIndex(index *ast.IndexNode) goschema.Index {
 		Condition:      index.Condition,
 		Operator:       index.Operator,
 		IncludeColumns: index.IncludeColumns,
+		NullsDistinct:  cloneBoolPtr(index.NullsDistinct),
 		StorageParams:  maps.Clone(index.StorageParams),
 		TableName:      index.Table,
 	}
@@ -584,6 +585,12 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 				fieldSchema := ToField(column, tableSchema.StructName, "")
 				database.Fields = append(database.Fields, fieldSchema)
 			}
+			for _, constraint := range node.Constraints {
+				constraintSchema, ok := ToConstraint(constraint, tableSchema.StructName, tableSchema.Name)
+				if ok {
+					database.Constraints = append(database.Constraints, constraintSchema)
+				}
+			}
 
 		case *ast.IndexNode:
 			// Convert index definitions
@@ -593,6 +600,30 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 	}
 
 	return database
+}
+
+func ToConstraint(constraint *ast.ConstraintNode, structName, tableName string) (goschema.Constraint, bool) {
+	switch constraint.Type {
+	case ast.UniqueConstraint:
+		return goschema.Constraint{
+			StructName:    structName,
+			Name:          constraint.Name,
+			Type:          "UNIQUE",
+			Table:         tableName,
+			Columns:       append([]string(nil), constraint.Columns...),
+			NullsDistinct: cloneBoolPtr(constraint.NullsDistinct),
+		}, true
+	default:
+		return goschema.Constraint{}, false
+	}
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 // MergeFieldOverrides merges platform-specific field variants to reconstruct platform overrides.

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -550,6 +550,21 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.StorageParams["pages_per_range"] == "2"
 			},
 		},
+		{
+			name: "index nulls not distinct",
+			index: func() *ast.IndexNode {
+				nullsDistinct := false
+				index := ast.NewIndex("idx_users_c", "users", "c").SetUnique()
+				index.NullsDistinct = &nullsDistinct
+				return index
+			}(),
+			expected: func(index goschema.Index) bool {
+				return index.Name == "idx_users_c" &&
+					index.Unique &&
+					index.NullsDistinct != nil &&
+					!*index.NullsDistinct
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -653,6 +668,27 @@ func TestToDatabase_CompleteSchema(t *testing.T) {
 	c.Assert(result.Indexes, qt.HasLen, 2)
 	c.Assert(result.Indexes[0].Name, qt.Equals, "idx_users_status")
 	c.Assert(result.Indexes[1].Name, qt.Equals, "idx_posts_user")
+}
+
+func TestToDatabase_UniqueConstraintNullsNotDistinct(t *testing.T) {
+	c := qt.New(t)
+	nullsDistinct := false
+	usersTable := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("c", "INTEGER")).
+		AddConstraint(&ast.ConstraintNode{
+			Type:          ast.UniqueConstraint,
+			Name:          "users_c_key",
+			Columns:       []string{"c"},
+			NullsDistinct: &nullsDistinct,
+		})
+
+	result := toschema.ToDatabase(&ast.StatementList{Statements: []ast.Node{usersTable}})
+
+	c.Assert(result.Constraints, qt.HasLen, 1)
+	c.Assert(result.Constraints[0].Name, qt.Equals, "users_c_key")
+	c.Assert(result.Constraints[0].Type, qt.Equals, "UNIQUE")
+	c.Assert(result.Constraints[0].NullsDistinct, qt.IsNotNil)
+	c.Assert(*result.Constraints[0].NullsDistinct, qt.IsFalse)
 }
 
 func TestToDatabase_EmptySchema(t *testing.T) {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -242,6 +242,9 @@ type Index struct {
 	Parts   []IndexPart
 	Unique  bool   // Whether this is a unique index
 	Comment string // Index comment/description
+	// NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
+	// state. Nil means the clause was not specified.
+	NullsDistinct *bool
 
 	// Type carries the dialect-specific index type. For PostgreSQL this is
 	// GIN/GIST/BTREE/HASH; for ClickHouse data-skipping indexes it is
@@ -307,6 +310,9 @@ type Constraint struct {
 
 	// UNIQUE/PRIMARY KEY constraint specific fields
 	Columns []string // Column names for UNIQUE/PRIMARY KEY constraints
+	// NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+	// Nil means the clause was not specified.
+	NullsDistinct *bool
 
 	// FOREIGN KEY constraint specific fields
 	ForeignTable   string   // Referenced table name

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -2848,6 +2848,13 @@ func (p *Parser) parseTableConstraint() (*ast.ConstraintNode, error) {
 	}
 
 	p.skipWhitespace()
+	if constraint.Type == ast.UniqueConstraint {
+		constraint.NullsDistinct, err = p.parseNullsDistinctClause()
+		if err != nil {
+			return nil, err
+		}
+		p.skipWhitespace()
+	}
 
 	// Parse column list for PRIMARY KEY, UNIQUE, FOREIGN KEY
 	err = p.parseTableColumnList(constraint)
@@ -3545,6 +3552,11 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 		return nil, err
 	}
 	p.skipWhitespace()
+	nullsDistinct, err := p.parseNullsDistinctClause()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
 	storageParams, err := p.parseCreateIndexStorageParams()
 	if err != nil {
 		return nil, err
@@ -3553,6 +3565,7 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	index := ast.NewIndex(indexName, tableName, columns...)
 	index.Type = indexType
 	index.IncludeColumns = includeColumns
+	index.NullsDistinct = nullsDistinct
 	index.StorageParams = storageParams
 	return index, nil
 }
@@ -3586,6 +3599,24 @@ func (p *Parser) parseCreateIndexIncludeColumns() ([]string, error) {
 		return nil, fmt.Errorf("expected ',' or ')' in index INCLUDE list at position %d", p.current.Start)
 	}
 	return columns, p.expect(lexer.TokenOperator, ")")
+}
+
+func (p *Parser) parseNullsDistinctClause() (*bool, error) {
+	if !p.current.MatchIdentifierValue("NULLS") {
+		return nil, nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	nullsDistinct := true
+	if p.current.MatchIdentifierValue("NOT") {
+		nullsDistinct = false
+		p.advance()
+		p.skipWhitespace()
+	}
+	if err := p.expect(lexer.TokenIdentifier, "DISTINCT"); err != nil {
+		return nil, fmt.Errorf("expected DISTINCT after NULLS clause: %w", err)
+	}
+	return &nullsDistinct, nil
 }
 
 func (p *Parser) parseCreateIndexStorageParams() (map[string]string, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -97,6 +97,29 @@ func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 	c.Assert(fkConstraint.Reference.Column, qt.Equals, "id")
 }
 
+func TestParser_ParseCreateTable_UniqueNullsNotDistinct(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE users (
+		c INTEGER,
+		CONSTRAINT users_c_key UNIQUE NULLS NOT DISTINCT (c)
+	);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Constraints, qt.HasLen, 1)
+	constraint := createTable.Constraints[0]
+	c.Assert(constraint.Type, qt.Equals, ast.UniqueConstraint)
+	c.Assert(constraint.Name, qt.Equals, "users_c_key")
+	c.Assert(constraint.Columns, qt.DeepEquals, []string{"c"})
+	c.Assert(constraint.NullsDistinct, qt.IsNotNil)
+	c.Assert(*constraint.NullsDistinct, qt.IsFalse)
+}
+
 func TestParser_ParseCreateTable_WithCompositeForeignKey(t *testing.T) {
 	c := qt.New(t)
 
@@ -1338,6 +1361,23 @@ func TestParser_ParseCreateIndexUsingAndStorageParams(t *testing.T) {
 	c.Assert(index.Type, qt.Equals, "BRIN")
 	c.Assert(index.Columns, qt.DeepEquals, []string{"c"})
 	c.Assert(index.StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
+}
+
+func TestParser_ParseCreateUniqueIndexNullsNotDistinct(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE UNIQUE INDEX idx_users_c ON users (c) NULLS NOT DISTINCT;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Unique, qt.IsTrue)
+	c.Assert(index.NullsDistinct, qt.IsNotNil)
+	c.Assert(*index.NullsDistinct, qt.IsFalse)
 }
 
 func TestParser_ParseCreateIndexIncludeRejectsInvalidLists(t *testing.T) {

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -433,6 +433,9 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	if node.Unique {
 		parts = append(parts, "UNIQUE")
 	}
+	if node.NullsDistinct != nil && !node.Unique {
+		return fmt.Errorf("postgresql NULLS DISTINCT is only valid for unique indexes")
+	}
 
 	parts = append(parts, "INDEX")
 
@@ -472,6 +475,10 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 
 	if len(node.IncludeColumns) > 0 {
 		parts = append(parts, fmt.Sprintf("INCLUDE (%s)", strings.Join(node.IncludeColumns, ", ")))
+	}
+
+	if node.NullsDistinct != nil {
+		parts = append(parts, renderNullsDistinctClause(node.NullsDistinct))
 	}
 
 	if len(node.StorageParams) > 0 {
@@ -790,10 +797,14 @@ func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, err
 		}
 		return line, nil
 	case ast.UniqueConstraint:
-		if constraint.Name != "" {
-			return fmt.Sprintf("  CONSTRAINT %s UNIQUE (%s)", constraint.Name, strings.Join(constraint.Columns, ", ")), nil
+		clause := "UNIQUE"
+		if constraint.NullsDistinct != nil {
+			clause += " " + renderNullsDistinctClause(constraint.NullsDistinct)
 		}
-		return fmt.Sprintf("  UNIQUE (%s)", strings.Join(constraint.Columns, ", ")), nil
+		if constraint.Name != "" {
+			return fmt.Sprintf("  CONSTRAINT %s %s (%s)", constraint.Name, clause, strings.Join(constraint.Columns, ", ")), nil
+		}
+		return fmt.Sprintf("  %s (%s)", clause, strings.Join(constraint.Columns, ", ")), nil
 	case ast.ForeignKeyConstraint:
 		if !r.capabilities().Has(capability.ForeignKeys) {
 			return "", nil
@@ -809,6 +820,13 @@ func (r *Renderer) renderConstraint(constraint *ast.ConstraintNode) (string, err
 	default:
 		return "", fmt.Errorf("unknown constraint type: %v", constraint.Type)
 	}
+}
+
+func renderNullsDistinctClause(nullsDistinct *bool) string {
+	if nullsDistinct != nil && *nullsDistinct {
+		return "NULLS DISTINCT"
+	}
+	return "NULLS NOT DISTINCT"
 }
 
 // renderForeignKeyConstraint renders a foreign key constraint

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -90,6 +90,20 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			expected: "CREATE INDEX idx_users_c ON users USING BRIN (c) WITH (pages_per_range='2');\n",
 		},
 		{
+			name: "unique index nulls not distinct",
+			index: func() *ast.IndexNode {
+				nullsDistinct := false
+				return &ast.IndexNode{
+					Name:          "idx_users_c",
+					Table:         "users",
+					Columns:       []string{"c"},
+					Unique:        true,
+					NullsDistinct: &nullsDistinct,
+				}
+			}(),
+			expected: "CREATE UNIQUE INDEX idx_users_c ON users (c) NULLS NOT DISTINCT;\n",
+		},
+		{
 			name: "trigram index",
 			index: &ast.IndexNode{
 				Name:     "idx_users_name_trgm",
@@ -185,6 +199,21 @@ func TestPostgreSQLRenderer_RejectsUnsafeIndexStorageParamName(t *testing.T) {
 
 	_, err := renderer.Render(index)
 	c.Assert(err, qt.ErrorMatches, `invalid PostgreSQL index storage parameter .*`)
+}
+
+func TestPostgreSQLRenderer_RejectsNullsDistinctOnNonUniqueIndex(t *testing.T) {
+	c := qt.New(t)
+	renderer := postgres.New()
+	nullsDistinct := false
+	index := &ast.IndexNode{
+		Name:          "idx_users_c",
+		Table:         "users",
+		Columns:       []string{"c"},
+		NullsDistinct: &nullsDistinct,
+	}
+
+	_, err := renderer.Render(index)
+	c.Assert(err, qt.ErrorMatches, `postgresql NULLS DISTINCT is only valid for unique indexes`)
 }
 
 func TestPostgreSQLRenderer_VisitExtension(t *testing.T) {
@@ -700,6 +729,24 @@ func TestPostgreSQLRenderer_PrimaryKeyInclude(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.Contains, "  CONSTRAINT users_pkey PRIMARY KEY (id) INCLUDE (covering)")
+}
+
+func TestPostgreSQLRenderer_UniqueConstraintNullsNotDistinct(t *testing.T) {
+	c := qt.New(t)
+	nullsDistinct := false
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("c", "integer")).
+		AddConstraint(&ast.ConstraintNode{
+			Type:          ast.UniqueConstraint,
+			Name:          "users_c_key",
+			Columns:       []string{"c"},
+			NullsDistinct: &nullsDistinct,
+		})
+
+	result, err := postgres.New().Render(table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.Contains, "  CONSTRAINT users_c_key UNIQUE NULLS NOT DISTINCT (c)")
 }
 
 func TestPostgreSQLRenderer_RejectsIdentityGeneratedColumnMix(t *testing.T) {

--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -53,6 +53,44 @@ func TestNewPostgreSQLReaderWithCapabilities(t *testing.T) {
 	c.Assert(reader.caps.Has(capability.XMLType), qt.IsFalse)
 }
 
+func TestPostgresNullsDistinctFromDefinition(t *testing.T) {
+	tests := []struct {
+		name        string
+		definition  string
+		expected    bool
+		expectedSet bool
+	}{
+		{
+			name:        "nulls not distinct",
+			definition:  `CREATE UNIQUE INDEX users_c_key ON public.users USING btree (c) NULLS NOT DISTINCT`,
+			expected:    false,
+			expectedSet: true,
+		},
+		{
+			name:        "nulls distinct",
+			definition:  `CREATE UNIQUE INDEX users_c_key ON public.users USING btree (c) NULLS DISTINCT`,
+			expected:    true,
+			expectedSet: true,
+		},
+		{
+			name:       "absent",
+			definition: `CREATE UNIQUE INDEX users_c_key ON public.users USING btree (c)`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			actual := postgresNullsDistinctFromDefinition(test.definition)
+			if !test.expectedSet {
+				c.Assert(actual, qt.IsNil)
+				return
+			}
+			c.Assert(actual, qt.IsNotNil)
+			c.Assert(*actual, qt.Equals, test.expected)
+		})
+	}
+}
+
 func TestPostgreSQLReader_ReadSchema_NoConnection(t *testing.T) {
 	c := qt.New(t)
 

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -384,12 +384,13 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 
 		// Parse index definition to extract columns and properties
 		index := types.DBIndex{
-			Name:       indexName,
-			TableName:  tableName,
-			Schema:     r.outputSchema(schemaName),
-			Definition: indexDef,
-			IsUnique:   isUnique,
-			IsPrimary:  isPrimary,
+			Name:          indexName,
+			TableName:     tableName,
+			Schema:        r.outputSchema(schemaName),
+			Definition:    indexDef,
+			IsUnique:      isUnique,
+			IsPrimary:     isPrimary,
+			NullsDistinct: postgresNullsDistinctFromDefinition(indexDef),
 		}
 
 		// Extract column names from index definition (simplified parsing)
@@ -458,7 +459,17 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 				COALESCE(string_agg(ukcu.column_name, ',' ORDER BY kcu.ordinal_position) FILTER (WHERE ukcu.column_name IS NOT NULL), ''),
 				COALESCE(rc.delete_rule, ''),
 			COALESCE(rc.update_rule, ''),
-			COALESCE(cc.check_clause, '')
+			COALESCE(cc.check_clause, ''),
+			COALESCE((
+				SELECT pg_get_constraintdef(pc.oid)
+				FROM pg_constraint pc
+				JOIN pg_class pc_table ON pc_table.oid = pc.conrelid
+				JOIN pg_namespace pc_schema ON pc_schema.oid = pc_table.relnamespace
+				WHERE pc_schema.nspname = tc.table_schema
+				AND pc_table.relname = tc.table_name
+				AND pc.conname = tc.constraint_name
+				LIMIT 1
+			), '')
 		FROM information_schema.table_constraints AS tc
 		LEFT JOIN information_schema.key_column_usage AS kcu
 			ON tc.constraint_name = kcu.constraint_name
@@ -495,7 +506,7 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 	var constraints []types.DBConstraint
 	for rows.Next() {
 		var constraint types.DBConstraint
-		var columnNames, foreignSchema, foreignTable, foreignColumns, deleteRule, updateRule, checkClause string
+		var columnNames, foreignSchema, foreignTable, foreignColumns, deleteRule, updateRule, checkClause, constraintDefinition string
 
 		err := rows.Scan(
 			&constraint.Schema,
@@ -509,6 +520,7 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 			&deleteRule,
 			&updateRule,
 			&checkClause,
+			&constraintDefinition,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan constraint: %w", err)
@@ -537,11 +549,25 @@ func (r *Reader) readBasicConstraintsForSchema(schemaName string) ([]types.DBCon
 		if checkClause != "" {
 			constraint.CheckClause = &checkClause
 		}
+		constraint.NullsDistinct = postgresNullsDistinctFromDefinition(constraintDefinition)
 
 		constraints = append(constraints, constraint)
 	}
 
 	return constraints, nil
+}
+
+func postgresNullsDistinctFromDefinition(definition string) *bool {
+	upper := strings.ToUpper(definition)
+	if strings.Contains(upper, "NULLS NOT DISTINCT") {
+		nullsDistinct := false
+		return &nullsDistinct
+	}
+	if strings.Contains(upper, "NULLS DISTINCT") {
+		nullsDistinct := true
+		return &nullsDistinct
+	}
+	return nil
 }
 
 // readPostgreSQLConstraints reads PostgreSQL-specific constraints from pg_constraint

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -103,6 +103,9 @@ type DBIndex struct {
 	IsUnique   bool     `json:"is_unique"`
 	IsPrimary  bool     `json:"is_primary"`
 	Definition string   `json:"definition"` // Full index definition
+	// NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
+	// state. Nil means the clause was not present in the definition.
+	NullsDistinct *bool `json:"nulls_distinct,omitempty"`
 
 	// Type is the ClickHouse data-skipping-index type. One of
 	// "minmax" / "set(N)" / "bloom_filter" / "bloom_filter(p)" /
@@ -140,6 +143,9 @@ type DBConstraint struct {
 	DeleteRule     *string  `json:"delete_rule"`  // CASCADE, RESTRICT, etc.
 	UpdateRule     *string  `json:"update_rule"`  // CASCADE, RESTRICT, etc.
 	CheckClause    *string  `json:"check_clause"` // For CHECK constraints
+	// NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+	// Nil means the clause was not present in the definition.
+	NullsDistinct *bool `json:"nulls_distinct,omitempty"`
 	// EXCLUDE constraint specific fields (PostgreSQL only)
 	UsingMethod     *string `json:"using_method"`     // Index method: gist, btree, etc.
 	ExcludeElements *string `json:"exclude_elements"` // Elements with operators: "room_id WITH =, during WITH &&"

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -33,7 +33,9 @@ current schema IR:
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
   `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`; PostgreSQL
-  indexes also support `include` and BRIN `page_per_range`
+  indexes also support `include`, BRIN `page_per_range`, and
+  `nulls_distinct`
+- `unique` blocks with `columns` and PostgreSQL `nulls_distinct`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified
   `ref_columns` entry
 - `check` blocks with `expr`
@@ -130,6 +132,27 @@ table "users" {
     type = BRIN
     columns = [column.c]
     page_per_range = 2
+  }
+}
+```
+
+## PostgreSQL NULLS NOT DISTINCT Example
+
+```hcl
+table "users" {
+  column "c" {
+    type = int
+  }
+
+  index "users_c_idx" {
+    unique = true
+    columns = [column.c]
+    nulls_distinct = false
+  }
+
+  unique "users_c_key" {
+    columns = [column.c]
+    nulls_distinct = false
   }
 }
 ```

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -604,11 +604,20 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 	for _, table := range generated.Tables {
 		structToTableMap[table.StructName] = table.QualifiedName()
 	}
+	replacementIndexes := stringSet(diff.IndexesRemoved)
+	guardedDrops := p.capabilities().Has(capability.DropIndexIfExists)
 
 	for _, indexName := range diff.IndexesAdded {
 		// Find the index definition
 		for _, idx := range generated.Indexes {
 			if idx.Name == indexName {
+				if _, replacing := replacementIndexes[indexName]; replacing {
+					dropIndexNode := ast.NewDropIndex(indexName)
+					if guardedDrops {
+						dropIndexNode.SetIfExists()
+					}
+					result = append(result, dropIndexNode)
+				}
 				// Use enhanced index creation with PostgreSQL features
 				indexNode := fromschema.FromIndexWithTableMapping(idx, structToTableMap)
 				// CONCURRENTLY is opt-in policy AND capability-gated: the
@@ -632,7 +641,11 @@ func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast
 	// the default preset keeps today's output; a preset without it (or a
 	// composed set) actually changes the plan.
 	guarded := p.capabilities().Has(capability.DropIndexIfExists)
+	replacementIndexes := stringSet(diff.IndexesAdded)
 	for _, indexName := range diff.IndexesRemoved {
+		if _, replaced := replacementIndexes[indexName]; replaced {
+			continue
+		}
 		dropIndexNode := ast.NewDropIndex(indexName)
 		if guarded {
 			dropIndexNode.SetIfExists()
@@ -640,6 +653,14 @@ func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast
 		result = append(result, dropIndexNode)
 	}
 	return result
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
 }
 
 func (p *Planner) removeTables(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
@@ -1935,7 +1956,9 @@ func (p *Planner) convertConstraintToAST(constraint goschema.Constraint) *ast.Co
 		if len(constraint.Columns) == 0 {
 			return nil // Invalid UNIQUE constraint
 		}
-		return ast.NewUniqueConstraint(constraint.Name, constraint.Columns...)
+		astConstraint := ast.NewUniqueConstraint(constraint.Name, constraint.Columns...)
+		astConstraint.NullsDistinct = cloneBoolPtr(constraint.NullsDistinct)
+		return astConstraint
 
 	case "PRIMARY KEY":
 		if len(constraint.Columns) == 0 {
@@ -1960,4 +1983,12 @@ func (p *Planner) convertConstraintToAST(constraint goschema.Constraint) *ast.Co
 	default:
 		return nil // Unsupported constraint type
 	}
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }

--- a/migration/planner/dialects/postgres/postgres_test.go
+++ b/migration/planner/dialects/postgres/postgres_test.go
@@ -623,6 +623,33 @@ func TestPlanner_GenerateMigrationSQL_IndexesAdded(t *testing.T) {
 				return indexNode.Name == "uk_users_email" && indexNode.Unique
 			},
 		},
+		{
+			name: "same name index replacement drops before create",
+			diff: &types.SchemaDiff{
+				IndexesAdded:   []string{"idx_users_c"},
+				IndexesRemoved: []string{"idx_users_c"},
+			},
+			generated: func() *goschema.Database {
+				nullsDistinct := false
+				return &goschema.Database{
+					Indexes: []goschema.Index{
+						{Name: "idx_users_c", StructName: "users", Fields: []string{"c"}, Unique: true, NullsDistinct: &nullsDistinct},
+					},
+				}
+			}(),
+			expected: func(nodes []ast.Node) bool {
+				if len(nodes) != 2 {
+					return false
+				}
+				dropNode, dropOk := nodes[0].(*ast.DropIndexNode)
+				indexNode, indexOk := nodes[1].(*ast.IndexNode)
+				return dropOk && indexOk &&
+					dropNode.Name == "idx_users_c" &&
+					indexNode.Name == "idx_users_c" &&
+					indexNode.NullsDistinct != nil &&
+					!*indexNode.NullsDistinct
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -1055,6 +1055,7 @@ func appendConstraintAddition(infos []difftypes.ConstraintAdditionInfo, genConst
 		TableName:      genConstraint.Table,
 		Type:           genConstraint.Type,
 		Columns:        append([]string(nil), genConstraint.Columns...),
+		NullsDistinct:  cloneBoolPtr(genConstraint.NullsDistinct),
 		ForeignTable:   genConstraint.ForeignTable,
 		ForeignColumn:  genConstraint.ForeignColumn,
 		ForeignColumns: append([]string(nil), genConstraint.ForeignColumnsOrDefault()...),
@@ -1138,10 +1139,23 @@ func checkConstraintChanged(_ goschema.Constraint, _ types.DBConstraint) bool {
 
 // uniqueConstraintChanged compares UNIQUE constraint definitions
 func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
-	// For UNIQUE constraints, we primarily compare the columns involved
-	// This is a simplified comparison - in practice, we might need to compare
-	// the actual column lists from the database constraint
-	return false // For now, assume UNIQUE constraints don't change
+	return !slices.Equal(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault()) ||
+		!boolPtrEqual(genConstraint.NullsDistinct, dbConstraint.NullsDistinct)
+}
+
+func boolPtrEqual(left, right *bool) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 // foreignKeyConstraintChanged compares FOREIGN KEY constraint definitions.
@@ -1733,9 +1747,9 @@ func isMySQLConstraintBasedUniqueIndex(indexName, tableName string) bool {
 // - Index operations can be expensive on large tables in production
 func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
 	// Create sets for comparison
-	genIndexes := make(map[string]bool)
+	genIndexes := make(map[string]goschema.Index)
 	for _, index := range generated.Indexes {
-		genIndexes[index.Name] = true
+		genIndexes[index.Name] = index
 	}
 
 	// MySQL/MariaDB transparently create a backing index for every FOREIGN KEY,
@@ -1753,7 +1767,7 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 		}
 	}
 
-	dbIndexes := make(map[string]bool)
+	dbIndexes := make(map[string]types.DBIndex)
 	for _, index := range database.Indexes {
 		// Skip primary key indexes as they're handled with tables
 		if index.IsPrimary {
@@ -1772,30 +1786,32 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 			continue
 		}
 
-		dbIndexes[index.Name] = true
+		dbIndexes[index.Name] = index
 	}
 
 	// Find added and removed indexes
-	for indexName := range genIndexes {
-		if !dbIndexes[indexName] {
+	for indexName, genIndex := range genIndexes {
+		dbIndex, exists := dbIndexes[indexName]
+		switch {
+		case !exists:
 			diff.IndexesAdded = append(diff.IndexesAdded, indexName)
+		case indexDefinitionsChanged(genIndex, dbIndex):
+			diff.IndexesAdded = append(diff.IndexesAdded, indexName)
+			diff.IndexesRemoved = append(diff.IndexesRemoved, indexName)
+			diff.IndexesRemovedWithTables = append(diff.IndexesRemovedWithTables, difftypes.IndexRemovalInfo{
+				Name:      indexName,
+				TableName: dbIndex.QualifiedTableName(),
+			})
 		}
 	}
 
-	for indexName := range dbIndexes {
-		if !genIndexes[indexName] {
+	for indexName, dbIndex := range dbIndexes {
+		if _, exists := genIndexes[indexName]; !exists {
 			diff.IndexesRemoved = append(diff.IndexesRemoved, indexName)
-
-			// Also populate the detailed removal info with table name for MySQL/MariaDB support
-			for _, index := range database.Indexes {
-				if index.Name == indexName {
-					diff.IndexesRemovedWithTables = append(diff.IndexesRemovedWithTables, difftypes.IndexRemovalInfo{
-						Name:      indexName,
-						TableName: index.QualifiedTableName(),
-					})
-					break
-				}
-			}
+			diff.IndexesRemovedWithTables = append(diff.IndexesRemovedWithTables, difftypes.IndexRemovalInfo{
+				Name:      indexName,
+				TableName: dbIndex.QualifiedTableName(),
+			})
 		}
 	}
 
@@ -1807,6 +1823,10 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 	sort.Slice(diff.IndexesRemovedWithTables, func(i, j int) bool {
 		return diff.IndexesRemovedWithTables[i].Name < diff.IndexesRemovedWithTables[j].Name
 	})
+}
+
+func indexDefinitionsChanged(genIndex goschema.Index, dbIndex types.DBIndex) bool {
+	return !boolPtrEqual(genIndex.NullsDistinct, dbIndex.NullsDistinct)
 }
 
 // compareNamedItems is a generic helper function that compares two maps of named items

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -737,6 +737,26 @@ func TestIndexes_HappyPath(t *testing.T) {
 				IndexesRemoved: []string{"old_index"},
 			},
 		},
+		{
+			name: "index nulls distinct changed",
+			generated: func() *goschema.Database {
+				nullsDistinct := false
+				return &goschema.Database{
+					Indexes: []goschema.Index{
+						{Name: "idx_users_c", StructName: "users", Fields: []string{"c"}, Unique: true, NullsDistinct: &nullsDistinct},
+					},
+				}
+			}(),
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{Name: "idx_users_c", TableName: "users", Columns: []string{"c"}, IsUnique: true},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				IndexesAdded:   []string{"idx_users_c"},
+				IndexesRemoved: []string{"idx_users_c"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -129,6 +129,38 @@ func TestConstraints(t *testing.T) {
 			},
 		},
 		{
+			name: "UNIQUE constraint nulls distinct changed",
+			generated: func() *goschema.Database {
+				nullsDistinct := false
+				return &goschema.Database{
+					Constraints: []goschema.Constraint{
+						{
+							StructName:    "User",
+							Name:          "users_c_key",
+							Type:          "UNIQUE",
+							Table:         "users",
+							Columns:       []string{"c"},
+							NullsDistinct: &nullsDistinct,
+						},
+					},
+				}
+			}(),
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "users_c_key",
+						TableName:   "users",
+						Type:        "UNIQUE",
+						ColumnNames: []string{"c"},
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"users_c_key"},
+				ConstraintsRemoved: []string{"users_c_key"},
+			},
+		},
+		{
 			name: "FOREIGN KEY constraint added",
 			generated: &goschema.Database{
 				Constraints: []goschema.Constraint{

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -58,6 +58,9 @@ type ConstraintAdditionInfo struct {
 
 	// Columns are the local columns the constraint covers (FK source columns).
 	Columns []string `json:"columns,omitempty"`
+	// NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+	// Nil means the clause was not specified.
+	NullsDistinct *bool `json:"nulls_distinct,omitempty"`
 
 	// ForeignTable / ForeignColumn / ForeignColumns describe the FK target
 	// (FOREIGN KEY only). ForeignColumn is kept for compatibility with older


### PR DESCRIPTION
## Summary
- add tri-state PostgreSQL NULLS [NOT] DISTINCT support to index and unique constraint IR
- parse Atlas HCL index/unique nulls_distinct and table-level unique blocks
- parse/render SQL for CREATE UNIQUE INDEX and UNIQUE constraints with NULLS [NOT] DISTINCT
- read NULLS [NOT] DISTINCT from PostgreSQL pg_get_indexdef/pg_get_constraintdef output
- detect unique constraint and explicit index nulls_distinct drift; recreate same-name indexes in drop-then-create order
- document Atlas HCL nulls_distinct support

## Validation
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- live PostgreSQL 18 smoke: CREATE UNIQUE INDEX ... NULLS NOT DISTINCT and ALTER TABLE ... ADD CONSTRAINT ... UNIQUE NULLS NOT DISTINCT, verified pg_indexes output