### PR TITLE
Add an external-command desired-schema source (#669)

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -8,21 +8,30 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
 )
 
 const (
-	rootDirFlag    = "root-dir"
-	schemaFileFlag = "schema-file"
-	dialectFlag    = "dialect"
+	rootDirFlag      = "root-dir"
+	schemaFileFlag   = "schema-file"
+	schemaCmdFlag    = "schema-cmd"
+	schemaFormatFlag = "schema-format"
+	dialectFlag      = "dialect"
 )
 
+const schemaCmdUsage = "External program whose stdout is the desired schema " +
+	"(for example an ORM exporter). Run directly without a shell, split on " +
+	`whitespace, so arguments cannot contain spaces. Example: "go run ./loader"`
+
 type options struct {
-	rootDirs    []string
-	schemaFiles []string
-	dialect     string
+	rootDirs     []string
+	schemaFiles  []string
+	schemaCmd    string
+	schemaFormat string
+	dialect      string
 }
 
 func NewGenerateCommand() *cobra.Command {
@@ -49,13 +58,27 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to generate from instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
+	flags.StringVar(&opts.schemaCmd, schemaCmdFlag, "", schemaCmdUsage)
+	flags.StringVar(&opts.schemaFormat, schemaFormatFlag, "sql", "Format of the --schema-cmd output: sql")
 	flags.StringVar(&opts.dialect, dialectFlag, "", "Database dialect (postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, spanner). If empty, generates for all dialects")
 }
 
