### PR TITLE
docs: add internal link validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,8 @@ jobs:
           set -euo pipefail
           cd docs/site
           npm ci
+          npm run check:links:selftest
+          npm run check:links
           npm run build
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"
           cp -r dist/. "$GITHUB_WORKSPACE/_site/edge/"
@@ -81,9 +83,13 @@ jobs:
           set -euo pipefail
           workdir="$(mktemp -d)"
           git worktree add --force "$workdir" origin/master
-          ( cd "$workdir/docs/site" \
-            && DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm ci \
-            && DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build )
+          (
+            cd "$workdir/docs/site"
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm ci
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:links:selftest
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:links
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build
+          )
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"
           cp -r "$workdir/docs/site/dist/." "$GITHUB_WORKSPACE/_site/edge/"
           git worktree remove --force "$workdir" || true
@@ -97,9 +103,17 @@ jobs:
             workdir="$(mktemp -d)"
             git worktree add --force "$workdir" "refs/tags/$tag"
             if [ -f "$workdir/docs/site/package.json" ]; then
-              if ( cd "$workdir/docs/site" \
-                   && DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm ci \
-                   && DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run build ); then
+              if (
+                cd "$workdir/docs/site"
+                DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm ci
+                if [ -f scripts/check-links.mjs ]; then
+                  DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run check:links:selftest
+                  DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run check:links
+                else
+                  echo "::warning::$tag has no docs link checker; skipping link validation"
+                fi
+                DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run build
+              ); then
                 mkdir -p "$GITHUB_WORKSPACE/_site/$tag"
                 cp -r "$workdir/docs/site/dist/." "$GITHUB_WORKSPACE/_site/$tag/"
               else

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -4,6 +4,8 @@ This directory contains the Astro + Starlight documentation site.
 
 ```bash
 npm ci
+ASTRO_TELEMETRY_DISABLED=1 npm run check:links:selftest
+ASTRO_TELEMETRY_DISABLED=1 npm run check:links
 ASTRO_TELEMETRY_DISABLED=1 npm run build
 npm run versions:selftest
 npm audit --audit-level=low
@@ -16,3 +18,6 @@ ASTRO_TELEMETRY_DISABLED=1 npm run dev
 ```
 
 The site is versioned by `DOCS_VERSION`; `edge` tracks `master`.
