### PR TITLE
Support multiple Go roots in `ptah render` (composite schema, #666 Phase 2)

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -22,7 +22,7 @@ const (
 )
 
 type options struct {
-	rootDir    string
+	rootDirs   []string
 	schemaFile string
 	dialect    string
 }
@@ -49,13 +49,13 @@ schema, or SQL schema file instead.`,
 
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
-	flags.StringVar(&opts.rootDir, rootDirFlag, "./", "Root directory to scan for Go entities")
+	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringVar(&opts.schemaFile, schemaFileFlag, "", "YAML, HCL, or SQL schema file to generate from instead of scanning Go entities")
 	flags.StringVar(&opts.dialect, dialectFlag, "", "Database dialect (postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, spanner). If empty, generates for all dialects")
 }
 
 func generateCommand(_ *cobra.Command, opts *options) error {
-	result, err := loadSchema(opts.rootDir, opts.schemaFile)
+	result, err := loadSchema(opts.rootDirs, opts.schemaFile)
 	if err != nil {
 		return err
 	}
@@ -119,30 +119,37 @@ func generateCommand(_ *cobra.Command, opts *options) error {
 	return nil
 }
 
-func loadSchema(rootDir, schemaFile string) (*goschema.Database, error) {
+func loadSchema(rootDirs []string, schemaFile string) (*goschema.Database, error) {
 	if schemaFile != "" {
 		return loadSchemaFile(schemaFile)
 	}
 
-	// Convert to absolute path
-	absPath, err := filepath.Abs(rootDir)
-	if err != nil {
-		return nil, fmt.Errorf("error resolving path: %w", err)
+	if len(rootDirs) == 0 {
+		rootDirs = []string{"./"}
 	}
 
-	// Check if directory exists
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("directory does not exist: %s", absPath)
+	// Resolve and validate every root before parsing so a bad path fails fast.
+	absRoots := make([]string, 0, len(rootDirs))
+	for _, rootDir := range rootDirs {
+		absPath, err := filepath.Abs(rootDir)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving path: %w", err)
+		}
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("directory does not exist: %s", absPath)
+		}
+		absRoots = append(absRoots, absPath)
 	}
 
-	fmt.Printf("Scanning directory: %s\n", absPath)
-	fmt.Println("=" + strings.Repeat("=", len(absPath)+19))
+	for _, absPath := range absRoots {
+		fmt.Printf("Scanning directory: %s\n", absPath)
+	}
 	fmt.Println()
 
-	// Parse the entire package recursively
-	result, err := goschema.ParseDir(absPath)
+	// Parse every root into one composite schema (merged and finalized together).
+	result, err := goschema.ParseDirs(absRoots...)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing package: %w", err)
+		return nil, fmt.Errorf("error parsing packages: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -26,7 +26,7 @@ tables:
 		qt.IsNil,
 	)
 
-	db, err := loadSchema("", path)
+	db, err := loadSchema(nil, path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -47,7 +47,7 @@ table "users" {
 }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema("", path)
+	db, err := loadSchema(nil, path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -65,7 +65,7 @@ CREATE TABLE users (
 );
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema("", path)
+	db, err := loadSchema(nil, path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -78,6 +78,40 @@ func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "schema.json")
 	c.Assert(os.WriteFile(path, []byte(`{}`), 0o600), qt.IsNil)
 
-	_, err := loadSchema("", path)
+	_, err := loadSchema(nil, path)
 	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, .hcl, and .sql are supported`)
+}
+
+func TestLoadSchemaMergesMultipleRoots(t *testing.T) {
+	c := qt.New(t)
+
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(rootA, "users.go"), []byte(`package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(rootB, "orders.go"), []byte(`package entities
+
+//migrator:schema:table name="orders"
+type Order struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+
+	db, err := loadSchema([]string{rootA, rootB}, "")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 2)
+}
+
+func TestLoadSchemaRejectsMissingRoot(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := loadSchema([]string{filepath.Join(t.TempDir(), "does-not-exist")}, "")
+	c.Assert(err, qt.ErrorMatches, `directory does not exist: .*does-not-exist`)
 }

