### PR TITLE
Add migration advisory locks

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -178,8 +178,10 @@ jobs:
       - name: Run migrator safety integration tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
         run: |
-          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration' -timeout 2m
+          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration' -timeout 2m
 
       - name: Run all databases comprehensive test
         env:

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ Apply all pending migrations to bring database up to latest version:
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations
 
 # Production rollout defaults: fail fast on hot-table locks and runaway statements
-./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --lock-timeout 3s --statement-timeout 30s
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --lock-timeout 3s --statement-timeout 30s --migration-lock-timeout 30s
 
 # Dry run to preview what would be applied
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dry-run
@@ -731,6 +731,16 @@ Migration files can override the CLI defaults with top-of-file directives:
 ```
 
 PostgreSQL uses `SET LOCAL lock_timeout` and `SET LOCAL statement_timeout` inside the migration transaction. MySQL and MariaDB use `SET SESSION innodb_lock_wait_timeout`; statement timeouts use `max_execution_time` on MySQL and `max_statement_time` on MariaDB. Generated migrations that contain `ALTER TABLE` include the recommended `3s` lock timeout and `30s` statement timeout directives for supported dialects.
+
+`migrate-up`, `migrate-down`, and programmatic `MigrateTo` acquire a
+session-level migration advisory lock around the planning and apply window for
+PostgreSQL, MySQL, and MariaDB. PostgreSQL uses `pg_advisory_lock`; MySQL and
+MariaDB use `GET_LOCK('ptah_migrate', timeout)`. By default Ptah waits until
+the lock is available; MariaDB does not accept MySQL's negative infinite
+timeout, so Ptah uses a long server-side wait there unless an explicit timeout
+is configured. Set `--migration-lock-timeout` to make concurrent runners fail
+with a typed migration lock timeout error that callers can detect with
+`migrator.IsMigrationLockTimeout`.
 
 Most migrations run inside the normal per-migration transaction. If the database
 rejects transactional execution, use an explicit file directive:
@@ -788,7 +798,7 @@ Roll back migrations to a specific version:
 ./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5
 
 # Use the same production safety defaults for rollback DDL
-./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --lock-timeout 3s --statement-timeout 30s
+./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --lock-timeout 3s --statement-timeout 30s --migration-lock-timeout 30s
 
 # Dry run to preview rollback
 ./package-migrator migrate-down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --dry-run

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -33,17 +33,18 @@ before running down migrations in production.`,
 }
 
 const (
-	dbURLFlag            = "db-url"
-	migrationsFlag       = "migrations-dir"
-	targetFlag           = "target"
-	dirFormatFlag        = "dir-format"
-	atlasEnvFlag         = "atlas-env"
-	dryRunFlag           = "dry-run"
-	verboseFlag          = "verbose"
-	confirmFlag          = "confirm"
-	execOrderFlag        = "exec-order"
-	lockTimeoutFlag      = "lock-timeout"
-	statementTimeoutFlag = "statement-timeout"
+	dbURLFlag                = "db-url"
+	migrationsFlag           = "migrations-dir"
+	targetFlag               = "target"
+	dirFormatFlag            = "dir-format"
+	atlasEnvFlag             = "atlas-env"
+	dryRunFlag               = "dry-run"
+	verboseFlag              = "verbose"
+	confirmFlag              = "confirm"
+	execOrderFlag            = "exec-order"
+	migrationLockTimeoutFlag = "migration-lock-timeout"
+	lockTimeoutFlag          = "lock-timeout"
+	statementTimeoutFlag     = "statement-timeout"
 )
 
 var migrateDownFlags = map[string]cobraflags.Flag{
@@ -92,6 +93,11 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: string(migrator.ExecOrderLinear),
 		Usage: "Execution order policy for pending migrations below the current version: linear, linear-skip, or non-linear",
 	},
