### PR TITLE
Support safe SQLite add-column rollbacks

### DIFF
--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -364,11 +364,15 @@ func (r *Renderer) VisitRawSQL(node *ast.RawSQLNode) error {
 }
 
 func (r *Renderer) writeTableOptions(options map[string]string) {
+	var tableOptions []string
 	if strings.EqualFold(options["STRICT"], "true") {
-		r.w.Write(" STRICT")
+		tableOptions = append(tableOptions, "STRICT")
 	}
 	if strings.EqualFold(options["WITHOUT_ROWID"], "true") || strings.EqualFold(options["WITHOUT ROWID"], "true") {
-		r.w.Write(" WITHOUT ROWID")
+		tableOptions = append(tableOptions, "WITHOUT ROWID")
+	}
+	if len(tableOptions) > 0 {
+		r.w.Write(" " + strings.Join(tableOptions, ", "))
 	}
 }
 

--- a/core/renderer/internal/dialects/sqlite/sqlite_test.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite_test.go
@@ -34,6 +34,23 @@ func TestRenderCreateTable(t *testing.T) {
 `)
 }
 
+func TestRenderCreateTableWithStrictAndWithoutRowID(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("users").
+		AddColumn(ast.NewColumn("id", "TEXT").SetPrimary())
+	table.SetOption("STRICT", "true")
+	table.SetOption("WITHOUT_ROWID", "true")
+
+	sql, err := renderer.RenderSQL("sqlite", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `CREATE TABLE "users" (
+  "id" TEXT PRIMARY KEY
+) STRICT, WITHOUT ROWID;
+`)
+}
+
 func TestRenderIndexes(t *testing.T) {
 	c := qt.New(t)
 

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -32,6 +32,8 @@ type DBTable struct {
 	Columns       []DBColumn `json:"columns"`
 	EstimatedRows int64      `json:"estimated_rows,omitempty"` // Best-effort planner estimate from database statistics
 	RLSEnabled    bool       `json:"rls_enabled"`              // Whether RLS is enabled on this table (PostgreSQL)
+	Strict        bool       `json:"strict,omitempty"`         // SQLite STRICT table option
+	WithoutRowID  bool       `json:"without_rowid,omitempty"`  // SQLite WITHOUT ROWID table option
 }
 
 // QualifiedName returns schema.table when Schema is set, or Name otherwise.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -204,8 +204,8 @@ value or wants to pin a specific server version in tests/CI.
   CHECK-drop spelling disabled because SQLite cannot add, drop, or modify
   table constraints in place; those operations require a table rebuild plan.
   The SQLite planner emits native `CREATE TABLE`, `ALTER TABLE ... ADD COLUMN`,
-  indexes, views, triggers, drops, and explicit rebuild-required errors for
-  unsupported structural changes.
+  conservative simple column-drop rebuilds, indexes, views, triggers, drops,
+  and explicit rebuild-required errors for unsupported structural changes.
 - **Trigger replacement (#158).** Planners mark modified triggers as replacement
   intent. Renderers emit `CREATE OR REPLACE TRIGGER` only when
   `create_or_replace_trigger` is present. PostgreSQL 14+ and MariaDB use

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -31,6 +31,10 @@ The SQLite renderer and planner support:
 - `DROP INDEX IF EXISTS` and `DROP TABLE IF EXISTS`.
 - `ALTER TABLE ... ADD COLUMN` for SQLite-native column additions, plus
   `RENAME COLUMN` and `RENAME TO`.
+- Simple column-drop plans through a table rebuild: create a temporary table
+  from the retained schema, copy retained columns, drop the original table,
+  rename the rebuilt table, and recreate retained indexes/triggers when their
+  metadata can be round-tripped safely.
 - Views without `WITH CHECK OPTION`.
 - Row-level triggers; SQLite does not support statement-level triggers.
 
@@ -56,10 +60,17 @@ table are ignored.
 ## ALTER TABLE Limits
 
 SQLite cannot add, drop, or modify table constraints in place, and many column
-shape changes require rebuilding the table. Ptah currently reports explicit
-errors for these cases instead of emitting unsafe or partial SQL:
+shape changes require rebuilding the table. Ptah emits a rebuild plan for simple
+column drops, including the down migration generated for SQLite add-column
+changes. Ptah still reports explicit errors instead of emitting unsafe or
+partial SQL for unsupported rebuild shapes:
 
-- dropping columns;
+- combining dropped columns with other table changes in the same diff;
+- dropping columns from tables referenced by inbound foreign keys;
+- dropping columns when the internal rebuild table name would collide with an
+  existing table;
+- dropping columns from tables whose retained triggers use SQLite syntax Ptah
+  cannot round-trip yet, such as `UPDATE OF` trigger columns;
 - modifying column type, nullability, default, primary key, unique, or generated
   column shape;
 - adding or removing table constraints on existing tables;
@@ -67,8 +78,8 @@ errors for these cases instead of emitting unsafe or partial SQL:
 - PostgreSQL-only objects such as extensions, materialized views, row-level
   security, roles, grants, and `EXCLUDE` constraints.
 
-Table rebuild planning is intentionally left as a separate feature. Until that
-exists, SQLite migrations should model rebuild-only changes manually.
+Broader table rebuild planning remains intentionally conservative. SQLite
+migrations should still model complex rebuild-only changes manually.
 
 `ALTER TABLE ... ADD COLUMN` has narrower SQLite rules than `CREATE TABLE`.
 Ptah only emits native add-column migrations for shapes SQLite can apply in

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -83,11 +83,13 @@ func convertTablesAndFields(
 		tableStructNames[dbTable.QualifiedName()] = structName
 
 		table := goschema.Table{
-			StructName: structName,
-			Name:       dbTable.Name,
-			Schema:     dbTable.Schema,
-			Comment:    dbTable.Comment,
-			PrimaryKey: primaryKeysByTable[dbTable.QualifiedName()],
+			StructName:   structName,
+			Name:         dbTable.Name,
+			Schema:       dbTable.Schema,
+			Comment:      dbTable.Comment,
+			PrimaryKey:   primaryKeysByTable[dbTable.QualifiedName()],
+			Strict:       dbTable.Strict,
+			WithoutRowID: dbTable.WithoutRowID,
 		}
 		database.Tables = append(database.Tables, table)
 

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -470,6 +470,28 @@ func TestConvertDBSchemaToGoSchema_ColumnCharsetCollate(t *testing.T) {
 	c.Assert(result.Fields[0].Collate, qt.Equals, "hebrew_general_ci")
 }
 
+func TestConvertDBSchemaToGoSchema_SQLiteTableOptions(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name:         "users",
+			Strict:       true,
+			WithoutRowID: true,
+			Columns: []types.DBColumn{{
+				Name:         "id",
+				DataType:     "TEXT",
+				IsPrimaryKey: true,
+			}},
+		}},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Tables, qt.HasLen, 1)
+	c.Assert(result.Tables[0].Strict, qt.IsTrue)
+	c.Assert(result.Tables[0].WithoutRowID, qt.IsTrue)
+}
+
 func TestConvertDBSchemaToGoSchema_ExtensionDefaultValues(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dbschema/sqlite/reader.go
+++ b/internal/dbschema/sqlite/reader.go
@@ -57,7 +57,7 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	var schema types.DBSchema
 	for _, tableName := range catalog.tableNames {
 		ddl := catalog.tableDDLByName[tableName]
-		table := r.readTable(tableName, columnsByTable[tableName])
+		table := r.readTable(tableName, columnsByTable[tableName], ddl)
 		schema.Tables = append(schema.Tables, table)
 
 		schema.Indexes = append(schema.Indexes, indexesByTable[tableName]...)
@@ -171,13 +171,25 @@ func (r *Reader) readSchemaCatalog() (sqliteSchemaCatalog, error) {
 	return catalog, nil
 }
 
-func (r *Reader) readTable(name string, columns []types.DBColumn) types.DBTable {
+func (r *Reader) readTable(name string, columns []types.DBColumn, ddl string) types.DBTable {
+	strict, withoutRowID := sqliteTableOptions(ddl)
 	return types.DBTable{
-		Name:    name,
-		Schema:  r.outputSchema(),
-		Type:    "TABLE",
-		Columns: columns,
+		Name:         name,
+		Schema:       r.outputSchema(),
+		Type:         "TABLE",
+		Columns:      columns,
+		Strict:       strict,
+		WithoutRowID: withoutRowID,
 	}
+}
+
+func sqliteTableOptions(ddl string) (strict bool, withoutRowID bool) {
+	idx := strings.LastIndex(ddl, ")")
+	if idx < 0 {
+		return false, false
+	}
+	tail := strings.ToUpper(ddl[idx+1:])
+	return strings.Contains(tail, "STRICT"), strings.Contains(tail, "WITHOUT ROWID")
 }
 
 func (r *Reader) outputSchema() string {
@@ -1347,15 +1359,16 @@ func parseTriggerDDL(name, table, schema, ddl string) types.DBTrigger {
 		ForEach: "ROW",
 		Body:    strings.TrimSpace(ddl),
 	}
-	matches := triggerHeaderPattern.FindStringSubmatch(ddl)
+	matches := triggerHeaderPattern.FindStringSubmatchIndex(ddl)
 	if len(matches) == 0 {
 		return trigger
 	}
-	trigger.Timing = strings.ToUpper(strings.Join(strings.Fields(matches[1]), " "))
-	trigger.Event = strings.ToUpper(matches[2])
-	trigger.Table = strings.Trim(matches[3], `"`)
-	if strings.TrimSpace(matches[4]) != "" {
-		trigger.ForEach = strings.ToUpper(matches[4])
+	trigger.Body = strings.TrimSpace(ddl[matches[1]:])
+	trigger.Timing = strings.ToUpper(strings.Join(strings.Fields(ddl[matches[2]:matches[3]]), " "))
+	trigger.Event = strings.ToUpper(ddl[matches[4]:matches[5]])
+	trigger.Table = strings.Trim(ddl[matches[6]:matches[7]], `"`)
+	if matches[8] >= 0 {
+		trigger.ForEach = strings.ToUpper(ddl[matches[8]:matches[9]])
 	}
 	return trigger
 }

--- a/internal/dbschema/sqlite/table_options_test.go
+++ b/internal/dbschema/sqlite/table_options_test.go
@@ -1,0 +1,29 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/sqlite"
+)
+
+func TestReaderTableOptions(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT NOT NULL) WITHOUT ROWID, STRICT`)
+	c.Assert(err, qt.IsNil)
+
+	schema, err := sqlite.NewSQLiteReader(db, "main").ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(schema.Tables, qt.HasLen, 1)
+	c.Assert(schema.Tables[0].Strict, qt.IsTrue)
+	c.Assert(schema.Tables[0].WithoutRowID, qt.IsTrue)
+}

--- a/internal/dbschema/sqlite/trigger_body_test.go
+++ b/internal/dbschema/sqlite/trigger_body_test.go
@@ -1,0 +1,31 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/sqlite"
+)
+
+func TestReaderTriggerBodyExcludesCreateTriggerHeader(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, `CREATE TRIGGER trg_users_email AFTER UPDATE ON users FOR EACH ROW BEGIN SELECT NEW.email; END`)
+	c.Assert(err, qt.IsNil)
+
+	schema, err := sqlite.NewSQLiteReader(db, "main").ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(schema.Triggers, qt.HasLen, 1)
+	c.Assert(schema.Triggers[0].Body, qt.Contains, "BEGIN SELECT NEW.email; END")
+	c.Assert(schema.Triggers[0].Body, qt.Not(qt.Contains), "CREATE TRIGGER")
+}

--- a/internal/planner/dialects/sqlite/sqlite.go
+++ b/internal/planner/dialects/sqlite/sqlite.go
@@ -47,7 +47,11 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 		return nil, err
 	}
 	result = append(result, addedTables...)
-	result = append(result, p.modifyTables(diff, generated)...)
+	modifiedTables, err := p.modifyTables(diff, generated)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, modifiedTables...)
 	result = append(result, p.addViews(diff, generated)...)
 	result = append(result, p.modifyViews(diff, generated)...)
 	result = append(result, p.addTriggers(diff, generated)...)
@@ -76,10 +80,11 @@ func rejectUnsupportedChanges(diff *types.SchemaDiff) error {
 func rejectUnsupportedTableChanges(diff *types.SchemaDiff) error {
 	for _, table := range diff.TablesModified {
 		switch {
-		case len(table.ColumnsRemoved) > 0:
-			return unsupportedFeaturef("dropping columns from table %s requires a table rebuild plan", table.TableName)
 		case len(table.ColumnsModified) > 0:
 			return unsupportedFeaturef("modifying columns on table %s requires a table rebuild plan", table.TableName)
+		case len(table.ColumnsRemoved) > 0 && (len(table.ColumnsAdded) > 0 ||
+			len(table.ConstraintsAdded) > 0 || len(table.ConstraintsRemoved) > 0):
+			return unsupportedFeaturef("combining dropped columns with other table changes on %s requires a manual rebuild plan", table.TableName)
 		case len(table.ConstraintsAdded) > 0 || len(table.ConstraintsRemoved) > 0:
 			return unsupportedFeaturef("changing constraints on table %s requires a table rebuild plan", table.TableName)
 		}
@@ -179,9 +184,17 @@ func withDefaultForeignKeyName(tableName string, constraint goschema.Constraint)
 	return constraint
 }
 
-func (p *Planner) modifyTables(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+func (p *Planner) modifyTables(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error) {
 	var result []ast.Node
 	for _, tableDiff := range diff.TablesModified {
+		if len(tableDiff.ColumnsRemoved) > 0 {
+			nodes, err := p.rebuildTableWithoutColumns(tableDiff, diff, generated)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, nodes...)
+			continue
+		}
 		for _, columnName := range tableDiff.ColumnsAdded {
 			if column := findColumn(generated, tableDiff.TableName, columnName); column != nil {
 				result = append(result, &ast.AlterTableNode{
@@ -191,7 +204,191 @@ func (p *Planner) modifyTables(diff *types.SchemaDiff, generated *goschema.Datab
 			}
 		}
 	}
-	return result
+	return result, nil
+}
+
+func (p *Planner) rebuildTableWithoutColumns(
+	tableDiff types.TableDiff,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+) ([]ast.Node, error) {
+	table := findTable(generated.Tables, tableDiff.TableName)
+	if table == nil {
+		return nil, unsupportedFeaturef("rebuilding table %s requires the retained table definition", tableDiff.TableName)
+	}
+	if err := validateRebuildTablePreconditions(*table, diff, generated); err != nil {
+		return nil, err
+	}
+
+	tempName := rebuildTableName(*table)
+
+	createNode := fromschema.FromTable(*table, generated.Fields, generated.Enums, DialectName)
+	if err := addInlineConstraints(createNode, *table, generated.Constraints); err != nil {
+		return nil, err
+	}
+	createNode.Name = qualifyLikeTable(*table, tempName)
+
+	columns := rebuildColumnNames(*table, generated.Fields)
+	if len(columns) == 0 {
+		return nil, unsupportedFeaturef("rebuilding table %s without retained columns is not supported", table.QualifiedName())
+	}
+
+	nodes := []ast.Node{
+		ast.NewComment("SQLite table rebuild to remove unsupported columns from " + table.QualifiedName()),
+		createNode,
+		ast.NewRawSQL("INSERT INTO " + quoteQualifiedIdentifier(createNode.Name) +
+			" (" + quoteIdentifierList(columns) + ") SELECT " + quoteIdentifierList(columns) +
+			" FROM " + quoteQualifiedIdentifier(table.QualifiedName()) + ";"),
+		ast.NewDropTable(table.QualifiedName()),
+		ast.NewRawSQL("ALTER TABLE " + quoteQualifiedIdentifier(createNode.Name) +
+			" RENAME TO " + quoteIdentifier(table.Name) + ";"),
+	}
+	nodes = append(nodes, p.recreateTableIndexes(*table, generated)...)
+	triggers, err := p.recreateTableTriggers(*table, generated)
+	if err != nil {
+		return nil, err
+	}
+	nodes = append(nodes, triggers...)
+	return nodes, nil
+}
+
+func validateRebuildTablePreconditions(table goschema.Table, diff *types.SchemaDiff, generated *goschema.Database) error {
+	tempName := rebuildTableName(table)
+	if tableNameCollides(generated.Tables, table, tempName) || removedTableNameCollides(diff.TablesRemoved, table, tempName) {
+		return unsupportedFeaturef("rebuilding table %s would collide with existing table %s", table.QualifiedName(), tempName)
+	}
+	if hasInboundForeignKey(table, generated) {
+		return unsupportedFeaturef("rebuilding table %s with inbound foreign keys requires a manual rebuild plan", table.QualifiedName())
+	}
+	return nil
+}
+
+func findTable(tables []goschema.Table, name string) *goschema.Table {
+	for i := range tables {
+		if tables[i].Name == name || tables[i].QualifiedName() == name {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func rebuildTableName(table goschema.Table) string {
+	return "__ptah_rebuild_" + table.Name
+}
+
+func tableNameCollides(tables []goschema.Table, target goschema.Table, name string) bool {
+	for _, table := range tables {
+		if table.Schema == target.Schema && table.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func removedTableNameCollides(removed []string, target goschema.Table, name string) bool {
+	qualified := qualifyLikeTable(target, name)
+	for _, tableName := range removed {
+		if tableName == name || tableName == qualified {
+			return true
+		}
+	}
+	return false
+}
+
+func qualifyLikeTable(table goschema.Table, name string) string {
+	if strings.TrimSpace(table.Schema) == "" {
+		return name
+	}
+	return table.Schema + "." + name
+}
+
+func rebuildColumnNames(table goschema.Table, fields []goschema.Field) []string {
+	var columns []string
+	for _, field := range fields {
+		if field.StructName == table.StructName {
+			columns = append(columns, field.Name)
+		}
+	}
+	return columns
+}
+
+func (p *Planner) recreateTableIndexes(table goschema.Table, generated *goschema.Database) []ast.Node {
+	tableMap := structToTableMap(generated.Tables)
+	var nodes []ast.Node
+	for _, index := range generated.Indexes {
+		tableName := generatedIndexTableName(index, tableMap)
+		if tableName == table.Name || tableName == table.QualifiedName() {
+			nodes = append(nodes, fromschema.FromIndexWithTableMapping(index, tableMap))
+		}
+	}
+	return nodes
+}
+
+func generatedIndexTableName(index goschema.Index, tableMap map[string]string) string {
+	if strings.TrimSpace(index.TableName) != "" {
+		return index.TableName
+	}
+	return tableMap[index.StructName]
+}
+
+func hasInboundForeignKey(table goschema.Table, generated *goschema.Database) bool {
+	for _, field := range generated.Fields {
+		fkRef := fromschema.ParseForeignKeyReference(field.Foreign)
+		if fkRef != nil && tableMatchesName(table, fkRef.Table) {
+			return true
+		}
+	}
+	for _, constraint := range generated.Constraints {
+		if strings.EqualFold(constraint.Type, "FOREIGN KEY") && tableMatchesName(table, constraint.ForeignTable) {
+			return true
+		}
+	}
+	return false
+}
+
+func tableMatchesName(table goschema.Table, name string) bool {
+	return name == table.Name || name == table.QualifiedName()
+}
+
+func (p *Planner) recreateTableTriggers(table goschema.Table, generated *goschema.Database) ([]ast.Node, error) {
+	var nodes []ast.Node
+	for _, trigger := range generated.Triggers {
+		if trigger.Table == table.Name || trigger.Table == table.QualifiedName() {
+			if triggerBodyContainsCreateTrigger(trigger.Body) {
+				return nil, unsupportedFeaturef(
+					"rebuilding table %s with trigger %s requires a manual rebuild plan",
+					table.QualifiedName(),
+					trigger.Name,
+				)
+			}
+			nodes = append(nodes, fromschema.FromTrigger(trigger))
+		}
+	}
+	return nodes, nil
+}
+
+func triggerBodyContainsCreateTrigger(body string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(body)), "CREATE TRIGGER")
+}
+
+func quoteIdentifierList(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = quoteIdentifier(name)
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func quoteQualifiedIdentifier(name string) string {
+	parts := strings.Split(name, ".")
+	for i, part := range parts {
+		parts[i] = quoteIdentifier(part)
+	}
+	return strings.Join(parts, ".")
+}
+
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func validateAddedColumns(diff *types.SchemaDiff, generated *goschema.Database) error {

--- a/internal/planner/dialects/sqlite/sqlite_test.go
+++ b/internal/planner/dialects/sqlite/sqlite_test.go
@@ -93,6 +93,148 @@ func TestPlannerAddsColumnsAndIndexes(t *testing.T) {
 	c.Assert(sql, qt.Contains, `CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_display_name" ON "users" ("display_name") WHERE display_name IS NOT NULL`)
 }
 
