### PR TITLE
Detect scaleless-decimal and unbounded-varchar type changes (fixes #693)

### DIFF
--- a/migration/internal/typechange/typechange.go
+++ b/migration/internal/typechange/typechange.go
@@ -2,6 +2,7 @@
 package typechange
 
 import (
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -20,8 +21,12 @@ func IsNarrowing(oldType, newType string) bool {
 	if isTextType(oldSpec.name) && isSizedString(newSpec.name) {
 		return true
 	}
-	if oldSpec.kind == "string" && newSpec.kind == "string" && oldSpec.arg > 0 && newSpec.arg > 0 {
-		return newSpec.arg < oldSpec.arg
+	if oldSpec.kind == "string" && newSpec.kind == "string" {
+		oldLen, oldOK := stringLength(oldSpec)
+		newLen, newOK := stringLength(newSpec)
+		if oldOK && newOK {
+			return newLen < oldLen
+		}
 	}
 	if oldSpec.kind == "integer" && newSpec.kind == "integer" {
 		return integerRank(newSpec.name) < integerRank(oldSpec.name)
@@ -49,8 +54,12 @@ func IsWidening(oldType, newType string) bool {
 	if oldSpec.name == "" || newSpec.name == "" || oldSpec.name == newSpec.name && oldSpec.arg == 0 && newSpec.arg == 0 {
 		return false
 	}
-	if oldSpec.kind == "string" && newSpec.kind == "string" && oldSpec.arg > 0 && newSpec.arg > 0 {
-		return newSpec.arg > oldSpec.arg
+	if oldSpec.kind == "string" && newSpec.kind == "string" {
+		oldLen, oldOK := stringLength(oldSpec)
+		newLen, newOK := stringLength(newSpec)
+		if oldOK && newOK {
+			return newLen > oldLen
+		}
 	}
 	if oldSpec.kind == "integer" && newSpec.kind == "integer" {
 		return integerRank(newSpec.name) > integerRank(oldSpec.name)
@@ -139,35 +148,57 @@ func integerRank(name string) int {
 }
 
 func decimalNarrows(oldArgs, newArgs []int) bool {
-	if len(oldArgs) == 0 || len(newArgs) == 0 {
+	oldP, oldS, oldOK := decimalPrecisionScale(oldArgs)
+	newP, newS, newOK := decimalPrecisionScale(newArgs)
+	if !oldOK || !newOK {
 		return false
 	}
-	if newArgs[0] < oldArgs[0] {
-		return true
-	}
-	if len(oldArgs) < 2 || len(newArgs) < 2 {
-		return false
-	}
-	oldScale := oldArgs[1]
-	newScale := newArgs[1]
-	oldIntegerDigits := oldArgs[0] - oldScale
-	newIntegerDigits := newArgs[0] - newScale
-	return newScale < oldScale || newIntegerDigits < oldIntegerDigits
+	oldIntegerDigits := oldP - oldS
+	newIntegerDigits := newP - newS
+	return newP < oldP || newS < oldS || newIntegerDigits < oldIntegerDigits
 }
 
 func decimalWidens(oldArgs, newArgs []int) bool {
-	if len(oldArgs) == 0 || len(newArgs) == 0 {
+	oldP, oldS, oldOK := decimalPrecisionScale(oldArgs)
+	newP, newS, newOK := decimalPrecisionScale(newArgs)
+	if !oldOK || !newOK {
 		return false
 	}
-	if newArgs[0] > oldArgs[0] {
-		return true
+	oldIntegerDigits := oldP - oldS
+	newIntegerDigits := newP - newS
+	return newP > oldP || newS > oldS || newIntegerDigits > oldIntegerDigits
+}
+
+// decimalPrecisionScale returns the precision and scale carried by a decimal
+// type's parsed arguments. A precision given without a scale defaults the scale
+// to 0 (NUMERIC(10) is NUMERIC(10,0)), so a later scale addition or removal is
+// still a comparable change. ok is false for a bare NUMERIC with no precision at
+// all, whose unbounded precision cannot be compared against a sized one.
+func decimalPrecisionScale(args []int) (precision, scale int, ok bool) {
+	switch len(args) {
+	case 0:
+		return 0, 0, false
+	case 1:
+		return args[0], 0, true
+	default:
+		return args[0], args[1], true
 	}
-	if len(oldArgs) < 2 || len(newArgs) < 2 {
-		return false
+}
+
+// unboundedStringLength is the effective length of a bare VARCHAR (no declared
+// limit); it compares greater than any real column length.
+const unboundedStringLength = math.MaxInt
+
+// stringLength returns the effective character length of a sized-string spec.
+// A declared length is used as-is; a bare VARCHAR is unbounded. ok is false for
+// a bare CHAR / CHARACTER, whose implicit length is dialect-defined, so such a
+// type is not compared on length.
+func stringLength(s spec) (length int, ok bool) {
+	if s.arg > 0 {
+		return s.arg, true
 	}
-	oldScale := oldArgs[1]
-	newScale := newArgs[1]
-	oldIntegerDigits := oldArgs[0] - oldScale
-	newIntegerDigits := newArgs[0] - newScale
-	return newScale > oldScale || newIntegerDigits > oldIntegerDigits
+	if s.name == "varchar" {
+		return unboundedStringLength, true
+	}
+	return 0, false
 }

--- a/migration/internal/typechange/typechange_test.go
+++ b/migration/internal/typechange/typechange_test.go
@@ -46,6 +46,17 @@ func TestIsWidening(t *testing.T) {
 		{"decimal precision down", "numeric(12,2)", "numeric(10,2)", false},
 		{"decimal unchanged", "numeric(10,2)", "numeric(10,2)", false},
 
+		// Scaleless decimal — NUMERIC(10) means NUMERIC(10,0) (ptah#693).
+		{"decimal scaleless precision up", "numeric(10)", "numeric(12)", true},
+		{"decimal scale added", "numeric(10)", "numeric(10,2)", true},
+		{"decimal scaleless precision down", "numeric(12)", "numeric(10)", false},
+
+		// Unbounded VARCHAR compares greater than any finite length (ptah#693).
+		{"varchar bounded to unbounded", "varchar(50)", "varchar", true},
+		{"varchar unbounded to bounded", "varchar", "varchar(50)", false},
+		// A bare CHAR has a dialect-defined length, so it is not compared.
+		{"char bare to varchar not compared", "char", "varchar(50)", false},
+
 		// Cross-category and empty inputs never widen.
 		{"integer to text", "integer", "text", false},
 		{"empty old", "", "bigint", false},
@@ -56,6 +67,43 @@ func TestIsWidening(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			c.Assert(typechange.IsWidening(tt.oldType, tt.newType), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestIsNarrowing(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldType string
+		newType string
+		want    bool
+	}{
+		// Existing behavior stays intact.
+		{"integer range down", "bigint", "integer", true},
+		{"integer range up is not narrowing", "integer", "bigint", false},
+		{"varchar length down", "varchar(255)", "varchar(100)", true},
+		{"varchar length up is not narrowing", "varchar(100)", "varchar(255)", false},
+		{"text to sized string", "text", "varchar(255)", true},
+		{"integer aliases are not narrowing", "int4", "integer", false},
+
+		// Scaleless decimal — dropping fractional scale loses data (ptah#693); this
+		// is the case migration/safety must gate as destructive.
+		{"decimal scale dropped", "numeric(10,2)", "numeric(10)", true},
+		{"decimal scaleless precision down", "numeric(12)", "numeric(10)", true},
+		{"decimal scaleless precision up is not narrowing", "numeric(10)", "numeric(12)", false},
+
+		// Unbounded VARCHAR (ptah#693).
+		{"varchar unbounded to bounded", "varchar", "varchar(50)", true},
+		{"varchar bounded to unbounded is not narrowing", "varchar(50)", "varchar", false},
+		{"char bare to varchar is not compared", "char", "varchar(50)", false},
+
+		{"empty input", "", "numeric(10)", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(typechange.IsNarrowing(tt.oldType, tt.newType), qt.Equals, tt.want)
 		})
 	}
 }
@@ -72,6 +120,8 @@ func TestWideningNarrowingAreOpposites(t *testing.T) {
 		{"integer range", "integer", "bigint"},
 		{"varchar length", "varchar(50)", "varchar(100)"},
 		{"decimal precision", "numeric(10,2)", "numeric(12,2)"},
+		{"decimal scaleless precision", "numeric(10)", "numeric(12)"},
+		{"varchar bounded vs unbounded", "varchar(50)", "varchar"},
 	}
 
 	for _, p := range pairs {


### PR DESCRIPTION
## Summary

`typechange.IsNarrowing` / `IsWidening` detect within-category column type changes that the schema-diff normalizer folds away (integer width, string length, decimal precision/scale). Two changes still slipped through — both fixed here.

### 1. Decimal scale change where one side omits the scale

`decimalNarrows` / `decimalWidens` bailed via a `len(args) < 2` guard when either operand lacked an explicit scale, so `NUMERIC(10,2) -> NUMERIC(10)` was reported as *no change*. `NUMERIC(10)` is `NUMERIC(10,0)`, so a new `decimalPrecisionScale` defaults the missing scale to `0`, and both functions compare precision, scale, and integer digits (`precision - scale`).

This also closes a **safety gap**: `migration/safety` gates destructive migrations through `IsNarrowing` (`safety.go:415` → `IsTypeNarrowing` → `typechange.IsNarrowing`). A scale reduction that drops fractional data (`NUMERIC(10,2) -> NUMERIC(10)`) was **not** flagged as destructive; it now is.

### 2. Unbounded VARCHAR

The string length comparison required both sides to declare a length (`oldArg > 0 && newArg > 0`), so `VARCHAR(50) -> VARCHAR` (unbounded) and the reverse were missed. `stringLength` now models a bare `VARCHAR` as unbounded (`math.MaxInt`, greater than any declared length). A bare `CHAR` / `CHARACTER` keeps its dialect-defined implicit length and is deliberately still not compared.

## Scope note

A bare `NUMERIC` with no precision stays uncompared: its precision is unbounded and its scale undefined, so — unlike an unbounded `VARCHAR`, whose sentinel is only ever used in comparisons — it has no well-defined capacity to weigh against a sized decimal. Left as a deliberate, documented boundary.

## Verification

- New unit tests for both directions, including the scale-narrowing safety case, unbounded-varchar transitions, `char`-bare non-comparison, and widening/narrowing opposite pairs. Full `typechange` suite and the whole unit suite pass with no regressions (the change is strictly additive — for every previously-handled input the result is unchanged).
- `go vet`, `gofmt`, `golangci-lint` (0 issues), and the test-style gate all pass.

Fixes #693.