### PR TITLE
Convert cmdutil tests to black-box package

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1134,11 +1134,6 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/internal/cmdutil/cmdutil_test.go",
-      "package": "cmdutil",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "cmd/migrate/migrate_test.go",
       "package": "migrate",
       "reason": "same-package test file is not named *_internal_test.go"

--- a/cmd/internal/cmdutil/cmdutil_test.go
+++ b/cmd/internal/cmdutil/cmdutil_test.go
@@ -1,4 +1,4 @@
-package cmdutil
+package cmdutil_test
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
@@ -17,7 +18,7 @@ func TestWrapRunEMapsOrdinaryErrorsToExit2(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "boom"}
 	cmd.SetErr(&stderr)
-	run := WrapRunE(func(_ *cobra.Command, _ []string) error {
+	run := cmdutil.WrapRunE(func(_ *cobra.Command, _ []string) error {
 		return errors.New("boom")
 	})
 
@@ -34,7 +35,7 @@ func TestWrapRunEPreservesExplicitExitCodes(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd := &cobra.Command{Use: "diff"}
 	cmd.SetErr(&stderr)
-	run := WrapRunE(func(_ *cobra.Command, _ []string) error {
+	run := cmdutil.WrapRunE(func(_ *cobra.Command, _ []string) error {
 		return exitcode.New(1, errors.New("diff found"))
 	})
 


### PR DESCRIPTION
## Summary
- convert cmd/internal/cmdutil tests from same-package white-box to black-box cmdutil_test package
- keep coverage through exported cmdutil.WrapRunE
- refresh teststyle baseline from 55 to 54 white-box files, conditional groups unchanged at 186

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./cmd/internal/cmdutil
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache ./scripts/check-test-style.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./cmd/internal/cmdutil
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./cmd/internal/cmdutil
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-lint-cache golangci-lint run ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... (sandbox hit known dbschema bind restriction)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... (outside sandbox)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool govulncheck ./... (outside sandbox)
- git diff --check
- gopls diagnostics: No diagnostics

## Self-review
- pass 1: checked that this tests only exported cmdutil.WrapRunE and is a valid black-box conversion
- pass 2: checked Go internal import legality and baseline scope; exactly one white-box entry was removed
- side review: no findings