### PR TITLE
Fix circular foreign key schema generation

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -2,11 +2,22 @@ package generate
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 )
+
+func outputStatementContaining(output, marker string) string {
+	for statement := range strings.SplitSeq(output, "-- Statement ") {
+		if strings.Contains(statement, marker) {
+			return statement
+		}
+	}
+	return ""
+}
 
 func TestLoadSchemaFile_YAML(t *testing.T) {
 	c := qt.New(t)
@@ -58,4 +69,23 @@ func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
 
 	_, err := loadSchema("", path)
 	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, and .hcl are supported`)
+}
+
+func TestGenerateCommand_MutualForeignKeysAreTwoPhase(t *testing.T) {
+	c := qt.New(t)
+
+	fixtureDir := filepath.Join("..", "..", "integration", "fixtures", "entities", "029-roundtrip-mutual-cycle")
+	cmd := exec.Command("go", "run", "../main.go", "generate", "--root-dir", fixtureDir, "--dialect", "postgres")
+	output, err := cmd.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("generate output:\n%s", output))
+
+	sql := string(output)
+	leftCreate := outputStatementContaining(sql, `CREATE TABLE "left_nodes"`)
+	rightCreate := outputStatementContaining(sql, `CREATE TABLE "right_nodes"`)
+	c.Assert(leftCreate, qt.Not(qt.Equals), "")
+	c.Assert(rightCreate, qt.Not(qt.Equals), "")
+	c.Assert(leftCreate, qt.Not(qt.Contains), "FOREIGN KEY")
+	c.Assert(rightCreate, qt.Not(qt.Contains), "FOREIGN KEY")
+	c.Assert(sql, qt.Contains, `ALTER TABLE "left_nodes" ADD CONSTRAINT "fk_left_nodes_right_id" FOREIGN KEY ("right_id") REFERENCES "right_nodes"("id")`)
+	c.Assert(sql, qt.Contains, `ALTER TABLE "right_nodes" ADD CONSTRAINT "fk_right_nodes_left_id" FOREIGN KEY ("left_id") REFERENCES "left_nodes"("id")`)
 }

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -556,6 +556,8 @@ func isKnownTablePlatformOverride(key string) bool {
 	return slices.Contains(knownKeys, key)
 }
 
+type fieldConverter func(goschema.Field, []goschema.Enum, string) *ast.ColumnNode
+
 // FromTable converts a goschema.Table to an ast.CreateTableNode with all associated columns and constraints.
 //
 // This function creates a complete table definition by combining table metadata with its associated
@@ -632,6 +634,16 @@ func isKnownTablePlatformOverride(key string) bool {
 // Returns a fully configured *ast.CreateTableNode ready for SQL generation.
 // The node contains the table definition with all columns, constraints, and platform-specific options.
 func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.CreateTableNode {
+	return fromTableWithFieldConverter(table, fields, enums, targetPlatform, FromField)
+}
+
+func fromTableWithFieldConverter(
+	table goschema.Table,
+	fields []goschema.Field,
+	enums []goschema.Enum,
+	targetPlatform string,
+	convertField fieldConverter,
+) *ast.CreateTableNode {
 	createTable := ast.NewCreateTable(table.QualifiedName())
 
 	newTable := applyTablePlatformOverrides(createTable, table, targetPlatform)
@@ -676,8 +688,7 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 				field.Primary = false
 			}
 			field = withDefaultForeignKeyName(newTable.Name, field)
-			column := FromField(field, enums, targetPlatform)
-			createTable.AddColumn(column)
+			createTable.AddColumn(convertField(field, enums, targetPlatform))
 		}
 	}
 
@@ -688,6 +699,15 @@ func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.E
 	}
 
 	return createTable
+}
+
+func fromTableWithoutForeignKeys(
+	table goschema.Table,
+	fields []goschema.Field,
+	enums []goschema.Enum,
+	targetPlatform string,
+) *ast.CreateTableNode {
+	return fromTableWithFieldConverter(table, fields, enums, targetPlatform, FromFieldWithoutForeignKeys)
 }
 
 func withDefaultForeignKeyName(tableName string, field goschema.Field) goschema.Field {
@@ -768,6 +788,7 @@ func FromConstraint(constraint goschema.Constraint) *ast.ConstraintNode {
 			Columns:  constraint.ForeignColumns,
 			OnDelete: constraint.OnDelete,
 			OnUpdate: constraint.OnUpdate,
+			Name:     constraint.Name,
 		})
 	case "CHECK":
 		return &ast.ConstraintNode{
@@ -788,12 +809,31 @@ func addTableConstraints(createTable *ast.CreateTableNode, table goschema.Table,
 		if !constraintBelongsToTable(constraint, table) {
 			continue
 		}
+		if isForeignKeyConstraint(constraint) {
+			continue
+		}
 
 		node := FromConstraint(constraint)
 		if node != nil {
 			createTable.AddConstraint(node)
 		}
 	}
+}
+
+func isForeignKeyConstraint(constraint goschema.Constraint) bool {
+	return strings.EqualFold(constraint.Type, "FOREIGN KEY")
+}
+
+func withDefaultConstraintForeignKeyName(tableName string, constraint goschema.Constraint) goschema.Constraint {
+	if !isForeignKeyConstraint(constraint) || constraint.Name != "" {
+		return constraint
+	}
+	columnName := strings.Join(constraint.Columns, "_")
+	if columnName == "" {
+		columnName = "foreign_key"
+	}
+	constraint.Name = GenerateForeignKeyName(tableName, columnName)
+	return constraint
 }
 
 func constraintBelongsToTable(constraint goschema.Constraint, table goschema.Table) bool {
@@ -1052,6 +1092,77 @@ func FromMaterializedView(view goschema.MaterializedView) *ast.CreateMaterialize
 	return viewNode
 }
 
+func appendForeignKeyConstraintStatements(
+	statements *ast.StatementList,
+	tables []goschema.Table,
+	fields []goschema.Field,
+	constraints []goschema.Constraint,
+	targetPlatform string,
+) {
+	appendFieldForeignKeyConstraintStatements(statements, tables, fields, targetPlatform)
+	appendTableForeignKeyConstraintStatements(statements, tables, constraints)
+}
+
+func appendFieldForeignKeyConstraintStatements(
+	statements *ast.StatementList,
+	tables []goschema.Table,
+	fields []goschema.Field,
+	targetPlatform string,
+) {
+	for _, table := range tables {
+		for _, field := range fields {
+			if field.StructName != table.StructName {
+				continue
+			}
+			field = applyPlatformOverrides(field, targetPlatform)
+			if field.Foreign == "" {
+				continue
+			}
+			field = withDefaultForeignKeyName(table.Name, field)
+			fkRef := ParseForeignKeyReference(field.Foreign)
+			if fkRef == nil {
+				continue
+			}
+			fkRef.OnDelete = field.OnDelete
+			fkRef.OnUpdate = field.OnUpdate
+			fkRef.Name = field.ForeignKeyName
+			statements.Statements = append(statements.Statements, &ast.AlterTableNode{
+				Name: table.QualifiedName(),
+				Operations: []ast.AlterOperation{
+					&ast.AddConstraintOperation{
+						Constraint: ast.NewForeignKeyConstraint(field.ForeignKeyName, []string{field.Name}, fkRef),
+					},
+				},
+			})
+		}
+	}
+}
+
+func appendTableForeignKeyConstraintStatements(
+	statements *ast.StatementList,
+	tables []goschema.Table,
+	constraints []goschema.Constraint,
+) {
+	for _, table := range tables {
+		for _, constraint := range constraints {
+			if !constraintBelongsToTable(constraint, table) || !isForeignKeyConstraint(constraint) {
+				continue
+			}
+			constraint = withDefaultConstraintForeignKeyName(table.Name, constraint)
+			node := FromConstraint(constraint)
+			if node == nil {
+				continue
+			}
+			statements.Statements = append(statements.Statements, &ast.AlterTableNode{
+				Name: table.QualifiedName(),
+				Operations: []ast.AlterOperation{
+					&ast.AddConstraintOperation{Constraint: node},
+				},
+			})
+		}
+	}
+}
+
 // FromTrigger converts a goschema.Trigger to an ast.CreateTriggerNode.
 func FromTrigger(trigger goschema.Trigger) *ast.CreateTriggerNode {
 	trigger.Canonicalize()
@@ -1166,16 +1277,17 @@ func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
 // The function generates statements in the following order to respect dependencies:
 //  1. Schema definitions (CREATE SCHEMA statements)
 //  2. Enum type definitions (CREATE TYPE statements)
-//  3. Table definitions (CREATE TABLE statements) with embedded fields processed
-//  4. Extension definitions
-//  5. Dialect-specific objects such as roles, functions, views, RLS policies, grants, and triggers
-//  6. Index definitions (CREATE INDEX statements)
+//  3. Table definitions (CREATE TABLE statements) with embedded fields processed, but without foreign keys
+//  4. Foreign key constraints (ALTER TABLE statements)
+//  5. Extension definitions
+//  6. Dialect-specific objects such as roles, functions, views, RLS policies, grants, and triggers
+//  7. Index definitions (CREATE INDEX statements)
 //
 // This ordering ensures that:
 //   - Schemas are created before tables that reference them
 //   - Enum types are created before tables that reference them
 //   - Tables are created before indexes that reference them
-//   - Foreign key dependencies are handled by the table creation order
+//   - Foreign key dependencies are handled after table creation, so cyclic table references remain executable
 //   - Embedded fields are processed and converted to regular fields before table creation
 //
 // # Embedded Field Processing
@@ -1240,10 +1352,11 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// 3. Add table definitions (they may be referenced by indexes)
 	// Use the combined field list that includes embedded field expansions
 	for _, table := range database.Tables {
-		tableNode := FromTable(table, allFields, database.Enums, targetPlatform)
+		tableNode := fromTableWithoutForeignKeys(table, allFields, database.Enums, targetPlatform)
 		addTableConstraints(tableNode, table, database.Constraints)
 		statements.Statements = append(statements.Statements, tableNode)
 	}
+	appendForeignKeyConstraintStatements(statements, database.Tables, allFields, database.Constraints, targetPlatform)
 
 	// 4. Add extension definitions (PostgreSQL-specific)
 	for _, extension := range database.Extensions {

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 )
 
+func tableStatementByName(statements *ast.StatementList, name string) *ast.CreateTableNode {
+	for _, stmt := range statements.Statements {
+		table, ok := stmt.(*ast.CreateTableNode)
+		if ok && table.Name == name {
+			return table
+		}
+	}
+	return nil
+}
+
+func foreignKeyAlterStatementByName(statements *ast.StatementList, tableName, constraintName string) *ast.AlterTableNode {
+	for _, stmt := range statements.Statements {
+		alter, ok := stmt.(*ast.AlterTableNode)
+		if !ok || alter.Name != tableName {
+			continue
+		}
+		for _, operation := range alter.Operations {
+			add, ok := operation.(*ast.AddConstraintOperation)
+			if ok && add.Constraint.Name == constraintName && add.Constraint.Type == ast.ForeignKeyConstraint {
+				return alter
+			}
+		}
+	}
+	return nil
+}
+
 func TestFromField_BasicProperties(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -753,6 +779,66 @@ func TestFromDatabase_TableLevelConstraints(t *testing.T) {
 	c.Assert(table.Constraints[0].Expression, qt.Equals, "position('@' in email) > 1")
 }
 
+func TestFromDatabase_TableLevelForeignKeysAreTwoPhase(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Account", Name: "accounts"},
+			{StructName: "Profile", Name: "profiles"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Account", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Account", Name: "profile_id", Type: "INTEGER"},
+			{StructName: "Profile", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Profile", Name: "account_id", Type: "INTEGER"},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Account",
+				Name:           "fk_accounts_profiles",
+				Type:           "FOREIGN KEY",
+				Columns:        []string{"profile_id"},
+				ForeignTable:   "profiles",
+				ForeignColumns: []string{"id"},
+				OnDelete:       "CASCADE",
+			},
+			{
+				StructName:    "Profile",
+				Type:          "FOREIGN KEY",
+				Columns:       []string{"account_id"},
+				ForeignTable:  "accounts",
+				ForeignColumn: "id",
+				OnUpdate:      "RESTRICT",
+			},
+		},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+
+	c.Assert(result.Statements, qt.HasLen, 4)
+	accounts := result.Statements[0].(*ast.CreateTableNode)
+	profiles := result.Statements[1].(*ast.CreateTableNode)
+	c.Assert(accounts.Constraints, qt.HasLen, 0)
+	c.Assert(profiles.Constraints, qt.HasLen, 0)
+
+	accountsFK := foreignKeyAlterStatementByName(result, "accounts", "fk_accounts_profiles")
+	c.Assert(accountsFK, qt.IsNotNil)
+	addAccountsFK := accountsFK.Operations[0].(*ast.AddConstraintOperation)
+	c.Assert(addAccountsFK.Constraint.Columns, qt.DeepEquals, []string{"profile_id"})
+	c.Assert(addAccountsFK.Constraint.Reference.Table, qt.Equals, "profiles")
+	c.Assert(addAccountsFK.Constraint.Reference.ReferencedColumns(), qt.DeepEquals, []string{"id"})
+	c.Assert(addAccountsFK.Constraint.Reference.OnDelete, qt.Equals, "CASCADE")
+
+	profilesFK := foreignKeyAlterStatementByName(result, "profiles", "fk_profiles_account_id")
+	c.Assert(profilesFK, qt.IsNotNil)
+	addProfilesFK := profilesFK.Operations[0].(*ast.AddConstraintOperation)
+	c.Assert(addProfilesFK.Constraint.Columns, qt.DeepEquals, []string{"account_id"})
+	c.Assert(addProfilesFK.Constraint.Reference.Table, qt.Equals, "accounts")
+	c.Assert(addProfilesFK.Constraint.Reference.ReferencedColumns(), qt.DeepEquals, []string{"id"})
+	c.Assert(addProfilesFK.Constraint.Reference.OnUpdate, qt.Equals, "RESTRICT")
+}
+
 func TestFromDatabase_Schemas(t *testing.T) {
 	c := qt.New(t)
 
@@ -1146,9 +1232,9 @@ func TestFromDatabase_CompleteSchema(t *testing.T) {
 	result := fromschema.FromDatabase(database, "")
 
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(result.Statements, qt.HasLen, 5) // 1 enum + 2 tables + 2 indexes
+	c.Assert(result.Statements, qt.HasLen, 6) // 1 enum + 2 tables + 1 FK + 2 indexes
 
-	// Check statement ordering: enums first, then tables, then indexes
+	// Check statement ordering: enums first, then tables, then foreign keys, then indexes
 	enumNode, ok := result.Statements[0].(*ast.EnumNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(enumNode.Name, qt.Equals, "user_status")
@@ -1161,11 +1247,15 @@ func TestFromDatabase_CompleteSchema(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(table2Node.Name, qt.Equals, "posts")
 
-	index1Node, ok := result.Statements[3].(*ast.IndexNode)
+	fkNode, ok := result.Statements[3].(*ast.AlterTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(fkNode.Name, qt.Equals, "posts")
+
+	index1Node, ok := result.Statements[4].(*ast.IndexNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(index1Node.Name, qt.Equals, "idx_users_status")
 
-	index2Node, ok := result.Statements[4].(*ast.IndexNode)
+	index2Node, ok := result.Statements[5].(*ast.IndexNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(index2Node.Name, qt.Equals, "idx_posts_user")
 }
@@ -1871,7 +1961,7 @@ func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {
 				},
 			},
 			expected: func(result *ast.StatementList) bool {
-				if len(result.Statements) != 1 {
+				if len(result.Statements) != 2 {
 					return false
 				}
 				tableNode, ok := result.Statements[0].(*ast.CreateTableNode)
@@ -1884,10 +1974,9 @@ func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {
 					tableNode.Columns[0].Name == "id" &&
 					tableNode.Columns[1].Name == "user_id" &&
 					tableNode.Columns[1].Type == "INTEGER" &&
-					tableNode.Columns[1].ForeignKey != nil &&
-					tableNode.Columns[1].ForeignKey.Table == "users" &&
-					tableNode.Columns[1].ForeignKey.Column == "id" &&
-					tableNode.Columns[1].Comment == "Reference to user"
+					tableNode.Columns[1].ForeignKey == nil &&
+					tableNode.Columns[1].Comment == "Reference to user" &&
+					foreignKeyAlterStatementByName(result, "posts", "fk_post_user_id") != nil
 			},
 		},
 		{
@@ -1919,7 +2008,7 @@ func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {
 				},
 			},
 			expected: func(result *ast.StatementList) bool {
-				if len(result.Statements) != 1 {
+				if len(result.Statements) != 2 {
 					return false
 				}
 				tableNode, ok := result.Statements[0].(*ast.CreateTableNode)
@@ -1933,9 +2022,8 @@ func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {
 					tableNode.Columns[1].Name == "customer_uuid" &&
 					tableNode.Columns[1].Type == "VARCHAR(36)" && // UUID type inference
 					tableNode.Columns[1].Nullable == true &&
-					tableNode.Columns[1].ForeignKey != nil &&
-					tableNode.Columns[1].ForeignKey.Table == "customers" &&
-					tableNode.Columns[1].ForeignKey.Column == "uuid"
+					tableNode.Columns[1].ForeignKey == nil &&
+					foreignKeyAlterStatementByName(result, "orders", "fk_order_customer_uuid") != nil
 			},
 		},
 		{
@@ -2239,7 +2327,7 @@ func TestFromDatabase_EmbeddedFields_ComplexScenario(t *testing.T) {
 	result := fromschema.FromDatabase(database, "")
 
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(result.Statements, qt.HasLen, 1)
+	c.Assert(result.Statements, qt.HasLen, 2)
 
 	tableNode, ok := result.Statements[0].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
@@ -2296,9 +2384,13 @@ func TestFromDatabase_EmbeddedFields_ComplexScenario(t *testing.T) {
 	c.Assert(columns["author_id"], qt.IsNotNil)
 	c.Assert(columns["author_id"].Type, qt.Equals, "INTEGER")
 	c.Assert(columns["author_id"].Comment, qt.Equals, "Article author")
-	c.Assert(columns["author_id"].ForeignKey, qt.IsNotNil)
-	c.Assert(columns["author_id"].ForeignKey.Table, qt.Equals, "users")
-	c.Assert(columns["author_id"].ForeignKey.Column, qt.Equals, "id")
+	c.Assert(columns["author_id"].ForeignKey, qt.IsNil)
+
+	authorFK := foreignKeyAlterStatementByName(result, "articles", "fk_article_author_id")
+	c.Assert(authorFK, qt.IsNotNil)
+	addAuthorFK := authorFK.Operations[0].(*ast.AddConstraintOperation)
+	c.Assert(addAuthorFK.Constraint.Reference.Table, qt.Equals, "users")
+	c.Assert(addAuthorFK.Constraint.Reference.ReferencedColumns(), qt.DeepEquals, []string{"id"})
 }
 
 // TestFromField_EnumConversion_SQLInjectionPrevention tests that enum values are properly escaped
@@ -2356,7 +2448,7 @@ func TestFromField_EnumConversion_SQLInjectionPrevention(t *testing.T) {
 
 // TestFromDatabase_EmbeddedRelationFKActions verifies that on_delete /
 // on_update declared on a //migrator:embedded mode="relation" annotation
-// flow through to the column-level ForeignKey on the generated table.
+// flow through to the generated foreign key constraint.
 //
 // Regression coverage for the embedded path of issue #117 — the field-level
 // fix wired the regular Field path, and this test pins the parallel wiring
@@ -2390,13 +2482,7 @@ func TestFromDatabase_EmbeddedRelationFKActions(t *testing.T) {
 	statements := fromschema.FromDatabase(db, "postgres")
 	c.Assert(statements, qt.IsNotNil)
 
-	var postsTable *ast.CreateTableNode
-	for _, stmt := range statements.Statements {
-		if t, ok := stmt.(*ast.CreateTableNode); ok && t.Name == "posts" {
-			postsTable = t
-			break
-		}
-	}
+	postsTable := tableStatementByName(statements, "posts")
 	c.Assert(postsTable, qt.IsNotNil)
 
 	var authorCol *ast.ColumnNode
@@ -2407,8 +2493,12 @@ func TestFromDatabase_EmbeddedRelationFKActions(t *testing.T) {
 		}
 	}
 	c.Assert(authorCol, qt.IsNotNil)
-	c.Assert(authorCol.ForeignKey, qt.IsNotNil)
-	c.Assert(authorCol.ForeignKey.Table, qt.Equals, "users")
-	c.Assert(authorCol.ForeignKey.OnDelete, qt.Equals, "CASCADE")
-	c.Assert(authorCol.ForeignKey.OnUpdate, qt.Equals, "RESTRICT")
+	c.Assert(authorCol.ForeignKey, qt.IsNil)
+
+	authorFK := foreignKeyAlterStatementByName(statements, "posts", "fk_post_author_id")
+	c.Assert(authorFK, qt.IsNotNil)
+	addAuthorFK := authorFK.Operations[0].(*ast.AddConstraintOperation)
+	c.Assert(addAuthorFK.Constraint.Reference.Table, qt.Equals, "users")
+	c.Assert(addAuthorFK.Constraint.Reference.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(addAuthorFK.Constraint.Reference.OnUpdate, qt.Equals, "RESTRICT")
 }

--- a/core/goschema/pointer_embedded_integration_test.go
+++ b/core/goschema/pointer_embedded_integration_test.go
@@ -162,15 +162,18 @@ type BlogPost struct {
 	// Generate schema
 	statements := fromschema.FromDatabase(*database, "postgresql")
 
-	// Find the BlogPost CREATE TABLE statement
-	var blogPostSQL string
+	// Find the BlogPost CREATE TABLE and FK ALTER TABLE statements
+	var blogPostSQL, blogPostFKSQL string
 	for _, stmt := range statements.Statements {
 		sql, err := renderer.RenderSQL("postgresql", stmt)
 		c.Assert(err, qt.IsNil)
 		sql = legacyRenderedSQL(sql)
 		if containsSubstr(sql, "CREATE TABLE blog_posts") {
 			blogPostSQL = sql
-			break
+			continue
+		}
+		if containsSubstr(sql, "ALTER TABLE blog_posts") && containsSubstr(sql, "FOREIGN KEY") {
+			blogPostFKSQL = sql
 		}
 	}
 
@@ -202,9 +205,10 @@ type BlogPost struct {
 			qt.Commentf("BlogPost table should NOT contain skipped column %s", column))
 	}
 
-	// Verify foreign key constraint is present
-	c.Assert(containsSubstr(blogPostSQL, "FOREIGN KEY"), qt.IsTrue)
-	c.Assert(containsSubstr(blogPostSQL, "REFERENCES users(id)"), qt.IsTrue)
+	// Verify foreign key constraint is emitted after table creation.
+	c.Assert(containsSubstr(blogPostSQL, "FOREIGN KEY"), qt.IsFalse)
+	c.Assert(containsSubstr(blogPostFKSQL, "FOREIGN KEY"), qt.IsTrue)
+	c.Assert(containsSubstr(blogPostFKSQL, "REFERENCES users(id)"), qt.IsTrue)
 
 	t.Logf("Generated BlogPost SQL:\n%s", blogPostSQL)
 }

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -74,7 +74,7 @@ func checkForCircularDependencies(r *Database, sorted *[]Table) {
 		return
 	}
 
-	slog.Warn("Circular dependency detected in foreign key relationships. Some tables may not be ordered correctly.")
+	slog.Warn("Circular dependency detected in foreign key relationships; emit foreign keys after table creation to keep DDL executable.")
 	// Add remaining tables to the end
 	for _, table := range r.Tables {
 		found := false

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -454,15 +454,61 @@ func TestGetOrderedCreateStatements(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	statements := renderer.GetOrderedCreateStatements(result, "postgres")
-	c.Assert(statements, qt.HasLen, len(result.Tables)+3) // 1 type + 2 indexes
 
 	c.Assert(statements[0], qt.Contains, "CREATE TYPE")
-	c.Assert(statements[17], qt.Contains, "CREATE INDEX")
-	c.Assert(statements[18], qt.Contains, "CREATE INDEX")
 
-	for i := 1; i < 17; i++ {
-		c.Assert(statements[i], qt.Contains, "CREATE TABLE")
+	createTables := 0
+	foreignKeyAlters := 0
+	indexes := 0
+	seenForeignKeyAlter := false
+	seenIndex := false
+	for _, statement := range statements[1:] {
+		switch {
+		case strings.Contains(statement, "CREATE TABLE"):
+			c.Assert(seenForeignKeyAlter, qt.IsFalse)
+			c.Assert(seenIndex, qt.IsFalse)
+			c.Assert(statement, qt.Not(qt.Contains), "FOREIGN KEY")
+			createTables++
+		case strings.Contains(statement, "ALTER TABLE") && strings.Contains(statement, "FOREIGN KEY"):
+			c.Assert(seenIndex, qt.IsFalse)
+			seenForeignKeyAlter = true
+			foreignKeyAlters++
+		case strings.Contains(statement, "CREATE INDEX"):
+			seenIndex = true
+			indexes++
+		}
 	}
+
+	c.Assert(createTables, qt.Equals, len(result.Tables))
+	c.Assert(foreignKeyAlters > 0, qt.IsTrue)
+	c.Assert(indexes, qt.Equals, 2)
+}
+
+func TestGetOrderedCreateStatements_MutualForeignKeysAreTwoPhase(t *testing.T) {
+	c := qt.New(t)
+
+	result := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "A", Name: "a"},
+			{StructName: "B", Name: "b"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "A", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "A", Name: "b_id", Type: "INTEGER", Foreign: "b(id)", ForeignKeyName: "fk_a_b"},
+			{StructName: "B", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "B", Name: "a_id", Type: "INTEGER", Foreign: "a(id)", ForeignKeyName: "fk_b_a"},
+		},
+	}
+
+	statements := renderer.GetOrderedCreateStatements(result, "postgres")
+
+	c.Assert(statements, qt.HasLen, 4)
+	c.Assert(statements[0], qt.Contains, `CREATE TABLE "a"`)
+	c.Assert(statements[0], qt.Not(qt.Contains), "FOREIGN KEY")
+	c.Assert(statements[1], qt.Contains, `CREATE TABLE "b"`)
+	c.Assert(statements[1], qt.Not(qt.Contains), "FOREIGN KEY")
+	c.Assert(statements[2], qt.Contains, `ALTER TABLE "a" ADD CONSTRAINT "fk_a_b" FOREIGN KEY ("b_id") REFERENCES "b"("id")`)
+	c.Assert(statements[3], qt.Contains, `ALTER TABLE "b" ADD CONSTRAINT "fk_b_a" FOREIGN KEY ("a_id") REFERENCES "a"("id")`)
 }
 
 func TestGenerateSchema_Deterministic(t *testing.T) {

--- a/integration/gonative/circular_fk_generate_integration_test.go
+++ b/integration/gonative/circular_fk_generate_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestPostgreSQLGenerateMutualForeignKeysApplyIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupMutualForeignKeyTables(t, db)
+	defer cleanupMutualForeignKeyTables(t, db)
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	c.Assert(ok, qt.IsTrue)
+	fixtureDir := filepath.Join(
+		filepath.Dir(currentFile),
+		"..",
+		"fixtures",
+		"entities",
+		"029-roundtrip-mutual-cycle",
+	)
+
+	database, err := goschema.ParseDir(fixtureDir)
+	c.Assert(err, qt.IsNil)
+
+	sqlText := strings.Join(renderer.GetOrderedCreateStatements(database, "postgres"), "\n")
+	c.Assert(sqlText, qt.Contains, `ALTER TABLE "left_nodes" ADD CONSTRAINT "fk_left_nodes_right_id"`)
+	c.Assert(sqlText, qt.Contains, `ALTER TABLE "right_nodes" ADD CONSTRAINT "fk_right_nodes_left_id"`)
+
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", stmt))
+	}
+
+	var foreignKeyCount int
+	err = db.QueryRow(`
+		SELECT count(*)
+		FROM pg_constraint
+		WHERE contype = 'f'
+			AND conname IN ('fk_left_nodes_right_id', 'fk_right_nodes_left_id')
+	`).Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func cleanupMutualForeignKeyTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`DROP TABLE IF EXISTS "left_nodes", "right_nodes" CASCADE`)
+	qt.Assert(t, err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary

- make `fromschema.FromDatabase` emit tables without foreign keys, then add all field-level and table-level foreign keys in a separate `ALTER TABLE ... ADD CONSTRAINT` phase
- keep `FromTable` as the low-level inline-FK converter while moving the public schema-to-DDL path used by `generate` / `read-db` to two-phase output
- generate stable names for unnamed table-level FK constraints and update the circular-dependency warning text so it no longer implies generated DDL is broken

## Self-Review

- Logic: covers the actual schema-to-DDL path from the issue comments, not the already cycle-safe migration planner path.
- Dialects: uses existing AST renderers, so PostgreSQL/MySQL/MariaDB/Cockroach/Yugabyte behavior stays capability-gated by renderers; field-level FKs keep stable generated names.
- Table-level constraints: non-FK constraints remain inline; table-level FKs now join the second phase so composite/table-level cycles are not left behind.
- Safety: no raw SQL concatenation from new code beyond existing renderer paths; no config relaxation or linter exclusions.
- Compatibility: intentionally changes pre-GA `FromDatabase` statement ordering to the cleaner two-phase architecture.

## Validation

- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1`
- `POSTGRES_TEST_DSN='postgres://ptah_user:ptah_password@localhost:5433/ptah_test?sslmode=disable' go test -tags integration ./integration/gonative -run TestPostgreSQLGenerateMutualForeignKeysApplyIntegration -count=1 -v`

Fixes #137
