### PR TITLE
Harden project config loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This file gives coding agents repository-local guidance for working in Ptah.
 
+## Language And Spelling
+
+Use American English spelling in code, comments, documentation, issue/PR text,
+and user-facing CLI output unless preserving an exact external quote or protocol
+token. Prefer spellings such as `behavior`, `color`, `canceled`, `initialize`,
+`normalize`, and `analyze`.
+
 ## Code Style And Linting
 
 Ptah treats `.golangci.yml` as a strict contract. Fix code to satisfy the configured linters instead of relaxing thresholds, disabling checks, or broadening exclusions. In particular, keep `revive` `error-strings` enabled and preserve the current "stricter wins" lint posture unless a maintainer explicitly asks for a config change.

--- a/README.md
+++ b/README.md
@@ -788,13 +788,15 @@ helpers such as `{{ define "shared/users" }}` and are not executed as standalone
 migrations. The template data object exposes `.Env`; CLI commands set it with
 `--atlas-env`, and programmatic callers can pass `WithAtlasTemplateData`.
 
-Ptah can also read a limited Atlas project config subset from `atlas.hcl`.
-Supported `env` blocks can provide `url`, `dev`, `exclude`, `migration { dir,
-format, revisions_schema, lock_timeout, exec_order }`, and `lint { latest }`.
-Project config precedence is explicit CLI flags, then `atlas.hcl`, then
-`ptah.yaml`, then built-in defaults. Use `--env <name>` when multiple `env`
-blocks exist; a single env is selected automatically. See
-[Atlas Project Config](docs/atlas_project_config.md).
+Ptah reads project defaults from strict `ptah.yaml` named environments and can
+also translate a limited Atlas project config subset from `atlas.hcl`.
+Supported settings include database URL, dev/shadow URL, schema allow-list,
+migration directory/revision-table settings, timeouts, execution order, lint
+defaults, and online-DDL routing. Project config precedence is explicit CLI
+flags, then `PTAH_*` environment variables, then `atlas.hcl`, then `ptah.yaml`,
+then built-in defaults. Use `--env <name>` when multiple env blocks exist; a
+single env is selected automatically. See [Ptah Project Config](docs/project_config.md)
+and [Atlas Project Config](docs/atlas_project_config.md).
 
 `--dir-format` controls only migration-file discovery. To continue a database
 that already uses Atlas's runtime history table, pass `--revision-format atlas`

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -101,6 +101,11 @@ func ParseSchemas(raw string) []string {
 	return schemas
 }
 
+// JoinSchemas formats a project-config schema list as the CLI flag value.
+func JoinSchemas(schemas []string) string {
+	return strings.Join(schemas, ",")
+}
+
 // ParseConnectTimeout parses the raw string value returned by the
 // [ConnectTimeoutFlagName] flag. A zero duration is accepted and signals that
 // callers should not wrap the parent context with a deadline.

--- a/cmd/internal/dbcli/onlineddl.go
+++ b/cmd/internal/dbcli/onlineddl.go
@@ -31,13 +31,19 @@ func NewConfigFlag() cobraflags.Flag {
 // An explicitly passed path must exist; the conventional ./ptah.yaml is
 // optional and yields a disabled config when absent.
 func LoadOnlineDDLConfig(path string) (*onlineddl.Config, error) {
+	return LoadOnlineDDLConfigForEnv(path, "")
+}
+
+// LoadOnlineDDLConfigForEnv loads the online_ddl section after applying a
+// selected project environment.
+func LoadOnlineDDLConfigForEnv(path, envName string) (*onlineddl.Config, error) {
 	if path == "" {
-		return onlineddl.LoadConfig(onlineddl.ConfigFileName)
+		return onlineddl.LoadConfigForEnv(onlineddl.ConfigFileName, envName)
 	}
 	if _, err := os.Stat(path); err != nil {
 		return nil, fmt.Errorf("ptah config %s: %w", path, err)
 	}
-	return onlineddl.LoadConfig(path)
+	return onlineddl.LoadConfigForEnv(path, envName)
 }
 
 // MigrateGenerateConfig is the migrate.generate section of ptah.yaml.

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	// EnvFlagName selects an env block from atlas.hcl.
+	// EnvFlagName selects an env block from project config.
 	EnvFlagName = "env"
 )
 
-// NewEnvFlag returns the shared Atlas project env selection flag.
+// NewEnvFlag returns the shared project env selection flag.
 func NewEnvFlag() cobraflags.Flag {
 	return &cobraflags.StringFlag{
 		Name:  EnvFlagName,
 		Value: "",
-		Usage: "Atlas project env name to read from atlas.hcl",
+		Usage: "Project env name to read from ptah.yaml or atlas.hcl",
 	}
 }
 

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -64,3 +64,58 @@ migration:
 	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
 	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
 }
