### PR TITLE
Fix live roundtrip primary key drift

### DIFF
--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -675,6 +675,7 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 			if tableLevelPK && slices.Contains(newTable.PrimaryKey, field.Name) {
 				field.Primary = false
 			}
+			field = withDefaultForeignKeyName(newTable.Name, field)
 			column := FromField(field, enums, targetPlatform)
 			createTable.AddColumn(column)
 		}
@@ -687,6 +688,14 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	}
 
 	return createTable
+}
+
+func withDefaultForeignKeyName(tableName string, field goschema.Field) goschema.Field {
+	if field.Foreign == "" || field.ForeignKeyName != "" {
+		return field
+	}
+	field.ForeignKeyName = GenerateForeignKeyName(tableName, field.Name)
+	return field
 }
 
 func toASTPartition(partition *goschema.PartitionSpec) *ast.PartitionSpec {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -631,6 +631,29 @@ func TestFromTable_CompositePrimaryKey(t *testing.T) {
 	c.Assert(result.Constraints[0].Columns, qt.DeepEquals, []string{"user_id", "role_id"})
 }
 
+func TestFromTable_FieldForeignKeyWithoutNameUsesTableColumnConvention(t *testing.T) {
+	c := qt.New(t)
+
+	table := goschema.Table{
+		StructName: "Book",
+		Name:       "books",
+	}
+	fields := []goschema.Field{
+		{
+			StructName: "Book",
+			Name:       "author_id",
+			Type:       "INTEGER",
+			Foreign:    "authors(id)",
+		},
+	}
+
+	result := fromschema.FromTable(table, fields, nil, "postgres")
+	c.Assert(result, qt.IsNotNil)
+	c.Assert(result.Columns, qt.HasLen, 1)
+	c.Assert(result.Columns[0].ForeignKey, qt.IsNotNil)
+	c.Assert(result.Columns[0].ForeignKey.Name, qt.Equals, "fk_books_author_id")
+}
+
 func TestFromTable_PrimaryKeyParts(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -569,3 +569,24 @@ func TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified(t *t
 		})
 	}
 }
+
+func TestPlanner_GenerateMigrationAST_TableQualifiedPrimaryKeyAddition(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &types.SchemaDiff{
+				ConstraintsAdded: []string{"PRIMARY"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:      "PRIMARY",
+					TableName: "memberships",
+					Type:      "PRIMARY KEY",
+					Columns:   []string{"org_id", "user_id"},
+				}},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+			c.Assert(sql, qt.Contains, "ALTER TABLE memberships ADD PRIMARY KEY (org_id, user_id);")
+		})
+	}
+}

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -794,6 +794,19 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
+		if add.Type != "PRIMARY KEY" || add.TableName == "" || len(add.Columns) == 0 {
+			continue
+		}
+		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			continue
+		}
+		result = append(result, &ast.AlterTableNode{
+			Name:       add.TableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: ast.NewPrimaryKeyConstraint(add.Columns...)}},
+		})
+		handled[add.Name] = struct{}{}
+	}
+	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
 		}

--- a/migration/planner/dialects/postgres/hostless_constraints_test.go
+++ b/migration/planner/dialects/postgres/hostless_constraints_test.go
@@ -144,3 +144,21 @@ func TestPlanner_GenerateMigrationAST_EmptyTableNameAdditionTreatedAsHostless(t 
 	c.Assert(sql, qt.Not(qt.Contains), "information_schema.table_constraints",
 		qt.Commentf("the name-only DO block must not be used when removal hosts are known"))
 }
+
+func TestPlanner_GenerateMigrationAST_TableQualifiedPrimaryKeyAddition(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		ConstraintsAdded: []string{"memberships_pkey"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+			Name:      "memberships_pkey",
+			TableName: "memberships",
+			Type:      "PRIMARY KEY",
+			Columns:   []string{"org_id", "user_id"},
+		}},
+	}
+
+	sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(diff, &goschema.Database{})...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ALTER TABLE memberships ADD PRIMARY KEY (org_id, user_id);")
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1439,6 +1439,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
+	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
@@ -1481,6 +1482,29 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 			}
 			continue
 		}
