### PR TITLE
Preserve PRIMARY KEY and FOREIGN KEY from SQL schema sources (#708)

### DIFF
--- a/internal/convert/toschema/sql_roundtrip_test.go
+++ b/internal/convert/toschema/sql_roundtrip_test.go
@@ -1,0 +1,96 @@
+package toschema_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/internal/convert/toschema"
+	"github.com/stokaro/ptah/internal/parser"
+)
+
+// These tests exercise the SQL -> goschema.Database path used by the
+// external_schema source and SQL --schema-file, asserting that table-level
+// PRIMARY KEY and ALTER TABLE ADD CONSTRAINT FOREIGN KEY survive (see #708).
+
+func parseToDatabase(c *qt.C, sql string) goschema.Database {
+	statements, err := parser.NewParser(sql).Parse()
+	c.Assert(err, qt.IsNil)
+	return toschema.ToDatabase(statements)
+}
+
+func findTable(db goschema.Database, name string) (goschema.Table, bool) {
+	for _, t := range db.Tables {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return goschema.Table{}, false
+}
+
+func findConstraint(db goschema.Database, typ, table string) (goschema.Constraint, bool) {
+	for _, con := range db.Constraints {
+		if con.Type == typ && con.Table == table {
+			return con, true
+		}
+	}
+	return goschema.Constraint{}, false
+}
+
+func TestToDatabase_TableLevelPrimaryKeyCaptured(t *testing.T) {
+	c := qt.New(t)
+
+	db := parseToDatabase(c, `CREATE TABLE users (id bigserial, name varchar(255), PRIMARY KEY (id));`)
+
+	users, ok := findTable(db, "users")
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(users.PrimaryKey, qt.DeepEquals, []string{"id"})
+}
+
+func TestToDatabase_AlterTableForeignKeyCaptured(t *testing.T) {
+	c := qt.New(t)
+
+	db := parseToDatabase(c, `CREATE TABLE users (id bigserial, PRIMARY KEY (id));
+CREATE TABLE pets (id bigserial, user_id bigint, PRIMARY KEY (id));
+ALTER TABLE pets ADD CONSTRAINT fk_pets_user FOREIGN KEY (user_id) REFERENCES users(id);`)
+
+	fk, ok := findConstraint(db, "FOREIGN KEY", "pets")
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(fk.Name, qt.Equals, "fk_pets_user")
+	c.Assert(fk.Columns, qt.DeepEquals, []string{"user_id"})
+	c.Assert(fk.ForeignTable, qt.Equals, "users")
+	c.Assert(fk.ForeignColumn, qt.Equals, "id")
+}
+
+func TestToDatabase_TableLevelForeignKeyInCreateCaptured(t *testing.T) {
+	c := qt.New(t)
+
+	db := parseToDatabase(c, `CREATE TABLE pets (id bigserial, user_id bigint, FOREIGN KEY (user_id) REFERENCES users(id));`)
+
+	fk, ok := findConstraint(db, "FOREIGN KEY", "pets")
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(fk.ForeignTable, qt.Equals, "users")
+	c.Assert(fk.Columns, qt.DeepEquals, []string{"user_id"})
+}
+
+func TestToDatabase_SQLRoundTripRendersPrimaryKeyAndForeignKey(t *testing.T) {
+	c := qt.New(t)
+
+	// End-to-end: SQL (as an ORM exporter emits it) -> goschema -> render must
+	// preserve a single-column table-level PK (inline) and an ALTER TABLE foreign
+	// key (#708).
+	db := parseToDatabase(c, `CREATE TABLE users (id bigserial, name varchar(255), PRIMARY KEY (id));
+CREATE TABLE pets (id bigserial, user_id bigint, PRIMARY KEY (id));
+ALTER TABLE pets ADD CONSTRAINT fk_pets_user FOREIGN KEY (user_id) REFERENCES users(id);`)
+	goschema.Finalize(&db)
+
+	statements, err := renderer.GetOrderedCreateStatements(&db, "postgres")
+	c.Assert(err, qt.IsNil)
+	rendered := strings.Join(statements, "\n")
+
+	c.Assert(rendered, qt.Contains, `"id" bigserial PRIMARY KEY`)
+	c.Assert(rendered, qt.Contains, `ALTER TABLE "pets" ADD CONSTRAINT "fk_pets_user" FOREIGN KEY ("user_id") REFERENCES "users"("id")`)
+}

--- a/internal/convert/toschema/toschema.go
+++ b/internal/convert/toschema/toschema.go
@@ -594,10 +594,16 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 			database.Tables = append(database.Tables, tableSchema)
 
 			// Extract fields from table columns
+			fieldsStart := len(database.Fields)
 			for _, column := range node.Columns {
 				fieldSchema := ToField(column, tableSchema.StructName, "")
 				database.Fields = append(database.Fields, fieldSchema)
 			}
+			// A single-column table-level PRIMARY KEY (col) renders inline on the
+			// column, matching how it is expressed as an inline primary key and how
+			// the HCL loader treats it; a composite key stays on Table.PrimaryKey and
+			// renders as a table constraint.
+			markPrimaryFields(database.Fields[fieldsStart:], tableSchema.PrimaryKey)
 			for _, constraint := range node.Constraints {
 				constraintSchema, ok := ToConstraint(constraint, tableSchema.StructName, tableSchema.Name)
 				if ok {
@@ -609,10 +615,42 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 			// Convert index definitions
 			indexSchema := ToIndex(node)
 			database.Indexes = append(database.Indexes, indexSchema)
+
+		case *ast.AlterTableNode:
+			// Capture constraints added by ALTER TABLE ... ADD CONSTRAINT, such
+			// as the foreign keys ORM schema exporters emit as separate
+			// statements after the CREATE TABLEs.
+			structName := generateStructName(node.Name)
+			for _, op := range node.Operations {
+				add, ok := op.(*ast.AddConstraintOperation)
+				if !ok || add.Constraint == nil {
+					continue
+				}
+				constraintSchema, ok := ToConstraint(add.Constraint, structName, node.Name)
+				if ok {
+					database.Constraints = append(database.Constraints, constraintSchema)
+				}
+			}
 		}
 	}
 
 	return database
+}
+
+// markPrimaryFields marks the field backing a single-column table-level primary
+// key as the column primary key, so it renders inline. Composite keys (len != 1)
+// are left on Table.PrimaryKey and render as a table constraint.
+func markPrimaryFields(fields []goschema.Field, columns []string) {
+	if len(columns) != 1 {
+		return
+	}
+	for i := range fields {
+		if fields[i].Name == columns[0] {
+			fields[i].Primary = true
+			fields[i].Nullable = false
+			return
+		}
+	}
 }
 
 func ToConstraint(constraint *ast.ConstraintNode, structName, tableName string) (goschema.Constraint, bool) {
@@ -630,6 +668,22 @@ func ToConstraint(constraint *ast.ConstraintNode, structName, tableName string) 
 			),
 			NullsDistinct: cloneBoolPtr(constraint.NullsDistinct),
 		}, true
