### PR TITLE
Add lint analyzer extension APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,14 +658,36 @@ Findings carry stable rule codes grouped into families:
 
 `--dialect` both gates the dialect-specific rule families and selects the dialect's SQL syntax for scanning (MySQL `#` comments, `/*!...*/` executable comments and backslash string escapes; PostgreSQL dollar quotes and nested block comments). With no dialect set, every rule runs under a hybrid scanner.
 
-Exit codes mirror `drift`: `0` clean (for the selected threshold), `1` findings above `--fail-on` (`error` by default; `any`, `none`), `2` command error. `--format text|json|github-actions` selects the output; the GitHub format annotates PR files inline. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
+Exit codes mirror `drift`: `0` clean (for the selected threshold), `1` findings above `--fail-on` (`error` by default; `any`, `none`), `2` command error. `--format text|json|github-actions|sarif` selects the output; the GitHub format annotates PR files inline, and SARIF 2.1.0 can be uploaded to GitHub code scanning. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
 
 ```yaml
 dialect: postgres
 disabled-rules:
   - MF103
   - MY
+rules:
+  DS103:
+    severity: warning
+  DS102:
+    severity: error
+    exclude:
+      - legacy/**
 ```
+
+Inline suppressions apply to the next statement only. Ptah accepts both its
+native directive and the Atlas-compatible alias:
+
+```sql
+-- ptah:nolint DS102
+ALTER TABLE users DROP COLUMN legacy_note;
+
+-- atlas:nolint DS103
+ALTER TABLE users ALTER COLUMN email TYPE VARCHAR(512);
+```
+
+Go integrations can provide custom analyzers without reimplementing Ptah's
+dialect-aware scanner by passing `lint.Options{ExtraRules: []lint.Rule{...}}`
+or by preparing files first with `lint.PrepareFS`.
 
 #### Generate Migration SQL
 Generate SQL migration statements to synchronize schemas:
@@ -673,6 +695,14 @@ Generate SQL migration statements to synchronize schemas:
 ```bash
 ./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
 ./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
+```
+
+Use `--report json` when CI needs the destructive-safety verdict as structured
+data instead of text:
+
+```bash
+./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --report json
+./ptah migrate generate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --report json
 ```
 
 **Output:** SQL statements to bring the database in sync with Go entities
@@ -1143,7 +1173,8 @@ ptah migrate generate \
 that database, replays existing migrations, applies the candidate migration,
 re-introspects the schema, and only writes files when the replayed schema
 matches the Go source. A mismatch aborts before writing files with a diagnostic
-such as `shadow check failed: missing column users.email`.
+such as `shadow check failed: missing column users.email`. Library callers can
+inspect structured shadow mismatches via `generator.ShadowVerificationError`.
 
 You can make this the default for `migrate generate` by configuring the same
 disposable database in `ptah.yaml`; an explicit `--shadow-db` value still wins:

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -17,12 +18,14 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/risk"
 )
 
 const (
 	formatText          = "text"
 	formatJSON          = "json"
 	formatGitHubActions = "github-actions"
+	formatSARIF         = "sarif"
 
 	failOnError = "error"
 	failOnAny   = "any"
@@ -73,8 +76,8 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	}
 
 	cmd.Flags().StringVar(&dir, "dir", "./migrations", "Directory containing migration files")
