### PR TITLE
Add Atlas CLI flag aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,16 +1049,23 @@ it is redesigned independently.
 | `ptah atlas migrate hash` | `ptah migrate-hash` |
 | `ptah atlas migrate validate` | `ptah migrate-validate` |
 | `ptah atlas migrate lint` | `ptah lint` |
-| `ptah atlas migrate diff` | `ptah migrate` |
 | `ptah atlas schema inspect` | `ptah read-db` |
 | `ptah atlas schema diff` | `ptah compare` |
 
-The Atlas-compatible commands delegate to the native commands, so their flag
-parsing and exit codes are the native contracts: `0` for success, `1` for
-drift/findings where a native command documents that content state, and `2` for
-command/usage errors on commands with an explicit 0/1/2 contract (`drift`,
-`lint`, and `migrate-validate`). Other runtime failures continue to use the CLI
-fallback non-zero exit code.
+Atlas-compatible aliases accept the Atlas OSS flag names on the compatibility
+surface and translate implemented flags to the native Ptah flags before
+execution. For example, `ptah atlas migrate apply --url ... --dir ...` maps to
+`ptah migrate-up --db-url ... --migrations-dir ...`, and
+`ptah atlas schema inspect --url ...` maps to `ptah read-db --db-url ...`.
+Flags that are part of the Atlas OSS CLI but do not have Ptah behavior yet are
+advertised and rejected explicitly instead of being silently ignored.
+
+The implemented Atlas-compatible commands delegate to native commands after
+flag translation, so their exit codes are the native contracts: `0` for success,
+`1` for drift/findings where a native command documents that content state, and
+`2` for command/usage errors on commands with an explicit 0/1/2 contract
+(`drift`, `lint`, and `migrate-validate`). Other runtime failures continue to
+use the CLI fallback non-zero exit code.
 
 #### Migration Directory Integrity (`ptah.sum` / `atlas.sum`)
 

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -3,6 +3,7 @@ package atlas
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -26,6 +27,31 @@ type atlasVerb struct {
 	native     string
 	factory    func() *cobra.Command
 	prefixArgs []string
+	flags      []atlasFlag
+}
+
+type atlasFlagKind int
+
+const (
+	atlasStringFlag atlasFlagKind = iota
+	atlasStringArrayFlag
+	atlasBoolFlag
+)
+
+type atlasFlag struct {
+	name        string
+	shorthand   string
+	usage       string
+	kind        atlasFlagKind
+	nativeName  string
+	unsupported bool
+}
+
+type parsedAtlasFlag struct {
+	name     string
+	value    string
+	hasValue bool
+	ok       bool
 }
 
 // NewAtlasCommand returns the Atlas compatibility namespace.
