### PR TITLE
Harden Ptah Action publication path

### DIFF
--- a/.github/actions/ptah/install.sh
+++ b/.github/actions/ptah/install.sh
@@ -42,7 +42,7 @@ install_from_source() {
 		ref="master"
 	fi
 	printf 'No Ptah release asset found for %s; installing from source at %s.\n' "$version" "$ref" >&2
-	GOBIN="$install_dir" go install "github.com/stokaro/ptah/cmd/ptah@$ref"
+	GOPROXY=direct GOBIN="$install_dir" go install "github.com/stokaro/ptah/cmd/ptah@$ref"
 	chmod +x "$install_dir/ptah"
 	printf '%s\n' "$install_dir" >>"$GITHUB_PATH"
 	printf 'ptah-bin=%s\n' "$install_dir/ptah" >>"$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ capabilities include:
   Automatically generates `up` and `down` SQL migrations to bring the database in sync.
 
 - ✅ **Pull Request Migration Checks**
-  Provides an in-repository composite GitHub Action that comments generated
+  Provides a Marketplace GitHub Action that comments generated
   migration SQL, safety verdicts, and lint findings on pull requests.
 
 - 🚀 **Migration Execution**
@@ -936,11 +936,11 @@ permissions:
   checks: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 steps:
   - uses: actions/checkout@v7
-  - uses: stokaro/ptah/.github/actions/ptah@master
+  - uses: stokaro/ptah-action@v1
     with:
       dir: ./internal/models
       db-url: ${{ secrets.PTAH_DATABASE_URL }}

--- a/docs/github_action.md
+++ b/docs/github_action.md
@@ -1,16 +1,13 @@
 # Ptah GitHub Action
 
-Ptah ships a composite GitHub Action at `.github/actions/ptah`. The action
-generates a migration plan for a pull request, evaluates the safety verdict,
-optionally lints a migration directory, and updates one sticky pull request
-comment. It also writes a dedicated `Ptah destructive-change verdict` check run
-from the machine-readable safety report.
+Ptah ships a Marketplace GitHub Action as `stokaro/ptah-action@v1` and keeps
+the source composite action at `.github/actions/ptah`. The action generates a
+migration plan for a pull request, evaluates the safety verdict, optionally
+lints a migration directory, and updates one sticky pull request comment. It
+also writes a dedicated `Ptah destructive-change verdict` check run from the
+machine-readable safety report.
 
-Marketplace publication as `stokaro/ptah-action@v1` is tracked separately in
-[#463](https://github.com/stokaro/ptah/issues/463). Until that package is
-published, use the in-repository composite action path shown below.
-
-For local repository use:
+For repository use:
 
 ```yaml
 name: Ptah
@@ -22,7 +19,7 @@ permissions:
   checks: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   ptah:
@@ -30,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: stokaro/ptah/.github/actions/ptah@master
+      - uses: stokaro/ptah-action@v1
         with:
           dir: ./internal/models
           db-url: ${{ secrets.PTAH_DATABASE_URL }}
@@ -40,16 +37,22 @@ jobs:
           comment: "true"
 ```
 
+Use `stokaro/ptah/.github/actions/ptah@master` only when validating changes to
+the in-repository composite action before they are published to
+`stokaro/ptah-action`.
+
 The action downloads the requested Ptah release binary by default. Use
 `version` to pin a release tag, or `binary-path` when a workflow builds Ptah
 from source before invoking the action. If a release asset is not available yet,
 the installer falls back to `go install github.com/stokaro/ptah/cmd/ptah@...`
-using `master` for `version: latest`.
+using `master` for `version: latest`. Source fallback uses direct module fetch
+to avoid stale Go module proxy results for moving refs.
 
 The `checks: write` permission is needed for the destructive-change check run.
-The `issues: write` permission is needed for sticky pull request comments. On
-forked pull requests without write-scoped tokens, the action skips the comment
-or check-run write and still completes the local Ptah validation path.
+The `issues: write` and `pull-requests: write` permissions are needed for
+sticky pull request comments. On forked pull requests without write-scoped
+tokens, the action skips the comment or check-run write and still completes the
+local Ptah validation path.
 
 ## Inputs
 
@@ -76,7 +79,9 @@ or check-run write and still completes the local Ptah validation path.
 | --- | --- |
 | `plan-path` | Text migration plan report. |
 | `safety-path` | JSON safety report. |
+| `safety-error-path` | Text stderr captured from the safety report command. |
 | `lint-path` | JSON lint report. |
+| `lint-error-path` | Text stderr captured from the lint command. |
 | `destructive` | `true`, `false`, or `unknown`. |
 
 ## Behavior


### PR DESCRIPTION
## Summary

- document `stokaro/ptah-action@v1` as the published Marketplace action path
- require `pull-requests: write` in PR-comment workflow examples
- make source fallback install Ptah with `GOPROXY=direct` so `version: latest` does not use a stale moving-ref module proxy snapshot

## Validation

- `bash -n .github/actions/ptah/install.sh`
- `shellcheck .github/actions/ptah/install.sh`
- YAML parse for `.github/actions/ptah/action.yml`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-build-cache go test -count=1 ./cmd/migrate`
- installer fallback smoke installed `v0.0.0-20260721054314-82741f7f97c4`
- installed Ptah plan smoke printed normal SQL and `Generated 1 migration statements`

Related to #463.
