### PR TITLE
Reduce white-box teststyle baseline

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -337,12 +337,6 @@
       "count": 3
     },
     {
-      "path": "dbschema/connection_internal_test.go",
-      "function": "TestConvertClickHouseURL",
-      "kind": "if",
-      "count": 1
-    },
-    {
       "path": "dbschema/sqlserver_live_test.go",
       "function": "TestSQLServerLiveComputedColumnZeroDiff",
       "kind": "if",
@@ -1275,11 +1269,6 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/internal/buildinfo/write_test.go",
-      "package": "buildinfo",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/internal/cliobs/cliobs_test.go",
       "package": "cliobs",
       "reason": "same-package test file is not named *_internal_test.go"
@@ -1287,11 +1276,6 @@
     {
       "path": "cmd/internal/cmdadapter/cmdadapter_test.go",
       "package": "cmdadapter",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/internal/cmdflags/env_test.go",
-      "package": "cmdflags",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
@@ -1385,19 +1369,9 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go",
-      "package": "clickhouse",
-      "reason": "missing white-box justification comment after package clause"
-    },
-    {
       "path": "core/renderer/internal/dialects/mssql/mssql_test.go",
       "package": "mssql",
       "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "dbschema/connection_internal_test.go",
-      "package": "dbschema",
-      "reason": "missing white-box justification comment after package clause"
     },
     {
       "path": "dbschema/schema_scope_test.go",

--- a/cmd/internal/buildinfo/write_test.go
+++ b/cmd/internal/buildinfo/write_test.go
@@ -1,17 +1,19 @@
-package buildinfo
+package buildinfo_test
 
 import (
 	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/buildinfo"
 )
 
 func TestWritePrintsStableCLIFormat(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
 
-	Write(&out, Info{
+	buildinfo.Write(&out, buildinfo.Info{
 		Version:  "v1.2.3",
 		Commit:   "abc123",
 		Date:     "2026-07-21T20:00:00Z",

--- a/cmd/internal/cmdflags/env_test.go
+++ b/cmd/internal/cmdflags/env_test.go
@@ -1,17 +1,19 @@
-package cmdflags
+package cmdflags_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdflags"
 )
 
 func TestEnvNameNormalizesFlagName(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(EnvName("PTAH", "db-url"), qt.Equals, "PTAH_DB_URL")
-	c.Assert(EnvName("PTAH", "migration.lock-timeout"), qt.Equals, "PTAH_MIGRATION_LOCK_TIMEOUT")
+	c.Assert(cmdflags.EnvName("PTAH", "db-url"), qt.Equals, "PTAH_DB_URL")
+	c.Assert(cmdflags.EnvName("PTAH", "migration.lock-timeout"), qt.Equals, "PTAH_MIGRATION_LOCK_TIMEOUT")
 }
 
 func TestInitializeEnvAppliesEnvironmentDefaults(t *testing.T) {
@@ -27,7 +29,7 @@ func TestInitializeEnvAppliesEnvironmentDefaults(t *testing.T) {
 	child.Flags().BoolVar(&verbose, "verbose", false, "Verbose output")
 	root.AddCommand(child)
 
-	InitializeEnv("PTAH", root)
+	cmdflags.InitializeEnv("PTAH", root)
 
 	c.Assert(dbURL, qt.Equals, "postgres://example")
 	c.Assert(verbose, qt.IsTrue)
@@ -46,7 +48,7 @@ func TestInitializeEnvDoesNotOverrideExplicitFlag(t *testing.T) {
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL")
 	c.Assert(cmd.Flags().Set("db-url", "postgres://cli"), qt.IsNil)
 
-	InitializeEnv("PTAH", cmd)
+	cmdflags.InitializeEnv("PTAH", cmd)
 
 	c.Assert(dbURL, qt.Equals, "postgres://cli")
 }
@@ -59,7 +61,7 @@ func TestInitializeEnvIgnoresEmptyEnvironmentValues(t *testing.T) {
 	cmd := &cobra.Command{Use: "ptah"}
 	cmd.Flags().StringVar(&dbURL, "db-url", "postgres://default", "Database URL")
 
-	InitializeEnv("PTAH", cmd)
+	cmdflags.InitializeEnv("PTAH", cmd)
 
 	c.Assert(dbURL, qt.Equals, "postgres://default")
 }
@@ -71,9 +73,9 @@ func TestInitializeEnvSkipsDisabledEnvironmentBinding(t *testing.T) {
 	var autoApprove bool
 	cmd := &cobra.Command{Use: "ptah"}
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation")
-	c.Assert(DisableEnvBinding(cmd.Flags(), "auto-approve"), qt.IsNil)
+	c.Assert(cmdflags.DisableEnvBinding(cmd.Flags(), "auto-approve"), qt.IsNil)
 
-	InitializeEnv("PTAH", cmd)
+	cmdflags.InitializeEnv("PTAH", cmd)
 
 	c.Assert(autoApprove, qt.IsFalse)
 	c.Assert(cmd.Flags().Lookup("auto-approve").Changed, qt.IsFalse)
@@ -87,8 +89,8 @@ func TestInitializeEnvAnnotatesUsageOnce(t *testing.T) {
 	cmd := &cobra.Command{Use: "ptah"}
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL")
 
-	InitializeEnv("PTAH", cmd)
-	InitializeEnv("PTAH", cmd)
+	cmdflags.InitializeEnv("PTAH", cmd)
+	cmdflags.InitializeEnv("PTAH", cmd)
 
 	c.Assert(cmd.Flags().Lookup("db-url").Usage, qt.Equals, "Database URL [env: PTAH_DB_URL]")
 }

--- a/core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse_internal_test.go
@@ -1,8 +1,9 @@
 package clickhouse
 
-// White-box tests for helpers whose behavior cannot be observed through the
-// renderer's public surface alone. The rest of the dialect's test coverage
-// lives in clickhouse_test.go as a black-box package.
+// White-box testing required: splitColumns is an unexported parser helper whose
+// edge-case behavior cannot be fully observed through the renderer's public
+// surface alone. The rest of the dialect's test coverage lives in
+// clickhouse_test.go as a black-box package.
 
 import (
 	"testing"

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -1,5 +1,9 @@
 package dbschema
 
+// White-box testing required: this file exercises unexported DSN normalization
+// helpers and connection option paths that are not directly observable through
+// the public connection API alone.
+
 import (
 	"strings"
 	"testing"
@@ -11,7 +15,7 @@ import (
 )
 
 func TestConvertClickHouseURL(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name     string
 		input    string
 		expected string
@@ -20,11 +24,6 @@ func TestConvertClickHouseURL(t *testing.T) {
 			name:     "passthrough canonical URL",
 			input:    "clickhouse://default:secret@localhost:9000/analytics",
 			expected: "clickhouse://default:secret@localhost:9000/analytics",
-		},
-		{
-			name:     "preserves query parameters",
-			input:    "clickhouse://default:secret@localhost:9000/analytics?secure=true&dial_timeout=10s",
-			expected: "clickhouse://default:secret@localhost:9000/analytics?secure=true&dial_timeout=10s",
 		},
 		{
 			name:     "rewrites uppercase scheme",
@@ -37,14 +36,41 @@ func TestConvertClickHouseURL(t *testing.T) {
 			expected: "::not-a-url::",
 		},
 		{
-			name:     "preserves secure=true on native port",
-			input:    "clickhouse://default@localhost:9000/analytics?secure=true",
-			expected: "clickhouse://default@localhost:9000/analytics?secure=true",
-		},
-		{
 			name:     "native TLS port 9440 round-trips",
 			input:    "clickhouse://default@localhost:9440/analytics",
 			expected: "clickhouse://default@localhost:9440/analytics",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(convertClickHouseURL(tt.input), qt.Equals, tt.expected)
+		})
+	}
+}
+
+func TestConvertClickHouseURL_PreservesQueryParameters(t *testing.T) {
+	c := qt.New(t)
+
+	got := convertClickHouseURL("clickhouse://default:secret@localhost:9000/analytics?secure=true&dial_timeout=10s")
+
+	c.Assert(got, qt.Contains, "clickhouse://default:secret@localhost:9000/analytics?")
+	for kv := range strings.SplitSeq("secure=true&dial_timeout=10s", "&") {
+		c.Assert(got, qt.Contains, kv)
+	}
+}
+
+func TestConvertClickHouseURL_ExactQueryRoundTrips(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "preserves secure=true on native port",
+			input:    "clickhouse://default@localhost:9000/analytics?secure=true",
+			expected: "clickhouse://default@localhost:9000/analytics?secure=true",
 		},
 		{
 			name:     "HTTP-SSL port 8443 with secure flag round-trips",
@@ -53,22 +79,10 @@ func TestConvertClickHouseURL(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			got := convertClickHouseURL(tc.input)
-			// url.Parse() doesn't always preserve raw query ordering. For the
-			// expected URLs that carry multiple parameters we assert by
-			// fragments; single-param and no-param URLs round-trip exactly.
-			if strings.Count(tc.expected, "&") > 0 {
-				prefix, _, _ := strings.Cut(tc.expected, "?")
-				c.Assert(got, qt.Contains, prefix)
-				for kv := range strings.SplitSeq(tc.expected[strings.Index(tc.expected, "?")+1:], "&") {
-					c.Assert(got, qt.Contains, kv)
-				}
-				return
-			}
-			c.Assert(got, qt.Equals, tc.expected)
+			c.Assert(convertClickHouseURL(tt.input), qt.Equals, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- convert cmd/internal/buildinfo and cmd/internal/cmdflags tests to black-box packages
- add required white-box justifications to existing *_internal_test.go files
- split the ClickHouse URL normalization test so it no longer branches inside the test loop
- reduce the test-style baseline from 207 to 206 conditional groups and from 74 to 70 white-box files

Refs #541

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/internal/buildinfo ./cmd/internal/cmdflags ./core/renderer/internal/dialects/clickhouse
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./dbschema
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...
- git diff --check
- gopls diagnostics