### PR TITLE
Refactor Atlas migrate apply runtime out of cmd

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -3,17 +3,15 @@ package atlas
 import (
 	"fmt"
 	"io"
-	"io/fs"
-	"log/slog"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -142,171 +140,72 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
-	conn.SchemaWriter().SetDryRun(opts.dryRun)
 
-	mig, err := newAtlasApplyMigrator(conn, os.DirFS(dir), atlasApplyMigratorOptions{
-		execOrder:            execOrder,
-		txMode:               txMode,
-		revisionsSchema:      opts.revisionsSchema,
-		migrationLockName:    opts.lockName,
-		migrationLockTimeout: migrationLockTimeout,
+	plan, err := atlasmigrate.PrepareApply(cmd.Context(), conn, atlasmigrate.ApplyOptions{
+		Dir:                  dir,
+		DryRun:               opts.dryRun,
+		ExecOrder:            execOrder,
+		TxMode:               txMode,
+		RevisionsSchema:      opts.revisionsSchema,
+		MigrationLockName:    opts.lockName,
+		MigrationLockTimeout: migrationLockTimeout,
+		Amount:               amount,
+		ToVersion:            toVersion,
+		AllowDirty:           opts.allowDirty,
+		BaselineVersion:      baselineVersion,
 	})
 	if err != nil {
 		return err
 	}
 
 	out := cmd.OutOrStdout()
-	startedAt := time.Now()
 	if opts.dryRun && !formatOutput {
 		fmt.Fprintln(out, "Dry run mode: no changes will be made.")
 	}
-	var assumedAppliedVersions []int64
-	if baselineVersion > 0 {
-		if opts.dryRun {
-			assumedAppliedVersions, err = atlasApplyBaselineVersions(mig, baselineVersion)
-			if err != nil {
-				return err
-			}
-			if !formatOutput {
-				fmt.Fprintf(out, "Would baseline migrations at version %d.\n", baselineVersion)
-			}
-		} else if err := mig.BaselineWithOptions(cmd.Context(), migrator.BaselineOptions{Version: baselineVersion}); err != nil {
-			return fmt.Errorf("error baselining migrations: %w", err)
+	if opts.dryRun && baselineVersion > 0 && !formatOutput {
+		fmt.Fprintf(out, "Would baseline migrations at version %d.\n", baselineVersion)
+	}
+	if plan.Noop() {
+		result, err := plan.Execute(cmd.Context())
+		if err != nil {
+			return err
 		}
-	}
-
-	status, err := mig.GetMigrationStatus(cmd.Context())
-	if err != nil {
-		return fmt.Errorf("error getting migration status: %w", err)
-	}
-	plannedCurrentVersion := statusCurrentAfterAssumedApplied(status.CurrentVersion, assumedAppliedVersions)
-	pending := status.PendingMigrations
-	if len(assumedAppliedVersions) > 0 {
-		pending = pendingAfterAssumedApplied(status.PendingMigrations, assumedAppliedVersions)
-	}
-	selected := selectedAtlasApplyVersions(pending, amount, toVersion)
-	if len(selected) == 0 && status.DirtyRevision == nil {
 		if formatOutput {
-			return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
-				Conn:             conn,
-				FS:               os.DirFS(dir),
-				Dir:              opts.dir,
-				URL:              opts.url,
-				Status:           status,
-				Migrations:       mig.MigrationProvider().Migrations(),
-				SelectedVersions: selected,
-				CurrentVersion:   plannedCurrentVersion,
-				Applied:          false,
-				StartedAt:        startedAt,
-				EndedAt:          time.Now(),
-			})
+			return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
 		}
 		fmt.Fprintln(out, "No migration files to execute.")
 		return nil
 	}
-	if len(selected) > 0 && !formatOutput {
-		fmt.Fprintf(out, "Migrating to version %d from %d pending migrations.\n", selected[len(selected)-1], len(selected))
+	if len(plan.SelectedVersions) > 0 && !formatOutput {
+		fmt.Fprintf(out, "Migrating to version %d from %d pending migrations.\n",
+			plan.SelectedVersions[len(plan.SelectedVersions)-1],
+			len(plan.SelectedVersions),
+		)
 	}
 
-	if err := mig.MigrateUpWithOptions(cmd.Context(), migrator.MigrateUpOptions{
-		TargetVersion:          toVersion,
-		Amount:                 amount,
-		AllowDirty:             opts.allowDirty,
-		AssumedAppliedVersions: assumedAppliedVersions,
-	}); err != nil {
-		if formatOutput {
-			writeErr := atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
-				Conn:             conn,
-				FS:               os.DirFS(dir),
-				Dir:              opts.dir,
-				URL:              opts.url,
-				Status:           status,
-				Migrations:       mig.MigrationProvider().Migrations(),
-				SelectedVersions: selected,
-				CurrentVersion:   plannedCurrentVersion,
-				ErrorText:        err.Error(),
-				ApplyError:       err,
-				Applied:          true,
-				StartedAt:        startedAt,
-				EndedAt:          time.Now(),
-			})
+	result, err := plan.Execute(cmd.Context())
+	if err != nil {
+		if formatOutput && result.ApplyError != nil {
+			writeErr := writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
 			if writeErr != nil {
-				return fmt.Errorf("error applying migrations: %w; additionally failed to write --format output: %v", err, writeErr)
+				return fmt.Errorf("%w; additionally failed to write --format output: %v", err, writeErr)
 			}
 		}
-		return fmt.Errorf("error applying migrations: %w", err)
+		return err
 	}
 
 	if opts.dryRun {
 		if formatOutput {
-			return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
-				Conn:             conn,
-				FS:               os.DirFS(dir),
-				Dir:              opts.dir,
-				URL:              opts.url,
-				Status:           status,
-				Migrations:       mig.MigrationProvider().Migrations(),
-				SelectedVersions: selected,
-				CurrentVersion:   plannedCurrentVersion,
-				Applied:          false,
-				StartedAt:        startedAt,
-				EndedAt:          time.Now(),
-			})
+			return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
 		}
-		fmt.Fprintf(out, "Would have applied %d migrations.\n", len(selected))
+		fmt.Fprintf(out, "Would have applied %d migrations.\n", len(plan.SelectedVersions))
 		return nil
 	}
-	finalStatus, err := mig.GetMigrationStatus(cmd.Context())
-	if err != nil {
-		return fmt.Errorf("error getting final migration status: %w", err)
-	}
 	if formatOutput {
-		return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
-			Conn:             conn,
-			FS:               os.DirFS(dir),
-			Dir:              opts.dir,
-			URL:              opts.url,
-			Status:           status,
-			Migrations:       mig.MigrationProvider().Migrations(),
-			SelectedVersions: selected,
-			CurrentVersion:   plannedCurrentVersion,
-			Applied:          true,
-			StartedAt:        startedAt,
-			EndedAt:          time.Now(),
-		})
+		return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
 	}
