### PR TITLE
Add typed opaque routine AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The core package contains all fundamental components for parsing, transforming, 
   - Converts SQL DDL tokens into Abstract Syntax Tree nodes
   - Supports CREATE TABLE, ALTER TABLE, CREATE INDEX, CREATE TYPE statements
   - Accepts optional dialect and capability settings for syntax that cannot be parsed correctly in generic best-effort mode
+  - Preserves dialect-aware routine boundaries with typed opaque AST nodes until routine sub-language parsers exist
   - Provides comprehensive error handling and position information
 
 - **`lexer/`** - SQL tokenization and lexical analysis

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -2302,6 +2302,44 @@ func (n *RawSQLNode) Accept(visitor Visitor) error {
 	return visitor.VisitRawSQL(n)
 }
 
+// RoutineKind identifies which CREATE routine form an opaque routine wraps.
+type RoutineKind string
+
+const (
+	RoutineKindFunction  RoutineKind = "function"
+	RoutineKindProcedure RoutineKind = "procedure"
+)
+
+// OpaqueRoutineNode wraps a dialect-specific routine whose outer boundary is
+// understood but whose body is intentionally preserved verbatim until a
+// dialect-specific routine-body AST exists.
+type OpaqueRoutineNode struct {
+	// SQL is the complete executable routine statement without client batch
+	// separators such as GO or DELIMITER markers.
+	SQL string
+	// Dialect is the normalized SQL dialect that selected this opaque routine
+	// path, for example mysql, mariadb, or sqlserver.
+	Dialect string
+	// Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+	Kind RoutineKind
+}
+
+// NewOpaqueRoutine creates a typed opaque routine wrapper.
+func NewOpaqueRoutine(sql, dialect string, kind RoutineKind) *OpaqueRoutineNode {
+	return &OpaqueRoutineNode{
+		SQL:     strings.TrimSpace(sql),
+		Dialect: dialect,
+		Kind:    kind,
+	}
+}
+
+// Accept renders opaque routines through the raw SQL visitor contract while
+// keeping the AST node type available to parser consumers.
+func (n *OpaqueRoutineNode) Accept(visitor Visitor) error {
+	raw := RawSQLNode{SQL: n.SQL}
+	return visitor.VisitRawSQL(&raw)
+}
+
 // Accept implements the Node interface for StatementList.
 //
 // This method visits each statement in the list in order. If any statement

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -662,6 +662,31 @@ func TestCreateFunctionNode_Accept(t *testing.T) {
 	c.Assert(visitor.VisitedNodes[0], qt.Equals, "CreateFunction:test_function")
 }
 
