### PR TITLE
Add dirty migration state and repair command

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -181,7 +181,7 @@ jobs:
           MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
         run: |
-          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration' -timeout 2m
+          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration' -timeout 3m
 
       - name: Run all databases comprehensive test
         env:

--- a/README.md
+++ b/README.md
@@ -763,11 +763,34 @@ of silently reporting "up to date". Use `--exec-order=non-linear` to apply those
 pending lower versions, or `--exec-order=linear-skip` to leave them unapplied with
 a warning.
 
+Ptah records migration state before executing each migration and marks the row
+`applied` only after the migration finishes. A failed migration leaves a dirty
+`schema_migrations` revision with statement progress, error text, execution
+time, and a SHA-256 checksum of the up SQL. `migrate-up`, `migrate-down`, and
+`migrate-to` refuse to continue while a dirty revision exists, so operators can
+inspect the database instead of accidentally running later migrations on a
+half-applied schema.
+
+After fixing the database state manually, use `migrate-repair` to mark the
+dirty revision resolved:
+
+```bash
+./package-migrator migrate-repair --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --version 12
+
+# For non-transactional engines, resume remaining up statements before marking applied.
+./package-migrator migrate-repair --db-url mysql://user:pass@tcp(localhost:3306)/database --migrations-dir ./migrations --version 12 --resume-from 2
+```
+
+Already-applied migrations are also checked against the current up SQL checksum.
+If a migration file is edited after it was applied, Ptah aborts before planning
+new work and reports a checksum mismatch for that version.
+
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
 - ✅ Detects out-of-order pending migrations below the current version
 - ✅ Each migration runs in its own transaction unless explicitly marked `no_transaction`
-- ✅ Automatic rollback on failure
+- ✅ Tracks dirty/failed migration state and refuses to continue until repaired
+- ✅ Verifies applied migration checksums before running new work
 - ✅ Executes Ptah paired down files and Atlas txtar `down.sql` sections
 - ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
 - ✅ Supports dry-run mode for preview

