### PR TITLE
Move Atlas schema apply runtime out of cmd

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1204,52 +1204,6 @@ func TestNewAtlasCommand_SchemaApplyRejectsInvalidTxMode(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `invalid tx-mode "statement": expected file, all, or none`)
 }
 
-func TestApplyAtlasSchemaChangesTxModeRollbackBehavior(t *testing.T) {
-	c := qt.New(t)
-	dir := t.TempDir()
-	sqlText := `
-CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
-CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
-`
-
-	allDB := filepath.Join(dir, "tx-mode-all.db")
-	allConn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+allDB)
-	c.Assert(err, qt.IsNil)
-	err = applyAtlasSchemaChanges(context.Background(), allConn, migrator.MigrationTxModeAll, sqlText)
-	dbschema.CloseAndWarn(allConn)
-
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "failed to execute SQL statement")
-	assertSQLiteTableMissing(c, allDB, "tx_mode_first")
-
-	noneDB := filepath.Join(dir, "tx-mode-none.db")
-	noneConn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+noneDB)
-	c.Assert(err, qt.IsNil)
-	err = applyAtlasSchemaChanges(context.Background(), noneConn, migrator.MigrationTxModeNone, sqlText)
-	dbschema.CloseAndWarn(noneConn)
-
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "failed to execute SQL statement")
-	assertSQLiteTableExists(c, noneDB, "tx_mode_first")
-}
-
-func TestSplitAtlasSchemaApplyStatementsUsesDialect(t *testing.T) {
-	c := qt.New(t)
-	sqlText := `
-CREATE TABLE tx_mode_batch_one (id INT);
-GO
-CREATE TABLE tx_mode_batch_two (id INT);
-GO
-`
-
-	statements := splitAtlasSchemaApplyStatements(sqlText, "sqlserver")
-
-	c.Assert(statements, qt.DeepEquals, []string{
-		"CREATE TABLE tx_mode_batch_one (id INT)",
-		"CREATE TABLE tx_mode_batch_two (id INT)",
-	})
-}
-
 func TestNewCompatCommand_SchemaApplyDryRunUsesAtlasRoot(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/internal/schemafile"
@@ -137,7 +138,7 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("generate migration SQL: %w", err))
 	}
-	path, err := writeAtlasMigrationFile(migrationsDir, name, atlasMigrationSQL(statements))
+	path, err := writeAtlasMigrationFile(migrationsDir, name, atlasschema.FormatMigrationSQL(statements))
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -313,19 +314,6 @@ func filterByTable[T any](values []T, keep func(T) bool) []T {
 		}
 	}
 	return out
-}
-
-func atlasMigrationSQL(statements []string) string {
-	var out strings.Builder
-	for _, stmt := range statements {
-		stmt = strings.TrimSpace(stmt)
-		if stmt == "" {
-			continue
-		}
-		out.WriteString(strings.TrimSuffix(stmt, ";"))
-		out.WriteString(";\n")
-	}
-	return out.String()
 }
 
 func writeAtlasMigrationFile(dir, name, sql string) (string, error) {

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -1,7 +1,6 @@
 package atlas
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -11,13 +10,10 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdflags"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
-	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlasurl"
-	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
-	"github.com/stokaro/ptah/migration/planner"
-	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
 type atlasSchemaApplyOptions struct {
@@ -85,26 +81,16 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		return cmdutil.Fail(cmd, err)
 	}
 
-	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	plan, err := atlasschema.PlanApply(conn, atlasschema.ApplyOptions{ToURLs: opts.toURLs})
 	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("read database schema: %w", err))
+		return cmdutil.Fail(cmd, err)
 	}
-	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{Dialect: conn.Info().Dialect})
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))
-	}
-
-	diff := schemadiff.CompareWithDialect(desired, current, conn.Info().Dialect)
-	if !diff.HasChanges() {
+	if !plan.HasChanges() {
 		fmt.Fprintln(cmd.OutOrStdout(), "Schema is synced, no changes to be made.")
 		return nil
 	}
 
-	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, desired, conn.Info().Dialect)
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("generate schema apply SQL: %w", err))
-	}
-	sqlText := atlasMigrationSQL(statements)
+	sqlText := plan.SQL()
 	printAtlasSchemaApplyPlan(cmd.OutOrStdout(), sqlText)
 	if opts.dryRun {
 		return nil
@@ -119,7 +105,7 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	}
 
 	conn.SchemaWriter().SetDryRun(false)
