### PR TITLE
Fix MySQL typed literal defaults

### DIFF
--- a/core/renderer/internal/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/internal/dialects/mysql/alter_ops_test.go
@@ -114,7 +114,13 @@ func TestMySQL_ColumnDefaultLiteralQuoting(t *testing.T) {
 	table := ast.NewCreateTable("products").
 		AddColumn(ast.NewColumn("status", "enum('draft','active')").
 			SetNotNull().
-			SetDefault("draft"))
+			SetDefault("draft")).
+		AddColumn(ast.NewColumn("archived", "BOOLEAN").
+			SetNotNull().
+			SetDefault("false")).
+		AddColumn(ast.NewColumn("views", "integer").
+			SetNotNull().
+			SetDefault("42"))
 	alter := &ast.AlterTableNode{
 		Name: "products",
 		Operations: []ast.AlterOperation{
@@ -123,14 +129,29 @@ func TestMySQL_ColumnDefaultLiteralQuoting(t *testing.T) {
 					SetNotNull().
 					SetDefault("'draft'"),
 			},
+			&ast.ModifyColumnOperation{
+				Column: ast.NewColumn("archived", "BOOLEAN").
+					SetNotNull().
+					SetDefault("false"),
+			},
+			&ast.ModifyColumnOperation{
+				Column: ast.NewColumn("views", "integer").
+					SetNotNull().
+					SetDefault("42"),
+			},
 		},
 	}
 
 	out := renderMySQL(t, table, alter)
 
 	c.Assert(out, qt.Contains, "`status` enum('draft','active') NOT NULL DEFAULT 'draft'")
+	c.Assert(out, qt.Contains, "`archived` BOOLEAN NOT NULL DEFAULT 0")
+	c.Assert(out, qt.Contains, "`views` integer NOT NULL DEFAULT 42")
 	c.Assert(out, qt.Contains, "ALTER TABLE `products` MODIFY COLUMN `status` enum('draft','active') NOT NULL DEFAULT 'draft';")
+	c.Assert(out, qt.Contains, "ALTER TABLE `products` MODIFY COLUMN `archived` BOOLEAN NOT NULL DEFAULT 0;")
+	c.Assert(out, qt.Contains, "ALTER TABLE `products` MODIFY COLUMN `views` integer NOT NULL DEFAULT 42;")
 	c.Assert(out, qt.Not(qt.Contains), "DEFAULT ''draft''")
