### PR TITLE
Support multiple Go roots in `ptah migrate generate` (composite schema, #666)

### DIFF
--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -3,11 +3,13 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
@@ -38,7 +40,7 @@ and performs an up/down/up round-trip.`,
 	}
 
 	flags := cmd.Flags()
-	flags.String(generateRootDirFlag, "./", "Root directory to scan for Go entities")
+	flags.StringArray(generateRootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.String(generateDBURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.String(generateMigrationsDirFlag, "", "Directory containing existing migrations and receiving generated files (required)")
 	flags.String(generateNameFlag, "migration", "Migration name")
@@ -56,9 +58,24 @@ and performs an up/down/up round-trip.`,
 }
 
 func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
-	rootDir, err := cmd.Flags().GetString(generateRootDirFlag)
+	rootDirs, err := cmd.Flags().GetStringArray(generateRootDirFlag)
 	if err != nil {
 		return err
+	}
+	if len(rootDirs) == 0 {
+		rootDirs = []string{"./"}
+	}
+	absRoots := make([]string, 0, len(rootDirs))
+	for _, root := range rootDirs {
+		absPath, err := filepath.Abs(root)
+		if err != nil {
+			return fmt.Errorf("error resolving root directory: %w", err)
+		}
+		absRoots = append(absRoots, absPath)
+	}
+	generated, err := goschema.ParseDirs(absRoots...)
+	if err != nil {
+		return fmt.Errorf("error parsing Go entities: %w", err)
 	}
 	dbURL, err := cmd.Flags().GetString(generateDBURLFlag)
 	if err != nil {
@@ -129,7 +146,7 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	defer cancelConnect()
 
 	files, err := generator.GenerateMigration(connectCtx, generator.GenerateMigrationOptions{
-		GoEntitiesDir:     rootDir,
+		Generated:         generated,
 		DatabaseURL:       dbURL,
 		MigrationName:     name,
 		OutputDir:         migrationsDir,

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -41,6 +41,10 @@ type GenerateMigrationOptions struct {
 	GoEntitiesDir string
 	// GoEntitiesFS is the filesystem to use for reading entities (optional, defaults to os.DirFS)
 	GoEntitiesFS fs.FS
+	// Generated is a pre-parsed desired schema (optional). When set, it is used
+	// directly and GoEntitiesDir/GoEntitiesFS are ignored, letting a caller supply
+	// a composite schema merged from several sources.
+	Generated *goschema.Database
 	// DatabaseURL is the connection string for the database
 	DatabaseURL string
 	// DBConn is the database connection (optional, if not provided, a new connection will be created)
@@ -284,29 +288,34 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		return nil, err
 	}
 
-	var entitiesDir string
+	// 1. Determine the desired schema: use a pre-merged one when provided (for a
+	// composite desired-state assembled from several sources), otherwise parse the
+	// Go entities directory.
+	generated := opts.Generated
+	if generated == nil {
+		var entitiesDir string
 
-	if opts.GoEntitiesFS == nil {
-		// Default to using the real filesystem
-		// We need to set up the filesystem root and relative path correctly
-		absPath, err := filepath.Abs(opts.GoEntitiesDir)
-		if err != nil {
-			return nil, fmt.Errorf("error resolving root directory path: %w", err)
+		if opts.GoEntitiesFS == nil {
+			// Default to using the real filesystem
+			// We need to set up the filesystem root and relative path correctly
+			absPath, err := filepath.Abs(opts.GoEntitiesDir)
+			if err != nil {
+				return nil, fmt.Errorf("error resolving root directory path: %w", err)
+			}
+
+			// Use the parent directory as filesystem root and the basename as the path
+			fsRoot := filepath.Dir(absPath)
+			entitiesDir = filepath.Base(absPath)
+			opts.GoEntitiesFS = os.DirFS(fsRoot)
+		} else {
+			// For custom filesystems, use the path as-is
+			entitiesDir = opts.GoEntitiesDir
 		}
 
-		// Use the parent directory as filesystem root and the basename as the path
-		fsRoot := filepath.Dir(absPath)
-		entitiesDir = filepath.Base(absPath)
-		opts.GoEntitiesFS = os.DirFS(fsRoot)
-	} else {
-		// For custom filesystems, use the path as-is
-		entitiesDir = opts.GoEntitiesDir
-	}
-
-	// 1. Parse Go entities to get desired schema
-	generated, err := goschema.ParseFS(opts.GoEntitiesFS, entitiesDir)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing Go entities: %w", err)
+		generated, err = goschema.ParseFS(opts.GoEntitiesFS, entitiesDir)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing Go entities: %w", err)
+		}
 	}
 
 	// 2. Connect to database and read current schema


### PR DESCRIPTION
## Summary

Extends composite desired-state schema (#666) to the file-based migration workflow: `ptah migrate generate` can now assemble its desired schema from **multiple Go roots**.

- **`migration/generator`**: `GenerateMigrationOptions` gains an optional `Generated *goschema.Database`. When set, it is used as the desired schema and the `GoEntitiesDir`/`GoEntitiesFS` parse is skipped — the minimal-risk seam for feeding a pre-merged composite schema into the generator.
- **`cmd/migrate/generate.go`**: `--root-dir` is now repeatable; the roots are parsed with `goschema.ParseDirs` and passed as `Generated`.

A single `--root-dir` (or none, defaulting to `./`) behaves exactly as before — `ParseDirs(["./"])` is equivalent to the previous single-root parse.

## Example

```
ptah migrate generate --root-dir ./common --root-dir ./services/orders --db-url postgres://localhost/app --migrations-dir ./migrations
```

writes migration files for the schema formed by merging the `common` and `orders` Go packages.

## Verification

- Full unit suite passes; the generator's existing (DB-backed) tests exercise the unchanged `Generated == nil` parse path, and the `migrate generate` integration path now flows through the `Generated` seam with a single root. `go vet`, `gofmt`, `golangci-lint` (0 issues), `qtlint`, test-style, and the public-API snapshot checks all pass (the new field is on an existing exported struct, so `go doc -short` is unchanged).

## Scope

This completes composite support across `render`, `compare`, `migrate`, and `migrate generate` for Go roots. Mixing heterogeneous source kinds (Go + YAML + HCL) in `compare`/`migrate`/`migrate generate`, and a `ptah.yaml` `src` list, remain follow-ups under #666.

Part of #666.