### PR TITLE
Parse PostgreSQL domains as type nodes

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -3835,7 +3835,7 @@ func (p *Parser) parseCreateType() (*ast.EnumNode, error) {
 }
 
 // parseCreateDomain parses CREATE DOMAIN statements (PostgreSQL).
-func (p *Parser) parseCreateDomain() (*ast.CommentNode, error) {
+func (p *Parser) parseCreateDomain() (*ast.CreateTypeNode, error) {
 	if err := p.expect(lexer.TokenIdentifier, "DOMAIN"); err != nil {
 		return nil, err
 	}
@@ -3843,9 +3843,9 @@ func (p *Parser) parseCreateDomain() (*ast.CommentNode, error) {
 	p.skipWhitespace()
 
 	// Get domain name
-	domainName, err := p.expectIdentifier()
+	domainName, err := p.parseQualifiedIdentifier("domain name")
 	if err != nil {
-		return nil, fmt.Errorf("expected domain name: %w", err)
+		return nil, err
 	}
 
 	p.skipWhitespace()
@@ -3862,12 +3862,9 @@ func (p *Parser) parseCreateDomain() (*ast.CommentNode, error) {
 		return nil, fmt.Errorf("expected base type: %w", err)
 	}
 
-	// For now, we'll represent domains as comments since they're not in the AST
-	// In a full implementation, you'd want to add a DomainNode to the AST
-	var domainText strings.Builder
-	fmt.Fprintf(&domainText, "CREATE DOMAIN %s AS %s", domainName, baseType)
+	domainDef := ast.NewDomainTypeDef(baseType)
 
-	// Parse optional constraints (CHECK, etc.)
+	// Parse optional domain constraints.
 	for {
 		p.skipWhitespace()
 
@@ -3876,20 +3873,39 @@ func (p *Parser) parseCreateDomain() (*ast.CommentNode, error) {
 		}
 
 		keyword := strings.ToUpper(p.current.Value)
-		if keyword != "CHECK" {
+		handled := true
+		switch keyword {
+		case "CHECK":
+			p.advance()
+			p.skipWhitespace()
+			checkExpr, err := p.parseCheckExpression()
+			if err != nil {
+				return nil, fmt.Errorf("expected check expression: %w", err)
+			}
+			domainDef.SetCheck(checkExpr)
+		case "NOT":
+			p.advance()
+			p.skipWhitespace()
+			if err := p.expect(lexer.TokenIdentifier, "NULL"); err != nil {
+				return nil, fmt.Errorf("expected NULL after NOT in domain definition: %w", err)
+			}
+			domainDef.SetNotNull()
+		case "DEFAULT":
+			p.advance()
+			defaultValue, err := p.parseDefaultValue()
+			if err != nil {
+				return nil, fmt.Errorf("expected domain default value: %w", err)
+			}
+			domainDef.Default = defaultValue
+		default:
+			handled = false
+		}
+		if !handled {
 			break
 		}
-
-		p.advance()
-		p.skipWhitespace()
-		checkExpr, err := p.parseCheckExpression()
-		if err != nil {
-			return nil, fmt.Errorf("expected check expression: %w", err)
-		}
-		fmt.Fprintf(&domainText, " CHECK (%s)", checkExpr)
 	}
 
-	return ast.NewComment(domainText.String()), nil
+	return ast.NewCreateType(domainName, domainDef), nil
 }
 
 // parseCommentStatement parses COMMENT ON statements (PostgreSQL).

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -2109,10 +2109,33 @@ func TestParser_ParsePostgreSQLDomain(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 1)
 
-	comment, ok := statements.Statements[0].(*ast.CommentNode)
+	domain, ok := statements.Statements[0].(*ast.CreateTypeNode)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(comment.Text, qt.Contains, "CREATE DOMAIN email_domain AS TEXT")
-	c.Assert(comment.Text, qt.Contains, "CHECK")
+	c.Assert(domain.Name, qt.Equals, "email_domain")
+	domainDef, ok := domain.TypeDef.(*ast.DomainTypeDef)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(domainDef.BaseType, qt.Equals, "TEXT")
+	c.Assert(domainDef.Nullable, qt.IsTrue)
+	c.Assert(domainDef.Check, qt.Contains, "VALUE ~*")
+}
+
+func TestParser_ParsePostgreSQLQualifiedDomain(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE DOMAIN script_column_domain.positive_int AS bigint CHECK (VALUE > 0);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	domain, ok := statements.Statements[0].(*ast.CreateTypeNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(domain.Name, qt.Equals, "script_column_domain.positive_int")
+	domainDef, ok := domain.TypeDef.(*ast.DomainTypeDef)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(domainDef.BaseType, qt.Equals, "bigint")
+	c.Assert(domainDef.Check, qt.Equals, "VALUE > 0")
 }
 
 func TestParser_ParsePostgreSQLSerialTypes(t *testing.T) {
@@ -2388,10 +2411,14 @@ func TestParser_ParsePostgreSQLMultipleStatements(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(enum.Name, qt.Equals, "status_enum")
 
-	// Check domain (represented as comment)
-	domain, ok := statements.Statements[1].(*ast.CommentNode)
+	// Check domain
+	domain, ok := statements.Statements[1].(*ast.CreateTypeNode)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(domain.Text, qt.Contains, "CREATE DOMAIN email_domain")
+	c.Assert(domain.Name, qt.Equals, "email_domain")
+	domainDef, ok := domain.TypeDef.(*ast.DomainTypeDef)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(domainDef.BaseType, qt.Equals, "TEXT")
+	c.Assert(domainDef.Check, qt.Contains, "VALUE ~*")
 
 	// Check table
 	table, ok := statements.Statements[2].(*ast.CreateTableNode)

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -201,6 +201,20 @@ func TestPostgreSQLRenderer_RejectsUnsafeIndexStorageParamName(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `invalid PostgreSQL index storage parameter .*`)
 }
 
+func TestPostgreSQLRenderer_CreateDomain(t *testing.T) {
+	c := qt.New(t)
+	renderer := postgres.New()
+	node := ast.NewCreateType(
+		"script_column_domain.positive_int",
+		ast.NewDomainTypeDef("bigint").SetCheck("VALUE > 0"),
+	)
+
+	sql, err := renderer.Render(node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, "CREATE DOMAIN script_column_domain.positive_int AS bigint CHECK (VALUE > 0);\n")
+}
+
 func TestPostgreSQLRenderer_RejectsNullsDistinctOnNonUniqueIndex(t *testing.T) {
 	c := qt.New(t)
 	renderer := postgres.New()


### PR DESCRIPTION
## Summary
- parse PostgreSQL CREATE DOMAIN statements into CreateTypeNode with DomainTypeDef instead of CommentNode
- support schema-qualified domain names such as script_column_domain.positive_int
- keep domain CHECK, NOT NULL, and DEFAULT data on the domain type definition
- add PostgreSQL renderer coverage for domain nodes

## Validation
- go test ./core/parser ./core/renderer/dialects/postgres -run 'TestParser_ParsePostgreSQLDomain|TestParser_ParsePostgreSQLQualifiedDomain|TestParser_ParsePostgreSQLMultipleStatements|TestPostgreSQLRenderer_CreateDomain' -count=1 -v
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...