### PR TITLE
Compose Go, YAML, and HCL sources in `ptah render` (composite schema, #666)

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -22,9 +22,9 @@ const (
 )
 
 type options struct {
-	rootDirs   []string
-	schemaFile string
-	dialect    string
+	rootDirs    []string
+	schemaFiles []string
+	dialect     string
 }
 
 func NewGenerateCommand() *cobra.Command {
@@ -50,12 +50,12 @@ schema, or SQL schema file instead.`,
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
-	flags.StringVar(&opts.schemaFile, schemaFileFlag, "", "YAML, HCL, or SQL schema file to generate from instead of scanning Go entities")
+	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to generate from instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	flags.StringVar(&opts.dialect, dialectFlag, "", "Database dialect (postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, spanner). If empty, generates for all dialects")
 }
 
 func generateCommand(_ *cobra.Command, opts *options) error {
-	result, err := loadSchema(opts.rootDirs, opts.schemaFile)
+	result, err := loadSchema(opts.rootDirs, opts.schemaFiles)
 	if err != nil {
 		return err
 	}
@@ -119,16 +119,79 @@ func generateCommand(_ *cobra.Command, opts *options) error {
 	return nil
 }
 
-func loadSchema(rootDirs []string, schemaFile string) (*goschema.Database, error) {
-	if schemaFile != "" {
-		return loadSchemaFile(schemaFile)
-	}
-
-	if len(rootDirs) == 0 {
+func loadSchema(rootDirs, schemaFiles []string) (*goschema.Database, error) {
+	// With no source of any kind, default to scanning the current directory for
+	// Go entities (the historical behavior).
+	if len(rootDirs) == 0 && len(schemaFiles) == 0 {
 		rootDirs = []string{"./"}
 	}
 
-	// Resolve and validate every root before parsing so a bad path fails fast.
+	// Single-source fast paths, unchanged from before: Go roots only, or exactly
+	// one schema file.
+	if len(schemaFiles) == 0 {
+		return loadGoRoots(rootDirs)
+	}
+	if len(rootDirs) == 0 && len(schemaFiles) == 1 {
+		return loadSchemaFile(schemaFiles[0])
+	}
+
+	// Composite: merge the Go roots (parsed un-finalized so Merge can run the
+	// single finalize pass) with each schema file.
+	var sources []*goschema.Database
+	if len(rootDirs) > 0 {
+		absRoots, err := resolveRootDirs(rootDirs)
+		if err != nil {
+			return nil, err
+		}
+		for _, absPath := range absRoots {
+			fmt.Printf("Scanning directory: %s\n", absPath)
+		}
+		goDB, err := goschema.ParseDirRaw(absRoots...)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing packages: %w", err)
+		}
+		sources = append(sources, goDB)
+	}
+	for _, schemaFile := range schemaFiles {
+		fmt.Printf("Loading schema file: %s\n", schemaFile)
+		fileDB, err := loadSchemaFile(schemaFile)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, fileDB)
+	}
+	fmt.Println()
+
+	result, err := goschema.Merge(sources...)
+	if err != nil {
+		return nil, fmt.Errorf("error merging composite schema: %w", err)
+	}
+	return result, nil
+}
+
+// loadGoRoots parses one or more Go entity roots into a finalized composite
+// schema.
+func loadGoRoots(rootDirs []string) (*goschema.Database, error) {
+	absRoots, err := resolveRootDirs(rootDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, absPath := range absRoots {
+		fmt.Printf("Scanning directory: %s\n", absPath)
+	}
+	fmt.Println()
+
+	result, err := goschema.ParseDirs(absRoots...)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing packages: %w", err)
+	}
+	return result, nil
+}
+
+// resolveRootDirs turns each root into an absolute path and fails fast if any
+// does not exist.
+func resolveRootDirs(rootDirs []string) ([]string, error) {
 	absRoots := make([]string, 0, len(rootDirs))
 	for _, rootDir := range rootDirs {
 		absPath, err := filepath.Abs(rootDir)
@@ -140,18 +203,7 @@ func loadSchema(rootDirs []string, schemaFile string) (*goschema.Database, error
 		}
 		absRoots = append(absRoots, absPath)
 	}
-
-	for _, absPath := range absRoots {
-		fmt.Printf("Scanning directory: %s\n", absPath)
-	}
-	fmt.Println()
-
-	// Parse every root into one composite schema (merged and finalized together).
-	result, err := goschema.ParseDirs(absRoots...)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing packages: %w", err)
-	}
-	return result, nil
+	return absRoots, nil
 }
 
 func loadSchemaFile(schemaFile string) (*goschema.Database, error) {

--- a/cmd/generate/generate_internal_test.go
+++ b/cmd/generate/generate_internal_test.go
@@ -26,7 +26,7 @@ tables:
 		qt.IsNil,
 	)
 
-	db, err := loadSchema(nil, path)
+	db, err := loadSchema(nil, []string{path})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -47,7 +47,7 @@ table "users" {
 }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema(nil, path)
+	db, err := loadSchema(nil, []string{path})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -65,7 +65,7 @@ CREATE TABLE users (
 );
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema(nil, path)
+	db, err := loadSchema(nil, []string{path})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
@@ -78,7 +78,7 @@ func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "schema.json")
 	c.Assert(os.WriteFile(path, []byte(`{}`), 0o600), qt.IsNil)
 
-	_, err := loadSchema(nil, path)
+	_, err := loadSchema(nil, []string{path})
 	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, .hcl, and .sql are supported`)
 }
 
