### PR TITLE
Support PostgreSQL table partitioning

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -77,10 +77,28 @@ type CreateTableNode struct {
 	Constraints []*ConstraintNode
 	// Options contains dialect-specific table options like ENGINE for MySQL
 	Options map[string]string
+	// Partition stores PostgreSQL PARTITION BY metadata.
+	Partition *PartitionSpec
 	// SelectBody stores the SELECT tail for CREATE TABLE ... SELECT statements.
 	SelectBody string
 	// Comment is an optional table comment
 	Comment string
+}
+
+// PartitionSpec represents a table PARTITION BY clause.
+type PartitionSpec struct {
+	// Type is the partitioning method, such as RANGE, LIST, or HASH.
+	Type string
+	// Parts contains column references or expressions used as partition keys.
+	Parts []PartitionPart
+}
+
+// PartitionPart represents one partition key column or expression.
+type PartitionPart struct {
+	// Name is the partition key column name.
+	Name string
+	// Expr is the raw partition key expression.
+	Expr string
 }
 
 // NewCreateTable creates a new CREATE TABLE node with the specified table name.

--- a/core/atlashcl/atlashcl.go
+++ b/core/atlashcl/atlashcl.go
@@ -137,49 +137,8 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 
 	fieldsStart := len(p.db.Fields)
 	for _, nested := range block.Body.Blocks {
-		switch nested.Type {
-		case "column":
-			field, err := p.parseColumn(table.StructName, nested)
-			if err != nil {
-				return err
-			}
-			p.db.Fields = append(p.db.Fields, field)
-		case "primary_key":
-			primaryKey, err := p.parsePrimaryKey(nested)
-			if err != nil {
-				return err
-			}
-			table.PrimaryKey = primaryKey.columns
-			table.PrimaryKeyParts = primaryKey.parts
-			table.PrimaryKeyInclude = primaryKey.include
-		case "index":
-			index, err := p.parseIndex(table.StructName, table.Name, nested)
-			if err != nil {
-				return err
-			}
-			p.db.Indexes = append(p.db.Indexes, index)
-		case "unique":
-			constraint, err := p.parseUnique(table.StructName, table.Name, nested)
-			if err != nil {
-				return err
-			}
-			p.db.Constraints = append(p.db.Constraints, constraint)
-		case "foreign_key":
-			spec, err := p.parseForeignKey(nested)
-			if err != nil {
-				return err
-			}
-			if err := p.applyForeignKey(table, fieldsStart, nested, spec); err != nil {
-				return err
-			}
-		case "check":
-			constraint, err := p.parseCheck(table.StructName, table.Name, nested)
-			if err != nil {
-				return err
-			}
-			p.db.Constraints = append(p.db.Constraints, constraint)
-		default:
-			return p.blockError(nested, "unsupported table block %q", nested.Type)
+		if err := p.parseTableBlock(&table, fieldsStart, nested); err != nil {
+			return err
 		}
 	}
 	markPrimaryFields(p.db.Fields[fieldsStart:], table.PrimaryKey)
@@ -187,6 +146,63 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 		return err
 	}
 	p.db.Tables = append(p.db.Tables, table)
