### PR TITLE
Harden MySQL routine body parsing

### DIFF
--- a/core/ast/routines.go
+++ b/core/ast/routines.go
@@ -201,6 +201,9 @@ const (
 	MySQLRoutineStatementInsert      MySQLRoutineStatementKind = "insert"
 	MySQLRoutineStatementUpdate      MySQLRoutineStatementKind = "update"
 	MySQLRoutineStatementDelete      MySQLRoutineStatementKind = "delete"
+	MySQLRoutineStatementOpen        MySQLRoutineStatementKind = "open"
+	MySQLRoutineStatementFetch       MySQLRoutineStatementKind = "fetch"
+	MySQLRoutineStatementClose       MySQLRoutineStatementKind = "close"
 	MySQLRoutineStatementLabel       MySQLRoutineStatementKind = "label"
 )
 

--- a/core/parser/README.md
+++ b/core/parser/README.md
@@ -263,7 +263,7 @@ The parser includes comprehensive tests covering:
 
 Run tests with:
 ```bash
-go test -v ./ptah/core/parser
+go test -v ./core/parser
 ```
 
 ## Integration
@@ -282,7 +282,10 @@ Current limitations include:
   modeled in the AST.
 - Basic expression parsing in CHECK constraints
 - Simplified handling of complex data types
-- No support for stored procedures or functions
+- Stored procedure and function support is dialect-scoped. MySQL/MariaDB,
+  PostgreSQL-family, and SQL Server dialect modes expose routine metadata for
+  supported routine forms while preserving expression internals as raw SQL;
+  unsupported routine body shapes fall back to typed opaque routines or raw SQL.
 
 ## Future Enhancements
 

--- a/core/parser/mysql_routine.go
+++ b/core/parser/mysql_routine.go
@@ -114,9 +114,11 @@ func (p mysqlRoutineParser) collectDefiner(targetIdx int) string {
 		return ""
 	}
 
-	clause := strings.TrimSpace(p.rawFragment(p.tokens[createIdx].End, p.tokens[targetIdx].Start))
-	if strings.HasPrefix(strings.ToUpper(clause), "DEFINER") {
-		return clause
+	for i := createIdx + 1; i < targetIdx; i++ {
+		if !p.tokens[i].MatchIdentifierValue("DEFINER") {
+			continue
+		}
+		return strings.TrimSpace(p.rawFragment(p.tokens[i].Start, p.tokens[targetIdx].Start))
 	}
 	return ""
 }
@@ -166,11 +168,23 @@ func (p mysqlRoutineParser) findRoutineBodyStart(startIdx int) int {
 		if p.tokens[i].Type != lexer.TokenIdentifier {
 			continue
 		}
+		if p.isOuterBodyLabel(i) {
+			return i
+		}
 		if p.tokens[i].MatchIdentifierValue("BEGIN") || p.tokens[i].MatchIdentifierValue("RETURN") {
 			return i
 		}
 	}
 	return -1
