### PR TITLE
Optimize schema introspection column loading

### DIFF
--- a/dbschema/clickhouse/clickhouse_test.go
+++ b/dbschema/clickhouse/clickhouse_test.go
@@ -1,10 +1,14 @@
 package clickhouse
 
 import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/dbschema/internal/dbtest"
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
@@ -66,4 +70,50 @@ func TestWriter_DryRun_NoDBRequired(t *testing.T) {
 	// DropAllTables dry-run prints a stub table list and emits no DDL,
 	// so it must succeed without a live DB.
 	c.Assert(w.DropAllTables(), qt.IsNil)
+}
+
+func TestReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
+	c := qt.New(t)
+
+	tableRows := make([][]driver.Value, 0, 50)
+	columnRows := make([][]driver.Value, 0, 100)
+	for i := range 50 {
+		tableName := fmt.Sprintf("table_%02d", i)
+		tableRows = append(tableRows, []driver.Value{tableName, ""})
+		columnRows = append(columnRows,
+			[]driver.Value{tableName, "id", "UInt64", "", "", uint64(1), ""},
+			[]driver.Value{tableName, "payload", "Nullable(String)", "", "", uint64(2), ""},
+		)
+	}
+	columnRows[3][3] = "DEFAULT"
+	columnRows[3][4] = "0"
+
+	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		switch {
+		case strings.Contains(query, "FROM system.columns"):
+			return dbtest.QueryResult{
+				Columns: []string{"table", "name", "type", "default_kind", "default_expression", "position", "comment"},
+				Rows:    columnRows,
+			}, nil
+		case strings.Contains(query, "FROM system.tables"):
+			return dbtest.QueryResult{
+				Columns: []string{"name", "comment"},
+				Rows:    tableRows,
+			}, nil
+		default:
+			return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+		}
+	})
+	reader := NewClickHouseReader(db.SQL, "default")
+
+	tables, err := reader.readTables("default")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(tables, qt.HasLen, 50)
+	c.Assert(tables[0].Name, qt.Equals, "table_00")
+	c.Assert(tables[0].Columns, qt.HasLen, 2)
+	c.Assert(tables[0].Columns[1].IsNullable, qt.Equals, "YES")
+	c.Assert(tables[1].Columns[1].ColumnDefault, qt.IsNotNil)
+	c.Assert(*tables[1].Columns[1].ColumnDefault, qt.Equals, "0")
 }

--- a/dbschema/clickhouse/reader.go
+++ b/dbschema/clickhouse/reader.go
@@ -71,6 +71,11 @@ func (r *Reader) resolveDatabaseName() (string, error) {
 }
 
 func (r *Reader) readTables(dbName string) ([]types.DBTable, error) {
+	columnsByTable, err := r.readColumnsByTable(dbName)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse: read columns: %w", err)
+	}
+
 	rows, err := r.db.Query(`
 		SELECT name, comment
 		FROM system.tables
@@ -98,11 +103,7 @@ func (r *Reader) readTables(dbName string) ([]types.DBTable, error) {
 			return nil, err
 		}
 		t := types.DBTable{Name: name, Type: "TABLE", Comment: comment}
-		columns, err := r.readColumns(dbName, name)
-		if err != nil {
-			return nil, fmt.Errorf("clickhouse: read columns for %s: %w", name, err)
-		}
-		t.Columns = columns
+		t.Columns = columnsByTable[name]
 		tables = append(tables, t)
 	}
 	if err := rows.Err(); err != nil {
@@ -111,25 +112,26 @@ func (r *Reader) readTables(dbName string) ([]types.DBTable, error) {
 	return tables, nil
 }
 
-func (r *Reader) readColumns(dbName, table string) ([]types.DBColumn, error) {
+func (r *Reader) readColumnsByTable(dbName string) (map[string][]types.DBColumn, error) {
 	rows, err := r.db.Query(`
-		SELECT name, type, default_kind, default_expression, position, comment
+		SELECT table, name, type, default_kind, default_expression, position, comment
 		FROM system.columns
-		WHERE database = ? AND table = ?
-		ORDER BY position
-	`, dbName, table)
+		WHERE database = ?
+		ORDER BY table, position
+	`, dbName)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var cols []types.DBColumn
+	columnsByTable := make(map[string][]types.DBColumn)
 	for rows.Next() {
 		var (
+			tableName                                         string
 			name, dataType, defaultKind, defaultExpr, comment string
 			position                                          int
 		)
-		if err := rows.Scan(&name, &dataType, &defaultKind, &defaultExpr, &position, &comment); err != nil {
+		if err := rows.Scan(&tableName, &name, &dataType, &defaultKind, &defaultExpr, &position, &comment); err != nil {
 			return nil, err
 		}
 		nullable := "NO"
@@ -164,12 +166,12 @@ func (r *Reader) readColumns(dbName, table string) ([]types.DBColumn, error) {
 			}
 			col.GeneratedKind = defaultKind
 		}
-		cols = append(cols, col)
+		columnsByTable[tableName] = append(columnsByTable[tableName], col)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	return cols, nil
+	return columnsByTable, nil
 }
 
 // skippingIndexTablePresent reports whether system.data_skipping_indices is

