### PR TITLE
Harden Atlas parity audit gaps

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -183,6 +183,15 @@ jobs:
         run: |
           go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_' -timeout 3m
 
+      - name: Run no-transaction and shadow generator integration tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -v ./migration/migrator -run 'TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration' -timeout 3m
+          go test -v ./migration/generator -run 'TestGenerateMigrationShadowVerificationWithRealDB|TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB' -timeout 5m
+          go test -v ./cmd/migrateup -run 'TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres' -timeout 3m
+
       - name: Run migrate-baseline integration tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ rules:
 ```
 
 Inline suppressions apply to the next statement only. Ptah accepts both its
-native directive and the Atlas-compatible alias:
+native directive and Atlas's `atlas:nolint` directive:
 
 ```sql
 -- ptah:nolint DS102
@@ -920,9 +920,11 @@ already-recorded migration using an explicit Ptah `.down.sql` file or an Atlas
 txtar `down.sql` section.
 
 `-- +ptah` directives inside `migration.sql` and `down.sql` are parsed per
-section for timeout and validation purposes. The current `no_transaction` model
-is still migration-level: if either direction opts out of transactions, Ptah
-treats the migration as non-transactional.
+section for timeout, validation, and transaction handling. `no_transaction`
+applies only to the direction whose SQL section contains it, so a
+non-transactional `down.sql` does not force `migration.sql` to run outside a
+transaction. Atlas `-- atlas:txmode none` comments are accepted as the Atlas
+equivalent for the section where they appear.
 
 #### Apply Migrations
 Apply all pending migrations to bring database up to latest version:
@@ -1174,15 +1176,15 @@ Atlas-compatible command paths are available only under `ptah atlas`:
 | `ptah atlas schema inspect` | `ptah db read` |
 | `ptah atlas schema diff` | `ptah schema compare` |
 
-Atlas-compatible aliases accept Atlas OSS flag names under `ptah atlas` and
-translate implemented flags to the native Ptah flags before execution. For
+Atlas command paths accept Atlas OSS flag names under `ptah atlas` and translate
+implemented flags to the native Ptah flags before execution. For
 example, `ptah atlas migrate apply --url ... --dir ...` maps to
 `ptah migrations up --db-url ... --migrations-dir ...`, and
 `ptah atlas schema inspect --url ...` maps to `ptah db read --db-url ...`.
 Flags that are part of the Atlas OSS CLI but do not have Ptah behavior yet are
 advertised and rejected explicitly instead of being silently ignored.
 
-The implemented Atlas-compatible commands delegate to native commands after
+The implemented Atlas command paths delegate to native commands after
 flag translation, so their exit codes follow the native command contract
 documented in [CLI Exit Codes](docs/exit_codes.md). Unsupported Atlas-compatible
 flags are rejected explicitly and exit `2`.

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -55,12 +55,12 @@ type parsedAtlasFlag struct {
 	ok       bool
 }
 
-// NewAtlasCommand returns the Atlas compatibility namespace.
+// NewAtlasCommand returns the Atlas command namespace.
 func NewAtlasCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "atlas",
-		Short: "Atlas-compatible command namespace",
-		Long: `Atlas-compatible command namespace.
+		Short: "Atlas OSS command namespace",
+		Long: `Atlas OSS command namespace.
 
 These commands reserve the Atlas OSS CLI surface under Ptah. Commands that have
 an existing Ptah equivalent forward to that native command while keeping the
