### PR TITLE
Accept multiple Go roots in `ptah compare` and `ptah migrate` (composite schema, #666)

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +26,7 @@ const (
 )
 
 type options struct {
-	rootDir        string
+	rootDirs       []string
 	dbURL          string
 	exitOnDiff     bool
 	connectTimeout string
@@ -52,7 +53,7 @@ currently exists in the database, helping you identify what needs to be migrated
 
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
-	flags.StringVar(&opts.rootDir, rootDirFlag, "./", "Root directory to scan for Go entities")
+	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.exitOnDiff, exitCodeFlag, false, "Exit with 1 when the schema diff is non-empty")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
@@ -66,17 +67,26 @@ func compareCommand(cmd *cobra.Command, opts *options) error {
 		return fmt.Errorf("database URL is required")
 	}
 
-	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", opts.rootDir, dbschema.FormatDatabaseURL(opts.dbURL))
+	roots := opts.rootDirs
+	if len(roots) == 0 {
+		roots = []string{"./"}
+	}
+
+	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", strings.Join(roots, ", "), dbschema.FormatDatabaseURL(opts.dbURL))
 	fmt.Fprintln(out, "=== SCHEMA COMPARISON ===")
 	fmt.Fprintln(out)
 
-	// 1. Parse Go entities
-	absPath, err := filepath.Abs(opts.rootDir)
-	if err != nil {
-		return fmt.Errorf("error resolving path: %w", err)
+	// 1. Parse Go entities from every root into one composite schema
+	absRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		absPath, err := filepath.Abs(root)
+		if err != nil {
+			return fmt.Errorf("error resolving path: %w", err)
+		}
+		absRoots = append(absRoots, absPath)
 	}
 
-	result, err := goschema.ParseDir(absPath)
+	result, err := goschema.ParseDirs(absRoots...)
 	if err != nil {
 		return fmt.Errorf("error parsing Go entities: %w", err)
 	}

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -29,7 +29,7 @@ const (
 )
 
 type options struct {
-	rootDir          string
+	rootDirs         []string
 	dbURL            string
 	checkDestructive bool
 	allowDestructive bool
@@ -58,7 +58,7 @@ the SQL statements needed to update the database to match your entities.`,
 
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
-	flags.StringVar(&opts.rootDir, rootDirFlag, "./", "Root directory to scan for Go entities")
+	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.checkDestructive, checkDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
 	flags.BoolVar(&opts.allowDestructive, allowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
@@ -77,19 +77,29 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	if reportFormat != "text" && reportFormat != "html" && reportFormat != "json" {
 		return fmt.Errorf("unsupported report format %q", reportFormat)
 	}
+	roots := opts.rootDirs
+	if len(roots) == 0 {
+		roots = []string{"./"}
+	}
+	rootsDisplay := strings.Join(roots, ", ")
+
 	if reportFormat == "text" {
-		fmt.Fprintf(out, "Generating migration from %s to database %s\n", opts.rootDir, dbschema.FormatDatabaseURL(opts.dbURL))
+		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootsDisplay, dbschema.FormatDatabaseURL(opts.dbURL))
 		fmt.Fprintln(out, "=== GENERATE MIGRATION SQL ===")
 		fmt.Fprintln(out)
 	}
 
-	// 1. Parse Go entities
-	absPath, err := filepath.Abs(opts.rootDir)
-	if err != nil {
-		return fmt.Errorf("error resolving path: %w", err)
+	// 1. Parse Go entities from every root into one composite schema
+	absRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		absPath, err := filepath.Abs(root)
+		if err != nil {
+			return fmt.Errorf("error resolving path: %w", err)
+		}
+		absRoots = append(absRoots, absPath)
 	}
 
-	result, err := goschema.ParseDir(absPath)
+	result, err := goschema.ParseDirs(absRoots...)
 	if err != nil {
 		return fmt.Errorf("error parsing Go entities: %w", err)
 	}
@@ -158,7 +168,7 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 
 	fmt.Fprintln(out, "-- Migration generated from schema differences")
 	fmt.Fprintf(out, "-- Generated on: %s\n", "now") // You could add actual timestamp
-	fmt.Fprintf(out, "-- Source: %s\n", opts.rootDir)
+	fmt.Fprintf(out, "-- Source: %s\n", rootsDisplay)
 	fmt.Fprintf(out, "-- Target: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
 	fmt.Fprintln(out)
 


### PR DESCRIPTION
## Summary

Extends composite desired-state schema (#666) from `ptah render` to the migration workflow: `ptah compare` and `ptah migrate` now accept a **repeatable `--root-dir`** and parse the roots with `goschema.ParseDirs`, so a schema assembled from several Go packages (e.g. a shared `common` package plus per-service tables) can be **diffed against** and **migrated to** a database — the composite feature's primary use case, not just rendering.

A single `--root-dir` (or none, defaulting to `./`) behaves exactly as before.

## Example

```
ptah migrate --root-dir ./common --root-dir ./services/orders --db-url postgres://localhost/app
```

generates the migration to reconcile the database with the merged `common` + `orders` schema.

## Changes

- `cmd/compare/compare.go` and `cmd/migrate/migrate.go`: `--root-dir` is now `StringArrayVar` (repeatable); the roots are resolved and passed to `goschema.ParseDirs` (the primitive added in #697). Display output joins the roots.

No new public API — this reuses `ParseDirs`. The merge behavior itself is covered by the existing `goschema.ParseDirs` and render `loadSchema` tests.

## Scope

The file-based `ptah migrate generate` path threads a single `GoEntitiesDir` into `migration/generator`; extending it to multiple roots (via a pre-merged `*goschema.Database` option on the generator) is a follow-up under #666, along with mixing heterogeneous source kinds (Go + YAML + HCL).

## Verification

- Full unit suite passes (backward compatibility). `go vet`, `gofmt`, `golangci-lint` (0 issues), `qtlint`, test-style, and the public-API snapshot checks all pass.

Part of #666.