### PR TITLE
Add Atlas revision runtime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,15 @@ helpers such as `{{ define "shared/users" }}` and are not executed as standalone
 migrations. The template data object exposes `.Env`; CLI commands set it with
 `--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
 
+`--dir-format` controls only migration-file discovery. To continue a database
+that already uses Atlas's runtime history table, pass `--revision-format atlas`
+to `migrate-up`, `migrate-down`, `migrate-status`, `migrate-repair`, or
+`migrate-baseline`. Atlas revision mode uses `atlas_schema_revisions` by
+default, stores string migration versions, reads the Atlas `applied`/`total` and
+`error` state fields, and writes the Atlas `hash` value from `atlas.sum` when it
+is available. `--migrations-schema` and `--migrations-table` still override the
+metadata table location when needed.
+
 If an Atlas migration has no embedded `down.sql`, `migrate-down` fails with a
 typed error explaining that Atlas dynamic down-plan synthesis is not implemented
 yet. This is different from transaction rollback: transaction rollback undoes a
@@ -718,6 +727,9 @@ Apply all pending migrations to bring database up to latest version:
 
 # Apply an Atlas-style versioned migration directory
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
+
+# Continue an Atlas-managed database using atlas_schema_revisions
+./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --revision-format atlas
 
 # Apply Atlas SQL template migrations with .Env set to dev
 ./package-migrator migrate-up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
@@ -882,6 +894,9 @@ Show current migration status and pending migrations:
 # Check an Atlas-style versioned migration directory
 ./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas
 
+# Check an Atlas-managed revisions table
+./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --revision-format atlas
+
 # Check Atlas SQL template migrations with .Env set to dev
 ./package-migrator migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
 ```
@@ -893,6 +908,32 @@ Show current migration status and pending migrations:
 - List of pending migrations
 - Out-of-order pending migrations
 - Migration history and timestamps
+
+#### Atlas-Compatible CLI Namespace And Exit Codes
+
+Ptah keeps the existing kebab-case commands as native commands, and reserves an
+Atlas-compatible command tree under `ptah atlas <command> ...` for scripts that
+expect Atlas OSS command paths. The native command tree remains separate while
+it is redesigned independently.
+
+| Atlas-compatible command | Native command |
+| --- | --- |
+| `ptah atlas migrate apply` | `ptah migrate-up` |
+| `ptah atlas migrate down` | `ptah migrate-down` |
+| `ptah atlas migrate status` | `ptah migrate-status` |
+| `ptah atlas migrate hash` | `ptah migrate-hash` |
+| `ptah atlas migrate validate` | `ptah migrate-validate` |
+| `ptah atlas migrate lint` | `ptah lint` |
+| `ptah atlas migrate diff` | `ptah migrate` |
+| `ptah atlas schema inspect` | `ptah read-db` |
+| `ptah atlas schema diff` | `ptah compare` |
+
+The Atlas-compatible commands delegate to the native commands, so their flag
+parsing and exit codes are the native contracts: `0` for success, `1` for
+drift/findings where a native command documents that content state, and `2` for
+command/usage errors on commands with an explicit 0/1/2 contract (`drift`,
+`lint`, and `migrate-validate`). Other runtime failures continue to use the CLI
+fallback non-zero exit code.
 
 #### Migration Directory Integrity (`ptah.sum` / `atlas.sum`)
 

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -5,12 +5,27 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/compare"
+	"github.com/stokaro/ptah/cmd/dropall"
+	"github.com/stokaro/ptah/cmd/internal/cmdalias"
+	"github.com/stokaro/ptah/cmd/lint"
+	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/cmd/migratedown"
+	"github.com/stokaro/ptah/cmd/migratehash"
+	"github.com/stokaro/ptah/cmd/migraterepair"
+	"github.com/stokaro/ptah/cmd/migratestatus"
+	"github.com/stokaro/ptah/cmd/migrateup"
+	"github.com/stokaro/ptah/cmd/migratevalidate"
+	"github.com/stokaro/ptah/cmd/readdb"
 )
 
 type atlasVerb struct {
-	use    string
-	short  string
-	native string
+	use        string
+	short      string
+	native     string
+	factory    func() *cobra.Command
+	prefixArgs []string
 }
 
 // NewAtlasCommand returns the Atlas compatibility namespace.
@@ -21,8 +36,8 @@ func NewAtlasCommand() *cobra.Command {
 		Long: `Atlas-compatible command namespace.
 
 These commands reserve the Atlas OSS CLI surface under Ptah. Commands that have
-an existing Ptah equivalent point to that native command. Runtime-compatible
-flag translation and Atlas revision-table compatibility are tracked separately.`,
+an existing Ptah equivalent forward to that native command while keeping the
+native Ptah command tree separate for future redesign.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
@@ -43,11 +58,11 @@ func newAtlasSchemaCommand() *cobra.Command {
 		},
 	}
 	for _, verb := range []atlasVerb{
-		{use: "inspect", short: "Inspect a database schema", native: "read-db"},
+		{use: "inspect", short: "Inspect a database schema", native: "read-db", factory: readdb.NewReadDBCommand},
 		{use: "apply", short: "Apply a desired schema to a database", native: ""},
-		{use: "diff", short: "Diff desired schema against a database", native: "compare"},
+		{use: "diff", short: "Diff desired schema against a database", native: "compare", factory: compare.NewCompareCommand},
 		{use: "fmt", short: "Format schema files", native: ""},
-		{use: "clean", short: "Clean database schema objects", native: "drop-all"},
+		{use: "clean", short: "Clean database schema objects", native: "drop-all", factory: dropall.NewDropAllCommand},
 	} {
 		cmd.AddCommand(newAtlasAliasCommand("schema", verb))
 	}
@@ -63,15 +78,16 @@ func newAtlasMigrateCommand() *cobra.Command {
 		},
 	}
 	for _, verb := range []atlasVerb{
-		{use: "apply", short: "Apply pending migrations", native: "migrate-up"},
-		{use: "diff", short: "Generate migration SQL from differences", native: "migrate"},
-		{use: "hash", short: "Write or update the migration directory checksum", native: "migrate-hash"},
+		{use: "apply", short: "Apply pending migrations", native: "migrate-up", factory: migrateup.NewMigrateUpCommand},
+		{use: "diff", short: "Generate migration SQL from differences", native: "migrate", factory: migrate.NewMigrateCommand},
+		{use: "down", short: "Roll back migrations", native: "migrate-down", factory: migratedown.NewMigrateDownCommand},
+		{use: "hash", short: "Write or update the migration directory checksum", native: "migrate-hash", factory: migratehash.NewMigrateHashCommand},
 		{use: "import", short: "Import migrations from another tool", native: ""},
-		{use: "lint", short: "Lint migration files", native: "lint"},
-		{use: "new", short: "Create a new migration file", native: "migrate generate"},
-		{use: "set", short: "Set migration revision state", native: "migrate-repair"},
-		{use: "status", short: "Show migration status", native: "migrate-status"},
-		{use: "validate", short: "Validate migration directory integrity", native: "migrate-validate"},
+		{use: "lint", short: "Lint migration files", native: "lint", factory: lint.NewLintCommand},
+		{use: "new", short: "Create a new migration file", native: "migrate generate", factory: migrate.NewMigrateCommand, prefixArgs: []string{"generate"}},
+		{use: "set", short: "Set migration revision state", native: "migrate-repair", factory: migraterepair.NewMigrateRepairCommand},
+		{use: "status", short: "Show migration status", native: "migrate-status", factory: migratestatus.NewMigrateStatusCommand},
+		{use: "validate", short: "Validate migration directory integrity", native: "migrate-validate", factory: migratevalidate.NewMigrateValidateCommand},
 	} {
 		cmd.AddCommand(newAtlasAliasCommand("migrate", verb))
 	}
@@ -99,6 +115,15 @@ func newAtlasLicenseCommand() *cobra.Command {
 }
 
 func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
+	if verb.factory != nil {
+		return cmdalias.NewForwardCommandWithArgs(
+			verb.use,
+			verb.short,
+			verb.native,
+			verb.factory,
+			verb.prefixArgs...,
+		)
+	}
 	cmd := &cobra.Command{
 		Use:   verb.use,
 		Short: verb.short,

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/migrateup"
 )
 
 func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
@@ -19,6 +22,7 @@ func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
 		{"schema", "clean"},
 		{"migrate", "apply"},
 		{"migrate", "diff"},
