### PR TITLE
Introduce dialect-aware parser options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The core package contains all fundamental components for parsing, transforming, 
 - **`parser/`** - SQL DDL token-to-AST parser
   - Converts SQL DDL tokens into Abstract Syntax Tree nodes
   - Supports CREATE TABLE, ALTER TABLE, CREATE INDEX, CREATE TYPE statements
+  - Accepts optional dialect and capability settings for syntax that cannot be parsed correctly in generic best-effort mode
   - Provides comprehensive error handling and position information
 
 - **`lexer/`** - SQL tokenization and lexical analysis

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -86,6 +86,32 @@ func main() {
 }
 ```
 
+### Dialect-Aware Parsing
+
+`parser.NewParser(sql)` keeps the compatibility-oriented best-effort behavior
+used by existing callers. When the target SQL family is known, pass an explicit
+dialect:
+
+```go
+p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+```
+
+Capabilities are separate from dialect identity. Pass them only when the caller
+knows the concrete server feature set:
+
+```go
+p := parser.NewParser(
+    sql,
+    parser.WithDialect(platform.Postgres),
+    parser.WithCapabilities(capability.Postgres13()),
+)
+```
+
+Dialect-specific routine bodies are handled behind parser strategies. Generic
+mode stays best-effort; dialect mode can use a routine boundary detector that is
+specific to the selected SQL family without turning the generic DDL parser into
+a stored-procedure sub-language parser.
+
 ### Parsing Multiple Statements
 
 ```go

--- a/core/parser/options.go
+++ b/core/parser/options.go
@@ -1,0 +1,43 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
+)
+
+// Option configures parser behavior.
+type Option func(*Parser)
+
+// WithDialect selects the SQL dialect grammar for syntax that cannot be
+// interpreted correctly by the compatibility parser alone.
+func WithDialect(dialect string) Option {
+	return func(p *Parser) {
+		normalized := platform.NormalizeDialect(dialect)
+		if normalized == "" {
+			normalized = strings.ToLower(strings.TrimSpace(dialect))
+		}
+		p.dialect = normalized
+	}
+}
+
+// WithCapabilities sets the target feature set used by dialect-specific
+// parser decisions. The set is cloned so callers can reuse or mutate their
+// original value safely.
+func WithCapabilities(capabilities capability.Capabilities) Option {
+	return func(p *Parser) {
+		p.capabilities = capabilities.Clone()
+	}
+}
+
+// Dialect returns the normalized dialect selected for this parser. An empty
+// string means compatibility-oriented best-effort mode.
+func (p *Parser) Dialect() string {
+	return p.dialect
+}
+
+// Capabilities returns an independent copy of the parser capability set.
+func (p *Parser) Capabilities() capability.Capabilities {
+	return p.capabilities.Clone()
+}

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/sqlutil"
 )
 
@@ -25,6 +26,9 @@ type Parser struct {
 	previous  lexer.Token
 	startTime time.Time
 	timeout   time.Duration
+
+	dialect      string
+	capabilities capability.Capabilities
 }
 
 // NewParser creates a new parser with the given SQL input.
