### PR TITLE
Remove migratedown integration test conditional

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -25,12 +25,6 @@
       "count": 3
     },
     {
-      "path": "cmd/migratedown/migratedown_test.go",
-      "function": "TestMigrateDownCommand_Integration",
-      "kind": "if",
-      "count": 1
-    },
-    {
       "path": "cmd/migrateup/migrateup_test.go",
       "function": "TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres",
       "kind": "if",

--- a/cmd/migratedown/migratedown_test.go
+++ b/cmd/migratedown/migratedown_test.go
@@ -126,12 +126,8 @@ func TestMigrateDownCommandRejectsRelativeTraversalDirectory(t *testing.T) {
 // TestMigrateDownCommand_Integration tests the actual migration logic
 // This test requires a real database connection and is skipped if no test database is available
 func TestMigrateDownCommand_Integration(t *testing.T) {
-	dbURL := os.Getenv("TEST_DATABASE_URL")
-	if dbURL == "" {
-		t.Skip("TEST_DATABASE_URL not set, skipping integration test")
-	}
-
 	c := qt.New(t)
+	dbURL := requiredTestDatabaseURL(t)
 
 	// Create a temporary directory for test migrations
 	tempDir := t.TempDir()
@@ -140,10 +136,10 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 	upSQL := `CREATE TABLE test_table (id INTEGER PRIMARY KEY);`
 	downSQL := `DROP TABLE test_table;`
 
-	err := os.WriteFile(tempDir+"/001_create_test_table.up.sql", []byte(upSQL), 0644) //nolint:gosec // 0644 is fine
+	err := os.WriteFile(tempDir+"/001_create_test_table.up.sql", []byte(upSQL), 0o644) //nolint:gosec // 0o644 is fine
 	c.Assert(err, qt.IsNil)
 
-	err = os.WriteFile(tempDir+"/001_create_test_table.down.sql", []byte(downSQL), 0644) //nolint:gosec // 0644 is fine
+	err = os.WriteFile(tempDir+"/001_create_test_table.down.sql", []byte(downSQL), 0o644) //nolint:gosec // 0o644 is fine
 	c.Assert(err, qt.IsNil)
 
 	// Connect to database
@@ -181,6 +177,16 @@ func TestMigrateDownCommand_Integration(t *testing.T) {
 	finalStatus, err := mig.GetMigrationStatus(context.Background())
 	c.Assert(err, qt.IsNil)
 	c.Assert(finalStatus.CurrentVersion, qt.Equals, 0)
+}
+
+func requiredTestDatabaseURL(t *testing.T) string {
+	t.Helper()
+
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("TEST_DATABASE_URL not set, skipping integration test")
+	}
+	return dbURL
 }
 
 func captureStdIO(c *qt.C, input string, run func() error) (string, error) {


### PR DESCRIPTION
## Summary

- Move the `TEST_DATABASE_URL` skip branch out of `TestMigrateDownCommand_Integration` into a helper.
- Keep the integration test behavior unchanged while making the test function declarative.
- Remove the stale #541 baseline entry for `cmd/migratedown`: baseline is now 192 conditional groups and 55 white-box files.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/migratedown`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...` (passes outside sandbox; sandbox blocks `dbschema` bind tests with `operation not permitted`)
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./...`
- `git diff --check`
- global `gopls` diagnostics: no diagnostics

## Self-Review

- Checked that integration skip semantics remain tied to `TEST_DATABASE_URL`.
- Checked that no prohibited conditional remains in `cmd/migratedown` test functions.
- Sidecar review: no findings.

Closes #541
