### PR TITLE
Fix MySQL FK rollback ordering

### DIFF
--- a/integration/scenarios_roundtrip_fixtures.go
+++ b/integration/scenarios_roundtrip_fixtures.go
@@ -43,41 +43,21 @@ var roundTripFixtures = []roundTripFixture{
 		Name:        "parent_child_fk_drop_order",
 		Description: "parent/child tables created in one migration roll down to empty through generated down SQL",
 		Versions:    []string{"028-roundtrip-parent-child"},
-		// blocked on #127: MySQL/MariaDB cannot drop the parent before the child.
-		BlockedByDialect: map[string]string{
-			"mysql":   "#127",
-			"mariadb": "#127",
-		},
 	},
 	{
 		Name:        "three_level_fk_chain",
 		Description: "three-table foreign-key chain is generated, applied, introspected, and rolled back",
 		Versions:    []string{"034-roundtrip-fk-chain"},
-		// blocked on #127: MySQL/MariaDB need child-before-parent table drops.
-		BlockedByDialect: map[string]string{
-			"mysql":   "#127",
-			"mariadb": "#127",
-		},
 	},
 	{
 		Name:        "diamond_fk_graph",
 		Description: "diamond-shaped foreign-key graph is generated and verified through the round-trip path",
 		Versions:    []string{"035-roundtrip-fk-diamond"},
-		// blocked on #127: MySQL/MariaDB need topological table drops.
-		BlockedByDialect: map[string]string{
-			"mysql":   "#127",
-			"mariadb": "#127",
-		},
 	},
 	{
 		Name:        "mutual_fk_cycle",
 		Description: "mutual foreign-key cycle is generated, applied, introspected, and rolled back",
 		Versions:    []string{"029-roundtrip-mutual-cycle"},
-		// blocked on #127: MySQL/MariaDB need child-before-parent table drops.
-		BlockedByDialect: map[string]string{
-			"mysql":   "#127",
-			"mariadb": "#127",
-		},
 	},
 	{
 		Name:        "same_name_check_drift",

--- a/migration/generator/fk_drop_order_integration_test.go
+++ b/migration/generator/fk_drop_order_integration_test.go
@@ -67,6 +67,57 @@ func TestFKDropOrder_DownRoundTrip_Integration(t *testing.T) {
 	}
 }
 
