### PR TITLE
docs: quick start generates migrations from annotations

### DIFF
--- a/docs/site/src/content/docs/getting-started.md
+++ b/docs/site/src/content/docs/getting-started.md
@@ -43,6 +43,8 @@ type User struct {
 EOF
 ```
 
+Prefer not to annotate Go structs? Ptah also reads the desired schema from an **Atlas HCL** file (or YAML and plain SQL) — see [Atlas HCL schema](../workflows/schema-files/#atlas-hcl-schema), where `ptah schema render --schema-file …` takes a file instead of `--root-dir`.
+
 ## Preview the SQL
 
 Before generating a migration, you can see the SQL your annotations produce:

--- a/docs/site/src/content/docs/getting-started.md
+++ b/docs/site/src/content/docs/getting-started.md
@@ -3,7 +3,7 @@ title: Quick start
 description: Build Ptah and run a complete local schema, migration, hash, Atlas-compatible, and cleanup flow.
 ---
 
-This guide is a copy-pasteable path from a fresh checkout to a working local SQLite migration run. Run commands from the Ptah repository root.
+This guide is a copy-pasteable path from a fresh checkout to a working local SQLite migration run. You annotate Go structs; Ptah generates the migrations from those annotations — you do not hand-write the SQL. Run commands from the Ptah repository root.
 
 ## Build the CLI
 
@@ -19,6 +19,8 @@ ptah version ...
 ```
 
 ## Create a tiny Go model
+
+The `//migrator:schema:*` annotations are your source of truth: they describe the desired schema, and every later step is driven from them.
 
 ```bash
 rm -rf /tmp/ptah-quickstart
@@ -41,7 +43,9 @@ type User struct {
 EOF
 ```
 
-## Render SQL
+## Preview the SQL
+
+Before generating a migration, you can see the SQL your annotations produce:
 
 ```bash
 ./bin/ptah schema render \
@@ -56,34 +60,41 @@ CREATE TABLE "users"
 "email" TEXT NOT NULL
 ```
 
-## Create and edit a migration
+## Generate the first migration
+
+Let Ptah write the migration for you. Point it at a throwaway SQLite database: because the database is empty, the difference between it and your annotated schema is the whole schema, so Ptah generates the full `CREATE TABLE` — and the matching rollback — automatically.
 
 ```bash
-./bin/ptah migrations create init \
-  --migrations-dir /tmp/ptah-quickstart/migrations
+DB_URL=sqlite:////tmp/ptah-quickstart/app.db
+
+./bin/ptah migrations generate \
+  --root-dir /tmp/ptah-quickstart/models \
+  --db-url "$DB_URL" \
+  --migrations-dir /tmp/ptah-quickstart/migrations \
+  --name init
 
 ls /tmp/ptah-quickstart/migrations
 ```
 
-Use the rendered SQL as a guide, write the `*.up.sql` body, and add the rollback:
+Ptah writes both the up and the down file:
 
-```bash
-up_file=$(ls /tmp/ptah-quickstart/migrations/*.up.sql)
-down_file=${up_file%.up.sql}.down.sql
-
-cat > "$up_file" <<'EOF'
-CREATE TABLE "users" (
-  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  "email" TEXT NOT NULL,
-  "name" TEXT,
-  CONSTRAINT "uni_users_email" UNIQUE ("email")
-);
-EOF
-
-cat > "$down_file" <<'EOF'
-DROP TABLE "users";
-EOF
+```text
+Generated migration files for sqlite:////tmp/ptah-quickstart/app.db:
+UP:   .../<timestamp>_init.up.sql
+DOWN: .../<timestamp>_init.down.sql
 ```
+
+The generated `*.up.sql` is derived from your annotations, not hand-written:
+
+```sql
+CREATE TABLE "users" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "email" TEXT NOT NULL UNIQUE,
+  "name" TEXT
+);
+```
+
+Prefer to author a migration by hand? `ptah migrations create <name> --migrations-dir /tmp/ptah-quickstart/migrations` scaffolds empty `*.up.sql` / `*.down.sql` files for you to fill in. This quick start uses generation so the annotations stay the single source of truth.
 
 ## Hash and validate the directory
 
@@ -98,11 +109,9 @@ Expected output includes:
 OK: migrations directory matches ptah.sum
 ```
 
