### PR TITLE
Fix generated column round trips

### DIFF
--- a/core/renderer/internal/dialects/mysql/alter_ops_test.go
+++ b/core/renderer/internal/dialects/mysql/alter_ops_test.go
@@ -101,11 +101,29 @@ func TestMySQL_CreateTableGeneratedColumn(t *testing.T) {
 		AddColumn(ast.NewColumn("id", "int").SetPrimary()).
 		AddColumn(ast.NewColumn("slug", "varchar(255)").
 			SetNotNull().
-			SetGenerated("lower(name)", "STORED"))
+			SetGenerated("lower(name)", "stored"))
 
 	out := renderMySQL(t, table)
 
-	c.Assert(out, qt.Contains, "`slug` varchar(255) NOT NULL AS (lower(name)) STORED")
+	c.Assert(out, qt.Contains, "`slug` varchar(255) GENERATED ALWAYS AS (lower(name)) STORED NOT NULL")
+}
+
+func TestMySQL_AlterTableAddGeneratedColumn(t *testing.T) {
+	c := qt.New(t)
+	alter := &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.AddColumnOperation{
+				Column: ast.NewColumn("slug", "varchar(255)").
+					SetNotNull().
+					SetGenerated("lower(name)", "stored"),
+			},
+		},
+	}
+
+	out := renderMySQL(t, alter)
+
+	c.Assert(out, qt.Contains, "ALTER TABLE `users` ADD COLUMN `slug` varchar(255) GENERATED ALWAYS AS (lower(name)) STORED NOT NULL;")
 }
 
 func TestMySQL_ColumnDefaultLiteralQuoting(t *testing.T) {

--- a/core/renderer/internal/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/internal/dialects/mysqllike/mysqllike.go
@@ -658,7 +658,24 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 	parts = append(parts, fmt.Sprintf("  %s %s", escapeIdentifier(column.Name), columnType))
 	parts = r.appendColumnCharsetCollate(parts, column)
 
-	// Column constraints
+	parts = r.appendColumnMainClauses(parts, column)
+	return r.renderColumnTail(parts, column), nil
+}
+
+func (r *Renderer) appendColumnMainClauses(parts []string, column *ast.ColumnNode) []string {
+	if column.GeneratedExpression != "" {
+		parts = append(parts, renderGeneratedColumn(column))
+		return appendMySQLColumnConstraints(parts, column)
+	}
+
+	parts = appendMySQLColumnConstraints(parts, column)
+	if column.AutoInc {
+		parts = append(parts, r.renderAutoIncrement())
+	}
+	return parts
+}
+
+func appendMySQLColumnConstraints(parts []string, column *ast.ColumnNode) []string {
 	if column.Primary {
 		parts = append(parts, "PRIMARY KEY")
 	} else {
@@ -669,15 +686,14 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 			parts = append(parts, "UNIQUE")
 		}
 	}
+	return parts
+}
 
-	// Auto increment (dialect-specific)
-	if column.AutoInc {
-		parts = append(parts, r.renderAutoIncrement())
-	}
-	if column.GeneratedExpression != "" {
-		parts = append(parts, renderGeneratedColumn(column))
-	}
+func (r *Renderer) renderColumnTail(parts []string, column *ast.ColumnNode) string {
+	return strings.Join(r.appendColumnTail(parts, column), " ")
+}
 
