### PR TITLE
Harden migration generator round-trip edge cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ token. Prefer spellings such as `behavior`, `color`, `canceled`, `initialize`,
 
 Ptah treats `.golangci.yml` as a strict contract. Fix code to satisfy the configured linters instead of relaxing thresholds, disabling checks, or broadening exclusions. In particular, keep `revive` `error-strings` enabled and preserve the current "stricter wins" lint posture unless a maintainer explicitly asks for a config change.
 
+Ptah is pre-GA. Do not add legacy command aliases, compatibility wrappers,
+fallback APIs, or backward-compatibility behavior just to preserve an older
+internal shape. Prefer the cleaner architecture and update callers/tests/docs
+unless a maintainer explicitly asks for a compatibility layer.
+
 The `modernize` linter is enabled. Prefer current Go idioms when writing or editing code:
 
 - Use standard library helpers such as `slices.Contains`, `maps.Copy`, `strings.CutPrefix`, and `strings.SplitSeq` when they fit the code.

--- a/integration/README.md
+++ b/integration/README.md
@@ -120,7 +120,17 @@ docker compose --profile test run --rm ptah-tester --scenarios=failure_diagnosti
 
 # Run dynamic scenarios for schema evolution testing
 docker compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evolution,dynamic_rollback_single
+
+# Run generator round-trip edge-case fixtures
+docker compose --profile test run --rm ptah-tester --scenarios=migration_generator_roundtrip_fixtures
 ```
+
+The `migration_generator_roundtrip_fixtures` scenario validates generated
+migrations through apply, introspect, step-by-step rollback, down-to-zero, and
+re-apply cycles. Its fixtures cover empty schemas, single tables, composite
+primary keys, foreign-key chains and diamonds, cycles, same-name
+`CHECK`/`UNIQUE` changes, enum add/remove transitions, and foreign keys added
+to already-existing columns.
 
 ### Database Selection
 

--- a/integration/fixtures/entities/046-roundtrip-existing-fk-base/account.go
+++ b/integration/fixtures/entities/046-roundtrip-existing-fk-base/account.go
@@ -1,0 +1,10 @@
+package entities
+
+//migrator:schema:table name="accounts"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}

--- a/integration/fixtures/entities/046-roundtrip-existing-fk-base/user.go
+++ b/integration/fixtures/entities/046-roundtrip-existing-fk-base/user.go
@@ -1,0 +1,16 @@
+package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="account_id" type="INTEGER"
+	AccountID *int64
+
+	//migrator:schema:field name="manager_id" type="INTEGER"
+	ManagerID *int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+	Email string
+}

--- a/integration/fixtures/entities/047-roundtrip-existing-fk-added/account.go
+++ b/integration/fixtures/entities/047-roundtrip-existing-fk-added/account.go
@@ -1,0 +1,10 @@
+package entities
+
+//migrator:schema:table name="accounts"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}

--- a/integration/fixtures/entities/047-roundtrip-existing-fk-added/user.go
+++ b/integration/fixtures/entities/047-roundtrip-existing-fk-added/user.go
@@ -1,0 +1,16 @@
+package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="account_id" type="INTEGER" foreign="accounts(id)"
+	AccountID *int64
+
+	//migrator:schema:field name="manager_id" type="INTEGER" foreign="users(id)"
+	ManagerID *int64
+
+	//migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+	Email string
+}

--- a/integration/scenarios_roundtrip_fixtures.go
+++ b/integration/scenarios_roundtrip_fixtures.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/dbschema"
@@ -16,6 +17,11 @@ type roundTripFixture struct {
 	Description      string
 	Versions         []string
 	BlockedByDialect map[string]string
+}
+
+type appliedRoundTripMigration struct {
+	Version         string
+	PreviousVersion string
 }
 
 var roundTripFixtures = []roundTripFixture{
@@ -98,6 +104,11 @@ var roundTripFixtures = []roundTripFixture{
 		Description: "enum value removal is carried as an explicit round-trip fixture",
 		Versions:    []string{"040-roundtrip-enum-v2-add", "041-roundtrip-enum-v3-remove"},
 	},
+	{
+		Name:        "foreign_key_added_to_existing_columns",
+		Description: "foreign keys added to existing columns, including a self-reference, round-trip through generated migrations",
+		Versions:    []string{"046-roundtrip-existing-fk-base", "047-roundtrip-existing-fk-added"},
+	},
 }
 
 func testMigrationGeneratorRoundTripFixtures(
@@ -160,30 +171,27 @@ func runRoundTripFixture(
 		return err
 	}
 
-	generatedMigrations := 0
-	for _, version := range fixture.Versions {
+	appliedMigrations := make([]appliedRoundTripMigration, 0, len(fixture.Versions))
+	for versionIndex, version := range fixture.Versions {
 		applied, err := generateAndApplyRoundTripVersion(ctx, conn, vem, dh, migrationsFS, migrationsDir, fixture, version)
 		if err != nil {
 			return err
 		}
 		if applied {
-			generatedMigrations++
+			appliedMigrations = append(appliedMigrations, appliedRoundTripMigration{
+				Version:         version,
+				PreviousVersion: previousRoundTripVersion(fixture.Versions, versionIndex),
+			})
 		}
 		if err := validateSchemaConsistency(ctx, conn, vem, version); err != nil {
 			return fmt.Errorf("%s after %s: %w", fixture.Name, version, err)
 		}
 	}
 
-	if generatedMigrations > 0 {
-		for range generatedMigrations {
-			if err := dh.MigrateDown(ctx, migrationsFS); err != nil {
-				return fmt.Errorf("%s down-to-zero: %w", fixture.Name, err)
-			}
+	if len(appliedMigrations) > 0 {
+		if err := rollbackRoundTripFixtureMigrations(ctx, conn, vem, dh, migrationsFS, fixture, appliedMigrations); err != nil {
+			return err
 		}
-		if err := validateEmptySchema(ctx, conn); err != nil {
-			return fmt.Errorf("%s down-to-zero validation: %w", fixture.Name, err)
-		}
-
 		if err := dh.MigrateUp(ctx, migrationsFS); err != nil {
 			return fmt.Errorf("%s re-apply all generated migrations: %w", fixture.Name, err)
 		}
@@ -194,6 +202,53 @@ func runRoundTripFixture(
 	}
 
 	return resetRoundTripFixtureDatabase(ctx, conn)
+}
+
+func previousRoundTripVersion(versions []string, versionIndex int) string {
+	if versionIndex == 0 {
+		return ""
+	}
+	return versions[versionIndex-1]
+}
+
+func rollbackRoundTripFixtureMigrations(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	vem *VersionedEntityManager,
+	dh *DatabaseHelper,
+	migrationsFS fs.FS,
+	fixture roundTripFixture,
+	appliedMigrations []appliedRoundTripMigration,
+) error {
+	for _, applied := range slices.Backward(appliedMigrations) {
+		if err := dh.MigrateDown(ctx, migrationsFS); err != nil {
+			return fmt.Errorf("%s down from %s: %w", fixture.Name, applied.Version, err)
+		}
+		if err := validateRoundTripRollbackState(ctx, conn, vem, fixture, applied); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRoundTripRollbackState(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	vem *VersionedEntityManager,
+	fixture roundTripFixture,
+	applied appliedRoundTripMigration,
+) error {
+	if applied.PreviousVersion == "" {
+		if err := validateEmptySchema(ctx, conn); err != nil {
+			return fmt.Errorf("%s down-to-zero validation after %s: %w", fixture.Name, applied.Version, err)
+		}
+		return nil
+	}
+
+	if err := validateSchemaConsistency(ctx, conn, vem, applied.PreviousVersion); err != nil {
+		return fmt.Errorf("%s rollback from %s to %s: %w", fixture.Name, applied.Version, applied.PreviousVersion, err)
+	}
+	return nil
 }
 
 func resetRoundTripFixtureDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -5,6 +5,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema/types"
 )
 
@@ -47,6 +48,105 @@ func TestGetAllScenarios(t *testing.T) {
 	for _, scenarioName := range originalScenarios {
 		c.Assert(scenarioNames[scenarioName], qt.IsTrue, qt.Commentf("Original scenario %s should still be included", scenarioName))
 	}
+}
+
+func TestRoundTripFixturesCoverIssue147EdgeCases(t *testing.T) {
+	c := qt.New(t)
+
+	fixtures := make(map[string]roundTripFixture, len(roundTripFixtures))
+	for _, fixture := range roundTripFixtures {
+		fixtures[fixture.Name] = fixture
+	}
+
+	expected := map[string][]string{
+		"empty_schema":                          {"024-roundtrip-empty"},
+		"single_table":                          {"025-roundtrip-single-table"},
+		"composite_primary_key":                 {"026-roundtrip-composite-pk"},
+		"self_referencing_fk":                   {"027-roundtrip-self-reference"},
+		"parent_child_fk_drop_order":            {"028-roundtrip-parent-child"},
+		"three_level_fk_chain":                  {"034-roundtrip-fk-chain"},
+		"diamond_fk_graph":                      {"035-roundtrip-fk-diamond"},
+		"mutual_fk_cycle":                       {"029-roundtrip-mutual-cycle"},
+		"same_name_check_drift":                 {"030-roundtrip-check-v1", "031-roundtrip-check-v2"},
+		"same_name_unique_drift":                {"032-roundtrip-unique-v1", "033-roundtrip-unique-v2"},
+		"same_name_check_to_unique_drift":       {"042-roundtrip-check-to-unique-v1", "043-roundtrip-check-to-unique-v2"},
+		"same_name_unique_to_check_drift":       {"044-roundtrip-unique-to-check-v1", "045-roundtrip-unique-to-check-v2"},
+		"composite_primary_key_add_remove":      {"036-roundtrip-pk-base", "037-roundtrip-pk-composite-added", "038-roundtrip-pk-composite-removed"},
+		"enum_value_add":                        {"039-roundtrip-enum-v1", "040-roundtrip-enum-v2-add"},
+		"enum_value_remove":                     {"040-roundtrip-enum-v2-add", "041-roundtrip-enum-v3-remove"},
+		"foreign_key_added_to_existing_columns": {"046-roundtrip-existing-fk-base", "047-roundtrip-existing-fk-added"},
+	}
+	for name, versions := range expected {
+		fixture, ok := fixtures[name]
+		c.Assert(ok, qt.IsTrue, qt.Commentf("missing round-trip fixture %s", name))
+		c.Assert(fixture.Versions, qt.DeepEquals, versions)
+	}
+}
+
+func TestExistingColumnForeignKeyFixtureMetadata(t *testing.T) {
+	c := qt.New(t)
+
+	baseSchema := loadRoundTripFixtureSchema(c, "046-roundtrip-existing-fk-base")
+	addedSchema := loadRoundTripFixtureSchema(c, "047-roundtrip-existing-fk-added")
+
+	baseUsers := findRoundTripTable(c, baseSchema, "users")
+	addedUsers := findRoundTripTable(c, addedSchema, "users")
+
+	baseAccountID := findRoundTripField(c, baseSchema, baseUsers.StructName, "account_id")
+	baseManagerID := findRoundTripField(c, baseSchema, baseUsers.StructName, "manager_id")
+	c.Assert(baseAccountID.Type, qt.Equals, "INTEGER")
+	c.Assert(baseAccountID.Foreign, qt.Equals, "")
+	c.Assert(baseManagerID.Type, qt.Equals, "INTEGER")
+	c.Assert(baseManagerID.Foreign, qt.Equals, "")
+
+	addedAccountID := findRoundTripField(c, addedSchema, addedUsers.StructName, "account_id")
+	addedManagerID := findRoundTripField(c, addedSchema, addedUsers.StructName, "manager_id")
+	c.Assert(addedAccountID.Type, qt.Equals, baseAccountID.Type)
+	c.Assert(addedAccountID.Foreign, qt.Equals, "accounts(id)")
+	c.Assert(addedManagerID.Type, qt.Equals, baseManagerID.Type)
+	c.Assert(addedManagerID.Foreign, qt.Equals, "users(id)")
+}
+
+func loadRoundTripFixtureSchema(c *qt.C, version string) *goschema.Database {
+	c.Helper()
+
+	vem, err := NewVersionedEntityManager(testFixtures)
+	c.Assert(err, qt.IsNil)
+	defer vem.Cleanup()
+
+	c.Assert(vem.LoadEntityVersion(version), qt.IsNil)
+
+	schema, err := vem.GenerateSchemaFromEntities()
+	c.Assert(err, qt.IsNil)
+
+	return schema
+}
+
+func findRoundTripTable(c *qt.C, schema *goschema.Database, name string) *goschema.Table {
+	c.Helper()
+
+	for i := range schema.Tables {
+		if schema.Tables[i].Name == name {
+			return &schema.Tables[i]
+		}
+	}
+
+	c.Fatalf("missing table %s", name)
+	return nil
+}
+
+func findRoundTripField(c *qt.C, schema *goschema.Database, structName, name string) *goschema.Field {
+	c.Helper()
+
+	for i := range schema.Fields {
+		field := &schema.Fields[i]
+		if field.StructName == structName && field.Name == name {
+			return field
+		}
+	}
+
+	c.Fatalf("missing field %s.%s", structName, name)
+	return nil
 }
 
 // TestGetDynamicScenarios verifies the dynamic scenarios function

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -758,6 +758,7 @@ func generateDownMigrationSQLWithOptions(
 	// rebuild the full prior body from the pre-change DB state — that is exactly
 	// the definition the down must restore.
 	reverseDiff := reverseSchemaDiffWithSchema(diff, generated, dbSchema)
+	addMySQLFamilyForeignKeyBackingIndexRemovals(reverseDiff, diff, dbSchema, dialect)
 
 	caps := capability.ForDialect(dialect)
 	if len(capsOverride) > 0 {
@@ -812,6 +813,78 @@ func supportsGeneratedTimeoutDirectives(dialect string) bool {
 	return slices.Contains([]string{platform.Postgres, platform.MySQL, platform.MariaDB}, normalized)
 }
 
+func addMySQLFamilyForeignKeyBackingIndexRemovals(
+	reverseDiff *types.SchemaDiff,
+	upDiff *types.SchemaDiff,
+	dbSchema *dbschematypes.DBSchema,
+	dialect string,
+) {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB:
+	default:
+		return
+	}
+
+	priorIndexes := dbIndexByTableName(dbSchema)
+	removedNames := stringSet(reverseDiff.IndexesRemoved)
+	removedWithTables := indexRemovalSet(reverseDiff.IndexesRemovedWithTables)
+	for _, add := range upDiff.ConstraintsAddedWithTables {
+		if add.TableName == "" || add.Name == "" || !strings.EqualFold(add.Type, "FOREIGN KEY") {
+			continue
+		}
+		if priorIndexes[indexKey(add.TableName, add.Name)] {
+			continue
+		}
+		if _, ok := removedNames[add.Name]; !ok {
+			reverseDiff.IndexesRemoved = append(reverseDiff.IndexesRemoved, add.Name)
+			removedNames[add.Name] = struct{}{}
+		}
+		key := indexKey(add.TableName, add.Name)
+		if removedWithTables[key] {
+			continue
+		}
+		reverseDiff.IndexesRemovedWithTables = append(reverseDiff.IndexesRemovedWithTables, types.IndexRemovalInfo{
+			Name:      add.Name,
+			TableName: add.TableName,
+		})
+		removedWithTables[key] = true
+	}
+
+	slices.Sort(reverseDiff.IndexesRemoved)
+	slices.SortFunc(reverseDiff.IndexesRemovedWithTables, func(a, b types.IndexRemovalInfo) int {
+		if byTable := strings.Compare(a.TableName, b.TableName); byTable != 0 {
+			return byTable
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
+func dbIndexByTableName(dbSchema *dbschematypes.DBSchema) map[string]bool {
+	out := make(map[string]bool)
+	if dbSchema == nil {
+		return out
+	}
+	for _, index := range dbSchema.Indexes {
+		out[indexKey(index.TableName, index.Name)] = true
+		if index.Schema != "" {
+			out[indexKey(dbschematypes.QualifyTableName(index.Schema, index.TableName), index.Name)] = true
+		}
+	}
+	return out
+}
+
+func indexRemovalSet(indexes []types.IndexRemovalInfo) map[string]bool {
+	out := make(map[string]bool, len(indexes))
+	for _, index := range indexes {
+		out[indexKey(index.TableName, index.Name)] = true
+	}
+	return out
+}
+
+func indexKey(tableName, indexName string) string {
+	return tableName + "." + indexName
+}
+
 // reverseSchemaDiff creates a reverse diff for generating down migrations
 //
 // Deprecated: Use reverseSchemaDiffWithSchema for proper RLS policy table name resolution
@@ -824,8 +897,8 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 // schema is the generated (target) Go schema, used to resolve table names for
 // RLS policies. dbSchema is the introspected (pre-change) database schema, used
 // to rebuild prior FK/PK/CHECK/UNIQUE definitions for reversed constraint
-// additions; it may be nil for legacy callers that only have the generated
-// schema (the reversed additions then fall back to the name-only path).
+// additions; it may be nil when callers only have the generated schema (the
+// reversed additions then fall back to the name-only path).
 func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	return &types.SchemaDiff{
 		// Reverse table operations
@@ -1082,8 +1155,8 @@ func foreignReferenceTable(ref string) string {
 // per real host table. This is what makes the down of a multi-host mixin FK
 // modify apply cleanly: a name-only down re-adds only one host (and drops only
 // one host), so the others collide on re-add (issue #197 DOWN path). When
-// dbSchema is nil (legacy callers) the names still flow through ConstraintsAdded
-// and the planners fall back to the name-only field scan.
+// dbSchema is nil, the names still flow through ConstraintsAdded and the
+// planners fall back to the name-only field scan.
 func reverseConstraintAdditions(diff *types.SchemaDiff, dbSchema *dbschematypes.DBSchema) []types.ConstraintAdditionInfo {
 	if dbSchema == nil || len(diff.ConstraintsRemovedWithTables) == 0 {
 		return nil
@@ -1211,9 +1284,8 @@ func derefString(s *string) string {
 // are resolved from the generated schema, which is the source the up side
 // synthesized them from. This lets dialect planners that need the table and a
 // type-specific drop syntax (MySQL/MariaDB DROP FOREIGN KEY) emit a real drop in
-// the down migration. When the schema is unavailable (legacy callers) the names
-// still flow through ConstraintsRemoved; only the richer per-table info is
-// omitted.
+// the down migration. When the schema is unavailable, the names still flow
+// through ConstraintsRemoved; only the richer per-table info is omitted.
 func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database) []types.ConstraintRemovalInfo {
 	if schema == nil {
 		return nil
@@ -1233,7 +1305,7 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 	// from a struct name that does not exist (issue #197). ConstraintsAddedWithTables
 	// carries the concrete table for each addition, so the down side drops the
 	// FK from exactly the table the up side added it to. Names present here are
-	// recorded so the legacy field-scan fallback below does not double-emit them.
+	// recorded so the field-scan fallback below does not double-emit them.
 	var infos []types.ConstraintRemovalInfo
 	seen := make(map[string]struct{})
 	handled := make(map[string]struct{})
@@ -1251,8 +1323,7 @@ func reverseConstraintRemovals(diff *types.SchemaDiff, schema *goschema.Database
 	infos = appendAddedTableForeignKeyRemovals(infos, seen, diff.TablesAdded, schema)
 
 	// Index field-level constraint names to their owning table for the names
-	// that did not arrive with table-qualified info (legacy callers / explicit
-	// table-level constraints).
+	// that did not arrive with table-qualified info.
 	structToTable := make(map[string]string, len(schema.Tables))
 	for _, t := range schema.Tables {
 		structToTable[t.StructName] = t.Name

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -1102,3 +1102,68 @@ func TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily(t *te
 		})
 	}
 }
+
+func TestGenerateDownMigrationSQL_MySQLFamilyDropsGeneratedForeignKeyBackingIndex(t *testing.T) {
+	generatedSchema := &goschema.Database{}
+	upDiff := &types.SchemaDiff{
+		ConstraintsAdded: []string{"fk_users_account_id"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{
+			{
+				Name:         "fk_users_account_id",
+				TableName:    "users",
+				Type:         "FOREIGN KEY",
+				Columns:      []string{"account_id"},
+				ForeignTable: "accounts",
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		dbSchema  *dbschematypes.DBSchema
+		wantIndex bool
+	}{
+		{
+			name:      "no prior same-named index",
+			dbSchema:  &dbschematypes.DBSchema{},
+			wantIndex: true,
+		},
+		{
+			name: "pre-change DB already had that index",
+			dbSchema: &dbschematypes.DBSchema{
+				Indexes: []dbschematypes.DBIndex{
+					{Name: "fk_users_account_id", TableName: "users"},
+				},
+			},
+			wantIndex: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, dialect := range []string{"mysql", "mariadb"} {
+				t.Run(dialect, func(t *testing.T) {
+					c := qt.New(t)
+
+					downSQL, err := generateDownMigrationSQL(upDiff, generatedSchema, tt.dbSchema, dialect)
+					c.Assert(err, qt.IsNil)
+					downSQL = normalizedRenderedSQL(downSQL)
+
+					dropFK := "ALTER TABLE users DROP FOREIGN KEY fk_users_account_id;"
+					dropIndex := "DROP INDEX fk_users_account_id ON users;"
+					if dialect == "mariadb" {
+						dropFK = "ALTER TABLE users DROP FOREIGN KEY IF EXISTS fk_users_account_id;"
+						dropIndex = "DROP INDEX IF EXISTS fk_users_account_id ON users;"
+					}
+					c.Assert(downSQL, qt.Contains, dropFK)
+					if tt.wantIndex {
+						c.Assert(downSQL, qt.Contains, dropIndex)
+						assertSQLBefore(t, downSQL, dropFK, dropIndex)
+						return
+					}
+					c.Assert(downSQL, qt.Not(qt.Contains), "DROP INDEX",
+						qt.Commentf("pre-existing index must not be dropped:\n%s", downSQL))
+				})
+			}
+		})
+	}
+}

--- a/migration/generator/test_helpers_test.go
+++ b/migration/generator/test_helpers_test.go
@@ -7,3 +7,7 @@ var simpleRenderedIdentifierQuoteRE = regexp.MustCompile("[`\"]([a-z_][a-z0-9_]*
 func legacyRenderedSQL(sql string) string {
 	return simpleRenderedIdentifierQuoteRE.ReplaceAllString(sql, "$1")
 }
