### PR TITLE
Define CLI exit-code contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,19 @@ annotations after a successful export.
 
 ## Command Reference
 
+### CLI Exit Codes
+
+Ptah uses one exit-code contract across native commands:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Expected negative result: drift, lint findings, migration integrity drift, pending migrations with `--exit-code`, or a non-empty schema diff with `--exit-code`. |
+| `2` | Command or usage error: bad flags, unknown command, invalid input, connection failure, parse failure, unsupported dialect, unwritable output, or recovered internal panic. |
+| `3+` | Reserved. |
+
+Per-command details are documented in [CLI Exit Codes](docs/exit_codes.md).
+
 ### Generate Schema
 Generate SQL DDL statements from Go entities without touching the database:
 
@@ -580,6 +593,9 @@ Compare your Go entities with the current database schema:
 ```bash
 ./ptah compare --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
 ./ptah compare --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
+
+# Return 1 when the diff is non-empty, 0 when it is empty
+./ptah compare --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --exit-code
 ```
 
 **Output:** Detailed differences showing what needs to be added, removed, or modified
@@ -591,12 +607,6 @@ Check whether the live database still matches the schema declared by Go entities
 ./ptah drift --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
 ./ptah drift --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
-
-Exit codes are designed for scheduled CI checks:
-
-- `0` - no failing drift for the selected threshold
-- `1` - drift detected
-- `2` - command error, such as a connection or parse failure
 
 Use `--format text|json|github-actions` to choose output, and `--ignore tables=audit_log,sessions` to suppress intentionally unmanaged tables. By default any drift returns `1`; use `--severity destructive` to return `1` only for destructive drift such as dropped tables, dropped columns, removed constraints, disabled RLS, or removed database objects.
 
@@ -658,7 +668,7 @@ Findings carry stable rule codes grouped into families:
 
 `--dialect` both gates the dialect-specific rule families and selects the dialect's SQL syntax for scanning (MySQL `#` comments, `/*!...*/` executable comments and backslash string escapes; PostgreSQL dollar quotes and nested block comments). With no dialect set, every rule runs under a hybrid scanner.
 
-Exit codes mirror `drift`: `0` clean (for the selected threshold), `1` findings above `--fail-on` (`error` by default; `any`, `none`), `2` command error. `--format text|json|github-actions|sarif` selects the output; the GitHub format annotates PR files inline, and SARIF 2.1.0 can be uploaded to GitHub code scanning. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
+`--fail-on` controls whether findings become exit code `1`: `error` by default, `any`, or `none`. `--format text|json|github-actions|sarif` selects the output; the GitHub format annotates PR files inline, and SARIF 2.1.0 can be uploaded to GitHub code scanning. Disable rules per code or family with `--disable DS101 --disable MY`, or persistently via `.ptah-lint.yaml` in the migrations directory:
 
 ```yaml
 dialect: postgres
@@ -1010,6 +1020,9 @@ Show current migration status and pending migrations:
 # JSON output for automation
 ./ptah migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --json
 
+# Return 1 when pending migrations are available, 0 when there are none
+./ptah migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --exit-code
+
 # Check status from a custom migration state table
 ./ptah migrate-status --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --migrations-schema infra --migrations-table ptah_migrations
 
@@ -1061,11 +1074,9 @@ Flags that are part of the Atlas OSS CLI but do not have Ptah behavior yet are
 advertised and rejected explicitly instead of being silently ignored.
 
 The implemented Atlas-compatible commands delegate to native commands after
-flag translation, so their exit codes are the native contracts: `0` for success,
-`1` for drift/findings where a native command documents that content state, and
-`2` for command/usage errors on commands with an explicit 0/1/2 contract
-(`drift`, `lint`, and `migrate-validate`). Other runtime failures continue to
-use the CLI fallback non-zero exit code.
+flag translation, so their exit codes follow the native command contract
+documented in [CLI Exit Codes](docs/exit_codes.md). Unsupported Atlas-compatible
+flags are rejected explicitly and exit `2`.
 
 #### Migration Directory Integrity (`ptah.sum` / `atlas.sum`)
 
@@ -1094,10 +1105,9 @@ and `-- atlas:sum ignore` support. Auto validation reads `atlas.sum` when it is
 the only integrity file present, reads `ptah.sum` otherwise, and errors if both
 files exist so CI does not silently choose the wrong format.
 
-`migrate-validate` exits `0` when clean, `1` on drift (a file added, removed, or
-edited out of band — with a diff on stderr), and `2` when the expected integrity
-file is missing or unreadable. `migrate-up --verify-sum` runs the same check
-before applying and aborts on drift.
+`migrate-validate` exits `1` on integrity drift (a file added, removed, or
+edited out of band, with a diff on stderr). `migrate-up --verify-sum` runs the
+same check before applying and aborts on drift.
 
 ```yaml
 # CI (GitHub Actions)

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/cmd/compare"
 	"github.com/stokaro/ptah/cmd/dropall"
 	"github.com/stokaro/ptah/cmd/internal/cmdalias"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratedown"
