### PR TITLE
Move Atlas migrate apply parsing into runtime

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -72,8 +71,9 @@ Native Ptah equivalent: ptah migrations up.`,
 }
 
 func atlasMigrateApplyArgs(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 {
-		return cmdutil.Fail(cmd, fmt.Errorf("accepts at most one amount argument"))
+	_, err := atlasmigrate.ParseApplyAmount(args)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	return nil
 }
@@ -107,15 +107,15 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		return fmt.Errorf("invalid migration directory: %w", err)
 	}
 
-	amount, err := parseAtlasMigrateApplyAmount(args)
+	amount, err := atlasmigrate.ParseApplyAmount(args)
 	if err != nil {
 		return err
 	}
-	toVersion, err := parseAtlasMigrationVersionFlag("to-version", opts.toVersion)
+	toVersion, err := atlasmigrate.ParseMigrationVersionFlag("to-version", opts.toVersion)
 	if err != nil {
 		return err
 	}
-	baselineVersion, err := parseAtlasMigrationVersionFlag("baseline", opts.baseline)
+	baselineVersion, err := atlasmigrate.ParseMigrationVersionFlag("baseline", opts.baseline)
 	if err != nil {
 		return err
 	}
@@ -207,32 +207,6 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 	}
 	fmt.Fprintf(out, "Migration complete. Current version: %d\n", result.FinalStatus.CurrentVersion)
 	return nil
-}
-
-func parseAtlasMigrateApplyAmount(args []string) (uint64, error) {
-	if len(args) == 0 {
-		return 0, nil
-	}
-	value, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("amount argument %q is not a valid unsigned integer: %w", args[0], err)
-	}
-	return value, nil
-}
-
-func parseAtlasMigrationVersionFlag(name, value string) (int64, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0, nil
-	}
-	parsed, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("--%s %q is not a valid migration version: %w", name, value, err)
-	}
-	if parsed <= 0 {
-		return 0, fmt.Errorf("--%s must be greater than zero", name)
-	}
-	return parsed, nil
 }
 
 func writeAtlasMigrateApplyFormat(

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -157,6 +158,38 @@ func (p ApplyPlan) Execute(ctx context.Context) (ApplyResult, error) {
 	result.FinalStatus = finalStatus
 	result.Applied = true
 	return result, nil
+}
+
+// ParseApplyAmount parses the optional Atlas migrate apply amount argument.
+func ParseApplyAmount(args []string) (uint64, error) {
+	if len(args) == 0 {
+		return 0, nil
+	}
+	if len(args) > 1 {
+		return 0, errors.New("accepts at most one amount argument")
+	}
+	value, err := strconv.ParseUint(strings.TrimSpace(args[0]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("amount argument %q is not a valid unsigned integer: %w", args[0], err)
+	}
+	return value, nil
+}
+
+// ParseMigrationVersionFlag parses positive Atlas migration version flags such
+// as --to-version and --baseline.
+func ParseMigrationVersionFlag(name, value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("--%s %q is not a valid migration version: %w", name, value, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("--%s must be greater than zero", name)
+	}
+	return parsed, nil
 }
 
 func validateApplyOptions(conn *dbschema.DatabaseConnection, opts ApplyOptions) error {

--- a/internal/atlasmigrate/apply_test.go
+++ b/internal/atlasmigrate/apply_test.go
@@ -243,6 +243,112 @@ func TestPrepareApply_FailurePath(t *testing.T) {
 	})
 }
 
+func TestParseApplyAmount_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		args []string
+		want uint64
+	}{
+		{
+			name: "empty",
+			args: nil,
+			want: 0,
+		},
+		{
+			name: "positive amount",
+			args: []string{"2"},
+			want: 2,
+		},
+		{
+			name: "trimmed amount",
+			args: []string{" 3 "},
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got, err := atlasmigrate.ParseApplyAmount(tt.args)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestParseApplyAmount_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("too many arguments", func(c *qt.C) {
+		got, err := atlasmigrate.ParseApplyAmount([]string{"1", "2"})
+		c.Assert(err, qt.ErrorMatches, "accepts at most one amount argument")
+		c.Assert(got, qt.Equals, uint64(0))
+	})
+
+	c.Run("invalid unsigned integer", func(c *qt.C) {
+		got, err := atlasmigrate.ParseApplyAmount([]string{"nope"})
+		c.Assert(err, qt.ErrorMatches, `amount argument "nope" is not a valid unsigned integer: .*`)
+		c.Assert(got, qt.Equals, uint64(0))
+	})
+}
+
+func TestParseMigrationVersionFlag_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+		want  int64
+	}{
+		{
+			name:  "empty",
+			value: "",
+			want:  0,
+		},
+		{
+			name:  "positive version",
+			value: "42",
+			want:  42,
+		},
+		{
+			name:  "trimmed version",
+			value: " 7 ",
+			want:  7,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got, err := atlasmigrate.ParseMigrationVersionFlag("to-version", tt.value)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestParseMigrationVersionFlag_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("invalid integer", func(c *qt.C) {
+		got, err := atlasmigrate.ParseMigrationVersionFlag("baseline", "nope")
+		c.Assert(err, qt.ErrorMatches, `--baseline "nope" is not a valid migration version: .*`)
+		c.Assert(got, qt.Equals, int64(0))
+	})
+
+	c.Run("zero", func(c *qt.C) {
+		got, err := atlasmigrate.ParseMigrationVersionFlag("to-version", "0")
+		c.Assert(err, qt.ErrorMatches, "--to-version must be greater than zero")
+		c.Assert(got, qt.Equals, int64(0))
+	})
+
+	c.Run("negative", func(c *qt.C) {
+		got, err := atlasmigrate.ParseMigrationVersionFlag("baseline", "-1")
+		c.Assert(err, qt.ErrorMatches, "--baseline must be greater than zero")
+		c.Assert(got, qt.Equals, int64(0))
+	})
+}
+
 func writeAtlasApplyMigrationFile(c *qt.C, dir, name, sql string) {
 	c.Helper()
 	c.Assert(os.MkdirAll(dir, 0755), qt.IsNil)


### PR DESCRIPTION
## Summary
- move Atlas migrate apply amount/version parsing from cmd/atlas into internal/atlasmigrate
- keep cmd/atlas using the parser only for Cobra argument validation and runtime option mapping
- add black-box declarative parser tests for happy and failure paths

Refs #540

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./internal/atlasmigrate ./cmd/atlas
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./...