-	if err := applyAtlasSchemaChanges(cmd.Context(), conn, txMode, sqlText); err != nil {
+	if err := atlasschema.ApplySQL(cmd.Context(), conn, txMode, sqlText); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("apply schema changes: %w", err))
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Schema apply completed successfully.")
@@ -142,70 +128,6 @@ func validateAtlasSchemaApplyOptions(cmd *cobra.Command, opts atlasSchemaApplyOp
 		}
 	}
 	return ensureLocalSchemaURLs("--to", opts.toURLs)
-}
-
-type atlasSchemaApplyExecutor interface {
-	ExecuteSQL(ctx context.Context, sql string, args ...any) error
-}
-
-func applyAtlasSchemaChanges(
-	ctx context.Context,
-	conn *dbschema.DatabaseConnection,
-	txMode migrator.MigrationTxMode,
-	sqlText string,
-) error {
-	statements := splitAtlasSchemaApplyStatements(sqlText, conn.Info().Dialect)
-	switch txMode {
-	case migrator.MigrationTxModeNone:
-		return executeAtlasSchemaApplyStatements(ctx, conn.Writer(), statements)
-	case migrator.MigrationTxModeFile, migrator.MigrationTxModeAll:
-		// Schema apply generates one plan, so Atlas file/all modes both wrap
-		// the complete generated plan in one transaction.
-		tx, err := conn.SchemaWriter().BeginTransaction(ctx)
-		if err != nil {
-			return fmt.Errorf("begin schema apply transaction: %w", err)
-		}
-		if err := executeAtlasSchemaApplyStatements(ctx, tx, statements); err != nil {
-			_ = tx.Rollback()
-			return err
-		}
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit schema apply transaction: %w", err)
-		}
-		return nil
-	default:
-		return fmt.Errorf("invalid tx-mode %q", txMode)
-	}
-}
-
-func splitAtlasSchemaApplyStatements(sqlText, dialect string) []string {
-	statements := sqlutil.SplitSQLStatementsForDialect(sqlText, dialect)
-	filtered := statements[:0]
-	for _, stmt := range statements {
-		stmt = strings.TrimSpace(sqlutil.StripComments(stmt))
-		if stmt != "" {
-			filtered = append(filtered, stmt)
-		}
-	}
-	return filtered
-}
-
-func executeAtlasSchemaApplyStatements(ctx context.Context, executor atlasSchemaApplyExecutor, statements []string) error {
-	for i, stmt := range statements {
-		stmt = strings.TrimSpace(stmt)
-		if stmt == "" {
-			continue
-		}
-		if err := executor.ExecuteSQL(ctx, stmt); err != nil {
-			return &migrator.MigrationExecutionError{
-				Err:            fmt.Errorf("failed to execute SQL statement: %w", err),
-				Statement:      stmt,
-				StatementIndex: i + 1,
-				Total:          len(statements),
-			}
-		}
-	}
-	return nil
 }
 
 func validateAtlasDevURLDialect(devURL, targetDialect string) error {

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -1,0 +1,136 @@
+package atlasschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/schemafile"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+type ApplyOptions struct {
+	ToURLs []string
+}
+
+type ApplyPlan struct {
+	statements []string
+}
+
+func (p ApplyPlan) HasChanges() bool {
+	return len(p.statements) > 0
+}
+
+func (p ApplyPlan) SQL() string {
+	return FormatMigrationSQL(p.statements)
+}
+
+func PlanApply(conn *dbschema.DatabaseConnection, opts ApplyOptions) (ApplyPlan, error) {
+	if conn == nil {
+		return ApplyPlan{}, errors.New("schema apply planning requires database connection")
+	}
+	if len(opts.ToURLs) == 0 {
+		return ApplyPlan{}, errors.New("schema apply planning requires desired schema URLs")
+	}
+
+	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	if err != nil {
+		return ApplyPlan{}, fmt.Errorf("read database schema: %w", err)
+	}
+	desired, err := schemafile.LoadAll(opts.ToURLs, schemafile.Options{Dialect: conn.Info().Dialect})
+	if err != nil {
+		return ApplyPlan{}, fmt.Errorf("load --to schema: %w", err)
+	}
+
+	diff := schemadiff.CompareWithDialect(desired, current, conn.Info().Dialect)
+	if !diff.HasChanges() {
+		return ApplyPlan{}, nil
+	}
+
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, desired, conn.Info().Dialect)
+	if err != nil {
+		return ApplyPlan{}, fmt.Errorf("generate schema apply SQL: %w", err)
+	}
+	return ApplyPlan{statements: statements}, nil
+}
+
+func ApplySQL(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	txMode migrator.MigrationTxMode,
+	sqlText string,
+) error {
+	if conn == nil {
+		return errors.New("schema apply execution requires database connection")
+	}
+
+	statements := SplitApplyStatements(sqlText, conn.Info().Dialect)
+	switch txMode {
+	case migrator.MigrationTxModeNone:
+		return executeApplyStatements(ctx, conn.Writer(), statements)
+	case migrator.MigrationTxModeFile, migrator.MigrationTxModeAll:
+		tx, err := conn.SchemaWriter().BeginTransaction(ctx)
+		if err != nil {
+			return fmt.Errorf("begin schema apply transaction: %w", err)
+		}
+		if err := executeApplyStatements(ctx, tx, statements); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit schema apply transaction: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid tx-mode %q", txMode)
+	}
+}
+
+func SplitApplyStatements(sqlText, dialect string) []string {
+	statements := sqlutil.SplitSQLStatementsForDialect(sqlText, dialect)
+	filtered := statements[:0]
+	for _, stmt := range statements {
+		stmt = strings.TrimSpace(sqlutil.StripComments(stmt))
+		if stmt != "" {
+			filtered = append(filtered, stmt)
+		}
+	}
+	return filtered
+}
+
+func FormatMigrationSQL(statements []string) string {
+	var out strings.Builder
+	for _, stmt := range statements {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		out.WriteString(strings.TrimSuffix(stmt, ";"))
+		out.WriteString(";\n")
+	}
+	return out.String()
+}
+
+func executeApplyStatements(ctx context.Context, executor types.SchemaExecutor, statements []string) error {
+	for i, stmt := range statements {
+		stmt = strings.TrimSpace(stmt)
+		if stmt == "" {
+			continue
+		}
+		if err := executor.ExecuteSQL(ctx, stmt); err != nil {
+			return &migrator.MigrationExecutionError{
+				Err:            fmt.Errorf("failed to execute SQL statement: %w", err),
+				Statement:      stmt,
+				StatementIndex: i + 1,
+				Total:          len(statements),
+			}
+		}
+	}
+	return nil
+}

