### PR TITLE
Add Ptah annotation schema and language server

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Check public Go API released baseline
         run: scripts/check-public-api-released.sh
 
+      - name: Check annotation JSON Schema freshness
+        run: |
+          go run ./cmd/ptah schema annotations --out schemas/migrator-annotations.schema.json
+          git diff --exit-code -- schemas/migrator-annotations.schema.json
+
       - name: qtlint
         run: go tool qtlint ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
       - ".goreleaser.yaml"
       - "Dockerfile"
       - "cmd/**"
+      - "internal/**"
+      - "schemas/**"
       - "go.mod"
       - "go.sum"
       - "docs/release_process.md"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,11 +28,33 @@ builds:
         -X github.com/stokaro/ptah/cmd/internal/buildinfo.Version={{ .Version }}
         -X github.com/stokaro/ptah/cmd/internal/buildinfo.Commit={{ .Commit }}
         -X github.com/stokaro/ptah/cmd/internal/buildinfo.Date={{ .CommitDate }}
+  - id: ptah-ls
+    main: ./cmd/ptah-ls
+    binary: ptah-ls
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - >-
+        -s -w
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Version={{ .Version }}
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Commit={{ .Commit }}
+        -X github.com/stokaro/ptah/cmd/internal/buildinfo.Date={{ .CommitDate }}
 
 archives:
   - id: ptah
     ids:
       - ptah
+      - ptah-ls
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
@@ -126,6 +148,7 @@ brews:
   - name: ptah
     ids:
       - ptah
+      - ptah-ls
     repository:
       owner: stokaro
       name: homebrew-ptah

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 build:
 	@echo "Building Ptah binaries..."
 	go build -ldflags "$(LDFLAGS)" -o bin/ptah ./cmd/ptah
+	go build -ldflags "$(LDFLAGS)" -o bin/ptah-ls ./cmd/ptah-ls
 	go build -o bin/ptah-integration-test ./cmd/integration-test
 
 # Run unit tests

--- a/README.md
+++ b/README.md
@@ -222,6 +222,28 @@ Contains sample Go structs with schema annotations for testing and demonstration
 
 Ptah uses structured comments to define database schema information directly in Go structs. Here's the annotation format:
 
+### Annotation Tooling
+
+Ptah publishes a generated JSON Schema for every supported `//migrator`
+directive and attribute at
+[`schemas/migrator-annotations.schema.json`](schemas/migrator-annotations.schema.json).
+Regenerate it from the parser metadata with:
+
+```bash
+ptah schema annotations --format json-schema --out schemas/migrator-annotations.schema.json
+```
+
+Editor integrations should use `ptah-ls`, the Ptah annotation language server.
+It provides diagnostics for unknown directives and attributes, attribute-name
+completions, and hover documentation for Go files. For example,
+`//migrator:schema:field name="x" defaul=...` reports `defaul` as an unknown
+attribute, and hovering `//migrator:schema:rls:policy` shows the supported
+policy attributes.
+
+The thin VS Code wrapper lives in [`editors/vscode`](editors/vscode). It starts
+`ptah-ls` from `PATH` by default; set `ptah.languageServer.path` when the binary
+is installed elsewhere.
+
 ### Table Definition
 ```go
 //migrator:schema:table name="products" platform.mysql.engine="InnoDB" platform.mysql.comment="Product catalog"
@@ -1829,11 +1851,11 @@ type User struct {
     ID int64
 
     // Embedded as separate columns
-    //migrator:schema:embedded mode="columns"
+    //migrator:embedded mode="inline"
     Address Address
 
     // Embedded as JSON
-    //migrator:schema:embedded mode="json" name="address_data" type="JSONB"
+    //migrator:embedded mode="json" name="address_data" type="JSONB"
     Metadata Address
 }
 ```

