### PR TITLE
Fix documented database safety claims

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           docker run --detach --name ptah-cockroachdb \
             --publish 26257:26257 \
-            cockroachdb/cockroach:v23.2.5 \
+            cockroachdb/cockroach:v26.2.4 \
             start-single-node --insecure --advertise-addr=localhost:26257
 
           docker run --detach --name ptah-yugabytedb \

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Check documentation safety claims
+        run: |
+          ! grep -F "All operations are wrapped in transactions" README.md
+          ! grep -F "All operations wrapped in transactions" README.md
+          ! grep -F "locking prevents double-apply" README.md
+
       - name: qtlint
         run: go tool qtlint ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ The system is organized into several key packages:
 - `schemadiff/` - Schema comparison and difference analysis
 
 **`dbschema/`** - Database operations:
-- Connection management for PostgreSQL, MySQL, MariaDB
+- Connection management for PostgreSQL-family targets, MySQL, MariaDB, ClickHouse, and Spanner
 - Schema reading/introspection and writing capabilities
 - Database cleaning and schema dropping operations
 
@@ -153,11 +153,11 @@ _ int
 ### Integration Tests  
 - Located in `integration/gonative/` directory
 - Use build tag `integration` 
-- Require live databases (PostgreSQL, MySQL, MariaDB)
+- Require live databases for PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse coverage
 - Comprehensive test framework with scenarios covering:
   - Basic migration operations (up/down/status)
   - Idempotency testing
-  - Concurrency and locking
+  - Parallel execution smoke
   - Partial failure recovery
   - Schema diff validation
 

--- a/INTEGRATION_TEST_IMPLEMENTATION.md
+++ b/INTEGRATION_TEST_IMPLEMENTATION.md
@@ -57,9 +57,10 @@ All scenarios from the original plan have been implemented:
 - ✅ Re-apply already applied migrations
 - ✅ Run migrate up when database is already up-to-date
 
-#### Concurrency ✅
+#### Parallel Execution Smoke ✅
 - ✅ Launch two migrate up processes in parallel
-- ✅ Ensure locking prevents double-apply
+- ✅ Verify at least one runner succeeds and the final migration state is consistent
+- ⚠️ Ptah does not yet provide a migration-level lock; production deployments must enforce a single runner externally until #124 lands
 
 #### Partial Failure Recovery ✅
 - ✅ Handle multi-step migration with intentional failure

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ capabilities include:
   Supports PostgreSQL RLS policies, roles, grants, and custom functions for multi-tenant data isolation.
 
 - 🔍 **Database Introspection**
-  Reads the current schema directly from PostgreSQL, MySQL, MariaDB, or ClickHouse for comparison and analysis.
+  Reads the current schema directly from PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse for comparison and analysis.
 
 - 🧮 **Schema Diffing**
   Compares code-based schema with the live database schema using AST representations.
@@ -91,7 +91,7 @@ The core package contains all fundamental components for parsing, transforming, 
 
 - **`renderer/`** - Dialect-specific SQL generation from AST
   - Converts AST nodes to database-specific SQL statements
-  - Supports PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, YugabyteDB, and Spanner dialects
+  - Supports PostgreSQL-family targets, MySQL, MariaDB, ClickHouse, and Spanner dialects
   - Implements visitor pattern for extensible rendering
 
 - **`platform/`** - Database platform constants and identifiers
@@ -117,11 +117,11 @@ Provides comprehensive database migration functionality:
 - **`migrator/`** - Migration execution engine
   - Applies and rolls back database migrations
   - Tracks migration history and versions
-  - Provides dry-run capabilities and transaction safety
+  - Provides dry-run capabilities, dirty-state tracking, and dialect-aware transaction handling
 
 - **`planner/`** - Migration planning and SQL generation
   - Converts schema differences into executable SQL statements
-  - Dialect-specific planners for PostgreSQL, MySQL, MariaDB, ClickHouse, and PostgreSQL-family distributed SQL targets
+  - Dialect-specific planners for PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse
   - Handles dependency ordering and safety checks
 
 - **`schemadiff/`** - Schema comparison and difference analysis
@@ -132,9 +132,9 @@ Provides comprehensive database migration functionality:
 #### `dbschema/` - Database Schema Operations
 Handles all database interactions and schema operations:
 