+func (r *Renderer) appendColumnTail(parts []string, column *ast.ColumnNode) []string {
 	// Default value
 	switch {
 	case column.Default == nil:
@@ -706,7 +722,7 @@ func (r *Renderer) renderColumn(column *ast.ColumnNode) (string, error) {
 		parts = append(parts, fmt.Sprintf("CHECK (json_valid(%s))", escapeIdentifier(column.Name)))
 	}
 
-	return strings.Join(parts, " "), nil
+	return parts
 }
 
 func (r *Renderer) rendersNamedColumnCheckAsTableConstraint(column *ast.ColumnNode) bool {
@@ -749,9 +765,9 @@ func (r *Renderer) needsMariaDBJSONCheck(column *ast.ColumnNode) bool {
 }
 
 func renderGeneratedColumn(column *ast.ColumnNode) string {
-	sql := fmt.Sprintf("AS (%s)", column.GeneratedExpression)
+	sql := fmt.Sprintf("GENERATED ALWAYS AS (%s)", column.GeneratedExpression)
 	if column.GeneratedKind != "" {
-		sql += " " + column.GeneratedKind
+		sql += " " + strings.ToUpper(strings.TrimSpace(column.GeneratedKind))
 	}
 	return sql
 }
@@ -872,46 +888,8 @@ func (r *Renderer) renderColumnWithEnums(column *ast.ColumnNode, enumValues []st
 	parts = append(parts, fmt.Sprintf("  %s %s", escapeIdentifier(column.Name), columnType))
 	parts = r.appendColumnCharsetCollate(parts, column)
 
-	// Column constraints - MariaDB order: PRIMARY KEY, then NOT NULL, then UNIQUE
-	if column.Primary {
-		parts = append(parts, "PRIMARY KEY")
-		if column.AutoInc {
-			parts = append(parts, r.renderAutoIncrement())
-		}
-	} else {
-		if !column.Nullable {
-			parts = append(parts, "NOT NULL")
-		}
-		if column.Unique {
-			parts = append(parts, "UNIQUE")
-		}
-		if column.AutoInc {
-			parts = append(parts, r.renderAutoIncrement())
-		}
-	}
-
-	// Default values
-	if column.Default != nil {
-		if column.Default.Expression != "" {
-			parts = append(parts, fmt.Sprintf("DEFAULT %s", column.Default.Expression))
-		} else if column.Default.HasLiteral() {
-			parts = append(parts, fmt.Sprintf("DEFAULT %s", r.renderDefaultLiteral(column)))
-		}
-	}
-	if column.UpdateExpression != "" {
-		parts = append(parts, "ON UPDATE", column.UpdateExpression)
-	}
-	if column.GeneratedExpression != "" {
-		parts = append(parts, renderGeneratedColumn(column))
-	}
-
-	// Check constraints
-	if column.Check != "" {
-		parts = append(parts, fmt.Sprintf("CHECK (%s)", column.Check))
-	}
-	if r.needsMariaDBJSONCheck(column) {
-		parts = append(parts, fmt.Sprintf("CHECK (json_valid(%s))", escapeIdentifier(column.Name)))
-	}
+	parts = r.appendColumnMainClauses(parts, column)
+	parts = r.appendColumnTail(parts, column)
 
 	// Comments
 	if column.Comment != "" {

--- a/integration/gonative/generated_column_conformance_integration_test.go
+++ b/integration/gonative/generated_column_conformance_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
+	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
+	postgresreader "github.com/stokaro/ptah/internal/dbschema/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestGeneratedColumnConformanceFixture_RoundTrip_Postgres(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec(`DROP TABLE IF EXISTS contacts`)
+	defer func() { _, _ = db.Exec(`DROP TABLE IF EXISTS contacts`) }()
+
+	target := generatedColumnConformanceSchema()
+	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.Postgres)
+	_, err = db.Exec(createSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema must apply: %s", createSQL))
+
+	reader := postgresreader.NewPostgreSQLReader(db, "public")
+	liveSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.Postgres)
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func TestGeneratedColumnConformanceFixture_RoundTrip_MySQL(t *testing.T) {
+	dsn := skipIfNoMySQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec("DROP TABLE IF EXISTS contacts")
+	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS contacts") }()
+
+	target := generatedColumnConformanceSchema()
+	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.MySQL)
+	_, err = db.Exec(createSQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema must apply: %s", createSQL))
+
+	reader := mysqlreader.NewMySQLReader(db, "")
+	liveSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func generatedColumnConformanceSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Contact", Name: "contacts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Contact", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Contact", Name: "email", Type: "VARCHAR(255)", Nullable: false},
+			{
+				StructName:          "Contact",
+				Name:                "email_normalized",
+				Type:                "VARCHAR(255)",
+				GeneratedExpression: "lower(email)",
+				GeneratedKind:       "stored",
+			},
+		},
+		Indexes: []goschema.Index{
+			{StructName: "Contact", Name: "idx_contacts_email_normalized", Fields: []string{"email_normalized"}},
+		},
+	}
+}
+
+func renderGeneratedColumnConformanceSQL(c *qt.C, target *goschema.Database, dialect string) string {
+	createAST := fromschema.FromDatabase(*target, dialect)
+	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
+	c.Assert(err, qt.IsNil)
+	return strings.TrimSpace(createSQL)
+}

