### PR TITLE
Close Atlas lex and lint conformance gaps

### DIFF
--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/sqlutil"
 )
 
 // Parser converts SQL tokens into AST nodes.
@@ -34,7 +35,7 @@ type Parser struct {
 //
 //	parser := NewParser("CREATE TABLE users (id INTEGER PRIMARY KEY);")
 func NewParser(input string) *Parser {
-	normalized := normalizeClientDelimiters(input)
+	normalized := sqlutil.NormalizeClientDelimiters(input)
 	l := lexer.NewLexer(normalized)
 	p := &Parser{
 		lexer:     l,

--- a/core/sqlutil/client_delimiters.go
+++ b/core/sqlutil/client_delimiters.go
@@ -1,8 +1,10 @@
-package parser
+package sqlutil
 
 import "strings"
 
-func normalizeClientDelimiters(input string) string {
+// NormalizeClientDelimiters rewrites MySQL DELIMITER and Atlas delimiter
+// directives into regular semicolon-terminated SQL before tokenization.
+func NormalizeClientDelimiters(input string) string {
 	delimiter := ";"
 	allowCommentDelimiter := false
 	var output strings.Builder
@@ -104,7 +106,7 @@ func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelim
 	for pos := 0; pos < len(input); {
 		switch {
 		case allowCommentDelimiter && strings.HasPrefix(input[pos:], delimiter):
-			output.WriteString(replacement)
+			writeDelimiterReplacement(&output, replacement)
 			pos += len(delimiter)
 		case strings.HasPrefix(input[pos:], "--"):
 			pos = writeUntilLineEnd(&output, input, pos)
@@ -115,7 +117,7 @@ func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelim
 		case input[pos] == '\'' || input[pos] == '"' || input[pos] == '`':
 			pos = writeQuotedSQL(&output, input, pos, input[pos])
 		case strings.HasPrefix(input[pos:], delimiter):
-			output.WriteString(replacement)
+			writeDelimiterReplacement(&output, replacement)
 			pos += len(delimiter)
 		case input[pos] == '$':
 			if nextPos, ok := writeDollarQuotedSQL(&output, input, pos); ok {
@@ -130,6 +132,28 @@ func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelim
 		}
 	}
 	return output.String()
+}
+
+func writeDelimiterReplacement(output *strings.Builder, replacement string) {
+	if builderEndsWithSemicolon(output) {
+		return
+	}
+	output.WriteString(replacement)
+}
+
+func builderEndsWithSemicolon(output *strings.Builder) bool {
+	text := output.String()
+	for i := len(text) - 1; i >= 0; i-- {
+		switch text[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case ';':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func isClientHashOperatorContinuation(input string, pos int) bool {

--- a/core/sqlutil/splitter.go
+++ b/core/sqlutil/splitter.go
@@ -40,6 +40,7 @@ func SplitSQLStatements(sql string) []string {
 		return []string{}
 	}
 
+	sql = NormalizeClientDelimiters(sql)
 	lexr := lexer.NewLexer(sql)
 	var statements []string
 	var currentStatement strings.Builder
@@ -87,10 +88,12 @@ func SplitSQLStatements(sql string) []string {
 }
 
 type statementSplitState struct {
-	afterCreate       bool
-	inCreateTrigger   bool
-	triggerCompound   bool
-	pendingTriggerEnd bool
+	createPrefix          createStatementPrefix
+	inCompoundCreate      bool
+	compoundDepth         int
+	caseDepth             int
+	pendingEndKeyword     bool
+	pendingCaseEndKeyword bool
 }
 
 func (s *statementSplitState) reset() {
@@ -103,37 +106,114 @@ func (s *statementSplitState) observe(token lexer.Token) {
 	}
 
 	value := strings.ToUpper(token.Value)
-	if !s.inCreateTrigger {
-		s.observeCreateTriggerPrefix(value)
-		return
-	}
-
-	if !s.triggerCompound {
-		s.triggerCompound = value == "BEGIN"
+	if !s.inCompoundCreate {
+		s.observeCreatePrefix(value)
 		return
 	}
 
 	switch value {
-	case "END":
-		s.pendingTriggerEnd = true
-	default:
-		if s.pendingTriggerEnd {
-			s.pendingTriggerEnd = false
+	case "CASE":
+		if s.pendingEndKeyword || s.pendingCaseEndKeyword {
+			s.pendingEndKeyword = false
+			s.pendingCaseEndKeyword = false
+			return
 		}
+		s.caseDepth++
+	case "BEGIN":
+		s.compoundDepth++
+		s.pendingEndKeyword = false
+		s.pendingCaseEndKeyword = false
+	case "END":
+		if s.caseDepth > 0 {
+			s.caseDepth--
+			s.pendingEndKeyword = false
+			s.pendingCaseEndKeyword = true
+			return
+		}
+		s.pendingEndKeyword = true
+		s.pendingCaseEndKeyword = false
+	default:
+		if s.pendingEndKeyword && isEndContinuationKeyword(value) {
+			s.pendingEndKeyword = false
+		}
+		s.pendingCaseEndKeyword = false
 	}
 }
 
-func (s *statementSplitState) observeCreateTriggerPrefix(value string) {
-	if value == "CREATE" {
-		s.afterCreate = true
+type createStatementPrefix int
+
+const (
+	createPrefixNone createStatementPrefix = iota
+	createPrefixCreate
+	createPrefixCreateObject
+	createPrefixCreateObjectBeforeBody
+)
+
+func (s *statementSplitState) observeCreatePrefix(value string) {
+	switch s.createPrefix {
+	case createPrefixNone:
+		if value == "CREATE" {
+			s.createPrefix = createPrefixCreate
+		}
 		return
-	}
-	if s.afterCreate && value == "TRIGGER" {
-		s.inCreateTrigger = true
+
+	case createPrefixCreate:
+		if isCompoundCreateObject(value) {
+			s.createPrefix = createPrefixCreateObject
+			return
+		}
+		if value == "OR" || value == "REPLACE" || value == "DEFINER" {
+			return
+		}
+		s.createPrefix = createPrefixNone
+		return
+
+	case createPrefixCreateObject:
+		s.createPrefix = createPrefixCreateObjectBeforeBody
+		return
+
+	case createPrefixCreateObjectBeforeBody:
+		if value == "BEGIN" {
+			s.inCompoundCreate = true
+			s.compoundDepth = 1
+			s.pendingEndKeyword = false
+		}
 		return
 	}
 }
 
-func (s statementSplitState) keepSemicolonInsideStatement() bool {
-	return s.inCreateTrigger && s.triggerCompound && !s.pendingTriggerEnd
+func isCompoundCreateObject(value string) bool {
+	switch value {
+	case "FUNCTION", "PROCEDURE", "TRIGGER":
+		return true
+	default:
+		return false
+	}
+}
+
+func isEndContinuationKeyword(value string) bool {
+	switch value {
+	case "IF", "LOOP", "REPEAT", "WHILE", "CASE":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *statementSplitState) keepSemicolonInsideStatement() bool {
+	if !s.inCompoundCreate {
+		return false
+	}
+	if !s.pendingEndKeyword {
+		return true
+	}
+	if s.compoundDepth > 0 {
+		s.compoundDepth--
+	}
+	s.pendingEndKeyword = false
+	if s.compoundDepth == 0 {
+		s.inCompoundCreate = false
+		return false
+	}
+	return true
 }

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -220,6 +220,152 @@ END`,
 	}
 }
 
+func TestSplitSQLStatements_ClientDelimiters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name: "mysql delimiter command",
+			input: `DELIMITER $$
+CREATE FUNCTION gen_uuid() RETURNS VARCHAR(22)
+BEGIN
+    RETURN concat(NOW(6), RAND());
+END;$$
+DELIMITER ;
+CALL gen_uuid();`,
+			expected: []string{
+				`CREATE FUNCTION gen_uuid() RETURNS VARCHAR(22)
+BEGIN
+    RETURN concat(NOW(6), RAND());
+END`,
+				"CALL gen_uuid()",
+			},
+		},
+		{
+			name: "atlas comment delimiter",
+			input: `-- atlas:delimiter -- end
+
+CREATE PROCEDURE dorepeat(p1 INT)
+BEGIN
+    SET @x = 0;
+END;
+-- end
+CALL dorepeat(1000);`,
+			expected: []string{
+				`CREATE PROCEDURE dorepeat(p1 INT)
+BEGIN
+    SET @x = 0;
+END`,
+				"CALL dorepeat(1000)",
+			},
+		},
+		{
+			name: "atlas escaped blank line delimiter",
+			input: `-- atlas:delimiter \n\n
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+CREATE OR REPLACE FUNCTION public.slugify(
+    v TEXT
+) RETURNS TEXT STRICT IMMUTABLE AS $$
+BEGIN
+    RETURN lower(v);
+END;
+LANGUAGE plpgsql;
+`,
+			expected: []string{
+				"CREATE EXTENSION IF NOT EXISTS unaccent",
+				`CREATE OR REPLACE FUNCTION public.slugify(
+    v TEXT
+) RETURNS TEXT STRICT IMMUTABLE AS $$
+BEGIN
+    RETURN lower(v);
+END;
+LANGUAGE plpgsql;`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := sqlutil.SplitSQLStatements(tt.input)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestSplitSQLStatements_CompoundRoutineBodies(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE PROCEDURE CompProc(IN p INT)
+BEGIN
+    DECLARE v1 INT DEFAULT 0;
+    BEGIN
+        IF v1 > 100 THEN
+            CALL OtherProc(p);
+        END IF;
+    END;
+END;
+
+CREATE FUNCTION CompFunc(eID INT) RETURNS INT
+BEGIN
+    DECLARE b INT;
+    RETURN b;
+END;
+
+CREATE TABLE after_routines (id INT);`
+
+	result := sqlutil.SplitSQLStatements(input)
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE PROCEDURE CompProc(IN p INT)
+BEGIN
+    DECLARE v1 INT DEFAULT 0;
+    BEGIN
+        IF v1 > 100 THEN
+            CALL OtherProc(p);
+        END IF;
+    END;
+END`,
+		`CREATE FUNCTION CompFunc(eID INT) RETURNS INT
+BEGIN
+    DECLARE b INT;
+    RETURN b;
+END`,
+		"CREATE TABLE after_routines (id INT)",
+	})
+}
+
+func TestSplitSQLStatements_CompoundBodiesWithCaseExpressions(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE
+    WHEN (new.a = 4) THEN RAISE(IGNORE) END;
+END;
+
+CREATE FUNCTION functest_S_15(x int) RETURNS boolean
+    LANGUAGE SQL
+BEGIN ATOMIC
+select case when x % 2 = 0 then true else false end;
+END;`
+
+	result := sqlutil.SplitSQLStatements(input)
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE TRIGGER before_tbl_insert BEFORE INSERT ON tbl BEGIN SELECT CASE
+    WHEN (new.a = 4) THEN RAISE(IGNORE) END;
+END`,
+		`CREATE FUNCTION functest_S_15(x int) RETURNS boolean
+    LANGUAGE SQL
+BEGIN ATOMIC
+select case when x % 2 = 0 then true else false end;
+END`,
+	})
+}
+
 func TestSplitSQLStatements_Comments(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -114,6 +114,9 @@ type File struct {
 	// independently of the migrator's parser as defense in depth (see the
 	// strictNameRe comment).
 	WellFormedName bool
+	// NoTransaction reports whether file-scoped directives opt this migration
+	// out of the migrator's transaction wrapper.
+	NoTransaction bool
 	// Statements holds the parsed statements of up migrations. Empty for
 	// down migrations (statement rules do not run there).
 	Statements []Statement
@@ -336,6 +339,7 @@ func prepareFile(
 		// .up.sql files whose version prefix is malformed.
 		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
 		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
+		NoTransaction:  fileNoTransactionDirective(string(raw)),
 	}
 	switch {
 	case atlasFormat:
@@ -382,6 +386,18 @@ func parseKnownMigrationName(name string) (*migrator.MigrationFile, error) {
 		return parsed, nil
 	}
 	return migrator.ParseAtlasMigrationFileNameForAutoDetection(name)
+}
+
+func fileNoTransactionDirective(sql string) bool {
+	if value := migrator.ParseFileDirectives(sql)[migrator.DirectiveNoTransaction]; value == "true" {
+		return true
+	}
+	for line := range strings.Lines(sql) {
+		if strings.EqualFold(strings.TrimSpace(line), "-- atlas:txmode none") {
+			return true
+		}
+	}
+	return false
 }
 
 // runRules applies every enabled rule to one prepared file.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -231,8 +231,8 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		{"drop system versioning", "ALTER TABLE users DROP SYSTEM VERSIONING;", nil},
 
 		// Columns that happen to be named like keywords are not hazards.
-		{"column named type set not null", "ALTER TABLE users ALTER COLUMN type SET NOT NULL;", nil},
-		{"quoted column named type", `ALTER TABLE users ALTER COLUMN "type" SET NOT NULL;`, nil},
+		{"column named type set not null", "ALTER TABLE users ALTER COLUMN type SET NOT NULL;", []string{"LT101", "PG303"}},
+		{"quoted column named type", `ALTER TABLE users ALTER COLUMN "type" SET NOT NULL;`, []string{"LT101", "PG303"}},
 		{"column named not drop default", "ALTER TABLE users ALTER COLUMN not DROP DEFAULT;", nil},
 		{"added column named modify", "ALTER TABLE users ADD COLUMN modify TEXT;", nil},
 		{"added column named rename", "ALTER TABLE users ADD COLUMN rename TEXT;", nil},
@@ -277,7 +277,7 @@ func TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards(t *testing.T) {
 		{"comment inside alter clause", "ALTER TABLE users DROP/*hidden*/COLUMN email;", []string{"DS102"}},
 		{"hazard text inside a string literal", "ALTER TABLE t ADD COLUMN note TEXT DEFAULT 'use DROP COLUMN x';", nil},
 		{"concurrently in a literal is no guard", "CREATE INDEX i ON t (a) WHERE b = 'CONCURRENTLY';", []string{"PG101"}},
-		{"create index concurrently is safe", "CREATE UNIQUE INDEX CONCURRENTLY uq ON t (a);", nil},
+		{"create index concurrently requires non-transactional migration", "CREATE UNIQUE INDEX CONCURRENTLY uq ON t (a);", []string{"PG103"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -288,6 +288,94 @@ func TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards(t *testing.T) {
 			} else {
 				c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
 			}
+		})
+	}
+}
+
+func TestLintFS_AtlasAnalyzerCatalogHazards(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		want    []string
+	}{
+		{"drop schema", "postgres", "DROP SCHEMA s;", []string{"DS107"}},
+		{"add non-nullable column without default", "postgres", "ALTER TABLE t ADD COLUMN c INT NOT NULL;", []string{"DD101"}},
+		{"add unique constraint", "postgres", "ALTER TABLE t ADD CONSTRAINT u UNIQUE (email);", []string{"PG105"}},
+		{"drop index without concurrently", "postgres", "DROP INDEX idx;", []string{"PG106"}},
+		{"add primary key", "postgres", "ALTER TABLE t ADD PRIMARY KEY (id);", []string{"PG104"}},
+		{"volatile default", "postgres", "ALTER TABLE t ADD COLUMN c UUID DEFAULT gen_random_uuid();", []string{"PG302"}},
+		{"set not null", "postgres", "ALTER TABLE t ALTER COLUMN c SET NOT NULL;", []string{"PG303"}},
+		{"add check", "postgres", "ALTER TABLE t ADD CONSTRAINT ck CHECK (id > 0);", []string{"PG305"}},
+		{"add foreign key", "postgres", "ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (p_id) REFERENCES p (id);", []string{"PG306"}},
+		{"set unlogged", "postgres", "ALTER TABLE t SET UNLOGGED;", []string{"PG307"}},
+		{"create trigger", "postgres", "CREATE TRIGGER tr BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION f();", []string{"PG308"}},
+		{"stored generated column", "postgres", "ALTER TABLE t ADD COLUMN g INT GENERATED ALWAYS AS (c * 2) STORED;", []string{"PG309"}},
+		{"identity column", "postgres", "ALTER TABLE t ADD COLUMN n INT GENERATED ALWAYS AS IDENTITY;", []string{"PG310"}},
+		{"access method", "postgres", "ALTER TABLE t SET ACCESS METHOD heap2;", []string{"PG311"}},
+		{"column alignment", "postgres", "CREATE TABLE t (a BOOLEAN, b BIGINT, c BOOLEAN, d BIGINT);", []string{"PG110"}},
+		{"mysql inline references", "mysql", "ALTER TABLE t ADD COLUMN p_id INT REFERENCES p (id);", []string{"MY102"}},
+		{"mysql add foreign key", "mysql", "ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (p_id) REFERENCES p (id);", []string{"MY131"}},
+		{"mysql add primary key", "mysql", "ALTER TABLE t ADD PRIMARY KEY (id);", []string{"MY132"}},
+		{"mysql fulltext index", "mysql", "ALTER TABLE t ADD FULLTEXT INDEX ft (c);", []string{"MY134"}},
+		{"mysql spatial index", "mysql", "ALTER TABLE t ADD SPATIAL INDEX sp (g);", []string{"MY135"}},
+		{"sqlite set not null", "sqlite", "ALTER TABLE t ALTER COLUMN c SET NOT NULL;", []string{"LT101"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := lintOneDialect(c, tt.dialect, tt.sql)
+			c.Assert(got, qt.DeepEquals, tt.want, qt.Commentf("sql: %s", tt.sql))
+		})
+	}
+}
+
+func TestLintFS_TransactionHazards(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_x.up.sql": `CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;
+`,
+		"0000000001_x.down.sql": "-- restore\n",
+	})
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG103", "TX101"})
+
+	c.Assert(lintOneDialect(c, "postgres", "BEGIN;\nALTER TABLE t ADD COLUMN c INT;\nCOMMIT;"), qt.DeepEquals, []string{"TX201"})
+}
+
+func TestLintFS_NonTransactionalDirectivesSuppressTransactionFindings(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "ptah directive",
+			sql: `-- +ptah no_transaction
+CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;`,
+		},
+		{
+			name: "atlas directive",
+			sql: `-- atlas:txmode none
+CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			fsys := fixture(map[string]string{
+				"0000000001_x.up.sql":   tt.sql,
+				"0000000001_x.down.sql": "-- restore\n",
+			})
+			findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(findings), qt.HasLen, 0)
 		})
 	}
 }
@@ -305,7 +393,7 @@ func TestLintFS_DialectAwareScanning(t *testing.T) {
 		{"postgres trailing backslash literal", "postgres",
 			"INSERT INTO paths (prefix) VALUES ('C:\\');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
 		{"postgres like escape literal", "postgres",
-			"ALTER TABLE t ADD CONSTRAINT chk CHECK (code NOT LIKE '%\\_%' ESCAPE '\\');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},
+			"ALTER TABLE t ADD CONSTRAINT chk CHECK (code NOT LIKE '%\\_%' ESCAPE '\\');\nALTER TABLE users DROP COLUMN email;", []string{"PG305", "DS102"}},
 		// MySQL treats backslash as an escape: \' stays inside the literal.
 		{"mysql backslash-escaped quote", "mysql",
 			"INSERT INTO notes (t) VALUES ('it\\'s; fine');\nALTER TABLE users DROP COLUMN email;", []string{"DS102"}},

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -13,10 +13,13 @@ import (
 func Rules() []Rule {
 	var rules []Rule
 	rules = append(rules, dataSafetyRules()...)
+	rules = append(rules, dataDependentRules()...)
 	rules = append(rules, migrationFormRules()...)
 	rules = append(rules, compatibilityRules()...)
 	rules = append(rules, postgresRules()...)
 	rules = append(rules, mysqlRules()...)
+	rules = append(rules, sqliteRules()...)
+	rules = append(rules, transactionRules()...)
 	return rules
 }
 
@@ -187,6 +190,23 @@ func rlsDisabledRule() Rule {
 	}
 }
 
+// dataDependentRules covers changes whose safety depends on existing row data.
+func dataDependentRules() []Rule {
+	return []Rule{
+		{
+			Code:     "DD101",
+			Title:    "non-nullable column added without a default",
+			Severity: SeverityWarning,
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddColumnNotNullWithoutDefault(stmt.Words) {
+					return false, ""
+				}
+				return true, "adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it nullable, backfill, then enforce NOT NULL in a later migration"
+			},
+		},
+	}
+}
+
 // migrationFormRules covers the MF family: file-level migration hygiene.
 func migrationFormRules() []Rule {
 	return []Rule{
@@ -274,56 +294,197 @@ func compatibilityRules() []Rule {
 // postgresRules covers the PG family: PostgreSQL-specific hazards.
 func postgresRules() []Rule {
 	return []Rule{
-		{
-			Code:     "PG101",
-			Title:    "index built with a table lock",
-			Severity: SeverityWarning,
-			Dialects: []string{"postgres"},
-			// File-level: an index on a table this same migration created is
-			// built on an empty table — no lock hazard, and CONCURRENTLY
-			// would be impossible inside the transactional migration anyway.
-			CheckFile: func(file *File) []Finding {
-				if !file.IsUp {
-					return nil
+		postgresCreateIndexRule(),
+		postgresEnumAddValueRule(),
+		postgresConcurrentIndexRule(),
+		postgresAddPrimaryKeyRule(),
+		postgresAddUniqueConstraintRule(),
+		postgresDropIndexRule(),
+		postgresColumnAlignmentRule(),
+		postgresVolatileDefaultRule(),
+		postgresSetNotNullRule(),
+		postgresAddCheckRule(),
+		postgresAddForeignKeyRule(),
+		postgresSetPersistenceRule(),
+		postgresCreateTriggerRule(),
+		postgresAddStoredGeneratedRule(),
+		postgresAddIdentityRule(),
+		postgresSetAccessMethodRule(),
+	}
+}
+
+func postgresCreateIndexRule() Rule {
+	return Rule{
+		Code:     "PG101",
+		Title:    "index built with a table lock",
+		Severity: SeverityWarning,
+		Dialects: []string{"postgres"},
+		// File-level: an index on a table this same migration created is
+		// built on an empty table, so there is no lock hazard.
+		CheckFile: func(file *File) []Finding {
+			if !file.IsUp {
+				return nil
+			}
+			var findings []Finding
+			created := map[string]bool{}
+			for i := range file.Statements {
+				stmt := &file.Statements[i]
+				if ref := createdTableRef(stmt.Words); ref != "" {
+					created[ref] = true
+					continue
 				}
-				var findings []Finding
-				created := map[string]bool{}
-				for i := range file.Statements {
-					stmt := &file.Statements[i]
-					if ref := createdTableRef(stmt.Words); ref != "" {
-						created[ref] = true
-						continue
-					}
-					if !isCreateIndex(stmt.Words) || slices.Contains(stmt.Words, "CONCURRENTLY") {
-						continue
-					}
-					if refersToCreated(created, indexTargetRef(stmt.Words)) {
-						continue
-					}
-					findings = append(findings, Finding{
-						Rule:     "PG101",
-						Title:    "index built with a table lock",
-						Severity: SeverityWarning,
-						File:     file.Path,
-						Line:     stmt.Line,
-						Message:  "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction",
-					})
+				if !isCreateIndex(stmt.Words) || slices.Contains(stmt.Words, "CONCURRENTLY") {
+					continue
 				}
-				return findings
-			},
+				if refersToCreated(created, indexTargetRef(stmt.Words)) {
+					continue
+				}
+				findings = append(findings, Finding{
+					Rule:     "PG101",
+					Title:    "index built with a table lock",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Line:     stmt.Line,
+					Message:  "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction",
+				})
+			}
+			return findings
 		},
-		{
-			Code:     "PG102",
-			Title:    "enum value added inside a transaction",
-			Severity: SeverityWarning,
-			Dialects: []string{"postgres"},
-			CheckStatement: func(stmt *Statement) (bool, string) {
-				if !hasWordPrefix(stmt.Words, "ALTER", "TYPE") || !hasWordSeq(stmt.Words, "ADD", "VALUE") {
-					return false, ""
+	}
+}
+
+func postgresEnumAddValueRule() Rule {
+	return postgresStatementRule("PG102", "enum value added inside a transaction", func(stmt *Statement) (bool, string) {
+		if !hasWordPrefix(stmt.Words, "ALTER", "TYPE") || !hasWordSeq(stmt.Words, "ADD", "VALUE") {
+			return false, ""
+		}
+		return true, "ALTER TYPE ... ADD VALUE cannot run inside a transaction block before PostgreSQL 12, and the new value stays unusable within the same transaction on newer versions; run it in its own non-transactional migration"
+	})
+}
+
+func postgresConcurrentIndexRule() Rule {
+	return Rule{
+		Code:     "PG103",
+		Title:    "concurrent index operation in a transactional migration",
+		Severity: SeverityWarning,
+		Dialects: []string{"postgres"},
+		CheckFile: func(file *File) []Finding {
+			if !file.IsUp || file.NoTransaction {
+				return nil
+			}
+			var findings []Finding
+			for i := range file.Statements {
+				stmt := &file.Statements[i]
+				if !scanConcurrentIndexOperation(stmt.Words) {
+					continue
 				}
-				return true, "ALTER TYPE ... ADD VALUE cannot run inside a transaction block before PostgreSQL 12, and the new value stays unusable within the same transaction on newer versions; run it in its own non-transactional migration"
-			},
+				findings = append(findings, Finding{
+					Rule:     "PG103",
+					Title:    "concurrent index operation in a transactional migration",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Line:     stmt.Line,
+					Message:  "CONCURRENTLY cannot run inside PostgreSQL's normal migration transaction; mark the migration non-transactional before applying",
+				})
+			}
+			return findings
 		},
+	}
+}
+
+func postgresAddPrimaryKeyRule() Rule {
+	return postgresAlterRule("PG104", "primary key added with an access-exclusive lock", scanAddPrimaryKey,
+		"adding a primary key takes an ACCESS EXCLUSIVE lock and can scan existing rows; build a supporting unique index concurrently first, then attach it")
+}
+
+func postgresAddUniqueConstraintRule() Rule {
+	return postgresAlterRule("PG105", "unique constraint added with an access-exclusive lock", scanAddUniqueConstraint,
+		"adding a unique constraint takes an ACCESS EXCLUSIVE lock and validates existing rows; build a unique index concurrently first when the table is populated")
+}
+
+func postgresDropIndexRule() Rule {
+	return postgresStatementRule("PG106", "index dropped with a table lock", func(stmt *Statement) (bool, string) {
+		if !hasWordPrefix(stmt.Words, "DROP", "INDEX") || slices.Contains(stmt.Words, "CONCURRENTLY") {
+			return false, ""
+		}
+		return true, "DROP INDEX without CONCURRENTLY blocks writes while PostgreSQL removes the index; use DROP INDEX CONCURRENTLY outside a transaction for populated tables"
+	})
+}
+
+func postgresColumnAlignmentRule() Rule {
+	return postgresStatementRule("PG110", "non-optimal column alignment", func(stmt *Statement) (bool, string) {
+		if !scanCreateTableMixedAlignment(stmt.Words) {
+			return false, ""
+		}
+		return true, "this PostgreSQL column order can waste tuple padding; place wider fixed-size columns before narrow columns when creating large tables"
+	})
+}
+
+func postgresVolatileDefaultRule() Rule {
+	return postgresAlterRule("PG302", "volatile default rewrites existing rows", scanAddColumnWithVolatileDefault,
+		"adding a column with a volatile DEFAULT rewrites or evaluates every existing row; add the column first, backfill in batches, then set the default")
+}
+
+func postgresSetNotNullRule() Rule {
+	return postgresAlterRule("PG303", "not-null validation scans existing rows", scanSetNotNull,
+		"SET NOT NULL scans the table to validate existing rows; backfill first and consider a validated CHECK constraint path on large tables")
+}
+
+func postgresAddCheckRule() Rule {
+	return postgresAlterRule("PG305", "check constraint validates existing rows", scanAddCheckConstraint,
+		"adding a CHECK constraint validates existing rows and can hold locks; add it NOT VALID first, then validate separately")
+}
+
+func postgresAddForeignKeyRule() Rule {
+	return postgresAlterRule("PG306", "foreign key validates existing rows", scanAddForeignKey,
+		"adding a foreign key validates existing rows and can block writes on both tables; add it NOT VALID first, then validate separately")
+}
+
+func postgresSetPersistenceRule() Rule {
+	return postgresAlterRule("PG307", "table persistence changed", scanSetTablePersistence,
+		"changing LOGGED/UNLOGGED rewrites the table and takes heavyweight locks; schedule it as a maintenance operation")
+}
+
+func postgresCreateTriggerRule() Rule {
+	return postgresStatementRule("PG308", "trigger added with a write-blocking lock", func(stmt *Statement) (bool, string) {
+		if !hasWordPrefix(stmt.Words, "CREATE", "TRIGGER") {
+			return false, ""
+		}
+		return true, "CREATE TRIGGER takes a SHARE ROW EXCLUSIVE lock and can block concurrent writes; deploy during a quiet window on hot tables"
+	})
+}
+
+func postgresAddStoredGeneratedRule() Rule {
+	return postgresAlterRule("PG309", "stored generated column rewrites rows", scanAddStoredGeneratedColumn,
+		"adding a STORED generated column computes and stores a value for every existing row; plan the rewrite and lock impact")
+}
+
+func postgresAddIdentityRule() Rule {
+	return postgresAlterRule("PG310", "identity column rewrites rows", scanAddIdentityColumn,
+		"adding an identity column can rewrite existing rows and requires sequence ownership changes; use a staged nullable column path on populated tables")
+}
+
+func postgresSetAccessMethodRule() Rule {
+	return postgresAlterRule("PG311", "table access method changed", scanSetAccessMethod,
+		"changing a table's access method rewrites the table; schedule it as a maintenance operation")
+}
+
+func postgresAlterRule(code, title string, scan func([]string) bool, message string) Rule {
+	return postgresStatementRule(code, title, func(stmt *Statement) (bool, string) {
+		if !isAlterTable(stmt.Words) || !scan(stmt.Words) {
+			return false, ""
+		}
+		return true, message
+	})
+}
+
+func postgresStatementRule(code, title string, check func(*Statement) (bool, string)) Rule {
+	return Rule{
+		Code:           code,
+		Title:          title,
+		Severity:       SeverityWarning,
+		Dialects:       []string{"postgres"},
+		CheckStatement: check,
 	}
 }
 
@@ -339,13 +500,143 @@ func mysqlRules() []Rule {
 				if !isAlterTable(stmt.Words) {
 					return false, ""
 				}
-				heavy := scanModifyChange(stmt.Words) || scanConvertCharset(stmt.Words)
+				heavy := scanModifyChange(stmt.Words) || scanConvertCharset(stmt.Words) ||
+					scanAddColumnNotNullWithoutDefault(stmt.Words)
 				if !heavy || scanPinnedOnlineDDL(stmt.Words) {
 					return false, ""
 				}
 				return true, "this ALTER TABLE form usually rebuilds the table and blocks writes for the duration on MySQL/MariaDB; " +
 					"for large tables use an online-DDL tool (gh-ost, pt-online-schema-change), or pin ALGORITHM=INPLACE/LOCK=NONE " +
 					"so the server refuses a blocking rebuild instead of performing it"
+			},
+		},
+		{
+			Code:     "MY102",
+			Title:    "inline reference ignored on added column",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddColumnInlineReference(stmt.Words) {
+					return false, ""
+				}
+				return true, "MySQL ignores inline REFERENCES in ADD COLUMN; add an explicit FOREIGN KEY constraint instead"
+			},
+		},
+		{
+			Code:     "MY131",
+			Title:    "foreign key added with blocking DDL",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddForeignKey(stmt.Words) {
+					return false, ""
+				}
+				return true, "adding a foreign key can copy or lock the table and block writes on MySQL/MariaDB; use an online migration plan for populated tables"
+			},
+		},
+		{
+			Code:     "MY132",
+			Title:    "primary key added with table rebuild",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddPrimaryKey(stmt.Words) {
+					return false, ""
+				}
+				return true, "adding a primary key rebuilds the table and blocks DML on MySQL/MariaDB; use a staged online-DDL path for large tables"
+			},
+		},
+		{
+			Code:     "MY134",
+			Title:    "fulltext index added with blocking DDL",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddIndexKind(stmt.Words, "FULLTEXT") {
+					return false, ""
+				}
+				return true, "adding a FULLTEXT index can rebuild the table and block writes on MySQL/MariaDB; use an online-DDL strategy for populated tables"
+			},
+		},
+		{
+			Code:     "MY135",
+			Title:    "spatial index added with blocking DDL",
+			Severity: SeverityWarning,
+			Dialects: []string{"mysql", "mariadb"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanAddIndexKind(stmt.Words, "SPATIAL") {
+					return false, ""
+				}
+				return true, "adding a SPATIAL index can rebuild the table and block writes on MySQL/MariaDB; use an online-DDL strategy for populated tables"
+			},
+		},
+	}
+}
+
+func sqliteRules() []Rule {
+	return []Rule{
+		{
+			Code:     "LT101",
+			Title:    "not-null constraint added without a default",
+			Severity: SeverityWarning,
+			Dialects: []string{"sqlite"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !isAlterTable(stmt.Words) || !scanSetNotNull(stmt.Words) {
+					return false, ""
+				}
+				return true, "SQLite cannot safely enforce NOT NULL on existing nullable data without a staged rebuild and backfill"
+			},
+		},
+	}
+}
+
+func transactionRules() []Rule {
+	return []Rule{
+		{
+			Code:     "TX101",
+			Title:    "transactional and non-transactional statements mixed",
+			Severity: SeverityWarning,
+			Dialects: []string{"postgres"},
+			CheckFile: func(file *File) []Finding {
+				if !file.IsUp || file.NoTransaction {
+					return nil
+				}
+				var nonTransactional *Statement
+				transactional := false
+				for i := range file.Statements {
+					stmt := &file.Statements[i]
+					if isTransactionControlStatement(stmt.Words) {
+						continue
+					}
+					if isPostgresNonTransactionalStatement(stmt.Words) {
+						nonTransactional = stmt
+						continue
+					}
+					transactional = true
+				}
+				if nonTransactional == nil || !transactional {
+					return nil
+				}
+				return []Finding{{
+					Rule:     "TX101",
+					Title:    "transactional and non-transactional statements mixed",
+					Severity: SeverityWarning,
+					File:     file.Path,
+					Line:     nonTransactional.Line,
+					Message:  "this migration mixes PostgreSQL statements that require autocommit with transactional DDL; split them into separate migrations",
+				}}
+			},
+		},
+		{
+			Code:     "TX201",
+			Title:    "transaction block embedded in migration",
+			Severity: SeverityWarning,
+			Dialects: []string{"postgres"},
+			CheckStatement: func(stmt *Statement) (bool, string) {
+				if !hasWordPrefix(stmt.Words, "BEGIN") && !hasWordPrefix(stmt.Words, "START", "TRANSACTION") {
+					return false, ""
+				}
+				return true, "explicit transaction blocks conflict with the migrator's transaction management; remove BEGIN/COMMIT or mark the migration non-transactional"
 			},
 		},
 	}
@@ -614,7 +905,7 @@ func scanDestructiveObjectDrop(w []string) bool {
 		return false
 	}
 	switch w[1] {
-	case "TYPE", "EXTENSION", "FUNCTION", "ROLE", "POLICY":
+	case "TYPE", "EXTENSION", "FUNCTION", "ROLE", "POLICY", "SCHEMA":
 		return true
 	default:
 		return false
@@ -632,6 +923,281 @@ func scanConvertCharset(w []string) bool {
 		}
 	}
 	return false
+}
+
+func scanAddColumnNotNullWithoutDefault(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		start, end, ok := addColumnClause(w, i)
+		if !ok {
+			continue
+		}
+		clause := w[start:end]
+		if hasWordSeq(clause, "NOT", "NULL") && !slices.Contains(clause, "DEFAULT") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddColumnWithVolatileDefault(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		start, end, ok := addColumnClause(w, i)
+		if !ok {
+			continue
+		}
+		clause := w[start:end]
+		for j := range clause {
+			if clause[j] == "DEFAULT" && j+1 < len(clause) && isVolatilePostgresDefault(clause[j+1]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func scanAddColumnInlineReference(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		start, end, ok := addColumnClause(w, i)
+		if ok && slices.Contains(w[start:end], "REFERENCES") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddStoredGeneratedColumn(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		start, end, ok := addColumnClause(w, i)
+		if ok && hasWordSeq(w[start:end], "GENERATED", "ALWAYS", "AS") && slices.Contains(w[start:end], "STORED") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddIdentityColumn(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		start, end, ok := addColumnClause(w, i)
+		if ok && hasWordSeq(w[start:end], "GENERATED", "ALWAYS", "AS", "IDENTITY") {
+			return true
+		}
+	}
+	return false
+}
+
+func addColumnClause(w []string, i int) (start int, end int, ok bool) {
+	if i >= len(w) || w[i] != "ADD" {
+		return 0, 0, false
+	}
+	j := i + 1
+	if j < len(w) && w[j] == "COLUMN" {
+		j++
+	}
+	if j < len(w) && addConstraintTargets[w[j]] {
+		return 0, 0, false
+	}
+	j = skipIfNotExists(w, j)
+	if j >= len(w) || !identLike(w[j]) {
+		return 0, 0, false
+	}
+	return j + 1, clauseEnd(w, i), true
+}
+
+var addConstraintTargets = map[string]bool{
+	"CHECK":      true,
+	"CONSTRAINT": true,
+	"FOREIGN":    true,
+	"FULLTEXT":   true,
+	"INDEX":      true,
+	"KEY":        true,
+	"PRIMARY":    true,
+	"SPATIAL":    true,
+	"UNIQUE":     true,
+}
+
+func skipIfNotExists(w []string, j int) int {
+	if j+2 < len(w) && w[j] == "IF" && w[j+1] == "NOT" && w[j+2] == "EXISTS" {
+		return j + 3
+	}
+	return j
+}
+
+func clauseEnd(w []string, start int) int {
+	depth := 0
+	for i := start; i < len(w); i++ {
+		switch w[i] {
+		case "(":
+			depth++
+		case ")":
+			if depth > 0 {
+				depth--
+			}
+		case ",":
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return len(w)
+}
+
+func isVolatilePostgresDefault(word string) bool {
+	switch strings.Trim(word, "\"`") {
+	case "GEN_RANDOM_UUID", "UUID_GENERATE_V4", "NOW", "CLOCK_TIMESTAMP", "RANDOM":
+		return true
+	default:
+		return false
+	}
+}
+
+func scanConcurrentIndexOperation(w []string) bool {
+	if isCreateIndex(w) {
+		return slices.Contains(w, "CONCURRENTLY")
+	}
+	return hasWordPrefix(w, "DROP", "INDEX") && slices.Contains(w, "CONCURRENTLY")
+}
+
+func scanAddPrimaryKey(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if hasWordPrefix(w[i:], "ADD", "PRIMARY", "KEY") ||
+			hasWordPrefix(w[i:], "ADD", "CONSTRAINT") && slices.Contains(w[i:clauseEnd(w, i)], "PRIMARY") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddUniqueConstraint(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		clause := w[i:clauseEnd(w, i)]
+		if hasWordPrefix(clause, "ADD", "UNIQUE") ||
+			hasWordPrefix(clause, "ADD", "CONSTRAINT") && slices.Contains(clause, "UNIQUE") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddCheckConstraint(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		clause := w[i:clauseEnd(w, i)]
+		if hasWordPrefix(clause, "ADD", "CHECK") ||
+			hasWordPrefix(clause, "ADD", "CONSTRAINT") && slices.Contains(clause, "CHECK") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddForeignKey(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		clause := w[i:clauseEnd(w, i)]
+		if hasWordPrefix(clause, "ADD", "FOREIGN", "KEY") ||
+			hasWordPrefix(clause, "ADD", "CONSTRAINT") && hasWordSeq(clause, "FOREIGN", "KEY") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanSetTablePersistence(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if hasWordPrefix(w[i:], "SET", "LOGGED") || hasWordPrefix(w[i:], "SET", "UNLOGGED") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanSetAccessMethod(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if hasWordPrefix(w[i:], "SET", "ACCESS", "METHOD") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanSetNotNull(w []string) bool {
+	for _, i := range clauseStarts(w) {
+		if hasWordPrefix(w[i:], "ALTER", "COLUMN") && hasWordSeq(w[i:], "SET", "NOT", "NULL") {
+			return true
+		}
+		if hasWordPrefix(w[i:], "ALTER") && len(w[i:]) > 1 && identLike(w[i+1]) && hasWordSeq(w[i:], "SET", "NOT", "NULL") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanAddIndexKind(w []string, kind string) bool {
+	for _, i := range clauseStarts(w) {
+		clause := w[i:clauseEnd(w, i)]
+		if !hasWordPrefix(clause, "ADD") || !slices.Contains(clause, kind) {
+			continue
+		}
+		if slices.Contains(clause, "INDEX") || slices.Contains(clause, "KEY") {
+			return true
+		}
+	}
+	return false
+}
+
+func scanCreateTableMixedAlignment(w []string) bool {
+	if !hasWordPrefix(w, "CREATE", "TABLE") {
+		return false
+	}
+	open := slices.Index(w, "(")
+	closeIndex := len(w) - 1
+	for closeIndex > open && w[closeIndex] != ")" {
+		closeIndex--
+	}
+	if open < 0 || closeIndex <= open {
+		return false
+	}
+	seenNarrow := false
+	for i := open + 1; i < closeIndex; i++ {
+		if w[i] == "," {
+			continue
+		}
+		if !identLike(w[i]) || i+1 >= closeIndex {
+			continue
+		}
+		width := postgresTypeWidthClass(w[i+1])
+		if width == 0 {
+			continue
+		}
+		if width == 1 {
+			seenNarrow = true
+			continue
+		}
+		if seenNarrow && width > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func postgresTypeWidthClass(word string) int {
+	switch strings.Trim(word, "\"`") {
+	case "BOOL", "BOOLEAN", "CHAR", "SMALLINT", "INT2":
+		return 1
+	case "BIGINT", "INT8", "BIGSERIAL", "DOUBLE", "TIMESTAMP", "TIMESTAMPTZ", "UUID":
+		return 2
+	default:
+		return 0
+	}
+}
+
+func isTransactionControlStatement(w []string) bool {
+	return hasWordPrefix(w, "BEGIN") ||
+		hasWordPrefix(w, "START", "TRANSACTION") ||
+		hasWordPrefix(w, "COMMIT") ||
+		hasWordPrefix(w, "ROLLBACK")
+}
+
+func isPostgresNonTransactionalStatement(w []string) bool {
+	return scanConcurrentIndexOperation(w)
 }
 
 // createdTableRef returns the normalized reference of the table a CREATE

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -18,7 +18,8 @@ type MigrationFunc func(context.Context, *dbschema.DatabaseConnection) error
 // This is needed because MySQL doesn't handle multiple statements in a single ExecuteSQL call.
 // Unlike simple string splitting, this properly handles semicolons within string literals and comments.
 func SplitSQLStatements(sql string) []string {
-	return sqlutil.SplitSQLStatements(sqlutil.StripComments(sql))
+	normalized := sqlutil.NormalizeClientDelimiters(sql)
+	return sqlutil.SplitSQLStatements(sqlutil.StripComments(normalized))
 }
 
 // StatementInterceptor lets an external executor take over individual

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -159,6 +159,30 @@ func TestSplitSQLStatements(t *testing.T) {
 	}
 }
 
+func TestSplitSQLStatements_AtlasDelimiterBeforeCommentStripping(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `-- atlas:delimiter -- end
+CREATE PROCEDURE dorepeat(p1 INT)
+BEGIN
+    SET @x = 0;
+    REPEAT SET @x = @x + 1; UNTIL @x > p1 END REPEAT;
+END;
+-- end
+CALL dorepeat(1000);`
+
+	result := SplitSQLStatements(sql)
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE PROCEDURE dorepeat(p1 INT)
+BEGIN
+    SET @x = 0;
+    REPEAT SET @x = @x + 1; UNTIL @x > p1 END REPEAT;
+END`,
+		"CALL dorepeat(1000)",
+	})
+}
+
 func TestMigrationFuncFromSQLFilename_Success(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What changed

- Moved client delimiter normalization into `core/sqlutil` so both parser and migrator splitting understand MySQL `DELIMITER` and Atlas `-- atlas:delimiter` directives.
- Extended statement splitting to keep compound `CREATE FUNCTION`, `CREATE PROCEDURE`, and `CREATE TRIGGER` bodies together without parsing function sub-languages.
- Added CASE-expression tracking for compound bodies so `CASE ... END;` does not terminate the surrounding routine or trigger.
- Expanded migration lint coverage for Atlas analyzer catalog hazards across PostgreSQL, MySQL/MariaDB, SQLite, data-dependent, and transaction-safety concerns.
- Added directive-aware transaction linting so `-- +ptah no_transaction` and `-- atlas:txmode none` suppress transaction-wrapper warnings.

## Why

The full Atlas conformance probe had three real Ptah-side gap buckets: lex splitting, lint analyzer coverage, and CLI surface. This PR closes the real splitter and lint analyzer gaps in Ptah. It deliberately does not add `ptah atlas ...` stub commands just to satisfy the current CLI-surface probe, because that probe only checks `--help` resolution and would turn green without real Atlas-compatible command behavior.

## Validation

- `go test ./core/sqlutil ./core/parser ./migration/migrator ./migration/lint ./cmd/lint -count=1`
- `go test ./... -count=1`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go run ./cmd/gap-probe --md /private/tmp/ptah-final-gaps-2.md --json /private/tmp/ptah-final-gaps-2.json` in `ptah-atlas-conformance` with local Ptah via `GOWORK`

Conformance result with local Ptah: 57 gaps before this work, 16 gaps after this work. Remaining gaps are all `atlas-cli-surface`.
