### PR TITLE
Inline docs site exit code reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,6 +70,7 @@ jobs:
           npm ci
           npm run check:links:selftest
           npm run check:links
+          npm run check:exit-codes
           npm run build
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"
           cp -r dist/. "$GITHUB_WORKSPACE/_site/edge/"
@@ -88,6 +89,7 @@ jobs:
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm ci
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:links:selftest
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:links
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build
           )
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"
@@ -111,6 +113,9 @@ jobs:
                   DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run check:links
                 else
                   echo "::warning::$tag has no docs link checker; skipping link validation"
+                fi
+                if [ -f scripts/check-exit-codes.mjs ]; then
+                  DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
                 fi
                 DOCS_VERSION="$tag" ASTRO_TELEMETRY_DISABLED=1 npm run build
               ); then

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -10,6 +10,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "check:exit-codes": "node scripts/check-exit-codes.mjs",
     "check:links": "node scripts/check-links.mjs",
     "check:links:selftest": "node scripts/check-links.mjs --selftest",
     "versions:selftest": "node scripts/gen-versions.mjs --selftest"

--- a/docs/site/scripts/check-exit-codes.mjs
+++ b/docs/site/scripts/check-exit-codes.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(scriptDir, '..');
+const repoRoot = join(siteRoot, '..', '..');
+const sourcePath = join(repoRoot, 'docs', 'exit_codes.md');
+const sitePath = join(siteRoot, 'src', 'content', 'docs', 'reference', 'exit-codes.md');
+
+function tableRows(source) {
+  return source
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('| `'));
+}
+
+function main() {
+  const sourceRows = tableRows(readFileSync(sourcePath, 'utf8'));
+  const site = readFileSync(sitePath, 'utf8');
+  const missing = sourceRows.filter((row) => !site.includes(row));
+
+  if (missing.length > 0) {
+    console.error(`${sitePath} is missing ${missing.length} exit-code reference row(s):`);
+    for (const row of missing) {
+      console.error(`- ${row}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`check-exit-codes.mjs: OK (${sourceRows.length} reference rows)`);
+}
+
+main();

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -7,12 +7,10 @@ Ptah uses exit codes as a public scripting contract:
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Success. |
-| `1` | Expected negative result from a check, such as drift, lint findings, pending migrations with `--exit-code`, or migration hash drift. |
-| `2` | Command or usage error, including bad flags, invalid input, parse failures, connection failures, unsupported dialects, and recovered internal panics. |
-| `3+` | Reserved until documented for a specific use. |
-
-Use the detailed matrix in [CLI exit codes](https://github.com/stokaro/ptah/blob/master/docs/exit_codes.md) when wiring Ptah into CI.
+| `0` | Success. The command completed and did not find a configured failing condition. |
+| `1` | Expected negative result. A check found drift, lint findings, integrity drift, pending migrations, or a non-empty diff when that behavior is enabled. |
+| `2` | Command or usage error. Examples: bad flags, unknown commands, invalid input, connection failure, parse failure, unsupported dialect, unwritable output, or an internal panic recovered by the root command. |
+| `3+` | Reserved. Do not rely on these codes until Ptah documents a specific use. |
 
 Common gates:
 
@@ -25,3 +23,69 @@ ptah migrations lint --dir ./migrations --dialect postgres
 Do not collapse all non-zero outcomes into the same remediation. A `1` usually
 means the command successfully found a condition you asked it to check; a `2`
 means the command itself did not complete correctly.
+
+## Native Commands
+
+The grouped command tree is the native Ptah surface. Ptah is pre-GA, so old
+root-level command spellings are removed instead of preserved.
+
+| Command | `0` | `1` | `2` |
+| --- | --- | --- | --- |
+| `ptah introspect` | Annotated Go model files generated. | Not used. | Usage error, invalid output path, connection failure, schema-read failure, render error, or write error. |
+| `ptah schema render` | Schema rendered. | Not used. | Usage error, parse error, unsupported dialect, or render error. |
+| `ptah schema export` | Schema exported. | Not used. | Usage error, invalid paths, parse error, render error, write error, or cleanup error. |
+| `ptah viz` | Schema diagram rendered. | Not used. | Usage error, invalid paths, parse error, unsupported format/theme, missing Graphviz for SVG, SVG render error, or write error. |
+| `ptah db read` | Schema read and printed. | Not used. | Usage error, connection failure, or schema-read failure. |
+| `ptah db drop-all` | Objects dropped, dry-run output printed, or operation canceled by the user. | Not used. | Usage error, connection failure, input read error, or drop failure. |
+| `ptah schema compare` | Diff printed, or no diff. | Non-empty diff when `--exit-code` is set. | Usage error, connection failure, parse failure, or diff generation failure. |
+| `ptah schema drift` | No drift that meets `--severity`, or `--exit-code=false`. | Drift meets `--severity` while `--exit-code=true`. | Usage error, connection failure, parse failure, or report error. |
+| `ptah migrations lint` | No findings above `--fail-on`, or `--fail-on=none`. | Findings meet `--fail-on`. | Usage error, invalid config, unreadable migration directory, or report error. |
+| `ptah sql lint` | No SQL lint findings with `error` severity. | One or more SQL lint findings with `error` severity. | Usage error, unreadable SQL input, unsupported dialect, or report error. |
+| `ptah migrations plan` | Migration SQL generated, or no schema changes. | Not used. | Usage error, connection failure, parse failure, safety check failure, or render error. |
+| `ptah migrations generate` | Migration file generated, or no migration needed. | Not used. | Usage error, connection failure, parse failure, shadow verification failure, safety check failure, or write error. |
+| `ptah migrations create` | Empty migration files created. | Not used. | Usage error, invalid directory, or write error. |
+| `ptah migrations baseline` | Existing migrations recorded as applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, verification failure, or write error. |
+| `ptah migrations up` | Pending migrations applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, integrity verification failure, lint/safety gate failure, pre-flight hook failure, lock failure, or migration execution failure. |
+| `ptah migrations down` | Requested rollback applied, or dry-run output printed. | Not used. | Usage error, connection failure, migration directory error, pre-flight hook failure, lock failure, or rollback failure. |
+| `ptah migrations repair` | Migration revision repaired, or dry-run output printed. | Not used. | Usage error, connection failure, revision lookup failure, or repair failure. |
+| `ptah migrations status` | Status printed, including pending migrations by default. | Pending migrations exist when `--exit-code` is set. | Usage error, connection failure, migration directory error, or status-read failure. |
+| `ptah migrations hash` | Integrity file written. | Not used. | Usage error, invalid directory, invalid migration format, or write error. |
+| `ptah migrations validate` | Integrity file matches the migration directory. | Migration content drift found. | Usage error, missing or unreadable integrity file, invalid directory, or invalid migration format. |
+| `ptah seed` | Seed files applied or already applied. | Not used. | Usage error, protected environment rejection, connection failure, invalid seed files, or seed execution failure. |
+| `ptah version` | Version information printed. | Not used. | Usage error. |
+
+## Atlas-Compatible Command Surfaces
+
+Commands under `ptah atlas <command> ...`, `ptah-compat <command> ...`, and a
+copied or symlinked executable named `atlas` either translate implemented
+Atlas-compatible flags and delegate to the matching native command, or execute
+a Ptah-owned utility behavior such as the license notice or schema formatting.
+
+| Atlas-compatible command | Native command |
+| --- | --- |
+| `ptah atlas version` | `ptah version` |
+| `ptah-compat version` / `atlas version` | `ptah version` |
+| `ptah atlas license` | Ptah license notice |
+| `ptah-compat license` / `atlas license` | Ptah license notice |
+| `ptah atlas migrate apply` | `ptah migrations up` |
+| `ptah-compat migrate apply` / `atlas migrate apply` | `ptah migrations up` |
+| `ptah atlas migrate down` | `ptah migrations down` |
+| `ptah-compat migrate down` / `atlas migrate down` | `ptah migrations down` |
+| `ptah atlas migrate import` | Import local migrations into a separate directory and write `atlas.sum` |
+| `ptah-compat migrate import` / `atlas migrate import` | Import local migrations into a separate directory and write `atlas.sum` |
+| `ptah atlas migrate status` | `ptah migrations status` |
+| `ptah-compat migrate status` / `atlas migrate status` | `ptah migrations status` |
+| `ptah atlas migrate hash` | `ptah migrations hash` |
+| `ptah atlas migrate validate` | `ptah migrations validate` |
+| `ptah atlas migrate lint` | `ptah migrations lint` |
+| `ptah atlas schema inspect` | `ptah db read` |
+| `ptah-compat schema inspect` / `atlas schema inspect` | `ptah db read` |
+| `ptah atlas schema diff` | `ptah schema compare` |
+| `ptah atlas schema fmt` | Format local `.hcl` files |
+| `ptah-compat schema fmt` / `atlas schema fmt` | Format local `.hcl` files |
+
+Unsupported Atlas-compatible flags are rejected explicitly and exit `2`.
+
+The repository copy of this contract is maintained in
+[CLI exit codes](https://github.com/stokaro/ptah/blob/master/docs/exit_codes.md),
+but this page is complete enough to use without opening GitHub.


### PR DESCRIPTION
## Summary
- inline the full native and Atlas-compatible exit code reference on the docs site exit-codes page
- keep the GitHub source link supplemental instead of required for understanding the contract
- add a docs-site check that verifies the published page contains every row from docs/exit_codes.md
- run the new check from the docs workflow without breaking historical tags that predate it

Closes #494

## Self-review
- Pass 1: content completeness. Verified the docs-site page now includes the general exit-code contract, every native command row, and every Atlas-compatible command mapping from docs/exit_codes.md.
- Pass 2: regression and CI coverage. Added npm run check:exit-codes and wired it into docs.yml so a link-only regression fails CI; historical tag builds only run it when the script exists.

## Tests
- npm run check:exit-codes
- npm run check:links:selftest
- npm run check:links
- ASTRO_TELEMETRY_DISABLED=1 npm run build