@@ -58,11 +84,55 @@ func newAtlasSchemaCommand() *cobra.Command {
 		},
 	}
 	for _, verb := range []atlasVerb{
-		{use: "inspect", short: "Inspect a database schema", native: "read-db", factory: readdb.NewReadDBCommand},
-		{use: "apply", short: "Apply a desired schema to a database", native: ""},
-		{use: "diff", short: "Diff desired schema against a database", native: "compare", factory: compare.NewCompareCommand},
+		{
+			use:     "inspect",
+			short:   "Inspect a database schema",
+			native:  "read-db",
+			factory: readdb.NewReadDBCommand,
+			flags: []atlasFlag{
+				atlasNativeString("url", "u", "Database URL to inspect", "db-url"),
+				atlasUnsupportedString("dev-url", "", "Dev database URL used by Atlas for file-backed inspection"),
+				atlasNativeString("schema", "", "Schema to inspect; repeat by comma in native Ptah", "schemas"),
+				atlasUnsupportedStringArray("exclude", "", "Schema objects to exclude from inspection"),
+				atlasUnsupportedString("format", "", "Atlas Go template output format"),
+			},
+		},
+		{
+			use:    "apply",
+			short:  "Apply a desired schema to a database",
+			native: "",
+			flags: []atlasFlag{
+				atlasString("url", "u", "Database URL to apply to"),
+				atlasStringArray("to", "", "Desired schema target"),
+				atlasString("dev-url", "", "Dev database URL"),
+				atlasBool("dry-run", "", "Show planned changes without applying them"),
+				atlasBool("auto-approve", "", "Skip interactive approval"),
+			},
+		},
+		{
+			use:     "diff",
+			short:   "Diff desired schema against a database",
+			native:  "compare",
+			factory: compare.NewCompareCommand,
+			flags: []atlasFlag{
+				atlasUnsupportedStringArray("from", "", "Source schema target"),
+				atlasUnsupportedStringArray("to", "", "Desired schema target"),
+				atlasUnsupportedString("dev-url", "", "Dev database URL"),
+				atlasUnsupportedString("format", "", "Atlas Go template output format"),
+			},
+		},
 		{use: "fmt", short: "Format schema files", native: ""},
-		{use: "clean", short: "Clean database schema objects", native: "drop-all", factory: dropall.NewDropAllCommand},
+		{
+			use:     "clean",
+			short:   "Clean database schema objects",
+			native:  "drop-all",
+			factory: dropall.NewDropAllCommand,
+			flags: []atlasFlag{
+				atlasNativeString("url", "u", "Database URL to clean", "db-url"),
+				atlasNativeBool("dry-run", "", "Show planned cleanup without applying it", "dry-run"),
+				atlasUnsupportedBool("auto-approve", "", "Skip interactive approval"),
+			},
+		},
 	} {
 		cmd.AddCommand(newAtlasAliasCommand("schema", verb))
 	}
