### PR TITLE
Move Atlas format rendering out of cmd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,225 @@ golangci-lint run ./...
 ```
 
 The fix pass can leave second-pass fallout such as unused imports, removed helper functions, or staticcheck suggestions. Clean those manually before considering the lint run complete.
+
+## Testing Standards
+
+### Declarative Tests Only
+
+All tests MUST be purely declarative. The following are prohibited in test
+functions:
+
+- `if` statements.
+- `switch` statements.
+- `goto` statements.
+
+`for` loops are allowed in test functions for table-driven tests that iterate
+over a static list of cases, and are not considered conditional logic for this
+guideline. Keep loop bodies simple and do not use loops to encode branching
+logic.
+
+Go 1.22 and newer makes range variables per-iteration, so the historical
+`test := test` workaround is not needed when using `c.Run()` closures in
+table-driven tests unless intentionally taking the address of a loop variable.
+
+### Do Not Hide Conditionals In Helpers
+
+Avoid helper functions that mask conditional logic, such as choosing between
+`qt.ErrorIs`, `qt.ErrorMatches`, and `qt.IsNil` based on fields in a test case.
+This makes tests harder to read and review.
+
+Instead, write explicit assertions per case, even when it is a bit repetitive.
+
+Bad:
+
+```go
+func checkError(c *qt.C, err error, wantIs error, wantLike string) {
+	if wantIs != nil {
+		c.Check(err, qt.ErrorIs, wantIs)
+		return
+	}
+	if wantLike != "" {
+		c.Check(err, qt.ErrorMatches, wantLike)
+		return
+	}
+	c.Check(err, qt.IsNil)
+}
+```
+
+Good:
+
+```go
+c.Run("unsupported dev url dialect", func(c *qt.C) {
+	got, err := atlasurl.DialectFromURL("spanner://localhost/dev")
+	c.Assert(err, qt.ErrorMatches, `unsupported --dev-url dialect "spanner://localhost/dev"`)
+	c.Assert(got, qt.Equals, "")
+})
+
+c.Run("postgres dev url", func(c *qt.C) {
+	got, err := atlasurl.DialectFromURL("postgres://localhost/dev")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.Equals, "postgres")
+})
+```
+
+### Separate Happy-Path And Failure-Path Tests
+
+Do not mix success and error cases in the same table. Prefer either:
+
+- `TestXxx_HappyPath` and `TestXxx_FailurePath`.
+- Separate `c.Run("happy ...")` and `c.Run("failure ...")` groups with distinct
+  tables.
+
+Bad:
+
+```go
+tests := []struct {
+	name    string
+	rawURL  string
+	want    string
+	wantErr string
+}{
+	{name: "postgres", rawURL: "postgres://localhost/dev", want: "postgres"},
+	{name: "unsupported", rawURL: "spanner://localhost/dev", wantErr: `unsupported --dev-url dialect "spanner://localhost/dev"`},
+}
+
+for _, test := range tests {
+	c.Run(test.name, func(c *qt.C) {
+		got, err := atlasurl.DialectFromURL(test.rawURL)
+		if test.wantErr != "" {
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			return
+		}
+		c.Assert(err, qt.IsNil)
+		c.Assert(got, qt.Equals, test.want)
+	})
+}
+```
+
+Good:
+
+Use table-driven tests with `c.Run()` for multiple test cases:
+
+```go
+func TestDialectFromURL_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{name: "postgres", rawURL: "postgres://localhost/dev", want: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, err := atlasurl.DialectFromURL(test.rawURL)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, test.want)
+		})
+	}
+}
+
+func TestDialectFromURL_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr string
+	}{
+		{
+			name:    "unsupported",
+			rawURL:  "spanner://localhost/dev",
+			wantErr: `unsupported --dev-url dialect "spanner://localhost/dev"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, err := atlasurl.DialectFromURL(test.rawURL)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(got, qt.Equals, "")
+		})
+	}
+}
+```
+
+Error checking patterns:
+
+```go
+// Success case.
+c.Assert(err, qt.IsNil)
+
+// Preferred for sentinel errors because it handles wrapped errors.
+c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidConfig)
+
+// Error type checks.
+var pathErr *os.PathError
+c.Assert(err, qt.ErrorAs, &pathErr)
+
+// Regex match when no sentinel is available.
+c.Assert(err, qt.ErrorMatches, "failed to load schema.*")
+
+// Substring check when matching part of the message is clearer.
+c.Assert(err, qt.IsNotNil)
+c.Assert(err.Error(), qt.Contains, "connection refused")
+```
+
+### Black-Box Testing By Default
+
+By default, all Go tests use black-box testing:
+
+- Test file: `*_test.go`.
+- Package name: `package atlasurl_test` with the `_test` suffix.
+- Test only exported API.
+
+```go
+package atlasurl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasurl"
+)
+
+func TestDialectFromURL_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	got, err := atlasurl.DialectFromURL("postgres://localhost/dev")
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.Equals, "postgres")
+}
+```
+
+### White-Box Testing As An Exception
+
+White-box testing, meaning same-package tests with access to unexported symbols,
+is permitted only when:
+
+1. Testing unexported functions critical for correctness.
+2. Testing internal state that cannot be observed through exported API.
+3. There is a clear technical justification.
+
+Requirements for white-box tests:
+
+- File naming: `*_internal_test.go`.
+- Package name: `package parser` without the `_test` suffix.
+- Include a comment immediately after the `package` line explaining the
+  justification.
+
+```go
+package parser
+
+// White-box testing required: this file verifies parser cursor invariants that
+// are not observable through the exported Parse API without making assertions
+// dependent on renderer output.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+```

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -84,7 +85,7 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		return fmt.Errorf("--format must not be empty")
 	}
 	if formatOutput {
-		if err := validateAtlasGoTemplate("atlas-migrate-apply-format", opts.format); err != nil {
+		if err := atlasreport.ValidateMigrateApplyTemplate(opts.format); err != nil {
 			return err
 		}
 	}
@@ -186,18 +187,18 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 	selected := selectedAtlasApplyVersions(pending, amount, toVersion)
 	if len(selected) == 0 && status.DirtyRevision == nil {
 		if formatOutput {
-			return writeAtlasMigrateApplyFormat(out, opts.format, atlasMigrateApplyResultOptions{
-				conn:             conn,
-				fsys:             os.DirFS(dir),
-				dir:              opts.dir,
-				url:              opts.url,
-				status:           status,
-				migrations:       mig.MigrationProvider().Migrations(),
-				selectedVersions: selected,
-				currentVersion:   plannedCurrentVersion,
-				applied:          false,
-				startedAt:        startedAt,
-				endedAt:          time.Now(),
+			return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
+				Conn:             conn,
+				FS:               os.DirFS(dir),
+				Dir:              opts.dir,
+				URL:              opts.url,
+				Status:           status,
+				Migrations:       mig.MigrationProvider().Migrations(),
+				SelectedVersions: selected,
+				CurrentVersion:   plannedCurrentVersion,
+				Applied:          false,
+				StartedAt:        startedAt,
+				EndedAt:          time.Now(),
 			})
 		}
 		fmt.Fprintln(out, "No migration files to execute.")
@@ -214,20 +215,20 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		AssumedAppliedVersions: assumedAppliedVersions,
 	}); err != nil {
 		if formatOutput {
-			writeErr := writeAtlasMigrateApplyFormat(out, opts.format, atlasMigrateApplyResultOptions{
-				conn:             conn,
-				fsys:             os.DirFS(dir),
-				dir:              opts.dir,
-				url:              opts.url,
-				status:           status,
-				migrations:       mig.MigrationProvider().Migrations(),
-				selectedVersions: selected,
-				currentVersion:   plannedCurrentVersion,
-				errorText:        err.Error(),
-				applyError:       err,
-				applied:          true,
-				startedAt:        startedAt,
-				endedAt:          time.Now(),
+			writeErr := atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
+				Conn:             conn,
+				FS:               os.DirFS(dir),
+				Dir:              opts.dir,
+				URL:              opts.url,
+				Status:           status,
+				Migrations:       mig.MigrationProvider().Migrations(),
+				SelectedVersions: selected,
+				CurrentVersion:   plannedCurrentVersion,
+				ErrorText:        err.Error(),
+				ApplyError:       err,
+				Applied:          true,
+				StartedAt:        startedAt,
+				EndedAt:          time.Now(),
 			})
 			if writeErr != nil {
 				return fmt.Errorf("error applying migrations: %w; additionally failed to write --format output: %v", err, writeErr)
@@ -238,18 +239,18 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 
 	if opts.dryRun {
 		if formatOutput {
-			return writeAtlasMigrateApplyFormat(out, opts.format, atlasMigrateApplyResultOptions{
-				conn:             conn,
-				fsys:             os.DirFS(dir),
-				dir:              opts.dir,
-				url:              opts.url,
-				status:           status,
-				migrations:       mig.MigrationProvider().Migrations(),
-				selectedVersions: selected,
-				currentVersion:   plannedCurrentVersion,
-				applied:          false,
-				startedAt:        startedAt,
-				endedAt:          time.Now(),
+			return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
+				Conn:             conn,
+				FS:               os.DirFS(dir),
+				Dir:              opts.dir,
+				URL:              opts.url,
+				Status:           status,
+				Migrations:       mig.MigrationProvider().Migrations(),
+				SelectedVersions: selected,
+				CurrentVersion:   plannedCurrentVersion,
+				Applied:          false,
+				StartedAt:        startedAt,
+				EndedAt:          time.Now(),
 			})
 		}
 		fmt.Fprintf(out, "Would have applied %d migrations.\n", len(selected))
@@ -260,18 +261,18 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		return fmt.Errorf("error getting final migration status: %w", err)
 	}
 	if formatOutput {
-		return writeAtlasMigrateApplyFormat(out, opts.format, atlasMigrateApplyResultOptions{
-			conn:             conn,
-			fsys:             os.DirFS(dir),
-			dir:              opts.dir,
-			url:              opts.url,
-			status:           status,
-			migrations:       mig.MigrationProvider().Migrations(),
-			selectedVersions: selected,
-			currentVersion:   plannedCurrentVersion,
-			applied:          true,
-			startedAt:        startedAt,
-			endedAt:          time.Now(),
+		return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
+			Conn:             conn,
+			FS:               os.DirFS(dir),
+			Dir:              opts.dir,
+			URL:              opts.url,
+			Status:           status,
+			Migrations:       mig.MigrationProvider().Migrations(),
+			SelectedVersions: selected,
+			CurrentVersion:   plannedCurrentVersion,
+			Applied:          true,
+			StartedAt:        startedAt,
+			EndedAt:          time.Now(),
 		})
 	}
 	fmt.Fprintf(out, "Migration complete. Current version: %d\n", finalStatus.CurrentVersion)

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 )
 
@@ -50,11 +51,11 @@ follow-up gaps.`,
 }
 
 func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) error {
-	format, err := normalizeAtlasSchemaInspectFormat(opts.format)
+	format, err := atlasreport.NormalizeSchemaInspectFormat(opts.format)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	if err := validateAtlasSchemaInspectTemplate(format); err != nil {
+	if err := atlasreport.ValidateSchemaInspectTemplate(format); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	if err := validateAtlasSchemaInspectOptions(opts); err != nil {
@@ -78,7 +79,7 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 		return cmdutil.Fail(cmd, fmt.Errorf("read database schema: %w", err))
 	}
 	dbsch := dbschematogo.ConvertDBSchemaToGoSchema(schema)
-	rendered, err := renderAtlasSchemaInspectFormat(format, newAtlasSchemaInspectReport(
+	rendered, err := atlasreport.RenderSchemaInspectFormat(format, atlasreport.NewSchemaInspectReport(
 		dbsch,
 		schema,
 		conn.Info(),
@@ -102,20 +103,6 @@ func validateAtlasSchemaInspectOptions(opts atlasSchemaInspectOptions) error {
 		return fmt.Errorf("atlas schema inspect accepts --include, but Ptah does not implement its behavior yet")
 	}
 	return nil
-}
-
-func normalizeAtlasSchemaInspectFormat(format string) (string, error) {
-	trimmed := strings.TrimSpace(format)
-	if trimmed == "" || trimmed == "hcl" {
-		return "{{ $.MarshalHCL }}", nil
-	}
-	if trimmed == "sql" {
-		return "{{ sql . }}", nil
-	}
-	if trimmed == "json" {
-		return "{{ json . }}", nil
-	}
-	return format, nil
 }
 
 func parseAtlasSchemaInspectSchemas(values []string) []string {

--- a/internal/atlasreport/migrate_apply.go
+++ b/internal/atlasreport/migrate_apply.go
@@ -1,4 +1,4 @@
-package atlas
+package atlasreport
 
 import (
 	"bytes"
@@ -22,20 +22,20 @@ import (
 
 var atlasMigrateApplyFailedVersionRe = regexp.MustCompile(`failed to apply migration ([0-9]+)`)
 
-type atlasMigrateApplyResultOptions struct {
-	conn             *dbschema.DatabaseConnection
-	fsys             fs.FS
-	dir              string
-	url              string
-	status           *migrator.MigrationStatus
-	migrations       []*migrator.Migration
-	selectedVersions []int64
-	currentVersion   int64
-	errorText        string
-	applyError       error
-	applied          bool
-	startedAt        time.Time
-	endedAt          time.Time
+type MigrateApplyResultOptions struct {
+	Conn             *dbschema.DatabaseConnection
+	FS               fs.FS
+	Dir              string
+	URL              string
+	Status           *migrator.MigrationStatus
+	Migrations       []*migrator.Migration
+	SelectedVersions []int64
+	CurrentVersion   int64
+	ErrorText        string
+	ApplyError       error
+	Applied          bool
+	StartedAt        time.Time
+	EndedAt          time.Time
 }
 
 type atlasMigrateApplyEnv struct {
@@ -90,7 +90,10 @@ type atlasMigrateApplyStatementError struct {
 	Text string `json:"Text,omitempty"`
 }
 
-func writeAtlasMigrateApplyFormat(w io.Writer, format string, opts atlasMigrateApplyResultOptions) error {
+func WriteMigrateApplyFormat(w io.Writer, format string, opts MigrateApplyResultOptions) error {
+	if err := validateMigrateApplyResultOptions(opts); err != nil {
+		return err
+	}
 	result, err := buildAtlasMigrateApplyResult(opts)
 	if err != nil {
 		return err
@@ -98,36 +101,49 @@ func writeAtlasMigrateApplyFormat(w io.Writer, format string, opts atlasMigrateA
 	return renderAtlasGoTemplate(w, "atlas-migrate-apply-format", format, result)
 }
 
-func buildAtlasMigrateApplyResult(opts atlasMigrateApplyResultOptions) (atlasMigrateApplyResult, error) {
-	filesByVersion, err := atlasMigrateApplyFilesByVersion(opts.fsys)
+func validateMigrateApplyResultOptions(opts MigrateApplyResultOptions) error {
+	if opts.Conn == nil {
+		return errors.New("migrate apply format requires database connection")
+	}
+	if opts.FS == nil {
+		return errors.New("migrate apply format requires migration filesystem")
+	}
+	if opts.Status == nil && opts.CurrentVersion <= 0 {
+		return errors.New("migrate apply format requires migration status or current version")
+	}
+	return nil
+}
+
+func buildAtlasMigrateApplyResult(opts MigrateApplyResultOptions) (atlasMigrateApplyResult, error) {
+	filesByVersion, err := atlasMigrateApplyFilesByVersion(opts.FS)
 	if err != nil {
 		return atlasMigrateApplyResult{}, err
 	}
-	migrationsByVersion := atlasMigrateApplyMigrationsByVersion(opts.migrations)
+	migrationsByVersion := atlasMigrateApplyMigrationsByVersion(opts.Migrations)
 	env := atlasMigrateApplyEnv{
-		Driver: opts.conn.Info().Dialect,
-		URL:    atlasMigrateApplyRedactedURL(opts.url),
-		Dir:    opts.dir,
+		Driver: opts.Conn.Info().Dialect,
+		URL:    atlasMigrateApplyRedactedURL(opts.URL),
+		Dir:    opts.Dir,
 	}
 	result := atlasMigrateApplyResult{
 		atlasMigrateApplyEnv: env,
 		Env:                  env,
-		Pending:              atlasMigrateApplyPendingFiles(filesByVersion, opts.selectedVersions),
+		Pending:              atlasMigrateApplyPendingFiles(filesByVersion, opts.SelectedVersions),
 		Current:              atlasMigrateApplyVersionString(atlasMigrateApplyCurrentVersion(opts)),
-		Target:               atlasMigrateApplyTargetVersion(atlasMigrateApplyCurrentVersion(opts), opts.selectedVersions),
-		Start:                opts.startedAt,
-		End:                  opts.endedAt,
-		Error:                opts.errorText,
+		Target:               atlasMigrateApplyTargetVersion(atlasMigrateApplyCurrentVersion(opts), opts.SelectedVersions),
+		Start:                opts.StartedAt,
+		End:                  opts.EndedAt,
+		Error:                opts.ErrorText,
 	}
-	if opts.applied {
+	if opts.Applied {
 		result.Applied = atlasMigrateApplyAppliedFiles(
 			filesByVersion,
 			migrationsByVersion,
-			opts.selectedVersions,
-			opts.conn.Info().Dialect,
-			opts.applyError,
-			opts.startedAt,
-			opts.endedAt,
+			opts.SelectedVersions,
+			opts.Conn.Info().Dialect,
+			opts.ApplyError,
+			opts.StartedAt,
+			opts.EndedAt,
 		)
 	}
 	return result, nil
@@ -270,11 +286,11 @@ func atlasMigrateApplySplitStatements(sql, dialect string) []string {
 	return filtered
 }
 
-func atlasMigrateApplyCurrentVersion(opts atlasMigrateApplyResultOptions) int64 {
-	if opts.currentVersion > 0 {
-		return opts.currentVersion
+func atlasMigrateApplyCurrentVersion(opts MigrateApplyResultOptions) int64 {
+	if opts.CurrentVersion > 0 {
+		return opts.CurrentVersion
 	}
-	return opts.status.CurrentVersion
+	return opts.Status.CurrentVersion
 }
 
 func atlasMigrateApplyTargetVersion(current int64, selectedVersions []int64) string {
@@ -334,6 +350,10 @@ func renderAtlasGoTemplate(w io.Writer, name, format string, data any) error {
 	}
 	_, err = w.Write(out.Bytes())
 	return err
+}
+
+func ValidateMigrateApplyTemplate(format string) error {
+	return validateAtlasGoTemplate("atlas-migrate-apply-format", format)
 }
 
 func validateAtlasGoTemplate(name, format string) error {

--- a/internal/atlasreport/migrate_apply_test.go
+++ b/internal/atlasreport/migrate_apply_test.go
@@ -1,0 +1,187 @@
+package atlasreport_test
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasreport"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestWriteMigrateApplyFormat_CustomTemplate(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "format.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	fsys := fstest.MapFS{
+		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);")},
+	}
+	var out bytes.Buffer
+	startedAt := time.Unix(100, 0).UTC()
+	endedAt := time.Unix(101, 0).UTC()
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ .Driver }}|{{ .Dir }}|{{ len .Pending }}|{{ len .Applied }}|{{ .Target }}|{{ printf "%.12s" (index (index .Applied 0).Applied 0) }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn: conn,
+			FS:   fsys,
+			Dir:  "file://migrations",
+			URL:  "sqlite://" + dbPath,
+			Status: &migrator.MigrationStatus{
+				CurrentVersion:    0,
+				PendingMigrations: []int64{1},
+			},
+			Migrations: []*migrator.Migration{
+				{
+					Version: 1,
+					UpSQL:   "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+				},
+			},
+			SelectedVersions: []int64{1},
+			Applied:          true,
+			StartedAt:        startedAt,
+			EndedAt:          endedAt,
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "sqlite|file://migrations|1|1|1|CREATE TABLE")
+}
+
+func TestWriteMigrateApplyFormat_JSONNoopMessage(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "noop.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	fsys := fstest.MapFS{
+		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);")},
+	}
+	var out bytes.Buffer
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn: conn,
+			FS:   fsys,
+			Dir:  "file://migrations",
+			URL:  "sqlite://" + dbPath,
+			Status: &migrator.MigrationStatus{
+				CurrentVersion: 1,
+			},
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, `"Message":"No migration files to execute"`)
+	c.Assert(out.String(), qt.Contains, `"Driver":"sqlite"`)
+}
+
+func TestWriteMigrateApplyFormat_RedactsSensitiveURL(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "redacted.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var out bytes.Buffer
+	query := url.Values{}
+	query.Set("sslmode", "disable")
+	query.Set("token", strings.Repeat("t", 6))
+	rawURL := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword("app", strings.Repeat("s", 6)),
+		Host:     "db.local",
+		Path:     "/app",
+		RawQuery: query.Encode(),
+	}
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ .URL }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn:           conn,
+			FS:             fstest.MapFS{},
+			URL:            rawURL.String(),
+			CurrentVersion: 1,
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "postgres://app@db.local/app?sslmode=disable&token=xxxxx")
+}
+
+func TestWriteMigrateApplyFormat_RequiresConnection(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+
+	err := atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			FS:             fstest.MapFS{},
+			CurrentVersion: 1,
+		},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migrate apply format requires database connection`)
+	c.Assert(out.String(), qt.Equals, "")
+}
+
+func TestWriteMigrateApplyFormat_RequiresFilesystem(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "missing-fs.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var out bytes.Buffer
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn:           conn,
+			CurrentVersion: 1,
+		},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migrate apply format requires migration filesystem`)
+	c.Assert(out.String(), qt.Equals, "")
+}
+
+func TestWriteMigrateApplyFormat_RequiresStatusOrCurrentVersion(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "missing-status.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var out bytes.Buffer
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn: conn,
+			FS:   fstest.MapFS{},
+		},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migrate apply format requires migration status or current version`)
+	c.Assert(out.String(), qt.Equals, "")
+}

