### PR TITLE
Add test style audit gate

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -54,6 +54,9 @@ jobs:
       - name: qtlint
         run: go tool qtlint ./...
 
+      - name: Check test style baseline
+        run: scripts/check-test-style.sh
+
       - name: Validate lint SARIF output
         run: go test ./cmd/lint -run 'TestRunLint_SARIF' -count=1
 

--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1,0 +1,1723 @@
+{
+  "test_conditionals": [
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestDBSchemaToGoSchema",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestParseAtlasHCL",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestParseSQL",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestSchemaToAST",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestSumFileNameConstantsMatchFormats",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestSumHelpers",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "atlascompat/atlascompat_test.go",
+      "function": "TestWriteSumBytes",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/compare/compare_test.go",
+      "function": "TestCompareExitCode",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestEmitterJSONModeWritesParseableJSONLines",
+      "kind": "if",
+      "count": 5
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestJSONOutputWriterFlushesPartialLine",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestJSONOutputWriterLogsSubprocessLines",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestMetricsDataRendersPrometheusCountersAndHistograms",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestMetricsDataWritesTypeOncePerMetricFamily",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "function": "TestStartRejectsInvalidLogOptions",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "cmd/internal/dbcli/dbcli_test.go",
+      "function": "TestParseConnectTimeout",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/introspect/introspect_test.go",
+      "function": "TestValidateOptions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/lint/lint_test.go",
+      "function": "TestRunLint_SARIFFormat",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/migrate/generate_test.go",
+      "function": "TestMigrateGenerateShadowVerificationWithRealDB",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/migratebaseline/migratebaseline_test.go",
+      "function": "TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/migratebaseline/migratebaseline_test.go",
+      "function": "TestVerifyBaselineShadowPostgresMatchIgnoresShadowMetadata",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/migratebaseline/migratebaseline_test.go",
+      "function": "TestVerifyBaselineShadowPostgresMismatchRequiresForce",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/migratedown/migratedown_test.go",
+      "function": "TestMigrateDownCommand_Integration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/migratestatus/exitcode_test.go",
+      "function": "TestMigrateStatusExitCode",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/migrateup/migrateup_test.go",
+      "function": "TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/migrateup/migrateup_test.go",
+      "function": "TestMigrateUpCommandPgDumpHookWritesArtifact",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "cmd/viz/viz_test.go",
+      "function": "TestCommandWritesSVGWhenGraphvizIsInstalled",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/viz/viz_test.go",
+      "function": "TestDOTParsesWithGraphvizWhenInstalled",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "cmd/viz/viz_test.go",
+      "function": "TestSVGReportsGraphvizStderrOnFailure",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/ast/ast_test.go",
+      "function": "TestConstraintType_Distinct",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/dependency_fix_test.go",
+      "function": "TestDependencyOrderingWithEmbeddedFields",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "core/goschema/dependency_fix_test.go",
+      "function": "TestEmbeddedFieldProcessingModes",
+      "kind": "if",
+      "count": 8
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "function": "TestEmbeddedEntityIDBugReproduction",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "function": "TestEmbeddedFieldProcessingDebug",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "function": "TestGitHubIssue49ExactScenario",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "function": "TestNestedEmbeddedFieldsComprehensive",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "function": "TestNestedEmbeddedFieldsWithPrefixes",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/goschema/field_order_integration_test.go",
+      "function": "TestFieldOrderConsistencyInMigrationGeneration",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "core/goschema/field_order_integration_test.go",
+      "function": "TestFieldOrderWithEmbeddedFields",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "core/goschema/field_order_integration_test.go",
+      "function": "TestFieldOrderWithMultipleTables",
+      "kind": "if",
+      "count": 5
+    },
+    {
+      "path": "core/goschema/issue_51_reproduction_test.go",
+      "function": "TestIssue51ExactReproduction",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "core/goschema/mysql_type_compatibility_test.go",
+      "function": "TestMySQLMigrationGeneratesCompatibleTypes",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "core/goschema/mysql_type_compatibility_test.go",
+      "function": "TestMySQLTypeCompatibilityForEmbeddedRelations",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestGetDependencyInfo",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestGetDependencyInfo_EmptyResult",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestParseDir_EmbeddedRelationFKActions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestParseField_CheckConstraint",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestParseField_ForeignKeyActions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestParseFile_EnumHandling",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/parser_test.go",
+      "function": "TestParseSource_RejectsUnknownAttributesOnAllDirectives",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/goschema/pointer_embedded_integration_test.go",
+      "function": "TestPointerEmbeddedFields_EndToEnd",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "core/goschema/pointer_embedded_test.go",
+      "function": "TestParseFile_PointerEmbeddedFields",
+      "kind": "switch",
+      "count": 3
+    },
+    {
+      "path": "core/goschema/rls_robust_parsing_test.go",
+      "function": "TestRLSPolicyParsingRobustness",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/goschema/utils_test.go",
+      "function": "TestDeduplicate_FieldOrderPreservation",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/utils_test.go",
+      "function": "TestDeduplicate_MultipleStructsFieldOrder",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseDir_Deduplication",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseDir_ErrorHandling",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseDir_ReflectionGuard",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseFS_ConflictingDuplicateSchemaObjectsFail",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseFS_ErrorCases",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/goschema/walker_test.go",
+      "function": "TestParseFS_PostgreSQLFeatures",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "core/ptaherr/errors_test.go",
+      "function": "TestSentinelErrorsAreDistinct",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_test.go",
+      "function": "TestColumnTypeMapping",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_test.go",
+      "function": "TestVisitDropIndex_RequiresTable",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/renderer/renderer_test.go",
+      "function": "TestEmbeddedFieldsInPackageParser",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/renderer/renderer_test.go",
+      "function": "TestGenerateSchema_Deterministic",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "core/renderer/renderer_test.go",
+      "function": "TestGetOrderedCreateStatements",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "core/renderer/renderer_test.go",
+      "function": "TestNewVisitorMethods_UnitTests",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "core/renderer/renderer_test.go",
+      "function": "TestPlatformSpecificOverrides",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "core/sqlutil/placeholders_test.go",
+      "function": "TestRebind",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/connection_internal_test.go",
+      "function": "TestConvertClickHouseURL",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/sqlserver_live_test.go",
+      "function": "TestSQLServerLiveComputedColumnZeroDiff",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/sqlserver_live_test.go",
+      "function": "TestSQLServerLiveDropAllTablesDropsForeignKeys",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/sqlserver_live_test.go",
+      "function": "TestSQLServerLiveDropAllTablesRejectsExternalForeignKeys",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/sqlserver_live_test.go",
+      "function": "TestSQLServerLiveReadSchema",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "dbschema/sqlserver_live_test.go",
+      "function": "TestSQLServerLiveRenderedUpsertMerge",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/atlas_project_config_e2e_test.go",
+      "function": "TestAtlasProjectConfigMigrateStatusAndUpE2E",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/dynamic_test.go",
+      "function": "TestDynamicScenariosBasic",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/check_constraint_integration_test.go",
+      "function": "TestFieldLevelCheckConstraint_Removal_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/check_constraint_integration_test.go",
+      "function": "TestFieldLevelCheckConstraint_RoundTrip_Integration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/circular_fk_generate_integration_test.go",
+      "function": "TestPostgreSQLForeignKeyReferencingUniqueIndexApplyIntegration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/circular_fk_generate_integration_test.go",
+      "function": "TestPostgreSQLGenerateMutualForeignKeysApplyIntegration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/driver_validation_test.go",
+      "function": "TestDriverMigrationCompleteness",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/driver_validation_test.go",
+      "function": "TestPgxDriverValidation",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/exclude_constraints_integration_test.go",
+      "function": "TestExcludeConstraints_EndToEnd_PostgreSQL",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/extension_functions_test.go",
+      "function": "TestPostgreSQLReader_CustomFunctionIncluded_Integration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/function_diff_integration_test.go",
+      "function": "TestFunctionDiff_BodyAndSecurityChange_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/function_diff_integration_test.go",
+      "function": "TestFunctionDiff_VolatilityChange_Integration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/gonative/integration_test.go",
+      "function": "TestGenerateCreateTableFromStubs",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "integration/gonative/postgres_integration_test.go",
+      "function": "TestPostgreSQLReader_ReadSchema_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/renderer_integration_test.go",
+      "function": "TestAlterType_Integration",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "integration/gonative/renderer_integration_test.go",
+      "function": "TestCreateType_Integration",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "integration/gonative/renderer_integration_test.go",
+      "function": "TestDropIndex_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/gonative/renderer_integration_test.go",
+      "function": "TestRenderer_DialectSpecificSQL",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/rls_integration_test.go",
+      "function": "TestRLSIntegrationFixtures",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "integration/scenarios_advanced_test.go",
+      "function": "TestMigrationGeneratorValidation",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/scenarios_advanced_test.go",
+      "function": "TestValidateEmptySchema",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/scenarios_advanced_test.go",
+      "function": "TestValidateSchemaConsistency",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/scenarios_test.go",
+      "function": "TestSQLServerCompatibleScenariosAreExplicit",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "integration/shadow_generate_e2e_test.go",
+      "function": "TestMigrateGenerateShadowDatabaseE2E",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/annotationmeta/meta_test.go",
+      "function": "TestDetachedFileScopesMatchParserSupport",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/convert/fromschema/fromschema_test.go",
+      "function": "TestFromDatabase_EmbeddedFields_InlineMode",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "internal/convert/fromschema/fromschema_test.go",
+      "function": "TestFromDatabase_EmbeddedFields_JsonMode",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "internal/convert/fromschema/fromschema_test.go",
+      "function": "TestFromDatabase_EmbeddedFields_RelationMode",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "internal/convert/fromschema/fromschema_test.go",
+      "function": "TestFromDatabase_EmbeddedFields_SkipAndDefaultModes",
+      "kind": "if",
+      "count": 6
+    },
+    {
+      "path": "internal/convert/fromschema/fromschema_test.go",
+      "function": "TestFromDatabase_EmbeddedRelationFKActions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/clickhouse/clickhouse_test.go",
+      "function": "TestClickHouseWriterConcurrentTransactionNoops",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/dbschema/clickhouse/clickhouse_test.go",
+      "function": "TestReaderReadTablesUsesBulkColumnQuery",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/mysql/mysql_test.go",
+      "function": "TestMySQLReaderReadTablesUsesBulkColumnQuery",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/mysql/mysql_test.go",
+      "function": "TestMySQLReaderReadTablesUsesBulkColumnQuery",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/mysql/mysql_test.go",
+      "function": "TestMySQLWriterConcurrentTransactions",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/dbschema/mysql/mysql_test.go",
+      "function": "TestMySQLWriterDropAllTablesRollsBackOnFailure",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/postgres/exclude_constraints_test.go",
+      "function": "TestParseExcludeConstraintDefinition",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/postgres/postgres_test.go",
+      "function": "TestPostgreSQLReaderReadTablesUsesBulkColumnQuery",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/postgres/postgres_test.go",
+      "function": "TestPostgreSQLWriterConcurrentTransactions",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/dbschema/postgres/postgres_test.go",
+      "function": "TestPostgreSQLWriterDropAllTablesRollsBackOnFailure",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/postgres/postgres_test.go",
+      "function": "TestPostgresNullsDistinctFromDefinition",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/dbschema/sqlite/sqlite_test.go",
+      "function": "TestSQLiteWriterConcurrentTransactions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/graphqlrender/render_test.go",
+      "function": "TestRenderRelationToExcludedTableIsOmitted",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/lexer/lexer_fuzz_test.go",
+      "function": "FuzzLexer",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/lexer/lexer_test.go",
+      "function": "TestLexer_NextToken_ComplexSQL",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/lexer/lexer_test.go",
+      "function": "TestLexer_NextToken_EdgeCases",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/lexer/lexer_test.go",
+      "function": "TestLexer_NextToken_HappyPath",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/onlineddl/dsn_test.go",
+      "function": "TestParseDatabaseURL",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/onlineddl/executor_test.go",
+      "function": "TestExecuteStatement_MissingBinaryFallbackPolicy",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/onlineddl/executor_test.go",
+      "function": "TestExecuteStatement_RowCountFailureFallbackPolicy",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/onlineddl/statement_test.go",
+      "function": "TestParseAlterTable",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/parser/parser_test.go",
+      "function": "TestParser_ParseDropTable",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/parser/parser_test.go",
+      "function": "TestParser_ParseExtendedPostgreSQLDemo",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "internal/pathguard/pathguard_test.go",
+      "function": "TestResolveWithinRootRejectsSymlinkEscape",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/planner/dialects/mysql/fk_actions_test.go",
+      "function": "TestPlanner_FieldLevelForeignKeyActions",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_EnumsAdded",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_EnumsModified",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_EnumsRemoved",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_IndexesAdded",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_TablesAdded",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/planner/dialects/mysql/mysql_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_TablesModified",
+      "kind": "if",
+      "count": 11
+    },
+    {
+      "path": "internal/planner/dialects/postgres/circular_dependency_test.go",
+      "function": "TestComplexDependencyChainTwoPhase",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "internal/planner/dialects/postgres/circular_dependency_test.go",
+      "function": "TestNoForeignKeysInCreateTable",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/postgres/exclude_constraints_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_ConstraintsAdded",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/planner/dialects/postgres/fk_actions_test.go",
+      "function": "TestPlanner_FieldLevelForeignKeyActions",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_ForeignKeyDependencyOrdering",
+      "kind": "if",
+      "count": 11
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_ForeignKeyDependencyOrdering_SQLOutput",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_ExtensionsAdded",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationAST_ExtensionsRemoved",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_ComplexScenario",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_EnumsAdded",
+      "kind": "if",
+      "count": 5
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_EnumsModified",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_EnumsRemoved",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_IndexesAdded",
+      "kind": "if",
+      "count": 5
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_IndexesRemoved",
+      "kind": "if",
+      "count": 5
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_TablesAdded",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_TablesModified",
+      "kind": "if",
+      "count": 14
+    },
+    {
+      "path": "internal/planner/dialects/postgres/postgres_test.go",
+      "function": "TestPlanner_GenerateMigrationSQL_TablesRemoved",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/compare_options_test.go",
+      "function": "TestGenerateMigration_CompareOptions_Integration_AddExtension",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/compare_options_test.go",
+      "function": "TestGenerateMigration_CompareOptions_Integration_CustomIgnoreList",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/compare_options_test.go",
+      "function": "TestGenerateMigration_CompareOptions_Integration_NilOptions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/compare_options_test.go",
+      "function": "TestGenerateMigration_CompareOptions_Integration_NoIgnoredExtensions",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/constraint_drift_integration_test.go",
+      "function": "TestConstraintDriftGenerateRoundTrip_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/constraint_drift_integration_test.go",
+      "function": "TestUniqueConstraintDriftGenerateRoundTrip_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/fk_drop_order_integration_test.go",
+      "function": "TestFKDropOrder_DownRoundTrip_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/fk_drop_order_integration_test.go",
+      "function": "TestFKDropOrder_MutualCycleDownRoundTrip_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/generator_test.go",
+      "function": "TestGenerateMigration_DatabaseConnectionFix",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/generator_test.go",
+      "function": "TestGenerateMigration_ExtensionHandling_WithRealDB",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/multihost_fk_down_integration_test.go",
+      "function": "TestMultiHostMixinFKModify_DownRoundTrip_Integration",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/multihost_fk_down_test.go",
+      "function": "TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/reverse_diff_test.go",
+      "function": "TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/generator/reverse_diff_test.go",
+      "function": "TestGenerateDownMigrationSQL_MySQLFamilyDropsGeneratedForeignKeyBackingIndex",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/generator/shadow_test.go",
+      "function": "TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/generator/shadow_test.go",
+      "function": "TestGenerateMigrationShadowVerificationWithRealDB",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/lint/lint_test.go",
+      "function": "TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/lint/lint_test.go",
+      "function": "TestLintFS_CustomRuleAndPrepareFSUsePublicScanner",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/lint/lint_test.go",
+      "function": "TestLintFS_DialectAwareScanning",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/lint/lint_test.go",
+      "function": "TestLintFS_OptionalKeywordForms",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/lint/lint_test.go",
+      "function": "TestLintFS_SameFileCreatedTablesAreExempt",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/lint/register_external_test.go",
+      "function": "TestRegisterCustomRuleFromExternalPackage",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/advisory_lock_test.go",
+      "function": "TestParseMigrationLockTimeout",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/atlas_integration_test.go",
+      "function": "TestAtlasFormat_MySQLIntegration",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "migration/migrator/atlas_integration_test.go",
+      "function": "TestAtlasTxtarDown_MySQLIntegration",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "migration/migrator/debug_test.go",
+      "function": "TestInitializeDebug",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleMigrator",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleMigrator_GetMigrationStatus",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleMigrator_GetPendingMigrations",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleMigrator_MigrateDown",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleMigrator_MigrateTo",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleNewFSMigrator",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleNewFSMigrator_errorHandling",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "ExampleParseMigrationFileName",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "Example_completeWorkflow",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "migration/migrator/example_test.go",
+      "function": "Example_registerMigrationsCustomFilesystem",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/lock_timeout_integration_test.go",
+      "function": "TestMigrateUp_PostgresLockTimeoutIntegration",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/migrator/migration_provider_test.go",
+      "function": "TestRegisteredMigrationProvider_ConcurrentRegisterAndMigrations",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/migrations_test.go",
+      "function": "TestParseMigrationTimeoutDirectives",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/observability_test.go",
+      "function": "TestMigratorObserverRecordsMigrateDown",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "migration/migrator/observability_test.go",
+      "function": "TestMigratorObserverRecordsMigrateUp",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/observability_test.go",
+      "function": "TestMigratorObserverRecordsMigrationStatus",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteAppliesMigrations",
+      "kind": "if",
+      "count": 8
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteTxModeAllRejectsNoTransactionBeforeWrites",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteTxModeAllRollsBackAllPendingBodies",
+      "kind": "if",
+      "count": 10
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteTxModeNoneRecordsPartialProgress",
+      "kind": "if",
+      "count": 8
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteTxModeNoneRejectsTimeoutsBeforeWrites",
+      "kind": "if",
+      "count": 7
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestFSMigratorSQLiteTxModeValidationRunsBeforePreflight",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestMigrateDownToWithPreflightAbortPreventsRollback",
+      "kind": "if",
+      "count": 11
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "function": "TestMigrateUpWithPreflightAbortPreventsApply",
+      "kind": "if",
+      "count": 10
+    },
+    {
+      "path": "migration/migrator/sqlserver_live_test.go",
+      "function": "TestSQLServerMigratorHonorsURLSchemaForMetadata",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/timeouts_test.go",
+      "function": "TestTimeoutStatements",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/tx_mode_test.go",
+      "function": "TestParseMigrationTxMode",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/migrator/util_test.go",
+      "function": "TestParseMigrationFileName",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/planner/determinism_test.go",
+      "function": "TestGenerateSchemaDiffSQL_DriftedFixtureCoverage",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/planner/determinism_test.go",
+      "function": "TestGenerateSchemaDiffSQL_EnableRLSSorted",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/planner/planner_test.go",
+      "function": "TestGenerateMigrationAST",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/planner/planner_test.go",
+      "function": "TestGetPlanner",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/safety/safety_test.go",
+      "function": "TestAssessRenderedSplitsPostgresModifyColumnStatements",
+      "kind": "switch",
+      "count": 1
+    },
+    {
+      "path": "migration/schemadiff/determinism_test.go",
+      "function": "TestCompare_ModifiedListsSorted",
+      "kind": "if",
+      "count": 2
+    },
+    {
+      "path": "migration/schemadiff/internal/compare/compare_test.go",
+      "function": "TestColumnByName_EdgeCases",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/schemadiff/internal/compare/extensions_test.go",
+      "function": "TestExtensions_EdgeCases",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/schemadiff/internal/compare/fk_constraints_test.go",
+      "function": "TestConstraints_FieldLevelForeignKey",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "migration/seeder/seeder_integration_test.go",
+      "function": "TestApply_Integration",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "function": "TestApplyMigrationsFromSubFS",
+      "kind": "if",
+      "count": 3
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "function": "TestMySQLDSNDatabasePreservesCredentialsEndpointAndQuery",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "function": "TestPostgresDatabaseURLPreservesCredentialsAndQuery",
+      "kind": "if",
+      "count": 1
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "function": "TestSQLiteApplyMigrationsSeedAndSnapshot",
+      "kind": "if",
+      "count": 4
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "function": "TestSeedSkipsCommentsAndEmptyStatements",
+      "kind": "if",
+      "count": 2
+    }
+  ],
+  "white_box_files": [
+    {
+      "path": "cmd/atlas/atlas_test.go",
+      "package": "atlas",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/compare/compare_test.go",
+      "package": "compare",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/db/db_test.go",
+      "package": "db",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/drift/drift_test.go",
+      "package": "drift",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/dropall/dropall_test.go",
+      "package": "dropall",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/generate/generate_test.go",
+      "package": "generate",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/integration-test/main_test.go",
+      "package": "main",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/internal/buildinfo/write_test.go",
+      "package": "buildinfo",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/internal/cliobs/cliobs_test.go",
+      "package": "cliobs",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/internal/cmdadapter/cmdadapter_test.go",
+      "package": "cmdadapter",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/internal/cmdflags/env_test.go",
+      "package": "cmdflags",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/internal/cmdutil/cmdutil_test.go",
+      "package": "cmdutil",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/introspect/introspect_test.go",
+      "package": "introspect",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/lint/lint_test.go",
+      "package": "lint",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migrate/generate_test.go",
+      "package": "migrate",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migrate/migrate_test.go",
+      "package": "migrate",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migrate/new_test.go",
+      "package": "migrate",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migratebaseline/migratebaseline_test.go",
+      "package": "migratebaseline",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migratehash/migratehash_test.go",
+      "package": "migratehash",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migraterepair/migraterepair_test.go",
+      "package": "migraterepair",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migratestatus/exitcode_test.go",
+      "package": "migratestatus",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migrateup/migrateup_test.go",
+      "package": "migrateup",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migratevalidate/migratevalidate_test.go",
+      "package": "migratevalidate",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/migrations/migrations_test.go",
+      "package": "migrations",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/ptah-compat/main_test.go",
+      "package": "main",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/root/root_test.go",
+      "package": "root",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/seed/seed_test.go",
+      "package": "seed",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/sql/sql_test.go",
+      "package": "sql",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "cmd/viz/viz_test.go",
+      "package": "viz",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "core/goschema/embedded_bug_reproduction_test.go",
+      "package": "goschema",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "core/goschema/internal/parseutils/parseutils_test.go",
+      "package": "parseutils",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go",
+      "package": "clickhouse",
+      "reason": "missing immediate white-box justification comment"
+    },
+    {
+      "path": "core/renderer/internal/dialects/mssql/mssql_test.go",
+      "package": "mssql",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "dbschema/connection_internal_test.go",
+      "package": "dbschema",
+      "reason": "missing immediate white-box justification comment"
+    },
+    {
+      "path": "dbschema/schema_scope_test.go",
+      "package": "dbschema",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "integration/dynamic_test.go",
+      "package": "integration",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "integration/reporting_test.go",
+      "package": "integration",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "integration/scenarios_advanced_test.go",
+      "package": "integration",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "integration/scenarios_test.go",
+      "package": "integration",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/dbschema/clickhouse/clickhouse_test.go",
+      "package": "clickhouse",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/dbschema/mssql/reader_test.go",
+      "package": "mssql",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/dbschema/mysql/mysql_test.go",
+      "package": "mysql",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/dbschema/postgres/postgres_test.go",
+      "package": "postgres",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/onlineddl/executor_test.go",
+      "package": "onlineddl",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/pathguard/pathguard_test.go",
+      "package": "pathguard",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/planner/dialects/mssql/mssql_test.go",
+      "package": "mssql",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/preflight/preflight_test.go",
+      "package": "preflight",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/ptahls/server_test.go",
+      "package": "ptahls",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "internal/sqllint/lint_test.go",
+      "package": "sqllint",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/baseline_shadow_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/concurrent_index_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/constraint_drift_integration_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/file_creation_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/fk_drop_order_integration_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/migration_file_generation_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/multihost_fk_down_integration_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/multihost_fk_down_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/no_transaction_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/reverse_diff_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/safety_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/shadow_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/generator/test_helpers_test.go",
+      "package": "generator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/advisory_lock_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/debug_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/directives_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/exec_order_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/migrations_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/observability_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/security_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/sqlite_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/timeouts_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/migrator/util_test.go",
+      "package": "migrator",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/schemadiff/internal/compare/issue34_integration_test.go",
+      "package": "compare",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/seeder/seeder_integration_test.go",
+      "package": "seeder",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "migration/seeder/seeder_test.go",
+      "package": "seeder",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "testkit/containers_test.go",
+      "package": "testkit",
+      "reason": "same-package test file is not named *_internal_test.go"
+    },
+    {
+      "path": "testkit/testkit_test.go",
+      "package": "testkit",
+      "reason": "same-package test file is not named *_internal_test.go"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,20 @@ Go 1.22 and newer makes range variables per-iteration, so the historical
 `test := test` workaround is not needed when using `c.Run()` closures in
 table-driven tests unless intentionally taking the address of a loop variable.
 
+Run the test-style baseline before finishing test changes:
+
+```bash
+scripts/check-test-style.sh
+```
+
+The baseline records existing violations while issue #541 is being cleaned up.
+New tests must not add entries. Cleanup PRs that intentionally remove entries
+should refresh the baseline with:
+
+```bash
+GOWORK=off go run ./internal/tools/teststyle -write-baseline
+```
+
 Bad:
 
 ```go

--- a/TESTING.md
+++ b/TESTING.md
@@ -225,3 +225,24 @@ docker compose down -v
 - `3` - Docker/environment issues
 
 All scripts return appropriate exit codes for CI/CD integration.
+
+# Test Style Baseline
+
+Ptah enforces the current declarative-test and white-box-test baseline while
+issue #541 is being cleaned up:
+
+```bash
+scripts/check-test-style.sh
+```
+
+The check fails when a PR adds a new prohibited conditional in a top-level
+`Test*`, `Fuzz*`, or `Example*` function, adds a same-package test file that is
+not named `*_internal_test.go`, or adds an internal test file without an
+immediate `// White-box testing required:` justification comment after the
+package clause.
+
+Cleanup PRs should reduce `.teststyle-baseline.json` with:
+
+```bash
+GOWORK=off go run ./internal/tools/teststyle -write-baseline
+```

--- a/internal/teststyle/audit.go
+++ b/internal/teststyle/audit.go
@@ -1,0 +1,334 @@
+// Package teststyle audits repository tests against Ptah's test style rules.
+package teststyle
+
+import (
+	"bufio"
+	"cmp"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+const whiteBoxJustificationPrefix = "// White-box testing required:"
+
+// Baseline records known test-style violations. Cleanup PRs should reduce this
+// file; ordinary feature PRs should keep it unchanged.
+type Baseline struct {
+	TestConditionals []ConditionalBaseline `json:"test_conditionals"`
+	WhiteBoxFiles    []WhiteBoxBaseline    `json:"white_box_files"`
+}
+
+// ConditionalBaseline records prohibited conditional statements in one test
+// function, grouped by statement kind.
+type ConditionalBaseline struct {
+	Path     string `json:"path"`
+	Function string `json:"function"`
+	Kind     string `json:"kind"`
+	Count    int    `json:"count"`
+}
+
+// WhiteBoxBaseline records a same-package test file that still needs black-box
+// conversion or an explicit white-box justification.
+type WhiteBoxBaseline struct {
+	Path    string `json:"path"`
+	Package string `json:"package"`
+	Reason  string `json:"reason"`
+}
+
+// Scan scans root and returns the current repository test-style baseline.
+func Scan(root string) (Baseline, error) {
+	if root == "" {
+		root = "."
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return Baseline{}, fmt.Errorf("resolve root: %w", err)
+	}
+
+	fset := token.NewFileSet()
+	conditionals := map[conditionalKey]int{}
+	var whiteBoxFiles []WhiteBoxBaseline
+
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if skippedDirectory(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		relativePath, err := filepath.Rel(root, path)
+		if err != nil {
+			return fmt.Errorf("relativize %s: %w", path, err)
+		}
+		relativePath = filepath.ToSlash(relativePath)
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", relativePath, err)
+		}
+		scanConditionals(relativePath, file, conditionals)
+		whiteBoxFiles = append(whiteBoxFiles, scanWhiteBoxFile(path, relativePath, file.Name.Name)...)
+		return nil
+	}); err != nil {
+		return Baseline{}, err
+	}
+
+	return Baseline{
+		TestConditionals: conditionalBaseline(conditionals),
+		WhiteBoxFiles:    sortedWhiteBoxBaseline(whiteBoxFiles),
+	}, nil
+}
+
+// ReadBaseline reads a baseline JSON file.
+func ReadBaseline(path string) (Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Baseline{}, fmt.Errorf("read baseline: %w", err)
+	}
+	var baseline Baseline
+	if err := json.Unmarshal(data, &baseline); err != nil {
+		return Baseline{}, fmt.Errorf("parse baseline: %w", err)
+	}
+	baseline.Normalize()
+	return baseline, nil
+}
+
+// WriteBaseline writes a deterministic baseline JSON file.
+func WriteBaseline(path string, baseline Baseline) error {
+	baseline.Normalize()
+	data, err := json.MarshalIndent(baseline, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal baseline: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write baseline: %w", err)
+	}
+	return nil
+}
+
+// Normalize sorts baseline entries deterministically.
+func (b *Baseline) Normalize() {
+	sort.Slice(b.TestConditionals, func(i, j int) bool {
+		return compareConditional(b.TestConditionals[i], b.TestConditionals[j]) < 0
+	})
+	sort.Slice(b.WhiteBoxFiles, func(i, j int) bool {
+		return compareWhiteBox(b.WhiteBoxFiles[i], b.WhiteBoxFiles[j]) < 0
+	})
+}
+
+// Diff returns a human-readable mismatch report. Empty string means equal.
+func Diff(want, got Baseline) string {
+	want = cloneBaseline(want)
+	got = cloneBaseline(got)
+	want.Normalize()
+	got.Normalize()
+
+	var builder strings.Builder
+	writeConditionalDiff(&builder, want.TestConditionals, got.TestConditionals)
+	writeWhiteBoxDiff(&builder, want.WhiteBoxFiles, got.WhiteBoxFiles)
+	return builder.String()
+}
+
+func cloneBaseline(baseline Baseline) Baseline {
+	return Baseline{
+		TestConditionals: slices.Clone(baseline.TestConditionals),
+		WhiteBoxFiles:    slices.Clone(baseline.WhiteBoxFiles),
+	}
+}
+
+type conditionalKey struct {
+	path     string
+	function string
+	kind     string
+}
+
+func skippedDirectory(name string) bool {
+	return name == ".git" || name == "vendor" || name == "node_modules"
+}
+
+func scanConditionals(path string, file *ast.File, conditionals map[conditionalKey]int) {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil || !isTestFunction(fn.Name.Name) {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			switch stmt := node.(type) {
+			case *ast.IfStmt:
+				addConditional(conditionals, path, fn.Name.Name, "if")
+			case *ast.SwitchStmt:
+				addConditional(conditionals, path, fn.Name.Name, "switch")
+			case *ast.TypeSwitchStmt:
+				addConditional(conditionals, path, fn.Name.Name, "type switch")
+			case *ast.BranchStmt:
+				if stmt.Tok == token.GOTO {
+					addConditional(conditionals, path, fn.Name.Name, "goto")
+				}
+			}
+			return true
+		})
+	}
+}
+
+func addConditional(conditionals map[conditionalKey]int, path, function, kind string) {
+	conditionals[conditionalKey{path: path, function: function, kind: kind}]++
+}
+
+func isTestFunction(name string) bool {
+	return strings.HasPrefix(name, "Test") ||
+		strings.HasPrefix(name, "Fuzz") ||
+		strings.HasPrefix(name, "Example")
+}
+
+func scanWhiteBoxFile(path string, relativePath string, packageName string) []WhiteBoxBaseline {
+	if strings.HasSuffix(packageName, "_test") {
+		return nil
+	}
+	if !strings.HasSuffix(relativePath, "_internal_test.go") {
+		return []WhiteBoxBaseline{{
+			Path:    relativePath,
+			Package: packageName,
+			Reason:  "same-package test file is not named *_internal_test.go",
+		}}
+	}
+	if hasWhiteBoxJustification(path) {
+		return nil
+	}
+	return []WhiteBoxBaseline{{
+		Path:    relativePath,
+		Package: packageName,
+		Reason:  "missing immediate white-box justification comment",
+	}}
+}
+
+func hasWhiteBoxJustification(path string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	seenPackage := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !seenPackage {
+			seenPackage = strings.HasPrefix(line, "package ")
+			continue
+		}
+		return strings.HasPrefix(line, whiteBoxJustificationPrefix)
+	}
+	return false
+}
+
+func conditionalBaseline(conditionals map[conditionalKey]int) []ConditionalBaseline {
+	result := make([]ConditionalBaseline, 0, len(conditionals))
+	for key, count := range conditionals {
+		result = append(result, ConditionalBaseline{
+			Path:     key.path,
+			Function: key.function,
+			Kind:     key.kind,
+			Count:    count,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return compareConditional(result[i], result[j]) < 0
+	})
+	return result
+}
+
+func sortedWhiteBoxBaseline(values []WhiteBoxBaseline) []WhiteBoxBaseline {
+	sort.Slice(values, func(i, j int) bool {
+		return compareWhiteBox(values[i], values[j]) < 0
+	})
+	return values
+}
+
+func compareConditional(a, b ConditionalBaseline) int {
+	return cmp.Or(
+		cmp.Compare(a.Path, b.Path),
+		cmp.Compare(a.Function, b.Function),
+		cmp.Compare(a.Kind, b.Kind),
+	)
+}
+
+func compareWhiteBox(a, b WhiteBoxBaseline) int {
+	return cmp.Or(
+		cmp.Compare(a.Path, b.Path),
+		cmp.Compare(a.Package, b.Package),
+		cmp.Compare(a.Reason, b.Reason),
+	)
+}
+
+func writeConditionalDiff(builder *strings.Builder, want, got []ConditionalBaseline) {
+	wantSet := conditionalSet(want)
+	gotSet := conditionalSet(got)
+	writeMissing(builder, "test conditional baseline is stale or too high", setDiff(wantSet, gotSet))
+	writeMissing(builder, "new test conditional violations", setDiff(gotSet, wantSet))
+}
+
+func writeWhiteBoxDiff(builder *strings.Builder, want, got []WhiteBoxBaseline) {
+	wantSet := whiteBoxSet(want)
+	gotSet := whiteBoxSet(got)
+	writeMissing(builder, "white-box baseline is stale or too high", setDiff(wantSet, gotSet))
+	writeMissing(builder, "new white-box test violations", setDiff(gotSet, wantSet))
+}
+
+func conditionalSet(values []ConditionalBaseline) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[fmt.Sprintf("%s\t%s\t%s\t%d", value.Path, value.Function, value.Kind, value.Count)] = struct{}{}
+	}
+	return result
+}
+
+func whiteBoxSet(values []WhiteBoxBaseline) map[string]struct{} {
+	result := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		result[fmt.Sprintf("%s\t%s\t%s", value.Path, value.Package, value.Reason)] = struct{}{}
+	}
+	return result
+}
+
+func setDiff(a, b map[string]struct{}) []string {
+	var result []string
+	for value := range a {
+		if _, ok := b[value]; !ok {
+			result = append(result, value)
+		}
+	}
+	slices.Sort(result)
+	return result
+}
+
+func writeMissing(builder *strings.Builder, title string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	if builder.Len() > 0 {
+		builder.WriteByte('\n')
+	}
+	fmt.Fprintf(builder, "%s:\n", title)
+	for _, value := range values {
+		fmt.Fprintf(builder, "  %s\n", value)
+	}
+}
+
+// ErrBaselineMismatch indicates current test-style findings differ from the
+// committed baseline.
+var ErrBaselineMismatch = errors.New("test style baseline mismatch")

