### PR TITLE
Remove native CLI compatibility forwarders

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,13 +576,13 @@ for SQLite URL forms, generated DDL, and ALTER TABLE limitations.
 ./ptah schema compare --root-dir ./models --db-url postgres://user:pass@localhost/db
 
 # Generate migration SQL
-./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost/db
+./ptah migrations plan --root-dir ./models --db-url postgres://user:pass@localhost/db
 
 # Create paired empty migration files for manual SQL
-./ptah migrate new add_user_preferences --migrations-dir ./migrations
+./ptah migrations create add_user_preferences --migrations-dir ./migrations
 
 # Generate migration SQL while introspecting specific PostgreSQL schemas
-./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost/db --schemas auth,billing,public
+./ptah migrations plan --root-dir ./models --db-url postgres://user:pass@localhost/db --schemas auth,billing,public
 
 # Apply migrations to database
 ./ptah migrations up --db-url postgres://user:pass@localhost/db --migrations-dir ./migrations
@@ -798,16 +798,16 @@ and DDL forms that Ptah's parser does not yet model.
 Generate SQL migration statements to synchronize schemas:
 
 ```bash
-./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
-./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
+./ptah migrations plan --root-dir ./models --db-url postgres://user:pass@localhost:5432/database
+./ptah migrations plan --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --schemas auth,billing,public
 ```
 
 Use `--report json` when CI needs the destructive-safety verdict as structured
 data instead of text:
 
 ```bash
-./ptah migrate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --report json
-./ptah migrate generate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --report json
+./ptah migrations plan --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --report json
+./ptah migrations generate --root-dir ./models --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --report json
 ```
 
 **Output:** SQL statements to bring the database in sync with Go entities
@@ -816,9 +816,9 @@ data instead of text:
 Create paired `.up.sql` and `.down.sql` files for manual SQL authoring:
 
 ```bash
-./ptah migrate new add_user_preferences --migrations-dir ./migrations
-./ptah migrate new --name hotfix_existing_data --migrations-dir ./migrations
-./ptah atlas migrate new add_user_preferences --migrations-dir ./migrations
+./ptah migrations create add_user_preferences --migrations-dir ./migrations
+./ptah migrations create --name hotfix_existing_data --migrations-dir ./migrations
+./ptah atlas migrate new add_user_preferences --dir ./migrations
 ```
 
 The command creates timestamped files using Ptah's paired migration naming
@@ -987,7 +987,7 @@ autocommit SQL instead of through the transaction-bound writer.
 
 Generated PostgreSQL migrations also use this path for indexes on populated
 existing tables. If live introspection reports an existing table with an
-estimated row count greater than zero, `migrate generate` emits
+estimated row count greater than zero, `migrations generate` emits
 `CREATE INDEX CONCURRENTLY` for new indexes on that table and writes the file
 with `-- +ptah no_transaction`. When a change set also contains ordinary
 transactional DDL, Ptah splits the output into separate migration versions:
@@ -1304,7 +1304,7 @@ files, err := generator.GenerateMigration(ctx, opts)
 **CLI generation with shadow verification:**
 
 ```bash
-ptah migrate generate \
+ptah migrations generate \
   --root-dir ./models \
   --db-url postgres://user:pass@localhost:5432/database \
   --migrations-dir ./migrations \
@@ -1319,7 +1319,7 @@ matches the Go source. A mismatch aborts before writing files with a diagnostic
 such as `shadow check failed: missing column users.email`. Library callers can
 inspect structured shadow mismatches via `generator.ShadowVerificationError`.
 
-You can make this the default for `migrate generate` by configuring the same
+You can make this the default for `migrations generate` by configuring the same
 disposable database in `ptah.yaml`; an explicit `--shadow-db` value still wins:
 
 ```yaml

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -204,12 +204,11 @@ func newAtlasMigrateCommand() *cobra.Command {
 			},
 		},
 		{
-			use:        "new",
-			short:      "Create a new migration file",
-			native:     "migrations create",
-			factory:    migrate.NewMigrateCommand,
-			prefixArgs: []string{"new"},
-			flags:      []atlasFlag{atlasNativeString("dir", "", "Migration directory", "migrations-dir")},
+			use:     "new",
+			short:   "Create a new migration file",
+			native:  "migrations create",
+			factory: migrate.NewMigrateCreateCommand,
+			flags:   []atlasFlag{atlasNativeString("dir", "", "Migration directory", "migrations-dir")},
 		},
 		{
 			use:     "set",

--- a/cmd/db/db.go
+++ b/cmd/db/db.go
@@ -5,7 +5,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/dropall"
-	"github.com/stokaro/ptah/cmd/internal/cmdalias"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/readdb"
 )
