### PR TITLE
Add Constraint-Deletion (CD) lint family with per-type codes (#670)

### DIFF
--- a/docs/native_cli.md
+++ b/docs/native_cli.md
@@ -62,6 +62,17 @@ versioned-migration tool into Ptah's native format, preserving version order and
 rewriting `ptah.sum`, so a team can adopt Ptah without hand-rewriting its
 history. See [Importing migrations](./migrations-import.md).
 
+`ptah migrations lint` and `ptah sql lint` report findings by rule code, grouped
+into families (`DS` data-safety, `PG`/`MY` dialect-specific, `TX` transaction,
+and others). Alongside `DS`, the `CD` (constraint-deletion) family flags dropping
+a constraint whose type is recoverable from the SQL — `CD101` foreign key,
+`CD102` check, `CD103` primary key (all `SeverityError`). `DS105` remains the
+fallback for the ANSI `DROP CONSTRAINT <name>` form, whose constraint type the
+SQL does not encode, so a typed drop yields exactly one finding (its `CD` code,
+never also `DS105`). Individual codes and whole families are disabled by code or
+prefix (for example `CD`, or a single `CD101`) and re-severitied per code through
+lint configuration, the same as every other family.
+
 ## Exit Codes
 
 Canonical grouped commands inherit the exit-code contract of the implementation

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -218,11 +218,16 @@ func TestLintFS_OptionalKeywordForms(t *testing.T) {
 		{"convert to charset synonym", "ALTER TABLE users CONVERT TO CHARSET utf8mb4;", []string{"MY101"}},
 
 		// Data-protection drops are destructive; storage-only drops stay silent.
-		{"drop constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", []string{"DS105"}},
-		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", []string{"DS105"}},
-		{"drop primary key", "ALTER TABLE users DROP PRIMARY KEY;", []string{"DS105"}},
+		// The untyped ANSI DROP CONSTRAINT <name> form stays DS105; the typed
+		// MySQL-family forms get their per-type CD codes without double-flagging.
+		{"drop named constraint", "ALTER TABLE users DROP CONSTRAINT uq_users_email;", []string{"DS105"}},
+		{"drop foreign key", "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;", []string{"CD101"}},
+		{"drop primary key", "ALTER TABLE users DROP PRIMARY KEY;", []string{"CD103"}},
 		{"drop index", "ALTER TABLE users DROP INDEX idx_users_email;", nil},
-		{"drop check", "ALTER TABLE users DROP CHECK chk_age;", []string{"DS105"}},
+		{"drop check", "ALTER TABLE users DROP CHECK chk_age;", []string{"CD102"}},
+		{"drop foreign key schema-qualified", "ALTER TABLE shop.orders DROP FOREIGN KEY fk_orders_user;", []string{"CD101"}},
+		{"drop foreign key if exists", "ALTER TABLE orders DROP FOREIGN KEY IF EXISTS fk_orders_user;", []string{"CD101"}},
+		{"drop named constraint cascade", "ALTER TABLE users DROP CONSTRAINT uq_users_email CASCADE;", []string{"DS105"}},
 		{"drop default attribute", "ALTER TABLE users ALTER COLUMN a DROP DEFAULT;", nil},
 		{"drop not null attribute", "ALTER TABLE users ALTER COLUMN a DROP NOT NULL;", []string{"DS104"}},
 		{"drop identity attribute", "ALTER TABLE users ALTER COLUMN a DROP IDENTITY IF EXISTS;", nil},
@@ -872,6 +877,48 @@ CREATE INDEX i ON b (c);
 	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{""}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101", "DS102", "PG101"})
+}
+
+func TestLintFS_ConstraintDeletionFamily(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fixture(map[string]string{
+		"0000000001_drops.up.sql": `ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;
+ALTER TABLE users DROP CHECK chk_age;
+ALTER TABLE users DROP PRIMARY KEY;
+ALTER TABLE users DROP CONSTRAINT uq_email;
+`,
+		"0000000001_drops.down.sql": "-- restore\n",
+	})
+
+	// Each typed drop gets its own CD code; the untyped ANSI DROP CONSTRAINT
+	// stays DS105. No statement is flagged by both a CD code and DS105.
+	findings, err := lint.LintFS(fsys, lint.Options{})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"CD101", "CD102", "CD103", "DS105"})
+
+	// Disabling the CD family silences the typed codes but keeps the DS105 fallback.
+	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{"CD"}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS105"})
+
+	// Disabling one CD code silences only that constraint type.
+	findings, err = lint.LintFS(fsys, lint.Options{Disabled: []string{"CD101"}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"CD102", "CD103", "DS105"})
+
+	// A per-code RuleConfig.Severity override applies to a CD code.
+	fkOnly := fixture(map[string]string{
+		"0000000001_fk.up.sql":   "ALTER TABLE orders DROP FOREIGN KEY fk_orders_user;\n",
+		"0000000001_fk.down.sql": "-- restore\n",
+	})
+	findings, err = lint.LintFS(fkOnly, lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{"CD101": {Severity: lint.SeverityWarning}},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "CD101")
+	c.Assert(findings[0].Severity, qt.Equals, lint.SeverityWarning)
 }
 
 func TestLintFS_DollarQuotedBodiesDoNotSplitStatements(t *testing.T) {

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -44,6 +44,7 @@ func Rules() []Rule {
 func builtinRules() []Rule {
 	var rules []Rule
 	rules = append(rules, dataSafetyRules()...)
+	rules = append(rules, constraintDeletionRules()...)
 	rules = append(rules, dataDependentRules()...)
 	rules = append(rules, migrationFormRules()...)
 	rules = append(rules, compatibilityRules()...)
@@ -98,6 +99,18 @@ func dataSafetyRules() []Rule {
 		databaseObjectDroppedRule(),
 		tableTruncatedRule(),
 		rlsDisabledRule(),
+	}
+}
+
+// constraintDeletionRules covers the CD family: dropping a constraint whose type
+// is recoverable from the SQL, split by constraint type so operators get a
+// precise per-type signal. The untyped ANSI DROP CONSTRAINT <name> form stays in
+// DS105 (dataSafetyRules) because its type is not determinable from the SQL.
+func constraintDeletionRules() []Rule {
+	return []Rule{
+		foreignKeyDroppedRule(),
+		checkConstraintDroppedRule(),
+		primaryKeyDroppedRule(),
 	}
 }
 
@@ -183,18 +196,54 @@ func notNullDroppedRule() Rule {
 	}
 }
 
+// constraintDroppedRule (DS105) is the untyped fallback for the ANSI
+// DROP CONSTRAINT <name> form, whose constraint type is not recoverable from the
+// SQL. The typed MySQL-family forms (DROP FOREIGN KEY / CHECK / PRIMARY KEY) are
+// reported by the more specific CD family, so a statement is never double-flagged.
 func constraintDroppedRule() Rule {
 	return Rule{
 		Code:     "DS105",
 		Title:    "constraint dropped",
 		Severity: SeverityError,
 		CheckStatement: func(stmt *Statement) (bool, string) {
-			if !isAlterTable(stmt.Words) || !scanDropConstraint(stmt.Words) {
+			if !isAlterTable(stmt.Words) || !scanDropNamedConstraint(stmt.Words) {
 				return false, ""
 			}
 			return true, "dropping a constraint removes an existing data protection; verify the replacement safety invariant before applying"
 		},
 	}
+}
+
+// alterTableDropRule builds an all-dialect, error-severity rule that fires when
+// an ALTER TABLE statement matches the given typed constraint-drop predicate. It
+// is the DROP-side analogue of postgresAlterRule and backs the CD family.
+func alterTableDropRule(code, title string, scan func([]string) bool, message string) Rule {
+	return Rule{
+		Code:     code,
+		Title:    title,
+		Severity: SeverityError,
+		CheckStatement: func(stmt *Statement) (bool, string) {
+			if !isAlterTable(stmt.Words) || !scan(stmt.Words) {
+				return false, ""
+			}
+			return true, message
+		},
+	}
+}
+
+func foreignKeyDroppedRule() Rule {
+	return alterTableDropRule("CD101", "foreign key dropped", scanDropForeignKey,
+		"dropping a foreign key removes referential-integrity enforcement; verify no application invariant relies on the database rejecting orphan rows before applying")
+}
+
+func checkConstraintDroppedRule() Rule {
+	return alterTableDropRule("CD102", "check constraint dropped", scanDropCheck,
+		"dropping a check constraint removes a value-validation guarantee; verify no data invariant depends on it before applying")
+}
+
+func primaryKeyDroppedRule() Rule {
+	return alterTableDropRule("CD103", "primary key dropped", scanDropPrimaryKey,
+		"dropping a primary key removes row-uniqueness and identity enforcement and can break replication; verify a replacement key exists before applying")
 }
 
 func enumValueRemovedRule() Rule {
@@ -937,26 +986,36 @@ func scanDropNotNull(w []string) bool {
 	return false
 }
 
-// scanDropConstraint reports whether an ALTER TABLE statement removes a data
-// protection constraint. Index/key/partition drops stay out of this rule.
-func scanDropConstraint(w []string) bool {
+// scanDropClause reports whether any clause of an ALTER TABLE statement begins
+// with the given word sequence, anchoring on the clause heads so that only a
+// top-level DROP form matches. It backs the typed constraint-drop predicates.
+func scanDropClause(w []string, prefix ...string) bool {
 	for _, i := range clauseStarts(w) {
-		if i >= len(w) || w[i] != "DROP" {
-			continue
-		}
-		switch {
-		case hasWordPrefix(w[i:], "DROP", "CONSTRAINT"):
-			return true
-		case hasWordPrefix(w[i:], "DROP", "FOREIGN", "KEY"):
-			return true
-		case hasWordPrefix(w[i:], "DROP", "PRIMARY", "KEY"):
-			return true
-		case hasWordPrefix(w[i:], "DROP", "CHECK"):
+		if hasWordPrefix(w[i:], prefix...) {
 			return true
 		}
 	}
 	return false
 }
+
+// scanDropForeignKey reports whether an ALTER TABLE statement drops a foreign
+// key via the MySQL-family DROP FOREIGN KEY form. The ANSI DROP CONSTRAINT
+// <name> form does not encode the constraint type, so it is not matched here.
+func scanDropForeignKey(w []string) bool { return scanDropClause(w, "DROP", "FOREIGN", "KEY") }
+
+// scanDropCheck reports whether an ALTER TABLE statement drops a check
+// constraint via the DROP CHECK form.
+func scanDropCheck(w []string) bool { return scanDropClause(w, "DROP", "CHECK") }
+
+// scanDropPrimaryKey reports whether an ALTER TABLE statement drops a primary
+// key via the DROP PRIMARY KEY form.
+func scanDropPrimaryKey(w []string) bool { return scanDropClause(w, "DROP", "PRIMARY", "KEY") }
+
+// scanDropNamedConstraint reports whether an ALTER TABLE statement drops a
+// constraint by name via the ANSI DROP CONSTRAINT <name> form, whose constraint
+// type is not recoverable from the SQL. This is the untyped fallback (DS105);
+// the typed forms above are reported by the CD family.
+func scanDropNamedConstraint(w []string) bool { return scanDropClause(w, "DROP", "CONSTRAINT") }
 
 func scanEnumValueRemoval(w []string) bool {
 	return hasWordSeq(w, "DELETE", "FROM", "PG_ENUM") ||


### PR DESCRIPTION
Closes #670.

## Summary

Splits the syntactically-typed constraint drops out of the generic `DS105` "constraint dropped" finding into a dedicated **Constraint-Deletion (`CD`)** lint family, so operators get a precise, per-constraint-type signal with per-code severity and disable control:

- `CD101` — foreign key dropped (`ALTER TABLE ... DROP FOREIGN KEY ...`)
- `CD102` — check constraint dropped (`ALTER TABLE ... DROP CHECK ...`)
- `CD103` — primary key dropped (`ALTER TABLE ... DROP PRIMARY KEY`)

`DS105` is reduced to the untyped fallback for the ANSI `DROP CONSTRAINT <name>` form, whose constraint type is not recoverable from the SQL — so a typed drop yields exactly one finding (its `CD` code, never also `DS105`).

This adopts Atlas's finer-grained per-constraint Constraint-Deletion taxonomy (which in Atlas requires the closed-source binary + an account) as an MIT, local, no-account, embeddable rule family — advancing the embeddable-lint-engine goal of #654 within the #278 frame.

## Design

Follows the existing PG typed-constraint rules as the template. The four-way `switch` in `scanDropConstraint` is factored into typed predicates (`scanDropForeignKey` / `scanDropCheck` / `scanDropPrimaryKey`) plus `scanDropNamedConstraint` for the fallback, all sharing a small `scanDropClause` helper that anchors on the `ALTER TABLE` clause heads via the existing `clauseStarts` / `hasWordPrefix` — so schema-qualified names, `IF EXISTS`, `ONLY`, descendant `*`, and `CASCADE`/`RESTRICT` suffixes are all handled. A new `alterTableDropRule` helper (the DROP-side analogue of `postgresAlterRule`) builds the all-dialect, `SeverityError` `CD` rules, registered via `constraintDeletionRules()` in `builtinRules()`.

No new machinery: `CD` codes get per-code and family-prefix (`--disable CD`) disable and per-code severity override for free from the existing config, and surface in SARIF output without wiring.

## Tests

`migration/lint/lint_test.go`: the curated table now asserts `CD101`/`CD102`/`CD103` for the typed forms and `DS105` for the named form, with added schema-qualified, `IF EXISTS`, and `CASCADE` cases; a new `TestLintFS_ConstraintDeletionFamily` covers no-double-flag, family disable (`CD` keeps `DS105`), single-code disable, and a per-code `RuleConfig.Severity` override. `go test ./migration/lint/... ./cmd/lint/...` passes.

## Docs

`docs/native_cli.md` describes the `CD` family and the `DS105` scope change.

## Conformance

Lint rule codes are outside the `stokaro/ptah-atlas-conformance` probe tiers (which measure schema fidelity, not linter taxonomy); this is a `migration/lint` unit-test-only feature. A `PARITY.md` note that `CD1xx` is intentionally out of the automated probes follows in the conformance repo.
