### PR TITLE
Share the desired-schema resolver across compare and migrate (#669)

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
-	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -20,13 +18,15 @@ import (
 )
 
 const (
-	rootDirFlag  = "root-dir"
-	dbURLFlag    = "db-url"
-	exitCodeFlag = "exit-code"
+	rootDirFlag    = "root-dir"
+	schemaFileFlag = "schema-file"
+	dbURLFlag      = "db-url"
+	exitCodeFlag   = "exit-code"
 )
 
 type options struct {
 	rootDirs       []string
+	schemaFiles    []string
 	dbURL          string
 	exitOnDiff     bool
 	connectTimeout string
@@ -54,6 +54,7 @@ currently exists in the database, helping you identify what needs to be migrated
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
+	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to compare instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.exitOnDiff, exitCodeFlag, false, "Exit with 1 when the schema diff is non-empty")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
@@ -67,28 +68,20 @@ func compareCommand(cmd *cobra.Command, opts *options) error {
 		return fmt.Errorf("database URL is required")
 	}
 
-	roots := opts.rootDirs
-	if len(roots) == 0 {
-		roots = []string{"./"}
+	loadOpts := schemaload.Options{
+		RootDirs:    opts.rootDirs,
+		SchemaFiles: opts.schemaFiles,
 	}
 
-	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", strings.Join(roots, ", "), dbschema.FormatDatabaseURL(opts.dbURL))
+	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", loadOpts.Sources(), dbschema.FormatDatabaseURL(opts.dbURL))
 	fmt.Fprintln(out, "=== SCHEMA COMPARISON ===")
 	fmt.Fprintln(out)
 
-	// 1. Parse Go entities from every root into one composite schema
-	absRoots := make([]string, 0, len(roots))
-	for _, root := range roots {
-		absPath, err := filepath.Abs(root)
-		if err != nil {
-			return fmt.Errorf("error resolving path: %w", err)
-		}
-		absRoots = append(absRoots, absPath)
-	}
-
-	result, err := goschema.ParseDirs(absRoots...)
+	// 1. Resolve the desired schema from Go entities and/or schema files into one
+	// composite schema.
+	result, err := schemaload.Load(loadOpts)
 	if err != nil {
-		return fmt.Errorf("error parsing Go entities: %w", err)
+		return err
 	}
 
 	// 2. Connect to database and read schema

--- a/cmd/compare/compare_test.go
+++ b/cmd/compare/compare_test.go
@@ -1,0 +1,23 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/compare"
+)
+
+func TestCompareCommandExposesRepeatableSchemaFileFlag(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := compare.NewCompareCommand()
+
+	schemaFile := cmd.Flags().Lookup("schema-file")
+	c.Assert(schemaFile, qt.IsNotNil)
+	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
+
+	rootDir := cmd.Flags().Lookup("root-dir")
+	c.Assert(rootDir, qt.IsNotNil)
+	c.Assert(rootDir.Value.Type(), qt.Equals, "stringArray")
+}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -2,17 +2,15 @@ package generate
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
-	"github.com/stokaro/ptah/internal/schemafile"
 )
 
 const (
@@ -55,7 +53,11 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 }
 
 func generateCommand(_ *cobra.Command, opts *options) error {
-	result, err := loadSchema(opts.rootDirs, opts.schemaFiles)
+	result, err := schemaload.Load(schemaload.Options{
+		RootDirs:    opts.rootDirs,
+		SchemaFiles: opts.schemaFiles,
+		Logf:        func(format string, args ...any) { fmt.Printf(format+"\n", args...) },
+	})
 	if err != nil {
 		return err
 	}
@@ -117,126 +119,4 @@ func generateCommand(_ *cobra.Command, opts *options) error {
 	}
 
 	return nil
-}
-
-func loadSchema(rootDirs, schemaFiles []string) (*goschema.Database, error) {
-	// With no source of any kind, default to scanning the current directory for
-	// Go entities (the historical behavior).
-	if len(rootDirs) == 0 && len(schemaFiles) == 0 {
-		rootDirs = []string{"./"}
-	}
-
-	// Single-source fast paths, unchanged from before: Go roots only, or exactly
-	// one schema file.
-	if len(schemaFiles) == 0 {
-		return loadGoRoots(rootDirs)
-	}
-	if len(rootDirs) == 0 && len(schemaFiles) == 1 {
-		return loadSchemaFile(schemaFiles[0])
-	}
-
-	// Composite: merge the Go roots (parsed un-finalized so Merge can run the
-	// single finalize pass) with each schema file.
-	var sources []*goschema.Database
-	if len(rootDirs) > 0 {
-		absRoots, err := resolveRootDirs(rootDirs)
-		if err != nil {
-			return nil, err
-		}
-		for _, absPath := range absRoots {
-			fmt.Printf("Scanning directory: %s\n", absPath)
-		}
-		goDB, err := goschema.ParseDirRaw(absRoots...)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing packages: %w", err)
-		}
-		sources = append(sources, goDB)
-	}
-	for _, schemaFile := range schemaFiles {
-		fmt.Printf("Loading schema file: %s\n", schemaFile)
-		fileDB, err := loadSchemaFile(schemaFile)
-		if err != nil {
-			return nil, err
-		}
-		sources = append(sources, fileDB)
-	}
-	fmt.Println()
-
-	result, err := goschema.Merge(sources...)
-	if err != nil {
-		return nil, fmt.Errorf("error merging composite schema: %w", err)
-	}
-	return result, nil
-}
-
-// loadGoRoots parses one or more Go entity roots into a finalized composite
-// schema.
-func loadGoRoots(rootDirs []string) (*goschema.Database, error) {
-	absRoots, err := resolveRootDirs(rootDirs)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, absPath := range absRoots {
-		fmt.Printf("Scanning directory: %s\n", absPath)
-	}
-	fmt.Println()
-
-	result, err := goschema.ParseDirs(absRoots...)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing packages: %w", err)
-	}
-	return result, nil
-}
-
-// resolveRootDirs turns each root into an absolute path and fails fast if any
-// does not exist.
-func resolveRootDirs(rootDirs []string) ([]string, error) {
-	absRoots := make([]string, 0, len(rootDirs))
-	for _, rootDir := range rootDirs {
-		absPath, err := filepath.Abs(rootDir)
-		if err != nil {
-			return nil, fmt.Errorf("error resolving path: %w", err)
-		}
-		if _, err := os.Stat(absPath); os.IsNotExist(err) {
-			return nil, fmt.Errorf("directory does not exist: %s", absPath)
-		}
-		absRoots = append(absRoots, absPath)
-	}
-	return absRoots, nil
-}
-
-func loadSchemaFile(schemaFile string) (*goschema.Database, error) {
-	absPath, err := filepath.Abs(schemaFile)
-	if err != nil {
-		return nil, fmt.Errorf("error resolving schema file: %w", err)
-	}
-
-	info, err := os.Stat(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("schema file does not exist: %s", absPath)
-		}
-		return nil, fmt.Errorf("stat schema file: %w", err)
-	}
-	if info.IsDir() {
-		return nil, fmt.Errorf("schema file is a directory: %s", absPath)
-	}
-
-	ext := strings.ToLower(filepath.Ext(absPath))
-	switch ext {
-	case ".yaml", ".yml", ".hcl", ".sql":
-	default:
-		return nil, fmt.Errorf("unsupported schema file extension %q: only .yaml, .yml, .hcl, and .sql are supported", filepath.Ext(absPath))
-	}
-
-	fmt.Printf("Reading schema file: %s\n", absPath)
-	fmt.Println("=" + strings.Repeat("=", len(absPath)+21))
-	fmt.Println()
-
-	result, err := schemafile.LoadPath(absPath, schemafile.Options{})
-	if err != nil {
-		return nil, fmt.Errorf("error parsing schema file: %w", err)
-	}
-	return result, nil
 }