+	c.Assert(out, qt.Not(qt.Contains), "DEFAULT 'false'")
 }
 
 func TestMySQL_AlterTable_ClickHouseOnlyOpsEmitComment(t *testing.T) {

--- a/core/renderer/internal/dialects/mysql/schema_objects_test.go
+++ b/core/renderer/internal/dialects/mysql/schema_objects_test.go
@@ -61,6 +61,28 @@ func TestMySQLRenderer_EmptyLiteralDefault(t *testing.T) {
 	c.Assert(sql, qt.Contains, "`name` varchar(255) NOT NULL DEFAULT ''")
 }
 
+func TestMySQLRenderer_TypedLiteralDefaults(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("products").
+		AddColumn(ast.NewColumn("archived", "BOOLEAN").SetNotNull().SetDefault("false")).
+		AddColumn(ast.NewColumn("published", "BOOL").SetNotNull().SetDefault("true")).
+		AddColumn(ast.NewColumn("views", "integer").SetNotNull().SetDefault("42")).
+		AddColumn(ast.NewColumn("status", "enum('draft','active')").SetNotNull().SetDefault("draft")).
+		AddColumn(ast.NewColumn("token", "varbinary(16)").SetDefault("abc")).
+		AddColumn(ast.NewColumn("created_at", "TIMESTAMP").SetNotNull().SetDefault("CURRENT_TIMESTAMP"))
+
+	sql := renderMySQL(t, table)
+
+	c.Assert(sql, qt.Contains, "`archived` BOOLEAN NOT NULL DEFAULT 0")
+	c.Assert(sql, qt.Contains, "`published` BOOL NOT NULL DEFAULT 1")
+	c.Assert(sql, qt.Contains, "`views` integer NOT NULL DEFAULT 42")
+	c.Assert(sql, qt.Contains, "`status` enum('draft','active') NOT NULL DEFAULT 'draft'")
+	c.Assert(sql, qt.Contains, "`token` varbinary(16) DEFAULT 'abc'")
+	c.Assert(sql, qt.Contains, "`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP")
+	c.Assert(sql, qt.Not(qt.Contains), "DEFAULT 'false'")
+}
+
 func TestMySQLRenderer_ColumnCharsetCollate(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/internal/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/internal/dialects/mysqllike/mysqllike.go
@@ -50,11 +50,83 @@ func (r *Renderer) escapeValue(value string) string {
 	return "'" + escaped + "'"
 }
 
-func (r *Renderer) renderDefaultLiteral(value string) string {
+func (r *Renderer) renderDefaultLiteral(column *ast.ColumnNode) string {
+	value := strings.TrimSpace(column.Default.Value)
 	if strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
 		return value
 	}
-	return r.escapeValue(value)
+	if literal, ok := renderBooleanDefaultLiteral(column.Type, value); ok {
+		return literal
+	}
+	if value == "" || mysqlDefaultNeedsLiteralQuotes(column.Type, value) {
+		return r.escapeValue(column.Default.Value)
+	}
+	return column.Default.Value
+}
+
+func renderBooleanDefaultLiteral(columnType, value string) (string, bool) {
+	if !isMySQLBooleanType(columnType) {
+		return "", false
+	}
+	switch strings.ToLower(value) {
+	case "false":
+		return "0", true
+	case "true":
+		return "1", true
+	default:
+		return "", false
+	}
+}
+
+func isMySQLBooleanType(columnType string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(columnType))
+	return normalized == "bool" ||
+		normalized == "boolean" ||
+		strings.HasPrefix(normalized, "tinyint(1)")
+}
+
+func mysqlDefaultNeedsLiteralQuotes(columnType, value string) bool {
+	if isMySQLNullDefault(value) || isMySQLTemporalDefaultExpression(columnType, value) {
+		return false
+	}
+
+	normalizedType := strings.ToLower(strings.TrimSpace(columnType))
+	switch {
+	case strings.HasPrefix(normalizedType, "enum("), strings.HasPrefix(normalizedType, "set("):
+		return true
+	case strings.Contains(normalizedType, "char"), strings.Contains(normalizedType, "text"):
+		return true
+	case strings.Contains(normalizedType, "binary"), strings.Contains(normalizedType, "blob"), normalizedType == "json":
+		return true
+	case strings.Contains(normalizedType, "date"), strings.Contains(normalizedType, "time"), strings.Contains(normalizedType, "year"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isMySQLNullDefault(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "NULL")
+}
+
+func isMySQLTemporalDefaultExpression(columnType, value string) bool {
+	normalizedType := strings.ToLower(strings.TrimSpace(columnType))
+	if !strings.Contains(normalizedType, "date") && !strings.Contains(normalizedType, "time") && !strings.Contains(normalizedType, "year") {
+		return false
+	}
+
+	normalizedValue := strings.ToUpper(strings.TrimSpace(value))
+	normalizedValue = strings.TrimSuffix(normalizedValue, "()")
+	switch normalizedValue {
+	case "CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME", "LOCALTIME", "LOCALTIMESTAMP", "NOW":
+		return true
+	default:
+		return strings.HasPrefix(normalizedValue, "CURRENT_TIMESTAMP(") ||
+			strings.HasPrefix(normalizedValue, "CURRENT_TIME(") ||
+			strings.HasPrefix(normalizedValue, "LOCALTIME(") ||
+			strings.HasPrefix(normalizedValue, "LOCALTIMESTAMP(") ||
+			strings.HasPrefix(normalizedValue, "NOW(")
+	}
 }
 
 func escapeIdentifier(identifier string) string {
@@ -611,7 +683,7 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	case column.Default == nil:
 		// No default value
 	case column.Default.HasLiteral():
-		parts = append(parts, fmt.Sprintf("DEFAULT %s", r.renderDefaultLiteral(column.Default.Value)))
+		parts = append(parts, fmt.Sprintf("DEFAULT %s", r.renderDefaultLiteral(column)))
 	case column.Default.Expression != "":
 		parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 	}
@@ -823,7 +895,7 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 		if column.Default.Expression != "" {
 			parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
 		} else if column.Default.HasLiteral() {
-			parts = append(parts, fmt.Sprintf("DEFAULT %s", r.renderDefaultLiteral(column.Default.Value)))
+			parts = append(parts, fmt.Sprintf("DEFAULT %s", r.renderDefaultLiteral(column)))
 		}
 	}
 	if column.UpdateExpression != "" {

--- a/core/renderer/renderer_test.go
+++ b/core/renderer/renderer_test.go
@@ -573,6 +573,32 @@ type Account struct {
 	}
 }
 
+func TestGetOrderedCreateStatements_MySQLBooleanDefaultsAreExecutable(t *testing.T) {
+	database, err := goschema.ParseSource("model.go", `package models
+
+//migrator:schema:table name="products"
+type Product struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+	//migrator:schema:field name="archived" type="BOOLEAN" not_null="true" default="false"
+	Archived bool
+}
+
+//migrator:schema:view name="live_products" body="SELECT id FROM products WHERE archived = false"
+type LiveProductsView struct{}
+`)
+	c := qt.New(t)
+	c.Assert(err, qt.IsNil)
+
+	statements, err := renderer.GetOrderedCreateStatements(&database, "mysql")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 2)
+	c.Assert(statements[0], qt.Contains, "`archived` BOOLEAN NOT NULL DEFAULT 0")
+	c.Assert(statements[0], qt.Not(qt.Contains), "DEFAULT 'false'")
+	c.Assert(statements[1], qt.Contains, "CREATE VIEW `live_products` AS")
+}
+
 func TestGetOrderedCreateStatements_MutualForeignKeysAreTwoPhase(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dbschema/mysql/mysql_test.go
+++ b/internal/dbschema/mysql/mysql_test.go
@@ -321,6 +321,20 @@ func TestNormalizeMySQLColumnDefaultQuotesCatalogStringLiterals(t *testing.T) {
 			want:         "42",
 		},
 		{
+			name:         "boolean numeric false",
+			columnType:   "tinyint(1)",
+			dataType:     "tinyint",
+			defaultValue: "0",
+			want:         "0",
+		},
+		{
+			name:         "boolean keyword false",
+			columnType:   "tinyint(1)",
+			dataType:     "tinyint",
+			defaultValue: "false",
+			want:         "false",
+		},
+		{
 			name:         "temporal expression",
 			columnType:   "timestamp",
 			dataType:     "timestamp",


### PR DESCRIPTION
## Summary
- Render MySQL/MariaDB literal defaults with column-type awareness instead of quoting every literal
- Normalize BOOLEAN/BOOL literal defaults to 0/1 and keep numeric defaults bare
- Preserve quoting for string-like, enum, binary, and empty literal defaults; keep temporal defaults like CURRENT_TIMESTAMP bare for temporal columns

## Validation
- env GOWORK=off go test ./core/renderer ./core/renderer/internal/dialects/mysql ./core/renderer/internal/dialects/mariadb ./internal/dbschema/mysql -count=1
- env GOWORK=off go test ./... -count=1
- env GOWORK=off go tool qtlint ./...
- env GOWORK=off golangci-lint run ./...
- Rendered live mysql/03-view fixture now emits archived BOOLEAN NOT NULL DEFAULT 0
- Applied products table + live_products view DDL successfully to MySQL 8.4

Closes #502