### PR TITLE
docs: add Atlas product comparison

### DIFF
--- a/docs/site/src/content/docs/examples/atlas-migrations.md
+++ b/docs/site/src/content/docs/examples/atlas-migrations.md
@@ -61,10 +61,11 @@ ptah migrations down \
   --confirm
 ```
 
-The `ptah atlas migrate down` command path exists as a Ptah extension path, but
-current conformance does not track it as an Atlas OSS drop-in target. Use the
-native command for rollback recipes until the Atlas-compatible path documents
-the same runtime contract.
+The `ptah atlas migrate down` command path exists and forwards to native Ptah
+rollback behavior. It is an Atlas OSS command path, but Ptah's compatibility
+surface does not yet match every Atlas dynamic down-planning flag and behavior.
+Use the native command for explicit target rollback recipes until the
+Atlas-compatible path documents the same runtime contract.
 
 ## Troubleshooting
 

--- a/docs/site/src/content/docs/operate/license-boundary.md
+++ b/docs/site/src/content/docs/operate/license-boundary.md
@@ -33,4 +33,5 @@ When documenting Atlas compatibility:
 
 - Say `Atlas-compatible` for implemented command paths and behavior.
 - Link to conformance reports for current evidence.
-- Do not say `full parity`, `drop-in replacement`, or equivalent claims until the full conformance gates prove it.
+- Do not say `full parity`, `drop-in replacement`, or equivalent claims until
+  conformance reports and the documented gap register both support that claim.

--- a/docs/site/src/content/docs/reference/commands.md
+++ b/docs/site/src/content/docs/reference/commands.md
@@ -55,7 +55,7 @@ ptah atlas schema inspect --url "$DATABASE_URL"
 | `ptah atlas migrate lint` | Forwards to `ptah migrations lint`. |
 | `ptah atlas migrate new` | Forwards to `ptah migrations create`. |
 | `ptah atlas migrate set` | Forwards to `ptah migrations repair`. |
-| `ptah atlas migrate down` | Ptah extension path; use native rollback docs for explicit target recipes. |
+| `ptah atlas migrate down` | Forwards to `ptah migrations down`; full Atlas dynamic down-planning semantics are tracked as a gap. |
 | `ptah atlas migrate diff` | Registered path; runtime behavior is not implemented yet. |
 | `ptah atlas migrate import` | Registered path; runtime behavior is not implemented yet. |
 | `ptah atlas schema inspect` | Forwards to `ptah db read`. |

--- a/docs/site/src/content/docs/reference/comparison.md
+++ b/docs/site/src/content/docs/reference/comparison.md
@@ -3,16 +3,30 @@ title: Comparison
 description: Ptah native commands, Atlas-compatible commands, feature parity, config precedence, and safety behavior.
 ---
 
+## Product positioning
+
+Ptah is an independent MIT-licensed implementation. It does not use Atlas source
+code; see [License boundary](../../operate/license-boundary/) for the repository
+and test-asset boundary.
+
+Atlas has both open and commercial/cloud feature sets. The current Atlas
+[feature availability](https://atlasgo.io/features) page lists database
+inspection, schema diffing, versioned migrations, and declarative migrations as
+open CLI features. The same page lists the migration linting CLI feature as Pro
+while also listing a basic Open lint-rule set. Checkpoints, visualization,
+interactive migrations, testing, deployment rollout, database security as code,
+and declarative data management are listed as Pro features.
+
 ## Command parity
 
 | Task | Native Ptah | Atlas-compatible Ptah | Atlas OSS |
 | --- | --- | --- | --- |
 | Apply migrations | `ptah migrations up` | `ptah atlas migrate apply` | `atlas migrate apply` |
-| Roll back migrations | `ptah migrations down` | Ptah extension path; not tracked as an Atlas OSS drop-in target by current conformance. | Not in the current OSS target corpus |
+| Roll back migrations | `ptah migrations down` | `ptah atlas migrate down` | `atlas migrate down` |
 | Migration status | `ptah migrations status` | `ptah atlas migrate status` | `atlas migrate status` |
 | Hash migrations | `ptah migrations hash` | `ptah atlas migrate hash` | `atlas migrate hash` |
 | Validate migrations | `ptah migrations validate` | `ptah atlas migrate validate` | `atlas migrate validate` |
-| Lint migrations | `ptah migrations lint` | `ptah atlas migrate lint` | `atlas migrate lint` |
+| Lint migrations | `ptah migrations lint` | `ptah atlas migrate lint` | Current Atlas docs list the migration linting CLI feature as Pro and a basic lint-rule set as Open. |
 | Create an empty migration | `ptah migrations create` | `ptah atlas migrate new` | `atlas migrate new` |
 | Repair revision state | `ptah migrations repair` | `ptah atlas migrate set` | `atlas migrate set` |
 | Inspect schema | `ptah db read` | `ptah atlas schema inspect` | `atlas schema inspect` |
@@ -23,11 +37,26 @@ behavior exists, and some accepted Atlas flags still fail explicitly rather than
 being silently ignored. The gap register below links that work to concrete
 tracking issues.
 
+## Detailed product comparison
+
+| Area | Ptah | Atlas OSS | Atlas Commercial / Cloud | Evidence |
+| --- | --- | --- | --- | --- |
+| License and implementation | MIT-licensed independent implementation. Ptah compatibility code is written in this repository and does not import or vendor Atlas source. | Atlas is an independent upstream product. Ptah treats its public command names, flags, file formats, and observable behavior as compatibility inputs. | Same Atlas product family plus licensed Pro and Cloud capabilities. | [License boundary](../../operate/license-boundary/), [Atlas feature availability](https://atlasgo.io/features) |
+| Command compatibility | Native command tree plus Atlas-compatible paths under `ptah atlas <command> ...` only. Some paths and flags are still tracked gaps. | Open CLI feature surface includes inspection, schema diffing, versioned migrations, and declarative migrations. | Pro and Cloud add capabilities that are not OSS drop-in targets, such as checkpoints, rollout, testing, and registry-backed workflows. | [Atlas CLI reference](https://atlasgo.io/cli-reference), [Atlas feature availability](https://atlasgo.io/features), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Schema inspection | `ptah db read` and `ptah atlas schema inspect` inspect supported live databases into Ptah schema IR/output formats. Atlas flags such as `--format`, `--exclude`, and `--dev-url` are tracked gaps. | `atlas schema inspect` is documented as an open CLI feature for inspecting a database schema. | Commercial database drivers broaden the set of inspectable engines. | [Atlas CLI reference](https://atlasgo.io/cli-reference), [Capabilities](../capabilities/), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Schema diff and apply | `ptah schema compare` and `ptah atlas schema diff` cover Ptah's current schema diff path. `ptah atlas schema apply` is registered but still a runtime placeholder. | Atlas OSS documents schema diffing and declarative migrations as open CLI features. | Cloud/Pro workflows add registry-backed plans, approvals, and deployment tracking. | [Atlas feature availability](https://atlasgo.io/features), [pre-planning schema migrations](https://atlasgo.io/declarative/plan), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Versioned migrations | `ptah migrations up`, `down`, `status`, `hash`, `validate`, `create`, `repair`, and Atlas-compatible counterparts cover local migration workflows. `ptah atlas migrate down` currently forwards to Ptah's pre-planned down-file rollback path and does not yet match every Atlas dynamic down-planning flag and behavior. `ptah atlas migrate import` and `ptah atlas migrate diff` remain runtime placeholders. | Atlas OSS includes versioned migrations and documents `atlas migrate down` for reverting applied migrations. | Atlas Registry and deployment reporting add remote migration-directory storage, tagging, history, and environment promotion workflows. Pro adds approval workflows for protected down plans. | [Atlas feature availability](https://atlasgo.io/features), [Atlas down migrations](https://atlasgo.io/versioned/down), [Atlas Cloud deployment docs](https://atlasgo.io/cloud/deployment), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Migration linting | Ptah ships first-party migration linting and the `ptah atlas migrate lint` compatibility path, with some Atlas flags still incomplete. | Current Atlas docs mark the official migration linting CLI feature as Pro while the feature availability page also lists a basic Open lint-rule set. | Pro migration linting includes Atlas analyzers, policy workflows, enforced checks, and browser reports. | [Atlas feature availability](https://atlasgo.io/features), [Atlas migration linting docs](https://atlasgo.io/versioned/lint), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Cloud and registry features | Ptah has no Atlas Cloud dependency and no Atlas Registry implementation. | Not part of the open drop-in target surface unless a workflow is explicitly available without Cloud credentials. | Atlas Cloud provides registry, deployment reporting, cloud CLI commands, UI, Pro seats, pipelines, and schema monitoring. | [Atlas Registry](https://atlasgo.io/cloud/features/registry), [Atlas Cloud deployment docs](https://atlasgo.io/cloud/deployment), [Atlas pricing](https://atlasgo.io/cloud/pricing) |
+| Supported databases | Ptah has first-party support for PostgreSQL, SQLite, MySQL/MariaDB, SQL Server subsets, and capability-gated PostgreSQL-compatible or specialty targets. | Atlas docs list PostgreSQL, MySQL, MariaDB, SQLite, TiDB, and LibSQL as Open drivers. | Atlas Pro adds SQL Server, ClickHouse, Redshift, Oracle, Spanner, Snowflake, Databricks, CockroachDB, Azure HorizonDB, YugabyteDB, Aurora DSQL, Azure Fabric, and related drivers. | [Capabilities](../capabilities/), [Atlas feature availability](https://atlasgo.io/features) |
+| HCL and config | Ptah parses strict Atlas schema HCL and project config subsets. Unsupported constructs fail explicitly rather than being silently ignored. | Atlas OSS supports SQL, HCL schema, external schema, remote/template directories, and related data sources listed as Open. | Pro data sources include composite schema and blob directory features. | [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md), [Atlas project config](https://github.com/stokaro/ptah/blob/master/docs/atlas_project_config.md), [Atlas feature availability](https://atlasgo.io/features), [`stokaro/ptah#511`](https://github.com/stokaro/ptah/issues/511) |
+| Conformance status | Ptah uses the separate `ptah-atlas-conformance` repository as measured evidence against Atlas fixtures and behavior. Current reports are green for their measured corpus, not a blanket parity claim; their CLI-surface classification still needs follow-up for `atlas migrate down`, which Ptah now tracks as an OSS gap in `stokaro/ptah#510`. | Atlas fixtures and CLI behavior provide the comparison target for OSS-compatible behavior. | Commercial/cloud-only behavior is separated from the OSS drop-in target and tracked as documentation scope. | [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md), [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md), [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510), [`stokaro/ptah-atlas-conformance#167`](https://github.com/stokaro/ptah-atlas-conformance/issues/167) |
+
 ## Feature parity evidence
 
 | Area | Ptah status | Evidence |
 | --- | --- | --- |
-| Offline Atlas fixture ingestion | Current imported Atlas fixture corpus is green: 160 fixtures, 636 observations, 0 non-OK in the linked report. | [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md) |
+| Offline Atlas fixture ingestion | Current imported Atlas fixture corpus is green: 160 fixtures, 636 observations, 0 non-OK in the linked report. The CLI-surface rows in that report still need follow-up for the `atlas migrate down` classification; the product gap is tracked in `stokaro/ptah#510`. | [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md), [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
 | Live database round trips | Current live smoke corpus is green: 10 observations, 0 non-OK in the linked report. This is evidence for the covered scenarios, not proof of every Atlas OSS runtime path. | [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md) |
 | Atlas CE differential checks | Current Atlas CE differential corpus is green: 5 observations, 0 non-OK in the linked report. This is evidence for the covered scenarios, not proof of every Atlas OSS schema object. | [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md) |
 | Atlas HCL schema files | Strict supported subset. Unsupported constructs fail explicitly instead of being ignored. | [Atlas HCL schema](https://github.com/stokaro/ptah/blob/master/docs/atlas_hcl_schema.md) |
@@ -39,10 +68,10 @@ tracking issues.
 | Gap | Type | Current boundary | Tracking |
 | --- | --- | --- | --- |
 | Atlas-compatible command runtime placeholders | Product behavior | These registered paths currently report that runtime behavior is not implemented yet: `ptah atlas schema apply`, `ptah atlas schema fmt`, `ptah atlas migrate diff`, `ptah atlas migrate import`, `ptah atlas version`, and `ptah atlas license`. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
-| Atlas-compatible flag semantics | Product behavior | Accepted flags whose behavior is still incomplete: `schema inspect --dev-url`, `schema inspect --exclude`, `schema inspect --format`, `schema diff --from`, `schema diff --to`, `schema diff --dev-url`, `schema diff --format`, `schema clean --auto-approve`, `migrate apply --tx-mode`, `migrate lint --dev-url`, `migrate lint --latest`, and `migrate validate --dev-url`. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Atlas-compatible down semantics | Product behavior | `ptah atlas migrate down` is an Atlas OSS command path, but current Ptah behavior is still mapped to native pre-planned down-file rollback rather than the full Atlas dynamic down-planning behavior and documented flag surface, including `--dev-url`, `--to-version`, `--to-tag`, `--skip-checks`, `--plan`, and additional CLI-reference flags such as `--format`, `--revisions-schema`, and lock options. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
+| Atlas-compatible flag semantics | Product behavior | Accepted flags whose behavior is still incomplete include `schema inspect --dev-url`, `schema inspect --exclude`, `schema inspect --format`, `schema diff --from`, `schema diff --to`, `schema diff --dev-url`, `schema diff --format`, `schema clean --auto-approve`, `migrate apply --tx-mode`, `migrate lint --dev-url`, `migrate lint --latest`, and `migrate validate --dev-url`. This is not the full Atlas flag gap: unregistered Atlas flags also need a full audit and either implementation or explicit out-of-scope classification. | [`stokaro/ptah#510`](https://github.com/stokaro/ptah/issues/510) |
 | Atlas HCL schema and project config subset audit | Product behavior and coverage | Current imported fixtures pass, and there are no concrete unsupported Atlas OSS schema/config constructs listed in the current conformance reports. Complete schema/config parity is not claimed until the remaining Atlas OSS surface is audited; newly discovered unsupported constructs should become focused implementation issues. | [`stokaro/ptah#511`](https://github.com/stokaro/ptah/issues/511) |
 | Live and differential corpus breadth | Conformance coverage | The live and Atlas CE differential reports are green for the current smoke corpus only. More fixtures are needed before using those checks as broad Atlas OSS parity evidence. | [`stokaro/ptah-atlas-conformance#167`](https://github.com/stokaro/ptah-atlas-conformance/issues/167) |
-| Atlas OSS vs Atlas Commercial scope | Documentation | Cloud, registry, Pro, and commercial-only Atlas commands are not OSS drop-in targets, but the public comparison needs a clearer split. | [`stokaro/ptah#497`](https://github.com/stokaro/ptah/issues/497) |
 
 A green docs build only proves the documentation site builds and internal links
 resolve. It is not parity evidence. Use the conformance reports for measured

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -25,7 +25,7 @@ fail clearly instead of being ignored.
 | Atlas-compatible command | Native Ptah command |
 | --- | --- |
 | `ptah atlas migrate apply` | `ptah migrations up` |
-| `ptah atlas migrate down` | Ptah extension path; use native `ptah migrations down` for explicit target rollback recipes until the Atlas-compatible path documents the same runtime contract. |
+| `ptah atlas migrate down` | Forwards to `ptah migrations down`; full Atlas dynamic down-planning semantics are tracked as a gap. |
 | `ptah atlas migrate status` | `ptah migrations status` |
 | `ptah atlas migrate hash` | `ptah migrations hash` |
 | `ptah atlas migrate validate` | `ptah migrations validate` |


### PR DESCRIPTION
## Summary

- Adds a detailed Ptah vs Atlas OSS vs Atlas Commercial / Cloud comparison to the docs site.
- Clarifies Ptah's independent MIT implementation and license boundary.
- Separates Atlas OSS capabilities from Pro/Cloud capabilities using official Atlas documentation links.
- Keeps known Ptah gaps explicit, including runtime placeholders, incomplete Atlas flags, and `ptah atlas migrate down` not yet matching Atlas dynamic down-planning semantics.
- Updates related Atlas-compatible docs so `ptah atlas migrate down` is no longer described as a Ptah-only extension path.

## Self-review

- Factual review against Atlas docs corrected the `migrate down` classification: `atlas migrate down` is an Atlas OSS command path.
- Factual review corrected migration linting wording: Atlas docs mark the official linting CLI feature as Pro while also listing a basic Open lint-rule set.
- Factual review found current conformance `gaps.md` still classifies `atlas migrate down` as out-of-scope; the comparison page now calls that out instead of using the report as blanket parity evidence, and #510 tracks the product gap.
- Acceptance review checked issue #497 requirements: licensing, implementation independence, command compatibility, schema inspect/diff, migrations, linting, cloud/commercial features, DB support, HCL/config support, conformance status, source links, and explicit follow-up issues.

## Validation

- `npm run check:links:selftest`
- `npm run check:links`
- `ASTRO_TELEMETRY_DISABLED=1 npm run build`
- `git diff --check`

Closes #497.
