### PR TITLE
Support generated columns and partial indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,11 +241,27 @@ Status string
 
 //migrator:schema:field name="category_id" type="INT" not_null="true" foreign="categories(id)" foreign_key_name="fk_product_category"
 CategoryID int64
+
+// PostgreSQL/MySQL generated column. PostgreSQL renders STORED generated
+// columns in the current portable preset; use `generated_kind="virtual"` only
+// with dialects that support virtual generated columns.
+//migrator:schema:field name="full_name" type="TEXT" generated="first_name || ' ' || last_name" stored="true"
+FullName string
 ```
+
+Ptah plans PostgreSQL generated-column expression changes with
+`ALTER COLUMN ... SET EXPRESSION` only when the target capabilities are
+PostgreSQL 17 or newer. Older PostgreSQL targets receive an explicit manual
+migration warning instead of an automatic destructive drop-and-recreate plan.
 
 ### Index Definition
 ```go
 //migrator:schema:index name="idx_products_category" fields="category_id"
+_ int
+
+// PostgreSQL/SQLite partial index. `condition=` remains accepted for older
+// annotations, but `where=` matches Atlas HCL terminology.
+//migrator:schema:index name="idx_active_products" fields="category_id" where="deleted_at IS NULL"
 _ int
 
 // ClickHouse data-skipping index: opt-in type + granularity

--- a/core/ast/operations.go
+++ b/core/ast/operations.go
@@ -83,6 +83,24 @@ func (op *ModifyColumnOperation) Accept(visitor Visitor) error {
 // alterOperation implements the marker method for type safety.
 func (op *ModifyColumnOperation) alterOperation() {}
 
+// AlterGeneratedColumnExpressionOperation changes the expression of an existing
+// generated column without dropping the column and its dependents.
+type AlterGeneratedColumnExpressionOperation struct {
+	// ColumnName is the generated column to alter.
+	ColumnName string
+	// Expression is the target generated-column expression without wrapping
+	// parentheses.
+	Expression string
+}
+
+// Accept implements the Node interface for AlterGeneratedColumnExpressionOperation.
+func (op *AlterGeneratedColumnExpressionOperation) Accept(_visitor Visitor) error {
+	return nil
+}
+
+// alterOperation implements the marker method for type safety.
+func (op *AlterGeneratedColumnExpressionOperation) alterOperation() {}
+
 // AddConstraintOperation represents an ADD CONSTRAINT operation in ALTER TABLE statements.
 //
 // This operation adds a new constraint to an existing table. The constraint can be

--- a/core/convert/dbschematogo/dbschematogo.go
+++ b/core/convert/dbschematogo/dbschematogo.go
@@ -105,6 +105,7 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 			TableName:  dbIndex.QualifiedTableName(),
 			Fields:     dbIndex.Columns,
 			Unique:     dbIndex.IsUnique,
+			Condition:  dbIndex.Condition,
 		}
 		database.Indexes = append(database.Indexes, index)
 	}

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -30,6 +30,7 @@ var knownIndexAttributes = map[string]bool{
 	"comment":     true,
 	"type":        true,
 	"condition":   true,
+	"where":       true,
 	"ops":         true,
 	"table":       true,
 	"granularity": true,
@@ -56,6 +57,9 @@ var knownFieldAttributes = map[string]bool{
 	"unique":              true,
 	"unique_expr":         true,
 	"index":               true,
+	"generated":           true,
+	"generated_kind":      true,
+	"stored":              true,
 	"default":             true,
 	"default_expr":        true,
 	"foreign":             true,
@@ -180,34 +184,52 @@ func (s *schemaParseState) parseFieldComment(
 		}
 		_, defaultSet := kv["default"]
 		s.schemaFields = append(s.schemaFields, Field{
-			StructName:         structName,
-			FieldName:          name.Name,
-			Name:               kv["name"],
-			Type:               fieldType,
-			Nullable:           kv["not_null"] != "true",
-			Primary:            kv["primary"] == "true",
-			AutoInc:            kv["auto_increment"] == "true" || identityGeneration != "",
-			IdentityGeneration: identityGeneration,
-			IdentityStart:      kv["identity_start"],
-			IdentityIncrement:  kv["identity_increment"],
-			IdentityOptions:    kv["identity_options"],
-			Unique:             kv["unique"] == "true",
-			UniqueExpr:         kv["unique_expr"],
-			Default:            kv["default"],
-			DefaultSet:         defaultSet,
-			DefaultExpr:        kv["default_expr"],
-			Foreign:            kv["foreign"],
-			ForeignKeyName:     kv["foreign_key_name"],
-			OnDelete:           kv["on_delete"],
-			OnUpdate:           kv["on_update"],
-			Enum:               enum,
-			Check:              kv["check"],
-			CheckName:          kv["check_name"],
-			Comment:            kv["comment"],
-			Overrides:          parseutils.ParsePlatformSpecific(kv),
+			StructName:          structName,
+			FieldName:           name.Name,
+			Name:                kv["name"],
+			Type:                fieldType,
+			Nullable:            kv["not_null"] != "true",
+			Primary:             kv["primary"] == "true",
+			AutoInc:             kv["auto_increment"] == "true" || identityGeneration != "",
+			IdentityGeneration:  identityGeneration,
+			IdentityStart:       kv["identity_start"],
+			IdentityIncrement:   kv["identity_increment"],
+			IdentityOptions:     kv["identity_options"],
+			Unique:              kv["unique"] == "true",
+			UniqueExpr:          kv["unique_expr"],
+			Default:             kv["default"],
+			DefaultSet:          defaultSet,
+			DefaultExpr:         kv["default_expr"],
+			Foreign:             kv["foreign"],
+			ForeignKeyName:      kv["foreign_key_name"],
+			OnDelete:            kv["on_delete"],
+			OnUpdate:            kv["on_update"],
+			Enum:                enum,
+			Check:               kv["check"],
+			CheckName:           kv["check_name"],
+			GeneratedExpression: kv["generated"],
+			GeneratedKind:       generatedColumnKind(kv),
+			Comment:             kv["comment"],
+			Overrides:           parseutils.ParsePlatformSpecific(kv),
 		})
 	}
 	return nil
+}
+
+func generatedColumnKind(kv map[string]string) string {
+	if strings.TrimSpace(kv["generated"]) == "" {
+		return ""
+	}
+	if kind := strings.TrimSpace(kv["generated_kind"]); kind != "" {
+		return strings.ToUpper(kind)
+	}
+	if stored := strings.TrimSpace(kv["stored"]); stored != "" {
+		if strings.EqualFold(stored, "true") {
+			return "STORED"
+		}
+		return "VIRTUAL"
+	}
+	return ""
 }
 
 func hasIdentitySettings(kv map[string]string) bool {
@@ -289,13 +311,22 @@ func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName st
 		Fields:      fields,
 		Unique:      kv["unique"] == "true",
 		Comment:     kv["comment"],
-		Type:        kv["type"],      // PG: GIN/GIST/BTREE/HASH; CH: minmax/set(N)/bloom_filter/...
-		Condition:   kv["condition"], // PG only: WHERE clause for partial indexes
-		Operator:    kv["ops"],       // PG only: operator class (gin_trgm_ops, etc.)
-		TableName:   tableName,       // Target table name
-		Granularity: granularity,     // CH only: GRANULARITY n for data-skipping indexes
+		Type:        kv["type"],                                  // PG: GIN/GIST/BTREE/HASH; CH: minmax/set(N)/bloom_filter/...
+		Condition:   firstNonEmpty(kv["where"], kv["condition"]), // PG/SQLite: WHERE clause for partial indexes
+		Operator:    kv["ops"],                                   // PG only: operator class (gin_trgm_ops, etc.)
+		TableName:   tableName,                                   // Target table name
+		Granularity: granularity,                                 // CH only: GRANULARITY n for data-skipping indexes
 	})
 	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // ParseConstraintComment parses a constraint comment and adds it to the constraints slice.
@@ -410,6 +441,12 @@ type schemaParseState struct {
 	roles                 []Role
 	grants                []Grant
 	schemas               []Schema
+}
+
+type structDeclaration struct {
+	name       string
+	genDecl    *ast.GenDecl
+	structType *ast.StructType
 }
 
 func newSchemaParseState() *schemaParseState {
@@ -583,31 +620,13 @@ func parseFileAST(f *ast.File) (Database, error) {
 	return result, nil
 }
 
-// processFileAST processes the entire AST file in a single optimized pass
+// processFileAST processes the entire AST file.
 func (s *schemaParseState) processFileAST(f *ast.File) error {
-	// First, collect table names from struct declarations
-	for _, decl := range f.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range genDecl.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			structName := typeSpec.Name.Name
-			_, ok = typeSpec.Type.(*ast.StructType)
-			if !ok {
-				continue
-			}
-
-			mapTableDirectiveStructNames(genDecl.Doc, structName, s.tableNameToStructName)
-		}
-	}
+	structDecls := collectStructDeclarations(f)
+	s.mapTableDirectiveStructNames(structDecls)
 
 	// Process all struct declarations