+func TestFKDropOrder_MutualCycleDownRoundTrip_Integration(t *testing.T) {
+	cases := []struct {
+		dialect string
+		envKey  string
+	}{
+		{"postgres", "POSTGRES_URL"},
+		{"mysql", "MYSQL_URL"},
+		{"mariadb", "MARIADB_URL"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.dialect, func(t *testing.T) {
+			url := os.Getenv(tc.envKey)
+			if url == "" {
+				t.Skipf("skipping %s: %s not set", tc.dialect, tc.envKey)
+			}
+
+			c := qt.New(t)
+			ctx := context.Background()
+			conn, err := dbschema.ConnectToDatabase(ctx, url)
+			if err != nil {
+				t.Skipf("skipping %s: cannot connect: %v", tc.dialect, err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			dialect := conn.Info().Dialect
+			dropMutualFKCycleTables(conn, dialect)
+			t.Cleanup(func() { dropMutualFKCycleTables(conn, dialect) })
+
+			target := mutualFKCycleSchema()
+			goschema.Finalize(target)
+			empty := &dbschematypes.DBSchema{}
+			upDiff := schemadiff.CompareWithDialect(target, empty, dialect)
+			c.Assert(upDiff.HasChanges(), qt.IsTrue)
+
+			upSQL, err := generateUpMigrationSQL(upDiff, target, dialect)
+			c.Assert(err, qt.IsNil)
+			execScript(c, conn, upSQL, "UP")
+
+			downSQL, err := generateDownMigrationSQL(upDiff, target, empty, dialect)
+			c.Assert(err, qt.IsNil)
+			t.Logf("[%s] generated mutual-cycle DOWN:\n%s", dialect, downSQL)
+			execScript(c, conn, downSQL, "DOWN")
+
+			dbAfterDown, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			c.Assert(hasMutualFKCycleTables(dbAfterDown), qt.IsFalse)
+		})
+	}
+}
+
 func dropFKOrderTables(conn *dbschema.DatabaseConnection, dialect string) {
 	for _, tableName := range []string{
 		"ptah_fk_order_tasks",
@@ -78,9 +129,28 @@ func dropFKOrderTables(conn *dbschema.DatabaseConnection, dialect string) {
 	}
 }
 
+func dropMutualFKCycleTables(conn *dbschema.DatabaseConnection, dialect string) {
+	if dialect == "mysql" || dialect == "mariadb" {
+		_, _ = conn.Exec("SET FOREIGN_KEY_CHECKS=0")
+		defer func() { _, _ = conn.Exec("SET FOREIGN_KEY_CHECKS=1") }()
+	}
+	for _, tableName := range []string{"left_nodes", "right_nodes"} {
+		_, _ = conn.Exec(dropTableSQL(dialect, tableName))
+	}
+}
+
 func hasFKOrderTables(schema *dbschematypes.DBSchema) bool {
 	for _, table := range schema.Tables {
 		if strings.HasPrefix(table.Name, "ptah_fk_order_") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMutualFKCycleTables(schema *dbschematypes.DBSchema) bool {
+	for _, table := range schema.Tables {
+		if table.Name == "left_nodes" || table.Name == "right_nodes" {
 			return true
 		}
 	}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1188,7 +1188,7 @@ func derefString(s *string) string {
 // still flow through ConstraintsRemoved; only the richer per-table info is
 // omitted.
 func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database) []types.ConstraintRemovalInfo {
-	if schema == nil || len(diff.ConstraintsAdded) == 0 {
+	if schema == nil {
 		return nil
 	}
 
@@ -1208,14 +1208,20 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 	// FK from exactly the table the up side added it to. Names present here are
 	// recorded so the legacy field-scan fallback below does not double-emit them.
 	var infos []types.ConstraintRemovalInfo
+	seen := make(map[string]struct{})
 	handled := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.TableName == "" {
 			continue
 		}
-		infos = append(infos, types.ConstraintRemovalInfo{Name: add.Name, TableName: add.TableName, Type: add.Type})
+		infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{
+			Name:      add.Name,
+			TableName: add.TableName,
+			Type:      add.Type,
+		})
 		handled[add.Name] = struct{}{}
 	}
+	infos = appendAddedTableForeignKeyRemovals(infos, seen, diff.TablesAdded, schema)
 
 	// Index field-level constraint names to their owning table for the names
 	// that did not arrive with table-qualified info (legacy callers / explicit
@@ -1256,14 +1262,104 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 		switch {
 		case tableConstraints[name].Name != "":
 			c := tableConstraints[name]
-			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: c.Table, Type: c.Type})
+			infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{Name: name, TableName: c.Table, Type: c.Type})
 		case fkTables[name] != "":
-			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: fkTables[name], Type: "FOREIGN KEY"})
+			infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{Name: name, TableName: fkTables[name], Type: "FOREIGN KEY"})
 		case checkTables[name] != "":
-			infos = append(infos, types.ConstraintRemovalInfo{Name: name, TableName: checkTables[name], Type: "CHECK"})
+			infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{Name: name, TableName: checkTables[name], Type: "CHECK"})
 		}
 	}
 	return infos
