### PR TITLE
Expose Atlas compatibility API

### DIFF
--- a/atlascompat/atlascompat.go
+++ b/atlascompat/atlascompat.go
@@ -1,0 +1,249 @@
+package atlascompat
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlashcl"
+	"github.com/stokaro/ptah/internal/convert/dbschematogo"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/parser"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// PtahSumFileName is the conventional Ptah migration-directory integrity file.
+const PtahSumFileName = "ptah.sum"
+
+// AtlasSumFileName is the conventional Atlas migration-directory integrity file.
+const AtlasSumFileName = "atlas.sum"
+
+// ParseAtlasHCL parses an Atlas schema HCL document into Ptah's Go schema IR.
+func ParseAtlasHCL(data []byte, filename string) (*goschema.Database, error) {
+	return atlashcl.Parse(data, filename)
+}
+
+// ParseAtlasHCLFile parses an Atlas schema HCL file into Ptah's Go schema IR.
+func ParseAtlasHCLFile(path string) (*goschema.Database, error) {
+	return atlashcl.ParseFile(path)
+}
+
+// ParseSQLOptions configures ParseSQL.
+type ParseSQLOptions struct {
+	// Dialect selects dialect-specific parsing behavior. Empty means
+	// compatibility-oriented best effort.
+	Dialect string
+	// Capabilities selects dialect capabilities for syntax where the same
+	// dialect has version-dependent behavior.
+	Capabilities capability.Capabilities
+	// Timeout caps parser work. Zero keeps Ptah's parser default.
+	Timeout time.Duration
+}
+
+// ParseSQL parses SQL DDL into Ptah AST statements.
+func ParseSQL(sql string, opts ParseSQLOptions) (*ast.StatementList, error) {
+	parserOpts := make([]parser.Option, 0, 3)
+	if strings.TrimSpace(opts.Dialect) != "" {
+		parserOpts = append(parserOpts, parser.WithDialect(opts.Dialect))
+	}
+	if len(opts.Capabilities) > 0 {
+		parserOpts = append(parserOpts, parser.WithCapabilities(opts.Capabilities))
+	}
+	if opts.Timeout > 0 {
+		parserOpts = append(parserOpts, parser.WithTimeout(opts.Timeout))
+	}
+	return parser.NewParser(sql, parserOpts...).Parse()
+}
+
+// SchemaToAST converts Ptah's Go schema IR into SQL AST statements for the
+// selected target platform.
+func SchemaToAST(database goschema.Database, targetPlatform string) *ast.StatementList {
+	return fromschema.FromDatabase(database, targetPlatform)
+}
+
+// DBSchemaToGoSchema converts an introspected database schema into Ptah's Go
+// schema IR.
+func DBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Database {
+	return dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+}
+
+// SumEntry is one migration file and its content hash.
+type SumEntry struct {
+	// Name is the slash-separated path of the file relative to the migrations
+	// directory.
+	Name string
+	// Hash is the h1: content hash of the file.
+	Hash string
+}
+
+// SumFile is a migration-directory integrity file.
+type SumFile struct {
+	// DirHash is the directory-level hash.
+	DirHash string
+	// Entries are per-file hashes sorted by name.
+	Entries []SumEntry
+}
+
+// Bytes renders the sum file in its on-disk form.
+func (s *SumFile) Bytes() []byte {
+	internal := toInternalSum(s)
+	if internal == nil {
+		return nil
+	}
+	return internal.Bytes()
+}
+
+// ParseSum parses a Ptah or Atlas h1 migration sum file.
+func ParseSum(data []byte) (*SumFile, error) {
+	sum, err := migratesum.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return fromInternalSum(sum), nil
+}
+
+// ComputeSum computes a migration-directory sum over fsys.
+func ComputeSum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error) {
+	sum, err := migratesum.ComputeWithFormat(fsys, format)
+	if err != nil {
+		return nil, err
+	}
+	return fromInternalSum(sum), nil
+}
+
+// SumFileNameForFormat returns the integrity file name for a migration
+// directory format.
+func SumFileNameForFormat(format migrator.MigrationDirFormat) (string, error) {
+	return migratesum.FileNameForFormat(format)
+}
+
+// WriteSum computes and writes a migration-directory sum file.
+func WriteSum(dir string, format migrator.MigrationDirFormat) (*SumFile, error) {
+	sum, err := migratesum.WriteWithFormat(dir, format)
+	if err != nil {
+		return nil, err
+	}
+	return fromInternalSum(sum), nil
+}
+
+// VerifySum verifies a migration-directory sum over fsys.
+func VerifySum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumResult, error) {
+	result, err := migratesum.VerifyWithFormat(fsys, format)
+	if err != nil {
+		return nil, err
+	}
+	return fromInternalResult(result), nil
+}
+
+// VerifySumDir verifies a migration-directory sum on disk.
+func VerifySumDir(dir string, format migrator.MigrationDirFormat) (*SumResult, error) {
+	result, err := migratesum.VerifyDirWithFormat(dir, format)
+	if err != nil {
+		return nil, err
+	}
+	return fromInternalResult(result), nil
+}
+
+// SumResult is the outcome of a migration-directory integrity verification.
+type SumResult struct {
+	// Added are migration files present on disk but absent from the sum file.
+	Added []string
+	// Removed are files recorded in the sum file but missing on disk.
+	Removed []string
+	// Changed are files whose content hash no longer matches the sum file.
+	Changed []string
+	// DirHashMismatch is set when the directory hash differs while per-file
+	// entries match.
+	DirHashMismatch bool
+	// SumFileName is the integrity file this result was compared against.
+	SumFileName string
+}
+
+// OK reports whether the directory matches its recorded sum exactly.
+func (r *SumResult) OK() bool {
+	return r != nil &&
+		len(r.Added) == 0 &&
+		len(r.Removed) == 0 &&
+		len(r.Changed) == 0 &&
+		!r.DirHashMismatch
+}
+
+// Describe renders a drift result as human-readable lines.
+func (r *SumResult) Describe() string {
+	if r == nil || r.OK() {
+		return ""
+	}
+	name := r.SumFileName
+	if name == "" {
+		name = PtahSumFileName
+	}
+	lines := []string{"migration directory does not match " + name + ":"}
+	for _, changed := range r.Changed {
+		lines = append(lines, "  changed: "+changed)
+	}
+	for _, added := range r.Added {
+		lines = append(lines, "  added (not in "+name+"): "+added)
+	}
+	for _, removed := range r.Removed {
+		lines = append(lines, "  removed (still in "+name+"): "+removed)
+	}
+	if r.DirHashMismatch {
+		lines = append(lines, "  directory hash mismatch ("+name+" was hand-edited)")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func fromInternalSum(sum *migratesum.SumFile) *SumFile {
+	if sum == nil {
+		return nil
+	}
+	entries := make([]SumEntry, len(sum.Entries))
+	for i, entry := range sum.Entries {
+		entries[i] = SumEntry{Name: entry.Name, Hash: entry.Hash}
+	}
+	return &SumFile{DirHash: sum.DirHash, Entries: entries}
+}
+
+func toInternalSum(sum *SumFile) *migratesum.SumFile {
+	if sum == nil {
+		return nil
+	}
+	entries := make([]migratesum.Entry, len(sum.Entries))
+	for i, entry := range sum.Entries {
+		entries[i] = migratesum.Entry{Name: entry.Name, Hash: entry.Hash}
+	}
+	return &migratesum.SumFile{DirHash: sum.DirHash, Entries: entries}
+}
+
+func fromInternalResult(result *migratesum.Result) *SumResult {
+	if result == nil {
+		return nil
+	}
+	return &SumResult{
+		Added:           append([]string(nil), result.Added...),
+		Removed:         append([]string(nil), result.Removed...),
+		Changed:         append([]string(nil), result.Changed...),
+		DirHashMismatch: result.DirHashMismatch,
+		SumFileName:     result.SumFileName,
+	}
+}
+
+// WriteSumBytes writes sum to dir/name. It is useful for tools that need to
+// materialize a sum produced elsewhere while keeping Ptah's on-disk format.
+func WriteSumBytes(dir, name string, sum *SumFile) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("sum file name is required")
+	}
+	if sum == nil {
+		return fmt.Errorf("sum file is required")
+	}
+	return os.WriteFile(filepath.Join(dir, name), sum.Bytes(), 0644) //nolint:gosec // Sum files are committed project files.
+}

