### PR TITLE
Document Atlas conformance scoreboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Ptah Migration Library Makefile
 
-.PHONY: help build test integration-test clean docker-build lint lint-qtlint lint-fix install-hooks
+.PHONY: help build test integration-test clean docker-build lint lint-qtlint lint-fix install-hooks conformance
 
 VERSION ?= $(shell git describe --tags --always --dirty)
 COMMIT ?= $(shell git rev-parse --short HEAD)
@@ -19,6 +19,7 @@ help:
 	@echo "  test               Run unit tests"
 	@echo "  integration-test   Run integration tests using Docker Compose"
 	@echo "  lint               Run golangci-lint and qtlint"
+	@echo "  conformance        Show Atlas conformance scoreboard location"
 	@echo "  lint-fix           Run auto-fixable linters"
 	@echo "  install-hooks      Install local Git hooks"
 	@echo "  docker-build       Build Docker images"
@@ -158,6 +159,24 @@ lint-fix:
 	go tool qtlint -fix ./...
 	golangci-lint run --fix ./...
 	$(MAKE) lint
+
+# Atlas parity scoreboard. The executable harness and Apache-2.0 Atlas fixture
+# corpus intentionally live outside this MIT repository, under
+# stokaro/ptah-atlas-conformance. Keep the dependency direction one-way:
+# conformance imports Ptah; Ptah does not import or vendor conformance.
+conformance:
+	@echo "Atlas conformance scoreboard:"
+	@echo "  docs/conformance.md"
+	@echo "  https://github.com/stokaro/ptah-atlas-conformance"
+	@echo ""
+	@echo "Run the harness from that repository:"
+	@echo "  make probe        # offline corpus report"
+	@echo "  make budget       # offline regression budget"
+	@echo "  make gate         # full offline parity gate"
+	@echo "  make probe-live   # live DB round-trip report"
+	@echo "  make budget-live  # live DB regression budget"
+	@echo "  make probe-diff   # Atlas CE differential report"
+	@echo "  make budget-diff  # Atlas CE differential regression budget"
 
 # Format code
 fmt:

--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,11 @@ flag translation, so their exit codes follow the native command contract
 documented in [CLI Exit Codes](docs/exit_codes.md). Unsupported Atlas-compatible
 flags are rejected explicitly and exit `2`.
 
+Ptah's current Atlas parity status is tracked in
+[Atlas Conformance](docs/conformance.md), backed by the CI-regenerated
+[`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance)
+scoreboards.
+
 #### Migration Directory Integrity (`ptah.sum` / `atlas.sum`)
 
 Once a migration is committed and applied somewhere, its content must never change.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,64 @@
+# Atlas Conformance
+
+Ptah's Atlas conformance scoreboard is maintained in the dedicated
+[`stokaro/ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance)
+repository.
+
+That repository is the authoritative, CI-regenerated answer to "are we there
+yet?" for Atlas OSS compatibility. It keeps Atlas's Apache-2.0 fixture corpus
+outside Ptah's MIT source tree while importing Ptah as the system under test.
+The dependency direction is intentionally one-way:
+
+```text
+ptah-atlas-conformance -> ptah
+ptah                  !-> ptah-atlas-conformance
+```
+
+## Current Scoreboard
+
+As of Ptah `18ae5f9d4d63136248986263732524e2314f9d7c`:
+
+| Tier | Purpose | Current result |
+| --- | --- | --- |
+| Offline Atlas corpus | Can Ptah ingest Atlas OSS fixture artifacts through public APIs? | 636 ok, 0 gap, 0 fail, 0 panic |
+| Live round-trip | Can Ptah generate, apply, introspect, and diff first-party schemas on real databases? | 8 ok, 2 known gaps |
+| Atlas CE differential | Do Atlas CE and Ptah agree on live end-state facts for shared fixtures? | 1 ok, 4 known gaps |
+
+The offline full-conformance gate is green. The live and differential full gates
+remain intentionally red until the known gaps are closed, while their regression
+budgets stay green when the reports are current and no new gaps appear.
+
+## Reports
+
+- Offline corpus report:
+  [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md)
+- Live round-trip report:
+  [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md)
+- Atlas CE differential report:
+  [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md)
+- Parity scope:
+  [`PARITY.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/PARITY.md)
+
+## Local Commands
+
+From this repository:
+
+```bash
+make conformance
+```
+
+From `ptah-atlas-conformance`:
+
+```bash
+make probe        # regenerate gaps.md / gaps.json
+make budget       # offline regression budget
+make gate         # full offline parity gate
+make probe-live   # live DB round-trip report
+make budget-live  # live DB regression budget
+make probe-diff   # Atlas CE differential report
+make budget-diff  # Atlas CE differential regression budget
+```
+
+Live and differential commands require real database URLs, and the differential
+tier also requires an Atlas CE binary built from the pinned `atlas.version` in
+the conformance repository.


### PR DESCRIPTION
## Summary
- add docs/conformance.md pointing Ptah users to the authoritative ptah-atlas-conformance scoreboard
- record the current scoreboard state from Ptah 18ae5f9 after conformance PR #160
- add a make conformance target that preserves the license/dependency boundary and shows where to run the harness
- link the conformance doc from the Atlas-compatible CLI section of README

## Self-review
- Pass 1: checked issue #285 against the current architecture and confirmed the executable harness/report trend now lives in the dedicated conformance repository, not inside Ptah.
- Pass 2: checked that the doc does not claim live/differential full parity, keeps Apache Atlas fixtures out of Ptah, and distinguishes green regression budgets from intentionally red full live/diff gates.

## Validation
- make conformance
- git diff --check
- env GOWORK=off go tool qtlint ./...
- env GOWORK=off golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-285-go-build-cache go test ./... -count=1

## Related evidence
- stokaro/ptah-atlas-conformance#160 bumped Ptah to 18ae5f9 and passed offline, full gate, live-roundtrip, and Atlas differential CI.

Closes #285