@@ -78,16 +148,95 @@ func newAtlasMigrateCommand() *cobra.Command {
 		},
 	}
 	for _, verb := range []atlasVerb{
-		{use: "apply", short: "Apply pending migrations", native: "migrate-up", factory: migrateup.NewMigrateUpCommand},
-		{use: "diff", short: "Generate migration SQL from differences", native: "migrate", factory: migrate.NewMigrateCommand},
+		{
+			use:     "apply",
+			short:   "Apply pending migrations",
+			native:  "migrate-up",
+			factory: migrateup.NewMigrateUpCommand,
+			flags: []atlasFlag{
+				atlasNativeString("url", "u", "Database URL to apply migrations to", "db-url"),
+				atlasNativeString("dir", "", "Migration directory", "migrations-dir"),
+				atlasNativeBool("dry-run", "", "Show migrations without applying them", "dry-run"),
+				atlasUnsupportedString("tx-mode", "", "Atlas transaction mode"),
+			},
+		},
+		{
+			use:    "diff",
+			short:  "Generate migration SQL from differences",
+			native: "",
+			flags: []atlasFlag{
+				atlasStringArray("to", "", "Desired schema target"),
+				atlasString("dev-url", "", "Dev database URL"),
+				atlasString("dir", "", "Migration directory"),
+				atlasString("format", "", "Atlas Go template output format"),
+			},
+		},
 		{use: "down", short: "Roll back migrations", native: "migrate-down", factory: migratedown.NewMigrateDownCommand},
-		{use: "hash", short: "Write or update the migration directory checksum", native: "migrate-hash", factory: migratehash.NewMigrateHashCommand},
-		{use: "import", short: "Import migrations from another tool", native: ""},
-		{use: "lint", short: "Lint migration files", native: "lint", factory: lint.NewLintCommand},
-		{use: "new", short: "Create a new migration file", native: "migrate new", factory: migrate.NewMigrateCommand, prefixArgs: []string{"new"}},
-		{use: "set", short: "Set migration revision state", native: "migrate-repair", factory: migraterepair.NewMigrateRepairCommand},
-		{use: "status", short: "Show migration status", native: "migrate-status", factory: migratestatus.NewMigrateStatusCommand},
-		{use: "validate", short: "Validate migration directory integrity", native: "migrate-validate", factory: migratevalidate.NewMigrateValidateCommand},
+		{
+			use:     "hash",
+			short:   "Write or update the migration directory checksum",
+			native:  "migrate-hash",
+			factory: migratehash.NewMigrateHashCommand,
+			flags:   []atlasFlag{atlasNativeString("dir", "", "Migration directory", "dir")},
+		},
+		{
+			use:    "import",
+			short:  "Import migrations from another tool",
+			native: "",
+			flags: []atlasFlag{
+				atlasString("from", "", "Source migration directory"),
+				atlasString("to", "", "Destination migration directory"),
+			},
+		},
+		{
+			use:     "lint",
+			short:   "Lint migration files",
+			native:  "lint",
+			factory: lint.NewLintCommand,
+			flags: []atlasFlag{
+				atlasUnsupportedString("dev-url", "", "Dev database URL"),
+				atlasNativeString("dir", "", "Migration directory", "dir"),
+				atlasUnsupportedString("latest", "", "Number of latest migrations to lint"),
+			},
+		},
+		{
+			use:        "new",
+			short:      "Create a new migration file",
+			native:     "migrate new",
+			factory:    migrate.NewMigrateCommand,
+			prefixArgs: []string{"new"},
+			flags:      []atlasFlag{atlasNativeString("dir", "", "Migration directory", "migrations-dir")},
+		},
+		{
+			use:     "set",
+			short:   "Set migration revision state",
+			native:  "migrate-repair",
+			factory: migraterepair.NewMigrateRepairCommand,
+			flags: []atlasFlag{
+				atlasNativeString("url", "u", "Database URL", "db-url"),
+				atlasNativeString("dir", "", "Migration directory", "migrations-dir"),
+			},
+		},
+		{
+			use:     "status",
+			short:   "Show migration status",
+			native:  "migrate-status",
+			factory: migratestatus.NewMigrateStatusCommand,
+			flags: []atlasFlag{
+				atlasNativeString("url", "u", "Database URL", "db-url"),
+				atlasNativeString("dir", "", "Migration directory", "migrations-dir"),
+			},
+		},
+		{
+			use:     "validate",
+			short:   "Validate migration directory integrity",
+			native:  "migrate-validate",
+			factory: migratevalidate.NewMigrateValidateCommand,
+			flags: []atlasFlag{
+				atlasUnsupportedString("dev-url", "", "Dev database URL"),
+				atlasNativeString("dir", "", "Migration directory", "dir"),
+			},
+		},
 	} {
 		cmd.AddCommand(newAtlasAliasCommand("migrate", verb))
 	}
@@ -115,14 +264,18 @@ func newAtlasLicenseCommand() *cobra.Command {
 }
 
 func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
+	mapper := atlasArgMapper(group, verb)
 	if verb.factory != nil {
-		return cmdalias.NewForwardCommandWithArgs(
+		cmd := cmdalias.NewForwardCommandWithArgsMapper(
 			verb.use,
 			verb.short,
 			verb.native,
 			verb.factory,
+			mapper,
 			verb.prefixArgs...,
 		)
+		registerAtlasFlags(cmd, verb.flags)
+		return cmd
 	}
 	cmd := &cobra.Command{
 		Use:   verb.use,
@@ -135,6 +288,7 @@ func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
 			return fmt.Errorf("atlas %s %s execution is not implemented yet; use `ptah %s`", group, verb.use, verb.native)
 		},
 	}
+	registerAtlasFlags(cmd, verb.flags)
 	return cmd
 }
 
@@ -143,4 +297,141 @@ func atlasAliasLong(group string, verb atlasVerb) string {
 		return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. Runtime compatibility is not implemented yet.", group, verb.use)
 	}
 	return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. The current native Ptah equivalent is `ptah %s`.", group, verb.use, verb.native)
