### PR TITLE
Move Atlas dev URL dialect validation out of cmd

### DIFF
--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -77,7 +77,7 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := validateAtlasDevURLDialect(opts.devURL, conn.Info().Dialect); err != nil {
+	if err := atlasurl.ValidateDialectMatch(opts.devURL, conn.Info().Dialect); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 
@@ -128,20 +128,6 @@ func validateAtlasSchemaApplyOptions(cmd *cobra.Command, opts atlasSchemaApplyOp
 		}
 	}
 	return ensureLocalSchemaURLs("--to", opts.toURLs)
-}
-
-func validateAtlasDevURLDialect(devURL, targetDialect string) error {
-	devDialect, err := atlasurl.DialectFromURL(devURL)
-	if err != nil {
-		return err
-	}
-	if devDialect == "" {
-		return nil
-	}
-	if devDialect != targetDialect {
-		return fmt.Errorf("--dev-url dialect %q does not match --url dialect %q", devDialect, targetDialect)
-	}
-	return nil
 }
 
 func printAtlasSchemaApplyPlan(out io.Writer, sqlText string) {

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasreport"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 )
 
@@ -70,7 +71,7 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := validateAtlasDevURLDialect(opts.devURL, conn.Info().Dialect); err != nil {
+	if err := atlasurl.ValidateDialectMatch(opts.devURL, conn.Info().Dialect); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 

--- a/internal/atlasurl/url.go
+++ b/internal/atlasurl/url.go
@@ -30,6 +30,26 @@ func DialectFromURL(rawURL string) (string, error) {
 	return "", fmt.Errorf("unsupported --dev-url dialect %q", rawURL)
 }
 
+// ValidateDialectMatch verifies that rawURL resolves to the same dialect as the
+// already-open target database.
+func ValidateDialectMatch(rawURL, targetDialect string) error {
+	dialect, err := DialectFromURL(rawURL)
+	if err != nil {
+		return err
+	}
+	if dialect == "" {
+		return nil
+	}
+	normalizedTarget := platform.NormalizeDialect(targetDialect)
+	if normalizedTarget == "" {
+		normalizedTarget = targetDialect
+	}
+	if dialect != normalizedTarget {
+		return fmt.Errorf("--dev-url dialect %q does not match --url dialect %q", dialect, normalizedTarget)
+	}
+	return nil
+}
+
 func dialectFromDockerURL(parsed *url.URL) (string, error) {
 	engine := parsed.Host
 	if engine == "" {

--- a/internal/atlasurl/url_test.go
+++ b/internal/atlasurl/url_test.go
@@ -53,3 +53,39 @@ func TestDialectFromURL_FailurePath(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDialectMatch_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name          string
+		rawURL        string
+		targetDialect string
+	}{
+		{name: "empty dev url", rawURL: "", targetDialect: "postgres"},
+		{name: "exact dialect", rawURL: "mysql://localhost/dev", targetDialect: "mysql"},
+		{name: "target alias", rawURL: "postgres://localhost/dev", targetDialect: "postgresql"},
+		{name: "docker dialect", rawURL: "docker://mariadb/11/dev", targetDialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := atlasurl.ValidateDialectMatch(test.rawURL, test.targetDialect)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestValidateDialectMatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("unsupported dev url", func(c *qt.C) {
+		err := atlasurl.ValidateDialectMatch("spanner://localhost/dev", "postgres")
+		c.Assert(err, qt.ErrorMatches, `unsupported --dev-url dialect "spanner://localhost/dev"`)
+	})
+
+	c.Run("mismatched dialect", func(c *qt.C) {
+		err := atlasurl.ValidateDialectMatch("mysql://localhost/dev", "postgres")
+		c.Assert(err, qt.ErrorMatches, `--dev-url dialect "mysql" does not match --url dialect "postgres"`)
+	})
+}


### PR DESCRIPTION
## Summary
- move Atlas --dev-url dialect matching from cmd/atlas to internal/atlasurl
- reuse the new validator from schema apply and schema inspect
- add black-box atlasurl tests for empty, matching, aliased, docker, unsupported, and mismatched URLs

## Self-review
- pass 1: verified behavior is unchanged for existing schema apply/inspect mismatch errors and the command layer now delegates reusable URL policy
- pass 2: checked package boundary, MariaDB-vs-MySQL semantics, exported API docs, declarative test shape, and absence of the old cmd helper

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./internal/atlasurl ./cmd/atlas
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./... (outside sandbox; sandbox cannot bind local TCP in dbschema tests)
- git diff --check

Refs #540