--- a/cmd/migraterepair/migraterepair.go
+++ b/cmd/migraterepair/migraterepair.go
@@ -1,0 +1,161 @@
+package migraterepair
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/go-extras/cobraflags"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+var migrateRepairCmd = &cobra.Command{
+	Use:   "migrate-repair",
+	Short: "Repair dirty migration metadata",
+	Long: `Repair dirty migration metadata after an operator has fixed a
+half-applied migration manually, or resume the migration from a specific
+statement.`,
+	RunE: migrateRepairCommand,
+}
+
+const (
+	dbURLFlag      = "db-url"
+	migrationsFlag = "migrations-dir"
+	versionFlag    = "version"
+	dirFormatFlag  = "dir-format"
+	atlasEnvFlag   = "atlas-env"
+	forceFlag      = "force"
+	resumeFromFlag = "resume-from"
+)
+
+var migrateRepairFlags = map[string]cobraflags.Flag{
+	dbURLFlag: &cobraflags.StringFlag{
+		Name:  dbURLFlag,
+		Value: "",
+		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
+	},
+	migrationsFlag: &cobraflags.StringFlag{
+		Name:  migrationsFlag,
+		Value: "",
+		Usage: "Directory containing migration files (required)",
+	},
+	versionFlag: &cobraflags.StringFlag{
+		Name:  versionFlag,
+		Value: "",
+		Usage: "Migration version to repair (required)",
+	},
+	dirFormatFlag: &cobraflags.StringFlag{
+		Name:  dirFormatFlag,
+		Value: string(migrator.MigrationDirFormatAuto),
+		Usage: "Migration directory format: auto, ptah, or atlas",
+	},
+	atlasEnvFlag: &cobraflags.StringFlag{
+		Name:  atlasEnvFlag,
+		Value: "",
+		Usage: "Value exposed as .Env when rendering Atlas SQL template migrations",
+	},
+	forceFlag: &cobraflags.BoolFlag{
+		Name:  forceFlag,
+		Value: false,
+		Usage: "Rewrite or create the revision row even when it is not dirty",
+	},
+	resumeFromFlag: &cobraflags.StringFlag{
+		Name:  resumeFromFlag,
+		Value: "",
+		Usage: "Execute remaining up statements starting from this 1-based statement number before marking applied",
+	},
+	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
+	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+}
+
+func NewMigrateRepairCommand() *cobra.Command {
+	cobraflags.RegisterMap(migrateRepairCmd, migrateRepairFlags)
+	return migrateRepairCmd
+}
+
+func migrateRepairCommand(_ *cobra.Command, _ []string) error {
+	dbURL := migrateRepairFlags[dbURLFlag].GetString()
+	migrationsDir := migrateRepairFlags[migrationsFlag].GetString()
+	versionValue := migrateRepairFlags[versionFlag].GetString()
+	dirFormatValue := migrateRepairFlags[dirFormatFlag].GetString()
+	atlasEnv := migrateRepairFlags[atlasEnvFlag].GetString()
+	force := migrateRepairFlags[forceFlag].GetBool()
+	resumeFromValue := migrateRepairFlags[resumeFromFlag].GetString()
+	migrationsSchema := migrateRepairFlags[dbcli.MigrationsSchemaFlagName].GetString()
+	migrationsTable := migrateRepairFlags[dbcli.MigrationsTableFlagName].GetString()
+
+	if dbURL == "" {
+		return fmt.Errorf("database URL is required")
+	}
+	if migrationsDir == "" {
+		return fmt.Errorf("migrations directory is required")
+	}
+	if versionValue == "" {
+		return fmt.Errorf("migration version is required")
+	}
+
+	version, err := strconv.ParseInt(versionValue, 10, 64)
+	if err != nil || version <= 0 {
+		return fmt.Errorf("invalid migration version %q", versionValue)
+	}
+	resumeFrom, err := parseResumeFrom(resumeFromValue)
+	if err != nil {
+		return err
+	}
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	connectTimeout, err := dbcli.ParseConnectTimeout(migrateRepairFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		os.DirFS(migrationsDir),
+		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: atlasEnv}),
+	)
+	if err != nil {
+		return fmt.Errorf("error registering migrations: %w", err)
+	}
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable)
+
+	err = mig.RepairMigration(context.Background(), migrator.RepairMigrationOptions{
+		Version:    version,
+		Force:      force,
+		ResumeFrom: resumeFrom,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Repaired migration %d\n", version)
+	return nil
+}
+
+func parseResumeFrom(value string) (int, error) {
+	if value == "" {
+		return 0, nil
+	}
+	resumeFrom, err := strconv.Atoi(value)
+	if err != nil || resumeFrom <= 0 {
+		return 0, fmt.Errorf("invalid resume-from value %q", value)
+	}
+	return resumeFrom, nil
+}

--- a/cmd/migraterepair/migraterepair_test.go
+++ b/cmd/migraterepair/migraterepair_test.go
@@ -1,0 +1,40 @@
+package migraterepair
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateRepairCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrateRepairCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "migrate-repair")
+	c.Assert(cmd.Short, qt.Contains, "Repair dirty migration metadata")
+	c.Assert(cmd.Flag(dbURLFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(migrationsFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(versionFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(forceFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(resumeFromFlag), qt.IsNotNil)
+}
+
+func TestParseResumeFrom(t *testing.T) {
+	c := qt.New(t)
+
+	resumeFrom, err := parseResumeFrom("")
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumeFrom, qt.Equals, 0)
+
+	resumeFrom, err = parseResumeFrom("3")
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumeFrom, qt.Equals, 3)
+
+	_, err = parseResumeFrom("0")
+	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "0"`)
+
+	_, err = parseResumeFrom("bad")
+	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "bad"`)
+}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -162,6 +162,25 @@ func outputHuman(status *migrator.MigrationStatus, conn *dbschema.DatabaseConnec
 	fmt.Printf("Pending Migrations: %d\n", len(status.PendingMigrations))
 	fmt.Printf("Out-of-order Migrations: %d\n", len(status.OutOfOrderMigrations))
 
+	if status.DirtyRevision != nil {
+		fmt.Println("Status: ❌ Dirty migration state detected")
+		fmt.Printf(
+			"Dirty Migration: version=%d state=%s applied=%d/%d\n",
+			status.DirtyRevision.Version,
+			status.DirtyRevision.State,
+			status.DirtyRevision.Applied,
+			status.DirtyRevision.Total,
+		)
+		if status.DirtyRevision.Error != "" {
+			fmt.Printf("Error: %s\n", status.DirtyRevision.Error)
+		}
+		if status.DirtyRevision.ErrorStatement != "" {
+			fmt.Printf("Error Statement: %s\n", status.DirtyRevision.ErrorStatement)
+		}
+		fmt.Println("\nRun 'migrate-repair --version <version>' after fixing the database state.")
+		return nil
+	}
+
 	if status.HasPendingChanges {
 		fmt.Println("Status: ⚠️  Pending migrations available")
 

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migratehash"
+	"github.com/stokaro/ptah/cmd/migraterepair"
 	"github.com/stokaro/ptah/cmd/migratestatus"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/cmd/migratevalidate"
@@ -54,6 +55,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(migrate.NewMigrateCommand())
 	rootCmd.AddCommand(migrateup.NewMigrateUpCommand())
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
+	rootCmd.AddCommand(migraterepair.NewMigrateRepairCommand())
 	rootCmd.AddCommand(migratestatus.NewMigrateStatusCommand())
 	rootCmd.AddCommand(migratehash.NewMigrateHashCommand())
 	rootCmd.AddCommand(migratevalidate.NewMigrateValidateCommand())

--- a/integration/fixtures/migrations/partial_failure/0000000003_failing_migration.up.sql
+++ b/integration/fixtures/migrations/partial_failure/0000000003_failing_migration.up.sql
@@ -1,5 +1,6 @@
--- This migration should fail, causing partial failure
+-- This migration should fail after one valid statement. Transactional engines
+-- roll the table back, but the metadata row still records failed progress.
 CREATE TABLE invalid_table (
-    id SERIAL PRIMARY KEY,
-    invalid_column INVALID_TYPE_THAT_DOES_NOT_EXIST
+    id SERIAL PRIMARY KEY
 );
+SELECT * FROM missing_partial_failure_dependency;

--- a/integration/fixtures/migrations/partial_failure_mysql/0000000003_failing_migration.up.sql
+++ b/integration/fixtures/migrations/partial_failure_mysql/0000000003_failing_migration.up.sql
@@ -1,6 +1,7 @@
--- This migration intentionally fails after some successful migrations
+-- This migration intentionally fails after one successful statement. MySQL and
+-- MariaDB auto-commit most DDL, so invalid_table remains half-applied and the
+-- dirty metadata row blocks retries until repair.
 CREATE TABLE invalid_table (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    invalid_foreign_key INT NOT NULL,
-    FOREIGN KEY (invalid_foreign_key) REFERENCES nonexistent_table(id)
+    id INT AUTO_INCREMENT PRIMARY KEY
 );
+UPDATE missing_partial_failure_dependency SET id = 1;

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -306,15 +306,40 @@ func testPartialFailureRecovery(ctx context.Context, conn *dbschema.DatabaseConn
 		return fmt.Errorf("expected migration to fail, but it succeeded")
 	}
 
-	// Check what was applied before failure
+	mig, err := migrator.NewFSMigrator(conn, migrationsFS)
+	if err != nil {
+		return fmt.Errorf("failed to create migrator after partial failure: %w", err)
+	}
+	status, err := mig.GetMigrationStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get migration status after partial failure: %w", err)
+	}
+	if status.DirtyRevision == nil {
+		return fmt.Errorf("expected dirty migration revision after partial failure")
+	}
+	if status.DirtyRevision.Version != 3 {
+		return fmt.Errorf("expected dirty migration version 3, got %d", status.DirtyRevision.Version)
+	}
+	if status.DirtyRevision.Total < 2 {
+		return fmt.Errorf("expected dirty migration to record multi-statement progress, got total=%d", status.DirtyRevision.Total)
+	}
+
+	err = helper.ApplyMigrations(ctx, migrationsFS)
+	if err == nil {
+		return fmt.Errorf("expected retry to fail while dirty migration state exists")
+	}
+	if !migrator.IsDirtyMigration(err) {
+		return fmt.Errorf("expected dirty migration error on retry, got %w", err)
+	}
+
+	// Check what was applied before failure.
 	version, err := helper.GetCurrentVersion(ctx, migrationsFS)
 	if err != nil {
 		return fmt.Errorf("should be able to query version after partial failure: %w", err)
 	}
 
-	// Should have applied some but not all migrations
-	if version == 0 {
-		return fmt.Errorf("expected some migrations to be applied before failure")
+	if version != 2 {
+		return fmt.Errorf("expected completed migration version 2 after failure, got %d", version)
 	}
 
 	// Verify we can still interact with the database

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -642,7 +642,7 @@ func testDynamicMigrationSQLGeneration(ctx context.Context, conn *dbschema.Datab
 // getCurrentMigrationVersion gets the current migration version from the database
 func getCurrentMigrationVersion(ctx context.Context, conn *dbschema.DatabaseConnection) (int64, error) {
 	// Query the schema_migrations table to get the highest version
-	query := "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+	query := "SELECT COALESCE(MAX(version), 0) FROM schema_migrations WHERE state = 'applied'"
 	row := conn.QueryRow(query)
 
 	var version int64
@@ -651,6 +651,14 @@ func getCurrentMigrationVersion(ctx context.Context, conn *dbschema.DatabaseConn
 	}
 
 	return version, nil
+}
+
+func clearMigrationRevision(ctx context.Context, conn *dbschema.DatabaseConnection, version int64) error {
+	query := sqlutil.Rebind(conn.Info().Dialect, "DELETE FROM schema_migrations WHERE version = ?")
+	if _, err := conn.ExecContext(ctx, query, version); err != nil {
+		return fmt.Errorf("failed to delete migration revision %d: %w", version, err)
+	}
+	return nil
 }
 
 // contains checks if a string contains a substring (case-insensitive)
@@ -1064,13 +1072,17 @@ func testDynamicPartialFailureRecovery(ctx context.Context, conn *dbschema.Datab
 			return fmt.Errorf("expected migration to fail, but it succeeded")
 		}
 
-		// Verify we're still at version 2 (the invalid migration should not have been recorded)
+		// Verify we're still at version 2. The invalid migration leaves a dirty
+		// metadata row, but dirty rows must not count as applied.
 		currentVersion, err := getCurrentMigrationVersion(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("failed to get current version after failure: %w", err)
 		}
 		if currentVersion != 2 {
 			return fmt.Errorf("expected version 2 after failed migration, got %d", currentVersion)
+		}
+		if err := clearMigrationRevision(ctx, conn, 999); err != nil {
+			return fmt.Errorf("failed to clear synthetic dirty migration: %w", err)
 		}
 
 		return nil
@@ -2084,6 +2096,9 @@ func testDynamicForeignKeyCascade(ctx context.Context, conn *dbschema.DatabaseCo
 		// This should fail due to foreign key constraint
 		if err := m.MigrateUp(ctx); err == nil {
 			return fmt.Errorf("dropping parent table should fail due to FK constraint")
+		}
+		if err := clearMigrationRevision(ctx, conn, 2); err != nil {
+			return fmt.Errorf("failed to clear synthetic dirty migration: %w", err)
 		}
 		return nil
 	})

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -344,11 +344,25 @@ The migrator automatically creates a `schema_migrations` table to track applied 
 
 ```sql
 CREATE TABLE schema_migrations (
-    version INTEGER PRIMARY KEY,
+    version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
-    applied_at TIMESTAMP NOT NULL
+    applied_at TIMESTAMP NOT NULL,
+    state VARCHAR(32) NOT NULL DEFAULT 'applied',
+    applied INTEGER NOT NULL DEFAULT 1,
+    total INTEGER NOT NULL DEFAULT 1,
+    error TEXT NULL,
+    error_stmt TEXT NULL,
+    execution_time_ms BIGINT NOT NULL DEFAULT 0,
+    checksum VARCHAR(64) NOT NULL DEFAULT ''
 );
 ```
+
+Rows are written as `pending` before migration SQL executes, then marked
+`applied` after success. Failed or interrupted runs leave a dirty row with
+statement progress and error details; later migration operations refuse to
+continue until `RepairMigration` or the `migrate-repair` CLI resolves it.
+Applied rows store an up-SQL checksum, so editing an already-applied migration
+file is detected before new work starts.
 
 ## Best Practices
 

--- a/migration/migrator/dirty_state_integration_test.go
+++ b/migration/migrator/dirty_state_integration_test.go
@@ -1,0 +1,237 @@
+package migrator_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue265Names("postgres")
+	cleanupIssue265(t, conn, names)
+	defer cleanupIssue265(t, conn, names)
+
+	mig := issue265Migrator(conn, names, issue265PostgresMigrations(names)...)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, "(?s).*failed to apply migration 2.*missing_table.*")
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+	c.Assert(status.DirtyRevision.Version, qt.Equals, int64(2))
+	c.Assert(status.DirtyRevision.State, qt.Equals, "failed")
+	c.Assert(status.DirtyRevision.Applied, qt.Equals, 0)
+	c.Assert(status.DirtyRevision.Total, qt.Equals, 2)
+	c.Assert(status.DirtyRevision.ErrorStatement, qt.Contains, "missing_table")
+	c.Assert(tableExists(t, conn, names.partialTable), qt.IsFalse)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+}
+
+func TestDirtyMigrationState_MySQLRepairReachesHead(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runIssue265MySQLFamilyRepair(t, dbURL, "mysql")
+}
+
+func TestDirtyMigrationState_MariaDBRepairReachesHead(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runIssue265MySQLFamilyRepair(t, dbURL, "mariadb")
+}
+
+func TestMigrationChecksumMismatch_PostgresIntegration(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue265Names("checksum")
+	cleanupIssue265(t, conn, names)
+	defer cleanupIssue265(t, conn, names)
+
+	err = issue265Migrator(conn, names, migrator.CreateMigrationFromSQL(
+		1,
+		"initial",
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.baseTable),
+		fmt.Sprintf("DROP TABLE %s", names.baseTable),
+	)).MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+
+	changed := issue265Migrator(conn, names, migrator.CreateMigrationFromSQL(
+		1,
+		"initial",
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY, changed TEXT)", names.baseTable),
+		fmt.Sprintf("DROP TABLE %s", names.baseTable),
+	))
+	err = changed.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "checksum mismatch")
+}
+
+type issue265TestNames struct {
+	migrationsTable string
+	baseTable       string
+	partialTable    string
+	headTable       string
+}
+
+func issue265Names(prefix string) issue265TestNames {
+	suffix := fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	return issue265TestNames{
+		migrationsTable: "schema_migrations_issue_265_" + suffix,
+		baseTable:       "ptah_issue_265_base_" + suffix,
+		partialTable:    "ptah_issue_265_partial_" + suffix,
+		headTable:       "ptah_issue_265_head_" + suffix,
+	}
+}
+
+func issue265Migrator(
+	conn *dbschema.DatabaseConnection,
+	names issue265TestNames,
+	migrations ...*migrator.Migration,
+) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationsTable("", names.migrationsTable).
+		WithMigrationLockTimeout(10 * time.Second)
+}
+
+func issue265PostgresMigrations(names issue265TestNames) []*migrator.Migration {
+	return []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(
+			1,
+			"base",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.baseTable),
+			fmt.Sprintf("DROP TABLE %s", names.baseTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			2,
+			"failing partial",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY); SELECT * FROM missing_table", names.partialTable),
+			fmt.Sprintf("DROP TABLE %s", names.partialTable),
+		),
+	}
+}
+
+func issue265MySQLFamilyMigrations(names issue265TestNames) []*migrator.Migration {
+	return []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(
+			1,
+			"base",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.baseTable),
+			fmt.Sprintf("DROP TABLE %s", names.baseTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			2,
+			"half applied",
+			fmt.Sprintf("ALTER TABLE %s ADD COLUMN nickname VARCHAR(64); UPDATE missing_table SET value = 1", names.baseTable),
+			fmt.Sprintf("ALTER TABLE %s DROP COLUMN nickname", names.baseTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			3,
+			"head",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.headTable),
+			fmt.Sprintf("DROP TABLE %s", names.headTable),
+		),
+	}
+}
+
+func runIssue265MySQLFamilyRepair(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue265Names(dialect)
+	cleanupIssue265(t, conn, names)
+	defer cleanupIssue265(t, conn, names)
+
+	migrations := issue265MySQLFamilyMigrations(names)
+	mig := issue265Migrator(conn, names, migrations...)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, "(?s).*failed to apply migration 2.*missing_table.*")
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+	c.Assert(status.DirtyRevision.Version, qt.Equals, int64(2))
+	c.Assert(status.DirtyRevision.Applied, qt.Equals, 1)
+	c.Assert(status.DirtyRevision.Total, qt.Equals, 2)
+	c.Assert(issue265ColumnExists(t, conn, names.baseTable, "nickname"), qt.IsTrue)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+
+	err = mig.RepairMigration(ctx, migrator.RepairMigrationOptions{Version: 2})
+	c.Assert(err, qt.IsNil)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue265TableExists(t, conn, names.headTable), qt.IsTrue)
+}
+
+func issue265ColumnExists(t *testing.T, conn *dbschema.DatabaseConnection, table, column string) bool {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?",
+		table,
+		column,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count > 0
+}
+
+func issue265TableExists(t *testing.T, conn *dbschema.DatabaseConnection, tableName string) bool {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?",
+		tableName,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count > 0
+}
+
+func cleanupIssue265(t *testing.T, conn *dbschema.DatabaseConnection, names issue265TestNames) {
+	t.Helper()
+
+	for _, statement := range []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.migrationsTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.headTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.partialTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.baseTable),
+	} {
+		if strings.TrimSpace(statement) == "" {
+			continue
+		}
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -80,10 +80,21 @@
 //	CREATE TABLE schema_migrations (
 //		version BIGINT PRIMARY KEY,
 //		description TEXT NOT NULL,
-//		applied_at TIMESTAMP NOT NULL
+//		applied_at TIMESTAMP NOT NULL,
+//		state VARCHAR(32) NOT NULL DEFAULT 'applied',
+//		applied INTEGER NOT NULL DEFAULT 1,
+//		total INTEGER NOT NULL DEFAULT 1,
+//		error TEXT NULL,
+//		error_stmt TEXT NULL,
+//		execution_time_ms BIGINT NOT NULL DEFAULT 0,
+//		checksum VARCHAR(64) NOT NULL DEFAULT ''
 //	);
 //
-// This table tracks which migrations have been applied and when. Use
+// This table tracks which migrations have been applied and when. Failed or
+// interrupted migrations leave a dirty revision row with statement progress and
+// error details; later migration operations refuse to continue until the row is
+// repaired. Applied rows also store a checksum of the up SQL so edited
+// migration files are detected before new work starts. Use
 // WithMigrationsTable(schema, table) to store migration history in a custom
 // schema or table, for example an `infra.ptah_migrations` table in PostgreSQL.
 //
@@ -103,6 +114,7 @@
 //   - GetAppliedMigrations(): List all applied migration versions
 //   - GetPendingMigrations(): List all pending migration versions
 //   - GetMigrationStatus(): Get comprehensive migration status information
+//   - RepairMigration(opts): Clear a dirty migration after manual repair, or resume remaining up statements
 //
 // # Migration Providers
 //
@@ -119,8 +131,8 @@
 //
 //   - If a migration succeeds, the transaction is committed
 //   - If a migration fails, the transaction is rolled back
-//   - Migration history is updated only after successful execution
-//   - Partial failures leave the database in a consistent state
+//   - Migration history is marked pending before execution and applied only after success
+//   - Partial failures leave dirty migration metadata that blocks later migration operations
 //
 // # SQL File Support
 //

--- a/migration/migrator/interceptor_test.go
+++ b/migration/migrator/interceptor_test.go
@@ -85,7 +85,7 @@ func TestMigrationFuncFromSQLFilenameWithInterceptor_ErrorAbortsMigration(t *tes
 
 	fn := migrator.MigrationFuncFromSQLFilenameWithInterceptor("m.sql", fsys, interceptor)
 	err := fn(context.Background(), nil)
-	c.Assert(err, qt.ErrorMatches, "failed to execute migration SQL: .*")
+	c.Assert(err, qt.ErrorMatches, "(?s)failed to execute migration SQL: .*")
 }
 
 func TestMigrationFuncFromSQLFilenameWithInterceptor_AtlasTxtarExecutesMigrationSectionOnly(t *testing.T) {

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -163,6 +163,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 				return up.fn(ctx, conn, migration.executionMode())
 			}
+			migration.UpSQL = up.sql
 			migration.UpTimeouts = up.timeouts
 			migration.NoTransaction = migration.NoTransaction || up.noTransaction
 		case "down":
@@ -173,6 +174,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 				return down.fn(ctx, conn, migration.executionMode())
 			}
