### PR TITLE
Harden schema dependency ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,15 @@ token. Prefer spellings such as `behavior`, `color`, `canceled`, `initialize`,
 
 Ptah treats `.golangci.yml` as a strict contract. Fix code to satisfy the configured linters instead of relaxing thresholds, disabling checks, or broadening exclusions. In particular, keep `revive` `error-strings` enabled and preserve the current "stricter wins" lint posture unless a maintainer explicitly asks for a config change.
 
-Ptah is pre-GA. Do not add legacy command aliases, compatibility wrappers,
-fallback APIs, or backward-compatibility behavior just to preserve an older
-internal shape. Prefer the cleaner architecture and update callers/tests/docs
-unless a maintainer explicitly asks for a compatibility layer.
+Ptah is pre-GA. Do not preserve old command aliases, compatibility wrappers,
+fallback APIs, or backward-compatibility behavior just to keep an older internal
+shape. Prefer the cleaner architecture and update callers/tests/docs unless a
+maintainer explicitly asks for a compatibility layer.
+
+Atlas OSS command parity belongs under `ptah atlas <command> ...` only. Do not
+add root-level Atlas command spellings or temporary aliases such as
+`ptah migrate apply` / `ptah schema inspect`; remove or redesign old paths
+instead of preserving them.
 
 The `modernize` linter is enabled. Prefer current Go idioms when writing or editing code:
 

--- a/core/convert/fromschema/fromschema.go
+++ b/core/convert/fromschema/fromschema.go
@@ -1293,17 +1293,23 @@ func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
 //
 // The function generates statements in the following order to respect dependencies:
 //  1. Schema definitions (CREATE SCHEMA statements)
-//  2. Enum type definitions (CREATE TYPE statements)
-//  3. Table definitions (CREATE TABLE statements) with embedded fields processed, but without foreign keys
-//  4. Foreign key constraints (ALTER TABLE statements)
-//  5. Extension definitions
-//  6. Dialect-specific objects such as roles, functions, views, RLS policies, grants, and triggers
-//  7. Index definitions (CREATE INDEX statements)
+//  2. Extension definitions
+//  3. Enum type definitions (CREATE TYPE statements)
+//  4. Table definitions (CREATE TABLE statements) with embedded fields processed, but without foreign keys
+//  5. PostgreSQL roles and functions
+//  6. Unique index definitions (CREATE UNIQUE INDEX statements)
+//  7. Foreign key constraints (ALTER TABLE statements)
+//  8. Dialect-specific objects such as views, RLS policies, grants, and triggers
+//  9. Non-unique index definitions (CREATE INDEX statements)
 //
 // This ordering ensures that:
 //   - Schemas are created before tables that reference them
+//   - Extensions are created before tables, indexes, or functions that may use them
 //   - Enum types are created before tables that reference them
+//   - PostgreSQL functions are created before indexes that may use them
 //   - Tables are created before indexes that reference them
+//   - Unique indexes are created before foreign keys because PostgreSQL can use
+//     a unique index as the referenced key
 //   - Foreign key dependencies are handled after table creation, so cyclic table references remain executable
 //   - Embedded fields are processed and converted to regular fields before table creation
 //
@@ -1360,41 +1366,47 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// 1. Add schema definitions first (they may be referenced by tables)
 	appendSchemaStatements(statements, database.Schemas)
 
-	// 2. Add enum definitions (they may be referenced by tables)
-	for _, enum := range database.Enums {
-		enumNode := FromEnum(enum)
-		statements.Statements = append(statements.Statements, enumNode)
-	}
-
-	// 3. Add table definitions (they may be referenced by indexes)
-	// Use the combined field list that includes embedded field expansions
-	appendTableStatements(statements, database, allFields, targetPlatform)
-
-	// 4. Add extension definitions (PostgreSQL-specific)
+	// 2. Add extension definitions (PostgreSQL-specific)
 	for _, extension := range database.Extensions {
 		extensionNode := FromExtension(extension)
 		statements.Statements = append(statements.Statements, extensionNode)
 	}
 
