### PR TITLE
Build planner dependency ordering

### DIFF
--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -133,6 +133,24 @@ For a detailed view of the migration workflow, see the [Migration Architecture D
   - Handles dependency ordering
   - Creates both UP and DOWN migration paths
 
+Planner ordering is separate from diff sorting. The schemadiff layer keeps
+change lists deterministic so generated migrations are stable across runs, but
+the planner must not treat that sorted order as a dependency model. Dialect
+planners build graph order from explicit dependency data where it exists:
+foreign-key table dependencies, function dependencies, and reverse
+child-before-parent ordering for table drops. PostgreSQL view-like objects use
+conservative body reference detection for dependencies between managed views and
+materialized views. Grants, RLS policies, triggers, and roles still rely on
+typed phase ordering plus deterministic diff order within each phase.
+Independent operations keep their deterministic diff order.
+
+For table creation, planners create all selected tables without foreign keys
+first, then add foreign keys in a separate phase after the participating tables
+exist. For table removal, planners use reverse dependency order when schema
+dependency data is available; generated down migrations also pre-order the
+reversed diff so callers that only have the diff still receive child-before-parent
+DROP TABLE statements.
+
 #### generator Package
 - **Purpose**: Generates migration files from planned operations
 - **Features**:

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/pathguard"
+	"github.com/stokaro/ptah/migration/internal/deporder"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/safety"
@@ -902,8 +903,8 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	return &types.SchemaDiff{
 		// Reverse table operations
-		TablesAdded:    diff.TablesRemoved,                               // Tables to remove become tables to add
-		TablesRemoved:  rollbackDropTableOrder(diff.TablesAdded, schema), // Tables to add become tables to remove
+		TablesAdded:    diff.TablesRemoved,                                // Tables to remove become tables to add
+		TablesRemoved:  deporder.TableDropOrder(diff.TablesAdded, schema), // Tables to add become tables to remove
 		TablesModified: reverseTableDiffs(diff.TablesModified),
 
 		// Reverse enum operations
@@ -964,107 +965,6 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 	}
 }
 
