### PR TITLE
Refactor Atlas schema fmt runtime out of cmd

### DIFF
--- a/cmd/atlas/schema_fmt.go
+++ b/cmd/atlas/schema_fmt.go
@@ -1,16 +1,12 @@
 package atlas
 
 import (
-	"bytes"
 	"fmt"
-	"os"
-	"path/filepath"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/internal/atlashclfmt"
 )
 
 func newAtlasSchemaFmtCommand() *cobra.Command {
@@ -34,82 +30,12 @@ func runAtlasSchemaFmt(cmd *cobra.Command, args []string) error {
 		paths = []string{"."}
 	}
 
-	for _, path := range paths {
-		changed, err := formatAtlasSchemaPath(path)
-		if err != nil {
-			return err
-		}
-		for _, file := range changed {
-			fmt.Fprintln(cmd.OutOrStdout(), file)
-		}
+	changed, err := atlashclfmt.FormatPaths(paths)
+	if err != nil {
+		return err
+	}
+	for _, file := range changed {
+		fmt.Fprintln(cmd.OutOrStdout(), file)
 	}
 	return nil
-}
-
-func formatAtlasSchemaPath(path string) ([]string, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("schema fmt %s: %w", path, err)
-	}
-	if !info.IsDir() {
-		changed, err := formatAtlasSchemaFile(path)
-		if err != nil || !changed {
-			return nil, err
-		}
-		return []string{path}, nil
-	}
-
-	var changed []string
-	err = filepath.WalkDir(path, func(file string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() || filepath.Ext(file) != ".hcl" {
-			return nil
-		}
-		fileChanged, err := formatAtlasSchemaFile(file)
-		if err != nil {
-			return err
-		}
-		if fileChanged {
-			changed = append(changed, file)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("schema fmt %s: %w", path, err)
-	}
-	return changed, nil
-}
-
-func formatAtlasSchemaFile(path string) (bool, error) {
-	if filepath.Ext(path) != ".hcl" {
-		return false, nil
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return false, fmt.Errorf("schema fmt %s: %w", path, err)
-	}
-	if info.IsDir() {
-		return false, nil
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false, fmt.Errorf("schema fmt %s: %w", path, err)
-	}
-	if _, diags := hclwrite.ParseConfig(data, path, hcl.Pos{Line: 1, Column: 1}); diags.HasErrors() {
-		return false, fmt.Errorf("schema fmt %s: %s", path, diags.Error())
-	}
-
-	formatted := hclwrite.Format(data)
-	if bytes.Equal(data, formatted) {
-		return false, nil
-	}
-	//nolint:gosec // schema fmt intentionally rewrites the user-selected local HCL file after stat/read validation.
-	if err := os.WriteFile(path, formatted, info.Mode().Perm()); err != nil {
-		return false, fmt.Errorf("schema fmt %s: %w", path, err)
-	}
-	return true, nil
 }

--- a/internal/atlashclfmt/fmt.go
+++ b/internal/atlashclfmt/fmt.go
@@ -1,0 +1,96 @@
+package atlashclfmt
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// FormatPaths formats Atlas HCL files under every provided path and returns
+// the files whose content changed.
+func FormatPaths(paths []string) ([]string, error) {
+	changed := make([]string, 0)
+	for _, path := range paths {
+		pathChanged, err := FormatPath(path)
+		if err != nil {
+			return nil, err
+		}
+		changed = append(changed, pathChanged...)
+	}
+	return changed, nil
+}
+
+// FormatPath formats one file or recursively formats every .hcl file under a
+// directory.
+func FormatPath(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("schema fmt %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		changed, err := FormatFile(path)
+		if err != nil || !changed {
+			return nil, err
+		}
+		return []string{path}, nil
+	}
+
+	changed := make([]string, 0)
+	err = filepath.WalkDir(path, func(file string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(file) != ".hcl" {
+			return nil
+		}
+		fileChanged, err := FormatFile(file)
+		if err != nil {
+			return err
+		}
+		if fileChanged {
+			changed = append(changed, file)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("schema fmt %s: %w", path, err)
+	}
+	return changed, nil
+}
+
+// FormatFile formats a single .hcl file. Non-HCL files are ignored.
+func FormatFile(path string) (bool, error) {
+	if filepath.Ext(path) != ".hcl" {
+		return false, nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("schema fmt %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("schema fmt %s: %w", path, err)
+	}
+	if _, diags := hclwrite.ParseConfig(data, path, hcl.Pos{Line: 1, Column: 1}); diags.HasErrors() {
+		return false, fmt.Errorf("schema fmt %s: %s", path, diags.Error())
+	}
+
+	formatted := hclwrite.Format(data)
+	if bytes.Equal(data, formatted) {
+		return false, nil
+	}
+	//nolint:gosec // schema fmt intentionally rewrites the user-selected local HCL file after stat/read validation.
+	if err := os.WriteFile(path, formatted, info.Mode().Perm()); err != nil {
+		return false, fmt.Errorf("schema fmt %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/internal/atlashclfmt/fmt_test.go
+++ b/internal/atlashclfmt/fmt_test.go
@@ -1,0 +1,88 @@
+package atlashclfmt_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashclfmt"
+)
+
+func TestFormatPaths_HappyPathFormatsFilesRecursively(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	changed := filepath.Join(dir, "changed.hcl")
+	nestedChanged := filepath.Join(dir, "nested", "changed.hcl")
+	unchanged := filepath.Join(dir, "nested", "unchanged.hcl")
+	ignored := filepath.Join(dir, "notes.txt")
+	c.Assert(os.MkdirAll(filepath.Dir(unchanged), 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(changed, []byte(`schema "main"{}`+"\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(nestedChanged, []byte(`schema "nested"{}`+"\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(unchanged, []byte(`schema "main" {}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(ignored, []byte(`schema "main"{}`+"\n"), 0o600), qt.IsNil)
+
+	result, err := atlashclfmt.FormatPaths([]string{dir})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, qt.DeepEquals, []string{changed, nestedChanged})
+	c.Assert(readFile(c, changed), qt.Equals, `schema "main" {}
+`)
+	c.Assert(readFile(c, nestedChanged), qt.Equals, `schema "nested" {}
+`)
+	c.Assert(readFile(c, unchanged), qt.Equals, `schema "main" {}
+`)
+	c.Assert(readFile(c, ignored), qt.Equals, `schema "main"{}`+"\n")
+}
+
+func TestFormatFile_HappyPathIgnoresNonHCLFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.txt")
+	c.Assert(os.WriteFile(path, []byte(`schema "main"{}`+"\n"), 0o600), qt.IsNil)
+
+	changed, err := atlashclfmt.FormatFile(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(changed, qt.IsFalse)
+	c.Assert(readFile(c, path), qt.Equals, `schema "main"{}`+"\n")
+}
+
+func TestFormatFile_FailurePathRejectsInvalidHCLWithoutRewriting(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.hcl")
+	original := []byte(`schema "main" {
+`)
+	c.Assert(os.WriteFile(path, original, 0o600), qt.IsNil)
+
+	changed, err := atlashclfmt.FormatFile(path)
+
+	c.Assert(err, qt.ErrorMatches, `schema fmt .*bad\.hcl: .*`)
+	c.Assert(changed, qt.IsFalse)
+	c.Assert(readFileBytes(c, path), qt.DeepEquals, original)
+}
+
+func TestFormatPath_FailurePathReportsMissingPath(t *testing.T) {
+	c := qt.New(t)
+	path := filepath.Join(t.TempDir(), "missing.hcl")
+
+	result, err := atlashclfmt.FormatPath(path)
+
+	c.Assert(err, qt.ErrorMatches, `schema fmt .*missing\.hcl: .*`)
+	c.Assert(result, qt.HasLen, 0)
+}
+
+func readFile(c *qt.C, path string) string {
+	c.Helper()
+	return string(readFileBytes(c, path))
+}
+
+func readFileBytes(c *qt.C, path string) []byte {
+	c.Helper()
+	data, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	return data
+}


### PR DESCRIPTION
## Summary
- move `ptah atlas schema fmt` file formatting runtime into `internal/atlashclfmt`
- keep `cmd/atlas` as a thin Cobra adapter for default args and changed-file output
- add black-box package tests for recursive formatting, ignored non-HCL files, invalid HCL no-rewrite behavior, and missing paths

## Self-review
- pass 1: verified the command layer no longer owns HCL parsing, directory walking, reads, or writes
- pass 2: verified behavior preservation for error prefixes, changed-file output order, non-HCL ignores, permissions, and invalid-HCL write safety

## Validation
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./internal/atlashclfmt ./cmd/atlas`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `env GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...` outside sandbox
- `git diff --check`

Refs #540