+
+func normalizedRenderedSQL(sql string) string {
+	return simpleRenderedIdentifierQuoteRE.ReplaceAllString(sql, "$1")
+}

--- a/migration/planner/dialects/mysql/constraint_scope_test.go
+++ b/migration/planner/dialects/mysql/constraint_scope_test.go
@@ -69,6 +69,42 @@ func TestPlanner_GenerateMigrationAST_CompositeForeignKeyAddition(t *testing.T) 
 	}
 }
 
+func TestPlanner_GenerateMigrationAST_ForeignKeyIndexesDropAfterConstraints(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &types.SchemaDiff{
+				ConstraintsRemoved: []string{"fk_users_account_id", "fk_users_manager_id"},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{
+					{Name: "fk_users_account_id", TableName: "users", Type: "FOREIGN KEY"},
+					{Name: "fk_users_manager_id", TableName: "users", Type: "FOREIGN KEY"},
+				},
+				IndexesRemoved: []string{"fk_users_account_id", "fk_users_manager_id"},
+				IndexesRemovedWithTables: []types.IndexRemovalInfo{
+					{Name: "fk_users_account_id", TableName: "users"},
+					{Name: "fk_users_manager_id", TableName: "users"},
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, &goschema.Database{})
+
+			assertContainsBefore(
+				c,
+				sql,
+				"ALTER TABLE users DROP FOREIGN KEY fk_users_account_id;",
+				"DROP INDEX fk_users_account_id ON users;",
+			)
+			assertContainsBefore(
+				c,
+				sql,
+				"ALTER TABLE users DROP FOREIGN KEY fk_users_manager_id;",
+				"DROP INDEX fk_users_manager_id ON users;",
+			)
+		})
+	}
+}
+
 func TestPlanner_GenerateMigrationAST_TableQualifiedCheckAndUniqueAdditions(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -470,7 +470,8 @@ func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast
 			result = append(result, dropIndexNode)
 		}
 	} else {
-		// Fallback to the basic removal list (for backward compatibility)
+		// Use name-only diff input when the caller did not populate
+		// table-qualified removals.
 		for _, indexName := range diff.IndexesRemoved {
 			dropIndexNode := ast.NewDropIndex(indexName)
 			if guarded {
@@ -514,8 +515,9 @@ func (p *Planner) handleEnumRemovals(result []ast.Node, diff *types.SchemaDiff) 
 //  1. Create new tables (MySQL handles enums inline, no separate enum creation needed)
 //  2. Modify existing tables (add/modify/remove columns)
 //  3. Add new indexes
-//  4. Remove indexes (safe operations)
-//  5. Remove tables (dangerous - commented out by default)
+//  4. Remove constraints
+//  5. Remove indexes (safe operations)
+//  6. Remove tables (dangerous - commented out by default)
 //
 // # MySQL-Specific Features
 //
@@ -609,15 +611,17 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	// 5.5. Add new constraints (must be done after tables and columns exist)
 	result = p.addNewConstraints(result, diff, generated)
 
-	// 6. Remove indexes (safe operations)
-	result = p.removeIndexes(result, diff)
-
-	// 6.5. Remove constraints (must be done before removing tables)
+	// 6. Remove constraints before indexes. MySQL-family servers keep the
+	// backing index after DROP FOREIGN KEY when the index was auto-created, so
+	// rollback plans may need to drop both. The FK must go first.
 	result = p.removeConstraints(result, diff)
 
 	// 6.6. Remove triggers and view-like objects before dependent tables.
 	result = p.removeTriggers(result, diff)
 	result = p.removeViews(result, diff)
+
+	// 6.7. Remove indexes after constraints so FK-backed indexes can be dropped.
+	result = p.removeIndexes(result, diff)
 
 	// 7. Remove tables (dangerous!)
 	result = p.removeTables(result, diff)
@@ -791,7 +795,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		removalByTableName[info.TableName+"."+info.Name] = info
 	}
 
-	// Removal info grouped by bare name, so the legacy ConstraintsAdded loop
+	// Removal info grouped by bare name, so the name-only ConstraintsAdded loop
 	// below can scope a modified non-FK constraint's DROP to its concrete host
 	// table(s). The comparator records every removal in
 	// ConstraintsRemovedWithTables in lockstep with the bare ConstraintsRemoved
@@ -831,7 +835,7 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	// embedded inline-relation mixin shares one name across every host table, and
 	// down migrations restore modified CHECK/UNIQUE definitions from the
 	// introspected DB schema. ConstraintsAddedWithTables carries the concrete
-	// table + definition. Names handled here are recorded so the legacy name loop
+	// table + definition. Names handled here are recorded so the name-only loop
 	// skips them.
 	handled := make(map[string]struct{})
 	droppedForModify := make(map[string]struct{})


### PR DESCRIPTION
## Summary

- add a round-trip fixture for foreign keys added to already-existing columns, including a self-reference
- validate every generated down migration against the previous fixture version before continuing down to zero
- fix MySQL/MariaDB rollback generation so down migrations drop auto-created FK backing indexes when the pre-change DB did not already have the same-named index
- keep MySQL/MariaDB rollback ordering as `DROP FOREIGN KEY` before `DROP INDEX`
- add tests that lock the issue #147 edge-case fixture registry, verify the new FK metadata transition, pin MySQL-family drop order, and cover generated FK-backed index removal/non-removal
- document the generator round-trip fixture scenario and its step-by-step rollback coverage
- document the pre-GA rule in `AGENTS.md`: do not add legacy command aliases, compatibility wrappers, fallback APIs, or backward-compatibility behavior unless a maintainer explicitly asks for that layer

Closes #147.

## Validation

- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go test ./migration/generator -run TestGenerateDownMigrationSQL_MySQLFamilyDropsGeneratedForeignKeyBackingIndex -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go test ./migration/planner/dialects/mysql -run TestPlanner_GenerateMigrationAST_ForeignKeyIndexesDropAfterConstraints -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go test ./migration/generator ./migration/planner/dialects/mysql ./integration ./cmd/integration-test -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go test ./integration ./integration/gonative -tags=integration -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-issue-147-golangci-cache golangci-lint run ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-issue-147-go-cache go test ./... -count=1` passed outside the sandbox; inside the sandbox, `dbschema` localhost listener tests fail with `bind: operation not permitted`

Local Docker live-DB validation was attempted with `docker compose --profile test build ptah-tester`, but Docker was not available in this environment: the OrbStack socket `unix:///Users/buster/.orbstack/run/docker.sock` was missing. GitHub Actions remains the live-DB contour for this PR.