### PR TITLE
Wait for MySQL testkit containers via SQL

### DIFF
--- a/testkit/go.mod
+++ b/testkit/go.mod
@@ -3,6 +3,9 @@ module github.com/stokaro/ptah/testkit
 go 1.26.5
 
 require (
+	github.com/frankban/quicktest v1.14.6
+	github.com/go-sql-driver/mysql v1.10.0
+	github.com/moby/moby/api v1.55.0
 	github.com/stokaro/ptah v0.0.0
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.43.0
@@ -36,22 +39,23 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-isatty v0.0.23 // indirect
 	github.com/microsoft/go-mssqldb v1.10.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
@@ -66,6 +70,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/testkit/go.sum
+++ b/testkit/go.sum
@@ -40,6 +40,7 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -81,6 +82,7 @@ github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0kt
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
 github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20260709232956-b9395ee17fa0 h1:du0WGc8xSKq/++e0cglxhS/mXVqsR7+c7jLEi5Vqduw=
@@ -147,6 +149,7 @@ github.com/pierrec/lz4/v4 v4.1.27 h1:+PhzhWDrjRj89TH2sw43nE3+4+W8lSxIuQadEHZyjUk
 github.com/pierrec/lz4/v4 v4.1.27/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -154,6 +157,7 @@ github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/testkit/mysql_readiness_internal_test.go
+++ b/testkit/mysql_readiness_internal_test.go
@@ -1,0 +1,20 @@
+package testkit
+
+// White-box testing required: mysqlReadinessDSN is an unexported readiness
+// helper whose output is consumed by testcontainers before Ptah can observe the
+// database through exported testkit APIs.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/moby/moby/api/types/network"
+)
+
+func Test_mysqlReadinessDSN(t *testing.T) {
+	c := qt.New(t)
+
+	got := mysqlReadinessDSN("root", "secret", "ptah_test")("127.0.0.1", network.MustParsePort("3306/tcp"))
+
+	c.Assert(got, qt.Equals, "root:secret@tcp(127.0.0.1:3306)/ptah_test?multiStatements=true&parseTime=true")
+}

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io/fs"
+	"net"
 	"net/url"
 	"path/filepath"
 	"slices"
@@ -14,6 +15,8 @@ import (
 	"time"
 	"unicode"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/moby/moby/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
 	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -279,7 +282,10 @@ func startMySQLLike(t testing.TB, dialect, defaultImage string, opts ...Option) 
 		tcmysql.WithUsername(cfg.username),
 		tcmysql.WithPassword(cfg.password),
 		tcmysql.WithDatabase(baseDB),
-		testcontainers.WithWaitStrategy(wait.ForListeningPort("3306/tcp")),
+		testcontainers.WithWaitStrategy(
+			wait.ForSQL("3306/tcp", "mysql", mysqlReadinessDSN(cfg.username, cfg.password, baseDB)).
+				WithStartupTimeout(cfg.startupTimeout),
+		),
 		reuseOption(cfg.reuseName),
 	)
 	requireNoError(t, err, "start "+dialect+" container")
@@ -349,6 +355,20 @@ func postgresDatabaseURL(dbURL, database string) string {
 
 func mysqlURL(dialect, dsn string) string {
 	return dialect + "://" + dsn
+}
+
+func mysqlReadinessDSN(username, password, database string) func(host string, port network.Port) string {
+	return func(host string, port network.Port) string {
+		cfg := mysqldriver.NewConfig()
+		cfg.User = username
+		cfg.Passwd = password
+		cfg.Net = "tcp"
+		cfg.Addr = net.JoinHostPort(host, port.Port())
+		cfg.DBName = database
+		cfg.ParseTime = true
+		cfg.MultiStatements = true
+		return cfg.FormatDSN()
+	}
 }
 
 func mysqlDSNDatabase(dsn, database string) string {


### PR DESCRIPTION
## Summary

- fix the master `testkit / containers` failure from run `29992996550`, job `89159869826`
- replace MySQL/MariaDB port-open readiness with `testcontainers` SQL readiness
- build the readiness DSN with `go-sql-driver/mysql.Config.FormatDSN` and cover it with a focused white-box unit test

## Root Cause

The failed master job reached the MariaDB container port before MariaDB accepted a stable SQL ping. The next Ptah connection then hit `packets.go:58 unexpected EOF` and failed with `failed to ping database: invalid connection`.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -count=1 ./...` in `testkit`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache CI=1 go test -count=1 -tags=testkitcontainers ./...` in `testkit` with OrbStack/Docker
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go vet ./...` in `testkit`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...` from repo root, outside sandbox for local TCP bind tests
- `GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `git diff --check`
