### PR TITLE
Harden SQL Server GO batch comment handling

### DIFF
--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -1826,7 +1826,7 @@ func TestParser_ParseSQLServerDialectProcedureStopsAtGoBatch(t *testing.T) {
 
 	sql := `CREATE PROCEDURE dbo.p1 AS
   SELECT 1
-GO
+GO /* deploy */
 CREATE TABLE after_proc (id int);`
 	statements, err := parser.NewParser(sql, parser.WithDialect("mssql")).Parse()
 	c.Assert(err, qt.IsNil)

--- a/core/sqllint/lint_test.go
+++ b/core/sqllint/lint_test.go
@@ -201,13 +201,17 @@ func TestLintSource_SQLServerProcedureWithoutBeginStaysSingleStatement(t *testin
 		Name: "proc.sql",
 		SQL: `CREATE PROCEDURE [dbo].[list_users] AS
 SELECT 1 AS [first];
-SELECT 2 AS [second];`,
+SELECT 2 AS [second];
+GO /* deploy */
+CREATE TABLE after_proc (id int);`,
 	}, Options{Dialect: platform.SQLServer})
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings, qt.HasLen, 2)
 	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
 	c.Assert(findings[0].Message, qt.Contains, "CREATE PROCEDURE")
+	c.Assert(findings[1].Rule, qt.Equals, RuleTableWithoutPrimaryKey)
+	c.Assert(findings[1].Message, qt.Contains, "after_proc")
 }
 
 func TestLintSource_CapabilityAwareCreateIndexConcurrently(t *testing.T) {

--- a/core/sqlutil/splitter.go
+++ b/core/sqlutil/splitter.go
@@ -65,7 +65,8 @@ func splitSQLStatements(sql string, dialect string) []string {
 			break
 		}
 		if skippingGoBatchLine {
-			if token.Type == lexer.TokenWhitespace && strings.ContainsAny(token.Value, "\r\n") {
+			if (token.Type == lexer.TokenWhitespace || token.Type == lexer.TokenComment) &&
+				strings.ContainsAny(token.Value, "\r\n") {
 				skippingGoBatchLine = false
 			}
 			continue
@@ -275,21 +276,66 @@ func (s *statementSplitState) keepSemicolonInsideStatement() bool {
 // utility batch separator command on its own line. Identifiers such as
 // "AS go" or variables such as "@go" are ordinary T-SQL tokens.
 func IsSQLServerGoBatchSeparatorAt(input string, start, end int) bool {
+	if !sqlServerGoLinePrefixIsEmpty(input, start) {
+		return false
+	}
+	return sqlServerGoTrailerIsBatchSeparator(input, end)
+}
+
+func sqlServerGoLinePrefixIsEmpty(input string, start int) bool {
 	for i := start - 1; i >= 0 && input[i] != '\n' && input[i] != '\r'; i-- {
 		if input[i] != ' ' && input[i] != '\t' {
 			return false
 		}
 	}
+	return true
+}
 
-	i := end
-	for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
-		i++
+func sqlServerGoTrailerIsBatchSeparator(input string, pos int) bool {
+	i := pos
+	consumedCount := false
+	for {
+		i = skipSQLServerHorizontalSpace(input, i)
+		if !consumedCount && i < len(input) && input[i] >= '0' && input[i] <= '9' {
+			consumedCount = true
+			i = skipSQLServerDigits(input, i)
+			continue
+		}
+		switch {
+		case i >= len(input) || input[i] == '\n' || input[i] == '\r':
+			return true
+		case strings.HasPrefix(input[i:], "--"):
+			return true
+		case strings.HasPrefix(input[i:], "/*"):
+			next, ok := skipSQLServerBlockComment(input, i)
+			if !ok {
+				return false
+			}
+			i = next
+		default:
+			return false
+		}
 	}
-	for i < len(input) && input[i] >= '0' && input[i] <= '9' {
-		i++
+}
+
+func skipSQLServerHorizontalSpace(input string, pos int) int {
+	for pos < len(input) && (input[pos] == ' ' || input[pos] == '\t') {
+		pos++
 	}
-	for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
-		i++
+	return pos
+}
+
+func skipSQLServerDigits(input string, pos int) int {
+	for pos < len(input) && input[pos] >= '0' && input[pos] <= '9' {
+		pos++
 	}
-	return i >= len(input) || input[i] == '\n' || input[i] == '\r' || strings.HasPrefix(input[i:], "--")
+	return pos
+}
+
+func skipSQLServerBlockComment(input string, pos int) (int, bool) {
+	commentEnd := strings.Index(input[pos+2:], "*/")
+	if commentEnd == -1 {
+		return pos, false
+	}
+	return pos + commentEnd + len("/**/"), true
 }

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -345,7 +345,7 @@ func TestSplitSQLStatementsForDialect_SQLServerProcedureWithoutBegin(t *testing.
 	input := `CREATE PROCEDURE [dbo].[list_users] AS
 SELECT 1 AS [first];
 SELECT 2 AS [second];
-GO
+GO /* deploy */
 CREATE TABLE after_proc (id int);`
 
 	result := sqlutil.SplitSQLStatementsForDialect(input, "sqlserver")


### PR DESCRIPTION
Follow-up to #416 / #323.

## Summary
- treat SQL Server GO block-comment lines as valid batch separators
- keep parser and sqlutil splitter on the same exported GO boundary helper
- add parser, splitter, and sqllint regressions so no-BEGIN procedures split correctly before following DDL

## Validation
- go test ./core/parser ./core/sqlutil ./core/sqllint ./cmd/sql -count=1
- go tool qtlint ./...
- golangci-lint run --timeout=30m ./...
- go test -race ./core/parser -count=1
- go test ./... -count=1