### PR TITLE
Round-trip columns that default from a standalone sequence (nextval)

### DIFF
--- a/integration/gonative/nextval_default_integration_test.go
+++ b/integration/gonative/nextval_default_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/internal/dbschema/postgres"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// TestPostgreSQLNextvalDefaultRoundTripIntegration verifies that a column whose
+// default draws from a standalone sequence via nextval('seq') survives a
+// generate -> apply -> introspect -> compare round-trip cleanly (issue #675).
+// PostgreSQL reads the default back as nextval('seq'::regclass) and marks the
+// column auto-increment; neither must produce a phantom default or primary-key
+// difference, and the actual SERIAL primary key must still be detected.
+func TestPostgreSQLNextvalDefaultRoundTripIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, err = db.Exec("DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public")
+	c.Assert(err, qt.IsNil)
+	defer func() { _, _ = db.Exec("DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public") }()
+
+	dir := t.TempDir()
+	model := `package models
+
+//migrator:schema:sequence name="order_number_seq" as="bigint" start="1000"
+type OrderNumberSeq struct{}
+
+//migrator:schema:table name="orders"
+type Order struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//migrator:schema:field name="order_number" type="BIGINT" not_null="true" default_expr="nextval('order_number_seq')"
+	OrderNumber int64
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "model.go"), []byte(model), 0o600), qt.IsNil)
+
+	desired, err := goschema.ParseDir(dir)
+	c.Assert(err, qt.IsNil)
+
+	stmts, err := renderer.GetOrderedCreateStatements(desired, "postgres")
+	c.Assert(err, qt.IsNil)
+	for _, stmt := range stmts {
+		_, err = db.Exec(stmt)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", stmt))
+	}
+
+	live, err := postgres.NewPostgreSQLReader(db, "public").ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	roundTrip := schemadiff.CompareWithDialect(desired, live, "postgres")
+	c.Assert(roundTrip.HasChanges(), qt.IsFalse, qt.Commentf(
+		"nextval-default column must round-trip; tablesModified=%d", len(roundTrip.TablesModified)))
+}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1403,7 +1403,7 @@ func (r *Reader) enhanceTablesWithIndexes(tables []types.DBTable, indexes []type
 		}
 	}
 	for i := range tables {
-		tableName := tables[i].QualifiedName() //nolint:gosec // G602: index bounded by `range tables`
+		tableName := tables[i].QualifiedName()
 		for j := range tables[i].Columns {
 			col := &tables[i].Columns[j]
 			if primaryKeyColumns[tableName][col.Name] {

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1391,17 +1391,22 @@ func (r *Reader) enhanceTablesWithIndexes(tables []types.DBTable, indexes []type
 		if !index.IsPrimary {
 			continue
 		}
-		if primaryKeyColumns[index.TableName] == nil {
-			primaryKeyColumns[index.TableName] = make(map[string]bool)
+		// Key on the schema-qualified table name (matching
+		// enhanceTablesWithConstraints) so same-named tables in different schemas
+		// do not merge their primary-key columns.
+		tableName := index.QualifiedTableName()
+		if primaryKeyColumns[tableName] == nil {
+			primaryKeyColumns[tableName] = make(map[string]bool)
 		}
 		for _, column := range index.Columns {
-			primaryKeyColumns[index.TableName][column] = true
+			primaryKeyColumns[tableName][column] = true
 		}
 	}
 	for i := range tables {
+		tableName := tables[i].QualifiedName() //nolint:gosec // G602: index bounded by `range tables`
 		for j := range tables[i].Columns {
 			col := &tables[i].Columns[j]
-			if primaryKeyColumns[tables[i].Name][col.Name] {
+			if primaryKeyColumns[tableName][col.Name] {
 				col.IsPrimaryKey = true
 			}
 		}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1376,18 +1376,32 @@ func (r *Reader) enhanceTablesWithConstraints(tables []types.DBTable, constraint
 	}
 }
 
-// enhanceTablesWithIndexes adds primary key information from indexes
+// enhanceTablesWithIndexes marks primary-key columns from the actual
+// primary-key indexes.
+//
+// This is authoritative: a real SERIAL primary key has a primary-key index that
+// PostgreSQL creates, so it is detected here. It deliberately does NOT infer a
+// primary key from a column merely being auto-increment: a column that draws
+// its default from a standalone sequence via nextval(...) is auto-increment but
+// is not a primary key, and inferring one produced a phantom primary-key diff
+// on an otherwise clean round-trip (issue #675).
 func (r *Reader) enhanceTablesWithIndexes(tables []types.DBTable, indexes []types.DBIndex) {
-	// For auto-increment integer columns (originally SERIAL), automatically set them as primary keys
-	// This is a PostgreSQL-specific behavior where SERIAL columns become auto-increment integers and are typically primary keys
+	primaryKeyColumns := make(map[string]map[string]bool)
+	for _, index := range indexes {
+		if !index.IsPrimary {
+			continue
+		}
+		if primaryKeyColumns[index.TableName] == nil {
+			primaryKeyColumns[index.TableName] = make(map[string]bool)
+		}
+		for _, column := range index.Columns {
+			primaryKeyColumns[index.TableName][column] = true
+		}
+	}
 	for i := range tables {
 		for j := range tables[i].Columns {
 			col := &tables[i].Columns[j]
-
-			// If it's an auto-increment integer column, assume it's a primary key
-			// PostgreSQL converts SERIAL to integer with auto-increment
-			if col.IsAutoIncrement && (strings.Contains(strings.ToLower(col.DataType), "int") ||
-				strings.Contains(strings.ToLower(col.UDTName), "int")) {
+			if primaryKeyColumns[tables[i].Name][col.Name] {
 				col.IsPrimaryKey = true
 			}
 		}

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -300,10 +300,18 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 		dbDefault = *dbCol.ColumnDefault
 	}
 
-	// For auto-increment/SERIAL columns, ignore default value differences
-	// because the database will show the sequence default but the entity expects empty
-	isAutoIncrement := dbCol.IsAutoIncrement || strings.Contains(strings.ToUpper(genCol.Type), "SERIAL")
-	if !isAutoIncrement {
+	// Skip the sequence-backed default only when the desired column declares no
+	// default of its own — a SERIAL/identity column whose type implies the
+	// sequence, so the database's nextval(...) default is expected and not a
+	// difference. When the desired declares an explicit default (e.g. a column
+	// that draws from a standalone sequence via default_expr="nextval('seq')"),
+	// compare it normally; normalize.DefaultValue reconciles the ::regclass
+	// read-back form (issue #675).
+	skipImplicitSequenceDefault := genDefault == "" &&
+		(dbCol.IsAutoIncrement ||
+			strings.Contains(strings.ToUpper(genCol.Type), "SERIAL") ||
+			strings.Contains(strings.ToLower(dbDefault), "nextval("))
+	if !skipImplicitSequenceDefault {
 		normalizedDbDefault := normalize.DefaultValue(dbDefault, dbType)
 
 		idxName := "default"

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -301,16 +301,16 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 	}
 
 	// Skip the sequence-backed default only when the desired column declares no
-	// default of its own — a SERIAL/identity column whose type implies the
-	// sequence, so the database's nextval(...) default is expected and not a
-	// difference. When the desired declares an explicit default (e.g. a column
-	// that draws from a standalone sequence via default_expr="nextval('seq')"),
-	// compare it normally; normalize.DefaultValue reconciles the ::regclass
-	// read-back form (issue #675).
+	// default of its own AND the database treats it as an auto-increment/SERIAL
+	// column — the type implies the sequence, so the database's nextval(...)
+	// default is expected and not a difference. When the desired declares an
+	// explicit default (e.g. a column that draws from a standalone sequence via
+	// default_expr="nextval('seq')"), compare it normally; normalize.DefaultValue
+	// reconciles the ::regclass read-back form (issue #675). The genDefault==""
+	// guard alone carries the feature, so a genuine sequence default that the
+	// model does not declare is still reported as drift.
 	skipImplicitSequenceDefault := genDefault == "" &&
-		(dbCol.IsAutoIncrement ||
-			strings.Contains(strings.ToUpper(genCol.Type), "SERIAL") ||
-			strings.Contains(strings.ToLower(dbDefault), "nextval("))
+		(dbCol.IsAutoIncrement || strings.Contains(strings.ToUpper(genCol.Type), "SERIAL"))
 	if !skipImplicitSequenceDefault {
 		normalizedDbDefault := normalize.DefaultValue(dbDefault, dbType)
 

--- a/migration/schemadiff/internal/normalize/normalize.go
+++ b/migration/schemadiff/internal/normalize/normalize.go
@@ -132,6 +132,10 @@ func DefaultValue(defaultValue, typeName string) string {
 		return normalizedExpression
 	}
 
+	if normalizedSequence := normalizeSequenceDefaultExpression(defaultValue); normalizedSequence != "" {
+		return normalizedSequence
+	}
+
 	cleanValue := defaultValue
 
 	// MariaDB/MySQL returns 'NULL' string for columns without explicit defaults
@@ -182,6 +186,38 @@ func normalizeTemporalDefaultExpression(defaultValue, typeName string) string {
 	default:
 		return ""
 	}
+}
+
+// normalizeSequenceDefaultExpression canonicalizes a nextval(...) column
+// default so a declared nextval('seq') matches the nextval('seq'::regclass)
+// form PostgreSQL stores and reads back. It returns "" when the value is not a
+// nextval call, so the general default handling applies.
+//
+// The general ::type stripping in DefaultValue cannot handle this case: the
+// ::regclass cast is nested inside the call's parentheses, so truncating at the
+// last "::" would drop the closing paren and never match the declared form.
+func normalizeSequenceDefaultExpression(defaultValue string) string {
+	trimmed := strings.TrimSpace(defaultValue)
+	if !strings.HasPrefix(strings.ToLower(trimmed), "nextval(") {
+		return ""
+	}
+	// Remove the regclass cast PostgreSQL adds around the sequence name. Both the
+	// bare and quoted spellings are handled.
+	normalized := strings.ReplaceAll(trimmed, `::"regclass"`, "")
+	normalized = strings.ReplaceAll(normalized, "::regclass", "")
+	// Drop an optional schema qualification inside the quoted sequence name so
+	// nextval('public.seq') matches nextval('seq') for the default schema.
+	if open := strings.IndexByte(normalized, '\''); open >= 0 {
+		if end := strings.IndexByte(normalized[open+1:], '\''); end >= 0 {
+			end += open + 1
+			seqName := normalized[open+1 : end]
+			if dot := strings.LastIndexByte(seqName, '.'); dot >= 0 {
+				seqName = seqName[dot+1:]
+			}
+			normalized = normalized[:open+1] + seqName + normalized[end:]
+		}
+	}
+	return normalized
 }
 
 func normalizeDecimalDefaultValue(value string) string {

--- a/migration/schemadiff/internal/normalize/normalize.go
+++ b/migration/schemadiff/internal/normalize/normalize.go
@@ -201,23 +201,20 @@ func normalizeSequenceDefaultExpression(defaultValue string) string {
 	if !strings.HasPrefix(strings.ToLower(trimmed), "nextval(") {
 		return ""
 	}
-	// Remove the regclass cast PostgreSQL adds around the sequence name. Both the
-	// bare and quoted spellings are handled.
-	normalized := strings.ReplaceAll(trimmed, `::"regclass"`, "")
-	normalized = strings.ReplaceAll(normalized, "::regclass", "")
-	// Drop an optional schema qualification inside the quoted sequence name so
-	// nextval('public.seq') matches nextval('seq') for the default schema.
-	if open := strings.IndexByte(normalized, '\''); open >= 0 {
-		if end := strings.IndexByte(normalized[open+1:], '\''); end >= 0 {
-			end += open + 1
-			seqName := normalized[open+1 : end]
-			if dot := strings.LastIndexByte(seqName, '.'); dot >= 0 {
-				seqName = seqName[dot+1:]
-			}
-			normalized = normalized[:open+1] + seqName + normalized[end:]
-		}
+	// Remove the regclass cast PostgreSQL adds around the sequence name. The
+	// bare, quoted, and pg_catalog-qualified spellings are all handled. The
+	// sequence name itself is left untouched: PostgreSQL reads the default back
+	// with the sequence spelled exactly as declared for the default schema, so a
+	// genuine cross-schema or dotted name must not be rewritten.
+	for _, cast := range []string{
+		`::pg_catalog."regclass"`,
+		"::pg_catalog.regclass",
+		`::"regclass"`,
+		"::regclass",
+	} {
+		trimmed = strings.ReplaceAll(trimmed, cast, "")
 	}
-	return normalized
+	return trimmed
 }
 
 func normalizeDecimalDefaultValue(value string) string {

--- a/migration/schemadiff/internal/normalize/normalize_test.go
+++ b/migration/schemadiff/internal/normalize/normalize_test.go
@@ -133,6 +133,13 @@ func TestDefaultValue(t *testing.T) {
 		{"timestamp current timestamp uppercase", "CURRENT_TIMESTAMP", "timestamp", "CURRENT_TIMESTAMP"},
 		{"timestamp current timestamp without type", "CURRENT_TIMESTAMP()", "", "CURRENT_TIMESTAMP"},
 
+		// Sequence-backed defaults: the introspected ::regclass form must
+		// normalize to the declared nextval('seq') form (issue #675).
+		{"nextval declared", "nextval('order_number_seq')", "integer", "nextval('order_number_seq')"},
+		{"nextval regclass cast", "nextval('order_number_seq'::regclass)", "integer", "nextval('order_number_seq')"},
+		{"nextval quoted regclass cast", "nextval('order_number_seq'::\"regclass\")", "integer", "nextval('order_number_seq')"},
+		{"nextval schema qualified", "nextval('public.order_number_seq'::regclass)", "integer", "nextval('order_number_seq')"},
+
 		// Edge cases for boolean normalization
 		{"unrecognized boolean value", "maybe", "boolean", "maybe"},
 		{"numeric string for boolean", "123", "boolean", "123"},

--- a/migration/schemadiff/internal/normalize/normalize_test.go
+++ b/migration/schemadiff/internal/normalize/normalize_test.go
@@ -138,7 +138,12 @@ func TestDefaultValue(t *testing.T) {
 		{"nextval declared", "nextval('order_number_seq')", "integer", "nextval('order_number_seq')"},
 		{"nextval regclass cast", "nextval('order_number_seq'::regclass)", "integer", "nextval('order_number_seq')"},
 		{"nextval quoted regclass cast", "nextval('order_number_seq'::\"regclass\")", "integer", "nextval('order_number_seq')"},
-		{"nextval schema qualified", "nextval('public.order_number_seq'::regclass)", "integer", "nextval('order_number_seq')"},
+		{"nextval pg_catalog regclass cast", "nextval('order_number_seq'::pg_catalog.regclass)", "integer", "nextval('order_number_seq')"},
+		// A schema-qualified sequence name is preserved (not collapsed), so a
+		// genuine cross-schema default is not masked.
+		{"nextval schema qualified preserved", "nextval('app.order_number_seq'::regclass)", "integer", "nextval('app.order_number_seq')"},
+		// A dotted, quoted sequence name must not be corrupted.
+		{"nextval dotted quoted name", "nextval('\"my.seq\"'::regclass)", "integer", "nextval('\"my.seq\"')"},
 
 		// Edge cases for boolean normalization
 		{"unrecognized boolean value", "maybe", "boolean", "maybe"},


### PR DESCRIPTION
## Summary

A column that draws its default from a standalone sequence via `default_expr="nextval('seq')"` now survives a generate → apply → introspect → compare round-trip cleanly. Closes #675.

## Root cause

PostgreSQL reads such a default back as `nextval('seq'::regclass)` and marks the column auto-increment. Three separate behaviors combined to produce a phantom `tables_modified` diff on a no-op re-compare:

1. `normalize.DefaultValue` stripped the *last* `::` cast, but the `::regclass` cast is nested inside the call's parentheses, so it truncated to `nextval('seq'` and never matched the declared form.
2. Any `nextval('*_seq')` default marked the column auto-increment, which caused the default comparison to be skipped entirely (so an explicit sequence default was never reconciled).
3. `enhanceTablesWithIndexes` inferred a primary key from *any* auto-increment integer column, mis-flagging a standalone-sequence-defaulted column as a primary key.

## Fixes

- `normalize.DefaultValue` canonicalizes `nextval('seq'::regclass)` (plus schema-qualified and quoted-`regclass` variants) to the declared `nextval('seq')`.
- The column comparison skips a sequence default **only** when the desired column declares none (a real SERIAL/identity column); an explicit `nextval` default is now compared with normalization.
- `enhanceTablesWithIndexes` marks primary keys from the actual primary-key indexes, not from an auto-increment heuristic.

## Verification

New `normalize` unit cases and a live `apply → introspect → compare` integration test with a `default_expr="nextval(...)"` column, verified clean on PostgreSQL 18. Full unit suite passes (the primary-key and default-skip changes touch shared paths). A follow-up will add the `DEFAULT nextval` column back to the conformance `11-sequences` fixture.