--- a/internal/atlasschema/apply_test.go
+++ b/internal/atlasschema/apply_test.go
@@ -1,0 +1,178 @@
+package atlasschema_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlasschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestPlanApply_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "plan.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL
+);
+`), 0o600), qt.IsNil)
+	conn := connectSQLite(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasschema.PlanApply(conn, atlasschema.ApplyOptions{
+		ToURLs: []string{"file://" + schemaPath},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsTrue)
+	c.Assert(plan.SQL(), qt.Contains, "CREATE TABLE")
+	c.Assert(plan.SQL(), qt.Contains, "users")
+}
+
+func TestPlanApply_Synced(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "synced.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	schemaSQL := `
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`
+	c.Assert(os.WriteFile(schemaPath, []byte(schemaSQL), 0o600), qt.IsNil)
+	conn := connectSQLite(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+	c.Assert(atlasschema.ApplySQL(context.Background(), conn, migrator.MigrationTxModeAll, schemaSQL), qt.IsNil)
+
+	plan, err := atlasschema.PlanApply(conn, atlasschema.ApplyOptions{
+		ToURLs: []string{"file://" + schemaPath},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsFalse)
+	c.Assert(plan.SQL(), qt.Equals, "")
+}
+
+func TestPlanApply_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil connection", func(c *qt.C) {
+		plan, err := atlasschema.PlanApply(nil, atlasschema.ApplyOptions{
+			ToURLs: []string{"file:///schema.sql"},
+		})
+		c.Assert(err, qt.ErrorMatches, "schema apply planning requires database connection")
+		c.Assert(plan.HasChanges(), qt.IsFalse)
+		c.Assert(plan.SQL(), qt.Equals, "")
+	})
+
+	c.Run("empty desired schema URLs", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(t.TempDir(), "empty-to.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasschema.PlanApply(conn, atlasschema.ApplyOptions{})
+		c.Assert(err, qt.ErrorMatches, "schema apply planning requires desired schema URLs")
+		c.Assert(plan.HasChanges(), qt.IsFalse)
+		c.Assert(plan.SQL(), qt.Equals, "")
+	})
+}
+
+func TestApplySQL_TxModeAllRollsBackOnFailure(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "tx-mode-all.db")
+	conn := connectSQLite(c, dbPath)
+	sqlText := `
+CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
+CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
+`
+
+	err := atlasschema.ApplySQL(context.Background(), conn, migrator.MigrationTxModeAll, sqlText)
+	dbschema.CloseAndWarn(conn)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "failed to execute SQL statement")
+	c.Assert(sqliteTableExists(c, dbPath, "tx_mode_first"), qt.IsFalse)
+}
+
+func TestApplySQL_TxModeNoneKeepsPriorStatementsOnFailure(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "tx-mode-none.db")
+	conn := connectSQLite(c, dbPath)
+	sqlText := `
+CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
+CREATE TABLE tx_mode_first (id INTEGER PRIMARY KEY);
+`
+
+	err := atlasschema.ApplySQL(context.Background(), conn, migrator.MigrationTxModeNone, sqlText)
+	dbschema.CloseAndWarn(conn)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "failed to execute SQL statement")
+	c.Assert(sqliteTableExists(c, dbPath, "tx_mode_first"), qt.IsTrue)
+}
+
+func TestApplySQL_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil connection", func(c *qt.C) {
+		err := atlasschema.ApplySQL(context.Background(), nil, migrator.MigrationTxModeAll, "SELECT 1;")
+		c.Assert(err, qt.ErrorMatches, "schema apply execution requires database connection")
+	})
+}
+
+func TestSplitApplyStatements_UsesDialect(t *testing.T) {
+	c := qt.New(t)
+	sqlText := `
+CREATE TABLE tx_mode_batch_one (id INT);
+GO
+CREATE TABLE tx_mode_batch_two (id INT);
+GO
+`
+
+	statements := atlasschema.SplitApplyStatements(sqlText, "sqlserver")
+
+	c.Assert(statements, qt.DeepEquals, []string{
+		"CREATE TABLE tx_mode_batch_one (id INT)",
+		"CREATE TABLE tx_mode_batch_two (id INT)",
+	})
+}
+
+func TestFormatMigrationSQL_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	sqlText := atlasschema.FormatMigrationSQL([]string{
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);",
+		" ",
+		"CREATE INDEX users_id_idx ON users (id)",
+	})
+
+	c.Assert(sqlText, qt.Equals, "CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE INDEX users_id_idx ON users (id);\n")
+}
+
+func connectSQLite(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	return conn
+}
+
+func sqliteTableExists(c *qt.C, dbPath, table string) bool {
+	c.Helper()
+	conn := connectSQLite(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	c.Assert(err, qt.IsNil)
+	return slices.ContainsFunc(schema.Tables, func(dbTable types.DBTable) bool {
+		return dbTable.Name == table
+	})
+}


### PR DESCRIPTION
## Summary

Part of #540.

This moves the Atlas `schema apply` planning/execution runtime out of `cmd/atlas` into `internal/atlasschema`, keeping the Cobra command as the CLI adapter for flags, prompts, and user-facing output.

Changes:

- add `internal/atlasschema.PlanApply` for current-schema loading, target schema loading, diffing, and SQL planning
- add `internal/atlasschema.ApplySQL` for Atlas-compatible schema apply transaction modes
- reuse `internal/atlasschema.FormatMigrationSQL` from both `schema apply` and `migrate diff`
- keep command-level tests for CLI behavior and move runtime rollback/splitting coverage into black-box package tests
- validate reusable package boundaries for nil connections and missing desired schema URLs

Docs impact: internal refactor only, no user-facing CLI semantics changed.

## Self-review

Pass 1:

- checked that old `applyAtlasSchemaChanges`, `splitAtlasSchemaApplyStatements`, and `atlasMigrationSQL` helpers are gone from `cmd/atlas`
- found and removed unnecessary exported `Desired` state from `ApplyPlan`
- added package-level validation for nil connections and empty desired schema URLs

Pass 2:

- narrowed `ApplyPlan` further by making raw statements unexported; callers use `HasChanges()` and `SQL()`
- verified CLI-specific concerns remain in `cmd/atlas`: flag validation, dev URL dialect validation, dry-run output, prompt confirmation, and user-facing messages
- verified new tests are black-box and contain no `if`, `switch`, or `goto` in test functions

## Validation

```bash
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./internal/atlasschema ./cmd/atlas
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...
```

`gopls go_diagnostics` was attempted for the changed files, but this linked worktree still reports `no package metadata for file .../internal/atlasschema/apply_test.go`; the compiler/lint/test gates above passed.
