### PR TITLE
Add SQL Server upsert rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1446,6 +1446,10 @@ make integration-test-sqlserver
 
 ### Using the AST API
 
+The AST API covers schema DDL and selected reusable DML nodes. SQL Server
+upserts can be built with `ast.UpsertNode` and rendered as `MERGE`; see
+[DML Upsert AST](docs/dml_upsert.md).
+
 ```go
 package main
 

--- a/core/ast/ast.go
+++ b/core/ast/ast.go
@@ -81,6 +81,8 @@ type Visitor interface {
 	// VisitRawSQL renders a literal SQL fragment verbatim. Use sparingly —
 	// reach for structured nodes first.
 	VisitRawSQL(*RawSQLNode) error
+	// VisitUpsert renders a dialect-independent upsert statement.
+	VisitUpsert(*UpsertNode) error
 }
 
 // DefaultValue represents different types of default values for table columns.

--- a/core/ast/ast_test.go
+++ b/core/ast/ast_test.go
@@ -66,6 +66,11 @@ func TestVisitorInterface_HappyPath(t *testing.T) {
 			node:         &ast.CommentNode{Text: "This is a comment"},
 			expectedCall: "Comment:This is a comment",
 		},
+		{
+			name:         "UpsertNode",
+			node:         &ast.UpsertNode{Table: "users"},
+			expectedCall: "Upsert:users",
+		},
 	}
 
 	for _, tt := range tests {
@@ -126,6 +131,10 @@ func TestVisitorInterface_ErrorPath(t *testing.T) {
 		{
 			name: "CommentNode",
 			node: &ast.CommentNode{Text: "This is a comment"},
+		},
+		{
+			name: "UpsertNode",
+			node: &ast.UpsertNode{Table: "users"},
 		},
 	}
 

--- a/core/ast/dml.go
+++ b/core/ast/dml.go
@@ -1,0 +1,86 @@
+package ast
+
+import "slices"
+
+// UpsertAssignment describes one column assignment in the UPDATE arm of an
+// upsert statement. Expression is a SQL expression fragment, typically a
+// bind placeholder or a reference to the source row.
+type UpsertAssignment struct {
+	Column     string
+	Expression string
+}
+
+// UpsertNode represents a dialect-independent row upsert operation.
+//
+// InsertColumns and Values must have the same length. MatchColumns identifies
+// the key columns used to decide whether the source row matches an existing
+// target row. UpdateAssignments controls the update arm. The optional predicate
+// fields are SQL expression fragments appended to the dialect-specific update
+// and insert conditions.
+type UpsertNode struct {
+	Table             string
+	InsertColumns     []string
+	Values            []string
+	MatchColumns      []string
+	UpdateAssignments []UpsertAssignment
+	UpdatePredicate   string
+	InsertPredicate   string
+	Comment           string
+}
+
+// NewUpsert creates an upsert node for table.
+func NewUpsert(table string) *UpsertNode {
+	return &UpsertNode{Table: table}
+}
+
+// SetInsert sets the columns and value expressions used by the INSERT arm.
+func (n *UpsertNode) SetInsert(columns, values []string) *UpsertNode {
+	n.InsertColumns = slices.Clone(columns)
+	n.Values = slices.Clone(values)
+	return n
+}
+
+// AddInsertValue appends one INSERT column/value pair.
+func (n *UpsertNode) AddInsertValue(column, value string) *UpsertNode {
+	n.InsertColumns = append(n.InsertColumns, column)
+	n.Values = append(n.Values, value)
+	return n
+}
+
+// SetMatchColumns sets the key columns used by the upsert match condition.
+func (n *UpsertNode) SetMatchColumns(columns ...string) *UpsertNode {
+	n.MatchColumns = slices.Clone(columns)
+	return n
+}
+
+// AddUpdateAssignment appends one UPDATE assignment.
+func (n *UpsertNode) AddUpdateAssignment(column, expression string) *UpsertNode {
+	n.UpdateAssignments = append(n.UpdateAssignments, UpsertAssignment{
+		Column:     column,
+		Expression: expression,
+	})
+	return n
+}
+
+// SetUpdatePredicate adds a predicate to the update arm.
+func (n *UpsertNode) SetUpdatePredicate(predicate string) *UpsertNode {
+	n.UpdatePredicate = predicate
+	return n
+}
+
+// SetInsertPredicate adds a predicate to the insert arm.
+func (n *UpsertNode) SetInsertPredicate(predicate string) *UpsertNode {
+	n.InsertPredicate = predicate
+	return n
+}
+
+// SetComment sets a SQL comment emitted before the rendered upsert.
+func (n *UpsertNode) SetComment(comment string) *UpsertNode {
+	n.Comment = comment
+	return n
+}
+
+// Accept implements the Node interface for UpsertNode.
+func (n *UpsertNode) Accept(visitor Visitor) error {
+	return visitor.VisitUpsert(n)
+}

--- a/core/ast/dml_test.go
+++ b/core/ast/dml_test.go
@@ -1,0 +1,53 @@
+package ast_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+)
+
+func TestUpsertNodeBuilder(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewUpsert("dbo.users").
+		AddInsertValue("id", "@p1").
+		AddInsertValue("email", "@p2").
+		SetMatchColumns("id").
+		AddUpdateAssignment("email", "src.[email]").
+		SetUpdatePredicate("target.[deleted_at] IS NULL").
+		SetInsertPredicate("@allow_insert = 1").
+		SetComment("upsert user")
+
+	c.Assert(node.Table, qt.Equals, "dbo.users")
+	c.Assert(node.InsertColumns, qt.DeepEquals, []string{"id", "email"})
+	c.Assert(node.Values, qt.DeepEquals, []string{"@p1", "@p2"})
+	c.Assert(node.MatchColumns, qt.DeepEquals, []string{"id"})
+	c.Assert(node.UpdateAssignments, qt.DeepEquals, []ast.UpsertAssignment{
+		{Column: "email", Expression: "src.[email]"},
+	})
+	c.Assert(node.UpdatePredicate, qt.Equals, "target.[deleted_at] IS NULL")
+	c.Assert(node.InsertPredicate, qt.Equals, "@allow_insert = 1")
+	c.Assert(node.Comment, qt.Equals, "upsert user")
+}
+
+func TestUpsertNodeBuilderCopiesInputSlices(t *testing.T) {
+	c := qt.New(t)
+
+	columns := []string{"id", "email"}
+	values := []string{"@p1", "@p2"}
+	matchColumns := []string{"id"}
+
+	node := ast.NewUpsert("dbo.users").
+		SetInsert(columns, values).
+		SetMatchColumns(matchColumns...)
+
+	columns[0] = "mutated_column"
+	values[0] = "mutated_value"
+	matchColumns[0] = "mutated_match"
+
+	c.Assert(node.InsertColumns, qt.DeepEquals, []string{"id", "email"})
+	c.Assert(node.Values, qt.DeepEquals, []string{"@p1", "@p2"})
+	c.Assert(node.MatchColumns, qt.DeepEquals, []string{"id"})
+}

--- a/core/ast/doc.go
+++ b/core/ast/doc.go
@@ -1,9 +1,9 @@
-// Package ast provides an Abstract Syntax Tree (AST) representation for SQL DDL statements.
+// Package ast provides an Abstract Syntax Tree (AST) representation for SQL statements.
 //
 // This package is a core component of the Ptah schema management tool, implementing
 // the visitor pattern to enable dialect-specific SQL generation from a common AST
-// representation. It supports CREATE TABLE, ALTER TABLE, CREATE INDEX, and other
-// DDL operations across multiple database platforms.
+// representation. It supports CREATE TABLE, ALTER TABLE, CREATE INDEX, generic
+// upsert nodes, and other operations across multiple database platforms.
 //
 // # Architecture
 //
@@ -25,6 +25,7 @@
 //   - IndexNode: Represents CREATE INDEX statements
 //   - EnumNode: Represents CREATE TYPE ... AS ENUM statements (PostgreSQL)
 //   - CommentNode: Represents SQL comments
+//   - UpsertNode: Represents a dialect-independent row upsert operation
 //
 // # Visitor Pattern
 //
@@ -39,6 +40,7 @@
 //		VisitIndex(*IndexNode) error
 //		VisitEnum(*EnumNode) error
 //		VisitComment(*CommentNode) error
+//		VisitUpsert(*UpsertNode) error
 //	}
 //
 // # Usage Example

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -291,3 +291,11 @@ func (m *MockVisitor) VisitRawSQL(node *ast.RawSQLNode) error {
 	}
 	return nil
 }
+
+func (m *MockVisitor) VisitUpsert(node *ast.UpsertNode) error {
+	m.VisitedNodes = append(m.VisitedNodes, "Upsert:"+node.Table)
+	if m.ReturnError {
+		return errors.New("mock error")
+	}
+	return nil
+}

--- a/core/renderer/internal/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/internal/bufwriter"
 )
 
@@ -763,6 +764,10 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	}
 	r.w.WriteLinef("ALTER TABLE %s DROP INDEX %s;", node.Table, node.Name)
 	return nil
+}
+
+func (r *Renderer) VisitUpsert(_ *ast.UpsertNode) error {
+	return fmt.Errorf("%w: clickhouse: upsert rendering is not implemented", ptaherr.ErrUnsupportedFeature)
 }
 
 // VisitDropTable emits DROP TABLE [IF EXISTS] name. The SYNC modifier is

--- a/core/renderer/internal/dialects/mariadb/mariadb.go
+++ b/core/renderer/internal/dialects/mariadb/mariadb.go
@@ -50,6 +50,10 @@ func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 	return r.r.VisitAlterType(node)
 }
 
+func (r *Renderer) VisitUpsert(node *ast.UpsertNode) error {
+	return r.r.VisitUpsert(node)
+}
+
 func (r *Renderer) Dialect() string {
 	return r.r.Dialect()
 }

--- a/core/renderer/internal/dialects/mssql/mssql_test.go
+++ b/core/renderer/internal/dialects/mssql/mssql_test.go
@@ -92,6 +92,177 @@ func TestRenderer_MapsGenericIntegerTypes(t *testing.T) {
 	c.Assert(sql, qt.Contains, "  [legacy_id] INT NOT NULL\n")
 }
 
+func TestRenderer_UpsertUsesSQLServerMerge(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewUpsert("dbo.user").
+		SetInsert([]string{"id", "email", "updated_at"}, []string{"@p1", "@p2", "SYSUTCDATETIME()"}).
+		SetMatchColumns("id").
+		AddUpdateAssignment("email", "source.[email]").
+		AddUpdateAssignment("updated_at", "source.[updated_at]").
+		SetComment("upsert user")
+
+	sql, err := New().Render(node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, ""+
+		"-- upsert user\n"+
+		"MERGE INTO [dbo].[user] WITH (HOLDLOCK) AS target\n"+
+		"USING (VALUES (@p1, @p2, SYSUTCDATETIME())) AS source ([id], [email], [updated_at])\n"+
+		"ON target.[id] = source.[id]\n"+
+		"WHEN MATCHED THEN\n"+
+		"    UPDATE SET [email] = source.[email], [updated_at] = source.[updated_at]\n"+
+		"WHEN NOT MATCHED THEN\n"+
+		"    INSERT ([id], [email], [updated_at])\n"+
+		"    VALUES (source.[id], source.[email], source.[updated_at]);\n")
+}
+
+func TestRenderer_UpsertEscapesIdentifiersAndRendersPredicates(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewUpsert("tenant]db.order").
+		SetInsert([]string{"id", "tenant_id", "from"}, []string{"@p1", "@tenant", "@p2"}).
+		SetMatchColumns("id", "tenant_id").
+		SetUpdatePredicate("target.[deleted_at] IS NULL").
+		SetInsertPredicate("@allow_insert = 1").
+		AddUpdateAssignment("from", "source.[from]")
+
+	sql, err := New().Render(node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, ""+
+		"MERGE INTO [tenant]]db].[order] WITH (HOLDLOCK) AS target\n"+
+		"USING (VALUES (@p1, @tenant, @p2)) AS source ([id], [tenant_id], [from])\n"+
+		"ON target.[id] = source.[id] AND target.[tenant_id] = source.[tenant_id]\n"+
+		"WHEN MATCHED AND (target.[deleted_at] IS NULL) THEN\n"+
+		"    UPDATE SET [from] = source.[from]\n"+
+		"WHEN NOT MATCHED AND (@allow_insert = 1) THEN\n"+
+		"    INSERT ([id], [tenant_id], [from])\n"+
+		"    VALUES (source.[id], source.[tenant_id], source.[from]);\n")
+}
+
+func TestRenderer_UpsertSanitizesCommentLine(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewUpsert("users").
+		AddInsertValue("id", "@p1").
+		SetMatchColumns("id").
+		AddUpdateAssignment("id", "source.[id]").
+		SetComment("first line\nDROP TABLE users")
+
+	sql, err := New().Render(node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "-- first line DROP TABLE users\n")
+	c.Assert(sql, qt.Not(qt.Contains), "-- first line\nDROP TABLE users")
+}
+
+func TestRenderer_UpsertValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		node *ast.UpsertNode
+		err  string
+	}{
+		{
+			name: "nil node",
+			node: nil,
+			err:  "upsert node is nil",
+		},
+		{
+			name: "empty table",
+			node: ast.NewUpsert("").
+				AddInsertValue("id", "@p1").
+				SetMatchColumns("id").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: "upsert table is required",
+		},
+		{
+			name: "mismatched insert values",
+			node: ast.NewUpsert("users").
+				SetInsert([]string{"id"}, []string{"@p1", "@p2"}).
+				SetMatchColumns("id").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: `upsert insert columns and values length mismatch: 1 columns, 2 values`,
+		},
+		{
+			name: "empty insert column",
+			node: ast.NewUpsert("users").
+				AddInsertValue(" ", "@p1").
+				SetMatchColumns("id").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: "upsert insert column is empty",
+		},
+		{
+			name: "empty value expression",
+			node: ast.NewUpsert("users").
+				AddInsertValue("id", " ").
+				SetMatchColumns("id").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: "upsert value expression is empty",
+		},
+		{
+			name: "duplicate insert column",
+			node: ast.NewUpsert("users").
+				SetInsert([]string{"id", "[id]"}, []string{"@p1", "@p2"}).
+				SetMatchColumns("id").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: `upsert insert column "\[id\]" is duplicated`,
+		},
+		{
+			name: "empty match column",
+			node: ast.NewUpsert("users").
+				AddInsertValue("id", "@p1").
+				SetMatchColumns(" ").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: "upsert match column is empty",
+		},
+		{
+			name: "duplicate match column",
+			node: ast.NewUpsert("users").
+				AddInsertValue("id", "@p1").
+				SetMatchColumns("id", "[id]").
+				AddUpdateAssignment("id", "source.[id]"),
+			err: `upsert match column "\[id\]" is duplicated`,
+		},
+		{
+			name: "match column missing from insert columns",
+			node: ast.NewUpsert("users").
+				AddInsertValue("email", "@p1").
+				SetMatchColumns("id").
+				AddUpdateAssignment("email", "source.[email]"),
+			err: `upsert match column "id" must also be an insert column`,
+		},
+		{
+			name: "empty update expression",
+			node: ast.NewUpsert("users").
+				AddInsertValue("id", "@p1").
+				SetMatchColumns("id").
+				AddUpdateAssignment("email", " "),
+			err: "upsert update assignment expression is empty",
+		},
+		{
+			name: "duplicate update assignment column",
+			node: ast.NewUpsert("users").
+				AddInsertValue("id", "@p1").
+				SetMatchColumns("id").
+				AddUpdateAssignment("email", "source.[email]").
+				AddUpdateAssignment("[email]", "source.[email]"),
+			err: `upsert update assignment column "\[email\]" is duplicated`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql, err := New().Render(tt.node)
+
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(err, qt.ErrorMatches, tt.err)
+		})
+	}
+}
+
 func TestRenderer_IdentifierEscaping(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/internal/dialects/mssql/upsert.go
+++ b/core/renderer/internal/dialects/mssql/upsert.go
@@ -1,0 +1,158 @@
+package mssql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+)
+
+func (r *Renderer) VisitUpsert(node *ast.UpsertNode) error {
+	if err := validateUpsert(node); err != nil {
+		return err
+	}
+	if comment := renderUpsertComment(node.Comment); comment != "" {
+		r.w.WriteLinef("-- %s", comment)
+	}
+
+	r.w.WriteLinef("MERGE INTO %s WITH (HOLDLOCK) AS target", escapeQualifiedIdentifier(node.Table))
+	r.w.WriteLinef(
+		"USING (VALUES (%s)) AS source (%s)",
+		strings.Join(trimmedList(node.Values), ", "),
+		strings.Join(escapeIdentifierList(node.InsertColumns), ", "),
+	)
+	r.w.WriteLinef("ON %s", renderUpsertMatch(node))
+	r.w.WriteLinef("WHEN MATCHED%s THEN", renderUpsertPredicate(node.UpdatePredicate))
+	r.w.WriteLinef("    UPDATE SET %s", strings.Join(renderUpsertAssignments(node.UpdateAssignments), ", "))
+	r.w.WriteLinef("WHEN NOT MATCHED%s THEN", renderUpsertPredicate(node.InsertPredicate))
+	r.w.WriteLinef("    INSERT (%s)", strings.Join(escapeIdentifierList(node.InsertColumns), ", "))
+	r.w.WriteLinef("    VALUES (%s);", strings.Join(renderUpsertSourceValues(node.InsertColumns), ", "))
+	return nil
+}
+
+func validateUpsert(node *ast.UpsertNode) error {
+	if node == nil {
+		return fmt.Errorf("upsert node is nil")
+	}
+	if strings.TrimSpace(node.Table) == "" {
+		return fmt.Errorf("upsert table is required")
+	}
+	if len(node.InsertColumns) == 0 {
+		return fmt.Errorf("upsert insert columns are required")
+	}
+	if len(node.InsertColumns) != len(node.Values) {
+		return fmt.Errorf("upsert insert columns and values length mismatch: %d columns, %d values",
+			len(node.InsertColumns), len(node.Values))
+	}
+	if len(node.MatchColumns) == 0 {
+		return fmt.Errorf("upsert match columns are required")
+	}
+	if len(node.UpdateAssignments) == 0 {
+		return fmt.Errorf("upsert update assignments are required")
+	}
+	if err := validateUpsertColumns(node); err != nil {
+		return err
+	}
+	return validateUpsertAssignments(node.UpdateAssignments)
+}
+
+func validateUpsertColumns(node *ast.UpsertNode) error {
+	insertColumns := make(map[string]struct{}, len(node.InsertColumns))
+	for _, column := range node.InsertColumns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("upsert insert column is empty")
+		}
+		normalized := normalizedUpsertIdentifier(column)
+		if _, ok := insertColumns[normalized]; ok {
+			return fmt.Errorf("upsert insert column %q is duplicated", column)
+		}
+		insertColumns[normalized] = struct{}{}
+	}
+	for _, value := range node.Values {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("upsert value expression is empty")
+		}
+	}
+	matchColumns := make(map[string]struct{}, len(node.MatchColumns))
+	for _, column := range node.MatchColumns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("upsert match column is empty")
+		}
+		normalized := normalizedUpsertIdentifier(column)
+		if _, ok := matchColumns[normalized]; ok {
+			return fmt.Errorf("upsert match column %q is duplicated", column)
+		}
+		matchColumns[normalized] = struct{}{}
+		if _, ok := insertColumns[normalized]; !ok {
+			return fmt.Errorf("upsert match column %q must also be an insert column", column)
+		}
+	}
+	return nil
+}
+
+func validateUpsertAssignments(assignments []ast.UpsertAssignment) error {
+	updateColumns := make(map[string]struct{}, len(assignments))
+	for _, assignment := range assignments {
+		if strings.TrimSpace(assignment.Column) == "" {
+			return fmt.Errorf("upsert update assignment column is empty")
+		}
+		normalized := normalizedUpsertIdentifier(assignment.Column)
+		if _, ok := updateColumns[normalized]; ok {
+			return fmt.Errorf("upsert update assignment column %q is duplicated", assignment.Column)
+		}
+		updateColumns[normalized] = struct{}{}
+		if strings.TrimSpace(assignment.Expression) == "" {
+			return fmt.Errorf("upsert update assignment expression is empty")
+		}
+	}
+	return nil
+}
+
+func renderUpsertMatch(node *ast.UpsertNode) string {
+	parts := make([]string, 0, len(node.MatchColumns)+1)
+	for _, column := range node.MatchColumns {
+		escaped := escapeIdentifier(column)
+		parts = append(parts, "target."+escaped+" = source."+escaped)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func renderUpsertPredicate(predicate string) string {
+	if trimmed := strings.TrimSpace(predicate); trimmed != "" {
+		return " AND (" + trimmed + ")"
+	}
+	return ""
+}
+
+func renderUpsertComment(comment string) string {
+	withoutLineBreaks := strings.NewReplacer("\r", " ", "\n", " ").Replace(comment)
+	return strings.Join(strings.Fields(withoutLineBreaks), " ")
+}
+
+func normalizedUpsertIdentifier(identifier string) string {
+	return unquoteIdentifier(strings.TrimSpace(identifier))
+}
+
+func renderUpsertAssignments(assignments []ast.UpsertAssignment) []string {
+	rendered := make([]string, len(assignments))
+	for i, assignment := range assignments {
+		rendered[i] = escapeIdentifier(assignment.Column) + " = " + strings.TrimSpace(assignment.Expression)
+	}
+	return rendered
+}
+
+func renderUpsertSourceValues(columns []string) []string {
+	values := make([]string, len(columns))
+	for i, column := range columns {
+		values[i] = "source." + escapeIdentifier(column)
+	}
+	return values
+}
+
+func trimmedList(values []string) []string {
+	trimmed := make([]string, len(values))
+	for i, value := range values {
+		trimmed[i] = strings.TrimSpace(value)
+	}
+	return trimmed
+}

--- a/core/renderer/internal/dialects/mysql/mysql.go
+++ b/core/renderer/internal/dialects/mysql/mysql.go
@@ -50,6 +50,10 @@ func (r *Renderer) VisitAlterType(node *ast.AlterTypeNode) error {
 	return r.r.VisitAlterType(node)
 }
 
+func (r *Renderer) VisitUpsert(node *ast.UpsertNode) error {
+	return r.r.VisitUpsert(node)
+}
+
 func (r *Renderer) Dialect() string {
 	return r.r.Dialect()
 }

--- a/core/renderer/internal/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/internal/dialects/mysqllike/mysqllike.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/internal/bufwriter"
 )
 
@@ -262,6 +263,10 @@ func (r *Renderer) GetDialect() string {
 // GetOutput returns the current generated SQL output (alias for Output for compatibility)
 func (r *Renderer) GetOutput() string {
 	return r.Output()
+}
+
+func (r *Renderer) VisitUpsert(_ *ast.UpsertNode) error {
+	return fmt.Errorf("%w: %s: upsert rendering is not implemented", ptaherr.ErrUnsupportedFeature, r.dialect)
 }
 
 // VisitCreateTable renders MariaDB-specific CREATE TABLE statements

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -23,6 +23,10 @@ type Renderer struct {
 	w            bufwriter.Writer
 }
 
+func (r *Renderer) VisitUpsert(_ *ast.UpsertNode) error {
+	return unsupportedFeaturef("upsert rendering is not implemented for %s", r.dialect)
+}
+
 func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	// Build DROP INDEX statement for PostgreSQL
 	var parts []string

--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -163,6 +163,10 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	return nil
 }
 
+func (r *Renderer) VisitUpsert(_ *ast.UpsertNode) error {
+	return unsupportedFeaturef("upsert rendering is not implemented")
+}
+
 func (r *Renderer) VisitEnum(_ *ast.EnumNode) error {
 	return nil
 }

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -207,6 +207,28 @@ func TestRenderSQL_UnsupportedDialect(t *testing.T) {
 	c.Assert(renderErr.Dialect, qt.Equals, "oracle")
 }
 
+func TestRenderSQL_UpsertUnsupportedDialects(t *testing.T) {
+	node := ast.NewUpsert("users").
+		AddInsertValue("id", "?").
+		SetMatchColumns("id").
+		AddUpdateAssignment("id", "source.id")
+
+	for _, dialect := range []string{"postgres", "mysql", "mariadb", "sqlite", "clickhouse"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql, err := renderer.RenderSQL(dialect, node)
+
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			var renderErr *ptaherr.RenderError
+			c.Assert(err, qt.ErrorAs, &renderErr)
+			c.Assert(renderErr.Dialect, qt.Equals, dialect)
+			c.Assert(renderErr.Node, qt.Equals, node)
+		})
+	}
+}
+
 func TestRenderer_Interface(t *testing.T) {
 	// Test that all dialect renderers implement the RenderVisitor interface
 	dialects := []string{"postgresql", "mysql", "mariadb", "sqlserver"}

--- a/dbschema/sqlserver_live_test.go
+++ b/dbschema/sqlserver_live_test.go
@@ -11,7 +11,9 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -169,6 +171,56 @@ func TestSQLServerLiveDropAllTablesDropsForeignKeys(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(schema.Tables, qt.HasLen, 0)
 	c.Assert(sqlServerLiveTableExists(t, scopedConn, schemaName, "schema_migrations"), qt.IsFalse)
+}
+
+func TestSQLServerLiveRenderedUpsertMerge(t *testing.T) {
+	dbURL := os.Getenv("PTAH_SQLSERVER_TEST_URL")
+	if dbURL == "" {
+		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
+	}
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	schemaName := fmt.Sprintf("ptah_upsert_%d", time.Now().UnixNano())
+	_, err = conn.ExecContext(ctx, "EXEC('CREATE SCHEMA "+quoteSQLServerIdentifier(schemaName)+"')")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS "+quoteSQLServerIdentifier(schemaName)+".[users]")
+		_, _ = conn.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+quoteSQLServerIdentifier(schemaName))
+	}()
+
+	_, err = conn.ExecContext(ctx, `CREATE TABLE `+quoteSQLServerIdentifier(schemaName)+`.[users] (
+		[id] INT NOT NULL PRIMARY KEY,
+		[email] NVARCHAR(320) NOT NULL
+	);`)
+	c.Assert(err, qt.IsNil)
+
+	upsert := ast.NewUpsert(schemaName+".users").
+		SetInsert([]string{"id", "email"}, []string{"@p1", "@p2"}).
+		SetMatchColumns("id").
+		AddUpdateAssignment("email", "source.[email]")
+	upsertSQL, err := renderer.RenderSQL("sqlserver", upsert)
+	c.Assert(err, qt.IsNil)
+	c.Assert(upsertSQL, qt.Contains, "WITH (HOLDLOCK)")
+
+	_, err = conn.ExecContext(ctx, upsertSQL, 7, "first@example.com")
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, upsertSQL, 7, "second@example.com")
+	c.Assert(err, qt.IsNil)
+
+	var count int
+	var email string
+	err = conn.QueryRowContext(ctx,
+		`SELECT COUNT(*), MAX([email]) FROM `+quoteSQLServerIdentifier(schemaName)+`.[users] WHERE [id] = @p1`,
+		7,
+	).Scan(&count, &email)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+	c.Assert(email, qt.Equals, "second@example.com")
 }
 
 func TestSQLServerLiveComputedColumnZeroDiff(t *testing.T) {

--- a/docs/dml_upsert.md
+++ b/docs/dml_upsert.md
@@ -1,0 +1,75 @@
+# DML Upsert AST
+
+Ptah exposes a small dialect-independent DML AST for one-row upsert rendering.
+The first concrete renderer is SQL Server, where an `ast.UpsertNode` renders to
+`MERGE`.
+
+This API is separate from schema DDL parsing. Ptah's schema parser still treats
+DML statements such as `INSERT`, `UPDATE`, `DELETE`, and `MERGE` as
+schema-neutral migration content and skips them when building a schema AST.
+
+## Model
+
+`ast.UpsertNode` describes the portable intent of an upsert:
+
+- target table name;
+- insert columns and value expressions;
+- match columns used to compare `target` and `source`;
+- update assignments for the matched arm;
+- optional update and insert predicates;
+- optional SQL comment.
+
+The renderer escapes table and column identifiers. Value expressions,
+assignment expressions, and predicates are SQL fragments by design, so callers
+should pass bind placeholders or trusted builder output, not unsanitized user
+input.
+
+Match conditions are intentionally structured as column comparisons. Do not use
+target-only filters to decide whether a row exists; SQL Server documents that
+filtering target rows in the `MERGE` `ON` clause can produce incorrect results.
+Use `UpdatePredicate` and `InsertPredicate` for action-specific filtering, or
+include every key column in `MatchColumns`.
+
+## SQL Server Rendering
+
+SQL Server renders the node as `MERGE INTO ... USING (VALUES ...)`:
+
+```go
+node := ast.NewUpsert("dbo.users").
+    SetInsert(
+        []string{"id", "email", "updated_at"},
+        []string{"@p1", "@p2", "SYSUTCDATETIME()"},
+    ).
+    SetMatchColumns("id").
+    AddUpdateAssignment("email", "source.[email]").
+    AddUpdateAssignment("updated_at", "source.[updated_at]").
+    SetComment("upsert user")
+
+sql, err := renderer.RenderSQL("sqlserver", node)
+```
+
+The generated SQL is:
+
+```sql
+-- upsert user
+MERGE INTO [dbo].[users] WITH (HOLDLOCK) AS target
+USING (VALUES (@p1, @p2, SYSUTCDATETIME())) AS source ([id], [email], [updated_at])
+ON target.[id] = source.[id]
+WHEN MATCHED THEN
+    UPDATE SET [email] = source.[email], [updated_at] = source.[updated_at]
+WHEN NOT MATCHED THEN
+    INSERT ([id], [email], [updated_at])
+    VALUES (source.[id], source.[email], source.[updated_at]);
+```
+
+`WITH (HOLDLOCK)` is emitted by default for SQL Server upserts. SQL Server's
+`MERGE` concurrency behavior is different from separate `INSERT` and `UPDATE`
+statements, and `HOLDLOCK` gives the target table serializable locking
+semantics for the statement.
+
+## Unsupported Dialects
+
+Dialects without an implemented upsert renderer fail explicitly with
+`ptaherr.ErrUnsupportedFeature`. They do not emit comments or partial SQL,
+because DML rendering must not look successful when no mutation statement was
+generated.

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -50,9 +50,10 @@ CI runs two public API checks:
   non-command, non-example, non-fixture package that is importable from outside
   this module but not listed here.
 - `scripts/check-public-api-snapshot.sh` regenerates the `go doc -short`
-  exported-symbol snapshot for every package listed here and compares it with
-  `docs/public_api.snapshot`. Any exported surface change must update the
-  snapshot in the same reviewed change.
+  exported-symbol snapshot for every package listed here, expands public
+  interface method sets, and compares it with `docs/public_api.snapshot`.
+  Any exported surface change must update the snapshot in the same reviewed
+  change.
 
 After the first `v0.x` tag exists, add a released-baseline API compatibility
 check (`apidiff` or `gorelease`) for the stable package list. Until then, there

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -177,7 +177,180 @@ type SetSuperuserOperation struct{ ... }
 type StatementList struct{ ... }
 type TypeDefinition interface{ ... }
 type TypeOperation interface{ ... }
+type UpsertAssignment struct{ ... }
+type UpsertNode struct{ ... }
+    func NewUpsert(table string) *UpsertNode
 type Visitor interface{ ... }
+
+### github.com/stokaro/ptah/core/ast.AlterOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterOperation interface {
+    Node
+    // Has unexported methods.
+}
+    AlterOperation represents different types of operations that can be
+    performed in ALTER TABLE statements.
+
+    This interface extends the Node interface and includes a marker method to
+    ensure type safety. All ALTER operations must implement both the visitor
+    pattern and the marker method.
+
+
+### github.com/stokaro/ptah/core/ast.Node
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type Node interface {
+    // Accept implements the visitor pattern for rendering
+    Accept(visitor Visitor) error
+}
+    Node represents any SQL AST node that can be visited by a Visitor.
+
+    All AST nodes implement this interface to participate in the visitor
+    pattern. The Accept method allows visitors to traverse the AST and generate
+    dialect-specific SQL output.
+
+
+### github.com/stokaro/ptah/core/ast.RoleOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RoleOperation interface {
+    // GetOperationType returns a string identifier for the operation type
+    GetOperationType() string
+}
+    RoleOperation represents an operation that can be performed on a role during
+    ALTER ROLE.
+
+    This interface allows for different types of role modifications to be
+    represented in a type-safe manner. Each operation type implements this
+    interface to provide specific role modification behavior.
+
+
+### github.com/stokaro/ptah/core/ast.TypeDefinition
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type TypeDefinition interface {
+    Node
+    // Has unexported methods.
+}
+    TypeDefinition represents different types of type definitions that can be
+    used in CREATE TYPE statements.
+
+    This interface allows for various type definitions including enums,
+    composite types, domains, and ranges. Each implementation provides the
+    specific structure for its type.
+
+
+### github.com/stokaro/ptah/core/ast.TypeOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type TypeOperation interface {
+    Node
+    // Has unexported methods.
+}
+    TypeOperation represents different types of operations that can be performed
+    in ALTER TYPE statements.
+
+    This interface extends the Node interface and includes a marker method
+    to ensure type safety. All ALTER TYPE operations must implement both the
+    visitor pattern and the marker method.
+
+
+### github.com/stokaro/ptah/core/ast.Visitor
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type Visitor interface {
+    // VisitCreateTable renders a CREATE TABLE statement
+    VisitCreateTable(*CreateTableNode) error
+    // VisitCreateSchema renders a CREATE SCHEMA statement
+    VisitCreateSchema(*CreateSchemaNode) error
+    // VisitCreateDatabase renders a CREATE DATABASE statement
+    VisitCreateDatabase(*CreateDatabaseNode) error
+    // VisitAlterTable renders an ALTER TABLE statement
+    VisitAlterTable(*AlterTableNode) error
+    // VisitColumn renders a column definition (typically called from other visitors)
+    VisitColumn(*ColumnNode) error
+    // VisitConstraint renders a constraint definition (typically called from other visitors)
+    VisitConstraint(*ConstraintNode) error
+    // VisitIndex renders a CREATE INDEX statement
+    VisitIndex(*IndexNode) error
+    // VisitDropIndex renders a DROP INDEX statement
+    VisitDropIndex(*DropIndexNode) error
+    // VisitEnum renders an enum type definition (PostgreSQL-specific, legacy)
+    VisitEnum(*EnumNode) error
+    // VisitCreateType renders a CREATE TYPE statement with various type definitions
+    VisitCreateType(*CreateTypeNode) error
+    // VisitAlterType renders an ALTER TYPE statement with various operations
+    VisitAlterType(*AlterTypeNode) error
+    // VisitComment renders a SQL comment
+    VisitComment(*CommentNode) error
+    // VisitDropTable renders a DROP TABLE statement
+    VisitDropTable(*DropTableNode) error
+    // VisitDropType renders a DROP TYPE statement (PostgreSQL-specific)
+    VisitDropType(*DropTypeNode) error
+    // VisitExtension renders a CREATE EXTENSION statement (PostgreSQL-specific)
+    VisitExtension(*ExtensionNode) error
+    // VisitDropExtension renders a DROP EXTENSION statement (PostgreSQL-specific)
+    VisitDropExtension(*DropExtensionNode) error
+    // VisitCreateFunction renders a CREATE FUNCTION statement (PostgreSQL-specific)
+    VisitCreateFunction(*CreateFunctionNode) error
+    // VisitDropFunction renders a DROP FUNCTION statement (PostgreSQL-specific)
+    VisitDropFunction(*DropFunctionNode) error
+    // VisitCreateView renders a CREATE VIEW statement
+    VisitCreateView(*CreateViewNode) error
+    // VisitDropView renders a DROP VIEW statement
+    VisitDropView(*DropViewNode) error
+    // VisitCreateMaterializedView renders a CREATE MATERIALIZED VIEW statement
+    VisitCreateMaterializedView(*CreateMaterializedViewNode) error
+    // VisitDropMaterializedView renders a DROP MATERIALIZED VIEW statement
+    VisitDropMaterializedView(*DropMaterializedViewNode) error
+    // VisitRefreshMaterializedView renders a REFRESH MATERIALIZED VIEW statement
+    VisitRefreshMaterializedView(*RefreshMaterializedViewNode) error
+    // VisitCreateTrigger renders a CREATE TRIGGER statement
+    VisitCreateTrigger(*CreateTriggerNode) error
+    // VisitDropTrigger renders a DROP TRIGGER statement
+    VisitDropTrigger(*DropTriggerNode) error
+    // VisitCreatePolicy renders a CREATE POLICY statement for RLS (PostgreSQL-specific)
+    VisitCreatePolicy(*CreatePolicyNode) error
+    // VisitDropPolicy renders a DROP POLICY statement for RLS (PostgreSQL-specific)
+    VisitDropPolicy(*DropPolicyNode) error
+    // VisitAlterTableEnableRLS renders an ALTER TABLE ENABLE ROW LEVEL SECURITY statement (PostgreSQL-specific)
+    VisitAlterTableEnableRLS(*AlterTableEnableRLSNode) error
+    // VisitAlterTableDisableRLS renders an ALTER TABLE DISABLE ROW LEVEL SECURITY statement (PostgreSQL-specific)
+    VisitAlterTableDisableRLS(*AlterTableDisableRLSNode) error
+    // VisitCreateRole renders a CREATE ROLE statement (PostgreSQL-specific)
+    VisitCreateRole(*CreateRoleNode) error
+    // VisitDropRole renders a DROP ROLE statement (PostgreSQL-specific)
+    VisitDropRole(*DropRoleNode) error
+    // VisitAlterRole renders an ALTER ROLE statement (PostgreSQL-specific)
+    VisitAlterRole(*AlterRoleNode) error
+    // VisitGrantPrivilege renders a GRANT statement (PostgreSQL-specific)
+    VisitGrantPrivilege(*GrantPrivilegeNode) error
+    // VisitRevokePrivilege renders a REVOKE statement (PostgreSQL-specific)
+    VisitRevokePrivilege(*RevokePrivilegeNode) error
+    // VisitRawSQL renders a literal SQL fragment verbatim. Use sparingly —
+    // reach for structured nodes first.
+    VisitRawSQL(*RawSQLNode) error
+    // VisitUpsert renders a dialect-independent upsert statement.
+    VisitUpsert(*UpsertNode) error
+}
+    Visitor defines the interface for visiting AST nodes using the visitor
+    pattern.
+
+    The visitor pattern allows for dialect-specific rendering of SQL statements
+    without modifying the AST node structures. Each visitor method corresponds
+    to a specific node type and is responsible for generating the appropriate
+    SQL representation for that node.
+
+    Implementations of this interface should handle the rendering logic for
+    their specific database dialect (PostgreSQL, MySQL, MariaDB, etc.).
+
 
 ## github.com/stokaro/ptah/core/goschema
 
@@ -265,6 +438,40 @@ type RenderVisitor interface{ ... }
     func NewRenderer(dialect string) (RenderVisitor, error)
     func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (RenderVisitor, error)
 
+### github.com/stokaro/ptah/core/renderer.RenderVisitor
+
+package renderer // import "github.com/stokaro/ptah/core/renderer"
+
+type RenderVisitor interface {
+    ast.Visitor
+
+    // Dialect returns the database dialect this renderer targets.
+    Dialect() string
+
+    // Reset clears the internal output buffer.
+    Reset()
+
+    // Output returns the current generated SQL output.
+    Output() string
+
+    // Render renders an AST node to SQL and returns the result.
+    Render(node ast.Node) (string, error)
+
+    // GetDialect returns the database dialect.
+    GetDialect() string
+
+    // GetOutput returns the current generated SQL output.
+    GetOutput() string
+}
+    RenderVisitor defines the interface for rendering AST nodes to SQL
+    statements.
+
+    This interface extends ast.Visitor with methods for managing renderer state
+    and retrieving the generated SQL output.
+
+func NewRenderer(dialect string) (RenderVisitor, error)
+func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (RenderVisitor, error)
+
 ## github.com/stokaro/ptah/core/sqlutil
 
 func IsSQLServerGoBatchSeparatorAt(input string, start, end int) bool
@@ -305,6 +512,65 @@ type SchemaExecutor interface{ ... }
 type SchemaReader interface{ ... }
 type SchemaTransaction interface{ ... }
 type SchemaWriter interface{ ... }
+
+### github.com/stokaro/ptah/dbschema/types.SchemaExecutor
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type SchemaExecutor interface {
+    ExecuteSQL(ctx context.Context, sql string, args ...any) error
+    IsDryRun() bool
+}
+    SchemaExecutor executes SQL statements produced by schema operations.
+
+    ExecuteSQL accepts a context and an optional slice of arguments that are
+    bound as native driver parameters, mirroring database/sql's ExecContext.
+    Use placeholders (`?` or the dialect-native form such as `$1`/`$2`
+    for PostgreSQL) instead of interpolating values into the SQL string;
+    this prevents the SQL injection class of bugs that the no-args signature
+    used to invite (see issue #130). Identifiers (table/column names) cannot be
+    parameterized — route them through a validated escape helper instead.
+
+
+### github.com/stokaro/ptah/dbschema/types.SchemaReader
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type SchemaReader interface {
+    ReadSchema() (*DBSchema, error)
+}
+    SchemaReader interface for reading database schemas
+
+
+### github.com/stokaro/ptah/dbschema/types.SchemaTransaction
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type SchemaTransaction interface {
+    SchemaExecutor
+    Commit() error
+    Rollback() error
+}
+    SchemaTransaction executes schema changes inside a database transaction.
+
+    It deliberately owns transaction lifecycle instead of storing the active
+    transaction on the parent SchemaWriter. That keeps dialect writers
+    reentrant: concurrent callers may begin independent transactions without
+    racing over shared writer state.
+
+
+### github.com/stokaro/ptah/dbschema/types.SchemaWriter
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type SchemaWriter interface {
+    SchemaExecutor
+    DropAllTables() error
+    BeginTransaction(ctx context.Context) (SchemaTransaction, error)
+    SetDryRun(dryRun bool)
+}
+    SchemaWriter interface for writing schemas to databases.
+
 
 ## github.com/stokaro/ptah/migration/generator
 
@@ -407,6 +673,41 @@ type RevisionTableFormat string
     func ParseRevisionTableFormat(value string) (RevisionTableFormat, error)
 type StatementInterceptor interface{ ... }
 
+### github.com/stokaro/ptah/migration/migrator.MigrationProvider
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationProvider interface {
+    // Migrations provides a list of migrations sorted by version in ascending order
+    Migrations() []*Migration
+}
+    MigrationProvider provides a list of migrations
+
+
+### github.com/stokaro/ptah/migration/migrator.StatementInterceptor
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementInterceptor interface {
+    ValidateDirectives(directives map[string]string) error
+    ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (handled bool, err error)
+}
+    StatementInterceptor lets an external executor take over individual
+    migration statements — for example, routing ALTER TABLE statements through
+    an online-DDL tool (gh-ost, pt-online-schema-change) instead of executing
+    them on the migration connection.
+
+    ValidateDirectives is called once per migration, before any statement runs,
+    so a bad directive fails the migration cleanly with nothing applied instead
+    of surfacing only when the first affected statement is reached.
+
+    ExecuteStatement receives one statement (comments stripped) together
+    with the file-level directives of the migration it came from (see
+    ParseFileDirectives). It returns handled=true when it fully executed the
+    statement itself; on handled=false the migrator executes the statement
+    normally. A non-nil error aborts the migration.
+
+
 ## github.com/stokaro/ptah/migration/planner
 
 func GenerateSchemaDiffAST(diff *types.SchemaDiff, generated *goschema.Database, dialect string) ([]ast.Node, error)
@@ -428,6 +729,69 @@ type Planner interface{ ... }
     func GetPlanner(dialect string) (Planner, error)
     func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (Planner, error)
     func GetPlannerWithOptions(dialect string, opts Options) (Planner, error)
+
+### github.com/stokaro/ptah/migration/planner.Planner
+
+package planner // import "github.com/stokaro/ptah/migration/planner"
+
+type Planner interface {
+    GenerateMigrationAST(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node
+    GenerateMigrationASTChecked(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error)
+}
+    Planner defines the interface for database-specific migration planning.
+
+    Implementations of this interface are responsible for converting schema
+    differences into Abstract Syntax Tree (AST) nodes that represent the SQL
+    operations needed to migrate from the current database schema to the target
+    schema.
+
+    The interface is designed to be dialect-agnostic at the contract level while
+    allowing implementations to handle database-specific features, constraints,
+    and optimization strategies.
+
+    # Implementation Requirements
+
+    Implementations must:
+      - Generate AST nodes in dependency-aware order (e.g., create tables before
+        foreign keys)
+      - Handle dialect-specific data types and constraints appropriately
+      - Provide safe migration paths that minimize data loss risks
+      - Support rollback scenarios where applicable
+
+    # Parameters
+
+      - diff: Contains the differences between target and current schemas
+      - generated: The target schema derived from Go struct annotations
+
+    # Return Value
+
+    Returns a slice of AST nodes representing the SQL operations needed for
+    migration. The nodes are ordered to respect database dependencies and
+    constraints.
+
+    # Example Implementation Pattern
+
+        func (p *PostgresPlanner) GenerateMigrationASTChecked(
+            diff *types.SchemaDiff,
+            generated *goschema.Database,
+        ) ([]ast.Node, error) {
+            var nodes []ast.Node
+
+            // 1. Create enum types first (PostgreSQL-specific)
+            nodes = append(nodes, p.generateEnumCreations(diff, generated)...)
+
+            // 2. Create tables in dependency order
+            nodes = append(nodes, p.generateTableCreations(diff, generated)...)
+
+            // 3. Add indexes and constraints
+            nodes = append(nodes, p.generateIndexCreations(diff, generated)...)
+
+            return nodes, nil
+        }
+
+func GetPlanner(dialect string) (Planner, error)
+func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (Planner, error)
+func GetPlannerWithOptions(dialect string, opts Options) (Planner, error)
 
 ## github.com/stokaro/ptah/migration/risk
 

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -57,10 +57,9 @@ The SQL Server support is deliberately conservative:
 - Automatic column removal is rejected because SQL Server requires dependent
   constraints, defaults, and indexes to be dropped in the correct order first.
 - SQL Server metadata repair/baseline paths use SQL Server-compatible revision
-  table SQL, but Ptah does not yet expose a general DML/upsert AST. User-schema
-  `MERGE` generation is tracked separately in
-  [#457](https://github.com/stokaro/ptah/issues/457) and is outside the current
-  DDL renderer surface.
+  table SQL. User-schema upserts can be rendered through Ptah's reusable
+  DML upsert AST as SQL Server `MERGE`; see
+  [DML Upsert AST](dml_upsert.md).
 - View and trigger introspection records SQL Server's persisted definition text,
   but Ptah does not yet normalize it into body-only drift-safe definitions.
 - Index introspection covers key columns but does not yet preserve included

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -80,7 +80,7 @@ The system operates through four main layers:
 ### 2. Core Processing
 
 #### ast Package
-- **Purpose**: Provides database-agnostic AST representation for SQL DDL
+- **Purpose**: Provides database-agnostic AST representation for schema DDL and selected reusable SQL statement nodes
 - **Key Node Types**:
   - `CreateTableNode`: Table creation with columns and constraints
   - `AlterTableNode`: Table modifications and alterations
@@ -88,10 +88,11 @@ The system operates through four main layers:
   - `ConstraintNode`: Primary keys, foreign keys, unique constraints
   - `IndexNode`: Index creation statements
   - `EnumNode`: Enum type definitions
+  - `UpsertNode`: Reusable DML upsert intent rendered by supporting dialects
 - **Pattern**: Implements visitor pattern for dialect-specific rendering
 
 #### Internal Builder And Parser Helpers
-- **Purpose**: Repository-internal helpers for building and parsing SQL DDL AST nodes
+- **Purpose**: Repository-internal helpers for building and parsing AST nodes
 - **Boundary**: These packages are implementation details behind Go `internal/`
   boundaries; embedders should use the stable `core/ast`, `core/goschema`,
   `core/renderer`, and migration packages documented in
@@ -211,6 +212,14 @@ type ColumnNode struct {
     DataType     string
     Constraints  []ColumnConstraint
     DefaultValue *DefaultValue
+}
+
+type UpsertNode struct {
+    Table             string
+    InsertColumns     []string
+    Values            []string
+    MatchColumns      []string
+    UpdateAssignments []UpsertAssignment
 }
 ```
 

