### PR TITLE
Support index part operator classes

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -488,6 +488,8 @@ type IndexPart struct {
 	Name string
 	// Expr is a raw indexed expression. It is mutually exclusive with Name.
 	Expr string
+	// Operator is the PostgreSQL operator class for this index part.
+	Operator string
 	// Prefix stores the MySQL index prefix length for column parts.
 	Prefix string
 	// Desc indicates DESC ordering for this index part.

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -457,11 +457,12 @@ func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.I
 		if err != nil {
 			return nil, nil, err
 		}
+		operator := p.optionalSQLExpression(nested.Body.Attributes["ops"])
 		prefix := p.optionalRawExpr(nested.Body.Attributes["prefix"])
 		if columnAttr != nil {
 			column := p.columnNameFromExpr(columnAttr)
 			columns = append(columns, column)
-			parts = append(parts, goschema.IndexPart{Name: column, Prefix: prefix, Desc: desc})
+			parts = append(parts, goschema.IndexPart{Name: column, Operator: operator, Prefix: prefix, Desc: desc})
 			continue
 		}
 		if prefix != "" {
@@ -469,7 +470,7 @@ func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.I
 		}
 		expr := p.exprString(exprAttr)
 		columns = append(columns, expr)
-		parts = append(parts, goschema.IndexPart{Expr: expr, Desc: desc})
+		parts = append(parts, goschema.IndexPart{Expr: expr, Operator: operator, Desc: desc})
 	}
 	return columns, parts, nil
 }
@@ -833,6 +834,7 @@ func (p *parser) rejectUnsupportedIndexOnAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"column": true,
 		"expr":   true,