+func TestPlannerRebuildsTableWhenDroppingColumn(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+			{Name: "email", Type: "TEXT", StructName: "User", Nullable: false},
+		},
+		Indexes: []goschema.Index{{
+			Name:       "idx_users_email",
+			StructName: "User",
+			Fields:     []string{"email"},
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:    "trg_users_email",
+			Table:   "users",
+			Timing:  "AFTER",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "BEGIN SELECT NEW.email; END",
+		}},
+	}
+	diff := &types.SchemaDiff{TablesModified: []types.TableDiff{{
+		TableName:      "users",
+		ColumnsRemoved: []string{"name"},
+	}}}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.SQLite)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, `CREATE TABLE "__ptah_rebuild_users"`)
+	c.Assert(sql, qt.Contains, `INSERT INTO "__ptah_rebuild_users" ("id", "email") SELECT "id", "email" FROM "users";`)
+	c.Assert(sql, qt.Contains, `DROP TABLE "users";`)
+	c.Assert(sql, qt.Contains, `ALTER TABLE "__ptah_rebuild_users" RENAME TO "users";`)
+	c.Assert(sql, qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
+	c.Assert(sql, qt.Contains, `CREATE TRIGGER "trg_users_email" AFTER UPDATE ON "users" FOR EACH ROW BEGIN SELECT NEW.email; END;`)
+	c.Assert(sql, qt.Not(qt.Contains), "DROP COLUMN")
+}
+
+func TestPlannerRejectsUnsafeTableRebuildPreconditions(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		generated *goschema.Database
+		want      string
+	}{
+		{
+			name: "temporary table name collision",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "users", StructName: "User"},
+					{Name: "__ptah_rebuild_users", StructName: "RebuildUser"},
+				},
+				Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+			},
+			want: `sqlite: rebuilding table users would collide with existing table __ptah_rebuild_users`,
+		},
+		{
+			name: "inbound field foreign key",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "users", StructName: "User"},
+					{Name: "posts", StructName: "Post"},
+				},
+				Fields: []goschema.Field{
+					{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+					{Name: "user_id", Type: "INTEGER", StructName: "Post", Foreign: "users(id)"},
+				},
+			},
+			want: `sqlite: rebuilding table users with inbound foreign keys requires a manual rebuild plan`,
+		},
+		{
+			name: "inbound table foreign key",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "users", StructName: "User"},
+					{Name: "memberships", StructName: "Membership"},
+				},
+				Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+				Constraints: []goschema.Constraint{{
+					Type:           "FOREIGN KEY",
+					Table:          "memberships",
+					Columns:        []string{"user_id", "tenant_id"},
+					ForeignTable:   "users",
+					ForeignColumns: []string{"id", "tenant_id"},
+				}},
+			},
+			want: `sqlite: rebuilding table users with inbound foreign keys requires a manual rebuild plan`,
+		},
+		{
+			name: "unsupported trigger syntax",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+				Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+				Triggers: []goschema.Trigger{{
+					Name:  "trg_users_email",
+					Table: "users",
+					Body:  "CREATE TRIGGER trg_users_email AFTER UPDATE OF email ON users BEGIN SELECT NEW.email; END",
+				}},
+			},
+			want: `sqlite: rebuilding table users with trigger trg_users_email requires a manual rebuild plan`,
+		},
+	}
+	diff := &types.SchemaDiff{TablesModified: []types.TableDiff{{
+		TableName:      "users",
+		ColumnsRemoved: []string{"name"},
+	}}}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			nodes, err := planner.GenerateSchemaDiffAST(diff, tt.generated, platform.SQLite)
+			c.Assert(nodes, qt.IsNil)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}
+
+func TestPlannerRejectsTableRebuildTempNameRemovedTableCollision(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+	}
+	diff := &types.SchemaDiff{
+		TablesRemoved: []string{"__ptah_rebuild_users"},
+		TablesModified: []types.TableDiff{{
+			TableName:      "users",
+			ColumnsRemoved: []string{"name"},
+		}},
+	}
+
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.SQLite)
+
+	c.Assert(nodes, qt.IsNil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `sqlite: rebuilding table users would collide with existing table __ptah_rebuild_users`)
+}
+
 func TestPlannerRejectsAddColumnShapesThatNeedRebuild(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -175,13 +317,6 @@ func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
 		want string
 	}{
 		{
-			name: "drop column",
-			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{
-				{TableName: "users", ColumnsRemoved: []string{"name"}},
-			}},
-			want: "sqlite: dropping columns from table users requires a table rebuild plan",
-		},
-		{
 			name: "modify column",
 			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{
 				{TableName: "users", ColumnsModified: []types.ColumnDiff{{ColumnName: "name"}}},
@@ -200,32 +335,13 @@ func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
 			diff: &types.SchemaDiff{EnumsModified: []types.EnumDiff{{EnumName: "enum_users_status"}}},
 			want: "sqlite: changing enum-backed CHECK constraints requires a table rebuild plan",
 		},
-		{
-			name: "exclude constraint",
-			diff: &types.SchemaDiff{TablesAdded: []string{"bookings"}},
-			want: "sqlite: EXCLUDE constraints are not supported",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			generated := &goschema.Database{}
-			if tt.name == "exclude constraint" {
-				generated = &goschema.Database{
-					Tables: []goschema.Table{{Name: "bookings", StructName: "Booking"}},
-					Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "Booking", Primary: true}},
-					Constraints: []goschema.Constraint{{
-						Name:            "no_overlap",
-						Type:            "EXCLUDE",
-						StructName:      "Booking",
-						UsingMethod:     "gist",
-						ExcludeElements: "room_id WITH =",
-					}},
-				}
-			}
 