--- a/atlascompat/atlascompat_test.go
+++ b/atlascompat/atlascompat_test.go
@@ -1,0 +1,174 @@
+package atlascompat_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stokaro/ptah/atlascompat"
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/goschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestParseAtlasHCL(t *testing.T) {
+	db, err := atlascompat.ParseAtlasHCL([]byte(`
+schema "main" {}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`), "schema.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(db.Tables); got != 1 {
+		t.Fatalf("tables = %d", got)
+	}
+	if got := len(db.Fields); got != 1 {
+		t.Fatalf("fields = %d", got)
+	}
+}
+
+func TestParseSQL(t *testing.T) {
+	list, err := atlascompat.ParseSQL("CREATE TABLE users (id int PRIMARY KEY);", atlascompat.ParseSQLOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(list.Statements); got != 1 {
+		t.Fatalf("statements = %d", got)
+	}
+	if _, ok := list.Statements[0].(*ast.CreateTableNode); !ok {
+		t.Fatalf("statement = %T, want *ast.CreateTableNode", list.Statements[0])
+	}
+}
+
+func TestSchemaToAST(t *testing.T) {
+	list := atlascompat.SchemaToAST(goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			FieldName:  "ID",
+			Name:       "id",
+			Type:       "INTEGER",
+			Primary:    true,
+		}},
+	}, "sqlite")
+
+	if got := len(list.Statements); got != 1 {
+		t.Fatalf("statements = %d", got)
+	}
+	if _, ok := list.Statements[0].(*ast.CreateTableNode); !ok {
+		t.Fatalf("statement = %T, want *ast.CreateTableNode", list.Statements[0])
+	}
+}
+
+func TestDBSchemaToGoSchema(t *testing.T) {
+	db := atlascompat.DBSchemaToGoSchema(&dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name: "users",
+			Columns: []dbschematypes.DBColumn{{
+				Name:         "id",
+				DataType:     "integer",
+				IsNullable:   "NO",
+				IsPrimaryKey: true,
+			}},
+		}},
+	})
+
+	if got := len(db.Tables); got != 1 {
+		t.Fatalf("tables = %d", got)
+	}
+	if got := len(db.Fields); got != 1 {
+		t.Fatalf("fields = %d", got)
+	}
+	if !db.Fields[0].Primary {
+		t.Fatalf("field primary = false")
+	}
+}
+
+func TestSumHelpers(t *testing.T) {
+	fsys := fstest.MapFS{
+		"20260721150000_init.sql": {
+			Data: []byte("CREATE TABLE users (id int);\n"),
+		},
+	}
+	sum, err := atlascompat.ComputeSum(fsys, migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.DirHash == "" {
+		t.Fatal("missing directory hash")
+	}
+	if got := len(sum.Entries); got != 1 {
+		t.Fatalf("entries = %d", got)
+	}
+
+	parsed, err := atlascompat.ParseSum(sum.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.DirHash != sum.DirHash {
+		t.Fatalf("parsed dir hash = %q, want %q", parsed.DirHash, sum.DirHash)
+	}
+
+	withSum := fstest.MapFS{
+		"20260721150000_init.sql": {
+			Data: []byte("CREATE TABLE users (id int);\n"),
+		},
+		atlascompat.AtlasSumFileName: {
+			Data: sum.Bytes(),
+		},
+	}
+	result, err := atlascompat.VerifySum(withSum, migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.OK() {
+		t.Fatalf("verify result = %s", result.Describe())
+	}
+}
+
+func TestSumFileNameConstantsMatchFormats(t *testing.T) {
+	ptahName, err := atlascompat.SumFileNameForFormat(migrator.MigrationDirFormatPtah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ptahName != atlascompat.PtahSumFileName {
+		t.Fatalf("ptah sum file name = %q, want %q", ptahName, atlascompat.PtahSumFileName)
+	}
+
+	atlasName, err := atlascompat.SumFileNameForFormat(migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if atlasName != atlascompat.AtlasSumFileName {
+		t.Fatalf("atlas sum file name = %q, want %q", atlasName, atlascompat.AtlasSumFileName)
+	}
+}
+
+func TestWriteSumBytes(t *testing.T) {
+	dir := t.TempDir()
+	sum := &atlascompat.SumFile{
+		DirHash: "h1:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+	}
+	if err := atlascompat.WriteSumBytes(dir, atlascompat.AtlasSumFileName, sum); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, atlascompat.AtlasSumFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), sum.DirHash+"\n") {
+		t.Fatalf("written sum = %q", data)
+	}
+}

--- a/atlascompat/doc.go
+++ b/atlascompat/doc.go
@@ -1,0 +1,7 @@
+// Package atlascompat exposes narrow helpers for Atlas compatibility tooling.
+//
+// The package is intentionally small. It gives external conformance and
+// migration-compatibility tools stable entry points for behavior Ptah supports
+// publicly, while keeping parser, HCL, conversion, and sum-file implementation
+// packages behind Go internal boundaries.
+package atlascompat

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -8,6 +8,7 @@ non-fixture packages that may remain importable without an explicit review.
 
 These packages are intended for application and tool embedders:
 
+- `github.com/stokaro/ptah/atlascompat`
 - `github.com/stokaro/ptah/config`
 - `github.com/stokaro/ptah/config/projectconfig`
 - `github.com/stokaro/ptah/core/ast`
@@ -28,6 +29,11 @@ These packages are intended for application and tool embedders:
 - `github.com/stokaro/ptah/migration/schemadiff`
 - `github.com/stokaro/ptah/migration/schemadiff/types`
 - `github.com/stokaro/ptah/migration/seeder`
+
+`atlascompat` is a narrow compatibility surface for external Atlas parity and
+conformance tooling. It intentionally wraps parser, Atlas HCL, schema
+conversion, and migration sum internals without making those implementation
+packages importable directly.
 
 Public failures from these packages should use `core/ptaherr` where the caller
 can reasonably branch on the error. In particular, annotation failures should

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1,3 +1,24 @@
+## github.com/stokaro/ptah/atlascompat
+
+const AtlasSumFileName = "atlas.sum"
+const PtahSumFileName = "ptah.sum"
+func DBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Database
+func ParseAtlasHCL(data []byte, filename string) (*goschema.Database, error)
+func ParseAtlasHCLFile(path string) (*goschema.Database, error)
+func ParseSQL(sql string, opts ParseSQLOptions) (*ast.StatementList, error)
+func SchemaToAST(database goschema.Database, targetPlatform string) *ast.StatementList
+func SumFileNameForFormat(format migrator.MigrationDirFormat) (string, error)
+func WriteSumBytes(dir, name string, sum *SumFile) error
+type ParseSQLOptions struct{ ... }
+type SumEntry struct{ ... }
+type SumFile struct{ ... }
+    func ComputeSum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error)
+    func ParseSum(data []byte) (*SumFile, error)
+    func WriteSum(dir string, format migrator.MigrationDirFormat) (*SumFile, error)
+type SumResult struct{ ... }
+    func VerifySum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumResult, error)
+    func VerifySumDir(dir string, format migrator.MigrationDirFormat) (*SumResult, error)
+
 ## github.com/stokaro/ptah/config
 
 type CompareOptions struct{ ... }

--- a/docs/site/src/content/docs/documentation-map.md
+++ b/docs/site/src/content/docs/documentation-map.md
@@ -14,6 +14,7 @@ Use this page when you know what you need to do, but not where the relevant Ptah
 | I need Atlas-style commands | [Atlas-compatible CLI](./workflows/atlas-cli/) | [Comparison](./reference/comparison/) |
 | I need to run Ptah in CI | [CI](./workflows/ci/) | [Exit codes](./reference/exit-codes/) |
 | I need dialect behavior | [Capabilities](./reference/capabilities/) | Dialect-specific reference markdown in `docs/` |
+| I need the public Go API | [`docs/public_api.md`](https://github.com/stokaro/ptah/blob/master/docs/public_api.md) | Stable packages, snapshots, and public API guard scripts |
 | I need diagrams | [Schema visualization example](./examples/schema-viz/) | [`examples/viz`](https://github.com/stokaro/ptah/tree/master/examples/viz) |
 | A command failed | [Troubleshooting](./operate/troubleshooting/) | The relevant command reference page |
 | I need Atlas parity evidence | [Conformance](./operate/conformance/) | [`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance) |

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -95,7 +95,7 @@ The system operates through four main layers:
 - **Purpose**: Repository-internal helpers for building and parsing AST nodes
 - **Boundary**: These packages are implementation details behind Go `internal/`
   boundaries; embedders should use the stable `core/ast`, `core/goschema`,
-  `core/renderer`, and migration packages documented in
+  `core/renderer`, `atlascompat`, and migration packages documented in
   [Public Go API](public_api.md).
 
 #### renderer Package


### PR DESCRIPTION
## Summary

- add `github.com/stokaro/ptah/atlascompat` as the narrow public surface for Atlas compatibility and conformance tooling
- wrap Atlas HCL parsing, SQL parsing with dialect/capability options, schema conversion, and migration sum helpers without exposing implementation packages
- document the new stable API package and update the public API snapshot

Closes #492.

## Validation

- `env GOWORK=off go test ./... -count=1`
- `env GOWORK=off go test ./atlascompat ./internal/atlashcl ./internal/parser ./internal/migratesum ./internal/convert/fromschema ./internal/convert/dbschematogo -count=1`
- `env GOWORK=off scripts/check-public-api.sh`
- `env GOWORK=off scripts/check-public-api-snapshot.sh`
- `env GOWORK=off scripts/check-public-api-released.sh`
- `env GOWORK=off golangci-lint run ./atlascompat`
- `npm run build` in `docs/site`
- `npm run versions:selftest` in `docs/site`
- companion `ptah-atlas-conformance` with local replace to this branch:
  - `go mod tidy`
  - `go test ./internal/probe ./cmd/gap-probe ./cmd/gap-budget -count=1`
  - `make probe`
  - `make budget`

Notes:

- `go tool qtlint ./...` is not runnable in this sandbox: the local tool reports `matched no packages` for both package patterns and expanded import paths. The new package does not use quicktest, and `golangci-lint run ./atlascompat` reports 0 issues outside the sandbox.