-	cmd.Flags().StringVar(&dialect, "dialect", "", "Target dialect gating dialect-specific rules: postgres, mysql or mariadb (empty runs every rule)")
-	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
+	cmd.Flags().StringVar(&dialect, "dialect", "", "Target dialect gating dialect-specific rules: postgres, mysql, mariadb, clickhouse, cockroachdb, yugabytedb, or spanner (empty runs every rule)")
+	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions, sarif")
 	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+lint.ConfigFileName+" when present)")
 	cmd.Flags().StringVar(&atlasEnv, "atlas-env", "", "Value exposed as .Env when rendering Atlas SQL template migrations")
 	cmd.Flags().StringVar(&envName, dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")
@@ -112,6 +115,66 @@ type lintReport struct {
 	Error            string         `json:"error,omitempty"`
 }
 
+type sarifReport struct {
+	Version string     `json:"version"`
+	Schema  string     `json:"$schema"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri,omitempty"`
+	Rules          []sarifRule `json:"rules,omitempty"`
+}
+
+type sarifRule struct {
+	ID               string             `json:"id"`
+	Name             string             `json:"name,omitempty"`
+	ShortDescription sarifMessage       `json:"shortDescription,omitzero"`
+	DefaultConfig    sarifDefaultConfig `json:"defaultConfiguration"`
+}
+
+type sarifDefaultConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifResult struct {
+	RuleID    string          `json:"ruleId"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations,omitempty"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
+}
+
 func runLint(cmd *cobra.Command, opts runOptions) error {
 	if err := validateFormat(opts.format); err != nil {
 		return writeError(cmd.ErrOrStderr(), formatText, opts.failOn, err.Error())
@@ -143,7 +206,7 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
 	}
 	if !isValidDialect(cfg.Dialect) {
-		msg := fmt.Sprintf("invalid dialect %q in lint config: expected postgres, mysql, or mariadb", cfg.Dialect)
+		msg := fmt.Sprintf("invalid dialect %q in lint config: expected postgres, mysql, mariadb, clickhouse, cockroachdb, yugabytedb, or spanner", cfg.Dialect)
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, msg)
 	}
 	// An explicitly passed --dialect wins even when set to "" (run every
@@ -159,6 +222,7 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 		Disabled:          disabled,
 		PathPrefix:        filepath.ToSlash(opts.dir),
 		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.atlasEnv},
+		RuleConfigs:       cfg.Rules,
 	})
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
@@ -228,10 +292,77 @@ func writeReport(w io.Writer, format string, report lintReport) error {
 	case formatGitHubActions:
 		writeGitHubActions(w, report)
 		return nil
+	case formatSARIF:
+		return writeSARIF(w, report)
 	default:
 		writeText(w, report)
 		return nil
 	}
+}
+
+func writeSARIF(w io.Writer, report lintReport) error {
+	rules := sarifRules(report.Findings)
+	results := make([]sarifResult, 0, len(report.Findings))
+	for _, finding := range report.Findings {
+		location := sarifLocation{
+			PhysicalLocation: sarifPhysicalLocation{
+				ArtifactLocation: sarifArtifactLocation{URI: finding.File},
+			},
+		}
+		if finding.Line > 0 {
+			location.PhysicalLocation.Region = &sarifRegion{StartLine: finding.Line}
+		}
+		results = append(results, sarifResult{
+			RuleID:    finding.Rule,
+			Level:     sarifLevel(finding.Severity),
+			Message:   sarifMessage{Text: fmt.Sprintf("%s: %s", finding.Title, finding.Message)},
+			Locations: []sarifLocation{location},
+		})
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(sarifReport{
+		Version: "2.1.0",
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Runs: []sarifRun{{
+			Tool: sarifTool{Driver: sarifDriver{
+				Name:           "ptah lint",
+				InformationURI: "https://github.com/stokaro/ptah",
+				Rules:          rules,
+			}},
+			Results: results,
+		}},
+	})
+}
+
+func sarifRules(findings []lint.Finding) []sarifRule {
+	byCode := make(map[string]lint.Finding)
+	for _, finding := range findings {
+		if _, ok := byCode[finding.Rule]; !ok {
+			byCode[finding.Rule] = finding
+		}
+	}
+	codes := make([]string, 0, len(byCode))
+	for code := range byCode {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	rules := make([]sarifRule, 0, len(codes))
+	for _, code := range codes {
+		finding := byCode[code]
+		rules = append(rules, sarifRule{
+			ID:               code,
+			Name:             finding.Title,
+			ShortDescription: sarifMessage{Text: finding.Title},
+			DefaultConfig:    sarifDefaultConfig{Level: sarifLevel(finding.Severity)},
+		})
+	}
+	return rules
+}
+
+func sarifLevel(severity lint.Severity) string {
+	return risk.SARIFLevel(severity)
 }
 
 func writeText(w io.Writer, report lintReport) {
@@ -299,10 +430,10 @@ func writeError(w io.Writer, format, failOn, msg string) error {
 
 func validateFormat(format string) error {
 	switch format {
-	case formatText, formatJSON, formatGitHubActions:
+	case formatText, formatJSON, formatGitHubActions, formatSARIF:
 		return nil
 	default:
-		return fmt.Errorf("invalid --format value %q: expected text, json, or github-actions", format)
+		return fmt.Errorf("invalid --format value %q: expected text, json, github-actions, or sarif", format)
 	}
 }
 
@@ -319,12 +450,12 @@ func validateDialect(dialect string) error {
 	if isValidDialect(dialect) {
 		return nil
 	}
-	return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, or mariadb", dialect)
+	return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, mariadb, clickhouse, cockroachdb, yugabytedb, or spanner", dialect)
 }
 
 func isValidDialect(dialect string) bool {
 	switch dialect {
-	case "", "postgres", "mysql", "mariadb":
+	case "", "postgres", "mysql", "mariadb", "clickhouse", "cockroachdb", "yugabytedb", "spanner":
 		return true
 	default:
 		return false

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -3,6 +3,8 @@ package lint
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -69,6 +71,70 @@ func TestRunLint_GitHubActionsFormatAnnotatesFileAndLine(t *testing.T) {
 	c.Assert(stderr, qt.Contains, "::warning file=testdata/bad/misnamed.sql::MF103:")
 }
 
+func TestRunLint_SARIFFormat(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, _, err := execute("--dir", "testdata/bad", "--format", "sarif", "--fail-on", "none")
+
+	c.Assert(err, qt.IsNil)
+	var report struct {
+		Version string `json:"version"`
+		Runs    []struct {
+			Tool struct {
+				Driver struct {
+					Name  string `json:"name"`
+					Rules []struct {
+						ID string `json:"id"`
+					} `json:"rules"`
+				} `json:"driver"`
+			} `json:"tool"`
+			Results []struct {
+				RuleID    string `json:"ruleId"`
+				Level     string `json:"level"`
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+						Region struct {
+							StartLine int `json:"startLine"`
+						} `json:"region"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
+	c.Assert(report.Version, qt.Equals, "2.1.0")
+	c.Assert(report.Runs, qt.HasLen, 1)
+	c.Assert(report.Runs[0].Tool.Driver.Name, qt.Equals, "ptah lint")
+	c.Assert(report.Runs[0].Tool.Driver.Rules[0].ID, qt.Not(qt.Equals), "")
+	var dropTableResult struct {
+		RuleID    string `json:"ruleId"`
+		Level     string `json:"level"`
+		Locations []struct {
+			PhysicalLocation struct {
+				ArtifactLocation struct {
+					URI string `json:"uri"`
+				} `json:"artifactLocation"`
+				Region struct {
+					StartLine int `json:"startLine"`
+				} `json:"region"`
+			} `json:"physicalLocation"`
+		} `json:"locations"`
+	}
+	for _, result := range report.Runs[0].Results {
+		if result.RuleID == "DS101" {
+			dropTableResult = result
+			break
+		}
+	}
+	c.Assert(dropTableResult.RuleID, qt.Equals, "DS101")
+	c.Assert(dropTableResult.Level, qt.Equals, "error")
+	c.Assert(dropTableResult.Locations[0].PhysicalLocation.ArtifactLocation.URI, qt.Contains, "testdata/bad/")
+	c.Assert(dropTableResult.Locations[0].PhysicalLocation.Region.StartLine, qt.Equals, 2)
+}
+
 func TestRunLint_ConfigFileDisablesRulesAndSetsDialect(t *testing.T) {
 	c := qt.New(t)
 
@@ -91,6 +157,38 @@ func TestRunLint_ConfigFileDisablesRulesAndSetsDialect(t *testing.T) {
 		c.Assert(f.Rule, qt.Not(qt.Equals), "MY101",
 			qt.Commentf("dialect: postgres from the config must gate MY rules; got %v", f))
 	}
+}
+
+func TestRunLint_ConfigRuleSeverityAndExclude(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	write := func(name, content string) {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		c.Assert(os.MkdirAll(filepath.Dir(path), 0o750), qt.IsNil)
+		c.Assert(os.WriteFile(path, []byte(content), 0o600), qt.IsNil)
+	}
+	write(lint.ConfigFileName, `rules:
+  DS102:
+    severity: warning
+    exclude:
+      - legacy/**
+`)
+	write("legacy/0000000001_legacy.up.sql", "ALTER TABLE users DROP COLUMN old_legacy;\n")
+	write("legacy/0000000001_legacy.down.sql", "ALTER TABLE users ADD COLUMN old_legacy TEXT;\n")
+	write("main/0000000002_main.up.sql", "ALTER TABLE users DROP COLUMN old_main;\n")
+	write("main/0000000002_main.down.sql", "ALTER TABLE users ADD COLUMN old_main TEXT;\n")
+
+	stdout, _, err := execute("--dir", dir, "--format", "json")
+
+	c.Assert(err, qt.IsNil)
+	var report struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
+	c.Assert(report.Findings, qt.HasLen, 1)
+	c.Assert(report.Findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(report.Findings[0].Severity, qt.Equals, lint.SeverityWarning)
+	c.Assert(report.Findings[0].File, qt.Contains, "main/0000000002_main.up.sql")
 }
 
 func TestRunLint_FailOnThresholds(t *testing.T) {
@@ -127,6 +225,12 @@ func TestRunLint_InvalidFlagValuesExitCode2(t *testing.T) {
 	_, stderr, err = execute("--dir", "testdata/bad", "--dialect", "oracle")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(stderr, qt.Contains, "invalid --dialect")
+	c.Assert(stderr, qt.Contains, "clickhouse")
+	c.Assert(stderr, qt.Contains, "spanner")
+
+	stdout, _, err := execute("--dir", "testdata/clean", "--dialect", "clickhouse")
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "No lint findings.")
 
 	_, stderr, err = execute("--dir", "testdata/does-not-exist")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -44,7 +44,7 @@ and performs an up/down/up round-trip.`,
 	flags.String(generateShadowDBFlag, "", "Shadow database URL used to verify generated migrations before writing files")
 	flags.Bool(generateCheckDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
 	flags.Bool(generateAllowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
-	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "" or html`)
+	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "", html, or json`)
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
 	flags.String(dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String(), "Initial database connection timeout")
 	flags.String(dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -66,7 +67,7 @@ func newMigrateFlags() map[string]cobraflags.Flag {
 		reportFormatFlag: &cobraflags.StringFlag{
 			Name:  reportFormatFlag,
 			Value: "text",
-			Usage: "Safety report format: text or html",
+			Usage: "Safety report format: text, html, or json",
 		},
 		dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 		dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
@@ -116,10 +117,10 @@ func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Fla
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
-	if reportFormat != "text" && reportFormat != "html" {
+	if reportFormat != "text" && reportFormat != "html" && reportFormat != "json" {
 		return fmt.Errorf("unsupported report format %q", reportFormat)
 	}
-	if reportFormat != "html" {
+	if reportFormat == "text" {
 		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootDir, dbschema.FormatDatabaseURL(dbURL))
 		fmt.Fprintln(out, "=== GENERATE MIGRATION SQL ===")
 		fmt.Fprintln(out)
@@ -166,8 +167,8 @@ func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Fla
 	if err != nil {
 		return fmt.Errorf("error assessing migration safety: %w", err)
 	}
-	if reportFormat == "html" {
-		if err := safety.RenderHTML(out, assessments); err != nil {
+	if reportFormat == "html" || reportFormat == "json" {
+		if err := renderSafetyReport(out, reportFormat, assessments); err != nil {
 			return fmt.Errorf("error rendering safety report: %w", err)
 		}
 		if checkDestructive && safety.HasDestructiveAssessment(assessments) && !allowDestructive {
@@ -176,7 +177,7 @@ func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Fla
 		return nil
 	}
 	fmt.Fprint(out, astNodes)
-	if err := safety.RenderText(out, assessments); err != nil {
+	if err := renderSafetyReport(out, reportFormat, assessments); err != nil {
 		return fmt.Errorf("error rendering safety report: %w", err)
 	}
 	if checkDestructive && safety.HasDestructiveAssessment(assessments) && !allowDestructive {
@@ -211,4 +212,17 @@ func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Fla
 	fmt.Fprintln(out, "⚠️  Review the SQL carefully before executing!")
 
 	return nil
+}
+
+func renderSafetyReport(w io.Writer, format string, assessments []safety.StatementAssessment) error {
+	switch format {
+	case "text":
+		return safety.RenderText(w, assessments)
+	case "html":
+		return safety.RenderHTML(w, assessments)
+	case "json":
+		return safety.RenderJSON(w, assessments)
+	default:
+		return fmt.Errorf("unsupported report format %q", format)
+	}
 }

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -1,0 +1,35 @@
+package migrate
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+func TestRenderSafetyReportJSON(t *testing.T) {
+	c := qt.New(t)
+
+	var out bytes.Buffer
+	assessments := []safety.StatementAssessment{{
+		Index:     1,
+		NodeType:  "sql",
+		Statement: "DROP TABLE users",
+		Severity:  safety.Destructive,
+		Reason:    "drops a table",
+	}}
+
+	err := renderSafetyReport(&out, "json", assessments)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Not(qt.Contains), "Safety Assessment")
+
+	var report safety.Report
+	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil)
+	c.Assert(report.Highest, qt.Equals, safety.Destructive)
+	c.Assert(report.Destructive, qt.IsTrue)
+	c.Assert(report.Assessments, qt.DeepEquals, assessments)
+}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/onlineddl"
+	"github.com/stokaro/ptah/migration/risk"
 )
 
 var migrateUpCmd = &cobra.Command{
@@ -356,17 +357,22 @@ func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder
 }
 
 func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint.Finding, error) {
+	cfg, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
+	if err != nil {
+		return nil, err
+	}
 	findings, err := lint.LintFS(fsys, lint.Options{
-		Dialect:  dialect,
-		Disabled: []string{"MF", "BC", "PG", "MY"},
-		Versions: pending,
+		Dialect:     dialect,
+		Disabled:    append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
+		Versions:    pending,
+		RuleConfigs: cfg.Rules,
 	})
 	if err != nil {
 		return nil, err
 	}
 	var destructive []lint.Finding
 	for _, finding := range findings {
-		if strings.HasPrefix(finding.Rule, "DS") {
+		if strings.HasPrefix(finding.Rule, "DS") && risk.IsBlocking(finding.Severity) {
 			destructive = append(destructive, finding)
 		}
 	}

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -9,6 +9,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -76,6 +77,41 @@ ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
 	c.Assert(findings, qt.HasLen, 5)
 	c.Assert([]string{findings[0].Rule, findings[1].Rule, findings[2].Rule, findings[3].Rule, findings[4].Rule}, qt.DeepEquals, []string{"DS102", "DS107", "DS107", "DS108", "DS109"})
 	c.Assert(findings[0].File, qt.Equals, "0000000002_next.up.sql")
+}
+
+func TestLintPendingDestructiveHonorsLintConfigSeverityAndDisable(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: &fstest.MapFile{Data: []byte(`disabled-rules:
+  - DS102
+rules:
+  DS103:
+    severity: warning
+`)},
+		"0000000001_change_type.up.sql": &fstest.MapFile{
+			Data: []byte("ALTER TABLE users ALTER COLUMN email TYPE VARCHAR(512);\n"),
+		},
+		"0000000001_change_type.down.sql": &fstest.MapFile{Data: []byte("-- restore\n")},
+		"0000000002_drop_column.up.sql": &fstest.MapFile{
+			Data: []byte("ALTER TABLE users DROP COLUMN legacy;\n"),
+		},
+		"0000000002_drop_column.down.sql": &fstest.MapFile{Data: []byte("-- restore\n")},
+		"0000000003_drop_table.up.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE audit_log;\n"),
+		},
+		"0000000003_drop_table.down.sql": &fstest.MapFile{Data: []byte("-- restore\n")},
+	}
+
+	findings, err := lintPendingDestructive(fsys, []int64{1, 2}, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0,
+		qt.Commentf("DS103 is warning-grade and DS102 is disabled by config"))
+
+	findings, err = lintPendingDestructive(fsys, []int64{1, 2, 3}, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
 }
 
 func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing.T) {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -312,10 +312,23 @@ func checkDestructiveAllowed(opts GenerateMigrationOptions, assessments []safety
 }
 
 func createSafetyReportFile(upFile, format string, assessments []safety.StatementAssessment) (string, error) {
-	if !strings.EqualFold(format, "html") {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "html":
+		reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.html"
+		return writeSafetyReportFile(reportFile, func(file *os.File) error {
+			return safety.RenderHTML(file, assessments)
+		})
+	case "json":
+		reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.json"
+		return writeSafetyReportFile(reportFile, func(file *os.File) error {
+			return safety.RenderJSON(file, assessments)
+		})
+	default:
 		return "", fmt.Errorf("unsupported safety report format %q", format)
 	}
-	reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.html"
+}
+
+func writeSafetyReportFile(reportFile string, render func(*os.File) error) (string, error) {
 	file, err := os.Create(reportFile)
 	if err != nil {
 		return "", err
@@ -325,7 +338,7 @@ func createSafetyReportFile(upFile, format string, assessments []safety.Statemen
 			slog.Warn("failed to close safety report", "path", reportFile, "error", closeErr)
 		}
 	}()
-	if err := safety.RenderHTML(file, assessments); err != nil {
+	if err := render(file); err != nil {
 		return "", err
 	}
 	return reportFile, nil

--- a/migration/generator/safety_test.go
+++ b/migration/generator/safety_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,17 @@ func TestCreateSafetyReportFile(t *testing.T) {
 	c.Assert(string(content), qt.Contains, "DROP TABLE legacy;")
 	c.Assert(string(content), qt.Contains, "destructive")
 
-	_, err = createSafetyReportFile(upFile, "json", nil)
-	c.Assert(err, qt.ErrorMatches, `unsupported safety report format "json"`)
+	jsonReportFile, err := createSafetyReportFile(upFile, "json", []safety.StatementAssessment{{
+		Index:    1,
+		Severity: safety.Destructive,
+		Reason:   "DROP TABLE removes the table and all rows",
+	}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(jsonReportFile, qt.Equals, filepath.Join(dir, "1234567890_drop_legacy.safety.json"))
+	rawJSON, err := os.ReadFile(jsonReportFile)
+	c.Assert(err, qt.IsNil)
+	var report safety.Report
+	c.Assert(json.Unmarshal(rawJSON, &report), qt.IsNil)
+	c.Assert(report.Highest, qt.Equals, safety.Destructive)
+	c.Assert(report.Destructive, qt.IsTrue)
 }

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -22,6 +22,40 @@ import (
 
 var missingColumnErrorRe = regexp.MustCompile(`column "([^"]+)" of relation "([^"]+)" does not exist`)
 
+// ShadowVerificationResult is a structured shadow-database verification
+// outcome. Errors preserve the historical text form through
+// ShadowVerificationError.Error while exposing mismatches to callers that need
+// machine-readable diagnostics.
+type ShadowVerificationResult struct {
+	Stage      string           `json:"stage"`
+	Success    bool             `json:"success"`
+	Mismatches []ShadowMismatch `json:"mismatches,omitempty"`
+}
+
+// ShadowMismatch describes one schema mismatch found during shadow
+// verification.
+type ShadowMismatch struct {
+	Kind       string            `json:"kind"`
+	Object     string            `json:"object,omitempty"`
+	Table      string            `json:"table,omitempty"`
+	Column     string            `json:"column,omitempty"`
+	Constraint string            `json:"constraint,omitempty"`
+	Changes    map[string]string `json:"changes,omitempty"`
+	Message    string            `json:"message"`
+}
+
+// ShadowVerificationError wraps a structured shadow verification result.
+type ShadowVerificationError struct {
+	Result ShadowVerificationResult `json:"result"`
+}
+
+func (e *ShadowVerificationError) Error() string {
+	if len(e.Result.Mismatches) > 0 {
+		return "shadow check failed: " + e.Result.Mismatches[0].Message
+	}
+	return "shadow check failed: schema differs"
+}
+
 type shadowMigrationOptions struct {
 	DatabaseURL   string
 	MigrationsDir string
@@ -139,68 +173,87 @@ func assertShadowSchemaMatches(conn *dbschema.DatabaseConnection, opts shadowMig
 	if !diff.HasChanges() {
 		return nil
 	}
-	return fmt.Errorf("shadow check failed: %s", describeShadowDiff(diff))
+	return &ShadowVerificationError{Result: ShadowVerificationResult{
+		Stage:      "schema-match",
+		Success:    false,
+		Mismatches: collectShadowMismatches(diff),
+	}}
 }
 
 func describeShadowDiff(diff *types.SchemaDiff) string {
+	mismatches := collectShadowMismatches(diff)
+	if len(mismatches) > 0 {
+		return mismatches[0].Message
+	}
+	return "schema differs"
+}
+
+func collectShadowMismatches(diff *types.SchemaDiff) []ShadowMismatch {
 	if diff == nil {
-		return "schema differs"
+		return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
 	}
 
 	for _, tableName := range sortedStrings(diff.TablesAdded) {
-		return "missing table " + tableName
+		return []ShadowMismatch{{Kind: "missing_table", Table: tableName, Object: tableName, Message: "missing table " + tableName}}
 	}
 	for _, table := range sortedTableDiffs(diff.TablesModified) {
 		for _, columnName := range sortedStrings(table.ColumnsAdded) {
-			return fmt.Sprintf("missing column %s.%s", table.TableName, columnName)
+			message := fmt.Sprintf("missing column %s.%s", table.TableName, columnName)
+			return []ShadowMismatch{{Kind: "missing_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message}}
 		}
 		for _, constraintName := range sortedStrings(table.ConstraintsAdded) {
-			return fmt.Sprintf("missing constraint %s.%s", table.TableName, constraintName)
+			message := fmt.Sprintf("missing constraint %s.%s", table.TableName, constraintName)
+			return []ShadowMismatch{{Kind: "missing_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message}}
 		}
 		for _, column := range sortedColumnDiffs(table.ColumnsModified) {
-			return fmt.Sprintf("column mismatch %s.%s: %s", table.TableName, column.ColumnName, describeChanges(column.Changes))
+			message := fmt.Sprintf("column mismatch %s.%s: %s", table.TableName, column.ColumnName, describeChanges(column.Changes))
+			return []ShadowMismatch{{Kind: "column_mismatch", Table: table.TableName, Column: column.ColumnName, Object: table.TableName + "." + column.ColumnName, Changes: column.Changes, Message: message}}
 		}
 		for _, columnName := range sortedStrings(table.ColumnsRemoved) {
-			return fmt.Sprintf("extra column %s.%s", table.TableName, columnName)
+			message := fmt.Sprintf("extra column %s.%s", table.TableName, columnName)
+			return []ShadowMismatch{{Kind: "extra_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message}}
 		}
 		for _, constraintName := range sortedStrings(table.ConstraintsRemoved) {
-			return fmt.Sprintf("extra constraint %s.%s", table.TableName, constraintName)
+			message := fmt.Sprintf("extra constraint %s.%s", table.TableName, constraintName)
+			return []ShadowMismatch{{Kind: "extra_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message}}
 		}
 	}
 	for _, enumName := range sortedStrings(diff.EnumsAdded) {
-		return "missing enum " + enumName
+		return []ShadowMismatch{{Kind: "missing_enum", Object: enumName, Message: "missing enum " + enumName}}
 	}
 	for _, enum := range sortedEnumDiffs(diff.EnumsModified) {
 		for _, value := range sortedStrings(enum.ValuesAdded) {
-			return fmt.Sprintf("missing enum value %s.%s", enum.EnumName, value)
+			message := fmt.Sprintf("missing enum value %s.%s", enum.EnumName, value)
+			return []ShadowMismatch{{Kind: "missing_enum_value", Object: enum.EnumName + "." + value, Message: message}}
 		}
 		for _, value := range sortedStrings(enum.ValuesRemoved) {
-			return fmt.Sprintf("extra enum value %s.%s", enum.EnumName, value)
+			message := fmt.Sprintf("extra enum value %s.%s", enum.EnumName, value)
+			return []ShadowMismatch{{Kind: "extra_enum_value", Object: enum.EnumName + "." + value, Message: message}}
 		}
 	}
 	for _, indexName := range sortedStrings(diff.IndexesAdded) {
-		return "missing index " + indexName
+		return []ShadowMismatch{{Kind: "missing_index", Object: indexName, Message: "missing index " + indexName}}
 	}
 	for _, extensionName := range sortedStrings(diff.ExtensionsAdded) {
-		return "missing extension " + extensionName
+		return []ShadowMismatch{{Kind: "missing_extension", Object: extensionName, Message: "missing extension " + extensionName}}
 	}
 	for _, functionName := range sortedStrings(diff.FunctionsAdded) {
-		return "missing function " + functionName
+		return []ShadowMismatch{{Kind: "missing_function", Object: functionName, Message: "missing function " + functionName}}
 	}
 	for _, policyName := range sortedStrings(diff.RLSPoliciesAdded) {
-		return "missing RLS policy " + policyName
+		return []ShadowMismatch{{Kind: "missing_rls_policy", Object: policyName, Message: "missing RLS policy " + policyName}}
 	}
 	for _, tableName := range sortedStrings(diff.RLSEnabledTablesAdded) {
-		return "missing RLS enablement " + tableName
+		return []ShadowMismatch{{Kind: "missing_rls_enablement", Table: tableName, Object: tableName, Message: "missing RLS enablement " + tableName}}
 	}
 	for _, roleName := range sortedStrings(diff.RolesAdded) {
-		return "missing role " + roleName
+		return []ShadowMismatch{{Kind: "missing_role", Object: roleName, Message: "missing role " + roleName}}
 	}
 	for _, constraintName := range sortedStrings(diff.ConstraintsAdded) {
-		return "missing constraint " + constraintName
+		return []ShadowMismatch{{Kind: "missing_constraint", Constraint: constraintName, Object: constraintName, Message: "missing constraint " + constraintName}}
 	}
 
-	return "schema differs"
+	return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
 }
 
 func sortedStrings(values []string) []string {

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -27,6 +27,16 @@ func TestDescribeShadowDiffMissingColumn(t *testing.T) {
 	}
 
 	c.Assert(describeShadowDiff(diff), qt.Equals, "missing column users.email")
+	mismatches := collectShadowMismatches(diff)
+	c.Assert(mismatches, qt.HasLen, 1)
+	c.Assert(mismatches[0].Kind, qt.Equals, "missing_column")
+	c.Assert(mismatches[0].Table, qt.Equals, "users")
+	c.Assert(mismatches[0].Column, qt.Equals, "email")
+	c.Assert((&ShadowVerificationError{Result: ShadowVerificationResult{
+		Stage:      "schema-match",
+		Success:    false,
+		Mismatches: mismatches,
+	}}).Error(), qt.Equals, "shadow check failed: missing column users.email")
 }
 
 func TestDescribeChangesIsDeterministic(t *testing.T) {

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -22,6 +22,11 @@ const ConfigFileName = ".ptah-lint.yaml"
 //	disabled-rules:
 //	  - MF103
 //	  - MY
+//	rules:
+//	  DS103:
+//	    severity: warning
+//	    exclude:
+//	      - legacy/**
 type Config struct {
 	// Dialect is the target dialect used to gate dialect-specific rules;
 	// the --dialect flag overrides it.
@@ -29,6 +34,8 @@ type Config struct {
 	// DisabledRules lists rule codes or family prefixes to skip; merged
 	// with --disable flags.
 	DisabledRules []string `yaml:"disabled-rules"`
+	// Rules carries per-rule severity and path-scope overrides.
+	Rules map[string]RuleConfig `yaml:"rules"`
 }
 
 // LoadConfig reads a lint configuration file. A missing file at the
@@ -42,9 +49,44 @@ func LoadConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read lint config %s: %w", path, err)
 	}
+	cfg, err := parseConfig(raw, path)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// LoadConfigFS reads a lint configuration from fsys. A missing file is not an
+// error, matching LoadConfig's conventional-file behavior.
+func LoadConfigFS(fsys fs.FS, name string) (*Config, error) {
+	raw, err := fs.ReadFile(fsys, name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read lint config %s: %w", name, err)
+	}
+	return parseConfig(raw, name)
+}
+
+func parseConfig(raw []byte, name string) (*Config, error) {
 	var cfg Config
 	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse lint config %s: %w", path, err)
+		return nil, fmt.Errorf("failed to parse lint config %s: %w", name, err)
+	}
+	if err := validateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse lint config %s: %w", name, err)
 	}
 	return &cfg, nil
+}
+
+func validateConfig(cfg Config) error {
+	for code, rule := range cfg.Rules {
+		switch rule.Severity {
+		case "", SeverityWarning, SeverityError:
+		default:
+			return fmt.Errorf("rule %s has unsupported severity %q", code, rule.Severity)
+		}
+	}
+	return nil
 }

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -16,16 +16,13 @@
 // string literals, quoted identifiers, comments (including the MySQL-family
 // # line comments and /*!...*/ executable comments) and PostgreSQL
 // dollar-quoted bodies never confuse the splitter, and Options.Dialect
-// selects which of those syntaxes apply. Every statement is then checked in
-// two complementary forms:
+// selects which of those syntaxes apply. Every statement is then checked through
+// the token form exposed to rules:
 //
-//   - Statement.Words — the token-word sequence the built-in rules scan,
+//   - Statement.Words — the token-word sequence rules scan,
 //     anchored at ALTER TABLE clause boundaries; string literals and quoted
 //     identifiers stay opaque single words, so data or a column named like a
-//     keyword can neither trigger nor mask a rule;
-//   - a best-effort AST (Statement.Node) parsed with core/parser for the
-//     statements it supports, available to rules that want structural
-//     precision.
+//     keyword can neither trigger nor mask a rule.
 //
 // Statement-level rules run on up migrations only: a down migration dropping
 // what its up created is the expected shape, not a hazard. File-level form
@@ -41,20 +38,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/stokaro/ptah/core/ast"
-	"github.com/stokaro/ptah/core/parser"
 	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/risk"
 )
 
 // Severity is the urgency of a finding.
-type Severity string
+type Severity = risk.Severity
 
 const (
 	// SeverityWarning marks patterns that deserve review before a prod
 	// rollout but are not necessarily destructive.
-	SeverityWarning Severity = "warning"
+	SeverityWarning Severity = risk.Warning
 	// SeverityError marks patterns that destroy data or database objects.
-	SeverityError Severity = "error"
+	SeverityError Severity = risk.Error
 )
 
 // Finding is one rule hit in one migration file.
@@ -83,12 +79,11 @@ type Statement struct {
 	// as single opaque words (so a literal containing "DROP COLUMN" or a
 	// column named "type" can never impersonate a keyword).
 	Words []string
-	// Node is the best-effort parse of the statement into ptah's DDL AST;
-	// nil when the statement is outside the parser's supported subset.
-	// Word-scan rules must not rely on it.
-	Node ast.Node
 	// Line is the 1-based line number of the statement's first token.
 	Line int
+	// SuppressedRules lists rule codes or families suppressed by a leading
+	// ptah:nolint or atlas:nolint directive.
+	SuppressedRules []string
 }
 
 // File is one migration file prepared for linting.
@@ -140,6 +135,14 @@ type Rule struct {
 	CheckFile func(file *File) []Finding
 }
 
+// RuleConfig customizes one rule for a lint run.
+type RuleConfig struct {
+	// Severity overrides the rule's default severity when set.
+	Severity Severity `yaml:"severity,omitempty"`
+	// Exclude lists slash-separated path globs where this rule is skipped.
+	Exclude []string `yaml:"exclude,omitempty"`
+}
+
 // Options configures a lint run.
 type Options struct {
 	// Dialect gates dialect-specific rules — "postgres" enables PG rules,
@@ -160,6 +163,13 @@ type Options struct {
 	// AtlasTemplateData supplies data for Atlas SQL template migrations.
 	// When nil, templates render with migrator.AtlasTemplateData{}.
 	AtlasTemplateData any
+	// ExtraRules appends caller-provided rules to the built-in registry for
+	// this run. It is the preferred API for out-of-tree analyzers that should
+	// not mutate global process state.
+	ExtraRules []Rule
+	// RuleConfigs carries per-rule severity and path-scoping overrides,
+	// normally loaded from .ptah-lint.yaml.
+	RuleConfigs map[string]RuleConfig
 }
 
 // LintFS lints every *.sql file under fsys — recursively, because the
@@ -168,6 +178,35 @@ type Options struct {
 // suffix is matched case-insensitively so that stray case variants (x.UP.SQL)
 // at least earn a naming warning instead of vanishing.
 func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
+	if err := validateRules(rulesForOptions(opts)); err != nil {
+		return nil, err
+	}
+	files, err := PrepareFS(fsys, opts)
+	if err != nil {
+		return nil, err
+	}
+	var findings []Finding
+	for _, file := range files {
+		findings = append(findings, runRules(file, opts)...)
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Rule < findings[j].Rule
+	})
+	return findings, nil
+}
+
+// PrepareFS loads and tokenizes every migration file under fsys using the
+// same dialect-aware scanner and naming rules as LintFS. Custom analyzer
+// packages can call this when they need Ptah-prepared File and Statement
+// values without reimplementing the scanner.
+func PrepareFS(fsys fs.FS, opts Options) ([]*File, error) {
 	var names []string
 	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -213,25 +252,15 @@ func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
 	}
 
 	mode := modeForDialect(opts.Dialect)
-	var findings []Finding
+	files := make([]*File, 0, len(names))
 	for _, name := range names {
 		file, err := prepareFile(fsys, name, present, versionDirs, opts.PathPrefix, mode, opts.AtlasTemplateData)
 		if err != nil {
 			return nil, err
 		}
-		findings = append(findings, runRules(file, opts)...)
+		files = append(files, file)
 	}
-
-	sort.SliceStable(findings, func(i, j int) bool {
-		if findings[i].File != findings[j].File {
-			return findings[i].File < findings[j].File
-		}
-		if findings[i].Line != findings[j].Line {
-			return findings[i].Line < findings[j].Line
-		}
-		return findings[i].Rule < findings[j].Rule
-	})
-	return findings, nil
+	return files, nil
 }
 
 func filterNamesByVersion(names []string, versions []int64) []string {
@@ -370,11 +399,11 @@ func prepareFile(
 		}
 		for _, rawStmt := range splitStatementsWithLines(sql, mode) {
 			file.Statements = append(file.Statements, Statement{
-				SQL:       rawStmt.text,
-				Canonical: canonicalize(rawStmt.text, mode),
-				Words:     tokenizeWords(rawStmt.text, mode),
-				Node:      parseBestEffort(rawStmt.text),
-				Line:      rawStmt.line,
+				SQL:             rawStmt.text,
+				Canonical:       canonicalize(rawStmt.text, mode),
+				Words:           tokenizeWords(rawStmt.text, mode),
+				Line:            rawStmt.line,
+				SuppressedRules: rawStmt.suppressedRules,
 			})
 		}
 	}
@@ -403,20 +432,30 @@ func fileNoTransactionDirective(sql string) bool {
 // runRules applies every enabled rule to one prepared file.
 func runRules(file *File, opts Options) []Finding {
 	var findings []Finding
-	for _, rule := range Rules() {
-		if ruleDisabled(rule.Code, opts.Disabled) || !ruleAppliesToDialect(rule, opts.Dialect) {
+	for _, rule := range rulesForOptions(opts) {
+		if ruleDisabled(rule.Code, opts.Disabled) || !ruleAppliesToDialect(rule, opts.Dialect) || ruleExcludedForFile(rule.Code, file, opts.RuleConfigs) {
 			continue
 		}
+		severity := ruleSeverity(rule, opts.RuleConfigs)
 		if rule.CheckFile != nil {
-			findings = append(findings, rule.CheckFile(file)...)
+			for _, finding := range rule.CheckFile(file) {
+				if fileFindingSuppressed(file, finding) {
+					continue
+				}
+				finding.Severity = severity
+				findings = append(findings, finding)
+			}
 			continue
 		}
 		for i := range file.Statements {
+			if statementSuppressesRule(&file.Statements[i], rule.Code) {
+				continue
+			}
 			if hit, message := rule.CheckStatement(&file.Statements[i]); hit {
 				findings = append(findings, Finding{
 					Rule:     rule.Code,
 					Title:    rule.Title,
-					Severity: rule.Severity,
+					Severity: severity,
 					File:     file.Path,
 					Line:     file.Statements[i].Line,
 					Message:  message,
@@ -425,6 +464,88 @@ func runRules(file *File, opts Options) []Finding {
 		}
 	}
 	return findings
+}
+
+func rulesForOptions(opts Options) []Rule {
+	rules := Rules()
+	return append(rules, opts.ExtraRules...)
+}
+
+func ruleSeverity(rule Rule, configs map[string]RuleConfig) Severity {
+	config, ok := configs[rule.Code]
+	if !ok || config.Severity == "" {
+		return rule.Severity
+	}
+	return config.Severity
+}
+
+func ruleExcludedForFile(code string, file *File, configs map[string]RuleConfig) bool {
+	config, ok := configs[code]
+	if !ok {
+		return false
+	}
+	for _, pattern := range config.Exclude {
+		if pathGlobMatches(pattern, file.Name) || pathGlobMatches(pattern, file.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func statementSuppressesRule(stmt *Statement, code string) bool {
+	for _, entry := range stmt.SuppressedRules {
+		if entry == "*" || strings.HasPrefix(code, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func fileFindingSuppressed(file *File, finding Finding) bool {
+	if finding.Line == 0 {
+		return false
+	}
+	for i := range file.Statements {
+		stmt := &file.Statements[i]
+		if stmt.Line == finding.Line && statementSuppressesRule(stmt, finding.Rule) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathGlobMatches(pattern, value string) bool {
+	pattern = path.Clean(strings.TrimSpace(pattern))
+	value = path.Clean(value)
+	if pattern == "." || value == "." {
+		return false
+	}
+	if ok, err := path.Match(pattern, value); err == nil && ok {
+		return true
+	}
+	return matchGlobSegments(strings.Split(pattern, "/"), strings.Split(value, "/"))
+}
+
+func matchGlobSegments(pattern, value []string) bool {
+	if len(pattern) == 0 {
+		return len(value) == 0
+	}
+	if pattern[0] == "**" {
+		for i := 0; i <= len(value); i++ {
+			if matchGlobSegments(pattern[1:], value[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(value) == 0 {
+		return false
+	}
+	ok, err := path.Match(pattern[0], value[0])
+	if err != nil || !ok {
+		return false
+	}
+	return matchGlobSegments(pattern[1:], value[1:])
 }
 
 // ruleDisabled reports whether code matches any disabled entry — exact code
@@ -458,8 +579,9 @@ var strictNameRe = regexp.MustCompile(`^\d{10}_.+\.(up|down)\.sql$`)
 
 // rawStatement is one raw SQL statement plus the line it starts on.
 type rawStatement struct {
-	text string
-	line int
+	text            string
+	line            int
+	suppressedRules []string
 }
 
 // splitStatementsWithLines splits SQL into statements using the dialect-aware
@@ -471,28 +593,73 @@ func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
 	start := -1
 	end := 0
 	startLine := 0
+	lastStatementEndLine := 0
+	var pendingSuppressions []string
+	var activeSuppressions []string
 	for _, tok := range scanSQL(raw, mode) {
 		switch tok.kind {
 		case tokSemicolon:
 			if start >= 0 {
-				statements = append(statements, rawStatement{text: raw[start:end], line: startLine})
+				statements = append(statements, rawStatement{text: raw[start:end], line: startLine, suppressedRules: activeSuppressions})
 				start = -1
+				activeSuppressions = nil
+				lastStatementEndLine = tok.line
 			}
-		case tokWhitespace, tokComment:
+		case tokWhitespace:
 			// Never starts a statement; keep end untouched so trailing
 			// comments/whitespace are not included in the statement text.
+		case tokComment:
+			if start < 0 && tok.line != lastStatementEndLine {
+				pendingSuppressions = append(pendingSuppressions, parseNoLintDirective(tok.text)...)
+			}
 		default:
 			if start < 0 {
 				start = tok.start
 				startLine = tok.line
+				activeSuppressions = append([]string(nil), pendingSuppressions...)
+				pendingSuppressions = nil
 			}
 			end = tok.end
 		}
 	}
 	if start >= 0 {
-		statements = append(statements, rawStatement{text: raw[start:end], line: startLine})
+		statements = append(statements, rawStatement{text: raw[start:end], line: startLine, suppressedRules: activeSuppressions})
 	}
 	return statements
+}
+
+func parseNoLintDirective(comment string) []string {
+	trimmed := strings.TrimSpace(comment)
+	if !strings.HasPrefix(trimmed, "--") && !strings.HasPrefix(trimmed, "#") {
+		return nil
+	}
+	lower := strings.ToLower(comment)
+	idx := strings.Index(lower, "ptah:nolint")
+	markerLen := len("ptah:nolint")
+	if idx < 0 {
+		idx = strings.Index(lower, "atlas:nolint")
+		markerLen = len("atlas:nolint")
+	}
+	if idx < 0 {
+		return nil
+	}
+	rest := strings.TrimSpace(comment[idx+markerLen:])
+	if rest == "" {
+		return []string{"*"}
+	}
+	parts := strings.FieldsFunc(rest, isNoLintSeparator)
+	rules := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.ToUpper(strings.TrimSpace(part))
+		if part != "" {
+			rules = append(rules, part)
+		}
+	}
+	return rules
+}
+
+func isNoLintSeparator(r rune) bool {
+	return strings.ContainsRune(",;:/*)([]{}\"'` \t\r\n", r)
 }
 
 // canonicalize renders a statement in its display form: comments removed,
@@ -540,14 +707,4 @@ func tokenizeWords(sql string, mode scanMode) []string {
 		}
 	}
 	return words
