### PR TITLE
Fix duplicate JSON embedded columns

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -112,3 +112,16 @@ func TestGenerateCommand_MutualForeignKeysAreTwoPhase(t *testing.T) {
 	c.Assert(sql, qt.Contains, `ALTER TABLE "left_nodes" ADD CONSTRAINT "fk_left_nodes_right_id" FOREIGN KEY ("right_id") REFERENCES "right_nodes"("id")`)
 	c.Assert(sql, qt.Contains, `ALTER TABLE "right_nodes" ADD CONSTRAINT "fk_right_nodes_left_id" FOREIGN KEY ("left_id") REFERENCES "left_nodes"("id")`)
 }
+
+func TestGenerateCommand_JsonEmbeddedFieldRendersOnce(t *testing.T) {
+	c := qt.New(t)
+
+	fixtureDir := filepath.Join("..", "..", "integration", "fixtures", "entities", "023-go-annotations-objects")
+	cmd := exec.Command("go", "run", "../main.go", "schema", "render", "--root-dir", fixtureDir, "--dialect", "postgres")
+	output, err := cmd.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("generate output:\n%s", output))
+
+	usersCreate := outputStatementContaining(string(output), `CREATE TABLE "users"`)
+	c.Assert(usersCreate, qt.Not(qt.Equals), "")
+	c.Assert(strings.Count(usersCreate, `"metadata" JSONB NOT NULL`), qt.Equals, 1)
+}

--- a/cmd/viz/viz_test.go
+++ b/cmd/viz/viz_test.go
@@ -37,6 +37,27 @@ func TestCommandWritesMermaid(t *testing.T) {
 	c.Assert(stdout.String(), qt.Contains, `  users ||--o{ posts : "fk_posts_author"`)
 }
 
