### PR TITLE
Move Atlas migrate apply report adapter out of cmd

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -2,8 +2,6 @@ package atlas
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/internal/atlasmigratereport"
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -172,7 +171,7 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 			return err
 		}
 		if formatOutput {
-			return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
+			return writeAtlasMigrateApplyFormat(cmd, opts, dir, conn, result)
 		}
 		fmt.Fprintln(out, "No migration files to execute.")
 		return nil
@@ -187,7 +186,7 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 	result, err := plan.Execute(cmd.Context())
 	if err != nil {
 		if formatOutput && result.ApplyError != nil {
-			writeErr := writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
+			writeErr := writeAtlasMigrateApplyFormat(cmd, opts, dir, conn, result)
 			if writeErr != nil {
 				return fmt.Errorf("%w; additionally failed to write --format output: %v", err, writeErr)
 			}
@@ -197,38 +196,30 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 
 	if opts.dryRun {
 		if formatOutput {
-			return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
+			return writeAtlasMigrateApplyFormat(cmd, opts, dir, conn, result)
 		}
 		fmt.Fprintf(out, "Would have applied %d migrations.\n", len(plan.SelectedVersions))
 		return nil
 	}
 	if formatOutput {
-		return writeAtlasMigrateApplyFormat(out, opts, dir, conn, result)
+		return writeAtlasMigrateApplyFormat(cmd, opts, dir, conn, result)
 	}
 	fmt.Fprintf(out, "Migration complete. Current version: %d\n", result.FinalStatus.CurrentVersion)
 	return nil
 }
 
 func writeAtlasMigrateApplyFormat(
-	out io.Writer,
+	cmd *cobra.Command,
 	opts atlasMigrateApplyOptions,
 	resolvedDir string,
 	conn *dbschema.DatabaseConnection,
 	result atlasmigrate.ApplyResult,
 ) error {
-	return atlasreport.WriteMigrateApplyFormat(out, opts.format, atlasreport.MigrateApplyResultOptions{
-		Conn:             conn,
-		FS:               os.DirFS(resolvedDir),
-		Dir:              opts.dir,
-		URL:              opts.url,
-		Status:           result.Status,
-		Migrations:       result.Migrations,
-		SelectedVersions: result.SelectedVersions,
-		CurrentVersion:   result.CurrentVersion,
-		ErrorText:        result.ErrorText,
-		ApplyError:       result.ApplyError,
-		Applied:          result.Applied,
-		StartedAt:        result.StartedAt,
-		EndedAt:          result.EndedAt,
+	return atlasmigratereport.WriteApplyFormat(cmd.OutOrStdout(), opts.format, atlasmigratereport.ApplyFormatOptions{
+		Conn:        conn,
+		ResolvedDir: resolvedDir,
+		Dir:         opts.dir,
+		URL:         opts.url,
+		Result:      result,
 	})
 }

--- a/internal/atlasmigratereport/apply.go
+++ b/internal/atlasmigratereport/apply.go
@@ -1,0 +1,39 @@
+package atlasmigratereport
+
+import (
+	"io"
+	"os"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/internal/atlasreport"
+)
+
+type ApplyFormatOptions struct {
+	Conn        *dbschema.DatabaseConnection
+	ResolvedDir string
+	Dir         string
+	URL         string
+	Result      atlasmigrate.ApplyResult
+}
+
+// WriteApplyFormat renders Atlas migrate apply format output from the runtime
+// result produced by internal/atlasmigrate.
+func WriteApplyFormat(w io.Writer, format string, opts ApplyFormatOptions) error {
+	result := opts.Result
+	return atlasreport.WriteMigrateApplyFormat(w, format, atlasreport.MigrateApplyResultOptions{
+		Conn:             opts.Conn,
+		FS:               os.DirFS(opts.ResolvedDir),
+		Dir:              opts.Dir,
+		URL:              opts.URL,
+		Status:           result.Status,
+		Migrations:       result.Migrations,
+		SelectedVersions: result.SelectedVersions,
+		CurrentVersion:   result.CurrentVersion,
+		ErrorText:        result.ErrorText,
+		ApplyError:       result.ApplyError,
+		Applied:          result.Applied,
+		StartedAt:        result.StartedAt,
+		EndedAt:          result.EndedAt,
+	})
+}

--- a/internal/atlasmigratereport/apply_test.go
+++ b/internal/atlasmigratereport/apply_test.go
@@ -1,0 +1,69 @@
+package atlasmigratereport_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/internal/atlasmigratereport"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestWriteApplyFormat_CustomTemplate(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "runtime-format.db")
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join(migrationsDir, "1_create_users.sql"),
+			[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var out bytes.Buffer
+	startedAt := time.Unix(200, 0).UTC()
+	endedAt := time.Unix(201, 0).UTC()
+	err = atlasmigratereport.WriteApplyFormat(
+		&out,
+		`{{ .Driver }}|{{ .Dir }}|{{ len .Pending }}|{{ len .Applied }}|{{ .Target }}|{{ printf "%.12s" (index (index .Applied 0).Applied 0) }}`,
+		atlasmigratereport.ApplyFormatOptions{
+			Conn:        conn,
+			ResolvedDir: migrationsDir,
+			Dir:         "file://migrations",
+			URL:         "sqlite://" + dbPath,
+			Result: atlasmigrate.ApplyResult{
+				Status: &migrator.MigrationStatus{
+					CurrentVersion:    0,
+					PendingMigrations: []int64{1},
+				},
+				Migrations: []*migrator.Migration{
+					{
+						Version: 1,
+						UpSQL:   "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+					},
+				},
+				SelectedVersions: []int64{1},
+				Applied:          true,
+				StartedAt:        startedAt,
+				EndedAt:          endedAt,
+			},
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "sqlite|file://migrations|1|1|1|CREATE TABLE")
+}


### PR DESCRIPTION
## Summary
- add internal/atlasmigratereport as the adapter between atlasmigrate runtime results and atlasreport formatting
- remove migrate apply report-result field mapping from cmd/atlas
- keep cmd/atlas focused on stdout wiring and command flow

Refs #540

## Validation
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./cmd/atlas ./internal/atlasreport ./internal/atlasmigrate ./internal/atlasmigratereport
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go tool qtlint ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- env GOWORK=off GOCACHE=/private/tmp/ptah-gocache go test -count=1 ./...