### PR TITLE
Accept Atlas inspect HCL dialect attributes

### DIFF
--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -160,8 +160,12 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 
 	fieldsStart := len(p.db.Fields)
+	unlabeledCheckOrdinal := 0
 	for _, nested := range block.Body.Blocks {
-		if err := p.parseTableBlock(&table, fieldsStart, nested); err != nil {
+		if nested.Type == "check" && len(nested.Labels) == 0 {
+			unlabeledCheckOrdinal++
+		}
+		if err := p.parseTableBlock(&table, fieldsStart, unlabeledCheckOrdinal, nested); err != nil {
 			return err
 		}
 	}
@@ -173,7 +177,7 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	return nil
 }
 
-func (p *parser) parseTableBlock(table *goschema.Table, fieldsStart int, block *hclsyntax.Block) error {
+func (p *parser) parseTableBlock(table *goschema.Table, fieldsStart, unlabeledCheckOrdinal int, block *hclsyntax.Block) error {
 	switch block.Type {
 	case "column":
 		field, err := p.parseColumn(table.StructName, block)
@@ -210,7 +214,7 @@ func (p *parser) parseTableBlock(table *goschema.Table, fieldsStart int, block *
 			return err
 		}
 	case "check":
-		constraint, err := p.parseCheck(table.StructName, table.Name, block)
+		constraint, err := p.parseCheck(table.StructName, table.Name, unlabeledCheckOrdinal, block)
 		if err != nil {
 			return err
 		}
@@ -264,7 +268,7 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		StructName:          structName,
 		FieldName:           name,
 		Name:                name,
-		Type:                p.columnTypeName(typeAttr),
+		Type:                p.columnTypeName(block, typeAttr),
 		Nullable:            p.optionalBool(block.Body.Attributes["null"], false),
 		AutoInc:             p.optionalBool(block.Body.Attributes["auto_increment"], false) || identity.generation != "",
 		IdentityGeneration:  identity.generation,
@@ -784,20 +788,30 @@ func (p *parser) requireForeignKeyLocalColumns(fieldsStart int, block *hclsyntax
 	return nil
 }
 
-func (p *parser) parseCheck(structName, tableName string, block *hclsyntax.Block) (goschema.Constraint, error) {
-	if len(block.Labels) != 1 {
-		return goschema.Constraint{}, p.blockError(block, "check block requires exactly one label")
+func (p *parser) parseCheck(
+	structName, tableName string,
+	unlabeledOrdinal int,
+	block *hclsyntax.Block,
+) (goschema.Constraint, error) {
+	if len(block.Labels) > 1 {
+		return goschema.Constraint{}, p.blockError(block, "check block accepts at most one label")
 	}
 	if err := p.rejectUnsupportedCheckAttrs(block); err != nil {
 		return goschema.Constraint{}, err
 	}
 	expr := p.optionalString(block.Body.Attributes["expr"])
 	if expr == "" {
-		return goschema.Constraint{}, p.blockError(block, "check %q requires expr", block.Labels[0])
+		return goschema.Constraint{}, p.blockError(block, "check requires expr")
+	}
+	name := tableName + "_check"
+	if len(block.Labels) == 1 {
+		name = block.Labels[0]
+	} else if unlabeledOrdinal > 1 {
+		name = fmt.Sprintf("%s_check_%d", tableName, unlabeledOrdinal)
 	}
 	return goschema.Constraint{
 		StructName:      structName,
-		Name:            block.Labels[0],
+		Name:            name,
 		Type:            "CHECK",
 		Table:           tableName,
 		CheckExpression: expr,
@@ -919,6 +933,7 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 		"charset":        true,
 		"collate":        true,
 		"comment":        true,
+		"unsigned":       true,
 	}, "column")
 }
 
@@ -1120,10 +1135,13 @@ func (p *parser) exprString(attr *hclsyntax.Attribute) string {
 	return p.rawExpr(attr)
 }
 
-func (p *parser) columnTypeName(attr *hclsyntax.Attribute) string {
+func (p *parser) columnTypeName(block *hclsyntax.Block, attr *hclsyntax.Attribute) string {
 	typ := p.rawExpr(attr)
 	if enumName, ok := strings.CutPrefix(typ, "enum."); ok {
 		return enumName
+	}
+	if p.optionalBool(block.Body.Attributes["unsigned"], false) && !strings.Contains(strings.ToLower(typ), "unsigned") {
+		return typ + " unsigned"
 	}
 	return typ
 }

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -782,6 +782,71 @@ table "accounts" {
 	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, "status IN ('active', 'disabled')")
 }
 
+func TestParseColumnUnsignedAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "invoices" {
+  column "subtotal" {
+    type     = decimal(12,2)
+    unsigned = true
+  }
+  column "tax_rate" {
+    type     = decimal(5,4)
+    unsigned = false
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 2)
+	c.Assert(db.Fields[0].Type, qt.Equals, "decimal(12,2) unsigned")
+	c.Assert(db.Fields[1].Type, qt.Equals, "decimal(5,4)")
+}
+
+func TestParseUnlabeledCheckBlock(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "accounts" {
+  column "status" {
+    type = text
+  }
+  check {
+    expr = "status IN ('active', 'disabled')"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Constraints, qt.HasLen, 1)
+	c.Assert(db.Constraints[0].Name, qt.Equals, "accounts_check")
+	c.Assert(db.Constraints[0].Table, qt.Equals, "accounts")
+	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, "status IN ('active', 'disabled')")
+}
+
+func TestParseMultipleUnlabeledCheckBlocks(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "accounts" {
+  column "status" {
+    type = text
+  }
+  check {
+    expr = "status <> ''"
+  }
+  check {
+    expr = "length(status) < 64"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Constraints, qt.HasLen, 2)
+	c.Assert(db.Constraints[0].Name, qt.Equals, "accounts_check")
+	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, "status <> ''")
+	c.Assert(db.Constraints[1].Name, qt.Equals, "accounts_check_2")
+	c.Assert(db.Constraints[1].CheckExpression, qt.Equals, "length(status) < 64")
+}
+
 func TestParseEmptyLiteralDefault(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- accept Atlas-inspected HCL column `unsigned` attributes and preserve true unsigned types in Ptah IR
- accept unlabeled Atlas HCL `check` blocks, with deterministic names for multiple anonymous checks
- add parser regression tests for unsigned columns and unlabeled checks

## Validation
- `GOCACHE=/private/tmp/ptah-647-go-cache go test ./internal/atlashcl ./atlascompat ./internal/atlashclrender ./cmd/schema -count=1`
- `GOCACHE=/private/tmp/ptah-647-go-cache go tool qtlint ./...`
- `GOCACHE=/private/tmp/ptah-647-go-cache ./scripts/check-test-style.sh`
- `GOCACHE=/private/tmp/ptah-647-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-647-golangci-cache golangci-lint run ./...`
- `GOCACHE=/private/tmp/ptah-647-go-cache go test ./...` outside sandbox because `dbschema` opens a local TCP listener
- `git diff --check`

Unblocks expanding Atlas differential conformance beyond PostgreSQL in #647.
