### PR TITLE
Fix SQLite schema round-trip drift

### DIFF
--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -487,7 +487,11 @@ func renderConstraint(constraint *ast.ConstraintNode) (string, error) {
 }
 
 func renderInlineForeignKey(ref *ast.ForeignKeyRef) string {
-	return "REFERENCES " + escapeQualifiedIdentifier(ref.Table) + " (" +
+	prefix := ""
+	if ref.Name != "" {
+		prefix = "CONSTRAINT " + escapeIdentifier(ref.Name) + " "
+	}
+	return prefix + "REFERENCES " + escapeQualifiedIdentifier(ref.Table) + " (" +
 		strings.Join(escapeIdentifierList(ref.ReferencedColumns()), ", ") + ")" +
 		renderReferentialActions(ref)
 }

--- a/core/renderer/internal/dialects/sqlite/sqlite_test.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite_test.go
@@ -51,6 +51,25 @@ func TestRenderCreateTableWithStrictAndWithoutRowID(t *testing.T) {
 `)
 }
 
+func TestRenderColumnForeignKeyPreservesConstraintName(t *testing.T) {
+	c := qt.New(t)
+
+	table := ast.NewCreateTable("projects").
+		AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary()).
+		AddColumn(ast.NewColumn("organization_id", "INTEGER").
+			SetForeignKey("organizations", "id", "fk_projects_organization"))
+	table.Columns[1].ForeignKey.OnDelete = "CASCADE"
+
+	sql, err := renderer.RenderSQL("sqlite", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `CREATE TABLE "projects" (
+  "id" INTEGER PRIMARY KEY,
+  "organization_id" INTEGER CONSTRAINT "fk_projects_organization" REFERENCES "organizations" ("id") ON DELETE CASCADE
+);
+`)
+}
+
 func TestRenderIndexes(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dbschema/sqlite/sqlite_test.go
+++ b/internal/dbschema/sqlite/sqlite_test.go
@@ -56,6 +56,10 @@ func TestReaderReadSchema(t *testing.T) {
 		status TEXT CHECK (status IN ('active', 'disabled')),
 		CONSTRAINT fk_users_account_id FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE
 	) STRICT`)
+	execSQL(t, db, `CREATE TABLE invoices (
+		id INTEGER PRIMARY KEY,
+		account_id INTEGER CONSTRAINT fk_invoices_account REFERENCES accounts(id) ON DELETE SET NULL
+	)`)
 	execSQL(t, db, `CREATE UNIQUE INDEX idx_users_email_active ON users(email) WHERE status = 'active'`)
 	execSQL(t, db, `CREATE INDEX idx_users_note_where ON users(note) WHERE note = 'contains WHERE token' AND status = 'active'`)
 	execSQL(t, db, `CREATE VIEW active_users AS SELECT id, email FROM users WHERE status = 'active'`)
@@ -66,7 +70,7 @@ func TestReaderReadSchema(t *testing.T) {
 
 	schema, err := sqlite.NewSQLiteReader(db, "main").ReadSchema()
 	c.Assert(err, qt.IsNil)
-	c.Assert(schema.Tables, qt.HasLen, 2)
+	c.Assert(schema.Tables, qt.HasLen, 3)
 	c.Assert(schema.Views, qt.HasLen, 1)
 	c.Assert(schema.Triggers, qt.HasLen, 1)
 
@@ -103,6 +107,14 @@ func TestReaderReadSchema(t *testing.T) {
 	c.Assert(*fk.ForeignTable, qt.Equals, "accounts")
 	c.Assert(*fk.ForeignColumn, qt.Equals, "id")
 	c.Assert(*fk.DeleteRule, qt.Equals, "CASCADE")
+
+	inlineFK := findConstraint(schema.Constraints, "fk_invoices_account")
+	c.Assert(inlineFK, qt.IsNotNil)
+	c.Assert(inlineFK.TableName, qt.Equals, "invoices")
+	c.Assert(inlineFK.ColumnNames, qt.DeepEquals, []string{"account_id"})
+	c.Assert(*inlineFK.ForeignTable, qt.Equals, "accounts")
+	c.Assert(*inlineFK.ForeignColumn, qt.Equals, "id")
+	c.Assert(*inlineFK.DeleteRule, qt.Equals, "SET NULL")
 
 	check := findConstraint(schema.Constraints, "users_email_check")
 	c.Assert(check, qt.IsNotNil)

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -254,14 +254,12 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 		return colDiff
 	}
 
-	// Compare data types (simplified)
-	genType := normalize.Type(genCol.Type)
 	dbRawType := rawDBColumnType(dbCol)
-	dbType := normalize.Type(dbRawType)
+	genType, dbType := normalizeColumnTypesForDialect(genCol.Type, dbRawType, dialect)
 
 	if genType != dbType {
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbType, genType)
-	} else if typechange.IsNarrowing(dbRawType, genCol.Type) {
+	} else if shouldReportNarrowingTypeChange(dbRawType, genCol.Type, dialect) {
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
 	}
 