--- a/internal/teststyle/audit_test.go
+++ b/internal/teststyle/audit_test.go
@@ -1,0 +1,134 @@
+package teststyle_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/teststyle"
+)
+
+func TestScanReportsConditionalsAndWhiteBoxViolations(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeFile(c, dir, "sample/blackbox_test.go", `package sample_test
+
+import "testing"
+
+func TestDeclarative(t *testing.T) {}
+`)
+	writeFile(c, dir, "sample/mixed_test.go", `package sample
+
+import "testing"
+
+func TestBad(t *testing.T) {
+	if true {}
+	switch 1 { case 1: }
+	goto done
+done:
+}
+`)
+	writeFile(c, dir, "sample/valid_internal_test.go", `package sample
+// White-box testing required: verifies unexported parser state that is not observable through the exported API.
+
+import "testing"
+
+func TestInternal(t *testing.T) {}
+`)
+	writeFile(c, dir, "sample/missing_internal_test.go", `package sample
+
+import "testing"
+
+func TestMissingComment(t *testing.T) {}
+`)
+
+	got, err := teststyle.Scan(dir)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, teststyle.Baseline{
+		TestConditionals: []teststyle.ConditionalBaseline{
+			{Path: "sample/mixed_test.go", Function: "TestBad", Kind: "goto", Count: 1},
+			{Path: "sample/mixed_test.go", Function: "TestBad", Kind: "if", Count: 1},
+			{Path: "sample/mixed_test.go", Function: "TestBad", Kind: "switch", Count: 1},
+		},
+		WhiteBoxFiles: []teststyle.WhiteBoxBaseline{
+			{Path: "sample/missing_internal_test.go", Package: "sample", Reason: "missing immediate white-box justification comment"},
+			{Path: "sample/mixed_test.go", Package: "sample", Reason: "same-package test file is not named *_internal_test.go"},
+		},
+	})
+}
+
+func TestBaselineRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.json")
+	baseline := teststyle.Baseline{
+		TestConditionals: []teststyle.ConditionalBaseline{
+			{Path: "a_test.go", Function: "TestA", Kind: "if", Count: 1},
+		},
+		WhiteBoxFiles: []teststyle.WhiteBoxBaseline{
+			{Path: "b_test.go", Package: "b", Reason: "same-package test file is not named *_internal_test.go"},
+		},
+	}
+
+	err := teststyle.WriteBaseline(path, baseline)
+	got, readErr := teststyle.ReadBaseline(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, baseline)
+	c.Assert(teststyle.Diff(baseline, got), qt.Equals, "")
+}
+
+func TestDiffReportsNewAndStaleEntries(t *testing.T) {
+	c := qt.New(t)
+	want := teststyle.Baseline{
+		TestConditionals: []teststyle.ConditionalBaseline{
+			{Path: "old_test.go", Function: "TestOld", Kind: "if", Count: 1},
+		},
+	}
+	got := teststyle.Baseline{
+		TestConditionals: []teststyle.ConditionalBaseline{
+			{Path: "new_test.go", Function: "TestNew", Kind: "switch", Count: 1},
+		},
+	}
+
+	diff := teststyle.Diff(want, got)
+
+	c.Assert(diff, qt.Contains, "test conditional baseline is stale or too high")
+	c.Assert(diff, qt.Contains, "old_test.go")
+	c.Assert(diff, qt.Contains, "new test conditional violations")
+	c.Assert(diff, qt.Contains, "new_test.go")
+}
+
+func TestDiffDoesNotMutateInputs(t *testing.T) {
+	c := qt.New(t)
+	want := teststyle.Baseline{
+		TestConditionals: []teststyle.ConditionalBaseline{
+			{Path: "z_test.go", Function: "TestZ", Kind: "if", Count: 1},
+			{Path: "a_test.go", Function: "TestA", Kind: "switch", Count: 1},
+		},
+	}
+	got := teststyle.Baseline{
+		WhiteBoxFiles: []teststyle.WhiteBoxBaseline{
+			{Path: "z_internal_test.go", Package: "sample", Reason: "missing immediate white-box justification comment"},
+			{Path: "a_test.go", Package: "sample", Reason: "same-package test file is not named *_internal_test.go"},
+		},
+	}
+	wantBefore := want
+	gotBefore := got
+
+	_ = teststyle.Diff(want, got)
+
+	c.Assert(want, qt.DeepEquals, wantBefore)
+	c.Assert(got, qt.DeepEquals, gotBefore)
+}
+
+func writeFile(c *qt.C, root string, relativePath string, data string) {
+	c.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(data), 0o600), qt.IsNil)
+}

