### PR TITLE
Add migration pre-flight hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,12 @@ Apply all pending migrations to bring database up to latest version:
 
 # Apply Atlas SQL template migrations with .Env set to dev
 ./ptah migrations up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --dir-format atlas --atlas-env dev
+
+# Run a custom backup gate before applying migrations
+./ptah migrations up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --pre-up-hook './scripts/backup-before-migrate'
+
+# Write a PostgreSQL custom-format dump before applying migrations
+./ptah migrations up --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --pg-dump-to ./backups
 ```
 
 Migration files can override the CLI defaults with top-of-file directives:
@@ -1162,6 +1168,36 @@ If the tool is not on PATH, ptah warns and falls back to a plain `ALTER TABLE`.
 See [docs/online-ddl.md](docs/online-ddl.md) for prerequisites (binlog ROW format,
 privileges, topology flags) and invocation details.
 
+**Pre-flight backup hooks:** `migrations up` and `migrations down` can run
+operator-defined checks before changing the schema. Use `--pre-up-hook <cmd>`
+or `--pre-down-hook <cmd>` for a shell command, `--pg-dump-to <dir>` for a
+PostgreSQL-compatible custom-format dump, `--mysqldump-to <dir>` for a MySQL or
+MariaDB SQL dump, and `--webhook <url>` to POST migration metadata to an
+external coordinator. A hook must succeed before Ptah starts applying or
+rolling back migrations; non-zero command exit, dump failure, webhook network
+failure, or a non-200 webhook response aborts the migration.
+
+Custom hook commands receive `PTAH_DB_URL`, `PTAH_DIALECT`,
+`PTAH_CURRENT_VERSION`, and `PTAH_TARGET_VERSION`. Built-in dump files are named
+`ptah_pre_v{from}_to_v{to}_{ts}.dump` for `pg_dump` and
+`ptah_pre_v{from}_to_v{to}_{ts}.sql` for `mysqldump`, with a high-precision UTC
+timestamp. The webhook payload includes direction, dialect, current version, target version,
+and a redacted database URL. Webhooks have a 30-second timeout and redirects are
+not followed, so the configured endpoint itself must return HTTP 200. Dry-run
+mode reports configured pre-flight hooks but skips them because backups and
+webhooks are side effects.
+
+The same settings can live in `ptah.yaml`:
+
+```yaml
+migration:
+  pre_up_hook: ./scripts/backup-before-up
+  pre_down_hook: ./scripts/backup-before-down
+  pg_dump_to: ./backups/postgres
+  mysqldump_to: ./backups/mysql
+  webhook: https://ops.example/hooks/ptah-migration
+```
+
 #### Roll Back Migrations
 Roll back migrations to a specific version:
 
@@ -1176,6 +1212,9 @@ Roll back migrations to a specific version:
 
 # Roll back using the same custom migration state table
 ./ptah migrations down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --migrations-schema infra --migrations-table ptah_migrations
+
+# Run a custom backup gate before rollback
+./ptah migrations down --db-url postgres://user:pass@localhost:5432/database --migrations-dir ./migrations --target 5 --pre-down-hook './scripts/backup-before-rollback'
 ```
 
 **Features:**

--- a/cmd/internal/dbcli/preflight.go
+++ b/cmd/internal/dbcli/preflight.go
@@ -1,0 +1,65 @@
+package dbcli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stokaro/ptah/internal/preflight"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// MigrationPreflightRequest contains the CLI context for one migration
+// pre-flight run.
+type MigrationPreflightRequest struct {
+	DryRun bool
+	Hooks  preflight.Options
+}
+
+// RunMigrationPreflight runs configured migration pre-flight hooks, or reports
+// that they were skipped for dry-run commands because backup hooks have side
+// effects.
+func RunMigrationPreflight(ctx context.Context, req MigrationPreflightRequest) error {
+	if !req.Hooks.Enabled() {
+		return nil
+	}
+	if req.DryRun {
+		fmt.Println("Pre-flight hooks configured; skipped in dry-run mode")
+		return nil
+	}
+
+	fmt.Println("Running pre-flight hooks...")
+	results, err := preflight.Runner{Stdout: os.Stdout}.Execute(ctx, req.Hooks)
+	if err != nil {
+		return err
+	}
+	for _, result := range results {
+		if result.Artifact != "" {
+			fmt.Printf("Pre-flight %s completed: %s\n", result.Name, result.Artifact)
+			continue
+		}
+		fmt.Printf("Pre-flight %s completed\n", result.Name)
+	}
+	return nil
+}
+
+// LockedMigrationPreflightHook adapts configured CLI pre-flight hooks into a
+// migrator hook that receives the migration plan selected under the migration
+// lock.
+func LockedMigrationPreflightHook(dryRun bool, opts preflight.Options) migrator.PreMigrationHook {
+	if !opts.Enabled() {
+		return nil
+	}
+	return func(ctx context.Context, plan migrator.MigrationPlan) error {
+		opts.CurrentVersion = plan.CurrentVersion
+		opts.TargetVersion = plan.TargetVersion
+		if err := RunMigrationPreflight(ctx, MigrationPreflightRequest{
+			DryRun: dryRun,
+			Hooks:  opts,
+		}); err != nil {
+			return err
+		}
+		fmt.Println()
+		return nil
+	}
+}

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/onlineddl"
+	"github.com/stokaro/ptah/internal/preflight"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -46,6 +47,10 @@ const (
 	migrationLockTimeoutFlag = "migration-lock-timeout"
 	lockTimeoutFlag          = "lock-timeout"
 	statementTimeoutFlag     = "statement-timeout"
+	preDownHookFlag          = "pre-down-hook"
+	pgDumpToFlag             = "pg-dump-to"
+	mySQLDumpToFlag          = "mysqldump-to"
+	webhookFlag              = "webhook"
 )
 
 var migrateDownFlags = map[string]cobraflags.Flag{
@@ -109,6 +114,26 @@ var migrateDownFlags = map[string]cobraflags.Flag{
 		Value: "",
 		Usage: "Default per-migration statement timeout, such as 30s or 2m",
 	},
+	preDownHookFlag: &cobraflags.StringFlag{
+		Name:  preDownHookFlag,
+		Value: "",
+		Usage: "Shell command to run before rolling back migrations; aborts unless it exits 0",
+	},
+	pgDumpToFlag: &cobraflags.StringFlag{
+		Name:  pgDumpToFlag,
+		Value: "",
+		Usage: "Directory where pg_dump writes a custom-format backup before rolling back migrations",
+	},
+	mySQLDumpToFlag: &cobraflags.StringFlag{
+		Name:  mySQLDumpToFlag,
+		Value: "",
+		Usage: "Directory where mysqldump writes a SQL backup before rolling back migrations",
+	},
+	webhookFlag: &cobraflags.StringFlag{
+		Name:  webhookFlag,
+		Value: "",
+		Usage: "Webhook URL to POST migration metadata before rolling back migrations; must return HTTP 200",
+	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
 	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
@@ -141,6 +166,10 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 	migrationLockTimeoutValue := migrateDownFlags[migrationLockTimeoutFlag].GetString()
 	lockTimeout := migrateDownFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateDownFlags[statementTimeoutFlag].GetString()
+	preDownHook := migrateDownFlags[preDownHookFlag].GetString()
+	pgDumpTo := migrateDownFlags[pgDumpToFlag].GetString()
+	mySQLDumpTo := migrateDownFlags[mySQLDumpToFlag].GetString()
+	webhook := migrateDownFlags[webhookFlag].GetString()
 	migrationsSchema := migrateDownFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateDownFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateDownFlags[dbcli.RevisionTableFormatFlagName].GetString()
@@ -158,6 +187,10 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
 	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
 	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
+	preDownHook = dbcli.EffectiveString(cmd, preDownHookFlag, preDownHook, projectCfg.Migration.PreDownHook)
+	pgDumpTo = dbcli.EffectiveString(cmd, pgDumpToFlag, pgDumpTo, projectCfg.Migration.PostgresDumpTo)
+	mySQLDumpTo = dbcli.EffectiveString(cmd, mySQLDumpToFlag, mySQLDumpTo, projectCfg.Migration.MySQLDumpTo)
+	webhook = dbcli.EffectiveString(cmd, webhookFlag, webhook, projectCfg.Migration.Webhook)
 	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
 	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
 	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
@@ -324,8 +357,19 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 		fmt.Println()
 	}
 
+	preflightHook := dbcli.LockedMigrationPreflightHook(dryRun, preflight.Options{
+		Direction:          preflight.DirectionDown,
+		DatabaseURL:        dbURL,
+		DisplayDatabaseURL: dbschema.FormatDatabaseURL(dbURL),
+		Dialect:            conn.Info().Dialect,
+		Command:            preDownHook,
+		PostgresDumpDir:    pgDumpTo,
+		MySQLDumpDir:       mySQLDumpTo,
+		WebhookURL:         webhook,
+	})
+
 	// Run down migrations
-	err = mig.MigrateDownTo(context.Background(), targetVersion)
+	err = mig.MigrateDownToWithPreflight(context.Background(), targetVersion, preflightHook)
 	if err != nil {
 		return fmt.Errorf("error running down migrations: %w", err)
 	}

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -2,10 +2,13 @@ package migratedown_test
 
 import (
 	"context"
+	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/spf13/pflag"
 
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/dbschema"
@@ -20,6 +23,47 @@ func TestMigrateDownCommand_Creation(t *testing.T) {
 	c.Assert(cmd.Use, qt.Equals, "down")
 	c.Assert(cmd.Short, qt.Contains, "Roll back migrations")
 	c.Assert(cmd.Flag("migration-lock-timeout"), qt.IsNotNil)
+}
+
+func TestMigrateDownCommandPreflightHookAbortPreventsRollback(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(tempDir, "000001_create_guarded.up.sql"), []byte("CREATE TABLE guarded_down (id INTEGER PRIMARY KEY);"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tempDir, "000001_create_guarded.down.sql"), []byte("DROP TABLE guarded_down;"), 0o600), qt.IsNil)
+
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, os.DirFS(tempDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+
+	cmd := migratedown.NewMigrateDownCommand()
+	resetMigrateDownCommandForTest(c, cmd)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", tempDir,
+		"--target", "0",
+		"--confirm",
+		"--pre-down-hook", "echo rollback backup refused; exit 8",
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, "(?s).*down pre-flight custom command hook failed: exit status 8\nrollback backup refused")
+	resetMigrateDownCommandForTest(c, cmd)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+
+	var count int
+	err = conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'guarded_down'").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
 }
 
 // TestMigrateDownCommand_Integration tests the actual migration logic