@@ -80,7 +80,7 @@ native Ptah command tree separate for future redesign.`,
 func newAtlasSchemaCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
-		Short: "Atlas schema command compatibility",
+		Short: "Atlas schema commands",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
@@ -137,7 +137,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 			},
 		},
 	} {
-		cmd.AddCommand(newAtlasAliasCommand("schema", verb))
+		cmd.AddCommand(newAtlasAdapterCommand("schema", verb))
 	}
 	return cmd
 }
@@ -145,7 +145,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 func newAtlasMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate",
-		Short: "Atlas migrate command compatibility",
+		Short: "Atlas migrate commands",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
@@ -241,7 +241,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 			},
 		},
 	} {
-		cmd.AddCommand(newAtlasAliasCommand("migrate", verb))
+		cmd.AddCommand(newAtlasAdapterCommand("migrate", verb))
 	}
 	return cmd
 }
@@ -251,7 +251,7 @@ func newAtlasVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Print Ptah version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return fmt.Errorf("atlas version compatibility is not implemented yet; use the native Ptah version command once issue #268 lands")
+			return fmt.Errorf("atlas version is not implemented yet; use the native Ptah version command once issue #268 lands")
 		},
 	}
 	cmdutil.ConfigureCommand(cmd)
@@ -263,14 +263,14 @@ func newAtlasLicenseCommand() *cobra.Command {
 		Use:   "license",
 		Short: "Print license information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return fmt.Errorf("atlas license compatibility is not implemented yet")
+			return fmt.Errorf("atlas license is not implemented yet")
 		},
 	}
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 
-func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
+func newAtlasAdapterCommand(group string, verb atlasVerb) *cobra.Command {
 	mapper := atlasArgMapper(group, verb)
 	if verb.factory != nil {
 		cmd := cmdalias.NewForwardCommandWithArgsMapper(
@@ -287,10 +287,10 @@ func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   verb.use,
 		Short: verb.short,
-		Long:  atlasAliasLong(group, verb),
+		Long:  atlasCommandLong(group, verb),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if verb.native == "" {
-				return fmt.Errorf("atlas %s %s compatibility is not implemented yet", group, verb.use)
+				return fmt.Errorf("atlas %s %s is not implemented yet", group, verb.use)
 			}
 			return fmt.Errorf("atlas %s %s execution is not implemented yet; use `ptah %s`", group, verb.use, verb.native)
 		},
@@ -300,11 +300,11 @@ func newAtlasAliasCommand(group string, verb atlasVerb) *cobra.Command {
 	return cmd
 }
 
-func atlasAliasLong(group string, verb atlasVerb) string {
+func atlasCommandLong(group string, verb atlasVerb) string {
 	if verb.native == "" {
-		return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. Runtime compatibility is not implemented yet.", group, verb.use)
+		return fmt.Sprintf("Atlas OSS `atlas %s %s` command path. Runtime behavior is not implemented yet.", group, verb.use)
 	}
-	return fmt.Sprintf("Atlas-compatible `atlas %s %s` command path. The current native Ptah equivalent is `ptah %s`.", group, verb.use, verb.native)
+	return fmt.Sprintf("Atlas OSS `atlas %s %s` command path. The current native Ptah implementation is `ptah %s`.", group, verb.use, verb.native)
 }
 
 func atlasString(name, shorthand, usage string) atlasFlag {

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -325,5 +325,5 @@ func TestNewAtlasCommand_UnsupportedCommandsAreExplicit(t *testing.T) {
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, "atlas schema apply compatibility is not implemented yet")
+	c.Assert(err, qt.ErrorMatches, "atlas schema apply is not implemented yet")
 }

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -2,13 +2,18 @@ package migrateup
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -114,6 +119,91 @@ rules:
 	c.Assert(findings[0].Rule, qt.Equals, "DS101")
 }
 
+func TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres(t *testing.T) {
+	dbURL := postgresTestURL()
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	}
+
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	widenTable := "ptah_migrateup_widen_" + suffix
+	dropTable := "ptah_migrateup_drop_" + suffix
+	widenRevisions := "ptah_migrateup_widen_revisions_" + suffix
+	dropRevisions := "ptah_migrateup_drop_revisions_" + suffix
+	defer cleanupPostgresObjects(t, conn, widenTable, dropTable, widenRevisions, dropRevisions)
+
+	widenDir := t.TempDir()
+	writeMigrateUpFile(c, widenDir, lint.ConfigFileName, `rules:
+  DS103:
+    severity: warning
+`)
+	writeMigrateUpFile(c, widenDir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", widenTable))
+	writeMigrateUpFile(c, widenDir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", widenTable))
+	writeMigrateUpFile(c, widenDir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", widenTable))
+	writeMigrateUpFile(c, widenDir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", widenTable))
+
+	cmd := NewMigrateUpCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", widenDir,
+		"--migrations-table", widenRevisions,
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+
+	var maxLength int
+	err = conn.QueryRowContext(ctx, `
+		SELECT character_maximum_length
+		FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = $1 AND column_name = 'email'
+	`, widenTable).Scan(&maxLength)
+	c.Assert(err, qt.IsNil)
+	c.Assert(maxLength, qt.Equals, 512)
+
+	dropDir := t.TempDir()
+	writeMigrateUpFile(c, dropDir, lint.ConfigFileName, `rules:
+  DS103:
+    severity: warning
+`)
+	writeMigrateUpFile(c, dropDir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", dropTable))
+	writeMigrateUpFile(c, dropDir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", dropTable))
+	writeMigrateUpFile(c, dropDir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", dropTable))
+	writeMigrateUpFile(c, dropDir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", dropTable))
+	writeMigrateUpFile(c, dropDir, "0000000003_drop_table.up.sql", fmt.Sprintf("DROP TABLE %s;\n", dropTable))
+	writeMigrateUpFile(c, dropDir, "0000000003_drop_table.down.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(512));\n", dropTable))
+
+	cmd = NewMigrateUpCommand()
+	stdout.Reset()
+	stderr.Reset()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dropDir,
+		"--migrations-table", dropRevisions,
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "pending migrations contain destructive statements")
+	c.Assert(err.Error(), qt.Contains, "DS101")
+
+	var dropExists bool
+	err = conn.QueryRowContext(ctx, "SELECT to_regclass($1) IS NOT NULL", "public."+dropTable).Scan(&dropExists)
+	c.Assert(err, qt.IsNil)
+	c.Assert(dropExists, qt.IsFalse)
+}
+
 func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing.T) {
 	c := qt.New(t)
 
@@ -137,4 +227,33 @@ func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing
 		qt.DeepEquals,
 		[]int64{6},
 	)
+}
+
+func postgresTestURL() string {
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func writeMigrateUpFile(c *qt.C, dir, name, content string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+}
+
+func cleanupPostgresObjects(t *testing.T, conn *dbschema.DatabaseConnection, names ...string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, name := range names {
+		if !safePostgresIdentifier(name) {
+			t.Fatalf("unsafe test identifier %q", name)
+		}
+		_, _ = conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", name))
+	}
+}
+
+func safePostgresIdentifier(name string) bool {
+	return name != "" && strings.Trim(name, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_") == ""
 }

--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -24,7 +24,7 @@ func NewMigrationsCommand() *cobra.Command {
 		Long: `Manage migration plans, files, and revision state.
 
 This is Ptah's native migration namespace. It deliberately uses Ptah-owned
