### PR TITLE
Add typed public API errors

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -34,6 +34,12 @@ jobs:
           ! grep -F "All operations wrapped in transactions" README.md
           ! grep -F "locking prevents double-apply" README.md
 
+      - name: Check public Go API ledger
+        run: scripts/check-public-api.sh
+
+      - name: Check public Go API snapshot
+        run: scripts/check-public-api-snapshot.sh
+
       - name: qtlint
         run: go tool qtlint ./...
 

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/goschema/internal/parseutils"
+	"github.com/stokaro/ptah/core/ptaherr"
 )
 
 // knownIndexAttributes lists every attribute key recognized on a
@@ -105,32 +106,53 @@ var knownSchemaAttributes = map[string]bool{
 // Platform-specific overrides (platform.*) are always allowed. This catches
 // typos like default_fn-vs-default_expr at parse time instead of silently
 // dropping them and producing wrong SQL.
-func validateAttributes(kv map[string]string, known map[string]bool, directive, location string) error {
+type annotationErrorContext struct {
+	file      string
+	line      int
+	directive string
+	location  string
+}
+
+func validateAttributes(kv map[string]string, known map[string]bool, ctx annotationErrorContext) error {
 	for k := range kv {
 		if known[k] || strings.HasPrefix(k, "platform.") {
 			continue
 		}
 		slog.Error("unknown annotation attribute",
-			"directive", directive,
+			"directive", ctx.directive,
 			"attribute", k,
-			"location", location,
+			"location", ctx.location,
 		)
-		return fmt.Errorf("unknown annotation attribute %q on %s at %s", k, directive, location)
+		return &ptaherr.ParseError{
+			File:      ctx.file,
+			Line:      ctx.line,
+			Directive: strings.TrimPrefix(ctx.directive, "//"),
+			Attribute: k,
+			Err:       ptaherr.ErrUnknownAttribute,
+			Message:   fmt.Sprintf("unknown annotation attribute %q on %s at %s", k, ctx.directive, ctx.location),
+		}
 	}
 	return nil
 }
 
-func requireAttributes(kv map[string]string, required []string, directive, location string) error {
+func requireAttributes(kv map[string]string, required []string, ctx annotationErrorContext) error {
 	for _, key := range required {
 		if strings.TrimSpace(kv[key]) != "" {
 			continue
 		}
 		slog.Error("missing required annotation attribute",
-			"directive", directive,
+			"directive", ctx.directive,
 			"attribute", key,
-			"location", location,
+			"location", ctx.location,
 		)
-		return fmt.Errorf("missing required annotation attribute %q on %s at %s", key, directive, location)
+		return &ptaherr.ParseError{
+			File:      ctx.file,
+			Line:      ctx.line,
+			Directive: strings.TrimPrefix(ctx.directive, "//"),
+			Attribute: key,
+			Err:       ptaherr.ErrMissingRequiredAttribute,
+			Message:   fmt.Sprintf("missing required annotation attribute %q on %s at %s", key, ctx.directive, ctx.location),
+		}
 	}
 	return nil
 }
@@ -149,7 +171,11 @@ func (s *schemaParseState) parseFieldComment(
 	if len(field.Names) > 0 {
 		location = structName + "." + field.Names[0].Name
 	}
-	if err := validateAttributes(kv, knownFieldAttributes, "//migrator:schema:field", location); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownFieldAttributes,
+		s.annotationContext(comment, "//migrator:schema:field", location),
+	); err != nil {
 		return err
 	}
 
@@ -177,7 +203,14 @@ func (s *schemaParseState) parseFieldComment(
 
 		identityGeneration := normalizeIdentityGeneration(kv["identity_generation"])
 		if kv["identity_generation"] != "" && identityGeneration == "" {
-			return fmt.Errorf("invalid identity_generation %q on //migrator:schema:field at %s", kv["identity_generation"], location)
+			return &ptaherr.ParseError{
+				File:      s.filename,
+				Line:      s.annotationContext(comment, "//migrator:schema:field", location).line,
+				Directive: "migrator:schema:field",
+				Attribute: "identity_generation",
+				Err:       ptaherr.ErrInvalidAttributeValue,
+				Message:   fmt.Sprintf("invalid identity_generation %q on //migrator:schema:field at %s", kv["identity_generation"], location),
+			}
 		}
 		if identityGeneration == "" && hasIdentitySettings(kv) {
 			identityGeneration = "BY_DEFAULT"
@@ -273,7 +306,11 @@ func (s *schemaParseState) parseEmbeddedComment(comment *ast.Comment, field *ast
 
 func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	if err := validateAttributes(kv, knownIndexAttributes, "//migrator:schema:index", structName); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownIndexAttributes,
+		s.annotationContext(comment, "//migrator:schema:index", structName),
+	); err != nil {
 		return err
 	}
 
@@ -300,7 +337,14 @@ func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName st
 	if g := strings.TrimSpace(kv["granularity"]); g != "" {
 		n, err := strconv.Atoi(g)
 		if err != nil || n < 0 {
-			return fmt.Errorf("invalid granularity %q on //migrator:schema:index at %s (must be a non-negative integer)", g, structName)
+			return &ptaherr.ParseError{
+				File:      s.filename,
+				Line:      s.annotationContext(comment, "//migrator:schema:index", structName).line,
+				Directive: "migrator:schema:index",
+				Attribute: "granularity",
+				Err:       ptaherr.ErrInvalidAttributeValue,
+				Message:   fmt.Sprintf("invalid granularity %q on //migrator:schema:index at %s (must be a non-negative integer)", g, structName),
+			}
 		}
 		granularity = n
 	}
@@ -394,10 +438,18 @@ func (s *schemaParseState) parseExtensionComment(comment *ast.Comment) {
 
 func (s *schemaParseState) parseSchemaComment(comment *ast.Comment) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	if err := validateAttributes(kv, knownSchemaAttributes, "//migrator:schema:schema", kv["name"]); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownSchemaAttributes,
+		s.annotationContext(comment, "//migrator:schema:schema", kv["name"]),
+	); err != nil {
 		return err
 	}
-	if err := requireAttributes(kv, []string{"name"}, "//migrator:schema:schema", kv["name"]); err != nil {
+	if err := requireAttributes(
+		kv,
+		[]string{"name"},
+		s.annotationContext(comment, "//migrator:schema:schema", kv["name"]),
+	); err != nil {
 		return err
 	}
 
@@ -424,6 +476,8 @@ func (s *schemaParseState) parseTableComment(comment *ast.Comment, structName st
 }
 
 type schemaParseState struct {
+	filename              string
+	fset                  *token.FileSet
 	tableNameToStructName map[string]string
 	globalEnumsMap        map[string]Enum
 	embeddedFields        []EmbeddedField
@@ -449,11 +503,29 @@ type structDeclaration struct {
 	structType *ast.StructType
 }
 
-func newSchemaParseState() *schemaParseState {
+func newSchemaParseState(filename string, fset *token.FileSet) *schemaParseState {
 	return &schemaParseState{
+		filename:              filename,
+		fset:                  fset,
 		tableNameToStructName: make(map[string]string),
 		globalEnumsMap:        make(map[string]Enum),
 	}
+}
+
+func (s *schemaParseState) annotationContext(
+	comment *ast.Comment,
+	directive string,
+	location string,
+) annotationErrorContext {
+	ctx := annotationErrorContext{
+		file:      s.filename,
+		directive: directive,
+		location:  location,
+	}
+	if s.fset != nil && comment != nil {
+		ctx.line = s.fset.Position(comment.Slash).Line
+	}
+	return ctx
 }
 
 func (s *schemaParseState) parseStructComment(comment *ast.Comment, structName string) error {
@@ -556,10 +628,14 @@ func ParseFile(filename string) (Database, error) {
 	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
 	if err != nil {
 		slog.Error("Failed to parse file", "error", err)
-		return Database{}, fmt.Errorf("parse Go file %q: %w", filename, err)
+		return Database{}, &ptaherr.ParseError{
+			File:    filename,
+			Err:     err,
+			Message: fmt.Sprintf("parse Go file %q: %v", filename, err),
+		}
 	}
 
-	return parseFileAST(f)
+	return parseFileAST(filename, fset, f)
 }
 
 // ParseSource parses a Go source string and returns the database schema.
@@ -569,14 +645,18 @@ func ParseSource(filename string, source any) (Database, error) {
 	f, err := parser.ParseFile(fset, filename, source, parser.ParseComments)
 	if err != nil {
 		slog.Error("Failed to parse file", "error", err)
-		return Database{}, fmt.Errorf("parse Go source %q: %w", filename, err)
+		return Database{}, &ptaherr.ParseError{
+			File:    filename,
+			Err:     err,
+			Message: fmt.Sprintf("parse Go source %q: %v", filename, err),
+		}
 	}
 
-	return parseFileAST(f)
+	return parseFileAST(filename, fset, f)
 }
 
-func parseFileAST(f *ast.File) (Database, error) {
-	state := newSchemaParseState()
+func parseFileAST(filename string, fset *token.FileSet, f *ast.File) (Database, error) {
+	state := newSchemaParseState(filename, fset)
 	if err := state.processFileAST(f); err != nil {
 		return Database{}, err
 	}
@@ -821,10 +901,18 @@ func (s *schemaParseState) parseFunctionComment(comment *ast.Comment, structName
 
 func (s *schemaParseState) parseViewComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	if err := validateAttributes(kv, knownViewAttributes, "//migrator:schema:view", structName); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownViewAttributes,
+		s.annotationContext(comment, "//migrator:schema:view", structName),
+	); err != nil {
 		return err
 	}
-	if err := requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:view", structName); err != nil {
+	if err := requireAttributes(
+		kv,
+		[]string{"name", "body"},
+		s.annotationContext(comment, "//migrator:schema:view", structName),
+	); err != nil {
 		return err
 	}
 	s.views = append(s.views, View{
@@ -839,10 +927,18 @@ func (s *schemaParseState) parseViewComment(comment *ast.Comment, structName str
 
 func (s *schemaParseState) parseMaterializedViewComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	if err := validateAttributes(kv, knownMaterializedViewAttributes, "//migrator:schema:matview", structName); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownMaterializedViewAttributes,
+		s.annotationContext(comment, "//migrator:schema:matview", structName),
+	); err != nil {
 		return err
 	}
-	if err := requireAttributes(kv, []string{"name", "body"}, "//migrator:schema:matview", structName); err != nil {
+	if err := requireAttributes(
+		kv,
+		[]string{"name", "body"},
+		s.annotationContext(comment, "//migrator:schema:matview", structName),
+	); err != nil {
 		return err
 	}
 	refreshStrategy := kv["refresh_strategy"]
@@ -863,10 +959,18 @@ func (s *schemaParseState) parseMaterializedViewComment(comment *ast.Comment, st
 
 func (s *schemaParseState) parseTriggerComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
-	if err := validateAttributes(kv, knownTriggerAttributes, "//migrator:schema:trigger", structName); err != nil {
+	if err := validateAttributes(
+		kv,
+		knownTriggerAttributes,
+		s.annotationContext(comment, "//migrator:schema:trigger", structName),
+	); err != nil {
 		return err
 	}
-	if err := requireAttributes(kv, []string{"name", "table", "timing", "event", "body"}, "//migrator:schema:trigger", structName); err != nil {
+	if err := requireAttributes(
+		kv,
+		[]string{"name", "table", "timing", "event", "body"},
+		s.annotationContext(comment, "//migrator:schema:trigger", structName),
+	); err != nil {
 		return err
 	}
 	trigger := Trigger{

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -373,12 +373,6 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-// ParseConstraintComment parses a constraint comment and adds it to the constraints slice.
-// This function is exported for testing purposes.
-func ParseConstraintComment(comment *ast.Comment, structName string, schemaConstraints *[]Constraint) {
-	*schemaConstraints = append(*schemaConstraints, parseConstraintComment(comment, structName))
-}
-
 func (s *schemaParseState) parseConstraintComment(comment *ast.Comment, structName string) {
 	s.schemaConstraints = append(s.schemaConstraints, parseConstraintComment(comment, structName))
 }
@@ -503,6 +497,11 @@ type structDeclaration struct {
 	structType *ast.StructType
 }
 
+type schemaCommentTarget struct {
+	structName string
+	field      *ast.Field
+}
+
 func newSchemaParseState(filename string, fset *token.FileSet) *schemaParseState {
 	return &schemaParseState{
 		filename:              filename,
@@ -528,40 +527,40 @@ func (s *schemaParseState) annotationContext(
 	return ctx
 }
 
-func (s *schemaParseState) parseStructComment(comment *ast.Comment, structName string) error {
-	if handled, err := s.parseStructScopedComment(comment, structName); handled || err != nil {
+func (s *schemaParseState) parseStructComment(comment *ast.Comment, target schemaCommentTarget) error {
+	if handled, err := s.parseStructScopedComment(comment, target); handled || err != nil {
 		return err
 	}
 
-	return s.parseSharedComment(comment, structName)
+	return s.parseSharedComment(comment, target)
 }
 
-func (s *schemaParseState) parseStructFieldComment(comment *ast.Comment, structName string, field *ast.Field) error {
-	if handled, err := s.parseFieldScopedComment(comment, structName, field); handled || err != nil {
+func (s *schemaParseState) parseStructFieldComment(comment *ast.Comment, target schemaCommentTarget) error {
+	if handled, err := s.parseFieldScopedComment(comment, target); handled || err != nil {
 		return err
 	}
 
-	return s.parseSharedComment(comment, structName)
+	return s.parseSharedComment(comment, target)
 }
 
-func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, structName string, field *ast.Field) (bool, error) {
+func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, target schemaCommentTarget) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
-		return true, s.parseFieldComment(comment, field, structName)
+		return true, s.parseFieldComment(comment, target.field, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
-		s.parseEmbeddedComment(comment, field, structName)
+		s.parseEmbeddedComment(comment, target.field, target.structName)
 		return true, nil
 	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
-		return true, s.parseIndexComment(comment, structName)
+		return true, s.parseIndexComment(comment, target.structName)
 	default:
 		return false, nil
 	}
 }
 
-func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, structName string) (bool, error) {
+func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, target schemaCommentTarget) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
-		s.parseTableComment(comment, structName)
+		s.parseTableComment(comment, target.structName)
 		return true, nil
 	case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
 		return true, s.parseSchemaComment(comment)
@@ -570,52 +569,57 @@ func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, struct
 	}
 }
 
-func (s *schemaParseState) parseSharedComment(comment *ast.Comment, structName string) error {
+func (s *schemaParseState) parseSharedComment(comment *ast.Comment, target schemaCommentTarget) error {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
-		s.parseConstraintComment(comment, structName)
+		s.parseConstraintComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
 		s.parseExtensionComment(comment)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
-		s.parseFunctionComment(comment, structName)
+		s.parseFunctionComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
-		return s.parseViewComment(comment, structName)
+		return s.parseViewComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
-		return s.parseMaterializedViewComment(comment, structName)
+		return s.parseMaterializedViewComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
-		return s.parseTriggerComment(comment, structName)
+		return s.parseTriggerComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-		s.parseRLSPolicyComment(comment, structName)
+		s.parseRLSPolicyComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-		s.parseRLSEnableComment(comment, structName)
+		s.parseRLSEnableComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
-		s.parseRoleComment(comment, structName)
+		s.parseRoleComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
-		s.parseGrantComment(comment, structName)
+		s.parseGrantComment(comment, target.structName)
 	}
 	return nil
 }
 
-func (s *schemaParseState) processTableComments(structName string, genDecl *ast.GenDecl) error {
-	if genDecl.Doc == nil {
+func (s *schemaParseState) processStructComments(structDecl structDeclaration) error {
+	if structDecl.genDecl.Doc == nil {
 		return nil
 	}
 
-	for _, comment := range genDecl.Doc.List {
-		if err := s.parseStructComment(comment, structName); err != nil {
+	target := schemaCommentTarget{structName: structDecl.name}
+	for _, comment := range structDecl.genDecl.Doc.List {
+		if err := s.parseStructComment(comment, target); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *schemaParseState) processFieldComments(structName string, structType *ast.StructType) error {
-	for _, field := range structType.Fields.List {
+func (s *schemaParseState) processFieldComments(structDecl structDeclaration) error {
+	for _, field := range structDecl.structType.Fields.List {
 		if field.Doc == nil {
 			continue
 		}
+		target := schemaCommentTarget{
+			structName: structDecl.name,
+			field:      field,
+		}
 		for _, comment := range field.Doc.List {
-			if err := s.parseStructFieldComment(comment, structName, field); err != nil {
+			if err := s.parseStructFieldComment(comment, target); err != nil {
 				return err
 			}
 		}
@@ -778,10 +782,10 @@ func (s *schemaParseState) processDeclarations(structDecls []structDeclaration) 
 }
 
 func (s *schemaParseState) processDeclaration(structDecl structDeclaration) error {
-	if err := s.processTableComments(structDecl.name, structDecl.genDecl); err != nil {
+	if err := s.processStructComments(structDecl); err != nil {
 		return err
 	}
-	return s.processFieldComments(structDecl.name, structDecl.structType)
+	return s.processFieldComments(structDecl)
 }
 
 // processAllFileComments scans comments for RLS annotations that are separated

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -1,7 +1,6 @@
 package goschema_test
 
 import (
-	"go/ast"
 	"os"
 	"path/filepath"
 	"slices"
@@ -867,7 +866,7 @@ func TestParseRLSEnableComment(t *testing.T) {
 	}
 }
 
-func TestParseConstraintComment(t *testing.T) {
+func TestParseSource_ConstraintComment(t *testing.T) {
 	tests := []struct {
 		name     string
 		comment  string
@@ -936,12 +935,11 @@ func TestParseConstraintComment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			var constraints []goschema.Constraint
-			comment := &ast.Comment{Text: tt.comment}
-			goschema.ParseConstraintComment(comment, "TestStruct", &constraints)
+			source := "package test\n\n" + tt.comment + "\ntype TestStruct struct{}\n"
+			db := mustParseSource(c, "constraints.go", source)
 
-			c.Assert(constraints, qt.HasLen, 1)
-			constraint := constraints[0]
+			c.Assert(db.Constraints, qt.HasLen, 1)
+			constraint := db.Constraints[0]
 
 			c.Assert(constraint.StructName, qt.Equals, tt.expected.StructName)
 			c.Assert(constraint.Name, qt.Equals, tt.expected.Name)

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -2,6 +2,7 @@ package goschema
 
 import (
 	"bufio"
+	"errors"
 	"io/fs"
 	"os"
 	"strings"
@@ -91,6 +92,8 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
 	}
 
+	var parseErrors []error
+
 	// Walk through all directories recursively
 	err := fs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -114,7 +117,8 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 
 		database, err := parseDatabaseFile(fsys, path)
 		if err != nil {
-			return err
+			parseErrors = append(parseErrors, err)
+			return nil
 		}
 
 		// Add to result
@@ -139,6 +143,9 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 	})
 
 	if err != nil {
+		return nil, err
+	}
+	if err := errors.Join(parseErrors...); err != nil {
 		return nil, err
 	}
 

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -13,6 +13,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/ptaherr"
 )
 
 func TestParseDir_ExtensionMerging(t *testing.T) {
@@ -305,6 +306,46 @@ type User struct {
 	result, err := goschema.ParseDir(rootDir)
 	c.Assert(result, qt.IsNil)
 	c.Assert(err, qt.ErrorMatches, `unknown annotation attribute "bogus" on //migrator:schema:field at User.ID`)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnknownAttribute)
+
+	var parseErr *ptaherr.ParseError
+	c.Assert(err, qt.ErrorAs, &parseErr)
+	c.Assert(parseErr.File, qt.Equals, "user.go")
+	c.Assert(parseErr.Line, qt.Equals, 5)
+	c.Assert(parseErr.Directive, qt.Equals, "migrator:schema:field")
+	c.Assert(parseErr.Attribute, qt.Equals, "bogus")
+}
+
+func TestParseDir_MultipleInvalidFieldAttributesReturnsJoinedError(t *testing.T) {
+	c := qt.New(t)
+
+	rootDir := c.TempDir()
+	first := `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="int" bogus="y"
+	ID int64
+}
+`
+	second := `package models
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:schema:field name="id" type="int" wrong="y"
+	ID int64
+}
+`
+	err := os.WriteFile(filepath.Join(rootDir, "user.go"), []byte(first), 0o600)
+	c.Assert(err, qt.IsNil)
+	err = os.WriteFile(filepath.Join(rootDir, "post.go"), []byte(second), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goschema.ParseDir(rootDir)
+	c.Assert(result, qt.IsNil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnknownAttribute)
+	c.Assert(err.Error(), qt.Contains, `unknown annotation attribute "bogus"`)
+	c.Assert(err.Error(), qt.Contains, `unknown annotation attribute "wrong"`)
 }
 
 func TestParseDir_SyntaxErrorReturnsError(t *testing.T) {

--- a/core/ptaherr/errors.go
+++ b/core/ptaherr/errors.go
@@ -1,0 +1,143 @@
+// Package ptaherr defines typed errors returned by Ptah's public Go APIs.
+package ptaherr
+
+import (
+	"errors"
+
+	"github.com/stokaro/ptah/core/ast"
+)
+
+var (
+	// ErrUnsupportedDialect marks errors caused by an unknown or unsupported
+	// database dialect.
+	ErrUnsupportedDialect = errors.New("unsupported database dialect")
+
+	// ErrUnknownAttribute marks Go annotation directives containing an
+	// attribute Ptah does not recognize.
+	ErrUnknownAttribute = errors.New("unknown annotation attribute")
+
+	// ErrMissingRequiredAttribute marks Go annotation directives missing a
+	// required attribute.
+	ErrMissingRequiredAttribute = errors.New("missing required annotation attribute")
+
+	// ErrInvalidAttributeValue marks Go annotation directives containing a
+	// recognized attribute with an invalid value.
+	ErrInvalidAttributeValue = errors.New("invalid annotation attribute value")
+
+	// ErrUnsupportedFeature marks dialect or capability feature mismatches.
+	ErrUnsupportedFeature = errors.New("unsupported feature")
+)
+
+// ParseError reports a Go annotation or source parsing failure.
+type ParseError struct {
+	File      string
+	Line      int
+	Directive string
+	Attribute string
+	Err       error
+	Message   string
+}
+
+func (e *ParseError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "parse error"
+}
+
+func (e *ParseError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// PlanError reports migration planning failures.
+type PlanError struct {
+	Dialect string
+	Err     error
+	Message string
+}
+
+func (e *PlanError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "plan error"
+}
+
+func (e *PlanError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// RenderError reports SQL rendering failures.
+type RenderError struct {
+	Dialect string
+	Node    ast.Node
+	Err     error
+	Message string
+}
+
+func (e *RenderError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "render error"
+}
+
+func (e *RenderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// CapabilityError reports a requested feature that is not available for the
+// selected dialect or concrete server capability set.
+type CapabilityError struct {
+	Dialect string
+	Feature string
+	Err     error
+	Message string
+}
+
+func (e *CapabilityError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "capability error"
+}
+
+func (e *CapabilityError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}

--- a/core/ptaherr/errors_test.go
+++ b/core/ptaherr/errors_test.go
@@ -1,0 +1,166 @@
+package ptaherr_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/ptaherr"
+)
+
+func TestParseError(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.ParseError{
+		File:      "models.go",
+		Line:      12,
+		Directive: "migrator:schema:field",
+		Attribute: "bogus",
+		Err:       ptaherr.ErrUnknownAttribute,
+		Message:   `unknown annotation attribute "bogus" on //migrator:schema:field at models.go:12`,
+	}
+
+	var parseErr *ptaherr.ParseError
+	c.Assert(err, qt.ErrorAs, &parseErr)
+	c.Assert(parseErr.File, qt.Equals, "models.go")
+	c.Assert(parseErr.Line, qt.Equals, 12)
+	c.Assert(parseErr.Directive, qt.Equals, "migrator:schema:field")
+	c.Assert(parseErr.Attribute, qt.Equals, "bogus")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnknownAttribute)
+	c.Assert(err.Error(), qt.Equals, `unknown annotation attribute "bogus" on //migrator:schema:field at models.go:12`)
+	c.Assert(err.Unwrap(), qt.Equals, ptaherr.ErrUnknownAttribute)
+}
+
+func TestParseErrorFallbackMessages(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.ParseError{Err: ptaherr.ErrMissingRequiredAttribute}
+	c.Assert(err.Error(), qt.Equals, "missing required annotation attribute")
+
+	err = &ptaherr.ParseError{}
+	c.Assert(err.Error(), qt.Equals, "parse error")
+
+	var nilErr *ptaherr.ParseError
+	c.Assert(nilErr.Error(), qt.Equals, "<nil>")
+	c.Assert(nilErr.Unwrap(), qt.IsNil)
+}
+
+func TestPlanError(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.PlanError{
+		Dialect: "sqlserver",
+		Err:     ptaherr.ErrUnsupportedDialect,
+		Message: "unsupported database dialect: sqlserver",
+	}
+
+	var planErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &planErr)
+	c.Assert(planErr.Dialect, qt.Equals, "sqlserver")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
+	c.Assert(err.Error(), qt.Equals, "unsupported database dialect: sqlserver")
+	c.Assert(err.Unwrap(), qt.Equals, ptaherr.ErrUnsupportedDialect)
+}
+
+func TestPlanErrorFallbackMessages(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.PlanError{Err: ptaherr.ErrUnsupportedFeature}
+	c.Assert(err.Error(), qt.Equals, "unsupported feature")
+
+	err = &ptaherr.PlanError{}
+	c.Assert(err.Error(), qt.Equals, "plan error")
+
+	var nilErr *ptaherr.PlanError
+	c.Assert(nilErr.Error(), qt.Equals, "<nil>")
+	c.Assert(nilErr.Unwrap(), qt.IsNil)
+}
+
+func TestRenderError(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewComment("hello")
+	err := &ptaherr.RenderError{
+		Dialect: "sqlite",
+		Node:    node,
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: "render SQL for sqlite node *ast.CommentNode: unsupported feature",
+	}
+
+	var renderErr *ptaherr.RenderError
+	c.Assert(err, qt.ErrorAs, &renderErr)
+	c.Assert(renderErr.Dialect, qt.Equals, "sqlite")
+	c.Assert(renderErr.Node, qt.Equals, node)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err.Error(), qt.Equals, "render SQL for sqlite node *ast.CommentNode: unsupported feature")
+	c.Assert(err.Unwrap(), qt.Equals, ptaherr.ErrUnsupportedFeature)
+}
+
+func TestRenderErrorFallbackMessages(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.RenderError{Err: ptaherr.ErrUnsupportedDialect}
+	c.Assert(err.Error(), qt.Equals, "unsupported database dialect")
+
+	err = &ptaherr.RenderError{}
+	c.Assert(err.Error(), qt.Equals, "render error")
+
+	var nilErr *ptaherr.RenderError
+	c.Assert(nilErr.Error(), qt.Equals, "<nil>")
+	c.Assert(nilErr.Unwrap(), qt.IsNil)
+}
+
+func TestCapabilityError(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.CapabilityError{
+		Dialect: "sqlite",
+		Feature: "materialized views",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: "sqlite does not support materialized views",
+	}
+
+	var capabilityErr *ptaherr.CapabilityError
+	c.Assert(err, qt.ErrorAs, &capabilityErr)
+	c.Assert(capabilityErr.Dialect, qt.Equals, "sqlite")
+	c.Assert(capabilityErr.Feature, qt.Equals, "materialized views")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err.Error(), qt.Equals, "sqlite does not support materialized views")
+	c.Assert(err.Unwrap(), qt.Equals, ptaherr.ErrUnsupportedFeature)
+}
+
+func TestCapabilityErrorFallbackMessages(t *testing.T) {
+	c := qt.New(t)
+
+	err := &ptaherr.CapabilityError{Err: ptaherr.ErrUnsupportedFeature}
+	c.Assert(err.Error(), qt.Equals, "unsupported feature")
+
+	err = &ptaherr.CapabilityError{}
+	c.Assert(err.Error(), qt.Equals, "capability error")
+
+	var nilErr *ptaherr.CapabilityError
+	c.Assert(nilErr.Error(), qt.Equals, "<nil>")
+	c.Assert(nilErr.Unwrap(), qt.IsNil)
+}
+
+func TestSentinelErrorsAreDistinct(t *testing.T) {
+	c := qt.New(t)
+
+	sentinels := []error{
+		ptaherr.ErrUnsupportedDialect,
+		ptaherr.ErrUnknownAttribute,
+		ptaherr.ErrMissingRequiredAttribute,
+		ptaherr.ErrInvalidAttributeValue,
+		ptaherr.ErrUnsupportedFeature,
+	}
+	for i, left := range sentinels {
+		for j, right := range sentinels {
+			if i == j {
+				c.Assert(left, qt.ErrorIs, right)
+				continue
+			}
+			c.Assert(left, qt.Not(qt.ErrorIs), right)
+		}
+	}
+}

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -33,6 +33,7 @@
 package renderer
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/stokaro/ptah/core/ast"
@@ -40,6 +41,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer/dialects/clickhouse"
 	"github.com/stokaro/ptah/core/renderer/dialects/mariadb"
 	"github.com/stokaro/ptah/core/renderer/dialects/mysql"
@@ -84,7 +86,11 @@ func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
 		return postgres.NewWithCapabilities(caps, normalizedDialect), nil
 	default:
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
+		return nil, &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrUnsupportedDialect,
+			Message: fmt.Sprintf("unsupported database dialect: %s", dialect),
+		}
 	}
 }
 
@@ -113,7 +119,16 @@ func VisitorRenderSQL(r types.RenderVisitor, nodes ...ast.Node) (string, error) 
 	r.Reset()
 	for _, node := range nodes {
 		if err := node.Accept(r); err != nil {
-			return "", err
+			var renderErr *ptaherr.RenderError
+			if errors.As(err, &renderErr) {
+				return "", err
+			}
+			return "", &ptaherr.RenderError{
+				Dialect: r.GetDialect(),
+				Node:    node,
+				Err:     err,
+				Message: err.Error(),
+			}
 		}
 	}
 	return r.Output(), nil

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer"
 )
 
@@ -198,6 +199,11 @@ func TestRenderSQL_UnsupportedDialect(t *testing.T) {
 	sql, err := renderer.RenderSQL("sqlserver", comment)
 	c.Assert(sql, qt.Equals, "")
 	c.Assert(err, qt.ErrorMatches, "unsupported database dialect: sqlserver")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
+
+	var renderErr *ptaherr.RenderError
+	c.Assert(err, qt.ErrorAs, &renderErr)
+	c.Assert(renderErr.Dialect, qt.Equals, "sqlserver")
 }
 
 func TestRenderer_Interface(t *testing.T) {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -1,60 +1,91 @@
 # Public Go API
 
-Ptah is pre-GA, so this document defines the intended public API surface before
-the first stable release. Public packages should return typed errors instead of
-requiring callers to match strings.
+Ptah is pre-GA, but embedders need a documented surface and a typed error
+contract. Packages in this document are the only non-command, non-example,
+non-fixture packages that may remain importable without an explicit review.
 
-## Typed Errors
+## Stable Embedder API
 
-Use `github.com/stokaro/ptah/core/ptaherr` with standard Go error matching:
+These packages are intended for application and tool embedders:
 
-```go
-var parseErr *ptaherr.ParseError
-if errors.As(err, &parseErr) {
-    // parseErr.File, parseErr.Line, parseErr.Directive, parseErr.Attribute
-}
+- `github.com/stokaro/ptah/config`
+- `github.com/stokaro/ptah/config/projectconfig`
+- `github.com/stokaro/ptah/core/ast`
+- `github.com/stokaro/ptah/core/goschema`
+- `github.com/stokaro/ptah/core/platform`
+- `github.com/stokaro/ptah/core/platform/capability`
+- `github.com/stokaro/ptah/core/ptaherr`
+- `github.com/stokaro/ptah/core/renderer`
+- `github.com/stokaro/ptah/core/sqlutil`
+- `github.com/stokaro/ptah/dbschema`
+- `github.com/stokaro/ptah/dbschema/types`
+- `github.com/stokaro/ptah/migration/generator`
+- `github.com/stokaro/ptah/migration/lint`
+- `github.com/stokaro/ptah/migration/migrator`
+- `github.com/stokaro/ptah/migration/planner`
+- `github.com/stokaro/ptah/migration/risk`
+- `github.com/stokaro/ptah/migration/safety`
+- `github.com/stokaro/ptah/migration/schemadiff`
+- `github.com/stokaro/ptah/migration/schemadiff/types`
+- `github.com/stokaro/ptah/migration/seeder`
 
-if errors.Is(err, ptaherr.ErrUnsupportedDialect) {
-    // choose a supported dialect or report configuration feedback
-}
-```
+Public failures from these packages should use `core/ptaherr` where the caller
+can reasonably branch on the error. In particular, annotation failures should
+support `errors.As(err, *ptaherr.ParseError)`, and unsupported dialect failures
+should support `errors.Is(err, ptaherr.ErrUnsupportedDialect)`.
 
-The first typed error contract covers:
+## Provisional Surface
 
-- `*ptaherr.ParseError` from Go schema parsing failures.
-- `*ptaherr.RenderError` from renderer selection and AST rendering failures.
-- `*ptaherr.PlanError` from planner selection and migration planning failures.
-- `ptaherr.ErrUnknownAttribute`, `ErrMissingRequiredAttribute`,
-  `ErrInvalidAttributeValue`, `ErrUnsupportedDialect`, and
-  `ErrUnsupportedFeature` sentinels.
+These packages are currently importable and therefore tracked by CI, but they
+are not yet a stable API commitment. Before GA, either promote them to the
+stable list above or move them behind `internal/` package boundaries. Track that
+package-boundary cleanup in
+[#426](https://github.com/stokaro/ptah/issues/426).
 
-## Supported Packages
+- `github.com/stokaro/ptah/core/astbuilder`
+- `github.com/stokaro/ptah/core/atlashcl`
+- `github.com/stokaro/ptah/core/atlashclrender`
+- `github.com/stokaro/ptah/core/convert/dbschematogo`
+- `github.com/stokaro/ptah/core/convert/fromschema`
+- `github.com/stokaro/ptah/core/convert/toschema`
+- `github.com/stokaro/ptah/core/lexer`
+- `github.com/stokaro/ptah/core/parser`
+- `github.com/stokaro/ptah/core/renderer/dialects/clickhouse`
+- `github.com/stokaro/ptah/core/renderer/dialects/mariadb`
+- `github.com/stokaro/ptah/core/renderer/dialects/mysql`
+- `github.com/stokaro/ptah/core/renderer/dialects/mysqllike`
+- `github.com/stokaro/ptah/core/renderer/dialects/postgres`
+- `github.com/stokaro/ptah/core/renderer/dialects/sqlite`
+- `github.com/stokaro/ptah/core/renderer/types`
+- `github.com/stokaro/ptah/core/sqllint`
+- `github.com/stokaro/ptah/core/yamlschema`
+- `github.com/stokaro/ptah/dbschema/clickhouse`
+- `github.com/stokaro/ptah/dbschema/mysql`
+- `github.com/stokaro/ptah/dbschema/postgres`
+- `github.com/stokaro/ptah/dbschema/sqlite`
+- `github.com/stokaro/ptah/migration/migratesum`
+- `github.com/stokaro/ptah/migration/onlineddl`
+- `github.com/stokaro/ptah/migration/planner/dialects/clickhouse`
+- `github.com/stokaro/ptah/migration/planner/dialects/mysql`
+- `github.com/stokaro/ptah/migration/planner/dialects/postgres`
+- `github.com/stokaro/ptah/migration/planner/dialects/sqlite`
+- `github.com/stokaro/ptah/migration/planner/registry`
+- `github.com/stokaro/ptah/migration/typechange`
 
-These packages are intended for embedders:
+## Compatibility Guard
 
-- `core/ast`
-- `core/goschema`
-- `core/platform`
-- `core/platform/capability`
-- `core/ptaherr`
-- `core/renderer`
-- `core/sqlutil`
-- `dbschema`
-- `migration/generator`
-- `migration/lint`
-- `migration/migrator`
-- `migration/planner`
-- `migration/risk`
-- `migration/safety`
-- `migration/schemadiff`
-- `migration/seeder`
+CI runs two public API checks:
 
-Packages under `cmd/`, `internal/`, and nested implementation packages such as
-renderer and planner dialect packages are not part of the supported API unless a
-future release promotes them here.
+- `scripts/check-public-api.sh` fails when `go list ./...` finds a
+  non-command, non-example, non-fixture package that is importable from outside
+  this module but not listed here.
+- `scripts/check-public-api-snapshot.sh` regenerates the `go doc -short`
+  exported-symbol snapshot for every package listed here and compares it with
+  `docs/public_api.snapshot`. Any exported surface change must update the
+  snapshot in the same reviewed change.
 
-## Remaining Pre-GA Work
-
-Before a stable release, Ptah still needs an automated exported-surface check
-against this document and a cleanup pass that moves unlisted implementation
-packages under `internal/` or explicitly documents why they remain importable.
+After the first `v0.x` tag exists, add a released-baseline API compatibility
+check (`apidiff` or `gorelease`) for the stable package list. Until then, there
+is no authoritative released baseline to compare against; the package ledger
+and snapshot are the enforceable pre-release guards. Track the released-baseline
+upgrade in [#427](https://github.com/stokaro/ptah/issues/427).

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -1,0 +1,60 @@
+# Public Go API
+
+Ptah is pre-GA, so this document defines the intended public API surface before
+the first stable release. Public packages should return typed errors instead of
+requiring callers to match strings.
+
+## Typed Errors
+
+Use `github.com/stokaro/ptah/core/ptaherr` with standard Go error matching:
+
+```go
+var parseErr *ptaherr.ParseError
+if errors.As(err, &parseErr) {
+    // parseErr.File, parseErr.Line, parseErr.Directive, parseErr.Attribute
+}
+
+if errors.Is(err, ptaherr.ErrUnsupportedDialect) {
+    // choose a supported dialect or report configuration feedback
+}
+```
+
+The first typed error contract covers:
+
+- `*ptaherr.ParseError` from Go schema parsing failures.
+- `*ptaherr.RenderError` from renderer selection and AST rendering failures.
+- `*ptaherr.PlanError` from planner selection and migration planning failures.
+- `ptaherr.ErrUnknownAttribute`, `ErrMissingRequiredAttribute`,
+  `ErrInvalidAttributeValue`, `ErrUnsupportedDialect`, and
+  `ErrUnsupportedFeature` sentinels.
+
+## Supported Packages
+
+These packages are intended for embedders:
+
+- `core/ast`
+- `core/goschema`
+- `core/platform`
+- `core/platform/capability`
+- `core/ptaherr`
+- `core/renderer`
+- `core/sqlutil`
+- `dbschema`
+- `migration/generator`
+- `migration/lint`
+- `migration/migrator`
+- `migration/planner`
+- `migration/risk`
+- `migration/safety`
+- `migration/schemadiff`
+- `migration/seeder`
+
+Packages under `cmd/`, `internal/`, and nested implementation packages such as
+renderer and planner dialect packages are not part of the supported API unless a
+future release promotes them here.
+
+## Remaining Pre-GA Work
+
+Before a stable release, Ptah still needs an automated exported-surface check
+against this document and a cleanup pass that moves unlisted implementation
+packages under `internal/` or explicitly documents why they remain importable.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1,0 +1,747 @@
+## github.com/stokaro/ptah/config
+
+type CompareOptions struct{ ... }
+    func DefaultCompareOptions() *CompareOptions
+    func WithAdditionalIgnoredExtensions(extensions ...string) *CompareOptions
+    func WithIgnoredExtensions(extensions ...string) *CompareOptions
+
+## github.com/stokaro/ptah/config/projectconfig
+
+const PtahFileName = "ptah.yaml" ...
+type Config struct{ ... }
+    func Load(opts LoadOptions) (Config, error)
+    func LoadAtlasFile(path, envName string) (Config, error)
+    func LoadPtahFile(path, envName string) (Config, error)
+    func Merge(base, override Config) Config
+    func ParseAtlas(data []byte, filename, envName string) (Config, error)
+    func ParsePtah(data []byte, filename, envName string) (Config, error)
+type LintConfig struct{ ... }
+type LoadOptions struct{ ... }
+type MigrationConfig struct{ ... }
+
+## github.com/stokaro/ptah/core/ast
+
+type AddColumnOperation struct{ ... }
+type AddConstraintOperation struct{ ... }
+type AddEnumValueOperation struct{ ... }
+    func NewAddEnumValueOperation(value string) *AddEnumValueOperation
+type AddSkippingIndexOperation struct{ ... }
+type AlterGeneratedColumnExpressionOperation struct{ ... }
+type AlterOperation interface{ ... }
+type AlterRoleNode struct{ ... }
+    func NewAlterRole(name string) *AlterRoleNode
+type AlterTableDisableRLSNode struct{ ... }
+    func NewAlterTableDisableRLS(table string) *AlterTableDisableRLSNode
+type AlterTableEnableRLSNode struct{ ... }
+    func NewAlterTableEnableRLS(table string) *AlterTableEnableRLSNode
+type AlterTableNode struct{ ... }
+type AlterTypeNode struct{ ... }
+    func NewAlterType(name string) *AlterTypeNode
+type ColumnNode struct{ ... }
+    func NewColumn(name, dataType string) *ColumnNode
+type CommentNode struct{ ... }
+    func NewComment(text string) *CommentNode
+type CompositeField struct{ ... }
+type CompositeTypeDef struct{ ... }
+    func NewCompositeTypeDef(fields ...*CompositeField) *CompositeTypeDef
+type ConstraintColumn struct{ ... }
+type ConstraintNode struct{ ... }
+    func NewExcludeConstraint(name, usingMethod, elements string) *ConstraintNode
+    func NewForeignKeyConstraint(name string, columns []string, ref *ForeignKeyRef) *ConstraintNode
+    func NewPrimaryKeyConstraint(columns ...string) *ConstraintNode
+    func NewUniqueConstraint(name string, columns ...string) *ConstraintNode
+type ConstraintType int
+    const PrimaryKeyConstraint ConstraintType = iota ...
+type CreateDatabaseNode struct{ ... }
+    func NewCreateDatabase(name string) *CreateDatabaseNode
+type CreateFunctionNode struct{ ... }
+    func NewCreateFunction(name string) *CreateFunctionNode
+type CreateMaterializedViewNode struct{ ... }
+    func NewCreateMaterializedView(name string) *CreateMaterializedViewNode
+type CreatePolicyNode struct{ ... }
+    func NewCreatePolicy(name, table string) *CreatePolicyNode
+type CreateRoleNode struct{ ... }
+    func NewCreateRole(name string) *CreateRoleNode
+type CreateSchemaNode struct{ ... }
+    func NewCreateSchema(name string) *CreateSchemaNode
+type CreateTableNode struct{ ... }
+    func NewCreateTable(name string) *CreateTableNode
+type CreateTriggerNode struct{ ... }
+    func NewCreateTrigger(name, table string) *CreateTriggerNode
+type CreateTypeNode struct{ ... }
+    func NewCreateType(name string, typeDef TypeDefinition) *CreateTypeNode
+type CreateViewNode struct{ ... }
+    func NewCreateView(name string) *CreateViewNode
+type DefaultValue struct{ ... }
+type DomainTypeDef struct{ ... }
+    func NewDomainTypeDef(baseType string) *DomainTypeDef
+type DropColumnOperation struct{ ... }
+type DropConstraintOperation struct{ ... }
+type DropExtensionNode struct{ ... }
+    func NewDropExtension(name string) *DropExtensionNode
+type DropFunctionNode struct{ ... }
+    func NewDropFunction(name string) *DropFunctionNode
+type DropIndexNode struct{ ... }
+    func NewDropIndex(name string) *DropIndexNode
+type DropMaterializedViewNode struct{ ... }
+    func NewDropMaterializedView(name string) *DropMaterializedViewNode
+type DropPolicyNode struct{ ... }
+    func NewDropPolicy(name, table string) *DropPolicyNode
+type DropRoleNode struct{ ... }
+    func NewDropRole(name string) *DropRoleNode
+type DropTableNode struct{ ... }
+    func NewDropTable(name string) *DropTableNode
+type DropTriggerNode struct{ ... }
+    func NewDropTrigger(name, table string) *DropTriggerNode
+type DropTypeNode struct{ ... }
+    func NewDropType(name string) *DropTypeNode
+type DropViewNode struct{ ... }
+    func NewDropView(name string) *DropViewNode
+type EnumNode struct{ ... }
+    func NewEnum(name string, values ...string) *EnumNode
+type EnumTypeDef struct{ ... }
+    func NewEnumTypeDef(values ...string) *EnumTypeDef
+type ExtensionNode struct{ ... }
+    func NewExtension(name string) *ExtensionNode
+type ForeignKeyRef struct{ ... }
+type FunctionBodyKind string
+    const FunctionBodyQuoted FunctionBodyKind = "quoted" ...
+type GrantPrivilegeNode struct{ ... }
+    func NewGrantPrivilege(role, objectType, objectName string, privileges []string) *GrantPrivilegeNode
+type IndexNode struct{ ... }
+    func NewIndex(name, table string, columns ...string) *IndexNode
+type IndexPart struct{ ... }
+type ModifyColumnOperation struct{ ... }
+type ModifyTTLOperation struct{ ... }
+type MySQLRoutineBody struct{ ... }
+type MySQLRoutineCursor struct{ ... }
+type MySQLRoutineDeclaration struct{ ... }
+type MySQLRoutineDeclarationKind string
+    const MySQLRoutineDeclarationVariable MySQLRoutineDeclarationKind = "variable" ...
+type MySQLRoutineHandler struct{ ... }
+type MySQLRoutineNode struct{ ... }
+    func NewMySQLRoutine(sql, dialect string, kind RoutineKind) *MySQLRoutineNode
+type MySQLRoutineStatement struct{ ... }
+type MySQLRoutineStatementKind string
+    const MySQLRoutineStatementRaw MySQLRoutineStatementKind = "raw" ...
+type Node interface{ ... }
+type OpaqueRoutineNode struct{ ... }
+    func NewOpaqueRoutine(sql, dialect string, kind RoutineKind) *OpaqueRoutineNode
+type PartitionPart struct{ ... }
+type PartitionSpec struct{ ... }
+type PostgresDoBlockNode struct{ ... }
+    func NewPostgresDoBlock(sql string) *PostgresDoBlockNode
+type PostgresRoutineBody struct{ ... }
+type PostgresRoutineNode struct{ ... }
+    func NewPostgresRoutine(sql, dialect string, kind RoutineKind) *PostgresRoutineNode
+type PostgresRoutineStatement struct{ ... }
+type PostgresRoutineStatementKind string
+    const PostgresRoutineStatementRaw PostgresRoutineStatementKind = "raw" ...
+type RawSQLNode struct{ ... }
+    func NewRawSQL(sql string) *RawSQLNode
+type RefreshMaterializedViewNode struct{ ... }
+    func NewRefreshMaterializedView(name string) *RefreshMaterializedViewNode
+type RenameColumnOperation struct{ ... }
+type RenameEnumValueOperation struct{ ... }
+    func NewRenameEnumValueOperation(oldValue, newValue string) *RenameEnumValueOperation
+type RenameTableOperation struct{ ... }
+type RenameTypeOperation struct{ ... }
+    func NewRenameTypeOperation(newName string) *RenameTypeOperation
+type RevokePrivilegeNode struct{ ... }
+    func NewRevokePrivilege(role, objectType, objectName string, privileges []string) *RevokePrivilegeNode
+type RoleOperation interface{ ... }
+type RoutineKind string
+    const RoutineKindFunction RoutineKind = "function" ...
+type SQLServerRoutineBody struct{ ... }
+type SQLServerRoutineForm string
+    const SQLServerRoutineFormProcedure SQLServerRoutineForm = "procedure" ...
+type SQLServerRoutineNode struct{ ... }
+    func NewSQLServerRoutine(sql, dialect string, kind RoutineKind) *SQLServerRoutineNode
+type SQLServerRoutineStatement struct{ ... }
+type SQLServerRoutineStatementKind string
+    const SQLServerRoutineStatementRaw SQLServerRoutineStatementKind = "raw" ...
+type SetCreateDBOperation struct{ ... }
+    func NewSetCreateDBOperation(createDB bool) *SetCreateDBOperation
+type SetCreateRoleOperation struct{ ... }
+    func NewSetCreateRoleOperation(createRole bool) *SetCreateRoleOperation
+type SetInheritOperation struct{ ... }
+    func NewSetInheritOperation(inherit bool) *SetInheritOperation
+type SetLoginOperation struct{ ... }
+    func NewSetLoginOperation(login bool) *SetLoginOperation
+type SetPasswordOperation struct{ ... }
+    func NewSetPasswordOperation(password string) *SetPasswordOperation
+type SetReplicationOperation struct{ ... }
+    func NewSetReplicationOperation(replication bool) *SetReplicationOperation
+type SetSuperuserOperation struct{ ... }
+    func NewSetSuperuserOperation(superuser bool) *SetSuperuserOperation
+type StatementList struct{ ... }
+type TypeDefinition interface{ ... }
+type TypeOperation interface{ ... }
+type Visitor interface{ ... }
+
+## github.com/stokaro/ptah/core/astbuilder
+
+type ColumnBuilder struct{ ... }
+type ForeignKeyBuilder struct{ ... }
+type IndexBuilder struct{ ... }
+    func NewIndex(name, table string, columns ...string) *IndexBuilder
+type SchemaBuilder struct{ ... }
+    func NewSchema() *SchemaBuilder
+type SchemaColumnBuilder struct{ ... }
+type SchemaForeignKeyBuilder struct{ ... }
+type SchemaIndexBuilder struct{ ... }
+type SchemaTableBuilder struct{ ... }
+type TableBuilder struct{ ... }
+    func NewTable(name string) *TableBuilder
+
+## github.com/stokaro/ptah/core/atlashcl
+
+func Parse(data []byte, filename string) (*goschema.Database, error)
+func ParseFile(path string) (*goschema.Database, error)
+
+## github.com/stokaro/ptah/core/atlashclrender
+
+type Diagnostic struct{ ... }
+type Result struct{ ... }
+    func Render(db *goschema.Database) (Result, error)
+type Severity string
+    const SeverityWarning Severity = "warning"
+
+## github.com/stokaro/ptah/core/convert/dbschematogo
+
+func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Database
+
+## github.com/stokaro/ptah/core/convert/fromschema
+
+func FromConstraint(constraint goschema.Constraint) *ast.ConstraintNode
+func FromDatabase(database goschema.Database, targetPlatform string) *ast.StatementList
+func FromEnum(enum goschema.Enum) *ast.EnumNode
+func FromExtension(extension goschema.Extension) *ast.ExtensionNode
+func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.ColumnNode
+func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.ColumnNode
+func FromFunction(function goschema.Function) *ast.CreateFunctionNode
+func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode
+func FromIndex(index goschema.Index) *ast.IndexNode
+func FromIndexWithTableMapping(index goschema.Index, structToTableMap map[string]string) *ast.IndexNode
+func FromMaterializedView(view goschema.MaterializedView) *ast.CreateMaterializedViewNode
+func FromRLSEnabledTable(rlsEnabled goschema.RLSEnabledTable) *ast.AlterTableEnableRLSNode
+func FromRLSPolicy(policy goschema.RLSPolicy) *ast.CreatePolicyNode
+func FromRole(role goschema.Role) *ast.CreateRoleNode
+func FromTable(table goschema.Table, fields []goschema.Field, enums []goschema.Enum, ...) *ast.CreateTableNode
+func FromTrigger(trigger goschema.Trigger) *ast.CreateTriggerNode
+func FromView(view goschema.View) *ast.CreateViewNode
+func GenerateForeignKeyName(tableName, fieldName string) string
+func ParseForeignKeyReference(foreign string) *ast.ForeignKeyRef
+func ProcessEmbeddedFields(embeddedFields []goschema.EmbeddedField, originalFields []goschema.Field) []goschema.Field
+
+## github.com/stokaro/ptah/core/convert/toschema
+
+func MergeFieldOverrides(baseField goschema.Field, platformFields map[string]goschema.Field) goschema.Field
+func MergeTableOverrides(baseTable goschema.Table, platformTables map[string]goschema.Table) goschema.Table
+func ToConstraint(constraint *ast.ConstraintNode, structName, tableName string) (goschema.Constraint, bool)
+func ToDatabase(statements *ast.StatementList) goschema.Database
+func ToEnum(enum *ast.EnumNode) goschema.Enum
+func ToExtension(extension *ast.ExtensionNode) goschema.Extension
+func ToField(column *ast.ColumnNode, structName, sourcePlatform string) goschema.Field
+func ToIndex(index *ast.IndexNode) goschema.Index
+func ToTable(table *ast.CreateTableNode, sourcePlatform string) goschema.Table
+
+## github.com/stokaro/ptah/core/goschema
+
+func Deduplicate(r *Database)
+func Finalize(r *Database)
+func GetDependencyInfo(r *Database) string
+func QualifyTableName(schema, table string) string
+func UniqueStructNames(embeddedFields []EmbeddedField) []string
+type Constraint struct{ ... }
+type Database struct{ ... }
+    func ParseDir(rootDir string) (*Database, error)
+    func ParseFS(fsys fs.FS, rootDir string) (*Database, error)
+    func ParseFile(filename string) (Database, error)
+    func ParseFileWithDependencies(filename string) (Database, error)
+    func ParseSource(filename string, source any) (Database, error)
+type EmbeddedField struct{ ... }
+type Enum struct{ ... }
+type Extension struct{ ... }
+type Field struct{ ... }
+type Function struct{ ... }
+type Grant struct{ ... }
+type Index struct{ ... }
+type IndexPart struct{ ... }
+type MaterializedView struct{ ... }
+type PartitionPart struct{ ... }
+type PartitionSpec struct{ ... }
+type PrimaryKeyPart struct{ ... }
+type RLSEnabledTable struct{ ... }
+type RLSPolicy struct{ ... }
+type Role struct{ ... }
+type Schema struct{ ... }
+type SelfReferencingFK struct{ ... }
+type Table struct{ ... }
+type Trigger struct{ ... }
+type View struct{ ... }
+
+## github.com/stokaro/ptah/core/lexer
+
+type Lexer struct{ ... }
+    func NewLexer(input string) *Lexer
+type Token struct{ ... }
+type TokenType int
+    const TokenUnknown TokenType = iota ...
+
+## github.com/stokaro/ptah/core/parser
+
+type Option func(*Parser)
+    func WithCapabilities(capabilities capability.Capabilities) Option
+    func WithDialect(dialect string) Option
+    func WithTimeout(timeout time.Duration) Option
+type Parser struct{ ... }
+    func NewParser(input string, opts ...Option) *Parser
+
+## github.com/stokaro/ptah/core/platform
+
+const Postgres = "postgres" ...
+func IsPostgresFamily(dialect string) bool
+func NormalizeDialect(dialect string) string
+
+## github.com/stokaro/ptah/core/platform/capability
+
+func Doc(key Capability) string
+type Capabilities map[Capability]bool
+    func ClickHouse24() Capabilities
+    func CockroachDB23() Capabilities
+    func ForDialect(dialect string) Capabilities
+    func ForServerVersion(dialect, version string) Capabilities
+    func ForServerVersionResult(dialect, version string) (Capabilities, bool)
+    func MariaDB1011() Capabilities
+    func MariaDBLegacy() Capabilities
+    func MySQL80() Capabilities
+    func MySQL8016() Capabilities
+    func MySQLLegacy() Capabilities
+    func Postgres13() Capabilities
+    func Postgres16() Capabilities
+    func Postgres17() Capabilities
+    func SQLite3() Capabilities
+    func SpannerPostgres() Capabilities
+    func YugabyteDB25() Capabilities
+type Capability string
+    const DropConstraintGeneric Capability = "drop_constraint_generic" ...
+    func All() []Capability
+
+## github.com/stokaro/ptah/core/ptaherr
+
+var ErrUnsupportedDialect = errors.New("unsupported database dialect") ...
+type CapabilityError struct{ ... }
+type ParseError struct{ ... }
+type PlanError struct{ ... }
+type RenderError struct{ ... }
+
+## github.com/stokaro/ptah/core/renderer
+
+func GetOrderedCreateStatements(r *goschema.Database, dialect string) []string
+func GetOrderedCreateStatementsE(r *goschema.Database, dialect string) ([]string, error)
+func GetOrderedCreateStatementsWithCapabilities(r *goschema.Database, dialect string, caps capability.Capabilities) []string
+func GetOrderedCreateStatementsWithCapabilitiesE(r *goschema.Database, dialect string, caps capability.Capabilities) ([]string, error)
+func NewRenderer(dialect string) (types.RenderVisitor, error)
+func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (types.RenderVisitor, error)
+func RenderSQL(dialect string, nodes ...ast.Node) (string, error)
+func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nodes ...ast.Node) (string, error)
+func SupportedDialects() []string
+func VisitorRenderSQL(r types.RenderVisitor, nodes ...ast.Node) (string, error)
+
+## github.com/stokaro/ptah/core/renderer/dialects/clickhouse
+
+const DialectName = "clickhouse"
+type Renderer struct{ ... }
+    func New() *Renderer
+
+## github.com/stokaro/ptah/core/renderer/dialects/mariadb
+
+type Renderer struct{ ... }
+    func New() *Renderer
+    func NewWithCapabilities(caps capability.Capabilities) *Renderer
+
+## github.com/stokaro/ptah/core/renderer/dialects/mysql
+
+type Renderer struct{ ... }
+    func New() *Renderer
+    func NewWithCapabilities(caps capability.Capabilities) *Renderer
+
+## github.com/stokaro/ptah/core/renderer/dialects/mysqllike
+
+type Renderer struct{ ... }
+    func New(dialect string, buf *bufwriter.Writer) *Renderer
+    func NewWithCapabilities(dialect string, buf *bufwriter.Writer, caps capability.Capabilities) *Renderer
+
+## github.com/stokaro/ptah/core/renderer/dialects/postgres
+
+type Renderer struct{ ... }
+    func New() *Renderer
+    func NewWithCapabilities(caps capability.Capabilities, dialect string) *Renderer
+
+## github.com/stokaro/ptah/core/renderer/dialects/sqlite
+
+const DialectName = "sqlite"
+type Renderer struct{ ... }
+    func New() *Renderer
+
+## github.com/stokaro/ptah/core/renderer/types
+
+type RenderVisitor interface{ ... }
+
+## github.com/stokaro/ptah/core/sqllint
+
+const RuleParseError = "SQL001" ...
+type Context struct{ ... }
+type Finding struct{ ... }
+    func LintSource(source Source, opts Options) ([]Finding, error)
+type Options struct{ ... }
+type Rule interface{ ... }
+    func DefaultRules() []Rule
+type Severity string
+    const SeverityInfo Severity = "info" ...
+type Source struct{ ... }
+
+## github.com/stokaro/ptah/core/sqlutil
+
+func IsSQLServerGoBatchSeparatorAt(input string, start, end int) bool
+func IsScalarIFExpressionFragment(fragment string) bool
+func NormalizeClientDelimiters(input string) string
+func Rebind(dialect, query string) string
+func SplitSQLStatements(sql string) []string
+func SplitSQLStatementsForDialect(sql string, dialect string) []string
+func StripComments(sql string) string
+
+## github.com/stokaro/ptah/core/yamlschema
+
+func Parse(data []byte) (*goschema.Database, error)
+func ParseFile(path string) (*goschema.Database, error)
+
+## github.com/stokaro/ptah/dbschema
+
+func CloseAndWarn(conn *DatabaseConnection)
+func FormatDatabaseURL(dbURL string) string
+func ReadSchemaWithSchemas(conn *DatabaseConnection, schemas []string) (*types.DBSchema, error)
+type DatabaseConnection struct{ ... }
+    func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, error)
+
+## github.com/stokaro/ptah/dbschema/clickhouse
+
+type Reader struct{ ... }
+    func NewClickHouseReader(db *sql.DB, schema string) *Reader
+type Writer struct{ ... }
+    func NewClickHouseWriter(db *sql.DB, schema string) *Writer
+
+## github.com/stokaro/ptah/dbschema/mysql
+
+type Reader struct{ ... }
+    func NewMySQLReader(db *sql.DB, schema string) *Reader
+type Writer struct{ ... }
+    func NewMySQLWriter(db *sql.DB, schema string) *Writer
+
+## github.com/stokaro/ptah/dbschema/postgres
+
+type ExcludeConstraintDefinition struct{ ... }
+type PostgreSQLWriter struct{ ... }
+    func NewPostgreSQLWriter(db *sql.DB, schema string) *PostgreSQLWriter
+type Reader struct{ ... }
+    func NewPostgreSQLReader(db *sql.DB, schema string) *Reader
+    func NewPostgreSQLReaderWithCapabilities(db *sql.DB, schema string, caps capability.Capabilities) *Reader
+
+## github.com/stokaro/ptah/dbschema/sqlite
+
+type Reader struct{ ... }
+    func NewSQLiteReader(db *sql.DB, schema string) *Reader
+type Writer struct{ ... }
+    func NewSQLiteWriter(db *sql.DB, schema string) *Writer
+
+## github.com/stokaro/ptah/dbschema/types
+
+func QualifyTableName(schema, table string) string
+type DBColumn struct{ ... }
+type DBConstraint struct{ ... }
+type DBEnum struct{ ... }
+type DBExtension struct{ ... }
+type DBFunction struct{ ... }
+type DBGrant struct{ ... }
+type DBIndex struct{ ... }
+type DBInfo struct{ ... }
+type DBMatView struct{ ... }
+type DBRLSPolicy struct{ ... }
+type DBRole struct{ ... }
+type DBSchema struct{ ... }
+type DBTable struct{ ... }
+type DBTrigger struct{ ... }
+type DBView struct{ ... }
+type SchemaReader interface{ ... }
+type SchemaWriter interface{ ... }
+
+## github.com/stokaro/ptah/migration/generator
+
+func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
+type BaselineShadowVerifyOptions struct{ ... }
+type EmptyMigrationOptions struct{ ... }
+type GenerateMigrationOptions struct{ ... }
+type MigrationFilePair struct{ ... }
+type MigrationFiles struct{ ... }
+    func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
+    func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error)
+type ShadowMismatch struct{ ... }
+type ShadowVerificationError struct{ ... }
+type ShadowVerificationResult struct{ ... }
+
+## github.com/stokaro/ptah/migration/lint
+
+const ConfigFileName = ".ptah-lint.yaml"
+func Describe(f Finding) string
+func Register(rule Rule) error
+type Config struct{ ... }
+    func LoadConfig(path string) (*Config, error)
+    func LoadConfigFS(fsys fs.FS, name string) (*Config, error)
+type File struct{ ... }
+    func PrepareFS(fsys fs.FS, opts Options) ([]*File, error)
+type Finding struct{ ... }
+    func LintFS(fsys fs.FS, opts Options) ([]Finding, error)
+type Options struct{ ... }
+type Rule struct{ ... }
+    func Rules() []Rule
+type RuleConfig struct{ ... }
+type Severity = risk.Severity
+    const SeverityWarning Severity = risk.Warning ...
+type Statement struct{ ... }
+
+## github.com/stokaro/ptah/migration/migratesum
+
+const AtlasFileName = "atlas.sum"
+const FileName = "ptah.sum"
+var ErrSumFileMissing = errors.New("ptah.sum not found; run `ptah migrate-hash` to create it")
+func FileNameForFormat(format migrator.MigrationDirFormat) (string, error)
+type Entry struct{ ... }
+type Result struct{ ... }
+    func Verify(fsys fs.FS) (*Result, error)
+    func VerifyDir(dir string) (*Result, error)
+    func VerifyDirWithFormat(dir string, format migrator.MigrationDirFormat) (*Result, error)
+    func VerifyWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*Result, error)
+type SumFile struct{ ... }
+    func Compute(fsys fs.FS) (*SumFile, error)
+    func ComputeWithFormat(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error)
+    func Parse(data []byte) (*SumFile, error)
+    func Write(dir string) (*SumFile, error)
+    func WriteWithFormat(dir string, format migrator.MigrationDirFormat) (*SumFile, error)
+
+## github.com/stokaro/ptah/migration/migrator
+
+const DirectiveNoTransaction = "no_transaction"
+func FindMigrationGaps(versions []int64) []int64
+func GenerateMigrationFileName(version int64, description, direction string) string
+func GetNextMigrationVersion() int64
+func GroupMigrationFiles(files []MigrationFile) map[int64]MigrationPair
+func IsDirtyMigration(err error) bool
+func IsMigrationLockTimeout(err error) bool
+func LooksAtlasTemplateSQL(sql string) bool
+func MigrationFuncFromSQLFilenameWithTimeouts(filename string, fsys fs.FS) (MigrationFunc, MigrationTimeouts, error)
+func MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) (MigrationFunc, MigrationTimeouts, error)
+func NoopMigrationFunc(_ctx context.Context, _conn *dbschema.DatabaseConnection) error
+func ParseFileDirectives(sql string) map[string]string
+func ParseMigrationLockTimeout(value string) (time.Duration, error)
+func RenderAtlasTemplateSQL(fsys fs.FS, filename string, data any) (sql string, rendered bool, err error)
+func SplitSQLStatements(sql string) []string
+func ValidateMigrationFileName(filename string) bool
+func ValidateMigrationPairs(pairs map[int64]MigrationPair) []int64
+type AtlasDownNotImplementedError struct{ ... }
+type AtlasTemplateData struct{ ... }
+type BaselineOptions struct{ ... }
+type ChecksumMismatchError struct{ ... }
+type DirtyMigrationError struct{ ... }
+type ExecOrder string
+    const ExecOrderLinear ExecOrder = "linear" ...
+    func ParseExecOrder(value string) (ExecOrder, error)
+type FSMigrationProvider struct{ ... }
+    func NewFSMigrationProvider(fsys fs.FS, opts ...FSProviderOption) (*FSMigrationProvider, error)
+type FSProviderOption func(*FSMigrationProvider)
+    func WithAtlasTemplateData(data any) FSProviderOption
+    func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption
+    func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
+type Migration struct{ ... }
+    func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration
+type MigrationDirFormat string
+    const MigrationDirFormatAuto MigrationDirFormat = "auto" ...
+    func ParseMigrationDirFormat(value string) (MigrationDirFormat, error)
+type MigrationExecutionError struct{ ... }
+type MigrationFile struct{ ... }
+    func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationFile, error)
+    func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error)
+    func ParseAtlasMigrationFileNameForAutoDetection(filename string) (*MigrationFile, error)
+    func ParseMigrationFileName(filename string) (*MigrationFile, error)
+type MigrationFunc func(context.Context, *dbschema.DatabaseConnection) error
+    func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc
+    func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc
+type MigrationLockTimeoutError struct{ ... }
+type MigrationPair struct{ ... }
+type MigrationProvider interface{ ... }
+type MigrationRevision struct{ ... }
+type MigrationStatus struct{ ... }
+type MigrationTimeouts struct{ ... }
+    func ParseMigrationTimeouts(lockTimeout, statementTimeout string) (MigrationTimeouts, error)
+type Migrator struct{ ... }
+    func NewFSMigrator(conn *dbschema.DatabaseConnection, fsys fs.FS, opts ...FSProviderOption) (*Migrator, error)
+    func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) *Migrator
+type OutOfOrderError struct{ ... }
+    func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
+type RegisteredMigrationProvider struct{ ... }
+    func NewRegisteredMigrationProvider(migrations ...*Migration) *RegisteredMigrationProvider
+type RepairMigrationOptions struct{ ... }
+type RevisionTableFormat string
+    const RevisionTableFormatPtah RevisionTableFormat = "ptah" ...
+    func ParseRevisionTableFormat(value string) (RevisionTableFormat, error)
+type StatementInterceptor interface{ ... }
+
+## github.com/stokaro/ptah/migration/onlineddl
+
+const ToolGhost = "ghost" ...
+const FallbackError = "error" ...
+const ConfigFileName = "ptah.yaml"
+const DirectiveFallback = "online_ddl_fallback"
+const DirectiveNone = "none"
+const DirectiveTool = "online_ddl_tool"
+type AlterTarget struct{ ... }
+    func ParseAlterTable(stmt string) (AlterTarget, bool)
+type CommandRunner func(ctx context.Context, binary string, args []string) error
+type Config struct{ ... }
+    func LoadConfig(path string) (*Config, error)
+    func LoadConfigForEnv(path, envName string) (*Config, error)
+type Conn interface{ ... }
+type DSN struct{ ... }
+    func ParseDatabaseURL(dbURL string) (DSN, error)
+type Executor struct{ ... }
+    func New(cfg Config) *Executor
+
+## github.com/stokaro/ptah/migration/planner
+
+func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]ast.Node, error)
+func GenerateSchemaDiffASTWithCapabilities(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) ([]ast.Node, error)
+func GenerateSchemaDiffASTWithOptions(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) ([]ast.Node, error)
+func GenerateSchemaDiffSQL(diff *types.SchemaDiff, generated *goschema.Database, dialect string) (string, error)
+func GenerateSchemaDiffSQLStatements(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]string, error)
+func GenerateSchemaDiffSQLStatementsWithCapabilities(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) ([]string, error)
+func GenerateSchemaDiffSQLStatementsWithOptions(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) ([]string, error)
+func GenerateSchemaDiffSQLWithCapabilities(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) (string, error)
+func GenerateSchemaDiffSQLWithOptions(diff *types.SchemaDiff, generated *goschema.Database, dialect string, ...) (string, error)
+func NodeRequiresNoTransaction(dialect string, node ast.Node) bool
+func Register(dialect string, factory Factory) error
+func RegisteredDialects() []string
+func RequiresNoTransaction(dialect string, nodes []ast.Node) bool
+type Factory = registry.Factory
+type Options = registry.Options
+type Planner = registry.Planner
+    func GetPlanner(dialect string) (Planner, error)
+    func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (Planner, error)
+    func GetPlannerWithOptions(dialect string, opts Options) (Planner, error)
+
+## github.com/stokaro/ptah/migration/planner/dialects/clickhouse
+
+type Planner struct{}
+    func New() *Planner
+
+## github.com/stokaro/ptah/migration/planner/dialects/mysql
+
+const DialectName = "mysql"
+type Planner struct{ ... }
+    func New() *Planner
+    func NewWithCapabilities(caps capability.Capabilities) *Planner
+
+## github.com/stokaro/ptah/migration/planner/dialects/postgres
+
+const DialectName = "postgres"
+type Planner struct{ ... }
+    func New() *Planner
+    func NewWithCapabilities(caps capability.Capabilities) *Planner
+
+## github.com/stokaro/ptah/migration/planner/dialects/sqlite
+
+const DialectName = platform.SQLite
+type Planner struct{}
+    func New() *Planner
+
+## github.com/stokaro/ptah/migration/planner/registry
+
+func Register(dialect string, factory Factory) error
+func RegisteredDialects() []string
+type Factory func(Options) Planner
+type Options struct{ ... }
+type Planner interface{ ... }
+    func Get(dialect string, opts Options) (Planner, error)
+
+## github.com/stokaro/ptah/migration/risk
+
+func IsBlocking(severity Severity) bool
+func Rank(severity Severity) int
+func SARIFLevel(severity Severity) string
+type Severity string
+    const Safe Severity = "safe" ...
+
+## github.com/stokaro/ptah/migration/safety
+
+func HasDestructive(findings []Finding) bool
+func HasDestructiveAssessment(assessments []StatementAssessment) bool
+func IsTypeNarrowing(oldType, newType string) bool
+func RenderHTML(w io.Writer, assessments []StatementAssessment) error
+func RenderJSON(w io.Writer, assessments []StatementAssessment) error
+func RenderText(w io.Writer, assessments []StatementAssessment) error
+type Finding struct{ ... }
+    func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding
+type Report struct{ ... }
+    func NewReport(assessments []StatementAssessment) Report
+type Severity = risk.Severity
+    const Safe Severity = risk.Safe ...
+    func Classify(node ast.Node) Severity
+    func Highest(findings []Finding) Severity
+    func HighestAssessment(assessments []StatementAssessment) Severity
+type StatementAssessment struct{ ... }
+    func Assess(nodes []ast.Node) []StatementAssessment
+    func AssessRendered(nodes []ast.Node, dialect string) ([]StatementAssessment, error)
+    func AssessRenderedWithCapabilities(nodes []ast.Node, dialect string, caps capability.Capabilities) ([]StatementAssessment, error)
+    func AssessSQL(statement string) StatementAssessment
+
+## github.com/stokaro/ptah/migration/schemadiff
+
+func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.SchemaDiff
+func CompareWithDialect(generated *goschema.Database, database *types.DBSchema, dialect string) *difftypes.SchemaDiff
+func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, ...) *difftypes.SchemaDiff
+
+## github.com/stokaro/ptah/migration/schemadiff/types
+
+type ColumnDiff struct{ ... }
+type ConstraintAdditionInfo struct{ ... }
+type ConstraintRemovalInfo struct{ ... }
+type EnumDiff struct{ ... }
+type FunctionDiff struct{ ... }
+type GrantRef struct{ ... }
+type IndexRemovalInfo struct{ ... }
+type MaterializedViewDiff struct{ ... }
+type RLSPolicyDiff struct{ ... }
+type RLSPolicyRef struct{ ... }
+type RoleDiff struct{ ... }
+type SchemaDiff struct{ ... }
+type TableDiff struct{ ... }
+type TriggerDiff struct{ ... }
+type TriggerRef struct{ ... }
+type ViewDiff struct{ ... }
+
+## github.com/stokaro/ptah/migration/seeder
+
+func DefaultProtectedEnvs() []string
+func IsConflictError(err error) bool
+func ValidateOptions(opts Options) error
+type Options struct{ ... }
+type Result struct{ ... }
+    func Apply(ctx context.Context, conn *dbschema.DatabaseConnection, fsys fs.FS, ...) (*Result, error)
+type SeedFile struct{ ... }
+    func Discover(fsys fs.FS) ([]SeedFile, error)
+    func Select(seeds []SeedFile, env string) []SeedFile
+
+## github.com/stokaro/ptah/migration/typechange
+
+func IsNarrowing(oldType, newType string) bool
+func Same(left, right string) bool
+

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -633,7 +634,13 @@ func (p *Planner) rejectMaterializedViews(diff *types.SchemaDiff) error {
 		len(diff.MaterializedViewsRemoved) == 0 {
 		return nil
 	}
-	return fmt.Errorf("materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target")
+	message := "materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target"
+	return &ptaherr.CapabilityError{
+		Dialect: DialectName,
+		Feature: "materialized views",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: message,
+	}
 }
 
 func (p *Planner) addNewViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {

--- a/migration/planner/dialects/mysql/schema_objects_test.go
+++ b/migration/planner/dialects/mysql/schema_objects_test.go
@@ -6,6 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer"
 	migrationplanner "github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
@@ -93,6 +94,7 @@ func TestPlanner_GenerateMigrationAST_RejectsMaterializedViews(t *testing.T) {
 
 	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
 	c.Assert(nodes, qt.IsNil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
 	c.Assert(err, qt.ErrorMatches, "materialized views are not supported by MySQL or MariaDB.*")
 
 	c.Assert(func() {

--- a/migration/planner/dialects/sqlite/sqlite.go
+++ b/migration/planner/dialects/sqlite/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -76,31 +77,31 @@ func rejectUnsupportedTableChanges(diff *types.SchemaDiff) error {
 	for _, table := range diff.TablesModified {
 		switch {
 		case len(table.ColumnsRemoved) > 0:
-			return fmt.Errorf("sqlite: dropping columns from table %s requires a table rebuild plan", table.TableName)
+			return unsupportedFeaturef("dropping columns from table %s requires a table rebuild plan", table.TableName)
 		case len(table.ColumnsModified) > 0:
-			return fmt.Errorf("sqlite: modifying columns on table %s requires a table rebuild plan", table.TableName)
+			return unsupportedFeaturef("modifying columns on table %s requires a table rebuild plan", table.TableName)
 		case len(table.ConstraintsAdded) > 0 || len(table.ConstraintsRemoved) > 0:
-			return fmt.Errorf("sqlite: changing constraints on table %s requires a table rebuild plan", table.TableName)
+			return unsupportedFeaturef("changing constraints on table %s requires a table rebuild plan", table.TableName)
 		}
 	}
 	if len(diff.ConstraintsAdded) > 0 || len(diff.ConstraintsRemoved) > 0 {
-		return fmt.Errorf("sqlite: changing constraints on existing tables requires a table rebuild plan")
+		return unsupportedFeaturef("changing constraints on existing tables requires a table rebuild plan")
 	}
 	if len(diff.EnumsModified) > 0 || len(diff.EnumsRemoved) > 0 {
-		return fmt.Errorf("sqlite: changing enum-backed CHECK constraints requires a table rebuild plan")
+		return unsupportedFeaturef("changing enum-backed CHECK constraints requires a table rebuild plan")
 	}
 	return nil
 }
 
 func rejectUnsupportedSchemaObjects(diff *types.SchemaDiff) error {
 	if len(diff.MaterializedViewsAdded) > 0 || len(diff.MaterializedViewsModified) > 0 || len(diff.MaterializedViewsRemoved) > 0 {
-		return fmt.Errorf("sqlite: materialized views are not supported")
+		return unsupportedFeaturef("materialized views are not supported")
 	}
 	if len(diff.ExtensionsAdded) > 0 || len(diff.ExtensionsRemoved) > 0 {
-		return fmt.Errorf("sqlite: extensions are not supported")
+		return unsupportedFeaturef("extensions are not supported")
 	}
 	if len(diff.FunctionsAdded) > 0 || len(diff.FunctionsModified) > 0 || len(diff.FunctionsRemoved) > 0 {
-		return fmt.Errorf("sqlite: functions are not supported")
+		return unsupportedFeaturef("functions are not supported")
 	}
 	return nil
 }
@@ -108,12 +109,12 @@ func rejectUnsupportedSchemaObjects(diff *types.SchemaDiff) error {
 func rejectUnsupportedAccessControl(diff *types.SchemaDiff) error {
 	if len(diff.RLSPoliciesAdded) > 0 || len(diff.RLSPoliciesModified) > 0 || len(diff.RLSPoliciesRemoved) > 0 ||
 		len(diff.RLSEnabledTablesAdded) > 0 || len(diff.RLSEnabledTablesRemoved) > 0 {
-		return fmt.Errorf("sqlite: row-level security is not supported")
+		return unsupportedFeaturef("row-level security is not supported")
 	}
 	if len(diff.RolesAdded) > 0 || len(diff.RolesModified) > 0 || len(diff.RolesRemoved) > 0 ||
 		len(diff.GrantsAdded) > 0 || len(diff.GrantsRemoved) > 0 ||
 		len(diff.GrantOptionsAdded) > 0 || len(diff.GrantOptionsRevoked) > 0 {
-		return fmt.Errorf("sqlite: roles and grants are not supported")
+		return unsupportedFeaturef("roles and grants are not supported")
 	}
 	return nil
 }
@@ -144,7 +145,7 @@ func addInlineConstraints(node *ast.CreateTableNode, table goschema.Table, const
 			continue
 		}
 		if strings.EqualFold(constraint.Type, "EXCLUDE") {
-			return fmt.Errorf("sqlite: EXCLUDE constraints are not supported")
+			return unsupportedFeaturef("EXCLUDE constraints are not supported")
 		}
 		if slices.ContainsFunc(node.Constraints, func(existing *ast.ConstraintNode) bool {
 			return existing.Name != "" && existing.Name == constraint.Name
@@ -228,7 +229,7 @@ func validateAddedColumn(tableName string, column *ast.ColumnNode) error {
 }
 
 func sqliteColumnRebuildError(tableName, columnName string) error {
-	return fmt.Errorf("sqlite: adding column %s to table %s requires a table rebuild plan", columnName, tableName)
+	return unsupportedFeaturef("adding column %s to table %s requires a table rebuild plan", columnName, tableName)
 }
 
 func hasNonNullLiteralDefault(defaultValue *ast.DefaultValue) bool {
@@ -392,4 +393,14 @@ func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *go
 		}
 	}
 	return nil
+}
+
+func unsupportedFeaturef(format string, args ...any) error {
+	message := fmt.Sprintf("sqlite: "+format, args...)
+	return &ptaherr.CapabilityError{
+		Dialect: DialectName,
+		Feature: message,
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: message,
+	}
 }

--- a/migration/planner/dialects/sqlite/sqlite_test.go
+++ b/migration/planner/dialects/sqlite/sqlite_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -144,6 +145,10 @@ func TestPlannerRejectsAddColumnShapesThatNeedRebuild(t *testing.T) {
 
 			nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.SQLite)
 			c.Assert(nodes, qt.IsNil)
+			var planErr *ptaherr.PlanError
+			c.Assert(err, qt.ErrorAs, &planErr)
+			c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
 			c.Assert(err, qt.ErrorMatches, `sqlite: adding column `+tt.field.Name+` to table users requires a table rebuild plan`)
 		})
 	}
@@ -222,6 +227,10 @@ func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
 
 			nodes, err := planner.GenerateSchemaDiffAST(tt.diff, generated, platform.SQLite)
 			c.Assert(nodes, qt.IsNil)
+			var planErr *ptaherr.PlanError
+			c.Assert(err, qt.ErrorAs, &planErr)
+			c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
 			c.Assert(err, qt.ErrorMatches, tt.want)
 		})
 	}

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -327,11 +327,9 @@ func registerMySQLFamilyPlanner(dialect string) error {
 //   - GenerateSchemaDiffSQLStatements: For individual SQL statements
 //   - GetPlanner: For direct planner access
 func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]ast.Node, error) {
-	planner, err := GetPlannerWithCapabilities(dialect, capability.ForDialect(dialect))
-	if err != nil {
-		return nil, err
-	}
-	return planner.GenerateMigrationASTChecked(diff, generated)
+	return GenerateSchemaDiffASTWithOptions(diff, generated, dialect, Options{
+		Capabilities: capability.ForDialect(dialect),
+	})
 }
 
 // GenerateSchemaDiffASTWithCapabilities generates AST nodes for a concrete

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -66,12 +66,14 @@
 package planner
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/migration/planner/dialects/clickhouse"
@@ -353,9 +355,13 @@ func GenerateSchemaDiffASTWithOptions(
 ) ([]ast.Node, error) {
 	planner, err := GetPlannerWithOptions(dialect, opts)
 	if err != nil {
-		return nil, err
+		return nil, wrapPlanError(dialect, err)
 	}
-	return planner.GenerateMigrationASTChecked(diff, generated)
+	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	if err != nil {
+		return nil, wrapPlanError(dialect, err)
+	}
+	return nodes, nil
 }
 
 // NodeRequiresNoTransaction reports whether a single planned AST node must run
@@ -562,7 +568,37 @@ func GenerateSchemaDiffSQLWithOptions(
 	}
 	output, err := renderer.RenderSQLWithCapabilities(dialect, caps, astNodes...)
 	if err != nil {
-		return "", err
+		return "", wrapRenderError(dialect, err)
 	}
 	return output, nil
+}
+
+func wrapPlanError(dialect string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var planErr *ptaherr.PlanError
+	if errors.As(err, &planErr) {
+		return err
+	}
+	return &ptaherr.PlanError{
+		Dialect: dialect,
+		Err:     err,
+		Message: err.Error(),
+	}
+}
+
+func wrapRenderError(dialect string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var renderErr *ptaherr.RenderError
+	if errors.As(err, &renderErr) {
+		return err
+	}
+	return &ptaherr.RenderError{
+		Dialect: dialect,
+		Err:     err,
+		Message: err.Error(),
+	}
 }

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -170,12 +170,28 @@ func TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError(t *testing.T) {
 
 	sql, err := planner.GenerateSchemaDiffSQL(&types.SchemaDiff{}, &goschema.Database{}, "sqlserver")
 	c.Assert(sql, qt.Equals, "")
-	c.Assert(err, qt.ErrorMatches, "unsupported database dialect: sqlserver")
 	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
 
 	var planErr *ptaherr.PlanError
 	c.Assert(err, qt.ErrorAs, &planErr)
 	c.Assert(planErr.Dialect, qt.Equals, "sqlserver")
+}
+
+func TestGenerateSchemaDiffAST_WrapsPlannerFailures(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{TablesModified: []types.TableDiff{
+		{TableName: "users", ColumnsRemoved: []string{"name"}},
+	}}
+
+	nodes, err := planner.GenerateSchemaDiffAST(diff, &goschema.Database{}, platform.SQLite)
+
+	c.Assert(nodes, qt.IsNil)
+	var planErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &planErr)
+	c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, "sqlite: dropping columns from table users requires a table rebuild plan")
 }
 
 func TestRequiresNoTransaction(t *testing.T) {

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	dbtypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/planner/dialects/mysql"
@@ -159,9 +160,22 @@ func TestGetPlannerRejectsFactoryReturningNil(t *testing.T) {
 func TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError(t *testing.T) {
 	c := qt.New(t)
 
+	nodes, err := planner.GenerateSchemaDiffAST(&types.SchemaDiff{}, &goschema.Database{}, "sqlserver")
+	c.Assert(nodes, qt.IsNil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
+
+	var astPlanErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &astPlanErr)
+	c.Assert(astPlanErr.Dialect, qt.Equals, "sqlserver")
+
 	sql, err := planner.GenerateSchemaDiffSQL(&types.SchemaDiff{}, &goschema.Database{}, "sqlserver")
 	c.Assert(sql, qt.Equals, "")
 	c.Assert(err, qt.ErrorMatches, "unsupported database dialect: sqlserver")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
+
+	var planErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &planErr)
+	c.Assert(planErr.Dialect, qt.Equals, "sqlserver")
 }
 
 func TestRequiresNoTransaction(t *testing.T) {

--- a/migration/planner/registry/registry.go
+++ b/migration/planner/registry/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -73,14 +74,22 @@ func Register(dialect string, factory Factory) error {
 func Get(dialect string, opts Options) (Planner, error) {
 	normalized := normalizeRegistryDialect(dialect)
 	if normalized == "" {
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
+		return nil, &ptaherr.PlanError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrUnsupportedDialect,
+			Message: fmt.Sprintf("unsupported database dialect: %s", dialect),
+		}
 	}
 
 	mu.RLock()
 	factory, exists := factories[normalized]
 	mu.RUnlock()
 	if !exists {
-		return nil, fmt.Errorf("unsupported database dialect: %s", dialect)
+		return nil, &ptaherr.PlanError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrUnsupportedDialect,
+			Message: fmt.Sprintf("unsupported database dialect: %s", dialect),
+		}
 	}
 	planner := factory(opts)
 	if planner == nil {

--- a/scripts/check-public-api-snapshot.sh
+++ b/scripts/check-public-api-snapshot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GOWORK=off
+
+snapshot="docs/public_api.snapshot"
+update=0
+if [[ "${1:-}" == "--update" ]]; then
+	update=1
+fi
+
+tmp="$(mktemp)"
+packages="$(mktemp)"
+trap 'rm -f "$tmp" "$packages"' EXIT
+
+grep -Eo '`github\.com/stokaro/ptah[^`]+`' docs/public_api.md |
+	tr -d '`' |
+	sort -u >"$packages"
+
+while IFS= read -r package_path; do
+	printf '## %s\n\n' "$package_path" >>"$tmp"
+	go doc -short "$package_path" | sed 's/[[:space:]]*$//' >>"$tmp"
+	printf '\n' >>"$tmp"
+done <"$packages"
+
+if [[ "$update" -eq 1 ]]; then
+	cp "$tmp" "$snapshot"
+	exit 0
+fi
+
+diff -u "$snapshot" "$tmp"

--- a/scripts/check-public-api.sh
+++ b/scripts/check-public-api.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export GOWORK=off
+
+module_path="$(go list -m -f '{{.Path}}')"
+allowlist="$(mktemp)"
+packages="$(mktemp)"
+trap 'rm -f "$allowlist" "$packages"' EXIT
+
+grep -Eo '`github\.com/stokaro/ptah[^`]+`' docs/public_api.md |
+	tr -d '`' |
+	sort -u >"$allowlist"
+
+go list -f '{{.ImportPath}}|{{.Name}}' ./... >"$packages"
+
+missing=0
+while IFS='|' read -r import_path package_name; do
+	case "$import_path" in
+		"$module_path"/cmd | "$module_path"/cmd/*) continue ;;
+		"$module_path"/examples | "$module_path"/examples/*) continue ;;
+		"$module_path"/integration | "$module_path"/integration/*) continue ;;
+		"$module_path"/stubs) continue ;;
+		"$module_path"/internal | "$module_path"/internal/*) continue ;;
+		"$module_path"/*/internal/*) continue ;;
+		"$module_path"/*/testutil) continue ;;
+		"$module_path"/*/mocks) continue ;;
+	esac
+	if [[ "$package_name" == "main" ]]; then
+		continue
+	fi
+	if ! grep -Fxq "$import_path" "$allowlist"; then
+		printf 'undocumented public package: %s\n' "$import_path" >&2
+		missing=1
+	fi
+done <"$packages"
+
+if [[ "$missing" -ne 0 ]]; then
+	printf 'Add the package to docs/public_api.md or move it behind an internal/ boundary.\n' >&2
+	exit 1
+fi


### PR DESCRIPTION
Refs #271.

## Summary

- add `core/ptaherr` with typed `ParseError`, `PlanError`, `RenderError`, and capability errors
- add sentinels for `errors.Is`: unknown/missing/invalid annotation attributes, unsupported dialect, unsupported feature
- wire typed parse errors through Go schema annotation validation and Go source parse failures
- make `ParseFS` collect multiple per-file parse errors with `errors.Join`
- wire renderer unsupported dialect and node render failures through `*ptaherr.RenderError`
- wire planner unsupported dialect/planning failures through `*ptaherr.PlanError`
- add `docs/public_api.md` with the first public API and typed error contract

## Scope Boundary

This is a first #271 slice, not the full issue closure. Remaining #271 work:

- exported API surface gate in CI
- move or explicitly classify packages not listed in `docs/public_api.md`
- broader typed error coverage for every public package
- removal of legacy no-error planner helpers after dependent tests are migrated

## Self-review

Pass 1:
- checked issue #271 acceptance against this slice and added exact coverage for `GenerateSchemaDiffAST(..., "sqlserver")`
- preserved existing CLI-facing error strings while adding `errors.Is` / `errors.As` behavior
- verified `ParseDir` now returns joined errors for two bad annotations

Pass 2:
- checked parse/render/plan wrapping does not double-wrap already typed errors
- kept filesystem walk errors distinct from per-file parse errors
- documented remaining pre-GA API work instead of pretending this PR completes the whole issue

## Validation

- gopls diagnostics attempted; temp worktree metadata produced stale false positives for the new package, so compiler checks below are authoritative
- `GOWORK=off go test ./core/ptaherr ./core/goschema ./core/renderer ./migration/planner ./migration/planner/registry`
- `GOWORK=off go test ./migration/planner -run TestGenerateSchemaDiffSQL_UnsupportedDialectReturnsError -count=1 -v`
- `GOWORK=off go test ./...`
- `GOWORK=off go tool qtlint ./...`
- `GOWORK=off golangci-lint run ./...`
- `git diff --check`
