### PR TITLE
Add Atlas project config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,14 @@ helpers such as `{{ define "shared/users" }}` and are not executed as standalone
 migrations. The template data object exposes `.Env`; CLI commands set it with
 `--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
 
+Ptah can also read a limited Atlas project config subset from `atlas.hcl`.
+Supported `env` blocks can provide `url`, `dev`, `exclude`, `migration { dir,
+format, revisions_schema, lock_timeout, exec_order }`, and `lint { latest }`.
+Project config precedence is explicit CLI flags, then `atlas.hcl`, then
+`ptah.yaml`, then built-in defaults. Use `--env <name>` when multiple `env`
+blocks exist; a single env is selected automatically. See
+[Atlas Project Config](docs/atlas_project_config.md).
+
 `--dir-format` controls only migration-file discovery. To continue a database
 that already uses Atlas's runtime history table, pass `--revision-format atlas`
 to `migrate-up`, `migrate-down`, `migrate-status`, `migrate-repair`, or
@@ -951,6 +959,9 @@ Show current migration status and pending migrations:
 
 # Check Atlas SQL template migrations with .Env set to dev
 ./ptah migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
+
+# Read db URL, migration directory, and Atlas revision-table settings from atlas.hcl
+./ptah migrate-status --env local --json
 ```
 
 **Output includes:**

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -1,0 +1,58 @@
+package dbcli
+
+import (
+	"github.com/go-extras/cobraflags"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+const (
+	// EnvFlagName selects an env block from atlas.hcl.
+	EnvFlagName = "env"
+)
+
+// NewEnvFlag returns the shared Atlas project env selection flag.
+func NewEnvFlag() cobraflags.Flag {
+	return &cobraflags.StringFlag{
+		Name:  EnvFlagName,
+		Value: "",
+		Usage: "Atlas project env name to read from atlas.hcl",
+	}
+}
+
+// LoadProjectConfig loads project-level configuration for a command. The
+// explicit Ptah config path controls ptah.yaml only; atlas.hcl is discovered by
+// its conventional name in the current working directory.
+func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig.Config, error) {
+	envName, err := stringFlag(cmd, EnvFlagName)
+	if err != nil {
+		return projectconfig.Config{}, err
+	}
+	return projectconfig.Load(projectconfig.LoadOptions{
+		PtahPath: ptahConfigPath,
+		EnvName:  envName,
+	})
+}
+
+// EffectiveString returns flagValue when flagName was explicitly set, otherwise
+// configValue when it is non-empty, otherwise flagValue.
+func EffectiveString(cmd *cobra.Command, flagName, flagValue, configValue string) string {
+	if flagChanged(cmd, flagName) || configValue == "" {
+		return flagValue
+	}
+	return configValue
+}
+
+func stringFlag(cmd *cobra.Command, name string) (string, error) {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		return "", nil
+	}
+	return flag.Value.String(), nil
+}
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && flag.Changed
+}

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -1,0 +1,66 @@
+package dbcli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestEffectiveStringPrefersExplicitCLIFlag(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("db-url", "builtin", "")
+	c.Assert(cmd.Flags().Set("db-url", "cli"), qt.IsNil)
+
+	got := dbcli.EffectiveString(cmd, "db-url", "cli", "config")
+
+	c.Assert(got, qt.Equals, "cli")
+}
+
+func TestEffectiveStringUsesConfigWhenFlagIsDefault(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("migrations-dir", "./migrations", "")
+
+	got := dbcli.EffectiveString(cmd, "migrations-dir", "./migrations", "atlas-migrations")
+
+	c.Assert(got, qt.Equals, "atlas-migrations")
+}
+
+func TestLoadProjectConfigReadsAtlasEnvAndPtahFallback(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, projectconfig.PtahFileName), []byte(`url: postgres://ptah/db
+migration:
+  dir: ./ptah-migrations
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, projectconfig.AtlasFileName), []byte(`env "local" {
+  url = "postgres://atlas/db"
+  migration {
+    dir = "file://atlas-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	originalWD, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	defer func() {
+		c.Assert(os.Chdir(originalWD), qt.IsNil)
+	}()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(dbcli.EnvFlagName, "", "")
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://atlas/db")
+	c.Assert(cfg.Migration.Dir, qt.Equals, "atlas-migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+}

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -37,6 +38,7 @@ func NewLintCommand() *cobra.Command {
 	var format string
 	var configPath string
 	var atlasEnv string
+	var envName string
 	var disabled []string
 	var failOn string
 
@@ -75,6 +77,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
 	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+lint.ConfigFileName+" when present)")
 	cmd.Flags().StringVar(&atlasEnv, "atlas-env", "", "Value exposed as .Env when rendering Atlas SQL template migrations")
+	cmd.Flags().StringVar(&envName, dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")
 	cmd.Flags().StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DS101 or MY (repeatable)")
 	cmd.Flags().StringVar(&failOn, "fail-on", failOnError, "Failure threshold controlling the exit code: error, any or none")
 
@@ -125,6 +128,12 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 		msg := fmt.Sprintf("unexpected positional arguments %q: pass the migrations directory via --dir", opts.positional)
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, msg)
 	}
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, "")
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	opts.dir = dbcli.EffectiveString(cmd, "dir", opts.dir, projectCfg.Migration.Dir)
+	opts.atlasEnv = dbcli.EffectiveString(cmd, "atlas-env", opts.atlasEnv, projectCfg.EnvName)
 	if err := validateDir(opts.dir); err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
 	}

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -47,6 +47,7 @@ and performs an up/down/up round-trip.`,
 	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "" or html`)
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
 	flags.String(dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String(), "Initial database connection timeout")
