### PR TITLE
Add brownfield baseline workflow

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -181,7 +181,13 @@ jobs:
           MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
         run: |
-          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration' -timeout 3m
+          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_' -timeout 3m
+
+      - name: Run migrate-baseline integration tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -v ./cmd/migratebaseline -run 'TestVerifyBaselineShadowPostgres|TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL' -timeout 3m
 
       - name: Run all databases comprehensive test
         env:

--- a/README.md
+++ b/README.md
@@ -785,12 +785,43 @@ Already-applied migrations are also checked against the current up SQL checksum.
 If a migration file is edited after it was applied, Ptah aborts before planning
 new work and reports a checksum mismatch for that version.
 
+#### Baseline an Existing Database
+
+Use `migrate-baseline` when adopting Ptah on a database whose schema already
+exists. The command initializes the migration metadata table and records every
+migration at or below the baseline version as `applied` without executing those
+migration SQL bodies. By default the baseline version is the highest migration
+in the directory.
+
+```bash
+# Strong verification: replay migrations on a disposable shadow database, then
+# compare the shadow schema to the existing target schema before writing metadata.
+./package-migrator migrate-baseline --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --shadow-db postgres://user:pass@localhost:5432/ptah_shadow
+
+# Preview exactly which rows would be written and which metadata table is used.
+./package-migrator migrate-baseline --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dry-run
+
+# Baseline through a specific version and use a custom metadata table.
+./package-migrator migrate-baseline --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --version 20260718120000 --migrations-schema infra --migrations-table ptah_migrations
+```
+
+Without `--shadow-db`, Ptah falls back to a weaker entity drift check: it parses
+Go entities from `--root-dir`, introspects the target database, and refuses to
+baseline if they differ. This does not prove that the migration files reproduce
+the target schema; use a disposable shadow database for production brownfield
+adoption. `migrate-baseline` refuses to write into a non-empty metadata table
+unless `--force` is set. With `--force`, verification failures are treated as
+explicit operator overrides, and existing metadata rows at or below the baseline
+version can be updated. Ptah still refuses to rewrite history if the metadata
+table already contains revisions above the requested baseline version.
+
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
 - ✅ Detects out-of-order pending migrations below the current version
 - ✅ Each migration runs in its own transaction unless explicitly marked `no_transaction`
 - ✅ Tracks dirty/failed migration state and refuses to continue until repaired
 - ✅ Verifies applied migration checksums before running new work
+- ✅ Baselines existing databases by stamping migration metadata without executing DDL
 - ✅ Executes Ptah paired down files and Atlas txtar `down.sql` sections
 - ✅ Tracks applied migrations in `schema_migrations` table, or a custom `--migrations-schema`/`--migrations-table`
 - ✅ Supports dry-run mode for preview
@@ -1583,6 +1614,7 @@ This project is part of the Inventario system and follows the same licensing ter
 - ✅ **PostgreSQL extensions support** - Support for PostgreSQL extensions in schema definitions
 - ✅ **PostgreSQL EXCLUDE constraints** - Full support for EXCLUDE constraints with USING methods, elements, and WHERE conditions
 - ✅ **Migration file generation** - Automatic generation of timestamped migration files from schema differences