+		"ops":    true,
 		"prefix": true,
 		"desc":   true,
 	}, "index on")

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -341,10 +341,12 @@ table "users" {
   index "rank_score_idx" {
     on {
       column = column.rank
+      ops    = bpchar_ops
       prefix = 7
     }
     on {
       column = column.score
+      ops    = sql("tsvector_ops(siglen=8)")
       desc = true
     }
   }
@@ -359,8 +361,8 @@ table "users" {
 	c.Assert(db.Indexes, qt.HasLen, 2)
 	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"rank", "score"})
 	c.Assert(db.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
-		{Name: "rank", Prefix: "7"},
-		{Name: "score", Desc: true},
+		{Name: "rank", Operator: "bpchar_ops", Prefix: "7"},
+		{Name: "score", Operator: "tsvector_ops(siglen=8)", Desc: true},
 	})
 	c.Assert(db.Indexes[1].Fields, qt.DeepEquals, []string{"first_name || ' ' || last_name"})
 	c.Assert(db.Indexes[1].Parts, qt.DeepEquals, []goschema.IndexPart{

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1396,10 +1396,11 @@ func toASTIndexParts(parts []goschema.IndexPart) []ast.IndexPart {
 	astParts := make([]ast.IndexPart, 0, len(parts))
 	for _, part := range parts {
 		astParts = append(astParts, ast.IndexPart{
-			Name:   part.Name,
-			Expr:   part.Expr,
-			Prefix: part.Prefix,
-			Desc:   part.Desc,
+			Name:     part.Name,
+			Expr:     part.Expr,
+			Operator: part.Operator,
+			Prefix:   part.Prefix,
+			Desc:     part.Desc,
 		})
 	}
 	return astParts

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -874,8 +874,8 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 				StructName: "users",
 				Fields:     []string{"stale_rank", "stale_name"},
 				Parts: []goschema.IndexPart{
-					{Name: "rank", Prefix: "7", Desc: true},
-					{Expr: "lower(name)"},
+					{Name: "rank", Operator: "bpchar_ops", Prefix: "7", Desc: true},
+					{Expr: "lower(name)", Operator: "text_pattern_ops"},
 				},
 			},
 			expected: func(idx *ast.IndexNode) bool {
@@ -885,8 +885,8 @@ func TestFromIndex_BasicIndex(t *testing.T) {
 					idx.Columns[0] == "rank" &&
 					idx.Columns[1] == "lower(name)" &&
 					len(idx.Parts) == 2 &&
-					idx.Parts[0] == (ast.IndexPart{Name: "rank", Prefix: "7", Desc: true}) &&
-					idx.Parts[1] == (ast.IndexPart{Expr: "lower(name)"})
+					idx.Parts[0] == (ast.IndexPart{Name: "rank", Operator: "bpchar_ops", Prefix: "7", Desc: true}) &&
+					idx.Parts[1] == (ast.IndexPart{Expr: "lower(name)", Operator: "text_pattern_ops"})
 			},
 		},
 		{

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -398,10 +398,11 @@ func toSchemaIndexParts(parts []ast.IndexPart) []goschema.IndexPart {
 	schemaParts := make([]goschema.IndexPart, 0, len(parts))
 	for _, part := range parts {
 		schemaParts = append(schemaParts, goschema.IndexPart{
-			Name:   part.Name,
-			Expr:   part.Expr,
-			Prefix: part.Prefix,
-			Desc:   part.Desc,
+			Name:     part.Name,
+			Expr:     part.Expr,
+			Operator: part.Operator,
+			Prefix:   part.Prefix,
+			Desc:     part.Desc,
 		})
 	}
 	return schemaParts

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -506,8 +506,8 @@ func TestToIndex_BasicIndex(t *testing.T) {
 			name: "structured index parts",
 			index: ast.NewIndex("idx_users_rank_name", "users").
 				SetParts([]ast.IndexPart{
-					{Name: "rank", Prefix: "7", Desc: true},
-					{Expr: "lower(name)"},
+					{Name: "rank", Operator: "bpchar_ops", Prefix: "7", Desc: true},
+					{Expr: "lower(name)", Operator: "text_pattern_ops"},
 				}),
 			expected: func(index goschema.Index) bool {
 				return index.Name == "idx_users_rank_name" &&
@@ -516,8 +516,8 @@ func TestToIndex_BasicIndex(t *testing.T) {
 					index.Fields[0] == "rank" &&
 					index.Fields[1] == "lower(name)" &&
 					len(index.Parts) == 2 &&
-					index.Parts[0] == (goschema.IndexPart{Name: "rank", Prefix: "7", Desc: true}) &&
-					index.Parts[1] == (goschema.IndexPart{Expr: "lower(name)"})
+					index.Parts[0] == (goschema.IndexPart{Name: "rank", Operator: "bpchar_ops", Prefix: "7", Desc: true}) &&
+					index.Parts[1] == (goschema.IndexPart{Expr: "lower(name)", Operator: "text_pattern_ops"})
 			},
 		},
 		{

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -169,10 +169,11 @@ type Field struct {
 
 // IndexPart represents one column or expression inside an index definition.
 type IndexPart struct {
-	Name   string // Column name
-	Expr   string // Raw index expression
-	Prefix string // MySQL index prefix length
-	Desc   bool   // Whether this part is ordered DESC
+	Name     string // Column name
+	Expr     string // Raw index expression
+	Operator string // PostgreSQL operator class for this part
+	Prefix   string // MySQL index prefix length
+	Desc     bool   // Whether this part is ordered DESC
 }
 
 // Index represents a database index definition parsed from Go struct annotations.

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -463,7 +463,9 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	var columnSpecs []string
 	for _, part := range node.EffectiveParts() {
 		columnSpec := renderIndexPart(part)
-		if node.Operator != "" {
+		if part.Operator != "" {
+			columnSpec = fmt.Sprintf("%s %s", columnSpec, part.Operator)
+		} else if node.Operator != "" {
 			columnSpec = fmt.Sprintf("%s %s", columnSpec, node.Operator)
 		}
 		if part.Desc {

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -58,6 +58,15 @@ func TestPostgreSQLRenderer_VisitIndex_PostgreSQLFeatures(t *testing.T) {
 			expected: "CREATE INDEX idx_users_full_name ON users ((first_name || ' ' || last_name));\n",
 		},
 		{
+			name: "per-part operator classes",
+			index: ast.NewIndex("idx_users_search", "users").
+				SetParts([]ast.IndexPart{
+					{Name: "name", Operator: "bpchar_pattern_ops"},
+					{Name: "body", Operator: "tsvector_ops(siglen=8)"},
+				}),
+			expected: "CREATE INDEX idx_users_search ON users (name bpchar_pattern_ops, body tsvector_ops(siglen=8));\n",
+		},
+		{
 			name: "partial index",
 			index: &ast.IndexNode{
 				Name:      "idx_active_users",


### PR DESCRIPTION
Summary: add per-index-part PostgreSQL operator class metadata, parse Atlas HCL index on { ops = ... } blocks, preserve the metadata through schema converters, and render per-part operator classes while keeping the existing index-level Operator fallback for compatibility. Validation: targeted parser/converter/PostgreSQL renderer tests passed, go test ./... passed outside sandbox, go tool qtlint ./... passed outside sandbox, golangci-lint run --fix ./... passed with 0 issues, and golangci-lint run ./... passed with 0 issues.