-- **Connection management** for PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, YugabyteDB, and Spanner
+- **Connection management** for PostgreSQL-family targets, MySQL, MariaDB, ClickHouse, and Spanner
 - **Schema reading and introspection** from live databases (including ClickHouse `system.tables` / `system.columns` / `system.data_skipping_indices`)
-- **Schema writing and migration execution** with transaction support (transactions are no-ops on ClickHouse — see the package godoc)
+- **Schema writing and migration execution** with dialect-specific transaction semantics (PostgreSQL-family DDL is transactional; MySQL/MariaDB DDL implicitly commits; ClickHouse transaction methods are no-ops)
 - **Database cleaning and schema dropping** capabilities
 - **Type definitions** for database schema representation
 
@@ -962,7 +962,7 @@ table already contains revisions above the requested baseline version.
 **Features:**
 - ✅ Applies migrations in correct order based on version numbers
 - ✅ Detects out-of-order pending migrations below the current version
-- ✅ Each migration runs in its own transaction unless explicitly marked `no_transaction`
+- ✅ PostgreSQL-family migrations run in transactions unless explicitly marked `no_transaction`
 - ✅ Tracks dirty/failed migration state and refuses to continue until repaired
 - ✅ Verifies applied migration checksums before running new work
 - ✅ Baselines existing databases by stamping migration metadata without executing DDL
@@ -971,6 +971,14 @@ table already contains revisions above the requested baseline version.
 - ✅ Supports dry-run mode for preview
 - ✅ Supports per-migration lock and statement timeout directives
 - ✅ Online DDL for large MySQL/MariaDB tables via gh-ost / pt-online-schema-change