-## Apply, inspect, status, and roll back
+## Apply and inspect
 
 ```bash
-DB_URL=sqlite:////tmp/ptah-quickstart/app.db
-
 ./bin/ptah migrations up \
   --db-url "$DB_URL" \
   --migrations-dir /tmp/ptah-quickstart/migrations \
@@ -113,7 +122,67 @@ DB_URL=sqlite:////tmp/ptah-quickstart/app.db
 ./bin/ptah migrations status \
   --db-url "$DB_URL" \
   --migrations-dir /tmp/ptah-quickstart/migrations
+```
 
+Expected output includes the applied version and the introspected `users` table:
+
+```text
+✅ Migrations completed successfully!
+Database is now at version: ...
+```
+
+## Change the schema and regenerate
+
+This is the loop Ptah is built for. Change your annotations and generate again: Ptah diffs your desired schema against the live database and writes a migration for **just the delta** — here, a new `posts` table — instead of a full rebuild.
+
+```bash
+cat > /tmp/ptah-quickstart/models/post.go <<'EOF'
+package models
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true" auto_increment="true" not_null="true"
+	ID int
+
+	//migrator:schema:field name="title" type="TEXT" not_null="true"
+	Title string
+}
+EOF
+
+./bin/ptah migrations generate \
+  --root-dir /tmp/ptah-quickstart/models \
+  --db-url "$DB_URL" \
+  --migrations-dir /tmp/ptah-quickstart/migrations \
+  --name add_posts
+```
+
+The new `*.up.sql` contains only the new table — `users` is left untouched because the database already has it:
+
+```sql
+CREATE TABLE "posts" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "title" TEXT NOT NULL
+);
+```
+
+Hash, apply, and confirm both tables now exist:
+
+```bash
+./bin/ptah migrations hash --dir /tmp/ptah-quickstart/migrations
+
+./bin/ptah migrations up \
+  --db-url "$DB_URL" \
+  --migrations-dir /tmp/ptah-quickstart/migrations \
+  --verify-sum
+
+./bin/ptah db read --db-url "$DB_URL"
+```
+
+Expected `db read` output now includes both `CREATE TABLE "posts"` and `CREATE TABLE "users"`.
+
+## Roll back
+
+```bash
 ./bin/ptah migrations down \
   --db-url "$DB_URL" \
   --migrations-dir /tmp/ptah-quickstart/migrations \
@@ -121,7 +190,7 @@ DB_URL=sqlite:////tmp/ptah-quickstart/app.db
   --confirm
 ```
 
-Expected status after `up` includes the initial migration as applied. The final `down` returns the database to an empty application schema.
+`--target 0` rolls back every applied migration, returning the database to an empty application schema.
 
 ## Try the Atlas-compatible path
 


### PR DESCRIPTION
## Problem

The quick start told the reader to annotate their Go structs and then **hand-write** the migration SQL with `ptah migrations create` + a `cat > *.up.sql <<EOF` heredoc. So the `//migrator:schema:*` annotations — Ptah's whole value proposition — never actually *drove* a migration. A newcomer's takeaway was "annotate, then transcribe the SQL by hand," which reasonably invites the question *"why annotate at all?"*

## Change

Rewrite the migration part of the quick start around `ptah migrations generate`:

- **Generate the first migration** — point `generate` at a throwaway SQLite database. Because it's empty, the diff against the annotated schema is the whole schema, so Ptah writes the full `CREATE TABLE` **and** the rollback automatically, straight from the annotations.
- **Change the schema and regenerate** — add a second entity (`posts`), run `generate` again, and Ptah emits a migration for *just the delta* (`CREATE TABLE "posts"`, `users` untouched). This is the loop Ptah is built for.
- `migrations create` is kept as a one-line note for hand-authored migrations, so the escape hatch is still discoverable without being the default path.

Scope is **documentation only** (`docs/site/src/content/docs/getting-started.md`); no product code changes.

## Verification

Every command in the rewritten guide was run end-to-end against SQLite: `render` → `generate init` → `hash`/`validate` → `up` (1 applied) → `status` → add `posts` → `generate add_posts` (delta migration) → `up` (2 tables) → `down --target 0` (clean) → `atlas migrate hash/validate`. All green.

### Note for follow-up (not in this PR)

While testing I hit a real product edge, unrelated to this doc change: on SQLite, `ptah migrations generate` for a **column addition** fails because the generated *down* migration would `DROP COLUMN`, which SQLite can't do without a table rebuild (`sqlite: dropping columns from table ... requires a table rebuild plan`). That's why the change-loop example adds a table rather than a column. Worth a separate issue if we want SQLite column-drop rebuild plans in the generator.