### PR TITLE
Align Atlas-compatible error exit codes

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -41,7 +41,10 @@ type atlasPositionalArg struct {
 	nativeName string
 }
 
-const atlasDirFormatDefault = "atlas"
+const (
+	atlasDirFormatDefault = "atlas"
+	atlasErrorExitCode    = 1
+)
 
 var unsupportedAtlasDirFormats = []string{
 	"dbmate",
@@ -53,11 +56,13 @@ var unsupportedAtlasDirFormats = []string{
 
 // NewAtlasCommand returns the Atlas command namespace.
 func NewAtlasCommand() *cobra.Command {
-	return newAtlasCommand("atlas [command]", "Atlas OSS command namespace", `Atlas OSS command namespace.
+	cmd := newAtlasCommand("atlas [command]", "Atlas OSS command namespace", `Atlas OSS command namespace.
 
 These commands reserve the Atlas OSS CLI surface under Ptah. Commands that have
 an existing Ptah equivalent forward to that native command while keeping the
 native Ptah command tree separate for future redesign.`)
+	cmdutil.SetErrorCodePolicy(cmd, atlasErrorExitCode)
+	return cmd
 }
 
 // NewCompatCommand returns an Atlas-compatible root command.
@@ -72,6 +77,7 @@ This executable exposes Atlas-style commands at process root for scripts that
 expect commands such as migrate apply or schema inspect. Runtime behavior is the
 same compatibility layer used by ptah atlas <command> ...`)
 	cmdflags.InstallEnvBinding("PTAH", cmd)
+	cmdutil.SetErrorCodePolicy(cmd, atlasErrorExitCode)
 	return cmd
 }
 

--- a/cmd/atlas/atlas_lint_devurl_test.go
+++ b/cmd/atlas/atlas_lint_devurl_test.go
@@ -54,9 +54,9 @@ func TestNewAtlasCommand_MigrateLintRejectsDockerDevURL(t *testing.T) {
 		"--dev-url", "docker://postgres/16/dev",
 	})
 
-	err := cmd.Execute()
+	err := executeAtlasTestCommand(cmd)
 
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(out.String(), qt.Contains, "docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for migration SQL replay")
 }
 

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -16,6 +16,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/dbschema"
@@ -197,10 +198,10 @@ func TestNewCompatCommand_UnknownNestedCommandFails(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"migrate", "aplly"})
 
-	err := cmd.Execute()
+	err := executeAtlasCommandForTest(cmd)
 
 	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["aplly"\]`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(out.String(), qt.Contains, `error: unexpected positional arguments ["aplly"]`)
 }
 
@@ -212,10 +213,10 @@ func TestNewAtlasCommand_UnknownNestedCommandFails(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"migrate", "aplly"})
 
-	err := cmd.Execute()
+	err := executeAtlasCommandForTest(cmd)
 
 	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["aplly"\]`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(out.String(), qt.Contains, `error: unexpected positional arguments ["aplly"]`)
 }
 
@@ -230,10 +231,10 @@ func TestNewAtlasCommand_UnknownTopLevelCommandFails(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"definitely-not-a-command"})
 
