### PR TITLE
Add PostgreSQL routine body parser metadata

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1365,6 +1365,9 @@ type CreateFunctionNode struct {
 	Body string
 	// BodyKind specifies how Body should be rendered.
 	BodyKind FunctionBodyKind
+	// RoutineBody contains dialect-specific parser metadata for the function
+	// body. Rendering still uses Body and BodyKind.
+	RoutineBody *PostgresRoutineBody
 	// Security specifies security attributes (e.g., "DEFINER", "INVOKER")
 	Security string
 	// Volatility specifies function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")

--- a/core/ast/routines.go
+++ b/core/ast/routines.go
@@ -5,6 +5,78 @@ import (
 	"strings"
 )
 
+// PostgresDoBlockNode represents a PostgreSQL DO statement parsed through the
+// dialect-specific routine layer.
+type PostgresDoBlockNode struct {
+	// SQL is the complete executable DO statement.
+	SQL string
+	// Language stores the optional LANGUAGE clause. Empty means PostgreSQL's
+	// default plpgsql language.
+	Language string
+	// Body is the parsed anonymous routine body.
+	Body PostgresRoutineBody
+}
+
+// PostgresRoutineNode represents a PostgreSQL CREATE PROCEDURE statement parsed
+// through the dialect-specific routine layer.
+type PostgresRoutineNode struct {
+	// SQL is the complete executable routine statement.
+	SQL string
+	// Dialect is the normalized SQL dialect that selected this parser path.
+	Dialect string
+	// Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+	Kind RoutineKind
+	// Name is the routine name, including schema qualifiers or quoting.
+	Name string
+	// Parameters contains the raw parameter list without surrounding
+	// parentheses.
+	Parameters string
+	// Language stores the normalized LANGUAGE clause when present.
+	Language string
+	// Body is the parsed routine body metadata.
+	Body PostgresRoutineBody
+}
+
+// PostgresRoutineBody contains parser metadata for a PostgreSQL function,
+// procedure, or DO body. Expressions remain raw PostgreSQL fragments.
+type PostgresRoutineBody struct {
+	// SQL is the raw body text without string or dollar-quote delimiters.
+	SQL string
+	// Delimiter is the dollar-quote delimiter such as $$ or $tag$. It is empty
+	// for single-quoted and SQL-standard bodies.
+	Delimiter string
+	// Language is the normalized body language known at parse time.
+	Language string
+	// Statements are top-level PL/pgSQL-ish statements when the body is a
+	// block; SQL-language bodies usually remain a single raw statement.
+	Statements []PostgresRoutineStatement
+}
+
+// PostgresRoutineStatementKind identifies a PostgreSQL routine-body statement
+// class.
+type PostgresRoutineStatementKind string
+
+const (
+	PostgresRoutineStatementRaw         PostgresRoutineStatementKind = "raw"
+	PostgresRoutineStatementDeclaration PostgresRoutineStatementKind = "declaration"
+	PostgresRoutineStatementBlock       PostgresRoutineStatementKind = "block"
+	PostgresRoutineStatementException   PostgresRoutineStatementKind = "exception"
+	PostgresRoutineStatementReturn      PostgresRoutineStatementKind = "return"
+	PostgresRoutineStatementPerform     PostgresRoutineStatementKind = "perform"
+	PostgresRoutineStatementExecute     PostgresRoutineStatementKind = "execute"
+	PostgresRoutineStatementRaise       PostgresRoutineStatementKind = "raise"
+	PostgresRoutineStatementIf          PostgresRoutineStatementKind = "if"
+	PostgresRoutineStatementCase        PostgresRoutineStatementKind = "case"
+	PostgresRoutineStatementLoop        PostgresRoutineStatementKind = "loop"
+)
+
+// PostgresRoutineStatement is one top-level statement inside a PostgreSQL
+// routine body.
+type PostgresRoutineStatement struct {
+	Kind PostgresRoutineStatementKind
+	SQL  string
+}
+
 // MySQLRoutineNode represents a MySQL-family CREATE FUNCTION or CREATE
 // PROCEDURE statement parsed through the dialect-specific routine layer.
 type MySQLRoutineNode struct {
@@ -128,6 +200,34 @@ func (n *MySQLRoutineNode) SetCharacteristics(characteristics []string) *MySQLRo
 // Accept renders MySQL routines through the raw SQL visitor contract while
 // keeping the structured routine metadata available to parser consumers.
 func (n *MySQLRoutineNode) Accept(visitor Visitor) error {
+	raw := RawSQLNode{SQL: n.SQL}
+	return visitor.VisitRawSQL(&raw)
+}
+
+// NewPostgresDoBlock creates a PostgreSQL DO block node.
+func NewPostgresDoBlock(sql string) *PostgresDoBlockNode {
+	return &PostgresDoBlockNode{SQL: strings.TrimSpace(sql)}
+}
+
+// NewPostgresRoutine creates a PostgreSQL routine node.
+func NewPostgresRoutine(sql, dialect string, kind RoutineKind) *PostgresRoutineNode {
+	return &PostgresRoutineNode{
+		SQL:     strings.TrimSpace(sql),
+		Dialect: dialect,
+		Kind:    kind,
+	}
+}
+
+// Accept renders PostgreSQL DO blocks through the raw SQL visitor contract
+// while keeping routine-body metadata available to parser consumers.
+func (n *PostgresDoBlockNode) Accept(visitor Visitor) error {
+	raw := RawSQLNode{SQL: n.SQL}
+	return visitor.VisitRawSQL(&raw)
+}
+
+// Accept renders PostgreSQL routines through the raw SQL visitor contract while
+// keeping routine-body metadata available to parser consumers.
+func (n *PostgresRoutineNode) Accept(visitor Visitor) error {
 	raw := RawSQLNode{SQL: n.SQL}
 	return visitor.VisitRawSQL(&raw)
 }

--- a/core/ast/routines_test.go
+++ b/core/ast/routines_test.go
@@ -60,3 +60,52 @@ func TestMySQLRoutineNode_AcceptPropagatesRawSQLError(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() SELECT 1;"})
 }
+
+func TestNewPostgresDoBlock(t *testing.T) {
+	c := qt.New(t)
+
+	block := ast.NewPostgresDoBlock(" DO $$ BEGIN RAISE NOTICE 'x'; END $$; ")
+
+	c.Assert(block.SQL, qt.Equals, "DO $$ BEGIN RAISE NOTICE 'x'; END $$;")
+	c.Assert(block.Language, qt.Equals, "")
+	c.Assert(block.Body.SQL, qt.Equals, "")
+}
+
+func TestPostgresDoBlockNode_AcceptDelegatesToRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	block := ast.NewPostgresDoBlock(" DO $$ BEGIN PERFORM 1; END $$; ")
+	visitor := &mocks.MockVisitor{}
+
+	err := block.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(block.SQL, qt.Equals, "DO $$ BEGIN PERFORM 1; END $$;")
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:DO $$ BEGIN PERFORM 1; END $$;"})
+}
+
+func TestNewPostgresRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewPostgresRoutine(" CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$; ", "postgres", ast.RoutineKindProcedure)
+	routine.Name = "p"
+	routine.Language = "sql"
+
+	c.Assert(routine.SQL, qt.Equals, "CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$;")
+	c.Assert(routine.Dialect, qt.Equals, "postgres")
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Name, qt.Equals, "p")
+	c.Assert(routine.Language, qt.Equals, "sql")
+}
+
+func TestPostgresRoutineNode_AcceptDelegatesToRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewPostgresRoutine(" CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$; ", "postgres", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$;"})
+}

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -119,6 +119,16 @@ for local variables, named conditions, cursors, and handlers. Labels and
 control-flow statement classes are still distinguished without parsing scalar
 SQL expressions.
 
