### PR TITLE
Move Atlas migrate diff runtime out of cmd

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1832,11 +1832,7 @@ func TestNewAtlasCommand_MigrateDiffLockTimeout(t *testing.T) {
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
 	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
-	lock, err := acquireAtlasMigrateDiffDirLock(context.Background(), migrationsDir, 0)
-	c.Assert(err, qt.IsNil)
-	defer func() {
-		c.Assert(lock.release(), qt.IsNil)
-	}()
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"), []byte("held\n"), 0o600), qt.IsNil)
 	schemaPath := filepath.Join(dir, "schema.sql")
 	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE locked_diff (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
 
@@ -1853,7 +1849,7 @@ func TestNewAtlasCommand_MigrateDiffLockTimeout(t *testing.T) {
 		"locked_diff",
 	})
 
-	err = cmd.Execute()
+	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `migration directory lock timeout after 1ms: .*\.ptah-migrate-diff\.lock`)
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 0)

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -1,32 +1,18 @@
 package atlas
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
-	dbschematypes "github.com/stokaro/ptah/dbschema/types"
-	"github.com/stokaro/ptah/internal/atlasschema"
-	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/internal/pathguard"
-	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
-	"github.com/stokaro/ptah/migration/planner"
-	"github.com/stokaro/ptah/migration/schemadiff"
 )