+	}
+	return result
+}
+
+func (p *Planner) addPrimaryKeyConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	removalByTableName map[string]types.ConstraintRemovalInfo,
+	handled map[string]struct{},
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	for _, add := range additions {
+		if add.Type != "PRIMARY KEY" || add.TableName == "" || len(add.Columns) == 0 {
+			continue
+		}
+		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.emitModifyDrop(result, add, droppedForModify)
+		}
+		result = append(result, &ast.AlterTableNode{
+			Name:       add.TableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: ast.NewPrimaryKeyConstraint(add.Columns...)}},
+		})
+		handled[add.Name] = struct{}{}
 	}
 	return result
 }

--- a/migration/schemadiff/composite_primary_key_test.go
+++ b/migration/schemadiff/composite_primary_key_test.go
@@ -1,0 +1,106 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestCompareWithDialect_TableLevelCompositePrimaryKeyMatchesIntrospectedPostgresPrimaryKey(t *testing.T) {
+	c := qt.New(t)
+	generated := compositePrimaryKeySchema()
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "memberships",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "org_id", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "user_id", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "role", DataType: "text", IsNullable: "NO"},
+			},
+		}},
+		Constraints: []types.DBConstraint{{
+			Name:        "memberships_pkey",
+			TableName:   "memberships",
+			Type:        "PRIMARY KEY",
+			ColumnNames: []string{"org_id", "user_id"},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+}
+
+func TestCompareWithDialect_TableLevelCompositePrimaryKeyMissingFromExistingTableIsAdded(t *testing.T) {
+	c := qt.New(t)
+
+	generated := compositePrimaryKeySchema()
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "memberships",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "org_id", DataType: "integer", IsNullable: "NO"},
+				{Name: "user_id", DataType: "integer", IsNullable: "NO"},
+				{Name: "role", DataType: "text", IsNullable: "NO"},
+			},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+	c.Assert(diff.ConstraintsAdded, qt.DeepEquals, []string{"memberships_pkey"})
+	c.Assert(diff.ConstraintsAddedWithTables, qt.HasLen, 1)
+	c.Assert(diff.ConstraintsAddedWithTables[0].TableName, qt.Equals, "memberships")
+	c.Assert(diff.ConstraintsAddedWithTables[0].Type, qt.Equals, "PRIMARY KEY")
+	c.Assert(diff.ConstraintsAddedWithTables[0].Columns, qt.DeepEquals, []string{"org_id", "user_id"})
+	c.Assert(diff.TablesModified, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+}
+
+func TestCompareWithDialect_BlankTablePrimaryKeyDoesNotSynthesizeConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+			PrimaryKey: []string{""},
+		}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true, Nullable: false},
+			{StructName: "User", Name: "email", Type: "TEXT", Nullable: false},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "users",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "email", DataType: "text", IsNullable: "NO"},
+			},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+	c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+	c.Assert(diff.ConstraintsAddedWithTables, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+}
+
+func compositePrimaryKeySchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "Membership",
+			Name:       "memberships",
+			PrimaryKey: []string{"org_id", "user_id"},
+		}},
+		Fields: []goschema.Field{
+			{StructName: "Membership", Name: "org_id", Type: "INTEGER", Nullable: false},
+			{StructName: "Membership", Name: "user_id", Type: "INTEGER", Nullable: false},
+			{StructName: "Membership", Name: "role", Type: "TEXT", Nullable: false},
+		},
+	}
+}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -242,6 +242,9 @@ func TableColumns(genTable goschema.Table, dbTable types.DBTable, generated *gos
 	// Find modified columns
 	for colName, genCol := range genColumns {
 		if dbCol, exists := dbColumns[colName]; exists {
+			if columnInTablePrimaryKey(genTable, genCol.Name) {
+				genCol = normalizeTablePrimaryKeyColumn(genCol, dbCol)
+			}
 			colDiff := Columns(genCol, dbCol)
 			if len(colDiff.Changes) > 0 {
 				tableDiff.ColumnsModified = append(tableDiff.ColumnsModified, colDiff)
@@ -422,6 +425,39 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 	}
 
 	return colDiff
+}
+
+func normalizeTablePrimaryKeyColumn(genCol goschema.Field, dbCol types.DBColumn) goschema.Field {
+	genCol.Nullable = false
+	genCol.Primary = dbCol.IsPrimaryKey
+	return genCol
+}
+
+func columnInTablePrimaryKey(table goschema.Table, column string) bool {
+	return slices.Contains(tablePrimaryKeyColumns(table), column)
+}
+
+func tablePrimaryKeyColumns(table goschema.Table) []string {
+	if len(table.PrimaryKeyParts) == 0 {
+		return nonEmptyNames(table.PrimaryKey)
+	}
+	columns := make([]string, 0, len(table.PrimaryKeyParts))
+	for _, part := range table.PrimaryKeyParts {
+		if name := strings.TrimSpace(part.Name); name != "" {
+			columns = append(columns, name)
+		}
+	}
+	return columns
+}
+
+func nonEmptyNames(names []string) []string {
+	filtered := make([]string, 0, len(names))
+	for _, name := range names {
+		if name := strings.TrimSpace(name); name != "" {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
 }
 
 func generatedColumnDiff(genCol goschema.Field, dbCol types.DBColumn) string {
@@ -939,6 +975,15 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 		}
 	}
 
+	for _, synthesized := range synthesizeTablePrimaryKeyConstraints(generated, database, dialect) {
+		key := synthesized.Table + "." + synthesized.Name
+		// Don't clobber an explicit table-level constraint that happens to
+		// share the same name.
+		if _, exists := genConstraints[key]; !exists {
+			genConstraints[key] = synthesized
+		}
+	}
+
 	// Synthesize table-level Constraint entries from field-level `foreign=`
 	// annotations so on_delete / on_update drift on an existing field-level
 	// FK participates in comparison (issue #189), mirroring the field-level
@@ -1080,12 +1125,18 @@ func constraintDefinitionsChanged(genConstraint goschema.Constraint, dbConstrain
 		return checkConstraintChanged(genConstraint, dbConstraint)
 	case "UNIQUE":
 		return uniqueConstraintChanged(genConstraint, dbConstraint)
+	case "PRIMARY KEY":
+		return primaryKeyConstraintChanged(genConstraint, dbConstraint)
 	case "FOREIGN KEY":
 		return foreignKeyConstraintChanged(genConstraint, dbConstraint, dialect)
 	default:
 		// For unknown constraint types, assume no change
 		return false
 	}
+}
+
+func primaryKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
+	return !slices.Equal(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault())
 }
 
 // excludeConstraintChanged compares EXCLUDE constraint definitions
@@ -1419,6 +1470,55 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 		})
 	}
 	return synthesized
