### PR TITLE
Support atlas schema apply format templates

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1063,24 +1063,6 @@ func TestNewCompatCommand_SchemaApplyDryRunUsesAtlasRoot(t *testing.T) {
 	assertSQLiteTableMissing(c, dbPath, "users")
 }
 
-func TestNewAtlasCommand_SchemaApplyRejectsUnsupportedFormat(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewAtlasCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{
-		"schema", "apply",
-		"--url", "sqlite://apply.db",
-		"--to", "file://schema.sql",
-		"--format", "{{ sql . }}",
-	})
-
-	err := cmd.Execute()
-
-	c.Assert(err, qt.ErrorMatches, `atlas schema apply accepts --format, but Ptah does not implement its behavior yet`)
-}
-
 func TestNewAtlasCommand_SchemaApplyRejectsDevURLDialectMismatch(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -1,6 +1,7 @@
 package atlas
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -36,7 +38,7 @@ Compares a live database from --url with local --to schema files and applies the
 generated schema changes directly to the target database. This implementation
 currently supports local file:// schema files with .hcl, .yaml, .yml, or .sql
 extensions. Database desired-state URLs, Atlas project env:// URLs, schema
-filters, and custom output templates remain explicit follow-up gaps.`,
+filters, and Atlas Cloud planning remain explicit follow-up gaps.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaApply(cmd, opts)
 		},
@@ -60,6 +62,15 @@ filters, and custom output templates remain explicit follow-up gaps.`,
 }
 
 func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error {
+	formatOutput := cmd.Flags().Changed("format")
+	if formatOutput && strings.TrimSpace(opts.format) == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
+	}
+	if formatOutput {
+		if err := atlasreport.ValidateSchemaApplyTemplate(opts.format); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
+	}
 	if err := validateAtlasSchemaApplyOptions(cmd, opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -86,19 +97,43 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		return cmdutil.Fail(cmd, err)
 	}
 	if !plan.HasChanges() {
+		if formatOutput {
+			return writeAtlasSchemaApplyFormat(cmd, opts, plan.Statements())
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Schema is synced, no changes to be made.")
 		return nil
 	}
 
+	formattedPlan := ""
 	sqlText := plan.SQL()
-	printAtlasSchemaApplyPlan(cmd.OutOrStdout(), sqlText)
+	if formatOutput {
+		var err error
+		formattedPlan, err = renderAtlasSchemaApplyFormat(opts, plan.Statements())
+		if err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
+		fmt.Fprint(cmd.OutOrStdout(), formattedPlan)
+	} else {
+		printAtlasSchemaApplyPlan(cmd.OutOrStdout(), sqlText)
+	}
 	if opts.dryRun {
 		return nil
 	}
 
-	ok, err := confirmAtlasSchemaApply(opts, cmd.OutOrStdout(), cmd.InOrStdin())
-	if err != nil {
-		return cmdutil.Fail(cmd, err)
+	ok := true
+	if opts.autoApprove {
+		if !formatOutput {
+			fmt.Fprintln(cmd.OutOrStdout(), "Auto-approval enabled; applying schema changes.")
+		}
+	} else {
+		if formatOutput && !strings.HasSuffix(formattedPlan, "\n") {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		var err error
+		ok, err = promptAtlasSchemaApplyConfirmation(cmd.OutOrStdout(), cmd.InOrStdin())
+		if err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 	if !ok {
 		return nil
@@ -106,6 +141,9 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 
 	if err := plan.Execute(cmd.Context()); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("apply schema changes: %w", err))
+	}
+	if formatOutput {
+		return nil
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Schema apply completed successfully.")
 	return nil
@@ -117,9 +155,6 @@ func validateAtlasSchemaApplyOptions(cmd *cobra.Command, opts atlasSchemaApplyOp
 	}
 	if len(opts.toURLs) == 0 {
 		return fmt.Errorf("--to is required")
-	}
-	if strings.TrimSpace(opts.format) != "" {
-		return fmt.Errorf("atlas schema apply accepts --format, but Ptah does not implement its behavior yet")
 	}
 	for _, name := range []string{"schema", "exclude", "include"} {
 		if values, err := cmd.Flags().GetStringArray(name); err == nil && len(values) > 0 {
@@ -134,12 +169,25 @@ func printAtlasSchemaApplyPlan(out io.Writer, sqlText string) {
 	fmt.Fprintln(out, strings.TrimSpace(sqlText))
 }
 
-func confirmAtlasSchemaApply(opts atlasSchemaApplyOptions, prompt io.Writer, input io.Reader) (bool, error) {
-	if opts.autoApprove {
-		fmt.Fprintln(prompt, "Auto-approval enabled; applying schema changes.")
-		return true, nil
+func writeAtlasSchemaApplyFormat(cmd *cobra.Command, opts atlasSchemaApplyOptions, statements []string) error {
+	rendered, err := renderAtlasSchemaApplyFormat(opts, statements)
+	if err != nil {
+		return err
 	}
+	_, err = io.WriteString(cmd.OutOrStdout(), rendered)
+	return err
+}
 
+func renderAtlasSchemaApplyFormat(opts atlasSchemaApplyOptions, statements []string) (string, error) {
+	report := atlasreport.NewSchemaApply(statements)
+	var out bytes.Buffer
+	if err := atlasreport.WriteSchemaApply(&out, opts.format, report); err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func promptAtlasSchemaApplyConfirmation(prompt io.Writer, input io.Reader) (bool, error) {
 	fmt.Fprint(prompt, "Apply these schema changes? Type 'YES' to confirm: ")
 	var confirmation string
 	if _, err := fmt.Fscan(input, &confirmation); err != nil {

--- a/cmd/atlas/schema_apply_format_test.go
+++ b/cmd/atlas/schema_apply_format_test.go
@@ -1,0 +1,160 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestSchemaApplySupportsFormat(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "apply-format.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--to", "file://" + schemaPath,
+		"--format", `{{ len .Changes }}|{{ printf "%.6s" (.MarshalSQL) }}|{{ sql . "  " }}`,
+		"--auto-approve",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "1|CREATE|  CREATE TABLE")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Auto-approval enabled")
+	c.Assert(out.String(), qt.Not(qt.Contains), "Schema apply completed successfully.")
+	c.Assert(sqliteTableCount(c, dbPath, "users"), qt.Equals, 1)
+}
+
+func TestSchemaApplyFormatDryRunDoesNotApply(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "apply-format-dry-run.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE dry_run_users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--to", "file://" + schemaPath,
+		"--format", `{{ sql . "" }}`,
+		"--dry-run",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "CREATE TABLE")
+	c.Assert(sqliteTableCount(c, dbPath, "dry_run_users"), qt.Equals, 0)
+}
+
+func TestSchemaApplyFormatSeparatesInteractivePrompt(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "apply-format-prompt.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE prompt_users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(bytes.NewBufferString("NO\n"))
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--to", "file://" + schemaPath,
+		"--format", `{{ len .Changes }}`,
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "1\nApply these schema changes?")
+	c.Assert(out.String(), qt.Contains, "Schema apply canceled.")
+	c.Assert(sqliteTableCount(c, dbPath, "prompt_users"), qt.Equals, 0)
+}
+
+func TestSchemaApplyFormatReportsSynced(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "apply-format-synced.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	schemaSQL := `CREATE TABLE synced_users (id INTEGER PRIMARY KEY);`
+	c.Assert(os.WriteFile(schemaPath, []byte(schemaSQL), 0o600), qt.IsNil)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(atlasschema.ApplySQL(context.Background(), conn, migrator.MigrationTxModeAll, schemaSQL), qt.IsNil)
+	dbschema.CloseAndWarn(conn)
+
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--to", "file://" + schemaPath,
+		"--format", `{{ with .Changes }}changed{{ else }}synced{{ end }}`,
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "synced")
+}
+
+func TestSchemaApplyRejectsInvalidFormatBeforeLoadingFiles(t *testing.T) {
+	c := qt.New(t)
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", "sqlite://apply.db",
+		"--to", "file://schema.sql",
+		"--format", "{{ if }}",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `parse --format template: .*`)
+	c.Assert(out.String(), qt.Not(qt.Contains), "connect to --url")
+}
+
+func sqliteTableCount(c *qt.C, dbPath, table string) int {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	row := conn.QueryRowContext(
+		context.Background(),
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		table,
+	)
+	var count int
+	c.Assert(row.Scan(&count), qt.IsNil)
+	return count
+}

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -56,7 +56,7 @@ model. Unsupported flags fail clearly instead of being ignored.
 | Atlas-compatible command | Ptah behavior |
 | --- | --- |
 | `ptah atlas schema inspect` | Inspects a live database and writes Atlas-shaped HCL by default, SQL with `--format sql` / `--format '{{ sql . }}'`, JSON with `--format json` / `--format '{{ json . }}'`, or custom Go-template output. |
-| `ptah atlas schema apply` | Applies local desired schema files to a live database through Ptah schema diff and migration execution. |
+| `ptah atlas schema apply` | Applies local desired schema files to a live database through Ptah schema diff and migration execution; supports Atlas-style `--format` templates over the planned changes. |
 | `ptah atlas schema diff` | Local `file://` schema-file diff for `.hcl`, `.yaml`, `.yml`, and `.sql` sources. |
 | `ptah atlas schema fmt` | Formats local `.hcl` files using HCL canonical layout. |
 
@@ -96,6 +96,17 @@ ptah atlas schema apply \
 `--dev-url` is accepted for dialect validation only in this path today. It must
 match the target database dialect; Ptah does not yet execute Atlas's
 dev-database simulation for declarative apply.
+
+`--format` accepts Atlas-style Go templates over the planned apply changes. The
+supported template surface includes the `sql` helper and `.MarshalSQL`:
+
+```bash
+ptah atlas schema apply \
+  --url "$DATABASE_URL" \
+  --to file://schema.sql \
+  --dry-run \
+  --format '{{ sql . "  " }}'
+```
 
 `ptah atlas schema diff` accepts one or more `--from` and `--to` local schema
 file URLs and requires `--dev-url` so Ptah can choose the SQL dialect. The

--- a/internal/atlasreport/schema_apply.go
+++ b/internal/atlasreport/schema_apply.go
@@ -1,0 +1,67 @@
+package atlasreport
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"text/template"
+)
+
+type SchemaApply struct {
+	Changes []SchemaApplyChange
+}
+
+type SchemaApplyChange = SchemaChange
+
+func NewSchemaApply(statements []string) SchemaApply {
+	return SchemaApply{
+		Changes: schemaChanges(statements),
+	}
+}
+
+func WriteSchemaApply(w io.Writer, format string, result SchemaApply) error {
+	return renderSchemaApplyTemplate(w, "atlas-schema-apply-format", format, result)
+}
+
+func ValidateSchemaApplyTemplate(format string) error {
+	_, err := newSchemaApplyTemplate("atlas-schema-apply-format", format)
+	return err
+}
+
+func renderSchemaApplyTemplate(w io.Writer, name, format string, data SchemaApply) error {
+	tmpl, err := newSchemaApplyTemplate(name, format)
+	if err != nil {
+		return err
+	}
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, data); err != nil {
+		return fmt.Errorf("execute --format template: %w", err)
+	}
+	_, err = w.Write(out.Bytes())
+	return err
+}
+
+func newSchemaApplyTemplate(name, format string) (*template.Template, error) {
+	tmpl, err := template.New(name).Funcs(template.FuncMap{
+		"sql": schemaApplySQL,
+	}).Parse(format)
+	if err != nil {
+		return nil, fmt.Errorf("parse --format template: %w", err)
+	}
+	return tmpl, nil
+}
+
+func (r SchemaApply) MarshalSQL(indent ...string) (string, error) {
+	if len(indent) > 1 {
+		return "", fmt.Errorf("unexpected number of arguments: %d", len(indent))
+	}
+	sql := schemaChangesSQLText(r.Changes)
+	if len(indent) == 0 || indent[0] == "" || sql == "" {
+		return sql, nil
+	}
+	return schemaIndentSQL(sql, indent[0]), nil
+}
+
+func schemaApplySQL(result SchemaApply, indent ...string) (string, error) {
+	return result.MarshalSQL(indent...)
+}

--- a/internal/atlasreport/schema_apply_test.go
+++ b/internal/atlasreport/schema_apply_test.go
@@ -1,0 +1,44 @@
+package atlasreport_test
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasreport"
+)
+
+func TestSchemaApplyCustomSQLTemplate(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	report := atlasreport.NewSchemaApply([]string{
+		`CREATE TABLE "users" ("id" integer);`,
+	})
+
+	err := atlasreport.WriteSchemaApply(&out, `{{ len .Changes }}|{{ .MarshalSQL }}|{{ sql . "  " }}`, report)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "1|CREATE TABLE \"users\" (\"id\" integer);\n|  CREATE TABLE \"users\" (\"id\" integer);\n")
+}
+
+func TestSchemaApplyTemplateValidationRejectsUnknownHelpers(t *testing.T) {
+	c := qt.New(t)
+
+	err := atlasreport.ValidateSchemaApplyTemplate(`{{ json . }}`)
+
+	c.Assert(err, qt.ErrorMatches, `parse --format template: .*function "json" not defined.*`)
+}
+
+func TestSchemaApplyTemplateExecutionErrorDoesNotWritePartialOutput(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	report := atlasreport.NewSchemaApply([]string{
+		`CREATE TABLE "users" ("id" integer);`,
+	})
+
+	err := atlasreport.WriteSchemaApply(&out, `before {{ sql . "  " "extra" }}`, report)
+
+	c.Assert(err, qt.ErrorMatches, `execute --format template: .*unexpected number of arguments: 2.*`)
+	c.Assert(out.String(), qt.Equals, "")
+}

--- a/internal/atlasreport/schema_diff.go
+++ b/internal/atlasreport/schema_diff.go
@@ -25,15 +25,17 @@ type SchemaDiff struct {
 	Changes []SchemaDiffChange
 }
 
-type SchemaDiffChange struct {
+type SchemaChange struct {
 	Cmd string
 }
+
+type SchemaDiffChange = SchemaChange
 
 func NewSchemaDiff(from, to *goschema.Database, statements []string) SchemaDiff {
 	return SchemaDiff{
 		From:    from,
 		To:      to,
-		Changes: schemaDiffChanges(statements),
+		Changes: schemaChanges(statements),
 	}
 }
 
@@ -83,10 +85,10 @@ func NormalizeMigrateDiffFormat(format string) string {
 	return format
 }
 
-func schemaDiffChanges(statements []string) []SchemaDiffChange {
-	changes := make([]SchemaDiffChange, 0, len(statements))
+func schemaChanges(statements []string) []SchemaChange {
+	changes := make([]SchemaChange, 0, len(statements))
 	for _, statement := range statements {
-		changes = append(changes, SchemaDiffChange{Cmd: schemaDiffStatement(statement)})
+		changes = append(changes, SchemaChange{Cmd: schemaStatement(statement)})
 	}
 	return changes
 }
@@ -95,18 +97,18 @@ func (r SchemaDiff) MarshalSQL(indent ...string) (string, error) {
 	if len(indent) > 1 {
 		return "", fmt.Errorf("unexpected number of arguments: %d", len(indent))
 	}
-	sql := schemaDiffSQLText(r.Changes)
+	sql := schemaChangesSQLText(r.Changes)
 	if len(indent) == 0 || indent[0] == "" || sql == "" {
 		return sql, nil
 	}
-	return schemaDiffIndentSQL(sql, indent[0]), nil
+	return schemaIndentSQL(sql, indent[0]), nil
 }
 
 func schemaDiffSQL(result SchemaDiff, indent ...string) (string, error) {
 	return result.MarshalSQL(indent...)
 }
 
-func schemaDiffSQLText(changes []SchemaDiffChange) string {
+func schemaChangesSQLText(changes []SchemaChange) string {
 	var sql strings.Builder
 	for _, change := range changes {
 		fmt.Fprintf(&sql, "%s;\n", strings.TrimSuffix(change.Cmd, ";"))
@@ -114,11 +116,11 @@ func schemaDiffSQLText(changes []SchemaDiffChange) string {
 	return sql.String()
 }
 
-func schemaDiffStatement(statement string) string {
+func schemaStatement(statement string) string {
 	return strings.TrimSuffix(statement, ";")
 }
 
-func schemaDiffIndentSQL(sql, indent string) string {
+func schemaIndentSQL(sql, indent string) string {
 	trimmed := strings.TrimSuffix(sql, "\n")
 	return indent + strings.ReplaceAll(trimmed, "\n", "\n"+indent) + "\n"
 }

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/core/sqlutil"
@@ -47,6 +48,10 @@ func (p ApplyPlan) HasChanges() bool {
 
 func (p ApplyPlan) SQL() string {
 	return FormatMigrationSQL(p.statements)
+}
+
+func (p ApplyPlan) Statements() []string {
+	return slices.Clone(p.statements)
 }
 
 func PlanApply(conn *dbschema.DatabaseConnection, opts ApplyOptions) (ApplyPlan, error) {
@@ -106,6 +111,10 @@ func (p ApplyRuntimePlan) HasChanges() bool {
 
 func (p ApplyRuntimePlan) SQL() string {
 	return p.plan.SQL()
+}
+
+func (p ApplyRuntimePlan) Statements() []string {
+	return p.plan.Statements()
 }
 
 // Execute applies the prepared schema diff. Dry-run and no-op plans return


### PR DESCRIPTION
Refs #510

## Summary
- add an Atlas-style schema apply format report with `.Changes`, `.MarshalSQL`, and the `sql` helper
- wire `ptah atlas schema apply --format` without polluting machine-formatted output during auto-approved applies
- document the supported schema apply format surface

## Self-review
- Pass 1: checked cmd remains a thin layer over `internal/atlasschema` planning and `internal/atlasreport` rendering; avoided reconstructing statements from rendered SQL by exposing cloned plan statements.
- Pass 2: checked CLI output semantics, dry-run/apply/synced paths, black-box test placement, docs, qtlint style, and reviewer-agent feedback. Fixed the no-newline template prompt glue case.

## Validation
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./cmd/atlas ./internal/atlasreport ./internal/atlasschema`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache scripts/check-public-api-snapshot.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...` (sandbox run only fails `dbschema` local listener tests with `bind: operation not permitted`)
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./dbschema` outside sandbox