--- a/cmd/internal/schemaload/schemaload.go
+++ b/cmd/internal/schemaload/schemaload.go
@@ -1,0 +1,165 @@
+// Package schemaload resolves a desired-state schema from Go entity roots and/or
+// language-agnostic schema files, merging multiple sources into one composite
+// schema. It is the shared desired-source resolver behind the render, compare,
+// and migrate commands, so every command accepts the same --root-dir and
+// --schema-file inputs and composes them the same way.
+package schemaload
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/schemafile"
+)
+
+// Options selects the desired-schema sources and how loading is reported.
+type Options struct {
+	// RootDirs are Go entity roots scanned for migrator directives (repeatable).
+	RootDirs []string
+	// SchemaFiles are YAML, HCL, or SQL schema files (repeatable).
+	SchemaFiles []string
+	// Dialect is an optional dialect hint used when parsing SQL schema files.
+	Dialect string
+	// Logf, when non-nil, receives human-readable progress messages. Commands
+	// that emit machine-readable output (SQL, safety reports) leave it nil so the
+	// resolver stays quiet.
+	Logf func(format string, args ...any)
+}
+
+func (o Options) logf(format string, args ...any) {
+	if o.Logf != nil {
+		o.Logf(format, args...)
+	}
+}
+
+// Sources returns a human-readable, comma-separated list of the configured
+// desired-schema sources, applying the same current-directory default that Load
+// applies when nothing is configured. It is intended for progress and report
+// headers.
+func (o Options) Sources() string {
+	parts := make([]string, 0, len(o.RootDirs)+len(o.SchemaFiles))
+	parts = append(parts, o.RootDirs...)
+	parts = append(parts, o.SchemaFiles...)
+	if len(parts) == 0 {
+		parts = append(parts, "./")
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Load resolves the desired schema described by opts. With no source at all it
+// defaults to scanning the current directory for Go entities (the historical
+// behavior). Multiple sources of any kind are merged into one composite schema.
+func Load(opts Options) (*goschema.Database, error) {
+	rootDirs := opts.RootDirs
+	schemaFiles := opts.SchemaFiles
+
+	// With no source of any kind, default to scanning the current directory for
+	// Go entities.
+	if len(rootDirs) == 0 && len(schemaFiles) == 0 {
+		rootDirs = []string{"./"}
+	}
+
+	// Single-source fast paths: Go roots only, or exactly one schema file.
+	if len(schemaFiles) == 0 {
+		return opts.loadGoRoots(rootDirs)
+	}
+	if len(rootDirs) == 0 && len(schemaFiles) == 1 {
+		return opts.loadSchemaFile(schemaFiles[0])
+	}
+
+	// Composite: merge the Go roots (parsed un-finalized so Merge runs a single
+	// finalize pass) with each schema file.
+	var sources []*goschema.Database
+	if len(rootDirs) > 0 {
+		absRoots, err := resolveRootDirs(rootDirs)
+		if err != nil {
+			return nil, err
+		}
+		for _, absPath := range absRoots {
+			opts.logf("Scanning directory: %s", absPath)
+		}
+		goDB, err := goschema.ParseDirRaw(absRoots...)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing packages: %w", err)
+		}
+		sources = append(sources, goDB)
+	}
+	for _, schemaFile := range schemaFiles {
+		fileDB, err := opts.loadSchemaFile(schemaFile)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, fileDB)
+	}
+
+	result, err := goschema.Merge(sources...)
+	if err != nil {
+		return nil, fmt.Errorf("error merging composite schema: %w", err)
+	}
+	return result, nil
+}
+
+// loadGoRoots parses one or more Go entity roots into a finalized composite
+// schema.
+func (o Options) loadGoRoots(rootDirs []string) (*goschema.Database, error) {
+	absRoots, err := resolveRootDirs(rootDirs)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, absPath := range absRoots {
+		o.logf("Scanning directory: %s", absPath)
+	}
+
+	result, err := goschema.ParseDirs(absRoots...)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing packages: %w", err)
+	}
+	return result, nil
+}
+
+// resolveRootDirs turns each root into an absolute path and fails fast if any
+// does not exist.
+func resolveRootDirs(rootDirs []string) ([]string, error) {
+	absRoots := make([]string, 0, len(rootDirs))
+	for _, rootDir := range rootDirs {
+		absPath, err := filepath.Abs(rootDir)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving path: %w", err)
+		}
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("directory does not exist: %s", absPath)
+		}
+		absRoots = append(absRoots, absPath)
+	}
+	return absRoots, nil
+}
+
+// loadSchemaFile resolves a single YAML, HCL, or SQL schema file into a
+// finalized schema.
+func (o Options) loadSchemaFile(schemaFile string) (*goschema.Database, error) {
+	absPath, err := filepath.Abs(schemaFile)
+	if err != nil {
+		return nil, fmt.Errorf("error resolving schema file: %w", err)
+	}
+
+	// Reject unsupported extensions here so the error is reported without the
+	// generic "error parsing schema file" wrapper, matching the render command's
+	// long-standing message.
+	switch strings.ToLower(filepath.Ext(absPath)) {
+	case ".yaml", ".yml", ".hcl", ".sql":
+	default:
+		return nil, fmt.Errorf("unsupported schema file extension %q: only .yaml, .yml, .hcl, and .sql are supported", filepath.Ext(absPath))
+	}
+
+	o.logf("Reading schema file: %s", absPath)
+
+	result, err := schemafile.LoadPath(absPath, schemafile.Options{Dialect: o.Dialect})
+	if err != nil {
+		return nil, fmt.Errorf("error parsing schema file: %w", err)
+	}
+	return result, nil
+}