-func rollbackDropTableOrder(tableNames []string, schema *goschema.Database) []string {
-	ordered := append([]string(nil), tableNames...)
-	if schema == nil || len(ordered) < 2 {
-		return ordered
-	}
-
-	candidates := make(map[string]bool, len(ordered))
-	for _, tableName := range ordered {
-		candidates[tableName] = true
-	}
-
-	dependencies := generatedTableDependencies(schema)
-	dependents := make(map[string][]string)
-	for _, child := range ordered {
-		for _, parent := range dependencies[child] {
-			if candidates[parent] && parent != child && !slices.Contains(dependents[parent], child) {
-				dependents[parent] = append(dependents[parent], child)
-			}
-		}
-	}
-
-	result := make([]string, 0, len(ordered))
-	state := make(map[string]int, len(ordered))
-	var visit func(string)
-	visit = func(tableName string) {
-		switch state[tableName] {
-		case 1:
-			return
-		case 2:
-			return
-		}
-		state[tableName] = 1
-		for _, child := range dependents[tableName] {
-			visit(child)
-		}
-		state[tableName] = 2
-		result = append(result, tableName)
-	}
-
-	for _, tableName := range ordered {
-		visit(tableName)
-	}
-	return result
-}
-
-func generatedTableDependencies(schema *goschema.Database) map[string][]string {
-	dependencies := make(map[string][]string, len(schema.Tables))
-	for _, table := range schema.Tables {
-		dependencies[table.QualifiedName()] = append([]string(nil), schema.Dependencies[table.QualifiedName()]...)
-	}
-
-	for _, field := range schema.Fields {
-		if field.Foreign == "" {
-			continue
-		}
-		table := generatedTableByStructName(schema.Tables, field.StructName)
-		if table == nil {
-			continue
-		}
-		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(field.Foreign))
-	}
-
-	for _, embedded := range schema.EmbeddedFields {
-		if embedded.Mode != "relation" || embedded.Ref == "" {
-			continue
-		}
-		table := generatedTableByStructName(schema.Tables, embedded.StructName)
-		if table == nil {
-			continue
-		}
-		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(embedded.Ref))
-	}
-
-	for _, constraint := range schema.Constraints {
-		if constraint.ForeignTable == "" || !strings.EqualFold(constraint.Type, "FOREIGN KEY") {
-			continue
-		}
-		table := generatedTableReference(schema.Tables, constraint.StructName, constraint.Table)
-		if table == nil {
-			continue
-		}
-		addGeneratedTableDependency(dependencies, schema.Tables, *table, constraint.ForeignTable)
-	}
-
-	return dependencies
-}
-
-func addGeneratedTableDependency(
-	dependencies map[string][]string,
-	tables []goschema.Table,
-	table goschema.Table,
-	refTable string,
-) {
-	tableName := table.QualifiedName()
-	refTable = resolveGeneratedReferenceTableName(tables, table, refTable)
-	if tableName == refTable || slices.Contains(dependencies[tableName], refTable) {
-		return
-	}
-	dependencies[tableName] = append(dependencies[tableName], refTable)
-}
-
 func generatedTableByStructName(tables []goschema.Table, structName string) *goschema.Table {
 	for i := range tables {
 		if tables[i].StructName == structName {
@@ -1108,39 +1008,6 @@ func generatedTableReference(tables []goschema.Table, structName, tableName stri
 		match = &tables[i]
 	}
 	return match
-}
-
-func resolveGeneratedReferenceTableName(tables []goschema.Table, current goschema.Table, refTable string) string {
-	refTable = strings.TrimSpace(refTable)
-	if strings.Contains(refTable, ".") {
-		return refTable
-	}
-	for _, table := range tables {
-		if table.Schema == current.Schema && table.Name == refTable {
-			return table.QualifiedName()
-		}
-	}
-	var match string
-	for _, table := range tables {
-		if table.Name != refTable {
-			continue
-		}
-		if match != "" {
-			return refTable
-		}
-		match = table.QualifiedName()
-	}
-	if match != "" {
-		return match
-	}
-	return refTable
-}
-
-func foreignReferenceTable(ref string) string {
-	if tableName, _, ok := strings.Cut(ref, "("); ok {
-		return strings.TrimSpace(tableName)
-	}
-	return strings.TrimSpace(ref)
 }
 
 // reverseConstraintAdditions builds the table-qualified additions for the down

--- a/migration/internal/deporder/deporder.go
+++ b/migration/internal/deporder/deporder.go
@@ -1,0 +1,483 @@
+package deporder
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+// ViewLike is a PostgreSQL view-like object that can reference other view-like
+// objects in its SELECT body.
+type ViewLike struct {
+	Name         string
+	Body         string
+	Materialized bool
+}
+
+// StableTopologicalSort returns nodes ordered so dependencies come first while
+// preserving caller order for otherwise independent nodes. Cycles degrade
+// deterministically by appending remaining nodes in caller order.
+func StableTopologicalSort(nodes []string, dependencies map[string][]string) []string {
+	index := indexNodes(nodes)
+	inDegree := make(map[string]int, len(index))
+	dependents := make(map[string][]string, len(index))
+
+	for node := range index {
+		inDegree[node] = 0
+	}
+	for node, deps := range dependencies {
+		if _, ok := index[node]; !ok {
+			continue
+		}
+		seenDeps := make(map[string]struct{}, len(deps))
+		for _, dep := range deps {
+			if dep == node {
+				continue
+			}
+			if _, ok := index[dep]; !ok {
+				continue
+			}
+			if _, seen := seenDeps[dep]; seen {
+				continue
+			}
+			seenDeps[dep] = struct{}{}
+			inDegree[node]++
+			dependents[dep] = append(dependents[dep], node)
+		}
+	}
+
+	for node := range dependents {
+		sortByIndex(dependents[node], index)
+	}
+
+	queue := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if inDegree[node] == 0 {
+			queue = append(queue, node)
+		}
+	}
+
+	result := make([]string, 0, len(nodes))
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		result = append(result, current)
+
+		for _, dependent := range dependents[current] {
+			inDegree[dependent]--
+			if inDegree[dependent] == 0 {
+				queue = appendStable(queue, dependent, index)
+			}
+		}
+	}
+
+	if len(result) == len(nodes) {
+		return result
+	}
+
+	seen := make(map[string]struct{}, len(result))
+	for _, node := range result {
+		seen[node] = struct{}{}
+	}
+	for _, node := range nodes {
+		if _, ok := seen[node]; !ok {
+			result = append(result, node)
+		}
+	}
+	return result
+}
+
+// StableReverseDependencySort returns nodes ordered so dependents come before
+// the objects they depend on, preserving caller order for independent nodes.
+func StableReverseDependencySort(nodes []string, dependencies map[string][]string) []string {
+	index := indexNodes(nodes)
+	dependents := make(map[string][]string, len(index))
+	for _, child := range nodes {
+		for _, parent := range dependencies[child] {
+			if parent == child {
+				continue
+			}
+			if _, ok := index[parent]; ok && !slices.Contains(dependents[parent], child) {
+				dependents[parent] = append(dependents[parent], child)
+			}
+		}
+	}
+	for node := range dependents {
+		sortByIndex(dependents[node], index)
+	}
+
+	result := make([]string, 0, len(nodes))
+	state := make(map[string]int, len(nodes))
+	var visit func(string)
+	visit = func(node string) {
+		switch state[node] {
+		case 1, 2:
+			return
+		}
+		state[node] = 1
+		for _, dependent := range dependents[node] {
+			visit(dependent)
+		}
+		state[node] = 2
+		result = append(result, node)
+	}
+
+	for _, node := range nodes {
+		visit(node)
+	}
+	return result
+}
+
+// TablesForCreate returns target tables in dependency order for CREATE TABLE
+// operations. It accepts either qualified or unqualified table names.
+func TablesForCreate(schema *goschema.Database, tableNames []string) []goschema.Table {
+	if schema == nil || len(tableNames) == 0 {
+		return nil
+	}
+
+	tablesByKey := mapTablesByQualifiedName(schema.Tables)
+	keys := tableKeysInInputOrder(schema.Tables, tableNames)
+	orderedKeys := StableTopologicalSort(keys, GeneratedTableDependencies(schema))
+
+	tables := make([]goschema.Table, 0, len(orderedKeys))
+	for _, key := range orderedKeys {
+		if table, ok := tablesByKey[key]; ok {
+			tables = append(tables, table)
+		}
+	}
+	return tables
+}
+
+// TableDropOrder returns table names in child-before-parent order for DROP
+// TABLE operations. Output names match the caller's input spelling.
+func TableDropOrder(tableNames []string, schema *goschema.Database) []string {
+	ordered := append([]string(nil), tableNames...)
+	if schema == nil || len(ordered) < 2 {
+		return ordered
+	}
+
+	inputByKey := make(map[string]string, len(ordered))
+	keys := make([]string, 0, len(ordered))
+	for _, tableName := range ordered {
+		key := resolveTableKey(schema.Tables, tableName)
+		if _, seen := inputByKey[key]; seen {
+			continue
+		}
+		inputByKey[key] = tableName
+		keys = append(keys, key)
+	}
+
+	orderedKeys := StableReverseDependencySort(keys, GeneratedTableDependencies(schema))
+	result := make([]string, 0, len(orderedKeys))
+	for _, key := range orderedKeys {
+		result = append(result, inputByKey[key])
+	}
+	return result
+}
+
+// GeneratedTableDependencies returns table dependency edges derived from
+// finalized metadata plus inline field and table-level FK definitions.
+func GeneratedTableDependencies(schema *goschema.Database) map[string][]string {
+	dependencies := make(map[string][]string, len(schema.Tables))
+	for _, table := range schema.Tables {
+		dependencies[table.QualifiedName()] = append([]string(nil), schema.Dependencies[table.QualifiedName()]...)
+	}
+
+	for _, field := range schema.Fields {
+		if field.Foreign == "" {
+			continue
+		}
+		table := generatedTableByStructName(schema.Tables, field.StructName)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(field.Foreign))
+	}
+
+	for _, embedded := range schema.EmbeddedFields {
+		if embedded.Mode != "relation" || embedded.Ref == "" {
+			continue
+		}
+		table := generatedTableByStructName(schema.Tables, embedded.StructName)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, foreignReferenceTable(embedded.Ref))
+	}
+
+	for _, constraint := range schema.Constraints {
+		if constraint.ForeignTable == "" || !strings.EqualFold(constraint.Type, "FOREIGN KEY") {
+			continue
+		}
+		table := generatedTableReference(schema.Tables, constraint.StructName, constraint.Table)
+		if table == nil {
+			continue
+		}
+		addGeneratedTableDependency(dependencies, schema.Tables, *table, constraint.ForeignTable)
+	}
+
+	return dependencies
+}
+
+// FunctionsForCreate returns target functions in dependency order.
+func FunctionsForCreate(schema *goschema.Database, functionNames []string) []goschema.Function {
+	if schema == nil || len(functionNames) == 0 {
+		return nil
+	}
+
+	functionByName := make(map[string]goschema.Function, len(schema.Functions))
+	requested := make(map[string]struct{}, len(functionNames))
+	for _, functionName := range functionNames {
+		requested[functionName] = struct{}{}
+	}
+	names := make([]string, 0, len(functionNames))
+	for _, fn := range schema.Functions {
+		functionByName[fn.Name] = fn
+		if _, ok := requested[fn.Name]; ok {
+			names = append(names, fn.Name)
+		}
+	}
+
+	orderedNames := StableTopologicalSort(names, schema.FunctionDependencies)
+
+	functions := make([]goschema.Function, 0, len(orderedNames))
+	for _, name := range orderedNames {
+		if fn, ok := functionByName[name]; ok {
+			functions = append(functions, fn)
+		}
+	}
+	return functions
+}
+
+// ViewLikesForCreate returns views and materialized views in dependency order
+// when their bodies reference other added view-like objects.
+func ViewLikesForCreate(objects []ViewLike) []ViewLike {
+	if len(objects) < 2 {
+		return append([]ViewLike(nil), objects...)
+	}
+
+	ids := make([]string, 0, len(objects))
+	byID := make(map[string]ViewLike, len(objects))
+	idsByName := make(map[string][]string, len(objects))
+	for i, object := range objects {
+		id := viewLikeID(object, i)
+		ids = append(ids, id)
+		byID[id] = object
+		idsByName[object.Name] = append(idsByName[object.Name], id)
+	}
+
+	dependencies := make(map[string][]string, len(objects))
+	for i, object := range objects {
+		id := viewLikeID(object, i)
+		for candidateName, candidateIDs := range idsByName {
+			if candidateName == object.Name || !referencesIdentifier(object.Body, candidateName) {
+				continue
+			}
+			dependencies[id] = append(dependencies[id], candidateIDs...)
+		}
+	}
+
+	orderedIDs := StableTopologicalSort(ids, dependencies)
+	ordered := make([]ViewLike, 0, len(orderedIDs))
+	for _, id := range orderedIDs {
+		ordered = append(ordered, byID[id])
+	}
+	return ordered
+}
+
+func indexNodes(nodes []string) map[string]int {
+	index := make(map[string]int, len(nodes))
+	for i, node := range nodes {
+		if _, exists := index[node]; !exists {
+			index[node] = i
+		}
+	}
+	return index
+}
+
+func sortByIndex(nodes []string, index map[string]int) {
+	slices.SortFunc(nodes, func(a, b string) int {
+		return index[a] - index[b]
+	})
+}
+
+func appendStable(queue []string, node string, index map[string]int) []string {
+	insertAt := len(queue)
+	for i, queued := range queue {
+		if index[node] < index[queued] {
+			insertAt = i
+			break
+		}
+	}
+	queue = append(queue, "")
+	copy(queue[insertAt+1:], queue[insertAt:])
+	queue[insertAt] = node
+	return queue
+}
+
+func mapTablesByQualifiedName(tables []goschema.Table) map[string]goschema.Table {
+	result := make(map[string]goschema.Table, len(tables))
+	for _, table := range tables {
+		result[table.QualifiedName()] = table
+	}
+	return result
+}
+
+func tableKeysInInputOrder(tables []goschema.Table, tableNames []string) []string {
+	keys := make([]string, 0, len(tableNames))
+	seen := make(map[string]struct{}, len(tableNames))
+	for _, tableName := range tableNames {
+		key := resolveTableKey(tables, tableName)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		if generatedTableByName(tables, tableName) == nil {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func resolveTableKey(tables []goschema.Table, tableName string) string {
+	if table := generatedTableByName(tables, tableName); table != nil {
+		return table.QualifiedName()
+	}
+	return tableName
+}
+
+func generatedTableByName(tables []goschema.Table, tableName string) *goschema.Table {
+	tableName = strings.TrimSpace(tableName)
+	for i := range tables {
+		table := &tables[i]
+		if table.Name == tableName || table.QualifiedName() == tableName {
+			return table
+		}
+	}
+	return nil
+}
+
+func generatedTableByStructName(tables []goschema.Table, structName string) *goschema.Table {
+	for i := range tables {
+		if tables[i].StructName == structName {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func generatedTableReference(tables []goschema.Table, structName, tableName string) *goschema.Table {
+	tableName = strings.TrimSpace(tableName)
+	for i := range tables {
+		table := &tables[i]
+		if tableName == "" && table.StructName == structName {
+			return table
+		}
+		if tableName != "" && table.StructName == structName && (table.Name == tableName || table.QualifiedName() == tableName) {
+			return table
+		}
+	}
+	if tableName == "" {
+		return nil
+	}
+	return generatedTableByName(tables, tableName)
+}
+
+func addGeneratedTableDependency(
+	dependencies map[string][]string,
+	tables []goschema.Table,
+	table goschema.Table,
+	refTable string,
+) {
+	tableName := table.QualifiedName()
+	refTable = resolveGeneratedReferenceTableName(tables, table, refTable)
+	if tableName == refTable || slices.Contains(dependencies[tableName], refTable) {
+		return
+	}
+	dependencies[tableName] = append(dependencies[tableName], refTable)
+}
+
+func resolveGeneratedReferenceTableName(tables []goschema.Table, table goschema.Table, refTable string) string {
+	refTable = strings.TrimSpace(refTable)
+	if strings.Contains(refTable, ".") {
+		return refTable
+	}
+
+	if table.Schema != "" {
+		schemaQualified := table.Schema + "." + refTable
+		if ref := generatedTableByName(tables, schemaQualified); ref != nil {
+			return ref.QualifiedName()
+		}
+	}
+
+	var match string
+	for _, candidate := range tables {
+		if candidate.Name != refTable {
+			continue
+		}
+		if match != "" {
+			return refTable
+		}
+		match = candidate.QualifiedName()
+	}
+	if match != "" {
+		return match
+	}
+	return refTable
+}
+
+func foreignReferenceTable(reference string) string {
+	table, _, _ := strings.Cut(strings.TrimSpace(reference), "(")
+	return strings.TrimSpace(table)
+}
+
+func viewLikeID(object ViewLike, index int) string {
+	kind := "view"
+	if object.Materialized {
+		kind = "matview"
+	}
+	return kind + ":" + object.Name + ":" + strconv.Itoa(index)
+}
+
+func referencesIdentifier(body, name string) bool {
+	body = strings.ToLower(body)
+	name = strings.ToLower(strings.TrimSpace(name))
+	if body == "" || name == "" {
+		return false
+	}
+
+	for start := 0; start < len(body); {
+		index := strings.Index(body[start:], name)
+		if index < 0 {
+			return false
+		}
+		index += start
+		end := index + len(name)
+		if (isIdentifierBoundary(body, index-1) || isQualifiedIdentifierTail(body, index-1)) && isIdentifierBoundary(body, end) {
+			return true
+		}
+		start = end
+	}
+	return false
+}
+
+func isIdentifierBoundary(value string, index int) bool {
+	if index < 0 || index >= len(value) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(value[index:])
+	return !isSQLIdentifierRune(r)
+}
+
+func isQualifiedIdentifierTail(value string, index int) bool {
+	return index >= 0 && index < len(value) && value[index] == '.'
+}
+
+func isSQLIdentifierRune(r rune) bool {
+	return r == '_' || r == '$' || r == '.' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/migration/internal/deporder/deporder_test.go
+++ b/migration/internal/deporder/deporder_test.go
@@ -1,0 +1,213 @@
+package deporder_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/migration/internal/deporder"
+)
+
+func TestStableTopologicalSort_OrdersDependenciesBeforeDependents(t *testing.T) {
+	c := qt.New(t)
+
+	ordered := deporder.StableTopologicalSort(
+		[]string{"tasks", "memberships", "projects", "accounts"},
+		map[string][]string{
+			"tasks":       {"projects"},
+			"projects":    {"accounts"},
+			"memberships": {"accounts"},
+		},
+	)
+
+	c.Assert(ordered, qt.DeepEquals, []string{"accounts", "memberships", "projects", "tasks"})
+}
+
+func TestStableTopologicalSort_CycleFallsBackToCallerOrder(t *testing.T) {
+	c := qt.New(t)
+
+	ordered := deporder.StableTopologicalSort(
+		[]string{"a", "b", "c"},
+		map[string][]string{
+			"a": {"b"},
+			"b": {"a"},
+		},
+	)
+
+	c.Assert(ordered, qt.DeepEquals, []string{"c", "a", "b"})
+}
+
+func TestStableReverseDependencySort_OrdersDependentsBeforeParents(t *testing.T) {
+	c := qt.New(t)
+
+	ordered := deporder.StableReverseDependencySort(
+		[]string{"accounts", "projects", "memberships", "tasks"},
+		map[string][]string{
+			"tasks":       {"projects"},
+			"projects":    {"accounts"},
+			"memberships": {"accounts"},
+		},
+	)
+
+	c.Assert(ordered, qt.DeepEquals, []string{"tasks", "projects", "memberships", "accounts"})
+}
+
+func TestTablesForCreate_DerivesForeignKeyDependencies(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Task", Name: "tasks"},
+			{StructName: "Project", Name: "projects"},
+			{StructName: "Account", Name: "accounts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Task", Name: "project_id", Foreign: "projects(id)"},
+			{StructName: "Project", Name: "account_id", Foreign: "accounts(id)"},
+		},
+	}
+
+	tables := deporder.TablesForCreate(schema, []string{"tasks", "projects", "accounts"})
+
+	c.Assert(tableNames(tables), qt.DeepEquals, []string{"accounts", "projects", "tasks"})
+}
+
+func TestTableDropOrder_DerivesForeignKeyDependencies(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Account", Name: "accounts"},
+			{StructName: "Project", Name: "projects"},
+			{StructName: "Task", Name: "tasks"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Task", Name: "project_id", Foreign: "projects(id)"},
+			{StructName: "Project", Name: "account_id", Foreign: "accounts(id)"},
+		},
+	}
+
+	ordered := deporder.TableDropOrder([]string{"accounts", "projects", "tasks"}, schema)
+
+	c.Assert(ordered, qt.DeepEquals, []string{"tasks", "projects", "accounts"})
+}
+
+func TestTablesForCreate_ResolvesUnqualifiedForeignKeyWithinCurrentSchema(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "AuditAccount", Schema: "audit", Name: "accounts"},
+			{StructName: "AppProject", Schema: "app", Name: "projects"},
+			{StructName: "AppAccount", Schema: "app", Name: "accounts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "AppProject", Name: "account_id", Foreign: "accounts(id)"},
+		},
+	}
+
+	tables := deporder.TablesForCreate(schema, []string{"app.projects", "app.accounts", "audit.accounts"})
+
+	c.Assert(qualifiedTableNames(tables), qt.DeepEquals, []string{"app.accounts", "app.projects", "audit.accounts"})
+}
+
+func TestFunctionsForCreate_UsesFunctionDependencyMap(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Functions: []goschema.Function{
+			{Name: "a_child"},
+			{Name: "z_parent"},
+		},
+		FunctionDependencies: map[string][]string{
+			"a_child": {"z_parent"},
+		},
+	}
+
+	functions := deporder.FunctionsForCreate(schema, []string{"a_child", "z_parent"})
+
+	c.Assert(functionNames(functions), qt.DeepEquals, []string{"z_parent", "a_child"})
+}
+
+func TestFunctionsForCreate_FallsBackToGeneratedFunctionOrder(t *testing.T) {
+	c := qt.New(t)
+	schema := &goschema.Database{
+		Functions: []goschema.Function{
+			{Name: "z_parent"},
+			{Name: "a_child"},
+		},
+	}
+
+	functions := deporder.FunctionsForCreate(schema, []string{"a_child", "z_parent"})
+
+	c.Assert(functionNames(functions), qt.DeepEquals, []string{"z_parent", "a_child"})
+}
+
+func TestViewLikesForCreate_OrdersMaterializedViewBeforeDependentView(t *testing.T) {
+	c := qt.New(t)
+
+	objects := deporder.ViewLikesForCreate([]deporder.ViewLike{
+		{Name: "a_report", Body: "SELECT id FROM z_base"},
+		{Name: "z_base", Body: "SELECT id FROM users", Materialized: true},
+	})
+
+	c.Assert(viewLikeNames(objects), qt.DeepEquals, []string{"z_base", "a_report"})
+	c.Assert(objects[0].Materialized, qt.IsTrue)
+}
+
+func TestViewLikesForCreate_DoesNotMatchIdentifierSubstrings(t *testing.T) {
+	c := qt.New(t)
+
+	objects := deporder.ViewLikesForCreate([]deporder.ViewLike{
+		{Name: "a_report", Body: "SELECT id FROM z_baseline"},
+		{Name: "z_base", Body: "SELECT id FROM users", Materialized: true},
+	})
+
+	c.Assert(viewLikeNames(objects), qt.DeepEquals, []string{"a_report", "z_base"})
+}
+
+func TestViewLikesForCreate_MatchesSchemaQualifiedReferences(t *testing.T) {
+	c := qt.New(t)
+
+	for _, body := range []string{
+		"SELECT id FROM public.z_base",
+		`SELECT id FROM "public"."z_base"`,
+	} {
+		objects := deporder.ViewLikesForCreate([]deporder.ViewLike{
+			{Name: "a_report", Body: body},
+			{Name: "z_base", Body: "SELECT id FROM users", Materialized: true},
+		})
+
+		c.Assert(viewLikeNames(objects), qt.DeepEquals, []string{"z_base", "a_report"}, qt.Commentf("body: %s", body))
+		c.Assert(objects[0].Materialized, qt.IsTrue)
+	}
+}
+
+func tableNames(tables []goschema.Table) []string {
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.Name)
+	}
+	return names
+}
+
+func qualifiedTableNames(tables []goschema.Table) []string {
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.QualifiedName())
+	}
+	return names
+}
+
+func functionNames(functions []goschema.Function) []string {
+	names := make([]string, 0, len(functions))
+	for _, fn := range functions {
+		names = append(names, fn.Name)
+	}
+	return names
+}
+
+func viewLikeNames(objects []deporder.ViewLike) []string {
+	names := make([]string, 0, len(objects))
+	for _, object := range objects {
+		names = append(names, object.Name)
+	}
+	return names
+}