+		{"migrate", "down"},
 		{"migrate", "hash"},
 		{"migrate", "import"},
 		{"migrate", "lint"},
@@ -41,12 +45,11 @@ func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(out.String(), qt.Contains, "Usage:")
-			c.Assert(out.String(), qt.Contains, "atlas "+strings.Join(path, " "))
 		})
 	}
 }
 
-func TestNewAtlasCommand_RuntimeIsExplicitlyGuarded(t *testing.T) {
+func TestNewAtlasCommand_ForwardsSupportedCommands(t *testing.T) {
 	c := qt.New(t)
 	cmd := NewAtlasCommand()
 	var out bytes.Buffer
@@ -56,5 +59,33 @@ func TestNewAtlasCommand_RuntimeIsExplicitlyGuarded(t *testing.T) {
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, "atlas migrate apply execution is not implemented yet; use `ptah migrate-up`")
+	c.Assert(err, qt.ErrorMatches, "database URL is required")
+}
+
+func TestNewAtlasCommand_ForwardsParentedNativeCommand(t *testing.T) {
+	c := qt.New(t)
+	root := &cobra.Command{Use: "ptah"}
+	root.AddCommand(migrateup.NewMigrateUpCommand())
+	root.AddCommand(NewAtlasCommand())
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"atlas", "migrate", "apply"})
+
+	err := root.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "database URL is required")
+}
+
+func TestNewAtlasCommand_UnsupportedCommandsAreExplicit(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"schema", "apply"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "atlas schema apply compatibility is not implemented yet")
 }

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -45,8 +45,13 @@ var compareFlags = map[string]cobraflags.Flag{
 	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
 
+var compareFlagsRegistered bool
+
 func NewCompareCommand() *cobra.Command {
-	cobraflags.RegisterMap(compareCmd, compareFlags)
+	if !compareFlagsRegistered {
+		cobraflags.RegisterMap(compareCmd, compareFlags)
+		compareFlagsRegistered = true
+	}
 	return compareCmd
 }
 

--- a/cmd/internal/cmdalias/cmdalias.go
+++ b/cmd/internal/cmdalias/cmdalias.go
@@ -1,0 +1,68 @@
+// Package cmdalias contains small Cobra forwarding helpers for compatibility
+// command paths.
+package cmdalias
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// NewForwardCommand returns a command that forwards its raw arguments to a
+// native command factory. It is intended for compatibility aliases whose
+// behavior, flags, and exit-code contract should stay owned by the native
+// command.
+func NewForwardCommand(use, short, native string, factory func() *cobra.Command) *cobra.Command {
+	return NewForwardCommandWithArgs(use, short, native, factory)
+}
+
+// NewForwardCommandWithArgs returns a forwarding command that prepends fixed
+// arguments before the user-provided arguments.
+func NewForwardCommandWithArgs(
+	use string,
+	short string,
+	native string,
+	factory func() *cobra.Command,
+	prefixArgs ...string,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:                use,
+		Short:              short,
+		Long:               fmt.Sprintf("Compatibility alias for `ptah %s`.", native),
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		SilenceErrors:      true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := factory()
+			resetCommandFlags(target)
+			parent := target.Parent()
+			if parent != nil {
+				parent.RemoveCommand(target)
+				defer parent.AddCommand(target)
+			}
+			forwardArgs := make([]string, 0, len(prefixArgs)+len(args))
+			forwardArgs = append(forwardArgs, prefixArgs...)
+			forwardArgs = append(forwardArgs, args...)
+			target.SetArgs(forwardArgs)
+			target.SetIn(cmd.InOrStdin())
+			target.SetOut(cmd.OutOrStdout())
+			target.SetErr(cmd.ErrOrStderr())
+			return target.Execute()
+		},
+	}
+}
+
+func resetCommandFlags(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		_ = flag.Value.Set(flag.DefValue)
+		flag.Changed = false
+	})
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		_ = flag.Value.Set(flag.DefValue)
+		flag.Changed = false
+	})
+	for _, child := range cmd.Commands() {
+		resetCommandFlags(child)
+	}
+}

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -26,6 +26,8 @@ const (
 	MigrationsSchemaFlagName = "migrations-schema"
 	// MigrationsTableFlagName is the CLI flag name for the schema_migrations table name.
 	MigrationsTableFlagName = "migrations-table"
+	// RevisionTableFormatFlagName is the CLI flag name for the migration revision table layout.
+	RevisionTableFormatFlagName = "revision-format"
 )
 
 // DefaultConnectTimeout is the default value for [ConnectTimeoutFlagName]. It
@@ -66,8 +68,17 @@ func NewMigrationsSchemaFlag() cobraflags.Flag {
 func NewMigrationsTableFlag() cobraflags.Flag {
 	return &cobraflags.StringFlag{
 		Name:  MigrationsTableFlagName,
-		Value: "schema_migrations",
-		Usage: "Table name for Ptah's migration tracking table.",
+		Value: "",
+		Usage: "Table name for the migration tracking table. Empty uses the revision format default.",
+	}
+}
+
+// NewRevisionTableFormatFlag returns the migration revision table layout flag.
+func NewRevisionTableFormatFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  RevisionTableFormatFlagName,
+		Value: "ptah",
+		Usage: "Migration revision table format: ptah or atlas.",
 	}
 }
 

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -39,6 +39,20 @@ func TestAddMigrateGenerateCommandIsIdempotent(t *testing.T) {
 	c.Assert(count, qt.Equals, 1)
 }
 
+func TestMigrateCommandRejectsAtlasApplyAtRoot(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrateCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"apply"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unknown command "apply" for "migrate"`)
+}
+
 func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 	dbURL := migrateGenerateTestDatabaseURL()
 	if dbURL == "" {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -25,6 +25,7 @@ var migrateCmd = &cobra.Command{
 	
 This command compares your Go entities with the current database schema and generates
 the SQL statements needed to update the database to match your entities.`,
+	Args: cobra.NoArgs,
 	RunE: migrateCommand,
 }
 
@@ -38,34 +39,38 @@ const (
 	reportFormatFlag     = "report"
 )
 
