### PR TITLE
Fail `ptah atlas <unknown-subcommand>` instead of exiting 0 (#687)

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -84,7 +84,7 @@ func newAtlasCommand(use, short, long string) *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmdutil.ConfigureCommandArgs(cmd, nil)
+	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	cmd.AddCommand(newAtlasVersionCommand())
 	cmd.AddCommand(newAtlasLicenseCommand())
 	cmd.AddCommand(newAtlasSchemaCommand())

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -219,6 +219,37 @@ func TestNewAtlasCommand_UnknownNestedCommandFails(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, `error: unexpected positional arguments ["aplly"]`)
 }
 
+// TestNewAtlasCommand_UnknownTopLevelCommandFails guards #687: `ptah atlas
+// <unknown>` must fail (exit non-zero), not silently print help and exit 0, so a
+// script with a typo does not masquerade as success.
+func TestNewAtlasCommand_UnknownTopLevelCommandFails(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"definitely-not-a-command"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["definitely-not-a-command"\]`)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+}
+
+func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewCompatCommand("ptah-compat")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"definitely-not-a-command"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+}
+
 func TestNewAtlasCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Closes #687.

## Problem

The top-level `ptah atlas` namespace exited **0** and printed help when given an unknown subcommand, so a script with a typo silently succeeded:

```
$ ptah atlas definitely-not-a-command ; echo "exit=$?"
... help ...
exit=0
```

Atlas CE exits non-zero with an `unknown command` error. This is a drop-in hazard — `ptah atlas migrate applyy` would run as a no-op success and the mistake goes unnoticed in CI.

## Fix

The `schema` and `migrate` subgroups already reject a stray positional argument via `cmdutil.NoPositionalArgs` (which routes through `Fail` for a printed message + usage exit code). Only the top group factory `newAtlasCommand` — used by both `ptah atlas` and the `ptah-compat` root — still passed `nil`, letting an unknown subcommand fall through to `RunE`, which printed help and returned nil. Give it the same `NoPositionalArgs` validator, so:

- no arguments → prints help, exits 0 (unchanged);
- an unknown subcommand → prints an error to stderr and exits non-zero, and is now consistent with the subgroups.

A one-line change; the `schema`/`migrate`/adapter commands are untouched (they already handle this).

## Tests

Adds top-level unknown-subcommand regression tests for both `NewAtlasCommand` and `NewCompatCommand` (they would have passed silently before the fix), alongside the existing nested-command tests.

## Context

Surfaced by the CLI exit/error-behavior conformance matrix (`stokaro/ptah-atlas-conformance`, #646), which records exit code, stream, and error class across Atlas OSS success/failure paths.
