### PR TITLE
Fix FK-safe down table drop order

### DIFF
--- a/migration/generator/fk_drop_order_integration_test.go
+++ b/migration/generator/fk_drop_order_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package generator
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestFKDropOrder_DownRoundTrip_Integration(t *testing.T) {
+	cases := []struct {
+		dialect string
+		envKey  string
+	}{
+		{"postgres", "POSTGRES_URL"},
+		{"mysql", "MYSQL_URL"},
+		{"mariadb", "MARIADB_URL"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			url := os.Getenv(tc.envKey)
+			if url == "" {
+				t.Skipf("skipping %s: %s not set", tc.dialect, tc.envKey)
+			}
+
+			c := qt.New(t)
+			ctx := context.Background()
+			conn, err := dbschema.ConnectToDatabase(ctx, url)
+			if err != nil {
+				t.Skipf("skipping %s: cannot connect: %v", tc.dialect, err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			dialect := conn.Info().Dialect
+			dropFKOrderTables(conn, dialect)
+			t.Cleanup(func() { dropFKOrderTables(conn, dialect) })
+
+			target := fkOrderSchema()
+			goschema.Finalize(target)
+			empty := &dbschematypes.DBSchema{}
+			upDiff := schemadiff.CompareWithDialect(target, empty, dialect)
+			c.Assert(upDiff.HasChanges(), qt.IsTrue)
+
+			upSQL, err := generateUpMigrationSQL(upDiff, target, dialect)
+			c.Assert(err, qt.IsNil)
+			execScript(c, conn, upSQL, "UP")
+
+			downSQL, err := generateDownMigrationSQL(upDiff, target, empty, dialect)
+			c.Assert(err, qt.IsNil)
+			t.Logf("[%s] generated DOWN:\n%s", dialect, downSQL)
+			execScript(c, conn, downSQL, "DOWN")
+
+			dbAfterDown, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			c.Assert(hasFKOrderTables(dbAfterDown), qt.IsFalse)
+		})
+	}
+}
+
+func dropFKOrderTables(conn *dbschema.DatabaseConnection, dialect string) {
+	for _, tableName := range []string{
+		"ptah_fk_order_tasks",
+		"ptah_fk_order_memberships",
+		"ptah_fk_order_projects",
+		"ptah_fk_order_accounts",
+	} {
+		_, _ = conn.Exec(dropTableSQL(dialect, tableName))
+	}
+}
+
+func hasFKOrderTables(schema *dbschematypes.DBSchema) bool {
+	for _, table := range schema.Tables {
+		if strings.HasPrefix(table.Name, "ptah_fk_order_") {
+			return true
+		}
+	}
+	return false
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -367,8 +367,8 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	return &types.SchemaDiff{
 		// Reverse table operations
-		TablesAdded:    diff.TablesRemoved, // Tables to remove become tables to add
-		TablesRemoved:  diff.TablesAdded,   // Tables to add become tables to remove
+		TablesAdded:    diff.TablesRemoved,                               // Tables to remove become tables to add
+		TablesRemoved:  rollbackDropTableOrder(diff.TablesAdded, schema), // Tables to add become tables to remove
 		TablesModified: reverseTableDiffs(diff.TablesModified),
 
 		// Reverse enum operations
@@ -428,6 +428,185 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
 		ConstraintsAddedWithTables:   reverseConstraintAdditions(diff, dbSchema),
 	}
+}
+
+func rollbackDropTableOrder(tableNames []string, schema *goschema.Database) []string {
+	ordered := append([]string(nil), tableNames...)
+	if schema == nil || len(ordered) < 2 {
+		return ordered
+	}
+
+	candidates := make(map[string]bool, len(ordered))
+	for _, tableName := range ordered {
+		candidates[tableName] = true
+	}
+
+	dependencies := generatedTableDependencies(schema)
+	dependents := make(map[string][]string)
+	for _, child := range ordered {
+		for _, parent := range dependencies[child] {
+			if candidates[parent] && parent != child && !slices.Contains(dependents[parent], child) {
+				dependents[parent] = append(dependents[parent], child)
+			}
+		}
+	}
+
+	result := make([]string, 0, len(ordered))
+	state := make(map[string]int, len(ordered))
+	var visit func(string)
+	visit = func(tableName string) {
+		switch state[tableName] {
+		case 1:
+			return
+		case 2:
+			return
+		}
+		state[tableName] = 1
+		for _, child := range dependents[tableName] {
+			visit(child)
+		}
+		state[tableName] = 2
+		result = append(result, tableName)
+	}
+
+	for _, tableName := range ordered {
+		visit(tableName)
+	}
+	return result
+}
+
+func generatedTableDependencies(schema *goschema.Database) map[string][]string {
+	dependencies := make(map[string][]string, len(schema.Tables))
+	for _, table := range schema.Tables {
+		dependencies[table.QualifiedName()] = append([]string(nil), schema.Dependencies[table.QualifiedName()]...)
+	}
+
+	for _, field := range schema.Fields {
+		if field.Foreign == "" {
+			continue
+		}
+		table := generatedTableByStructName(schema.Tables, field.StructName)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(field.Foreign))
+	}
+
+	for _, embedded := range schema.EmbeddedFields {
+		if embedded.Mode != "relation" || embedded.Ref == "" {
+			continue
+		}
+		table := generatedTableByStructName(schema.Tables, embedded.StructName)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(embedded.Ref))
+	}
+
+	for _, constraint := range schema.Constraints {
+		if constraint.ForeignTable == "" || !strings.EqualFold(constraint.Type, "FOREIGN KEY") {
+			continue
+		}
+		table := generatedTableReference(schema.Tables, constraint.StructName, constraint.Table)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, constraint.ForeignTable)
+	}
+
+	return dependencies
+}
+
+func addGeneratedTableDependency(
+	dependencies map[string][]string,
+	tables []goschema.Table,
+	table goschema.Table,
+	refTable string,
+) {
+	tableName := table.QualifiedName()
+	refTable = resolveGeneratedReferenceTableName(tables, table, refTable)
+	if tableName == refTable || slices.Contains(dependencies[tableName], refTable) {
+		return
+	}
+	dependencies[tableName] = append(dependencies[tableName], refTable)
+}
+
+func generatedTableByStructName(tables []goschema.Table, structName string) *goschema.Table {
+	for i := range tables {
+		if tables[i].StructName == structName {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func generatedTableReference(tables []goschema.Table, structName, tableName string) *goschema.Table {
+	tableName = strings.TrimSpace(tableName)
+	for i := range tables {
+		table := &tables[i]
+		if tableName == "" && table.StructName == structName {
+			return table
+		}
+		if tableName != "" && table.StructName == structName && (table.Name == tableName || table.QualifiedName() == tableName) {
+			return table
+		}
+	}
+	if tableName == "" {
+		return nil
+	}
+	if strings.Contains(tableName, ".") {
+		for i := range tables {
+			if tables[i].QualifiedName() == tableName {
+				return &tables[i]
+			}
+		}
+		return nil
+	}
+
+	var match *goschema.Table
+	for i := range tables {
+		if tables[i].Name != tableName {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = &tables[i]
+	}
+	return match
+}
+
+func resolveGeneratedReferenceTableName(tables []goschema.Table, current goschema.Table, refTable string) string {
+	refTable = strings.TrimSpace(refTable)
+	if strings.Contains(refTable, ".") {
+		return refTable
+	}
+	for _, table := range tables {
+		if table.Schema == current.Schema && table.Name == refTable {
+			return table.QualifiedName()
+		}
+	}
+	var match string
+	for _, table := range tables {
+		if table.Name != refTable {
+			continue
+		}
+		if match != "" {
+			return refTable
+		}
+		match = table.QualifiedName()
+	}
+	if match != "" {
+		return match
+	}
+	return refTable
+}
+
+func foreignReferenceTable(ref string) string {
+	if tableName, _, ok := strings.Cut(ref, "("); ok {
+		return strings.TrimSpace(tableName)
+	}
+	return strings.TrimSpace(ref)
 }
 
 // reverseConstraintAdditions builds the table-qualified additions for the down
@@ -491,16 +670,30 @@ func foreignKeyAdditionFromDBConstraint(name, table string, dbFK dbschematypes.D
 		OnUpdate:  derefString(dbFK.UpdateRule),
 	}
 	if columns := dbFK.ColumnNamesOrDefault(); len(columns) > 0 {
-		info.Columns = append([]string(nil), columns...)
+		info.Columns = uniqueStringsPreserveOrder(columns)
 	}
 	if dbFK.ForeignTable != nil {
 		info.ForeignTable = *dbFK.ForeignTable
 	}
 	if foreignColumns := dbFK.ForeignColumnsOrDefault(); len(foreignColumns) > 0 {
+		foreignColumns = uniqueStringsPreserveOrder(foreignColumns)
 		info.ForeignColumn = foreignColumns[0]
-		info.ForeignColumns = append([]string(nil), foreignColumns...)
+		info.ForeignColumns = foreignColumns
 	}
 	return info
+}
+
+func uniqueStringsPreserveOrder(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 // derefString returns the pointed-to string or "" when nil.

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -324,6 +324,76 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 	c.Assert(result.GrantOptionsRevoked, qt.DeepEquals, input.GrantOptionsAdded)
 }
 
+func TestGenerateDownMigrationSQL_DropsFKChainChildBeforeParent(t *testing.T) {
+	c := qt.New(t)
+	schema := fkOrderSchema()
+	upDiff := &types.SchemaDiff{
+		TablesAdded: []string{
+			"ptah_fk_order_accounts",
+			"ptah_fk_order_projects",
+			"ptah_fk_order_tasks",
+		},
+	}
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+}
+
+func TestGenerateDownMigrationSQL_DropsFKDiamondLeavesBeforeRoot(t *testing.T) {
+	c := qt.New(t)
+	schema := fkOrderSchema()
+	upDiff := &types.SchemaDiff{
+		TablesAdded: []string{
+			"ptah_fk_order_accounts",
+			"ptah_fk_order_memberships",
+			"ptah_fk_order_projects",
+			"ptah_fk_order_tasks",
+		},
+	}
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_memberships")
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_memberships", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+}
+
+func TestGenerateDownMigrationSQL_DropsSchemaQualifiedTableLevelFKChildBeforeParent(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Account", Schema: "app", Name: "accounts"},
+			{StructName: "Project", Schema: "app", Name: "projects"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Account", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "Project", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "Project", Name: "account_id", Type: "VARCHAR(36)"},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				Name:           "fk_projects_account",
+				Type:           "FOREIGN KEY",
+				Table:          "app.projects",
+				Columns:        []string{"account_id"},
+				ForeignTable:   "app.accounts",
+				ForeignColumns: []string{"id"},
+			},
+		},
+	}
+	upDiff := &types.SchemaDiff{TablesAdded: []string{"app.accounts", "app.projects"}}
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS app.projects", "DROP TABLE IF EXISTS app.accounts")
+}
+
 func TestReverseSchemaDiff_GrantOptionUpgradeDownRevokesOnlyOption(t *testing.T) {
 	c := qt.New(t)
 	upDiff := &types.SchemaDiff{
@@ -668,6 +738,80 @@ func TestReverseSchemaDiff_FieldLevelCheckRemovalsWithTables(t *testing.T) {
 		{Name: "files_category_check", TableName: "files", Type: "CHECK"},
 		{Name: "files_status_valid", TableName: "files", Type: "CHECK"},
 	})
+}
+
+func TestForeignKeyAdditionFromDBConstraint_DeduplicatesRepeatedIntrospectionColumns(t *testing.T) {
+	c := qt.New(t)
+	foreignTable := "ptah_tenants"
+	dbConstraint := dbschematypes.DBConstraint{
+		Name:           "fk_entity_tenant",
+		TableName:      "ptah_area",
+		Type:           "FOREIGN KEY",
+		ColumnNames:    []string{"tenant_id", "tenant_id", "tenant_id"},
+		ForeignTable:   &foreignTable,
+		ForeignColumns: []string{"id", "id", "id"},
+	}
+
+	info := foreignKeyAdditionFromDBConstraint("fk_entity_tenant", "ptah_area", dbConstraint)
+
+	c.Assert(info.Columns, qt.DeepEquals, []string{"tenant_id"})
+	c.Assert(info.ForeignColumns, qt.DeepEquals, []string{"id"})
+	c.Assert(info.ForeignColumn, qt.Equals, "id")
+}
+
+func fkOrderSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "PtahFKOrderAccount", Name: "ptah_fk_order_accounts"},
+			{StructName: "PtahFKOrderProject", Name: "ptah_fk_order_projects"},
+			{StructName: "PtahFKOrderMembership", Name: "ptah_fk_order_memberships"},
+			{StructName: "PtahFKOrderTask", Name: "ptah_fk_order_tasks"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "PtahFKOrderAccount", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "PtahFKOrderProject", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderProject",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_projects_account",
+			},
+			{StructName: "PtahFKOrderMembership", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderMembership",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_memberships_account",
+			},
+			{StructName: "PtahFKOrderTask", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "project_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_projects(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_project",
+			},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "membership_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_memberships(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_membership",
+			},
+		},
+	}
+}
+
+func assertSQLBefore(t *testing.T, sql, earlier, later string) {
+	t.Helper()
+	c := qt.New(t)
+	earlierIndex := strings.Index(sql, earlier)
+	laterIndex := strings.Index(sql, later)
+	c.Assert(earlierIndex >= 0, qt.IsTrue, qt.Commentf("%q not found in SQL:\n%s", earlier, sql))
+	c.Assert(laterIndex >= 0, qt.IsTrue, qt.Commentf("%q not found in SQL:\n%s", later, sql))
+	c.Assert(earlierIndex < laterIndex, qt.IsTrue, qt.Commentf("%q must appear before %q:\n%s", earlier, later, sql))
 }
 
 // TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction is the

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -1220,7 +1220,7 @@ func cloneBoolPtr(value *bool) *bool {
 // (the same hazard checkConstraintChanged guards against for CHECK clauses).
 func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint, dialect string) bool {
 	// Compare local columns.
-	if !slices.Equal(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault()) {
+	if !slices.Equal(genConstraint.Columns, uniqueStringsPreserveOrder(dbConstraint.ColumnNamesOrDefault())) {
 		return true
 	}
 
@@ -1230,7 +1230,7 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 	}
 
 	// Compare referenced columns.
-	if !slices.Equal(genConstraint.ForeignColumnsOrDefault(), dbConstraint.ForeignColumnsOrDefault()) {
+	if !slices.Equal(genConstraint.ForeignColumnsOrDefault(), uniqueStringsPreserveOrder(dbConstraint.ForeignColumnsOrDefault())) {
 		return true
 	}
 
@@ -1245,6 +1245,19 @@ func foreignKeyConstraintChanged(genConstraint goschema.Constraint, dbConstraint
 	}
 
 	return false
+}
+
+func uniqueStringsPreserveOrder(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func foreignTableRefMatches(generated string, dbConstraint types.DBConstraint) bool {

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -337,3 +337,44 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 		})
 	}
 }