+func TestCommandDoesNotDuplicateJSONEmbeddedColumns(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeJSONEmbeddedModel(c, dir)
+
+	cmd := NewCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--root-dir", dir,
+		"--format", "mermaid",
+		"--include-columns",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+	c.Assert(strings.Count(stdout.String(), "    JSONB metadata\n"), qt.Equals, 1)
+}
+
 func TestREADMEExampleMatchesGeneratedMermaid(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -272,6 +293,26 @@ type Post struct {
 
 	//migrator:schema:field name="author_id" type="INTEGER" foreign="users(id)" foreign_key_name="fk_posts_author"
 	AuthorID int64
+}
+`
+	c.Assert(os.WriteFile(path, []byte(content), 0o600), qt.IsNil)
+}
+
+func writeJSONEmbeddedModel(c *qt.C, dir string) {
+	path := filepath.Join(dir, "model.go")
+	content := `package models
+
+type UserMetadata struct {
+	TraceID string
+}
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:embedded mode="json" name="metadata" type="JSONB"
+	Metadata UserMetadata
 }
 `
 	c.Assert(os.WriteFile(path, []byte(content), 0o600), qt.IsNil)

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -1815,20 +1815,55 @@ func validateEnumField(field goschema.Field, enums []goschema.Enum) {
 //
 // Returns a combined slice of goschema.Field containing both the original fields and
 // the generated fields from embedded field processing. This combined list is ready
-// for use in table creation.
+// for use in table creation. When originalFields already contains an embedded
+// field's generated concrete column, that original field is kept and the duplicate
+// generated field is skipped so callers can safely pass parser-finalized schemas.
 func ProcessEmbeddedFields(embeddedFields []goschema.EmbeddedField, originalFields []goschema.Field) []goschema.Field {
 	// Start with the original fields
 	allFields := make([]goschema.Field, len(originalFields))
 	copy(allFields, originalFields)
+	seenFields := fieldKeySet(originalFields)
 
 	// Process embedded fields for each struct
 	structNames := goschema.UniqueStructNames(embeddedFields)
 	for _, structName := range structNames {
 		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, originalFields, structName)
-		allFields = append(allFields, generatedFields...)
+		allFields = appendNewFields(allFields, generatedFields, seenFields)
 	}
 
 	return allFields
+}
+
+type fieldKey struct {
+	structName string
+	name       string
+}
+
+func fieldKeySet(fields []goschema.Field) map[fieldKey]struct{} {
+	seen := make(map[fieldKey]struct{}, len(fields))
+	for _, field := range fields {
+		seen[fieldKeyFor(field)] = struct{}{}
+	}
+	return seen
+}
+
+func appendNewFields(fields []goschema.Field, newFields []goschema.Field, seen map[fieldKey]struct{}) []goschema.Field {
+	for _, field := range newFields {
+		key := fieldKeyFor(field)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func fieldKeyFor(field goschema.Field) fieldKey {
+	return fieldKey{
+		structName: field.StructName,
+		name:       field.Name,
+	}
 }
 
 func processEmbeddedInlineMode(generatedFields []goschema.Field, embedded goschema.EmbeddedField, allFields []goschema.Field, allEmbeddedFields []goschema.EmbeddedField, structName string) []goschema.Field {

--- a/internal/convert/fromschema/fromschema_test.go
+++ b/internal/convert/fromschema/fromschema_test.go
@@ -20,6 +20,26 @@ func tableStatementByName(statements *ast.StatementList, name string) *ast.Creat
 	return nil
 }
 
+func countColumns(table *ast.CreateTableNode, name string) int {
+	count := 0
+	for _, column := range table.Columns {
+		if column.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func countFields(fields []goschema.Field, structName, name string) int {
+	count := 0
+	for _, field := range fields {
+		if field.StructName == structName && field.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
 func tableStatementIndexByName(statements *ast.StatementList, name string) int {
 	for i, stmt := range statements.Statements {
 		table, ok := stmt.(*ast.CreateTableNode)
@@ -2166,6 +2186,46 @@ func TestFromDatabase_EmbeddedFields_JsonMode(t *testing.T) {
 			c.Assert(test.expected(result), qt.IsTrue)
 		})
 	}
+}
+
+func TestFromDatabase_EmbeddedFields_JsonModeDoesNotDuplicateAlreadyProcessedField(t *testing.T) {
+	c := qt.New(t)
+	database := goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+		}},
+		Fields: []goschema.Field{
+			{
+				StructName: "User",
+				Name:       "id",
+				Type:       "SERIAL",
+				Primary:    true,
+			},
+			{
+				StructName: "User",
+				FieldName:  "UserMeta",
+				Name:       "metadata",
+				Type:       "JSONB",
+				Nullable:   false,
+			},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{{
+			StructName:       "User",
+			Mode:             "json",
+			Name:             "metadata",
+			Type:             "JSONB",
+			EmbeddedTypeName: "UserMeta",
+		}},
+	}
+
+	fields := fromschema.ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
+	c.Assert(countFields(fields, "User", "metadata"), qt.Equals, 1)
+
+	statements := fromschema.FromDatabase(database, "postgres")
+	table := tableStatementByName(statements, "users")
+	c.Assert(table, qt.IsNotNil)
+	c.Assert(countColumns(table, "metadata"), qt.Equals, 1)
 }
 
 func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- make `fromschema.ProcessEmbeddedFields` idempotent for concrete columns that already exist in parser-finalized schemas
- add a shared converter regression test proving `mode="json"` embedded fields produce one JSON column after a second processing pass
- add command-level coverage for `schema render` and `viz` so the fixture from #481 stays duplicate-free

Closes #481.

## Self-Review Notes

- Pass 1 checked the root cause and confirmed the bug is the second embedded-field expansion in `fromschema`, not one renderer. The fix is scoped to concrete column keys `(StructName, Name)`, so identical column names in different tables remain valid.
- Pass 2 checked blast radius across manual IR databases, parser-finalized databases, schema render, visualization, and existing local dedupe in `schemaviz`. No docs changes are needed because this is a correctness bug fix with unchanged command surface.
- Independent reviewer pass found no blocking issues. Residual note: the `viz` test is output smoke because `schemaviz` also dedupes fields locally; the shared-path regression is covered by `fromschema` and `schema render` tests.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./internal/convert/fromschema ./cmd/generate ./cmd/viz -count=1`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./internal/convert/fromschema ./cmd/generate ./cmd/viz`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...` outside sandbox because DB/testkit tests open localhost sockets
- `git diff --check`
- manual smoke: `ptah schema render --root-dir integration/fixtures/entities/023-go-annotations-objects --dialect postgres`
- manual smoke: `ptah viz --root-dir integration/fixtures/entities/023-go-annotations-objects --format mermaid --include-columns`