+- ✅ **Brownfield baseline workflow** - Adopt existing databases by verifying and stamping migration metadata without replaying DDL
 - ✅ **Dry-run capabilities** - Preview operations before execution across all commands
 - ✅ **Transaction safety** - All operations wrapped in transactions for consistency
 

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -1,0 +1,316 @@
+package migratebaseline
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-extras/cobraflags"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/schemaops"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+const (
+	dbURLFlag       = "db-url"
+	migrationsFlag  = "migrations-dir"
+	versionFlag     = "version"
+	forceFlag       = "force"
+	dryRunFlag      = "dry-run"
+	shadowDBFlag    = "shadow-db"
+	rootDirFlag     = "root-dir"
+	dirFormatFlag   = "dir-format"
+	atlasEnvFlag    = "atlas-env"
+	lockTimeoutFlag = "migration-lock-timeout"
+)
+
+func NewMigrateBaselineCommand() *cobra.Command {
+	flags := newMigrateBaselineFlags()
+	cmd := &cobra.Command{
+		Use:   "migrate-baseline",
+		Short: "Record existing migrations as already applied",
+		Long: `Record existing migrations as already applied without executing their SQL bodies.
+
+Use this when adopting Ptah on a database whose schema already exists. Generate
+the initial migration from an empty scratch database, verify the existing
+database matches that migration, then baseline the existing database so future
+migrate-up runs apply only new migrations.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return migrateBaselineCommand(cmd, args, flags)
+		},
+	}
+	cobraflags.RegisterMap(cmd, flags)
+	return cmd
+}
+
+func newMigrateBaselineFlags() map[string]cobraflags.Flag {
+	return map[string]cobraflags.Flag{
+		dbURLFlag: &cobraflags.StringFlag{
+			Name:  dbURLFlag,
+			Value: "",
+			Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
+		},
+		migrationsFlag: &cobraflags.StringFlag{
+			Name:  migrationsFlag,
+			Value: "",
+			Usage: "Directory containing migration files (required)",
+		},
+		versionFlag: &cobraflags.StringFlag{
+			Name:  versionFlag,
+			Value: "",
+			Usage: "Baseline version. Defaults to the highest version in --migrations-dir",
+		},
+		forceFlag: &cobraflags.BoolFlag{
+			Name:  forceFlag,
+			Value: false,
+			Usage: "Proceed despite existing migration metadata or verification drift",
+		},
+		dryRunFlag: &cobraflags.BoolFlag{
+			Name:  dryRunFlag,
+			Value: false,
+			Usage: "Show the metadata rows that would be inserted without writing them",
+		},
+		shadowDBFlag: &cobraflags.StringFlag{
+			Name:  shadowDBFlag,
+			Value: "",
+			Usage: "Disposable shadow database URL used to verify baselined migrations reproduce the target schema",
+		},
+		rootDirFlag: &cobraflags.StringFlag{
+			Name:  rootDirFlag,
+			Value: "./",
+			Usage: "Root directory to scan for Go entities when --shadow-db is not set",
+		},
+		dirFormatFlag: &cobraflags.StringFlag{
+			Name:  dirFormatFlag,
+			Value: string(migrator.MigrationDirFormatAuto),
+			Usage: "Migration directory format: auto, ptah, or atlas",
+		},
+		atlasEnvFlag: &cobraflags.StringFlag{
+			Name:  atlasEnvFlag,
+			Value: "",
+			Usage: "Value exposed as .Env when rendering Atlas SQL template migrations",
+		},
+		lockTimeoutFlag: &cobraflags.StringFlag{
+			Name:  lockTimeoutFlag,
+			Value: "",
+			Usage: "Timeout for acquiring the session-level migration advisory lock, such as 10s or 2m",
+		},
+		dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
+		dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
+		dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+		dbcli.SchemasFlagName:          dbcli.NewSchemasFlag(),
+	}
+}
+
+func migrateBaselineCommand(cmd *cobra.Command, _ []string, flags map[string]cobraflags.Flag) error {
+	ctx := cmd.Context()
+	dbURL := flags[dbURLFlag].GetString()
+	migrationsDir := flags[migrationsFlag].GetString()
+	versionValue := flags[versionFlag].GetString()
+	force := flags[forceFlag].GetBool()
+	dryRun := flags[dryRunFlag].GetBool()
+	shadowDB := flags[shadowDBFlag].GetString()
+	rootDir := flags[rootDirFlag].GetString()
+	dirFormatValue := flags[dirFormatFlag].GetString()
+	atlasEnv := flags[atlasEnvFlag].GetString()
+	lockTimeoutValue := flags[lockTimeoutFlag].GetString()
+	migrationsSchema := flags[dbcli.MigrationsSchemaFlagName].GetString()
+	migrationsTable := flags[dbcli.MigrationsTableFlagName].GetString()
+	schemas := dbcli.ParseSchemas(flags[dbcli.SchemasFlagName].GetString())
+
+	if dbURL == "" {
+		return fmt.Errorf("database URL is required")
+	}
+	if migrationsDir == "" {
+		return fmt.Errorf("migrations directory is required")
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	providerOpts := []migrator.FSProviderOption{
+		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(migrator.AtlasTemplateData{Env: atlasEnv}),
+	}
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir), providerOpts...)
+	if err != nil {
+		return fmt.Errorf("error registering migrations: %w", err)
+	}
+	version, err := baselineVersion(versionValue, provider.Migrations())
+	if err != nil {
+		return err
+	}
+	rows := baselineRows(version, provider.Migrations())
+	if len(rows) == 0 {
+		return fmt.Errorf("no migrations found at or below baseline version %d", version)
+	}
+
+	connectTimeout, err := dbcli.ParseConnectTimeout(flags[dbcli.ConnectTimeoutFlagName].GetString())
+	if err != nil {
+		return err
+	}
+	lockTimeout, err := migrator.ParseMigrationLockTimeout(lockTimeoutValue)
+	if err != nil {
+		return err
+	}
+	connectCtx, cancelConnect := dbcli.ConnectContext(ctx, connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
+	cancelConnect()
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	conn.Writer().SetDryRun(dryRun)
+	mig := migrator.NewMigrator(conn, provider).
+		WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithMigrationLockTimeout(lockTimeout)
+	if dryRun {
+		printDryRun(dbURL, migrationsDir, version, mig, rows)
+		return nil
+	}
+
+	if err := verifyBaseline(ctx, baselineVerifyOptions{
+		dbURL:          dbURL,
+		shadowDB:       shadowDB,
+		rootDir:        rootDir,
+		version:        version,
+		force:          force,
+		conn:           conn,
+		connectTimeout: connectTimeout,
+		schemas:        schemas,
+		migrationsDir:  migrationsDir,
+		providerOpts:   providerOpts,
+	}); err != nil {
+		return err
+	}
+	if err := mig.BaselineWithOptions(ctx, migrator.BaselineOptions{Version: version, Force: force}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Baselined %d migration(s) through version %d in %s\n", len(rows), version, mig.MigrationsTableIdentifier())
+	return nil
+}
+
+type baselineVerifyOptions struct {
+	dbURL          string
+	shadowDB       string
+	rootDir        string
+	version        int64
+	force          bool
+	conn           *dbschema.DatabaseConnection
+	connectTimeout time.Duration
+	schemas        []string
+	migrationsDir  string
+	providerOpts   []migrator.FSProviderOption
+}
+
+func verifyBaseline(ctx context.Context, opts baselineVerifyOptions) error {
+	handler := verificationErrorHandler{force: opts.force}
+	if opts.shadowDB != "" {
+		err := generator.VerifyBaselineShadow(ctx, generator.BaselineShadowVerifyOptions{
+			ShadowDatabaseURL: opts.shadowDB,
+			TargetConn:        opts.conn,
+			MigrationsDir:     opts.migrationsDir,
+			Version:           opts.version,
+			Dialect:           opts.conn.Info().Dialect,
+			Capabilities:      opts.conn.Info().Capabilities,
+			Schemas:           opts.schemas,
+			ProviderOptions:   opts.providerOpts,
+			ConnectTimeout:    opts.connectTimeout,
+		})
+		handler.kind = "shadow"
+		return handler.handle(err)
+	}
+
+	fmt.Println("No --shadow-db provided; using weaker entity drift verification.")
+	result, err := schemaops.Compare(ctx, schemaops.CompareOptions{
+		RootDir:        opts.rootDir,
+		DatabaseURL:    opts.dbURL,
+		ConnectTimeout: opts.connectTimeout,
+		Schemas:        opts.schemas,
+	})
+	if err != nil {
+		return err
+	}
+	if !result.Diff.HasChanges() {
+		return nil
+	}
+	findings := safety.ClassifySchemaDiff(result.Diff)
+	err = fmt.Errorf("baseline drift verification failed: schema drift detected; findings: %v", findings)
+	handler.kind = "drift"
+	return handler.handle(err)
+}
+
+type verificationErrorHandler struct {
+	kind  string
+	force bool
+}
+
+func (h verificationErrorHandler) handle(err error) error {
+	if err == nil {
+		return nil
+	}
+	if !h.force {
+		return err
+	}
+	fmt.Printf("WARNING: %s verification failed but --force was set: %v\n", h.kind, err)
+	return nil
+}
+
+func baselineVersion(value string, migrations []*migrator.Migration) (int64, error) {
+	if value != "" {
+		version, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || version <= 0 {
+			return 0, fmt.Errorf("invalid baseline version %q", value)
+		}
+		return version, nil
+	}
+	var version int64
+	for _, migration := range migrations {
+		if migration.Version > version {
+			version = migration.Version
+		}
+	}
+	if version == 0 {
+		return 0, fmt.Errorf("migrations directory contains no migrations")
+	}
+	return version, nil
+}
+
+func baselineRows(version int64, migrations []*migrator.Migration) []*migrator.Migration {
+	rows := make([]*migrator.Migration, 0, len(migrations))
+	for _, migration := range migrations {
+		if migration.Version <= version {
+			rows = append(rows, migration)
+		}
+	}
+	return rows
+}
+
+func printDryRun(
+	dbURL string,
+	migrationsDir string,
+	version int64,
+	mig *migrator.Migrator,
+	rows []*migrator.Migration,
+) {
+	fmt.Println("=== DRY RUN BASELINE ===")
+	fmt.Println("No metadata rows will be written.")
+	fmt.Printf("Database: %s\n", dbschema.FormatDatabaseURL(dbURL))
+	fmt.Printf("Migrations directory: %s\n", migrationsDir)
+	fmt.Printf("Metadata table: %s\n", mig.MigrationsTableIdentifier())
+	fmt.Printf("Baseline version: %d\n", version)
+	fmt.Println("Rows:")
+	for _, migration := range rows {
+		fmt.Printf("- version=%d description=%q\n", migration.Version, migration.Description)
+	}
+}

--- a/cmd/migratebaseline/migratebaseline_test.go
+++ b/cmd/migratebaseline/migratebaseline_test.go
@@ -1,0 +1,299 @@
+package migratebaseline
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMigrateBaselineCommandCreation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrateBaselineCommand()
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "migrate-baseline")
+	c.Assert(cmd.Flag(dbURLFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(migrationsFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(versionFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(forceFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(dryRunFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(shadowDBFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(dirFormatFlag), qt.IsNotNil)
+	c.Assert(cmd.Flag(lockTimeoutFlag), qt.IsNotNil)
+}
+
+func TestBaselineVersionDefaultsToHighestMigration(t *testing.T) {
+	c := qt.New(t)
+
+	version, err := baselineVersion("", []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(2, "second", "SELECT 2", "SELECT 2"),
+		migrator.CreateMigrationFromSQL(10, "tenth", "SELECT 10", "SELECT 10"),
+		migrator.CreateMigrationFromSQL(7, "seventh", "SELECT 7", "SELECT 7"),
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, int64(10))
+}
+
+func TestBaselineVersionValidatesExplicitValue(t *testing.T) {
+	c := qt.New(t)
+
+	version, err := baselineVersion("42", nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, int64(42))
+
+	_, err = baselineVersion("0", nil)
+	c.Assert(err, qt.ErrorMatches, `invalid baseline version "0"`)
+
+	_, err = baselineVersion("abc", nil)
+	c.Assert(err, qt.ErrorMatches, `invalid baseline version "abc"`)
+}
+
+func TestBaselineRowsIncludesOnlyVersionsAtOrBelowBaseline(t *testing.T) {
+	c := qt.New(t)
+
+	rows := baselineRows(7, []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(2, "second", "SELECT 2", "SELECT 2"),
+		migrator.CreateMigrationFromSQL(7, "seventh", "SELECT 7", "SELECT 7"),
+		migrator.CreateMigrationFromSQL(10, "tenth", "SELECT 10", "SELECT 10"),
+	})
+
+	c.Assert(rows, qt.HasLen, 2)
+	c.Assert(rows[0].Version, qt.Equals, int64(2))
+	c.Assert(rows[1].Version, qt.Equals, int64(7))
+}
+
+func TestVerifyBaselineShadowPostgresMismatchRequiresForce(t *testing.T) {
+	dbURL := postgresBaselineTestURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+	if conn.Info().Dialect != "postgres" {
+		t.Skipf("baseline shadow verification test requires PostgreSQL, got %s", conn.Info().Dialect)
+	}
+
+	suffix := time.Now().UnixNano()
+	schema := fmt.Sprintf("ptah_issue_269_shadow_%d", suffix)
+	shadowDBName := fmt.Sprintf("ptah_issue_269_shadow_db_%d", suffix)
+	shadowDBURL := baselineShadowDatabaseURL(c, dbURL, shadowDBName)
+	createBaselineShadowDatabase(c, ctx, conn, shadowDBName)
+	defer dropBaselineShadowDatabase(c, ctx, conn, shadowDBName)
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+quotePostgresIdent(schema)+" CASCADE")
+	}()
+
+	_, err = conn.ExecContext(ctx, "CREATE SCHEMA "+quotePostgresIdent(schema))
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s.%s (id INTEGER PRIMARY KEY)",
+		quotePostgresIdent(schema),
+		quotePostgresIdent("users"),
+	))
+	c.Assert(err, qt.IsNil)
+
+	migrationsDir := c.TempDir()
+	writeBaselineShadowMigration(c, migrationsDir, schema)
+	opts := baselineVerifyOptions{
+		shadowDB:      shadowDBURL,
+		version:       1,
+		conn:          conn,
+		schemas:       []string{schema},
+		migrationsDir: migrationsDir,
+	}
+
+	err = verifyBaseline(ctx, opts)
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: .*`)
+
+	opts.force = true
+	err = verifyBaseline(ctx, opts)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestVerifyBaselineShadowPostgresMatchIgnoresShadowMetadata(t *testing.T) {
+	dbURL := postgresBaselineTestURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	adminConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(adminConn)
+	if adminConn.Info().Dialect != "postgres" {
+		t.Skipf("baseline shadow verification test requires PostgreSQL, got %s", adminConn.Info().Dialect)
+	}
+
+	suffix := time.Now().UnixNano()
+	targetDBName := fmt.Sprintf("ptah_issue_269_target_db_%d", suffix)
+	shadowDBName := fmt.Sprintf("ptah_issue_269_shadow_db_%d", suffix)
+	targetDBURL := baselineShadowDatabaseURL(c, dbURL, targetDBName)
+	shadowDBURL := baselineShadowDatabaseURL(c, dbURL, shadowDBName)
+	createBaselineShadowDatabase(c, ctx, adminConn, targetDBName)
+	createBaselineShadowDatabase(c, ctx, adminConn, shadowDBName)
+	defer dropBaselineShadowDatabase(c, ctx, adminConn, targetDBName)
+	defer dropBaselineShadowDatabase(c, ctx, adminConn, shadowDBName)
+
+	targetConn, err := dbschema.ConnectToDatabase(ctx, targetDBURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(targetConn)
+	_, err = targetConn.ExecContext(ctx, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+	c.Assert(err, qt.IsNil)
+
+	migrationsDir := c.TempDir()
+	writeBaselineShadowPublicMigration(c, migrationsDir)
+	err = verifyBaseline(ctx, baselineVerifyOptions{
+		shadowDB:      shadowDBURL,
+		version:       1,
+		conn:          targetConn,
+		migrationsDir: migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL(t *testing.T) {
+	dbURL := postgresBaselineTestURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	adminConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(adminConn)
+	if adminConn.Info().Dialect != "postgres" {
+		t.Skipf("migrate-baseline command test requires PostgreSQL, got %s", adminConn.Info().Dialect)
+	}
+
+	suffix := time.Now().UnixNano()
+	targetDBName := fmt.Sprintf("ptah_issue_269_cli_target_%d", suffix)
+	shadowDBName := fmt.Sprintf("ptah_issue_269_cli_shadow_%d", suffix)
+	targetDBURL := baselineShadowDatabaseURL(c, dbURL, targetDBName)
+	shadowDBURL := baselineShadowDatabaseURL(c, dbURL, shadowDBName)
+	createBaselineShadowDatabase(c, ctx, adminConn, targetDBName)
+	createBaselineShadowDatabase(c, ctx, adminConn, shadowDBName)
+	defer dropBaselineShadowDatabase(c, ctx, adminConn, targetDBName)
+	defer dropBaselineShadowDatabase(c, ctx, adminConn, shadowDBName)
+
+	targetConn, err := dbschema.ConnectToDatabase(ctx, targetDBURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(targetConn)
+	_, err = targetConn.ExecContext(ctx, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+	c.Assert(err, qt.IsNil)
+
+	migrationsDir := c.TempDir()
+	writeBaselineShadowPublicMigration(c, migrationsDir)
+	metadataTable := fmt.Sprintf("schema_migrations_issue_269_cli_%d", suffix)
+	cmd := NewMigrateBaselineCommand()
+	cmd.SetArgs([]string{
+		"--db-url", targetDBURL,
+		"--migrations-dir", migrationsDir,
+		"--shadow-db", shadowDBURL,
+		"--migrations-table", metadataTable,
+		"--connect-timeout", "5s",
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNil)
+
+	var version int64
+	var state string
+	err = targetConn.QueryRowContext(
+		ctx,
+		fmt.Sprintf("SELECT version, state FROM %s", quotePostgresIdent(metadataTable)),
+	).Scan(&version, &state)
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, int64(1))
+	c.Assert(state, qt.Equals, "applied")
+}
+
+func postgresBaselineTestURL() string {
+	for _, name := range []string{"POSTGRES_TEST_DSN", "TEST_DATABASE_URL", "POSTGRES_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func baselineShadowDatabaseURL(c *qt.C, dbURL, dbName string) string {
+	c.Helper()
+
+	parsed, err := url.Parse(dbURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + dbName
+	return parsed.String()
+}
+
+func createBaselineShadowDatabase(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection, dbName string) {
+	c.Helper()
+
+	dropBaselineShadowDatabase(c, ctx, conn, dbName)
+	_, err := conn.ExecContext(ctx, "CREATE DATABASE "+quotePostgresIdent(dbName))
+	c.Assert(err, qt.IsNil)
+}
+
+func dropBaselineShadowDatabase(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection, dbName string) {
+	c.Helper()
+
+	_, err := conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quotePostgresIdent(dbName)+" WITH (FORCE)")
+	c.Assert(err, qt.IsNil)
+}
+
+func writeBaselineShadowMigration(c *qt.C, dir, schema string) {
+	c.Helper()
+
+	upSQL := fmt.Sprintf(
+		"CREATE SCHEMA IF NOT EXISTS %s;\nCREATE TABLE %s.%s (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n",
+		quotePostgresIdent(schema),
+		quotePostgresIdent(schema),
+		quotePostgresIdent("users"),
+	)
+	downSQL := fmt.Sprintf(
+		"DROP TABLE IF EXISTS %s.%s;\nDROP SCHEMA IF EXISTS %s;\n",
+		quotePostgresIdent(schema),
+		quotePostgresIdent("users"),
+		quotePostgresIdent(schema),
+	)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte(upSQL), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte(downSQL), 0600), qt.IsNil)
+}
+
+func writeBaselineShadowPublicMigration(c *qt.C, dir string) {
+	c.Helper()
+
+	upSQL := "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+	downSQL := "DROP TABLE IF EXISTS users;\n"
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte(upSQL), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte(downSQL), 0600), qt.IsNil)
+}
+
+func quotePostgresIdent(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/cmd/migratebaseline"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migratehash"
 	"github.com/stokaro/ptah/cmd/migraterepair"
@@ -53,6 +54,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(compare.NewCompareCommand())
 	rootCmd.AddCommand(drift.NewDriftCommand())
 	rootCmd.AddCommand(migrate.NewMigrateCommand())
+	rootCmd.AddCommand(migratebaseline.NewMigrateBaselineCommand())
 	rootCmd.AddCommand(migrateup.NewMigrateUpCommand())
 	rootCmd.AddCommand(migratedown.NewMigrateDownCommand())
 	rootCmd.AddCommand(migraterepair.NewMigrateRepairCommand())

--- a/migration/generator/baseline_shadow.go
+++ b/migration/generator/baseline_shadow.go
@@ -1,0 +1,143 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/convert/dbschematogo"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// BaselineShadowVerifyOptions configures shadow verification before metadata
+// baselining.
+type BaselineShadowVerifyOptions struct {
+	ShadowDatabaseURL string
+	TargetConn        *dbschema.DatabaseConnection
+	MigrationsDir     string
+	Version           int64
+	Dialect           string
+	Capabilities      capability.Capabilities
+	CompareOptions    *config.CompareOptions
+	Schemas           []string
+	ProviderOptions   []migrator.FSProviderOption
+	ConnectTimeout    time.Duration
+}
+
+// VerifyBaselineShadow replays migrations up to Version on the shadow database
+// and compares the resulting schema with the target database.
+func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error {
+	if opts.TargetConn == nil {
+		return fmt.Errorf("baseline shadow check failed: target database connection is required")
+	}
+	connectCtx, cancelConnect := baselineShadowConnectContext(ctx, opts.ConnectTimeout)
+	shadowConn, err := dbschema.ConnectToDatabase(connectCtx, opts.ShadowDatabaseURL)
+	cancelConnect()
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: connect to shadow database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(shadowConn)
+
+	if !sameDialect(opts.Dialect, shadowConn.Info().Dialect) {
+		return fmt.Errorf(
+			"baseline shadow check failed: shadow database dialect %q does not match target dialect %q",
+			shadowConn.Info().Dialect,
+			opts.Dialect,
+		)
+	}
+	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, shadowConn.Info().Capabilities) {
+		return fmt.Errorf("baseline shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
+	}
+	if err := shadowConn.Writer().DropAllTables(); err != nil {
+		return fmt.Errorf("baseline shadow check failed: drop all objects: %w", err)
+	}
+	if err := resetBaselineShadowSchemas(ctx, shadowConn, opts.Schemas); err != nil {
+		return err
+	}
+
+	migrations, err := loadPriorMigrations(opts.MigrationsDir, opts.ProviderOptions...)
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: load migrations: %w", err)
+	}
+	migrations = migrationsAtOrBelow(migrations, opts.Version)
+	if len(migrations) == 0 {
+		return fmt.Errorf("baseline shadow check failed: no migrations found at or below version %d", opts.Version)
+	}
+
+	mig := migrator.NewMigrator(shadowConn, migrator.NewRegisteredMigrationProvider(migrations...))
+	if err := mig.MigrateUp(ctx); err != nil {
+		if description := describeReplayError(err); description != "" {
+			return fmt.Errorf("baseline shadow check failed: %s", description)
+		}
+		return fmt.Errorf("baseline shadow check failed: replay migrations: %w", err)
+	}
+	if err := dropBaselineShadowMetadata(ctx, shadowConn, mig.MigrationsTableIdentifier()); err != nil {
+		return err
+	}
+
+	targetSchema, err := dbschema.ReadSchemaWithSchemas(opts.TargetConn, opts.Schemas)
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: read target schema: %w", err)
+	}
+	shadowSchema, err := dbschema.ReadSchemaWithSchemas(shadowConn, opts.Schemas)
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: read shadow schema: %w", err)
+	}
+	compareOpts := withDialect(opts.CompareOptions, opts.Dialect)
+	diff := schemadiff.CompareWithOptions(dbschematogo.ConvertDBSchemaToGoSchema(shadowSchema), targetSchema, compareOpts)
+	if !diff.HasChanges() {
+		return nil
+	}
+	return fmt.Errorf("baseline shadow check failed: %s", describeShadowDiff(diff))
+}
+
+func baselineShadowConnectContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func migrationsAtOrBelow(migrations []*migrator.Migration, version int64) []*migrator.Migration {
+	out := make([]*migrator.Migration, 0, len(migrations))
+	for _, migration := range migrations {
+		if migration.Version <= version {
+			out = append(out, migration)
+		}
+	}
+	return out
+}
+
+func resetBaselineShadowSchemas(ctx context.Context, conn *dbschema.DatabaseConnection, schemas []string) error {
+	if conn.Info().Dialect != "postgres" {
+		return nil
+	}
+	for _, schema := range schemas {
+		if schema == "" || schema == "public" {
+			continue
+		}
+		_, err := conn.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+quoteBaselinePostgresIdentifier(schema)+" CASCADE")
+		if err != nil {
+			return fmt.Errorf("baseline shadow check failed: drop schema %q: %w", schema, err)
+		}
+	}
+	return nil
+}
+
+func dropBaselineShadowMetadata(ctx context.Context, conn *dbschema.DatabaseConnection, tableIdentifier string) error {
+	_, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS "+tableIdentifier)
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: drop metadata table: %w", err)
+	}
+	return nil
+}
+
+func quoteBaselinePostgresIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}