+			migration.DownSQL = down.sql
 			migration.DownTimeouts = down.timeouts
 			migration.NoTransaction = migration.NoTransaction || down.noTransaction
 		default:
@@ -299,6 +301,7 @@ func setAtlasUp(parts *atlasParts, up sqlMigrationFile) {
 	migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 		return up.fn(ctx, conn, migration.executionMode())
 	}
+	migration.UpSQL = up.sql
 	migration.UpTimeouts = up.timeouts
 	migration.NoTransaction = migration.NoTransaction || up.noTransaction
 	parts.hasUp = true
@@ -309,6 +312,7 @@ func setAtlasDown(parts *atlasParts, down sqlMigrationFile) {
 	migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 		return down.fn(ctx, conn, migration.executionMode())
 	}
+	migration.DownSQL = down.sql
 	migration.DownTimeouts = down.timeouts
 	migration.NoTransaction = migration.NoTransaction || down.noTransaction
 	parts.hasDown = true

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -51,6 +51,7 @@ type sqlMigrationFunc func(context.Context, *dbschema.DatabaseConnection, migrat
 
 type sqlMigrationFile struct {
 	fn            sqlMigrationFunc
+	sql           string
 	timeouts      MigrationTimeouts
 	noTransaction bool
 }
@@ -232,6 +233,7 @@ func migrationFuncFromSQLStringWithMetadata(filename, sql string, interceptor St
 		fn: func(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
 			return executeMigrationFileSQL(ctx, conn, filename, sql, interceptor, mode)
 		},
+		sql:           sql,
 		timeouts:      timeouts,
 		noTransaction: noTransaction,
 	}, nil
@@ -334,6 +336,8 @@ type Migration struct {
 	Description     string
 	Up              MigrationFunc
 	Down            MigrationFunc
+	UpSQL           string
+	DownSQL         string
 	UpTimeouts      MigrationTimeouts
 	DownTimeouts    MigrationTimeouts
 	downUnavailable bool
@@ -360,6 +364,8 @@ func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *
 	migration := &Migration{
 		Version:       version,
 		Description:   description,
+		UpSQL:         upSQL,
+		DownSQL:       downSQL,
 		NoTransaction: upNoTransaction || downNoTransaction,
 	}
 
@@ -387,14 +393,19 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 	// Split SQL by semicolons and execute each statement
 	statements := SplitSQLStatements(sql)
 
-	for _, stmt := range statements {
+	for i, stmt := range statements {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue // Skip empty statements and comments
 		}
 
 		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
-			return fmt.Errorf("failed to execute SQL statement: %w\nSQL: %s", err, stmt)
+			return &MigrationExecutionError{
+				Err:            fmt.Errorf("failed to execute SQL statement: %w", err),
+				Statement:      stmt,
+				StatementIndex: i + 1,
+				Total:          len(statements),
+			}
 		}
 	}
 
@@ -421,7 +432,7 @@ func executeMigrationFileSQL(
 	}
 
 	statements := SplitSQLStatements(sql)
-	for _, stmt := range statements {
+	for i, stmt := range statements {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
 			continue
@@ -430,7 +441,12 @@ func executeMigrationFileSQL(
 		if interceptor != nil {
 			handled, err := interceptor.ExecuteStatement(ctx, conn, stmt, directives)
 			if err != nil {
-				return fmt.Errorf("failed to execute migration SQL: %w", err)
+				return &MigrationExecutionError{
+					Err:            fmt.Errorf("failed to execute migration SQL: %w", err),
+					Statement:      stmt,
+					StatementIndex: i + 1,
+					Total:          len(statements),
+				}
 			}
 			if handled {
 				continue
@@ -438,10 +454,32 @@ func executeMigrationFileSQL(
 		}
 
 		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
-			return fmt.Errorf("failed to execute migration SQL: %w", err)
+			return &MigrationExecutionError{
+				Err:            fmt.Errorf("failed to execute migration SQL: %w", err),
+				Statement:      stmt,
+				StatementIndex: i + 1,
+				Total:          len(statements),
+			}
 		}
 	}
 	return nil
+}
+
+// MigrationExecutionError reports the statement that failed while applying a
+// SQL migration.
+type MigrationExecutionError struct {
+	Err            error
+	Statement      string
+	StatementIndex int
+	Total          int
+}
+
+func (e *MigrationExecutionError) Error() string {
+	return fmt.Sprintf("%v\nSQL: %s", e.Err, e.Statement)
+}
+
+func (e *MigrationExecutionError) Unwrap() error {
+	return e.Err
 }
 
 func executeMigrationStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, mode migrationExecutionMode) error {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -16,12 +16,13 @@ import (
 
 // MigrationStatus represents the current state of migrations
 type MigrationStatus struct {
-	CurrentVersion       int64   `json:"current_version"`
-	AppliedMigrations    []int64 `json:"applied_migrations"`
-	PendingMigrations    []int64 `json:"pending_migrations"`
-	OutOfOrderMigrations []int64 `json:"out_of_order_migrations"`
-	TotalMigrations      int     `json:"total_migrations"`
-	HasPendingChanges    bool    `json:"has_pending_changes"`
+	CurrentVersion       int64              `json:"current_version"`
+	AppliedMigrations    []int64            `json:"applied_migrations"`
+	PendingMigrations    []int64            `json:"pending_migrations"`
+	OutOfOrderMigrations []int64            `json:"out_of_order_migrations"`
+	TotalMigrations      int                `json:"total_migrations"`
+	HasPendingChanges    bool               `json:"has_pending_changes"`
+	DirtyRevision        *MigrationRevision `json:"dirty_revision,omitempty"`
 }
 
 // Migrator handles database migrations for ptah
@@ -122,20 +123,23 @@ func (m *Migrator) createMigrationsTableSQL() string {
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
     version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
-    applied_at TIMESTAMP NOT NULL
+    applied_at TIMESTAMP NOT NULL,
+    state VARCHAR(32) NOT NULL DEFAULT 'applied',
+    applied INTEGER NOT NULL DEFAULT 1,
+    total INTEGER NOT NULL DEFAULT 1,
+    error TEXT NULL,
+    error_stmt TEXT NULL,
+    execution_time_ms BIGINT NOT NULL DEFAULT 0,
+    checksum VARCHAR(64) NOT NULL DEFAULT ''
 )`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) getVersionSQL() string {
-	return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s", m.qualifiedMigrationsTable())
+	return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s WHERE state = 'applied'", m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) getAppliedMigrationsSQL() string {
-	return fmt.Sprintf("SELECT version FROM %s ORDER BY version", m.qualifiedMigrationsTable())
-}
-
-func (m *Migrator) recordMigrationSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version, description, applied_at) VALUES (?, ?, ?)", m.qualifiedMigrationsTable())
+	return fmt.Sprintf("SELECT version FROM %s WHERE state = 'applied' ORDER BY version", m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) deleteMigrationSQL() string {
@@ -172,10 +176,82 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 	if err := m.ensureMigrationsVersionColumn(ctx); err != nil {
 		return fmt.Errorf("failed to prepare migrations version column: %w", err)
 	}
+	if err := m.ensureMigrationsRevisionColumns(ctx); err != nil {
+		return fmt.Errorf("failed to prepare migrations revision columns: %w", err)
+	}
 
 	// Mark as initialized
 	m.initialized = true
 	return nil
+}
+
+func (m *Migrator) ensureMigrationsRevisionColumns(ctx context.Context) error {
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "state", definition: "VARCHAR(32) NOT NULL DEFAULT 'applied'"},
+		{name: "applied", definition: "INTEGER NOT NULL DEFAULT 1"},
+		{name: "total", definition: "INTEGER NOT NULL DEFAULT 1"},
+		{name: "error", definition: "TEXT NULL"},
+		{name: "error_stmt", definition: "TEXT NULL"},
+		{name: "execution_time_ms", definition: "BIGINT NOT NULL DEFAULT 0"},
+		{name: "checksum", definition: "VARCHAR(64) NOT NULL DEFAULT ''"},
+	}
+	for _, column := range columns {
+		if err := m.ensureMigrationsRevisionColumn(ctx, column.name, column.definition); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) ensureMigrationsRevisionColumn(ctx context.Context, name, definition string) error {
+	exists, err := m.migrationsColumnExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	query := fmt.Sprintf(
+		"ALTER TABLE %s ADD COLUMN %s %s",
+		m.qualifiedMigrationsTable(),
+		m.quoteIdentifier(name),
+		definition,
+	)
+	if _, err := m.conn.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("failed to add migrations metadata column %s: %w", name, err)
+	}
+	return nil
+}
+
+func (m *Migrator) migrationsColumnExists(ctx context.Context, name string) (bool, error) {
+	if m.conn.Info().Dialect == "clickhouse" {
+		return m.clickHouseMigrationsColumnExists(ctx, name)
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, `
+SELECT COUNT(*)
+FROM information_schema.columns
+WHERE table_schema = ? AND table_name = ? AND column_name = ?`)
+	var count int
+	if err := m.conn.QueryRowContext(ctx, query, m.metadataSchemaName(), m.migrationsTableName(), name).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to inspect migrations metadata column %s: %w", name, err)
+	}
+	return count > 0, nil
+}
+
+func (m *Migrator) clickHouseMigrationsColumnExists(ctx context.Context, name string) (bool, error) {
+	var count int
+	if err := m.conn.QueryRowContext(
+		ctx,
+		`SELECT count() FROM system.columns WHERE database = currentDatabase() AND table = ? AND name = ?`,
+		m.migrationsTableName(),
+		name,
+	).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to inspect migrations metadata column %s: %w", name, err)
+	}
+	return count > 0, nil
 }
 
 func (m *Migrator) ensureMigrationsVersionColumn(ctx context.Context) error {
@@ -358,6 +434,10 @@ func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, er
 	currentVersion := maxAppliedVersion(appliedMigrations)
 	pendingMigrations := pendingMigrationVersions(m.MigrationProvider().Migrations(), appliedMigrations)
 	outOfOrderMigrations := outOfOrderMigrationVersions(pendingMigrations, currentVersion)
+	dirtyRevision, err := m.dirtyRevision(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dirty migration revision: %w", err)
+	}
 
 	return &MigrationStatus{
 		CurrentVersion:       currentVersion,
@@ -365,7 +445,8 @@ func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, er
 		PendingMigrations:    pendingMigrations,
 		OutOfOrderMigrations: outOfOrderMigrations,
 		TotalMigrations:      len(m.MigrationProvider().Migrations()),
-		HasPendingChanges:    len(pendingMigrations) > 0,
+		HasPendingChanges:    len(pendingMigrations) > 0 || dirtyRevision != nil,
+		DirtyRevision:        dirtyRevision,
 	}, nil
 }
 
@@ -379,6 +460,9 @@ func (m *Migrator) migrateUpLocked(ctx context.Context) error {
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
+	if err := m.failIfDirty(ctx); err != nil {
+		return err
+	}
 
 	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
@@ -387,6 +471,9 @@ func (m *Migrator) migrateUpLocked(ctx context.Context) error {
 	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	migrations := m.migrationProvider.Migrations()
+	if err := m.verifyAppliedMigrationChecksums(ctx, migrations); err != nil {
+		return err
+	}
 	migrationsToApply, err := m.migrationsToApply(migrations, appliedMigrations, 0)
 	if err != nil {
 		return err
@@ -413,6 +500,9 @@ func (m *Migrator) migrateDownLocked(ctx context.Context) error {
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
+	if err := m.failIfDirty(ctx); err != nil {
+		return err
+	}
 
 	targetVersion, err := m.GetPreviousMigrationVersion(ctx)
 	if err != nil {
@@ -434,6 +524,9 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64)
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
+	if err := m.failIfDirty(ctx); err != nil {
+		return err
+	}
 
 	appliedMigrations, err := m.GetAppliedMigrations(ctx)
 	if err != nil {
@@ -448,6 +541,9 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64)
 	}
 
 	migrationMap := migrationsByVersion(m.migrationProvider.Migrations())
+	if err := m.verifyAppliedMigrationChecksums(ctx, m.migrationProvider.Migrations()); err != nil {
+		return err
+	}
 	migrationsToRollback, err := migrationsToRollback(migrationMap, appliedMigrations, targetVersion)
 	if err != nil {
 		return err
@@ -460,55 +556,9 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64)
 	deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
 
 	for _, migration := range migrationsToRollback {
-		m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
-		if migration.downUnavailable {
-			if err := migration.Down(ctx, m.conn); err != nil {
-				return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
-			}
-			continue
-		}
-		if migration.NoTransaction {
-			if err := m.rollbackMigrationNoTransaction(ctx, migration, deleteSQL); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// Begin transaction for this migration rollback
-		if err := m.conn.Writer().BeginTransaction(); err != nil {
-			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
-		}
-
-		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts))
-		if err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
-		}
-
-		// Apply down migration
-		if err := migration.Down(ctx, m.conn); err != nil {
-			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
-		}
-
-		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
+		if err := m.rollbackMigration(ctx, migration, deleteSQL); err != nil {
 			return err
 		}
-
-		// Remove migration record.
-		if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
-		}
-
-		// Commit transaction
-		if err := m.conn.Writer().CommitTransaction(); err != nil {
-			return fmt.Errorf("failed to commit transaction for migration %d: %w", migration.Version, err)
-		}
-
-		m.logger.Info("Rolled back migration", "version", migration.Version, "description", migration.Description)
 	}
 
 	m.logger.Info("All migrations rolled back successfully")
@@ -526,6 +576,9 @@ func (m *Migrator) migrateToLocked(ctx context.Context, targetVersion int64) err
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
+	}
+	if err := m.failIfDirty(ctx); err != nil {
+		return err
 	}
 
 	appliedMigrations, err := m.GetAppliedMigrations(ctx)
@@ -566,6 +619,9 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int64) error {
 	currentVersion := maxAppliedVersion(appliedMigrations)
 
 	migrations := m.migrationProvider.Migrations()
+	if err := m.verifyAppliedMigrationChecksums(ctx, migrations); err != nil {
+		return err
+	}
 	migrationsToApply, err := m.migrationsToApply(migrations, appliedMigrations, targetVersion)
 	if err != nil {
 		return err
@@ -581,86 +637,259 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int64) error {
 }
 
 func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migration) error {
-	// Rebind once: the template and dialect are loop-invariant. Values are
-	// still bound as native driver parameters via these placeholders so we
-	// never interpolate user-controlled strings into the SQL text.
-	recordSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.recordMigrationSQL())
-
 	for _, migration := range migrations {
+		startedAt := time.Now()
 		m.logger.Info("Applying migration", "version", migration.Version, "description", migration.Description)
+		if err := m.beginMigrationRevision(ctx, migration); err != nil {
+			return fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
+		}
 		if migration.NoTransaction {
-			if err := m.applyUpMigrationNoTransaction(ctx, migration, recordSQL); err != nil {
+			if err := m.applyUpMigrationNoTransaction(ctx, migration, startedAt); err != nil {
 				return err
 			}
 			continue
 		}
 
-		// Begin transaction for this migration
-		if err := m.conn.Writer().BeginTransaction(); err != nil {
-			return fmt.Errorf("failed to begin transaction for migration %d: %w", migration.Version, err)
-		}
-
-		restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
-		if err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to apply timeouts for migration %d: %w", migration.Version, err)
-		}
-
-		// Apply migration
-		if err := migration.Up(ctx, m.conn); err != nil {
-			err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
-		}
-
-		if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
+		if err := m.applyUpMigrationTransactional(ctx, migration, startedAt); err != nil {
 			return err
 		}
-
-		// Record migration via parameter binding.
-		if err := m.conn.Writer().ExecuteSQL(ctx, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
-			_ = m.conn.Writer().RollbackTransaction()
-			return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
-		}
-
-		// Commit transaction
-		if err := m.conn.Writer().CommitTransaction(); err != nil {
-			return fmt.Errorf("failed to commit transaction for migration %d: %w", migration.Version, err)
-		}
-
-		m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
 	}
 
 	return nil
 }
 
-func (m *Migrator) applyUpMigrationNoTransaction(ctx context.Context, migration *Migration, recordSQL string) error {
+func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration *Migration, startedAt time.Time) error {
+	if err := m.conn.Writer().BeginTransaction(); err != nil {
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to begin transaction for migration %d", migration.Version),
+		)
+	}
+
+	restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
+	if err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to apply timeouts for migration %d", migration.Version),
+		)
+	}
+
+	if err := migration.Up(ctx, m.conn); err != nil {
+		err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to apply migration %d", migration.Version),
+		)
+	}
+
+	if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.UpSQL, "")
+	}
+
+	if err := m.conn.Writer().CommitTransaction(); err != nil {
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to commit transaction for migration %d", migration.Version),
+		)
+	}
+	if err := m.completeMigrationRevision(ctx, migration, startedAt); err != nil {
+		return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
+	}
+
+	m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
+	return nil
+}
+
+func (m *Migrator) applyUpMigrationNoTransaction(ctx context.Context, migration *Migration, startedAt time.Time) error {
 	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts)); err != nil {
-		return err
+		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.UpSQL, "")
 	}
 	if err := migration.Up(ctx, m.conn); err != nil {
-		return fmt.Errorf("failed to apply migration %d: %w", migration.Version, err)
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to apply migration %d", migration.Version),
+		)
 	}
-	if err := executeSQLOutsideTransaction(ctx, m.conn, recordSQL, migration.Version, migration.Description, time.Now()); err != nil {
+	if err := m.completeMigrationRevision(ctx, migration, startedAt); err != nil {
 		return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Applied non-transactional migration", "version", migration.Version, "description", migration.Description)
 	return nil
 }
 
-func (m *Migrator) rollbackMigrationNoTransaction(ctx context.Context, migration *Migration, deleteSQL string) error {
+func (m *Migrator) rollbackMigration(ctx context.Context, migration *Migration, deleteSQL string) error {
+	startedAt := time.Now()
+	m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
+	if err := m.beginRollbackRevision(ctx, migration); err != nil {
+		return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
+	}
+	if migration.downUnavailable {
+		return m.rollbackMigrationWithoutRegisteredDown(ctx, migration, startedAt, deleteSQL)
+	}
+	if migration.NoTransaction {
+		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
+	}
+	return m.rollbackMigrationTransactional(ctx, migration, startedAt, deleteSQL)
+}
+
+func (m *Migrator) rollbackMigrationWithoutRegisteredDown(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	deleteSQL string,
+) error {
+	if err := migration.Down(ctx, m.conn); err != nil {
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to revert migration %d", migration.Version),
+		)
+	}
+	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
+	}
+	m.logger.Info("Rolled back migration", "version", migration.Version, "description", migration.Description)
+	return nil
+}
+
+func (m *Migrator) rollbackMigrationTransactional(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	deleteSQL string,
+) error {
+	if err := m.conn.Writer().BeginTransaction(); err != nil {
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to begin transaction for migration %d", migration.Version),
+		)
+	}
+
+	restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts))
+	if err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to apply timeouts for migration %d", migration.Version),
+		)
+	}
+
+	if err := migration.Down(ctx, m.conn); err != nil {
+		err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to revert migration %d", migration.Version),
+		)
+	}
+
+	if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.DownSQL, "")
+	}
+
+	if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
+	}
+
+	if err := m.conn.Writer().CommitTransaction(); err != nil {
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to commit transaction for migration %d", migration.Version),
+		)
+	}
+
+	m.logger.Info("Rolled back migration", "version", migration.Version, "description", migration.Description)
+	return nil
+}
+
+func (m *Migrator) rollbackMigrationNoTransaction(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	deleteSQL string,
+) error {
 	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts)); err != nil {
-		return err
+		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.DownSQL, "")
 	}
 	if err := migration.Down(ctx, m.conn); err != nil {
-		return fmt.Errorf("failed to revert migration %d: %w", migration.Version, err)
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to revert migration %d", migration.Version),
+		)
 	}
 	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
 		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Rolled back non-transactional migration", "version", migration.Version, "description", migration.Description)
 	return nil
+}
+
+func (m *Migrator) failMigrationWithDirtyState(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	failure error,
+	sqlText string,
+	prefix string,
+) error {
+	if revisionErr := m.failMigrationRevision(ctx, migration, startedAt, failure, sqlText); revisionErr != nil {
+		if prefix == "" {
+			return fmt.Errorf("%w; additionally failed to record dirty migration state: %v", failure, revisionErr)
+		}
+		return fmt.Errorf("%s: %w; additionally failed to record dirty migration state: %v", prefix, failure, revisionErr)
+	}
+	if prefix == "" {
+		return failure
+	}
+	return fmt.Errorf("%s: %w", prefix, failure)
 }
 
 func ensureNoTransactionHasNoTimeouts(version int64, timeouts MigrationTimeouts) error {

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -293,6 +293,9 @@ func parseRevisionAppliedAtString(value string) (time.Time, error) {
 }
 
 func (m *Migrator) failIfDirty(ctx context.Context) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
 	revision, err := m.dirtyRevision(ctx)
 	if err != nil {
 		return err

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -1,0 +1,520 @@
+package migrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+)
+
+const (
+	migrationStateApplied = "applied"
+	migrationStatePending = "pending"
+	migrationStateFailed  = "failed"
+)
+
+// MigrationRevision records one row from the migration metadata table.
+type MigrationRevision struct {
+	Version         int64         `json:"version"`
+	Description     string        `json:"description"`
+	State           string        `json:"state"`
+	Applied         int           `json:"applied"`
+	Total           int           `json:"total"`
+	Error           string        `json:"error,omitempty"`
+	ErrorStatement  string        `json:"error_stmt,omitempty"`
+	ExecutionTime   time.Duration `json:"execution_time"`
+	Checksum        string        `json:"checksum,omitempty"`
+	AppliedAt       time.Time     `json:"applied_at"`
+	Dirty           bool          `json:"dirty"`
+	ChecksumCurrent string        `json:"checksum_current,omitempty"`
+}
+
+// DirtyMigrationError reports that a previous migration run left a dirty row.
+type DirtyMigrationError struct {
+	Revision MigrationRevision
+}
+
+func (e *DirtyMigrationError) Error() string {
+	return fmt.Sprintf(
+		"migration %d is dirty: state=%s applied=%d/%d error=%q error_stmt=%q",
+		e.Revision.Version,
+		e.Revision.State,
+		e.Revision.Applied,
+		e.Revision.Total,
+		e.Revision.Error,
+		e.Revision.ErrorStatement,
+	)
+}
+
+// IsDirtyMigration reports whether err wraps a dirty migration error.
+func IsDirtyMigration(err error) bool {
+	var target *DirtyMigrationError
+	return errors.As(err, &target)
+}
+
+// ChecksumMismatchError reports that an already-applied migration file changed.
+type ChecksumMismatchError struct {
+	Version  int64
+	Stored   string
+	Computed string
+}
+
+func (e *ChecksumMismatchError) Error() string {
+	return fmt.Sprintf("migration %d checksum mismatch: stored %s, current %s", e.Version, e.Stored, e.Computed)
+}
+
+// RepairMigrationOptions configures migration metadata repair.
+type RepairMigrationOptions struct {
+	Version    int64
+	Force      bool
+	ResumeFrom int
+}
+
+func migrationChecksum(sqlText string) string {
+	sum := sha256.Sum256([]byte(sqlText))
+	return hex.EncodeToString(sum[:])
+}
+
+func migrationStatementCount(sqlText string) int {
+	return len(SplitSQLStatements(sqlText))
+}
+
+func migrationExecutionProgress(err error, dialect string) (applied int, total int, stmt string) {
+	var execErr *MigrationExecutionError
+	if !errors.As(err, &execErr) {
+		return 0, 0, ""
+	}
+
+	total = execErr.Total
+	applied = execErr.StatementIndex - 1
+	if dialect == "postgres" || dialect == "cockroachdb" || dialect == "yugabytedb" {
+		applied = 0
+	}
+	if applied < 0 {
+		applied = 0
+	}
+	return applied, total, execErr.Statement
+}
+
+func (m *Migrator) getDirtyRevisionSQL() string {
+	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+FROM %s
+WHERE state <> ?
+ORDER BY version
+LIMIT 1`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) getRevisionSQL() string {
+	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+FROM %s
+WHERE version = ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) beginMigrationSQL() string {
+	return fmt.Sprintf(`INSERT INTO %s (version, description, applied_at, state, applied, total, error, error_stmt, execution_time_ms, checksum)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) completeMigrationSQL() string {
+	if m.isClickHouse() {
+		return fmt.Sprintf(`ALTER TABLE %s
+UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?
+WHERE version = ?
+SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+	}
+	return fmt.Sprintf(`UPDATE %s
+SET state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) beginRollbackSQL() string {
+	if m.isClickHouse() {
+		return fmt.Sprintf(`ALTER TABLE %s
+UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?
+WHERE version = ?
+SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+	}
+	return fmt.Sprintf(`UPDATE %s
+SET state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) failMigrationSQL() string {
+	if m.isClickHouse() {
+		return fmt.Sprintf(`ALTER TABLE %s
+UPDATE state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?
+WHERE version = ?
+SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+	}
+	return fmt.Sprintf(`UPDATE %s
+SET state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) forceAppliedMigrationSQL() string {
+	return fmt.Sprintf(`INSERT INTO %s (version, description, applied_at, state, applied, total, error, error_stmt, execution_time_ms, checksum)
+VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+%s`, m.qualifiedMigrationsTable(), m.forceAppliedConflictClause())
+}
+
+func (m *Migrator) forceAppliedUpdateSQL() string {
+	return fmt.Sprintf(`ALTER TABLE %s
+UPDATE description = ?, applied_at = ?, state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, checksum = ?
+WHERE version = ?
+SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) isClickHouse() bool {
+	return m.conn != nil && m.conn.Info().Dialect == "clickhouse"
+}
+
+func (m *Migrator) forceAppliedConflictClause() string {
+	if m.conn == nil {
+		return ""
+	}
+	switch m.conn.Info().Dialect {
+	case "postgres", "cockroachdb", "yugabytedb":
+		return `ON CONFLICT (version) DO UPDATE SET
+description = EXCLUDED.description,
+applied_at = EXCLUDED.applied_at,
+state = EXCLUDED.state,
+applied = EXCLUDED.applied,
+total = EXCLUDED.total,
+error = NULL,
+error_stmt = NULL,
+execution_time_ms = EXCLUDED.execution_time_ms,
+checksum = EXCLUDED.checksum`
+	case "mysql", "mariadb":
+		return `ON DUPLICATE KEY UPDATE
+description = VALUES(description),
+applied_at = VALUES(applied_at),
+state = VALUES(state),
+applied = VALUES(applied),
+total = VALUES(total),
+error = NULL,
+error_stmt = NULL,
+execution_time_ms = VALUES(execution_time_ms),
+checksum = VALUES(checksum)`
+	default:
+		return ""
+	}
+}
+
+func (m *Migrator) dirtyRevision(ctx context.Context) (*MigrationRevision, error) {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getDirtyRevisionSQL())
+	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, migrationStateApplied))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	revision.Dirty = true
+	return &revision, nil
+}
+
+func (m *Migrator) getRevision(ctx context.Context, version int64) (*MigrationRevision, error) {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getRevisionSQL())
+	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, version))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	revision.Dirty = revision.State != migrationStateApplied
+	return &revision, nil
+}
+
+func (m *Migrator) scanRevisionRow(row *sql.Row) (MigrationRevision, error) {
+	var revision MigrationRevision
+	var executionTimeMs int64
+	var appliedAt any
+	if err := row.Scan(
+		&revision.Version,
+		&revision.Description,
+		&revision.State,
+		&revision.Applied,
+		&revision.Total,
+		&revision.Error,
+		&revision.ErrorStatement,
+		&executionTimeMs,
+		&revision.Checksum,
+		&appliedAt,
+	); err != nil {
+		return MigrationRevision{}, err
+	}
+	parsedAppliedAt, err := parseRevisionAppliedAt(appliedAt)
+	if err != nil {
+		return MigrationRevision{}, err
+	}
+	revision.AppliedAt = parsedAppliedAt
+	revision.ExecutionTime = time.Duration(executionTimeMs) * time.Millisecond
+	return revision, nil
+}
+
+func parseRevisionAppliedAt(value any) (time.Time, error) {
+	switch v := value.(type) {
+	case time.Time:
+		return v, nil
+	case []byte:
+		return parseRevisionAppliedAtString(string(v))
+	case string:
+		return parseRevisionAppliedAtString(v)
+	case nil:
+		return time.Time{}, nil
+	default:
+		return time.Time{}, fmt.Errorf("unsupported applied_at value %T", value)
+	}
+}
+
+func parseRevisionAppliedAtString(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999",
+		"2006-01-02 15:04:05",
+		time.RFC3339Nano,
+	} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("failed to parse applied_at %q", value)
+}
+
+func (m *Migrator) failIfDirty(ctx context.Context) error {
+	revision, err := m.dirtyRevision(ctx)
+	if err != nil {
+		return err
+	}
+	if revision != nil {
+		return &DirtyMigrationError{Revision: *revision}
+	}
+	return nil
+}
+
+func (m *Migrator) beginMigrationRevision(ctx context.Context, migration *Migration) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migration.Version,
+		migration.Description,
+		time.Now(),
+		migrationStatePending,
+		0,
+		migrationStatementCount(migration.UpSQL),
+		nil,
+		nil,
+		0,
+		migrationChecksum(migration.UpSQL),
+	)
+}
+
+func (m *Migrator) completeMigrationRevision(ctx context.Context, migration *Migration, startedAt time.Time) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.completeMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migrationStateApplied,
+		migrationStatementCount(migration.UpSQL),
+		migrationStatementCount(migration.UpSQL),
+		time.Since(startedAt).Milliseconds(),
+		time.Now(),
+		migration.Version,
+	)
+}
+
+func (m *Migrator) beginRollbackRevision(ctx context.Context, migration *Migration) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginRollbackSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migrationStatePending,
+		0,
+		migrationStatementCount(migration.DownSQL),
+		0,
+		migration.Version,
+	)
+}
+
+func (m *Migrator) failMigrationRevision(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	failure error,
+	sqlText string,
+) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	applied, total, stmt := migrationExecutionProgress(failure, m.conn.Info().Dialect)
+	if total == 0 {
+		total = migrationStatementCount(sqlText)
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migrationStateFailed,
+		applied,
+		total,
+		strings.TrimSpace(failure.Error()),
+		stmt,
+		time.Since(startedAt).Milliseconds(),
+		migration.Version,
+	)
+}
+
+func (m *Migrator) verifyAppliedMigrationChecksums(ctx context.Context, migrations []*Migration) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	for _, migration := range migrations {
+		revision, err := m.getRevision(ctx, migration.Version)
+		if err != nil {
+			return err
+		}
+		if revision == nil || revision.State != migrationStateApplied || revision.Checksum == "" {
+			continue
+		}
+		checksum := migrationChecksum(migration.UpSQL)
+		if revision.Checksum != checksum {
+			return &ChecksumMismatchError{
+				Version:  migration.Version,
+				Stored:   revision.Checksum,
+				Computed: checksum,
+			}
+		}
+	}
+	return nil
+}
+
+// RepairMigration clears dirty migration metadata after an operator has fixed
+// the database manually, or resumes the up migration from a specific statement.
+func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOptions) error {
+	if opts.Version <= 0 {
+		return fmt.Errorf("repair version must be greater than zero")
+	}
+	if err := m.Initialize(ctx); err != nil {
+		return fmt.Errorf("failed to initialize migrations table: %w", err)
+	}
+	migration := m.migrationByVersion(opts.Version)
+	if migration == nil {
+		return fmt.Errorf("migration %d not found", opts.Version)
+	}
+	revision, err := m.getRevision(ctx, opts.Version)
+	if err != nil {
+		return err
+	}
+	if revision == nil && !opts.Force {
+		return fmt.Errorf("migration %d has no revision row; rerun with --force to mark it applied", opts.Version)
+	}
+	if revision != nil && !revision.Dirty && !opts.Force {
+		return fmt.Errorf("migration %d is not dirty; rerun with --force to rewrite it", opts.Version)
+	}
+	if opts.ResumeFrom > 0 {
+		if err := m.resumeMigration(ctx, migration, opts.ResumeFrom); err != nil {
+			return err
+		}
+	}
+	return m.forceAppliedMigration(ctx, migration)
+}
+
+func (m *Migrator) migrationByVersion(version int64) *Migration {
+	for _, migration := range m.migrationProvider.Migrations() {
+		if migration.Version == version {
+			return migration
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) resumeMigration(ctx context.Context, migration *Migration, resumeFrom int) error {
+	statements := SplitSQLStatements(migration.UpSQL)
+	if resumeFrom < 1 || resumeFrom > len(statements) {
+		return fmt.Errorf("resume-from must be between 1 and %d", len(statements))
+	}
+	for i := resumeFrom - 1; i < len(statements); i++ {
+		stmt := strings.TrimSpace(statements[i])
+		if stmt == "" {
+			continue
+		}
+		if err := executeSQLOutsideTransaction(ctx, m.conn, stmt); err != nil {
+			return fmt.Errorf("failed to resume migration %d at statement %d: %w", migration.Version, i+1, err)
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) forceAppliedMigration(ctx context.Context, migration *Migration) error {
+	if m.isClickHouse() {
+		revision, err := m.getRevision(ctx, migration.Version)
+		if err != nil {
+			return err
+		}
+		if revision != nil {
+			return m.forceAppliedMigrationClickHouse(ctx, migration)
+		}
+	}
+	if m.forceAppliedConflictClause() == "" {
+		deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
+		if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+			return err
+		}
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migration.Version,
+		migration.Description,
+		time.Now(),
+		migrationStateApplied,
+		migrationStatementCount(migration.UpSQL),
+		migrationStatementCount(migration.UpSQL),
+		0,
+		migrationChecksum(migration.UpSQL),
+	)
+}
+
+func (m *Migrator) forceAppliedMigrationClickHouse(ctx context.Context, migration *Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedUpdateSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migration.Description,
+		time.Now(),
+		migrationStateApplied,
+		migrationStatementCount(migration.UpSQL),
+		migrationStatementCount(migration.UpSQL),
+		0,
+		migrationChecksum(migration.UpSQL),
+		migration.Version,
+	)
+}

--- a/migration/migrator/security_test.go
+++ b/migration/migrator/security_test.go
@@ -14,40 +14,33 @@ import (
 // obvious `%s`/`%d` form.
 var fmtVerbRe = regexp.MustCompile(`%[#+\- 0]*\d*(?:\.\d+)?[bcdeEfFgGoOpqstTUvxX]`)
 
-// TestRecordMigrationSQL_UsesPlaceholders is a regression guard for #130.
+// TestMigrationMetadataSQL_UsesPlaceholders is a regression guard for #130.
 //
-// The recorded migration SQL must use bind placeholders rather than fmt verbs,
-// so a description containing `'` or `;` cannot be interpolated directly into
-// the SQL text by the migrator. If anyone reverts the generated SQL back to
-// `VALUES (%d, '%s', '%s')`, this test fails before the regression reaches
-// production. We assert both that exactly three `?` placeholders are present
-// (so changing `VALUES (?, %s, NOW())` would also fail even though `?` is
-// technically still there) and that no Go fmt verb of any flavor is left in
-// the SQL that the migrator actually executes.
-func TestRecordMigrationSQL_UsesPlaceholders(t *testing.T) {
+// Migration metadata SQL must use bind placeholders rather than fmt verbs, so
+// migration descriptions and error text cannot be interpolated directly into
+// the SQL text by the migrator.
+func TestMigrationMetadataSQL_UsesPlaceholders(t *testing.T) {
 	c := qt.New(t)
 
-	sql := (&Migrator{}).recordMigrationSQL()
+	queries := map[string]struct {
+		sql          string
+		placeholders int
+	}{
+		"begin migration":    {sql: (&Migrator{}).beginMigrationSQL(), placeholders: 10},
+		"complete migration": {sql: (&Migrator{}).completeMigrationSQL(), placeholders: 6},
+		"begin rollback":     {sql: (&Migrator{}).beginRollbackSQL(), placeholders: 5},
+		"fail migration":     {sql: (&Migrator{}).failMigrationSQL(), placeholders: 7},
+		"force applied":      {sql: (&Migrator{}).forceAppliedMigrationSQL(), placeholders: 8},
+		"delete migration":   {sql: (&Migrator{}).deleteMigrationSQL(), placeholders: 1},
+	}
 
-	c.Assert(strings.Count(sql, "?"), qt.Equals, 3,
-		qt.Commentf("record migration SQL must contain exactly 3 ? placeholders (version, description, applied_at)"))
+	for name, query := range queries {
+		c.Assert(strings.Count(query.sql, "?"), qt.Equals, query.placeholders,
+			qt.Commentf("%s SQL must contain exactly %d placeholders", name, query.placeholders))
 
-	c.Assert(fmtVerbRe.FindString(sql), qt.Equals, "",
-		qt.Commentf("record migration SQL must not contain any Go fmt verb - values must be bound as driver parameters"))
-}
-
-// TestDeleteMigrationSQL_UsesPlaceholders is the same regression guard for
-// the migration-deletion path.
-func TestDeleteMigrationSQL_UsesPlaceholders(t *testing.T) {
-	c := qt.New(t)
-
-	sql := (&Migrator{}).deleteMigrationSQL()
-
-	c.Assert(strings.Count(sql, "?"), qt.Equals, 1,
-		qt.Commentf("delete migration SQL must contain exactly 1 ? placeholder (version)"))
-
-	c.Assert(fmtVerbRe.FindString(sql), qt.Equals, "",
-		qt.Commentf("delete migration SQL must not contain any Go fmt verb - values must be bound as driver parameters"))
+		c.Assert(fmtVerbRe.FindString(query.sql), qt.Equals, "",
+			qt.Commentf("%s SQL must not contain any Go fmt verb - values must be bound as driver parameters", name))
+	}
 }
 
 func TestMigrator_CustomMigrationsTableSQL(t *testing.T) {
@@ -57,7 +50,8 @@ func TestMigrator_CustomMigrationsTableSQL(t *testing.T) {
 
 	c.Assert(m.migrationsSchemaStatement(), qt.Equals, `CREATE SCHEMA IF NOT EXISTS "infra"`)
 	c.Assert(m.createMigrationsTableSQL(), qt.Contains, `CREATE TABLE IF NOT EXISTS "infra"."ptah_migrations"`)
-	c.Assert(m.getVersionSQL(), qt.Equals, `SELECT COALESCE(MAX(version), 0) FROM "infra"."ptah_migrations"`)
-	c.Assert(m.recordMigrationSQL(), qt.Equals, `INSERT INTO "infra"."ptah_migrations" (version, description, applied_at) VALUES (?, ?, ?)`)
+	c.Assert(m.getVersionSQL(), qt.Equals, `SELECT COALESCE(MAX(version), 0) FROM "infra"."ptah_migrations" WHERE state = 'applied'`)
+	c.Assert(m.beginMigrationSQL(), qt.Contains, `INSERT INTO "infra"."ptah_migrations"`)
+	c.Assert(m.completeMigrationSQL(), qt.Contains, `UPDATE "infra"."ptah_migrations"`)
 	c.Assert(m.deleteMigrationSQL(), qt.Equals, `DELETE FROM "infra"."ptah_migrations" WHERE version = ?`)
 }


### PR DESCRIPTION
## Summary
- extend schema_migrations with pending/failed/applied state, statement progress, errors, execution time, and up-SQL checksums
- write pending metadata before migration execution, block migrate operations on dirty rows, and verify applied checksums before planning new work
- add migrate-repair with force/resume support, status output for dirty revisions, docs, CI coverage, and partial-failure fixtures

## Validation
- gopls diagnostics: clean
- golangci-lint run ./...
- go test ./... -count=1
- live PostgreSQL/MySQL/MariaDB dirty-state + repair + checksum tests
- ClickHouse migrate-up/migrate-down smoke for metadata compatibility

Closes #265