+	flags.String(dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")
 	flags.String(dbcli.SchemasFlagName, "", "Comma-separated schemas to introspect when supported")
 
 	return cmd
@@ -77,10 +78,13 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	shadowDB, err = effectiveMigrateGenerateShadowDB(shadowDB, configPath)
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
 	if err != nil {
 		return err
 	}
+	dbURL = dbcli.EffectiveString(cmd, generateDBURLFlag, dbURL, projectCfg.DatabaseURL)
+	migrationsDir = dbcli.EffectiveString(cmd, generateMigrationsDirFlag, migrationsDir, projectCfg.Migration.Dir)
+	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, shadowDB, projectCfg.DevURL)
 	reportFormat, err := cmd.Flags().GetString(generateReportFormatFlag)
 	if err != nil {
 		return err
@@ -146,15 +150,4 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(out, "REPORT: %s\n", files.ReportFile)
 	}
 	return nil
-}
-
-func effectiveMigrateGenerateShadowDB(flagValue, configPath string) (string, error) {
-	if flagValue != "" {
-		return flagValue, nil
-	}
-	cfg, err := dbcli.LoadMigrateGenerateConfig(configPath)
-	if err != nil {
-		return "", err
-	}
-	return cfg.ShadowDatabaseURL, nil
 }

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -22,21 +23,41 @@ func TestMigrateGenerateCommandExposesShadowDBFlag(t *testing.T) {
 	c.Assert(cmd.Flags().Lookup(generateShadowDBFlag), qt.IsNotNil)
 	c.Assert(cmd.Flags().Lookup(generateMigrationsDirFlag), qt.IsNotNil)
 	c.Assert(cmd.Flags().Lookup("config"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("env"), qt.IsNotNil)
 }
 
-func TestEffectiveMigrateGenerateShadowDB(t *testing.T) {
+func TestMigrateGenerateProjectConfigPrecedence(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
-	path := filepath.Join(dir, "ptah.yaml")
-	c.Assert(os.WriteFile(path, []byte("migrate:\n  generate:\n    shadow_db: postgres://localhost/shadow\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "ptah.yaml"), []byte("migrate:\n  generate:\n    shadow_db: postgres://localhost/ptah_shadow\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(`env "local" {
+  dev = "postgres://localhost/atlas_shadow"
+}
+`), 0o600), qt.IsNil)
 
-	shadowDB, err := effectiveMigrateGenerateShadowDB("", path)
+	originalWD, err := os.Getwd()
 	c.Assert(err, qt.IsNil)
-	c.Assert(shadowDB, qt.Equals, "postgres://localhost/shadow")
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	defer func() {
+		c.Assert(os.Chdir(originalWD), qt.IsNil)
+	}()
 
-	shadowDB, err = effectiveMigrateGenerateShadowDB("postgres://localhost/flag_shadow", path)
+	cmd := newMigrateGenerateCommand()
+	c.Assert(cmd.ParseFlags([]string{"--shadow-db", "postgres://localhost/flag_shadow"}), qt.IsNil)
+	flagShadow, err := cmd.Flags().GetString(generateShadowDBFlag)
 	c.Assert(err, qt.IsNil)
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+	c.Assert(err, qt.IsNil)
+
+	shadowDB := dbcli.EffectiveString(cmd, generateShadowDBFlag, flagShadow, cfg.DevURL)
+
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/flag_shadow")
+
+	cmd = newMigrateGenerateCommand()
+	cfg, err = dbcli.LoadProjectConfig(cmd, "")
+	c.Assert(err, qt.IsNil)
+	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, "", cfg.DevURL)
+	c.Assert(shadowDB, qt.Equals, "postgres://localhost/atlas_shadow")
 }
 
 func TestAddMigrateGenerateCommandIsIdempotent(t *testing.T) {

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -110,6 +110,7 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
+	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
 	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
 	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
 	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
@@ -125,7 +126,7 @@ func NewMigrateDownCommand() *cobra.Command {
 	return migrateDownCmd
 }
 
-func migrateDownCommand(_ *cobra.Command, _ []string) error {
+func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 	dbURL := migrateDownFlags[dbURLFlag].GetString()
 	migrationsDir := migrateDownFlags[migrationsFlag].GetString()
 	targetVersionValue := migrateDownFlags[targetFlag].GetString()
@@ -141,6 +142,20 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateDownFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateDownFlags[dbcli.RevisionTableFormatFlagName].GetString()
+	configPath := migrateDownFlags[dbcli.ConfigFlagName].GetString()
+
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
+	if err != nil {
+		return err
+	}
+	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
+	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
+	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
+	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
+	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
+	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
+	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -219,7 +234,7 @@ func migrateDownCommand(_ *cobra.Command, _ []string) error {
 
 	// Online-DDL routing works for down migrations too: a rollback ALTER on
 	// a large table is just as lock-heavy as the forward one.
-	onlineCfg, err := dbcli.LoadOnlineDDLConfig(migrateDownFlags[dbcli.ConfigFlagName].GetString())
+	onlineCfg, err := dbcli.LoadOnlineDDLConfig(configPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -71,6 +71,7 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Usage: "Output status in JSON format",
 	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
 	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
 	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
 	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
@@ -86,7 +87,7 @@ func NewMigrateStatusCommand() *cobra.Command {
 	return migrateStatusCmd
 }
 
-func migrateStatusCommand(_ *cobra.Command, _ []string) error {
+func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 	dbURL := migrateStatusFlags[dbURLFlag].GetString()
 	migrationsDir := migrateStatusFlags[migrationsFlag].GetString()
 	dirFormatValue := migrateStatusFlags[dirFormatFlag].GetString()
@@ -96,6 +97,17 @@ func migrateStatusCommand(_ *cobra.Command, _ []string) error {
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateStatusFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateStatusFlags[dbcli.RevisionTableFormatFlagName].GetString()
+
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, "")
+	if err != nil {
+		return err
+	}
+	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
+	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
+	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
+	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
+	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -111,6 +111,7 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
+	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
 	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
 	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
 	dbcli.RevisionTableFormatFlagName: dbcli.NewRevisionTableFormatFlag(),
@@ -126,7 +127,7 @@ func NewMigrateUpCommand() *cobra.Command {
 	return migrateUpCmd
 }
 
-func migrateUpCommand(_ *cobra.Command, _ []string) error {
+func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	dbURL := migrateUpFlags[dbURLFlag].GetString()
 	migrationsDir := migrateUpFlags[migrationsFlag].GetString()
 	dryRun := migrateUpFlags[dryRunFlag].GetBool()
@@ -142,6 +143,20 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	migrationsSchema := migrateUpFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateUpFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateUpFlags[dbcli.RevisionTableFormatFlagName].GetString()
+	configPath := migrateUpFlags[dbcli.ConfigFlagName].GetString()
+
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
+	if err != nil {
+		return err
+	}
+	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
+	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
+	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
+	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
+	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
+	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
+	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -150,7 +165,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
 	}
-	migrationsDir, err := pathguard.ResolveCLIPath(migrationsDir)
+	migrationsDir, err = pathguard.ResolveCLIPath(migrationsDir)
 	if err != nil {
 		return fmt.Errorf("invalid migrations directory: %w", err)
 	}
@@ -231,7 +246,7 @@ func migrateUpCommand(_ *cobra.Command, _ []string) error {
 	// Online-DDL routing: `-- +ptah online_ddl_tool=...` directives always
 	// work; the ptah.yaml online_ddl section adds automatic routing of
 	// ALTERs on tables above the configured row threshold.
-	onlineCfg, err := dbcli.LoadOnlineDDLConfig(migrateUpFlags[dbcli.ConfigFlagName].GetString())
+	onlineCfg, err := dbcli.LoadOnlineDDLConfig(configPath)
 	if err != nil {
 		return err
 	}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -1,0 +1,315 @@
+package projectconfig
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// LoadAtlasFile loads the supported subset of an Atlas project config file. A
+// missing file returns an empty config unless envName is set.
+func LoadAtlasFile(path, envName string) (Config, error) {
+	raw, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist) && envName == "":
+		return Config{}, nil
+	case errors.Is(err, fs.ErrNotExist):
+		return Config{}, fmt.Errorf("atlas config %s: %w", path, err)
+	case err != nil:
+		return Config{}, fmt.Errorf("failed to read atlas config %s: %w", path, err)
+	}
+	return ParseAtlas(raw, path, envName)
+}
+
+// ParseAtlas parses the supported subset of an Atlas project config file.
+func ParseAtlas(data []byte, filename, envName string) (Config, error) {
+	if filename == "" {
+		filename = AtlasFileName
+	}
+	file, diags := hclsyntax.ParseConfig(data, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return Config{}, fmt.Errorf("parse atlas project config: %s", diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return Config{}, fmt.Errorf("parse atlas project config: unsupported body type %T", file.Body)
+	}
+
+	p := atlasParser{}
+	return p.parse(body, envName)
+}
+
+type atlasParser struct{}
+
+func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error) {
+	if len(body.Attributes) > 0 {
+		for name, attr := range body.Attributes {
+			return Config{}, unsupportedAttr(name, attr)
+		}
+	}
+
+	envs := make([]atlasEnv, 0)
+	for _, block := range body.Blocks {
+		if block.Type != "env" {
+			return Config{}, unsupportedBlock(block)
+		}
+		env, err := p.parseEnv(block)
+		if err != nil {
+			return Config{}, err
+		}
+		envs = append(envs, env)
+	}
+	if len(envs) == 0 {
+		return Config{}, nil
+	}
+
+	selected, err := selectAtlasEnv(envs, envName)
+	if err != nil {
+		return Config{}, err
+	}
+	return selected.config, nil
+}
+
+type atlasEnv struct {
+	name   string
+	config Config
+	rng    hcl.Range
+}
+
+func (p atlasParser) parseEnv(block *hclsyntax.Block) (atlasEnv, error) {
+	if len(block.Labels) > 1 {
+		return atlasEnv{}, unsupportedBlock(block)
+	}
+	name := ""
+	if len(block.Labels) == 1 {
+		name = block.Labels[0]
+	}
+
+	env := atlasEnv{
+		name: name,
+		config: Config{
+			EnvName: name,
+		},
+		rng: block.TypeRange,
+	}
+
+	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "url":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return atlasEnv{}, err
+			}
+			env.config.DatabaseURL = value
+		case "dev":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return atlasEnv{}, err
+			}
+			env.config.DevURL = value
+		case "exclude":
+			values, err := stringListAttr(attrName, attr)
+			if err != nil {
+				return atlasEnv{}, err
+			}
+			env.config.Exclude = values
+		default:
+			return atlasEnv{}, unsupportedAttr(attrName, attr)
+		}
+	}
+
+	seenMigration := false
+	seenLint := false
+	for _, nested := range block.Body.Blocks {
+		switch nested.Type {
+		case "migration":
+			if seenMigration {
+				return atlasEnv{}, unsupportedBlock(nested)
+			}
+			seenMigration = true
+			if err := p.parseMigration(nested, &env.config); err != nil {
+				return atlasEnv{}, err
+			}
+		case "lint":
+			if seenLint {
+				return atlasEnv{}, unsupportedBlock(nested)
+			}
+			seenLint = true
+			if err := p.parseLint(nested, &env.config); err != nil {
+				return atlasEnv{}, err
+			}
+		default:
+			return atlasEnv{}, unsupportedBlock(nested)
+		}
+	}
+
+	return env, nil
+}
+
+func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
+	if len(block.Labels) > 0 {
+		return unsupportedBlock(block)
+	}
+	migration := cfg.Migration
+	if migration.Format == "" {
+		migration.Format = "atlas"
+	}
+	if migration.RevisionFormat == "" {
+		migration.RevisionFormat = "atlas"
+	}
+
+	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "dir":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			dir, err := normalizeAtlasMigrationDir(value, attr)
+			if err != nil {
+				return err
+			}
+			migration.Dir = dir
+		case "format":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			migration.Format = value
+		case "revisions_schema":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			migration.RevisionsSchema = value
+		case "lock_timeout":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			migration.LockTimeout = value
+		case "exec_order":
+			value, err := stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			migration.ExecOrder = value
+		default:
+			return unsupportedAttr(attrName, attr)
+		}
+	}
+	if len(block.Body.Blocks) > 0 {
+		return unsupportedBlock(block.Body.Blocks[0])
+	}
+	cfg.Migration = migration
+	return nil
+}
+
+func (p atlasParser) parseLint(block *hclsyntax.Block, cfg *Config) error {
+	if len(block.Labels) > 0 {
+		return unsupportedBlock(block)
+	}
+	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "latest":
+			value, err := intAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			cfg.Lint.Latest = &value
+		default:
+			return unsupportedAttr(attrName, attr)
+		}
+	}
+	if len(block.Body.Blocks) > 0 {
+		return unsupportedBlock(block.Body.Blocks[0])
+	}
+	return nil
+}
+
+func selectAtlasEnv(envs []atlasEnv, envName string) (atlasEnv, error) {
+	if envName != "" {
+		for _, env := range envs {
+			if env.name == envName {
+				return env, nil
+			}
+		}
+		return atlasEnv{}, fmt.Errorf("atlas env %q not found", envName)
+	}
+	if len(envs) == 1 {
+		return envs[0], nil
+	}
+	return atlasEnv{}, fmt.Errorf("atlas.hcl contains multiple env blocks; pass --env")
+}
+
+func stringAttr(name string, attr *hclsyntax.Attribute) (string, error) {
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.String {
+		return "", unsupportedAttr(name, attr)
+	}
+	return value.AsString(), nil
+}
+
+func intAttr(name string, attr *hclsyntax.Attribute) (int, error) {
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.Number {
+		return 0, unsupportedAttr(name, attr)
+	}
+	raw, accuracy := value.AsBigFloat().Int64()
+	if accuracy != big.Exact {
+		return 0, unsupportedAttr(name, attr)
+	}
+	return int(raw), nil
+}
+
+func stringListAttr(name string, attr *hclsyntax.Attribute) ([]string, error) {
+	value, diags := attr.Expr.Value(nil)
+	valueType := value.Type()
+	if diags.HasErrors() || !value.CanIterateElements() || (!valueType.IsTupleType() && !valueType.IsListType()) {
+		return nil, unsupportedAttr(name, attr)
+	}
+	values := make([]string, 0, value.LengthInt())
+	it := value.ElementIterator()
+	for it.Next() {
+		_, item := it.Element()
+		if item.Type() != cty.String {
+			return nil, unsupportedAttr(name, attr)
+		}
+		values = append(values, item.AsString())
+	}
+	return values, nil
+}
+
+func normalizeAtlasMigrationDir(value string, attr *hclsyntax.Attribute) (string, error) {
+	switch {
+	case strings.HasPrefix(value, "file://"):
+		dir := strings.TrimPrefix(value, "file://")
+		if dir == "" {
+			return "", unsupportedAttr("dir", attr)
+		}
+		return dir, nil
+	case strings.Contains(value, "://"):
+		return "", unsupportedAttr("dir", attr)
+	default:
+		return value, nil
+	}
+}
+
+func unsupportedBlock(block *hclsyntax.Block) error {
+	return unsupported(block.Type, block.TypeRange)
+}
+
+func unsupportedAttr(name string, attr *hclsyntax.Attribute) error {
+	return unsupported(name, attr.NameRange)
+}
+
+func unsupported(name string, rng hcl.Range) error {
+	return fmt.Errorf("unsupported atlas.hcl construct %q at %s:%d", name, rng.Filename, rng.Start.Line)
+}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1,0 +1,175 @@
+package projectconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestParseAtlasProjectConfig(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  url = "postgres://app@localhost:5432/app?sslmode=disable"
+  dev = "docker://postgres/16/dev"
+  exclude = ["tmp_*"]
+  migration {
+    dir              = "file://migrations"
+    format           = "atlas"
+    revisions_schema = "atlas"
+    lock_timeout     = "3s"
+    exec_order       = "linear"
+  }
+  lint {
+    latest = 5
+  }
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "local")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://app@localhost:5432/app?sslmode=disable")
+	c.Assert(cfg.DevURL, qt.Equals, "docker://postgres/16/dev")
+	c.Assert(cfg.Exclude, qt.DeepEquals, []string{"tmp_*"})
+	c.Assert(cfg.Migration.Dir, qt.Equals, "migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionsSchema, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.LockTimeout, qt.Equals, "3s")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "linear")
+	c.Assert(cfg.Lint.Latest, qt.IsNotNil)
+	c.Assert(*cfg.Lint.Latest, qt.Equals, 5)
+}
+
+func TestParseAtlasProjectConfigSelectsEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "dev" {
+  url = "postgres://dev/db"
+}
+env "prod" {
+  url = "postgres://prod/db"
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://prod/db")
+
+	_, err = projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl contains multiple env blocks; pass --env`)
+}
+
+func TestParseAtlasProjectConfigRequiresEnvWhenMultipleBlocksExist(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  url = "postgres://default/db"
+}
+env "prod" {
+  url = "postgres://prod/db"
+}
+`)
+
+	_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl contains multiple env blocks; pass --env`)
+}
+
+func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		err  string
+	}{
+		{
+			name: "cloud block",
+			raw: `atlas {
+  cloud {}
+}
+`,
+			err: `unsupported atlas\.hcl construct "atlas" at atlas\.hcl:1`,
+		},
+		{
+			name: "unknown env attribute",
+			raw: `env "local" {
+  src = "schema.hcl"
+}
+`,
+			err: `unsupported atlas\.hcl construct "src" at atlas\.hcl:2`,
+		},
+		{
+			name: "unknown migration attribute",
+			raw: `env "local" {
+  migration {
+    remote_dir = "atlas://example"
+  }
+}
+`,
+			err: `unsupported atlas\.hcl construct "remote_dir" at atlas\.hcl:3`,
+		},
+		{
+			name: "duplicate migration block",
+			raw: `env "local" {
+  migration {}
+  migration {}
+}
+`,
+			err: `unsupported atlas\.hcl construct "migration" at atlas\.hcl:3`,
+		},
+		{
+			name: "exclude object",
+			raw: `env "local" {
+  exclude = { tmp = "tmp_*" }
+}
+`,
+			err: `unsupported atlas\.hcl construct "exclude" at atlas\.hcl:2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "")
+
+			c.Assert(err, qt.ErrorMatches, tt.err)
+		})
+	}
+}
+
+func TestLoadMergesAtlasOverPtah(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	ptahPath := filepath.Join(dir, "ptah.yaml")
+	atlasPath := filepath.Join(dir, "atlas.hcl")
+	c.Assert(os.WriteFile(ptahPath, []byte(`url: postgres://ptah/db
+migration:
+  dir: ./ptah-migrations
+  exec_order: non-linear
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(atlasPath, []byte(`env "local" {
+  url = "postgres://atlas/db"
+  migration {
+    dir = "file://atlas-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cfg, err := projectconfig.Load(projectconfig.LoadOptions{
+		PtahPath:  ptahPath,
+		AtlasPath: atlasPath,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://atlas/db")
+	c.Assert(cfg.Migration.Dir, qt.Equals, "atlas-migrations")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+}

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -1,0 +1,97 @@
+// Package projectconfig loads Ptah project-level configuration from Ptah and
+// Atlas project config files.
+package projectconfig
+
+import "slices"
+
+const (
+	// PtahFileName is the conventional Ptah project config file.
+	PtahFileName = "ptah.yaml"
+	// AtlasFileName is the conventional Atlas project config file.
+	AtlasFileName = "atlas.hcl"
+)
+
+// Config is Ptah's project-level configuration IR. Loaders translate supported
+// file formats into this shape; command code should consume this type instead
+// of branching on the original file format.
+type Config struct {
+	// EnvName is the selected Atlas env name, when the source had one.
+	EnvName string
+	// DatabaseURL is the target database URL used by migration commands.
+	DatabaseURL string
+	// DevURL is the disposable dev/shadow database URL.
+	DevURL string
+	// Exclude lists schema patterns excluded by project config.
+	Exclude []string
+	// Migration holds migration-directory and runtime settings.
+	Migration MigrationConfig
+	// Lint holds migration-lint settings.
+	Lint LintConfig
+}
+
+// MigrationConfig is the migration section of the project config IR.
+type MigrationConfig struct {
+	Dir             string
+	Format          string
+	RevisionsSchema string
+	RevisionFormat  string
+	LockTimeout     string
+	ExecOrder       string
+}
+
+// LintConfig is the lint section of the project config IR.
+type LintConfig struct {
+	Latest *int
+}
+
+// Merge returns base overridden by non-zero values from override.
+func Merge(base, override Config) Config {
+	result := base
+	if override.EnvName != "" {
+		result.EnvName = override.EnvName
+	}
+	if override.DatabaseURL != "" {
+		result.DatabaseURL = override.DatabaseURL
+	}
+	if override.DevURL != "" {
+		result.DevURL = override.DevURL
+	}
+	if len(override.Exclude) > 0 {
+		result.Exclude = slices.Clone(override.Exclude)
+	}
+	result.Migration = mergeMigration(result.Migration, override.Migration)
+	result.Lint = mergeLint(result.Lint, override.Lint)
+	return result
+}
+
+func mergeMigration(base, override MigrationConfig) MigrationConfig {
+	result := base
+	if override.Dir != "" {
+		result.Dir = override.Dir
+	}
+	if override.Format != "" {
+		result.Format = override.Format
+	}
+	if override.RevisionsSchema != "" {
+		result.RevisionsSchema = override.RevisionsSchema
+	}
+	if override.RevisionFormat != "" {
+		result.RevisionFormat = override.RevisionFormat
+	}
+	if override.LockTimeout != "" {
+		result.LockTimeout = override.LockTimeout
+	}
+	if override.ExecOrder != "" {
+		result.ExecOrder = override.ExecOrder
+	}
+	return result
+}
+
+func mergeLint(base, override LintConfig) LintConfig {
+	result := base
+	if override.Latest != nil {
+		latest := *override.Latest
+		result.Latest = &latest
+	}
+	return result
+}

--- a/config/projectconfig/load.go
+++ b/config/projectconfig/load.go
@@ -1,0 +1,31 @@
+package projectconfig
+
+// LoadOptions selects project config files and the Atlas env.
+type LoadOptions struct {
+	PtahPath  string
+	AtlasPath string
+	EnvName   string
+}
+
+// Load reads Ptah and Atlas project config files and merges them with the
+// documented precedence: atlas.hcl beats ptah.yaml.
+func Load(opts LoadOptions) (Config, error) {
+	ptahPath := opts.PtahPath
+	if ptahPath == "" {
+		ptahPath = PtahFileName
+	}
+	atlasPath := opts.AtlasPath
+	if atlasPath == "" {
+		atlasPath = AtlasFileName
+	}
+
+	ptah, err := LoadPtahFile(ptahPath)
+	if err != nil {
+		return Config{}, err
+	}
+	atlas, err := LoadAtlasFile(atlasPath, opts.EnvName)
+	if err != nil {
+		return Config{}, err
+	}
+	return Merge(ptah, atlas), nil
+}

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -1,0 +1,82 @@
+package projectconfig
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type yamlConfig struct {
+	URL       string            `yaml:"url"`
+	Dev       string            `yaml:"dev"`
+	Exclude   []string          `yaml:"exclude"`
+	Migration yamlMigration     `yaml:"migration"`
+	Lint      yamlLint          `yaml:"lint"`
+	Migrate   yamlMigrateConfig `yaml:"migrate"`
+	OnlineDDL any               `yaml:"online_ddl"`
+}
+
+type yamlMigration struct {
+	Dir             string `yaml:"dir"`
+	Format          string `yaml:"format"`
+	RevisionsSchema string `yaml:"revisions_schema"`
+	RevisionFormat  string `yaml:"revision_format"`
+	LockTimeout     string `yaml:"lock_timeout"`
+	ExecOrder       string `yaml:"exec_order"`
+}
+
+type yamlLint struct {
+	Latest *int `yaml:"latest"`
+}
+
+type yamlMigrateConfig struct {
+	Generate yamlMigrateGenerateConfig `yaml:"generate"`
+}
+
+type yamlMigrateGenerateConfig struct {
+	ShadowDatabaseURL string `yaml:"shadow_db"`
+}
+
+// LoadPtahFile loads Ptah's project config file. A missing file returns an
+// empty config.
+func LoadPtahFile(path string) (Config, error) {
+	raw, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return Config{}, nil
+	case err != nil:
+		return Config{}, fmt.Errorf("failed to read ptah config %s: %w", path, err)
+	}
+
+	var cfg yamlConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return Config{}, fmt.Errorf("failed to parse ptah config %s: %w", path, err)
+	}
+	return cfg.projectConfig(), nil
+}
+
+func (c yamlConfig) projectConfig() Config {
+	dev := c.Dev
+	if dev == "" {
+		dev = c.Migrate.Generate.ShadowDatabaseURL
+	}
+	return Config{
+		DatabaseURL: c.URL,
+		DevURL:      dev,
+		Exclude:     c.Exclude,
+		Migration: MigrationConfig{
+			Dir:             c.Migration.Dir,
+			Format:          c.Migration.Format,
+			RevisionsSchema: c.Migration.RevisionsSchema,
+			RevisionFormat:  c.Migration.RevisionFormat,
+			LockTimeout:     c.Migration.LockTimeout,
+			ExecOrder:       c.Migration.ExecOrder,
+		},
+		Lint: LintConfig{
+			Latest: c.Lint.Latest,
+		},
+	}
+}

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -229,9 +229,10 @@ The Atlas HCL frontend is intentionally conservative. It does not yet model
 Atlas features that Ptah cannot represent without losing semantics, including:
 
 - composite foreign keys
-- Atlas project `env` execution semantics
 - Atlas HCL objects outside direct schema definitions, such as variables,
   realms, extensions, and other dialect-specific object types
 
-Project-level `env` and `variable` blocks may appear next to schema objects, but
-they are not executed by `ptah generate --schema-file`.
+Project-level `env` and `variable` blocks may appear next to schema objects in
+schema HCL files, but they are not executed by `ptah generate --schema-file`.
+Command-level `atlas.hcl` project config support is documented in
+[Atlas Project Config](atlas_project_config.md).

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -1,0 +1,110 @@
+# Atlas Project Config
+
+Ptah can read a limited Atlas project config subset from `atlas.hcl` and
+translate it into Ptah's project config IR. This is project configuration for
+commands, not schema HCL input. Schema HCL input is documented separately in
+[Atlas HCL Schema Input](atlas_hcl_schema.md).
+
+## Supported Subset
+
+Ptah accepts top-level `env` blocks with either one label or no label:
+
+```hcl
+env "local" {
+  url = "postgres://user:pass@localhost:5432/app?sslmode=disable"
+  dev = "postgres://user:pass@localhost:5432/app_shadow?sslmode=disable"
+  exclude = ["tmp_*"]
+
+  migration {
+    dir              = "file://migrations"
+    format           = "atlas"
+    revisions_schema = "atlas"
+    lock_timeout     = "3s"
+    exec_order       = "linear"
+  }
+
+  lint {
+    latest = 5
+  }
+}
+```
+
+The supported attributes map to Ptah settings as follows:
+
+| Atlas setting | Ptah setting |
+| --- | --- |
+| `env.url` | `--db-url` default |
+| `env.dev` | `migrate generate --shadow-db` default |
+| `env.exclude` | Project config IR exclude list |
+| `migration.dir` | `--migrations-dir` or `--dir` default |
+| `migration.format` | `--dir-format` default |
+| `migration.revisions_schema` | `--migrations-schema` default |
+| `migration.lock_timeout` | `--lock-timeout` default |
+| `migration.exec_order` | `--exec-order` default |
+| `lint.latest` | Project config IR lint setting |
+
+`env.exclude` and `lint.latest` are preserved in the project config IR for
+consumers that understand them. The current CLI wiring uses the connection,
+dev database, migration directory, migration execution, revision-table, and
+template env settings.
+
+When an `atlas.hcl` `migration` block is present, Ptah also defaults
+`revision-format` to `atlas`, so migration commands use
+`atlas_schema_revisions` unless an explicit CLI flag overrides it. `file://`
+migration directories are normalized to local paths. Other URI schemes are
+rejected.
+
+## Env Selection
+
+Use `--env <name>` when an `atlas.hcl` file contains multiple `env` blocks.
+When the file contains exactly one `env` block, Ptah selects it automatically.
+If the file contains multiple envs and no `--env` is provided, Ptah returns:
+
+```text
+atlas.hcl contains multiple env blocks; pass --env
+```
+
+## Precedence
+
+Ptah merges configuration in this order:
+
+1. Explicit CLI flags
+2. `atlas.hcl`
+3. `ptah.yaml`
+4. Built-in command defaults
+
+This means a repo can keep an Atlas-shaped migration setup while still letting
+one-off CLI invocations override any value:
+
+```bash
+ptah migrate-status --env local --json
+ptah migrate-up --env local
+ptah migrate-up --env local --db-url postgres://override/db
+```
+
+## Commands
+
+The project config is currently consumed by commands that need the mapped
+settings:
+
+- `migrate-up`
+- `migrate-down`
+- `migrate-status`
+- `lint`
+- `migrate generate`
+
+Atlas-compatible aliases under `ptah atlas <command> ...` inherit this behavior
+when they forward to one of these native commands.
+
+## Unsupported Constructs
+
+Ptah intentionally rejects everything outside the documented subset. Unsupported
+attributes, blocks, duplicate `migration` or `lint` blocks, dynamic expressions,
+and non-file migration directory URI schemes fail with a location-aware error:
+
+```text
+unsupported atlas.hcl construct "src" at atlas.hcl:2
+```
+
+This hard-fail policy prevents partially interpreted Atlas project configs from
+silently changing migration behavior.

--- a/integration/atlas_project_config_e2e_test.go
+++ b/integration/atlas_project_config_e2e_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+func TestAtlasProjectConfigMigrateStatusAndUpE2E(t *testing.T) {
+	dbURL := postgresE2EDatabaseURL(t)
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		t.Skip("PostgreSQL URL required for atlas.hcl project config e2e test")
+	}
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah")
+	buildPtah(c, ctx, repoRoot, binaryPath)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_atlas_project_config_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	workDir := t.TempDir()
+	writeAtlasProjectConfigFixture(c, workDir, replaceDatabaseName(c, dbURL, testDBName))
+
+	output, err := runPtahInDir(ctx, workDir, binaryPath, "migrate-status", "--env", "local", "--json")
+	c.Assert(err, qt.IsNil, qt.Commentf("migrate-status output:\n%s", output))
+	c.Assert(readStatusField(c, output, "total_migrations"), qt.Equals, float64(1))
+	c.Assert(readStatusField(c, output, "has_pending_changes"), qt.Equals, true)
+
+	output, err = runPtahInDir(ctx, workDir, binaryPath, "migrate-up", "--env", "local")
+	c.Assert(err, qt.IsNil, qt.Commentf("migrate-up output:\n%s", output))
+	c.Assert(output, qt.Contains, "Migration directory format: atlas")
+	c.Assert(output, qt.Contains, "Database is now at version: 20260719010101")
+
+	output, err = runPtahInDir(ctx, workDir, binaryPath, "migrate-status", "--env", "local", "--json")
+	c.Assert(err, qt.IsNil, qt.Commentf("final migrate-status output:\n%s", output))
+	c.Assert(readStatusField(c, output, "current_version"), qt.Equals, float64(20260719010101))
+	c.Assert(readStatusField(c, output, "has_pending_changes"), qt.Equals, false)
+
+	verifyAtlasProjectConfigDatabaseState(c, ctx, replaceDatabaseName(c, dbURL, testDBName))
+}
+
+func writeAtlasProjectConfigFixture(c *qt.C, workDir, dbURL string) {
+	migrationsDir := filepath.Join(workDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(workDir, "atlas.hcl"), []byte(fmt.Sprintf(`env "local" {
+  url = %q
+  migration {
+    dir              = "file://migrations"
+    revisions_schema = "ptah_issue_276"
+    lock_timeout     = "3s"
+    exec_order       = "linear"
+  }
+}
+`, dbURL)), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "atlas.sum"), []byte(
+		"h1:directory\n"+
+			"20260719010101_create_project_config_widgets.sql h1:ptahissue276\n",
+	), 0600), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "20260719010101_create_project_config_widgets.sql"),
+		[]byte("CREATE TABLE ptah_issue_276_widgets (id INT PRIMARY KEY);\n"),
+		0600,
+	), qt.IsNil)
+}
+
+func runPtahInDir(ctx context.Context, dir, binaryPath string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func readStatusField(c *qt.C, output, field string) any {
+	var payload map[string]any
+	c.Assert(json.Unmarshal([]byte(output), &payload), qt.IsNil, qt.Commentf("status output:\n%s", output))
+	return payload[field]
+}
+
+func verifyAtlasProjectConfigDatabaseState(c *qt.C, ctx context.Context, dbURL string) {
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	var tableName string
+	err = db.QueryRowContext(ctx, `SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public' AND table_name = 'ptah_issue_276_widgets'`).Scan(&tableName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableName, qt.Equals, "ptah_issue_276_widgets")
+
+	var version, hash string
+	err = db.QueryRowContext(ctx, `SELECT version, hash
+FROM ptah_issue_276.atlas_schema_revisions
+WHERE version = '20260719010101'`).Scan(&version, &hash)
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, "20260719010101")
+	c.Assert(hash, qt.Equals, "ptahissue276")
+}


### PR DESCRIPTION
## Summary
- add a strict project config IR and loaders for ptah.yaml plus the supported atlas.hcl env subset
- wire atlas.hcl defaults into migrate-up, migrate-down, migrate-status, migrate generate, and lint while keeping explicit CLI flags highest precedence
- document Atlas project config support separately from schema HCL input

## Validation
- go test ./... -count=1
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- POSTGRES_TEST_DSN='postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' go test -tags=integration ./integration -run TestAtlasProjectConfigMigrateStatusAndUpE2E -count=1 -v

Closes #276