### PR TITLE
Make compare, migrate plan, and drift config-aware (#669)

### DIFF
--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
-	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -64,6 +63,8 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.schemaFormat, schemaFormatFlag, "sql", "Format of the --schema-cmd output: sql")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Database URL (required). Example: postgres://localhost:5432/dbname")
 	flags.BoolVar(&opts.exitOnDiff, exitCodeFlag, false, "Exit with 1 when the schema diff is non-empty")
+	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
+	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 }
@@ -71,17 +72,28 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 func compareCommand(cmd *cobra.Command, opts *options) error {
 	out := cmd.OutOrStdout()
 
-	if opts.dbURL == "" {
+	configPath, err := cmd.Flags().GetString(dbcli.ConfigFlagName)
+	if err != nil {
+		return err
+	}
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
+	if err != nil {
+		return err
+	}
+	dbURL := dbcli.EffectiveString(cmd, dbURLFlag, opts.dbURL, projectCfg.DatabaseURL)
+	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemas, dbcli.JoinSchemas(projectCfg.Schemas))
+
+	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
 
 	loadOpts := schemaload.Options{
 		RootDirs:    opts.rootDirs,
 		SchemaFiles: opts.schemaFiles,
-		Commands:    schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
+		Commands:    dbcli.ExternalSchemaCommands(opts.schemaCmd, opts.schemaFormat, projectCfg),
 	}
 
-	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", loadOpts.Sources(), dbschema.FormatDatabaseURL(opts.dbURL))
+	fmt.Fprintf(out, "Comparing schema from %s with database %s\n", loadOpts.Sources(), dbschema.FormatDatabaseURL(dbURL))
 	fmt.Fprintln(out, "=== SCHEMA COMPARISON ===")
 	fmt.Fprintln(out)
 
@@ -99,14 +111,14 @@ func compareCommand(cmd *cobra.Command, opts *options) error {
 	}
 
 	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
-	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.dbURL)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
 	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	schemas := dbcli.ParseSchemas(opts.schemas)
+	schemas := dbcli.ParseSchemas(schemasValue)
 	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading database schema: %w", err)

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaops"
-	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/migration/safety"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -43,6 +42,7 @@ func NewDriftCommand() *cobra.Command {
 	var useExitCode bool
 	var connectTimeoutRaw string
 	var schemasRaw string
+	var configPath string
 
 	cmd := &cobra.Command{
 		Use:           "drift",
@@ -62,6 +62,7 @@ func NewDriftCommand() *cobra.Command {
 				useExitCode:       useExitCode,
 				connectTimeoutRaw: connectTimeoutRaw,
 				schemasRaw:        schemasRaw,
+				configPath:        configPath,
 			})
 		},
 	}
@@ -82,6 +83,8 @@ func NewDriftCommand() *cobra.Command {
 		dbcli.DefaultConnectTimeout.String(),
 		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
 	)
+	cmd.Flags().StringVar(&configPath, dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
+	cmd.Flags().String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
@@ -99,6 +102,7 @@ type runOptions struct {
 	useExitCode       bool
 	connectTimeoutRaw string
 	schemasRaw        string
+	configPath        string
 }
 
 type driftReport struct {
@@ -116,14 +120,22 @@ type driftReport struct {
 }
 
 func runDrift(cmd *cobra.Command, opts runOptions) error {
-	if opts.dbURL == "" {
-		return writeError(cmd.ErrOrStderr(), opts.format, "database URL is required")
-	}
 	if err := validateFormat(opts.format); err != nil {
 		return writeError(cmd.ErrOrStderr(), formatText, err.Error())
 	}
 	if err := validateSeverity(opts.severity); err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, opts.configPath)
+	if err != nil {
+		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
+	}
+	dbURL := dbcli.EffectiveString(cmd, "db-url", opts.dbURL, projectCfg.DatabaseURL)
+	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemasRaw, dbcli.JoinSchemas(projectCfg.Schemas))
+
+	if dbURL == "" {
+		return writeError(cmd.ErrOrStderr(), opts.format, "database URL is required")
 	}
 
 	ignoredTables, err := parseIgnoredTables(opts.ignored)
@@ -134,13 +146,13 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
 	}
