### PR TITLE
Add standalone SQL lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ The core package contains all fundamental components for parsing, transforming, 
   - SQL statement splitting and comment removal
   - AST-based parsing for proper handling of strings and comments
 
+- **`sqllint/`** - Standalone SQL lint engine
+  - Uses Ptah's parser, AST, and target capability presets for regular SQL files
+  - Reports unsupported SQL explicitly so skipped statements cannot look clean
+  - Provides reusable rules independent of migration-directory layout
+
 - **`convert/`** - Schema conversion utilities
   - Converts between different schema representations
   - Handles transformations between goschema and database schema formats
@@ -148,6 +153,7 @@ Provides command-line interface for all Ptah operations:
 - **`compare`** - Compare Go entities with current database schema
 - **`drift`** - Check live database drift with CI-friendly exit codes
 - **`lint`** - Lint migration files for production-unsafe patterns (rule-coded, CI-friendly)
+- **`sql lint`** - Lint standalone SQL files or stdin with parser-backed DDL rules
 - **`migrate`** - Generate migration SQL for schema differences
 - **`migrate-up`** - Apply migrations to bring database up to latest version
 - **`migrate-down`** - Roll back migrations to previous versions
@@ -706,6 +712,28 @@ ALTER TABLE users ALTER COLUMN email TYPE VARCHAR(512);
 Go integrations can provide custom analyzers without reimplementing Ptah's
 dialect-aware scanner by passing `lint.Options{ExtraRules: []lint.Rule{...}}`
 or by preparing files first with `lint.PrepareFS`.
+
+#### Lint Standalone SQL
+Lint ordinary SQL files outside a migration directory:
+
+```bash
+./ptah sql lint --dialect postgres schema.sql
+cat schema.sql | ./ptah sql lint --dialect cockroachdb --version "CockroachDB CCL v23.1.0" --stdin
+./ptah sql lint --dialect sqlite --format json schema.sql
+```
+
+`ptah sql lint` is parser-backed and migration-layout independent. It accepts
+file paths or `--stdin`, supports `--format text|json`, and returns exit code
+`1` when an error-severity finding is present. Disable rules per code or family
+with `--disable DDL001 --disable CAP`. The first built-in rules cover general
+DDL quality, such as `DDL001` for `CREATE TABLE` without a primary key, and
+capability-aware validation, such as `CAP001` for
+`CREATE INDEX CONCURRENTLY` on targets whose preset disables
+`create_index_concurrently`.
+
+Unsupported statements are reported as `SQL002` findings instead of being
+silently treated as clean. That includes non-DDL statements such as `SELECT`
+and DDL forms that Ptah's parser does not yet model.
 
 #### Generate Migration SQL
 Generate SQL migration statements to synchronize schemas:

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stokaro/ptah/cmd/readdb"
 	"github.com/stokaro/ptah/cmd/schema"
 	"github.com/stokaro/ptah/cmd/seed"
+	sqlcmd "github.com/stokaro/ptah/cmd/sql"
 	"github.com/stokaro/ptah/cmd/version"
 )
 
@@ -62,6 +63,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(seed.NewSeedCommand())
 	cmd.AddCommand(dropall.NewDropAllCommand())
 	cmd.AddCommand(lint.NewLintCommand())
+	cmd.AddCommand(sqlcmd.NewSQLCommand())
 	cmd.AddCommand(atlas.NewAtlasCommand())
 	cmd.AddCommand(version.NewVersionCommand())
 

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -183,6 +183,7 @@ func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
 		{name: "seed", args: []string{"seed", "--bogus-flag"}},
 		{name: "drop-all", args: []string{"drop-all", "--bogus-flag"}},
 		{name: "lint", args: []string{"lint", "--bogus-flag"}},
+		{name: "sql lint", args: []string{"sql", "lint", "--bogus-flag"}},
 		{name: "atlas version", args: []string{"atlas", "version", "--bogus-flag"}},
 		{name: "version", args: []string{"version", "--bogus-flag"}},
 	}