+func TestOpaqueRoutineNode_AcceptDelegatesToRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewOpaqueRoutine(" CREATE PROCEDURE p() SELECT 1; ", "mysql", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(routine.SQL, qt.Equals, "CREATE PROCEDURE p() SELECT 1;")
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() SELECT 1;"})
+}
+
+func TestOpaqueRoutineNode_AcceptPropagatesRawSQLError(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewOpaqueRoutine("CREATE PROCEDURE p() SELECT 1;", "mysql", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{ReturnError: true}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() SELECT 1;"})
+}
+
 func TestNewCreatePolicy(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -110,7 +110,11 @@ p := parser.NewParser(
 Dialect-specific routine bodies are handled behind parser strategies. Generic
 mode stays best-effort; dialect mode can use a routine boundary detector that is
 specific to the selected SQL family without turning the generic DDL parser into
-a stored-procedure sub-language parser.
+a stored-procedure sub-language parser. When a dialect-aware routine boundary is
+known but the body sub-language is not structured yet, the parser returns an
+`ast.OpaqueRoutineNode`: renderers emit its SQL through the raw-SQL visitor
+contract, while parser consumers can still distinguish it from arbitrary raw
+SQL.
 
 ### Parsing Multiple Statements
 

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -550,6 +550,14 @@ func (p *Parser) parseCreateRawSQLServerRoutine(statementStart int) (ast.Node, e
 	return ast.NewRawSQL(sql), nil
 }
 
+func (p *Parser) parseCreateOpaqueSQLServerRoutine(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
+	sql, err := p.collectRawSQLServerRoutine(statementStart)
+	if err != nil {
+		return nil, err
+	}
+	return ast.NewOpaqueRoutine(sql, p.dialect, kind), nil
+}
+
 func (p *Parser) collectRawSQLServerRoutine(statementStart int) (string, error) {
 	blockDepth := 0
 	caseDepth := 0
@@ -628,6 +636,14 @@ func (p *Parser) parseCreateRawRoutineStatement(statementStart int) (ast.Node, e
 		return nil, err
 	}
 	return ast.NewRawSQL(sql), nil
+}
+
+func (p *Parser) parseCreateOpaqueRoutineStatement(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
+	sql, err := p.collectRawRoutineStatement(statementStart)
+	if err != nil {
+		return nil, err
+	}
+	return ast.NewOpaqueRoutine(sql, p.dialect, kind), nil
 }
 
 func (p *Parser) collectRawRoutineStatement(statementStart int) (string, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -834,6 +834,31 @@ DELIMITER ;`
 	c.Assert(raw.SQL, qt.Contains, "RETURN x+2;")
 }
 
+func TestParser_ParseMySQLDialectCompoundFunctionAsOpaqueRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DELIMITER |
+CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC
+BEGIN
+       INSERT INTO t1 VALUES (x);
+       RETURN x+2;
+END|
+DELIMITER ;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.SQL, qt.Contains, "CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC")
+	c.Assert(routine.SQL, qt.Contains, "INSERT INTO t1 VALUES (x);")
+	c.Assert(routine.SQL, qt.Contains, "RETURN x+2;")
+}
+
 func TestParser_ParseMySQLCreateFunctionWithNestedCompoundBody(t *testing.T) {
 	c := qt.New(t)
 
@@ -1025,7 +1050,7 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
 }
 
-func TestParser_ParseSQLServerDialectUnbracketedFunctionAsRawSQL(t *testing.T) {
+func TestParser_ParseSQLServerDialectUnbracketedFunctionAsOpaqueRoutine(t *testing.T) {
 	c := qt.New(t)
 
 	sql := `CREATE FUNCTION dbo.f7 (@a int) RETURNS int AS BEGIN
@@ -1039,11 +1064,13 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 2)
 
-	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(raw.SQL, qt.Contains, "CREATE FUNCTION dbo.f7")
-	c.Assert(raw.SQL, qt.Contains, "RETURN @a")
-	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+	c.Assert(routine.Dialect, qt.Equals, platform.SQLServer)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.SQL, qt.Contains, "CREATE FUNCTION dbo.f7")
+	c.Assert(routine.SQL, qt.Contains, "RETURN @a")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
 
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
@@ -1061,12 +1088,14 @@ CREATE TABLE after_proc (id int);`
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 2)
 
-	raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(raw.SQL, qt.Contains, "CREATE PROCEDURE dbo.p1")
-	c.Assert(raw.SQL, qt.Contains, "SELECT 1")
-	c.Assert(raw.SQL, qt.Not(qt.Contains), "GO")
-	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
+	c.Assert(routine.Dialect, qt.Equals, platform.SQLServer)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.SQL, qt.Contains, "CREATE PROCEDURE dbo.p1")
+	c.Assert(routine.SQL, qt.Contains, "SELECT 1")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "GO")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
 
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
@@ -1131,6 +1160,40 @@ CALL proc();`
 	c.Assert(raw.SQL, qt.Contains, "IF(@rows != 1, 's', '')")
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "CALL proc")
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "-- end --")
+}
+
+func TestParser_ParseMySQLDialectDefinerProcedureAsOpaqueRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `-- atlas:delimiter \n-- end --\n
+
+CREATE DEFINER='boring' PROCEDURE proc ()
+    COMMENT 'ATLAS_DELIMITER'
+    SQL SECURITY INVOKER
+    NOT DETERMINISTIC
+    MODIFIES SQL DATA
+BEGIN
+    SELECT CONCAT('Enabled ', @rows := ROW_COUNT(), ' background thread', IF(@rows != 1, 's', '')) AS summary;
+END
+
+-- end --
+
+CALL proc();`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.SQL, qt.Contains, "CREATE DEFINER='boring' PROCEDURE proc ()")
+	c.Assert(routine.SQL, qt.Contains, "SQL SECURITY INVOKER")
+	c.Assert(routine.SQL, qt.Contains, "IF(@rows != 1, 's', '')")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CALL proc")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "-- end --")
 }
 
 func TestParser_ParseCreateTrigger(t *testing.T) {

--- a/core/parser/routine.go
+++ b/core/parser/routine.go
@@ -1,7 +1,10 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
 	"github.com/stokaro/ptah/core/platform"
 )
 
@@ -38,20 +41,45 @@ type mysqlFamilyRoutineParser struct{}
 
 func (mysqlFamilyRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
 	if target == "PROCEDURE" {
-		return p.parseCreateRawRoutineStatement(statementStart)
+		return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindProcedure)
 	}