-	if err := s.processDeclarations(f); err != nil {
+	if err := s.processDeclarations(structDecls); err != nil {
 		return err
 	}
 
@@ -616,28 +635,8 @@ func (s *schemaParseState) processFileAST(f *ast.File) error {
 	return nil
 }
 
-func mapTableDirectiveStructNames(doc *ast.CommentGroup, structName string, tableNameToStructName map[string]string) {
-	if doc == nil {
-		return
-	}
-	for _, comment := range doc.List {
-		if !strings.HasPrefix(comment.Text, "//migrator:schema:table") {
-			continue
-		}
-		kv := parseutils.ParseKeyValueComment(comment.Text)
-		tableName := kv["name"]
-		if tableName == "" {
-			continue
-		}
-		tableNameToStructName[tableName] = structName
-		if schemaName := kv["schema"]; schemaName != "" {
-			tableNameToStructName[QualifyTableName(schemaName, tableName)] = structName
-		}
-	}
-}
-
-// processDeclarations processes all struct declarations in the file
-func (s *schemaParseState) processDeclarations(f *ast.File) error {
+func collectStructDeclarations(f *ast.File) []structDeclaration {
+	var structDecls []structDeclaration
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -648,18 +647,54 @@ func (s *schemaParseState) processDeclarations(f *ast.File) error {
 			if !ok {
 				continue
 			}
-			structName := typeSpec.Name.Name
 			structType, ok := typeSpec.Type.(*ast.StructType)
 			if !ok {
 				continue
 			}
+			structDecls = append(structDecls, structDeclaration{
+				name:       typeSpec.Name.Name,
+				genDecl:    genDecl,
+				structType: structType,
+			})
+		}
+	}
+	return structDecls
+}
 
-			if err := s.processTableComments(structName, genDecl); err != nil {
-				return err
-			}
-			if err := s.processFieldComments(structName, structType); err != nil {
-				return err
-			}
+func (s *schemaParseState) mapTableDirectiveStructNames(structDecls []structDeclaration) {
+	for _, structDecl := range structDecls {
+		if structDecl.genDecl.Doc == nil {
+			continue
+		}
+		for _, comment := range structDecl.genDecl.Doc.List {
+			s.mapTableDirectiveStructName(comment, structDecl.name)
+		}
+	}
+}
+
+func (s *schemaParseState) mapTableDirectiveStructName(comment *ast.Comment, structName string) {
+	if !strings.HasPrefix(comment.Text, "//migrator:schema:table") {
+		return
+	}
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	tableName := kv["name"]
+	if tableName == "" {
+		return
+	}
+	s.tableNameToStructName[tableName] = structName
+	if schemaName := kv["schema"]; schemaName != "" {
+		s.tableNameToStructName[QualifyTableName(schemaName, tableName)] = structName
+	}
+}
+
+// processDeclarations processes all struct declarations in the file.
+func (s *schemaParseState) processDeclarations(structDecls []structDeclaration) error {
+	for _, structDecl := range structDecls {
+		if err := s.processTableComments(structDecl.name, structDecl.genDecl); err != nil {
+			return err
+		}
+		if err := s.processFieldComments(structDecl.name, structDecl.structType); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/core/goschema/postgresql_features_test.go
+++ b/core/goschema/postgresql_features_test.go
@@ -112,6 +112,18 @@ func TestParseIndexWithPostgreSQLFeatures(t *testing.T) {
 			},
 		},
 		{
+			name:    "partial index with atlas-style where alias",
+			comment: "//migrator:schema:index name=\"idx_active\" fields=\"status\" where=\"deleted_at IS NULL\"",
+			expected: goschema.Index{
+				Name:      "idx_active",
+				Fields:    []string{"status"},
+				Type:      "",
+				Condition: "deleted_at IS NULL",
+				Operator:  "",
+				TableName: "",
+			},
+		},
+		{
 			name:    "trigram index",
 			comment: "//migrator:schema:index name=\"idx_name_trgm\" fields=\"name\" type=\"GIN\" ops=\"gin_trgm_ops\"",
 			expected: goschema.Index{
@@ -173,6 +185,58 @@ type TestEntity struct {
 			c.Assert(idx.Condition, qt.Equals, tt.expected.Condition)
 			c.Assert(idx.Operator, qt.Equals, tt.expected.Operator)
 			c.Assert(idx.TableName, qt.Equals, tt.expected.TableName)
+		})
+	}
+}
+
+func TestParseGeneratedColumnField(t *testing.T) {
+	tests := []struct {
+		name     string
+		comment  string
+		expected goschema.Field
+	}{
+		{
+			name:    "stored generated column",
+			comment: "//migrator:schema:field name=\"full_name\" type=\"TEXT\" generated=\"first_name || ' ' || last_name\" stored=\"true\"",
+			expected: goschema.Field{
+				Name:                "full_name",
+				Type:                "TEXT",
+				GeneratedExpression: "first_name || ' ' || last_name",
+				GeneratedKind:       "STORED",
+			},
+		},
+		{
+			name:    "explicit generated kind",
+			comment: "//migrator:schema:field name=\"full_name\" type=\"TEXT\" generated=\"concat(first_name, ' ', last_name)\" generated_kind=\"virtual\"",
+			expected: goschema.Field{
+				Name:                "full_name",
+				Type:                "TEXT",
+				GeneratedExpression: "concat(first_name, ' ', last_name)",
+				GeneratedKind:       "VIRTUAL",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			content := `package test
+
+type TestEntity struct {
+	` + tt.comment + `
+	FullName string
+}
+`
+
+			database := parseStringAsGoFile(c, content)
+
+			c.Assert(database.Fields, qt.HasLen, 1)
+			field := database.Fields[0]
+			c.Assert(field.Name, qt.Equals, tt.expected.Name)
+			c.Assert(field.Type, qt.Equals, tt.expected.Type)
+			c.Assert(field.GeneratedExpression, qt.Equals, tt.expected.GeneratedExpression)
+			c.Assert(field.GeneratedKind, qt.Equals, tt.expected.GeneratedKind)
 		})
 	}
 }

--- a/core/parser/parser.go
+++ b/core/parser/parser.go
@@ -3836,15 +3836,33 @@ func (p *Parser) parseCreateIndexAfterKeyword(indexType string) (*ast.IndexNode,
 	if err != nil {
 		return nil, err
 	}
+	p.skipWhitespace()
+	condition := p.parseCreateIndexCondition()
 
 	index := ast.NewIndex(indexName, tableName, columns...)
 	index.Type = indexType
 	index.IncludeColumns = includeColumns
 	index.NullsDistinct = nullsDistinct
 	index.StorageParams = storageParams
+	index.Condition = condition
 	index.Concurrently = concurrently
 	index.IfNotExists = ifNotExists
 	return index, nil
+}
+
+func (p *Parser) parseCreateIndexCondition() string {
+	if !p.current.MatchIdentifierValue("WHERE") {
+		return ""
+	}
+	p.advance()
+	p.skipWhitespace()
+	start := p.current.Start
+	end := start
+	for !p.isAtEnd() && p.current.Type != lexer.TokenSemicolon {
+		end = p.current.End
+		p.advance()
+	}
+	return strings.TrimSpace(p.input[start:end])
 }
 
 func (p *Parser) parseCreateIndexIncludeColumns() ([]string, error) {

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -2682,10 +2682,28 @@ func TestParser_ParseCreateIndexInclude(t *testing.T) {
 	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"active", "version"})
 }
 
+func TestParser_ParseCreatePartialIndex(t *testing.T) {
+	c := qt.New(t)
+
+	sql := "CREATE INDEX idx_users_email_active ON users (email) WHERE deleted_at IS NULL;"
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	index, ok := statements.Statements[0].(*ast.IndexNode)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(index.Name, qt.Equals, "idx_users_email_active")
+	c.Assert(index.Table, qt.Equals, "users")
+	c.Assert(index.Columns, qt.DeepEquals, []string{"email"})
+	c.Assert(index.Condition, qt.Equals, "deleted_at IS NULL")
+}
+
 func TestParser_ParseCreateIndexUsingAndStorageParams(t *testing.T) {
 	c := qt.New(t)
 
-	sql := "CREATE INDEX idx_users_c ON users USING BRIN (c) WITH (pages_per_range='2');"
+	sql := "CREATE INDEX idx_users_c ON users USING BRIN (c) WITH (pages_per_range='2') WHERE c IS NOT NULL;"
 	p := parser.NewParser(sql)
 
 	statements, err := p.Parse()
@@ -2699,6 +2717,7 @@ func TestParser_ParseCreateIndexUsingAndStorageParams(t *testing.T) {
 	c.Assert(index.Type, qt.Equals, "BRIN")
 	c.Assert(index.Columns, qt.DeepEquals, []string{"c"})
 	c.Assert(index.StorageParams, qt.DeepEquals, map[string]string{"pages_per_range": "2"})
+	c.Assert(index.Condition, qt.Equals, "c IS NOT NULL")
 }
 
 func TestParser_ParseCreateUniqueIndexNullsNotDistinct(t *testing.T) {

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -112,6 +112,13 @@ const (
 	// CREATE OR REPLACE TRIGGER and an explicit drop/create sequence.
 	CreateOrReplaceTrigger Capability = "create_or_replace_trigger"
 
+	// AlterGeneratedColumnExpression marks support for changing a generated
+	// column expression in place. PostgreSQL added
+	// ALTER TABLE ... ALTER COLUMN ... SET EXPRESSION AS (...) in 17. Older
+	// versions require destructive workarounds that Ptah does not plan
+	// automatically.
+	AlterGeneratedColumnExpression Capability = "alter_generated_column_expression"
+
 	// RowLevelSecurity marks support for row-level security policies
 	// (PostgreSQL ALTER TABLE ... ENABLE ROW LEVEL SECURITY + CREATE POLICY).
 	RowLevelSecurity Capability = "row_level_security"
@@ -182,6 +189,9 @@ var registry = map[Capability]spec{
 	},
 	CreateOrReplaceTrigger: {
 		doc: "CREATE OR REPLACE TRIGGER (PostgreSQL 14+, MariaDB; not MySQL)",
+	},
+	AlterGeneratedColumnExpression: {
+		doc: "in-place ALTER COLUMN SET EXPRESSION for generated columns (PostgreSQL 17+)",
 	},
 	RowLevelSecurity: {
 		doc: "row-level security policies (PostgreSQL)",
@@ -306,21 +316,22 @@ func All() []Capability {
 // (see the MySQL planner's constraint-drop ownership rules, issue #207).
 func MySQL80() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:    true,
-		DropConstraintIfExists:   false,
-		DropIndexIfExists:        false,
-		CheckConstraintsEnforced: true,
-		DropCheckClause:          true,
-		EnumInlineColumn:         true,
-		EnumCustomType:           false,
-		CreateIndexConcurrently:  false,
-		CreateOrReplaceTrigger:   false,
-		RowLevelSecurity:         false,
-		RoleManagement:           false,
-		ForeignKeys:              true,
-		Sequences:                false,
-		XMLType:                  false,
-		AdvisoryLocks:            false,
+		DropConstraintGeneric:          true,
+		DropConstraintIfExists:         false,
+		DropIndexIfExists:              false,
+		CheckConstraintsEnforced:       true,
+		DropCheckClause:                true,
+		EnumInlineColumn:               true,
+		EnumCustomType:                 false,
+		CreateIndexConcurrently:        false,
+		CreateOrReplaceTrigger:         false,
+		AlterGeneratedColumnExpression: false,
+		RowLevelSecurity:               false,
+		RoleManagement:                 false,
+		ForeignKeys:                    true,
+		Sequences:                      false,
+		XMLType:                        false,
+		AdvisoryLocks:                  false,
 	}
 }
 
@@ -345,21 +356,22 @@ func MySQLLegacy() Capabilities {
 // constraint and index drops.
 func MariaDB1011() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:    true,
-		DropConstraintIfExists:   true,
-		DropIndexIfExists:        true,
-		CheckConstraintsEnforced: true,
-		DropCheckClause:          false,
-		EnumInlineColumn:         true,
-		EnumCustomType:           false,
-		CreateIndexConcurrently:  false,
-		CreateOrReplaceTrigger:   true,
-		RowLevelSecurity:         false,
-		RoleManagement:           false,
-		ForeignKeys:              true,
-		Sequences:                true,
-		XMLType:                  false,
-		AdvisoryLocks:            false,
+		DropConstraintGeneric:          true,
+		DropConstraintIfExists:         true,
+		DropIndexIfExists:              true,
+		CheckConstraintsEnforced:       true,
+		DropCheckClause:                false,
+		EnumInlineColumn:               true,
+		EnumCustomType:                 false,
+		CreateIndexConcurrently:        false,
+		CreateOrReplaceTrigger:         true,
+		AlterGeneratedColumnExpression: false,
+		RowLevelSecurity:               false,
+		RoleManagement:                 false,
+		ForeignKeys:                    true,
+		Sequences:                      true,
+		XMLType:                        false,
+		AdvisoryLocks:                  false,
 	}
 }
 
@@ -377,25 +389,31 @@ func MariaDBLegacy() Capabilities {
 		With(CreateOrReplaceTrigger, false)
 }
 
-// Postgres16 is the preset for PostgreSQL 14+ (14/15/16/17 share these).
+// Postgres16 is the preset for PostgreSQL 14–16.
 func Postgres16() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:    true,
-		DropConstraintIfExists:   true,
-		DropIndexIfExists:        true,
-		CheckConstraintsEnforced: true,
-		DropCheckClause:          false,
-		EnumInlineColumn:         false,
-		EnumCustomType:           true,
-		CreateIndexConcurrently:  true,
-		CreateOrReplaceTrigger:   true,
-		RowLevelSecurity:         true,
-		RoleManagement:           true,
-		ForeignKeys:              true,
-		Sequences:                true,
-		XMLType:                  true,
-		AdvisoryLocks:            true,
+		DropConstraintGeneric:          true,
+		DropConstraintIfExists:         true,
+		DropIndexIfExists:              true,
+		CheckConstraintsEnforced:       true,
+		DropCheckClause:                false,
+		EnumInlineColumn:               false,
+		EnumCustomType:                 true,
+		CreateIndexConcurrently:        true,
+		CreateOrReplaceTrigger:         true,
+		AlterGeneratedColumnExpression: false,
+		RowLevelSecurity:               true,
+		RoleManagement:                 true,
+		ForeignKeys:                    true,
+		Sequences:                      true,
+		XMLType:                        true,
+		AdvisoryLocks:                  true,
 	}
+}
+
+// Postgres17 is the preset for PostgreSQL 17+.
+func Postgres17() Capabilities {
+	return Postgres16().With(AlterGeneratedColumnExpression, true)
 }
 
 // Postgres13 is the preset for PostgreSQL 12–13: identical to Postgres16