-	fmt.Fprintf(out, "Migration complete. Current version: %d\n", finalStatus.CurrentVersion)
+	fmt.Fprintf(out, "Migration complete. Current version: %d\n", result.FinalStatus.CurrentVersion)
 	return nil
-}
-
-type atlasApplyMigratorOptions struct {
-	execOrder            migrator.ExecOrder
-	txMode               migrator.MigrationTxMode
-	revisionsSchema      string
-	migrationLockName    string
-	migrationLockTimeout time.Duration
-}
-
-func newAtlasApplyMigrator(
-	conn *dbschema.DatabaseConnection,
-	fsys fs.FS,
-	opts atlasApplyMigratorOptions,
-) (*migrator.Migrator, error) {
-	mig, err := migrator.NewFSMigrator(
-		conn,
-		fsys,
-		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error registering migrations: %w", err)
-	}
-	return mig.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
-		WithMigrationsTable(opts.revisionsSchema, "").
-		WithExecOrder(opts.execOrder).
-		WithTransactionMode(opts.txMode).
-		WithMigrationLockName(opts.migrationLockName).
-		WithMigrationLockTimeout(opts.migrationLockTimeout).
-		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))), nil
 }
 
 func parseAtlasMigrateApplyAmount(args []string) (uint64, error) {
@@ -335,52 +234,26 @@ func parseAtlasMigrationVersionFlag(name, value string) (int64, error) {
 	return parsed, nil
 }
 
-func atlasApplyBaselineVersions(mig *migrator.Migrator, baselineVersion int64) ([]int64, error) {
-	versions := make([]int64, 0)
-	for _, migration := range mig.MigrationProvider().Migrations() {
-		if migration.Version <= baselineVersion {
-			versions = append(versions, migration.Version)
-		}
-	}
-	if len(versions) == 0 {
-		return nil, fmt.Errorf("no migrations found at or below baseline version %d", baselineVersion)
-	}
-	return versions, nil
-}
-
-func pendingAfterAssumedApplied(pending []int64, assumedApplied []int64) []int64 {
-	assumed := make(map[int64]struct{}, len(assumedApplied))
-	for _, version := range assumedApplied {
-		assumed[version] = struct{}{}
-	}
-	filtered := make([]int64, 0, len(pending))
-	for _, version := range pending {
-		if _, ok := assumed[version]; !ok {
-			filtered = append(filtered, version)
-		}
-	}
-	return filtered
-}
-
-func selectedAtlasApplyVersions(pending []int64, amount uint64, toVersion int64) []int64 {
-	selected := make([]int64, 0, len(pending))
-	for _, version := range pending {
-		if toVersion > 0 && version > toVersion {
-			continue
-		}
-		selected = append(selected, version)
-		if amount > 0 && uint64(len(selected)) == amount {
-			break
-		}
-	}
-	return selected
-}
-
-func statusCurrentAfterAssumedApplied(current int64, assumedApplied []int64) int64 {
-	for _, version := range assumedApplied {
-		if version > current {
-			current = version
-		}
-	}
-	return current
+func writeAtlasMigrateApplyFormat(
+	out io.Writer,
+	opts atlasMigrateApplyOptions,
+	resolvedDir string,
+	conn *dbschema.DatabaseConnection,
+	result atlasmigrate.ApplyResult,
+) error {
+	return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
+		Conn:             conn,
+		FS:               os.DirFS(resolvedDir),
+		Dir:              opts.dir,
+		URL:              opts.url,
+		Status:           result.Status,
+		Migrations:       result.Migrations,
+		SelectedVersions: result.SelectedVersions,
+		CurrentVersion:   result.CurrentVersion,
+		ErrorText:        result.ErrorText,
+		ApplyError:       result.ApplyError,
+		Applied:          result.Applied,
+		StartedAt:        result.StartedAt,
+		EndedAt:          result.EndedAt,
+	})
 }

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -1,0 +1,259 @@
+package atlasmigrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+type ApplyOptions struct {
+	Dir                  string
+	DryRun               bool
+	ExecOrder            migrator.ExecOrder
+	TxMode               migrator.MigrationTxMode
+	RevisionsSchema      string
+	MigrationLockName    string
+	MigrationLockTimeout time.Duration
+	Amount               uint64
+	ToVersion            int64
+	AllowDirty           bool
+	BaselineVersion      int64
+}
+
+// ApplyPlan is the selected Atlas migrate apply work prepared from the
+// migration directory and current revision state.
+type ApplyPlan struct {
+	Status           *migrator.MigrationStatus
+	Migrations       []*migrator.Migration
+	SelectedVersions []int64
+	CurrentVersion   int64
+	DryRun           bool
+	StartedAt        time.Time
+
+	mig  *migrator.Migrator
+	opts ApplyOptions
+}
+
+// ApplyResult contains execution metadata needed by CLI output and Atlas
+// template rendering.
+type ApplyResult struct {
+	Status           *migrator.MigrationStatus
+	FinalStatus      *migrator.MigrationStatus
+	Migrations       []*migrator.Migration
+	SelectedVersions []int64
+	CurrentVersion   int64
+	Applied          bool
+	DryRun           bool
+	StartedAt        time.Time
+	EndedAt          time.Time
+	ErrorText        string
+	ApplyError       error
+}
+
+// PrepareApply builds the Atlas-format migrator, applies real baseline
+// metadata when requested, and selects the pending migrations to execute.
+func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts ApplyOptions) (ApplyPlan, error) {
+	if err := validateApplyOptions(conn, opts); err != nil {
+		return ApplyPlan{}, err
+	}
+	startedAt := time.Now()
+
+	conn.SchemaWriter().SetDryRun(opts.DryRun)
+	mig, err := newApplyMigrator(conn, os.DirFS(opts.Dir), applyMigratorOptions{
+		execOrder:            opts.ExecOrder,
+		txMode:               opts.TxMode,
+		revisionsSchema:      opts.RevisionsSchema,
+		migrationLockName:    opts.MigrationLockName,
+		migrationLockTimeout: opts.MigrationLockTimeout,
+	})
+	if err != nil {
+		return ApplyPlan{}, err
+	}
+
+	var assumedAppliedVersions []int64
+	if opts.BaselineVersion > 0 {
+		if opts.DryRun {
+			assumedAppliedVersions, err = applyBaselineVersions(mig, opts.BaselineVersion)
+			if err != nil {
+				return ApplyPlan{}, err
+			}
+		} else if err := mig.BaselineWithOptions(ctx, migrator.BaselineOptions{Version: opts.BaselineVersion}); err != nil {
+			return ApplyPlan{}, fmt.Errorf("error baselining migrations: %w", err)
+		}
+	}
+
+	status, err := mig.GetMigrationStatus(ctx)
+	if err != nil {
+		return ApplyPlan{}, fmt.Errorf("error getting migration status: %w", err)
+	}
+	plannedCurrentVersion := statusCurrentAfterAssumedApplied(status.CurrentVersion, assumedAppliedVersions)
+	pending := status.PendingMigrations
+	if len(assumedAppliedVersions) > 0 {
+		pending = pendingAfterAssumedApplied(status.PendingMigrations, assumedAppliedVersions)
+	}
+
+	return ApplyPlan{
+		Status:           status,
+		Migrations:       mig.MigrationProvider().Migrations(),
+		SelectedVersions: selectedApplyVersions(pending, opts.Amount, opts.ToVersion),
+		CurrentVersion:   plannedCurrentVersion,
+		DryRun:           opts.DryRun,
+		StartedAt:        startedAt,
+		mig:              mig,
+		opts:             opts,
+	}, nil
+}
+
+// Noop reports whether the selected plan has no migrations to execute and no
+// dirty revision requiring recovery.
+func (p ApplyPlan) Noop() bool {
+	return len(p.SelectedVersions) == 0 && p.Status != nil && p.Status.DirtyRevision == nil
+}
+
+// Execute applies the selected plan. Dry-run and no-op plans return metadata
+// without modifying schema state.
+func (p ApplyPlan) Execute(ctx context.Context) (ApplyResult, error) {
+	result := ApplyResult{
+		Status:           p.Status,
+		Migrations:       p.Migrations,
+		SelectedVersions: p.SelectedVersions,
+		CurrentVersion:   p.CurrentVersion,
+		DryRun:           p.DryRun,
+		StartedAt:        p.StartedAt,
+	}
+	if p.Noop() || p.opts.DryRun {
+		result.EndedAt = time.Now()
+		return result, nil
+	}
+
+	err := p.mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
+		TargetVersion: p.opts.ToVersion,
+		Amount:        p.opts.Amount,
+		AllowDirty:    p.opts.AllowDirty,
+	})
+	result.EndedAt = time.Now()
+	if err != nil {
+		result.Applied = true
+		result.ApplyError = err
+		result.ErrorText = err.Error()
+		return result, fmt.Errorf("error applying migrations: %w", err)
+	}
+
+	finalStatus, err := p.mig.GetMigrationStatus(ctx)
+	if err != nil {
+		result.Applied = true
+		result.ErrorText = err.Error()
+		return result, fmt.Errorf("error getting final migration status: %w", err)
+	}
+	result.FinalStatus = finalStatus
+	result.Applied = true
+	return result, nil
+}
+
+func validateApplyOptions(conn *dbschema.DatabaseConnection, opts ApplyOptions) error {
+	if conn == nil {
+		return errors.New("migrate apply requires database connection")
+	}
+	if strings.TrimSpace(opts.Dir) == "" {
+		return errors.New("migrate apply requires migration directory")
+	}
+	if opts.Amount > 0 && opts.ToVersion > 0 {
+		return errors.New("amount argument and --to-version cannot both be set")
+	}
+	if opts.ToVersion < 0 {
+		return errors.New("migrate apply target version must be greater than or equal to zero")
+	}
+	if opts.BaselineVersion < 0 {
+		return errors.New("migrate apply baseline version must be greater than or equal to zero")
+	}
+	return nil
+}
+
+type applyMigratorOptions struct {
+	execOrder            migrator.ExecOrder
+	txMode               migrator.MigrationTxMode
+	revisionsSchema      string
+	migrationLockName    string
+	migrationLockTimeout time.Duration
+}
+
+func newApplyMigrator(
+	conn *dbschema.DatabaseConnection,
+	fsys fs.FS,
+	opts applyMigratorOptions,
+) (*migrator.Migrator, error) {
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error registering migrations: %w", err)
+	}
+	return mig.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithMigrationsTable(opts.revisionsSchema, "").
+		WithExecOrder(opts.execOrder).
+		WithTransactionMode(opts.txMode).
+		WithMigrationLockName(opts.migrationLockName).
+		WithMigrationLockTimeout(opts.migrationLockTimeout).
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))), nil
+}
+
+func applyBaselineVersions(mig *migrator.Migrator, baselineVersion int64) ([]int64, error) {
+	versions := make([]int64, 0)
+	for _, migration := range mig.MigrationProvider().Migrations() {
+		if migration.Version <= baselineVersion {
+			versions = append(versions, migration.Version)
+		}
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no migrations found at or below baseline version %d", baselineVersion)
+	}
+	return versions, nil
+}
+
+func pendingAfterAssumedApplied(pending []int64, assumedApplied []int64) []int64 {
+	assumed := make(map[int64]struct{}, len(assumedApplied))
+	for _, version := range assumedApplied {
+		assumed[version] = struct{}{}
+	}
+	filtered := make([]int64, 0, len(pending))
+	for _, version := range pending {
+		if _, ok := assumed[version]; !ok {
+			filtered = append(filtered, version)
+		}
+	}
+	return filtered
+}
+
+func selectedApplyVersions(pending []int64, amount uint64, toVersion int64) []int64 {
+	selected := make([]int64, 0, len(pending))
+	for _, version := range pending {
+		if toVersion > 0 && version > toVersion {
+			continue
+		}
+		selected = append(selected, version)
+		if amount > 0 && uint64(len(selected)) == amount {
+			break
+		}
+	}
+	return selected
+}
+
+func statusCurrentAfterAssumedApplied(current int64, assumedApplied []int64) int64 {
+	for _, version := range assumedApplied {
+		if version > current {
+			current = version
+		}
+	}
+	return current
+}