--- a/migration/planner/dialects/mysql/dependency_order_test.go
+++ b/migration/planner/dialects/mysql/dependency_order_test.go
@@ -1,0 +1,193 @@
+package mysql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_MySQLFamilyOrdersFKChainTables(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			generated := dependencyOrderSchema()
+			diff := &types.SchemaDiff{
+				TablesAdded: []string{
+					"ptah_fk_order_tasks",
+					"ptah_fk_order_projects",
+					"ptah_fk_order_accounts",
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, generated)
+
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_projects")
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_projects", "CREATE TABLE ptah_fk_order_tasks")
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_tasks", "ALTER TABLE ptah_fk_order_projects ADD CONSTRAINT")
+		})
+	}
+}
+
+func TestPlanner_GenerateMigrationAST_MySQLFamilyOrdersFKDiamondTables(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			generated := dependencyOrderSchema()
+			diff := &types.SchemaDiff{
+				TablesAdded: []string{
+					"ptah_fk_order_tasks",
+					"ptah_fk_order_projects",
+					"ptah_fk_order_memberships",
+					"ptah_fk_order_accounts",
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, generated)
+
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_projects")
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_memberships")
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_projects", "CREATE TABLE ptah_fk_order_tasks")
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_memberships", "CREATE TABLE ptah_fk_order_tasks")
+		})
+	}
+}
+
+func TestPlanner_GenerateMigrationAST_MySQLFamilyDropsFKDiamondTablesInDependencyOrder(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			generated := dependencyOrderSchema()
+			diff := &types.SchemaDiff{
+				TablesRemoved: []string{
+					"ptah_fk_order_accounts",
+					"ptah_fk_order_projects",
+					"ptah_fk_order_memberships",
+					"ptah_fk_order_tasks",
+				},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, generated)
+
+			assertContainsBefore(c, sql, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+			assertContainsBefore(c, sql, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_memberships")
+			assertContainsBefore(c, sql, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+			assertContainsBefore(c, sql, "DROP TABLE IF EXISTS ptah_fk_order_memberships", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+		})
+	}
+}
+
+func TestPlanner_GenerateMigrationAST_MySQLFamilyAddsReferencedUniqueIndexBeforeNewTableFKs(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			generated := referencedUniqueKeySchema()
+			diff := &types.SchemaDiff{
+				TablesAdded:  []string{"ptah_fk_order_children", "ptah_fk_order_parents"},
+				IndexesAdded: []string{"uq_ptah_fk_order_parents_code_idx"},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, generated)
+
+			assertContainsBefore(c, sql, "CREATE TABLE ptah_fk_order_parents", "CREATE TABLE ptah_fk_order_children")
+			assertContainsBefore(c, sql, "CREATE UNIQUE INDEX uq_ptah_fk_order_parents_code_idx", "ALTER TABLE ptah_fk_order_children ADD CONSTRAINT")
+		})
+	}
+}
+
+func TestPlanner_GenerateMigrationAST_MySQLFamilyAddsReferencedUniqueConstraintBeforeNewTableFKs(t *testing.T) {
+	for _, dialect := range mysqlFamilyDialects {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			generated := referencedUniqueKeySchema()
+			diff := &types.SchemaDiff{
+				TablesAdded:      []string{"ptah_fk_order_children", "ptah_fk_order_parents"},
+				ConstraintsAdded: []string{"uq_ptah_fk_order_parents_code"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:      "uq_ptah_fk_order_parents_code",
+					TableName: "ptah_fk_order_parents",
+					Type:      "UNIQUE",
+					Columns:   []string{"code"},
+				}},
+			}
+
+			sql := renderMySQLFamily(c, dialect, diff, generated)
+
+			assertContainsBefore(c, sql, "ALTER TABLE ptah_fk_order_parents ADD CONSTRAINT uq_ptah_fk_order_parents_code", "ALTER TABLE ptah_fk_order_children ADD CONSTRAINT")
+		})
+	}
+}
+
+func dependencyOrderSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "PtahFKOrderTask", Name: "ptah_fk_order_tasks"},
+			{StructName: "PtahFKOrderProject", Name: "ptah_fk_order_projects"},
+			{StructName: "PtahFKOrderMembership", Name: "ptah_fk_order_memberships"},
+			{StructName: "PtahFKOrderAccount", Name: "ptah_fk_order_accounts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "PtahFKOrderAccount", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "PtahFKOrderProject", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderProject",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_projects_account",
+			},
+			{StructName: "PtahFKOrderMembership", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderMembership",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_memberships_account",
+			},
+			{StructName: "PtahFKOrderTask", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "project_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_projects(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_project",
+			},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "membership_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_memberships(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_membership",
+			},
+		},
+	}
+}
+
+func referencedUniqueKeySchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "PtahFKOrderChild", Name: "ptah_fk_order_children"},
+			{StructName: "PtahFKOrderParent", Name: "ptah_fk_order_parents"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "PtahFKOrderParent", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "PtahFKOrderParent", Name: "code", Type: "VARCHAR(36)"},
+			{StructName: "PtahFKOrderChild", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderChild",
+				Name:           "parent_code",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_parents(code)",
+				ForeignKeyName: "fk_ptah_fk_order_children_parent_code",
+			},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "PtahFKOrderParent",
+			Name:       "uq_ptah_fk_order_parents_code_idx",
+			Fields:     []string{"code"},
+			Unique:     true,
+		}},
+	}
+}