+
+func TestConstraints_FieldLevelForeignKeyDeduplicatesRepeatedIntrospectionColumns(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Area", Name: "ptah_area"}},
+		Fields: []goschema.Field{
+			{StructName: "Area", Name: "id", Type: "TEXT", Primary: true},
+			{
+				StructName:     "Area",
+				Name:           "tenant_id",
+				Type:           "TEXT",
+				Foreign:        "ptah_tenants(id)",
+				ForeignKeyName: "fk_entity_tenant",
+			},
+		},
+	}
+	foreignTable := "ptah_tenants"
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{Name: "ptah_area", Columns: []types.DBColumn{{Name: "id"}, {Name: "tenant_id"}}},
+			{Name: "ptah_tenants", Columns: []types.DBColumn{{Name: "id"}}},
+		},
+		Constraints: []types.DBConstraint{
+			{
+				Name:           "fk_entity_tenant",
+				TableName:      "ptah_area",
+				Type:           "FOREIGN KEY",
+				ColumnNames:    []string{"tenant_id", "tenant_id", "tenant_id"},
+				ForeignTable:   &foreignTable,
+				ForeignColumns: []string{"id", "id", "id"},
+				DeleteRule:     new("NO ACTION"),
+				UpdateRule:     new("NO ACTION"),
+			},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Constraints(generated, database, diff, nil)
+
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("added=%v removed=%v", diff.ConstraintsAdded, diff.ConstraintsRemoved))
+}