--- a/dbschema/internal/dbtest/driver.go
+++ b/dbschema/internal/dbtest/driver.go
@@ -1,0 +1,109 @@
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"strconv"
+	"sync/atomic"
+)
+
+type QueryResult struct {
+	Columns []string
+	Rows    [][]driver.Value
+}
+
+type QueryHandler func(query string, args []driver.NamedValue) (QueryResult, error)
+
+type DB struct {
+	SQL        *sql.DB
+	queryCount *atomic.Int64
+}
+
+func Open(t interface{ Cleanup(func()) }, handler QueryHandler) *DB {
+	name := "ptah_dbtest_" + strconv.FormatInt(driverID.Add(1), 10)
+	queryCount := new(atomic.Int64)
+	sql.Register(name, &countingDriver{
+		handler:    handler,
+		queryCount: queryCount,
+	})
+	db, err := sql.Open(name, "")
+	if err != nil {
+		panic(err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return &DB{SQL: db, queryCount: queryCount}
+}
+
+func (db *DB) QueryCount() int {
+	return int(db.queryCount.Load())
+}
+
+var driverID atomic.Int64
+
+type countingDriver struct {
+	handler    QueryHandler
+	queryCount *atomic.Int64
+}
+
+func (d *countingDriver) Open(_ string) (driver.Conn, error) {
+	return &countingConn{
+		handler:    d.handler,
+		queryCount: d.queryCount,
+	}, nil
+}
+
+type countingConn struct {
+	handler    QueryHandler
+	queryCount *atomic.Int64
+}
+
+func (c *countingConn) Prepare(_ string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare is not supported")
+}
+
+func (c *countingConn) Close() error {
+	return nil
+}
+
+func (c *countingConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("transactions are not supported")
+}
+
+func (c *countingConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.queryCount.Add(1)
+	result, err := c.handler(query, args)
+	if err != nil {
+		return nil, err
+	}
+	return &rows{columns: result.Columns, rows: result.Rows}, nil
+}
+
+var _ driver.QueryerContext = (*countingConn)(nil)
+
+type rows struct {
+	columns []string
+	rows    [][]driver.Value
+	index   int
+}
+
+func (r *rows) Columns() []string {
+	return r.columns
+}
+
+func (r *rows) Close() error {
+	return nil
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	if r.index >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.index])
+	r.index++
+	return nil
+}

--- a/dbschema/mysql/mysql_test.go
+++ b/dbschema/mysql/mysql_test.go
@@ -2,12 +2,17 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/dbschema/internal/dbtest"
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
@@ -70,20 +75,6 @@ func TestMySQLReader_CheckConstraintIntrospectionErrorClassification(t *testing.
 		Number:  1142,
 		Message: "SELECT command denied to user",
 	}), qt.IsFalse)
-}
-
-func TestMySQLReader_parseTableFromDDLGeneratedColumn(t *testing.T) {
-	c := qt.New(t)
-
-	reader := NewMySQLReader(nil, "")
-	table, err := reader.parseTableFromDDL("CREATE TABLE `users` (`name` varchar(255), `name_lc` varchar(255) GENERATED ALWAYS AS (lower(`name`)) STORED)")
-	c.Assert(err, qt.IsNil)
-
-	nameLC := findColumn(table.Columns, "name_lc")
-	c.Assert(nameLC, qt.IsNotNil)
-	c.Assert(nameLC.GeneratedExpression, qt.IsNotNil)
-	c.Assert(*nameLC.GeneratedExpression, qt.Equals, "lower(`name`)")
-	c.Assert(nameLC.GeneratedKind, qt.Equals, "STORED")
 }
 
 func TestMySQLReader_parseEnumValues(t *testing.T) {
@@ -153,152 +144,6 @@ func TestMySQLReader_parseEnumValues(t *testing.T) {
 	})
 }
 
