### PR TITLE
Add empty migration creation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,9 @@ for the supported Atlas HCL subset and current limitations.
 # Generate migration SQL
 ./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost/db
 
+# Create paired empty migration files for manual SQL
+./ptah migrate new add_user_preferences --migrations-dir ./migrations
+
 # Generate migration SQL while introspecting specific PostgreSQL schemas
 ./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost/db --schemas auth,billing,public
 
@@ -653,6 +656,18 @@ Generate SQL migration statements to synchronize schemas:
 ```
 
 **Output:** SQL statements to bring the database in sync with Go entities
+
+#### Create Empty Migration Files
+Create paired `.up.sql` and `.down.sql` files for manual SQL authoring:
+
+```bash
+./ptah migrate new add_user_preferences --migrations-dir ./migrations
+./ptah migrate new --name hotfix_existing_data --migrations-dir ./migrations
+./ptah atlas migrate new add_user_preferences --migrations-dir ./migrations
+```
+
+The command creates timestamped files using Ptah's paired migration naming
+convention and writes comment headers for the UP and DOWN directions.
 
 #### Apply Seed Data
 Apply environment-scoped SQL seeds from a `seeds/` directory:

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -84,7 +84,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{use: "hash", short: "Write or update the migration directory checksum", native: "migrate-hash", factory: migratehash.NewMigrateHashCommand},
 		{use: "import", short: "Import migrations from another tool", native: ""},
 		{use: "lint", short: "Lint migration files", native: "lint", factory: lint.NewLintCommand},
-		{use: "new", short: "Create a new migration file", native: "migrate generate", factory: migrate.NewMigrateCommand, prefixArgs: []string{"generate"}},
+		{use: "new", short: "Create a new migration file", native: "migrate new", factory: migrate.NewMigrateCommand, prefixArgs: []string{"new"}},
 		{use: "set", short: "Set migration revision state", native: "migrate-repair", factory: migraterepair.NewMigrateRepairCommand},
 		{use: "status", short: "Show migration status", native: "migrate-status", factory: migratestatus.NewMigrateStatusCommand},
 		{use: "validate", short: "Validate migration directory integrity", native: "migrate-validate", factory: migratevalidate.NewMigrateValidateCommand},

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -2,6 +2,7 @@ package atlas
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -76,6 +77,24 @@ func TestNewAtlasCommand_ForwardsParentedNativeCommand(t *testing.T) {
 	err := root.Execute()
 
 	c.Assert(err, qt.ErrorMatches, "database URL is required")
+}
+
+func TestNewAtlasCommand_MigrateNewCreatesSkeletonFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "new", "manual_hotfix", "--migrations-dir", dir})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Generated empty migration files:")
+	matches, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.*.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 2)
 }
 
 func TestNewAtlasCommand_HelpUsesAtlasPathForForwardedParentedCommand(t *testing.T) {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -79,6 +79,7 @@ func NewMigrateCommand() *cobra.Command {
 		migrateFlagsRegistered = true
 	}
 	addMigrateGenerateCommand(migrateCmd)
+	addMigrateNewCommand(migrateCmd)
 	return migrateCmd
 }
 
@@ -89,6 +90,15 @@ func addMigrateGenerateCommand(cmd *cobra.Command) {
 		}
 	}
 	cmd.AddCommand(newMigrateGenerateCommand())
+}
+
+func addMigrateNewCommand(cmd *cobra.Command) {
+	for _, child := range cmd.Commands() {
+		if child.Name() == "new" {
+			return
+		}
+	}
+	cmd.AddCommand(newMigrateNewCommand())
 }
 
 func migrateCommand(cmd *cobra.Command, _ []string) error {

--- a/cmd/migrate/new.go
+++ b/cmd/migrate/new.go
@@ -1,0 +1,77 @@
+package migrate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+const (
+	newMigrationsDirFlag = "migrations-dir"
+	newNameFlag          = "name"
+)
+
+func newMigrateNewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "new [name]",
+		Short: "Create empty migration files for manual SQL",
+		Long: `Create paired empty migration files for manual SQL authoring.
+
+The command writes timestamped .up.sql and .down.sql files using Ptah's paired
+migration naming convention.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: migrateNewCommand,
+	}
+
+	flags := cmd.Flags()
+	flags.String(newMigrationsDirFlag, "", "Directory receiving generated migration files (required)")
+	flags.String(newNameFlag, "", "Migration name; optional when [name] is provided")
+
+	return cmd
+}
+
+func migrateNewCommand(cmd *cobra.Command, args []string) error {
+	migrationsDir, err := cmd.Flags().GetString(newMigrationsDirFlag)
+	if err != nil {
+		return err
+	}
+	name, err := cmd.Flags().GetString(newNameFlag)
+	if err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		if strings.TrimSpace(name) != "" {
+			return fmt.Errorf("migration name must be provided either as an argument or --name, not both")
+		}
+		name = args[0]
+	}
+
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("migration name is required")
+	}
+	if strings.TrimSpace(migrationsDir) == "" {
+		return fmt.Errorf("migrations directory is required")
+	}
+	migrationsDir, err = pathguard.ResolveCLIPath(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("invalid migrations directory: %w", err)
+	}
+
+	files, err := generator.GenerateEmptyMigration(generator.EmptyMigrationOptions{
+		MigrationName: name,
+		OutputDir:     migrationsDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Generated empty migration files:\n")
+	fmt.Fprintf(out, "UP:   %s\n", files.UpFile)
+	fmt.Fprintf(out, "DOWN: %s\n", files.DownFile)
+	return nil
+}

--- a/cmd/migrate/new_test.go
+++ b/cmd/migrate/new_test.go
@@ -1,0 +1,102 @@
+package migrate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateNewCommandCreatesSkeletonFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	cmd := newMigrateNewCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"add_user_preferences", "--migrations-dir", dir})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Generated empty migration files:")
+	matches, globErr := filepath.Glob(filepath.Join(dir, "*_add_user_preferences.*.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 2)
+
+	upBytes, readErr := os.ReadFile(matches[0])
+	c.Assert(readErr, qt.IsNil)
+	content := string(upBytes)
+	c.Assert(content, qt.Contains, "-- Migration: add_user_preferences")
+	c.Assert(content, qt.Contains, "-- Add your migration SQL here.")
+}
+
+func TestMigrateNewCommandAcceptsNameFlag(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	cmd := newMigrateNewCommand()
+	cmd.SetArgs([]string{"--name", "manual_hotfix", "--migrations-dir", dir})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	matches, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.*.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 2)
+}
+
+func TestMigrateNewCommandValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		err  string
+	}{
+		{
+			name: "missing name",
+			args: []string{"--migrations-dir", t.TempDir()},
+			err:  "migration name is required",
+		},
+		{
+			name: "missing migrations dir",
+			args: []string{"manual_hotfix"},
+			err:  "migrations directory is required",
+		},
+		{
+			name: "name argument and flag conflict",
+			args: []string{"manual_hotfix", "--name", "other", "--migrations-dir", t.TempDir()},
+			err:  "migration name must be provided either as an argument or --name, not both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			cmd := newMigrateNewCommand()
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, tt.err)
+		})
+	}
+}
+
+func TestAddMigrateNewCommandIsIdempotent(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrateCommand()
+	addMigrateNewCommand(cmd)
+	addMigrateNewCommand(cmd)
+
+	count := 0
+	for _, child := range cmd.Commands() {
+		if child.Name() == "new" {
+			count++
+		}
+	}
+	c.Assert(count, qt.Equals, 1)
+}