@@ -68,6 +69,7 @@ native Ptah command tree separate for future redesign.`,
 			return cmd.Help()
 		},
 	}
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	cmd.AddCommand(newAtlasVersionCommand())
 	cmd.AddCommand(newAtlasLicenseCommand())
 	cmd.AddCommand(newAtlasSchemaCommand())
@@ -83,6 +85,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	for _, verb := range []atlasVerb{
 		{
 			use:     "inspect",
@@ -147,6 +150,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	for _, verb := range []atlasVerb{
 		{
 			use:     "apply",
@@ -244,23 +248,27 @@ func newAtlasMigrateCommand() *cobra.Command {
 }
 
 func newAtlasVersionCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print Ptah version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("atlas version compatibility is not implemented yet; use the native Ptah version command once issue #268 lands")
 		},
 	}
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
 }
 
 func newAtlasLicenseCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "license",
 		Short: "Print license information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("atlas license compatibility is not implemented yet")
 		},
 	}
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
 }
 
 func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
@@ -289,6 +297,7 @@ func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
 		},
 	}
 	registerAtlasFlags(cmd, verb.flags)
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -2,17 +2,21 @@ package compare
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
 var compareCmd = &cobra.Command{
@@ -26,8 +30,9 @@ currently exists in the database, helping you identify what needs to be migrated
 }
 
 const (
-	rootDirFlag = "root-dir"
-	dbURLFlag   = "db-url"
+	rootDirFlag  = "root-dir"
+	dbURLFlag    = "db-url"
+	exitCodeFlag = "exit-code"
 )
 
 var compareFlags = map[string]cobraflags.Flag{
@@ -41,6 +46,11 @@ var compareFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Database URL (required). Example: postgres://localhost:5432/dbname",
 	},
+	exitCodeFlag: &cobraflags.BoolFlag{
+		Name:  exitCodeFlag,
+		Value: false,
+		Usage: "Exit with 1 when the schema diff is non-empty",
+	},
 	dbcli.ConnectTimeoutFlagName: dbcli.NewConnectTimeoutFlag(),
 	dbcli.SchemasFlagName:        dbcli.NewSchemasFlag(),
 }
@@ -52,20 +62,23 @@ func NewCompareCommand() *cobra.Command {
 		cobraflags.RegisterMap(compareCmd, compareFlags)
 		compareFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(compareCmd)
 	return compareCmd
 }
 
-func compareCommand(_ *cobra.Command, _ []string) error {
+func compareCommand(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
 	rootDir := compareFlags[rootDirFlag].GetString()
 	dbURL := compareFlags[dbURLFlag].GetString()
+	exitOnDiff := compareFlags[exitCodeFlag].GetBool()
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
 
-	fmt.Printf("Comparing schema from %s with database %s\n", rootDir, dbschema.FormatDatabaseURL(dbURL))
-	fmt.Println("=== SCHEMA COMPARISON ===")
-	fmt.Println()
+	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", rootDir, dbschema.FormatDatabaseURL(dbURL))
+	fmt.Fprintln(out, "=== SCHEMA COMPARISON ===")
+	fmt.Fprintln(out)
 
 	// 1. Parse Go entities
 	absPath, err := filepath.Abs(rootDir)
@@ -107,7 +120,17 @@ func compareCommand(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error generating schema diff SQL: %w", err)
 	}
-	fmt.Print(output)
+	fmt.Fprint(out, output)
 
+	if exitOnDiff {
+		return nonEmptyDiffExitCode(diff)
+	}
+	return nil
+}
+
+func nonEmptyDiffExitCode(diff *difftypes.SchemaDiff) error {
+	if diff.HasChanges() {
+		return exitcode.New(1, errors.New("schema diff is non-empty"))
+	}
 	return nil
 }

--- a/cmd/compare/compare_test.go
+++ b/cmd/compare/compare_test.go
@@ -1,0 +1,36 @@
+package compare
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestCompareExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     *difftypes.SchemaDiff
+		wantCode int
+	}{
+		{name: "empty diff", diff: &difftypes.SchemaDiff{}, wantCode: 0},
+		{name: "non-empty diff", diff: &difftypes.SchemaDiff{TablesAdded: []string{"users"}}, wantCode: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := nonEmptyDiffExitCode(tt.diff)
+
+			if tt.wantCode == 0 {
+				c.Assert(err, qt.IsNil)
+				return
+			}
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, tt.wantCode)
+		})
+	}
+}

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaops"
@@ -72,6 +73,7 @@ func NewDriftCommand() *cobra.Command {
 		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
 	)
 
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -51,6 +52,7 @@ func NewDropAllCommand() *cobra.Command {
 		cobraflags.RegisterMap(dropAllCmd, dropAllFlags)
 		dropAllFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(dropAllCmd)
 
 	return dropAllCmd
 }

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/core/atlashcl"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
@@ -57,6 +58,7 @@ func NewGenerateCommand() *cobra.Command {
 		cobraflags.RegisterMap(generateCmd, generateFlags)
 		generateFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(generateCmd)
 
 	return generateCmd
 }

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
 func outputStatementContaining(output, marker string) string {
@@ -69,6 +72,26 @@ func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
 
 	_, err := loadSchema("", path)
 	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, and .hcl are supported`)