--- a/migration/planner/dialects/mysql/mysql.go
+++ b/migration/planner/dialects/mysql/mysql.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/migration/internal/deporder"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -116,35 +117,23 @@ func (p *Planner) handleEnumModifications(result []ast.Node, diff *types.SchemaD
 }
 
 func (p *Planner) addNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	tablesToAdd := createTableLookupMap(diff.TablesAdded)
+	orderedTables := deporder.TablesForCreate(generated, diff.TablesAdded)
 
 	// Phase 1: Create tables without foreign key constraints
-	result = p.createTablesWithoutForeignKeys(result, generated, tablesToAdd)
-
-	// Phase 2: Add foreign key constraints via ALTER TABLE statements
-	result = p.addForeignKeyConstraints(result, generated, tablesToAdd)
+	result = p.createTablesWithoutForeignKeys(result, generated, orderedTables)
 
 	return result
 }
 
-// createTableLookupMap creates a map for quick table lookup
-func createTableLookupMap(tableNames []string) map[string]bool {
-	tablesToAdd := make(map[string]bool)
-	for _, tableName := range tableNames {
-		tablesToAdd[tableName] = true
-	}
-	return tablesToAdd
+func (p *Planner) addForeignKeyConstraintsForNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	return p.addForeignKeyConstraints(result, generated, deporder.TablesForCreate(generated, diff.TablesAdded))
 }
 
 // createTablesWithoutForeignKeys creates all tables without foreign key constraints