+
+func TestLoadProjectConfigReadsNamedPtahEnvRuntimeDefaults(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, projectconfig.PtahFileName), []byte(`env:
+  prod:
+    url: postgres://prod/db
+    dev: postgres://prod/shadow
+    schemas: [public, tenant]
+    migration:
+      dir: ./migrations
+      format: atlas
+      revisions_schema: atlas
+      revisions_table: atlas_schema_revisions
+      revision_format: atlas
+      lock_timeout: 3s
+      statement_timeout: 30s
+      connect_timeout: 10s
+      migration_lock_timeout: 15s
+      exec_order: non-linear
+    lint:
+      dialect: postgres
+      disabled-rules: [MF103]
+`), 0o600), qt.IsNil)
+	originalWD, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	defer func() {
+		c.Assert(os.Chdir(originalWD), qt.IsNil)
+	}()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(dbcli.EnvFlagName, "", "")
+	c.Assert(cmd.Flags().Set(dbcli.EnvFlagName, "prod"), qt.IsNil)
+
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://prod/db")
+	c.Assert(cfg.DevURL, qt.Equals, "postgres://prod/shadow")
+	c.Assert(cfg.Schemas, qt.DeepEquals, []string{"public", "tenant"})
+	c.Assert(cfg.Migration.Dir, qt.Equals, "./migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionsSchema, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionsTable, qt.Equals, "atlas_schema_revisions")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.LockTimeout, qt.Equals, "3s")
+	c.Assert(cfg.Migration.StatementTimeout, qt.Equals, "30s")
+	c.Assert(cfg.Migration.ConnectTimeout, qt.Equals, "10s")
+	c.Assert(cfg.Migration.MigrationLockTimeout, qt.Equals, "15s")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
+	c.Assert(cfg.Lint.Dialect, qt.Equals, "postgres")
+	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{"MF103"})
+}

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -80,7 +80,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions, sarif")
 	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+lint.ConfigFileName+" when present)")
 	cmd.Flags().StringVar(&atlasEnv, "atlas-env", "", "Value exposed as .Env when rendering Atlas SQL template migrations")
-	cmd.Flags().StringVar(&envName, dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")
+	cmd.Flags().StringVar(&envName, dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 	cmd.Flags().StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DS101 or MY (repeatable)")
 	cmd.Flags().StringVar(&failOn, "fail-on", failOnError, "Failure threshold controlling the exit code: error, any or none")
 
@@ -204,6 +204,12 @@ func runLint(cmd *cobra.Command, opts runOptions) error {
 	cfg, err := loadConfig(opts)
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, opts.failOn, err.Error())
+	}
+	if cfg.Dialect == "" {
+		cfg.Dialect = projectCfg.Lint.Dialect
+	}
+	if len(cfg.DisabledRules) == 0 {
+		cfg.DisabledRules = append([]string{}, projectCfg.Lint.DisabledRules...)
 	}
 	if !isValidDialect(cfg.Dialect) {
 		msg := fmt.Sprintf("invalid dialect %q in lint config: expected postgres, mysql, mariadb, clickhouse, cockroachdb, yugabytedb, or spanner", cfg.Dialect)

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -159,6 +159,42 @@ func TestRunLint_ConfigFileDisablesRulesAndSetsDialect(t *testing.T) {
 	}
 }
 
+func TestRunLint_ProjectConfigDisablesRulesAndSetsDialect(t *testing.T) {
+	c := qt.New(t)
+	badDir, err := filepath.Abs("testdata/bad")
+	c.Assert(err, qt.IsNil)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "ptah.yaml"), []byte(`lint:
+  dialect: postgres
+  disabled-rules:
+    - MF
+`), 0o600), qt.IsNil)
+	originalWD, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	defer func() {
+		c.Assert(os.Chdir(originalWD), qt.IsNil)
+	}()
+
+	_, stderr, err := execute("--dir", badDir, "--format", "json")
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf("DS errors remain, so the run still fails"))
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	var report struct {
+		Dialect  string         `json:"dialect"`
+		Findings []lint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stderr), &report), qt.IsNil)
+	c.Assert(report.Dialect, qt.Equals, "postgres")
+	for _, f := range report.Findings {
+		c.Assert(f.Rule, qt.Not(qt.Contains), "MF",
+			qt.Commentf("the MF family is disabled by ptah.yaml; got %v", f))
+		c.Assert(f.Rule, qt.Not(qt.Equals), "MY101",
+			qt.Commentf("dialect: postgres from ptah.yaml must gate MY rules; got %v", f))
+	}
+}
+
 func TestRunLint_ConfigRuleSeverityAndExclude(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -47,7 +47,7 @@ and performs an up/down/up round-trip.`,
 	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "", html, or json`)
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
 	flags.String(dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String(), "Initial database connection timeout")
-	flags.String(dbcli.EnvFlagName, "", "Atlas project env name to read from atlas.hcl")
+	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 	flags.String(dbcli.SchemasFlagName, "", "Comma-separated schemas to introspect when supported")
 
 	return cmd
@@ -105,6 +105,8 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	schemasValue = dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, schemasValue, dbcli.JoinSchemas(projectCfg.Schemas))
+	connectTimeoutValue = dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, connectTimeoutValue, projectCfg.Migration.ConnectTimeout)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -153,9 +153,13 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
 	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
 	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
+	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
 	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
+	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
 	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
 	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
