### PR TITLE
Normalize MariaDB schema readback drift

### DIFF
--- a/internal/dbschema/mysql/reader.go
+++ b/internal/dbschema/mysql/reader.go
@@ -392,6 +392,7 @@ func (r *Reader) readViews(dbName string) ([]types.DBView, error) {
 		if err != nil {
 			return nil, err
 		}
+		view.Schema = dbName
 		views = append(views, view)
 	}
 	return views, nil

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -403,14 +403,18 @@ func normalizeGeneratedExpression(expression, dialect string) string {
 	expression = normalize.Expression(expression)
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
-		return normalizeCatalogGeneratedExpression(stripPostgresGeneratedTypeCasts(expression))
+		return normalizeCatalogGeneratedExpression(stripPostgresGeneratedTypeCasts(expression), dialect)
 	case platform.MySQL, platform.MariaDB:
-		return normalizeCatalogGeneratedExpression(expression)
+		return normalizeMySQLGeneratedExpression(normalizeCatalogGeneratedExpression(expression, dialect))
 	case platform.SQLServer:
 		return normalizeSQLServerGeneratedExpression(expression)
 	default:
 		return expression
 	}
+}
+
+func normalizeMySQLGeneratedExpression(expression string) string {
+	return replaceSQLFunctionOutsideSingleQuotedSQL(expression, "lcase(", "lower(")
 }
 
 func normalizeSQLServerGeneratedExpression(expression string) string {
@@ -443,23 +447,13 @@ func normalizeSQLServerGeneratedExpression(expression string) string {
 	return b.String()
 }
 
-func normalizeCatalogGeneratedExpression(expression string) string {
+func normalizeCatalogGeneratedExpression(expression, dialect string) string {
 	var b strings.Builder
-	inString := false
+	mysqlFamily := isMySQLFamilyDialect(dialect)
 	for i := 0; i < len(expression); i++ {
 		ch := expression[i]
-		if ch == '\'' {
-			b.WriteByte(ch)
-			if inString && i+1 < len(expression) && expression[i+1] == '\'' {
-				i++
-				b.WriteByte('\'')
-				continue
-			}
-			inString = !inString
-			continue
-		}
-		if inString {
-			b.WriteByte(ch)
+		if ch == '\'' || (mysqlFamily && ch == '"') {
+			i = copyQuotedSQL(&b, expression, i)
 			continue
 		}
 		switch ch {

--- a/migration/schemadiff/internal/compare/compare_schema_objects_test.go
+++ b/migration/schemadiff/internal/compare/compare_schema_objects_test.go
@@ -38,6 +38,41 @@ func TestViews_IgnoresDatabaseOnlyQualification(t *testing.T) {
 	c.Assert(diff.ViewsModified, qt.HasLen, 0)
 }
 
+func TestViews_MatchesGeneratedQualifiedNameToDatabaseSchema(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "tenant.active_users", Body: "SELECT id FROM tenant.users WHERE deleted_at IS NULL"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{{
+			Name:   "active_users",
+			Schema: "tenant",
+			Body:   "SELECT id FROM tenant.users WHERE deleted_at IS NULL",
+		}},
+	}, diff)
+
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+}
+
+func TestViews_DetectsAmbiguousDatabaseSchemasForUnqualifiedGeneratedView(t *testing.T) {
+	c := qt.New(t)
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Views(&goschema.Database{
+		Views: []goschema.View{{Name: "active_users", Body: "SELECT id FROM users"}},
+	}, &dbschematypes.DBSchema{
+		Views: []dbschematypes.DBView{
+			{Name: "active_users", Schema: "tenant", Body: "SELECT id FROM tenant.users"},
+			{Name: "active_users", Schema: "other", Body: "SELECT id FROM other.users"},
+		},
+	}, diff)
+
+	c.Assert(diff.ViewsAdded, qt.DeepEquals, []string{"active_users"})
+	c.Assert(diff.ViewsRemoved, qt.DeepEquals, []string{"other.active_users", "tenant.active_users"})
+	c.Assert(diff.ViewsModified, qt.HasLen, 0)
+}
+
 func TestViews_IgnoresMySQLCanonicalViewBody(t *testing.T) {
 	c := qt.New(t)
 	diff := &difftypes.SchemaDiff{}
@@ -46,7 +81,8 @@ func TestViews_IgnoresMySQLCanonicalViewBody(t *testing.T) {
 		Views: []goschema.View{{Name: "live_products", Body: "SELECT id, name FROM products WHERE archived = false"}},
 	}, &dbschematypes.DBSchema{
 		Views: []dbschematypes.DBView{{
-			Name: "live_products",
+			Name:   "live_products",
+			Schema: "ptah_issue_502",
 			Body: "select `ptah_issue_502`.`products`.`id` AS `id`,`ptah_issue_502`.`products`.`name` AS `name` " +
 				"from `ptah_issue_502`.`products` where (`ptah_issue_502`.`products`.`archived` = false)",
 		}},

--- a/migration/schemadiff/internal/compare/schema_objects.go
+++ b/migration/schemadiff/internal/compare/schema_objects.go
@@ -116,27 +116,49 @@ func Functions(generated *goschema.Database, database *types.DBSchema, diff *dif
 
 // Views compares view definitions between generated and database schemas.
 func Views(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
-	generatedViews := make(map[string]goschema.View)
+	ViewsWithDialect(generated, database, diff, "")
+}
+
+// ViewsWithDialect compares view definitions with dialect-aware normalization
+// for catalog readback forms that are semantically equivalent to Ptah-rendered
+// view SQL.
+func ViewsWithDialect(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, dialect string) {
+	generatedViews := make(map[string]goschema.View, len(generated.Views))
 	for _, view := range generated.Views {
 		generatedViews[view.Name] = view
 	}
 
-	databaseViews := make(map[string]types.DBView)
+	databaseViewsByName := make(map[string][]types.DBView, len(database.Views))
+	databaseViewsByQualifiedName := make(map[string]types.DBView, len(database.Views))
 	for _, view := range database.Views {
-		databaseViews[view.QualifiedName()] = view
+		databaseViewsByName[view.Name] = append(databaseViewsByName[view.Name], view)
+		databaseViewsByQualifiedName[view.QualifiedName()] = view
 	}
 
-	addedViews, removedViews := compareNamedItems(generatedViews, databaseViews)
-	diff.ViewsAdded = append(diff.ViewsAdded, addedViews...)
-	diff.ViewsRemoved = append(diff.ViewsRemoved, removedViews...)
-
+	matchedDatabaseViews := make(map[string]struct{}, len(database.Views))
 	for viewName, generatedView := range generatedViews {
-		if databaseView, exists := databaseViews[viewName]; exists {
-			viewDiff := ViewDefinitions(generatedView, databaseView)
-			if len(viewDiff.Changes) > 0 {
-				diff.ViewsModified = append(diff.ViewsModified, viewDiff)
-			}
+		databaseView, exists := findDatabaseViewForGeneratedView(
+			generatedView,
+			databaseViewsByName,
+			databaseViewsByQualifiedName,
+		)
+		if !exists {
+			diff.ViewsAdded = append(diff.ViewsAdded, viewName)
+			continue
 		}
+
+		matchedDatabaseViews[databaseView.QualifiedName()] = struct{}{}
+		viewDiff := ViewDefinitionsWithDialect(generatedView, databaseView, dialect)
+		if len(viewDiff.Changes) > 0 {
+			diff.ViewsModified = append(diff.ViewsModified, viewDiff)
+		}
+	}
+
+	for _, view := range database.Views {
+		if _, ok := matchedDatabaseViews[view.QualifiedName()]; ok {
+			continue
+		}
+		diff.ViewsRemoved = append(diff.ViewsRemoved, viewNameForDiff(view))
 	}
 
 	sort.Strings(diff.ViewsAdded)
@@ -144,6 +166,34 @@ func Views(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 	sort.Slice(diff.ViewsModified, func(i, j int) bool {
 		return diff.ViewsModified[i].ViewName < diff.ViewsModified[j].ViewName
 	})
+}
+
+func findDatabaseViewForGeneratedView(
+	generatedView goschema.View,
+	databaseViewsByName map[string][]types.DBView,
+	databaseViewsByQualifiedName map[string]types.DBView,
+) (types.DBView, bool) {
+	if viewNameHasSchema(generatedView.Name) {
+		view, ok := databaseViewsByQualifiedName[generatedView.Name]
+		return view, ok
+	}
+	candidates := databaseViewsByName[generatedView.Name]
+	if len(candidates) != 1 {
+		return types.DBView{}, false
+	}
+	return candidates[0], true
+}
+
+func viewNameHasSchema(name string) bool {
+	schema, viewName, ok := strings.Cut(name, ".")
+	return ok && strings.TrimSpace(schema) != "" && strings.TrimSpace(viewName) != ""
+}
+
+func viewNameForDiff(view types.DBView) string {
+	if view.Schema == "" {
+		return view.Name
+	}
+	return view.QualifiedName()
 }
 
 // MaterializedViews compares materialized view definitions between generated
@@ -280,12 +330,18 @@ func FunctionDefinitions(genFunction goschema.Function, dbFunction types.DBFunct
 
 // ViewDefinitions performs detailed comparison between generated and database view definitions.
 func ViewDefinitions(genView goschema.View, dbView types.DBView) difftypes.ViewDiff {
+	return ViewDefinitionsWithDialect(genView, dbView, "")
+}
+
+// ViewDefinitionsWithDialect performs detailed comparison between generated and
+// database view definitions with dialect-aware catalog readback normalization.
+func ViewDefinitionsWithDialect(genView goschema.View, dbView types.DBView, dialect string) difftypes.ViewDiff {
 	viewDiff := difftypes.ViewDiff{
 		ViewName: genView.Name,
 		Changes:  make(map[string]string),
 	}
 
-	if !schemaObjectBodiesEqual(genView.Body, dbView.Body) {
+	if !schemaObjectBodiesEqual(genView.Body, dbView.Body, dialect, dbView.Schema) {
 		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
 	}
 
@@ -305,50 +361,59 @@ func MaterializedViewDefinitions(genView goschema.MaterializedView, dbView types
 		Changes:  make(map[string]string),
 	}
 
-	if !schemaObjectBodiesEqual(genView.Body, dbView.Body) {
+	if !schemaObjectBodiesEqual(genView.Body, dbView.Body, "", "") {
 		viewDiff.Changes["body"] = fmt.Sprintf("%s -> %s", strings.TrimSpace(dbView.Body), strings.TrimSpace(genView.Body))
 	}
 
 	return viewDiff
 }
 
-func schemaObjectBodiesEqual(generatedBody, databaseBody string) bool {
-	if normalizeSQLBodyPreservingQualifiers(generatedBody) == normalizeSQLBodyPreservingQualifiers(databaseBody) {
+func schemaObjectBodiesEqual(generatedBody, databaseBody, dialect, databaseSchema string) bool {
+	if normalizeSQLBodyPreservingQualifiers(generatedBody, dialect) == normalizeSQLBodyPreservingQualifiers(databaseBody, dialect) {
 		return true
 	}
 
 	if schemaQualifierPattern.MatchString(strings.ToLower(generatedBody)) {
 		return false
 	}
-	return normalizeSQLBodyPreservingQualifiers(generatedBody) == normalizeSQLBodyStrippingQualifiers(databaseBody)
+	return normalizeSQLBodyPreservingQualifiers(generatedBody, dialect) ==
+		normalizeSQLBodyStrippingQualifiers(databaseBody, dialect, databaseSchema)
 }
 
-func normalizeSQLBodyPreservingQualifiers(body string) string {
-	return canonicalizeNormalizedSQLBody(normalizeSQLBody(body))
+func normalizeSQLBodyPreservingQualifiers(body, dialect string) string {
+	return canonicalizeNormalizedSQLBody(normalizeSQLBody(body, dialect), dialect)
 }
 
-func normalizeSQLBodyStrippingQualifiers(body string) string {
-	return canonicalizeNormalizedSQLBody(schemaQualifierPattern.ReplaceAllString(normalizeSQLBody(body), ""))
+func normalizeSQLBodyStrippingQualifiers(body, dialect, schema string) string {
+	return canonicalizeNormalizedSQLBody(stripSQLQualifiers(normalizeSQLBody(body, dialect), schema), dialect)
 }
 
-func normalizeSQLBody(body string) string {
+func normalizeSQLBody(body, dialect string) string {
 	body = strings.TrimSpace(body)
 	body = strings.TrimSuffix(body, ";")
 	body = strings.TrimSpace(body)
-	body = strings.ReplaceAll(body, "\"", "")
-	body = strings.ReplaceAll(body, "`", "")
-	body = strings.ToLower(body)
+	body = normalizeSQLCaseAndIdentifierQuotes(body, dialect)
 	body = stripDefaultAggregateAliases(body)
-	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
-	body = sqlCommaSpacingPattern.ReplaceAllString(body, ",")
+	body = collapseWhitespaceOutsideQuotedSQL(body)
+	body = normalizeCommaSpacingOutsideQuotedSQL(body)
 	return strings.TrimSpace(body)
 }
 
-func canonicalizeNormalizedSQLBody(body string) string {
+func canonicalizeNormalizedSQLBody(body, dialect string) string {
 	body = stripDefaultColumnAliases(body)
 	body = stripSimpleComparisonParentheses(body)
 	body = regexp.MustCompile(`\s+`).ReplaceAllString(body, " ")
+	if isMySQLFamilyDialect(dialect) {
+		body = normalizeMySQLBooleanViewPredicates(body)
+	}
 	return strings.TrimSpace(body)
+}
+
+func normalizeMySQLBooleanViewPredicates(body string) string {
+	body = replaceSQLLiteralOutsideSingleQuotedSQL(body, " = false", " = 0")
+	body = replaceSQLLiteralOutsideSingleQuotedSQL(body, "= false", "= 0")
+	body = replaceSQLLiteralOutsideSingleQuotedSQL(body, " = true", " = 1")
+	return replaceSQLLiteralOutsideSingleQuotedSQL(body, "= true", "= 1")
 }
 
 func stripDefaultAggregateAliases(body string) string {

--- a/migration/schemadiff/internal/compare/shared.go
+++ b/migration/schemadiff/internal/compare/shared.go
@@ -31,7 +31,6 @@ var (
 			`(?:=|<>|!=|<=|>=|<|>|like|is(?:\s+not)?)\s*` +
 			`(?:[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*|[0-9]+(?:\.[0-9]+)?|'[^']*'|true|false|null))\)`,
 	)
-	sqlCommaSpacingPattern = regexp.MustCompile(`\s*,\s*`)
 	schemaQualifierPattern = regexp.MustCompile(`\b[a-z_][a-z0-9_]*\.`)
 )
 

--- a/migration/schemadiff/internal/compare/sql_normalize.go
+++ b/migration/schemadiff/internal/compare/sql_normalize.go
@@ -1,0 +1,260 @@
+package compare
+
+import (
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+func isMySQLFamilyDialect(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB:
+		return true
+	default:
+		return false
+	}
+}
+
+func replaceSQLFunctionOutsideSingleQuotedSQL(value, old, replacement string) string {
+	return replaceOutsideSingleQuotedSQL(value, old, replacement, func(value string, start int) bool {
+		return start == 0 || !isSQLIdentifierByte(value[start-1])
+	})
+}
+
+func replaceSQLLiteralOutsideSingleQuotedSQL(value, old, replacement string) string {
+	return replaceOutsideSingleQuotedSQL(value, old, replacement, func(value string, start int) bool {
+		end := start + len(old)
+		return end == len(value) || !isSQLIdentifierByte(value[end])
+	})
+}
+
+func replaceOutsideSingleQuotedSQL(
+	value string,
+	old string,
+	replacement string,
+	allowed func(value string, start int) bool,
+) string {
+	var b strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' || value[i] == '"' {
+			i = copyQuotedSQL(&b, value, i)
+			continue
+		}
+		if strings.HasPrefix(value[i:], old) && allowed(value, i) {
+			b.WriteString(replacement)
+			i += len(old) - 1
+			continue
+		}
+		b.WriteByte(value[i])
+	}
+	return b.String()
+}
+
+func normalizeSQLCaseAndIdentifierQuotes(value, dialect string) string {
+	var b strings.Builder
+	mysqlFamily := isMySQLFamilyDialect(dialect)
+	for i := 0; i < len(value); i++ {
+		switch ch := value[i]; {
+		case ch == '\'' || (mysqlFamily && ch == '"'):
+			i = copyQuotedSQL(&b, value, i)
+		case ch == '`' || ch == '"':
+			i = copyIdentifierQuote(&b, value, i)
+		default:
+			b.WriteByte(lowerASCII(ch))
+		}
+	}
+	return b.String()
+}
+
+func stripSQLQualifiers(value, schema string) string {
+	schema = strings.ToLower(strings.TrimSpace(schema))
+	if schema != "" {
+		value = stripMatchingSchemaQualifiers(value, schema)
+	}
+	return stripSinglePartQualifiers(value)
+}
+
+func stripMatchingSchemaQualifiers(value, schema string) string {
+	var b strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' || value[i] == '"' {
+			i = copyQuotedSQL(&b, value, i)
+			continue
+		}
+		if strings.HasPrefix(value[i:], schema+".") && startsIdentifierAt(value, i) {
+			i += len(schema)
+			continue
+		}
+		b.WriteByte(value[i])
+	}
+	return b.String()
+}
+
+func stripSinglePartQualifiers(value string) string {
+	var b strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' || value[i] == '"' {
+			i = copyQuotedSQL(&b, value, i)
+			continue
+		}
+		if !isSQLIdentifierByte(value[i]) {
+			b.WriteByte(value[i])
+			continue
+		}
+		start := i
+		for i < len(value) && isSQLIdentifierByte(value[i]) {
+			i++
+		}
+		if i < len(value) && value[i] == '.' && canStripSinglePartQualifier(value, start, i) {
+			continue
+		}
+		b.WriteString(value[start:i])
+		i--
+	}
+	return b.String()
+}
+
+func canStripSinglePartQualifier(value string, start, dot int) bool {
+	if start > 0 && value[start-1] == '.' {
+		return false
+	}
+	if previousSQLWordIsRelationIntroducer(value, start) {
+		return false
+	}
+	nextStart := dot + 1
+	if nextStart >= len(value) || !isSQLIdentifierByte(value[nextStart]) {
+		return false
+	}
+	nextEnd := nextStart
+	for nextEnd < len(value) && isSQLIdentifierByte(value[nextEnd]) {
+		nextEnd++
+	}
+	return nextEnd >= len(value) || value[nextEnd] != '.'
+}
+
+func previousSQLWordIsRelationIntroducer(value string, start int) bool {
+	end := start
+	for end > 0 && isSQLWhitespace(value[end-1]) {
+		end--
+	}
+	start = end
+	for start > 0 && isSQLIdentifierByte(value[start-1]) {
+		start--
+	}
+	switch value[start:end] {
+	case "from", "join", "update", "into", "table":
+		return true
+	default:
+		return false
+	}
+}
+
+func startsIdentifierAt(value string, start int) bool {
+	return (start == 0 || !isSQLIdentifierByte(value[start-1])) &&
+		start+1 < len(value) && isSQLIdentifierByte(value[start])
+}
+
+func collapseWhitespaceOutsideQuotedSQL(value string) string {
+	var b strings.Builder
+	inWhitespace := false
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' || value[i] == '"' {
+			i = copyQuotedSQL(&b, value, i)
+			inWhitespace = false
+			continue
+		}
+		if isSQLWhitespace(value[i]) {
+			inWhitespace = true
+			continue
+		}
+		if inWhitespace && b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		inWhitespace = false
+		b.WriteByte(value[i])
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func normalizeCommaSpacingOutsideQuotedSQL(value string) string {
+	var b strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\'' || value[i] == '"' {
+			i = copyQuotedSQL(&b, value, i)
+			continue
+		}
+		if value[i] != ',' {
+			b.WriteByte(value[i])
+			continue
+		}
+		trimTrailingSpaces(&b)
+		b.WriteByte(',')
+		for i+1 < len(value) && isSQLWhitespace(value[i+1]) {
+			i++
+		}
+	}
+	return b.String()
+}
+
+func trimTrailingSpaces(b *strings.Builder) {
+	value := strings.TrimRight(b.String(), " \t\n\r")
+	b.Reset()
+	b.WriteString(value)
+}
+
+func copyQuotedSQL(b *strings.Builder, value string, start int) int {
+	quote := value[start]
+	b.WriteByte(value[start])
+	for i := start + 1; i < len(value); i++ {
+		b.WriteByte(value[i])
+		if value[i] == '\\' && i+1 < len(value) {
+			i++
+			b.WriteByte(value[i])
+			continue
+		}
+		if value[i] != quote {
+			continue
+		}
+		if i+1 < len(value) && value[i+1] == quote {
+			i++
+			b.WriteByte(value[i])
+			continue
+		}
+		return i
+	}
+	return len(value) - 1
+}
+
+func copyIdentifierQuote(b *strings.Builder, value string, start int) int {
+	quote := value[start]
+	for i := start + 1; i < len(value); i++ {
+		if value[i] == quote {
+			if i+1 < len(value) && value[i+1] == quote {
+				i++
+				b.WriteByte(lowerASCII(value[i]))
+				continue
+			}
+			return i
+		}
+		b.WriteByte(lowerASCII(value[i]))
+	}
+	return len(value) - 1
+}
+
+func isSQLIdentifierByte(ch byte) bool {
+	return ch == '_' ||
+		(ch >= '0' && ch <= '9') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= 'a' && ch <= 'z')
+}
+
+func isSQLWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+func lowerASCII(ch byte) byte {
+	if ch >= 'A' && ch <= 'Z' {
+		return ch + ('a' - 'A')
+	}
+	return ch
+}

--- a/migration/schemadiff/internal/compare/triggers.go
+++ b/migration/schemadiff/internal/compare/triggers.go
@@ -105,7 +105,7 @@ func TriggerDefinitions(genTrigger goschema.Trigger, dbTrigger types.DBTrigger) 
 }
 
 func normalizeTriggerBody(body string) string {
-	body = normalizeSQLBodyPreservingQualifiers(body)
+	body = normalizeSQLBodyPreservingQualifiers(body, "")
 	body = strings.TrimPrefix(body, "begin ")
 	body = strings.TrimPrefix(body, "begin")
 	body = strings.TrimSpace(body)

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -19,10 +19,10 @@ func Compare(generated *goschema.Database, database *types.DBSchema) *difftypes.
 }
 
 // CompareWithDialect performs schema comparison using default options plus the
-// supplied target dialect. The dialect drives dialect-specific normalization —
-// currently the MySQL/MariaDB RESTRICT == NO ACTION fold for foreign-key
-// referential actions (see config.CompareOptions.Dialect). Pass an empty
-// dialect for dialect-neutral comparison (equivalent to Compare).
+// supplied target dialect. The dialect drives dialect-specific normalization,
+// such as MySQL-family catalog spellings and referential-action folds (see
+// config.CompareOptions.Dialect). Pass an empty dialect for dialect-neutral
+// comparison (equivalent to Compare).
 func CompareWithDialect(generated *goschema.Database, database *types.DBSchema, dialect string) *difftypes.SchemaDiff {
 	opts := config.DefaultCompareOptions()
 	opts.Dialect = dialect
@@ -79,7 +79,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.Functions(generated, database, diff)
 
 	// Compare views, materialized views, and triggers
-	compare.Views(generated, database, diff)
+	compare.ViewsWithDialect(generated, database, diff, opts.Dialect)
 	compare.MaterializedViews(generated, database, diff)
 	compare.Triggers(generated, database, diff)
 

--- a/migration/schemadiff/schemadiff_test.go
+++ b/migration/schemadiff/schemadiff_test.go
@@ -160,6 +160,17 @@ func TestCompareWithDialect_GeneratedColumnCatalogExpressionsMatch(t *testing.T)
 			databaseKind:       "STORED",
 		},
 		{
+			name:               "mariadb lower alias",
+			dialect:            "mariadb",
+			generatedType:      "VARCHAR(255)",
+			generatedExpr:      "lower(email)",
+			generatedKind:      "stored",
+			databaseType:       "varchar",
+			databaseColumnType: "varchar(255)",
+			databaseExpr:       "lcase(`email`)",
+			databaseKind:       "STORED",
+		},
+		{
 			name:               "postgres numeric cast parameters",
 			dialect:            "postgres",
 			generatedType:      "DECIMAL(10,2)",
@@ -243,6 +254,241 @@ func TestCompareWithDialect_GeneratedColumnStringLiteralMismatchIsAGap(t *testin
 	c.Assert(diff.TablesModified, qt.HasLen, 1)
 	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
 	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["generated"], qt.Contains, "'ACTIVE'")
+}
+
+func TestCompareWithDialect_GeneratedColumnEscapedStringLiteralMismatchIsAGap(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "contacts", StructName: "Contact"}},
+		Fields: []goschema.Field{
+			{
+				StructName:          "Contact",
+				Name:                "email_normalized",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: `concat(email, 'can\'t lcase(email)')`,
+				GeneratedKind:       "stored",
+			},
+		},
+	}
+	databaseExpression := `concat(` + "`email`" + `, 'can\'t lower(email)')`
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "contacts",
+			Type: "TABLE",
+			Columns: []types.DBColumn{{
+				Name:                "email_normalized",
+				DataType:            "text",
+				IsNullable:          "YES",
+				GeneratedExpression: &databaseExpression,
+				GeneratedKind:       "STORED",
+			}},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.TablesModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["generated"], qt.Contains, `lcase`)
+}
+
+func TestCompareWithDialect_GeneratedColumnDoubleQuotedStringLiteralMismatchIsAGap(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "contacts", StructName: "Contact"}},
+		Fields: []goschema.Field{
+			{
+				StructName:          "Contact",
+				Name:                "email_normalized",
+				Type:                "TEXT",
+				Nullable:            true,
+				GeneratedExpression: `concat(email, "lcase(email)")`,
+				GeneratedKind:       "stored",
+			},
+		},
+	}
+	databaseExpression := `concat(` + "`email`" + `, "lower(email)")`
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "contacts",
+			Type: "TABLE",
+			Columns: []types.DBColumn{{
+				Name:                "email_normalized",
+				DataType:            "text",
+				IsNullable:          "YES",
+				GeneratedExpression: &databaseExpression,
+				GeneratedKind:       "STORED",
+			}},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.TablesModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 1)
+	c.Assert(diff.TablesModified[0].ColumnsModified[0].Changes["generated"], qt.Contains, `lcase`)
+}
+
+func TestCompareWithDialect_MariaDBViewBodyMatchesCatalogReadback(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "live_products",
+			Body: "SELECT id, name FROM products WHERE archived = false",
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name:   "live_products",
+			Schema: "conf",
+			Body: "select `conf`.`products`.`id` AS `id`,`conf`.`products`.`name` AS `name` " +
+				"from `conf`.`products` where `conf`.`products`.`archived` = 0",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+}
+
+func TestCompareWithDialect_MariaDBViewPredicateDriftStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "live_products",
+			Body: "SELECT id, name FROM products WHERE archived = false",
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name:   "live_products",
+			Schema: "conf",
+			Body: "select `conf`.`products`.`id` AS `id`,`conf`.`products`.`name` AS `name` " +
+				"from `conf`.`products` where `conf`.`products`.`archived` = 1",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestCompareWithDialect_MariaDBViewWrongSchemaQualifierStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "live_products",
+			Body: "SELECT id, name FROM products WHERE archived = false",
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name:   "live_products",
+			Schema: "conf",
+			Body: "select `otherdb`.`products`.`id` AS `id`,`otherdb`.`products`.`name` AS `name` " +
+				"from `otherdb`.`products` where `otherdb`.`products`.`archived` = 0",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestCompareWithDialect_MariaDBViewWrongSchemaRelationStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "live_products",
+			Body: "SELECT id, name FROM products WHERE archived = false",
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name:   "live_products",
+			Schema: "conf",
+			Body: "select `products`.`id` AS `id`,`products`.`name` AS `name` " +
+				"from `otherdb`.`products` where `products`.`archived` = 0",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestCompareWithDialect_MariaDBViewStringLiteralDriftStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "view_notes",
+			Body: "SELECT 'archived = false' AS note",
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name: "view_notes",
+			Body: "select 'archived = 0' AS `note`",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestCompareWithDialect_MariaDBViewEscapedStringLiteralDriftStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "view_notes",
+			Body: `SELECT 'can\'t = false' AS note`,
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name: "view_notes",
+			Body: `select 'can\'t = 0' AS ` + "`note`",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
+}
+
+func TestCompareWithDialect_MariaDBViewDoubleQuotedStringLiteralDriftStillDiffs(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Views: []goschema.View{{
+			Name: "view_notes",
+			Body: `SELECT "archived = false" AS note`,
+		}},
+	}
+	database := &types.DBSchema{
+		Views: []types.DBView{{
+			Name: "view_notes",
+			Body: `select "archived = 0" AS ` + "`note`",
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "mariadb")
+
+	c.Assert(diff.ViewsModified, qt.HasLen, 1)
+	c.Assert(diff.ViewsModified[0].Changes["body"], qt.Not(qt.Equals), "")
 }
 
 func TestCompareWithDialect_SQLServerGeneratedExpressionNormalizesCatalogDefinition(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize MariaDB generated-column catalog readback for `lcase(...)` vs Ptah-authored `lower(...)`
- compare MySQL-family view bodies with dialect-aware catalog normalization while preserving real schema/literal drift
- carry MySQL/MariaDB view schema metadata from the reader so qualifier stripping is limited to the current schema

## Why

The expanded live conformance tier for issue #653 found two MariaDB-only round-trip gaps:

- `mariadb/03-view`: MariaDB reports view definitions with current-schema/table qualifiers and boolean predicates as `0`
- `mariadb/07-generated-column`: MariaDB reports `lower(email)` generated columns as `lcase(email)`

Both are catalog readback spellings, not user-visible DDL drift. The fix keeps those equivalent while adding negative tests for wrong schema qualifiers and string-literal drift so normalization cannot hide unsafe differences.

## Validation

- `GOCACHE=/private/tmp/ptah-653-go-cache go test ./...`
- `GOCACHE=/private/tmp/ptah-653-go-cache go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-653-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-653-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-conformance-653-go-cache ... make probe-live` in `ptah-atlas-conformance` with local Ptah replace: `36 observations across 4 dialect(s), 0 non-OK`

Part of #653.
