### PR TITLE
Close ParseFS files during walk

### DIFF
--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -112,15 +112,10 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 			return nil
 		}
 
-		file, err := fsys.Open(path)
+		database, err := parseDatabaseFile(fsys, path)
 		if err != nil {
 			return err
 		}
-		defer file.Close()
-		reader := bufio.NewReader(file)
-
-		// Parse the file
-		database := ParseSource(path, reader)
 
 		// Add to result
 		result.Schemas = append(result.Schemas, database.Schemas...)
@@ -169,4 +164,14 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 	sortFunctionsByDependencies(result)
 
 	return result, nil
+}
+
+func parseDatabaseFile(fsys fs.FS, path string) (Database, error) {
+	file, err := fsys.Open(path)
+	if err != nil {
+		return Database{}, err
+	}
+	defer file.Close()
+
+	return ParseSource(path, bufio.NewReader(file)), nil
 }

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -363,6 +363,71 @@ func createTestFS(files map[string]string) fs.FS {
 	return fsys
 }
 
+type countingFS struct {
+	fsys           fs.FS
+	openGoFiles    int
+	maxOpenGoFiles int
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	file, err := c.fsys.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(name, ".go") {
+		return file, nil
+	}
+
+	c.openGoFiles++
+	c.maxOpenGoFiles = max(c.maxOpenGoFiles, c.openGoFiles)
+
+	return &countingFile{
+		File: file,
+		onClose: func() {
+			c.openGoFiles--
+		},
+	}, nil
+}
+
+type countingFile struct {
+	fs.File
+	onClose func()
+	closed  bool
+}
+
+func (f *countingFile) Close() error {
+	err := f.File.Close()
+	if !f.closed {
+		f.closed = true
+		f.onClose()
+	}
+	return err
+}
+
+func TestParseFS_ClosesFilesDuringWalk(t *testing.T) {
+	c := qt.New(t)
+
+	files := make(map[string]string)
+	for i := range 100 {
+		files[fmt.Sprintf("model_%03d.go", i)] = fmt.Sprintf(`package models
+
+//migrator:schema:table name="table_%03d"
+type Model%03d struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`, i, i)
+	}
+
+	fsys := &countingFS{fsys: createTestFS(files)}
+
+	result, err := goschema.ParseFS(fsys, ".")
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Tables, qt.HasLen, 100)
+	c.Assert(fsys.openGoFiles, qt.Equals, 0)
+	c.Assert(fsys.maxOpenGoFiles, qt.Equals, 1)
+}
+
 func TestParseFS_HappyPath(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary

- move per-file parsing into a helper so `defer file.Close()` runs once per walked file instead of at the end of `ParseFS`
- add an in-memory regression test that proves `ParseFS` keeps at most one Go file open during a multi-file walk

Closes #146.

## Validation

- `go test ./core/goschema -run 'TestParseFS_ClosesFilesDuringWalk|TestParseFS' -count=1`
- `go test ./core/goschema -count=1`
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`