### PR TITLE
Add planner dialect registry

### DIFF
--- a/migration/planner/doc.go
+++ b/migration/planner/doc.go
@@ -36,7 +36,8 @@
 //   - GenerateSchemaDiffAST(): Generates AST nodes from schema differences
 //   - GenerateSchemaDiffSQL(): Generates complete SQL string from schema differences
 //   - GenerateSchemaDiffSQLStatements(): Generates individual SQL statements as string slice
-//   - GetPlanner(): Factory function to get dialect-specific planners
+//   - GetPlanner(): Registry-backed function to get dialect-specific planners
+//   - Register(): Extension point for third-party planner dialects
 //
 // # Usage Example
 //
@@ -147,10 +148,18 @@
 // New database dialects can be added by:
 //
 //  1. Implementing the Planner interface
-//  2. Creating a new dialect package under dialects/
-//  3. Adding the dialect to the GetPlanner() factory function
-//  4. Adding a capability preset when a dialect reuses an existing planner
-//  5. Implementing dialect-specific SQL generation logic
+//  2. Registering a factory with Register, typically from the dialect package's init
+//  3. Adding a capability preset when a dialect reuses an existing planner
+//  4. Implementing dialect-specific SQL generation logic
+//
+// Built-in dialects are registered by this package. Third-party packages can
+// register additional dialects without forking Ptah:
+//
+//	func init() {
+//		planner.MustRegister("acme", func(opts planner.Options) planner.Planner {
+//			return acmeplanner.New(opts.Capabilities)
+//		})
+//	}
 //
 // # Thread Safety
 //

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -6,11 +6,11 @@
 //
 // # Architecture Overview
 //
-// The planner package follows a factory pattern with dialect-specific implementations:
+// The planner package follows a registry pattern with dialect-specific implementations:
 //
 //	┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐
 //	│   SchemaDiff    │───▶│     Planner      │───▶│   AST Nodes     │
-//	│   (Changes)     │    │   (Factory)      │    │  (SQL Logic)    │
+//	│   (Changes)     │    │   (Registry)     │    │  (SQL Logic)    │
 //	└─────────────────┘    └──────────────────┘    └─────────────────┘
 //	                                │
 //	                                ▼
