### PR TITLE
Add goschema.Merge to combine multiple parsed schema sources (#666 Phase 1)

### DIFF
--- a/core/goschema/merge.go
+++ b/core/goschema/merge.go
@@ -1,0 +1,126 @@
+package goschema
+
+// newDatabase returns an empty Database with every slice and map field
+// initialized, ready to accumulate schema objects from one or more sources.
+func newDatabase() *Database {
+	return &Database{
+		Schemas:                    []Schema{},
+		Tables:                     []Table{},
+		Fields:                     []Field{},
+		Indexes:                    []Index{},
+		Constraints:                []Constraint{},
+		Enums:                      []Enum{},
+		EmbeddedFields:             []EmbeddedField{},
+		Extensions:                 []Extension{},
+		Functions:                  []Function{},
+		Sequences:                  []Sequence{},
+		Domains:                    []Domain{},
+		CompositeTypes:             []CompositeType{},
+		Ranges:                     []Range{},
+		Views:                      []View{},
+		MaterializedViews:          []MaterializedView{},
+		Triggers:                   []Trigger{},
+		RLSPolicies:                []RLSPolicy{},
+		RLSEnabledTables:           []RLSEnabledTable{},
+		Roles:                      []Role{},
+		Grants:                     []Grant{},
+		Dependencies:               make(map[string][]string),
+		FunctionDependencies:       make(map[string][]string),
+		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
+	}
+}
+
+// appendDatabase concatenates every schema slice of src onto dst. The derived
+// maps (Dependencies, FunctionDependencies, SelfReferencingForeignKeys) are not
+// copied: they are rebuilt from the combined slices by finalizeDatabase, so
+// carrying them here would only risk duplicating self-referencing entries.
+func appendDatabase(dst, src *Database) {
+	dst.Schemas = append(dst.Schemas, src.Schemas...)
+	dst.Tables = append(dst.Tables, src.Tables...)
+	dst.Fields = append(dst.Fields, src.Fields...)
+	dst.Indexes = append(dst.Indexes, src.Indexes...)
+	dst.Constraints = append(dst.Constraints, src.Constraints...)
+	dst.Enums = append(dst.Enums, src.Enums...)
+	dst.EmbeddedFields = append(dst.EmbeddedFields, src.EmbeddedFields...)
+	dst.Extensions = append(dst.Extensions, src.Extensions...)
+	dst.Functions = append(dst.Functions, src.Functions...)
+	dst.Sequences = append(dst.Sequences, src.Sequences...)
+	dst.Domains = append(dst.Domains, src.Domains...)
+	dst.CompositeTypes = append(dst.CompositeTypes, src.CompositeTypes...)
+	dst.Ranges = append(dst.Ranges, src.Ranges...)
+	dst.Views = append(dst.Views, src.Views...)
+	dst.MaterializedViews = append(dst.MaterializedViews, src.MaterializedViews...)
+	dst.Triggers = append(dst.Triggers, src.Triggers...)
+	dst.RLSPolicies = append(dst.RLSPolicies, src.RLSPolicies...)
+	dst.RLSEnabledTables = append(dst.RLSEnabledTables, src.RLSEnabledTables...)
+	dst.Roles = append(dst.Roles, src.Roles...)
+	dst.Grants = append(dst.Grants, src.Grants...)
+}
+
+// finalizeDatabase runs the shared post-merge pipeline over an accumulator that
+// already holds the concatenated schema slices of one or more sources. It
+// validates that no two sources define the same object differently,
+// deduplicates identical definitions, normalizes table-scoped names, expands
+// embedded fields into concrete fields, and then rebuilds the dependency graph
+// and ordering. It is the single finalize path shared by ParseFS and Merge.
+func finalizeDatabase(result *Database) error {
+	if err := validateDuplicateSchemaObjectDefinitions(result); err != nil {
+		return err
+	}
+
+	// deduplicate entities (same table/field defined in multiple files/sources)
+	Deduplicate(result)
+	normalizeTableScopedNames(result)
+
+	// Process embedded fields BEFORE building dependency graph so that foreign
+	// keys contributed by embedded fields are included in dependency analysis.
+	result.Fields = processEmbeddedFields(result.EmbeddedFields, result.Fields)
+
+	// Build dependency graph for foreign key ordering.
+	buildDependencyGraph(result)
+
+	// Sort tables and functions by dependency order.
+	sortTablesByDependencies(result)
+	sortFunctionsByDependencies(result)
+
+	return nil
+}
+
+// Merge combines several parsed source schemas into a single finalized Database.
+//
+// It concatenates every schema slice of the inputs and then runs the same
+// finalize pipeline that ParseFS applies to the per-file schemas of one
+// directory, so it reconciles cross-source objects exactly as ParseFS reconciles
+// cross-file ones. Conflicting definitions of a named schema, view, materialized
+// view, trigger, constraint, or role are rejected with an error. Tables, fields,
+// and the remaining object kinds are deduplicated first-wins: identical
+// definitions across sources collapse to one, and if two sources define the same
+// table or field differently the first is kept (matching ParseFS's cross-file
+// behavior; stricter table/field conflict detection for composite sources is a
+// follow-up). Embedded fields are then expanded and the dependency graph and
+// table/function ordering are rebuilt. The derived maps of the inputs are
+// ignored and recomputed from the merged slices. A nil input is skipped.
+//
+// Merge is the reusable form of the merge ParseFS performs internally, so it can
+// assemble a composite desired-state schema from heterogeneous sources (several
+// Go roots, or a mix of Go, YAML, and HCL) and feed the result to the existing
+// render/compare/migrate paths unchanged.
+//
+// Inputs must be freshly parsed sources whose embedded fields have not yet been
+// expanded into concrete fields (as produced by parsing a single file), not the
+// already-finalized output of ParseDir/ParseFS: processEmbeddedFields is not
+// idempotent, so re-finalizing an already-expanded schema would duplicate the
+// generated fields.
+func Merge(dbs ...*Database) (*Database, error) {
+	result := newDatabase()
+	for _, db := range dbs {
+		if db == nil {
+			continue
+		}
+		appendDatabase(result, db)
+	}
+	if err := finalizeDatabase(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/core/goschema/merge_test.go
+++ b/core/goschema/merge_test.go
@@ -1,0 +1,138 @@
+package goschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+const usersSource = `package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+	//migrator:schema:field name="name" type="TEXT"
+	Name string
+}
+`
+
+const ordersSource = `package entities
+
+//migrator:schema:table name="orders"
+type Order struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+	//migrator:schema:field name="user_id" type="INTEGER" foreign="users(id)"
+	UserID int64
+}
+`
+
+// parseRaw parses a single Go source into a raw (un-finalized) Database, the
+// form Merge expects — the same thing ParseFS accumulates per file.
+func parseRaw(c *qt.C, filename, source string) *goschema.Database {
+	db, err := goschema.ParseSource(filename, source)
+	c.Assert(err, qt.IsNil)
+	return &db
+}
+
+// tableIndex returns the position of the named table in db.Tables, or -1.
+func tableIndex(db *goschema.Database, name string) int {
+	for i, table := range db.Tables {
+		if table.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestMergeCombinesDistinctSourcesAndOrdersForeignKeys(t *testing.T) {
+	c := qt.New(t)
+
+	users := parseRaw(c, "users.go", usersSource)
+	orders := parseRaw(c, "orders.go", ordersSource)
+
+	merged, err := goschema.Merge(users, orders)
+	c.Assert(err, qt.IsNil)
+
+	// Both tables are present.
+	c.Assert(len(merged.Tables), qt.Equals, 2)
+	usersIdx := tableIndex(merged, "users")
+	ordersIdx := tableIndex(merged, "orders")
+	c.Assert(usersIdx >= 0, qt.IsTrue)
+	c.Assert(ordersIdx >= 0, qt.IsTrue)
+
+	// orders references users, so the dependency sort places users first.
+	c.Assert(usersIdx < ordersIdx, qt.IsTrue)
+
+	// Fields from both sources survive the merge.
+	c.Assert(len(merged.Fields), qt.Equals, 4)
+}
+
+func TestMergeDeduplicatesIdenticalObjects(t *testing.T) {
+	c := qt.New(t)
+
+	// The same table defined in two sources collapses to one, as it does across
+	// files within a single ParseFS.
+	first := parseRaw(c, "users_a.go", usersSource)
+	second := parseRaw(c, "users_b.go", usersSource)
+
+	merged, err := goschema.Merge(first, second)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(len(merged.Tables), qt.Equals, 1)
+	c.Assert(tableIndex(merged, "users") >= 0, qt.IsTrue)
+	c.Assert(len(merged.Fields), qt.Equals, 2)
+}
+
+func TestMergeErrorsOnConflictingDefinitions(t *testing.T) {
+	c := qt.New(t)
+
+	// Two sources declaring the same view differently must be rejected rather
+	// than silently picking one.
+	first := &goschema.Database{
+		Views: []goschema.View{{StructName: "ActiveUsers", Name: "active_users", Body: "SELECT id FROM users WHERE active"}},
+	}
+	second := &goschema.Database{
+		Views: []goschema.View{{StructName: "ActiveUsers", Name: "active_users", Body: "SELECT id FROM users"}},
+	}
+
+	merged, err := goschema.Merge(first, second)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(merged, qt.IsNil)
+	c.Assert(err.Error(), qt.Contains, "active_users")
+}
+
+func TestMergeIdenticalViewsAcrossSourcesDeduplicate(t *testing.T) {
+	c := qt.New(t)
+
+	view := goschema.View{StructName: "ActiveUsers", Name: "active_users", Body: "SELECT id FROM users"}
+	first := &goschema.Database{Views: []goschema.View{view}}
+	second := &goschema.Database{Views: []goschema.View{view}}
+
+	merged, err := goschema.Merge(first, second)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(merged.Views), qt.Equals, 1)
+}
+
+func TestMergeSkipsNilSources(t *testing.T) {
+	c := qt.New(t)
+
+	users := parseRaw(c, "users.go", usersSource)
+
+	merged, err := goschema.Merge(nil, users, nil)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(merged.Tables), qt.Equals, 1)
+	c.Assert(tableIndex(merged, "users") >= 0, qt.IsTrue)
+}
+
+func TestMergeNoSourcesReturnsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	merged, err := goschema.Merge()
+	c.Assert(err, qt.IsNil)
+	c.Assert(merged, qt.IsNotNil)
+	c.Assert(len(merged.Tables), qt.Equals, 0)
+}

--- a/core/goschema/merge_test.go
+++ b/core/goschema/merge_test.go
@@ -58,7 +58,7 @@ func TestMergeCombinesDistinctSourcesAndOrdersForeignKeys(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Both tables are present.
-	c.Assert(len(merged.Tables), qt.Equals, 2)
+	c.Assert(merged.Tables, qt.HasLen, 2)
 	usersIdx := tableIndex(merged, "users")
 	ordersIdx := tableIndex(merged, "orders")
 	c.Assert(usersIdx >= 0, qt.IsTrue)
@@ -68,7 +68,7 @@ func TestMergeCombinesDistinctSourcesAndOrdersForeignKeys(t *testing.T) {
 	c.Assert(usersIdx < ordersIdx, qt.IsTrue)
 
 	// Fields from both sources survive the merge.
-	c.Assert(len(merged.Fields), qt.Equals, 4)
+	c.Assert(merged.Fields, qt.HasLen, 4)
 }
 
 func TestMergeDeduplicatesIdenticalObjects(t *testing.T) {
@@ -82,9 +82,9 @@ func TestMergeDeduplicatesIdenticalObjects(t *testing.T) {
 	merged, err := goschema.Merge(first, second)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(len(merged.Tables), qt.Equals, 1)
+	c.Assert(merged.Tables, qt.HasLen, 1)
 	c.Assert(tableIndex(merged, "users") >= 0, qt.IsTrue)
-	c.Assert(len(merged.Fields), qt.Equals, 2)
+	c.Assert(merged.Fields, qt.HasLen, 2)
 }
 
 func TestMergeErrorsOnConflictingDefinitions(t *testing.T) {
@@ -114,7 +114,7 @@ func TestMergeIdenticalViewsAcrossSourcesDeduplicate(t *testing.T) {
 
 	merged, err := goschema.Merge(first, second)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(merged.Views), qt.Equals, 1)
+	c.Assert(merged.Views, qt.HasLen, 1)
 }
 
 func TestMergeSkipsNilSources(t *testing.T) {
@@ -124,7 +124,7 @@ func TestMergeSkipsNilSources(t *testing.T) {
 
 	merged, err := goschema.Merge(nil, users, nil)
 	c.Assert(err, qt.IsNil)
-	c.Assert(len(merged.Tables), qt.Equals, 1)
+	c.Assert(merged.Tables, qt.HasLen, 1)
 	c.Assert(tableIndex(merged, "users") >= 0, qt.IsTrue)
 }
 
@@ -134,5 +134,5 @@ func TestMergeNoSourcesReturnsEmpty(t *testing.T) {
 	merged, err := goschema.Merge()
 	c.Assert(err, qt.IsNil)
 	c.Assert(merged, qt.IsNotNil)
-	c.Assert(len(merged.Tables), qt.Equals, 0)
+	c.Assert(merged.Tables, qt.HasLen, 0)
 }

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -76,31 +76,7 @@ func ParseDir(rootDir string) (*Database, error) {
 //		return fmt.Errorf("failed to render schema: %w", err)
 //	}
 func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
-	result := &Database{
-		Schemas:                    []Schema{},
-		Tables:                     []Table{},
-		Fields:                     []Field{},
-		Indexes:                    []Index{},
-		Constraints:                []Constraint{},
-		Enums:                      []Enum{},
-		EmbeddedFields:             []EmbeddedField{},
-		Extensions:                 []Extension{},
-		Functions:                  []Function{},
-		Sequences:                  []Sequence{},
-		Domains:                    []Domain{},
-		CompositeTypes:             []CompositeType{},
-		Ranges:                     []Range{},
-		Views:                      []View{},
-		MaterializedViews:          []MaterializedView{},
-		Triggers:                   []Trigger{},
-		RLSPolicies:                []RLSPolicy{},
-		RLSEnabledTables:           []RLSEnabledTable{},
-		Roles:                      []Role{},
-		Grants:                     []Grant{},
-		Dependencies:               make(map[string][]string),
-		FunctionDependencies:       make(map[string][]string),
-		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
-	}
+	result := newDatabase()
 
 	var parseErrors []error
 
@@ -131,27 +107,8 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 			return nil
 		}
 
-		// Add to result
-		result.Schemas = append(result.Schemas, database.Schemas...)
-		result.EmbeddedFields = append(result.EmbeddedFields, database.EmbeddedFields...)
-		result.Fields = append(result.Fields, database.Fields...)
-		result.Indexes = append(result.Indexes, database.Indexes...)
-		result.Tables = append(result.Tables, database.Tables...)
-		result.Enums = append(result.Enums, database.Enums...)
-		result.Extensions = append(result.Extensions, database.Extensions...)
-		result.Functions = append(result.Functions, database.Functions...)
-		result.Sequences = append(result.Sequences, database.Sequences...)
-		result.Domains = append(result.Domains, database.Domains...)
-		result.CompositeTypes = append(result.CompositeTypes, database.CompositeTypes...)
-		result.Ranges = append(result.Ranges, database.Ranges...)
-		result.RLSPolicies = append(result.RLSPolicies, database.RLSPolicies...)
-		result.RLSEnabledTables = append(result.RLSEnabledTables, database.RLSEnabledTables...)
-		result.Roles = append(result.Roles, database.Roles...)
-		result.Constraints = append(result.Constraints, database.Constraints...)
-		result.Views = append(result.Views, database.Views...)
-		result.MaterializedViews = append(result.MaterializedViews, database.MaterializedViews...)
-		result.Triggers = append(result.Triggers, database.Triggers...)
-		result.Grants = append(result.Grants, database.Grants...)
+		// Add this file's schema objects to the accumulator.
+		appendDatabase(result, &database)
 
 		return nil
 	})
@@ -163,26 +120,9 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 		return nil, err
 	}
 
-	if err := validateDuplicateSchemaObjectDefinitions(result); err != nil {
+	if err := finalizeDatabase(result); err != nil {
 		return nil, err
 	}
-
-	// deduplicate entities (same table/field defined in multiple files)
-	Deduplicate(result)
-	normalizeTableScopedNames(result)
-
-	// Process embedded fields BEFORE building dependency graph
-	// This ensures that foreign keys from embedded fields are included in dependency analysis
-	result.Fields = processEmbeddedFields(result.EmbeddedFields, result.Fields)
-
-	// Build dependency graph for foreign key ordering
-	buildDependencyGraph(result)
-
-	// Sort tables by dependency order
-	sortTablesByDependencies(result)
-
-	// Sort functions by dependency order
-	sortFunctionsByDependencies(result)
 
 	return result, nil
 }

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -412,6 +412,7 @@ type CompositeType struct{ ... }
 type CompositeTypeField struct{ ... }
 type Constraint struct{ ... }
 type Database struct{ ... }
+    func Merge(dbs ...*Database) (*Database, error)
     func ParseDir(rootDir string) (*Database, error)
     func ParseFS(fsys fs.FS, rootDir string) (*Database, error)
     func ParseFile(filename string) (Database, error)


### PR DESCRIPTION
## Summary

First phase of composite desired-state schema (#666): a reusable primitive to merge multiple parsed schema sources into one `*goschema.Database`, which the existing `render`/`compare`/`migrate` paths already consume unchanged. This is the embeddable-core (MIT, local, no-account) counterpart to Atlas's Pro-only `data "composite_schema"` datasource.

`ParseFS` already performs a merge-of-many-Databases internally — it concatenates every slice of the per-file parse results and runs a finalize pipeline (validate → deduplicate → normalize → expand embedded fields → build dependency graph → sort). That merge was inlined and reachable only from a single directory walk.

## Changes

- **New `core/goschema/merge.go`**: exported `Merge(dbs ...*Database) (*Database, error)`, backed by shared unexported helpers `newDatabase()`, `appendDatabase(dst, src)`, and `finalizeDatabase(result)`.
- **Refactor `ParseFS`** to use those helpers instead of its inlined struct init / 20 slice-appends / 7-step finalize — **no behavior change** (the existing walker/parser tests cover the single-source path).
- **New `core/goschema/merge_test.go`**: distinct-source merge with cross-source foreign-key ordering, dedup of identical objects (tables and views), conflict error, nil-skip, zero-arg.
- `docs/public_api.snapshot`: the `Merge` signature.

## Design notes

- **Input contract**: `Merge` takes *freshly parsed* (pre-finalize) sources — the same raw per-file Databases `ParseFS` accumulates — not the already-finalized output of `ParseDir`/`ParseFS`. `processEmbeddedFields` is not idempotent, so re-finalizing an already-expanded schema would duplicate the generated fields. This is documented on `Merge`.
- **Conflict semantics**: conflicting definitions of a named schema, view, materialized view, trigger, constraint, or role are errors. Tables and fields deduplicate first-wins across sources, matching `ParseFS`'s existing cross-file behavior. Making the shared finalize path error on conflicting tables/fields would change that long-standing behavior, so **stricter table/field conflict detection for composite sources is deferred** to a follow-up phase (tracked under #666), along with the CLI/config wiring (repeatable `--root-dir`/`--schema-file`, `ptah.yaml` `src`).

## Verification

- Full unit suite passes (backward compatibility). `go vet`, `gofmt`, `golangci-lint` (0 issues), test-style, and the public-API ledger/snapshot checks all pass.
- Independent review confirmed the extraction is behavior-preserving (all 20 slices + 3 maps handled identically, finalize order unchanged, derived maps correctly recomputed) and flagged the doc's conflict-detection wording, now corrected to match the actual behavior.

Part of #666.