-// TestMySQLReader_parseTableFromDDL tests the new DDL parsing functionality
-func TestMySQLReader_parseTableFromDDL(t *testing.T) {
-	tests := []struct {
-		name        string
-		ddl         string
-		expectError bool
-		validate    func(c *qt.C, table types.DBTable)
-	}{
-		{
-			name: "simple table with primary key",
-			ddl: "CREATE TABLE `users` (\n" +
-				"  `id` int NOT NULL AUTO_INCREMENT,\n" +
-				"  `name` varchar(255) NOT NULL,\n" +
-				"  `email` varchar(255) DEFAULT NULL,\n" +
-				"  PRIMARY KEY (`id`)\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
-			expectError: false,
-			validate: func(c *qt.C, table types.DBTable) {
-				c.Assert(table.Name, qt.Equals, "users")
-				c.Assert(table.Type, qt.Equals, "BASE TABLE")
-				c.Assert(table.Columns, qt.HasLen, 3)
-
-				// Check id column
-				idCol := table.Columns[0]
-				c.Assert(idCol.Name, qt.Equals, "id")
-				c.Assert(idCol.DataType, qt.Equals, "int")
-				c.Assert(idCol.IsNullable, qt.Equals, "NO")
-				c.Assert(idCol.IsAutoIncrement, qt.IsTrue)
-				c.Assert(idCol.IsPrimaryKey, qt.IsTrue)
-
-				// Check name column
-				nameCol := table.Columns[1]
-				c.Assert(nameCol.Name, qt.Equals, "name")
-				c.Assert(nameCol.DataType, qt.Equals, "varchar(255)")
-				c.Assert(nameCol.IsNullable, qt.Equals, "NO")
-				c.Assert(nameCol.IsAutoIncrement, qt.IsFalse)
-				c.Assert(nameCol.IsPrimaryKey, qt.IsFalse)
-
-				// Check email column
-				emailCol := table.Columns[2]
-				c.Assert(emailCol.Name, qt.Equals, "email")
-				c.Assert(emailCol.DataType, qt.Equals, "varchar(255)")
-				c.Assert(emailCol.IsNullable, qt.Equals, "YES")
-				c.Assert(emailCol.IsAutoIncrement, qt.IsFalse)
-				c.Assert(emailCol.IsPrimaryKey, qt.IsFalse)
-			},
-		},
-		{
-			name: "table with unique constraint",
-			ddl: "CREATE TABLE `products` (\n" +
-				"  `id` int NOT NULL AUTO_INCREMENT,\n" +
-				"  `sku` varchar(100) NOT NULL,\n" +
-				"  PRIMARY KEY (`id`),\n" +
-				"  UNIQUE KEY `uk_sku` (`sku`)\n" +
-				") ENGINE=InnoDB",
-			expectError: false,
-			validate: func(c *qt.C, table types.DBTable) {
-				c.Assert(table.Name, qt.Equals, "products")
-				c.Assert(table.Columns, qt.HasLen, 2)
-
-				// Check sku column should be marked as unique
-				skuCol := table.Columns[1]
-				c.Assert(skuCol.Name, qt.Equals, "sku")
-				c.Assert(skuCol.IsUnique, qt.IsTrue)
-			},
-		},
-		{
-			name: "real MySQL SHOW CREATE TABLE output",
-			ddl: "CREATE TABLE `test_table` (\n" +
-				"  `id` int NOT NULL AUTO_INCREMENT,\n" +
-				"  `name` varchar(255) NOT NULL,\n" +
-				"  `status` enum('active','inactive') DEFAULT 'active',\n" +
-				"  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,\n" +
-				"  PRIMARY KEY (`id`),\n" +
-				"  UNIQUE KEY `unique_name` (`name`)\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
-			expectError: false,
-			validate: func(c *qt.C, table types.DBTable) {
-				c.Assert(table.Name, qt.Equals, "test_table")
-				c.Assert(table.Columns, qt.HasLen, 4)
-
-				// Check id column
-				idCol := table.Columns[0]
-				c.Assert(idCol.Name, qt.Equals, "id")
-				c.Assert(idCol.IsAutoIncrement, qt.IsTrue)
-				c.Assert(idCol.IsPrimaryKey, qt.IsTrue)
-
-				// Check name column
-				nameCol := table.Columns[1]
-				c.Assert(nameCol.Name, qt.Equals, "name")
-				c.Assert(nameCol.IsUnique, qt.IsTrue)
-
-				// Check status column (enum)
-				statusCol := table.Columns[2]
-				c.Assert(statusCol.Name, qt.Equals, "status")
-				c.Assert(statusCol.DataType, qt.Equals, "enum('active','inactive')")
-
-				// Check created_at column
-				createdCol := table.Columns[3]
-				c.Assert(createdCol.Name, qt.Equals, "created_at")
-				c.Assert(createdCol.DataType, qt.Equals, "timestamp")
-				c.Assert(createdCol.IsNullable, qt.Equals, "YES")
-			},
-		},
-		{
-			name: "column charset and collate",
-			ddl: "CREATE TABLE `users` (\n" +
-				"  `name` varchar(255) CHARACTER SET hebrew COLLATE hebrew_general_ci NOT NULL\n" +
-				") ENGINE=InnoDB",
-			expectError: false,
-			validate: func(c *qt.C, table types.DBTable) {
-				c.Assert(table.Columns, qt.HasLen, 1)
-				nameCol := table.Columns[0]
-				c.Assert(nameCol.Name, qt.Equals, "name")
-				c.Assert(nameCol.Charset, qt.Equals, "hebrew")
-				c.Assert(nameCol.Collate, qt.Equals, "hebrew_general_ci")
-				c.Assert(nameCol.IsNullable, qt.Equals, "NO")
-			},
-		},
-		{
-			name:        "invalid DDL",
-			ddl:         "INVALID SQL STATEMENT",
-			expectError: true,
-			validate:    nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			c := qt.New(t)
-			reader := &Reader{}
-
-			table, err := reader.parseTableFromDDL(test.ddl)
-
-			if test.expectError {
-				c.Assert(err, qt.IsNotNil)
-			} else {
-				c.Assert(err, qt.IsNil)
-				if test.validate != nil {
-					test.validate(c, table)
-				}
-			}
-		})
-	}
-}
-
 func TestMySQLReader_ReadSchema_NoConnection(t *testing.T) {
 	c := qt.New(t)
 
@@ -310,6 +155,197 @@ func TestMySQLReader_ReadSchema_NoConnection(t *testing.T) {
 
 	// Note: We don't test ReadSchema() with nil db as it would panic
 	// This is expected behavior - the reader requires a valid database connection
+}
+
+func TestMySQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
+	c := qt.New(t)
+
+	tableRows := make([][]driver.Value, 0, 50)
+	columnRows := make([][]driver.Value, 0, 150)
+	for i := range 50 {
+		tableName := fmt.Sprintf("table_%02d", i)
+		comment := ""
+		if i == 0 {
+			comment = "customer accounts"
+		}
+		tableRows = append(tableRows, []driver.Value{tableName, "BASE TABLE", comment})
+		columnRows = append(columnRows,
+			[]driver.Value{tableName, "id", "int", "int", "NO", nil, nil, int64(10), int64(0), int64(1), nil, nil, "auto_increment", nil},
+			[]driver.Value{tableName, "email", "varchar", "varchar(255)", "NO", nil, int64(255), nil, nil, int64(2), "utf8mb4", "utf8mb4_0900_ai_ci", "", nil},
+			[]driver.Value{tableName, "email_lc", "varchar", "varchar(255)", "YES", nil, int64(255), nil, nil, int64(3), "utf8mb4", "utf8mb4_0900_ai_ci", "STORED GENERATED", "lower(`email`)"},
+		)
+	}
+
+	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		switch {
+		case strings.Contains(query, "FROM information_schema.COLUMNS"):
+			return dbtest.QueryResult{
+				Columns: []string{
+					"TABLE_NAME",
+					"COLUMN_NAME",
+					"DATA_TYPE",
+					"COLUMN_TYPE",
+					"IS_NULLABLE",
+					"COLUMN_DEFAULT",
+					"CHARACTER_MAXIMUM_LENGTH",
+					"NUMERIC_PRECISION",
+					"NUMERIC_SCALE",
+					"ORDINAL_POSITION",
+					"CHARACTER_SET_NAME",
+					"COLLATION_NAME",
+					"EXTRA",
+					"GENERATION_EXPRESSION",
+				},
+				Rows: columnRows,
+			}, nil
+		case strings.Contains(query, "FROM information_schema.TABLES"):
+			return dbtest.QueryResult{
+				Columns: []string{"TABLE_NAME", "TABLE_TYPE", "TABLE_COMMENT"},
+				Rows:    tableRows,
+			}, nil
+		default:
+			return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+		}
+	})
+	reader := NewMySQLReader(db.SQL, "app")
+
+	tables, err := reader.readTables("app")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(tables, qt.HasLen, 50)
+	c.Assert(tables[0].Name, qt.Equals, "table_00")
+	c.Assert(tables[0].Comment, qt.Equals, "customer accounts")
+	c.Assert(tables[0].Columns, qt.HasLen, 3)
+
+	id := tables[0].Columns[0]
+	c.Assert(id.IsAutoIncrement, qt.IsTrue)
+	c.Assert(id.NumericPrecision, qt.IsNotNil)
+	c.Assert(*id.NumericPrecision, qt.Equals, 10)
+	c.Assert(id.NumericScale, qt.IsNotNil)
+	c.Assert(*id.NumericScale, qt.Equals, 0)
+
+	email := tables[0].Columns[1]
+	c.Assert(email.DataType, qt.Equals, "varchar(255)")
+	c.Assert(email.ColumnType, qt.Equals, "varchar(255)")
+	c.Assert(email.CharacterMaxLength, qt.IsNotNil)
+	c.Assert(*email.CharacterMaxLength, qt.Equals, 255)
+	c.Assert(email.Charset, qt.Equals, "utf8mb4")
+	c.Assert(email.Collate, qt.Equals, "utf8mb4_0900_ai_ci")
+
+	emailLC := tables[0].Columns[2]
+	c.Assert(emailLC.GeneratedKind, qt.Equals, "STORED")
+	c.Assert(emailLC.GeneratedExpression, qt.IsNotNil)
+	c.Assert(*emailLC.GeneratedExpression, qt.Equals, "lower(`email`)")
+}
+
+func TestEnhanceTablesWithPrimaryKeys(t *testing.T) {
+	c := qt.New(t)
+
+	tables := []types.DBTable{
+		{
+			Name: "memberships",
+			Columns: []types.DBColumn{
+				{Name: "org_id"},
+				{Name: "user_id"},
+				{Name: "role"},
+			},
+		},
+	}
+	constraints := []types.DBConstraint{
+		{
+			TableName:   "memberships",
+			Type:        "PRIMARY KEY",
+			ColumnNames: []string{"org_id", "user_id"},
+		},
+	}
+
+	enhanceTablesWithPrimaryKeys(tables, constraints)
+
+	c.Assert(tables[0].Columns[0].IsPrimaryKey, qt.IsTrue)
+	c.Assert(tables[0].Columns[1].IsPrimaryKey, qt.IsTrue)
+	c.Assert(tables[0].Columns[2].IsPrimaryKey, qt.IsFalse)
+}
+
+func TestApplyMySQLColumnMetadataKeepsGeneratedExpressionWithoutExtra(t *testing.T) {
+	c := qt.New(t)
+
+	var col types.DBColumn
+	applyMySQLColumnMetadata(
+		&col,
+		sql.NullString{String: "default", Valid: true},
+		sql.NullInt64{Int64: 255, Valid: true},
+		sql.NullInt64{Int64: 10, Valid: true},
+		sql.NullInt64{Int64: 2, Valid: true},
+		sql.NullString{String: "utf8mb4", Valid: true},
+		sql.NullString{String: "utf8mb4_0900_ai_ci", Valid: true},
+		sql.NullString{},
+		sql.NullString{String: "lower(`email`)", Valid: true},
+	)
+
+	c.Assert(col.GeneratedExpression, qt.IsNotNil)
+	c.Assert(*col.GeneratedExpression, qt.Equals, "lower(`email`)")
+	c.Assert(col.GeneratedKind, qt.Equals, "")
+	c.Assert(col.ColumnDefault, qt.IsNotNil)
+	c.Assert(*col.ColumnDefault, qt.Equals, "default")
+}
+
+func TestNormalizeMySQLColumnDefaultQuotesCatalogStringLiterals(t *testing.T) {
+	tests := []struct {
+		name         string
+		columnType   string
+		dataType     string
+		defaultValue string
+		want         string
+	}{
+		{
+			name:         "enum value",
+			columnType:   "enum('draft','active')",
+			dataType:     "enum",
+			defaultValue: "draft",
+			want:         "'draft'",
+		},
+		{
+			name:         "varchar value with quote",
+			columnType:   "varchar(255)",
+			dataType:     "varchar",
+			defaultValue: "owner's draft",
+			want:         "'owner''s draft'",
+		},
+		{
+			name:         "numeric value",
+			columnType:   "int",
+			dataType:     "int",
+			defaultValue: "42",
+			want:         "42",
+		},
+		{
+			name:         "temporal expression",
+			columnType:   "timestamp",
+			dataType:     "timestamp",
+			defaultValue: "current_timestamp()",
+			want:         "current_timestamp()",
+		},
+		{
+			name:         "quoted value preserved",
+			columnType:   "varchar(255)",
+			dataType:     "varchar",
+			defaultValue: "'draft'",
+			want:         "'draft'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			col := &types.DBColumn{
+				ColumnType: test.columnType,
+				DataType:   test.dataType,
+			}
+
+			c.Assert(normalizeMySQLColumnDefault(col, test.defaultValue), qt.Equals, test.want)
+		})
+	}
 }
 
 func TestNewMySQLWriter(t *testing.T) {
@@ -547,13 +583,4 @@ func TestQuoteIdent(t *testing.T) {
 			c.Assert(quoteIdent(tc.in), qt.Equals, tc.want)
 		})
 	}
