### PR TITLE
Normalize atlas.hcl relative paths

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -314,7 +314,10 @@ func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 			if err != nil {
 				return nil, err
 			}
-			args = applyAtlasProjectConfigToArgs(verb.flags, args, cfg)
+			args, err = applyAtlasProjectConfigToArgs(verb.flags, args, cfg, project.flags)
+			if err != nil {
+				return nil, err
+			}
 			if verb.nativeProjectConfig {
 				args, err = applyAtlasProjectConfigToNativeArgs(args, project.flags)
 				if err != nil {

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/pathguard"
 	migrationlint "github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -3312,6 +3314,550 @@ func TestNewAtlasCommand_MigrateDiffRejectsInvalidFormat(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `parse --format template: .*function "json" not defined.*`)
+}
+
+func TestNewAtlasCommand_MigrateApplyResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "apply-relative.db")
+	writeAtlasApplyMigration(c, migrationsDir, "1_apply_relative.sql", "CREATE TABLE apply_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "apply",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	assertSQLiteTableExists(c, dbPath, "apply_relative_users")
+}
+
+func TestNewAtlasCommand_MigrateStatusResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "status-relative.db")
+	writeAtlasApplyMigration(c, migrationsDir, "1_status_relative.sql", "CREATE TABLE status_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "status",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Pending Migrations: 1")
+}
+
+func TestNewAtlasCommand_MigrateValidateResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	writeAtlasApplyMigration(c, migrationsDir, "1_validate_relative.sql", "CREATE TABLE validate_relative_users (id INTEGER PRIMARY KEY);")
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "validate",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "OK: migrations directory matches atlas.sum")
+}
+
+func TestNewAtlasCommand_MigrateHashResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	writeAtlasApplyMigration(c, migrationsDir, "1_hash_relative.sql", "CREATE TABLE hash_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "hash",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
+}
+
+func TestNewAtlasCommand_MigrateNewResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "new", "relative_create",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Generated empty migration file:")
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
+}
+
+func TestAtlasArgMapper_MigrateSetResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	writeAtlasApplyMigration(c, migrationsDir, "1_set_relative.sql", "CREATE TABLE set_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	mapper := atlasArgMapper("migrate", atlasVerb{
+		use: "set",
+		flags: []atlasargs.Flag{
+			atlasargs.NativeString("url", "u", "Database URL", "db-url"),
+			atlasargs.NativeLocalDir("dir", "", "Migration directory", "migrations-dir"),
+			atlasMigrateDirFormatFlag("dir-format"),
+			atlasargs.NativeString("revisions-schema", "", "Schema for the revision table", "migrations-schema"),
+		},
+	})
+
+	got, err := mapper(&cobra.Command{Use: "set"}, []string{
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+	wantMigrationsDir, resolveErr := pathguard.ResolveWithinRoot(migrationsDir, "")
+	c.Assert(resolveErr, qt.IsNil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, []string{
+		"--migrations-dir", wantMigrationsDir,
+		"--dir-format", "atlas",
+	})
+}
+
+func TestNewAtlasCommand_MigrateDownResolvesProjectRelativeMigrationDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	dbPath := filepath.Join(dir, "down-relative.db")
+	writeAtlasApplyMigration(c, migrationsDir, "1_down_relative.sql", "CREATE TABLE down_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_down_relative.down.sql"), []byte("DROP TABLE down_relative_users;\n"), 0o600), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	apply := NewAtlasCommand()
+	var applyOut bytes.Buffer
+	apply.SetOut(&applyOut)
+	apply.SetErr(&applyOut)
+	apply.SetArgs([]string{
+		"migrate", "apply",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+	err := apply.Execute()
+	c.Assert(err, qt.IsNil)
+	assertSQLiteTableExists(c, dbPath, "down_relative_users")
+
+	down := NewAtlasCommand()
+	var downOut bytes.Buffer
+	down.SetIn(strings.NewReader("YES\n"))
+	down.SetOut(&downOut)
+	down.SetErr(&downOut)
+	down.SetArgs([]string{
+		"migrate", "down",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--to-version", "0",
+	})
+
+	err = down.Execute()
+
+	c.Assert(err, qt.IsNil)
+	assertSQLiteTableMissing(c, dbPath, "down_relative_users")
+	c.Assert(sqliteAtlasAppliedVersions(c, dbPath), qt.HasLen, 0)
+}
+
+func TestNewAtlasCommand_MigrateStatusAllowsExplicitDirToOverrideUnsupportedProjectDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(dir, "explicit-migrations")
+	writeAtlasApplyMigration(c, migrationsDir, "1_override_relative.sql", "CREATE TABLE override_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.MkdirAll(projectDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "status-override-relative.db")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "atlas://remote"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "status",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--dir", "file://" + filepath.ToSlash(migrationsDir),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Pending Migrations: 1")
+}
+
+func TestNewAtlasCommand_MigrateStatusRejectsUnsupportedProjectDirWhenUsed(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	c.Assert(os.MkdirAll(projectDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "status-unsupported-relative.db")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "atlas://remote"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "status",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas migrate status --dir: only local file:// migration directories are supported`)
+}
+
+func TestNewAtlasCommand_MigrateStatusAllowsParentRelativeProjectDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(dir, "shared-migrations")
+	writeAtlasApplyMigration(c, migrationsDir, "1_parent_relative.sql", "CREATE TABLE parent_relative_users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.MkdirAll(projectDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "status-parent-relative.db")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://../shared-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "status",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "Pending Migrations: 1")
+}
+
+func TestNewAtlasCommand_SchemaApplyResolvesProjectRelativeSchemaSrc(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	c.Assert(os.MkdirAll(projectDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	dbPath := filepath.Join(dir, "schema-apply-relative.db")
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "schema.sql"), []byte(`CREATE TABLE schema_apply_relative (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  dev = "sqlite://dev.db"
+  schema {
+    src = "file://schema.sql"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("y\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--auto-approve",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	assertSQLiteTableExists(c, dbPath, "schema_apply_relative")
+}
+
+func TestNewAtlasCommand_SchemaDiffResolvesProjectRelativeSchemaSrc(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	c.Assert(os.MkdirAll(projectDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	fromPath := filepath.Join(dir, "from.sql")
+	c.Assert(os.WriteFile(fromPath, []byte(`CREATE TABLE keep_existing (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "schema.sql"), []byte(`CREATE TABLE schema_diff_relative (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  dev = "sqlite://dev.db"
+  schema {
+    src = "file://schema.sql"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "diff",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--from", "file://" + filepath.ToSlash(fromPath),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, `CREATE TABLE "schema_diff_relative"`)
+}
+
+func TestNewAtlasCommand_MigrateDiffResolvesProjectRelativeDirAndSchemaSrc(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "schema.sql"), []byte(`CREATE TABLE migrate_diff_relative (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  dev = "sqlite://`+filepath.ToSlash(filepath.Join(dir, "migrate-diff-relative-dev.db"))+`"
+  schema {
+    src = "file://schema.sql"
+  }
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "diff",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"relative",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
+}
+
+func TestNewAtlasCommand_ProjectRelativeSchemaSrcRejectsUnsupportedScheme(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	c.Assert(os.MkdirAll(projectDir, 0755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0755), qt.IsNil)
+	t.Chdir(outsideDir)
+	fromPath := filepath.Join(dir, "from.sql")
+	c.Assert(os.WriteFile(fromPath, []byte(`CREATE TABLE unsupported_scheme_from (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  dev = "sqlite://dev.db"
+  schema {
+    src = "env://src"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "diff",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--from", "file://" + filepath.ToSlash(fromPath),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas.hcl schema.src: only local file:// schema files are supported`)
+}
+
+func TestNewAtlasCommand_ProjectRelativeSchemaSrcRejectsQuery(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, "project")
+	outsideDir := filepath.Join(dir, "outside")
+	c.Assert(os.MkdirAll(projectDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
+	t.Chdir(outsideDir)
+	fromPath := filepath.Join(dir, "from.sql")
+	c.Assert(os.WriteFile(fromPath, []byte(`CREATE TABLE query_from (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "schema.sql"), []byte(`CREATE TABLE query_to (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
+  dev = "sqlite://dev.db"
+  schema {
+    src = "file://schema.sql?format=sql"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "diff",
+		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
+		"--env", "local",
+		"--from", "file://" + filepath.ToSlash(fromPath),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas.hcl schema.src: schema file URL query parameters are not supported yet`)
 }
 
 type atlasMigrateApplyJSONResult struct {

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -97,6 +97,12 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Migrate.Apply)
 		formatOutput = formatOutput || projectCfg.Format.Migrate.Apply != ""
 	}
+	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+		opts.dir, err = atlasProjectConfigLocalDir(cmd, opts.dir)
+		if err != nil {
+			return fmt.Errorf("atlas migrate apply --dir: %w", err)
+		}
+	}
 	if formatOutput && strings.TrimSpace(opts.format) == "" {
 		return fmt.Errorf("--format must not be empty")
 	}

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -93,6 +93,18 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl diff.concurrent_index.create is not supported by migrate diff yet"))
 		}
 	}
+	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+		opts.dirURL, err = atlasProjectConfigLocalDir(cmd, opts.dirURL)
+		if err != nil {
+			return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
+		}
+	}
+	if loaded && !cmd.Flags().Changed("to") && len(projectCfg.SchemaSources) > 0 {
+		opts.toURLs, err = atlasProjectConfigSchemaURLs(cmd, opts.toURLs)
+		if err != nil {
+			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
+		}
+	}
 	if err := validateAtlasMigrateDiffOptions(cmd, opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasargs"
+	"github.com/stokaro/ptah/internal/atlasprojectpath"
 	"github.com/stokaro/ptah/internal/atlasschema"
 )
 
@@ -98,22 +99,43 @@ func loadRequiredAtlasProjectConfigForCommand(
 }
 
 func atlasProjectConfigLocalDir(cmd *cobra.Command, raw string) (string, error) {
-	localDir, err := atlasargs.LocalDirValue(raw)
-	if err != nil {
-		return "", err
-	}
-	if filepath.IsAbs(localDir) {
-		return localDir, nil
-	}
 	flags, _, err := atlasProjectFlagsFromCommand(cmd)
 	if err != nil {
 		return "", err
 	}
+	return atlasProjectConfigLocalDirFromFlags(flags, raw)
+}
+
+func atlasProjectConfigSchemaURLs(cmd *cobra.Command, raw []string) ([]string, error) {
+	flags, _, err := atlasProjectFlagsFromCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return atlasProjectConfigSchemaURLsFromFlags(flags, raw)
+}
+
+func atlasProjectConfigLocalDirFromFlags(flags atlasProjectFlagValues, raw string) (string, error) {
+	baseDir, err := atlasProjectConfigBaseDir(flags)
+	if err != nil {
+		return "", err
+	}
+	return atlasprojectpath.LocalDir(raw, baseDir)
+}
+
+func atlasProjectConfigSchemaURLsFromFlags(flags atlasProjectFlagValues, raw []string) ([]string, error) {
+	baseDir, err := atlasProjectConfigBaseDir(flags)
+	if err != nil {
+		return nil, err
+	}
+	return atlasprojectpath.SchemaFileURLs(raw, baseDir)
+}
+
+func atlasProjectConfigBaseDir(flags atlasProjectFlagValues) (string, error) {
 	configPath, err := atlasConfigPathValue(flags.configPath)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(filepath.Dir(configPath), filepath.FromSlash(localDir)), nil
+	return filepath.Dir(configPath), nil
 }
 
 type missingAtlasEnvSelectionMode int
@@ -289,17 +311,24 @@ func applyAtlasProjectConfigToArgs(
 	flags []atlasargs.Flag,
 	args []string,
 	cfg projectconfig.Config,
-) []string {
+	projectFlags atlasProjectFlagValues,
+) ([]string, error) {
 	args = appendAtlasProjectStringArg(flags, args, "url", cfg.DatabaseURL)
 	args = appendAtlasProjectStringArg(flags, args, "dev-url", cfg.DevURL)
-	args = appendAtlasProjectStringArg(flags, args, "dir", cfg.Migration.Dir)
+	if cfg.Migration.Dir != "" && atlasFlagRegistered(flags, "dir") && !atlasFlagPresent(flags, args, "dir") {
+		dir, err := atlasProjectConfigLocalDirFromFlags(projectFlags, cfg.Migration.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("atlas.hcl migration.dir: %w", err)
+		}
+		args = append(args, "--dir", dir)
+	}
 	args = appendAtlasProjectStringArg(flags, args, "dir-format", cfg.Migration.Format)
 	args = appendAtlasProjectStringArg(flags, args, "revisions-schema", cfg.Migration.RevisionsSchema)
 	args = appendAtlasProjectStringArg(flags, args, "lock-timeout", cfg.Migration.LockTimeout)
 	args = appendAtlasProjectStringArg(flags, args, "latest", atlasProjectLatest(cfg))
 	args = appendAtlasProjectStringArg(flags, args, "git-base", cfg.Lint.GitBase)
 	args = appendAtlasProjectStringArg(flags, args, "git-dir", cfg.Lint.GitDir)
-	return args
+	return args, nil
 }
 
 func applyAtlasProjectConfigToNativeArgs(args []string, flags atlasProjectFlagValues) ([]string, error) {

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -94,6 +94,12 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 			return cmdutil.Fail(cmd, err)
 		}
 	}
+	if loaded && !cmd.Flags().Changed("to") && !cmd.Flags().Changed(atlasFileFlagName) && len(projectCfg.SchemaSources) > 0 {
+		opts.toURLs, err = atlasProjectConfigSchemaURLs(cmd, opts.toURLs)
+		if err != nil {
+			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
+		}
+	}
 	if cmd.Flags().Changed(atlasFileFlagName) {
 		opts.toURLs = opts.filePaths
 	}

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -71,6 +71,12 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 			return cmdutil.Fail(cmd, err)
 		}
 	}
+	if loaded && !cmd.Flags().Changed("to") && len(projectCfg.SchemaSources) > 0 {
+		opts.toURLs, err = atlasProjectConfigSchemaURLs(cmd, opts.toURLs)
+		if err != nil {
+			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
+		}
+	}
 	format := atlasreport.NormalizeSchemaDiffFormat(opts.format)
 	if err := atlasreport.ValidateSchemaDiffTemplate(format); err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -384,11 +384,7 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			if err != nil {
 				return err
 			}
-			dir, err := normalizeAtlasMigrationDir(value, attr)
-			if err != nil {
-				return err
-			}
-			migration.Dir = dir
+			migration.Dir = normalizeAtlasMigrationDir(value)
 		case "format":
 			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
@@ -1137,19 +1133,11 @@ func stringListValue(name string, attr *hclsyntax.Attribute, value cty.Value) ([
 	return values, nil
 }
 
-func normalizeAtlasMigrationDir(value string, attr *hclsyntax.Attribute) (string, error) {
-	switch {
-	case strings.HasPrefix(value, "file://"):
-		dir := strings.TrimPrefix(value, "file://")
-		if dir == "" {
-			return "", unsupportedAttr("dir", attr)
-		}
-		return dir, nil
-	case strings.Contains(value, "://"):
-		return "", unsupportedAttr("dir", attr)
-	default:
-		return value, nil
+func normalizeAtlasMigrationDir(value string) string {
+	if path, found := strings.CutPrefix(value, "file://"); found && path != "" {
+		return path
 	}
+	return value
 }
 
 func atlasGetenvFunc() function.Function {

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -115,7 +115,11 @@ The supported attributes map to Ptah settings as follows:
 The nested `schema.src` form matches Atlas project config syntax. Ptah currently
 uses local schema file sources only, matching the local schema-file boundary of
 `ptah atlas schema apply`, `ptah atlas schema diff`, and
-`ptah atlas migrate diff`.
+`ptah atlas migrate diff`. Plain local schema paths and relative `file://`
+schema URLs declared in `atlas.hcl` resolve relative to the directory containing
+that `atlas.hcl` file, not the process working directory. Explicit CLI `--to`
+and `--from` values keep CLI semantics and resolve relative to the process
+working directory unless they are absolute.
 
 `env.exclude` accepts either one string or a list of strings. `ptah atlas schema
 apply --env <name>` uses it as the default resource exclusion filter unless an
@@ -174,8 +178,11 @@ single-session executor.
 When an `atlas.hcl` `migration` block is present, Ptah also defaults
 `revision-format` to `atlas`, so migration commands use
 `atlas_schema_revisions` unless an explicit CLI flag overrides it. `file://`
-migration directories are normalized to local paths. Other URI schemes are
-rejected.
+migration directories are normalized to local paths. Relative migration
+directories declared in `atlas.hcl` resolve relative to the directory containing
+that `atlas.hcl` file, not the process working directory. Explicit CLI `--dir`
+values keep CLI semantics and resolve relative to the process working directory
+unless they are absolute. Other URI schemes are rejected.
 
 ## Expression Evaluation
 
@@ -308,8 +315,8 @@ Ptah intentionally rejects everything outside the documented subset. Unsupported
 attributes, unsupported data sources, unsupported lint policy blocks or attributes,
 Cloud or registry sources such as `schema.repo`, unsupported format blocks,
 unsupported diff policy fields, duplicate `migration` or `lint` blocks,
-variables without defaults that are not supplied through `--var`, and non-file
-migration directory URI schemes fail with a location-aware error:
+variables without defaults that are not supplied through `--var` fail with a
+location-aware error:
 
 ```text
 unsupported atlas.hcl construct "src" at atlas.hcl:2
@@ -317,3 +324,7 @@ unsupported atlas.hcl construct "src" at atlas.hcl:2
 
 This hard-fail policy prevents partially interpreted Atlas project configs from
 silently changing migration behavior.
+
+Non-local URI schemes in `migration.dir` and `schema.src` fail explicitly when
+a command needs that configured value. An explicit CLI path flag still wins over
+the matching `atlas.hcl` value before URI validation.

--- a/docs/site/src/content/docs/reference/atlas-project-config.md
+++ b/docs/site/src/content/docs/reference/atlas-project-config.md
@@ -119,6 +119,23 @@ env "local" {
 Explicit CLI flags win over `atlas.hcl`, and `atlas.hcl` wins over built-in
 defaults.
 
+`env.src` and `env.schema.src` accept local schema-file sources for
+`schema apply`, `schema diff`, and `migrate diff`. Plain local schema paths and
+relative `file://` schema URLs declared in `atlas.hcl` resolve relative to the
+directory containing that `atlas.hcl` file, not the process working directory.
+Explicit CLI `--to` and `--from` values keep CLI semantics and resolve relative
+to the process working directory unless they are absolute.
+
+When an `atlas.hcl` `migration` block is present, Ptah defaults
+`revision-format` to `atlas`, so migration commands use
+`atlas_schema_revisions` unless an explicit CLI flag overrides it. Relative
+`migration.dir` values declared in `atlas.hcl` resolve relative to the directory
+containing that `atlas.hcl` file. Explicit CLI `--dir` values keep CLI semantics
+and resolve relative to the process working directory unless they are absolute.
+Non-local URI schemes in `migration.dir` and `schema.src` fail explicitly when a
+command needs that configured value; an explicit CLI path flag still wins before
+URI validation.
+
 ## Environment Selection
 
 Use Atlas project flags on commands under `ptah atlas schema ...` and

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -21,6 +21,12 @@ references for local schema-file workflows.
 Supported Atlas env blocks can also set `schema.src`, `schema.mode`, `format`,
 and local `diff` policy defaults for `ptah atlas ...` commands.
 
+For Atlas-compatible commands, plain local schema paths, relative `file://`
+schema URLs, and relative `migration.dir` values declared in `atlas.hcl` resolve
+relative to the directory containing that `atlas.hcl` file. Explicit CLI path
+flags such as `--to`, `--from`, and `--dir` keep CLI semantics and resolve
+relative to the process working directory unless they are absolute.
+
 ## Minimal `ptah.yaml`
 
 ```yaml

--- a/internal/atlasprojectpath/path.go
+++ b/internal/atlasprojectpath/path.go
@@ -1,0 +1,86 @@
+// Package atlasprojectpath resolves local paths declared in atlas.hcl.
+package atlasprojectpath
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+// LocalDir resolves a local Atlas migration directory URL relative to baseDir.
+func LocalDir(rawURL, baseDir string) (string, error) {
+	path, rawQuery, err := localPath(rawURL, "migration directories")
+	if err != nil {
+		return "", err
+	}
+	if rawQuery != "" {
+		return "", fmt.Errorf("migration directory URL query parameters are not supported yet")
+	}
+	return resolvePath(path, baseDir)
+}
+
+// SchemaFileURLs resolves local Atlas schema file URLs relative to baseDir.
+func SchemaFileURLs(rawURLs []string, baseDir string) ([]string, error) {
+	resolved := make([]string, 0, len(rawURLs))
+	for _, rawURL := range rawURLs {
+		value, err := SchemaFileURL(rawURL, baseDir)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, value)
+	}
+	return resolved, nil
+}
+
+// SchemaFileURL resolves one local Atlas schema file URL relative to baseDir.
+func SchemaFileURL(rawURL, baseDir string) (string, error) {
+	path, rawQuery, err := localPath(rawURL, "schema files")
+	if err != nil {
+		return "", err
+	}
+	if rawQuery != "" {
+		return "", fmt.Errorf("schema file URL query parameters are not supported yet")
+	}
+	resolved, err := resolvePath(path, baseDir)
+	if err != nil {
+		return "", err
+	}
+	return "file://" + filepath.ToSlash(resolved), nil
+}
+
+func localPath(rawURL, resource string) (path string, rawQuery string, err error) {
+	base, rawQuery, _ := strings.Cut(strings.TrimSpace(rawURL), "?")
+	if base == "" {
+		return "", "", fmt.Errorf("%s URL is required", resource)
+	}
+	if rawQuery != "" {
+		if _, err := url.ParseQuery(rawQuery); err != nil {
+			return "", "", fmt.Errorf("parse %s URL query: %w", resource, err)
+		}
+	}
+	if strings.Contains(base, "://") && !strings.HasPrefix(base, "file://") {
+		return "", "", fmt.Errorf("only local file:// %s are supported", resource)
+	}
+	path = strings.TrimPrefix(base, "file://")
+	if path == "" {
+		path = "."
+	}
+	path, err = url.PathUnescape(path)
+	if err != nil {
+		return "", "", fmt.Errorf("decode %s URL path: %w", resource, err)
+	}
+	return filepath.Clean(filepath.FromSlash(path)), rawQuery, nil
+}
+
+func resolvePath(path, baseDir string) (string, error) {
+	if filepath.IsAbs(path) {
+		return pathguard.ResolveWithinRoot(path, "")
+	}
+	if strings.TrimSpace(baseDir) == "" {
+		return "", fmt.Errorf("atlas.hcl base directory is required")
+	}
+	return pathguard.ResolveWithinRoot(filepath.Join(baseDir, path), "")
+}

--- a/internal/atlasprojectpath/path_test.go
+++ b/internal/atlasprojectpath/path_test.go
@@ -1,0 +1,95 @@
+package atlasprojectpath_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasprojectpath"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestLocalDir_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	baseDir := t.TempDir()
+	want, err := pathguard.ResolveWithinRoot(filepath.Join(baseDir, "migrations"), baseDir)
+	c.Assert(err, qt.IsNil)
+
+	resolved, err := atlasprojectpath.LocalDir("file://migrations", baseDir)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(resolved, qt.Equals, want)
+}
+
+func TestLocalDir_PreservesAbsolutePath(t *testing.T) {
+	c := qt.New(t)
+	baseDir := t.TempDir()
+	absoluteDir := filepath.Join(baseDir, "absolute-migrations")
+	want, err := pathguard.ResolveWithinRoot(absoluteDir, "")
+	c.Assert(err, qt.IsNil)
+
+	resolved, err := atlasprojectpath.LocalDir(absoluteDir, t.TempDir())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(resolved, qt.Equals, want)
+}
+
+func TestLocalDir_AllowsParentRelativePath(t *testing.T) {
+	c := qt.New(t)
+	rootDir := t.TempDir()
+	baseDir := filepath.Join(rootDir, "project")
+	c.Assert(os.MkdirAll(baseDir, 0o755), qt.IsNil)
+	want, err := pathguard.ResolveWithinRoot(filepath.Join(rootDir, "migrations"), "")
+	c.Assert(err, qt.IsNil)
+
+	resolved, err := atlasprojectpath.LocalDir("file://../migrations", baseDir)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(resolved, qt.Equals, want)
+}
+
+func TestLocalDir_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlasprojectpath.LocalDir("postgres://localhost/db", t.TempDir())
+
+	c.Assert(err, qt.ErrorMatches, `only local file:// migration directories are supported`)
+}
+
+func TestSchemaFileURLs_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	baseDir := t.TempDir()
+	schemaHCL, err := pathguard.ResolveWithinRoot(filepath.Join(baseDir, "schema.hcl"), baseDir)
+	c.Assert(err, qt.IsNil)
+	schemaSQL, err := pathguard.ResolveWithinRoot(filepath.Join(baseDir, "schema.sql"), baseDir)
+	c.Assert(err, qt.IsNil)
+
+	resolved, err := atlasprojectpath.SchemaFileURLs([]string{
+		"file://schema.hcl",
+		"schema.sql",
+	}, baseDir)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(resolved, qt.DeepEquals, []string{
+		"file://" + filepath.ToSlash(schemaHCL),
+		"file://" + filepath.ToSlash(schemaSQL),
+	})
+}
+
+func TestSchemaFileURL_RejectsQuery(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlasprojectpath.SchemaFileURL("file://schema.hcl?format=hcl", t.TempDir())
+
+	c.Assert(err, qt.ErrorMatches, `schema file URL query parameters are not supported yet`)
+}
+
+func TestSchemaFileURL_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlasprojectpath.SchemaFileURL("env://src", t.TempDir())
+
+	c.Assert(err, qt.ErrorMatches, `only local file:// schema files are supported`)
+}


### PR DESCRIPTION
Fixes #630.

## Summary

- Added a reusable `internal/atlasprojectpath` resolver for local `atlas.hcl` migration directory and schema file paths.
- Resolved config-provided `migration.dir`, `env.src`, and `env.schema.src` relative to the selected `atlas.hcl` file for dedicated and forwarded Atlas adapters.
- Preserved CLI precedence: explicit `--dir`, `--to`, and `--from` values keep normal CLI working-directory semantics and can override unsupported config values.
- Documented config-relative path behavior in root docs and the docs site reference.

## Self-Review

- Pass 1: checked command precedence, unsupported URI handling, config path base directory behavior, and docs coverage.
- Pass 2: checked adapter coverage, test-style rules, lint posture, no testify usage, no generated docs artifacts staged, and no dependency changes.
- Multi-agent review findings addressed: delayed unsupported `migration.dir` validation until the value is used, updated the dedicated site config reference, allowed parent-relative config paths, added forwarded/native adapter coverage, and rejected schema file URL query strings explicitly.

## Validation

- `env GOCACHE=/private/tmp/ptah-630-go-cache go test ./internal/atlasprojectpath ./config/projectconfig ./cmd/internal/dbcli ./cmd/atlas ./internal/schemafile ./internal/atlasargs`
- `env GOCACHE=/private/tmp/ptah-630-go-cache go test ./cmd/atlas -run 'TestNewAtlasCommand_(MigrateApplyResolvesProjectRelativeMigrationDir|MigrateStatusResolvesProjectRelativeMigrationDir|MigrateValidateResolvesProjectRelativeMigrationDir|MigrateHashResolvesProjectRelativeMigrationDir|MigrateNewResolvesProjectRelativeMigrationDir|MigrateDownResolvesProjectRelativeMigrationDir|MigrateStatusAllowsExplicitDirToOverrideUnsupportedProjectDir|MigrateStatusRejectsUnsupportedProjectDirWhenUsed|MigrateStatusAllowsParentRelativeProjectDir|SchemaApplyResolvesProjectRelativeSchemaSrc|SchemaDiffResolvesProjectRelativeSchemaSrc|MigrateDiffResolvesProjectRelativeDirAndSchemaSrc|ProjectRelativeSchemaSrcRejectsUnsupportedScheme|ProjectRelativeSchemaSrcRejectsQuery)' -count=1`
- `env GOCACHE=/private/tmp/ptah-630-go-cache go test ./internal/atlasprojectpath -count=1`
- `env GOCACHE=/private/tmp/ptah-630-go-cache go tool qtlint ./...`
- `env GOCACHE=/private/tmp/ptah-630-go-cache scripts/check-test-style.sh`
- `env GOCACHE=/private/tmp/ptah-630-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-630-golangci-cache golangci-lint run ./...`
- `env GOCACHE=/private/tmp/ptah-630-go-cache go test ./...`
- `npm ci` in `docs/site`
- `npm run build` in `docs/site`
- `npm run check:core-doc-links` in `docs/site`
- `npm run check:page-health` in `docs/site`
- `npm run check:links` in `docs/site`
- `git diff --check`
