### PR TITLE
Continue test package boundary cleanup

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -49,24 +49,6 @@
       "count": 3
     },
     {
-      "path": "cmd/viz/viz_test.go",
-      "function": "TestCommandWritesSVGWhenGraphvizIsInstalled",
-      "kind": "if",
-      "count": 1
-    },
-    {
-      "path": "cmd/viz/viz_test.go",
-      "function": "TestDOTParsesWithGraphvizWhenInstalled",
-      "kind": "if",
-      "count": 1
-    },
-    {
-      "path": "cmd/viz/viz_test.go",
-      "function": "TestSVGReportsGraphvizStderrOnFailure",
-      "kind": "if",
-      "count": 1
-    },
-    {
       "path": "core/goschema/dependency_fix_test.go",
       "function": "TestDependencyOrderingWithEmbeddedFields",
       "kind": "if",
@@ -1240,18 +1222,8 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/migraterepair/migraterepair_test.go",
-      "package": "migraterepair",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/migrateup/migrateup_test.go",
       "package": "migrateup",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/migratevalidate/migratevalidate_test.go",
-      "package": "migratevalidate",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
@@ -1265,18 +1237,8 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/seed/seed_test.go",
-      "package": "seed",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/sql/sql_test.go",
       "package": "sql",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/viz/viz_test.go",
-      "package": "viz",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {

--- a/cmd/migraterepair/migraterepair_internal_test.go
+++ b/cmd/migraterepair/migraterepair_internal_test.go
@@ -1,0 +1,33 @@
+package migraterepair
+
+// White-box testing required: parseResumeFrom is a small validation boundary
+// for resume semantics whose zero/default behavior is clearer to test directly
+// than through a database-backed repair command execution.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseResumeFrom_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	resumeFrom, err := parseResumeFrom("")
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumeFrom, qt.Equals, 0)
+
+	resumeFrom, err = parseResumeFrom("3")
+	c.Assert(err, qt.IsNil)
+	c.Assert(resumeFrom, qt.Equals, 3)
+}
+
+func TestParseResumeFrom_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parseResumeFrom("0")
+	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "0"`)
+
+	_, err = parseResumeFrom("bad")
+	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "bad"`)
+}

--- a/cmd/migraterepair/migraterepair_test.go
+++ b/cmd/migraterepair/migraterepair_test.go
@@ -1,40 +1,24 @@
-package migraterepair
+package migraterepair_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migraterepair"
 )
 
 func TestMigrateRepairCommand_Creation(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrateRepairCommand()
+	cmd := migraterepair.NewMigrateRepairCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "repair")
 	c.Assert(cmd.Short, qt.Contains, "Repair dirty migration metadata")
