### PR TITLE
docs: clarify Atlas comparison gaps

### DIFF
--- a/docs/site/src/content/docs/examples/atlas-migrations.md
+++ b/docs/site/src/content/docs/examples/atlas-migrations.md
@@ -61,10 +61,10 @@ ptah migrations down \
   --confirm
 ```
 
-The Atlas-compatible `ptah atlas migrate down` command path exists, but the
-current help surface does not expose the native rollback flags. Use the native
-command for rollback recipes until the Atlas-compatible path documents the same
-runtime contract.
+The `ptah atlas migrate down` command path exists as a Ptah extension path, but
+current conformance does not track it as an Atlas OSS drop-in target. Use the
+native command for rollback recipes until the Atlas-compatible path documents
+the same runtime contract.
 
 ## Troubleshooting
 

--- a/docs/site/src/content/docs/operate/conformance.md
+++ b/docs/site/src/content/docs/operate/conformance.md
@@ -21,7 +21,10 @@ The authoritative current numbers live in the conformance repository reports:
 - [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md)
 - [`PARITY.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/PARITY.md)
 
-Ptah documentation must not claim full Atlas OSS parity until the full conformance gates are green.
+Green conformance reports mean that the current measured corpus has no red
+results. They do not, by themselves, prove every Atlas OSS command, flag,
+dialect feature, and output mode. Use the comparison gap register for product
+and coverage gaps that are outside the current measured corpus.
 
 ## How to read green and red checks
 
@@ -30,11 +33,16 @@ The conformance repository separates regression budgets from full parity:
 | Gate type | Meaning |
 | --- | --- |
 | Regression budget | No new gaps beyond the accepted budget for that contour. Should stay green. |
-| Full conformance | Every checked case in that contour passes. May stay red while known gaps remain. |
+| Full conformance | Every checked case in that contour passes. May stay red while the measured corpus still has non-OK results. |
 
 A green regression-budget check does not mean Ptah has full Atlas OSS parity.