--- a/integration/gonative/generated_column_conformance_integration_test.go
+++ b/integration/gonative/generated_column_conformance_integration_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/convert/fromschema"
 	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
 	postgresreader "github.com/stokaro/ptah/internal/dbschema/postgres"
+	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
@@ -33,12 +35,12 @@ func TestGeneratedColumnConformanceFixture_RoundTrip_Postgres(t *testing.T) {
 
 	target := generatedColumnConformanceSchema()
 	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.Postgres)
-	_, err = db.Exec(createSQL)
-	c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema must apply: %s", createSQL))
+	execGeneratedColumnConformanceSQL(c, db, createSQL)
 
 	reader := postgresreader.NewPostgreSQLReader(db, "public")
 	liveSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
+	liveSchema = filterGeneratedColumnConformanceSchema(liveSchema)
 
 	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.Postgres)
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
@@ -57,12 +59,12 @@ func TestGeneratedColumnConformanceFixture_RoundTrip_MySQL(t *testing.T) {
 
 	target := generatedColumnConformanceSchema()
 	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.MySQL)
-	_, err = db.Exec(createSQL)
-	c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema must apply: %s", createSQL))
+	execGeneratedColumnConformanceSQL(c, db, createSQL)
 
 	reader := mysqlreader.NewMySQLReader(db, "")
 	liveSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
+	liveSchema = filterGeneratedColumnConformanceSchema(liveSchema)
 
 	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