-var migrateFlags = map[string]cobraflags.Flag{
-	rootDirFlag: &cobraflags.StringFlag{
-		Name:  rootDirFlag,
-		Value: "./",
-		Usage: "Root directory to scan for Go entities",
-	},
-	dbURLFlag: &cobraflags.StringFlag{
-		Name:  dbURLFlag,
-		Value: "",
-		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
-	},
-	checkDestructiveFlag: &cobraflags.BoolFlag{
-		Name:  checkDestructiveFlag,
-		Value: false,
-		Usage: "Fail when generated migration SQL contains destructive statements",
-	},
-	allowDestructiveFlag: &cobraflags.BoolFlag{
-		Name:  allowDestructiveFlag,
-		Value: false,
-		Usage: "Allow destructive statements when --check-destructive is set",
-	},
-	reportFormatFlag: &cobraflags.StringFlag{
-		Name:  reportFormatFlag,
-		Value: "text",
-		Usage: "Safety report format: text or html",
-	},
-	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
-	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
+var migrateFlags = newMigrateFlags()
+
+func newMigrateFlags() map[string]cobraflags.Flag {
+	return map[string]cobraflags.Flag{
+		rootDirFlag: &cobraflags.StringFlag{
+			Name:  rootDirFlag,
+			Value: "./",
+			Usage: "Root directory to scan for Go entities",
+		},
+		dbURLFlag: &cobraflags.StringFlag{
+			Name:  dbURLFlag,
+			Value: "",
+			Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
+		},
+		checkDestructiveFlag: &cobraflags.BoolFlag{
+			Name:  checkDestructiveFlag,
+			Value: false,
+			Usage: "Fail when generated migration SQL contains destructive statements",
+		},
+		allowDestructiveFlag: &cobraflags.BoolFlag{
+			Name:  allowDestructiveFlag,
+			Value: false,
+			Usage: "Allow destructive statements when --check-destructive is set",
+		},
+		reportFormatFlag: &cobraflags.StringFlag{
+			Name:  reportFormatFlag,
+			Value: "text",
+			Usage: "Safety report format: text or html",
+		},
+		dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
+		dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
+	}
 }
 
 func NewMigrateCommand() *cobra.Command {
@@ -87,12 +92,16 @@ func addMigrateGenerateCommand(cmd *cobra.Command) {
 }
 
 func migrateCommand(cmd *cobra.Command, _ []string) error {
+	return migrateCommandWithFlags(cmd, migrateFlags)
+}
+
+func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Flag) error {
 	out := cmd.OutOrStdout()
-	rootDir := migrateFlags[rootDirFlag].GetString()
-	dbURL := migrateFlags[dbURLFlag].GetString()
-	checkDestructive := migrateFlags[checkDestructiveFlag].GetBool()
-	allowDestructive := migrateFlags[allowDestructiveFlag].GetBool()
-	reportFormat := strings.ToLower(strings.TrimSpace(migrateFlags[reportFormatFlag].GetString()))
+	rootDir := flags[rootDirFlag].GetString()
+	dbURL := flags[dbURLFlag].GetString()
+	checkDestructive := flags[checkDestructiveFlag].GetBool()
+	allowDestructive := flags[allowDestructiveFlag].GetBool()
+	reportFormat := strings.ToLower(strings.TrimSpace(flags[reportFormatFlag].GetString()))
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -118,7 +127,7 @@ func migrateCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	// 2. Connect to database and read schema
-	connectTimeout, err := dbcli.ParseConnectTimeout(migrateFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	connectTimeout, err := dbcli.ParseConnectTimeout(flags[dbcli.ConnectTimeoutFlagName].GetString())
 	if err != nil {
 		return err
 	}
@@ -131,7 +140,7 @@ func migrateCommand(cmd *cobra.Command, _ []string) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	schemas := dbcli.ParseSchemas(migrateFlags[dbcli.SchemasFlagName].GetString())
+	schemas := dbcli.ParseSchemas(flags[dbcli.SchemasFlagName].GetString())
 	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading database schema: %w", err)

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -102,10 +102,11 @@ func newMigrateBaselineFlags() map[string]cobraflags.Flag {
 			Value: "",
 			Usage: "Timeout for acquiring the session-level migration advisory lock, such as 10s or 2m",
 		},
-		dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
-		dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
-		dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
-		dbcli.SchemasFlagName:          dbcli.NewSchemasFlag(),
+		dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+		dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
+		dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
+		dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
+		dbcli.SchemasFlagName:             dbcli.NewSchemasFlag(),
 	}
 }
 
@@ -123,6 +124,7 @@ func migrateBaselineCommand(cmd *cobra.Command, _ []string, flags map[string]cob
 	lockTimeoutValue := flags[lockTimeoutFlag].GetString()
 	migrationsSchema := flags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := flags[dbcli.MigrationsTableFlagName].GetString()
+	revisionFormatValue := flags[dbcli.RevisionTableFormatFlagName].GetString()
 	schemas := dbcli.ParseSchemas(flags[dbcli.SchemasFlagName].GetString())
 
 	if dbURL == "" {
@@ -133,6 +135,10 @@ func migrateBaselineCommand(cmd *cobra.Command, _ []string, flags map[string]cob
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	revisionFormat, err := migrator.ParseRevisionTableFormat(revisionFormatValue)
 	if err != nil {
 		return err
 	}
@@ -172,6 +178,7 @@ func migrateBaselineCommand(cmd *cobra.Command, _ []string, flags map[string]cob
 	conn.Writer().SetDryRun(dryRun)
 	mig := migrator.NewMigrator(conn, provider).
 		WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithRevisionTableFormat(revisionFormat).
 		WithMigrationLockTimeout(lockTimeout)
 	if dryRun {
 		printDryRun(dbURL, migrationsDir, version, mig, rows)

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -108,14 +108,20 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Default per-migration statement timeout, such as 30s or 2m",
 	},
-	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
-	dbcli.ConfigFlagName:           dbcli.NewConfigFlag(),
-	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
-	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
+	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
+	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
 }
 
+var migrateDownFlagsRegistered bool
+
 func NewMigrateDownCommand() *cobra.Command {
-	cobraflags.RegisterMap(migrateDownCmd, migrateDownFlags)
+	if !migrateDownFlagsRegistered {
+		cobraflags.RegisterMap(migrateDownCmd, migrateDownFlags)
+		migrateDownFlagsRegistered = true
+	}
 	return migrateDownCmd
 }
 
@@ -134,6 +140,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
 	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateDownFlags[dbcli.MigrationsTableFlagName].GetString()
+	revisionFormatValue := migrateDownFlags[dbcli.RevisionTableFormatFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -152,6 +159,10 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	revisionFormat, err := migrator.ParseRevisionTableFormat(revisionFormatValue)
 	if err != nil {
 		return err
 	}
@@ -229,6 +240,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
 	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithRevisionTableFormat(revisionFormat).
 		WithDefaultTimeouts(timeouts).
 		WithExecOrder(execOrder).
 		WithMigrationLockTimeout(migrationLockTimeout)

--- a/cmd/migraterepair/migraterepair.go
+++ b/cmd/migraterepair/migraterepair.go
@@ -69,9 +69,10 @@ var migrateRepairFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Execute remaining up statements starting from this 1-based statement number before marking applied",
 	},
-	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
-	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
-	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
+	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
 }
 
 func NewMigrateRepairCommand() *cobra.Command {
@@ -89,6 +90,7 @@ func migrateRepairCommand(_ *cobra.Command, _ []string) error {
 	resumeFromValue := migrateRepairFlags[resumeFromFlag].GetString()
 	migrationsSchema := migrateRepairFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateRepairFlags[dbcli.MigrationsTableFlagName].GetString()
+	revisionFormatValue := migrateRepairFlags[dbcli.RevisionTableFormatFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -109,6 +111,10 @@ func migrateRepairCommand(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	revisionFormat, err := migrator.ParseRevisionTableFormat(revisionFormatValue)
 	if err != nil {
 		return err
 	}
@@ -134,7 +140,8 @@ func migrateRepairCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithRevisionTableFormat(revisionFormat)
 
 	err = mig.RepairMigration(context.Background(), migrator.RepairMigrationOptions{
 		Version:    version,

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -70,13 +70,19 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Output status in JSON format",
 	},
-	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
-	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
-	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
+	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
 }
 
+var migrateStatusFlagsRegistered bool
+
 func NewMigrateStatusCommand() *cobra.Command {
-	cobraflags.RegisterMap(migrateStatusCmd, migrateStatusFlags)
+	if !migrateStatusFlagsRegistered {
+		cobraflags.RegisterMap(migrateStatusCmd, migrateStatusFlags)
+		migrateStatusFlagsRegistered = true
+	}
 	return migrateStatusCmd
 }
 
@@ -89,6 +95,7 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	jsonOutput := migrateStatusFlags[jsonFlag].GetBool()
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateStatusFlags[dbcli.MigrationsTableFlagName].GetString()
+	revisionFormatValue := migrateStatusFlags[dbcli.RevisionTableFormatFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -99,6 +106,10 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	revisionFormat, err := migrator.ParseRevisionTableFormat(revisionFormatValue)
 	if err != nil {
 		return err
 	}
@@ -128,7 +139,8 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
-	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable)
+	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithRevisionTableFormat(revisionFormat)
 
 	// Get migration status
 	status, err := mig.GetMigrationStatus(context.Background())

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -108,14 +108,20 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Allow pending migrations that contain destructive statements",
 	},
-	dbcli.ConnectTimeoutFlagName:   dbcli.NewConnectTimeoutFlag(),
-	dbcli.ConfigFlagName:           dbcli.NewConfigFlag(),
-	dbcli.MigrationsSchemaFlagName: dbcli.NewMigrationsSchemaFlag(),
-	dbcli.MigrationsTableFlagName:  dbcli.NewMigrationsTableFlag(),
+	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
+	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
+	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
+	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
 }
 
+var migrateUpFlagsRegistered bool
+
 func NewMigrateUpCommand() *cobra.Command {
-	cobraflags.RegisterMap(migrateUpCmd, migrateUpFlags)
+	if !migrateUpFlagsRegistered {
+		cobraflags.RegisterMap(migrateUpCmd, migrateUpFlags)
+		migrateUpFlagsRegistered = true
+	}
 	return migrateUpCmd
 }
 
@@ -134,6 +140,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	allowDestructive := migrateUpFlags[allowDestructiveFlag].GetBool()
 	migrationsSchema := migrateUpFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateUpFlags[dbcli.MigrationsTableFlagName].GetString()
+	revisionFormatValue := migrateUpFlags[dbcli.RevisionTableFormatFlagName].GetString()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -144,6 +151,10 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+	if err != nil {
+		return err
+	}
+	revisionFormat, err := migrator.ParseRevisionTableFormat(revisionFormatValue)
 	if err != nil {
 		return err
 	}
@@ -235,6 +246,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("error registering migrations: %w", err)
 	}
 	mig = mig.WithMigrationsTable(migrationsSchema, migrationsTable).
+		WithRevisionTableFormat(revisionFormat).
 		WithDefaultTimeouts(timeouts).
 		WithExecOrder(execOrder).
 		WithMigrationLockTimeout(migrationLockTimeout)

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -38,8 +38,13 @@ var readDBFlags = map[string]cobraflags.Flag{
 	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
 
+var readDBFlagsRegistered bool
+
 func NewReadDBCommand() *cobra.Command {
-	cobraflags.RegisterMap(readDBCmd, readDBFlags)
+	if !readDBFlagsRegistered {
+		cobraflags.RegisterMap(readDBCmd, readDBFlags)
+		readDBFlagsRegistered = true
+	}
 	return readDBCmd
 }
 

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -106,6 +106,15 @@ helpers such as `{{ define "shared/users" }}` and are not executed as standalone
 migrations. The template data object exposes `.Env`; CLI commands set it with
 `--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
 
+`--dir-format` controls only migration-file discovery. To continue a database
+that already uses Atlas's runtime history table, pass `--revision-format atlas`
+on the CLI or `WithRevisionTableFormat(RevisionTableFormatAtlas)` in Go. Atlas
+revision mode uses `atlas_schema_revisions` by default, stores string migration
+versions, reads the Atlas `applied`/`total` and `error` state fields, and writes
+the Atlas `hash` value from `atlas.sum` when it is available. Custom
+`--migrations-schema` / `--migrations-table` values still override the metadata
+table location.
+
 If an Atlas migration does not provide `down.sql`, `migrate-down` returns a typed
 error explaining that Atlas dynamic down-plan synthesis is not implemented yet.
 This is distinct from transaction rollback on a failed migration: transaction
@@ -142,6 +151,11 @@ go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-
 With an Atlas-style versioned migration directory:
 ```bash
 go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas
+```
+
+Continue an Atlas-managed database using `atlas_schema_revisions`:
+```bash
+go run ./cmd migrate-up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas --revision-format atlas
 ```
 
 ### Migrate Down
@@ -186,6 +200,11 @@ With an Atlas-style versioned migration directory:
 go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas
 ```
 
+Check an Atlas-managed revisions table:
+```bash
+go run ./cmd migrate-status --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dir-format atlas --revision-format atlas
+```
+
 ## API Overview
 
 The migrator package provides a clean, modular API with the following key components:
@@ -225,6 +244,7 @@ pending and out of order.
 - **`WithExecOrder(policy)`**: Configures out-of-order migration handling
 - **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
 - **`WithAtlasTemplateData(data)`**: Supplies data, including `.Env`, for Atlas SQL template migrations
+- **`WithRevisionTableFormat(format)`**: Selects Ptah's native `schema_migrations` layout or Atlas's `atlas_schema_revisions` layout
 - **`Baseline(ctx, version)` / `BaselineWithOptions(ctx, opts)`**: Records provider migrations as already applied without executing their SQL bodies
 
 ## Programmatic Usage

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -3,12 +3,15 @@ package migrator_test
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -40,6 +43,10 @@ func TestAtlasTxtarDown_PostgresIntegration(t *testing.T) {
 
 func TestAtlasTemplate_PostgresIntegration(t *testing.T) {
 	runAtlasTemplateIntegration(t, postgresTestURL(t))
+}
+
+func TestAtlasRevisionTable_PostgresIntegration(t *testing.T) {
+	runAtlasRevisionTableIntegration(t, postgresTestURL(t))
 }
 
 func TestAtlasTxtarDown_MySQLIntegration(t *testing.T) {
@@ -187,6 +194,100 @@ CREATE TABLE ptah_issue_299_users_{{ $ }} (id INT PRIMARY KEY);
 	c.Assert(issue299Versions(t, conn), qt.DeepEquals, []int64{1, 2})
 }
 
+func runAtlasRevisionTableIntegration(t *testing.T, dbURL string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	cleanupIssue275(t, conn)
+	defer cleanupIssue275(t, conn)
+
+	const firstVersion = int64(20240101120000)
+	const secondVersion = int64(20240101120100)
+	seedFS := fstest.MapFS{
+		"atlas.sum": &fstest.MapFile{Data: []byte(
+			"h1:directory\n" +
+				"20240101120000_seed.sql h1:seedhash\n",
+		)},
+		"20240101120000_seed.sql": &fstest.MapFile{Data: []byte("CREATE TABLE ptah_issue_275_seed (id INT PRIMARY KEY);\n")},
+	}
+	seedMigrator, err := migrator.NewFSMigrator(
+		conn,
+		seedFS,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	seedMigrator = seedMigrator.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas)
+	c.Assert(seedMigrator.Initialize(ctx), qt.IsNil)
+	_, err = conn.ExecContext(ctx, "CREATE TABLE ptah_issue_275_seed (id INT PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	insertRevision := sqlutil.Rebind(conn.Info().Dialect, `INSERT INTO atlas_schema_revisions
+(version, description, type, applied, total, executed_at, execution_time, error, error_stmt, hash, partial_hashes, operator_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?)`)
+	_, err = conn.ExecContext(ctx, insertRevision,
+		"20240101120000",
+		"Seed",
+		2,
+		1,
+		1,
+		time.Now(),
+		int64(100),
+		"seedhash",
+		"Atlas",
+	)
+	c.Assert(err, qt.IsNil)
+
+	status, err := seedMigrator.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, firstVersion)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{firstVersion})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+	c.Assert(status.HasPendingChanges, qt.IsFalse)
+
+	nextFS := fstest.MapFS{
+		"atlas.sum": &fstest.MapFile{Data: []byte(
+			"h1:directory\n" +
+				"20240101120000_seed.sql h1:seedhash\n" +
+				"20240101120100_next.sql h1:nexthash\n",
+		)},
+		"20240101120000_seed.sql": &fstest.MapFile{Data: []byte("CREATE TABLE ptah_issue_275_seed (id INT PRIMARY KEY);\n")},
+		"20240101120100_next.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+CREATE TABLE ptah_issue_275_next (id INT PRIMARY KEY);
+
+-- down.sql --
+DROP TABLE ptah_issue_275_next;
+`)},
+	}
+	nextMigrator, err := migrator.NewFSMigrator(
+		conn,
+		nextFS,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	nextMigrator = nextMigrator.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas)
+
+	err = nextMigrator.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_275_next"), qt.IsTrue)
+	c.Assert(issue275Revisions(t, conn), qt.DeepEquals, []issue275Revision{
+		{Version: strconv.FormatInt(firstVersion, 10), Description: "Seed", RevisionType: 2, Applied: 1, Total: 1, Hash: "seedhash", OperatorVersion: "Atlas"},
+		{Version: strconv.FormatInt(secondVersion, 10), Description: "Next", RevisionType: 2, Applied: 1, Total: 1, Hash: "nexthash", OperatorVersion: "Ptah"},
+	})
+
+	err = nextMigrator.MigrateDownTo(ctx, firstVersion)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists(t, conn, "ptah_issue_275_next"), qt.IsFalse)
+	c.Assert(issue275Revisions(t, conn), qt.DeepEquals, []issue275Revision{
+		{Version: strconv.FormatInt(firstVersion, 10), Description: "Seed", RevisionType: 2, Applied: 1, Total: 1, Hash: "seedhash", OperatorVersion: "Atlas"},
+	})
+}
+
 func cleanupIssue273(t *testing.T, conn *dbschema.DatabaseConnection) {
 	t.Helper()
 
@@ -208,6 +309,18 @@ func cleanupIssue299(t *testing.T, conn *dbschema.DatabaseConnection) {
 		"DROP TABLE IF EXISTS ptah_issue_299_prod",
 		"DROP TABLE IF EXISTS ptah_issue_299_dev",
 		"DROP TABLE IF EXISTS schema_migrations_issue_299",
+	} {
+		_, _ = conn.ExecContext(context.Background(), statement)
+	}
+}
+
+func cleanupIssue275(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS ptah_issue_275_next",
+		"DROP TABLE IF EXISTS ptah_issue_275_seed",
+		"DROP TABLE IF EXISTS atlas_schema_revisions",
 	} {
 		_, _ = conn.ExecContext(context.Background(), statement)
 	}
@@ -305,6 +418,43 @@ func issue299Versions(t *testing.T, conn *dbschema.DatabaseConnection) []int64 {
 	}
 	qt.Assert(t, rows.Err(), qt.IsNil)
 	return versions
+}
+
+type issue275Revision struct {
+	Version         string
+	Description     string
+	RevisionType    int
+	Applied         int
+	Total           int
+	Hash            string
+	OperatorVersion string
+}
+
+func issue275Revisions(t *testing.T, conn *dbschema.DatabaseConnection) []issue275Revision {
+	t.Helper()
+
+	rows, err := conn.Query(`SELECT version, description, type, applied, total, hash, operator_version
+FROM atlas_schema_revisions
+ORDER BY CAST(version AS BIGINT)`)
+	qt.Assert(t, err, qt.IsNil)
+	defer rows.Close()
+
+	var revisions []issue275Revision
+	for rows.Next() {
+		var revision issue275Revision
+		qt.Assert(t, rows.Scan(
+			&revision.Version,
+			&revision.Description,
+			&revision.RevisionType,
+			&revision.Applied,
+			&revision.Total,
+			&revision.Hash,
+			&revision.OperatorVersion,
+		), qt.IsNil)
+		revisions = append(revisions, revision)
+	}
+	qt.Assert(t, rows.Err(), qt.IsNil)
+	return revisions
 }
 
 func issue290WidgetTableExists(t *testing.T, conn *dbschema.DatabaseConnection) bool {

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -2,6 +2,7 @@ package migrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -203,6 +204,10 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 }
 
 func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
+	hashes, err := readAtlasSumHashes(p.fsys)
+	if err != nil {
+		return err
+	}
 	partsByVersion := make(map[int64]*atlasParts)
 	for i := range files {
 		migrationFile := files[i]
@@ -218,6 +223,9 @@ func (p *FSMigrationProvider) loadAtlas(files []MigrationFile) error {
 				},
 			}
 			partsByVersion[migrationFile.Version] = parts
+		}
+		if hash := hashes[migrationFile.Path]; hash != "" && migrationFile.Direction == "up" {
+			parts.migration.Checksum = hash
 		}
 		if err := p.loadAtlasFile(parts, migrationFile); err != nil {
 			return err
@@ -321,6 +329,30 @@ func setAtlasDown(parts *atlasParts, down sqlMigrationFile) {
 func isAtlasDirectionalMigrationFile(file MigrationFile) bool {
 	base := path.Base(file.Path)
 	return strings.HasSuffix(base, ".up.sql") || strings.HasSuffix(base, ".down.sql")
+}
+
+func readAtlasSumHashes(fsys fs.FS) (map[string]string, error) {
+	data, err := fs.ReadFile(fsys, "atlas.sum")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read atlas.sum: %w", err)
+	}
+	hashes := make(map[string]string)
+	lines := strings.Split(strings.TrimRight(string(data), "\r\n"), "\n")
+	for _, line := range lines[1:] {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		idx := strings.LastIndex(line, " ")
+		if idx <= 0 || idx == len(line)-1 {
+			return nil, fmt.Errorf("malformed atlas.sum entry line: %q", line)
+		}
+		hashes[line[:idx]] = line[idx+1:]
+	}
+	return hashes, nil
 }
 
 func sortMigrations(migrations []*Migration) {

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -161,6 +161,11 @@ func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fstest.MapFS{
+		"atlas.sum": &fstest.MapFile{Data: []byte(
+			"h1:directory\n" +
+				"20220318104614_team_A.sql h1:teamhash\n" +
+				"20220318104615_add_users.sql h1:userhash\n",
+		)},
 		"20220318104615_add_users.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id INT);\n")},
 		"20220318104614_team_A.sql":    &fstest.MapFile{Data: []byte("CREATE TABLE teams (id INT);\n")},
 	}
@@ -172,8 +177,10 @@ func TestNewFSMigrationProvider_AtlasFormat(t *testing.T) {
 	c.Assert(migrations, qt.HasLen, 2)
 	c.Assert(migrations[0].Version, qt.Equals, int64(20220318104614))
 	c.Assert(migrations[0].Description, qt.Equals, "Team A")
+	c.Assert(migrations[0].Checksum, qt.Equals, "h1:teamhash")
 	c.Assert(migrations[1].Version, qt.Equals, int64(20220318104615))
 	c.Assert(migrations[1].Description, qt.Equals, "Add Users")
+	c.Assert(migrations[1].Checksum, qt.Equals, "h1:userhash")
 
 	err = migrations[0].Down(context.Background(), nil)
 	c.Assert(err, qt.ErrorMatches, `migration 20220318104614 has no Atlas down migration; dynamic Atlas-style down migrations are not implemented yet; add an atlas txtar down.sql section or migrate down manually`)

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -335,6 +335,7 @@ func NoopMigrationFunc(_ctx context.Context, _conn *dbschema.DatabaseConnection)
 type Migration struct {
 	Version         int64
 	Description     string
+	Checksum        string
 	Up              MigrationFunc
 	Down            MigrationFunc
 	UpSQL           string

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ type Migrator struct {
 	defaultTimeouts      MigrationTimeouts
 	migrationsTable      string
 	migrationsSchema     string
+	revisionTableFormat  RevisionTableFormat
 	execOrder            ExecOrder
 	migrationLockTimeout time.Duration
 	initialized          bool
@@ -54,11 +56,12 @@ func NewFSMigrator(conn *dbschema.DatabaseConnection, fsys fs.FS, opts ...FSProv
 // NewMigrator creates a new migrator with the given database connection
 func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) *Migrator {
 	return &Migrator{
-		conn:              conn,
-		migrationProvider: provider,
-		migrationsTable:   "schema_migrations",
-		execOrder:         ExecOrderLinear,
-		logger:            slog.Default(),
+		conn:                conn,
+		migrationProvider:   provider,
+		migrationsTable:     defaultPtahMigrationsTable,
+		revisionTableFormat: RevisionTableFormatPtah,
+		execOrder:           ExecOrderLinear,
+		logger:              slog.Default(),
 	}
 }
 
@@ -83,17 +86,33 @@ func (m *Migrator) WithMigrationsTable(schema, table string) *Migrator {
 	tmp.migrationsSchema = strings.TrimSpace(schema)
 	tmp.migrationsTable = strings.TrimSpace(table)
 	if tmp.migrationsTable == "" {
-		tmp.migrationsTable = "schema_migrations"
+		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
 	tmp.initialized = false
 	return &tmp
 }
 
-func (m *Migrator) qualifiedMigrationsTable() string {
-	table := m.migrationsTable
-	if table == "" {
-		table = "schema_migrations"
+// WithRevisionTableFormat sets the database table layout used for migration
+// revision metadata.
+func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator {
+	tmp := *m
+	tmp.revisionTableFormat = format
+	if tmp.migrationsTable == "" || tmp.migrationsTable == defaultPtahMigrationsTable {
+		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
+	tmp.initialized = false
+	return &tmp
+}
+
+func (m *Migrator) defaultMigrationsTable() string {
+	if m.revisionTableFormat.isAtlas() {
+		return defaultAtlasRevisionsTable
+	}
+	return defaultPtahMigrationsTable
+}
+
+func (m *Migrator) qualifiedMigrationsTable() string {
+	table := m.migrationsTableName()
 	if m.migrationsSchema == "" {
 		return m.quoteIdentifier(table)
 	}
@@ -125,6 +144,9 @@ func (m *Migrator) quoteIdentifier(identifier string) string {
 }
 
 func (m *Migrator) createMigrationsTableSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return m.createAtlasRevisionsTableSQL()
+	}
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
     version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
@@ -140,10 +162,24 @@ func (m *Migrator) createMigrationsTableSQL() string {
 }
 
 func (m *Migrator) getVersionSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(
+			"SELECT COALESCE(MAX(%s), 0) FROM %s WHERE applied = total AND COALESCE(error, '') = ''",
+			m.atlasVersionNumberExpression(),
+			m.qualifiedMigrationsTable(),
+		)
+	}
 	return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s WHERE state = 'applied'", m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) getAppliedMigrationsSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(
+			"SELECT version FROM %s WHERE applied = total AND COALESCE(error, '') = '' ORDER BY %s",
+			m.qualifiedMigrationsTable(),
+			m.atlasVersionNumberExpression(),
+		)
+	}
 	return fmt.Sprintf("SELECT version FROM %s WHERE state = 'applied' ORDER BY version", m.qualifiedMigrationsTable())
 }
 
@@ -174,15 +210,16 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 
 	// Deliberately outside the migration writer for the same reason as schema
 	// creation: there is no active migration transaction yet.
-	_, err := m.conn.ExecContext(ctx, m.createMigrationsTableSQL())
-	if err != nil {
+	if _, err := m.conn.ExecContext(ctx, m.createMigrationsTableSQL()); err != nil {
 		return fmt.Errorf("failed to create migrations table: %w", err)
 	}
-	if err := m.ensureMigrationsVersionColumn(ctx); err != nil {
-		return fmt.Errorf("failed to prepare migrations version column: %w", err)
-	}
-	if err := m.ensureMigrationsRevisionColumns(ctx); err != nil {
-		return fmt.Errorf("failed to prepare migrations revision columns: %w", err)
+	if !m.revisionTableFormat.isAtlas() {
+		if err := m.ensureMigrationsVersionColumn(ctx); err != nil {
+			return fmt.Errorf("failed to prepare migrations version column: %w", err)
+		}
+		if err := m.ensureMigrationsRevisionColumns(ctx); err != nil {
+			return fmt.Errorf("failed to prepare migrations revision columns: %w", err)
+		}
 	}
 
 	// Mark as initialized
@@ -345,7 +382,7 @@ func (m *Migrator) metadataSchemaName() string {
 
 func (m *Migrator) migrationsTableName() string {
 	if m.migrationsTable == "" {
-		return "schema_migrations"
+		return m.defaultMigrationsTable()
 	}
 	return m.migrationsTable
 }
@@ -361,13 +398,7 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int64, error) {
 	}
 
 	// Query the current version
-	var version int64
-	row := m.conn.QueryRowContext(ctx, m.getVersionSQL())
-	if err := row.Scan(&version); err != nil {
-		return 0, fmt.Errorf("failed to get current version: %w", err)
-	}
-
-	return version, nil
+	return m.scanCurrentVersion(ctx)
 }
 
 // GetAppliedMigrations returns a list of applied migration versions
@@ -389,8 +420,8 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error) {
 
 	applied := make([]int64, 0)
 	for rows.Next() {
-		var version int64
-		if err := rows.Scan(&version); err != nil {
+		version, err := m.scanAppliedVersion(rows)
+		if err != nil {
 			return nil, fmt.Errorf("failed to scan migration version: %w", err)
 		}
 		applied = append(applied, version)
@@ -401,6 +432,42 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error) {
 	}
 
 	return applied, nil
+}
+
+func (m *Migrator) scanCurrentVersion(ctx context.Context) (int64, error) {
+	row := m.conn.QueryRowContext(ctx, m.getVersionSQL())
+	var version int64
+	if err := row.Scan(&version); err != nil {
+		return 0, fmt.Errorf("failed to get current version: %w", err)
+	}
+	return version, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (m *Migrator) scanAppliedVersion(row rowScanner) (int64, error) {
+	if m.revisionTableFormat.isAtlas() {
+		var version string
+		if err := row.Scan(&version); err != nil {
+			return 0, err
+		}
+		return parseAtlasRevisionVersion(version)
+	}
+	var version int64
+	if err := row.Scan(&version); err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+func parseAtlasRevisionVersion(version string) (int64, error) {
+	parsed, err := strconv.ParseInt(strings.TrimSpace(version), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Atlas revision version %q is not a numeric Ptah migration version: %w", version, err)
+	}
+	return parsed, nil
 }
 
 // GetPendingMigrations returns a list of pending migration versions
@@ -780,7 +847,7 @@ func (m *Migrator) rollbackMigrationWithoutRegisteredDown(
 			fmt.Sprintf("failed to revert migration %d", migration.Version),
 		)
 	}
-	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Rolled back migration", "version", migration.Version, "description", migration.Description)
@@ -835,7 +902,7 @@ func (m *Migrator) rollbackMigrationTransactional(
 		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.DownSQL, "")
 	}
 
-	if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
+	if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 		_ = m.conn.Writer().RollbackTransaction()
 		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 	}
@@ -874,7 +941,7 @@ func (m *Migrator) rollbackMigrationNoTransaction(
 			fmt.Sprintf("failed to revert migration %d", migration.Version),
 		)
 	}
-	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Rolled back non-transactional migration", "version", migration.Version, "description", migration.Description)

--- a/migration/migrator/revision_table.go
+++ b/migration/migrator/revision_table.go
@@ -1,0 +1,40 @@
+package migrator
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	defaultPtahMigrationsTable = "schema_migrations"
+	defaultAtlasRevisionsTable = "atlas_schema_revisions"
+)
+
+// RevisionTableFormat selects the database table layout used for migration
+// revision metadata.
+type RevisionTableFormat string
+
+const (
+	// RevisionTableFormatPtah stores metadata in Ptah's native
+	// schema_migrations table layout.
+	RevisionTableFormatPtah RevisionTableFormat = "ptah"
+	// RevisionTableFormatAtlas stores metadata in Atlas's
+	// atlas_schema_revisions table layout.
+	RevisionTableFormatAtlas RevisionTableFormat = "atlas"
+)
+
+// ParseRevisionTableFormat normalizes a revision table format value.
+func ParseRevisionTableFormat(value string) (RevisionTableFormat, error) {
+	switch RevisionTableFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case "", RevisionTableFormatPtah:
+		return RevisionTableFormatPtah, nil
+	case RevisionTableFormatAtlas:
+		return RevisionTableFormatAtlas, nil
+	default:
+		return "", fmt.Errorf("unknown revision table format %q: expected ptah or atlas", value)
+	}
+}
+
+func (f RevisionTableFormat) isAtlas() bool {
+	return f == RevisionTableFormatAtlas
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,9 +15,11 @@ import (
 )
 
 const (
-	migrationStateApplied = "applied"
-	migrationStatePending = "pending"
-	migrationStateFailed  = "failed"
+	migrationStateApplied    = "applied"
+	migrationStatePending    = "pending"
+	migrationStateFailed     = "failed"
+	atlasRevisionTypeExecute = 2
+	ptahOperatorVersion      = "Ptah"
 )
 
 // MigrationRevision records one row from the migration metadata table.
@@ -87,6 +90,17 @@ func migrationChecksum(sqlText string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func migrationRevisionHash(migration *Migration) string {
+	if migration.Checksum == "" {
+		return migrationChecksum(migration.UpSQL)
+	}
+	return normalizeAtlasRevisionHash(migration.Checksum)
+}
+
+func normalizeAtlasRevisionHash(hash string) string {
+	return strings.TrimPrefix(hash, "h1:")
+}
+
 func migrationStatementCount(sqlText string) int {
 	return len(SplitSQLStatements(sqlText))
 }
@@ -109,6 +123,13 @@ func migrationExecutionProgress(err error, dialect string) (applied int, total i
 }
 
 func (m *Migrator) getDirtyRevisionSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at
+FROM %s
+WHERE applied <> total OR COALESCE(error, '') <> ''
+ORDER BY %s
+LIMIT 1`, m.qualifiedMigrationsTable(), m.atlasVersionNumberExpression())
+	}
 	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
 FROM %s
 WHERE state <> ?
@@ -117,17 +138,31 @@ LIMIT 1`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) getRevisionSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at
+FROM %s
+WHERE version = ?`, m.qualifiedMigrationsTable())
+	}
 	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
 FROM %s
 WHERE version = ?`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) beginMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`INSERT INTO %s (version, description, type, applied, total, executed_at, execution_time, error, error_stmt, hash, partial_hashes, operator_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
+	}
 	return fmt.Sprintf(`INSERT INTO %s (version, description, applied_at, state, applied, total, error, error_stmt, execution_time_ms, checksum)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) completeMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`UPDATE %s
+SET applied = ?, total = ?, executed_at = ?, execution_time = ?, error = NULL, error_stmt = NULL, partial_hashes = NULL, operator_version = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+	}
 	if m.isClickHouse() {
 		return fmt.Sprintf(`ALTER TABLE %s
 UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?