@@ -410,21 +428,22 @@ func Postgres13() Capabilities {
 // (Enum8/Enum16).
 func ClickHouse24() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:    false,
-		DropConstraintIfExists:   false,
-		DropIndexIfExists:        false,
-		CheckConstraintsEnforced: false,
-		DropCheckClause:          false,
-		EnumInlineColumn:         true,
-		EnumCustomType:           false,
-		CreateIndexConcurrently:  false,
-		CreateOrReplaceTrigger:   false,
-		RowLevelSecurity:         false,
-		RoleManagement:           false,
-		ForeignKeys:              false,
-		Sequences:                false,
-		XMLType:                  false,
-		AdvisoryLocks:            false,
+		DropConstraintGeneric:          false,
+		DropConstraintIfExists:         false,
+		DropIndexIfExists:              false,
+		CheckConstraintsEnforced:       false,
+		DropCheckClause:                false,
+		EnumInlineColumn:               true,
+		EnumCustomType:                 false,
+		CreateIndexConcurrently:        false,
+		CreateOrReplaceTrigger:         false,
+		AlterGeneratedColumnExpression: false,
+		RowLevelSecurity:               false,
+		RoleManagement:                 false,
+		ForeignKeys:                    false,
+		Sequences:                      false,
+		XMLType:                        false,
+		AdvisoryLocks:                  false,
 	}
 }
 
@@ -434,21 +453,22 @@ func ClickHouse24() Capabilities {
 // advisory-lock surface.
 func SQLite3() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:    false,
-		DropConstraintIfExists:   false,
-		DropIndexIfExists:        true,
-		CheckConstraintsEnforced: true,
-		DropCheckClause:          false,
-		EnumInlineColumn:         false,
-		EnumCustomType:           false,
-		CreateIndexConcurrently:  false,
-		CreateOrReplaceTrigger:   false,
-		RowLevelSecurity:         false,
-		RoleManagement:           false,
-		ForeignKeys:              true,
-		Sequences:                false,
-		XMLType:                  false,
-		AdvisoryLocks:            false,
+		DropConstraintGeneric:          false,
+		DropConstraintIfExists:         false,
+		DropIndexIfExists:              true,
+		CheckConstraintsEnforced:       true,
+		DropCheckClause:                false,
+		EnumInlineColumn:               false,
+		EnumCustomType:                 false,
+		CreateIndexConcurrently:        false,
+		CreateOrReplaceTrigger:         false,
+		AlterGeneratedColumnExpression: false,
+		RowLevelSecurity:               false,
+		RoleManagement:                 false,
+		ForeignKeys:                    true,
+		Sequences:                      false,
+		XMLType:                        false,
+		AdvisoryLocks:                  false,
 	}
 }
 