-A red full-conformance check is expected while the report still lists known
-gaps.
+A red full-conformance check is expected while the report still lists measured
+non-OK results.
+
+Even when both regression-budget and full-conformance checks are green, the
+claim is limited to the corpus represented by the generated reports. Expanding
+live and differential coverage is tracked in
+[`stokaro/ptah-atlas-conformance#167`](https://github.com/stokaro/ptah-atlas-conformance/issues/167).
 
 ## Local commands
 

--- a/docs/site/src/content/docs/operate/troubleshooting.md
+++ b/docs/site/src/content/docs/operate/troubleshooting.md
@@ -93,6 +93,10 @@ Use the native Ptah command when it has a documented equivalent, or check
 The conformance repo has two kinds of gates:
 
 - Regression-budget gates should stay green when no new gaps appear.
-- Full-conformance gates remain red until the known gaps are closed.
+- Full-conformance gates are red while the measured corpus still has non-OK
+  results.
 
-This is intentional. A green regression gate does not mean Ptah has complete Atlas OSS parity.
+This is intentional. A green regression gate does not mean Ptah has complete
+Atlas OSS parity. Even green full-conformance reports only prove the current
+measured corpus; use [Comparison](../../reference/comparison/) for tracked
+product, coverage, and documentation gaps.

--- a/docs/site/src/content/docs/reference/commands.md
+++ b/docs/site/src/content/docs/reference/commands.md
@@ -55,7 +55,7 @@ ptah atlas schema inspect --url "$DATABASE_URL"
 | `ptah atlas migrate lint` | Forwards to `ptah migrations lint`. |
 | `ptah atlas migrate new` | Forwards to `ptah migrations create`. |
 | `ptah atlas migrate set` | Forwards to `ptah migrations repair`. |
-| `ptah atlas migrate down` | Registered path; use native rollback docs for explicit target recipes. |
+| `ptah atlas migrate down` | Ptah extension path; use native rollback docs for explicit target recipes. |
 | `ptah atlas migrate diff` | Registered path; runtime behavior is not implemented yet. |
 | `ptah atlas migrate import` | Registered path; runtime behavior is not implemented yet. |
 | `ptah atlas schema inspect` | Forwards to `ptah db read`. |

--- a/docs/site/src/content/docs/reference/comparison.md
+++ b/docs/site/src/content/docs/reference/comparison.md
@@ -8,7 +8,7 @@ description: Ptah native commands, Atlas-compatible commands, feature parity, co
 | Task | Native Ptah | Atlas-compatible Ptah | Atlas OSS |
 | --- | --- | --- | --- |
 | Apply migrations | `ptah migrations up` | `ptah atlas migrate apply` | `atlas migrate apply` |
-| Roll back migrations | `ptah migrations down` | Registered path; use native rollback recipes for explicit targets until Atlas-compatible flags are documented. | `atlas migrate down` |
+| Roll back migrations | `ptah migrations down` | Ptah extension path; not tracked as an Atlas OSS drop-in target by current conformance. | Not in the current OSS target corpus |
 | Migration status | `ptah migrations status` | `ptah atlas migrate status` | `atlas migrate status` |
 | Hash migrations | `ptah migrations hash` | `ptah atlas migrate hash` | `atlas migrate hash` |
 | Validate migrations | `ptah migrations validate` | `ptah atlas migrate validate` | `atlas migrate validate` |
@@ -19,20 +19,35 @@ description: Ptah native commands, Atlas-compatible commands, feature parity, co
 | Diff schema | `ptah schema compare` | `ptah atlas schema diff` | `atlas schema diff` |
 
 Some Atlas command paths are intentionally registered before complete runtime
-behavior exists. `ptah atlas migrate diff` and `ptah atlas migrate import`
-currently report that runtime behavior is not implemented yet. Use conformance
-reports for the current compatibility boundary.
+behavior exists, and some accepted Atlas flags still fail explicitly rather than
+being silently ignored. The gap register below links that work to concrete
+tracking issues.
 
-## Feature parity
+## Feature parity evidence
 
 | Area | Ptah status | Evidence |
 | --- | --- | --- |
-| Offline Atlas fixture ingestion | Currently green in the conformance repo. | [Conformance](../../operate/conformance/) |
-| Live database round trips | Has known gaps. | [Conformance](../../operate/conformance/) |
-| Atlas CE differential checks | Has known gaps. | [Conformance](../../operate/conformance/) |
-| Atlas HCL schema files | Supported subset. | [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
-| Atlas project config | Supported subset. | [Atlas project config](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md) |
+| Offline Atlas fixture ingestion | Current imported Atlas fixture corpus is green: 160 fixtures, 636 observations, 0 non-OK in the linked report. | [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md) |
+| Live database round trips | Current live smoke corpus is green: 10 observations, 0 non-OK in the linked report. This is evidence for the covered scenarios, not proof of every Atlas OSS runtime path. | [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md) |
+| Atlas CE differential checks | Current Atlas CE differential corpus is green: 5 observations, 0 non-OK in the linked report. This is evidence for the covered scenarios, not proof of every Atlas OSS schema object. | [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md) |
+| Atlas HCL schema files | Strict supported subset. Unsupported constructs fail explicitly instead of being ignored. | [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
+| Atlas project config | Strict supported subset. Unsupported constructs fail explicitly instead of being ignored. | [Atlas project config](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md) |
 | Native Go annotations | First-party Ptah workflow. | [Go schema workflow](../../workflows/go-schema/) |
+
+## Gap register
+
+| Gap | Type | Current boundary | Tracking |
+| --- | --- | --- | --- |
+| Atlas-compatible command runtime placeholders | Product behavior | These registered paths currently report that runtime behavior is not implemented yet: `ptah atlas schema apply`, `ptah atlas schema fmt`, `ptah atlas migrate diff`, `ptah atlas migrate import`, `ptah atlas version`, and `ptah atlas license`. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Atlas-compatible flag semantics | Product behavior | Accepted flags whose behavior is still incomplete: `schema inspect --dev-url`, `schema inspect --exclude`, `schema inspect --format`, `schema diff --from`, `schema diff --to`, `schema diff --dev-url`, `schema diff --format`, `schema clean --auto-approve`, `migrate apply --tx-mode`, `migrate lint --dev-url`, `migrate lint --latest`, and `migrate validate --dev-url`. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Atlas HCL schema and project config subset audit | Product behavior and coverage | Current imported fixtures pass, and there are no concrete unsupported Atlas OSS schema/config constructs listed in the current conformance reports. Complete schema/config parity is not claimed until the remaining Atlas OSS surface is audited; newly discovered unsupported constructs should become focused implementation issues. | [`stokaro/ptah#511`](https://github.com/stokaro/ptah/issues/511) |
+| Live and differential corpus breadth | Conformance coverage | The live and Atlas CE differential reports are green for the current smoke corpus only. More fixtures are needed before using those checks as broad Atlas OSS parity evidence. | [`stokaro/ptah-atlas-conformance#167`](https://github.com/stokaro/ptah-atlas-conformance/issues/167) |
+| Atlas OSS vs Atlas Commercial scope | Documentation | Cloud, registry, Pro, and commercial-only Atlas commands are not OSS drop-in targets, but the public comparison needs a clearer split. | [`stokaro/ptah#497`](https://github.com/stokaro/ptah/issues/497) |
+
+A green docs build only proves the documentation site builds and internal links
+resolve. It is not parity evidence. Use the conformance reports for measured
+behavior and the gap register above for known product, coverage, and
+documentation gaps.
 
 ## Config precedence
 

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -25,7 +25,7 @@ fail clearly instead of being ignored.
 | Atlas-compatible command | Native Ptah command |
 | --- | --- |
 | `ptah atlas migrate apply` | `ptah migrations up` |
-| `ptah atlas migrate down` | Registered path; use native `ptah migrations down` for explicit target rollback recipes until the Atlas-compatible flags are documented. |
+| `ptah atlas migrate down` | Ptah extension path; use native `ptah migrations down` for explicit target rollback recipes until the Atlas-compatible path documents the same runtime contract. |
 | `ptah atlas migrate status` | `ptah migrations status` |
 | `ptah atlas migrate hash` | `ptah migrations hash` |
 | `ptah atlas migrate validate` | `ptah migrations validate` |
@@ -72,5 +72,7 @@ When converting scripts, keep the `atlas` namespace in the Ptah command:
 ## Parity expectations
 
 Ptah is not documented as a full Atlas OSS replacement until the external
-conformance gates prove that claim. Use [Conformance](../../operate/conformance/)
-for current evidence and known gaps.
+conformance reports and the comparison gap register support that claim. Use
+[Conformance](../../operate/conformance/) for current evidence and
+[Comparison](../../reference/comparison/) for tracked product, coverage, and
+documentation gaps.


### PR DESCRIPTION
## Summary

- replace vague comparison-page gap wording with concrete product, conformance-coverage, and documentation gap rows
- link current evidence directly to `gaps.md`, `gaps-live.md`, and `gaps-diff.md`
- align adjacent Atlas CLI docs around `ptah atlas migrate down` as a Ptah extension path, not a current Atlas OSS target
- create and link follow-up trackers:
  - `stokaro/ptah#510`
  - `stokaro/ptah#511`
  - `stokaro/ptah-atlas-conformance#167`

## Validation

- `npm run check:links:selftest`
- `npm run check:links`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `git diff --check`
- self-review pass 1: compared documentation claims with current `gaps.md`, `gaps-live.md`, and `gaps-diff.md`
- self-review pass 2: checked #495 acceptance criteria and fixed factual/vagueness findings

Closes #495
