### PR TITLE
Fix MySQL enum ordered DDL

### DIFF
--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -543,6 +543,36 @@ func TestGetOrderedCreateStatements(t *testing.T) {
 	c.Assert(indexes, qt.Equals, 2)
 }
 
+func TestGetOrderedCreateStatements_MySQLFamilyInlineEnumsAreExecutable(t *testing.T) {
+	database, err := goschema.ParseSource("model.go", `package models
+
+//migrator:schema:table name="accounts"
+type Account struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+	//migrator:schema:field name="status" type="ENUM" enum="active,suspended,deleted" not_null="true" default="active"
+	Status string
+}
+`)
+	c := qt.New(t)
+	c.Assert(err, qt.IsNil)
+
+	for _, dialect := range []string{"mysql", "mariadb"} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := renderer.GetOrderedCreateStatements(&database, dialect)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements, qt.HasLen, 1)
+			for _, statement := range statements {
+				c.Assert(strings.TrimSpace(statement), qt.Not(qt.Equals), "")
+			}
+			c.Assert(statements[0], qt.Contains, "`status` ENUM('active', 'suspended', 'deleted') NOT NULL DEFAULT 'active'")
+		})
+	}
+}
+
 func TestGetOrderedCreateStatements_MutualForeignKeysAreTwoPhase(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -317,6 +317,15 @@ func applyInlineEnumModel(field goschema.Field, enum goschema.Enum, targetPlatfo
 	return newField
 }
 
+func emitsStandaloneEnumDefinitions(targetPlatform string) bool {
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB, platform.SQLite, platform.SQLServer:
+		return false
+	default:
+		return true
+	}
+}
+
 // FromField converts a goschema.Field to an ast.ColumnNode with comprehensive attribute mapping.
 //
 // This function transforms a high-level field definition into a concrete column AST node,
@@ -1437,10 +1446,15 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		statements.Statements = append(statements.Statements, extensionNode)
 	}
 
-	// 3. Add enum definitions (they may be referenced by tables)
-	for _, enum := range database.Enums {
-		enumNode := FromEnum(enum)
-		statements.Statements = append(statements.Statements, enumNode)
+	// 3. Add enum definitions when the dialect has standalone enum types.
+	// MySQL, MariaDB, SQLite, and SQL Server model enums on the column itself,
+	// so adding top-level enum nodes would render to no executable DDL and
+	// break live apply loops with empty statements.
+	if emitsStandaloneEnumDefinitions(targetPlatform) {
+		for _, enum := range database.Enums {
+			enumNode := FromEnum(enum)
+			statements.Statements = append(statements.Statements, enumNode)
+		}
 	}
 
 	// 4. Add table definitions (they may be referenced by indexes)

--- a/internal/convert/fromschema/fromschema_test.go
+++ b/internal/convert/fromschema/fromschema_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/internal/convert/fromschema"
 )
 
