### PR TITLE
Fix SQLite Atlas revisions schema handling

### DIFF
--- a/internal/atlasmigrate/apply_test.go
+++ b/internal/atlasmigrate/apply_test.go
@@ -76,6 +76,33 @@ func TestPrepareApplyExecute_BaselineRecordsAtlasRevisions(t *testing.T) {
 	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2", "3"})
 }
 
+func TestPrepareApplyExecute_SQLiteMainRevisionsSchema(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE main_revisions_schema_one (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "main-revisions-schema.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:             migrationsDir,
+		ExecOrder:       migrator.ExecOrderLinear,
+		TxMode:          migrator.MigrationTxModeFile,
+		RevisionsSchema: "main",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.SelectedVersions, qt.DeepEquals, []int64{1})
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsTrue)
+	c.Assert(result.FinalStatus.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(sqliteTableExists(c, conn, "main_revisions_schema_one"), qt.IsTrue)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1"})
+}
+
 func TestPrepareApplyExecute_DryRunBaselinePlansRemaining(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/atlasmigrate/status_test.go
+++ b/internal/atlasmigrate/status_test.go
@@ -1,0 +1,46 @@
+package atlasmigrate_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestStatus_SQLiteMainRevisionsSchema(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE status_main_revisions_schema_one (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "status-main-revisions-schema.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:             migrationsDir,
+		ExecOrder:       migrator.ExecOrderLinear,
+		TxMode:          migrator.MigrationTxModeFile,
+		RevisionsSchema: "main",
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = plan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+
+	got, err := atlasmigrate.Status(ctx, conn, atlasmigrate.StatusOptions{
+		Dir:             migrationsDir,
+		RevisionsSchema: "main",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(got.Status.PendingMigrations, qt.HasLen, 0)
+	c.Assert(got.AppliedRevisions, qt.HasLen, 1)
+	c.Assert(got.AppliedRevisions[0].Version, qt.Equals, int64(1))
+	c.Assert(got.AppliedRevisions[0].Description, qt.Equals, "One")
+	c.Assert(got.AppliedRevisions[0].OperatorVersion, qt.Equals, "Ptah")
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -209,6 +209,9 @@ func (m *Migrator) migrationsSchemaStatement() string {
 	if schema == "" {
 		return ""
 	}
+	if platform.NormalizeDialect(m.connectionDialect()) == platform.SQLite {
+		return ""
+	}
 	if m.isSQLServer() {
 		return fmt.Sprintf(
 			"IF SCHEMA_ID(%s) IS NULL EXEC(%s)",


### PR DESCRIPTION
## Summary
- skip unsupported CREATE SCHEMA metadata initialization on SQLite while preserving schema-qualified revision table names such as main.atlas_schema_revisions
- add Atlas migrate apply/status regressions for SQLite --revisions-schema main

## Why
The conformance migrate-runtime probe found that Ptah accepted --revisions-schema but failed at runtime on SQLite by trying to execute CREATE SCHEMA. Atlas-style SQLite fixtures use the main database schema for revision metadata, so this has to work as real runtime behavior, not just as flag acceptance.

## Validation
- go test ./internal/atlasmigrate ./migration/migrator -count=1
- go test ./... -count=1 (outside sandbox; sandbox blocks localhost TCP bind in dbschema tests)
- go tool qtlint ./...
- golangci-lint run ./...
- manual ptah atlas migrate apply --revisions-schema main against SQLite and inspected atlas_schema_revisions rows

Refs stokaro/ptah#648