### PR TITLE
Fix MySQL defaults/types round-trip drift

### DIFF
--- a/integration/gonative/defaults_types_conformance_integration_test.go
+++ b/integration/gonative/defaults_types_conformance_integration_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
+	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
+	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestDefaultsTypesConformanceFixture_RoundTrip_MySQL(t *testing.T) {
+	dsn := skipIfNoMySQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec("DROP TABLE IF EXISTS invoices")
+	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS invoices") }()
+
+	target := defaultsTypesConformanceSchema()
+	createSQL := renderDefaultsTypesConformanceSQL(c, target, platform.MySQL)
+	execDefaultsTypesConformanceSQL(c, db, createSQL)
+
+	reader := mysqlreader.NewMySQLReader(db, "")
+	liveSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	liveSchema = filterDefaultsTypesConformanceSchema(liveSchema)
+
+	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func defaultsTypesConformanceSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Invoice", Name: "invoices"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Invoice", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName: "Invoice",
+				Name:       "invoice_number",
+				Type:       "VARCHAR(32)",
+				Nullable:   false,
+				Unique:     true,
+			},
+			{
+				StructName: "Invoice",
+				Name:       "subtotal",
+				Type:       "DECIMAL(12,2)",
+				Nullable:   false,
+				Default:    "0.00",
+				DefaultSet: true,
+			},
+			{
+				StructName:  "Invoice",
+				Name:        "tax_rate",
+				Type:        "DECIMAL(5,4)",
+				Nullable:    false,
+				DefaultExpr: "0",
+			},
+			{
+				StructName:  "Invoice",
+				Name:        "issued_at",
+				Type:        "TIMESTAMP",
+				Nullable:    false,
+				DefaultExpr: "CURRENT_TIMESTAMP",
+			},
+			{
+				StructName: "Invoice",
+				Name:       "paid",
+				Type:       "BOOLEAN",
+				Nullable:   false,
+				Default:    "false",
+				DefaultSet: true,
+			},
+		},
+	}
+}
+
+func renderDefaultsTypesConformanceSQL(c *qt.C, target *goschema.Database, dialect string) string {
+	createAST := fromschema.FromDatabase(*target, dialect)
+	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
+	c.Assert(err, qt.IsNil)
+	return strings.TrimSpace(createSQL)
+}
+
+func execDefaultsTypesConformanceSQL(c *qt.C, db *sql.DB, sqlText string) {
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		_, err := db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("defaults/types schema statement must apply: %s", stmt))
+	}
+}
+
+func filterDefaultsTypesConformanceSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
+	keepTables := map[string]struct{}{
+		"invoices": {},
+	}
+	out := *in
+	out.Tables = filterTables(in.Tables, keepTables)
+	out.Indexes = filterIndexes(in.Indexes, keepTables)
+	out.Constraints = filterConstraints(in.Constraints, keepTables)
+	return &out
+}

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -313,7 +313,7 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 			idxName = "default_expr"
 		}
 
