### PR TITLE
Fix MySQL constraints/actions round-trip drift

### DIFF
--- a/integration/gonative/conformance_roundtrip_helpers_integration_test.go
+++ b/integration/gonative/conformance_roundtrip_helpers_integration_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"strings"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func renderConformanceSQL(c *qt.C, target *goschema.Database, dialect string) string {
+	createAST := fromschema.FromDatabase(*target, dialect)
+	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
+	c.Assert(err, qt.IsNil)
+	return strings.TrimSpace(createSQL)
+}
+
+func execConformanceSQL(c *qt.C, db *sql.DB, sqlText, fixture string) {
+	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
+		_, err := db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("%s schema statement must apply: %s", fixture, stmt))
+	}
+}
+
+func filterConformanceSchema(in *dbschematypes.DBSchema, keepTables map[string]struct{}) *dbschematypes.DBSchema {
+	out := *in
+	out.Tables = filterTables(in.Tables, keepTables)
+	out.Indexes = filterIndexes(in.Indexes, keepTables)
+	out.Constraints = filterConstraints(in.Constraints, keepTables)
+	return &out
+}

--- a/integration/gonative/constraints_actions_conformance_integration_test.go
+++ b/integration/gonative/constraints_actions_conformance_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+func TestConstraintsActionsConformanceFixture_RoundTrip_MySQL(t *testing.T) {
+	dsn := skipIfNoMySQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, _ = db.Exec("DROP TABLE IF EXISTS projects")
+	_, _ = db.Exec("DROP TABLE IF EXISTS organizations")
+	defer func() {
+		_, _ = db.Exec("DROP TABLE IF EXISTS projects")
+		_, _ = db.Exec("DROP TABLE IF EXISTS organizations")
+	}()
+
+	target := constraintsActionsConformanceSchema()
+	createSQL := renderConformanceSQL(c, target, platform.MySQL)
+	execConformanceSQL(c, db, createSQL, "constraints/actions")
+
+	reader := mysqlreader.NewMySQLReader(db, "")
+	liveSchema, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+	liveSchema = filterConformanceSchema(liveSchema, constraintsActionsConformanceTables())
+
+	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func constraintsActionsConformanceSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Organization", Name: "organizations"},
+			{StructName: "Project", Name: "projects"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Organization", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName: "Organization",
+				Name:       "slug",
+				Type:       "VARCHAR(64)",
+				Nullable:   false,
+				Unique:     true,
+			},
+			{StructName: "Project", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName:     "Project",
+				Name:           "organization_id",
+				Type:           "INTEGER",
+				Nullable:       false,
+				Foreign:        "organizations(id)",
+				ForeignKeyName: "fk_projects_organization",
+				OnDelete:       "CASCADE",
+				OnUpdate:       "RESTRICT",
+			},
+			{
+				StructName: "Project",
+				Name:       "slug",
+				Type:       "VARCHAR(64)",
+				Nullable:   false,
+			},
+			{
+				StructName: "Project",
+				Name:       "status",
+				Type:       "VARCHAR(16)",
+				Nullable:   false,
+				Default:    "active",
+				DefaultSet: true,
+			},
+			{
+				StructName:  "Project",
+				Name:        "budget_cents",
+				Type:        "INTEGER",
+				Nullable:    false,
+				DefaultExpr: "0",
+				Check:       "budget_cents >= 0",
+				CheckName:   "projects_budget_nonnegative",
+			},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				StructName: "Project",
+				Name:       "projects_org_slug_unique",
+				Type:       "UNIQUE",
+				Table:      "projects",
+				Columns:    []string{"organization_id", "slug"},
+			},
+			{
+				StructName:      "Project",
+				Name:            "projects_status_check",
+				Type:            "CHECK",
+				Table:           "projects",
+				CheckExpression: "status IN ('active', 'archived')",
+			},
+		},
+	}
+}
+
+func constraintsActionsConformanceTables() map[string]struct{} {
+	return map[string]struct{}{
+		"organizations": {},
+		"projects":      {},
+	}
+}