-spellings such as "plan" and "up" instead of root-level Atlas aliases such as
+spellings such as "plan" and "up" instead of root-level Atlas-looking paths such as
 "migrate diff" or "migrate apply". Atlas-compatible commands stay under
 ptah atlas.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -100,7 +100,7 @@ func TestNewRootCommand_NativeCommandTreeIsRegistered(t *testing.T) {
 	}
 }
 
-func TestNewRootCommand_AtlasLookingRootAliasesStayRejected(t *testing.T) {
+func TestNewRootCommand_AtlasLookingRootPathsStayRejected(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
@@ -279,7 +279,7 @@ func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
 	}
 }
 
-func TestNewRootCommand_OldRootCommandSpellingsAreNotRegistered(t *testing.T) {
+func TestNewRootCommand_UngroupedRootCommandSpellingsAreNotRegistered(t *testing.T) {
 	tests := [][]string{
 		{"generate"},
 		{"read-db"},

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -38,8 +38,11 @@ func TestSchemaExportCommandWritesAtlasHCL(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Contains, `table "users"`)
 	c.Assert(string(content), qt.Contains, `column "created_at"`)
-	_, err = atlashcl.Parse(content, "schema.hcl")
+	c.Assert(string(content), qt.Contains, `primary_key {`)
+	parsed, err := atlashcl.Parse(content, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("schema.hcl:\n%s", string(content)))
+	c.Assert(parsed.Tables, qt.HasLen, 1)
+	c.Assert(parsed.Tables[0].PrimaryKey, qt.DeepEquals, []string{"id"})
 }
 
 func TestSchemaCommand_RegistersNativePaths(t *testing.T) {

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -66,6 +66,26 @@ env "prod" {
 	c.Assert(err, qt.ErrorMatches, `atlas\.hcl contains multiple env blocks; pass --env`)
 }
 
+func TestParseAtlasProjectConfigUsesSingleUnlabeledEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  url = "postgres://default/db"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "postgres://default/db")
+	c.Assert(cfg.Migration.Dir, qt.Equals, "migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+}
+
 func TestParseAtlasProjectConfigRequiresEnvWhenMultipleBlocksExist(t *testing.T) {
 	c := qt.New(t)
 	raw := []byte(`env {

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -483,11 +483,25 @@ func (s *schemaParseState) parseTableComment(comment *ast.Comment, structName st
 		Schema:     kv["schema"],
 		Engine:     kv["engine"],
 		Comment:    kv["comment"],
-		PrimaryKey: strings.Split(kv["primary_key"], ","),
-		Checks:     strings.Split(kv["checks"], ","),
+		PrimaryKey: splitCSVAttribute(kv["primary_key"]),
+		Checks:     splitCSVAttribute(kv["checks"]),
 		CustomSQL:  kv["custom"],
 		Overrides:  parseutils.ParsePlatformSpecific(kv),
 	})
+}
+
+func splitCSVAttribute(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
 }
 
 type schemaParseState struct {

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -190,6 +190,26 @@ type User struct {
 	c.Assert(db.Fields[0].IdentityOptions, qt.Equals, "MINVALUE 0 START WITH 0")
 }
 
+func TestParseSource_TableCommentLeavesAbsentCSVAttributesEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	db := mustParseSource(c, "schema.go", `
+package test
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`)
+
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].PrimaryKey, qt.IsNil)
+	c.Assert(db.Tables[0].Checks, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].Primary, qt.IsTrue)
+}
+
 func TestParseSchemaObjectAnnotations(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -94,7 +94,7 @@ settings:
 - `lint`
 - `migrations generate`
 
-Atlas-compatible aliases under `ptah atlas <command> ...` inherit this behavior
+Atlas command paths under `ptah atlas <command> ...` inherit this behavior
 when they forward to one of these native commands.
 
 ## Unsupported Constructs

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -38,7 +38,7 @@ root-level command spellings are removed instead of preserved.
 | `ptah seed` | Seed files applied or already applied. | Not used. | Usage error, protected environment rejection, connection failure, invalid seed files, or seed execution failure. |
 | `ptah version` | Version information printed. | Not used. | Usage error. |
 
-## Atlas-Compatible Aliases
+## Atlas Command Surface
 
 Commands under `ptah atlas <command> ...` translate implemented Atlas-compatible flags and then delegate to the matching native command. Their exit codes therefore follow the native command contract:
 

--- a/migration/generator/doc.go
+++ b/migration/generator/doc.go
@@ -60,8 +60,10 @@
 //	}
 //
 //	fmt.Printf("Generated migration files:\n")
-//	fmt.Printf("Up:   %s\n", files.UpFile)
-//	fmt.Printf("Down: %s\n", files.DownFile)
+//	for _, pair := range files.Files {
+//		fmt.Printf("Up:   %s\n", pair.UpFile)
+//		fmt.Printf("Down: %s\n", pair.DownFile)
+//	}
 //
 // # Migration File Structure
 //

--- a/migration/generator/example/main.go
+++ b/migration/generator/example/main.go
@@ -73,26 +73,36 @@ func main() {
 
 	// Display results
 	fmt.Printf("✅ Migration generated successfully!\n")
-	fmt.Printf("  Version: %d\n", files.Version)
-	fmt.Printf("  UP file:   %s\n", files.UpFile)
-	fmt.Printf("  DOWN file: %s\n", files.DownFile)
+	for _, pair := range files.Files {
+		fmt.Printf("  Version: %d\n", pair.Version)
+		fmt.Printf("  UP file:   %s\n", pair.UpFile)
+		fmt.Printf("  DOWN file: %s\n", pair.DownFile)
+		if pair.ReportFile != "" {
+			fmt.Printf("  Report:    %s\n", pair.ReportFile)
+		}
+		if pair.NoTransaction {
+			fmt.Println("  Transaction: disabled")
+		}
+	}
 	fmt.Println()
 
 	// Display file contents for review
-	fmt.Println("=== UP MIGRATION ===")
-	upContent, err := os.ReadFile(files.UpFile)
-	if err != nil {
-		log.Printf("Warning: Could not read UP migration file: %v", err)
-	} else {
-		fmt.Println(string(upContent))
-	}
+	for _, pair := range files.Files {
+		fmt.Printf("=== UP MIGRATION %d ===\n", pair.Version)
+		upContent, err := os.ReadFile(pair.UpFile)
+		if err != nil {
+			log.Printf("Warning: Could not read UP migration file: %v", err)
+		} else {
+			fmt.Println(string(upContent))
+		}
 
-	fmt.Println("=== DOWN MIGRATION ===")
-	downContent, err := os.ReadFile(files.DownFile)
-	if err != nil {
-		log.Printf("Warning: Could not read DOWN migration file: %v", err)
-	} else {
-		fmt.Println(string(downContent))
+		fmt.Printf("=== DOWN MIGRATION %d ===\n", pair.Version)
+		downContent, err := os.ReadFile(pair.DownFile)
+		if err != nil {
+			log.Printf("Warning: Could not read DOWN migration file: %v", err)
+		} else {
+			fmt.Println(string(downContent))
+		}
 	}
 
 	fmt.Println("⚠️  Please review the generated SQL carefully before applying the migration!")

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -47,6 +47,7 @@ type ShadowMismatch struct {
 // ShadowVerificationError wraps a structured shadow verification result.
 type ShadowVerificationError struct {
 	Result ShadowVerificationResult `json:"result"`
+	Err    error                    `json:"-"`
 }
 
 func (e *ShadowVerificationError) Error() string {
@@ -54,6 +55,27 @@ func (e *ShadowVerificationError) Error() string {
 		return "shadow check failed: " + e.Result.Mismatches[0].Message
 	}
 	return "shadow check failed: schema differs"
+}
+
+func (e *ShadowVerificationError) Unwrap() error {
+	return e.Err
+}
+
+func newShadowVerificationError(stage, kind, message string, err error) *ShadowVerificationError {
+	if err != nil {
+		message = fmt.Sprintf("%s: %v", message, err)
+	}
+	return &ShadowVerificationError{
+		Result: ShadowVerificationResult{
+			Stage:   stage,
+			Success: false,
+			Mismatches: []ShadowMismatch{{
+				Kind:    kind,
+				Message: message,
+			}},
+		},
+		Err: err,
+	}
 }
 
 type shadowMigrationOptions struct {
@@ -77,25 +99,35 @@ type shadowCandidate struct {
 func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) error {
 	conn, err := dbschema.ConnectToDatabase(ctx, opts.DatabaseURL)
 	if err != nil {
-		return fmt.Errorf("shadow check failed: connect to shadow database: %w", err)
+		return newShadowVerificationError("connect", "connect_error", "connect to shadow database", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
 
 	if !sameDialect(opts.Dialect, conn.Info().Dialect) {
-		return fmt.Errorf("shadow check failed: shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect)
+		return newShadowVerificationError(
+			"dialect-check",
+			"dialect_mismatch",
+			fmt.Sprintf("shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect),
+			nil,
+		)
 	}
 	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, conn.Info().Capabilities) {
-		return fmt.Errorf("shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
+		return newShadowVerificationError(
+			"capability-check",
+			"capability_mismatch",
+			fmt.Sprintf("shadow database capabilities do not match target %s capabilities", opts.Dialect),
+			nil,
+		)
 	}
 
 	if err := conn.SchemaWriter().DropAllTables(); err != nil {
-		return fmt.Errorf("shadow check failed: drop all objects: %w", err)
+		return newShadowVerificationError("drop-all", "drop_all_error", "drop all objects", err)
 	}
 	replayCtx := context.Background()
 
 	prior, err := loadPriorMigrations(opts.MigrationsDir)
 	if err != nil {
-		return fmt.Errorf("shadow check failed: load prior migrations: %w", err)
+		return newShadowVerificationError("load-prior", "load_prior_error", "load prior migrations", err)
 	}
 
 	migrations := make([]*migrator.Migration, 0, len(prior)+len(opts.Candidates))
@@ -109,9 +141,9 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 	mig := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...))
 	if err := mig.MigrateUp(replayCtx); err != nil {
 		if description := describeReplayError(err); description != "" {
-			return fmt.Errorf("shadow check failed: %s", description)
+			return newShadowVerificationError("replay", "replay_error", description, err)
 		}
-		return fmt.Errorf("shadow check failed: replay migrations: %w", err)
+		return newShadowVerificationError("replay", "replay_error", "replay migrations", err)
 	}
 	if err := assertShadowSchemaMatches(conn, opts); err != nil {
 		return err
@@ -119,10 +151,10 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 
 	previousVersion := latestMigrationVersion(prior)
 	if err := mig.MigrateDownTo(replayCtx, previousVersion); err != nil {
-		return fmt.Errorf("shadow check failed: round-trip down: %w", err)
+		return newShadowVerificationError("round-trip-down", "round_trip_down_error", "round-trip down", err)
 	}
 	if err := mig.MigrateTo(replayCtx, latestMigrationVersion(migrations)); err != nil {
-		return fmt.Errorf("shadow check failed: round-trip up: %w", err)
+		return newShadowVerificationError("round-trip-up", "round_trip_up_error", "round-trip up", err)
 	}
 	return assertShadowSchemaMatches(conn, opts)
 }
@@ -173,7 +205,7 @@ func latestMigrationVersion(migrations []*migrator.Migration) int64 {
 func assertShadowSchemaMatches(conn *dbschema.DatabaseConnection, opts shadowMigrationOptions) error {
 	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, opts.Schemas)
 	if err != nil {
-		return fmt.Errorf("shadow check failed: re-introspect shadow database: %w", err)
+		return newShadowVerificationError("re-introspect", "re_introspect_error", "re-introspect shadow database", err)
 	}
 
 	diff := schemadiff.CompareWithOptions(opts.Generated, dbSchema, opts.CompareOpts)

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -71,6 +71,24 @@ func TestLoadPriorMigrationsMissingDir(t *testing.T) {
 	c.Assert(migrations, qt.HasLen, 0)
 }
 
+func TestVerifyShadowMigrationConnectErrorIsStructured(t *testing.T) {
+	c := qt.New(t)
+
+	err := verifyShadowMigration(context.Background(), shadowMigrationOptions{
+		DatabaseURL: "not-a-dsn",
+		Dialect:     "postgres",
+	})
+
+	var shadowErr *ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "connect")
+	c.Assert(shadowErr.Result.Success, qt.IsFalse)
+	c.Assert(shadowErr.Result.Mismatches, qt.HasLen, 1)
+	c.Assert(shadowErr.Result.Mismatches[0].Kind, qt.Equals, "connect_error")
+	c.Assert(shadowErr.Err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, `shadow check failed: connect to shadow database: invalid database URL: missing scheme`)
+}
+
 func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 	dbURL := shadowTestDatabaseURL()
 	if dbURL == "" {
@@ -112,7 +130,13 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 		})
 
 		c.Assert(files, qt.IsNil)
-		c.Assert(err, qt.ErrorMatches, `shadow check failed: missing column users\.name`)
+		c.Assert(err.Error(), qt.Contains, "shadow check failed: missing column users.name: ")
+		var shadowErr *ShadowVerificationError
+		c.Assert(err, qt.ErrorAs, &shadowErr)
+		c.Assert(shadowErr.Result.Stage, qt.Equals, "replay")
+		c.Assert(shadowErr.Result.Mismatches, qt.HasLen, 1)
+		c.Assert(shadowErr.Result.Mismatches[0].Kind, qt.Equals, "replay_error")
+		c.Assert(shadowErr.Err, qt.IsNotNil)
 		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
 		c.Assert(globErr, qt.IsNil)
 		c.Assert(matches, qt.HasLen, 2)
@@ -193,10 +217,11 @@ func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *t
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(files, qt.IsNotNil)
-	c.Assert(files.Files, qt.HasLen, 1)
-	c.Assert(files.Files[0].NoTransaction, qt.IsTrue)
+	c.Assert(files.Files, qt.HasLen, 2)
+	c.Assert(files.Files[0].NoTransaction, qt.IsFalse)
+	c.Assert(files.Files[1].NoTransaction, qt.IsTrue)
 
-	upSQL, err := os.ReadFile(files.UpFile)
+	upSQL, err := os.ReadFile(files.Files[1].UpFile)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(upSQL), qt.Contains, "-- +ptah no_transaction")
 	c.Assert(string(upSQL), qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -123,9 +123,11 @@ txtar `down.sql` sections revert already-applied migrations, and Atlas dynamic
 `migrate down` would synthesize a downgrade plan from database/dev state.
 
 `-- +ptah` directives inside `migration.sql` and `down.sql` are parsed per
-section for timeout and validation purposes. The current `no_transaction` model
-is still migration-level: if either direction opts out of transactions, Ptah
-treats the migration as non-transactional.
+section for timeout, validation, and transaction handling. `no_transaction`
+applies only to the direction whose SQL section contains it, so a
+non-transactional `down.sql` does not force `migration.sql` to run outside a
+transaction. Atlas `-- atlas:txmode none` comments are accepted as the Atlas
+equivalent for the section where they appear.
 
 ### Migrate Up
 Apply all pending migrations:

--- a/migration/migrator/directives_test.go
+++ b/migration/migrator/directives_test.go
@@ -75,3 +75,43 @@ func TestParseFileDirectives(t *testing.T) {
 		})
 	}
 }
+
+func TestHasAtlasTxModeNoneDirective(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			name: "line-start directive",
+			sql:  "-- atlas:txmode none\nCREATE INDEX CONCURRENTLY users_email_idx ON users (email);\n",
+			want: true,
+		},
+		{
+			name: "case-insensitive directive",
+			sql:  "  -- ATLAS:TXMODE NONE\nSELECT 1;\n",
+			want: true,
+		},
+		{
+			name: "trailing comment is not directive",
+			sql:  "SELECT 1; -- atlas:txmode none\n",
+			want: false,
+		},
+		{
+			name: "string literal is not directive",
+			sql:  "INSERT INTO notes (body) VALUES ('runbook:\n-- atlas:txmode none\ndone');\n",
+			want: false,
+		},
+		{
+			name: "other tx mode is transactional",
+			sql:  "-- atlas:txmode file\nSELECT 1;\n",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(hasAtlasTxModeNoneDirective(tt.sql), qt.Equals, tt.want)
+		})
+	}
+}

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -174,22 +174,26 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 				return fmt.Errorf("failed to load up migration %s: %w", migrationFile.Path, err)
 			}
 			migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-				return up.fn(ctx, conn, migration.executionMode())
+				return up.fn(ctx, conn, migration.upExecutionMode())
 			}
 			migration.UpSQL = up.sql
 			migration.UpTimeouts = up.timeouts
-			migration.NoTransaction = migration.NoTransaction || up.noTransaction
+			migration.UpNoTransaction = up.noTransaction
+			migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
+			migration.directionalNoTransactionMode = true
 		case "down":
 			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)
 			if err != nil {
 				return fmt.Errorf("failed to load down migration %s: %w", migrationFile.Path, err)
 			}
 			migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-				return down.fn(ctx, conn, migration.executionMode())
+				return down.fn(ctx, conn, migration.downExecutionMode())
 			}
 			migration.DownSQL = down.sql
 			migration.DownTimeouts = down.timeouts
-			migration.NoTransaction = migration.NoTransaction || down.noTransaction
+			migration.DownNoTransaction = down.noTransaction
+			migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
+			migration.directionalNoTransactionMode = true
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}
@@ -319,22 +323,26 @@ func (p *FSMigrationProvider) loadAtlasDown(parts *atlasParts, migrationFile Mig
 func setAtlasUp(parts *atlasParts, up sqlMigrationFile) {
 	migration := parts.migration
 	migration.Up = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return up.fn(ctx, conn, migration.executionMode())
+		return up.fn(ctx, conn, migration.upExecutionMode())
 	}
 	migration.UpSQL = up.sql
 	migration.UpTimeouts = up.timeouts
-	migration.NoTransaction = migration.NoTransaction || up.noTransaction
+	migration.UpNoTransaction = up.noTransaction
+	migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
+	migration.directionalNoTransactionMode = true
 	parts.hasUp = true
 }
 
 func setAtlasDown(parts *atlasParts, down sqlMigrationFile) {
 	migration := parts.migration
 	migration.Down = func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		return down.fn(ctx, conn, migration.executionMode())
+		return down.fn(ctx, conn, migration.downExecutionMode())
 	}
 	migration.DownSQL = down.sql
 	migration.DownTimeouts = down.timeouts
-	migration.NoTransaction = migration.NoTransaction || down.noTransaction
+	migration.DownNoTransaction = down.noTransaction
+	migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
+	migration.directionalNoTransactionMode = true
 	parts.hasDown = true
 }
 

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -488,7 +488,7 @@ DROP TABLE users;
 	c.Assert(err, qt.ErrorMatches, `failed to load Atlas migration 20240305171147_invalid_down_directive.sql: invalid migration directives in 20240305171147_invalid_down_directive.sql#down.sql: invalid \+ptah no_transaction value "maybe": expected true or false`)
 }
 
-func TestNewFSMigrationProvider_AtlasTxtarDownNoTransactionIsMigrationLevel(t *testing.T) {
+func TestNewFSMigrationProvider_AtlasTxtarDownNoTransactionIsDirectional(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fstest.MapFS{
@@ -508,6 +508,32 @@ DROP TABLE users;
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1)
 	c.Assert(migrations[0].NoTransaction, qt.IsTrue)
+	c.Assert(migrations[0].UpNoTransaction, qt.IsFalse)
+	c.Assert(migrations[0].DownNoTransaction, qt.IsTrue)
+}
+
+func TestNewFSMigrationProvider_AtlasTxModeNoneIsNoTransaction(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"20240305171147_concurrent_index.sql": &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+-- atlas:txmode none
+CREATE INDEX CONCURRENTLY users_email_idx ON users (email);
+
+-- down.sql --
+DROP INDEX users_email_idx;
+`)},
+	}
+	provider, err := migrator.NewFSMigrationProvider(fsys, migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas))
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].NoTransaction, qt.IsTrue)
+	c.Assert(migrations[0].UpNoTransaction, qt.IsTrue)
+	c.Assert(migrations[0].DownNoTransaction, qt.IsFalse)
 }
 
 func TestNewFSMigrationProvider_UnknownOnlySQLFilesError(t *testing.T) {

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stokaro/ptah/core/lexer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -226,7 +227,7 @@ func migrationFuncFromSQLStringWithMetadata(filename, sql string, interceptor St
 		return sqlMigrationFile{}, err
 	}
 
-	noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(sql))
+	noTransaction, err := parseNoTransactionDirectiveFromSQL(sql)
 	if err != nil {
 		return sqlMigrationFile{}, fmt.Errorf("invalid migration directives in %s: %w", filename, err)
 	}
@@ -343,15 +344,27 @@ type Migration struct {
 	UpTimeouts      MigrationTimeouts
 	DownTimeouts    MigrationTimeouts
 	downUnavailable bool
-	// NoTransaction runs the migration body and metadata update outside the
-	// normal per-migration transaction. Use this only for statements that cannot
-	// run transactionally; ordinary migrations should leave it false so dry-run,
-	// timeout, and rollback behavior all go through the dialect writer.
-	NoTransaction bool
+	// UpNoTransaction runs the up body and metadata update outside the normal
+	// per-migration transaction. Use this only for statements that cannot run
+	// transactionally.
+	UpNoTransaction bool
+	// DownNoTransaction is the down-direction counterpart to UpNoTransaction.
+	DownNoTransaction bool
+	// NoTransaction reports whether either direction opts out of the normal
+	// per-migration transaction. Execution uses the direction-specific fields.
+	NoTransaction                bool
+	directionalNoTransactionMode bool
 }
 
-func (m *Migration) executionMode() migrationExecutionMode {
-	if m.NoTransaction {
+func (m *Migration) upExecutionMode() migrationExecutionMode {
+	if m.UpNoTransaction || (!m.directionalNoTransactionMode && m.NoTransaction) {
+		return migrationExecutionNoTransaction
+	}
+	return migrationExecutionTransactional
+}
+
+func (m *Migration) downExecutionMode() migrationExecutionMode {
+	if m.DownNoTransaction || (!m.directionalNoTransactionMode && m.NoTransaction) {
 		return migrationExecutionNoTransaction
 	}
 	return migrationExecutionTransactional
@@ -360,29 +373,32 @@ func (m *Migration) executionMode() migrationExecutionMode {
 // CreateMigrationFromSQL creates a migration from SQL strings
 // This is useful for programmatically creating migrations
 func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration {
-	upNoTransaction, upDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(upSQL))
-	downNoTransaction, downDirectiveErr := parseNoTransactionDirective(ParseFileDirectives(downSQL))
+	upNoTransaction, upDirectiveErr := parseNoTransactionDirectiveFromSQL(upSQL)
+	downNoTransaction, downDirectiveErr := parseNoTransactionDirectiveFromSQL(downSQL)
 
 	migration := &Migration{
-		Version:       version,
-		Description:   description,
-		UpSQL:         upSQL,
-		DownSQL:       downSQL,
-		NoTransaction: upNoTransaction || downNoTransaction,
+		Version:                      version,
+		Description:                  description,
+		UpSQL:                        upSQL,
+		DownSQL:                      downSQL,
+		UpNoTransaction:              upNoTransaction,
+		DownNoTransaction:            downNoTransaction,
+		NoTransaction:                upNoTransaction || downNoTransaction,
+		directionalNoTransactionMode: true,
 	}
 
 	upFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 		if upDirectiveErr != nil {
 			return fmt.Errorf("invalid up migration directives: %w", upDirectiveErr)
 		}
-		return executeSQLStatements(ctx, conn, upSQL, migration.executionMode())
+		return executeSQLStatements(ctx, conn, upSQL, migration.upExecutionMode())
 	}
 
 	downFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 		if downDirectiveErr != nil {
 			return fmt.Errorf("invalid down migration directives: %w", downDirectiveErr)
 		}
-		return executeSQLStatements(ctx, conn, downSQL, migration.executionMode())
+		return executeSQLStatements(ctx, conn, downSQL, migration.downExecutionMode())
 	}
 
 	migration.Up = upFunc
@@ -513,4 +529,36 @@ func parseNoTransactionDirective(directives map[string]string) (bool, error) {
 		return false, fmt.Errorf("invalid +ptah %s value %q: expected true or false", DirectiveNoTransaction, value)
 	}
 	return noTransaction, nil
+}
+
+func parseNoTransactionDirectiveFromSQL(sql string) (bool, error) {
+	noTransaction, err := parseNoTransactionDirective(ParseFileDirectives(sql))
+	if err != nil || noTransaction {
+		return noTransaction, err
+	}
+	return hasAtlasTxModeNoneDirective(sql), nil
+}
+
+func hasAtlasTxModeNoneDirective(sql string) bool {
+	lexr := lexer.NewLexer(sql)
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		if tok.Type != lexer.TokenComment {
+			continue
+		}
+		comment, ok := strings.CutPrefix(tok.Value, "--")
+		if !ok {
+			continue
+		}
+		if !commentStartsLine(sql, tok.Start) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(comment), "atlas:txmode none") {
+			return true
+		}
+	}
+	return false
 }

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -47,6 +47,8 @@ func TestCreateMigrationFromSQL(t *testing.T) {
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
 	c.Assert(migration.NoTransaction, qt.IsFalse)
+	c.Assert(migration.UpNoTransaction, qt.IsFalse)
+	c.Assert(migration.DownNoTransaction, qt.IsFalse)
 
 	// Test that the functions don't panic (we can't test execution without a real DB)
 	c.Assert(migration.Up, qt.IsNotNil)
@@ -62,6 +64,43 @@ func TestCreateMigrationFromSQL_NoTransactionDirective(t *testing.T) {
 	)
 
 	c.Assert(migration.NoTransaction, qt.IsTrue)
+	c.Assert(migration.UpNoTransaction, qt.IsTrue)
+	c.Assert(migration.DownNoTransaction, qt.IsFalse)
+}
+
+func TestCreateMigrationFromSQL_DownNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	migration := CreateMigrationFromSQL(1, "Drop concurrent index",
+		"SELECT 1;",
+		"-- +ptah no_transaction\nDROP INDEX CONCURRENTLY users_email_idx;",
+	)
+
+	c.Assert(migration.NoTransaction, qt.IsTrue)
+	c.Assert(migration.UpNoTransaction, qt.IsFalse)
+	c.Assert(migration.DownNoTransaction, qt.IsTrue)
+}
+
+func TestCreateMigrationFromSQL_AtlasTxModeNoneDirective(t *testing.T) {
+	c := qt.New(t)
+
+	migration := CreateMigrationFromSQL(1, "Add concurrent index",
+		"-- atlas:txmode none\nCREATE INDEX CONCURRENTLY users_email_idx ON users (email);",
+		"DROP INDEX users_email_idx;",
+	)
+
+	c.Assert(migration.NoTransaction, qt.IsTrue)
+	c.Assert(migration.UpNoTransaction, qt.IsTrue)
+	c.Assert(migration.DownNoTransaction, qt.IsFalse)
+}
+
+func TestMigration_ExplicitNoTransactionFieldControlsManualMigrations(t *testing.T) {
+	c := qt.New(t)
+
+	migration := &Migration{NoTransaction: true}
+
+	c.Assert(migration.upExecutionMode(), qt.Equals, migrationExecutionNoTransaction)
+	c.Assert(migration.downExecutionMode(), qt.Equals, migrationExecutionNoTransaction)
 }
 
 func TestCreateMigrationFromSQL_InvalidNoTransactionDirective(t *testing.T) {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -719,7 +719,7 @@ func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migratio
 		if err := m.beginMigrationRevision(ctx, migration); err != nil {
 			return fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
 		}
-		if migration.NoTransaction {
+		if migration.UpNoTransaction {
 			if err := m.applyUpMigrationNoTransaction(ctx, migration, startedAt); err != nil {
 				return err
 			}
@@ -827,7 +827,7 @@ func (m *Migrator) rollbackMigration(ctx context.Context, migration *Migration, 
 	if migration.downUnavailable {
 		return m.rollbackMigrationWithoutRegisteredDown(ctx, migration, startedAt, deleteSQL)
 	}
-	if migration.NoTransaction {
+	if migration.DownNoTransaction {
 		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
 	}
 	return m.rollbackMigrationTransactional(ctx, migration, startedAt, deleteSQL)

--- a/migration/migrator/migrator_test.go
+++ b/migration/migrator/migrator_test.go
@@ -77,6 +77,28 @@ func TestNewFSMigrator_LoadsNoTransactionDirective(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	migration := m.MigrationProvider().Migrations()[0]
 	c.Assert(migration.NoTransaction, qt.IsTrue)
+	c.Assert(migration.UpNoTransaction, qt.IsTrue)
+	c.Assert(migration.DownNoTransaction, qt.IsFalse)
+}
+
+func TestNewFSMigrator_LoadsDirectionalDownNoTransactionDirective(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_drop_concurrent_index.up.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;"),
+		},
+		"0000000001_drop_concurrent_index.down.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah no_transaction\nDROP INDEX CONCURRENTLY idx_users_email;"),
+		},
+	}
+
+	m, err := migrator.NewFSMigrator(nil, fsys)
+	c.Assert(err, qt.IsNil)
+	migration := m.MigrationProvider().Migrations()[0]
+	c.Assert(migration.NoTransaction, qt.IsTrue)
+	c.Assert(migration.UpNoTransaction, qt.IsFalse)
+	c.Assert(migration.DownNoTransaction, qt.IsTrue)
 }
 
 func TestNewFSMigrator_InvalidNoTransactionDirective(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens gaps found during the multi-agent/self-review audit of closed Atlas-parity issues #276, #381, #270, #152, and #137.

- Fixes Go annotation table parsing so absent CSV attributes stay empty instead of becoming `[]string{""}`; this restores field-level primary key export to Atlas HCL.
- Adds explicit atlas.hcl coverage for a single unlabeled `env {}` block.
- Makes `no_transaction` execution direction-specific for up/down SQL while preserving explicit manual `Migration{NoTransaction:true}` behavior.
- Accepts Atlas `-- atlas:txmode none` comments as the section-local no-transaction directive.
- Makes shadow verification errors structured across non-diff stages and exposes causes through `Unwrap`.
- Adds command-level Postgres coverage for `migrations up` honoring `.ptah-lint.yaml` severity overrides.
- Adds CI coverage for existing live no-transaction/shadow-generator acceptance tests.
- Updates docs/examples to match multi-file generation and direction-specific transaction behavior.

## Follow-up Issues Created

- #442: full Atlas HCL export/parser support for IR schema objects beyond tables.
- #443: validate lint SARIF output against SARIF 2.1.0 and GitHub code scanning constraints.

## Self-Review

Pass 1:
- Found and fixed doc drift in `migration/migrator/README.md` that still described migration-level `no_transaction`.
- Found and fixed the manual `Migration{NoTransaction:true}` API edge by adding an internal direction-specific marker.

Pass 2:
- Rechecked remaining audit findings. Current PR fixes concrete correctness/test/CI gaps; broader full Atlas HCL object export and SARIF schema validation are intentionally tracked as #442/#443 instead of being hidden behind green tests.
- Verified Atlas `txmode none` parsing is lexer-driven, so string literals and trailing comments do not opt a migration out of transactions.

## Validation

- `env GOWORK=off GOCACHE=/private/tmp/ptah-goal-audit-go-cache go test ./migration/migrator ./migration/generator ./migration/lint ./cmd/lint ./cmd/migrateup ./cmd/migrate ./migration/safety ./core/goschema ./cmd/schema ./core/atlashclrender ./core/atlashcl ./config/projectconfig ./cmd/internal/dbcli -count=1`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-goal-audit-go-cache go test ./...` (run outside sandbox because `dbschema` binds `127.0.0.1:0`)
- `env GOWORK=off GOCACHE=/private/tmp/ptah-goal-audit-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-goal-audit-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-goal-audit-golangci-cache golangci-lint run ./...`
- `ptah schema export` repro on `integration/fixtures/entities/023-go-annotations-objects`, followed by `ptah schema render`; exported HCL now contains `primary_key { columns = [column.id] }` and renders `id SERIAL PRIMARY KEY NOT NULL`.