+}
+
+func appendAddedTableForeignKeyRemovals(
+	infos []types.ConstraintRemovalInfo,
+	seen map[string]struct{},
+	tableNames []string,
+	schema *goschema.Database,
+) []types.ConstraintRemovalInfo {
+	addedTables := make(map[string]struct{}, len(tableNames))
+	for _, tableName := range tableNames {
+		addedTables[tableName] = struct{}{}
+	}
+	if len(addedTables) == 0 {
+		return infos
+	}
+
+	for _, field := range schema.Fields {
+		if field.Foreign == "" {
+			continue
+		}
+		table := generatedTableByStructName(schema.Tables, field.StructName)
+		if table == nil || !generatedTableInSet(*table, addedTables) {
+			continue
+		}
+		tableName := table.QualifiedName()
+		name := field.ForeignKeyName
+		if name == "" {
+			name = fromschema.GenerateForeignKeyName(table.Name, field.Name)
+		}
+		infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{
+			Name:      name,
+			TableName: tableName,
+			Type:      "FOREIGN KEY",
+		})
+	}
+
+	for _, constraint := range schema.Constraints {
+		if !strings.EqualFold(constraint.Type, "FOREIGN KEY") {
+			continue
+		}
+		table := generatedTableReference(schema.Tables, constraint.StructName, constraint.Table)
+		if table == nil || !generatedTableInSet(*table, addedTables) {
+			continue
+		}
+		tableName := table.QualifiedName()
+		if constraint.Table != "" {
+			tableName = constraint.Table
+		}
+		name := constraint.Name
+		if name == "" {
+			name = defaultForeignKeyConstraintName(table.Name, constraint.Columns)
+		}
+		infos = appendConstraintRemovalInfo(infos, seen, types.ConstraintRemovalInfo{
+			Name:      name,
+			TableName: tableName,
+			Type:      "FOREIGN KEY",
+		})
+	}
+
+	return infos
+}
+
+func generatedTableInSet(table goschema.Table, tableNames map[string]struct{}) bool {
+	_, byName := tableNames[table.Name]
+	_, byQualifiedName := tableNames[table.QualifiedName()]
+	return byName || byQualifiedName
+}
+
+func appendConstraintRemovalInfo(
+	infos []types.ConstraintRemovalInfo,
+	seen map[string]struct{},
+	info types.ConstraintRemovalInfo,
+) []types.ConstraintRemovalInfo {
+	if info.Name == "" || info.TableName == "" {
+		return infos
+	}
+	key := info.TableName + "." + info.Name
+	if _, ok := seen[key]; ok {
+		return infos
+	}
+	seen[key] = struct{}{}
+	return append(infos, info)
+}
+
+func defaultForeignKeyConstraintName(tableName string, columns []string) string {
+	columnName := strings.Join(columns, "_")
+	if columnName == "" {
+		columnName = "foreign_key"
+	}
+	return fromschema.GenerateForeignKeyName(tableName, columnName)
 }
 
 // reverseTableDiffs reverses table modifications for down migrations

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -399,6 +399,69 @@ func TestGenerateDownMigrationSQL_DropsSchemaQualifiedTableLevelFKChildBeforePar
 	assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS app.projects", "DROP TABLE IF EXISTS app.accounts")
 }
 
