### PR TITLE
Clarify Atlas implementation independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,21 @@ The name **Ptah** is also an acronym:
 
 ## Independent Atlas-Compatible Implementation
 
-Ptah is an independent implementation. This repository does **not** vendor,
-copy, link, or execute Atlas source code, and Ptah's runtime behavior is
-implemented in Ptah code.
+**Ptah does not use Atlas source code.** Ptah is a fully independent
+implementation: this repository does **not** vendor, copy, link, embed, or
+execute Atlas code, and Ptah's runtime behavior is implemented in Ptah itself.
 
-Atlas compatibility work is based on Atlas OSS command interfaces, file formats,
-observable behavior, and test assets. Test assets that originate from Atlas are
-kept outside this repository in
-[`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance),
-where they are used to measure compatibility against Ptah without mixing Atlas
-source or fixture corpus into the main Ptah codebase.
+Atlas compatibility work is based on publicly observable compatibility inputs:
+Atlas OSS command interfaces, file formats, behavior, and test assets. Test
+assets that originate from Atlas are intentionally kept outside this repository
+in
+[`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance).
+That repository measures Ptah against the Atlas fixture corpus without mixing
+Atlas source or Atlas-originated test assets into the main Ptah codebase.
+
+This keeps the Ptah repository license-clean: Ptah stays an independent MIT
+implementation, while borrowed Atlas OSS test assets remain isolated in the
+separate conformance repository with their own provenance boundary.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- make the README statement about Atlas independence explicit and prominent
- document that Ptah does not vendor, copy, link, embed, or execute Atlas code
- clarify that Atlas-originated test assets stay isolated in ptah-atlas-conformance

## Validation
- git diff --check
- rg -n "github.com/ariga|github.com/ent|ariga.io|entgo.io|Atlas Authors|Copyright .*Atlas" -S .