+}
+
+func atlasString(name, shorthand, usage string) atlasFlag {
+	return atlasFlag{name: name, shorthand: shorthand, usage: usage, kind: atlasStringFlag}
+}
+
+func atlasStringArray(name, shorthand, usage string) atlasFlag {
+	return atlasFlag{name: name, shorthand: shorthand, usage: usage, kind: atlasStringArrayFlag}
+}
+
+func atlasBool(name, shorthand, usage string) atlasFlag {
+	return atlasFlag{name: name, shorthand: shorthand, usage: usage, kind: atlasBoolFlag}
+}
+
+func atlasNativeString(name, shorthand, usage, nativeName string) atlasFlag {
+	f := atlasString(name, shorthand, usage)
+	f.nativeName = nativeName
+	return f
+}
+
+func atlasNativeBool(name, shorthand, usage, nativeName string) atlasFlag {
+	f := atlasBool(name, shorthand, usage)
+	f.nativeName = nativeName
+	return f
+}
+
+func atlasUnsupportedString(name, shorthand, usage string) atlasFlag {
+	f := atlasString(name, shorthand, usage)
+	f.unsupported = true
+	return f
+}
+
+func atlasUnsupportedStringArray(name, shorthand, usage string) atlasFlag {
+	f := atlasStringArray(name, shorthand, usage)
+	f.unsupported = true
+	return f
+}
+
+func atlasUnsupportedBool(name, shorthand, usage string) atlasFlag {
+	f := atlasBool(name, shorthand, usage)
+	f.unsupported = true
+	return f
+}
+
+func registerAtlasFlags(cmd *cobra.Command, flags []atlasFlag) {
+	for _, flag := range flags {
+		switch flag.kind {
+		case atlasStringFlag:
+			cmd.Flags().StringP(flag.name, flag.shorthand, "", flag.usage)
+		case atlasStringArrayFlag:
+			cmd.Flags().StringArrayP(flag.name, flag.shorthand, nil, flag.usage)
+		case atlasBoolFlag:
+			cmd.Flags().BoolP(flag.name, flag.shorthand, false, flag.usage)
+		}
+	}
+}
+
+func atlasArgMapper(group string, verb atlasVerb) cmdalias.ArgMapper {
+	return func(args []string) ([]string, error) {
+		return mapAtlasArgs(group, verb, args)
+	}
+}
+
+func mapAtlasArgs(group string, verb atlasVerb, args []string) ([]string, error) {
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
+		parsed := splitAtlasFlag(arg)
+		if !parsed.ok {
+			out = append(out, arg)
+			continue
+		}
+		flag, found := findAtlasFlag(verb.flags, parsed.name)
+		if !found {
+			out = append(out, arg)
+			continue
+		}
+		displayName := "--" + flag.name
+		if len(parsed.name) == 1 {
+			displayName = "-" + parsed.name
+		}
+		if flag.unsupported {
+			return nil, fmt.Errorf("atlas %s %s accepts %s, but Ptah does not implement its behavior yet",
+				group, verb.use, displayName)
+		}
+		nativeName := flag.name
+		if flag.nativeName != "" {
+			nativeName = flag.nativeName
+		}
+		nativeFlag := "--" + nativeName
+		if flag.kind == atlasBoolFlag {
+			if parsed.hasValue {
+				out = append(out, nativeFlag+"="+parsed.value)
+			} else {
+				out = append(out, nativeFlag)
+			}
+			continue
+		}
+		if parsed.hasValue {
+			out = append(out, nativeFlag+"="+parsed.value)
+			continue
+		}
+		out = append(out, nativeFlag)
+		if i+1 < len(args) {
+			i++
+			out = append(out, args[i])
+		}
+	}
+	return out, nil
+}
+
+func splitAtlasFlag(arg string) parsedAtlasFlag {
+	switch {
+	case strings.HasPrefix(arg, "--") && len(arg) > len("--"):
+		body := strings.TrimPrefix(arg, "--")
+		if before, after, found := strings.Cut(body, "="); found {
+			return parsedAtlasFlag{name: before, value: after, hasValue: true, ok: true}
+		}
+		return parsedAtlasFlag{name: body, ok: true}
+	case strings.HasPrefix(arg, "-") && len(arg) == 2:
+		return parsedAtlasFlag{name: strings.TrimPrefix(arg, "-"), ok: true}
+	default:
+		return parsedAtlasFlag{}
+	}
+}
+
+func findAtlasFlag(flags []atlasFlag, name string) (atlasFlag, bool) {
+	for _, flag := range flags {
+		if flag.name == name || flag.shorthand == name {
+			return flag, true
+		}
+	}
+	return atlasFlag{}, false
 }

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -51,6 +51,98 @@ func TestNewAtlasCommand_OSSCommandPathsResolve(t *testing.T) {
 	}
 }
 