+	migrationLockTimeoutFlag: &cobraflags.StringFlag{
+		Name:  migrationLockTimeoutFlag,
+		Value: "",
+		Usage: "Timeout for acquiring the session-level migration advisory lock, such as 10s or 2m",
+	},
 	lockTimeoutFlag: &cobraflags.StringFlag{
 		Name:  lockTimeoutFlag,
 		Value: "",
@@ -123,6 +129,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	verbose := migrateDownFlags[verboseFlag].GetBool()
 	skipConfirm := migrateDownFlags[confirmFlag].GetBool()
 	execOrderValue := migrateDownFlags[execOrderFlag].GetString()
+	migrationLockTimeoutValue := migrateDownFlags[migrationLockTimeoutFlag].GetString()
 	lockTimeout := migrateDownFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
 	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
@@ -158,6 +165,10 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	execOrder, err := migrator.ParseExecOrder(execOrderValue)
+	if err != nil {
+		return err
+	}
+	migrationLockTimeout, err := migrator.ParseMigrationLockTimeout(migrationLockTimeoutValue)
 	if err != nil {
 		return err
 	}
@@ -217,7 +228,10 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts).WithExecOrder(execOrder)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithDefaultTimeouts(timeouts).
+		WithExecOrder(execOrder).
+		WithMigrationLockTimeout(migrationLockTimeout)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -19,6 +19,7 @@ func TestMigrateDownCommand_Creation(t *testing.T) {
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "migrate-down")
 	c.Assert(cmd.Short, qt.Contains, "Roll back migrations")
+	c.Assert(cmd.Flag("migration-lock-timeout"), qt.IsNotNil)
 }
 
 // TestMigrateDownCommand_Integration tests the actual migration logic

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -33,17 +33,18 @@ migration process stops.`,
 }
 
 const (
-	dbURLFlag            = "db-url"
-	migrationsFlag       = "migrations-dir"
-	dryRunFlag           = "dry-run"
-	verboseFlag          = "verbose"
-	verifySumFlag        = "verify-sum"
-	dirFormatFlag        = "dir-format"
-	atlasEnvFlag         = "atlas-env"
-	execOrderFlag        = "exec-order"
-	lockTimeoutFlag      = "lock-timeout"
-	statementTimeoutFlag = "statement-timeout"
-	allowDestructiveFlag = "allow-destructive"
+	dbURLFlag                = "db-url"
+	migrationsFlag           = "migrations-dir"
+	dryRunFlag               = "dry-run"
+	verboseFlag              = "verbose"
+	verifySumFlag            = "verify-sum"
+	dirFormatFlag            = "dir-format"
+	atlasEnvFlag             = "atlas-env"
+	execOrderFlag            = "exec-order"
+	migrationLockTimeoutFlag = "migration-lock-timeout"
+	lockTimeoutFlag          = "lock-timeout"
+	statementTimeoutFlag     = "statement-timeout"
+	allowDestructiveFlag     = "allow-destructive"
 )
 
 var migrateUpFlags = map[string]cobraflags.Flag{
@@ -87,6 +88,11 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: string(migrator.ExecOrderLinear),
 		Usage: "Execution order policy for pending migrations below the current version: linear, linear-skip, or non-linear",
 	},
+	migrationLockTimeoutFlag: &cobraflags.StringFlag{
+		Name:  migrationLockTimeoutFlag,
+		Value: "",
+		Usage: "Timeout for acquiring the session-level migration advisory lock, such as 10s or 2m",
+	},
 	lockTimeoutFlag: &cobraflags.StringFlag{
 		Name:  lockTimeoutFlag,
 		Value: "",
@@ -122,6 +128,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	dirFormatValue := migrateUpFlags[dirFormatFlag].GetString()
 	atlasEnv := migrateUpFlags[atlasEnvFlag].GetString()
 	execOrderValue := migrateUpFlags[execOrderFlag].GetString()
+	migrationLockTimeoutValue := migrateUpFlags[migrationLockTimeoutFlag].GetString()
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
 	allowDestructive := migrateUpFlags[allowDestructiveFlag].GetBool()
@@ -165,6 +172,10 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	execOrder, err := migrator.ParseExecOrder(execOrderValue)
+	if err != nil {
+		return err
+	}
+	migrationLockTimeout, err := migrator.ParseMigrationLockTimeout(migrationLockTimeoutValue)
 	if err != nil {
 		return err
 	}
@@ -223,7 +234,10 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).WithDefaultTimeouts(timeouts).WithExecOrder(execOrder)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithDefaultTimeouts(timeouts).
+		WithExecOrder(execOrder).
+		WithMigrationLockTimeout(migrationLockTimeout)
 
 	// Get migration status before running
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -36,6 +36,8 @@ func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
 	write("0000000001_init.up.sql", "CREATE TABLE t (id BIGINT);\n")
 
 	cmd := NewMigrateUpCommand()
+	c.Assert(cmd.Flag(migrationLockTimeoutFlag), qt.IsNotNil)
+
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -194,6 +194,12 @@ func (dc *DatabaseConnection) ExecContext(ctx context.Context, query string, arg
 	return dc.db.ExecContext(ctx, query, args...)
 }
 
+// Conn returns a dedicated database session. Callers that use session-scoped
+// database features must close the returned connection when finished.
+func (dc *DatabaseConnection) Conn(ctx context.Context) (*sql.Conn, error) {
+	return dc.db.Conn(ctx)
+}
+
 // Close closes the database connection
 func (dc *DatabaseConnection) Close() error {
 	if dc.db != nil {

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -363,12 +363,24 @@ CREATE TABLE schema_migrations (
 8. **Use production timeouts**: Run production DDL with `--lock-timeout 3s --statement-timeout 30s` so hot-table locks and runaway statements fail fast
 9. **Version numbers**: Use sequential version numbers or timestamps
 
+### Migration Advisory Locks
+
+PostgreSQL, MySQL, and MariaDB migrators acquire a session-level advisory lock
+around the planning and apply window for `MigrateUp`, `MigrateDown`,
+`MigrateDownTo`, and `MigrateTo`. This prevents concurrent runners from reading
+the same pending migration set and applying it more than once.
+
+By default the migrator waits until the lock is available. Use
+`WithMigrationLockTimeout` or the CLI `--migration-lock-timeout` flag to bound
+that wait. Timed-out callers receive a typed error that can be detected with
+`migrator.IsMigrationLockTimeout`.
+
 ### Per-Migration Timeouts
 
 Set CLI defaults for every pending migration:
 
 ```bash
