### PR TITLE
Support generated concurrent index migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,16 @@ additions that must be used later in the same migration. Ptah rejects migration
 timeouts on `no_transaction` migrations because those statements run as raw
 autocommit SQL instead of through the transaction-bound writer.
 
+Generated PostgreSQL migrations also use this path for indexes on populated
+existing tables. If live introspection reports an existing table with an
+estimated row count greater than zero, `migrate generate` emits
+`CREATE INDEX CONCURRENTLY` for new indexes on that table and writes the file
+with `-- +ptah no_transaction`. When a change set also contains ordinary
+transactional DDL, Ptah splits the output into separate migration versions:
+transactional changes first, then concurrent indexes. PostgreSQL-family targets
+whose capability preset disables concurrent indexes, including YugabyteDB and
+CockroachDB, keep regular `CREATE INDEX` output.
+
 Ptah detects out-of-order migrations from the applied version set. By default,
 `migrate-up` uses `--exec-order=linear` and fails if a pending migration version is
 below the current high-water mark, which catches ordinary branch merge races instead

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -144,10 +144,12 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Generated migration files for %s:\n", dbschema.FormatDatabaseURL(dbURL))
-	fmt.Fprintf(out, "UP:   %s\n", files.UpFile)
-	fmt.Fprintf(out, "DOWN: %s\n", files.DownFile)
-	if files.ReportFile != "" {
-		fmt.Fprintf(out, "REPORT: %s\n", files.ReportFile)
+	for _, pair := range files.Files {
+		fmt.Fprintf(out, "UP:   %s\n", pair.UpFile)
+		fmt.Fprintf(out, "DOWN: %s\n", pair.DownFile)
+		if pair.ReportFile != "" {
+			fmt.Fprintf(out, "REPORT: %s\n", pair.ReportFile)
+		}
 	}
 	return nil
 }

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -192,11 +192,13 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	tablesQuery := `
 		SELECT table_schema, table_name, table_type,
 		       COALESCE(obj_description(c.oid), '') as table_comment,
+		       COALESCE(GREATEST(c.reltuples::bigint, st.n_live_tup, 0), 0) AS estimated_rows,
 		       COALESCE(c.relrowsecurity, false) AS rls_enabled
 			FROM information_schema.tables t
-			LEFT JOIN pg_class c ON c.relname = t.table_name
-		LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE t.table_schema = $1 AND (n.nspname = $1 OR n.nspname IS NULL)
+			LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
+			LEFT JOIN pg_class c ON c.relname = t.table_name AND c.relnamespace = n.oid
+			LEFT JOIN pg_stat_all_tables st ON st.relid = c.oid
+			WHERE t.table_schema = $1
 			AND t.table_type = 'BASE TABLE'
 			AND t.table_name NOT IN ('schema_migrations')
 			ORDER BY table_schema, table_name`