+func TestNewAtlasCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  []string
+		flags []string
+	}{
+		{
+			name:  "schema_inspect",
+			path:  []string{"schema", "inspect"},
+			flags: []string{"--url", "--dev-url", "--schema", "--exclude", "--format"},
+		},
+		{
+			name:  "schema_apply",
+			path:  []string{"schema", "apply"},
+			flags: []string{"--url", "--to", "--dev-url", "--dry-run", "--auto-approve"},
+		},
+		{
+			name:  "schema_diff",
+			path:  []string{"schema", "diff"},
+			flags: []string{"--from", "--to", "--dev-url", "--format"},
+		},
+		{
+			name:  "schema_clean",
+			path:  []string{"schema", "clean"},
+			flags: []string{"--url", "--dry-run", "--auto-approve"},
+		},
+		{
+			name:  "migrate_diff",
+			path:  []string{"migrate", "diff"},
+			flags: []string{"--to", "--dev-url", "--dir", "--format"},
+		},
+		{
+			name:  "migrate_apply",
+			path:  []string{"migrate", "apply"},
+			flags: []string{"--url", "--dir", "--dry-run", "--tx-mode"},
+		},
+		{
+			name:  "migrate_lint",
+			path:  []string{"migrate", "lint"},
+			flags: []string{"--dev-url", "--dir", "--latest"},
+		},
+		{
+			name:  "migrate_hash",
+			path:  []string{"migrate", "hash"},
+			flags: []string{"--dir"},
+		},
+		{
+			name:  "migrate_status",
+			path:  []string{"migrate", "status"},
+			flags: []string{"--url", "--dir"},
+		},
+		{
+			name:  "migrate_validate",
+			path:  []string{"migrate", "validate"},
+			flags: []string{"--dev-url", "--dir"},
+		},
+		{
+			name:  "migrate_new",
+			path:  []string{"migrate", "new"},
+			flags: []string{"--dir"},
+		},
+		{
+			name:  "migrate_set",
+			path:  []string{"migrate", "set"},
+			flags: []string{"--url", "--dir"},
+		},
+		{
+			name:  "migrate_import",
+			path:  []string{"migrate", "import"},
+			flags: []string{"--from", "--to"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			cmd := NewAtlasCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(append(tt.path, "--help"))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil)
+			for _, flag := range tt.flags {
+				c.Assert(out.String(), qt.Contains, flag)
+			}
+		})
+	}
+}
+
 func TestNewAtlasCommand_ForwardsSupportedCommands(t *testing.T) {
 	c := qt.New(t)
 	cmd := NewAtlasCommand()
@@ -62,6 +154,58 @@ func TestNewAtlasCommand_ForwardsSupportedCommands(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, "database URL is required")
+}
+
+func TestNewAtlasCommand_MapsAtlasFlagFormsToNativeFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "long_value",
+			args: []string{"migrate", "apply", "--url", "postgres://localhost/db"},
+		},
+		{
+			name: "long_equals_value",
+			args: []string{"migrate", "apply", "--url=postgres://localhost/db"},
+		},
+		{
+			name: "shorthand_value",
+			args: []string{"migrate", "apply", "-u", "postgres://localhost/db"},
+		},
+		{
+			name: "bool",
+			args: []string{"migrate", "apply", "--url", "postgres://localhost/db", "--dry-run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			cmd := NewAtlasCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, "migrations directory is required")
+		})
+	}
+}
+
+func TestNewAtlasCommand_UnsupportedAtlasFlagsFailExplicitly(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"schema", "inspect", "--url", "postgres://localhost/db", "--format", "{{ sql . }}"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "atlas schema inspect accepts --format, but Ptah does not implement its behavior yet")
 }
 
 func TestNewAtlasCommand_ForwardsParentedNativeCommand(t *testing.T) {
@@ -87,6 +231,24 @@ func TestNewAtlasCommand_MigrateNewCreatesSkeletonFiles(t *testing.T) {
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"migrate", "new", "manual_hotfix", "--migrations-dir", dir})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Generated empty migration files:")
+	matches, globErr := filepath.Glob(filepath.Join(dir, "*_manual_hotfix.*.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 2)
+}
+
+func TestNewAtlasCommand_MigrateNewAcceptsAtlasDirFlag(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "new", "manual_hotfix", "--dir", dir})
 
 	err := cmd.Execute()
 