-	err := cmd.Execute()
+	err := executeAtlasCommandForTest(cmd)
 
 	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["definitely-not-a-command"\]`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 }
 
 func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
@@ -244,10 +245,10 @@ func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"definitely-not-a-command"})
 
-	err := cmd.Execute()
+	err := executeAtlasCommandForTest(cmd)
 
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 }
 
 func TestNewAtlasCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
@@ -4553,6 +4554,11 @@ func TestNewAtlasCommand_HelpAdvertisesGroupedNativeEquivalents(t *testing.T) {
 func writeAtlasTestFile(c *qt.C, dir, name, content string) {
 	c.Helper()
 	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+}
+
+func executeAtlasCommandForTest(cmd *cobra.Command) error {
+	executed, err := cmd.ExecuteC()
+	return cmdutil.NormalizeCommandError(executed, err, 2)
 }
 
 func readAtlasTestFile(c *qt.C, dir, name string) string {

--- a/cmd/atlas/atlas_usage_test.go
+++ b/cmd/atlas/atlas_usage_test.go
@@ -2,12 +2,15 @@ package atlas_test
 
 import (
 	"bytes"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
 func TestNewAtlasCommand_UsageMatchesAtlasCE(t *testing.T) {
@@ -125,11 +128,32 @@ func TestNewCompatCommandNamedAtlas_UsageMatchesAtlasCE(t *testing.T) {
 	}
 }
 
+func TestNewAtlasCommand_ForwardedNativeFailureExits1(t *testing.T) {
+	c := qt.New(t)
+	missingDir := filepath.Join(t.TempDir(), "missing")
+	cmd := atlas.NewAtlasCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "hash", "--dir", "file://" + missingDir})
+
+	err := executeAtlasTestCommand(cmd)
+
+	c.Assert(err, qt.ErrorMatches, "migrations directory .*")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(out.String(), qt.Contains, "error: migrations directory")
+}
+
 func executeAtlasUsageTestCommand(cmd *cobra.Command, args []string) (string, error) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs(args)
-	err := cmd.Execute()
+	err := executeAtlasTestCommand(cmd)
 	return out.String(), err
+}
+
+func executeAtlasTestCommand(cmd *cobra.Command) error {
+	executed, err := cmd.ExecuteC()
+	return cmdutil.NormalizeCommandError(executed, err, 2)
 }

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -1,18 +1,23 @@
 // Package cmdutil holds small helpers shared by CLI subcommands: consistent
-// usage-error reporting (exit code 2 with a printed message) and directory
-// validation.
+// usage-error reporting, command-tree error policies, and directory validation.
 package cmdutil
 
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 )
 
-const configuredAnnotation = "ptah.exitcode_configured"
+const (
+	configuredAnnotation      = "ptah.exitcode_configured"
+	errorCodePolicyAnnotation = "ptah.error_code_policy"
+	unconfiguredErrorCode     = -1
+	nativeCommandErrorCode    = 2
+)
 
 // ConfigureCommand installs Ptah's common CLI error contract on cmd. It is
 // idempotent because many command constructors return package-level singletons.
@@ -40,16 +45,66 @@ func ConfigureCommandArgs(cmd *cobra.Command, args cobra.PositionalArgs) {
 	}
 }
 
+// SetErrorCodePolicy marks cmd and its future descendants with an inherited
+// process exit code. [NormalizeCommandError] applies the policy after Cobra
+// finishes command execution and validation.
+func SetErrorCodePolicy(cmd *cobra.Command, code int) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[errorCodePolicyAnnotation] = strconv.Itoa(code)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+}
+
+// NormalizeCommandError applies the nearest configured ancestor error policy
+// to err. Commands without a configured policy preserve explicit exit codes
+// and map an ordinary error to fallback.
+func NormalizeCommandError(cmd *cobra.Command, err error, fallback int) error {
+	if err == nil {
+		return nil
+	}
+	if code, ok := commandErrorCode(cmd); ok {
+		currentCode := exitcode.Code(err, unconfiguredErrorCode)
+		switch currentCode {
+		case code:
+			return err
+		case unconfiguredErrorCode:
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+		}
+		return exitcode.New(code, err)
+	}
+	if exitcode.Code(err, unconfiguredErrorCode) != unconfiguredErrorCode {
+		return err
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	return exitcode.New(fallback, err)
+}
+
+func commandErrorCode(cmd *cobra.Command) (int, bool) {
+	for current := cmd; current != nil; current = current.Parent() {
+		policy, ok := current.Annotations[errorCodePolicyAnnotation]
+		if !ok {
+			continue
+		}
+		code, err := strconv.Atoi(policy)
+		if err == nil {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
 // WrapRunE maps ordinary command failures to exit code 2 while preserving
 // expected-negative results that already carry an explicit exit code.
 func WrapRunE(run func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		err := run(cmd, args)
-		if err == nil || exitcode.Code(err, -1) != -1 {
+		if err == nil || exitcode.Code(err, unconfiguredErrorCode) != unconfiguredErrorCode {
 			return err
 		}
 		fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
-		return exitcode.New(2, err)
+		return exitcode.New(nativeCommandErrorCode, err)
 	}
 }
 
@@ -58,7 +113,7 @@ func WrapRunE(run func(*cobra.Command, []string) error) func(*cobra.Command, []s
 // through this so the message still reaches the user.
 func Fail(cmd *cobra.Command, err error) error {
 	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
-	return exitcode.New(2, err)
+	return exitcode.New(nativeCommandErrorCode, err)
 }
 
 // FlagErrorFunc reports a cobra flag-parse error (unknown flag, bad value)

--- a/cmd/internal/cmdutil/cmdutil_test.go
+++ b/cmd/internal/cmdutil/cmdutil_test.go
@@ -45,3 +45,83 @@ func TestWrapRunEPreservesExplicitExitCodes(t *testing.T) {
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(stderr.String(), qt.Equals, "")
 }
+
+func TestNormalizeCommandError_MapsCobraFlagGroupErrors(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := &cobra.Command{
+		Use:  "root",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	cmd.Flags().Bool("first", false, "First choice")
+	cmd.Flags().Bool("second", false, "Second choice")
+	cmd.MarkFlagsMutuallyExclusive("first", "second")
+	cmdutil.SetErrorCodePolicy(cmd, 1)
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--first", "--second"})
+
+	executed, err := cmd.ExecuteC()
+	err = cmdutil.NormalizeCommandError(executed, err, 2)
+
+	c.Assert(err, qt.ErrorMatches, `if any flags in the group \[first second\] are set none of the others can be; \[first second\] were all set`)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "error: if any flags in the group [first second] are set none of the others can be; [first second] were all set\n")
+}
+
+func TestNormalizeCommandError_MapsLateDescendantErrors(t *testing.T) {
+	c := qt.New(t)
+
+	root := &cobra.Command{Use: "root"}
+	cmdutil.SetErrorCodePolicy(root, 1)
+	root.AddCommand(&cobra.Command{
+		Use:  "late",
+		RunE: commandError("late failure"),
+	})
+	var stderr bytes.Buffer
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"late"})
+
+	executed, err := root.ExecuteC()
+	err = cmdutil.NormalizeCommandError(executed, err, 2)
+
+	c.Assert(err, qt.ErrorMatches, "late failure")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "error: late failure\n")
+}
+
+func TestNormalizeCommandError_PreservesNativeExplicitExitCode(t *testing.T) {
+	c := qt.New(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "native"}
+	cmd.SetErr(&stderr)
+	err := cmdutil.NormalizeCommandError(cmd, exitcode.New(1, errors.New("drift")), 2)
+
+	c.Assert(err, qt.ErrorMatches, "drift")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "")
+}
+
+func TestNormalizeCommandError_RemapExplicitErrorWithoutDuplicateOutput(t *testing.T) {
+	c := qt.New(t)
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "atlas"}
+	cmd.SetErr(&stderr)
+	cmdutil.SetErrorCodePolicy(cmd, 1)
+	_, err := stderr.WriteString("error: boom\n")
+	c.Assert(err, qt.IsNil)
+
+	err = cmdutil.NormalizeCommandError(cmd, exitcode.New(2, errors.New("boom")), 2)
+
+	c.Assert(err, qt.ErrorMatches, "boom")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stderr.String(), qt.Equals, "error: boom\n")
+}
+
+func commandError(message string) func(*cobra.Command, []string) error {
+	return func(_ *cobra.Command, _ []string) error {
+		return errors.New(message)
+	}
+}

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -11,12 +11,7 @@ import (
 
 func TestCompatBinaryNamedAtlasResolvesRootCommands(t *testing.T) {
 	c := qt.New(t)
-	binPath := filepath.Join(t.TempDir(), "atlas")
-
-	build := exec.Command("go", "build", "-o", binPath, ".")
-	build.Env = append(os.Environ(), "GOWORK=off")
-	buildOut, err := build.CombinedOutput()
-	c.Assert(err, qt.IsNil, qt.Commentf("%s", buildOut))
+	binPath := buildCompatBinary(c)
 
 	run := exec.Command(binPath, "migrate", "down", "--help")
 	runOut, err := run.CombinedOutput()
@@ -26,4 +21,66 @@ func TestCompatBinaryNamedAtlasResolvesRootCommands(t *testing.T) {
 	c.Assert(output, qt.Contains, "Usage:")
 	c.Assert(output, qt.Contains, "atlas migrate down")
 	c.Assert(output, qt.Not(qt.Contains), "atlas atlas migrate down")
+}
+
+func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+
+	tests := []struct {
+		name       string
+		command    func(string) *exec.Cmd
+		wantStderr string
+	}{
+		{
+			name: "unknown flag",
+			command: func(binPath string) *exec.Cmd {
+				return exec.Command(binPath, "version", "--bogus-flag")
+			},
+			wantStderr: "error: unknown flag: --bogus-flag\n",
+		},
+		{
+			name: "mutually exclusive flags",
+			command: func(binPath string) *exec.Cmd {
+				return exec.Command(
+					binPath,
+					"schema", "apply",
+					"--url", "sqlite://schema.db",
+					"--to", "file://schema.sql",
+					"--file", "schema.sql",
+					"--dry-run",
+				)
+			},
+			wantStderr: "error: if any flags in the group [file to] are set none of the others can be; [file to] were all set\n",
+		},
+		{
+			name: "lazy completion command",
+			command: func(binPath string) *exec.Cmd {
+				return exec.Command(binPath, "completion", "bash", "extra")
+			},
+			wantStderr: "error: unknown command \"extra\" for \"atlas completion bash\"\n",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			run := tt.command(binPath)
+			runOut, err := run.CombinedOutput()
+			var exitErr *exec.ExitError
+
+			c.Assert(err, qt.ErrorAs, &exitErr, qt.Commentf("%s", runOut))
+			c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+			c.Assert(string(runOut), qt.Equals, tt.wantStderr)
+		})
+	}
+}
+
+func buildCompatBinary(c *qt.C) string {
+	c.Helper()
+	binPath := filepath.Join(c.TempDir(), "atlas")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Env = append(os.Environ(), "GOWORK=off")
+	buildOut, err := build.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", buildOut))
+	return binPath
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -77,12 +77,11 @@ func executeWithRecovery(cmd *cobra.Command) (err error) {
 		}
 	}()
 
-	err = cmd.Execute()
-	if err == nil || exitcode.Code(err, -1) != -1 {
-		return err
+	executed, err := cmd.ExecuteC()
+	if executed == nil {
+		executed = cmd
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
-	return exitcode.New(2, err)
+	return cmdutil.NormalizeCommandError(executed, err, 2)
 }
 
 const rootLongDescription = `Ptah generates database schemas from Go entities,