-}
-
-// parseBestEffort parses a statement into ptah's DDL AST when it falls inside
-// the parser's supported subset, and returns nil otherwise.
-func parseBestEffort(sql string) ast.Node {
-	statements, err := parser.NewParser(sql).Parse()
-	if err != nil || statements == nil || len(statements.Statements) != 1 {
-		return nil
-	}
-	return statements.Statements[0]
 }

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -695,6 +695,115 @@ ALTER TABLE users MODIFY COLUMN email VARCHAR(64);
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101", "DS103", "MY101"})
 }
 
+func TestLintFS_CustomRuleAndPrepareFSUsePublicScanner(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_create_users.up.sql":   "CREATE TABLE users (id INT);\n",
+		"0000000001_create_users.down.sql": "DROP TABLE users;\n",
+	})
+
+	files, err := lint.PrepareFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 2)
+	var upFile *lint.File
+	for _, file := range files {
+		if file.IsUp {
+			upFile = file
+		}
+	}
+	c.Assert(upFile, qt.IsNotNil)
+	c.Assert(upFile.Statements[0].Words, qt.DeepEquals, []string{"CREATE", "TABLE", "USERS", "(", "ID", "INT", ")"})
+
+	customRule := lint.Rule{
+		Code:     "XX001",
+		Title:    "custom create table analyzer",
+		Severity: lint.SeverityWarning,
+		CheckStatement: func(stmt *lint.Statement) (bool, string) {
+			if len(stmt.Words) >= 3 && stmt.Words[0] == "CREATE" && stmt.Words[1] == "TABLE" {
+				return true, "custom analyzer saw a create table statement through Ptah's scanner"
+			}
+			return false, ""
+		},
+	}
+	findings, err := lint.LintFS(fsys, lint.Options{ExtraRules: []lint.Rule{customRule}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"XX001"})
+	c.Assert(findings[0].Message, qt.Contains, "Ptah's scanner")
+}
+
+func TestLintFS_InvalidCustomRuleFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_x.up.sql":   "SELECT 1;\n",
+		"0000000001_x.down.sql": "-- restore\n",
+	}), lint.Options{ExtraRules: []lint.Rule{{Code: "XX001", Title: "broken"}}})
+
+	c.Assert(err, qt.ErrorMatches, "rule XX001 has unsupported severity.*")
+}
+
+func TestLintFS_RuleConfigsOverrideSeverityAndExcludePaths(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"legacy/0000000001_legacy.up.sql":   "ALTER TABLE users DROP COLUMN old_legacy;\n",
+		"legacy/0000000001_legacy.down.sql": "ALTER TABLE users ADD COLUMN old_legacy TEXT;\n",
+		"main/0000000002_main.up.sql":       "ALTER TABLE users DROP COLUMN old_main;\n",
+		"main/0000000002_main.down.sql":     "ALTER TABLE users ADD COLUMN old_main TEXT;\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{
+			"DS102": {
+				Severity: lint.SeverityWarning,
+				Exclude:  []string{"legacy/**"},
+			},
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(findings[0].Severity, qt.Equals, lint.SeverityWarning)
+	c.Assert(findings[0].File, qt.Equals, "main/0000000002_main.up.sql")
+}
+
+func TestLintFS_InlineNoLintSuppressesStatementAndFileFindings(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_suppress.up.sql": `-- ptah:nolint DS102
+ALTER TABLE users DROP COLUMN legacy;
+-- atlas:nolint DS102
+ALTER TABLE users DROP COLUMN legacy_two;
+-- ptah:nolint DS101
+DROP TABLE audit_log;
+ALTER TABLE users ALTER COLUMN email TYPE TEXT;
+`,
+		"0000000001_suppress.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS103"})
+}
+
+func TestLintFS_TrailingNoLintCommentDoesNotSuppressNextStatement(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_trailing.up.sql": `ALTER TABLE users ALTER COLUMN email TYPE TEXT; -- ptah:nolint DS102
+ALTER TABLE users DROP COLUMN legacy;
+`,
+		"0000000001_trailing.down.sql": "-- restore\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS103", "DS102"})
+}
+
 func TestLintFS_DisabledRulesAndFamilies(t *testing.T) {
 	c := qt.New(t)
 
@@ -767,12 +876,23 @@ func TestLoadConfig(t *testing.T) {
 	c := qt.New(t)
 
 	dir := t.TempDir()
-	c.Assert(writeFile(dir+"/.ptah-lint.yaml", "dialect: postgres\ndisabled-rules:\n  - MF\n  - BC101\n"), qt.IsNil)
+	c.Assert(writeFile(dir+"/.ptah-lint.yaml", `dialect: postgres
+disabled-rules:
+  - MF
+  - BC101
+rules:
+  DS103:
+    severity: warning
+    exclude:
+      - legacy/**
+`), qt.IsNil)
 
 	cfg, err := lint.LoadConfig(dir + "/.ptah-lint.yaml")
 	c.Assert(err, qt.IsNil)
 	c.Assert(cfg.Dialect, qt.Equals, "postgres")
 	c.Assert(cfg.DisabledRules, qt.DeepEquals, []string{"MF", "BC101"})
+	c.Assert(cfg.Rules["DS103"].Severity, qt.Equals, lint.SeverityWarning)
+	c.Assert(cfg.Rules["DS103"].Exclude, qt.DeepEquals, []string{"legacy/**"})
 
 	// A missing file at the conventional location is not an error.
 	cfg, err = lint.LoadConfig(dir + "/nope.yaml")
@@ -784,6 +904,10 @@ func TestLoadConfig(t *testing.T) {
 	c.Assert(writeFile(dir+"/broken.yaml", "dialect: [not, a, string"), qt.IsNil)
 	_, err = lint.LoadConfig(dir + "/broken.yaml")
 	c.Assert(err, qt.ErrorMatches, "failed to parse lint config .*")
+
+	c.Assert(writeFile(dir+"/bad-severity.yaml", "rules:\n  DS102:\n    severity: fatal\n"), qt.IsNil)
+	_, err = lint.LoadConfig(dir + "/bad-severity.yaml")
+	c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported severity "fatal".*`)
 }
 
 func TestRules_EveryRuleHasCodeTitleAndOneChecker(t *testing.T) {

--- a/migration/lint/register_external_test.go
+++ b/migration/lint/register_external_test.go
@@ -1,0 +1,36 @@
+package lint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/lint"
+)
+
+func TestRegisterCustomRuleFromExternalPackage(t *testing.T) {
+	c := qt.New(t)
+
+	err := lint.Register(lint.Rule{
+		Code:     "ZZ999",
+		Title:    "external analyzer sentinel",
+		Severity: lint.SeverityWarning,
+		CheckStatement: func(stmt *lint.Statement) (bool, string) {
+			if stmt.Canonical == "SELECT 424242" {
+				return true, "external analyzer used Ptah's prepared statement"
+			}
+			return false, ""
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	findings, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_custom.up.sql":   "SELECT 424242;\n",
+		"0000000001_custom.down.sql": "-- restore\n",
+	}), lint.Options{})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "ZZ999")
+	c.Assert(findings[0].Message, qt.Contains, "Ptah's prepared statement")
+}

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -4,13 +4,44 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 )
 
-// Rules returns the built-in rule set. The slice is rebuilt on every call so
-// callers can never corrupt the registry.
+var registeredRules = struct {
+	sync.RWMutex
+	rules []Rule
+}{}
+
+// Register appends a process-wide custom lint rule. Prefer Options.ExtraRules
+// for request-scoped analyzers; Register exists for plugin-style integrations
+// that initialize rules once at process startup.
+func Register(rule Rule) error {
+	if err := validateRule(rule); err != nil {
+		return err
+	}
+	registeredRules.Lock()
+	defer registeredRules.Unlock()
+	for _, existing := range append(builtinRules(), registeredRules.rules...) {
+		if existing.Code == rule.Code {
+			return fmt.Errorf("duplicate rule code %s", rule.Code)
+		}
+	}
+	registeredRules.rules = append(registeredRules.rules, rule)
+	return nil
+}
+
+// Rules returns the built-in rule set plus process-wide registered rules. The
+// slice is rebuilt on every call so callers can never corrupt the registry.
 func Rules() []Rule {
+	rules := builtinRules()
+	registeredRules.RLock()
+	defer registeredRules.RUnlock()
+	return append(rules, registeredRules.rules...)
+}
+
+func builtinRules() []Rule {
 	var rules []Rule
 	rules = append(rules, dataSafetyRules()...)
 	rules = append(rules, dataDependentRules()...)
@@ -21,6 +52,38 @@ func Rules() []Rule {
 	rules = append(rules, sqliteRules()...)
 	rules = append(rules, transactionRules()...)
 	return rules
+}
+
+func validateRule(rule Rule) error {
+	if strings.TrimSpace(rule.Code) == "" {
+		return fmt.Errorf("rule code is required")
+	}
+	if strings.TrimSpace(rule.Title) == "" {
+		return fmt.Errorf("rule %s title is required", rule.Code)
+	}
+	switch rule.Severity {
+	case SeverityWarning, SeverityError:
+	default:
+		return fmt.Errorf("rule %s has unsupported severity %q", rule.Code, rule.Severity)
+	}
+	if (rule.CheckStatement != nil) == (rule.CheckFile != nil) {
+		return fmt.Errorf("rule %s must set exactly one checker", rule.Code)
+	}
+	return nil
+}
+
+func validateRules(rules []Rule) error {
+	seen := make(map[string]struct{}, len(rules))
+	for _, rule := range rules {
+		if err := validateRule(rule); err != nil {
+			return err
+		}
+		if _, ok := seen[rule.Code]; ok {
+			return fmt.Errorf("duplicate rule code %s", rule.Code)
+		}
+		seen[rule.Code] = struct{}{}
+	}
+	return nil
 }
 
 // dataSafetyRules covers the DS family: statements that destroy data.

--- a/migration/risk/severity.go
+++ b/migration/risk/severity.go
@@ -1,0 +1,44 @@
+// Package risk defines shared severity vocabulary for migration safety checks.
+package risk
+
+// Severity is the shared risk level type used by lint and safety reports.
+type Severity string
+
+const (
+	// Safe marks changes that should not remove data or tighten existing
+	// constraints.
+	Safe Severity = "safe"
+	// Warning marks changes that deserve review before a production rollout.
+	Warning Severity = "warning"
+	// Error marks lint findings that should block by default.
+	Error Severity = "error"
+	// Destructive marks generated migration statements that remove data,
+	// database objects, or protections.
+	Destructive Severity = "destructive"
+)
+
+// Rank returns a comparable severity order. Error and Destructive are both
+// blocking severities expressed in different output vocabularies.
+func Rank(severity Severity) int {
+	switch severity {
+	case Destructive, Error:
+		return 2
+	case Warning:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// IsBlocking reports whether severity should fail safety gates by default.
+func IsBlocking(severity Severity) bool {
+	return Rank(severity) >= Rank(Error)
+}
+
+// SARIFLevel maps Ptah severity values to SARIF result levels.
+func SARIFLevel(severity Severity) string {
+	if IsBlocking(severity) {
+		return "error"
+	}
+	return "warning"
+}

--- a/migration/risk/severity_test.go
+++ b/migration/risk/severity_test.go
@@ -1,0 +1,23 @@
+package risk_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/risk"
+)
+
+func TestSeverityRankAndMachineLevels(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(risk.Rank(risk.Safe) < risk.Rank(risk.Warning), qt.IsTrue)
+	c.Assert(risk.Rank(risk.Warning) < risk.Rank(risk.Error), qt.IsTrue)
+	c.Assert(risk.Rank(risk.Error), qt.Equals, risk.Rank(risk.Destructive))
+
+	c.Assert(risk.IsBlocking(risk.Warning), qt.IsFalse)
+	c.Assert(risk.IsBlocking(risk.Error), qt.IsTrue)
+	c.Assert(risk.IsBlocking(risk.Destructive), qt.IsTrue)
+	c.Assert(risk.SARIFLevel(risk.Warning), qt.Equals, "warning")
+	c.Assert(risk.SARIFLevel(risk.Destructive), qt.Equals, "error")
+}

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -2,6 +2,7 @@
 package safety
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -12,20 +13,21 @@ import (
 	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/migration/risk"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 	"github.com/stokaro/ptah/migration/typechange"
 )
 
 // Severity is the operational risk level for a schema change.
-type Severity string
+type Severity = risk.Severity
 
 const (
 	// Safe changes should not remove data or tighten existing constraints.
-	Safe Severity = "safe"
+	Safe Severity = risk.Safe
 	// Warning changes are data-dependent or may affect runtime behavior.
-	Warning Severity = "warning"
+	Warning Severity = risk.Warning
 	// Destructive changes remove data, database objects, or protections.
-	Destructive Severity = "destructive"
+	Destructive Severity = risk.Destructive
 )
 
 // Finding summarizes one non-empty schema-diff category.
@@ -43,6 +45,13 @@ type StatementAssessment struct {
 	Statement string   `json:"statement,omitempty"`
 	Severity  Severity `json:"severity"`
 	Reason    string   `json:"reason"`
+}
+
+// Report is the machine-readable safety report envelope.
+type Report struct {
+	Highest     Severity              `json:"highest"`
+	Destructive bool                  `json:"destructive"`
+	Assessments []StatementAssessment `json:"assessments"`
 }
 
 // ClassifySchemaDiff returns severity findings for every non-empty diff
@@ -196,6 +205,23 @@ func HighestAssessment(assessments []StatementAssessment) Severity {
 // HasDestructiveAssessment returns true when any statement is destructive.
 func HasDestructiveAssessment(assessments []StatementAssessment) bool {
 	return HighestAssessment(assessments) == Destructive
+}
+
+// NewReport returns a machine-readable safety report envelope.
+func NewReport(assessments []StatementAssessment) Report {
+	highest := HighestAssessment(assessments)
+	return Report{
+		Highest:     highest,
+		Destructive: highest == Destructive,
+		Assessments: assessments,
+	}
+}
+
+// RenderJSON writes a machine-readable safety report.
+func RenderJSON(w io.Writer, assessments []StatementAssessment) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(NewReport(assessments))
 }
 
 // RenderText writes a compact text table for statement assessments.
@@ -509,14 +535,7 @@ func aggregate(findings []Finding) []Finding {
 }
 
 func severityRank(severity Severity) int {
-	switch severity {
-	case Destructive:
-		return 3
-	case Warning:
-		return 2
-	default:
-		return 1
-	}
+	return risk.Rank(severity)
 }
 
 // IsTypeNarrowing reports whether changing from oldType to newType can lose

--- a/migration/safety/safety_test.go
+++ b/migration/safety/safety_test.go
@@ -1,6 +1,8 @@
 package safety_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -144,6 +146,29 @@ func TestAssessHighestSeverity(t *testing.T) {
 	c.Assert(assessments[0].Index, qt.Equals, 1)
 	c.Assert(safety.HighestAssessment(assessments), qt.Equals, safety.Warning)
 	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsFalse)
+}
+
+func TestRenderJSON(t *testing.T) {
+	c := qt.New(t)
+
+	assessments := []safety.StatementAssessment{{
+		Index:     1,
+		NodeType:  "sql",
+		Subject:   "legacy",
+		Statement: "DROP TABLE legacy;",
+		Severity:  safety.Destructive,
+		Reason:    "DROP TABLE removes the table and all rows",
+	}}
+	var buf bytes.Buffer
+
+	err := safety.RenderJSON(&buf, assessments)
+
+	c.Assert(err, qt.IsNil)
+	var report safety.Report
+	c.Assert(json.Unmarshal(buf.Bytes(), &report), qt.IsNil)
+	c.Assert(report.Highest, qt.Equals, safety.Destructive)
+	c.Assert(report.Destructive, qt.IsTrue)
+	c.Assert(report.Assessments, qt.DeepEquals, assessments)
 }
 
 func TestAssessRenderedSplitsPostgresModifyColumnStatements(t *testing.T) {


### PR DESCRIPTION
## Summary

- add public lint analyzer extension APIs via `lint.Register`, `Options.ExtraRules`, and `PrepareFS`
- support per-rule severity/exclude config, inline `ptah:nolint` / `atlas:nolint`, SARIF output, and expanded lint dialect validation
- add structured safety JSON reports, structured shadow verification errors, and a shared migration risk severity type
- remove unused lint `Statement.Node` / `parseBestEffort` AST parsing path

Fixes #270.

## Validation

- `go test ./migration/risk ./migration/lint ./cmd/lint ./cmd/migrate ./cmd/migrateup ./migration/safety ./migration/generator -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1`

## Self-Review

- Verified external-package custom analyzer coverage through both `Register` and `ExtraRules` without private scanner access.
- Verified `migrate-up` loads `.ptah-lint.yaml`, honors severity/disabled rules, and still blocks real DS errors in the same pending batch.
- Verified inline suppressions apply to the next statement only and cover file-level DS101 findings by line.
- Ran an independent subagent review; it found one stale dialect error message, which was fixed and covered by test.
