### PR TITLE
Fix UTF-8 dollar quote lexing

### DIFF
--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -690,14 +690,18 @@ func (s *schemaParseState) mapTableDirectiveStructName(comment *ast.Comment, str
 // processDeclarations processes all struct declarations in the file.
 func (s *schemaParseState) processDeclarations(structDecls []structDeclaration) error {
 	for _, structDecl := range structDecls {
-		if err := s.processTableComments(structDecl.name, structDecl.genDecl); err != nil {
-			return err
-		}
-		if err := s.processFieldComments(structDecl.name, structDecl.structType); err != nil {
+		if err := s.processDeclaration(structDecl); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s *schemaParseState) processDeclaration(structDecl structDeclaration) error {
+	if err := s.processTableComments(structDecl.name, structDecl.genDecl); err != nil {
+		return err
+	}
+	return s.processFieldComments(structDecl.name, structDecl.structType)
 }
 
 // processAllFileComments scans comments for RLS annotations that are separated

--- a/core/lexer/lexer.go
+++ b/core/lexer/lexer.go
@@ -372,16 +372,14 @@ func (l *Lexer) scanOperator() Token {
 
 // isDollarQuotedString checks if the current position starts a PostgreSQL dollar-quoted string
 func (l *Lexer) isDollarQuotedString() bool {
-	const maxDollarTagLength = 128 // Reasonable upper bound for tag length
 	if l.peek() != '$' {
 		return false
 	}
 
 	// Look ahead to find the closing $ of the opening tag
 	pos := l.pos + 1
-	tagLen := 0
-	for pos < len(l.input) && tagLen < maxDollarTagLength {
-		ch := rune(l.input[pos])
+	for pos < len(l.input) {
+		ch, size := utf8.DecodeRuneInString(l.input[pos:])
 		if ch == '$' {
 			// Found potential closing $ of opening tag
 			return true
@@ -390,8 +388,7 @@ func (l *Lexer) isDollarQuotedString() bool {
 			// Invalid character in tag name
 			return false
 		}
-		pos++
-		tagLen++
+		pos += size
 	}
 	return false
 }
@@ -433,7 +430,8 @@ func (l *Lexer) scanDollarQuotedString() Token {
 			remainingInput := l.input[l.pos:]
 			if strings.HasPrefix(remainingInput, openingTag) {
 				// Found matching closing tag
-				for i := 0; i < len(openingTag); i++ {
+				tagEnd := l.pos + len(openingTag)
+				for l.pos < tagEnd {
 					l.advance()
 				}
 				break

--- a/core/lexer/lexer_fuzz_test.go
+++ b/core/lexer/lexer_fuzz_test.go
@@ -1,0 +1,28 @@
+package lexer_test
+
+import (
+	"testing"
+
+	"github.com/stokaro/ptah/core/lexer"
+)
+
+func FuzzLexerUTF8(f *testing.F) {
+	for _, seed := range []string{
+		"CREATE TABLE café (id INT, naïve TEXT);",
+		"CREATE TABLE таблица (ключ INT);",
+		"$тег$héllo$тег$",
+		"SELECT 'héllo 🚀';",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, input string) {
+		l := lexer.NewLexer(input)
+		for tokens := 0; tokens <= len(input)+1; tokens++ {
+			if l.NextToken().Type == lexer.TokenEOF {
+				return
+			}
+		}
+		t.Fatalf("lexer did not reach EOF after %d tokens", len(input)+1)
+	})
+}

--- a/core/lexer/lexer_test.go
+++ b/core/lexer/lexer_test.go
@@ -563,6 +563,76 @@ func TestLexer_TokenPositions(t *testing.T) {
 	c.Assert(token3.End, qt.Equals, 9)
 }
 
+func TestLexer_UTF8Identifiers(t *testing.T) {
+	c := qt.New(t)
+
+	input := `CREATE TABLE café (id INT, "naïve" TEXT);`
+	l := lexer.NewLexer(input)
+
+	tokens := collectTokens(l)
+
+	c.Assert(tokens, qt.DeepEquals, []lexer.Token{
+		{Type: lexer.TokenIdentifier, Value: "CREATE", Start: 0, End: 6},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 6, End: 7},
+		{Type: lexer.TokenIdentifier, Value: "TABLE", Start: 7, End: 12},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 12, End: 13},
+		{Type: lexer.TokenIdentifier, Value: "café", Start: 13, End: 18},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 18, End: 19},
+		{Type: lexer.TokenOperator, Value: "(", Start: 19, End: 20},
+		{Type: lexer.TokenIdentifier, Value: "id", Start: 20, End: 22},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 22, End: 23},
+		{Type: lexer.TokenIdentifier, Value: "INT", Start: 23, End: 26},
+		{Type: lexer.TokenOperator, Value: ",", Start: 26, End: 27},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 27, End: 28},
+		{Type: lexer.TokenString, Value: `"naïve"`, Start: 28, End: 36},
+		{Type: lexer.TokenWhitespace, Value: " ", Start: 36, End: 37},
+		{Type: lexer.TokenIdentifier, Value: "TEXT", Start: 37, End: 41},
+		{Type: lexer.TokenOperator, Value: ")", Start: 41, End: 42},
+		{Type: lexer.TokenSemicolon, Value: ";", Start: 42, End: 43},
+		{Type: lexer.TokenEOF, Value: "", Start: 43, End: 43},
+	})
+}
+
+func TestLexer_UTF8DollarQuotedStringTag(t *testing.T) {
+	c := qt.New(t)
+
+	input := "$тег$héllo$тег$"
+	l := lexer.NewLexer(input)
+
+	token := l.NextToken()
+
+	c.Assert(token.Type, qt.Equals, lexer.TokenString)
+	c.Assert(token.Value, qt.Equals, input)
+	c.Assert(token.Start, qt.Equals, 0)
+	c.Assert(token.End, qt.Equals, len(input))
+	c.Assert(l.NextToken().Type, qt.Equals, lexer.TokenEOF)
+}
+
+func TestLexer_LongDollarQuotedStringTag(t *testing.T) {
+	c := qt.New(t)
+
+	tag := strings.Repeat("tag", 60)
+	input := "$" + tag + "$body$" + tag + "$"
+	l := lexer.NewLexer(input)
+
+	token := l.NextToken()
+
+	c.Assert(token.Type, qt.Equals, lexer.TokenString)
+	c.Assert(token.Value, qt.Equals, input)
+	c.Assert(token.End, qt.Equals, len(input))
+}
+
+func collectTokens(l *lexer.Lexer) []lexer.Token {
+	var tokens []lexer.Token
+	for {
+		token := l.NextToken()
+		tokens = append(tokens, token)
+		if token.Type == lexer.TokenEOF {
+			return tokens
+		}
+	}
+}
+
 func BenchmarkLexer_SimpleSQL(b *testing.B) {
 	input := "SELECT id, name, email FROM users WHERE active = 'true' ORDER BY name;"
 

--- a/core/parser/parser_test.go
+++ b/core/parser/parser_test.go
@@ -604,6 +604,23 @@ func TestParser_ParseCreateTable_UnicodeIdentifiers(t *testing.T) {
 	c.Assert(createTable.Columns[0].Type, qt.Equals, "int")
 }
 
+func TestParser_ParseCreateTable_LatinUTF8Identifier(t *testing.T) {
+	c := qt.New(t)
+
+	sql := `CREATE TABLE café (id INT, naïve TEXT);`
+	p := parser.NewParser(sql)
+
+	statements, err := p.Parse()
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements.Statements, qt.HasLen, 1)
+
+	createTable := statements.Statements[0].(*ast.CreateTableNode)
+	c.Assert(createTable.Name, qt.Equals, "café")
+	c.Assert(createTable.Columns, qt.HasLen, 2)
+	c.Assert(createTable.Columns[0].Name, qt.Equals, "id")
+	c.Assert(createTable.Columns[1].Name, qt.Equals, "naïve")
+}
+
 func TestParser_ParseCreateTable_EscapedDefaultStrings(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- Fix PostgreSQL dollar-quoted string detection for UTF-8 tag names by decoding runes instead of casting bytes.
- Remove the hard 128-byte dollar-tag cap and consume UTF-8 closing tags without splitting runes.
- Add lexer/parser coverage for UTF-8 identifiers, UTF-8 dollar-quote tags, long tags, and bounded UTF-8 fuzz seeds.
- Refactor Go schema declaration processing so field-comment processing uses structured parser state instead of long argument plumbing.

Fixes #132.

## Validation
- gopls diagnostics on edited Go files
- go test ./core/lexer ./core/parser ./core/goschema -count=1
- git diff --check
- gofmt -l core/goschema/parser.go core/lexer/lexer.go core/lexer/lexer_test.go core/lexer/lexer_fuzz_test.go core/parser/parser_test.go
- go test ./... -count=1 (sandbox fails on local listener permission; rerun outside sandbox passed)
- go tool qtlint ./...
- golangci-lint run --timeout=30m ./...