### PR TITLE
Detect CHECK and UNIQUE constraint drift

### DIFF
--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -135,6 +135,8 @@ func TestPostgreSQLReader_enhanceTablesWithConstraints(t *testing.T) {
 				{Name: "id", IsPrimaryKey: false, IsUnique: false},
 				{Name: "email", IsPrimaryKey: false, IsUnique: false},
 				{Name: "name", IsPrimaryKey: false, IsUnique: false},
+				{Name: "sku", IsPrimaryKey: false, IsUnique: false},
+				{Name: "region", IsPrimaryKey: false, IsUnique: false},
 			},
 		},
 	}
@@ -142,6 +144,7 @@ func TestPostgreSQLReader_enhanceTablesWithConstraints(t *testing.T) {
 	constraints := []types.DBConstraint{
 		{TableName: "test_table", ColumnName: "id", Type: "PRIMARY KEY"},
 		{TableName: "test_table", ColumnName: "email", Type: "UNIQUE"},
+		{TableName: "test_table", ColumnNames: []string{"sku", "region"}, Type: "UNIQUE"},
 	}
 
 	// Test the enhancement
@@ -159,6 +162,14 @@ func TestPostgreSQLReader_enhanceTablesWithConstraints(t *testing.T) {
 	nameCol := testutils.FindColumn(tables[0].Columns, "name")
 	c.Assert(nameCol.IsPrimaryKey, qt.IsFalse)
 	c.Assert(nameCol.IsUnique, qt.IsFalse)
+
+	skuCol := testutils.FindColumn(tables[0].Columns, "sku")
+	c.Assert(skuCol.IsPrimaryKey, qt.IsFalse)
+	c.Assert(skuCol.IsUnique, qt.IsFalse)
+
+	regionCol := testutils.FindColumn(tables[0].Columns, "region")
+	c.Assert(regionCol.IsPrimaryKey, qt.IsFalse)
+	c.Assert(regionCol.IsUnique, qt.IsFalse)
 }
 
 func TestNewPostgreSQLWriter(t *testing.T) {

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -796,10 +796,14 @@ func (r *Reader) enhanceTablesWithConstraints(tables []types.DBTable, constraint
 			primaryKeys[tableName][constraint.ColumnName] = true
 		}
 		if constraint.Type == "UNIQUE" {
+			columns := constraint.ColumnNamesOrDefault()
+			if len(columns) != 1 {
+				continue
+			}
 			if uniqueKeys[tableName] == nil {
 				uniqueKeys[tableName] = make(map[string]bool)
 			}
-			uniqueKeys[tableName][constraint.ColumnName] = true
+			uniqueKeys[tableName][columns[0]] = true
 		}
 	}
 

--- a/migration/generator/constraint_drift_integration_test.go
+++ b/migration/generator/constraint_drift_integration_test.go
@@ -1,0 +1,202 @@
+//go:build integration
+
+package generator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestConstraintDriftGenerateRoundTrip_Integration(t *testing.T) {
+	dbURL := os.Getenv("POSTGRES_URL")
+	if dbURL == "" {
+		t.Skip("skipping PostgreSQL constraint drift integration: POSTGRES_URL not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("skipping PostgreSQL constraint drift integration: cannot connect: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	cleanupConstraintDriftTable(conn)
+	t.Cleanup(func() { cleanupConstraintDriftTable(conn) })
+
+	_, err = conn.ExecContext(ctx, `
+CREATE TABLE ptah_constraint_drift (
+  id integer PRIMARY KEY,
+  price integer NOT NULL,
+  sku text NOT NULL,
+  region text NOT NULL,
+  category text NOT NULL,
+  CONSTRAINT ptah_constraint_price_check CHECK (price > 0),
+  CONSTRAINT ptah_constraint_unique UNIQUE (sku, region)
+)`)
+	c.Assert(err, qt.IsNil)
+
+	root := c.TempDir()
+	entitiesDir := filepath.Join(root, "entities")
+	migrationsDir := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(`package entities
+
+//migrator:schema:table name="ptah_constraint_drift"
+//migrator:schema:constraint name="ptah_constraint_price_check" type="CHECK" check="price >= 0"
+//migrator:schema:constraint name="ptah_constraint_unique" type="UNIQUE" columns="sku,region,category"
+type Product struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int
+
+	//migrator:schema:field name="price" type="INTEGER" not_null="true"
+	Price int
+
+	//migrator:schema:field name="sku" type="TEXT" not_null="true"
+	SKU string
+
+	//migrator:schema:field name="region" type="TEXT" not_null="true"
+	Region string
+
+	//migrator:schema:field name="category" type="TEXT" not_null="true"
+	Category string
+}
+`), 0600), qt.IsNil)
+
+	files, err := GenerateMigration(ctx, GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DBConn:        conn,
+		MigrationName: "constraint_drift",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+
+	upSQLBytes, err := os.ReadFile(files.UpFile)
+	c.Assert(err, qt.IsNil)
+	upSQL := string(upSQLBytes)
+	c.Assert(upSQL, qt.Contains, "DROP CONSTRAINT")
+	c.Assert(strings.Count(upSQL, "ADD CONSTRAINT ptah_constraint_price_check"), qt.Equals, 1)
+	c.Assert(strings.Count(upSQL, "ADD CONSTRAINT ptah_constraint_unique"), qt.Equals, 1)
+
+	execScript(c, conn, upSQL, "UP")
+
+	desired, err := goschema.ParseFS(os.DirFS(root), "entities")
+	c.Assert(err, qt.IsNil)
+	dbAfter, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	diff := schemadiff.CompareWithDialect(desired, dbAfter, "postgres")
+	c.Assert(diff.HasChanges(), qt.IsFalse,
+		qt.Commentf("post-migration diff must be clean; added=%v removed=%v modified=%v",
+			diff.ConstraintsAdded, diff.ConstraintsRemoved, diff.TablesModified))
+}
+
+func TestUniqueConstraintDriftGenerateRoundTrip_Integration(t *testing.T) {
+	cases := []struct {
+		dialect string
+		envKey  string
+	}{
+		{"postgres", "POSTGRES_URL"},
+		{"mysql", "MYSQL_URL"},
+		{"mariadb", "MARIADB_URL"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			dbURL := os.Getenv(tc.envKey)
+			if dbURL == "" {
+				t.Skipf("skipping %s unique constraint drift integration: %s not set", tc.dialect, tc.envKey)
+			}
+
+			c := qt.New(t)
+			ctx := context.Background()
+			conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+			if err != nil {
+				t.Skipf("skipping %s unique constraint drift integration: cannot connect: %v", tc.dialect, err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			dialect := conn.Info().Dialect
+			cleanupUniqueConstraintDriftTable(conn, dialect)
+			t.Cleanup(func() { cleanupUniqueConstraintDriftTable(conn, dialect) })
+
+			_, err = conn.ExecContext(ctx, `
+CREATE TABLE ptah_unique_constraint_drift (
+  id integer PRIMARY KEY,
+  sku varchar(255) NOT NULL,
+  region varchar(255) NOT NULL,
+  category varchar(255) NOT NULL,
+  CONSTRAINT ptah_unique_constraint_unique UNIQUE (sku, region)
+)`)
+			c.Assert(err, qt.IsNil)
+
+			root := c.TempDir()
+			entitiesDir := filepath.Join(root, "entities")
+			migrationsDir := filepath.Join(root, "migrations")
+			c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+			c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+			c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(`package entities
+
+//migrator:schema:table name="ptah_unique_constraint_drift"
+//migrator:schema:constraint name="ptah_unique_constraint_unique" type="UNIQUE" columns="sku,region,category"
+type Product struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int
+
+	//migrator:schema:field name="sku" type="VARCHAR(255)" not_null="true"
+	SKU string
+
+	//migrator:schema:field name="region" type="VARCHAR(255)" not_null="true"
+	Region string
+
+	//migrator:schema:field name="category" type="VARCHAR(255)" not_null="true"
+	Category string
+}
+`), 0600), qt.IsNil)
+
+			files, err := GenerateMigration(ctx, GenerateMigrationOptions{
+				GoEntitiesDir: entitiesDir,
+				DBConn:        conn,
+				MigrationName: "unique_constraint_drift",
+				OutputDir:     migrationsDir,
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.IsNotNil)
+
+			upSQLBytes, err := os.ReadFile(files.UpFile)
+			c.Assert(err, qt.IsNil)
+			upSQL := string(upSQLBytes)
+			c.Assert(strings.Count(upSQL, "ADD CONSTRAINT ptah_unique_constraint_unique"), qt.Equals, 1,
+				qt.Commentf("[%s] generated UP must re-add the changed UNIQUE constraint:\n%s", dialect, upSQL))
+
+			execScript(c, conn, upSQL, "UP")
+
+			desired, err := goschema.ParseFS(os.DirFS(root), "entities")
+			c.Assert(err, qt.IsNil)
+			dbAfter, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			diff := schemadiff.CompareWithDialect(desired, dbAfter, dialect)
+			c.Assert(diff.HasChanges(), qt.IsFalse,
+				qt.Commentf("[%s] post-migration diff must be clean; added=%v removed=%v modified=%v",
+					dialect, diff.ConstraintsAdded, diff.ConstraintsRemoved, diff.TablesModified))
+		})
+	}
+}
+
+func cleanupConstraintDriftTable(conn *dbschema.DatabaseConnection) {
+	_, _ = conn.Exec("DROP TABLE IF EXISTS ptah_constraint_drift CASCADE")
+}
+
+func cleanupUniqueConstraintDriftTable(conn *dbschema.DatabaseConnection, dialect string) {
+	_, _ = conn.Exec(dropTableSQL(dialect, "ptah_unique_constraint_drift"))
+}

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/convert/fromschema"
@@ -1160,38 +1161,156 @@ func excludeConstraintChanged(genConstraint goschema.Constraint, dbConstraint ty
 }
 
 // checkConstraintChanged compares CHECK constraint definitions.
-//
-// In practice, we cannot rely on a literal string compare here: PostgreSQL
-// stores the parsed/analyzed node tree (`pg_constraint.conbin`) and
-// `information_schema.check_constraints.check_clause` is `pg_get_expr`
-// decompiling it — which normalizes parens, injects `::type` casts, and
-// rewrites `IN (...)` to `= ANY (ARRAY[...])`. So `check_clause` never
-// round-trips byte-equal to what the user wrote in `check=`. Doing the
-// naive compare would mark every CHECK as drifted on the very next run,
-// producing a perpetual drop+add loop (see issue #112 discussion).
-//
-// For v1 the contract is "spelling-equivalence + a stable generated name
-// is enough as long as users don't author the same CHECK two different
-// ways" (verbatim from the issue body). Trusting the constraint name
-// gives us:
-//   - Adding `check=` → ConstraintsAdded (name not in DB).
-//   - Removing `check=` → ConstraintsRemoved (name not in generated).
-//   - Renaming via `check_name=` → drop + add (different name).
-//   - Idempotency after apply → no diff (same name).
-//
-// The known limitation is that changing only the expression while keeping
-// the constraint name will not trigger a migration. Users who need that
-// today should change `check_name=` alongside the expression; an
-// expression-normalization pass (and possibly AST-level compare) is a
-// follow-up tracked against future work.
-func checkConstraintChanged(_ goschema.Constraint, _ types.DBConstraint) bool {
-	return false
+func checkConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
+	dbClause := getStringValue(dbConstraint.CheckClause)
+	if strings.TrimSpace(genConstraint.CheckExpression) == "" || strings.TrimSpace(dbClause) == "" {
+		return false
+	}
+	if checkExpressionHasUnsupportedRewrite(genConstraint.CheckExpression, dbClause) {
+		return false
+	}
+	return normalizeCheckExpression(genConstraint.CheckExpression) != normalizeCheckExpression(dbClause)
 }
 
 // uniqueConstraintChanged compares UNIQUE constraint definitions
 func uniqueConstraintChanged(genConstraint goschema.Constraint, dbConstraint types.DBConstraint) bool {
-	return !slices.Equal(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault()) ||
+	return !stringSetsEqual(genConstraint.Columns, dbConstraint.ColumnNamesOrDefault()) ||
 		!boolPtrEqual(genConstraint.NullsDistinct, dbConstraint.NullsDistinct)
+}
+
+func normalizeCheckExpression(expr string) string {
+	expr = trimBalancedCheckParens(strings.TrimSpace(expr))
+
+	var b strings.Builder
+	inString := false
+	for i := 0; i < len(expr); i++ {
+		ch := expr[i]
+		if ch == '\'' {
+			b.WriteByte(ch)
+			if inString && i+1 < len(expr) && expr[i+1] == '\'' {
+				i++
+				b.WriteByte('\'')
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if !inString && ch == ':' && i+1 < len(expr) && expr[i+1] == ':' && checkCastFollowsLiteral(expr, i) {
+			i += 2
+			for i < len(expr) && isCheckCastChar(rune(expr[i])) {
+				i++
+			}
+			i--
+			continue
+		}
+		if !inString && unicode.IsSpace(rune(ch)) {
+			continue
+		}
+		if !inString && ch >= 'A' && ch <= 'Z' {
+			ch += 'a' - 'A'
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+func trimBalancedCheckParens(expr string) string {
+	for {
+		trimmed := strings.TrimSpace(expr)
+		if len(trimmed) < 2 || trimmed[0] != '(' || trimmed[len(trimmed)-1] != ')' {
+			return trimmed
+		}
+		if !checkOuterParensWrap(trimmed) {
+			return trimmed
+		}
+		expr = trimmed[1 : len(trimmed)-1]
+	}
+}
+
+func checkOuterParensWrap(expr string) bool {
+	depth := 0
+	inString := false
+	for i := 0; i < len(expr); i++ {
+		ch := expr[i]
+		if ch == '\'' {
+			if inString && i+1 < len(expr) && expr[i+1] == '\'' {
+				i++
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 || (depth == 0 && i != len(expr)-1) {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}
+
+func isCheckCastChar(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || ch == '[' || ch == ']' || ch == '.'
+}
+
+func checkCastFollowsLiteral(expr string, castIndex int) bool {
+	for i := castIndex - 1; i >= 0; i-- {
+		ch := expr[i]
+		if unicode.IsSpace(rune(ch)) {
+			continue
+		}
+		return ch == '\'' || (ch >= '0' && ch <= '9')
+	}
+	return false
+}
+
+func checkExpressionHasUnsupportedRewrite(generated, database string) bool {
+	db := strings.ToLower(database)
+	return checkExpressionContainsInOperator(generated) && strings.Contains(db, "any") && strings.Contains(db, "array[")
+}
+
+func checkExpressionContainsInOperator(expr string) bool {
+	inString := false
+	for i := 0; i < len(expr)-1; i++ {
+		ch := expr[i]
+		if ch == '\'' {
+			if inString && i+1 < len(expr) && expr[i+1] == '\'' {
+				i++
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if inString || (ch != 'i' && ch != 'I') || (expr[i+1] != 'n' && expr[i+1] != 'N') {
+			continue
+		}
+		prevIdent := i > 0 && isCheckIdentChar(rune(expr[i-1]))
+		nextIdent := i+2 < len(expr) && isCheckIdentChar(rune(expr[i+2]))
+		if !prevIdent && !nextIdent {
+			return true
+		}
+	}
+	return false
+}
+
+func isCheckIdentChar(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_'
+}
+
+func stringSetsEqual(left, right []string) bool {
+	left = uniqueStringsPreserveOrder(left)
+	right = uniqueStringsPreserveOrder(right)
+	sort.Strings(left)
+	sort.Strings(right)
+	return slices.Equal(left, right)
 }
 
 func boolPtrEqual(left, right *bool) bool {
@@ -1874,9 +1993,13 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 	// naturally empty there and the filter is a no-op. Keyed by table.index so a
 	// constraint name only suppresses the index on its own table.
 	fkBackedIndexes := make(map[string]struct{}, len(database.Constraints))
+	uniqueConstraintIndexes := make(map[string]struct{}, len(database.Constraints))
 	for _, c := range database.Constraints {
-		if c.Type == "FOREIGN KEY" {
+		switch c.Type {
+		case "FOREIGN KEY":
 			fkBackedIndexes[c.QualifiedTableName()+"."+c.Name] = struct{}{}
+		case "UNIQUE":
+			uniqueConstraintIndexes[c.QualifiedTableName()+"."+c.Name] = struct{}{}
 		}
 	}
 
@@ -1890,6 +2013,9 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 		// Skip constraint-based unique indexes (automatically created by UNIQUE constraints)
 		// but allow explicitly defined unique indexes (created via schema annotations)
 		if index.IsUnique && isConstraintBasedUniqueIndex(index.Name, index.TableName, index.Columns) {
+			continue
+		}
+		if _, ok := uniqueConstraintIndexes[index.QualifiedTableName()+"."+index.Name]; ok {
 			continue
 		}
 

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -862,6 +862,26 @@ func TestIndexes_UnhappyPath(t *testing.T) {
 			expected: &difftypes.SchemaDiff{},
 		},
 		{
+			name: "custom-named unique constraint backing indexes should be ignored",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{Name: "ptah_constraint_unique", TableName: "ptah_constraint_drift", Type: "UNIQUE", ColumnNames: []string{"sku", "region"}},
+				},
+				Indexes: []types.DBIndex{
+					{
+						Name:      "ptah_constraint_unique",
+						TableName: "ptah_constraint_drift",
+						Columns:   []string{"sku", "region"},
+						IsUnique:  true,
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
 			name: "mixed constraint-based and explicitly defined unique indexes",
 			generated: &goschema.Database{
 				Indexes: []goschema.Index{

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -109,6 +109,90 @@ func TestConstraints(t *testing.T) {
 			},
 		},
 		{
+			name: "CHECK constraint modified",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName:      "Product",
+						Name:            "positive_price",
+						Type:            "CHECK",
+						Table:           "products",
+						CheckExpression: "price >= 0",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "positive_price",
+						TableName:   "products",
+						Type:        "CHECK",
+						CheckClause: new("price > 0"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"positive_price"},
+				ConstraintsRemoved: []string{"positive_price"},
+			},
+		},
+		{
+			name: "CHECK constraint semantic parentheses are preserved",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName:      "Invoice",
+						Name:            "positive_balance",
+						Type:            "CHECK",
+						Table:           "invoices",
+						CheckExpression: "amount - (discount - fee) > 0",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "positive_balance",
+						TableName:   "invoices",
+						Type:        "CHECK",
+						CheckClause: new("amount - discount - fee > 0"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"positive_balance"},
+				ConstraintsRemoved: []string{"positive_balance"},
+			},
+		},
+		{
+			name: "CHECK constraint explicit column cast is preserved",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName:      "Invoice",
+						Name:            "positive_amount",
+						Type:            "CHECK",
+						Table:           "invoices",
+						CheckExpression: "amount::numeric > 0",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "positive_amount",
+						TableName:   "invoices",
+						Type:        "CHECK",
+						CheckClause: new("amount > 0"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"positive_amount"},
+				ConstraintsRemoved: []string{"positive_amount"},
+			},
+		},
+		{
 			name: "UNIQUE constraint added",
 			generated: &goschema.Database{
 				Constraints: []goschema.Constraint{
@@ -127,6 +211,59 @@ func TestConstraints(t *testing.T) {
 			expected: &difftypes.SchemaDiff{
 				ConstraintsAdded: []string{"unique_user_email"},
 			},
+		},
+		{
+			name: "UNIQUE constraint column set changed",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName: "User",
+						Name:       "unique_user_email",
+						Type:       "UNIQUE",
+						Table:      "users",
+						Columns:    []string{"user_id", "email", "tenant_id"},
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "unique_user_email",
+						TableName:   "users",
+						Type:        "UNIQUE",
+						ColumnNames: []string{"user_id", "email"},
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"unique_user_email"},
+				ConstraintsRemoved: []string{"unique_user_email"},
+			},
+		},
+		{
+			name: "UNIQUE constraint column order changed",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName: "User",
+						Name:       "unique_user_email",
+						Type:       "UNIQUE",
+						Table:      "users",
+						Columns:    []string{"user_id", "email"},
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "unique_user_email",
+						TableName:   "users",
+						Type:        "UNIQUE",
+						ColumnNames: []string{"email", "user_id"},
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
 		},
 		{
 			name: "UNIQUE constraint nulls distinct changed",
@@ -659,12 +796,11 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 		{
 			// Realistic introspection shape: PostgreSQL stores the clause
 			// as the parser/rewriter produced it, NOT as the user wrote
-			// it. The user authored `category IN ('a','b')`; what comes
+			// it. The user authored `category IN('a','b')`; what comes
 			// back is roughly `((category)::text = ANY ((ARRAY['a'::text,
-			// 'b'::text])::text[]))`. The diff must STILL be empty —
-			// that's the whole point of the trust-name v1 contract. If a
-			// future regression reintroduces an expression compare here,
-			// this case will start failing.
+			// 'b'::text])::text[]))`. The comparator deliberately treats
+			// that `IN (...)` to `ANY (ARRAY[...])` form as an unsupported
+			// rewrite rather than emitting a perpetual drop+add loop.
 			name: "field-level CHECK matches existing — no diff (idempotency, Postgres-normalized clause)",
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
@@ -673,7 +809,7 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 						StructName: "File",
 						Name:       "category",
 						Type:       "TEXT",
-						Check:      "category IN ('a','b')",
+						Check:      "category IN('a','b')",
 					},
 				},
 			},
@@ -691,15 +827,7 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 			expected: &difftypes.SchemaDiff{},
 		},
 		{
-			// v1 trade-off documented on checkConstraintChanged: an
-			// expression-only change with the same constraint name does
-			// NOT trigger a migration, because PostgreSQL normalizes the
-			// stored clause (parens / casts / `IN (...)` → `= ANY
-			// (ARRAY[...])`) and a literal string compare would otherwise
-			// produce a permanent drift loop on every run. Users who need
-			// to force a regen should change `check_name=` alongside the
-			// expression — covered by the next case below.
-			name: "field-level CHECK expression-only change is intentionally not surfaced (v1)",
+			name: "field-level CHECK expression-only change surfaces as drop + add",
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{StructName: "File", Name: "files"}},
 				Fields: []goschema.Field{
@@ -722,7 +850,10 @@ func TestConstraints_FieldLevelCheck(t *testing.T) {
 					},
 				},
 			},
-			expected: &difftypes.SchemaDiff{},
+			expected: &difftypes.SchemaDiff{
+				ConstraintsAdded:   []string{"files_category_check"},
+				ConstraintsRemoved: []string{"files_category_check"},
+			},
 		},
 		{
 			// Renaming the constraint via `check_name=` while keeping the


### PR DESCRIPTION
## Summary

Closes #126.

- detect CHECK expression drift instead of treating same-name CHECK constraints as always equal
- detect UNIQUE column-set drift while intentionally ignoring column order for uniqueness semantics
- avoid illegal/generated churn from PostgreSQL UNIQUE backing indexes after a constraint rewrite
- stop marking PostgreSQL multi-column UNIQUE constraints as per-column `IsUnique`
- add unit and live integration coverage for CHECK/UNIQUE drift and post-apply clean diff

## Self-Review

Logic:
- CHECK comparison normalizes only conservative spelling differences: outer wrapper parentheses, whitespace, ASCII keyword case, and literal casts such as `'x'::text`.
- Semantic parentheses and explicit column casts are preserved, so `amount - (discount - fee)` and `amount - discount - fee` still drift.
- PostgreSQL `IN (...)` to `ANY (ARRAY[...])` decompilation is treated as an unsupported rewrite to avoid perpetual drop/add loops until Ptah has a structural expression comparator.
- UNIQUE comparison uses a set because column order does not change the unique key's logical column set for this drift contract.

Safety:
- Generated migrations still go through existing planner/renderers; this PR only changes whether drift is surfaced.
- PostgreSQL custom-named UNIQUE backing indexes are ignored when the same-name UNIQUE constraint is present, avoiding invalid `DROP INDEX` before `DROP CONSTRAINT`.
- No new SQL interpolation paths from user input were added.

Component impact:
- Schemadiff now emits drop+add for same-name CHECK/UNIQUE modifications.
- PostgreSQL introspection no longer reports a multi-column table-level UNIQUE as individual column uniqueness, preventing false post-apply drift.
- Existing field-level CHECK idempotency for PostgreSQL-normalized `IN` clauses remains covered.

Coverage:
- Unit tests cover CHECK expression drift, semantic parentheses, explicit column casts, UNIQUE column-set drift, UNIQUE order stability, field-level CHECK drift, and custom UNIQUE backing indexes.
- Live integration covers CHECK+UNIQUE generate/apply/re-introspect on PostgreSQL.
- Live integration covers UNIQUE generate/apply/re-introspect on PostgreSQL, MySQL, and MariaDB.

Known limitation:
- CHECK expression equivalence is still not AST-level. This PR deliberately fixes the silent-drift gap while avoiding broad SQL expression parsing in schemadiff.

## Validation

- `go_vulncheck ./...` via gopls: no vulnerabilities reported
- `go_diagnostics` on tracked touched Go files: no diagnostics
- `go test ./dbschema/postgres ./migration/schemadiff/internal/compare -run 'TestPostgreSQLReader_enhanceTablesWithConstraints|TestIndexes_UnhappyPath|TestConstraints|TestConstraints_FieldLevelCheck' -count=1`
- `env 'POSTGRES_URL=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' 'MYSQL_URL=mysql://ptah_user:ptah_password@tcp(localhost:3310)/ptah_test' 'MARIADB_URL=mariadb://ptah_user:ptah_password@tcp(localhost:3307)/ptah_test' go test -tags=integration ./migration/generator -run 'TestConstraintDriftGenerateRoundTrip_Integration|TestUniqueConstraintDriftGenerateRoundTrip_Integration' -count=1 -v`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `env 'POSTGRES_URL=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' 'MYSQL_URL=mysql://ptah_user:ptah_password@tcp(localhost:3310)/ptah_test' 'MARIADB_URL=mariadb://ptah_user:ptah_password@tcp(localhost:3307)/ptah_test' go test -tags=integration ./migration/generator -count=1`