+	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, migrateDownFlags[dbcli.ConnectTimeoutFlagName].GetString(), projectCfg.Migration.ConnectTimeout)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -199,7 +203,7 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	connectTimeout, err := dbcli.ParseConnectTimeout(migrateDownFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	connectTimeout, err := dbcli.ParseConnectTimeout(connectTimeoutValue)
 	if err != nil {
 		return err
 	}
@@ -234,7 +238,7 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 
 	// Online-DDL routing works for down migrations too: a rollback ALTER on
 	// a large table is just as lock-heavy as the forward one.
-	onlineCfg, err := dbcli.LoadOnlineDDLConfig(configPath)
+	onlineCfg, err := dbcli.LoadOnlineDDLConfigForEnv(configPath, projectCfg.EnvName)
 	if err != nil {
 		return err
 	}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -71,6 +71,7 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Usage: "Output status in JSON format",
 	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
+	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
 	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
 	dbcli.MigrationsSchemaFlagName:    dbcli.NewMigrationsSchemaFlag(),
 	dbcli.MigrationsTableFlagName:     dbcli.NewMigrationsTableFlag(),
@@ -97,8 +98,9 @@ func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateStatusFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateStatusFlags[dbcli.RevisionTableFormatFlagName].GetString()
+	configPath := migrateStatusFlags[dbcli.ConfigFlagName].GetString()
 
-	projectCfg, err := dbcli.LoadProjectConfig(cmd, "")
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
 	if err != nil {
 		return err
 	}
@@ -107,7 +109,9 @@ func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
 	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
 	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
 	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
+	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, migrateStatusFlags[dbcli.ConnectTimeoutFlagName].GetString(), projectCfg.Migration.ConnectTimeout)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -126,7 +130,7 @@ func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	connectTimeout, err := dbcli.ParseConnectTimeout(migrateStatusFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	connectTimeout, err := dbcli.ParseConnectTimeout(connectTimeoutValue)
 	if err != nil {
 		return err
 	}

--- a/cmd/migratestatus/migratestatus_test.go
+++ b/cmd/migratestatus/migratestatus_test.go
@@ -17,6 +17,7 @@ func TestMigrateStatusCommand_Creation(t *testing.T) {
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "migrate-status")
 	c.Assert(cmd.Short, qt.Contains, "Show current migration status")
+	c.Assert(cmd.Flag(dbcli.ConfigFlagName), qt.IsNotNil)
 	c.Assert(cmd.Flag(dbcli.MigrationsSchemaFlagName), qt.IsNotNil)
 	c.Assert(cmd.Flag(dbcli.MigrationsTableFlagName), qt.IsNotNil)
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -155,9 +155,13 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
 	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
 	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
+	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
 	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
+	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
 	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
+	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
 	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
+	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, migrateUpFlags[dbcli.ConnectTimeoutFlagName].GetString(), projectCfg.Migration.ConnectTimeout)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
@@ -212,7 +216,7 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	connectTimeout, err := dbcli.ParseConnectTimeout(migrateUpFlags[dbcli.ConnectTimeoutFlagName].GetString())
+	connectTimeout, err := dbcli.ParseConnectTimeout(connectTimeoutValue)
 	if err != nil {
 		return err
 	}
@@ -247,7 +251,7 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	// Online-DDL routing: `-- +ptah online_ddl_tool=...` directives always
 	// work; the ptah.yaml online_ddl section adds automatic routing of
 	// ALTERs on tables above the configured row threshold.
-	onlineCfg, err := dbcli.LoadOnlineDDLConfig(configPath)
+	onlineCfg, err := dbcli.LoadOnlineDDLConfigForEnv(configPath, projectCfg.EnvName)
 	if err != nil {
 		return err
 	}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -14,14 +14,12 @@ import (
 )
 
 // LoadAtlasFile loads the supported subset of an Atlas project config file. A