@@ -24,21 +23,13 @@ under ptah atlas.`,
 		},
 	}
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
-	readCmd := cmdalias.NewForwardCommandWithTargetHelp(
-		"read",
-		"Read schema from a live database",
-		"read-db",
-		readdb.NewReadDBCommand,
-	)
+	readCmd := readdb.NewReadDBCommand()
+	readCmd.Short = "Read schema from a live database"
 	readCmd.Long = "Read schema from a live database using Ptah's native database namespace."
 	cmd.AddCommand(readCmd)
 
-	dropAllCmd := cmdalias.NewForwardCommandWithTargetHelp(
-		"drop-all",
-		"Drop all schema objects in a live database",
-		"drop-all",
-		dropall.NewDropAllCommand,
-	)
+	dropAllCmd := dropall.NewDropAllCommand()
+	dropAllCmd.Short = "Drop all schema objects in a live database"
 	dropAllCmd.Long = "Drop all schema objects in a live database using Ptah's native database namespace."
 	cmd.AddCommand(dropAllCmd)
 	return cmd

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -18,7 +18,7 @@ import (
 )
 
 var generateCmd = &cobra.Command{
-	Use:   "generate",
+	Use:   "render",
 	Short: "Generate schema from Go entities, YAML schema files, or Atlas HCL schema files",
 	Long: `Generate database schema from Go entities in the specified directory or from a schema file.
 	

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -24,7 +24,7 @@ const (
 	generateReportFormatFlag     = "report"
 )
 
