### PR TITLE
Extract Atlas schema apply runtime

### DIFF
--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasschema"
-	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -77,11 +76,12 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := atlasurl.ValidateDialectMatch(opts.devURL, conn.Info().Dialect); err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-
-	plan, err := atlasschema.PlanApply(conn, atlasschema.ApplyOptions{ToURLs: opts.toURLs})
+	plan, err := atlasschema.PrepareApply(conn, atlasschema.ApplyRuntimeOptions{
+		DevURL: opts.devURL,
+		ToURLs: opts.toURLs,
+		TxMode: txMode,
+		DryRun: opts.dryRun,
+	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -104,8 +104,7 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		return nil
 	}
 
-	conn.SchemaWriter().SetDryRun(false)
-	if err := atlasschema.ApplySQL(cmd.Context(), conn, txMode, sqlText); err != nil {
+	if err := plan.Execute(cmd.Context()); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("apply schema changes: %w", err))
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Schema apply completed successfully.")

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
@@ -21,6 +22,23 @@ type ApplyOptions struct {
 
 type ApplyPlan struct {
 	statements []string
+}
+
+// ApplyRuntimeOptions configures Atlas schema apply planning and execution.
+type ApplyRuntimeOptions struct {
+	DevURL string
+	ToURLs []string
+	TxMode migrator.MigrationTxMode
+	DryRun bool
+}
+
+// ApplyRuntimePlan is a prepared Atlas schema apply operation for one open
+// database connection.
+type ApplyRuntimePlan struct {
+	plan   ApplyPlan
+	dryRun bool
+	conn   *dbschema.DatabaseConnection
+	txMode migrator.MigrationTxMode
 }
 
 func (p ApplyPlan) HasChanges() bool {
@@ -58,6 +76,50 @@ func PlanApply(conn *dbschema.DatabaseConnection, opts ApplyOptions) (ApplyPlan,
 		return ApplyPlan{}, fmt.Errorf("generate schema apply SQL: %w", err)
 	}
 	return ApplyPlan{statements: statements}, nil
+}
+
+// PrepareApply validates Atlas schema apply runtime inputs and builds the
+// executable apply plan for the already-open target database connection.
+func PrepareApply(conn *dbschema.DatabaseConnection, opts ApplyRuntimeOptions) (ApplyRuntimePlan, error) {
+	if conn == nil {
+		return ApplyRuntimePlan{}, errors.New("schema apply requires database connection")
+	}
+	if err := atlasurl.ValidateDialectMatch(opts.DevURL, conn.Info().Dialect); err != nil {
+		return ApplyRuntimePlan{}, err
+	}
+
+	plan, err := PlanApply(conn, ApplyOptions{ToURLs: opts.ToURLs})
+	if err != nil {
+		return ApplyRuntimePlan{}, err
+	}
+	return ApplyRuntimePlan{
+		plan:   plan,
+		dryRun: opts.DryRun,
+		conn:   conn,
+		txMode: opts.TxMode,
+	}, nil
+}
+
+func (p ApplyRuntimePlan) HasChanges() bool {
+	return p.plan.HasChanges()
+}
+
+func (p ApplyRuntimePlan) SQL() string {
+	return p.plan.SQL()
+}
+
+// Execute applies the prepared schema diff. Dry-run and no-op plans return
+// without modifying schema state.
+func (p ApplyRuntimePlan) Execute(ctx context.Context) error {
+	if !p.HasChanges() || p.dryRun {
+		return nil
+	}
+	if p.conn == nil {
+		return errors.New("schema apply execution requires database connection")
+	}
+
+	p.conn.SchemaWriter().SetDryRun(false)
+	return ApplySQL(ctx, p.conn, p.txMode, p.SQL())
 }
 
 func ApplySQL(

--- a/internal/atlasschema/apply_test.go
+++ b/internal/atlasschema/apply_test.go
@@ -86,6 +86,121 @@ func TestPlanApply_FailurePath(t *testing.T) {
 	})
 }
 
+func TestPrepareApply_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "runtime-apply.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE runtime_users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL
+);
+`), 0o600), qt.IsNil)
+	conn := connectSQLite(c, dbPath)
+
+	plan, err := atlasschema.PrepareApply(conn, atlasschema.ApplyRuntimeOptions{
+		DevURL: "sqlite://dev.db",
+		ToURLs: []string{"file://" + schemaPath},
+		TxMode: migrator.MigrationTxModeAll,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsTrue)
+	c.Assert(plan.SQL(), qt.Contains, "runtime_users")
+
+	err = plan.Execute(context.Background())
+	dbschema.CloseAndWarn(conn)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqliteTableExists(c, dbPath, "runtime_users"), qt.IsTrue)
+}
+
+func TestPrepareApply_DryRunDoesNotApply(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "runtime-dry-run.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE runtime_dry_run (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+	conn := connectSQLite(c, dbPath)
+
+	plan, err := atlasschema.PrepareApply(conn, atlasschema.ApplyRuntimeOptions{
+		DevURL: "sqlite://dev.db",
+		ToURLs: []string{"file://" + schemaPath},
+		TxMode: migrator.MigrationTxModeAll,
+		DryRun: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsTrue)
+
+	err = plan.Execute(context.Background())
+	dbschema.CloseAndWarn(conn)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqliteTableExists(c, dbPath, "runtime_dry_run"), qt.IsFalse)
+}
+
+func TestPrepareApply_Synced(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "runtime-synced.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	schemaSQL := `
+CREATE TABLE runtime_synced (
+  id INTEGER PRIMARY KEY
+);
+`
+	c.Assert(os.WriteFile(schemaPath, []byte(schemaSQL), 0o600), qt.IsNil)
+	conn := connectSQLite(c, dbPath)
+	c.Assert(atlasschema.ApplySQL(context.Background(), conn, migrator.MigrationTxModeAll, schemaSQL), qt.IsNil)
+
+	plan, err := atlasschema.PrepareApply(conn, atlasschema.ApplyRuntimeOptions{
+		DevURL: "sqlite://dev.db",
+		ToURLs: []string{"file://" + schemaPath},
+		TxMode: migrator.MigrationTxModeAll,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsFalse)
+	c.Assert(plan.SQL(), qt.Equals, "")
+
+	err = plan.Execute(context.Background())
+	dbschema.CloseAndWarn(conn)
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestPrepareApply_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil connection", func(c *qt.C) {
+		plan, err := atlasschema.PrepareApply(nil, atlasschema.ApplyRuntimeOptions{
+			DevURL: "sqlite://dev.db",
+			ToURLs: []string{"file:///schema.sql"},
+			TxMode: migrator.MigrationTxModeAll,
+		})
+		c.Assert(err, qt.ErrorMatches, "schema apply requires database connection")
+		c.Assert(plan.HasChanges(), qt.IsFalse)
+		c.Assert(plan.SQL(), qt.Equals, "")
+	})
+
+	c.Run("dev URL dialect mismatch", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(t.TempDir(), "runtime-dev-url-mismatch.db"))
+		defer dbschema.CloseAndWarn(conn)
+
+		plan, err := atlasschema.PrepareApply(conn, atlasschema.ApplyRuntimeOptions{
+			DevURL: "postgres://localhost/dev",
+			ToURLs: []string{"file:///schema.sql"},
+			TxMode: migrator.MigrationTxModeAll,
+		})
+		c.Assert(err, qt.ErrorMatches, `--dev-url dialect "postgres" does not match --url dialect "sqlite"`)
+		c.Assert(plan.HasChanges(), qt.IsFalse)
+		c.Assert(plan.SQL(), qt.Equals, "")
+	})
+}
+
 func TestApplySQL_TxModeAllRollsBackOnFailure(t *testing.T) {
 	c := qt.New(t)
 	dbPath := filepath.Join(t.TempDir(), "tx-mode-all.db")


### PR DESCRIPTION
## Summary
- move Atlas schema apply planning/execution orchestration into internal/atlasschema
- keep cmd/atlas focused on CLI validation, connection setup, prompt, and output
- add black-box runtime tests for apply, dry-run, synced, and failure paths

Refs #540

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./internal/atlasschema ./cmd/atlas
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./...