### PR TITLE
Align MariaDB planner documentation

### DIFF
--- a/migration/planner/doc.go
+++ b/migration/planner/doc.go
@@ -58,15 +58,16 @@
 //
 // The package includes dialect-specific planners in the dialects subdirectory:
 //
-//   - dialects/postgres: PostgreSQL-specific migration planning
-//   - dialects/mysql: MySQL-specific migration planning
-//   - dialects/mariadb: MariaDB-specific migration planning (planned)
+//   - dialects/postgres: PostgreSQL and PostgreSQL-family migration planning
+//   - dialects/mysql: MySQL and MariaDB migration planning
+//   - dialects/clickhouse: ClickHouse migration planning
 //
 // Each dialect planner handles platform-specific features and limitations:
 //
 //   - PostgreSQL: ENUM types, SERIAL columns, advanced constraints
 //   - MySQL: AUTO_INCREMENT, ENGINE specifications, charset handling
-//   - MariaDB: MariaDB-specific extensions and optimizations
+//   - MariaDB: MySQL-family planning with the MariaDB capability preset
+//   - ClickHouse: MergeTree-oriented table and index planning
 //
 // # Migration Order
 //
@@ -144,7 +145,8 @@
 //  1. Implementing the Planner interface
 //  2. Creating a new dialect package under dialects/
 //  3. Adding the dialect to the GetPlanner() factory function
-//  4. Implementing dialect-specific SQL generation logic
+//  4. Adding a capability preset when a dialect reuses an existing planner
+//  5. Implementing dialect-specific SQL generation logic
 //
 // # Thread Safety
 //

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/core/platform"
 	dbtypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
 	"github.com/stokaro/ptah/migration/safety"
 	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -32,7 +33,7 @@ func TestGetPlanner(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "mariadb planner not implemented",
+			name:    "mariadb planner",
 			dialect: platform.MariaDB,
 			wantErr: false,
 		},
@@ -75,6 +76,15 @@ func TestGetPlanner(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetPlanner_MariaDBUsesMySQLPlanner(t *testing.T) {
+	c := qt.New(t)
+
+	plannerInstance := planner.GetPlanner(platform.MariaDB)
+	_, ok := plannerInstance.(*mysql.Planner)
+
+	c.Assert(ok, qt.IsTrue)
 }
 
 func TestRequiresNoTransaction(t *testing.T) {


### PR DESCRIPTION
## Summary

- update planner package docs so MariaDB is documented as MySQL-family planning with the MariaDB capability preset, not a planned standalone `dialects/mariadb` package
- rename the stale MariaDB test case
- add a factory regression test proving `GetPlanner(mariadb)` uses the MySQL planner implementation

Closes #144.

## Validation

- `go test ./migration/planner -run 'TestGetPlanner|TestGetPlanner_MariaDBUsesMySQLPlanner|TestGetPlanner_CapabilityWiring' -count=1`
- `go test ./migration/planner ./migration/planner/dialects/mysql -count=1`
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`