-func newMigrateGenerateCommand() *cobra.Command {
+func NewMigrateGenerateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate migration files from schema differences",

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -17,7 +17,7 @@ import (
 func TestMigrateGenerateCommandExposesShadowDBFlag(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := newMigrateGenerateCommand()
+	cmd := NewMigrateGenerateCommand()
 
 	c.Assert(cmd.Name(), qt.Equals, "generate")
 	c.Assert(cmd.Flags().Lookup(generateShadowDBFlag), qt.IsNotNil)
@@ -42,7 +42,7 @@ func TestMigrateGenerateProjectConfigPrecedence(t *testing.T) {
 		c.Assert(os.Chdir(originalWD), qt.IsNil)
 	}()
 
-	cmd := newMigrateGenerateCommand()
+	cmd := NewMigrateGenerateCommand()
 	c.Assert(cmd.ParseFlags([]string{"--shadow-db", "postgres://localhost/flag_shadow"}), qt.IsNil)
 	flagShadow, err := cmd.Flags().GetString(generateShadowDBFlag)
 	c.Assert(err, qt.IsNil)
@@ -53,30 +53,14 @@ func TestMigrateGenerateProjectConfigPrecedence(t *testing.T) {
 
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/flag_shadow")
 
-	cmd = newMigrateGenerateCommand()
+	cmd = NewMigrateGenerateCommand()
 	cfg, err = dbcli.LoadProjectConfig(cmd, "")
 	c.Assert(err, qt.IsNil)
 	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, "", cfg.DevURL)
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/atlas_shadow")
 }
 
-func TestAddMigrateGenerateCommandIsIdempotent(t *testing.T) {
-	c := qt.New(t)
-
-	cmd := NewMigrateCommand()
-	addMigrateGenerateCommand(cmd)
-	addMigrateGenerateCommand(cmd)
-
-	count := 0
-	for _, child := range cmd.Commands() {
-		if child.Name() == "generate" {
-			count++
-		}
-	}
-	c.Assert(count, qt.Equals, 1)
-}
-
-func TestMigrateCommandRejectsAtlasApplyAtRoot(t *testing.T) {
+func TestMigratePlanCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 	c := qt.New(t)
 
 	cmd := NewMigrateCommand()
@@ -122,10 +106,9 @@ func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 		prepareMigrateGenerateTargetDB(c, ctx, conn)
 
 		var out bytes.Buffer
-		cmd := NewMigrateCommand()
+		cmd := NewMigrateGenerateCommand()
 		cmd.SetOut(&out)
 		cmd.SetArgs([]string{
-			"generate",
 			"--root-dir", entitiesDir,
 			"--db-url", dbURL,
 			"--migrations-dir", migrationsDir,
@@ -150,10 +133,9 @@ func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 		prepareMigrateGenerateTargetDB(c, ctx, conn)
 
 		var out bytes.Buffer
-		cmd := NewMigrateCommand()
+		cmd := NewMigrateGenerateCommand()
 		cmd.SetOut(&out)
 		cmd.SetArgs([]string{
-			"generate",
 			"--root-dir", entitiesDir,
 			"--db-url", dbURL,
 			"--migrations-dir", migrationsDir,

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -21,7 +21,7 @@ import (
 )
 
 var migrateCmd = &cobra.Command{
-	Use:   "migrate",
+	Use:   "plan",
 	Short: "Generate migration SQL from differences",
 	Long: `Generate migration SQL statements based on differences between Go entities and database schema.
 	
@@ -79,28 +79,8 @@ func NewMigrateCommand() *cobra.Command {
 		cobraflags.RegisterMap(migrateCmd, migrateFlags)
 		migrateFlagsRegistered = true
 	}
-	addMigrateGenerateCommand(migrateCmd)
-	addMigrateNewCommand(migrateCmd)
 	cmdutil.ConfigureCommandArgs(migrateCmd, cmdutil.NoPositionalArgs)
 	return migrateCmd
-}
-
-func addMigrateGenerateCommand(cmd *cobra.Command) {
-	for _, child := range cmd.Commands() {
-		if child.Name() == "generate" {
-			return
-		}
-	}
-	cmd.AddCommand(newMigrateGenerateCommand())
-}
-
-func addMigrateNewCommand(cmd *cobra.Command) {
-	for _, child := range cmd.Commands() {
-		if child.Name() == "new" {
-			return
-		}
-	}
-	cmd.AddCommand(newMigrateNewCommand())
 }
 
 func migrateCommand(cmd *cobra.Command, _ []string) error {

--- a/cmd/migrate/new.go
+++ b/cmd/migrate/new.go
@@ -16,9 +16,9 @@ const (
 	newNameFlag          = "name"
 )
 
-func newMigrateNewCommand() *cobra.Command {
+func NewMigrateCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "new [name]",
+		Use:   "create [name]",
 		Short: "Create empty migration files for manual SQL",
 		Long: `Create paired empty migration files for manual SQL authoring.
 

--- a/cmd/migrate/new_test.go
+++ b/cmd/migrate/new_test.go
@@ -13,7 +13,7 @@ func TestMigrateNewCommandCreatesSkeletonFiles(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
-	cmd := newMigrateNewCommand()
+	cmd := NewMigrateCreateCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -38,7 +38,7 @@ func TestMigrateNewCommandAcceptsNameFlag(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
-	cmd := newMigrateNewCommand()
+	cmd := NewMigrateCreateCommand()
 	cmd.SetArgs([]string{"--name", "manual_hotfix", "--migrations-dir", dir})
 
 	err := cmd.Execute()
@@ -75,7 +75,7 @@ func TestMigrateNewCommandValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			cmd := newMigrateNewCommand()
+			cmd := NewMigrateCreateCommand()
 			cmd.SetArgs(tt.args)
 
 			err := cmd.Execute()
@@ -85,18 +85,10 @@ func TestMigrateNewCommandValidation(t *testing.T) {
 	}
 }
 
-func TestAddMigrateNewCommandIsIdempotent(t *testing.T) {
+func TestMigrateCreateCommandUsesNativeName(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrateCommand()
-	addMigrateNewCommand(cmd)
-	addMigrateNewCommand(cmd)
+	cmd := NewMigrateCreateCommand()
 
-	count := 0
-	for _, child := range cmd.Commands() {
-		if child.Name() == "new" {
-			count++
-		}
-	}
-	c.Assert(count, qt.Equals, 1)
+	c.Assert(cmd.Name(), qt.Equals, "create")
 }

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -35,7 +35,7 @@ const (
 func NewMigrateBaselineCommand() *cobra.Command {
 	flags := newMigrateBaselineFlags()
 	cmd := &cobra.Command{
-		Use:   "migrate-baseline",
+		Use:   "baseline",
 		Short: "Record existing migrations as already applied",
 		Long: `Record existing migrations as already applied without executing their SQL bodies.
 

--- a/cmd/migratebaseline/migratebaseline_test.go
+++ b/cmd/migratebaseline/migratebaseline_test.go
@@ -21,7 +21,7 @@ func TestMigrateBaselineCommandCreation(t *testing.T) {
 
 	cmd := NewMigrateBaselineCommand()
 	c.Assert(cmd, qt.IsNotNil)
-	c.Assert(cmd.Use, qt.Equals, "migrate-baseline")
+	c.Assert(cmd.Use, qt.Equals, "baseline")
 	c.Assert(cmd.Flag(dbURLFlag), qt.IsNotNil)
 	c.Assert(cmd.Flag(migrationsFlag), qt.IsNotNil)
 	c.Assert(cmd.Flag(versionFlag), qt.IsNotNil)

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -17,7 +17,7 @@ import (
 )
 
 var migrateDownCmd = &cobra.Command{
-	Use:   "migrate-down",
+	Use:   "down",
 	Short: "Roll back migrations to a specific version",
 	Long: `Roll back database migrations to a specific target version.
 

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -17,7 +17,7 @@ func TestMigrateDownCommand_Creation(t *testing.T) {
 
 	cmd := migratedown.NewMigrateDownCommand()
 	c.Assert(cmd, qt.IsNotNil)
-	c.Assert(cmd.Use, qt.Equals, "migrate-down")
+	c.Assert(cmd.Use, qt.Equals, "down")
 	c.Assert(cmd.Short, qt.Contains, "Roll back migrations")
 	c.Assert(cmd.Flag("migration-lock-timeout"), qt.IsNotNil)
 }

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -18,7 +18,7 @@ func NewMigrateHashCommand() *cobra.Command {
 	var dirFormatValue string
 
 	cmd := &cobra.Command{
-		Use:   "migrate-hash",
+		Use:   "hash",
 		Short: "Write or update the ptah.sum integrity file for a migrations directory",
 		Long: `migrations hash recomputes the integrity hashes of every migration file in a
 directory and writes them to ptah.sum. Run it whenever you add, remove, or

--- a/cmd/migraterepair/migraterepair.go
+++ b/cmd/migraterepair/migraterepair.go
@@ -16,7 +16,7 @@ import (
 )
 
 var migrateRepairCmd = &cobra.Command{
-	Use:   "migrate-repair",
+	Use:   "repair",
 	Short: "Repair dirty migration metadata",
 	Long: `Repair dirty migration metadata after an operator has fixed a
 half-applied migration manually, or resume the migration from a specific

--- a/cmd/migraterepair/migraterepair_test.go
+++ b/cmd/migraterepair/migraterepair_test.go
@@ -12,7 +12,7 @@ func TestMigrateRepairCommand_Creation(t *testing.T) {
 	cmd := NewMigrateRepairCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
-	c.Assert(cmd.Use, qt.Equals, "migrate-repair")
+	c.Assert(cmd.Use, qt.Equals, "repair")
 	c.Assert(cmd.Short, qt.Contains, "Repair dirty migration metadata")
 	c.Assert(cmd.Flag(dbURLFlag), qt.IsNotNil)
 	c.Assert(cmd.Flag(migrationsFlag), qt.IsNotNil)

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -18,7 +18,7 @@ import (
 )
 
 var migrateStatusCmd = &cobra.Command{
-	Use:   "migrate-status",
+	Use:   "status",
 	Short: "Show current migration status",
 	Long: `Show the current migration status of the database.
 

--- a/cmd/migratestatus/migratestatus_test.go
+++ b/cmd/migratestatus/migratestatus_test.go
@@ -18,7 +18,7 @@ func TestMigrateStatusCommand_Creation(t *testing.T) {
 	cmd := migratestatus.NewMigrateStatusCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
-	c.Assert(cmd.Use, qt.Equals, "migrate-status")
+	c.Assert(cmd.Use, qt.Equals, "status")
 	c.Assert(cmd.Short, qt.Contains, "Show current migration status")
 	c.Assert(cmd.Flag(dbcli.ConfigFlagName), qt.IsNotNil)
 	c.Assert(cmd.Flag(dbcli.MigrationsSchemaFlagName), qt.IsNotNil)

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -22,7 +22,7 @@ import (
 )
 
 var migrateUpCmd = &cobra.Command{
-	Use:   "migrate-up",
+	Use:   "up",
 	Short: "Run pending migrations up to the latest version",
 	Long: `Run all pending database migrations up to the latest version.
 

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -21,7 +21,7 @@ func NewMigrateValidateCommand() *cobra.Command {
 	var dirFormatValue string
 
 	cmd := &cobra.Command{
-		Use:   "migrate-validate",
+		Use:   "validate",
 		Short: "Verify a migrations directory against its committed ptah.sum",
 		Long: `migrations validate recomputes the integrity hashes of a migrations directory
 and compares them against the committed ptah.sum. It exits:

--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -4,7 +4,6 @@ package migrations
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/stokaro/ptah/cmd/internal/cmdalias"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
@@ -34,56 +33,23 @@ ptah atlas.`,
 	}
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 
-	for _, alias := range []struct {
-		use        string
-		short      string
-		long       string
-		native     string
-		factory    func() *cobra.Command
-		prefixArgs []string
-	}{
-		{
-			use:     "plan",
-			short:   "Plan migration SQL from schema differences",
-			long:    "Plan migration SQL from schema differences without writing migration files.",
-			native:  "migrate",
-			factory: migrate.NewMigrateCommand,
-		},
-		{
-			use:        "generate",
-			short:      "Generate migration files from schema differences",
-			long:       "Generate migration files from schema differences and write them to the migrations directory.",
-			native:     "migrate generate",
-			factory:    migrate.NewMigrateCommand,
-			prefixArgs: []string{"generate"},
-		},
-		{
-			use:        "create",
-			short:      "Create empty migration files for manual SQL",
-			long:       "Create empty migration files for manual SQL.",
-			native:     "migrate new",
-			factory:    migrate.NewMigrateCommand,
-			prefixArgs: []string{"new"},
-		},
-		{use: "up", short: "Run pending migrations", long: "Run pending migrations against a live database.", native: "migrations up", factory: migrateup.NewMigrateUpCommand},
-		{use: "down", short: "Roll back migrations", long: "Roll back migrations against a live database.", native: "migrations down", factory: migratedown.NewMigrateDownCommand},
-		{use: "status", short: "Show migration status", long: "Show migration status for a live database and migrations directory.", native: "migrations status", factory: migratestatus.NewMigrateStatusCommand},
-		{use: "baseline", short: "Record existing migrations as applied", long: "Record existing migrations as already applied in the revision table.", native: "migrations baseline", factory: migratebaseline.NewMigrateBaselineCommand},
-		{use: "repair", short: "Repair migration revision metadata", long: "Repair migration revision metadata after a dirty or partial migration state.", native: "migrations repair", factory: migraterepair.NewMigrateRepairCommand},
-		{use: "hash", short: "Write or update migration directory integrity", long: "Write or update the migration directory integrity file.", native: "migrations hash", factory: migratehash.NewMigrateHashCommand},
-		{use: "validate", short: "Validate migration directory integrity", long: "Validate the migration directory against its integrity file.", native: "migrations validate", factory: migratevalidate.NewMigrateValidateCommand},
-		{use: "lint", short: "Lint migration files", long: "Lint migration files for production-unsafe patterns.", native: "lint", factory: lint.NewLintCommand},
-	} {
-		aliasCmd := cmdalias.NewForwardCommandWithTargetHelp(
-			alias.use,
-			alias.short,
-			alias.native,
-			alias.factory,
-			alias.prefixArgs...,
-		)
-		aliasCmd.Long = alias.long
-		cmd.AddCommand(aliasCmd)
-	}
+	cmd.AddCommand(migrationCommand(migrate.NewMigrateCommand(), "Plan migration SQL from schema differences", "Plan migration SQL from schema differences without writing migration files."))
+	cmd.AddCommand(migrationCommand(migrate.NewMigrateGenerateCommand(), "Generate migration files from schema differences", "Generate migration files from schema differences and write them to the migrations directory."))
+	cmd.AddCommand(migrationCommand(migrate.NewMigrateCreateCommand(), "Create empty migration files for manual SQL", "Create empty migration files for manual SQL."))
+	cmd.AddCommand(migrationCommand(migrateup.NewMigrateUpCommand(), "Run pending migrations", "Run pending migrations against a live database."))
+	cmd.AddCommand(migrationCommand(migratedown.NewMigrateDownCommand(), "Roll back migrations", "Roll back migrations against a live database."))
+	cmd.AddCommand(migrationCommand(migratestatus.NewMigrateStatusCommand(), "Show migration status", "Show migration status for a live database and migrations directory."))
+	cmd.AddCommand(migrationCommand(migratebaseline.NewMigrateBaselineCommand(), "Record existing migrations as applied", "Record existing migrations as already applied in the revision table."))
+	cmd.AddCommand(migrationCommand(migraterepair.NewMigrateRepairCommand(), "Repair migration revision metadata", "Repair migration revision metadata after a dirty or partial migration state."))
+	cmd.AddCommand(migrationCommand(migratehash.NewMigrateHashCommand(), "Write or update migration directory integrity", "Write or update the migration directory integrity file."))
+	cmd.AddCommand(migrationCommand(migratevalidate.NewMigrateValidateCommand(), "Validate migration directory integrity", "Validate the migration directory against its integrity file."))
+	cmd.AddCommand(migrationCommand(lint.NewLintCommand(), "Lint migration files", "Lint migration files for production-unsafe patterns."))
 
+	return cmd
+}
+
+func migrationCommand(cmd *cobra.Command, short string, long string) *cobra.Command {
+	cmd.Short = short
+	cmd.Long = long
 	return cmd
 }

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -16,7 +16,7 @@ import (
 )
 
 var readDBCmd = &cobra.Command{
-	Use:   "read-db",
+	Use:   "read",
 	Short: "Read schema from database",
 	Long: `Read and display the current schema from the specified database.
 	

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stokaro/ptah/cmd/compare"
 	"github.com/stokaro/ptah/cmd/drift"
 	"github.com/stokaro/ptah/cmd/generate"
-	"github.com/stokaro/ptah/cmd/internal/cmdalias"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/core/atlashclrender"
 	"github.com/stokaro/ptah/core/goschema"
@@ -47,30 +46,18 @@ under ptah atlas.`,
 	}
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	cmd.AddCommand(newSchemaExportCommand())
-	renderCmd := cmdalias.NewForwardCommandWithTargetHelp(
-		"render",
-		"Render desired schema SQL",
-		"generate",
-		generate.NewGenerateCommand,
-	)
+	renderCmd := generate.NewGenerateCommand()
+	renderCmd.Short = "Render desired schema SQL"
 	renderCmd.Long = "Render desired schema SQL from Go annotations, YAML schema files, or Atlas HCL schema files."
 	cmd.AddCommand(renderCmd)
 
-	compareCmd := cmdalias.NewForwardCommandWithTargetHelp(
-		"compare",
-		"Compare desired schema with a live database",
-		"compare",
-		compare.NewCompareCommand,
-	)
+	compareCmd := compare.NewCompareCommand()
+	compareCmd.Short = "Compare desired schema with a live database"
 	compareCmd.Long = "Compare desired schema with a live database."
 	cmd.AddCommand(compareCmd)
 
-	driftCmd := cmdalias.NewForwardCommandWithTargetHelp(
-		"drift",
-		"Check live database drift against desired schema",
-		"drift",
-		drift.NewDriftCommand,
-	)
+	driftCmd := drift.NewDriftCommand()
+	driftCmd.Short = "Check live database drift against desired schema"
 	driftCmd.Long = "Check live database drift against desired schema."
 	cmd.AddCommand(driftCmd)
 	return cmd

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -42,7 +42,7 @@ func TestSchemaExportCommandWritesAtlasHCL(t *testing.T) {
 	c.Assert(err, qt.IsNil, qt.Commentf("schema.hcl:\n%s", string(content)))
 }
 
-func TestSchemaCommand_RegistersNativeAliasPaths(t *testing.T) {
+func TestSchemaCommand_RegistersNativePaths(t *testing.T) {
 	c := qt.New(t)
 
 	cmd := schema.NewSchemaCommand()
@@ -58,7 +58,7 @@ func TestSchemaCommand_RegistersNativeAliasPaths(t *testing.T) {
 	}
 }
 
-func TestSchemaCommand_RenderHelpShowsNativeAlias(t *testing.T) {
+func TestSchemaCommand_RenderHelpShowsNativePath(t *testing.T) {
 	c := qt.New(t)
 
 	cmd := schema.NewSchemaCommand()

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -34,7 +34,7 @@ The supported attributes map to Ptah settings as follows:
 | Atlas setting | Ptah setting |
 | --- | --- |
 | `env.url` | `--db-url` default |
-| `env.dev` | `migrate generate --shadow-db` default |
+| `env.dev` | `migrations generate --shadow-db` default |
 | `env.exclude` | Project config IR exclude list |
 | `migration.dir` | `--migrations-dir` or `--dir` default |
 | `migration.format` | `--dir-format` default |
@@ -92,7 +92,7 @@ settings:
 - `migrations down`
 - `migrations status`
 - `lint`
-- `migrate generate`
+- `migrations generate`
 
 Atlas-compatible aliases under `ptah atlas <command> ...` inherit this behavior
 when they forward to one of these native commands.

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -63,7 +63,7 @@ env:
 | Key | Meaning |
 | --- | --- |
 | `url` | Default target database URL for migration commands |
-| `dev` | Disposable dev/shadow database URL for `migrate generate` |
+| `dev` | Disposable dev/shadow database URL for `migrations generate` |
 | `schemas` | Default schemas to introspect when the command supports schema scoping |
 | `exclude` | Project-level exclude patterns for config consumers |
 | `migration.dir` | Default migrations directory |


### PR DESCRIPTION
## Summary

- register `ptah schema`, `ptah db`, and `ptah migrations` subcommands directly instead of wrapping older root command spellings through `cmdalias`
- rename command `Use` values to the native grouped command names (`render`, `read`, `plan`, `create`, `up`, `down`, etc.)
- split migration planning, file generation, and empty-file creation into native constructors instead of the old aggregate `migrate generate/new` shape
- keep `cmdalias` only for the explicit `ptah atlas ...` adapter surface
- update README/project-config docs to use `ptah migrations plan/generate/create`

## Validation

- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache go test ./cmd/... -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-remove-legacy-golangci-cache golangci-lint run ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache go test ./cmd/... ./config/... -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache go test ./... -count=1` outside sandbox because `dbschema` tests bind localhost listeners
- `env GOWORK=off GOCACHE=/private/tmp/ptah-remove-legacy-go-cache go test ./integration ./integration/gonative -tags=integration -count=1`
- runtime smoke: `go run ./cmd/main.go migrations --help`
- runtime smoke: `go run ./cmd/main.go migrations up --help`
- runtime smoke: `go run ./cmd/main.go schema render --help`
- runtime smoke: `go run ./cmd/main.go migrate-up --help` fails with `unknown command`
- runtime smoke: `go run ./cmd/main.go migrate generate --help` fails with `unknown command`
- runtime smoke: `go run ./cmd/main.go read-db --help` fails with `unknown command`
- runtime smoke: `go run ./cmd/main.go atlas migrate new --help` shows `ptah atlas migrate new` forwarding to `ptah migrations create`