### PR TITLE
Convert focused command tests to black-box packages

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1190,18 +1190,8 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/db/db_test.go",
-      "package": "db",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/drift/drift_test.go",
       "package": "drift",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/dropall/dropall_test.go",
-      "package": "dropall",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
@@ -1250,11 +1240,6 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/migratehash/migratehash_test.go",
-      "package": "migratehash",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/migraterepair/migraterepair_test.go",
       "package": "migraterepair",
       "reason": "same-package test file is not named *_internal_test.go"
@@ -1267,11 +1252,6 @@
     {
       "path": "cmd/migratevalidate/migratevalidate_test.go",
       "package": "migratevalidate",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/migrations/migrations_test.go",
-      "package": "migrations",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {

--- a/cmd/db/db_test.go
+++ b/cmd/db/db_test.go
@@ -1,16 +1,18 @@
-package db
+package db_test
 
 import (
 	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/db"
 )
 
 func TestNewDBCommand_RegistersNativePaths(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDBCommand()
+	cmd := db.NewDBCommand()
 	for _, path := range [][]string{
 		{"read"},
 		{"drop-all"},
@@ -24,7 +26,7 @@ func TestNewDBCommand_RegistersNativePaths(t *testing.T) {
 func TestNewDBCommand_HelpShowsNativeBoundary(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDBCommand()
+	cmd := db.NewDBCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -41,7 +43,7 @@ func TestNewDBCommand_HelpShowsNativeBoundary(t *testing.T) {
 func TestNewDBCommand_RejectsUnknownPositionalCommand(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDBCommand()
+	cmd := db.NewDBCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"inspect"})
@@ -55,7 +57,7 @@ func TestNewDBCommand_RejectsUnknownPositionalCommand(t *testing.T) {
 func TestNewDBCommand_ReadHelpShowsTargetFlags(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDBCommand()
+	cmd := db.NewDBCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -72,7 +74,7 @@ func TestNewDBCommand_ReadHelpShowsTargetFlags(t *testing.T) {
 func TestNewDBCommand_ForwardsReadFlagErrors(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDBCommand()
+	cmd := db.NewDBCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"read", "--bogus-flag"})

--- a/cmd/dropall/dropall_test.go
+++ b/cmd/dropall/dropall_test.go
@@ -1,4 +1,4 @@
-package dropall
+package dropall_test
 
 import (
 	"io"
@@ -9,13 +9,15 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/pflag"
+
+	"github.com/stokaro/ptah/cmd/dropall"
 )
 
 func TestDropAllCommandDeclinedConfirmationPrintsCanceled(t *testing.T) {
 	c := qt.New(t)
 
 	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
-	cmd := NewDropAllCommand()
+	cmd := dropall.NewDropAllCommand()
 	resetDropAllCommandForTest(c, cmd)
 	cmd.SetArgs([]string{"--db-url", dbURL})
 
@@ -29,7 +31,7 @@ func TestDropAllCommandAutoApproveSkipsConfirmation(t *testing.T) {
 	c := qt.New(t)
 
 	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
-	cmd := NewDropAllCommand()
+	cmd := dropall.NewDropAllCommand()
 	resetDropAllCommandForTest(c, cmd)
 	cmd.SetArgs([]string{"--db-url", dbURL, "--auto-approve"})
 

--- a/cmd/migratehash/migratehash_test.go
+++ b/cmd/migratehash/migratehash_test.go
@@ -1,4 +1,4 @@
-package migratehash
+package migratehash_test
 
 import (
 	"bytes"
@@ -9,11 +9,12 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/migratehash"
 	"github.com/stokaro/ptah/internal/migratesum"
 )
 
 func execute(args ...string) (stdout string, err error) {
-	cmd := NewMigrateHashCommand()
+	cmd := migratehash.NewMigrateHashCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)

--- a/cmd/migrations/migrations_test.go
+++ b/cmd/migrations/migrations_test.go
@@ -1,16 +1,18 @@
-package migrations
+package migrations_test
 
 import (
 	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migrations"
 )
 
 func TestNewMigrationsCommand_RegistersNativePaths(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	for _, path := range [][]string{
 		{"plan"},
 		{"generate"},
@@ -33,7 +35,7 @@ func TestNewMigrationsCommand_RegistersNativePaths(t *testing.T) {
 func TestNewMigrationsCommand_HelpShowsNativeBoundary(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -50,7 +52,7 @@ func TestNewMigrationsCommand_HelpShowsNativeBoundary(t *testing.T) {
 func TestNewMigrationsCommand_RejectsUnknownPositionalCommand(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"apply"})
@@ -64,7 +66,7 @@ func TestNewMigrationsCommand_RejectsUnknownPositionalCommand(t *testing.T) {
 func TestNewMigrationsCommand_ForwardsCreateHelpToMigrateNew(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -82,7 +84,7 @@ func TestNewMigrationsCommand_ForwardsCreateHelpToMigrateNew(t *testing.T) {
 func TestNewMigrationsCommand_UpHelpShowsTargetFlags(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -100,7 +102,7 @@ func TestNewMigrationsCommand_UpHelpShowsTargetFlags(t *testing.T) {
 func TestNewMigrationsCommand_ForwardsUpFlagErrors(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrationsCommand()
+	cmd := migrations.NewMigrationsCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"up", "--bogus-flag"})


### PR DESCRIPTION
## Summary

- convert focused command tests to black-box packages in `cmd/db`, `cmd/dropall`, `cmd/migratehash`, and `cmd/migrations`
- keep the tests on exported command constructors only, without adding white-box justifications that are not needed
- reduce the test-style white-box baseline from 69 to 65 files

Part of #541.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/db ./cmd/dropall ./cmd/migrations ./cmd/migratehash`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `git diff --check`
- `gopls diagnostics`