+func TestGenerateDownMigrationSQL_DropsMySQLFamilyFKChainInDependencyOrder(t *testing.T) {
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			schema := fkOrderSchema()
+			goschema.Finalize(schema)
+			upDiff := schemadiff.CompareWithDialect(schema, &dbschematypes.DBSchema{}, dialect)
+
+			downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, dialect)
+			c.Assert(err, qt.IsNil)
+			downSQL = legacyRenderedSQL(downSQL)
+
+			assertSQLBefore(t, downSQL, "ALTER TABLE ptah_fk_order_tasks DROP FOREIGN KEY", "DROP TABLE IF EXISTS ptah_fk_order_tasks")
+			assertSQLBefore(t, downSQL, "ALTER TABLE ptah_fk_order_projects DROP FOREIGN KEY", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+		})
+	}
+}
+
+func TestGenerateDownMigrationSQL_DropsMySQLFamilyFKDiamondInDependencyOrder(t *testing.T) {
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			schema := fkOrderSchema()
+			goschema.Finalize(schema)
+			upDiff := schemadiff.CompareWithDialect(schema, &dbschematypes.DBSchema{}, dialect)
+
+			downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, dialect)
+			c.Assert(err, qt.IsNil)
+			downSQL = legacyRenderedSQL(downSQL)
+
+			assertSQLBefore(t, downSQL, "ALTER TABLE ptah_fk_order_tasks DROP FOREIGN KEY", "DROP TABLE IF EXISTS ptah_fk_order_tasks")
+			assertSQLBefore(t, downSQL, "ALTER TABLE ptah_fk_order_projects DROP FOREIGN KEY", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+			assertSQLBefore(t, downSQL, "ALTER TABLE ptah_fk_order_memberships DROP FOREIGN KEY", "DROP TABLE IF EXISTS ptah_fk_order_memberships")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_memberships")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+			assertSQLBefore(t, downSQL, "DROP TABLE IF EXISTS ptah_fk_order_memberships", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+		})
+	}
+}
+
+func TestGenerateDownMigrationSQL_DropsMySQLFamilyMutualFKCycleTogether(t *testing.T) {
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			schema := mutualFKCycleSchema()
+			goschema.Finalize(schema)
+			upDiff := schemadiff.CompareWithDialect(schema, &dbschematypes.DBSchema{}, dialect)
+
+			downSQL, err := generateDownMigrationSQL(upDiff, schema, &dbschematypes.DBSchema{}, dialect)
+			c.Assert(err, qt.IsNil)
+			downSQL = legacyRenderedSQL(downSQL)
+
+			assertSQLBefore(t, downSQL, "ALTER TABLE left_nodes DROP FOREIGN KEY", "DROP TABLE IF EXISTS left_nodes")
+			assertSQLBefore(t, downSQL, "ALTER TABLE right_nodes DROP FOREIGN KEY", "DROP TABLE IF EXISTS right_nodes")
+			c.Assert(downSQL, qt.Contains, "fk_left_nodes_right_id")
+			c.Assert(downSQL, qt.Contains, "fk_right_nodes_left_id")
+		})
+	}
+}
+
 func TestReverseSchemaDiff_GrantOptionUpgradeDownRevokesOnlyOption(t *testing.T) {
 	c := qt.New(t)
 	upDiff := &types.SchemaDiff{
@@ -746,6 +809,58 @@ func TestReverseSchemaDiff_FieldLevelCheckRemovalsWithTables(t *testing.T) {
 	})
 }
 
+// TestReverseSchemaDiff_AddedTableForeignKeyRemovalsWithTables verifies the
+// down metadata required by MySQL/MariaDB when a whole table is created by the
+// up migration. Those dialects cannot rely on DROP TABLE CASCADE, so FKs owned
+// by the added table must be explicitly removed before the table drop even when
+// the comparator does not report them as standalone constraint additions.
+func TestReverseSchemaDiff_AddedTableForeignKeyRemovalsWithTables(t *testing.T) {
+	c := qt.New(t)
+
+	generatedSchema := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Account", Schema: "app", Name: "accounts"},
+			{StructName: "Project", Schema: "app", Name: "projects"},
+			{StructName: "Audit", Schema: "app", Name: "audits"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Project", Name: "account_id", Type: "INTEGER", Foreign: "app.accounts(id)"},
+			{
+				StructName:     "Project",
+				Name:           "owner_id",
+				Type:           "INTEGER",
+				Foreign:        "app.accounts(id)",
+				ForeignKeyName: "fk_project_owner_id",
+			},
+			{StructName: "Audit", Name: "project_id", Type: "INTEGER", Foreign: "app.projects(id)"},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{StructName: "Project", Mode: "relation", Field: "owner_id", Ref: "app.accounts(id)"},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Project",
+				Type:           "FOREIGN KEY",
+				Table:          "app.projects",
+				Columns:        []string{"tenant_id", "reviewer_id"},
+				ForeignTable:   "app.accounts",
+				ForeignColumns: []string{"tenant_id", "id"},
+			},
+		},
+	}
+	upDiff := &types.SchemaDiff{
+		TablesAdded: []string{"app.projects"},
+	}
+
+	result := reverseSchemaDiffWithSchema(upDiff, generatedSchema, nil)
+
+	c.Assert(result.ConstraintsRemovedWithTables, qt.DeepEquals, []types.ConstraintRemovalInfo{
+		{Name: "fk_projects_account_id", TableName: "app.projects", Type: "FOREIGN KEY"},
+		{Name: "fk_project_owner_id", TableName: "app.projects", Type: "FOREIGN KEY"},
+		{Name: "fk_projects_tenant_id_reviewer_id", TableName: "app.projects", Type: "FOREIGN KEY"},
+	})
+}
+
 func TestForeignKeyAdditionFromDBConstraint_DeduplicatesRepeatedIntrospectionColumns(t *testing.T) {
 	c := qt.New(t)
 	foreignTable := "ptah_tenants"
@@ -805,6 +920,33 @@ func fkOrderSchema() *goschema.Database {
 				Type:           "VARCHAR(36)",
 				Foreign:        "ptah_fk_order_memberships(id)",
 				ForeignKeyName: "fk_ptah_fk_order_tasks_membership",
+			},
+		},
+	}
+}
+
+func mutualFKCycleSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "LeftNode", Name: "left_nodes"},
+			{StructName: "RightNode", Name: "right_nodes"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "LeftNode", Name: "id", Type: "INTEGER", Primary: true},
+			{
+				StructName:     "LeftNode",
+				Name:           "right_id",
+				Type:           "INTEGER",
+				Foreign:        "right_nodes(id)",
+				ForeignKeyName: "fk_left_nodes_right_id",
+			},
+			{StructName: "RightNode", Name: "id", Type: "INTEGER", Primary: true},
+			{
+				StructName:     "RightNode",
+				Name:           "left_id",
+				Type:           "INTEGER",
+				Foreign:        "left_nodes(id)",
+				ForeignKeyName: "fk_right_nodes_left_id",
 			},
 		},
 	}

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -32,6 +32,14 @@ func renderMySQLFamily(c *qt.C, dialect string, diff *types.SchemaDiff, generate
 	return sql
 }
 