+}
+
+func TestGenerateCommandUnsupportedDialectExits2WithoutPanicTrace(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewGenerateCommand()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--root-dir", filepath.Join("..", "..", "stubs"), "--dialect", "oracle"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(errOut.String(), qt.Contains, "error: error rendering oracle schema: unsupported database dialect: oracle")
+	c.Assert(errOut.String(), qt.Not(qt.Contains), "panic:")
+	c.Assert(errOut.String(), qt.Not(qt.Contains), "goroutine")
+	c.Assert(errOut.String(), qt.Not(qt.Contains), "Usage:")
 }
 
 func TestGenerateCommand_MutualForeignKeysAreTwoPhase(t *testing.T) {

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -12,6 +12,47 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
+const configuredAnnotation = "ptah.exitcode_configured"
+
+// ConfigureCommand installs Ptah's common CLI error contract on cmd. It is
+// idempotent because many command constructors return package-level singletons.
+func ConfigureCommand(cmd *cobra.Command) {
+	ConfigureCommandArgs(cmd, NoPositionalArgs)
+}
+
+// ConfigureCommandArgs installs Ptah's common CLI error contract on cmd while
+// preserving a command-specific Args validator.
+func ConfigureCommandArgs(cmd *cobra.Command, args cobra.PositionalArgs) {
+	if cmd.Annotations != nil && cmd.Annotations[configuredAnnotation] == "true" {
+		return
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[configuredAnnotation] = "true"
+
+	cmd.Args = args
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetFlagErrorFunc(FlagErrorFunc)
+	if cmd.RunE != nil {
+		cmd.RunE = WrapRunE(cmd.RunE)
+	}
+}
+
+// WrapRunE maps ordinary command failures to exit code 2 while preserving
+// expected-negative results that already carry an explicit exit code.
+func WrapRunE(run func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		err := run(cmd, args)
+		if err == nil || exitcode.Code(err, -1) != -1 {
+			return err
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+		return exitcode.New(2, err)
+	}
+}
+
 // Fail prints err to the command's stderr and returns it as an exit-2 usage
 // error. Commands that set SilenceErrors must route their usage failures
 // through this so the message still reaches the user.

--- a/cmd/internal/cmdutil/cmdutil_test.go
+++ b/cmd/internal/cmdutil/cmdutil_test.go
@@ -1,0 +1,46 @@
+package cmdutil
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+)
+
+func TestWrapRunEMapsOrdinaryErrorsToExit2(t *testing.T) {
+	c := qt.New(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "boom"}
+	cmd.SetErr(&stderr)
+	run := WrapRunE(func(_ *cobra.Command, _ []string) error {
+		return errors.New("boom")
+	})
+
+	err := run(cmd, nil)
+
+	c.Assert(err, qt.ErrorMatches, "boom")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr.String(), qt.Equals, "error: boom\n")
+}
+
+func TestWrapRunEPreservesExplicitExitCodes(t *testing.T) {
+	c := qt.New(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "diff"}
+	cmd.SetErr(&stderr)
+	run := WrapRunE(func(_ *cobra.Command, _ []string) error {
+		return exitcode.New(1, errors.New("diff found"))
+	})
+
+	err := run(cmd, nil)
+
+	c.Assert(err, qt.ErrorMatches, "diff found")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "")
+}

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/migration/lint"
@@ -84,13 +85,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	cmd.Flags().StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DS101 or MY (repeatable)")
 	cmd.Flags().StringVar(&failOn, "fail-on", failOnError, "Failure threshold controlling the exit code: error, any or none")
 