@@ -210,7 +212,7 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	var tables []types.DBTable
 	for rows.Next() {
 		var table types.DBTable
-		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment, &table.RLSEnabled)
+		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment, &table.EstimatedRows, &table.RLSEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -25,12 +25,13 @@ type DBSchema struct {
 
 // DBTable represents a database table
 type DBTable struct {
-	Name       string     `json:"name"`
-	Schema     string     `json:"schema,omitempty"`
-	Type       string     `json:"type"` // TABLE, VIEW, etc.
-	Comment    string     `json:"comment"`
-	Columns    []DBColumn `json:"columns"`
-	RLSEnabled bool       `json:"rls_enabled"` // Whether RLS is enabled on this table (PostgreSQL)
+	Name          string     `json:"name"`
+	Schema        string     `json:"schema,omitempty"`
+	Type          string     `json:"type"` // TABLE, VIEW, etc.
+	Comment       string     `json:"comment"`
+	Columns       []DBColumn `json:"columns"`
+	EstimatedRows int64      `json:"estimated_rows,omitempty"` // Best-effort planner estimate from database statistics
+	RLSEnabled    bool       `json:"rls_enabled"`              // Whether RLS is enabled on this table (PostgreSQL)
 }
 
 // QualifiedName returns schema.table when Schema is set, or Name otherwise.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -167,9 +167,12 @@ value or wants to pin a specific server version in tests/CI.
 - **`CREATE INDEX CONCURRENTLY` (postgres).**
   `postgres.New().WithConcurrentIndexes()` emits `CONCURRENTLY` for new
   indexes **only** when the capability is present. It is a policy opt-in
-  because concurrent builds cannot run inside a transaction block (#152 tracks
-  migrator support); a capability-less target (CockroachDB-style preset, #171)
-  keeps plain `CREATE INDEX` regardless of policy.
+  because concurrent builds cannot run inside a transaction block. The
+  high-level migration generator uses the same capability to emit
+  `CREATE INDEX CONCURRENTLY` plus `-- +ptah no_transaction` for new indexes on
+  populated existing PostgreSQL tables; a capability-less target
+  (CockroachDB-style preset, #171) keeps plain `CREATE INDEX` regardless of
+  policy.
 - **Distributed-SQL PostgreSQL-family adapters (#171).**
   `platform.CockroachDB`, `platform.YugabyteDB`, and `platform.Spanner`
   normalize as distinct dialects but reuse the PostgreSQL planner, renderer,

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -228,6 +228,25 @@ type GenerateMigrationOptions struct {
 - `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
 - `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks (optional)
 
+### PostgreSQL Concurrent Indexes
+
+When Ptah generates a new PostgreSQL index on an existing table whose
+introspected row estimate is greater than zero, it emits `CREATE INDEX
+CONCURRENTLY` and marks that migration file with `-- +ptah no_transaction`.
+This avoids PostgreSQL's `CREATE INDEX CONCURRENTLY cannot run inside a
+transaction block` failure and reduces write blocking on populated tables.
+
+If a generated change set contains both ordinary transactional DDL and
+concurrent index builds, Ptah writes separate migration file pairs: the
+transactional migration first, then the `no_transaction` concurrent-index
+migration at the next version. Rollbacks naturally run in the reverse order, so
+the index is dropped before prerequisite schema changes are reverted.
+
+Ptah only enables this policy when the live target capabilities include
+PostgreSQL `CREATE INDEX CONCURRENTLY`. PostgreSQL-wire engines such as
+YugabyteDB and CockroachDB keep regular `CREATE INDEX` output when their
+capability preset disables the keyword.
+
 ### Database URL Examples
 
 - PostgreSQL: `postgres://user:password@localhost:5432/database`

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -1,0 +1,222 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanGeneratedMigrationSpecs_ConcurrentIndexForPopulatedPostgresTable(t *testing.T) {
+	c := qt.New(t)
+
+	specs, assessments, err := planGeneratedMigrationSpecs(
+		indexOnlyDiff(),
+		indexOnlyGeneratedSchema(),
+		&dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{Name: "users", Type: "BASE TABLE", EstimatedRows: 10}}},
+		postgresInfo(capability.Postgres16()),
+		100,
+		"add_user_email_index",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(specs, qt.HasLen, 1)
+	c.Assert(len(assessments) > 0, qt.IsTrue)
+	c.Assert(specs[0].NoTransaction, qt.IsTrue)
+	c.Assert(specs[0].UpSQL, qt.Contains, "-- +ptah no_transaction")
+	c.Assert(specs[0].UpSQL, qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+	c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "+ptah lock_timeout")
+	c.Assert(specs[0].DownSQL, qt.Contains, "-- +ptah no_transaction")
+	c.Assert(specs[0].DownSQL, qt.Contains, `DROP INDEX IF EXISTS "idx_users_email";`)
+}
+
+func TestPlanGeneratedMigrationSpecs_ConcurrentIndexRequiresPopulatedCapablePostgres(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbSchema *dbschematypes.DBSchema
+		info     dbschematypes.DBInfo
+	}{
+		{
+			name:     "empty table stays transactional",
+			dbSchema: &dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{Name: "users", Type: "BASE TABLE"}}},
+			info:     postgresInfo(capability.Postgres16()),
+		},
+		{
+			name:     "missing table stats stays transactional",
+			dbSchema: &dbschematypes.DBSchema{},
+			info:     postgresInfo(capability.Postgres16()),
+		},
+		{
+			name:     "capability-disabled postgres family stays transactional",
+			dbSchema: &dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{Name: "users", Type: "BASE TABLE", EstimatedRows: 10}}},
+			info:     postgresInfo(capability.Postgres16().With(capability.CreateIndexConcurrently, false)),
+		},
+		{
+			name:     "yugabyte stays transactional",
+			dbSchema: &dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{Name: "users", Type: "BASE TABLE", EstimatedRows: 10}}},
+			info: dbschematypes.DBInfo{
+				Dialect:      platform.YugabyteDB,
+				Capabilities: capability.YugabyteDB25(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			specs, _, err := planGeneratedMigrationSpecs(indexOnlyDiff(), indexOnlyGeneratedSchema(), tt.dbSchema, tt.info, 100, "add_index")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(specs, qt.HasLen, 1)
+			c.Assert(specs[0].NoTransaction, qt.IsFalse)
+			c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "CONCURRENTLY")
+			c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "-- +ptah no_transaction")
+			c.Assert(specs[0].UpSQL, qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+		})
+	}
+}
+
+func TestPlanGeneratedMigrationSpecs_SplitsTransactionalAndConcurrentIndex(t *testing.T) {
+	c := qt.New(t)
+
+	diff := indexOnlyDiff()
+	diff.TablesAdded = []string{"posts"}
+	generated := indexOnlyGeneratedSchema()
+	generated.Tables = append(generated.Tables, goschema.Table{StructName: "Post", Name: "posts"})
+	generated.Fields = append(generated.Fields, goschema.Field{
+		StructName: "Post",
+		Name:       "id",
+		Type:       "SERIAL",
+		Primary:    true,
+		AutoInc:    true,
+	})
+
+	specs, _, err := planGeneratedMigrationSpecs(
+		diff,
+		generated,
+		&dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{Name: "users", Type: "BASE TABLE", EstimatedRows: 10}}},
+		postgresInfo(capability.Postgres16()),
+		100,
+		"add_posts_and_user_index",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(specs, qt.HasLen, 2)
+	c.Assert(specs[0].Version, qt.Equals, int64(100))
+	c.Assert(specs[0].Name, qt.Equals, "add_posts_and_user_index_transactional")
+	c.Assert(specs[0].NoTransaction, qt.IsFalse)
+	c.Assert(specs[0].UpSQL, qt.Contains, `CREATE TABLE "posts"`)
+	c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "idx_users_email")
+
+	c.Assert(specs[1].Version, qt.Equals, int64(101))
+	c.Assert(specs[1].Name, qt.Equals, "add_posts_and_user_index_concurrent_indexes")
+	c.Assert(specs[1].NoTransaction, qt.IsTrue)
+	c.Assert(specs[1].UpSQL, qt.Contains, "-- +ptah no_transaction")
+	c.Assert(specs[1].UpSQL, qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+	c.Assert(specs[1].DownSQL, qt.Contains, `DROP INDEX IF EXISTS "idx_users_email";`)
+}
+
+func TestPlanGeneratedMigrationSpecs_SplitsPopulatedAndEmptyTableIndexes(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{IndexesAdded: []string{"idx_users_email", "idx_posts_title"}}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email"}},
+			{Name: "idx_posts_title", StructName: "Post", Fields: []string{"title"}},
+		},
+	}
+	dbSchema := &dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{
+		{Name: "users", Type: "BASE TABLE", EstimatedRows: 10},
+		{Name: "posts", Type: "BASE TABLE", EstimatedRows: 0},
+	}}
+
+	specs, _, err := planGeneratedMigrationSpecs(diff, generated, dbSchema, postgresInfo(capability.Postgres16()), 100, "add_indexes")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(specs, qt.HasLen, 2)
+	c.Assert(specs[0].NoTransaction, qt.IsFalse)
+	c.Assert(specs[0].UpSQL, qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_posts_title" ON "posts" ("title");`)
+	c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "idx_users_email")
+	c.Assert(specs[1].NoTransaction, qt.IsTrue)
+	c.Assert(specs[1].UpSQL, qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+	c.Assert(specs[1].UpSQL, qt.Not(qt.Contains), "idx_posts_title")
+}
+
+func TestPlanGeneratedMigrationSpecs_RefusesUnsplitNonTransactionalMix(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{"users"},
+		EnumsModified: []types.EnumDiff{{
+			EnumName:    "status",
+			ValuesAdded: []string{"archived"},
+		}},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			Name:       "id",
+			Type:       "SERIAL",
+			Primary:    true,
+			AutoInc:    true,
+		}},
+		Enums: []goschema.Enum{{Name: "status", Values: []string{"active", "archived"}}},
+	}
+
+	specs, _, err := planGeneratedMigrationSpecs(diff, generated, &dbschematypes.DBSchema{}, postgresInfo(capability.Postgres16()), 100, "mixed")
+
+	c.Assert(specs, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, "generated migration mixes transactional statements with non-transactional statements that cannot be split automatically")
+}
+
+func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	files, err := createMigrationFilesFromSpecs(dir, "", []generatedMigrationSpec{
+		{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
+		{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 2)
+	c.Assert(files.UpFile, qt.Equals, files.Files[0].UpFile)
+	c.Assert(files.Files[0].NoTransaction, qt.IsFalse)
+	c.Assert(files.Files[1].NoTransaction, qt.IsTrue)
+	c.Assert(files.Files[0].Version < files.Files[1].Version, qt.IsTrue)
+	c.Assert(strings.HasSuffix(files.Files[0].UpFile, "100_transactional.up.sql"), qt.IsTrue)
+	c.Assert(strings.HasSuffix(files.Files[1].UpFile, "101_concurrent_indexes.up.sql"), qt.IsTrue)
+}
+
+func indexOnlyDiff() *types.SchemaDiff {
+	return &types.SchemaDiff{IndexesAdded: []string{"idx_users_email"}}
+}
+
+func indexOnlyGeneratedSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email"}},
+		},
+	}
+}
+
+func postgresInfo(caps capability.Capabilities) dbschematypes.DBInfo {
+	return dbschematypes.DBInfo{
+		Dialect:      platform.Postgres,
+		Capabilities: caps,
+	}
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -13,11 +13,13 @@ import (
 	"time"
 
 	"github.com/stokaro/ptah/config"
+	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/convert/dbschematogo"
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
@@ -57,7 +59,7 @@ type GenerateMigrationOptions struct {
 	// AllowDestructive permits destructive up migrations when CheckDestructive is set.
 	AllowDestructive bool
 	// ReportFormat optionally writes a safety report next to generated files.
-	// Supported values: "", "html".
+	// Supported values: "", "html", "json".
 	ReportFormat string
 	// ShadowDatabaseURL enables pre-write verification on an ephemeral database.
 	// The generator drops all objects in this database, replays existing
@@ -66,12 +68,22 @@ type GenerateMigrationOptions struct {
 	ShadowDatabaseURL string
 }
 
-// MigrationFiles represents the generated migration files
+// MigrationFilePair represents one generated up/down migration file pair.
+type MigrationFilePair struct {
+	UpFile        string // Path to the up migration file
+	DownFile      string // Path to the down migration file
+	ReportFile    string // Path to the safety report file, when requested
+	Version       int64  // Migration version (timestamp)
+	NoTransaction bool   // Whether the pair is marked with +ptah no_transaction
+}
+
+// MigrationFiles represents the generated migration files.
 type MigrationFiles struct {
-	UpFile     string // Path to the up migration file
-	DownFile   string // Path to the down migration file
-	ReportFile string // Path to the safety report file, when requested
-	Version    int64  // Migration version (timestamp)
+	UpFile     string              // Path to the first up migration file
+	DownFile   string              // Path to the first down migration file
+	ReportFile string              // Path to the first safety report file, when requested
+	Version    int64               // First migration version (timestamp)
+	Files      []MigrationFilePair // All generated migration file pairs, in apply order
 }
 
 // EmptyMigrationOptions contains options for skeleton migration creation.
@@ -211,36 +223,15 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	slog.Debug("Generated migration version", "version", version)
 
 	info := conn.Info()
-	upNodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
-	assessments, err := safety.AssessRenderedWithCapabilities(upNodes, info.Dialect, info.Capabilities)
+	specs, assessments, err := planGeneratedMigrationSpecs(diff, generated, dbSchema, info, version, opts.MigrationName)
 	if err != nil {
-		return nil, fmt.Errorf("error assessing migration safety: %w", err)
+		return nil, err
+	}
+	if len(specs) == 0 {
+		return nil, nil
 	}
 	if err := checkDestructiveAllowed(opts, assessments); err != nil {
 		return nil, err
-	}
-
-	// 5. Generate up migration SQL
-	requiresNoTransaction := planner.RequiresNoTransaction(info.Dialect, upNodes)
-	directiveOpts := generatedDirectiveOptions{skipTimeouts: requiresNoTransaction}
-	upSQL, err := generateUpMigrationSQLWithOptions(diff, generated, info.Dialect, directiveOpts, info.Capabilities)
-	if err != nil {
-		return nil, fmt.Errorf("error generating up migration SQL: %w", err)
-	}
-
-	// Check if no actual migration is needed (empty upSQL indicates no changes)
-	if upSQL == "" {
-		// No migration needed - this is a successful no-op operation
-		return nil, nil
-	}
-	if requiresNoTransaction {
-		upSQL = withNoTransactionDirective(upSQL)
-	}
-
-	// 6. Generate down migration SQL
-	downSQL, err := generateDownMigrationSQLWithOptions(diff, generated, dbSchema, info.Dialect, directiveOpts, info.Capabilities)
-	if err != nil {
-		return nil, fmt.Errorf("error generating down migration SQL: %w", err)
 	}
 
 	if opts.ShadowDatabaseURL != "" {
@@ -249,10 +240,7 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 			MigrationsDir: opts.OutputDir,
 			Dialect:       info.Dialect,
 			Capabilities:  info.Capabilities,
-			Version:       version,
-			Name:          opts.MigrationName,
-			UpSQL:         upSQL,
-			DownSQL:       downSQL,
+			Candidates:    shadowCandidatesFromSpecs(specs),
 			Generated:     generated,
 			CompareOpts:   compareOpts,
 			Schemas:       opts.Schemas,
@@ -262,16 +250,9 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 	}
 
 	// 7. Create migration files
-	files, err := createMigrationFiles(opts.OutputDir, version, opts.MigrationName, upSQL, downSQL)
+	files, err := createMigrationFilesFromSpecs(opts.OutputDir, opts.ReportFormat, specs)
 	if err != nil {
 		return nil, fmt.Errorf("error creating migration files: %w", err)
-	}
-	if opts.ReportFormat != "" {
-		reportFile, err := createSafetyReportFile(files.UpFile, opts.ReportFormat, assessments)
-		if err != nil {
-			return nil, fmt.Errorf("error creating safety report: %w", err)
-		}
-		files.ReportFile = reportFile
 	}
 
 	return files, nil
@@ -309,6 +290,350 @@ func checkDestructiveAllowed(opts GenerateMigrationOptions, assessments []safety
 		return fmt.Errorf("destructive migration statements require AllowDestructive")
 	}
 	return nil
+}
+
+type generatedMigrationSpec struct {
+	Version       int64
+	Name          string
+	UpSQL         string
+	DownSQL       string
+	Assessments   []safety.StatementAssessment
+	NoTransaction bool
+}
+
+func planGeneratedMigrationSpecs(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dbSchema *dbschematypes.DBSchema,
+	info dbschematypes.DBInfo,
+	version int64,
+	migrationName string,
+) ([]generatedMigrationSpec, []safety.StatementAssessment, error) {
+	concurrentIndexNames := concurrentIndexNamesForPopulatedTables(diff, generated, dbSchema, info)
+	plannerOpts := planner.Options{
+		Capabilities:         info.Capabilities,
+		ConcurrentIndexNames: concurrentIndexNames,
+	}
+	upNodes := planner.GenerateSchemaDiffASTWithOptions(diff, generated, info.Dialect, plannerOpts)
+	if len(upNodes) == 0 {
+		return nil, nil, nil
+	}
+	requiresNoTransaction := planner.RequiresNoTransaction(info.Dialect, upNodes)
+	if !requiresNoTransaction {
+		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
+			Diff:         diff,
+			Generated:    generated,
+			DBSchema:     dbSchema,
+			Dialect:      info.Dialect,
+			Capabilities: info.Capabilities,
+			Version:      version,
+			Name:         migrationName,
+		})
+		if err != nil || spec.UpSQL == "" {
+			return nil, assessments, err
+		}
+		return []generatedMigrationSpec{spec}, assessments, nil
+	}
+
+	nodeGroups := splitNoTransactionNodes(info.Dialect, upNodes)
+	if len(nodeGroups.transactional) == 0 {
+		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
+			Diff:                 diff,
+			Generated:            generated,
+			DBSchema:             dbSchema,
+			Dialect:              info.Dialect,
+			Capabilities:         info.Capabilities,
+			Version:              version,
+			Name:                 migrationName,
+			ConcurrentIndexNames: concurrentIndexNames,
+			NoTransaction:        true,
+		})
+		if err != nil || spec.UpSQL == "" {
+			return nil, assessments, err
+		}
+		return []generatedMigrationSpec{spec}, assessments, nil
+	}
+	if !allNoTransactionNodesAreConcurrentIndexes(nodeGroups.noTransaction) {
+		return nil, nil, fmt.Errorf("generated migration mixes transactional statements with non-transactional statements that cannot be split automatically")
+	}
+
+	diffGroups := splitConcurrentIndexDiff(diff, concurrentIndexNames)
+	specs := make([]generatedMigrationSpec, 0, 2)
+	allAssessments := make([]safety.StatementAssessment, 0)
+	if diffGroups.transactional.HasChanges() {
+		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
+			Diff:         diffGroups.transactional,
+			Generated:    generated,
+			DBSchema:     dbSchema,
+			Dialect:      info.Dialect,
+			Capabilities: info.Capabilities,
+			Version:      version,
+			Name:         migrationName + "_transactional",
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if spec.UpSQL != "" {
+			specs = append(specs, spec)
+			allAssessments = append(allAssessments, assessments...)
+			version++
+		}
+	}
+	if diffGroups.noTransaction.HasChanges() {
+		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
+			Diff:                 diffGroups.noTransaction,
+			Generated:            generated,
+			DBSchema:             dbSchema,
+			Dialect:              info.Dialect,
+			Capabilities:         info.Capabilities,
+			Version:              version,
+			Name:                 migrationName + "_concurrent_indexes",
+			ConcurrentIndexNames: concurrentIndexNames,
+			NoTransaction:        true,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if spec.UpSQL != "" {
+			specs = append(specs, spec)
+			allAssessments = append(allAssessments, assessments...)
+		}
+	}
+	return specs, allAssessments, nil
+}
+
+type generatedMigrationSpecOptions struct {
+	Diff                 *types.SchemaDiff
+	Generated            *goschema.Database
+	DBSchema             *dbschematypes.DBSchema
+	Dialect              string
+	Capabilities         capability.Capabilities
+	Version              int64
+	Name                 string
+	ConcurrentIndexNames []string
+	NoTransaction        bool
+}
+
+func buildGeneratedMigrationSpec(opts generatedMigrationSpecOptions) (generatedMigrationSpec, []safety.StatementAssessment, error) {
+	plannerOpts := planner.Options{
+		Capabilities:         opts.Capabilities,
+		ConcurrentIndexNames: opts.ConcurrentIndexNames,
+	}
+	upNodes := planner.GenerateSchemaDiffASTWithOptions(opts.Diff, opts.Generated, opts.Dialect, plannerOpts)
+	assessments, err := safety.AssessRenderedWithCapabilities(upNodes, opts.Dialect, opts.Capabilities)
+	if err != nil {
+		return generatedMigrationSpec{}, nil, fmt.Errorf("error assessing migration safety: %w", err)
+	}
+	directiveOpts := generatedDirectiveOptions{skipTimeouts: opts.NoTransaction}
+	upSQL, err := renderGeneratedMigrationSQL(upNodes, opts.Dialect, opts.Capabilities, "UP", directiveOpts)
+	if err != nil {
+		return generatedMigrationSpec{}, nil, fmt.Errorf("error generating up migration SQL: %w", err)
+	}
+	if upSQL == "" {
+		return generatedMigrationSpec{}, assessments, nil
+	}
+	if opts.NoTransaction {
+		upSQL = withNoTransactionDirective(upSQL)
+	}
+
+	downSQL, err := generateDownMigrationSQLWithOptions(opts.Diff, opts.Generated, opts.DBSchema, opts.Dialect, directiveOpts, opts.Capabilities)
+	if err != nil {
+		return generatedMigrationSpec{}, nil, fmt.Errorf("error generating down migration SQL: %w", err)
+	}
+	if opts.NoTransaction {
+		downSQL = withNoTransactionDirective(downSQL)
+	}
+
+	return generatedMigrationSpec{
+		Version:       opts.Version,
+		Name:          opts.Name,
+		UpSQL:         upSQL,
+		DownSQL:       downSQL,
+		Assessments:   assessments,
+		NoTransaction: opts.NoTransaction,
+	}, assessments, nil
+}
+
+func renderGeneratedMigrationSQL(
+	nodes []ast.Node,
+	dialect string,
+	caps capability.Capabilities,
+	direction string,
+	directiveOpts generatedDirectiveOptions,
+) (string, error) {
+	rawSQL, err := renderer.RenderSQLWithCapabilities(dialect, caps, nodes...)
+	if err != nil {
+		return "", err
+	}
+	statements := sqlutil.SplitSQLStatements(rawSQL)
+	if len(statements) == 0 || !hasActualSQLStatements(statements) {
+		return "", nil
+	}
+	header := fmt.Sprintf("-- Migration generated from schema differences\n-- Generated on: %s\n-- Direction: %s\n\n",
+		time.Now().Format(time.RFC3339), direction)
+	return withGeneratedTimeoutDirectivesForOptions(header+strings.Join(statements, ";\n")+";", dialect, directiveOpts), nil
+}
+
+type splitMigrationNodes struct {
+	transactional []ast.Node
+	noTransaction []ast.Node
+}
+
+func splitNoTransactionNodes(dialect string, nodes []ast.Node) splitMigrationNodes {
+	txNodes := make([]ast.Node, 0, len(nodes))
+	noTxNodes := make([]ast.Node, 0)
+	for _, node := range nodes {
+		if planner.NodeRequiresNoTransaction(dialect, node) {
+			noTxNodes = append(noTxNodes, node)
+			continue
+		}
+		txNodes = append(txNodes, node)
+	}
+	return splitMigrationNodes{transactional: txNodes, noTransaction: noTxNodes}
+}
+
+func allNoTransactionNodesAreConcurrentIndexes(nodes []ast.Node) bool {
+	for _, node := range nodes {
+		index, ok := node.(*ast.IndexNode)
+		if !ok || !index.Concurrently {
+			return false
+		}
+	}
+	return true
+}
+
+func concurrentIndexNamesForPopulatedTables(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dbSchema *dbschematypes.DBSchema,
+	info dbschematypes.DBInfo,
+) []string {
+	if !platform.IsPostgresFamily(info.Dialect) || !info.Capabilities.Has(capability.CreateIndexConcurrently) {
+		return nil
+	}
+	added := stringSet(diff.IndexesAdded)
+	populatedTables := populatedTableSet(dbSchema)
+	structToTable := generatedStructTableMap(generated)
+	var names []string
+	for _, index := range generated.Indexes {
+		if _, ok := added[index.Name]; !ok {
+			continue
+		}
+		tableName := resolveGeneratedIndexTable(index, structToTable)
+		if _, ok := populatedTables[tableName]; ok {
+			names = append(names, index.Name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func populatedTableSet(dbSchema *dbschematypes.DBSchema) map[string]struct{} {
+	out := make(map[string]struct{})
+	if dbSchema == nil {
+		return out
+	}
+	for _, table := range dbSchema.Tables {
+		if table.EstimatedRows <= 0 {
+			continue
+		}
+		out[table.QualifiedName()] = struct{}{}
+		if table.Schema != "" {
+			out[table.Name] = struct{}{}
+		}
+	}
+	return out
+}
+
+func generatedStructTableMap(generated *goschema.Database) map[string]string {
+	out := make(map[string]string, len(generated.Tables))
+	for _, table := range generated.Tables {
+		out[table.StructName] = table.QualifiedName()
+	}
+	return out
+}
+
+func resolveGeneratedIndexTable(index goschema.Index, structToTable map[string]string) string {
+	if strings.TrimSpace(index.TableName) != "" {
+		return index.TableName
+	}
+	return structToTable[index.StructName]
+}
+
+type splitSchemaDiffs struct {
+	transactional *types.SchemaDiff
+	noTransaction *types.SchemaDiff
+}
+
+func splitConcurrentIndexDiff(diff *types.SchemaDiff, concurrentIndexNames []string) splitSchemaDiffs {
+	concurrent := stringSet(concurrentIndexNames)
+	txDiff := cloneSchemaDiff(diff)
+	noTxDiff := emptySchemaDiff()
+	txDiff.IndexesAdded = txDiff.IndexesAdded[:0]
+	for _, indexName := range diff.IndexesAdded {
+		if _, ok := concurrent[indexName]; ok {
+			noTxDiff.IndexesAdded = append(noTxDiff.IndexesAdded, indexName)
+			continue
+		}
+		txDiff.IndexesAdded = append(txDiff.IndexesAdded, indexName)
+	}
+	return splitSchemaDiffs{transactional: txDiff, noTransaction: noTxDiff}
+}
+
+func stringSet(values []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}
+
+func emptySchemaDiff() *types.SchemaDiff {
+	return &types.SchemaDiff{}
+}
+
+func cloneSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
+	clone := *diff
+	clone.TablesAdded = slices.Clone(diff.TablesAdded)
+	clone.TablesRemoved = slices.Clone(diff.TablesRemoved)
+	clone.TablesModified = slices.Clone(diff.TablesModified)
+	clone.EnumsAdded = slices.Clone(diff.EnumsAdded)
+	clone.EnumsRemoved = slices.Clone(diff.EnumsRemoved)
+	clone.EnumsModified = slices.Clone(diff.EnumsModified)
+	clone.IndexesAdded = slices.Clone(diff.IndexesAdded)
+	clone.IndexesRemoved = slices.Clone(diff.IndexesRemoved)
+	clone.IndexesRemovedWithTables = slices.Clone(diff.IndexesRemovedWithTables)
+	clone.ExtensionsAdded = slices.Clone(diff.ExtensionsAdded)
+	clone.ExtensionsRemoved = slices.Clone(diff.ExtensionsRemoved)
+	clone.FunctionsAdded = slices.Clone(diff.FunctionsAdded)
+	clone.FunctionsRemoved = slices.Clone(diff.FunctionsRemoved)
+	clone.FunctionsModified = slices.Clone(diff.FunctionsModified)
+	clone.ViewsAdded = slices.Clone(diff.ViewsAdded)
+	clone.ViewsRemoved = slices.Clone(diff.ViewsRemoved)
+	clone.ViewsModified = slices.Clone(diff.ViewsModified)
+	clone.MaterializedViewsAdded = slices.Clone(diff.MaterializedViewsAdded)
+	clone.MaterializedViewsRemoved = slices.Clone(diff.MaterializedViewsRemoved)
+	clone.MaterializedViewsModified = slices.Clone(diff.MaterializedViewsModified)
+	clone.TriggersAdded = slices.Clone(diff.TriggersAdded)
+	clone.TriggersRemoved = slices.Clone(diff.TriggersRemoved)
+	clone.TriggersModified = slices.Clone(diff.TriggersModified)
+	clone.RLSPoliciesAdded = slices.Clone(diff.RLSPoliciesAdded)
+	clone.RLSPoliciesRemoved = slices.Clone(diff.RLSPoliciesRemoved)
+	clone.RLSPoliciesModified = slices.Clone(diff.RLSPoliciesModified)
+	clone.RLSEnabledTablesAdded = slices.Clone(diff.RLSEnabledTablesAdded)
+	clone.RLSEnabledTablesRemoved = slices.Clone(diff.RLSEnabledTablesRemoved)
+	clone.RolesAdded = slices.Clone(diff.RolesAdded)
+	clone.RolesRemoved = slices.Clone(diff.RolesRemoved)
+	clone.RolesModified = slices.Clone(diff.RolesModified)
+	clone.GrantsAdded = slices.Clone(diff.GrantsAdded)
+	clone.GrantsRemoved = slices.Clone(diff.GrantsRemoved)
+	clone.GrantOptionsAdded = slices.Clone(diff.GrantOptionsAdded)
+	clone.GrantOptionsRevoked = slices.Clone(diff.GrantOptionsRevoked)
+	clone.ConstraintsAdded = slices.Clone(diff.ConstraintsAdded)
+	clone.ConstraintsAddedWithTables = slices.Clone(diff.ConstraintsAddedWithTables)
+	clone.ConstraintsRemoved = slices.Clone(diff.ConstraintsRemoved)
+	clone.ConstraintsRemovedWithTables = slices.Clone(diff.ConstraintsRemovedWithTables)
+	return &clone
 }
 
 func createSafetyReportFile(upFile, format string, assessments []safety.StatementAssessment) (string, error) {
@@ -1184,11 +1509,72 @@ func createMigrationFiles(outputDir string, version int64, migrationName, upSQL,
 			return nil, fmt.Errorf("failed to write down migration file: %w", err)
 		}
 
-		return &MigrationFiles{
+		pair := MigrationFilePair{
 			UpFile:   upFilePath,
 			DownFile: downFilePath,
 			Version:  version,
-		}, nil
+		}
+		return migrationFilesFromPairs([]MigrationFilePair{pair}), nil
+	}
+}
+
+func createMigrationFilesFromSpecs(outputDir, reportFormat string, specs []generatedMigrationSpec) (*MigrationFiles, error) {
+	pairs := make([]MigrationFilePair, 0, len(specs))
+	cleanup := func() {
+		for _, pair := range pairs {
+			_ = os.Remove(pair.UpFile)
+			_ = os.Remove(pair.DownFile)
+			if pair.ReportFile != "" {
+				_ = os.Remove(pair.ReportFile)
+			}
+		}
+	}
+	for _, spec := range specs {
+		files, err := createMigrationFiles(outputDir, spec.Version, spec.Name, spec.UpSQL, spec.DownSQL)
+		if err != nil {
+			cleanup()
+			return nil, err
+		}
+		pair := files.Files[0]
+		pair.NoTransaction = spec.NoTransaction
+		if reportFormat != "" {
+			reportFile, err := createSafetyReportFile(pair.UpFile, reportFormat, spec.Assessments)
+			if err != nil {
+				pairs = append(pairs, pair)
+				cleanup()
+				return nil, fmt.Errorf("error creating safety report: %w", err)
+			}
+			pair.ReportFile = reportFile
+		}
+		pairs = append(pairs, pair)
+	}
+	return migrationFilesFromPairs(pairs), nil
+}
+
+func shadowCandidatesFromSpecs(specs []generatedMigrationSpec) []shadowCandidate {
+	candidates := make([]shadowCandidate, 0, len(specs))
+	for _, spec := range specs {
+		candidates = append(candidates, shadowCandidate{
+			Version: spec.Version,
+			Name:    spec.Name,
+			UpSQL:   spec.UpSQL,
+			DownSQL: spec.DownSQL,
+		})
+	}
+	return candidates
+}
+
+func migrationFilesFromPairs(pairs []MigrationFilePair) *MigrationFiles {
+	if len(pairs) == 0 {
+		return nil
+	}
+	first := pairs[0]
+	return &MigrationFiles{
+		UpFile:     first.UpFile,
+		DownFile:   first.DownFile,
+		ReportFile: first.ReportFile,
+		Version:    first.Version,
+		Files:      pairs,
 	}
 }
 

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -61,13 +61,17 @@ type shadowMigrationOptions struct {
 	MigrationsDir string
 	Dialect       string
 	Capabilities  capability.Capabilities
-	Version       int64
-	Name          string
-	UpSQL         string
-	DownSQL       string
+	Candidates    []shadowCandidate
 	Generated     *goschema.Database
 	CompareOpts   *config.CompareOptions
 	Schemas       []string
+}
+
+type shadowCandidate struct {
+	Version int64
+	Name    string
+	UpSQL   string
+	DownSQL string
 }
 
 func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) error {
@@ -94,10 +98,13 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 		return fmt.Errorf("shadow check failed: load prior migrations: %w", err)
 	}
 
-	candidate := migrator.CreateMigrationFromSQL(opts.Version, opts.Name, opts.UpSQL, opts.DownSQL)
-	migrations := make([]*migrator.Migration, 0, len(prior)+1)
+	migrations := make([]*migrator.Migration, 0, len(prior)+len(opts.Candidates))
 	migrations = append(migrations, prior...)
-	migrations = append(migrations, candidate)
+	for _, candidate := range opts.Candidates {
+		migrations = append(migrations,
+			migrator.CreateMigrationFromSQL(candidate.Version, candidate.Name, candidate.UpSQL, candidate.DownSQL),
+		)
+	}
 
 	mig := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...))
 	if err := mig.MigrateUp(replayCtx); err != nil {
@@ -114,7 +121,7 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 	if err := mig.MigrateDownTo(replayCtx, previousVersion); err != nil {
 		return fmt.Errorf("shadow check failed: round-trip down: %w", err)
 	}
-	if err := mig.MigrateTo(replayCtx, opts.Version); err != nil {
+	if err := mig.MigrateTo(replayCtx, latestMigrationVersion(migrations)); err != nil {
 		return fmt.Errorf("shadow check failed: round-trip up: %w", err)
 	}
 	return assertShadowSchemaMatches(conn, opts)

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -145,6 +145,68 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 	})
 }
 