-
-const atlasRevisionTableName = "atlas_schema_revisions"
-const atlasMigrateDiffLockFileName = ".ptah-migrate-diff.lock"
 
 type atlasMigrateDiffOptions struct {
 	toURLs      []string
@@ -73,7 +59,7 @@ follow-up gaps.`,
 	return cmd
 }
 
-func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name string) (result error) {
+func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name string) error {
 	if err := validateAtlasMigrateDiffOptions(cmd, opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -90,23 +76,8 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("resolve migration directory: %w", err))
 	}
-	if err := os.MkdirAll(migrationsDir, 0755); err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("create migration directory: %w", err))
-	}
-	dirLock, err := acquireAtlasMigrateDiffDirLock(cmd.Context(), migrationsDir, lockTimeout)
-	if err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-	defer func() {
-		if err := dirLock.release(); err != nil && result == nil {
-			result = cmdutil.Fail(cmd, err)
-		}
-	}()
-	if err := verifyAtlasMigrationDirSum(migrationsDir); err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
 
-	connectCtx, cancel := dbcli.ConnectContext(context.Background(), dbcli.DefaultConnectTimeout)
+	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
 	defer cancel()
 	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.devURL)
 	if err != nil {
@@ -114,40 +85,21 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := replayAtlasMigrationDir(context.Background(), conn, migrationsDir); err != nil {
+	diffResult, err := atlasmigrate.GenerateDiff(cmd.Context(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      opts.toURLs,
+		Name:        name,
+		LockTimeout: lockTimeout,
+	})
+	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("read dev database schema: %w", err))
-	}
-	current = withoutAtlasRevisionTable(current)
-
-	dialect := conn.Info().Dialect
-	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{Dialect: dialect})
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))
-	}
-	diff := schemadiff.CompareWithDialect(desired, current, dialect)
-	if !diff.HasChanges() {
+	if diffResult.Synced {
 		fmt.Fprintln(cmd.OutOrStdout(), "The migration directory is synced with the desired state, no changes to be made")
 		return nil
 	}
-
-	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, desired, dialect)
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("generate migration SQL: %w", err))
-	}
-	path, err := writeAtlasMigrationFile(migrationsDir, name, atlasschema.FormatMigrationSQL(statements))
-	if err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-	if _, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas); err != nil {
-		_ = os.Remove(path)
-		return cmdutil.Fail(cmd, fmt.Errorf("write atlas.sum: %w", err))
-	}
-	fmt.Fprintf(cmd.OutOrStdout(), "Created migration file: %s\n", path)
-	fmt.Fprintf(cmd.OutOrStdout(), "Updated migration checksum: %s\n", filepath.Join(migrationsDir, migratesum.AtlasFileName))
+	fmt.Fprintf(cmd.OutOrStdout(), "Created migration file: %s\n", diffResult.MigrationPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated migration checksum: %s\n", diffResult.SumPath)
 	return nil
 }
 
@@ -172,213 +124,4 @@ func validateAtlasMigrateDiffOptions(cmd *cobra.Command, opts atlasMigrateDiffOp
 		return fmt.Errorf("atlas migrate diff accepts docker --dev-url values, but Ptah requires a directly connectable dev database URL")
 	}
 	return ensureLocalSchemaURLs("--to", opts.toURLs)
-}
-
-type atlasMigrateDiffDirLock struct {
-	path string
-	file *os.File
-}
-
-func acquireAtlasMigrateDiffDirLock(
-	ctx context.Context,
-	migrationsDir string,
-	timeout time.Duration,
-) (*atlasMigrateDiffDirLock, error) {
-	lockPath := filepath.Join(migrationsDir, atlasMigrateDiffLockFileName)
-	startedAt := time.Now()
-	for {
-		lock, err := tryAcquireAtlasMigrateDiffDirLock(lockPath)
-		if err == nil {
-			return lock, nil
-		}
-		if !errors.Is(err, os.ErrExist) {
-			return nil, err
-		}
-		if timeout > 0 && time.Since(startedAt) >= timeout {
-			return nil, fmt.Errorf("migration directory lock timeout after %s: %s", timeout, lockPath)
-		}
-		if err := waitForAtlasMigrateDiffDirLockRetry(ctx, startedAt, timeout); err != nil {
-			return nil, err
-		}
-	}
-}
-
-func tryAcquireAtlasMigrateDiffDirLock(lockPath string) (*atlasMigrateDiffDirLock, error) {
-	file, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("create migration directory lock: %w", err)
-	}
-	if _, err := fmt.Fprintf(file, "pid=%d\n", os.Getpid()); err != nil {
-		_ = file.Close()
-		_ = os.Remove(lockPath)
-		return nil, fmt.Errorf("write migration directory lock: %w", err)
-	}
-	return &atlasMigrateDiffDirLock{path: lockPath, file: file}, nil
-}
-
-func waitForAtlasMigrateDiffDirLockRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
-	wait := 25 * time.Millisecond
-	if timeout > 0 {
-		remaining := timeout - time.Since(startedAt)
-		if remaining <= 0 {
-			return nil
-		}
-		wait = min(wait, remaining)
-	}
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("acquire migration directory lock: %w", ctx.Err())
-	case <-timer.C:
-		return nil
-	}
-}
-
-func (l *atlasMigrateDiffDirLock) release() error {
-	if l == nil {
-		return nil
-	}
-	closeErr := l.file.Close()
-	removeErr := os.Remove(l.path)
-	if closeErr != nil && removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("release migration directory lock: %w", errors.Join(closeErr, removeErr))
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close migration directory lock: %w", closeErr)
-	}
-	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("remove migration directory lock: %w", removeErr)
-	}
-	return nil
-}
-
-func verifyAtlasMigrationDirSum(migrationsDir string) error {
-	result, err := migratesum.VerifyDirWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
-	if errors.Is(err, migratesum.ErrSumFileMissing) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("migration directory checksum verification failed: %w", err)
-	}
-	if !result.OK() {
-		return fmt.Errorf("migration directory checksum verification failed:\n%s", result.Describe())
-	}
-	return nil
-}
-
-func replayAtlasMigrationDir(ctx context.Context, conn *dbschema.DatabaseConnection, migrationsDir string) error {
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
-		return fmt.Errorf("clean dev database: %w", err)
-	}
-	provider, err := migrator.NewFSMigrationProvider(
-		os.DirFS(migrationsDir),
-		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
-	)
-	if err != nil {
-		return fmt.Errorf("load migration directory: %w", err)
-	}
-	for _, migration := range provider.Migrations() {
-		if err := migration.Up(ctx, conn); err != nil {
-			return fmt.Errorf("replay migration %d on --dev-url: %w", migration.Version, err)
-		}
-	}
-	return nil
-}
-
-func withoutAtlasRevisionTable(schema *dbschematypes.DBSchema) *dbschematypes.DBSchema {
-	if schema == nil {
-		return &dbschematypes.DBSchema{}
-	}
-	out := *schema
-	out.Tables = filterByTable(out.Tables, func(table dbschematypes.DBTable) bool {
-		return !strings.EqualFold(table.Name, atlasRevisionTableName)
-	})
-	out.Indexes = filterByTable(out.Indexes, func(index dbschematypes.DBIndex) bool {
-		return !strings.EqualFold(index.TableName, atlasRevisionTableName)
-	})
-	out.Constraints = filterByTable(out.Constraints, func(constraint dbschematypes.DBConstraint) bool {
-		return !strings.EqualFold(constraint.TableName, atlasRevisionTableName)
-	})
-	return &out
-}
-
-func filterByTable[T any](values []T, keep func(T) bool) []T {
-	out := make([]T, 0, len(values))
-	for _, value := range values {
-		if keep(value) {
-			out = append(out, value)
-		}
-	}
-	return out
-}
-
-func writeAtlasMigrationFile(dir, name, sql string) (string, error) {
-	if strings.TrimSpace(sql) == "" {
-		return "", fmt.Errorf("migration SQL is empty")
-	}
-	version, err := nextAtlasMigrationVersion(dir)
-	if err != nil {
-		return "", err
-	}
-	slug := atlasMigrationSlug(name)
-	for {
-		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", version, slug))
-		err := writeNewAtlasMigrationFile(path, sql)
-		if err == nil {
-			return path, nil
-		}
-		if !errors.Is(err, os.ErrExist) {
-			return "", fmt.Errorf("write migration file: %w", err)
-		}
-		version++
-	}
-}
-
-func writeNewAtlasMigrationFile(path, sql string) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		return err
-	}
-	if _, err := file.WriteString(sql); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return fmt.Errorf("write migration SQL: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return fmt.Errorf("close migration file: %w", err)
-	}
-	return nil
-}
-
-func nextAtlasMigrationVersion(dir string) (int64, error) {
-	files, err := migrator.DiscoverMigrationFiles(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
-	if err != nil {
-		return 0, err
-	}
-	version := migrator.GetNextMigrationVersion()
-	for _, file := range files {
-		if file.Version >= version {
-			version = file.Version + 1
-		}
-	}
-	return version, nil
-}
-
-var atlasMigrationSlugInvalidChars = regexp.MustCompile(`[^a-z0-9_]+`)
-
-func atlasMigrationSlug(name string) string {
-	slug := strings.ToLower(strings.TrimSpace(name))
-	slug = strings.ReplaceAll(slug, "-", "_")
-	slug = strings.ReplaceAll(slug, " ", "_")
-	slug = atlasMigrationSlugInvalidChars.ReplaceAllString(slug, "")
-	slug = strings.Trim(slug, "_")
-	if slug == "" {
-		return "migration"
-	}
-	return slug
 }

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -1,0 +1,309 @@
+package atlasmigrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlasschema"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/schemafile"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+const (
+	revisionTableName = "atlas_schema_revisions"
+	lockFileName      = ".ptah-migrate-diff.lock"
+)
+
+type DiffOptions struct {
+	Dir         string
+	ToURLs      []string
+	Name        string
+	LockTimeout time.Duration
+}
+
+type DiffResult struct {
+	Synced        bool
+	MigrationPath string
+	SumPath       string
+}
+
+func GenerateDiff(ctx context.Context, conn *dbschema.DatabaseConnection, opts DiffOptions) (result DiffResult, err error) {
+	if conn == nil {
+		return DiffResult{}, errors.New("migrate diff requires dev database connection")
+	}
+	if strings.TrimSpace(opts.Dir) == "" {
+		return DiffResult{}, errors.New("migrate diff requires migration directory")
+	}
+	if len(opts.ToURLs) == 0 {
+		return DiffResult{}, errors.New("migrate diff requires desired schema URLs")
+	}
+	if strings.TrimSpace(opts.Name) == "" {
+		opts.Name = "migration"
+	}
+
+	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
+		return DiffResult{}, fmt.Errorf("create migration directory: %w", err)
+	}
+	dirLock, err := acquireDirLock(ctx, opts.Dir, opts.LockTimeout)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	defer func() {
+		if releaseErr := dirLock.release(); releaseErr != nil && err == nil {
+			err = releaseErr
+		}
+	}()
+	if err := verifyDirSum(opts.Dir); err != nil {
+		return DiffResult{}, err
+	}
+
+	if err := replayDir(ctx, conn, opts.Dir); err != nil {
+		return DiffResult{}, err
+	}
+	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	if err != nil {
+		return DiffResult{}, fmt.Errorf("read dev database schema: %w", err)
+	}
+	current = withoutRevisionTable(current)
+
+	dialect := conn.Info().Dialect
+	desired, err := schemafile.LoadAll(opts.ToURLs, schemafile.Options{Dialect: dialect})
+	if err != nil {
+		return DiffResult{}, fmt.Errorf("load --to schema: %w", err)
+	}
+	diff := schemadiff.CompareWithDialect(desired, current, dialect)
+	if !diff.HasChanges() {
+		return DiffResult{Synced: true}, nil
+	}
+
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, desired, dialect)
+	if err != nil {
+		return DiffResult{}, fmt.Errorf("generate migration SQL: %w", err)
+	}
+	path, err := writeMigrationFile(opts.Dir, opts.Name, atlasschema.FormatMigrationSQL(statements))
+	if err != nil {
+		return DiffResult{}, err
+	}
+	sumPath := filepath.Join(opts.Dir, migratesum.AtlasFileName)
+	if _, err := migratesum.WriteWithFormat(opts.Dir, migrator.MigrationDirFormatAtlas); err != nil {
+		_ = os.Remove(path)
+		return DiffResult{}, fmt.Errorf("write atlas.sum: %w", err)
+	}
+	return DiffResult{MigrationPath: path, SumPath: sumPath}, nil
+}
+
+type dirLock struct {
+	path string
+	file *os.File
+}
+
+func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Duration) (*dirLock, error) {
+	lockPath := filepath.Join(migrationsDir, lockFileName)
+	startedAt := time.Now()
+	for {
+		lock, err := tryAcquireDirLock(lockPath)
+		if err == nil {
+			return lock, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		if timeout > 0 && time.Since(startedAt) >= timeout {
+			return nil, fmt.Errorf("migration directory lock timeout after %s: %s", timeout, lockPath)
+		}
+		if err := waitForDirLockRetry(ctx, startedAt, timeout); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func tryAcquireDirLock(lockPath string) (*dirLock, error) {
+	file, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("create migration directory lock: %w", err)
+	}
+	if _, err := fmt.Fprintf(file, "pid=%d\n", os.Getpid()); err != nil {
+		_ = file.Close()
+		_ = os.Remove(lockPath)
+		return nil, fmt.Errorf("write migration directory lock: %w", err)
+	}
+	return &dirLock{path: lockPath, file: file}, nil
+}
+
+func waitForDirLockRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
+	wait := 25 * time.Millisecond
+	if timeout > 0 {
+		remaining := timeout - time.Since(startedAt)
+		if remaining <= 0 {
+			return nil
+		}
+		wait = min(wait, remaining)
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("acquire migration directory lock: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (l *dirLock) release() error {
+	if l == nil {
+		return nil
+	}
+	closeErr := l.file.Close()
+	removeErr := os.Remove(l.path)
+	if closeErr != nil && removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("release migration directory lock: %w", errors.Join(closeErr, removeErr))
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close migration directory lock: %w", closeErr)
+	}
+	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("remove migration directory lock: %w", removeErr)
+	}
+	return nil
+}
+
+func verifyDirSum(migrationsDir string) error {
+	result, err := migratesum.VerifyDirWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	if errors.Is(err, migratesum.ErrSumFileMissing) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("migration directory checksum verification failed: %w", err)
+	}
+	if !result.OK() {
+		return fmt.Errorf("migration directory checksum verification failed:\n%s", result.Describe())
+	}
+	return nil
+}
+
+func replayDir(ctx context.Context, conn *dbschema.DatabaseConnection, migrationsDir string) error {
+	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+		return fmt.Errorf("clean dev database: %w", err)
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		os.DirFS(migrationsDir),
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	if err != nil {
+		return fmt.Errorf("load migration directory: %w", err)
+	}
+	for _, migration := range provider.Migrations() {
+		if err := migration.Up(ctx, conn); err != nil {
+			return fmt.Errorf("replay migration %d on --dev-url: %w", migration.Version, err)
+		}
+	}
+	return nil
+}
+
+func withoutRevisionTable(schema *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	if schema == nil {
+		return &dbschematypes.DBSchema{}
+	}
+	out := *schema
+	out.Tables = filterByTable(out.Tables, func(table dbschematypes.DBTable) bool {
+		return !strings.EqualFold(table.Name, revisionTableName)
+	})
+	out.Indexes = filterByTable(out.Indexes, func(index dbschematypes.DBIndex) bool {
+		return !strings.EqualFold(index.TableName, revisionTableName)
+	})
+	out.Constraints = filterByTable(out.Constraints, func(constraint dbschematypes.DBConstraint) bool {
+		return !strings.EqualFold(constraint.TableName, revisionTableName)
+	})
+	return &out
+}
+
+func filterByTable[T any](values []T, keep func(T) bool) []T {
+	out := make([]T, 0, len(values))
+	for _, value := range values {
+		if keep(value) {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func writeMigrationFile(dir, name, sql string) (string, error) {
+	if strings.TrimSpace(sql) == "" {
+		return "", fmt.Errorf("migration SQL is empty")
+	}
+	version, err := nextMigrationVersion(dir)
+	if err != nil {
+		return "", err
+	}
+	slug := migrationSlug(name)
+	for {
+		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", version, slug))
+		err := writeNewMigrationFile(path, sql)
+		if err == nil {
+			return path, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return "", fmt.Errorf("write migration file: %w", err)
+		}
+		version++
+	}
+}
+
+func writeNewMigrationFile(path, sql string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := file.WriteString(sql); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("write migration SQL: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("close migration file: %w", err)
+	}
+	return nil
+}
+
+func nextMigrationVersion(dir string) (int64, error) {
+	files, err := migrator.DiscoverMigrationFiles(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		return 0, err
+	}
+	version := migrator.GetNextMigrationVersion()
+	for _, file := range files {
+		if file.Version >= version {
+			version = file.Version + 1
+		}
+	}
+	return version, nil
+}
+
+var migrationSlugInvalidChars = regexp.MustCompile(`[^a-z0-9_]+`)
+
+func migrationSlug(name string) string {
+	slug := strings.ToLower(strings.TrimSpace(name))
+	slug = strings.ReplaceAll(slug, "-", "_")
+	slug = strings.ReplaceAll(slug, " ", "_")
+	slug = migrationSlugInvalidChars.ReplaceAllString(slug, "")
+	slug = strings.Trim(slug, "_")
+	if slug == "" {
+		return "migration"
+	}
+	return slug
+}

--- a/internal/atlasmigrate/diff_test.go
+++ b/internal/atlasmigrate/diff_test.go
@@ -1,0 +1,250 @@
+package atlasmigrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestGenerateDiff_HappyPathCreatesAtlasMigrationFromLocalSchema(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL DEFAULT ''
+);
+`), 0o600), qt.IsNil)
+
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      []string{"file://" + schemaPath},
+		Name:        "add_email",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Synced, qt.IsFalse)
+	c.Assert(result.MigrationPath, qt.Contains, "_add_email.sql")
+	c.Assert(result.SumPath, qt.Equals, filepath.Join(migrationsDir, "atlas.sum"))
+	migrationFiles := atlasSQLFiles(c, migrationsDir)
+	c.Assert(migrationFiles, qt.HasLen, 2)
+	newSQL, err := os.ReadFile(result.MigrationPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(newSQL), qt.Contains, "ADD COLUMN")
+	c.Assert(string(newSQL), qt.Contains, "email")
+	sum, err := os.ReadFile(result.SumPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, filepath.Base(result.MigrationPath))
+}
+
+func TestGenerateDiff_SyncedReturnsNoChange(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      []string{"file://" + schemaPath},
+		Name:        "noop",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Synced, qt.IsTrue)
+	c.Assert(result.MigrationPath, qt.Equals, "")
+	c.Assert(result.SumPath, qt.Equals, "")
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
+}
+
+func TestGenerateDiff_RejectsChecksumDrift(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+`), 0o600), qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL DEFAULT ''
+);
+`), 0o600), qt.IsNil)
+
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      []string{"file://" + schemaPath},
+		Name:        "add_email",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `(?s)migration directory checksum verification failed:.*migration directory does not match atlas\.sum:.*changed: 1_init\.sql.*`)
+	c.Assert(result.Synced, qt.IsFalse)
+	c.Assert(result.MigrationPath, qt.Equals, "")
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
+}
+
+func TestGenerateDiff_LockTimeout(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"), []byte("held\n"), 0o600), qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE locked_diff (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      []string{"file://" + schemaPath},
+		Name:        "locked_diff",
+		LockTimeout: time.Millisecond,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `migration directory lock timeout after 1ms: .*\.ptah-migrate-diff\.lock`)
+	c.Assert(result.Synced, qt.IsFalse)
+	c.Assert(result.MigrationPath, qt.Equals, "")
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 0)
+}
+
+func TestGenerateDiff_ReleasesLockAfterError(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		ToURLs:      []string{"file://" + filepath.Join(dir, "missing.sql")},
+		Name:        "missing_schema",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `load --to schema: .*`)
+	c.Assert(result.Synced, qt.IsFalse)
+	c.Assert(fileExists(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock")), qt.IsFalse)
+}
+
+func TestGenerateDiff_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil dev database connection", func(c *qt.C) {
+		result, err := atlasmigrate.GenerateDiff(context.Background(), nil, atlasmigrate.DiffOptions{
+			Dir:    c.TempDir(),
+			ToURLs: []string{"file://schema.sql"},
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate diff requires dev database connection")
+		c.Assert(result.Synced, qt.IsFalse)
+	})
+
+	c.Run("missing migration directory", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "dev.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+			ToURLs: []string{"file://schema.sql"},
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate diff requires migration directory")
+		c.Assert(result.Synced, qt.IsFalse)
+	})
+
+	c.Run("missing desired schema URLs", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "dev.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+			Dir: c.TempDir(),
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate diff requires desired schema URLs")
+		c.Assert(result.Synced, qt.IsFalse)
+	})
+}
+
+func connectSQLite(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	return conn
+}
+
+func atlasSQLFiles(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		files = append(files, filepath.Join(dir, name))
+	}
+	files = slices.DeleteFunc(files, func(path string) bool {
+		return !strings.HasSuffix(path, ".sql")
+	})
+	slices.Sort(files)
+	return files
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}


