### PR TITLE
docs: remove unsupported `migrations plan --schema-file` from schema files workflow

### DIFF
--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -106,12 +106,13 @@ ptah atlas schema diff \
 
 ## Validate before applying
 
-Keep schema-file workflows reviewable:
+Preview the SQL Ptah derives from your schema file and review it before you apply anything:
 
 ```bash
 ptah schema render --schema-file schema.yaml --dialect postgres >/tmp/schema.sql
-ptah migrations plan --schema-file schema.yaml --db-url "$DATABASE_URL" >/tmp/plan.sql
 ```
 
-Review both files. The render output proves Ptah understood the desired schema;
-the plan output proves what would change in the target database.
+The rendered SQL proves Ptah understood the desired schema. Note that
+`--schema-file` currently feeds `ptah schema render` only — planning and
+generating migrations (`ptah migrations plan` / `ptah migrations generate`) read
+the desired schema from Go entities via `--root-dir`, not from a schema file.


### PR DESCRIPTION
Closes #566.

The **Validate before applying** section of the schema-files workflow told readers to run:

```bash
ptah migrations plan --schema-file schema.yaml --db-url "$DATABASE_URL" >/tmp/plan.sql
```

but `ptah migrations plan` does not accept `--schema-file` — copy-pasting it fails with an unknown-flag error. `--schema-file` is registered only for `ptah schema render` (`cmd/generate`); `migrations plan`, `migrations generate`, `schema compare`, and `schema drift` all read the desired schema from Go entities via `--root-dir`. So a schema file can be **rendered**, but not planned/diffed against a live database today.

## Change

Rewrite the section to render only, and state the limitation explicitly:

```bash
ptah schema render --schema-file schema.yaml --dialect postgres >/tmp/schema.sql
```

> The rendered SQL proves Ptah understood the desired schema. Note that `--schema-file` currently feeds `ptah schema render` only — planning and generating migrations read the desired schema from Go entities via `--root-dir`, not from a schema file.

Verified the retained command works on the doc's own YAML example (`schema render --schema-file … --dialect postgres` → valid `CREATE TABLE`, exit 0).

Docs-only change. The broader product option — teaching `migrations plan`/`generate` to accept `--schema-file` so file sources reach the diff path — is noted in #566 as a follow-up enhancement.