### PR TITLE
Add SQL Server routine body metadata

### DIFF
--- a/cmd/sql/sql.go
+++ b/cmd/sql/sql.go
@@ -68,7 +68,7 @@ directory specific.`,
 	}
 
 	flags := cmd.Flags()
-	flags.StringVar(&dialect, "dialect", "", "Target dialect: postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner")
+	flags.StringVar(&dialect, "dialect", "", "Target dialect: postgres, mysql, mariadb, sqlite, sqlserver, clickhouse, cockroachdb, yugabytedb, or spanner")
 	flags.StringVar(&version, "version", "", "Server version string used to refine target capabilities")
 	flags.StringVar(&format, "format", formatText, "Output format: text or json")
 	flags.BoolVar(&stdin, "stdin", false, "Read SQL from stdin")
@@ -149,7 +149,7 @@ func validateSQLLintOptions(opts sqlLintOptions) error {
 		return fmt.Errorf("invalid --format value %q: expected text or json", opts.format)
 	}
 	if opts.dialect != "" && platform.NormalizeDialect(opts.dialect) == "" {
-		return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner", opts.dialect)
+		return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, mariadb, sqlite, sqlserver, clickhouse, cockroachdb, yugabytedb, or spanner", opts.dialect)
 	}
 	if opts.version != "" && opts.dialect == "" {
 		return fmt.Errorf("--version requires --dialect")

--- a/core/ast/routines.go
+++ b/core/ast/routines.go
@@ -77,6 +77,70 @@ type PostgresRoutineStatement struct {
 	SQL  string
 }
 
+// SQLServerRoutineNode represents a SQL Server CREATE FUNCTION or CREATE
+// PROCEDURE statement parsed through the dialect-specific routine layer.
+type SQLServerRoutineNode struct {
+	// SQL is the complete executable routine statement without GO separators.
+	SQL string
+	// Dialect is the normalized SQL dialect that selected this parser path.
+	Dialect string
+	// Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+	Kind RoutineKind
+	// Name is the routine name, including bracketed schema qualifiers.
+	Name string
+	// Parameters contains the raw parameter list without surrounding
+	// parentheses.
+	Parameters string
+	// Returns contains the raw T-SQL RETURNS clause for functions.
+	Returns string
+	// Form classifies the SQL Server routine shape.
+	Form SQLServerRoutineForm
+	// Body is parsed routine-body metadata. Expressions remain raw T-SQL.
+	Body SQLServerRoutineBody
+}
+
+// SQLServerRoutineForm identifies SQL Server function and procedure shapes.
+type SQLServerRoutineForm string
+
+const (
+	SQLServerRoutineFormProcedure                   SQLServerRoutineForm = "procedure"
+	SQLServerRoutineFormScalarFunction              SQLServerRoutineForm = "scalar_function"
+	SQLServerRoutineFormInlineTableValuedFunction   SQLServerRoutineForm = "inline_table_valued_function"
+	SQLServerRoutineFormMultiStatementTableFunction SQLServerRoutineForm = "multi_statement_table_valued_function"
+)
+
+// SQLServerRoutineBody contains parser metadata for a T-SQL routine body.
+type SQLServerRoutineBody struct {
+	// SQL is the raw body text after AS.
+	SQL string
+	// Statements are top-level T-SQL routine-body statements when boundaries
+	// are recoverable without parsing scalar expressions.
+	Statements []SQLServerRoutineStatement
+}
+
+// SQLServerRoutineStatementKind identifies a T-SQL routine-body statement
+// class.
+type SQLServerRoutineStatementKind string
+
+const (
+	SQLServerRoutineStatementRaw         SQLServerRoutineStatementKind = "raw"
+	SQLServerRoutineStatementDeclaration SQLServerRoutineStatementKind = "declaration"
+	SQLServerRoutineStatementAssignment  SQLServerRoutineStatementKind = "assignment"
+	SQLServerRoutineStatementBlock       SQLServerRoutineStatementKind = "block"
+	SQLServerRoutineStatementIf          SQLServerRoutineStatementKind = "if"
+	SQLServerRoutineStatementWhile       SQLServerRoutineStatementKind = "while"
+	SQLServerRoutineStatementReturn      SQLServerRoutineStatementKind = "return"
+	SQLServerRoutineStatementInsert      SQLServerRoutineStatementKind = "insert"
+	SQLServerRoutineStatementSelect      SQLServerRoutineStatementKind = "select"
+)
+
+// SQLServerRoutineStatement is one top-level statement inside a T-SQL routine
+// body.
+type SQLServerRoutineStatement struct {
+	Kind SQLServerRoutineStatementKind
+	SQL  string
+}
+
 // MySQLRoutineNode represents a MySQL-family CREATE FUNCTION or CREATE
 // PROCEDURE statement parsed through the dialect-specific routine layer.
 type MySQLRoutineNode struct {
@@ -228,6 +292,22 @@ func (n *PostgresDoBlockNode) Accept(visitor Visitor) error {
 // Accept renders PostgreSQL routines through the raw SQL visitor contract while
 // keeping routine-body metadata available to parser consumers.
 func (n *PostgresRoutineNode) Accept(visitor Visitor) error {
+	raw := RawSQLNode{SQL: n.SQL}
+	return visitor.VisitRawSQL(&raw)
+}
+
+// NewSQLServerRoutine creates a SQL Server routine node.
+func NewSQLServerRoutine(sql, dialect string, kind RoutineKind) *SQLServerRoutineNode {
+	return &SQLServerRoutineNode{
+		SQL:     strings.TrimSpace(sql),
+		Dialect: dialect,
+		Kind:    kind,
+	}
+}
+
+// Accept renders SQL Server routines through the raw SQL visitor contract while
+// keeping routine-body metadata available to parser consumers.
+func (n *SQLServerRoutineNode) Accept(visitor Visitor) error {
 	raw := RawSQLNode{SQL: n.SQL}
 	return visitor.VisitRawSQL(&raw)
 }

--- a/core/ast/routines_test.go
+++ b/core/ast/routines_test.go
@@ -109,3 +109,31 @@ func TestPostgresRoutineNode_AcceptDelegatesToRawSQL(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE p() LANGUAGE sql AS $$ SELECT 1 $$;"})
 }
+
+func TestNewSQLServerRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewSQLServerRoutine(" CREATE FUNCTION [dbo].[f]() RETURNS int AS BEGIN RETURN 1; END ", "sqlserver", ast.RoutineKindFunction)
+	routine.Name = "[dbo].[f]"
+	routine.Returns = "int"
+	routine.Form = ast.SQLServerRoutineFormScalarFunction
+
+	c.Assert(routine.SQL, qt.Equals, "CREATE FUNCTION [dbo].[f]() RETURNS int AS BEGIN RETURN 1; END")
+	c.Assert(routine.Dialect, qt.Equals, "sqlserver")
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "[dbo].[f]")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormScalarFunction)
+}
+
+func TestSQLServerRoutineNode_AcceptDelegatesToRawSQL(t *testing.T) {
+	c := qt.New(t)
+
+	routine := ast.NewSQLServerRoutine(" CREATE PROCEDURE [dbo].[p] AS SELECT 1; ", "sqlserver", ast.RoutineKindProcedure)
+	visitor := &mocks.MockVisitor{}
+
+	err := routine.Accept(visitor)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(visitor.VisitedNodes, qt.DeepEquals, []string{"RawSQL:CREATE PROCEDURE [dbo].[p] AS SELECT 1;"})
+}

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -129,6 +129,18 @@ PL/pgSQL expressions remain raw; the body parser classifies top-level
 declarations, block statements, exceptions, returns, dynamic execution, raises,
 and control-flow statements.
 
+SQL Server dialect mode parses `CREATE [OR ALTER] FUNCTION`,
+`CREATE [OR ALTER] PROCEDURE`, and `CREATE PROC` through a T-SQL routine layer.
+The parser preserves the executable statement in `ast.SQLServerRoutineNode.SQL`,
+strips line-scoped client `GO` batch separators from the node, and records
+routine metadata for scalar functions, inline table-valued functions,
+multi-statement table-valued functions, and procedures. `Returns` is the raw
+fragment between `RETURNS` and the body `AS`, so SQL Server routine options
+inside that fragment are preserved even when they are not structurally modeled
+yet. T-SQL scalar expressions remain raw; the body parser classifies
+recoverable top-level declarations, assignments, `BEGIN` blocks, `IF`, `WHILE`,
+`RETURN`, and `INSERT` / `SELECT` statements.
+
 When a dialect-aware routine boundary is known but the body sub-language is not
 structured yet, the parser returns an `ast.OpaqueRoutineNode`: renderers emit its
 SQL through the raw-SQL visitor contract, while parser consumers can still

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -122,8 +122,11 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseDoStatement()
 	case "GO":
 		// SQL Server tooling uses GO as a batch separator, not as schema DDL.
-		p.skipGoBatchSeparator()
-		return nil, nil
+		if p.isCurrentSQLServerGoBatchSeparator() {
+			p.skipGoBatchSeparator()
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unsupported SQL statement: %s at position %d", keyword, p.current.Start)
 	case "ANALYZE", "BEGIN", "CALL", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "SHOW", "UPDATE", "USE", "VACUUM", "WITH":
 		p.skipSchemaNeutralStatement()
 		return nil, nil
@@ -170,7 +173,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, TRIGGER, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, PROCEDURE, PROC, TRIGGER, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
@@ -185,7 +188,7 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateTable()
 	case "VIEW":
 		return p.parseCreateView()
-	case "FUNCTION", "PROCEDURE":
+	case "FUNCTION", "PROC", "PROCEDURE":
 		return p.parseCreateRoutine(target, statementStart)
 	case "DEFINER":
 		return p.parseCreateDefinerRoutine(statementStart)
@@ -355,10 +358,29 @@ func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, er
 		return nil, err
 	}
 	p.skipWhitespace()
-	if err := p.expect(lexer.TokenIdentifier, "REPLACE"); err != nil {
-		return nil, fmt.Errorf("expected REPLACE after CREATE OR: %w", err)
+	orMode := strings.ToUpper(p.current.Value)
+	switch orMode {
+	case "REPLACE", "ALTER":
+		p.advance()
+	default:
+		return nil, fmt.Errorf("expected REPLACE or ALTER after CREATE OR, got %s at position %d", p.current.Value, p.current.Start)
 	}
 	p.skipWhitespace()
+	if orMode == "ALTER" && !p.isSQLServerRoutineDialect() {
+		return nil, fmt.Errorf("unsupported CREATE OR ALTER outside SQL Server dialect at position %d", p.current.Start)
+	}
+	if orMode == "ALTER" {
+		switch {
+		case p.current.MatchIdentifierValue("FUNCTION"):
+			return p.parseCreateRoutine("FUNCTION", statementStart)
+		case p.current.MatchIdentifierValue("PROC"):
+			return p.parseCreateRoutine("PROC", statementStart)
+		case p.current.MatchIdentifierValue("PROCEDURE"):
+			return p.parseCreateRoutine("PROCEDURE", statementStart)
+		default:
+			return nil, fmt.Errorf("unsupported CREATE OR ALTER target: %s at position %d", p.current.Value, p.current.Start)
+		}
+	}
 	if p.current.MatchIdentifierValue("VIEW") {
 		return p.parseCreateOrReplaceView()
 	}
@@ -474,6 +496,13 @@ func (p *Parser) skipGoBatchSeparator() {
 	}
 }
 
+func (p *Parser) isCurrentSQLServerGoBatchSeparator() bool {
+	if !p.current.MatchIdentifierValue("GO") {
+		return false
+	}
+	return sqlutil.IsSQLServerGoBatchSeparatorAt(p.input, p.current.Start, p.current.End)
+}
+
 // isNumeric checks if a string represents a numeric value.
 func isNumeric(s string) bool {
 	if s == "" {
@@ -541,28 +570,27 @@ func (p *Parser) parseCreateFunction(statementStart int) (ast.Node, error) {
 }
 
 func (p *Parser) isSQLServerBracketedRoutineNameStart() bool {
-	// Bracketed function names enter T-SQL's routine-body sub-language. Until
-	// #323 adds a dialect-aware body parser, preserve the statement as raw SQL.
+	// Bracketed function names enter T-SQL's routine-body sub-language. The
+	// compatibility parser preserves them as raw SQL without dialect metadata.
 	return p.current.MatchOperatorValue("[")
 }
 
 func (p *Parser) parseCreateRawSQLServerRoutine(statementStart int) (ast.Node, error) {
-	sql, err := p.collectRawSQLServerRoutine(statementStart)
+	sql, err := p.collectRawSQLServerRoutine(statementStart, sqlServerRoutineStopAtTopLevelSemicolon)
 	if err != nil {
 		return nil, err
 	}
 	return ast.NewRawSQL(sql), nil
 }
 
-func (p *Parser) parseCreateOpaqueSQLServerRoutine(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
-	sql, err := p.collectRawSQLServerRoutine(statementStart)
-	if err != nil {
-		return nil, err
-	}
-	return ast.NewOpaqueRoutine(sql, p.dialect, kind), nil
-}
+type sqlServerRoutineSemicolonMode int
 
-func (p *Parser) collectRawSQLServerRoutine(statementStart int) (string, error) {
+const (
+	sqlServerRoutineStopAtTopLevelSemicolon sqlServerRoutineSemicolonMode = iota
+	sqlServerRoutineKeepTopLevelSemicolon
+)
+
+func (p *Parser) collectRawSQLServerRoutine(statementStart int, semicolonMode sqlServerRoutineSemicolonMode) (string, error) {
 	blockDepth := 0
 	caseDepth := 0
 	for !p.isAtEnd() {
@@ -575,19 +603,22 @@ func (p *Parser) collectRawSQLServerRoutine(statementStart int) (string, error) 
 			continue
 		}
 
-		if p.current.Type == lexer.TokenSemicolon && blockDepth == 0 {
+		if p.current.Type == lexer.TokenSemicolon &&
+			blockDepth == 0 &&
+			semicolonMode == sqlServerRoutineStopAtTopLevelSemicolon {
 			sql := p.rawStatement(statementStart)
 			p.advance()
 			return sql, nil
 		}
-		if p.current.MatchIdentifierValue("GO") && blockDepth == 0 {
+		if p.isCurrentSQLServerGoBatchSeparator() && blockDepth == 0 {
 			sql := p.rawStatementFragment(statementStart, p.current.Start)
 			p.advance()
 			return sql, nil
 		}
 
 		if p.current.Type == lexer.TokenIdentifier {
-			if complete := trackSQLServerRawRoutineKeyword(strings.ToUpper(p.current.Value), &blockDepth, &caseDepth); complete {
+			nextValue := sqlServerRawRoutineNextSignificantValue(p.input, p.current.End)
+			if complete := trackSQLServerRawRoutineKeyword(strings.ToUpper(p.current.Value), nextValue, &blockDepth, &caseDepth); complete {
 				end := p.current.End
 				p.advance()
 				return p.rawStatementFragment(statementStart, end), nil
@@ -617,13 +648,19 @@ func (p *Parser) skipSQLServerBracketedIdentifier() {
 	}
 }
 
-func trackSQLServerRawRoutineKeyword(keyword string, blockDepth, caseDepth *int) bool {
+func trackSQLServerRawRoutineKeyword(keyword string, nextValue string, blockDepth, caseDepth *int) bool {
 	switch keyword {
 	case "BEGIN":
+		if sqlServerRawRoutineNonBlockBeginFollower(nextValue) {
+			return false
+		}
 		(*blockDepth)++
 	case "CASE":
 		(*caseDepth)++
 	case "END":
+		if strings.EqualFold(nextValue, "CONVERSATION") {
+			return false
+		}
 		if *caseDepth > 0 {
 			(*caseDepth)--
 		} else if *blockDepth > 0 {
@@ -632,6 +669,33 @@ func trackSQLServerRawRoutineKeyword(keyword string, blockDepth, caseDepth *int)
 		}
 	}
 	return false
+}
+
+func sqlServerRawRoutineNextSignificantValue(input string, pos int) string {
+	if pos >= len(input) {
+		return ""
+	}
+	l := lexer.NewLexer(input[pos:])
+	for {
+		tok := l.NextToken()
+		switch tok.Type {
+		case lexer.TokenWhitespace, lexer.TokenComment:
+			continue
+		case lexer.TokenEOF:
+			return ""
+		default:
+			return strings.ToUpper(tok.Value)
+		}
+	}
+}
+
+func sqlServerRawRoutineNonBlockBeginFollower(value string) bool {
+	switch strings.ToUpper(value) {
+	case "CONVERSATION", "DIALOG", "DISTRIBUTED", "TRAN", "TRANSACTION":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *Parser) parseCreateRawRoutineStatement(statementStart int) (ast.Node, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -1394,6 +1394,28 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(createTable.Name, qt.Equals, "after_fn")
 }
 
+func TestParser_ParseSQLServerDialectInlineTableFunctionMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f2](@a as INT, @b as INT = 1)
+RETURNS TABLE
+AS RETURN SELECT @a as [a], @b as [b];`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Name, qt.Equals, "[f2]")
+	c.Assert(routine.Parameters, qt.Equals, "@a as INT, @b as INT = 1")
+	c.Assert(routine.Returns, qt.Equals, "TABLE")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormInlineTableValuedFunction)
+	c.Assert(routine.Body.SQL, qt.Contains, "RETURN SELECT @a as [a]")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementReturn,
+	})
+}
+
 func TestParser_ParseSQLServerMultiStatementTableFunctionAsRawSQL(t *testing.T) {
 	c := qt.New(t)
 
@@ -1420,6 +1442,74 @@ CREATE TABLE after_fn (id int);`
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerDialectMultiStatementTableFunctionMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f3] (@a int, @b int = 1) RETURNS @t1 TABLE ([c1] int NOT NULL, [double] AS [c1] * 2) AS BEGIN
+  INSERT @t1
+  SELECT 1 AS [c1];
+RETURN;
+END`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Name, qt.Equals, "[f3]")
+	c.Assert(routine.Parameters, qt.Equals, "@a int, @b int = 1")
+	c.Assert(routine.Returns, qt.Equals, "@t1 TABLE ([c1] int NOT NULL, [double] AS [c1] * 2)")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormMultiStatementTableFunction)
+	c.Assert(routine.Body.SQL, qt.Contains, "INSERT @t1")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementInsert,
+		ast.SQLServerRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseSQLServerDialectReturnTableDefaultWithAS(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f_cast] (@a int) RETURNS @t TABLE ([c] int DEFAULT CAST(1 AS int)) AS BEGIN
+  INSERT @t
+  SELECT @a AS [c];
+RETURN;
+END`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Returns, qt.Equals, "@t TABLE ([c] int DEFAULT CAST(1 AS int))")
+	c.Assert(routine.Body.SQL, qt.Contains, "INSERT @t")
+	c.Assert(routine.Body.SQL, qt.Contains, "RETURN")
+}
+
+func TestParser_ParseSQLServerDialectTableFunctionIgnoresBracketedKeywords(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [f_keywords] (@a int) RETURNS @t TABLE ([AS] int NOT NULL, [END]]value] int NOT NULL) AS BEGIN
+  INSERT @t
+  SELECT @a AS [AS], @a AS [END]]value];
+RETURN;
+END`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Returns, qt.Equals, "@t TABLE ([AS] int NOT NULL, [END]]value] int NOT NULL)")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormMultiStatementTableFunction)
+	c.Assert(routine.Body.SQL, qt.Contains, "INSERT @t")
+	c.Assert(routine.Body.SQL, qt.Contains, "SELECT @a AS [AS], @a AS [END]]value]")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementInsert,
+		ast.SQLServerRoutineStatementReturn,
+	})
 }
 
 func TestParser_ParseSQLServerGoDelimitedFunctionsAsRawSQL(t *testing.T) {
@@ -1498,7 +1588,82 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(raw.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
 }
 
-func TestParser_ParseSQLServerDialectUnbracketedFunctionAsOpaqueRoutine(t *testing.T) {
+func TestParser_ParseSQLServerDialectBracketedScalarFunctionAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION [dbo].[score](@user_id int)
+RETURNS int
+AS
+BEGIN
+    DECLARE @score int;
+    SET @score = 1;
+    IF @score > 0
+    BEGIN
+        SET @score = @score + 1;
+    END;
+    RETURN @score;
+END
+GO
+CREATE TABLE after_fn (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.SQLServer))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.SQLServer)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "[dbo].[score]")
+	c.Assert(routine.Parameters, qt.Equals, "@user_id int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormScalarFunction)
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "GO")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementDeclaration,
+		ast.SQLServerRoutineStatementAssignment,
+		ast.SQLServerRoutineStatementIf,
+		ast.SQLServerRoutineStatementReturn,
+	})
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerDialectCreateOrAlterFunctionAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE OR ALTER FUNCTION dbo.score(@returns int)
+RETURNS int
+AS
+BEGIN
+    RETURN @returns;
+END`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Name, qt.Equals, "dbo.score")
+	c.Assert(routine.Parameters, qt.Equals, "@returns int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.SQL, qt.Contains, "CREATE OR ALTER FUNCTION dbo.score")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseCreateOrAlterRequiresSQLServerDialect(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parser.NewParser(`CREATE OR ALTER FUNCTION dbo.score() RETURNS int AS BEGIN RETURN 1; END`).Parse()
+	c.Assert(err, qt.ErrorMatches, `unsupported CREATE OR ALTER outside SQL Server dialect at position \d+`)
+}
+
+func TestParser_ParseSQLServerDialectUnbracketedFunctionAsRoutine(t *testing.T) {
 	c := qt.New(t)
 
 	sql := `CREATE FUNCTION dbo.f7 (@a int) RETURNS int AS BEGIN