@@ -140,6 +175,11 @@ WHERE version = ?`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) beginRollbackSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`UPDATE %s
+SET applied = ?, total = ?, executed_at = ?, execution_time = ?, error = NULL, error_stmt = NULL, partial_hashes = NULL, operator_version = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+	}
 	if m.isClickHouse() {
 		return fmt.Sprintf(`ALTER TABLE %s
 UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?
@@ -152,6 +192,11 @@ WHERE version = ?`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) failMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`UPDATE %s
+SET applied = ?, total = ?, execution_time = ?, error = ?, error_stmt = ?, operator_version = ?
+WHERE version = ?`, m.qualifiedMigrationsTable())
+	}
 	if m.isClickHouse() {
 		return fmt.Sprintf(`ALTER TABLE %s
 UPDATE state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?
@@ -164,6 +209,11 @@ WHERE version = ?`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) forceAppliedMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`INSERT INTO %s (version, description, type, applied, total, executed_at, execution_time, error, error_stmt, hash, partial_hashes, operator_version)
+VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?)
+%s`, m.qualifiedMigrationsTable(), m.forceAppliedConflictClause())
+	}
 	return fmt.Sprintf(`INSERT INTO %s (version, description, applied_at, state, applied, total, error, error_stmt, execution_time_ms, checksum)
 VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
 %s`, m.qualifiedMigrationsTable(), m.forceAppliedConflictClause())