--- a/cmd/internal/schemaload/schemaload_test.go
+++ b/cmd/internal/schemaload/schemaload_test.go
@@ -1,8 +1,4 @@
-package generate
-
-// White-box testing required: loadSchema is the command package's internal
-// schema-source dispatcher, and its extension routing can be verified directly
-// without invoking the whole CLI command.
+package schemaload_test
 
 import (
 	"os"
@@ -10,9 +6,11 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 )
 
-func TestLoadSchemaFile_YAML(t *testing.T) {
+func TestLoad_YAMLSchemaFile(t *testing.T) {
 	c := qt.New(t)
 
 	path := filepath.Join(t.TempDir(), "schema.yaml")
@@ -26,13 +24,13 @@ tables:
 		qt.IsNil,
 	)
 
-	db, err := loadSchema(nil, []string{path})
+	db, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
 }
 
-func TestLoadSchemaFile_AtlasHCL(t *testing.T) {
+func TestLoad_AtlasHCLSchemaFile(t *testing.T) {
 	c := qt.New(t)
 
 	path := filepath.Join(t.TempDir(), "schema.hcl")
@@ -47,14 +45,14 @@ table "users" {
 }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema(nil, []string{path})
+	db, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
 	c.Assert(db.Fields[0].Primary, qt.IsTrue)
 }
 
-func TestLoadSchemaFile_SQL(t *testing.T) {
+func TestLoad_SQLSchemaFile(t *testing.T) {
 	c := qt.New(t)
 
 	path := filepath.Join(t.TempDir(), "schema.sql")
@@ -65,24 +63,24 @@ CREATE TABLE users (
 );
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema(nil, []string{path})
+	db, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 1)
 	c.Assert(db.Tables[0].Name, qt.Equals, "users")
 	c.Assert(db.Fields, qt.HasLen, 2)
 }
 
-func TestLoadSchemaFile_RejectsUnsupportedExtension(t *testing.T) {
+func TestLoad_RejectsUnsupportedExtension(t *testing.T) {
 	c := qt.New(t)
 
 	path := filepath.Join(t.TempDir(), "schema.json")
 	c.Assert(os.WriteFile(path, []byte(`{}`), 0o600), qt.IsNil)
 
-	_, err := loadSchema(nil, []string{path})
+	_, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
 	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension ".json": only .yaml, .yml, .hcl, and .sql are supported`)
 }
 
-func TestLoadSchemaMergesMultipleRoots(t *testing.T) {
+func TestLoad_MergesMultipleRoots(t *testing.T) {
 	c := qt.New(t)
 
 	rootA := t.TempDir()
@@ -104,19 +102,19 @@ type Order struct {
 }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema([]string{rootA, rootB}, nil)
+	db, err := schemaload.Load(schemaload.Options{RootDirs: []string{rootA, rootB}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 2)
 }
 
-func TestLoadSchemaRejectsMissingRoot(t *testing.T) {
+func TestLoad_RejectsMissingRoot(t *testing.T) {
 	c := qt.New(t)
 
-	_, err := loadSchema([]string{filepath.Join(t.TempDir(), "does-not-exist")}, nil)
+	_, err := schemaload.Load(schemaload.Options{RootDirs: []string{filepath.Join(t.TempDir(), "does-not-exist")}})
 	c.Assert(err, qt.ErrorMatches, `directory does not exist: .*does-not-exist`)
 }
 
-func TestLoadSchemaMergesGoRootAndSchemaFile(t *testing.T) {
+func TestLoad_MergesGoRootAndSchemaFile(t *testing.T) {
 	c := qt.New(t)
 
 	root := t.TempDir()
@@ -137,7 +135,51 @@ tables:
       id: { type: SERIAL, primary: true }
 `), 0o600), qt.IsNil)
 