@@ -95,4 +97,22 @@ func renderGeneratedColumnConformanceSQL(c *qt.C, target *goschema.Database, dia
 	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
 	c.Assert(err, qt.IsNil)
 	return strings.TrimSpace(createSQL)
+}
+
+func execGeneratedColumnConformanceSQL(c *qt.C, db *sql.DB, sqlText string) {
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		_, err := db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema statement must apply: %s", stmt))
+	}
+}
+
+func filterGeneratedColumnConformanceSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	keepTables := map[string]struct{}{
+		"contacts": {},
+	}
+	out := *in
+	out.Tables = filterTables(in.Tables, keepTables)
+	out.Indexes = filterIndexes(in.Indexes, keepTables)
+	out.Constraints = filterConstraints(in.Constraints, keepTables)
+	return &out
 }

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -362,10 +362,19 @@ func generatedColumnDiff(genCol goschema.Field, dbCol types.DBColumn, dialect st
 
 func normalizeGeneratedExpression(expression, dialect string) string {
 	expression = normalize.Expression(expression)
-	if platform.NormalizeDialect(dialect) != platform.SQLServer {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres:
+		return normalizeCatalogGeneratedExpression(stripPostgresGeneratedTypeCasts(expression))
+	case platform.MySQL, platform.MariaDB:
+		return normalizeCatalogGeneratedExpression(expression)
+	case platform.SQLServer:
+		return normalizeSQLServerGeneratedExpression(expression)
+	default:
 		return expression
 	}
+}
 
+func normalizeSQLServerGeneratedExpression(expression string) string {
 	var b strings.Builder
 	inString := false
 	for i := 0; i < len(expression); i++ {
@@ -393,6 +402,153 @@ func normalizeGeneratedExpression(expression, dialect string) string {
 		b.WriteByte(ch)
 	}
 	return b.String()
+}
+
+func normalizeCatalogGeneratedExpression(expression string) string {
+	var b strings.Builder
+	inString := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if ch == '\'' {
+			b.WriteByte(ch)
+			if inString && i+1 < len(expression) && expression[i+1] == '\'' {
+				i++
+				b.WriteByte('\'')
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			b.WriteByte(ch)
+			continue
+		}
+		switch ch {
+		case '`', '"', ' ', '\t', '\n', '\r':
+			continue
+		default:
+			if ch >= 'A' && ch <= 'Z' {
+				ch += 'a' - 'A'
+			}
+			b.WriteByte(ch)
+		}
+	}
+	return collapseParenthesizedIdentifiers(b.String())
+}
+
+func stripPostgresGeneratedTypeCasts(expression string) string {
+	var b strings.Builder
+	inString := false
+	inIdentifier := false
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if ch == '\'' && !inIdentifier {
+			b.WriteByte(ch)
+			if inString && i+1 < len(expression) && expression[i+1] == '\'' {
+				i++
+				b.WriteByte('\'')
+				continue
+			}
+			inString = !inString
+			continue
+		}
+		if ch == '"' && !inString {
+			b.WriteByte(ch)
+			if inIdentifier && i+1 < len(expression) && expression[i+1] == '"' {
+				i++
+				b.WriteByte('"')
+				continue
+			}
+			inIdentifier = !inIdentifier
+			continue
+		}
+		if !inString && !inIdentifier && i+1 < len(expression) && ch == ':' && expression[i+1] == ':' {
+			i = skipPostgresGeneratedTypeCast(expression, i)
+			i--
+			continue
+		}
+		b.WriteByte(ch)
+	}
+	return b.String()
+}
+
+func skipPostgresGeneratedTypeCast(expression string, start int) int {
+	i := start + 2
+	for i < len(expression) && isPostgresTypeCastCharacter(expression[i]) {
+		i++
+	}
+	if i >= len(expression) || expression[i] != '(' {
+		return i
+	}
+	depth := 0
+	for i < len(expression) {
+		switch expression[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+		i++
+	}
+	return i
+}
+
+func isPostgresTypeCastCharacter(ch byte) bool {
+	return ch == ' ' || ch == '.' || ch == '_' ||
+		(ch >= '0' && ch <= '9') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= 'a' && ch <= 'z')
+}
+
+func collapseParenthesizedIdentifiers(expression string) string {
+	for {
+		next, changed := collapseOneParenthesizedIdentifier(expression)
+		if !changed {
+			return expression
+		}
+		expression = next
+	}
+}
+
+func collapseOneParenthesizedIdentifier(expression string) (string, bool) {
+	for start := 0; start < len(expression); start++ {
+		if expression[start] != '(' {
+			continue
+		}
+		if start > 0 && isIdentifierExpression(expression[start-1:start]) {
+			continue
+		}
+		end := strings.IndexByte(expression[start+1:], ')')
+		if end < 0 {
+			return expression, false
+		}
+		end += start + 1
+		inner := expression[start+1 : end]
+		if !isIdentifierExpression(inner) {
+			continue
+		}
+		return expression[:start] + inner + expression[end+1:], true
+	}
+	return expression, false
+}
+
+func isIdentifierExpression(expression string) bool {
+	if expression == "" {
+		return false
+	}
+	for i := 0; i < len(expression); i++ {
+		ch := expression[i]
+		if ch != '_' && ch != '.' &&
+			(ch < '0' || ch > '9') &&
+			(ch < 'a' || ch > 'z') &&
+			(ch < 'A' || ch > 'Z') {
+			return false
+		}
+	}
+	return true
 }
 
 func writeSQLServerBracketedIdentifier(b *strings.Builder, expression string, start int) int {

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -125,6 +125,126 @@ func TestCompareWithDialect_GeneratedColumnDefaultKindMatchesDialect(t *testing.
 	}
 }
 
+func TestCompareWithDialect_GeneratedColumnCatalogExpressionsMatch(t *testing.T) {
+	tests := []struct {
+		name               string
+		dialect            string
+		generatedType      string
+		generatedExpr      string
+		generatedKind      string
+		databaseType       string
+		databaseColumnType string
+		databaseExpr       string
+		databaseKind       string
+	}{
+		{
+			name:               "postgres lower varchar cast",
+			dialect:            "postgres",
+			generatedType:      "VARCHAR(255)",
+			generatedExpr:      "lower(email)",
+			generatedKind:      "stored",
+			databaseType:       "varchar",
+			databaseColumnType: "varchar(255)",
+			databaseExpr:       "lower((email)::text)",
+			databaseKind:       "STORED",
+		},
+		{
+			name:               "mysql backtick identifier",
+			dialect:            "mysql",
+			generatedType:      "VARCHAR(255)",
+			generatedExpr:      "lower(email)",
+			generatedKind:      "stored",
+			databaseType:       "varchar",
+			databaseColumnType: "varchar(255)",
+			databaseExpr:       "lower(`email`)",
+			databaseKind:       "STORED",
+		},
+		{
+			name:               "postgres numeric cast parameters",
+			dialect:            "postgres",
+			generatedType:      "DECIMAL(10,2)",
+			generatedExpr:      "round(amount)",
+			generatedKind:      "stored",
+			databaseType:       "decimal",
+			databaseColumnType: "decimal(10,2)",
+			databaseExpr:       "round((amount)::numeric(10,2))",
+			databaseKind:       "STORED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				Tables: []goschema.Table{{Name: "contacts", StructName: "Contact"}},
+				Fields: []goschema.Field{
+					{
+						StructName:          "Contact",
+						Name:                "email_normalized",
+						Type:                tt.generatedType,
+						Nullable:            true,
+						GeneratedExpression: tt.generatedExpr,
+						GeneratedKind:       tt.generatedKind,
+					},
+				},
+			}
+			database := &types.DBSchema{
+				Tables: []types.DBTable{{
+					Name: "contacts",
+					Type: "TABLE",
+					Columns: []types.DBColumn{{
+						Name:                "email_normalized",
+						DataType:            tt.databaseType,
+						ColumnType:          tt.databaseColumnType,
+						IsNullable:          "YES",
+						GeneratedExpression: &tt.databaseExpr,
+						GeneratedKind:       tt.databaseKind,
+					}},
+				}},
+			}
+
+			diff := schemadiff.CompareWithDialect(generated, database, tt.dialect)
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestCompareWithDialect_GeneratedColumnStringLiteralMismatchIsAGap(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "contacts", StructName: "Contact"}},
+		Fields: []goschema.Field{
+			{
+				StructName:          "Contact",
+				Name:                "email_normalized",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: "concat(email, 'ACTIVE')",
+				GeneratedKind:       "stored",
+			},
+		},
+	}
+	databaseExpression := "concat(`email`, 'active')"
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "contacts",
+			Type: "TABLE",
+			Columns: []types.DBColumn{{
+				Name:                "email_normalized",
+				DataType:            "text",
+				IsNullable:          "YES",
+				GeneratedExpression: &databaseExpression,
+				GeneratedKind:       "STORED",
+			}},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mysql")
+	c.Assert(diff.TablesModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["generated"], qt.Contains, "'ACTIVE'")
+}
+
 func TestCompareWithDialect_SQLServerGeneratedExpressionNormalizesCatalogDefinition(t *testing.T) {
 	for _, tt := range []struct {
 		name                string


### PR DESCRIPTION
Closes #610.

## Summary

- fixes MySQL/MariaDB generated-column rendering order so generated columns render as `GENERATED ALWAYS AS (...) STORED|VIRTUAL NOT NULL` instead of invalid `NOT NULL AS (...) stored`
- normalizes generated-column catalog readback for Postgres/MySQL/MariaDB during schemadiff:
  - Postgres `lower((email)::text)` now matches `lower(email)`
  - Postgres cast parameters such as `::numeric(10,2)` are stripped as catalog noise
  - MySQL backtick-quoted readback such as ``lower(`email`)`` now matches `lower(email)`
  - string literal contents remain case-sensitive
- adds live Postgres/MySQL integration coverage for the conformance `07-generated-column` fixture shape

## Self-Review

Pass 1:
- Reproduced the original failure on real Postgres/MySQL containers.
- Verified the bug had two causes: Postgres expression readback drift and invalid MySQL generated-column DDL.
- Kept the fix scoped to generated-column rendering and generated-expression comparison.

Pass 2:
- Checked for over-normalization: added a string-literal mismatch test so `'ACTIVE'` and `'active'` remain different.
- Checked duplicated renderer paths: refactored MySQL-like create/alter column rendering to share the generated-column clause order.
- Checked dependency/testing policy: no direct `testify`; new tests use `quicktest`.
- Checked documentation impact: generated-column docs already describe the feature; this PR fixes validity/round-trip behavior without changing the documented API.

## Validation

- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./core/renderer/internal/dialects/mysql ./core/renderer/internal/dialects/mariadb ./migration/schemadiff ./migration/schemadiff/internal/compare -count=1`
- `POSTGRES_TEST_DSN=... MYSQL_TEST_DSN=... GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -tags=integration ./integration/gonative -run 'TestGeneratedColumnConformanceFixture_RoundTrip_(Postgres|MySQL)' -count=1 -v`
- `scripts/check-test-style.sh`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...`
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...` (outside sandbox because `dbschema` tests open local TCP listeners)
- `GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...`
- `git diff --check`

## Downstream Conformance Check

With a temporary `go.work` pointing `ptah-atlas-conformance` at this local Ptah worktree:

- `go run ./cmd/gap-probe-live -gate` now reports 2 live gaps instead of 4
- `postgres/07-generated-column` is gone
- `mysql/07-generated-column` is gone
- remaining gaps are `mysql/06-constraints-actions` and `mysql/09-defaults-types`