-go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --lock-timeout 3s --statement-timeout 30s
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --lock-timeout 3s --statement-timeout 30s --migration-lock-timeout 30s
 ```
 
 Override those defaults in a specific migration file with top-of-file directives:

--- a/migration/migrator/advisory_lock.go
+++ b/migration/migrator/advisory_lock.go
@@ -1,0 +1,197 @@
+package migrator
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/stokaro/ptah/dbschema"
+)
+
+const migrationAdvisoryLockName = "ptah_migrate"
+const migrationAdvisoryUnlockTimeout = 10 * time.Second
+const mariaDBDefaultAdvisoryLockTimeoutSeconds = 31_536_000
+
+// postgresMigrationAdvisoryLockKey is the stable FNV-1a 64-bit hash of
+// migrationAdvisoryLockName, stored as a signed value for pg_advisory_lock.
+const postgresMigrationAdvisoryLockKey int64 = -7752083082818440098
+
+// MigrationLockTimeoutError reports that another runner held the migration
+// advisory lock longer than this migrator was configured to wait.
+type MigrationLockTimeoutError struct {
+	Dialect string
+	Name    string
+	Timeout time.Duration
+}
+
+func (e *MigrationLockTimeoutError) Error() string {
+	return fmt.Sprintf("timed out acquiring migration lock %q for %s after %s", e.Name, e.Dialect, e.Timeout)
+}
+
+// IsMigrationLockTimeout reports whether err wraps a migration lock timeout.
+func IsMigrationLockTimeout(err error) bool {
+	var target *MigrationLockTimeoutError
+	return errors.As(err, &target)
+}
+
+// ParseMigrationLockTimeout parses the session-level advisory lock timeout.
+// Empty means wait indefinitely.
+func ParseMigrationLockTimeout(value string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	duration, err := parsePositiveDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid migration lock timeout: %w", err)
+	}
+	return duration, nil
+}
+
+// WithMigrationLockTimeout returns a copy of the migrator that limits how long
+// it waits for the session-level migration advisory lock. Zero means wait
+// indefinitely.
+func (m *Migrator) WithMigrationLockTimeout(timeout time.Duration) *Migrator {
+	tmp := *m
+	tmp.migrationLockTimeout = timeout
+	return &tmp
+}
+
+func (m *Migrator) withMigrationLock(ctx context.Context, operation string, fn func(context.Context) error) error {
+	if m.conn == nil || m.conn.Writer().IsDryRun() {
+		return fn(ctx)
+	}
+
+	lock, err := acquireMigrationLock(ctx, m.conn, m.migrationLockTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to acquire migration lock for %s: %w", operation, err)
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), migrationAdvisoryUnlockTimeout)
+		defer cancel()
+		if err := lock.release(releaseCtx); err != nil {
+			m.logger.Warn("failed to release migration lock", "operation", operation, "error", err)
+		}
+	}()
+
+	return fn(ctx)
+}
+
+type migrationLock struct {
+	conn        *sql.Conn
+	releaseFunc func(context.Context) error
+}
+
+func acquireMigrationLock(ctx context.Context, conn *dbschema.DatabaseConnection, timeout time.Duration) (*migrationLock, error) {
+	switch conn.Info().Dialect {
+	case "postgres", "mysql", "mariadb":
+	default:
+		return &migrationLock{}, nil
+	}
+
+	session, err := conn.Conn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	lock := &migrationLock{conn: session}
+	var acquireErr error
+	switch conn.Info().Dialect {
+	case "postgres":
+		lock.releaseFunc = releasePostgresMigrationLock(session)
+		acquireErr = acquirePostgresMigrationLock(ctx, session, timeout)
+	case "mysql", "mariadb":
+		lock.releaseFunc = releaseMySQLMigrationLock(session)
+		acquireErr = acquireMySQLMigrationLock(ctx, session, conn.Info().Dialect, timeout)
+	}
+	if acquireErr != nil {
+		_ = session.Close()
+		return nil, acquireErr
+	}
+	return lock, nil
+}
+
+func (l *migrationLock) release(ctx context.Context) error {
+	if l.conn == nil {
+		return nil
+	}
+	defer l.conn.Close()
+	return l.releaseFunc(ctx)
+}
+
+func acquirePostgresMigrationLock(ctx context.Context, conn *sql.Conn, timeout time.Duration) error {
+	lockCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		lockCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	if _, err := conn.ExecContext(lockCtx, "SELECT pg_advisory_lock($1)", postgresMigrationLockKey()); err != nil {
+		if timeout > 0 && errors.Is(lockCtx.Err(), context.DeadlineExceeded) {
+			return &MigrationLockTimeoutError{Dialect: "postgres", Name: migrationAdvisoryLockName, Timeout: timeout}
+		}
+		return err
+	}
+	return nil
+}
+
+func releasePostgresMigrationLock(conn *sql.Conn) func(context.Context) error {
+	return func(ctx context.Context) error {
+		var released bool
+		if err := conn.QueryRowContext(ctx, "SELECT pg_advisory_unlock($1)", postgresMigrationLockKey()).Scan(&released); err != nil {
+			return err
+		}
+		if !released {
+			return fmt.Errorf("postgres migration advisory lock was not held")
+		}
+		return nil
+	}
+}
+
+func acquireMySQLMigrationLock(ctx context.Context, conn *sql.Conn, dialect string, timeout time.Duration) error {
+	timeoutSeconds := mySQLMigrationLockTimeoutSeconds(dialect, timeout)
+
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", migrationAdvisoryLockName, timeoutSeconds).Scan(&acquired); err != nil {
+		return err
+	}
+	if !acquired.Valid {
+		return fmt.Errorf("GET_LOCK(%q) returned NULL", migrationAdvisoryLockName)
+	}
+	if acquired.Int64 == 0 {
+		return &MigrationLockTimeoutError{Dialect: dialect, Name: migrationAdvisoryLockName, Timeout: timeout}
+	}
+	return nil
+}
+
+func releaseMySQLMigrationLock(conn *sql.Conn) func(context.Context) error {
+	return func(ctx context.Context) error {
+		var released sql.NullInt64
+		if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", migrationAdvisoryLockName).Scan(&released); err != nil {
+			return err
+		}
+		if !released.Valid {
+			return fmt.Errorf("mysql migration advisory lock was not held")
+		}
+		if released.Int64 == 0 {
+			return fmt.Errorf("mysql migration advisory lock was not released")
+		}
+		return nil
+	}
+}
+
+func mySQLMigrationLockTimeoutSeconds(dialect string, timeout time.Duration) float64 {
+	if timeout > 0 {
+		return math.Ceil(timeout.Seconds())
+	}
+	if dialect == "mariadb" {
+		return mariaDBDefaultAdvisoryLockTimeoutSeconds
+	}
+	return -1
+}
+
+func postgresMigrationLockKey() int64 {
+	return postgresMigrationAdvisoryLockKey
+}

--- a/migration/migrator/advisory_lock_integration_test.go
+++ b/migration/migrator/advisory_lock_integration_test.go
@@ -1,0 +1,252 @@
+package migrator_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const issue124ConcurrentRunners = 10
+
+func TestMigrationAdvisoryLock_PostgresConcurrentRunners(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	baseConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = baseConn.Close() }()
+
+	names := issue124Names(time.Now().UnixNano())
+	cleanupIssue124(t, baseConn, names)
+	defer cleanupIssue124(t, baseConn, names)
+
+	migrations := issue124Migrations(names)
+	errs := runIssue124ConcurrentMigrations(t, dbURL, func(conn *dbschema.DatabaseConnection) error {
+		return issue124Migrator(conn, names.migrationsTable, migrations).MigrateUp(ctx)
+	})
+	c.Assert(errs, qt.HasLen, 0)
+
+	c.Assert(tableExists(t, baseConn, names.itemsTable), qt.IsTrue)
+	c.Assert(tableExists(t, baseConn, names.logTable), qt.IsTrue)
+	assertIssue124State(t, baseConn, names, 2, 1)
+
+	errs = runIssue124ConcurrentMigrations(t, dbURL, func(conn *dbschema.DatabaseConnection) error {
+		return issue124Migrator(conn, names.migrationsTable, migrations).MigrateDownTo(ctx, 0)
+	})
+	c.Assert(errs, qt.HasLen, 0)
+
+	c.Assert(tableExists(t, baseConn, names.itemsTable), qt.IsFalse)
+	c.Assert(tableExists(t, baseConn, names.logTable), qt.IsFalse)
+	assertIssue124State(t, baseConn, names, 0, 0)
+}
+
+func TestMigrationAdvisoryLock_PostgresTimeoutIntegration(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	baseConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = baseConn.Close() }()
+
+	names := issue124Names(time.Now().UnixNano())
+	cleanupIssue124(t, baseConn, names)
+	defer cleanupIssue124(t, baseConn, names)
+
+	lockConn, err := baseConn.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = lockConn.Close() }()
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(-7752083082818440098))
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", int64(-7752083082818440098))
+	}()
+
+	err = issue124Migrator(baseConn, names.migrationsTable, issue124Migrations(names)).
+		WithMigrationLockTimeout(100 * time.Millisecond).
+		MigrateUp(ctx)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsMigrationLockTimeout(err), qt.IsTrue)
+}
+
+func TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runIssue124MySQLFamilyDefaultTimeoutIntegration(t, dbURL)
+}
+
+func TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runIssue124MySQLFamilyDefaultTimeoutIntegration(t, dbURL)
+}
+
+type issue124TestNames struct {
+	migrationsTable string
+	itemsTable      string
+	logTable        string
+}
+
+func issue124Names(suffix int64) issue124TestNames {
+	return issue124TestNames{
+		migrationsTable: fmt.Sprintf("schema_migrations_issue_124_%d", suffix),
+		itemsTable:      fmt.Sprintf("ptah_issue_124_items_%d", suffix),
+		logTable:        fmt.Sprintf("ptah_issue_124_log_%d", suffix),
+	}
+}
+
+func issue124Migrator(
+	conn *dbschema.DatabaseConnection,
+	migrationsTable string,
+	migrations []*migrator.Migration,
+) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationsTable("", migrationsTable).
+		WithMigrationLockTimeout(10 * time.Second)
+}
+
+func issue124Migrations(names issue124TestNames) []*migrator.Migration {
+	return []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(
+			1,
+			"create issue 124 items",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.itemsTable),
+			fmt.Sprintf("DROP TABLE %s", names.itemsTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			2,
+			"create issue 124 log",
+			fmt.Sprintf(
+				"CREATE TABLE %s (id INTEGER PRIMARY KEY); INSERT INTO %s (id) VALUES (1)",
+				names.logTable,
+				names.logTable,
+			),
+			fmt.Sprintf("DROP TABLE %s", names.logTable),
+		),
+	}
+}
+
+func runIssue124ConcurrentMigrations(
+	t *testing.T,
+	dbURL string,
+	run func(*dbschema.DatabaseConnection) error,
+) []error {
+	t.Helper()
+
+	start := make(chan struct{})
+	errCh := make(chan error, issue124ConcurrentRunners)
+	var wg sync.WaitGroup
+
+	for range issue124ConcurrentRunners {
+		wg.Go(func() {
+			conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer func() { _ = conn.Close() }()
+
+			<-start
+			if err := run(conn); err != nil {
+				errCh <- err
+			}
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
+func assertIssue124State(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	names issue124TestNames,
+	wantMigrations int,
+	wantLogRows int,
+) {
+	t.Helper()
+
+	var migrationRows int
+	err := conn.QueryRowContext(context.Background(), fmt.Sprintf("SELECT COUNT(*) FROM %s", names.migrationsTable)).
+		Scan(&migrationRows)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, migrationRows, qt.Equals, wantMigrations)
+
+	var logRows int
+	if wantLogRows > 0 {
+		err = conn.QueryRowContext(context.Background(), fmt.Sprintf("SELECT COUNT(*) FROM %s", names.logTable)).
+			Scan(&logRows)
+		qt.Assert(t, err, qt.IsNil)
+	}
+	qt.Assert(t, logRows, qt.Equals, wantLogRows)
+}
+
+func cleanupIssue124(t *testing.T, conn *dbschema.DatabaseConnection, names issue124TestNames) {
+	t.Helper()
+
+	for _, statement := range []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.migrationsTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.logTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.itemsTable),
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func runIssue124MySQLFamilyDefaultTimeoutIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue124Names(time.Now().UnixNano())
+	cleanupIssue124(t, conn, names)
+	defer cleanupIssue124(t, conn, names)
+
+	err = issue124Migrator(conn, names.migrationsTable, issue124Migrations(names)).MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+
+	var logRows int
+	err = conn.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.logTable)).Scan(&logRows)
+	c.Assert(err, qt.IsNil)
+	c.Assert(logRows, qt.Equals, 1)
+}
+
+func mySQLFamilyTestURL(t *testing.T, dialect string, envNames ...string) string {
+	t.Helper()
+
+	for _, envName := range envNames {
+		dbURL := os.Getenv(envName)
+		if dbURL == "" {
+			continue
+		}
+		if !strings.HasPrefix(dbURL, dialect+"://") {
+			t.Skipf("%s URL required for %s advisory lock integration test", dialect, dialect)
+		}
+		return dbURL
+	}
+
+	t.Skipf("%s not set", strings.Join(envNames, " or "))
+	return ""
+}

--- a/migration/migrator/advisory_lock_test.go
+++ b/migration/migrator/advisory_lock_test.go
@@ -1,0 +1,118 @@
+package migrator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseMigrationLockTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Duration
+		wantErr string
+	}{
+		{
+			name:  "empty waits indefinitely",
+			value: "",
+			want:  0,
+		},
+		{
+			name:  "valid duration",
+			value: "2m",
+			want:  2 * time.Minute,
+		},
+		{
+			name:    "zero rejected",
+			value:   "0s",
+			wantErr: "invalid migration lock timeout: must be greater than zero",
+		},
+		{
+			name:    "negative rejected",
+			value:   "-1s",
+			wantErr: "invalid migration lock timeout: must be greater than zero",
+		},
+		{
+			name:    "invalid rejected",
+			value:   "soon",
+			wantErr: `invalid migration lock timeout: time: invalid duration "soon"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := ParseMigrationLockTimeout(tt.value)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestIsMigrationLockTimeout(t *testing.T) {
+	c := qt.New(t)
+
+	err := fmt.Errorf("wrapped: %w", &MigrationLockTimeoutError{
+		Dialect: "postgres",
+		Name:    migrationAdvisoryLockName,
+		Timeout: 250 * time.Millisecond,
+	})
+
+	c.Assert(IsMigrationLockTimeout(err), qt.IsTrue)
+	c.Assert(IsMigrationLockTimeout(fmt.Errorf("other error")), qt.IsFalse)
+}
+
+func TestPostgresMigrationLockKeyStable(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(postgresMigrationLockKey(), qt.Equals, int64(-7752083082818440098))
+}
+
+func TestMySQLMigrationLockTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		timeout time.Duration
+		want    float64
+	}{
+		{
+			name:    "mysql default uses native infinite timeout",
+			dialect: "mysql",
+			want:    -1,
+		},
+		{
+			name:    "mariadb default avoids unsupported negative timeout",
+			dialect: "mariadb",
+			want:    mariaDBDefaultAdvisoryLockTimeoutSeconds,
+		},
+		{
+			name:    "mysql explicit subsecond rounds up",
+			dialect: "mysql",
+			timeout: 500 * time.Millisecond,
+			want:    1,
+		},
+		{
+			name:    "mariadb explicit duration",
+			dialect: "mariadb",
+			timeout: 2 * time.Second,
+			want:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(mySQLMigrationLockTimeoutSeconds(tt.dialect, tt.timeout), qt.Equals, tt.want)
+		})
+	}
+}

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -87,6 +87,11 @@
 // WithMigrationsTable(schema, table) to store migration history in a custom
 // schema or table, for example an `infra.ptah_migrations` table in PostgreSQL.
 //