### PR DESCRIPTION
## Summary

Part of #540.

This moves the Atlas `migrate diff` runtime out of `cmd/atlas` into `internal/atlasmigrate`, keeping the command layer responsible for Cobra flags, CLI-only validation, local `file://` path adaptation, dev DB connection setup, and stdout text.

Changes:

- add `internal/atlasmigrate.GenerateDiff`
- move migration directory creation, lock handling, checksum verification, dev DB replay, Atlas revision-table filtering, schema diff planning, migration file writing, and `atlas.sum` update into the package runtime
- leave `cmd/atlas/migrate_diff.go` as a thin adapter around `atlasmigrate.GenerateDiff`
- add black-box package tests for happy path, synced no-op, checksum drift, lock timeout, lock release after runtime error, and package boundary validation
- keep command-level regression coverage for CLI output and adapter validation

Docs impact: internal refactor only; no user-facing command semantics changed.

## Self-review

Pass 1:

- verified old migrate-diff runtime helpers are gone from `cmd/atlas`
- adjusted the package boundary after read-only agent review: `internal/atlasmigrate` instead of a subcommand-specific package, leaving room for `migrate apply`
- kept `atlasLocalDirValue`, `pathguard.ResolveCLIPath`, `dbcli.ConnectContext`, `cmdutil.Fail`, and unsupported flag checks in `cmd/atlas`

Pass 2:

- renamed generic package API types to `DiffOptions` / `DiffResult` so later migrate APIs do not collide
- removed the remaining command-side directory creation because it belongs to runtime
- added lock-release-after-error coverage and removed conditional branching from the new test file
- confirmed documentation impact is internal-only

## Validation

```bash
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./internal/atlasmigrate ./cmd/atlas
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...
```

`gopls go_diagnostics` was attempted for the changed files, but this linked worktree still reports `no package metadata for file .../internal/atlasmigrate/diff_test.go`; compiler, qtlint, golangci-lint, and the full test suite passed.
