### PR TITLE
Add online-DDL fallback policy

### DIFF
--- a/docs/online-ddl.md
+++ b/docs/online-ddl.md
@@ -34,6 +34,7 @@ Create a `ptah.yaml` next to where you run the CLI (or pass `--config`):
 online_ddl:
   tool: ghost            # or pt-osc
   threshold_rows: 1000000
+  fallback: error        # optional: error or plain
   args:
     - --allow-on-master
     - --max-load=Threads_running=25
@@ -47,11 +48,19 @@ deployment-specific switches belong.
 
 ## Fallback behavior
 
-The routing degrades safely — the plain `ALTER TABLE` on the migration
-connection is always the fallback:
+Fallback behavior depends on how the tool was selected:
 
-- the tool binary is not on `PATH` → warning + plain ALTER;
-- the row-count estimate fails → warning + plain ALTER;
+- an explicit `-- +ptah online_ddl_tool=...` directive defaults to
+  `fallback=error`, so a missing/non-executable tool aborts and no plain
+  `ALTER TABLE` is applied;
+- automatic threshold routing defaults to `fallback=plain`, preserving the
+  original warning + plain ALTER behavior for opportunistic routing;
+- `online_ddl.fallback: error | plain` overrides those defaults globally;
+- `-- +ptah online_ddl_fallback=error | plain` overrides the policy for one
+  migration file, including migrations that rely on directives with no config
+  file;
+- under `fallback=error`, a missing/non-executable tool or row-count estimate
+  failure aborts before the statement reaches the migration connection;
 - the dialect is not MySQL/MariaDB → directives are ignored with a warning;
 - the tool itself exits non-zero → the migration **fails** (no silent
   fallback once the tool has started: it may have left a shadow table

--- a/migration/onlineddl/config.go
+++ b/migration/onlineddl/config.go
@@ -11,8 +11,9 @@
 //     routes any ALTER TABLE automatically when the target table's estimated
 //     row count reaches the threshold.
 //
-// When the selected tool is not on PATH the executor logs a warning and the
-// statement falls back to a plain ALTER TABLE on the migration connection.
+// Fallback behavior depends on intent: explicit tool directives fail closed by
+// default, while automatic threshold routing preserves the original warning +
+// plain ALTER fallback unless online_ddl.fallback overrides it.
 package onlineddl
 
 import (
@@ -36,6 +37,16 @@ const (
 	ToolPTOSC = "pt-osc"
 )
 
+// Fallback policies accepted in configuration and directives.
+const (
+	// FallbackError aborts instead of letting a routed statement degrade to a
+	// plain ALTER TABLE.
+	FallbackError = "error"
+	// FallbackPlain falls through so the migrator executes the plain ALTER
+	// TABLE on its own connection.
+	FallbackPlain = "plain"
+)
+
 // Config is the online_ddl section of ptah.yaml.
 type Config struct {
 	// Tool selects the online-DDL tool used for automatic routing: "ghost"
@@ -49,6 +60,10 @@ type Config struct {
 	// Args are extra arguments appended to every tool invocation — e.g.
 	// gh-ost's --allow-on-master or --max-load, pt-osc's --max-lag.
 	Args []string `yaml:"args"`
+	// Fallback controls what happens when a selected online-DDL path cannot be
+	// used: "error" aborts, "plain" runs the plain ALTER. Empty uses the
+	// source default.
+	Fallback string `yaml:"fallback"`
 }
 
 // ptahConfig is the ptah.yaml envelope.
@@ -74,6 +89,11 @@ func (c Config) Validate() error {
 	}
 	if c.ThresholdRows > 0 && c.Tool == "" {
 		return fmt.Errorf("online_ddl threshold_rows is set but no tool is configured")
+	}
+	if c.Fallback != "" {
+		if err := validateConfigFallback(c.Fallback); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/migration/onlineddl/config_test.go
+++ b/migration/onlineddl/config_test.go
@@ -22,11 +22,12 @@ func writeConfig(t *testing.T, content string) string {
 func TestLoadConfig(t *testing.T) {
 	c := qt.New(t)
 
-	path := writeConfig(t, "online_ddl:\n  tool: ghost\n  threshold_rows: 1000000\n  args:\n    - --allow-on-master\n    - --max-load=Threads_running=25\n")
+	path := writeConfig(t, "online_ddl:\n  tool: ghost\n  threshold_rows: 1000000\n  fallback: error\n  args:\n    - --allow-on-master\n    - --max-load=Threads_running=25\n")
 	cfg, err := onlineddl.LoadConfig(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
 	c.Assert(cfg.ThresholdRows, qt.Equals, int64(1000000))
+	c.Assert(cfg.Fallback, qt.Equals, onlineddl.FallbackError)
 	c.Assert(cfg.Args, qt.DeepEquals, []string{"--allow-on-master", "--max-load=Threads_running=25"})
 	c.Assert(cfg.Enabled(), qt.IsTrue)
 }
@@ -54,6 +55,9 @@ func TestLoadConfig_Invalid(t *testing.T) {
 
 	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  threshold_rows: 100\n"))
 	c.Assert(err, qt.ErrorMatches, ".*threshold_rows is set but no tool is configured.*")
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  tool: ghost\n  fallback: warn\n"))
+	c.Assert(err, qt.ErrorMatches, `invalid online_ddl config .*unknown online_ddl fallback "warn".*`)
 }
 
 func TestConfig_Enabled(t *testing.T) {

--- a/migration/onlineddl/executor.go
+++ b/migration/onlineddl/executor.go
@@ -18,6 +18,10 @@ import (
 // tool, written as `-- +ptah online_ddl_tool=ghost` in a migration file.
 const DirectiveTool = "online_ddl_tool"
 
+// DirectiveFallback is the per-migration directive key selecting the fallback
+// policy, written as `-- +ptah online_ddl_fallback=error`.
+const DirectiveFallback = "online_ddl_fallback"
+
 // DirectiveNone is the DirectiveTool value that opts a migration out of
 // automatic threshold routing.
 const DirectiveNone = "none"
@@ -41,6 +45,11 @@ type CommandRunner func(ctx context.Context, binary string, args []string) error
 type toolInvocation struct {
 	args    []string
 	cleanup func() error
+}
+
+type toolRoute struct {
+	tool     string
+	fallback string
 }
 
 // Executor routes ALTER TABLE migration statements through an online-DDL
@@ -84,22 +93,25 @@ func (e *Executor) WithDryRun(dryRun bool) *Executor {
 	return &tmp
 }
 
-// ValidateDirectives implements migrator.StatementInterceptor: it rejects an
-// unknown online_ddl_tool directive value before any statement runs, so a
-// typo fails the migration cleanly instead of aborting midway (after earlier,
+// ValidateDirectives implements migrator.StatementInterceptor: it rejects
+// unknown online-DDL directive values before any statement runs, so a typo
+// fails the migration cleanly instead of aborting midway (after earlier,
 // implicitly committed DDL) when the first ALTER is reached.
 func (e *Executor) ValidateDirectives(directives map[string]string) error {
-	tool, ok := directives[DirectiveTool]
-	if !ok {
-		return nil
+	if tool, ok := directives[DirectiveTool]; ok {
+		switch tool {
+		case ToolGhost, ToolPTOSC, DirectiveNone:
+		default:
+			return fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
+				DirectiveTool, tool, ToolGhost, ToolPTOSC, DirectiveNone)
+		}
 	}
-	switch tool {
-	case ToolGhost, ToolPTOSC, DirectiveNone:
-		return nil
-	default:
-		return fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
-			DirectiveTool, tool, ToolGhost, ToolPTOSC, DirectiveNone)
+	if fallback, ok := directives[DirectiveFallback]; ok {
+		if err := validateFallbackDirective(fallback); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // ExecuteStatement implements migrator.StatementInterceptor: it returns
@@ -130,17 +142,21 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 		return false, nil
 	}
 
-	tool, err := e.pickTool(ctx, conn, target, directives)
-	if err != nil || tool == "" {
+	route, err := e.pickTool(ctx, conn, target, directives)
+	if err != nil || route.tool == "" {
 		return false, err
 	}
 
-	binary := binaryFor(tool)
+	binary := binaryFor(route.tool)
 	if _, err := e.lookPath(binary); err != nil {
 		// Not just ErrNotFound: a non-executable binary or a permission
 		// error also lands here, so surface the underlying cause.
+		if route.fallback == FallbackError {
+			return false, fmt.Errorf("online-DDL tool %s unavailable for table %s: %w; no ALTER TABLE was applied",
+				binary, target.Table, err)
+		}
 		e.logger.Warn("online-DDL tool unavailable on PATH; falling back to a plain ALTER TABLE",
-			"tool", tool, "binary", binary, "table", target.Table, "error", err)
+			"tool", route.tool, "binary", binary, "table", target.Table, "error", err)
 		return false, nil
 	}
 
@@ -153,7 +169,7 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 	}
 
 	if e.dryRun {
-		if err := validateToolInvocation(tool, dsn, target); err != nil {
+		if err := validateToolInvocation(route.tool, dsn, target); err != nil {
 			return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
 		}
 		e.logger.Info("DRY RUN: would run online-DDL tool",
@@ -161,7 +177,7 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 		return true, nil
 	}
 
-	invocation, err := buildArgs(tool, dsn, target, e.cfg.Args)
+	invocation, err := buildArgs(route.tool, dsn, target, e.cfg.Args)
 	if err != nil {
 		return false, fmt.Errorf("cannot build %s invocation: %w", binary, err)
 	}
@@ -183,33 +199,78 @@ func (e *Executor) executeStatement(ctx context.Context, conn Conn, stmt string,
 
 // pickTool decides which tool (if any) handles the statement: an explicit
 // directive wins; otherwise the configured tool applies when the table's
-// estimated row count reaches the threshold. Empty means "not routed".
-func (e *Executor) pickTool(ctx context.Context, conn Conn, target AlterTarget, directives map[string]string) (string, error) {
+// estimated row count reaches the threshold. Empty tool means "not routed".
+func (e *Executor) pickTool(ctx context.Context, conn Conn, target AlterTarget, directives map[string]string) (toolRoute, error) {
 	if directiveTool, ok := directives[DirectiveTool]; ok {
 		if directiveTool != ToolGhost && directiveTool != ToolPTOSC {
-			return "", fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
+			return toolRoute{}, fmt.Errorf("unknown %s directive value %q: expected %s, %s or %s",
 				DirectiveTool, directiveTool, ToolGhost, ToolPTOSC, DirectiveNone)
 		}
-		return directiveTool, nil
+		fallback, err := e.fallbackPolicy(directives, FallbackError)
+		if err != nil {
+			return toolRoute{}, err
+		}
+		return toolRoute{tool: directiveTool, fallback: fallback}, nil
 	}
 
 	if !e.cfg.Enabled() {
-		return "", nil
+		return toolRoute{}, nil
+	}
+	fallback, err := e.fallbackPolicy(directives, FallbackPlain)
+	if err != nil {
+		return toolRoute{}, err
 	}
 	rows, err := e.rowCount(ctx, conn, target.Schema, target.Table)
 	if err != nil {
-		// Fail open: the plain ALTER is the pre-feature behavior, and a
-		// broken estimate must not block a migration.
+		if fallback == FallbackError {
+			return toolRoute{}, fmt.Errorf("online-DDL row-count check failed for table %s: %w; no ALTER TABLE was applied",
+				target.Table, err)
+		}
 		e.logger.Warn("online-DDL row-count check failed; executing a plain ALTER TABLE",
 			"table", target.Table, "error", err)
-		return "", nil
+		return toolRoute{}, nil
 	}
 	if rows < e.cfg.ThresholdRows {
-		return "", nil
+		return toolRoute{}, nil
 	}
 	e.logger.Info("Routing ALTER TABLE through the online-DDL tool: table exceeds the row threshold",
 		"table", target.Table, "rows", rows, "threshold", e.cfg.ThresholdRows, "tool", e.cfg.Tool)
-	return e.cfg.Tool, nil
+	return toolRoute{tool: e.cfg.Tool, fallback: fallback}, nil
+}
+
+func (e *Executor) fallbackPolicy(directives map[string]string, defaultPolicy string) (string, error) {
+	if fallback, ok := directives[DirectiveFallback]; ok {
+		if err := validateFallbackDirective(fallback); err != nil {
+			return "", err
+		}
+		return fallback, nil
+	}
+	if e.cfg.Fallback != "" {
+		if err := validateConfigFallback(e.cfg.Fallback); err != nil {
+			return "", err
+		}
+		return e.cfg.Fallback, nil
+	}
+	return defaultPolicy, nil
+}
+
+func validateFallbackDirective(value string) error {
+	switch value {
+	case FallbackError, FallbackPlain:
+		return nil
+	default:
+		return fmt.Errorf("unknown %s directive value %q: expected %s or %s",
+			DirectiveFallback, value, FallbackError, FallbackPlain)
+	}
+}
+
+func validateConfigFallback(value string) error {
+	switch value {
+	case FallbackError, FallbackPlain:
+		return nil
+	default:
+		return fmt.Errorf("unknown online_ddl fallback %q: expected %s or %s", value, FallbackError, FallbackPlain)
+	}
 }
 
 // binaryFor maps a canonical tool name to its binary on PATH.

--- a/migration/onlineddl/executor_test.go
+++ b/migration/onlineddl/executor_test.go
@@ -288,34 +288,139 @@ func TestValidateDirectives(t *testing.T) {
 	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: ToolGhost}), qt.IsNil)
 	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: ToolPTOSC}), qt.IsNil)
 	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: DirectiveNone}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveFallback: FallbackError}), qt.IsNil)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveFallback: FallbackPlain}), qt.IsNil)
 	c.Assert(e.ValidateDirectives(map[string]string{"unrelated": "x"}), qt.IsNil)
 	c.Assert(e.ValidateDirectives(map[string]string{DirectiveTool: "goste"}),
 		qt.ErrorMatches, `unknown online_ddl_tool directive value "goste".*`)
