### PR TITLE
Split focused command tests by package boundary

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1172,16 +1172,6 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/drift/drift_test.go",
-      "package": "drift",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/generate/generate_test.go",
-      "package": "generate",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/integration-test/main_test.go",
       "package": "main",
       "reason": "same-package test file is not named *_internal_test.go"
@@ -1234,11 +1224,6 @@
     {
       "path": "cmd/root/root_test.go",
       "package": "root",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/sql/sql_test.go",
-      "package": "sql",
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {

--- a/cmd/drift/drift_internal_test.go
+++ b/cmd/drift/drift_internal_test.go
@@ -1,0 +1,74 @@
+package drift
+
+// White-box testing required: drift ignore parsing and report formatting are
+// internal command helpers whose edge cases are clearer to verify directly
+// than through full live-database command execution.
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+func TestParseIgnoredTables(t *testing.T) {
+	c := qt.New(t)
+
+	tables, err := parseIgnoredTables([]string{"tables=audit_log,sessions", "tables= audit_log , events "})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(tables, qt.DeepEquals, []string{"audit_log", "events", "sessions"})
+}
+
+func TestParseIgnoredTablesRejectsUnknownScope(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := parseIgnoredTables([]string{"views=audit_view"})
+
+	c.Assert(err, qt.ErrorMatches, `invalid --ignore value "views=audit_view": expected tables=name\[,name\.\.\.\]`)
+}
+
+func TestShouldFailDrift(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(shouldFailDrift(safety.Warning, severityAll), qt.IsTrue)
+	c.Assert(shouldFailDrift(safety.Warning, severityDestructive), qt.IsFalse)
+	c.Assert(shouldFailDrift(safety.Destructive, severityDestructive), qt.IsTrue)
+}
+
+func TestWriteGitHubActionsReport(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	err := writeGitHubActionsReport(&buf, driftReport{
+		Drift:            true,
+		Failed:           true,
+		FailureThreshold: severityDestructive,
+		HighestSeverity:  safety.Destructive,
+		Findings: []safety.Finding{
+			{Category: "tables_removed", Count: 1, Severity: safety.Destructive},
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "::error title=Ptah schema drift::")
+	c.Assert(buf.String(), qt.Contains, "tables_removed: 1")
+}
+
+func TestWriteJSONReport(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	err := writeReport(&buf, formatJSON, driftReport{
+		Drift:            true,
+		Failed:           false,
+		FailureThreshold: severityDestructive,
+		HighestSeverity:  safety.Warning,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, `"drift": true`)
+	c.Assert(buf.String(), qt.Contains, `"highest_severity": "warning"`)
+}

--- a/cmd/drift/drift_test.go
+++ b/cmd/drift/drift_test.go
@@ -1,4 +1,4 @@
-package drift
+package drift_test
 
 import (
 	"bytes"
@@ -6,14 +6,14 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/cmd/drift"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
-	"github.com/stokaro/ptah/migration/safety"
 )
 
 func TestNewDriftCommand_Creation(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDriftCommand()
+	cmd := drift.NewDriftCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "drift")
@@ -23,7 +23,7 @@ func TestNewDriftCommand_Creation(t *testing.T) {
 func TestRunDrift_MissingDatabaseURLReturnsCode2(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewDriftCommand()
+	cmd := drift.NewDriftCommand()
 	var stderr bytes.Buffer
 	cmd.SetErr(&stderr)
 	cmd.SetOut(&bytes.Buffer{})
@@ -34,64 +34,4 @@ func TestRunDrift_MissingDatabaseURLReturnsCode2(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(stderr.String(), qt.Contains, "database URL is required")
-}
-
-func TestParseIgnoredTables(t *testing.T) {
-	c := qt.New(t)
-
-	tables, err := parseIgnoredTables([]string{"tables=audit_log,sessions", "tables= audit_log , events "})
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(tables, qt.DeepEquals, []string{"audit_log", "events", "sessions"})
-}
-
-func TestParseIgnoredTablesRejectsUnknownScope(t *testing.T) {
-	c := qt.New(t)
-
-	_, err := parseIgnoredTables([]string{"views=audit_view"})
-
-	c.Assert(err, qt.ErrorMatches, `invalid --ignore value "views=audit_view": expected tables=name\[,name\.\.\.\]`)
-}
-
-func TestShouldFailDrift(t *testing.T) {
-	c := qt.New(t)
-
-	c.Assert(shouldFailDrift(safety.Warning, severityAll), qt.IsTrue)
-	c.Assert(shouldFailDrift(safety.Warning, severityDestructive), qt.IsFalse)
-	c.Assert(shouldFailDrift(safety.Destructive, severityDestructive), qt.IsTrue)
-}
-
-func TestWriteGitHubActionsReport(t *testing.T) {
-	c := qt.New(t)
-
-	var buf bytes.Buffer
-	err := writeGitHubActionsReport(&buf, driftReport{
-		Drift:            true,
-		Failed:           true,
-		FailureThreshold: severityDestructive,
-		HighestSeverity:  safety.Destructive,
-		Findings: []safety.Finding{
-			{Category: "tables_removed", Count: 1, Severity: safety.Destructive},
-		},
-	})
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(buf.String(), qt.Contains, "::error title=Ptah schema drift::")
-	c.Assert(buf.String(), qt.Contains, "tables_removed: 1")
-}
-
-func TestWriteJSONReport(t *testing.T) {
-	c := qt.New(t)
-
-	var buf bytes.Buffer
-	err := writeReport(&buf, formatJSON, driftReport{
-		Drift:            true,
-		Failed:           false,
-		FailureThreshold: severityDestructive,
-		HighestSeverity:  safety.Warning,
-	})
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(buf.String(), qt.Contains, `"drift": true`)
-	c.Assert(buf.String(), qt.Contains, `"highest_severity": "warning"`)
 }

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -1,0 +1,83 @@
+package generate
+
+// White-box testing required: loadSchema is the command package's internal
+// schema-source dispatcher, and its extension routing can be verified directly
+// without invoking the whole CLI command.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestLoadSchemaFile_YAML(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.yaml")
+	c.Assert(
+		os.WriteFile(path, []byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+`), 0o600),
+		qt.IsNil,
+	)
+
+	db, err := loadSchema("", path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "users")
+}
+
+func TestLoadSchemaFile_AtlasHCL(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.hcl")
+	c.Assert(os.WriteFile(path, []byte(`
+table "users" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`), 0o600), qt.IsNil)
+
+	db, err := loadSchema("", path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "users")
+	c.Assert(db.Fields[0].Primary, qt.IsTrue)
+}
+
+func TestLoadSchemaFile_SQL(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+`), 0o600), qt.IsNil)
+
+	db, err := loadSchema("", path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "users")
+	c.Assert(db.Fields, qt.HasLen, 2)
+}
+
+func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.json")
+	c.Assert(os.WriteFile(path, []byte(`{}`), 0o600), qt.IsNil)
+
+	_, err := loadSchema("", path)
+	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, .hcl, and .sql are supported`)
+}

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -1,8 +1,7 @@
-package generate
+package generate_test
 
 import (
 	"bytes"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/cmd/generate"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
@@ -22,80 +22,10 @@ func outputStatementContaining(output, marker string) string {
 	return ""
 }
 
-func TestLoadSchemaFile_YAML(t *testing.T) {
-	c := qt.New(t)
-
-	path := filepath.Join(t.TempDir(), "schema.yaml")
-	c.Assert(
-		os.WriteFile(path, []byte(`
-tables:
-  users:
-    columns:
-      id: { type: SERIAL, primary: true }
-`), 0o600),
-		qt.IsNil,
-	)
-
-	db, err := loadSchema("", path)
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.Tables, qt.HasLen, 1)
-	c.Assert(db.Tables[0].Name, qt.Equals, "users")
-}
-
-func TestLoadSchemaFile_AtlasHCL(t *testing.T) {
-	c := qt.New(t)
-
-	path := filepath.Join(t.TempDir(), "schema.hcl")
-	c.Assert(os.WriteFile(path, []byte(`
-table "users" {
-  column "id" {
-    type = int
-  }
-  primary_key {
-    columns = [column.id]
-  }
-}
-`), 0o600), qt.IsNil)
-
-	db, err := loadSchema("", path)
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.Tables, qt.HasLen, 1)
-	c.Assert(db.Tables[0].Name, qt.Equals, "users")
-	c.Assert(db.Fields[0].Primary, qt.IsTrue)
-}
-
-func TestLoadSchemaFile_SQL(t *testing.T) {
-	c := qt.New(t)
-
-	path := filepath.Join(t.TempDir(), "schema.sql")
-	c.Assert(os.WriteFile(path, []byte(`
-CREATE TABLE users (
-  id INTEGER PRIMARY KEY,
-  name TEXT NOT NULL
-);
-`), 0o600), qt.IsNil)
-
-	db, err := loadSchema("", path)
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.Tables, qt.HasLen, 1)
-	c.Assert(db.Tables[0].Name, qt.Equals, "users")
-	c.Assert(db.Fields, qt.HasLen, 2)
-}
-
-func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
-	c := qt.New(t)
-
-	path := filepath.Join(t.TempDir(), "schema.json")
-	c.Assert(os.WriteFile(path, []byte(`{}`), 0o600), qt.IsNil)
-
-	_, err := loadSchema("", path)
-	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, .hcl, and .sql are supported`)
-}
-
 func TestGenerateCommandUnsupportedDialectExits2WithoutPanicTrace(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewGenerateCommand()
+	cmd := generate.NewGenerateCommand()
 	var out bytes.Buffer
 	var errOut bytes.Buffer
 	cmd.SetOut(&out)

--- a/cmd/sql/sql_internal_test.go
+++ b/cmd/sql/sql_internal_test.go
@@ -1,0 +1,40 @@
+package sql
+
+// White-box testing required: writeSQLLintReport is the command package's
+// internal formatter boundary, and writer-error propagation is not exposed
+// through the public cobra command API.
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/sqllint"
+)
+
+func TestWriteSQLLintReport_TextPropagatesWriterError(t *testing.T) {
+	c := qt.New(t)
+	errBoom := errors.New("boom")
+
+	err := writeSQLLintReport(failingWriter{err: errBoom}, formatText, sqlLintReport{
+		Findings: []sqllint.Finding{{
+			Rule:     sqllint.RuleUnsupportedStatement,
+			Severity: sqllint.SeverityError,
+			File:     "schema.sql",
+			Line:     1,
+			Column:   1,
+			Message:  "bad",
+		}},
+	})
+
+	c.Assert(err, qt.ErrorIs, errBoom)
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}

--- a/cmd/sql/sql_test.go
+++ b/cmd/sql/sql_test.go
@@ -1,9 +1,8 @@
-package sql
+package sql_test
 
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,11 +10,12 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
+	"github.com/stokaro/ptah/cmd/sql"
 	"github.com/stokaro/ptah/internal/sqllint"
 )
 
 func execute(args ...string) (stdout, stderr string, err error) {
-	cmd := NewSQLCommand()
+	cmd := sql.NewSQLCommand()
 	var out, errOut bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
@@ -25,7 +25,7 @@ func execute(args ...string) (stdout, stderr string, err error) {
 }
 
 func executeWithStdin(stdin string, args ...string) (stdout, stderr string, err error) {
-	cmd := NewSQLCommand()
+	cmd := sql.NewSQLCommand()
 	var out, errOut bytes.Buffer
 	cmd.SetIn(bytes.NewBufferString(stdin))
 	cmd.SetOut(&out)
@@ -38,7 +38,7 @@ func executeWithStdin(stdin string, args ...string) (stdout, stderr string, err 
 func TestNewSQLCommand_Creation(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewSQLCommand()
+	cmd := sql.NewSQLCommand()
 
 	c.Assert(cmd, qt.IsNotNil)
 	c.Assert(cmd.Use, qt.Equals, "sql")
@@ -155,34 +155,8 @@ func TestSQLLint_UsageErrorsExitTwo(t *testing.T) {
 	}
 }
 
-func TestWriteSQLLintReport_TextPropagatesWriterError(t *testing.T) {
-	c := qt.New(t)
-	errBoom := errors.New("boom")
-
-	err := writeSQLLintReport(failingWriter{err: errBoom}, formatText, sqlLintReport{
-		Findings: []sqllint.Finding{{
-			Rule:     sqllint.RuleUnsupportedStatement,
-			Severity: sqllint.SeverityError,
-			File:     "schema.sql",
-			Line:     1,
-			Column:   1,
-			Message:  "bad",
-		}},
-	})
-
-	c.Assert(err, qt.ErrorIs, errBoom)
-}
-
-func writeSQLFile(c *qt.C, dir, name, sql string) string {
+func writeSQLFile(c *qt.C, dir, name, statement string) string {
 	path := filepath.Join(dir, name)
-	c.Assert(os.WriteFile(path, []byte(sql), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(statement), 0o600), qt.IsNil)
 	return path
-}
-
-type failingWriter struct {
-	err error
-}
-
-func (w failingWriter) Write(_ []byte) (int, error) {
-	return 0, w.err
 }


### PR DESCRIPTION
## Summary

- Convert exported command behavior tests in `cmd/sql`, `cmd/drift`, and `cmd/generate` to black-box packages.
- Move the remaining internal helper coverage into justified `*_internal_test.go` files.
- Reduce the test-style white-box baseline from 61 to 58 files while keeping conditional groups at 194.

Part of #541.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/sql ./cmd/drift ./cmd/generate`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./cmd/sql ./cmd/drift ./cmd/generate`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `git diff --check`
- global `gopls` diagnostics: no diagnostics

## Self-review

- Logic: runtime code is untouched; tests were only split by package boundary.
- Test standards: black-box files use exported command constructors; internal helpers now live in `*_internal_test.go` files with required white-box justification comments.
- Baseline: regenerated by `go run ./internal/tools/teststyle -write-baseline`; final scanner output is `194 conditional groups, 58 white-box files`.
- Independent review: sidecar review reported no blockers after confirming focused tests, teststyle, and diff hygiene.