+}
+
+func (p mysqlRoutineParser) isOuterBodyLabel(idx int) bool {
+	colonIdx := p.nextSignificant(idx + 1)
+	if colonIdx == -1 || !p.tokens[colonIdx].MatchOperatorValue(":") {
+		return false
+	}
+	beginIdx := p.nextSignificant(colonIdx + 1)
+	return beginIdx != -1 && p.tokens[beginIdx].MatchIdentifierValue("BEGIN")
 }
 
 func (p mysqlRoutineParser) collectFunctionReturns(startIdx, bodyIdx int) string {
@@ -265,6 +279,15 @@ func (p mysqlRoutineParser) afterSignificantTokens(startIdx, bodyIdx, count int)
 
 func (p mysqlRoutineParser) parseRoutineBody(bodyIdx int) (ast.MySQLRoutineBody, error) {
 	switch {
+	case p.isOuterBodyLabel(bodyIdx):
+		bodySQL, err := p.collectCompoundBodySQL(bodyIdx)
+		if err != nil {
+			return ast.MySQLRoutineBody{}, err
+		}
+		return ast.MySQLRoutineBody{
+			SQL:        bodySQL,
+			Statements: parseMySQLRoutineBodyStatements(bodySQL),
+		}, nil
 	case p.tokens[bodyIdx].MatchIdentifierValue("BEGIN"):
 		bodySQL, err := p.collectCompoundBodySQL(bodyIdx)
 		if err != nil {
@@ -289,6 +312,14 @@ func (p mysqlRoutineParser) parseRoutineBody(bodyIdx int) (ast.MySQLRoutineBody,
 }
 
 func (p mysqlRoutineParser) collectCompoundBodySQL(beginIdx int) (string, error) {
+	bodyStartIdx := beginIdx
+	bodyLabel := ""
+	if p.isOuterBodyLabel(beginIdx) {
+		bodyLabel = p.tokens[beginIdx].Value
+		colonIdx := p.nextSignificant(beginIdx + 1)
+		beginIdx = p.nextSignificant(colonIdx + 1)
+	}
+
 	depth := 0
 	caseDepth := 0
 	pendingEndTrailer := false
@@ -309,11 +340,20 @@ func (p mysqlRoutineParser) collectCompoundBodySQL(beginIdx int) (string, error)
 		}
 		trackRoutineCompoundKeyword(keyword, &depth, &caseDepth, &pendingEndTrailer)
 		if depth == 0 && keyword == "END" {
-			return strings.TrimSpace(p.rawFragment(p.tokens[beginIdx].Start, tok.End)), nil
+			end := p.compoundBodyEnd(i, bodyLabel)
+			return strings.TrimSpace(p.rawFragment(p.tokens[bodyStartIdx].Start, end)), nil
 		}
 	}
 
 	return "", fmt.Errorf("unterminated MySQL routine body at position %d", p.tokens[beginIdx].Start)
+}
+
+func (p mysqlRoutineParser) compoundBodyEnd(endIdx int, bodyLabel string) int {
+	nextIdx := p.nextSignificant(endIdx + 1)
+	if bodyLabel != "" && nextIdx != -1 && strings.EqualFold(p.tokens[nextIdx].Value, bodyLabel) {
+		return p.tokens[nextIdx].End
+	}
+	return p.tokens[endIdx].End
 }
 
 func (p mysqlRoutineParser) statementEndFrom(startIdx int) int {
@@ -464,7 +504,8 @@ func (p mysqlRoutineBodyParser) classifyStatement(startIdx int) ast.MySQLRoutine
 		return ast.MySQLRoutineStatementRaw
 	}
 
-	switch strings.ToUpper(tok.Value) {
+	keyword := strings.ToUpper(tok.Value)
+	switch keyword {
 	case "DECLARE":
 		return p.classifyDeclareStatement(startIdx)
 	case "IF":
@@ -472,35 +513,31 @@ func (p mysqlRoutineBodyParser) classifyStatement(startIdx int) ast.MySQLRoutine
 			return ast.MySQLRoutineStatementRaw
 		}
 		return ast.MySQLRoutineStatementIf
-	case "CASE":
-		return ast.MySQLRoutineStatementCase
-	case "BEGIN":
-		return ast.MySQLRoutineStatementBlock
-	case "LOOP":
-		return ast.MySQLRoutineStatementLoop
-	case "WHILE":
-		return ast.MySQLRoutineStatementWhile
-	case "REPEAT":
-		return ast.MySQLRoutineStatementRepeat
-	case "LEAVE":
-		return ast.MySQLRoutineStatementLeave
-	case "ITERATE":
-		return ast.MySQLRoutineStatementIterate
-	case "RETURN":
-		return ast.MySQLRoutineStatementReturn
-	case "SET":
-		return ast.MySQLRoutineStatementSet
-	case "SELECT":
-		return ast.MySQLRoutineStatementSelect
-	case "INSERT":
-		return ast.MySQLRoutineStatementInsert
-	case "UPDATE":
-		return ast.MySQLRoutineStatementUpdate
-	case "DELETE":
-		return ast.MySQLRoutineStatementDelete
-	default:
-		return ast.MySQLRoutineStatementRaw
 	}
+
+	if kind, ok := mysqlRoutineStatementKindsByKeyword[keyword]; ok {
+		return kind
+	}
+	return ast.MySQLRoutineStatementRaw
+}
+
+var mysqlRoutineStatementKindsByKeyword = map[string]ast.MySQLRoutineStatementKind{
+	"CASE":    ast.MySQLRoutineStatementCase,
+	"BEGIN":   ast.MySQLRoutineStatementBlock,
+	"LOOP":    ast.MySQLRoutineStatementLoop,
+	"WHILE":   ast.MySQLRoutineStatementWhile,
+	"REPEAT":  ast.MySQLRoutineStatementRepeat,
+	"LEAVE":   ast.MySQLRoutineStatementLeave,
+	"ITERATE": ast.MySQLRoutineStatementIterate,
+	"RETURN":  ast.MySQLRoutineStatementReturn,
+	"SET":     ast.MySQLRoutineStatementSet,
+	"SELECT":  ast.MySQLRoutineStatementSelect,
+	"INSERT":  ast.MySQLRoutineStatementInsert,
+	"UPDATE":  ast.MySQLRoutineStatementUpdate,
+	"DELETE":  ast.MySQLRoutineStatementDelete,
+	"OPEN":    ast.MySQLRoutineStatementOpen,
+	"FETCH":   ast.MySQLRoutineStatementFetch,
+	"CLOSE":   ast.MySQLRoutineStatementClose,
 }
 
 func (p mysqlRoutineBodyParser) classifyDeclareStatement(startIdx int) ast.MySQLRoutineStatementKind {
@@ -520,6 +557,10 @@ func (p mysqlRoutineBodyParser) classifyDeclareStatement(startIdx int) ast.MySQL
 
 func (p mysqlRoutineBodyParser) outerBlockRange() (beginIdx int, endIdx int) {
 	beginIdx = p.nextSignificant(0)
+	if beginIdx != -1 && p.isLabelStatement(beginIdx) {
+		colonIdx := p.nextSignificant(beginIdx + 1)
+		beginIdx = p.nextSignificant(colonIdx + 1)
+	}
 	if beginIdx == -1 || !p.tokens[beginIdx].MatchIdentifierValue("BEGIN") {
 		return -1, -1
 	}
@@ -555,12 +596,42 @@ func (p mysqlRoutineBodyParser) isLabelStatement(startIdx int) bool {
 
 func (p mysqlRoutineParser) isScalarIF(idx int) bool {
 	nextIdx := p.nextSignificant(idx + 1)
-	return nextIdx != -1 && p.tokens[nextIdx].MatchOperatorValue("(")
+	return isScalarMySQLRoutineIF(p.tokens, nextIdx)
 }
 
 func (p mysqlRoutineBodyParser) isScalarIF(idx int) bool {
 	nextIdx := p.nextSignificant(idx + 1)
-	return nextIdx != -1 && p.tokens[nextIdx].MatchOperatorValue("(")
+	return isScalarMySQLRoutineIF(p.tokens, nextIdx)
+}
+
+func isScalarMySQLRoutineIF(tokens []lexer.Token, openParenIdx int) bool {
+	if openParenIdx == -1 || openParenIdx >= len(tokens) || !tokens[openParenIdx].MatchOperatorValue("(") {
+		return false
+	}
+
+	closeParenIdx := matchingMySQLRoutineParen(tokens, openParenIdx)
+	if closeParenIdx == -1 {
+		return true
+	}
+
+	nextIdx := nextSignificantMySQLRoutineToken(tokens, closeParenIdx+1)
+	return nextIdx == -1 || !tokens[nextIdx].MatchIdentifierValue("THEN")
+}
+
+func matchingMySQLRoutineParen(tokens []lexer.Token, openParenIdx int) int {
+	depth := 0
+	for i := openParenIdx; i < len(tokens); i++ {
+		switch {
+		case tokens[i].MatchOperatorValue("("):
+			depth++
+		case tokens[i].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 func (p mysqlRoutineParser) findFirstIdentifier(value string) int {

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -390,6 +390,9 @@ func (p *Parser) parseCreateOrReplaceStatement(statementStart int) (ast.Node, er
 	if p.current.MatchIdentifierValue("PROCEDURE") {
 		return p.parseCreateRoutine("PROCEDURE", statementStart)
 	}
+	if p.current.MatchIdentifierValue("DEFINER") {
+		return p.parseCreateDefinerRoutine(statementStart)
+	}
 	if p.current.MatchIdentifierValue("TRIGGER") {
 		node, err := p.parseCreateTrigger(statementStart)
 		if err != nil {
@@ -980,7 +983,7 @@ func (p *Parser) collectFunctionBeginBody() (string, bool, error) {
 
 func (p *Parser) trackCurrentRoutineCompoundKeyword(blockDepth, caseDepth *int, pendingEndTrailer *bool) {
 	keyword := strings.ToUpper(p.current.Value)
-	if keyword == "IF" && p.current.End < len(p.input) && p.input[p.current.End] == '(' {
+	if keyword == "IF" && sqlutil.IsScalarIFExpressionFragment(p.input[p.current.End:]) {
 		// MySQL scalar IF(...) calls are not compound IF ... END IF blocks.
 		return
 	}

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -2109,6 +2109,94 @@ CREATE TABLE after_proc (id int);`
 	c.Assert(createTable.Name, qt.Equals, "after_proc")
 }
 
+func TestParser_ParseMySQLDialectParenthesizedProceduralIF(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE PROCEDURE parenthesized_if()
+BEGIN
+    DECLARE seen INT DEFAULT 0;
+    IF (seen = 0) THEN
+        SET seen = 1;
+    END IF;
+    SELECT IF(seen = 1, 'yes', 'no') AS result;
+END;
+CREATE TABLE after_proc (id int);`
+	p := parser.NewParser(sql, parser.WithDialect(platform.MySQL))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Body.SQL, qt.Contains, "END IF")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementDeclaration,
+		ast.MySQLRoutineStatementIf,
+		ast.MySQLRoutineStatementSelect,
+	})
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
+func TestParser_ParseMariaDBDialectDefinerRoutineHardening(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE OR REPLACE DEFINER=`root`@`localhost` PROCEDURE p1() main: BEGIN\n" +
+		"    DECLARE done BOOL DEFAULT FALSE;\n" +
+		"    DECLARE cur CURSOR FOR SELECT id FROM users;\n" +
+		"    DECLARE CONTINUE HANDLER FOR NOT FOUND BEGIN\n" +
+		"        SET done = TRUE;\n" +
+		"    END;\n" +
+		"    OPEN cur;\n" +
+		"    FETCH cur INTO done;\n" +
+		"    CLOSE cur;\n" +
+		"    IF (done = FALSE) THEN\n" +
+		"        SET done = TRUE;\n" +
+		"    END IF;\n" +
+		"    SELECT IF(done, 1, 0) AS value;\n" +
+		"END main;\n" +
+		"CREATE TABLE after_proc (id int);"
+	p := parser.NewParser(sql, parser.WithDialect(platform.MariaDB))
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 2)
+
+	routine, ok := statements.Statements[0].(*ast.MySQLRoutineNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(routine.Dialect, qt.Equals, platform.MariaDB)
+	c.Assert(routine.Kind, qt.Equals, ast.RoutineKindProcedure)
+	c.Assert(routine.Definer, qt.Equals, "DEFINER=`root`@`localhost`")
+	c.Assert(routine.Name, qt.Equals, "p1")
+	c.Assert(routine.SQL, qt.Contains, "CREATE OR REPLACE DEFINER=`root`@`localhost` PROCEDURE p1()")
+	c.Assert(routine.SQL, qt.Not(qt.Contains), "CREATE TABLE after_proc")
+	c.Assert(routine.Body.SQL, qt.Contains, "main: BEGIN")
+	c.Assert(routine.Body.SQL, qt.Contains, "END main")
+	c.Assert(routineStatementKinds(routine.Body.Statements), qt.DeepEquals, []ast.MySQLRoutineStatementKind{
+		ast.MySQLRoutineStatementDeclaration,
+		ast.MySQLRoutineStatementCursor,
+		ast.MySQLRoutineStatementHandler,
+		ast.MySQLRoutineStatementOpen,
+		ast.MySQLRoutineStatementFetch,
+		ast.MySQLRoutineStatementClose,
+		ast.MySQLRoutineStatementIf,
+		ast.MySQLRoutineStatementSelect,
+	})
+	c.Assert(routine.Body.Statements[2].Handler, qt.DeepEquals, &ast.MySQLRoutineHandler{
+		Action:       "CONTINUE",
+		Conditions:   []string{"NOT FOUND"},
+		StatementSQL: "BEGIN\n        SET done = TRUE;\n    END",
+	})
+
+	createTable, ok := statements.Statements[1].(*ast.CreateTableNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(createTable.Name, qt.Equals, "after_proc")
+}
+
 func TestParser_ParseMySQLDialectMalformedDeclareMetadataStaysRaw(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -1020,12 +1020,14 @@ func (r *Renderer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) error {
 	return fmt.Errorf("REVOKE privilege management is not supported in %s (PostgreSQL-specific feature)", r.dialectUpper)
 }
 
-// VisitRawSQL refuses to emit raw SQL. The only emitter of RawSQLNode today
-// is the PostgreSQL planner's constraint-drop path, which produces a PG-
-// specific DO block; routing that through a MySQL-family renderer would
-// produce a migration the target server can't execute. If a future caller
-// genuinely needs dialect-neutral raw SQL it should add a typed escape hatch
-// rather than relying on this method.
+// VisitRawSQL renders a literal SQL fragment verbatim. Dialect-specific
+// routine nodes use this path to preserve executable routine bodies while
+// keeping parser metadata available to callers.
 func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
-	return fmt.Errorf("RawSQLNode is not supported in %s: %q was emitted by a Postgres-specific planner path", r.dialectUpper, node.SQL)
+	sql := strings.TrimSpace(node.SQL)
+	if !strings.HasSuffix(sql, ";") {
+		sql += ";"
+	}
+	r.w.WriteLine(sql)
+	return nil
 }

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -20,6 +20,21 @@ func TestSupportedDialects(t *testing.T) {
 	c.Assert(dialects, qt.DeepEquals, expected)
 }
 
+func TestRenderSQL_MySQLFamilyRoutinePreservesRawSQL(t *testing.T) {
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			routine := ast.NewMySQLRoutine("CREATE PROCEDURE p1() BEGIN SELECT 1; END", dialect, ast.RoutineKindProcedure)
+
+			sql, err := renderer.RenderSQL(dialect, routine)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, "CREATE PROCEDURE p1() BEGIN SELECT 1; END;\n")
+		})
+	}
+}
+
 func TestNewRenderer_SupportedDialects(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/core/sqlutil/client_delimiters.go
+++ b/core/sqlutil/client_delimiters.go
@@ -105,7 +105,7 @@ func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelim
 	var output strings.Builder
 	for pos := 0; pos < len(input); {
 		switch {
-		case allowCommentDelimiter && strings.HasPrefix(input[pos:], delimiter):
+		case allowCommentDelimiter && isCommentDelimiterAt(input, pos, delimiter):
 			writeDelimiterReplacement(&output, replacement)
 			pos += len(delimiter)
 		case strings.HasPrefix(input[pos:], "--"):
@@ -132,6 +132,26 @@ func rewriteClientDelimitedStatements(input, delimiter string, allowCommentDelim
 		}
 	}
 	return output.String()
+}
+
+func isCommentDelimiterAt(input string, pos int, delimiter string) bool {
+	if !strings.HasPrefix(input[pos:], delimiter) {
+		return false
+	}
+	if strings.ContainsAny(delimiter, "\r\n") {
+		return true
+	}
+
+	lineStart := strings.LastIndexAny(input[:pos], "\r\n") + 1
+	if strings.TrimSpace(input[lineStart:pos]) != "" {
+		return false
+	}
+
+	lineEnd := pos + len(delimiter)
+	for lineEnd < len(input) && input[lineEnd] != '\n' && input[lineEnd] != '\r' {
+		lineEnd++
+	}
+	return strings.TrimSpace(input[pos:lineEnd]) == delimiter
 }
 
 func writeDelimiterReplacement(output *strings.Builder, replacement string) {

--- a/core/sqlutil/routine_fragments.go
+++ b/core/sqlutil/routine_fragments.go
@@ -1,0 +1,38 @@
+package sqlutil
+
+import "github.com/stokaro/ptah/core/lexer"
+
+// IsScalarIFExpressionFragment reports whether fragment starts with a MySQL
+// scalar IF(...) expression tail rather than a procedural IF ... THEN block.
+func IsScalarIFExpressionFragment(fragment string) bool {
+	l := lexer.NewLexer(fragment)
+	tok := nextNonTriviaToken(l)
+	if !tok.MatchOperatorValue("(") {
+		return false
+	}
+
+	depth := 1
+	for depth > 0 {
+		tok = l.NextToken()
+		switch {
+		case tok.Type == lexer.TokenEOF:
+			return true
+		case tok.MatchOperatorValue("("):
+			depth++
+		case tok.MatchOperatorValue(")"):
+			depth--
+		}
+	}
+
+	tok = nextNonTriviaToken(l)
+	return !tok.MatchIdentifierValue("THEN")
+}
+
+func nextNonTriviaToken(l *lexer.Lexer) lexer.Token {
+	for {
+		tok := l.NextToken()
+		if tok.Type != lexer.TokenWhitespace && tok.Type != lexer.TokenComment {
+			return tok
+		}
+	}
+}

--- a/core/sqlutil/routine_fragments_test.go
+++ b/core/sqlutil/routine_fragments_test.go
@@ -1,0 +1,56 @@
+package sqlutil_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+)
+
+func TestIsScalarIFExpressionFragment(t *testing.T) {
+	tests := []struct {
+		name     string
+		fragment string
+		expected bool
+	}{
+		{
+			name:     "scalar function call",
+			fragment: "(seen = 1, 'yes', 'no') AS result",
+			expected: true,
+		},
+		{
+			name:     "procedural parenthesized condition",
+			fragment: "(seen = 0) THEN",
+			expected: false,
+		},
+		{
+			name:     "procedural condition with trivia",
+			fragment: " /* leading */ (seen = 0) /* trailing */ THEN",
+			expected: false,
+		},
+		{
+			name:     "nested scalar expression",
+			fragment: "(IF(enabled, 1, 0), 'yes', 'no')",
+			expected: true,
+		},
+		{
+			name:     "unterminated call stays scalar",
+			fragment: "(",
+			expected: true,
+		},
+		{
+			name:     "not an IF call tail",
+			fragment: " condition THEN",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(sqlutil.IsScalarIFExpressionFragment(tt.fragment), qt.Equals, tt.expected)
+		})
+	}
+}

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -262,6 +262,26 @@ END`,
 			},
 		},
 		{
+			name: "atlas comment delimiter requires exact line",
+			input: `-- atlas:delimiter -- end
+
+CREATE PROCEDURE setup()
+BEGIN
+    -- end of setup is a normal routine comment
+    SELECT 1;
+END
+-- end
+CREATE TABLE after_proc (id INT);`,
+			expected: []string{
+				`CREATE PROCEDURE setup()
+BEGIN
+    -- end of setup is a normal routine comment
+    SELECT 1;
+END`,
+				"CREATE TABLE after_proc (id INT)",
+			},
+		},
+		{
 			name: "atlas escaped blank line delimiter",
 			input: `-- atlas:delimiter \n\n
 
@@ -336,6 +356,35 @@ BEGIN
     RETURN b;
 END`,
 		"CREATE TABLE after_routines (id INT)",
+	})
+}
+
+func TestSplitSQLStatements_CompoundRoutineWithScalarAndParenthesizedIF(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE PROCEDURE parenthesized_if()
+BEGIN
+    DECLARE seen INT DEFAULT 0;
+    IF (seen = 0) THEN
+        SET seen = 1;
+    END IF;
+    SELECT IF(seen = 1, 'yes', 'no') AS result;
+END;
+
+CREATE TABLE after_proc (id INT);`
+
+	result := sqlutil.SplitSQLStatements(input)
+
+	c.Assert(result, qt.DeepEquals, []string{
+		`CREATE PROCEDURE parenthesized_if()
+BEGIN
+    DECLARE seen INT DEFAULT 0;
+    IF (seen = 0) THEN
+        SET seen = 1;
+    END IF;
+    SELECT IF(seen = 1, 'yes', 'no') AS result;
+END`,
+		"CREATE TABLE after_proc (id INT)",
 	})
 }
 


### PR DESCRIPTION
## Summary
- harden MySQL/MariaDB routine parsing for parenthesized procedural IF, CREATE OR REPLACE DEFINER, outer routine labels, compound handlers, and cursor OPEN/FETCH/CLOSE statements
- make Atlas comment delimiters exact-line matches so routine comments like `-- end of setup` do not truncate statements
- let MySQL-family renderers preserve typed routine raw SQL and document the current dialect-scoped routine support contract

Refs #322

## Self-review
- pass 1: audited issue acceptance against current parser/sqlutil/renderer/docs and tightened the labeled-body end boundary so only the matching outer label is included
- pass 2: rechecked splitter behavior, renderer raw-SQL blast radius, parser fallback behavior, docs, and test coverage; confirmed `SplitSQLStatements` intentionally does not count IF as a compound opener because `END IF` is handled as an END continuation inside the outer routine block

## Tests
- `go test ./core/parser ./core/sqlutil ./core/renderer -count=1`
- `go tool qtlint ./...`
- `golangci-lint run --timeout=30m ./...`
- `go test ./... -count=1`
- `go test -race ./core/parser ./core/sqlutil ./core/renderer -count=1`
- `git diff --check`