@@ -181,7 +231,43 @@ func (m *Migrator) countRevisionsSQL() string {
 }
 
 func (m *Migrator) countRevisionsAboveSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s > ?`, m.qualifiedMigrationsTable(), m.atlasVersionNumberExpression())
+	}
 	return fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE version > ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) atlasVersionNumberExpression() string {
+	switch m.conn.Info().Dialect {
+	case "mysql", "mariadb":
+		return "CAST(version AS SIGNED)"
+	default:
+		return "CAST(version AS BIGINT)"
+	}
+}
+
+func (m *Migrator) createAtlasRevisionsTableSQL() string {
+	partialHashesType := "JSON"
+	if m.conn != nil {
+		switch m.conn.Info().Dialect {
+		case "postgres", "cockroachdb", "yugabytedb":
+			partialHashesType = "JSONB"
+		}
+	}
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+    version VARCHAR(255) PRIMARY KEY,
+    description TEXT NOT NULL,
+    type BIGINT NOT NULL DEFAULT 2,
+    applied BIGINT NOT NULL DEFAULT 0,
+    total BIGINT NOT NULL DEFAULT 0,
+    executed_at TIMESTAMP NOT NULL,
+    execution_time BIGINT NOT NULL,
+    error TEXT NULL,
+    error_stmt TEXT NULL,
+    hash VARCHAR(255) NOT NULL,
+    partial_hashes %s NULL,
+    operator_version VARCHAR(255) NOT NULL
+)`, m.qualifiedMigrationsTable(), partialHashesType)
 }
 
 func (m *Migrator) isClickHouse() bool {
@@ -194,6 +280,20 @@ func (m *Migrator) forceAppliedConflictClause() string {
 	}
 	switch m.conn.Info().Dialect {
 	case "postgres", "cockroachdb", "yugabytedb":
+		if m.revisionTableFormat.isAtlas() {
+			return `ON CONFLICT (version) DO UPDATE SET
+description = EXCLUDED.description,
+type = EXCLUDED.type,
+applied = EXCLUDED.applied,
+total = EXCLUDED.total,
+executed_at = EXCLUDED.executed_at,
+execution_time = EXCLUDED.execution_time,
+error = NULL,
+error_stmt = NULL,
+hash = EXCLUDED.hash,
+partial_hashes = NULL,
+operator_version = EXCLUDED.operator_version`
+		}
 		return `ON CONFLICT (version) DO UPDATE SET
 description = EXCLUDED.description,
 applied_at = EXCLUDED.applied_at,
@@ -205,6 +305,20 @@ error_stmt = NULL,
 execution_time_ms = EXCLUDED.execution_time_ms,
 checksum = EXCLUDED.checksum`
 	case "mysql", "mariadb":
+		if m.revisionTableFormat.isAtlas() {
+			return `ON DUPLICATE KEY UPDATE
+description = VALUES(description),
+type = VALUES(type),
+applied = VALUES(applied),
+total = VALUES(total),
+executed_at = VALUES(executed_at),
+execution_time = VALUES(execution_time),
+error = NULL,
+error_stmt = NULL,
+hash = VALUES(hash),
+partial_hashes = NULL,
+operator_version = VALUES(operator_version)`
+		}
 		return `ON DUPLICATE KEY UPDATE
 description = VALUES(description),
 applied_at = VALUES(applied_at),
@@ -222,7 +336,11 @@ checksum = VALUES(checksum)`
 
 func (m *Migrator) dirtyRevision(ctx context.Context) (*MigrationRevision, error) {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getDirtyRevisionSQL())
-	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, migrationStateApplied))
+	row := m.conn.QueryRowContext(ctx, query, migrationStateApplied)
+	if m.revisionTableFormat.isAtlas() {
+		row = m.conn.QueryRowContext(ctx, query)
+	}
+	revision, err := m.scanRevisionRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -235,7 +353,7 @@ func (m *Migrator) dirtyRevision(ctx context.Context) (*MigrationRevision, error
 
 func (m *Migrator) getRevision(ctx context.Context, version int64) (*MigrationRevision, error) {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getRevisionSQL())
-	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, version))
+	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, m.revisionVersionArg(version)))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -247,6 +365,9 @@ func (m *Migrator) getRevision(ctx context.Context, version int64) (*MigrationRe
 }
 
 func (m *Migrator) scanRevisionRow(row *sql.Row) (MigrationRevision, error) {
+	if m.revisionTableFormat.isAtlas() {
+		return m.scanAtlasRevisionRow(row)
+	}
 	var revision MigrationRevision
 	var executionTimeMs int64
 	var appliedAt any
@@ -271,6 +392,49 @@ func (m *Migrator) scanRevisionRow(row *sql.Row) (MigrationRevision, error) {
 	revision.AppliedAt = parsedAppliedAt
 	revision.ExecutionTime = time.Duration(executionTimeMs) * time.Millisecond
 	return revision, nil
+}
+
+func (m *Migrator) scanAtlasRevisionRow(row *sql.Row) (MigrationRevision, error) {
+	var revision MigrationRevision
+	var version string
+	var revisionType int
+	var executionTime int64
+	var executedAt any
+	if err := row.Scan(
+		&version,
+		&revision.Description,
+		&revisionType,
+		&revision.Applied,
+		&revision.Total,
+		&revision.Error,
+		&revision.ErrorStatement,
+		&executionTime,
+		&revision.Checksum,
+		&executedAt,
+	); err != nil {
+		return MigrationRevision{}, err
+	}
+	parsedVersion, err := parseAtlasRevisionVersion(version)
+	if err != nil {
+		return MigrationRevision{}, err
+	}
+	parsedExecutedAt, err := parseRevisionAppliedAt(executedAt)
+	if err != nil {
+		return MigrationRevision{}, err
+	}
+	revision.Version = parsedVersion
+	revision.State = atlasRevisionState(revision)
+	revision.AppliedAt = parsedExecutedAt
+	revision.ExecutionTime = time.Duration(executionTime)
+	_ = revisionType
+	return revision, nil
+}
+
+func atlasRevisionState(revision MigrationRevision) string {
+	if revision.Error != "" || revision.Applied != revision.Total {
+		return migrationStateFailed
+	}
+	return migrationStateApplied
 }
 
 func parseRevisionAppliedAt(value any) (time.Time, error) {
@@ -324,6 +488,9 @@ func (m *Migrator) beginMigrationRevision(ctx context.Context, migration *Migrat
 	if m.conn.Writer().IsDryRun() {
 		return nil
 	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.beginAtlasMigrationRevision(ctx, migration)
+	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginMigrationSQL())
 	return executeSQLOutsideTransaction(
 		ctx,
@@ -342,9 +509,33 @@ func (m *Migrator) beginMigrationRevision(ctx context.Context, migration *Migrat
 	)
 }
 
+func (m *Migrator) beginAtlasMigrationRevision(ctx context.Context, migration *Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		strconv.FormatInt(migration.Version, 10),
+		migration.Description,
+		atlasRevisionTypeExecute,
+		0,
+		migrationStatementCount(migration.UpSQL),
+		time.Now(),
+		int64(0),
+		nil,
+		nil,
+		migrationRevisionHash(migration),
+		nil,
+		ptahOperatorVersion,
+	)
+}
+
 func (m *Migrator) completeMigrationRevision(ctx context.Context, migration *Migration, startedAt time.Time) error {
 	if m.conn.Writer().IsDryRun() {
 		return nil
+	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.completeAtlasMigrationRevision(ctx, migration, startedAt)
 	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.completeMigrationSQL())
 	return executeSQLOutsideTransaction(
@@ -360,9 +551,28 @@ func (m *Migrator) completeMigrationRevision(ctx context.Context, migration *Mig
 	)
 }
 
+func (m *Migrator) completeAtlasMigrationRevision(ctx context.Context, migration *Migration, startedAt time.Time) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.completeMigrationSQL())
+	total := migrationStatementCount(migration.UpSQL)
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		total,
+		total,
+		time.Now(),
+		time.Since(startedAt).Nanoseconds(),
+		ptahOperatorVersion,
+		strconv.FormatInt(migration.Version, 10),
+	)
+}
+
 func (m *Migrator) beginRollbackRevision(ctx context.Context, migration *Migration) error {
 	if m.conn.Writer().IsDryRun() {
 		return nil
+	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.beginAtlasRollbackRevision(ctx, migration)
 	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginRollbackSQL())
 	return executeSQLOutsideTransaction(
@@ -374,6 +584,21 @@ func (m *Migrator) beginRollbackRevision(ctx context.Context, migration *Migrati
 		migrationStatementCount(migration.DownSQL),
 		0,
 		migration.Version,
+	)
+}
+
+func (m *Migrator) beginAtlasRollbackRevision(ctx context.Context, migration *Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.beginRollbackSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		0,
+		migrationStatementCount(migration.DownSQL),
+		time.Now(),
+		int64(0),
+		ptahOperatorVersion,
+		strconv.FormatInt(migration.Version, 10),
 	)
 }
 
