### PR TITLE
Return errors for user-input planning failures

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -103,7 +103,10 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	diff := schemadiff.CompareWithDialect(result, dbSchema, info.Dialect)
 
 	// 4. Display differences
-	output := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, result, info.Dialect, info.Capabilities)
+	output, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, result, info.Dialect, info.Capabilities)
+	if err != nil {
+		return fmt.Errorf("error generating schema diff SQL: %w", err)
+	}
 	fmt.Print(output)
 
 	return nil

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -113,7 +113,10 @@ func generateCommand(_ *cobra.Command, _ []string) error {
 		}
 
 		// Generate table statements
-		statements := renderer.GetOrderedCreateStatements(result, d)
+		statements, err := renderer.GetOrderedCreateStatementsE(result, d)
+		if err != nil {
+			return fmt.Errorf("error rendering %s schema: %w", d, err)
+		}
 
 		for i, statement := range statements {
 			fmt.Printf("-- Statement %d/%d\n", i+1, len(statements))

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -162,7 +162,10 @@ func migrateCommandWithFlags(cmd *cobra.Command, flags map[string]cobraflags.Fla
 
 	// 4. Display differences summary
 	info := conn.Info()
-	astNodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, result, info.Dialect, info.Capabilities)
+	astNodes, err := planner.GenerateSchemaDiffASTWithCapabilities(diff, result, info.Dialect, info.Capabilities)
+	if err != nil {
+		return fmt.Errorf("error generating migration plan: %w", err)
+	}
 	assessments, err := safety.AssessRenderedWithCapabilities(astNodes, info.Dialect, info.Capabilities)
 	if err != nil {
 		return fmt.Errorf("error assessing migration safety: %w", err)

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -98,7 +98,10 @@ func readDBCommand(_ *cobra.Command, _ []string) error {
 	// Format and display the schema
 	dbsch := dbschematogo.ConvertDBSchemaToGoSchema(schema)
 	info := conn.Info()
-	statements := renderer.GetOrderedCreateStatementsWithCapabilities(dbsch, info.Dialect, info.Capabilities)
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilitiesE(dbsch, info.Dialect, info.Capabilities)
+	if err != nil {
+		return fmt.Errorf("error rendering schema: %w", err)
+	}
 	output := strings.Join(statements, ";\n") + ";"
 	fmt.Print(output)
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -2,6 +2,7 @@
 package root
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/go-extras/cobraflags"
@@ -74,10 +75,21 @@ func Execute(args ...string) {
 	cmd := NewRootCommand()
 	cmd.SetArgs(args)
 
-	err := cmd.Execute()
+	err := executeWithRecovery(cmd)
 	if err != nil {
 		os.Exit(exitcode.Code(err, 1)) //revive:disable-line:deep-exit
 	}
+}
+
+func executeWithRecovery(cmd *cobra.Command) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("internal error: %v", recovered)
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
+		}
+	}()
+
+	return cmd.Execute()
 }
 
 const rootLongDescription = `Ptah generates database schemas from Go entities,

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
 )
 
 func TestNewRootCommand_UsesPtahBranding(t *testing.T) {
@@ -95,4 +96,22 @@ func TestNewRootCommand_PTAHDBURLFeedsCommandFlag(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Not(qt.Contains), "database URL is required")
 	c.Assert(err.Error(), qt.Contains, "error connecting to database")
+}
+
+func TestExecuteWithRecovery_ConvertsCommandPanicToError(t *testing.T) {
+	c := qt.New(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{
+		Use: "panic",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			panic("bad annotation")
+		},
+	}
+	cmd.SetErr(&stderr)
+
+	err := executeWithRecovery(cmd)
+
+	c.Assert(err, qt.ErrorMatches, "internal error: bad annotation")
+	c.Assert(stderr.String(), qt.Contains, "error: internal error: bad annotation")
 }

--- a/core/goschema/embedded_bug_reproduction_test.go
+++ b/core/goschema/embedded_bug_reproduction_test.go
@@ -75,7 +75,8 @@ func TestEmbeddedEntityIDBugReproduction(t *testing.T) {
 	c := qt.New(t)
 
 	// Parse the test file to get the schema
-	database := ParseFile("embedded_bug_reproduction_test.go")
+	database, err := ParseFile("embedded_bug_reproduction_test.go")
+	c.Assert(err, qt.IsNil)
 
 	// Process embedded fields to get all fields
 	allFields := processEmbeddedFields(database.EmbeddedFields, database.Fields)
@@ -160,7 +161,8 @@ func TestEmbeddedFieldProcessingDebug(t *testing.T) {
 	c := qt.New(t)
 
 	// Parse the test file to get the schema
-	database := ParseFile("embedded_bug_reproduction_test.go")
+	database, err := ParseFile("embedded_bug_reproduction_test.go")
+	c.Assert(err, qt.IsNil)
 
 	t.Logf("Found %d tables", len(database.Tables))
 	for _, table := range database.Tables {
@@ -206,7 +208,8 @@ func TestNestedEmbeddedFieldsComprehensive(t *testing.T) {
 	c := qt.New(t)
 
 	// Parse the test file to get the schema
-	database := ParseFile("embedded_bug_reproduction_test.go")
+	database, err := ParseFile("embedded_bug_reproduction_test.go")
+	c.Assert(err, qt.IsNil)
 
 	// Process embedded fields to get all fields
 	allFields := processEmbeddedFields(database.EmbeddedFields, database.Fields)
@@ -333,7 +336,8 @@ func TestNestedEmbeddedFieldsWithPrefixes(t *testing.T) {
 	c := qt.New(t)
 
 	// Parse the test file to get the schema
-	database := ParseFile("embedded_bug_reproduction_test.go")
+	database, err := ParseFile("embedded_bug_reproduction_test.go")
+	c.Assert(err, qt.IsNil)
 
 	// Process embedded fields to get all fields
 	allFields := processEmbeddedFields(database.EmbeddedFields, database.Fields)
@@ -450,7 +454,8 @@ type Area struct {
 	c.Assert(err, qt.IsNil)
 
 	// Parse the test file
-	database := ParseFile(testFile)
+	database, err := ParseFile(testFile)
+	c.Assert(err, qt.IsNil)
 
 	// Process embedded fields
 	allFields := processEmbeddedFields(database.EmbeddedFields, database.Fields)

--- a/core/goschema/index_annotations_test.go
+++ b/core/goschema/index_annotations_test.go
@@ -26,9 +26,8 @@ type Event struct {
 	_ int
 }
 `
-	db := goschema.ParseSource("fixture.go", src)
-
 	c := qt.New(t)
+	db := mustParseSource(c, "fixture.go", src)
 	c.Assert(db.Indexes, qt.HasLen, 1)
 	idx := db.Indexes[0]
 	c.Assert(idx.Name, qt.Equals, "idx_e_payload")
@@ -54,11 +53,8 @@ type Event struct {
 }
 `
 	c := qt.New(t)
-	defer func() {
-		r := recover()
-		c.Assert(r, qt.IsNotNil, qt.Commentf("expected parser to panic on unknown index attribute"))
-	}()
-	_ = goschema.ParseSource("fixture.go", src)
+	_, err := goschema.ParseSource("fixture.go", src)
+	c.Assert(err, qt.ErrorMatches, `unknown annotation attribute "granluarity" on //migrator:schema:index at Event`)
 }
 
 // TestParseIndexAnnotation_NoTypeNoGranularity confirms that the new fields