@@ -34,6 +35,25 @@ func countFields(fields []goschema.Field, structName, name string) int {
 	count := 0
 	for _, field := range fields {
 		if field.StructName == structName && field.Name == name {
+			count++
+		}
+	}
+	return count
+}
+
+func columnByName(table *ast.CreateTableNode, name string) *ast.ColumnNode {
+	for _, column := range table.Columns {
+		if column.Name == name {
+			return column
+		}
+	}
+	return nil
+}
+
+func countEnumStatements(statements *ast.StatementList) int {
+	count := 0
+	for _, statement := range statements.Statements {
+		if _, ok := statement.(*ast.EnumNode); ok {
 			count++
 		}
 	}
@@ -1507,6 +1527,100 @@ func TestFromDatabase_EmptySchema(t *testing.T) {
 
 	c.Assert(result, qt.IsNotNil)
 	c.Assert(result.Statements, qt.HasLen, 0)
+}
+
+func TestFromDatabase_InlineEnumDialectsOmitStandaloneEnumStatements(t *testing.T) {
+	database := goschema.Database{
+		Enums: []goschema.Enum{{
+			Name:   "enum_account_status",
+			Values: []string{"active", "suspended", "deleted"},
+		}},
+		Tables: []goschema.Table{{
+			StructName: "Account",
+			Name:       "accounts",
+		}},
+		Fields: []goschema.Field{{
+			StructName: "Account",
+			Name:       "status",
+			Type:       "enum_account_status",
+			Nullable:   false,
+			Default:    "active",
+			DefaultSet: true,
+		}},
+	}
+
+	tests := []struct {
+		dialect       string
+		expectedType  string
+		expectedCheck string
+	}{
+		{
+			dialect:      platform.MySQL,
+			expectedType: "ENUM('active', 'suspended', 'deleted')",
+		},
+		{
+			dialect:      platform.MariaDB,
+			expectedType: "ENUM('active', 'suspended', 'deleted')",
+		},
+		{
+			dialect:       platform.SQLite,
+			expectedType:  "TEXT",
+			expectedCheck: "status IN ('active', 'suspended', 'deleted')",
+		},
+		{
+			dialect:       platform.SQLServer,
+			expectedType:  "NVARCHAR(255)",
+			expectedCheck: "[status] IN ('active', 'suspended', 'deleted')",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			result := fromschema.FromDatabase(database, test.dialect)
+
+			c.Assert(result, qt.IsNotNil)
+			c.Assert(countEnumStatements(result), qt.Equals, 0)
+			table := tableStatementByName(result, "accounts")
+			c.Assert(table, qt.IsNotNil)
+			status := columnByName(table, "status")
+			c.Assert(status, qt.IsNotNil)
+			c.Assert(status.Type, qt.Equals, test.expectedType)
+			c.Assert(status.Check, qt.Equals, test.expectedCheck)
+		})
+	}
+}
+
+func TestFromDatabase_PostgresKeepsStandaloneEnumStatements(t *testing.T) {
+	c := qt.New(t)
+
+	database := goschema.Database{
+		Enums: []goschema.Enum{{
+			Name:   "enum_account_status",
+			Values: []string{"active", "suspended", "deleted"},
+		}},
+		Tables: []goschema.Table{{
+			StructName: "Account",
+			Name:       "accounts",
+		}},
+		Fields: []goschema.Field{{
+			StructName: "Account",
+			Name:       "status",
+			Type:       "enum_account_status",
+			Nullable:   false,
+		}},
+	}
+
+	result := fromschema.FromDatabase(database, platform.Postgres)
+
+	c.Assert(result, qt.IsNotNil)
+	c.Assert(countEnumStatements(result), qt.Equals, 1)
+	table := tableStatementByName(result, "accounts")
+	c.Assert(table, qt.IsNotNil)
+	status := columnByName(table, "status")
+	c.Assert(status, qt.IsNotNil)
+	c.Assert(status.Type, qt.Equals, "enum_account_status")
 }
 
 func TestFromDatabase_MySQLIncludesViewsAndTriggers(t *testing.T) {


### PR DESCRIPTION
## Summary

- skip standalone enum AST nodes for dialects that model enums on columns (`mysql`, `mariadb`, `sqlite`, `sqlserver`)
- keep PostgreSQL standalone enum behavior unchanged
- add regression coverage for the live-like MySQL/MariaDB enum fixture path so ordered create statements are executable and never include an empty enum statement

Closes #503.

## Self-review

Pass 1:

- Tightened the helper name from an inline-enum-only wording to `emitsStandaloneEnumDefinitions`, because SQLite and SQL Server use column-local CHECK modeling rather than `ENUM(...)`.
- Kept the behavior boundary in `fromschema.FromDatabase`, where the executable statement list is assembled, instead of hiding empty statements in conformance.

Pass 2:

- Reworked the renderer regression to parse Go annotations with `type="ENUM" enum="..."`, matching the live fixture contour more closely than a hand-built `goschema.Database`.
- Verified PostgreSQL still emits standalone enum statements.

## Validation

- `env GOWORK=off go test ./internal/convert/fromschema ./core/renderer -count=1`
- `env GOWORK=off go test ./... -count=1`
- `env GOWORK=off golangci-lint run ./internal/convert/fromschema ./core/renderer`
- `env GOWORK=off go tool qtlint ./...`
- `git diff --check`

Docs were not changed: this fixes internal DDL generation for existing documented dialect behavior.
