### PR TITLE
Default generated column kind by platform

### DIFF
--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -263,7 +263,7 @@ func (p *parser) parseGeneratedColumn(block *hclsyntax.Block) (generatedColumnSp
 		return generatedColumnSpec{}, p.blockError(asBlocks[1], "column can contain at most one as block")
 	}
 	if attr != nil {
-		return generatedColumnSpec{expression: p.exprString(attr), kind: "VIRTUAL"}, nil
+		return generatedColumnSpec{expression: p.exprString(attr)}, nil
 	}
 	if len(asBlocks) == 0 {
 		return generatedColumnSpec{}, nil

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -767,7 +767,7 @@ table "users" {
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Fields, qt.HasLen, 2)
 	c.Assert(db.Fields[0].GeneratedExpression, qt.Equals, "lower(name)")
-	c.Assert(db.Fields[0].GeneratedKind, qt.Equals, "VIRTUAL")
+	c.Assert(db.Fields[0].GeneratedKind, qt.Equals, "")
 	c.Assert(db.Fields[1].GeneratedExpression, qt.Equals, "lower(name)")
 	c.Assert(db.Fields[1].GeneratedKind, qt.Equals, "STORED")
 }

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -83,6 +83,24 @@ func GenerateForeignKeyName(tableName, fieldName string) string {
 	return "fk_" + strings.ToLower(tableName) + "_" + strings.ToLower(fieldName)
 }
 
+func defaultGeneratedKind(field goschema.Field, targetPlatform string) string {
+	if field.GeneratedExpression == "" || field.GeneratedKind != "" {
+		return field.GeneratedKind
+	}
+	switch {
+	case isPostgreSQLPlatform(targetPlatform):
+		return "STORED"
+	case targetPlatform == "mysql" || targetPlatform == "mariadb":
+		return "VIRTUAL"
+	default:
+		return field.GeneratedKind
+	}
+}
+
+func isPostgreSQLPlatform(targetPlatform string) bool {
+	return strings.EqualFold(targetPlatform, "postgres") || strings.EqualFold(targetPlatform, "postgresql")
+}
+
 func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschema.Field {
 	fieldType := field.Type
 	checkConstraint := field.Check
@@ -349,7 +367,7 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 		}
 	}
 	if field.GeneratedExpression != "" {
-		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
+		column.SetGenerated(field.GeneratedExpression, defaultGeneratedKind(field, targetPlatform))
 	}
 	if field.UpdateExpression != "" {
 		column.SetUpdateExpression(field.UpdateExpression)
@@ -439,7 +457,7 @@ func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, ta
 		}
 	}
 	if field.GeneratedExpression != "" {
-		column.SetGenerated(field.GeneratedExpression, field.GeneratedKind)
+		column.SetGenerated(field.GeneratedExpression, defaultGeneratedKind(field, targetPlatform))
 	}
 	if field.UpdateExpression != "" {
 		column.SetUpdateExpression(field.UpdateExpression)

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -12,9 +12,10 @@ import (
 
 func TestFromField_BasicProperties(t *testing.T) {
 	tests := []struct {
-		name     string
-		field    goschema.Field
-		expected func(*ast.ColumnNode) bool
+		name           string
+		field          goschema.Field
+		targetPlatform string
+		expected       func(*ast.ColumnNode) bool
 	}{
 		{
 			name: "basic field with name and type",
@@ -102,6 +103,43 @@ func TestFromField_BasicProperties(t *testing.T) {
 			},
 		},
 		{
+			name: "PostgreSQL generated field defaults to stored",
+			field: goschema.Field{
+				Name:                "slug",
+				Type:                "TEXT",
+				GeneratedExpression: "lower(name)",
+			},
+			targetPlatform: "postgres",
+			expected: func(col *ast.ColumnNode) bool {
+				return col.GeneratedExpression == "lower(name)" && col.GeneratedKind == "STORED"
+			},
+		},
+		{
+			name: "PostgreSQL explicit virtual generated field is preserved",
+			field: goschema.Field{
+				Name:                "slug",
+				Type:                "TEXT",
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "VIRTUAL",
+			},
+			targetPlatform: "postgres",
+			expected: func(col *ast.ColumnNode) bool {
+				return col.GeneratedExpression == "lower(name)" && col.GeneratedKind == "VIRTUAL"
+			},
+		},
+		{
+			name: "MySQL generated field defaults to virtual",
+			field: goschema.Field{
+				Name:                "slug",
+				Type:                "TEXT",
+				GeneratedExpression: "lower(name)",
+			},
+			targetPlatform: "mysql",
+			expected: func(col *ast.ColumnNode) bool {
+				return col.GeneratedExpression == "lower(name)" && col.GeneratedKind == "VIRTUAL"
+			},
+		},
+		{
 			name: "column update expression",
 			field: goschema.Field{
 				Name:             "updated_at",
@@ -129,7 +167,7 @@ func TestFromField_BasicProperties(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			result := fromschema.FromField(test.field, nil, "")
+			result := fromschema.FromField(test.field, nil, test.targetPlatform)
 			c.Assert(result, qt.IsNotNil)
 			c.Assert(test.expected(result), qt.IsTrue)
 		})


### PR DESCRIPTION
## Summary
- keep Atlas HCL shorthand generated columns (`as = ...`) dialect-neutral in the parsed schema IR
- default generated column kind during schema-to-AST conversion based on the target platform
- use STORED by default for PostgreSQL and VIRTUAL by default for MySQL/MariaDB while preserving explicit generated kinds

## Validation
- go test ./core/atlashcl ./core/convert/fromschema ./core/renderer/dialects/postgres -run 'TestParseGeneratedColumns|TestFromField_BasicProperties|TestPostgreSQLRenderer_Generated|TestPostgreSQLGenerated' -count=1 -v
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