@@ -391,6 +616,9 @@ func (m *Migrator) failMigrationRevision(
 	if total == 0 {
 		total = migrationStatementCount(sqlText)
 	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.failAtlasMigrationRevision(ctx, migration, startedAt, failure, applied, total, stmt)
+	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
 	return executeSQLOutsideTransaction(
 		ctx,
@@ -406,6 +634,30 @@ func (m *Migrator) failMigrationRevision(
 	)
 }
 
+func (m *Migrator) failAtlasMigrationRevision(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	failure error,
+	applied int,
+	total int,
+	stmt string,
+) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		applied,
+		total,
+		time.Since(startedAt).Nanoseconds(),
+		strings.TrimSpace(failure.Error()),
+		stmt,
+		ptahOperatorVersion,
+		strconv.FormatInt(migration.Version, 10),
+	)
+}
+
 func (m *Migrator) verifyAppliedMigrationChecksums(ctx context.Context, migrations []*Migration) error {
 	if m.conn.Writer().IsDryRun() {
 		return nil
@@ -418,11 +670,12 @@ func (m *Migrator) verifyAppliedMigrationChecksums(ctx context.Context, migratio
 		if revision == nil || revision.State != migrationStateApplied || revision.Checksum == "" {
 			continue
 		}
-		checksum := migrationChecksum(migration.UpSQL)
-		if revision.Checksum != checksum {
+		checksum := migrationRevisionHash(migration)
+		stored := normalizeAtlasRevisionHash(revision.Checksum)
+		if stored != checksum {
 			return &ChecksumMismatchError{
 				Version:  migration.Version,
-				Stored:   revision.Checksum,
+				Stored:   stored,
 				Computed: checksum,
 			}
 		}
@@ -538,9 +791,15 @@ func (m *Migrator) writeBaselineMigrationRows(ctx context.Context, migrations []
 	for _, migration := range migrations {
 		if m.forceAppliedConflictClause() == "" {
 			deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
-			if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, migration.Version); err != nil {
+			if err := m.conn.Writer().ExecuteSQL(ctx, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 				return fmt.Errorf("failed to prepare baseline revision %d: %w", migration.Version, err)
 			}
+		}
+		if m.revisionTableFormat.isAtlas() {
+			if err := m.writeAtlasBaselineMigrationRow(ctx, query, migration); err != nil {
+				return err
+			}
+			continue
 		}
 		if err := m.conn.Writer().ExecuteSQL(
 			ctx,
@@ -552,10 +811,30 @@ func (m *Migrator) writeBaselineMigrationRows(ctx context.Context, migrations []
 			migrationStatementCount(migration.UpSQL),
 			migrationStatementCount(migration.UpSQL),
 			0,
-			migrationChecksum(migration.UpSQL),
+			migrationRevisionHash(migration),
 		); err != nil {
 			return fmt.Errorf("failed to record baseline revision %d: %w", migration.Version, err)
 		}
+	}
+	return nil
+}
+
+func (m *Migrator) writeAtlasBaselineMigrationRow(ctx context.Context, query string, migration *Migration) error {
+	total := migrationStatementCount(migration.UpSQL)
+	if err := m.conn.Writer().ExecuteSQL(
+		ctx,
+		query,
+		strconv.FormatInt(migration.Version, 10),
+		migration.Description,
+		atlasRevisionTypeExecute,
+		total,
+		total,
+		time.Now(),
+		int64(0),
+		migrationRevisionHash(migration),
+		ptahOperatorVersion,
+	); err != nil {
+		return fmt.Errorf("failed to record baseline revision %d: %w", migration.Version, err)
 	}
 	return nil
 }
@@ -629,9 +908,12 @@ func (m *Migrator) forceAppliedMigration(ctx context.Context, migration *Migrati
 	}
 	if m.forceAppliedConflictClause() == "" {
 		deleteSQL := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
-		if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, migration.Version); err != nil {
+		if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 			return err
 		}
+	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.forceAppliedAtlasMigration(ctx, migration)
 	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedMigrationSQL())
 	return executeSQLOutsideTransaction(
@@ -645,7 +927,26 @@ func (m *Migrator) forceAppliedMigration(ctx context.Context, migration *Migrati
 		migrationStatementCount(migration.UpSQL),
 		migrationStatementCount(migration.UpSQL),
 		0,
-		migrationChecksum(migration.UpSQL),
+		migrationRevisionHash(migration),
+	)
+}
+
+func (m *Migrator) forceAppliedAtlasMigration(ctx context.Context, migration *Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedMigrationSQL())
+	total := migrationStatementCount(migration.UpSQL)
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		strconv.FormatInt(migration.Version, 10),
+		migration.Description,
+		atlasRevisionTypeExecute,
+		total,
+		total,
+		time.Now(),
+		int64(0),
+		migrationRevisionHash(migration),
+		ptahOperatorVersion,
 	)
 }
 
@@ -661,7 +962,14 @@ func (m *Migrator) forceAppliedMigrationClickHouse(ctx context.Context, migratio
 		migrationStatementCount(migration.UpSQL),
 		migrationStatementCount(migration.UpSQL),
 		0,
-		migrationChecksum(migration.UpSQL),
+		migrationRevisionHash(migration),
 		migration.Version,
 	)
+}
+
+func (m *Migrator) revisionVersionArg(version int64) any {
+	if m.revisionTableFormat.isAtlas() {
+		return strconv.FormatInt(version, 10)
+	}
+	return version
 }


### PR DESCRIPTION
## Summary

- add `--revision-format` with Ptah and Atlas revision table modes
- read Atlas migration checksums from `atlas.sum` and write Atlas-shaped `atlas_schema_revisions` rows
- expose Atlas-compatible forwarding under `ptah atlas <command> ...` while keeping native Ptah commands separate
- reject `ptah migrate apply` at the native root and document the separate native CLI redesign in #370

Closes #275

## Validation

- `go test ./cmd/atlas ./cmd/migrate ./cmd/packagemigrator -count=1`
- `go test ./cmd/... -count=1`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...` outside sandbox
- `POSTGRES_TEST_DSN=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable go test ./migration/migrator -count=1 -run 'TestAtlas(Format|TxtarDown|Template|RevisionTable)_PostgresIntegration'`
- root smoke: `go run ./cmd atlas migrate apply`
- root smoke: `go run ./cmd migrate apply`
- root smoke: `go run ./cmd atlas schema inspect --help`
- `git diff --check`