### PR TITLE
Add MySQL routine declaration metadata

### DIFF
--- a/core/ast/routines.go
+++ b/core/ast/routines.go
@@ -71,8 +71,43 @@ const (
 // MySQLRoutineStatement is one top-level statement inside a MySQL routine
 // body. SQL expression internals are preserved as raw fragments.
 type MySQLRoutineStatement struct {
-	Kind MySQLRoutineStatementKind
-	SQL  string
+	Kind        MySQLRoutineStatementKind
+	SQL         string
+	Declaration *MySQLRoutineDeclaration
+	Cursor      *MySQLRoutineCursor
+	Handler     *MySQLRoutineHandler
+}
+
+// MySQLRoutineDeclarationKind identifies the DECLARE subform.
+type MySQLRoutineDeclarationKind string
+
+const (
+	MySQLRoutineDeclarationVariable  MySQLRoutineDeclarationKind = "variable"
+	MySQLRoutineDeclarationCondition MySQLRoutineDeclarationKind = "condition"
+)
+
+// MySQLRoutineDeclaration models DECLARE variable and condition statements.
+// TypeSQL, DefaultSQL, and ConditionSQL remain raw MySQL fragments; expression
+// parsing is intentionally outside the routine statement-boundary layer.
+type MySQLRoutineDeclaration struct {
+	Kind         MySQLRoutineDeclarationKind
+	Names        []string
+	TypeSQL      string
+	DefaultSQL   string
+	ConditionSQL string
+}
+
+// MySQLRoutineCursor models DECLARE ... CURSOR statements.
+type MySQLRoutineCursor struct {
+	Name      string
+	SelectSQL string
+}
+
+// MySQLRoutineHandler models DECLARE ... HANDLER statements.
+type MySQLRoutineHandler struct {
+	Action       string
+	Conditions   []string
+	StatementSQL string
 }
 
 // NewMySQLRoutine creates a MySQL-family routine node.

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -114,8 +114,10 @@ a stored-procedure sub-language parser.
 
 MySQL and MariaDB dialect mode parses routine headers and top-level routine-body
 statement boundaries into `ast.MySQLRoutineNode`. Expressions remain raw SQL
-fragments in this slice, but declarations, handlers, cursors, labels, and
-control-flow statement classes are distinguished by the routine-body parser.
+fragments in this slice, but declaration statements now carry typed metadata
+for local variables, named conditions, cursors, and handlers. Labels and
+control-flow statement classes are still distinguished without parsing scalar
+SQL expressions.
 
 When a dialect-aware routine boundary is known but the body sub-language is not
 structured yet, the parser returns an `ast.OpaqueRoutineNode`: renderers emit its

--- a/core/parser/mysql_routine.go
+++ b/core/parser/mysql_routine.go
@@ -405,10 +405,53 @@ func (p mysqlRoutineBodyParser) statement(startIdx, endIdx int) ast.MySQLRoutine
 		end = p.tokens[endIdx].Start
 	}
 	sql := strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end))