-// missing file returns an empty config unless envName is set.
+// missing file returns an empty config.
 func LoadAtlasFile(path, envName string) (Config, error) {
 	raw, err := os.ReadFile(path)
 	switch {
-	case errors.Is(err, fs.ErrNotExist) && envName == "":
-		return Config{}, nil
 	case errors.Is(err, fs.ErrNotExist):
-		return Config{}, fmt.Errorf("atlas config %s: %w", path, err)
+		return Config{}, nil
 	case err != nil:
 		return Config{}, fmt.Errorf("failed to read atlas config %s: %w", path, err)
 	}
@@ -120,6 +118,7 @@ func (p atlasParser) parseEnv(block *hclsyntax.Block) (atlasEnv, error) {
 				return atlasEnv{}, err
 			}
 			env.config.Exclude = values
+			env.config.presence.exclude = true
 		default:
 			return atlasEnv{}, unsupportedAttr(attrName, attr)
 		}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -149,12 +149,14 @@ func TestLoadMergesAtlasOverPtah(t *testing.T) {
 	ptahPath := filepath.Join(dir, "ptah.yaml")
 	atlasPath := filepath.Join(dir, "atlas.hcl")
 	c.Assert(os.WriteFile(ptahPath, []byte(`url: postgres://ptah/db
+exclude: [tmp_*]
 migration:
   dir: ./ptah-migrations
   exec_order: non-linear
 `), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(atlasPath, []byte(`env "local" {
   url = "postgres://atlas/db"
+  exclude = []
   migration {
     dir = "file://atlas-migrations"
   }
@@ -168,6 +170,7 @@ migration:
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://atlas/db")
+	c.Assert(cfg.Exclude, qt.DeepEquals, []string{})
 	c.Assert(cfg.Migration.Dir, qt.Equals, "atlas-migrations")
 	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
 	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -15,33 +15,49 @@ const (
 // file formats into this shape; command code should consume this type instead
 // of branching on the original file format.
 type Config struct {
-	// EnvName is the selected Atlas env name, when the source had one.
+	// EnvName is the selected project env name, when the source had one.
 	EnvName string
 	// DatabaseURL is the target database URL used by migration commands.
 	DatabaseURL string
 	// DevURL is the disposable dev/shadow database URL.
 	DevURL string
+	// Schemas restricts database introspection to selected schemas.
+	Schemas []string
 	// Exclude lists schema patterns excluded by project config.
 	Exclude []string
 	// Migration holds migration-directory and runtime settings.
 	Migration MigrationConfig
 	// Lint holds migration-lint settings.
 	Lint LintConfig
+
+	presence configPresence
+}
+
+type configPresence struct {
+	schemas           bool
+	exclude           bool
+	lintDisabledRules bool
 }
 
 // MigrationConfig is the migration section of the project config IR.
 type MigrationConfig struct {
-	Dir             string
-	Format          string
-	RevisionsSchema string
-	RevisionFormat  string
-	LockTimeout     string
-	ExecOrder       string
+	Dir                  string
+	Format               string
+	RevisionsSchema      string
+	RevisionsTable       string
+	RevisionFormat       string
+	LockTimeout          string
+	StatementTimeout     string
+	ConnectTimeout       string
+	MigrationLockTimeout string
+	ExecOrder            string
 }
 
 // LintConfig is the lint section of the project config IR.
 type LintConfig struct {
-	Latest *int
+	Dialect       string
+	DisabledRules []string
+	Latest        *int
 }
 
 // Merge returns base overridden by non-zero values from override.
@@ -56,11 +72,19 @@ func Merge(base, override Config) Config {
 	if override.DevURL != "" {
 		result.DevURL = override.DevURL
 	}
-	if len(override.Exclude) > 0 {
+	if override.presence.schemas || len(override.Schemas) > 0 {
+		result.Schemas = slices.Clone(override.Schemas)
+		result.presence.schemas = true
+	}
+	if override.presence.exclude || len(override.Exclude) > 0 {
 		result.Exclude = slices.Clone(override.Exclude)
+		result.presence.exclude = true
 	}
 	result.Migration = mergeMigration(result.Migration, override.Migration)
-	result.Lint = mergeLint(result.Lint, override.Lint)
+	result.Lint = mergeLint(result.Lint, override.Lint, override.presence)
+	if override.presence.lintDisabledRules || len(override.Lint.DisabledRules) > 0 {
+		result.presence.lintDisabledRules = true
+	}
 	return result
 }
 
@@ -75,11 +99,23 @@ func mergeMigration(base, override MigrationConfig) MigrationConfig {
 	if override.RevisionsSchema != "" {
 		result.RevisionsSchema = override.RevisionsSchema
 	}
+	if override.RevisionsTable != "" {
+		result.RevisionsTable = override.RevisionsTable
+	}
 	if override.RevisionFormat != "" {
 		result.RevisionFormat = override.RevisionFormat
 	}
 	if override.LockTimeout != "" {
 		result.LockTimeout = override.LockTimeout
+	}
+	if override.StatementTimeout != "" {
+		result.StatementTimeout = override.StatementTimeout
+	}
+	if override.ConnectTimeout != "" {
+		result.ConnectTimeout = override.ConnectTimeout
+	}
+	if override.MigrationLockTimeout != "" {
+		result.MigrationLockTimeout = override.MigrationLockTimeout
 	}
 	if override.ExecOrder != "" {
 		result.ExecOrder = override.ExecOrder
@@ -87,8 +123,14 @@ func mergeMigration(base, override MigrationConfig) MigrationConfig {
 	return result
 }
 
-func mergeLint(base, override LintConfig) LintConfig {
+func mergeLint(base, override LintConfig, presence configPresence) LintConfig {
 	result := base
+	if override.Dialect != "" {
+		result.Dialect = override.Dialect
+	}
+	if presence.lintDisabledRules || len(override.DisabledRules) > 0 {
+		result.DisabledRules = slices.Clone(override.DisabledRules)
+	}
 	if override.Latest != nil {
 		latest := *override.Latest
 		result.Latest = &latest

--- a/config/projectconfig/load.go
+++ b/config/projectconfig/load.go
@@ -19,7 +19,7 @@ func Load(opts LoadOptions) (Config, error) {
 		atlasPath = AtlasFileName
 	}
 
-	ptah, err := LoadPtahFile(ptahPath)
+	ptah, err := LoadPtahFile(ptahPath, opts.EnvName)
 	if err != nil {
 		return Config{}, err
 	}

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -1,35 +1,56 @@
 package projectconfig
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 
 	"go.yaml.in/yaml/v3"
 )
 
-type yamlConfig struct {
+type yamlDocument struct {
+	yamlSettings `yaml:",inline"`
+	Env          map[string]yamlSettings `yaml:"env"`
+}
+
+type yamlSettings struct {
 	URL       string            `yaml:"url"`
 	Dev       string            `yaml:"dev"`
-	Exclude   []string          `yaml:"exclude"`
+	Schemas   *[]string         `yaml:"schemas"`
+	Exclude   *[]string         `yaml:"exclude"`
 	Migration yamlMigration     `yaml:"migration"`
 	Lint      yamlLint          `yaml:"lint"`
 	Migrate   yamlMigrateConfig `yaml:"migrate"`
-	OnlineDDL any               `yaml:"online_ddl"`
+	OnlineDDL yamlOnlineDDL     `yaml:"online_ddl"`
 }
 
 type yamlMigration struct {
-	Dir             string `yaml:"dir"`
-	Format          string `yaml:"format"`
-	RevisionsSchema string `yaml:"revisions_schema"`
-	RevisionFormat  string `yaml:"revision_format"`
-	LockTimeout     string `yaml:"lock_timeout"`
-	ExecOrder       string `yaml:"exec_order"`
+	Dir                  string `yaml:"dir"`
+	Format               string `yaml:"format"`
+	RevisionsSchema      string `yaml:"revisions_schema"`
+	RevisionsTable       string `yaml:"revisions_table"`
+	RevisionFormat       string `yaml:"revision_format"`
+	LockTimeout          string `yaml:"lock_timeout"`
+	StatementTimeout     string `yaml:"statement_timeout"`
+	ConnectTimeout       string `yaml:"connect_timeout"`
+	MigrationLockTimeout string `yaml:"migration_lock_timeout"`
+	ExecOrder            string `yaml:"exec_order"`
 }
 
 type yamlLint struct {
-	Latest *int `yaml:"latest"`
+	Dialect       string    `yaml:"dialect"`
+	DisabledRules *[]string `yaml:"disabled-rules"`
+	Latest        *int      `yaml:"latest"`
+}
+
+type yamlOnlineDDL struct {
+	Tool          string   `yaml:"tool"`
+	ThresholdRows int64    `yaml:"threshold_rows"`
+	Args          []string `yaml:"args"`
+	Fallback      string   `yaml:"fallback"`
 }
 
 type yamlMigrateConfig struct {
@@ -42,7 +63,7 @@ type yamlMigrateGenerateConfig struct {
 
 // LoadPtahFile loads Ptah's project config file. A missing file returns an
 // empty config.
-func LoadPtahFile(path string) (Config, error) {
+func LoadPtahFile(path, envName string) (Config, error) {
 	raw, err := os.ReadFile(path)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
@@ -51,32 +72,84 @@ func LoadPtahFile(path string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to read ptah config %s: %w", path, err)
 	}
 
-	var cfg yamlConfig
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
-		return Config{}, fmt.Errorf("failed to parse ptah config %s: %w", path, err)
-	}
-	return cfg.projectConfig(), nil
+	return ParsePtah(raw, path, envName)
 }
 
-func (c yamlConfig) projectConfig() Config {
+// ParsePtah parses Ptah's strict YAML project config.
+func ParsePtah(data []byte, filename, envName string) (Config, error) {
+	if filename == "" {
+		filename = PtahFileName
+	}
+	var doc yamlDocument
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&doc); err != nil {
+		return Config{}, fmt.Errorf("failed to parse ptah config %s: %w", filename, err)
+	}
+	return selectPtahEnv(doc, envName)
+}
+
+func selectPtahEnv(doc yamlDocument, envName string) (Config, error) {
+	base := doc.yamlSettings.projectConfig()
+	if len(doc.Env) == 0 {
+		return base, nil
+	}
+	if envName != "" {
+		env, ok := doc.Env[envName]
+		if !ok {
+			return Config{}, fmt.Errorf("ptah env %q not found", envName)
+		}
+		selected := env.projectConfig()
+		selected.EnvName = envName
+		return Merge(base, selected), nil
+	}
+	if len(doc.Env) > 1 {
+		return Config{}, fmt.Errorf("ptah.yaml contains multiple env blocks; pass --env")
+	}
+	for name, env := range doc.Env {
+		selected := env.projectConfig()
+		selected.EnvName = name
+		return Merge(base, selected), nil
+	}
+	return base, nil
+}
+
+func (c yamlSettings) projectConfig() Config {
 	dev := c.Dev
 	if dev == "" {
 		dev = c.Migrate.Generate.ShadowDatabaseURL
 	}
-	return Config{
+	cfg := Config{
 		DatabaseURL: c.URL,
 		DevURL:      dev,
-		Exclude:     c.Exclude,
 		Migration: MigrationConfig{
-			Dir:             c.Migration.Dir,
-			Format:          c.Migration.Format,
-			RevisionsSchema: c.Migration.RevisionsSchema,
-			RevisionFormat:  c.Migration.RevisionFormat,
-			LockTimeout:     c.Migration.LockTimeout,
-			ExecOrder:       c.Migration.ExecOrder,
+			Dir:                  c.Migration.Dir,
+			Format:               c.Migration.Format,
+			RevisionsSchema:      c.Migration.RevisionsSchema,
+			RevisionsTable:       c.Migration.RevisionsTable,
+			RevisionFormat:       c.Migration.RevisionFormat,
+			LockTimeout:          c.Migration.LockTimeout,
+			StatementTimeout:     c.Migration.StatementTimeout,
+			ConnectTimeout:       c.Migration.ConnectTimeout,
+			MigrationLockTimeout: c.Migration.MigrationLockTimeout,
+			ExecOrder:            c.Migration.ExecOrder,
 		},
 		Lint: LintConfig{
-			Latest: c.Lint.Latest,
+			Dialect: c.Lint.Dialect,
+			Latest:  c.Lint.Latest,
 		},
 	}
+	if c.Schemas != nil {
+		cfg.Schemas = slices.Clone(*c.Schemas)
+		cfg.presence.schemas = true
+	}
+	if c.Exclude != nil {
+		cfg.Exclude = slices.Clone(*c.Exclude)
+		cfg.presence.exclude = true
+	}
+	if c.Lint.DisabledRules != nil {
+		cfg.Lint.DisabledRules = slices.Clone(*c.Lint.DisabledRules)
+		cfg.presence.lintDisabledRules = true
+	}
+	return cfg
 }

--- a/config/projectconfig/yaml_test.go
+++ b/config/projectconfig/yaml_test.go
@@ -1,0 +1,175 @@
+package projectconfig_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestParsePtahProjectConfigNamedEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`url: postgres://base/db
+dev: postgres://base/dev
+schemas: [base]
+migration:
+  dir: ./base-migrations
+  format: ptah
+  revisions_schema: base_schema
+  revisions_table: base_revisions
+  revision_format: ptah
+  lock_timeout: 1s
+  statement_timeout: 2s
+  connect_timeout: 3s
+  migration_lock_timeout: 4s
+  exec_order: linear
+lint:
+  dialect: mysql
+  disabled-rules: [MF103]
+env:
+  prod:
+    url: postgres://prod/db
+    dev: postgres://prod/dev
+    schemas: [public, tenant]
+    migration:
+      dir: ./prod-migrations
+      revisions_schema: prod_schema
+      revisions_table: prod_revisions
+      lock_timeout: 5s
+      statement_timeout: 6s
+      connect_timeout: 7s
+      migration_lock_timeout: 8s
+      exec_order: non-linear
+    lint:
+      dialect: postgres
+      disabled-rules: [DS103]
+`)
+
+	cfg, err := projectconfig.ParsePtah(raw, "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://prod/db")
+	c.Assert(cfg.DevURL, qt.Equals, "postgres://prod/dev")
+	c.Assert(cfg.Schemas, qt.DeepEquals, []string{"public", "tenant"})
+	c.Assert(cfg.Migration.Dir, qt.Equals, "./prod-migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "ptah")
+	c.Assert(cfg.Migration.RevisionsSchema, qt.Equals, "prod_schema")
+	c.Assert(cfg.Migration.RevisionsTable, qt.Equals, "prod_revisions")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "ptah")
+	c.Assert(cfg.Migration.LockTimeout, qt.Equals, "5s")
+	c.Assert(cfg.Migration.StatementTimeout, qt.Equals, "6s")
+	c.Assert(cfg.Migration.ConnectTimeout, qt.Equals, "7s")
+	c.Assert(cfg.Migration.MigrationLockTimeout, qt.Equals, "8s")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
+	c.Assert(cfg.Lint.Dialect, qt.Equals, "postgres")
+	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{"DS103"})
+}
+
+func TestParsePtahProjectConfigRejectsUnknownKeys(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte(`url: postgres://app/db
+urll: postgres://typo/db
+`), "ptah.yaml", "")
+
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: yaml: unmarshal errors:\n  line 2: field urll not found in type projectconfig\.yamlDocument`)
+}
+
+func TestParsePtahProjectConfigRejectsUnknownOnlineDDLKeys(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte(`online_ddl:
+  threshhold_rows: 100
+`), "ptah.yaml", "")
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field threshhold_rows not found.*`)
+
+	_, err = projectconfig.ParsePtah([]byte(`env:
+  prod:
+    online_ddl:
+      tooll: ghost
+`), "ptah.yaml", "prod")
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field tooll not found.*`)
+}
+
+func TestParsePtahProjectConfigAllowsOnlineDDLSection(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+env:
+  prod:
+    url: postgres://prod/db
+    online_ddl:
+      fallback: error
+`)
+
+	cfg, err := projectconfig.ParsePtah(raw, "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://prod/db")
+}
+
+func TestParsePtahProjectConfigEnvCanClearInheritedLists(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`schemas: [public]
+exclude: [tmp_*]
+lint:
+  disabled-rules: [DS]
+env:
+  prod:
+    schemas: []
+    exclude: []
+    lint:
+      disabled-rules: []
+`)
+
+	cfg, err := projectconfig.ParsePtah(raw, "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Schemas, qt.DeepEquals, []string{})
+	c.Assert(cfg.Exclude, qt.DeepEquals, []string{})
+	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{})
+}
+
+func TestParsePtahProjectConfigSelectsSingleEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env:
+  local:
+    url: postgres://local/db
+`)
+
+	cfg, err := projectconfig.ParsePtah(raw, "ptah.yaml", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "local")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://local/db")
+}
+
+func TestParsePtahProjectConfigRequiresEnvWhenMultipleEnvsExist(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env:
+  dev:
+    url: postgres://dev/db
+  prod:
+    url: postgres://prod/db
+`)
+
+	_, err := projectconfig.ParsePtah(raw, "ptah.yaml", "")
+
+	c.Assert(err, qt.ErrorMatches, `ptah\.yaml contains multiple env blocks; pass --env`)
+}
+
+func TestParsePtahProjectConfigMissingEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env:
+  dev:
+    url: postgres://dev/db
+`)
+
+	_, err := projectconfig.ParsePtah(raw, "ptah.yaml", "prod")
+
+	c.Assert(err, qt.ErrorMatches, `ptah env "prod" not found`)
+}

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -69,9 +69,10 @@ atlas.hcl contains multiple env blocks; pass --env
 Ptah merges configuration in this order:
 
 1. Explicit CLI flags
