### PR TITLE
Expand Ptah docs site guides

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -5,6 +5,8 @@ This directory contains the Astro + Starlight documentation site.
 ```bash
 npm ci
 ASTRO_TELEMETRY_DISABLED=1 npm run build
+npm run versions:selftest
+npm audit --audit-level=low
 ```
 
 For local development:

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
       ],
       sidebar: [
         { label: 'Start', slug: 'getting-started' },
+        { label: 'Install Ptah', slug: 'install' },
         { label: 'Documentation map', slug: 'documentation-map' },
         {
           label: 'Use Ptah',

--- a/docs/site/src/content/docs/documentation-map.md
+++ b/docs/site/src/content/docs/documentation-map.md
@@ -7,18 +7,19 @@ Use this page when you know what you need to do, but not where the relevant Ptah
 
 | Situation | Read first | Then read |
 | --- | --- | --- |
-| I want to try Ptah locally | [Quick start](./getting-started/) | [Go model example](./examples/go-model/) |
-| My Go app owns the schema | [Go schema workflow](./workflows/go-schema/) | [Migrations](./workflows/migrations/) |
-| My schema lives in YAML | [Schema files](./workflows/schema-files/) | [YAML schema reference](https://github.com/stokaro/ptah/blob/master/docs/yaml_schema.md) |
-| My schema lives in Atlas HCL | [Schema files](./workflows/schema-files/) | [Atlas HCL schema reference](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
-| I need Atlas-style commands | [Atlas-compatible CLI](./workflows/atlas-cli/) | [Comparison](./reference/comparison/) |
-| I need to run Ptah in CI | [CI](./workflows/ci/) | [Exit codes](./reference/exit-codes/) |
-| I need dialect behavior | [Capabilities](./reference/capabilities/) | Dialect-specific reference markdown in `docs/` |
+| I need to install Ptah | [Install Ptah](../install/) | [Quick start](../getting-started/) |
+| I want to try Ptah locally | [Quick start](../getting-started/) | [Go model example](../examples/go-model/) |
+| My Go app owns the schema | [Go schema workflow](../workflows/go-schema/) | [Migrations](../workflows/migrations/) |
+| My schema lives in YAML | [Schema files](../workflows/schema-files/) | [YAML schema reference](https://github.com/stokaro/ptah/blob/master/docs/yaml_schema.md) |
+| My schema lives in Atlas HCL | [Schema files](../workflows/schema-files/) | [Atlas HCL schema reference](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
+| I need Atlas-style commands | [Atlas-compatible CLI](../workflows/atlas-cli/) | [Comparison](../reference/comparison/) |
+| I need to run Ptah in CI | [CI](../workflows/ci/) | [Exit codes](../reference/exit-codes/) |
+| I need dialect behavior | [Capabilities](../reference/capabilities/) | Dialect-specific reference markdown such as `docs/sqlite.md` and `docs/sqlserver.md` |
 | I need the public Go API | [`docs/public_api.md`](https://github.com/stokaro/ptah/blob/master/docs/public_api.md) | Stable packages, snapshots, and public API guard scripts |
-| I need diagrams | [Schema visualization example](./examples/schema-viz/) | [`examples/viz`](https://github.com/stokaro/ptah/tree/master/examples/viz) |
-| A command failed | [Troubleshooting](./operate/troubleshooting/) | The relevant command reference page |
-| I need Atlas parity evidence | [Conformance](./operate/conformance/) | [`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance) |
-| I need license assurance | [License boundary](./operate/license-boundary/) | Conformance repository provenance notes |
+| I need diagrams | [Schema visualization example](../examples/schema-viz/) | [`examples/viz`](https://github.com/stokaro/ptah/tree/master/examples/viz) |
+| A command failed | [Troubleshooting](../operate/troubleshooting/) | The relevant command reference page |
+| I need Atlas parity evidence | [Conformance](../operate/conformance/) | [`ptah-atlas-conformance`](https://github.com/stokaro/ptah-atlas-conformance) |
+| I need license assurance | [License boundary](../operate/license-boundary/) | Conformance repository provenance notes |
 
 ## Documentation layers
 
@@ -30,3 +31,14 @@ Use this page when you know what you need to do, but not where the relevant Ptah
 | `ptah-atlas-conformance` | External Atlas compatibility evidence and gap reports. |
 
 When a task is covered by both the site and a source reference, use the site for the workflow and the source reference for exact flags, schema shapes, or implementation details.
+
+## Maintenance rule
+
+When Ptah behavior changes, update both layers that readers will hit:
+
+- the task page in `docs/site/src/content/docs/`;
+- the exact source reference in `docs/*.md`, `examples/*`, package docs, or
+  conformance reports.
+
+Do not update only the nearest README when a command path, flag, config key,
+generated SQL shape, public API, or Atlas parity claim changes.

--- a/docs/site/src/content/docs/examples/atlas-hcl.md
+++ b/docs/site/src/content/docs/examples/atlas-hcl.md
@@ -3,6 +3,11 @@ title: Atlas HCL example
 description: A minimal supported Atlas HCL schema file.
 ---
 
+Use this example when you already have Atlas HCL schema files and want Ptah to
+read the supported schema subset.
+
+Create `schema.hcl`:
+
 ```hcl
 schema "public" {}
 
@@ -25,8 +30,25 @@ table "accounts" {
 }
 ```
 
+Render it:
+
 ```bash
 ptah schema render --schema-file schema.hcl --dialect postgres
 ```
 
-Ptah supports a deliberate Atlas HCL subset. Unsupported constructs are errors, not silent no-ops. See [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md).
+## Plan against a database
+
+```bash
+ptah migrations plan \
+  --schema-file schema.hcl \
+  --db-url "$DATABASE_URL"
+```
+
+Use `atlas.hcl` project config separately from schema HCL. A project config can
+provide database URLs, migration directories, and environment selection; a
+schema HCL file provides desired schema objects.
+
+Ptah supports a deliberate Atlas HCL subset. Unsupported constructs are errors,
+not silent no-ops. See
+[Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md)
+and [Atlas project config subset](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md).

--- a/docs/site/src/content/docs/examples/atlas-migrations.md
+++ b/docs/site/src/content/docs/examples/atlas-migrations.md
@@ -3,7 +3,11 @@ title: Atlas-style migrations example
 description: Use an Atlas-style migration directory with Ptah.
 ---
 
-Atlas-style migration files can include `migration.sql` and `down.sql` sections inside txtar archives.
+Atlas-style migration files can include `migration.sql` and `down.sql` sections
+inside txtar archives. Ptah executes those known sections and ignores unrelated
+embedded files.
+
+Create an Atlas-style migration:
 
 ```text
 -- atlas:txtar
@@ -16,6 +20,12 @@ CREATE TABLE users (
 
 -- down.sql --
 DROP TABLE users;
+```
+
+Name the file with a migration version, for example:
+
+```text
+migrations/20260721120000_create_users.sql
 ```
 
 Hash and validate the directory:
@@ -35,3 +45,29 @@ ptah migrations up \
 ```
 
 Use `ptah atlas migrate apply --dir ./migrations --url "$DATABASE_URL"` when you need the Atlas-compatible command path.
+
+## Roll back
+
+The `down.sql` section is used by rollback:
+
+Use the native command when you need an explicit rollback target:
+
+```bash
+ptah migrations down \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir ./migrations \
+  --dir-format atlas \
+  --target 0 \
+  --confirm
+```
+
+The Atlas-compatible `ptah atlas migrate down` command path exists, but the
+current help surface does not expose the native rollback flags. Use the native
+command for rollback recipes until the Atlas-compatible path documents the same
+runtime contract.
+
+## Troubleshooting
+
+If validation or apply fails, force Atlas directory parsing with
+`--dir-format atlas` and inspect the migration file for section names. Ptah
+recognizes `migration.sql` and `down.sql`; other section names are not executed.

--- a/docs/site/src/content/docs/examples/go-model.md
+++ b/docs/site/src/content/docs/examples/go-model.md
@@ -3,6 +3,18 @@ title: Go model example
 description: A tiny annotated Go model and the rendered SQL path.
 ---
 
+This example shows the smallest Go-annotation source that is still useful in a
+real project: a table, a primary key, a unique constraint, and a generated SQL
+smoke check.
+
+## Files
+
+```text
+models/
+  account.go
+migrations/
+```
+
 Create a model:
 
 ```go
@@ -18,7 +30,7 @@ type Account struct {
 }
 ```
 
-Render it:
+Render it from the project root:
 
 ```bash
 ptah schema render --root-dir ./models --dialect postgres
@@ -28,11 +40,43 @@ Expected shape:
 
 ```sql
 CREATE TABLE "accounts" (
-  "id" SERIAL NOT NULL,
-  "email" VARCHAR(255) NOT NULL,
-  PRIMARY KEY ("id"),
-  CONSTRAINT "uni_accounts_email" UNIQUE ("email")
+  "id" SERIAL PRIMARY KEY NOT NULL,
+  "email" TEXT UNIQUE NOT NULL
 );
 ```
 
 The exact type rendering depends on the selected dialect and field tags.
+
+## Generate migration SQL
+
+When a database is available, compare the desired Go model with the live state:
+
+```bash
+ptah migrations plan \
+  --root-dir ./models \
+  --db-url "$DATABASE_URL"
+```
+
+Generate files only after reviewing the plan:
+
+```bash
+ptah migrations generate \
+  --root-dir ./models \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir ./migrations
+
+ptah migrations hash --dir ./migrations
+ptah migrations validate --dir ./migrations
+```
+
+## Verify across dialects
+
+Render multiple dialects when annotations are meant to be portable:
+
+```bash
+ptah schema render --root-dir ./models --dialect postgres >/tmp/accounts.pg.sql
+ptah schema render --root-dir ./models --dialect sqlite >/tmp/accounts.sqlite.sql
+```
+
+Dialect differences are expected. The important check is that each target
+renders valid SQL for the capabilities it supports.

--- a/docs/site/src/content/docs/examples/schema-viz.md
+++ b/docs/site/src/content/docs/examples/schema-viz.md
@@ -3,7 +3,9 @@ title: Schema visualization example
 description: Render schema diagrams as Mermaid, DOT, or SVG.
 ---
 
-Ptah includes a checked-in visualization example at [`examples/viz`](https://github.com/stokaro/ptah/tree/master/examples/viz).
+Ptah includes a checked-in visualization example at
+[`examples/viz`](https://github.com/stokaro/ptah/tree/master/examples/viz). Use
+it to verify that diagram output is useful, not just syntactically generated.
 
 The example contains:
 
@@ -43,3 +45,26 @@ ptah viz \
 ```
 
 SVG output requires the Graphviz `dot` binary. If Graphviz is unavailable, generate Mermaid or DOT and render it with another tool.
+
+## Inspect the result
+
+After rebuilding, compare the committed artifacts:
+
+```bash
+git diff -- examples/viz/schema.sql examples/viz/schema.mmd examples/viz/schema.dot examples/viz/schema.svg
+```
+
+The example should show a connected schema with readable table names,
+relationships, and columns. A diagram that renders but loses relationships is a
+bug in the visualization path, not an acceptable example.
+
+## Choose an output format
+
+| Format | Use when |
+| --- | --- |
+| Mermaid | You want Markdown-friendly diagrams. |
+| DOT | You want Graphviz source for another renderer. |
+| SVG | You want a committed image artifact. |
+
+Use `--exclude-tables` to trim noisy tables and `--include-columns` when the
+diagram is meant to document table shape rather than only relationships.

--- a/docs/site/src/content/docs/examples/yaml-schema.md
+++ b/docs/site/src/content/docs/examples/yaml-schema.md
@@ -3,24 +3,54 @@ title: YAML schema example
 description: A minimal Ptah YAML schema file.
 ---
 
+Use YAML when Ptah owns the schema file and you want strict, compact input.
+
+Create `schema.yaml`:
+
 ```yaml
 tables:
   accounts:
     columns:
       id:
-        type: int
-        primary_key: true
+        type: SERIAL
+        primary: true
       email:
-        type: varchar
-        nullable: false
+        type: VARCHAR(255)
+        not_null: true
     indexes:
       accounts_email_key:
-        columns: [email]
+        fields: [email]
         unique: true
 ```
+
+Render it:
 
 ```bash
 ptah schema render --schema-file schema.yaml --dialect postgres
 ```
 
-Use YAML for Ptah-owned schema files. See the full reference in [YAML schema](https://github.com/stokaro/ptah/blob/master/docs/yaml_schema.md).
+Expected output includes a `CREATE TABLE` statement for `accounts` and a unique
+index or constraint for `email`, depending on dialect rendering.
+
+## Use it for migrations
+
+```bash
+ptah migrations plan \
+  --schema-file schema.yaml \
+  --db-url "$DATABASE_URL"
+
+ptah migrations generate \
+  --schema-file schema.yaml \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir ./migrations
+```
+
+Then hash and validate the directory:
+
+```bash
+ptah migrations hash --dir ./migrations
+ptah migrations validate --dir ./migrations
+```
+
+Use YAML for Ptah-owned schema files. See the full reference in
+[YAML schema](https://github.com/stokaro/ptah/blob/master/docs/yaml_schema.md).

--- a/docs/site/src/content/docs/getting-started.md
+++ b/docs/site/src/content/docs/getting-started.md
@@ -95,7 +95,7 @@ EOF
 Expected output includes:
 
 ```text
-Migration directory integrity verified
+OK: migrations directory matches ptah.sum
 ```
 
 ## Apply, inspect, status, and roll back
@@ -146,7 +146,7 @@ rm -f ./bin/ptah
 
 ## Next steps
 
-- Use [Go schema workflow](./workflows/go-schema/) when the application owns schema definitions in Go code.
-- Use [Schema files](./workflows/schema-files/) for YAML or Atlas HCL sources.
-- Use [Migrations](./workflows/migrations/) before applying Ptah to shared databases.
-- Use [Comparison](./reference/comparison/) to understand where Ptah currently matches Atlas and where conformance gaps remain.
+- Use [Go schema workflow](../workflows/go-schema/) when the application owns schema definitions in Go code.
+- Use [Schema files](../workflows/schema-files/) for YAML or Atlas HCL sources.
+- Use [Migrations](../workflows/migrations/) before applying Ptah to shared databases.
+- Use [Comparison](../reference/comparison/) to understand where Ptah currently matches Atlas and where conformance gaps remain.

--- a/docs/site/src/content/docs/index.mdx
+++ b/docs/site/src/content/docs/index.mdx
@@ -13,6 +13,10 @@ hero:
       link: ./getting-started/
       icon: right-arrow
       variant: primary
+    - text: Install
+      link: ./install/
+      icon: download
+      variant: secondary
     - text: View on GitHub
       link: https://github.com/stokaro/ptah
       icon: external
@@ -25,6 +29,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
   <LinkCard title="Quick start" href="./getting-started/" description="Build Ptah, create a tiny schema, run migrations, verify hashes, and clean up." />
+  <LinkCard title="Install Ptah" href="./install/" description="Build from source, install with Go, verify the command tree, and add optional tools." />
   <LinkCard title="Go schema workflow" href="./workflows/go-schema/" description="Use annotated Go structs as the application-owned schema source." />
   <LinkCard title="Schema files" href="./workflows/schema-files/" description="Render and migrate from YAML schema files or Atlas HCL schema files." />
   <LinkCard title="Migrations" href="./workflows/migrations/" description="Plan, generate, apply, roll back, hash, validate, and inspect migrations." />
@@ -35,6 +40,17 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
   <LinkCard title="Troubleshooting" href="./operate/troubleshooting/" description="Fix Graphviz, database URL, hash mismatch, unsupported capability, and conformance issues." />
 </CardGrid>
 
+## Choose your path
+
+| If you have | Start with |
+| --- | --- |
+| A Go application with schema annotations | [Go schema workflow](./workflows/go-schema/) |
+| YAML or Atlas HCL schema files | [Schema files](./workflows/schema-files/) |
+| An existing migration directory | [Migrations](./workflows/migrations/) |
+| Scripts written for Atlas OSS commands | [Atlas-compatible CLI](./workflows/atlas-cli/) |
+| A pull-request gate to build | [CI](./workflows/ci/) |
+| A compatibility question | [Conformance](./operate/conformance/) |
+
 :::caution[Atlas parity status]
 Ptah is working toward Atlas OSS command and behavior parity, but full parity is not claimed here. The current evidence is tracked in the separate conformance repository and summarized in [Conformance](./operate/conformance/).
 :::
@@ -42,3 +58,16 @@ Ptah is working toward Atlas OSS command and behavior parity, but full parity is
 ## License-clean implementation
 
 Ptah does not use Atlas source code. Atlas interface behavior and Apache-2.0 test assets are evaluated in the separate `ptah-atlas-conformance` repository so the Ptah source tree stays MIT and implementation-independent. See [License boundary](./operate/license-boundary/).
+
+## Documentation layers
+
+The site is the first reader-facing layer. Detailed source references remain in
+the repository for exact schema formats, public API contracts, dialect tables,
+and release operations.
+
+| Layer | Use it for |
+| --- | --- |
+| `docs/site` | Task-oriented workflows and examples. |
+| `docs/*.md` | Exact command, config, dialect, conformance, and design references. |
+| `examples/*` | Runnable inputs and generated artifacts. |
+| `ptah-atlas-conformance` | Atlas compatibility evidence and gap reports. |

--- a/docs/site/src/content/docs/install.md
+++ b/docs/site/src/content/docs/install.md
@@ -1,0 +1,82 @@
+---
+title: Install Ptah
+description: Install, build, and verify the Ptah CLI before using it in a project.
+---
+
+Use this page to get a `ptah` binary onto a developer machine or CI runner.
+
+## Choose an install path
+
+| Situation | Recommended command |
+| --- | --- |
+| You are developing Ptah itself | `GOWORK=off go build -o ./bin/ptah ./cmd/ptah` |
+| You want the latest module version in another project | `go install github.com/stokaro/ptah/cmd/ptah@latest` |
+| You want a reproducible CI toolchain | Pin a version or pseudo-version in the install command |
+
+Ptah is pre-GA, so pinning is better for automation than relying on `latest`.
+
+## Build from a checkout
+
+From the repository root:
+
+```bash
+GOWORK=off go build -o ./bin/ptah ./cmd/ptah
+./bin/ptah version
+```
+
+Expected shape:
+
+```text
+ptah version ...
+```
+
+Use the local binary in examples:
+
+```bash
+./bin/ptah schema render --root-dir ./examples/viz/models --dialect postgres
+```
+
+## Install with Go
+
+```bash
+go install github.com/stokaro/ptah/cmd/ptah@latest
+ptah version
+```
+
+If `ptah` is not found after `go install`, add `$(go env GOPATH)/bin` to your
+`PATH`.
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+ptah version
+```
+
+## Optional tools
+
+Some Ptah features need extra local tools:
+
+| Tool | Needed for |
+| --- | --- |
+| Graphviz `dot` | `ptah viz --format svg` |
+| Database client/server | Live `db`, `schema compare`, and `migrations` workflows |
+| Atlas CE binary | Differential checks in the external conformance repository |
+
+Mermaid and DOT visualization output do not require Graphviz.
+
+## Verify command shape
+
+```bash
+ptah --help
+ptah migrations --help
+ptah atlas migrate --help
+```
+
+Atlas-compatible commands are nested under `ptah atlas <command> ...`. Root-level
+Atlas spellings such as `ptah migrate apply` are intentionally not part of the
+supported command tree.
+
+## Next steps
+
+- Run the [Quick start](../getting-started/) for a complete SQLite smoke test.
+- Use [Commands](../reference/commands/) when wiring Ptah into scripts.
+- Use [CI](../workflows/ci/) when pinning Ptah in pull-request checks.

--- a/docs/site/src/content/docs/operate/conformance.md
+++ b/docs/site/src/content/docs/operate/conformance.md
@@ -23,6 +23,19 @@ The authoritative current numbers live in the conformance repository reports:
 
 Ptah documentation must not claim full Atlas OSS parity until the full conformance gates are green.
 
+## How to read green and red checks
+
+The conformance repository separates regression budgets from full parity:
+
+| Gate type | Meaning |
+| --- | --- |
+| Regression budget | No new gaps beyond the accepted budget for that contour. Should stay green. |
+| Full conformance | Every checked case in that contour passes. May stay red while known gaps remain. |
+
+A green regression-budget check does not mean Ptah has full Atlas OSS parity.
+A red full-conformance check is expected while the report still lists known
+gaps.
+
 ## Local commands
 
 From the Ptah repository:
@@ -44,3 +57,11 @@ make budget-diff
 ```
 
 Live and differential probes require real database URLs. Differential probes also require an Atlas CE binary built from the pinned Atlas version in the conformance repository.
+
+## When to update reports
+
+Update conformance after Ptah changes that affect Atlas command behavior,
+schema parsing/rendering, migration directory semantics, live database
+round-trips, or public compatibility APIs. Bump the Ptah module version in the
+conformance repository, run `go mod tidy`, regenerate the relevant reports, and
+let both regression and full-conformance checks show the expected state.

--- a/docs/site/src/content/docs/operate/license-boundary.md
+++ b/docs/site/src/content/docs/operate/license-boundary.md
@@ -16,6 +16,17 @@ ptah                  !-> ptah-atlas-conformance
 
 Ptah can be tested by the conformance repo, but Ptah does not import or vendor that repository.
 
+## What is allowed
+
+Ptah compatibility work may use:
+
+- Atlas public command names, flags, file formats, and documented behavior;
+- observable behavior from running Atlas OSS;
+- Apache-2.0 test assets kept in the separate conformance repository;
+- independently written Ptah code, tests, and documentation.
+
+Ptah must not copy, vendor, or port Atlas source code into this repository.
+
 ## Documentation rule
 
 When documenting Atlas compatibility:

--- a/docs/site/src/content/docs/operate/troubleshooting.md
+++ b/docs/site/src/content/docs/operate/troubleshooting.md
@@ -36,6 +36,14 @@ ptah db read --db-url sqlite:////tmp/app.db
 
 For PostgreSQL-like databases, include database name and credentials in the URL, or provide them through the environment your driver expects.
 
+If a command also accepts project config, confirm which source won:
+
+```bash
+ptah migrations status --env dev --migrations-dir ./migrations
+```
+
+Explicit flags win over environment variables and config files.
+
 ## Hash validation fails
 
 Regenerate the hash after intentionally changing migrations:
@@ -56,7 +64,7 @@ ptah schema render --root-dir ./models --dialect sqlite
 ptah schema render --root-dir ./models --dialect postgres
 ```
 
-Reference: [Capabilities](../reference/capabilities/).
+Reference: [Capabilities](../../reference/capabilities/).
 
 ## `atlas.hcl` fails to load
 
@@ -67,6 +75,18 @@ unsupported atlas.hcl construct ...
 ```
 
 Reference: [Atlas project config subset](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md).
+
+## Atlas-compatible command is registered but not implemented
+
+Some Atlas-compatible paths exist so scripts fail in the right namespace before
+runtime behavior is complete. Example help text:
+
+```text
+Runtime behavior is not implemented yet.
+```
+
+Use the native Ptah command when it has a documented equivalent, or check
+[Conformance](../conformance/) for the current gap.
 
 ## Conformance reports look red
 

--- a/docs/site/src/content/docs/reference/capabilities.md
+++ b/docs/site/src/content/docs/reference/capabilities.md
@@ -3,7 +3,9 @@ title: Capabilities
 description: Dialect capability summary and links to detailed support tables.
 ---
 
-Ptah tracks dialect features through capability metadata. Renderers and migration planners should check capabilities rather than hard-code optimistic behavior.
+Ptah tracks dialect features through capability metadata. Renderers and
+migration planners should check capabilities rather than hard-code optimistic
+behavior.
 
 High-level dialect coverage:
 
@@ -15,6 +17,22 @@ High-level dialect coverage:
 | SQL Server | Supported subset with dedicated docs. |
 | CockroachDB / YugabyteDB | PostgreSQL-compatible paths with capability differences. |
 | ClickHouse / Spanner | Explicit capability-limited support. |
+
+## What capabilities decide
+
+Capabilities answer questions that a dialect name alone cannot answer:
+
+| Question | Example capability |
+| --- | --- |
+| Can this target drop constraints with the generic SQL spelling? | `drop_constraint_generic` |
+| Can this target guard index drops with `IF EXISTS`? | `drop_index_if_exists` |
+| Are CHECK constraints enforced? | `check_constraints_enforced` |
+| Are enums inline column types or standalone custom types? | `enum_inline_column`, `enum_custom_type` |
+| Can PostgreSQL-style concurrent indexes be emitted? | `create_index_concurrently` |
+| Does the target support roles, RLS, XML, or advisory locks? | `role_management`, `row_level_security`, `xml_type`, `advisory_locks` |
+
+The same parser or planner family can therefore adapt to MySQL versus MariaDB,
+PostgreSQL versus CockroachDB/YugabyteDB/Spanner, and version-specific behavior.
 
 References:
 

--- a/docs/site/src/content/docs/reference/commands.md
+++ b/docs/site/src/content/docs/reference/commands.md
@@ -16,11 +16,13 @@ Reference: [native CLI command tree](https://github.com/stokaro/ptah/blob/master
 | --- | --- |
 | `ptah introspect` | Generate annotated Go models from a live database. |
 | `ptah schema render` | Render desired schema SQL from Go, YAML, or Atlas HCL inputs. |
+| `ptah schema annotations` | Export Ptah Go annotation metadata. |
 | `ptah schema compare` | Compare desired schema with a live database. |
 | `ptah schema drift` | Check live database drift against desired schema. |
 | `ptah schema export` | Export one schema source format to another. |
 | `ptah viz` | Render desired schema diagrams as Mermaid, DOT, or SVG. |
 | `ptah db read` | Read schema from a live database. |
+| `ptah db drop-all` | Drop all schema objects in a live database. |
 | `ptah migrations plan` | Print migration SQL from desired/live schema differences. |
 | `ptah migrations generate` | Generate migration files from desired/live schema differences. |
 | `ptah migrations create` | Create empty migration files for manual SQL. |
@@ -30,6 +32,9 @@ Reference: [native CLI command tree](https://github.com/stokaro/ptah/blob/master
 | `ptah migrations hash` | Write or update migration-directory integrity. |
 | `ptah migrations validate` | Validate migration-directory integrity. |
 | `ptah migrations lint` | Lint migration files. |
+| `ptah sql lint` | Lint standalone SQL files. |
+| `ptah seed` | Apply environment-scoped SQL seed files. |
+| `ptah version` | Print Ptah build information. |
 
 ## Atlas-compatible commands
 
@@ -40,3 +45,21 @@ ptah atlas migrate apply --url "$DATABASE_URL" --dir ./migrations
 ptah atlas migrate status --url "$DATABASE_URL" --dir ./migrations
 ptah atlas schema inspect --url "$DATABASE_URL"
 ```
+
+| Command | Current status |
+| --- | --- |
+| `ptah atlas migrate apply` | Forwards to `ptah migrations up`. |
+| `ptah atlas migrate status` | Forwards to `ptah migrations status`. |
+| `ptah atlas migrate hash` | Forwards to `ptah migrations hash`. |
+| `ptah atlas migrate validate` | Forwards to `ptah migrations validate`. |
+| `ptah atlas migrate lint` | Forwards to `ptah migrations lint`. |
+| `ptah atlas migrate new` | Forwards to `ptah migrations create`. |
+| `ptah atlas migrate set` | Forwards to `ptah migrations repair`. |
+| `ptah atlas migrate down` | Registered path; use native rollback docs for explicit target recipes. |
+| `ptah atlas migrate diff` | Registered path; runtime behavior is not implemented yet. |
+| `ptah atlas migrate import` | Registered path; runtime behavior is not implemented yet. |
+| `ptah atlas schema inspect` | Forwards to `ptah db read`. |
+| `ptah atlas schema diff` | Forwards to `ptah schema compare`. |
+
+Run `ptah <command> --help` or `ptah atlas <command> --help` for exact flags in
+the version you are using.

--- a/docs/site/src/content/docs/reference/comparison.md
+++ b/docs/site/src/content/docs/reference/comparison.md
@@ -8,24 +8,31 @@ description: Ptah native commands, Atlas-compatible commands, feature parity, co
 | Task | Native Ptah | Atlas-compatible Ptah | Atlas OSS |
 | --- | --- | --- | --- |
 | Apply migrations | `ptah migrations up` | `ptah atlas migrate apply` | `atlas migrate apply` |
-| Roll back migrations | `ptah migrations down` | `ptah atlas migrate down` | `atlas migrate down` |
+| Roll back migrations | `ptah migrations down` | Registered path; use native rollback recipes for explicit targets until Atlas-compatible flags are documented. | `atlas migrate down` |
 | Migration status | `ptah migrations status` | `ptah atlas migrate status` | `atlas migrate status` |
 | Hash migrations | `ptah migrations hash` | `ptah atlas migrate hash` | `atlas migrate hash` |
 | Validate migrations | `ptah migrations validate` | `ptah atlas migrate validate` | `atlas migrate validate` |
 | Lint migrations | `ptah migrations lint` | `ptah atlas migrate lint` | `atlas migrate lint` |
+| Create an empty migration | `ptah migrations create` | `ptah atlas migrate new` | `atlas migrate new` |
+| Repair revision state | `ptah migrations repair` | `ptah atlas migrate set` | `atlas migrate set` |
 | Inspect schema | `ptah db read` | `ptah atlas schema inspect` | `atlas schema inspect` |
 | Diff schema | `ptah schema compare` | `ptah atlas schema diff` | `atlas schema diff` |
+
+Some Atlas command paths are intentionally registered before complete runtime
+behavior exists. `ptah atlas migrate diff` and `ptah atlas migrate import`
+currently report that runtime behavior is not implemented yet. Use conformance
+reports for the current compatibility boundary.
 
 ## Feature parity
 
 | Area | Ptah status | Evidence |
 | --- | --- | --- |
-| Offline Atlas fixture ingestion | Currently green in the conformance repo. | [Conformance](../operate/conformance/) |
-| Live database round trips | Has known gaps. | [Conformance](../operate/conformance/) |
-| Atlas CE differential checks | Has known gaps. | [Conformance](../operate/conformance/) |
+| Offline Atlas fixture ingestion | Currently green in the conformance repo. | [Conformance](../../operate/conformance/) |
+| Live database round trips | Has known gaps. | [Conformance](../../operate/conformance/) |
+| Atlas CE differential checks | Has known gaps. | [Conformance](../../operate/conformance/) |
 | Atlas HCL schema files | Supported subset. | [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
 | Atlas project config | Supported subset. | [Atlas project config](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md) |
-| Native Go annotations | First-party Ptah workflow. | [Go schema workflow](../workflows/go-schema/) |
+| Native Go annotations | First-party Ptah workflow. | [Go schema workflow](../../workflows/go-schema/) |
 
 ## Config precedence
 
@@ -47,4 +54,4 @@ description: Ptah native commands, Atlas-compatible commands, feature parity, co
 | Rollback | Requires explicit `--target`; use `--confirm` for non-interactive runs. |
 | Destructive migration plans | Should be gated in CI; use the GitHub Action or explicit review. |
 
-Reference: [Exit codes](./exit-codes/).
+Reference: [Exit codes](../exit-codes/).

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -15,6 +15,40 @@ Configuration precedence is:
 
 Use `ptah.yaml` for Ptah-owned configuration and the supported `atlas.hcl` subset for Atlas-compatible project config.
 
+## Minimal `ptah.yaml`
+
+```yaml
+env:
+  dev:
+    url: sqlite:////tmp/ptah-dev.db
+    migration:
+      dir: ./migrations
+```
+
+Run with the named environment:
+
+```bash
+ptah migrations status --env dev
+ptah migrations up --env dev --verify-sum
+```
+
+If a config file has multiple environments, pass `--env`. Ptah fails instead of
+guessing.
+
+## Operational settings
+
+Project config can also define timeouts, revision table layout, migration
+directory format, backup destinations, pre-flight hooks, webhooks, lint defaults,
+and online-DDL policy.
+
+| Setting area | Example keys |
+| --- | --- |
+| Database target | `url`, `dev`, `schemas` |
+| Migration directory and revisions | `migration.dir`, `migration.format`, `migration.revisions_table`, `migration.revision_format` |
+| Safety and operations | `migration.pre_up_hook`, `migration.pg_dump_to`, `migration.webhook`, `migration.exec_order` |
+| Lint defaults | `lint.dialect`, `lint.disabled-rules` |
+| Online DDL | `online_ddl.tool`, `online_ddl.threshold_rows` |
+
 References:
 
 - [Project configuration](https://github.com/stokaro/ptah/blob/master/docs/project_config.md)

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -3,7 +3,14 @@ title: Exit codes
 description: How Ptah commands behave when used as automation gates.
 ---
 
-Ptah uses exit code `0` for success and `1` for command-specific failure states. `migrations status --exit-code` also returns `1` when pending migrations exist.
+Ptah uses exit codes as a public scripting contract:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Expected negative result from a check, such as drift, lint findings, pending migrations with `--exit-code`, or migration hash drift. |
+| `2` | Command or usage error, including bad flags, invalid input, parse failures, connection failures, unsupported dialects, and recovered internal panics. |
+| `3+` | Reserved until documented for a specific use. |
 
 Use the detailed matrix in [CLI exit codes](https://github.com/stokaro/ptah/blob/master/docs/exit_codes.md) when wiring Ptah into CI.
 
@@ -14,3 +21,7 @@ ptah migrations validate --dir ./migrations
 ptah migrations status --db-url "$DATABASE_URL" --migrations-dir ./migrations --exit-code
 ptah migrations lint --dir ./migrations --dialect postgres
 ```
+
+Do not collapse all non-zero outcomes into the same remediation. A `1` usually
+means the command successfully found a condition you asked it to check; a `2`
+means the command itself did not complete correctly.

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -7,18 +7,33 @@ Atlas-compatible command paths live under `ptah atlas <command> ...`.
 
 Ptah does not add root-level Atlas spellings such as `ptah migrate apply` or `ptah schema inspect`. Those paths are intentionally invalid because the native Ptah command tree is being designed separately before GA.
 
+## Translation model
+
+Implemented Atlas-compatible commands translate Atlas-style flags into Ptah's
+native command model and then delegate to native behavior. Unsupported flags
+fail clearly instead of being ignored.
+
+| Atlas flag style | Native Ptah concept |
+| --- | --- |
+| `--url` | `--db-url` |
+| `--dir` | `--migrations-dir` |
+| `atlas.hcl` env | Project config IR |
+| Atlas revision table mode | Ptah revision format and table settings |
+
 ## Migration commands
 
 | Atlas-compatible command | Native Ptah command |
 | --- | --- |
 | `ptah atlas migrate apply` | `ptah migrations up` |
-| `ptah atlas migrate down` | `ptah migrations down` |
+| `ptah atlas migrate down` | Registered path; use native `ptah migrations down` for explicit target rollback recipes until the Atlas-compatible flags are documented. |
 | `ptah atlas migrate status` | `ptah migrations status` |
 | `ptah atlas migrate hash` | `ptah migrations hash` |
 | `ptah atlas migrate validate` | `ptah migrations validate` |
 | `ptah atlas migrate lint` | `ptah migrations lint` |
 | `ptah atlas migrate new` | `ptah migrations create` |
-| `ptah atlas migrate diff` | `ptah migrations plan` or `ptah migrations generate`, depending on flags |
+| `ptah atlas migrate set` | `ptah migrations repair` |
+| `ptah atlas migrate diff` | Command path registered; runtime behavior is not implemented yet. |
+| `ptah atlas migrate import` | Command path registered; runtime behavior is not implemented yet. |
 
 ## Schema commands
 
@@ -38,3 +53,24 @@ ptah atlas schema inspect --url "$DATABASE_URL"
 ```
 
 Ptah translates implemented Atlas-style flags and then delegates to native behavior. Unsupported Atlas flags should fail clearly instead of being ignored.
+
+## Check before migration
+
+```bash
+ptah atlas migrate hash --dir ./migrations
+ptah atlas migrate validate --dir ./migrations
+ptah atlas migrate status --url "$DATABASE_URL" --dir ./migrations
+```
+
+When converting scripts, keep the `atlas` namespace in the Ptah command:
+
+| Do | Do not |
+| --- | --- |
+| `ptah atlas migrate apply --url "$DATABASE_URL" --dir ./migrations` | `ptah migrate apply --url "$DATABASE_URL" --dir ./migrations` |
+| `ptah atlas schema inspect --url "$DATABASE_URL"` | `ptah schema inspect --url "$DATABASE_URL"` |
+
+## Parity expectations
+
+Ptah is not documented as a full Atlas OSS replacement until the external
+conformance gates prove that claim. Use [Conformance](../../operate/conformance/)
+for current evidence and known gaps.

--- a/docs/site/src/content/docs/workflows/ci.md
+++ b/docs/site/src/content/docs/workflows/ci.md
@@ -49,6 +49,33 @@ ptah schema render --root-dir ./models --dialect postgres >/tmp/ptah-schema.sql
 
 Use a disposable database for `migrations plan`, `migrations generate`, and `migrations up` in pull requests.
 
+## Recommended pull-request contour
+
+| Check | Why it exists |
+| --- | --- |
+| `migrations validate` | Fails when committed migration files and `ptah.sum` disagree. |
+| `migrations lint` | Catches risky SQL before it reaches a database. |
+| `schema render` | Proves the desired schema source still parses. |
+| `migrations plan` against a disposable DB | Shows the SQL Ptah would apply. |
+| `migrations up --verify-sum --dry-run` | Exercises the apply path without changing the shared target. |
+
+For live checks, prefer throwaway databases or service containers. Do not point a
+pull-request job at a production database.
+
 ## Exit behavior
 
-See [Exit codes](../reference/exit-codes/) before using Ptah as a gate. `migrations status --exit-code` returns `1` when pending migrations exist; most other usage, parse, connection, and safety failures return `1`.
+See [Exit codes](../../reference/exit-codes/) before using Ptah as a gate. `0`
+means success, `1` is reserved for command-specific negative check results such
+as drift, lint findings, pending migrations with `--exit-code`, or migration
+hash drift. Usage errors, parse failures, connection failures, unsupported
+dialects, and other command errors use `2`.
+
+## Keep CI deterministic
+
+- Pin the Ptah version used by CI.
+- Commit migration files and `ptah.sum` together.
+- Keep database URLs in secrets.
+- Run Atlas-compatible scripts through `ptah atlas ...`, not root-level Atlas
+  aliases.
+- Link CI failures to [Troubleshooting](../../operate/troubleshooting/) so users
+  have recovery steps.

--- a/docs/site/src/content/docs/workflows/go-schema.md
+++ b/docs/site/src/content/docs/workflows/go-schema.md
@@ -3,7 +3,17 @@ title: Go schema workflow
 description: Use annotated Go structs as the desired database schema.
 ---
 
-Use this workflow when your Go application owns the schema and the database should follow the annotated model types.
+Use this workflow when your Go application owns the schema and the database
+should follow annotated model types. Ptah reads comments, not runtime Go tags,
+so the model remains ordinary Go code.
+
+## When to use it
+
+| Use Go annotations when | Use another source when |
+| --- | --- |
+| The application structs already describe the domain. | A database team owns SQL or HCL directly. |
+| You want code review to cover schema changes next to model changes. | You need an Atlas HCL construct Ptah has not implemented yet. |
+| You want generated migrations from desired/live differences. | You only need to apply an existing migration directory. |
 
 ## Model the schema
 
@@ -34,6 +44,13 @@ Render the desired SQL before connecting to a database:
 ptah schema render --root-dir ./models --dialect postgres
 ```
 
+Smoke-check the command before you involve a live database:
+
+```bash
+ptah schema render --root-dir ./models --dialect sqlite >/tmp/ptah-schema.sql
+sed -n '1,80p' /tmp/ptah-schema.sql
+```
+
 ## Compare before changing data
 
 For an existing database, inspect and compare first:
@@ -59,8 +76,35 @@ ptah migrations validate --dir ./migrations
 ptah migrations up --db-url "$DATABASE_URL" --migrations-dir ./migrations --verify-sum
 ```
 
+For shared environments, add these guards:
+
+```bash
+ptah migrations validate --dir ./migrations
+ptah migrations lint --dir ./migrations --dialect postgres
+ptah migrations up \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir ./migrations \
+  --verify-sum \
+  --dry-run
+```
+
+Run without `--dry-run` only after reviewing the generated SQL and committed
+`ptah.sum`.
+
+## Keep generated schema reviewable
+
+When a model change is surprising, render more than one dialect:
+
+```bash
+ptah schema render --root-dir ./models --dialect postgres >/tmp/schema.pg.sql
+ptah schema render --root-dir ./models --dialect mysql >/tmp/schema.mysql.sql
+```
+
+This catches annotations that are valid but map differently across dialects,
+such as enum storage, serial columns, constraints, or generated columns.
+
 ## Keep references close
 
-- Full native command tree: [Commands](../reference/commands/).
+- Full native command tree: [Commands](../../reference/commands/).
 - Annotation comparison with Atlas HCL: [Go annotations vs Atlas HCL](https://github.com/stokaro/ptah/blob/master/docs/go_annotations_vs_atlas_hcl.md).
 - Programmatic parser usage: [Public API](https://github.com/stokaro/ptah/blob/master/docs/public_api.md).

--- a/docs/site/src/content/docs/workflows/migrations.md
+++ b/docs/site/src/content/docs/workflows/migrations.md
@@ -3,7 +3,9 @@ title: Migrations
 description: Plan, generate, apply, roll back, hash, validate, and inspect Ptah migrations.
 ---
 
-Ptah migrations are the operational boundary between desired schema and live database state.
+Ptah migrations are the operational boundary between desired schema and live
+database state. Treat migration files as code: review them, hash them, lint
+them, and apply them through a repeatable command.
 
 ## Recommended loop
 
@@ -24,6 +26,18 @@ ptah migrations up \
   --migrations-dir ./migrations \
   --verify-sum
 ```
+
+## Manual migration files
+
+Create an empty pair when you want to write SQL by hand:
+
+```bash
+ptah migrations create add_accounts --migrations-dir ./migrations
+```
+
+Then edit the generated `*.up.sql` and `*.down.sql` files. Keep the rollback
+real even if the first consumer only applies migrations forward; `down` support
+is part of Ptah's migration contract.
 
 ## Rollback
 
@@ -58,6 +72,22 @@ ptah migrations validate --dir ./migrations
 
 Use `--verify-sum` on `migrations up` to block out-of-band migration edits.
 
+## Safety gates
+
+Use dry-run and lint before applying to shared environments:
+
+```bash
+ptah migrations lint --dir ./migrations --dialect postgres
+ptah migrations up \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir ./migrations \
+  --verify-sum \
+  --dry-run
+```
+
+Destructive statements require explicit policy. Use `--allow-destructive` only
+after the plan has been reviewed and the rollback path is understood.
+
 ## Status
 
 ```bash
@@ -71,9 +101,25 @@ Set `--exit-code` in CI when pending migrations should fail the job.
 
 ## Atlas-style directories
 
-Ptah can read Ptah split files and supported Atlas-style migration directories. Use `--dir-format atlas` when auto-detection should not guess:
+Ptah can read Ptah split files and supported Atlas-style migration directories.
+Use `--dir-format atlas` when auto-detection should not guess:
 
 ```bash
 ptah migrations validate --dir ./migrations --dir-format atlas
 ptah migrations up --db-url "$DATABASE_URL" --migrations-dir ./migrations --dir-format atlas
 ```
+
+Atlas-compatible command paths are available under `ptah atlas migrate ...`:
+
+```bash
+ptah atlas migrate hash --dir ./migrations
+ptah atlas migrate apply --url "$DATABASE_URL" --dir ./migrations
+```
+
+## Operational hooks
+
+`ptah.yaml` can configure pre-migration hooks, backup destinations, timeouts,
+revision table settings, and webhooks. Use those for production-like runs
+instead of relying on ad hoc wrapper scripts.
+
+Reference: [Configuration](../../reference/configuration/).

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -3,7 +3,16 @@ title: Schema files
 description: Use YAML schema files or Atlas HCL schema files as Ptah input.
 ---
 
-Ptah can render and migrate from schema files when Go annotations are not the source of truth.
+Ptah can render and migrate from schema files when Go annotations are not the
+source of truth.
+
+## Pick a source format
+
+| Format | Best for | Notes |
+| --- | --- | --- |
+| Ptah YAML | Ptah-owned schema files with compact structure. | Strict parser; unknown keys fail. |
+| Atlas HCL schema | Reusing supported Atlas schema files. | Supported subset only; unsupported constructs fail. |
+| Live database | Introspection, drift checks, and migration planning. | Requires a database URL. |
 
 ## YAML schema
 
@@ -14,15 +23,23 @@ tables:
   users:
     columns:
       id:
-        type: int
-        primary_key: true
+        type: SERIAL
+        primary: true
       email:
-        type: varchar
-        nullable: false
+        type: VARCHAR(255)
+        not_null: true
 ```
 
 ```bash
 ptah schema render --schema-file schema.yaml --dialect postgres
+```
+
+Use the same input to plan against a live database:
+
+```bash
+ptah migrations plan \
+  --schema-file schema.yaml \
+  --db-url "$DATABASE_URL"
 ```
 
 Reference: [YAML schema](https://github.com/stokaro/ptah/blob/master/docs/yaml_schema.md).
@@ -52,8 +69,23 @@ table "users" {
 ptah schema render --schema-file schema.hcl --dialect postgres
 ```
 
+Ptah reads schema HCL as desired schema input. Project configuration HCL is a
+different file type and is described in [Configuration](../../reference/configuration/).
+
 Reference: [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md).
 
 :::caution[Supported subset]
 Ptah intentionally rejects unsupported Atlas HCL constructs instead of silently guessing. If a construct is not implemented, treat the error as a compatibility gap and check the conformance reports.
 :::
+
+## Validate before applying
+
+Keep schema-file workflows reviewable:
+
+```bash
+ptah schema render --schema-file schema.yaml --dialect postgres >/tmp/schema.sql
+ptah migrations plan --schema-file schema.yaml --db-url "$DATABASE_URL" >/tmp/plan.sql
+```
+
+Review both files. The render output proves Ptah understood the desired schema;
+the plan output proves what would change in the target database.


### PR DESCRIPTION
## Summary

- expand the Astro/Starlight docs site from a thin map into task-oriented Ptah documentation modeled after the Inventario docs structure
- add an Install Ptah page and surface it in the Starlight sidebar and homepage
- deepen workflow, example, reference, and operate pages with copy-pasteable commands, expected results, safety notes, and conformance/license boundaries
- fix stale or overbroad docs claims found during review: exit code semantics, YAML schema keys, Go rendered SQL shape, quickstart validate output, nested internal links, and Atlas-compatible command status for `migrate down`, `migrate diff`, and `migrate import`

## Documentation impact map

- Root docs site entrypoints: `docs/site/README.md`, `docs/site/astro.config.mjs`, `index.mdx`, `documentation-map.md`, new `install.md`
- Workflows: Go schema, schema files, migrations, Atlas-compatible CLI, CI
- Examples: Go model, YAML schema, Atlas HCL, Atlas-style migrations, schema visualization
- Reference: commands, configuration, capabilities, comparison, exit codes
- Operate: troubleshooting, conformance, license boundary

## Validation

- `GOWORK=off go build -o ./bin/ptah ./cmd/ptah`
- `./bin/ptah --help`
- `./bin/ptah atlas migrate diff --help`
- `./bin/ptah schema render --root-dir ./examples/viz/models --dialect postgres`
- YAML schema smoke: `./bin/ptah schema render --schema-file /private/tmp/ptah-docs-smoke-yaml/schema.yaml --dialect postgres`
- Atlas HCL smoke: `./bin/ptah schema render --schema-file /private/tmp/ptah-docs-smoke-hcl/schema.hcl --dialect postgres`
- Go model smoke: `./bin/ptah schema render --root-dir /private/tmp/ptah-docs-smoke-go/models --dialect postgres`
- Quickstart SQLite smoke: create, hash, validate, up, read, status, down
- `cd docs/site && npm ci`
- `cd docs/site && ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `cd docs/site && npm run versions:selftest`
- `cd docs/site && npm audit --audit-level=low`
- generated-site internal link checker: `checked 23 html files; internal links resolve`
- `git diff --check`

## Self-review

Coverage pass checked every Starlight section plus source references for native CLI, project config, capabilities, conformance, exit codes, YAML schema, and actual CLI help.

Truth pass found and fixed stale behavior in the existing site docs: old validate output text, invalid YAML keys, inaccurate rendered SQL examples, wrong exit-code simplification, broken relative links from non-index pages, and unsupported/partial Atlas-compatible command overclaims.
