### PR TITLE
Convert migrate command tests to black-box package

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1192,17 +1192,7 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/migrate/generate_test.go",
-      "package": "migrate",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/migrate/migrate_test.go",
-      "package": "migrate",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "cmd/migrate/new_test.go",
       "package": "migrate",
       "reason": "same-package test file is not named *_internal_test.go"
     },

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -1,4 +1,4 @@
-package migrate
+package migrate_test
 
 import (
 	"bytes"
@@ -10,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -17,11 +18,11 @@ import (
 func TestMigrateGenerateCommandExposesShadowDBFlag(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrateGenerateCommand()
+	cmd := migrate.NewMigrateGenerateCommand()
 
 	c.Assert(cmd.Name(), qt.Equals, "generate")
-	c.Assert(cmd.Flags().Lookup(generateShadowDBFlag), qt.IsNotNil)
-	c.Assert(cmd.Flags().Lookup(generateMigrationsDirFlag), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("shadow-db"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("migrations-dir"), qt.IsNotNil)
 	c.Assert(cmd.Flags().Lookup("config"), qt.IsNotNil)
 	c.Assert(cmd.Flags().Lookup("env"), qt.IsNotNil)
 }
@@ -42,28 +43,28 @@ func TestMigrateGenerateProjectConfigPrecedence(t *testing.T) {
 		c.Assert(os.Chdir(originalWD), qt.IsNil)
 	}()
 
-	cmd := NewMigrateGenerateCommand()
+	cmd := migrate.NewMigrateGenerateCommand()
 	c.Assert(cmd.ParseFlags([]string{"--shadow-db", "postgres://localhost/flag_shadow"}), qt.IsNil)
-	flagShadow, err := cmd.Flags().GetString(generateShadowDBFlag)
+	flagShadow, err := cmd.Flags().GetString("shadow-db")
 	c.Assert(err, qt.IsNil)
 	cfg, err := dbcli.LoadProjectConfig(cmd, "")
 	c.Assert(err, qt.IsNil)
 
-	shadowDB := dbcli.EffectiveString(cmd, generateShadowDBFlag, flagShadow, cfg.DevURL)
+	shadowDB := dbcli.EffectiveString(cmd, "shadow-db", flagShadow, cfg.DevURL)
 
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/flag_shadow")
 
-	cmd = NewMigrateGenerateCommand()
+	cmd = migrate.NewMigrateGenerateCommand()
 	cfg, err = dbcli.LoadProjectConfig(cmd, "")
 	c.Assert(err, qt.IsNil)
-	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, "", cfg.DevURL)
+	shadowDB = dbcli.EffectiveString(cmd, "shadow-db", "", cfg.DevURL)
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/atlas_shadow")
 }
 
 func TestMigratePlanCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrateCommand()
+	cmd := migrate.NewMigrateCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -106,7 +107,7 @@ func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 		prepareMigrateGenerateTargetDB(c, ctx, conn)
 
 		var out bytes.Buffer
-		cmd := NewMigrateGenerateCommand()
+		cmd := migrate.NewMigrateGenerateCommand()
 		cmd.SetOut(&out)
 		cmd.SetArgs([]string{
 			"--root-dir", entitiesDir,
@@ -133,7 +134,7 @@ func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 		prepareMigrateGenerateTargetDB(c, ctx, conn)
 
 		var out bytes.Buffer
-		cmd := NewMigrateGenerateCommand()
+		cmd := migrate.NewMigrateGenerateCommand()
 		cmd.SetOut(&out)
 		cmd.SetArgs([]string{
 			"--root-dir", entitiesDir,

--- a/cmd/migrate/new_test.go
+++ b/cmd/migrate/new_test.go
@@ -1,4 +1,4 @@
-package migrate
+package migrate_test
 
 import (
 	"bytes"
@@ -7,13 +7,15 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migrate"
 )
 
 func TestMigrateNewCommandCreatesSkeletonFiles(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
-	cmd := NewMigrateCreateCommand()
+	cmd := migrate.NewMigrateCreateCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
@@ -38,7 +40,7 @@ func TestMigrateNewCommandAcceptsNameFlag(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
-	cmd := NewMigrateCreateCommand()
+	cmd := migrate.NewMigrateCreateCommand()
 	cmd.SetArgs([]string{"--name", "manual_hotfix", "--migrations-dir", dir})
 
 	err := cmd.Execute()
@@ -75,7 +77,7 @@ func TestMigrateNewCommandValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
-			cmd := NewMigrateCreateCommand()
+			cmd := migrate.NewMigrateCreateCommand()
 			cmd.SetArgs(tt.args)
 
 			err := cmd.Execute()
@@ -88,7 +90,7 @@ func TestMigrateNewCommandValidation(t *testing.T) {
 func TestMigrateCreateCommandUsesNativeName(t *testing.T) {
 	c := qt.New(t)
 
-	cmd := NewMigrateCreateCommand()
+	cmd := migrate.NewMigrateCreateCommand()
 
 	c.Assert(cmd.Name(), qt.Equals, "create")
 }


### PR DESCRIPTION
## Summary

- Convert `cmd/migrate` command behavior tests in `generate_test.go` and `new_test.go` to black-box package tests.
- Replace checks against unexported flag constants with the public CLI flag names they represent.
- Reduce the test-style white-box baseline from 58 to 56 files while keeping conditional groups at 194.

Part of #541.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/migrate`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...`
- `git diff --check`
- global `gopls` diagnostics: no diagnostics

## Self-review

- Logic: runtime code is untouched; the tests still exercise the same command behavior through exported constructors.
- Public contract: unexported flag constant references were replaced with literal public flag names (`shadow-db`, `migrations-dir`) that the CLI exposes.
- Baseline: regenerated by `go run ./internal/tools/teststyle -write-baseline`; final scanner output is `194 conditional groups, 56 white-box files`.
- Independent review: sidecar review reported no findings.