@@ -1512,17 +1677,148 @@ CREATE TABLE after_fn (id int);`
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 2)
 
-	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(routine.Dialect, qt.Equals, platform.SQLServer)
 	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindFunction)
+	c.Assert(routine.Name, qt.Equals, "dbo.f7")
+	c.Assert(routine.Parameters, qt.Equals, "@a int")
+	c.Assert(routine.Returns, qt.Equals, "int")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormScalarFunction)
 	c.Assert(routine.SQL, qt.Contains, "CREATE FUNCTION dbo.f7")
 	c.Assert(routine.SQL, qt.Contains, "RETURN @a")
 	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+	c.Assert(routine.Body.SQL, qt.Contains, "RETURN @a")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementReturn,
+	})
 
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(createTable.Name, qt.Equals, "after_fn")
+}
+
+func TestParser_ParseSQLServerDialectProcedureParametersAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE [dbo].[touch_user] @user_id int, @enabled bit = (1) AS
+BEGIN
+  SELECT @user_id;
+END`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Name, qt.Equals, "[dbo].[touch_user]")
+	c.Assert(routine.Parameters, qt.Equals, "@user_id int, @enabled bit = (1)")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormProcedure)
+	c.Assert(routine.Body.SQL, qt.Contains, "SELECT @user_id")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementSelect,
+	})
+}
+
+func TestParser_ParseSQLServerDialectProcAliasAsRoutine(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROC [dbo].[touch_user] @user_id int AS SELECT @user_id;`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Name, qt.Equals, "[dbo].[touch_user]")
+	c.Assert(routine.Parameters, qt.Equals, "@user_id int")
+	c.Assert(routine.Body.SQL, qt.Equals, "SELECT @user_id")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementSelect,
+	})
+}
+
+func TestParser_ParseSQLServerDialectProcedureWithoutBeginSplitsStatements(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Name, qt.Equals, "[dbo].[list_users]")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementSelect,
+		ast.SQLServerRoutineStatementSelect,
+	})
+	c.Assert(routine.Body.Statements[0].SQL, qt.Contains, "SELECT 1 AS [first]")
+	c.Assert(routine.Body.Statements[1].SQL, qt.Contains, "SELECT 2 AS [second]")
+}
+
+func TestParser_ParseSQLServerDialectProcedureWithoutSemicolonsSplitsSupportedStatements(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE [dbo].[score_user] AS
+DECLARE @score int
+SET @score = 1
+RETURN @score
+GO`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementDeclaration,
+		ast.SQLServerRoutineStatementAssignment,
+		ast.SQLServerRoutineStatementReturn,
+	})
+}
+
+func TestParser_ParseProcAliasIsOnlyTypedInSQLServerDialect(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROC [dbo].[touch_user] @user_id int AS SELECT @user_id
+GO
+CREATE TABLE after_proc (id int);`
+	for _, dialect := range []string{"", platform.Postgres, platform.MySQL} {
+		statements, err := parser.NewParser(sql, parser.WithDialect(dialect)).Parse()
+		c.Assert(err, qt.IsNil, qt.Commentf("dialect %q", dialect))
+		c.Assert(statements.Statements, qt.HasLen, 2, qt.Commentf("dialect %q", dialect))
+
+		raw, ok := statements.Statements[0].(*ast.RawSQLNode)
+		c.Assert(ok, qt.IsTrue, qt.Commentf("dialect %q", dialect))
+		c.Assert(raw.SQL, qt.Contains, "CREATE PROC [dbo].[touch_user]")
+		c.Assert(raw.SQL, qt.Not(qt.Contains), "GO")
+	}
+}
+
+func TestParser_ParseSQLServerDialectProcedureDoesNotTreatGoAliasAsBatch(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE dbo.p AS
+SELECT go AS value, [go] AS bracketed;
+GO
+CREATE TABLE after_proc (id int);`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Body.SQL, qt.Contains, "SELECT go AS value")
+	c.Assert(routine.Body.SQL, qt.Contains, "[go] AS bracketed")
+	c.Assert(routine.Body.SQL, qt.Not(qt.Contains), "GO")
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
 }
 
 func TestParser_ParseSQLServerDialectProcedureStopsAtGoBatch(t *testing.T) {
@@ -1530,24 +1826,75 @@ func TestParser_ParseSQLServerDialectProcedureStopsAtGoBatch(t *testing.T) {
 
 	sql := `CREATE PROCEDURE dbo.p1 AS
   SELECT 1
-GO
+GO /* deploy */
 CREATE TABLE after_proc (id int);`
 	statements, err := parser.NewParser(sql, parser.WithDialect("mssql")).Parse()
 	c.Assert(err, qt.IsNil)
 	c.Assert(statements.Statements, qt.HasLen, 2)
 
-	routine, ok := statements.Statements[0].(*ast.OpaqueRoutineNode)
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(routine.Dialect, qt.Equals, platform.SQLServer)
 	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Name, qt.Equals, "dbo.p1")
+	c.Assert(routine.Form, qt.Equals, ast.SQLServerRoutineFormProcedure)
 	c.Assert(routine.SQL, qt.Contains, "CREATE PROCEDURE dbo.p1")
 	c.Assert(routine.SQL, qt.Contains, "SELECT 1")
 	c.Assert(routine.SQL, qt.Not(qt.Contains), "GO")
 	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
+	c.Assert(routine.Body.SQL, qt.Equals, "SELECT 1")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementSelect,
+	})
 
 	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
