### PR TITLE
Remove migrate generate test conditional

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1,12 +1,6 @@
 {
   "test_conditionals": [
     {
-      "path": "cmd/migrate/generate_test.go",
-      "function": "TestMigrateGenerateShadowVerificationWithRealDB",
-      "kind": "if",
-      "count": 3
-    },
-    {
       "path": "core/goschema/dependency_fix_test.go",
       "function": "TestDependencyOrderingWithEmbeddedFields",
       "kind": "if",

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -76,22 +76,11 @@ func TestMigratePlanCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 }
 
 func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
-	dbURL := migrateGenerateTestDatabaseURL()
-	if dbURL == "" {
-		t.Skip("PostgreSQL test database URL is not set")
-	}
-
 	c := qt.New(t)
 	ctx := context.Background()
 
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	if err != nil {
-		t.Skipf("test database is not available: %v", err)
-	}
+	dbURL, conn := requireMigrateGeneratePostgresTestConnection(t, ctx)
 	defer dbschema.CloseAndWarn(conn)
-	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
-		t.Skipf("shadow CLI acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
-	}
 	releaseLock := acquireMigrateGenerateTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
@@ -161,6 +150,29 @@ func migrateGenerateTestDatabaseURL() string {
 		}
 	}
 	return ""
+}
+
+func requireMigrateGeneratePostgresTestConnection(
+	t *testing.T,
+	ctx context.Context,
+) (string, *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	dbURL := migrateGenerateTestDatabaseURL()
+	if dbURL == "" {
+		t.Skip("PostgreSQL test database URL is not set")
+	}
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		t.Skipf("test database is not available: %v", err)
+	}
+	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
+		dbschema.CloseAndWarn(conn)
+		t.Skipf("shadow CLI acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
+	}
+
+	return dbURL, conn
 }
 
 func acquireMigrateGenerateTestLock(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) func() {


### PR DESCRIPTION
## Summary
- move PostgreSQL test database setup for migrate generate shadow verification into a helper
- keep the live DB test body declarative under the teststyle rule
- refresh the teststyle baseline from 187 to 186 conditional groups, with white-box files unchanged at 55
- remove the last command-level conditional entry from the teststyle conditional baseline

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/migrate
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./cmd/migrate
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./cmd/migrate
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... (sandbox hit known dbschema bind restriction)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... (outside sandbox)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./... (outside sandbox)
- git diff --check
- gopls diagnostics: No diagnostics

## Self-review
- pass 1: checked skip/connect/dialect behavior and cleanup parity; non-Postgres skip now closes the connection before skipping
- pass 2: checked baseline scope; all command-level conditional entries are gone from teststyle baseline
- side review: no findings