+func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *testing.T) {
+	dbURL := shadowTestDatabaseURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
+		t.Skipf("concurrent index acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
+	}
+	releaseLock := acquireShadowTestLock(c, ctx, conn)
+	defer releaseLock()
+	defer func() {
+		c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	}()
+
+	c.Assert(conn.Writer().DropAllTables(), qt.IsNil)
+	_, err = conn.ExecContext(ctx, `
+		CREATE TABLE users (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL,
+			email TEXT NOT NULL
+		);
+		INSERT INTO users (name, email) VALUES ('Ada', 'ada@example.com');
+		ANALYZE users;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	dir := t.TempDir()
+	entitiesDir := writeConcurrentIndexEntities(c, dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+
+	files, err := GenerateMigration(ctx, GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   dbURL,
+		MigrationName: "add_users_email_index",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(files.Files[0].NoTransaction, qt.IsTrue)
+
+	upSQL, err := os.ReadFile(files.UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upSQL), qt.Contains, "-- +ptah no_transaction")
+	c.Assert(string(upSQL), qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	mig := migrator.NewMigrator(conn, provider)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+}
+
 func shadowTestDatabaseURL() string {
 	for _, name := range []string{"TEST_DATABASE_URL", "TEST_DB_URL", "POSTGRES_TEST_DSN", "POSTGRES_URL"} {
 		if value := os.Getenv(name); value != "" {
@@ -152,6 +214,29 @@ func shadowTestDatabaseURL() string {
 		}
 	}
 	return ""
+}
+
+func writeConcurrentIndexEntities(c *qt.C, dir string) string {
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0755), qt.IsNil)
+
+	content := `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+
+	//migrator:schema:field name="email" type="TEXT"
+	//migrator:schema:index name="idx_users_email" fields="email"
+	Email string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0600), qt.IsNil)
+	return entitiesDir
 }
 
 func acquireShadowTestLock(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) func() {

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -474,9 +474,10 @@ ALTER TABLE users ALTER COLUMN status SET DEFAULT 'archived';
 `no_transaction` executes the migration body and metadata update outside the
 normal per-migration transaction. This is intended for narrow database
 requirements such as PostgreSQL enum value additions that must be used by a
-later statement in the same migration. Migration timeouts are rejected for
-`no_transaction` migrations because Ptah cannot safely apply writer/session
-timeouts to raw autocommit statements.
+later statement in the same migration, or PostgreSQL `CREATE INDEX
+CONCURRENTLY` operations. Migration timeouts
+are rejected for `no_transaction` migrations because Ptah cannot safely apply
+writer/session timeouts to raw autocommit statements.
 
 ## Safety Features
 

--- a/migration/planner/dialects/postgres/concurrent_index_test.go
+++ b/migration/planner/dialects/postgres/concurrent_index_test.go
@@ -105,3 +105,51 @@ func TestPlanner_ConcurrentIndexes(t *testing.T) {
 			qt.Commentf("the original planner must keep the default policy; got:\n%s", sql))
 	})
 }
