### PR TITLE
Make ptah-compat test black-box

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -1144,11 +1144,6 @@
       "reason": "same-package test file is not named *_internal_test.go"
     },
     {
-      "path": "cmd/ptah-compat/main_test.go",
-      "package": "main",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
       "path": "core/goschema/embedded_bug_reproduction_test.go",
       "package": "goschema",
       "reason": "same-package test file is not named *_internal_test.go"

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -1,4 +1,4 @@
-package main
+package main_test
 
 import (
 	"os"


### PR DESCRIPTION
## Summary
- convert cmd/ptah-compat/main_test.go to package main_test
- keep the binary-level atlas-name compatibility check unchanged
- reduce the teststyle white-box baseline from 52 to 51 files

## Validation
- go test ./cmd/ptah-compat
- ./scripts/check-test-style.sh
- go tool qtlint ./cmd/ptah-compat
- golangci-lint run ./cmd/ptah-compat
- go tool qtlint ./...
- golangci-lint run ./...
- go test ./... outside sandbox
- go tool govulncheck ./...
- git diff --check
- gopls workspace diagnostics

## Self-review
- No production code changed.
- The test already verifies behavior through a built binary, so package main_test is the correct default.
- Baseline changed only by removing the old cmd/ptah-compat/main_test.go white-box violation.