+func TestParser_ParseSQLServerDialectDoesNotStopAtGoIdentifier(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE FUNCTION dbo.go_alias(@go int)
+RETURNS TABLE
+AS RETURN SELECT @go AS go;
+GO
+CREATE TABLE after_fn (id int);`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Parameters, qt.Equals, "@go int")
+	c.Assert(routine.Body.SQL, qt.Contains, "RETURN SELECT @go AS go")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_fn")
+}
+
+func TestParser_ParseSQLServerDialectIgnoresNonBlockBeginEndStatements(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE dbo.conversation AS
+BEGIN
+  BEGIN TRANSACTION;
+  END CONVERSATION @handle;
+  SELECT 1;
+END
+GO
+CREATE TABLE after_proc (id int);`
+	statements, err := parser.NewParser(sql, parser.WithDialect(platform.SQLServer)).Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.SQLServerRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Body.SQL, qt.Contains, "BEGIN TRANSACTION")
+	c.Assert(routine.Body.SQL, qt.Contains, "END CONVERSATION @handle")
+	c.Assert(sqlServerRoutineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.SQLServerRoutineStatementKind{
+		ast.SQLServerRoutineStatementBlock,
+		ast.SQLServerRoutineStatementRaw,
+		ast.SQLServerRoutineStatementSelect,
+	})
 }
 
 func TestParser_ParseCreateProcedureAsRawSQL(t *testing.T) {
@@ -1903,6 +2250,14 @@ func routineStatementKinds(statements []ast.MySQLRoutineStatement) []ast.MySQLRo
 
 func postgresRoutineStatementKinds(statements []ast.PostgresRoutineStatement) []ast.PostgresRoutineStatementKind {
 	kinds := make([]ast.PostgresRoutineStatementKind, 0, len(statements))
+	for _, stmt := range statements {
+		kinds = append(kinds, stmt.Kind)
+	}
+	return kinds
+}
+
+func sqlServerRoutineStatementKinds(statements []ast.SQLServerRoutineStatement) []ast.SQLServerRoutineStatementKind {
+	kinds := make([]ast.SQLServerRoutineStatementKind, 0, len(statements))
 	for _, stmt := range statements {
 		kinds = append(kinds, stmt.Kind)
 	}

--- a/core/parser/postgres_routine.go
+++ b/core/parser/postgres_routine.go
@@ -20,6 +20,9 @@ func (postgresRoutineParser) parseCreateRoutine(p *Parser, target string, statem
 		}
 		return parsePostgresRoutineSQL(sql, p.dialect, ast.RoutineKindProcedure), nil
 	}
+	if target == "PROC" {
+		return compatibilityRoutineParser{}.parseCreateRoutine(p, target, statementStart)
+	}
 	return p.parseCreateFunction(statementStart)
 }
 