@@ -64,6 +108,7 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 
 	// Test the migrate down command
 	cmd := migratedown.NewMigrateDownCommand()
+	resetMigrateDownCommandForTest(c, cmd)
 	cmd.SetArgs([]string{
 		"--db-url", dbURL,
 		"--migrations-dir", tempDir,
@@ -73,9 +118,43 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 
 	err = cmd.Execute()
 	c.Assert(err, qt.IsNil)
+	resetMigrateDownCommandForTest(c, cmd)
 
 	// Verify migration was rolled back
 	finalStatus, err := mig.GetMigrationStatus(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(finalStatus.CurrentVersion, qt.Equals, 0)
+}
+
+func resetMigrateDownCommandForTest(c *qt.C, cmd interface{ Flag(string) *pflag.Flag }) {
+	c.Helper()
+	for name, value := range map[string]string{
+		"db-url":                 "",
+		"migrations-dir":         "",
+		"target":                 "0",
+		"dir-format":             "auto",
+		"atlas-env":              "",
+		"dry-run":                "false",
+		"verbose":                "false",
+		"confirm":                "false",
+		"exec-order":             "linear",
+		"migration-lock-timeout": "",
+		"lock-timeout":           "",
+		"statement-timeout":      "",
+		"pre-down-hook":          "",
+		"pg-dump-to":             "",
+		"mysqldump-to":           "",
+		"webhook":                "",
+		"connect-timeout":        "10s",
+		"config":                 "",
+		"env":                    "",
+		"migrations-schema":      "",
+		"migrations-table":       "",
+		"revision-format":        "ptah",
+	} {
+		flag := cmd.Flag(name)
+		c.Assert(flag, qt.IsNotNil, qt.Commentf("flag %s", name))
+		c.Assert(flag.Value.Set(value), qt.IsNil)
+		flag.Changed = false
+	}
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/onlineddl"
 	"github.com/stokaro/ptah/internal/pathguard"
+	"github.com/stokaro/ptah/internal/preflight"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/risk"
@@ -48,6 +49,10 @@ const (
 	lockTimeoutFlag          = "lock-timeout"
 	statementTimeoutFlag     = "statement-timeout"
 	allowDestructiveFlag     = "allow-destructive"
+	preUpHookFlag            = "pre-up-hook"
+	pgDumpToFlag             = "pg-dump-to"
+	mySQLDumpToFlag          = "mysqldump-to"
+	webhookFlag              = "webhook"
 )
 
 var migrateUpFlags = map[string]cobraflags.Flag{
@@ -111,6 +116,26 @@ var migrateUpFlags = map[string]cobraflags.Flag{
 		Value: false,
 		Usage: "Allow pending migrations that contain destructive statements",
 	},
+	preUpHookFlag: &cobraflags.StringFlag{
+		Name:  preUpHookFlag,
+		Value: "",
+		Usage: "Shell command to run before applying pending migrations; aborts unless it exits 0",
+	},
+	pgDumpToFlag: &cobraflags.StringFlag{
+		Name:  pgDumpToFlag,
+		Value: "",
+		Usage: "Directory where pg_dump writes a custom-format backup before applying migrations",
+	},
+	mySQLDumpToFlag: &cobraflags.StringFlag{
+		Name:  mySQLDumpToFlag,
+		Value: "",
+		Usage: "Directory where mysqldump writes a SQL backup before applying migrations",
+	},
+	webhookFlag: &cobraflags.StringFlag{
+		Name:  webhookFlag,
+		Value: "",
+		Usage: "Webhook URL to POST migration metadata before applying migrations; must return HTTP 200",
+	},
 	dbcli.ConnectTimeoutFlagName:      dbcli.NewConnectTimeoutFlag(),
 	dbcli.ConfigFlagName:              dbcli.NewConfigFlag(),
 	dbcli.EnvFlagName:                 dbcli.NewEnvFlag(),
@@ -143,6 +168,10 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	lockTimeout := migrateUpFlags[lockTimeoutFlag].GetString()
 	statementTimeout := migrateUpFlags[statementTimeoutFlag].GetString()
 	allowDestructive := migrateUpFlags[allowDestructiveFlag].GetBool()
+	preUpHook := migrateUpFlags[preUpHookFlag].GetString()
+	pgDumpTo := migrateUpFlags[pgDumpToFlag].GetString()
+	mySQLDumpTo := migrateUpFlags[mySQLDumpToFlag].GetString()
+	webhook := migrateUpFlags[webhookFlag].GetString()
 	migrationsSchema := migrateUpFlags[dbcli.MigrationsSchemaFlagName].GetString()
 	migrationsTable := migrateUpFlags[dbcli.MigrationsTableFlagName].GetString()
 	revisionFormatValue := migrateUpFlags[dbcli.RevisionTableFormatFlagName].GetString()
@@ -160,6 +189,10 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
 	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
 	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
+	preUpHook = dbcli.EffectiveString(cmd, preUpHookFlag, preUpHook, projectCfg.Migration.PreUpHook)
+	pgDumpTo = dbcli.EffectiveString(cmd, pgDumpToFlag, pgDumpTo, projectCfg.Migration.PostgresDumpTo)
+	mySQLDumpTo = dbcli.EffectiveString(cmd, mySQLDumpToFlag, mySQLDumpTo, projectCfg.Migration.MySQLDumpTo)
+	webhook = dbcli.EffectiveString(cmd, webhookFlag, webhook, projectCfg.Migration.Webhook)
 	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
 	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
 	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
@@ -307,7 +340,7 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !allowDestructive {
-		findings, err := lintPendingDestructive(migrationsFS, pendingMigrationsForSafetyCheck(status, execOrder), conn.Info().Dialect)
+		findings, err := lintPendingDestructive(migrationsFS, pendingMigrationsForRun(status, execOrder), conn.Info().Dialect)
 		if err != nil {
 			return fmt.Errorf("error checking pending migration safety: %w", err)
 		}
@@ -317,9 +350,19 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println()
+	preflightHook := dbcli.LockedMigrationPreflightHook(dryRun, preflight.Options{
+		Direction:          preflight.DirectionUp,
+		DatabaseURL:        dbURL,
+		DisplayDatabaseURL: dbschema.FormatDatabaseURL(dbURL),
+		Dialect:            conn.Info().Dialect,
+		Command:            preUpHook,
+		PostgresDumpDir:    pgDumpTo,
+		MySQLDumpDir:       mySQLDumpTo,
+		WebhookURL:         webhook,
+	})
 
 	// Run migrations
-	err = mig.MigrateUp(context.Background())
+	err = mig.MigrateUpWithPreflight(context.Background(), preflightHook)
 	if err != nil {
 		return fmt.Errorf("error running migrations: %w", err)
 	}
@@ -342,7 +385,7 @@ func migrateUpCommand(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func pendingMigrationsForSafetyCheck(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int64 {
+func pendingMigrationsForRun(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int64 {
 	if execOrder != migrator.ExecOrderLinearSkip {
 		return status.PendingMigrations
 	}

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/spf13/pflag"
 
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/migration/lint"
@@ -24,8 +28,8 @@ import (
 // on the integrity check before ever touching the database, so a bogus,
 // unreachable --db-url is never dialed.
 //
-// The command uses package-global flag state, so this package keeps a single
-// command-level test to avoid re-registering flags.
+// The command uses package-global flag state, so command-level tests reset the
+// relevant flag values before and after execution.
 func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
 	c := qt.New(t)
 
@@ -42,6 +46,8 @@ func TestMigrateUp_VerifySumAbortsOnDriftBeforeConnecting(t *testing.T) {
 	write("0000000001_init.up.sql", "CREATE TABLE t (id BIGINT);\n")
 
 	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
 	c.Assert(cmd.Flag(migrationLockTimeoutFlag), qt.IsNotNil)
 
 	var out, errOut bytes.Buffer
@@ -149,6 +155,8 @@ func TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres(t *testing.T) {
 	writeMigrateUpFile(c, widenDir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", widenTable))
 
 	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -183,6 +191,7 @@ func TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres(t *testing.T) {
 	writeMigrateUpFile(c, dropDir, "0000000003_drop_table.down.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(512));\n", dropTable))
 
 	cmd = NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
 	stdout.Reset()
 	stderr.Reset()
 	cmd.SetOut(&stdout)
@@ -204,7 +213,164 @@ func TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres(t *testing.T) {
 	c.Assert(dropExists, qt.IsFalse)
 }
 
-func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing.T) {
+func TestMigrateUpCommandPreflightHookAbortPreventsMigration(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	writeMigrateUpFile(c, dir, "0000000001_create_guarded.up.sql", "CREATE TABLE guarded (id INTEGER PRIMARY KEY);\n")
+	writeMigrateUpFile(c, dir, "0000000001_create_guarded.down.sql", "DROP TABLE guarded;\n")
+
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--pre-up-hook", "echo backup refused; exit 7",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "(?s).*up pre-flight custom command hook failed: exit status 7\nbackup refused")
+
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var count int
+	err = conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'guarded'").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}
+
+func TestMigrateUpCommandReadsPreflightHookFromConfig(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	writeMigrateUpFile(c, dir, "0000000001_create_config_guarded.up.sql", "CREATE TABLE config_guarded (id INTEGER PRIMARY KEY);\n")
+	writeMigrateUpFile(c, dir, "0000000001_create_config_guarded.down.sql", "DROP TABLE config_guarded;\n")
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+	configPath := filepath.Join(t.TempDir(), "ptah.yaml")
+	config := fmt.Appendf(nil, `url: %s
+migration:
+  dir: %s
+  pre_up_hook: "echo config backup refused; exit 9"
+`, dbURL, dir)
+	c.Assert(os.WriteFile(configPath, config, 0o600), qt.IsNil)
+
+	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
+	cmd.SetArgs([]string{"--config", configPath})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "(?s).*up pre-flight custom command hook failed: exit status 9\nconfig backup refused")
+}
+
+func TestMigrateUpCommandPgDumpHookWritesArtifact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake pg_dump shell script requires a POSIX shell")
+	}
+	c := qt.New(t)
+	ctx := context.Background()
+	dbURL := postgresTestURL()
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	}
+	tableName := fmt.Sprintf("ptah_preflight_pg_dump_%d", time.Now().UnixNano())
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	cleanupPostgresObjects(t, conn, tableName)
+	defer cleanupPostgresObjects(t, conn, tableName)
+
+	dir := t.TempDir()
+	writeMigrateUpFile(c, dir, "0000000001_create_dump_guarded.up.sql", fmt.Sprintf("CREATE TABLE %s (id BIGINT);\n", tableName))
+	writeMigrateUpFile(c, dir, "0000000001_create_dump_guarded.down.sql", fmt.Sprintf("DROP TABLE %s;\n", tableName))
+
+	argsLog := filepath.Join(t.TempDir(), "pg_dump_args.log")
+	fakeBin := filepath.Join(t.TempDir(), "pg_dump")
+	fakeScript := fmt.Appendf(nil, `#!/bin/sh
+out=""
+: > %[1]q
+while [ "$#" -gt 0 ]; do
+  printf '%%s\n' "$1" >> %[1]q
+  if [ "$1" = "--file" ]; then
+    shift
+    out="$1"
+    printf '%%s\n' "$1" >> %[1]q
+  fi
+  shift
+done
+if [ -z "$out" ]; then
+  echo "missing --file" >&2
+  exit 64
+fi
+printf 'fake custom dump\n' > "$out"
+`, argsLog)
+	c.Assert(os.WriteFile(fakeBin, fakeScript, 0o600), qt.IsNil)
+	c.Assert(os.Chmod(fakeBin, 0o700), qt.IsNil)
+	t.Setenv("PATH", filepath.Dir(fakeBin)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dumpDir := t.TempDir()
+	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--pg-dump-to", dumpDir,
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	matches, err := filepath.Glob(filepath.Join(dumpDir, "ptah_pre_v0_to_v1_*.dump"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 1)
+	dumpData, err := os.ReadFile(matches[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(dumpData), qt.Equals, "fake custom dump\n")
+
+	argsData, err := os.ReadFile(argsLog)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(argsData), qt.Contains, "--format=custom\n")
+	c.Assert(string(argsData), qt.Contains, "--file\n"+matches[0]+"\n")
+	if password := databaseURLPasswordForTest(dbURL); password != "" {
+		c.Assert(string(argsData), qt.Not(qt.Contains), password)
+	}
+}
+
+func TestMigrateUpCommandDryRunSkipsPreflightSideEffects(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	writeMigrateUpFile(c, dir, "0000000001_create_dry_guarded.up.sql", "CREATE TABLE dry_guarded (id INTEGER PRIMARY KEY);\n")
+	writeMigrateUpFile(c, dir, "0000000001_create_dry_guarded.down.sql", "DROP TABLE dry_guarded;\n")
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+
+	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--dry-run",
+		"--pre-up-hook", "echo should not run; exit 97",
+		"--pg-dump-to", filepath.Join(t.TempDir(), "pg"),
+		"--mysqldump-to", filepath.Join(t.TempDir(), "mysql"),
+		"--webhook", "https://ops.example/hooks/ptah",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestPendingMigrationsForRunSkipsOutOfOrderWhenLinearSkip(t *testing.T) {
 	c := qt.New(t)
 
 	status := &migrator.MigrationStatus{
@@ -213,17 +379,17 @@ func TestPendingMigrationsForSafetyCheckSkipsOutOfOrderWhenLinearSkip(t *testing
 	}
 
 	c.Assert(
-		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinear),
+		pendingMigrationsForRun(status, migrator.ExecOrderLinear),
 		qt.DeepEquals,
 		[]int64{3, 6},
 	)
 	c.Assert(
-		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderNonLinear),
+		pendingMigrationsForRun(status, migrator.ExecOrderNonLinear),
 		qt.DeepEquals,
 		[]int64{3, 6},
 	)
 	c.Assert(
-		pendingMigrationsForSafetyCheck(status, migrator.ExecOrderLinearSkip),
+		pendingMigrationsForRun(status, migrator.ExecOrderLinearSkip),
 		qt.DeepEquals,
 		[]int64{6},
 	)
@@ -241,6 +407,52 @@ func postgresTestURL() string {
 func writeMigrateUpFile(c *qt.C, dir, name, content string) {
 	c.Helper()
 	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+}
+
+func databaseURLPasswordForTest(dbURL string) string {
+	parsed, err := url.Parse(dbURL)
+	if err != nil || parsed.User == nil {
+		return ""
+	}
+	password, ok := parsed.User.Password()
+	if !ok {
+		return ""
+	}
+	return password
+}
+
+func resetMigrateUpCommandForTest(c *qt.C, cmd interface{ Flag(string) *pflag.Flag }) {
+	c.Helper()
+	setMigrateUpFlagForTest(c, cmd, dbURLFlag, "")
+	setMigrateUpFlagForTest(c, cmd, migrationsFlag, "")
+	setMigrateUpFlagForTest(c, cmd, dryRunFlag, "false")
+	setMigrateUpFlagForTest(c, cmd, verboseFlag, "false")
+	setMigrateUpFlagForTest(c, cmd, verifySumFlag, "false")
+	setMigrateUpFlagForTest(c, cmd, dirFormatFlag, string(migrator.MigrationDirFormatAuto))
+	setMigrateUpFlagForTest(c, cmd, atlasEnvFlag, "")
+	setMigrateUpFlagForTest(c, cmd, execOrderFlag, string(migrator.ExecOrderLinear))
+	setMigrateUpFlagForTest(c, cmd, migrationLockTimeoutFlag, "")
+	setMigrateUpFlagForTest(c, cmd, lockTimeoutFlag, "")
+	setMigrateUpFlagForTest(c, cmd, statementTimeoutFlag, "")
+	setMigrateUpFlagForTest(c, cmd, allowDestructiveFlag, "false")
+	setMigrateUpFlagForTest(c, cmd, preUpHookFlag, "")
+	setMigrateUpFlagForTest(c, cmd, pgDumpToFlag, "")
+	setMigrateUpFlagForTest(c, cmd, mySQLDumpToFlag, "")
+	setMigrateUpFlagForTest(c, cmd, webhookFlag, "")
+	setMigrateUpFlagForTest(c, cmd, dbcli.ConfigFlagName, "")
+	setMigrateUpFlagForTest(c, cmd, dbcli.EnvFlagName, "")
+	setMigrateUpFlagForTest(c, cmd, dbcli.MigrationsSchemaFlagName, "")
+	setMigrateUpFlagForTest(c, cmd, dbcli.MigrationsTableFlagName, "")
+	setMigrateUpFlagForTest(c, cmd, dbcli.RevisionTableFormatFlagName, string(migrator.RevisionTableFormatPtah))
+	setMigrateUpFlagForTest(c, cmd, dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String())
+}
+
+func setMigrateUpFlagForTest(c *qt.C, cmd interface{ Flag(string) *pflag.Flag }, name, value string) {
+	c.Helper()
+	flag := cmd.Flag(name)
+	c.Assert(flag, qt.IsNotNil, qt.Commentf("flag %s", name))
+	c.Assert(flag.Value.Set(value), qt.IsNil)
+	flag.Changed = false
 }
 
 func cleanupPostgresObjects(t *testing.T, conn *dbschema.DatabaseConnection, names ...string) {

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -51,6 +51,11 @@ type MigrationConfig struct {
 	ConnectTimeout       string
 	MigrationLockTimeout string
 	ExecOrder            string
+	PreUpHook            string
+	PreDownHook          string
+	PostgresDumpTo       string
+	MySQLDumpTo          string
+	Webhook              string
 }
 
 // LintConfig is the lint section of the project config IR.
@@ -119,6 +124,21 @@ func mergeMigration(base, override MigrationConfig) MigrationConfig {
 	}
 	if override.ExecOrder != "" {
 		result.ExecOrder = override.ExecOrder
+	}
+	if override.PreUpHook != "" {
+		result.PreUpHook = override.PreUpHook
+	}
+	if override.PreDownHook != "" {
+		result.PreDownHook = override.PreDownHook
+	}
+	if override.PostgresDumpTo != "" {
+		result.PostgresDumpTo = override.PostgresDumpTo
+	}
+	if override.MySQLDumpTo != "" {
+		result.MySQLDumpTo = override.MySQLDumpTo
+	}
+	if override.Webhook != "" {
+		result.Webhook = override.Webhook
 	}
 	return result
 }

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -38,6 +38,11 @@ type yamlMigration struct {
 	ConnectTimeout       string `yaml:"connect_timeout"`
 	MigrationLockTimeout string `yaml:"migration_lock_timeout"`
 	ExecOrder            string `yaml:"exec_order"`
+	PreUpHook            string `yaml:"pre_up_hook"`
+	PreDownHook          string `yaml:"pre_down_hook"`
+	PostgresDumpTo       string `yaml:"pg_dump_to"`
+	MySQLDumpTo          string `yaml:"mysqldump_to"`
+	Webhook              string `yaml:"webhook"`
 }
 
 type yamlLint struct {
@@ -133,6 +138,11 @@ func (c yamlSettings) projectConfig() Config {
 			ConnectTimeout:       c.Migration.ConnectTimeout,
 			MigrationLockTimeout: c.Migration.MigrationLockTimeout,
 			ExecOrder:            c.Migration.ExecOrder,
+			PreUpHook:            c.Migration.PreUpHook,
+			PreDownHook:          c.Migration.PreDownHook,
+			PostgresDumpTo:       c.Migration.PostgresDumpTo,
+			MySQLDumpTo:          c.Migration.MySQLDumpTo,
+			Webhook:              c.Migration.Webhook,
 		},
 		Lint: LintConfig{
 			Dialect: c.Lint.Dialect,

--- a/config/projectconfig/yaml_test.go
+++ b/config/projectconfig/yaml_test.go
@@ -24,6 +24,11 @@ migration:
   connect_timeout: 3s
   migration_lock_timeout: 4s
   exec_order: linear
+  pre_up_hook: base-backup
+  pre_down_hook: base-rollback-backup
+  pg_dump_to: ./base-pg-dumps
+  mysqldump_to: ./base-mysql-dumps
+  webhook: https://hooks.example/base
 lint:
   dialect: mysql
   disabled-rules: [MF103]
@@ -41,6 +46,11 @@ env:
       connect_timeout: 7s
       migration_lock_timeout: 8s
       exec_order: non-linear
+      pre_up_hook: prod-backup
+      pre_down_hook: prod-rollback-backup
+      pg_dump_to: ./prod-pg-dumps
+      mysqldump_to: ./prod-mysql-dumps
+      webhook: https://hooks.example/prod
     lint:
       dialect: postgres
       disabled-rules: [DS103]
@@ -63,6 +73,11 @@ env:
 	c.Assert(cfg.Migration.ConnectTimeout, qt.Equals, "7s")
 	c.Assert(cfg.Migration.MigrationLockTimeout, qt.Equals, "8s")
 	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
+	c.Assert(cfg.Migration.PreUpHook, qt.Equals, "prod-backup")
+	c.Assert(cfg.Migration.PreDownHook, qt.Equals, "prod-rollback-backup")
+	c.Assert(cfg.Migration.PostgresDumpTo, qt.Equals, "./prod-pg-dumps")
+	c.Assert(cfg.Migration.MySQLDumpTo, qt.Equals, "./prod-mysql-dumps")
+	c.Assert(cfg.Migration.Webhook, qt.Equals, "https://hooks.example/prod")
 	c.Assert(cfg.Lint.Dialect, qt.Equals, "postgres")
 	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{"DS103"})
 }
@@ -91,6 +106,16 @@ func TestParsePtahProjectConfigRejectsUnknownOnlineDDLKeys(t *testing.T) {
       tooll: ghost
 `), "ptah.yaml", "prod")
 	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field tooll not found.*`)
+}
+
+func TestParsePtahProjectConfigRejectsUnknownMigrationPreflightKeys(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte(`migration:
+  pg_dumpto: ./backups
+`), "ptah.yaml", "")
+
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field pg_dumpto not found.*`)
 }
 
 func TestParsePtahProjectConfigAllowsOnlineDDLSection(t *testing.T) {

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -29,8 +29,8 @@ root-level command spellings are removed instead of preserved.
 | `ptah migrations generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
 | `ptah migrations create` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |
 | `ptah migrations baseline` | Existing migrations recorded as applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, verification failure, or write error. |
-| `ptah migrations up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, lock failure, or migration execution failure. |
-| `ptah migrations down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, lock failure, or rollback failure. |
+| `ptah migrations up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, pre-flight hook failure, lock failure, or migration execution failure. |
+| `ptah migrations down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, pre-flight hook failure, lock failure, or rollback failure. |
 | `ptah migrations repair` | Migration revision repaired, or dry-run output printed. | Not used. | Usage error, connection failure, revision lookup failure, or repair failure. |
 | `ptah migrations status` | Status printed, including pending migrations by default. | Pending migrations exist when `--exit-code` is set. | Usage error, connection failure, migration directory error, or status-read failure. |
 | `ptah migrations hash` | Integrity file written. | Not used. | Usage error, invalid directory, invalid migration format, or write error. |

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -29,6 +29,11 @@ env:
       connect_timeout: 10s
       migration_lock_timeout: 15s
       exec_order: linear
+      pre_up_hook: ./scripts/backup-before-up
+      pre_down_hook: ./scripts/backup-before-down
+      pg_dump_to: ./backups/postgres
+      mysqldump_to: ./backups/mysql
+      webhook: https://ops.example/hooks/ptah-migration
     lint:
       dialect: postgres
       disabled-rules: [MF103]
@@ -76,6 +81,11 @@ env:
 | `migration.connect_timeout` | Initial database connection timeout |
 | `migration.migration_lock_timeout` | Session-level migration advisory lock timeout |
 | `migration.exec_order` | Pending migration execution policy |
+| `migration.pre_up_hook` | Shell command that must succeed before `migrations up` changes the schema |
+| `migration.pre_down_hook` | Shell command that must succeed before `migrations down` changes the schema |
+| `migration.pg_dump_to` | Directory for a PostgreSQL-compatible pre-migration custom-format dump |
+| `migration.mysqldump_to` | Directory for a MySQL/MariaDB pre-migration SQL dump |
+| `migration.webhook` | URL that receives migration metadata before `migrations up` or `migrations down`; it must return HTTP 200 |
 | `lint.dialect` | Default lint dialect |
 | `lint.disabled-rules` | Default lint disabled rule codes or families |
 | `lint.latest` | Atlas-compatible project config value preserved in the IR |
@@ -83,6 +93,14 @@ env:
 
 `migrate.generate.shadow_db` is also accepted as the older spelling for `dev`.
 When both are present, `dev` wins.
+
+Custom pre-flight hook commands receive the raw `PTAH_DB_URL`, `PTAH_DIALECT`,
+`PTAH_CURRENT_VERSION`, and `PTAH_TARGET_VERSION` environment variables.
+`pg_dump_to` writes files named `ptah_pre_v{from}_to_v{to}_{ts}.dump`, and
+`mysqldump_to` writes `ptah_pre_v{from}_to_v{to}_{ts}.sql`, with a
+high-precision UTC timestamp. Webhooks have a 30-second timeout and redirects
+are not followed. Dry-run migration commands do not execute hooks because
+backups and webhooks are side effects.
 
 ## Precedence
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -644,6 +644,8 @@ type Migration struct{ ... }
 type MigrationDirFormat string
     const MigrationDirFormatAuto MigrationDirFormat = "auto" ...
     func ParseMigrationDirFormat(value string) (MigrationDirFormat, error)
+type MigrationDirection string
+    const MigrationDirectionUp MigrationDirection = "up" ...
 type MigrationExecutionError struct{ ... }
 type MigrationFile struct{ ... }
     func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationFile, error)
@@ -655,6 +657,7 @@ type MigrationFunc func(context.Context, *dbschema.DatabaseConnection) error
     func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc
 type MigrationLockTimeoutError struct{ ... }
 type MigrationPair struct{ ... }
+type MigrationPlan struct{ ... }
 type MigrationProvider interface{ ... }
 type MigrationRevision struct{ ... }
 type MigrationStatus struct{ ... }
@@ -665,6 +668,7 @@ type Migrator struct{ ... }
     func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) *Migrator
 type OutOfOrderError struct{ ... }
     func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
+type PreMigrationHook func(ctx context.Context, plan MigrationPlan) error
 type RegisteredMigrationProvider struct{ ... }
     func NewRegisteredMigrationProvider(migrations ...*Migration) *RegisteredMigrationProvider
 type RepairMigrationOptions struct{ ... }

--- a/internal/onlineddl/config.go
+++ b/internal/onlineddl/config.go
@@ -95,6 +95,11 @@ type yamlMigration struct {
 	ConnectTimeout       string `yaml:"connect_timeout"`
 	MigrationLockTimeout string `yaml:"migration_lock_timeout"`
 	ExecOrder            string `yaml:"exec_order"`
+	PreUpHook            string `yaml:"pre_up_hook"`
+	PreDownHook          string `yaml:"pre_down_hook"`
+	PostgresDumpTo       string `yaml:"pg_dump_to"`
+	MySQLDumpTo          string `yaml:"mysqldump_to"`
+	Webhook              string `yaml:"webhook"`
 }
 
 type yamlLint struct {

--- a/internal/onlineddl/config_test.go
+++ b/internal/onlineddl/config_test.go
@@ -39,11 +39,18 @@ func TestLoadConfig_AllowsProjectConfigEnvelope(t *testing.T) {
 schemas: [public]
 migration:
   dir: ./migrations
+  pre_up_hook: ./scripts/backup-before-up
+  pre_down_hook: ./scripts/backup-before-down
+  pg_dump_to: ./backups/postgres
+  mysqldump_to: ./backups/mysql
+  webhook: https://ops.example/hooks/ptah-migration
 lint:
   dialect: postgres
 env:
   prod:
     url: postgres://prod/db
+    migration:
+      pre_up_hook: ./scripts/prod-backup-before-up
 online_ddl:
   tool: ghost
   threshold_rows: 1000000

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,536 @@
+// Package preflight runs migration pre-flight hooks before schema changes.
+package preflight
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+const defaultWebhookTimeout = 30 * time.Second
+
+// Direction identifies the migration direction guarded by pre-flight hooks.
+type Direction string
+
+const (
+	// DirectionUp runs before applying pending up migrations.
+	DirectionUp Direction = "up"
+	// DirectionDown runs before rolling back migrations.
+	DirectionDown Direction = "down"
+)
+
+// Options describes all configured pre-flight hooks for one migration run.
+type Options struct {
+	Direction          Direction
+	DatabaseURL        string
+	DisplayDatabaseURL string
+	Dialect            string
+	CurrentVersion     int64
+	TargetVersion      int64
+	Command            string
+	PostgresDumpDir    string
+	MySQLDumpDir       string
+	WebhookURL         string
+}
+
+// Enabled reports whether any hook is configured.
+func (o Options) Enabled() bool {
+	return o.Command != "" || o.PostgresDumpDir != "" || o.MySQLDumpDir != "" || o.WebhookURL != ""
+}
+
+// Result describes one successful hook execution.
+type Result struct {
+	Name     string
+	Artifact string
+}
+
+// CommandRunner runs an external command and returns its combined output.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args []string, env []string) (string, error)
+}
+
+// ExecCommandRunner runs commands with os/exec.
+type ExecCommandRunner struct{}
+
+// Run executes one command with the supplied extra environment.
+func (ExecCommandRunner) Run(ctx context.Context, name string, args []string, env []string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// Runner executes configured pre-flight hooks.
+type Runner struct {
+	CommandRunner CommandRunner
+	HTTPClient    *http.Client
+	Now           func() time.Time
+	Stdout        io.Writer
+}
+
+// Execute runs every configured hook in deterministic order.
+func (r Runner) Execute(ctx context.Context, opts Options) ([]Result, error) {
+	if !opts.Enabled() {
+		return nil, nil
+	}
+	runner := r.withDefaults()
+
+	env := opts.env()
+	results := make([]Result, 0, 4)
+	if opts.Command != "" {
+		result, err := runner.runCommandHook(ctx, opts, env)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	if opts.PostgresDumpDir != "" {
+		result, err := runner.runPostgresDump(ctx, opts)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	if opts.MySQLDumpDir != "" {
+		result, err := runner.runMySQLDump(ctx, opts)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	if opts.WebhookURL != "" {
+		result, err := runner.runWebhook(ctx, opts)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func (r Runner) withDefaults() Runner {
+	if r.CommandRunner == nil {
+		r.CommandRunner = ExecCommandRunner{}
+	}
+	if r.HTTPClient == nil {
+		r.HTTPClient = defaultHTTPClient()
+	}
+	if r.Now == nil {
+		r.Now = time.Now
+	}
+	if r.Stdout == nil {
+		r.Stdout = io.Discard
+	}
+	return r
+}
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: defaultWebhookTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (o Options) env() []string {
+	return []string{
+		"PTAH_DB_URL=" + o.DatabaseURL,
+		"PTAH_DIALECT=" + o.Dialect,
+		fmt.Sprintf("PTAH_CURRENT_VERSION=%d", o.CurrentVersion),
+		fmt.Sprintf("PTAH_TARGET_VERSION=%d", o.TargetVersion),
+	}
+}
+
+func (r Runner) runCommandHook(ctx context.Context, opts Options, env []string) (Result, error) {
+	name, args := shellCommand(opts.Command)
+	output, err := r.CommandRunner.Run(ctx, name, args, env)
+	output = sanitizeHookOutput(output, opts)
+	if err != nil {
+		return Result{}, hookError(opts.Direction, "custom command", err, output)
+	}
+	r.writeHookOutput("custom command", output)
+	return Result{Name: "custom command"}, nil
+}
+
+func (r Runner) runPostgresDump(ctx context.Context, opts Options) (Result, error) {
+	if !isPostgresDumpDialect(opts.Dialect) {
+		return Result{}, fmt.Errorf("%s pre-flight pg_dump hook requires a PostgreSQL-compatible dialect, got %s", opts.Direction, opts.Dialect)
+	}
+	path, err := r.dumpPath(opts.PostgresDumpDir, ".dump", opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	args, extraEnv := postgresDumpCommand(opts.DatabaseURL, path)
+	output, err := r.CommandRunner.Run(ctx, "pg_dump", args, extraEnv)
+	output = sanitizeHookOutput(output, opts)
+	if err != nil {
+		return Result{}, hookError(opts.Direction, "pg_dump", err, output)
+	}
+	r.writeHookOutput("pg_dump", output)
+	return Result{Name: "pg_dump", Artifact: path}, nil
+}
+
+func (r Runner) runMySQLDump(ctx context.Context, opts Options) (Result, error) {
+	if !isMySQLDumpDialect(opts.Dialect) {
+		return Result{}, fmt.Errorf("%s pre-flight mysqldump hook requires MySQL or MariaDB dialect, got %s", opts.Direction, opts.Dialect)
+	}
+	path, err := r.dumpPath(opts.MySQLDumpDir, ".sql", opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	args, extraEnv, err := mysqlDumpCommand(opts.DatabaseURL, path)
+	if err != nil {
+		return Result{}, err
+	}
+	output, err := r.CommandRunner.Run(ctx, "mysqldump", args, extraEnv)
+	output = sanitizeHookOutput(output, opts)
+	if err != nil {
+		return Result{}, hookError(opts.Direction, "mysqldump", err, output)
+	}
+	r.writeHookOutput("mysqldump", output)
+	return Result{Name: "mysqldump", Artifact: path}, nil
+}
+
+func (r Runner) dumpPath(dir, ext string, opts Options) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("%s pre-flight backup directory %s: %w", opts.Direction, dir, err)
+	}
+	name := fmt.Sprintf(
+		"ptah_pre_v%d_to_v%d_%s%s",
+		opts.CurrentVersion,
+		opts.TargetVersion,
+		r.Now().UTC().Format("20060102T150405.000000000Z"),
+		ext,
+	)
+	return filepath.Join(dir, name), nil
+}
+
+type webhookPayload struct {
+	Direction          Direction `json:"direction"`
+	Dialect            string    `json:"dialect"`
+	CurrentVersion     int64     `json:"current_version"`
+	TargetVersion      int64     `json:"target_version"`
+	DisplayDatabaseURL string    `json:"database_url,omitempty"`
+}
+
+func (r Runner) runWebhook(ctx context.Context, opts Options) (Result, error) {
+	payload := webhookPayload{
+		Direction:          opts.Direction,
+		Dialect:            opts.Dialect,
+		CurrentVersion:     opts.CurrentVersion,
+		TargetVersion:      opts.TargetVersion,
+		DisplayDatabaseURL: opts.DisplayDatabaseURL,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return Result{}, fmt.Errorf("%s pre-flight webhook payload: %w", opts.Direction, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, opts.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("%s pre-flight webhook request: %w", opts.Direction, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return Result{}, webhookError(opts.Direction, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Result{}, fmt.Errorf("%s pre-flight webhook failed: expected HTTP 200, got %d", opts.Direction, resp.StatusCode)
+	}
+	return Result{Name: "webhook"}, nil
+}
+
+func shellCommand(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/C", command}
+	}
+	return "/bin/sh", []string{"-c", command}
+}
+
+func hookError(direction Direction, name string, err error, output string) error {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return fmt.Errorf("%s pre-flight %s hook failed: %w", direction, name, err)
+	}
+	return fmt.Errorf("%s pre-flight %s hook failed: %w\n%s", direction, name, err, output)
+}
+
+func webhookError(direction Direction, err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		redactedURL := redactSecretURL(urlErr.URL)
+		cause := urlErr.Err
+		for {
+			nested, ok := cause.(*url.Error)
+			if !ok {
+				break
+			}
+			if nested.URL != "" {
+				redactedURL = redactSecretURL(nested.URL)
+			}
+			cause = nested.Err
+		}
+		return fmt.Errorf("%s pre-flight webhook failed for %s: %w", direction, redactedURL, cause)
+	}
+	return fmt.Errorf("%s pre-flight webhook failed: %w", direction, err)
+}
+
+func sanitizeHookOutput(output string, opts Options) string {
+	if output == "" {
+		return ""
+	}
+	replacements := hookOutputReplacements(opts)
+	for _, replacement := range replacements {
+		if replacement.old == "" {
+			continue
+		}
+		output = strings.ReplaceAll(output, replacement.old, replacement.new)
+	}
+	return output
+}
+
+type hookOutputReplacement struct {
+	old string
+	new string
+}
+
+func hookOutputReplacements(opts Options) []hookOutputReplacement {
+	displayURL := opts.DisplayDatabaseURL
+	if displayURL == "" {
+		displayURL = redactedDatabaseURL(opts.DatabaseURL)
+	}
+	replacements := []hookOutputReplacement{
+		{old: opts.DatabaseURL, new: displayURL},
+	}
+	password := databaseURLPassword(opts.DatabaseURL)
+	if password != "" {
+		replacements = append(
+			replacements,
+			hookOutputReplacement{old: "PGPASSWORD=" + password, new: "PGPASSWORD=redacted"},
+			hookOutputReplacement{old: "MYSQL_PWD=" + password, new: "MYSQL_PWD=redacted"},
+			hookOutputReplacement{old: password, new: "redacted"},
+		)
+	}
+	return replacements
+}
+
+func redactSecretURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsed.User != nil {
+		if _, ok := parsed.User.Password(); ok {
+			parsed.User = url.User(parsed.User.Username())
+		}
+	}
+	parsed.RawQuery = redactSecretQuery(parsed.Query()).Encode()
+	return parsed.String()
+}
+
+func stripSecretURLQuery(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	if parsed.User != nil {
+		if _, ok := parsed.User.Password(); ok {
+			parsed.User = url.User(parsed.User.Username())
+		}
+	}
+	parsed.RawQuery = stripSecretQuery(parsed.Query()).Encode()
+	return parsed.String()
+}
+
+func redactSecretQuery(query url.Values) url.Values {
+	redacted := make(url.Values, len(query))
+	for key, values := range query {
+		copied := append([]string(nil), values...)
+		if isSecretQueryKey(key) {
+			for idx := range copied {
+				copied[idx] = "redacted"
+			}
+		}
+		redacted[key] = copied
+	}
+	return redacted
+}
+
+func stripSecretQuery(query url.Values) url.Values {
+	stripped := make(url.Values, len(query))
+	for key, values := range query {
+		if isSecretQueryKey(key) {
+			continue
+		}
+		stripped[key] = append([]string(nil), values...)
+	}
+	return stripped
+}
+
+func isSecretQueryKey(key string) bool {
+	switch strings.ToLower(key) {
+	case "access_token",
+		"api_key",
+		"apikey",
+		"aws_secret_access_key",
+		"aws_session_token",
+		"client_secret",
+		"id_token",
+		"password",
+		"passwd",
+		"private_key",
+		"pwd",
+		"refresh_token",
+		"secret",
+		"sslcert",
+		"sslkey",
+		"sslpassword",
+		"token":
+		return true
+	default:
+		return false
+	}
+}
+
+func redactedDatabaseURL(dbURL string) string {
+	parsed, err := parseDatabaseURL(dbURL)
+	if err != nil {
+		return dbURL
+	}
+	if parsed.User != nil {
+		if _, ok := parsed.User.Password(); ok {
+			parsed.User = url.User(parsed.User.Username())
+		}
+	}
+	parsed.RawQuery = redactSecretQuery(parsed.Query()).Encode()
+	return parsed.String()
+}
+
+func databaseURLPassword(dbURL string) string {
+	parsed, err := parseDatabaseURL(dbURL)
+	if err != nil || parsed.User == nil {
+		return ""
+	}
+	password, ok := parsed.User.Password()
+	if !ok {
+		return ""
+	}
+	return password
+}
+
+func parseDatabaseURL(dbURL string) (*url.URL, error) {
+	if strings.HasPrefix(dbURL, "mysql://") || strings.HasPrefix(dbURL, "mariadb://") {
+		return parseMySQLURL(dbURL)
+	}
+	return url.Parse(dbURL)
+}
+
+func (r Runner) writeHookOutput(name, output string) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return
+	}
+	fmt.Fprintf(r.Stdout, "%s output:\n%s\n", name, output)
+}
+
+func isPostgresDumpDialect(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		return true
+	default:
+		return false
+	}
+}
+
+func isMySQLDumpDialect(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB:
+		return true
+	default:
+		return false
+	}
+}
+
+func mysqlDumpCommand(dbURL, outputPath string) (args []string, env []string, err error) {
+	parsed, err := parseMySQLURL(dbURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	dbName := strings.TrimPrefix(parsed.Path, "/")
+	if dbName == "" {
+		return nil, nil, fmt.Errorf("mysqldump pre-flight hook requires a database name in %s", parsed.Redacted())
+	}
+
+	args = []string{"--result-file", outputPath}
+	if parsed.Hostname() != "" {
+		args = append(args, "--protocol=TCP", "--host", parsed.Hostname())
+	}
+	if parsed.Port() != "" {
+		args = append(args, "--port", parsed.Port())
+	}
+	if parsed.User != nil {
+		if user := parsed.User.Username(); user != "" {
+			args = append(args, "--user", user)
+		}
+		if password, ok := parsed.User.Password(); ok {
+			env = append(env, "MYSQL_PWD="+password)
+		}
+	}
+	args = append(args, dbName)
+	return args, env, nil
+}
+
+func postgresDumpCommand(dbURL, outputPath string) (args []string, env []string) {
+	dumpURL := postgresDumpURL(dbURL)
+	parsed, err := url.Parse(dumpURL)
+	if err == nil && parsed.User != nil {
+		if password, ok := parsed.User.Password(); ok {
+			displayURL := *parsed
+			displayURL.User = url.User(parsed.User.Username())
+			dumpURL = displayURL.String()
+			env = append(env, "PGPASSWORD="+password)
+		}
+	}
+	dumpURL = stripSecretURLQuery(dumpURL)
+	args = []string{"--format=custom", "--file", outputPath, dumpURL}
+	return args, env
+}
+
+func postgresDumpURL(dbURL string) string {
+	parsed, err := url.Parse(dbURL)
+	if err != nil {
+		return dbURL
+	}
+	switch platform.NormalizeDialect(parsed.Scheme) {
+	case platform.CockroachDB, platform.YugabyteDB:
+		parsed.Scheme = platform.Postgres
+	}
+	return parsed.String()
+}
+
+func parseMySQLURL(dbURL string) (*url.URL, error) {
+	if strings.Contains(dbURL, "@tcp(") {
+		normalized := strings.Replace(dbURL, "@tcp(", "@", 1)
+		normalized = strings.Replace(normalized, ")", "", 1)
+		return url.Parse(normalized)
+	}
+	return url.Parse(dbURL)
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,368 @@
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type commandCall struct {
+	Name string
+	Args []string
+	Env  []string
+}
+
+type fakeCommandRunner struct {
+	calls  []commandCall
+	output string
+	err    error
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func (r *fakeCommandRunner) Run(_ context.Context, name string, args []string, env []string) (string, error) {
+	r.calls = append(r.calls, commandCall{
+		Name: name,
+		Args: append([]string(nil), args...),
+		Env:  append([]string(nil), env...),
+	})
+	return r.output, r.err
+}
+
+func TestExecuteCommandHookSetsRequiredEnvironment(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{}
+
+	results, err := Runner{CommandRunner: runner}.Execute(context.Background(), Options{
+		Direction:      DirectionUp,
+		DatabaseURL:    "postgres://app@db/prod",
+		Dialect:        "postgres",
+		CurrentVersion: 7,
+		TargetVersion:  9,
+		Command:        "backup --before-migration",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.DeepEquals, []Result{{Name: "custom command"}})
+	c.Assert(runner.calls, qt.HasLen, 1)
+	c.Assert(runner.calls[0].Name, qt.Equals, "/bin/sh")
+	c.Assert(runner.calls[0].Args, qt.DeepEquals, []string{"-c", "backup --before-migration"})
+	c.Assert(runner.calls[0].Env, qt.Contains, "PTAH_DB_URL=postgres://app@db/prod")
+	c.Assert(runner.calls[0].Env, qt.Contains, "PTAH_DIALECT=postgres")
+	c.Assert(runner.calls[0].Env, qt.Contains, "PTAH_CURRENT_VERSION=7")
+	c.Assert(runner.calls[0].Env, qt.Contains, "PTAH_TARGET_VERSION=9")
+}
+
+func TestExecuteCommandHookFailureIncludesOutput(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{
+		output: "snapshot refused\n",
+		err:    errors.New("exit status 42"),
+	}
+
+	_, err := Runner{CommandRunner: runner}.Execute(context.Background(), Options{
+		Direction: DirectionDown,
+		Command:   "false",
+	})
+
+	c.Assert(err, qt.ErrorMatches, "(?s)down pre-flight custom command hook failed: exit status 42\nsnapshot refused")
+}
+
+func TestCommandHookOutputRedactsDatabaseSecrets(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{
+		output: "PTAH_DB_URL=mysql://app:pw-value@tcp(db.internal:3307)/shop\nMYSQL_PWD=pw-value\npassword=pw-value\n",
+		err:    errors.New("exit status 42"),
+	}
+
+	_, err := Runner{CommandRunner: runner}.Execute(context.Background(), Options{
+		Direction:          DirectionUp,
+		DatabaseURL:        "mysql://app:pw-value@tcp(db.internal:3307)/shop",
+		DisplayDatabaseURL: "mysql://app@db.internal:3307/shop",
+		Command:            "backup",
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "pw-value")
+	c.Assert(err.Error(), qt.Contains, "PTAH_DB_URL=mysql://app@db.internal:3307/shop")
+	c.Assert(err.Error(), qt.Contains, "MYSQL_PWD=redacted")
+}
+
+func TestCommandHookOutputFallbackRedactsURLQuerySecrets(t *testing.T) {
+	c := qt.New(t)
+	dbPassword := "pg-" + "pass"
+	queryToken := "query-" + "token"
+	dbURL := "postgres://app:" + dbPassword + "@db.internal/prod?sslmode=require&token=" + queryToken
+	runner := &fakeCommandRunner{
+		output: "PTAH_DB_URL=" + dbURL + "\n",
+		err:    errors.New("exit status 42"),
+	}
+
+	_, err := Runner{CommandRunner: runner}.Execute(context.Background(), Options{
+		Direction:   DirectionUp,
+		DatabaseURL: dbURL,
+		Command:     "backup",
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Not(qt.Contains), dbPassword)
+	c.Assert(err.Error(), qt.Not(qt.Contains), queryToken)
+	c.Assert(err.Error(), qt.Contains, "PTAH_DB_URL=postgres://app@db.internal/prod?sslmode=require&token=redacted")
+}
+
+func TestPostgresDumpUsesCustomFormatAndStableFilename(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{}
+	dir := t.TempDir()
+	dbURL := "postgres://app:" + "pg-pass" + "@db/prod"
+
+	results, err := Runner{
+		CommandRunner: runner,
+		Now:           func() time.Time { return time.Date(2026, 7, 21, 12, 13, 14, 0, time.FixedZone("UTC+2", 2*60*60)) },
+	}.Execute(context.Background(), Options{
+		Direction:       DirectionUp,
+		DatabaseURL:     dbURL,
+		Dialect:         "postgres",
+		CurrentVersion:  1,
+		TargetVersion:   3,
+		PostgresDumpDir: dir,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Name, qt.Equals, "pg_dump")
+	c.Assert(results[0].Artifact, qt.Matches, `.*/ptah_pre_v1_to_v3_20260721T101314\.000000000Z\.dump`)
+	c.Assert(runner.calls, qt.HasLen, 1)
+	c.Assert(runner.calls[0].Name, qt.Equals, "pg_dump")
+	c.Assert(runner.calls[0].Args, qt.DeepEquals, []string{
+		"--format=custom",
+		"--file",
+		results[0].Artifact,
+		"postgres://app@db/prod",
+	})
+	c.Assert(strings.Join(runner.calls[0].Args, " "), qt.Not(qt.Contains), "pg-pass")
+	c.Assert(runner.calls[0].Env, qt.Contains, "PGPASSWORD=pg-pass")
+	c.Assert(strings.Join(runner.calls[0].Env, "\n"), qt.Not(qt.Contains), "PTAH_DB_URL=")
+}
+
+func TestPostgresDumpRejectsNonPostgresDialect(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := Runner{}.Execute(context.Background(), Options{
+		Direction:       DirectionUp,
+		Dialect:         "sqlite",
+		PostgresDumpDir: t.TempDir(),
+	})
+
+	c.Assert(err, qt.ErrorMatches, `up pre-flight pg_dump hook requires a PostgreSQL-compatible dialect, got sqlite`)
+}
+
+func TestMySQLDumpParsesTCPURLAndKeepsPasswordOutOfArgs(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{}
+
+	results, err := Runner{
+		CommandRunner: runner,
+		Now:           func() time.Time { return time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC) },
+	}.Execute(context.Background(), Options{
+		Direction:      DirectionUp,
+		DatabaseURL:    "mysql://app:secret@tcp(db.internal:3307)/shop?parseTime=true",
+		Dialect:        "mysql",
+		CurrentVersion: 2,
+		TargetVersion:  5,
+		MySQLDumpDir:   t.TempDir(),
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results[0].Artifact, qt.Matches, `.*/ptah_pre_v2_to_v5_20260721T000000\.000000000Z\.sql`)
+	c.Assert(runner.calls, qt.HasLen, 1)
+	c.Assert(runner.calls[0].Name, qt.Equals, "mysqldump")
+	c.Assert(runner.calls[0].Args, qt.DeepEquals, []string{
+		"--result-file",
+		results[0].Artifact,
+		"--protocol=TCP",
+		"--host",
+		"db.internal",
+		"--port",
+		"3307",
+		"--user",
+		"app",
+		"shop",
+	})
+	c.Assert(strings.Join(runner.calls[0].Args, " "), qt.Not(qt.Contains), "secret")
+	c.Assert(runner.calls[0].Env, qt.Contains, "MYSQL_PWD=secret")
+	c.Assert(strings.Join(runner.calls[0].Env, "\n"), qt.Not(qt.Contains), "PTAH_DB_URL=")
+}
+
+func TestMySQLDumpAcceptsURLWithoutUserInfo(t *testing.T) {
+	c := qt.New(t)
+	runner := &fakeCommandRunner{}
+
+	results, err := Runner{
+		CommandRunner: runner,
+		Now:           func() time.Time { return time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC) },
+	}.Execute(context.Background(), Options{
+		Direction:      DirectionUp,
+		DatabaseURL:    "mysql://db.internal/shop",
+		Dialect:        "mysql",
+		CurrentVersion: 2,
+		TargetVersion:  5,
+		MySQLDumpDir:   t.TempDir(),
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(runner.calls, qt.HasLen, 1)
+	c.Assert(runner.calls[0].Args, qt.DeepEquals, []string{
+		"--result-file",
+		results[0].Artifact,
+		"--protocol=TCP",
+		"--host",
+		"db.internal",
+		"shop",
+	})
+	c.Assert(runner.calls[0].Env, qt.HasLen, 0)
+}
+
+func TestPostgresDumpNormalizesPostgresWireSchemes(t *testing.T) {
+	c := qt.New(t)
+
+	args, env := postgresDumpCommand("cockroachdb://app:pw@db.internal:26257/defaultdb?sslmode=disable", "/tmp/pre.dump")
+	c.Assert(args, qt.DeepEquals, []string{
+		"--format=custom",
+		"--file",
+		"/tmp/pre.dump",
+		"postgres://app@db.internal:26257/defaultdb?sslmode=disable",
+	})
+	c.Assert(env, qt.DeepEquals, []string{"PGPASSWORD=pw"})
+
+	args, env = postgresDumpCommand("yugabytedb://yugabyte:pw@db.internal:5433/yugabyte", "/tmp/pre.dump")
+	c.Assert(args[3], qt.Equals, "postgres://yugabyte@db.internal:5433/yugabyte")
+	c.Assert(env, qt.DeepEquals, []string{"PGPASSWORD=pw"})
+}
+
+func TestPostgresDumpStripsSecretQueryParamsFromArgs(t *testing.T) {
+	c := qt.New(t)
+
+	args, env := postgresDumpCommand(
+		"postgres://app:pg-pass@db.internal/prod?sslmode=require&sslpassword=query-secret&token=api-token",
+		"/tmp/pre.dump",
+	)
+
+	c.Assert(args, qt.DeepEquals, []string{
+		"--format=custom",
+		"--file",
+		"/tmp/pre.dump",
+		"postgres://app@db.internal/prod?sslmode=require",
+	})
+	c.Assert(strings.Join(args, " "), qt.Not(qt.Contains), "query-secret")
+	c.Assert(strings.Join(args, " "), qt.Not(qt.Contains), "api-token")
+	c.Assert(env, qt.DeepEquals, []string{"PGPASSWORD=pg-pass"})
+}
+
+func TestWebhookPostsMetadataAndRequiresHTTP200(t *testing.T) {
+	c := qt.New(t)
+	var payload webhookPayload
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.Header.Get("Content-Type"), qt.Equals, "application/json")
+		c.Assert(json.NewDecoder(r.Body).Decode(&payload), qt.IsNil)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	results, err := Runner{HTTPClient: client}.Execute(context.Background(), Options{
+		Direction:          DirectionUp,
+		DatabaseURL:        "postgres://app@db/prod",
+		DisplayDatabaseURL: "postgres://app@db/prod",
+		Dialect:            "postgres",
+		CurrentVersion:     1,
+		TargetVersion:      2,
+		WebhookURL:         "https://ops.example/hooks/ptah",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.DeepEquals, []Result{{Name: "webhook"}})
+	c.Assert(payload, qt.DeepEquals, webhookPayload{
+		Direction:          DirectionUp,
+		Dialect:            "postgres",
+		CurrentVersion:     1,
+		TargetVersion:      2,
+		DisplayDatabaseURL: "postgres://app@db/prod",
+	})
+}
+
+func TestWebhookRejectsNonOKResponse(t *testing.T) {
+	c := qt.New(t)
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusAccepted,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	_, err := Runner{HTTPClient: client}.Execute(context.Background(), Options{
+		Direction:  DirectionUp,
+		WebhookURL: "https://ops.example/hooks/ptah",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `up pre-flight webhook failed: expected HTTP 200, got 202`)
+}
+
+func TestWebhookNetworkErrorRedactsSecretURLParams(t *testing.T) {
+	c := qt.New(t)
+	client := &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, &url.Error{
+			Op:  "Post",
+			URL: "https://ops.example/hooks/ptah?token=secret-token&env=prod",
+			Err: errors.New("dial tcp: no route to host"),
+		}
+	})}
+
+	_, err := Runner{HTTPClient: client}.Execute(context.Background(), Options{
+		Direction:  DirectionUp,
+		WebhookURL: "https://ops.example/hooks/ptah?token=secret-token&env=prod",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `up pre-flight webhook failed for https://ops.example/hooks/ptah\?env=prod&token=redacted: dial tcp: no route to host`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "secret-token")
+}
+
+func TestDefaultHTTPClientDoesNotFollowRedirects(t *testing.T) {
+	c := qt.New(t)
+	requests := 0
+	client := defaultHTTPClient()
+	c.Assert(client.Timeout, qt.Equals, defaultWebhookTimeout)
+	client.Transport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		requests++
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     http.Header{"Location": []string{"https://ops.example/redirected"}},
+		}, nil
+	})
+
+	_, err := Runner{HTTPClient: client}.Execute(context.Background(), Options{
+		Direction:  DirectionUp,
+		WebhookURL: "https://ops.example/hooks/ptah",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `up pre-flight webhook failed: expected HTTP 200, got 302`)
+	c.Assert(requests, qt.Equals, 1)
+}

--- a/migration/migrator/advisory_lock_integration_test.go
+++ b/migration/migrator/advisory_lock_integration_test.go
@@ -82,6 +82,65 @@ func TestMigrationAdvisoryLock_PostgresTimeoutIntegration(t *testing.T) {
 	c.Assert(migrator.IsMigrationLockTimeout(err), qt.IsTrue)
 }
 
+func TestMigrationPreflightHookRunsInsidePostgresAdvisoryLock(t *testing.T) {
+	dbURL := postgresTestURL(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	baseConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = baseConn.Close() }()
+
+	names := issue124Names(time.Now().UnixNano())
+	cleanupIssue124(t, baseConn, names)
+	defer cleanupIssue124(t, baseConn, names)
+
+	firstConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = firstConn.Close() }()
+
+	secondConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = secondConn.Close() }()
+
+	hookStarted := make(chan struct{})
+	releaseHook := make(chan struct{})
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- issue124Migrator(firstConn, names.migrationsTable, issue124Migrations(names)).
+			MigrateUpWithPreflight(ctx, func(ctx context.Context, _ migrator.MigrationPlan) error {
+				close(hookStarted)
+				select {
+				case <-releaseHook:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			})
+	}()
+
+	select {
+	case <-hookStarted:
+	case <-time.After(5 * time.Second):
+		close(releaseHook)
+		t.Fatal("pre-flight hook did not start")
+	}
+
+	err = issue124Migrator(secondConn, names.migrationsTable, issue124Migrations(names)).
+		WithMigrationLockTimeout(100 * time.Millisecond).
+		MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsMigrationLockTimeout(err), qt.IsTrue)
+
+	close(releaseHook)
+	select {
+	case err := <-firstErr:
+		c.Assert(err, qt.IsNil)
+	case <-time.After(5 * time.Second):
+		t.Fatal("first migration did not finish after releasing pre-flight hook")
+	}
+}
+
 func TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
 	runIssue124AdvisoryLockDefaultTimeoutIntegration(t, dbURL)

--- a/migration/migrator/exec_order_test.go
+++ b/migration/migrator/exec_order_test.go
@@ -88,6 +88,23 @@ func TestMigrationsToRollbackRequiresAppliedMigrationFile(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `applied migration 5 is above target version 2 but is missing from the migration provider`)
 }
 
+func TestUpTargetVersionKeepsCurrentHighWaterForOutOfOrderMigration(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(upTargetVersion(5, testMigrations(3)), qt.Equals, int64(5))
+	c.Assert(upTargetVersion(5, testMigrations(6, 7)), qt.Equals, int64(7))
+}
+
+func TestDownTargetVersionUsesFinalAppliedVersion(t *testing.T) {
+	c := qt.New(t)
+
+	applied := []int64{1, 3, 5}
+	c.Assert(downTargetVersion(applied, 4), qt.Equals, int64(3))
+	c.Assert(downTargetVersion(applied, 3), qt.Equals, int64(3))
+	c.Assert(downTargetVersion(applied, 2), qt.Equals, int64(1))
+	c.Assert(downTargetVersion(applied, 0), qt.Equals, int64(0))
+}
+
 func testMigrations(versions ...int64) []*Migration {
 	migrations := make([]*Migration, 0, len(versions))
 	for _, version := range versions {
@@ -99,12 +116,4 @@ func testMigrations(versions ...int64) []*Migration {
 		})
 	}
 	return migrations
-}
-
-func migrationVersions(migrations []*Migration) []int64 {
-	versions := make([]int64, 0, len(migrations))
-	for _, migration := range migrations {
-		versions = append(versions, migration.Version)
-	}
-	return versions
 }

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -28,6 +28,30 @@ type MigrationStatus struct {
 	DirtyRevision        *MigrationRevision `json:"dirty_revision,omitempty"`
 }
 
+// MigrationDirection identifies the migration direction in a selected plan.
+type MigrationDirection string
+
+const (
+	// MigrationDirectionUp applies pending migrations.
+	MigrationDirectionUp MigrationDirection = "up"
+	// MigrationDirectionDown rolls applied migrations back.
+	MigrationDirectionDown MigrationDirection = "down"
+)
+
+// MigrationPlan describes the migration work selected while holding the
+// migration lock.
+type MigrationPlan struct {
+	Direction      MigrationDirection
+	CurrentVersion int64
+	TargetVersion  int64
+	Versions       []int64
+}
+
+// PreMigrationHook runs after the migrator has acquired its migration lock and
+// selected the final migration plan, but before it changes schema or revision
+// state.
+type PreMigrationHook func(ctx context.Context, plan MigrationPlan) error
+
 // Migrator handles database migrations for ptah
 type Migrator struct {
 	conn                 *dbschema.DatabaseConnection
@@ -666,10 +690,18 @@ func (m *Migrator) GetMigrationStatus(ctx context.Context) (*MigrationStatus, er
 
 // MigrateUp migrates the database up to the latest version
 func (m *Migrator) MigrateUp(ctx context.Context) error {
-	return m.withMigrationLock(ctx, "migrate up", m.migrateUpLocked)
+	return m.MigrateUpWithPreflight(ctx, nil)
 }
 
-func (m *Migrator) migrateUpLocked(ctx context.Context) error {
+// MigrateUpWithPreflight migrates up after running hook inside the migration
+// advisory lock. A nil hook is equivalent to [Migrator.MigrateUp].
+func (m *Migrator) MigrateUpWithPreflight(ctx context.Context, hook PreMigrationHook) error {
+	return m.withMigrationLock(ctx, "migrate up", func(ctx context.Context) error {
+		return m.migrateUpLocked(ctx, hook)
+	})
+}
+
+func (m *Migrator) migrateUpLocked(ctx context.Context, hook PreMigrationHook) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -690,6 +722,14 @@ func (m *Migrator) migrateUpLocked(ctx context.Context) error {
 	}
 	migrationsToApply, err := m.migrationsToApply(migrations, appliedMigrations, 0)
 	if err != nil {
+		return err
+	}
+	if err := runPreMigrationHook(ctx, hook, MigrationPlan{
+		Direction:      MigrationDirectionUp,
+		CurrentVersion: currentVersion,
+		TargetVersion:  upTargetVersion(currentVersion, migrationsToApply),
+		Versions:       migrationVersions(migrationsToApply),
+	}); err != nil {
 		return err
 	}
 
@@ -723,17 +763,23 @@ func (m *Migrator) migrateDownLocked(ctx context.Context) error {
 		return fmt.Errorf("failed to get previous version: %w", err)
 	}
 
-	return m.migrateDownToLocked(ctx, targetVersion)
+	return m.migrateDownToLocked(ctx, targetVersion, nil)
 }
 
 // MigrateDownTo migrates the database down to the specified target version
 func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error {
+	return m.MigrateDownToWithPreflight(ctx, targetVersion, nil)
+}
+
+// MigrateDownToWithPreflight migrates down after running hook inside the
+// migration advisory lock. A nil hook is equivalent to [Migrator.MigrateDownTo].
+func (m *Migrator) MigrateDownToWithPreflight(ctx context.Context, targetVersion int64, hook PreMigrationHook) error {
 	return m.withMigrationLock(ctx, "migrate down", func(ctx context.Context) error {
-		return m.migrateDownToLocked(ctx, targetVersion)
+		return m.migrateDownToLocked(ctx, targetVersion, hook)
 	})
 }
 
-func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64) error {
+func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64, hook PreMigrationHook) error {
 	// Initialize the migrations table
 	if err := m.Initialize(ctx); err != nil {
 		return fmt.Errorf("failed to initialize migrations table: %w", err)
@@ -760,6 +806,14 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64)
 	}
 	migrationsToRollback, err := migrationsToRollback(migrationMap, appliedMigrations, targetVersion)
 	if err != nil {
+		return err
+	}
+	if err := runPreMigrationHook(ctx, hook, MigrationPlan{
+		Direction:      MigrationDirectionDown,
+		CurrentVersion: currentVersion,
+		TargetVersion:  downTargetVersion(appliedMigrations, targetVersion),
+		Versions:       migrationVersions(migrationsToRollback),
+	}); err != nil {
 		return err
 	}
 
@@ -816,7 +870,7 @@ func (m *Migrator) migrateToLocked(ctx context.Context, targetVersion int64) err
 	}
 
 	// Migrate down to target version
-	return m.migrateDownToLocked(ctx, targetVersion)
+	return m.migrateDownToLocked(ctx, targetVersion, nil)
 }
 
 // MigrationProvider returns the migration provider
@@ -848,6 +902,46 @@ func (m *Migrator) migrateUpTo(ctx context.Context, targetVersion int64) error {
 
 	m.logger.Info("Migrated successfully", "targetVersion", targetVersion)
 	return nil
+}
+
+func runPreMigrationHook(ctx context.Context, hook PreMigrationHook, plan MigrationPlan) error {
+	if hook == nil || len(plan.Versions) == 0 {
+		return nil
+	}
+	plan.Versions = slices.Clone(plan.Versions)
+	return hook(ctx, plan)
+}
+
+func migrationVersions(migrations []*Migration) []int64 {
+	versions := make([]int64, 0, len(migrations))
+	for _, migration := range migrations {
+		versions = append(versions, migration.Version)
+	}
+	return versions
+}
+
+func maxMigrationVersion(migrations []*Migration) int64 {
+	var maxVersion int64
+	for _, migration := range migrations {
+		if migration.Version > maxVersion {
+			maxVersion = migration.Version
+		}
+	}
+	return maxVersion
+}
+
+func upTargetVersion(currentVersion int64, migrations []*Migration) int64 {
+	return max(currentVersion, maxMigrationVersion(migrations))
+}
+
+func downTargetVersion(applied []int64, targetVersion int64) int64 {
+	var finalVersion int64
+	for _, version := range applied {
+		if version <= targetVersion && version > finalVersion {
+			finalVersion = version
+		}
+	}
+	return finalVersion
 }
 
 func (m *Migrator) applyUpMigrations(ctx context.Context, migrations []*Migration) error {

--- a/migration/migrator/sqlite_test.go
+++ b/migration/migrator/sqlite_test.go
@@ -2,6 +2,7 @@ package migrator
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"path/filepath"
 	"testing"
@@ -59,4 +60,127 @@ func TestFSMigratorSQLiteAppliesMigrations(t *testing.T) {
 	if version != 1 {
 		t.Fatalf("current version = %d, want 1", version)
 	}
+}
+
+func TestMigrateUpWithPreflightAbortPreventsApply(t *testing.T) {
+	ctx := context.Background()
+	conn := openSQLiteMigratorTestDB(t)
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close SQLite connection: %v", err)
+		}
+	}()
+
+	m, err := NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_guarded.up.sql": {
+			Data: []byte("CREATE TABLE guarded_preflight (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_guarded.down.sql": {
+			Data: []byte("DROP TABLE guarded_preflight;"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create filesystem migrator: %v", err)
+	}
+	hookErr := errors.New("preflight refused")
+	err = m.MigrateUpWithPreflight(ctx, func(ctx context.Context, plan MigrationPlan) error {
+		if plan.Direction != MigrationDirectionUp {
+			t.Fatalf("direction = %q, want up", plan.Direction)
+		}
+		if plan.CurrentVersion != 0 || plan.TargetVersion != 1 {
+			t.Fatalf("plan versions = %d -> %d, want 0 -> 1", plan.CurrentVersion, plan.TargetVersion)
+		}
+		if len(plan.Versions) != 1 || plan.Versions[0] != 1 {
+			t.Fatalf("plan versions = %v, want [1]", plan.Versions)
+		}
+		var count int
+		if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'guarded_preflight'").Scan(&count); err != nil {
+			t.Fatalf("query guarded table before hook abort: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("guarded table exists before hook abort")
+		}
+		return hookErr
+	})
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("MigrateUpWithPreflight error = %v, want %v", err, hookErr)
+	}
+
+	var count int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'guarded_preflight'").Scan(&count); err != nil {
+		t.Fatalf("query guarded table after hook abort: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("guarded table exists after hook abort")
+	}
+}
+
+func TestMigrateDownToWithPreflightAbortPreventsRollback(t *testing.T) {
+	ctx := context.Background()
+	conn := openSQLiteMigratorTestDB(t)
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("close SQLite connection: %v", err)
+		}
+	}()
+
+	m, err := NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_guarded.up.sql": {
+			Data: []byte("CREATE TABLE guarded_rollback_preflight (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_guarded.down.sql": {
+			Data: []byte("DROP TABLE guarded_rollback_preflight;"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create filesystem migrator: %v", err)
+	}
+	if err := m.MigrateUp(ctx); err != nil {
+		t.Fatalf("migrate up: %v", err)
+	}
+
+	hookErr := errors.New("rollback preflight refused")
+	err = m.MigrateDownToWithPreflight(ctx, 0, func(_ context.Context, plan MigrationPlan) error {
+		if plan.Direction != MigrationDirectionDown {
+			t.Fatalf("direction = %q, want down", plan.Direction)
+		}
+		if plan.CurrentVersion != 1 || plan.TargetVersion != 0 {
+			t.Fatalf("plan versions = %d -> %d, want 1 -> 0", plan.CurrentVersion, plan.TargetVersion)
+		}
+		if len(plan.Versions) != 1 || plan.Versions[0] != 1 {
+			t.Fatalf("plan versions = %v, want [1]", plan.Versions)
+		}
+		return hookErr
+	})
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("MigrateDownToWithPreflight error = %v, want %v", err, hookErr)
+	}
+
+	version, err := m.GetCurrentVersion(ctx)
+	if err != nil {
+		t.Fatalf("get current version: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("current version after hook abort = %d, want 1", version)
+	}
+	var count int
+	if err := conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'guarded_rollback_preflight'").Scan(&count); err != nil {
+		t.Fatalf("query guarded table after rollback hook abort: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("guarded table count = %d, want 1", count)
+	}
+}
+
+func openSQLiteMigratorTestDB(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+	dbURL := (&url.URL{
+		Scheme: platform.SQLite,
+		Path:   filepath.Join(t.TempDir(), "ptah-test.sqlite"),
+	}).String()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	if err != nil {
+		t.Fatalf("connect to SQLite: %v", err)
+	}
+	return conn
 }


### PR DESCRIPTION
## Summary
- add custom migration pre-flight hooks for migrations up/down with PTAH_* plan environment
- add built-in pg_dump, mysqldump, and webhook hooks with secret-safe process args and error output
- run hooks after the migration lock selects the final plan and before schema/revision mutation
- wire ptah.yaml config, README, project config docs, and exit-code docs

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./internal/preflight ./cmd/internal/dbcli ./cmd/migrateup ./cmd/migratedown ./migration/migrator ./config/projectconfig ./internal/onlineddl
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -race ./internal/preflight ./cmd/migrateup ./cmd/migratedown ./config/projectconfig ./internal/onlineddl ./migration/migrator
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...

Closes #166