+	c.Assert(e.ValidateDirectives(map[string]string{DirectiveFallback: "warn"}),
+		qt.ErrorMatches, `unknown online_ddl_fallback directive value "warn".*`)
 }
 
-func TestExecuteStatement_FallbackPathsWarn(t *testing.T) {
-	c := qt.New(t)
+func TestExecuteStatement_MissingBinaryFallbackPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        Config
+		directives map[string]string
+		rows       int64
+		wantErr    string
+		wantWarn   bool
+	}{
+		{
+			name:       "explicit directive defaults to error",
+			directives: map[string]string{DirectiveTool: ToolGhost},
+			wantErr:    `online-DDL tool gh-ost unavailable for table users: executable file not found in \$PATH; no ALTER TABLE was applied`,
+		},
+		{
+			name:       "explicit directive can opt into plain fallback",
+			cfg:        Config{Fallback: FallbackError},
+			directives: map[string]string{DirectiveTool: ToolGhost, DirectiveFallback: FallbackPlain},
+			wantWarn:   true,
+		},
+		{
+			name:     "threshold routing defaults to plain fallback",
+			cfg:      Config{Tool: ToolGhost, ThresholdRows: 1000},
+			rows:     1000,
+			wantWarn: true,
+		},
+		{
+			name:    "threshold routing can opt into error fallback",
+			cfg:     Config{Tool: ToolGhost, ThresholdRows: 1000, Fallback: FallbackError},
+			rows:    1000,
+			wantErr: `online-DDL tool gh-ost unavailable for table users: executable file not found in \$PATH; no ALTER TABLE was applied`,
+		},
+		{
+			name:       "config plain fallback overrides explicit directive default",
+			cfg:        Config{Fallback: FallbackPlain},
+			directives: map[string]string{DirectiveTool: ToolGhost},
+			wantWarn:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			var ran []invocation
+			e := testExecutor(tt.cfg, &ran, errors.New("executable file not found in $PATH"), tt.rows, nil).WithLogger(logger)
 
-	// Missing binary warns then falls through.
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, nil))
-	var ran []invocation
-	e := testExecutor(Config{}, &ran, errors.New("not found"), 0, nil).WithLogger(logger)
-	handled, err := e.executeStatement(context.Background(), mysqlConn(),
-		"ALTER TABLE users ADD COLUMN a INT", map[string]string{DirectiveTool: ToolGhost})
-	c.Assert(err, qt.IsNil)
-	c.Assert(handled, qt.IsFalse)
-	c.Assert(buf.String(), qt.Contains, "unavailable on PATH")
-	c.Assert(buf.String(), qt.Contains, "not found", qt.Commentf("the underlying lookPath error is surfaced"))
+			handled, err := e.executeStatement(context.Background(), mysqlConn(),
+				"ALTER TABLE users ADD COLUMN a INT", tt.directives)
 