+	case ast.ForeignKeyConstraint:
+		fk := goschema.Constraint{
+			StructName: structName,
+			Name:       constraint.Name,
+			Type:       "FOREIGN KEY",
+			Table:      tableName,
+			Columns:    append([]string(nil), constraint.Columns...),
+		}
+		if ref := constraint.Reference; ref != nil {
+			fk.ForeignTable = ref.Table
+			fk.ForeignColumn = ref.Column
+			fk.ForeignColumns = append([]string(nil), ref.Columns...)
+			fk.OnDelete = ref.OnDelete
+			fk.OnUpdate = ref.OnUpdate
+		}
+		return fk, true
 	default:
 		return goschema.Constraint{}, false
 	}

--- a/migration/schemadiff/composite_primary_key_test.go
+++ b/migration/schemadiff/composite_primary_key_test.go
@@ -90,6 +90,81 @@ func TestCompareWithDialect_BlankTablePrimaryKeyDoesNotSynthesizeConstraint(t *t
 	c.Assert(diff.ConstraintsAddedWithTables, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
 }
 
+func TestCompareWithDialect_SingleColumnFieldLevelPrimaryKeyIsNotDuplicated(t *testing.T) {
+	c := qt.New(t)
+
+	// A single-column table-level PRIMARY KEY that is also carried as a column
+	// primary key (Field.Primary) — the shape the SQL and HCL loaders produce —
+	// must be compared field-to-field, not synthesized as a separate table
+	// constraint. Otherwise an already-existing primary key is reported as a
+	// spurious ADD PRIMARY KEY (#708).
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "Pet",
+			Name:       "pets",
+			PrimaryKey: []string{"id"},
+		}},
+		Fields: []goschema.Field{
+			{StructName: "Pet", Name: "id", Type: "BIGINT", Primary: true, Nullable: false},
+			{StructName: "Pet", Name: "name", Type: "TEXT", Nullable: false},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "pets",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "name", DataType: "text", IsNullable: "NO"},
+			},
+		}},
+		Constraints: []types.DBConstraint{{
+			Name:        "pets_pkey",
+			TableName:   "pets",
+			Type:        "PRIMARY KEY",
+			ColumnNames: []string{"id"},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+	c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+}
+
+func TestCompareWithDialect_SingleColumnFieldLevelPrimaryKeyMissingFromDBIsDetected(t *testing.T) {
+	c := qt.New(t)
+
+	// The mirror of the previous test: when the database is missing the primary
+	// key, comparison must still detect it (via the field-level path, since the
+	// table-level constraint is not synthesized for a field-level PK). It must
+	// not be silently dropped (#708).
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "Pet",
+			Name:       "pets",
+			PrimaryKey: []string{"id"},
+		}},
+		Fields: []goschema.Field{
+			{StructName: "Pet", Name: "id", Type: "BIGINT", Primary: true, Nullable: false},
+			{StructName: "Pet", Name: "name", Type: "TEXT", Nullable: false},
+		},
+	}
+	database := &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "pets",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO"},
+				{Name: "name", DataType: "text", IsNullable: "NO"},
+			},
+		}},
+	}
+
+	diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+	c.Assert(diff.HasChanges(), qt.IsTrue, qt.Commentf("diff: %#v", diff))
+	c.Assert(diff.ConstraintsAdded, qt.Contains, "pets_pkey", qt.Commentf("diff: %#v", diff))
+}
+
 func compositePrimaryKeySchema() *goschema.Database {
 	return &goschema.Database{
 		Tables: []goschema.Table{{

--- a/migration/schemadiff/internal/compare/field_constraints.go
+++ b/migration/schemadiff/internal/compare/field_constraints.go
@@ -18,9 +18,27 @@ import (
 // foreignKeyConstraintChanged (issue #189). FKs without a synthesized
 // counterpart (e.g. a column that is not yet in the database, which never gets
 // synthesized) keep the previous filter-out behavior.
+// buildTablePrimaryKeyColumnSets maps each generated table's qualified name to
+// the set of columns in its table-level primary key.
+func buildTablePrimaryKeyColumnSets(generated *goschema.Database) map[string]map[string]struct{} {
+	result := make(map[string]map[string]struct{}, len(generated.Tables))
+	for _, table := range generated.Tables {
+		columns := make(map[string]struct{})
+		for _, column := range tablePrimaryKeyColumns(table) {
+			columns[column] = struct{}{}
+		}
+		result[table.QualifiedName()] = columns
+	}
+	return result
+}
+
 func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema.Database, synthesizedFKKeys map[string]struct{}) bool {
 	// Create a map of table.column -> field for quick lookup
 	fieldMap := make(map[string]goschema.Field)
+	// tablePKColumns maps a qualified table name to the set of columns in its
+	// table-level primary key (Table.PrimaryKey), which are synthesized as a
+	// table-level PRIMARY KEY constraint.
+	tablePKColumns := buildTablePrimaryKeyColumnSets(generated)
 	for _, field := range generated.Fields {
 		// Get table name for this field
 		tableName := field.StructName // default to struct name
@@ -43,10 +61,18 @@ func isFieldLevelConstraint(dbConstraint types.DBConstraint, generated *goschema
 			return true
 		}
 	case "PRIMARY KEY":
-		// Check if there's a field with primary=true for this column
-		key := dbConstraint.QualifiedTableName() + "." + getConstraintColumn(dbConstraint)
+		// Treat as field-level only when the column is a column-level primary key
+		// that is NOT also part of the table's PrimaryKey. A single-column
+		// table-level PK is normalized to carry both Field.Primary and
+		// Table.PrimaryKey; it is synthesized as a table-level constraint, so the
+		// database constraint must stay in the comparison to match/add correctly
+		// (#708).
+		column := getConstraintColumn(dbConstraint)
+		key := dbConstraint.QualifiedTableName() + "." + column
 		if field, exists := fieldMap[key]; exists && field.Primary {
-			return true
+			if _, synthesized := tablePKColumns[dbConstraint.QualifiedTableName()][column]; !synthesized {
+				return true
+			}
 		}
 	case "UNIQUE":
 		// Check if there's a field with unique=true for this column


### PR DESCRIPTION
## Summary

Closes #708. The SQL → `goschema` path (`internal/convert/toschema.ToDatabase`, used by the `external_schema` source and SQL `--schema-file`) dropped two constraint forms that ORM schema exporters emit, so a schema loaded from an ORM lost its primary and foreign keys — producing wrong diffs/migrations.

Discovered by validating the `external_schema` source end-to-end against the flagship ORM provider, `ariga.io/atlas-provider-gorm`: it emits `PRIMARY KEY ("id")` inside `CREATE TABLE` and foreign keys as separate `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` statements — both of which Ptah was silently discarding.

## Changes

- **Foreign key via `ALTER TABLE`** — `ToDatabase` now has an `*ast.AlterTableNode` case that converts `ADD CONSTRAINT ... FOREIGN KEY` (the parser already produced the node; it was just never consumed), and `ToConstraint` gains a `FOREIGN KEY` case (it previously handled only `UNIQUE`). Table-level FKs written inside `CREATE TABLE` are captured by the same `ToConstraint` case. The FK is now in the IR (so compare/migrate see it) and renders.
- **Single-column table-level `PRIMARY KEY (col)`** — normalized to a column primary key (`Field.Primary`), matching the HCL loader's convention, so it renders inline (`id ... PRIMARY KEY`) instead of being dropped from render output. Composite keys stay on `Table.PrimaryKey` and render as a table constraint.
- **Comparator symmetry** — a single-column PK now carries both `Field.Primary` and `Table.PrimaryKey`. `isFieldLevelConstraint` now filters a database primary key out of the comparison only when the column is a column-level primary key that is **not** also part of the table's primary key. Without this, the synthesized table-level PK (from `Table.PrimaryKey`) and the database PK compared asymmetrically, reporting a **spurious `ADD PRIMARY KEY`** on tables that already have one. This also fixes the same **pre-existing latent asymmetry for the HCL loader**.

## Testing

- New `toschema` round-trip tests: table-level PK captured; `ALTER TABLE` FK captured; table-level-FK-in-`CREATE TABLE` captured; and an end-to-end SQL → `goschema` → render test asserting the inline PK and the `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` both survive.
- New `schemadiff` regression tests covering the full PK matrix: a single-column field-level PK that **exists** in the DB produces **no** spurious `ADD PRIMARY KEY`, and one **missing** from the DB is still added. (Verified the first test fails without the comparator fix.)
- Full unit suite, `go vet`, `golangci-lint` (0 issues), test-style, and public-API-snapshot checks all pass. Verified end-to-end against live `atlas-provider-gorm` output: `ptah schema render --schema-cmd "go run ."` renders both tables' inline PKs and the foreign key.

This makes the `external_schema` / SQL `--schema-file` sources usable with real ORM output — the payoff for #669's external-source work.