### PR TITLE
Detect column widening in schema diff (INTEGER->BIGINT, VARCHAR length)

### DIFF
--- a/integration/fixtures/entities/004-field-rename/post.go
+++ b/integration/fixtures/entities/004-field-rename/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/005-field-type-change/post.go
+++ b/integration/fixtures/entities/005-field-type-change/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/006-field-drop/post.go
+++ b/integration/fixtures/entities/006-field-drop/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/007-index-add/post.go
+++ b/integration/fixtures/entities/007-index-add/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/008-index-remove/post.go
+++ b/integration/fixtures/entities/008-index-remove/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/009-add-constraints/post.go
+++ b/integration/fixtures/entities/009-add-constraints/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/010-drop-constraints/post.go
+++ b/integration/fixtures/entities/010-drop-constraints/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/011-add-entity/post.go
+++ b/integration/fixtures/entities/011-add-entity/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/012-drop-entity/post.go
+++ b/integration/fixtures/entities/012-drop-entity/post.go
@@ -13,7 +13,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/013-embedded-fields/post.go
+++ b/integration/fixtures/entities/013-embedded-fields/post.go
@@ -11,7 +11,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/014-rls-functions/post.go
+++ b/integration/fixtures/entities/014-rls-functions/post.go
@@ -11,7 +11,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/015-rls-advanced/post.go
+++ b/integration/fixtures/entities/015-rls-advanced/post.go
@@ -11,7 +11,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/integration/fixtures/entities/018-rls-functions-modified/post.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/post.go
@@ -11,7 +11,7 @@ type Post struct {
 	//migrator:schema:field name="content" type="TEXT" not_null="true"
 	Content string
 
-	//migrator:schema:field name="user_id" type="BIGINT" not_null="true"
+	//migrator:schema:field name="user_id" type="INTEGER" not_null="true"
 	UserID int64
 
 	//migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" not_null="true" default="draft"

--- a/migration/internal/typechange/typechange.go
+++ b/migration/internal/typechange/typechange.go
@@ -32,6 +32,35 @@ func IsNarrowing(oldType, newType string) bool {
 	return false
 }
 
+// IsWidening reports whether changing from oldType to newType keeps the same
+// type category but increases the representable range, length, or precision.
+//
+// It is the widening counterpart to IsNarrowing. The schema-diff normalizer
+// deliberately folds together members of a category (for example INTEGER and
+// BIGINT both normalize to "integer", and VARCHAR loses its length) so that
+// harmless dialect aliases do not surface as spurious changes. That folding also
+// hides genuine widenings — INTEGER -> BIGINT or VARCHAR(50) -> VARCHAR(100) —
+// which are real ALTERs that a database built directly from the desired schema
+// would apply. Reusing integerRank keeps the alias folding intact: INT, INTEGER
+// and INT4 share a rank, so widening compares range, not spelling.
+func IsWidening(oldType, newType string) bool {
+	oldSpec := parseSpec(oldType)
+	newSpec := parseSpec(newType)
+	if oldSpec.name == "" || newSpec.name == "" || oldSpec.name == newSpec.name && oldSpec.arg == 0 && newSpec.arg == 0 {
+		return false
+	}
+	if oldSpec.kind == "string" && newSpec.kind == "string" && oldSpec.arg > 0 && newSpec.arg > 0 {
+		return newSpec.arg > oldSpec.arg
+	}
+	if oldSpec.kind == "integer" && newSpec.kind == "integer" {
+		return integerRank(newSpec.name) > integerRank(oldSpec.name)
+	}
+	if oldSpec.kind == "decimal" && newSpec.kind == "decimal" {
+		return decimalWidens(oldSpec.args, newSpec.args)
+	}
+	return false
+}
+
 // Same reports whether two type names normalize to the same semantic type.
 func Same(left, right string) bool {
 	return normalizeName(left) == normalizeName(right)
@@ -124,4 +153,21 @@ func decimalNarrows(oldArgs, newArgs []int) bool {
 	oldIntegerDigits := oldArgs[0] - oldScale
 	newIntegerDigits := newArgs[0] - newScale
 	return newScale < oldScale || newIntegerDigits < oldIntegerDigits
+}
+
+func decimalWidens(oldArgs, newArgs []int) bool {
+	if len(oldArgs) == 0 || len(newArgs) == 0 {
+		return false
+	}
+	if newArgs[0] > oldArgs[0] {
+		return true
+	}
+	if len(oldArgs) < 2 || len(newArgs) < 2 {
+		return false
+	}
+	oldScale := oldArgs[1]
+	newScale := newArgs[1]
+	oldIntegerDigits := oldArgs[0] - oldScale
+	newIntegerDigits := newArgs[0] - newScale
+	return newScale > oldScale || newIntegerDigits > oldIntegerDigits
 }

--- a/migration/internal/typechange/typechange_test.go
+++ b/migration/internal/typechange/typechange_test.go
@@ -1,0 +1,86 @@
+package typechange_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/internal/typechange"
+)
+
+func TestIsWidening(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldType string
+		newType string
+		want    bool
+	}{
+		// Integer width increases (the core INTEGER -> BIGINT gap).
+		{"smallint to integer", "smallint", "integer", true},
+		{"integer to bigint", "integer", "bigint", true},
+		{"smallint to bigint", "smallint", "bigint", true},
+		{"int2 to int8 postgres aliases", "int2", "int8", true},
+
+		// Same range through dialect aliases must not read as a change.
+		{"int alias integer", "int", "integer", false},
+		{"int4 alias integer", "int4", "integer", false},
+		{"int8 alias bigint", "int8", "bigint", false},
+		{"identical integer", "integer", "integer", false},
+
+		// The narrowing direction is not a widening.
+		{"bigint to integer", "bigint", "integer", false},
+		{"integer to smallint", "integer", "smallint", false},
+
+		// String length increases.
+		{"varchar length up", "varchar(50)", "varchar(100)", true},
+		{"varchar length up postgres spelling", "character varying(50)", "varchar(100)", true},
+		{"varchar length down", "varchar(100)", "varchar(50)", false},
+		{"varchar same length", "varchar(100)", "varchar(100)", false},
+		// text has no length, so a text/varchar transition is not a same-category widening
+		// (it is a narrowing, handled by IsNarrowing).
+		{"text to varchar", "text", "varchar(255)", false},
+
+		// Decimal precision/scale increases.
+		{"decimal precision up", "numeric(10,2)", "numeric(12,2)", true},
+		{"decimal scale up", "numeric(10,2)", "numeric(10,4)", true},
+		{"decimal precision down", "numeric(12,2)", "numeric(10,2)", false},
+		{"decimal unchanged", "numeric(10,2)", "numeric(10,2)", false},
+
+		// Cross-category and empty inputs never widen.
+		{"integer to text", "integer", "text", false},
+		{"empty old", "", "bigint", false},
+		{"empty new", "integer", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(typechange.IsWidening(tt.oldType, tt.newType), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestWideningNarrowingAreOpposites documents that within a category the two
+// detectors are mirror images: a pure width/length increase widens one way and
+// narrows the other, and neither fires when the range is unchanged.
+func TestWideningNarrowingAreOpposites(t *testing.T) {
+	pairs := []struct {
+		name    string
+		smaller string
+		larger  string
+	}{
+		{"integer range", "integer", "bigint"},
+		{"varchar length", "varchar(50)", "varchar(100)"},
+		{"decimal precision", "numeric(10,2)", "numeric(12,2)"},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(typechange.IsWidening(p.smaller, p.larger), qt.IsTrue)
+			c.Assert(typechange.IsNarrowing(p.smaller, p.larger), qt.IsFalse)
+			c.Assert(typechange.IsWidening(p.larger, p.smaller), qt.IsFalse)
+			c.Assert(typechange.IsNarrowing(p.larger, p.smaller), qt.IsTrue)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -259,7 +259,7 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 
 	if genType != dbType {
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbType, genType)
-	} else if shouldReportNarrowingTypeChange(dbRawType, genCol.Type, dialect) {
+	} else if shouldReportSizedTypeChange(dbRawType, genCol.Type, dialect) {
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
 	}
 
@@ -338,12 +338,19 @@ func normalizeColumnTypesForDialect(genType, dbType, dialect string) (generatedT
 	}
 }
 
-func shouldReportNarrowingTypeChange(dbType, genType, dialect string) bool {
+// shouldReportSizedTypeChange reports a within-category change that the type
+// normalizer folds away — a change in integer width, string length, or decimal
+// precision, in either direction. Narrowing (e.g. BIGINT -> INTEGER) can lose
+// data; widening (e.g. INTEGER -> BIGINT, VARCHAR(50) -> VARCHAR(100)) cannot,
+// but it is still a real ALTER that a database built directly from the desired
+// schema would carry, so both are reported. The SQLite guard suppresses these
+// for SQLite's type affinity, where such distinctions do not exist.
+func shouldReportSizedTypeChange(dbType, genType, dialect string) bool {
 	if platform.NormalizeDialect(dialect) == platform.SQLite &&
 		normalize.Type(dbType) == normalize.Type(sqliteRenderedColumnType(genType)) {
 		return false
 	}
-	return typechange.IsNarrowing(dbType, genType)
+	return typechange.IsNarrowing(dbType, genType) || typechange.IsWidening(dbType, genType)
 }
 
 func sqliteRenderedColumnType(rawType string) string {

--- a/migration/schemadiff/internal/compare/compare_test.go
+++ b/migration/schemadiff/internal/compare/compare_test.go
@@ -183,6 +183,76 @@ func TestColumns_HappyPath(t *testing.T) {
 			},
 		},
 		{
+			name: "varchar widening preserves raw type",
+			genCol: goschema.Field{
+				Name: "name",
+				Type: "VARCHAR(255)",
+			},
+			dbCol: types.DBColumn{
+				Name:     "name",
+				DataType: "VARCHAR(100)",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "name",
+				Changes: map[string]string{
+					"type": "VARCHAR(100) -> VARCHAR(255)",
+				},
+			},
+		},
+		{
+			name: "postgres varchar widening uses length metadata",
+			genCol: goschema.Field{
+				Name: "name",
+				Type: "VARCHAR(255)",
+			},
+			dbCol: types.DBColumn{
+				Name:               "name",
+				DataType:           "character varying",
+				UDTName:            "varchar",
+				CharacterMaxLength: func() *int { value := 100; return &value }(),
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "name",
+				Changes: map[string]string{
+					"type": "varchar(100) -> VARCHAR(255)",
+				},
+			},
+		},
+		{
+			name: "integer widening preserves raw type",
+			genCol: goschema.Field{
+				Name: "count",
+				Type: "bigint",
+			},
+			dbCol: types.DBColumn{
+				Name:     "count",
+				DataType: "integer",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "count",
+				Changes: map[string]string{
+					"type": "integer -> bigint",
+				},
+			},
+		},
+		{
+			name: "decimal widening preserves raw type",
+			genCol: goschema.Field{
+				Name: "price",
+				Type: "NUMERIC(12,2)",
+			},
+			dbCol: types.DBColumn{
+				Name:     "price",
+				DataType: "NUMERIC(10,2)",
+			},
+			expected: difftypes.ColumnDiff{
+				ColumnName: "price",
+				Changes: map[string]string{
+					"type": "NUMERIC(10,2) -> NUMERIC(12,2)",
+				},
+			},
+		},
+		{
 			name: "primary key change",
 			genCol: goschema.Field{
 				Name:    "id",
@@ -1126,8 +1196,9 @@ func TestTableColumns_EdgeCases(t *testing.T) {
 	c.Assert(result.TableName, qt.Equals, "users")
 	c.Assert(result.ColumnsModified, qt.HasLen, 1)
 	c.Assert(result.ColumnsModified[0].ColumnName, qt.Equals, "name")
-	c.Assert(result.ColumnsModified[0].Changes, qt.HasLen, 1) // Only nullable should change (types are both varchar)
+	c.Assert(result.ColumnsModified[0].Changes, qt.HasLen, 2) // nullable tightens and the varchar length widens 100 -> 255
 	c.Assert(result.ColumnsModified[0].Changes["nullable"], qt.Equals, "true -> false")
+	c.Assert(result.ColumnsModified[0].Changes["type"], qt.Equals, "VARCHAR(100) -> VARCHAR(255)")
 }
 
 func TestTablesAndColumns_SortingConsistency(t *testing.T) {


### PR DESCRIPTION
## Summary

`ptah atlas schema apply` did not detect column **widenings** — `INTEGER -> BIGINT` and `VARCHAR(50) -> VARCHAR(100)` — so it reported *"Schema is synced, no changes to be made"* and never planned the `ALTER`. A database built directly from the desired schema ends up with `bigint` / `varchar(100)`, while an incrementally-applied one keeps the old width, so the two diverge.

## Root cause

The schema-diff type normalizer (`migration/schemadiff/internal/normalize`.`Type`) deliberately folds integer widths together (`smallint`/`int`/`integer`/`bigint` → `"integer"`) and drops `VARCHAR` length, so that harmless dialect aliases (`int` vs `integer` vs `int4`) do not surface as spurious changes. That same folding hid genuine width/length increases.

## Fix

The normalizer is already paired with a within-category detector — `migration/internal/typechange`.`IsNarrowing` — that catches the *data-losing* direction the normalizer hides (used by the column comparison's narrowing check). Widenings are simply the other direction:

- Add the symmetric `typechange.IsWidening`, reusing the existing `integerRank` so aliases still fold (width is compared by **range, not spelling**: `int == integer == int4`), plus string-length and decimal precision/scale increases.
- The column comparison now reports a within-category change in **either** direction (`shouldReportNarrowingTypeChange` → `shouldReportSizedTypeChange`, returning `IsNarrowing(...) || IsWidening(...)`).
- The SQLite type-affinity guard is preserved, so SQLite — where these width distinctions do not exist — is unaffected.

The migration planner already renders a `"type"` change as `ALTER COLUMN ... TYPE <desired>` regardless of direction (widening reuses the exact path narrowing and cross-category changes already use), and `migration/safety` keeps using `IsNarrowing` alone (widenings are non-destructive).

## Verification

Live PostgreSQL apply (the scenario #691 reported as broken):

- `INTEGER -> BIGINT`: now plans `type: int4 -> BIGINT`; column becomes `bigint`.
- `VARCHAR(50) -> VARCHAR(100)`: now plans the change; length becomes `100`.
- `BIGINT -> INTEGER` (narrowing): still works — no regression.
- `INTEGER -> INTEGER` and dialect aliases: still *"Schema is synced"* — no false positives / non-convergence.

Unit tests added for `IsWidening` (including alias-safety and widening/narrowing symmetry) and for the column comparison (integer, varchar, postgres length-metadata, and decimal widening cases). Full unit suite, `go vet`, `gofmt`, test-style, and `golangci-lint` all pass.

Fixes #691.