-	// 5. Add PostgreSQL-specific features (functions and RLS)
-	// These features are only supported by PostgreSQL, so we only generate them for PostgreSQL dialects
+	// 3. Add enum definitions (they may be referenced by tables)
+	for _, enum := range database.Enums {
+		enumNode := FromEnum(enum)
+		statements.Statements = append(statements.Statements, enumNode)
+	}
+
+	// 4. Add table definitions (they may be referenced by indexes)
+	// Use the combined field list that includes embedded field expansions
+	appendTableStatements(statements, database, allFields, targetPlatform)
+
 	isPostgreSQL := isPostgreSQLPlatform(targetPlatform)
+	if isPostgreSQL {
+		appendPostgreSQLPreIndexFeatureStatements(statements, database)
+	}
+
+	// 6. Add unique indexes before foreign keys. PostgreSQL accepts a unique
+	// index as the referenced key for a foreign key, so it must exist before
+	// the FK constraint is added.
+	appendUniqueIndexStatements(statements, database.Tables, database.Indexes)
+
+	// 7. Add foreign key constraints after all tables and unique indexes exist.
+	if !isSQLiteTarget(targetPlatform) {
+		appendForeignKeyConstraintStatements(statements, database.Tables, allFields, database.Constraints, targetPlatform)
+	}
 
 	if isPostgreSQL {
-		appendPostgreSQLFeatureStatements(statements, database)
+		appendPostgreSQLPostForeignKeyFeatureStatements(statements, database)
 	}
 
 	if supportsStandaloneViewsAndTriggers(targetPlatform) {
 		appendViewAndTriggerStatements(statements, database)
 	}
 
-	// 7. Add index definitions last
-	// Create a mapping from struct names to table names for proper index table resolution
-	structToTableMap := createStructToTableMap(database.Tables)
-	for _, index := range database.Indexes {
-		indexNode := FromIndexWithTableMapping(index, structToTableMap)
-		statements.Statements = append(statements.Statements, indexNode)
-	}
+	// 9. Add non-unique indexes last.
+	appendNonUniqueIndexStatements(statements, database.Tables, database.Indexes)
 
 	return statements
 }
@@ -1418,18 +1430,46 @@ func appendTableStatements(
 		addTableConstraints(tableNode, table, database.Constraints, mode)
 		statements.Statements = append(statements.Statements, tableNode)
 	}
-	if !sqliteTarget {
-		appendForeignKeyConstraintStatements(statements, database.Tables, allFields, database.Constraints, targetPlatform)
+}
+
+func appendUniqueIndexStatements(statements *ast.StatementList, tables []goschema.Table, indexes []goschema.Index) {
+	appendMatchingIndexStatements(statements, tables, indexes, func(index goschema.Index) bool {
+		return index.Unique
+	})
+}
+
+func appendNonUniqueIndexStatements(statements *ast.StatementList, tables []goschema.Table, indexes []goschema.Index) {
+	appendMatchingIndexStatements(statements, tables, indexes, func(index goschema.Index) bool {
+		return !index.Unique
+	})
+}
+
+func appendMatchingIndexStatements(
+	statements *ast.StatementList,
+	tables []goschema.Table,
+	indexes []goschema.Index,
+	matches func(goschema.Index) bool,
+) {
+	structToTableMap := createStructToTableMap(tables)
+	for _, index := range indexes {
+		if !matches(index) {
+			continue
+		}
+		indexNode := FromIndexWithTableMapping(index, structToTableMap)
+		statements.Statements = append(statements.Statements, indexNode)
 	}
 }
 
