### PR TITLE
Support schema-qualified Atlas HCL refs

### DIFF
--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -9,6 +9,7 @@ import (
 
 // DBSchema represents the complete schema read from a database
 type DBSchema struct {
+	Schemas     []DBSchemaInfo `json:"schemas"`
 	Tables      []DBTable      `json:"tables"`
 	Enums       []DBEnum       `json:"enums"`
 	Indexes     []DBIndex      `json:"indexes"`
@@ -21,6 +22,14 @@ type DBSchema struct {
 	RLSPolicies []DBRLSPolicy  `json:"rls_policies"` // PostgreSQL RLS policies
 	Roles       []DBRole       `json:"roles"`        // PostgreSQL roles
 	Grants      []DBGrant      `json:"grants"`       // PostgreSQL privilege grants
+}
+
+// DBSchemaInfo represents a database schema/namespace.
+type DBSchemaInfo struct {
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+	Charset string `json:"charset,omitempty"`
+	Collate string `json:"collate,omitempty"`
 }
 
 // DBTable represents a database table

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -539,6 +539,7 @@ type DBMatView struct{ ... }
 type DBRLSPolicy struct{ ... }
 type DBRole struct{ ... }
 type DBSchema struct{ ... }
+type DBSchemaInfo struct{ ... }
 type DBTable struct{ ... }
 type DBTrigger struct{ ... }
 type DBView struct{ ... }

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -148,7 +148,7 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 
 	table := goschema.Table{
-		StructName:    labels.name,
+		StructName:    hclTableStructName(labels.schema, labels.name),
 		Name:          labels.name,
 		Schema:        labels.schema,
 		Engine:        p.optionalString(block.Body.Attributes["engine"]),
@@ -176,6 +176,16 @@ func (p *parser) parseTable(block *hclsyntax.Block) error {
 	}
 	p.db.Tables = append(p.db.Tables, table)
 	return nil
+}
+
+func hclTableStructName(schema, name string) string {
+	schema = strings.TrimSpace(schema)
+	switch strings.ToLower(schema) {
+	case "", "main", "public":
+		return name
+	default:
+		return schema + "." + name
+	}
 }
 
 type tableLabels struct {

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -1245,11 +1245,17 @@ func tableColumnFromRef(raw string) (table string, column string) {
 		return "", ""
 	}
 	column = parts[len(parts)-1]
-	for i := 0; i+2 < len(parts); i++ {
-		if parts[i] == "table" && parts[i+2] == "column" {
-			table = parts[i+1]
-			break
+	columnMarker := -1
+	for i, part := range parts {
+		if part == "column" {
+			columnMarker = i
 		}
+	}
+	if columnMarker >= 0 && columnMarker+1 < len(parts) {
+		column = parts[columnMarker+1]
+	}
+	if len(parts) > 0 && parts[0] == "table" && columnMarker > 1 {
+		table = strings.Join(parts[1:columnMarker], ".")
 	}
 	return table, column
 }

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -152,7 +152,11 @@ table "invoices" {
 `), "schema.hcl")
 
 	c.Assert(err, qt.IsNil)
-	userID := fieldByName(db.Fields, "invoices", "user_id")
+	authUsers := tableByName(db.Tables, "users")
+	billingInvoices := tableByName(db.Tables, "invoices")
+	c.Assert(authUsers.StructName, qt.Equals, "auth.users")
+	c.Assert(billingInvoices.StructName, qt.Equals, "billing.invoices")
+	userID := fieldByName(db.Fields, "billing.invoices", "user_id")
 	c.Assert(userID.Foreign, qt.Equals, "auth.users(id)")
 	c.Assert(userID.ForeignKeyName, qt.Equals, "fk_invoices_auth_user")
 	c.Assert(userID.OnDelete, qt.Equals, "CASCADE")

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -112,6 +112,53 @@ table "public" "users" {
 	c.Assert(err, qt.ErrorMatches, `.*table "users" schema label conflicts with schema attribute "audit".*`)
 }
 
+func TestParseAtlasPostgreSQLSchemaQualifiedForeignKeyRefs(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+schema "auth" {}
+schema "billing" {}
+
+table "auth" "users" {
+  schema = schema.auth
+  column "id" {
+    null = false
+    type = serial
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+
+table "invoices" {
+  schema = schema.billing
+  column "id" {
+    null = false
+    type = serial
+  }
+  column "user_id" {
+    null = false
+    type = integer
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_invoices_auth_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.auth.users.column.id]
+    on_delete   = CASCADE
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	userID := fieldByName(db.Fields, "invoices", "user_id")
+	c.Assert(userID.Foreign, qt.Equals, "auth.users(id)")
+	c.Assert(userID.ForeignKeyName, qt.Equals, "fk_invoices_auth_user")
+	c.Assert(userID.OnDelete, qt.Equals, "CASCADE")
+	c.Assert(db.Dependencies["billing.invoices"], qt.DeepEquals, []string{"auth.users"})
+}
+
 func TestParseTablePartition(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -12,6 +12,7 @@ import (
 // This is needed for down migrations where we use the current DB state as the target
 func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Database {
 	database := newDatabase()
+	convertSchemas(database, dbSchema.Schemas)
 	convertEnums(database, dbSchema.Enums)
 
 	// Index single-column FOREIGN KEY constraints by table.column so the
@@ -40,8 +41,20 @@ func ConvertDBSchemaToGoSchema(dbSchema *dbschematypes.DBSchema) *goschema.Datab
 	return database
 }
 
+func convertSchemas(database *goschema.Database, schemas []dbschematypes.DBSchemaInfo) {
+	for _, schema := range schemas {
+		database.Schemas = append(database.Schemas, goschema.Schema{
+			Name:    schema.Name,
+			Comment: schema.Comment,
+			Charset: schema.Charset,
+			Collate: schema.Collate,
+		})
+	}
+}
+
 func newDatabase() *goschema.Database {
 	return &goschema.Database{
+		Schemas:           make([]goschema.Schema, 0),
 		Tables:            make([]goschema.Table, 0),
 		Fields:            make([]goschema.Field, 0),
 		Indexes:           make([]goschema.Index, 0),
@@ -77,9 +90,9 @@ func convertTablesAndFields(
 	compositePKColumns map[string]map[string]bool,
 ) map[string]string {
 	tableStructNames := make(map[string]string, len(dbSchema.Tables))
+	tableNameCounts := tableNameCounts(dbSchema.Tables)
 	for _, dbTable := range dbSchema.Tables {
-		// Generate struct name from table name (simple conversion)
-		structName := generateStructName(dbTable.Name)
+		structName := dbTableStructName(dbTable, tableNameCounts)
 		tableStructNames[dbTable.QualifiedName()] = structName
 
 		table := goschema.Table{
@@ -129,6 +142,21 @@ func convertTablesAndFields(
 		}
 	}
 	return tableStructNames
+}
+
+func tableNameCounts(tables []dbschematypes.DBTable) map[string]int {
+	counts := make(map[string]int, len(tables))
+	for _, table := range tables {
+		counts[table.Name]++
+	}
+	return counts
+}
+
+func dbTableStructName(table dbschematypes.DBTable, tableNameCounts map[string]int) string {
+	if tableNameCounts[table.Name] > 1 && strings.TrimSpace(table.Schema) != "" {
+		return generateStructName(table.Schema + "_" + table.Name)
+	}
+	return generateStructName(table.Name)
 }
 
 func convertIndexes(dbSchema *dbschematypes.DBSchema, tableStructNames map[string]string) []goschema.Index {

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -169,6 +169,23 @@ func TestConvertDBSchemaToGoSchema_ExtensionsWithOtherElements(t *testing.T) {
 	c.Assert(result.Enums[0].Name, qt.Equals, "status_type")
 }
 
+func TestConvertDBSchemaToGoSchema_Schemas(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &types.DBSchema{
+		Schemas: []types.DBSchemaInfo{
+			{Name: "auth", Comment: "Authentication objects"},
+			{Name: "billing", Charset: "utf8mb4", Collate: "utf8mb4_0900_ai_ci"},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Schemas, qt.DeepEquals, []goschema.Schema{
+		{Name: "auth", Comment: "Authentication objects"},
+		{Name: "billing", Charset: "utf8mb4", Collate: "utf8mb4_0900_ai_ci"},
+	})
+}
+
 func TestConvertDBSchemaToGoSchema_GeneratedColumns(t *testing.T) {
 	c := qt.New(t)
 	expression := "lower(name)"
@@ -295,6 +312,51 @@ func TestConvertDBSchemaToGoSchema_SchemaQualifiedObjectOwnersUseTableStructName
 	c.Assert(result.Constraints[0].Name, qt.Equals, "orders_tenant_check")
 	c.Assert(result.RLSPolicies, qt.HasLen, 1)
 	c.Assert(result.RLSPolicies[0].StructName, qt.Equals, "Orders")
+}
+
+func TestConvertDBSchemaToGoSchema_DuplicateTableNamesUseSchemaQualifiedStructNames(t *testing.T) {
+	c := qt.New(t)
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Schema: "auth",
+				Name:   "users",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "integer"},
+					{Name: "email", DataType: "text"},
+				},
+			},
+			{
+				Schema: "billing",
+				Name:   "users",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "integer"},
+					{Name: "external_id", DataType: "text"},
+				},
+			},
+		},
+		Indexes: []types.DBIndex{
+			{Schema: "auth", TableName: "users", Name: "users_email_key", Columns: []string{"email"}, IsUnique: true},
+			{Schema: "billing", TableName: "users", Name: "users_external_id_key", Columns: []string{"external_id"}, IsUnique: true},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Tables, qt.DeepEquals, []goschema.Table{
+		{StructName: "AuthUsers", Schema: "auth", Name: "users"},
+		{StructName: "BillingUsers", Schema: "billing", Name: "users"},
+	})
+	c.Assert(result.Fields, qt.DeepEquals, []goschema.Field{
+		{StructName: "AuthUsers", FieldName: "Id", Name: "id", Type: "integer", Nullable: false},
+		{StructName: "AuthUsers", FieldName: "Email", Name: "email", Type: "text", Nullable: false},
+		{StructName: "BillingUsers", FieldName: "Id", Name: "id", Type: "integer", Nullable: false},
+		{StructName: "BillingUsers", FieldName: "ExternalId", Name: "external_id", Type: "text", Nullable: false},
+	})
+	c.Assert(result.Indexes, qt.DeepEquals, []goschema.Index{
+		{StructName: "AuthUsers", Name: "users_email_key", TableName: "auth.users", Fields: []string{"email"}, Unique: true},
+		{StructName: "BillingUsers", Name: "users_external_id_key", TableName: "billing.users", Fields: []string{"external_id"}, Unique: true},
+	})
 }
 
 func TestConvertDBSchemaToGoSchema_DBDefaultExpression(t *testing.T) {

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -256,6 +256,32 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 	c.Assert(*tables[0].Columns[1].CharacterMaxLength, qt.Equals, 255)
 }
 
+func TestPostgreSQLReaderReadSchemasSkipsMissingScopedSchema(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, func(_ string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		return dbtest.QueryResult{
+			Columns: []string{"nspname", "schema_comment"},
+		}, nil
+	})
+	reader := NewPostgreSQLReader(db.SQL, "public")
+	reader.SetSchemas([]string{"missing"})
+
+	schemas, err := reader.readSchemas()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemas, qt.HasLen, 0)
+}
+
+func TestPostgreSQLReaderReadSchemasUnscopedDoesNotQuery(t *testing.T) {
+	c := qt.New(t)
+	reader := NewPostgreSQLReader(nil, "public")
+
+	schemas, err := reader.readSchemas()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemas, qt.IsNil)
+}
+
 func TestPostgreSQLReader_ExtensionFunctionFiltering(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -81,6 +82,12 @@ func (r *Reader) outputSchema(schemaName string) string {
 // ReadSchema reads the complete database schema
 func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	schema := &types.DBSchema{}
+
+	schemas, err := r.readSchemas()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schemas: %w", err)
+	}
+	schema.Schemas = schemas
 
 	// Read tables
 	tables, err := r.readTables()
@@ -172,6 +179,40 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	// Enhance tables with primary key information from indexes
 	r.enhanceTablesWithIndexes(schema.Tables, schema.Indexes)
 
+	return schema, nil
+}
+
+func (r *Reader) readSchemas() ([]types.DBSchemaInfo, error) {
+	if !r.scoped {
+		return nil, nil
+	}
+	schemas := make([]types.DBSchemaInfo, 0, len(r.schemasToRead()))
+	for _, schemaName := range r.schemasToRead() {
+		schema, err := r.readSchemaInfo(schemaName)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, err
+		}
+		schemas = append(schemas, schema)
+	}
+	return schemas, nil
+}
+
+func (r *Reader) readSchemaInfo(schemaName string) (types.DBSchemaInfo, error) {
+	schemasQuery := `
+		SELECT
+			n.nspname,
+			COALESCE(obj_description(n.oid, 'pg_namespace'), '') AS schema_comment
+		FROM pg_namespace n
+		WHERE n.nspname = $1`
+
+	var schema types.DBSchemaInfo
+	err := r.db.QueryRow(schemasQuery, schemaName).Scan(&schema.Name, &schema.Comment)
+	if err != nil {
+		return types.DBSchemaInfo{}, fmt.Errorf("failed to query schema %s: %w", schemaName, err)
+	}
 	return schema, nil
 }
 


### PR DESCRIPTION
## Summary
- parse Atlas HCL refs like `table.auth.users.column.id`
- preserve schema-qualified FK targets in Ptah IR as `auth.users(id)`
- cover the shape emitted by Atlas CE inspect for cross-schema PostgreSQL FKs

## Validation
- `GOCACHE=/private/tmp/ptah-650-parser-go-cache go test ./internal/atlashcl ./atlascompat ./internal/schemafile -count=1`
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache GOLANGCI_LINT_CACHE=/private/tmp/ptah-650-parser-golangci-cache golangci-lint run ./internal/atlashcl ./atlascompat ./internal/schemafile`
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache go tool qtlint ./...`
- `env GOCACHE=/private/tmp/ptah-650-parser-go-cache go test ./... -count=1` (outside sandbox; passed)

Follow-up to #671 for conformance hardening in stokaro/ptah-atlas-conformance#650.