### PR TITLE
Add a ptah.yaml external_schema config block (#669)

### DIFF
--- a/cmd/internal/schemasource/schemasource.go
+++ b/cmd/internal/schemasource/schemasource.go
@@ -81,6 +81,23 @@ func CommandsFromCLI(cmdLine, format, dialect string) []Command {
 	}}
 }
 
+// CommandsFromConfig builds the external-command sources from a configuration
+// block that already provides an explicit argument list (for example a
+// ptah.yaml external_schema block). The list is used verbatim — no whitespace
+// splitting — so arguments may contain spaces. It returns nil when program is
+// empty.
+func CommandsFromConfig(program []string, format, dir string, env []string) []Command {
+	if len(program) == 0 {
+		return nil
+	}
+	return []Command{{
+		Args:   program,
+		Format: format,
+		Dir:    dir,
+		Env:    env,
+	}}
+}
+
 // Run executes cmd and parses its standard output into a desired schema. It
 // bounds execution with a timeout, and on failure surfaces the program's stderr.
 func Run(ctx context.Context, cmd Command) (*goschema.Database, error) {

--- a/cmd/internal/schemasource/schemasource_test.go
+++ b/cmd/internal/schemasource/schemasource_test.go
@@ -167,3 +167,29 @@ func TestCommandsFromCLI_ReturnsNilWhenEmpty(t *testing.T) {
 	c.Assert(schemasource.CommandsFromCLI("", "sql", ""), qt.IsNil)
 	c.Assert(schemasource.CommandsFromCLI("   ", "sql", ""), qt.IsNil)
 }
+
+func TestCommandsFromConfig_UsesArgsVerbatim(t *testing.T) {
+	c := qt.New(t)
+
+	commands := schemasource.CommandsFromConfig(
+		[]string{"go", "run", "./loader", "--path", "./models with spaces"},
+		"sql",
+		"./project",
+		[]string{"FOO=bar"},
+	)
+
+	c.Assert(commands, qt.HasLen, 1)
+	// The explicit argument list is used verbatim — no whitespace splitting — so
+	// an argument containing spaces survives intact.
+	c.Assert(commands[0].Args, qt.DeepEquals, []string{"go", "run", "./loader", "--path", "./models with spaces"})
+	c.Assert(commands[0].Format, qt.Equals, "sql")
+	c.Assert(commands[0].Dir, qt.Equals, "./project")
+	c.Assert(commands[0].Env, qt.DeepEquals, []string{"FOO=bar"})
+}
+
+func TestCommandsFromConfig_ReturnsNilWhenEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(schemasource.CommandsFromConfig(nil, "sql", "", nil), qt.IsNil)
+	c.Assert(schemasource.CommandsFromConfig([]string{}, "sql", "", nil), qt.IsNil)
+}

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -80,14 +80,6 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	generated, err := schemaload.LoadContext(cmd.Context(), schemaload.Options{
-		RootDirs:    rootDirs,
-		SchemaFiles: schemaFiles,
-		Commands:    schemasource.CommandsFromCLI(schemaCmd, schemaFormat, ""),
-	})
-	if err != nil {
-		return err
-	}
 	dbURL, err := cmd.Flags().GetString(generateDBURLFlag)
 	if err != nil {
 		return err
@@ -112,6 +104,27 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Resolve the external schema command from the --schema-cmd flag, falling
+	// back to the ptah.yaml external_schema block when the flag is unset.
+	commands := schemasource.CommandsFromCLI(schemaCmd, schemaFormat, "")
+	if commands == nil {
+		commands = schemasource.CommandsFromConfig(
+			projectCfg.ExternalSchema.Program,
+			projectCfg.ExternalSchema.Format,
+			projectCfg.ExternalSchema.WorkingDir,
+			projectCfg.ExternalSchema.Env,
+		)
+	}
+	generated, err := schemaload.LoadContext(cmd.Context(), schemaload.Options{
+		RootDirs:    rootDirs,
+		SchemaFiles: schemaFiles,
+		Commands:    commands,
+	})
+	if err != nil {
+		return err
+	}
+
 	dbURL = dbcli.EffectiveString(cmd, generateDBURLFlag, dbURL, projectCfg.DatabaseURL)
 	migrationsDir = dbcli.EffectiveString(cmd, generateMigrationsDirFlag, migrationsDir, projectCfg.Migration.Dir)
 	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, shadowDB, projectCfg.DevURL)

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -41,17 +41,39 @@ type Config struct {
 	Format FormatConfig
 	// Diff holds Atlas-compatible schema diff policy.
 	Diff DiffConfig
+	// ExternalSchema configures an external program that emits the desired
+	// schema to stdout.
+	ExternalSchema ExternalSchemaConfig
 
 	presence configPresence
 }
 
 type configPresence struct {
-	databaseURL       bool
-	devURL            bool
-	schemaSources     bool
-	schemas           bool
-	exclude           bool
-	lintDisabledRules bool
+	databaseURL           bool
+	devURL                bool
+	schemaSources         bool
+	schemas               bool
+	exclude               bool
+	lintDisabledRules     bool
+	externalSchemaProgram bool
+	externalSchemaEnv     bool
+}
+
+// ExternalSchemaConfig configures an external program whose standard output is
+// the desired schema. It is Ptah's open equivalent of Atlas's external_schema
+// data source: Program is run directly (no shell) and must print the complete
+// desired schema — currently SQL DDL — to stdout.
+type ExternalSchemaConfig struct {
+	// Program is the executable and its arguments as an explicit argv list.
+	// Program[0] is the command; it is run without a shell.
+	Program []string
+	// Format is the stdout format (default "sql").
+	Format string
+	// WorkingDir is the directory the program runs in; empty uses the current
+	// working directory.
+	WorkingDir string
+	// Env holds extra "KEY=VALUE" entries passed to the program.
+	Env []string
 }
 
 // ConfigBool preserves whether a boolean project config value was set