--- a/integration/gonative/defaults_types_conformance_integration_test.go
+++ b/integration/gonative/defaults_types_conformance_integration_test.go
@@ -4,7 +4,6 @@ package gonative_test
 
 import (
 	"database/sql"
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -12,11 +11,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
-	"github.com/stokaro/ptah/core/renderer"
-	dbschematypes "github.com/stokaro/ptah/dbschema/types"
-	"github.com/stokaro/ptah/internal/convert/fromschema"
 	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
-	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
@@ -32,13 +27,13 @@ func TestDefaultsTypesConformanceFixture_RoundTrip_MySQL(t *testing.T) {
 	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS invoices") }()
 
 	target := defaultsTypesConformanceSchema()
-	createSQL := renderDefaultsTypesConformanceSQL(c, target, platform.MySQL)
-	execDefaultsTypesConformanceSQL(c, db, createSQL)
+	createSQL := renderConformanceSQL(c, target, platform.MySQL)
+	execConformanceSQL(c, db, createSQL, "defaults/types")
 
 	reader := mysqlreader.NewMySQLReader(db, "")
 	liveSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
-	liveSchema = filterDefaultsTypesConformanceSchema(liveSchema)
+	liveSchema = filterConformanceSchema(liveSchema, defaultsTypesConformanceTables())
 
 	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
@@ -92,27 +87,8 @@ func defaultsTypesConformanceSchema() *goschema.Database {
 	}
 }
 
-func renderDefaultsTypesConformanceSQL(c *qt.C, target *goschema.Database, dialect string) string {
-	createAST := fromschema.FromDatabase(*target, dialect)
-	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
-	c.Assert(err, qt.IsNil)
-	return strings.TrimSpace(createSQL)
-}
-
-func execDefaultsTypesConformanceSQL(c *qt.C, db *sql.DB, sqlText string) {
-	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
-		_, err := db.Exec(stmt)
-		c.Assert(err, qt.IsNil, qt.Commentf("defaults/types schema statement must apply: %s", stmt))
-	}
-}
-
-func filterDefaultsTypesConformanceSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
-	keepTables := map[string]struct{}{
+func defaultsTypesConformanceTables() map[string]struct{} {
+	return map[string]struct{}{
 		"invoices": {},
 	}
-	out := *in
-	out.Tables = filterTables(in.Tables, keepTables)
-	out.Indexes = filterIndexes(in.Indexes, keepTables)
-	out.Constraints = filterConstraints(in.Constraints, keepTables)
-	return &out
 }

--- a/integration/gonative/generated_column_conformance_integration_test.go
+++ b/integration/gonative/generated_column_conformance_integration_test.go
@@ -4,7 +4,6 @@ package gonative_test
 
 import (
 	"database/sql"
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -13,12 +12,8 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
-	"github.com/stokaro/ptah/core/renderer"
-	dbschematypes "github.com/stokaro/ptah/dbschema/types"
-	"github.com/stokaro/ptah/internal/convert/fromschema"
 	mysqlreader "github.com/stokaro/ptah/internal/dbschema/mysql"
 	postgresreader "github.com/stokaro/ptah/internal/dbschema/postgres"
-	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
@@ -34,13 +29,13 @@ func TestGeneratedColumnConformanceFixture_RoundTrip_Postgres(t *testing.T) {
 	defer func() { _, _ = db.Exec(`DROP TABLE IF EXISTS contacts`) }()
 
 	target := generatedColumnConformanceSchema()
-	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.Postgres)
-	execGeneratedColumnConformanceSQL(c, db, createSQL)
+	createSQL := renderConformanceSQL(c, target, platform.Postgres)
+	execConformanceSQL(c, db, createSQL, "generated-column")
 
 	reader := postgresreader.NewPostgreSQLReader(db, "public")
 	liveSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
-	liveSchema = filterGeneratedColumnConformanceSchema(liveSchema)
+	liveSchema = filterConformanceSchema(liveSchema, generatedColumnConformanceTables())
 
 	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.Postgres)
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
@@ -58,13 +53,13 @@ func TestGeneratedColumnConformanceFixture_RoundTrip_MySQL(t *testing.T) {
 	defer func() { _, _ = db.Exec("DROP TABLE IF EXISTS contacts") }()
 
 	target := generatedColumnConformanceSchema()
-	createSQL := renderGeneratedColumnConformanceSQL(c, target, platform.MySQL)
-	execGeneratedColumnConformanceSQL(c, db, createSQL)
+	createSQL := renderConformanceSQL(c, target, platform.MySQL)
+	execConformanceSQL(c, db, createSQL, "generated-column")
 
 	reader := mysqlreader.NewMySQLReader(db, "")
 	liveSchema, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
-	liveSchema = filterGeneratedColumnConformanceSchema(liveSchema)
+	liveSchema = filterConformanceSchema(liveSchema, generatedColumnConformanceTables())
 
 	diff := schemadiff.CompareWithDialect(target, liveSchema, platform.MySQL)
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
@@ -92,27 +87,8 @@ func generatedColumnConformanceSchema() *goschema.Database {
 	}
 }
 
-func renderGeneratedColumnConformanceSQL(c *qt.C, target *goschema.Database, dialect string) string {
-	createAST := fromschema.FromDatabase(*target, dialect)
-	createSQL, err := renderer.RenderSQL(dialect, createAST.Statements...)
-	c.Assert(err, qt.IsNil)
-	return strings.TrimSpace(createSQL)
-}
-
-func execGeneratedColumnConformanceSQL(c *qt.C, db *sql.DB, sqlText string) {
-	for _, stmt := range migrator.SplitSQLStatements(sqlText) {
-		_, err := db.Exec(stmt)
-		c.Assert(err, qt.IsNil, qt.Commentf("generated-column schema statement must apply: %s", stmt))
-	}
-}
-
-func filterGeneratedColumnConformanceSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {
-	keepTables := map[string]struct{}{
+func generatedColumnConformanceTables() map[string]struct{} {
+	return map[string]struct{}{
 		"contacts": {},
 	}
-	out := *in
-	out.Tables = filterTables(in.Tables, keepTables)
-	out.Indexes = filterIndexes(in.Indexes, keepTables)
-	out.Constraints = filterConstraints(in.Constraints, keepTables)
-	return &out
 }

--- a/migration/schemadiff/internal/compare/check_constraints.go
+++ b/migration/schemadiff/internal/compare/check_constraints.go
@@ -8,40 +8,130 @@ import (
 func normalizeCheckExpression(expr string) string {
 	expr = trimBalancedCheckParens(strings.TrimSpace(expr))
 
-	var b strings.Builder
-	inString := false
-	for i := 0; i < len(expr); i++ {
-		ch := expr[i]
-		if ch == '\'' {
-			b.WriteByte(ch)
-			if inString && i+1 < len(expr) && expr[i+1] == '\'' {
-				i++
-				b.WriteByte('\'')
-				continue
-			}
-			inString = !inString
-			continue
-		}
-		if !inString && ch == ':' && i+1 < len(expr) && expr[i+1] == ':' && checkCastFollowsLiteral(expr, i) {
-			i += 2
-			for i < len(expr) && isCheckCastChar(rune(expr[i])) {
-				i++
-			}
-			i--
-			continue
-		}
-		if !inString && unicode.IsSpace(rune(ch)) {
-			continue
-		}
-		if !inString && ch == '`' {
-			continue
-		}
-		if !inString && ch >= 'A' && ch <= 'Z' {
-			ch += 'a' - 'A'
-		}
-		b.WriteByte(ch)
+	normalizer := checkExpressionNormalizer{expr: expr}
+	return normalizer.normalize()
+}
+
+type checkExpressionNormalizer struct {
+	expr     string
+	builder  strings.Builder
+	inString bool
+	pos      int
+}
+
+func (n *checkExpressionNormalizer) normalize() string {
+	for n.pos = 0; n.pos < len(n.expr); n.pos++ {
+		n.writeNext()
 	}
-	return b.String()
+	return n.builder.String()
+}
+
+func (n *checkExpressionNormalizer) writeNext() {
+	ch := n.expr[n.pos]
+	if n.writeEscapedQuote(ch) || n.writeStringQuote(ch) || n.skipCharsetIntroducer(ch) || n.skipLiteralCast(ch) {
+		return
+	}
+	if !n.inString && unicode.IsSpace(rune(ch)) {
+		return
+	}
+	if !n.inString && ch == '`' {
+		return
+	}
+	if !n.inString && ch >= 'A' && ch <= 'Z' {
+		ch += 'a' - 'A'
+	}
+	n.builder.WriteByte(ch)
+}
+
+func (n *checkExpressionNormalizer) writeEscapedQuote(ch byte) bool {
+	if ch != '\\' || n.pos+1 >= len(n.expr) || n.expr[n.pos+1] != '\'' {
+		return false
+	}
+	if !n.inString || checkEscapedQuoteClosesString(n.expr, n.pos+1) {
+		return true
+	}
+	n.builder.WriteByte('\'')
+	n.pos++
+	return true
+}
+
+func (n *checkExpressionNormalizer) writeStringQuote(ch byte) bool {
+	if ch != '\'' {
+		return false
+	}
+	n.builder.WriteByte(ch)
+	if n.inString && n.pos+1 < len(n.expr) && n.expr[n.pos+1] == '\'' {
+		n.pos++
+		return true
+	}
+	n.inString = !n.inString
+	return true
+}
+
+func (n *checkExpressionNormalizer) skipCharsetIntroducer(ch byte) bool {
+	if n.inString || ch != '_' || !checkCharsetIntroducerFollows(n.expr, n.pos) {
+		return false
+	}
+	n.pos = skipCheckCharsetIntroducer(n.expr, n.pos)
+	if n.pos < len(n.expr) && n.expr[n.pos] == '\\' {
+		return true
+	}
+	n.pos--
+	return true
+}
+
+func (n *checkExpressionNormalizer) skipLiteralCast(ch byte) bool {
+	if n.inString || ch != ':' || n.pos+1 >= len(n.expr) || n.expr[n.pos+1] != ':' || !checkCastFollowsLiteral(n.expr, n.pos) {
+		return false
+	}
+	n.pos += 2
+	for n.pos < len(n.expr) && isCheckCastChar(rune(n.expr[n.pos])) {
+		n.pos++
+	}
+	n.pos--
+	return true
+}
+
+func checkEscapedQuoteClosesString(expr string, quoteIndex int) bool {
+	next := quoteIndex + 1
+	if next >= len(expr) {
+		return true
+	}
+	return !isCheckStringBodyChar(rune(expr[next]))
+}
+
+func checkCharsetIntroducerFollows(expr string, start int) bool {
+	i := start + 1
+	if i >= len(expr) || !isCheckCharsetNameStart(rune(expr[i])) {
+		return false
+	}
+	for i < len(expr) && isCheckCharsetNameChar(rune(expr[i])) {
+		i++
+	}
+	if i < len(expr) && expr[i] == '\'' {
+		return true
+	}
+	return i+1 < len(expr) && expr[i] == '\\' && expr[i+1] == '\''
+}
+
+func skipCheckCharsetIntroducer(expr string, start int) int {
+	i := start + 1
+	for i < len(expr) && isCheckCharsetNameChar(rune(expr[i])) {
+		i++
+	}
+	return i
+}
+
+func isCheckCharsetNameStart(ch rune) bool {
+	return unicode.IsLetter(ch)
+}
+
+func isCheckCharsetNameChar(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_'
+}
+
+func isCheckStringBodyChar(ch rune) bool {
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_'
 }
 
 func trimBalancedCheckParens(expr string) string {
@@ -62,6 +152,12 @@ func checkOuterParensWrap(expr string) bool {
 	inString := false
 	for i := 0; i < len(expr); i++ {
 		ch := expr[i]
+		if ch == '\\' && i+1 < len(expr) && expr[i+1] == '\'' {
+			if inString && !checkEscapedQuoteClosesString(expr, i+1) {
+				i++
+			}
+			continue
+		}
 		if ch == '\'' {
 			if inString && i+1 < len(expr) && expr[i+1] == '\'' {
 				i++

--- a/migration/schemadiff/internal/compare/fk_constraints_test.go
+++ b/migration/schemadiff/internal/compare/fk_constraints_test.go
@@ -145,6 +145,30 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 			expected: &difftypes.SchemaDiff{},
 		},
 		{
+			// Atlas-style underscore action spelling is equivalent to the
+			// spaced SQL spelling reported by information_schema.
+			name: "on_delete SET_NULL matches existing SET NULL — no diff (idempotent)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnDelete:       "SET_NULL",
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(new("SET NULL"), new("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
 			// Idempotency #2: the model leaves the action empty while Postgres
 			// reports the default as NO ACTION. The normalization ("" == NO
 			// ACTION, trim + upper-case) must make this a no-op, otherwise every
@@ -161,6 +185,30 @@ func TestConstraints_FieldLevelForeignKey(t *testing.T) {
 						Foreign:        "files(id)",
 						ForeignKeyName: "fk_export_file",
 						// OnDelete / OnUpdate intentionally empty.
+					},
+				},
+			},
+			database: &types.DBSchema{
+				Tables:      []types.DBTable{exportsTable},
+				Constraints: []types.DBConstraint{dbFK(new("NO ACTION"), new("NO ACTION"))},
+			},
+			expected: &difftypes.SchemaDiff{},
+		},
+		{
+			// Atlas-style underscore action spelling is equivalent to the
+			// spaced SQL spelling reported by information_schema.
+			name: "on_update NO_ACTION matches existing NO ACTION — no diff (idempotent)",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+				Fields: []goschema.Field{
+					{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+					{
+						StructName:     "Export",
+						Name:           "file_id",
+						Type:           "TEXT",
+						Foreign:        "files(id)",
+						ForeignKeyName: "fk_export_file",
+						OnUpdate:       "NO_ACTION",
 					},
 				},
 			},

--- a/migration/schemadiff/internal/compare/foreign_keys.go
+++ b/migration/schemadiff/internal/compare/foreign_keys.go
@@ -77,6 +77,7 @@ func foreignTableRefMatches(generated string, dbConstraint types.DBConstraint) b
 // RESTRICT <-> NO ACTION change the user intended.
 func normalizeReferentialAction(action, dialect string) string {
 	normalized := strings.ToUpper(strings.TrimSpace(action))
+	normalized = strings.ReplaceAll(normalized, "_", " ")
 	if normalized == "" {
 		return "NO ACTION"
 	}

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -399,6 +399,162 @@ func TestCompareWithDialect_MySQLDefaultsTypesFixtureMatchesCatalogReadback(t *t
 	c.Assert(diff.TablesModified, qt.HasLen, 0)
 }
 
+func TestCompareWithDialect_MySQLConstraintsActionsFixtureMatchesCatalogReadback(t *testing.T) {
+	c := qt.New(t)
+	statusDefault := "'active'"
+	budgetDefault := "0"
+	budgetCheck := "(`budget_cents` >= 0)"
+	statusCheck := "(`status` in (_latin1\\'active\\',_latin1\\'archived\\'))"
+	deleteRule := "CASCADE"
+	updateRule := "RESTRICT"
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "organizations", StructName: "Organization"},
+			{Name: "projects", StructName: "Project"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Organization", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Organization", Name: "slug", Type: "VARCHAR(64)", Nullable: false, Unique: true},
+			{StructName: "Project", Name: "id", Type: "SERIAL", Primary: true},
+			{
+				StructName:     "Project",
+				Name:           "organization_id",
+				Type:           "INTEGER",
+				Nullable:       false,
+				Foreign:        "organizations(id)",
+				ForeignKeyName: "fk_projects_organization",
+				OnDelete:       "CASCADE",
+				OnUpdate:       "RESTRICT",
+			},
+			{StructName: "Project", Name: "slug", Type: "VARCHAR(64)", Nullable: false},
+			{
+				StructName: "Project",
+				Name:       "status",
+				Type:       "VARCHAR(16)",
+				Nullable:   false,
+				Default:    "active",
+				DefaultSet: true,
+			},
+			{
+				StructName:  "Project",
+				Name:        "budget_cents",
+				Type:        "INTEGER",
+				Nullable:    false,
+				DefaultExpr: "0",
+				Check:       "budget_cents >= 0",
+				CheckName:   "projects_budget_nonnegative",
+			},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				StructName: "Project",
+				Name:       "projects_org_slug_unique",
+				Type:       "UNIQUE",
+				Table:      "projects",
+				Columns:    []string{"organization_id", "slug"},
+			},
+			{
+				StructName:      "Project",
+				Name:            "projects_status_check",
+				Type:            "CHECK",
+				Table:           "projects",
+				CheckExpression: "status IN ('active', 'archived')",
+			},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "organizations",
+				Type: "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "int", ColumnType: "int", IsNullable: "NO", IsPrimaryKey: true, IsAutoIncrement: true},
+					{Name: "slug", DataType: "varchar(64)", ColumnType: "varchar(64)", IsNullable: "NO", IsUnique: true},
+				},
+			},
+			{
+				Name: "projects",
+				Type: "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "int", ColumnType: "int", IsNullable: "NO", IsPrimaryKey: true, IsAutoIncrement: true},
+					{Name: "organization_id", DataType: "int", ColumnType: "int", IsNullable: "NO"},
+					{Name: "slug", DataType: "varchar(64)", ColumnType: "varchar(64)", IsNullable: "NO"},
+					{Name: "status", DataType: "varchar(16)", ColumnType: "varchar(16)", IsNullable: "NO", ColumnDefault: &statusDefault},
+					{Name: "budget_cents", DataType: "int", ColumnType: "int", IsNullable: "NO", ColumnDefault: &budgetDefault},
+				},
+			},
+		},
+		Constraints: []types.DBConstraint{
+			{Name: "PRIMARY", TableName: "organizations", Type: "PRIMARY KEY", ColumnName: "id", ColumnNames: []string{"id"}},
+			{Name: "slug", TableName: "organizations", Type: "UNIQUE", ColumnName: "slug", ColumnNames: []string{"slug"}},
+			{Name: "PRIMARY", TableName: "projects", Type: "PRIMARY KEY", ColumnName: "id", ColumnNames: []string{"id"}},
+			{
+				Name:           "fk_projects_organization",
+				TableName:      "projects",
+				Type:           "FOREIGN KEY",
+				ColumnName:     "organization_id",
+				ColumnNames:    []string{"organization_id"},
+				ForeignTable:   new("organizations"),
+				ForeignColumn:  new("id"),
+				ForeignColumns: []string{"id"},
+				DeleteRule:     &deleteRule,
+				UpdateRule:     &updateRule,
+			},
+			{
+				Name:        "projects_budget_nonnegative",
+				TableName:   "projects",
+				Type:        "CHECK",
+				CheckClause: &budgetCheck,
+			},
+			{
+				Name:        "projects_org_slug_unique",
+				TableName:   "projects",
+				Type:        "UNIQUE",
+				ColumnName:  "organization_id",
+				ColumnNames: []string{"organization_id", "slug"},
+			},
+			{
+				Name:        "projects_status_check",
+				TableName:   "projects",
+				Type:        "CHECK",
+				CheckClause: &statusCheck,
+			},
+		},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mysql")
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func TestCompareWithDialect_MySQLCharsetEscapedStringLiteralMatchesGeneratedEscapes(t *testing.T) {
+	c := qt.New(t)
+	checkClause := "(`name` <> _latin1\\'owner\\'s\\')"
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "projects", StructName: "Project"}},
+		Constraints: []goschema.Constraint{{
+			StructName:      "Project",
+			Name:            "projects_name_check",
+			Type:            "CHECK",
+			Table:           "projects",
+			CheckExpression: "name <> 'owner''s'",
+		}},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{Name: "projects", Type: "TABLE"}},
+		Constraints: []types.DBConstraint{{
+			Name:        "projects_name_check",
+			TableName:   "projects",
+			Type:        "CHECK",
+			CheckClause: &checkClause,
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mysql")
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
 func TestCompareWithDialect_SQLiteInlineEnumsMatchGeneratedEnumFields(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Fixes #611.

## Summary
- normalize MySQL CHECK expressions that information_schema reports with charset introducers and backslash-escaped string delimiters
- normalize underscore referential actions such as SET_NULL/NO_ACTION before FK comparison
- add a MySQL live conformance regression for the constraints/actions fixture and share live round-trip helpers across conformance-style integration tests

## Validation
- go test ./migration/schemadiff ./migration/schemadiff/internal/compare -count=1
- golangci-lint run ./...
- scripts/check-test-style.sh
- go tool qtlint ./...
- MYSQL_TEST_DSN='root:pw@tcp(127.0.0.1:53306)/ptah612' go test -tags=integration ./integration/gonative -timeout 15m -count=1
- go test ./...
- conformance replace proof: CONFORMANCE_MYSQL_URL='mysql://root:pw@tcp(127.0.0.1:53306)/ptah612' make gate-live => 9 observations, 0 non-OK