--- a/internal/tools/teststyle/main.go
+++ b/internal/tools/teststyle/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/stokaro/ptah/internal/teststyle"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	flags := flag.NewFlagSet("teststyle", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	baselinePath := flags.String("baseline", ".teststyle-baseline.json", "Path to the committed test-style baseline")
+	writeBaseline := flags.Bool("write-baseline", false, "Rewrite the baseline from current findings")
+	root := flags.String("root", ".", "Repository root to scan")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	current, err := teststyle.Scan(*root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "teststyle: scan failed: %v\n", err)
+		return 1
+	}
+	if *writeBaseline {
+		if err := teststyle.WriteBaseline(*baselinePath, current); err != nil {
+			fmt.Fprintf(os.Stderr, "teststyle: write baseline failed: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "teststyle: wrote %s (%d conditional groups, %d white-box files)\n",
+			*baselinePath, len(current.TestConditionals), len(current.WhiteBoxFiles))
+		return 0
+	}
+
+	baseline, err := teststyle.ReadBaseline(*baselinePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "teststyle: read baseline failed: %v\n", err)
+		return 1
+	}
+	if diff := teststyle.Diff(baseline, current); diff != "" {
+		fmt.Fprintf(os.Stderr, "teststyle: %v\n%s\n\nRun GOWORK=off go run ./internal/tools/teststyle -write-baseline after intentional cleanup.\n",
+			teststyle.ErrBaselineMismatch, diff)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "teststyle: OK (%d conditional groups, %d white-box files)\n",
+		len(current.TestConditionals), len(current.WhiteBoxFiles))
+	return 0
+}