--- a/core/goschema/parsedirs_test.go
+++ b/core/goschema/parsedirs_test.go
@@ -1,0 +1,57 @@
+package goschema_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+func writeGoFile(c *qt.C, dir, name, content string) {
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+}
+
+func TestParseDirsMergesMultipleRoots(t *testing.T) {
+	c := qt.New(t)
+
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeGoFile(c, rootA, "users.go", usersSource)
+	writeGoFile(c, rootB, "orders.go", ordersSource)
+
+	db, err := goschema.ParseDirs(rootA, rootB)
+	c.Assert(err, qt.IsNil)
+
+	// Both roots contribute their table, finalized together.
+	c.Assert(db.Tables, qt.HasLen, 2)
+	c.Assert(db.Fields, qt.HasLen, 4)
+
+	// orders (root B) references users (root A), so the shared dependency sort
+	// orders users first across roots.
+	c.Assert(tableIndex(db, "users") < tableIndex(db, "orders"), qt.IsTrue)
+}
+
+func TestParseDirsSingleRoot(t *testing.T) {
+	c := qt.New(t)
+
+	root := t.TempDir()
+	writeGoFile(c, root, "users.go", usersSource)
+
+	db, err := goschema.ParseDirs(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(tableIndex(db, "users") >= 0, qt.IsTrue)
+	c.Assert(db.Fields, qt.HasLen, 2)
+}
+
+func TestParseDirsNoRootsReturnsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := goschema.ParseDirs()
+	c.Assert(err, qt.IsNil)
+	c.Assert(db, qt.IsNotNil)
+	c.Assert(db.Tables, qt.HasLen, 0)
+}

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -77,7 +77,47 @@ func ParseDir(rootDir string) (*Database, error) {
 //	}
 func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 	result := newDatabase()
+	if err := accumulateGoFiles(result, fsys, rootDir); err != nil {
+		return nil, err
+	}
+	if err := finalizeDatabase(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
+// ParseDirs parses several Go entity roots into a single composite schema.
+//
+// Each root is walked like ParseDir, every file's schema objects from every root
+// are accumulated together, and the finalize pipeline (deduplicate, expand
+// embedded fields, build the dependency graph, sort) runs once over the combined
+// set — so a table in one root can reference a table in another. It is the
+// multi-root form of ParseDir, for a composite desired-state schema assembled
+// from several Go packages (for example a shared "common" package plus
+// per-service tables).
+//
+// Identical definitions across roots are deduplicated; conflicting definitions
+// of a named schema, view, materialized view, trigger, constraint, or role are
+// an error, matching ParseDir's cross-file behavior. With a single root it is
+// equivalent to ParseDir.
+func ParseDirs(roots ...string) (*Database, error) {
+	result := newDatabase()
+	for _, root := range roots {
+		if err := accumulateGoFiles(result, os.DirFS(root), "."); err != nil {
+			return nil, err
+		}
+	}
+	if err := finalizeDatabase(result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// accumulateGoFiles walks the non-test, non-vendor Go source files under rootDir
+// in fsys and appends each parsed file's schema objects onto result without
+// finalizing. It is the shared, pre-finalize body of ParseFS and ParseDirs, so
+// multiple roots can accumulate into one result before a single finalize pass.
+func accumulateGoFiles(result *Database, fsys fs.FS, rootDir string) error {
 	var parseErrors []error
 
 	// Walk through all directories recursively
@@ -114,17 +154,9 @@ func ParseFS(fsys fs.FS, rootDir string) (*Database, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err := errors.Join(parseErrors...); err != nil {
-		return nil, err
-	}
-
-	if err := finalizeDatabase(result); err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return errors.Join(parseErrors...)
 }
 
 func parseDatabaseFile(fsys fs.FS, path string) (Database, error) {

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -414,6 +414,7 @@ type Constraint struct{ ... }
 type Database struct{ ... }
     func Merge(dbs ...*Database) (*Database, error)
     func ParseDir(rootDir string) (*Database, error)
+    func ParseDirs(roots ...string) (*Database, error)
     func ParseFS(fsys fs.FS, rootDir string) (*Database, error)
     func ParseFile(filename string) (Database, error)
     func ParseFileWithDependencies(filename string) (Database, error)


### PR DESCRIPTION
## Summary

Phase 2 of composite desired-state schema (#666): make the desired schema assemblable from **multiple Go entity roots**, both as a library call and via the CLI.

- **`goschema.ParseDirs(roots ...string) (*Database, error)`** — the multi-root form of `ParseDir`. It walks every root, accumulates all files, and runs the finalize pipeline (dedup, embedded-field expansion, dependency graph, sort) **once over the combined set**, so a table in one root can reference a table in another. This is the correct approach for Go sources: merging *finalized* `ParseDir` outputs would double embedded-field expansions (the non-idempotence noted in Phase 1's `Merge` contract), whereas a single finalize over the union is clean.
- **`ParseFS` refactor** — the file walk is extracted into a shared `accumulateGoFiles` used by both `ParseFS` and `ParseDirs`, with no behavior change (existing walker/parser tests cover it).
- **CLI** — `ptah render`'s `--root-dir` is now repeatable; the roots feed `ParseDirs`. A single `--root-dir` (or none, defaulting to `./`) behaves exactly as before.

## Example

```
ptah render --root-dir ./common --root-dir ./services/orders --dialect postgres
```

emits SQL for the schema formed by merging the `common` and `orders` Go packages.

## Scope

This covers the common multi-Go-root composite case. Deferred as follow-ups under #666:
- Mixing heterogeneous source kinds (Go + YAML + Atlas HCL) via `goschema.Merge` — needs raw (pre-finalize) parses of each kind.
- Wiring composite desired-state into `ptah compare` / `ptah migrate`.
- `ptah.yaml` `src`/schema-source list (Phase 4).

## Verification

- New tests: `goschema.ParseDirs` (two-root merge with cross-root FK ordering, single-root equivalence, no-roots) and the CLI `loadSchema` (multi-root merge, missing-root error).
- Full unit suite passes (backward compatibility). `go vet`, `gofmt`, `golangci-lint` (0 issues), `qtlint`, test-style, and the public-API ledger/snapshot checks all pass.

Part of #666.