--- a/cmd/internal/cmdalias/cmdalias.go
+++ b/cmd/internal/cmdalias/cmdalias.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// ArgMapper rewrites compatibility command arguments before they are forwarded
+// to the native command.
+type ArgMapper func([]string) ([]string, error)
+
 // NewForwardCommand returns a command that forwards its raw arguments to a
 // native command factory. It is intended for compatibility aliases whose
 // behavior, flags, and exit-code contract should stay owned by the native
@@ -26,6 +30,19 @@ func NewForwardCommandWithArgs(
 	factory func() *cobra.Command,
 	prefixArgs ...string,
 ) *cobra.Command {
+	return NewForwardCommandWithArgsMapper(use, short, native, factory, nil, prefixArgs...)
+}
+
+// NewForwardCommandWithArgsMapper returns a forwarding command that can rewrite
+// compatibility arguments before prepending fixed arguments.
+func NewForwardCommandWithArgsMapper(
+	use string,
+	short string,
+	native string,
+	factory func() *cobra.Command,
+	mapper ArgMapper,
+	prefixArgs ...string,
+) *cobra.Command {
 	return &cobra.Command{
 		Use:                use,
 		Short:              short,
@@ -36,6 +53,13 @@ func NewForwardCommandWithArgs(
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if hasHelpArg(args) {
 				return cmd.Help()
+			}
+			if mapper != nil {
+				var err error
+				args, err = mapper(args)
+				if err != nil {
+					return err
+				}
 			}
 			target := factory()
 			resetCommandFlags(target)


### PR DESCRIPTION
## Summary

Closes #401.

This expands the `ptah atlas ...` compatibility namespace so Atlas OSS command paths advertise the expected Atlas flag surface and translate implemented flag aliases to Ptah's native command flags before forwarding.

Key changes:
- add Atlas-compatible flag registration for `schema` and `migrate` subcommands measured by conformance
- map implemented aliases such as `--url` to `--db-url` and `--dir` to `--migrations-dir`
- reject accepted-but-unimplemented Atlas flags explicitly instead of silently ignoring them
- keep native Ptah commands outside the `atlas` tree and document the compatibility contract

`ptah atlas migrate diff` is no longer documented as a native `ptah migrate` alias because that would imply Atlas-equivalent behavior we do not actually provide yet.

## Validation

- `go test ./cmd/atlas -count=1`
- `go test ./cmd/internal/cmdalias -count=1`
- `go test ./cmd/atlas -run TestNewAtlasCommand_AdvertisesEssentialAtlasFlags -count=1`
- `go build -o /private/tmp/ptah-401 ./cmd/ptah`
- real-binary smoke: all expected `ptah atlas ... --help` flags present
- `go test ./... -count=1`
- `go tool qtlint ./...`
- `golangci-lint run ./...`