### PR TITLE
Harden schema export cleanup

### DIFF
--- a/core/atlashclrender/render_test.go
+++ b/core/atlashclrender/render_test.go
@@ -173,6 +173,41 @@ func TestRenderReportsLossyObjectDetails(t *testing.T) {
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", string(rendered.Data)))
 }
 
+func TestRenderReportsPlatformOverrideDiagnostics(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+			Overrides: map[string]map[string]string{
+				"mysql": {"engine": "InnoDB"},
+			},
+		}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			FieldName:  "ID",
+			Name:       "id",
+			Type:       "SERIAL",
+			Primary:    true,
+			Overrides: map[string]map[string]string{
+				"mysql": {"type": "INT AUTO_INCREMENT"},
+			},
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{
+		"table users",
+		"column User.id",
+	})
+	c.Assert(string(rendered.Data), qt.Contains, `table "users"`)
+	c.Assert(string(rendered.Data), qt.Contains, `column "id"`)
+	_, err = atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", string(rendered.Data)))
+}
+
 func TestRenderPreservesQualifiedTargetsAndRoleInheritance(t *testing.T) {
 	c := qt.New(t)
 	db := &goschema.Database{

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -91,7 +91,7 @@ settings:
 - `migrations up`
 - `migrations down`
 - `migrations status`
-- `lint`
+- `migrations lint`
 - `migrations generate`
 
 Atlas command paths under `ptah atlas <command> ...` inherit this behavior

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -78,7 +78,7 @@ Cleanup removes only Ptah schema annotation comments:
 - `//migrator:schema:*`
 - `//migrator:embedded ...`
 
-It preserves regular Go comments, formats cleaned Go files with `gofmt`, and
+It preserves regular Go comments, leaves unrelated formatting untouched, and
 keeps original file permissions. Cleanup is idempotent: running it again after
 annotations were removed should report no changed files.
 

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -4,10 +4,8 @@ package goannotationcleanup
 import (
 	"bytes"
 	"fmt"
-	"go/format"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 )
 
@@ -32,6 +30,10 @@ const (
 	cleanModeWrite cleanMode = iota
 	cleanModeDryRun
 )
+
+type removedLine struct {
+	number int
+}
 
 // CleanDir removes Ptah schema annotations from Go files under RootDir.
 func CleanDir(opts Options) ([]Result, error) {
@@ -83,34 +85,32 @@ func cleanFile(path string, mode cleanMode) (Result, error) {
 		return Result{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	after, removed := removeAnnotationLines(before)
-	if removed == 0 {
+	if len(removed) == 0 {
 		return Result{Path: path}, nil
-	}
-	formatted, err := format.Source(after)
-	if err != nil {
-		return Result{}, fmt.Errorf("format cleaned Go file %s: %w", path, err)
 	}
 	result := Result{
 		Path:         path,
-		Changed:      !bytes.Equal(before, formatted),
-		RemovedLines: removed,
-		Diff:         unifiedDiff(path, before, formatted),
+		Changed:      !bytes.Equal(before, after),
+		RemovedLines: len(removed),
+		Diff:         unifiedRemovalDiff(path, before, removed),
 	}
 	if result.Changed && mode == cleanModeWrite {
-		if err := os.WriteFile(path, formatted, info.Mode().Perm()); err != nil {
+		if err := os.WriteFile(path, after, info.Mode().Perm()); err != nil {
 			return Result{}, fmt.Errorf("write cleaned Go file %s: %w", path, err)
 		}
 	}
 	return result, nil
 }
 
-func removeAnnotationLines(data []byte) ([]byte, int) {
+func removeAnnotationLines(data []byte) ([]byte, []removedLine) {
 	lines := bytes.SplitAfter(data, []byte("\n"))
 	filtered := make([][]byte, 0, len(lines))
-	removed := 0
-	for _, line := range lines {
+	removed := make([]removedLine, 0)
+	for i, line := range lines {
 		if isPtahSchemaAnnotationLine(line) {
-			removed++
+			removed = append(removed, removedLine{
+				number: i + 1,
+			})
 			continue
 		}
 		filtered = append(filtered, line)
@@ -124,35 +124,80 @@ func isPtahSchemaAnnotationLine(line []byte) bool {
 		strings.HasPrefix(trimmed, "//migrator:embedded")
 }
 
-func unifiedDiff(path string, before, after []byte) string {
-	if bytes.Equal(before, after) {
+func unifiedRemovalDiff(path string, before []byte, removed []removedLine) string {
+	if len(removed) == 0 {
 		return ""
 	}
 	var builder strings.Builder
 	builder.WriteString("--- " + path + "\n")
 	builder.WriteString("+++ " + path + "\n")
-	builder.WriteString("@@\n")
-	beforeLines := strings.SplitAfter(string(before), "\n")
-	afterLines := strings.SplitAfter(string(after), "\n")
-	for _, line := range beforeLines {
-		if line == "" {
-			continue
-		}
-		if !containsLine(afterLines, line) {
-			builder.WriteString("-" + line)
-		}
+
+	lines := splitLines(before)
+	removedSet := make(map[int]struct{}, len(removed))
+	for _, line := range removed {
+		removedSet[line.number] = struct{}{}
 	}
-	for _, line := range afterLines {
-		if line == "" {
-			continue
+
+	const contextLines = 2
+	removedBefore := 0
+	for i := 0; i < len(removed); {
+		oldStart := max(1, removed[i].number-contextLines)
+		oldEnd := min(len(lines), removed[i].number+contextLines)
+		j := i + 1
+		for j < len(removed) && removed[j].number <= oldEnd+contextLines+1 {
+			oldEnd = min(len(lines), max(oldEnd, removed[j].number+contextLines))
+			j++
 		}
-		if !containsLine(beforeLines, line) {
-			builder.WriteString("+" + line)
+
+		oldCount := oldEnd - oldStart + 1
+		removedInHunk := countRemovedInRange(removed[i:j], oldStart, oldEnd)
+		newStart := max(1, oldStart-removedBefore)
+		newCount := oldCount - removedInHunk
+		fmt.Fprintf(&builder, "@@ -%s +%s @@\n", diffRange(oldStart, oldCount), diffRange(newStart, newCount))
+		for lineNumber := oldStart; lineNumber <= oldEnd; lineNumber++ {
+			line := lines[lineNumber-1]
+			if _, ok := removedSet[lineNumber]; ok {
+				writeDiffLine(&builder, '-', line)
+				continue
+			}
+			writeDiffLine(&builder, ' ', line)
 		}
+
+		removedBefore += j - i
+		i = j
 	}
 	return builder.String()
 }
 
-func containsLine(lines []string, target string) bool {
-	return slices.Contains(lines, target)
+func splitLines(data []byte) []string {
+	lines := strings.SplitAfter(string(data), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func countRemovedInRange(lines []removedLine, start, end int) int {
+	count := 0
+	for _, line := range lines {
+		if line.number >= start && line.number <= end {
+			count++
+		}
+	}
+	return count
+}
+
+func diffRange(start, count int) string {
+	if count == 1 {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, count)
+}
+
+func writeDiffLine(builder *strings.Builder, prefix byte, line string) {
+	builder.WriteByte(prefix)
+	builder.WriteString(line)
+	if !strings.HasSuffix(line, "\n") {
+		builder.WriteByte('\n')
+	}
 }

--- a/internal/goannotationcleanup/cleanup_test.go
+++ b/internal/goannotationcleanup/cleanup_test.go
@@ -3,6 +3,7 @@ package goannotationcleanup_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -61,4 +62,48 @@ type User struct {
 	results, err = goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
 	c.Assert(err, qt.IsNil)
 	c.Assert(results, qt.HasLen, 0)
+}
+
+func TestCleanDirPreservesUnrelatedFormattingByteForByte(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := "package models\n\n// User is business documentation.\n//migrator:schema:table name=\"users\"\ntype User struct{ID int64}\n"
+	expected := "package models\n\n// User is business documentation.\ntype User struct{ID int64}\n"
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, expected)
+}
+
+func TestCleanDirDiffReportsDuplicateRemovedLinesByPosition(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	annotation := "//migrator:schema:field name=\"id\" type=\"SERIAL\"\n"
+	original := "package models\n\ntype User struct {\n" +
+		annotation +
+		"ID int64\n\n" +
+		annotation +
+		"OtherID int64\n}\n"
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
+		RootDir: dir,
+		DryRun:  true,
+		Diff:    true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].RemovedLines, qt.Equals, 2)
+	c.Assert(strings.Count(results[0].Diff, "-"+annotation), qt.Equals, 2)
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, original)
 }


### PR DESCRIPTION
Hardens #381 after the post-merge audit.

Changes:
- preserve unrelated Go formatting byte-for-byte when removing Ptah annotations
- make cleanup diff position-aware so duplicate annotation lines are reported correctly
- add Atlas HCL renderer coverage for lossy platform override diagnostics
- fix docs command naming for native migration lint

Notes:
- no legacy/root compatibility command is added; Atlas-compatible commands remain under ptah atlas

Validation:
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./internal/goannotationcleanup ./cmd/schema ./cmd/root ./core/atlashclrender
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./internal/goannotationcleanup ./cmd/schema ./cmd/root ./core/atlashclrender ./config/projectconfig ./cmd/internal/dbcli ./cmd/migrateup ./cmd/migratestatus ./migration/migrator ./migration/migratesum
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go tool qtlint ./...
- GOWORK=off GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test -race ./internal/goannotationcleanup ./cmd/schema ./core/atlashclrender
- git diff --check