### PR TITLE
Add MySQL routine body parser slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The core package contains all fundamental components for parsing, transforming, 
   - Converts SQL DDL tokens into Abstract Syntax Tree nodes
   - Supports CREATE TABLE, ALTER TABLE, CREATE INDEX, CREATE TYPE statements
   - Accepts optional dialect and capability settings for syntax that cannot be parsed correctly in generic best-effort mode
-  - Preserves dialect-aware routine boundaries with typed opaque AST nodes until routine sub-language parsers exist
+  - Parses MySQL/MariaDB routine headers and routine-body statement boundaries in dialect-aware mode
+  - Preserves other dialect-aware routine boundaries with typed opaque AST nodes until routine sub-language parsers exist
   - Provides comprehensive error handling and position information
 
 - **`lexer/`** - SQL tokenization and lexical analysis

--- a/core/ast/routines.go
+++ b/core/ast/routines.go
@@ -1,0 +1,98 @@
+package ast
+
+import (
+	"slices"
+	"strings"
+)
+
+// MySQLRoutineNode represents a MySQL-family CREATE FUNCTION or CREATE
+// PROCEDURE statement parsed through the dialect-specific routine layer.
+type MySQLRoutineNode struct {
+	// SQL is the complete executable routine statement without client
+	// delimiter commands.
+	SQL string
+	// Dialect is the normalized SQL dialect that selected this parser path.
+	Dialect string
+	// Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+	Kind RoutineKind
+	// Definer stores an optional MySQL DEFINER clause such as
+	// DEFINER=`user`@`host`.
+	Definer string
+	// Name is the routine name, including any schema qualifier or identifier
+	// quoting used by the source statement.
+	Name string
+	// Parameters contains the raw parameter list without surrounding
+	// parentheses.
+	Parameters string
+	// Returns contains the raw MySQL function return type. It is empty for
+	// procedures.
+	Returns string
+	// Characteristics stores raw routine characteristics before the body, such
+	// as DETERMINISTIC, SQL SECURITY INVOKER, or MODIFIES SQL DATA.
+	Characteristics []string
+	// Body is the parsed routine body. Expressions remain raw SQL fragments;
+	// statement boundaries and procedural statement kinds are modeled.
+	Body MySQLRoutineBody
+}
+
+// MySQLRoutineBody contains a parsed MySQL routine body.
+type MySQLRoutineBody struct {
+	// SQL is the full body fragment, usually BEGIN ... END or RETURN ...
+	SQL string
+	// Statements are the top-level routine-body statements.
+	Statements []MySQLRoutineStatement
+}
+
+// MySQLRoutineStatementKind identifies a MySQL routine-body statement class.
+type MySQLRoutineStatementKind string
+
+const (
+	MySQLRoutineStatementRaw         MySQLRoutineStatementKind = "raw"
+	MySQLRoutineStatementDeclaration MySQLRoutineStatementKind = "declaration"
+	MySQLRoutineStatementHandler     MySQLRoutineStatementKind = "handler"
+	MySQLRoutineStatementCursor      MySQLRoutineStatementKind = "cursor"
+	MySQLRoutineStatementIf          MySQLRoutineStatementKind = "if"
+	MySQLRoutineStatementCase        MySQLRoutineStatementKind = "case"
+	MySQLRoutineStatementBlock       MySQLRoutineStatementKind = "block"
+	MySQLRoutineStatementLoop        MySQLRoutineStatementKind = "loop"
+	MySQLRoutineStatementWhile       MySQLRoutineStatementKind = "while"
+	MySQLRoutineStatementRepeat      MySQLRoutineStatementKind = "repeat"
+	MySQLRoutineStatementLeave       MySQLRoutineStatementKind = "leave"
+	MySQLRoutineStatementIterate     MySQLRoutineStatementKind = "iterate"
+	MySQLRoutineStatementReturn      MySQLRoutineStatementKind = "return"
+	MySQLRoutineStatementSet         MySQLRoutineStatementKind = "set"
+	MySQLRoutineStatementSelect      MySQLRoutineStatementKind = "select"
+	MySQLRoutineStatementInsert      MySQLRoutineStatementKind = "insert"
+	MySQLRoutineStatementUpdate      MySQLRoutineStatementKind = "update"
+	MySQLRoutineStatementDelete      MySQLRoutineStatementKind = "delete"
+	MySQLRoutineStatementLabel       MySQLRoutineStatementKind = "label"
+)
+
+// MySQLRoutineStatement is one top-level statement inside a MySQL routine
+// body. SQL expression internals are preserved as raw fragments.
+type MySQLRoutineStatement struct {
+	Kind MySQLRoutineStatementKind
+	SQL  string
+}
+
+// NewMySQLRoutine creates a MySQL-family routine node.
+func NewMySQLRoutine(sql, dialect string, kind RoutineKind) *MySQLRoutineNode {
+	return &MySQLRoutineNode{
+		SQL:     strings.TrimSpace(sql),
+		Dialect: dialect,
+		Kind:    kind,
+	}
+}
+
+// SetCharacteristics replaces routine characteristics.
+func (n *MySQLRoutineNode) SetCharacteristics(characteristics []string) *MySQLRoutineNode {
+	n.Characteristics = slices.Clone(characteristics)
+	return n
+}
+
+// Accept renders MySQL routines through the raw SQL visitor contract while
+// keeping the structured routine metadata available to parser consumers.
+func (n *MySQLRoutineNode) Accept(visitor Visitor) error {
+	raw := RawSQLNode{SQL: n.SQL}
+	return visitor.VisitRawSQL(&raw)
+}