-}
-
-func findColumn(columns []types.DBColumn, name string) *types.DBColumn {
-	for i := range columns {
-		if columns[i].Name == name {
-			return &columns[i]
-		}
-	}
-	return nil
 }

--- a/dbschema/mysql/reader.go
+++ b/dbschema/mysql/reader.go
@@ -8,8 +8,6 @@ import (
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 
-	"github.com/stokaro/ptah/core/ast"
-	coreparser "github.com/stokaro/ptah/core/parser"
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
@@ -86,52 +84,28 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	}
 	schema.Triggers = triggers
 
-	// Reconcile per-column uniqueness against the authoritative index metadata.
-	// The DDL parser collapses every table-level KEY/INDEX clause to a UNIQUE
-	// constraint (it has no dedicated non-unique-index node), so a non-unique
-	// backing index — e.g. the index MySQL/MariaDB auto-creates for a FOREIGN
-	// KEY (`KEY fk_posts_user_id (user_id)`) — would otherwise mark its column
-	// as unique and produce a spurious `unique: true -> false` diff on an
-	// unchanged schema (issue #189 follow-up). information_schema.STATISTICS
-	// (NON_UNIQUE) is authoritative, so a column is unique only when a
-	// single-column unique index actually covers it.
+	// Reconcile per-column flags after all catalog metadata is loaded.
+	// information_schema.KEY_COLUMN_USAGE carries primary-key membership, and
+	// information_schema.STATISTICS (NON_UNIQUE) is authoritative for unique
+	// indexes. Keeping these derived flags in one post-pass avoids depending on
+	// per-column metadata that is either absent or lossy across MySQL/MariaDB
+	// versions.
+	enhanceTablesWithPrimaryKeys(schema.Tables, schema.Constraints)
 	reconcileColumnUniqueness(schema)
 
 	return schema, nil
 }
 