@@ -79,8 +75,8 @@ type User struct {
 	_ int
 }
 `
-	db := goschema.ParseSource("fixture.go", src)
 	c := qt.New(t)
+	db := mustParseSource(c, "fixture.go", src)
 	c.Assert(db.Indexes, qt.HasLen, 1)
 	idx := db.Indexes[0]
 	c.Assert(idx.Type, qt.Equals, "")

--- a/core/goschema/issue_51_reproduction_test.go
+++ b/core/goschema/issue_51_reproduction_test.go
@@ -94,7 +94,8 @@ func TestIssue51ExactReproduction(t *testing.T) {
 	nodes := planner.GenerateMigrationAST(diff, db)
 
 	// Render to SQL
-	r := renderer.NewRenderer("postgresql")
+	r, err := renderer.NewRenderer("postgresql")
+	c.Assert(err, qt.IsNil)
 	var sqlStatements []string
 	for _, node := range nodes {
 		sql, err := r.Render(node)

--- a/core/goschema/mysql_type_compatibility_test.go
+++ b/core/goschema/mysql_type_compatibility_test.go
@@ -121,7 +121,8 @@ func TestMySQLMigrationGeneratesCompatibleTypes(t *testing.T) {
 	nodes := planner.GenerateMigrationAST(diff, db)
 
 	// Render to SQL
-	r := renderer.NewRenderer("mysql")
+	r, err := renderer.NewRenderer("mysql")
+	c.Assert(err, qt.IsNil)
 	var sqlStatements []string
 	for _, node := range nodes {
 		sql, err := r.Render(node)

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -97,11 +97,11 @@ var knownSchemaAttributes = map[string]bool{
 	"comment": true,
 }
 
-// validateAttributes panics if kv contains any key the directive does not
-// recognize. Platform-specific overrides (platform.*) are always allowed.
-// This catches typos like default_fn-vs-default_expr at parse time instead of
-// silently dropping them and producing wrong SQL.
-func validateAttributes(kv map[string]string, known map[string]bool, directive, location string) {
+// validateAttributes rejects any key the directive does not recognize.
+// Platform-specific overrides (platform.*) are always allowed. This catches
+// typos like default_fn-vs-default_expr at parse time instead of silently
+// dropping them and producing wrong SQL.
+func validateAttributes(kv map[string]string, known map[string]bool, directive, location string) error {
 	for k := range kv {
 		if known[k] || strings.HasPrefix(k, "platform.") {
 			continue
@@ -111,11 +111,12 @@ func validateAttributes(kv map[string]string, known map[string]bool, directive, 
 			"attribute", k,
 			"location", location,
 		)
-		panic(fmt.Sprintf("unknown annotation attribute %q on %s at %s", k, directive, location))
+		return fmt.Errorf("unknown annotation attribute %q on %s at %s", k, directive, location)
 	}
+	return nil
 }
 
-func requireAttributes(kv map[string]string, required []string, directive, location string) {
+func requireAttributes(kv map[string]string, required []string, directive, location string) error {
 	for _, key := range required {
 		if strings.TrimSpace(kv[key]) != "" {
 			continue
@@ -125,11 +126,18 @@ func requireAttributes(kv map[string]string, required []string, directive, locat
 			"attribute", key,
 			"location", location,
 		)
-		panic(fmt.Sprintf("missing required annotation attribute %q on %s at %s", key, directive, location))
+		return fmt.Errorf("missing required annotation attribute %q on %s at %s", key, directive, location)
 	}
+	return nil
 }
 
-func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string, globalEnumsMap map[string]Enum, schemaFields *[]Field) {
+func parseFieldComment(
+	comment *ast.Comment,
+	field *ast.Field,
+	structName string,
+	globalEnumsMap map[string]Enum,
+	schemaFields *[]Field,
+) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 
 	// Validate the directive itself, not each named carrier. For anonymous /
@@ -139,7 +147,9 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 	if len(field.Names) > 0 {
 		location = structName + "." + field.Names[0].Name
 	}
-	validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", location)
+	if err := validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", location); err != nil {
+		return err
+	}
 
 	for _, name := range field.Names {
 		enumRaw := kv["enum"]
@@ -165,7 +175,7 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 
 		identityGeneration := normalizeIdentityGeneration(kv["identity_generation"])
 		if kv["identity_generation"] != "" && identityGeneration == "" {
-			panic(fmt.Sprintf("invalid identity_generation %q on //migrator:schema:field at %s", kv["identity_generation"], location))
+			return fmt.Errorf("invalid identity_generation %q on //migrator:schema:field at %s", kv["identity_generation"], location)
 		}
 		if identityGeneration == "" && hasIdentitySettings(kv) {
 			identityGeneration = "BY_DEFAULT"
@@ -199,6 +209,7 @@ func parseFieldComment(comment *ast.Comment, field *ast.Field, structName string
 			Overrides:          parseutils.ParsePlatformSpecific(kv),
 		})
 	}
+	return nil
 }
 
 func hasIdentitySettings(kv map[string]string) bool {
@@ -240,9 +251,11 @@ func parseEmbeddedComment(comment *ast.Comment, field *ast.Field, structName str
 	})
 }
 
-func parseIndexComment(comment *ast.Comment, structName string, schemaIndexes *[]Index) {
+func parseIndexComment(comment *ast.Comment, structName string, schemaIndexes *[]Index) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	validateAttributes(kv, knownIndexAttributes, "//migrator:schema:index", structName)
+	if err := validateAttributes(kv, knownIndexAttributes, "//migrator:schema:index", structName); err != nil {
+		return err
+	}
 
 	// "columns=" is a legacy synonym for "fields=" (several integration
 	// fixtures still spell it that way); prefer the modern name and fall
@@ -267,7 +280,7 @@ func parseIndexComment(comment *ast.Comment, structName string, schemaIndexes *[
 	if g := strings.TrimSpace(kv["granularity"]); g != "" {
 		n, err := strconv.Atoi(g)
 		if err != nil || n < 0 {
-			panic(fmt.Sprintf("invalid granularity %q on //migrator:schema:index at %s (must be a non-negative integer)", g, structName))
+			return fmt.Errorf("invalid granularity %q on //migrator:schema:index at %s (must be a non-negative integer)", g, structName)
 		}
 		granularity = n
 	}
@@ -284,6 +297,7 @@ func parseIndexComment(comment *ast.Comment, structName string, schemaIndexes *[
 		TableName:   tableName,       // Target table name
 		Granularity: granularity,     // CH only: GRANULARITY n for data-skipping indexes
 	})
+	return nil
 }
 
 // ParseConstraintComment parses a constraint comment and adds it to the constraints slice.
@@ -341,15 +355,20 @@ func parseExtensionComment(comment *ast.Comment, extensions *[]Extension) {
 	})
 }
 
-func parseSchemaComment(comment *ast.Comment, schemas *[]Schema) {
+func parseSchemaComment(comment *ast.Comment, schemas *[]Schema) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	validateAttributes(kv, knownSchemaAttributes, "//migrator:schema:schema", kv["name"])
-	requireAttributes(kv, []string{"name"}, "//migrator:schema:schema", kv["name"])
+	if err := validateAttributes(kv, knownSchemaAttributes, "//migrator:schema:schema", kv["name"]); err != nil {
+		return err
+	}
+	if err := requireAttributes(kv, []string{"name"}, "//migrator:schema:schema", kv["name"]); err != nil {
+		return err
+	}
 
 	*schemas = append(*schemas, Schema{
 		Name:    kv["name"],
 		Comment: kv["comment"],
 	})
+	return nil
 }
 
 func parseTableComment(comment *ast.Comment, structName string, tableDirectives *[]Table) {
@@ -367,258 +386,194 @@ func parseTableComment(comment *ast.Comment, structName string, tableDirectives 
 	})
 }
 
-func parseComment(
-	comment *ast.Comment,
-	structName string,
-	field *ast.Field,
-	globalEnumsMap map[string]Enum,
-	schemaFields *[]Field,
-	embeddedFields *[]EmbeddedField,
-	schemaIndexes *[]Index,
-	schemaConstraints *[]Constraint,
-	extensions *[]Extension,
-	functions *[]Function,
-	views *[]View,
-	materializedViews *[]MaterializedView,
-	triggers *[]Trigger,
-	rlsPolicies *[]RLSPolicy,
-	rlsEnabledTables *[]RLSEnabledTable,
-	roles *[]Role,
-	grants *[]Grant,
-) {
-	switch {
-	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
-		parseFieldComment(comment, field, structName, globalEnumsMap, schemaFields)
-	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
-		parseEmbeddedComment(comment, field, structName, embeddedFields)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
-		parseIndexComment(comment, structName, schemaIndexes)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
-		ParseConstraintComment(comment, structName, schemaConstraints)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
-		parseExtensionComment(comment, extensions)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
-		parseFunctionComment(comment, structName, functions)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
-		parseViewComment(comment, structName, views)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
-		parseMaterializedViewComment(comment, structName, materializedViews)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
-		parseTriggerComment(comment, structName, triggers)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-		parseRLSPolicyComment(comment, structName, rlsPolicies)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-		parseRLSEnableComment(comment, structName, rlsEnabledTables)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
-		parseRoleComment(comment, structName, roles)
-	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
-		parseGrantComment(comment, structName, grants)
+type schemaParseState struct {
+	tableNameToStructName map[string]string
+	globalEnumsMap        map[string]Enum
+	embeddedFields        []EmbeddedField
+	schemaFields          []Field
+	schemaIndexes         []Index
+	schemaConstraints     []Constraint
+	tableDirectives       []Table
+	extensions            []Extension
+	functions             []Function
+	views                 []View
+	materializedViews     []MaterializedView
+	triggers              []Trigger
+	rlsPolicies           []RLSPolicy
+	rlsEnabledTables      []RLSEnabledTable
+	roles                 []Role
+	grants                []Grant
+	schemas               []Schema
+}
+
+func newSchemaParseState() *schemaParseState {
+	return &schemaParseState{
+		tableNameToStructName: make(map[string]string),
+		globalEnumsMap:        make(map[string]Enum),
 	}
 }
 
-func processTableComments(
-	structName string,
-	genDecl *ast.GenDecl,
-	tableDirectives *[]Table,
-	schemaConstraints *[]Constraint,
-	extensions *[]Extension,
-	functions *[]Function,
-	views *[]View,
-	materializedViews *[]MaterializedView,
-	triggers *[]Trigger,
-	rlsPolicies *[]RLSPolicy,
-	rlsEnabledTables *[]RLSEnabledTable,
-	roles *[]Role,
-	grants *[]Grant,
-	schemas *[]Schema,
-) {
+func (s *schemaParseState) parseComment(comment *ast.Comment, structName string, field *ast.Field) error {
+	switch {
+	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
+		return parseFieldComment(comment, field, structName, s.globalEnumsMap, &s.schemaFields)
+	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
+		parseEmbeddedComment(comment, field, structName, &s.embeddedFields)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
+		return parseIndexComment(comment, structName, &s.schemaIndexes)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
+		ParseConstraintComment(comment, structName, &s.schemaConstraints)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
+		parseExtensionComment(comment, &s.extensions)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
+		parseFunctionComment(comment, structName, &s.functions)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
+		return parseViewComment(comment, structName, &s.views)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
+		return parseMaterializedViewComment(comment, structName, &s.materializedViews)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
+		return parseTriggerComment(comment, structName, &s.triggers)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
+		parseRLSPolicyComment(comment, structName, &s.rlsPolicies)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
+		parseRLSEnableComment(comment, structName, &s.rlsEnabledTables)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
+		parseRoleComment(comment, structName, &s.roles)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
+		parseGrantComment(comment, structName, &s.grants)
+	}
+	return nil
+}
+
+func (s *schemaParseState) processTableComments(structName string, genDecl *ast.GenDecl) error {
 	if genDecl.Doc == nil {
-		return
+		return nil
 	}
 
 	for _, comment := range genDecl.Doc.List {
 		switch {
 		case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
-			parseTableComment(comment, structName, tableDirectives)
+			parseTableComment(comment, structName, &s.tableDirectives)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
-			ParseConstraintComment(comment, structName, schemaConstraints)
+			ParseConstraintComment(comment, structName, &s.schemaConstraints)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
-			parseExtensionComment(comment, extensions)
+			parseExtensionComment(comment, &s.extensions)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
-			parseFunctionComment(comment, structName, functions)
+			parseFunctionComment(comment, structName, &s.functions)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
-			parseViewComment(comment, structName, views)
+			if err := parseViewComment(comment, structName, &s.views); err != nil {
+				return err
+			}
 		case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
-			parseMaterializedViewComment(comment, structName, materializedViews)
+			if err := parseMaterializedViewComment(comment, structName, &s.materializedViews); err != nil {
+				return err
+			}
 		case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
-			parseTriggerComment(comment, structName, triggers)
+			if err := parseTriggerComment(comment, structName, &s.triggers); err != nil {
+				return err
+			}
 		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-			parseRLSPolicyComment(comment, structName, rlsPolicies)
+			parseRLSPolicyComment(comment, structName, &s.rlsPolicies)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-			parseRLSEnableComment(comment, structName, rlsEnabledTables)
+			parseRLSEnableComment(comment, structName, &s.rlsEnabledTables)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
-			parseRoleComment(comment, structName, roles)
+			parseRoleComment(comment, structName, &s.roles)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
-			parseGrantComment(comment, structName, grants)
+			parseGrantComment(comment, structName, &s.grants)
 		case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
-			parseSchemaComment(comment, schemas)
+			if err := parseSchemaComment(comment, &s.schemas); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
-func processFieldComments(
-	structName string,
-	structType *ast.StructType,
-	globalEnumsMap map[string]Enum,
-	schemaFields *[]Field,
-	embeddedFields *[]EmbeddedField,
-	schemaIndexes *[]Index,
-	schemaConstraints *[]Constraint,
-	extensions *[]Extension,
-	functions *[]Function,
-	views *[]View,
-	materializedViews *[]MaterializedView,
-	triggers *[]Trigger,
-	rlsPolicies *[]RLSPolicy,
-	rlsEnabledTables *[]RLSEnabledTable,
-	roles *[]Role,
-	grants *[]Grant,
-) {
+func (s *schemaParseState) processFieldComments(structName string, structType *ast.StructType) error {
 	for _, field := range structType.Fields.List {
 		if field.Doc == nil {
 			continue
 		}
 		for _, comment := range field.Doc.List {
-			parseComment(comment, structName, field, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
+			if err := s.parseComment(comment, structName, field); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
-func ParseFile(filename string) Database {
+func ParseFile(filename string) (Database, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
 	if err != nil {
 		slog.Error("Failed to parse file", "error", err)
-		panic("Failed to parse file")
+		return Database{}, fmt.Errorf("parse Go file %q: %w", filename, err)
 	}
 
 	return parseFileAST(f)
 }
 
-// ParseSource parses a Go source string and returns the database schema
-// source can be a string, []byte, or io.Reader
-func ParseSource(filename string, source any) Database {
+// ParseSource parses a Go source string and returns the database schema.
+// source can be a string, []byte, or io.Reader.
+func ParseSource(filename string, source any) (Database, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, source, parser.ParseComments)
 	if err != nil {
 		slog.Error("Failed to parse file", "error", err)
-		panic("Failed to parse file")
+		return Database{}, fmt.Errorf("parse Go source %q: %w", filename, err)
 	}
 
 	return parseFileAST(f)
 }
 
-func parseFileAST(f *ast.File) Database {
-	var embeddedFields []EmbeddedField
-	var schemaFields []Field
-	var schemaIndexes []Index
-	var schemaConstraints []Constraint
-	var tableDirectives []Table
-	var extensions []Extension
-	var functions []Function
-	var views []View
-	var materializedViews []MaterializedView
-	var triggers []Trigger
-	var rlsPolicies []RLSPolicy
-	var rlsEnabledTables []RLSEnabledTable
-	var roles []Role
-	var grants []Grant
-	var schemas []Schema
-	globalEnumsMap := make(map[string]Enum)
+func parseFileAST(f *ast.File) (Database, error) {
+	state := newSchemaParseState()
+	if err := state.processFileAST(f); err != nil {
+		return Database{}, err
+	}
 
-	// Single pass: collect table names and process all declarations and comments
-	tableNameToStructName := make(map[string]string)
-	processFileAST(
-		f,
-		tableNameToStructName,
-		globalEnumsMap,
-		&embeddedFields,
-		&schemaFields,
-		&schemaIndexes,
-		&schemaConstraints,
-		&tableDirectives,
-		&extensions,
-		&functions,
-		&views,
-		&materializedViews,
-		&triggers,
-		&rlsPolicies,
-		&rlsEnabledTables,
-		&roles,
-		&grants,
-		&schemas,
-	)
-
-	enums := make([]Enum, 0, len(globalEnumsMap))
-	keys := make([]string, 0, len(globalEnumsMap))
-	for k := range globalEnumsMap {
+	enums := make([]Enum, 0, len(state.globalEnumsMap))
+	keys := make([]string, 0, len(state.globalEnumsMap))
+	for k := range state.globalEnumsMap {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		enums = append(enums, globalEnumsMap[k])
+		enums = append(enums, state.globalEnumsMap[k])
 	}
 
 	// Sort extensions alphabetically for consistent output
-	sort.Slice(extensions, func(i, j int) bool {
-		return extensions[i].Name < extensions[j].Name
+	sort.Slice(state.extensions, func(i, j int) bool {
+		return state.extensions[i].Name < state.extensions[j].Name
 	})
 
 	result := Database{
-		Schemas:           schemas,
-		Tables:            tableDirectives,
-		Fields:            schemaFields,
-		Indexes:           schemaIndexes,
-		Constraints:       schemaConstraints,
+		Schemas:           state.schemas,
+		Tables:            state.tableDirectives,
+		Fields:            state.schemaFields,
+		Indexes:           state.schemaIndexes,
+		Constraints:       state.schemaConstraints,
 		Enums:             enums,
-		EmbeddedFields:    embeddedFields,
-		Extensions:        extensions,
-		Functions:         functions,
-		Views:             views,
-		MaterializedViews: materializedViews,
-		Triggers:          triggers,
-		RLSPolicies:       rlsPolicies,
-		RLSEnabledTables:  rlsEnabledTables,
-		Roles:             roles,
-		Grants:            grants,
+		EmbeddedFields:    state.embeddedFields,
+		Extensions:        state.extensions,
+		Functions:         state.functions,
+		Views:             state.views,
+		MaterializedViews: state.materializedViews,
+		Triggers:          state.triggers,
+		RLSPolicies:       state.rlsPolicies,
+		RLSEnabledTables:  state.rlsEnabledTables,
+		Roles:             state.roles,
+		Grants:            state.grants,
 		Dependencies:      make(map[string][]string),
 	}
 	normalizeTableScopedNames(&result)
 	buildDependencyGraph(&result)
-	return result
+	return result, nil
 }
 
 // processFileAST processes the entire AST file in a single optimized pass
-func processFileAST(
-	f *ast.File,
-	tableNameToStructName map[string]string,
-	globalEnumsMap map[string]Enum,
-	embeddedFields *[]EmbeddedField,
-	schemaFields *[]Field,
-	schemaIndexes *[]Index,
-	schemaConstraints *[]Constraint,
-	tableDirectives *[]Table,
-	extensions *[]Extension,
-	functions *[]Function,
-	views *[]View,
-	materializedViews *[]MaterializedView,
-	triggers *[]Trigger,
-	rlsPolicies *[]RLSPolicy,
-	rlsEnabledTables *[]RLSEnabledTable,
-	roles *[]Role,
-	grants *[]Grant,
-	schemas *[]Schema,
-) {
+func (s *schemaParseState) processFileAST(f *ast.File) error {
 	// First, collect table names from struct declarations
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
@@ -636,34 +591,18 @@ func processFileAST(
 				continue
 			}
 
-			mapTableDirectiveStructNames(genDecl.Doc, structName, tableNameToStructName)
+			mapTableDirectiveStructNames(genDecl.Doc, structName, s.tableNameToStructName)
 		}
 	}
 
 	// Process all struct declarations
-	processDeclarations(
-		f,
-		tableNameToStructName,
-		globalEnumsMap,
-		embeddedFields,
-		schemaFields,
-		schemaIndexes,
-		schemaConstraints,
-		tableDirectives,
-		extensions,
-		functions,
-		views,
-		materializedViews,
-		triggers,
-		rlsPolicies,
-		rlsEnabledTables,
-		roles,
-		grants,
-		schemas,
-	)
+	if err := s.processDeclarations(f); err != nil {
+		return err
+	}
 
 	// Process all file comments for RLS annotations that might not be associated with struct declarations
-	processAllFileComments(f, tableNameToStructName, rlsPolicies, rlsEnabledTables)
+	processAllFileComments(f, s.tableNameToStructName, &s.rlsPolicies, &s.rlsEnabledTables)
+	return nil
 }
 
 func mapTableDirectiveStructNames(doc *ast.CommentGroup, structName string, tableNameToStructName map[string]string) {
@@ -687,26 +626,7 @@ func mapTableDirectiveStructNames(doc *ast.CommentGroup, structName string, tabl
 }
 
 // processDeclarations processes all struct declarations in the file
-func processDeclarations(
-	f *ast.File,
-	tableNameToStructName map[string]string,
-	globalEnumsMap map[string]Enum,
-	embeddedFields *[]EmbeddedField,
-	schemaFields *[]Field,
-	schemaIndexes *[]Index,
-	schemaConstraints *[]Constraint,
-	tableDirectives *[]Table,
-	extensions *[]Extension,
-	functions *[]Function,
-	views *[]View,
-	materializedViews *[]MaterializedView,
-	triggers *[]Trigger,
-	rlsPolicies *[]RLSPolicy,
-	rlsEnabledTables *[]RLSEnabledTable,
-	roles *[]Role,
-	grants *[]Grant,
-	schemas *[]Schema,
-) {
+func (s *schemaParseState) processDeclarations(f *ast.File) error {
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -723,10 +643,15 @@ func processDeclarations(
 				continue
 			}
 
-			processTableComments(structName, genDecl, tableDirectives, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants, schemas)
-			processFieldComments(structName, structType, globalEnumsMap, schemaFields, embeddedFields, schemaIndexes, schemaConstraints, extensions, functions, views, materializedViews, triggers, rlsPolicies, rlsEnabledTables, roles, grants)
+			if err := s.processTableComments(structName, genDecl); err != nil {
+				return err
+			}
+			if err := s.processFieldComments(structName, structType); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // processAllFileComments scans all comments in the file for RLS annotations
@@ -825,10 +750,14 @@ func parseFunctionComment(comment *ast.Comment, structName string, functions *[]
 	*functions = append(*functions, fn)
 }
 
-func parseViewComment(comment *ast.Comment, structName string, views *[]View) {
+func parseViewComment(comment *ast.Comment, structName string, views *[]View) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	validateAttributes(kv, knownViewAttributes, "//migrator:schema:view", structName)
-	requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:view", structName)
+	if err := validateAttributes(kv, knownViewAttributes, "//migrator:schema:view", structName); err != nil {
+		return err
+	}
+	if err := requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:view", structName); err != nil {
+		return err
+	}
 	*views = append(*views, View{
 		StructName: structName,
 		Name:       kv["name"],
@@ -836,12 +765,17 @@ func parseViewComment(comment *ast.Comment, structName string, views *[]View) {
 		WithCheck:  kv["with_check"] == "true",
 		Comment:    kv["comment"],
 	})
+	return nil
 }
 
-func parseMaterializedViewComment(comment *ast.Comment, structName string, materializedViews *[]MaterializedView) {
+func parseMaterializedViewComment(comment *ast.Comment, structName string, materializedViews *[]MaterializedView) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	validateAttributes(kv, knownMaterializedViewAttributes, "//migrator:schema:matview", structName)
-	requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:matview", structName)
+	if err := validateAttributes(kv, knownMaterializedViewAttributes, "//migrator:schema:matview", structName); err != nil {
+		return err
+	}
+	if err := requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:matview", structName); err != nil {
+		return err
+	}
 	refreshStrategy := kv["refresh_strategy"]
 	if refreshStrategy == "" {
 		refreshStrategy = "manual"
@@ -855,12 +789,17 @@ func parseMaterializedViewComment(comment *ast.Comment, structName string, mater
 	}
 	matView.Canonicalize()
 	*materializedViews = append(*materializedViews, matView)
+	return nil
 }
 
-func parseTriggerComment(comment *ast.Comment, structName string, triggers *[]Trigger) {
+func parseTriggerComment(comment *ast.Comment, structName string, triggers *[]Trigger) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	validateAttributes(kv, knownTriggerAttributes, "//migrator:schema:trigger", structName)
-	requireAttributes(kv, []string{"name", "table", "timing", "event", "body"}, "//migrator:schema:trigger", structName)
+	if err := validateAttributes(kv, knownTriggerAttributes, "//migrator:schema:trigger", structName); err != nil {
+		return err
+	}
+	if err := requireAttributes(kv, []string{"name", "table", "timing", "event", "body"}, "//migrator:schema:trigger", structName); err != nil {
+		return err
+	}
 	trigger := Trigger{
 		StructName: structName,
 		Name:       kv["name"],
@@ -873,6 +812,7 @@ func parseTriggerComment(comment *ast.Comment, structName string, triggers *[]Tr
 	}
 	trigger.Canonicalize()
 	*triggers = append(*triggers, trigger)
+	return nil
 }
 
 func parseRLSPolicyComment(comment *ast.Comment, structName string, rlsPolicies *[]RLSPolicy) {
@@ -949,10 +889,13 @@ func splitCommaList(value string) []string {
 }
 
 // ParseFileWithDependencies parses a Go file and automatically discovers and parses
-// related files in the same directory to resolve embedded type references
-func ParseFileWithDependencies(filename string) Database {
+// related files in the same directory to resolve embedded type references.
+func ParseFileWithDependencies(filename string) (Database, error) {
 	// Parse the main file
-	database := ParseFile(filename)
+	database, err := ParseFile(filename)
+	if err != nil {
+		return Database{}, err
+	}
 
 	// Get the directory of the main file
 	dir := filepath.Dir(filename)
@@ -961,8 +904,7 @@ func ParseFileWithDependencies(filename string) Database {
 	pattern := filepath.Join(dir, "*.go")
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
-		slog.Warn("Failed to find related files", "error", err)
-		return database
+		return Database{}, fmt.Errorf("find related Go files for %q: %w", filename, err)
 	}
 
 	// Collect embedded type names that we need to resolve
@@ -978,7 +920,10 @@ func ParseFileWithDependencies(filename string) Database {
 		}
 
 		// Parse the related file
-		dbmatch := ParseFile(match)
+		dbmatch, err := ParseFile(match)
+		if err != nil {
+			return Database{}, fmt.Errorf("parse related Go file %q: %w", match, err)
+		}
 		relatedFields := dbmatch.Fields
 
 		// Only add fields from embedded types that we actually need
@@ -990,5 +935,5 @@ func ParseFileWithDependencies(filename string) Database {
 	}
 
 	buildDependencyGraph(&database)
-	return database
+	return database, nil
 }

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -14,6 +14,20 @@ import (
 	"github.com/stokaro/ptah/core/goschema/internal/parseutils"
 )
 
+func mustParseSource(c *qt.C, filename string, source any) goschema.Database {
+	c.Helper()
+	db, err := goschema.ParseSource(filename, source)
+	c.Assert(err, qt.IsNil)
+	return db
+}
+
+func mustParseFile(c *qt.C, filename string) goschema.Database {
+	c.Helper()
+	db, err := goschema.ParseFile(filename)
+	c.Assert(err, qt.IsNil)
+	return db
+}
+
 func TestParseKeyValueComment_SimplifiedSyntax(t *testing.T) {
 	c := qt.New(t)
 
@@ -125,7 +139,7 @@ func TestParseKeyValueComment_SimplifiedSyntax(t *testing.T) {
 func TestParseSource_FieldIdentityAttributes(t *testing.T) {
 	c := qt.New(t)
 
-	db := goschema.ParseSource("schema.go", `
+	db := mustParseSource(c, "schema.go", `
 package test
 
 //migrator:schema:table name="users"
@@ -146,8 +160,7 @@ type User struct {
 func TestParseSource_FieldIdentityAttributesRejectInvalidGeneration(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(func() {
-		goschema.ParseSource("schema.go", `
+	_, err := goschema.ParseSource("schema.go", `
 package test
 
 //migrator:schema:table name="users"
@@ -156,13 +169,13 @@ type User struct {
 	ID int64
 }
 `)
-	}, qt.PanicMatches, `invalid identity_generation "BY_DEFUALT".*`)
+	c.Assert(err, qt.ErrorMatches, `invalid identity_generation "BY_DEFUALT".*`)
 }
 
 func TestParseSource_FieldIdentityOptionsDefaultGeneration(t *testing.T) {
 	c := qt.New(t)
 
-	db := goschema.ParseSource("schema.go", `
+	db := mustParseSource(c, "schema.go", `
 package test
 
 //migrator:schema:table name="users"
@@ -181,7 +194,7 @@ type User struct {
 func TestParseSchemaObjectAnnotations(t *testing.T) {
 	c := qt.New(t)
 
-	db := goschema.ParseSource("schema_objects.go", `
+	db := mustParseSource(c, "schema_objects.go", `
 package test
 
 //migrator:schema:view name="active_users" body="SELECT id FROM users WHERE deleted_at IS NULL" with_check="true" comment="Active users"
@@ -245,13 +258,12 @@ func TestParseSchemaObjectAnnotations_RejectsInvalidAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c.Assert(func() {
-				goschema.ParseSource("schema_object_invalid.go", `
+			_, err := goschema.ParseSource("schema_object_invalid.go", `
 package test
 `+tt.annotation+`
 type User struct{}
 `)
-			}, qt.PanicMatches, ".*"+tt.want+".*")
+			c.Assert(err, qt.ErrorMatches, ".*"+tt.want+".*")
 		})
 	}
 }
@@ -393,7 +405,7 @@ type Product struct {
 	c.Assert(err, qt.IsNil)
 
 	// Parse the file
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	// Should have 4 fields and 1 enum
 	c.Assert(database.Fields, qt.HasLen, 4)
@@ -434,7 +446,7 @@ type User struct {
 	err := os.WriteFile(testFile, []byte(content), 0o600)
 	c.Assert(err, qt.IsNil)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 	c.Assert(database.Tables, qt.HasLen, 1)
 	c.Assert(database.Tables[0].Name, qt.Equals, "users")
 	c.Assert(database.Tables[0].Schema, qt.Equals, "auth")
@@ -474,7 +486,7 @@ type User struct {
 	err := os.WriteFile(testFile, []byte(content), 0o600)
 	c.Assert(err, qt.IsNil)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 	c.Assert(database.Constraints, qt.HasLen, 2)
 	c.Assert(database.Constraints[0].Table, qt.Equals, "auth.users")
 	c.Assert(database.Constraints[1].Table, qt.Equals, "auth.users")
@@ -740,7 +752,7 @@ func TestParseFunctionComment(t *testing.T) {
 			tmp := t.TempDir() + "/fn.go"
 			c.Assert(os.WriteFile(tmp, []byte(src), 0o644), qt.IsNil) //nolint:gosec // 0644 is fine for a test fixture
 
-			db := goschema.ParseFile(tmp)
+			db := mustParseFile(c, tmp)
 			c.Assert(db.Functions, qt.HasLen, 1)
 			c.Assert(db.Functions[0], qt.DeepEquals, tt.expected)
 		})
@@ -987,15 +999,9 @@ type Widget struct {
 			err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
 			c.Assert(err, qt.IsNil)
 
-			defer func() {
-				r := recover()
-				c.Assert(r, qt.IsNotNil, qt.Commentf("expected panic for unknown attribute"))
-				msg, _ := r.(string)
-				c.Assert(msg, qt.Contains, "unknown annotation attribute")
-				c.Assert(msg, qt.Contains, tt.mustContain)
-			}()
-
-			_ = goschema.ParseFile(testFile)
+			_, err = goschema.ParseFile(testFile)
+			c.Assert(err, qt.ErrorMatches, ".*unknown annotation attribute.*")
+			c.Assert(err.Error(), qt.Contains, tt.mustContain)
 		})
 	}
 }
@@ -1025,7 +1031,7 @@ type Widget struct {
 	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
 	c.Assert(err, qt.IsNil)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 	c.Assert(database.Fields, qt.HasLen, 3)
 }
 
@@ -1059,7 +1065,7 @@ type CommodityService struct {
 	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
 	c.Assert(err, qt.IsNil)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	var fkField *goschema.Field
 	for i, f := range database.Fields {
@@ -1151,7 +1157,7 @@ type File struct {
 	err := os.WriteFile(testFile, []byte(content), 0644) //nolint:gosec // 0644 is fine for tests
 	c.Assert(err, qt.IsNil)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	var category, typ *goschema.Field
 	for i, f := range database.Fields {

--- a/core/goschema/pointer_embedded_test.go
+++ b/core/goschema/pointer_embedded_test.go
@@ -69,7 +69,7 @@ type RegularPost struct {
 	c.Assert(err, qt.IsNil)
 
 	// Parse the file
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	// Should have 2 tables
 	c.Assert(database.Tables, qt.HasLen, 2)

--- a/core/goschema/postgresql_features_test.go
+++ b/core/goschema/postgresql_features_test.go
@@ -288,7 +288,7 @@ func parseStringAsGoFile(c *qt.C, content string) goschema.Database {
 	c.Assert(err, qt.IsNil)
 
 	// Parse the file
-	return goschema.ParseFile(tmpFile)
+	return mustParseFile(c, tmpFile)
 }
 
 // Helper function to write content to a file

--- a/core/goschema/rls_edge_cases_test.go
+++ b/core/goschema/rls_edge_cases_test.go
@@ -5,7 +5,6 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/goschema/testutil"
 )
 
@@ -130,7 +129,7 @@ type User struct {
 			defer testutil.RemoveTempFile(t, tempFile)
 
 			// Parse the file
-			database := goschema.ParseFile(tempFile)
+			database := mustParseFile(c, tempFile)
 
 			// Check RLS policies
 			c.Assert(database.RLSPolicies, qt.HasLen, tt.expectedPolicies,

--- a/core/goschema/rls_integration_test.go
+++ b/core/goschema/rls_integration_test.go
@@ -73,7 +73,7 @@ type Product struct {
 	defer cleanupTestFile(testFile)
 
 	// Parse the file
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	// Verify functions were parsed correctly
 	c.Assert(database.Functions, qt.HasLen, 2)
@@ -185,7 +185,7 @@ type TestTable struct {
 	c.Assert(err, qt.IsNil)
 	defer cleanupTestFile(testFile)
 
-	database := goschema.ParseFile(testFile)
+	database := mustParseFile(c, testFile)
 
 	// Verify that the functions and RLS policies were parsed
 	c.Assert(database.Functions, qt.HasLen, 1)

--- a/core/goschema/rls_robust_parsing_test.go
+++ b/core/goschema/rls_robust_parsing_test.go
@@ -5,7 +5,6 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
-	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/goschema/testutil"
 )
 
@@ -142,7 +141,7 @@ type User struct {
 			defer testutil.RemoveTempFile(t, tempFile)
 
 			// Parse the file
-			database := goschema.ParseFile(tempFile)
+			database := mustParseFile(c, tempFile)
 
 			// Check RLS policies
 			c.Assert(database.RLSPolicies, qt.HasLen, tt.expectedPolicies,

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -173,5 +173,5 @@ func parseDatabaseFile(fsys fs.FS, path string) (Database, error) {
 	}
 	defer file.Close()
 
-	return ParseSource(path, bufio.NewReader(file)), nil
+	return ParseSource(path, bufio.NewReader(file))
 }

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -287,6 +287,38 @@ func TestParseDir_ErrorHandling(t *testing.T) {
 	}
 }
 
+func TestParseDir_InvalidFieldAttributeReturnsError(t *testing.T) {
+	c := qt.New(t)
+
+	rootDir := c.TempDir()
+	source := `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="int" bogus="y"
+	ID int64
+}
+`
+	err := os.WriteFile(filepath.Join(rootDir, "user.go"), []byte(source), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goschema.ParseDir(rootDir)
+	c.Assert(result, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `unknown annotation attribute "bogus" on //migrator:schema:field at User.ID`)
+}
+
+func TestParseDir_SyntaxErrorReturnsError(t *testing.T) {
+	c := qt.New(t)
+
+	rootDir := c.TempDir()
+	err := os.WriteFile(filepath.Join(rootDir, "broken.go"), []byte("package models\nfunc broken("), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goschema.ParseDir(rootDir)
+	c.Assert(result, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `.*parse Go source "broken.go":.*`)
+}
+
 func TestParseDir_Deduplication(t *testing.T) {
 	c := qt.New(t)
 
@@ -728,7 +760,7 @@ func TestParseFS_ErrorCases(t *testing.T) {
 	}
 }
 
-func TestParseFS_PanicCases(t *testing.T) {
+func TestParseFS_SyntaxErrorReturnsError(t *testing.T) {
 	tests := []struct {
 		name  string
 		files map[string]string
@@ -755,10 +787,9 @@ type User struct {
 			// Create test filesystem
 			fsys := createTestFS(tt.files)
 
-			// Expect panic
-			c.Assert(func() {
-				_, _ = goschema.ParseFS(fsys, ".")
-			}, qt.PanicMatches, "Failed to parse file")
+			result, err := goschema.ParseFS(fsys, ".")
+			c.Assert(result, qt.IsNil)
+			c.Assert(err, qt.ErrorMatches, `.*parse Go source "invalid.go":.*`)
 		})
 	}
 }
@@ -1382,7 +1413,7 @@ func TestParseDir_ReflectionGuard(t *testing.T) {
 		full := filepath.Join(fixtureDir, e.Name())
 		content, err := os.ReadFile(full)
 		c.Assert(err, qt.IsNil)
-		db := goschema.ParseSource(e.Name(), string(content))
+		db := mustParseSource(c, e.Name(), string(content))
 		// General reflection merge over ALL slice fields from ParseSource (future-proof, no hard-coded list of 6)
 		fvSrc := reflect.ValueOf(db)
 		fvDst := reflect.ValueOf(&merged).Elem()

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -4,9 +4,11 @@
 // across different database dialects. It implements a factory pattern to create appropriate
 // dialect renderers and provides a unified interface for SQL generation.
 //
-// The package supports multiple database platforms including PostgreSQL, MySQL, MariaDB,
-// and provides a generic fallback for unknown dialects. Each dialect renderer implements
-// the ast.Visitor interface to ensure consistent behavior across different database systems.
+// The package supports multiple database platforms including PostgreSQL, MySQL,
+// MariaDB, and ClickHouse. Unsupported dialects are reported as errors instead
+// of falling back to a generic renderer. Each dialect renderer implements the
+// ast.Visitor interface to ensure consistent behavior across different database
+// systems.
 //
 // Example usage:
 //
@@ -57,29 +59,29 @@ func SupportedDialects() []string {
 // handles common dialect aliases (e.g., "postgres" for "postgresql").
 //
 // Returns an error if the dialect is not supported.
-func NewRenderer(dialect string) types.RenderVisitor {
+func NewRenderer(dialect string) (types.RenderVisitor, error) {
 	return NewRendererWithCapabilities(dialect, capability.ForDialect(dialect))
 }
 
 // NewRendererWithCapabilities creates a renderer for a concrete server
 // capability set. Use this on live database paths where capabilities were
 // resolved from DBInfo.Version; NewRenderer remains the offline default.
-func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) types.RenderVisitor {
+func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (types.RenderVisitor, error) {
 	normalizedDialect := platform.NormalizeDialect(dialect)
 
 	switch normalizedDialect {
 	case platform.Postgres:
-		return postgres.NewWithCapabilities(caps, normalizedDialect)
+		return postgres.NewWithCapabilities(caps, normalizedDialect), nil
 	case platform.MySQL:
-		return mysql.NewWithCapabilities(caps)
+		return mysql.NewWithCapabilities(caps), nil
 	case platform.MariaDB:
-		return mariadb.NewWithCapabilities(caps)
+		return mariadb.NewWithCapabilities(caps), nil
 	case platform.ClickHouse:
-		return clickhouse.New()
+		return clickhouse.New(), nil
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(caps, normalizedDialect)
+		return postgres.NewWithCapabilities(caps, normalizedDialect), nil
 	default:
-		panic(fmt.Sprintf("unsupported database dialect: %s", dialect))
+		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
 	}
 }
 
@@ -88,13 +90,19 @@ func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) t
 // This function is useful for one-off SQL generation where you don't need to reuse the renderer.
 // For multiple operations, it's more efficient to create a renderer once and reuse it.
 func RenderSQL(dialect string, nodes ...ast.Node) (string, error) {
-	r := NewRenderer(dialect)
+	r, err := NewRenderer(dialect)
+	if err != nil {
+		return "", err
+	}
 	return VisitorRenderSQL(r, nodes...)
 }
 
 // RenderSQLWithCapabilities renders SQL for a concrete server capability set.
 func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nodes ...ast.Node) (string, error) {
-	r := NewRendererWithCapabilities(dialect, caps)
+	r, err := NewRendererWithCapabilities(dialect, caps)
+	if err != nil {
+		return "", err
+	}
 	return VisitorRenderSQL(r, nodes...)
 }
 
@@ -109,7 +117,12 @@ func VisitorRenderSQL(r types.RenderVisitor, nodes ...ast.Node) (string, error) 
 }
 
 func GetOrderedCreateStatements(r *goschema.Database, dialect string) []string {
-	return GetOrderedCreateStatementsWithCapabilities(r, dialect, capability.ForDialect(dialect))
+	statements, _ := GetOrderedCreateStatementsE(r, dialect)
+	return statements
+}
+
+func GetOrderedCreateStatementsE(r *goschema.Database, dialect string) ([]string, error) {
+	return GetOrderedCreateStatementsWithCapabilitiesE(r, dialect, capability.ForDialect(dialect))
 }
 
 // GetOrderedCreateStatementsWithCapabilities renders ordered create statements
@@ -119,16 +132,27 @@ func GetOrderedCreateStatementsWithCapabilities(
 	dialect string,
 	caps capability.Capabilities,
 ) []string {
+	statements, _ := GetOrderedCreateStatementsWithCapabilitiesE(r, dialect, caps)
+	return statements
+}
+
+// GetOrderedCreateStatementsWithCapabilitiesE renders ordered create statements
+// for a concrete server capability set and reports renderer errors.
+func GetOrderedCreateStatementsWithCapabilitiesE(
+	r *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) ([]string, error) {
 	var statements []string
 
 	astNodes := fromschema.FromDatabase(*r, dialect)
 	for _, node := range astNodes.Statements {
 		sql, err := RenderSQLWithCapabilities(dialect, caps, node)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 		statements = append(statements, sql)
 	}
 
-	return statements
+	return statements, nil
 }

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -92,7 +92,8 @@ func TestNewRenderer_SupportedDialects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			r := renderer.NewRenderer(tt.dialect)
+			r, err := renderer.NewRenderer(tt.dialect)
+			c.Assert(err, qt.IsNil)
 			c.Assert(r, qt.IsNotNil)
 			c.Assert(r.GetDialect(), qt.Equals, tt.expected)
 		})
@@ -130,9 +131,9 @@ func TestNewRenderer_UnsupportedDialects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			c.Assert(func() {
-				renderer.NewRenderer(tt.dialect)
-			}, qt.PanicMatches, "unsupported database dialect: "+tt.dialect)
+			r, err := renderer.NewRenderer(tt.dialect)
+			c.Assert(r, qt.IsNil)
+			c.Assert(err, qt.ErrorMatches, "unsupported database dialect: "+tt.dialect)
 		})
 	}
 }
@@ -173,9 +174,9 @@ func TestRenderSQL_UnsupportedDialect(t *testing.T) {
 
 	comment := &ast.CommentNode{Text: "Test comment"}
 
-	c.Assert(func() {
-		_, _ = renderer.RenderSQL("unsupported", comment)
-	}, qt.PanicMatches, "unsupported database dialect: unsupported")
+	sql, err := renderer.RenderSQL("sqlserver", comment)
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(err, qt.ErrorMatches, "unsupported database dialect: sqlserver")
 }
 
 func TestRenderer_Interface(t *testing.T) {
@@ -186,7 +187,8 @@ func TestRenderer_Interface(t *testing.T) {
 		t.Run(dialect, func(t *testing.T) {
 			c := qt.New(t)
 
-			r := renderer.NewRenderer(dialect)
+			r, err := renderer.NewRenderer(dialect)
+			c.Assert(err, qt.IsNil)
 
 			// Test interface methods
 			c.Assert(r.GetDialect(), qt.IsNotNil)
@@ -236,7 +238,8 @@ func TestRenderer_BasicRendering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			r := renderer.NewRenderer(tt.dialect)
+			r, err := renderer.NewRenderer(tt.dialect)
+			c.Assert(err, qt.IsNil)
 
 			sql, err := r.Render(tt.node)
 			c.Assert(err, qt.IsNil)
@@ -275,7 +278,8 @@ func TestRenderer_CreateTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			r := renderer.NewRenderer(tt.dialect)
+			r, err := renderer.NewRenderer(tt.dialect)
+			c.Assert(err, qt.IsNil)
 
 			table := &ast.CreateTableNode{
 				Name: "users",

--- a/core/yamlschema/yamlschema_test.go
+++ b/core/yamlschema/yamlschema_test.go
@@ -25,7 +25,7 @@ tables:
 `))
 	c.Assert(err, qt.IsNil)
 
-	goDB := goschema.ParseSource("schema.go", `
+	goDB, err := goschema.ParseSource("schema.go", `
 package test
 
 //migrator:schema:table name="users"
@@ -40,6 +40,7 @@ type User struct {
 	_ int
 }
 `)
+	c.Assert(err, qt.IsNil)
 
 	yamlSQL := strings.Join(renderer.GetOrderedCreateStatements(yamlDB, "postgres"), "\n")
 	goSQL := strings.Join(renderer.GetOrderedCreateStatements(&goDB, "postgres"), "\n")

--- a/examples/ast_demo/ast_example.go
+++ b/examples/ast_demo/ast_example.go
@@ -25,7 +25,11 @@ func DemonstrateASTApproach() {
 		Build()
 
 	// Render for PostgreSQL
-	pgRenderer := renderer.NewRenderer("postgresql")
+	pgRenderer, err := renderer.NewRenderer("postgresql")
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
 	pgSQL, err := pgRenderer.Render(table)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
@@ -36,7 +40,11 @@ func DemonstrateASTApproach() {
 	fmt.Println(pgSQL)
 
 	// Render for MySQL
-	mysqlRenderer := renderer.NewRenderer("mysql")
+	mysqlRenderer, err := renderer.NewRenderer("mysql")
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
 	mysqlSQL, err := mysqlRenderer.Render(table)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -434,8 +434,14 @@ func (vem *VersionedEntityManager) GenerateMigrationSQL(_ctx context.Context, co
 
 	// Generate migration SQL
 	info := conn.Info()
-	nodes := planner.GenerateSchemaDiffASTWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
-	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
+	nodes, err := planner.GenerateSchemaDiffASTWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
+	if err != nil {
+		return nil, false, fmt.Errorf("error generating migration plan: %w", err)
+	}
+	statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, info.Dialect, info.Capabilities)
+	if err != nil {
+		return nil, false, fmt.Errorf("error generating migration SQL: %w", err)
+	}
 
 	return statements, planner.RequiresNoTransaction(info.Dialect, nodes), nil
 }

--- a/integration/gonative/check_constraint_integration_test.go
+++ b/integration/gonative/check_constraint_integration_test.go
@@ -155,10 +155,9 @@ func TestFieldLevelCheckConstraint_Removal_Integration(t *testing.T) {
 	c.Assert(diff.HasChanges(), qt.IsTrue)
 	c.Assert(diff.ConstraintsRemoved, qt.Contains, "ptah_test_check_drop_score_check")
 
-	migrationSQL := strings.Join(
-		planner.GenerateSchemaDiffSQLStatements(diff, withoutCheck, "postgres"),
-		";\n",
-	) + ";"
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, withoutCheck, "postgres")
+	c.Assert(err, qt.IsNil)
+	migrationSQL := strings.Join(statements, ";\n") + ";"
 	c.Assert(strings.Contains(migrationSQL, "ptah_test_check_drop_score_check"), qt.IsTrue,
 		qt.Commentf("drop migration must reference the synthesized constraint by its auto-name; got: %s", migrationSQL))
 

--- a/integration/gonative/exclude_constraints_integration_test.go
+++ b/integration/gonative/exclude_constraints_integration_test.go
@@ -159,7 +159,8 @@ func TestExcludeConstraints_EndToEnd_PostgreSQL(t *testing.T) {
 			c.Assert(len(diff.ConstraintsAdded), qt.Equals, len(tt.expectedSQL))
 
 			// Step 3: Generate migration AST using PostgreSQL planner
-			nodes := planner.GenerateSchemaDiffAST(diff, tt.generated, "postgres")
+			nodes, err := planner.GenerateSchemaDiffAST(diff, tt.generated, "postgres")
+			c.Assert(err, qt.IsNil)
 
 			// Step 4: Render AST to SQL
 			sql, err := renderer.RenderSQL("postgres", nodes...)
@@ -229,7 +230,8 @@ func TestExcludeConstraints_EndToEnd_MySQL(t *testing.T) {
 	diff := schemadiff.Compare(generated, database)
 
 	// Step 2: Generate migration AST using MySQL planner
-	nodes := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
+	c.Assert(err, qt.IsNil)
 
 	// Step 3: Render AST to SQL
 	sql, err := renderer.RenderSQL("mysql", nodes...)
@@ -298,6 +300,7 @@ func TestExcludeConstraints_EmptySchema(t *testing.T) {
 	c.Assert(diff.HasChanges(), qt.IsFalse)
 
 	// Generate migration AST - should be empty
-	nodes := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+	c.Assert(err, qt.IsNil)
 	c.Assert(len(nodes), qt.Equals, 0)
 }

--- a/integration/gonative/function_diff_integration_test.go
+++ b/integration/gonative/function_diff_integration_test.go
@@ -86,7 +86,8 @@ func TestFunctionDiff_BodyAndSecurityChange_Integration(t *testing.T) {
 	c.Assert(mod.Changes["security"], qt.Equals, "DEFINER -> INVOKER")
 
 	// Plan, render, and apply the up migration.
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	c.Assert(err, qt.IsNil)
 	c.Assert(len(statements) > 0, qt.IsTrue,
 		qt.Commentf("planner must emit at least one SQL statement for FunctionsModified"))
 
@@ -168,7 +169,8 @@ func TestFunctionDiff_VolatilityChange_Integration(t *testing.T) {
 	c.Assert(diff.FunctionsModified, qt.HasLen, 1)
 	c.Assert(diff.FunctionsModified[0].Changes["volatility"], qt.Equals, "VOLATILE -> STABLE")
 
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	c.Assert(err, qt.IsNil)
 	c.Assert(len(statements), qt.Not(qt.Equals), 0)
 	sqlText := strings.Join(statements, ";\n") + ";"
 	c.Assert(strings.Contains(sqlText, "STABLE"), qt.IsTrue)

--- a/integration/gonative/integration_test.go
+++ b/integration/gonative/integration_test.go
@@ -35,7 +35,8 @@ func TestGenerateCreateTableFromStubs(t *testing.T) {
 			c := qt.New(t)
 
 			// Parse the entity file
-			database := goschema.ParseFile(file)
+			database, err := goschema.ParseFile(file)
+			c.Assert(err, qt.IsNil)
 
 			// Verify that we got data from the file
 			c.Assert(database.Tables, qt.Not(qt.HasLen), 0, qt.Commentf("No table directives found in %s", file))

--- a/integration/gonative/multi_schema_postgres_test.go
+++ b/integration/gonative/multi_schema_postgres_test.go
@@ -56,7 +56,8 @@ func TestPostgreSQLMultiSchemaGenerateApplyReadDiffIntegration(t *testing.T) {
 		RLSPoliciesAdded:      []string{"ptah_ms_users_visible"},
 		RLSEnabledTablesAdded: []string{"ptah_ms_auth.ptah_ms_users"},
 	}
-	nodes := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+	c.Assert(err, qt.IsNil)
 	migrationSQL, err := renderer.RenderSQL("postgres", nodes...)
 	c.Assert(err, qt.IsNil)
 	migrationSQLForAssert := legacyRenderedSQL(migrationSQL)

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -36,7 +36,8 @@ func TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration(t *testing.T) {
 	diff := schemadiff.Compare(target, &dbschematypes.DBSchema{})
 	c.Assert(diff.HasChanges(), qt.IsTrue)
 
-	nodes := planner.GenerateSchemaDiffAST(diff, target, "postgres")
+	nodes, err := planner.GenerateSchemaDiffAST(diff, target, "postgres")
+	c.Assert(err, qt.IsNil)
 	migrationSQL, err := renderer.RenderSQL("postgres", nodes...)
 	c.Assert(err, qt.IsNil)
 	for _, stmt := range migrator.SplitSQLStatements(migrationSQL) {

--- a/integration/gonative/schema_objects_integration_test.go
+++ b/integration/gonative/schema_objects_integration_test.go
@@ -33,7 +33,8 @@ func TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration(t *testing.
 	diff := schemadiff.Compare(target, &dbschematypes.DBSchema{})
 	c.Assert(diff.HasChanges(), qt.IsTrue)
 
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, target, "postgres")
+	c.Assert(err, qt.IsNil)
 	sqlText := strings.Join(statements, ";\n") + ";"
 	_, err = db.Exec(sqlText)
 	c.Assert(err, qt.IsNil, qt.Commentf("generated migration SQL must execute: %s", sqlText))
@@ -56,7 +57,8 @@ func TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration(t *testing.
 	c.Assert(bodyDiff.MaterializedViewsModified, qt.HasLen, 1)
 	c.Assert(bodyDiff.TriggersModified, qt.HasLen, 1)
 
-	modifiedStatements := planner.GenerateSchemaDiffSQLStatements(bodyDiff, modified, "postgres")
+	modifiedStatements, err := planner.GenerateSchemaDiffSQLStatements(bodyDiff, modified, "postgres")
+	c.Assert(err, qt.IsNil)
 	modifiedSQL := strings.Join(modifiedStatements, ";\n") + ";"
 	_, err = db.Exec(modifiedSQL)
 	c.Assert(err, qt.IsNil, qt.Commentf("modified migration SQL must execute: %s", modifiedSQL))
@@ -76,7 +78,8 @@ func TestSchemaObjects_RoundTripAndBodyChange_PostgreSQL_Integration(t *testing.
 		TableName:   "ptah_schema_objects_users",
 	}})
 
-	removalStatements := planner.GenerateSchemaDiffSQLStatements(removalDiff, tableOnly, "postgres")
+	removalStatements, err := planner.GenerateSchemaDiffSQLStatements(removalDiff, tableOnly, "postgres")
+	c.Assert(err, qt.IsNil)
 	removalSQL := strings.Join(removalStatements, ";\n") + ";"
 	_, err = db.Exec(removalSQL)
 	c.Assert(err, qt.IsNil, qt.Commentf("removal migration SQL must execute: %s", removalSQL))

--- a/integration/rls_integration_test.go
+++ b/integration/rls_integration_test.go
@@ -73,7 +73,8 @@ func TestRLSIntegrationFixtures(t *testing.T) {
 			}
 
 			diff := schemadiff.Compare(generated, dbSchema)
-			sql := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+			sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+			c.Assert(err, qt.IsNil)
 
 			// Verify that SQL is generated (non-empty)
 			c.Assert(len(sql) > 0, qt.IsTrue, qt.Commentf("No SQL generated for fixture: %s", tc.fixtureDir))

--- a/migration/generator/extension_integration_test.go
+++ b/migration/generator/extension_integration_test.go
@@ -131,7 +131,8 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 			c.Assert(diff.HasChanges(), qt.IsTrue, qt.Commentf("Expected schema changes to be detected"))
 
 			// 2. Generate up migration SQL
-			upSQL := planner.GenerateSchemaDiffSQL(diff, tt.generatedSchema, "postgres")
+			upSQL, err := planner.GenerateSchemaDiffSQL(diff, tt.generatedSchema, "postgres")
+			c.Assert(err, qt.IsNil)
 			upSQL = legacyRenderedSQL(upSQL)
 
 			// 3. Generate down migration SQL by reversing the diff
@@ -151,7 +152,8 @@ func TestExtensionMigration_EndToEnd(t *testing.T) {
 				}
 			}
 
-			downSQL := planner.GenerateSchemaDiffSQL(reverseDiff, dbAsGoSchema, "postgres")
+			downSQL, err := planner.GenerateSchemaDiffSQL(reverseDiff, dbAsGoSchema, "postgres")
+			c.Assert(err, qt.IsNil)
 			downSQL = legacyRenderedSQL(downSQL)
 
 			// 4. Verify up migration SQL

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -314,7 +314,10 @@ func planGeneratedMigrationSpecs(
 		Capabilities:         info.Capabilities,
 		ConcurrentIndexNames: concurrentIndexNames,
 	}
-	upNodes := planner.GenerateSchemaDiffASTWithOptions(diff, generated, info.Dialect, plannerOpts)
+	upNodes, err := planner.GenerateSchemaDiffASTWithOptions(diff, generated, info.Dialect, plannerOpts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error generating up migration plan: %w", err)
+	}
 	if len(upNodes) == 0 {
 		return nil, nil, nil
 	}
@@ -419,7 +422,10 @@ func buildGeneratedMigrationSpec(opts generatedMigrationSpecOptions) (generatedM
 		Capabilities:         opts.Capabilities,
 		ConcurrentIndexNames: opts.ConcurrentIndexNames,
 	}
-	upNodes := planner.GenerateSchemaDiffASTWithOptions(opts.Diff, opts.Generated, opts.Dialect, plannerOpts)
+	upNodes, err := planner.GenerateSchemaDiffASTWithOptions(opts.Diff, opts.Generated, opts.Dialect, plannerOpts)
+	if err != nil {
+		return generatedMigrationSpec{}, nil, fmt.Errorf("error generating up migration plan: %w", err)
+	}
 	assessments, err := safety.AssessRenderedWithCapabilities(upNodes, opts.Dialect, opts.Capabilities)
 	if err != nil {
 		return generatedMigrationSpec{}, nil, fmt.Errorf("error assessing migration safety: %w", err)
@@ -706,7 +712,10 @@ func generateUpMigrationSQLWithOptions(
 	if len(capsOverride) > 0 {
 		caps = capsOverride[0]
 	}
-	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, dialect, caps)
+	statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, dialect, caps)
+	if err != nil {
+		return "", fmt.Errorf("error generating up migration SQL: %w", err)
+	}
 
 	if len(statements) == 0 || !hasActualSQLStatements(statements) {
 		// No actual SQL statements generated - this is a successful no-op operation
@@ -754,7 +763,10 @@ func generateDownMigrationSQLWithOptions(
 	if len(capsOverride) > 0 {
 		caps = capsOverride[0]
 	}
-	statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(reverseDiff, dbAsGoSchema, dialect, caps)
+	statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(reverseDiff, dbAsGoSchema, dialect, caps)
+	if err != nil {
+		return "", fmt.Errorf("error generating down migration SQL: %w", err)
+	}
 
 	if len(statements) == 0 {
 		// If no statements generated, create a simple comment

--- a/migration/generator/rls_migration_test.go
+++ b/migration/generator/rls_migration_test.go
@@ -29,7 +29,8 @@ func TestRLSMigrationGeneration(t *testing.T) {
 	diff := schemadiff.Compare(generated, dbSchema)
 
 	// Generate migration SQL
-	sql := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+	c.Assert(err, qt.IsNil)
 	sql = legacyRenderedSQL(sql)
 
 	t.Logf("Generated SQL:\n%s", sql)

--- a/migration/planner/capability_wiring_test.go
+++ b/migration/planner/capability_wiring_test.go
@@ -30,7 +30,8 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 	t.Run("mariadb gets guarded drops", func(t *testing.T) {
 		c := qt.New(t)
 
-		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mariadb")
+		nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "mariadb")
+		c.Assert(err, qt.IsNil)
 		sql, err := renderer.RenderSQL("mariadb", nodes...)
 		c.Assert(err, qt.IsNil)
 		sql = legacyRenderedSQL(sql)
@@ -41,7 +42,8 @@ func TestGetPlanner_CapabilityWiring(t *testing.T) {
 	t.Run("mysql stays unguarded", func(t *testing.T) {
 		c := qt.New(t)
 
-		nodes := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
+		nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "mysql")
+		c.Assert(err, qt.IsNil)
 		sql, err := renderer.RenderSQL("mysql", nodes...)
 		c.Assert(err, qt.IsNil)
 		sql = legacyRenderedSQL(sql)
@@ -65,7 +67,8 @@ func TestGenerateSchemaDiffSQLStatementsWithCapabilities_UsesServerVersionPreset
 		c := qt.New(t)
 		caps := capability.ForServerVersion("mysql", "5.7.44")
 
-		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		c.Assert(err, qt.IsNil)
 		sql := legacyRenderedSQL(strings.Join(statements, "\n"))
 
 		c.Assert(sql, qt.Contains, "WARNING: cannot drop CHECK constraint chk_qty")
@@ -76,7 +79,8 @@ func TestGenerateSchemaDiffSQLStatementsWithCapabilities_UsesServerVersionPreset
 		c := qt.New(t)
 		caps := capability.ForServerVersion("mysql", "8.0.17")
 
-		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		c.Assert(err, qt.IsNil)
 		sql := legacyRenderedSQL(strings.Join(statements, "\n"))
 
 		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CHECK chk_qty")
@@ -86,7 +90,8 @@ func TestGenerateSchemaDiffSQLStatementsWithCapabilities_UsesServerVersionPreset
 		c := qt.New(t)
 		caps := capability.ForServerVersion("mysql", "8.0.19")
 
-		statements := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(diff, generated, "mysql", caps)
+		c.Assert(err, qt.IsNil)
 		sql := legacyRenderedSQL(strings.Join(statements, "\n"))
 
 		c.Assert(sql, qt.Contains, "ALTER TABLE things DROP CONSTRAINT chk_qty")
@@ -104,7 +109,8 @@ func TestGetPlanner_DistributedSQLCapabilityWiring(t *testing.T) {
 		},
 	}
 
-	nodes := planner.GenerateSchemaDiffAST(diff, generated, platform.CockroachDB)
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.CockroachDB)
+	c.Assert(err, qt.IsNil)
 	sql, err := renderer.RenderSQL(platform.CockroachDB, nodes...)
 	c.Assert(err, qt.IsNil)
 	sql = legacyRenderedSQL(sql)

--- a/migration/planner/determinism_test.go
+++ b/migration/planner/determinism_test.go
@@ -117,11 +117,13 @@ func TestGenerateSchemaDiffSQL_Deterministic(t *testing.T) {
 			t.Run(dialect+"/"+scenario.name, func(t *testing.T) {
 				c := qt.New(t)
 
-				first := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+				first, err := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+				c.Assert(err, qt.IsNil)
 				c.Assert(first, qt.Not(qt.Equals), "")
 
 				for i := range 100 {
-					sql := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+					sql, err := planner.GenerateSchemaDiffSQL(schemadiff.CompareWithDialect(gen, scenario.db, dialect), gen, dialect)
+					c.Assert(err, qt.IsNil)
 					c.Assert(sql, qt.Equals, first, qt.Commentf("iteration %d produced different SQL", i))
 				}
 			})
@@ -170,7 +172,8 @@ func TestGenerateSchemaDiffSQL_EnableRLSSorted(t *testing.T) {
 	c := qt.New(t)
 
 	gen := multiTenantRLSSchema()
-	sql := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
+	sql, err := planner.GenerateSchemaDiffSQL(schemadiff.Compare(gen, &dbtypes.DBSchema{}), gen, "postgres")
+	c.Assert(err, qt.IsNil)
 
 	var enableStmts []string
 	for line := range strings.SplitSeq(sql, "\n") {

--- a/migration/planner/dialects/clickhouse/clickhouse.go
+++ b/migration/planner/dialects/clickhouse/clickhouse.go
@@ -49,10 +49,15 @@ func New() *Planner { return &Planner{} }
 // reduce them to comments anyway, and emitting nothing keeps the output
 // migration small.
 func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	nodes, _ := p.GenerateMigrationASTChecked(diff, generated)
+	return nodes
+}
+
+func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error) {
 	var result []ast.Node
 
 	if diff == nil || generated == nil {
-		return result
+		return result, nil
 	}
 
 	if len(diff.EnumsAdded)+len(diff.EnumsRemoved)+len(diff.EnumsModified) > 0 {
@@ -65,7 +70,7 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	result = p.removeIndexes(result, diff)
 	result = p.removeTables(result, diff)
 
-	return result
+	return result, nil
 }
 
 func (p *Planner) addNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -571,6 +571,11 @@ func (p *Planner) handleEnumRemovals(result []ast.Node, diff *types.SchemaDiff) 
 // to SQL using a MySQL-specific visitor. Comments and warnings are included
 // as CommentNode instances for documentation and safety.
 func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	nodes, _ := p.GenerateMigrationASTChecked(diff, generated)
+	return nodes
+}
+
+func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error) {
 	var result []ast.Node
 
 	// Note: MySQL doesn't use separate enum types like PostgreSQL
@@ -591,7 +596,9 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 4.5. Add and modify views/triggers after tables exist.
 	result = p.addNewViews(result, diff, generated)
 	result = p.modifyExistingViews(result, diff, generated)
-	p.rejectMaterializedViews(diff)
+	if err := p.rejectMaterializedViews(diff); err != nil {
+		return nil, err
+	}
 	result = p.addNewTriggers(result, diff, generated)
 	result = p.modifyExistingTriggers(result, diff, generated)
 
@@ -617,16 +624,16 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 8. Handle enum removals (MySQL-specific warnings)
 	result = p.handleEnumRemovals(result, diff)
 
-	return result
+	return result, nil
 }
 
-func (p *Planner) rejectMaterializedViews(diff *types.SchemaDiff) {
+func (p *Planner) rejectMaterializedViews(diff *types.SchemaDiff) error {
 	if len(diff.MaterializedViewsAdded) == 0 &&
 		len(diff.MaterializedViewsModified) == 0 &&
 		len(diff.MaterializedViewsRemoved) == 0 {
-		return
+		return nil
 	}
-	panic("materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target")
+	return fmt.Errorf("materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target")
 }
 
 func (p *Planner) addNewViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {

--- a/migration/planner/dialects/mysql/schema_objects_test.go
+++ b/migration/planner/dialects/mysql/schema_objects_test.go
@@ -63,7 +63,8 @@ func TestPlanner_GenerateSchemaDiffSQLStatements_CompoundTriggerBody(t *testing.
 		}},
 	}
 
-	statements := migrationplanner.GenerateSchemaDiffSQLStatements(diff, generated, "mysql")
+	statements, err := migrationplanner.GenerateSchemaDiffSQLStatements(diff, generated, "mysql")
+	c.Assert(err, qt.IsNil)
 	for i, statement := range statements {
 		statements[i] = legacyRenderedSQL(statement)
 	}
@@ -90,7 +91,11 @@ func TestPlanner_GenerateMigrationAST_RejectsMaterializedViews(t *testing.T) {
 		}},
 	}
 
+	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	c.Assert(nodes, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, "materialized views are not supported by MySQL or MariaDB.*")
+
 	c.Assert(func() {
-		planner.GenerateMigrationAST(diff, generated)
-	}, qt.PanicMatches, "materialized views are not supported by MySQL or MariaDB.*")
+		_ = planner.GenerateMigrationAST(diff, generated)
+	}, qt.Not(qt.PanicMatches), ".*")
 }

--- a/migration/planner/dialects/postgres/circular_dependency_test.go
+++ b/migration/planner/dialects/postgres/circular_dependency_test.go
@@ -48,7 +48,8 @@ func TestTwoPhaseTableCreationWithSelfReference(t *testing.T) {
 	nodes := planner.GenerateMigrationAST(diff, generated)
 
 	// Render the nodes to SQL
-	r := renderer.NewRenderer("postgresql")
+	r, err := renderer.NewRenderer("postgresql")
+	c.Assert(err, qt.IsNil)
 	var sqlStatements []string
 	for _, node := range nodes {
 		sql, err := r.Render(node)
@@ -135,7 +136,8 @@ func TestComplexDependencyChainTwoPhase(t *testing.T) {
 	nodes := planner.GenerateMigrationAST(diff, generated)
 
 	// Render the nodes to SQL
-	r := renderer.NewRenderer("postgresql")
+	r, err := renderer.NewRenderer("postgresql")
+	c.Assert(err, qt.IsNil)
 	var sqlStatements []string
 	for _, node := range nodes {
 		sql, err := r.Render(node)
@@ -216,7 +218,8 @@ func TestNoForeignKeysInCreateTable(t *testing.T) {
 	nodes := planner.GenerateMigrationAST(diff, generated)
 
 	// Render the nodes to SQL
-	r := renderer.NewRenderer("postgresql")
+	r, err := renderer.NewRenderer("postgresql")
+	c.Assert(err, qt.IsNil)
 	var sqlStatements []string
 	for _, node := range nodes {
 		sql, err := r.Render(node)

--- a/migration/planner/dialects/postgres/exclude_constraints_test.go
+++ b/migration/planner/dialects/postgres/exclude_constraints_test.go
@@ -620,7 +620,8 @@ func TestPlanner_GenerateMigrationAST_ConstraintsRemoved_MultipleSplitCleanly(t 
 	diff := &types.SchemaDiff{
 		ConstraintsRemoved: []string{"first_constraint", "second_constraint"},
 	}
-	statements := planner.GenerateSchemaDiffSQLStatements(diff, &goschema.Database{}, "postgres")
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, &goschema.Database{}, "postgres")
+	c.Assert(err, qt.IsNil)
 	c.Assert(statements, qt.HasLen, 2,
 		qt.Commentf("each DO block must end up as its own statement after SQL splitting; got %d statements:\n%s",
 			len(statements), strings.Join(statements, "\n---\n")))

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -942,6 +942,11 @@ func (p *Planner) removeEnums(result []ast.Node, diff *types.SchemaDiff) []ast.N
 // to SQL using a PostgreSQL-specific visitor. Comments and warnings are included
 // as CommentNode instances for documentation and safety.
 func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	nodes, _ := p.GenerateMigrationASTChecked(diff, generated)
+	return nodes
+}
+
+func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error) {
 	var result []ast.Node
 
 	// 0. Add new extensions first (PostgreSQL extensions should be created before other objects)
@@ -1056,7 +1061,7 @@ func (p *Planner) GenerateMigrationAST(diff *types.SchemaDiff, generated *gosche
 	// 16. Remove extensions (dangerous!)
 	result = p.removeExtensions(result, diff)
 
-	return result
+	return result, nil
 }
 
 func (p *Planner) addNewRoles(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {

--- a/migration/planner/doc.go
+++ b/migration/planner/doc.go
@@ -26,6 +26,7 @@
 //
 //	type Planner interface {
 //		GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
+//		GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
 //	}
 //
 // # Main Functions
@@ -45,7 +46,10 @@
 //	diff := schemadiff.Compare(generated, database)
 //
 //	// Generate SQL statements for PostgreSQL
-//	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, "postgres")
+//	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, "postgres")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //
 //	// Execute statements
 //	for _, stmt := range statements {

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -26,6 +26,7 @@
 //
 //	type Planner interface {
 //		GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
+//		GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
 //	}
 //
 // Each implementation handles dialect-specific features, constraints, and SQL generation patterns.
@@ -44,26 +45,25 @@
 // The package provides multiple levels of abstraction for different use cases:
 //
 //	// High-level: Get SQL statements directly
-//	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, "postgres")
+//	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, "postgres")
 //
 //	// Mid-level: Get complete SQL string
-//	sql := planner.GenerateSchemaDiffSQL(diff, generated, "postgres")
+//	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, "postgres")
 //
 //	// Low-level: Get AST nodes for custom processing
-//	nodes := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
+//	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "postgres")
 //
 // # Error Handling
 //
-// The package uses panic-based error handling for unrecoverable errors such as:
-//   - Unsupported database dialects
-//   - SQL rendering failures
-//   - Unimplemented dialect features
-//
-// This design choice reflects the fact that these are typically configuration or
-// implementation errors that should be caught during development rather than runtime.
+// Public helpers return errors for user-controlled and configuration-dependent
+// failures, including unsupported dialects, renderer failures, and unsupported
+// dialect features. CLI callers should surface these errors directly instead of
+// relying on panic recovery.
 package planner
 
 import (
+	"fmt"
+
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
@@ -106,7 +106,10 @@ import (
 //
 // # Example Implementation Pattern
 //
-//	func (p *PostgresPlanner) GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+//	func (p *PostgresPlanner) GenerateMigrationASTChecked(
+//		diff *types.SchemaDiff,
+//		generated *goschema.Database,
+//	) ([]ast.Node, error) {
 //		var nodes []ast.Node
 //
 //		// 1. Create enum types first (PostgreSQL-specific)
@@ -118,7 +121,7 @@ import (
 //		// 3. Add indexes and constraints
 //		nodes = append(nodes, p.generateIndexCreations(diff, generated)...)
 //
-//		return nodes
+//		return nodes, nil
 //	}
 type Planner interface {
 	// GenerateMigrationAST converts schema differences into database-specific AST nodes.
@@ -146,6 +149,10 @@ type Planner interface {
 	// The returned nodes can be rendered to SQL using the renderer package or
 	// processed further for validation, optimization, or custom transformations.
 	GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
+	// GenerateMigrationASTChecked is the error-returning planning path used by public
+	// helpers and CLI flows. Dialect implementations should return user-facing
+	// errors here for unsupported features instead of panicking.
+	GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
 }
 
 // Options configures high-level planner helpers.
@@ -189,26 +196,30 @@ func (o Options) capabilities(dialect string) capability.Capabilities {
 //
 // # Return Value
 //
-// Returns a Planner implementation specific to the requested dialect.
-//
-// # Panics
-//
-// This function panics in the following cases:
-//   - Unknown or unsupported dialect is specified
-//   - Empty or invalid dialect string is provided
+// Returns a Planner implementation specific to the requested dialect, or an
+// error for unknown, unsupported, empty, or invalid dialect strings.
 //
 // # Usage Example
 //
 //	import "github.com/stokaro/ptah/core/platform"
 //
 //	// Get PostgreSQL planner
-//	pgPlanner := planner.GetPlanner(platform.Postgres)
+//	pgPlanner, err := planner.GetPlanner(platform.Postgres)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //
 //	// Get MySQL planner
-//	mysqlPlanner := planner.GetPlanner(platform.MySQL)
+//	mysqlPlanner, err := planner.GetPlanner(platform.MySQL)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //
 //	// Generate migration AST
-//	nodes := pgPlanner.GenerateMigrationAST(diff, generated)
+//	nodes, err := pgPlanner.GenerateMigrationASTChecked(diff, generated)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //
 // # Design Rationale
 //
@@ -217,7 +228,7 @@ func (o Options) capabilities(dialect string) capability.Capabilities {
 //   - Allow easy extension for new database dialects
 //   - Centralize dialect validation and error handling
 //   - Enable dependency injection and testing scenarios
-func GetPlanner(dialect string) Planner {
+func GetPlanner(dialect string) (Planner, error) {
 	return GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
 }
 
@@ -225,28 +236,27 @@ func GetPlanner(dialect string) Planner {
 // a concrete target capability set. Live database paths should pass
 // DBInfo.Capabilities so planning uses the same server-version preset as
 // readers and renderers. Offline callers should use GetPlanner.
-func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) Planner {
+func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (Planner, error) {
 	return GetPlannerWithOptions(dialect, Options{Capabilities: caps})
 }
 
 // GetPlannerWithOptions returns a dialect-specific migration planner with
 // explicit high-level generation policy.
-func GetPlannerWithOptions(dialect string, opts Options) Planner {
+func GetPlannerWithOptions(dialect string, opts Options) (Planner, error) {
 	caps := opts.capabilities(dialect)
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
-		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
+		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...), nil
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
+		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...), nil
 	case platform.MySQL:
-		return mysql.NewWithCapabilities(caps)
+		return mysql.NewWithCapabilities(caps), nil
 	case platform.MariaDB:
-		return mysql.NewWithCapabilities(caps)
+		return mysql.NewWithCapabilities(caps), nil
 	case platform.ClickHouse:
-		return clickhouse.New()
+		return clickhouse.New(), nil
 	default:
-		// For unknown dialects, use a generic generator that doesn't apply dialect-specific transformations
-		panic("not implemented")
+		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
 	}
 }
 
@@ -290,9 +300,12 @@ func GetPlannerWithOptions(dialect string, opts Options) Planner {
 //   - GenerateSchemaDiffSQL: For complete SQL string generation
 //   - GenerateSchemaDiffSQLStatements: For individual SQL statements
 //   - GetPlanner: For direct planner access
-func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) []ast.Node {
-	planner := GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
-	return planner.GenerateMigrationAST(diff, generated)
+func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]ast.Node, error) {
+	planner, err := GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
+	if err != nil {
+		return nil, err
+	}
+	return planner.GenerateMigrationASTChecked(diff, generated)
 }
 
 // GenerateSchemaDiffASTWithCapabilities generates AST nodes for a concrete
@@ -302,7 +315,7 @@ func GenerateSchemaDiffASTWithCapabilities(
 	generated *goschema.Database,
 	dialect string,
 	caps capability.Capabilities,
-) []ast.Node {
+) ([]ast.Node, error) {
 	return GenerateSchemaDiffASTWithOptions(diff, generated, dialect, Options{Capabilities: caps})
 }
 
@@ -313,9 +326,12 @@ func GenerateSchemaDiffASTWithOptions(
 	generated *goschema.Database,
 	dialect string,
 	opts Options,
-) []ast.Node {
-	planner := GetPlannerWithOptions(dialect, opts)
-	return planner.GenerateMigrationAST(diff, generated)
+) ([]ast.Node, error) {
+	planner, err := GetPlannerWithOptions(dialect, opts)
+	if err != nil {
+		return nil, err
+	}
+	return planner.GenerateMigrationASTChecked(diff, generated)
 }
 
 // NodeRequiresNoTransaction reports whether a single planned AST node must run
@@ -404,10 +420,13 @@ func RequiresNoTransaction(dialect string, nodes []ast.Node) bool {
 //
 //   - GenerateSchemaDiffSQL: For complete SQL string without splitting
 //   - GenerateSchemaDiffAST: For AST nodes without rendering
-func GenerateSchemaDiffSQLStatements(diff *types.SchemaDiff, generated *goschema.Database, dialect string) []string {
-	output := GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, capability.ForDialect(dialect))
+func GenerateSchemaDiffSQLStatements(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]string, error) {
+	output, err := GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, capability.ForDialect(dialect))
+	if err != nil {
+		return nil, err
+	}
 	statements := sqlutil.SplitSQLStatements(output)
-	return statements
+	return statements, nil
 }
 
 // GenerateSchemaDiffSQLStatementsWithCapabilities generates individual SQL
@@ -417,7 +436,7 @@ func GenerateSchemaDiffSQLStatementsWithCapabilities(
 	generated *goschema.Database,
 	dialect string,
 	caps capability.Capabilities,
-) []string {
+) ([]string, error) {
 	return GenerateSchemaDiffSQLStatementsWithOptions(diff, generated, dialect, Options{Capabilities: caps})
 }
 
@@ -428,10 +447,13 @@ func GenerateSchemaDiffSQLStatementsWithOptions(
 	generated *goschema.Database,
 	dialect string,
 	opts Options,
-) []string {
-	output := GenerateSchemaDiffSQLWithOptions(diff, generated, dialect, opts)
+) ([]string, error) {
+	output, err := GenerateSchemaDiffSQLWithOptions(diff, generated, dialect, opts)
+	if err != nil {
+		return nil, err
+	}
 	statements := sqlutil.SplitSQLStatements(output)
-	return statements
+	return statements, nil
 }
 
 // GenerateSchemaDiffSQL generates complete SQL for schema differences as a single string.
@@ -494,7 +516,7 @@ func GenerateSchemaDiffSQLStatementsWithOptions(
 //
 //   - GenerateSchemaDiffSQLStatements: For individual SQL statements
 //   - GenerateSchemaDiffAST: For AST nodes without rendering
-func GenerateSchemaDiffSQL(diff *types.SchemaDiff, generated *goschema.Database, dialect string) string {
+func GenerateSchemaDiffSQL(diff *types.SchemaDiff, generated *goschema.Database, dialect string) (string, error) {
 	return GenerateSchemaDiffSQLWithCapabilities(diff, generated, dialect, capability.ForDialect(dialect))
 }
 
@@ -505,7 +527,7 @@ func GenerateSchemaDiffSQLWithCapabilities(
 	generated *goschema.Database,
 	dialect string,
 	caps capability.Capabilities,
-) string {
+) (string, error) {
 	return GenerateSchemaDiffSQLWithOptions(diff, generated, dialect, Options{Capabilities: caps})
 }
 
@@ -516,12 +538,15 @@ func GenerateSchemaDiffSQLWithOptions(
 	generated *goschema.Database,
 	dialect string,
 	opts Options,
-) string {
+) (string, error) {
 	caps := opts.capabilities(dialect)
-	astNodes := GenerateSchemaDiffASTWithOptions(diff, generated, dialect, opts)
+	astNodes, err := GenerateSchemaDiffASTWithOptions(diff, generated, dialect, opts)
+	if err != nil {
+		return "", err
+	}
 	output, err := renderer.RenderSQLWithCapabilities(dialect, caps, astNodes...)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return output
+	return output, nil
 }

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -63,17 +63,14 @@ func TestGetPlanner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
+			plannerInstance, err := planner.GetPlanner(tt.dialect)
 			if tt.wantErr {
-				defer func() {
-					r := recover()
-					c.Assert(r, qt.IsNotNil)
-				}()
-				planner.GetPlanner(tt.dialect)
-				c.Assert(false, qt.IsTrue, qt.Commentf("Expected panic but none occurred"))
-			} else {
-				plannerInstance := planner.GetPlanner(tt.dialect)
-				c.Assert(plannerInstance, qt.IsNotNil)
+				c.Assert(plannerInstance, qt.IsNil)
+				c.Assert(err, qt.ErrorMatches, "unsupported database dialect: "+tt.dialect)
+				return
 			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(plannerInstance, qt.IsNotNil)
 		})
 	}
 }
@@ -81,10 +78,19 @@ func TestGetPlanner(t *testing.T) {
 func TestGetPlanner_MariaDBUsesMySQLPlanner(t *testing.T) {
 	c := qt.New(t)
 
-	plannerInstance := planner.GetPlanner(platform.MariaDB)
+	plannerInstance, err := planner.GetPlanner(platform.MariaDB)
+	c.Assert(err, qt.IsNil)
 	_, ok := plannerInstance.(*mysql.Planner)
 
 	c.Assert(ok, qt.IsTrue)
+}
+
+func TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError(t *testing.T) {
+	c := qt.New(t)
+
+	sql, err := planner.GenerateSchemaDiffSQL(&types.SchemaDiff{}, &goschema.Database{}, "sqlserver")
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(err, qt.ErrorMatches, "unsupported database dialect: sqlserver")
 }
 
 func TestRequiresNoTransaction(t *testing.T) {
@@ -127,7 +133,8 @@ func TestGeneratedNarrowingTypeChangeIsDestructive(t *testing.T) {
 	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
 	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["type"], qt.Equals, "VARCHAR(255) -> VARCHAR(100)")
 
-	nodes := planner.GenerateSchemaDiffAST(diff, generated, platform.Postgres)
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.Postgres)
+	c.Assert(err, qt.IsNil)
 	assessments, err := safety.AssessRendered(nodes, platform.Postgres)
 	c.Assert(err, qt.IsNil)
 	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsTrue)
@@ -142,7 +149,8 @@ func TestGeneratedRLSPolicyRemovalIsDestructive(t *testing.T) {
 		},
 	}
 
-	nodes := planner.GenerateSchemaDiffAST(diff, &goschema.Database{}, platform.Postgres)
+	nodes, err := planner.GenerateSchemaDiffAST(diff, &goschema.Database{}, platform.Postgres)
+	c.Assert(err, qt.IsNil)
 	assessments, err := safety.AssessRendered(nodes, platform.Postgres)
 	c.Assert(err, qt.IsNil)
 	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsTrue)
@@ -196,18 +204,15 @@ func TestGenerateMigrationAST(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
+			nodes, err := planner.GenerateSchemaDiffAST(tt.diff, tt.generated, tt.dialect)
 			if tt.wantErr {
-				defer func() {
-					r := recover()
-					c.Assert(r, qt.IsNotNil)
-				}()
-				planner.GenerateSchemaDiffAST(tt.diff, tt.generated, tt.dialect)
-				c.Assert(false, qt.IsTrue, qt.Commentf("Expected panic but none occurred"))
-			} else {
-				nodes := planner.GenerateSchemaDiffAST(tt.diff, tt.generated, tt.dialect)
-				c.Assert(nodes, qt.IsNotNil)
-				c.Assert(nodes, qt.HasLen, 1) // Should have one CREATE TABLE statement
+				c.Assert(nodes, qt.IsNil)
+				c.Assert(err, qt.IsNotNil)
+				return
 			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(nodes, qt.IsNotNil)
+			c.Assert(nodes, qt.HasLen, 1) // Should have one CREATE TABLE statement
 		})
 	}
 }

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -378,7 +378,8 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 			}
 
 			if len(tt.wantSQL) > 0 {
-				statements := planner.GenerateSchemaDiffSQLStatements(diff, tt.generated, "postgres")
+				statements, err := planner.GenerateSchemaDiffSQLStatements(diff, tt.generated, "postgres")
+				c.Assert(err, qt.IsNil)
 				sql := strings.Join(statements, "\n")
 				for _, expected := range tt.wantSQL {
 					c.Assert(sql, qt.Contains, expected)


### PR DESCRIPTION
## Summary

- Convert Go schema parsing failures caused by user input from panics into returned errors.
- Return errors for unsupported renderer/planner dialects and MySQL/MariaDB materialized-view planning.
- Add a root CLI panic recovery boundary as a final safety net.
- Refactor the Go schema parser around a structured parse state instead of long pointer-heavy argument lists.

## Tests

- go test ./integration/gonative -tags=integration -run ^\$'
- go test ./... -count=1
- go tool qtlint ./...
- golangci-lint run ./...
- git diff --check

## Self-review

- Logic: user-input parser, renderer, planner, generator, and CLI paths now propagate errors instead of panicking.
- Safety: non-test panic scan only finds the root recovery boundary and test-only panics.
- Coverage: added ParseDir/ParseFS negative tests, unsupported renderer/planner dialect tests, MySQL materialized-view error tests, CLI recovery tests, and tagged integration compile coverage.
- Compatibility: public helper signatures now return errors where callers need to handle user-controlled failures; this is acceptable before GA.
