### PR TITLE
Use American English spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ _ int
 _ int
 ```
 
-`type` and `granularity` are honoured only by the ClickHouse renderer (which falls back to `minmax` / `GRANULARITY 8192` when unset). Other dialects ignore them.
+`type` and `granularity` are honored only by the ClickHouse renderer (which falls back to `minmax` / `GRANULARITY 8192` when unset). Other dialects ignore them.
 
 ### ClickHouse Engine Configuration (ClickHouse only)
 

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -114,7 +114,7 @@ func dropAllCommand(_ *cobra.Command, _ []string) error {
 		}
 
 		if confirmation != "DELETE EVERYTHING" {
-			fmt.Println("Operation cancelled.")
+			fmt.Println("Operation canceled.")
 			return nil
 		}
 
@@ -126,7 +126,7 @@ func dropAllCommand(_ *cobra.Command, _ []string) error {
 		}
 
 		if confirmation != "YES I AM SURE" {
-			fmt.Println("Operation cancelled.")
+			fmt.Println("Operation canceled.")
 			return nil
 		}
 	}

--- a/cmd/dropall/dropall_test.go
+++ b/cmd/dropall/dropall_test.go
@@ -1,0 +1,73 @@
+package dropall
+
+import (
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/pflag"
+)
+
+func TestDropAllCommandDeclinedConfirmationPrintsCanceled(t *testing.T) {
+	c := qt.New(t)
+
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+	cmd := NewDropAllCommand()
+	resetDropAllCommandForTest(c, cmd)
+	cmd.SetArgs([]string{"--db-url", dbURL})
+
+	out, err := captureStdIO(c, "no\n", cmd.Execute)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Operation canceled.")
+	resetDropAllCommandForTest(c, cmd)
+}
+
+func captureStdIO(c *qt.C, input string, run func() error) (string, error) {
+	c.Helper()
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	inR, inW, err := os.Pipe()
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(inR.Close(), qt.IsNil) }()
+
+	_, err = inW.WriteString(input)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inW.Close(), qt.IsNil)
+
+	outR, outW, err := os.Pipe()
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(outR.Close(), qt.IsNil) }()
+
+	os.Stdin = inR
+	os.Stdout = outW
+
+	runErr := run()
+	c.Assert(outW.Close(), qt.IsNil)
+
+	output, err := io.ReadAll(outR)
+	c.Assert(err, qt.IsNil)
+	return string(output), runErr
+}
+
+func resetDropAllCommandForTest(c *qt.C, cmd interface{ Flag(string) *pflag.Flag }) {
+	c.Helper()
+	for name, value := range map[string]string{
+		"db-url":          "",
+		"dry-run":         "false",
+		"connect-timeout": "10s",
+	} {
+		flag := cmd.Flag(name)
+		c.Assert(flag, qt.IsNotNil, qt.Commentf("flag %s", name))
+		c.Assert(flag.Value.Set(value), qt.IsNil)
+		flag.Changed = false
+	}
+}

--- a/cmd/internal/dbcli/dbcli.go
+++ b/cmd/internal/dbcli/dbcli.go
@@ -1,6 +1,6 @@
 // Package dbcli holds small helpers shared by the CLI subcommands that connect
 // to a database. Centralising the connect-timeout flag and context
-// construction keeps behaviour consistent across commands.
+// construction keeps behavior consistent across commands.
 //
 // For the close-with-warning idiom used after a successful Connect, prefer
 // [github.com/stokaro/ptah/dbschema.CloseAndWarn] — it lives next to the
@@ -123,7 +123,7 @@ func ParseConnectTimeout(raw string) (time.Duration, error) {
 // ConnectContext derives a context for the initial database connection from
 // the supplied parent. When timeout is zero or negative, the parent is
 // returned unchanged together with a no-op CancelFunc so callers can `defer
