### PR TITLE
Redesign native CLI command tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1110,23 +1110,44 @@ Show current migration status and pending migrations:
 - Out-of-order pending migrations
 - Migration history and timestamps
 
-#### Atlas-Compatible CLI Namespace And Exit Codes
+#### Native And Atlas-Compatible CLI Namespaces
 
-Ptah keeps the existing kebab-case commands as native commands, and reserves an
-Atlas-compatible command tree under `ptah atlas <command> ...` for scripts that
-expect Atlas OSS command paths. The native command tree remains separate while
-it is redesigned independently.
+Ptah's native command tree is intentionally separate from the Atlas-compatible
+surface. New Ptah scripts should prefer the grouped native commands documented
+in [Native CLI Command Tree](docs/native_cli.md), while scripts that expect
+Atlas OSS command paths should use `ptah atlas <command> ...`.
+
+| Canonical native command | Legacy compatibility command |
+| --- | --- |
+| `ptah schema render` | `ptah generate` |
+| `ptah schema compare` | `ptah compare` |
+| `ptah schema drift` | `ptah drift` |
+| `ptah db read` | `ptah read-db` |
+| `ptah db drop-all` | `ptah drop-all` |
+| `ptah migrations plan` | `ptah migrate` |
+| `ptah migrations generate` | `ptah migrate generate` |
+| `ptah migrations create` | `ptah migrate new` |
+| `ptah migrations up` | `ptah migrate-up` |
+| `ptah migrations down` | `ptah migrate-down` |
+| `ptah migrations status` | `ptah migrate-status` |
+| `ptah migrations baseline` | `ptah migrate-baseline` |
+| `ptah migrations repair` | `ptah migrate-repair` |
+| `ptah migrations hash` | `ptah migrate-hash` |
+| `ptah migrations validate` | `ptah migrate-validate` |
+| `ptah migrations lint` | `ptah lint` |
+
+Atlas-compatible command paths are available only under `ptah atlas`:
 
 | Atlas-compatible command | Native command |
 | --- | --- |