@@ -238,8 +260,32 @@ func Merge(base, override Config) Config {
 	result.Lint = mergeLint(result.Lint, override.Lint, override.presence)
 	result.Format = mergeFormat(result.Format, override.Format)
 	result.Diff = mergeDiff(result.Diff, override.Diff)
+	result.ExternalSchema = mergeExternalSchema(result.ExternalSchema, override.ExternalSchema, override.presence)
 	if override.presence.lintDisabledRules || len(override.Lint.DisabledRules) > 0 {
 		result.presence.lintDisabledRules = true
+	}
+	if override.presence.externalSchemaProgram || len(override.ExternalSchema.Program) > 0 {
+		result.presence.externalSchemaProgram = true
+	}
+	if override.presence.externalSchemaEnv || len(override.ExternalSchema.Env) > 0 {
+		result.presence.externalSchemaEnv = true
+	}
+	return result
+}
+
+func mergeExternalSchema(base, override ExternalSchemaConfig, presence configPresence) ExternalSchemaConfig {
+	result := base
+	if presence.externalSchemaProgram || len(override.Program) > 0 {
+		result.Program = slices.Clone(override.Program)
+	}
+	if override.Format != "" {
+		result.Format = override.Format
+	}
+	if override.WorkingDir != "" {
+		result.WorkingDir = override.WorkingDir
+	}
+	if presence.externalSchemaEnv || len(override.Env) > 0 {
+		result.Env = slices.Clone(override.Env)
 	}
 	return result
 }

