### PR TITLE
Remove panic-based planner registration

### DIFF
--- a/migration/planner/doc.go
+++ b/migration/planner/doc.go
@@ -156,9 +156,13 @@
 // register additional dialects without forking Ptah:
 //
 //	func init() {
-//		planner.MustRegister("acme", func(opts planner.Options) planner.Planner {
+//		err := planner.Register("acme", func(opts planner.Options) planner.Planner {
 //			return acmeplanner.New(opts.Capabilities)
 //		})
+//		if err != nil {
+//			// Store or report the error through the extension package's own
+//			// initialization contract.
+//		}
 //	}
 //
 // # Thread Safety

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -82,7 +82,10 @@ import (
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
-var builtInPlannerRegistration sync.Once
+var builtInPlannerRegistration struct {
+	once sync.Once
+	err  error
+}
 
 // Planner defines the interface for database-specific migration planning.
 //
@@ -142,19 +145,17 @@ type Factory = registry.Factory
 // Register registers a planner factory for a dialect. Third-party dialects can
 // call this from init and then use the standard planner helpers.
 func Register(dialect string, factory Factory) error {
-	ensureBuiltInPlannersRegistered()
+	if err := ensureBuiltInPlannersRegistered(); err != nil {
+		return err
+	}
 	return registry.Register(dialect, factory)
-}
-
-// MustRegister registers a planner factory and panics if registration fails.
-func MustRegister(dialect string, factory Factory) {
-	ensureBuiltInPlannersRegistered()
-	registry.MustRegister(dialect, factory)
 }
 
 // RegisteredDialects returns the registered planner dialect names.
 func RegisteredDialects() []string {
-	ensureBuiltInPlannersRegistered()
+	if err := ensureBuiltInPlannersRegistered(); err != nil {
+		return nil
+	}
 	return registry.RegisteredDialects()
 }
 
@@ -232,43 +233,56 @@ func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (P
 // GetPlannerWithOptions returns a dialect-specific migration planner with
 // explicit high-level generation policy.
 func GetPlannerWithOptions(dialect string, opts Options) (Planner, error) {
-	ensureBuiltInPlannersRegistered()
+	if err := ensureBuiltInPlannersRegistered(); err != nil {
+		return nil, err
+	}
 	return registry.Get(dialect, opts)
 }
 
-func ensureBuiltInPlannersRegistered() {
-	builtInPlannerRegistration.Do(func() {
-		for _, dialect := range []string{
-			platform.Postgres,
-			platform.CockroachDB,
-			platform.YugabyteDB,
-			platform.Spanner,
-		} {
-			registerPostgresFamilyPlanner(dialect)
-		}
+func ensureBuiltInPlannersRegistered() error {
+	builtInPlannerRegistration.once.Do(func() {
+		builtInPlannerRegistration.err = registerBuiltInPlanners()
+	})
+	return builtInPlannerRegistration.err
+}
 
-		for _, dialect := range []string{platform.MySQL, platform.MariaDB} {
-			registerMySQLFamilyPlanner(dialect)
+func registerBuiltInPlanners() error {
+	for _, dialect := range []string{
+		platform.Postgres,
+		platform.CockroachDB,
+		platform.YugabyteDB,
+		platform.Spanner,
+	} {
+		if err := registerPostgresFamilyPlanner(dialect); err != nil {
+			return err
 		}
+	}
 
-		registry.MustRegister(platform.ClickHouse, func(Options) Planner {
-			return clickhouse.New()
-		})
-		registry.MustRegister(platform.SQLite, func(Options) Planner {
-			return sqlite.New()
-		})
+	for _, dialect := range []string{platform.MySQL, platform.MariaDB} {
+		if err := registerMySQLFamilyPlanner(dialect); err != nil {
+			return err
+		}
+	}
+
+	if err := registry.Register(platform.ClickHouse, func(Options) Planner {
+		return clickhouse.New()
+	}); err != nil {
+		return err
+	}
+	return registry.Register(platform.SQLite, func(Options) Planner {
+		return sqlite.New()
 	})
 }
 
-func registerPostgresFamilyPlanner(dialect string) {
-	registry.MustRegister(dialect, func(opts Options) Planner {
+func registerPostgresFamilyPlanner(dialect string) error {
+	return registry.Register(dialect, func(opts Options) Planner {
 		return postgres.NewWithCapabilities(opts.CapabilitiesFor(dialect)).
 			WithConcurrentIndexNames(opts.ConcurrentIndexNames...)
 	})
 }
 
-func registerMySQLFamilyPlanner(dialect string) {
-	registry.MustRegister(dialect, func(opts Options) Planner {
+func registerMySQLFamilyPlanner(dialect string) error {
+	return registry.Register(dialect, func(opts Options) Planner {
 		return mysql.NewWithCapabilities(opts.CapabilitiesFor(dialect))
 	})
 }

--- a/migration/planner/registry/registry.go
+++ b/migration/planner/registry/registry.go
@@ -69,13 +69,6 @@ func Register(dialect string, factory Factory) error {
 	return nil
 }
 
-// MustRegister registers a planner factory and panics if registration fails.
-func MustRegister(dialect string, factory Factory) {
-	if err := Register(dialect, factory); err != nil {
-		panic(err)
-	}
-}
-
 // Get returns a registered planner for dialect.
 func Get(dialect string, opts Options) (Planner, error) {
 	normalized := normalizeRegistryDialect(dialect)


### PR DESCRIPTION
Closes #128.

## Summary

- remove the last non-test `panic` from planner registration
- make built-in planner registration return an error through `sync.Once` instead of using `MustRegister`
- remove the public panic-based `MustRegister` helper and update planner docs to use `Register`

## Notes

Current `master` already contains the larger #128 plumbing: `goschema` annotation errors return errors, renderer/planner unsupported dialects return errors, and root command execution has recovery as a final safety net. This PR finishes the remaining non-test panic site left after #423.

The broader typed public error model and removal of legacy no-error planner APIs remains tracked by #271.

## Self-review

Pass 1:
- verified `rg -n 'panic\(' --type go | rg -v '_test\.go|cmd/root/root.go'` returns no matches
- verified #128 acceptance coverage already exists for bogus goschema attributes and unsupported `RenderSQL("sqlserver", ...)`
- verified planner unsupported dialects return errors

Pass 2:
- checked for stale `MustRegister` references in planner docs/code
- verified built-in planner registration still wires PostgreSQL-family, MySQL/MariaDB, ClickHouse, and SQLite planners
- kept the change scoped to panic removal; typed `errors.Is`/`errors.As` work remains #271

## Validation

- gopls diagnostics on edited files
- `GOWORK=off go test ./migration/planner ./migration/planner/registry ./migration/planner/dialects/...`
- `GOWORK=off go test ./cmd/root ./core/goschema ./core/renderer`
- `GOWORK=off go test ./migration/planner -run 'TestGetPlanner|TestRegister|TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError' -count=1 -v`
- `GOWORK=off go test ./...`
- `GOWORK=off go tool qtlint ./...`
- `GOWORK=off golangci-lint run ./...`
- `git diff --check`