--- a/core/parser/routine.go
+++ b/core/parser/routine.go
@@ -27,11 +27,18 @@ func (p *Parser) routineParser() routineParser {
 	}
 }
 
+func (p *Parser) isSQLServerRoutineDialect() bool {
+	return p.dialect == platform.SQLServer
+}
+
 type compatibilityRoutineParser struct{}
 
 func (compatibilityRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
-	if target == "PROCEDURE" {
+	switch target {
+	case "PROCEDURE":
 		return p.parseCreateRawRoutineStatement(statementStart)
+	case "PROC":
+		return p.parseCreateRawSQLServerRoutine(statementStart)
 	}
 	return p.parseCreateFunction(statementStart)
 }
@@ -45,6 +52,9 @@ type mysqlFamilyRoutineParser struct{}
 func (mysqlFamilyRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
 	if target == "PROCEDURE" {
 		return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindProcedure)
+	}
+	if target == "PROC" {
+		return compatibilityRoutineParser{}.parseCreateRoutine(p, target, statementStart)
 	}
 	return p.parseCreateMySQLRoutineStatement(statementStart, ast.RoutineKindFunction)
 }
@@ -73,9 +83,9 @@ type sqlServerRoutineParser struct{}
 func (sqlServerRoutineParser) parseCreateRoutine(p *Parser, target string, statementStart int) (ast.Node, error) {
 	switch target {
 	case "FUNCTION":
-		return p.parseCreateOpaqueSQLServerRoutine(statementStart, ast.RoutineKindFunction)
-	case "PROCEDURE":
-		return p.parseCreateOpaqueSQLServerRoutine(statementStart, ast.RoutineKindProcedure)
+		return p.parseCreateSQLServerRoutineStatement(statementStart, ast.RoutineKindFunction)
+	case "PROC", "PROCEDURE":
+		return p.parseCreateSQLServerRoutineStatement(statementStart, ast.RoutineKindProcedure)
 	}
 	return compatibilityRoutineParser{}.parseCreateRoutine(p, target, statementStart)
 }