+func assertContainsBefore(c *qt.C, sql, earlier, later string) {
+	earlierIndex := strings.Index(sql, earlier)
+	laterIndex := strings.Index(sql, later)
+	c.Assert(earlierIndex >= 0, qt.IsTrue, qt.Commentf("%q not found in SQL:\n%s", earlier, sql))
+	c.Assert(laterIndex >= 0, qt.IsTrue, qt.Commentf("%q not found in SQL:\n%s", later, sql))
+	c.Assert(earlierIndex < laterIndex, qt.IsTrue, qt.Commentf("%q must appear before %q:\n%s", earlier, later, sql))
+}
+
 func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) {
 	for _, dialect := range mysqlFamilyDialects {
 		t.Run(dialect, func(t *testing.T) {
@@ -57,6 +65,27 @@ func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) 
 
 			c.Assert(sql, qt.Contains, "ALTER TABLE orders ADD CONSTRAINT fk_orders_accounts FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE;",
 				qt.Commentf("composite FK addition must preserve all referenced columns; got:\n%s", sql))
+		})
+	}
+}
+
+func TestPlanner_GenerateMigrationAST_DropsFKBeforeRemovingItsTable(t *testing.T) {
+	diff := &types.SchemaDiff{
+		TablesRemoved: []string{"tasks", "projects", "accounts"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "fk_tasks_project", TableName: "tasks", Type: "FOREIGN KEY"},
+			{Name: "fk_projects_account", TableName: "projects", Type: "FOREIGN KEY"},
+		},
+	}
+
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+			assertContainsBefore(c, sql, "ALTER TABLE tasks DROP FOREIGN KEY fk_tasks_project;", "DROP TABLE IF EXISTS tasks;")
+			assertContainsBefore(c, sql, "ALTER TABLE projects DROP FOREIGN KEY fk_projects_account;", "DROP TABLE IF EXISTS projects;")
 		})
 	}
 }