--- a/migration/generator/doc.go
+++ b/migration/generator/doc.go
@@ -15,6 +15,7 @@
 //
 //   - Dynamic migration generation from schema differences
 //   - Automatic up and down migration file creation
+//   - Empty migration skeleton creation for manual SQL
 //   - Timestamped migration versioning
 //   - Dialect-specific SQL generation
 //   - Proper dependency ordering and safety checks
@@ -36,6 +37,7 @@
 // The package provides these main types:
 //
 //   - GenerateMigrationOptions: Configuration for migration generation
+//   - EmptyMigrationOptions: Configuration for empty migration skeleton creation
 //   - MigrationFiles: Information about generated migration files
 //
 // # Usage Example

--- a/migration/generator/file_creation_test.go
+++ b/migration/generator/file_creation_test.go
@@ -46,6 +46,83 @@ func TestCreateMigrationFilesRequiresExistingParent(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `failed to create output directory: parent directory .* is not available: .*`)
 }
 
+func TestGenerateEmptyMigrationCreatesSkeletonPair(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "Add User Preferences",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Version, qt.Not(qt.Equals), int64(0))
+	c.Assert(filepath.Base(files.UpFile), qt.Matches, `[0-9]+_add_user_preferences\.up\.sql`)
+	c.Assert(filepath.Base(files.DownFile), qt.Matches, `[0-9]+_add_user_preferences\.down\.sql`)
+
+	upBytes, err := os.ReadFile(files.UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upBytes), qt.Contains, "-- Migration: Add User Preferences\n")
+	c.Assert(string(upBytes), qt.Contains, "-- Direction: UP\n")
+	c.Assert(string(upBytes), qt.Contains, "-- Add your migration SQL here.\n")
+
+	downBytes, err := os.ReadFile(files.DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downBytes), qt.Contains, "-- Migration: Add User Preferences\n")
+	c.Assert(string(downBytes), qt.Contains, "-- Direction: DOWN\n")
+	c.Assert(string(downBytes), qt.Contains, "-- Add your migration SQL here.\n")
+}
+
+func TestGenerateEmptyMigrationSkipsExistingVersion(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	first, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "same second",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+
+	second, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "same second",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.Version > first.Version, qt.IsTrue)
+	c.Assert(second.UpFile, qt.Not(qt.Equals), first.UpFile)
+	c.Assert(second.DownFile, qt.Not(qt.Equals), first.DownFile)
+}
+
+func TestGenerateEmptyMigrationValidation(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := filepath.Join(root, "..", "outside")
+
+	_, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "",
+		OutputDir:     root,
+	})
+	c.Assert(err, qt.ErrorMatches, `migration name is required`)
+
+	_, err = GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "init",
+		OutputDir:     "",
+	})
+	c.Assert(err, qt.ErrorMatches, `output directory is required`)
+
+	_, err = GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "!!!",
+		OutputDir:     root,
+	})
+	c.Assert(err, qt.ErrorMatches, `migration name must contain letters, digits, or underscores`)
+
+	_, err = GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName:     "init",
+		OutputDir:         outside,
+		AllowedOutputRoot: root,
+	})
+	c.Assert(err, qt.ErrorMatches, `error validating output directory: .*outside allowed root.*`)
+}
+
 func TestGenerateMigrationRejectsOutputOutsideAllowedRoot(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -74,6 +74,67 @@ type MigrationFiles struct {
 	Version    int64  // Migration version (timestamp)
 }
 
+// EmptyMigrationOptions contains options for skeleton migration creation.
+type EmptyMigrationOptions struct {
+	// MigrationName is the descriptive migration name used in filenames and headers.
+	MigrationName string
+	// OutputDir is the directory where migration files will be saved.
+	OutputDir string
+	// AllowedOutputRoot constrains OutputDir when set.
+	AllowedOutputRoot string
+}
+
+// GenerateEmptyMigration creates paired up/down skeleton migration files for
+// manual SQL authoring.
+func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error) {
+	name := strings.TrimSpace(opts.MigrationName)
+	if err := validateEmptyMigrationName(name); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(opts.OutputDir) == "" {
+		return nil, fmt.Errorf("output directory is required")
+	}
+
+	outputDir, err := pathguard.ResolveWithinRoot(opts.OutputDir, opts.AllowedOutputRoot)
+	if err != nil {
+		return nil, fmt.Errorf("error validating output directory: %w", err)
+	}
+
+	version := migrator.GetNextMigrationVersion()
+	version = nextAvailableMigrationVersion(outputDir, version, name)
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
+
+	return createMigrationFiles(
+		outputDir,
+		version,
+		name,
+		emptyMigrationSQL(name, generatedAt, "UP"),
+		emptyMigrationSQL(name, generatedAt, "DOWN"),
+	)
+}
+
+func validateEmptyMigrationName(name string) error {
+	if name == "" {
+		return fmt.Errorf("migration name is required")
+	}
+
+	fileName := migrator.GenerateMigrationFileName(1, name, "up")
+	if strings.HasPrefix(fileName, "0000000001_.") {
+		return fmt.Errorf("migration name must contain letters, digits, or underscores")
+	}
+
+	return nil
+}
+
+func emptyMigrationSQL(name, generatedAt, direction string) string {
+	return fmt.Sprintf(`-- Migration: %s
+-- Generated on: %s
+-- Direction: %s
+
+-- Add your migration SQL here.
+`, name, generatedAt, direction)
+}
+
 // GenerateMigration generates both up and down migration files by comparing
 // the desired schema (from Go entities) with the current database state.
 //


### PR DESCRIPTION
## Summary
- add `ptah migrate new` for paired empty .up.sql/.down.sql skeleton generation
- route `ptah atlas migrate new` to the new skeleton command instead of schema diff generation
- document the command and cover generator, CLI, and Atlas forwarding behavior

Closes #41

## Validation
- `go test ./migration/generator -run 'TestGenerateEmptyMigration|TestCreateMigrationFiles' -count=1`
- `go test ./cmd/migrate -run 'TestMigrateNewCommand|TestAddMigrateNewCommand' -count=1`
- `go test ./cmd/atlas -run 'TestNewAtlasCommand_MigrateNewCreatesSkeletonFiles|TestNewAtlasCommand_OSSCommandPathsResolve' -count=1`
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`
- `go run ./cmd/ptah atlas migrate new cli_smoke --migrations-dir /tmp/ptah-migrate-new-smoke`