### PR TITLE
Harden migration path handling

### DIFF
--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
 )
 
@@ -96,6 +97,10 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	}
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
+	}
+	migrationsDir, err = pathguard.ResolveCLIPath(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("invalid migrations directory: %w", err)
 	}
 
 	connectTimeout, err := dbcli.ParseConnectTimeout(connectTimeoutValue)

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -148,6 +149,10 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
+	}
+	migrationsDir, err := pathguard.ResolveCLIPath(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("invalid migrations directory: %w", err)
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)

--- a/internal/pathguard/pathguard.go
+++ b/internal/pathguard/pathguard.go
@@ -1,0 +1,90 @@
+package pathguard
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveWithinRoot returns an absolute, cleaned path and, when allowedRoot is
+// set, verifies that the path stays inside that root after resolving existing
+// symlinks. Missing final path components are allowed so callers can validate
+// directories before creating them.
+func ResolveWithinRoot(path, allowedRoot string) (string, error) {
+	resolved, err := resolvePath(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(allowedRoot) == "" {
+		return resolved, nil
+	}
+
+	root, err := resolvePath(allowedRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve allowed root: %w", err)
+	}
+	if !isSubpath(root, resolved) {
+		return "", fmt.Errorf("%q is outside allowed root %q", resolved, root)
+	}
+	return resolved, nil
+}
+
+// ResolveCLIPath applies a conservative boundary to relative CLI paths while
+// preserving historical support for explicit absolute paths.
+func ResolveCLIPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return ResolveWithinRoot(path, "")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	return ResolveWithinRoot(path, cwd)
+}
+
+func resolvePath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute path: %w", err)
+	}
+	return resolveExistingPrefix(filepath.Clean(abs))
+}
+
+func resolveExistingPrefix(path string) (string, error) {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved), nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	var suffix []string
+	for current := path; ; current = filepath.Dir(current) {
+		parent := filepath.Dir(current)
+		if parent == current {
+			return filepath.Clean(filepath.Join(append([]string{current}, suffix...)...)), nil
+		}
+
+		suffix = append([]string{filepath.Base(current)}, suffix...)
+		resolved, err := filepath.EvalSymlinks(parent)
+		if err == nil {
+			parts := append([]string{filepath.Clean(resolved)}, suffix...)
+			return filepath.Clean(filepath.Join(parts...)), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+	}
+}
+
+func isSubpath(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel))
+}