+// PostgreSQL, MySQL, and MariaDB migrations acquire a session-level advisory
+// lock around the planning and apply window. Use WithMigrationLockTimeout to
+// bound the wait for that lock; callers can detect acquisition timeouts with
+// IsMigrationLockTimeout.
+//
 // # Migration Operations
 //
 // The migrator supports several migration operations:

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -26,14 +26,15 @@ type MigrationStatus struct {
 
 // Migrator handles database migrations for ptah
 type Migrator struct {
-	conn              *dbschema.DatabaseConnection
-	migrationProvider MigrationProvider
-	defaultTimeouts   MigrationTimeouts
-	migrationsTable   string
-	migrationsSchema  string
-	execOrder         ExecOrder
-	initialized       bool
-	logger            *slog.Logger
+	conn                 *dbschema.DatabaseConnection
+	migrationProvider    MigrationProvider
+	defaultTimeouts      MigrationTimeouts
+	migrationsTable      string
+	migrationsSchema     string
+	execOrder            ExecOrder
+	migrationLockTimeout time.Duration
+	initialized          bool
+	logger               *slog.Logger
 }
 
 // NewFSMigrator creates a new migrator that loads migrations from a filesystem.
@@ -370,6 +371,10 @@ func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, er
 
 // MigrateUp migrates the database up to the latest version
 func (m *Migrator) MigrateUp(ctx context.Context) error {
+	return m.withMigrationLock(ctx, "migrate up", m.migrateUpLocked)
+}
+
+func (m *Migrator) migrateUpLocked(ctx context.Context) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -398,6 +403,12 @@ func (m *Migrator) MigrateUp(ctx context.Context) error {
 
 // MigrateDown migrates the database down to the previous version
 func (m *Migrator) MigrateDown(ctx context.Context) error {
+	return m.withMigrationLock(ctx, "migrate down", func(ctx context.Context) error {
+		return m.migrateDownLocked(ctx)
+	})
+}
+
+func (m *Migrator) migrateDownLocked(ctx context.Context) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -408,11 +419,17 @@ func (m *Migrator) MigrateDown(ctx context.Context) error {
 		return fmt.Errorf("failed to get previous version: %w", err)
 	}
 
-	return m.MigrateDownTo(ctx, targetVersion)
+	return m.migrateDownToLocked(ctx, targetVersion)
 }
 
 // MigrateDownTo migrates the database down to the specified target version
 func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error {
+	return m.withMigrationLock(ctx, "migrate down", func(ctx context.Context) error {
+		return m.migrateDownToLocked(ctx, targetVersion)
+	})
+}
+
+func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -500,6 +517,12 @@ func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error
 
 // MigrateTo migrates the database to a specific version (up or down)
 func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int64) error {
+	return m.withMigrationLock(ctx, "migrate to", func(ctx context.Context) error {
+		return m.migrateToLocked(ctx, targetVersion)
+	})
+}
+
+func (m *Migrator) migrateToLocked(ctx context.Context, targetVersion int64) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -526,7 +549,7 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int64) error {
 	}
 
 	// Migrate down to target version
-	return m.MigrateDownTo(ctx, targetVersion)
+	return m.migrateDownToLocked(ctx, targetVersion)
 }
 
 // MigrationProvider returns the migration provider


### PR DESCRIPTION
## Summary
- add session-level advisory locks around migrator planning and apply paths for PostgreSQL, MySQL, and MariaDB
- expose migration lock timeout parsing/API and wire --migration-lock-timeout into migrate-up/migrate-down
- document advisory-lock behavior and add CI coverage for live Postgres concurrency/timeout tests

Fixes #124

## Validation
- gopls diagnostics: no diagnostics
- go test ./migration/migrator -count=1 -v
- POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:55432/ptah_test?sslmode=disable go test ./migration/migrator -count=1 -run 'TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration' -v
- go test ./migration/migrator ./cmd/migrateup ./cmd/migratedown ./dbschema -count=1
- golangci-lint run --fix ./...
- golangci-lint run ./...
- go test ./...