+
+Transaction semantics are engine-specific. PostgreSQL-family DDL can roll back
+when a migration fails inside a transaction. MySQL and MariaDB implicitly commit
+most DDL, so a failed multi-statement migration can leave earlier DDL applied;
+Ptah records dirty migration state so operators can inspect and repair before
+continuing. ClickHouse transaction hooks are no-ops in Ptah because
+multi-statement transactions are experimental and require explicit session
+setup outside Ptah's current protection model.
 
 **Online DDL (MySQL/MariaDB):** route lock-heavy `ALTER TABLE` statements through
 [gh-ost](https://github.com/github/gh-ost) or
@@ -1008,7 +1016,7 @@ Roll back migrations to a specific version:
 **Features:**
 - ✅ Rolls back to any previous version
 - ✅ Executes down migrations in reverse order
-- ✅ Transaction safety with automatic rollback on failure
+- ✅ Transactional rollback on PostgreSQL-family engines; dirty-state tracking on engines where DDL cannot be rolled back
 - ✅ Updates migration tracking table
 
 #### Check Migration Status
@@ -1282,8 +1290,8 @@ Run comprehensive integration tests across multiple database platforms:
 ```
 
 **Features:**
-- ✅ Tests across PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, and YugabyteDB
-- ✅ Comprehensive scenario coverage (basic, concurrency, idempotency, failure recovery)
+- ✅ Tests across PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse
+- ✅ Comprehensive scenario coverage (basic, parallel execution smoke, idempotency, failure recovery)
 - ✅ Multiple report formats (TXT, JSON, HTML)
 - ✅ Automated database setup and cleanup
 - ✅ ClickHouse scenarios are opt-in per scenario (`ClickHouseCompatible`); incompatible scenarios skip cleanly against a ClickHouse connection
@@ -1440,7 +1448,7 @@ go test -v ./migration/...
 
 ### Integration Testing Framework
 
-Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets. CockroachDB and YugabyteDB have live common-subset scenarios in CI; Spanner uses capability, planning, and rendering coverage only.
+Ptah includes a comprehensive integration testing framework that validates migration functionality across PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse. CockroachDB and YugabyteDB have live common-subset scenarios in CI; Spanner uses capability, planning, and rendering coverage only.
 
 #### Run Integration Tests
 
@@ -1481,9 +1489,10 @@ The integration test suite covers:
 - Re-apply already applied migrations
 - Run migrate up when database is already up-to-date
 
-**🔀 Concurrency**
-- Launch parallel migrate up processes
-- Ensure locking prevents double-apply
+**🔀 Parallel Execution Smoke**
+- Launch two migrate up processes in parallel
+- Verify at least one runner succeeds and the final migration state is consistent
+- Ptah does not yet provide a migration-level lock; enforce a single production runner externally until #124 lands
 
 **🧪 Partial Failure Recovery**
 - Handle multi-step migrations with intentional failures
@@ -1550,17 +1559,22 @@ docker run --name test-mysql \
 - **AST-Based**: Uses Abstract Syntax Trees for type-safe SQL generation
 - **Visitor Pattern**: Enables dialect-specific rendering without modifying core AST
 - **Dependency Aware**: Automatically handles table creation order based on foreign keys
-- **Transaction Safe**: All operations are wrapped in transactions for consistency
+- **Dialect-Aware Safety**: PostgreSQL-family DDL uses transactions; MySQL/MariaDB implicit commits and ClickHouse no-op transactions are documented and tracked through dirty migration state
 
 ### Supported Databases
 
-- **PostgreSQL** - Full support including enums, constraints (CHECK, UNIQUE, FOREIGN KEY, EXCLUDE), indexes, RLS policies, and extensions
-- **MySQL** - Full support with MySQL-specific optimizations
-- **MariaDB** - Full support with MariaDB-specific features
-- **ClickHouse** - Opt-in MergeTree-oriented support for compatible scenarios
-- **CockroachDB** - PostgreSQL-family common subset via `platform.CockroachDB`; no `CREATE INDEX CONCURRENTLY`, XML, advisory locks, or RLS; covered by a live common-subset integration scenario
-- **YugabyteDB** - PostgreSQL-family common subset via `platform.YugabyteDB`; regular `CREATE INDEX` is used instead of PostgreSQL `CONCURRENTLY`; covered by a live common-subset integration scenario
-- **Spanner** - Conservative PostgreSQL-interface routing via `platform.Spanner`; full Spanner-specific DDL is not yet implemented
+This matrix describes workflow readiness. It is separate from the lower-level
+DDL capability matrix in [docs/capabilities.md](docs/capabilities.md).
+
+| Target | Parse + render | Introspect | Diff | Apply | Transactional apply | Live CI coverage | Production-supported |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| PostgreSQL | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| MySQL | Yes | Yes | Yes | Yes | No; DDL implicitly commits | Yes | Yes, with MySQL DDL caveats |
+| MariaDB | Yes | Yes | Yes | Yes | No; DDL implicitly commits | Yes | Yes, with MariaDB DDL caveats |
+| ClickHouse | Yes, compatible MergeTree subset | Yes | Yes, compatible subset | Yes, compatible subset | No; transaction hooks are no-ops | Yes | Limited to compatible scenarios |
+| CockroachDB | PostgreSQL-family common subset | Yes | Yes, common subset | Yes, common subset | Yes for supported transactional DDL | Yes | Limited to common-subset workflows |
+| YugabyteDB | PostgreSQL-family common subset | Yes | Yes, common subset | Yes, common subset | Yes for supported transactional DDL | Yes | Limited to common-subset workflows |
+| Spanner | Conservative PostgreSQL-interface routing | Partial/offline-oriented | Partial/offline-oriented | Not production-ready | No verified live apply path | No | No |
 
 ---
 
@@ -1802,17 +1816,26 @@ This project is part of the Inventario system and follows the same licensing ter
 
 ### ✅ Completed Features
 - ✅ **Migration versioning and rollback capabilities** - Full migration system with up/down migrations, version tracking, and rollback support
-- ✅ **Comprehensive integration testing** - Multi-database testing framework with PostgreSQL, MySQL, MariaDB, and ClickHouse support
+- ✅ **Comprehensive integration testing** - Multi-database testing framework with PostgreSQL-family, MySQL, MariaDB, and ClickHouse coverage
 - ✅ **ClickHouse dialect** - MergeTree-family engine annotations, data-skipping indexes, and live introspection via `system.tables`
+- ✅ **CockroachDB and YugabyteDB common-subset support** - PostgreSQL-family rendering, planning, and live integration coverage for supported features
+- ✅ **Spanner capability routing** - Conservative PostgreSQL-interface planning/rendering presets without live production support
 - ✅ **PostgreSQL extensions support** - Support for PostgreSQL extensions in schema definitions
 - ✅ **PostgreSQL EXCLUDE constraints** - Full support for EXCLUDE constraints with USING methods, elements, and WHERE conditions
+- ✅ **YAML schema frontend** - Language-agnostic schema files rendered through the same internal model as Go annotations
+- ✅ **Atlas HCL schema input and Go annotation export** - Parse supported Atlas schema HCL and export Go annotations to Atlas HCL
+- ✅ **Migration linting** - Rule-coded production-safety linting with text, JSON, GitHub Actions, and SARIF output
+- ✅ **Schema drift checks** - CI-friendly live drift detection with stable exit codes
 - ✅ **Migration file generation** - Automatic generation of timestamped migration files from schema differences
 - ✅ **Brownfield baseline workflow** - Adopt existing databases by verifying and stamping migration metadata without replaying DDL
+- ✅ **Online DDL hooks** - Optional gh-ost / pt-online-schema-change routing for large MySQL/MariaDB alters
+- ✅ **Migration directory integrity** - `ptah.sum` / `atlas.sum` hashing and validation
+- ✅ **Seed runner** - Environment-scoped SQL seed execution with production guards
+- ✅ **Stable CLI exit-code contract** - Documented `0` / `1` / `2` process semantics for scripting
 - ✅ **Dry-run capabilities** - Preview operations before execution across all commands
-- ✅ **Transaction safety** - All operations wrapped in transactions for consistency
+- ✅ **Dialect-aware transaction handling** - PostgreSQL-family transactional DDL with documented MySQL/MariaDB and ClickHouse caveats
 
 ### 🚧 In Progress
-- [ ] **Enhanced schema validation** - Advanced validation and linting capabilities
 - [ ] **Performance optimizations** - Optimizations for large schemas and complex migrations
 
 ### 🎯 Planned Features

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -101,6 +101,6 @@ func executeWithRecovery(cmd *cobra.Command) (err error) {
 const rootLongDescription = `Ptah generates database schemas from Go entities,
 compares desired schemas with live databases, and manages database migrations.
 
-It supports PostgreSQL, MySQL, MariaDB, ClickHouse, CockroachDB, YugabyteDB,
-and Spanner-oriented schema workflows, with Atlas-compatible commands grouped
+It supports PostgreSQL-family targets, MySQL, MariaDB, ClickHouse, and
+Spanner-oriented schema workflows, with Atlas-compatible commands grouped
 under ptah atlas.`

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -406,15 +406,6 @@ type schemaParseState struct {
 	schemas               []Schema
 }
 
-type schemaCommentTarget struct {
-	structName string
-	field      *ast.Field
-}
-
-func (t schemaCommentTarget) isField() bool {
-	return t.field != nil
-}
-
 func newSchemaParseState() *schemaParseState {
 	return &schemaParseState{
 		tableNameToStructName: make(map[string]string),
@@ -422,35 +413,37 @@ func newSchemaParseState() *schemaParseState {
 	}
 }
 
-func (s *schemaParseState) parseComment(comment *ast.Comment, target schemaCommentTarget) error {
-	if target.isField() {
-		if handled, err := s.parseFieldScopedComment(comment, target); handled || err != nil {
-			return err
-		}
-	} else {
-		if handled, err := s.parseTypeScopedComment(comment, target.structName); handled || err != nil {
-			return err
-		}
+func (s *schemaParseState) parseStructComment(comment *ast.Comment, structName string) error {
+	if handled, err := s.parseStructScopedComment(comment, structName); handled || err != nil {
+		return err
 	}
 
-	return s.parseSharedComment(comment, target.structName)
+	return s.parseSharedComment(comment, structName)
 }
 
-func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, target schemaCommentTarget) (bool, error) {
+func (s *schemaParseState) parseStructFieldComment(comment *ast.Comment, structName string, field *ast.Field) error {
+	if handled, err := s.parseFieldScopedComment(comment, structName, field); handled || err != nil {
+		return err
+	}
+
+	return s.parseSharedComment(comment, structName)
+}
+
+func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, structName string, field *ast.Field) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
-		return true, parseFieldComment(comment, target.field, target.structName, s.globalEnumsMap, &s.schemaFields)
+		return true, parseFieldComment(comment, field, structName, s.globalEnumsMap, &s.schemaFields)
 	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
-		parseEmbeddedComment(comment, target.field, target.structName, &s.embeddedFields)
+		parseEmbeddedComment(comment, field, structName, &s.embeddedFields)
 		return true, nil
 	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
-		return true, parseIndexComment(comment, target.structName, &s.schemaIndexes)
+		return true, parseIndexComment(comment, structName, &s.schemaIndexes)
 	default:
 		return false, nil
 	}
 }
 
-func (s *schemaParseState) parseTypeScopedComment(comment *ast.Comment, structName string) (bool, error) {
+func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, structName string) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
 		parseTableComment(comment, structName, &s.tableDirectives)
@@ -493,9 +486,8 @@ func (s *schemaParseState) processTableComments(structName string, genDecl *ast.
 		return nil
 	}
 
-	target := schemaCommentTarget{structName: structName}
 	for _, comment := range genDecl.Doc.List {
-		if err := s.parseComment(comment, target); err != nil {
+		if err := s.parseStructComment(comment, structName); err != nil {
 			return err
 		}
 	}
@@ -507,9 +499,8 @@ func (s *schemaParseState) processFieldComments(structName string, structType *a
 		if field.Doc == nil {
 			continue
 		}
-		target := schemaCommentTarget{structName: structName, field: field}
 		for _, comment := range field.Doc.List {
-			if err := s.parseComment(comment, target); err != nil {
+			if err := s.parseStructFieldComment(comment, structName, field); err != nil {
 				return err
 			}
 		}

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -34,11 +34,11 @@ The system operates through four main layers:
 
 ### Key Design Principles
 
-- **Database Agnostic**: Core logic works with PostgreSQL, MySQL, and MariaDB
+- **Database Agnostic**: Core logic works across supported PostgreSQL-family, MySQL, MariaDB, ClickHouse, and Spanner workflows
 - **AST-Based**: Uses Abstract Syntax Trees for type-safe SQL generation
 - **Visitor Pattern**: Enables dialect-specific rendering without modifying core AST
 - **Dependency Aware**: Automatically handles table creation order based on foreign keys
-- **Transaction Safe**: All operations are wrapped in transactions for consistency
+- **Dialect-Aware Safety**: Migration execution records dirty state and uses transactions only where the target engine supports transactional DDL
 
 ## Core Components
 
@@ -100,7 +100,7 @@ The system operates through four main layers:
 
 #### renderer Package
 - **Purpose**: Converts AST nodes to dialect-specific SQL statements
-- **Supported Dialects**: PostgreSQL, MySQL, MariaDB
+- **Supported Dialects**: PostgreSQL-family targets, MySQL, MariaDB, ClickHouse, and Spanner
 - **Functionality**: Implements visitor pattern to traverse AST and generate SQL
 
 ### 3. Database Integration
@@ -215,14 +215,27 @@ type SchemaDiff struct {
 ## Supported Databases
 
 ### PostgreSQL
-- Full support including enums, constraints, and indexes
+- Full support including enums, constraints, indexes, RLS policies, roles, grants, extensions, and functions
 - Native enum types with CREATE TYPE statements
-- Advanced constraint support
+- Transactional DDL for ordinary migration execution
 
 ### MySQL/MariaDB
-- Full support with platform-specific optimizations
+- Full support with platform-specific optimizations and online DDL hooks
 - ENUM column types for enumerated values
 - Engine-specific table options (InnoDB, MyISAM)
+- DDL implicitly commits, so failed multi-statement migrations can leave earlier DDL applied; Ptah records dirty migration state for recovery
+
+### ClickHouse
+- Compatible MergeTree-oriented subset with live introspection through system tables
+- Transaction hooks are no-ops; compatible scenarios rely on dirty-state tracking rather than rollback
+
+### CockroachDB/YugabyteDB
+- PostgreSQL-family common subset with live CI coverage for supported scenarios
+- Capability presets disable PostgreSQL features the target does not support, such as advisory locks or `CREATE INDEX CONCURRENTLY` where unavailable
+
+### Spanner
+- Conservative PostgreSQL-interface routing for planning and rendering
+- No live CI coverage and not production-supported yet
 
 ## Go Struct Annotations
 
@@ -261,10 +274,11 @@ type Product struct {
 
 ## Error Handling and Safety
 
-### Transaction Safety
-- All migration operations run in transactions
-- Automatic rollback on failure
-- Dry-run mode for validation
+### Transaction Semantics
+- PostgreSQL-family DDL runs in transactions unless a migration opts out with `-- +ptah no_transaction`
+- MySQL/MariaDB DDL implicitly commits; failed migrations can leave partial DDL applied and must be inspected before repair
+- ClickHouse transaction methods are no-ops in Ptah
+- Dry-run mode is available for validation
 
 ### Safety Mechanisms
 - Confirmation prompts for destructive operations

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,6 +1,6 @@
 # Ptah Migration Library Integration Tests
 
-This directory contains comprehensive integration tests for the Ptah migration library. The tests validate migration functionality across multiple database backends including PostgreSQL, MySQL, MariaDB, ClickHouse, and opt-in PostgreSQL-family distributed SQL targets.
+This directory contains comprehensive integration tests for the Ptah migration library. The tests validate migration functionality across PostgreSQL-family targets, MySQL, MariaDB, and ClickHouse.
 
 ## Overview
 
@@ -22,9 +22,10 @@ The integration test suite covers all aspects of the migration system as outline
 - Re-apply already applied migrations
 - Run migrate up when database is already up-to-date
 
-### 🔀 Concurrency
-- Launch parallel migrate up processes
-- Ensure locking prevents double-apply
+### 🔀 Parallel Execution Smoke
+- Launch two migrate up processes in parallel
+- Verify at least one runner succeeds and the final migration state is consistent
+- Ptah does not yet provide a migration-level lock; enforce a single production runner externally until #124 lands
 
 ### 🧪 Partial Failure Recovery
 - Handle multi-step migrations with intentional failures

--- a/integration/scenarios.go
+++ b/integration/scenarios.go
@@ -78,11 +78,11 @@ func GetAllScenarios() []TestScenario {
 			TestFunc:    testIdempotencyUpToDate,
 		},
 
-		// Concurrency
+		// Parallel execution smoke
 		{
-			Name:        "concurrency_parallel_migrate",
-			Description: "Launch two migrate up processes in parallel",
-			TestFunc:    testConcurrencyParallelMigrate,
+			Name:        "parallel_migrate_smoke",
+			Description: "Launch two migrate up processes in parallel and verify final consistency",
+			TestFunc:    testParallelMigrateSmoke,
 		},
 
 		// Partial Failure Recovery

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -214,8 +214,10 @@ func testIdempotencyUpToDate(ctx context.Context, conn *dbschema.DatabaseConnect
 	return nil
 }
 
-// testConcurrencyParallelMigrate tests parallel migration execution
-func testConcurrencyParallelMigrate(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error {
+// testParallelMigrateSmoke verifies final consistency when two runners race.
+// It does not assert a migration-level lock; production deployments must
+// enforce a single runner externally until Ptah implements #124.
+func testParallelMigrateSmoke(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error {
 	migrationsFS, err := GetMigrationsFS(fixtures, conn, "basic")
 	if err != nil {
 		return fmt.Errorf("failed to get migrations filesystem: %w", err)


### PR DESCRIPTION
## Summary

- remove undocumented locking and blanket transaction-safety claims from README, integration docs, and system docs
- publish a target readiness matrix with live CI and production-support columns
- document MySQL/MariaDB implicit commits and ClickHouse no-op transaction hooks
- rename the parallel integration scenario to a consistency smoke instead of implying a lock guarantee
- align the CockroachDB image used in CI with `docker-compose.yaml`
- add a lint-workflow grep guard so unsafe README claims cannot quietly return

## Self-Review

- Pass 1 checked #266 acceptance item by item: forbidden README claims are absent, stale three-dialect wording is gone from `cmd/` and `docs/system_design.md`, the support matrix includes every target and marks Spanner live/prod support as negative, and CockroachDB tags match.
- Pass 2 checked scope and regression risk: code changes are limited to root help text and integration scenario naming; coverage is not removed, only renamed to match the actual assertion.

## Validation

- `! grep -F "All operations are wrapped in transactions" README.md && ! grep -F "All operations wrapped in transactions" README.md && ! grep -F "locking prevents double-apply" README.md`
- `rg -i "locking prevents double-apply" README.md`
- `rg -n "PostgreSQL, MySQL, MariaDB" cmd/ docs/system_design.md`
- `git diff --check`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./integration ./cmd/root -count=1`
- `go test ./... -count=1`

Closes #266.