-// cancel()` unconditionally; cancelling the returned function in that case
+// cancel()` unconditionally; canceling the returned function in that case
 // does not affect the parent context.
 func ConnectContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -351,7 +351,7 @@ func migrateDownCommand(cmd *cobra.Command, _ []string) error {
 		fmt.Scanln(&confirmation)
 
 		if confirmation != "YES" {
-			fmt.Println("Migration rollback cancelled.")
+			fmt.Println("Migration rollback canceled.")
 			return nil
 		}
 		fmt.Println()

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -2,6 +2,7 @@ package migratedown_test
 
 import (
 	"context"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -66,6 +67,41 @@ func TestMigrateDownCommandPreflightHookAbortPreventsRollback(t *testing.T) {
 	c.Assert(count, qt.Equals, 1)
 }
 
+func TestMigrateDownCommandDeclinedConfirmationPrintsCanceled(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(tempDir, "000001_create_declined.up.sql"), []byte("CREATE TABLE declined_down (id INTEGER PRIMARY KEY);"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tempDir, "000001_create_declined.down.sql"), []byte("DROP TABLE declined_down;"), 0o600), qt.IsNil)
+
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, os.DirFS(tempDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+
+	cmd := migratedown.NewMigrateDownCommand()
+	resetMigrateDownCommandForTest(c, cmd)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", tempDir,
+		"--target", "0",
+	})
+
+	out, err := captureStdIO(c, "NO\n", cmd.Execute)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Migration rollback canceled.")
+	resetMigrateDownCommandForTest(c, cmd)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+}
+
 // TestMigrateDownCommand_Integration tests the actual migration logic
 // This test requires a real database connection and is skipped if no test database is available
 func TestMigrateDownCommand_Integration(t *testing.T) {
@@ -124,6 +160,39 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 	finalStatus, err := mig.GetMigrationStatus(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(finalStatus.CurrentVersion, qt.Equals, 0)
+}
+
+func captureStdIO(c *qt.C, input string, run func() error) (string, error) {
+	c.Helper()
+
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdin = oldStdin
+		os.Stdout = oldStdout
+	}()
+
+	inR, inW, err := os.Pipe()
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(inR.Close(), qt.IsNil) }()
+
+	_, err = inW.WriteString(input)
+	c.Assert(err, qt.IsNil)
+	c.Assert(inW.Close(), qt.IsNil)
+
+	outR, outW, err := os.Pipe()
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(outR.Close(), qt.IsNil) }()
+
+	os.Stdin = inR
+	os.Stdout = outW
+
+	runErr := run()
+	c.Assert(outW.Close(), qt.IsNil)
+
+	output, err := io.ReadAll(outR)
+	c.Assert(err, qt.IsNil)
+	return string(output), runErr
 }
 
 func resetMigrateDownCommandForTest(c *qt.C, cmd interface{ Flag(string) *pflag.Flag }) {

--- a/core/renderer/internal/dialects/clickhouse/clickhouse.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse.go
@@ -117,7 +117,7 @@ func escapeStringLiteral(s string) string {
 // not surprised by silent conversions.
 //
 // `jsonMapped` is set when the original SQL type was JSON/JSONB and was
-// rewritten to a String-based type; the notice for this case is finalised
+// rewritten to a String-based type; the notice for this case is finalized
 // in renderColumnType so it reflects the post-Nullable-wrap final type.
 type typeMapping struct {
 	mapped     string
@@ -146,7 +146,7 @@ var directTypeMap = map[string]string{
 }
 
 // mapColumnType translates a generic SQL column type spelling into the
-// ClickHouse equivalent. Type names not recognised are returned verbatim;
+// ClickHouse equivalent. Type names not recognized are returned verbatim;
 // callers may legitimately write native ClickHouse type names in their
 // annotations (e.g. `LowCardinality(String)`), and this function must not
 // mangle them.
@@ -194,7 +194,7 @@ func mapColumnType(t string) (typeMapping, error) {
 	case "JSON", "JSONB":
 		// Treat JSON as a String; ClickHouse's native JSON type is still
 		// experimental. Users who want it can override via platform.clickhouse.type.
-		// The notice is finalised in renderColumnType so it reflects the
+		// The notice is finalized in renderColumnType so it reflects the
 		// post-Nullable-wrap final type (e.g. Nullable(String)).
 		return typeMapping{
 			mapped:     "String",
@@ -207,12 +207,12 @@ func mapColumnType(t string) (typeMapping, error) {
 	// spelling has been forwarded as-is.
 	mapping := typeMapping{mapped: t}
 	if !looksLikeClickHouseNativeType(t) {
-		mapping.notice = fmt.Sprintf("unrecognised SQL type %q passed through verbatim; verify it is a native ClickHouse type", t)
+		mapping.notice = fmt.Sprintf("unrecognized SQL type %q passed through verbatim; verify it is a native ClickHouse type", t)
 	}
 	return mapping, nil
 }
 
-// looksLikeClickHouseNativeType is a heuristic that recognises common
+// looksLikeClickHouseNativeType is a heuristic that recognizes common
 // ClickHouse-native type spellings (LowCardinality, Array, Map, Nullable,
 // Enum8/16, FixedString, Tuple, Nested, ...). It only needs to avoid
 // false-positively warning on legitimate native types; precise validation is
@@ -232,7 +232,7 @@ func looksLikeClickHouseNativeType(t string) bool {
 	return false
 }
 
-// columnTypeOptions controls renderColumnType's behaviour.
+// columnTypeOptions controls renderColumnType's behavior.
 type columnTypeOptions struct {
 	// forceNotNull disables Nullable(...) wrapping regardless of the
 	// column's declared nullability — used for columns that participate in
@@ -244,7 +244,7 @@ type columnTypeOptions struct {
 // applying Nullable() wrapping for nullable columns subject to opts.
 //
 // If the underlying type mapping was a JSON/JSONB → String rewrite, the
-// advisory notice is finalised here so it mentions the *final* rendered type
+// advisory notice is finalized here so it mentions the *final* rendered type
 // (e.g. `Nullable(String)` when the column ends up nullable) rather than the
 // pre-wrap form.
 func renderColumnType(col *ast.ColumnNode, opts columnTypeOptions) (typeMapping, error) {

--- a/core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go
@@ -1,6 +1,6 @@
 package clickhouse
 
-// White-box tests for helpers whose behaviour cannot be observed through the
+// White-box tests for helpers whose behavior cannot be observed through the
 // renderer's public surface alone. The rest of the dialect's test coverage
 // lives in clickhouse_test.go as a black-box package.
 

--- a/core/renderer/internal/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse_test.go
@@ -219,6 +219,7 @@ func TestColumnTypeMapping(t *testing.T) {
 		{name: "serial errors", col: ast.NewColumn("c", "SERIAL").SetNotNull(), wantErr: true, contains: "auto-increment"},
 		{name: "time errors", col: ast.NewColumn("c", "TIME").SetNotNull(), wantErr: true, contains: "TIME"},
 		{name: "native CH type passthrough", col: ast.NewColumn("c", "LowCardinality(String)").SetNotNull(), want: "c LowCardinality(String)"},
+		{name: "unknown SQL type warns", col: ast.NewColumn("c", "GEOGRAPHY").SetNotNull(), want: "c GEOGRAPHY", contains: `unrecognized SQL type "GEOGRAPHY" passed through verbatim`},
 	}
 
 	for _, tc := range cases {
@@ -235,6 +236,9 @@ func TestColumnTypeMapping(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			out := render(t, tbl)
 			c.Assert(out, qt.Contains, tc.want)
+			if tc.contains != "" {
+				c.Assert(out, qt.Contains, tc.contains)
+			}
 		})
 	}
 }

--- a/core/renderer/internal/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/internal/dialects/mysql/alter_ops_test.go
@@ -23,7 +23,7 @@ func renderMySQL(t *testing.T, nodes ...ast.Node) string {
 
 // MySQL 8.0+ supports `ALTER TABLE x RENAME COLUMN old TO new`; the renderer
 // emits it unconditionally and the runtime DB version is the user's problem
-// (matches the existing dialect behaviour for AUTO_INCREMENT etc.).
+// (matches the existing dialect behavior for AUTO_INCREMENT etc.).
 func TestMySQL_AlterTable_RenameColumn(t *testing.T) {
 	c := qt.New(t)
 	alter := &ast.AlterTableNode{

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -25,7 +25,7 @@ import (
 // ConnectToDatabase creates a database connection from a URL.
 //
 // The provided context governs the initial Ping used to verify the connection
-// and the metadata queries issued to populate [DBInfo]. Cancelling the context
+// and the metadata queries issued to populate [DBInfo]. Canceling the context
 // before or during the call causes ConnectToDatabase to return promptly with
 // the context error wrapped in a descriptive message. The context does not
 // affect the lifetime of the returned *DatabaseConnection; callers are
@@ -70,7 +70,7 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		db.SetMaxOpenConns(1)
 	}
 
-	// Test the connection — honour the caller-supplied context so a stuck or
+	// Test the connection — honor the caller-supplied context so a stuck or
 	// slow host cannot block ConnectToDatabase indefinitely.
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
@@ -525,11 +525,11 @@ func convertPostgresWireURL(dbURL string) string {
 	}
 }
 
-// convertClickHouseURL normalises a ClickHouse connection URL into the form
+// convertClickHouseURL normalizes a ClickHouse connection URL into the form
 // expected by the clickhouse-go/v2 driver's database/sql registration.
 //
 // The driver accepts either the canonical `clickhouse://user:pass@host:port/db`
-// URL form or the legacy DSN form. We canonicalise to the URL form and pass
+// URL form or the legacy DSN form. We canonicalize to the URL form and pass
 // the query parameters through unchanged. If the input cannot be parsed as a
 // URL we return it as-is so the driver can produce its own (likely better)
 // error message.
@@ -541,7 +541,7 @@ func convertClickHouseURL(dbURL string) string {
 	if parsed.Scheme == "" {
 		return dbURL
 	}
-	// The driver registers as the lowercase scheme "clickhouse". Normalise.
+	// The driver registers as the lowercase scheme "clickhouse". Normalize.
 	parsed.Scheme = "clickhouse"
 	return parsed.String()
 }

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -183,7 +183,7 @@ func TestConnectToDatabase_SQLiteFile(t *testing.T) {
 // "host accepts but never answers" without depending on routing tables or
 // reserved IP blocks (those behave differently on offline/restricted hosts).
 //
-// The listener and a sentinel "drainer" goroutine are wired to a cancellable
+// The listener and a sentinel "drainer" goroutine are wired to a cancelable
 // context so the test can guarantee the goroutine exits even if the call
 // under test races ahead.
 func stuckPostgresURL(t *testing.T) string {
@@ -219,10 +219,10 @@ func stuckPostgresURL(t *testing.T) string {
 	return fmt.Sprintf("postgres://user:pass@%s/db", ln.Addr())
 }
 
-// TestConnectToDatabase_CancelledContext is the acceptance test for issue #139.
-// A pre-cancelled context must short-circuit the call so that
+// TestConnectToDatabase_CanceledContext is the acceptance test for issue #139.
+// A pre-canceled context must short-circuit the call so that
 // ConnectToDatabase returns promptly with context.Canceled.
-func TestConnectToDatabase_CancelledContext(t *testing.T) {
+func TestConnectToDatabase_CanceledContext(t *testing.T) {
 	c := qt.New(t)
 
 	dbURL := stuckPostgresURL(t)
@@ -242,7 +242,7 @@ func TestConnectToDatabase_CancelledContext(t *testing.T) {
 	// "Promptly" is intentionally loose to avoid flakiness on slow CI runners,
 	// but well below the multi-second TCP timeout the bug describes.
 	c.Assert(elapsed < 2*time.Second, qt.IsTrue,
-		qt.Commentf("ConnectToDatabase took %s with a cancelled context, want <2s", elapsed))
+		qt.Commentf("ConnectToDatabase took %s with a canceled context, want <2s", elapsed))
 }
 
 // TestConnectToDatabase_DeadlineExceeded covers the typical --connect-timeout

--- a/examples/extension_ignore/main.go
+++ b/examples/extension_ignore/main.go
@@ -11,7 +11,7 @@
 //		log.Fatalf("Failed to parse Go entities: %v", err)
 //	}
 //
-//	// Connect to database (supply a context so the call can be cancelled).
+//	// Connect to database (supply a context so the call can be canceled).
 //	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 //	defer cancel()
 //	conn, err := dbschema.ConnectToDatabase(ctx, "postgres://user:pass@localhost/db")

--- a/internal/dbschema/clickhouse/writer.go
+++ b/internal/dbschema/clickhouse/writer.go
@@ -108,7 +108,7 @@ func (w *transactionWriter) IsDryRun() bool { return w.writer.IsDryRun() }
 // Identifiers cannot be bound as parameters; quoteIdent doubles any
 // embedded backtick so a name harvested from system.tables cannot break
 // out of the quoted identifier. The explicit "contains backtick" rejection
-// below is defence-in-depth — in a real ClickHouse deployment system.tables
+// below is defense-in-depth — in a real ClickHouse deployment system.tables
 // will not contain such names, but rejecting them outright keeps parity
 // with the postgres/mysql writers and makes the safety property obvious.
 func (w *Writer) DropAllTables() error {

--- a/internal/planner/dialects/clickhouse/clickhouse.go
+++ b/internal/planner/dialects/clickhouse/clickhouse.go
@@ -1,13 +1,13 @@
 // Package clickhouse implements ClickHouse-specific migration planning.
 //
-// ClickHouse only honours a subset of the schema features expressible
+// ClickHouse only honors a subset of the schema features expressible
 // through Ptah's annotations: tables, columns and a narrow set of
 // constraints (CHECK only). Enums, custom types, extensions, functions,
 // row-level security policies and roles are PostgreSQL-shaped and have no
 // direct equivalent here, so this planner deliberately drops them from
 // the output rather than emitting unrunnable SQL.
 //
-// The renderer is the second line of defence: any AST node this planner
+// The renderer is the second line of defense: any AST node this planner
 // did emit that ClickHouse cannot express is rendered as a
 // `-- CLICKHOUSE: ... is not supported` comment. Keeping both layers
 // honest means the planner stays free to emit dialect-neutral nodes

--- a/internal/planner/dialects/clickhouse/clickhouse_test.go
+++ b/internal/planner/dialects/clickhouse/clickhouse_test.go
@@ -155,7 +155,7 @@ func TestGenerateMigrationAST_IndexUnresolvedStructEmitsWarning(t *testing.T) {
 }
 
 // TestGenerateMigrationAST_IndexExplicitTableNameWins verifies that when an
-// index annotation carries `table=` we honour it without consulting the
+// index annotation carries `table=` we honor it without consulting the
 // struct→table map. This is the supported escape hatch for cross-struct
 // indexes.
 func TestGenerateMigrationAST_IndexExplicitTableNameWins(t *testing.T) {

--- a/internal/planner/dialects/postgres/postgres_test.go
+++ b/internal/planner/dialects/postgres/postgres_test.go
@@ -53,7 +53,7 @@ func TestPlanner_GenerateMigrationSQL_EnumsAdded(t *testing.T) {
 			generated: &goschema.Database{
 				Enums: []goschema.Enum{
 					{Name: "user_status", Values: []string{"active", "inactive"}},
-					{Name: "order_status", Values: []string{"pending", "completed", "cancelled"}},
+					{Name: "order_status", Values: []string{"pending", "completed", "canceled"}},
 				},
 			},
 			expected: func(nodes []ast.Node) bool {
@@ -73,7 +73,9 @@ func TestPlanner_GenerateMigrationSQL_EnumsAdded(t *testing.T) {
 					return false
 				}
 
-				return true
+				return enum2.Values[0] == "pending" &&
+					enum2.Values[1] == "completed" &&
+					enum2.Values[2] == "canceled"
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- replace owned British English spellings in comments, docs, CLI output, and test data with American English
- add regression coverage for user-visible canceled/unrecognized output
- keep AGENTS.md American English guidance as the future convention

## Self-review
- Pass 1: repository-wide spelling scan across behavior/color/cancel/normalize/canonicalize/analyze/serialize/optimize/initialize/authorize/license/favor/catalog/dialog/center/labor/model/fulfill/artifact/organize/recognize/customize/synchronize/honor/defense families found no remaining unowned British spellings.
- Pass 2: behavioral/API review found no public API rename risk; user-visible CLI and ClickHouse advisory strings are now covered by focused tests; enum fixture value propagation is asserted exactly.
- Multi-agent review findings were addressed: honor/defense leftovers fixed, declined prompt tests added, unknown ClickHouse notice test added, enum values asserted.

## Validation
- `git diff --check`
- `go test ./cmd/dropall ./cmd/migratedown ./cmd/internal/dbcli ./dbschema ./core/renderer/internal/dialects/clickhouse ./core/renderer/internal/dialects/mysql ./internal/dbschema/clickhouse ./internal/planner/dialects/clickhouse ./internal/planner/dialects/postgres`
- `go tool qtlint ./...`
- `golangci-lint run ./...`
- `go test ./...`

Closes #398