-	// Flag-parse errors (unknown flags and the like) must surface a message
-	// and exit 2 like every other usage error, not vanish under SilenceErrors.
-	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
-		fmt.Fprintf(c.ErrOrStderr(), "error: %s\n", err)
-		return exitcode.New(2, err)
-	})
-
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -50,6 +51,7 @@ and performs an up/down/up round-trip.`,
 	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 	flags.String(dbcli.SchemasFlagName, "", "Comma-separated schemas to introspect when supported")
 
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
@@ -26,7 +27,6 @@ var migrateCmd = &cobra.Command{
 	
 This command compares your Go entities with the current database schema and generates
 the SQL statements needed to update the database to match your entities.`,
-	Args: cobra.NoArgs,
 	RunE: migrateCommand,
 }
 
@@ -81,6 +81,7 @@ func NewMigrateCommand() *cobra.Command {
 	}
 	addMigrateGenerateCommand(migrateCmd)
 	addMigrateNewCommand(migrateCmd)
+	cmdutil.ConfigureCommandArgs(migrateCmd, nil)
 	return migrateCmd
 }
 

--- a/cmd/migrate/new.go
+++ b/cmd/migrate/new.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
 )
@@ -31,6 +32,7 @@ migration naming convention.`,
 	flags.String(newMigrationsDirFlag, "", "Directory receiving generated migration files (required)")
 	flags.String(newNameFlag, "", "Migration name; optional when [name] is provided")
 
+	cmdutil.ConfigureCommandArgs(cmd, cobra.MaximumNArgs(1))
 	return cmd
 }
 

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaops"
 	"github.com/stokaro/ptah/dbschema"
@@ -47,6 +48,7 @@ migrate-up runs apply only new migrations.`,
 		},
 	}
 	cobraflags.RegisterMap(cmd, flags)
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -123,6 +124,7 @@ func NewMigrateDownCommand() *cobra.Command {
 		cobraflags.RegisterMap(migrateDownCmd, migrateDownFlags)
 		migrateDownFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(migrateDownCmd)
 	return migrateDownCmd
 }
 

--- a/cmd/migraterepair/migraterepair.go
+++ b/cmd/migraterepair/migraterepair.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -82,6 +83,7 @@ func NewMigrateRepairCommand() *cobra.Command {
 		cobraflags.RegisterMap(migrateRepairCmd, migrateRepairFlags)
 		migrateRepairFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(migrateRepairCmd)
 
 	return migrateRepairCmd
 }

