### PR TITLE
Fix MySQL view body roundtrip comparison

### DIFF
--- a/migration/schemadiff/internal/compare/compare_schema_objects_test.go
+++ b/migration/schemadiff/internal/compare/compare_schema_objects_test.go
@@ -38,6 +38,41 @@ func TestViews_IgnoresDatabaseOnlyQualification(t *testing.T) {
 	c.Assert(diff.ViewsModified, qt.HasLen, 0)
 }
 
+func TestViews_IgnoresMySQLCanonicalViewBody(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "live_products", Body: "SELECT id, name FROM products WHERE archived = false"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{
+			Name: "live_products",
+			Body: "select `ptah_issue_502`.`products`.`id` AS `id`,`ptah_issue_502`.`products`.`name` AS `name` " +
+				"from `ptah_issue_502`.`products` where (`ptah_issue_502`.`products`.`archived` = false)",
+		}},
+	}, diff)
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 0)
+}
+
+func TestViews_DetectsMySQLCanonicalPredicateChange(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "live_products", Body: "SELECT id, name FROM products WHERE archived = false"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{
+			Name: "live_products",
+			Body: "select `ptah_issue_502`.`products`.`id` AS `id`,`ptah_issue_502`.`products`.`name` AS `name` " +
+				"from `ptah_issue_502`.`products` where (`ptah_issue_502`.`products`.`archived` = true)",
+		}},
+	}, diff)
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
 func TestViews_DetectsExplicitQualifierChange(t *testing.T) {
 	c := qt.New(t)
 	diff := &difftypes.SchemaDiff{}

--- a/migration/schemadiff/internal/compare/schema_objects.go
+++ b/migration/schemadiff/internal/compare/schema_objects.go
@@ -324,11 +324,11 @@ func schemaObjectBodiesEqual(generatedBody, databaseBody string) bool {
 }
 
 func normalizeSQLBodyPreservingQualifiers(body string) string {
-	return normalizeSQLBody(body)
+	return canonicalizeNormalizedSQLBody(normalizeSQLBody(body))
 }
 
 func normalizeSQLBodyStrippingQualifiers(body string) string {
-	return schemaQualifierPattern.ReplaceAllString(normalizeSQLBody(body), "")
+	return canonicalizeNormalizedSQLBody(schemaQualifierPattern.ReplaceAllString(normalizeSQLBody(body), ""))
 }
 
 func normalizeSQLBody(body string) string {
@@ -339,6 +339,14 @@ func normalizeSQLBody(body string) string {
 	body = strings.ReplaceAll(body, "`", "")
 	body = strings.ToLower(body)
 	body = stripDefaultAggregateAliases(body)
+	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
+	body = sqlCommaSpacingPattern.ReplaceAllString(body, ",")
+	return strings.TrimSpace(body)
+}
+
+func canonicalizeNormalizedSQLBody(body string) string {
+	body = stripDefaultColumnAliases(body)
+	body = stripSimpleComparisonParentheses(body)
 	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
 	return strings.TrimSpace(body)
 }
@@ -351,4 +359,18 @@ func stripDefaultAggregateAliases(body string) string {
 		}
 		return parts[1] + "(" + parts[2] + ")"
 	})
+}
+
+func stripDefaultColumnAliases(body string) string {
+	return defaultColumnAliasPattern.ReplaceAllStringFunc(body, func(match string) string {
+		parts := defaultColumnAliasPattern.FindStringSubmatch(match)
+		if len(parts) != 3 || parts[1] != parts[2] {
+			return match
+		}
+		return parts[1]
+	})
+}
+
+func stripSimpleComparisonParentheses(body string) string {
+	return simpleComparisonParenthesesPattern.ReplaceAllString(body, "$1")
 }

--- a/migration/schemadiff/internal/compare/shared.go
+++ b/migration/schemadiff/internal/compare/shared.go
@@ -24,8 +24,15 @@ var (
 	// Match indexes that start with "idx_" or "index_", or end with "_idx" or "_index"
 	customIndexPattern = regexp.MustCompile(`(?i)(^(idx|index)_|_(idx|index)$)`)
 
-	defaultAggregateAliasPattern = regexp.MustCompile(`\b(count|sum|avg|min|max)\(([^)]*)\)\s+as\s+([a-z_][a-z0-9_]*)\b`)
-	schemaQualifierPattern       = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`)
+	defaultAggregateAliasPattern       = regexp.MustCompile(`\b(count|sum|avg|min|max)\(([^)]*)\)\s+as\s+([a-z_][a-z0-9_]*)\b`)
+	defaultColumnAliasPattern          = regexp.MustCompile(`\b([a-z_][a-z0-9_]*)\s+as\s+([a-z_][a-z0-9_]*)\b`)
+	simpleComparisonParenthesesPattern = regexp.MustCompile(
+		`\(([a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*\s*` +
+			`(?:=|<>|!=|<=|>=|<|>|like|is(?:\s+not)?)\s*` +
+			`(?:[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*|[0-9]+(?:\.[0-9]+)?|'[^']*'|true|false|null))\)`,
+	)
+	sqlCommaSpacingPattern = regexp.MustCompile(`\s*,\s*`)
+	schemaQualifierPattern = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`)
 )
 
 func nonEmptyNames(names []string) []string {


### PR DESCRIPTION
## Summary

- Canonicalize MySQL-style view bodies that add same-name column aliases, database/table qualifiers, comma spacing changes, and harmless parentheses around simple predicates.
- Preserve detection for real predicate/body changes and explicit qualifier differences.
- Add regression coverage using the exact `mysql/03-view` body shape returned by MySQL `information_schema`.

## Validation

- `env GOWORK=off go test ./migration/schemadiff/... -count=1`
- `env GOWORK=off go test ./... -count=1`
- `env GOWORK=off go tool qtlint ./...`
- `env GOWORK=off golangci-lint run ./...`
- `ptah-atlas-conformance` with local replace: `make gate-live` -> GREEN, 10 observations, 0 non-OK

Closes #507