-	c.Assert(cmd.Flag(dbURLFlag), qt.IsNotNil)
-	c.Assert(cmd.Flag(migrationsFlag), qt.IsNotNil)
-	c.Assert(cmd.Flag(versionFlag), qt.IsNotNil)
-	c.Assert(cmd.Flag(forceFlag), qt.IsNotNil)
-	c.Assert(cmd.Flag(resumeFromFlag), qt.IsNotNil)
-}
-
-func TestParseResumeFrom(t *testing.T) {
-	c := qt.New(t)
-
-	resumeFrom, err := parseResumeFrom("")
-	c.Assert(err, qt.IsNil)
-	c.Assert(resumeFrom, qt.Equals, 0)
-
-	resumeFrom, err = parseResumeFrom("3")
-	c.Assert(err, qt.IsNil)
-	c.Assert(resumeFrom, qt.Equals, 3)
-
-	_, err = parseResumeFrom("0")
-	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "0"`)
-
-	_, err = parseResumeFrom("bad")
-	c.Assert(err, qt.ErrorMatches, `invalid resume-from value "bad"`)
+	c.Assert(cmd.Flag("db-url"), qt.IsNotNil)
+	c.Assert(cmd.Flag("migrations-dir"), qt.IsNotNil)
+	c.Assert(cmd.Flag("version"), qt.IsNotNil)
+	c.Assert(cmd.Flag("force"), qt.IsNotNil)
+	c.Assert(cmd.Flag("resume-from"), qt.IsNotNil)
 }

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -1,4 +1,4 @@
-package migratevalidate
+package migratevalidate_test
 
 import (
 	"bytes"
@@ -9,12 +9,13 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/migratevalidate"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
 func execute(args ...string) (stdout, stderr string, err error) {
-	cmd := NewMigrateValidateCommand()
+	cmd := migratevalidate.NewMigrateValidateCommand()
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -24,26 +25,23 @@ func execute(args ...string) (stdout, stderr string, err error) {
 }
 
 // migrationsDir writes a clean pair plus a matching ptah.sum and returns the dir.
-func migrationsDir(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
+func migrationsDir(c *qt.C) string {
+	c.Helper()
+	dir := c.TempDir()
 	write := func(name, content string) {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
 	}
 	write("0000000001_init.up.sql", "CREATE TABLE t (id INT);\n")
 	write("0000000001_init.down.sql", "DROP TABLE t;\n")
-	if _, err := migratesum.Write(dir); err != nil {
-		t.Fatal(err)
-	}
+	_, err := migratesum.Write(dir)
+	c.Assert(err, qt.IsNil)
 	return dir
 }
 
 func TestValidate_CleanDirectoryExitsZero(t *testing.T) {
 	c := qt.New(t)
 
-	stdout, _, err := execute("--dir", migrationsDir(t))
+	stdout, _, err := execute("--dir", migrationsDir(c))
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Contains, "OK: migrations directory matches ptah.sum")
 }
@@ -65,7 +63,7 @@ func TestValidate_AutoReadsAtlasSum(t *testing.T) {
 func TestValidate_EditedMigrationExitsOneWithDiff(t *testing.T) {
 	c := qt.New(t)
 
-	dir := migrationsDir(t)
+	dir := migrationsDir(c)
 	// Tamper with an already-hashed migration.
 	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
 		[]byte("CREATE TABLE t (id BIGINT);\n"), 0o600), qt.IsNil)
@@ -105,7 +103,7 @@ func TestValidate_PositionalArgExitsTwoWithMessage(t *testing.T) {
 	// A stray positional (e.g. the path typed without --dir) is a usage
 	// error (exit 2 with a message), not a silent exit 1 that would look
 	// like drift.
-	_, stderr, err := execute(migrationsDir(t), "stray")
+	_, stderr, err := execute(migrationsDir(c), "stray")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(stderr, qt.Contains, "unexpected positional arguments")
 }
@@ -113,7 +111,7 @@ func TestValidate_PositionalArgExitsTwoWithMessage(t *testing.T) {
 func TestValidate_CorruptSumFileExitsTwoNotOne(t *testing.T) {
 	c := qt.New(t)
 
-	dir := migrationsDir(t)
+	dir := migrationsDir(c)
 	// A structurally broken ptah.sum (an h1: hash that is not valid base64)
 	// is a usage failure (exit 2), not content drift (exit 1).
 	c.Assert(os.WriteFile(filepath.Join(dir, "ptah.sum"),

--- a/cmd/seed/seed_internal_test.go
+++ b/cmd/seed/seed_internal_test.go
@@ -1,0 +1,31 @@
+package seed
+
+// White-box testing required: runSeed validates pre-connection seed options
+// that are not fully observable through NewSeedCommand without attempting a
+// database connection.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestRunSeedRequiresDatabaseURL(t *testing.T) {
+	c := qt.New(t)
+
+	err := runSeed(t.Context(), runOptions{env: "test", seedsDir: "seeds"})
+
+	c.Assert(err, qt.ErrorMatches, `database URL is required`)
+}
+
+func TestRunSeedValidatesProtectedEnvBeforeConnecting(t *testing.T) {
+	c := qt.New(t)
+
+	err := runSeed(t.Context(), runOptions{
+		dbURL:    "postgres://localhost/db",
+		seedsDir: "seeds",
+		env:      "prod",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `refusing to seed protected environment "prod" without --allow-prod`)
+}

--- a/cmd/seed/seed_test.go
+++ b/cmd/seed/seed_test.go
@@ -1,37 +1,19 @@
-package seed
+package seed_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/seed"
 )
 
 func TestNewSeedCommand_Creation(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewSeedCommand()
+	cmd := seed.NewSeedCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "seed")
 	c.Assert(cmd.Short, qt.Contains, "seed")
-}
-
-func TestRunSeedRequiresDatabaseURL(t *testing.T) {
-	c := qt.New(t)
-
-	err := runSeed(t.Context(), runOptions{env: "test", seedsDir: "seeds"})
-
-	c.Assert(err, qt.ErrorMatches, `database URL is required`)
-}
-
-func TestRunSeedValidatesProtectedEnvBeforeConnecting(t *testing.T) {
-	c := qt.New(t)
-
-	err := runSeed(t.Context(), runOptions{
-		dbURL:    "postgres://localhost/db",
-		seedsDir: "seeds",
-		env:      "prod",
-	})
-
-	c.Assert(err, qt.ErrorMatches, `refusing to seed protected environment "prod" without --allow-prod`)
 }

--- a/cmd/viz/viz_test.go
+++ b/cmd/viz/viz_test.go
@@ -1,4 +1,4 @@
-package viz
+package viz_test
 
 import (
 	"bytes"
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/viz"
 )
 
 func TestCommandWritesMermaid(t *testing.T) {
@@ -17,7 +19,7 @@ func TestCommandWritesMermaid(t *testing.T) {
 	dir := t.TempDir()
 	writeModel(c, dir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -42,7 +44,7 @@ func TestCommandDoesNotDuplicateJSONEmbeddedColumns(t *testing.T) {
 	dir := t.TempDir()
 	writeJSONEmbeddedModel(c, dir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -63,7 +65,7 @@ func TestCommandExcludesTables(t *testing.T) {
 	dir := t.TempDir()
 	writeModel(c, dir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -84,13 +86,11 @@ func TestCommandExcludesTables(t *testing.T) {
 
 func TestDOTParsesWithGraphvizWhenInstalled(t *testing.T) {
 	c := qt.New(t)
-	if _, err := exec.LookPath("dot"); err != nil {
-		t.Skipf("Graphviz dot not installed: %v", err)
-	}
+	requireGraphvizDot(t)
 	dir := t.TempDir()
 	writeModel(c, dir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -117,13 +117,11 @@ func TestDOTParsesWithGraphvizWhenInstalled(t *testing.T) {
 
 func TestCommandWritesSVGWhenGraphvizIsInstalled(t *testing.T) {
 	c := qt.New(t)
-	if _, err := exec.LookPath("dot"); err != nil {
-		t.Skipf("Graphviz dot not installed: %v", err)
-	}
+	requireGraphvizDot(t)
 	dir := t.TempDir()
 	writeModel(c, dir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
@@ -171,7 +169,7 @@ func TestExampleArtifactsMatchGeneratedOutput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			cmd := NewCommand()
+			cmd := viz.NewCommand()
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&stderr)
@@ -197,7 +195,7 @@ func TestSVGReportsFriendlyGraphvizErrorWhenDotIsMissing(t *testing.T) {
 	writeModel(c, dir)
 	t.Setenv("PATH", t.TempDir())
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
@@ -212,9 +210,7 @@ func TestSVGReportsFriendlyGraphvizErrorWhenDotIsMissing(t *testing.T) {
 }
 
 func TestSVGReportsGraphvizStderrOnFailure(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test uses a POSIX shell script")
-	}
+	skipOnWindows(t)
 	c := qt.New(t)
 	dir := t.TempDir()
 	writeModel(c, dir)
@@ -224,7 +220,7 @@ func TestSVGReportsGraphvizStderrOnFailure(t *testing.T) {
 	c.Assert(os.Chmod(dotPath, 0o700), qt.IsNil)
 	t.Setenv("PATH", binDir)
 
-	cmd := NewCommand()
+	cmd := viz.NewCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
@@ -236,6 +232,23 @@ func TestSVGReportsGraphvizStderrOnFailure(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `render SVG with Graphviz dot: .*: graphviz exploded`)
 	c.Assert(stderr.String(), qt.Contains, "graphviz exploded")
+}
+
+func requireGraphvizDot(t *testing.T) {
+	t.Helper()
+
+	_, err := exec.LookPath("dot")
+	if err != nil {
+		t.Skipf("Graphviz dot not installed: %v", err)
+	}
+}
+
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell script")
+	}
 }
 
 func writeModel(c *qt.C, dir string) {


### PR DESCRIPTION
## Summary

- Convert `cmd/viz` and `cmd/migratevalidate` tests to black-box packages.
- Split `cmd/seed` and `cmd/migraterepair` so exported command-constructor tests are black-box and the remaining internal tests use justified `*_internal_test.go` files.
- Reduce the test-style baseline from 197 to 194 conditional groups and from 65 to 61 white-box files.

Part of #541.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/viz ./cmd/migratevalidate ./cmd/seed ./cmd/migraterepair`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `git diff --check`
- global `gopls` diagnostics: no diagnostics

## Self-review

- Logic: test behavior is unchanged except for package boundaries and removal of test-body conditionals in `cmd/viz`.
- Safety: runtime code is untouched; this is test-only.
- Testing standards: new same-package tests are `*_internal_test.go` and include the required white-box justification after the package clause.
- Review: sidecar review found a stale baseline blocker; fixed by regenerating `.teststyle-baseline.json` to `194 conditional groups, 61 white-box files`.
