### PR TITLE
Prohibit testify usage in project tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ should refresh the baseline with:
 GOWORK=off go run ./internal/tools/teststyle -write-baseline
 ```
 
+Never use `testify` in Ptah code, tests, examples, or documentation snippets.
+Use `quicktest` imported as `qt`, the Go standard library `testing` package, or
+existing project-specific test helpers instead. Existing transitive dependency
+metadata from third-party packages is not permission to add direct
+`github.com/stretchr/testify` imports or `assert`/`require` examples.
+
 Bad:
 
 ```go

--- a/migration/schemadiff/internal/compare/column_search.go
+++ b/migration/schemadiff/internal/compare/column_search.go
@@ -50,8 +50,8 @@ import (
 //	```go
 //	result := compare.TableColumns(genTable, dbTable, generated)
 //	nameDiff := compare.ColumnByName(result.ColumnsModified, "name")
-//	assert.NotNil(t, nameDiff)
-//	assert.Equal(t, "varchar -> text", nameDiff.Changes["type"])
+//	c.Assert(nameDiff, qt.IsNotNil)
+//	c.Assert(nameDiff.Changes["type"], qt.Equals, "varchar -> text")
 //	```
 //
 // **Conditional migration logic**:

--- a/scripts/check-test-style.sh
+++ b/scripts/check-test-style.sh
@@ -4,6 +4,11 @@ set -eu
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+if rg -n 'github\.com/stretchr/testify|\b(assert|require)\.' --glob '*.go' .; then
+	echo "teststyle: testify/assert/require usage is prohibited; use quicktest as qt instead" >&2
+	exit 1
+fi
+
 go_cache="${GOCACHE:-$(go env GOCACHE)}"
 if ! mkdir -p "$go_cache" 2>/dev/null || [ ! -w "$go_cache" ]; then
 	GOCACHE="${TMPDIR:-/tmp}/ptah-go-cache"


### PR DESCRIPTION
## Summary
- document that Ptah code, tests, examples, and docs snippets must not use testify
- enforce the rule in scripts/check-test-style.sh for Go files
- replace the existing assert.* documentation snippet with quicktest-style assertions

## Notes
- testkit/go.mod still contains a transitive github.com/stretchr/testify entry from third-party dependencies such as testcontainers-go; this PR blocks direct usage in Ptah-owned Go code and snippets without pretending that transitive module metadata is gone.

## Validation
- scripts/check-test-style.sh
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./migration/schemadiff/internal/compare
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./... (from testkit/)
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- rg -n 'github\.com/stretchr/testify|\b(assert|require)\.' --glob '*.go' .