-2. `atlas.hcl`
-3. `ptah.yaml`
-4. Built-in command defaults
+2. `PTAH_*` environment variables
+3. `atlas.hcl`
+4. `ptah.yaml`
+5. Built-in command defaults
 
 This means a repo can keep an Atlas-shaped migration setup while still letting
 one-off CLI invocations override any value:

--- a/docs/online-ddl.md
+++ b/docs/online-ddl.md
@@ -46,6 +46,23 @@ routed through the tool automatically. Smaller tables get a plain `ALTER`.
 `args` are appended verbatim to every tool invocation — this is where
 deployment-specific switches belong.
 
+`online_ddl` can also live inside a named `ptah.yaml` environment selected
+with `--env`. Environment-specific values override top-level defaults. Explicit
+empty values clear inherited settings, so an environment can disable automatic
+routing with:
+
+```yaml
+online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+
+env:
+  local:
+    online_ddl:
+      tool: ""
+      threshold_rows: 0
+```
+
 ## Fallback behavior
 
 Fallback behavior depends on how the tool was selected:

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -1,0 +1,98 @@
+# Ptah Project Config
+
+`ptah.yaml` is Ptah's project-level configuration file. It is command
+configuration, not a schema source. Schema input remains Go annotations, YAML
+schema, Atlas schema HCL, or database introspection depending on the command.
+
+Ptah reads `ptah.yaml` strictly: unknown keys are errors. This prevents a typo
+from being silently ignored while migrations run with different settings than
+the operator expected.
+
+## Named Environments
+
+Use `env` blocks to name reusable database targets:
+
+```yaml
+env:
+  prod:
+    url: postgres://user:pass@prod-host:5432/app
+    dev: postgres://user:pass@localhost:5432/app_shadow
+    schemas: [public]
+    migration:
+      dir: ./migrations
+      format: atlas
+      revisions_schema: atlas
+      revisions_table: atlas_schema_revisions
+      revision_format: atlas
+      lock_timeout: 3s
+      statement_timeout: 30s
+      connect_timeout: 10s
+      migration_lock_timeout: 15s
+      exec_order: linear
+    lint:
+      dialect: postgres
+      disabled-rules: [MF103]
+    online_ddl:
+      tool: ghost
+      threshold_rows: 1000000
+```
+
+Select an environment with `--env <name>` on commands that load project
+configuration. If `ptah.yaml` contains exactly one environment, Ptah selects it
+automatically. If it contains multiple environments and no `--env` is passed,
+Ptah fails instead of guessing.
+
+Top-level settings are allowed and are merged as defaults for every named
+environment:
+
+```yaml
+migration:
+  exec_order: linear
+
+env:
+  dev:
+    url: postgres://localhost/dev
+  prod:
+    url: postgres://prod/app
+    migration:
+      exec_order: non-linear
+```
+
+## Supported Keys
+
+| Key | Meaning |
+| --- | --- |
+| `url` | Default target database URL for migration commands |
+| `dev` | Disposable dev/shadow database URL for `migrate generate` |
+| `schemas` | Default schemas to introspect when the command supports schema scoping |
+| `exclude` | Project-level exclude patterns for config consumers |
+| `migration.dir` | Default migrations directory |
+| `migration.format` | Migration directory format: `auto`, `ptah`, or `atlas` |
+| `migration.revisions_schema` | Migration metadata schema |
+| `migration.revisions_table` | Migration metadata table |
+| `migration.revision_format` | Revision table layout: `ptah` or `atlas` |
+| `migration.lock_timeout` | Default per-migration lock timeout |
+| `migration.statement_timeout` | Default per-migration statement timeout |
+| `migration.connect_timeout` | Initial database connection timeout |
+| `migration.migration_lock_timeout` | Session-level migration advisory lock timeout |
+| `migration.exec_order` | Pending migration execution policy |
+| `lint.dialect` | Default lint dialect |
+| `lint.disabled-rules` | Default lint disabled rule codes or families |
+| `lint.latest` | Atlas-compatible project config value preserved in the IR |
+| `online_ddl` | Automatic online-DDL routing config for MySQL/MariaDB |
+
+`migrate.generate.shadow_db` is also accepted as the older spelling for `dev`.
+When both are present, `dev` wins.
+
+## Precedence
+
+Runtime values resolve in this order:
+
+1. Explicit CLI flags
+2. Environment variables such as `PTAH_DB_URL`
+3. `atlas.hcl`
+4. `ptah.yaml`
+5. Built-in command defaults
+
+`atlas.hcl` is translated into the same project config IR. See
+[Atlas Project Config](atlas_project_config.md) for the supported Atlas subset.

