### PR TITLE
Unblock same-name constraint drift fixtures

### DIFF
--- a/core/renderer/dialects/mariadb/schema_objects_test.go
+++ b/core/renderer/dialects/mariadb/schema_objects_test.go
@@ -51,6 +51,21 @@ func TestMariaDBRenderer_ColumnOnUpdateExpression(t *testing.T) {
 	c.Assert(sql, qt.Contains, "`updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)")
 }
 
+func TestMariaDBRenderer_NamedColumnCheckRendersAsTableConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("products").
+		AddColumn(ast.NewColumn("id", "int").SetPrimary()).
+		AddColumn(ast.NewColumn("quantity", "integer").SetNotNull().SetCheck("quantity > 0").SetCheckName("products_quantity_check"))
+
+	sql, err := renderer.RenderSQL("mariadb", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "`quantity` integer NOT NULL,")
+	c.Assert(sql, qt.Contains, "CONSTRAINT `products_quantity_check` CHECK (quantity > 0)")
+	c.Assert(sql, qt.Not(qt.Contains), "`quantity` integer NOT NULL CONSTRAINT")
+}
+
 func TestMariaDBRenderer_EscapesReservedIdentifiers(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/dialects/mysql/schema_objects_test.go
@@ -87,6 +87,17 @@ func TestMySQLRenderer_JSONColumnRemainsNativeJSON(t *testing.T) {
 	c.Assert(sql, qt.Not(qt.Contains), "json_valid")
 }
 
+func TestMySQLRenderer_NamedColumnCheckRemainsInline(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("products").
+		AddColumn(ast.NewColumn("quantity", "integer").SetNotNull().SetCheck("quantity > 0").SetCheckName("products_quantity_check"))
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "`quantity` integer NOT NULL CONSTRAINT `products_quantity_check` CHECK (quantity > 0)")
+}
+
 func TestMySQLRenderer_IndexParts(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/dialects/mysqllike/mysqllike.go
@@ -311,6 +311,13 @@ func (r *Renderer) VisitCreateTable(node *ast.CreateTableNode) error {
 		lines = append(lines, line)
 	}
 
+	for _, column := range node.Columns {
+		if !r.rendersNamedColumnCheckAsTableConstraint(column) {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  CONSTRAINT %s CHECK (%s)", escapeIdentifier(column.CheckName), column.Check))
+	}
+
 	// Render table-level constraints
 	for _, constraint := range node.Constraints {
 		line, err := r.renderConstraint(constraint)
@@ -614,10 +621,9 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 
 	// Check constraint. When `check_name=` is provided, emit the explicit
 	// `CONSTRAINT <name> CHECK (...)` form so the constraint round-trips
-	// stably through MySQL/MariaDB introspection (which otherwise auto-names
-	// CHECKs as `<table>_chk_N` and would not match the drift detector's
-	// expected name).
-	if column.Check != "" {
+	// stably through introspection (which otherwise auto-names CHECKs as
+	// `<table>_chk_N` and would not match the drift detector's expected name).
+	if column.Check != "" && !r.rendersNamedColumnCheckAsTableConstraint(column) {
 		if column.CheckName != "" {
 			parts = append(parts, fmt.Sprintf("CONSTRAINT %s CHECK (%s)", escapeIdentifier(column.CheckName), column.Check))
 		} else {
@@ -629,6 +635,10 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	}
 
 	return strings.Join(parts, " "), nil
+}
+
+func (r *Renderer) rendersNamedColumnCheckAsTableConstraint(column *ast.ColumnNode) bool {
+	return r.dialect == "mariadb" && column.Check != "" && column.CheckName != ""
 }
 
 func (r *Renderer) renderColumnType(column *ast.ColumnNode, columnType string) string {

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema/types"
@@ -39,6 +40,36 @@ func TestNewMySQLReader(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestMySQLReader_CheckConstraintIntrospectionErrorClassification(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(isMissingCheckConstraintTableNameColumn(&mysqldriver.MySQLError{
+		Number:  1054,
+		Message: "Unknown column 'TABLE_NAME' in 'field list'",
+	}), qt.IsTrue)
+	c.Assert(isMissingCheckConstraintTableNameColumn(&mysqldriver.MySQLError{
+		Number:  1054,
+		Message: "Unknown column 'table_name' in 'field list'",
+	}), qt.IsTrue)
+	c.Assert(isMissingCheckConstraintTableNameColumn(&mysqldriver.MySQLError{
+		Number:  1054,
+		Message: "Unknown column 'CHECK_CLAUSE' in 'field list'",
+	}), qt.IsFalse)
+
+	c.Assert(isMissingCheckConstraintsTable(&mysqldriver.MySQLError{
+		Number:  1109,
+		Message: "Unknown table 'CHECK_CONSTRAINTS' in information_schema",
+	}), qt.IsTrue)
+	c.Assert(isMissingCheckConstraintsTable(&mysqldriver.MySQLError{
+		Number:  1146,
+		Message: "Table 'information_schema.check_constraints' doesn't exist",
+	}), qt.IsTrue)
+	c.Assert(isMissingCheckConstraintsTable(&mysqldriver.MySQLError{
+		Number:  1142,
+		Message: "SELECT command denied to user",
+	}), qt.IsFalse)
 }
 
 func TestMySQLReader_parseTableFromDDLGeneratedColumn(t *testing.T) {

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -2,8 +2,11 @@ package mysql
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/core/ast"
 	coreparser "github.com/stokaro/ptah/core/parser"
@@ -14,6 +17,11 @@ import (
 type Reader struct {
 	db     *sql.DB
 	schema string
+}
+
+type checkConstraintClauses struct {
+	byTableName map[string]string
+	byName      map[string]string
 }
 
 // NewMySQLReader creates a new MySQL schema reader
@@ -477,6 +485,10 @@ func (r *Reader) readIndexes(dbName string) ([]types.DBIndex, error) {
 
 // readConstraints reads all constraints
 func (r *Reader) readConstraints(dbName string) ([]types.DBConstraint, error) {
+	checkClauses, err := r.readCheckConstraintClauses(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("read check constraint clauses: %w", err)
+	}
 	query := `
 		SELECT
 			tc.CONSTRAINT_NAME,
@@ -531,26 +543,18 @@ func (r *Reader) readConstraints(dbName string) ([]types.DBConstraint, error) {
 		// Get or create the constraint
 		constraint, exists := constraintMap[key]
 		if !exists {
-			constraint = &types.DBConstraint{
-				Name:      constraintName,
-				TableName: tableName,
-				Type:      constraintType,
-			}
-
-			// Set foreign key references if they exist
-			if referencedTable != "" {
-				constraint.ForeignTable = &referencedTable
-			}
-			if referencedColumn != "" {
-				constraint.ForeignColumn = &referencedColumn
-			}
-			if deleteRule != "" {
-				constraint.DeleteRule = &deleteRule
-			}
-			if updateRule != "" {
-				constraint.UpdateRule = &updateRule
-			}
-
+			constraint = newConstraint(
+				constraintName,
+				tableName,
+				constraintType,
+				constraintRefs{
+					referencedTable:  referencedTable,
+					referencedColumn: referencedColumn,
+					deleteRule:       deleteRule,
+					updateRule:       updateRule,
+				},
+				checkClauses,
+			)
 			constraintMap[key] = constraint
 		}
 
@@ -567,6 +571,9 @@ func (r *Reader) readConstraints(dbName string) ([]types.DBConstraint, error) {
 			constraint.ForeignColumns = append(constraint.ForeignColumns, referencedColumn)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	// Convert map to slice
 	var constraints []types.DBConstraint
@@ -575,6 +582,129 @@ func (r *Reader) readConstraints(dbName string) ([]types.DBConstraint, error) {
 	}
 
 	return constraints, nil
+}
+
+type constraintRefs struct {
+	referencedTable  string
+	referencedColumn string
+	deleteRule       string
+	updateRule       string
+}
+
+func newConstraint(name, tableName, constraintType string, refs constraintRefs, checkClauses checkConstraintClauses) *types.DBConstraint {
+	constraint := &types.DBConstraint{
+		Name:      name,
+		TableName: tableName,
+		Type:      constraintType,
+	}
+	if refs.referencedTable != "" {
+		constraint.ForeignTable = &refs.referencedTable
+	}
+	if refs.referencedColumn != "" {
+		constraint.ForeignColumn = &refs.referencedColumn
+	}
+	if refs.deleteRule != "" {
+		constraint.DeleteRule = &refs.deleteRule
+	}
+	if refs.updateRule != "" {
+		constraint.UpdateRule = &refs.updateRule
+	}
+	if checkClause := checkClauses.forConstraint(tableName, name); checkClause != "" {
+		constraint.CheckClause = &checkClause
+	}
+	return constraint
+}
+
+func (c checkConstraintClauses) forConstraint(tableName, constraintName string) string {
+	if checkClause := c.byTableName[tableName+"."+constraintName]; checkClause != "" {
+		return checkClause
+	}
+	return c.byName[constraintName]
+}
+
+func (r *Reader) readCheckConstraintClauses(dbName string) (checkConstraintClauses, error) {
+	clauses := checkConstraintClauses{
+		byTableName: make(map[string]string),
+		byName:      make(map[string]string),
+	}
+	err := r.readTableAwareCheckConstraintClauses(dbName, clauses.byTableName)
+	if err == nil {
+		return clauses, nil
+	}
+	if isMissingCheckConstraintsTable(err) {
+		return clauses, nil
+	}
+	if !isMissingCheckConstraintTableNameColumn(err) {
+		return clauses, err
+	}
+
+	err = r.readNameOnlyCheckConstraintClauses(dbName, clauses.byName)
+	if err == nil {
+		return clauses, nil
+	}
+	if isMissingCheckConstraintsTable(err) {
+		return clauses, nil
+	}
+	return clauses, err
+}
+
+func isMissingCheckConstraintTableNameColumn(err error) bool {
+	var mysqlErr *mysqldriver.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == 1054 && strings.Contains(strings.ToUpper(mysqlErr.Message), "TABLE_NAME")
+}
+
+func isMissingCheckConstraintsTable(err error) bool {
+	var mysqlErr *mysqldriver.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	if mysqlErr.Number != 1109 && mysqlErr.Number != 1146 {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(mysqlErr.Message), "CHECK_CONSTRAINTS")
+}
+
+func (r *Reader) readTableAwareCheckConstraintClauses(dbName string, clauses map[string]string) error {
+	rows, err := r.db.Query(`
+		SELECT CONSTRAINT_NAME, TABLE_NAME, CHECK_CLAUSE
+		FROM information_schema.CHECK_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = ?`, dbName)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var constraintName, tableName, checkClause string
+		if err := rows.Scan(&constraintName, &tableName, &checkClause); err != nil {
+			return err
+		}
+		clauses[tableName+"."+constraintName] = checkClause
+	}
+	return rows.Err()
+}
+
+func (r *Reader) readNameOnlyCheckConstraintClauses(dbName string, clauses map[string]string) error {
+	rows, err := r.db.Query(`
+		SELECT CONSTRAINT_NAME, CHECK_CLAUSE
+		FROM information_schema.CHECK_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = ?`, dbName)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var constraintName, checkClause string
+		if err := rows.Scan(&constraintName, &checkClause); err != nil {
+			return err
+		}
+		clauses[constraintName] = checkClause
+	}
+	return rows.Err()
 }
 
 // parseEnumValues parses enum values from MySQL column type

--- a/integration/fixtures/entities/042-roundtrip-check-to-unique-v1/account.go
+++ b/integration/fixtures/entities/042-roundtrip-check-to-unique-v1/account.go
@@ -1,0 +1,15 @@
+package entities
+
+//migrator:schema:table name="accounts"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+	Email string
+
+	//migrator:schema:field name="region" type="VARCHAR(64)" not_null="true"
+	Region string
+}
+
+//migrator:schema:constraint name="accounts_identity_guard" type="CHECK" table="accounts" check="email <> ''"

--- a/integration/fixtures/entities/043-roundtrip-check-to-unique-v2/account.go
+++ b/integration/fixtures/entities/043-roundtrip-check-to-unique-v2/account.go
@@ -1,0 +1,15 @@
+package entities
+
+//migrator:schema:table name="accounts"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+	Email string
+
+	//migrator:schema:field name="region" type="VARCHAR(64)" not_null="true"
+	Region string
+}
+
+//migrator:schema:constraint name="accounts_identity_guard" type="UNIQUE" table="accounts" columns="email,region"

--- a/integration/fixtures/entities/044-roundtrip-unique-to-check-v1/product.go
+++ b/integration/fixtures/entities/044-roundtrip-unique-to-check-v1/product.go
@@ -1,0 +1,15 @@
+package entities
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="sku" type="VARCHAR(64)" not_null="true"
+	SKU string
+
+	//migrator:schema:field name="quantity" type="INTEGER" not_null="true"
+	Quantity int
+}
+
+//migrator:schema:constraint name="products_quantity_guard" type="UNIQUE" table="products" columns="sku"

--- a/integration/fixtures/entities/045-roundtrip-unique-to-check-v2/product.go
+++ b/integration/fixtures/entities/045-roundtrip-unique-to-check-v2/product.go
@@ -1,0 +1,15 @@
+package entities
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="sku" type="VARCHAR(64)" not_null="true"
+	SKU string
+
+	//migrator:schema:field name="quantity" type="INTEGER" not_null="true"
+	Quantity int
+}
+
+//migrator:schema:constraint name="products_quantity_guard" type="CHECK" table="products" check="quantity > 10"

--- a/integration/scenarios_roundtrip_fixtures.go
+++ b/integration/scenarios_roundtrip_fixtures.go
@@ -63,23 +63,21 @@ var roundTripFixtures = []roundTripFixture{
 		Name:        "same_name_check_drift",
 		Description: "same-name CHECK expression changes must be detected by generated migrations",
 		Versions:    []string{"030-roundtrip-check-v1", "031-roundtrip-check-v2"},
-		// blocked on #126: CHECK expression-only drift is intentionally not surfaced yet.
-		BlockedByDialect: map[string]string{
-			"postgres": "#126",
-			"mysql":    "#126",
-			"mariadb":  "#126",
-		},
 	},
 	{
 		Name:        "same_name_unique_drift",
 		Description: "same-name UNIQUE column-set changes must be detected by generated migrations",
 		Versions:    []string{"032-roundtrip-unique-v1", "033-roundtrip-unique-v2"},
-		// blocked on #126: UNIQUE same-name definition drift is not detected yet.
-		BlockedByDialect: map[string]string{
-			"postgres": "#126",
-			"mysql":    "#126",
-			"mariadb":  "#126",
-		},
+	},
+	{
+		Name:        "same_name_check_to_unique_drift",
+		Description: "same-name CHECK to UNIQUE type changes must be detected by generated migrations",
+		Versions:    []string{"042-roundtrip-check-to-unique-v1", "043-roundtrip-check-to-unique-v2"},
+	},
+	{
+		Name:        "same_name_unique_to_check_drift",
+		Description: "same-name UNIQUE to CHECK type changes must be detected by generated migrations",
+		Versions:    []string{"044-roundtrip-unique-to-check-v1", "045-roundtrip-unique-to-check-v2"},
 	},
 	{
 		Name:        "composite_primary_key_add_remove",

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -755,8 +755,8 @@ func generateDownMigrationSQLWithOptions(
 	// Create a reverse diff to generate down migration. We pass the original
 	// generated schema to resolve table names for RLS policies, and the
 	// introspected database schema so the reversed constraint additions can
-	// rebuild the FULL prior FK body (columns, target, on_delete/on_update) from
-	// the pre-change DB state — that is exactly the action the down must restore.
+	// rebuild the full prior body from the pre-change DB state — that is exactly
+	// the definition the down must restore.
 	reverseDiff := reverseSchemaDiffWithSchema(diff, generated, dbSchema)
 
 	caps := capability.ForDialect(dialect)
@@ -823,9 +823,9 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 //
 // schema is the generated (target) Go schema, used to resolve table names for
 // RLS policies. dbSchema is the introspected (pre-change) database schema, used
-// to rebuild the prior FK definition for the reversed constraint additions; it
-// may be nil for legacy callers that only have the generated schema (the
-// reversed additions then fall back to the name-only path).
+// to rebuild prior FK/PK/CHECK/UNIQUE definitions for reversed constraint
+// additions; it may be nil for legacy callers that only have the generated
+// schema (the reversed additions then fall back to the name-only path).
 func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	return &types.SchemaDiff{
 		// Reverse table operations
@@ -872,19 +872,18 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		// Reverse constraint operations. A modified constraint is expressed by
 		// the comparator as remove + add of the SAME name (e.g. an on_delete
 		// change on a field-level FK, issue #189). Swapping the two slices makes
-		// the down migration drop the new definition and re-add the old one — the
-		// down planner resolves the old definition from the introspected schema
-		// (see dbschematogo.ConvertDBSchemaToGoSchema, which now carries the
-		// FK action), so the prior action is faithfully restored.
+		// the down migration drop the new definition and re-add the old one.
+		// reverseConstraintAdditions restores the prior table-qualified body
+		// from the introspected schema for the constraint types whose down
+		// add-path needs more than a name.
 		//
-		// ConstraintsAddedWithTables carries the table-qualified prior FK body so
-		// the down add-path can fan a mixin-shared FK name out to every host
-		// table. Without it the down add-path falls back to the name-only field
-		// scan, which emits one ADD for a single host while the per-host DROP also
-		// resolves only one host — so the 2nd host's re-add collides with its
-		// still-present old constraint (Postgres 42710, MySQL 1826) and the
-		// rollback aborts half-applied. This is the DOWN mirror of the UP
-		// multi-host fix (issue #197).
+		// ConstraintsAddedWithTables carries the table-qualified prior body so
+		// the down add-path can fan a shared constraint name out to every real
+		// host table. Without it the down add-path falls back to name-only
+		// resolution, which can emit one ADD for a single host while per-host
+		// DROP also resolves only one host; the 2nd host's re-add then collides
+		// with its still-present old constraint (Postgres 42710, MySQL 1826)
+		// and the rollback aborts half-applied.
 		ConstraintsAdded:             diff.ConstraintsRemoved,
 		ConstraintsRemoved:           diff.ConstraintsAdded,
 		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
@@ -1074,9 +1073,9 @@ func foreignReferenceTable(ref string) string {
 // reverseConstraintAdditions builds the table-qualified additions for the down
 // migration. In the down direction the constraints to add back are the ones the
 // up migration REMOVED (diff.ConstraintsRemovedWithTables) — restoring their
-// prior definition. The prior FK body (columns, foreign table/column,
-// on_delete/on_update) is read from the introspected (pre-change) database
-// schema, which is the authoritative source for what the down must restore.
+// prior definition. The prior body is read from the introspected (pre-change)
+// database schema, which is the authoritative source for what the down must
+// restore.
 //
 // Carrying the full per-host body here lets both dialect planners' add-paths
 // (which already prefer ConstraintsAddedWithTables) emit one correct ALTER TABLE
@@ -1096,10 +1095,10 @@ func reverseConstraintAdditions(diff *types.SchemaDiff, dbSchema *dbschematypes.
 	// name-only key would collapse them onto one host.
 	dbConstraintByTableName := make(map[string]dbschematypes.DBConstraint)
 	for _, c := range dbSchema.Constraints {
-		if c.Type != "FOREIGN KEY" && c.Type != "PRIMARY KEY" {
+		if c.Type != "FOREIGN KEY" && c.Type != "PRIMARY KEY" && c.Type != "CHECK" && c.Type != "UNIQUE" {
 			continue
 		}
-		dbConstraintByTableName[c.TableName+"."+c.Name] = c
+		dbConstraintByTableName[c.QualifiedTableName()+"."+c.Name] = c
 	}
 
 	var infos []types.ConstraintAdditionInfo
@@ -1110,8 +1109,9 @@ func reverseConstraintAdditions(diff *types.SchemaDiff, dbSchema *dbschematypes.
 		dbConstraint, ok := dbConstraintByTableName[removed.TableName+"."+removed.Name]
 		if !ok {
 			// No introspected body to restore (e.g. the constraint was a
-			// pure-removal not present pre-change, or a non-FK). The name still
-			// rides in ConstraintsAdded for the name-only fallback.
+			// pure-removal not present pre-change, or a type this helper does not
+			// reconstruct). The name still rides in ConstraintsAdded for the
+			// name-only fallback.
 			continue
 		}
 		switch removed.Type {
@@ -1126,9 +1126,36 @@ func reverseConstraintAdditions(diff *types.SchemaDiff, dbSchema *dbschematypes.
 					Columns:   append([]string(nil), columns...),
 				})
 			}
+		case "CHECK":
+			if dbConstraint.CheckClause != nil && *dbConstraint.CheckClause != "" {
+				infos = append(infos, types.ConstraintAdditionInfo{
+					Name:            removed.Name,
+					TableName:       removed.TableName,
+					Type:            "CHECK",
+					CheckExpression: *dbConstraint.CheckClause,
+				})
+			}
+		case "UNIQUE":
+			if columns := dbConstraint.ColumnNamesOrDefault(); len(columns) > 0 {
+				infos = append(infos, types.ConstraintAdditionInfo{
+					Name:          removed.Name,
+					TableName:     removed.TableName,
+					Type:          "UNIQUE",
+					Columns:       append([]string(nil), columns...),
+					NullsDistinct: cloneBoolPtr(dbConstraint.NullsDistinct),
+				})
+			}
 		}
 	}
 	return infos
+}
+
+func cloneBoolPtr(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 // foreignKeyAdditionFromDBConstraint builds a ConstraintAdditionInfo carrying the

--- a/migration/generator/multihost_fk_down_test.go
+++ b/migration/generator/multihost_fk_down_test.go
@@ -258,6 +258,62 @@ func TestReverseConstraintAdditions_RestoresCompositeForeignKeyBody(t *testing.T
 	})
 }
 
+func TestReverseConstraintAdditions_RestoresCheckConstraintBody(t *testing.T) {
+	c := qt.New(t)
+	checkClause := "quantity > 0"
+	dbSchema := &dbschematypes.DBSchema{
+		Constraints: []dbschematypes.DBConstraint{{
+			Name:        "products_quantity_check",
+			TableName:   "products",
+			Type:        "CHECK",
+			CheckClause: &checkClause,
+		}},
+	}
+	upDiff := &types.SchemaDiff{
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "products_quantity_check", TableName: "products", Type: "CHECK"},
+		},
+	}
+
+	additions := reverseConstraintAdditions(upDiff, dbSchema)
+
+	c.Assert(additions, qt.DeepEquals, []types.ConstraintAdditionInfo{{
+		Name:            "products_quantity_check",
+		TableName:       "products",
+		Type:            "CHECK",
+		CheckExpression: "quantity > 0",
+	}})
+}
+
+func TestReverseConstraintAdditions_RestoresUniqueConstraintBody(t *testing.T) {
+	c := qt.New(t)
+	nullsDistinct := false
+	dbSchema := &dbschematypes.DBSchema{
+		Constraints: []dbschematypes.DBConstraint{{
+			Name:          "accounts_identity_unique",
+			TableName:     "accounts",
+			Type:          "UNIQUE",
+			ColumnNames:   []string{"email"},
+			NullsDistinct: &nullsDistinct,
+		}},
+	}
+	upDiff := &types.SchemaDiff{
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+			{Name: "accounts_identity_unique", TableName: "accounts", Type: "UNIQUE"},
+		},
+	}
+
+	additions := reverseConstraintAdditions(upDiff, dbSchema)
+
+	c.Assert(additions, qt.HasLen, 1)
+	c.Assert(additions[0].Name, qt.Equals, "accounts_identity_unique")
+	c.Assert(additions[0].TableName, qt.Equals, "accounts")
+	c.Assert(additions[0].Type, qt.Equals, "UNIQUE")
+	c.Assert(additions[0].Columns, qt.DeepEquals, []string{"email"})
+	c.Assert(additions[0].NullsDistinct, qt.IsNotNil)
+	c.Assert(*additions[0].NullsDistinct, qt.Equals, false)
+}
+
 // TestReverseConstraintAdditions_NilDBSchema is the legacy-caller path: with no
 // introspected schema there is no body to restore, so the helper returns nil and
 // the names ride the name-only fallback via ConstraintsAdded.

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -69,6 +69,70 @@ func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) 
 	}
 }
 
+func TestPlanner_GenerateMigrationAST_TableQualifiedCheckAndUniqueAdditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     *types.SchemaDiff
+		wantDrop string
+		wantSQL  string
+	}{
+		{
+			name: "unique to check",
+			diff: &types.SchemaDiff{
+				ConstraintsAdded: []string{"products_quantity_guard"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:            "products_quantity_guard",
+					TableName:       "products",
+					Type:            "CHECK",
+					CheckExpression: "quantity > 10",
+				}},
+				ConstraintsRemoved: []string{"products_quantity_guard"},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+					Name:      "products_quantity_guard",
+					TableName: "products",
+					Type:      "UNIQUE",
+				}},
+			},
+			wantDrop: "ALTER TABLE products DROP INDEX products_quantity_guard;",
+			wantSQL:  "ALTER TABLE products ADD CONSTRAINT products_quantity_guard CHECK (quantity > 10);",
+		},
+		{
+			name: "check to unique",
+			diff: &types.SchemaDiff{
+				ConstraintsAdded: []string{"accounts_identity"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:      "accounts_identity",
+					TableName: "accounts",
+					Type:      "UNIQUE",
+					Columns:   []string{"email", "region"},
+				}},
+				ConstraintsRemoved: []string{"accounts_identity"},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+					Name:      "accounts_identity",
+					TableName: "accounts",
+					Type:      "CHECK",
+				}},
+			},
+			wantDrop: "ALTER TABLE accounts DROP CONSTRAINT accounts_identity;",
+			wantSQL:  "ALTER TABLE accounts ADD CONSTRAINT accounts_identity UNIQUE (email, region);",
+		},
+	}
+
+	for _, dialect := range mysqlFamilyDialects {
+		for _, tt := range tests {
+			t.Run(dialect+"/"+tt.name, func(t *testing.T) {
+				c := qt.New(t)
+
+				sql := renderMySQLFamily(c, dialect, tt.diff, &goschema.Database{})
+
+				assertContainsBefore(c, sql, tt.wantDrop, tt.wantSQL)
+				c.Assert(sql, qt.Contains, tt.wantSQL)
+				c.Assert(strings.Count(sql, tt.wantSQL), qt.Equals, 1)
+			})
+		}
+	}
+}
+
 func TestPlanner_GenerateMigrationAST_DropsFKBeforeRemovingItsTable(t *testing.T) {
 	diff := &types.SchemaDiff{
 		TablesRemoved: []string{"tasks", "projects", "accounts"},

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -828,11 +828,11 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	}
 
 	// Prefer the table-qualified additions when present. A field-level FK from an
-	// embedded inline-relation mixin shares one name across every host table, so
-	// resolving the table from the field's Go struct name targets the mixin
-	// struct rather than the real tables (issue #197). ConstraintsAddedWithTables
-	// carries the concrete table + full FK definition. Names handled here are
-	// recorded so the legacy name loop skips them.
+	// embedded inline-relation mixin shares one name across every host table, and
+	// down migrations restore modified CHECK/UNIQUE definitions from the
+	// introspected DB schema. ConstraintsAddedWithTables carries the concrete
+	// table + definition. Names handled here are recorded so the legacy name loop
+	// skips them.
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	for _, add := range diff.ConstraintsAddedWithTables {
@@ -848,6 +848,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		})
 		handled[add.Name] = struct{}{}
 	}
+	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
@@ -882,6 +883,54 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	return result
 }
 
+func (p *Planner) addCheckAndUniqueConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	removalByTableName map[string]types.ConstraintRemovalInfo,
+	handled map[string]struct{},
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	for _, add := range additions {
+		constraint := p.constraintAdditionNode(add)
+		if constraint == nil {
+			continue
+		}
+		if info, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.appendScopedDrop(result, info, droppedForModify)
+		}
+		result = append(result, &ast.AlterTableNode{
+			Name:       add.TableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: constraint}},
+		})
+		handled[add.Name] = struct{}{}
+	}
+	return result
+}
+
+func (p *Planner) constraintAdditionNode(add types.ConstraintAdditionInfo) *ast.ConstraintNode {
+	if add.TableName == "" {
+		return nil
+	}
+	switch add.Type {
+	case "CHECK":
+		if add.CheckExpression == "" || !p.capabilities().Has(capability.CheckConstraintsEnforced) {
+			return nil
+		}
+		return &ast.ConstraintNode{
+			Type:       ast.CheckConstraint,
+			Name:       add.Name,
+			Expression: add.CheckExpression,
+		}
+	case "UNIQUE":
+		if len(add.Columns) == 0 {
+			return nil
+		}
+		return ast.NewUniqueConstraint(add.Name, add.Columns...)
+	default:
+		return nil
+	}
+}
+
 // emitModifyDropForName appends the DROP(s) that must precede the re-ADD of a
 // modified constraint reached via the bare ConstraintsAdded name list (the
 // non-FK and field-level synthesis paths; FK modifies are handled per-host in
@@ -905,12 +954,12 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 //
 // When addedHosts is empty the re-added hosts are unknown — e.g. a
 // reverse/down diff fills ConstraintsRemovedWithTables but not
-// ConstraintsAddedWithTables (reverseConstraintAdditions restores only
-// FOREIGN KEYs, and nothing at all when the introspected schema is absent). In
-// that case every recorded removal host is dropped here and removeConstraints
-// skips the name entirely (its hostless-re-add rule), so each host is still
-// dropped exactly once. A name with no recorded removal host at all emits no
-// drop: MySQL has no anonymous-block equivalent of the postgres
+// ConstraintsAddedWithTables because the prior definition could not be
+// reconstructed from schema context. In that case every recorded removal host
+// is dropped here and removeConstraints skips the name entirely (its
+// hostless-re-add rule), so each host is still dropped exactly once. A name
+// with no recorded removal host at all emits no drop: MySQL has no
+// anonymous-block equivalent of the postgres
 // information_schema DO fallback to resolve the owner at runtime, so the
 // re-add proceeds alone (pre-existing behavior for hand-built diffs).
 func (p *Planner) emitModifyDropForName(

--- a/migration/planner/dialects/postgres/hostless_constraints_test.go
+++ b/migration/planner/dialects/postgres/hostless_constraints_test.go
@@ -12,13 +12,79 @@ import (
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
+func TestPlanner_GenerateMigrationAST_TableQualifiedCheckAndUniqueAdditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     *types.SchemaDiff
+		wantDrop string
+		wantAdd  string
+	}{
+		{
+			name: "unique to check",
+			diff: &types.SchemaDiff{
+				ConstraintsAdded: []string{"products_quantity_guard"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:            "products_quantity_guard",
+					TableName:       "products",
+					Type:            "CHECK",
+					CheckExpression: "quantity > 10",
+				}},
+				ConstraintsRemoved: []string{"products_quantity_guard"},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+					Name:      "products_quantity_guard",
+					TableName: "products",
+					Type:      "UNIQUE",
+				}},
+			},
+			wantDrop: "ALTER TABLE products DROP CONSTRAINT IF EXISTS products_quantity_guard;",
+			wantAdd:  "ALTER TABLE products ADD CONSTRAINT products_quantity_guard CHECK (quantity > 10);",
+		},
+		{
+			name: "check to unique",
+			diff: &types.SchemaDiff{
+				ConstraintsAdded: []string{"accounts_identity"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:      "accounts_identity",
+					TableName: "accounts",
+					Type:      "UNIQUE",
+					Columns:   []string{"email", "region"},
+				}},
+				ConstraintsRemoved: []string{"accounts_identity"},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+					Name:      "accounts_identity",
+					TableName: "accounts",
+					Type:      "CHECK",
+				}},
+			},
+			wantDrop: "ALTER TABLE accounts DROP CONSTRAINT IF EXISTS accounts_identity;",
+			wantAdd:  "ALTER TABLE accounts ADD CONSTRAINT accounts_identity UNIQUE (email, region);",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql, err := renderer.RenderSQL("postgres", postgres.New().GenerateMigrationAST(tt.diff, &goschema.Database{})...)
+			c.Assert(err, qt.IsNil)
+			sql = legacyRenderedSQL(sql)
+
+			dropIdx := strings.Index(sql, tt.wantDrop)
+			addIdx := strings.Index(sql, tt.wantAdd)
+			c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
+				qt.Commentf("drop must precede add; got:\n%s", sql))
+			c.Assert(strings.Count(sql, tt.wantAdd), qt.Equals, 1)
+		})
+	}
+}
+
 // TestPlanner_GenerateMigrationAST_HostlessReAdd_DropsExactlyOnce guards the
 // hostless-re-add ownership rule (issue #229). When a name is re-added with NO
 // recorded addition hosts (ConstraintsAdded carries it but
 // ConstraintsAddedWithTables has no entry — the shape of every reverse/down
-// diff of a non-FK constraint modify, since reverseConstraintAdditions
-// restores FOREIGN KEYs only), the add side drops every recorded removal host
-// BEFORE the re-add, and removeConstraints must skip the name entirely.
+// diff whose old constraint body could not be reconstructed), the add side
+// drops every recorded removal host BEFORE the re-add, and removeConstraints
+// must skip the name entirely.
 //
 // Before the fix removeConstraints emitted a second guarded drop AFTER the
 // re-add — and IF EXISTS is no protection against dropping a constraint that

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -1673,6 +1673,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})
 	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
+	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
 	for _, add := range diff.ConstraintsAddedWithTables {
 		if add.Type != "FOREIGN KEY" || add.TableName == "" {
 			continue
@@ -1717,6 +1718,56 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		}
 	}
 	return result
+}
+
+func (p *Planner) addCheckAndUniqueConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	removalByTableName map[string]types.ConstraintRemovalInfo,
+	handled map[string]struct{},
+	droppedForModify map[string]struct{},
+) []ast.Node {
+	for _, add := range additions {
+		constraint := constraintAdditionNode(add)
+		if constraint == nil {
+			continue
+		}
+		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.emitModifyDrop(result, add, droppedForModify)
+		}
+		result = append(result, &ast.AlterTableNode{
+			Name:       add.TableName,
+			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: constraint}},
+		})
+		handled[add.Name] = struct{}{}
+	}
+	return result
+}
+
+func constraintAdditionNode(add types.ConstraintAdditionInfo) *ast.ConstraintNode {
+	if add.TableName == "" {
+		return nil
+	}
+	switch add.Type {
+	case "CHECK":
+		if add.CheckExpression == "" {
+			return nil
+		}
+		return &ast.ConstraintNode{
+			Type:       ast.CheckConstraint,
+			Name:       add.Name,
+			Expression: add.CheckExpression,
+		}
+	case "UNIQUE":
+		if len(add.Columns) == 0 {
+			return nil
+		}
+		constraint := ast.NewUniqueConstraint(add.Name, add.Columns...)
+		constraint.NullsDistinct = cloneBoolPtr(add.NullsDistinct)
+		return constraint
+	default:
+		return nil
+	}
 }
 
 func (p *Planner) addPrimaryKeyConstraintsWithTables(
@@ -1797,12 +1848,12 @@ func (p *Planner) emitModifyDrop(
 //
 // When addedHosts is empty the re-added hosts are unknown — e.g. a down/reverse
 // diff fills ConstraintsRemovedWithTables but not ConstraintsAddedWithTables
-// (reverseConstraintAdditions restores only FOREIGN KEYs, and nothing at all
-// when the schema context is absent). In that case the drop is still scoped to
-// every recorded removal host (the pre-#206 behavior), NOT the name-only DO
-// block — otherwise the reverse direction would regress a known-host drop back
-// to the information_schema LIMIT 1 lookup. Only a name with no recorded removal
-// host at all falls back to the DO block.
+// because the prior definition could not be reconstructed from schema context.
+// In that case the drop is still scoped to every recorded removal host (the
+// pre-#206 behavior), NOT the name-only DO block — otherwise the reverse
+// direction would regress a known-host drop back to the information_schema LIMIT
+// 1 lookup. Only a name with no recorded removal host at all falls back to the
+// DO block.
 func (p *Planner) emitModifyDropForName(
 	result []ast.Node,
 	name string,

--- a/migration/schemadiff/internal/compare/compare.go
+++ b/migration/schemadiff/internal/compare/compare.go
@@ -1097,16 +1097,17 @@ func appendConstraintRemoval(infos []difftypes.ConstraintRemovalInfo, dbConstrai
 // one entry and matches the legacy field-scan behavior.
 func appendConstraintAddition(infos []difftypes.ConstraintAdditionInfo, genConstraint goschema.Constraint) []difftypes.ConstraintAdditionInfo {
 	return append(infos, difftypes.ConstraintAdditionInfo{
-		Name:           genConstraint.Name,
-		TableName:      genConstraint.Table,
-		Type:           genConstraint.Type,
-		Columns:        append([]string(nil), genConstraint.Columns...),
-		NullsDistinct:  cloneBoolPtr(genConstraint.NullsDistinct),
-		ForeignTable:   genConstraint.ForeignTable,
-		ForeignColumn:  genConstraint.ForeignColumn,
-		ForeignColumns: append([]string(nil), genConstraint.ForeignColumnsOrDefault()...),
-		OnDelete:       genConstraint.OnDelete,
-		OnUpdate:       genConstraint.OnUpdate,
+		Name:            genConstraint.Name,
+		TableName:       genConstraint.Table,
+		Type:            genConstraint.Type,
+		Columns:         append([]string(nil), genConstraint.Columns...),
+		NullsDistinct:   cloneBoolPtr(genConstraint.NullsDistinct),
+		CheckExpression: genConstraint.CheckExpression,
+		ForeignTable:    genConstraint.ForeignTable,
+		ForeignColumn:   genConstraint.ForeignColumn,
+		ForeignColumns:  append([]string(nil), genConstraint.ForeignColumnsOrDefault()...),
+		OnDelete:        genConstraint.OnDelete,
+		OnUpdate:        genConstraint.OnUpdate,
 	})
 }
 
@@ -1204,6 +1205,9 @@ func normalizeCheckExpression(expr string) string {
 			continue
 		}
 		if !inString && unicode.IsSpace(rune(ch)) {
+			continue
+		}
+		if !inString && ch == '`' {
 			continue
 		}
 		if !inString && ch >= 'A' && ch <= 'Z' {

--- a/migration/schemadiff/internal/compare/constraints_test.go
+++ b/migration/schemadiff/internal/compare/constraints_test.go
@@ -193,6 +193,31 @@ func TestConstraints(t *testing.T) {
 			},
 		},
 		{
+			name: "CHECK constraint MySQL quoted identifier is equivalent",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{
+					{
+						StructName:      "Product",
+						Name:            "products_quantity_check",
+						Type:            "CHECK",
+						Table:           "products",
+						CheckExpression: "quantity > 0",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{
+					{
+						Name:        "products_quantity_check",
+						TableName:   "products",
+						Type:        "CHECK",
+						CheckClause: new("(`quantity` > 0)"),
+					},
+				},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
 			name: "UNIQUE constraint added",
 			generated: &goschema.Database{
 				Constraints: []goschema.Constraint{
@@ -342,6 +367,84 @@ func TestConstraints(t *testing.T) {
 			for _, expected := range tt.expected.ConstraintsRemoved {
 				c.Assert(diff.ConstraintsRemoved, qt.Contains, expected)
 			}
+		})
+	}
+}
+
+func TestConstraints_SameNameTypeDriftCarriesAdditionBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		generated *goschema.Database
+		database  *types.DBSchema
+		expected  []difftypes.ConstraintAdditionInfo
+	}{
+		{
+			name: "CHECK to UNIQUE",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{{
+					StructName: "Account",
+					Name:       "accounts_identity",
+					Type:       "UNIQUE",
+					Table:      "accounts",
+					Columns:    []string{"email", "region"},
+				}},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{{
+					Name:        "accounts_identity",
+					TableName:   "accounts",
+					Type:        "CHECK",
+					CheckClause: new("email <> ''"),
+				}},
+			},
+			expected: []difftypes.ConstraintAdditionInfo{{
+				Name:      "accounts_identity",
+				TableName: "accounts",
+				Type:      "UNIQUE",
+				Columns:   []string{"email", "region"},
+			}},
+		},
+		{
+			name: "UNIQUE to CHECK",
+			generated: &goschema.Database{
+				Constraints: []goschema.Constraint{{
+					StructName:      "Product",
+					Name:            "products_quantity_guard",
+					Type:            "CHECK",
+					Table:           "products",
+					CheckExpression: "quantity > 10",
+				}},
+			},
+			database: &types.DBSchema{
+				Constraints: []types.DBConstraint{{
+					Name:        "products_quantity_guard",
+					TableName:   "products",
+					Type:        "UNIQUE",
+					ColumnNames: []string{"quantity"},
+				}},
+			},
+			expected: []difftypes.ConstraintAdditionInfo{{
+				Name:            "products_quantity_guard",
+				TableName:       "products",
+				Type:            "CHECK",
+				CheckExpression: "quantity > 10",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &difftypes.SchemaDiff{}
+			compare.Constraints(tt.generated, tt.database, diff, nil)
+
+			c.Assert(diff.ConstraintsAdded, qt.DeepEquals, []string{tt.expected[0].Name})
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, []string{tt.expected[0].Name})
+			c.Assert(diff.ConstraintsAddedWithTables, qt.DeepEquals, tt.expected)
+			c.Assert(diff.ConstraintsRemovedWithTables, qt.HasLen, 1)
+			c.Assert(diff.ConstraintsRemovedWithTables[0].Name, qt.Equals, tt.expected[0].Name)
+			c.Assert(diff.ConstraintsRemovedWithTables[0].TableName, qt.Equals, tt.expected[0].TableName)
 		})
 	}
 }

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -56,11 +56,14 @@ type ConstraintAdditionInfo struct {
 	// Type is the constraint type (FOREIGN KEY, CHECK, UNIQUE, ...).
 	Type string `json:"type"`
 
-	// Columns are the local columns the constraint covers (FK source columns).
+	// Columns are the local columns the constraint covers (UNIQUE columns or FK
+	// source columns).
 	Columns []string `json:"columns,omitempty"`
 	// NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
 	// Nil means the clause was not specified.
 	NullsDistinct *bool `json:"nulls_distinct,omitempty"`
+	// CheckExpression is the CHECK predicate body (CHECK only).
+	CheckExpression string `json:"check_expression,omitempty"`
 
 	// ForeignTable / ForeignColumn / ForeignColumns describe the FK target
 	// (FOREIGN KEY only). ForeignColumn is kept for compatibility with older


### PR DESCRIPTION
## Summary
- unblock same-name CHECK and UNIQUE drift round-trip fixtures by removing the closed #126 allowlist entries
- carry CHECK expressions through table-qualified constraint additions and restore prior CHECK/UNIQUE bodies for DOWN migrations
- introspect MySQL/MariaDB CHECK clauses from information_schema with a MariaDB table-aware query, MySQL name-only fallback, and fail-closed error handling
- render MariaDB named column CHECK constraints as table-level constraints inside CREATE TABLE
- add CHECK->UNIQUE and UNIQUE->CHECK fixture pairs for round-trip coverage

## Self-review
- Pass 1: checked rollback correctness, same-name type drift handling, table scoping, MySQL/MariaDB CHECK introspection, and renderer dialect behavior; fixed late rows.Err propagation.
- Pass 2: checked API/docs/comments/test coverage and stale FK-only assumptions; updated comments and field documentation.
- Multi-agent review: no blocker/major findings; addressed the minor stale-comment finding before PR.

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-430-go-build-cache go test ./... -count=1
- env GOWORK=off go tool qtlint ./...
- env GOWORK=off golangci-lint run ./...
- scripts/check-public-api-snapshot.sh
- git diff --check
- make docker-build
- docker compose --profile test run --rm ptah-tester --databases=postgres,mysql,mariadb --scenarios=migration_generator_roundtrip_fixtures --report=stdout,txt,json --verbose --output=./reports
  - 3 passed, 0 failed, 0 skipped; 100.0% success rate

## Notes
- Ptah repo does not currently contain docs/conformance.md. The conformance report should be regenerated in the conformance repo after this PR lands and Ptah is bumped there.

Refs #430