### PR TITLE
Align Atlas report data shapes

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1332,6 +1332,36 @@ func TestNewAtlasCommand_MigrateStatusFormatRendersAtlasReport(t *testing.T) {
 	c.Assert(out.String(), qt.Equals, "PENDING|No migration applied yet|20260723120000|1|1|20260723120000_init.sql")
 }
 
+func TestNewAtlasCommand_MigrateStatusFormatRendersAppliedRevisionReport(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "status-applied-format.db")
+	writeAtlasApplyMigration(c, dir, "20260723120000_create_users.sql", "CREATE TABLE users (id integer primary key)")
+
+	apply := NewAtlasCommand()
+	var applyOut bytes.Buffer
+	apply.SetOut(&applyOut)
+	apply.SetErr(&applyOut)
+	apply.SetArgs([]string{"migrate", "apply", "--url", "sqlite://" + dbPath, "--dir", dir})
+	err := apply.Execute()
+	c.Assert(err, qt.IsNil)
+
+	status := NewAtlasCommand()
+	var statusOut bytes.Buffer
+	status.SetOut(&statusOut)
+	status.SetErr(&statusOut)
+	status.SetArgs([]string{
+		"migrate", "status",
+		"--url", "sqlite://" + dbPath,
+		"--dir", dir,
+		"--format", "{{ .Status }}|{{ len .Applied }}|{{ (index .Applied 0).Version }}|{{ (index .Applied 0).Description }}|{{ (index .Applied 0).Type }}|{{ (index .Applied 0).Applied }}|{{ (index .Applied 0).Total }}|{{ (index .Applied 0).OperatorVersion }}",
+	})
+	err = status.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statusOut.String(), qt.Equals, "OK|1|20260723120000|create_users|applied|1|1|Ptah")
+}
+
 func TestNewAtlasCommand_MigrateStatusUsesDefaultDirWithoutEnvWhenURLExplicit(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -2604,14 +2634,17 @@ CREATE TABLE format_json_posts (id INTEGER PRIMARY KEY);
 	var result atlasMigrateApplyJSONResult
 	c.Assert(json.Unmarshal(out.Bytes(), &result), qt.IsNil)
 	c.Assert(result.Driver, qt.Equals, "sqlite")
-	c.Assert(result.URL, qt.Equals, "sqlite://user@"+dbPath+"?password=xxxxx")
+	c.Assert(result.URL.Scheme, qt.Equals, "sqlite")
+	c.Assert(result.URL.Path, qt.Equals, dbPath)
+	c.Assert(result.URL.RawQuery, qt.Equals, "password=xxxxx")
+	c.Assert(result.URL.Schema, qt.Equals, "main")
 	c.Assert(result.Current, qt.Equals, "")
 	c.Assert(result.Target, qt.Equals, "1")
 	c.Assert(result.Message, qt.Equals, "Migrated to version 1 from  (1 migrations in total)")
 	c.Assert(result.Pending, qt.HasLen, 1)
 	c.Assert(result.Pending[0].Name, qt.Equals, "1_create_users.sql")
 	c.Assert(result.Pending[0].Version, qt.Equals, "1")
-	c.Assert(result.Pending[0].Description, qt.Equals, "Create Users")
+	c.Assert(result.Pending[0].Description, qt.Equals, "create_users")
 	c.Assert(result.Applied, qt.HasLen, 1)
 	c.Assert(result.Applied[0].Name, qt.Equals, "1_create_users.sql")
 	c.Assert(result.Applied[0].Applied, qt.DeepEquals, []string{
@@ -2748,6 +2781,7 @@ func TestNewAtlasCommand_MigrateApplyFormatsDryRunResult(t *testing.T) {
 	var result atlasMigrateApplyJSONResult
 	c.Assert(json.Unmarshal(out.Bytes(), &result), qt.IsNil)
 	c.Assert(result.Target, qt.Equals, "1")
+	c.Assert(result.Message, qt.Equals, "")
 	c.Assert(result.Pending, qt.HasLen, 1)
 	c.Assert(result.Applied, qt.HasLen, 0)
 	assertSQLiteTableMissing(c, dbPath, "format_dry_run")
@@ -4071,7 +4105,7 @@ func TestNewAtlasCommand_ProjectRelativeSchemaSrcRejectsQuery(t *testing.T) {
 
 type atlasMigrateApplyJSONResult struct {
 	Driver  string
-	URL     string
+	URL     atlasReportJSONURL
 	Pending []struct {
 		Name        string
 		Version     string
@@ -4089,6 +4123,18 @@ type atlasMigrateApplyJSONResult struct {
 	Target  string
 	Error   string
 	Message string
+}
+
+type atlasReportJSONURL struct {
+	Scheme   string
+	Opaque   string
+	User     map[string]any
+	Host     string
+	Path     string
+	Fragment string
+	RawQuery string
+	RawPath  string
+	Schema   string
 }
 
 type atlasSchemaInspectJSONResult struct {

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -120,11 +120,12 @@ func runAtlasMigrateStatus(cmd *cobra.Command, opts atlasMigrateStatusOptions) e
 	}
 	if formatOutput {
 		err := atlasreport.WriteMigrateStatusFormat(cmd.OutOrStdout(), opts.format, atlasreport.MigrateStatusOptions{
-			Driver: conn.Info().Dialect,
-			URL:    opts.url,
-			Dir:    atlasStatusDirURL(opts.dir),
-			FS:     os.DirFS(dir),
-			Status: result.Status,
+			Driver:           conn.Info().Dialect,
+			URL:              opts.url,
+			Dir:              atlasStatusDirURL(opts.dir),
+			FS:               os.DirFS(dir),
+			Status:           result.Status,
+			AppliedRevisions: result.AppliedRevisions,
 		})
 		if err != nil {
 			return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_clean_format_test.go
+++ b/cmd/atlas/schema_clean_format_test.go
@@ -38,7 +38,10 @@ func TestSchemaCleanFormatDryRunJSONDoesNotApply(t *testing.T) {
 	got := schemaCleanJSONReport{}
 	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
 	c.Assert(got.Env.Driver, qt.Equals, "sqlite")
-	c.Assert(got.Env.URL, qt.Equals, "sqlite://"+dbPath+"?password=xxxxx")
+	c.Assert(got.Env.URL.Scheme, qt.Equals, "sqlite")
+	c.Assert(got.Env.URL.Path, qt.Equals, dbPath)
+	c.Assert(got.Env.URL.RawQuery, qt.Equals, "password=xxxxx")
+	c.Assert(got.Env.URL.Schema, qt.Equals, "main")
 	c.Assert(got.DryRun, qt.Equals, true)
 	c.Assert(got.Applied, qt.Equals, false)
 	c.Assert(got.Objects, qt.DeepEquals, []schemaCleanJSONObject{{Type: "table", Name: "users"}})
@@ -250,12 +253,20 @@ func TestSchemaCleanUsesAtlasProjectEnvURLAndFormat(t *testing.T) {
 type schemaCleanJSONReport struct {
 	Env struct {
 		Driver string
-		URL    string
+		URL    schemaCleanJSONURL
 	}
 	DryRun  bool
 	Applied bool
 	Objects []schemaCleanJSONObject
 	Changes []schemaCleanJSONChange
+}
+
+type schemaCleanJSONURL struct {
+	Scheme   string
+	Host     string
+	Path     string
+	RawQuery string
+	Schema   string
 }
 
 type schemaCleanJSONObject struct {

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -382,6 +382,25 @@ and `.Files`, so Atlas-style templates such as `{{ json .Files }}` work for
 the supported local lint subset. Formatted output redacts credentials from URLs
 before rendering.
 
+Atlas-compatible format reports use the same data shape for `ptah atlas` and
+`ptah-compat`. URL fields render as redacted URL strings in Go templates such as
+`{{ .Env.URL }}`, but `{{ json . }}` emits an Atlas-like URL object with
+`Scheme`, `User`, `Host`, `Path`, `RawQuery`, `Fragment`, `RawPath`,
+`RawFragment`, `ForceQuery`, `OmitHost`, and, for SQLite URLs, `Schema`. Query
+keys that look like passwords, tokens, secrets, or API keys are replaced with
+`xxxxx`; URL userinfo passwords are removed.
+
+| Command | Format data fields |
+| --- | --- |
+| `ptah atlas schema inspect --format` | `.Realm`, `.Schema`, `.MarshalHCL`, `.MarshalSQL`, `.MarshalJSON`, plus `hcl`, `sql`, `json`, `base64url`, `mermaid`, `split`, and `write` template helpers. |
+| `ptah atlas schema apply --format` | `.Changes`, `.MarshalSQL`, plus the `sql` helper for the planned SQL statements. |
+| `ptah atlas schema clean --format` | `.Env.Driver`, `.Env.URL`, `.DryRun`, `.Applied`, `.Objects`, and `.Changes`. |
+| `ptah atlas schema diff --format` | `.Changes`, `.MarshalSQL`, plus the `sql` helper for generated migration SQL. |
+| `ptah atlas migrate apply --format` | `.Driver`, `.URL`, `.Dir`, `.Env`, `.Pending`, `.Applied`, `.Current`, `.Target`, `.Start`, `.End`, `.Error`, and JSON `.Message` for successful or no-op reports. `.Pending` and `.Applied` entries expose `.Name`, `.Version`, `.Description`; applied entries also expose `.Applied`, `.Skipped`, `.Checks`, and statement `.Error`. |
+| `ptah atlas migrate diff --format` | `.Changes`, `.MarshalSQL`, plus the `sql` helper for generated migration SQL. |
+| `ptah atlas migrate lint --format` | `.Env.Driver`, `.Env.URL`, `.Env.Dir`, `.Steps`, and `.Files`. Step entries expose `.Name`, `.Text`, `.Error`, and `.Result`; file entries expose `.Name`, `.Text`, `.Error`, and `.Findings`. |
+| `ptah atlas migrate status --format` | `.Env.Driver`, `.Env.URL`, `.Env.Dir`, `.Available`, `.Applied`, `.Pending`, `.Current`, `.Next`, and `.Status`. Available and pending migration file entries expose `.Name`, `.Version`, and `.Description`. Applied revision entries expose `.Version`, `.Description`, `.Type`, `.Applied`, `.Total`, `.ExecutedAt`, `.ExecutionTime`, `.Error`, `.ErrorStmt`, and `.OperatorVersion`. |
+
 For existing scripts that already call `atlas`, install or copy the
 `ptah-compat` drop-in replacement under that executable name:
 

--- a/internal/atlasmigrate/status.go
+++ b/internal/atlasmigrate/status.go
@@ -16,7 +16,8 @@ type StatusOptions struct {
 }
 
 type StatusResult struct {
-	Status *migrator.MigrationStatus
+	Status           *migrator.MigrationStatus
+	AppliedRevisions []migrator.MigrationRevision
 }
 
 func Status(ctx context.Context, conn *dbschema.DatabaseConnection, opts StatusOptions) (StatusResult, error) {
@@ -41,5 +42,12 @@ func Status(ctx context.Context, conn *dbschema.DatabaseConnection, opts StatusO
 	if err != nil {
 		return StatusResult{}, fmt.Errorf("error getting migration status: %w", err)
 	}
-	return StatusResult{Status: status}, nil
+	appliedRevisions, err := mig.GetAppliedRevisions(ctx)
+	if err != nil {
+		return StatusResult{}, fmt.Errorf("error getting applied migration revisions: %w", err)
+	}
+	return StatusResult{
+		Status:           status,
+		AppliedRevisions: appliedRevisions,
+	}, nil
 }

--- a/internal/atlasreport/common.go
+++ b/internal/atlasreport/common.go
@@ -2,19 +2,33 @@ package atlasreport
 
 import (
 	"net/url"
+	"path"
 	"strings"
 )
 
 type atlasEnv struct {
-	Driver string `json:"Driver,omitempty"`
-	URL    string `json:"URL,omitempty"`
-	Dir    string `json:"Dir,omitempty"`
+	Driver string           `json:"Driver,omitempty"`
+	URL    atlasTemplateURL `json:"URL,omitzero"`
+	Dir    string           `json:"Dir,omitempty"`
 }
 
-func atlasRedactedURL(raw string) string {
+type atlasTemplateURL struct {
+	url.URL
+	Schema string `json:"Schema,omitempty"`
+}
+
+func (u atlasTemplateURL) String() string {
+	return u.URL.String()
+}
+
+func (u atlasTemplateURL) IsZero() bool {
+	return u.URL.String() == "" && u.Schema == ""
+}
+
+func atlasRedactedURL(raw string) atlasTemplateURL {
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return ""
+		return atlasTemplateURL{}
 	}
 	if parsed.User != nil {
 		username := parsed.User.Username()
@@ -31,7 +45,11 @@ func atlasRedactedURL(raw string) string {
 		}
 	}
 	parsed.RawQuery = query.Encode()
-	return parsed.String()
+	result := atlasTemplateURL{URL: *parsed}
+	if parsed.Scheme == "sqlite" {
+		result.Schema = "main"
+	}
+	return result
 }
 
 func isAtlasSensitiveQueryKey(key string) bool {
@@ -47,4 +65,15 @@ func isAtlasSensitiveQueryKey(key string) bool {
 			strings.Contains(compact, "secret") ||
 			strings.Contains(compact, "apikey")
 	}
+}
+
+func atlasMigrationFileDescription(fileName string) string {
+	stem := strings.TrimSuffix(path.Base(fileName), ".sql")
+	stem = strings.TrimSuffix(stem, ".up")
+	stem = strings.TrimSuffix(stem, ".down")
+	_, description, ok := strings.Cut(stem, "_")
+	if !ok {
+		return ""
+	}
+	return description
 }

--- a/internal/atlasreport/migrate_apply.go
+++ b/internal/atlasreport/migrate_apply.go
@@ -38,9 +38,9 @@ type MigrateApplyResultOptions struct {
 }
 
 type atlasMigrateApplyEnv struct {
-	Driver string `json:"Driver,omitempty"`
-	URL    string `json:"URL,omitempty"`
-	Dir    string `json:"Dir,omitempty"`
+	Driver string           `json:"Driver,omitempty"`
+	URL    atlasTemplateURL `json:"URL,omitzero"`
+	Dir    string           `json:"Dir,omitempty"`
 }
 
 type atlasMigrateApplyResult struct {
@@ -161,7 +161,7 @@ func atlasMigrateApplyFilesByVersion(fsys fs.FS) (map[int64]atlasMigrateApplyFil
 		files[file.Version] = atlasMigrateApplyFile{
 			Name:        file.Path,
 			Version:     atlasMigrateApplyVersionString(file.Version),
-			Description: file.Name,
+			Description: atlasMigrationFileDescription(file.Path),
 		}
 	}
 	return files, nil
@@ -357,8 +357,9 @@ func (r atlasMigrateApplyResult) MarshalJSON() ([]byte, error) {
 	}
 	switch {
 	case r.Error != "":
-	case len(r.Applied) == 0:
+	case len(r.Applied) == 0 && len(r.Pending) == 0:
 		value.Message = "No migration files to execute"
+	case len(r.Applied) == 0:
 	default:
 		value.Message = fmt.Sprintf(
 			"Migrated to version %s from %s (%d migrations in total)",
@@ -375,11 +376,12 @@ func (f *atlasMigrateApplyAppliedFile) MarshalJSON() ([]byte, error) {
 		Name        string                           `json:"Name,omitempty"`
 		Version     string                           `json:"Version,omitempty"`
 		Description string                           `json:"Description,omitempty"`
-		Start       time.Time                        `json:"Start,omitzero"`
-		End         time.Time                        `json:"End,omitzero"`
-		Skipped     int                              `json:"Skipped,omitempty"`
-		Applied     []string                         `json:"Applied,omitempty"`
-		Error       *atlasMigrateApplyStatementError `json:"Error,omitempty"`
+		Start       time.Time                        `json:"Start"`
+		End         time.Time                        `json:"End"`
+		Skipped     int                              `json:"Skipped"`
+		Applied     []string                         `json:"Applied"`
+		Checks      []*atlasMigrateApplyFileChecks   `json:"Checks"`
+		Error       *atlasMigrateApplyStatementError `json:"Error"`
 	}
 	return json.Marshal(appliedFile{
 		Name:        f.Name,
@@ -389,6 +391,7 @@ func (f *atlasMigrateApplyAppliedFile) MarshalJSON() ([]byte, error) {
 		End:         f.End,
 		Skipped:     f.Skipped,
 		Applied:     f.Applied,
+		Checks:      f.Checks,
 		Error:       f.Error,
 	})
 }

--- a/internal/atlasreport/migrate_apply_test.go
+++ b/internal/atlasreport/migrate_apply_test.go
@@ -3,6 +3,8 @@ package atlasreport_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -89,6 +91,129 @@ func TestWriteMigrateApplyFormat_JSONNoopMessage(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, `"Message":"No migration files to execute"`)
 	c.Assert(out.String(), qt.Contains, `"Driver":"sqlite"`)
+}
+
+func TestWriteMigrateApplyFormat_JSONShape(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "shape.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	fsys := fstest.MapFS{
+		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);")},
+		"2_add_email.sql":    {Data: []byte("ALTER TABLE users ADD COLUMN email TEXT;")},
+	}
+	var out bytes.Buffer
+	startedAt := time.Unix(100, 0).UTC()
+	endedAt := time.Unix(101, 0).UTC()
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn: conn,
+			FS:   fsys,
+			Dir:  "file://migrations",
+			URL:  "sqlite://user:secret@" + dbPath + "?password=hidden&token=private",
+			Status: &migrator.MigrationStatus{
+				CurrentVersion:    0,
+				PendingMigrations: []int64{1, 2},
+			},
+			Migrations: []*migrator.Migration{
+				{
+					Version: 1,
+					UpSQL:   "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+				},
+				{
+					Version: 2,
+					UpSQL:   "ALTER TABLE users ADD COLUMN email TEXT;",
+				},
+			},
+			SelectedVersions: []int64{1},
+			Applied:          true,
+			StartedAt:        startedAt,
+			EndedAt:          endedAt,
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	var got migrateApplyJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
+	c.Assert(got.Driver, qt.Equals, "sqlite")
+	c.Assert(got.URL.Scheme, qt.Equals, "sqlite")
+	c.Assert(got.URL.Path, qt.Equals, dbPath)
+	c.Assert(got.URL.RawQuery, qt.Equals, "password=xxxxx&token=xxxxx")
+	c.Assert(got.URL.Schema, qt.Equals, "main")
+	c.Assert(got.Dir, qt.Equals, "file://migrations")
+	c.Assert(got.Pending, qt.DeepEquals, []migrateApplyJSONFile{
+		{Name: "1_create_users.sql", Version: "1", Description: "create_users"},
+	})
+	c.Assert(got.Applied, qt.HasLen, 1)
+	c.Assert(got.Applied[0].Name, qt.Equals, "1_create_users.sql")
+	c.Assert(got.Applied[0].Version, qt.Equals, "1")
+	c.Assert(got.Applied[0].Description, qt.Equals, "create_users")
+	c.Assert(got.Applied[0].Skipped, qt.Equals, 0)
+	c.Assert(got.Applied[0].Applied, qt.DeepEquals, []string{"CREATE TABLE users (id INTEGER PRIMARY KEY)"})
+	c.Assert(got.Applied[0].Checks, qt.IsNil)
+	c.Assert(got.Applied[0].Error, qt.IsNil)
+	c.Assert(got.Current, qt.Equals, "")
+	c.Assert(got.Target, qt.Equals, "1")
+	c.Assert(got.Message, qt.Equals, "Migrated to version 1 from  (1 migrations in total)")
+}
+
+func TestWriteMigrateApplyFormat_JSONErrorShape(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "error-shape.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	fsys := fstest.MapFS{
+		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);")},
+	}
+	var out bytes.Buffer
+	applyErr := &migrator.MigrationExecutionError{
+		Err:            errors.New("migration failed"),
+		Statement:      "CREATE TABLE users (id INTEGER PRIMARY KEY)",
+		StatementIndex: 0,
+		Total:          1,
+	}
+
+	err = atlasreport.WriteMigrateApplyFormat(
+		&out,
+		`{{ json . }}`,
+		atlasreport.MigrateApplyResultOptions{
+			Conn: conn,
+			FS:   fsys,
+			Dir:  "file://migrations",
+			URL:  "sqlite://" + dbPath,
+			Status: &migrator.MigrationStatus{
+				CurrentVersion:    0,
+				PendingMigrations: []int64{1},
+			},
+			Migrations: []*migrator.Migration{
+				{
+					Version: 1,
+					UpSQL:   "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+				},
+			},
+			SelectedVersions: []int64{1},
+			ErrorText:        "failed to apply migration 1: migration failed",
+			ApplyError:       applyErr,
+			Applied:          true,
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	var got migrateApplyJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
+	c.Assert(got.Error, qt.Equals, "failed to apply migration 1: migration failed")
+	c.Assert(got.Applied, qt.HasLen, 1)
+	c.Assert(got.Applied[0].Error, qt.IsNotNil)
+	c.Assert(got.Applied[0].Error.Stmt, qt.Equals, "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(got.Applied[0].Error.Text, qt.Equals, "migration failed")
+	c.Assert(got.Message, qt.Equals, "")
 }
 
 func TestWriteMigrateApplyFormat_RedactsSensitiveURL(t *testing.T) {
@@ -184,4 +309,45 @@ func TestWriteMigrateApplyFormat_RequiresStatusOrCurrentVersion(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `migrate apply format requires migration status or current version`)
 	c.Assert(out.String(), qt.Equals, "")
+}
+
+type migrateApplyJSONReport struct {
+	Driver  string
+	URL     atlasReportJSONURL
+	Dir     string
+	Pending []migrateApplyJSONFile
+	Applied []migrateApplyJSONAppliedFile
+	Current string
+	Target  string
+	Error   string
+	Message string
+}
+
+type migrateApplyJSONFile struct {
+	Name        string
+	Version     string
+	Description string
+}
+
+type migrateApplyJSONAppliedFile struct {
+	Name        string
+	Version     string
+	Description string
+	Skipped     int
+	Applied     []string
+	Checks      []any
+	Error       *migrateApplyJSONError
+}
+
+type migrateApplyJSONError struct {
+	Stmt string
+	Text string
+}
+
+type atlasReportJSONURL struct {
+	Scheme   string
+	Host     string
+	Path     string
+	RawQuery string
+	Schema   string
 }

--- a/internal/atlasreport/migrate_status.go
+++ b/internal/atlasreport/migrate_status.go
@@ -6,26 +6,32 @@ import (
 	"io/fs"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
 type MigrateStatusOptions struct {
-	Driver string
-	URL    string
-	Dir    string
-	FS     fs.FS
-	Status *migrator.MigrationStatus
+	Driver           string
+	URL              string
+	Dir              string
+	FS               fs.FS
+	Status           *migrator.MigrationStatus
+	AppliedRevisions []migrator.MigrationRevision
 }
 
 type MigrateStatus struct {
-	Env       atlasEnv            `json:"Env"`
-	Available []MigrateStatusFile `json:"Available,omitempty"`
-	Applied   []MigrateStatusFile `json:"Applied,omitempty"`
-	Pending   []MigrateStatusFile `json:"Pending,omitempty"`
-	Current   string              `json:"Current,omitempty"`
-	Next      string              `json:"Next,omitempty"`
-	Status    string              `json:"Status,omitempty"`
+	Env       atlasEnv                `json:"Env"`
+	Available []MigrateStatusFile     `json:"Available,omitempty"`
+	Applied   []MigrateStatusRevision `json:"Applied,omitempty"`
+	Pending   []MigrateStatusFile     `json:"Pending,omitempty"`
+	Current   string                  `json:"Current,omitempty"`
+	Next      string                  `json:"Next,omitempty"`
+	Status    string                  `json:"Status,omitempty"`
+	Count     int                     `json:"Count,omitempty"`
+	Total     int                     `json:"Total,omitempty"`
+	Error     string                  `json:"Error,omitempty"`
+	SQL       string                  `json:"SQL,omitempty"`
 }
 
 type MigrateStatusFile struct {
@@ -33,6 +39,19 @@ type MigrateStatusFile struct {
 	Version     string `json:"Version,omitempty"`
 	Description string `json:"Description,omitempty"`
 	Type        string `json:"Type,omitempty"`
+}
+
+type MigrateStatusRevision struct {
+	Version         string        `json:"Version,omitempty"`
+	Description     string        `json:"Description,omitempty"`
+	Type            string        `json:"Type,omitempty"`
+	Applied         int           `json:"Applied"`
+	Total           int           `json:"Total"`
+	ExecutedAt      time.Time     `json:"ExecutedAt,omitzero"`
+	ExecutionTime   time.Duration `json:"ExecutionTime"`
+	Error           string        `json:"Error,omitempty"`
+	ErrorStmt       string        `json:"ErrorStmt,omitempty"`
+	OperatorVersion string        `json:"OperatorVersion,omitempty"`
 }
 
 func WriteMigrateStatusFormat(w io.Writer, format string, opts MigrateStatusOptions) error {
@@ -62,13 +81,49 @@ func NewMigrateStatus(opts MigrateStatusOptions) (MigrateStatus, error) {
 			Dir:    opts.Dir,
 		},
 		Available: files,
-		Applied:   selectedMigrateStatusFiles(files, opts.Status.AppliedMigrations, "applied"),
+		Applied:   migrateStatusAppliedRevisions(files, opts.AppliedRevisions),
 		Pending:   selectedMigrateStatusFiles(files, opts.Status.PendingMigrations, ""),
 		Current:   migrateStatusCurrent(opts.Status.CurrentVersion),
 		Next:      migrateStatusNext(opts.Status.PendingMigrations),
 		Status:    migrateStatusLabel(opts.Status),
 	}
 	return result, nil
+}
+
+func migrateStatusAppliedRevisions(
+	files []MigrateStatusFile,
+	revisions []migrator.MigrationRevision,
+) []MigrateStatusRevision {
+	out := make([]MigrateStatusRevision, 0, len(revisions))
+	descriptions := migrateStatusFileDescriptions(files)
+	for _, revision := range revisions {
+		version := strconv.FormatInt(revision.Version, 10)
+		description := descriptions[revision.Version]
+		if description == "" {
+			description = revision.Description
+		}
+		out = append(out, MigrateStatusRevision{
+			Version:         version,
+			Description:     description,
+			Type:            "applied",
+			Applied:         revision.Applied,
+			Total:           revision.Total,
+			ExecutedAt:      revision.AppliedAt,
+			ExecutionTime:   revision.ExecutionTime,
+			Error:           revision.Error,
+			ErrorStmt:       revision.ErrorStatement,
+			OperatorVersion: revision.OperatorVersion,
+		})
+	}
+	return out
+}
+
+func migrateStatusFileDescriptions(files []MigrateStatusFile) map[int64]string {
+	descriptions := make(map[int64]string, len(files))
+	for _, file := range files {
+		descriptions[migrateStatusFileVersion(file)] = file.Description
+	}
+	return descriptions
 }
 
 func migrateStatusFiles(fsys fs.FS) ([]MigrateStatusFile, error) {
@@ -84,7 +139,7 @@ func migrateStatusFiles(fsys fs.FS) ([]MigrateStatusFile, error) {
 		files = append(files, MigrateStatusFile{
 			Name:        file.Path,
 			Version:     strconv.FormatInt(file.Version, 10),
-			Description: file.Name,
+			Description: atlasMigrationFileDescription(file.Path),
 		})
 	}
 	return files, nil

--- a/internal/atlasreport/migrate_status_test.go
+++ b/internal/atlasreport/migrate_status_test.go
@@ -2,8 +2,10 @@ package atlasreport_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -34,10 +36,30 @@ func TestWriteMigrateStatusFormat_CustomTemplate(t *testing.T) {
 				TotalMigrations:   2,
 				HasPendingChanges: true,
 			},
+			AppliedRevisions: []migrator.MigrationRevision{
+				{Version: 1, Description: "Create Users", Applied: 1, Total: 1},
+			},
 		})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "PENDING|1|2|2|1|1|2_add_email.sql")
+}
+
+func TestWriteMigrateStatusFormat_ExposesAtlasZeroValueFields(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+
+	err := atlasreport.WriteMigrateStatusFormat(&out,
+		`{{ .Count }}|{{ .Total }}|{{ .Error }}|{{ .SQL }}`,
+		atlasreport.MigrateStatusOptions{
+			FS: fstest.MapFS{},
+			Status: &migrator.MigrationStatus{
+				CurrentVersion: 1,
+			},
+		})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "0|0||")
 }
 
 func TestWriteMigrateStatusFormat_RedactsSensitiveURL(t *testing.T) {
@@ -62,6 +84,99 @@ func TestWriteMigrateStatusFormat_RedactsSensitiveURL(t *testing.T) {
 	c.Assert(out.String(), qt.Equals, "postgres://app@db.local/app?access_token=xxxxx&api_key=xxxxx&auth-token=xxxxx&client_secret=xxxxx&sslmode=disable&token=xxxxx")
 }
 
+func TestWriteMigrateStatusFormat_JSONShape(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id integer);")},
+		"2_add_email.sql":    {Data: []byte("ALTER TABLE users ADD COLUMN email text;")},
+	}
+	var out bytes.Buffer
+
+	err := atlasreport.WriteMigrateStatusFormat(&out, `{{ json . }}`, atlasreport.MigrateStatusOptions{
+		Driver: "sqlite",
+		URL:    "sqlite://user:secret@db.sqlite?password=hidden&token=private",
+		Dir:    "file://migrations?format=atlas",
+		FS:     fsys,
+		Status: &migrator.MigrationStatus{
+			CurrentVersion:    1,
+			AppliedMigrations: []int64{1},
+			PendingMigrations: []int64{2},
+			TotalMigrations:   2,
+			HasPendingChanges: true,
+		},
+		AppliedRevisions: []migrator.MigrationRevision{
+			{
+				Version:         1,
+				Description:     "Create Users",
+				Applied:         1,
+				Total:           1,
+				AppliedAt:       time.Unix(100, 0).UTC(),
+				ExecutionTime:   50 * time.Millisecond,
+				OperatorVersion: "Ptah",
+			},
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	var got migrateStatusJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
+	c.Assert(got.Env.Driver, qt.Equals, "sqlite")
+	c.Assert(got.Env.URL.Scheme, qt.Equals, "sqlite")
+	c.Assert(got.Env.URL.Host, qt.Equals, "db.sqlite")
+	c.Assert(got.Env.URL.RawQuery, qt.Equals, "password=xxxxx&token=xxxxx")
+	c.Assert(got.Env.URL.Schema, qt.Equals, "main")
+	c.Assert(got.Env.Dir, qt.Equals, "file://migrations?format=atlas")
+	c.Assert(got.Available, qt.DeepEquals, []migrateStatusJSONFile{
+		{Name: "1_create_users.sql", Version: "1", Description: "create_users"},
+		{Name: "2_add_email.sql", Version: "2", Description: "add_email"},
+	})
+	c.Assert(got.Applied, qt.DeepEquals, []migrateStatusJSONRevision{
+		{
+			Version:         "1",
+			Description:     "create_users",
+			Type:            "applied",
+			Applied:         1,
+			Total:           1,
+			ExecutedAt:      time.Unix(100, 0).UTC(),
+			ExecutionTime:   50 * time.Millisecond,
+			OperatorVersion: "Ptah",
+		},
+	})
+	c.Assert(got.Pending, qt.DeepEquals, []migrateStatusJSONFile{
+		{Name: "2_add_email.sql", Version: "2", Description: "add_email"},
+	})
+	c.Assert(got.Current, qt.Equals, "1")
+	c.Assert(got.Next, qt.Equals, "2")
+	c.Assert(got.Status, qt.Equals, "PENDING")
+}
+
+func TestWriteMigrateStatusFormat_OmitsDescriptionForVersionOnlyFile(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"1.sql": {Data: []byte("CREATE TABLE users (id integer);")},
+	}
+	var out bytes.Buffer
+
+	err := atlasreport.WriteMigrateStatusFormat(&out, `{{ json . }}`, atlasreport.MigrateStatusOptions{
+		FS: fsys,
+		Status: &migrator.MigrationStatus{
+			PendingMigrations: []int64{1},
+			TotalMigrations:   1,
+			HasPendingChanges: true,
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	var got migrateStatusJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
+	c.Assert(got.Available, qt.DeepEquals, []migrateStatusJSONFile{
+		{Name: "1.sql", Version: "1"},
+	})
+	c.Assert(got.Pending, qt.DeepEquals, []migrateStatusJSONFile{
+		{Name: "1.sql", Version: "1"},
+	})
+}
+
 func TestWriteMigrateStatusFormat_RejectsInvalidTemplate(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
@@ -75,4 +190,38 @@ func TestWriteMigrateStatusFormat_RejectsInvalidTemplate(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `parse --format template: .*`)
 	c.Assert(out.String(), qt.Equals, "")
+}
+
+type migrateStatusJSONReport struct {
+	Env struct {
+		Driver string
+		URL    atlasReportJSONURL
+		Dir    string
+	}
+	Available []migrateStatusJSONFile
+	Applied   []migrateStatusJSONRevision
+	Pending   []migrateStatusJSONFile
+	Current   string
+	Next      string
+	Status    string
+}
+
+type migrateStatusJSONRevision struct {
+	Version         string
+	Description     string
+	Type            string
+	Applied         int
+	Total           int
+	ExecutedAt      time.Time
+	ExecutionTime   time.Duration
+	Error           string
+	ErrorStmt       string
+	OperatorVersion string
+}
+
+type migrateStatusJSONFile struct {
+	Name        string
+	Version     string
+	Description string
+	Type        string
 }

--- a/internal/atlasreport/schema_clean_test.go
+++ b/internal/atlasreport/schema_clean_test.go
@@ -29,7 +29,12 @@ func TestSchemaCleanFormatRendersJSONWithRedactedURL(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	got := map[string]any{}
 	c.Assert(json.Unmarshal(out.Bytes(), &got), qt.IsNil)
-	c.Assert(got["Env"].(map[string]any)["URL"], qt.Equals, "sqlite://user@db.sqlite?password=xxxxx&token=xxxxx")
+	gotURL := got["Env"].(map[string]any)["URL"].(map[string]any)
+	c.Assert(gotURL["Scheme"], qt.Equals, "sqlite")
+	c.Assert(gotURL["User"], qt.DeepEquals, map[string]any{})
+	c.Assert(gotURL["Host"], qt.Equals, "db.sqlite")
+	c.Assert(gotURL["RawQuery"], qt.Equals, "password=xxxxx&token=xxxxx")
+	c.Assert(gotURL["Schema"], qt.Equals, "main")
 	c.Assert(got["DryRun"], qt.Equals, true)
 	c.Assert(got["Applied"], qt.Equals, false)
 	c.Assert(got["Changes"].([]any)[0].(map[string]any)["Cmd"], qt.Equals, `DROP TABLE IF EXISTS "users"`)
@@ -49,6 +54,20 @@ func TestSchemaCleanFormatRendersCustomTemplate(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, `sqlite|1|DROP TABLE IF EXISTS "users"`)
+}
+
+func TestSchemaCleanFormatRendersURLAsStringInCustomTemplate(t *testing.T) {
+	c := qt.New(t)
+	report := atlasreport.NewSchemaClean(atlasreport.SchemaCleanOptions{
+		Driver: "sqlite",
+		URL:    "sqlite://user:secret@db.sqlite?password=hidden&token=private",
+	})
+
+	var out bytes.Buffer
+	err := atlasreport.WriteSchemaClean(&out, "{{ .Env.URL }}", report)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "sqlite://user@db.sqlite?password=xxxxx&token=xxxxx")
 }
 
 func TestSchemaCleanFormatRejectsInvalidTemplate(t *testing.T) {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -612,35 +612,65 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int64, error) {
 
 // GetAppliedMigrations returns a list of applied migration versions
 func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error) {
-	// First ensure the migrations table exists
+	return queryMigrationRows(
+		ctx,
+		m,
+		m.getAppliedMigrationsSQL(),
+		m.scanAppliedVersion,
+		"failed to query applied migrations",
+		"failed to scan migration version",
+		"error iterating migration rows",
+	)
+}
+
+// GetAppliedRevisions returns full metadata rows for applied migrations.
+func (m *Migrator) GetAppliedRevisions(ctx context.Context) ([]MigrationRevision, error) {
+	return queryMigrationRows(
+		ctx,
+		m,
+		m.getAppliedRevisionsSQL(),
+		m.scanRevisionRow,
+		"failed to query applied migration revisions",
+		"failed to scan migration revision",
+		"error iterating migration revision rows",
+	)
+}
+
+func queryMigrationRows[T any](
+	ctx context.Context,
+	m *Migrator,
+	query string,
+	scan func(rowScanner) (T, error),
+	queryErr string,
+	scanErr string,
+	iterErr string,
+) ([]T, error) {
 	if err := m.Initialize(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
 	if m.conn.Writer().IsDryRun() {
-		return []int64{}, nil
+		return []T{}, nil
 	}
 
-	// Query all applied migration versions
-	rows, err := m.conn.QueryContext(ctx, m.getAppliedMigrationsSQL())
+	rows, err := m.conn.QueryContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query applied migrations: %w", err)
+		return nil, fmt.Errorf("%s: %w", queryErr, err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	applied := make([]int64, 0)
+	items := make([]T, 0)
 	for rows.Next() {
-		version, err := m.scanAppliedVersion(rows)
+		item, err := scan(rows)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan migration version: %w", err)
+			return nil, fmt.Errorf("%s: %w", scanErr, err)
 		}
-		applied = append(applied, version)
+		items = append(items, item)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating migration rows: %w", err)
+		return nil, fmt.Errorf("%s: %w", iterErr, err)
 	}
-
-	return applied, nil
+	return items, nil
 }
 
 func (m *Migrator) scanCurrentVersion(ctx context.Context) (int64, error) {

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -35,6 +35,7 @@ type MigrationRevision struct {
 	ExecutionTime   time.Duration `json:"execution_time"`
 	Checksum        string        `json:"checksum,omitempty"`
 	AppliedAt       time.Time     `json:"applied_at"`
+	OperatorVersion string        `json:"operator_version,omitempty"`
 	Dirty           bool          `json:"dirty"`
 	ChecksumCurrent string        `json:"checksum_current,omitempty"`
 }
@@ -138,12 +139,12 @@ func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMod
 func (m *Migrator) getDirtyRevisionSQL() string {
 	if m.revisionTableFormat.isAtlas() {
 		if m.isSQLServer() {
-			return fmt.Sprintf(`SELECT TOP (1) version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at
+			return fmt.Sprintf(`SELECT TOP (1) version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at, COALESCE(operator_version, '')
 FROM %s
 WHERE applied <> total OR COALESCE(error, '') <> ''
 ORDER BY %s`, m.qualifiedMigrationsTable(), m.atlasVersionNumberExpression())
 		}
-		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at
+		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at, COALESCE(operator_version, '')
 FROM %s
 WHERE applied <> total OR COALESCE(error, '') <> ''
 ORDER BY %s
@@ -164,13 +165,30 @@ LIMIT 1`, m.qualifiedMigrationsTable())
 
 func (m *Migrator) getRevisionSQL() string {
 	if m.revisionTableFormat.isAtlas() {
-		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at
+		return fmt.Sprintf(`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at, COALESCE(operator_version, '')
 FROM %s
 WHERE version = ?`, m.qualifiedMigrationsTable())
 	}
 	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
 FROM %s
 WHERE version = ?`, m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) getAppliedRevisionsSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return fmt.Sprintf(
+			`SELECT version, description, type, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time, hash, executed_at, COALESCE(operator_version, '')
+FROM %s
+WHERE applied = total AND COALESCE(error, '') = ''
+ORDER BY %s`,
+			m.qualifiedMigrationsTable(),
+			m.atlasVersionNumberExpression(),
+		)
+	}
+	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+FROM %s
+WHERE state = 'applied'
+ORDER BY version`, m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) beginMigrationSQL() string {
@@ -408,7 +426,7 @@ func (m *Migrator) getRevision(ctx context.Context, version int64) (*MigrationRe
 	return &revision, nil
 }
 
-func (m *Migrator) scanRevisionRow(row *sql.Row) (MigrationRevision, error) {
+func (m *Migrator) scanRevisionRow(row rowScanner) (MigrationRevision, error) {
 	if m.revisionTableFormat.isAtlas() {
 		return m.scanAtlasRevisionRow(row)
 	}
@@ -438,7 +456,7 @@ func (m *Migrator) scanRevisionRow(row *sql.Row) (MigrationRevision, error) {
 	return revision, nil
 }
 
-func (m *Migrator) scanAtlasRevisionRow(row *sql.Row) (MigrationRevision, error) {
+func (m *Migrator) scanAtlasRevisionRow(row rowScanner) (MigrationRevision, error) {
 	var revision MigrationRevision
 	var version string
 	var revisionType int
@@ -455,6 +473,7 @@ func (m *Migrator) scanAtlasRevisionRow(row *sql.Row) (MigrationRevision, error)
 		&executionTime,
 		&revision.Checksum,
 		&executedAt,
+		&revision.OperatorVersion,
 	); err != nil {
 		return MigrationRevision{}, err
 	}


### PR DESCRIPTION
## Summary
- Align Atlas-compatible report URL fields with Atlas-style JSON object output while preserving redacted string rendering in Go templates.
- Align Atlas migration file descriptions in report output with raw filename descriptions, including omitting Description for version-only files.
- Expose Atlas migrate status applied revisions with Applied/Total/ExecutedAt/ExecutionTime/Error/ErrorStmt/OperatorVersion fields, and keep Atlas zero-value status fields available to templates.
- Fix migrate apply dry-run JSON so pending dry-runs do not claim "No migration files to execute"; keep applied-file JSON fields such as Skipped, Checks, and Error visible with Atlas-like null/zero behavior.
- Document supported Atlas-compatible report data fields.

## Self-review
- Pass 1: checked Atlas v1.2.0 CLI JSON for migrate status/apply against Ptah output; found and fixed URL object shape, filename Description semantics, and version-only Description omission.
- Pass 2: sidecar review found applied status revision shape, dry-run apply Message, and applied-file JSON omissions; all three were fixed and covered with tests.
- Additional parity check: Atlas templates expose `.Count`, `.Total`, `.Error`, and `.SQL` on migrate status even when JSON omits them; Ptah now exposes the same zero-value fields.

## Verification
- `GOCACHE=/private/tmp/ptah-631-go-cache go test ./migration/migrator ./internal/atlasmigrate ./internal/atlasreport ./cmd/atlas -count=1`
- `GOCACHE=/private/tmp/ptah-631-go-cache go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `GOCACHE=/private/tmp/ptah-631-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-631-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-631-go-cache go test ./...`
- `npm run check:exit-codes`
- `npm run check:page-health`
- `npm run versions:selftest`
- `npm run check:core-doc-links`
- `npm run check:links`
- `npm run build`
- `git diff --check`

Fixes #631