--- a/migration/onlineddl/config.go
+++ b/migration/onlineddl/config.go
@@ -17,6 +17,7 @@
 package onlineddl
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -66,9 +67,55 @@ type Config struct {
 	Fallback string `yaml:"fallback"`
 }
 
-// ptahConfig is the ptah.yaml envelope.
+// ptahConfig is the top-level ptah.yaml envelope.
 type ptahConfig struct {
-	OnlineDDL Config `yaml:"online_ddl"`
+	ptahSettings `yaml:",inline"`
+	Env          map[string]ptahSettings `yaml:"env"`
+}
+
+type ptahSettings struct {
+	URL       string        `yaml:"url"`
+	Dev       string        `yaml:"dev"`
+	Schemas   []string      `yaml:"schemas"`
+	Exclude   []string      `yaml:"exclude"`
+	Migration yamlMigration `yaml:"migration"`
+	Lint      yamlLint      `yaml:"lint"`
+	Migrate   yamlMigrate   `yaml:"migrate"`
+	OnlineDDL yamlOnlineDDL `yaml:"online_ddl"`
+}
+
+type yamlMigration struct {
+	Dir                  string `yaml:"dir"`
+	Format               string `yaml:"format"`
+	RevisionsSchema      string `yaml:"revisions_schema"`
+	RevisionsTable       string `yaml:"revisions_table"`
+	RevisionFormat       string `yaml:"revision_format"`
+	LockTimeout          string `yaml:"lock_timeout"`
+	StatementTimeout     string `yaml:"statement_timeout"`
+	ConnectTimeout       string `yaml:"connect_timeout"`
+	MigrationLockTimeout string `yaml:"migration_lock_timeout"`
+	ExecOrder            string `yaml:"exec_order"`
+}
+
+type yamlLint struct {
+	Dialect       string   `yaml:"dialect"`
+	DisabledRules []string `yaml:"disabled-rules"`
+	Latest        *int     `yaml:"latest"`
+}
+
+type yamlMigrate struct {
+	Generate yamlMigrateGenerate `yaml:"generate"`
+}
+
+type yamlMigrateGenerate struct {
+	ShadowDatabaseURL string `yaml:"shadow_db"`
+}
+
+type yamlOnlineDDL struct {
+	Tool          *string   `yaml:"tool"`
+	ThresholdRows *int64    `yaml:"threshold_rows"`
+	Args          *[]string `yaml:"args"`
+	Fallback      *string   `yaml:"fallback"`
 }
 
 // Enabled reports whether automatic threshold routing is configured.