--- a/core/ast/routines_test.go
+++ b/core/ast/routines_test.go
@@ -1,0 +1,62 @@
+package ast_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/ast/mocks"
+)
+
+func TestNewMySQLRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewMySQLRoutine(" CREATE FUNCTION fn() RETURNS int RETURN 1; ", "mysql", ast.RoutineKindFunction)
+	routine.Name = "fn"
+	routine.Parameters = ""
+	routine.Returns = "int"
+	routine.SetCharacteristics([]string{"DETERMINISTIC"})
+	routine.Body = ast.MySQLRoutineBody{
+		SQL: "RETURN 1",
+		Statements: []ast.MySQLRoutineStatement{{
+			Kind: ast.MySQLRoutineStatementReturn,
+			SQL:  "RETURN 1",
+		}},
+	}
+
+	c.Assert(routine.SQL, qt.Equals, "CREATE FUNCTION fn() RETURNS int RETURN 1;")
+	c.Assert(routine.Dialect, qt.Equals, "mysql")
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "fn")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Characteristics, qt.DeepEquals, []string{"DETERMINISTIC"})
+	c.Assert(routine.Body.Statements, qt.DeepEquals, []ast.MySQLRoutineStatement{{
+		Kind: ast.MySQLRoutineStatementReturn,
+		SQL:  "RETURN 1",
+	}})
+}
+
+func TestMySQLRoutineNode_AcceptDelegatesToRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewMySQLRoutine(" CREATE PROCEDURE p() SELECT 1; ", "mysql", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() SELECT 1;"})
+}
+
+func TestMySQLRoutineNode_AcceptPropagatesRawSQLError(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewMySQLRoutine("CREATE PROCEDURE p() SELECT 1;", "mysql", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{ReturnError: true}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() SELECT 1;"})
+}

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -110,11 +110,17 @@ p := parser.NewParser(
 Dialect-specific routine bodies are handled behind parser strategies. Generic
 mode stays best-effort; dialect mode can use a routine boundary detector that is
 specific to the selected SQL family without turning the generic DDL parser into
-a stored-procedure sub-language parser. When a dialect-aware routine boundary is
-known but the body sub-language is not structured yet, the parser returns an
-`ast.OpaqueRoutineNode`: renderers emit its SQL through the raw-SQL visitor
-contract, while parser consumers can still distinguish it from arbitrary raw
-SQL.
+a stored-procedure sub-language parser.
+
+MySQL and MariaDB dialect mode parses routine headers and top-level routine-body
+statement boundaries into `ast.MySQLRoutineNode`. Expressions remain raw SQL
+fragments in this slice, but declarations, handlers, cursors, labels, and
+control-flow statement classes are distinguished by the routine-body parser.
+
+When a dialect-aware routine boundary is known but the body sub-language is not
+structured yet, the parser returns an `ast.OpaqueRoutineNode`: renderers emit its
+SQL through the raw-SQL visitor contract, while parser consumers can still
+distinguish it from arbitrary raw SQL.
 
 ### Parsing Multiple Statements
 

--- a/core/parser/mysql_routine.go
+++ b/core/parser/mysql_routine.go
@@ -1,0 +1,601 @@
+package parser
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+)
+
+func (p *Parser) parseCreateMySQLRoutineStatement(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
+	sql, err := p.collectRawRoutineStatement(statementStart)
+	if err != nil {
+		return nil, err
+	}
+	routine, err := parseMySQLRoutineSQL(sql, p.dialect, kind)
+	if err != nil {
+		return ast.NewOpaqueRoutine(sql, p.dialect, kind), nil
+	}
+	return routine, nil
+}
+
+func parseMySQLRoutineSQL(sql, dialect string, kind ast.RoutineKind) (*ast.MySQLRoutineNode, error) {
+	parser := newMySQLRoutineParser(sql, dialect, kind)
+	return parser.parse()
+}
+
+type mysqlRoutineParser struct {
+	input  string
+	tokens []lexer.Token
+
+	dialect string
+	kind    ast.RoutineKind
+}
+
+func newMySQLRoutineParser(sql, dialect string, kind ast.RoutineKind) mysqlRoutineParser {
+	trimmed := strings.TrimSpace(sql)
+	return mysqlRoutineParser{
+		input:   trimmed,
+		tokens:  tokenizeMySQLRoutineSQL(trimmed),
+		dialect: dialect,
+		kind:    kind,
+	}
+}
+
+func tokenizeMySQLRoutineSQL(sql string) []lexer.Token {
+	l := lexer.NewLexer(sql)
+	tokens := make([]lexer.Token, 0)
+	for {
+		tok := l.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Type == lexer.TokenEOF {
+			return tokens
+		}
+	}
+}
+
+func (p mysqlRoutineParser) parse() (*ast.MySQLRoutineNode, error) {
+	routine := ast.NewMySQLRoutine(p.input, p.dialect, p.kind)
+	targetIdx, err := p.findRoutineTarget()
+	if err != nil {
+		return nil, err
+	}
+
+	routine.Definer = p.collectDefiner(targetIdx)
+	afterNameIdx, err := p.parseRoutineName(targetIdx, routine)
+	if err != nil {
+		return nil, err
+	}
+
+	afterParamsIdx, err := p.parseRoutineParameters(afterNameIdx, routine)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyIdx := p.findRoutineBodyStart(afterParamsIdx)
+	if bodyIdx == -1 {
+		return nil, fmt.Errorf("unsupported MySQL routine body at position %d", p.tokens[afterParamsIdx].Start)
+	}
+
+	if routine.Kind == ast.RoutineKindFunction {
+		routine.Returns = p.collectFunctionReturns(afterParamsIdx, bodyIdx)
+	}
+	routine.SetCharacteristics(p.collectRoutineCharacteristics(afterParamsIdx, bodyIdx))
+
+	body, err := p.parseRoutineBody(bodyIdx)
+	if err != nil {
+		return nil, err
+	}
+	routine.Body = body
+
+	return routine, nil
+}
+
+func (p mysqlRoutineParser) findRoutineTarget() (int, error) {
+	for i, tok := range p.tokens {
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+		if tok.MatchIdentifierValue("FUNCTION") && p.kind == ast.RoutineKindFunction {
+			return i, nil
+		}
+		if tok.MatchIdentifierValue("PROCEDURE") && p.kind == ast.RoutineKindProcedure {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("expected CREATE %s target", strings.ToUpper(string(p.kind)))
+}
+
+func (p mysqlRoutineParser) collectDefiner(targetIdx int) string {
+	createIdx := p.findFirstIdentifier("CREATE")
+	if createIdx == -1 || createIdx >= targetIdx {
+		return ""
+	}
+
+	clause := strings.TrimSpace(p.rawFragment(p.tokens[createIdx].End, p.tokens[targetIdx].Start))
+	if strings.HasPrefix(strings.ToUpper(clause), "DEFINER") {
+		return clause
+	}
+	return ""
+}
+
+func (p mysqlRoutineParser) parseRoutineName(targetIdx int, routine *ast.MySQLRoutineNode) (int, error) {
+	nameStartIdx := p.nextSignificant(targetIdx + 1)
+	if nameStartIdx == -1 {
+		return -1, fmt.Errorf("expected MySQL routine name")
+	}
+
+	for i := nameStartIdx; i < len(p.tokens); i++ {
+		if p.tokens[i].MatchOperatorValue("(") {
+			routine.Name = strings.TrimSpace(p.rawFragment(p.tokens[nameStartIdx].Start, p.tokens[i].Start))
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("expected parameter list for MySQL routine %s", p.rawToken(nameStartIdx))
+}
+
+func (p mysqlRoutineParser) parseRoutineParameters(openParenIdx int, routine *ast.MySQLRoutineNode) (int, error) {
+	closeParenIdx, err := p.matchingParen(openParenIdx)
+	if err != nil {
+		return -1, err
+	}
+	routine.Parameters = strings.TrimSpace(p.rawFragment(p.tokens[openParenIdx].End, p.tokens[closeParenIdx].Start))
+	return closeParenIdx + 1, nil
+}
+
+func (p mysqlRoutineParser) matchingParen(openParenIdx int) (int, error) {
+	depth := 0
+	for i := openParenIdx; i < len(p.tokens); i++ {
+		switch {
+		case p.tokens[i].MatchOperatorValue("("):
+			depth++
+		case p.tokens[i].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return i, nil
+			}
+		}
+	}
+	return -1, fmt.Errorf("unterminated MySQL routine parameter list")
+}
+
+func (p mysqlRoutineParser) findRoutineBodyStart(startIdx int) int {
+	for i := startIdx; i < len(p.tokens); i++ {
+		if p.tokens[i].Type != lexer.TokenIdentifier {
+			continue
+		}
+		if p.tokens[i].MatchIdentifierValue("BEGIN") || p.tokens[i].MatchIdentifierValue("RETURN") {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p mysqlRoutineParser) collectFunctionReturns(startIdx, bodyIdx int) string {
+	returnsIdx := p.findIdentifierBetween("RETURNS", startIdx, bodyIdx)
+	if returnsIdx == -1 {
+		return ""
+	}
+
+	valueStartIdx := p.nextSignificant(returnsIdx + 1)
+	if valueStartIdx == -1 || valueStartIdx >= bodyIdx {
+		return ""
+	}
+
+	valueEnd := p.tokens[bodyIdx].Start
+	for i := valueStartIdx; i < bodyIdx; i++ {
+		if isMySQLRoutineCharacteristicStart(p.tokens[i]) {
+			valueEnd = p.tokens[i].Start
+			break
+		}
+	}
+	return strings.TrimSpace(p.rawFragment(p.tokens[valueStartIdx].Start, valueEnd))
+}
+
+func (p mysqlRoutineParser) collectRoutineCharacteristics(startIdx, bodyIdx int) []string {
+	characteristics := make([]string, 0)
+	for i := startIdx; i < bodyIdx; i++ {
+		if isMySQLRoutineCharacteristicStart(p.tokens[i]) {
+			characteristic, nextIdx := p.collectRoutineCharacteristic(i, bodyIdx)
+			if characteristic != "" {
+				characteristics = append(characteristics, characteristic)
+			}
+			i = nextIdx - 1
+		}
+	}
+	return characteristics
+}
+
+func (p mysqlRoutineParser) collectRoutineCharacteristic(startIdx, bodyIdx int) (string, int) {
+	endIdx := p.routineCharacteristicEnd(startIdx, bodyIdx)
+	end := p.tokens[endIdx].Start
+	if endIdx >= bodyIdx {
+		end = p.tokens[bodyIdx].Start
+	}
+	return strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end)), endIdx
+}
+
+func (p mysqlRoutineParser) routineCharacteristicEnd(startIdx, bodyIdx int) int {
+	switch strings.ToUpper(p.tokens[startIdx].Value) {
+	case "COMMENT", "LANGUAGE":
+		return p.afterSignificantTokens(startIdx, bodyIdx, 1)
+	case "NOT":
+		return p.afterOptionalKeyword(startIdx, bodyIdx, "DETERMINISTIC")
+	case "NO", "CONTAINS":
+		return p.afterOptionalKeyword(startIdx, bodyIdx, "SQL")
+	case "READS", "MODIFIES":
+		return p.afterOptionalKeywords(startIdx, bodyIdx, "SQL", "DATA")
+	case "SQL":
+		if nextIdx := p.nextSignificant(startIdx + 1); nextIdx != -1 && nextIdx < bodyIdx && p.tokens[nextIdx].MatchIdentifierValue("SECURITY") {
+			return p.afterSignificantTokens(startIdx, bodyIdx, 2)
+		}
+	}
+	return min(startIdx+1, bodyIdx)
+}
+
+func (p mysqlRoutineParser) afterOptionalKeyword(startIdx, bodyIdx int, keyword string) int {
+	return p.afterOptionalKeywords(startIdx, bodyIdx, keyword)
+}
+
+func (p mysqlRoutineParser) afterOptionalKeywords(startIdx, bodyIdx int, keywords ...string) int {
+	endIdx := startIdx + 1
+	for _, keyword := range keywords {
+		nextIdx := p.nextSignificant(endIdx)
+		if nextIdx == -1 || nextIdx >= bodyIdx || !p.tokens[nextIdx].MatchIdentifierValue(keyword) {
+			return endIdx
+		}
+		endIdx = nextIdx + 1
+	}
+	return min(endIdx, bodyIdx)
+}
+
+func (p mysqlRoutineParser) afterSignificantTokens(startIdx, bodyIdx, count int) int {
+	endIdx := startIdx + 1
+	for range count {
+		nextIdx := p.nextSignificant(endIdx)
+		if nextIdx == -1 || nextIdx >= bodyIdx {
+			return min(endIdx, bodyIdx)
+		}
+		endIdx = nextIdx + 1
+	}
+	return min(endIdx, bodyIdx)
+}
+
+func (p mysqlRoutineParser) parseRoutineBody(bodyIdx int) (ast.MySQLRoutineBody, error) {
+	switch {
+	case p.tokens[bodyIdx].MatchIdentifierValue("BEGIN"):
+		bodySQL, err := p.collectCompoundBodySQL(bodyIdx)
+		if err != nil {
+			return ast.MySQLRoutineBody{}, err
+		}
+		return ast.MySQLRoutineBody{
+			SQL:        bodySQL,
+			Statements: parseMySQLRoutineBodyStatements(bodySQL),
+		}, nil
+	case p.tokens[bodyIdx].MatchIdentifierValue("RETURN"):
+		bodySQL := strings.TrimSpace(p.rawFragment(p.tokens[bodyIdx].Start, p.statementEndFrom(bodyIdx)))
+		return ast.MySQLRoutineBody{
+			SQL: bodySQL,
+			Statements: []ast.MySQLRoutineStatement{{
+				Kind: ast.MySQLRoutineStatementReturn,
+				SQL:  bodySQL,
+			}},
+		}, nil
+	default:
+		return ast.MySQLRoutineBody{}, fmt.Errorf("unsupported MySQL routine body at position %d", p.tokens[bodyIdx].Start)
+	}
+}
+
+func (p mysqlRoutineParser) collectCompoundBodySQL(beginIdx int) (string, error) {
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+
+	for i := beginIdx; i < len(p.tokens); i++ {
+		tok := p.tokens[i]
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+
+		keyword := strings.ToUpper(tok.Value)
+		if keyword == "IF" && p.isScalarIF(i) {
+			continue
+		}
+		trackRoutineCompoundKeyword(keyword, &depth, &caseDepth, &pendingEndTrailer)
+		if depth == 0 && keyword == "END" {
+			return strings.TrimSpace(p.rawFragment(p.tokens[beginIdx].Start, tok.End)), nil
+		}
+	}
+
+	return "", fmt.Errorf("unterminated MySQL routine body at position %d", p.tokens[beginIdx].Start)
+}
+
+func (p mysqlRoutineParser) statementEndFrom(startIdx int) int {
+	for i := startIdx; i < len(p.tokens); i++ {
+		if p.tokens[i].Type == lexer.TokenSemicolon || p.tokens[i].Type == lexer.TokenEOF {
+			return p.tokens[i].Start
+		}
+	}
+	return len(p.input)
+}
+
+func parseMySQLRoutineBodyStatements(bodySQL string) []ast.MySQLRoutineStatement {
+	parser := mysqlRoutineBodyParser{
+		input:  strings.TrimSpace(bodySQL),
+		tokens: tokenizeMySQLRoutineSQL(bodySQL),
+	}
+	return parser.parseStatements()
+}
+
+type mysqlRoutineBodyParser struct {
+	input  string
+	tokens []lexer.Token
+}
+
+func (p mysqlRoutineBodyParser) parseStatements() []ast.MySQLRoutineStatement {
+	beginIdx, endIdx := p.outerBlockRange()
+	if beginIdx == -1 || endIdx == -1 || beginIdx >= endIdx {
+		return p.singleStatement()
+	}
+
+	statements := make([]ast.MySQLRoutineStatement, 0)
+	statementStartIdx := -1
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+
+	for i := beginIdx + 1; i < endIdx; i++ {
+		tok := p.tokens[i]
+		if statementStartIdx == -1 {
+			if isMySQLRoutineTrivia(tok) {
+				continue
+			}
+			statementStartIdx = i
+		}
+
+		if tok.Type == lexer.TokenIdentifier {
+			keyword := strings.ToUpper(tok.Value)
+			if keyword != "IF" || !p.isScalarIF(i) {
+				trackRoutineCompoundKeyword(keyword, &depth, &caseDepth, &pendingEndTrailer)
+			}
+		}
+
+		if tok.Type == lexer.TokenSemicolon && depth == 0 && caseDepth == 0 && statementStartIdx != -1 {
+			statements = append(statements, p.statement(statementStartIdx, i))
+			statementStartIdx = -1
+			pendingEndTrailer = false
+			continue
+		}
+
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+		}
+	}
+
+	if statementStartIdx != -1 {
+		statements = append(statements, p.statement(statementStartIdx, endIdx))
+	}
+	return statements
+}
+
+func (p mysqlRoutineBodyParser) singleStatement() []ast.MySQLRoutineStatement {
+	startIdx := p.nextSignificant(0)
+	if startIdx == -1 {
+		return nil
+	}
+	endIdx := len(p.tokens) - 1
+	if endIdx < startIdx {
+		return nil
+	}
+	return []ast.MySQLRoutineStatement{p.statement(startIdx, endIdx)}
+}
+
+func (p mysqlRoutineBodyParser) statement(startIdx, endIdx int) ast.MySQLRoutineStatement {
+	if startIdx < 0 || endIdx >= len(p.tokens) || startIdx > endIdx {
+		return ast.MySQLRoutineStatement{}
+	}
+	end := p.tokens[endIdx].End
+	if p.tokens[endIdx].Type == lexer.TokenEOF {
+		end = p.tokens[endIdx].Start
+	}
+	sql := strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end))
+	return ast.MySQLRoutineStatement{
+		Kind: p.classifyStatement(startIdx),
+		SQL:  sql,
+	}
+}
+
+func (p mysqlRoutineBodyParser) classifyStatement(startIdx int) ast.MySQLRoutineStatementKind {
+	if p.isLabelStatement(startIdx) {
+		return ast.MySQLRoutineStatementLabel
+	}
+
+	tok := p.tokens[startIdx]
+	if tok.Type != lexer.TokenIdentifier {
+		return ast.MySQLRoutineStatementRaw
+	}
+
+	switch strings.ToUpper(tok.Value) {
+	case "DECLARE":
+		return p.classifyDeclareStatement(startIdx)
+	case "IF":
+		if p.isScalarIF(startIdx) {
+			return ast.MySQLRoutineStatementRaw
+		}
+		return ast.MySQLRoutineStatementIf
+	case "CASE":
+		return ast.MySQLRoutineStatementCase
+	case "BEGIN":
+		return ast.MySQLRoutineStatementBlock
+	case "LOOP":
+		return ast.MySQLRoutineStatementLoop
+	case "WHILE":
+		return ast.MySQLRoutineStatementWhile
+	case "REPEAT":
+		return ast.MySQLRoutineStatementRepeat
+	case "LEAVE":
+		return ast.MySQLRoutineStatementLeave
+	case "ITERATE":
+		return ast.MySQLRoutineStatementIterate
+	case "RETURN":
+		return ast.MySQLRoutineStatementReturn
+	case "SET":
+		return ast.MySQLRoutineStatementSet
+	case "SELECT":
+		return ast.MySQLRoutineStatementSelect
+	case "INSERT":
+		return ast.MySQLRoutineStatementInsert
+	case "UPDATE":
+		return ast.MySQLRoutineStatementUpdate
+	case "DELETE":
+		return ast.MySQLRoutineStatementDelete
+	default:
+		return ast.MySQLRoutineStatementRaw
+	}
+}
+
+func (p mysqlRoutineBodyParser) classifyDeclareStatement(startIdx int) ast.MySQLRoutineStatementKind {
+	for i := startIdx + 1; i < len(p.tokens); i++ {
+		if p.tokens[i].Type == lexer.TokenSemicolon || p.tokens[i].Type == lexer.TokenEOF {
+			return ast.MySQLRoutineStatementDeclaration
+		}
+		if p.tokens[i].MatchIdentifierValue("HANDLER") {
+			return ast.MySQLRoutineStatementHandler
+		}
+		if p.tokens[i].MatchIdentifierValue("CURSOR") {
+			return ast.MySQLRoutineStatementCursor
+		}
+	}
+	return ast.MySQLRoutineStatementDeclaration
+}
+
+func (p mysqlRoutineBodyParser) outerBlockRange() (beginIdx int, endIdx int) {
+	beginIdx = p.nextSignificant(0)
+	if beginIdx == -1 || !p.tokens[beginIdx].MatchIdentifierValue("BEGIN") {
+		return -1, -1
+	}
+
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+	for i := beginIdx; i < len(p.tokens); i++ {
+		tok := p.tokens[i]
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+		keyword := strings.ToUpper(tok.Value)
+		if keyword == "IF" && p.isScalarIF(i) {
+			continue
+		}
+		trackRoutineCompoundKeyword(keyword, &depth, &caseDepth, &pendingEndTrailer)
+		if depth == 0 && keyword == "END" {
+			return beginIdx, i
+		}
+	}
+	return -1, -1
+}
+
+func (p mysqlRoutineBodyParser) isLabelStatement(startIdx int) bool {
+	nextIdx := p.nextSignificant(startIdx + 1)
+	return nextIdx != -1 && p.tokens[nextIdx].MatchOperatorValue(":")
+}
+
+func (p mysqlRoutineParser) isScalarIF(idx int) bool {
+	nextIdx := p.nextSignificant(idx + 1)
+	return nextIdx != -1 && p.tokens[nextIdx].MatchOperatorValue("(")
+}
+
+func (p mysqlRoutineBodyParser) isScalarIF(idx int) bool {
+	nextIdx := p.nextSignificant(idx + 1)
+	return nextIdx != -1 && p.tokens[nextIdx].MatchOperatorValue("(")
+}
+
+func (p mysqlRoutineParser) findFirstIdentifier(value string) int {
+	for i, tok := range p.tokens {
+		if tok.MatchIdentifierValue(value) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p mysqlRoutineParser) findIdentifierBetween(value string, startIdx, endIdx int) int {
+	for i := startIdx; i < endIdx && i < len(p.tokens); i++ {
+		if p.tokens[i].MatchIdentifierValue(value) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p mysqlRoutineParser) nextSignificant(startIdx int) int {
+	return nextSignificantMySQLRoutineToken(p.tokens, startIdx)
+}
+
+func (p mysqlRoutineBodyParser) nextSignificant(startIdx int) int {
+	return nextSignificantMySQLRoutineToken(p.tokens, startIdx)
+}
+
+func nextSignificantMySQLRoutineToken(tokens []lexer.Token, startIdx int) int {
+	for i := max(startIdx, 0); i < len(tokens); i++ {
+		if !isMySQLRoutineTrivia(tokens[i]) && tokens[i].Type != lexer.TokenEOF {
+			return i
+		}
+	}
+	return -1
+}
+
+func isMySQLRoutineTrivia(tok lexer.Token) bool {
+	return tok.Type == lexer.TokenWhitespace || tok.Type == lexer.TokenComment
+}
+
+func (p mysqlRoutineParser) rawToken(idx int) string {
+	if idx < 0 || idx >= len(p.tokens) {
+		return ""
+	}
+	return p.tokens[idx].Value
+}
+
+func (p mysqlRoutineParser) rawFragment(start, end int) string {
+	return rawMySQLRoutineFragment(p.input, start, end)
+}
+
+func (p mysqlRoutineBodyParser) rawFragment(start, end int) string {
+	return rawMySQLRoutineFragment(p.input, start, end)
+}
+
+func rawMySQLRoutineFragment(input string, start, end int) string {
+	if start < 0 || start > end || end > len(input) {
+		return ""
+	}
+	return input[start:end]
+}
+
+func isMySQLRoutineCharacteristicStart(tok lexer.Token) bool {
+	if tok.Type != lexer.TokenIdentifier {
+		return false
+	}
+	return slices.Contains(mysqlRoutineCharacteristicKeywords, strings.ToUpper(tok.Value))
+}
+
+var mysqlRoutineCharacteristicKeywords = []string{
+	"COMMENT",
+	"CONTAINS",
+	"DETERMINISTIC",
+	"LANGUAGE",
+	"MODIFIES",
+	"NO",
+	"NOT",
+	"READS",
+	"SQL",
+}

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -638,14 +638,6 @@ func (p *Parser) parseCreateRawRoutineStatement(statementStart int) (ast.Node, e
 	return ast.NewRawSQL(sql), nil
 }
 
-func (p *Parser) parseCreateOpaqueRoutineStatement(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
-	sql, err := p.collectRawRoutineStatement(statementStart)
-	if err != nil {
-		return nil, err
-	}
-	return ast.NewOpaqueRoutine(sql, p.dialect, kind), nil
-}
-
 func (p *Parser) collectRawRoutineStatement(statementStart int) (string, error) {
 	blockDepth := 0
 	caseDepth := 0

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -834,7 +834,7 @@ DELIMITER ;`
 	c.Assert(raw.SQL, qt.Contains, "RETURN x+2;")
 }
 
-func TestParser_ParseMySQLDialectCompoundFunctionAsOpaqueRoutine(t *testing.T) {
+func TestParser_ParseMySQLDialectCompoundFunctionAsRoutine(t *testing.T) {
 	c := qt.New(t)
 
 	sql := `DELIMITER |
@@ -850,13 +850,46 @@ DELIMITER ;`
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 1)
 
-	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
 	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "fn1")
+	c.Assert(routine.Parameters, qt.Equals, "x int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Characteristics, qt.DeepEquals, []string{"DETERMINISTIC"})
 	c.Assert(routine.SQL, qt.Contains, "CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC")
-	c.Assert(routine.SQL, qt.Contains, "INSERT INTO t1 VALUES (x);")
-	c.Assert(routine.SQL, qt.Contains, "RETURN x+2;")
+	c.Assert(routine.Body.SQL, qt.Contains, "INSERT INTO t1 VALUES (x);")
+	c.Assert(routine.Body.SQL, qt.Contains, "RETURN x+2;")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementInsert,
+		ast.MySQLRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseMariaDBDialectCompoundFunctionAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION fn1(x int) RETURNS int DETERMINISTIC
+BEGIN
+       RETURN x+2;
+END;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MariaDB))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MariaDB)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "fn1")
+	c.Assert(routine.Parameters, qt.Equals, "x int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementReturn,
+	})
 }
 
 func TestParser_ParseMySQLCreateFunctionWithNestedCompoundBody(t *testing.T) {
@@ -1162,7 +1195,7 @@ CALL proc();`
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "-- end --")
 }
 
-func TestParser_ParseMySQLDialectDefinerProcedureAsOpaqueRoutine(t *testing.T) {
+func TestParser_ParseMySQLDialectDefinerProcedureAsRoutine(t *testing.T) {
 	c := qt.New(t)
 
 	sql := `-- atlas:delimiter \n-- end --\n
@@ -1185,15 +1218,128 @@ CALL proc();`
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 1)
 
-	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
 	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Definer, qt.Equals, "DEFINER='boring'")
+	c.Assert(routine.Name, qt.Equals, "proc")
+	c.Assert(routine.Characteristics, qt.DeepEquals, []string{
+		"COMMENT 'ATLAS_DELIMITER'",
+		"SQL SECURITY INVOKER",
+		"NOT DETERMINISTIC",
+		"MODIFIES SQL DATA",
+	})
 	c.Assert(routine.SQL, qt.Contains, "CREATE DEFINER='boring' PROCEDURE proc ()")
 	c.Assert(routine.SQL, qt.Contains, "SQL SECURITY INVOKER")
 	c.Assert(routine.SQL, qt.Contains, "IF(@rows != 1, 's', '')")
 	c.Assert(routine.SQL, qt.Not(qt.Contains), "CALL proc")
 	c.Assert(routine.SQL, qt.Not(qt.Contains), "-- end --")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementSelect,
+	})
+}
+
+func TestParser_ParseMySQLDialectDefinerFunctionAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE DEFINER=`root`@`localhost` FUNCTION `add2` (a int, b int) RETURNS int DETERMINISTIC RETURN a + b;"
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Definer, qt.Equals, "DEFINER=`root`@`localhost`")
+	c.Assert(routine.Name, qt.Equals, "`add2`")
+	c.Assert(routine.Parameters, qt.Equals, "a int, b int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Characteristics, qt.DeepEquals, []string{"DETERMINISTIC"})
+	c.Assert(routine.Body.SQL, qt.Equals, "RETURN a + b")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseMySQLDialectRoutineBodyStatementKinds(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE control_flow()
+BEGIN
+    DECLARE done BOOL DEFAULT FALSE;
+    DECLARE cur CURSOR FOR SELECT id FROM users;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+    SET @seen = 0;
+    BEGIN
+        SET @seen = @seen + 10;
+    END;
+    IF @seen = 0 THEN
+        SET @seen = 1;
+    END IF;
+    CASE
+        WHEN @seen = 1 THEN SET @seen = 2;
+        ELSE SET @seen = 3;
+    END CASE;
+    WHILE @seen < 5 DO
+        SET @seen = @seen + 1;
+    END WHILE;
+    REPEAT
+        SET @seen = @seen - 1;
+    UNTIL @seen = 0 END REPEAT;
+    scan_loop: LOOP
+        LEAVE scan_loop;
+    END LOOP scan_loop;
+    SELECT IF(@seen = 0, 1, 0);
+END;
+CREATE TABLE after_proc (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementDeclaration,
+		ast.MySQLRoutineStatementCursor,
+		ast.MySQLRoutineStatementHandler,
+		ast.MySQLRoutineStatementSet,
+		ast.MySQLRoutineStatementBlock,
+		ast.MySQLRoutineStatementIf,
+		ast.MySQLRoutineStatementCase,
+		ast.MySQLRoutineStatementWhile,
+		ast.MySQLRoutineStatementRepeat,
+		ast.MySQLRoutineStatementLabel,
+		ast.MySQLRoutineStatementSelect,
+	})
+	c.Assert(routine.Body.Statements[10].SQL, qt.Contains, "IF(@seen = 0, 1, 0)")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
+func TestParser_ParseMySQLDialectUnsupportedRoutineBodyAsOpaqueRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE PROCEDURE p1() SELECT 1;"
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MySQL)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.SQL, qt.Equals, "CREATE PROCEDURE p1() SELECT 1")
 }
 
 func TestParser_ParseCreateTrigger(t *testing.T) {
@@ -1246,6 +1392,14 @@ END;`
 	c.Assert(deleteTrigger.Event, qt.Equals, "DELETE")
 	c.Assert(deleteTrigger.ForEach, qt.Equals, "ROW")
 	c.Assert(deleteTrigger.Body, qt.Contains, "coalesce(old.a,'NULL')")
+}
+
+func routineStatementKinds(statements []ast.MySQLRoutineStatement) []ast.MySQLRoutineStatementKind {
+	kinds := make([]ast.MySQLRoutineStatementKind, 0, len(statements))
+	for _, stmt := range statements {
+		kinds = append(kinds, stmt.Kind)
+	}
+	return kinds
 }
 
 func TestParser_ParseCreateOrReplaceTrigger(t *testing.T) {

--- a/core/parser/routine.go
+++ b/core/parser/routine.go
@@ -41,16 +41,9 @@ type mysqlFamilyRoutineParser struct{}
 
 func (mysqlFamilyRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
 	if target == "PROCEDURE" {
-		return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindProcedure)
+		return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindProcedure)
 	}
-	node, err := p.parseCreateFunction(statementStart)
-	if err != nil {
-		return nil, err
-	}
-	if raw, ok := node.(*ast.RawSQLNode); ok {
-		return ast.NewOpaqueRoutine(raw.SQL, p.dialect, ast.RoutineKindFunction), nil
-	}
-	return node, nil
+	return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindFunction)
 }
 
 func (mysqlFamilyRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
@@ -60,9 +53,9 @@ func (mysqlFamilyRoutineParser) parseCreateDefinerRoutine(p *Parser, statementSt
 		}
 		switch {
 		case p.current.MatchIdentifierValue("FUNCTION"):
-			return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindFunction)
+			return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindFunction)
 		case p.current.MatchIdentifierValue("PROCEDURE"):
-			return p.parseCreateOpaqueRoutineStatement(statementStart, ast.RoutineKindProcedure)
+			return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindProcedure)
 		case p.current.Type == lexer.TokenSemicolon:
 			return nil, fmt.Errorf("unsupported CREATE DEFINER target at position %d", p.current.Start)
 		default:

--- a/core/sqllint/lint.go
+++ b/core/sqllint/lint.go
@@ -334,6 +334,8 @@ func (unsupportedRoutineRule) CheckStatement(ctx Context, stmt ast.Node) []Findi
 			keyword = "raw SQL"
 		}
 		return []Finding{ctx.unsupportedModeledSQLFinding(keyword, keywordOffset)}
+	case *ast.MySQLRoutineNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.OpaqueRoutineNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.CreateFunctionNode:

--- a/core/sqllint/lint_test.go
+++ b/core/sqllint/lint_test.go
@@ -138,24 +138,26 @@ func TestLintSource_RawSQLNodesAreExplicitUnsupportedFindings(t *testing.T) {
 	}
 }
 
-func TestLintSource_OpaqueRoutineNodesAreExplicitUnsupportedFindings(t *testing.T) {
+func TestLintSource_MySQLRoutineNodesAreExplicitUnsupportedFindings(t *testing.T) {
 	c := qt.New(t)
 
-	findings, err := LintSource(Source{
-		Name: "routine.sql",
-		SQL: `DELIMITER //
+	for _, dialect := range []string{platform.MySQL, platform.MariaDB} {
+		findings, err := LintSource(Source{
+			Name: "routine.sql",
+			SQL: `DELIMITER //
 CREATE PROCEDURE p1()
 BEGIN
   SELECT 1;
 END//
 DELIMITER ;`,
-	}, Options{Dialect: platform.MySQL})
+		}, Options{Dialect: dialect})
 