@@ -321,6 +319,47 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 	}
 
 	return colDiff
+}
+
+func normalizeColumnTypesForDialect(genType, dbType, dialect string) (generatedType, databaseType string) {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.SQLite:
+		return normalize.Type(sqliteRenderedColumnType(genType)), normalize.Type(dbType)
+	default:
+		return normalize.Type(genType), normalize.Type(dbType)
+	}
+}
+
+func shouldReportNarrowingTypeChange(dbType, genType, dialect string) bool {
+	if platform.NormalizeDialect(dialect) == platform.SQLite &&
+		normalize.Type(dbType) == normalize.Type(sqliteRenderedColumnType(genType)) {
+		return false
+	}
+	return typechange.IsNarrowing(dbType, genType)
+}
+
+func sqliteRenderedColumnType(rawType string) string {
+	upper := strings.ToUpper(strings.TrimSpace(rawType))
+	base := upper
+	if idx := strings.Index(base, "("); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	switch base {
+	case "":
+		return "blob"
+	case "BOOLEAN", "BOOL":
+		return "integer"
+	case "SERIAL", "BIGSERIAL", "SMALLSERIAL", "AUTO_INCREMENT":
+		return "integer"
+	case "VARCHAR", "CHARACTER VARYING", "CHAR", "CHARACTER", "TEXT", "CITEXT", "ENUM":
+		return "text"
+	case "BYTEA", "BLOB":
+		return "blob"
+	case "DOUBLE PRECISION":
+		return "real"
+	default:
+		return rawType
+	}
 }
 
 func normalizeTablePrimaryKeyColumn(genCol goschema.Field, dbCol types.DBColumn) goschema.Field {

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -172,6 +173,10 @@ func isMySQLConstraintBasedUniqueIndex(indexName, tableName string) bool {
 // - Space Complexity: O(n + m) for the boolean maps
 // - Index operations can be expensive on large tables in production
 func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	IndexesWithDialect(generated, database, diff, "")
+}
+
+func IndexesWithDialect(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, dialect string) {
 	// Create sets for comparison
 	genIndexes := make(map[string]goschema.Index)
 	for _, index := range generated.Indexes {
@@ -201,6 +206,9 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 	for _, index := range database.Indexes {
 		// Skip primary key indexes as they're handled with tables
 		if index.IsPrimary {
+			continue
+		}
+		if isSQLiteInternalAutoindex(index.Name, dialect) {
 			continue
 		}
 
@@ -256,6 +264,11 @@ func Indexes(generated *goschema.Database, database *types.DBSchema, diff *difft
 	sort.Slice(diff.IndexesRemovedWithTables, func(i, j int) bool {
 		return diff.IndexesRemovedWithTables[i].Name < diff.IndexesRemovedWithTables[j].Name
 	})
+}
+
+func isSQLiteInternalAutoindex(indexName, dialect string) bool {
+	return platform.NormalizeDialect(dialect) == platform.SQLite &&
+		strings.HasPrefix(indexName, "sqlite_autoindex_")
 }
 
 func indexDefinitionsChanged(genIndex goschema.Index, dbIndex types.DBIndex) bool {

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -70,7 +70,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.Enums(generated, database, diff)
 
 	// Compare database index definitions
-	compare.Indexes(generated, database, diff)
+	compare.IndexesWithDialect(generated, database, diff, opts.Dialect)
 
 	// Compare PostgreSQL extensions with configuration options
 	compare.Extensions(generated, database, diff, opts)

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -604,6 +604,148 @@ func TestCompareWithDialect_SQLiteInlineEnumsMatchGeneratedEnumFields(t *testing
 	c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
 }
 
+func TestCompareWithDialect_SQLiteRenderedColumnTypesMatchCatalogReadback(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name          string
+		generatedType string
+		databaseType  string
+	}{
+		{name: "varchar renders as text", generatedType: "VARCHAR(255)", databaseType: "TEXT"},
+		{name: "char renders as text", generatedType: "CHAR(2)", databaseType: "TEXT"},
+		{name: "boolean renders as integer", generatedType: "BOOLEAN", databaseType: "INTEGER"},
+		{name: "serial renders as integer", generatedType: "SERIAL", databaseType: "INTEGER"},
+		{name: "bytea renders as blob", generatedType: "BYTEA", databaseType: "BLOB"},
+		{name: "double precision renders as real", generatedType: "DOUBLE PRECISION", databaseType: "REAL"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				sqliteColumnGeneratedSchema(tt.generatedType),
+				sqliteColumnDatabaseSchema(tt.databaseType),
+				"sqlite",
+			)
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+		})
+	}
+}
+
+func TestCompareWithDialect_SQLiteDistinctColumnTypesStillDiff(t *testing.T) {
+	c := qt.New(t)
+
+	diff := schemadiff.CompareWithDialect(
+		sqliteColumnGeneratedSchema("INTEGER"),
+		sqliteColumnDatabaseSchema("TEXT"),
+		"sqlite",
+	)
+
+	c.Assert(diff.TablesModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["type"], qt.Equals, "text -> integer")
+}
+
+func TestCompareWithDialect_SQLiteDeclaredTypeDriftStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name          string
+		generatedType string
+		databaseType  string
+		wantChange    string
+	}{
+		{name: "database boolean is not rendered integer", generatedType: "INTEGER", databaseType: "BOOLEAN", wantChange: "boolean -> integer"},
+		{name: "database varchar is not rendered text", generatedType: "TEXT", databaseType: "VARCHAR(255)", wantChange: "varchar -> text"},
+		{name: "database empty type is not rendered blob", generatedType: "BLOB", databaseType: "", wantChange: " -> blob"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				sqliteColumnGeneratedSchema(tt.generatedType),
+				sqliteColumnDatabaseSchema(tt.databaseType),
+				"sqlite",
+			)
+			c.Assert(diff.TablesModified, qt.HasLen, 1)
+			c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+			c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["type"], qt.Equals, tt.wantChange)
+		})
+	}
+}
+
+func TestCompareWithDialect_SQLiteUniqueConstraintAutoindexIsIgnored(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{
+			Name:       "projects",
+			StructName: "Project",
+		}},
+		Fields: []goschema.Field{
+			{StructName: "Project", Name: "organization_id", Type: "INTEGER", Nullable: false},
+			{StructName: "Project", Name: "slug", Type: "VARCHAR(64)", Nullable: false},
+		},
+		Constraints: []goschema.Constraint{{
+			Name:       "projects_org_slug_unique",
+			Type:       "UNIQUE",
+			Table:      "projects",
+			StructName: "Project",
+			Columns:    []string{"organization_id", "slug"},
+		}},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "projects",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "organization_id", DataType: "INTEGER", ColumnType: "INTEGER", IsNullable: "NO"},
+				{Name: "slug", DataType: "TEXT", ColumnType: "TEXT", IsNullable: "NO"},
+			},
+		}},
+		Indexes: []types.DBIndex{{
+			Name:      "sqlite_autoindex_projects_1",
+			TableName: "projects",
+			Columns:   []string{"organization_id", "slug"},
+			IsUnique:  true,
+		}},
+		Constraints: []types.DBConstraint{{
+			Name:        "projects_org_slug_unique",
+			TableName:   "projects",
+			Type:        "UNIQUE",
+			ColumnName:  "organization_id",
+			ColumnNames: []string{"organization_id", "slug"},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "sqlite")
+
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func TestCompareWithDialect_NonSQLiteAutoindexNameIsCompared(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "projects", StructName: "Project"}},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{Name: "projects", Type: "TABLE"}},
+		Indexes: []types.DBIndex{{
+			Name:      "sqlite_autoindex_projects_1",
+			TableName: "projects",
+			Columns:   []string{"slug"},
+			IsUnique:  true,
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+
+	c.Assert(diff.IndexesRemoved, qt.DeepEquals, []string{"sqlite_autoindex_projects_1"})
+	c.Assert(diff.IndexesRemovedWithTables, qt.HasLen, 1)
+	c.Assert(diff.IndexesRemovedWithTables[0].TableName, qt.Equals, "projects")
+}
+
 func TestCompareWithDialect_SQLServerInlineEnumsMatchGeneratedEnumFields(t *testing.T) {
 	c := qt.New(t)
 
@@ -655,6 +797,32 @@ func TestCompareWithDialect_SQLServerInlineEnumsMatchGeneratedEnumFields(t *test
 	c.Assert(diff.TablesModified, qt.HasLen, 0)
 	c.Assert(diff.ConstraintsAdded, qt.HasLen, 0)
 	c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
+}
+
+func sqliteColumnGeneratedSchema(columnType string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{
+			Name:       "users",
+			StructName: "User",
+		}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "User", Name: "value", Type: columnType, Nullable: false},
+		},
+	}
+}
+
+func sqliteColumnDatabaseSchema(columnType string) *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "users",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "INTEGER", ColumnType: "INTEGER", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "value", DataType: columnType, ColumnType: columnType, IsNullable: "NO"},
+			},
+		}},
+	}
 }
 
 func TestCompareWithOptions_CustomIgnoreList(t *testing.T) {


### PR DESCRIPTION
## What Changed

Fixes the SQLite live round-trip drift surfaced while implementing `stokaro/ptah#653` in conformance:

- render named SQLite inline foreign keys as `CONSTRAINT <name> REFERENCES ...` so the SQLite reader can recover the original constraint name from catalog DDL;
- compare SQLite column types against Ptah's rendered SQLite surface on the generated side only, so Ptah round-trips `VARCHAR -> TEXT`, `BOOLEAN -> INTEGER`, `BYTEA -> BLOB`, etc. without hiding manually declared database drift;
- ignore SQLite internal `sqlite_autoindex_*` indexes only when the active comparison dialect is SQLite;
- add regressions for renderer output, SQLite reader readback, SQLite type round-trip equivalence, inverse type drift, SQLite autoindexes, and non-SQLite indexes with the same name prefix.

## Why

The new SQLite live conformance tier initially reported 8/9 SQLite fixtures as non-OK. The root causes were Ptah-side false drift after applying Ptah's own SQLite DDL and introspecting it back:

- generated string/bool/blob aliases were compared against SQLite catalog declarations before applying SQLite renderer mapping;
- named inline foreign keys lost their names in rendered SQLite DDL, causing field-level FKs to be reported as missing;
- SQLite's internal UNIQUE backing indexes were treated as removable user indexes.

## Self-Review

Two-pass self-review was done before opening the PR.

Pass 1 found and fixed the obvious live conformance failures, reducing SQLite-only live conformance from 8 non-OK to 2 non-OK.

Pass 2 used an independent review agent. It found two issues:

- the `sqlite_autoindex_*` filter was global instead of SQLite-only;
- the first type normalization was symmetric and could hide real database-declared SQLite drift.

Both were fixed before this PR: index comparison is now dialect-aware, and SQLite type comparison is asymmetric with negative tests for inverse drift.

## Validation

- `GOCACHE=/private/tmp/ptah-653-go-cache go test ./core/renderer/internal/dialects/sqlite ./internal/dbschema/sqlite ./migration/schemadiff -count=1`
- `GOCACHE=/private/tmp/ptah-653-go-cache go test ./...` outside sandbox
- `GOCACHE=/private/tmp/ptah-653-go-cache go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-653-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-653-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-653-go-cache scripts/check-test-style.sh`
- `git diff --check`
- conformance local replace smoke: `GOCACHE=/private/tmp/ptah-conformance-653-go-cache make probe-live` in `ptah-atlas-conformance` with `replace github.com/stokaro/ptah => /private/tmp/ptah-issue-653`: `9 observations across 1 dialect(s), 0 non-OK`

The final conformance repository bump/report regeneration will happen after this Ptah PR lands, using the merged Ptah pseudo-version rather than a local replace.