+}
+
+func synthesizeTablePrimaryKeyConstraints(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	dialect string,
+) []goschema.Constraint {
+	if generated == nil || database == nil {
+		return nil
+	}
+
+	dbTables := make(map[string]struct{}, len(database.Tables))
+	for _, table := range database.Tables {
+		dbTables[table.QualifiedName()] = struct{}{}
+	}
+
+	var synthesized []goschema.Constraint
+	for _, table := range generated.Tables {
+		columns := tablePrimaryKeyColumns(table)
+		if len(columns) == 0 {
+			continue
+		}
+		if _, exists := dbTables[table.QualifiedName()]; !exists {
+			continue
+		}
+
+		name := tablePrimaryKeyConstraintName(table, database.Constraints, dialect)
+		synthesized = append(synthesized, goschema.Constraint{
+			StructName: table.StructName,
+			Name:       name,
+			Type:       "PRIMARY KEY",
+			Table:      table.QualifiedName(),
+			Columns:    append([]string(nil), columns...),
+		})
+	}
+	return synthesized
+}
+
+func tablePrimaryKeyConstraintName(table goschema.Table, dbConstraints []types.DBConstraint, dialect string) string {
+	for _, constraint := range dbConstraints {
+		if constraint.Type == "PRIMARY KEY" && constraint.QualifiedTableName() == table.QualifiedName() {
+			return constraint.Name
+		}
+	}
+
+	if isMySQLFamily(dialect) {
+		return "PRIMARY"
+	}
+	return table.Name + "_pkey"
 }
 
 // synthesizeFieldLevelForeignKeyConstraints turns each field-level `foreign=`


### PR DESCRIPTION
## Summary
- assign conventional names to field-level foreign keys when converting schema fields to AST
- treat table-level primary keys as table constraints during schema comparison without creating blank constraints from parser defaults
- emit table-qualified primary key additions in PostgreSQL and MySQL/MariaDB planners

## Validation
- go test ./core/convert/fromschema ./migration/schemadiff ./migration/schemadiff/internal/compare ./migration/planner/dialects/postgres ./migration/planner/dialects/mysql -count=1
- golangci-lint run ./...
- GOWORK=/private/tmp/go.work CONFORMANCE_DB_URL=postgres://ptah_user:ptah_password@localhost:5433/conf?sslmode=disable make gate-live
- go test ./... -count=1