--- a/cmd/root/root_internal_test.go
+++ b/cmd/root/root_internal_test.go
@@ -153,7 +153,6 @@ func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
 		{name: "seed", args: []string{"seed", "--bogus-flag"}},
 		{name: "sql lint", args: []string{"sql", "lint", "--bogus-flag"}},
 		{name: "viz", args: []string{"viz", "--bogus-flag"}},
-		{name: "atlas version", args: []string{"atlas", "version", "--bogus-flag"}},
 		{name: "version", args: []string{"version", "--bogus-flag"}},
 	}
 
@@ -167,6 +166,48 @@ func TestZZZRootUsageErrorsExit2WithoutUsage(t *testing.T) {
 			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 			c.Assert(stderr, qt.Contains, "error: unknown flag: --bogus-flag")
 			c.Assert(stderr, qt.Not(qt.Contains), "Usage:")
+		})
+	}
+}
+
+func TestZZZAtlasUsageErrorsExit1WithoutUsage(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "unknown flag",
+			args:       []string{"atlas", "version", "--bogus-flag"},
+			wantStderr: "error: unknown flag: --bogus-flag\n",
+		},
+		{
+			name: "mutually exclusive flags",
+			args: []string{
+				"atlas", "schema", "apply",
+				"--url", "sqlite://schema.db",
+				"--to", "file://schema.sql",
+				"--file", "schema.sql",
+				"--dry-run",
+			},
+			wantStderr: "error: if any flags in the group [file to] are set none of the others can be; [file to] were all set\n",
+		},
+		{
+			name:       "lazy completion command",
+			args:       []string{"atlas", "completion", "bash", "extra"},
+			wantStderr: "error: unexpected positional arguments [\"completion\" \"bash\" \"extra\"]\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, stderr, err := executeRoot(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(stderr, qt.Equals, tt.wantStderr)
 		})
 	}
 }

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -1,6 +1,6 @@
 # CLI Exit Codes
 
