### PR TITLE
Extract Atlas schema inspect runtime

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -640,14 +640,6 @@ func TestNewAtlasCommand_SchemaInspectRejectsUnsupportedFilters(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "atlas schema inspect accepts --exclude, but Ptah does not implement its behavior yet")
 }
 
-func TestParseAtlasSchemaInspectSchemasAcceptsRepeatedAndCommaValues(t *testing.T) {
-	c := qt.New(t)
-
-	schemas := parseAtlasSchemaInspectSchemas([]string{"public, auth", "tenant"})
-
-	c.Assert(schemas, qt.DeepEquals, []string{"public", "auth", "tenant"})
-}
-
 func TestNewAtlasCommand_ForwardsParentedNativeCommand(t *testing.T) {
 	c := qt.New(t)
 	root := &cobra.Command{Use: "ptah"}

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -9,9 +9,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
-	"github.com/stokaro/ptah/internal/atlasreport"
-	"github.com/stokaro/ptah/internal/atlasurl"
-	"github.com/stokaro/ptah/internal/convert/dbschematogo"
+	"github.com/stokaro/ptah/internal/atlasschema"
 )
 
 type atlasSchemaInspectOptions struct {
@@ -52,11 +50,8 @@ follow-up gaps.`,
 }
 
 func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) error {
-	format, err := atlasreport.NormalizeSchemaInspectFormat(opts.format)
+	format, err := atlasschema.NormalizeInspectFormat(opts.format)
 	if err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-	if err := atlasreport.ValidateSchemaInspectTemplate(format); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	if err := validateAtlasSchemaInspectOptions(opts); err != nil {
@@ -71,21 +66,12 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := atlasurl.ValidateDialectMatch(opts.devURL, conn.Info().Dialect); err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-
-	schema, err := dbschema.ReadSchemaWithSchemas(conn, parseAtlasSchemaInspectSchemas(opts.schemas))
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("read database schema: %w", err))
-	}
-	dbsch := dbschematogo.ConvertDBSchemaToGoSchema(schema)
-	rendered, err := atlasreport.RenderSchemaInspectFormat(format, atlasreport.NewSchemaInspectReport(
-		dbsch,
-		schema,
-		conn.Info(),
-		cmd.ErrOrStderr(),
-	))
+	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		DevURL:      opts.devURL,
+		Schemas:     opts.schemas,
+		Format:      format,
+		Diagnostics: cmd.ErrOrStderr(),
+	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -104,16 +90,4 @@ func validateAtlasSchemaInspectOptions(opts atlasSchemaInspectOptions) error {
 		return fmt.Errorf("atlas schema inspect accepts --include, but Ptah does not implement its behavior yet")
 	}
 	return nil
-}
-
-func parseAtlasSchemaInspectSchemas(values []string) []string {
-	var schemas []string
-	for _, value := range values {
-		for part := range strings.SplitSeq(value, ",") {
-			if schema := strings.TrimSpace(part); schema != "" {
-				schemas = append(schemas, schema)
-			}
-		}
-	}
-	return schemas
 }

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -1,0 +1,77 @@
+package atlasschema
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasreport"
+	"github.com/stokaro/ptah/internal/atlasurl"
+	"github.com/stokaro/ptah/internal/convert/dbschematogo"
+)
+
+// InspectOptions configures Atlas-compatible schema inspection.
+type InspectOptions struct {
+	DevURL      string
+	Schemas     []string
+	Format      string
+	Diagnostics io.Writer
+}
+
+// NormalizeInspectFormat returns and validates the executable Atlas schema
+// inspect template.
+func NormalizeInspectFormat(format string) (string, error) {
+	normalized, err := atlasreport.NormalizeSchemaInspectFormat(format)
+	if err != nil {
+		return "", err
+	}
+	if err := atlasreport.ValidateSchemaInspectTemplate(normalized); err != nil {
+		return "", err
+	}
+	return normalized, nil
+}
+
+// Inspect reads a live schema and renders it with Atlas-compatible formatting.
+func Inspect(conn *dbschema.DatabaseConnection, opts InspectOptions) (string, error) {
+	format, err := NormalizeInspectFormat(opts.Format)
+	if err != nil {
+		return "", err
+	}
+	if conn == nil {
+		return "", errors.New("schema inspect requires database connection")
+	}
+	if err := atlasurl.ValidateDialectMatch(opts.DevURL, conn.Info().Dialect); err != nil {
+		return "", err
+	}
+
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, SplitSchemaNames(opts.Schemas))
+	if err != nil {
+		return "", fmt.Errorf("read database schema: %w", err)
+	}
+	dbsch := dbschematogo.ConvertDBSchemaToGoSchema(schema)
+	rendered, err := atlasreport.RenderSchemaInspectFormat(format, atlasreport.NewSchemaInspectReport(
+		dbsch,
+		schema,
+		conn.Info(),
+		opts.Diagnostics,
+	))
+	if err != nil {
+		return "", err
+	}
+	return rendered, nil
+}
+
+// SplitSchemaNames expands repeated and comma-separated Atlas schema filters.
+func SplitSchemaNames(values []string) []string {
+	var schemas []string
+	for _, value := range values {
+		for part := range strings.SplitSeq(value, ",") {
+			if schema := strings.TrimSpace(part); schema != "" {
+				schemas = append(schemas, schema)
+			}
+		}
+	}
+	return schemas
+}

--- a/internal/atlasschema/inspect_test.go
+++ b/internal/atlasschema/inspect_test.go
@@ -1,0 +1,96 @@
+package atlasschema_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
+)
+
+func TestInspect_HappyPathHCL(t *testing.T) {
+	c := qt.New(t)
+	conn := connectSQLite(c, filepath.Join(t.TempDir(), "inspect-hcl.db"))
+	defer dbschema.CloseAndWarn(conn)
+	createInspectSchema(c, conn)
+
+	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		Format: "hcl",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, `table "users"`)
+	c.Assert(rendered, qt.Contains, `column "email"`)
+}
+
+func TestInspect_HappyPathCustomTemplate(t *testing.T) {
+	c := qt.New(t)
+	conn := connectSQLite(c, filepath.Join(t.TempDir(), "inspect-template.db"))
+	defer dbschema.CloseAndWarn(conn)
+	createInspectSchema(c, conn)
+
+	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		Format: `{{ len .Realm.Schemas }}/{{ len (index .Schema.Schemas 0).Tables }}/{{ base64url "a+b/c=" }}/{{ printf "%.6s" (sql .) }}`,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Equals, "1/2/a-b_c/CREATE")
+}
+
+func TestInspect_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("invalid format before connection", func(c *qt.C) {
+		rendered, err := atlasschema.Inspect(nil, atlasschema.InspectOptions{
+			Format: "{{ if }}",
+		})
+		c.Assert(err, qt.ErrorMatches, `parse --format template: .*`)
+		c.Assert(rendered, qt.Equals, "")
+	})
+
+	c.Run("nil connection", func(c *qt.C) {
+		rendered, err := atlasschema.Inspect(nil, atlasschema.InspectOptions{})
+		c.Assert(err, qt.ErrorMatches, "schema inspect requires database connection")
+		c.Assert(rendered, qt.Equals, "")
+	})
+
+	c.Run("dev url dialect mismatch", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "inspect-mismatch.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+			DevURL: "postgres://localhost/dev",
+		})
+		c.Assert(err, qt.ErrorMatches, `--dev-url dialect "postgres" does not match --url dialect "sqlite"`)
+		c.Assert(rendered, qt.Equals, "")
+	})
+}
+
+func TestSplitSchemaNames(t *testing.T) {
+	c := qt.New(t)
+
+	schemas := atlasschema.SplitSchemaNames([]string{"public, auth", "tenant"})
+
+	c.Assert(schemas, qt.DeepEquals, []string{"public", "auth", "tenant"})
+}
+
+func createInspectSchema(c *qt.C, conn *dbschema.DatabaseConnection) {
+	c.Helper()
+	_, err := conn.ExecContext(context.Background(), `
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL
+);
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  CONSTRAINT posts_user_fk FOREIGN KEY (user_id) REFERENCES users (id)
+);
+CREATE UNIQUE INDEX users_email_key ON users (email);
+`)
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary
- move Atlas schema inspect runtime orchestration into internal/atlasschema
- keep cmd/atlas/schema inspect focused on CLI validation, connect/close, and stdout/stderr wiring
- move repeated/comma schema filter parsing to package-level tests and remove the cmd white-box parser test

## Self-review
- pass 1: verified command behavior remains covered by existing HCL/SQL/JSON/custom-template command tests and invalid format still fails before connecting
- pass 2: checked package boundaries, error ordering, declarative black-box tests, exported API docs, and absence of schema read/convert/render runtime from cmd/atlas/schema_inspect.go

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./internal/atlasschema ./cmd/atlas
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./... (outside sandbox; sandbox cannot bind local TCP in dbschema tests)
- git diff --cached --check

Refs #540