-		normalizeGenDefaultFn := normalize.DefaultValue(genDefault, "")
+		normalizeGenDefaultFn := normalize.DefaultValue(genDefault, genType)
 
 		if normalizeGenDefaultFn != normalizedDbDefault {
 			colDiff.Changes[idxName] = fmt.Sprintf("%s -> %s", dbDefault, genDefault)

--- a/migration/schemadiff/internal/normalize/normalize.go
+++ b/migration/schemadiff/internal/normalize/normalize.go
@@ -128,8 +128,8 @@ func DefaultValue(defaultValue, typeName string) string {
 		return ""
 	}
 
-	if strings.ToUpper(defaultValue) == "CURRENT_TIMESTAMP()" {
-		return "CURRENT_TIMESTAMP"
+	if normalizedExpression := normalizeTemporalDefaultExpression(defaultValue, typeName); normalizedExpression != "" {
+		return normalizedExpression
 	}
 
 	cleanValue := defaultValue
@@ -161,9 +161,77 @@ func DefaultValue(defaultValue, typeName string) string {
 		// If it's not a recognized boolean value, return as-is
 		return cleanValue
 	}
+	if typeName == "decimal" {
+		return normalizeDecimalDefaultValue(cleanValue)
+	}
 
 	// Return cleaned value for all other types
 	return cleanValue
+}
+
+func normalizeTemporalDefaultExpression(defaultValue, typeName string) string {
+	normalizedType := strings.ToLower(strings.TrimSpace(typeName))
+	if normalizedType != "" && normalizedType != "timestamp" {
+		return ""
+	}
+	normalizedValue := strings.ToUpper(strings.TrimSpace(defaultValue))
+	normalizedValue = strings.TrimSuffix(normalizedValue, "()")
+	switch normalizedValue {
+	case "CURRENT_TIMESTAMP", "NOW", "LOCALTIME", "LOCALTIMESTAMP":
+		return normalizedValue
+	default:
+		return ""
+	}
+}
+
+func normalizeDecimalDefaultValue(value string) string {
+	value = strings.TrimSpace(value)
+	sign := ""
+	if after, ok := strings.CutPrefix(value, "-"); ok {
+		sign = "-"
+		value = after
+	} else if after, ok := strings.CutPrefix(value, "+"); ok {
+		value = after
+	}
+	if value == "" || strings.Count(value, ".") > 1 {
+		return sign + value
+	}
+	parts := strings.Split(value, ".")
+	for _, part := range parts {
+		if !isDecimalDigits(part) {
+			return sign + value
+		}
+	}
+	intPart := strings.TrimLeft(parts[0], "0")
+	if intPart == "" {
+		intPart = "0"
+	}
+	if len(parts) == 1 {
+		if intPart == "0" {
+			return intPart
+		}
+		return sign + intPart
+	}
+	fracPart := strings.TrimRight(parts[1], "0")
+	if fracPart == "" {
+		if intPart == "0" {
+			return intPart
+		}
+		return sign + intPart
+	}
+	return sign + intPart + "." + fracPart
+}
+
+func isDecimalDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func IsDefaultExpr(value string) bool {

--- a/migration/schemadiff/internal/normalize/normalize_test.go
+++ b/migration/schemadiff/internal/normalize/normalize_test.go
@@ -125,6 +125,13 @@ func TestDefaultValue(t *testing.T) {
 		{"double quoted null", "\"NULL\"", "varchar", "NULL"},
 		{"nested quotes", "\"'value'\"", "varchar", "value"},
 		{"special characters", "'special@#$%'", "varchar", "special@#$%"},
+		{"decimal scale-only zeros", "0.0000", "decimal", "0"},
+		{"decimal trailing zeros", "123.4500", "decimal", "123.45"},
+		{"decimal leading zeros", "00123.4500", "decimal", "123.45"},
+		{"negative decimal trailing zeros", "-00123.4500", "decimal", "-123.45"},
+		{"timestamp current timestamp lowercase", "current_timestamp()", "timestamp", "CURRENT_TIMESTAMP"},
+		{"timestamp current timestamp uppercase", "CURRENT_TIMESTAMP", "timestamp", "CURRENT_TIMESTAMP"},
+		{"timestamp current timestamp without type", "CURRENT_TIMESTAMP()", "", "CURRENT_TIMESTAMP"},
 
 		// Edge cases for boolean normalization
 		{"unrecognized boolean value", "maybe", "boolean", "maybe"},

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -299,6 +299,106 @@ func TestCompareWithDialect_SQLServerGeneratedExpressionNormalizesCatalogDefinit
 	}
 }
 
+func TestCompareWithDialect_MySQLDefaultsTypesFixtureMatchesCatalogReadback(t *testing.T) {
+	c := qt.New(t)
+	subtotalDefault := "0.00"
+	taxRateDefault := "0.0000"
+	issuedAtDefault := "current_timestamp()"
+	paidDefault := "0"
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "invoices", StructName: "Invoice"}},
+		Fields: []goschema.Field{
+			{StructName: "Invoice", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Invoice", Name: "invoice_number", Type: "VARCHAR(32)", Nullable: false, Unique: true},
+			{
+				StructName: "Invoice",
+				Name:       "subtotal",
+				Type:       "DECIMAL(12,2)",
+				Nullable:   false,
+				Default:    "0.00",
+				DefaultSet: true,
+			},
+			{
+				StructName:  "Invoice",
+				Name:        "tax_rate",
+				Type:        "DECIMAL(5,4)",
+				Nullable:    false,
+				DefaultExpr: "0",
+			},
+			{
+				StructName:  "Invoice",
+				Name:        "issued_at",
+				Type:        "TIMESTAMP",
+				Nullable:    false,
+				DefaultExpr: "CURRENT_TIMESTAMP",
+			},
+			{
+				StructName: "Invoice",
+				Name:       "paid",
+				Type:       "BOOLEAN",
+				Nullable:   false,
+				Default:    "false",
+				DefaultSet: true,
+			},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "invoices",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{
+					Name:            "id",
+					DataType:        "int",
+					ColumnType:      "int",
+					IsNullable:      "NO",
+					IsPrimaryKey:    true,
+					IsAutoIncrement: true,
+				},
+				{
+					Name:       "invoice_number",
+					DataType:   "varchar(32)",
+					ColumnType: "varchar(32)",
+					IsNullable: "NO",
+					IsUnique:   true,
+				},
+				{
+					Name:          "subtotal",
+					DataType:      "decimal(12,2)",
+					ColumnType:    "decimal(12,2)",
+					IsNullable:    "NO",
+					ColumnDefault: &subtotalDefault,
+				},
+				{
+					Name:          "tax_rate",
+					DataType:      "decimal(5,4)",
+					ColumnType:    "decimal(5,4)",
+					IsNullable:    "NO",
+					ColumnDefault: &taxRateDefault,
+				},
+				{
+					Name:          "issued_at",
+					DataType:      "timestamp",
+					ColumnType:    "timestamp",
+					IsNullable:    "NO",
+					ColumnDefault: &issuedAtDefault,
+				},
+				{
+					Name:          "paid",
+					DataType:      "tinyint(1)",
+					ColumnType:    "tinyint(1)",
+					IsNullable:    "NO",
+					ColumnDefault: &paidDefault,
+				},
+			},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mysql")
+	c.Assert(diff.TablesModified, qt.HasLen, 0)
+}
+
 func TestCompareWithDialect_SQLiteInlineEnumsMatchGeneratedEnumFields(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- normalize decimal defaults numerically so MySQL catalog scale padding such as 0.0000 matches generated default 0
- compare generated defaults with the generated column type, preserving boolean/decimal default equivalence
- add a MySQL live regression test for the conformance 09-defaults-types fixture

Fixes #612.

## Validation
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./migration/schemadiff ./migration/schemadiff/internal/normalize ./migration/schemadiff/internal/compare -count=1
- MYSQL_TEST_DSN=root:pw@tcp(localhost:53306)/ptah612 GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -tags=integration ./integration/gonative -run TestDefaultsTypesConformanceFixture_RoundTrip_MySQL -count=1 -v
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./core/renderer/internal/dialects/mysql ./core/renderer/internal/dialects/mariadb ./core/renderer/internal/dialects/mysqllike -count=1
- scripts/check-test-style.sh
- MYSQL_TEST_DSN=root:pw@tcp(localhost:53306)/ptah612 GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test -tags=integration ./integration/gonative -timeout 15m -count=1
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go tool qtlint ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache go test ./...
- GOWORK=off GOCACHE=/private/tmp/ptah-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-golangci-cache golangci-lint run ./...
- rg -n 'github\.com/stretchr/testify|\b(assert|require)\.' --glob '*.go' .
- git diff --check

## Conformance check
Using ptah-atlas-conformance with a temporary go.mod replace to this worktree:

- CONFORMANCE_MYSQL_URL=mysql://root:pw@tcp(localhost:53306)/ptah612 GOWORK=off GOCACHE=/private/tmp/ptah-go-cache make gate-live
- expected red with only mysql/06-constraints-actions remaining; mysql/09-defaults-types no longer appears.