-	return ast.MySQLRoutineStatement{
+	statement := ast.MySQLRoutineStatement{
 		Kind: p.classifyStatement(startIdx),
 		SQL:  sql,
 	}
+	p.populateDeclareMetadata(&statement, startIdx, endIdx)
+	return statement
+}
+
+func (p mysqlRoutineBodyParser) populateDeclareMetadata(statement *ast.MySQLRoutineStatement, startIdx, endIdx int) {
+	if statement == nil {
+		return
+	}
+
+	switch statement.Kind {
+	case ast.MySQLRoutineStatementDeclaration:
+		statement.Declaration = p.parseDeclareStatement(startIdx, endIdx)
+	case ast.MySQLRoutineStatementCursor:
+		statement.Cursor = p.parseCursorStatement(startIdx, endIdx)
+	case ast.MySQLRoutineStatementHandler:
+		statement.Handler = p.parseHandlerStatement(startIdx, endIdx)
+	}
+}
+
+func (p mysqlRoutineBodyParser) findSignificantKeyword(startIdx, endIdx int, keyword string) int {
+	for i := startIdx; i < endIdx; i++ {
+		if p.tokens[i].MatchIdentifierValue(keyword) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p mysqlRoutineBodyParser) statementContentEnd(endIdx int) int {
+	if endIdx < 0 || endIdx >= len(p.tokens) {
+		return len(p.input)
+	}
+	if p.tokens[endIdx].Type == lexer.TokenSemicolon || p.tokens[endIdx].Type == lexer.TokenEOF {
+		return p.tokens[endIdx].Start
+	}
+	return p.tokens[endIdx].End
+}
+
+func (p mysqlRoutineBodyParser) rawTokenRange(startIdx int, end int) string {
+	if startIdx < 0 || startIdx >= len(p.tokens) {
+		return ""
+	}
+	return strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end))
 }
 
 func (p mysqlRoutineBodyParser) classifyStatement(startIdx int) ast.MySQLRoutineStatementKind {

--- a/core/parser/mysql_routine_declare.go
+++ b/core/parser/mysql_routine_declare.go
@@ -1,0 +1,183 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+)
+
+func (p mysqlRoutineBodyParser) parseDeclareStatement(startIdx, endIdx int) *ast.MySQLRoutineDeclaration {
+	nameIdx := p.nextSignificant(startIdx + 1)
+	if nameIdx == -1 || nameIdx >= endIdx {
+		return nil
+	}
+
+	if conditionIdx := p.nextSignificant(nameIdx + 1); conditionIdx != -1 &&
+		conditionIdx < endIdx &&
+		p.tokens[conditionIdx].MatchIdentifierValue("CONDITION") {
+		return p.parseConditionDeclaration(nameIdx, conditionIdx, endIdx)
+	}
+
+	return p.parseVariableDeclaration(nameIdx, endIdx)
+}
+
+func (p mysqlRoutineBodyParser) parseConditionDeclaration(nameIdx, conditionIdx, endIdx int) *ast.MySQLRoutineDeclaration {
+	forIdx := p.findSignificantKeyword(conditionIdx+1, endIdx, "FOR")
+	if forIdx == -1 {
+		return nil
+	}
+	valueStartIdx := p.nextSignificant(forIdx + 1)
+	if valueStartIdx == -1 || valueStartIdx >= endIdx {
+		return nil
+	}
+
+	return &ast.MySQLRoutineDeclaration{
+		Kind:         ast.MySQLRoutineDeclarationCondition,
+		Names:        []string{p.tokens[nameIdx].Value},
+		ConditionSQL: p.rawTokenRange(valueStartIdx, p.statementContentEnd(endIdx)),
+	}
+}
+
+func (p mysqlRoutineBodyParser) parseVariableDeclaration(nameIdx, endIdx int) *ast.MySQLRoutineDeclaration {
+	names, typeStartIdx := p.parseDeclareNames(nameIdx, endIdx)
+	if len(names) == 0 || typeStartIdx == -1 || typeStartIdx >= endIdx {
+		return nil
+	}
+
+	defaultIdx := p.findSignificantKeyword(typeStartIdx, endIdx, "DEFAULT")
+	typeEnd := p.statementContentEnd(endIdx)
+	defaultSQL := ""
+	if defaultIdx != -1 {
+		typeEnd = p.tokens[defaultIdx].Start
+		defaultStartIdx := p.nextSignificant(defaultIdx + 1)
+		if defaultStartIdx == -1 || defaultStartIdx >= endIdx {
+			return nil
+		}
+		defaultSQL = p.rawTokenRange(defaultStartIdx, p.statementContentEnd(endIdx))
+	}
+
+	return &ast.MySQLRoutineDeclaration{
+		Kind:       ast.MySQLRoutineDeclarationVariable,
+		Names:      names,
+		TypeSQL:    strings.TrimSpace(p.rawFragment(p.tokens[typeStartIdx].Start, typeEnd)),
+		DefaultSQL: defaultSQL,
+	}
+}
+
+func (p mysqlRoutineBodyParser) parseDeclareNames(nameIdx, endIdx int) ([]string, int) {
+	names := []string{p.tokens[nameIdx].Value}
+	nextIdx := p.nextSignificant(nameIdx + 1)
+	if nextIdx == -1 || nextIdx >= endIdx || !p.tokens[nextIdx].MatchOperatorValue(",") {
+		return names, nextIdx
+	}
+
+	for nextIdx != -1 && nextIdx < endIdx && p.tokens[nextIdx].MatchOperatorValue(",") {
+		nameIdx = p.nextSignificant(nextIdx + 1)
+		if nameIdx == -1 || nameIdx >= endIdx || p.tokens[nameIdx].Type != lexer.TokenIdentifier {
+			return names, -1
+		}
+		names = append(names, p.tokens[nameIdx].Value)
+		nextIdx = p.nextSignificant(nameIdx + 1)
+	}
+	return names, nextIdx
+}
+
+func (p mysqlRoutineBodyParser) parseCursorStatement(startIdx, endIdx int) *ast.MySQLRoutineCursor {
+	nameIdx := p.nextSignificant(startIdx + 1)
+	if nameIdx == -1 || nameIdx >= endIdx {
+		return nil
+	}
+
+	forIdx := p.findSignificantKeyword(nameIdx+1, endIdx, "FOR")
+	if forIdx == -1 {
+		return nil
+	}
+	selectIdx := p.nextSignificant(forIdx + 1)
+	if selectIdx == -1 || selectIdx >= endIdx {
+		return nil
+	}
+
+	return &ast.MySQLRoutineCursor{
+		Name:      p.tokens[nameIdx].Value,
+		SelectSQL: p.rawTokenRange(selectIdx, p.statementContentEnd(endIdx)),
+	}
+}
+
+func (p mysqlRoutineBodyParser) parseHandlerStatement(startIdx, endIdx int) *ast.MySQLRoutineHandler {
+	actionIdx := p.nextSignificant(startIdx + 1)
+	if actionIdx == -1 || actionIdx >= endIdx {
+		return nil
+	}
+	handlerIdx := p.findSignificantKeyword(actionIdx+1, endIdx, "HANDLER")
+	if handlerIdx == -1 {
+		return nil
+	}
+	forIdx := p.findSignificantKeyword(handlerIdx+1, endIdx, "FOR")
+	if forIdx == -1 {
+		return nil
+	}
+
+	conditionStartIdx := p.nextSignificant(forIdx + 1)
+	if conditionStartIdx == -1 || conditionStartIdx >= endIdx {
+		return nil
+	}
+	conditions, statementStartIdx := p.parseHandlerConditions(conditionStartIdx, endIdx)
+	if statementStartIdx == -1 {
+		return nil
+	}
+
+	return &ast.MySQLRoutineHandler{
+		Action:       strings.ToUpper(p.tokens[actionIdx].Value),
+		Conditions:   conditions,
+		StatementSQL: p.rawTokenRange(statementStartIdx, p.statementContentEnd(endIdx)),
+	}
+}
+
+func (p mysqlRoutineBodyParser) parseHandlerConditions(startIdx, endIdx int) ([]string, int) {
+	conditions := make([]string, 0, 1)
+	currentIdx := startIdx
+	for currentIdx != -1 && currentIdx < endIdx {
+		conditionEndIdx := p.handlerConditionEnd(currentIdx, endIdx)
+		if conditionEndIdx == -1 {
+			return nil, -1
+		}
+		conditions = append(conditions, p.rawTokenRange(currentIdx, p.tokens[conditionEndIdx].Start))
+
+		nextIdx := p.nextSignificant(conditionEndIdx)
+		if nextIdx == -1 || nextIdx >= endIdx {
+			return nil, -1
+		}
+		if !p.tokens[nextIdx].MatchOperatorValue(",") {
+			return conditions, nextIdx
+		}
+		currentIdx = p.nextSignificant(nextIdx + 1)
+	}
+	return nil, -1
+}
+
+func (p mysqlRoutineBodyParser) handlerConditionEnd(startIdx, endIdx int) int {
+	if startIdx == -1 || startIdx >= endIdx {
+		return -1
+	}
+
+	if p.tokens[startIdx].MatchIdentifierValue("SQLSTATE") {
+		valueIdx := p.nextSignificant(startIdx + 1)
+		if valueIdx != -1 && valueIdx < endIdx && p.tokens[valueIdx].MatchIdentifierValue("VALUE") {
+			valueIdx = p.nextSignificant(valueIdx + 1)
+		}
+		if valueIdx == -1 || valueIdx >= endIdx {
+			return -1
+		}
+		return p.nextSignificant(valueIdx + 1)
+	}
+
+	if p.tokens[startIdx].MatchIdentifierValue("NOT") {
+		foundIdx := p.nextSignificant(startIdx + 1)
+		if foundIdx != -1 && foundIdx < endIdx && p.tokens[foundIdx].MatchIdentifierValue("FOUND") {
+			return p.nextSignificant(foundIdx + 1)
+		}
+	}
+
+	return p.nextSignificant(startIdx + 1)
+}

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -1270,9 +1270,10 @@ func TestParser_ParseMySQLDialectRoutineBodyStatementKinds(t *testing.T) {
 
 	sql := `CREATE PROCEDURE control_flow()
 BEGIN
-    DECLARE done BOOL DEFAULT FALSE;
+    DECLARE done, retried BOOL DEFAULT FALSE;
+    DECLARE duplicate_key CONDITION FOR SQLSTATE '23000';
     DECLARE cur CURSOR FOR SELECT id FROM users;
-    DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND, duplicate_key SET done = TRUE;
     SET @seen = 0;
     BEGIN
         SET @seen = @seen + 10;
@@ -1307,6 +1308,7 @@ CREATE TABLE after_proc (id int);`
 	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
 	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
 		ast.MySQLRoutineStatementDeclaration,
+		ast.MySQLRoutineStatementDeclaration,
 		ast.MySQLRoutineStatementCursor,
 		ast.MySQLRoutineStatementHandler,
 		ast.MySQLRoutineStatementSet,
@@ -1318,11 +1320,93 @@ CREATE TABLE after_proc (id int);`
 		ast.MySQLRoutineStatementLabel,
 		ast.MySQLRoutineStatementSelect,
 	})
-	c.Assert(routine.Body.Statements[10].SQL, qt.Contains, "IF(@seen = 0, 1, 0)")
+	c.Assert(routine.Body.Statements[0].Declaration, qt.DeepEquals, &ast.MySQLRoutineDeclaration{
+		Kind:       ast.MySQLRoutineDeclarationVariable,
+		Names:      []string{"done", "retried"},
+		TypeSQL:    "BOOL",
+		DefaultSQL: "FALSE",
+	})
+	c.Assert(routine.Body.Statements[1].Declaration, qt.DeepEquals, &ast.MySQLRoutineDeclaration{
+		Kind:         ast.MySQLRoutineDeclarationCondition,
+		Names:        []string{"duplicate_key"},
+		ConditionSQL: "SQLSTATE '23000'",
+	})
+	c.Assert(routine.Body.Statements[2].Cursor, qt.DeepEquals, &ast.MySQLRoutineCursor{
+		Name:      "cur",
+		SelectSQL: "SELECT id FROM users",
+	})
+	c.Assert(routine.Body.Statements[3].Handler, qt.DeepEquals, &ast.MySQLRoutineHandler{
+		Action:       "CONTINUE",
+		Conditions:   []string{"NOT FOUND", "duplicate_key"},
+		StatementSQL: "SET done = TRUE",
+	})
+	c.Assert(routine.Body.Statements[11].SQL, qt.Contains, "IF(@seen = 0, 1, 0)")
 
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
+func TestParser_ParseMySQLDialectMalformedDeclareMetadataStaysRaw(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE malformed_handler()
+BEGIN
+    DECLARE CONTINUE HANDLER FOR;
+    DECLARE v INT DEFAULT;
+END;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Body.Statements, qt.HasLen, 2)
+	c.Assert(routine.Body.Statements[0].Kind, qt.Equals, ast.MySQLRoutineStatementHandler)
+	c.Assert(routine.Body.Statements[0].SQL, qt.Equals, "DECLARE CONTINUE HANDLER FOR;")
+	c.Assert(routine.Body.Statements[0].Handler, qt.IsNil)
+	c.Assert(routine.Body.Statements[1].Kind, qt.Equals, ast.MySQLRoutineStatementDeclaration)
+	c.Assert(routine.Body.Statements[1].SQL, qt.Equals, "DECLARE v INT DEFAULT;")
+	c.Assert(routine.Body.Statements[1].Declaration, qt.IsNil)
+}
+
+func TestParser_ParseMySQLDialectHandlerMetadataStatementStarts(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE handler_starts()
+BEGIN
+    DECLARE v INT DEFAULT 0;
+    DECLARE cur CURSOR FOR SELECT id FROM users;
+    DECLARE CONTINUE HANDLER FOR NOT FOUND CLOSE cur;
+    DECLARE CONTINUE HANDLER FOR SQLSTATE VALUE '23000' FETCH cur INTO v;
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION GET DIAGNOSTICS CONDITION 1 v = MESSAGE_TEXT;
+END;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Body.Statements, qt.HasLen, 5)
+	c.Assert(routine.Body.Statements[2].Handler, qt.DeepEquals, &ast.MySQLRoutineHandler{
+		Action:       "CONTINUE",
+		Conditions:   []string{"NOT FOUND"},
+		StatementSQL: "CLOSE cur",
+	})
+	c.Assert(routine.Body.Statements[3].Handler, qt.DeepEquals, &ast.MySQLRoutineHandler{
+		Action:       "CONTINUE",
+		Conditions:   []string{"SQLSTATE VALUE '23000'"},
+		StatementSQL: "FETCH cur INTO v",
+	})
+	c.Assert(routine.Body.Statements[4].Handler, qt.DeepEquals, &ast.MySQLRoutineHandler{
+		Action:       "EXIT",
+		Conditions:   []string{"SQLEXCEPTION"},
+		StatementSQL: "GET DIAGNOSTICS CONDITION 1 v = MESSAGE_TEXT",
+	})
 }
 
 func TestParser_ParseMySQLDialectUnsupportedRoutineBodyAsOpaqueRoutine(t *testing.T) {


### PR DESCRIPTION
## Summary

- add typed MySQL/MariaDB routine statement metadata for DECLARE variables, named conditions, cursors, and handlers
- keep routine rendering on the raw SQL visitor contract while exposing structured parser data for declaration-family statements
- split DECLARE metadata extraction into a dedicated routine parser file and document the parser contract

## Self-review

- Pass 1: checked malformed DECLARE/HANDLER input for nil-safe metadata fallback; added regression coverage so statement Kind+SQL survives when metadata cannot be parsed.
- Pass 2: checked decomposition and moved declaration-family parsing out of the main routine body splitter.
- Scope check: no generic SQL parser expansion and no expression parser changes; scalar SQL fragments remain raw.

## Validation

- go test ./core/ast ./core/parser ./core/sqllint -count=1
- go tool qtlint ./...
- golangci-lint run ./...
- go test ./... -count=1

Refs #322