--- a/internal/atlasmigrate/apply_test.go
+++ b/internal/atlasmigrate/apply_test.go
@@ -1,0 +1,277 @@
+package atlasmigrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestPrepareApplyExecute_HappyPathAppliesSelectedAmount(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE apply_amount_one (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_two.sql", "CREATE TABLE apply_amount_two (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "3_three.sql", "CREATE TABLE apply_amount_three (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "apply.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+		Amount:    2,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.SelectedVersions, qt.DeepEquals, []int64{1, 2})
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsTrue)
+	c.Assert(result.SelectedVersions, qt.DeepEquals, []int64{1, 2})
+	c.Assert(result.FinalStatus.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(sqliteTableExists(c, conn, "apply_amount_one"), qt.IsTrue)
+	c.Assert(sqliteTableExists(c, conn, "apply_amount_two"), qt.IsTrue)
+	c.Assert(sqliteTableExists(c, conn, "apply_amount_three"), qt.IsFalse)
+}
+
+func TestPrepareApplyExecute_BaselineRecordsAtlasRevisions(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE baseline_one (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_two.sql", "CREATE TABLE baseline_two (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "3_three.sql", "CREATE TABLE baseline_three (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "baseline.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:             migrationsDir,
+		ExecOrder:       migrator.ExecOrderLinear,
+		TxMode:          migrator.MigrationTxModeFile,
+		BaselineVersion: 2,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(plan.SelectedVersions, qt.DeepEquals, []int64{3})
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsTrue)
+	c.Assert(result.FinalStatus.CurrentVersion, qt.Equals, int64(3))
+	c.Assert(sqliteTableExists(c, conn, "baseline_one"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, conn, "baseline_two"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, conn, "baseline_three"), qt.IsTrue)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2", "3"})
+}
+
+func TestPrepareApplyExecute_DryRunBaselinePlansRemaining(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE dry_baseline_one (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_two.sql", "CREATE TABLE dry_baseline_two (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "3_three.sql", "CREATE TABLE dry_baseline_three (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dry-baseline.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:             migrationsDir,
+		DryRun:          true,
+		ExecOrder:       migrator.ExecOrderLinear,
+		TxMode:          migrator.MigrationTxModeFile,
+		BaselineVersion: 2,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(plan.SelectedVersions, qt.DeepEquals, []int64{3})
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsFalse)
+	c.Assert(result.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(result.SelectedVersions, qt.DeepEquals, []int64{3})
+	c.Assert(sqliteTableExists(c, conn, "dry_baseline_one"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, conn, "dry_baseline_two"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, conn, "dry_baseline_three"), qt.IsFalse)
+}
+
+func TestPrepareApplyExecute_NoopReturnsResult(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_noop.sql", "CREATE TABLE apply_noop (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "noop.db"))
+	defer dbschema.CloseAndWarn(conn)
+	firstPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = firstPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.Noop(), qt.IsTrue)
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsFalse)
+	c.Assert(result.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(result.SelectedVersions, qt.HasLen, 0)
+}
+
+func TestPrepareApplyExecute_ReturnsPlannedResultOnApplyError(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_error.sql", "CREATE TABLE apply_error_before (id INTEGER PRIMARY KEY); SELECT * FROM missing_table;")
+	conn := connectSQLite(c, filepath.Join(dir, "error.db"))
+	defer dbschema.CloseAndWarn(conn)
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.ErrorMatches, `(?s)error applying migrations: .*missing_table.*`)
+	c.Assert(result.Applied, qt.IsTrue)
+	c.Assert(result.ApplyError, qt.IsNotNil)
+	c.Assert(result.ErrorText, qt.Contains, "missing_table")
+	c.Assert(result.SelectedVersions, qt.DeepEquals, []int64{1})
+	c.Assert(result.Status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(result.EndedAt.IsZero(), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, conn, "apply_error_before"), qt.IsFalse)
+}
+
+func TestPrepareApply_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil database connection", func(c *qt.C) {
+		plan, err := atlasmigrate.PrepareApply(context.Background(), nil, atlasmigrate.ApplyOptions{
+			Dir: c.TempDir(),
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate apply requires database connection")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+
+	c.Run("missing migration directory", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "missing-dir.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasmigrate.PrepareApply(context.Background(), conn, atlasmigrate.ApplyOptions{})
+		c.Assert(err, qt.ErrorMatches, "migrate apply requires migration directory")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+
+	c.Run("ambiguous target", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "ambiguous.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasmigrate.PrepareApply(context.Background(), conn, atlasmigrate.ApplyOptions{
+			Dir:       c.TempDir(),
+			Amount:    1,
+			ToVersion: 1,
+		})
+		c.Assert(err, qt.ErrorMatches, "amount argument and --to-version cannot both be set")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+
+	c.Run("negative target version", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "negative-target.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasmigrate.PrepareApply(context.Background(), conn, atlasmigrate.ApplyOptions{
+			Dir:       c.TempDir(),
+			ToVersion: -1,
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate apply target version must be greater than or equal to zero")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+
+	c.Run("negative baseline version", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "negative-baseline.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasmigrate.PrepareApply(context.Background(), conn, atlasmigrate.ApplyOptions{
+			Dir:             c.TempDir(),
+			BaselineVersion: -1,
+		})
+		c.Assert(err, qt.ErrorMatches, "migrate apply baseline version must be greater than or equal to zero")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+
+	c.Run("dry-run baseline without matching migrations", func(c *qt.C) {
+		dir := c.TempDir()
+		migrationsDir := filepath.Join(dir, "migrations")
+		writeAtlasApplyMigrationFile(c, migrationsDir, "3_three.sql", "CREATE TABLE missing_baseline_three (id INTEGER PRIMARY KEY);")
+		conn := connectSQLite(c, filepath.Join(dir, "missing-baseline.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasmigrate.PrepareApply(context.Background(), conn, atlasmigrate.ApplyOptions{
+			Dir:             migrationsDir,
+			DryRun:          true,
+			BaselineVersion: 2,
+		})
+		c.Assert(err, qt.ErrorMatches, "no migrations found at or below baseline version 2")
+		c.Assert(plan.SelectedVersions, qt.HasLen, 0)
+	})
+}
+
+func writeAtlasApplyMigrationFile(c *qt.C, dir, name, sql string) {
+	c.Helper()
+	c.Assert(os.MkdirAll(dir, 0755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(sql), 0o600), qt.IsNil)
+}
+
+func sqliteTableExists(c *qt.C, conn *dbschema.DatabaseConnection, table string) bool {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		table,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count == 1
+}
+
+func sqliteAtlasRevisionVersions(c *qt.C, conn *dbschema.DatabaseConnection) []string {
+	c.Helper()
+	rows, err := conn.QueryContext(context.Background(), `SELECT version FROM atlas_schema_revisions ORDER BY CAST(version AS INTEGER)`)
+	c.Assert(err, qt.IsNil)
+	defer rows.Close()
+	versions := make([]string, 0)
+	for rows.Next() {
+		var version string
+		c.Assert(rows.Scan(&version), qt.IsNil)
+		versions = append(versions, version)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return versions
+}


### PR DESCRIPTION
## Summary
- move reusable Atlas migrate apply planning/execution into internal/atlasmigrate
- keep cmd/atlas as CLI validation, path/url resolution, output, and format wiring
- add black-box package tests for amount selection, baseline, dry-run baseline, no-op, apply error, and validation failures

Refs #540

## Self-review
- Pass 1: checked command/runtime boundaries, removed stale cmd helpers, and fixed double-prefix error wrapping in the --format apply-error path.
- Pass 2: checked error-state behavior, preserved the old no-format-on-final-status-error contract, and marked post-apply final-status failures honestly in ApplyResult.
- External reviewer pass: addressed the final-status error-path finding before opening the PR.

## Validation
- ok  	github.com/stokaro/ptah/internal/atlasmigrate	0.533s
ok  	github.com/stokaro/ptah/cmd/atlas	0.934s
- ok  	github.com/stokaro/ptah/internal/atlasmigrate	(cached)
ok  	github.com/stokaro/ptah/cmd/atlas	(cached)
- 
- 0 issues.
- ok  	github.com/stokaro/ptah/atlascompat	0.317s
?   	github.com/stokaro/ptah/cmd	[no test files]
ok  	github.com/stokaro/ptah/cmd/atlas	0.500s
ok  	github.com/stokaro/ptah/cmd/compare	1.041s
ok  	github.com/stokaro/ptah/cmd/db	0.745s
ok  	github.com/stokaro/ptah/cmd/drift	1.349s
ok  	github.com/stokaro/ptah/cmd/dropall	1.576s
ok  	github.com/stokaro/ptah/cmd/generate	2.074s
ok  	github.com/stokaro/ptah/cmd/integration-test	2.005s
ok  	github.com/stokaro/ptah/cmd/internal/buildinfo	2.104s
ok  	github.com/stokaro/ptah/cmd/internal/cliobs	2.192s
ok  	github.com/stokaro/ptah/cmd/internal/cmdadapter	2.303s
ok  	github.com/stokaro/ptah/cmd/internal/cmdflags	2.439s
ok  	github.com/stokaro/ptah/cmd/internal/cmdutil	2.603s
ok  	github.com/stokaro/ptah/cmd/internal/dbcli	2.688s
ok  	github.com/stokaro/ptah/cmd/internal/exitcode	2.552s
ok  	github.com/stokaro/ptah/cmd/internal/schemaops	2.573s
ok  	github.com/stokaro/ptah/cmd/introspect	2.582s
ok  	github.com/stokaro/ptah/cmd/lint	2.409s
ok  	github.com/stokaro/ptah/cmd/migrate	2.678s
ok  	github.com/stokaro/ptah/cmd/migratebaseline	2.910s
ok  	github.com/stokaro/ptah/cmd/migratedown	2.643s
ok  	github.com/stokaro/ptah/cmd/migratehash	2.779s
ok  	github.com/stokaro/ptah/cmd/migraterepair	2.910s
ok  	github.com/stokaro/ptah/cmd/migratestatus	3.058s
ok  	github.com/stokaro/ptah/cmd/migrateup	3.081s
ok  	github.com/stokaro/ptah/cmd/migratevalidate	3.231s
ok  	github.com/stokaro/ptah/cmd/migrations	3.189s
?   	github.com/stokaro/ptah/cmd/ptah	[no test files]
ok  	github.com/stokaro/ptah/cmd/ptah-compat	6.231s
?   	github.com/stokaro/ptah/cmd/ptah-ls	[no test files]
?   	github.com/stokaro/ptah/cmd/readdb	[no test files]
ok  	github.com/stokaro/ptah/cmd/root	3.130s
ok  	github.com/stokaro/ptah/cmd/schema	3.177s
ok  	github.com/stokaro/ptah/cmd/seed	3.187s
ok  	github.com/stokaro/ptah/cmd/sql	3.296s
?   	github.com/stokaro/ptah/cmd/version	[no test files]
ok  	github.com/stokaro/ptah/cmd/viz	5.318s
ok  	github.com/stokaro/ptah/config	3.043s
ok  	github.com/stokaro/ptah/config/projectconfig	2.900s
ok  	github.com/stokaro/ptah/core/ast	2.755s
?   	github.com/stokaro/ptah/core/ast/mocks	[no test files]
ok  	github.com/stokaro/ptah/core/goschema	2.671s
ok  	github.com/stokaro/ptah/core/goschema/internal/parseutils	2.495s
?   	github.com/stokaro/ptah/core/goschema/testutil	[no test files]
ok  	github.com/stokaro/ptah/core/platform	1.985s
ok  	github.com/stokaro/ptah/core/platform/capability	1.808s
ok  	github.com/stokaro/ptah/core/ptaherr	2.096s
ok  	github.com/stokaro/ptah/core/renderer	2.182s
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/clickhouse	2.037s
?   	github.com/stokaro/ptah/core/renderer/internal/dialects/internal/bufwriter	[no test files]
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/mariadb	2.023s
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/mssql	2.014s
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/mysql	1.937s
?   	github.com/stokaro/ptah/core/renderer/internal/dialects/mysqllike	[no test files]
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/postgres	2.007s
ok  	github.com/stokaro/ptah/core/renderer/internal/dialects/sqlite	2.008s
ok  	github.com/stokaro/ptah/core/sqlutil	2.035s
ok  	github.com/stokaro/ptah/dbschema	1.848s
ok  	github.com/stokaro/ptah/dbschema/types	1.784s
?   	github.com/stokaro/ptah/examples/extension_ignore	[no test files]
?   	github.com/stokaro/ptah/examples/migrator	[no test files]
?   	github.com/stokaro/ptah/examples/migrator_parser	[no test files]
?   	github.com/stokaro/ptah/examples/migrator_parser/models	[no test files]
?   	github.com/stokaro/ptah/examples/viz/models	[no test files]
ok  	github.com/stokaro/ptah/integration	1.891s
?   	github.com/stokaro/ptah/integration/fixtures/entities/000-initial	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/001-add-fields	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/002-add-posts	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/003-add-enums	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/004-field-rename	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/005-field-type-change	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/006-field-drop	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/007-index-add	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/008-index-remove	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/009-add-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/010-drop-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/011-add-entity	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/012-drop-entity	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/013-embedded-fields	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/014-rls-functions	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/015-rls-advanced	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/016-rls-multiple-files	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/016-roles	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/017-rls-inventario-reproduction	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/017-roles-advanced	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/018-rls-functions-modified	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/019-field-check-constraints	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/020-field-check-constraints-modified	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/021-fk-actions-initial	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/022-fk-actions-changed	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/023-go-annotations-objects	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/024-roundtrip-empty	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/025-roundtrip-single-table	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/026-roundtrip-composite-pk	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/027-roundtrip-self-reference	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/028-roundtrip-parent-child	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/029-roundtrip-mutual-cycle	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/030-roundtrip-check-v1	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/031-roundtrip-check-v2	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/032-roundtrip-unique-v1	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/033-roundtrip-unique-v2	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/034-roundtrip-fk-chain	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/035-roundtrip-fk-diamond	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/036-roundtrip-pk-base	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/037-roundtrip-pk-composite-added	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/038-roundtrip-pk-composite-removed	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/039-roundtrip-enum-v1	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/040-roundtrip-enum-v2-add	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/041-roundtrip-enum-v3-remove	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/042-roundtrip-check-to-unique-v1	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/043-roundtrip-check-to-unique-v2	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/044-roundtrip-unique-to-check-v1	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/045-roundtrip-unique-to-check-v2	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/046-roundtrip-existing-fk-base	[no test files]
?   	github.com/stokaro/ptah/integration/fixtures/entities/047-roundtrip-existing-fk-added	[no test files]
ok  	github.com/stokaro/ptah/integration/gonative	2.001s
ok  	github.com/stokaro/ptah/internal/annotationmeta	2.145s
ok  	github.com/stokaro/ptah/internal/annotationparse	2.252s
ok  	github.com/stokaro/ptah/internal/annotationschema	2.387s
ok  	github.com/stokaro/ptah/internal/astbuilder	2.291s
ok  	github.com/stokaro/ptah/internal/atlashcl	2.272s
ok  	github.com/stokaro/ptah/internal/atlashclrender	2.301s
ok  	github.com/stokaro/ptah/internal/atlasmigrate	2.172s
ok  	github.com/stokaro/ptah/internal/atlasmigrateimport	1.903s
ok  	github.com/stokaro/ptah/internal/atlasreport	2.162s
ok  	github.com/stokaro/ptah/internal/atlasschema	2.162s
ok  	github.com/stokaro/ptah/internal/atlasurl	2.307s
ok  	github.com/stokaro/ptah/internal/convert/dbschematogo	2.489s
ok  	github.com/stokaro/ptah/internal/convert/fromschema	2.634s
ok  	github.com/stokaro/ptah/internal/convert/goschematogo	2.500s
ok  	github.com/stokaro/ptah/internal/convert/toschema	2.418s
ok  	github.com/stokaro/ptah/internal/dbschema/clickhouse	2.335s
?   	github.com/stokaro/ptah/internal/dbschema/dbtest	[no test files]
ok  	github.com/stokaro/ptah/internal/dbschema/mssql	2.448s
ok  	github.com/stokaro/ptah/internal/dbschema/mysql	2.230s
ok  	github.com/stokaro/ptah/internal/dbschema/postgres	2.120s
ok  	github.com/stokaro/ptah/internal/dbschema/sqlite	2.060s
ok  	github.com/stokaro/ptah/internal/deporder	1.955s
?   	github.com/stokaro/ptah/internal/examples/ast_demo	[no test files]
?   	github.com/stokaro/ptah/internal/examples/mysql_demo	[no test files]
?   	github.com/stokaro/ptah/internal/examples/parser_demo	[no test files]
?   	github.com/stokaro/ptah/internal/examples/postgresql_demo	[no test files]
ok  	github.com/stokaro/ptah/internal/goannotationcleanup	1.976s
ok  	github.com/stokaro/ptah/internal/lexer	1.961s
ok  	github.com/stokaro/ptah/internal/migratesum	1.807s
ok  	github.com/stokaro/ptah/internal/onlineddl	6.388s
ok  	github.com/stokaro/ptah/internal/parser	2.098s
ok  	github.com/stokaro/ptah/internal/pathguard	2.230s
ok  	github.com/stokaro/ptah/internal/planner/dialects/clickhouse	2.142s
ok  	github.com/stokaro/ptah/internal/planner/dialects/mssql	2.104s
ok  	github.com/stokaro/ptah/internal/planner/dialects/mysql	2.044s
ok  	github.com/stokaro/ptah/internal/planner/dialects/postgres	2.031s
ok  	github.com/stokaro/ptah/internal/planner/dialects/sqlite	2.070s
ok  	github.com/stokaro/ptah/internal/preflight	2.064s
ok  	github.com/stokaro/ptah/internal/ptahls	2.109s
ok  	github.com/stokaro/ptah/internal/schemafile	1.958s
ok  	github.com/stokaro/ptah/internal/schemaviz	1.919s
ok  	github.com/stokaro/ptah/internal/sqllint	1.934s
?   	github.com/stokaro/ptah/internal/testutils	[no test files]
ok  	github.com/stokaro/ptah/internal/yamlschema	1.935s
ok  	github.com/stokaro/ptah/migration/generator	1.777s
?   	github.com/stokaro/ptah/migration/generator/example	[no test files]
?   	github.com/stokaro/ptah/migration/internal/typechange	[no test files]
ok  	github.com/stokaro/ptah/migration/lint	1.941s
ok  	github.com/stokaro/ptah/migration/migrator	2.070s
ok  	github.com/stokaro/ptah/migration/planner	2.185s
ok  	github.com/stokaro/ptah/migration/risk	2.299s
ok  	github.com/stokaro/ptah/migration/safety	2.446s
ok  	github.com/stokaro/ptah/migration/schemadiff	2.445s
ok  	github.com/stokaro/ptah/migration/schemadiff/internal/compare	2.336s
ok  	github.com/stokaro/ptah/migration/schemadiff/internal/normalize	2.359s
ok  	github.com/stokaro/ptah/migration/schemadiff/types	2.382s
ok  	github.com/stokaro/ptah/migration/seeder	2.009s
?   	github.com/stokaro/ptah/stubs	[no test files] (outside sandbox; sandbox blocks dbschema listen tests)
- 