--- a/cmd/migratestatus/exitcode_test.go
+++ b/cmd/migratestatus/exitcode_test.go
@@ -1,0 +1,36 @@
+package migratestatus
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMigrateStatusExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *migrator.MigrationStatus
+		wantCode int
+	}{
+		{name: "clean", status: &migrator.MigrationStatus{}, wantCode: 0},
+		{name: "pending", status: &migrator.MigrationStatus{HasPendingChanges: true}, wantCode: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := pendingMigrationsExitCode(tt.status)
+
+			if tt.wantCode == 0 {
+				c.Assert(err, qt.IsNil)
+				return
+			}
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, tt.wantCode)
+		})
+	}
+}

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -3,13 +3,16 @@ package migratestatus
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -37,6 +40,7 @@ const (
 	atlasEnvFlag   = "atlas-env"
 	verboseFlag    = "verbose"
 	jsonFlag       = "json"
+	exitCodeFlag   = "exit-code"
 )
 
 var migrateStatusFlags = map[string]cobraflags.Flag{
@@ -70,6 +74,11 @@ var migrateStatusFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Output status in JSON format",
 	},
+	exitCodeFlag: &cobraflags.BoolFlag{
+		Name:  exitCodeFlag,
+		Value: false,
+		Usage: "Exit with 1 when pending migrations are available",
+	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
 	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
@@ -85,6 +94,7 @@ func NewMigrateStatusCommand() *cobra.Command {
 		cobraflags.RegisterMap(migrateStatusCmd, migrateStatusFlags)
 		migrateStatusFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(migrateStatusCmd)
 	return migrateStatusCmd
 }
 
@@ -95,6 +105,7 @@ func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 	atlasEnv := migrateStatusFlags[atlasEnvFlag].GetString()
 	verbose := migrateStatusFlags[verboseFlag].GetBool()
 	jsonOutput := migrateStatusFlags[jsonFlag].GetBool()
+	exitOnPending := migrateStatusFlags[exitCodeFlag].GetBool()
 	migrationsSchema := migrateStatusFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateStatusFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateStatusFlags[dbcli.RevisionTableFormatFlagName].GetString()
@@ -165,10 +176,24 @@ func migrateStatusCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	if jsonOutput {
-		return outputJSON(status)
+		if err := outputJSON(status); err != nil {
+			return err
+		}
+	} else if err := outputHuman(status, conn, verbose); err != nil {
+		return err
 	}
 
-	return outputHuman(status, conn, verbose)
+	if exitOnPending {
+		return pendingMigrationsExitCode(status)
+	}
+	return nil
+}
+
+func pendingMigrationsExitCode(status *migrator.MigrationStatus) error {
+	if status.HasPendingChanges {
+		return exitcode.New(1, errors.New("pending migrations available"))
+	}
+	return nil
 }
 
 func outputJSON(status *migrator.MigrationStatus) error {

--- a/cmd/migratestatus/migratestatus_test.go
+++ b/cmd/migratestatus/migratestatus_test.go
@@ -1,11 +1,14 @@
 package migratestatus_test
 
 import (
+	"bytes"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/migratestatus"
 )
 
@@ -20,4 +23,27 @@ func TestMigrateStatusCommand_Creation(t *testing.T) {
 	c.Assert(cmd.Flag(dbcli.ConfigFlagName), qt.IsNotNil)
 	c.Assert(cmd.Flag(dbcli.MigrationsSchemaFlagName), qt.IsNotNil)
 	c.Assert(cmd.Flag(dbcli.MigrationsTableFlagName), qt.IsNotNil)
+	c.Assert(cmd.Flag("exit-code"), qt.IsNotNil)
+}
+
+func TestMigrateStatusCommand_UnreachableDatabaseExits2(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migratestatus.NewMigrateStatusCommand()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--db-url", "postgres://u:p@127.0.0.1:1/db?sslmode=disable",
+		"--migrations-dir", filepath.ToSlash(t.TempDir()),
+		"--connect-timeout", "1ms",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(errOut.String(), qt.Contains, "error connecting to database")
+	c.Assert(errOut.String(), qt.Not(qt.Contains), "Usage:")
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -125,6 +126,7 @@ func NewMigrateUpCommand() *cobra.Command {
 		cobraflags.RegisterMap(migrateUpCmd, migrateUpFlags)
 		migrateUpFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(migrateUpCmd)
 	return migrateUpCmd
 }
 

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-extras/cobraflags"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/core/convert/dbschematogo"
 	"github.com/stokaro/ptah/core/renderer"
@@ -45,6 +46,7 @@ func NewReadDBCommand() *cobra.Command {
 		cobraflags.RegisterMap(readDBCmd, readDBFlags)
 		readDBFlagsRegistered = true
 	}
+	cmdutil.ConfigureCommand(readDBCmd)
 	return readDBCmd
 }
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/cmd/dropall"
 	"github.com/stokaro/ptah/cmd/generate"
 	"github.com/stokaro/ptah/cmd/internal/buildinfo"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
@@ -39,11 +40,11 @@ func NewRootCommand() *cobra.Command {
 		Short:   "Ptah schema management and migration tooling",
 		Long:    rootLongDescription,
 		Version: buildinfo.Resolve().Version,
-		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 
 	cmd.AddCommand(generate.NewGenerateCommand())
 	cmd.AddCommand(readdb.NewReadDBCommand())
@@ -77,19 +78,24 @@ func Execute(args ...string) {
 
 	err := executeWithRecovery(cmd)
 	if err != nil {
-		os.Exit(exitcode.Code(err, 1)) //revive:disable-line:deep-exit
+		os.Exit(exitcode.Code(err, 2)) //revive:disable-line:deep-exit
 	}
 }
 
 func executeWithRecovery(cmd *cobra.Command) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("internal error: %v", recovered)
+			err = exitcode.New(2, fmt.Errorf("internal error: %v", recovered))
 			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
 		}
 	}()
 