+	return nil
+}
+
+func (p *parser) parseTableBlock(table *goschema.Table, fieldsStart int, block *hclsyntax.Block) error {
+	switch block.Type {
+	case "column":
+		field, err := p.parseColumn(table.StructName, block)
+		if err != nil {
+			return err
+		}
+		p.db.Fields = append(p.db.Fields, field)
+	case "primary_key":
+		primaryKey, err := p.parsePrimaryKey(block)
+		if err != nil {
+			return err
+		}
+		table.PrimaryKey = primaryKey.columns
+		table.PrimaryKeyParts = primaryKey.parts
+		table.PrimaryKeyInclude = primaryKey.include
+	case "index":
+		index, err := p.parseIndex(table.StructName, table.Name, block)
+		if err != nil {
+			return err
+		}
+		p.db.Indexes = append(p.db.Indexes, index)
+	case "unique":
+		constraint, err := p.parseUnique(table.StructName, table.Name, block)
+		if err != nil {
+			return err
+		}
+		p.db.Constraints = append(p.db.Constraints, constraint)
+	case "foreign_key":
+		spec, err := p.parseForeignKey(block)
+		if err != nil {
+			return err
+		}
+		if err := p.applyForeignKey(*table, fieldsStart, block, spec); err != nil {
+			return err
+		}
+	case "check":
+		constraint, err := p.parseCheck(table.StructName, table.Name, block)
+		if err != nil {
+			return err
+		}
+		p.db.Constraints = append(p.db.Constraints, constraint)
+	case "partition":
+		partition, err := p.parsePartition(block)
+		if err != nil {
+			return err
+		}
+		if table.Partition != nil {
+			return p.blockError(block, "table %q has multiple partition blocks", table.Name)
+		}
+		table.Partition = partition
+	default:
+		return p.blockError(block, "unsupported table block %q", block.Type)
+	}
 	return nil
 }
 
@@ -514,6 +530,75 @@ func (p *parser) parsePrimaryKey(block *hclsyntax.Block) (primaryKeySpec, error)
 	return primaryKeySpec{columns: columns, parts: parts, include: include}, nil
 }
 
+func (p *parser) parsePartition(block *hclsyntax.Block) (*goschema.PartitionSpec, error) {
+	if len(block.Labels) != 0 {
+		return nil, p.blockError(block, "partition block does not accept labels")
+	}
+	if err := p.rejectUnsupportedPartitionAttrs(block); err != nil {
+		return nil, err
+	}
+	partitionType := strings.ToUpper(p.optionalString(block.Body.Attributes["type"]))
+	if partitionType == "" {
+		return nil, p.blockError(block, "partition requires type")
+	}
+	if block.Body.Attributes["columns"] != nil {
+		if len(block.Body.Blocks) > 0 {
+			return nil, p.blockError(block.Body.Blocks[0], "partition cannot mix columns attribute with by blocks")
+		}
+		columns, err := p.parseColumnsAttr(block, "columns")
+		if err != nil {
+			return nil, err
+		}
+		if len(columns) == 0 {
+			return nil, p.blockError(block, "partition requires at least one column")
+		}
+		return &goschema.PartitionSpec{Type: partitionType, Parts: partitionColumnParts(columns)}, nil
+	}
+
+	parts, err := p.parsePartitionParts(block)
+	if err != nil {
+		return nil, err
+	}
+	return &goschema.PartitionSpec{Type: partitionType, Parts: parts}, nil
+}
+
+func (p *parser) parsePartitionParts(block *hclsyntax.Block) ([]goschema.PartitionPart, error) {
+	if len(block.Body.Blocks) == 0 {
+		return nil, p.blockError(block, "partition requires columns attribute or by blocks")
+	}
+	parts := make([]goschema.PartitionPart, 0, len(block.Body.Blocks))
+	for _, nested := range block.Body.Blocks {
+		if nested.Type != "by" {
+			return nil, p.blockError(nested, "unsupported partition block %q", nested.Type)
+		}
+		if err := p.rejectUnsupportedPartitionByAttrs(nested); err != nil {
+			return nil, err
+		}
+		columnAttr := nested.Body.Attributes["column"]
+		exprAttr := nested.Body.Attributes["expr"]
+		if columnAttr == nil && exprAttr == nil {
+			return nil, p.blockError(nested, "partition by block requires column or expr")
+		}
+		if columnAttr != nil && exprAttr != nil {
+			return nil, p.blockError(nested, "partition by block cannot set both column and expr")
+		}
+		if columnAttr != nil {
+			parts = append(parts, goschema.PartitionPart{Name: p.columnNameFromExpr(columnAttr)})
+			continue
+		}
+		parts = append(parts, goschema.PartitionPart{Expr: p.exprString(exprAttr)})
+	}
+	return parts, nil
+}
+
+func partitionColumnParts(columns []string) []goschema.PartitionPart {
+	parts := make([]goschema.PartitionPart, 0, len(columns))
+	for _, column := range columns {
+		parts = append(parts, goschema.PartitionPart{Name: column})
+	}
+	return parts
+}
+
 func (p *parser) validatePrimaryKeyType(block *hclsyntax.Block) error {
 	primaryKeyType := strings.ToUpper(p.optionalString(block.Body.Attributes["type"]))
 	switch primaryKeyType {
@@ -771,6 +856,20 @@ func (p *parser) rejectUnsupportedPrimaryKeyOnAttrs(block *hclsyntax.Block) erro
 		"prefix": true,
 		"desc":   true,
 	}, "primary_key on")