-func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
+func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *goschema.Database, tables []goschema.Table) []ast.Node {
 	allFields := generated.Fields
 
-	for _, table := range generated.Tables {
-		if !tablesToAdd[table.Name] {
-			continue
-		}
-
+	for _, table := range tables {
 		astNode := fromschema.FromTable(table, allFields, generated.Enums, DialectName)
 		for _, column := range astNode.Columns {
 			column.ForeignKey = nil
@@ -156,12 +145,8 @@ func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *g
 }
 
 // addForeignKeyConstraints adds foreign key constraints via ALTER TABLE statements
-func (p *Planner) addForeignKeyConstraints(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
-	for _, table := range generated.Tables {
-		if !tablesToAdd[table.Name] {
-			continue
-		}
-
+func (p *Planner) addForeignKeyConstraints(result []ast.Node, generated *goschema.Database, tables []goschema.Table) []ast.Node {
+	for _, table := range tables {
 		result = p.addRegularForeignKeys(result, generated, table)
 		result = p.addSelfReferencingForeignKeys(result, generated, table)
 	}
@@ -483,8 +468,8 @@ func (p *Planner) removeIndexes(result []ast.Node, diff *types.SchemaDiff) []ast
 	return result
 }
 
-func (p *Planner) removeTables(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
-	for _, tableName := range diff.TablesRemoved {
+func (p *Planner) removeTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, tableName := range deporder.TableDropOrder(diff.TablesRemoved, generated) {
 		dropTableNode := ast.NewDropTable(tableName).
 			SetIfExists().
 			SetCascade().
@@ -611,6 +596,10 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	// 5.5. Add new constraints (must be done after tables and columns exist)
 	result = p.addNewConstraints(result, diff, generated)
 
+	// 5.6. Add field-level foreign keys for new tables after referenced
+	// unique indexes and constraints have been created.
+	result = p.addForeignKeyConstraintsForNewTables(result, diff, generated)
+
 	// 6. Remove constraints before indexes. MySQL-family servers keep the
 	// backing index after DROP FOREIGN KEY when the index was auto-created, so
 	// rollback plans may need to drop both. The FK must go first.
@@ -624,7 +613,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	result = p.removeIndexes(result, diff)
 
 	// 7. Remove tables (dangerous!)
-	result = p.removeTables(result, diff)
+	result = p.removeTables(result, diff, generated)
 
 	// 8. Handle enum removals (MySQL-specific warnings)
 	result = p.handleEnumRemovals(result, diff)
@@ -768,6 +757,33 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		structToTable[t.StructName] = t.Name
 	}
 
+	state := newConstraintPlanState(diff)
+
+	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
+	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
+	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, nonForeignKeyConstraints)
+	result = p.addForeignKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
+	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, foreignKeyConstraints)
+	return result
+}
+
+type constraintKindFilter int
+
+const (
+	nonForeignKeyConstraints constraintKindFilter = iota
+	foreignKeyConstraints
+)
+
+type constraintPlanState struct {
+	removedNames       map[string]struct{}
+	removalByTableName map[string]types.ConstraintRemovalInfo
+	removalsByName     map[string][]types.ConstraintRemovalInfo
+	addedHostsByName   map[string]map[string]struct{}
+	handled            map[string]struct{}
+	droppedForModify   map[string]struct{}
+}
+
+func newConstraintPlanState(diff *types.SchemaDiff) constraintPlanState {
 	// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved
 	// is a modification (the comparator expresses a changed constraint as
 	// remove + add of the same name — e.g. an on_delete change on a field-level
@@ -831,46 +847,59 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		hosts[add.TableName] = struct{}{}
 	}
 
+	return constraintPlanState{
+		removedNames:       removedNames,
+		removalByTableName: removalByTableName,
+		removalsByName:     removalsByName,
+		addedHostsByName:   addedHostsByName,
+		handled:            make(map[string]struct{}),
+		droppedForModify:   make(map[string]struct{}),
+	}
+}
+
+func (p *Planner) addPrimaryKeyConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	state constraintPlanState,
+) []ast.Node {
 	// Prefer the table-qualified additions when present. A field-level FK from an
 	// embedded inline-relation mixin shares one name across every host table, and
 	// down migrations restore modified CHECK/UNIQUE definitions from the
 	// introspected DB schema. ConstraintsAddedWithTables carries the concrete
 	// table + definition. Names handled here are recorded so the name-only loop
 	// skips them.
-	handled := make(map[string]struct{})
-	droppedForModify := make(map[string]struct{})
-	for _, add := range diff.ConstraintsAddedWithTables {
+	for _, add := range additions {
 		if add.Type != "PRIMARY KEY" || add.TableName == "" || len(add.Columns) == 0 {
 			continue
 		}
-		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
+		if _, modified := state.removalByTableName[add.TableName+"."+add.Name]; modified {
 			continue
 		}
 		result = append(result, &ast.AlterTableNode{
 			Name:       add.TableName,
 			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: ast.NewPrimaryKeyConstraint(add.Columns...)}},
 		})
-		handled[add.Name] = struct{}{}
+		state.handled[add.Name] = struct{}{}
 	}
-	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
-	for _, add := range diff.ConstraintsAddedWithTables {
-		if add.Type != "FOREIGN KEY" || add.TableName == "" {
-			continue
-		}
-		// For a modification, emit the DROP FOREIGN KEY from this exact host
-		// table before its re-add — only when this host's (table, name) is in
-		// the removal set; a pure-add host gets no phantom drop.
-		if info, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
-			result = p.appendScopedDrop(result, info, droppedForModify)
-		}
-		result = append(result, p.foreignKeyAdditionNode(add))
-		handled[add.Name] = struct{}{}
-	}
+	return result
+}
 