@@ -98,10 +145,17 @@ func (c Config) Validate() error {
 	return nil
 }
 
-// LoadConfig reads the online_ddl section of a ptah.yaml file. A missing file
-// at the conventional location is not an error — it yields a zero Config
-// (automatic routing disabled); an unreadable, malformed or invalid file is.
+// LoadConfig reads the top-level online_ddl section of a ptah.yaml file. A
+// missing file at the conventional location is not an error — it yields a zero
+// Config (automatic routing disabled); an unreadable, malformed or invalid
+// file is.
 func LoadConfig(path string) (*Config, error) {
+	return LoadConfigForEnv(path, "")
+}
+
+// LoadConfigForEnv reads the online_ddl section of a ptah.yaml file after
+// applying the selected project environment, when present.
+func LoadConfigForEnv(path, envName string) (*Config, error) {
 	raw, err := os.ReadFile(path)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
@@ -111,11 +165,68 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	var cfg ptahConfig
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse ptah config %s: %w", path, err)
 	}
-	if err := cfg.OnlineDDL.Validate(); err != nil {
+	onlineDDL := selectOnlineDDLConfig(cfg, envName)
+	if err := onlineDDL.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid online_ddl config in %s: %w", path, err)
 	}
-	return &cfg.OnlineDDL, nil
+	return &onlineDDL, nil
+}
+
+func selectOnlineDDLConfig(cfg ptahConfig, envName string) Config {
+	base := cfg.OnlineDDL.config()
+	if envName != "" {
+		if env, ok := cfg.Env[envName]; ok {
+			return mergeOnlineDDL(base, env.OnlineDDL)
+		}
+		return base
+	}
+	if len(cfg.Env) != 1 {
+		return base
+	}
+	for _, env := range cfg.Env {
+		return mergeOnlineDDL(base, env.OnlineDDL)
+	}
+	return base
+}
+
+func (c yamlOnlineDDL) config() Config {
+	var cfg Config
+	if c.Tool != nil {
+		cfg.Tool = *c.Tool
+	}
+	if c.ThresholdRows != nil {
+		cfg.ThresholdRows = *c.ThresholdRows
+	}
+	if c.Args != nil {
+		cfg.Args = append([]string{}, (*c.Args)...)
+	}
+	if c.Fallback != nil {
+		cfg.Fallback = *c.Fallback
+	}
+	return cfg
+}
+
+func mergeOnlineDDL(base Config, override yamlOnlineDDL) Config {
+	result := base
+	if override.Tool != nil {
+		result.Tool = *override.Tool
+		if *override.Tool == "" && override.ThresholdRows == nil {
+			result.ThresholdRows = 0
+		}
+	}
+	if override.ThresholdRows != nil {
+		result.ThresholdRows = *override.ThresholdRows
+	}
+	if override.Args != nil {
+		result.Args = append([]string{}, (*override.Args)...)
+	}
+	if override.Fallback != nil {
+		result.Fallback = *override.Fallback
+	}
+	return result
 }