--- a/internal/atlasreport/schema_diff_test.go
+++ b/internal/atlasreport/schema_diff_test.go
@@ -1,18 +1,20 @@
-package atlasreport
+package atlasreport_test
 
 import (
 	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasreport"
 )
 
 func TestSchemaDiffDefaultFormatReportsSyncedSchemas(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
-	report := NewSchemaDiff(nil, nil, nil)
+	report := atlasreport.NewSchemaDiff(nil, nil, nil)
 
-	err := WriteSchemaDiff(&out, NormalizeSchemaDiffFormat(""), report)
+	err := atlasreport.WriteSchemaDiff(&out, atlasreport.NormalizeSchemaDiffFormat(""), report)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "Schemas are synced, no changes to be made.\n")
@@ -21,11 +23,11 @@ func TestSchemaDiffDefaultFormatReportsSyncedSchemas(t *testing.T) {
 func TestSchemaDiffCustomSQLTemplate(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
-	report := NewSchemaDiff(nil, nil, []string{
+	report := atlasreport.NewSchemaDiff(nil, nil, []string{
 		`CREATE TABLE "users" ("id" integer);`,
 	})
 
-	err := WriteSchemaDiff(&out, `{{ len .Changes }}|{{ .MarshalSQL }}|{{ sql . "  " }}`, report)
+	err := atlasreport.WriteSchemaDiff(&out, `{{ len .Changes }}|{{ .MarshalSQL }}|{{ sql . "  " }}`, report)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "1|CREATE TABLE \"users\" (\"id\" integer);\n|  CREATE TABLE \"users\" (\"id\" integer);\n")
@@ -34,7 +36,7 @@ func TestSchemaDiffCustomSQLTemplate(t *testing.T) {
 func TestSchemaDiffTemplateValidationRejectsUnknownHelpers(t *testing.T) {
 	c := qt.New(t)
 
-	err := ValidateSchemaDiffTemplate(`{{ json . }}`)
+	err := atlasreport.ValidateSchemaDiffTemplate(`{{ json . }}`)
 
 	c.Assert(err, qt.ErrorMatches, `parse --format template: .*function "json" not defined.*`)
 }
@@ -42,11 +44,11 @@ func TestSchemaDiffTemplateValidationRejectsUnknownHelpers(t *testing.T) {
 func TestSchemaDiffTemplateExecutionErrorDoesNotWritePartialOutput(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
-	report := NewSchemaDiff(nil, nil, []string{
+	report := atlasreport.NewSchemaDiff(nil, nil, []string{
 		`CREATE TABLE "users" ("id" integer);`,
 	})
 
-	err := WriteSchemaDiff(&out, `before {{ sql . "  " "extra" }}`, report)
+	err := atlasreport.WriteSchemaDiff(&out, `before {{ sql . "  " "extra" }}`, report)
 
 	c.Assert(err, qt.ErrorMatches, `execute --format template: .*unexpected number of arguments: 2.*`)
 	c.Assert(out.String(), qt.Equals, "")

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -1,4 +1,4 @@
-package atlas
+package atlasreport
 
 import (
 	"encoding/json"
@@ -16,7 +16,7 @@ import (
 	"github.com/stokaro/ptah/internal/schemaviz"
 )
 
-type atlasSchemaInspectReport struct {
+type SchemaInspectReport struct {
 	db          *goschema.Database
 	info        dbschematypes.DBInfo
 	diagnostics io.Writer
@@ -77,7 +77,7 @@ type atlasSchemaInspectJSONForeignKey struct {
 	} `json:"references"`
 }
 
-func renderAtlasSchemaInspectFormat(format string, report *atlasSchemaInspectReport) (string, error) {
+func RenderSchemaInspectFormat(format string, report *SchemaInspectReport) (string, error) {
 	var out strings.Builder
 	if err := renderAtlasSchemaInspectTemplate(&out, "atlas-schema-inspect-format", format, report); err != nil {
 		return "", err
@@ -85,14 +85,14 @@ func renderAtlasSchemaInspectFormat(format string, report *atlasSchemaInspectRep
 	return out.String(), nil
 }
 
-func newAtlasSchemaInspectReport(
+func NewSchemaInspectReport(
 	db *goschema.Database,
 	schema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	diagnostics io.Writer,
-) *atlasSchemaInspectReport {
+) *SchemaInspectReport {
 	realm := atlasSchemaInspectJSON(schema, info)
-	return &atlasSchemaInspectReport{
+	return &SchemaInspectReport{
 		db:          db,
 		info:        info,
 		diagnostics: diagnostics,
@@ -101,16 +101,30 @@ func newAtlasSchemaInspectReport(
 	}
 }
 
-func validateAtlasSchemaInspectTemplate(format string) error {
+func ValidateSchemaInspectTemplate(format string) error {
 	_, err := newAtlasSchemaInspectTemplate("atlas-schema-inspect-format", format)
 	return err
+}
+
+func NormalizeSchemaInspectFormat(format string) (string, error) {
+	trimmed := strings.TrimSpace(format)
+	if trimmed == "" || trimmed == "hcl" {
+		return "{{ $.MarshalHCL }}", nil
+	}
+	if trimmed == "sql" {
+		return "{{ sql . }}", nil
+	}
+	if trimmed == "json" {
+		return "{{ json . }}", nil
+	}
+	return format, nil
 }
 
 func renderAtlasSchemaInspectTemplate(
 	out *strings.Builder,
 	name string,
 	format string,
-	report *atlasSchemaInspectReport,
+	report *SchemaInspectReport,
 ) error {
 	tmpl, err := newAtlasSchemaInspectTemplate(name, format)
 	if err != nil {
@@ -137,7 +151,7 @@ func newAtlasSchemaInspectTemplate(name, format string) (*template.Template, err
 	return tmpl, nil
 }
 
-func (r *atlasSchemaInspectReport) MarshalHCL() (string, error) {
+func (r *SchemaInspectReport) MarshalHCL() (string, error) {
 	rendered, err := atlashclrender.Render(r.db)
 	if err != nil {
 		return "", fmt.Errorf("render Atlas HCL: %w", err)
@@ -150,7 +164,7 @@ func (r *atlasSchemaInspectReport) MarshalHCL() (string, error) {
 	return string(rendered.Data), nil
 }
 
-func (r *atlasSchemaInspectReport) MarshalSQL(indent ...string) (string, error) {
+func (r *SchemaInspectReport) MarshalSQL(indent ...string) (string, error) {
 	if len(indent) > 1 {
 		return "", fmt.Errorf("unexpected number of arguments: %d", len(indent))
 	}
@@ -169,15 +183,15 @@ func (r *atlasSchemaInspectReport) MarshalSQL(indent ...string) (string, error) 
 	return indent[0] + strings.ReplaceAll(sql, "\n", "\n"+indent[0]), nil
 }
 
-func (r *atlasSchemaInspectReport) MarshalJSON() ([]byte, error) {
+func (r *SchemaInspectReport) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Realm)
 }
 
-func atlasSchemaInspectSQL(report *atlasSchemaInspectReport, indent ...string) (string, error) {
+func atlasSchemaInspectSQL(report *SchemaInspectReport, indent ...string) (string, error) {
 	return report.MarshalSQL(indent...)
 }
 
-func atlasSchemaInspectMermaid(report *atlasSchemaInspectReport, _ ...string) (string, error) {
+func atlasSchemaInspectMermaid(report *SchemaInspectReport, _ ...string) (string, error) {
 	out, err := schemaviz.Render(report.db, schemaviz.Options{
 		Format:         schemaviz.FormatMermaid,
 		IncludeColumns: true,

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -1,0 +1,85 @@
+package atlasreport_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlasreport"
+)
+
+func TestNormalizeSchemaInspectFormat_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{name: "default", format: "", want: "{{ $.MarshalHCL }}"},
+		{name: "hcl", format: "hcl", want: "{{ $.MarshalHCL }}"},
+		{name: "sql", format: "sql", want: "{{ sql . }}"},
+		{name: "json", format: "json", want: "{{ json . }}"},
+		{name: "custom", format: "{{ json . }}", want: "{{ json . }}"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, err := atlasreport.NormalizeSchemaInspectFormat(test.format)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, test.want)
+		})
+	}
+}
+
+func TestRenderSchemaInspectFormat_JSONTemplate(t *testing.T) {
+	c := qt.New(t)
+	report := atlasreport.NewSchemaInspectReport(
+		&goschema.Database{},
+		&types.DBSchema{
+			Tables: []types.DBTable{
+				{
+					Name:   "users",
+					Schema: "main",
+					Columns: []types.DBColumn{
+						{Name: "id", DataType: "integer", IsNullable: "NO"},
+					},
+				},
+			},
+		},
+		types.DBInfo{Dialect: "sqlite", Schema: "main"},
+		nil,
+	)
+
+	rendered, err := atlasreport.RenderSchemaInspectFormat(`{{ json . }}`, report)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, `"schemas":[{"name":"main"`)
+	c.Assert(rendered, qt.Contains, `"tables":[{"name":"users"`)
+	c.Assert(rendered, qt.Contains, `"columns":[{"name":"id","type":"integer"`)
+}
+
+func TestValidateSchemaInspectTemplate_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	err := atlasreport.ValidateSchemaInspectTemplate(`{{ unknown . }}`)
+
+	c.Assert(err, qt.ErrorMatches, `parse --format template: .*function "unknown" not defined.*`)
+}
+
+func TestRenderSchemaInspectFormat_UnsupportedFileTemplateFunction(t *testing.T) {
+	c := qt.New(t)
+	report := atlasreport.NewSchemaInspectReport(
+		&goschema.Database{},
+		&types.DBSchema{},
+		types.DBInfo{Dialect: "sqlite", Schema: "main"},
+		nil,
+	)
+
+	rendered, err := atlasreport.RenderSchemaInspectFormat(`{{ split . }}`, report)
+
+	c.Assert(err, qt.ErrorMatches, `execute --format template: .*atlas schema inspect accepts split/write templates, but Ptah does not implement their behavior yet`)
+	c.Assert(rendered, qt.Equals, "")
+}

--- a/internal/atlasschema/diff_test.go
+++ b/internal/atlasschema/diff_test.go
@@ -1,4 +1,4 @@
-package atlasschema
+package atlasschema_test
 
 import (
 	"os"
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasschema"
 )
 
 func TestDiffLocalFilesReturnsSchemaDiffReport(t *testing.T) {
@@ -32,7 +34,7 @@ table "users" {
 }
 `), 0o600), qt.IsNil)
 
-	report, err := DiffLocalFiles(DiffOptions{
+	report, err := atlasschema.DiffLocalFiles(atlasschema.DiffOptions{
 		FromURLs: []string{"file://" + from},
 		ToURLs:   []string{"file://" + to},
 		DevURL:   "postgres://localhost/dev",
@@ -48,7 +50,7 @@ table "users" {
 func TestDiffLocalFilesRequiresDevURL(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := DiffLocalFiles(DiffOptions{})
+	_, err := atlasschema.DiffLocalFiles(atlasschema.DiffOptions{})
 
 	c.Assert(err, qt.ErrorMatches, `--dev-url is required for local schema file diffing`)
 }

--- a/internal/atlasurl/url_test.go
+++ b/internal/atlasurl/url_test.go
@@ -1,19 +1,20 @@
-package atlasurl
+package atlasurl_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasurl"
 )
 
-func TestDialectFromURL(t *testing.T) {
+func TestDialectFromURL_HappyPath(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
-		name    string
-		rawURL  string
-		want    string
-		wantErr string
+		name   string
+		rawURL string
+		want   string
 	}{
 		{name: "empty", rawURL: "", want: ""},
 		{name: "postgres", rawURL: "postgres://localhost/dev", want: "postgres"},
@@ -21,19 +22,34 @@ func TestDialectFromURL(t *testing.T) {
 		{name: "sqlserver", rawURL: "sqlserver://localhost/dev", want: "sqlserver"},
 		{name: "docker postgres", rawURL: "docker://postgres/16/dev", want: "postgres"},
 		{name: "docker postgres port", rawURL: "docker://postgres:16/dev", want: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, err := atlasurl.DialectFromURL(test.rawURL)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, test.want)
+		})
+	}
+}
+
+func TestDialectFromURL_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr string
+	}{
 		{name: "missing docker engine", rawURL: "docker:///dev", wantErr: `docker --dev-url is missing database engine`},
 		{name: "unsupported", rawURL: "spanner://localhost/dev", wantErr: `unsupported --dev-url dialect "spanner://localhost/dev"`},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			got, err := DialectFromURL(test.rawURL)
-			if test.wantErr != "" {
-				c.Assert(err, qt.ErrorMatches, test.wantErr)
-				return
-			}
-			c.Assert(err, qt.IsNil)
-			c.Assert(got, qt.Equals, test.want)
+			got, err := atlasurl.DialectFromURL(test.rawURL)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(got, qt.Equals, "")
 		})
 	}
 }


### PR DESCRIPTION
## What Changed

- Moved Atlas `schema inspect --format` rendering out of `cmd/atlas` into `internal/atlasreport`.
- Moved Atlas `migrate apply --format` rendering out of `cmd/atlas` into `internal/atlasreport`.
- Added package-level black-box tests for the new `internal/atlasreport` schema inspect and migrate apply formatting APIs.
- Converted the new `internal/atlasurl`, `internal/atlasschema`, and schema-diff report tests to black-box package tests.
- Added `AGENTS.md` testing standards:
  - declarative tests only;
  - no `if`, `switch`, or `goto` in test functions;
  - do not hide branching in assertion helpers;
  - separate happy-path and failure-path tests;
  - black-box tests by default;
  - white-box tests only as `*_internal_test.go` with a justification comment.

## Why

This is a scoped slice of #540. `cmd/atlas` should stay a thin CLI layer that parses flags, validates user input, and calls reusable packages. Report/template rendering is reusable Atlas-compat behavior and should not live directly in command files.

This also captures the project testing rules discussed while reviewing `internal/atlasurl/url_test.go`. The repo-wide test audit is tracked separately in #541.

## Validation

- `git diff --check`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./internal/atlasreport ./internal/atlasschema ./internal/atlasurl ./cmd/atlas`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...` outside sandbox

Refs #540
Refs #541