@@ -523,9 +552,10 @@ func TestPlanner_GenerateMigrationAST_ModifyDrop_HostScopedWhenAddedHostsAbsent(
 
 // TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified locks
 // the pure-removal path: every removal with a known host is dropped exactly
-// once with the type-correct syntax; constraints on tables that are themselves
-// being dropped are skipped; a duplicate removal entry for the same (table,
-// name) is deduped — MySQL would abort on the second, unguarded drop otherwise.
+// once with the type-correct syntax; non-FK constraints on tables that are
+// themselves being dropped are skipped; a duplicate removal entry for the same
+// (table, name) is deduped — MySQL would abort on the second, unguarded drop
+// otherwise.
 func TestPlanner_GenerateMigrationAST_PureConstraintRemovals_TableQualified(t *testing.T) {
 	for _, dialect := range mysqlFamilyDialects {
 		t.Run(dialect, func(t *testing.T) {

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -1120,6 +1120,12 @@ func (p *Planner) fieldLevelForeignKeyConstraintNode(constraintName string, gene
 // here would abort the migration. Exactly-once emission per (table, name) —
 // split between the two functions and deduped inside each — is what stands in
 // for postgres's IF EXISTS idempotency guard.
+//
+// FK removals are still emitted when the owning table is also being dropped.
+// MySQL/MariaDB do not support PostgreSQL-style DROP TABLE CASCADE, and mutual
+// FK cycles cannot be solved by table ordering alone. Dropping the FKs first
+// gives both acyclic graphs and cycles a deterministic rollback path. Non-FK
+// constraints on dropped tables stay implicit in the DROP TABLE operation.
 func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	// (table, name) pairs being re-added — modifications owned by
 	// addNewConstraints — plus, per name, how many hosts were recorded at all.
@@ -1141,9 +1147,6 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 		addedBareNames[name] = struct{}{}
 	}
 
-	// Constraints owned by a table that is itself being dropped do not need an
-	// explicit drop — the DROP TABLE cascades them. Emitting one is at best
-	// redundant and at worst invalid, so skip them.
 	droppedTables := make(map[string]struct{}, len(diff.TablesRemoved))
 	for _, t := range diff.TablesRemoved {
 		droppedTables[t] = struct{}{}
@@ -1166,7 +1169,7 @@ func (p *Planner) removeConstraints(result []ast.Node, diff *types.SchemaDiff) [
 			// recorded removal host for this name.
 			continue
 		}
-		if _, droppedTable := droppedTables[info.TableName]; droppedTable {
+		if _, droppedTable := droppedTables[info.TableName]; droppedTable && !strings.EqualFold(info.Type, "FOREIGN KEY") {
 			continue
 		}
 		result = p.appendScopedDrop(result, info, dropped)


### PR DESCRIPTION
## Summary
- emit explicit FK drops for generated down migrations when newly added tables own foreign keys, so MySQL/MariaDB can roll back parent/child, chain, diamond, and mutual-cycle table graphs
- keep non-FK constraints implicit when dropping tables, while allowing FK removals before table drops in the MySQL-family planner
- unblock the MySQL/MariaDB round-trip FK fixtures that were still allowlisted against closed #127

Fixes #431

## Self-review
- correctness: verified FK removal metadata for field-level FKs, materialized embedded-relation FKs, schema-qualified tables, table-level FKs, unnamed composite table-level FKs, acyclic dependency ordering, and mutual cycles
- regression risk: kept existing exactly-once constraint-drop ownership for modified constraints; non-FK constraints on dropped tables remain skipped
- coverage: added generator SQL tests, direct reverse-diff metadata tests, planner tests, build-tagged live DB tests, and enabled the affected fixture scenarios for MySQL/MariaDB
- docs: docs/conformance.md is not present on current master; #431 references that file from the #285 worktree/report context, so this PR closes the Ptah behavior gap and leaves report regeneration to the conformance/docs branch once that artifact exists on the target branch

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-431-go-build-cache go test ./migration/generator ./migration/planner/dialects/mysql ./integration ./core/renderer/dialects/mysql ./core/renderer/dialects/mariadb -count=1
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-431-go-build-cache go test -tags=integration ./migration/generator -run 'TestFKDropOrder' -count=1
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-431-go-build-cache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-431-go-build-cache golangci-lint run ./... (0 issues; sandbox cache-write warnings only)
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-431-go-build-cache go test ./... -count=1
- make docker-build
- docker compose --profile test run --rm ptah-tester --databases=mysql,mariadb --scenarios=migration_generator_roundtrip_fixtures --report=stdout,txt,json --verbose --output=./reports: 2 passed, 0 failed, 0 skipped