--- a/internal/pathguard/pathguard_test.go
+++ b/internal/pathguard/pathguard_test.go
@@ -1,0 +1,55 @@
+package pathguard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestResolveWithinRootAllowsMissingChild(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "migrations")
+
+	resolved, err := ResolveWithinRoot(path, root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(filepath.Base(resolved), qt.Equals, "migrations")
+}
+
+func TestResolveWithinRootRejectsTraversal(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "..", "outside")
+
+	_, err := ResolveWithinRoot(path, root)
+	c.Assert(err, qt.ErrorMatches, `.*outside allowed root.*`)
+}
+
+func TestResolveWithinRootRejectsSymlinkEscape(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink setup is not available: %v", err)
+	}
+
+	_, err := ResolveWithinRoot(filepath.Join(link, "migrations"), root)
+	c.Assert(err, qt.ErrorMatches, `.*outside allowed root.*`)
+}
+
+func TestResolveCLIPathRejectsRelativeTraversal(t *testing.T) {
+	c := qt.New(t)
+	originalWD, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	root := t.TempDir()
+	c.Assert(os.Chdir(root), qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(os.Chdir(originalWD), qt.IsNil)
+	})
+
+	_, err = ResolveCLIPath("../outside")
+	c.Assert(err, qt.ErrorMatches, `.*outside allowed root.*`)
+}

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -202,6 +202,9 @@ type GenerateMigrationOptions struct {
     // OutputDir is the directory where migration files will be saved (always real filesystem)
     OutputDir string
 
+    // AllowedOutputRoot constrains OutputDir when accepting user-supplied paths
+    AllowedOutputRoot string
+
     // CompareOptions are the options to use when comparing schemas
     CompareOptions *config.CompareOptions
 

--- a/migration/generator/file_creation_test.go
+++ b/migration/generator/file_creation_test.go
@@ -1,0 +1,60 @@
+package generator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	version := int64(42)
+	name := "constraint_drift"
+
+	oldUp := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "up"))
+	oldDown := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "down"))
+	c.Assert(os.WriteFile(oldUp, nil, 0600), qt.IsNil)
+	c.Assert(os.WriteFile(oldDown, []byte("SELECT old_down;\n"), 0600), qt.IsNil)
+
+	files, err := createMigrationFiles(dir, version, name, "SELECT up;\n", "SELECT down;\n")
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Version, qt.Equals, version+1)
+
+	oldDownBytes, err := os.ReadFile(oldDown)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(oldDownBytes), qt.Equals, "SELECT old_down;\n")
+
+	upBytes, err := os.ReadFile(files.UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upBytes), qt.Equals, "SELECT up;\n")
+	downBytes, err := os.ReadFile(files.DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downBytes), qt.Equals, "SELECT down;\n")
+}
+
+func TestCreateMigrationFilesRequiresExistingParent(t *testing.T) {
+	c := qt.New(t)
+	dir := filepath.Join(t.TempDir(), "missing", "migrations")
+
+	_, err := createMigrationFiles(dir, 1, "init", "SELECT 1;\n", "SELECT 2;\n")
+	c.Assert(err, qt.ErrorMatches, `failed to create output directory: parent directory .* is not available: .*`)
+}
+
+func TestGenerateMigrationRejectsOutputOutsideAllowedRoot(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := filepath.Join(root, "..", "outside")
+
+	_, err := GenerateMigration(context.Background(), GenerateMigrationOptions{
+		GoEntitiesDir:     root,
+		OutputDir:         outside,
+		AllowedOutputRoot: root,
+	})
+	c.Assert(err, qt.ErrorMatches, `error validating output directory: .*outside allowed root.*`)
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/safety"
@@ -41,6 +43,9 @@ type GenerateMigrationOptions struct {
 	MigrationName string
 	// OutputDir is the directory where migration files will be saved (always real filesystem)
 	OutputDir string
+	// AllowedOutputRoot constrains OutputDir when set. Embedders that accept
+	// user-supplied output paths should set this to the project/workspace root.
+	AllowedOutputRoot string
 	// CompareOptions are the options to use when comparing schemas
 	CompareOptions *config.CompareOptions
 	// Schemas restricts database introspection to the listed schemas when the
@@ -78,9 +83,9 @@ type MigrationFiles struct {
 // yet propagate the context; future work may thread it through there too.
 // When opts.DBConn is supplied the context is currently unused.
 func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error) {
-	// Set default migration name if not provided
-	if opts.MigrationName == "" {
-		opts.MigrationName = "migration"
+	opts, err := normalizeGenerateMigrationOptions(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	var entitiesDir string
@@ -207,6 +212,18 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	}
 
 	return files, nil
+}
+
+func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {
+	if opts.MigrationName == "" {
+		opts.MigrationName = "migration"
+	}
+	outputDir, err := pathguard.ResolveWithinRoot(opts.OutputDir, opts.AllowedOutputRoot)
+	if err != nil {
+		return opts, fmt.Errorf("error validating output directory: %w", err)
+	}
+	opts.OutputDir = outputDir
+	return opts, nil
 }
 
 // withDialect returns a copy of opts with the Dialect set, allocating a default
@@ -974,7 +991,7 @@ func nextAvailableMigrationVersion(outputDir string, version int64, migrationNam
 	for {
 		upFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "up"))
 		downFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "down"))
-		if !nonEmptyFileExists(upFilePath) && !nonEmptyFileExists(downFilePath) {
+		if !fileExists(upFilePath) && !fileExists(downFilePath) {
 			return version
 		}
 		version++
@@ -1002,9 +1019,9 @@ func latestExistingMigrationVersion(outputDir string) int64 {
 	return latest
 }
 
-func nonEmptyFileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.Size() > 0
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func withNoTransactionDirective(sql string) string {
@@ -1019,31 +1036,81 @@ func withNoTransactionDirective(sql string) string {
 
 // createMigrationFiles creates the up and down migration files
 func createMigrationFiles(outputDir string, version int64, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
-	// Ensure output directory exists
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
+	if err := ensureMigrationOutputDir(outputDir); err != nil {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	// Generate file names using the existing utility
-	upFileName := migrator.GenerateMigrationFileName(version, migrationName, "up")
-	downFileName := migrator.GenerateMigrationFileName(version, migrationName, "down")
+	for {
+		upFileName := migrator.GenerateMigrationFileName(version, migrationName, "up")
+		downFileName := migrator.GenerateMigrationFileName(version, migrationName, "down")
 
-	upFilePath := filepath.Join(outputDir, upFileName)
-	downFilePath := filepath.Join(outputDir, downFileName)
+		upFilePath := filepath.Join(outputDir, upFileName)
+		downFilePath := filepath.Join(outputDir, downFileName)
 
-	// Write up migration file
-	if err := os.WriteFile(upFilePath, []byte(upSQL), 0644); err != nil { //nolint:gosec // 0644 is fine
-		return nil, fmt.Errorf("failed to write up migration file: %w", err)
+		if err := writeNewMigrationFile(upFilePath, upSQL); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				version++
+				continue
+			}
+			return nil, fmt.Errorf("failed to write up migration file: %w", err)
+		}
+
+		if err := writeNewMigrationFile(downFilePath, downSQL); err != nil {
+			_ = os.Remove(upFilePath)
+			if errors.Is(err, os.ErrExist) {
+				version++
+				continue
+			}
+			return nil, fmt.Errorf("failed to write down migration file: %w", err)
+		}
+
+		return &MigrationFiles{
+			UpFile:   upFilePath,
+			DownFile: downFilePath,
+			Version:  version,
+		}, nil
+	}
+}
+
+func ensureMigrationOutputDir(outputDir string) error {
+	info, err := os.Stat(outputDir)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("%q exists and is not a directory", outputDir)
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
 	}
 
-	// Write down migration file
-	if err := os.WriteFile(downFilePath, []byte(downSQL), 0644); err != nil { //nolint:gosec // 0644 is fine
-		return nil, fmt.Errorf("failed to write down migration file: %w", err)
+	parent := filepath.Dir(outputDir)
+	if parentInfo, statErr := os.Stat(parent); statErr != nil {
+		return fmt.Errorf("parent directory %q is not available: %w", parent, statErr)
+	} else if !parentInfo.IsDir() {
+		return fmt.Errorf("parent path %q is not a directory", parent)
 	}
+	return os.Mkdir(outputDir, 0755)
+}
 
-	return &MigrationFiles{
-		UpFile:   upFilePath,
-		DownFile: downFilePath,
-		Version:  version,
-	}, nil
+func writeNewMigrationFile(path, content string) error {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	removeOnError := true
+	defer func() {
+		if removeOnError {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	removeOnError = false
+	return nil
 }


### PR DESCRIPTION
## Summary

Closes #141.

- add `internal/pathguard` for absolute path normalization, existing-symlink resolution, and optional allowed-root boundary checks
- validate `migrate generate --migrations-dir` and `migrate-up --migrations-dir` before using the path for checksum verification or `os.DirFS`
- add `GenerateMigrationOptions.AllowedOutputRoot` so embedders can constrain user-supplied output directories
- replace migration file `os.WriteFile` writes with `os.OpenFile(... O_CREATE|O_EXCL|O_WRONLY ...)`
- treat any existing up or down file as a version collision, regardless of size
- replace deep `MkdirAll` output creation with one-level `Mkdir` requiring an existing parent directory
- document `AllowedOutputRoot` in the generator README

## Self-Review

Security:
- Relative CLI migration paths are resolved under the current working directory, so `../outside` traversal is rejected before database connection or filesystem loading.
- Existing symlink components are resolved before the allowed-root check, so a path under the root that points outside is rejected.
- Explicit absolute CLI paths remain supported for compatibility. Library embedders that accept untrusted absolute paths now have `AllowedOutputRoot` for strict containment.

Correctness:
- The interrupted-run case from the issue is covered: an empty up file plus populated down file at version N causes generation at N+1 and does not overwrite the old down file.
- Atomic `O_EXCL` writes prevent concurrent writers from truncating each other. If down-file creation collides after up-file creation, the newly-created up file is removed and the writer retries with the next version.
- Output directory creation no longer silently creates arbitrary deep trees; the immediate parent must already exist.

Compatibility:
- Existing library callers remain source-compatible because `AllowedOutputRoot` is optional.
- Absolute CLI paths remain accepted to avoid breaking established automation that stores migrations outside the process cwd.

Gaps:
- This is filesystem boundary validation, not a full OS sandbox. Callers still need normal file permissions and should set `AllowedOutputRoot` when paths are user-controlled.

## Validation

- `go_diagnostics` on touched Go files: no diagnostics
- `go test ./internal/pathguard ./migration/generator ./cmd/migrate ./cmd/migrateup -count=1`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `env 'POSTGRES_URL=postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' 'MYSQL_URL=mysql://ptah_user:ptah_password@tcp(localhost:3310)/ptah_test' 'MARIADB_URL=mariadb://ptah_user:ptah_password@tcp(localhost:3307)/ptah_test' go test -tags=integration ./migration/generator -count=1`
- `rg -n "os\\.(WriteFile|MkdirAll)\\(" migration/generator/generator.go cmd/migrate/generate.go cmd/migrateup/migrateup.go` returned no matches
