### PR TITLE
Accept an external schema command on compare, migrate, and drift (#669)

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -18,15 +19,19 @@ import (
 )
 
 const (
-	rootDirFlag    = "root-dir"
-	schemaFileFlag = "schema-file"
-	dbURLFlag      = "db-url"
-	exitCodeFlag   = "exit-code"
+	rootDirFlag      = "root-dir"
+	schemaFileFlag   = "schema-file"
+	schemaCmdFlag    = "schema-cmd"
+	schemaFormatFlag = "schema-format"
+	dbURLFlag        = "db-url"
+	exitCodeFlag     = "exit-code"
 )
 
 type options struct {
 	rootDirs       []string
 	schemaFiles    []string
+	schemaCmd      string
+	schemaFormat   string
 	dbURL          string
 	exitOnDiff     bool
 	connectTimeout string
@@ -55,6 +60,8 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to compare instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
+	flags.StringVar(&opts.schemaCmd, schemaCmdFlag, "", `External program whose stdout is the desired schema; run without a shell, split on whitespace. Example: "go run ./loader"`)
+	flags.StringVar(&opts.schemaFormat, schemaFormatFlag, "sql", "Format of the --schema-cmd output: sql")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.exitOnDiff, exitCodeFlag, false, "Exit with 1 when the schema diff is non-empty")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
@@ -71,15 +78,16 @@ func compareCommand(cmd *cobra.Command, opts *options) error {
 	loadOpts := schemaload.Options{
 		RootDirs:    opts.rootDirs,
 		SchemaFiles: opts.schemaFiles,
+		Commands:    schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
 	}
 
 	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", loadOpts.Sources(), dbschema.FormatDatabaseURL(opts.dbURL))
 	fmt.Fprintln(out, "=== SCHEMA COMPARISON ===")
 	fmt.Fprintln(out)
 
-	// 1. Resolve the desired schema from Go entities and/or schema files into one
-	// composite schema.
-	result, err := schemaload.Load(loadOpts)
+	// 1. Resolve the desired schema from Go entities, schema files, and/or an
+	// external command into one composite schema.
+	result, err := schemaload.LoadContext(cmd.Context(), loadOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/compare/compare_test.go
+++ b/cmd/compare/compare_test.go
@@ -21,3 +21,12 @@ func TestCompareCommandExposesRepeatableSchemaFileFlag(t *testing.T) {
 	c.Assert(rootDir, qt.IsNotNil)
 	c.Assert(rootDir.Value.Type(), qt.Equals, "stringArray")
 }
+
+func TestCompareCommandExposesSchemaCommandFlags(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := compare.NewCompareCommand()
+
+	c.Assert(cmd.Flags().Lookup("schema-cmd"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("schema-format"), qt.IsNotNil)
+}

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaops"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/migration/safety"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -33,6 +34,8 @@ var errDriftDetected = errors.New("schema drift detected")
 func NewDriftCommand() *cobra.Command {
 	var rootDirs []string
 	var schemaFiles []string
+	var schemaCmd string
+	var schemaFormat string
 	var dbURL string
 	var format string
 	var severity string
@@ -50,6 +53,8 @@ func NewDriftCommand() *cobra.Command {
 			return runDrift(cmd, runOptions{
 				rootDirs:          rootDirs,
 				schemaFiles:       schemaFiles,
+				schemaCmd:         schemaCmd,
+				schemaFormat:      schemaFormat,
 				dbURL:             dbURL,
 				format:            format,
 				severity:          severity,
@@ -63,6 +68,8 @@ func NewDriftCommand() *cobra.Command {
 
 	cmd.Flags().StringArrayVar(&rootDirs, "root-dir", nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	cmd.Flags().StringArrayVar(&schemaFiles, "schema-file", nil, "YAML, HCL, or SQL schema file to check drift against instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
+	cmd.Flags().StringVar(&schemaCmd, "schema-cmd", "", `External program whose stdout is the desired schema; run without a shell, split on whitespace. Example: "go run ./loader"`)
+	cmd.Flags().StringVar(&schemaFormat, "schema-format", "sql", "Format of the --schema-cmd output: sql")
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions")
 	cmd.Flags().StringVar(&severity, "severity", severityAll, "Failing drift threshold: all or destructive")
@@ -83,6 +90,8 @@ func NewDriftCommand() *cobra.Command {
 type runOptions struct {
 	rootDirs          []string
 	schemaFiles       []string
+	schemaCmd         string
+	schemaFormat      string
 	dbURL             string
 	format            string
 	severity          string
@@ -130,6 +139,7 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 	result, err := schemaops.Compare(cmd.Context(), schemaops.CompareOptions{
 		RootDirs:       opts.rootDirs,
 		SchemaFiles:    opts.schemaFiles,
+		Commands:       schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
 		DatabaseURL:    opts.dbURL,
 		ConnectTimeout: connectTimeout,
 		IgnoredTables:  ignoredTables,

--- a/cmd/drift/drift_test.go
+++ b/cmd/drift/drift_test.go
@@ -32,6 +32,9 @@ func TestNewDriftCommand_ExposesRepeatableSchemaSources(t *testing.T) {
 	schemaFile := cmd.Flags().Lookup("schema-file")
 	c.Assert(schemaFile, qt.IsNotNil)
 	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
+
+	c.Assert(cmd.Flags().Lookup("schema-cmd"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("schema-format"), qt.IsNotNil)
 }
 
 func TestRunDrift_MissingDatabaseURLReturnsCode2(t *testing.T) {

--- a/cmd/internal/schemaops/schemaops.go
+++ b/cmd/internal/schemaops/schemaops.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/config"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
@@ -21,6 +22,7 @@ import (
 type CompareOptions struct {
 	RootDirs       []string
 	SchemaFiles    []string
+	Commands       []schemasource.Command
 	DatabaseURL    string
 	ConnectTimeout time.Duration
 	IgnoredTables  []string
@@ -37,9 +39,9 @@ type CompareResult struct {
 	Diff        *difftypes.SchemaDiff
 }
 
-// Compare resolves the desired schema from Go entities and/or schema files,
-// reads the live database schema, applies command filters, and returns a
-// dialect-aware schema diff.
+// Compare resolves the desired schema from Go entities, schema files, and/or an
+// external command, reads the live database schema, applies command filters, and
+// returns a dialect-aware schema diff.
 func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
 	if opts.DatabaseURL == "" {
 		return nil, fmt.Errorf("database URL is required")
@@ -48,8 +50,9 @@ func Compare(ctx context.Context, opts CompareOptions) (*CompareResult, error) {
 	loadOpts := schemaload.Options{
 		RootDirs:    opts.RootDirs,
 		SchemaFiles: opts.SchemaFiles,
+		Commands:    opts.Commands,
 	}
-	generated, err := schemaload.Load(loadOpts)
+	generated, err := schemaload.LoadContext(ctx, loadOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/internal/schemasource/schemasource.go
+++ b/cmd/internal/schemasource/schemasource.go
@@ -67,6 +67,20 @@ func ParseCommandLine(line string) []string {
 	return strings.Fields(line)
 }
 
+// CommandsFromCLI builds the external-command sources from command-line flag
+// values. It returns nil when no command is configured, so callers can pass the
+// result straight into a resolver's command list.
+func CommandsFromCLI(cmdLine, format, dialect string) []Command {
+	if strings.TrimSpace(cmdLine) == "" {
+		return nil
+	}
+	return []Command{{
+		Args:    ParseCommandLine(cmdLine),
+		Format:  format,
+		Dialect: dialect,
+	}}
+}
+
 // Run executes cmd and parses its standard output into a desired schema. It
 // bounds execution with a timeout, and on failure surfaces the program's stderr.
 func Run(ctx context.Context, cmd Command) (*goschema.Database, error) {

--- a/cmd/internal/schemasource/schemasource_test.go
+++ b/cmd/internal/schemasource/schemasource_test.go
@@ -149,3 +149,21 @@ func TestParseCommandLine_SplitsOnWhitespace(t *testing.T) {
 	c.Assert(schemasource.ParseCommandLine("go run ./loader"), qt.DeepEquals, []string{"go", "run", "./loader"})
 	c.Assert(schemasource.ParseCommandLine("   "), qt.HasLen, 0)
 }
+
+func TestCommandsFromCLI_BuildsCommand(t *testing.T) {
+	c := qt.New(t)
+
+	commands := schemasource.CommandsFromCLI("go run ./loader", "sql", "postgres")
+
+	c.Assert(commands, qt.HasLen, 1)
+	c.Assert(commands[0].Args, qt.DeepEquals, []string{"go", "run", "./loader"})
+	c.Assert(commands[0].Format, qt.Equals, "sql")
+	c.Assert(commands[0].Dialect, qt.Equals, "postgres")
+}
+
+func TestCommandsFromCLI_ReturnsNilWhenEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(schemasource.CommandsFromCLI("", "sql", ""), qt.IsNil)
+	c.Assert(schemasource.CommandsFromCLI("   ", "sql", ""), qt.IsNil)
+}

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
@@ -17,6 +18,8 @@ import (
 const (
 	generateRootDirFlag          = "root-dir"
 	generateSchemaFileFlag       = "schema-file"
+	generateSchemaCmdFlag        = "schema-cmd"
+	generateSchemaFormatFlag     = "schema-format"
 	generateDBURLFlag            = "db-url"
 	generateMigrationsDirFlag    = "migrations-dir"
 	generateNameFlag             = "name"
@@ -42,6 +45,8 @@ and performs an up/down/up round-trip.`,
 	flags := cmd.Flags()
 	flags.StringArray(generateRootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringArray(generateSchemaFileFlag, nil, "YAML, HCL, or SQL schema file to generate a migration toward instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
+	flags.String(generateSchemaCmdFlag, "", `External program whose stdout is the desired schema; run without a shell, split on whitespace. Example: "go run ./loader"`)
+	flags.String(generateSchemaFormatFlag, "sql", "Format of the --schema-cmd output: sql")
 	flags.String(generateDBURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.String(generateMigrationsDirFlag, "", "Directory containing existing migrations and receiving generated files (required)")
 	flags.String(generateNameFlag, "migration", "Migration name")
@@ -67,9 +72,18 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	generated, err := schemaload.Load(schemaload.Options{
+	schemaCmd, err := cmd.Flags().GetString(generateSchemaCmdFlag)
+	if err != nil {
+		return err
+	}
+	schemaFormat, err := cmd.Flags().GetString(generateSchemaFormatFlag)
+	if err != nil {
+		return err
+	}
+	generated, err := schemaload.LoadContext(cmd.Context(), schemaload.Options{
 		RootDirs:    rootDirs,
 		SchemaFiles: schemaFiles,
+		Commands:    schemasource.CommandsFromCLI(schemaCmd, schemaFormat, ""),
 	})
 	if err != nil {
 		return err

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
@@ -22,6 +23,8 @@ import (
 const (
 	rootDirFlag          = "root-dir"
 	schemaFileFlag       = "schema-file"
+	schemaCmdFlag        = "schema-cmd"
+	schemaFormatFlag     = "schema-format"
 	dbURLFlag            = "db-url"
 	checkDestructiveFlag = "check-destructive"
 	allowDestructiveFlag = "allow-destructive"
@@ -31,6 +34,8 @@ const (
 type options struct {
 	rootDirs         []string
 	schemaFiles      []string
+	schemaCmd        string
+	schemaFormat     string
 	dbURL            string
 	checkDestructive bool
 	allowDestructive bool
@@ -61,6 +66,8 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to migrate toward instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
+	flags.StringVar(&opts.schemaCmd, schemaCmdFlag, "", `External program whose stdout is the desired schema; run without a shell, split on whitespace. Example: "go run ./loader"`)
+	flags.StringVar(&opts.schemaFormat, schemaFormatFlag, "sql", "Format of the --schema-cmd output: sql")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.checkDestructive, checkDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
 	flags.BoolVar(&opts.allowDestructive, allowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
@@ -82,6 +89,7 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	loadOpts := schemaload.Options{
 		RootDirs:    opts.rootDirs,
 		SchemaFiles: opts.schemaFiles,
+		Commands:    schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
 	}
 	rootsDisplay := loadOpts.Sources()
 
@@ -91,9 +99,9 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 		fmt.Fprintln(out)
 	}
 
-	// 1. Resolve the desired schema from Go entities and/or schema files into one
-	// composite schema.
-	result, err := schemaload.Load(loadOpts)
+	// 1. Resolve the desired schema from Go entities, schema files, and/or an
+	// external command into one composite schema.
+	result, err := schemaload.LoadContext(cmd.Context(), loadOpts)
 	if err != nil {
 		return err
 	}

--- a/cmd/migrate/schemafile_flag_test.go
+++ b/cmd/migrate/schemafile_flag_test.go
@@ -27,3 +27,21 @@ func TestMigrateGenerateCommandExposesRepeatableSchemaFileFlag(t *testing.T) {
 	c.Assert(schemaFile, qt.IsNotNil)
 	c.Assert(schemaFile.Value.Type(), qt.Equals, "stringArray")
 }
+
+func TestMigratePlanCommandExposesSchemaCommandFlags(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migrate.NewMigrateCommand()
+
+	c.Assert(cmd.Flags().Lookup("schema-cmd"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("schema-format"), qt.IsNotNil)
+}
+
+func TestMigrateGenerateCommandExposesSchemaCommandFlags(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := migrate.NewMigrateGenerateCommand()
+
+	c.Assert(cmd.Flags().Lookup("schema-cmd"), qt.IsNotNil)
+	c.Assert(cmd.Flags().Lookup("schema-format"), qt.IsNotNil)
+}

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -148,13 +148,21 @@ commands — see [Go schema](../go-schema/).
 ## Load from an external program
 
 When the desired schema lives in an ORM or framework rather than in Go
-annotations or a static file, `ptah schema render --schema-cmd` runs an external
-program and reads its standard output as the desired schema. The program is
-executed directly — never through a shell — so an ORM's own schema exporter can
-feed Ptah's engine:
+annotations or a static file, `--schema-cmd` runs an external program and reads
+its standard output as the desired schema. The program is executed directly —
+never through a shell — so an ORM's own schema exporter can feed Ptah's engine:
 
 ```bash
 ptah schema render --schema-cmd "./scripts/export-schema" --dialect postgres
+```
+
+`--schema-cmd` is accepted wherever Ptah needs a desired schema —
+`ptah schema render`, `ptah schema compare`, `ptah schema drift`, and the
+migration commands (`ptah migrations plan` / `ptah migrations generate`) — so you
+can diff, plan, migrate, and drift-check a live database against an ORM's schema:
+
+```bash
+ptah schema drift --schema-cmd "./scripts/export-schema" --db-url "$DATABASE_URL"
 ```
 
 The command's stdout is parsed as SQL by default; set `--schema-format sql`
@@ -175,6 +183,4 @@ ptah schema render \
 ```
 
 This is Ptah's open, local, MIT equivalent of Atlas's `data "external_schema"`
-source and its ORM provider loaders. External-command support currently lands on
-`ptah schema render`; the other commands gain it as the shared resolver is
-extended.
+source and its ORM provider loaders.


### PR DESCRIPTION
## Summary

Completes the external-command desired-schema source across the command surface. #704 added `--schema-cmd` to `ptah schema render`; this extends it to **`ptah schema compare`**, **`ptah schema drift`**, and the migration commands (**`ptah migrations plan`** / **`ptah migrations generate`**). A live database can now be diffed, planned, migrated, and drift-checked against an ORM or framework schema exporter — not just Go entities and static schema files:

```bash
ptah schema drift    --schema-cmd "./scripts/export-schema" --db-url "$DATABASE_URL"
ptah schema compare  --schema-cmd "./scripts/export-schema" --db-url "$DATABASE_URL"
ptah migrations plan --schema-cmd "./scripts/export-schema" --db-url "$DATABASE_URL"
```

This is where the practical workflow value of the external source lives (CI drift detection and migration planning against your ORM's schema), and it mirrors the `--schema-file` roll-out from #702/#703.

## Changes

- **`schemasource.CommandsFromCLI(cmdLine, format, dialect)`** — small shared helper that turns the flag values into a command source, returning nil when unset, so each command wires it identically.
- **`compare`, `migrations plan`, `migrations generate`** — add `--schema-cmd` / `--schema-format` and resolve through `schemaload.LoadContext(cmd.Context(), …)` with the command included, so it runs under the command's context (cancellation honored).
- **`schemaops.Compare`** (behind `drift` and `migratebaseline`) gains a `Commands` option and resolves via `LoadContext`; `drift` exposes the flags. `migratebaseline` is unchanged (it does not set `Commands`).
- Docs: the external-program section now notes it works across render, compare, drift, and the migration commands.

The external command composes with `--root-dir` and `--schema-file` exactly like the other sources, via the same composite `Merge`.

## Testing

- Flag-registration tests for `--schema-cmd`/`--schema-format` on compare, migrate plan, migrate generate, and drift; unit tests for `CommandsFromCLI`.
- Full unit suite, `go vet`, `golangci-lint` (0 issues), test-style, and public-API-snapshot checks all pass.
- Verified end-to-end against a live PostgreSQL: `ptah schema drift --schema-cmd ./loader` detects the expected drift (exit 1, `sources` shows the command), reusing the already-reviewed `schemasource` runner from #704.

## Follow-ups

A `ptah.yaml external_schema` config block (with an explicit argument list, avoiding the whitespace-split limitation) and HCL/YAML command-output formats remain, per #669's phasing.