-	db, err := loadSchema([]string{root}, []string{yamlPath})
+	db, err := schemaload.Load(schemaload.Options{RootDirs: []string{root}, SchemaFiles: []string{yamlPath}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Tables, qt.HasLen, 2)
+}
+
+func TestLoad_MergesMultipleSchemaFiles(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	usersPath := filepath.Join(dir, "users.yaml")
+	c.Assert(os.WriteFile(usersPath, []byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+`), 0o600), qt.IsNil)
+	ordersPath := filepath.Join(dir, "orders.sql")
+	c.Assert(os.WriteFile(ordersPath, []byte(`
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY
+);
+`), 0o600), qt.IsNil)
+
+	db, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{usersPath, ordersPath}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 2)
+}
+
+func TestLoad_ReportsProgressThroughLogf(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.yaml")
+	c.Assert(os.WriteFile(path, []byte(`
+tables:
+  users:
+    columns:
+      id: { type: SERIAL, primary: true }
+`), 0o600), qt.IsNil)
+
+	var messages []string
+	_, err := schemaload.Load(schemaload.Options{
+		SchemaFiles: []string{path},
+		Logf:        func(format string, args ...any) { messages = append(messages, format) },
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(messages, qt.HasLen, 1)
+	c.Assert(messages[0], qt.Equals, "Reading schema file: %s")
 }

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -3,13 +3,12 @@ package migrate
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
-	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
@@ -17,6 +16,7 @@ import (
 
 const (
 	generateRootDirFlag          = "root-dir"
+	generateSchemaFileFlag       = "schema-file"
 	generateDBURLFlag            = "db-url"
 	generateMigrationsDirFlag    = "migrations-dir"
 	generateNameFlag             = "name"
@@ -41,6 +41,7 @@ and performs an up/down/up round-trip.`,
 
 	flags := cmd.Flags()
 	flags.StringArray(generateRootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
+	flags.StringArray(generateSchemaFileFlag, nil, "YAML, HCL, or SQL schema file to generate a migration toward instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	flags.String(generateDBURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.String(generateMigrationsDirFlag, "", "Directory containing existing migrations and receiving generated files (required)")
 	flags.String(generateNameFlag, "migration", "Migration name")
@@ -62,20 +63,16 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	if len(rootDirs) == 0 {
-		rootDirs = []string{"./"}
-	}
-	absRoots := make([]string, 0, len(rootDirs))
-	for _, root := range rootDirs {
-		absPath, err := filepath.Abs(root)
-		if err != nil {
-			return fmt.Errorf("error resolving root directory: %w", err)
-		}
-		absRoots = append(absRoots, absPath)
-	}
-	generated, err := goschema.ParseDirs(absRoots...)
+	schemaFiles, err := cmd.Flags().GetStringArray(generateSchemaFileFlag)
 	if err != nil {
-		return fmt.Errorf("error parsing Go entities: %w", err)
+		return err
+	}
+	generated, err := schemaload.Load(schemaload.Options{
+		RootDirs:    rootDirs,
+		SchemaFiles: schemaFiles,
+	})
+	if err != nil {
+		return err
 	}
 	dbURL, err := cmd.Flags().GetString(generateDBURLFlag)
 	if err != nil {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
-	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
@@ -22,6 +21,7 @@ import (
 
 const (
 	rootDirFlag          = "root-dir"
+	schemaFileFlag       = "schema-file"
 	dbURLFlag            = "db-url"
 	checkDestructiveFlag = "check-destructive"
 	allowDestructiveFlag = "allow-destructive"
@@ -30,6 +30,7 @@ const (
 
 type options struct {
 	rootDirs         []string
+	schemaFiles      []string
 	dbURL            string
 	checkDestructive bool
 	allowDestructive bool
@@ -59,6 +60,7 @@ the SQL statements needed to update the database to match your entities.`,
 func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
+	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to migrate toward instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.checkDestructive, checkDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
 	flags.BoolVar(&opts.allowDestructive, allowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
@@ -77,11 +79,11 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	if reportFormat != "text" && reportFormat != "html" && reportFormat != "json" {
 		return fmt.Errorf("unsupported report format %q", reportFormat)
 	}
-	roots := opts.rootDirs
-	if len(roots) == 0 {
-		roots = []string{"./"}
+	loadOpts := schemaload.Options{
+		RootDirs:    opts.rootDirs,
+		SchemaFiles: opts.schemaFiles,
 	}
-	rootsDisplay := strings.Join(roots, ", ")
+	rootsDisplay := loadOpts.Sources()
 
 	if reportFormat == "text" {
 		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootsDisplay, dbschema.FormatDatabaseURL(opts.dbURL))
@@ -89,19 +91,11 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 		fmt.Fprintln(out)
 	}
 
-	// 1. Parse Go entities from every root into one composite schema
-	absRoots := make([]string, 0, len(roots))
-	for _, root := range roots {
-		absPath, err := filepath.Abs(root)
-		if err != nil {
-			return fmt.Errorf("error resolving path: %w", err)
-		}
-		absRoots = append(absRoots, absPath)
-	}
-
-	result, err := goschema.ParseDirs(absRoots...)
+	// 1. Resolve the desired schema from Go entities and/or schema files into one
+	// composite schema.
+	result, err := schemaload.Load(loadOpts)
 	if err != nil {
-		return fmt.Errorf("error parsing Go entities: %w", err)
+		return err
 	}
 
 	// 2. Connect to database and read schema

--- a/cmd/migrate/schemafile_flag_test.go
+++ b/cmd/migrate/schemafile_flag_test.go
@@ -1,0 +1,29 @@
+package migrate_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migrate"
+)
+
+func TestMigratePlanCommandExposesRepeatableSchemaFileFlag(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migrate.NewMigrateCommand()
+
+	schemaFile := cmd.Flags().Lookup("schema-file")
+	c.Assert(schemaFile, qt.IsNotNil)
+	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
+}
+
+func TestMigrateGenerateCommandExposesRepeatableSchemaFileFlag(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migrate.NewMigrateGenerateCommand()
+
+	schemaFile := cmd.Flags().Lookup("schema-file")
+	c.Assert(schemaFile, qt.IsNotNil)
+	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
+}


### PR DESCRIPTION
## Summary

Extends Ptah's desired-state schema sources so `ptah schema compare`, `ptah migrations plan`, and `ptah migrations generate` accept the same `--schema-file` (YAML, HCL, or SQL) inputs that `ptah schema render` already supports. Previously those three commands only read Go entities via `--root-dir`; a language-agnostic schema file could be *rendered* but not *compared* or *migrated* against.

The change hoists the render command's composite schema loader into a new internal package and reuses it everywhere:

- **New `cmd/internal/schemaload` package** — `Load(Options{RootDirs, SchemaFiles, Dialect, Logf})` resolves Go roots and/or schema files into one composite schema, with the same single-source fast paths (Go-only → `ParseDirs`, one file → `LoadPath`) and composite `Merge` behavior render used before. `Options.Sources()` renders a consistent source description for progress output and report headers.
- **`ptah schema compare`**, **`ptah migrations plan`**, **`ptah migrations generate`** — each gains a repeatable `--schema-file` flag and now delegates schema resolution to `schemaload.Load`, composing Go roots and schema files into one desired schema.
- **`ptah schema render`** — refactored to consume the shared loader (passing a logger so its progress output is unchanged); its `loadSchema` tests move to the `schemaload` package.

This means, for example, a Go-free project can drive migrations from a single SQL or YAML file:

```
ptah migrations plan --schema-file schema.sql --db-url postgres://...
ptah schema compare  --schema-file a.yaml --schema-file b.sql --db-url postgres://...
```

## Why

`--schema-file` support was asymmetric: only `render` had it. Hoisting the composite loader removes that asymmetry and eliminates the duplicated per-command `ParseDirs` boilerplate, giving every schema-consuming command identical, composable source handling.

## Testing

- `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), test-style and public-API-snapshot checks all clean.
- Full unit suite green; `schemaload` package has direct coverage for every fast path, the composite Go+file merge, multi-file merge, missing-root and unsupported-extension errors, and progress logging. compare/migrate gain flag-registration tests.
- Verified end-to-end against a live PostgreSQL: `compare` and `migrations plan` from a YAML file produce the expected `CREATE TABLE` diff, and a mixed `--schema-file a.yaml --schema-file b.sql` compare merges both sources.

## Follow-ups (out of scope)

- `cmd/internal/schemaops` (used by `ptah schema drift` and `ptah migratebaseline`) is still single-root, Go-only — the natural next consolidation target for `schemaload`.
- Threading the connection dialect into SQL schema-file parsing (currently parsed with the default dialect, matching prior render behavior).