--- a/migration/generator/baseline_shadow_test.go
+++ b/migration/generator/baseline_shadow_test.go
@@ -1,0 +1,24 @@
+package generator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBaselineShadowConnectContextAppliesOnlyConfiguredTimeout(t *testing.T) {
+	c := qt.New(t)
+
+	ctx, cancel := baselineShadowConnectContext(context.Background(), time.Second)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(time.Until(deadline) > 0, qt.IsTrue)
+
+	ctx, cancel = baselineShadowConnectContext(context.Background(), 0)
+	defer cancel()
+	_, ok = ctx.Deadline()
+	c.Assert(ok, qt.IsFalse)
+}

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -98,7 +98,7 @@ func sameDialect(left, right string) bool {
 	return platform.NormalizeDialect(left) == platform.NormalizeDialect(right)
 }
 
-func loadPriorMigrations(dir string) ([]*migrator.Migration, error) {
+func loadPriorMigrations(dir string, opts ...migrator.FSProviderOption) ([]*migrator.Migration, error) {
 	if strings.TrimSpace(dir) == "" {
 		return nil, nil
 	}
@@ -109,7 +109,7 @@ func loadPriorMigrations(dir string) ([]*migrator.Migration, error) {
 		return nil, err
 	}
 
-	provider, err := migrator.NewFSMigrationProvider(os.DirFS(dir))
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(dir), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -225,6 +225,7 @@ pending and out of order.
 - **`WithExecOrder(policy)`**: Configures out-of-order migration handling
 - **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
 - **`WithAtlasTemplateData(data)`**: Supplies data, including `.Env`, for Atlas SQL template migrations
+- **`Baseline(ctx, version)` / `BaselineWithOptions(ctx, opts)`**: Records provider migrations as already applied without executing their SQL bodies
 
 ## Programmatic Usage
 
@@ -338,6 +339,37 @@ if status.HasPendingChanges {
 }
 ```
 
+### Brownfield Baseline
+
+Use baseline mode when the target database schema already exists and should
+become managed by Ptah from this point forward. Baseline writes migration
+metadata only; it does not execute the migration bodies.
+
+```go
+provider, err := migrator.NewFSMigrationProvider(os.DirFS("/path/to/migrations"))
+if err != nil {
+    panic(err)
+}
+
+m := migrator.NewMigrator(conn, provider).
+    WithMigrationsTable("infra", "ptah_migrations")
+
+err = m.BaselineWithOptions(context.Background(), migrator.BaselineOptions{
+    Version: 20260718120000,
+})
+if err != nil {
+    panic(err)
+}
+```
+
+`BaselineWithOptions` refuses to write when the metadata table already contains
+rows unless `Force` is set. `Force` can fill or update metadata at or below the
+baseline version, but it refuses to rewrite history when rows above that version
+already exist. The CLI `migrate-baseline` adds pre-flight schema verification:
+with `--shadow-db`, it replays baselined migrations on a disposable database and
+compares the result to the target; without `--shadow-db`, it uses the weaker
+entity drift check against `--root-dir`.
+
 ## Migration Table
 
 The migrator automatically creates a `schema_migrations` table to track applied migrations:
@@ -433,11 +465,12 @@ timeouts to raw autocommit statements.
 - **Confirmation Prompts**: Down migrations require confirmation (unless `--confirm` is used)
 - **Dry Run Mode**: Preview migrations without applying them
 - **Migration Timeouts**: File-level directives and CLI defaults can cap lock waits and statement runtime for safer production rollouts
+- **Baseline Guardrails**: Brownfield baselining refuses existing migration metadata by default and the CLI can verify against a replayed shadow database
 - **Validation**: Migrations are validated before execution
 
 ## Limitations
 
-- **Concurrent Migrations**: No built-in protection against concurrent migration execution
+- **Baseline Verification Without Shadow DB**: Entity drift checks cannot prove that migration files replay to the same schema; use `--shadow-db` for production adoption
 - **Advanced Features**: Some advanced migration features like conditional migrations or complex rollback scenarios are not yet implemented
 
 ## Integration with Ptah

--- a/migration/migrator/baseline_integration_test.go
+++ b/migration/migrator/baseline_integration_test.go
@@ -1,0 +1,248 @@
+package migrator_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestBaseline_PostgresRecordsAppliedWithoutExecutingSQL(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue269Names(time.Now().UnixNano())
+	cleanupIssue269(t, conn, names)
+	defer cleanupIssue269(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.itemsTable))
+	c.Assert(err, qt.IsNil)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 2})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(tableExists(t, conn, names.itemsTable), qt.IsTrue)
+	c.Assert(tableExists(t, conn, names.logTable), qt.IsFalse)
+	assertIssue269Revisions(t, conn, names, []issue269Revision{
+		{Version: 1, State: "applied", Applied: 1, Total: 1},
+		{Version: 2, State: "applied", Applied: 1, Total: 1},
+	})
+
+	status, err := issue269Migrator(conn, names).GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1, 2})
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{3})
+}
+
+func TestBaseline_PostgresSecondRunRequiresForce(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue269Names(time.Now().UnixNano())
+	cleanupIssue269(t, conn, names)
+	defer cleanupIssue269(t, conn, names)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 1})
+	c.Assert(err, qt.IsNil)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 2})
+	c.Assert(err, qt.ErrorMatches, "schema migrations table is not empty.*")
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 2, Force: true})
+	c.Assert(err, qt.IsNil)
+	assertIssue269Revisions(t, conn, names, []issue269Revision{
+		{Version: 1, State: "applied", Applied: 1, Total: 1},
+		{Version: 2, State: "applied", Applied: 1, Total: 1},
+	})
+}
+
+func TestBaseline_PostgresForceRejectsHistoryAboveBaseline(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue269Names(time.Now().UnixNano())
+	cleanupIssue269(t, conn, names)
+	defer cleanupIssue269(t, conn, names)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 3})
+	c.Assert(err, qt.IsNil)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 2, Force: true})
+	c.Assert(err, qt.ErrorMatches, "schema migrations table contains revisions above baseline version 2.*")
+	assertIssue269Revisions(t, conn, names, []issue269Revision{
+		{Version: 1, State: "applied", Applied: 1, Total: 1},
+		{Version: 2, State: "applied", Applied: 1, Total: 1},
+		{Version: 3, State: "applied", Applied: 1, Total: 1},
+	})
+}
+
+func TestBaseline_MySQLRecordsAppliedWithoutExecutingSQL(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runIssue269MySQLFamilyBaselineIntegration(t, dbURL)
+}
+
+func TestBaseline_MariaDBRecordsAppliedWithoutExecutingSQL(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runIssue269MySQLFamilyBaselineIntegration(t, dbURL)
+}
+
+type issue269TestNames struct {
+	migrationsTable string
+	itemsTable      string
+	logTable        string
+}
+
+type issue269Revision struct {
+	Version int64
+	State   string
+	Applied int
+	Total   int
+}
+
+func issue269Names(suffix int64) issue269TestNames {
+	return issue269TestNames{
+		migrationsTable: fmt.Sprintf("schema_migrations_issue_269_%d", suffix),
+		itemsTable:      fmt.Sprintf("ptah_issue_269_items_%d", suffix),
+		logTable:        fmt.Sprintf("ptah_issue_269_log_%d", suffix),
+	}
+}
+
+func issue269Migrator(conn *dbschema.DatabaseConnection, names issue269TestNames) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(issue269Migrations(names)...)).
+		WithMigrationsTable("", names.migrationsTable)
+}
+
+func issue269Migrations(names issue269TestNames) []*migrator.Migration {
+	return []*migrator.Migration{
+		migrator.CreateMigrationFromSQL(
+			1,
+			"create issue 269 items",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.itemsTable),
+			fmt.Sprintf("DROP TABLE %s", names.itemsTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			2,
+			"create issue 269 log",
+			fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.logTable),
+			fmt.Sprintf("DROP TABLE %s", names.logTable),
+		),
+		migrator.CreateMigrationFromSQL(
+			3,
+			"add issue 269 marker",
+			fmt.Sprintf("ALTER TABLE %s ADD COLUMN marker INTEGER", names.itemsTable),
+			fmt.Sprintf("ALTER TABLE %s DROP COLUMN marker", names.itemsTable),
+		),
+	}
+}
+
+func runIssue269MySQLFamilyBaselineIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue269Names(time.Now().UnixNano())
+	cleanupIssue269(t, conn, names)
+	defer cleanupIssue269(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.itemsTable))
+	c.Assert(err, qt.IsNil)
+
+	err = issue269Migrator(conn, names).
+		BaselineWithOptions(ctx, migrator.BaselineOptions{Version: 2})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(mysqlFamilyTableExists(t, conn, names.itemsTable), qt.IsTrue)
+	c.Assert(mysqlFamilyTableExists(t, conn, names.logTable), qt.IsFalse)
+	assertIssue269Revisions(t, conn, names, []issue269Revision{
+		{Version: 1, State: "applied", Applied: 1, Total: 1},
+		{Version: 2, State: "applied", Applied: 1, Total: 1},
+	})
+}
+
+func assertIssue269Revisions(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	names issue269TestNames,
+	want []issue269Revision,
+) {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT COUNT(*) FROM %s", names.migrationsTable),
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, count, qt.Equals, len(want))
+
+	for _, wantRevision := range want {
+		var got issue269Revision
+		err = conn.QueryRowContext(
+			context.Background(),
+			sqlutil.Rebind(
+				conn.Info().Dialect,
+				fmt.Sprintf("SELECT version, state, applied, total FROM %s WHERE version = ?", names.migrationsTable),
+			),
+			wantRevision.Version,
+		).Scan(&got.Version, &got.State, &got.Applied, &got.Total)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, got, qt.DeepEquals, wantRevision)
+	}
+}
+
+func cleanupIssue269(t *testing.T, conn *dbschema.DatabaseConnection, names issue269TestNames) {
+	t.Helper()
+
+	for _, statement := range []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.migrationsTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.logTable),
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", names.itemsTable),
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func mysqlFamilyTableExists(t *testing.T, conn *dbschema.DatabaseConnection, tableName string) bool {
+	t.Helper()
+
+	var exists int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?",
+		tableName,
+	).Scan(&exists)
+	qt.Assert(t, err, qt.IsNil)
+	return exists > 0
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -100,6 +100,11 @@ func (m *Migrator) qualifiedMigrationsTable() string {
 	return m.quoteIdentifier(m.migrationsSchema) + "." + m.quoteIdentifier(table)
 }
 
+// MigrationsTableIdentifier returns the dialect-quoted metadata table name.
+func (m *Migrator) MigrationsTableIdentifier() string {
+	return m.qualifiedMigrationsTable()
+}
+
 func (m *Migrator) migrationsSchemaStatement() string {
 	if m.migrationsSchema == "" {
 		return ""
@@ -434,9 +439,13 @@ func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, er
 	currentVersion := maxAppliedVersion(appliedMigrations)
 	pendingMigrations := pendingMigrationVersions(m.MigrationProvider().Migrations(), appliedMigrations)
 	outOfOrderMigrations := outOfOrderMigrationVersions(pendingMigrations, currentVersion)
-	dirtyRevision, err := m.dirtyRevision(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get dirty migration revision: %w", err)
+	var dirtyRevision *MigrationRevision
+	if !m.conn.Writer().IsDryRun() {
+		var err error
+		dirtyRevision, err = m.dirtyRevision(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get dirty migration revision: %w", err)
+		}
 	}
 
 	return &MigrationStatus{

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -76,6 +76,12 @@ type RepairMigrationOptions struct {
 	ResumeFrom int
 }
 
+// BaselineOptions configures migration metadata baselining.
+type BaselineOptions struct {
+	Version int64
+	Force   bool
+}
+
 func migrationChecksum(sqlText string) string {
 	sum := sha256.Sum256([]byte(sqlText))
 	return hex.EncodeToString(sum[:])
@@ -168,6 +174,14 @@ func (m *Migrator) forceAppliedUpdateSQL() string {
 UPDATE description = ?, applied_at = ?, state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, checksum = ?
 WHERE version = ?
 SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) countRevisionsSQL() string {
+	return fmt.Sprintf(`SELECT COUNT(*) FROM %s`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) countRevisionsAboveSQL() string {
+	return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE version > ?`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) isClickHouse() bool {
@@ -411,6 +425,136 @@ func (m *Migrator) verifyAppliedMigrationChecksums(ctx context.Context, migratio
 				Stored:   revision.Checksum,
 				Computed: checksum,
 			}
+		}
+	}
+	return nil
+}
+
+// Baseline records provider migrations up to version as already applied without
+// executing their SQL bodies.
+func (m *Migrator) Baseline(ctx context.Context, version int64) error {
+	return m.BaselineWithOptions(ctx, BaselineOptions{Version: version})
+}
+
+// BaselineWithOptions records provider migrations up to opts.Version as already
+// applied without executing their SQL bodies.
+func (m *Migrator) BaselineWithOptions(ctx context.Context, opts BaselineOptions) error {
+	return m.withMigrationLock(ctx, "baseline", func(ctx context.Context) error {
+		return m.baselineLocked(ctx, opts)
+	})
+}
+
+func (m *Migrator) baselineLocked(ctx context.Context, opts BaselineOptions) error {
+	if opts.Version <= 0 {
+		return fmt.Errorf("baseline version must be greater than zero")
+	}
+	migrations := m.migrationsAtOrBelow(opts.Version)
+	if len(migrations) == 0 {
+		return fmt.Errorf("no migrations found at or below baseline version %d", opts.Version)
+	}
+	if err := m.Initialize(ctx); err != nil {
+		return fmt.Errorf("failed to initialize migrations table: %w", err)
+	}
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	if err := m.failIfDirty(ctx); err != nil {
+		return err
+	}
+	revisionCount, err := m.revisionCount(ctx)
+	if err != nil {
+		return err
+	}
+	if revisionCount > 0 && !opts.Force {
+		return fmt.Errorf("schema migrations table is not empty; rerun with force to baseline anyway")
+	}
+	if opts.Force {
+		if err := m.failIfRevisionAboveBaseline(ctx, opts.Version); err != nil {
+			return err
+		}
+	}
+	return m.baselineMigrations(ctx, migrations)
+}
+
+func (m *Migrator) migrationsAtOrBelow(version int64) []*Migration {
+	migrations := m.migrationProvider.Migrations()
+	out := make([]*Migration, 0, len(migrations))
+	for _, migration := range migrations {
+		if migration.Version <= version {
+			out = append(out, migration)
+		}
+	}
+	return out
+}
+
+func (m *Migrator) revisionCount(ctx context.Context) (int, error) {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.countRevisionsSQL())
+	var count int
+	if err := m.conn.QueryRowContext(ctx, query).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count migration revisions: %w", err)
+	}
+	return count, nil
+}
+
+func (m *Migrator) baselineMigrations(ctx context.Context, migrations []*Migration) error {
+	if m.isClickHouse() {
+		return m.baselineMigrationsNoTransaction(ctx, migrations)
+	}
+	if err := m.conn.Writer().BeginTransaction(); err != nil {
+		return fmt.Errorf("failed to begin baseline transaction: %w", err)
+	}
+	if err := m.writeBaselineMigrations(ctx, migrations); err != nil {
+		_ = m.conn.Writer().RollbackTransaction()
+		return err
+	}
+	if err := m.conn.Writer().CommitTransaction(); err != nil {
+		return fmt.Errorf("failed to commit baseline transaction: %w", err)
+	}
+	return nil
+}
+
+func (m *Migrator) baselineMigrationsNoTransaction(ctx context.Context, migrations []*Migration) error {
+	return m.writeBaselineMigrations(ctx, migrations)
+}
+
+func (m *Migrator) writeBaselineMigrations(ctx context.Context, migrations []*Migration) error {
+	return m.writeBaselineMigrationRows(ctx, migrations)
+}
+
+func (m *Migrator) failIfRevisionAboveBaseline(ctx context.Context, version int64) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.countRevisionsAboveSQL())
+	var count int
+	if err := m.conn.QueryRowContext(ctx, query, version).Scan(&count); err != nil {
+		return fmt.Errorf("failed to inspect migration revisions above baseline: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("schema migrations table contains revisions above baseline version %d; refusing to rewrite migration history", version)
+	}
+	return nil
+}
+
+func (m *Migrator) writeBaselineMigrationRows(ctx context.Context, migrations []*Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedMigrationSQL())
+	for _, migration := range migrations {
+		if m.forceAppliedConflictClause() == "" {
+			deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
+			if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
+				return fmt.Errorf("failed to prepare baseline revision %d: %w", migration.Version, err)
+			}
+		}
+		if err := m.conn.Writer().ExecuteSQL(
+			ctx,
+			query,
+			migration.Version,
+			migration.Description,
+			time.Now(),
+			migrationStateApplied,
+			migrationStatementCount(migration.UpSQL),
+			migrationStatementCount(migration.UpSQL),
+			0,
+			migrationChecksum(migration.UpSQL),
+		); err != nil {
+			return fmt.Errorf("failed to record baseline revision %d: %w", migration.Version, err)
 		}
 	}
 	return nil