+}
+
+func (p *parser) rejectUnsupportedPartitionAttrs(block *hclsyntax.Block) error {
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"type":    true,
+		"columns": true,
+	}, "partition")
+}
+
+func (p *parser) rejectUnsupportedPartitionByAttrs(block *hclsyntax.Block) error {
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"column": true,
+		"expr":   true,
+	}, "partition by")
 }
 
 func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {

--- a/core/atlashcl/atlashcl_test.go
+++ b/core/atlashcl/atlashcl_test.go
@@ -53,6 +53,64 @@ table "users" {
 	c.Assert(sql, qt.Contains, `CREATE UNIQUE INDEX`)
 }
 
+func TestParseTablePartition(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "main" {}
+
+table "metrics" {
+  schema = schema.main
+  column "x" {
+    null = false
+    type = integer
+  }
+  column "y" {
+    null = false
+    type = integer
+  }
+  partition {
+    type = RANGE
+    by {
+      column = column.x
+    }
+    by {
+      expr = "floor(y)"
+    }
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Partition, qt.DeepEquals, &goschema.PartitionSpec{
+		Type: "RANGE",
+		Parts: []goschema.PartitionPart{
+			{Name: "x"},
+			{Expr: "floor(y)"},
+		},
+	})
+
+	sql := strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n")
+	c.Assert(sql, qt.Contains, `PARTITION BY RANGE (x, (floor(y)))`)
+}
+
+func TestParseTablePartitionRequiresColumnOrBy(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "metrics" {
+  column "x" {
+    type = integer
+  }
+  partition {
+    type    = RANGE
+    columns = []
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*partition requires at least one column.*`)
+}
+
 func TestParsePostgreSQLEnumBlock(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -666,6 +666,7 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 			createTable.SetOption("STRICT", "true")
 		}
 	}
+	createTable.Partition = toASTPartition(newTable.Partition)
 
 	// Add columns for fields that belong to this table
 	tableLevelPK := tableNeedsPrimaryKeyConstraint(newTable)
@@ -686,6 +687,17 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	}
 
 	return createTable
+}
+
+func toASTPartition(partition *goschema.PartitionSpec) *ast.PartitionSpec {
+	if partition == nil {
+		return nil
+	}
+	parts := make([]ast.PartitionPart, 0, len(partition.Parts))
+	for _, part := range partition.Parts {
+		parts = append(parts, ast.PartitionPart{Name: part.Name, Expr: part.Expr})
+	}
+	return &ast.PartitionSpec{Type: partition.Type, Parts: parts}
 }
 
 func tableNeedsPrimaryKeyConstraint(table goschema.Table) bool {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -1452,6 +1452,29 @@ func TestFromTable_PlatformOverrides(t *testing.T) {
 				return table.Name == "events" && !strict && !withoutRowID
 			},
 		},
+		{
+			name: "PostgreSQL partition",
+			table: goschema.Table{
+				StructName: "Metric",
+				Name:       "metrics",
+				Partition: &goschema.PartitionSpec{
+					Type: "RANGE",
+					Parts: []goschema.PartitionPart{
+						{Name: "x"},
+						{Expr: "floor(y)"},
+					},
+				},
+			},
+			fields:         []goschema.Field{},
+			targetPlatform: "postgres",
+			expected: func(table *ast.CreateTableNode) bool {
+				return table.Partition != nil &&
+					table.Partition.Type == "RANGE" &&
+					len(table.Partition.Parts) == 2 &&
+					table.Partition.Parts[0].Name == "x" &&
+					table.Partition.Parts[1].Expr == "floor(y)"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/convert/toschema/toschema.go
+++ b/core/convert/toschema/toschema.go
@@ -247,6 +247,7 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 		StructName: generateStructName(table.Name),
 		Name:       table.Name,
 		Comment:    table.Comment,
+		Partition:  toSchemaPartition(table.Partition),
 	}
 
 	// Extract ENGINE option if present
@@ -298,6 +299,17 @@ func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table {
 	}
 
 	return tableSchema
+}
+
+func toSchemaPartition(partition *ast.PartitionSpec) *goschema.PartitionSpec {
+	if partition == nil {
+		return nil
+	}
+	parts := make([]goschema.PartitionPart, 0, len(partition.Parts))
+	for _, part := range partition.Parts {
+		parts = append(parts, goschema.PartitionPart{Name: part.Name, Expr: part.Expr})
+	}
+	return &goschema.PartitionSpec{Type: partition.Type, Parts: parts}
 }
 
 func toPrimaryKeyParts(constraint *ast.ConstraintNode) []goschema.PrimaryKeyPart {

--- a/core/convert/toschema/toschema_test.go
+++ b/core/convert/toschema/toschema_test.go
@@ -352,6 +352,28 @@ func TestToTable_BasicTable(t *testing.T) {
 					!table.WithoutRowID
 			},
 		},
+		{
+			name: "PostgreSQL partition",
+			table: func() *ast.CreateTableNode {
+				table := ast.NewCreateTable("metrics")
+				table.Partition = &ast.PartitionSpec{
+					Type: "RANGE",
+					Parts: []ast.PartitionPart{
+						{Name: "x"},
+						{Expr: "floor(y)"},
+					},
+				}
+				return table
+			}(),
+			sourcePlatform: "postgres",
+			expected: func(table goschema.Table) bool {
+				return table.Partition != nil &&
+					table.Partition.Type == "RANGE" &&
+					len(table.Partition.Parts) == 2 &&
+					table.Partition.Parts[0].Name == "x" &&
+					table.Partition.Parts[1].Expr == "floor(y)"
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -407,6 +407,7 @@ type Table struct {
 	// primary keys.
 	PrimaryKeyInclude []string
 	Checks            []string                     // Table-level check constraints
+	Partition         *PartitionSpec               // PostgreSQL table partitioning metadata
 	CustomSQL         string                       // Custom SQL to append to CREATE TABLE
 	Overrides         map[string]map[string]string // Platform-specific overrides
 }
@@ -416,6 +417,18 @@ type PrimaryKeyPart struct {
 	Name   string // Column name
 	Prefix string // MySQL index prefix length
 	Desc   bool   // Whether the column is ordered DESC
+}
+
+// PartitionSpec represents PostgreSQL table partitioning metadata.
+type PartitionSpec struct {
+	Type  string          // Partitioning method, such as RANGE, LIST, or HASH
+	Parts []PartitionPart // Partition key columns or expressions
+}
+
+// PartitionPart represents one partition key column or expression.
+type PartitionPart struct {
+	Name string // Column name
+	Expr string // Raw partition expression
 }
 
 // QualifiedName returns the schema-qualified database table name when a schema

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -1361,16 +1361,166 @@ func (p *Parser) parseCreateTableElements(table *ast.CreateTableNode) error {
 }
 
 func (p *Parser) parseCreateTableSuffix(table *ast.CreateTableNode) error {
-	// Parse optional table options (ENGINE, etc.)
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("PARTITION") {
+		if err := p.parsePostgreSQLPartitionClause(table); err != nil {
+			return err
+		}
+	}
+	// Parse optional table options (ENGINE, WITH, TABLESPACE, etc.)
 	if err := p.parseTableOptions(table); err != nil {
 		return err
 	}
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("PARTITION") {
+		if err := p.parsePostgreSQLPartitionClause(table); err != nil {
+			return err
+		}
+	}
+	p.skipWhitespace()
 	if p.current.MatchIdentifierValue("AS") || p.current.MatchIdentifierValue("SELECT") {
 		if err := p.parseCreateTableSelectBody(table); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (p *Parser) parsePostgreSQLPartitionClause(table *ast.CreateTableNode) error {
+	if table.Partition != nil {
+		return fmt.Errorf("duplicate PARTITION BY clause at position %d", p.current.Start)
+	}
+	if err := p.expect(lexer.TokenIdentifier, "PARTITION"); err != nil {
+		return err
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "BY"); err != nil {
+		return fmt.Errorf("expected BY after PARTITION: %w", err)
+	}
+	p.skipWhitespace()
+	partitionType, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected partition type: %w", err)
+	}
+	p.skipWhitespace()
+	body, err := p.collectParenthesizedBody("partition key")
+	if err != nil {
+		return err
+	}
+	parts, err := parsePartitionPartsSQL(body)
+	if err != nil {
+		return err
+	}
+	table.Partition = &ast.PartitionSpec{Type: strings.ToUpper(partitionType), Parts: parts}
+	return nil
+}
+
+func parsePartitionPartsSQL(body string) ([]ast.PartitionPart, error) {
+	items, err := splitTopLevelComma(body)
+	if err != nil {
+		return nil, err
+	}
+	parts := make([]ast.PartitionPart, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return nil, fmt.Errorf("empty partition key")
+		}
+		if isBarePartitionColumn(item) {
+			parts = append(parts, ast.PartitionPart{Name: item})
+			continue
+		}
+		if unwrapped, ok := stripEnclosingParens(item); ok {
+			item = unwrapped
+		}
+		parts = append(parts, ast.PartitionPart{Expr: item})
+	}
+	return parts, nil
+}
+
+func stripEnclosingParens(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "(") || !strings.HasSuffix(value, ")") {
+		return "", false
+	}
+	depth := 0
+	for i, r := range value {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(value)-1 {
+				return "", false
+			}
+		}
+		if depth < 0 {
+			return "", false
+		}
+	}
+	if depth != 0 {
+		return "", false
+	}
+	return strings.TrimSpace(value[1 : len(value)-1]), true
+}
+
+func isBarePartitionColumn(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+		return !strings.Contains(value[1:len(value)-1], `"`)
+	}
+	for i, r := range value {
+		if r == '_' || r == '$' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func splitTopLevelComma(body string) ([]string, error) {
+	var items []string
+	start := 0
+	depth := 0
+	var quote rune
+	for pos, r := range body {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"':
+			quote = r
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, fmt.Errorf("unbalanced partition expression")
+			}
+		case ',':
+			if depth == 0 {
+				items = append(items, body[start:pos])
+				start = pos + len(string(r))
+			}
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quoted partition expression")
+	}
+	if depth != 0 {
+		return nil, fmt.Errorf("unbalanced partition expression")
+	}
+	items = append(items, body[start:])
+	return items, nil
 }
 
 func (p *Parser) parseCreateTableSelectBody(table *ast.CreateTableNode) error {
@@ -3056,7 +3206,7 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 
 		var err error
 		option := strings.ToUpper(p.current.Value)
-		if option == "AS" || option == "SELECT" || option == "GO" {
+		if isCreateTableOptionBoundary(option) {
 			return nil
 		}
 		switch option {
@@ -3097,6 +3247,15 @@ func (p *Parser) parseTableOptions(table *ast.CreateTableNode) error {
 	}
 
 	return nil
+}
+
+func isCreateTableOptionBoundary(option string) bool {
+	switch option {
+	case "AS", "SELECT", "GO", "PARTITION":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *Parser) handleSQLiteWithoutRowID(table *ast.CreateTableNode) error {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -66,6 +66,37 @@ func TestParser_ParseCreateTable_ColumnCharsetCollate(t *testing.T) {
 	c.Assert(createTable.Columns[0].Nullable, qt.IsFalse)
 }
 
+func TestParser_ParseCreateTable_PostgreSQLPartitionBy(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE metrics (x integer NOT NULL, y integer NOT NULL) PARTITION BY RANGE (x, (floor(y)), (y * 2));`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	createTable, ok := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Partition, qt.DeepEquals, &ast.PartitionSpec{
+		Type: "RANGE",
+		Parts: []ast.PartitionPart{
+			{Name: "x"},
+			{Expr: "floor(y)"},
+			{Expr: "y * 2"},
+		},
+	})
+}
+
+func TestParser_ParseCreateTable_RejectsDuplicatePartitionBy(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE metrics (x integer NOT NULL) PARTITION BY RANGE (x) PARTITION BY LIST (x);`
+	p := parser.NewParser(sql)
+
+	_, err := p.Parse()
+	c.Assert(err, qt.ErrorMatches, `.*duplicate PARTITION BY clause.*`)
+}
+
 func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -266,10 +266,22 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 
 	r.w.Write(")")
 
+	if node.Partition != nil {
+		partition, err := r.renderPartition(node.Partition)
+		if err != nil {
+			return err
+		}
+		r.w.Write(" ")
+		r.w.Write(partition)
+	}
+
 	// Table options (PostgreSQL-specific filtering applied)
 	if len(node.Options) > 0 {
-		r.w.Write(" ")
-		r.w.Write(r.renderTableOptions(node.Options))
+		options := r.renderTableOptions(node.Options)
+		if options != "" {
+			r.w.Write(" ")
+			r.w.Write(options)
+		}
 	}
 
 	r.w.WriteLine(";")
@@ -311,6 +323,38 @@ func (r *Renderer) renderCreateTableLines(node *ast.CreateTableNode) ([]string, 
 	}
 
 	return r.appendColumnForeignKeyLines(lines, node.Columns)
+}
+
+func (r *Renderer) renderPartition(partition *ast.PartitionSpec) (string, error) {
+	partitionType := strings.ToUpper(strings.TrimSpace(partition.Type))
+	if partitionType == "" {
+		return "", fmt.Errorf("postgres partition requires type")
+	}
+	if len(partition.Parts) == 0 {
+		return "", fmt.Errorf("postgres partition requires at least one key")
+	}
+	parts := make([]string, 0, len(partition.Parts))
+	for _, part := range partition.Parts {
+		switch {
+		case part.Name != "" && part.Expr != "":
+			return "", fmt.Errorf("postgres partition key cannot set both column and expression")
+		case part.Name != "":
+			parts = append(parts, part.Name)
+		case part.Expr != "":
+			parts = append(parts, renderPartitionExpression(part.Expr))
+		default:
+			return "", fmt.Errorf("postgres partition key cannot be empty")
+		}
+	}
+	return fmt.Sprintf("PARTITION BY %s (%s)", partitionType, strings.Join(parts, ", ")), nil
+}
+
+func renderPartitionExpression(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if strings.HasPrefix(expr, "(") && strings.HasSuffix(expr, ")") {
+		return expr
+	}
+	return "(" + expr + ")"
 }
 
 func (r *Renderer) appendColumnForeignKeyLines(lines []string, columns []*ast.ColumnNode) ([]string, error) {

--- a/core/renderer/dialects/postgres/postgresql_features_test.go
+++ b/core/renderer/dialects/postgres/postgresql_features_test.go
@@ -810,6 +810,35 @@ CREATE TABLE user_sessions (
 	c.Assert(result, qt.Equals, expected)
 }
 
+func TestPostgreSQLRenderer_TablePartition(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("metrics").
+		AddColumn(ast.NewColumn("x", "integer").SetNotNull()).
+		AddColumn(ast.NewColumn("y", "integer").SetNotNull())
+	table.Partition = &ast.PartitionSpec{
+		Type: "RANGE",
+		Parts: []ast.PartitionPart{
+			{Name: "x"},
+			{Expr: "floor(y)"},
+			{Expr: "y * 2"},
+		},
+	}
+
+	renderer := postgres.New()
+	result, err := renderer.Render(table)
+
+	c.Assert(err, qt.IsNil)
+	expected := `-- POSTGRES TABLE: metrics --
+CREATE TABLE metrics (
+  x integer NOT NULL,
+  y integer NOT NULL
+) PARTITION BY RANGE (x, (floor(y)), (y * 2));
+
+`
+	c.Assert(result, qt.Equals, expected)
+}
+
 func TestPostgreSQLRenderer_ExcludeConstraint_Errors(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/integration/gonative/postgres_partition_integration_test.go
+++ b/integration/gonative/postgres_partition_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestPostgreSQLPartitionedTableExecuteIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupPostgreSQLPartitionedTable(t, db)
+	defer cleanupPostgreSQLPartitionedTable(t, db)
+
+	table := ast.NewCreateTable("ptah_partition_metrics").
+		AddColumn(ast.NewColumn("x", "integer").SetNotNull()).
+		AddColumn(ast.NewColumn("y", "integer").SetNotNull())
+	table.Partition = &ast.PartitionSpec{
+		Type: "RANGE",
+		Parts: []ast.PartitionPart{
+			{Name: "x"},
+			{Expr: "y * 2"},
+		},
+	}
+
+	sqlText, err := renderer.RenderSQL("postgres", table)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlText, qt.Contains, "PARTITION BY RANGE (x, (y * 2))")
+
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", stmt))
+	}
+
+	var relkind, partitionKey string
+	err = db.QueryRow(`
+SELECT c.relkind, pg_get_partkeydef(c.oid)
+FROM pg_class c
+WHERE c.relname = 'ptah_partition_metrics'
+`).Scan(&relkind, &partitionKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(relkind, qt.Equals, "p")
+	c.Assert(partitionKey, qt.Contains, "RANGE")
+	c.Assert(partitionKey, qt.Contains, "x")
+	c.Assert(strings.ReplaceAll(partitionKey, " ", ""), qt.Contains, "y*2")
+}
+
+func cleanupPostgreSQLPartitionedTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_partition_metrics CASCADE")
+}


### PR DESCRIPTION
## Summary
- add first-class table partition metadata to Ptah AST and goschema models
- parse Atlas HCL partition blocks with column and expression partition keys
- parse and render PostgreSQL PARTITION BY clauses for CREATE TABLE
- add focused converter/parser/renderer/HCL tests plus a live PostgreSQL integration test

## Validation
- go test ./core/atlashcl ./core/parser ./core/renderer/dialects/postgres ./core/convert/fromschema ./core/convert/toschema -count=1
- go test ./...
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test -tags integration ./integration/gonative -run TestPostgreSQLPartitionedTableExecuteIntegration -count=1 -v

## Conformance note
A temporary local ptah-atlas-conformance dry-run with this branch moves postgres/table-partition.txtar past the initial unsupported apply path. The remaining dry-run failures are harness-side partition show/HCL/execsql modeling and will be addressed in the companion conformance PR after this lands.