-	// Row-count estimate failure warns then falls through.
-	buf.Reset()
-	e = testExecutor(Config{Tool: ToolGhost, ThresholdRows: 1}, &ran, nil, 0, errors.New("boom")).WithLogger(logger)
-	handled, err = e.executeStatement(context.Background(), mysqlConn(),
-		"ALTER TABLE users ADD COLUMN a INT", nil)
-	c.Assert(err, qt.IsNil)
-	c.Assert(handled, qt.IsFalse)
-	c.Assert(buf.String(), qt.Contains, "row-count check failed")
+			if tt.wantErr != "" {
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+			} else {
+				c.Assert(err, qt.IsNil)
+			}
+			c.Assert(handled, qt.IsFalse)
+			c.Assert(ran, qt.HasLen, 0)
+			if tt.wantWarn {
+				c.Assert(buf.String(), qt.Contains, "unavailable on PATH")
+				c.Assert(buf.String(), qt.Contains, "executable file not found in $PATH",
+					qt.Commentf("the underlying lookPath error is surfaced"))
+			} else {
+				c.Assert(buf.String(), qt.Not(qt.Contains), "falling back to a plain ALTER TABLE")
+			}
+		})
+	}
+}
+
+func TestExecuteStatement_RowCountFailureFallbackPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        Config
+		directives map[string]string
+		wantErr    string
+		wantWarn   bool
+	}{
+		{
+			name:     "threshold default falls through",
+			cfg:      Config{Tool: ToolGhost, ThresholdRows: 1},
+			wantWarn: true,
+		},
+		{
+			name:    "config error aborts",
+			cfg:     Config{Tool: ToolGhost, ThresholdRows: 1, Fallback: FallbackError},
+			wantErr: `online-DDL row-count check failed for table users: information_schema unavailable; no ALTER TABLE was applied`,
+		},
+		{
+			name:       "directive error aborts",
+			cfg:        Config{Tool: ToolGhost, ThresholdRows: 1},
+			directives: map[string]string{DirectiveFallback: FallbackError},
+			wantErr:    `online-DDL row-count check failed for table users: information_schema unavailable; no ALTER TABLE was applied`,
+		},
+		{
+			name:       "directive plain overrides config error",
+			cfg:        Config{Tool: ToolGhost, ThresholdRows: 1, Fallback: FallbackError},
+			directives: map[string]string{DirectiveFallback: FallbackPlain},
+			wantWarn:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+			var ran []invocation
+			e := testExecutor(tt.cfg, &ran, nil, 0, errors.New("information_schema unavailable")).WithLogger(logger)
+
+			handled, err := e.executeStatement(context.Background(), mysqlConn(),
+				"ALTER TABLE users ADD COLUMN a INT", tt.directives)
+
+			if tt.wantErr != "" {
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+			} else {
+				c.Assert(err, qt.IsNil)
+			}
+			c.Assert(handled, qt.IsFalse)
+			c.Assert(ran, qt.HasLen, 0)
+			if tt.wantWarn {
+				c.Assert(buf.String(), qt.Contains, "row-count check failed")
+			} else {
+				c.Assert(buf.String(), qt.Not(qt.Contains), "row-count check failed")
+			}
+		})
+	}
 }
 
 func TestExecuteStatement_DirectiveRoutesThroughPTOSC(t *testing.T) {
@@ -398,7 +503,7 @@ func TestExecuteStatement_ThresholdAutoRouting(t *testing.T) {
 	c.Assert(handled, qt.IsFalse)
 	c.Assert(ran, qt.HasLen, 0)
 
-	// Row-count estimate broken: fail open to the plain ALTER.
+	// Row-count estimate broken: threshold routing defaults to plain fallback.
 	ran = nil
 	e = testExecutor(cfg, &ran, nil, 0, errors.New("information_schema unavailable"))
 	handled, err = e.executeStatement(context.Background(), mysqlConn(),
@@ -431,7 +536,7 @@ func TestExecuteStatement_NonAlterAndNonMySQLPassThrough(t *testing.T) {
 	c.Assert(ran, qt.HasLen, 0)
 }
 
-func TestExecuteStatement_MissingBinaryFallsBackToPlainAlter(t *testing.T) {
+func TestExecuteStatement_ExplicitMissingBinaryAbortsByDefault(t *testing.T) {
 	c := qt.New(t)
 
 	var ran []invocation
@@ -441,8 +546,8 @@ func TestExecuteStatement_MissingBinaryFallsBackToPlainAlter(t *testing.T) {
 		"ALTER TABLE users ADD COLUMN bio TEXT",
 		map[string]string{DirectiveTool: ToolGhost})
 
-	c.Assert(err, qt.IsNil)
-	c.Assert(handled, qt.IsFalse, qt.Commentf("the migrator must execute the plain ALTER instead"))
+	c.Assert(err, qt.ErrorMatches, `online-DDL tool gh-ost unavailable for table users: executable file not found in \$PATH; no ALTER TABLE was applied`)
+	c.Assert(handled, qt.IsFalse)
 	c.Assert(ran, qt.HasLen, 0)
 }
 


### PR DESCRIPTION
Closes #263

## Summary
- add `online_ddl.fallback: error | plain` to config validation
- add per-migration `-- +ptah online_ddl_fallback=error | plain` directive validation
- default explicit online-DDL tool directives to fail closed when a selected binary is missing
- keep automatic threshold routing fail-open by default, with config/directive overrides
- apply `fallback=error` to missing/non-executable tools and row-count estimate failures
- update online-DDL documentation

## Validation
- `gopls` diagnostics: no diagnostics
- `go test ./migration/onlineddl -count=1 -v`
- `go test ./migration/onlineddl ./migration/migrator ./cmd/internal/dbcli ./cmd/migrateup ./cmd/migratedown -count=1`
- `golangci-lint run ./...`
- `go test ./...`