--- a/cmd/sql/sql.go
+++ b/cmd/sql/sql.go
@@ -1,0 +1,257 @@
+// Package sql contains commands for standalone SQL files.
+package sql
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/sqllint"
+)
+
+const (
+	formatText = "text"
+	formatJSON = "json"
+)
+
+var errSQLLintFindings = errors.New("sql lint findings found")
+
+// NewSQLCommand returns the standalone SQL command namespace.
+func NewSQLCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sql",
+		Short: "Work with standalone SQL files",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	cmd.AddCommand(newSQLLintCommand())
+	return cmd
+}
+
+func newSQLLintCommand() *cobra.Command {
+	var dialect string
+	var version string
+	var format string
+	var stdin bool
+	var disabled []string
+
+	cmd := &cobra.Command{
+		Use:   "lint [files...]",
+		Short: "Lint standalone SQL files",
+		Long: `Lint standalone SQL files using Ptah's SQL parser, AST, and
+target capability presets.
+
+This command is intentionally separate from ptah lint, which is migration
+directory specific.`,
+		Args:          cobra.ArbitraryArgs,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSQLLint(cmd, sqlLintOptions{
+				dialect:  dialect,
+				version:  version,
+				format:   format,
+				stdin:    stdin,
+				disabled: disabled,
+				files:    args,
+			})
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&dialect, "dialect", "", "Target dialect: postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner")
+	flags.StringVar(&version, "version", "", "Server version string used to refine target capabilities")
+	flags.StringVar(&format, "format", formatText, "Output format: text or json")
+	flags.BoolVar(&stdin, "stdin", false, "Read SQL from stdin")
+	flags.StringArrayVar(&disabled, "disable", nil, "Disable a rule code or family, for example DDL001 or CAP (repeatable)")
+	cmdutil.ConfigureCommandArgs(cmd, cobra.ArbitraryArgs)
+	return cmd
+}
+
+type sqlLintOptions struct {
+	dialect  string
+	version  string
+	format   string
+	stdin    bool
+	disabled []string
+	files    []string
+}
+
+type sqlLintReport struct {
+	Failed   bool              `json:"failed"`
+	Dialect  string            `json:"dialect,omitempty"`
+	Version  string            `json:"version,omitempty"`
+	Sources  []string          `json:"sources,omitempty"`
+	Disabled []string          `json:"disabled_rules,omitempty"`
+	Findings []sqllint.Finding `json:"findings"`
+	Error    string            `json:"error,omitempty"`
+}
+
+func runSQLLint(cmd *cobra.Command, opts sqlLintOptions) error {
+	if err := validateSQLLintOptions(opts); err != nil {
+		return writeSQLLintError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	sources, err := readSQLLintSources(cmd.InOrStdin(), opts)
+	if err != nil {
+		return writeSQLLintError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	normalizedDialect := platform.NormalizeDialect(opts.dialect)
+	var findings []sqllint.Finding
+	for _, source := range sources {
+		sourceFindings, err := sqllint.LintSource(source, sqllint.Options{
+			Dialect:       normalizedDialect,
+			Version:       opts.version,
+			DisabledRules: opts.disabled,
+		})
+		if err != nil {
+			return writeSQLLintError(cmd.ErrOrStderr(), opts.format, err.Error())
+		}
+		findings = append(findings, sourceFindings...)
+	}
+	if findings == nil {
+		findings = []sqllint.Finding{}
+	}
+
+	report := sqlLintReport{
+		Failed:   hasErrorFinding(findings),
+		Dialect:  normalizedDialect,
+		Version:  opts.version,
+		Sources:  sourceNames(sources),
+		Disabled: opts.disabled,
+		Findings: findings,
+	}
+	writer := cmd.OutOrStdout()
+	if report.Failed {
+		writer = cmd.ErrOrStderr()
+	}
+	if err := writeSQLLintReport(writer, opts.format, report); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	if report.Failed {
+		return exitcode.New(1, errSQLLintFindings)
+	}
+	return nil
+}
+
+func validateSQLLintOptions(opts sqlLintOptions) error {
+	if opts.format != formatText && opts.format != formatJSON {
+		return fmt.Errorf("invalid --format value %q: expected text or json", opts.format)
+	}
+	if opts.dialect != "" && platform.NormalizeDialect(opts.dialect) == "" {
+		return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner", opts.dialect)
+	}
+	if opts.version != "" && opts.dialect == "" {
+		return fmt.Errorf("--version requires --dialect")
+	}
+	if opts.stdin && len(opts.files) > 0 {
+		return fmt.Errorf("--stdin cannot be combined with file arguments")
+	}
+	if !opts.stdin && len(opts.files) == 0 {
+		return fmt.Errorf("at least one SQL file is required unless --stdin is set")
+	}
+	return nil
+}
+
+func readSQLLintSources(stdin io.Reader, opts sqlLintOptions) ([]sqllint.Source, error) {
+	if opts.stdin {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return []sqllint.Source{{Name: "<stdin>", SQL: string(data)}}, nil
+	}
+
+	sources := make([]sqllint.Source, 0, len(opts.files))
+	for _, path := range opts.files {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("SQL file %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("SQL file %s: is a directory", path)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read SQL file %s: %w", path, err)
+		}
+		sources = append(sources, sqllint.Source{
+			Name: filepath.ToSlash(path),
+			SQL:  string(data),
+		})
+	}
+	return sources, nil
+}
+
+func writeSQLLintReport(w io.Writer, format string, report sqlLintReport) error {
+	if format == formatJSON {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(report)
+	}
+	return writeSQLLintText(w, report)
+}
+
+func writeSQLLintText(w io.Writer, report sqlLintReport) error {
+	if report.Error != "" {
+		_, err := fmt.Fprintf(w, "error: %s\n", report.Error)
+		return err
+	}
+	if len(report.Findings) == 0 {
+		_, err := fmt.Fprintln(w, "No SQL lint findings.")
+		return err
+	}
+	for _, finding := range report.Findings {
+		if _, err := fmt.Fprintf(w, "%s:%d:%d: %s %s: %s\n",
+			finding.File,
+			finding.Line,
+			finding.Column,
+			finding.Severity,
+			finding.Rule,
+			finding.Message,
+		); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "\n%d finding(s).\n", len(report.Findings))
+	return err
+}
+
+func writeSQLLintError(w io.Writer, format, msg string) error {
+	report := sqlLintReport{
+		Failed:   true,
+		Findings: []sqllint.Finding{},
+		Error:    msg,
+	}
+	if err := writeSQLLintReport(w, format, report); err != nil {
+		return exitcode.New(2, fmt.Errorf("%s; additionally failed to write error report: %w", msg, err))
+	}
+	return exitcode.New(2, errors.New(msg))
+}
+
+func hasErrorFinding(findings []sqllint.Finding) bool {
+	for _, finding := range findings {
+		if finding.Severity == sqllint.SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+func sourceNames(sources []sqllint.Source) []string {
+	names := make([]string, 0, len(sources))
+	for _, source := range sources {
+		names = append(names, source.Name)
+	}
+	return names
+}

--- a/cmd/sql/sql_test.go
+++ b/cmd/sql/sql_test.go
@@ -1,0 +1,188 @@
+package sql
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/core/sqllint"
+)
+
+func execute(args ...string) (stdout, stderr string, err error) {
+	cmd := NewSQLCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func executeWithStdin(stdin string, args ...string) (stdout, stderr string, err error) {
+	cmd := NewSQLCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetIn(bytes.NewBufferString(stdin))
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestNewSQLCommand_Creation(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewSQLCommand()
+
+	c.Assert(cmd, qt.IsNotNil)
+	c.Assert(cmd.Use, qt.Equals, "sql")
+	c.Assert(cmd.Short, qt.Contains, "SQL")
+}
+
+func TestSQLLint_FileTextOutput(t *testing.T) {
+	c := qt.New(t)
+	path := writeSQLFile(c, t.TempDir(), "schema.sql", "CREATE TABLE users (email TEXT NOT NULL);")
+
+	stdout, stderr, err := execute("lint", "--dialect", "postgres", path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(stdout, qt.Contains, "warning DDL001")
+	c.Assert(stdout, qt.Contains, "table \"users\" has no primary key")
+}
+
+func TestSQLLint_MultipleFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	first := writeSQLFile(c, dir, "users.sql", "CREATE TABLE users (email TEXT NOT NULL);")
+	second := writeSQLFile(c, dir, "accounts.sql", "CREATE TABLE accounts (name TEXT NOT NULL);")
+
+	stdout, stderr, err := execute("lint", "--dialect", "postgres", first, second)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(stdout, qt.Contains, "users.sql")
+	c.Assert(stdout, qt.Contains, "accounts.sql")
+	c.Assert(stdout, qt.Contains, "2 finding(s).")
+}
+
+func TestSQLLint_DisableRule(t *testing.T) {
+	c := qt.New(t)
+	path := writeSQLFile(c, t.TempDir(), "schema.sql", "CREATE TABLE users (email TEXT NOT NULL);")
+
+	stdout, stderr, err := execute("lint", "--dialect", "postgres", "--disable", sqllint.RuleTableWithoutPrimaryKey, path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(stdout, qt.Contains, "No SQL lint findings.")
+}
+
+func TestSQLLint_JSONOutputForUnsupportedSQLExitsOne(t *testing.T) {
+	c := qt.New(t)
+	path := writeSQLFile(c, t.TempDir(), "query.sql", "SELECT 1;")
+
+	stdout, stderr, err := execute("lint", "--dialect", "postgres", "--format", "json", path)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stdout, qt.Equals, "")
+	var report struct {
+		Failed   bool              `json:"failed"`
+		Findings []sqllint.Finding `json:"findings"`
+	}
+	c.Assert(json.Unmarshal([]byte(stderr), &report), qt.IsNil)
+	c.Assert(report.Failed, qt.IsTrue)
+	c.Assert(report.Findings, qt.HasLen, 1)
+	c.Assert(report.Findings[0].Rule, qt.Equals, sqllint.RuleUnsupportedStatement)
+}
+
+func TestSQLLint_StdinCleanSQL(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := executeWithStdin(
+		"CREATE TABLE users (id BIGINT PRIMARY KEY, email TEXT NOT NULL);",
+		"lint",
+		"--dialect",
+		"postgres",
+		"--stdin",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(stdout, qt.Contains, "No SQL lint findings.")
+}
+
+func TestSQLLint_CapabilityAwareRuleUsesVersion(t *testing.T) {
+	c := qt.New(t)
+	path := writeSQLFile(c, t.TempDir(), "index.sql", "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);")
+
+	_, stderr, err := execute("lint", "--dialect", "cockroachdb", "--version", "CockroachDB CCL v23.1.0", path)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr, qt.Contains, "error CAP001")
+	c.Assert(stderr, qt.Contains, "create_index_concurrently")
+}
+
+func TestSQLLint_UsageErrorsExitTwo(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing input", args: []string{"lint"}},
+		{name: "stdin with file", args: []string{"lint", "--stdin", "schema.sql"}},
+		{name: "version without dialect", args: []string{"lint", "--version", "16", "--stdin"}},
+		{name: "bad format", args: []string{"lint", "--format", "sarif", "--stdin"}},
+		{name: "bad dialect", args: []string{"lint", "--dialect", "oracle", "--stdin"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, stderr, err := execute(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr, qt.Contains, "error:")
+		})
+	}
+}
+
+func TestWriteSQLLintReport_TextPropagatesWriterError(t *testing.T) {
+	c := qt.New(t)
+	errBoom := errors.New("boom")
+
+	err := writeSQLLintReport(failingWriter{err: errBoom}, formatText, sqlLintReport{
+		Findings: []sqllint.Finding{{
+			Rule:     sqllint.RuleUnsupportedStatement,
+			Severity: sqllint.SeverityError,
+			File:     "schema.sql",
+			Line:     1,
+			Column:   1,
+			Message:  "bad",
+		}},
+	})
+
+	c.Assert(err, qt.ErrorIs, errBoom)
+}
+
+func writeSQLFile(c *qt.C, dir, name, sql string) string {
+	path := filepath.Join(dir, name)
+	c.Assert(os.WriteFile(path, []byte(sql), 0o600), qt.IsNil)
+	return path
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -3669,6 +3669,26 @@ const regularIndexType = ""
 
 func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode, error) {
 	p.skipWhitespace()
+	concurrently := false
+	if p.current.MatchIdentifierValue("CONCURRENTLY") {
+		concurrently = true
+		p.advance()
+		p.skipWhitespace()
+	}
+	ifNotExists := false
+	if p.current.MatchIdentifierValue("IF") {
+		p.advance()
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "NOT"); err != nil {
+			return nil, fmt.Errorf("expected NOT after index IF: %w", err)
+		}
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "EXISTS"); err != nil {
+			return nil, fmt.Errorf("expected EXISTS after index IF NOT: %w", err)
+		}
+		p.skipWhitespace()
+		ifNotExists = true
+	}
 
 	// Get index name
 	indexName, err := p.expectIdentifier()
@@ -3727,6 +3747,8 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	index.IncludeColumns = includeColumns
 	index.NullsDistinct = nullsDistinct
 	index.StorageParams = storageParams
+	index.Concurrently = concurrently
+	index.IfNotExists = ifNotExists
 	return index, nil
 }
 

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -97,6 +97,72 @@ func TestParser_ParseCreateTable_RejectsDuplicatePartitionBy(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `.*duplicate PARTITION BY clause.*`)
 }
 