-func appendPostgreSQLFeatureStatements(statements *ast.StatementList, database goschema.Database) {
+func appendPostgreSQLPreIndexFeatureStatements(statements *ast.StatementList, database goschema.Database) {
 	for _, role := range database.Roles {
 		statements.Statements = append(statements.Statements, FromRole(role))
 	}
 	for _, function := range database.Functions {
 		statements.Statements = append(statements.Statements, FromFunction(function))
 	}
+}
+
+func appendPostgreSQLPostForeignKeyFeatureStatements(statements *ast.StatementList, database goschema.Database) {
 	for _, view := range database.Views {
 		statements.Statements = append(statements.Statements, FromView(view))
 	}

--- a/core/convert/fromschema/fromschema_test.go
+++ b/core/convert/fromschema/fromschema_test.go
@@ -20,6 +20,36 @@ func tableStatementByName(statements *ast.StatementList, name string) *ast.Creat
 	return nil
 }
 
+func tableStatementIndexByName(statements *ast.StatementList, name string) int {
+	for i, stmt := range statements.Statements {
+		table, ok := stmt.(*ast.CreateTableNode)
+		if ok && table.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func extensionStatementIndexByName(statements *ast.StatementList, name string) int {
+	for i, stmt := range statements.Statements {
+		extension, ok := stmt.(*ast.ExtensionNode)
+		if ok && extension.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func functionStatementIndexByName(statements *ast.StatementList, name string) int {
+	for i, stmt := range statements.Statements {
+		function, ok := stmt.(*ast.CreateFunctionNode)
+		if ok && function.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 func foreignKeyAlterStatementByName(statements *ast.StatementList, tableName, constraintName string) *ast.AlterTableNode {
 	for _, stmt := range statements.Statements {
 		alter, ok := stmt.(*ast.AlterTableNode)
@@ -34,6 +64,32 @@ func foreignKeyAlterStatementByName(statements *ast.StatementList, tableName, co
 		}
 	}
 	return nil
+}
+
+func indexStatementIndexByName(statements *ast.StatementList, name string) int {
+	for i, stmt := range statements.Statements {
+		index, ok := stmt.(*ast.IndexNode)
+		if ok && index.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func foreignKeyAlterStatementIndexByName(statements *ast.StatementList, constraintName string) int {
+	for i, stmt := range statements.Statements {
+		alter, ok := stmt.(*ast.AlterTableNode)
+		if !ok {
+			continue
+		}
+		for _, operation := range alter.Operations {
+			add, ok := operation.(*ast.AddConstraintOperation)
+			if ok && add.Constraint.Name == constraintName && add.Constraint.Type == ast.ForeignKeyConstraint {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 func TestFromField_BasicProperties(t *testing.T) {
@@ -878,6 +934,83 @@ func TestFromDatabase_TableLevelForeignKeysAreTwoPhase(t *testing.T) {
 	c.Assert(addProfilesFK.Constraint.Reference.Table, qt.Equals, "accounts")
 	c.Assert(addProfilesFK.Constraint.Reference.ReferencedColumns(), qt.DeepEquals, []string{"id"})
 	c.Assert(addProfilesFK.Constraint.Reference.OnUpdate, qt.Equals, "RESTRICT")
+}
+
+func TestFromDatabase_ExtensionsPrecedeTablesAndIndexes(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Extensions: []goschema.Extension{{Name: "citext", IfNotExists: true}},
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+		}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "User", Name: "email", Type: "CITEXT"},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			Name:       "uq_users_email",
+			Fields:     []string{"email"},
+			Unique:     true,
+		}},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+
+	extension := extensionStatementIndexByName(result, "citext")
+	table := tableStatementIndexByName(result, "users")
+	index := indexStatementIndexByName(result, "uq_users_email")
+
+	c.Assert(extension, qt.Not(qt.Equals), -1)
+	c.Assert(table, qt.Not(qt.Equals), -1)
+	c.Assert(index, qt.Not(qt.Equals), -1)
+	c.Assert(extension < table, qt.IsTrue)
+	c.Assert(extension < index, qt.IsTrue)
+}
+
+func TestFromDatabase_UniqueIndexesPrecedeForeignKeys(t *testing.T) {
+	c := qt.New(t)
+
+	db := goschema.Database{
+		Functions: []goschema.Function{{
+			Name:       "normalize_code",
+			Parameters: "value TEXT",
+			Returns:    "TEXT",
+			Language:   "sql",
+			Body:       "SELECT lower(value)",
+		}},
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Parent", Name: "code", Type: "TEXT"},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_code", Type: "TEXT", Foreign: "parents(code)", ForeignKeyName: "fk_children_parent_code"},
+		},
+		Indexes: []goschema.Index{
+			{StructName: "Child", Name: "idx_children_parent_code", Fields: []string{"parent_code"}},
+			{StructName: "Parent", Name: "uq_parents_code", Fields: []string{"code"}, Unique: true},
+		},
+	}
+
+	result := fromschema.FromDatabase(db, "postgres")
+
+	function := functionStatementIndexByName(result, "normalize_code")
+	uniqueIndex := indexStatementIndexByName(result, "uq_parents_code")
+	foreignKey := foreignKeyAlterStatementIndexByName(result, "fk_children_parent_code")
+	nonUniqueIndex := indexStatementIndexByName(result, "idx_children_parent_code")
+
+	c.Assert(function, qt.Not(qt.Equals), -1)
+	c.Assert(uniqueIndex, qt.Not(qt.Equals), -1)
+	c.Assert(foreignKey, qt.Not(qt.Equals), -1)
+	c.Assert(nonUniqueIndex, qt.Not(qt.Equals), -1)
+	c.Assert(function < uniqueIndex, qt.IsTrue)
+	c.Assert(uniqueIndex < foreignKey, qt.IsTrue)
+	c.Assert(foreignKey < nonUniqueIndex, qt.IsTrue)
 }
 
 func TestFromDatabase_SQLiteForeignKeysAreInline(t *testing.T) {

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -106,11 +106,12 @@ func checkForCircularDependencies(r *Database, sorted *[]Table) {
 // Circular dependency handling:
 //   - If circular dependencies are detected, a warning is logged
 //   - Remaining tables are appended to the end of the sorted list
-//   - This allows migration to proceed, but manual intervention may be needed
+//   - Schema rendering emits foreign keys after table creation, so the resulting
+//     DDL remains executable for supported dialects
 //
 // The method modifies the Tables slice in-place, reordering it according to dependency
-// requirements. This ensures that CREATE TABLE statements can be executed in the
-// returned order without foreign key constraint violations.
+// requirements. Renderers that support post-create foreign keys emit those
+// constraints in a separate phase after all tables exist.
 func sortTablesByDependencies(r *Database) {
 	// Create a map for quick table lookup
 	tableMap := make(map[string]Table)

--- a/integration/gonative/circular_fk_generate_integration_test.go
+++ b/integration/gonative/circular_fk_generate_integration_test.go
@@ -65,8 +65,107 @@ func TestPostgreSQLGenerateMutualForeignKeysApplyIntegration(t *testing.T) {
 	c.Assert(foreignKeyCount, qt.Equals, 2)
 }
 
+func TestPostgreSQLForeignKeyReferencingUniqueIndexApplyIntegration(t *testing.T) {
+	c := qt.New(t)
+
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "ptah_fk_unique_parents"},
+			{StructName: "Child", Name: "ptah_fk_unique_children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Parent", Name: "code", Type: "TEXT", Nullable: false},
+			{StructName: "Child", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName:     "Child",
+				Name:           "parent_code",
+				Type:           "TEXT",
+				Nullable:       false,
+				Foreign:        "ptah_fk_unique_parents(code)",
+				ForeignKeyName: "fk_ptah_fk_unique_children_parent_code",
+			},
+		},
+		Indexes: []goschema.Index{
+			{
+				StructName: "Child",
+				TableName:  "ptah_fk_unique_children",
+				Name:       "idx_ptah_fk_unique_children_parent_code",
+				Fields:     []string{"parent_code"},
+			},
+			{
+				StructName: "Parent",
+				TableName:  "ptah_fk_unique_parents",
+				Name:       "uq_ptah_fk_unique_parents_code",
+				Fields:     []string{"code"},
+				Unique:     true,
+			},
+		},
+	}
+
+	statements := renderer.GetOrderedCreateStatements(database, "postgres")
+	uniqueIndexPos := statementIndexContaining(statements, "CREATE UNIQUE INDEX", "uq_ptah_fk_unique_parents_code")
+	foreignKeyPos := statementIndexContaining(statements, "ALTER TABLE", "fk_ptah_fk_unique_children_parent_code")
+	nonUniqueIndexPos := statementIndexContaining(statements, "CREATE INDEX", "idx_ptah_fk_unique_children_parent_code")
+	c.Assert(uniqueIndexPos, qt.Not(qt.Equals), -1)
+	c.Assert(foreignKeyPos, qt.Not(qt.Equals), -1)
+	c.Assert(nonUniqueIndexPos, qt.Not(qt.Equals), -1)
+	c.Assert(uniqueIndexPos < foreignKeyPos, qt.IsTrue)
+	c.Assert(foreignKeyPos < nonUniqueIndexPos, qt.IsTrue)
+
+	dsn := skipIfNoPostgreSQL(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	cleanupUniqueIndexForeignKeyTables(t, db)
+	defer cleanupUniqueIndexForeignKeyTables(t, db)
+
+	sqlText := strings.Join(statements, "\n")
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", stmt))
+	}
+
+	var foreignKeyCount int
+	err = db.QueryRow(`
+		SELECT count(*)
+		FROM pg_constraint
+		WHERE contype = 'f'
+			AND conname = 'fk_ptah_fk_unique_children_parent_code'
+	`).Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 1)
+}
+
+func statementIndexContaining(statements []string, fragments ...string) int {
+	for i, stmt := range statements {
+		matches := true
+		for _, fragment := range fragments {
+			if !strings.Contains(stmt, fragment) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return i
+		}
+	}
+	return -1
+}
+
 func cleanupMutualForeignKeyTables(t *testing.T, db *sql.DB) {
 	t.Helper()
 	_, err := db.Exec(`DROP TABLE IF EXISTS "left_nodes", "right_nodes" CASCADE`)
+	qt.Assert(t, err, qt.IsNil)
+}
+
+func cleanupUniqueIndexForeignKeyTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`DROP TABLE IF EXISTS "ptah_fk_unique_children", "ptah_fk_unique_parents" CASCADE`)
 	qt.Assert(t, err, qt.IsNil)
 }


### PR DESCRIPTION
## Summary
- create PostgreSQL extensions before schema objects that may depend on extension types, functions, or operator classes
- keep PostgreSQL roles/functions ahead of indexes, then create unique indexes before foreign keys so FK constraints can reference unique-index-backed keys
- add unit coverage for extension/index/FK ordering plus a CI-backed Postgres integration test for FK references to a unique index
- refresh the circular dependency sorter docs so they describe the current two-phase FK renderer behavior

## Self-review
- Logic: all tables still exist before post-create FKs; SQLite remains inline because it has no native ADD CONSTRAINT path; unique indexes now exist before FKs that may reference them.
- Dependency order: extensions precede tables/indexes/functions; PostgreSQL functions precede indexes that may call them; remaining objects stay after FKs; non-unique indexes remain last.
- Safety: no new raw SQL construction paths outside existing AST renderers; integration cleanup drops only test-prefixed tables.
- CLI/API: no public API changes and no legacy/root compatibility commands.

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./core/convert/fromschema ./core/renderer ./core/goschema ./integration/gonative -count=1
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache-137 golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test ./... (outside sandbox; sandbox blocks dbschema listener tests)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOMODCACHE=/private/tmp/ptah-go-mod-cache-443-2 go test -tags integration ./integration/gonative -run 'TestPostgreSQLGenerateMutualForeignKeysApplyIntegration|TestPostgreSQLForeignKeyReferencingUniqueIndexApplyIntegration' -count=1 -v (local POSTGRES_TEST_DSN unset, tests skipped; CI integration job provides DSN)