### PR TITLE
Secure online-DDL credential handling

### DIFF
--- a/docs/online-ddl.md
+++ b/docs/online-ddl.md
@@ -66,15 +66,23 @@ For `ALTER TABLE <tbl> <clause>` with database URL
 
 ```text
 gh-ost --host=host --port=port --user=user --database=db --table=tbl \
-       --alter="<clause>" [--password=pass] [args...] --execute
+       --alter="<clause>" [--conf=/tmp/ptah-online-ddl-*.cnf] [args...] --execute
 
 pt-online-schema-change --alter "<clause>" [args...] --execute \
-       h=host,P=port,u=user,D=db,t=tbl,p=pass
+       h=host,P=port,u=user,D=db,t=tbl[,F=/tmp/ptah-online-ddl-*.cnf]
 ```
 
 A schema-qualified table (`ALTER TABLE shop.users ...`) overrides the
 database from the URL. The alter clause is passed through verbatim, so
 multi-part alters (`ADD COLUMN a INT, ADD INDEX idx (a)`) work.
+
+If the database URL contains a password, ptah writes a temporary MySQL
+defaults file with mode `0600`, passes only that file path to the tool, and
+removes it after the tool exits, fails, or is canceled. The password is never
+passed as a command-line argument. User-supplied credential configuration wins: when
+`online_ddl.args` already includes gh-ost `--conf`, pt-osc `--defaults-file`,
+or pt-osc DSN credentials (`p=` or `F=`), ptah does not generate its own
+credential file.
 
 ## Prerequisites you must provide
 
@@ -94,10 +102,10 @@ enabling:
 - **Privileges**: both tools need more than plain ALTER — gh-ost needs
   REPLICATION SLAVE/CLIENT plus DDL/DML on the schema; pt-osc needs
   CREATE/DROP/TRIGGER.
-- **Credentials on the command line** are visible in the process list. For
-  shared hosts prefer the tools' own config mechanisms (gh-ost `--conf`,
-  pt-osc `/etc/percona-toolkit/`), passing them via `online_ddl.args`, and a
-  database URL without an inline password.
+- **Credentials**: ptah never passes the database password on the command
+  line. For shared hosts you can still provide your own credential file via
+  `online_ddl.args` (`--conf` for gh-ost, `--defaults-file` or `F=` for
+  pt-osc); in that case ptah will not generate one.
 
 ## Interaction with migration transactions
 

--- a/migration/onlineddl/executor.go
+++ b/migration/onlineddl/executor.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/stokaro/ptah/dbschema"
@@ -36,6 +37,11 @@ type Conn interface {
 
 // CommandRunner executes an external tool invocation.
 type CommandRunner func(ctx context.Context, binary string, args []string) error
+
+type toolInvocation struct {
+	args    []string
+	cleanup func() error
+}
 
 // Executor routes ALTER TABLE migration statements through an online-DDL
 // tool. It implements migrator.StatementInterceptor.
@@ -146,18 +152,29 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 		dsn.Database = target.Schema
 	}
 
-	args, err := buildArgs(tool, dsn, target, e.cfg.Args)
-	if err != nil {
-		return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
-	}
 	if e.dryRun {
+		if err := validateToolInvocation(tool, dsn, target); err != nil {
+			return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
+		}
 		e.logger.Info("DRY RUN: would run online-DDL tool",
 			"tool", binary, "table", target.Table, "alter", target.Clause)
 		return true, nil
 	}
 
+	invocation, err := buildArgs(tool, dsn, target, e.cfg.Args)
+	if err != nil {
+		return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
+	}
+	if invocation.cleanup != nil {
+		defer func() {
+			if err := invocation.cleanup(); err != nil {
+				e.logger.Warn("failed to remove online-DDL credential file",
+					"tool", binary, "table", target.Table, "error", err)
+			}
+		}()
+	}
 	e.logger.Info("Running online-DDL tool", "tool", binary, "table", target.Table, "alter", target.Clause)