@@ -34,7 +38,7 @@ type Parser struct {
 // Example:
 //
 //	parser := NewParser("CREATE TABLE users (id INTEGER PRIMARY KEY);")
-func NewParser(input string) *Parser {
+func NewParser(input string, opts ...Option) *Parser {
 	normalized := sqlutil.NormalizeClientDelimiters(input)
 	l := lexer.NewLexer(normalized)
 	p := &Parser{
@@ -42,6 +46,9 @@ func NewParser(input string) *Parser {
 		input:     normalized,
 		startTime: time.Now(),
 		timeout:   30 * time.Second, // 30 second timeout to prevent infinite loops
+	}
+	for _, opt := range opts {
+		opt(p)
 	}
 	p.advance() // Load the first token
 	return p
@@ -212,13 +219,14 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 }
 
 func (p *Parser) parseCreateRoutine(target string, statementStart int) (ast.Node, error) {
-	if target == "PROCEDURE" {
-		return p.parseCreateRawRoutineStatement(statementStart)
-	}
-	return p.parseCreateFunction(statementStart)
+	return p.routineParser().parseCreateRoutine(p, target, statementStart)
 }
 
 func (p *Parser) parseCreateDefinerRoutine(statementStart int) (ast.Node, error) {
+	return p.routineParser().parseCreateDefinerRoutine(p, statementStart)
+}
+
+func (p *Parser) parseCreateDefinerRoutineBestEffort(statementStart int) (ast.Node, error) {
 	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
 		if err := p.checkTimeout(); err != nil {
 			return nil, err
@@ -352,10 +360,10 @@ func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, er
 		return p.parseCreateOrReplaceView()
 	}
 	if p.current.MatchIdentifierValue("FUNCTION") {
-		return p.parseCreateFunction(statementStart)
+		return p.parseCreateRoutine("FUNCTION", statementStart)
 	}
 	if p.current.MatchIdentifierValue("PROCEDURE") {
-		return p.parseCreateRawRoutineStatement(statementStart)
+		return p.parseCreateRoutine("PROCEDURE", statementStart)
 	}
 	if p.current.MatchIdentifierValue("TRIGGER") {
 		node, err := p.parseCreateTrigger(statementStart)
@@ -502,8 +510,8 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	}
 	p.skipWhitespace()
 
-	if p.isSQLServerBracketedFunctionNameStart() {
-		return p.parseCreateRawSQLServerFunction(statementStart)
+	if p.isSQLServerBracketedRoutineNameStart() {
+		return p.parseCreateRawSQLServerRoutine(statementStart)
 	}
 
 	functionName, err := p.parseQualifiedIdentifier("function name")
@@ -528,21 +536,21 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	return function, nil
 }
 
-func (p *Parser) isSQLServerBracketedFunctionNameStart() bool {
+func (p *Parser) isSQLServerBracketedRoutineNameStart() bool {
 	// Bracketed function names enter T-SQL's routine-body sub-language. Until
 	// #323 adds a dialect-aware body parser, preserve the statement as raw SQL.
 	return p.current.MatchOperatorValue("[")
 }
 
-func (p *Parser) parseCreateRawSQLServerFunction(statementStart int) (ast.Node, error) {
-	sql, err := p.collectRawSQLServerFunction(statementStart)
+func (p *Parser) parseCreateRawSQLServerRoutine(statementStart int) (ast.Node, error) {
+	sql, err := p.collectRawSQLServerRoutine(statementStart)
 	if err != nil {
 		return nil, err
 	}
 	return ast.NewRawSQL(sql), nil
 }
 
-func (p *Parser) collectRawSQLServerFunction(statementStart int) (string, error) {
+func (p *Parser) collectRawSQLServerRoutine(statementStart int) (string, error) {
 	blockDepth := 0
 	caseDepth := 0
 	for !p.isAtEnd() {
@@ -560,9 +568,14 @@ func (p *Parser) collectRawSQLServerFunction(statementStart int) (string, error)
 			p.advance()
 			return sql, nil
 		}
+		if p.current.MatchIdentifierValue("GO") && blockDepth == 0 {
+			sql := p.rawStatementFragment(statementStart, p.current.Start)
+			p.advance()
+			return sql, nil
+		}
 
 		if p.current.Type == lexer.TokenIdentifier {
-			if complete := trackSQLServerRawFunctionKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth); complete {
+			if complete := trackSQLServerRawRoutineKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth); complete {
 				end := p.current.End
 				p.advance()
 				return p.rawStatementFragment(statementStart, end), nil
@@ -572,7 +585,7 @@ func (p *Parser) collectRawSQLServerFunction(statementStart int) (string, error)
 	}
 
 	if blockDepth > 0 {
-		return "", fmt.Errorf("unterminated CREATE FUNCTION body at position %d", p.current.Start)
+		return "", fmt.Errorf("unterminated CREATE routine body at position %d", p.current.Start)
 	}
 	return p.rawStatementFragment(statementStart, p.previous.End), nil
 }
@@ -592,7 +605,7 @@ func (p *Parser) skipSQLServerBracketedIdentifier() {
 	}
 }
 
-func trackSQLServerRawFunctionKeyword(keyword string, blockDepth, caseDepth *int) bool {
+func trackSQLServerRawRoutineKeyword(keyword string, blockDepth, caseDepth *int) bool {
 	switch keyword {
 	case "BEGIN":
 		(*blockDepth)++

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/parser"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 )
 
@@ -15,6 +17,29 @@ func TestNewParser(t *testing.T) {
 
 	p := parser.NewParser("CREATE TABLE users (id INTEGER);")
 	c.Assert(p, qt.IsNotNil)
+	c.Assert(p.Dialect(), qt.Equals, "")
+	c.Assert(p.Capabilities(), qt.IsNil)
+}
+
+func TestNewParser_WithDialectAndCapabilities(t *testing.T) {
+	c := qt.New(t)
+
+	caps := capability.Postgres13()
+	p := parser.NewParser(
+		"CREATE TABLE users (id INTEGER);",
+		parser.WithDialect("postgresql"),
+		parser.WithCapabilities(caps),
+	)
+
+	c.Assert(p.Dialect(), qt.Equals, platform.Postgres)
+	c.Assert(p.Capabilities().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
+
+	caps[capability.CreateOrReplaceTrigger] = true
+	c.Assert(p.Capabilities().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
+
+	parserCaps := p.Capabilities()
+	parserCaps[capability.CreateOrReplaceTrigger] = true
+	c.Assert(p.Capabilities().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
 }
 
 func TestParser_ParseCreateTable_Basic(t *testing.T) {
@@ -998,6 +1023,54 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(raw.SQL, qt.Contains, "SELECT @a AS [END]]value];")
 	c.Assert(raw.SQL, qt.Contains, "RETURN\nEND")
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+}
+
+func TestParser_ParseSQLServerDialectUnbracketedFunctionAsRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION dbo.f7 (@a int) RETURNS int AS BEGIN
+  RETURN @a
+	END
+CREATE TABLE after_fn (id int);`
+	_, err := parser.NewParser(sql).Parse()
+	c.Assert(err, qt.IsNotNil)
+
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION dbo.f7")
+	c.Assert(raw.SQL, qt.Contains, "RETURN @a")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerDialectProcedureStopsAtGoBatch(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE dbo.p1 AS
+  SELECT 1
+GO
+CREATE TABLE after_proc (id int);`
+	statements, err := parser.NewParser(sql, parser.WithDialect("mssql")).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(raw.SQL, qt.Contains, "CREATE PROCEDURE dbo.p1")
+	c.Assert(raw.SQL, qt.Contains, "SELECT 1")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "GO")
+	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
 }
 
 func TestParser_ParseCreateProcedureAsRawSQL(t *testing.T) {

--- a/core/parser/routine.go
+++ b/core/parser/routine.go
@@ -1,0 +1,61 @@
+package parser
+
+import (
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+)
+
+type routineParser interface {
+	parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error)
+	parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error)
+}
+
+func (p *Parser) routineParser() routineParser {
+	switch p.dialect {
+	case platform.MySQL, platform.MariaDB:
+		return mysqlFamilyRoutineParser{}
+	case platform.SQLServer:
+		return sqlServerRoutineParser{}
+	default:
+		return compatibilityRoutineParser{}
+	}
+}
+
+type compatibilityRoutineParser struct{}
+
+func (compatibilityRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
+	if target == "PROCEDURE" {
+		return p.parseCreateRawRoutineStatement(statementStart)
+	}
+	return p.parseCreateFunction(statementStart)
+}
+
+func (compatibilityRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
+	return p.parseCreateDefinerRoutineBestEffort(statementStart)
+}
+
+type mysqlFamilyRoutineParser struct{}
+
+func (mysqlFamilyRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
+	if target == "PROCEDURE" {
+		return p.parseCreateRawRoutineStatement(statementStart)
+	}
+	return p.parseCreateFunction(statementStart)
+}
+
+func (mysqlFamilyRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
+	return p.parseCreateDefinerRoutineBestEffort(statementStart)
+}
+
+type sqlServerRoutineParser struct{}
+
+func (sqlServerRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
+	if target == "FUNCTION" || target == "PROCEDURE" {
+		return p.parseCreateRawSQLServerRoutine(statementStart)
+	}
+	return compatibilityRoutineParser{}.parseCreateRoutine(p, target, statementStart)
+}
+
+func (sqlServerRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
+	return compatibilityRoutineParser{}.parseCreateDefinerRoutine(p, statementStart)
+}

--- a/core/platform/constants.go
+++ b/core/platform/constants.go
@@ -10,6 +10,7 @@ const (
 	MariaDB     = "mariadb"
 	ClickHouse  = "clickhouse"
 	SQLite      = "sqlite"
+	SQLServer   = "sqlserver"
 	CockroachDB = "cockroachdb"
 	YugabyteDB  = "yugabytedb"
 	Spanner     = "spanner"
@@ -27,6 +28,8 @@ func NormalizeDialect(dialect string) string {
 		return ClickHouse
 	case "sqlite", "sqlite3":
 		return SQLite
+	case "mssql", "sqlserver", "sql-server", "sql_server", "tsql":
+		return SQLServer
 	case "cockroach", "cockroachdb", "crdb":
 		return CockroachDB
 	case "yugabyte", "yugabytedb", "ysql":

--- a/core/platform/constants_test.go
+++ b/core/platform/constants_test.go
@@ -38,13 +38,21 @@ func TestNormalizeDialect_SQLiteAliases(t *testing.T) {
 	}
 }
 
+func TestNormalizeDialect_SQLServerAliases(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{"mssql", "sqlserver", "sql-server", "sql_server", "tsql", " SQLServer "} {
+		c.Assert(platform.NormalizeDialect(dialect), qt.Equals, platform.SQLServer)
+	}
+}
+
 func TestIsPostgresFamily(t *testing.T) {
 	c := qt.New(t)
 
 	for _, dialect := range []string{"postgres", "pgx", "cockroachdb", "yugabytedb", "spanner"} {
 		c.Assert(platform.IsPostgresFamily(dialect), qt.IsTrue, qt.Commentf("dialect %q", dialect))
 	}
-	for _, dialect := range []string{"mysql", "mariadb", "clickhouse", "sqlite", "oracle"} {
+	for _, dialect := range []string{"mysql", "mariadb", "clickhouse", "sqlite", "sqlserver", "oracle"} {
 		c.Assert(platform.IsPostgresFamily(dialect), qt.IsFalse, qt.Commentf("dialect %q", dialect))
 	}
 }

--- a/core/platform/doc.go
+++ b/core/platform/doc.go
@@ -12,6 +12,7 @@
 //   - MySQL: MySQL database platform identifier
 //   - MariaDB: MariaDB database platform identifier
 //   - ClickHouse: ClickHouse database platform identifier
+//   - SQLServer: SQL Server parser dialect identifier
 //   - CockroachDB: CockroachDB PostgreSQL-family platform identifier
 //   - YugabyteDB: YugabyteDB YSQL PostgreSQL-family platform identifier
 //   - Spanner: Cloud Spanner PostgreSQL-interface platform identifier
@@ -21,6 +22,7 @@
 // Platform constants are used throughout the Ptah system for:
 //
 //   - Dialect-specific SQL generation
+//   - Dialect-aware SQL parsing
 //   - Database connection management
 //   - Migration planning and execution
 //   - Schema comparison and validation


### PR DESCRIPTION
## Summary

- adds parser options for explicit dialect and target capabilities without breaking existing parser.NewParser(sql) callers
- introduces parser routine strategies so compatibility mode, MySQL/MariaDB, and SQL Server can separate routine-boundary decisions
- adds SQL Server dialect normalization aliases for parser selection
- documents the Dialect + Capabilities parser contract

Refs #318.

## Notes

This is an architectural slice for #318, not the full umbrella closure. It establishes the public option surface and routine strategy boundary needed for the later MySQL/MariaDB, PostgreSQL, and SQL Server routine sub-language tracks.

## Validation

- gopls diagnostics: no diagnostics
- go test ./core/parser ./core/platform -count=1
- go test ./... -count=1
- go tool qtlint ./...
- golangci-lint run ./...
- git diff --check