--- a/cmd/ptah-ls/main.go
+++ b/cmd/ptah-ls/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/stokaro/ptah/cmd/internal/buildinfo"
+	"github.com/stokaro/ptah/internal/ptahls"
+)
+
+func main() {
+	flags := flag.NewFlagSet("ptah-ls", flag.ExitOnError)
+	showVersion := flags.Bool("version", false, "print version information")
+	flags.SetOutput(os.Stderr)
+	flags.Parse(os.Args[1:])
+
+	info := buildinfo.Resolve()
+	if *showVersion {
+		fmt.Fprintf(os.Stdout, "Version: %s\n", info.Version)
+		fmt.Fprintf(os.Stdout, "Commit: %s\n", info.Commit)
+		fmt.Fprintf(os.Stdout, "Date: %s\n", info.Date)
+		fmt.Fprintf(os.Stdout, "Go: %s\n", info.Go)
+		fmt.Fprintf(os.Stdout, "Platform: %s\n", info.Platform)
+		return
+	}
+
+	opts := ptahls.ServerOptions{Version: info.Version}
+	if err := ptahls.RunWithOptions(context.Background(), os.Stdin, os.Stdout, opts); err != nil {
+		fmt.Fprintf(os.Stderr, "ptah-ls: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/cmd/generate"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/annotationschema"
 	"github.com/stokaro/ptah/internal/atlashclrender"
 	"github.com/stokaro/ptah/internal/goannotationcleanup"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -45,6 +46,7 @@ under ptah atlas.`,
 		},
 	}
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	cmd.AddCommand(newSchemaAnnotationsCommand())
 	cmd.AddCommand(newSchemaExportCommand())
 	renderCmd := generate.NewGenerateCommand()
 	renderCmd.Short = "Render desired schema SQL"
@@ -61,6 +63,55 @@ under ptah atlas.`,
 	driftCmd.Long = "Check live database drift against desired schema."
 	cmd.AddCommand(driftCmd)
 	return cmd
+}
+
+func newSchemaAnnotationsCommand() *cobra.Command {
+	var format string
+	var outPath string
+
+	cmd := &cobra.Command{
+		Use:   "annotations",
+		Short: "Export Ptah Go annotation metadata",
+		Long: `Export Ptah Go annotation metadata.
+
+The JSON Schema output describes the parsed representation of every supported
+//migrator directive and attribute:
+
+  ptah schema annotations --format json-schema --out schemas/migrator-annotations.schema.json`,
+		Args:          cmdutil.NoPositionalArgs,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAnnotations(cmd, format, outPath)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&format, "format", "json-schema", "Annotation metadata format: json-schema")
+	flags.StringVar(&outPath, exportOutFlag, "", "Output JSON Schema file")
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	return cmd
+}
+
+func runAnnotations(cmd *cobra.Command, format, outPath string) error {
+	if strings.TrimSpace(format) != "json-schema" {
+		return cmdutil.Fail(cmd, fmt.Errorf("unsupported --format %q: expected json-schema", format))
+	}
+	data, err := annotationschema.Generate()
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	if strings.TrimSpace(outPath) == "" {
+		fmt.Fprint(cmd.OutOrStdout(), string(data))
+		return nil
+	}
+	resolved, err := resolveOutputPath(outPath)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	if err := os.WriteFile(resolved, data, 0o600); err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("write annotation JSON Schema: %w", err))
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Exported annotation JSON Schema to %s\n", resolved)
+	return nil
 }
 
 func newSchemaExportCommand() *cobra.Command {

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -104,6 +104,7 @@ func TestSchemaCommand_RegistersNativePaths(t *testing.T) {
 
 	cmd := schema.NewSchemaCommand()
 	for _, path := range [][]string{
+		{"annotations"},
 		{"export"},
 		{"render"},
 		{"compare"},
@@ -113,6 +114,31 @@ func TestSchemaCommand_RegistersNativePaths(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(found, qt.IsNotNil)
 	}
+}
+
+func TestSchemaAnnotationsCommandWritesJSONSchema(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "migrator-annotations.schema.json")
+
+	cmd := schema.NewSchemaCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"annotations",
+		"--format", "json-schema",
+		"--out", outPath,
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+	c.Assert(stdout.String(), qt.Contains, "Exported annotation JSON Schema")
+	content, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Contains, `"migrator.schema.field"`)
+	c.Assert(string(content), qt.Not(qt.Contains), `"defaul"`)
 }
 
 func TestSchemaCommand_RenderHelpShowsNativePath(t *testing.T) {

--- a/core/goschema/internal/parseutils/parseutils.go
+++ b/core/goschema/internal/parseutils/parseutils.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
 )
 
 var keyValuePairRe = regexp.MustCompile(`(\w+(?:\.\w+)*)=("(?:\\.|[^"\\])*"|[^\s]+)`)
@@ -13,34 +15,16 @@ var boolRe = regexp.MustCompile(`\b(\w+(?:\.\w+)*)\b`)
 // directiveTokens is the set of bareword tokens that appear in a
 // `//migrator:schema:<kind>` annotation header. They are never user-supplied
 // boolean attributes, so we never auto-promote them to `kv[token]="true"`.
-var directiveTokens = map[string]bool{
-	"migrator":   true,
-	"schema":     true,
-	"field":      true,
-	"table":      true,
-	"embed":      true,
-	"embedded":   true,
-	"constraint": true,
-	"enum":       true,
-	"extension":  true,
-	"function":   true,
-	"rls":        true,
-	"policy":     true,
-	"enable":     true,
-	"role":       true,
-}
+var directiveTokens = func() map[string]bool {
+	tokens := annotationmeta.DirectiveTokens()
+	tokens["embed"] = true
+	delete(tokens, "index")
+	return tokens
+}()
 
 // booleanAttrs is the set of bareword keys that, when written without `=`,
 // are auto-promoted to `kv[name]="true"`. See ParseKeyValueComment.
-var booleanAttrs = map[string]bool{
-	"not_null":       true,
-	"nullable":       true,
-	"primary":        true,
-	"unique":         true,
-	"auto_increment": true,
-	"index":          true,
-	"autoincrement":  true,
-}
+var booleanAttrs = annotationmeta.BooleanAttributes()
 
 func ParseKeyValueComment(comment string) map[string]string {
 	result := make(map[string]string)
@@ -130,17 +114,14 @@ func ParsePlatformSpecific(kv map[string]string) map[string]map[string]string {
 	out := make(map[string]map[string]string)
 	for k, v := range kv {
 		// Only use platform. prefix, dropping override. completely
-		if strings.HasPrefix(k, "platform.") {
+		if annotationmeta.IsPlatformAttribute(k) {
 			parts := strings.SplitN(k, ".", 3)
-
-			if len(parts) == 3 {
-				db := parts[1]
-				key := parts[2]
-				if _, ok := out[db]; !ok {
-					out[db] = make(map[string]string)
-				}
-				out[db][key] = v
+			db := parts[1]
+			key := parts[2]
+			if _, ok := out[db]; !ok {
+				out[db] = make(map[string]string)
 			}
+			out[db][key] = v
 		}
 
 		// Move engine and comment to platform-specific attributes

--- a/core/goschema/internal/parseutils/parseutils_test.go
+++ b/core/goschema/internal/parseutils/parseutils_test.go
@@ -25,3 +25,18 @@ func TestParseKeyValueComment_EnumDirectiveTokenIsNotBooleanAttribute(t *testing
 	c.Assert(kv["name"], qt.Equals, "status")
 	c.Assert(kv["values"], qt.Equals, "active,inactive")
 }
+
+func TestParsePlatformSpecificUsesSharedPlatformAttributeShape(t *testing.T) {
+	c := qt.New(t)
+
+	platform := ParsePlatformSpecific(map[string]string{
+		"platform.mysql.type":                   "INT",
+		"platform.postgres.identity.generation": "BY DEFAULT",
+		"platform.mysql":                        "ignored",
+		"platform.mysql.type-name":              "ignored",
+	})
+
+	c.Assert(platform["mysql"]["type"], qt.Equals, "INT")
+	c.Assert(platform["postgres"]["identity.generation"], qt.Equals, "BY DEFAULT")
+	c.Assert(platform["mysql"]["type-name"], qt.Equals, "")
+}

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -13,100 +13,8 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema/internal/parseutils"
 	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/internal/annotationmeta"
 )
-
-// knownIndexAttributes lists every attribute key recognized on a
-// //migrator:schema:index annotation. Keys with the "platform." prefix are
-// also accepted. The strict-unknown-key rejection mechanism (see
-// validateAttributes) is reused so typos like "granluarity" surface at parse
-// time rather than being silently dropped.
-//
-// "columns" is accepted as a legacy synonym for "fields"; several integration
-// fixtures use it. parseIndexComment falls back to it when "fields" is empty.
-var knownIndexAttributes = map[string]bool{
-	"name":           true,
-	"fields":         true,
-	"columns":        true,
-	"unique":         true,
-	"comment":        true,
-	"type":           true,
-	"condition":      true,
-	"where":          true,
-	"ops":            true,
-	"table":          true,
-	"granularity":    true,
-	"nulls_distinct": true,
-}
-
-// knownFieldAttributes lists every attribute key recognized on a
-// //migrator:schema:field annotation. Keys with the "platform." prefix are
-// also accepted (handled separately).
-//
-// "nullable", "index", and "autoincrement" are whitelisted because parseutils
-// auto-promotes them to booleans when written as bare words.
-var knownFieldAttributes = map[string]bool{
-	"name":                true,
-	"type":                true,
-	"not_null":            true,
-	"nullable":            true,
-	"primary":             true,
-	"auto_increment":      true,
-	"autoincrement":       true,
-	"identity_generation": true,
-	"identity_start":      true,
-	"identity_increment":  true,
-	"identity_options":    true,
-	"unique":              true,
-	"unique_expr":         true,
-	"index":               true,
-	"generated":           true,
-	"generated_kind":      true,
-	"stored":              true,
-	"default":             true,
-	"default_expr":        true,
-	"foreign":             true,
-	"foreign_key_name":    true,
-	"on_delete":           true,
-	"on_update":           true,
-	"enum":                true,
-	"check":               true,
-	"check_name":          true,
-	"comment":             true,
-}
-
-var knownViewAttributes = map[string]bool{
-	"name":       true,
-	"body":       true,
-	"with_check": true,
-	"comment":    true,
-}
-
-var knownMaterializedViewAttributes = map[string]bool{
-	"name":             true,
-	"body":             true,
-	"refresh_strategy": true,
-	"comment":          true,
-}
-
-var knownTriggerAttributes = map[string]bool{
-	"name":    true,
-	"table":   true,
-	"timing":  true,
-	"event":   true,
-	"for":     true,
-	"body":    true,
-	"comment": true,
-}
-
-var knownSchemaAttributes = map[string]bool{
-	"name":    true,
-	"comment": true,
-}
-
-var knownEnumAttributes = map[string]bool{
-	"name":   true,
-	"values": true,
-}
 
 // validateAttributes rejects any key the directive does not recognize.
 // Platform-specific overrides (platform.*) are always allowed. This catches
@@ -119,9 +27,10 @@ type annotationErrorContext struct {
 	location  string
 }
 
-func validateAttributes(kv map[string]string, known map[string]bool, ctx annotationErrorContext) error {
+func validateAttributes(kv map[string]string, ctx annotationErrorContext) error {
+	directive := strings.TrimPrefix(ctx.directive, "//")
 	for k := range kv {
-		if known[k] || strings.HasPrefix(k, "platform.") {
+		if annotationmeta.AllowsAttribute(directive, k) {
 			continue
 		}
 		slog.Error("unknown annotation attribute",
@@ -141,8 +50,8 @@ func validateAttributes(kv map[string]string, known map[string]bool, ctx annotat
 	return nil
 }
 
-func requireAttributes(kv map[string]string, required []string, ctx annotationErrorContext) error {
-	for _, key := range required {
+func requireAttributes(kv map[string]string, ctx annotationErrorContext) error {
+	for _, key := range annotationmeta.RequiredAttributes(ctx.directive) {
 		if strings.TrimSpace(kv[key]) != "" {
 			continue
 		}
@@ -179,7 +88,6 @@ func (s *schemaParseState) parseFieldComment(
 	}
 	if err := validateAttributes(
 		kv,
-		knownFieldAttributes,
 		s.annotationContext(comment, "//migrator:schema:field", location),
 	); err != nil {
 		return err
@@ -275,8 +183,15 @@ func hasIdentitySettings(kv map[string]string) bool {
 	return kv["identity_start"] != "" || kv["identity_increment"] != "" || kv["identity_options"] != ""
 }
 
-func (s *schemaParseState) parseEmbeddedComment(comment *ast.Comment, field *ast.Field, structName string) {
+func (s *schemaParseState) parseEmbeddedComment(comment *ast.Comment, field *ast.Field, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:embedded", structName),
+	); err != nil {
+		return err
+	}
+
 	// Handle embedded fields - get the field type name
 	var fieldTypeName string
 	if field.Type != nil {
@@ -308,13 +223,13 @@ func (s *schemaParseState) parseEmbeddedComment(comment *ast.Comment, field *ast
 		EmbeddedTypeName: fieldTypeName,
 		Overrides:        parseutils.ParsePlatformSpecific(kv),
 	})
+	return nil
 }
 
 func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownIndexAttributes,
 		s.annotationContext(comment, "//migrator:schema:index", structName),
 	); err != nil {
 		return err
@@ -380,8 +295,16 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (s *schemaParseState) parseConstraintComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseConstraintComment(comment *ast.Comment, structName string) error {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:constraint", structName),
+	); err != nil {
+		return err
+	}
 	s.schemaConstraints = append(s.schemaConstraints, parseConstraintComment(comment, structName))
+	return nil
 }
 
 func parseConstraintComment(comment *ast.Comment, structName string) Constraint {
@@ -440,8 +363,14 @@ func parseBoolPtr(value string) *bool {
 	return &parsed
 }
 
-func (s *schemaParseState) parseExtensionComment(comment *ast.Comment) {
+func (s *schemaParseState) parseExtensionComment(comment *ast.Comment) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:extension", kv["name"]),
+	); err != nil {
+		return err
+	}
 
 	s.extensions = append(s.extensions, Extension{
 		Name:        kv["name"],
@@ -449,20 +378,19 @@ func (s *schemaParseState) parseExtensionComment(comment *ast.Comment) {
 		Version:     kv["version"],
 		Comment:     kv["comment"],
 	})
+	return nil
 }
 
 func (s *schemaParseState) parseSchemaComment(comment *ast.Comment) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownSchemaAttributes,
 		s.annotationContext(comment, "//migrator:schema:schema", kv["name"]),
 	); err != nil {
 		return err
 	}
 	if err := requireAttributes(
 		kv,
-		[]string{"name"},
 		s.annotationContext(comment, "//migrator:schema:schema", kv["name"]),
 	); err != nil {
 		return err
@@ -475,8 +403,14 @@ func (s *schemaParseState) parseSchemaComment(comment *ast.Comment) error {
 	return nil
 }
 
-func (s *schemaParseState) parseTableComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseTableComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:table", structName),
+	); err != nil {
+		return err
+	}
 	s.tableDirectives = append(s.tableDirectives, Table{
 		StructName: structName,
 		Name:       kv["name"],
@@ -488,6 +422,7 @@ func (s *schemaParseState) parseTableComment(comment *ast.Comment, structName st
 		CustomSQL:  kv["custom"],
 		Overrides:  parseutils.ParsePlatformSpecific(kv),
 	})
+	return nil
 }
 
 func splitCSVAttribute(value string) []string {
@@ -583,8 +518,7 @@ func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, target 
 	case strings.HasPrefix(comment.Text, "//migrator:schema:field"):
 		return true, s.parseFieldComment(comment, target.field, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:embedded"):
-		s.parseEmbeddedComment(comment, target.field, target.structName)
-		return true, nil
+		return true, s.parseEmbeddedComment(comment, target.field, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:index"):
 		return true, s.parseIndexComment(comment, target.structName)
 	default:
@@ -595,8 +529,7 @@ func (s *schemaParseState) parseFieldScopedComment(comment *ast.Comment, target 
 func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, target schemaCommentTarget) (bool, error) {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:table"):
-		s.parseTableComment(comment, target.structName)
-		return true, nil
+		return true, s.parseTableComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:schema"):
 		return true, s.parseSchemaComment(comment)
 	default:
@@ -607,13 +540,13 @@ func (s *schemaParseState) parseStructScopedComment(comment *ast.Comment, target
 func (s *schemaParseState) parseSharedComment(comment *ast.Comment, target schemaCommentTarget) error {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:constraint"):
-		s.parseConstraintComment(comment, target.structName)
+		return s.parseConstraintComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:enum"):
 		return s.parseEnumComment(comment)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:extension"):
-		s.parseExtensionComment(comment)
+		return s.parseExtensionComment(comment)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:function"):
-		s.parseFunctionComment(comment, target.structName)
+		return s.parseFunctionComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:view"):
 		return s.parseViewComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:matview"):
@@ -621,13 +554,13 @@ func (s *schemaParseState) parseSharedComment(comment *ast.Comment, target schem
 	case strings.HasPrefix(comment.Text, "//migrator:schema:trigger"):
 		return s.parseTriggerComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-		s.parseRLSPolicyComment(comment, target.structName)
+		return s.parseRLSPolicyComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-		s.parseRLSEnableComment(comment, target.structName)
+		return s.parseRLSEnableComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:role"):
-		s.parseRoleComment(comment, target.structName)
+		return s.parseRoleComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
-		s.parseGrantComment(comment, target.structName)
+		return s.parseGrantComment(comment, target.structName)
 	}
 	return nil
 }
@@ -636,14 +569,12 @@ func (s *schemaParseState) parseEnumComment(comment *ast.Comment) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownEnumAttributes,
 		s.annotationContext(comment, "//migrator:schema:enum", kv["name"]),
 	); err != nil {
 		return err
 	}
 	if err := requireAttributes(
 		kv,
-		[]string{"name", "values"},
 		s.annotationContext(comment, "//migrator:schema:enum", kv["name"]),
 	); err != nil {
 		return err
@@ -776,8 +707,7 @@ func (s *schemaParseState) processFileAST(f *ast.File) error {
 	}
 
 	// Process all file comments for RLS annotations that might not be associated with struct declarations
-	s.processAllFileComments(f)
-	return nil
+	return s.processAllFileComments(f)
 }
 
 func collectStructDeclarations(f *ast.File) []structDeclaration {
@@ -851,14 +781,17 @@ func (s *schemaParseState) processDeclaration(structDecl structDeclaration) erro
 
 // processAllFileComments scans comments for RLS annotations that are separated
 // from struct declarations by blank lines.
-func (s *schemaParseState) processAllFileComments(f *ast.File) {
+func (s *schemaParseState) processAllFileComments(f *ast.File) error {
 	seen := s.newRLSCommentSet()
 
 	for _, commentGroup := range f.Comments {
 		for _, comment := range commentGroup.List {
-			s.parseFileScopedRLSComment(comment, seen)
+			if err := s.parseFileScopedRLSComment(comment, seen); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 type rlsCommentSet struct {
@@ -882,29 +815,36 @@ func (s *schemaParseState) newRLSCommentSet() rlsCommentSet {
 	return seen
 }
 
-func (s *schemaParseState) parseFileScopedRLSComment(comment *ast.Comment, seen rlsCommentSet) {
+func (s *schemaParseState) parseFileScopedRLSComment(comment *ast.Comment, seen rlsCommentSet) error {
 	switch {
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:policy"):
-		s.parseFileScopedRLSPolicyComment(comment, seen)
+		return s.parseFileScopedRLSPolicyComment(comment, seen)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:rls:enable"):
-		s.parseFileScopedRLSEnableComment(comment, seen)
+		return s.parseFileScopedRLSEnableComment(comment, seen)
 	}
+	return nil
 }
 
-func (s *schemaParseState) parseFileScopedRLSPolicyComment(comment *ast.Comment, seen rlsCommentSet) {
+func (s *schemaParseState) parseFileScopedRLSPolicyComment(comment *ast.Comment, seen rlsCommentSet) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:rls:policy", kv["table"]),
+	); err != nil {
+		return err
+	}
 	policyName := kv["name"]
 	tableName := kv["table"]
 	if policyName == "" || tableName == "" {
-		return
+		return nil
 	}
 	if _, exists := seen.policies[policyName]; exists {
-		return
+		return nil
 	}
 
 	structName, exists := s.tableNameToStructName[tableName]
 	if !exists {
-		return
+		return nil
 	}
 
 	s.rlsPolicies = append(s.rlsPolicies, RLSPolicy{
@@ -918,21 +858,28 @@ func (s *schemaParseState) parseFileScopedRLSPolicyComment(comment *ast.Comment,
 		Comment:             kv["comment"],
 	})
 	seen.policies[policyName] = struct{}{}
+	return nil
 }
 
-func (s *schemaParseState) parseFileScopedRLSEnableComment(comment *ast.Comment, seen rlsCommentSet) {
+func (s *schemaParseState) parseFileScopedRLSEnableComment(comment *ast.Comment, seen rlsCommentSet) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:rls:enable", kv["table"]),
+	); err != nil {
+		return err
+	}
 	tableName := kv["table"]
 	if tableName == "" {
-		return
+		return nil
 	}
 	if _, exists := seen.enabledTables[tableName]; exists {
-		return
+		return nil
 	}
 
 	structName, exists := s.tableNameToStructName[tableName]
 	if !exists {
-		return
+		return nil
 	}
 
 	s.rlsEnabledTables = append(s.rlsEnabledTables, RLSEnabledTable{
@@ -941,10 +888,17 @@ func (s *schemaParseState) parseFileScopedRLSEnableComment(comment *ast.Comment,
 		Comment:    kv["comment"],
 	})
 	seen.enabledTables[tableName] = struct{}{}
+	return nil
 }
 
-func (s *schemaParseState) parseFunctionComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseFunctionComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:function", structName),
+	); err != nil {
+		return err
+	}
 
 	fn := Function{
 		StructName: structName,
@@ -962,20 +916,19 @@ func (s *schemaParseState) parseFunctionComment(comment *ast.Comment, structName
 	// typed. See Function.Canonicalize for the per-field rules.
 	fn.Canonicalize()
 	s.functions = append(s.functions, fn)
+	return nil
 }
 
 func (s *schemaParseState) parseViewComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownViewAttributes,
 		s.annotationContext(comment, "//migrator:schema:view", structName),
 	); err != nil {
 		return err
 	}
 	if err := requireAttributes(
 		kv,
-		[]string{"name", "body"},
 		s.annotationContext(comment, "//migrator:schema:view", structName),
 	); err != nil {
 		return err
@@ -994,14 +947,12 @@ func (s *schemaParseState) parseMaterializedViewComment(comment *ast.Comment, st
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownMaterializedViewAttributes,
 		s.annotationContext(comment, "//migrator:schema:matview", structName),
 	); err != nil {
 		return err
 	}
 	if err := requireAttributes(
 		kv,
-		[]string{"name", "body"},
 		s.annotationContext(comment, "//migrator:schema:matview", structName),
 	); err != nil {
 		return err
@@ -1026,14 +977,12 @@ func (s *schemaParseState) parseTriggerComment(comment *ast.Comment, structName 
 	kv := parseutils.ParseKeyValueComment(comment.Text)
 	if err := validateAttributes(
 		kv,
-		knownTriggerAttributes,
 		s.annotationContext(comment, "//migrator:schema:trigger", structName),
 	); err != nil {
 		return err
 	}
 	if err := requireAttributes(
 		kv,
-		[]string{"name", "table", "timing", "event", "body"},
 		s.annotationContext(comment, "//migrator:schema:trigger", structName),
 	); err != nil {
 		return err
@@ -1053,8 +1002,14 @@ func (s *schemaParseState) parseTriggerComment(comment *ast.Comment, structName 
 	return nil
 }
 
-func (s *schemaParseState) parseRLSPolicyComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseRLSPolicyComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:rls:policy", structName),
+	); err != nil {
+		return err
+	}
 	s.rlsPolicies = append(s.rlsPolicies, RLSPolicy{
 		StructName:          structName,
 		Name:                kv["name"],
@@ -1065,19 +1020,33 @@ func (s *schemaParseState) parseRLSPolicyComment(comment *ast.Comment, structNam
 		WithCheckExpression: kv["with_check"],
 		Comment:             kv["comment"],
 	})
+	return nil
 }
 
-func (s *schemaParseState) parseRLSEnableComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseRLSEnableComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:rls:enable", structName),
+	); err != nil {
+		return err
+	}
 	s.rlsEnabledTables = append(s.rlsEnabledTables, RLSEnabledTable{
 		StructName: structName,
 		Table:      kv["table"],
 		Comment:    kv["comment"],
 	})
+	return nil
 }
 
-func (s *schemaParseState) parseRoleComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseRoleComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:role", structName),
+	); err != nil {
+		return err
+	}
 	s.roles = append(s.roles, Role{
 		StructName:  structName,
 		Name:        kv["name"],
@@ -1090,10 +1059,17 @@ func (s *schemaParseState) parseRoleComment(comment *ast.Comment, structName str
 		Replication: kv["replication"] == "true",
 		Comment:     kv["comment"],
 	})
+	return nil
 }
 
-func (s *schemaParseState) parseGrantComment(comment *ast.Comment, structName string) {
+func (s *schemaParseState) parseGrantComment(comment *ast.Comment, structName string) error {
 	kv := parseutils.ParseKeyValueComment(comment.Text)
+	if err := validateAttributes(
+		kv,
+		s.annotationContext(comment, "//migrator:schema:grant", structName),
+	); err != nil {
+		return err
+	}
 	privileges := splitCommaList(kv["privilege"])
 	if len(privileges) == 0 {
 		privileges = splitCommaList(kv["privileges"])
@@ -1109,6 +1085,7 @@ func (s *schemaParseState) parseGrantComment(comment *ast.Comment, structName st
 	}
 	grant.Canonicalize()
 	s.grants = append(s.grants, grant)
+	return nil
 }
 
 func splitCommaList(value string) []string {

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -190,6 +190,48 @@ type User struct {
 	c.Assert(db.Fields[0].IdentityOptions, qt.Equals, "MINVALUE 0 START WITH 0")
 }
 
+func TestParseSource_RejectsUnknownAttributesOnAllDirectives(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		field      bool
+	}{
+		{name: "table", annotation: `//migrator:schema:table name="users" bogus="x"`},
+		{name: "embedded", annotation: `//migrator:embedded mode="inline" bogus="x"`, field: true},
+		{name: "constraint", annotation: `//migrator:schema:constraint name="users_check" type="CHECK" bogus="x"`},
+		{name: "extension", annotation: `//migrator:schema:extension name="pg_trgm" bogus="x"`},
+		{name: "function", annotation: `//migrator:schema:function name="f" bogus="x"`},
+		{name: "rls_policy", annotation: `//migrator:schema:rls:policy name="p" table="users" bogus="x"`},
+		{name: "rls_enable", annotation: `//migrator:schema:rls:enable table="users" bogus="x"`},
+		{name: "role", annotation: `//migrator:schema:role name="app" bogus="x"`},
+		{name: "grant", annotation: `//migrator:schema:grant role="app" privilege="SELECT" bogus="x"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			annotation := tt.annotation
+			if tt.field {
+				annotation = ""
+			}
+			fieldAnnotation := `//migrator:schema:field name="id" type="SERIAL" primary="true"`
+			if tt.field {
+				fieldAnnotation = tt.annotation
+			}
+			_, err := goschema.ParseSource("schema.go", `
+package test
+
+`+annotation+`
+type User struct {
+	`+fieldAnnotation+`
+	ID int64
+}
+`)
+			c.Assert(err, qt.ErrorMatches, `unknown annotation attribute "bogus".*`)
+		})
+	}
+}
+
 func TestParseSource_TableCommentLeavesAbsentCSVAttributesEmpty(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -49,6 +49,7 @@ Ptah releases are produced by GoReleaser from annotated version tags.
    brew update
    brew install stokaro/ptah/ptah
    ptah version
+   ptah-ls --version
    ```
 
 ## Local Snapshot
@@ -58,10 +59,11 @@ Use a snapshot release to validate packaging without publishing:
 ```bash
 goreleaser release --snapshot --clean --skip=sign,docker
 ./dist/ptah_darwin_arm64*/ptah version
+./dist/ptah_darwin_arm64*/ptah-ls --version
 ```
 
 Snapshot releases should print snapshot version metadata, the current commit,
-the build date, Go version, and platform.
+the build date, Go version, and platform for both shipped binaries.
 
 If `syft` is not installed locally, skip SBOM generation for the local packaging
 smoke test only:

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+node_modules/**
+npm-debug.log
+*.vsix

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -1,0 +1,41 @@
+const vscode = require("vscode");
+const { LanguageClient } = require("vscode-languageclient/node");
+
+let client;
+
+async function activate(context) {
+  if (!vscode.workspace.isTrusted) {
+    return;
+  }
+
+  const config = vscode.workspace.getConfiguration("ptah");
+  const command = config.get("languageServer.path", "ptah-ls");
+  client = new LanguageClient(
+    "ptahAnnotations",
+    "Ptah Annotations",
+    {
+      command,
+      args: [],
+      options: {}
+    },
+    {
+      documentSelector: [{ scheme: "file", language: "go" }]
+    }
+  );
+  context.subscriptions.push(client);
+  await client.start();
+}
+
+async function deactivate() {
+  if (!client) {
+    return undefined;
+  }
+  await client.stop();
+  client = undefined;
+  return undefined;
+}
+
+module.exports = {
+  activate,
+  deactivate
+};

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "ptah-annotations",
+  "displayName": "Ptah Annotations",
+  "description": "Language support for Ptah //migrator Go annotations.",
+  "version": "0.1.0",
+  "publisher": "stokaro",
+  "license": "MIT",
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
+  "activationEvents": [
+    "onLanguage:go"
+  ],
+  "main": "./extension.js",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Ptah annotation diagnostics require starting the configured ptah-ls binary.",
+      "restrictedConfigurations": [
+        "ptah.languageServer.path"
+      ]
+    }
+  },
+  "contributes": {
+    "configuration": {
+      "title": "Ptah",
+      "properties": {
+        "ptah.languageServer.path": {
+          "type": "string",
+          "default": "ptah-ls",
+          "description": "Path to the ptah-ls executable."
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -1,0 +1,507 @@
+// Package annotationmeta defines Ptah Go annotation directive metadata.
+package annotationmeta
+
+import (
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Scope describes where a directive is valid in Go source.
+type Scope string
+
+const (
+	ScopeFile   Scope = "file"
+	ScopeStruct Scope = "struct"
+	ScopeField  Scope = "field"
+)
+
+// Attribute describes a single directive attribute.
+type Attribute struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Value       string `json:"value"`
+	Required    bool   `json:"required,omitempty"`
+	Boolean     bool   `json:"boolean,omitempty"`
+	AliasFor    string `json:"alias_for,omitempty"`
+}
+
+// Directive describes one //migrator annotation directive.
+type Directive struct {
+	Name          string      `json:"name"`
+	Description   string      `json:"description"`
+	Scopes        []Scope     `json:"scopes"`
+	Attributes    []Attribute `json:"attributes"`
+	AllowPlatform bool        `json:"allow_platform,omitempty"`
+}
+
+// Directives returns every supported annotation directive in stable order.
+func Directives() []Directive {
+	out := make([]Directive, len(directives))
+	copy(out, directives)
+	return out
+}
+
+// Lookup returns metadata for name, without a leading // comment marker.
+func Lookup(name string) (Directive, bool) {
+	name = strings.TrimPrefix(strings.TrimSpace(name), "//")
+	i := slices.IndexFunc(directives, func(d Directive) bool {
+		return d.Name == name
+	})
+	if i < 0 {
+		return Directive{}, false
+	}
+	return directives[i], true
+}
+
+// MatchCommentDirective returns the directive matching a comment line.
+func MatchCommentDirective(comment string) (Directive, bool) {
+	body := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(comment), "//"))
+	for _, directive := range directivesByDescendingLength() {
+		if !strings.HasPrefix(body, directive.Name) {
+			continue
+		}
+		rest := body[len(directive.Name):]
+		if rest == "" || rest[0] == ' ' || rest[0] == '\t' {
+			return directive, true
+		}
+	}
+	return Directive{}, false
+}
+
+// KnownAttributes returns a set containing every declared attribute name.
+func KnownAttributes(directive string) map[string]bool {
+	spec, ok := Lookup(directive)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]bool, len(spec.Attributes))
+	for _, attr := range spec.Attributes {
+		out[attr.Name] = true
+	}
+	return out
+}
+
+// RequiredAttributes returns every required attribute name for directive.
+func RequiredAttributes(directive string) []string {
+	spec, ok := Lookup(directive)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, attr := range spec.Attributes {
+		if attr.Required {
+			out = append(out, attr.Name)
+		}
+	}
+	return out
+}
+
+// AllowsAttribute reports whether key is valid for directive.
+func AllowsAttribute(directive, key string) bool {
+	spec, ok := Lookup(directive)
+	if !ok {
+		return false
+	}
+	if spec.AllowPlatform && IsPlatformAttribute(key) {
+		return true
+	}
+	return slices.ContainsFunc(spec.Attributes, func(attr Attribute) bool {
+		return attr.Name == key
+	})
+}
+
+// PlatformAttributePattern is the JSON Schema pattern for dialect-specific
+// override attributes accepted by the Go annotation parser.
+const PlatformAttributePattern = `^platform\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$`
+
+// IsPlatformAttribute reports whether key has the platform.<dialect>.<name>
+// shape consumed by parseutils.ParsePlatformSpecific.
+func IsPlatformAttribute(key string) bool {
+	parts := strings.Split(key, ".")
+	if len(parts) < 3 || parts[0] != "platform" {
+		return false
+	}
+	for _, part := range parts[1:] {
+		if !isIdentifierPart(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func isIdentifierPart(part string) bool {
+	if part == "" {
+		return false
+	}
+	for _, r := range part {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// AttributeNames returns sorted attribute names for directive.
+func AttributeNames(directive string) []string {
+	spec, ok := Lookup(directive)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(spec.Attributes))
+	for _, attr := range spec.Attributes {
+		names = append(names, attr.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// BooleanAttributes returns the attributes accepted as bare booleans.
+func BooleanAttributes() map[string]bool {
+	out := make(map[string]bool)
+	for _, directive := range directives {
+		for _, attr := range directive.Attributes {
+			if attr.Boolean {
+				out[attr.Name] = true
+			}
+		}
+	}
+	return out
+}
+
+// DirectiveTokens returns every directive path segment that must not be
+// auto-promoted to a bare boolean attribute by annotation parsers.
+func DirectiveTokens() map[string]bool {
+	out := map[string]bool{
+		"migrator": true,
+		"schema":   true,
+	}
+	for _, directive := range directives {
+		for part := range strings.SplitSeq(directive.Name, ":") {
+			out[part] = true
+		}
+	}
+	return out
+}
+
+// Markdown returns concise documentation for hover cards.
+func Markdown(directive Directive) string {
+	var b strings.Builder
+	b.WriteString("`//")
+	b.WriteString(directive.Name)
+	b.WriteString("`\n\n")
+	b.WriteString(directive.Description)
+	if len(directive.Attributes) == 0 {
+		return b.String()
+	}
+	b.WriteString("\n\nAttributes:\n")
+	for _, attr := range directive.Attributes {
+		b.WriteString("- `")
+		b.WriteString(attr.Name)
+		b.WriteString("`")
+		if attr.Required {
+			b.WriteString(" required")
+		}
+		if attr.AliasFor != "" {
+			b.WriteString(" alias for `")
+			b.WriteString(attr.AliasFor)
+			b.WriteString("`")
+		}
+		if attr.Description != "" {
+			b.WriteString(": ")
+			b.WriteString(attr.Description)
+		}
+		b.WriteString("\n")
+	}
+	if directive.AllowPlatform {
+		b.WriteString("- `platform.<dialect>.<key>`: dialect-specific override attributes.\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func directivesByDescendingLength() []Directive {
+	out := Directives()
+	sort.SliceStable(out, func(i, j int) bool {
+		return len(out[i].Name) > len(out[j].Name)
+	})
+	return out
+}
+
+const (
+	valueString  = "string"
+	valueBoolean = "boolean"
+	valueList    = "comma-list"
+	valueSQL     = "sql"
+)
+
+var directives = []Directive{
+	{
+		Name:          "migrator:schema:field",
+		Description:   "Maps a Go struct field to a database column.",
+		Scopes:        []Scope{ScopeField},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Column name.", valueString, false, false),
+			attr("type", "Database column type.", valueString, false, false),
+			attr("not_null", "Marks the column NOT NULL.", valueBoolean, false, true),
+			attr("nullable", "Bareword compatibility flag accepted by the parser.", valueBoolean, false, true),
+			attr("primary", "Marks the column as part of the primary key.", valueBoolean, false, true),
+			attr("auto_increment", "Marks the column as auto-incrementing.", valueBoolean, false, true),
+			alias("autoincrement", "auto_increment", "Legacy auto-increment spelling.", valueBoolean, true),
+			attr("identity_generation", "SQL identity generation mode.", valueString, false, false),
+			attr("identity_start", "SQL identity start value.", valueString, false, false),
+			attr("identity_increment", "SQL identity increment value.", valueString, false, false),
+			attr("identity_options", "Raw SQL identity options.", valueSQL, false, false),
+			attr("unique", "Adds a single-column unique constraint.", valueBoolean, false, true),
+			attr("unique_expr", "Unique expression for dialects that support expression indexes.", valueSQL, false, false),
+			attr("index", "Bareword compatibility flag accepted by the parser.", valueBoolean, false, true),
+			attr("generated", "Generated column expression.", valueSQL, false, false),
+			attr("generated_kind", "Generated column kind, such as STORED or VIRTUAL.", valueString, false, false),
+			attr("stored", "Shortcut controlling generated column storage.", valueBoolean, false, false),
+			attr("default", "Literal column default.", valueString, false, false),
+			attr("default_expr", "SQL default expression.", valueSQL, false, false),
+			attr("foreign", "Foreign key reference in table(column) form.", valueString, false, false),
+			attr("foreign_key_name", "Explicit foreign key constraint name.", valueString, false, false),
+			attr("on_delete", "Foreign key ON DELETE action.", valueString, false, false),
+			attr("on_update", "Foreign key ON UPDATE action.", valueString, false, false),
+			attr("enum", "Comma-separated enum values.", valueList, false, false),
+			attr("check", "Column CHECK expression.", valueSQL, false, false),
+			attr("check_name", "Explicit CHECK constraint name.", valueString, false, false),
+			attr("comment", "Column comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:          "migrator:embedded",
+		Description:   "Controls how an embedded Go field contributes schema objects.",
+		Scopes:        []Scope{ScopeField},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("mode", "Embedding mode: inline, json, or relation.", valueString, false, false),
+			attr("prefix", "Column prefix for inline embedded fields.", valueString, false, false),
+			attr("name", "Column name for json embedding.", valueString, false, false),
+			attr("type", "Column type for json embedding.", valueString, false, false),
+			attr("nullable", "Marks generated embedded columns nullable.", valueBoolean, false, true),
+			attr("not_null", "Compatibility flag accepted on embedded annotations.", valueBoolean, false, true),
+			attr("index", "Requests an index for generated relation columns.", valueBoolean, false, true),
+			attr("field", "Generated relation field name.", valueString, false, false),
+			attr("ref", "Relation target in table(column) form.", valueString, false, false),
+			attr("on_delete", "Generated foreign key ON DELETE action.", valueString, false, false),
+			attr("on_update", "Generated foreign key ON UPDATE action.", valueString, false, false),
+			attr("comment", "Generated column comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:index",
+		Description:   "Declares an index for a table.",
+		Scopes:        []Scope{ScopeStruct, ScopeField},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Index name.", valueString, false, false),
+			attr("fields", "Comma-separated Go field or column names.", valueList, false, false),
+			alias("columns", "fields", "Legacy synonym for fields.", valueList, false),
+			attr("unique", "Creates a unique index.", valueBoolean, false, true),
+			attr("comment", "Index comment.", valueString, false, false),
+			attr("type", "Index type or method.", valueString, false, false),
+			attr("condition", "Partial index condition.", valueSQL, false, false),
+			alias("where", "condition", "Atlas-style partial index condition alias.", valueSQL, false),
+			attr("ops", "PostgreSQL operator class.", valueString, false, false),
+			attr("table", "Explicit target table.", valueString, false, false),
+			attr("granularity", "ClickHouse data-skipping index granularity.", valueString, false, false),
+			attr("nulls_distinct", "Controls NULLS DISTINCT behavior where supported.", valueBoolean, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:table",
+		Description:   "Maps a Go struct to a database table.",
+		Scopes:        []Scope{ScopeStruct},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Table name.", valueString, false, false),
+			attr("schema", "Database schema name.", valueString, false, false),
+			attr("engine", "MySQL/MariaDB table engine shortcut.", valueString, false, false),
+			attr("comment", "Table comment.", valueString, false, false),
+			attr("primary_key", "Comma-separated primary key columns.", valueList, false, false),
+			attr("checks", "Comma-separated table-level check expressions.", valueList, false, false),
+			attr("custom", "Raw custom CREATE TABLE SQL.", valueSQL, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:schema",
+		Description:   "Declares a database schema or namespace.",
+		Scopes:        []Scope{ScopeStruct},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Schema name.", valueString, true, false),
+			attr("comment", "Schema comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:constraint",
+		Description: "Declares a table constraint.",
+		Scopes:      []Scope{ScopeStruct, ScopeField},
+		Attributes: []Attribute{
+			attr("name", "Constraint name.", valueString, false, false),
+			attr("type", "Constraint type: CHECK, UNIQUE, PRIMARY KEY, FOREIGN KEY, or EXCLUDE.", valueString, false, false),
+			attr("table", "Explicit target table.", valueString, false, false),
+			attr("using", "EXCLUDE index method.", valueString, false, false),
+			attr("elements", "EXCLUDE constraint elements.", valueSQL, false, false),
+			attr("condition", "Constraint WHERE condition.", valueSQL, false, false),
+			attr("check", "CHECK expression.", valueSQL, false, false),
+			attr("columns", "Comma-separated local columns.", valueList, false, false),
+			attr("nulls_distinct", "Controls NULLS DISTINCT behavior where supported.", valueBoolean, false, false),
+			attr("foreign_table", "Referenced table for FOREIGN KEY constraints.", valueString, false, false),
+			attr("foreign_column", "Single referenced column for FOREIGN KEY constraints.", valueString, false, false),
+			attr("foreign_columns", "Comma-separated referenced columns for composite FOREIGN KEY constraints.", valueList, false, false),
+			attr("on_delete", "Foreign key ON DELETE action.", valueString, false, false),
+			attr("on_update", "Foreign key ON UPDATE action.", valueString, false, false),
+			attr("comment", "Constraint comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:enum",
+		Description: "Declares a reusable enum type.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("name", "Enum type name.", valueString, true, false),
+			attr("values", "Comma-separated enum values.", valueList, true, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:extension",
+		Description: "Declares a PostgreSQL extension.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("name", "Extension name.", valueString, false, false),
+			attr("if_not_exists", "Adds IF NOT EXISTS where supported.", valueBoolean, false, false),
+			attr("version", "Extension version.", valueString, false, false),
+			attr("comment", "Extension comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:function",
+		Description: "Declares a database function.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("name", "Function name.", valueString, false, false),
+			attr("params", "Function parameter list.", valueString, false, false),
+			attr("returns", "Return type.", valueString, false, false),
+			attr("language", "Function language.", valueString, false, false),
+			attr("security", "Security mode, such as DEFINER.", valueString, false, false),
+			attr("volatility", "Volatility class.", valueString, false, false),
+			attr("body", "Function body SQL.", valueSQL, false, false),
+			attr("comment", "Function comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:view",
+		Description:   "Declares a database view.",
+		Scopes:        []Scope{ScopeStruct},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "View name.", valueString, true, false),
+			attr("body", "View SELECT body.", valueSQL, true, false),
+			attr("with_check", "Controls WITH CHECK OPTION where supported.", valueBoolean, false, false),
+			attr("comment", "View comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:matview",
+		Description:   "Declares a materialized view.",
+		Scopes:        []Scope{ScopeStruct},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Materialized view name.", valueString, true, false),
+			attr("body", "Materialized view SELECT body.", valueSQL, true, false),
+			attr("refresh_strategy", "Refresh strategy; defaults to manual.", valueString, false, false),
+			attr("comment", "Materialized view comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:          "migrator:schema:trigger",
+		Description:   "Declares a database trigger.",
+		Scopes:        []Scope{ScopeStruct},
+		AllowPlatform: true,
+		Attributes: []Attribute{
+			attr("name", "Trigger name.", valueString, true, false),
+			attr("table", "Target table.", valueString, true, false),
+			attr("timing", "Trigger timing, such as BEFORE or AFTER.", valueString, true, false),
+			attr("event", "Trigger event, such as INSERT or UPDATE.", valueString, true, false),
+			attr("for", "Trigger granularity; defaults to ROW.", valueString, false, false),
+			attr("body", "Trigger body SQL.", valueSQL, true, false),
+			attr("comment", "Trigger comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:rls:policy",
+		Description: "Declares a row-level security policy.",
+		Scopes:      []Scope{ScopeFile, ScopeStruct},
+		Attributes: []Attribute{
+			attr("name", "Policy name.", valueString, false, false),
+			attr("table", "Target table.", valueString, false, false),
+			attr("for", "Policy command, such as ALL or SELECT.", valueString, false, false),
+			attr("to", "Comma-separated roles.", valueList, false, false),
+			attr("using", "USING expression.", valueSQL, false, false),
+			attr("with_check", "WITH CHECK expression.", valueSQL, false, false),
+			attr("comment", "Policy comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:rls:enable",
+		Description: "Enables row-level security on a table.",
+		Scopes:      []Scope{ScopeFile, ScopeStruct},
+		Attributes: []Attribute{
+			attr("table", "Target table.", valueString, false, false),
+			attr("comment", "RLS enablement comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:role",
+		Description: "Declares a database role.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("name", "Role name.", valueString, false, false),
+			attr("login", "Creates the role with LOGIN.", valueBoolean, false, false),
+			attr("password", "Role password.", valueString, false, false),
+			attr("superuser", "Creates the role as SUPERUSER.", valueBoolean, false, false),
+			attr("createdb", "Allows database creation.", valueBoolean, false, false),
+			alias("create_db", "createdb", "Alias for createdb.", valueBoolean, false),
+			attr("createrole", "Allows role creation.", valueBoolean, false, false),
+			alias("create_role", "createrole", "Alias for createrole.", valueBoolean, false),
+			attr("inherit", "Controls role inheritance; defaults to true.", valueBoolean, false, false),
+			attr("replication", "Allows replication.", valueBoolean, false, false),
+			attr("comment", "Role comment.", valueString, false, false),
+		},
+	},
+	{
+		Name:        "migrator:schema:grant",
+		Description: "Declares database grants.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("role", "Target role.", valueString, false, false),
+			attr("privilege", "Privilege or comma-separated privileges.", valueList, false, false),
+			alias("privileges", "privilege", "Alias for privilege.", valueList, false),
+			attr("on_table", "Target table.", valueString, false, false),
+			attr("on_schema", "Target schema.", valueString, false, false),
+			attr("with_option", "Adds WITH GRANT OPTION where supported.", valueBoolean, false, false),
+			alias("grant_option", "with_option", "Alias for with_option.", valueBoolean, false),
+			attr("comment", "Grant comment.", valueString, false, false),
+		},
+	},
+}
+
+func attr(name, description, value string, required, boolean bool) Attribute {
+	return Attribute{
+		Name:        name,
+		Description: description,
+		Value:       value,
+		Required:    required,
+		Boolean:     boolean,
+	}
+}
+
+func alias(name, aliasFor, description, value string, boolean bool) Attribute {
+	a := attr(name, description, value, false, boolean)
+	a.AliasFor = aliasFor
+	return a
+}

--- a/internal/annotationmeta/meta_test.go
+++ b/internal/annotationmeta/meta_test.go
@@ -1,0 +1,33 @@
+package annotationmeta_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
+)
+
+func TestAllowsAttributeValidatesPlatformOverrideShape(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform.mysql.type"), qt.IsTrue)
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform.mysql.generated.kind"), qt.IsTrue)
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform.mysql"), qt.IsFalse)
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform..type"), qt.IsFalse)
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform.mysql.type-name"), qt.IsFalse)
+	c.Assert(annotationmeta.AllowsAttribute("migrator:schema:field", "platform.mysql.тип"), qt.IsFalse)
+}
+
+func TestDetachedFileScopesMatchParserSupport(t *testing.T) {
+	c := qt.New(t)
+
+	for _, directive := range annotationmeta.Directives() {
+		for _, scope := range directive.Scopes {
+			if scope != annotationmeta.ScopeFile {
+				continue
+			}
+			c.Assert(directive.Name, qt.Matches, `migrator:schema:rls:(policy|enable)`)
+		}
+	}
+}

--- a/internal/annotationparse/parse.go
+++ b/internal/annotationparse/parse.go
@@ -1,0 +1,137 @@
+// Package annotationparse scans Ptah Go annotation comments with positions.
+package annotationparse
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
+)
+
+var attrRe = regexp.MustCompile(`(\w+(?:\.\w+)*)=("(?:\\.|[^"\\])*"|[^\s]+)`)
+
+// Range is a zero-based byte-offset text range.
+type Range struct {
+	Start Position
+	End   Position
+}
+
+// Position is a zero-based line and byte-offset position.
+type Position struct {
+	Line      int
+	Character int
+}
+
+// Attribute is a parsed annotation attribute with source range.
+type Attribute struct {
+	Name       string
+	Value      string
+	Range      Range
+	ValueRange Range
+}
+
+// Annotation is a parsed //migrator annotation comment.
+type Annotation struct {
+	Line           int
+	Directive      string
+	DirectiveRange Range
+	CommentRange   Range
+	Attributes     []Attribute
+	Known          bool
+}
+
+// Scan returns every Ptah annotation comment found in text.
+func Scan(text string) []Annotation {
+	lines := strings.Split(text, "\n")
+	out := make([]Annotation, 0)
+	for lineNo, line := range lines {
+		annotation, ok := scanLine(lineNo, line)
+		if ok {
+			out = append(out, annotation)
+		}
+	}
+	return out
+}
+
+func scanLine(lineNo int, line string) (Annotation, bool) {
+	commentStart := strings.Index(line, "//")
+	if commentStart < 0 {
+		return Annotation{}, false
+	}
+	if strings.TrimSpace(line[:commentStart]) != "" {
+		return Annotation{}, false
+	}
+	bodyStart := commentStart + len("//")
+	for bodyStart < len(line) && (line[bodyStart] == ' ' || line[bodyStart] == '\t') {
+		bodyStart++
+	}
+	if !strings.HasPrefix(line[bodyStart:], "migrator:") {
+		return Annotation{}, false
+	}
+
+	directive, end := readDirective(line[bodyStart:])
+	annotation := Annotation{
+		Line:      lineNo,
+		Directive: directive,
+		DirectiveRange: Range{
+			Start: Position{Line: lineNo, Character: bodyStart},
+			End:   Position{Line: lineNo, Character: bodyStart + end},
+		},
+		CommentRange: Range{
+			Start: Position{Line: lineNo, Character: commentStart},
+			End:   Position{Line: lineNo, Character: len(line)},
+		},
+		Attributes: scanAttributes(lineNo, line),
+	}
+	_, annotation.Known = annotationmeta.Lookup(directive)
+	return annotation, true
+}
+
+func readDirective(body string) (string, int) {
+	best := ""
+	for _, directive := range annotationmeta.Directives() {
+		name := directive.Name
+		if !strings.HasPrefix(body, name) {
+			continue
+		}
+		rest := body[len(name):]
+		if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
+			continue
+		}
+		if len(name) > len(best) {
+			best = name
+		}
+	}
+	if best != "" {
+		return best, len(best)
+	}
+	end := len(body)
+	if i := strings.IndexAny(body, " \t"); i >= 0 {
+		end = i
+	}
+	return body[:end], end
+}
+
+func scanAttributes(lineNo int, line string) []Attribute {
+	matches := attrRe.FindAllStringSubmatchIndex(line, -1)
+	attrs := make([]Attribute, 0, len(matches))
+	for _, match := range matches {
+		nameStart := match[2]
+		nameEnd := match[3]
+		valueStart := match[4]
+		valueEnd := match[5]
+		attrs = append(attrs, Attribute{
+			Name:  line[nameStart:nameEnd],
+			Value: strings.Trim(line[valueStart:valueEnd], `"`),
+			Range: Range{
+				Start: Position{Line: lineNo, Character: nameStart},
+				End:   Position{Line: lineNo, Character: nameEnd},
+			},
+			ValueRange: Range{
+				Start: Position{Line: lineNo, Character: valueStart},
+				End:   Position{Line: lineNo, Character: valueEnd},
+			},
+		})
+	}
+	return attrs
+}

--- a/internal/annotationparse/parse_test.go
+++ b/internal/annotationparse/parse_test.go
@@ -1,0 +1,66 @@
+package annotationparse_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/annotationparse"
+)
+
+func TestScanReportsDirectiveAndAttributeRanges(t *testing.T) {
+	c := qt.New(t)
+
+	annotations := annotationparse.Scan(`package test
+
+type User struct {
+	//migrator:schema:field name="email" type="TEXT" defaul="x"
+	Email string
+}
+`)
+
+	c.Assert(annotations, qt.HasLen, 1)
+	annotation := annotations[0]
+	c.Assert(annotation.Directive, qt.Equals, "migrator:schema:field")
+	c.Assert(annotation.Known, qt.IsTrue)
+	c.Assert(annotation.DirectiveRange.Start.Line, qt.Equals, 3)
+	c.Assert(annotation.DirectiveRange.Start.Character, qt.Equals, 3)
+	c.Assert(annotation.Attributes, qt.HasLen, 3)
+	c.Assert(annotation.Attributes[2].Name, qt.Equals, "defaul")
+	c.Assert(annotation.Attributes[2].Range.Start.Line, qt.Equals, 3)
+	c.Assert(annotation.Attributes[2].Range.Start.Character, qt.Equals, 50)
+	c.Assert(annotation.Attributes[2].Range.End.Character, qt.Equals, 56)
+}
+
+func TestScanUsesLongestKnownDirectiveMatch(t *testing.T) {
+	c := qt.New(t)
+
+	annotations := annotationparse.Scan(`//migrator:schema:rls:policy name="tenant" table="users"`)
+
+	c.Assert(annotations, qt.HasLen, 1)
+	c.Assert(annotations[0].Directive, qt.Equals, "migrator:schema:rls:policy")
+	c.Assert(annotations[0].Known, qt.IsTrue)
+}
+
+func TestScanCapturesUnknownMigratorDirective(t *testing.T) {
+	c := qt.New(t)
+
+	annotations := annotationparse.Scan(`//migrator:schema:foreign_key name="fk"`)
+
+	c.Assert(annotations, qt.HasLen, 1)
+	c.Assert(annotations[0].Directive, qt.Equals, "migrator:schema:foreign_key")
+	c.Assert(annotations[0].Known, qt.IsFalse)
+}
+
+func TestScanIgnoresMigratorTextInsideStringLiterals(t *testing.T) {
+	c := qt.New(t)
+
+	annotations := annotationparse.Scan(`package test
+
+func example() {
+	_ = "//migrator:schema:field defaul=\"x\""
+}
+`)
+
+	c.Assert(annotations, qt.HasLen, 0)
+}

--- a/internal/annotationschema/schema.go
+++ b/internal/annotationschema/schema.go
@@ -1,0 +1,119 @@
+// Package annotationschema renders JSON Schema for Ptah Go annotations.
+package annotationschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
+)
+
+const SchemaPath = "schemas/migrator-annotations.schema.json"
+
+// Generate renders the JSON Schema document.
+func Generate() ([]byte, error) {
+	doc := map[string]any{
+		"$schema":     "https://json-schema.org/draft/2020-12/schema",
+		"$id":         "https://stokaro.github.io/ptah/schemas/migrator-annotations.schema.json",
+		"title":       "Ptah Go Annotation Directives",
+		"description": "Schema for parsed Ptah //migrator Go annotation directives.",
+		"oneOf":       directiveRefs(),
+		"$defs":       directiveDefs(),
+	}
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(doc); err != nil {
+		return nil, fmt.Errorf("encode annotation JSON Schema: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func directiveRefs() []map[string]string {
+	directives := annotationmeta.Directives()
+	refs := make([]map[string]string, 0, len(directives))
+	for _, directive := range directives {
+		refs = append(refs, map[string]string{
+			"$ref": "#/$defs/" + defName(directive.Name),
+		})
+	}
+	return refs
+}
+
+func directiveDefs() map[string]any {
+	defs := make(map[string]any)
+	for _, directive := range annotationmeta.Directives() {
+		defs[defName(directive.Name)] = directiveDef(directive)
+	}
+	return defs
+}
+
+func directiveDef(directive annotationmeta.Directive) map[string]any {
+	requiredAttrs := make([]string, 0)
+	properties := make(map[string]any)
+	for _, attr := range directive.Attributes {
+		properties[attr.Name] = attrSchema(attr)
+		if attr.Required {
+			requiredAttrs = append(requiredAttrs, attr.Name)
+		}
+	}
+	sort.Strings(requiredAttrs)
+
+	attrs := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(requiredAttrs) > 0 {
+		attrs["required"] = requiredAttrs
+	}
+	if directive.AllowPlatform {
+		attrs["patternProperties"] = map[string]any{
+			annotationmeta.PlatformAttributePattern: map[string]any{
+				"type":        "string",
+				"description": "Dialect-specific platform override.",
+			},
+		}
+	}
+
+	return map[string]any{
+		"type":        "object",
+		"description": directive.Description,
+		"properties": map[string]any{
+			"directive":  map[string]any{"const": directive.Name},
+			"attributes": attrs,
+		},
+		"required":             []string{"directive", "attributes"},
+		"additionalProperties": false,
+	}
+}
+
+func attrSchema(attr annotationmeta.Attribute) map[string]any {
+	schema := map[string]any{
+		"description": attr.Description,
+	}
+	switch attr.Value {
+	case "boolean":
+		schema["type"] = "string"
+		schema["enum"] = []string{"true", "false"}
+	case "comma-list", "sql", "string":
+		schema["type"] = "string"
+	default:
+		schema["type"] = "string"
+	}
+	if attr.AliasFor != "" {
+		schema["x-ptah-alias-for"] = attr.AliasFor
+	}
+	if attr.Boolean {
+		schema["x-ptah-bare-boolean"] = true
+	}
+	return schema
+}
+
+func defName(directive string) string {
+	return strings.ReplaceAll(directive, ":", ".")
+}

--- a/internal/annotationschema/schema_test.go
+++ b/internal/annotationschema/schema_test.go
@@ -1,0 +1,44 @@
+package annotationschema_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/annotationschema"
+)
+
+func TestGenerateMatchesCommittedSchema(t *testing.T) {
+	c := qt.New(t)
+
+	generated, err := annotationschema.Generate()
+	c.Assert(err, qt.IsNil)
+	committed, err := os.ReadFile("../../" + annotationschema.SchemaPath)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(string(generated), qt.Equals, string(committed))
+}
+
+func TestGenerateFieldSchemaRejectsUnknownAttributes(t *testing.T) {
+	c := qt.New(t)
+
+	generated, err := annotationschema.Generate()
+	c.Assert(err, qt.IsNil)
+
+	var doc map[string]any
+	c.Assert(json.Unmarshal(generated, &doc), qt.IsNil)
+	defs := doc["$defs"].(map[string]any)
+	field := defs["migrator.schema.field"].(map[string]any)
+	properties := field["properties"].(map[string]any)
+	attrs := properties["attributes"].(map[string]any)
+
+	c.Assert(attrs["additionalProperties"], qt.Equals, false)
+	c.Assert(attrs["patternProperties"], qt.IsNotNil)
+	patterns := attrs["patternProperties"].(map[string]any)
+	c.Assert(patterns[`^platform\.[A-Za-z0-9_]+\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$`], qt.IsNotNil)
+	attrProps := attrs["properties"].(map[string]any)
+	c.Assert(attrProps["default_expr"], qt.IsNotNil)
+	c.Assert(attrProps["defaul"], qt.IsNil)
+}

--- a/internal/ptahls/analysis.go
+++ b/internal/ptahls/analysis.go
@@ -1,0 +1,152 @@
+// Package ptahls implements the Ptah annotation language server.
+package ptahls
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
+	"github.com/stokaro/ptah/internal/annotationparse"
+)
+
+// DiagnosticSeverity follows the LSP DiagnosticSeverity values.
+type DiagnosticSeverity int
+
+const (
+	DiagnosticSeverityError DiagnosticSeverity = 1
+)
+
+// Diagnostic describes an editor diagnostic.
+type Diagnostic struct {
+	Range    annotationparse.Range
+	Severity DiagnosticSeverity
+	Code     string
+	Message  string
+	Source   string
+}
+
+// Completion describes one annotation attribute completion.
+type Completion struct {
+	Label         string
+	Detail        string
+	Documentation string
+}
+
+// Analyze returns diagnostics for Ptah annotations in text.
+func Analyze(text string) []Diagnostic {
+	var diagnostics []Diagnostic
+	for _, annotation := range annotationparse.Scan(text) {
+		if !annotation.Known {
+			diagnostics = append(diagnostics, Diagnostic{
+				Range:    annotation.DirectiveRange,
+				Severity: DiagnosticSeverityError,
+				Code:     "PTAH001",
+				Message:  fmt.Sprintf("unknown Ptah annotation directive %q", annotation.Directive),
+				Source:   "ptah",
+			})
+			continue
+		}
+		spec, _ := annotationmeta.Lookup(annotation.Directive)
+		seen := make(map[string]bool, len(annotation.Attributes))
+		for _, attr := range annotation.Attributes {
+			seen[attr.Name] = true
+			if annotationmeta.AllowsAttribute(annotation.Directive, attr.Name) {
+				continue
+			}
+			diagnostics = append(diagnostics, Diagnostic{
+				Range:    attr.Range,
+				Severity: DiagnosticSeverityError,
+				Code:     "PTAH002",
+				Message:  fmt.Sprintf("unknown attribute %q on //%s", attr.Name, annotation.Directive),
+				Source:   "ptah",
+			})
+		}
+		for _, attr := range spec.Attributes {
+			if !attr.Required || seen[attr.Name] {
+				continue
+			}
+			diagnostics = append(diagnostics, Diagnostic{
+				Range:    annotation.DirectiveRange,
+				Severity: DiagnosticSeverityError,
+				Code:     "PTAH003",
+				Message:  fmt.Sprintf("missing required attribute %q on //%s", attr.Name, annotation.Directive),
+				Source:   "ptah",
+			})
+		}
+	}
+	return diagnostics
+}
+
+// Hover returns Markdown documentation for the annotation at pos.
+func Hover(text string, pos annotationparse.Position) (string, bool) {
+	for _, annotation := range annotationparse.Scan(text) {
+		if annotation.Line != pos.Line || !annotation.Known {
+			continue
+		}
+		if !contains(annotation.CommentRange, pos) {
+			continue
+		}
+		spec, _ := annotationmeta.Lookup(annotation.Directive)
+		return annotationmeta.Markdown(spec), true
+	}
+	return "", false
+}
+
+// Complete returns attribute completions for the annotation at pos.
+func Complete(text string, pos annotationparse.Position) []Completion {
+	for _, annotation := range annotationparse.Scan(text) {
+		if annotation.Line != pos.Line || !annotation.Known {
+			continue
+		}
+		if !contains(annotation.CommentRange, pos) {
+			continue
+		}
+		for _, attr := range annotation.Attributes {
+			if contains(attr.ValueRange, pos) {
+				return nil
+			}
+		}
+		spec, _ := annotationmeta.Lookup(annotation.Directive)
+		used := make(map[string]bool, len(annotation.Attributes))
+		for _, attr := range annotation.Attributes {
+			used[attr.Name] = true
+		}
+		out := make([]Completion, 0, len(spec.Attributes))
+		for _, attr := range spec.Attributes {
+			if used[attr.Name] {
+				continue
+			}
+			detail := attr.Value
+			if attr.Required {
+				detail += ", required"
+			}
+			if attr.AliasFor != "" {
+				detail += ", alias for " + attr.AliasFor
+			}
+			out = append(out, Completion{
+				Label:         attr.Name,
+				Detail:        strings.TrimPrefix(detail, ", "),
+				Documentation: attr.Description,
+			})
+		}
+		slices.SortFunc(out, func(a, b Completion) int {
+			return strings.Compare(a.Label, b.Label)
+		})
+		return out
+	}
+	return nil
+}
+
+func contains(r annotationparse.Range, pos annotationparse.Position) bool {
+	if pos.Line < r.Start.Line || pos.Line > r.End.Line {
+		return false
+	}
+	if pos.Line == r.Start.Line && pos.Character < r.Start.Character {
+		return false
+	}
+	if pos.Line == r.End.Line && pos.Character > r.End.Character {
+		return false
+	}
+	return true
+}

--- a/internal/ptahls/analysis_test.go
+++ b/internal/ptahls/analysis_test.go
@@ -1,0 +1,68 @@
+package ptahls_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/annotationparse"
+	"github.com/stokaro/ptah/internal/ptahls"
+)
+
+func TestAnalyzeReportsUnknownAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	diagnostics := ptahls.Analyze(`package test
+
+type User struct {
+	//migrator:schema:field name="x" defaul="now()"
+	Name string
+}`)
+
+	c.Assert(diagnostics, qt.HasLen, 1)
+	c.Assert(diagnostics[0].Code, qt.Equals, "PTAH002")
+	c.Assert(diagnostics[0].Message, qt.Equals, `unknown attribute "defaul" on //migrator:schema:field`)
+	c.Assert(diagnostics[0].Range.Start.Line, qt.Equals, 3)
+	c.Assert(diagnostics[0].Range.Start.Character, qt.Equals, 34)
+}
+
+func TestHoverShowsRLSPolicyAttributes(t *testing.T) {
+	c := qt.New(t)
+
+	hover, ok := ptahls.Hover(
+		`//migrator:schema:rls:policy name="tenant" table="users"`,
+		annotationparse.Position{Line: 0, Character: 20},
+	)
+
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(hover, qt.Contains, "`//migrator:schema:rls:policy`")
+	c.Assert(hover, qt.Contains, "`using`")
+	c.Assert(hover, qt.Contains, "`with_check`")
+}
+
+func TestCompleteReturnsUnusedAttributes(t *testing.T) {
+	c := qt.New(t)
+
+	items := ptahls.Complete(
+		`//migrator:schema:field name="email" `,
+		annotationparse.Position{Line: 0, Character: 20},
+	)
+
+	var labels []string
+	for _, item := range items {
+		labels = append(labels, item.Label)
+	}
+	c.Assert(labels, qt.Contains, "default_expr")
+	c.Assert(labels, qt.Not(qt.Contains), "name")
+}
+
+func TestCompleteSuppressesAttributeNamesInsideValues(t *testing.T) {
+	c := qt.New(t)
+
+	items := ptahls.Complete(
+		`//migrator:schema:field name="email" default="now()"`,
+		annotationparse.Position{Line: 0, Character: 45},
+	)
+
+	c.Assert(items, qt.HasLen, 0)
+}

--- a/internal/ptahls/server.go
+++ b/internal/ptahls/server.go
@@ -1,0 +1,432 @@
+package ptahls
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/stokaro/ptah/internal/annotationparse"
+)
+
+const maxContentLength = 16 << 20
+
+var (
+	errExit               = errors.New("lsp exit")
+	errExitBeforeShutdown = errors.New("lsp exit before shutdown")
+)
+
+// ServerOptions configures the Ptah LSP server.
+type ServerOptions struct {
+	Version string
+}
+
+// Run serves the Ptah LSP protocol over reader/writer.
+func Run(ctx context.Context, reader io.Reader, writer io.Writer) error {
+	return RunWithOptions(ctx, reader, writer, ServerOptions{})
+}
+
+// RunWithOptions serves the Ptah LSP protocol with explicit server metadata.
+func RunWithOptions(ctx context.Context, reader io.Reader, writer io.Writer, opts ServerOptions) error {
+	server := &server{
+		reader:  bufio.NewReader(reader),
+		writer:  writer,
+		docs:    make(map[string]string),
+		version: opts.Version,
+	}
+	return server.run(ctx)
+}
+
+type server struct {
+	reader   *bufio.Reader
+	writer   io.Writer
+	mu       sync.Mutex
+	docs     map[string]string
+	version  string
+	shutdown bool
+}
+
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type textDocumentIdentifier struct {
+	URI string `json:"uri"`
+}
+
+type position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+type rangeValue struct {
+	Start position `json:"start"`
+	End   position `json:"end"`
+}
+
+type textDocumentItem struct {
+	URI  string `json:"uri"`
+	Text string `json:"text"`
+}
+
+type didOpenParams struct {
+	TextDocument textDocumentItem `json:"textDocument"`
+}
+
+type contentChange struct {
+	Text string `json:"text"`
+}
+
+type didChangeParams struct {
+	TextDocument   textDocumentIdentifier `json:"textDocument"`
+	ContentChanges []contentChange        `json:"contentChanges"`
+}
+
+type didCloseParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+}
+
+type hoverParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+	Position     position               `json:"position"`
+}
+
+type completionParams hoverParams
+
+type publishDiagnosticsParams struct {
+	URI         string          `json:"uri"`
+	Diagnostics []lspDiagnostic `json:"diagnostics"`
+}
+
+type lspDiagnostic struct {
+	Range    rangeValue `json:"range"`
+	Severity int        `json:"severity"`
+	Code     string     `json:"code"`
+	Source   string     `json:"source"`
+	Message  string     `json:"message"`
+}
+
+type completionItem struct {
+	Label         string        `json:"label"`
+	Kind          int           `json:"kind,omitempty"`
+	Detail        string        `json:"detail,omitempty"`
+	Documentation markupContent `json:"documentation"`
+}
+
+type markupContent struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+func (s *server) run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		msg, err := s.readMessage()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if err := s.handle(msg); err != nil {
+			if errors.Is(err, errExit) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func (s *server) handle(msg rpcMessage) error {
+	switch msg.Method {
+	case "initialize":
+		serverInfo := map[string]string{
+			"name": "ptah-ls",
+		}
+		if s.version != "" {
+			serverInfo["version"] = s.version
+		}
+		return s.respond(msg.ID, map[string]any{
+			"capabilities": map[string]any{
+				"textDocumentSync": 1,
+				"hoverProvider":    true,
+				"completionProvider": map[string]any{
+					"triggerCharacters": []string{" "},
+				},
+			},
+			"serverInfo": serverInfo,
+		})
+	case "shutdown":
+		s.shutdown = true
+		return s.respond(msg.ID, nil)
+	case "exit":
+		if s.shutdown {
+			return errExit
+		}
+		return errExitBeforeShutdown
+	case "textDocument/didOpen":
+		var params didOpenParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return s.respondError(msg.ID, -32602, err.Error())
+		}
+		s.docs[params.TextDocument.URI] = params.TextDocument.Text
+		return s.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didChange":
+		var params didChangeParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return s.respondError(msg.ID, -32602, err.Error())
+		}
+		if len(params.ContentChanges) > 0 {
+			s.docs[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
+		}
+		return s.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didClose":
+		var params didCloseParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return s.respondError(msg.ID, -32602, err.Error())
+		}
+		delete(s.docs, params.TextDocument.URI)
+		return s.sendNotification("textDocument/publishDiagnostics", publishDiagnosticsParams{
+			URI:         params.TextDocument.URI,
+			Diagnostics: []lspDiagnostic{},
+		})
+	case "textDocument/hover":
+		var params hoverParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return s.respondError(msg.ID, -32602, err.Error())
+		}
+		text := s.docs[params.TextDocument.URI]
+		value, ok := Hover(text, fromLSPPosition(text, params.Position))
+		if !ok {
+			return s.respond(msg.ID, nil)
+		}
+		return s.respond(msg.ID, map[string]any{
+			"contents": markupContent{Kind: "markdown", Value: value},
+		})
+	case "textDocument/completion":
+		var params completionParams
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return s.respondError(msg.ID, -32602, err.Error())
+		}
+		text := s.docs[params.TextDocument.URI]
+		return s.respond(msg.ID, toCompletionItems(Complete(text, fromLSPPosition(text, params.Position))))
+	default:
+		if msg.ID == nil {
+			return nil
+		}
+		return s.respondError(msg.ID, -32601, "method not found")
+	}
+}
+
+func (s *server) publishDiagnostics(uri string) error {
+	text := s.docs[uri]
+	diagnostics := Analyze(text)
+	return s.sendNotification("textDocument/publishDiagnostics", publishDiagnosticsParams{
+		URI:         uri,
+		Diagnostics: toLSPDiagnostics(text, diagnostics),
+	})
+}
+
+func (s *server) readMessage() (rpcMessage, error) {
+	contentLength := -1
+	for {
+		line, err := s.reader.ReadString('\n')
+		if err != nil {
+			return rpcMessage{}, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil {
+				return rpcMessage{}, fmt.Errorf("invalid Content-Length %q: %w", value, err)
+			}
+			contentLength = n
+		}
+	}
+	if contentLength < 0 {
+		return rpcMessage{}, fmt.Errorf("missing Content-Length header")
+	}
+	if contentLength > maxContentLength {
+		return rpcMessage{}, fmt.Errorf("Content-Length %d exceeds limit", contentLength)
+	}
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(s.reader, body); err != nil {
+		return rpcMessage{}, err
+	}
+	var msg rpcMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return rpcMessage{}, fmt.Errorf("decode LSP message: %w", err)
+	}
+	return msg, nil
+}
+
+func (s *server) respond(id any, result any) error {
+	return s.writePayload(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	})
+}
+
+func (s *server) respondError(id any, code int, message string) error {
+	return s.writeMessage(rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: message},
+	})
+}
+
+func (s *server) sendNotification(method string, params any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return s.writeMessage(rpcMessage{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  raw,
+	})
+}
+
+func (s *server) writeMessage(msg rpcMessage) error {
+	return s.writePayload(msg)
+}
+
+func (s *server) writePayload(payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Content-Length: %d\r\n\r\n", len(body))
+	buf.Write(body)
+	_, err = s.writer.Write(buf.Bytes())
+	return err
+}
+
+func toLSPDiagnostics(text string, diagnostics []Diagnostic) []lspDiagnostic {
+	out := make([]lspDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		out = append(out, lspDiagnostic{
+			Range:    toLSPRange(text, diagnostic.Range),
+			Severity: int(diagnostic.Severity),
+			Code:     diagnostic.Code,
+			Source:   diagnostic.Source,
+			Message:  diagnostic.Message,
+		})
+	}
+	return out
+}
+
+func toLSPRange(text string, r annotationparse.Range) rangeValue {
+	return rangeValue{
+		Start: toLSPPosition(text, r.Start),
+		End:   toLSPPosition(text, r.End),
+	}
+}
+
+func toLSPPosition(text string, pos annotationparse.Position) position {
+	line, ok := lineAt(text, pos.Line)
+	if !ok {
+		return position{Line: pos.Line, Character: pos.Character}
+	}
+	return position{Line: pos.Line, Character: byteOffsetToUTF16(line, pos.Character)}
+}
+
+func fromLSPPosition(text string, pos position) annotationparse.Position {
+	line, ok := lineAt(text, pos.Line)
+	if !ok {
+		return annotationparse.Position{Line: pos.Line, Character: pos.Character}
+	}
+	return annotationparse.Position{Line: pos.Line, Character: utf16ToByteOffset(line, pos.Character)}
+}
+
+func lineAt(text string, lineNo int) (string, bool) {
+	if lineNo < 0 {
+		return "", false
+	}
+	for i, line := range strings.Split(text, "\n") {
+		if i == lineNo {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+func byteOffsetToUTF16(line string, offset int) int {
+	if offset <= 0 {
+		return 0
+	}
+	units := 0
+	for byteIndex, r := range line {
+		if byteIndex >= offset {
+			return units
+		}
+		units += utf16RuneLen(r)
+	}
+	return units
+}
+
+func utf16ToByteOffset(line string, character int) int {
+	if character <= 0 {
+		return 0
+	}
+	units := 0
+	for byteIndex, r := range line {
+		next := units + utf16RuneLen(r)
+		if next > character {
+			return byteIndex
+		}
+		units = next
+	}
+	return len(line)
+}
+
+func utf16RuneLen(r rune) int {
+	if r >= 0x10000 {
+		return 2
+	}
+	return 1
+}
+
+func toCompletionItems(completions []Completion) []completionItem {
+	items := make([]completionItem, 0, len(completions))
+	for _, completion := range completions {
+		items = append(items, completionItem{
+			Label:         completion.Label,
+			Kind:          10,
+			Detail:        completion.Detail,
+			Documentation: markupContent{Kind: "markdown", Value: completion.Documentation},
+		})
+	}
+	return items
+}

--- a/internal/ptahls/server_test.go
+++ b/internal/ptahls/server_test.go
@@ -1,0 +1,137 @@
+package ptahls
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestRunPublishesUTF16DiagnosticsAndHandlesExit(t *testing.T) {
+	c := qt.New(t)
+
+	const uri = "file:///workspace/model.go"
+	text := `//migrator:schema:field comment="привет" defaul="x"`
+	input := framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params":  map[string]any{},
+	}) + framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "textDocument/didOpen",
+		"params": map[string]any{
+			"textDocument": map[string]any{
+				"uri":  uri,
+				"text": text,
+			},
+		},
+	}) + framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "textDocument/didClose",
+		"params": map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+		},
+	}) + framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "shutdown",
+		"params":  map[string]any{},
+	}) + framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "exit",
+	})
+
+	var out bytes.Buffer
+	err := RunWithOptions(context.Background(), strings.NewReader(input), &out, ServerOptions{Version: "v-test"})
+	c.Assert(err, qt.IsNil)
+
+	messages := readFramedMessages(c, out.String())
+	c.Assert(messages, qt.HasLen, 4)
+
+	initialize := decodeResult(c, messages[0])
+	c.Assert(initialize["serverInfo"], qt.DeepEquals, map[string]any{
+		"name":    "ptah-ls",
+		"version": "v-test",
+	})
+	c.Assert(initialize["capabilities"].(map[string]any)["completionProvider"], qt.DeepEquals, map[string]any{
+		"triggerCharacters": []any{" "},
+	})
+
+	params := decodeDiagnostics(c, messages[1])
+	c.Assert(params.URI, qt.Equals, uri)
+	c.Assert(params.Diagnostics, qt.HasLen, 1)
+	c.Assert(params.Diagnostics[0].Code, qt.Equals, "PTAH002")
+	c.Assert(params.Diagnostics[0].Range.Start.Character, qt.Equals, byteOffsetToUTF16(text, strings.Index(text, "defaul")))
+
+	clearParams := decodeDiagnostics(c, messages[2])
+	c.Assert(clearParams.Diagnostics, qt.HasLen, 0)
+	c.Assert(string(messages[2].Params), qt.Contains, `"diagnostics":[]`)
+}
+
+func TestRunReturnsErrorWhenExitArrivesBeforeShutdown(t *testing.T) {
+	c := qt.New(t)
+
+	err := Run(context.Background(), strings.NewReader(framedMessage(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "exit",
+	})), &bytes.Buffer{})
+
+	c.Assert(err, qt.ErrorIs, errExitBeforeShutdown)
+}
+
+func TestReadMessageRejectsOversizedContentLength(t *testing.T) {
+	c := qt.New(t)
+
+	s := &server{reader: bufio.NewReader(strings.NewReader("Content-Length: 16777217\r\n\r\n"))}
+	_, err := s.readMessage()
+
+	c.Assert(err, qt.ErrorMatches, "Content-Length 16777217 exceeds limit")
+}
+
+func framedMessage(payload any) string {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)
+}
+
+func readFramedMessages(c *qt.C, text string) []rpcMessage {
+	c.Helper()
+
+	s := &server{reader: bufio.NewReader(strings.NewReader(text))}
+	var messages []rpcMessage
+	for {
+		msg, err := s.readMessage()
+		if err != nil {
+			c.Assert(err, qt.ErrorIs, io.EOF)
+			return messages
+		}
+		messages = append(messages, msg)
+	}
+}
+
+func decodeResult(c *qt.C, msg rpcMessage) map[string]any {
+	c.Helper()
+
+	raw, err := json.Marshal(msg.Result)
+	c.Assert(err, qt.IsNil)
+	var result map[string]any
+	c.Assert(json.Unmarshal(raw, &result), qt.IsNil)
+	return result
+}
+
+func decodeDiagnostics(c *qt.C, msg rpcMessage) publishDiagnosticsParams {
+	c.Helper()
+
+	var params publishDiagnosticsParams
+	c.Assert(json.Unmarshal(msg.Params, &params), qt.IsNil)
+	return params
+}

--- a/schemas/migrator-annotations.schema.json
+++ b/schemas/migrator-annotations.schema.json
@@ -1,0 +1,1098 @@
+{
+  "$defs": {
+    "migrator.embedded": {
+      "additionalProperties": false,
+      "description": "Controls how an embedded Go field contributes schema objects.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "comment": {
+              "description": "Generated column comment.",
+              "type": "string"
+            },
+            "field": {
+              "description": "Generated relation field name.",
+              "type": "string"
+            },
+            "index": {
+              "description": "Requests an index for generated relation columns.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "mode": {
+              "description": "Embedding mode: inline, json, or relation.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Column name for json embedding.",
+              "type": "string"
+            },
+            "not_null": {
+              "description": "Compatibility flag accepted on embedded annotations.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "nullable": {
+              "description": "Marks generated embedded columns nullable.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "on_delete": {
+              "description": "Generated foreign key ON DELETE action.",
+              "type": "string"
+            },
+            "on_update": {
+              "description": "Generated foreign key ON UPDATE action.",
+              "type": "string"
+            },
+            "prefix": {
+              "description": "Column prefix for inline embedded fields.",
+              "type": "string"
+            },
+            "ref": {
+              "description": "Relation target in table(column) form.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Column type for json embedding.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:embedded"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.constraint": {
+      "additionalProperties": false,
+      "description": "Declares a table constraint.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "check": {
+              "description": "CHECK expression.",
+              "type": "string"
+            },
+            "columns": {
+              "description": "Comma-separated local columns.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Constraint comment.",
+              "type": "string"
+            },
+            "condition": {
+              "description": "Constraint WHERE condition.",
+              "type": "string"
+            },
+            "elements": {
+              "description": "EXCLUDE constraint elements.",
+              "type": "string"
+            },
+            "foreign_column": {
+              "description": "Single referenced column for FOREIGN KEY constraints.",
+              "type": "string"
+            },
+            "foreign_columns": {
+              "description": "Comma-separated referenced columns for composite FOREIGN KEY constraints.",
+              "type": "string"
+            },
+            "foreign_table": {
+              "description": "Referenced table for FOREIGN KEY constraints.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Constraint name.",
+              "type": "string"
+            },
+            "nulls_distinct": {
+              "description": "Controls NULLS DISTINCT behavior where supported.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "on_delete": {
+              "description": "Foreign key ON DELETE action.",
+              "type": "string"
+            },
+            "on_update": {
+              "description": "Foreign key ON UPDATE action.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Explicit target table.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Constraint type: CHECK, UNIQUE, PRIMARY KEY, FOREIGN KEY, or EXCLUDE.",
+              "type": "string"
+            },
+            "using": {
+              "description": "EXCLUDE index method.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:constraint"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.enum": {
+      "additionalProperties": false,
+      "description": "Declares a reusable enum type.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "description": "Enum type name.",
+              "type": "string"
+            },
+            "values": {
+              "description": "Comma-separated enum values.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "values"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:enum"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.extension": {
+      "additionalProperties": false,
+      "description": "Declares a PostgreSQL extension.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "comment": {
+              "description": "Extension comment.",
+              "type": "string"
+            },
+            "if_not_exists": {
+              "description": "Adds IF NOT EXISTS where supported.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Extension name.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Extension version.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:extension"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.field": {
+      "additionalProperties": false,
+      "description": "Maps a Go struct field to a database column.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "auto_increment": {
+              "description": "Marks the column as auto-incrementing.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "autoincrement": {
+              "description": "Legacy auto-increment spelling.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-alias-for": "auto_increment",
+              "x-ptah-bare-boolean": true
+            },
+            "check": {
+              "description": "Column CHECK expression.",
+              "type": "string"
+            },
+            "check_name": {
+              "description": "Explicit CHECK constraint name.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Column comment.",
+              "type": "string"
+            },
+            "default": {
+              "description": "Literal column default.",
+              "type": "string"
+            },
+            "default_expr": {
+              "description": "SQL default expression.",
+              "type": "string"
+            },
+            "enum": {
+              "description": "Comma-separated enum values.",
+              "type": "string"
+            },
+            "foreign": {
+              "description": "Foreign key reference in table(column) form.",
+              "type": "string"
+            },
+            "foreign_key_name": {
+              "description": "Explicit foreign key constraint name.",
+              "type": "string"
+            },
+            "generated": {
+              "description": "Generated column expression.",
+              "type": "string"
+            },
+            "generated_kind": {
+              "description": "Generated column kind, such as STORED or VIRTUAL.",
+              "type": "string"
+            },
+            "identity_generation": {
+              "description": "SQL identity generation mode.",
+              "type": "string"
+            },
+            "identity_increment": {
+              "description": "SQL identity increment value.",
+              "type": "string"
+            },
+            "identity_options": {
+              "description": "Raw SQL identity options.",
+              "type": "string"
+            },
+            "identity_start": {
+              "description": "SQL identity start value.",
+              "type": "string"
+            },
+            "index": {
+              "description": "Bareword compatibility flag accepted by the parser.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "name": {
+              "description": "Column name.",
+              "type": "string"
+            },
+            "not_null": {
+              "description": "Marks the column NOT NULL.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "nullable": {
+              "description": "Bareword compatibility flag accepted by the parser.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "on_delete": {
+              "description": "Foreign key ON DELETE action.",
+              "type": "string"
+            },
+            "on_update": {
+              "description": "Foreign key ON UPDATE action.",
+              "type": "string"
+            },
+            "primary": {
+              "description": "Marks the column as part of the primary key.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "stored": {
+              "description": "Shortcut controlling generated column storage.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "type": {
+              "description": "Database column type.",
+              "type": "string"
+            },
+            "unique": {
+              "description": "Adds a single-column unique constraint.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "unique_expr": {
+              "description": "Unique expression for dialects that support expression indexes.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:field"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.function": {
+      "additionalProperties": false,
+      "description": "Declares a database function.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "description": "Function body SQL.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Function comment.",
+              "type": "string"
+            },
+            "language": {
+              "description": "Function language.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Function name.",
+              "type": "string"
+            },
+            "params": {
+              "description": "Function parameter list.",
+              "type": "string"
+            },
+            "returns": {
+              "description": "Return type.",
+              "type": "string"
+            },
+            "security": {
+              "description": "Security mode, such as DEFINER.",
+              "type": "string"
+            },
+            "volatility": {
+              "description": "Volatility class.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:function"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.grant": {
+      "additionalProperties": false,
+      "description": "Declares database grants.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "comment": {
+              "description": "Grant comment.",
+              "type": "string"
+            },
+            "grant_option": {
+              "description": "Alias for with_option.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-alias-for": "with_option"
+            },
+            "on_schema": {
+              "description": "Target schema.",
+              "type": "string"
+            },
+            "on_table": {
+              "description": "Target table.",
+              "type": "string"
+            },
+            "privilege": {
+              "description": "Privilege or comma-separated privileges.",
+              "type": "string"
+            },
+            "privileges": {
+              "description": "Alias for privilege.",
+              "type": "string",
+              "x-ptah-alias-for": "privilege"
+            },
+            "role": {
+              "description": "Target role.",
+              "type": "string"
+            },
+            "with_option": {
+              "description": "Adds WITH GRANT OPTION where supported.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:grant"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.index": {
+      "additionalProperties": false,
+      "description": "Declares an index for a table.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "columns": {
+              "description": "Legacy synonym for fields.",
+              "type": "string",
+              "x-ptah-alias-for": "fields"
+            },
+            "comment": {
+              "description": "Index comment.",
+              "type": "string"
+            },
+            "condition": {
+              "description": "Partial index condition.",
+              "type": "string"
+            },
+            "fields": {
+              "description": "Comma-separated Go field or column names.",
+              "type": "string"
+            },
+            "granularity": {
+              "description": "ClickHouse data-skipping index granularity.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Index name.",
+              "type": "string"
+            },
+            "nulls_distinct": {
+              "description": "Controls NULLS DISTINCT behavior where supported.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "ops": {
+              "description": "PostgreSQL operator class.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Explicit target table.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Index type or method.",
+              "type": "string"
+            },
+            "unique": {
+              "description": "Creates a unique index.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-bare-boolean": true
+            },
+            "where": {
+              "description": "Atlas-style partial index condition alias.",
+              "type": "string",
+              "x-ptah-alias-for": "condition"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:index"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.matview": {
+      "additionalProperties": false,
+      "description": "Declares a materialized view.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "body": {
+              "description": "Materialized view SELECT body.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Materialized view comment.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Materialized view name.",
+              "type": "string"
+            },
+            "refresh_strategy": {
+              "description": "Refresh strategy; defaults to manual.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "body",
+            "name"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:matview"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.rls.enable": {
+      "additionalProperties": false,
+      "description": "Enables row-level security on a table.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "comment": {
+              "description": "RLS enablement comment.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Target table.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:rls:enable"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.rls.policy": {
+      "additionalProperties": false,
+      "description": "Declares a row-level security policy.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "comment": {
+              "description": "Policy comment.",
+              "type": "string"
+            },
+            "for": {
+              "description": "Policy command, such as ALL or SELECT.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Policy name.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Target table.",
+              "type": "string"
+            },
+            "to": {
+              "description": "Comma-separated roles.",
+              "type": "string"
+            },
+            "using": {
+              "description": "USING expression.",
+              "type": "string"
+            },
+            "with_check": {
+              "description": "WITH CHECK expression.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:rls:policy"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.role": {
+      "additionalProperties": false,
+      "description": "Declares a database role.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "comment": {
+              "description": "Role comment.",
+              "type": "string"
+            },
+            "create_db": {
+              "description": "Alias for createdb.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-alias-for": "createdb"
+            },
+            "create_role": {
+              "description": "Alias for createrole.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string",
+              "x-ptah-alias-for": "createrole"
+            },
+            "createdb": {
+              "description": "Allows database creation.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "createrole": {
+              "description": "Allows role creation.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "inherit": {
+              "description": "Controls role inheritance; defaults to true.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "login": {
+              "description": "Creates the role with LOGIN.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Role name.",
+              "type": "string"
+            },
+            "password": {
+              "description": "Role password.",
+              "type": "string"
+            },
+            "replication": {
+              "description": "Allows replication.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            },
+            "superuser": {
+              "description": "Creates the role as SUPERUSER.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:role"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.schema": {
+      "additionalProperties": false,
+      "description": "Declares a database schema or namespace.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "comment": {
+              "description": "Schema comment.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Schema name.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:schema"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.table": {
+      "additionalProperties": false,
+      "description": "Maps a Go struct to a database table.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "checks": {
+              "description": "Comma-separated table-level check expressions.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Table comment.",
+              "type": "string"
+            },
+            "custom": {
+              "description": "Raw custom CREATE TABLE SQL.",
+              "type": "string"
+            },
+            "engine": {
+              "description": "MySQL/MariaDB table engine shortcut.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Table name.",
+              "type": "string"
+            },
+            "primary_key": {
+              "description": "Comma-separated primary key columns.",
+              "type": "string"
+            },
+            "schema": {
+              "description": "Database schema name.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:table"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.trigger": {
+      "additionalProperties": false,
+      "description": "Declares a database trigger.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "body": {
+              "description": "Trigger body SQL.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Trigger comment.",
+              "type": "string"
+            },
+            "event": {
+              "description": "Trigger event, such as INSERT or UPDATE.",
+              "type": "string"
+            },
+            "for": {
+              "description": "Trigger granularity; defaults to ROW.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Trigger name.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Target table.",
+              "type": "string"
+            },
+            "timing": {
+              "description": "Trigger timing, such as BEFORE or AFTER.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "body",
+            "event",
+            "name",
+            "table",
+            "timing"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:trigger"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
+    "migrator.schema.view": {
+      "additionalProperties": false,
+      "description": "Declares a database view.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^platform\\.[A-Za-z0-9_]+\\.[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)*$": {
+              "description": "Dialect-specific platform override.",
+              "type": "string"
+            }
+          },
+          "properties": {
+            "body": {
+              "description": "View SELECT body.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "View comment.",
+              "type": "string"
+            },
+            "name": {
+              "description": "View name.",
+              "type": "string"
+            },
+            "with_check": {
+              "description": "Controls WITH CHECK OPTION where supported.",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "body",
+            "name"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:view"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://stokaro.github.io/ptah/schemas/migrator-annotations.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema for parsed Ptah //migrator Go annotation directives.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/migrator.schema.field"
+    },
+    {
+      "$ref": "#/$defs/migrator.embedded"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.index"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.table"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.schema"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.constraint"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.enum"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.extension"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.function"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.view"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.matview"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.trigger"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.rls.policy"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.rls.enable"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.role"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.grant"
+    }
+  ],
+  "title": "Ptah Go Annotation Directives"
+}


### PR DESCRIPTION
Closes #168.

## What Changed

- Added `internal/annotationmeta` as the shared directive/attribute metadata source for parser validation, JSON Schema generation, hover docs, and completions.
- Added `ptah schema annotations --format json-schema` and committed `schemas/migrator-annotations.schema.json`.
- Added `ptah-ls`, a small stdio LSP server with diagnostics, hover, completions, UTF-16 LSP position conversion, lifecycle handling, and bounded Content-Length parsing.
- Added a thin VS Code wrapper under `editors/vscode`, including Workspace Trust restrictions for the configurable language-server path.
- Wired `ptah-ls` into local builds, GoReleaser archives/Homebrew formula, release docs, and CI schema freshness checks.
- Hardened parser validation so all existing annotation directive families reject unknown attributes consistently.

## Self-Review Notes

- Pass 1 fixed review findings around file-scope metadata drift, platform override validation, LSP UTF-16 positions, stale diagnostic clearing, `exit` handling, Content-Length limits, and `ptah-ls --version`.
- Pass 2 checked generated schema freshness, VS Code workspace trust, release packaging paths, README examples, and acceptance coverage for `defaul` diagnostics and `rls:policy` hover docs.

## Validation

- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./internal/annotationmeta ./internal/annotationparse ./internal/annotationschema ./internal/ptahls ./cmd/ptah-ls ./cmd/schema ./core/goschema/internal/parseutils ./core/goschema`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go run ./cmd/ptah schema annotations --out schemas/migrator-annotations.schema.json`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go build -o /private/tmp/ptah-ls-check ./cmd/ptah-ls`
- `/private/tmp/ptah-ls-check --version`
- `env npm_config_cache=/private/tmp/ptah-npm-cache npm pack --dry-run --json`
- `node --check editors/vscode/extension.js`
- `goreleaser check`
- `git diff --check`