+The docs workflow runs internal link validation before building `edge` and
+before building released tags that include `scripts/check-links.mjs`. Older
+historical tags without that checker are still built with a warning.

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -10,6 +10,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "check:links": "node scripts/check-links.mjs",
+    "check:links:selftest": "node scripts/check-links.mjs --selftest",
     "versions:selftest": "node scripts/gen-versions.mjs --selftest"
   },
   "dependencies": {

--- a/docs/site/scripts/check-links.mjs
+++ b/docs/site/scripts/check-links.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, extname, join, relative, sep } from 'node:path';
+import path from 'node:path/posix';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(scriptDir, '..');
+const docsRoot = join(siteRoot, 'src', 'content', 'docs');
+const docExts = new Set(['.md', '.mdx']);
+const externalSchemes = /^[a-z][a-z0-9+.-]*:/i;
+
+function toPosix(value) {
+  return value.split(sep).join('/');
+}
+
+function walk(dir) {
+  const files = [];
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+      continue;
+    }
+    if (entry.isFile() && docExts.has(extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function routeFor(root, file) {
+  let route = toPosix(relative(root, file)).replace(/\.(md|mdx)$/, '');
+  if (route === 'index') return '/';
+  if (route.endsWith('/index')) route = route.slice(0, -'/index'.length);
+  return `/${route}/`;
+}
+
+function normalizeRoute(route) {
+  let normalized = path.normalize(route);
+  if (!normalized.startsWith('/')) normalized = `/${normalized}`;
+  if (!normalized.endsWith('/')) normalized = `${normalized}/`;
+  return normalized;
+}
+
+function stripFencedCode(source) {
+  return source.replace(/```[\s\S]*?```/g, '');
+}
+
+function extractLinks(file) {
+  const source = stripFencedCode(readFileSync(file, 'utf8'));
+  const links = [];
+  const patterns = [
+    /(?<!!)\[[^\]\n]+\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g,
+    /\bhref=["']([^"']+)["']/g,
+    /^\s+link:\s+([^\s]+)\s*$/gm,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      links.push(normalizeHref(match[1]));
+    }
+  }
+
+  return links;
+}
+
+function normalizeHref(href) {
+  const trimmed = href.trim();
+  if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function targetPath(href) {
+  const withoutHash = href.split('#', 1)[0];
+  return withoutHash.split('?', 1)[0];
+}
+
+function resolveRoute(sourceRoute, href) {
+  const parts = sourceRoute.split('/').filter(Boolean);
+  for (const segment of href.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (parts.length === 0) return { escaped: true, route: null };
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  return { escaped: false, route: normalizeRoute(`/${parts.join('/')}/`) };
+}
+
+function validateLink(root, routes, file, href, cwd) {
+  if (!href || href.startsWith('#') || externalSchemes.test(href)) {
+    return null;
+  }
+
+  const cleanHref = targetPath(href);
+  if (!cleanHref) return null;
+
+  if (cleanHref.startsWith('/')) {
+    return `${toPosix(relative(cwd, file))}: ${href} is root-relative; use a docs-relative link so GitHub Pages keeps /ptah/<version>/ in the URL`;
+  }
+
+  const sourceRoute = routeFor(root, file);
+  const { escaped, route: resolved } = resolveRoute(sourceRoute, cleanHref);
+  if (escaped) {
+    return `${toPosix(relative(cwd, file))}: ${href} escapes the docs route root`;
+  }
+  if (routes.has(resolved)) return null;
+
+  return `${toPosix(relative(cwd, file))}: ${href} resolves to missing route ${resolved}`;
+}
+
+function checkLinks(root, cwd) {
+  const files = walk(root);
+  const routes = new Set(files.map((file) => routeFor(root, file)));
+  const errors = [];
+
+  for (const file of files) {
+    for (const href of extractLinks(file)) {
+      const error = validateLink(root, routes, file, href, cwd);
+      if (error) errors.push(error);
+    }
+  }
+
+  return { errors, files, routes };
+}
+
+function writeDoc(root, name, content) {
+  const file = join(root, name);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function selftest() {
+  const tmp = mkdtempSync(join(tmpdir(), 'ptah-doc-links-'));
+  const root = join(tmp, 'src', 'content', 'docs');
+
+  try {
+    writeDoc(root, 'index.mdx', '---\ntitle: Home\n---\n[Start](./reference/comparison/)\n');
+    writeDoc(root, 'operate/conformance.md', '---\ntitle: Conformance\n---\n');
+    writeDoc(root, 'workflows/go-schema.md', '---\ntitle: Go schema\n---\n');
+    writeDoc(root, 'reference/exit-codes.md', '---\ntitle: Exit codes\n---\n');
+    writeDoc(
+      root,
+      'reference/comparison.md',
+      [
+        '---',
+        'title: Comparison',
+        '---',
+        '[Conformance](../operate/conformance/)',
+        '[Go schema workflow](../workflows/go-schema/)',
+        '[Exit codes](./exit-codes/)',
+      ].join('\n'),
+    );
+
+    const broken = checkLinks(root, tmp);
+    assert(broken.errors.length === 3, `expected 3 broken fixture links, got ${broken.errors.length}`);
+    assert(broken.errors.some((error) => error.includes('/reference/operate/conformance/')), 'catches conformance over-relative link');
+    assert(broken.errors.some((error) => error.includes('/reference/workflows/go-schema/')), 'catches workflow over-relative link');
+    assert(broken.errors.some((error) => error.includes('/reference/comparison/exit-codes/')), 'catches same-folder exit code link');
+
+    writeDoc(root, 'index.mdx', '---\ntitle: Home\n---\n[Escapes](../reference/comparison/)\n');
+    const escaped = checkLinks(root, tmp);
+    assert(escaped.errors.some((error) => error.includes('escapes the docs route root')), 'catches route-root escape from index');
+    writeDoc(root, 'index.mdx', '---\ntitle: Home\n---\n[Start](./reference/comparison/)\n');
+
+    writeDoc(
+      root,
+      'reference/comparison.md',
+      [
+        '---',
+        'title: Comparison',
+        '---',
+        '[Conformance](../../operate/conformance/)',
+        '[Go schema workflow](../../workflows/go-schema/)',
+        '[Exit codes](../exit-codes/)',
+      ].join('\n'),
+    );
+
+    const fixed = checkLinks(root, tmp);
+    assert(fixed.errors.length === 0, `expected fixed fixture links to pass, got ${fixed.errors.join('; ')}`);
+    console.log('check-links.mjs --selftest: OK');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  if (process.argv[2] === '--selftest') {
+    selftest();
+    return;
+  }
+
+  if (!existsSync(docsRoot)) {
+    console.error(`error: docs content directory not found: ${docsRoot}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const { errors, files, routes } = checkLinks(docsRoot, process.cwd());
+
+  if (errors.length > 0) {
+    console.error('Broken internal documentation links:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`check-links.mjs: OK (${files.length} pages, ${routes.size} routes)`);
+}
+
+main();


### PR DESCRIPTION
## Summary

- add a dependency-free docs internal link checker for Starlight content routes
- cover the exact broken comparison-page route class from #496 with a self-test fixture
- run link validation in docs CI before edge builds and released-tag builds that include the checker

## Validation

- `node --check scripts/check-links.mjs`
- `npm run check:links:selftest`
- `npm run check:links`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `npm run versions:selftest`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "docs.yml YAML: OK"'`

Closes #496
