### PR TITLE
Show Atlas paths for forwarded command help

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -45,6 +45,7 @@ func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(out.String(), qt.Contains, "Usage:")
+			c.Assert(out.String(), qt.Contains, "atlas "+strings.Join(path, " "))
 		})
 	}
 }
@@ -75,6 +76,23 @@ func TestNewAtlasCommand_ForwardsParentedNativeCommand(t *testing.T) {
 	err := root.Execute()
 
 	c.Assert(err, qt.ErrorMatches, "database URL is required")
+}
+
+func TestNewAtlasCommand_HelpUsesAtlasPathForForwardedParentedCommand(t *testing.T) {
+	c := qt.New(t)
+	root := &cobra.Command{Use: "ptah"}
+	root.AddCommand(migrateup.NewMigrateUpCommand())
+	root.AddCommand(NewAtlasCommand())
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"atlas", "migrate", "apply", "--help"})
+
+	err := root.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "ptah atlas migrate apply")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  migrate-up")
 }
 
 func TestNewAtlasCommand_UnsupportedCommandsAreExplicit(t *testing.T) {

--- a/cmd/internal/cmdalias/cmdalias.go
+++ b/cmd/internal/cmdalias/cmdalias.go
@@ -34,6 +34,9 @@ func NewForwardCommandWithArgs(
 		SilenceUsage:       true,
 		SilenceErrors:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if hasHelpArg(args) {
+				return cmd.Help()
+			}
 			target := factory()
 			resetCommandFlags(target)
 			parent := target.Parent()
@@ -51,6 +54,15 @@ func NewForwardCommandWithArgs(
 			return target.Execute()
 		},
 	}
+}
+
+func hasHelpArg(args []string) bool {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+	return false
 }
 
 func resetCommandFlags(cmd *cobra.Command) {


### PR DESCRIPTION
## Summary

- render `ptah atlas ...` alias help locally instead of forwarding `--help` to native commands
- keep runtime invocation forwarding unchanged for non-help args
- add regression coverage for parented forwarded commands and Atlas-path Usage output

This fixes the conformance `atlas-cli-surface` probe after #371: the commands existed, but `--help` showed native Usage lines such as `migrate-up`, so the probe could not prove that `ptah atlas migrate apply` resolved.

## Validation

- `go test ./cmd/atlas ./cmd/internal/cmdalias -count=1`
- `go test ./cmd/... -count=1`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...` outside sandbox
- `go run ./cmd atlas migrate apply --help`
- `go run ./cmd atlas migrate apply`
- `PTAH_BIN=/private/tmp/ptah-atlas-forward-help make budget` in `ptah-atlas-conformance`: 0 non-OK, budget 0
- `git diff --check`