-			nodes, err := planner.GenerateSchemaDiffAST(tt.diff, generated, platform.SQLite)
+			nodes, err := planner.GenerateSchemaDiffAST(tt.diff, &goschema.Database{}, platform.SQLite)
 			c.Assert(nodes, qt.IsNil)
 			var planErr *ptaherr.PlanError
 			c.Assert(err, qt.ErrorAs, &planErr)
@@ -234,4 +350,30 @@ func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
 			c.Assert(err, qt.ErrorMatches, tt.want)
 		})
 	}
+}
+
+func TestPlannerRejectsSQLiteExcludeConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "bookings", StructName: "Booking"}},
+		Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "Booking", Primary: true}},
+		Constraints: []goschema.Constraint{{
+			Name:            "no_overlap",
+			Type:            "EXCLUDE",
+			StructName:      "Booking",
+			UsingMethod:     "gist",
+			ExcludeElements: "room_id WITH =",
+		}},
+	}
+	diff := &types.SchemaDiff{TablesAdded: []string{"bookings"}}
+
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.SQLite)
+
+	c.Assert(nodes, qt.IsNil)
+	var planErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &planErr)
+	c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, "sqlite: EXCLUDE constraints are not supported")
 }

--- a/migration/generator/sqlite_add_column_test.go
+++ b/migration/generator/sqlite_add_column_test.go
@@ -1,0 +1,329 @@
+package generator_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestGenerateMigration_SQLiteAddColumnHasApplicableDownMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	modelsDir := filepath.Join(tempDir, "models")
+	migrationsDir := filepath.Join(tempDir, "migrations")
+	dbURL := "sqlite://" + filepath.Join(tempDir, "app.db")
+	c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "user.go"), []byte(sqliteAddColumnModel), 0o600), qt.IsNil)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `CREATE INDEX idx_users_email ON users (email)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `CREATE TRIGGER trg_users_email AFTER UPDATE ON users FOR EACH ROW BEGIN SELECT NEW.email; END`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `INSERT INTO users (id, email) VALUES (1, 'a@example.test')`)
+	c.Assert(err, qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: modelsDir,
+		DBConn:        conn,
+		MigrationName: "add_name",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	downSQL, err := os.ReadFile(files.Files[0].DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downSQL), qt.Contains, `CREATE TABLE "__ptah_rebuild_users"`)
+	c.Assert(string(downSQL), qt.Not(qt.Contains), "DROP COLUMN")
+
+	mig, err := migrator.NewFSMigrator(conn, os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	c.Assert(sqliteColumnCount(c, conn, "users", "name"), qt.Equals, 1)
+
+	c.Assert(mig.MigrateDownTo(ctx, 0), qt.IsNil)
+	c.Assert(sqliteColumnCount(c, conn, "users", "name"), qt.Equals, 0)
+	c.Assert(sqliteSchemaObjectCount(c, conn, "index", "idx_users_email", "users"), qt.Equals, 1)
+	c.Assert(sqliteSchemaObjectCount(c, conn, "trigger", "trg_users_email", "users"), qt.Equals, 1)
+	c.Assert(sqliteUserEmail(c, conn), qt.Equals, "a@example.test")
+}
+
+func TestGenerateMigration_SQLiteAddColumnPreservesStrictWithoutRowID(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	modelsDir := filepath.Join(tempDir, "models")
+	migrationsDir := filepath.Join(tempDir, "migrations")
+	dbURL := "sqlite://" + filepath.Join(tempDir, "app.db")
+	c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "user.go"), []byte(sqliteStrictAddColumnModel), 0o600), qt.IsNil)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(ctx, `CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT NOT NULL) WITHOUT ROWID, STRICT`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `INSERT INTO users (id, email) VALUES ('u1', 'strict@example.test')`)
+	c.Assert(err, qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: modelsDir,
+		DBConn:        conn,
+		MigrationName: "add_name",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+
+	mig, err := migrator.NewFSMigrator(conn, os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	c.Assert(mig.MigrateDownTo(ctx, 0), qt.IsNil)
+	c.Assert(sqliteTableSQL(c, conn, "users"), qt.Contains, "WITHOUT ROWID")
+	c.Assert(sqliteTableSQL(c, conn, "users"), qt.Contains, "STRICT")
+	c.Assert(sqliteUserEmailByID(c, conn, "u1"), qt.Equals, "strict@example.test")
+}
+
+func TestGenerateMigration_SQLiteAddColumnRejectsInboundForeignKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		childDDL string
+		model    string
+	}{
+		{
+			name:     "no action child",
+			childDDL: `CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL REFERENCES users(id))`,
+			model:    sqliteAddColumnWithChildModel,
+		},
+		{
+			name:     "cascade child",
+			childDDL: `CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE)`,
+			model:    sqliteAddColumnWithCascadeChildModel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx := context.Background()
+			tempDir := t.TempDir()
+			modelsDir := filepath.Join(tempDir, "models")
+			migrationsDir := filepath.Join(tempDir, "migrations")
+			dbURL := "sqlite://" + filepath.Join(tempDir, "app.db")
+			c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+			c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+			c.Assert(os.WriteFile(filepath.Join(modelsDir, "schema.go"), []byte(tt.model), 0o600), qt.IsNil)
+
+			conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+			c.Assert(err, qt.IsNil)
+			defer dbschema.CloseAndWarn(conn)
+			_, err = conn.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`)
+			c.Assert(err, qt.IsNil)
+			_, err = conn.ExecContext(ctx, tt.childDDL)
+			c.Assert(err, qt.IsNil)
+
+			files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+				GoEntitiesDir: modelsDir,
+				DBConn:        conn,
+				MigrationName: "add_name",
+				OutputDir:     migrationsDir,
+			})
+			c.Assert(files, qt.IsNil)
+			c.Assert(err, qt.ErrorMatches, `.*sqlite: rebuilding table users with inbound foreign keys requires a manual rebuild plan.*`)
+		})
+	}
+}
+
+func TestGenerateMigration_SQLiteAddColumnRejectsUnsupportedTriggerSyntax(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	modelsDir := filepath.Join(tempDir, "models")
+	migrationsDir := filepath.Join(tempDir, "migrations")
+	dbURL := "sqlite://" + filepath.Join(tempDir, "app.db")
+	c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "user.go"), []byte(sqliteAddColumnWithTriggerModel), 0o600), qt.IsNil)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `CREATE TRIGGER trg_users_email AFTER UPDATE OF email ON users FOR EACH ROW BEGIN SELECT NEW.email; END`)
+	c.Assert(err, qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: modelsDir,
+		DBConn:        conn,
+		MigrationName: "add_name",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(files, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `.*sqlite: rebuilding table users with trigger trg_users_email requires a manual rebuild plan.*`)
+}
+
+const sqliteAddColumnModel = `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:index name="idx_users_email" fields="email"
+	//migrator:schema:trigger name="trg_users_email" table="users" timing="after" event="update" body="BEGIN SELECT NEW.email; END"
+
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+`
+
+const sqliteStrictAddColumnModel = `package models
+
+//migrator:schema:table name="users" platform.sqlite.strict="true" platform.sqlite.without_rowid="true"
+type User struct {
+	//migrator:schema:field name="id" type="TEXT" primary="true"
+	ID string
+
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+`
+
+const sqliteAddColumnWithChildModel = `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)"
+	UserID int64
+}
+`
+
+const sqliteAddColumnWithCascadeChildModel = `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+
+//migrator:schema:table name="posts"
+type Post struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true" foreign="users(id)" on_delete="CASCADE"
+	UserID int64
+}
+`
+
+const sqliteAddColumnWithTriggerModel = `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:trigger name="trg_users_email" table="users" timing="after" event="update" body="BEGIN SELECT NEW.email; END"
+
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+`
+
+func sqliteColumnCount(c *qt.C, conn *dbschema.DatabaseConnection, table, column string) int {
+	c.Helper()
+	query := fmt.Sprintf("SELECT COUNT(*) FROM pragma_table_info(%s) WHERE name = ?", quoteSQLiteString(table))
+	var count int
+	err := conn.QueryRowContext(context.Background(), query, column).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func sqliteSchemaObjectCount(c *qt.C, conn *dbschema.DatabaseConnection, objectType, name, table string) int {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM sqlite_schema WHERE type = ? AND name = ? AND tbl_name = ?",
+		objectType,
+		name,
+		table,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func sqliteTableSQL(c *qt.C, conn *dbschema.DatabaseConnection, table string) string {
+	c.Helper()
+	var sql string
+	err := conn.QueryRowContext(context.Background(), "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ?", table).Scan(&sql)
+	c.Assert(err, qt.IsNil)
+	return sql
+}
+
+func sqliteUserEmail(c *qt.C, conn *dbschema.DatabaseConnection) string {
+	c.Helper()
+	var email string
+	err := conn.QueryRowContext(context.Background(), "SELECT email FROM users WHERE id = 1").Scan(&email)
+	c.Assert(err, qt.IsNil)
+	return email
+}
+
+func sqliteUserEmailByID(c *qt.C, conn *dbschema.DatabaseConnection, id string) string {
+	c.Helper()
+	var email string
+	err := conn.QueryRowContext(context.Background(), "SELECT email FROM users WHERE id = ?", id).Scan(&email)
+	c.Assert(err, qt.IsNil)
+	return email
+}
+
+func quoteSQLiteString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -191,7 +191,7 @@ func TestGenerateSchemaDiffAST_WrapsPlannerFailures(t *testing.T) {
 	c.Assert(err, qt.ErrorAs, &planErr)
 	c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
 	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
-	c.Assert(err, qt.ErrorMatches, "sqlite: dropping columns from table users requires a table rebuild plan")
+	c.Assert(err, qt.ErrorMatches, "sqlite: rebuilding table users requires the retained table definition")
 }
 
 func TestRequiresNoTransaction(t *testing.T) {


### PR DESCRIPTION
## Summary
- add conservative SQLite table-rebuild planning for simple column drops, which makes generated SQLite add-column down migrations executable
- preserve SQLite STRICT / WITHOUT ROWID table options through reader -> DB schema -> Go schema -> renderer round-trips
- reject unsafe rebuild shapes explicitly: inbound foreign keys, temp-table name collisions, missing retained table definitions, and retained triggers whose SQLite syntax cannot be round-tripped safely
- document the supported SQLite rebuild subset and remaining manual-rebuild cases

Closes #565

## Self-review
- Pass 1 caught per-iteration allocation/style and focused on executable up/down rollback for the simple SQLite add-column case.
- Pass 2 found a real trigger round-trip bug: SQLite reader stored full CREATE TRIGGER text as trigger body, causing invalid nested trigger SQL during rebuild. Fixed with reader body extraction and live rollback coverage.
- Multi-agent pass found safety gaps around inbound FKs, STRICT/WITHOUT ROWID preservation, missing target no-op, unsupported UPDATE OF trigger syntax, and temp-name collisions. Those are now fixed or rejected with tests.

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./core/renderer/internal/dialects/sqlite ./internal/dbschema/sqlite ./internal/convert/dbschematogo ./internal/planner/dialects/sqlite ./migration/generator ./migration/planner
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache scripts/check-public-api-snapshot.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./... (all packages passed except sandbox-only dbschema local listener bind)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./dbschema (rerun outside sandbox; passed)