+
+func TestPlanner_ConcurrentIndexNames(t *testing.T) {
+	diff := &types.SchemaDiff{IndexesAdded: []string{"idx_users_email", "idx_users_name"}}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email"}},
+			{Name: "idx_users_name", StructName: "User", Fields: []string{"name"}},
+		},
+	}
+
+	t.Run("only listed indexes are concurrent", func(t *testing.T) {
+		c := qt.New(t)
+
+		nodes := postgres.New().WithConcurrentIndexNames("", "idx_users_email").GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+		sql = legacyRenderedSQL(sql)
+
+		c.Assert(sql, qt.Contains, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);")
+		c.Assert(sql, qt.Contains, "CREATE INDEX IF NOT EXISTS idx_users_name ON users (name);")
+	})
+
+	t.Run("capability gate still wins", func(t *testing.T) {
+		c := qt.New(t)
+
+		caps := capability.Postgres16().With(capability.CreateIndexConcurrently, false)
+		nodes := postgres.NewWithCapabilities(caps).WithConcurrentIndexNames("idx_users_email").GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+		sql = legacyRenderedSQL(sql)
+
+		c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY")
+	})
+
+	t.Run("does not mutate receiver", func(t *testing.T) {
+		c := qt.New(t)
+
+		base := postgres.New()
+		_ = base.WithConcurrentIndexNames("idx_users_email")
+		nodes := base.GenerateMigrationAST(diff, generated)
+		sql, err := renderer.RenderSQL("postgres", nodes...)
+		c.Assert(err, qt.IsNil)
+		sql = legacyRenderedSQL(sql)
+
+		c.Assert(sql, qt.Not(qt.Contains), "CONCURRENTLY")
+	})
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -72,6 +72,11 @@ type Planner struct {
 	// postgres-compatible preset without it (CockroachDB, issue #171) keeps
 	// plain CREATE INDEX no matter the policy.
 	concurrentIndexes bool
+	// concurrentIndexNames requests CREATE INDEX CONCURRENTLY only for the
+	// listed newly added index names. This lets the generator target indexes
+	// on populated existing tables without changing indexes on newly-created
+	// tables.
+	concurrentIndexNames map[string]struct{}
 }
 
 // New returns a planner configured with the current PostgreSQL line preset
