### PR TITLE
Add GoReleaser release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - ".goreleaser.yaml"
+      - "Dockerfile"
+      - "cmd/**"
+      - "go.mod"
+      - "go.sum"
+      - "docs/release_process.md"
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  pull-requests: read
+
+jobs:
+  goreleaser-check:
+    name: goreleaser-check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.15.4
+          args: check
+
+      - uses: anchore/sbom-action/download-syft@v0.17.9
+
+      - name: Build snapshot artifacts
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.15.4
+          args: release --snapshot --clean --skip=sign,docker
+
+  release:
+    name: release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: sigstore/cosign-installer@v3.7.0
+
+      - uses: anchore/sbom-action/download-syft@v0.17.9
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.15.4
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,145 @@
+version: 2
+
+project_name: ptah
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: ptah
+    main: ./cmd/ptah
+    binary: ptah
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - >-
+        -s -w
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Version={{ .Version }}
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Commit={{ .Commit }}
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Date={{ .CommitDate }}
+
+archives:
+  - id: ptah
+    ids:
+      - ptah
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+
+source:
+  enabled: true
+
+sboms:
+  - id: archive
+    artifacts: archive
+  - id: source
+    artifacts: source
+
+signs:
+  - id: checksums
+    cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+    output: true
+  - id: sboms
+    cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--yes"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: sbom
+    output: true
+
+dockers:
+  - id: ptah-linux-amd64
+    ids:
+      - ptah
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile
+    use: buildx
+    image_templates:
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - id: ptah-linux-arm64
+    ids:
+      - ptah
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    image_templates:
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "ghcr.io/stokaro/ptah:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-amd64"
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/stokaro/ptah:latest"
+    image_templates:
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-amd64"
+      - "ghcr.io/stokaro/ptah:{{ .Version }}-arm64"
+
+# Issue #174 requires `brew install stokaro/ptah/ptah`, which is still a
+# Homebrew formula flow. GoReleaser's newer homebrew_casks replacement does not
+# satisfy that command contract, so the release workflow pins GoReleaser 2.15.4
+# while formula publishing remains required.
+brews:
+  - name: ptah
+    ids:
+      - ptah
+    repository:
+      owner: stokaro
+      name: homebrew-ptah
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/stokaro/ptah"
+    description: "Schema management and migration tooling for Go projects"
+    license: MIT
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} {{ .Tag }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates
+
+COPY ptah /usr/local/bin/ptah
+
+ENTRYPOINT ["/usr/local/bin/ptah"]

--- a/README.md
+++ b/README.md
@@ -397,6 +397,28 @@ type User struct {
 
 ### Installation
 
+Install the latest released CLI with Go:
+
+```bash
+go install github.com/stokaro/ptah/cmd/ptah@latest
+ptah version
+```
+
+On macOS or Linux with Homebrew:
+
+```bash
+brew install stokaro/ptah/ptah
+ptah version
+```
+
+Use the published container image:
+
+```bash
+docker run --rm ghcr.io/stokaro/ptah:latest version
+```
+
+Build from source:
+
 ```bash
 # Clone the repository
 git clone https://github.com/stokaro/ptah.git

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,0 +1,75 @@
+# Release Process
+
+Ptah releases are produced by GoReleaser from annotated version tags.
+
+## Prerequisites
+
+- `HOMEBREW_TAP_TOKEN` repository secret with permission to push to
+  `stokaro/homebrew-ptah`.
+- GitHub Actions package permissions enabled for publishing
+  `ghcr.io/stokaro/ptah`.
+- GoReleaser `v2.15.4`. The GitHub Actions workflow pins this version because
+  issue #174 requires a Homebrew formula install command
+  (`brew install stokaro/ptah/ptah`), while newer GoReleaser releases treat
+  formula publishing as deprecated in favor of casks.
+- The release workflow must pass on the release commit before tagging.
+
+## Cut A Release
+
+1. Start from a clean `master` checkout.
+2. Verify the release candidate:
+
+   ```bash
+   go test ./...
+   golangci-lint run ./...
+   goreleaser check
+   goreleaser release --snapshot --clean --skip=sign,docker
+   ```
+
+3. Create and push an annotated semver tag:
+
+   ```bash
+   git tag -a v0.1.0 -m "Release v0.1.0"
+   git push origin v0.1.0
+   ```
+
+4. Wait for the `Release` workflow to finish.
+5. Verify the GitHub Release contains archives for Linux, macOS, and Windows,
+   `checksums.txt`, SBOM artifacts, and cosign signature/certificate files.
+6. Verify the container images exist:
+
+   ```bash
+   docker pull ghcr.io/stokaro/ptah:v0.1.0
+   docker pull ghcr.io/stokaro/ptah:latest
+   ```
+
+7. Verify Homebrew install:
+
+   ```bash
+   brew update
+   brew install stokaro/ptah/ptah
+   ptah version
+   ```
+
+## Local Snapshot
+
+Use a snapshot release to validate packaging without publishing:
+
+```bash
+goreleaser release --snapshot --clean --skip=sign,docker
+./dist/ptah_darwin_arm64*/ptah version
+```
+
+Snapshot releases should print snapshot version metadata, the current commit,
+the build date, Go version, and platform.
+
+If `syft` is not installed locally, skip SBOM generation for the local packaging
+smoke test only:
+
+```bash
+goreleaser release --snapshot --clean --skip=sign,docker,sbom
+```
+
+The GitHub Actions release workflow installs `syft` and `cosign`; do not skip
+SBOM generation, checksum signing, Docker publishing, or Homebrew publishing for
+real tag releases.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/viper v1.21.0
+	github.com/spf13/pflag v1.0.10
 	github.com/zclconf/go-cty v1.19.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/text v0.40.0
@@ -49,7 +49,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/viper v1.21.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect


### PR DESCRIPTION
## Summary

- add a GoReleaser v2 config for cross-platform `ptah` archives on Linux, macOS, and Windows for amd64/arm64
- add tag-triggered release workflow that publishes GitHub Release artifacts, syft SBOMs, cosign signatures/certificates, GHCR images, and the `stokaro/homebrew-ptah` formula
- document release cutting and installation through `go install`, Homebrew, Docker, and source builds
- keep `go.mod` tidy after the CLI rename by making `pflag` a direct dependency and `viper` indirect

## Notes

The workflow intentionally runs a PR packaging smoke test with `goreleaser release --snapshot --clean --skip=sign,docker`; full signing, Docker publishing, and Homebrew publishing are reserved for tag pushes because they require GitHub OIDC, GHCR, and `HOMEBREW_TAP_TOKEN`.

GoReleaser 2.15.4 validates the config, but warns that `dockers`/`docker_manifests` and `brews` are deprecated in favor of newer surfaces. I kept them here because they are the current validated way to produce the required multi-arch GHCR manifest tags and Homebrew formula tap for this issue.

Closes #174.

## Validation

- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=sign,docker,sbom`
- `./dist/ptah_darwin_arm64*/ptah version`
- `go build -o /tmp/ptah-174 ./cmd/ptah`
- `/tmp/ptah-174 version`
- `go test ./...`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`