-	if err := e.run(ctx, binary, args); err != nil {
+	if err := e.run(ctx, binary, invocation.args); err != nil {
 		return false, fmt.Errorf("online-DDL tool %s failed for table %s: %w", binary, target.Table, err)
 	}
 	e.logger.Info("Online-DDL tool finished", "tool", binary, "table", target.Table)
@@ -205,53 +222,188 @@ func binaryFor(tool string) string {
 
 // buildArgs assembles the tool invocation. User-configured args go before
 // the final --execute so they can never be overridden by it.
-func buildArgs(tool string, dsn DSN, target AlterTarget, extra []string) ([]string, error) {
+func buildArgs(tool string, dsn DSN, target AlterTarget, extra []string) (toolInvocation, error) {
 	switch tool {
 	case ToolPTOSC:
 		return buildPTOSCArgs(dsn, target, extra)
 	default: // ToolGhost
-		// gh-ost takes each endpoint as its own --flag=value argv element, so
-		// values are passed literally with no delimiter to escape.
-		args := []string{
-			"--host=" + dsn.Host,
-			"--port=" + dsn.Port,
-			"--user=" + dsn.User,
-			"--database=" + dsn.Database,
-			"--table=" + target.Table,
-			"--alter=" + target.Clause,
-		}
-		if dsn.Password != "" {
-			args = append(args, "--password="+dsn.Password)
-		}
-		args = append(args, extra...)
-		return append(args, "--execute"), nil
+		return buildGhostArgs(dsn, target, extra)
 	}
 }
 
+func buildGhostArgs(dsn DSN, target AlterTarget, extra []string) (toolInvocation, error) {
+	// gh-ost takes each endpoint as its own --flag=value argv element, so
+	// values are passed literally with no delimiter to escape.
+	args := []string{
+		"--host=" + dsn.Host,
+		"--port=" + dsn.Port,
+		"--user=" + dsn.User,
+		"--database=" + dsn.Database,
+		"--table=" + target.Table,
+		"--alter=" + target.Clause,
+	}
+	cleanup, err := maybeAppendGhostCredential(&args, dsn, extra)
+	if err != nil {
+		return toolInvocation{}, err
+	}
+	args = append(args, extra...)
+	return toolInvocation{args: append(args, "--execute"), cleanup: cleanup}, nil
+}
+
+func maybeAppendGhostCredential(args *[]string, dsn DSN, extra []string) (func() error, error) {
+	if dsn.Password == "" || ghostArgsCarryCredentials(extra) {
+		return nil, nil
+	}
+	path, cleanup, err := createMySQLDefaultsFile(dsn)
+	if err != nil {
+		return nil, err
+	}
+	*args = append(*args, "--conf="+path)
+	return cleanup, nil
+}
+
 // buildPTOSCArgs assembles the pt-online-schema-change invocation. Its DSN is
-// a single comma-delimited argv element (h=,P=,u=,D=,t=[,p=]) that Percona's
+// a single comma-delimited argv element (h=,P=,u=,D=,t=[,F=]) that Percona's
 // DSN parser splits on literal commas with no un-escaping, so a comma in any
 // endpoint would silently smuggle extra DSN keys (host redirect, F= defaults
 // file). Rather than emit a corrupt or injectable DSN, refuse to build it.
-func buildPTOSCArgs(dsn DSN, target AlterTarget, extra []string) ([]string, error) {
-	fields := map[string]string{
-		"host": dsn.Host, "port": dsn.Port, "user": dsn.User,
-		"database": dsn.Database, "table": target.Table, "password": dsn.Password,
-	}
-	for name, value := range fields {
-		if strings.Contains(value, ",") {
-			return nil, fmt.Errorf("pt-online-schema-change cannot receive a %s containing a comma (%q); "+
-				"pass it via online_ddl.args (for example a --defaults-file) instead", name, value)
-		}
+func buildPTOSCArgs(dsn DSN, target AlterTarget, extra []string) (toolInvocation, error) {
+	if err := validatePTOSCFields(dsn, target); err != nil {
+		return toolInvocation{}, err
 	}
 
 	spec := fmt.Sprintf("h=%s,P=%s,u=%s,D=%s,t=%s", dsn.Host, dsn.Port, dsn.User, dsn.Database, target.Table)
-	if dsn.Password != "" {
-		spec += ",p=" + dsn.Password
+	cleanup, err := maybeAppendPTOSCCredential(&spec, dsn, extra)
+	if err != nil {
+		return toolInvocation{}, err
 	}
 	args := []string{"--alter", target.Clause}
 	args = append(args, extra...)
-	return append(args, "--execute", spec), nil
+	return toolInvocation{args: append(args, "--execute", spec), cleanup: cleanup}, nil
+}
+
+func validateToolInvocation(tool string, dsn DSN, target AlterTarget) error {
+	if tool != ToolPTOSC {
+		return nil
+	}
+	return validatePTOSCFields(dsn, target)
+}
+
+func validatePTOSCFields(dsn DSN, target AlterTarget) error {
+	fields := map[string]string{
+		"host": dsn.Host, "port": dsn.Port, "user": dsn.User,
+		"database": dsn.Database, "table": target.Table,
+	}
+	for name, value := range fields {
+		if strings.Contains(value, ",") {
+			return fmt.Errorf("pt-online-schema-change cannot receive a %s containing a comma (%q); "+
+				"pass it via online_ddl.args (for example a --defaults-file) instead", name, value)
+		}
+	}
+	return nil
+}
+
+func maybeAppendPTOSCCredential(spec *string, dsn DSN, extra []string) (func() error, error) {
+	if dsn.Password == "" || ptoscArgsCarryCredentials(extra) {
+		return nil, nil
+	}
+	path, cleanup, err := createMySQLDefaultsFile(dsn)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(path, ",") {
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			return nil, fmt.Errorf("online-DDL credential file path contains a comma and cleanup failed: %w", cleanupErr)
+		}
+		return nil, fmt.Errorf("online-DDL credential file path contains a comma; set online_ddl.args with --defaults-file instead")
+	}
+	*spec += ",F=" + path
+	return cleanup, nil
+}
+
+func ghostArgsCarryCredentials(args []string) bool {
+	return hasFlagArg(args, "--conf") || hasFlagArg(args, "--password")
+}
+
+func ptoscArgsCarryCredentials(args []string) bool {
+	if hasFlagArg(args, "--defaults-file") || hasFlagArg(args, "--defaults-extra-file") {
+		return true
+	}
+	for _, arg := range args {
+		if dsnArgContainsKey(arg, "p") || dsnArgContainsKey(arg, "F") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlagArg(args []string, flag string) bool {
+	for _, arg := range args {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func dsnArgContainsKey(arg, key string) bool {
+	for part := range strings.SplitSeq(arg, ",") {
+		name, _, ok := strings.Cut(part, "=")
+		if ok && name == key {
+			return true
+		}
+	}
+	return false
+}
+
+func createMySQLDefaultsFile(dsn DSN) (string, func() error, error) {
+	content, err := mysqlDefaultsFileContent(dsn)
+	if err != nil {
+		return "", nil, err
+	}
+	file, err := os.CreateTemp("", "ptah-online-ddl-*.cnf")
+	if err != nil {
+		return "", nil, fmt.Errorf("create online-DDL credential file: %w", err)
+	}
+	path := file.Name()
+	cleanup := func() error {
+		return os.Remove(path)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = file.Close()
+		_ = cleanup()
+		return "", nil, fmt.Errorf("secure online-DDL credential file %s: %w", filepath.Base(path), err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		_ = cleanup()
+		return "", nil, fmt.Errorf("write online-DDL credential file %s: %w", filepath.Base(path), err)
+	}
+	if err := file.Close(); err != nil {
+		_ = cleanup()
+		return "", nil, fmt.Errorf("close online-DDL credential file %s: %w", filepath.Base(path), err)
+	}
+	return path, cleanup, nil
+}
+
+func mysqlDefaultsFileContent(dsn DSN) (string, error) {
+	user, err := mysqlOptionValue(dsn.User)
+	if err != nil {
+		return "", fmt.Errorf("invalid MySQL user for online-DDL credential file: %w", err)
+	}
+	password, err := mysqlOptionValue(dsn.Password)
+	if err != nil {
+		return "", fmt.Errorf("invalid MySQL password for online-DDL credential file: %w", err)
+	}
+	return "[client]\nuser=" + user + "\npassword=" + password + "\n", nil
+}
+
+func mysqlOptionValue(value string) (string, error) {
+	if strings.ContainsAny(value, "\x00\r\n") {
+		return "", fmt.Errorf("value contains a control character")
+	}
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
+	return `"` + escaped + `"`, nil
 }
 
 // runCommand is the production CommandRunner: it streams the tool's output

--- a/migration/onlineddl/executor_test.go
+++ b/migration/onlineddl/executor_test.go
@@ -60,6 +60,55 @@ func testExecutor(cfg Config, ran *[]invocation, lookPathErr error, rows int64, 
 	return e
 }
 
+func assertNoArgContains(t *testing.T, args []string, needle string) {
+	t.Helper()
+	for _, arg := range args {
+		if strings.Contains(arg, needle) {
+			t.Fatalf("argv leaked %q in %#v", needle, args)
+		}
+	}
+}
+
+func requireArgPrefix(t *testing.T, args []string, prefix string) string {
+	t.Helper()
+	for _, arg := range args {
+		if value, ok := strings.CutPrefix(arg, prefix); ok {
+			return value
+		}
+	}
+	t.Fatalf("argv missing prefix %q: %#v", prefix, args)
+	return ""
+}
+
+func requireCredentialFileRemoved(t *testing.T, path string) {
+	t.Helper()
+	//nolint:gosec // test helper verifies cleanup of a path created by the code under test
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("credential file %s still exists or stat failed unexpectedly: %v", path, err)
+	}
+}
+
+func requirePTOSCSpec(t *testing.T, args []string) string {
+	t.Helper()
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "h=") {
+			return arg
+		}
+	}
+	t.Fatalf("pt-osc argv missing DSN spec: %#v", args)
+	return ""
+}
+
+func ptoscDSNValue(spec, key string) (string, bool) {
+	for part := range strings.SplitSeq(spec, ",") {
+		name, value, ok := strings.Cut(part, "=")
+		if ok && name == key {
+			return value, true
+		}
+	}
+	return "", false
+}
+
 func TestExecuteStatement_DirectiveRoutesThroughGhost(t *testing.T) {
 	c := qt.New(t)
 
@@ -74,16 +123,18 @@ func TestExecuteStatement_DirectiveRoutesThroughGhost(t *testing.T) {
 	c.Assert(handled, qt.IsTrue)
 	c.Assert(ran, qt.HasLen, 1)
 	c.Assert(ran[0].binary, qt.Equals, "gh-ost")
-	c.Assert(ran[0].args, qt.DeepEquals, []string{
+	c.Assert(ran[0].args[:6], qt.DeepEquals, []string{
 		"--host=db.internal",
 		"--port=3307",
 		"--user=app",
 		"--database=shop",
 		"--table=users",
 		"--alter=ADD COLUMN bio TEXT",
-		"--password=secret",
-		"--execute",
 	})
+	confPath := requireArgPrefix(t, ran[0].args, "--conf=")
+	assertNoArgContains(t, ran[0].args, "secret")
+	requireCredentialFileRemoved(t, confPath)
+	c.Assert(ran[0].args[len(ran[0].args)-1], qt.Equals, "--execute")
 }
 
 func TestExecuteStatement_GhostAppendsConfigArgsBeforeExecute(t *testing.T) {
@@ -98,18 +149,38 @@ func TestExecuteStatement_GhostAppendsConfigArgsBeforeExecute(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(handled, qt.IsTrue)
-	c.Assert(ran[0].args, qt.DeepEquals, []string{
+	c.Assert(ran[0].args[:6], qt.DeepEquals, []string{
 		"--host=db.internal",
 		"--port=3307",
 		"--user=app",
 		"--database=shop",
 		"--table=users",
 		"--alter=ADD COLUMN bio TEXT",
-		"--password=secret",
+	})
+	requireArgPrefix(t, ran[0].args, "--conf=")
+	assertNoArgContains(t, ran[0].args, "secret")
+	c.Assert(ran[0].args[len(ran[0].args)-3:], qt.DeepEquals, []string{
 		"--allow-on-master",
 		"--max-load=Threads_running=25",
 		"--execute",
 	})
+}
+
+func TestExecuteStatement_UserGhostConfSuppressesGeneratedCredential(t *testing.T) {
+	c := qt.New(t)
+
+	var ran []invocation
+	e := testExecutor(Config{Args: []string{"--conf=/etc/gh-ost.cnf"}}, &ran, nil, 0, nil)
+
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+	c.Assert(ran[0].args, qt.Contains, "--conf=/etc/gh-ost.cnf")
+	assertNoArgContains(t, ran[0].args, "secret")
 }
 
 func TestExecuteStatement_DirectiveWinsOverThreshold(t *testing.T) {
@@ -151,19 +222,62 @@ func TestExecuteStatement_PTOSCRejectsCommaInIdentifier(t *testing.T) {
 	c.Assert(ran, qt.HasLen, 0)
 }
 
-func TestExecuteStatement_PTOSCRejectsCommaInPassword(t *testing.T) {
+func TestExecuteStatement_PTOSCAcceptsCommaInPasswordWithoutArgvLeak(t *testing.T) {
 	c := qt.New(t)
 
 	var ran []invocation
 	e := testExecutor(Config{}, &ran, nil, 0, nil)
 	conn := fakeConn{info: types.DBInfo{Dialect: "mysql", URL: "mysql://app:se,cret@db:3306/shop"}}
 
-	_, err := e.executeStatement(context.Background(), conn,
+	handled, err := e.executeStatement(context.Background(), conn,
 		"ALTER TABLE users ADD COLUMN a INT",
 		map[string]string{DirectiveTool: ToolPTOSC})
 
-	c.Assert(err, qt.ErrorMatches, ".*cannot receive a password containing a comma.*")
-	c.Assert(ran, qt.HasLen, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+	c.Assert(ran, qt.HasLen, 1)
+	spec := requirePTOSCSpec(t, ran[0].args)
+	assertNoArgContains(t, ran[0].args, "se,cret")
+	_, hasPassword := ptoscDSNValue(spec, "p")
+	c.Assert(hasPassword, qt.IsFalse)
+	defaultsFile, ok := ptoscDSNValue(spec, "F")
+	c.Assert(ok, qt.IsTrue)
+	requireCredentialFileRemoved(t, defaultsFile)
+}
+
+func TestExecuteStatement_UserPTOSCCredentialsSuppressGeneratedCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "defaults-file", args: []string{"--defaults-file=/etc/my.cnf"}},
+		{name: "dsn-password-key", args: []string{"h=ignored,p=user-secret"}},
+		{name: "dsn-defaults-file-key", args: []string{"h=ignored,F=/etc/my.cnf"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var ran []invocation
+			e := testExecutor(Config{Args: tt.args}, &ran, nil, 0, nil)
+			//nolint:gosec // fixture URL with a made-up password, not a credential
+			conn := fakeConn{info: types.DBInfo{Dialect: "mysql", URL: "mysql://app:ptah-password@db:3306/shop"}}
+
+			handled, err := e.executeStatement(context.Background(), conn,
+				"ALTER TABLE users ADD COLUMN a INT",
+				map[string]string{DirectiveTool: ToolPTOSC})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(handled, qt.IsTrue)
+			c.Assert(ran, qt.HasLen, 1)
+			spec := ran[0].args[len(ran[0].args)-1]
+			c.Assert(spec, qt.Contains, "h=db,P=3306,u=app,D=shop,t=users")
+			assertNoArgContains(t, ran[0].args, "ptah-password")
+			_, hasPassword := ptoscDSNValue(spec, "p")
+			c.Assert(hasPassword, qt.IsFalse)
+			_, hasDefaultsFile := ptoscDSNValue(spec, "F")
+			c.Assert(hasDefaultsFile, qt.IsFalse)
+		})
+	}
 }
 
 func TestValidateDirectives(t *testing.T) {
@@ -218,11 +332,18 @@ func TestExecuteStatement_DirectiveRoutesThroughPTOSC(t *testing.T) {
 	c.Assert(handled, qt.IsTrue)
 	c.Assert(ran, qt.HasLen, 1)
 	c.Assert(ran[0].binary, qt.Equals, "pt-online-schema-change")
-	c.Assert(ran[0].args, qt.DeepEquals, []string{
+	c.Assert(ran[0].args[:3], qt.DeepEquals, []string{
 		"--alter", "MODIFY COLUMN bio VARCHAR(500)",
 		"--max-lag=5",
-		"--execute", "h=db.internal,P=3307,u=app,D=shop,t=users,p=secret",
 	})
+	c.Assert(ran[0].args[3], qt.Equals, "--execute")
+	spec := ran[0].args[4]
+	c.Assert(spec, qt.Contains, "h=db.internal,P=3307,u=app,D=shop,t=users")
+	c.Assert(spec, qt.Not(qt.Contains), ",p=secret")
+	defaultsFile, ok := ptoscDSNValue(spec, "F")
+	c.Assert(ok, qt.IsTrue)
+	assertNoArgContains(t, ran[0].args, "secret")
+	requireCredentialFileRemoved(t, defaultsFile)
 }
 
 func TestExecuteStatement_DirectiveNoneOptsOutOfAutoRouting(t *testing.T) {
@@ -355,10 +476,59 @@ func TestExecuteStatement_ToolFailureAbortsMigration(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "online-DDL tool gh-ost failed for table users: exit status 1")
 }
 
+func TestExecuteStatement_CredentialFileIs0600AndCleanedAfterToolFailure(t *testing.T) {
+	c := qt.New(t)
+
+	var credentialFile string
+	e := New(Config{})
+	e.lookPath = func(string) (string, error) { return "/bin/gh-ost", nil }
+	e.run = func(_ context.Context, _ string, args []string) error {
+		credentialFile = requireArgPrefix(t, args, "--conf=")
+		info, err := os.Stat(credentialFile)
+		c.Assert(err, qt.IsNil)
+		c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o600))
+		content, err := os.ReadFile(credentialFile)
+		c.Assert(err, qt.IsNil)
+		c.Assert(string(content), qt.Contains, `user="app"`)
+		c.Assert(string(content), qt.Contains, `password="secret"`)
+		return errors.New("exit status 1")
+	}
+
+	_, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.ErrorMatches, "online-DDL tool gh-ost failed for table users: exit status 1")
+	requireCredentialFileRemoved(t, credentialFile)
+}
+
+func TestExecuteStatement_CredentialFileCleanedAfterCancellation(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var credentialFile string
+	e := New(Config{})
+	e.lookPath = func(string) (string, error) { return "/bin/gh-ost", nil }
+	e.run = func(ctx context.Context, _ string, args []string) error {
+		credentialFile = requireArgPrefix(t, args, "--conf=")
+		cancel()
+		return ctx.Err()
+	}
+
+	_, err := e.executeStatement(ctx, mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolGhost})
+
+	c.Assert(err, qt.ErrorMatches, "online-DDL tool gh-ost failed for table users: context canceled")
+	requireCredentialFileRemoved(t, credentialFile)
+}
+
 func TestExecuteStatement_DryRunHandlesWithoutRunning(t *testing.T) {
 	c := qt.New(t)
 
 	var ran []invocation
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
 	e := testExecutor(Config{}, &ran, nil, 0, nil).WithDryRun(true)
 
 	handled, err := e.executeStatement(context.Background(), mysqlConn(),
@@ -368,6 +538,25 @@ func TestExecuteStatement_DryRunHandlesWithoutRunning(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(handled, qt.IsTrue, qt.Commentf("dry-run must not fall through to the writer either"))
 	c.Assert(ran, qt.HasLen, 0)
+	entries, err := os.ReadDir(tmpDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0, qt.Commentf("dry-run must not materialize credential files"))
+}
+
+func TestMySQLDefaultsFileContent(t *testing.T) {
+	c := qt.New(t)
+
+	//nolint:gosec // fixture password exercises escaping, not a credential
+	content, err := mysqlDefaultsFileContent(DSN{User: `app"user`, Password: `sec\ret"`})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(content, qt.Equals, `[client]
+user="app\"user"
+password="sec\\ret\""
+`)
+
+	_, err = mysqlDefaultsFileContent(DSN{User: "app", Password: "sec\nret"})
+	c.Assert(err, qt.ErrorMatches, "invalid MySQL password for online-DDL credential file: value contains a control character")
 }
 
 func TestExecuteStatement_EmptyPasswordOmitsPasswordArg(t *testing.T) {
@@ -385,6 +574,7 @@ func TestExecuteStatement_EmptyPasswordOmitsPasswordArg(t *testing.T) {
 	c.Assert(handled, qt.IsTrue)
 	for _, arg := range ran[0].args {
 		c.Assert(strings.HasPrefix(arg, "--password"), qt.IsFalse)
+		c.Assert(strings.HasPrefix(arg, "--conf"), qt.IsFalse)
 	}
 }
 
@@ -412,6 +602,49 @@ func TestExecuteStatement_RunsRealFakeBinary(t *testing.T) {
 
 	recorded, err := os.ReadFile(argsFile)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(recorded), qt.Equals,
-		"--host=db.internal\n--port=3307\n--user=app\n--database=shop\n--table=users\n--alter=ADD COLUMN bio TEXT\n--password=secret\n--execute\n")
+	recordedArgs := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+	c.Assert(recordedArgs[:6], qt.DeepEquals, []string{
+		"--host=db.internal",
+		"--port=3307",
+		"--user=app",
+		"--database=shop",
+		"--table=users",
+		"--alter=ADD COLUMN bio TEXT",
+	})
+	confPath := requireArgPrefix(t, recordedArgs, "--conf=")
+	assertNoArgContains(t, recordedArgs, "secret")
+	requireCredentialFileRemoved(t, confPath)
+	c.Assert(recordedArgs[len(recordedArgs)-1], qt.Equals, "--execute")
+}
+
+func TestExecuteStatement_RunsRealFakePTOSCBinaryWithoutPasswordArgv(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > \"%s\"\n", argsFile)
+	binPath := filepath.Join(dir, "pt-online-schema-change")
+	c.Assert(os.WriteFile(binPath, []byte(script), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(binPath, 0o700), qt.IsNil)
+	t.Setenv("PATH", dir)
+
+	e := New(Config{})
+	handled, err := e.executeStatement(context.Background(), mysqlConn(),
+		"ALTER TABLE users ADD COLUMN bio TEXT",
+		map[string]string{DirectiveTool: ToolPTOSC})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(handled, qt.IsTrue)
+
+	recorded, err := os.ReadFile(argsFile)
+	c.Assert(err, qt.IsNil)
+	recordedArgs := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+	c.Assert(recordedArgs[:3], qt.DeepEquals, []string{"--alter", "ADD COLUMN bio TEXT", "--execute"})
+	spec := recordedArgs[3]
+	c.Assert(spec, qt.Contains, "h=db.internal,P=3307,u=app,D=shop,t=users")
+	c.Assert(spec, qt.Not(qt.Contains), ",p=secret")
+	assertNoArgContains(t, recordedArgs, "secret")
+	defaultsFile, ok := ptoscDSNValue(spec, "F")
+	c.Assert(ok, qt.IsTrue)
+	requireCredentialFileRemoved(t, defaultsFile)
 }


### PR DESCRIPTION
Closes #264

## Summary
- write database URL passwords to temporary MySQL defaults files with mode `0600`
- pass credential files to gh-ost via `--conf` and pt-online-schema-change via DSN `F=` instead of argv passwords
- respect user-supplied credential args (`--conf`, `--defaults-file`, `p=`, `F=`) and avoid generating Ptah credentials in that case
- cover success, failure, cancellation, dry-run, fake-binary argv, comma password, and escaping behavior
- document the new credential handling behavior

## Validation
- `gopls` diagnostics: no diagnostics
- `go_vulncheck ./...`: no reported vulnerabilities
- `go test ./migration/onlineddl -count=1`
- `go test ./migration/onlineddl ./cmd/internal/dbcli ./cmd/migrateup ./cmd/migratedown -count=1`
- `golangci-lint run ./...`
- `go test ./...`