--- a/migration/migrator/transaction_integration_test.go
+++ b/migration/migrator/transaction_integration_test.go
@@ -34,7 +34,13 @@ func TestCreateMigrationFromSQL_PostgresFailureRollsBackStatements(t *testing.T)
 	err = mig.MigrateUp(ctx)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(columnExists(t, conn, "ptah_issue_262_users", "status"), qt.IsFalse)
-	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, int64(0))
+	c.Assert(issue262MigrationRecordCount(t, conn), qt.Equals, int64(1))
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+
+	_, err = conn.ExecContext(ctx, "DROP TABLE IF EXISTS schema_migrations_issue_262")
+	c.Assert(err, qt.IsNil)
 
 	fixedMigration := migrator.CreateMigrationFromSQL(1, "add status",
 		`ALTER TABLE ptah_issue_262_users ADD COLUMN status TEXT;
@@ -160,13 +166,13 @@ func columnExists(t *testing.T, conn *dbschema.DatabaseConnection, tableName, co
 	return exists
 }
 
-func issue262MigrationRecordCount(t *testing.T, conn *dbschema.DatabaseConnection) int {
+func issue262MigrationRecordCount(t *testing.T, conn *dbschema.DatabaseConnection) int64 {
 	t.Helper()
 
 	if !tableExists(t, conn, "schema_migrations_issue_262") {
 		return 0
 	}
-	var count int
+	var count int64
 	err := conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM schema_migrations_issue_262").Scan(&count)
 	qt.Assert(t, err, qt.IsNil)
 	return count


### PR DESCRIPTION
Closes #269

## Summary
- add `migrate-baseline` CLI and `Migrator.Baseline` / `BaselineWithOptions` API for stamping existing migrations without executing DDL
- add shadow-database baseline verification, dry-run output, custom metadata table support, force guardrails, and command wiring
- document the brownfield adoption flow and wire live baseline tests into CI

## Self-review notes
- `--force` can update metadata at or below the requested baseline, but refuses to rewrite history when metadata contains revisions above the baseline
- shadow verification drops Ptah metadata from the disposable shadow before schema comparison, so baseline verification does not fail on its own bookkeeping table
- CLI commands are created with isolated flag state, so tests and command-tree construction do not share package-global flag values

## Validation
- `gopls` diagnostics on changed Go files: no diagnostics
- `go test ./... -count=1`
- `golangci-lint run ./...`
- `POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable MYSQL_TEST_URL=mysql://ptah_user:ptah_password@tcp(localhost:3310)/ptah_test MARIADB_TEST_URL=mariadb://ptah_user:ptah_password@tcp(localhost:3307)/ptah_test go test -p 1 ./cmd/migratebaseline ./migration/generator ./migration/migrator -count=1`
- `git diff --cached --check`