-	c.Assert(err, qt.IsNil)
-	c.Assert(findings, qt.HasLen, 1)
-	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
-	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
-	c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+		c.Assert(err, qt.IsNil)
+		c.Assert(findings, qt.HasLen, 1)
+		c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+		c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+		c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+	}
 }
 
 func TestLintSource_UnsupportedStatementDoesNotMaskLaterDDL(t *testing.T) {


### PR DESCRIPTION
## What

- Add `ast.MySQLRoutineNode` and MySQL routine-body statement metadata for dialect-aware parser consumers.
- Add a MySQL/MariaDB routine parser layer behind the existing `routineParser` strategy.
- Parse routine headers, definers, parameters, function returns, characteristics, and top-level routine-body statement classes.
- Keep SQL expressions as raw fragments in this slice, and fall back to `ast.OpaqueRoutineNode` for valid routine forms outside the structured subset.
- Keep renderers compatible by delegating `MySQLRoutineNode.Accept` through the existing raw-SQL visitor contract.
- Keep SQL lint conservative: typed MySQL routines still report SQL002 until semantic linting inside routine bodies exists.
- Update parser docs and the top-level README.

## Why

This advances #322 and #318 without teaching the generic DDL parser more MySQL procedure-language heuristics. The generic no-dialect mode remains best-effort, while MySQL/MariaDB dialect mode now has a concrete routine sub-language entry point and reusable AST surface.

Refs #322.
Refs #318.

## Validation

- gopls diagnostics on changed Go files
- `go test ./core/ast ./core/parser ./core/sqllint -count=1`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./... -count=1`
- `git diff --check`