+PostgreSQL-family dialect mode keeps `CREATE FUNCTION` rendering on
+`ast.CreateFunctionNode`, but attaches parser-only `PostgresRoutineBody`
+metadata for quoted, SQL-standard `RETURN`, and `BEGIN ATOMIC` bodies.
+`CREATE PROCEDURE` and `DO` blocks become PostgreSQL-specific routine nodes in
+PostgreSQL-family dialect mode and still render through the raw-SQL visitor
+contract.
+PL/pgSQL expressions remain raw; the body parser classifies top-level
+declarations, block statements, exceptions, returns, dynamic execution, raises,
+and control-flow statements.
+
 When a dialect-aware routine boundary is known but the body sub-language is not
 structured yet, the parser returns an `ast.OpaqueRoutineNode`: renderers emit its
 SQL through the raw-SQL visitor contract, while parser consumers can still

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -134,6 +134,9 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 
 func (p *Parser) parseDoStatement() (ast.Node, error) {
 	statementStart := p.current.Start
+	if p.isPostgresRoutineDialect() {
+		return p.parsePostgresDoStatement(statementStart)
+	}
 	p.advance()
 	sql, err := p.collectRawStatement(statementStart, "DO statement")
 	if err != nil {
@@ -533,6 +536,7 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 	if raw {
 		return ast.NewRawSQL(p.rawStatement(statementStart)), nil
 	}
+	p.attachPostgresFunctionBody(function)
 	return function, nil
 }
 
@@ -825,6 +829,9 @@ func (p *Parser) parseFunctionBody(function *ast.CreateFunctionNode) error {
 
 	body := p.current.Value
 	function.SetBody(stripSQLStringDelimiters(body))
+	if p.isPostgresRoutineDialect() {
+		function.RoutineBody = &ast.PostgresRoutineBody{Delimiter: dollarQuoteDelimiter(body)}
+	}
 	p.advance()
 	return nil
 }

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -448,6 +448,50 @@ CREATE INDEX idx_users_name ON users (name);`
 	c.Assert(index.Columns, qt.DeepEquals, []string{"name"})
 }
 
+func TestParser_ParsePostgresDialectDoBlockAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `DO $do$
+DECLARE
+    created boolean;
+BEGIN
+    IF NOT created THEN
+        RAISE NOTICE 'missing';
+    END IF;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END;
+$do$;
+CREATE INDEX idx_users_name ON users (name);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	block, ok := statements.Statements[0].(*ast.PostgresDoBlockNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(block.SQL, qt.Contains, "DO $do$")
+	c.Assert(block.Language, qt.Equals, "plpgsql")
+	c.Assert(block.Body.Delimiter, qt.Equals, "$do$")
+	c.Assert(block.Body.Language, qt.Equals, "plpgsql")
+	c.Assert(block.Body.SQL, qt.Contains, "DECLARE")
+	c.Assert(block.Body.SQL, qt.Contains, "RAISE NOTICE 'missing';")
+	c.Assert(postgresRoutineStatementKinds(block.Body.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementDeclaration,
+		ast.PostgresRoutineStatementIf,
+		ast.PostgresRoutineStatementException,
+	})
+	rendered, err := renderer.RenderSQL(platform.Postgres, block)
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, "DO $do$")
+	c.Assert(rendered, qt.Contains, "RAISE NOTICE 'missing';")
+
+	index, ok := statements.Statements[1].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_name")
+}
+
 func TestParser_ParsePostgresExecuteFunctionTriggerAsRawSQL(t *testing.T) {
 	c := qt.New(t)
 
@@ -694,6 +738,377 @@ AS $$ SELECT value + 1; $$;`
 	c.Assert(createFunction.Language, qt.Equals, "sql")
 	c.Assert(createFunction.Volatility, qt.Equals, "IMMUTABLE")
 	c.Assert(createFunction.Body, qt.Equals, " SELECT value + 1; ")
+}
+
+func TestParser_ParsePostgresDialectSQLFunctionRoutineBodyMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.add_one(value integer)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT value + 1; $$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Body, qt.Equals, " SELECT value + 1; ")
+	c.Assert(createFunction.BodyKind, qt.Equals, ast.FunctionBodyQuoted)
+	c.Assert(createFunction.Language, qt.Equals, "sql")
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(*createFunction.RoutineBody, qt.DeepEquals, ast.PostgresRoutineBody{
+		SQL:       " SELECT value + 1; ",
+		Delimiter: "$$",
+		Language:  "sql",
+		Statements: []ast.PostgresRoutineStatement{{
+			Kind: ast.PostgresRoutineStatementRaw,
+			SQL:  "SELECT value + 1;",
+		}},
+	})
+}
+
+func TestParser_ParsePostgresDialectFunctionRoutineBodyMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.touch_user(user_id integer)
+RETURNS integer
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+    changed integer;
+BEGIN
+    EXECUTE 'SELECT 1';
+    RETURN user_id;
+END;
+$fn$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(createFunction.RoutineBody.Delimiter, qt.Equals, "$fn$")
+	c.Assert(createFunction.RoutineBody.Language, qt.Equals, "plpgsql")
+	c.Assert(createFunction.RoutineBody.SQL, qt.Contains, "DECLARE")
+	c.Assert(createFunction.RoutineBody.SQL, qt.Contains, "EXECUTE 'SELECT 1';")
+	c.Assert(createFunction.RoutineBody.SQL, qt.Contains, "RETURN user_id;")
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementDeclaration,
+		ast.PostgresRoutineStatementExecute,
+		ast.PostgresRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseGenericFunctionDoesNotClaimPostgresRoutineBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.add_one(value integer)
+RETURNS integer
+LANGUAGE sql
+AS $$ SELECT value + 1; $$;`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNil)
+}
+
+func TestParser_ParsePostgresDialectFunctionTaggedDollarQuoteBoundary(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.has_inner_delimiter()
+RETURNS void
+AS $fn$
+BEGIN
+    PERFORM '$$ not the delimiter';
+END;
+$fn$
+LANGUAGE plpgsql;
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(createFunction.RoutineBody.Delimiter, qt.Equals, "$fn$")
+	c.Assert(createFunction.RoutineBody.SQL, qt.Contains, "PERFORM '$$ not the delimiter';")
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementPerform,
+	})
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParsePostgresDialectFunctionNestedBlockRoutineBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.nested_block()
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    BEGIN
+        PERFORM 1;
+    END;
+    RETURN;
+END;
+$fn$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementBlock,
+		ast.PostgresRoutineStatementReturn,
+	})
+	c.Assert(createFunction.RoutineBody.Statements[0].SQL, qt.Contains, "PERFORM 1;")
+}
+
+func TestParser_ParsePostgresDialectFunctionSQLForUpdateDoesNotOpenLoop(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.lock_then_return()
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    PERFORM 1 FROM users FOR UPDATE;
+    RETURN;
+END;
+$fn$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementPerform,
+		ast.PostgresRoutineStatementReturn,
+	})
+	c.Assert(createFunction.RoutineBody.Statements[0].SQL, qt.Contains, "FOR UPDATE")
+}
+
+func TestParser_ParsePostgresDialectFunctionForLoopStatement(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.loop_then_return()
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    FOR i IN 1..3 LOOP
+        PERFORM i;
+    END LOOP;
+    RETURN;
+END;
+$fn$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementLoop,
+		ast.PostgresRoutineStatementReturn,
+	})
+	c.Assert(createFunction.RoutineBody.Statements[0].SQL, qt.Contains, "PERFORM i;")
+}
+
+func TestParser_ParsePostgresDialectTriggerFunctionBodyAndReference(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$fn$;
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_updated_at();`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.Returns, qt.Equals, "trigger")
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(createFunction.RoutineBody.SQL, qt.Contains, "NEW.updated_at := now();")
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementRaw,
+		ast.PostgresRoutineStatementReturn,
+	})
+
+	rawTrigger, ok := statements.Statements[1].(*ast.RawSQLNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(rawTrigger.SQL, qt.Contains, "EXECUTE FUNCTION public.touch_updated_at()")
+}
+
+func TestParser_ParsePostgresDialectProcedureRoutineBodyMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE public.touch_user(IN user_id integer)
+LANGUAGE plpgsql
+AS $proc$
+BEGIN
+    PERFORM user_id;
+END;
+$proc$;
+CREATE TABLE after_proc (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.PostgresRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Dialect, qt.Equals, platform.Postgres)
+	c.Assert(routine.Name, qt.Equals, "public.touch_user")
+	c.Assert(routine.Parameters, qt.Equals, "IN user_id integer")
+	c.Assert(routine.Language, qt.Equals, "plpgsql")
+	c.Assert(routine.Body.Delimiter, qt.Equals, "$proc$")
+	c.Assert(routine.Body.SQL, qt.Contains, "PERFORM user_id;")
+	c.Assert(postgresRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementPerform,
+	})
+	rendered, err := renderer.RenderSQL(platform.Postgres, routine)
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, "CREATE PROCEDURE public.touch_user")
+	c.Assert(rendered, qt.Contains, "PERFORM user_id;")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
+func TestParser_ParsePostgresDialectProcedureBodyUsesASString(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE public.greet(IN name text DEFAULT 'guest')
+LANGUAGE plpgsql
+AS $proc$
+BEGIN
+    RAISE NOTICE '%', name;
+END;
+$proc$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.PostgresRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Parameters, qt.Equals, "IN name text DEFAULT 'guest'")
+	c.Assert(routine.Body.SQL, qt.Contains, "RAISE NOTICE '%', name;")
+	c.Assert(routine.Body.SQL, qt.Not(qt.Equals), "guest")
+}
+
+func TestParser_ParsePostgresDialectProcedureAtomicBody(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE public.insert_data(a integer, b integer)
+LANGUAGE SQL
+BEGIN ATOMIC
+    INSERT INTO tbl VALUES (a);
+    INSERT INTO tbl VALUES (b);
+END;
+CREATE TABLE after_atomic (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.PostgresRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Language, qt.Equals, "sql")
+	c.Assert(routine.Body.SQL, qt.Contains, "BEGIN ATOMIC")
+	c.Assert(routine.Body.SQL, qt.Contains, "INSERT INTO tbl VALUES (b);")
+	c.Assert(routine.Body.Statements, qt.DeepEquals, []ast.PostgresRoutineStatement{{
+		Kind: ast.PostgresRoutineStatementRaw,
+		SQL:  routine.Body.SQL,
+	}})
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_atomic")
+}
+
+func TestParser_ParsePostgresRoutineBodyLoopDepth(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION public.looping()
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    FOR i IN 1..2 LOOP
+        RAISE NOTICE '%', i;
+    END LOOP;
+    WHILE false LOOP
+        RAISE NOTICE 'never';
+    END LOOP;
+    FOREACH item IN ARRAY ARRAY[1, 2] LOOP
+        RAISE NOTICE '%', item;
+    END LOOP;
+    RETURN;
+END;
+$fn$;`
+	p := parser.NewParser(sql, parser.WithDialect(platform.Postgres))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createFunction, ok := statements.Statements[0].(*ast.CreateFunctionNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createFunction.RoutineBody, qt.IsNotNil)
+	c.Assert(postgresRoutineStatementKinds(createFunction.RoutineBody.Statements), qt.DeepEquals, []ast.PostgresRoutineStatementKind{
+		ast.PostgresRoutineStatementLoop,
+		ast.PostgresRoutineStatementLoop,
+		ast.PostgresRoutineStatementLoop,
+		ast.PostgresRoutineStatementReturn,
+	})
 }
 
 func TestParser_ParseCreateOrReplaceFunction(t *testing.T) {
@@ -1480,6 +1895,14 @@ END;`
 
 func routineStatementKinds(statements []ast.MySQLRoutineStatement) []ast.MySQLRoutineStatementKind {
 	kinds := make([]ast.MySQLRoutineStatementKind, 0, len(statements))
+	for _, stmt := range statements {
+		kinds = append(kinds, stmt.Kind)
+	}
+	return kinds
+}
+
+func postgresRoutineStatementKinds(statements []ast.PostgresRoutineStatement) []ast.PostgresRoutineStatementKind {
+	kinds := make([]ast.PostgresRoutineStatementKind, 0, len(statements))
 	for _, stmt := range statements {
 		kinds = append(kinds, stmt.Kind)
 	}

--- a/core/parser/postgres_routine.go
+++ b/core/parser/postgres_routine.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -186,14 +187,14 @@ func parsePostgresSQLBody(sql string, tokens []lexer.Token) string {
 }
 
 func postgresRoutineStatementEnd(sql string, tokens []lexer.Token) int {
-	for i := len(tokens) - 1; i >= 0; i-- {
-		switch tokens[i].Type {
+	for _, tok := range slices.Backward(tokens) {
+		switch tok.Type {
 		case lexer.TokenEOF, lexer.TokenWhitespace, lexer.TokenComment:
 			continue
 		case lexer.TokenSemicolon:
-			return tokens[i].Start
+			return tok.Start
 		default:
-			return tokens[i].End
+			return tok.End
 		}
 	}
 	return len(sql)

--- a/core/parser/postgres_routine.go
+++ b/core/parser/postgres_routine.go
@@ -1,0 +1,505 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/platform"
+)
+
+type postgresRoutineParser struct{}
+
+func (postgresRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
+	if target == "PROCEDURE" {
+		sql, err := p.collectPostgresRoutineStatement(statementStart)
+		if err != nil {
+			return nil, err
+		}
+		return parsePostgresRoutineSQL(sql, p.dialect, ast.RoutineKindProcedure), nil
+	}
+	return p.parseCreateFunction(statementStart)
+}
+
+func (postgresRoutineParser) parseCreateDefinerRoutine(p *Parser, statementStart int) (ast.Node, error) {
+	return compatibilityRoutineParser{}.parseCreateDefinerRoutine(p, statementStart)
+}
+
+func (p *Parser) isPostgresRoutineDialect() bool {
+	return platform.IsPostgresFamily(p.dialect)
+}
+
+func (p *Parser) parsePostgresDoStatement(statementStart int) (ast.Node, error) {
+	p.advance()
+	sql, err := p.collectRawStatement(statementStart, "DO statement")
+	if err != nil {
+		return nil, err
+	}
+
+	block := ast.NewPostgresDoBlock(sql)
+	body, language := parsePostgresDoBlockSQL(sql)
+	block.Language = language
+	block.Body = body
+	return block, nil
+}
+
+func (p *Parser) collectPostgresRoutineStatement(statementStart int) (string, error) {
+	blockDepth := 0
+	for !p.isAtEnd() {
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+		if p.current.Type == lexer.TokenSemicolon && blockDepth == 0 {
+			sql := p.rawStatement(statementStart)
+			p.advance()
+			return sql, nil
+		}
+		if p.current.Type == lexer.TokenIdentifier {
+			trackPostgresSQLBodyKeyword(p.current.Value, &blockDepth)
+		}
+		p.advance()
+	}
+
+	if blockDepth > 0 {
+		return "", fmt.Errorf("unterminated CREATE PROCEDURE body at position %d", p.current.Start)
+	}
+	return p.rawStatementFragment(statementStart, p.previous.End), nil
+}
+
+func (p *Parser) attachPostgresFunctionBody(function *ast.CreateFunctionNode) {
+	if !p.isPostgresRoutineDialect() || function == nil {
+		return
+	}
+	delimiter := ""
+	if function.RoutineBody != nil {
+		delimiter = function.RoutineBody.Delimiter
+	}
+	body := parsePostgresRoutineBody(function.Body, function.Language, delimiter)
+	function.RoutineBody = &body
+}
+
+func parsePostgresDoBlockSQL(sql string) (ast.PostgresRoutineBody, string) {
+	tokens := tokenizePostgresRoutineSQL(sql)
+	bodyIdx := -1
+	language := ""
+	for i, tok := range tokens {
+		if tok.Type == lexer.TokenString && bodyIdx == -1 {
+			bodyIdx = i
+			continue
+		}
+		if tok.MatchIdentifierValue("LANGUAGE") {
+			if langIdx := nextPostgresRoutineToken(tokens, i+1); langIdx != -1 {
+				language = tokens[langIdx].Value
+			}
+		}
+	}
+	if language == "" {
+		language = "plpgsql"
+	}
+	language = strings.ToLower(language)
+	if bodyIdx == -1 {
+		return ast.PostgresRoutineBody{Language: language}, language
+	}
+
+	bodyToken := tokens[bodyIdx].Value
+	return parsePostgresRoutineBody(stripSQLStringDelimiters(bodyToken), language, dollarQuoteDelimiter(bodyToken)), language
+}
+
+func parsePostgresRoutineSQL(sql, dialect string, kind ast.RoutineKind) *ast.PostgresRoutineNode {
+	tokens := tokenizePostgresRoutineSQL(sql)
+	routine := ast.NewPostgresRoutine(sql, dialect, kind)
+	routine.Name, routine.Parameters = parsePostgresRoutineHeader(sql, tokens, strings.ToUpper(string(kind)))
+
+	bodyToken, language := parsePostgresRoutineBodyClause(tokens)
+	routine.Language = strings.ToLower(language)
+	if bodyToken != "" {
+		routine.Body = parsePostgresRoutineBody(stripSQLStringDelimiters(bodyToken), routine.Language, dollarQuoteDelimiter(bodyToken))
+	} else if bodySQL := parsePostgresSQLBody(sql, tokens); bodySQL != "" {
+		routine.Body = parsePostgresRoutineBody(bodySQL, routine.Language, "")
+	}
+	return routine
+}
+
+func parsePostgresRoutineHeader(sql string, tokens []lexer.Token, keyword string) (name string, parameters string) {
+	for i, tok := range tokens {
+		if !tok.MatchIdentifierValue(keyword) {
+			continue
+		}
+		nameIdx := nextPostgresRoutineToken(tokens, i+1)
+		if nameIdx == -1 {
+			return "", ""
+		}
+		for j := nameIdx; j < len(tokens); j++ {
+			if tokens[j].MatchOperatorValue("(") {
+				name := strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[j].Start])
+				params := parsePostgresRoutineParameters(sql, tokens, j)
+				return name, params
+			}
+		}
+		return strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[len(tokens)-1].Start]), ""
+	}
+	return "", ""
+}
+
+func parsePostgresRoutineParameters(sql string, tokens []lexer.Token, openIdx int) string {
+	depth := 0
+	paramsStart := tokens[openIdx].End
+	for i := openIdx; i < len(tokens); i++ {
+		switch {
+		case tokens[i].MatchOperatorValue("("):
+			depth++
+		case tokens[i].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(sql[paramsStart:tokens[i].Start])
+			}
+		}
+	}
+	return ""
+}
+
+func parsePostgresRoutineBodyClause(tokens []lexer.Token) (bodyToken string, language string) {
+	for i, tok := range tokens {
+		if tok.MatchIdentifierValue("LANGUAGE") {
+			if langIdx := nextPostgresRoutineToken(tokens, i+1); langIdx != -1 {
+				language = tokens[langIdx].Value
+			}
+			continue
+		}
+		if tok.MatchIdentifierValue("AS") && bodyToken == "" {
+			if bodyIdx := nextPostgresRoutineToken(tokens, i+1); bodyIdx != -1 && tokens[bodyIdx].Type == lexer.TokenString {
+				bodyToken = tokens[bodyIdx].Value
+			}
+		}
+	}
+	return bodyToken, language
+}
+
+func parsePostgresSQLBody(sql string, tokens []lexer.Token) string {
+	for _, tok := range tokens {
+		if tok.MatchIdentifierValue("BEGIN") {
+			return strings.TrimSpace(sql[tok.Start:postgresRoutineStatementEnd(sql, tokens)])
+		}
+	}
+	return ""
+}
+
+func postgresRoutineStatementEnd(sql string, tokens []lexer.Token) int {
+	for i := len(tokens) - 1; i >= 0; i-- {
+		switch tokens[i].Type {
+		case lexer.TokenEOF, lexer.TokenWhitespace, lexer.TokenComment:
+			continue
+		case lexer.TokenSemicolon:
+			return tokens[i].Start
+		default:
+			return tokens[i].End
+		}
+	}
+	return len(sql)
+}
+
+func parsePostgresRoutineBody(sql, language, delimiter string) ast.PostgresRoutineBody {
+	body := ast.PostgresRoutineBody{
+		SQL:       sql,
+		Delimiter: delimiter,
+		Language:  strings.ToLower(language),
+	}
+	if strings.EqualFold(language, "plpgsql") {
+		body.Statements = parsePostgresPLpgSQLStatements(sql)
+		return body
+	}
+	if strings.TrimSpace(sql) != "" {
+		body.Statements = []ast.PostgresRoutineStatement{{
+			Kind: ast.PostgresRoutineStatementRaw,
+			SQL:  strings.TrimSpace(sql),
+		}}
+	}
+	return body
+}
+
+func parsePostgresPLpgSQLStatements(sql string) []ast.PostgresRoutineStatement {
+	parser := postgresRoutineBodyParser{
+		input:  sql,
+		tokens: newPostgresRoutineTokenizer(sql).tokens(),
+	}
+	return parser.parseStatements()
+}
+
+// postgresRoutineTokenizer is the PostgreSQL routine sub-language tokenization
+// boundary. It intentionally reuses the shared SQL token primitives for string,
+// comment, and identifier handling, while keeping routine-body parsing separate
+// from the generic SQL statement parser.
+type postgresRoutineTokenizer struct {
+	lexer *lexer.Lexer
+}
+
+func newPostgresRoutineTokenizer(sql string) postgresRoutineTokenizer {
+	return postgresRoutineTokenizer{lexer: lexer.NewLexer(sql)}
+}
+
+func (t postgresRoutineTokenizer) tokens() []lexer.Token {
+	tokens := make([]lexer.Token, 0)
+	for {
+		tok := t.lexer.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Type == lexer.TokenEOF {
+			return tokens
+		}
+	}
+}
+
+type postgresRoutineBodyParser struct {
+	input  string
+	tokens []lexer.Token
+}
+
+func (p postgresRoutineBodyParser) parseStatements() []ast.PostgresRoutineStatement {
+	startIdx := p.nextSignificant(0)
+	if startIdx == -1 {
+		return nil
+	}
+
+	statements := make([]ast.PostgresRoutineStatement, 0)
+	if p.tokens[startIdx].MatchIdentifierValue("DECLARE") {
+		declareEndIdx := p.findTopLevelKeyword(startIdx+1, "BEGIN")
+		if declareEndIdx == -1 {
+			return []ast.PostgresRoutineStatement{p.statement(startIdx, len(p.tokens)-1)}
+		}
+		statements = append(statements, ast.PostgresRoutineStatement{
+			Kind: ast.PostgresRoutineStatementDeclaration,
+			SQL:  p.rawTokenRange(startIdx, p.tokens[declareEndIdx].Start),
+		})
+		startIdx = declareEndIdx
+	}
+
+	if p.tokens[startIdx].MatchIdentifierValue("BEGIN") {
+		return append(statements, p.parseOuterBlockStatements(startIdx)...)
+	}
+	return append(statements, p.statement(startIdx, len(p.tokens)-1))
+}
+
+func (p postgresRoutineBodyParser) parseOuterBlockStatements(beginIdx int) []ast.PostgresRoutineStatement {
+	endIdx := p.findMatchingBlockEnd(beginIdx)
+	if endIdx == -1 {
+		return []ast.PostgresRoutineStatement{p.statement(beginIdx, len(p.tokens)-1)}
+	}
+
+	statements := make([]ast.PostgresRoutineStatement, 0)
+	statementStartIdx := -1
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+
+	for i := beginIdx + 1; i < endIdx; i++ {
+		tok := p.tokens[i]
+		if statementStartIdx == -1 {
+			if isPostgresRoutineTrivia(tok) {
+				continue
+			}
+			statementStartIdx = i
+		}
+
+		if tok.MatchIdentifierValue("EXCEPTION") && depth == 0 && caseDepth == 0 {
+			if statementStartIdx != -1 && statementStartIdx != i {
+				statements = append(statements, p.statement(statementStartIdx, i))
+			}
+			statements = append(statements, ast.PostgresRoutineStatement{
+				Kind: ast.PostgresRoutineStatementException,
+				SQL:  p.rawTokenRange(i, p.tokens[endIdx].Start),
+			})
+			return statements
+		}
+
+		if tok.Type == lexer.TokenIdentifier {
+			trackPostgresRoutineKeyword(tok.Value, &depth, &caseDepth, &pendingEndTrailer)
+		}
+
+		if tok.Type == lexer.TokenSemicolon && depth == 0 && caseDepth == 0 && statementStartIdx != -1 {
+			statements = append(statements, p.statement(statementStartIdx, i))
+			statementStartIdx = -1
+			pendingEndTrailer = false
+			continue
+		}
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+		}
+	}
+
+	if statementStartIdx != -1 {
+		statements = append(statements, p.statement(statementStartIdx, endIdx))
+	}
+	return statements
+}
+
+func (p postgresRoutineBodyParser) statement(startIdx, endIdx int) ast.PostgresRoutineStatement {
+	if startIdx < 0 || endIdx >= len(p.tokens) || startIdx > endIdx {
+		return ast.PostgresRoutineStatement{}
+	}
+	end := p.tokens[endIdx].End
+	if p.tokens[endIdx].Type == lexer.TokenEOF {
+		end = p.tokens[endIdx].Start
+	}
+	return ast.PostgresRoutineStatement{
+		Kind: p.classifyStatement(startIdx),
+		SQL:  strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end)),
+	}
+}
+
+func (p postgresRoutineBodyParser) classifyStatement(startIdx int) ast.PostgresRoutineStatementKind {
+	if startIdx < 0 || startIdx >= len(p.tokens) || p.tokens[startIdx].Type != lexer.TokenIdentifier {
+		return ast.PostgresRoutineStatementRaw
+	}
+	switch strings.ToUpper(p.tokens[startIdx].Value) {
+	case "BEGIN":
+		return ast.PostgresRoutineStatementBlock
+	case "RETURN", "RETURNING":
+		return ast.PostgresRoutineStatementReturn
+	case "PERFORM":
+		return ast.PostgresRoutineStatementPerform
+	case "EXECUTE":
+		return ast.PostgresRoutineStatementExecute
+	case "RAISE":
+		return ast.PostgresRoutineStatementRaise
+	case "IF":
+		return ast.PostgresRoutineStatementIf
+	case "CASE":
+		return ast.PostgresRoutineStatementCase
+	case "LOOP", "FOR", "WHILE", "FOREACH":
+		return ast.PostgresRoutineStatementLoop
+	default:
+		return ast.PostgresRoutineStatementRaw
+	}
+}
+
+func (p postgresRoutineBodyParser) findMatchingBlockEnd(beginIdx int) int {
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+	for i := beginIdx; i < len(p.tokens); i++ {
+		tok := p.tokens[i]
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+		trackPostgresRoutineKeyword(tok.Value, &depth, &caseDepth, &pendingEndTrailer)
+		if depth == 0 && tok.MatchIdentifierValue("END") {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p postgresRoutineBodyParser) findTopLevelKeyword(startIdx int, keyword string) int {
+	depth := 0
+	caseDepth := 0
+	pendingEndTrailer := false
+	for i := startIdx; i < len(p.tokens); i++ {
+		tok := p.tokens[i]
+		if tok.Type == lexer.TokenSemicolon {
+			pendingEndTrailer = false
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+		if depth == 0 && caseDepth == 0 && tok.MatchIdentifierValue(keyword) {
+			return i
+		}
+		trackPostgresRoutineKeyword(tok.Value, &depth, &caseDepth, &pendingEndTrailer)
+	}
+	return -1
+}
+
+func trackPostgresRoutineKeyword(value string, blockDepth, caseDepth *int, pendingEndTrailer *bool) {
+	keyword := strings.ToUpper(value)
+	if *pendingEndTrailer {
+		*pendingEndTrailer = false
+		if isPostgresRoutineEndTrailerKeyword(keyword) {
+			return
+		}
+	}
+
+	switch keyword {
+	case "BEGIN", "IF", "LOOP":
+		(*blockDepth)++
+	case "CASE":
+		(*caseDepth)++
+	case "END":
+		if *caseDepth > 0 {
+			(*caseDepth)--
+		} else if *blockDepth > 0 {
+			(*blockDepth)--
+		}
+		*pendingEndTrailer = true
+	}
+}
+
+func trackPostgresSQLBodyKeyword(value string, blockDepth *int) {
+	switch strings.ToUpper(value) {
+	case "BEGIN":
+		(*blockDepth)++
+	case "END":
+		if *blockDepth > 0 {
+			(*blockDepth)--
+		}
+	}
+}
+
+func isPostgresRoutineEndTrailerKeyword(keyword string) bool {
+	switch keyword {
+	case "CASE", "IF", "LOOP":
+		return true
+	default:
+		return false
+	}
+}
+
+func tokenizePostgresRoutineSQL(sql string) []lexer.Token {
+	return newPostgresRoutineTokenizer(sql).tokens()
+}
+
+func nextPostgresRoutineToken(tokens []lexer.Token, startIdx int) int {
+	for i := max(startIdx, 0); i < len(tokens); i++ {
+		if !isPostgresRoutineTrivia(tokens[i]) && tokens[i].Type != lexer.TokenEOF {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p postgresRoutineBodyParser) nextSignificant(startIdx int) int {
+	return nextPostgresRoutineToken(p.tokens, startIdx)
+}
+
+func isPostgresRoutineTrivia(tok lexer.Token) bool {
+	return tok.Type == lexer.TokenWhitespace || tok.Type == lexer.TokenComment
+}
+
+func (p postgresRoutineBodyParser) rawTokenRange(startIdx int, end int) string {
+	if startIdx < 0 || startIdx >= len(p.tokens) {
+		return ""
+	}
+	return strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end))
+}
+
+func (p postgresRoutineBodyParser) rawFragment(start, end int) string {
+	if start < 0 || start > end || end > len(p.input) {
+		return ""
+	}
+	return p.input[start:end]
+}
+
+func dollarQuoteDelimiter(value string) string {
+	if !strings.HasPrefix(value, "$") {
+		return ""
+	}
+	end := strings.Index(value[1:], "$")
+	if end < 0 {
+		return ""
+	}
+	return value[:end+2]
+}

--- a/core/parser/routine.go
+++ b/core/parser/routine.go
@@ -20,6 +20,9 @@ func (p *Parser) routineParser() routineParser {
 	case platform.SQLServer:
 		return sqlServerRoutineParser{}
 	default:
+		if platform.IsPostgresFamily(p.dialect) {
+			return postgresRoutineParser{}
+		}
 		return compatibilityRoutineParser{}
 	}
 }

--- a/core/sqllint/lint.go
+++ b/core/sqllint/lint.go
@@ -338,6 +338,10 @@ func (unsupportedRoutineRule) CheckStatement(ctx Context, stmt ast.Node) []Findi
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.OpaqueRoutineNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
+	case *ast.PostgresDoBlockNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("DO", 0)}
+	case *ast.PostgresRoutineNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.CreateFunctionNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE FUNCTION", 0)}
 	case *ast.CreateTriggerNode:


### PR DESCRIPTION
## Summary
- add PostgreSQL-family routine nodes for DO blocks and CREATE PROCEDURE while preserving executable SQL through the raw-SQL visitor contract
- attach parser-only PostgreSQL routine body metadata to CREATE FUNCTION in dialect-aware mode
- classify top-level PL/pgSQL declarations, nested blocks, exception sections, returns, execution, raises, and control-flow statements without parsing scalar expressions
- keep default dialect-independent parsing conservative and document the routine-body contract

Fixes #324

## Validation
- gopls diagnostics on changed Go files
- go test ./core/ast ./core/parser ./core/sqllint -count=1
- go tool qtlint ./...
- golangci-lint run ./...
- go test -race ./core/parser -count=1
- go test ./... -count=1

## Self-review
- pass 1 checked issue #324 acceptance coverage and default parser behavior
- pass 2 checked statement-boundary edge cases and fixed SQL FOR UPDATE being mistaken for a PL/pgSQL loop opener