@@ -505,7 +525,7 @@ func SpannerPostgres() Capabilities {
 func ForDialect(dialect string) Capabilities {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
-		return Postgres16()
+		return Postgres17()
 	case platform.MySQL:
 		return MySQL80()
 	case platform.MariaDB:
@@ -578,6 +598,9 @@ func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 	case platform.MariaDB:
 		return mariaDBForVersion(version), parseableMariaDBVersion(version)
 	case platform.Postgres:
+		if v.major >= 17 {
+			return Postgres17(), true
+		}
 		if v.major >= 14 {
 			return Postgres16(), true
 		}

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -93,6 +93,7 @@ func TestPresets_AllValid_AndCoverEveryRegisteredCapability(t *testing.T) {
 		"MySQLLegacy":   capability.MySQLLegacy(),
 		"MariaDB1011":   capability.MariaDB1011(),
 		"MariaDBLegacy": capability.MariaDBLegacy(),
+		"Postgres17":    capability.Postgres17(),
 		"Postgres16":    capability.Postgres16(),
 		"Postgres13":    capability.Postgres13(),
 		"ClickHouse24":  capability.ClickHouse24(),
@@ -128,9 +129,13 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(capability.MySQL8016().Has(capability.CheckConstraintsEnforced), qt.IsTrue)
 	c.Assert(capability.MySQLLegacy().Has(capability.CheckConstraintsEnforced), qt.IsFalse)
 
-	// Postgres version presets gate CREATE OR REPLACE TRIGGER (PG 14+).
+	// Postgres version presets gate CREATE OR REPLACE TRIGGER (PG 14+) and
+	// generated-column SET EXPRESSION (PG 17+).
+	c.Assert(capability.Postgres17().Has(capability.AlterGeneratedColumnExpression), qt.IsTrue)
+	c.Assert(capability.Postgres16().Has(capability.AlterGeneratedColumnExpression), qt.IsFalse)
 	c.Assert(capability.Postgres16().Has(capability.CreateOrReplaceTrigger), qt.IsTrue)
 	c.Assert(capability.Postgres13().Has(capability.CreateOrReplaceTrigger), qt.IsFalse)
+	c.Assert(capability.Postgres13().Has(capability.AlterGeneratedColumnExpression), qt.IsFalse)
 	c.Assert(capability.Postgres13().Has(capability.CreateIndexConcurrently), qt.IsTrue)
 	c.Assert(capability.Postgres16().Has(capability.RoleManagement), qt.IsTrue)
 
@@ -218,6 +223,7 @@ func TestForDialect(t *testing.T) {
 	c.Assert(capability.ForDialect("mysql").Has(capability.DropConstraintIfExists), qt.IsFalse)
 	c.Assert(capability.ForDialect("mariadb").Has(capability.DropConstraintIfExists), qt.IsTrue)
 	c.Assert(capability.ForDialect("postgres").Has(capability.CreateIndexConcurrently), qt.IsTrue)
+	c.Assert(capability.ForDialect("postgres").Has(capability.AlterGeneratedColumnExpression), qt.IsTrue)
 	// Dialect aliases go through platform.NormalizeDialect.
 	c.Assert(capability.ForDialect("postgresql").Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(capability.ForDialect("pgx").Has(capability.EnumCustomType), qt.IsTrue)
@@ -261,7 +267,9 @@ func TestForServerVersion(t *testing.T) {
 		{"mariadb pre-10.2 degrades to the legacy floor", "mariadb", "10.1.48-MariaDB", capability.DropConstraintIfExists, false},
 		{"mariadb pre-10.2 over mysql protocol prefix", "mysql", "5.5.5-10.1.48-MariaDB", capability.CheckConstraintsEnforced, false},
 		{"mariadb unparseable stays on the modern preset", "mariadb", "MariaDB something", capability.DropConstraintIfExists, true},
+		{"postgres 17 banner", "postgres", "PostgreSQL 17.5", capability.AlterGeneratedColumnExpression, true},
 		{"postgres 16 banner", "postgres", "PostgreSQL 16.3 (Debian 16.3-1.pgdg120+1)", capability.CreateOrReplaceTrigger, true},
+		{"postgres 16 lacks generated expression alter", "postgres", "PostgreSQL 16.3", capability.AlterGeneratedColumnExpression, false},
 		{"postgres 14 exact boundary", "postgres", "PostgreSQL 14.0", capability.CreateOrReplaceTrigger, true},
 		{"postgres 13 plain", "postgres", "13.14", capability.CreateOrReplaceTrigger, false},
 		{"postgres 13 still concurrent-capable", "postgres", "13.14", capability.CreateIndexConcurrently, true},

--- a/core/renderer/dialects/postgres/alter_ops_test.go
+++ b/core/renderer/dialects/postgres/alter_ops_test.go
@@ -6,6 +6,8 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer/dialects/postgres"
 )
 
@@ -102,4 +104,41 @@ func TestPostgres_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {
 		qt.Commentf("postgres must not emit ADD INDEX for an AddSkippingIndexOperation; got: %q", out))
 	c.Assert(out, qt.Not(qt.Contains), "MODIFY TTL",
 		qt.Commentf("postgres must not emit MODIFY TTL for a ModifyTTLOperation; got: %q", out))
+}
+
+func TestPostgres_AlterTable_SetGeneratedExpression(t *testing.T) {
+	c := qt.New(t)
+	alter := &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.AlterGeneratedColumnExpressionOperation{
+				ColumnName: "slug",
+				Expression: "lower(name)",
+			},
+		},
+	}
+
+	out := renderPG(t, alter)
+
+	c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "slug" SET EXPRESSION AS (lower(name));`)
+}
+
+func TestPostgres_AlterTable_SetGeneratedExpressionUnsupported(t *testing.T) {
+	c := qt.New(t)
+	renderer := postgres.NewWithCapabilities(capability.Postgres16(), platform.Postgres)
+	alter := &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.AlterGeneratedColumnExpressionOperation{
+				ColumnName: "slug",
+				Expression: "lower(name)",
+			},
+		},
+	}
+
+	err := alter.Accept(renderer)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(renderer.Output(), qt.Contains, `ALTER COLUMN SET EXPRESSION requires PostgreSQL 17+`)
+	c.Assert(renderer.Output(), qt.Not(qt.Contains), `SET EXPRESSION AS`)
 }

--- a/core/renderer/dialects/postgres/postgres.go
+++ b/core/renderer/dialects/postgres/postgres.go
@@ -167,7 +167,7 @@ func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 
 // New creates a new PostgreSQL renderer
 func New() *Renderer {
-	return NewWithCapabilities(capability.Postgres16(), platform.Postgres)
+	return NewWithCapabilities(capability.Postgres17(), platform.Postgres)
 }
 
 // NewWithCapabilities creates a PostgreSQL-family renderer configured for a
@@ -522,6 +522,24 @@ func (r *Renderer) VisitAlterTable(node *ast.AlterTableNode) error {
 		case *ast.ModifyColumnOperation:
 			// PostgreSQL uses different syntax for modifying columns
 			r.renderPostgreSQLModifyColumn(node.Name, op.Column)
+		case *ast.AlterGeneratedColumnExpressionOperation:
+			if !r.capabilities().Has(capability.AlterGeneratedColumnExpression) {
+				r.w.WriteLinef(
+					"-- %s: ALTER COLUMN SET EXPRESSION requires PostgreSQL 17+; generated column %q was not changed.",
+					r.dialectUpper,
+					op.ColumnName,
+				)
+				continue
+			}
+			expression := strings.TrimSpace(op.Expression)
+			if expression == "" {
+				return fmt.Errorf("postgres: generated column %q has empty expression", op.ColumnName)
+			}
+			r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s SET EXPRESSION AS (%s);",
+				r.escapeQualifiedIdentifier(node.Name),
+				r.escapeIdentifier(op.ColumnName),
+				expression,
+			)
 		case *ast.RenameColumnOperation:
 			// PostgreSQL has supported `ALTER TABLE x RENAME COLUMN old TO new`
 			// for a long time; emit it unconditionally.

--- a/core/yamlschema/yamlschema.go
+++ b/core/yamlschema/yamlschema.go
@@ -92,6 +92,9 @@ type fieldSpec struct {
 	Unique             bool         `yaml:"unique"`
 	UniqueExpr         stringScalar `yaml:"unique_expr"`
 	Index              bool         `yaml:"index"`
+	Generated          stringScalar `yaml:"generated"`
+	GeneratedKind      stringScalar `yaml:"generated_kind"`
+	Stored             bool         `yaml:"stored"`
 	Default            stringScalar `yaml:"default"`
 	DefaultExpr        stringScalar `yaml:"default_expr"`
 	Foreign            stringScalar `yaml:"foreign"`
@@ -116,6 +119,7 @@ type indexSpec struct {
 	Comment     stringScalar `yaml:"comment"`
 	Type        stringScalar `yaml:"type"`
 	Condition   stringScalar `yaml:"condition"`
+	Where       stringScalar `yaml:"where"`
 	Operator    stringScalar `yaml:"ops"`
 	TableName   stringScalar `yaml:"table"`
 	Granularity int          `yaml:"granularity"`
@@ -384,37 +388,61 @@ func buildField(structName, key string, spec fieldSpec, db *goschema.Database) (
 	}
 
 	return goschema.Field{
-		StructName:         structName,
-		FieldName:          fieldName,
-		Name:               columnName,
-		Type:               fieldType,
-		Nullable:           nullable,
-		Primary:            spec.Primary,
-		AutoInc:            spec.AutoIncrement || spec.AutoInc || identityGeneration != "",
-		IdentityGeneration: identityGeneration,
-		IdentityStart:      string(spec.IdentityStart),
-		IdentityIncrement:  string(spec.IdentityIncrement),
-		IdentityOptions:    string(spec.IdentityOptions),
-		Unique:             spec.Unique,
-		UniqueExpr:         string(spec.UniqueExpr),
-		Default:            string(spec.Default),
-		DefaultExpr:        string(spec.DefaultExpr),
-		Foreign:            string(spec.Foreign),
-		ForeignKeyName:     string(spec.ForeignKeyName),
-		OnDelete:           string(spec.OnDelete),
-		OnUpdate:           string(spec.OnUpdate),
-		Enum:               enumValues,
-		Check:              string(spec.Check),
-		CheckName:          string(spec.CheckName),
-		Charset:            string(spec.Charset),
-		Collate:            string(spec.Collate),
-		Comment:            string(spec.Comment),
-		Overrides:          mergePlatform(spec.Platform, spec.Overrides),
+		StructName:          structName,
+		FieldName:           fieldName,
+		Name:                columnName,
+		Type:                fieldType,
+		Nullable:            nullable,
+		Primary:             spec.Primary,
+		AutoInc:             spec.AutoIncrement || spec.AutoInc || identityGeneration != "",
+		IdentityGeneration:  identityGeneration,
+		IdentityStart:       string(spec.IdentityStart),
+		IdentityIncrement:   string(spec.IdentityIncrement),
+		IdentityOptions:     string(spec.IdentityOptions),
+		Unique:              spec.Unique,
+		UniqueExpr:          string(spec.UniqueExpr),
+		Default:             string(spec.Default),
+		DefaultExpr:         string(spec.DefaultExpr),
+		Foreign:             string(spec.Foreign),
+		ForeignKeyName:      string(spec.ForeignKeyName),
+		OnDelete:            string(spec.OnDelete),
+		OnUpdate:            string(spec.OnUpdate),
+		Enum:                enumValues,
+		Check:               string(spec.Check),
+		CheckName:           string(spec.CheckName),
+		GeneratedExpression: string(spec.Generated),
+		GeneratedKind:       yamlGeneratedColumnKind(spec),
+		Charset:             string(spec.Charset),
+		Collate:             string(spec.Collate),
+		Comment:             string(spec.Comment),
+		Overrides:           mergePlatform(spec.Platform, spec.Overrides),
 	}, nil
 }
 
 func hasIdentitySettings(spec fieldSpec) bool {
 	return spec.IdentityStart != "" || spec.IdentityIncrement != "" || spec.IdentityOptions != ""
+}
+
+func yamlGeneratedColumnKind(spec fieldSpec) string {
+	if strings.TrimSpace(string(spec.Generated)) == "" {
+		return ""
+	}
+	if kind := strings.TrimSpace(string(spec.GeneratedKind)); kind != "" {
+		return strings.ToUpper(kind)
+	}
+	if spec.Stored {
+		return "STORED"
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func normalizeIdentityGeneration(value string) string {
@@ -469,7 +497,7 @@ func buildIndex(key, structName string, spec indexSpec) (goschema.Index, error) 
 		Unique:      spec.Unique,
 		Comment:     string(spec.Comment),
 		Type:        string(spec.Type),
-		Condition:   string(spec.Condition),
+		Condition:   firstNonEmpty(string(spec.Where), string(spec.Condition)),
 		Operator:    string(spec.Operator),
 		TableName:   string(spec.TableName),
 		Granularity: spec.Granularity,

--- a/core/yamlschema/yamlschema_test.go
+++ b/core/yamlschema/yamlschema_test.go
@@ -164,10 +164,15 @@ tables:
         platform:
           mysql:
             type: VARCHAR(191)
+      email_lc:
+        type: TEXT
+        generated: lower(email)
+        stored: true
     indexes:
       idx_users_email:
         fields: [email]
         unique: true
+        where: deleted_at IS NULL
     constraints:
       chk_users_email:
         type: CHECK
@@ -184,7 +189,9 @@ rls_policies:
 	c.Assert(db.Tables, qt.HasLen, 2)
 	c.Assert(db.Tables[0].Name, qt.Equals, "tenants")
 	c.Assert(db.Tables[1].Name, qt.Equals, "users")
-	c.Assert(db.Fields, qt.HasLen, 5)
+	c.Assert(db.Fields, qt.HasLen, 6)
+	c.Assert(db.Fields[5].GeneratedExpression, qt.Equals, "lower(email)")
+	c.Assert(db.Fields[5].GeneratedKind, qt.Equals, "STORED")
 	c.Assert(db.Enums, qt.DeepEquals, []goschema.Enum{{Name: "account_status", Values: []string{"active", "suspended"}}})
 	c.Assert(db.Extensions, qt.HasLen, 1)
 	c.Assert(db.Functions, qt.HasLen, 1)
@@ -199,9 +206,12 @@ rls_policies:
 	c.Assert(db.RLSEnabledTables, qt.HasLen, 1)
 	c.Assert(db.RLSPolicies, qt.HasLen, 1)
 	c.Assert(db.Constraints, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Condition, qt.Equals, "deleted_at IS NULL")
 	c.Assert(db.Dependencies["users"], qt.DeepEquals, []string{"tenants"})
 
 	sql := legacyRenderedSQL(strings.Join(renderer.GetOrderedCreateStatements(db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, "email_lc TEXT GENERATED ALWAYS AS (lower(email)) STORED")
+	c.Assert(sql, qt.Contains, "WHERE deleted_at IS NULL")
 	c.Assert(sql, qt.Contains, `CONSTRAINT chk_users_email CHECK (position('@' in email) > 1)`)
 	c.Assert(sql, qt.Contains, `ALTER TABLE users ENABLE ROW LEVEL SECURITY;`)
 	c.Assert(sql, qt.Contains, `CREATE POLICY users_tenant_isolation ON users`)

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -41,6 +41,20 @@ func TestNewMySQLReader(t *testing.T) {
 	})
 }
 
+func TestMySQLReader_parseTableFromDDLGeneratedColumn(t *testing.T) {
+	c := qt.New(t)
+
+	reader := NewMySQLReader(nil, "")
+	table, err := reader.parseTableFromDDL("CREATE TABLE `users` (`name` varchar(255), `name_lc` varchar(255) GENERATED ALWAYS AS (lower(`name`)) STORED)")
+	c.Assert(err, qt.IsNil)
+
+	nameLC := findColumn(table.Columns, "name_lc")
+	c.Assert(nameLC, qt.IsNotNil)
+	c.Assert(nameLC.GeneratedExpression, qt.IsNotNil)
+	c.Assert(*nameLC.GeneratedExpression, qt.Equals, "lower(`name`)")
+	c.Assert(nameLC.GeneratedKind, qt.Equals, "STORED")
+}
+
 func TestMySQLReader_parseEnumValues(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		tests := []struct {
@@ -502,4 +516,13 @@ func TestQuoteIdent(t *testing.T) {
 			c.Assert(quoteIdent(tc.in), qt.Equals, tc.want)
 		})
 	}
+}
+
+func findColumn(columns []types.DBColumn, name string) *types.DBColumn {
+	for i := range columns {
+		if columns[i].Name == name {
+			return &columns[i]
+		}
+	}
+	return nil
 }

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -270,6 +270,11 @@ func (r *Reader) convertASTToTable(node *ast.CreateTableNode) types.DBTable {
 			IsAutoIncrement: astCol.AutoInc,
 			IsPrimaryKey:    astCol.Primary,
 			IsUnique:        astCol.Unique,
+			GeneratedKind:   strings.ToUpper(astCol.GeneratedKind),
+		}
+		if astCol.GeneratedExpression != "" {
+			expression := astCol.GeneratedExpression
+			col.GeneratedExpression = &expression
 		}
 
 		// Handle default values

--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -91,6 +91,51 @@ func TestPostgresNullsDistinctFromDefinition(t *testing.T) {
 	}
 }
 
+func TestExtractPostgresIndexColumns(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition string
+		expected   []string
+	}{
+		{
+			name:       "plain index",
+			definition: `CREATE INDEX idx_users_email ON public.users USING btree (email)`,
+			expected:   []string{"email"},
+		},
+		{
+			name:       "partial index predicate does not leak into columns",
+			definition: `CREATE INDEX idx_users_email_active ON public.users USING btree (email) WHERE (deleted_at IS NULL)`,
+			expected:   []string{"email"},
+		},
+		{
+			name:       "expression index fallback",
+			definition: `CREATE INDEX idx_users_email_lc ON public.users USING btree (lower(email))`,
+			expected:   []string{"lower(email)"},
+		},
+		{
+			name:       "mixed expression and column fallback",
+			definition: `CREATE INDEX idx_users_email_tenant ON public.users USING btree (lower(email), tenant_id)`,
+			expected:   []string{"lower(email)", "tenant_id"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(extractPostgresIndexColumns(test.definition), qt.DeepEquals, test.expected)
+		})
+	}
+}
+
+func TestParsePostgresIndexColumnsJSONPreservesExpressionCommas(t *testing.T) {
+	c := qt.New(t)
+
+	columns, err := parsePostgresIndexColumns(`["concat(first_name, last_name)","tenant_id"]`, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(columns, qt.DeepEquals, []string{"concat(first_name, last_name)", "tenant_id"})
+}
+
 func TestPostgreSQLReader_ReadSchema_NoConnection(t *testing.T) {
 	c := qt.New(t)
 

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -243,10 +244,18 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 			character_maximum_length,
 			numeric_precision,
 			numeric_scale,
-			ordinal_position
-		FROM information_schema.columns
-		WHERE table_schema = $1 AND table_name = $2
-		ORDER BY ordinal_position`
+			ordinal_position,
+			COALESCE(a.attgenerated, '') AS generated_kind,
+			COALESCE(CASE WHEN a.attgenerated <> '' THEN pg_get_expr(ad.adbin, ad.adrelid) ELSE '' END, '') AS generated_expression
+		FROM information_schema.columns col
+		JOIN pg_namespace n ON n.nspname = col.table_schema
+		JOIN pg_class cls ON cls.relname = col.table_name AND cls.relnamespace = n.oid
+		LEFT JOIN pg_attribute a ON a.attrelid = cls.oid
+			AND a.attname = col.column_name
+			AND NOT a.attisdropped
+		LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+		WHERE col.table_schema = $1 AND col.table_name = $2
+		ORDER BY col.ordinal_position`
 
 	rows, err := r.db.Query(columnsQuery, schemaName, tableName)
 	if err != nil {
@@ -257,6 +266,8 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 	var columns []types.DBColumn
 	for rows.Next() {
 		var col types.DBColumn
+		var generatedKind string
+		var generatedExpression string
 		err := rows.Scan(
 			&col.Name,
 			&col.DataType,
@@ -267,9 +278,15 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 			&col.NumericPrecision,
 			&col.NumericScale,
 			&col.OrdinalPosition,
+			&generatedKind,
+			&generatedExpression,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+		if generatedExpression != "" {
+			col.GeneratedExpression = &generatedExpression
+			col.GeneratedKind = postgresGeneratedKind(generatedKind)
 		}
 
 		// Detect auto increment (SERIAL types)
@@ -283,6 +300,15 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 	}
 
 	return columns, nil
+}
+
+func postgresGeneratedKind(code string) string {
+	switch code {
+	case "s":
+		return "STORED"
+	default:
+		return ""
+	}
 }
 
 // readEnums reads all enum types
@@ -359,6 +385,12 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 			t.relname as tablename,
 			i.relname as indexname,
 			pg_get_indexdef(i.oid) as indexdef,
+			COALESCE((
+				SELECT json_agg(pg_get_indexdef(i.oid, keys.ordinality::integer, true) ORDER BY keys.ordinality)::text
+				FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+				WHERE keys.ordinality <= ix.indnkeyatts
+			), '[]') as index_columns,
+			COALESCE(pg_get_expr(ix.indpred, ix.indrelid), '') as predicate,
 			ix.indisprimary,
 			ix.indisunique
 		FROM pg_index ix
@@ -377,9 +409,9 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 
 	var indexes []types.DBIndex
 	for rows.Next() {
-		var schemaName, tableName, indexName, indexDef string
+		var schemaName, tableName, indexName, indexDef, indexColumns, predicate string
 		var isPrimary, isUnique bool
-		err := rows.Scan(&schemaName, &tableName, &indexName, &indexDef, &isPrimary, &isUnique)
+		err := rows.Scan(&schemaName, &tableName, &indexName, &indexDef, &indexColumns, &predicate, &isPrimary, &isUnique)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan index: %w", err)
 		}
@@ -390,29 +422,63 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 			TableName:     tableName,
 			Schema:        r.outputSchema(schemaName),
 			Definition:    indexDef,
+			Condition:     predicate,
 			IsUnique:      isUnique,
 			IsPrimary:     isPrimary,
 			NullsDistinct: postgresNullsDistinctFromDefinition(indexDef),
 		}
 
-		// Extract column names from index definition (simplified parsing)
-		if strings.Contains(indexDef, "(") && strings.Contains(indexDef, ")") {
-			start := strings.Index(indexDef, "(") + 1
-			end := strings.LastIndex(indexDef, ")")
-			if start < end {
-				columnsStr := indexDef[start:end]
-				columns := strings.Split(columnsStr, ",")
-				for i, col := range columns {
-					columns[i] = strings.TrimSpace(col)
-				}
-				index.Columns = columns
-			}
+		index.Columns, err = parsePostgresIndexColumns(indexColumns, indexDef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse index columns for %s: %w", indexName, err)
 		}
 
 		indexes = append(indexes, index)
 	}
 
 	return indexes, nil
+}
+
+func parsePostgresIndexColumns(value, indexDef string) ([]string, error) {
+	if strings.TrimSpace(value) == "" || strings.TrimSpace(value) == "[]" {
+		return extractPostgresIndexColumns(indexDef), nil
+	}
+	var columns []string
+	if err := json.Unmarshal([]byte(value), &columns); err != nil {
+		return nil, err
+	}
+	return columns, nil
+}
+
+func extractPostgresIndexColumns(indexDef string) []string {
+	start := strings.Index(indexDef, "(")
+	if start == -1 {
+		return nil
+	}
+	depth := 0
+	for i := start; i < len(indexDef); i++ {
+		switch indexDef[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return splitPostgresIndexColumns(indexDef[start+1 : i])
+			}
+		}
+	}
+	return nil
+}
+
+func splitPostgresIndexColumns(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	columns := strings.Split(value, ",")
+	for i, col := range columns {
+		columns[i] = strings.TrimSpace(col)
+	}
+	return columns
 }
 
 // readConstraints reads all constraints

--- a/dbschema/sqlite/reader.go
+++ b/dbschema/sqlite/reader.go
@@ -279,6 +279,9 @@ func (r *Reader) readIndexes(tableName, ddl string) ([]types.DBIndex, []types.DB
 			IsPrimary:  entry.origin == "pk",
 			Definition: definition,
 		}
+		if entry.partial != 0 {
+			index.Condition = extractIndexCondition(definition)
+		}
 		indexes = append(indexes, index)
 		if entry.origin == "u" {
 			constraints = append(constraints, types.DBConstraint{
@@ -292,6 +295,62 @@ func (r *Reader) readIndexes(tableName, ddl string) ([]types.DBIndex, []types.DB
 		}
 	}
 	return indexes, constraints, nil
+}
+
+func extractIndexCondition(definition string) string {
+	whereIdx := indexTopLevelKeyword(definition, "WHERE")
+	if whereIdx == -1 {
+		return ""
+	}
+	return strings.TrimSpace(definition[whereIdx+len("WHERE"):])
+}
+
+func indexTopLevelKeyword(definition, keyword string) int {
+	depth := 0
+	var quote byte
+	for i := 0; i < len(definition); i++ {
+		ch := definition[i]
+		if quote != 0 {
+			if ch == quote {
+				if i+1 < len(definition) && definition[i+1] == quote {
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+
+		switch ch {
+		case '\'', '"', '`':
+			quote = ch
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 && hasKeywordAt(definition, keyword, i) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func hasKeywordAt(input, keyword string, idx int) bool {
+	if idx > 0 && isSQLIdentByte(input[idx-1]) {
+		return false
+	}
+	if idx+len(keyword) > len(input) || !strings.EqualFold(input[idx:idx+len(keyword)], keyword) {
+		return false
+	}
+	return idx+len(keyword) == len(input) || !isSQLIdentByte(input[idx+len(keyword)])
+}
+
+func isSQLIdentByte(ch byte) bool {
+	return ch == '_' || ch == '$' || ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
 }
 
 type sqliteIndexEntry struct {

--- a/dbschema/sqlite/sqlite_test.go
+++ b/dbschema/sqlite/sqlite_test.go
@@ -46,10 +46,12 @@ func TestReaderReadSchema(t *testing.T) {
 		id INTEGER PRIMARY KEY,
 		account_id INTEGER NOT NULL,
 		email TEXT NOT NULL CONSTRAINT users_email_check CHECK (email <> ''),
+		note TEXT,
 		status TEXT CHECK (status IN ('active', 'disabled')),
 		CONSTRAINT fk_users_account_id FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
 	) STRICT`)
 	execSQL(t, db, `CREATE UNIQUE INDEX idx_users_email_active ON users(email) WHERE status = 'active'`)
+	execSQL(t, db, `CREATE INDEX idx_users_note_where ON users(note) WHERE note = 'contains WHERE token' AND status = 'active'`)
 	execSQL(t, db, `CREATE VIEW active_users AS SELECT id, email FROM users WHERE status = 'active'`)
 	execSQL(t, db, `CREATE TRIGGER trg_users_ai AFTER INSERT ON users
 		BEGIN
@@ -82,6 +84,11 @@ func TestReaderReadSchema(t *testing.T) {
 	c.Assert(index.Columns, qt.DeepEquals, []string{"email"})
 	c.Assert(index.IsUnique, qt.IsTrue)
 	c.Assert(index.Definition, qt.Contains, "CREATE UNIQUE INDEX idx_users_email_active")
+	c.Assert(index.Condition, qt.Equals, "status = 'active'")
+
+	noteIndex := findIndex(schema.Indexes, "idx_users_note_where")
+	c.Assert(noteIndex, qt.IsNotNil)
+	c.Assert(noteIndex.Condition, qt.Equals, "note = 'contains WHERE token' AND status = 'active'")
 
 	fk := findConstraint(schema.Constraints, "fk_users_account_id")
 	c.Assert(fk, qt.IsNotNil)

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -52,10 +52,9 @@ func QualifyTableName(schema, table string) string {
 
 // DBColumn represents a database column.
 //
-// GeneratedKind / GeneratedExpression are currently populated by the ClickHouse
-// reader for columns declared with non-DEFAULT default kinds (MATERIALIZED,
-// ALIAS, EPHEMERAL). Schema comparison can match these fields when the
-// goschema-side model also carries generated column metadata.
+// GeneratedKind / GeneratedExpression are populated by readers for dialects
+// that expose generated column metadata. Schema comparison matches these fields
+// when the goschema-side model also carries generated column metadata.
 type DBColumn struct {
 	Name               string  `json:"name"`
 	DataType           string  `json:"data_type"`
@@ -73,13 +72,11 @@ type DBColumn struct {
 	IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field
 	IsUnique           bool    `json:"is_unique"`         // Derived field
 
-	// GeneratedExpression holds the MATERIALIZED / ALIAS / EPHEMERAL
-	// expression for ClickHouse columns. Nil for plain columns. Other
-	// dialects always leave this nil.
+	// GeneratedExpression holds the generated-column expression. Nil for plain
+	// columns.
 	GeneratedExpression *string `json:"generated_expression,omitempty"`
-	// GeneratedKind names the ClickHouse default-kind: "MATERIALIZED",
-	// "ALIAS" or "EPHEMERAL". Empty for plain columns. Other dialects always
-	// leave this empty.
+	// GeneratedKind names the generated-column kind, for example STORED,
+	// VIRTUAL, MATERIALIZED, ALIAS, or EPHEMERAL. Empty for plain columns.
 	GeneratedKind string `json:"generated_kind,omitempty"`
 }
 
@@ -104,6 +101,9 @@ type DBIndex struct {
 	IsUnique   bool     `json:"is_unique"`
 	IsPrimary  bool     `json:"is_primary"`
 	Definition string   `json:"definition"` // Full index definition
+	// Condition is the WHERE clause for partial indexes when the dialect
+	// exposes one structurally.
+	Condition string `json:"condition,omitempty"`
 	// NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
 	// state. Nil means the clause was not present in the definition.
 	NullsDistinct *bool `json:"nulls_distinct,omitempty"`

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -49,6 +49,7 @@ so typos fail fast. Current registry:
 | `enum_custom_type` | Enums are separate named types (PostgreSQL `CREATE TYPE … AS ENUM`) |
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
 | `create_or_replace_trigger` | `CREATE OR REPLACE TRIGGER` (PostgreSQL 14+, MariaDB; not MySQL). Trigger renderers use this to choose replace vs. drop/create |
+| `alter_generated_column_expression` | In-place `ALTER COLUMN SET EXPRESSION` for generated columns (PostgreSQL 17+) |
 | `row_level_security` | Row-level security policies (PostgreSQL) |
 | `role_management` | PostgreSQL role and object privilege management (`CREATE/ALTER ROLE`, `GRANT`, `REVOKE`) |
 | `foreign_keys` | Declarative `FOREIGN KEY` constraints |
@@ -74,29 +75,31 @@ composed sets yourself.
 
 ## Presets
 
-| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres16 | Postgres13 | ClickHouse24 | CockroachDB23 | YugabyteDB25 | SQLite3 | SpannerPG |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `role_management` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres17 | Postgres16 | Postgres13 | ClickHouse24 | CockroachDB23 | YugabyteDB25 | SQLite3 | SpannerPG |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| `alter_generated_column_expression` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `role_management` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 Version lines: `MySQL80()` covers MySQL 8.0.19+ and 9.x; `MySQL8016()` covers
 8.0.16–8.0.18; `MySQLLegacy()` anything older. `MariaDB1011()` covers the
 supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
-floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres16()` covers
-PostgreSQL 14+; `Postgres13()` covers 12–13 (no `CREATE OR REPLACE TRIGGER`).
+floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres17()` covers
+PostgreSQL 17+; `Postgres16()` covers 14–16; `Postgres13()` covers 12–13
+(no `CREATE OR REPLACE TRIGGER`).
 `CockroachDB23()` and `YugabyteDB25()` are PostgreSQL-family presets for the
 common distributed-SQL subset; `SpannerPostgres()` is deliberately conservative
 because Spanner's PostgreSQL interface is not a drop-in PostgreSQL server.

--- a/docs/yaml_schema.md
+++ b/docs/yaml_schema.md
@@ -30,9 +30,16 @@ tables:
         type: VARCHAR(255)
         not_null: true
         unique: true
+      email_lc:
+        type: TEXT
+        generated: lower(email)
+        stored: true
     indexes:
       idx_users_email:
         fields: [email]
+      idx_active_users_email:
+        fields: [email]
+        where: deleted_at IS NULL
 ```
 
 This is equivalent to:
@@ -46,7 +53,13 @@ type User struct {
     //migrator:schema:field name="email" type="VARCHAR(255)" not_null="true" unique="true"
     Email string
 
+    //migrator:schema:field name="email_lc" type="TEXT" generated="lower(email)" stored="true"
+    EmailLC string
+
     //migrator:schema:index name="idx_users_email" fields="email"
+    _ int
+
+    //migrator:schema:index name="idx_active_users_email" fields="email" where="deleted_at IS NULL"
     _ int
 }
 ```
@@ -114,10 +127,17 @@ tables:
         platform:
           mysql:
             type: VARCHAR(191)
+      email_lc:
+        type: TEXT
+        generated: lower(email)
+        stored: true
     indexes:
       idx_users_email:
         fields: [email]
         unique: true
+      idx_active_users_email:
+        fields: [email]
+        where: deleted_at IS NULL
     constraints:
       chk_users_email:
         type: CHECK
@@ -173,6 +193,9 @@ Columns support the same information as field annotations:
 | `unique` | Marks the column unique. |
 | `unique_expr` | Unique expression. |
 | `index` | Requests an index for the column. |
+| `generated` | Generated-column SQL expression. |
+| `generated_kind` | Generated-column kind such as `STORED` or `VIRTUAL`. |
+| `stored` | Convenience boolean for `generated_kind: STORED`. Ignored unless `generated` is set. |
 | `default` | Literal default value. |
 | `default_expr` | Default SQL expression, such as `NOW()`. |
 | `foreign` | Foreign key reference in `table(column)` form. |
@@ -183,6 +206,11 @@ Columns support the same information as field annotations:
 | `check_name` | Explicit column check constraint name. |
 | `comment` | Column comment. |
 | `platform` / `overrides` | Dialect-specific overrides. |
+
+For PostgreSQL, Ptah plans generated-column expression changes with
+`ALTER COLUMN ... SET EXPRESSION` only for PostgreSQL 17+ capability sets.
+Older PostgreSQL targets receive an explicit manual migration warning instead
+of an automatic destructive drop-and-recreate plan.
 
 If `enum` is provided and `type` is empty or `ENUM`, Ptah creates an enum named
 `enum_<struct_name>_<field_name>` and uses that generated type for the column.
@@ -226,7 +254,7 @@ indexes:
 | `unique` | Emits a unique index. |
 | `comment` | Index comment. |
 | `type` | Dialect-specific index type. |
-| `condition` | Partial-index condition where supported. |
+| `where` / `condition` | Partial-index condition where supported. `where` matches Atlas terminology. |
 | `ops` | Operator or operator class string. |
 | `granularity` | ClickHouse data-skipping index granularity. |
 

--- a/integration/gonative/generated_partial_postgres_test.go
+++ b/integration/gonative/generated_partial_postgres_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/convert/fromschema"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema/postgres"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestGeneratedColumnAndPartialIndex_RoundTrip_Postgres(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	const schemaName = "ptah_generated_columns_test"
+	_, _ = db.Exec("DROP SCHEMA IF EXISTS " + schemaName + " CASCADE")
+	_, err = db.Exec("CREATE SCHEMA " + schemaName)
+	c.Assert(err, qt.IsNil)
+	defer func() { _, _ = db.Exec("DROP SCHEMA IF EXISTS " + schemaName + " CASCADE") }()
+
+	target := generatedPartialIndexSchema(schemaName, "lower(email)")
+	createAST := fromschema.FromDatabase(*target, platform.Postgres)
+	createSQL, err := renderer.RenderSQL(platform.Postgres, createAST.Statements...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(createSQL, qt.Contains, "GENERATED ALWAYS AS (lower(email)) STORED")
+	c.Assert(createSQL, qt.Contains, "WHERE deleted_at IS NULL")
+
+	_, err = db.Exec(createSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated/partial schema must apply: %s", createSQL))
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	reader.SetSchemas([]string{schemaName})
+	liveSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	expressionIndex := findDBIndex(liveSchema.Indexes, "idx_ptah_generated_users_email_expr_active")
+	c.Assert(expressionIndex, qt.IsNotNil)
+	c.Assert(expressionIndex.Columns, qt.DeepEquals, []string{"\"left\"(email, 2)", "deleted_at"})
+	c.Assert(expressionIndex.Condition, qt.Equals, "(deleted_at IS NULL)")
+
+	roundTripDiff := schemadiff.CompareWithDialect(target, liveSchema, platform.Postgres)
+	c.Assert(roundTripDiff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", roundTripDiff))
+
+	changed := generatedPartialIndexSchema(schemaName, "upper(email)")
+	changedDiff := schemadiff.CompareWithDialect(changed, liveSchema, platform.Postgres)
+	statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(
+		changedDiff,
+		changed,
+		platform.Postgres,
+		capability.Postgres17(),
+	)
+	c.Assert(err, qt.IsNil)
+	plannedSQL := strings.Join(statements, "\n")
+	c.Assert(plannedSQL, qt.Contains, `ALTER COLUMN "email_lc" SET EXPRESSION AS (upper(email))`)
+	c.Assert(plannedSQL, qt.Not(qt.Contains), `DROP COLUMN "email_lc"`)
+}
+
+func generatedPartialIndexSchema(schemaName, expression string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Schema: schemaName, Name: "ptah_generated_users"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "User", Name: "email", Type: "TEXT", Nullable: false},
+			{StructName: "User", Name: "deleted_at", Type: "TIMESTAMP", Nullable: true},
+			{
+				StructName:          "User",
+				Name:                "email_lc",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: expression,
+				GeneratedKind:       "STORED",
+			},
+		},
+		Indexes: []goschema.Index{
+			{
+				StructName: "User",
+				Name:       "idx_ptah_generated_users_email_active",
+				Fields:     []string{"email"},
+				Condition:  "deleted_at IS NULL",
+			},
+			{
+				StructName: "User",
+				Name:       "idx_ptah_generated_users_email_expr_active",
+				Fields:     []string{`"left"(email, 2)`, "deleted_at"},
+				Parts: []goschema.IndexPart{
+					{Expr: `"left"(email, 2)`},
+					{Name: "deleted_at"},
+				},
+				Condition: "deleted_at IS NULL",
+			},
+		},
+	}
+}
+
+func findDBIndex(indexes []dbschematypes.DBIndex, name string) *dbschematypes.DBIndex {
+	for i := range indexes {
+		if indexes[i].Name == name {
+			return &indexes[i]
+		}
+	}
+	return nil
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -59,9 +59,10 @@ const (
 type Planner struct {
 	// caps describes what the concrete target accepts (issue #225/#226); the
 	// nil zero value defaults to the current PostgreSQL line preset
-	// (capability.Postgres16) via the capabilities accessor, so a bare
+	// (capability.Postgres17) via the capabilities accessor, so a bare
 	// &Planner{} behaves exactly like New(). Version presets live in the
-	// capability package — capability.Postgres16 for PostgreSQL 14+,
+	// capability package — capability.Postgres17 for PostgreSQL 17+,
+	// capability.Postgres16 for PostgreSQL 14–16,
 	// capability.Postgres13 for 12–13.
 	caps capability.Capabilities
 	// concurrentIndexes requests CREATE INDEX CONCURRENTLY for new indexes.
@@ -80,9 +81,9 @@ type Planner struct {
 }
 
 // New returns a planner configured with the current PostgreSQL line preset
-// (capability.Postgres16: PostgreSQL 14+).
+// (capability.Postgres17: PostgreSQL 17+).
 func New() *Planner {
-	return NewWithCapabilities(capability.Postgres16())
+	return NewWithCapabilities(capability.Postgres17())
 }
 
 // NewWithCapabilities returns a planner for a specific capability set — e.g.
@@ -90,7 +91,7 @@ func New() *Planner {
 // from a live server via capability.ForServerVersion. The set is expected to
 // be valid (capability.Capabilities.Validate); presets always are. The set is
 // cloned, so later mutations by the caller cannot affect the planner. A nil
-// set defaults to the capability.Postgres16 preset.
+// set defaults to the capability.Postgres17 preset.
 func NewWithCapabilities(caps capability.Capabilities) *Planner {
 	return &Planner{caps: caps.Clone()}
 }
@@ -101,7 +102,7 @@ func NewWithCapabilities(caps capability.Capabilities) *Planner {
 // zero-value surprise.
 func (p *Planner) capabilities() capability.Capabilities {
 	if p.caps == nil {
-		return capability.Postgres16()
+		return capability.Postgres17()
 	}
 	return p.caps
 }
@@ -612,6 +613,7 @@ func (p *Planner) addForeignKeyConstraintsForNewColumns(result []ast.Node, table
 }
 
 func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.TableDiff, generated *goschema.Database) []ast.Node {
+	allFields := fromschema.ProcessEmbeddedFields(generated.EmbeddedFields, generated.Fields)
 	for _, colDiff := range tableDiff.ColumnsModified {
 		// Find the target field definition for this column
 		// We need to find the struct name that corresponds to this table name
@@ -624,7 +626,7 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 		}
 
 		// Now find the field using the correct struct name
-		for _, field := range generated.Fields {
+		for _, field := range allFields {
 			if field.StructName == targetStructName && field.Name == colDiff.ColumnName {
 				targetField = &field
 				break
@@ -639,6 +641,10 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 
 		// Create a column definition with the target field properties
 		columnNode := fromschema.FromField(*targetField, generated.Enums, "postgres")
+		if isGeneratedColumnChange(colDiff) {
+			result = p.modifyGeneratedColumnExpression(result, tableDiff.TableName, colDiff, columnNode)
+			continue
+		}
 
 		// Generate ALTER COLUMN statements using AST
 		alterNode := &ast.AlterTableNode{
@@ -663,6 +669,51 @@ func (p *Planner) modifyExistingTableColumns(result []ast.Node, tableDiff types.
 		result = append(result, astCommentNode)
 	}
 	return result
+}
+
+func (p *Planner) modifyGeneratedColumnExpression(
+	result []ast.Node,
+	tableName string,
+	colDiff types.ColumnDiff,
+	columnNode *ast.ColumnNode,
+) []ast.Node {
+	if columnNode == nil || strings.TrimSpace(columnNode.GeneratedExpression) == "" {
+		return append(result, ast.NewComment(fmt.Sprintf(
+			"WARNING: Generated column %s.%s changed, but the target schema is not a generated column; manual migration required.",
+			tableName,
+			colDiff.ColumnName,
+		)))
+	}
+	if !p.capabilities().Has(capability.AlterGeneratedColumnExpression) {
+		return append(result, ast.NewComment(fmt.Sprintf(
+			"WARNING: Generated column %s.%s changed, but ALTER COLUMN SET EXPRESSION requires PostgreSQL 17+; manual migration required.",
+			tableName,
+			colDiff.ColumnName,
+		)))
+	}
+
+	alterNode := &ast.AlterTableNode{
+		Name: tableName,
+		Operations: []ast.AlterOperation{
+			&ast.AlterGeneratedColumnExpressionOperation{
+				ColumnName: colDiff.ColumnName,
+				Expression: columnNode.GeneratedExpression,
+			},
+		},
+	}
+	result = append(result, alterNode)
+	result = append(result, ast.NewComment(fmt.Sprintf(
+		"Modify generated column %s.%s: %s",
+		tableName,
+		colDiff.ColumnName,
+		colDiff.Changes["generated"],
+	)))
+	return result
+}
+
+func isGeneratedColumnChange(colDiff types.ColumnDiff) bool {
+	_, ok := colDiff.Changes["generated"]
+	return ok
 }
 
 func findGeneratedTableByDiffName(generated *goschema.Database, tableName string) *goschema.Table {

--- a/migration/planner/dialects/postgres/postgres_test.go
+++ b/migration/planner/dialects/postgres/postgres_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -760,6 +761,139 @@ func TestPlanner_GenerateMigrationSQL_IndexesRemoved(t *testing.T) {
 			c.Assert(tt.expected(nodes), qt.IsTrue)
 		})
 	}
+}
+
+func TestPlanner_RecreatesGeneratedColumnOnExpressionChange(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{
+				TableName: "users",
+				ColumnsModified: []types.ColumnDiff{
+					{
+						ColumnName: "slug",
+						Changes: map[string]string{
+							"generated": "STORED upper(name) -> STORED lower(name)",
+						},
+					},
+				},
+			},
+		},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+		},
+		Fields: []goschema.Field{
+			{
+				StructName:          "User",
+				Name:                "slug",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "STORED",
+			},
+		},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "slug" SET EXPRESSION AS (lower(name));`)
+	c.Assert(sql, qt.Not(qt.Contains), `DROP COLUMN "slug"`)
+	c.Assert(sql, qt.Not(qt.Contains), `ADD COLUMN "slug"`)
+}
+
+func TestPlanner_GeneratedColumnExpressionChangeOnPostgres16RequiresManualMigration(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{
+				TableName: "users",
+				ColumnsModified: []types.ColumnDiff{
+					{
+						ColumnName: "slug",
+						Changes: map[string]string{
+							"generated": "STORED upper(name) -> STORED lower(name)",
+						},
+					},
+				},
+			},
+		},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+		},
+		Fields: []goschema.Field{
+			{
+				StructName:          "User",
+				Name:                "slug",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "STORED",
+			},
+		},
+	}
+
+	nodes := postgres.NewWithCapabilities(capability.Postgres16()).GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQLWithCapabilities("postgres", capability.Postgres16(), nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "WARNING: Generated column users.slug changed, but ALTER COLUMN SET EXPRESSION requires PostgreSQL 17+; manual migration required.")
+	c.Assert(sql, qt.Not(qt.Contains), `DROP COLUMN "slug"`)
+	c.Assert(sql, qt.Not(qt.Contains), `ADD COLUMN "slug"`)
+	c.Assert(sql, qt.Not(qt.Contains), "SET EXPRESSION AS")
+}
+
+func TestPlanner_RecreatesEmbeddedGeneratedColumnOnExpressionChange(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{
+			{
+				TableName: "users",
+				ColumnsModified: []types.ColumnDiff{
+					{
+						ColumnName: "slug",
+						Changes: map[string]string{
+							"generated": "STORED upper(name) -> STORED lower(name)",
+						},
+					},
+				},
+			},
+		},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+		},
+		Fields: []goschema.Field{
+			{
+				StructName:          "ComputedFields",
+				Name:                "slug",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: "lower(name)",
+				GeneratedKind:       "STORED",
+			},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{
+				StructName:       "User",
+				Mode:             "inline",
+				EmbeddedTypeName: "ComputedFields",
+			},
+		},
+	}
+
+	nodes := postgres.New().GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "slug" SET EXPRESSION AS (lower(name));`)
+	c.Assert(sql, qt.Not(qt.Contains), "Could not find field definition")
 }
 
 func TestPlanner_GenerateMigrationSQL_TablesRemoved(t *testing.T) {

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -393,6 +393,8 @@ func classifyAlterOperation(op ast.AlterOperation) (Severity, string) {
 		return Safe, "ADD COLUMN is additive"
 	case *ast.ModifyColumnOperation:
 		return classifyModifyColumn(o)
+	case *ast.AlterGeneratedColumnExpressionOperation:
+		return Warning, "SET EXPRESSION rewrites generated column values"
 	case *ast.AddSkippingIndexOperation:
 		return Warning, "ADD INDEX can affect write workload during build"
 	case *ast.ModifyTTLOperation:

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -2065,7 +2065,22 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 }
 
 func indexDefinitionsChanged(genIndex goschema.Index, dbIndex types.DBIndex) bool {
-	return !boolPtrEqual(genIndex.NullsDistinct, dbIndex.NullsDistinct)
+	return !boolPtrEqual(genIndex.NullsDistinct, dbIndex.NullsDistinct) ||
+		indexPredicateChanged(genIndex.Condition, dbIndex.Condition)
+}
+
+func indexPredicateChanged(generated, database string) bool {
+	if strings.TrimSpace(generated) == "" || strings.TrimSpace(database) == "" {
+		return strings.TrimSpace(generated) != strings.TrimSpace(database)
+	}
+	if checkExpressionHasUnsupportedRewrite(generated, database) {
+		return false
+	}
+	return normalizePredicate(generated) != normalizePredicate(database)
+}
+
+func normalizePredicate(value string) string {
+	return normalizeCheckExpression(value)
 }
 
 // compareNamedItems is a generic helper function that compares two maps of named items

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -757,6 +757,107 @@ func TestIndexes_HappyPath(t *testing.T) {
 				IndexesRemoved: []string{"idx_users_c"},
 			},
 		},
+		{
+			name: "partial index condition changed",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "idx_users_email_active", StructName: "users", Fields: []string{"email"}, Condition: "deleted_at IS NULL"},
+				},
+			},
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_users_email_active",
+						TableName: "users",
+						Columns:   []string{"email"},
+						Condition: "deleted_at IS NOT NULL",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				IndexesAdded:   []string{"idx_users_email_active"},
+				IndexesRemoved: []string{"idx_users_email_active"},
+			},
+		},
+		{
+			name: "partial index condition outer parentheses match",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "idx_users_email_active", StructName: "users", Fields: []string{"email"}, Condition: "deleted_at IS NULL"},
+				},
+			},
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_users_email_active",
+						TableName: "users",
+						Columns:   []string{"email"},
+						Condition: "(deleted_at IS NULL)",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			name: "partial index condition whitespace outside literals matches",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "idx_users_email_active", StructName: "users", Fields: []string{"email"}, Condition: "deleted_at   IS\nNULL"},
+				},
+			},
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_users_email_active",
+						TableName: "users",
+						Columns:   []string{"email"},
+						Condition: "(deleted_at IS NULL)",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			name: "partial index condition whitespace inside string literal differs",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "idx_users_email_active", StructName: "users", Fields: []string{"email"}, Condition: "status = 'a  b'"},
+				},
+			},
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_users_email_active",
+						TableName: "users",
+						Columns:   []string{"email"},
+						Condition: "status = 'a b'",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{
+				IndexesAdded:   []string{"idx_users_email_active"},
+				IndexesRemoved: []string{"idx_users_email_active"},
+			},
+		},
+		{
+			name: "partial index condition postgres IN rewrite does not drift",
+			generated: &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "idx_users_status", StructName: "users", Fields: []string{"status"}, Condition: "status IN ('active','pending')"},
+				},
+			},
+			database: &types.DBSchema{
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_users_status",
+						TableName: "users",
+						Columns:   []string{"status"},
+						Condition: "((status)::text = ANY ((ARRAY['active'::text, 'pending'::text])::text[]))",
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -57,7 +57,7 @@ func CompareWithDialect(generated *goschema.Database, database *types.DBSchema, 
 func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, opts *config.CompareOptions) *difftypes.SchemaDiff {
 	diff := &difftypes.SchemaDiff{}
 	generated, database = normalizeInlineEnumsForCompare(generated, database, opts)
-	generated = normalizeSQLiteGeneratedColumnsForCompare(generated, opts)
+	generated = normalizeGeneratedColumnsForCompare(generated, opts)
 
 	// Compare tables and their column structures
 	compare.TablesAndColumns(generated, database, diff)
@@ -128,23 +128,38 @@ func normalizeInlineEnumsForCompare(
 	return &normalizedGenerated, &normalizedDatabase
 }
 
-func normalizeSQLiteGeneratedColumnsForCompare(
+func normalizeGeneratedColumnsForCompare(
 	generated *goschema.Database,
 	opts *config.CompareOptions,
 ) *goschema.Database {
-	if generated == nil || opts == nil || platform.NormalizeDialect(opts.Dialect) != platform.SQLite {
+	if generated == nil || opts == nil {
 		return generated
 	}
 
+	defaultKind := defaultGeneratedColumnKind(platform.NormalizeDialect(opts.Dialect))
+	if defaultKind == "" {
+		return generated
+	}
 	normalizedGenerated := *generated
 	normalizedGenerated.Fields = append([]goschema.Field(nil), generated.Fields...)
 	for i := range normalizedGenerated.Fields {
 		field := &normalizedGenerated.Fields[i]
 		if field.GeneratedExpression != "" && field.GeneratedKind == "" {
-			field.GeneratedKind = "VIRTUAL"
+			field.GeneratedKind = defaultKind
 		}
 	}
 	return &normalizedGenerated
+}
+
+func defaultGeneratedColumnKind(dialect string) string {
+	switch dialect {
+	case platform.Postgres:
+		return "STORED"
+	case platform.MySQL, platform.MariaDB, platform.SQLite:
+		return "VIRTUAL"
+	default:
+		return ""
+	}
 }
 
 func isInlineEnumDialect(dialect string) bool {

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -82,6 +82,48 @@ func TestCompareWithDialect_MySQLFamilyInlineEnumsMatchGeneratedEnumFields(t *te
 	}
 }
 
+func TestCompareWithDialect_GeneratedColumnDefaultKindMatchesDialect(t *testing.T) {
+	tests := []struct {
+		name         string
+		dialect      string
+		databaseKind string
+	}{
+		{name: "postgres", dialect: "postgres", databaseKind: "STORED"},
+		{name: "mysql", dialect: "mysql", databaseKind: "VIRTUAL"},
+		{name: "mariadb", dialect: "mariadb", databaseKind: "VIRTUAL"},
+		{name: "sqlite", dialect: "sqlite", databaseKind: "VIRTUAL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			expression := "lower(email)"
+			generated := &goschema.Database{
+				Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+				Fields: []goschema.Field{
+					{StructName: "User", Name: "email_lc", Type: "TEXT", Nullable: true, GeneratedExpression: expression},
+				},
+			}
+			database := &types.DBSchema{
+				Tables: []types.DBTable{{
+					Name: "users",
+					Type: "TABLE",
+					Columns: []types.DBColumn{{
+						Name:                "email_lc",
+						DataType:            "TEXT",
+						IsNullable:          "YES",
+						GeneratedExpression: &expression,
+						GeneratedKind:       tt.databaseKind,
+					}},
+				}},
+			}
+
+			diff := schemadiff.CompareWithDialect(generated, database, tt.dialect)
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+		})
+	}
+}
+
 func TestCompareWithDialect_SQLiteInlineEnumsMatchGeneratedEnumFields(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

Closes #159.

- Add generated-column metadata across Go annotations, YAML schema, SQL parser, schema conversion, and database readers.
- Add partial-index predicate support via `where`/`condition`, including schema diff comparison and renderer/planner propagation.
- Add PostgreSQL 17 `alter_generated_column_expression` capability and render `ALTER COLUMN ... SET EXPRESSION`; older PostgreSQL capability sets now emit a manual-migration warning instead of destructive drop/recreate SQL.
- Harden PostgreSQL expression-index introspection, SQLite predicate extraction, and partial-predicate normalization.
- Refactor Go schema parsing so field comment processing uses parser state instead of passing a large argument list.
- Update generated-column and partial-index documentation.

## Validation

- `go test ./...`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test -tags=integration ./integration/gonative -run GeneratedColumnAndPartialIndex -v`
  - Skips live DB execution locally when `POSTGRES_TEST_DSN` is not set.