### PR DESCRIPTION
## Summary

- Fix down-migration table removal order so rollback drops FK dependents before their referenced parent tables.
- Build rollback dependencies from generated table fields, embedded relation fields, table-level FK constraints, and existing generated dependency metadata.
- Deduplicate repeated introspected FK local/referenced columns when restoring down FKs and comparing FK definitions, preventing shared-name Postgres FKs from generating churn or invalid duplicate-column SQL.

Closes #127.

## Self-review

- Logic: rollback ordering is scoped to the tables the down migration actually removes; unrelated dependencies are ignored, self-references do not recurse, and cycles keep a stable order instead of panicking.
- Dialects: verified against PostgreSQL, MySQL, and MariaDB live rollback paths. PostgreSQL still renders `CASCADE`, but the ordering is fixed for every dialect and is required for MySQL-family rollback.
- Safety: no new SQL interpolation surface is introduced; the change reorders already-planned table names and normalizes introspected FK column lists.
- Compatibility: nil schema and legacy callers preserve the prior table order. The bare constraint name lists remain intact; richer table-qualified metadata is only normalized.
- Coverage: added chain, diamond, schema-qualified table-level FK, FK restore dedupe, FK compare dedupe, and live DB rollback tests.

## Validation

- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `env POSTGRES_URL=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable MYSQL_URL=mysql://ptah_user:ptah_password@tcp(localhost:3310)/ptah_test MARIADB_URL=mariadb://ptah_user:ptah_password@tcp(localhost:3307)/ptah_test go test -tags=integration ./migration/generator -count=1`