-	schemas := dbcli.ParseSchemas(opts.schemasRaw)
+	schemas := dbcli.ParseSchemas(schemasValue)
 
 	result, err := schemaops.Compare(cmd.Context(), schemaops.CompareOptions{
 		RootDirs:       opts.rootDirs,
 		SchemaFiles:    opts.schemaFiles,
-		Commands:       schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
-		DatabaseURL:    opts.dbURL,
+		Commands:       dbcli.ExternalSchemaCommands(opts.schemaCmd, opts.schemaFormat, projectCfg),
+		DatabaseURL:    dbURL,
 		ConnectTimeout: connectTimeout,
 		IgnoredTables:  ignoredTables,
 		Schemas:        schemas,

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/config/projectconfig"
 )
 
@@ -72,6 +73,22 @@ func EffectiveString(cmd *cobra.Command, flagName, flagValue, configValue string
 		return flagValue
 	}
 	return configValue
+}
+
+// ExternalSchemaCommands resolves the external-command schema source for a
+// command, preferring the --schema-cmd flag value and falling back to the
+// ptah.yaml external_schema block when the flag is empty. It returns nil when
+// neither is configured.
+func ExternalSchemaCommands(schemaCmd, schemaFormat string, cfg projectconfig.Config) []schemasource.Command {
+	if commands := schemasource.CommandsFromCLI(schemaCmd, schemaFormat, ""); commands != nil {
+		return commands
+	}
+	return schemasource.CommandsFromConfig(
+		cfg.ExternalSchema.Program,
+		cfg.ExternalSchema.Format,
+		cfg.ExternalSchema.WorkingDir,
+		cfg.ExternalSchema.Env,
+	)
 }
 
 func stringFlag(cmd *cobra.Command, name string) (string, error) {

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -156,3 +156,39 @@ func TestLoadProjectConfigReadsNamedPtahEnvRuntimeDefaults(t *testing.T) {
 	c.Assert(cfg.Lint.Dialect, qt.Equals, "postgres")
 	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{"MF103"})
 }
+
+func TestExternalSchemaCommandsPrefersFlag(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{Program: []string{"config-loader"}},
+	}
+	commands := dbcli.ExternalSchemaCommands("go run ./flag-loader", "sql", cfg)
+
+	c.Assert(commands, qt.HasLen, 1)
+	c.Assert(commands[0].Args, qt.DeepEquals, []string{"go", "run", "./flag-loader"})
+}
+
+func TestExternalSchemaCommandsFallsBackToConfig(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program:    []string{"go", "run", "./config-loader"},
+			WorkingDir: "./app",
+			Env:        []string{"K=V"},
+		},
+	}
+	commands := dbcli.ExternalSchemaCommands("", "sql", cfg)
+
+	c.Assert(commands, qt.HasLen, 1)
+	c.Assert(commands[0].Args, qt.DeepEquals, []string{"go", "run", "./config-loader"})
+	c.Assert(commands[0].Dir, qt.Equals, "./app")
+	c.Assert(commands[0].Env, qt.DeepEquals, []string{"K=V"})
+}
+
+func TestExternalSchemaCommandsNilWhenNeitherSet(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(dbcli.ExternalSchemaCommands("", "sql", projectconfig.Config{}), qt.IsNil)
+}

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
-	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/generator"
@@ -105,21 +104,10 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Resolve the external schema command from the --schema-cmd flag, falling
-	// back to the ptah.yaml external_schema block when the flag is unset.
-	commands := schemasource.CommandsFromCLI(schemaCmd, schemaFormat, "")
-	if commands == nil {
-		commands = schemasource.CommandsFromConfig(
-			projectCfg.ExternalSchema.Program,
-			projectCfg.ExternalSchema.Format,
-			projectCfg.ExternalSchema.WorkingDir,
-			projectCfg.ExternalSchema.Env,
-		)
-	}
 	generated, err := schemaload.LoadContext(cmd.Context(), schemaload.Options{
 		RootDirs:    rootDirs,
 		SchemaFiles: schemaFiles,
-		Commands:    commands,
+		Commands:    dbcli.ExternalSchemaCommands(schemaCmd, schemaFormat, projectCfg),
 	})
 	if err != nil {
 		return err

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
-	"github.com/stokaro/ptah/cmd/internal/schemasource"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
@@ -72,6 +71,8 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.BoolVar(&opts.checkDestructive, checkDestructiveFlag, false, "Fail when generated migration SQL contains destructive statements")
 	flags.BoolVar(&opts.allowDestructive, allowDestructiveFlag, false, "Allow destructive statements when --check-destructive is set")
 	flags.StringVar(&opts.reportFormat, reportFormatFlag, "text", "Safety report format: text, html, or json")
+	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
+	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 }
@@ -80,7 +81,18 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	out := cmd.OutOrStdout()
 	reportFormat := strings.ToLower(strings.TrimSpace(opts.reportFormat))
 
-	if opts.dbURL == "" {
+	configPath, err := cmd.Flags().GetString(dbcli.ConfigFlagName)
+	if err != nil {
+		return err
+	}
+	projectCfg, err := dbcli.LoadProjectConfig(cmd, configPath)
+	if err != nil {
+		return err
+	}
+	dbURL := dbcli.EffectiveString(cmd, dbURLFlag, opts.dbURL, projectCfg.DatabaseURL)
+	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemas, dbcli.JoinSchemas(projectCfg.Schemas))
+
+	if dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
 	if reportFormat != "text" && reportFormat != "html" && reportFormat != "json" {
@@ -89,12 +101,12 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	loadOpts := schemaload.Options{
 		RootDirs:    opts.rootDirs,
 		SchemaFiles: opts.schemaFiles,
-		Commands:    schemasource.CommandsFromCLI(opts.schemaCmd, opts.schemaFormat, ""),
+		Commands:    dbcli.ExternalSchemaCommands(opts.schemaCmd, opts.schemaFormat, projectCfg),
 	}
 	rootsDisplay := loadOpts.Sources()
 
 	if reportFormat == "text" {
-		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootsDisplay, dbschema.FormatDatabaseURL(opts.dbURL))
+		fmt.Fprintf(out, "Generating migration from %s to database %s\n", rootsDisplay, dbschema.FormatDatabaseURL(dbURL))
 		fmt.Fprintln(out, "=== GENERATE MIGRATION SQL ===")
 		fmt.Fprintln(out)
 	}