--- a/config/projectconfig/external_schema_test.go
+++ b/config/projectconfig/external_schema_test.go
@@ -1,0 +1,100 @@
+package projectconfig_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestParsePtahExternalSchema(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := projectconfig.ParsePtah([]byte(`external_schema:
+  program: ["go", "run", "./loader"]
+  format: sql
+  working_dir: ./project
+  env: ["FOO=bar", "BAZ=qux"]
+`), "ptah.yaml", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"go", "run", "./loader"})
+	c.Assert(cfg.ExternalSchema.Format, qt.Equals, "sql")
+	c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "./project")
+	c.Assert(cfg.ExternalSchema.Env, qt.DeepEquals, []string{"FOO=bar", "BAZ=qux"})
+}
+
+func TestParsePtahExternalSchemaEnvOverridesBase(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := projectconfig.ParsePtah([]byte(`external_schema:
+  program: ["base-loader"]
+  format: sql
+env:
+  prod:
+    external_schema:
+      program: ["prod-loader", "--flag"]
+      working_dir: ./prod
+`), "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	// The env block's program replaces the base program; base format survives
+	// because the env block did not set it.
+	c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"prod-loader", "--flag"})
+	c.Assert(cfg.ExternalSchema.Format, qt.Equals, "sql")
+	c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "./prod")
+}
+
+func TestParsePtahExternalSchemaEnvEmptyProgramClearsBase(t *testing.T) {
+	c := qt.New(t)
+
+	// An explicit empty program list in the env block disables the inherited
+	// base loader (presence semantics, like schemas/exclude).
+	cfg, err := projectconfig.ParsePtah([]byte(`external_schema:
+  program: ["base-loader"]
+env:
+  prod:
+    external_schema:
+      program: []
+`), "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.Program, qt.HasLen, 0)
+}
+
+func TestParsePtahExternalSchemaAbsentIsZero(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := projectconfig.ParsePtah([]byte(`url: postgres://app/db`), "ptah.yaml", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.Program, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.Format, qt.Equals, "")
+}
+
+func TestMergeExternalSchema(t *testing.T) {
+	c := qt.New(t)
+
+	base := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program: []string{"base"},
+			Format:  "sql",
+			Env:     []string{"BASE=1"},
+		},
+	}
+	override := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			WorkingDir: "./override",
+		},
+	}
+
+	merged := projectconfig.Merge(base, override)
+
+	// Scalar override left blank keeps the base; working_dir comes from override.
+	c.Assert(merged.ExternalSchema.Program, qt.DeepEquals, []string{"base"})
+	c.Assert(merged.ExternalSchema.Format, qt.Equals, "sql")
+	c.Assert(merged.ExternalSchema.Env, qt.DeepEquals, []string{"BASE=1"})
+	c.Assert(merged.ExternalSchema.WorkingDir, qt.Equals, "./override")
+}

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -19,15 +19,28 @@ type yamlDocument struct {
 }
 
 type yamlSettings struct {
-	URL       string            `yaml:"url"`
-	Dev       string            `yaml:"dev"`
-	Schemas   *[]string         `yaml:"schemas"`
-	Exclude   *[]string         `yaml:"exclude"`
-	Migration yamlMigration     `yaml:"migration"`
-	Lint      yamlLint          `yaml:"lint"`
-	Migrate   yamlMigrateConfig `yaml:"migrate"`
-	OnlineDDL yamlOnlineDDL     `yaml:"online_ddl"`
-	Diff      yamlDiff          `yaml:"diff"`
+	URL            string             `yaml:"url"`
+	Dev            string             `yaml:"dev"`
+	Schemas        *[]string          `yaml:"schemas"`
+	Exclude        *[]string          `yaml:"exclude"`
+	Migration      yamlMigration      `yaml:"migration"`
+	Lint           yamlLint           `yaml:"lint"`
+	Migrate        yamlMigrateConfig  `yaml:"migrate"`
+	OnlineDDL      yamlOnlineDDL      `yaml:"online_ddl"`
+	Diff           yamlDiff           `yaml:"diff"`
+	ExternalSchema yamlExternalSchema `yaml:"external_schema"`
+}
+
+// yamlExternalSchema is the ptah.yaml external_schema block: program is an
+// explicit argv list (first element is the executable, run without a shell),
+// format is the stdout format (default sql), working_dir is the program's
+// working directory, and env holds extra "KEY=VALUE" entries. program and env
+// are pointers so an explicit empty list is distinguishable from an unset value.
+type yamlExternalSchema struct {
+	Program    *[]string `yaml:"program"`
+	Format     string    `yaml:"format"`
+	WorkingDir string    `yaml:"working_dir"`
+	Env        *[]string `yaml:"env"`
 }
 
 // yamlDiff is the ptah.yaml diff policy block. skip lists destructive change
@@ -171,6 +184,18 @@ func (c yamlSettings) projectConfig() (Config, error) {
 			Dialect: c.Lint.Dialect,
 			Latest:  c.Lint.Latest,
 		},
