### PR TITLE
Check drift against schema files, not only Go entities (#669)

### DIFF
--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -31,7 +31,8 @@ var errDriftDetected = errors.New("schema drift detected")
 
 // NewDriftCommand returns the drift-check command.
 func NewDriftCommand() *cobra.Command {
-	var rootDir string
+	var rootDirs []string
+	var schemaFiles []string
 	var dbURL string
 	var format string
 	var severity string
@@ -42,12 +43,13 @@ func NewDriftCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:           "drift",
-		Short:         "Check live database drift against Go entities",
+		Short:         "Check live database drift against a desired schema",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDrift(cmd, runOptions{
-				rootDir:           rootDir,
+				rootDirs:          rootDirs,
+				schemaFiles:       schemaFiles,
 				dbURL:             dbURL,
 				format:            format,
 				severity:          severity,
@@ -59,7 +61,8 @@ func NewDriftCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&rootDir, "root-dir", "./", "Root directory to scan for Go entities")
+	cmd.Flags().StringArrayVar(&rootDirs, "root-dir", nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
+	cmd.Flags().StringArrayVar(&schemaFiles, "schema-file", nil, "YAML, HCL, or SQL schema file to check drift against instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
 	cmd.Flags().StringVar(&severity, "severity", severityAll, "Failing drift threshold: all or destructive")
@@ -78,7 +81,8 @@ func NewDriftCommand() *cobra.Command {
 }
 
 type runOptions struct {
-	rootDir           string
+	rootDirs          []string
+	schemaFiles       []string
 	dbURL             string
 	format            string
 	severity          string
@@ -94,7 +98,7 @@ type driftReport struct {
 	FailureThreshold string                `json:"failure_threshold"`
 	HighestSeverity  safety.Severity       `json:"highest_severity"`
 	Dialect          string                `json:"dialect,omitempty"`
-	RootDir          string                `json:"root_dir,omitempty"`
+	Sources          string                `json:"sources,omitempty"`
 	DatabaseURL      string                `json:"database_url,omitempty"`
 	IgnoredTables    []string              `json:"ignored_tables,omitempty"`
 	Findings         []safety.Finding      `json:"findings,omitempty"`
@@ -124,7 +128,8 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 	schemas := dbcli.ParseSchemas(opts.schemasRaw)
 
 	result, err := schemaops.Compare(cmd.Context(), schemaops.CompareOptions{
-		RootDir:        opts.rootDir,
+		RootDirs:       opts.rootDirs,
+		SchemaFiles:    opts.schemaFiles,
 		DatabaseURL:    opts.dbURL,
 		ConnectTimeout: connectTimeout,
 		IgnoredTables:  ignoredTables,
@@ -144,7 +149,7 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 		FailureThreshold: opts.severity,
 		HighestSeverity:  highest,
 		Dialect:          result.Dialect,
-		RootDir:          result.RootDir,
+		Sources:          result.Sources,
 		DatabaseURL:      result.DatabaseURL,
 		IgnoredTables:    ignoredTables,
 		Findings:         findings,

--- a/cmd/drift/drift_test.go
+++ b/cmd/drift/drift_test.go
@@ -20,6 +20,20 @@ func TestNewDriftCommand_Creation(t *testing.T) {
 	c.Assert(cmd.Short, qt.Contains, "drift")
 }
 
+func TestNewDriftCommand_ExposesRepeatableSchemaSources(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := drift.NewDriftCommand()
+
+	rootDir := cmd.Flags().Lookup("root-dir")
+	c.Assert(rootDir, qt.IsNotNil)
+	c.Assert(rootDir.Value.Type(), qt.Equals, "stringArray")
+
+	schemaFile := cmd.Flags().Lookup("schema-file")
+	c.Assert(schemaFile, qt.IsNotNil)
+	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
+}
+
 func TestRunDrift_MissingDatabaseURLReturnsCode2(t *testing.T) {
 	c := qt.New(t)
 

--- a/cmd/internal/schemaops/schemaops.go
+++ b/cmd/internal/schemaops/schemaops.go
@@ -4,11 +4,11 @@ package schemaops
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
@@ -19,7 +19,8 @@ import (
 
 // CompareOptions configures a live schema comparison.
 type CompareOptions struct {
-	RootDir        string
+	RootDirs       []string
+	SchemaFiles    []string
 	DatabaseURL    string
 	ConnectTimeout time.Duration
 	IgnoredTables  []string
@@ -28,7 +29,7 @@ type CompareOptions struct {
 
 // CompareResult is the output of a live schema comparison.
 type CompareResult struct {
-	RootDir     string
+	Sources     string
 	DatabaseURL string
 	Dialect     string
 	Generated   *goschema.Database
@@ -36,24 +37,21 @@ type CompareResult struct {
 	Diff        *difftypes.SchemaDiff
 }
 
-// Compare parses Go entities, reads the live database schema, applies command
-// filters, and returns a dialect-aware schema diff.
+// Compare resolves the desired schema from Go entities and/or schema files,
+// reads the live database schema, applies command filters, and returns a
+// dialect-aware schema diff.
 func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
-	if opts.RootDir == "" {
-		opts.RootDir = "."
-	}
 	if opts.DatabaseURL == "" {
 		return nil, fmt.Errorf("database URL is required")
 	}
 
-	absPath, err := filepath.Abs(opts.RootDir)
-	if err != nil {
-		return nil, fmt.Errorf("error resolving path: %w", err)
+	loadOpts := schemaload.Options{
+		RootDirs:    opts.RootDirs,
+		SchemaFiles: opts.SchemaFiles,
 	}
-
-	generated, err := goschema.ParseDir(absPath)
+	generated, err := schemaload.Load(loadOpts)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing Go entities: %w", err)
+		return nil, err
 	}
 
 	connectCtx, cancelConnect := dbcli.ConnectContext(ctx, opts.ConnectTimeout)
@@ -79,7 +77,7 @@ func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
 	diff := schemadiff.CompareWithOptions(generated, dbSchema, compareOpts)
 
 	return &CompareResult{
-		RootDir:     absPath,
+		Sources:     loadOpts.Sources(),
 		DatabaseURL: dbschema.FormatDatabaseURL(opts.DatabaseURL),
 		Dialect:     conn.Info().Dialect,
 		Generated:   generated,

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -205,7 +205,7 @@ func verifyBaseline(ctx context.Context, opts baselineVerifyOptions) error {
 
 	fmt.Println("No --shadow-db provided; using weaker entity drift verification.")
 	result, err := schemaops.Compare(ctx, schemaops.CompareOptions{
-		RootDir:        opts.rootDir,
+		RootDirs:       []string{opts.rootDir},
 		DatabaseURL:    opts.dbURL,
 		ConnectTimeout: opts.connectTimeout,
 		Schemas:        opts.schemas,

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -117,10 +117,12 @@ Preview the SQL Ptah derives from your schema file and review it before you appl
 ptah schema render --schema-file schema.yaml --dialect postgres >/tmp/schema.sql
 ```
 
-The rendered SQL proves Ptah understood the desired schema. Note that
-`--schema-file` feeds `ptah schema render` only — planning and generating
-migrations (`ptah migrations plan` / `ptah migrations generate`) read the desired
-schema from Go entities via `--root-dir`, not from a schema file.
+The rendered SQL proves Ptah understood the desired schema. `--schema-file` is
+accepted wherever Ptah needs a desired schema: `ptah schema render`,
+`ptah schema compare`, `ptah schema drift`, and the migration commands
+(`ptah migrations plan` / `ptah migrations generate`). Each command reads the
+desired schema from Go entities (`--root-dir`), schema files (`--schema-file`),
+or any combination of the two.
 
 ## Compose multiple sources
 


### PR DESCRIPTION
## Summary

Completes the compare / migrate / **drift** trio for language-agnostic schema sources. Following #702 (which gave `compare` and the migration commands `--schema-file` support), this routes the shared `cmd/internal/schemaops.Compare` helper through the `schemaload` resolver so **`ptah schema drift`** accepts the same composite desired-schema inputs:

```
ptah schema drift --schema-file schema.yaml --db-url postgres://...
ptah schema drift --root-dir ./models --schema-file ./vendor/thirdparty.hcl --db-url postgres://...
```

A Go-free project (schema defined in YAML/HCL/SQL) can now run CI drift checks, and Go + file sources compose into one desired schema exactly as they do for render/compare/migrate.

## Changes

- **`cmd/internal/schemaops`** — `CompareOptions` now takes `RootDirs []string` + `SchemaFiles []string` (was a single `RootDir string`); `Compare` resolves the desired schema with `schemaload.Load` instead of a lone `goschema.ParseDir`. The dialect-aware comparison (`config.DefaultCompareOptions` + `schemadiff.CompareWithOptions`) and the ignored-table / enum / dependency filtering are unchanged.
- **`ptah schema drift`** — `--root-dir` is now repeatable and a repeatable `--schema-file` flag is added; both merge into one composite schema. The JSON report field `root_dir` is renamed to `sources` (a source may now be a file, not a directory).
- **`ptah migratebaseline`** — keeps its single `--root-dir`; its `Compare` call adapts to the new field. Behavior is unchanged.

## Notes

- **Output change**: the `ptah schema drift --format json` report renames `root_dir` → `sources`. It has no golden-file, doc, or CI consumer in-repo; text and `github-actions` output are unaffected (they never emitted the field).
- **Error message**: a desired-schema parse failure is now surfaced verbatim from the resolver (e.g. `directory does not exist: <path>`) instead of being wrapped as `error parsing Go entities`, matching compare/migrate.
- Corrects a stale note in `docs/workflows/schema-files.md` that still claimed `--schema-file` fed `render` only (it now lists render, compare, drift, and the migration commands).

## Testing

- `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), test-style and public-API-snapshot checks all clean; full unit suite green. New flag-registration test for drift's repeatable `--root-dir` / `--schema-file`.
- Verified end-to-end against a live PostgreSQL: `ptah schema drift --schema-file schema.yaml` detects the expected drift (exit 1, `sources` populated in JSON), and a mixed `--root-dir ./stubs --schema-file schema.yaml` run merges both sources.