### PR TITLE
Redact database URL query secrets

### DIFF
--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -230,39 +230,110 @@ func CloseAndWarn(conn *DatabaseConnection) {
 	}
 }
 
-// FormatDatabaseURL formats a database URL for display (hiding password)
+const redactedQueryValue = "redacted"
+
+var mySQLTCPPasswordPattern = regexp.MustCompile(`^((?:mysql|mariadb)://[^:@/?#]+):([^@/?#]+)@`)
+
+// FormatDatabaseURL formats a database URL for display (hiding secrets).
 func FormatDatabaseURL(dbURL string) string {
 	// Handle MySQL/MariaDB URLs specially since they have a different format
 	if (strings.HasPrefix(dbURL, "mysql://") || strings.HasPrefix(dbURL, "mariadb://")) && strings.Contains(dbURL, "@tcp(") {
 		// For MySQL/MariaDB URLs like mysql://user:pass@tcp(host:port)/db?params
-		// Just replace the password part
-		re := regexp.MustCompile(`://([^:]+):([^@]+)@`)
-		return re.ReplaceAllString(dbURL, "://$1:***@")
+		// Redact only the leading authority credentials, not DSN-like values in query params.
+		return redactURLQuery(mySQLTCPPasswordPattern.ReplaceAllString(dbURL, "$1:***@"))
 	}
 
 	parsedURL, err := url.Parse(dbURL)
 	if err != nil {
 		return dbURL
 	}
+	parsedURL.RawQuery = redactRawQuery(parsedURL.RawQuery)
 
 	// Hide password
 	if parsedURL.User != nil {
 		if _, hasPassword := parsedURL.User.Password(); hasPassword {
-			// Create a new URL string manually to avoid URL encoding of ***
-			username := parsedURL.User.Username()
-			host := parsedURL.Host
-			scheme := parsedURL.Scheme
-			path := parsedURL.Path
-
-			result := scheme + "://" + username + ":***@" + host + path
-			if parsedURL.RawQuery != "" {
-				result += "?" + parsedURL.RawQuery
-			}
-			return result
+			return formatURLWithRedactedUserPassword(parsedURL)
 		}
 	}
 
 	return parsedURL.String()
+}
+
+func formatURLWithRedactedUserPassword(parsedURL *url.URL) string {
+	displayURL := *parsedURL
+	username := displayURL.User.Username()
+	displayURL.User = nil
+
+	prefix := displayURL.Scheme + "://"
+	base := strings.TrimPrefix(displayURL.String(), prefix)
+	return prefix + username + ":***@" + base
+}
+
+func redactURLQuery(displayURL string) string {
+	prefix, rawQuery, ok := strings.Cut(displayURL, "?")
+	if !ok {
+		return displayURL
+	}
+
+	query, fragment, hasFragment := strings.Cut(rawQuery, "#")
+	redactedQuery := redactRawQuery(query)
+	if redactedQuery == "" {
+		if hasFragment {
+			return prefix + "#" + fragment
+		}
+		return prefix
+	}
+
+	result := prefix + "?" + redactedQuery
+	if hasFragment {
+		result += "#" + fragment
+	}
+	return result
+}
+
+func redactRawQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return ""
+	}
+	for key, values := range query {
+		if isSecretQueryParam(key) {
+			for idx := range values {
+				values[idx] = redactedQueryValue
+			}
+			query[key] = values
+		}
+	}
+	return query.Encode()
+}
+
+func isSecretQueryParam(key string) bool {
+	switch strings.ToLower(key) {
+	case "access_token",
+		"api_key",
+		"apikey",
+		"aws_secret_access_key",
+		"aws_session_token",
+		"client_secret",
+		"id_token",
+		"password",
+		"passwd",
+		"private_key",
+		"pwd",
+		"refresh_token",
+		"secret",
+		"sslcert",
+		"sslkey",
+		"sslpassword",
+		"token":
+		return true
+	default:
+		return false
+	}
 }
 
 // getDatabaseInfo retrieves database metadata

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -24,6 +24,21 @@ func TestFormatDatabaseURL(t *testing.T) {
 			expected: "postgres://user:***@localhost:5432/mydb",
 		},
 		{
+			name:     "PostgreSQL URL with query password",
+			input:    "postgres://user:secret123@localhost:5432/mydb?sslmode=disable&sslpassword=querysecret",
+			expected: "postgres://user:***@localhost:5432/mydb?sslmode=disable&sslpassword=redacted",
+		},
+		{
+			name:     "PostgreSQL URL with query password and no user password",
+			input:    "postgres://user@localhost:5432/mydb?password=querysecret",
+			expected: "postgres://user@localhost:5432/mydb?password=redacted",
+		},
+		{
+			name:     "PostgreSQL URL preserves fragment while redacting query",
+			input:    "postgres://user:secret123@localhost:5432/mydb?password=querysecret#frag",
+			expected: "postgres://user:***@localhost:5432/mydb?password=redacted#frag",
+		},
+		{
 			name:     "PostgreSQL URL without password",
 			input:    "postgres://user@localhost:5432/mydb",
 			expected: "postgres://user@localhost:5432/mydb",
@@ -37,6 +52,16 @@ func TestFormatDatabaseURL(t *testing.T) {
 			name:     "MySQL URL with password",
 			input:    "mysql://root:password@localhost:3306/testdb",
 			expected: "mysql://root:***@localhost:3306/testdb",
+		},
+		{
+			name:     "MySQL tcp URL with query secret",
+			input:    "mysql://root:password@tcp(localhost:3306)/testdb?parseTime=true&sslpassword=querysecret",
+			expected: "mysql://root:***@tcp(localhost:3306)/testdb?parseTime=true&sslpassword=redacted",
+		},
+		{
+			name:     "MySQL tcp URL does not redact embedded query URL credentials",
+			input:    "mysql://root@tcp(localhost:3306)/testdb?callback=https%3A%2F%2Fx%3Ay%40example.test&password=querysecret",
+			expected: "mysql://root@tcp(localhost:3306)/testdb?callback=https%3A%2F%2Fx%3Ay%40example.test&password=redacted",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- redact secret-bearing query parameters in `FormatDatabaseURL` display output
- anchor MySQL/MariaDB `@tcp(...)` credential masking to the start of the URL
- preserve safe query parameters and fragments while preventing literal secret values from reaching logs

Closes #138

## Validation
- `go test ./dbschema -run TestFormatDatabaseURL -count=1`
- `go test ./dbschema -count=1`
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`