+		ExternalSchema: ExternalSchemaConfig{
+			Format:     c.ExternalSchema.Format,
+			WorkingDir: c.ExternalSchema.WorkingDir,
+		},
+	}
+	if c.ExternalSchema.Program != nil {
+		cfg.ExternalSchema.Program = slices.Clone(*c.ExternalSchema.Program)
+		cfg.presence.externalSchemaProgram = true
+	}
+	if c.ExternalSchema.Env != nil {
+		cfg.ExternalSchema.Env = slices.Clone(*c.ExternalSchema.Env)
+		cfg.presence.externalSchemaEnv = true
 	}
 	if c.Schemas != nil {
 		cfg.Schemas = slices.Clone(*c.Schemas)

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -43,6 +43,7 @@ type ConfigBool struct{ ... }
 type DiffConcurrentIndexConfig struct{ ... }
 type DiffConfig struct{ ... }
 type DiffSkipConfig struct{ ... }
+type ExternalSchemaConfig struct{ ... }
 type FormatConfig struct{ ... }
 type LintConfig struct{ ... }
 type LintRuleConfig struct{ ... }

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -184,3 +184,21 @@ ptah schema render \
 
 This is Ptah's open, local, MIT equivalent of Atlas's `data "external_schema"`
 source and its ORM provider loaders.
+
+### Configure it in `ptah.yaml`
+
+Instead of the flag, declare the loader once in an `external_schema` block. Unlike
+`--schema-cmd` — which is a single string split on whitespace — the config form
+takes an explicit argument list, so arguments may contain spaces:
+
+```yaml
+external_schema:
+  program: ["go", "run", "ariga.io/atlas-provider-gorm", "load", "--path", "./models"]
+  format: sql          # optional, defaults to sql
+  working_dir: ./app   # optional; defaults to the current directory
+  env: ["APP_ENV=dev"] # optional extra KEY=VALUE entries
+```
+
+`ptah migrations generate` reads this block when `--schema-cmd` is not passed
+(the flag always wins). This mirrors Atlas's `data "external_schema"` block: the
+program must print the complete desired schema — currently SQL DDL — to stdout.

--- a/internal/onlineddl/config.go
+++ b/internal/onlineddl/config.go
@@ -74,14 +74,32 @@ type ptahConfig struct {
 }
 
 type ptahSettings struct {
-	URL       string        `yaml:"url"`
-	Dev       string        `yaml:"dev"`
-	Schemas   []string      `yaml:"schemas"`
-	Exclude   []string      `yaml:"exclude"`
-	Migration yamlMigration `yaml:"migration"`
-	Lint      yamlLint      `yaml:"lint"`
-	Migrate   yamlMigrate   `yaml:"migrate"`
-	OnlineDDL yamlOnlineDDL `yaml:"online_ddl"`
+	URL            string             `yaml:"url"`
+	Dev            string             `yaml:"dev"`
+	Schemas        []string           `yaml:"schemas"`
+	Exclude        []string           `yaml:"exclude"`
+	Migration      yamlMigration      `yaml:"migration"`
+	Lint           yamlLint           `yaml:"lint"`
+	Migrate        yamlMigrate        `yaml:"migrate"`
+	OnlineDDL      yamlOnlineDDL      `yaml:"online_ddl"`
+	Diff           yamlDiff           `yaml:"diff"`
+	ExternalSchema yamlExternalSchema `yaml:"external_schema"`
+}
+
+// yamlDiff and yamlExternalSchema mirror the diff and external_schema blocks of
+// ptah.yaml so this package's strict YAML decoder accepts them. The online-DDL
+// loader does not use either block; they are declared only so those keys do not
+// fail KnownFields decoding of the shared ptah.yaml.
+type yamlDiff struct {
+	Skip            []string `yaml:"skip"`
+	ConcurrentIndex *bool    `yaml:"concurrent_index"`
+}
+
+type yamlExternalSchema struct {
+	Program    []string `yaml:"program"`
+	Format     string   `yaml:"format"`
+	WorkingDir string   `yaml:"working_dir"`
+	Env        []string `yaml:"env"`
 }
 
 type yamlMigration struct {

--- a/internal/onlineddl/config_test.go
+++ b/internal/onlineddl/config_test.go
@@ -64,6 +64,46 @@ online_ddl:
 	c.Assert(cfg.Enabled(), qt.IsTrue)
 }
 
+func TestLoadConfig_AllowsExternalSchemaBlock(t *testing.T) {
+	c := qt.New(t)
+
+	// The online-DDL loader parses the whole ptah.yaml strictly; an
+	// external_schema block it does not use must not fail decoding.
+	path := writeConfig(t, `url: postgres://app/db
+external_schema:
+  program: ["go", "run", "./loader"]
+  format: sql
+  working_dir: ./project
+  env: ["FOO=bar"]
+online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+`)
+	cfg, err := onlineddl.LoadConfig(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
+}
+
+func TestLoadConfig_AllowsDiffBlock(t *testing.T) {
+	c := qt.New(t)
+
+	// A diff block (a shipped ptah.yaml feature) must not fail this package's
+	// strict decoding of the shared ptah.yaml.
+	path := writeConfig(t, `url: postgres://app/db
+diff:
+  skip: [drop_table]
+  concurrent_index: true
+online_ddl:
+  tool: ghost
+  threshold_rows: 1000000
+`)
+	cfg, err := onlineddl.LoadConfig(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Tool, qt.Equals, onlineddl.ToolGhost)
+}
+
 func TestLoadConfigForEnv_MergesNamedEnvironment(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

Completes #669's MVP acceptance criterion *"the external source is configurable via a `ptah.yaml` env block and via a CLI flag."* #704/#705 delivered the `--schema-cmd` flag everywhere; this adds the config form and honors it in **`ptah migrations generate`**:

```yaml
external_schema:
  program: ["go", "run", "ariga.io/atlas-provider-gorm", "load", "--path", "./models"]
  format: sql          # optional, defaults to sql
  working_dir: ./app   # optional; defaults to the current directory
  env: ["APP_ENV=dev"] # optional extra KEY=VALUE entries
```

This is Ptah's open, local, MIT equivalent of Atlas's `data "external_schema"` block (`program` as an argv list, `working_dir`, full-DDL-to-stdout contract). Unlike `--schema-cmd` — a single string split on whitespace — the config form takes an **explicit argument list**, so arguments may contain spaces. `--schema-cmd` still wins when set.

## Changes

- **`config/projectconfig`** — new `ExternalSchemaConfig` IR type + `Config.ExternalSchema`, with YAML parsing (`external_schema` block; `program`/`env` are presence-tracked pointers) and per-env `Merge` semantics matching `schemas`/`exclude`: an explicit empty `program: []` in an env block clears an inherited base loader.
- **`schemasource.CommandsFromConfig`** — builds a command from the explicit argv list, used **verbatim** (no whitespace splitting), returning nil when `program` is empty.
- **`ptah migrations generate`** — loads config, then resolves the desired schema from `--schema-cmd`, falling back to the `external_schema` block when the flag is unset.
- **`internal/onlineddl` strict decoder** — declares `external_schema` **and** the pre-existing `diff` block in its own `KnownFields(true)` `ptahSettings`. There are two independent strict YAML decoders over the same `ptah.yaml`; without this, `ptah migrations up`/`down` reject any config that uses these blocks. **This also fixes a pre-existing latent bug**: a `ptah.yaml` with a `diff:` block (a shipped feature) already broke `migrations up`/`down`.

## Testing

- Config unit tests: parse `external_schema`, per-env override (program replaced, base scalars survive), explicit-empty clear path, `Merge` semantics; `CommandsFromConfig` verbatim-args + nil-when-empty; onlineddl decoder accepts `external_schema` and `diff` blocks.
- Full unit suite, `go vet`, `golangci-lint` (0 issues), test-style, and public-API snapshot (regenerated for the new type) all pass.
- Verified end-to-end against a live PostgreSQL: `ptah migrations generate --config ptah.yaml` reads `external_schema.program`, runs the loader, and generates the expected migration; `migrations up` no longer errors on the new block.

## Follow-ups

- Honor `external_schema` config in `compare`, `migrate plan`, and `drift` too — those commands don't currently load `ptah.yaml` at all, so that's a broader "make them config-aware" change (they already accept `--schema-cmd`).
- `atlas.hcl` `data "external_schema"` parsing, and HCL/YAML command-output formats.