@@ -104,7 +104,7 @@ type Order struct {
 }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema([]string{rootA, rootB}, "")
+	db, err := loadSchema([]string{rootA, rootB}, nil)
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 2)
 }
@@ -112,6 +112,32 @@ type Order struct {
 func TestLoadSchemaRejectsMissingRoot(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := loadSchema([]string{filepath.Join(t.TempDir(), "does-not-exist")}, "")
+	_, err := loadSchema([]string{filepath.Join(t.TempDir(), "does-not-exist")}, nil)
 	c.Assert(err, qt.ErrorMatches, `directory does not exist: .*does-not-exist`)
+}
+
+func TestLoadSchemaMergesGoRootAndSchemaFile(t *testing.T) {
+	c := qt.New(t)
+
+	root := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(root, "users.go"), []byte(`package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+
+	yamlPath := filepath.Join(t.TempDir(), "orders.yaml")
+	c.Assert(os.WriteFile(yamlPath, []byte(`
+tables:
+  orders:
+    columns:
+      id: { type: SERIAL, primary: true }
+`), 0o600), qt.IsNil)
+
+	db, err := loadSchema([]string{root}, []string{yamlPath})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 2)
 }

--- a/core/goschema/parsedirs_test.go
+++ b/core/goschema/parsedirs_test.go
@@ -55,3 +55,24 @@ func TestParseDirsNoRootsReturnsEmpty(t *testing.T) {
 	c.Assert(db, qt.IsNotNil)
 	c.Assert(db.Tables, qt.HasLen, 0)
 }
+
+func TestParseDirRawFeedsMerge(t *testing.T) {
+	c := qt.New(t)
+
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeGoFile(c, rootA, "users.go", usersSource)
+	writeGoFile(c, rootB, "orders.go", ordersSource)
+
+	// ParseDirRaw yields un-finalized sources suitable for Merge to combine and
+	// finalize once, matching a single finalized ParseDirs over both roots.
+	rawA, err := goschema.ParseDirRaw(rootA)
+	c.Assert(err, qt.IsNil)
+	rawB, err := goschema.ParseDirRaw(rootB)
+	c.Assert(err, qt.IsNil)
+
+	merged, err := goschema.Merge(rawA, rawB)
+	c.Assert(err, qt.IsNil)
+	c.Assert(merged.Tables, qt.HasLen, 2)
+	c.Assert(tableIndex(merged, "users") < tableIndex(merged, "orders"), qt.IsTrue)
+}

--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -113,6 +113,26 @@ func ParseDirs(roots ...string) (*Database, error) {
 	return result, nil
 }
 
+// ParseDirRaw parses one or more Go entity roots into a single un-finalized
+// schema: it accumulates every file's schema objects but does NOT run the
+// finalize pipeline (deduplication, embedded-field expansion, dependency
+// ordering).
+//
+// It exists to feed goschema.Merge when composing a Go schema with schemas from
+// other source kinds (YAML, HCL): Merge runs the finalize pass once over the
+// combined set, and since the embedded-field expansion is not idempotent the Go
+// side must arrive un-finalized. For a directly usable, finalized schema use
+// ParseDir or ParseDirs instead.
+func ParseDirRaw(roots ...string) (*Database, error) {
+	result := newDatabase()
+	for _, root := range roots {
+		if err := accumulateGoFiles(result, os.DirFS(root), "."); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
 // accumulateGoFiles walks the non-test, non-vendor Go source files under rootDir
 // in fsys and appends each parsed file's schema objects onto result without
 // finalizing. It is the shared, pre-finalize body of ParseFS and ParseDirs, so

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -414,6 +414,7 @@ type Constraint struct{ ... }
 type Database struct{ ... }
     func Merge(dbs ...*Database) (*Database, error)
     func ParseDir(rootDir string) (*Database, error)
+    func ParseDirRaw(roots ...string) (*Database, error)
     func ParseDirs(roots ...string) (*Database, error)
     func ParseFS(fsys fs.FS, rootDir string) (*Database, error)
     func ParseFile(filename string) (Database, error)


### PR DESCRIPTION
## Summary

Brings composite desired-state schema (#666) to **full source-kind parity** with Atlas's Pro-only `composite_schema`: `ptah render` can now merge Go entity roots with YAML, HCL, and SQL schema files into one desired-state schema.

- **`goschema.ParseDirRaw(roots ...string)`** — the un-finalized form of `ParseDirs`. It accumulates the Go roots' schema objects but does not run the finalize pipeline, so it can be fed to `goschema.Merge` (which runs the single finalize pass over the combined set). This is required because the embedded-field expansion is not idempotent, so the Go side must arrive un-finalized.
- **`--schema-file` is now repeatable** and may be combined with `--root-dir`. When more than one source is given, the Go roots (parsed via `ParseDirRaw`) and each schema file (via the existing YAML/HCL/SQL loaders, which carry no embedded fields) are merged with `goschema.Merge`.

## Example

```
ptah render --root-dir ./common --schema-file ./vendor/thirdparty.hcl --dialect postgres
```

emits SQL for the schema formed by merging the Go `common` package with the vendored HCL tables.

## Backward compatibility

Single-source invocations are unchanged:
- No flags → scan `./` (Go), via `ParseDirs`.
- `--root-dir` (one or many) with no schema file → `ParseDirs`.
- A single `--schema-file` → straight through `loadSchemaFile` (unchanged; not routed through `Merge`).

Only the genuinely composite cases (multiple files, or mixed roots + files) go through `Merge`.

## Verification

- New tests: `ParseDirRaw` feeding `Merge`, and `loadSchema` merging a Go root with a YAML schema file. Existing single-source loader tests (YAML/HCL/SQL alone, multi-root) still pass.
- Full unit suite passes (backward compatibility). `go vet`, `gofmt`, `golangci-lint` (0 issues), `qtlint`, test-style, and the public-API ledger/snapshot checks all pass.

## Scope

Mixing source kinds in `compare`/`migrate`, and a `ptah.yaml` `src`/schema-source list, remain follow-ups under #666.

Part of #666.