### PR TITLE
Harden no-transaction directive handling

### DIFF
--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -38,6 +38,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/stokaro/ptah/core/lexer"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/risk"
 )
@@ -421,12 +422,45 @@ func fileNoTransactionDirective(sql string) bool {
 	if value := migrator.ParseFileDirectives(sql)[migrator.DirectiveNoTransaction]; value == "true" {
 		return true
 	}
-	for line := range strings.Lines(sql) {
-		if strings.EqualFold(strings.TrimSpace(line), "-- atlas:txmode none") {
+	return hasAtlasTxModeNoneDirective(sql)
+}
+
+func hasAtlasTxModeNoneDirective(sql string) bool {
+	lexr := lexer.NewLexer(sql)
+	for {
+		tok := lexr.NextToken()
+		if tok.Type == lexer.TokenEOF {
+			break
+		}
+		if tok.Type != lexer.TokenComment {
+			continue
+		}
+		comment, ok := strings.CutPrefix(tok.Value, "--")
+		if !ok {
+			continue
+		}
+		if !commentStartsLine(sql, tok.Start) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(comment), "atlas:txmode none") {
 			return true
 		}
 	}
 	return false
+}
+
+func commentStartsLine(sql string, pos int) bool {
+	for i := pos - 1; i >= 0; i-- {
+		switch sql[i] {
+		case '\n':
+			return true
+		case ' ', '\t', '\r':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // runRules applies every enabled rule to one prepared file.

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -380,6 +380,49 @@ ALTER TABLE t ADD COLUMN c INT;`,
 	}
 }
 
+func TestLintFS_AtlasTxModeNoneDirectiveRequiresLineComment(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "string literal",
+			sql: `INSERT INTO notes (body) VALUES ('runbook:
+-- atlas:txmode none
+done');
+CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;`,
+		},
+		{
+			name: "block comment",
+			sql: `/*
+-- atlas:txmode none
+*/
+CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;`,
+		},
+		{
+			name: "trailing comment",
+			sql: `SELECT 1; -- atlas:txmode none
+CREATE INDEX CONCURRENTLY idx ON t (id);
+ALTER TABLE t ADD COLUMN c INT;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			fsys := fixture(map[string]string{
+				"0000000001_x.up.sql":   tt.sql,
+				"0000000001_x.down.sql": "-- restore\n",
+			})
+			findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG103", "TX101"})
+		})
+	}
+}
+
 func TestLintFS_DialectAwareScanning(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -719,7 +719,7 @@ func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migratio
 		if err := m.beginMigrationRevision(ctx, migration); err != nil {
 			return fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
 		}
-		if migration.UpNoTransaction {
+		if migration.upExecutionMode() == migrationExecutionNoTransaction {
 			if err := m.applyUpMigrationNoTransaction(ctx, migration, startedAt); err != nil {
 				return err
 			}
@@ -827,7 +827,7 @@ func (m *Migrator) rollbackMigration(ctx context.Context, migration *Migration, 
 	if migration.downUnavailable {
 		return m.rollbackMigrationWithoutRegisteredDown(ctx, migration, startedAt, deleteSQL)
 	}
-	if migration.DownNoTransaction {
+	if migration.downExecutionMode() == migrationExecutionNoTransaction {
 		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
 	}
 	return m.rollbackMigrationTransactional(ctx, migration, startedAt, deleteSQL)


### PR DESCRIPTION
## Summary
- route migration apply/rollback through the direction-aware no-transaction execution mode
- parse Atlas txmode none in lint through SQL lexer comment tokens instead of raw line matching
- add regression coverage so strings, block comments, and trailing comments cannot suppress PG103/TX101

## Notes
- This is a hardening follow-up for #152.
- CLI command surface is unchanged; no root compatibility commands or aliases are added.

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./migration/migrator ./migration/lint -run 'NoTransaction|TransactionHazards|AtlasTxMode|Directive' -count=1
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./migration/migrator ./migration/lint ./migration/generator ./migration/planner ./migration/planner/dialects/postgres ./core/parser -count=1
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache-152 golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test -tags integration ./migration/migrator ./migration/generator -run 'TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration|TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB' -count=1 -v (local DSNs unset, both Postgres tests skipped)