+func TestParser_ParseCreateIndexConcurrently(t *testing.T) {
+	c := qt.New(t)
+
+	p := parser.NewParser("CREATE INDEX CONCURRENTLY idx_users_email ON users (email);")
+
+	statements, err := p.Parse()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_email")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"email"})
+	c.Assert(index.Concurrently, qt.IsTrue)
+	c.Assert(index.Unique, qt.IsFalse)
+}
+
+func TestParser_ParseCreateUniqueIndexConcurrently(t *testing.T) {
+	c := qt.New(t)
+
+	p := parser.NewParser("CREATE UNIQUE INDEX CONCURRENTLY idx_users_email ON users (email);")
+
+	statements, err := p.Parse()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_email")
+	c.Assert(index.Concurrently, qt.IsTrue)
+	c.Assert(index.Unique, qt.IsTrue)
+}
+
+func TestParser_ParseCreateIndexConcurrentlyIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	p := parser.NewParser("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);")
+
+	statements, err := p.Parse()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_email")
+	c.Assert(index.Concurrently, qt.IsTrue)
+	c.Assert(index.IfNotExists, qt.IsTrue)
+}
+
+func TestParser_ParseCreateIndexIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	p := parser.NewParser("CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);")
+
+	statements, err := p.Parse()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_email")
+	c.Assert(index.IfNotExists, qt.IsTrue)
+	c.Assert(index.Concurrently, qt.IsFalse)
+}
+
 func TestParser_ParseCreateTable_WithConstraints(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/sqllint/lint.go
+++ b/core/sqllint/lint.go
@@ -1,0 +1,406 @@
+// Package sqllint provides a parser-backed linter for standalone SQL files.
+package sqllint
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/parser"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/sqlutil"
+)
+
+const (
+	RuleParseError             = "SQL001"
+	RuleUnsupportedStatement   = "SQL002"
+	RuleTableWithoutPrimaryKey = "DDL001"
+	RuleUnsupportedCapability  = "CAP001"
+)
+
+type Severity string
+
+const (
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+type Source struct {
+	Name string
+	SQL  string
+}
+
+type Options struct {
+	Dialect       string
+	Version       string
+	Capabilities  capability.Capabilities
+	Rules         []Rule
+	DisabledRules []string
+}
+
+type Finding struct {
+	Rule         string   `json:"rule"`
+	Title        string   `json:"title"`
+	Severity     Severity `json:"severity"`
+	File         string   `json:"file,omitempty"`
+	Line         int      `json:"line,omitempty"`
+	Column       int      `json:"column,omitempty"`
+	Dialect      string   `json:"dialect,omitempty"`
+	Message      string   `json:"message"`
+	Rationale    string   `json:"rationale,omitempty"`
+	SuggestedFix string   `json:"suggested_fix,omitempty"`
+}
+
+type Rule interface {
+	ID() string
+	CheckStatement(ctx Context, stmt ast.Node) []Finding
+}
+
+type Context struct {
+	Source       Source
+	Dialect      string
+	Version      string
+	Capabilities capability.Capabilities
+	statement    sourceStatement
+}
+
+func DefaultRules() []Rule {
+	return []Rule{
+		unsupportedRoutineRule{},
+		tablePrimaryKeyRule{},
+		createIndexCapabilityRule{},
+	}
+}
+
+func LintSource(source Source, opts Options) ([]Finding, error) {
+	var findings []Finding
+	for _, statement := range splitSourceStatements(source) {
+		keyword, keywordOffset := firstKeyword(statement.sql)
+		if keyword == "" {
+			continue
+		}
+		if !isSupportedTopLevelKeyword(keyword) {
+			findings = append(findings, unsupportedStatementFinding(source, statement, opts, keyword, keywordOffset))
+			continue
+		}
+		statementFindings, err := lintParsedStatement(source, statement, opts)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, statementFindings...)
+	}
+	return findings, nil
+}
+
+func effectiveCapabilities(opts Options) capability.Capabilities {
+	if opts.Capabilities != nil {
+		return opts.Capabilities
+	}
+	if opts.Version != "" {
+		return capability.ForServerVersion(opts.Dialect, opts.Version)
+	}
+	return capability.ForDialect(opts.Dialect)
+}
+
+type sourceStatement struct {
+	sql    string
+	offset int
+}
+
+func splitSourceStatements(source Source) []sourceStatement {
+	statements := sqlutil.SplitSQLStatements(source.SQL)
+	out := make([]sourceStatement, 0, len(statements))
+	cursor := 0
+	for _, statement := range statements {
+		offset := cursor
+		if idx := strings.Index(source.SQL[cursor:], statement); idx >= 0 {
+			offset = cursor + idx
+		}
+		out = append(out, sourceStatement{sql: statement, offset: offset})
+		cursor = min(offset+len(statement), len(source.SQL))
+	}
+	return out
+}
+
+func unsupportedStatementFinding(source Source, statement sourceStatement, opts Options, keyword string, keywordOffset int) Finding {
+	line, column := lineColumn(source.SQL, statement.offset+keywordOffset)
+	return Finding{
+		Rule:      RuleUnsupportedStatement,
+		Title:     "Unsupported SQL statement",
+		Severity:  SeverityError,
+		File:      source.Name,
+		Line:      line,
+		Column:    column,
+		Dialect:   opts.Dialect,
+		Message:   fmt.Sprintf("ptah sql lint does not lint %s statements yet", keyword),
+		Rationale: "Unsupported SQL is reported explicitly so the file cannot be mistaken for a clean lint result.",
+	}
+}
+
+func lintParsedStatement(source Source, statement sourceStatement, opts Options) ([]Finding, error) {
+	stmtList, err := parser.NewParser(statementParserSQL(statement.sql)).Parse()
+	if err != nil {
+		return []Finding{parseErrorFinding(source, statement, opts, err)}, nil
+	}
+
+	ctx := Context{
+		Source:       source,
+		statement:    statement,
+		Dialect:      opts.Dialect,
+		Version:      opts.Version,
+		Capabilities: effectiveCapabilities(opts),
+	}
+	findings := make([]Finding, 0)
+	for _, stmt := range stmtList.Statements {
+		for _, rule := range effectiveRules(opts) {
+			if ruleDisabled(rule.ID(), opts.DisabledRules) {
+				continue
+			}
+			findings = append(findings, rule.CheckStatement(ctx, stmt)...)
+		}
+	}
+	return findings, nil
+}
+
+func statementParserSQL(sql string) string {
+	if strings.HasSuffix(strings.TrimSpace(sql), ";") {
+		return sql
+	}
+	return sql + ";"
+}
+
+func effectiveRules(opts Options) []Rule {
+	if opts.Rules != nil {
+		return opts.Rules
+	}
+	return DefaultRules()
+}
+
+func ruleDisabled(ruleID string, disabled []string) bool {
+	for _, item := range disabled {
+		item = strings.ToUpper(strings.TrimSpace(item))
+		if item == "" {
+			continue
+		}
+		if strings.EqualFold(item, ruleID) || strings.HasPrefix(ruleID, item) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstKeyword(statement string) (keyword string, offset int) {
+	l := lexer.NewLexer(statement)
+	for {
+		token := l.NextToken()
+		switch token.Type {
+		case lexer.TokenEOF:
+			return "", 0
+		case lexer.TokenWhitespace, lexer.TokenComment:
+			continue
+		case lexer.TokenIdentifier:
+			return strings.ToUpper(token.Value), token.Start
+		default:
+			return "", token.Start
+		}
+	}
+}
+
+func isSupportedTopLevelKeyword(keyword string) bool {
+	switch keyword {
+	case "ALTER", "COMMENT", "CREATE", "DO", "DROP", "GO":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseErrorFinding(source Source, statement sourceStatement, opts Options, err error) Finding {
+	line, column := lineColumn(source.SQL, statement.offset+parseErrorPosition(err))
+	return Finding{
+		Rule:      parseErrorRule(err),
+		Title:     parseErrorTitle(err),
+		Severity:  SeverityError,
+		File:      source.Name,
+		Line:      line,
+		Column:    column,
+		Dialect:   opts.Dialect,
+		Message:   err.Error(),
+		Rationale: "The SQL parser could not build an AST, so no rule can safely treat this statement as clean.",
+	}
+}
+
+func parseErrorRule(err error) string {
+	if strings.Contains(strings.ToLower(err.Error()), "unsupported") {
+		return RuleUnsupportedStatement
+	}
+	return RuleParseError
+}
+
+func parseErrorTitle(err error) string {
+	if parseErrorRule(err) == RuleUnsupportedStatement {
+		return "Unsupported SQL statement"
+	}
+	return "SQL parse error"
+}
+
+func parseErrorPosition(err error) int {
+	message := err.Error()
+	idx := strings.LastIndex(message, "position ")
+	if idx == -1 {
+		return 0
+	}
+	start := idx + len("position ")
+	end := start
+	for end < len(message) && message[end] >= '0' && message[end] <= '9' {
+		end++
+	}
+	pos, convErr := strconv.Atoi(message[start:end])
+	if convErr != nil {
+		return 0
+	}
+	return pos
+}
+
+type tablePrimaryKeyRule struct{}
+
+func (tablePrimaryKeyRule) ID() string {
+	return RuleTableWithoutPrimaryKey
+}
+
+func (tablePrimaryKeyRule) CheckStatement(ctx Context, stmt ast.Node) []Finding {
+	table, ok := stmt.(*ast.CreateTableNode)
+	if !ok {
+		return nil
+	}
+	if table.SelectBody != "" || createTableHasPrimaryKey(table) {
+		return nil
+	}
+	line, column := ctx.LineColumn(table.Name)
+	return []Finding{{
+		Rule:         RuleTableWithoutPrimaryKey,
+		Title:        "Table has no primary key",
+		Severity:     SeverityWarning,
+		File:         ctx.Source.Name,
+		Line:         line,
+		Column:       column,
+		Dialect:      ctx.Dialect,
+		Message:      fmt.Sprintf("table %q has no primary key", table.Name),
+		Rationale:    "Tables without primary keys are harder to reference, replicate, and migrate safely.",
+		SuggestedFix: "Add a column-level PRIMARY KEY or a table-level PRIMARY KEY constraint.",
+	}}
+}
+
+func createTableHasPrimaryKey(table *ast.CreateTableNode) bool {
+	for _, column := range table.Columns {
+		if column.Primary {
+			return true
+		}
+	}
+	for _, constraint := range table.Constraints {
+		if constraint.Type == ast.PrimaryKeyConstraint {
+			return true
+		}
+	}
+	return false
+}
+
+type unsupportedRoutineRule struct{}
+
+func (unsupportedRoutineRule) ID() string {
+	return RuleUnsupportedStatement
+}
+
+func (unsupportedRoutineRule) CheckStatement(ctx Context, stmt ast.Node) []Finding {
+	switch node := stmt.(type) {
+	case *ast.RawSQLNode:
+		keyword, keywordOffset := firstKeyword(node.SQL)
+		if keyword == "" {
+			keyword = "raw SQL"
+		}
+		return []Finding{ctx.unsupportedModeledSQLFinding(keyword, keywordOffset)}
+	case *ast.CreateFunctionNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE FUNCTION", 0)}
+	case *ast.CreateTriggerNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE TRIGGER", 0)}
+	default:
+		return nil
+	}
+}
+
+func (c Context) unsupportedModeledSQLFinding(label string, offset int) Finding {
+	if offset < 0 {
+		offset = 0
+	}
+	line, column := lineColumn(c.Source.SQL, c.statement.offset+offset)
+	return Finding{
+		Rule:      RuleUnsupportedStatement,
+		Title:     "Unsupported SQL statement",
+		Severity:  SeverityError,
+		File:      c.Source.Name,
+		Line:      line,
+		Column:    column,
+		Dialect:   c.Dialect,
+		Message:   fmt.Sprintf("ptah sql lint does not model %s statements yet", label),
+		Rationale: "This statement uses a routine or raw SQL sub-language that the SQL linter does not analyze yet.",
+	}
+}
+
+type createIndexCapabilityRule struct{}
+
+func (createIndexCapabilityRule) ID() string {
+	return RuleUnsupportedCapability
+}
+
+func (createIndexCapabilityRule) CheckStatement(ctx Context, stmt ast.Node) []Finding {
+	index, ok := stmt.(*ast.IndexNode)
+	if !ok {
+		return nil
+	}
+	if !index.Concurrently || ctx.Capabilities.Has(capability.CreateIndexConcurrently) {
+		return nil
+	}
+	line, column := ctx.LineColumn(index.Name)
+	return []Finding{{
+		Rule:      RuleUnsupportedCapability,
+		Title:     "Statement requires unsupported capability",
+		Severity:  SeverityError,
+		File:      ctx.Source.Name,
+		Line:      line,
+		Column:    column,
+		Dialect:   ctx.Dialect,
+		Message:   "CREATE INDEX CONCURRENTLY requires the create_index_concurrently capability",
+		Rationale: "Capability-aware lint rules catch SQL that is valid for one PostgreSQL-family target but not for another.",
+	}}
+}
+
+func (c Context) LineColumn(needle string) (line int, column int) {
+	pos := c.statement.offset
+	if idx := strings.Index(c.statement.sql, needle); idx >= 0 {
+		pos += idx
+	}
+	return lineColumn(c.Source.SQL, pos)
+}
+
+func lineColumn(input string, pos int) (line int, column int) {
+	if pos < 0 {
+		pos = 0
+	}
+	line = 1
+	column = 1
+	for i, r := range input {
+		if i >= pos {
+			break
+		}
+		if r == '\n' {
+			line++
+			column = 1
+			continue
+		}
+		column++
+	}
+	return line, column
+}

--- a/core/sqllint/lint_test.go
+++ b/core/sqllint/lint_test.go
@@ -1,0 +1,179 @@
+package sqllint
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
+)
+
+func TestLintSource_TableWithoutPrimaryKey(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "schema.sql",
+		SQL:  "CREATE TABLE users (email TEXT NOT NULL);",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleTableWithoutPrimaryKey)
+	c.Assert(findings[0].Severity, qt.Equals, SeverityWarning)
+	c.Assert(findings[0].File, qt.Equals, "schema.sql")
+}
+
+func TestLintSource_TablePrimaryKeyPasses(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "schema.sql",
+		SQL:  "CREATE TABLE users (id BIGINT PRIMARY KEY, email TEXT NOT NULL);",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0)
+}
+
+func TestLintSource_DisabledRules(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "schema.sql",
+		SQL:  "CREATE TABLE users (email TEXT NOT NULL);",
+	}, Options{
+		Dialect:       platform.Postgres,
+		DisabledRules: []string{RuleTableWithoutPrimaryKey},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0)
+}
+
+func TestLintSource_UnsupportedStatementIsExplicit(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "query.sql",
+		SQL:  "SELECT 1;",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+	c.Assert(findings[0].Message, qt.Contains, "SELECT")
+}
+
+func TestLintSource_UnsupportedStatementLocationSkipsLeadingComments(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "query.sql",
+		SQL:  "-- heading comment\nSELECT 1;",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Line, qt.Equals, 2)
+	c.Assert(findings[0].Column, qt.Equals, 1)
+}
+
+func TestLintSource_UnsupportedParserErrorIsExplicit(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "policy.sql",
+		SQL:  "CREATE POLICY p ON users USING (true);",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+	c.Assert(findings[0].Title, qt.Equals, "Unsupported SQL statement")
+}
+
+func TestLintSource_RawSQLNodesAreExplicitUnsupportedFindings(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "create function",
+			sql:  "CREATE FUNCTION f() RETURNS void AS $$ BEGIN RAISE NOTICE 'x'; END $$ LANGUAGE plpgsql;",
+		},
+		{
+			name: "create procedure",
+			sql:  "CREATE PROCEDURE p() LANGUAGE SQL AS $$ SELECT 1 $$;",
+		},
+		{
+			name: "create trigger execute function",
+			sql:  "CREATE TRIGGER trg AFTER INSERT ON users FOR EACH ROW EXECUTE FUNCTION audit_user();",
+		},
+		{
+			name: "do block",
+			sql:  "DO $$ BEGIN RAISE NOTICE 'x'; END $$;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			findings, err := LintSource(Source{
+				Name: "raw.sql",
+				SQL:  tt.sql,
+			}, Options{Dialect: platform.Postgres})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(findings, qt.HasLen, 1)
+			c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+			c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+			c.Assert(findings[0].Line, qt.Equals, 1)
+			c.Assert(findings[0].Column, qt.Equals, 1)
+		})
+	}
+}
+
+func TestLintSource_UnsupportedStatementDoesNotMaskLaterDDL(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "mixed.sql",
+		SQL: `CREATE POLICY p ON users USING (true);
+CREATE TABLE audit_log (message TEXT NOT NULL);`,
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 2)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[1].Rule, qt.Equals, RuleTableWithoutPrimaryKey)
+	c.Assert(findings[1].Line, qt.Equals, 2)
+}
+
+func TestLintSource_CapabilityAwareCreateIndexConcurrently(t *testing.T) {
+	c := qt.New(t)
+	source := Source{
+		Name: "index.sql",
+		SQL:  "CREATE INDEX CONCURRENTLY idx_users_email ON users (email);",
+	}
+
+	postgresFindings, err := LintSource(source, Options{
+		Dialect:      platform.Postgres,
+		Capabilities: capability.Postgres16(),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(postgresFindings, qt.HasLen, 0)
+
+	cockroachFindings, err := LintSource(source, Options{
+		Dialect:      platform.CockroachDB,
+		Capabilities: capability.CockroachDB23(),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(cockroachFindings, qt.HasLen, 1)
+	c.Assert(cockroachFindings[0].Rule, qt.Equals, RuleUnsupportedCapability)
+	c.Assert(cockroachFindings[0].Severity, qt.Equals, SeverityError)
+}

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -19,6 +19,7 @@ Ptah treats CLI exit codes as a public scripting contract.
 | `ptah compare` | Diff printed, or no diff. | Non-empty diff when `--exit-code` is set. | Usage error, connection failure, parse failure, or diff generation failure. |
 | `ptah drift` | No drift that meets `--severity`, or `--exit-code=false`. | Drift meets `--severity` while `--exit-code=true`. | Usage error, connection failure, parse failure, or report error. |
 | `ptah lint` | No findings above `--fail-on`, or `--fail-on=none`. | Findings meet `--fail-on`. | Usage error, invalid config, unreadable migration directory, or report error. |
+| `ptah sql lint` | No SQL lint findings with `error` severity. | One or more SQL lint findings with `error` severity. | Usage error, unreadable SQL input, unsupported dialect, or report error. |
 | `ptah migrate` | Migration SQL generated, or no schema changes. | Not used. | Usage error, connection failure, parse failure, safety check failure, or render error. |
 | `ptah migrate generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
 | `ptah migrate new` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |


### PR DESCRIPTION
## Summary
- add reusable core/sqllint engine for standalone SQL sources with parser/AST/capability-backed rules
- add ptah sql lint for files and --stdin with text/json output, --dialect, --version, and --disable
- report unsupported/non-modeled SQL explicitly as SQL002, including raw routine/DO/trigger forms
- parse CREATE [UNIQUE] INDEX CONCURRENTLY [IF NOT EXISTS] so capability lint can reason over IndexNode.Concurrently

## Validation
- gopls diagnostics: no diagnostics
- go test ./core/sqllint ./cmd/sql ./core/parser ./cmd/root -count=1
- go test ./... -count=1
- go tool qtlint ./...
- golangci-lint run ./...
- manual smoke: ptah sql lint reports SQL002 after leading comments and reports CREATE FUNCTION as SQL002 instead of clean

Closes #309