--- a/scripts/check-test-style.sh
+++ b/scripts/check-test-style.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+go_cache="${GOCACHE:-$(go env GOCACHE)}"
+if ! mkdir -p "$go_cache" 2>/dev/null || [ ! -w "$go_cache" ]; then
+	GOCACHE="${TMPDIR:-/tmp}/ptah-go-cache"
+	export GOCACHE
+	mkdir -p "$GOCACHE"
+fi
+
+GOWORK=off go run ./internal/tools/teststyle -baseline .teststyle-baseline.json -root .

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -22,6 +22,9 @@ set -eu
 echo "Running qtlint..."
 go tool qtlint ./...
 
+echo "Running test style baseline check..."
+scripts/check-test-style.sh
+
 echo "Running golangci-lint..."
 golangci-lint run ./...
 HOOK


### PR DESCRIPTION
## Summary
- add an internal teststyle scanner and CLI for declarative-test and white-box-test audits
- commit the current baseline: 222 conditional groups and 77 white-box files
- wire the baseline check into Go lint CI, the managed pre-commit hook, AGENTS.md, and TESTING.md

## Validation
- scripts/check-test-style.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./internal/teststyle ./internal/tools/teststyle
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache scripts/check-public-api.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache scripts/check-public-api-snapshot.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./... (sandbox fails only dbschema localhost bind tests)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./dbschema (outside sandbox)

Part of #541.
Closes #574.