@@ -111,6 +116,32 @@ func (p *Planner) WithConcurrentIndexes() *Planner {
 	cp := *p
 	cp.concurrentIndexes = true
 	return &cp
+}
+
+// WithConcurrentIndexNames returns a copy of the planner that emits
+// CREATE [UNIQUE] INDEX CONCURRENTLY only for the listed newly added indexes,
+// provided the target capability set includes capability.CreateIndexConcurrently.
+func (p *Planner) WithConcurrentIndexNames(indexNames ...string) *Planner {
+	cp := *p
+	cp.concurrentIndexNames = maps.Clone(p.concurrentIndexNames)
+	if cp.concurrentIndexNames == nil {
+		cp.concurrentIndexNames = make(map[string]struct{}, len(indexNames))
+	}
+	for _, indexName := range indexNames {
+		indexName = strings.TrimSpace(indexName)
+		if indexName != "" {
+			cp.concurrentIndexNames[indexName] = struct{}{}
+		}
+	}
+	return &cp
+}
+
+func (p *Planner) usesConcurrentIndex(indexName string) bool {
+	if p.concurrentIndexes {
+		return true
+	}
+	_, ok := p.concurrentIndexNames[indexName]
+	return ok
 }
 
 func (p *Planner) addNewEnums(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
@@ -770,7 +801,7 @@ func (p *Planner) addNewIndexes(result []ast.Node, diff *types.SchemaDiff, gener
 				// planner never emits it for a target that rejects it
 				// (issue #226; CockroachDB-style presets keep plain
 				// CREATE INDEX even when the policy is on).
-				if p.concurrentIndexes && p.capabilities().Has(capability.CreateIndexConcurrently) {
+				if p.usesConcurrentIndex(indexName) && p.capabilities().Has(capability.CreateIndexConcurrently) {
 					indexNode.Concurrently = true
 				}
 				result = append(result, indexNode)

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -148,6 +148,23 @@ type Planner interface {
 	GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
 }
 
+// Options configures high-level planner helpers.
+type Options struct {
+	// Capabilities describes the concrete target server. Nil means the
+	// dialect's default capability preset.
+	Capabilities capability.Capabilities
+	// ConcurrentIndexNames requests PostgreSQL CREATE INDEX CONCURRENTLY for
+	// exactly these newly added index names when the target supports it.
+	ConcurrentIndexNames []string
+}
+
+func (o Options) capabilities(dialect string) capability.Capabilities {
+	if o.Capabilities != nil {
+		return o.Capabilities
+	}
+	return capability.ForDialect(dialect)
+}
+
 // GetPlanner returns a dialect-specific migration planner for the given database dialect.
 //
 // This factory function creates and returns the appropriate planner implementation
@@ -209,11 +226,18 @@ func GetPlanner(dialect string) Planner {
 // DBInfo.Capabilities so planning uses the same server-version preset as
 // readers and renderers. Offline callers should use GetPlanner.
 func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) Planner {
+	return GetPlannerWithOptions(dialect, Options{Capabilities: caps})
+}
+
+// GetPlannerWithOptions returns a dialect-specific migration planner with
+// explicit high-level generation policy.
+func GetPlannerWithOptions(dialect string, opts Options) Planner {
+	caps := opts.capabilities(dialect)
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
-		return postgres.NewWithCapabilities(caps)
+		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(caps)
+		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
 	case platform.MySQL:
 		return mysql.NewWithCapabilities(caps)
 	case platform.MariaDB:
@@ -279,8 +303,40 @@ func GenerateSchemaDiffASTWithCapabilities(
 	dialect string,
 	caps capability.Capabilities,
 ) []ast.Node {
-	planner := GetPlannerWithCapabilities(dialect, caps)
+	return GenerateSchemaDiffASTWithOptions(diff, generated, dialect, Options{Capabilities: caps})
+}
+
+// GenerateSchemaDiffASTWithOptions generates AST nodes with explicit planning
+// options.
+func GenerateSchemaDiffASTWithOptions(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	opts Options,
+) []ast.Node {
+	planner := GetPlannerWithOptions(dialect, opts)
 	return planner.GenerateMigrationAST(diff, generated)
+}
+
+// NodeRequiresNoTransaction reports whether a single planned AST node must run
+// outside the migrator's per-migration transaction.
+func NodeRequiresNoTransaction(dialect string, node ast.Node) bool {
+	if !platform.IsPostgresFamily(dialect) {
+		return false
+	}
+	if index, ok := node.(*ast.IndexNode); ok {
+		return index.Concurrently
+	}
+	alterType, ok := node.(*ast.AlterTypeNode)
+	if !ok {
+		return false
+	}
+	for _, op := range alterType.Operations {
+		if _, ok := op.(*ast.AddEnumValueOperation); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // RequiresNoTransaction reports whether the planned migration contains
@@ -288,18 +344,9 @@ func GenerateSchemaDiffASTWithCapabilities(
 // transaction. Keep this conservative: it should only return true for DDL that
 // is known to be rejected or unusable in a PostgreSQL-family transaction.
 func RequiresNoTransaction(dialect string, nodes []ast.Node) bool {
-	if !platform.IsPostgresFamily(dialect) {
-		return false
-	}
 	for _, node := range nodes {
-		alterType, ok := node.(*ast.AlterTypeNode)
-		if !ok {
-			continue
-		}
-		for _, op := range alterType.Operations {
-			if _, ok := op.(*ast.AddEnumValueOperation); ok {
-				return true
-			}
+		if NodeRequiresNoTransaction(dialect, node) {
+			return true
 		}
 	}
 	return false
@@ -371,7 +418,18 @@ func GenerateSchemaDiffSQLStatementsWithCapabilities(
 	dialect string,
 	caps capability.Capabilities,
 ) []string {
-	output := GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, caps)
+	return GenerateSchemaDiffSQLStatementsWithOptions(diff, generated, dialect, Options{Capabilities: caps})
+}
+
+// GenerateSchemaDiffSQLStatementsWithOptions generates individual SQL
+// statements using explicit planning options.
+func GenerateSchemaDiffSQLStatementsWithOptions(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	opts Options,
+) []string {
+	output := GenerateSchemaDiffSQLWithOptions(diff, generated, dialect, opts)
 	statements := sqlutil.SplitSQLStatements(output)
 	return statements
 }
@@ -448,7 +506,19 @@ func GenerateSchemaDiffSQLWithCapabilities(
 	dialect string,
 	caps capability.Capabilities,
 ) string {
-	astNodes := GenerateSchemaDiffASTWithCapabilities(diff, generated, dialect, caps)
+	return GenerateSchemaDiffSQLWithOptions(diff, generated, dialect, Options{Capabilities: caps})
+}
+
+// GenerateSchemaDiffSQLWithOptions generates complete SQL using explicit
+// planning options.
+func GenerateSchemaDiffSQLWithOptions(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	dialect string,
+	opts Options,
+) string {
+	caps := opts.capabilities(dialect)
+	astNodes := GenerateSchemaDiffASTWithOptions(diff, generated, dialect, opts)
 	output, err := renderer.RenderSQLWithCapabilities(dialect, caps, astNodes...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary
- add row-estimate-aware PostgreSQL generation for populated-table indexes using CREATE INDEX CONCURRENTLY and +ptah no_transaction
- split generated transactional DDL and concurrent index builds into separate migration file pairs, including shadow verification replay for multiple candidates
- expose planner options for targeted concurrent index policy and document the behavior

Closes #152

## Validation
- go tool qtlint ./...
- golangci-lint run --fix ./...
- golangci-lint run ./...
- go test ./... -count=1

Note: the real PostgreSQL acceptance test is env-gated and runs when POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is configured.