### PR TITLE
Add Atlas CLI compatibility namespace

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -1,0 +1,121 @@
+// Package atlas exposes Atlas-compatible command paths.
+package atlas
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type atlasVerb struct {
+	use    string
+	short  string
+	native string
+}
+
+// NewAtlasCommand returns the Atlas compatibility namespace.
+func NewAtlasCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "atlas",
+		Short: "Atlas-compatible command namespace",
+		Long: `Atlas-compatible command namespace.
+
+These commands reserve the Atlas OSS CLI surface under Ptah. Commands that have
+an existing Ptah equivalent point to that native command. Runtime-compatible
+flag translation and Atlas revision-table compatibility are tracked separately.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newAtlasVersionCommand())
+	cmd.AddCommand(newAtlasLicenseCommand())
+	cmd.AddCommand(newAtlasSchemaCommand())
+	cmd.AddCommand(newAtlasMigrateCommand())
+	return cmd
+}
+
+func newAtlasSchemaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Atlas schema command compatibility",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	for _, verb := range []atlasVerb{
+		{use: "inspect", short: "Inspect a database schema", native: "read-db"},
+		{use: "apply", short: "Apply a desired schema to a database", native: ""},
+		{use: "diff", short: "Diff desired schema against a database", native: "compare"},
+		{use: "fmt", short: "Format schema files", native: ""},
+		{use: "clean", short: "Clean database schema objects", native: "drop-all"},
+	} {
+		cmd.AddCommand(newAtlasAliasCommand("schema", verb))
+	}
+	return cmd
+}
+
+func newAtlasMigrateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Atlas migrate command compatibility",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	for _, verb := range []atlasVerb{
+		{use: "apply", short: "Apply pending migrations", native: "migrate-up"},
+		{use: "diff", short: "Generate migration SQL from differences", native: "migrate"},
+		{use: "hash", short: "Write or update the migration directory checksum", native: "migrate-hash"},
+		{use: "import", short: "Import migrations from another tool", native: ""},
+		{use: "lint", short: "Lint migration files", native: "lint"},
+		{use: "new", short: "Create a new migration file", native: "migrate generate"},
+		{use: "set", short: "Set migration revision state", native: "migrate-repair"},
+		{use: "status", short: "Show migration status", native: "migrate-status"},
+		{use: "validate", short: "Validate migration directory integrity", native: "migrate-validate"},
+	} {
+		cmd.AddCommand(newAtlasAliasCommand("migrate", verb))
+	}
+	return cmd
+}
+
+func newAtlasVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print Ptah version information",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return fmt.Errorf("atlas version compatibility is not implemented yet; use the native Ptah version command once issue #268 lands")
+		},
+	}
+}
+
+func newAtlasLicenseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "license",
+		Short: "Print license information",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return fmt.Errorf("atlas license compatibility is not implemented yet")
+		},
+	}
+}
+
+func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   verb.use,
+		Short: verb.short,
+		Long:  atlasAliasLong(group, verb),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if verb.native == "" {
+				return fmt.Errorf("atlas %s %s compatibility is not implemented yet", group, verb.use)
+			}
+			return fmt.Errorf("atlas %s %s execution is not implemented yet; use `ptah %s`", group, verb.use, verb.native)
+		},
+	}
+	return cmd
+}
+
+func atlasAliasLong(group string, verb atlasVerb) string {
+	if verb.native == "" {
+		return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. Runtime compatibility is not implemented yet.", group, verb.use)
+	}
+	return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. The current native Ptah equivalent is `ptah %s`.", group, verb.use, verb.native)
+}

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1,0 +1,60 @@
+package atlas
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
+	paths := [][]string{
+		{"version"},
+		{"license"},
+		{"schema", "inspect"},
+		{"schema", "apply"},
+		{"schema", "diff"},
+		{"schema", "fmt"},
+		{"schema", "clean"},
+		{"migrate", "apply"},
+		{"migrate", "diff"},
+		{"migrate", "hash"},
+		{"migrate", "import"},
+		{"migrate", "lint"},
+		{"migrate", "new"},
+		{"migrate", "set"},
+		{"migrate", "status"},
+		{"migrate", "validate"},
+	}
+
+	for _, path := range paths {
+		t.Run(strings.Join(path, "_"), func(t *testing.T) {
+			c := qt.New(t)
+			cmd := NewAtlasCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(append(path, "--help"))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(out.String(), qt.Contains, "Usage:")
+			c.Assert(out.String(), qt.Contains, "atlas "+strings.Join(path, " "))
+		})
+	}
+}
+
+func TestNewAtlasCommand_RuntimeIsExplicitlyGuarded(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "apply"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "atlas migrate apply execution is not implemented yet; use `ptah migrate-up`")
+}

--- a/cmd/packagemigrator/packagemigrator.go
+++ b/cmd/packagemigrator/packagemigrator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/stokaro/ptah/cmd/atlas"
 	"github.com/stokaro/ptah/cmd/compare"
 	"github.com/stokaro/ptah/cmd/drift"
 	"github.com/stokaro/ptah/cmd/dropall"
@@ -64,6 +65,7 @@ func Execute(args ...string) {
 	rootCmd.AddCommand(seed.NewSeedCommand())
 	rootCmd.AddCommand(dropall.NewDropAllCommand())
 	rootCmd.AddCommand(lint.NewLintCommand())
+	rootCmd.AddCommand(atlas.NewAtlasCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
## What changed

- Added `ptah atlas ...` as an Atlas compatibility namespace.
- Registered the OSS Atlas command paths currently tracked by the companion conformance probe:
  - `atlas version`
  - `atlas license`
  - `atlas schema inspect|apply|diff|fmt|clean`
  - `atlas migrate apply|diff|hash|import|lint|new|set|status|validate`
- Added unit coverage that every command path resolves through Cobra help.

## Important limitation

This PR intentionally does not pretend runtime Atlas compatibility is complete. The namespace resolves the command surface and points commands with native Ptah equivalents at the native spelling, but execution is guarded with explicit errors until flag translation, Atlas revision-table compatibility, and missing capabilities from #275 are implemented.

That distinction matters: the current companion `atlas-cli-surface` probe is a command-resolution probe. With this PR, the full conformance report goes green for the current gate, but #275 still tracks real runtime compatibility work.

## Validation

- `go test ./cmd/atlas ./cmd/packagemigrator ./cmd -count=1`
- `go test ./... -count=1`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go run ./cmd/gap-probe --md /private/tmp/ptah-atlas-cli-gaps-final.md --json /private/tmp/ptah-atlas-cli-gaps-final.json` in `ptah-atlas-conformance` with local Ptah via `GOWORK`

Conformance result with local Ptah: `160 fixtures, 623 observations, 0 non-OK observation(s), 0 unwaived`.