-	return p.parseCreateFunction(statementStart)
+	node, err := p.parseCreateFunction(statementStart)
+	if err != nil {
+		return nil, err
+	}
+	if raw, ok := node.(*ast.RawSQLNode); ok {
+		return ast.NewOpaqueRoutine(raw.SQL, p.dialect, ast.RoutineKindFunction), nil
+	}
+	return node, nil
 }
 
 func (mysqlFamilyRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
-	return p.parseCreateDefinerRoutineBestEffort(statementStart)
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return nil, err
+		}
+		switch {
+		case p.current.MatchIdentifierValue("FUNCTION"):
+			return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindFunction)
+		case p.current.MatchIdentifierValue("PROCEDURE"):
+			return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindProcedure)
+		case p.current.Type == lexer.TokenSemicolon:
+			return nil, fmt.Errorf("unsupported CREATE DEFINER target at position %d", p.current.Start)
+		default:
+			p.advance()
+		}
+	}
+	return nil, fmt.Errorf("unsupported CREATE DEFINER target at position %d", p.current.Start)
 }
 
 type sqlServerRoutineParser struct{}
 
 func (sqlServerRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
-	if target == "FUNCTION" || target == "PROCEDURE" {
-		return p.parseCreateRawSQLServerRoutine(statementStart)
+	switch target {
+	case "FUNCTION":
+		return p.parseCreateOpaqueSQLServerRoutine(statementStart, ast.RoutineKindFunction)
+	case "PROCEDURE":
+		return p.parseCreateOpaqueSQLServerRoutine(statementStart, ast.RoutineKindProcedure)
 	}
 	return compatibilityRoutineParser{}.parseCreateRoutine(p, target, statementStart)
 }

--- a/core/sqllint/lint.go
+++ b/core/sqllint/lint.go
@@ -141,7 +141,8 @@ func unsupportedStatementFinding(source Source, statement sourceStatement, opts 
 }
 
 func lintParsedStatement(source Source, statement sourceStatement, opts Options) ([]Finding, error) {
-	stmtList, err := parser.NewParser(statementParserSQL(statement.sql)).Parse()
+	caps := effectiveCapabilities(opts)
+	stmtList, err := parser.NewParser(statementParserSQL(statement.sql), parserOptions(opts, caps)...).Parse()
 	if err != nil {
 		return []Finding{parseErrorFinding(source, statement, opts, err)}, nil
 	}
@@ -151,7 +152,7 @@ func lintParsedStatement(source Source, statement sourceStatement, opts Options)
 		statement:    statement,
 		Dialect:      opts.Dialect,
 		Version:      opts.Version,
-		Capabilities: effectiveCapabilities(opts),
+		Capabilities: caps,
 	}
 	findings := make([]Finding, 0)
 	for _, stmt := range stmtList.Statements {
@@ -163,6 +164,17 @@ func lintParsedStatement(source Source, statement sourceStatement, opts Options)
 		}
 	}
 	return findings, nil
+}
+
+func parserOptions(opts Options, caps capability.Capabilities) []parser.Option {
+	var parseOpts []parser.Option
+	if opts.Dialect != "" {
+		parseOpts = append(parseOpts, parser.WithDialect(opts.Dialect))
+	}
+	if caps != nil {
+		parseOpts = append(parseOpts, parser.WithCapabilities(caps))
+	}
+	return parseOpts
 }
 
 func statementParserSQL(sql string) string {
@@ -322,6 +334,8 @@ func (unsupportedRoutineRule) CheckStatement(ctx Context, stmt ast.Node) []Findi
 			keyword = "raw SQL"
 		}
 		return []Finding{ctx.unsupportedModeledSQLFinding(keyword, keywordOffset)}
+	case *ast.OpaqueRoutineNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.CreateFunctionNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE FUNCTION", 0)}
 	case *ast.CreateTriggerNode:

--- a/core/sqllint/lint_test.go
+++ b/core/sqllint/lint_test.go
@@ -138,6 +138,26 @@ func TestLintSource_RawSQLNodesAreExplicitUnsupportedFindings(t *testing.T) {
 	}
 }
 
+func TestLintSource_OpaqueRoutineNodesAreExplicitUnsupportedFindings(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "routine.sql",
+		SQL: `DELIMITER //
+CREATE PROCEDURE p1()
+BEGIN
+  SELECT 1;
+END//
+DELIMITER ;`,
+	}, Options{Dialect: platform.MySQL})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+	c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+}
+
 func TestLintSource_UnsupportedStatementDoesNotMaskLaterDDL(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## What

- Add `ast.OpaqueRoutineNode` with a routine kind and normalized dialect metadata.
- Return typed opaque routine nodes for dialect-aware MySQL/MariaDB and SQL Server routine boundary preservation.
- Keep renderer compatibility by delegating opaque routine rendering through the existing raw-SQL visitor contract.
- Pass SQL lint dialect/capability options into the parser so opaque routines become explicit unsupported routine findings instead of generic raw SQL.
- Document the routine boundary contract in the parser docs and top-level README.

## Why

This is the next architecture slice for #318. Dialect-aware parsing should not pretend routine bodies are fully structured before routine sub-language parsers exist, but parser consumers still need to distinguish intentionally preserved routine boundaries from arbitrary raw SQL.

Refs #318.

## Validation

- gopls diagnostics on changed Go files
- `go test ./core/ast ./core/parser ./core/sqllint -count=1`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1`
- `git diff --check`