--- a/migration/onlineddl/config_test.go
+++ b/migration/onlineddl/config_test.go
@@ -32,6 +32,77 @@ func TestLoadConfig(t *testing.T) {
 	c.Assert(cfg.Enabled(), qt.IsTrue)
 }
 
+func TestLoadConfig_AllowsProjectConfigEnvelope(t *testing.T) {
+	c := qt.New(t)
+
+	path := writeConfig(t, `url: postgres://app/db
+schemas: [public]
+migration:
+  dir: ./migrations
+lint:
+  dialect: postgres
+env:
+  prod:
+    url: postgres://prod/db
+online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+`)
+	cfg, err := onlineddl.LoadConfig(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
+	c.Assert(cfg.Enabled(), qt.IsTrue)
+}
+
+func TestLoadConfigForEnv_MergesNamedEnvironment(t *testing.T) {
+	c := qt.New(t)
+
+	path := writeConfig(t, `online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+env:
+  prod:
+    online_ddl:
+      threshold_rows: 2000000
+      fallback: error
+      args: ["--allow-on-master"]
+`)
+	cfg, err := onlineddl.LoadConfigForEnv(path, "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
+	c.Assert(cfg.ThresholdRows, qt.Equals, int64(2000000))
+	c.Assert(cfg.Fallback, qt.Equals, onlineddl.FallbackError)
+	c.Assert(cfg.Args, qt.DeepEquals, []string{"--allow-on-master"})
+}
+
+func TestLoadConfigForEnv_ClearsInheritedEnvironmentFields(t *testing.T) {
+	c := qt.New(t)
+
+	path := writeConfig(t, `online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+  fallback: error
+  args: ["--allow-on-master"]
+env:
+  prod:
+    online_ddl:
+      tool: ""
+      threshold_rows: 0
+      fallback: ""
+      args: []
+`)
+	cfg, err := onlineddl.LoadConfigForEnv(path, "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, "")
+	c.Assert(cfg.ThresholdRows, qt.Equals, int64(0))
+	c.Assert(cfg.Fallback, qt.Equals, "")
+	c.Assert(cfg.Args, qt.DeepEquals, []string{})
+	c.Assert(cfg.Enabled(), qt.IsFalse)
+}
+
 func TestLoadConfig_MissingFileYieldsDisabledConfig(t *testing.T) {
 	c := qt.New(t)
 
@@ -58,6 +129,15 @@ func TestLoadConfig_Invalid(t *testing.T) {
 
 	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  tool: ghost\n  fallback: warn\n"))
 	c.Assert(err, qt.ErrorMatches, `invalid online_ddl config .*unknown online_ddl fallback "warn".*`)
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "urll: postgres://typo/db\n"))
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config .*field urll not found.*`)
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "migration:\n  dri: ./typo\n"))
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config .*field dri not found.*`)
+
+	_, err = onlineddl.LoadConfig(writeConfig(t, "online_ddl:\n  threshhold_rows: 100\n"))
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config .*field threshhold_rows not found.*`)
 }
 
 func TestConfig_Enabled(t *testing.T) {


### PR DESCRIPTION
Closes #272.

## What changed

- Added strict `ptah.yaml` parsing with named `env` support.
- Added project defaults for schemas, migration revision table/schema, timeouts, exec order, lint dialect, and disabled lint rules.
- Applied project config defaults across generate/up/down/status/lint commands, including `migrate-status --config`.
- Made `online_ddl` env-aware and strict inside the `ptah.yaml` envelope.
- Made list and online-DDL merges presence-aware so explicit empty lists or zero values can clear inherited defaults.
- Documented `ptah.yaml` project config and updated online-DDL/project-config docs.
- Added repository guidance to prefer American English; broader cleanup is tracked in #398.

## Self-review fixes included

- Replaced loose `online_ddl: any` parsing with typed strict parsing.
- Replaced `map[string]any` online-DDL envelope parsing with typed envelope parsing.
- Added tests for unknown nested `online_ddl` keys and unknown neighboring project sections.
- Added tests for empty-list overrides and env-specific online-DDL disabling.
- Added CLI-level lint default coverage from `ptah.yaml`.

## Validation

- `go test ./migration/onlineddl ./cmd/internal/dbcli ./cmd/migrateup ./cmd/migratedown ./cmd/migratestatus ./cmd/migrate ./cmd/lint ./cmd/root ./config/projectconfig -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --fix ./...`
- `go test ./... -count=1`
- `golangci-lint run ./...`
- `git diff --check`
