### PR TITLE
Fix forwarded slice flag resets

### DIFF
--- a/cmd/internal/cmdadapter/cmdadapter.go
+++ b/cmd/internal/cmdadapter/cmdadapter.go
@@ -3,6 +3,7 @@
 package cmdadapter
 
 import (
+	"encoding/csv"
 	"fmt"
 	"strings"
 
@@ -13,6 +14,8 @@ import (
 )
 
 const envPrefix = "PTAH"
+
+const defaultSliceAnnotation = "ptah.cmdadapter.default-slice"
 
 // ArgMapper rewrites command arguments before they are forwarded to the target
 // command implementation.
@@ -109,6 +112,7 @@ func newForwardCommandWithArgsMapper(
 			forwardArgs := make([]string, 0, len(prefixArgs)+len(args))
 			forwardArgs = append(forwardArgs, prefixArgs...)
 			forwardArgs = append(forwardArgs, args...)
+			prepareExplicitSliceFlagsForParse(target, forwardArgs)
 			if help == targetHelp && hasHelpArg(forwardArgs) {
 				helpCommand, _, err := target.Find(argsWithoutHelp(forwardArgs))
 				if err != nil {
@@ -227,16 +231,182 @@ func useSuffix(use string) string {
 
 func resetCommandFlags(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		_ = flag.Value.Set(flag.DefValue)
-		flag.Changed = false
+		resetCommandFlag(flag)
 	})
 	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-		_ = flag.Value.Set(flag.DefValue)
-		flag.Changed = false
+		resetCommandFlag(flag)
 	})
 	for _, child := range cmd.Commands() {
 		resetCommandFlags(child)
 	}
+}
+
+func resetCommandFlag(flag *pflag.Flag) {
+	if slice, ok := resettableSliceValue(flag); ok {
+		_ = slice.Replace(defaultSliceValue(flag, slice))
+		if resettable, ok := slice.(*resettableSliceFlagValue); ok {
+			resettable.replaceNextSet = true
+		}
+		flag.Changed = false
+		return
+	}
+	_ = flag.Value.Set(flag.DefValue)
+	flag.Changed = false
+}
+
+func resettableSliceValue(flag *pflag.Flag) (pflag.SliceValue, bool) {
+	value, ok := flag.Value.(sliceFlagValue)
+	if !ok {
+		return nil, false
+	}
+	if resettable, ok := flag.Value.(*resettableSliceFlagValue); ok {
+		return resettable, true
+	}
+	resettable := &resettableSliceFlagValue{flag: flag, value: value}
+	flag.Value = resettable
+	return resettable, true
+}
+
+func defaultSliceValue(flag *pflag.Flag, value pflag.SliceValue) []string {
+	if values, ok := flag.Annotations[defaultSliceAnnotation]; ok {
+		return append([]string(nil), values...)
+	}
+	values, err := parseSliceDefault(flag.DefValue)
+	if err != nil {
+		values = value.GetSlice()
+	}
+	if flag.Annotations == nil {
+		flag.Annotations = map[string][]string{}
+	}
+	flag.Annotations[defaultSliceAnnotation] = append([]string(nil), values...)
+	return values
+}
+
+func parseSliceDefault(value string) ([]string, error) {
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("invalid slice default %q", value)
+	}
+	value = strings.TrimSuffix(strings.TrimPrefix(value, "["), "]")
+	if value == "" {
+		return []string{}, nil
+	}
+	return csv.NewReader(strings.NewReader(value)).Read()
+}
+
+func prepareExplicitSliceFlagsForParse(cmd *cobra.Command, args []string) {
+	flagsByName, flagsByShorthand := commandFlagMaps(cmd)
+	for name := range explicitFlagNames(args) {
+		flag := flagsByName[name]
+		if flag == nil {
+			flag = flagsByShorthand[name]
+		}
+		if flag == nil {
+			continue
+		}
+		resettable, ok := flag.Value.(*resettableSliceFlagValue)
+		if ok {
+			resettable.replaceNextSet = true
+		}
+	}
+}
+
+func commandFlagMaps(cmd *cobra.Command) (byName map[string]*pflag.Flag, byShorthand map[string]*pflag.Flag) {
+	byName = map[string]*pflag.Flag{}
+	byShorthand = map[string]*pflag.Flag{}
+	visitCommandFlags(cmd, byName, byShorthand)
+	return byName, byShorthand
+}
+
+func visitCommandFlags(cmd *cobra.Command, byName, byShorthand map[string]*pflag.Flag) {
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		byName[flag.Name] = flag
+		if flag.Shorthand != "" {
+			byShorthand[flag.Shorthand] = flag
+		}
+	})
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		byName[flag.Name] = flag
+		if flag.Shorthand != "" {
+			byShorthand[flag.Shorthand] = flag
+		}
+	})
+	for _, child := range cmd.Commands() {
+		visitCommandFlags(child, byName, byShorthand)
+	}
+}
+
+func explicitFlagNames(args []string) map[string]struct{} {
+	names := map[string]struct{}{}
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if name, ok := strings.CutPrefix(arg, "--"); ok {
+			if name == "" || strings.HasPrefix(name, "-") {
+				continue
+			}
+			name, _, _ = strings.Cut(name, "=")
+			names[name] = struct{}{}
+			continue
+		}
+		if strings.HasPrefix(arg, "-") && arg != "-" {
+			name := strings.TrimPrefix(arg, "-")
+			name, _, _ = strings.Cut(name, "=")
+			for _, shorthand := range name {
+				names[string(shorthand)] = struct{}{}
+			}
+		}
+	}
+	return names
+}
+
+type resettableSliceFlagValue struct {
+	flag           *pflag.Flag
+	value          sliceFlagValue
+	replaceNextSet bool
+}
+
+type sliceFlagValue interface {
+	pflag.Value
+	pflag.SliceValue
+}
+
+// pflag slice values keep an internal append-mode bit that is separate from
+// Flag.Changed, so reset must make the next user-provided value replace defaults.
+func (v *resettableSliceFlagValue) Set(value string) error {
+	if v.flag.Changed && !v.replaceNextSet {
+		return v.value.Set(value)
+	}
+	v.replaceNextSet = false
+	previous := v.value.GetSlice()
+	if err := v.value.Replace(nil); err != nil {
+		return err
+	}
+	if err := v.value.Set(value); err != nil {
+		_ = v.value.Replace(previous)
+		return err
+	}
+	return nil
+}
+
+func (v *resettableSliceFlagValue) Type() string {
+	return v.value.Type()
+}
+
+func (v *resettableSliceFlagValue) String() string {
+	return v.value.String()
+}
+
+func (v *resettableSliceFlagValue) Append(value string) error {
+	return v.value.Append(value)
+}
+
+func (v *resettableSliceFlagValue) Replace(values []string) error {
+	return v.value.Replace(values)
+}
+
+func (v *resettableSliceFlagValue) GetSlice() []string {
+	return v.value.GetSlice()
 }
 
 func resetCommandIO(cmd *cobra.Command) {

--- a/cmd/internal/cmdadapter/cmdadapter_test.go
+++ b/cmd/internal/cmdadapter/cmdadapter_test.go
@@ -100,6 +100,159 @@ func TestForwardCommandResetsTargetFlagsAndIO(t *testing.T) {
 	c.Assert(values, qt.DeepEquals, []string{"changed", "default"})
 }
 
+func TestForwardCommandResetsStringArrayEmptyDefault(t *testing.T) {
+	c := qt.New(t)
+
+	target := newStringArrayTargetCommand(nil, nil)
+	cmd := NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	var adapterOut bytes.Buffer
+	cmd.SetOut(&adapterOut)
+	cmd.SetErr(&adapterOut)
+	cmd.SetArgs([]string{"--value", "DS101", "--value", "MY"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	values, err := target.Flags().GetStringArray("value")
+	c.Assert(err, qt.IsNil)
+	c.Assert(values, qt.HasLen, 0)
+	c.Assert(target.Flags().Lookup("value").Value.String(), qt.Equals, "[]")
+	c.Assert(target.Flags().Lookup("value").Changed, qt.IsFalse)
+}
+
+func TestForwardCommandRepeatedStringArrayRunsReplaceDefault(t *testing.T) {
+	c := qt.New(t)
+
+	var runs [][]string
+	target := newStringArrayTargetCommand([]string{"prod", "production"}, func(values []string) {
+		runs = append(runs, values)
+	})
+	cmd := NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	var adapterOut bytes.Buffer
+	cmd.SetOut(&adapterOut)
+	cmd.SetErr(&adapterOut)
+	cmd.SetArgs([]string{"--value", "staging"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	cmd.SetArgs([]string{"--value", "qa", "--value", "dev"})
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(runs, qt.DeepEquals, [][]string{{"staging"}, {"qa", "dev"}})
+	values, err := target.Flags().GetStringArray("value")
+	c.Assert(err, qt.IsNil)
+	c.Assert(values, qt.DeepEquals, []string{"prod", "production"})
+	c.Assert(target.Flags().Lookup("value").Changed, qt.IsFalse)
+}
+
+func TestResetCommandFlagsStringArrayUsesDeclaredDefault(t *testing.T) {
+	c := qt.New(t)
+
+	target := newStringArrayTargetCommand([]string{"prod", "production"}, nil)
+	c.Assert(target.Flags().Set("value", "staging"), qt.IsNil)
+	values, err := target.Flags().GetStringArray("value")
+	c.Assert(err, qt.IsNil)
+	c.Assert(values, qt.DeepEquals, []string{"staging"})
+
+	resetCommandFlags(target)
+
+	values, err = target.Flags().GetStringArray("value")
+	c.Assert(err, qt.IsNil)
+	c.Assert(values, qt.DeepEquals, []string{"prod", "production"})
+	c.Assert(target.Flags().Lookup("value").Changed, qt.IsFalse)
+}
+
+func TestForwardCommandRepeatedStringSliceRunsReplaceDefault(t *testing.T) {
+	c := qt.New(t)
+
+	var runs [][]string
+	target := newStringSliceTargetCommand([]string{"prod"}, func(values []string) {
+		runs = append(runs, values)
+	})
+	cmd := NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	var adapterOut bytes.Buffer
+	cmd.SetOut(&adapterOut)
+	cmd.SetErr(&adapterOut)
+	cmd.SetArgs([]string{"--value", "staging"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	cmd.SetArgs([]string{"--value", "qa,dev"})
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(runs, qt.DeepEquals, [][]string{{"staging"}, {"qa", "dev"}})
+	values, err := target.Flags().GetStringSlice("value")
+	c.Assert(err, qt.IsNil)
+	c.Assert(values, qt.DeepEquals, []string{"prod"})
+	c.Assert(target.Flags().Lookup("value").Changed, qt.IsFalse)
+}
+
+func TestForwardCommandStringArrayCLIOverridesEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_VALUE", "prod")
+
+	var runs [][]string
+	target := newStringArrayTargetCommand(nil, func(values []string) {
+		runs = append(runs, values)
+	})
+	cmd := NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	var adapterOut bytes.Buffer
+	cmd.SetOut(&adapterOut)
+	cmd.SetErr(&adapterOut)
+	cmd.SetArgs([]string{"--value", "qa", "--value", "dev"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(runs, qt.DeepEquals, [][]string{{"qa", "dev"}})
+}
+
+func TestForwardCommandStringSliceCLIOverridesEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_VALUE", "prod,production")
+
+	var runs [][]string
+	target := newStringSliceTargetCommand(nil, func(values []string) {
+		runs = append(runs, values)
+	})
+	cmd := NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	var adapterOut bytes.Buffer
+	cmd.SetOut(&adapterOut)
+	cmd.SetErr(&adapterOut)
+	cmd.SetArgs([]string{"--value", "qa,dev"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(runs, qt.DeepEquals, [][]string{{"qa", "dev"}})
+}
+
+func TestExplicitFlagNamesIncludesShorthandClusters(t *testing.T) {
+	c := qt.New(t)
+
+	names := explicitFlagNames([]string{"-ab", "--value=qa", "--", "--ignored"})
+
+	c.Assert(names, qt.DeepEquals, map[string]struct{}{
+		"a":     {},
+		"b":     {},
+		"value": {},
+	})
+}
+
 func newTestTargetCommand(onRun func(string)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "target",
@@ -117,5 +270,43 @@ func newTestTargetCommand(onRun func(string)) *cobra.Command {
 		},
 	}
 	cmd.Flags().String("value", "default", "Value to print")
+	return cmd
+}
+
+func newStringArrayTargetCommand(defaults []string, onRun func([]string)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "target",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			values, err := cmd.Flags().GetStringArray("value")
+			if err != nil {
+				return err
+			}
+			if onRun != nil {
+				onRun(append([]string(nil), values...))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringArray("value", defaults, "Values to collect")
+	return cmd
+}
+
+func newStringSliceTargetCommand(defaults []string, onRun func([]string)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "target",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			values, err := cmd.Flags().GetStringSlice("value")
+			if err != nil {
+				return err
+			}
+			if onRun != nil {
+				onRun(append([]string(nil), values...))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringSlice("value", defaults, "Values to collect")
 	return cmd
 }


### PR DESCRIPTION
## Summary

- reset forwarded pflag collection flags through `SliceValue.Replace` instead of `Value.Set(DefValue)`
- wrap slice flag values so the first explicit CLI value after reset replaces defaults/env values, while repeated occurrences still append normally
- preserve declared defaults for repeated adapter executions and avoid leaking textual defaults such as `[]` into real values

## Self-review

- Pass 1: caught that `StringArray` has pflag-internal append state separate from `Flag.Changed`; added reset-aware behavior and regression tests for empty and non-empty defaults.
- Pass 2: sidecar review found the same class of bug for non-`StringArray` slice flags; fixed by wrapping all pflag `SliceValue` implementations and covering `StringSlice`.
- Pass 3: sidecar review found env-backed slice values could append CLI values instead of being overridden; fixed CLI-explicit slice preparation and added env precedence tests.
- Final hardening: covered shorthand cluster discovery for future slice shorthands.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./cmd/internal/cmdadapter ./cmd/atlas ./cmd/ptah-compat`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -race -count=1 ./cmd/internal/cmdadapter`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./cmd/...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `git diff --check`

Refs #521
