### PR TITLE
Reduce test-style baseline in cliobs and ClickHouse tests

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1,42 +1,6 @@
 {
   "test_conditionals": [
     {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestEmitterJSONModeWritesParseableJSONLines",
-      "kind": "if",
-      "count": 5
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestJSONOutputWriterFlushesPartialLine",
-      "kind": "if",
-      "count": 6
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestJSONOutputWriterLogsSubprocessLines",
-      "kind": "if",
-      "count": 7
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestMetricsDataRendersPrometheusCountersAndHistograms",
-      "kind": "if",
-      "count": 4
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestMetricsDataWritesTypeOncePerMetricFamily",
-      "kind": "if",
-      "count": 2
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "function": "TestStartRejectsInvalidLogOptions",
-      "kind": "if",
-      "count": 2
-    },
-    {
       "path": "cmd/lint/lint_test.go",
       "function": "TestRunLint_SARIFFormat",
       "kind": "if",
@@ -99,12 +63,6 @@
     {
       "path": "cmd/viz/viz_test.go",
       "function": "TestSVGReportsGraphvizStderrOnFailure",
-      "kind": "if",
-      "count": 1
-    },
-    {
-      "path": "core/ast/ast_test.go",
-      "function": "TestConstraintType_Distinct",
       "kind": "if",
       "count": 1
     },
@@ -293,18 +251,6 @@
       "function": "TestParseFS_PostgreSQLFeatures",
       "kind": "if",
       "count": 3
-    },
-    {
-      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_test.go",
-      "function": "TestColumnTypeMapping",
-      "kind": "if",
-      "count": 2
-    },
-    {
-      "path": "core/renderer/internal/dialects/clickhouse/clickhouse_test.go",
-      "function": "TestVisitDropIndex_RequiresTable",
-      "kind": "if",
-      "count": 1
     },
     {
       "path": "core/renderer/renderer_test.go",
@@ -1266,11 +1212,6 @@
     {
       "path": "cmd/integration-test/main_test.go",
       "package": "main",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/internal/cliobs/cliobs_test.go",
-      "package": "cliobs",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {

--- a/cmd/internal/cliobs/cliobs_internal_test.go
+++ b/cmd/internal/cliobs/cliobs_internal_test.go
@@ -1,0 +1,70 @@
+package cliobs
+
+// White-box testing required: metricsData is an internal Prometheus collector
+// implementation that is only observable through unexported series maps and
+// helper methods before the HTTP handler renders the final metrics text.
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMetricsDataRendersPrometheusCountersAndHistograms(t *testing.T) {
+	c := qt.New(t)
+
+	data := &metricsData{
+		counters:   make(map[string]*counterSeries),
+		histograms: make(map[string]*histogramSeries),
+	}
+	attrs := []migrator.ObservationAttribute{
+		{Key: "db.system", Value: "postgres"},
+		{Key: "migration.direction", Value: "up"},
+	}
+	data.addCounter("ptah_migrations_applied_total", 1, attrs)
+	data.recordDuration("ptah_migration_lock_wait_seconds", (250 * time.Millisecond).Seconds(), attrs)
+
+	recorder := httptest.NewRecorder()
+	data.ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := recorder.Body.String()
+	c.Assert(body, qt.Contains, "# TYPE ptah_migrations_applied_total counter")
+	c.Assert(body, qt.Contains, `ptah_migrations_applied_total{db_system="postgres",migration_direction="up"} 1`)
+	c.Assert(body, qt.Contains, "# TYPE ptah_migration_lock_wait_seconds histogram")
+	c.Assert(body, qt.Contains, `ptah_migration_lock_wait_seconds_count{db_system="postgres",migration_direction="up"} 1`)
+}
+
+func TestMetricsDataWritesTypeOncePerMetricFamily(t *testing.T) {
+	c := qt.New(t)
+
+	data := &metricsData{
+		counters:   make(map[string]*counterSeries),
+		histograms: make(map[string]*histogramSeries),
+	}
+	firstAttrs := []migrator.ObservationAttribute{
+		{Key: "db.system", Value: "postgres"},
+		{Key: "migration.direction", Value: "up"},
+		{Key: "migration.version", Value: 1},
+	}
+	secondAttrs := []migrator.ObservationAttribute{
+		{Key: "db.system", Value: "postgres"},
+		{Key: "migration.direction", Value: "up"},
+		{Key: "migration.version", Value: 2},
+	}
+	data.addCounter("ptah_migrations_applied_total", 1, firstAttrs)
+	data.addCounter("ptah_migrations_applied_total", 1, secondAttrs)
+	data.recordDuration("ptah_migration_duration_seconds", (10 * time.Millisecond).Seconds(), firstAttrs)
+	data.recordDuration("ptah_migration_duration_seconds", (20 * time.Millisecond).Seconds(), secondAttrs)
+
+	recorder := httptest.NewRecorder()
+	data.ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := recorder.Body.String()
+	c.Assert(strings.Count(body, "# TYPE ptah_migrations_applied_total counter"), qt.Equals, 1)
+	c.Assert(strings.Count(body, "# TYPE ptah_migration_duration_seconds histogram"), qt.Equals, 1)
+}

--- a/cmd/internal/cliobs/cliobs_test.go
+++ b/cmd/internal/cliobs/cliobs_test.go
@@ -1,196 +1,121 @@
-package cliobs
+package cliobs_test
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/stokaro/ptah/migration/migrator"
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/cliobs"
 )
 
 func TestEmitterJSONModeWritesParseableJSONLines(t *testing.T) {
+	c := qt.New(t)
+
 	var out bytes.Buffer
-	runtime, err := Start(context.Background(), Options{
+	runtime, err := cliobs.Start(context.Background(), cliobs.Options{
 		Command:   "test",
 		LogFormat: "json",
 		LogLevel:  "info",
 		LogWriter: &out,
 	})
-	if err != nil {
-		t.Fatalf("start observability: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := runtime.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown observability: %v", err)
-		}
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Assert(runtime.Shutdown(context.Background()), qt.IsNil)
 	})
 
-	emit := NewEmitter(&out, runtime)
+	emit := cliobs.NewEmitter(&out, runtime)
 	emit.Println("plain status")
 	emit.Printf("version: %d\n", 42)
 
-	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
-		var payload map[string]any
-		if err := json.Unmarshal([]byte(line), &payload); err != nil {
-			t.Fatalf("line is not JSON: %q: %v", line, err)
-		}
-		if payload["msg"] == "" {
-			t.Fatalf("line missing slog msg: %q", line)
-		}
-		if payload["correlation_id"] == "" {
-			t.Fatalf("line missing correlation_id: %q", line)
-		}
+	for _, payload := range parseJSONLogLines(c, out.String()) {
+		c.Assert(payload["msg"], qt.Not(qt.Equals), "")
+		c.Assert(payload["correlation_id"], qt.Not(qt.Equals), "")
 	}
 }
 
 func TestJSONOutputWriterLogsSubprocessLines(t *testing.T) {
+	c := qt.New(t)
+
 	var out bytes.Buffer
-	runtime, err := Start(context.Background(), Options{
+	runtime, err := cliobs.Start(context.Background(), cliobs.Options{
 		Command:   "test",
 		LogFormat: "json",
 		LogLevel:  "info",
 		LogWriter: &out,
 	})
-	if err != nil {
-		t.Fatalf("start observability: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := runtime.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown observability: %v", err)
-		}
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Assert(runtime.Shutdown(context.Background()), qt.IsNil)
 	})
 
-	writer := NewOutputWriter(&out, runtime, "hook output")
-	if _, err := writer.Write([]byte("line one\nline two\n")); err != nil {
-		t.Fatalf("write hook output: %v", err)
-	}
+	writer := cliobs.NewOutputWriter(&out, runtime, "hook output")
+	_, err = writer.Write([]byte("line one\nline two\n"))
+	c.Assert(err, qt.IsNil)
 
 	var records int
-	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
-		var payload map[string]any
-		if err := json.Unmarshal([]byte(line), &payload); err != nil {
-			t.Fatalf("line is not JSON: %q: %v", line, err)
-		}
-		if payload["msg"] != "hook output" {
-			t.Fatalf("msg = %#v, want hook output", payload["msg"])
-		}
-		if payload["output"] == "" {
-			t.Fatalf("output attr missing: %q", line)
-		}
+	for _, payload := range parseJSONLogLines(c, out.String()) {
+		c.Assert(payload["msg"], qt.Equals, "hook output")
+		c.Assert(payload["output"], qt.Not(qt.Equals), "")
 		records++
 	}
-	if records != 2 {
-		t.Fatalf("records = %d, want 2", records)
-	}
+	c.Assert(records, qt.Equals, 2)
 }
 
 func TestJSONOutputWriterFlushesPartialLine(t *testing.T) {
+	c := qt.New(t)
+
 	var out bytes.Buffer
-	runtime, err := Start(context.Background(), Options{
+	runtime, err := cliobs.Start(context.Background(), cliobs.Options{
 		Command:   "test",
 		LogFormat: "json",
 		LogLevel:  "info",
 		LogWriter: &out,
 	})
-	if err != nil {
-		t.Fatalf("start observability: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := runtime.Shutdown(context.Background()); err != nil {
-			t.Fatalf("shutdown observability: %v", err)
-		}
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Assert(runtime.Shutdown(context.Background()), qt.IsNil)
 	})
 
-	writer := NewOutputWriter(&out, runtime, "hook output")
-	if _, err := writer.Write([]byte("partial line")); err != nil {
-		t.Fatalf("write hook output: %v", err)
-	}
+	writer := cliobs.NewOutputWriter(&out, runtime, "hook output")
+	_, err = writer.Write([]byte("partial line"))
+	c.Assert(err, qt.IsNil)
 	flusher, ok := writer.(interface{ Flush() })
-	if !ok {
-		t.Fatalf("writer does not support Flush")
-	}
+	c.Assert(ok, qt.IsTrue)
 	flusher.Flush()
 
 	var payload map[string]any
-	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &payload); err != nil {
-		t.Fatalf("line is not JSON: %q: %v", out.String(), err)
-	}
-	if payload["output"] != "partial line" {
-		t.Fatalf("output = %#v, want partial line", payload["output"])
-	}
-}
-
-func TestMetricsDataRendersPrometheusCountersAndHistograms(t *testing.T) {
-	data := &metricsData{
-		counters:   make(map[string]*counterSeries),
-		histograms: make(map[string]*histogramSeries),
-	}
-	attrs := []migrator.ObservationAttribute{
-		{Key: "db.system", Value: "postgres"},
-		{Key: "migration.direction", Value: "up"},
-	}
-	data.addCounter("ptah_migrations_applied_total", 1, attrs)
-	data.recordDuration("ptah_migration_lock_wait_seconds", (250 * time.Millisecond).Seconds(), attrs)
-
-	recorder := httptest.NewRecorder()
-	data.ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
-
-	body := recorder.Body.String()
-	if !strings.Contains(body, "# TYPE ptah_migrations_applied_total counter") {
-		t.Fatalf("counter type missing:\n%s", body)
-	}
-	if !strings.Contains(body, `ptah_migrations_applied_total{db_system="postgres",migration_direction="up"} 1`) {
-		t.Fatalf("counter sample missing:\n%s", body)
-	}
-	if !strings.Contains(body, "# TYPE ptah_migration_lock_wait_seconds histogram") {
-		t.Fatalf("histogram type missing:\n%s", body)
-	}
-	if !strings.Contains(body, `ptah_migration_lock_wait_seconds_count{db_system="postgres",migration_direction="up"} 1`) {
-		t.Fatalf("histogram count missing:\n%s", body)
-	}
-}
-
-func TestMetricsDataWritesTypeOncePerMetricFamily(t *testing.T) {
-	data := &metricsData{
-		counters:   make(map[string]*counterSeries),
-		histograms: make(map[string]*histogramSeries),
-	}
-	firstAttrs := []migrator.ObservationAttribute{
-		{Key: "db.system", Value: "postgres"},
-		{Key: "migration.direction", Value: "up"},
-		{Key: "migration.version", Value: 1},
-	}
-	secondAttrs := []migrator.ObservationAttribute{
-		{Key: "db.system", Value: "postgres"},
-		{Key: "migration.direction", Value: "up"},
-		{Key: "migration.version", Value: 2},
-	}
-	data.addCounter("ptah_migrations_applied_total", 1, firstAttrs)
-	data.addCounter("ptah_migrations_applied_total", 1, secondAttrs)
-	data.recordDuration("ptah_migration_duration_seconds", (10 * time.Millisecond).Seconds(), firstAttrs)
-	data.recordDuration("ptah_migration_duration_seconds", (20 * time.Millisecond).Seconds(), secondAttrs)
-
-	recorder := httptest.NewRecorder()
-	data.ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
-
-	body := recorder.Body.String()
-	if count := strings.Count(body, "# TYPE ptah_migrations_applied_total counter"); count != 1 {
-		t.Fatalf("counter TYPE count = %d, want 1:\n%s", count, body)
-	}
-	if count := strings.Count(body, "# TYPE ptah_migration_duration_seconds histogram"); count != 1 {
-		t.Fatalf("histogram TYPE count = %d, want 1:\n%s", count, body)
-	}
+	c.Assert(json.Unmarshal(bytes.TrimSpace(out.Bytes()), &payload), qt.IsNil)
+	c.Assert(payload["output"], qt.Equals, "partial line")
 }
 
 func TestStartRejectsInvalidLogOptions(t *testing.T) {
-	if _, err := Start(context.Background(), Options{LogFormat: "xml"}); err == nil {
-		t.Fatalf("invalid log format was accepted")
+	c := qt.New(t)
+
+	c.Run("invalid log format", func(c *qt.C) {
+		_, err := cliobs.Start(context.Background(), cliobs.Options{LogFormat: "xml"})
+		c.Assert(err, qt.IsNotNil)
+	})
+
+	c.Run("invalid log level", func(c *qt.C) {
+		_, err := cliobs.Start(context.Background(), cliobs.Options{LogLevel: "trace"})
+		c.Assert(err, qt.IsNotNil)
+	})
+}
+
+func parseJSONLogLines(c *qt.C, raw string) []map[string]any {
+	c.Helper()
+
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	payloads := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		var payload map[string]any
+		c.Assert(json.Unmarshal([]byte(line), &payload), qt.IsNil)
+		payloads = append(payloads, payload)
 	}
-	if _, err := Start(context.Background(), Options{LogLevel: "trace"}); err == nil {
-		t.Fatalf("invalid log level was accepted")
-	}
+
+	return payloads
 }

--- a/core/ast/ast_test.go
+++ b/core/ast/ast_test.go
@@ -375,22 +375,15 @@ func TestConstraintType_Constants(t *testing.T) {
 func TestConstraintType_Distinct(t *testing.T) {
 	c := qt.New(t)
 
-	types := []ast.ConstraintType{
-		ast.PrimaryKeyConstraint,
-		ast.UniqueConstraint,
-		ast.ForeignKeyConstraint,
-		ast.CheckConstraint,
-		ast.ExcludeConstraint,
+	types := map[ast.ConstraintType]bool{
+		ast.PrimaryKeyConstraint: true,
+		ast.UniqueConstraint:     true,
+		ast.ForeignKeyConstraint: true,
+		ast.CheckConstraint:      true,
+		ast.ExcludeConstraint:    true,
 	}
 
-	// Verify all types are different
-	for i, t1 := range types {
-		for j, t2 := range types {
-			if i != j {
-				c.Assert(t1, qt.Not(qt.Equals), t2)
-			}
-		}
-	}
+	c.Assert(types, qt.HasLen, 5)
 }
 
 // Test default value edge cases

--- a/core/renderer/internal/dialects/clickhouse/clickhouse_test.go
+++ b/core/renderer/internal/dialects/clickhouse/clickhouse_test.go
@@ -195,13 +195,11 @@ func TestCreateTable_ForeignKeyAndUniqueAreSilentlyDropped(t *testing.T) {
 	c.Assert(out, qt.Not(qt.Contains), "UNIQUE")
 }
 
-func TestColumnTypeMapping(t *testing.T) {
+func TestColumnTypeMapping_HappyPath(t *testing.T) {
 	cases := []struct {
-		name     string
-		col      *ast.ColumnNode
-		want     string
-		wantErr  bool
-		contains string
+		name string
+		col  *ast.ColumnNode
+		want string
 	}{
 		{name: "varchar to String", col: ast.NewColumn("c", "VARCHAR(255)").SetNotNull(), want: "c String"},
 		{name: "text to String", col: ast.NewColumn("c", "TEXT").SetNotNull(), want: "c String"},
@@ -216,10 +214,7 @@ func TestColumnTypeMapping(t *testing.T) {
 		{name: "numeric(p,s) to Decimal", col: ast.NewColumn("c", "NUMERIC(12,4)").SetNotNull(), want: "c Decimal(12,4)"},
 		{name: "bytea to String", col: ast.NewColumn("c", "BYTEA").SetNotNull(), want: "c String"},
 		{name: "nullable wrapping", col: ast.NewColumn("c", "INTEGER"), want: "c Nullable(Int32)"},
-		{name: "serial errors", col: ast.NewColumn("c", "SERIAL").SetNotNull(), wantErr: true, contains: "auto-increment"},
-		{name: "time errors", col: ast.NewColumn("c", "TIME").SetNotNull(), wantErr: true, contains: "TIME"},
 		{name: "native CH type passthrough", col: ast.NewColumn("c", "LowCardinality(String)").SetNotNull(), want: "c LowCardinality(String)"},
-		{name: "unknown SQL type warns", col: ast.NewColumn("c", "GEOGRAPHY").SetNotNull(), want: "c GEOGRAPHY", contains: `unrecognized SQL type "GEOGRAPHY" passed through verbatim`},
 	}
 
 	for _, tc := range cases {
@@ -228,19 +223,45 @@ func TestColumnTypeMapping(t *testing.T) {
 			tbl := ast.NewCreateTable("t").AddColumn(ast.NewColumn("id", "BIGINT").SetPrimary())
 			tbl.AddColumn(tc.col)
 			err := renderErr(tbl)
-			if tc.wantErr {
-				c.Assert(err, qt.IsNotNil)
-				c.Assert(err.Error(), qt.Contains, tc.contains)
-				return
-			}
 			c.Assert(err, qt.IsNil)
 			out := render(t, tbl)
 			c.Assert(out, qt.Contains, tc.want)
-			if tc.contains != "" {
-				c.Assert(out, qt.Contains, tc.contains)
-			}
 		})
 	}
+}
+
+func TestColumnTypeMapping_FailurePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		col      *ast.ColumnNode
+		contains string
+	}{
+		{name: "serial errors", col: ast.NewColumn("c", "SERIAL").SetNotNull(), contains: "auto-increment"},
+		{name: "time errors", col: ast.NewColumn("c", "TIME").SetNotNull(), contains: "TIME"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			tbl := ast.NewCreateTable("t").AddColumn(ast.NewColumn("id", "BIGINT").SetPrimary())
+			tbl.AddColumn(tc.col)
+			err := renderErr(tbl)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tc.contains)
+		})
+	}
+}
+
+func TestColumnTypeMapping_UnknownSQLTypeWarning(t *testing.T) {
+	c := qt.New(t)
+	tbl := ast.NewCreateTable("t").AddColumn(ast.NewColumn("id", "BIGINT").SetPrimary())
+	tbl.AddColumn(ast.NewColumn("c", "GEOGRAPHY").SetNotNull())
+
+	err := renderErr(tbl)
+	c.Assert(err, qt.IsNil)
+	out := render(t, tbl)
+	c.Assert(out, qt.Contains, "c GEOGRAPHY")
+	c.Assert(out, qt.Contains, `unrecognized SQL type "GEOGRAPHY" passed through verbatim`)
 }
 
 func TestAlterTable_Operations(t *testing.T) {
@@ -329,13 +350,7 @@ func TestVisitDropIndex_RequiresTable(t *testing.T) {
 	// `ALTER TABLE ... DROP INDEX` as the required form, so to assert the
 	// absence of a real statement we look for a non-comment line.
 	c.Assert(out, qt.Contains, "-- CLICKHOUSE:")
-	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
-			continue
-		}
-		t.Fatalf("expected only comment output, got executable line: %q", line)
-	}
+	c.Assert(executableLines(out), qt.HasLen, 0)
 }
 
 func TestVisitDropIndex_OnTable(t *testing.T) {
@@ -758,4 +773,16 @@ func TestDialectAndOutputHelpers(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(out, qt.Contains, "-- hello --")
 	c.Assert(r.GetOutput(), qt.Equals, r.Output())
+}
+
+func executableLines(output string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
 }


### PR DESCRIPTION
## Summary

- move `cmd/internal/cliobs` exported API tests to black-box package coverage and keep only `metricsData` tests as justified white-box coverage
- split mixed ClickHouse column-type mapping tests into happy, failure, and warning paths
- replace small manual conditional assertions in AST and ClickHouse tests with declarative assertions
- reduce the test-style baseline from 206 to 197 conditional groups and from 70 to 69 white-box files

Part of #541.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/internal/cliobs ./core/ast ./core/renderer/internal/dialects/clickhouse`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `git diff --check`
- `gopls diagnostics`
