### PR TITLE
Protect migration provider slices

### DIFF
--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -22,6 +23,7 @@ type MigrationProvider interface {
 
 // RegisteredMigrationProvider is a simple in-memory implementation of MigrationProvider
 type RegisteredMigrationProvider struct {
+	mu         sync.Mutex
 	migrations []*Migration
 	sorted     bool
 }
@@ -30,24 +32,30 @@ type RegisteredMigrationProvider struct {
 // The migrations will be sorted by version when accessed through the Migrations() method.
 func NewRegisteredMigrationProvider(migrations ...*Migration) *RegisteredMigrationProvider {
 	return &RegisteredMigrationProvider{
-		migrations: migrations,
+		migrations: slices.Clone(migrations),
 	}
 }
 
 // Register adds a migration to the provider
 func (p *RegisteredMigrationProvider) Register(migration *Migration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.migrations = append(p.migrations, migration)
 	p.sorted = false
 }
 
 // Migrations returns the list of migrations sorted by version in ascending order
 func (p *RegisteredMigrationProvider) Migrations() []*Migration {
-	p.maybeSort()
-	return p.migrations
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.maybeSortLocked()
+	return slices.Clone(p.migrations)
 }
 
 // maybeSort sorts the migrations if they haven't been sorted yet
-func (p *RegisteredMigrationProvider) maybeSort() {
+func (p *RegisteredMigrationProvider) maybeSortLocked() {
 	if p.sorted {
 		return
 	}
@@ -59,6 +67,7 @@ func (p *RegisteredMigrationProvider) maybeSort() {
 // It scans the filesystem for migration files following the naming convention and
 // automatically creates Migration instances from the SQL files.
 type FSMigrationProvider struct {
+	mu                sync.Mutex
 	fsys              fs.FS
 	migrations        []*Migration
 	interceptor       StatementInterceptor
@@ -118,7 +127,10 @@ func NewFSMigrationProvider(fsys fs.FS, opts ...FSProviderOption) (*FSMigrationP
 
 // Migrations returns the list of migrations loaded from the filesystem, sorted by version in ascending order.
 func (p *FSMigrationProvider) Migrations() []*Migration {
-	return p.migrations
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return slices.Clone(p.migrations)
 }
 
 func (p *FSMigrationProvider) load() error {

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -3,6 +3,7 @@ package migrator_test
 import (
 	"context"
 	"io/fs"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -109,6 +110,83 @@ func TestRegisteredMigrationProvider_Sorting(t *testing.T) {
 	c.Assert(migrations[2].Version, qt.Equals, int64(3))
 }
 
+func TestRegisteredMigrationProvider_MigrationsReturnsDefensiveCopy(t *testing.T) {
+	c := qt.New(t)
+	provider := migrator.NewRegisteredMigrationProvider(
+		&migrator.Migration{
+			Version:     2,
+			Description: "Second migration",
+			Up:          migrator.NoopMigrationFunc,
+			Down:        migrator.NoopMigrationFunc,
+		},
+		&migrator.Migration{
+			Version:     1,
+			Description: "First migration",
+			Up:          migrator.NoopMigrationFunc,
+			Down:        migrator.NoopMigrationFunc,
+		},
+	)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations[0].Version, qt.Equals, int64(1))
+	migrations[0], migrations[1] = migrations[1], migrations[0]
+	migrations = append(migrations, &migrator.Migration{Version: 3})
+	c.Assert(migrations, qt.HasLen, 3)
+
+	next := provider.Migrations()
+	c.Assert(next, qt.HasLen, 2)
+	c.Assert(next[0].Version, qt.Equals, int64(1))
+	c.Assert(next[1].Version, qt.Equals, int64(2))
+}
+
+func TestRegisteredMigrationProvider_ConcurrentRegisterAndMigrations(t *testing.T) {
+	c := qt.New(t)
+	provider := migrator.NewRegisteredMigrationProvider()
+	const (
+		workers    = 4
+		iterations = 100
+	)
+
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := range workers {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for idx := range iterations {
+				version := int64(worker*iterations + idx + 1)
+				provider.Register(&migrator.Migration{
+					Version:     version,
+					Description: "Concurrent migration",
+					Up:          migrator.NoopMigrationFunc,
+					Down:        migrator.NoopMigrationFunc,
+				})
+			}
+		}(worker)
+	}
+
+	for range workers {
+		wg.Go(func() {
+			for range iterations {
+				migrations := provider.Migrations()
+				for idx := 1; idx < len(migrations); idx++ {
+					if migrations[idx-1].Version > migrations[idx].Version {
+						errs <- "migrations are not sorted"
+						return
+					}
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		c.Errorf("%s", err)
+	}
+	c.Assert(provider.Migrations(), qt.HasLen, workers*iterations)
+}
+
 func TestNewFSMigrationProvider_Success(t *testing.T) {
 	c := qt.New(t)
 
@@ -138,6 +216,37 @@ func TestNewFSMigrationProvider_Success(t *testing.T) {
 	c.Assert(migrations[0].Description, qt.Equals, "Create Users")
 	c.Assert(migrations[1].Version, qt.Equals, int64(2))
 	c.Assert(migrations[1].Description, qt.Equals, "Add Index")
+}
+
+func TestFSMigrationProvider_MigrationsReturnsDefensiveCopy(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_create_users.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY);"),
+		},
+		"0000000001_create_users.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;"),
+		},
+		"0000000002_add_index.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE INDEX idx_users_id ON users(id);"),
+		},
+		"0000000002_add_index.down.sql": &fstest.MapFile{
+			Data: []byte("DROP INDEX idx_users_id;"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	migrations[0], migrations[1] = migrations[1], migrations[0]
+	migrations = append(migrations, &migrator.Migration{Version: 3})
+	c.Assert(migrations, qt.HasLen, 3)
+
+	next := provider.Migrations()
+	c.Assert(next, qt.HasLen, 2)
+	c.Assert(next[0].Version, qt.Equals, int64(1))
+	c.Assert(next[1].Version, qt.Equals, int64(2))
 }
 
 func TestNewFSMigrationProvider_IncompleteMigrations(t *testing.T) {


### PR DESCRIPTION
## Summary
- return defensive copies from registered and filesystem migration providers
- guard registered provider register/sort/read paths with a mutex
- add regression coverage for external slice mutation and concurrent register/read access

Closes #131

## Notes
`MigrateDownTo` already builds rollback order from a separate version slice, so this PR fixes the remaining mutable provider API surface directly instead of changing rollback ordering logic.

## Validation
- `go test ./migration/migrator -run 'TestRegisteredMigrationProvider|TestFSMigrationProvider_MigrationsReturnsDefensiveCopy|TestNewFSMigrationProvider_Success' -count=1`
- `go test -race ./migration/migrator -run TestRegisteredMigrationProvider_ConcurrentRegisterAndMigrations -count=1`
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`