### PR TITLE
Refactor Go schema comment dispatch

### DIFF
--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -406,6 +406,15 @@ type schemaParseState struct {
 	schemas               []Schema
 }
 
+type schemaCommentTarget struct {
+	structName string
+	field      *ast.Field
+}
+
+func (t schemaCommentTarget) isField() bool {
+	return t.field != nil
+}
+
 func newSchemaParseState() *schemaParseState {
 	return &schemaParseState{
 		tableNameToStructName: make(map[string]string),
@@ -413,14 +422,48 @@ func newSchemaParseState() *schemaParseState {
 	}
 }
 
-func (s *schemaParseState) parseComment(comment *ast.Comment, structName string, field *ast.Field) error {
+func (s *schemaParseState) parseComment(comment *ast.Comment, target schemaCommentTarget) error {
+	if target.isField() {
+		if handled, err := s.parseFieldScopedComment(comment, target); handled || err != nil {
+			return err
+		}
+	} else {
+		if handled, err := s.parseTypeScopedComment(comment, target.structName); handled || err != nil {
+			return err
+		}
+	}
+
+	return s.parseSharedComment(comment, target.structName)
+}
+
+func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, target schemaCommentTarget) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
-		return parseFieldComment(comment, field, structName, s.globalEnumsMap, &s.schemaFields)
+		return true, parseFieldComment(comment, target.field, target.structName, s.globalEnumsMap, &s.schemaFields)
 	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
-		parseEmbeddedComment(comment, field, structName, &s.embeddedFields)
+		parseEmbeddedComment(comment, target.field, target.structName, &s.embeddedFields)
+		return true, nil
 	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
-		return parseIndexComment(comment, structName, &s.schemaIndexes)
+		return true, parseIndexComment(comment, target.structName, &s.schemaIndexes)
+	default:
+		return false, nil
+	}
+}
+
+func (s *schemaParseState) parseTypeScopedComment(comment *ast.Comment, structName string) (bool, error) {
+	switch {
+	case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
+		parseTableComment(comment, structName, &s.tableDirectives)
+		return true, nil
+	case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
+		return true, parseSchemaComment(comment, &s.schemas)
+	default:
+		return false, nil
+	}
+}
+
+func (s *schemaParseState) parseSharedComment(comment *ast.Comment, structName string) error {
+	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
 		ParseConstraintComment(comment, structName, &s.schemaConstraints)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
@@ -450,40 +493,10 @@ func (s *schemaParseState) processTableComments(structName string, genDecl *ast.
 		return nil
 	}
 
+	target := schemaCommentTarget{structName: structName}
 	for _, comment := range genDecl.Doc.List {
-		switch {
-		case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
-			parseTableComment(comment, structName, &s.tableDirectives)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
-			ParseConstraintComment(comment, structName, &s.schemaConstraints)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
-			parseExtensionComment(comment, &s.extensions)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
-			parseFunctionComment(comment, structName, &s.functions)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
-			if err := parseViewComment(comment, structName, &s.views); err != nil {
-				return err
-			}
-		case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
-			if err := parseMaterializedViewComment(comment, structName, &s.materializedViews); err != nil {
-				return err
-			}
-		case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
-			if err := parseTriggerComment(comment, structName, &s.triggers); err != nil {
-				return err
-			}
-		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-			parseRLSPolicyComment(comment, structName, &s.rlsPolicies)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-			parseRLSEnableComment(comment, structName, &s.rlsEnabledTables)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
-			parseRoleComment(comment, structName, &s.roles)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
-			parseGrantComment(comment, structName, &s.grants)
-		case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
-			if err := parseSchemaComment(comment, &s.schemas); err != nil {
-				return err
-			}
+		if err := s.parseComment(comment, target); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -494,8 +507,9 @@ func (s *schemaParseState) processFieldComments(structName string, structType *a
 		if field.Doc == nil {
 			continue
 		}
+		target := schemaCommentTarget{structName: structName, field: field}
 		for _, comment := range field.Doc.List {
-			if err := s.parseComment(comment, structName, field); err != nil {
+			if err := s.parseComment(comment, target); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- Replace duplicated type-level and field-level Go schema annotation dispatch with a shared parser target.
- Keep field-only annotations (`field`, `embedded`, `index`) and type-only annotations (`table`, `schema`) scoped explicitly.
- Preserve shared annotation handling for constraints, schema objects, RLS, roles, and grants.

## Verification
- `go test ./core/goschema -count=1`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1`
- `git diff --check`