-Ptah treats CLI exit codes as a public scripting contract.
+Native Ptah commands treat CLI exit codes as a public scripting contract.
 
 | Code | Meaning |
 | --- | --- |
@@ -8,6 +8,11 @@ Ptah treats CLI exit codes as a public scripting contract.
 | `1` | Expected negative result. A check found drift, lint findings, integrity drift, pending migrations, or a non-empty diff when that behavior is enabled. |
 | `2` | Command or usage error. Examples: bad flags, unknown commands, invalid input, connection failure, parse failure, unsupported dialect, unwritable output, or an internal panic recovered by the root command. |
 | `3+` | Reserved. Do not rely on these codes until Ptah documents a specific use. |
+
+This four-level contract applies to native Ptah commands. The Atlas-compatible
+surfaces intentionally use Atlas CE's narrower process contract: `0` for
+success and help, and `1` for command, usage, validation, and runtime failures.
+An internal panic recovered by Ptah's process boundary still exits `2`.
 
 ## Native Commands
 
@@ -72,5 +77,8 @@ shares this exit-code contract.
 
 Atlas CE community-version unsupported boundary stubs mirror Atlas CE: `--help`
 prints the unsupported notice and exits `0`, while direct execution prints the
-Atlas CE abort text and exits `1`. Unsupported Atlas-compatible flags are
-rejected explicitly and exit `2`.
+Atlas CE abort text and exits `1`. All other reported failures on
+`ptah atlas ...` and `ptah-compat`, including unsupported flags, malformed
+input, missing files, configuration errors, and database failures, also exit
+`1`. This normalization applies only to the compatibility trees; equivalent
+native Ptah command failures keep exit code `2`.

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -3,7 +3,7 @@ title: Exit codes
 description: How Ptah commands behave when used as automation gates.
 ---
 