-// readTables reads all tables and their columns using SHOW CREATE TABLE and DDL parsing
+// readTables reads all tables and their columns using bulk information_schema
+// queries.
 func (r *Reader) readTables(dbName string) ([]types.DBTable, error) {
-	// First, get just the table names
-	tableNames, err := r.getTableNames(dbName)
+	columnsByTable, err := r.readColumnsByTable(dbName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get table names: %w", err)
+		return nil, fmt.Errorf("failed to read columns: %w", err)
 	}
 
-	var tables []types.DBTable
-	for _, tableName := range tableNames {
-		// Get DDL for this table using SHOW CREATE TABLE
-		ddl, err := r.getTableDDL(tableName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get DDL for table %s: %w", tableName, err)
-		}
-
-		// Parse DDL using core parser
-		table, err := r.parseTableFromDDL(ddl)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse DDL for table %s: %w", tableName, err)
-		}
-
-		tables = append(tables, table)
-	}
-
-	return tables, nil
-}
-
-// getTableNames fetches just the table names from the database
-func (r *Reader) getTableNames(dbName string) ([]string, error) {
 	query := `
-		SELECT TABLE_NAME
+		SELECT TABLE_NAME, TABLE_TYPE, COALESCE(TABLE_COMMENT, '')
 		FROM information_schema.TABLES
 		WHERE TABLE_SCHEMA = ?
 		AND TABLE_TYPE = 'BASE TABLE'
@@ -144,84 +118,202 @@ func (r *Reader) getTableNames(dbName string) ([]string, error) {
 	}
 	defer rows.Close()
 
-	var tableNames []string
+	var tables []types.DBTable
 	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
+		var table types.DBTable
+		if err := rows.Scan(&table.Name, &table.Type, &table.Comment); err != nil {
 			return nil, err
 		}
-		tableNames = append(tableNames, tableName)
+		table.Columns = columnsByTable[table.Name]
+		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
-	return tableNames, nil
+	return tables, nil
 }
 
-// getTableDDL gets the DDL for a specific table using SHOW CREATE TABLE.
-// The table name comes from information_schema and cannot be passed as a
-// bind parameter to SHOW CREATE TABLE, so it is routed through quoteIdent
-// (doubling embedded backticks per MySQL conventions) before being
-// interpolated.
-func (r *Reader) getTableDDL(tableName string) (string, error) {
-	query := "SHOW CREATE TABLE " + quoteIdent(tableName)
+func (r *Reader) readColumnsByTable(dbName string) (map[string][]types.DBColumn, error) {
+	query := `
+		SELECT
+			TABLE_NAME,
+			COLUMN_NAME,
+			DATA_TYPE,
+			COLUMN_TYPE,
+			IS_NULLABLE,
+			COLUMN_DEFAULT,
+			CHARACTER_MAXIMUM_LENGTH,
+			NUMERIC_PRECISION,
+			NUMERIC_SCALE,
+			ORDINAL_POSITION,
+			CHARACTER_SET_NAME,
+			COLLATION_NAME,
+			EXTRA,
+			GENERATION_EXPRESSION
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = ?
+		AND TABLE_NAME NOT IN ('schema_migrations')
+		ORDER BY TABLE_NAME, ORDINAL_POSITION`
 
-	var name, ddl string
-	err := r.db.QueryRow(query).Scan(&name, &ddl)
+	rows, err := r.db.Query(query, dbName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get DDL for table %s: %w", tableName, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	columnsByTable := make(map[string][]types.DBColumn)
+	for rows.Next() {
+		var col types.DBColumn
+		var tableName string
+		var defaultValue sql.NullString
+		var characterMaxLength, numericPrecision, numericScale sql.NullInt64
+		var charset, collate, extra, generatedExpression sql.NullString
+
+		err := rows.Scan(
+			&tableName,
+			&col.Name,
+			&col.DataType,
+			&col.ColumnType,
+			&col.IsNullable,
+			&defaultValue,
+			&characterMaxLength,
+			&numericPrecision,
+			&numericScale,
+			&col.OrdinalPosition,
+			&charset,
+			&collate,
+			&extra,
+			&generatedExpression,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if col.ColumnType != "" {
+			col.DataType = col.ColumnType
+		}
+
+		applyMySQLColumnMetadata(
+			&col,
+			defaultValue,
+			characterMaxLength,
+			numericPrecision,
+			numericScale,
+			charset,
+			collate,
+			extra,
+			generatedExpression,
+		)
+		columnsByTable[tableName] = append(columnsByTable[tableName], col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
-	return ddl, nil
+	return columnsByTable, nil
 }
 
-// parseTableFromDDL parses a table DDL using the core parser and converts to parsertypes.DBTable
-func (r *Reader) parseTableFromDDL(ddl string) (types.DBTable, error) {
-	// Parse DDL using core parser
-	parser := coreparser.NewParser(ddl)
-	statements, err := parser.Parse()
-	if err != nil {
-		return types.DBTable{}, fmt.Errorf("failed to parse DDL: %w", err)
+func applyMySQLColumnMetadata(
+	col *types.DBColumn,
+	defaultValue sql.NullString,
+	characterMaxLength sql.NullInt64,
+	numericPrecision sql.NullInt64,
+	numericScale sql.NullInt64,
+	charset sql.NullString,
+	collate sql.NullString,
+	extra sql.NullString,
+	generatedExpression sql.NullString,
+) {
+	if defaultValue.Valid {
+		defaultSQL := normalizeMySQLColumnDefault(col, defaultValue.String)
+		col.ColumnDefault = &defaultSQL
 	}
-
-	if len(statements.Statements) == 0 {
-		return types.DBTable{}, fmt.Errorf("no statements found in DDL")
+	if characterMaxLength.Valid {
+		length := int(characterMaxLength.Int64)
+		col.CharacterMaxLength = &length
 	}
-
-	// Should be a CREATE TABLE statement
-	createTableNode, ok := statements.Statements[0].(*ast.CreateTableNode)
-	if !ok {
-		return types.DBTable{}, fmt.Errorf("expected CREATE TABLE statement, got %T", statements.Statements[0])
+	if numericPrecision.Valid {
+		precision := int(numericPrecision.Int64)
+		col.NumericPrecision = &precision
 	}
-
-	// Convert AST to parsertypes.DBTable
-	return r.convertASTToTable(createTableNode), nil
+	if numericScale.Valid {
+		scale := int(numericScale.Int64)
+		col.NumericScale = &scale
+	}
+	if charset.Valid {
+		col.Charset = charset.String
+	}
+	if collate.Valid {
+		col.Collate = collate.String
+	}
+	if extra.Valid {
+		extraValue := strings.ToLower(extra.String)
+		col.IsAutoIncrement = strings.Contains(extraValue, "auto_increment")
+		switch {
+		case strings.Contains(extraValue, "stored generated"):
+			col.GeneratedKind = "STORED"
+		case strings.Contains(extraValue, "virtual generated"):
+			col.GeneratedKind = "VIRTUAL"
+		}
+	}
+	if generatedExpression.Valid && generatedExpression.String != "" {
+		expression := generatedExpression.String
+		col.GeneratedExpression = &expression
+	}
 }
 
-func (r *Reader) applyColumnConstraint(table *types.DBTable, constraint *ast.ConstraintNode, primaryKeyColumns map[string]bool) {
-	switch constraint.Type {
-	case ast.PrimaryKeyConstraint:
-		// Mark columns as primary key
-		for _, colName := range constraint.Columns {
-			colName = strings.Trim(colName, "`")
-			for i := range table.Columns {
-				if table.Columns[i].Name == colName {
-					table.Columns[i].IsPrimaryKey = true
-				}
-			}
-		}
-	case ast.UniqueConstraint:
-		// Mark columns as unique (only if single column unique constraint)
-		// BUT skip if this column is already a primary key (primary keys are inherently unique)
-		if len(constraint.Columns) == 1 {
-			colName := strings.Trim(constraint.Columns[0], "`")
-			if !primaryKeyColumns[colName] {
-				for i := range table.Columns {
-					if table.Columns[i].Name == colName {
-						table.Columns[i].IsUnique = true
-					}
-				}
-			}
-		}
+func normalizeMySQLColumnDefault(col *types.DBColumn, defaultValue string) string {
+	value := strings.TrimSpace(defaultValue)
+	if value == "" || isQuotedMySQLDefault(value) || !mysqlDefaultNeedsLiteralQuotes(col, value) {
+		return defaultValue
 	}
+	return quoteMySQLDefaultLiteral(defaultValue)
+}
+
+func isQuotedMySQLDefault(value string) bool {
+	return len(value) >= 2 &&
+		((strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) ||
+			(strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)))
+}
+
+func mysqlDefaultNeedsLiteralQuotes(col *types.DBColumn, value string) bool {
+	if isMySQLDefaultExpression(value) {
+		return false
+	}
+
+	typeName := strings.ToLower(col.ColumnType)
+	if typeName == "" {
+		typeName = strings.ToLower(col.DataType)
+	}
+	switch {
+	case strings.HasPrefix(typeName, "enum("), strings.HasPrefix(typeName, "set("):
+		return true
+	case strings.Contains(typeName, "char"), strings.Contains(typeName, "text"):
+		return true
+	case strings.Contains(typeName, "date"), strings.Contains(typeName, "time"), strings.Contains(typeName, "year"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isMySQLDefaultExpression(value string) bool {
+	normalized := strings.TrimSpace(strings.ToUpper(value))
+	normalized = strings.TrimSuffix(normalized, "()")
+	switch normalized {
+	case "NULL", "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME", "LOCALTIME", "LOCALTIMESTAMP", "NOW", "UUID":
+		return true
+	default:
+		return strings.HasPrefix(normalized, "CURRENT_TIMESTAMP(") ||
+			strings.HasPrefix(normalized, "CURRENT_TIME(") ||
+			strings.HasPrefix(normalized, "LOCALTIME(") ||
+			strings.HasPrefix(normalized, "LOCALTIMESTAMP(") ||
+			strings.HasPrefix(normalized, "NOW(")
+	}
+}
+
+func quoteMySQLDefaultLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 // reconcileColumnUniqueness recomputes each column's IsUnique flag from the
@@ -251,83 +343,32 @@ func reconcileColumnUniqueness(schema *types.DBSchema) {
 	}
 }
 
-// convertASTToTable converts an AST CreateTableNode to parsertypes.DBTable
-func (r *Reader) convertASTToTable(node *ast.CreateTableNode) types.DBTable {
-	table := types.DBTable{
-		Name:    strings.Trim(node.Name, "`"), // Remove backticks
-		Type:    "BASE TABLE",                 // Default for regular tables
-		Comment: "",                           // Will be extracted from options if present
-	}
-
-	// Convert columns
-	for _, astCol := range node.Columns {
-		// Convert boolean nullable to string format expected by parsertypes
-		isNullable := "YES"
-		if !astCol.Nullable {
-			isNullable = "NO"
-		}
-
-		col := types.DBColumn{
-			Name:            strings.Trim(astCol.Name, "`"),
-			DataType:        astCol.Type,
-			ColumnType:      astCol.Type, // For MySQL, these are often the same
-			IsNullable:      isNullable,
-			Charset:         astCol.Charset,
-			Collate:         astCol.Collate,
-			OrdinalPosition: len(table.Columns) + 1,
-			IsAutoIncrement: astCol.AutoInc,
-			IsPrimaryKey:    astCol.Primary,
-			IsUnique:        astCol.Unique,
-			GeneratedKind:   strings.ToUpper(astCol.GeneratedKind),
-		}
-		if astCol.GeneratedExpression != "" {
-			expression := astCol.GeneratedExpression
-			col.GeneratedExpression = &expression
-		}
-
-		// Handle default values
-		if astCol.Default != nil {
-			if astCol.Default.Expression != "" {
-				col.ColumnDefault = &astCol.Default.Expression
-			} else {
-				col.ColumnDefault = &astCol.Default.Value
-			}
-		}
-
-		// Handle character length, precision, scale if available
-		// These would need to be parsed from the type string for MySQL
-		// For now, we'll leave them as nil since the AST doesn't provide them directly
-
-		table.Columns = append(table.Columns, col)
-	}
-
-	// Handle table-level constraints to update column flags
-	primaryKeyColumns := make(map[string]bool)
-
-	// First pass: identify primary key columns
-	for _, constraint := range node.Constraints {
-		if constraint.Type != ast.PrimaryKeyConstraint {
+func enhanceTablesWithPrimaryKeys(tables []types.DBTable, constraints []types.DBConstraint) {
+	primaryKeys := make(map[string]map[string]struct{})
+	for _, constraint := range constraints {
+		if constraint.Type != "PRIMARY KEY" {
 			continue
 		}
-		for _, colName := range constraint.Columns {
-			colName = strings.Trim(colName, "`")
-			primaryKeyColumns[colName] = true
+		if primaryKeys[constraint.TableName] == nil {
+			primaryKeys[constraint.TableName] = make(map[string]struct{})
+		}
+		for _, column := range constraint.ColumnNamesOrDefault() {
+			primaryKeys[constraint.TableName][column] = struct{}{}
 		}
 	}
 
-	// Second pass: apply constraints
-	for _, constraint := range node.Constraints {
-		r.applyColumnConstraint(&table, constraint, primaryKeyColumns)
-	}
-
-	// Extract table comment from options
-	for key, value := range node.Options {
-		if strings.ToUpper(key) == "COMMENT" {
-			table.Comment = strings.Trim(value, "'\"")
+	for ti := range tables {
+		table := &tables[ti]
+		tablePrimaryKeys := primaryKeys[table.Name]
+		if len(tablePrimaryKeys) == 0 {
+			continue
+		}
+		for ci := range table.Columns {
+			col := &table.Columns[ci]
+			_, primary := tablePrimaryKeys[col.Name]
+			col.IsPrimaryKey = primary
 		}
 	}
-
-	return table
 }
 
 func (r *Reader) readViews(dbName string) ([]types.DBView, error) {

--- a/dbschema/postgres/postgres_test.go
+++ b/dbschema/postgres/postgres_test.go
@@ -2,11 +2,15 @@ package postgres
 
 import (
 	"context"
+	"database/sql/driver"
+	"fmt"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/dbschema/internal/dbtest"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/testutils"
 )
@@ -147,6 +151,69 @@ func TestPostgreSQLReader_ReadSchema_NoConnection(t *testing.T) {
 
 	// Note: We don't test ReadSchema() with nil db as it would panic
 	// This is expected behavior - the reader requires a valid database connection
+}
+
+func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
+	c := qt.New(t)
+
+	tableRows := make([][]driver.Value, 0, 50)
+	columnRows := make([][]driver.Value, 0, 100)
+	for i := range 50 {
+		tableName := fmt.Sprintf("table_%02d", i)
+		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
+		columnRows = append(columnRows,
+			[]driver.Value{tableName, "id", "integer", "int4", "NO", nil, nil, nil, nil, int64(1), "", ""},
+			[]driver.Value{tableName, "name", "character varying", "varchar", "NO", nil, int64(255), nil, nil, int64(2), "", ""},
+		)
+	}
+
+	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		switch {
+		case strings.Contains(query, "FROM information_schema.columns"):
+			return dbtest.QueryResult{
+				Columns: []string{
+					"table_name",
+					"column_name",
+					"data_type",
+					"udt_name",
+					"is_nullable",
+					"column_default",
+					"character_maximum_length",
+					"numeric_precision",
+					"numeric_scale",
+					"ordinal_position",
+					"generated_kind",
+					"generated_expression",
+				},
+				Rows: columnRows,
+			}, nil
+		case strings.Contains(query, "FROM information_schema.tables"):
+			return dbtest.QueryResult{
+				Columns: []string{
+					"table_schema",
+					"table_name",
+					"table_type",
+					"table_comment",
+					"estimated_rows",
+					"rls_enabled",
+				},
+				Rows: tableRows,
+			}, nil
+		default:
+			return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+		}
+	})
+	reader := NewPostgreSQLReader(db.SQL, "public")
+
+	tables, err := reader.readTablesForSchema("public")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(tables, qt.HasLen, 50)
+	c.Assert(tables[0].Name, qt.Equals, "table_00")
+	c.Assert(tables[0].Columns, qt.HasLen, 2)
+	c.Assert(tables[0].Columns[1].CharacterMaxLength, qt.IsNotNil)
+	c.Assert(*tables[0].Columns[1].CharacterMaxLength, qt.Equals, 255)
 }
 
 func TestPostgreSQLReader_ExtensionFunctionFiltering(t *testing.T) {

--- a/dbschema/postgres/reader.go
+++ b/dbschema/postgres/reader.go
@@ -189,6 +189,11 @@ func (r *Reader) readTables() ([]types.DBTable, error) {
 }
 
 func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error) {
+	columnsByTable, err := r.readColumnsForSchema(schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read columns for schema %s: %w", schemaName, err)
+	}
+
 	// Read tables, excluding system tables like schema_migrations
 	tablesQuery := `
 		SELECT table_schema, table_name, table_type,
@@ -218,13 +223,7 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}
 		table.Schema = r.outputSchema(table.Schema)
-
-		// Read columns for this table
-		columns, err := r.readColumns(schemaName, table.Name)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read columns for table %s: %w", table.QualifiedName(), err)
-		}
-		table.Columns = columns
+		table.Columns = columnsByTable[table.Name]
 
 		tables = append(tables, table)
 	}
@@ -232,10 +231,12 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	return tables, nil
 }
 
-// readColumns reads all columns for a specific table
-func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, error) {
+// readColumnsForSchema reads all columns in a schema in one catalog query and
+// groups them by table name.
+func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBColumn, error) {
 	columnsQuery := `
 		SELECT
+			col.table_name,
 			column_name,
 			data_type,
 			udt_name,
@@ -254,21 +255,24 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 			AND a.attname = col.column_name
 			AND NOT a.attisdropped
 		LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
-		WHERE col.table_schema = $1 AND col.table_name = $2
-		ORDER BY col.ordinal_position`
+		WHERE col.table_schema = $1
+		AND col.table_name NOT IN ('schema_migrations')
+		ORDER BY col.table_name, col.ordinal_position`
 
-	rows, err := r.db.Query(columnsQuery, schemaName, tableName)
+	rows, err := r.db.Query(columnsQuery, schemaName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query columns: %w", err)
 	}
 	defer rows.Close()
 
-	var columns []types.DBColumn
+	columnsByTable := make(map[string][]types.DBColumn)
 	for rows.Next() {
 		var col types.DBColumn
 		var generatedKind string
 		var generatedExpression string
+		var tableName string
 		err := rows.Scan(
+			&tableName,
 			&col.Name,
 			&col.DataType,
 			&col.UDTName,
@@ -296,10 +300,13 @@ func (r *Reader) readColumns(schemaName, tableName string) ([]types.DBColumn, er
 				strings.Contains(defaultVal, "_seq")
 		}
 
-		columns = append(columns, col)
+		columnsByTable[tableName] = append(columnsByTable[tableName], col)
 	}
 
-	return columns, nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return columnsByTable, nil
 }
 
 func postgresGeneratedKind(code string) string {

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -20,6 +20,12 @@ func skipIfNoMySQL(t *testing.T) string {
 	return requireReachableTestDSN(t, "MYSQL_TEST_DSN", "mysql", "MySQL")
 }
 
+// skipIfNoMariaDB skips only when MARIADB_TEST_DSN is absent; a bad configured DSN fails.
+func skipIfNoMariaDB(t *testing.T) string {
+	t.Helper()
+	return requireReachableTestDSN(t, "MARIADB_TEST_DSN", "mysql", "MariaDB")
+}
+
 // Helper function to find a column by name
 func findColumn(columns []types.DBColumn, name string) *types.DBColumn {
 	for i := range columns {
@@ -49,6 +55,16 @@ func tableExists(db *sql.DB, tableName string, dryRun bool) bool {
 
 func TestMySQLReader_ReadSchema_Integration(t *testing.T) {
 	dsn := skipIfNoMySQL(t)
+	testMySQLCompatibleReaderReadSchema(t, dsn)
+}
+
+func TestMariaDBReader_ReadSchema_Integration(t *testing.T) {
+	dsn := skipIfNoMariaDB(t)
+	testMySQLCompatibleReaderReadSchema(t, dsn)
+}
+
+func testMySQLCompatibleReaderReadSchema(t *testing.T, dsn string) {
+	t.Helper()
 	c := qt.New(t)
 
 	db, err := sql.Open("mysql", dsn)
@@ -60,6 +76,7 @@ func TestMySQLReader_ReadSchema_Integration(t *testing.T) {
 		CREATE TABLE IF NOT EXISTS test_table (
 			id INT AUTO_INCREMENT PRIMARY KEY,
 			name VARCHAR(255) NOT NULL,
+			name_lc VARCHAR(255) GENERATED ALWAYS AS (lower(name)) STORED,
 			status ENUM('active', 'inactive') DEFAULT 'active',
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			UNIQUE KEY unique_name (name)
@@ -87,7 +104,7 @@ func TestMySQLReader_ReadSchema_Integration(t *testing.T) {
 		}
 	}
 	c.Assert(testTable, qt.IsNotNil)
-	c.Assert(testTable.Columns, qt.HasLen, 4)
+	c.Assert(testTable.Columns, qt.HasLen, 5)
 
 	// Verify column properties
 	idCol := findColumn(testTable.Columns, "id")
@@ -99,6 +116,12 @@ func TestMySQLReader_ReadSchema_Integration(t *testing.T) {
 	c.Assert(nameCol, qt.IsNotNil)
 	c.Assert(nameCol.IsNullable, qt.Equals, "NO")
 	c.Assert(nameCol.IsUnique, qt.IsTrue)
+
+	nameLCCol := findColumn(testTable.Columns, "name_lc")
+	c.Assert(nameLCCol, qt.IsNotNil)
+	c.Assert(nameLCCol.GeneratedKind, qt.Equals, "STORED")
+	c.Assert(nameLCCol.GeneratedExpression, qt.IsNotNil)
+	c.Assert(*nameLCCol.GeneratedExpression, qt.Contains, "name")
 
 	statusCol := findColumn(testTable.Columns, "status")
 	c.Assert(statusCol, qt.IsNotNil)


### PR DESCRIPTION
Closes #140

## Summary
- bulk-load table columns for PostgreSQL, MySQL/MariaDB, and ClickHouse readers instead of querying columns per table
- move MySQL/MariaDB table introspection fully onto information_schema metadata and remove the now-dead SHOW CREATE TABLE parser path
- add a reusable dbschema/internal/dbtest fake SQL driver for query-count regression tests
- add 50-table query-count tests and a MariaDB reader integration contour with generated-column coverage

## Self-review
- Pass 1: checked query-count proof, stale MySQL DDL-parser path, MariaDB compatibility, generated column metadata, primary-key/unique derived flags, and security around identifier interpolation; removed dead DDL parser code and kept catalog queries parameterized
- Pass 2: checked coverage/gates/docs impact; no docs update needed because this is an internal reader performance fix with no CLI/API change

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-140-go-build-cache go test ./... -count=1
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-140-go-build-cache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-140-go-build-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-issue-140-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-140-go-build-cache POSTGRES_TEST_DSN=... MYSQL_TEST_DSN=... MARIADB_TEST_DSN=... go test -tags=integration ./integration/gonative -run 'TestMySQLReader_ReadSchema_Integration|TestMariaDBReader_ReadSchema_Integration|TestPostgreSQLReader_ReadSchema_Integration' -count=1 -v\n