### PR TITLE
Unskip mutual FK round-trip on Postgres

### DIFF
--- a/integration/scenarios_roundtrip_fixtures.go
+++ b/integration/scenarios_roundtrip_fixtures.go
@@ -71,13 +71,12 @@ var roundTripFixtures = []roundTripFixture{
 	},
 	{
 		Name:        "mutual_fk_cycle",
-		Description: "mutual foreign-key cycle must either generate executable SQL or fail cleanly",
+		Description: "mutual foreign-key cycle is generated, applied, introspected, and rolled back",
 		Versions:    []string{"029-roundtrip-mutual-cycle"},
-		// blocked on #137: circular dependency handling still warns and emits broken DDL.
+		// blocked on #127: MySQL/MariaDB need child-before-parent table drops.
 		BlockedByDialect: map[string]string{
-			"postgres": "#137",
-			"mysql":    "#137",
-			"mariadb":  "#137",
+			"mysql":   "#127",
+			"mariadb": "#127",
 		},
 	},
 	{

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -66,9 +66,9 @@ type Planner struct {
 	caps capability.Capabilities
 	// concurrentIndexes requests CREATE INDEX CONCURRENTLY for new indexes.
 	// It is a POLICY choice (concurrent builds cannot run inside a
-	// transaction, so callers must arrange no-transaction execution — issue
-	// #152), and it only takes effect when the target also has the
-	// capability.CreateIndexConcurrently capability — a future
+	// transaction, so generator callers split such statements into
+	// no_transaction migration files), and it only takes effect when the target
+	// also has the capability.CreateIndexConcurrently capability — a future
 	// postgres-compatible preset without it (CockroachDB, issue #171) keeps
 	// plain CREATE INDEX no matter the policy.
 	concurrentIndexes bool
@@ -110,8 +110,8 @@ func (p *Planner) capabilities() capability.Capabilities {
 // CREATE [UNIQUE] INDEX CONCURRENTLY for newly added indexes, provided the
 // target capability set includes capability.CreateIndexConcurrently. The
 // receiver is not modified. Concurrent index builds cannot run inside a
-// transaction block; the caller owns arranging no-transaction execution for
-// such statements (issue #152 tracks first-class support in the migrator).
+// transaction block; callers must arrange no_transaction execution for such
+// statements.
 func (p *Planner) WithConcurrentIndexes() *Planner {
 	cp := *p
 	cp.concurrentIndexes = true


### PR DESCRIPTION
## Summary
- stop marking the Postgres mutual-FK round-trip fixture as blocked by closed issue #137
- keep MySQL/MariaDB blocked on #127 for child-before-parent table drops
- update stale #152 planner comments now that generator/migrator no_transaction support exists

## Self-review
Pass 1: checked for stale #137/#152 references and kept the diff scoped to the audit finding.
Pass 2: verified that the Postgres round-trip fixture now executes through the integration runner, while MySQL/MariaDB remain blocked for the separate #127 down-order gap.

## Validation
- go test ./migration/planner/dialects/postgres -count=1
- go test ./integration -run Test -count=1
- POSTGRES_TEST_DSN=... go test -tags integration ./integration/gonative -run TestPostgreSQLGenerateMutualForeignKeysApplyIntegration -count=1
- go test ./... -count=1 (outside sandbox; sandbox cannot bind 127.0.0.1:0 in dbschema tests)
- go tool qtlint ./... (outside sandbox)
- golangci-lint run ./... (outside sandbox)
- POSTGRES_URL=... go run ./cmd/integration-test --databases postgres --scenarios migration_generator_roundtrip_fixtures --report stdout --output /private/tmp/ptah-integration-audit --verbose