-Ptah uses exit codes as a public scripting contract:
+Native Ptah commands use exit codes as a public scripting contract:
 
 | Code | Meaning |
 | --- | --- |
@@ -11,6 +11,11 @@ Ptah uses exit codes as a public scripting contract:
 | `1` | Expected negative result. A check found drift, lint findings, integrity drift, pending migrations, or a non-empty diff when that behavior is enabled. |
 | `2` | Command or usage error. Examples: bad flags, unknown commands, invalid input, connection failure, parse failure, unsupported dialect, unwritable output, or an internal panic recovered by the root command. |
 | `3+` | Reserved. Do not rely on these codes until Ptah documents a specific use. |
+
+This four-level contract applies to native Ptah commands. The Atlas-compatible
+surfaces intentionally use Atlas CE's narrower process contract: `0` for
+success and help, and `1` for command, usage, validation, and runtime failures.
+An internal panic recovered by Ptah's process boundary still exits `2`.
 
 Common gates:
 
@@ -20,9 +25,10 @@ ptah migrations status --db-url "$DATABASE_URL" --migrations-dir ./migrations --
 ptah migrations lint --dir ./migrations --dialect postgres
 ```
 
-Do not collapse all non-zero outcomes into the same remediation. A `1` usually
-means the command successfully found a condition you asked it to check; a `2`
-means the command itself did not complete correctly.
+For native Ptah commands, do not collapse all non-zero outcomes into the same
+remediation. A `1` means the command successfully found a condition you asked
+it to check; a `2` means the command itself did not complete correctly.
+Atlas-compatible surfaces use `1` for both classes to match Atlas CE.
 
 ## Native Commands
 
@@ -87,7 +93,10 @@ shares this exit-code contract.
 
 Atlas CE community-version unsupported boundary stubs mirror Atlas CE: `--help`
 prints the unsupported notice and exits `0`, while direct execution prints the
-Atlas CE abort text and exits `1`. Unsupported Atlas-compatible flags are
-rejected explicitly and exit `2`.
+Atlas CE abort text and exits `1`. All other reported failures on
+`ptah atlas ...` and `ptah-compat`, including unsupported flags, malformed
+input, missing files, configuration errors, and database failures, also exit
+`1`. This normalization applies only to the compatibility trees; equivalent
+native Ptah command failures keep exit code `2`.
 
 This page is checked against the repository exit-code contract during docs CI.

--- a/docs/site/src/content/docs/workflows/ci.md
+++ b/docs/site/src/content/docs/workflows/ci.md
@@ -62,11 +62,14 @@ pull-request job at a production database.
 
 ## Exit behavior
 
-See [Exit codes](../../reference/exit-codes/) before using Ptah as a gate. `0`
-means success, `1` is reserved for command-specific negative check results such
-as drift, lint findings, pending migrations with `--exit-code`, or migration
-hash drift. Usage errors, parse failures, connection failures, unsupported
-dialects, and other command errors use `2`.
+See [Exit codes](../../reference/exit-codes/) before using Ptah as a gate. For
+native Ptah commands, `0` means success, `1` is reserved for command-specific
+negative check results such as drift, lint findings, pending migrations with
+`--exit-code`, or migration hash drift, and `2` means a usage, parse,
+connection, unsupported-dialect, or other command failure. Atlas-compatible
+surfaces use `1` for both negative results and command failures to match Atlas
+CE. A recovered internal panic remains exit `2` on either surface, so scripts
+should interpret the code according to the selected CLI surface.
 
 ## Keep CI deterministic
 


### PR DESCRIPTION
## Summary

- apply an inherited exit-code policy at the Cobra execution boundary for `ptah atlas` and `ptah-compat`
- map Atlas-compatible command, validation, and runtime failures to exit `1` while preserving native Ptah `0`/`1`/`2` behavior and recovered panic exit `2`
- cover Cobra-owned validation, lazy descendants, forwarded native commands, exact stderr, process exit behavior, and native isolation

## Validation

- `go test ./...`
- `go test -race ./cmd/internal/cmdutil ./cmd/atlas ./cmd/root ./cmd/ptah-compat`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `node docs/site/scripts/check-exit-codes.mjs`
- `npm run build`
- `npm run versions:selftest`
- `npm run check:links:selftest`
- `npm run check:core-doc-links`
- `npm audit --audit-level=low`

## Documentation impact

Updated the core exit-code reference, the documentation-site exit-code reference, and the CI workflow guide. No public Go API or dependency changes.

Fixes #688