### PR TITLE
Support Atlas HCL two-label table blocks

### DIFF
--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -133,8 +133,9 @@ func (p *parser) parseEnum(block *hclsyntax.Block) error {
 }
 
 func (p *parser) parseTable(block *hclsyntax.Block) error {
-	if len(block.Labels) != 1 {
-		return p.blockError(block, "table block requires exactly one label")
+	labels, err := p.tableLabels(block)
+	if err != nil {
+		return err
 	}
 
 	strict, err := p.optionalTableBool(block, "strict", false)
@@ -147,9 +148,9 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 
 	table := goschema.Table{
-		StructName:    block.Labels[0],
-		Name:          block.Labels[0],
-		Schema:        p.optionalRefName(block.Body.Attributes["schema"]),
+		StructName:    labels.name,
+		Name:          labels.name,
+		Schema:        labels.schema,
 		Engine:        p.optionalString(block.Body.Attributes["engine"]),
 		AutoIncrement: p.optionalString(block.Body.Attributes["auto_increment"]),
 		Charset:       p.optionalString(block.Body.Attributes["charset"]),
@@ -175,6 +176,26 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 	p.db.Tables = append(p.db.Tables, table)
 	return nil
+}
+
+type tableLabels struct {
+	schema string
+	name   string
+}
+
+func (p *parser) tableLabels(block *hclsyntax.Block) (tableLabels, error) {
+	schemaAttr := p.optionalRefName(block.Body.Attributes["schema"])
+	switch len(block.Labels) {
+	case 1:
+		return tableLabels{schema: schemaAttr, name: block.Labels[0]}, nil
+	case 2:
+		if schemaAttr != "" && schemaAttr != block.Labels[0] {
+			return tableLabels{}, p.blockError(block, "table %q schema label conflicts with schema attribute %q", block.Labels[1], schemaAttr)
+		}
+		return tableLabels{schema: block.Labels[0], name: block.Labels[1]}, nil
+	default:
+		return tableLabels{}, p.blockError(block, "table block requires one or two labels")
+	}
 }
 
 func (p *parser) parseTableBlock(table *goschema.Table, fieldsStart, unlabeledCheckOrdinal int, block *hclsyntax.Block) error {

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -60,6 +60,58 @@ table "users" {
 	c.Assert(sql, qt.Contains, `CREATE UNIQUE INDEX`)
 }
 
+func TestParseAtlasPostgreSQLTwoLabelTableBlock(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "public" {}
+
+table "public" "users" {
+  column "id" {
+    null = false
+    type = int
+  }
+  column "email" {
+    null = false
+    type = varchar(255)
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  index "idx_users_email" {
+    columns = [column.email]
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Schema, qt.Equals, "public")
+	c.Assert(db.Tables[0].Name, qt.Equals, "users")
+	c.Assert(db.Fields, qt.HasLen, 2)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].StructName, qt.Equals, "users")
+	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"email"})
+}
+
+func TestParseAtlasPostgreSQLTwoLabelTableRejectsConflictingSchemaAttr(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+schema "public" {}
+schema "audit" {}
+
+table "public" "users" {
+  schema = schema.audit
+  column "id" {
+    type = int
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*table "users" schema label conflicts with schema attribute "audit".*`)
+}
+
 func TestParseTablePartition(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- support Atlas/Postgres inspect HCL in the form `table "schema" "name"`
- keep the existing `table "name" { schema = schema.x }` form
- reject ambiguous table blocks when a two-label schema conflicts with the `schema` attribute

## Validation
- `GOCACHE=/private/tmp/ptah-650-parser-go-cache go test ./internal/atlashcl ./atlascompat ./internal/schemafile -count=1`
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-650-parser-golangci-cache golangci-lint run ./internal/atlashcl ./atlascompat ./internal/schemafile`
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache go test ./... -count=1` (outside sandbox; passed)
- `GOCACHE=/private/tmp/ptah-650-parser-go-cache go test ./... -count=1` (inside sandbox hit expected localhost bind restriction in `dbschema`, unrelated; outside-sandbox run passed)
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache go tool qtlint ./...`

Part of conformance hardening for stokaro/ptah-atlas-conformance#650.