-| `ptah atlas migrate apply` | `ptah migrate-up` |
-| `ptah atlas migrate down` | `ptah migrate-down` |
-| `ptah atlas migrate status` | `ptah migrate-status` |
-| `ptah atlas migrate hash` | `ptah migrate-hash` |
-| `ptah atlas migrate validate` | `ptah migrate-validate` |
-| `ptah atlas migrate lint` | `ptah lint` |
-| `ptah atlas schema inspect` | `ptah read-db` |
-| `ptah atlas schema diff` | `ptah compare` |
+| `ptah atlas migrate apply` | `ptah migrations up` |
+| `ptah atlas migrate down` | `ptah migrations down` |
+| `ptah atlas migrate status` | `ptah migrations status` |
+| `ptah atlas migrate hash` | `ptah migrations hash` |
+| `ptah atlas migrate validate` | `ptah migrations validate` |
+| `ptah atlas migrate lint` | `ptah migrations lint` |
+| `ptah atlas schema inspect` | `ptah db read` |
+| `ptah atlas schema diff` | `ptah schema compare` |
 
 Atlas-compatible aliases accept the Atlas OSS flag names on the compatibility
 surface and translate implemented flags to the native Ptah flags before

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -90,7 +90,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 		{
 			use:     "inspect",
 			short:   "Inspect a database schema",
-			native:  "read-db",
+			native:  "db read",
 			factory: readdb.NewReadDBCommand,
 			flags: []atlasFlag{
 				atlasNativeString("url", "u", "Database URL to inspect", "db-url"),
@@ -115,7 +115,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 		{
 			use:     "diff",
 			short:   "Diff desired schema against a database",
-			native:  "compare",
+			native:  "schema compare",
 			factory: compare.NewCompareCommand,
 			flags: []atlasFlag{
 				atlasUnsupportedStringArray("from", "", "Source schema target"),
@@ -128,7 +128,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 		{
 			use:     "clean",
 			short:   "Clean database schema objects",
-			native:  "drop-all",
+			native:  "db drop-all",
 			factory: dropall.NewDropAllCommand,
 			flags: []atlasFlag{
 				atlasNativeString("url", "u", "Database URL to clean", "db-url"),
@@ -155,7 +155,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:     "apply",
 			short:   "Apply pending migrations",
-			native:  "migrate-up",
+			native:  "migrations up",
 			factory: migrateup.NewMigrateUpCommand,
 			flags: []atlasFlag{
 				atlasNativeString("url", "u", "Database URL to apply migrations to", "db-url"),
@@ -175,11 +175,11 @@ func newAtlasMigrateCommand() *cobra.Command {
 				atlasString("format", "", "Atlas Go template output format"),
 			},
 		},
-		{use: "down", short: "Roll back migrations", native: "migrate-down", factory: migratedown.NewMigrateDownCommand},
+		{use: "down", short: "Roll back migrations", native: "migrations down", factory: migratedown.NewMigrateDownCommand},
 		{
 			use:     "hash",
 			short:   "Write or update the migration directory checksum",
-			native:  "migrate-hash",
+			native:  "migrations hash",
 			factory: migratehash.NewMigrateHashCommand,
 			flags:   []atlasFlag{atlasNativeString("dir", "", "Migration directory", "dir")},
 		},
@@ -195,7 +195,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:     "lint",
 			short:   "Lint migration files",
-			native:  "lint",
+			native:  "migrations lint",
 			factory: lint.NewLintCommand,
 			flags: []atlasFlag{
 				atlasUnsupportedString("dev-url", "", "Dev database URL"),
@@ -206,7 +206,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:        "new",
 			short:      "Create a new migration file",
-			native:     "migrate new",
+			native:     "migrations create",
 			factory:    migrate.NewMigrateCommand,
 			prefixArgs: []string{"new"},
 			flags:      []atlasFlag{atlasNativeString("dir", "", "Migration directory", "migrations-dir")},
@@ -214,7 +214,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:     "set",
 			short:   "Set migration revision state",
-			native:  "migrate-repair",
+			native:  "migrations repair",
 			factory: migraterepair.NewMigrateRepairCommand,
 			flags: []atlasFlag{
 				atlasNativeString("url", "u", "Database URL", "db-url"),
@@ -224,7 +224,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:     "status",
 			short:   "Show migration status",
-			native:  "migrate-status",
+			native:  "migrations status",
 			factory: migratestatus.NewMigrateStatusCommand,
 			flags: []atlasFlag{
 				atlasNativeString("url", "u", "Database URL", "db-url"),
@@ -234,7 +234,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{
 			use:     "validate",
 			short:   "Validate migration directory integrity",
-			native:  "migrate-validate",
+			native:  "migrations validate",
 			factory: migratevalidate.NewMigrateValidateCommand,
 			flags: []atlasFlag{
 				atlasUnsupportedString("dev-url", "", "Dev database URL"),

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -276,6 +276,45 @@ func TestNewAtlasCommand_HelpUsesAtlasPathForForwardedParentedCommand(t *testing
 	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  migrate-up")
 }
 
+func TestNewAtlasCommand_HelpAdvertisesGroupedNativeEquivalents(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantNative string
+		legacy     string
+	}{
+		{
+			name:       "migrate_apply",
+			args:       []string{"migrate", "apply", "--help"},
+			wantNative: "ptah migrations up",
+			legacy:     "ptah migrate-up",
+		},
+		{
+			name:       "schema_inspect",
+			args:       []string{"schema", "inspect", "--help"},
+			wantNative: "ptah db read",
+			legacy:     "ptah read-db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			cmd := NewAtlasCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(out.String(), qt.Contains, tt.wantNative)
+			c.Assert(out.String(), qt.Not(qt.Contains), tt.legacy)
+		})
+	}
+}
+
 func TestNewAtlasCommand_UnsupportedCommandsAreExplicit(t *testing.T) {
 	c := qt.New(t)
 	cmd := NewAtlasCommand()

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -1,0 +1,46 @@
+// Package db contains native live-database command groups.
+package db
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/dropall"
+	"github.com/stokaro/ptah/cmd/internal/cmdalias"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/readdb"
+)
+
+// NewDBCommand returns the native live-database command namespace.
+func NewDBCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "db",
+		Short: "Work with live database schemas",
+		Long: `Work with live database schemas.
+
+This is Ptah's native live-database namespace. Atlas-compatible spellings stay
+under ptah atlas, while the historical kebab-case commands remain available as
+compatibility commands until the native CLI reaches a stable release.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	readCmd := cmdalias.NewForwardCommandWithTargetHelp(
+		"read",
+		"Read schema from a live database",
+		"read-db",
+		readdb.NewReadDBCommand,
+	)
+	readCmd.Long = "Read schema from a live database using Ptah's native database namespace."
+	cmd.AddCommand(readCmd)
+
+	dropAllCmd := cmdalias.NewForwardCommandWithTargetHelp(
+		"drop-all",
+		"Drop all schema objects in a live database",
+		"drop-all",
+		dropall.NewDropAllCommand,
+	)
+	dropAllCmd.Long = "Drop all schema objects in a live database using Ptah's native database namespace."
+	cmd.AddCommand(dropAllCmd)
+	return cmd
+}

--- a/cmd/db/db_test.go
+++ b/cmd/db/db_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewDBCommand_RegistersNativePaths(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDBCommand()
+	for _, path := range [][]string{
+		{"read"},
+		{"drop-all"},
+	} {
+		found, _, err := cmd.Find(path)
+		c.Assert(err, qt.IsNil)
+		c.Assert(found, qt.IsNotNil)
+	}
+}
+
+func TestNewDBCommand_HelpShowsNativeBoundary(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDBCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Ptah's native live-database namespace")
+	c.Assert(out.String(), qt.Contains, "read")
+	c.Assert(out.String(), qt.Contains, "drop-all")
+}
+
+func TestNewDBCommand_RejectsUnknownPositionalCommand(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDBCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"inspect"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["inspect"\]`)
+	c.Assert(stderr.String(), qt.Contains, `unexpected positional arguments ["inspect"]`)
+}
+
+func TestNewDBCommand_ReadHelpShowsTargetFlags(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDBCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"read", "--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  db read [flags]")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  read-db")
+	c.Assert(out.String(), qt.Contains, "--db-url")
+}
+
+func TestNewDBCommand_ForwardsReadFlagErrors(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewDBCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"read", "--bogus-flag"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "unknown flag: --bogus-flag")
+}

--- a/cmd/internal/cmdalias/cmdalias.go
+++ b/cmd/internal/cmdalias/cmdalias.go
@@ -1,9 +1,10 @@
-// Package cmdalias contains small Cobra forwarding helpers for compatibility
-// command paths.
+// Package cmdalias contains small Cobra forwarding helpers for command paths
+// that delegate to another command implementation.
 package cmdalias
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -13,12 +14,31 @@ import (
 // to the native command.
 type ArgMapper func([]string) ([]string, error)
 
+type helpBehavior int
+
+const (
+	wrapperHelp helpBehavior = iota
+	targetHelp
+)
+
 // NewForwardCommand returns a command that forwards its raw arguments to a
-// native command factory. It is intended for compatibility aliases whose
-// behavior, flags, and exit-code contract should stay owned by the native
-// command.
+// native command factory. It is intended for command paths whose behavior,
+// flags, and exit-code contract should stay owned by the delegated command.
 func NewForwardCommand(use, short, native string, factory func() *cobra.Command) *cobra.Command {
 	return NewForwardCommandWithArgs(use, short, native, factory)
+}
+
+// NewForwardCommandWithTargetHelp returns a forwarding command whose --help
+// output is delegated to the target command. Use this for canonical command
+// paths that should expose the target command's real flag surface.
+func NewForwardCommandWithTargetHelp(
+	use string,
+	short string,
+	native string,
+	factory func() *cobra.Command,
+	prefixArgs ...string,
+) *cobra.Command {
+	return newForwardCommandWithArgsMapper(use, short, native, factory, nil, targetHelp, prefixArgs...)
 }
 
 // NewForwardCommandWithArgs returns a forwarding command that prepends fixed
@@ -34,13 +54,25 @@ func NewForwardCommandWithArgs(
 }
 
 // NewForwardCommandWithArgsMapper returns a forwarding command that can rewrite
-// compatibility arguments before prepending fixed arguments.
+// arguments before prepending fixed arguments.
 func NewForwardCommandWithArgsMapper(
 	use string,
 	short string,
 	native string,
 	factory func() *cobra.Command,
 	mapper ArgMapper,
+	prefixArgs ...string,
+) *cobra.Command {
+	return newForwardCommandWithArgsMapper(use, short, native, factory, mapper, wrapperHelp, prefixArgs...)
+}
+
+func newForwardCommandWithArgsMapper(
+	use string,
+	short string,
+	native string,
+	factory func() *cobra.Command,
+	mapper ArgMapper,
+	help helpBehavior,
 	prefixArgs ...string,
 ) *cobra.Command {
 	return &cobra.Command{
@@ -51,7 +83,7 @@ func NewForwardCommandWithArgsMapper(
 		SilenceUsage:       true,
 		SilenceErrors:      true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if hasHelpArg(args) {
+			if help == wrapperHelp && hasHelpArg(args) {
 				return cmd.Help()
 			}
 			if mapper != nil {
@@ -63,6 +95,7 @@ func NewForwardCommandWithArgsMapper(
 			}
 			target := factory()
 			resetCommandFlags(target)
+			defer resetCommandFlags(target)
 			parent := target.Parent()
 			if parent != nil {
 				parent.RemoveCommand(target)
@@ -71,10 +104,18 @@ func NewForwardCommandWithArgsMapper(
 			forwardArgs := make([]string, 0, len(prefixArgs)+len(args))
 			forwardArgs = append(forwardArgs, prefixArgs...)
 			forwardArgs = append(forwardArgs, args...)
+			if help == targetHelp && hasHelpArg(forwardArgs) {
+				helpCommand, _, err := target.Find(argsWithoutHelp(forwardArgs))
+				if err != nil {
+					return err
+				}
+				return renderTargetHelpWithAliasUsage(cmd, helpCommand)
+			}
 			target.SetArgs(forwardArgs)
 			target.SetIn(cmd.InOrStdin())
 			target.SetOut(cmd.OutOrStdout())
 			target.SetErr(cmd.ErrOrStderr())
+			defer resetCommandIO(target)
 			return target.Execute()
 		},
 	}
@@ -89,6 +130,66 @@ func hasHelpArg(args []string) bool {
 	return false
 }
 
+func argsWithoutHelp(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+func renderTargetHelpWithAliasUsage(alias *cobra.Command, target *cobra.Command) error {
+	originalUsage := target.UsageFunc()
+	target.SetUsageFunc(aliasUsageFunc(alias.CommandPath(), target))
+	target.SetIn(alias.InOrStdin())
+	target.SetOut(alias.OutOrStdout())
+	target.SetErr(alias.ErrOrStderr())
+	defer target.SetUsageFunc(originalUsage)
+	defer resetCommandIO(target)
+	return target.Help()
+}
+
+func aliasUsageFunc(aliasPath string, target *cobra.Command) func(*cobra.Command) error {
+	useLine := aliasUseLine(aliasPath, target)
+	return func(cmd *cobra.Command) error {
+		cmd.Println("Usage:")
+		cmd.Printf("  %s\n", useLine)
+		if cmd.HasAvailableLocalFlags() {
+			cmd.Println()
+			cmd.Println("Flags:")
+			cmd.Print(cmd.LocalFlags().FlagUsages())
+		}
+		if cmd.HasAvailableInheritedFlags() {
+			cmd.Println()
+			cmd.Println("Global Flags:")
+			cmd.Print(cmd.InheritedFlags().FlagUsages())
+		}
+		return nil
+	}
+}
+
+func aliasUseLine(aliasPath string, target *cobra.Command) string {
+	useLine := aliasPath
+	if suffix := useSuffix(target.Use); suffix != "" {
+		useLine += " " + suffix
+	}
+	if target.HasAvailableFlags() && !strings.Contains(useLine, "[flags]") {
+		useLine += " [flags]"
+	}
+	return useLine
+}
+
+func useSuffix(use string) string {
+	parts := strings.Fields(use)
+	if len(parts) <= 1 {
+		return ""
+	}
+	return strings.Join(parts[1:], " ")
+}
+
 func resetCommandFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		_ = flag.Value.Set(flag.DefValue)
@@ -100,5 +201,15 @@ func resetCommandFlags(cmd *cobra.Command) {
 	})
 	for _, child := range cmd.Commands() {
 		resetCommandFlags(child)
+	}
+}
+
+func resetCommandIO(cmd *cobra.Command) {
+	cmd.SetArgs(nil)
+	cmd.SetIn(nil)
+	cmd.SetOut(nil)
+	cmd.SetErr(nil)
+	for _, child := range cmd.Commands() {
+		resetCommandIO(child)
 	}
 }

--- a/cmd/internal/cmdalias/cmdalias_test.go
+++ b/cmd/internal/cmdalias/cmdalias_test.go
@@ -1,0 +1,121 @@
+package cmdalias
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+)
+
+func TestForwardCommandWithTargetHelpShowsTargetFlags(t *testing.T) {
+	c := qt.New(t)
+
+	target := newTestTargetCommand(nil)
+	cmd := NewForwardCommandWithTargetHelp("alias", "Alias command", "target", func() *cobra.Command {
+		return target
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "--value")
+}
+
+func TestForwardCommandWithTargetHelpUsesAliasUsage(t *testing.T) {
+	c := qt.New(t)
+
+	target := newTestTargetCommand(nil)
+	cmd := NewForwardCommandWithTargetHelp("alias", "Alias command", "target", func() *cobra.Command {
+		return target
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  alias [flags]")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  target")
+}
+
+func TestForwardCommandWithTargetHelpUsesAliasUsageForPrefixedChild(t *testing.T) {
+	c := qt.New(t)
+
+	target := &cobra.Command{Use: "target"}
+	child := newTestTargetCommand(nil)
+	child.Use = "child NAME"
+	target.AddCommand(child)
+	cmd := NewForwardCommandWithTargetHelp("alias", "Alias command", "target child", func() *cobra.Command {
+		return target
+	}, "child")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  alias NAME [flags]")
+	c.Assert(out.String(), qt.Contains, "--value")
+	c.Assert(out.String(), qt.Not(qt.Contains), "target child")
+}
+
+func TestForwardCommandResetsTargetFlagsAndIO(t *testing.T) {
+	c := qt.New(t)
+
+	var values []string
+	target := newTestTargetCommand(func(value string) {
+		values = append(values, value)
+	})
+	cmd := NewForwardCommandWithTargetHelp("alias", "Alias command", "target", func() *cobra.Command {
+		return target
+	})
+	var aliasOut bytes.Buffer
+	cmd.SetOut(&aliasOut)
+	cmd.SetErr(&aliasOut)
+	cmd.SetArgs([]string{"--value", "changed"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(aliasOut.String(), qt.Equals, "changed\n")
+	c.Assert(values, qt.DeepEquals, []string{"changed"})
+
+	var directOut bytes.Buffer
+	target.SetOut(&directOut)
+	target.SetErr(&directOut)
+	target.SetArgs(nil)
+	err = target.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(directOut.String(), qt.Equals, "default\n")
+	c.Assert(values, qt.DeepEquals, []string{"changed", "default"})
+}
+
+func newTestTargetCommand(onRun func(string)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "target",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			value, err := cmd.Flags().GetString("value")
+			if err != nil {
+				return err
+			}
+			if onRun != nil {
+				onRun(value)
+			}
+			_, err = cmd.OutOrStdout().Write([]byte(value + "\n"))
+			return err
+		},
+	}
+	cmd.Flags().String("value", "default", "Value to print")
+	return cmd
+}

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -72,11 +72,10 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 // argument with a printed message and exit code 2. Unlike cobra.NoArgs, whose
 // error is swallowed under SilenceErrors and degrades to a bare exit 1, this
 // routes through Fail so the failure is visible and carries the usage exit
-// code (e.g. a stray path typed instead of --dir does not masquerade as a
-// success/drift).
+// code, so a stray positional value does not masquerade as success/drift.
 func NoPositionalArgs(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return Fail(cmd, fmt.Errorf("unexpected positional arguments %q: pass the directory via --dir", args))
+		return Fail(cmd, fmt.Errorf("unexpected positional arguments %q", args))
 	}
 	return nil
 }

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -87,7 +87,7 @@ func TestMigrateCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, `unknown command "apply" for "migrate"`)
+	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["apply"\]`)
 }
 
 func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -81,7 +81,7 @@ func NewMigrateCommand() *cobra.Command {
 	}
 	addMigrateGenerateCommand(migrateCmd)
 	addMigrateNewCommand(migrateCmd)
-	cmdutil.ConfigureCommandArgs(migrateCmd, nil)
+	cmdutil.ConfigureCommandArgs(migrateCmd, cmdutil.NoPositionalArgs)
 	return migrateCmd
 }
 

--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -1,0 +1,89 @@
+// Package migrations contains Ptah's native migration command group.
+package migrations
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdalias"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/lint"
+	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/cmd/migratebaseline"
+	"github.com/stokaro/ptah/cmd/migratedown"
+	"github.com/stokaro/ptah/cmd/migratehash"
+	"github.com/stokaro/ptah/cmd/migraterepair"
+	"github.com/stokaro/ptah/cmd/migratestatus"
+	"github.com/stokaro/ptah/cmd/migrateup"
+	"github.com/stokaro/ptah/cmd/migratevalidate"
+)
+
+// NewMigrationsCommand returns the native migration command namespace.
+func NewMigrationsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrations",
+		Short: "Manage migration plans, files, and revision state",
+		Long: `Manage migration plans, files, and revision state.
+
+This is Ptah's native migration namespace. It deliberately uses Ptah-owned
+spellings such as "plan" and "up" instead of root-level Atlas aliases such as
+"migrate diff" or "migrate apply". Atlas-compatible commands stay under
+ptah atlas.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+
+	for _, alias := range []struct {
+		use        string
+		short      string
+		long       string
+		native     string
+		factory    func() *cobra.Command
+		prefixArgs []string
+	}{
+		{
+			use:     "plan",
+			short:   "Plan migration SQL from schema differences",
+			long:    "Plan migration SQL from schema differences without writing migration files.",
+			native:  "migrate",
+			factory: migrate.NewMigrateCommand,
+		},
+		{
+			use:        "generate",
+			short:      "Generate migration files from schema differences",
+			long:       "Generate migration files from schema differences and write them to the migrations directory.",
+			native:     "migrate generate",
+			factory:    migrate.NewMigrateCommand,
+			prefixArgs: []string{"generate"},
+		},
+		{
+			use:        "create",
+			short:      "Create empty migration files for manual SQL",
+			long:       "Create empty migration files for manual SQL.",
+			native:     "migrate new",
+			factory:    migrate.NewMigrateCommand,
+			prefixArgs: []string{"new"},
+		},
+		{use: "up", short: "Run pending migrations", long: "Run pending migrations against a live database.", native: "migrate-up", factory: migrateup.NewMigrateUpCommand},
+		{use: "down", short: "Roll back migrations", long: "Roll back migrations against a live database.", native: "migrate-down", factory: migratedown.NewMigrateDownCommand},
+		{use: "status", short: "Show migration status", long: "Show migration status for a live database and migrations directory.", native: "migrate-status", factory: migratestatus.NewMigrateStatusCommand},
+		{use: "baseline", short: "Record existing migrations as applied", long: "Record existing migrations as already applied in the revision table.", native: "migrate-baseline", factory: migratebaseline.NewMigrateBaselineCommand},
+		{use: "repair", short: "Repair migration revision metadata", long: "Repair migration revision metadata after a dirty or partial migration state.", native: "migrate-repair", factory: migraterepair.NewMigrateRepairCommand},
+		{use: "hash", short: "Write or update migration directory integrity", long: "Write or update the migration directory integrity file.", native: "migrate-hash", factory: migratehash.NewMigrateHashCommand},
+		{use: "validate", short: "Validate migration directory integrity", long: "Validate the migration directory against its integrity file.", native: "migrate-validate", factory: migratevalidate.NewMigrateValidateCommand},
+		{use: "lint", short: "Lint migration files", long: "Lint migration files for production-unsafe patterns.", native: "lint", factory: lint.NewLintCommand},
+	} {
+		aliasCmd := cmdalias.NewForwardCommandWithTargetHelp(
+			alias.use,
+			alias.short,
+			alias.native,
+			alias.factory,
+			alias.prefixArgs...,
+		)
+		aliasCmd.Long = alias.long
+		cmd.AddCommand(aliasCmd)
+	}
+
+	return cmd
+}

--- a/cmd/migrations/migrations_test.go
+++ b/cmd/migrations/migrations_test.go
@@ -1,0 +1,111 @@
+package migrations
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNewMigrationsCommand_RegistersNativePaths(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	for _, path := range [][]string{
+		{"plan"},
+		{"generate"},
+		{"create"},
+		{"up"},
+		{"down"},
+		{"status"},
+		{"baseline"},
+		{"repair"},
+		{"hash"},
+		{"validate"},
+		{"lint"},
+	} {
+		found, _, err := cmd.Find(path)
+		c.Assert(err, qt.IsNil)
+		c.Assert(found, qt.IsNotNil)
+	}
+}
+
+func TestNewMigrationsCommand_HelpShowsNativeBoundary(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Ptah's native migration namespace")
+	c.Assert(out.String(), qt.Contains, "plan")
+	c.Assert(out.String(), qt.Contains, "up")
+}
+
+func TestNewMigrationsCommand_RejectsUnknownPositionalCommand(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"apply"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["apply"\]`)
+	c.Assert(stderr.String(), qt.Contains, `unexpected positional arguments ["apply"]`)
+}
+
+func TestNewMigrationsCommand_ForwardsCreateHelpToMigrateNew(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"create", "--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  migrations create [name] [flags]")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  new")
+	c.Assert(out.String(), qt.Contains, "--migrations-dir")
+	c.Assert(out.String(), qt.Contains, "--name")
+}
+
+func TestNewMigrationsCommand_UpHelpShowsTargetFlags(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"up", "--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  migrations up [flags]")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  migrate-up")
+	c.Assert(out.String(), qt.Contains, "--db-url")
+	c.Assert(out.String(), qt.Contains, "--migrations-dir")
+}
+
+func TestNewMigrationsCommand_ForwardsUpFlagErrors(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewMigrationsCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"up", "--bogus-flag"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "unknown flag: --bogus-flag")
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/atlas"
 	"github.com/stokaro/ptah/cmd/compare"
+	"github.com/stokaro/ptah/cmd/db"
 	"github.com/stokaro/ptah/cmd/drift"
 	"github.com/stokaro/ptah/cmd/dropall"
 	"github.com/stokaro/ptah/cmd/generate"
@@ -25,6 +26,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migratestatus"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/cmd/migratevalidate"
+	"github.com/stokaro/ptah/cmd/migrations"
 	"github.com/stokaro/ptah/cmd/readdb"
 	"github.com/stokaro/ptah/cmd/schema"
 	"github.com/stokaro/ptah/cmd/seed"
@@ -50,8 +52,10 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(generate.NewGenerateCommand())
 	cmd.AddCommand(readdb.NewReadDBCommand())
 	cmd.AddCommand(schema.NewSchemaCommand())
+	cmd.AddCommand(db.NewDBCommand())
 	cmd.AddCommand(compare.NewCompareCommand())
 	cmd.AddCommand(drift.NewDriftCommand())
+	cmd.AddCommand(migrations.NewMigrationsCommand())
 	cmd.AddCommand(migrate.NewMigrateCommand())
 	cmd.AddCommand(migratebaseline.NewMigrateBaselineCommand())
 	cmd.AddCommand(migrateup.NewMigrateUpCommand())

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -3,6 +3,7 @@ package root
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -68,6 +69,80 @@ func TestNewRootCommand_SchemaExportSubcommandIsRegistered(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "Export one schema source format to another")
 	c.Assert(out.String(), qt.Contains, "--cleanup-go-annotations")
+}
+
+func TestNewRootCommand_NativeCommandTreeIsRegistered(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := NewRootCommand()
+	for _, path := range [][]string{
+		{"schema", "render"},
+		{"schema", "compare"},
+		{"schema", "drift"},
+		{"db", "read"},
+		{"db", "drop-all"},
+		{"migrations", "plan"},
+		{"migrations", "generate"},
+		{"migrations", "create"},
+		{"migrations", "up"},
+		{"migrations", "down"},
+		{"migrations", "status"},
+		{"migrations", "baseline"},
+		{"migrations", "repair"},
+		{"migrations", "hash"},
+		{"migrations", "validate"},
+		{"migrations", "lint"},
+	} {
+		found, _, err := cmd.Find(path)
+		c.Assert(err, qt.IsNil)
+		c.Assert(found.CommandPath(), qt.Equals, "ptah "+strings.Join(path, " "))
+	}
+}
+
+func TestNewRootCommand_AtlasLookingRootAliasesStayRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "migrate apply",
+			args: []string{"migrate", "apply"},
+			want: `unexpected positional arguments ["apply"]`,
+		},
+		{
+			name: "schema inspect",
+			args: []string{"schema", "inspect"},
+			want: `unexpected positional arguments ["inspect"]`,
+		},
+		{
+			name: "db inspect",
+			args: []string{"db", "inspect"},
+			want: `unexpected positional arguments ["inspect"]`,
+		},
+		{
+			name: "migrations apply",
+			args: []string{"migrations", "apply"},
+			want: `unexpected positional arguments ["apply"]`,
+		},
+		{
+			name: "migrations diff",
+			args: []string{"migrations", "diff"},
+			want: `unexpected positional arguments ["diff"]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, stderr, err := executeRoot(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr, qt.Contains, tt.want)
+		})
+	}
 }
 
 func TestNewRootCommand_VersionFlagWorks(t *testing.T) {
@@ -168,8 +243,24 @@ func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
 		{name: "generate", args: []string{"generate", "--bogus-flag"}},
 		{name: "read-db", args: []string{"read-db", "--bogus-flag"}},
 		{name: "schema export", args: []string{"schema", "export", "--bogus-flag"}},
+		{name: "schema render", args: []string{"schema", "render", "--bogus-flag"}},
+		{name: "schema compare", args: []string{"schema", "compare", "--bogus-flag"}},
+		{name: "schema drift", args: []string{"schema", "drift", "--bogus-flag"}},
+		{name: "db read", args: []string{"db", "read", "--bogus-flag"}},
+		{name: "db drop-all", args: []string{"db", "drop-all", "--bogus-flag"}},
 		{name: "compare", args: []string{"compare", "--bogus-flag"}},
 		{name: "drift", args: []string{"drift", "--bogus-flag"}},
+		{name: "migrations plan", args: []string{"migrations", "plan", "--bogus-flag"}},
+		{name: "migrations generate", args: []string{"migrations", "generate", "--bogus-flag"}},
+		{name: "migrations create", args: []string{"migrations", "create", "--bogus-flag"}},
+		{name: "migrations up", args: []string{"migrations", "up", "--bogus-flag"}},
+		{name: "migrations down", args: []string{"migrations", "down", "--bogus-flag"}},
+		{name: "migrations status", args: []string{"migrations", "status", "--bogus-flag"}},
+		{name: "migrations baseline", args: []string{"migrations", "baseline", "--bogus-flag"}},
+		{name: "migrations repair", args: []string{"migrations", "repair", "--bogus-flag"}},
+		{name: "migrations hash", args: []string{"migrations", "hash", "--bogus-flag"}},
+		{name: "migrations validate", args: []string{"migrations", "validate", "--bogus-flag"}},
+		{name: "migrations lint", args: []string{"migrations", "lint", "--bogus-flag"}},
 		{name: "migrate", args: []string{"migrate", "--bogus-flag"}},
 		{name: "migrate generate", args: []string{"migrate", "generate", "--bogus-flag"}},
 		{name: "migrate new", args: []string{"migrate", "new", "--bogus-flag"}},

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/compare"
+	"github.com/stokaro/ptah/cmd/drift"
+	"github.com/stokaro/ptah/cmd/generate"
+	"github.com/stokaro/ptah/cmd/internal/cmdalias"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/core/atlashclrender"
 	"github.com/stokaro/ptah/core/goschema"
@@ -28,17 +32,48 @@ const (
 	exportFormatAtlasHCL     = "atlas-hcl"
 )
 
-// NewSchemaCommand returns the schema conversion command tree.
+// NewSchemaCommand returns the native schema command tree.
 func NewSchemaCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
-		Short: "Convert schema sources",
+		Short: "Work with desired schema definitions",
+		Long: `Work with desired schema definitions.
+
+This is Ptah's native schema namespace. Atlas-compatible schema commands stay
+under ptah atlas, while historical root commands remain available as
+compatibility commands until the native CLI reaches a stable release.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
-	cmdutil.ConfigureCommandArgs(cmd, nil)
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	cmd.AddCommand(newSchemaExportCommand())
+	renderCmd := cmdalias.NewForwardCommandWithTargetHelp(
+		"render",
+		"Render desired schema SQL",
+		"generate",
+		generate.NewGenerateCommand,
+	)
+	renderCmd.Long = "Render desired schema SQL from Go annotations, YAML schema files, or Atlas HCL schema files."
+	cmd.AddCommand(renderCmd)
+
+	compareCmd := cmdalias.NewForwardCommandWithTargetHelp(
+		"compare",
+		"Compare desired schema with a live database",
+		"compare",
+		compare.NewCompareCommand,
+	)
+	compareCmd.Long = "Compare desired schema with a live database."
+	cmd.AddCommand(compareCmd)
+
+	driftCmd := cmdalias.NewForwardCommandWithTargetHelp(
+		"drift",
+		"Check live database drift against desired schema",
+		"drift",
+		drift.NewDriftCommand,
+	)
+	driftCmd.Long = "Check live database drift against desired schema."
+	cmd.AddCommand(driftCmd)
 	return cmd
 }
 

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -42,6 +42,40 @@ func TestSchemaExportCommandWritesAtlasHCL(t *testing.T) {
 	c.Assert(err, qt.IsNil, qt.Commentf("schema.hcl:\n%s", string(content)))
 }
 
+func TestSchemaCommand_RegistersNativeAliasPaths(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := schema.NewSchemaCommand()
+	for _, path := range [][]string{
+		{"export"},
+		{"render"},
+		{"compare"},
+		{"drift"},
+	} {
+		found, _, err := cmd.Find(path)
+		c.Assert(err, qt.IsNil)
+		c.Assert(found, qt.IsNotNil)
+	}
+}
+
+func TestSchemaCommand_RenderHelpShowsNativeAlias(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := schema.NewSchemaCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"render", "--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Usage:\n  schema render [flags]")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Usage:\n  generate")
+	c.Assert(out.String(), qt.Contains, "--dialect")
+	c.Assert(out.String(), qt.Contains, "--schema-file")
+}
+
 func TestSchemaExportCleanupDryRunAndWrite(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -11,27 +11,31 @@ Ptah treats CLI exit codes as a public scripting contract.
 
 ## Native Commands
 
+The grouped command tree is the preferred native surface. Historical kebab-case
+commands remain available as compatibility spellings before GA and use the same
+exit-code contract as the grouped command they map to.
+
 | Command | `0` | `1` | `2` |
 | --- | --- | --- | --- |
-| `ptah generate` | Schema rendered. | Not used. | Usage error, parse error, unsupported dialect, or render error. |
+| `ptah schema render` / `ptah generate` | Schema rendered. | Not used. | Usage error, parse error, unsupported dialect, or render error. |
 | `ptah schema export` | Schema exported. | Not used. | Usage error, invalid paths, parse error, render error, write error, or cleanup error. |
-| `ptah read-db` | Schema read and printed. | Not used. | Usage error, connection failure, or schema-read failure. |
-| `ptah compare` | Diff printed, or no diff. | Non-empty diff when `--exit-code` is set. | Usage error, connection failure, parse failure, or diff generation failure. |
-| `ptah drift` | No drift that meets `--severity`, or `--exit-code=false`. | Drift meets `--severity` while `--exit-code=true`. | Usage error, connection failure, parse failure, or report error. |
-| `ptah lint` | No findings above `--fail-on`, or `--fail-on=none`. | Findings meet `--fail-on`. | Usage error, invalid config, unreadable migration directory, or report error. |
+| `ptah db read` / `ptah read-db` | Schema read and printed. | Not used. | Usage error, connection failure, or schema-read failure. |
+| `ptah db drop-all` / `ptah drop-all` | Objects dropped, dry-run output printed, or operation canceled by the user. | Not used. | Usage error, connection failure, input read error, or drop failure. |
+| `ptah schema compare` / `ptah compare` | Diff printed, or no diff. | Non-empty diff when `--exit-code` is set. | Usage error, connection failure, parse failure, or diff generation failure. |
+| `ptah schema drift` / `ptah drift` | No drift that meets `--severity`, or `--exit-code=false`. | Drift meets `--severity` while `--exit-code=true`. | Usage error, connection failure, parse failure, or report error. |
+| `ptah migrations lint` / `ptah lint` | No findings above `--fail-on`, or `--fail-on=none`. | Findings meet `--fail-on`. | Usage error, invalid config, unreadable migration directory, or report error. |
 | `ptah sql lint` | No SQL lint findings with `error` severity. | One or more SQL lint findings with `error` severity. | Usage error, unreadable SQL input, unsupported dialect, or report error. |
-| `ptah migrate` | Migration SQL generated, or no schema changes. | Not used. | Usage error, connection failure, parse failure, safety check failure, or render error. |
-| `ptah migrate generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
-| `ptah migrate new` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |
-| `ptah migrate-baseline` | Existing migrations recorded as applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, verification failure, or write error. |
-| `ptah migrate-up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, lock failure, or migration execution failure. |
-| `ptah migrate-down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, lock failure, or rollback failure. |
-| `ptah migrate-repair` | Migration revision repaired, or dry-run output printed. | Not used. | Usage error, connection failure, revision lookup failure, or repair failure. |
-| `ptah migrate-status` | Status printed, including pending migrations by default. | Pending migrations exist when `--exit-code` is set. | Usage error, connection failure, migration directory error, or status-read failure. |
-| `ptah migrate-hash` | Integrity file written. | Not used. | Usage error, invalid directory, invalid migration format, or write error. |
-| `ptah migrate-validate` | Integrity file matches the migration directory. | Migration content drift found. | Usage error, missing or unreadable integrity file, invalid directory, or invalid migration format. |
+| `ptah migrations plan` / `ptah migrate` | Migration SQL generated, or no schema changes. | Not used. | Usage error, connection failure, parse failure, safety check failure, or render error. |
+| `ptah migrations generate` / `ptah migrate generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
+| `ptah migrations create` / `ptah migrate new` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |
+| `ptah migrations baseline` / `ptah migrate-baseline` | Existing migrations recorded as applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, verification failure, or write error. |
+| `ptah migrations up` / `ptah migrate-up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, lock failure, or migration execution failure. |
+| `ptah migrations down` / `ptah migrate-down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, lock failure, or rollback failure. |
+| `ptah migrations repair` / `ptah migrate-repair` | Migration revision repaired, or dry-run output printed. | Not used. | Usage error, connection failure, revision lookup failure, or repair failure. |
+| `ptah migrations status` / `ptah migrate-status` | Status printed, including pending migrations by default. | Pending migrations exist when `--exit-code` is set. | Usage error, connection failure, migration directory error, or status-read failure. |
+| `ptah migrations hash` / `ptah migrate-hash` | Integrity file written. | Not used. | Usage error, invalid directory, invalid migration format, or write error. |
+| `ptah migrations validate` / `ptah migrate-validate` | Integrity file matches the migration directory. | Migration content drift found. | Usage error, missing or unreadable integrity file, invalid directory, or invalid migration format. |
 | `ptah seed` | Seed files applied or already applied. | Not used. | Usage error, protected environment rejection, connection failure, invalid seed files, or seed execution failure. |
-| `ptah drop-all` | Objects dropped, dry-run output printed, or operation canceled by the user. | Not used. | Usage error, connection failure, input read error, or drop failure. |
 | `ptah version` | Version information printed. | Not used. | Usage error. |
 
 ## Atlas-Compatible Aliases
@@ -40,13 +44,13 @@ Commands under `ptah atlas <command> ...` translate implemented Atlas-compatible
 
 | Atlas-compatible command | Native command |
 | --- | --- |
-| `ptah atlas migrate apply` | `ptah migrate-up` |
-| `ptah atlas migrate down` | `ptah migrate-down` |
-| `ptah atlas migrate status` | `ptah migrate-status` |
-| `ptah atlas migrate hash` | `ptah migrate-hash` |
-| `ptah atlas migrate validate` | `ptah migrate-validate` |
-| `ptah atlas migrate lint` | `ptah lint` |
-| `ptah atlas schema inspect` | `ptah read-db` |
-| `ptah atlas schema diff` | `ptah compare` |
+| `ptah atlas migrate apply` | `ptah migrations up` |
+| `ptah atlas migrate down` | `ptah migrations down` |
+| `ptah atlas migrate status` | `ptah migrations status` |
+| `ptah atlas migrate hash` | `ptah migrations hash` |
+| `ptah atlas migrate validate` | `ptah migrations validate` |
+| `ptah atlas migrate lint` | `ptah migrations lint` |
+| `ptah atlas schema inspect` | `ptah db read` |
+| `ptah atlas schema diff` | `ptah schema compare` |
 
 Unsupported Atlas-compatible flags are rejected explicitly and exit `2`.

--- a/docs/native_cli.md
+++ b/docs/native_cli.md
@@ -1,0 +1,54 @@
+# Native CLI Command Tree
+
+Ptah has two CLI surfaces:
+
+- Native Ptah commands, owned by Ptah and documented here.
+- Atlas-compatible commands, reserved under `ptah atlas <command> ...`.
+
+Do not add root-level Atlas spellings such as `ptah migrate apply` or
+`ptah schema inspect`. Those paths belong to `ptah atlas migrate apply` and
+`ptah atlas schema inspect`.
+
+## Canonical Native Tree
+
+The native tree uses Ptah-owned noun/verb groups:
+
+| Native command | Purpose | Legacy compatibility command |
+| --- | --- | --- |
+| `ptah schema render` | Render desired schema SQL from Go, YAML, or Atlas HCL inputs. | `ptah generate` |
+| `ptah schema compare` | Compare desired schema with a live database. | `ptah compare` |
+| `ptah schema drift` | Check live database drift against desired schema. | `ptah drift` |
+| `ptah schema export` | Export one schema source format to another. | Same command; already canonical. |
+| `ptah db read` | Read schema from a live database. | `ptah read-db` |
+| `ptah db drop-all` | Drop all schema objects in a live database. | `ptah drop-all` |
+| `ptah migrations plan` | Print migration SQL from desired/live schema differences. | `ptah migrate` |
+| `ptah migrations generate` | Generate migration files from desired/live schema differences. | `ptah migrate generate` |
+| `ptah migrations create` | Create empty migration files for manual SQL. | `ptah migrate new` |
+| `ptah migrations up` | Run pending migrations. | `ptah migrate-up` |
+| `ptah migrations down` | Roll back migrations. | `ptah migrate-down` |
+| `ptah migrations status` | Show migration status. | `ptah migrate-status` |
+| `ptah migrations baseline` | Record existing migrations as applied. | `ptah migrate-baseline` |
+| `ptah migrations repair` | Repair migration revision metadata. | `ptah migrate-repair` |
+| `ptah migrations hash` | Write or update migration directory integrity. | `ptah migrate-hash` |
+| `ptah migrations validate` | Validate migration directory integrity. | `ptah migrate-validate` |
+| `ptah migrations lint` | Lint migration files. | `ptah lint` |
+| `ptah sql lint` | Lint standalone SQL files. | Same command; already canonical. |
+| `ptah seed` | Apply environment-scoped SQL seed files. | Same command; already canonical. |
+| `ptah version` | Print Ptah build information. | Same command; already canonical. |
+
+## Compatibility And Deprecation
+
+Ptah is pre-GA, so the grouped native commands are the preferred command tree
+for new scripts. The historical kebab-case commands remain available as
+compatibility spellings during the pre-GA period, and they delegate to the same
+implementation and exit-code contract as their canonical grouped equivalents.
+
+Before a stable release, maintainers may choose to hide or remove legacy
+spellings after documenting the change in release notes. Until then, tests cover
+both the grouped command resolution and representative legacy paths.
+
+## Exit Codes
+
+Canonical grouped commands inherit the exit-code contract of the implementation
+they delegate to. See [CLI Exit Codes](exit_codes.md) for the command-by-command
+matrix.


### PR DESCRIPTION
## Summary

- Add grouped native command namespaces:
  - `ptah schema render|compare|drift`
  - `ptah db read|drop-all`
  - `ptah migrations plan|generate|create|up|down|status|baseline|repair|hash|validate|lint`
- Keep Atlas-compatible paths only under `ptah atlas <command> ...`, and keep historical kebab-case commands as legacy compatibility spellings.
- Extend `cmdalias` so canonical aliases can show delegated target flags while preserving the alias `Usage:` line.
- Tighten root/parent command validation so Atlas-looking root paths such as `ptah migrate apply`, `ptah schema inspect`, `ptah db inspect`, and `ptah migrations apply` exit as usage errors.
- Document the new native tree and update the exit-code/README command mapping.

Fixes #370.

## Tests

- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/atlas ./cmd/internal/cmdalias ./cmd/db ./cmd/migrations ./cmd/schema ./cmd/root ./cmd/migrate -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/internal/cmdutil ./cmd/migrate ./cmd/db ./cmd/migrations ./cmd/schema ./cmd/root ./cmd/atlas ./cmd/sql ./cmd/migratehash ./cmd/migratevalidate -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `git diff --check`

## Self-review

- Pass 1: checked command tree registration, Atlas/root boundary, unknown command exit-code behavior, target flag forwarding, docs mapping.
- Pass 2: found and fixed two CLI contract gaps:
  - native alias help showed target legacy usage such as `migrate-up`; `cmdalias` now renders target flags with alias usage.
  - `NoPositionalArgs` had a misleading directory-specific error; it is now generic for all parent namespaces.