--- a/internal/examples/ast_demo/ast_example.go
+++ b/internal/examples/ast_demo/ast_example.go
@@ -299,6 +299,7 @@ func (a *SchemaAnalyzer) VisitRevokePrivilege(node *ast.RevokePrivilegeNode) err
 	return nil
 }
 func (a *SchemaAnalyzer) VisitRawSQL(node *ast.RawSQLNode) error { return nil }
+func (a *SchemaAnalyzer) VisitUpsert(node *ast.UpsertNode) error { return nil }
 
 // AuditTransformer adds audit columns to all tables
 type AuditTransformer struct{}

--- a/internal/parser/README.md
+++ b/internal/parser/README.md
@@ -49,7 +49,8 @@ The parser supports the following SQL DDL statements:
 
 ### Schema-neutral statements
 - DML and session-control statements such as `INSERT`, `UPDATE`, `DELETE`,
-  `SELECT`, `PRAGMA`, `SET`, `BEGIN`, `COMMIT`, and `ROLLBACK` are skipped.
+  `MERGE`, `SELECT`, `PRAGMA`, `SET`, `BEGIN`, `COMMIT`, and `ROLLBACK` are
+  skipped.
 
 These statements are intentionally not represented in the schema AST. They can
 appear in migration files alongside DDL, but they do not describe the database

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -127,7 +127,7 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("unsupported SQL statement: %s at position %d", keyword, p.current.Start)
-	case "ANALYZE", "BEGIN", "CALL", "COMMIT", "DELETE", "INSERT", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "SHOW", "UPDATE", "USE", "VACUUM", "WITH":
+	case "ANALYZE", "BEGIN", "CALL", "COMMIT", "DELETE", "INSERT", "MERGE", "PRAGMA", "REINDEX", "ROLLBACK", "SELECT", "SET", "SHOW", "UPDATE", "USE", "VACUUM", "WITH":
 		p.skipSchemaNeutralStatement()
 		return nil, nil
 	default:

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2405,6 +2405,11 @@ func TestParser_ParseSkipsSchemaNeutralStatements(t *testing.T) {
 
 	sql := `
 		INSERT INTO ignored_seed_data (id, name) VALUES (1, 'semi;colon');
+		MERGE INTO ignored_target AS target
+		USING (VALUES (1, 'seed')) AS source (id, name)
+		ON target.id = source.id
+		WHEN MATCHED THEN UPDATE SET name = source.name
+		WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name);
 		CREATE TABLE users (id INTEGER PRIMARY KEY);
 		PRAGMA foreign_keys = off;
 		SELECT * FROM users;

--- a/scripts/check-public-api-snapshot.sh
+++ b/scripts/check-public-api-snapshot.sh
@@ -18,9 +18,18 @@ grep -Eo '`github\.com/stokaro/ptah[^`]+`' docs/public_api.md |
 	sort -u >"$packages"
 
 while IFS= read -r package_path; do
+	doc="$(go doc -short "$package_path")"
 	printf '## %s\n\n' "$package_path" >>"$tmp"
-	go doc -short "$package_path" | sed 's/[[:space:]]*$//' >>"$tmp"
+	printf '%s\n' "$doc" | expand -t 4 | sed 's/[[:space:]]*$//' >>"$tmp"
 	printf '\n' >>"$tmp"
+
+	printf '%s\n' "$doc" |
+		sed -n -E 's/^type ([[:upper:]][[:alnum:]_]*) interface.*/\1/p' |
+		while IFS= read -r type_name; do
+			printf '### %s.%s\n\n' "$package_path" "$type_name" >>"$tmp"
+			go doc "$package_path.$type_name" | expand -t 4 | sed 's/[[:space:]]*$//' >>"$tmp"
+			printf '\n' >>"$tmp"
+		done
 done <"$packages"
 
 if [[ "$update" -eq 1 ]]; then


### PR DESCRIPTION
Closes #457

## Summary
- add a generic ast.UpsertNode / UpsertAssignment DML AST and visitor support
- render SQL Server upserts as MERGE WITH (HOLDLOCK), with escaped identifiers, structured match columns, validation, and predicate placement in WHEN arms
- return typed unsupported-feature errors for dialects without an upsert renderer
- keep MERGE schema-neutral in the parser and document the DML upsert API, public API surface, and SQL Server behavior
- expand the public API snapshot guard so public interface method changes are visible

## Verification
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache go test -count=1 ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache go test -count=1 ./core/ast ./core/renderer/internal/dialects/mssql ./core/renderer ./internal/parser ./dbschema
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-issue-457-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache scripts/check-public-api.sh
- env GOWORK=off GOCACHE=/private/tmp/ptah-issue-457-go-cache scripts/check-public-api-snapshot.sh
- git diff --check origin/master...HEAD

Note: sandboxed go test ./... was also run and failed only because dbschema tests could not bind 127.0.0.1:0 under the macOS sandbox; the same full command passed outside sandbox.