-	return cmd.Execute()
+	err = cmd.Execute()
+	if err == nil || exitcode.Code(err, -1) != -1 {
+		return err
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
+	return exitcode.New(2, err)
 }
 
 const rootLongDescription = `Ptah generates database schemas from Go entities,

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -7,6 +7,8 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
 func TestNewRootCommand_UsesPtahBranding(t *testing.T) {
@@ -113,5 +115,99 @@ func TestExecuteWithRecovery_ConvertsCommandPanicToError(t *testing.T) {
 	err := executeWithRecovery(cmd)
 
 	c.Assert(err, qt.ErrorMatches, "internal error: bad annotation")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(stderr.String(), qt.Contains, "error: internal error: bad annotation")
+}
+
+func TestZZZRootUnknownSubcommandExits2WithoutUsage(t *testing.T) {
+	c := qt.New(t)
+
+	_, stderr, err := executeRoot("bogus-subcommand")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stderr, qt.Contains, `unknown command "bogus-subcommand"`)
+	c.Assert(stderr, qt.Not(qt.Contains), "Usage:")
+}
+
+func TestZZZRootCommandErrorsExit2(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "compare unreachable database",
+			args: []string{
+				"compare",
+				"--root-dir", filepath.Join("..", "..", "stubs"),
+				"--db-url", "postgres://u:p@127.0.0.1:1/db?sslmode=disable",
+				"--connect-timeout", "1ms",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, stderr, err := executeRoot(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr, qt.Contains, "error connecting to database")
+			c.Assert(stderr, qt.Not(qt.Contains), "Usage:")
+		})
+	}
+}
+
+func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "generate", args: []string{"generate", "--bogus-flag"}},
+		{name: "read-db", args: []string{"read-db", "--bogus-flag"}},
+		{name: "schema export", args: []string{"schema", "export", "--bogus-flag"}},
+		{name: "compare", args: []string{"compare", "--bogus-flag"}},
+		{name: "drift", args: []string{"drift", "--bogus-flag"}},
+		{name: "migrate", args: []string{"migrate", "--bogus-flag"}},
+		{name: "migrate generate", args: []string{"migrate", "generate", "--bogus-flag"}},
+		{name: "migrate new", args: []string{"migrate", "new", "--bogus-flag"}},
+		{name: "migrate-baseline", args: []string{"migrate-baseline", "--bogus-flag"}},
+		{name: "migrate-up", args: []string{"migrate-up", "--bogus-flag"}},
+		{name: "migrate-down", args: []string{"migrate-down", "--bogus-flag"}},
+		{name: "migrate-repair", args: []string{"migrate-repair", "--bogus-flag"}},
+		{name: "migrate-status", args: []string{"migrate-status", "--bogus-flag"}},
+		{name: "migrate-hash", args: []string{"migrate-hash", "--bogus-flag"}},
+		{name: "migrate-validate", args: []string{"migrate-validate", "--bogus-flag"}},
+		{name: "seed", args: []string{"seed", "--bogus-flag"}},
+		{name: "drop-all", args: []string{"drop-all", "--bogus-flag"}},
+		{name: "lint", args: []string{"lint", "--bogus-flag"}},
+		{name: "atlas version", args: []string{"atlas", "version", "--bogus-flag"}},
+		{name: "version", args: []string{"version", "--bogus-flag"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, stderr, err := executeRoot(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr, qt.Contains, "error: unknown flag: --bogus-flag")
+			c.Assert(stderr, qt.Not(qt.Contains), "Usage:")
+		})
+	}
+}
+
+func executeRoot(args ...string) (stdout, stderr string, err error) {
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = executeWithRecovery(cmd)
+	return out.String(), errOut.String(), err
 }

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -37,6 +37,7 @@ func NewSchemaCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	cmd.AddCommand(newSchemaExportCommand())
 	return cmd
 }
@@ -59,7 +60,6 @@ The initial export path is Go annotations to Atlas schema HCL:
 
   ptah schema export --from go --to atlas-hcl --root-dir ./models --out schema.hcl`,
 		Args:          cmdutil.NoPositionalArgs,