--- a/core/parser/sqlserver_routine.go
+++ b/core/parser/sqlserver_routine.go
@@ -1,0 +1,496 @@
+package parser
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/lexer"
+)
+
+func (p *Parser) parseCreateSQLServerRoutineStatement(statementStart int, kind ast.RoutineKind) (ast.Node, error) {
+	mode := sqlServerRoutineKeepTopLevelSemicolon
+	if kind == ast.RoutineKindFunction {
+		mode = sqlServerRoutineStopAtTopLevelSemicolon
+	}
+	sql, err := p.collectRawSQLServerRoutine(statementStart, mode)
+	if err != nil {
+		return nil, err
+	}
+	return parseSQLServerRoutineSQL(sql, p.dialect, kind), nil
+}
+
+func parseSQLServerRoutineSQL(sql, dialect string, kind ast.RoutineKind) *ast.SQLServerRoutineNode {
+	tokens := newSQLServerRoutineTokenizer(sql).tokens()
+	routine := ast.NewSQLServerRoutine(sql, dialect, kind)
+	asIdx := findSQLServerRoutineBodyAS(tokens, kind)
+	routine.Name, routine.Parameters, routine.Returns = parseSQLServerRoutineHeader(sql, tokens, kind, asIdx)
+	routine.Form = classifySQLServerRoutineForm(routine)
+	routine.Body = parseSQLServerRoutineBody(sql, tokens, asIdx)
+	return routine
+}
+
+type sqlServerRoutineTokenizer struct {
+	lexer *lexer.Lexer
+}
+
+func newSQLServerRoutineTokenizer(sql string) sqlServerRoutineTokenizer {
+	return sqlServerRoutineTokenizer{lexer: lexer.NewLexer(sql)}
+}
+
+func (t sqlServerRoutineTokenizer) tokens() []lexer.Token {
+	tokens := make([]lexer.Token, 0)
+	for {
+		tok := t.lexer.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Type == lexer.TokenEOF {
+			return tokens
+		}
+	}
+}
+
+func parseSQLServerRoutineHeader(
+	sql string,
+	tokens []lexer.Token,
+	kind ast.RoutineKind,
+	asIdx int,
+) (name string, parameters string, returns string) {
+	keywordIdx := findSQLServerRoutineKeyword(tokens, strings.ToUpper(string(kind)), 0)
+	if keywordIdx == -1 && kind == ast.RoutineKindProcedure {
+		keywordIdx = findSQLServerRoutineKeyword(tokens, "PROC", 0)
+	}
+	if keywordIdx == -1 {
+		return "", "", ""
+	}
+
+	nameIdx := nextSQLServerRoutineToken(tokens, keywordIdx+1)
+	if nameIdx == -1 {
+		return "", "", ""
+	}
+	openParamsIdx := findSQLServerRoutineOperator(tokens, "(", nameIdx+1, asIdx)
+	if kind == ast.RoutineKindProcedure && asIdx != -1 {
+		if paramsIdx := findSQLServerRoutineOperator(tokens, "@", nameIdx+1, asIdx); paramsIdx != -1 &&
+			(openParamsIdx == -1 || paramsIdx < openParamsIdx) {
+			name = strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[paramsIdx].Start])
+			parameters = strings.TrimSpace(sql[tokens[paramsIdx].Start:tokens[asIdx].Start])
+			return name, parameters, ""
+		}
+	}
+	if openParamsIdx == -1 {
+		if asIdx == -1 {
+			return strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[len(tokens)-1].Start]), "", ""
+		}
+		return strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[asIdx].Start]), "", ""
+	}
+
+	name = strings.TrimSpace(sql[tokens[nameIdx].Start:tokens[openParamsIdx].Start])
+	parameters = parseSQLServerRoutineParameters(sql, tokens, openParamsIdx)
+	if kind == ast.RoutineKindFunction {
+		returns = parseSQLServerRoutineReturns(sql, tokens, findSQLServerRoutineClosingParen(tokens, openParamsIdx), asIdx)
+	}
+	return name, parameters, returns
+}
+
+func findSQLServerRoutineBodyAS(tokens []lexer.Token, kind ast.RoutineKind) int {
+	startIdx := 0
+	if kind == ast.RoutineKindFunction {
+		if returnsIdx := findSQLServerRoutineKeyword(tokens, "RETURNS", 0); returnsIdx != -1 {
+			return findSQLServerRoutineBodyASAfterReturns(tokens, returnsIdx+1)
+		}
+	}
+	return findSQLServerRoutineKeyword(tokens, "AS", startIdx)
+}
+
+func findSQLServerRoutineBodyASAfterReturns(tokens []lexer.Token, startIdx int) int {
+	depth := 0
+	for i := max(startIdx, 0); i < len(tokens); i++ {
+		switch {
+		case tokens[i].MatchOperatorValue("["):
+			i = sqlServerRoutineBracketEnd(tokens, i)
+		case tokens[i].MatchOperatorValue("("):
+			depth++
+		case tokens[i].MatchOperatorValue(")") && depth > 0:
+			depth--
+		case depth == 0 && tokens[i].MatchIdentifierValue("AS"):
+			return i
+		}
+	}
+	return -1
+}
+
+func parseSQLServerRoutineParameters(sql string, tokens []lexer.Token, openIdx int) string {
+	depth := 0
+	paramsStart := tokens[openIdx].End
+	for i := openIdx; i < len(tokens); i++ {
+		switch {
+		case tokens[i].MatchOperatorValue("("):
+			depth++
+		case tokens[i].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(sql[paramsStart:tokens[i].Start])
+			}
+		}
+	}
+	return ""
+}
+
+func findSQLServerRoutineClosingParen(tokens []lexer.Token, openIdx int) int {
+	depth := 0
+	for i := openIdx; i < len(tokens); i++ {
+		switch {
+		case tokens[i].MatchOperatorValue("("):
+			depth++
+		case tokens[i].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return openIdx
+}
+
+func parseSQLServerRoutineReturns(sql string, tokens []lexer.Token, afterIdx int, asIdx int) string {
+	returnsIdx := findSQLServerRoutineKeyword(tokens, "RETURNS", afterIdx+1)
+	if returnsIdx == -1 || returnsIdx >= asIdx {
+		return ""
+	}
+	return strings.TrimSpace(sql[tokens[returnsIdx].End:tokens[asIdx].Start])
+}
+
+func classifySQLServerRoutineForm(routine *ast.SQLServerRoutineNode) ast.SQLServerRoutineForm {
+	if routine.Kind == ast.RoutineKindProcedure {
+		return ast.SQLServerRoutineFormProcedure
+	}
+	returns := strings.ToUpper(routine.Returns)
+	switch {
+	case strings.HasPrefix(strings.TrimSpace(returns), "TABLE"):
+		return ast.SQLServerRoutineFormInlineTableValuedFunction
+	case strings.Contains(returns, " TABLE"):
+		return ast.SQLServerRoutineFormMultiStatementTableFunction
+	default:
+		return ast.SQLServerRoutineFormScalarFunction
+	}
+}
+
+func parseSQLServerRoutineBody(sql string, tokens []lexer.Token, asIdx int) ast.SQLServerRoutineBody {
+	if asIdx == -1 {
+		return ast.SQLServerRoutineBody{}
+	}
+	bodyStartIdx := nextSQLServerRoutineToken(tokens, asIdx+1)
+	if bodyStartIdx == -1 {
+		return ast.SQLServerRoutineBody{}
+	}
+	bodySQL := strings.TrimSpace(sql[tokens[bodyStartIdx].Start:sqlServerRoutineStatementEnd(sql, tokens)])
+	return ast.SQLServerRoutineBody{
+		SQL:        bodySQL,
+		Statements: parseSQLServerRoutineBodyStatements(bodySQL),
+	}
+}
+
+func parseSQLServerRoutineBodyStatements(sql string) []ast.SQLServerRoutineStatement {
+	parser := sqlServerRoutineBodyParser{
+		input:  sql,
+		tokens: newSQLServerRoutineTokenizer(sql).tokens(),
+	}
+	return parser.parseStatements()
+}
+
+type sqlServerRoutineBodyParser struct {
+	input  string
+	tokens []lexer.Token
+}
+
+func (p sqlServerRoutineBodyParser) parseStatements() []ast.SQLServerRoutineStatement {
+	startIdx := p.nextSignificant(0)
+	if startIdx == -1 {
+		return nil
+	}
+	if p.tokens[startIdx].MatchIdentifierValue("BEGIN") && !p.isNonBlockBegin(startIdx) {
+		return p.parseOuterBlockStatements(startIdx)
+	}
+	return p.parseStatementRange(startIdx, len(p.tokens)-1)
+}
+
+func (p sqlServerRoutineBodyParser) parseOuterBlockStatements(beginIdx int) []ast.SQLServerRoutineStatement {
+	endIdx := p.findMatchingBlockEnd(beginIdx)
+	if endIdx == -1 {
+		return []ast.SQLServerRoutineStatement{p.statement(beginIdx, len(p.tokens)-1)}
+	}
+
+	return p.parseStatementRange(beginIdx+1, endIdx)
+}
+
+func (p sqlServerRoutineBodyParser) parseStatementRange(startIdx, endIdx int) []ast.SQLServerRoutineStatement {
+	statements := make([]ast.SQLServerRoutineStatement, 0)
+	statementStartIdx := -1
+	blockDepth := 0
+	caseDepth := 0
+	for i := startIdx; i < endIdx; i++ {
+		tok := p.tokens[i]
+		if tok.MatchOperatorValue("[") {
+			i = sqlServerRoutineBracketEnd(p.tokens, i)
+			continue
+		}
+		if statementStartIdx == -1 {
+			if isSQLServerRoutineTrivia(tok) {
+				continue
+			}
+			statementStartIdx = i
+		}
+
+		if tok.Type == lexer.TokenIdentifier {
+			nextValue := p.nextSignificantValue(i + 1)
+			trackSQLServerRoutineBodyKeyword(tok.Value, nextValue, &blockDepth, &caseDepth)
+		}
+		if p.startsRecoverableStatement(i) &&
+			!p.keywordBelongsToCurrentStatement(statementStartIdx, i) &&
+			blockDepth == 0 &&
+			caseDepth == 0 &&
+			statementStartIdx != i {
+			statements = append(statements, p.statementUntil(statementStartIdx, tok.Start))
+			statementStartIdx = i
+		}
+		if tok.Type == lexer.TokenSemicolon && blockDepth == 0 && caseDepth == 0 && statementStartIdx != -1 {
+			statements = append(statements, p.statement(statementStartIdx, i))
+			statementStartIdx = -1
+		}
+	}
+	if statementStartIdx != -1 {
+		statements = append(statements, p.statementUntil(statementStartIdx, p.tokens[endIdx].Start))
+	}
+	return statements
+}
+
+func (p sqlServerRoutineBodyParser) statement(startIdx, endIdx int) ast.SQLServerRoutineStatement {
+	if startIdx < 0 || endIdx >= len(p.tokens) || startIdx > endIdx {
+		return ast.SQLServerRoutineStatement{}
+	}
+	end := p.tokens[endIdx].End
+	if p.tokens[endIdx].Type == lexer.TokenEOF {
+		end = p.tokens[endIdx].Start
+	}
+	return p.statementUntil(startIdx, end)
+}
+
+func (p sqlServerRoutineBodyParser) statementUntil(startIdx int, end int) ast.SQLServerRoutineStatement {
+	return ast.SQLServerRoutineStatement{
+		Kind: p.classifyStatement(startIdx),
+		SQL:  strings.TrimSpace(p.rawFragment(p.tokens[startIdx].Start, end)),
+	}
+}
+
+func (p sqlServerRoutineBodyParser) classifyStatement(startIdx int) ast.SQLServerRoutineStatementKind {
+	if startIdx < 0 || startIdx >= len(p.tokens) {
+		return ast.SQLServerRoutineStatementRaw
+	}
+	if p.tokens[startIdx].MatchOperatorValue("@") {
+		return ast.SQLServerRoutineStatementAssignment
+	}
+	if p.tokens[startIdx].Type != lexer.TokenIdentifier {
+		return ast.SQLServerRoutineStatementRaw
+	}
+	switch strings.ToUpper(p.tokens[startIdx].Value) {
+	case "BEGIN":
+		return ast.SQLServerRoutineStatementBlock
+	case "DECLARE":
+		return ast.SQLServerRoutineStatementDeclaration
+	case "IF":
+		return ast.SQLServerRoutineStatementIf
+	case "WHILE":
+		return ast.SQLServerRoutineStatementWhile
+	case "RETURN":
+		return ast.SQLServerRoutineStatementReturn
+	case "SELECT":
+		return ast.SQLServerRoutineStatementSelect
+	case "INSERT":
+		return ast.SQLServerRoutineStatementInsert
+	case "SET":
+		return ast.SQLServerRoutineStatementAssignment
+	default:
+		return ast.SQLServerRoutineStatementRaw
+	}
+}
+
+func (p sqlServerRoutineBodyParser) findMatchingBlockEnd(beginIdx int) int {
+	blockDepth := 0
+	caseDepth := 0
+	for i := beginIdx; i < len(p.tokens); i++ {
+		tok := p.tokens[i]
+		if tok.MatchOperatorValue("[") {
+			i = sqlServerRoutineBracketEnd(p.tokens, i)
+			continue
+		}
+		if tok.Type != lexer.TokenIdentifier {
+			continue
+		}
+		nextValue := p.nextSignificantValue(i + 1)
+		trackSQLServerRoutineBodyKeyword(tok.Value, nextValue, &blockDepth, &caseDepth)
+		if blockDepth == 0 && tok.MatchIdentifierValue("END") {
+			return i
+		}
+	}
+	return -1
+}
+
+func trackSQLServerRoutineBodyKeyword(value string, nextValue string, blockDepth, caseDepth *int) {
+	switch strings.ToUpper(value) {
+	case "BEGIN":
+		if sqlServerRawRoutineNonBlockBeginFollower(nextValue) {
+			return
+		}
+		(*blockDepth)++
+	case "CASE":
+		(*caseDepth)++
+	case "END":
+		if strings.EqualFold(nextValue, "CONVERSATION") {
+			return
+		}
+		if *caseDepth > 0 {
+			(*caseDepth)--
+		} else if *blockDepth > 0 {
+			(*blockDepth)--
+		}
+	}
+}
+
+func findSQLServerRoutineKeyword(tokens []lexer.Token, keyword string, startIdx int) int {
+	for i := max(startIdx, 0); i < len(tokens); i++ {
+		if tokens[i].MatchOperatorValue("[") {
+			i = sqlServerRoutineBracketEnd(tokens, i)
+			continue
+		}
+		if sqlServerRoutinePreviousSignificantIsOperator(tokens, i, "@") {
+			continue
+		}
+		if tokens[i].MatchIdentifierValue(keyword) {
+			return i
+		}
+	}
+	return -1
+}
+
+func findSQLServerRoutineOperator(tokens []lexer.Token, operator string, startIdx int, endIdx int) int {
+	if endIdx == -1 {
+		endIdx = len(tokens)
+	}
+	for i := max(startIdx, 0); i < endIdx; i++ {
+		if tokens[i].MatchOperatorValue("[") {
+			i = sqlServerRoutineBracketEnd(tokens, i)
+			continue
+		}
+		if tokens[i].MatchOperatorValue(operator) || tokens[i].Value == operator {
+			return i
+		}
+	}
+	return -1
+}
+
+func sqlServerRoutineStatementEnd(sql string, tokens []lexer.Token) int {
+	for _, tok := range slices.Backward(tokens) {
+		switch tok.Type {
+		case lexer.TokenEOF, lexer.TokenWhitespace, lexer.TokenComment:
+			continue
+		case lexer.TokenSemicolon:
+			return tok.Start
+		default:
+			return tok.End
+		}
+	}
+	return len(sql)
+}
+
+func nextSQLServerRoutineToken(tokens []lexer.Token, startIdx int) int {
+	for i := max(startIdx, 0); i < len(tokens); i++ {
+		if !isSQLServerRoutineTrivia(tokens[i]) && tokens[i].Type != lexer.TokenEOF {
+			return i
+		}
+	}
+	return -1
+}
+
+func sqlServerRoutineBracketEnd(tokens []lexer.Token, openIdx int) int {
+	for i := openIdx + 1; i < len(tokens); i++ {
+		if !tokens[i].MatchOperatorValue("]") {
+			continue
+		}
+		if i+1 < len(tokens) && tokens[i+1].MatchOperatorValue("]") {
+			i++
+			continue
+		}
+		return i
+	}
+	return openIdx
+}
+
+func (p sqlServerRoutineBodyParser) nextSignificant(startIdx int) int {
+	return nextSQLServerRoutineToken(p.tokens, startIdx)
+}
+
+func (p sqlServerRoutineBodyParser) nextSignificantValue(startIdx int) string {
+	idx := p.nextSignificant(startIdx)
+	if idx == -1 {
+		return ""
+	}
+	return strings.ToUpper(p.tokens[idx].Value)
+}
+
+func (p sqlServerRoutineBodyParser) isNonBlockBegin(idx int) bool {
+	return sqlServerRawRoutineNonBlockBeginFollower(p.nextSignificantValue(idx + 1))
+}
+
+func (p sqlServerRoutineBodyParser) startsRecoverableStatement(idx int) bool {
+	if idx < 0 || idx >= len(p.tokens) || p.tokens[idx].Type != lexer.TokenIdentifier {
+		return false
+	}
+	if sqlServerRoutinePreviousSignificantIsOperator(p.tokens, idx, "@") {
+		return false
+	}
+	switch strings.ToUpper(p.tokens[idx].Value) {
+	case "DECLARE", "IF", "INSERT", "RETURN", "SELECT", "SET", "WHILE":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p sqlServerRoutineBodyParser) keywordBelongsToCurrentStatement(statementStartIdx, keywordIdx int) bool {
+	if statementStartIdx < 0 || keywordIdx < 0 || keywordIdx >= len(p.tokens) {
+		return false
+	}
+	currentKind := p.classifyStatement(statementStartIdx)
+	switch {
+	case currentKind == ast.SQLServerRoutineStatementInsert && p.tokens[keywordIdx].MatchIdentifierValue("SELECT"):
+		return true
+	case currentKind == ast.SQLServerRoutineStatementReturn && p.tokens[keywordIdx].MatchIdentifierValue("SELECT"):
+		return true
+	case currentKind == ast.SQLServerRoutineStatementIf && !p.tokens[keywordIdx].MatchIdentifierValue("RETURN"):
+		return true
+	case currentKind == ast.SQLServerRoutineStatementWhile && !p.tokens[keywordIdx].MatchIdentifierValue("RETURN"):
+		return true
+	default:
+		return false
+	}
+}
+
+func sqlServerRoutinePreviousSignificantIsOperator(tokens []lexer.Token, idx int, operator string) bool {
+	for i := idx - 1; i >= 0; i-- {
+		if isSQLServerRoutineTrivia(tokens[i]) {
+			continue
+		}
+		return tokens[i].MatchOperatorValue(operator)
+	}
+	return false
+}
+
+func isSQLServerRoutineTrivia(tok lexer.Token) bool {
+	return tok.Type == lexer.TokenWhitespace || tok.Type == lexer.TokenComment
+}
+
+func (p sqlServerRoutineBodyParser) rawFragment(start, end int) string {
+	if start < 0 || start > end || end > len(p.input) {
+		return ""
+	}
+	return p.input[start:end]
+}

--- a/core/sqllint/lint.go
+++ b/core/sqllint/lint.go
@@ -77,7 +77,7 @@ func DefaultRules() []Rule {
 
 func LintSource(source Source, opts Options) ([]Finding, error) {
 	var findings []Finding
-	for _, statement := range splitSourceStatements(source) {
+	for _, statement := range splitSourceStatements(source, opts.Dialect) {
 		keyword, keywordOffset := firstKeyword(statement.sql)
 		if keyword == "" {
 			continue
@@ -110,8 +110,8 @@ type sourceStatement struct {
 	offset int
 }
 
-func splitSourceStatements(source Source) []sourceStatement {
-	statements := sqlutil.SplitSQLStatements(source.SQL)
+func splitSourceStatements(source Source, dialect string) []sourceStatement {
+	statements := sqlutil.SplitSQLStatementsForDialect(source.SQL, dialect)
 	out := make([]sourceStatement, 0, len(statements))
 	cursor := 0
 	for _, statement := range statements {
@@ -341,6 +341,8 @@ func (unsupportedRoutineRule) CheckStatement(ctx Context, stmt ast.Node) []Findi
 	case *ast.PostgresDoBlockNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("DO", 0)}
 	case *ast.PostgresRoutineNode:
+		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
+	case *ast.SQLServerRoutineNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE "+strings.ToUpper(string(node.Kind)), 0)}
 	case *ast.CreateFunctionNode:
 		return []Finding{ctx.unsupportedModeledSQLFinding("CREATE FUNCTION", 0)}

--- a/core/sqllint/lint_test.go
+++ b/core/sqllint/lint_test.go
@@ -160,6 +160,24 @@ DELIMITER ;`,
 	}
 }
 
+func TestLintSource_SQLServerRoutineNodesAreExplicitUnsupportedFindings(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "routine.sql",
+		SQL: `CREATE PROCEDURE [dbo].[p1] AS
+BEGIN
+  SELECT 1;
+END`,
+	}, Options{Dialect: platform.SQLServer})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
+	c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+}
+
 func TestLintSource_UnsupportedStatementDoesNotMaskLaterDDL(t *testing.T) {
 	c := qt.New(t)
 
@@ -174,6 +192,26 @@ CREATE TABLE audit_log (message TEXT NOT NULL);`,
 	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
 	c.Assert(findings[1].Rule, qt.Equals, RuleTableWithoutPrimaryKey)
 	c.Assert(findings[1].Line, qt.Equals, 2)
+}
+
+func TestLintSource_SQLServerProcedureWithoutBeginStaysSingleStatement(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "proc.sql",
+		SQL: `CREATE PROCEDURE [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];
+GO /* deploy */
+CREATE TABLE after_proc (id int);`,
+	}, Options{Dialect: platform.SQLServer})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 2)
+	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
+	c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+	c.Assert(findings[1].Rule, qt.Equals, RuleTableWithoutPrimaryKey)
+	c.Assert(findings[1].Message, qt.Contains, "after_proc")
 }
 
 func TestLintSource_CapabilityAwareCreateIndexConcurrently(t *testing.T) {

--- a/core/sqlutil/splitter.go
+++ b/core/sqlutil/splitter.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/lexer"
+	"github.com/stokaro/ptah/core/platform"
 )
 
 // StripComments removes all SQL comments from the input string using lexer-based parsing.
@@ -36,6 +37,16 @@ func StripComments(sql string) string {
 // SplitSQLStatements splits a SQL string into individual statements using AST-based parsing.
 // This properly handles semicolons within string literals and comments, unlike simple string splitting.
 func SplitSQLStatements(sql string) []string {
+	return splitSQLStatements(sql, "")
+}
+
+// SplitSQLStatementsForDialect splits SQL using dialect-specific client
+// statement boundaries where the generic splitter would be too aggressive.
+func SplitSQLStatementsForDialect(sql string, dialect string) []string {
+	return splitSQLStatements(sql, platform.NormalizeDialect(dialect))
+}
+
+func splitSQLStatements(sql string, dialect string) []string {
 	if strings.TrimSpace(sql) == "" {
 		return []string{}
 	}
@@ -44,13 +55,32 @@ func SplitSQLStatements(sql string) []string {
 	lexr := lexer.NewLexer(sql)
 	var statements []string
 	var currentStatement strings.Builder
-	var state statementSplitState
+	state := statementSplitState{dialect: dialect}
+	skippingGoBatchLine := false
 
 	for {
 		token := lexr.NextToken()
 
 		if token.Type == lexer.TokenEOF {
 			break
+		}
+		if skippingGoBatchLine {
+			if (token.Type == lexer.TokenWhitespace || token.Type == lexer.TokenComment) &&
+				strings.ContainsAny(token.Value, "\r\n") {
+				skippingGoBatchLine = false
+			}
+			continue
+		}
+		if state.isSQLServer() && token.MatchIdentifierValue("GO") && IsSQLServerGoBatchSeparatorAt(sql, token.Start, token.End) {
+			stmt := strings.TrimSpace(currentStatement.String())
+			if stmt != "" {
+				statements = append(statements, stmt)
+			}
+			currentStatement.Reset()
+			state.reset()
+			state.dialect = dialect
+			skippingGoBatchLine = true
+			continue
 		}
 
 		if token.Type == lexer.TokenSemicolon {
@@ -88,8 +118,11 @@ func SplitSQLStatements(sql string) []string {
 }
 
 type statementSplitState struct {
+	dialect               string
 	createPrefix          createStatementPrefix
+	createObject          string
 	inCompoundCreate      bool
+	sqlServerRoutine      bool
 	compoundDepth         int
 	caseDepth             int
 	pendingEndKeyword     bool
@@ -97,7 +130,8 @@ type statementSplitState struct {
 }
 
 func (s *statementSplitState) reset() {
-	*s = statementSplitState{}
+	dialect := s.dialect
+	*s = statementSplitState{dialect: dialect}
 }
 
 func (s *statementSplitState) observe(token lexer.Token) {
@@ -158,11 +192,12 @@ func (s *statementSplitState) observeCreatePrefix(value string) {
 		return
 
 	case createPrefixCreate:
-		if isCompoundCreateObject(value) {
+		if s.isCompoundCreateObject(value) {
 			s.createPrefix = createPrefixCreateObject
+			s.createObject = value
 			return
 		}
-		if value == "OR" || value == "REPLACE" || value == "DEFINER" {
+		if value == "OR" || value == "ALTER" || value == "REPLACE" || value == "DEFINER" {
 			return
 		}
 		s.createPrefix = createPrefixNone
@@ -173,6 +208,12 @@ func (s *statementSplitState) observeCreatePrefix(value string) {
 		return
 
 	case createPrefixCreateObjectBeforeBody:
+		if s.isSQLServerRoutineObject() && value == "AS" {
+			s.inCompoundCreate = true
+			s.sqlServerRoutine = true
+			s.pendingEndKeyword = false
+			return
+		}
 		if value == "BEGIN" {
 			s.inCompoundCreate = true
 			s.compoundDepth = 1
@@ -182,13 +223,23 @@ func (s *statementSplitState) observeCreatePrefix(value string) {
 	}
 }
 
-func isCompoundCreateObject(value string) bool {
+func (s statementSplitState) isCompoundCreateObject(value string) bool {
 	switch value {
 	case "FUNCTION", "PROCEDURE", "TRIGGER":
 		return true
+	case "PROC":
+		return s.isSQLServer()
 	default:
 		return false
 	}
+}
+
+func (s statementSplitState) isSQLServerRoutineObject() bool {
+	return s.isSQLServer() && (s.createObject == "FUNCTION" || s.createObject == "PROC" || s.createObject == "PROCEDURE")
+}
+
+func (s statementSplitState) isSQLServer() bool {
+	return s.dialect == platform.SQLServer
 }
 
 func isEndContinuationKeyword(value string) bool {
@@ -204,6 +255,9 @@ func (s *statementSplitState) keepSemicolonInsideStatement() bool {
 	if !s.inCompoundCreate {
 		return false
 	}
+	if s.sqlServerRoutine && !s.pendingEndKeyword {
+		return true
+	}
 	if !s.pendingEndKeyword {
 		return true
 	}
@@ -216,4 +270,72 @@ func (s *statementSplitState) keepSemicolonInsideStatement() bool {
 		return false
 	}
 	return true
+}
+
+// IsSQLServerGoBatchSeparatorAt reports whether a GO token is a SQL Server
+// utility batch separator command on its own line. Identifiers such as
+// "AS go" or variables such as "@go" are ordinary T-SQL tokens.
+func IsSQLServerGoBatchSeparatorAt(input string, start, end int) bool {
+	if !sqlServerGoLinePrefixIsEmpty(input, start) {
+		return false
+	}
+	return sqlServerGoTrailerIsBatchSeparator(input, end)
+}
+
+func sqlServerGoLinePrefixIsEmpty(input string, start int) bool {
+	for i := start - 1; i >= 0 && input[i] != '\n' && input[i] != '\r'; i-- {
+		if input[i] != ' ' && input[i] != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+func sqlServerGoTrailerIsBatchSeparator(input string, pos int) bool {
+	i := pos
+	consumedCount := false
+	for {
+		i = skipSQLServerHorizontalSpace(input, i)
+		if !consumedCount && i < len(input) && input[i] >= '0' && input[i] <= '9' {
+			consumedCount = true
+			i = skipSQLServerDigits(input, i)
+			continue
+		}
+		switch {
+		case i >= len(input) || input[i] == '\n' || input[i] == '\r':
+			return true
+		case strings.HasPrefix(input[i:], "--"):
+			return true
+		case strings.HasPrefix(input[i:], "/*"):
+			next, ok := skipSQLServerBlockComment(input, i)
+			if !ok {
+				return false
+			}
+			i = next
+		default:
+			return false
+		}
+	}
+}
+
+func skipSQLServerHorizontalSpace(input string, pos int) int {
+	for pos < len(input) && (input[pos] == ' ' || input[pos] == '\t') {
+		pos++
+	}
+	return pos
+}
+
+func skipSQLServerDigits(input string, pos int) int {
+	for pos < len(input) && input[pos] >= '0' && input[pos] <= '9' {
+		pos++
+	}
+	return pos
+}
+
+func skipSQLServerBlockComment(input string, pos int) (int, bool) {
+	commentEnd := strings.Index(input[pos+2:], "*/")
+	if commentEnd == -1 {
+		return pos, false
+	}
+	return pos + commentEnd + len("/**/"), true
 }

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -339,6 +339,44 @@ END`,
 	})
 }
 
+func TestSplitSQLStatementsForDialect_SQLServerProcedureWithoutBegin(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE PROCEDURE [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];
+GO /* deploy */
+CREATE TABLE after_proc (id int);`
+
+	result := sqlutil.SplitSQLStatementsForDialect(input, "sqlserver")
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE PROCEDURE [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];`,
+		"CREATE TABLE after_proc (id int)",
+	})
+}
+
+func TestSplitSQLStatementsForDialect_SQLServerCreateOrAlterProc(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE OR ALTER PROC [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];
+GO
+CREATE TABLE after_proc (id int);`
+
+	result := sqlutil.SplitSQLStatementsForDialect(input, "sqlserver")
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE OR ALTER PROC [dbo].[list_users] AS
+SELECT 1 AS [first];
+SELECT 2 AS [second];`,
+		"CREATE TABLE after_proc (id int)",
+	})
+}
+
 func TestSplitSQLStatements_CompoundBodiesWithCaseExpressions(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Fixes #323

## Summary
- add SQL Server routine AST metadata for functions, procedures, PROC aliases, and CREATE OR ALTER routines
- parse routine headers, return forms, and recoverable top-level T-SQL body statements while preserving raw SQL rendering
- make SQL Server lint splitting respect GO batch boundaries and no-BEGIN procedure bodies

## Validation
- go test ./core/parser ./core/sqlutil ./core/sqllint ./cmd/sql -count=1
- go tool qtlint ./...
- golangci-lint run --timeout=30m ./...
- go test -race ./core/parser -count=1
- go test ./... -count=1
- multi-agent self-review/follow-up review on GO boundaries, RETURNS TABLE AS handling, and sqllint splitter behavior