-func generateCommand(_ *cobra.Command, opts *options) error {
-	result, err := schemaload.Load(schemaload.Options{
+func generateCommand(cmd *cobra.Command, opts *options) error {
+	var commands []schemasource.Command
+	if strings.TrimSpace(opts.schemaCmd) != "" {
+		commands = append(commands, schemasource.Command{
+			Args:   schemasource.ParseCommandLine(opts.schemaCmd),
+			Format: opts.schemaFormat,
+		})
+	}
+
+	// The render dialect also hints SQL parsing for both schema files and command
+	// output, so the two SQL sources are treated consistently.
+	result, err := schemaload.LoadContext(cmd.Context(), schemaload.Options{
 		RootDirs:    opts.rootDirs,
 		SchemaFiles: opts.schemaFiles,
+		Commands:    commands,
+		Dialect:     opts.dialect,
 		Logf:        func(format string, args ...any) { fmt.Printf(format+"\n", args...) },
 	})
 	if err != nil {

--- a/cmd/internal/schemaload/schemaload.go
+++ b/cmd/internal/schemaload/schemaload.go
@@ -6,11 +6,13 @@
 package schemaload
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/internal/schemafile"
 )
@@ -21,6 +23,9 @@ type Options struct {
 	RootDirs []string
 	// SchemaFiles are YAML, HCL, or SQL schema files (repeatable).
 	SchemaFiles []string
+	// Commands are external programs whose stdout is a desired schema
+	// (repeatable). Each runs directly without a shell.
+	Commands []schemasource.Command
 	// Dialect is an optional dialect hint used when parsing SQL schema files.
 	Dialect string
 	// Logf, when non-nil, receives human-readable progress messages. Commands
@@ -40,38 +45,54 @@ func (o Options) logf(format string, args ...any) {
 // applies when nothing is configured. It is intended for progress and report
 // headers.
 func (o Options) Sources() string {
-	parts := make([]string, 0, len(o.RootDirs)+len(o.SchemaFiles))
+	parts := make([]string, 0, len(o.RootDirs)+len(o.SchemaFiles)+len(o.Commands))
 	parts = append(parts, o.RootDirs...)
 	parts = append(parts, o.SchemaFiles...)
+	for _, command := range o.Commands {
+		parts = append(parts, "$("+strings.Join(command.Args, " ")+")")
+	}
 	if len(parts) == 0 {
 		parts = append(parts, "./")
 	}
 	return strings.Join(parts, ", ")
 }
 
-// Load resolves the desired schema described by opts. With no source at all it
-// defaults to scanning the current directory for Go entities (the historical
-// behavior). Multiple sources of any kind are merged into one composite schema.
+// Load resolves the desired schema described by opts using a background context.
+// It is a convenience wrapper over LoadContext for callers that do not run
+// external schema commands or do not need cancellation.
 func Load(opts Options) (*goschema.Database, error) {
+	return LoadContext(context.Background(), opts)
+}
+
+// LoadContext resolves the desired schema described by opts. With no source at
+// all it defaults to scanning the current directory for Go entities (the
+// historical behavior). Multiple sources of any kind are merged into one
+// composite schema. Any external schema commands are run under ctx.
+func LoadContext(ctx context.Context, opts Options) (*goschema.Database, error) {
 	rootDirs := opts.RootDirs
 	schemaFiles := opts.SchemaFiles
+	commands := opts.Commands
 
 	// With no source of any kind, default to scanning the current directory for
 	// Go entities.
-	if len(rootDirs) == 0 && len(schemaFiles) == 0 {
+	if len(rootDirs) == 0 && len(schemaFiles) == 0 && len(commands) == 0 {
 		rootDirs = []string{"./"}
 	}
 
-	// Single-source fast paths: Go roots only, or exactly one schema file.
-	if len(schemaFiles) == 0 {
+	// Single-source fast paths: Go roots only, exactly one schema file, or
+	// exactly one command.
+	if len(schemaFiles) == 0 && len(commands) == 0 {
 		return opts.loadGoRoots(rootDirs)
 	}
-	if len(rootDirs) == 0 && len(schemaFiles) == 1 {
+	if len(rootDirs) == 0 && len(commands) == 0 && len(schemaFiles) == 1 {
 		return opts.loadSchemaFile(schemaFiles[0])
+	}
+	if len(rootDirs) == 0 && len(schemaFiles) == 0 && len(commands) == 1 {
+		return opts.loadCommand(ctx, commands[0])
 	}
 
 	// Composite: merge the Go roots (parsed un-finalized so Merge runs a single
-	// finalize pass) with each schema file.
+	// finalize pass) with each schema file and command output.
 	var sources []*goschema.Database
 	if len(rootDirs) > 0 {
 		absRoots, err := resolveRootDirs(rootDirs)
@@ -93,6 +114,13 @@ func Load(opts Options) (*goschema.Database, error) {
 			return nil, err
 		}
 		sources = append(sources, fileDB)
+	}
+	for _, command := range commands {
+		commandDB, err := opts.loadCommand(ctx, command)
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, commandDB)
 	}
 
 	result, err := goschema.Merge(sources...)
@@ -119,6 +147,16 @@ func (o Options) loadGoRoots(rootDirs []string) (*goschema.Database, error) {
 		return nil, fmt.Errorf("error parsing packages: %w", err)
 	}
 	return result, nil
+}
+
+// loadCommand runs an external schema command and returns its parsed output. The
+// resolver's dialect hint is applied when the command does not set its own.
+func (o Options) loadCommand(ctx context.Context, command schemasource.Command) (*goschema.Database, error) {
+	if command.Dialect == "" {
+		command.Dialect = o.Dialect
+	}
+	o.logf("Running schema command: %s", strings.Join(command.Args, " "))
+	return schemasource.Run(ctx, command)
 }
 
 // resolveRootDirs turns each root into an absolute path and fails fast if any

--- a/cmd/internal/schemaload/schemaload_test.go
+++ b/cmd/internal/schemaload/schemaload_test.go
@@ -1,6 +1,8 @@
 package schemaload_test
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 )
 
 func TestLoad_YAMLSchemaFile(t *testing.T) {
@@ -182,4 +185,60 @@ tables:
 	c.Assert(err, qt.IsNil)
 	c.Assert(messages, qt.HasLen, 1)
 	c.Assert(messages[0], qt.Equals, "Reading schema file: %s")
+}
+
+// runHelperProcess emits a fixed SQL schema when this test binary is re-executed
+// as an external schema command. It is not itself a test, which keeps
+// TestHelperProcess free of control flow.
+func runHelperProcess() {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stdout, "CREATE TABLE orders (\n  id INTEGER PRIMARY KEY\n);\n")
+	os.Exit(0)
+}
+
+// TestHelperProcess is not a real test; the command tests re-execute this binary
+// with -test.run=TestHelperProcess to stand in for an external schema program.
+func TestHelperProcess(t *testing.T) {
+	runHelperProcess()
+}
+
+func schemaCommand() schemasource.Command {
+	return schemasource.Command{
+		Args: []string{os.Args[0], "-test.run=TestHelperProcess"},
+		Env:  []string{"GO_WANT_HELPER_PROCESS=1"},
+	}
+}
+
+func TestLoad_RunsSchemaCommand(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := schemaload.LoadContext(context.Background(), schemaload.Options{
+		Commands: []schemasource.Command{schemaCommand()},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "orders")
+}
+
+func TestLoad_MergesGoRootAndSchemaCommand(t *testing.T) {
+	c := qt.New(t)
+
+	root := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(root, "users.go"), []byte(`package entities
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+
+	db, err := schemaload.LoadContext(context.Background(), schemaload.Options{
+		RootDirs: []string{root},
+		Commands: []schemasource.Command{schemaCommand()},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 2)
 }

--- a/cmd/internal/schemasource/schemasource.go
+++ b/cmd/internal/schemasource/schemasource.go
@@ -1,0 +1,192 @@
+// Package schemasource runs an external program that emits a desired schema to
+// its standard output and parses that output into Ptah's schema IR.
+//
+// It is the building block behind the external-command desired-schema source:
+// Ptah runs an operator-configured loader (for example an ORM's schema
+// exporter) and consumes its stdout, decoupling the desired state from how it
+// was produced. The program is always executed directly with an explicit
+// argument vector — never through a shell — so no shell quoting or expansion is
+// applied.
+package schemasource
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/convert/toschema"
+	"github.com/stokaro/ptah/internal/parser"
+)
+
+// DefaultTimeout bounds how long an external schema command may run when the
+// caller does not set an explicit timeout.
+const DefaultTimeout = 60 * time.Second
+
+// maxCapturedOutput bounds how much stdout (and, for error reporting, stderr)
+// Ptah buffers from a schema command, so a runaway program cannot exhaust memory.
+const maxCapturedOutput = 64 << 20 // 64 MiB
+
+// waitDelay bounds how long Run waits for a timed-out or canceled command's
+// inherited I/O to drain before force-closing it (see exec.Cmd.WaitDelay).
+// Without it, a program that spawns a surviving grandchild holding the stdout
+// pipe open could block Ptah past its timeout. It is a variable so tests can
+// shorten it.
+var waitDelay = 10 * time.Second
+
+// Command describes an external program that writes a desired schema to stdout.
+type Command struct {
+	// Args is the program and its arguments. Args[0] is the executable; it is run
+	// directly with no shell, so no shell quoting or expansion is applied.
+	Args []string
+	// Format is the stdout format. Empty defaults to "sql". "hcl" and "yaml" are
+	// not yet supported by the external source.
+	Format string
+	// Dialect is an optional dialect hint used when parsing SQL output.
+	Dialect string
+	// Dir is the working directory for the program. Empty uses the current
+	// working directory.
+	Dir string
+	// Timeout bounds execution. Zero uses DefaultTimeout; a negative value
+	// disables the timeout.
+	Timeout time.Duration
+	// Env holds extra "KEY=VALUE" entries appended to the current environment.
+	Env []string
+}
+
+// ParseCommandLine splits a whitespace-separated command line into arguments. It
+// does NOT interpret shell quoting, so an argument containing spaces cannot be
+// expressed this way — use the configuration file's explicit argument list for
+// those cases.
+func ParseCommandLine(line string) []string {
+	return strings.Fields(line)
+}
+
+// Run executes cmd and parses its standard output into a desired schema. It
+// bounds execution with a timeout, and on failure surfaces the program's stderr.
+func Run(ctx context.Context, cmd Command) (*goschema.Database, error) {
+	if len(cmd.Args) == 0 || strings.TrimSpace(cmd.Args[0]) == "" {
+		return nil, errors.New("schema command is empty")
+	}
+
+	format := strings.ToLower(strings.TrimSpace(cmd.Format))
+	if format == "" {
+		format = "sql"
+	}
+	if format != "sql" {
+		return nil, fmt.Errorf("unsupported schema command format %q: only \"sql\" is supported", cmd.Format)
+	}
+
+	timeout := cmd.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+	runCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	stdout, err := run(runCtx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := parseSQL(stdout, cmd.Dialect)
+	if err != nil {
+		return nil, fmt.Errorf("parse schema command %q output: %w", cmd.Args[0], err)
+	}
+	return db, nil
+}
+
+func run(ctx context.Context, cmd Command) ([]byte, error) {
+	// The program and its arguments are supplied by the operator running Ptah
+	// (through --schema-cmd or ptah.yaml), analogous to git's core.editor. Ptah
+	// runs it directly with an explicit argument vector and never through a
+	// shell, so there is no shell-injection surface.
+	c := exec.CommandContext(ctx, cmd.Args[0], cmd.Args[1:]...) //nolint:gosec // operator-provided command, run directly without a shell
+	c.Dir = cmd.Dir
+	// Bound the wait for a killed program's inherited I/O to drain, so a loader
+	// that leaves a surviving child holding the stdout pipe open cannot block
+	// Ptah past its timeout.
+	c.WaitDelay = waitDelay
+	if len(cmd.Env) > 0 {
+		c.Env = append(os.Environ(), cmd.Env...)
+	}
+
+	stdout := &cappedBuffer{limit: maxCapturedOutput}
+	stderr := &cappedBuffer{limit: maxCapturedOutput}
+	c.Stdout = stdout
+	c.Stderr = stderr
+
+	if err := c.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("schema command %q timed out", cmd.Args[0])
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil, fmt.Errorf("schema command %q canceled", cmd.Args[0])
+		}
+		return nil, fmt.Errorf("schema command %q failed: %w%s", cmd.Args[0], err, stderrSuffix(stderr.String()))
+	}
+	if stdout.truncated {
+		return nil, fmt.Errorf("schema command %q produced more than %d bytes of output", cmd.Args[0], maxCapturedOutput)
+	}
+	return stdout.Bytes(), nil
+}
+
+// cappedBuffer accumulates up to limit bytes and then silently discards the
+// rest, recording that truncation happened. Write always reports a full write so
+// the child process is not killed with a short-write error; the timeout still
+// bounds a program that keeps producing output past the cap.
+type cappedBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	if remaining := b.limit - b.buf.Len(); remaining > 0 {
+		if len(p) > remaining {
+			b.buf.Write(p[:remaining])
+			b.truncated = true
+		} else {
+			b.buf.Write(p)
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *cappedBuffer) Bytes() []byte  { return b.buf.Bytes() }
+func (b *cappedBuffer) String() string { return b.buf.String() }
+
+// stderrSuffix formats a trailing, length-bounded excerpt of the program's
+// stderr for inclusion in an error message.
+func stderrSuffix(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	const maxLen = 2000
+	if len(s) > maxLen {
+		s = "..." + s[len(s)-maxLen:]
+	}
+	return ": " + s
+}
+
+func parseSQL(data []byte, dialect string) (*goschema.Database, error) {
+	statements, err := parser.NewParser(string(data), parser.WithDialect(dialect)).Parse()
+	if err != nil {
+		return nil, err
+	}
+	db := toschema.ToDatabase(statements)
+	goschema.Finalize(&db)
+	return &db, nil
+}

--- a/cmd/internal/schemasource/schemasource_internal_test.go
+++ b/cmd/internal/schemasource/schemasource_internal_test.go
@@ -1,0 +1,72 @@
+package schemasource
+
+// White-box testing required: cappedBuffer is an unexported guard against
+// runaway command output, and the surviving-child timeout test needs to shorten
+// the unexported waitDelay so it runs fast.
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestCappedBuffer_KeepsOutputWithinLimit(t *testing.T) {
+	c := qt.New(t)
+
+	b := &cappedBuffer{limit: 8}
+	n, err := b.Write([]byte("abcd"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 4)
+	c.Assert(b.String(), qt.Equals, "abcd")
+	c.Assert(b.truncated, qt.IsFalse)
+}
+
+func TestCappedBuffer_TruncatesPastLimit(t *testing.T) {
+	c := qt.New(t)
+
+	b := &cappedBuffer{limit: 4}
+	n, err := b.Write([]byte("abcdef"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(n, qt.Equals, 6) // reports a full write so the child is not killed
+	c.Assert(b.String(), qt.Equals, "abcd")
+	c.Assert(b.truncated, qt.IsTrue)
+}
+
+func TestCappedBuffer_TruncatesOnLaterWrite(t *testing.T) {
+	c := qt.New(t)
+
+	b := &cappedBuffer{limit: 4}
+	_, _ = b.Write([]byte("abcd"))
+	_, err := b.Write([]byte("ef"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(b.String(), qt.Equals, "abcd")
+	c.Assert(b.truncated, qt.IsTrue)
+}
+
+// TestRun_TimeoutBoundedDespiteSurvivingChild proves the WaitDelay guard: a
+// program that leaves a grandchild holding the stdout pipe open must not block
+// Run past the timeout (the grandchild sleeps far longer than any wait here).
+func TestRun_TimeoutBoundedDespiteSurvivingChild(t *testing.T) {
+	c := qt.New(t)
+
+	restore := waitDelay
+	waitDelay = 200 * time.Millisecond
+	defer func() { waitDelay = restore }()
+
+	start := time.Now()
+	_, err := Run(context.Background(), Command{
+		Args:    []string{os.Args[0], "-test.run=TestHelperProcess"},
+		Env:     []string{"GO_WANT_HELPER_PROCESS=1", "SCHEMASOURCE_HELPER_MODE=orphan"},
+		Timeout: 200 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(elapsed < 10*time.Second, qt.IsTrue)
+}

--- a/cmd/internal/schemasource/schemasource_test.go
+++ b/cmd/internal/schemasource/schemasource_test.go
@@ -1,0 +1,151 @@
+package schemasource_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
+)
+
+// helperModes maps a mode name to the behavior the re-executed test binary
+// performs when it stands in for an external schema program.
+var helperModes = map[string]func(){
+	"sql": func() {
+		fmt.Fprint(os.Stdout, "CREATE TABLE widgets (\n  id INTEGER PRIMARY KEY,\n  name TEXT NOT NULL\n);\n")
+		os.Exit(0)
+	},
+	"badsql": func() {
+		fmt.Fprint(os.Stdout, "CREATE TABLE widgets (id INTEGER\n")
+		os.Exit(0)
+	},
+	"fail": func() {
+		fmt.Fprintln(os.Stderr, "loader blew up")
+		os.Exit(3)
+	},
+	"sleep": func() {
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
+	},
+	"orphan": func() {
+		// Spawn a grandchild that inherits stdout and outlives this process, so
+		// the stdout pipe stays open after the direct child exits.
+		child := exec.Command(os.Args[0], "-test.run=TestHelperProcess") //nolint:gosec // test fixture re-executing this test binary
+		child.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1", "SCHEMASOURCE_HELPER_MODE=sleep")
+		child.Stdout = os.Stdout
+		_ = child.Start()
+		os.Exit(0)
+	},
+}
+
+// runHelperProcess is executed when this test binary is re-run as the external
+// schema program by the tests below. It is not itself a test. Keeping the
+// dispatch here leaves TestHelperProcess free of control flow.
+func runHelperProcess() {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	emit, ok := helperModes[os.Getenv("SCHEMASOURCE_HELPER_MODE")]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "unknown helper mode")
+		os.Exit(1)
+	}
+	emit()
+}
+
+// TestHelperProcess is not a real test; the tests below re-execute this binary
+// with -test.run=TestHelperProcess to act as an external schema program.
+func TestHelperProcess(t *testing.T) {
+	runHelperProcess()
+}
+
+func helperArgs() []string {
+	return []string{os.Args[0], "-test.run=TestHelperProcess"}
+}
+
+func helperEnv(mode string) []string {
+	return []string{"GO_WANT_HELPER_PROCESS=1", "SCHEMASOURCE_HELPER_MODE=" + mode}
+}
+
+func TestRun_ParsesSQLStdout(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := schemasource.Run(context.Background(), schemasource.Command{
+		Args: helperArgs(),
+		Env:  helperEnv("sql"),
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Name, qt.Equals, "widgets")
+	c.Assert(db.Fields, qt.HasLen, 2)
+}
+
+func TestRun_SurfacesStderrOnFailure(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemasource.Run(context.Background(), schemasource.Command{
+		Args: helperArgs(),
+		Env:  helperEnv("fail"),
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "loader blew up")
+}
+
+func TestRun_TimesOut(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemasource.Run(context.Background(), schemasource.Command{
+		Args:    helperArgs(),
+		Env:     helperEnv("sleep"),
+		Timeout: 200 * time.Millisecond,
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "timed out")
+}
+
+func TestRun_ReportsParseError(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemasource.Run(context.Background(), schemasource.Command{
+		Args: helperArgs(),
+		Env:  helperEnv("badsql"),
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "parse schema command")
+}
+
+func TestRun_RejectsEmptyCommand(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemasource.Run(context.Background(), schemasource.Command{})
+
+	c.Assert(err, qt.ErrorMatches, "schema command is empty")
+}
+
+func TestRun_RejectsUnsupportedFormat(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemasource.Run(context.Background(), schemasource.Command{
+		Args:   helperArgs(),
+		Env:    helperEnv("sql"),
+		Format: "hcl",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `unsupported schema command format "hcl": only "sql" is supported`)
+}
+
+func TestParseCommandLine_SplitsOnWhitespace(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(schemasource.ParseCommandLine("go run ./loader"), qt.DeepEquals, []string{"go", "run", "./loader"})
+	c.Assert(schemasource.ParseCommandLine("   "), qt.HasLen, 0)
+}

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -144,3 +144,37 @@ conflicting definitions are an error. This is Ptah's open, local, no-account
 equivalent of Atlas's Pro-only `composite_schema` data source. For composing
 multiple Go packages — including on `ptah schema compare` and the migration
 commands — see [Go schema](../go-schema/).
+
+## Load from an external program
+
+When the desired schema lives in an ORM or framework rather than in Go
+annotations or a static file, `ptah schema render --schema-cmd` runs an external
+program and reads its standard output as the desired schema. The program is
+executed directly — never through a shell — so an ORM's own schema exporter can
+feed Ptah's engine:
+
+```bash
+ptah schema render --schema-cmd "./scripts/export-schema" --dialect postgres
+```
+
+The command's stdout is parsed as SQL by default; set `--schema-format sql`
+explicitly if you prefer. Execution is bounded by a timeout, and if the program
+exits non-zero its stderr is surfaced in the error. Because the program is run
+with an explicit argument vector split on whitespace, arguments cannot contain
+spaces — wrap a more complex invocation in a small script and point
+`--schema-cmd` at that.
+
+An external command composes with the other sources, so you can, for example,
+merge an ORM export with a vendored HCL file:
+
+```bash
+ptah schema render \
+  --schema-cmd "./scripts/export-schema" \
+  --schema-file ./vendor/thirdparty.hcl \
+  --dialect postgres
+```
+
+This is Ptah's open, local, MIT equivalent of Atlas's `data "external_schema"`
+source and its ORM provider loaders. External-command support currently lands on
+`ptah schema render`; the other commands gain it as the shared resolver is
+extended.


### PR DESCRIPTION
## Summary

Implements the MVP of #669's external desired-schema source. `ptah schema render --schema-cmd "<program>"` runs an external program and reads its standard output as the desired schema, so an ORM or framework schema exporter can feed Ptah's engine:

```bash
ptah schema render --schema-cmd "./scripts/export-schema" --dialect postgres
```

This is Ptah's open, local, MIT equivalent of Atlas's `data "external_schema"` source and its ORM provider loaders (GORM, Django, Ent, Prisma, …), which decouples Ptah's diff/plan/migrate pipeline from how the desired schema was produced. It builds directly on the composite resolver from #702/#703, so the external command composes with `--root-dir` and `--schema-file` into one desired schema.

## What's included

- **New `cmd/internal/schemasource`** — `Run(ctx, Command)` executes the program with an explicit argument vector (**never a shell**), parses its stdout as SQL into `goschema.Database`, and returns it. Safeguards:
  - **Timeout** (default 60s) via `context.WithTimeout`, plus **`Cmd.WaitDelay`** so a loader that leaves a surviving child holding the stdout pipe open cannot block Ptah past the deadline.
  - **Bounded capture** — stdout/stderr are buffered up to a 64 MiB cap, so a runaway program cannot exhaust memory; exceeding the cap is an error.
  - **stderr surfaced** (length-bounded) in the error when the program exits non-zero; clean `timed out` / `canceled` messages for context expiry.
- **`schemaload` integration** — adds a `Commands` source and a `LoadContext(ctx, opts)` entry point; an external command merges with Go roots and schema files exactly like the other sources. The existing `Load(opts)` is preserved as a background-context wrapper, so `compare`/`migrate`/`drift` are byte-for-byte unchanged.
- **`ptah schema render`** — new `--schema-cmd` and `--schema-format` (`sql`) flags. The command line is split on whitespace and run without a shell, so arguments cannot contain spaces (wrap complex invocations in a script). `--dialect` now consistently hints SQL parsing for both schema files and command output.
- **Docs** — a "Load from an external program" section in `workflows/schema-files.md`.

## Security posture

The program and its arguments are operator-provided (typed into `--schema-cmd`), analogous to git's `core.editor` and the repo's existing `cmd/migrateedit`. There is **no shell anywhere** — Ptah runs an explicit argv, so shell metacharacters become literal, non-executable tokens. The subprocess stdout flows only into the SQL parser → `goschema` IR (no file/exec/network sink), so adversarial loader output can at most produce a parse error, never code execution. Execution is time- and memory-bounded.

## Testing

- New `schemasource` tests via the self-exec helper-process idiom: SQL parse, stderr-on-failure, timeout, **surviving-child timeout bound** (regression test for the WaitDelay guard), output-cap truncation, parse-error, empty-command, unsupported-format, and command-line splitting. `schemaload` tests cover a single command source and a Go-root + command merge. `-race -count=2` clean.
- Full unit suite, `go vet`, `golangci-lint` (0 issues; the single `exec` line carries a scoped `//nolint:gosec` with rationale), test-style, and public-API-snapshot checks all pass.
- Verified end-to-end: `render --schema-cmd ./loader` renders the program's SQL; a failing loader surfaces its stderr and a non-zero exit; and `--root-dir ./stubs --schema-cmd ./loader` merges both sources.

## Scope / follow-ups

MVP is SQL output on `render` (smallest blast radius, per the issue's phasing). Follow-ups: extend the external source to `compare`/`migrate`/`drift` (the resolver already carries it), a `ptah.yaml` `external_schema` block with an explicit argument list, HCL/YAML output formats, and an ORM-loader recipes catalog.