-		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runExport(cmd, exportOptions{
@@ -82,7 +82,7 @@ The initial export path is Go annotations to Atlas schema HCL:
 	flags.BoolVar(&cleanupAnnotations, cleanupGoAnnotationsFlag, false, "Remove Ptah schema annotations from Go source after a successful export")
 	flags.BoolVar(&cleanupDryRun, cleanupDryRunFlag, false, "Show cleanup summary without modifying Go files")
 	flags.BoolVar(&cleanupDiff, cleanupDiffFlag, false, "Print cleanup diff without modifying Go files")
-	cmd.SetFlagErrorFunc(cmdutil.FlagErrorFunc)
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	return cmd
 }
 

--- a/cmd/seed/seed.go
+++ b/cmd/seed/seed.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/seeder"
@@ -68,6 +69,7 @@ no-op unless --force is set.`,
 		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
 	)
 
+	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -7,14 +7,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/buildinfo"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 )
 
 // NewVersionCommand returns the version-reporting command.
 func NewVersionCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print Ptah version information",
-		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			info := buildinfo.Resolve()
 			fmt.Fprintf(cmd.OutOrStdout(), "Version: %s\n", info.Version)
@@ -25,4 +25,6 @@ func NewVersionCommand() *cobra.Command {
 			return nil
 		},
 	}
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
 }

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -1,0 +1,51 @@
+# CLI Exit Codes
+
+Ptah treats CLI exit codes as a public scripting contract.
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. The command completed and did not find a configured failing condition. |
+| `1` | Expected negative result. A check found drift, lint findings, integrity drift, pending migrations, or a non-empty diff when that behavior is enabled. |
+| `2` | Command or usage error. Examples: bad flags, unknown commands, invalid input, connection failure, parse failure, unsupported dialect, unwritable output, or an internal panic recovered by the root command. |
+| `3+` | Reserved. Do not rely on these codes until Ptah documents a specific use. |
+
+## Native Commands
+
+| Command | `0` | `1` | `2` |
+| --- | --- | --- | --- |
+| `ptah generate` | Schema rendered. | Not used. | Usage error, parse error, unsupported dialect, or render error. |
+| `ptah schema export` | Schema exported. | Not used. | Usage error, invalid paths, parse error, render error, write error, or cleanup error. |
+| `ptah read-db` | Schema read and printed. | Not used. | Usage error, connection failure, or schema-read failure. |
+| `ptah compare` | Diff printed, or no diff. | Non-empty diff when `--exit-code` is set. | Usage error, connection failure, parse failure, or diff generation failure. |
+| `ptah drift` | No drift that meets `--severity`, or `--exit-code=false`. | Drift meets `--severity` while `--exit-code=true`. | Usage error, connection failure, parse failure, or report error. |
+| `ptah lint` | No findings above `--fail-on`, or `--fail-on=none`. | Findings meet `--fail-on`. | Usage error, invalid config, unreadable migration directory, or report error. |
+| `ptah migrate` | Migration SQL generated, or no schema changes. | Not used. | Usage error, connection failure, parse failure, safety check failure, or render error. |
+| `ptah migrate generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
+| `ptah migrate new` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |
+| `ptah migrate-baseline` | Existing migrations recorded as applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, verification failure, or write error. |
+| `ptah migrate-up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, lock failure, or migration execution failure. |
+| `ptah migrate-down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, lock failure, or rollback failure. |
+| `ptah migrate-repair` | Migration revision repaired, or dry-run output printed. | Not used. | Usage error, connection failure, revision lookup failure, or repair failure. |
+| `ptah migrate-status` | Status printed, including pending migrations by default. | Pending migrations exist when `--exit-code` is set. | Usage error, connection failure, migration directory error, or status-read failure. |
+| `ptah migrate-hash` | Integrity file written. | Not used. | Usage error, invalid directory, invalid migration format, or write error. |
+| `ptah migrate-validate` | Integrity file matches the migration directory. | Migration content drift found. | Usage error, missing or unreadable integrity file, invalid directory, or invalid migration format. |
+| `ptah seed` | Seed files applied or already applied. | Not used. | Usage error, protected environment rejection, connection failure, invalid seed files, or seed execution failure. |
+| `ptah drop-all` | Objects dropped, dry-run output printed, or operation canceled by the user. | Not used. | Usage error, connection failure, input read error, or drop failure. |
+| `ptah version` | Version information printed. | Not used. | Usage error. |
+
+## Atlas-Compatible Aliases
+
+Commands under `ptah atlas <command> ...` translate implemented Atlas-compatible flags and then delegate to the matching native command. Their exit codes therefore follow the native command contract:
+
+| Atlas-compatible command | Native command |
+| --- | --- |
+| `ptah atlas migrate apply` | `ptah migrate-up` |
+| `ptah atlas migrate down` | `ptah migrate-down` |
+| `ptah atlas migrate status` | `ptah migrate-status` |
+| `ptah atlas migrate hash` | `ptah migrate-hash` |
+| `ptah atlas migrate validate` | `ptah migrate-validate` |
+| `ptah atlas migrate lint` | `ptah lint` |
+| `ptah atlas schema inspect` | `ptah read-db` |
+| `ptah atlas schema diff` | `ptah compare` |
+
+Unsupported Atlas-compatible flags are rejected explicitly and exit `2`.


### PR DESCRIPTION
## Summary

- define a shared CLI exit-code contract and route native command errors through a common `cmdutil` wrapper
- add `--exit-code` to `compare` and `migrate-status`
- document the contract centrally in `docs/exit_codes.md` and README
- add tests for usage errors, command errors, explicit `1` results, recovered panics, and no usage dumps

## Validation

- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./cmd/internal/cmdutil ./cmd/root ./cmd/generate ./cmd/compare ./cmd/migratestatus ./cmd/lint ./cmd/drift ./cmd/migrate ./cmd/migrateup ./cmd/migratedown ./cmd/migraterepair ./cmd/migratebaseline ./cmd/readdb ./cmd/dropall ./cmd/seed ./cmd/version ./cmd/schema ./cmd/migratehash ./cmd/migratevalidate ./cmd/atlas -count=1`
- `go test ./... -count=1`
- live PostgreSQL smoke with built binary:
  - `compare --exit-code` on an empty isolated schema returned `0`
  - `compare --exit-code` on a non-empty diff returned `1`
  - `generate --bogus-flag` returned `2`
  - `generate --root-dir ./stubs --dialect oracle` returned `2` without a panic trace

Closes #277.