@@ -113,14 +125,14 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	}
 
 	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
-	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.dbURL)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, dbURL)
 	cancelConnect()
 	if err != nil {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	schemas := dbcli.ParseSchemas(opts.schemas)
+	schemas := dbcli.ParseSchemas(schemasValue)
 	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
 	if err != nil {
 		return fmt.Errorf("error reading database schema: %w", err)
@@ -171,7 +183,7 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	fmt.Fprintln(out, "-- Migration generated from schema differences")
 	fmt.Fprintf(out, "-- Generated on: %s\n", "now") // You could add actual timestamp
 	fmt.Fprintf(out, "-- Source: %s\n", rootsDisplay)
-	fmt.Fprintf(out, "-- Target: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
+	fmt.Fprintf(out, "-- Target: %s\n", dbschema.FormatDatabaseURL(dbURL))
 	fmt.Fprintln(out)
 
 	fmt.Fprint(out, migrationSQL)

--- a/docs/site/src/content/docs/workflows/schema-files.md
+++ b/docs/site/src/content/docs/workflows/schema-files.md
@@ -199,6 +199,10 @@ external_schema:
   env: ["APP_ENV=dev"] # optional extra KEY=VALUE entries
 ```
 
-`ptah migrations generate` reads this block when `--schema-cmd` is not passed
-(the flag always wins). This mirrors Atlas's `data "external_schema"` block: the
-program must print the complete desired schema — currently SQL DDL — to stdout.
+`ptah schema compare`, `ptah schema drift`, `ptah migrations plan`, and
+`ptah migrations generate` read this block when `--schema-cmd` is not passed (the
+flag always wins). Those commands also read `url` (the database) and `schemas`
+from `ptah.yaml`, and honor `--env` to select an env block — so a drift check can
+be as short as `ptah schema drift --config ptah.yaml`. This mirrors Atlas's
+`data "external_schema"` block: the program must print the complete desired
+schema — currently SQL DDL — to stdout.


### PR DESCRIPTION
## Summary

Completes #669 Phase 2. `ptah schema compare`, `ptah migrations plan`, and `ptah schema drift` now load `ptah.yaml`, so the `external_schema` block — plus the database URL and schemas — can be configured once instead of repeated on every invocation. Previously only `migrate generate` read `ptah.yaml`; the `--schema-cmd` flag worked everywhere but the `external_schema` config form did not.

A drift check can now be as short as:

```bash
ptah schema drift --config ptah.yaml
```

with `url`, `schemas`, and `external_schema` all resolved from the file.

## Changes

- **`dbcli.ExternalSchemaCommands(schemaCmd, schemaFormat, cfg)`** — new shared helper centralizing the flag-or-config precedence: the `--schema-cmd` flag wins when set, otherwise the `ptah.yaml` `external_schema` block is used (explicit argv list, verbatim). `migrate generate` is refactored onto it (behavior identical).
- **`compare`, `migrations plan`, `drift`** — each gains `--config` and `--env` flags, calls `dbcli.LoadProjectConfig`, and resolves `db-url`, `schemas`, and the external command from `ptah.yaml` with the flag winning over config (`dbcli.EffectiveString`), matching the established `migrate generate` pattern.
- Docs updated to note the config block is honored by compare/drift/plan/generate.

## Behavior note

These three commands now read `ptah.yaml`/`atlas.hcl` from the working directory (they ignored it before). Precedence is **CLI flag > `PTAH_*` env > `ptah.yaml` > default**. A **multi-env** config requires `--env` to select a block — the same contract `migrate generate` already enforces, so this aligns the four commands rather than adding new divergence.

## Testing

- New `dbcli.ExternalSchemaCommands` unit tests (flag-wins / config-fallback / nil-when-neither).
- Full unit suite, `go vet`, `golangci-lint` (0 issues, incl. gosec), test-style, and public-API-snapshot checks pass. No-config invocations remain byte-identical (missing config file → empty config → flag values unchanged); existing compare/drift/plan tests pass unchanged.
- Verified end-to-end against a live PostgreSQL: `ptah schema drift --config ptah.yaml` (no `--db-url`) reads url + schemas + external_schema from the file, runs the loader, and reports drift.

## Follow-ups

`atlas.hcl` `data "external_schema"` parsing and HCL/YAML command-output formats remain, per #669's phasing.