+func (p *Planner) addNamedConstraintsByKind(
+	result []ast.Node,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	structToTable map[string]string,
+	state constraintPlanState,
+	kind constraintKindFilter,
+) []ast.Node {
+	wantForeignKey := kind == foreignKeyConstraints
 	// Fallback for added constraints with no table-qualified FK entry above
 	// (table-level CHECK/UNIQUE, or field-level synthesis resolved by name).
 	for _, constraintName := range diff.ConstraintsAdded {
-		if _, done := handled[constraintName]; done {
+		if _, done := state.handled[constraintName]; done {
+			continue
+		}
+		if p.constraintNameIsForeignKey(constraintName, generated, structToTable) != wantForeignKey {
 			continue
 		}
 
@@ -878,13 +907,61 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		// re-add, scoped to the constraint's concrete host table(s) — never a
 		// name-keyed single-winner lookup, which collapses multiple removal
 		// hosts onto one arbitrary table (issue #207).
-		if _, modified := removedNames[constraintName]; modified {
-			result = p.emitModifyDropForName(result, constraintName, removalsByName, addedHostsByName[constraintName], droppedForModify)
+		if _, modified := state.removedNames[constraintName]; modified {
+			result = p.emitModifyDropForName(
+				result,
+				constraintName,
+				state.removalsByName,
+				state.addedHostsByName[constraintName],
+				state.droppedForModify,
+			)
 		}
 
 		result = p.appendAddConstraint(result, constraintName, generated, structToTable)
 	}
 	return result
+}
+
+func (p *Planner) addForeignKeyConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	state constraintPlanState,
+) []ast.Node {
+	for _, add := range additions {
+		if add.Type != "FOREIGN KEY" || add.TableName == "" {
+			continue
+		}
+		// For a modification, emit the DROP FOREIGN KEY from this exact host
+		// table before its re-add — only when this host's (table, name) is in
+		// the removal set; a pure-add host gets no phantom drop.
+		if info, modified := state.removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.appendScopedDrop(result, info, state.droppedForModify)
+		}
+		result = append(result, p.foreignKeyAdditionNode(add))
+		state.handled[add.Name] = struct{}{}
+	}
+	return result
+}
+
+func (p *Planner) constraintNameIsForeignKey(constraintName string, generated *goschema.Database, structToTable map[string]string) bool {
+	for _, constraint := range generated.Constraints {
+		if constraint.Name == constraintName {
+			return strings.EqualFold(constraint.Type, "FOREIGN KEY")
+		}
+	}
+	for _, field := range generated.Fields {
+		if field.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[field.StructName]
+		if tableName == "" {
+			tableName = field.StructName
+		}
+		if foreignKeyName(tableName, field) == constraintName {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Planner) addCheckAndUniqueConstraintsWithTables(

--- a/migration/planner/dialects/postgres/dependency_order_test.go
+++ b/migration/planner/dialects/postgres/dependency_order_test.go
@@ -1,0 +1,195 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/migration/planner/dialects/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestPlanner_GenerateMigrationAST_OrdersFKChainTables(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+	generated := dependencyOrderSchema()
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{
+			"ptah_fk_order_tasks",
+			"ptah_fk_order_projects",
+			"ptah_fk_order_accounts",
+		},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_projects")
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_projects", "CREATE TABLE ptah_fk_order_tasks")
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_tasks", "ALTER TABLE ptah_fk_order_projects ADD CONSTRAINT")
+}
+
+func TestPlanner_GenerateMigrationAST_OrdersFKDiamondTables(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+	generated := dependencyOrderSchema()
+	diff := &types.SchemaDiff{
+		TablesAdded: []string{
+			"ptah_fk_order_tasks",
+			"ptah_fk_order_projects",
+			"ptah_fk_order_memberships",
+			"ptah_fk_order_accounts",
+		},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_projects")
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_accounts", "CREATE TABLE ptah_fk_order_memberships")
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_projects", "CREATE TABLE ptah_fk_order_tasks")
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_memberships", "CREATE TABLE ptah_fk_order_tasks")
+}
+
+func TestPlanner_GenerateMigrationAST_DropsFKDiamondTablesInDependencyOrder(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+	generated := dependencyOrderSchema()
+	diff := &types.SchemaDiff{
+		TablesRemoved: []string{
+			"ptah_fk_order_accounts",
+			"ptah_fk_order_projects",
+			"ptah_fk_order_memberships",
+			"ptah_fk_order_tasks",
+		},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_projects")
+	assertBefore(t, sql, "DROP TABLE IF EXISTS ptah_fk_order_tasks", "DROP TABLE IF EXISTS ptah_fk_order_memberships")
+	assertBefore(t, sql, "DROP TABLE IF EXISTS ptah_fk_order_projects", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+	assertBefore(t, sql, "DROP TABLE IF EXISTS ptah_fk_order_memberships", "DROP TABLE IF EXISTS ptah_fk_order_accounts")
+}
+
+func TestPlanner_GenerateMigrationAST_AddsReferencedUniqueIndexBeforeNewTableFKs(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+	generated := referencedUniqueKeySchema()
+	diff := &types.SchemaDiff{
+		TablesAdded:  []string{"ptah_fk_order_children", "ptah_fk_order_parents"},
+		IndexesAdded: []string{"uq_ptah_fk_order_parents_code_idx"},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "CREATE TABLE ptah_fk_order_parents", "CREATE TABLE ptah_fk_order_children")
+	assertBefore(t, sql, "CREATE UNIQUE INDEX IF NOT EXISTS uq_ptah_fk_order_parents_code_idx", "ALTER TABLE ptah_fk_order_children ADD CONSTRAINT")
+}
+
+func TestPlanner_GenerateMigrationAST_AddsReferencedUniqueConstraintBeforeNewTableFKs(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+	generated := referencedUniqueKeySchema()
+	diff := &types.SchemaDiff{
+		TablesAdded:      []string{"ptah_fk_order_children", "ptah_fk_order_parents"},
+		ConstraintsAdded: []string{"uq_ptah_fk_order_parents_code"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+			Name:      "uq_ptah_fk_order_parents_code",
+			TableName: "ptah_fk_order_parents",
+			Type:      "UNIQUE",
+			Columns:   []string{"code"},
+		}},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "ALTER TABLE ptah_fk_order_parents ADD CONSTRAINT uq_ptah_fk_order_parents_code", "ALTER TABLE ptah_fk_order_children ADD CONSTRAINT")
+}
+
+func dependencyOrderSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "PtahFKOrderTask", Name: "ptah_fk_order_tasks"},
+			{StructName: "PtahFKOrderProject", Name: "ptah_fk_order_projects"},
+			{StructName: "PtahFKOrderMembership", Name: "ptah_fk_order_memberships"},
+			{StructName: "PtahFKOrderAccount", Name: "ptah_fk_order_accounts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "PtahFKOrderAccount", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "PtahFKOrderProject", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderProject",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_projects_account",
+			},
+			{StructName: "PtahFKOrderMembership", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderMembership",
+				Name:           "account_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_accounts(id)",
+				ForeignKeyName: "fk_ptah_fk_order_memberships_account",
+			},
+			{StructName: "PtahFKOrderTask", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "project_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_projects(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_project",
+			},
+			{
+				StructName:     "PtahFKOrderTask",
+				Name:           "membership_id",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_memberships(id)",
+				ForeignKeyName: "fk_ptah_fk_order_tasks_membership",
+			},
+		},
+	}
+}
+
+func referencedUniqueKeySchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "PtahFKOrderChild", Name: "ptah_fk_order_children"},
+			{StructName: "PtahFKOrderParent", Name: "ptah_fk_order_parents"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "PtahFKOrderParent", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{StructName: "PtahFKOrderParent", Name: "code", Type: "VARCHAR(36)"},
+			{StructName: "PtahFKOrderChild", Name: "id", Type: "VARCHAR(36)", Primary: true},
+			{
+				StructName:     "PtahFKOrderChild",
+				Name:           "parent_code",
+				Type:           "VARCHAR(36)",
+				Foreign:        "ptah_fk_order_parents(code)",
+				ForeignKeyName: "fk_ptah_fk_order_children_parent_code",
+			},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "PtahFKOrderParent",
+			Name:       "uq_ptah_fk_order_parents_code_idx",
+			Fields:     []string{"code"},
+			Unique:     true,
+		}},
+	}
+}

--- a/migration/planner/dialects/postgres/postgres.go
+++ b/migration/planner/dialects/postgres/postgres.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/core/convert/fromschema"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/migration/internal/deporder"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
@@ -331,24 +332,25 @@ func quotePostgresIdentifier(name string) string {
 }
 
 func (p *Planner) addNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	tablesToAdd := createTableLookupMap(diff.TablesAdded)
+	orderedTables := deporder.TablesForCreate(generated, diff.TablesAdded)
 
-	result = p.addSchemaPreconditions(result, generated, tablesToAdd)
+	result = p.addSchemaPreconditions(result, orderedTables)
 
 	// Phase 1: Create tables without foreign key constraints
-	result = p.createTablesWithoutForeignKeys(result, generated, tablesToAdd)
-
-	// Phase 2: Add foreign key constraints via ALTER TABLE statements
-	result = p.addForeignKeyConstraints(result, generated, tablesToAdd)
+	result = p.createTablesWithoutForeignKeys(result, generated, orderedTables)
 
 	return result
 }
 