@@ -66,7 +66,7 @@
 package planner
 
 import (
-	"fmt"
+	"sync"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
@@ -78,8 +78,11 @@ import (
 	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
 	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/planner/dialects/sqlite"
+	"github.com/stokaro/ptah/migration/planner/registry"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
+
+var builtInPlannerRegistration sync.Once
 
 // Planner defines the interface for database-specific migration planning.
 //
@@ -128,60 +131,39 @@ import (
 //
 //		return nodes, nil
 //	}
-type Planner interface {
-	// GenerateMigrationAST converts schema differences into database-specific AST nodes.
-	//
-	// This method is the core of the migration planning process. It takes the differences
-	// identified by schema comparison and the target schema definition, then generates
-	// a sequence of AST nodes that represent the SQL operations needed to transform
-	// the current database schema to match the target schema.
-	//
-	// The generated AST nodes are ordered to respect database dependencies:
-	//   1. Type definitions (enums, custom types)
-	//   2. Table creations in dependency order
-	//   3. Column additions and modifications
-	//   4. Index and constraint additions
-	//   5. Data migrations (if applicable)
-	//   6. Cleanup operations (drops, if safe)
-	//
-	// Parameters:
-	//   - diff: Schema differences identified by the schemadiff package
-	//   - generated: Target schema parsed from Go struct annotations
-	//
-	// Returns:
-	//   - []ast.Node: Ordered sequence of AST nodes for migration execution
-	//
-	// The returned nodes can be rendered to SQL using the renderer package or
-	// processed further for validation, optimization, or custom transformations.
-	GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
-	// GenerateMigrationASTChecked is the error-returning planning path used by public
-	// helpers and CLI flows. Dialect implementations should return user-facing
-	// errors here for unsupported features instead of panicking.
-	GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
-}
+type Planner = registry.Planner
 
 // Options configures high-level planner helpers.
-type Options struct {
-	// Capabilities describes the concrete target server. Nil means the
-	// dialect's default capability preset.
-	Capabilities capability.Capabilities
-	// ConcurrentIndexNames requests PostgreSQL CREATE INDEX CONCURRENTLY for
-	// exactly these newly added index names when the target supports it.
-	ConcurrentIndexNames []string
+type Options = registry.Options
+
+// Factory creates a planner for a dialect from construction options.
+type Factory = registry.Factory
+
+// Register registers a planner factory for a dialect. Third-party dialects can
+// call this from init and then use the standard planner helpers.
+func Register(dialect string, factory Factory) error {
+	ensureBuiltInPlannersRegistered()
+	return registry.Register(dialect, factory)
 }
 
-func (o Options) capabilities(dialect string) capability.Capabilities {
-	if o.Capabilities != nil {
-		return o.Capabilities
-	}
-	return capability.ForDialect(dialect)
+// MustRegister registers a planner factory and panics if registration fails.
+func MustRegister(dialect string, factory Factory) {
+	ensureBuiltInPlannersRegistered()
+	registry.MustRegister(dialect, factory)
+}
+
+// RegisteredDialects returns the registered planner dialect names.
+func RegisteredDialects() []string {
+	ensureBuiltInPlannersRegistered()
+	return registry.RegisteredDialects()
 }
 
 // GetPlanner returns a dialect-specific migration planner for the given database dialect.
 //
-// This factory function creates and returns the appropriate planner implementation
-// based on the specified database dialect. Each planner handles dialect-specific
-// features, SQL syntax variations, and optimization strategies.
+// This registry lookup creates and returns the appropriate planner
+// implementation based on the specified database dialect. Each planner handles
+// dialect-specific features, SQL syntax variations, and optimization
+// strategies.
 //
 // # Supported Dialects
 //
@@ -230,9 +212,9 @@ func (o Options) capabilities(dialect string) capability.Capabilities {
 //
 // # Design Rationale
 //
-// The factory pattern is used here to:
+// The registry pattern is used here to:
 //   - Provide a clean, consistent interface for planner creation
-//   - Allow easy extension for new database dialects
+//   - Allow third-party extension for new database dialects
 //   - Centralize dialect validation and error handling
 //   - Enable dependency injection and testing scenarios
 func GetPlanner(dialect string) (Planner, error) {
@@ -250,23 +232,45 @@ func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (P
 // GetPlannerWithOptions returns a dialect-specific migration planner with
 // explicit high-level generation policy.
 func GetPlannerWithOptions(dialect string, opts Options) (Planner, error) {
-	caps := opts.capabilities(dialect)
-	switch platform.NormalizeDialect(dialect) {
-	case platform.Postgres:
-		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...), nil
-	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(caps).WithConcurrentIndexNames(opts.ConcurrentIndexNames...), nil
-	case platform.MySQL:
-		return mysql.NewWithCapabilities(caps), nil
-	case platform.MariaDB:
-		return mysql.NewWithCapabilities(caps), nil
-	case platform.ClickHouse:
-		return clickhouse.New(), nil
-	case platform.SQLite:
-		return sqlite.New(), nil
-	default:
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
-	}
+	ensureBuiltInPlannersRegistered()
+	return registry.Get(dialect, opts)
+}
+
+func ensureBuiltInPlannersRegistered() {
+	builtInPlannerRegistration.Do(func() {
+		for _, dialect := range []string{
+			platform.Postgres,
+			platform.CockroachDB,
+			platform.YugabyteDB,
+			platform.Spanner,
+		} {
+			registerPostgresFamilyPlanner(dialect)
+		}
+
+		for _, dialect := range []string{platform.MySQL, platform.MariaDB} {
+			registerMySQLFamilyPlanner(dialect)
+		}
+
+		registry.MustRegister(platform.ClickHouse, func(Options) Planner {
+			return clickhouse.New()
+		})
+		registry.MustRegister(platform.SQLite, func(Options) Planner {
+			return sqlite.New()
+		})
+	})
+}
+
+func registerPostgresFamilyPlanner(dialect string) {
+	registry.MustRegister(dialect, func(opts Options) Planner {
+		return postgres.NewWithCapabilities(opts.CapabilitiesFor(dialect)).
+			WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
+	})
+}
+
+func registerMySQLFamilyPlanner(dialect string) {
+	registry.MustRegister(dialect, func(opts Options) Planner {
+		return mysql.NewWithCapabilities(opts.CapabilitiesFor(dialect))
+	})
 }
 
 // GenerateSchemaDiffAST generates AST nodes for schema differences using the specified dialect.
@@ -286,18 +290,15 @@ func GetPlannerWithOptions(dialect string, opts Options) (Planner, error) {
 // Returns a slice of AST nodes representing the SQL operations needed for migration.
 // The nodes are ordered to respect database dependencies and constraints.
 //
-// # Panics
-//
-// This function panics if:
-//   - An unsupported dialect is specified
-//   - The dialect-specific planner is not implemented
-//
 // # Usage Example
 //
 //	import "github.com/stokaro/ptah/core/platform"
 //
 //	// Generate AST nodes for PostgreSQL
-//	nodes := planner.GenerateSchemaDiffAST(diff, generated, platform.Postgres)
+//	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.Postgres)
+//	if err != nil {
+//		return err
+//	}
 //
 //	// Process nodes for custom validation or transformation
 //	for _, node := range nodes {
@@ -404,19 +405,15 @@ func RequiresNoTransaction(dialect string, nodes []ast.Node) bool {
 //  3. Split the SQL into individual statements using sqlutil.SplitSQLStatements
 //  4. Return the statements as a string slice
 //
-// # Panics
-//
-// This function panics if:
-//   - An unsupported dialect is specified
-//   - SQL rendering fails due to invalid AST nodes
-//   - Statement splitting encounters malformed SQL
-//
 // # Usage Example
 //
 //	import "github.com/stokaro/ptah/core/platform"
 //
 //	// Generate SQL statements for MySQL
-//	statements := planner.GenerateSchemaDiffSQLStatements(diff, generated, platform.MySQL)
+//	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, platform.MySQL)
+//	if err != nil {
+//		return err
+//	}
 //
 //	// Execute statements sequentially
 //	for _, stmt := range statements {
@@ -497,19 +494,15 @@ func GenerateSchemaDiffSQLStatementsWithOptions(
 //   - Comments for complex operations (dialect-dependent)
 //   - Dependency-ordered statements
 //
-// # Panics
-//
-// This function panics if:
-//   - An unsupported dialect is specified
-//   - SQL rendering fails due to invalid AST nodes
-//   - The renderer encounters an unhandled node type
-//
 // # Usage Example
 //
 //	import "github.com/stokaro/ptah/core/platform"
 //
 //	// Generate complete SQL script for PostgreSQL
-//	sql := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+//	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.Postgres)
+//	if err != nil {
+//		return err
+//	}
 //
 //	// Write to migration file
 //	if err := os.WriteFile("migration.sql", []byte(sql), 0644); err != nil {
@@ -548,7 +541,7 @@ func GenerateSchemaDiffSQLWithOptions(
 	dialect string,
 	opts Options,
 ) (string, error) {
-	caps := opts.capabilities(dialect)
+	caps := opts.CapabilitiesFor(dialect)
 	astNodes, err := GenerateSchemaDiffASTWithOptions(diff, generated, dialect, opts)
 	if err != nil {
 		return "", err

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -1,6 +1,8 @@
 package planner_test
 
 import (
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -8,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
 	dbtypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
@@ -15,6 +18,8 @@ import (
 	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
+
+var externalPlannerDialectSeq atomic.Int64
 
 func TestGetPlanner(t *testing.T) {
 	tests := []struct {
@@ -58,6 +63,11 @@ func TestGetPlanner(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "clickhouse planner",
+			dialect: platform.ClickHouse,
+			wantErr: false,
+		},
+		{
 			name:    "sqlite3 planner",
 			dialect: "sqlite3",
 			wantErr: false,
@@ -95,6 +105,57 @@ func TestGetPlanner_MariaDBUsesMySQLPlanner(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 }
 
+func TestRegisterExternalPlanner(t *testing.T) {
+	c := qt.New(t)
+
+	dialect := nextExternalPlannerDialect("external_planner_test")
+	err := planner.Register(dialect, func(opts planner.Options) planner.Planner {
+		return externalPlanner{caps: opts.CapabilitiesFor(dialect)}
+	})
+	c.Assert(err, qt.IsNil)
+
+	caps := capability.Postgres13()
+	registered, err := planner.GetPlannerWithOptions(dialect, planner.Options{Capabilities: caps})
+	c.Assert(err, qt.IsNil)
+
+	external, ok := registered.(externalPlanner)
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(external.caps.Has(capability.CreateIndexConcurrently), qt.IsTrue)
+}
+
+func TestRegisterRejectsDuplicateAndNilFactories(t *testing.T) {
+	c := qt.New(t)
+
+	dialect := nextExternalPlannerDialect("duplicate_planner_test")
+	err := planner.Register(dialect, func(planner.Options) planner.Planner {
+		return externalPlanner{}
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = planner.Register(dialect, func(planner.Options) planner.Planner {
+		return externalPlanner{}
+	})
+	c.Assert(err, qt.ErrorMatches, fmt.Sprintf(`planner registry: dialect %q is already registered`, dialect))
+
+	nilDialect := nextExternalPlannerDialect("nil_factory_planner_test")
+	err = planner.Register(nilDialect, nil)
+	c.Assert(err, qt.ErrorMatches, fmt.Sprintf(`planner registry: factory for dialect %q must not be nil`, nilDialect))
+}
+
+func TestGetPlannerRejectsFactoryReturningNil(t *testing.T) {
+	c := qt.New(t)
+
+	dialect := nextExternalPlannerDialect("nil_planner_test")
+	err := planner.Register(dialect, func(planner.Options) planner.Planner {
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+
+	registered, err := planner.GetPlanner(dialect)
+	c.Assert(registered, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, fmt.Sprintf(`planner registry: factory for dialect %q returned nil`, dialect))
+}
+
 func TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError(t *testing.T) {
 	c := qt.New(t)
 
@@ -114,6 +175,29 @@ func TestRequiresNoTransaction(t *testing.T) {
 	c.Assert(planner.RequiresNoTransaction(platform.MySQL, []ast.Node{enumAdd}), qt.IsFalse)
 	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{enumRename}), qt.IsFalse)
 	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{ast.NewComment("noop")}), qt.IsFalse)
+}
+
+type externalPlanner struct {
+	caps capability.Capabilities
+}
+
+func nextExternalPlannerDialect(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, externalPlannerDialectSeq.Add(1))
+}
+
+func (p externalPlanner) GenerateMigrationAST(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+) []ast.Node {
+	nodes, _ := p.GenerateMigrationASTChecked(diff, generated)
+	return nodes
+}
+
+func (p externalPlanner) GenerateMigrationASTChecked(
+	_ *types.SchemaDiff,
+	_ *goschema.Database,
+) ([]ast.Node, error) {
+	return []ast.Node{ast.NewComment("external planner")}, nil
 }
 
 func TestGeneratedNarrowingTypeChangeIsDestructive(t *testing.T) {

--- a/migration/planner/registry/registry.go
+++ b/migration/planner/registry/registry.go
@@ -1,0 +1,118 @@
+// Package registry contains the planner dialect registry used by the public
+// migration/planner package and extension implementations.
+package registry
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// Planner defines the interface for database-specific migration planning.
+type Planner interface {
+	GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
+	GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
+}
+
+// Options configures planner construction.
+type Options struct {
+	// Capabilities describes the concrete target server. Nil means the
+	// dialect's default capability preset.
+	Capabilities capability.Capabilities
+	// ConcurrentIndexNames requests PostgreSQL CREATE INDEX CONCURRENTLY for
+	// exactly these newly added index names when the target supports it.
+	ConcurrentIndexNames []string
+}
+
+// CapabilitiesFor returns the configured capability set, falling back to the
+// default preset for dialect when no explicit set was provided.
+func (o Options) CapabilitiesFor(dialect string) capability.Capabilities {
+	if o.Capabilities != nil {
+		return o.Capabilities
+	}
+	return capability.ForDialect(dialect)
+}
+
+// Factory creates a planner for a normalized dialect using construction
+// options supplied by the caller.
+type Factory func(Options) Planner
+
+var (
+	mu        sync.RWMutex
+	factories = map[string]Factory{}
+)
+
+// Register registers a planner factory for dialect.
+func Register(dialect string, factory Factory) error {
+	normalized := normalizeRegistryDialect(dialect)
+	if normalized == "" {
+		return fmt.Errorf("planner registry: dialect must not be empty")
+	}
+	if factory == nil {
+		return fmt.Errorf("planner registry: factory for dialect %q must not be nil", normalized)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, exists := factories[normalized]; exists {
+		return fmt.Errorf("planner registry: dialect %q is already registered", normalized)
+	}
+	factories[normalized] = factory
+	return nil
+}
+
+// MustRegister registers a planner factory and panics if registration fails.
+func MustRegister(dialect string, factory Factory) {
+	if err := Register(dialect, factory); err != nil {
+		panic(err)
+	}
+}
+
+// Get returns a registered planner for dialect.
+func Get(dialect string, opts Options) (Planner, error) {
+	normalized := normalizeRegistryDialect(dialect)
+	if normalized == "" {
+		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
+	}
+
+	mu.RLock()
+	factory, exists := factories[normalized]
+	mu.RUnlock()
+	if !exists {
+		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
+	}
+	planner := factory(opts)
+	if planner == nil {
+		return nil, fmt.Errorf("planner registry: factory for dialect %q returned nil", normalized)
+	}
+	return planner, nil
+}
+
+// RegisteredDialects returns the registered dialect names in stable order.
+func RegisteredDialects() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	dialects := make([]string, 0, len(factories))
+	for dialect := range factories {
+		dialects = append(dialects, dialect)
+	}
+	slices.Sort(dialects)
+	return dialects
+}
+
+func normalizeRegistryDialect(dialect string) string {
+	normalized := platform.NormalizeDialect(dialect)
+	if normalized != "" {
+		return normalized
+	}
+	return strings.ToLower(strings.TrimSpace(dialect))
+}


### PR DESCRIPTION
## Summary
- Move planner construction behind a registry-backed API while preserving the public `planner.Planner` and `planner.Options` names as aliases.
- Add `planner.Register`, `planner.MustRegister`, and `planner.RegisteredDialects` so external dialect packages can register factories without forking Ptah.
- Keep built-in planner wiring lazy and lint-compliant with `sync.Once`, preserving capability presets and concurrent-index options for existing dialects.
- Update planner package docs and add external-package tests for custom planners, duplicate/nil factories, nil planner returns, ClickHouse registration, and existing built-in behavior.

Fixes #142.

## Self-review
Pass 1 - API and logic:
- Verified `GetPlanner*` still returns built-ins for postgres/mysql/mariadb/sqlite/clickhouse and PostgreSQL-family aliases.
- Verified custom dialect names bypass `platform.NormalizeDialect` fallback safely and can be registered through the public package.
- Verified duplicate/nil factory/nil planner cases return explicit errors.

Pass 2 - blast radius and safety:
- Avoided `init` and blank imports to satisfy repo lint policy.
- Preserved capability wiring for MariaDB, PostgreSQL-family targets, and `ConcurrentIndexNames`.
- Kept unrelated `core/goschema/parser.go` working-tree cleanup out of this PR.

## Validation
- gopls diagnostics on edited Go files
- `go test ./migration/planner ./migration/planner/registry ./migration/planner/dialects/... -count=1`
- `go test ./migration/generator ./cmd/migrate ./cmd/compare ./integration/gonative ./integration -count=1`
- `git diff --check`
- `go test ./... -count=1` (sandbox listener failure reproduced, rerun outside sandbox passed)
- `go tool qtlint ./...`
- `golangci-lint run --timeout=30m ./...`