-func (p *Planner) addSchemaPreconditions(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
+func (p *Planner) addForeignKeyConstraintsForNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	return p.addForeignKeyConstraints(result, generated, deporder.TablesForCreate(generated, diff.TablesAdded))
+}
+
+func (p *Planner) addSchemaPreconditions(result []ast.Node, tables []goschema.Table) []ast.Node {
 	seen := make(map[string]struct{})
-	for _, table := range generated.Tables {
+	for _, table := range tables {
 		schema := strings.TrimSpace(table.Schema)
-		if schema == "" || !tablesToAdd[table.QualifiedName()] {
+		if schema == "" {
 			continue
 		}
 		if _, ok := seen[schema]; ok {
@@ -360,24 +362,11 @@ func (p *Planner) addSchemaPreconditions(result []ast.Node, generated *goschema.
 	return result
 }
 
-// createTableLookupMap creates a map for quick table lookup
-func createTableLookupMap(tableNames []string) map[string]bool {
-	tablesToAdd := make(map[string]bool)
-	for _, tableName := range tableNames {
-		tablesToAdd[tableName] = true
-	}
-	return tablesToAdd
-}
-
 // createTablesWithoutForeignKeys creates all tables without foreign key constraints
-func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
+func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *goschema.Database, tables []goschema.Table) []ast.Node {
 	allFields := generated.Fields
 
-	for _, table := range generated.Tables {
-		if !tablesToAdd[table.QualifiedName()] {
-			continue
-		}
-
+	for _, table := range tables {
 		astNode := fromschema.FromTable(table, allFields, generated.Enums, DialectName)
 		for _, column := range astNode.Columns {
 			column.ForeignKey = nil
@@ -389,12 +378,8 @@ func (p *Planner) createTablesWithoutForeignKeys(result []ast.Node, generated *g
 }
 
 // addForeignKeyConstraints adds foreign key constraints via ALTER TABLE statements
-func (p *Planner) addForeignKeyConstraints(result []ast.Node, generated *goschema.Database, tablesToAdd map[string]bool) []ast.Node {
-	for _, table := range generated.Tables {
-		if !tablesToAdd[table.QualifiedName()] {
-			continue
-		}
-
+func (p *Planner) addForeignKeyConstraints(result []ast.Node, generated *goschema.Database, tables []goschema.Table) []ast.Node {
+	for _, table := range tables {
 		result = p.addRegularForeignKeys(result, generated, table)
 		result = p.addSelfReferencingForeignKeys(result, generated, table)
 	}
@@ -891,8 +876,8 @@ func stringSet(values []string) map[string]struct{} {
 	return set
 }
 
-func (p *Planner) removeTables(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
-	for _, tableName := range diff.TablesRemoved {
+func (p *Planner) removeTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, tableName := range deporder.TableDropOrder(diff.TablesRemoved, generated) {
 		dropTableNode := ast.NewDropTable(tableName).
 			SetIfExists().
 			SetCascade().
@@ -1032,9 +1017,8 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	result = p.addForeignKeyConstraintsForModifiedTables(result, diff, generated)
 
 	// 6.6. Add and modify views, materialized views, and triggers after their tables/functions exist.
-	result = p.addNewViews(result, diff, generated)
+	result = p.addNewViewLikeObjects(result, diff, generated)
 	result = p.modifyExistingViews(result, diff, generated)
-	result = p.addNewMaterializedViews(result, diff, generated)
 	result = p.modifyExistingMaterializedViews(result, diff, generated)
 	result = p.addNewTriggers(result, diff, generated)
 	result = p.modifyExistingTriggers(result, diff, generated)
@@ -1058,6 +1042,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	// 9. Add RLS policies (must be done after RLS is enabled and columns exist)
 	if p.capabilities().Has(capability.RowLevelSecurity) {
 		result = p.addNewRLSPolicies(result, diff, generated)
+		result = p.modifyExistingRLSPolicies(result, diff, generated)
 	}
 
 	// 9.5. Add role privilege grants after roles and target objects exist.
@@ -1070,6 +1055,10 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 
 	// 10.5. Add new constraints (must be done after tables and columns exist)
 	result = p.addNewConstraints(result, diff, generated)
+
+	// 10.6. Add field-level foreign keys for new tables after referenced
+	// unique indexes and constraints have been created.
+	result = p.addForeignKeyConstraintsForNewTables(result, diff, generated)
 
 	// 11. Remove indexes (safe operations)
 	result = p.removeIndexes(result, diff)
@@ -1096,7 +1085,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	result = p.removeViews(result, diff)
 
 	// 13. Remove tables (dangerous!)
-	result = p.removeTables(result, diff)
+	result = p.removeTables(result, diff, generated)
 
 	// 13. Remove functions (must be done after removing policies that might use them)
 	result = p.removeFunctions(result, diff)
@@ -1337,15 +1326,8 @@ func (p *Planner) removeExtensions(result []ast.Node, diff *types.SchemaDiff) []
 }
 
 func (p *Planner) addNewFunctions(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	for _, functionName := range diff.FunctionsAdded {
-		// Find the function definition
-		for _, fn := range generated.Functions {
-			if fn.Name == functionName {
-				functionNode := fromschema.FromFunction(fn)
-				result = append(result, functionNode)
-				break
-			}
-		}
+	for _, fn := range deporder.FunctionsForCreate(generated, diff.FunctionsAdded) {
+		result = append(result, fromschema.FromFunction(fn))
 	}
 	return result
 }
@@ -1389,9 +1371,27 @@ func (p *Planner) removeFunctions(result []ast.Node, diff *types.SchemaDiff) []a
 	return result
 }
 
-func (p *Planner) addNewViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+func (p *Planner) addNewViewLikeObjects(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	objects := make([]deporder.ViewLike, 0, len(diff.ViewsAdded)+len(diff.MaterializedViewsAdded))
 	for _, viewName := range diff.ViewsAdded {
 		if view := findView(generated.Views, viewName); view != nil {
+			objects = append(objects, deporder.ViewLike{Name: view.Name, Body: view.Body})
+		}
+	}
+	for _, viewName := range diff.MaterializedViewsAdded {
+		if view := findMaterializedView(generated.MaterializedViews, viewName); view != nil {
+			objects = append(objects, deporder.ViewLike{Name: view.Name, Body: view.Body, Materialized: true})
+		}
+	}
+
+	for _, object := range deporder.ViewLikesForCreate(objects) {
+		if object.Materialized {
+			if view := findMaterializedView(generated.MaterializedViews, object.Name); view != nil {
+				result = append(result, fromschema.FromMaterializedView(*view))
+			}
+			continue
+		}
+		if view := findView(generated.Views, object.Name); view != nil {
 			result = append(result, fromschema.FromView(*view))
 		}
 	}
@@ -1410,15 +1410,6 @@ func (p *Planner) modifyExistingViews(result []ast.Node, diff *types.SchemaDiff,
 func (p *Planner) removeViews(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	for _, viewName := range diff.ViewsRemoved {
 		result = append(result, ast.NewDropView(viewName).SetIfExists().SetCascade())
-	}
-	return result
-}
-
-func (p *Planner) addNewMaterializedViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	for _, viewName := range diff.MaterializedViewsAdded {
-		if view := findMaterializedView(generated.MaterializedViews, viewName); view != nil {
-			result = append(result, fromschema.FromMaterializedView(*view))
-		}
 	}
 	return result
 }
@@ -1496,6 +1487,15 @@ func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *go
 	return nil
 }
 
+func findRLSPolicy(policies []goschema.RLSPolicy, tableName, policyName string) *goschema.RLSPolicy {
+	for i := range policies {
+		if policies[i].Table == tableName && policies[i].Name == policyName {
+			return &policies[i]
+		}
+	}
+	return nil
+}
+
 func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	// Create a set of tables that need RLS enabled
 	tablesNeedingRLS := make(map[string]bool)
@@ -1551,6 +1551,25 @@ func (p *Planner) addNewRLSPolicies(result []ast.Node, diff *types.SchemaDiff, g
 	return result
 }
 
+func (p *Planner) modifyExistingRLSPolicies(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	for _, policyDiff := range diff.RLSPoliciesModified {
+		if policy := findRLSPolicy(generated.RLSPolicies, policyDiff.TableName, policyDiff.PolicyName); policy != nil {
+			policyNode := fromschema.FromRLSPolicy(*policy).SetReplace()
+			policyNode.SetComment(fmt.Sprintf("Modify RLS policy %s on table %s: %s",
+				policyDiff.PolicyName,
+				policyDiff.TableName,
+				summarizeRLSChanges(policyDiff),
+			))
+			result = append(result, policyNode)
+		}
+	}
+	return result
+}
+
+func summarizeRLSChanges(policyDiff types.RLSPolicyDiff) string {
+	return strings.Join(slices.Sorted(maps.Keys(policyDiff.Changes)), ", ")
+}
+
 func (p *Planner) removeRLSPolicies(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	for _, policyRef := range diff.RLSPoliciesRemoved {
 		// Now we have both policy name and table name, so we can generate proper DROP POLICY statements
@@ -1595,6 +1614,33 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		structToTable[t.StructName] = t.QualifiedName()
 	}
 
+	state := newConstraintPlanState(diff)
+
+	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
+	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
+	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, nonForeignKeyConstraints)
+	result = p.addForeignKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
+	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, foreignKeyConstraints)
+	return result
+}
+
+type constraintKindFilter int
+
+const (
+	nonForeignKeyConstraints constraintKindFilter = iota
+	foreignKeyConstraints
+)
+
+type constraintPlanState struct {
+	removedNames       map[string]struct{}
+	removalByTableName map[string]types.ConstraintRemovalInfo
+	removalsByName     map[string][]types.ConstraintRemovalInfo
+	addedHostsByName   map[string]map[string]struct{}
+	handled            map[string]struct{}
+	droppedForModify   map[string]struct{}
+}
+
+func newConstraintPlanState(diff *types.SchemaDiff) constraintPlanState {
 	// A constraint name present in BOTH ConstraintsAdded and ConstraintsRemoved
 	// is a modification (the comparator expresses a changed constraint as
 	// remove + add of the same name — e.g. an on_delete change on a field-level
@@ -1670,27 +1716,31 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		hosts[add.TableName] = struct{}{}
 	}
 
-	handled := make(map[string]struct{})
-	droppedForModify := make(map[string]struct{})
-	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
-	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, removalByTableName, handled, droppedForModify)
-	for _, add := range diff.ConstraintsAddedWithTables {
-		if add.Type != "FOREIGN KEY" || add.TableName == "" {
-			continue
-		}
-		// Only emit the DROP-before-ADD when this exact host's FK is being
-		// modified (its (table, name) is in the removal set). A pure-add host
-		// gets no phantom drop.
-		if _, modified := removalByTableName[add.TableName+"."+add.Name]; modified {
-			result = p.emitModifyDrop(result, add, droppedForModify)
-		}
-		result = append(result, p.foreignKeyAdditionNode(add))
-		handled[add.Name] = struct{}{}
+	return constraintPlanState{
+		removedNames:       removedNames,
+		removalByTableName: removalByTableName,
+		removalsByName:     removalsByName,
+		addedHostsByName:   addedHostsByName,
+		handled:            make(map[string]struct{}),
+		droppedForModify:   make(map[string]struct{}),
 	}
+}
 
+func (p *Planner) addNamedConstraintsByKind(
+	result []ast.Node,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	structToTable map[string]string,
+	state constraintPlanState,
+	kind constraintKindFilter,
+) []ast.Node {
+	wantForeignKey := kind == foreignKeyConstraints
 	for _, constraintName := range diff.ConstraintsAdded {
 		// Already emitted via the table-qualified FK path above.
-		if _, done := handled[constraintName]; done {
+		if _, done := state.handled[constraintName]; done {
+			continue
+		}
+		if p.constraintNameIsForeignKey(constraintName, generated, structToTable) != wantForeignKey {
 			continue
 		}
 
@@ -1698,8 +1748,14 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		// scoped to the constraint's concrete host table when the comparator
 		// recorded it (issue #199) — never a name-only resolution that could drop
 		// a same-named constraint on the wrong table.
-		if _, modified := removedNames[constraintName]; modified {
-			result = p.emitModifyDropForName(result, constraintName, removalsByName, addedHostsByName[constraintName], droppedForModify)
+		if _, modified := state.removedNames[constraintName]; modified {
+			result = p.emitModifyDropForName(
+				result,
+				constraintName,
+				state.removalsByName,
+				state.addedHostsByName[constraintName],
+				state.droppedForModify,
+			)
 		}
 
 		// Resolve the ADD CONSTRAINT node, in precedence order:
@@ -1718,6 +1774,48 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 		}
 	}
 	return result
+}
+
+func (p *Planner) addForeignKeyConstraintsWithTables(
+	result []ast.Node,
+	additions []types.ConstraintAdditionInfo,
+	state constraintPlanState,
+) []ast.Node {
+	for _, add := range additions {
+		if add.Type != "FOREIGN KEY" || add.TableName == "" {
+			continue
+		}
+		// Only emit the DROP-before-ADD when this exact host's FK is being
+		// modified (its (table, name) is in the removal set). A pure-add host
+		// gets no phantom drop.
+		if _, modified := state.removalByTableName[add.TableName+"."+add.Name]; modified {
+			result = p.emitModifyDrop(result, add, state.droppedForModify)
+		}
+		result = append(result, p.foreignKeyAdditionNode(add))
+		state.handled[add.Name] = struct{}{}
+	}
+	return result
+}
+
+func (p *Planner) constraintNameIsForeignKey(constraintName string, generated *goschema.Database, structToTable map[string]string) bool {
+	for _, constraint := range generated.Constraints {
+		if constraint.Name == constraintName {
+			return strings.EqualFold(constraint.Type, "FOREIGN KEY")
+		}
+	}
+	for _, field := range generated.Fields {
+		if field.Foreign == "" {
+			continue
+		}
+		tableName := structToTable[field.StructName]
+		if tableName == "" {
+			tableName = field.StructName
+		}
+		if foreignKeyName(unqualifiedTableName(tableName), field) == constraintName {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Planner) addCheckAndUniqueConstraintsWithTables(

--- a/migration/planner/dialects/postgres/schema_objects_test.go
+++ b/migration/planner/dialects/postgres/schema_objects_test.go
@@ -1,6 +1,7 @@
 package postgres_test
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -108,4 +109,108 @@ func TestPlanner_GenerateMigrationAST_MaterializedViewRefreshStrategyDoesNotAuto
 	sql = legacyRenderedSQL(sql)
 	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW user_stats AS")
 	c.Assert(sql, qt.Not(qt.Contains), "REFRESH MATERIALIZED VIEW CONCURRENTLY")
+}
+
+func TestPlanner_GenerateMigrationAST_OrdersFunctionsByDependencies(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Functions: []goschema.Function{
+			{
+				Name:       "a_child",
+				Parameters: "",
+				Returns:    "INTEGER",
+				Language:   "sql",
+				Body:       "SELECT z_parent()",
+			},
+			{
+				Name:       "z_parent",
+				Parameters: "",
+				Returns:    "INTEGER",
+				Language:   "sql",
+				Body:       "SELECT 1",
+			},
+		},
+		FunctionDependencies: map[string][]string{
+			"a_child": {"z_parent"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		FunctionsAdded: []string{"a_child", "z_parent"},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "CREATE OR REPLACE FUNCTION z_parent()", "CREATE OR REPLACE FUNCTION a_child()")
+}
+
+func TestPlanner_GenerateMigrationAST_OrdersViewLikeObjectsByDependencies(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "a_report",
+			Body: "SELECT id FROM z_base",
+		}},
+		MaterializedViews: []goschema.MaterializedView{{
+			Name: "z_base",
+			Body: "SELECT id FROM users",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsAdded:             []string{"a_report"},
+		MaterializedViewsAdded: []string{"z_base"},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "CREATE MATERIALIZED VIEW z_base AS", "CREATE VIEW a_report AS")
+}
+
+func TestPlanner_GenerateMigrationAST_ModifiesRLSPolicies(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "tenant_isolation",
+			Table:           "accounts",
+			PolicyFor:       "SELECT",
+			ToRoles:         "app_user",
+			UsingExpression: "tenant_id = current_setting('app.tenant_id')::uuid",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{
+		RLSPoliciesModified: []difftypes.RLSPolicyDiff{{
+			PolicyName: "tenant_isolation",
+			TableName:  "accounts",
+			Changes:    map[string]string{"using_expression": "old -> new"},
+		}},
+	}
+
+	nodes := planner.GenerateMigrationAST(diff, generated)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	c.Assert(sql, qt.Contains, "DROP POLICY IF EXISTS tenant_isolation ON accounts;")
+	c.Assert(sql, qt.Contains, "CREATE POLICY tenant_isolation ON accounts FOR SELECT TO app_user")
+}
+
+func assertBefore(t *testing.T, sql, earlier, later string) {
+	t.Helper()
+	c := qt.New(t)
+	earlierIndex := strings.Index(sql, earlier)
+	laterIndex := strings.Index(sql, later)
+	c.Assert(earlierIndex, qt.Not(qt.Equals), -1, qt.Commentf("missing %q in:\n%s", earlier, sql))
+	c.Assert(laterIndex, qt.Not(qt.Equals), -1, qt.Commentf("missing %q in:\n%s", later, sql))
+	c.Assert(earlierIndex < laterIndex, qt.IsTrue, qt.Commentf("expected %q before %q in:\n%s", earlier, later, sql))
 }


### PR DESCRIPTION
## Summary
- add a shared migration/internal/deporder helper for stable dependency and reverse-dependency ordering
- make PostgreSQL and MySQL-family planners order table creates/drops, functions, view-like objects, and deferred FK phases from dependency data
- cover FK chains/diamonds, referenced unique key prerequisites, function/view ordering, modified RLS policies, and document planner ordering semantics

Fixes #451.

## Validation
- env GOWORK=off go test ./migration/internal/deporder ./migration/planner/dialects/postgres ./migration/planner/dialects/mysql ./migration/generator -count=1
- env GOWORK=off go test ./... -count=1
- env GOWORK=off golangci-lint run ./...
- env GOWORK=off go tool qtlint ./...
- env GOWORK=off ./scripts/check-public-api.sh
- env GOWORK=off ./scripts/check-public-api-snapshot.sh
- git diff --check

## Self-review
- addressed independent review findings for FK-before-unique-key ordering and schema-qualified view references
- reworked constraint planning to keep PK/unique/check prerequisites before FK constraints
- kept docs explicit about graph ordering vs heuristic/phase ordering