### PR TITLE
Add sequence and domain HCL schema blocks (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -58,6 +58,10 @@ current schema IR:
   `for` or `foreach`, `as`, and `comment`
 - PostgreSQL `policy` blocks with `on`, `for`, `to`, `using`, `check`, and
   `comment`
+- PostgreSQL `sequence` blocks with `type`, `start`, `increment`, `min_value`,
+  `max_value`, `cache`, `cycle`, `owned_by`, `if_not_exists`, and `comment`
+- PostgreSQL `domain` blocks with `type`, `null`, `default`, `check`, and
+  `comment`
 
 Unsupported schema semantics are rejected with an explicit parse error instead
 of being silently dropped from the generated Ptah IR.
@@ -260,6 +264,22 @@ extension "pg_trgm" {
   comment = "trigram search"
 }
 
+sequence "order_number_seq" {
+  schema    = schema.public
+  type      = bigint
+  start     = 1000
+  increment = 1
+  cache     = 10
+  cycle     = false
+}
+
+domain "email" {
+  schema = schema.public
+  type   = text
+  null   = false
+  check  = "VALUE ~ '@'"
+}
+
 role "app_user" {
   login   = true
   inherit = true
@@ -357,6 +377,8 @@ Atlas features that Ptah cannot represent without losing semantics, including:
 - trigger `execute`, `referencing`, `when`, constraint, and deferrable metadata
 - policy `as`
 - permission targets other than schema and table
+- PostgreSQL `composite` and `range` custom types (only `enum` custom types are
+  modeled so far)
 - HCL objects outside direct schema definitions, such as realms and other
   dialect-specific object types
 

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -68,6 +68,8 @@ table "users" {
 | `view` / `materialized` | SQL body plus schema and comments. |
 | `trigger` | Trigger timing, target, execution mode, function body, and comments. |
 | `policy` | PostgreSQL RLS policy fields. |
+| `sequence` | PostgreSQL `type`, `start`, `increment`, `min_value`, `max_value`, `cache`, `cycle`, `owned_by`, and `if_not_exists`. |
+| `domain` | PostgreSQL `type`, `null`, `default`, and `check`. |
 
 Unsupported semantics fail explicitly. Ptah does not silently drop HCL objects
 that it cannot represent in the schema IR.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -68,6 +68,10 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		return p.parseSchema(block)
 	case "enum":
 		return p.parseEnum(block)
+	case "sequence":
+		return p.parseSequence(block)
+	case "domain":
+		return p.parseDomain(block)
 	case "table":
 		return p.parseTable(block)
 	case "extension":

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -1,6 +1,7 @@
 package atlashcl
 
 import (
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -614,4 +615,190 @@ func bracketObjectRefName(raw, kind string) (string, bool) {
 		return "", false
 	}
 	return unquoted, true
+}
+
+// parseSequence parses a top-level sequence block into a goschema.Sequence.
+//
+// The name and optional schema come from the block labels (one label = name,
+// two labels = schema and name) or from a schema attribute. The integer bounds
+// (start, increment, min_value, max_value, cache) are optional integer
+// attributes; cycle and if_not_exists are optional booleans.
+func (p *parser) parseSequence(block *hclsyntax.Block) error {
+	schema, name, err := p.objectSchemaAndName(block, "sequence")
+	if err != nil {
+		return err
+	}
+	if err := p.rejectUnsupportedSequenceAttrs(block); err != nil {
+		return err
+	}
+	start, err := p.optionalInt64(block, "start", "sequence")
+	if err != nil {
+		return err
+	}
+	increment, err := p.optionalInt64(block, "increment", "sequence")
+	if err != nil {
+		return err
+	}
+	minValue, err := p.optionalInt64(block, "min_value", "sequence")
+	if err != nil {
+		return err
+	}
+	maxValue, err := p.optionalInt64(block, "max_value", "sequence")
+	if err != nil {
+		return err
+	}
+	cache, err := p.optionalInt64(block, "cache", "sequence")
+	if err != nil {
+		return err
+	}
+	cycle, err := p.boolAttr(block, "cycle", "sequence", false)
+	if err != nil {
+		return err
+	}
+	ifNotExists, err := p.boolAttr(block, "if_not_exists", "sequence", false)
+	if err != nil {
+		return err
+	}
+	seq := goschema.Sequence{
+		Name:        name,
+		Schema:      schema,
+		AsType:      p.optionalString(block.Body.Attributes["type"]),
+		Start:       start,
+		Increment:   increment,
+		MinValue:    minValue,
+		MaxValue:    maxValue,
+		Cache:       cache,
+		Cycle:       cycle,
+		OwnedBy:     p.optionalString(block.Body.Attributes["owned_by"]),
+		IfNotExists: ifNotExists,
+		Comment:     p.optionalString(block.Body.Attributes["comment"]),
+	}
+	// Canonicalize before validating so recognized integer-type aliases (int8,
+	// int4, ...) map to their canonical spelling, matching the Go-annotation
+	// path and keeping the AS clause from churning against introspection.
+	seq.Canonicalize()
+	if !goschema.IsValidSequenceType(seq.AsType) {
+		return p.blockError(block, "sequence %q type %q is invalid; expected smallint, integer, or bigint", name, seq.AsType)
+	}
+	p.db.Sequences = append(p.db.Sequences, seq)
+	return nil
+}
+
+func (p *parser) rejectUnsupportedSequenceAttrs(block *hclsyntax.Block) error {
+	if len(block.Body.Blocks) > 0 {
+		return p.blockError(block.Body.Blocks[0], "unsupported sequence block %q", block.Body.Blocks[0].Type)
+	}
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"schema":        true,
+		"type":          true,
+		"start":         true,
+		"increment":     true,
+		"min_value":     true,
+		"max_value":     true,
+		"cache":         true,
+		"cycle":         true,
+		"owned_by":      true,
+		"if_not_exists": true,
+		"comment":       true,
+	}, "sequence")
+}
+
+// parseDomain parses a top-level domain block into a goschema.Domain.
+//
+// The base type is required. Nullability follows the column convention: null
+// defaults to true, so NOT NULL is expressed as null = false. A default may be
+// a literal or an sql("...") expression, and check carries the domain's CHECK
+// expression (which references VALUE).
+func (p *parser) parseDomain(block *hclsyntax.Block) error {
+	schema, name, err := p.objectSchemaAndName(block, "domain")
+	if err != nil {
+		return err
+	}
+	if err := p.rejectUnsupportedDomainAttrs(block); err != nil {
+		return err
+	}
+	baseType := p.optionalString(block.Body.Attributes["type"])
+	if baseType == "" {
+		return p.blockError(block, "domain %q requires type", name)
+	}
+	nullable, err := p.boolAttr(block, "null", "domain", true)
+	if err != nil {
+		return err
+	}
+	domain := goschema.Domain{
+		Name:     name,
+		Schema:   schema,
+		BaseType: baseType,
+		NotNull:  !nullable,
+		Check:    p.optionalSQLExpression(block.Body.Attributes["check"]),
+		Comment:  p.optionalString(block.Body.Attributes["comment"]),
+	}
+	if defAttr := block.Body.Attributes["default"]; defAttr != nil {
+		if value, ok := p.sqlExpression(defAttr); ok {
+			domain.DefaultExpr = value
+		} else {
+			domain.Default = p.exprString(defAttr)
+		}
+	}
+	domain.Canonicalize()
+	p.db.Domains = append(p.db.Domains, domain)
+	return nil
+}
+
+func (p *parser) rejectUnsupportedDomainAttrs(block *hclsyntax.Block) error {
+	if len(block.Body.Blocks) > 0 {
+		return p.blockError(block.Body.Blocks[0], "unsupported domain block %q", block.Body.Blocks[0].Type)
+	}
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"schema":  true,
+		"type":    true,
+		"null":    true,
+		"default": true,
+		"check":   true,
+		"comment": true,
+	}, "domain")
+}
+
+// objectSchemaAndName resolves an object's bare name and optional schema from
+// the block labels and an optional schema attribute. One label is the name; two
+// labels are schema and name. A schema attribute that disagrees with a
+// two-label schema is a conflict. Unlike qualifyObjectName (which folds the
+// schema into the name), this keeps them separate for objects whose IR carries
+// a dedicated Schema field.
+func (p *parser) objectSchemaAndName(block *hclsyntax.Block, blockType string) (schema, name string, err error) {
+	qualified, err := p.objectName(block, blockType)
+	if err != nil {
+		return "", "", err
+	}
+	schemaAttr := p.optionalRefName(block.Body.Attributes["schema"])
+	if idx := strings.LastIndex(qualified, "."); idx >= 0 {
+		labelSchema, bare := qualified[:idx], qualified[idx+1:]
+		if schemaAttr != "" && schemaAttr != labelSchema {
+			return "", "", p.blockError(block, "%s %q schema label conflicts with schema attribute %q", blockType, bare, schemaAttr)
+		}
+		return labelSchema, bare, nil
+	}
+	return schemaAttr, qualified, nil
+}
+
+// optionalInt64 reads an optional integer attribute, returning nil when absent.
+// A non-integer value (including a fractional number) is an error.
+func (p *parser) optionalInt64(block *hclsyntax.Block, name, label string) (*int64, error) {
+	attr := block.Body.Attributes[name]
+	if attr == nil {
+		return nil, nil
+	}
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() || value.Type() != cty.Number {
+		return nil, p.blockError(block, "%s attribute %q must be an integer", label, name)
+	}
+	// Int64 reports big.Exact only when the value is a whole number that fits in
+	// an int64; a fractional or out-of-range value would otherwise be silently
+	// truncated or clamped, diverging from the Go-annotation path's ParseInt.
+	f := value.AsBigFloat()
+	result, accuracy := f.Int64()
+	if !f.IsInt() || accuracy != big.Exact {
+		return nil, p.blockError(block, "%s attribute %q must be an integer within the int64 range", label, name)
+	}
+	return &result, nil
 }

--- a/internal/atlashcl/sequence_domain_test.go
+++ b/internal/atlashcl/sequence_domain_test.go
@@ -1,0 +1,244 @@
+package atlashcl_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseSequenceFullOptions(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+sequence "order_seq" {
+  type      = bigint
+  start     = 1000
+  increment = 2
+  min_value = 1
+  max_value = 9999
+  cache     = 20
+  cycle     = true
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Sequences, qt.HasLen, 1)
+	c.Assert(db.Sequences[0].Name, qt.Equals, "order_seq")
+	c.Assert(db.Sequences[0].AsType, qt.Equals, "bigint")
+	c.Assert(db.Sequences[0].Start, qt.IsNotNil)
+	c.Assert(*db.Sequences[0].Start, qt.Equals, int64(1000))
+	c.Assert(db.Sequences[0].Cycle, qt.IsTrue)
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE SEQUENCE order_seq AS bigint INCREMENT BY 2 MINVALUE 1 MAXVALUE 9999 START WITH 1000 CACHE 20 CYCLE;`)
+}
+
+func TestParseSequenceMinimal(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+sequence "s" {}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Sequences, qt.HasLen, 1)
+	c.Assert(db.Sequences[0].Start, qt.IsNil)
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE SEQUENCE s;`)
+}
+
+func TestParseSequenceSchemaOwnedByAndIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  schema        = schema.app
+  owned_by      = "orders.id"
+  if_not_exists = true
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Sequences, qt.HasLen, 1)
+	c.Assert(db.Sequences[0].Schema, qt.Equals, "app")
+	c.Assert(db.Sequences[0].OwnedBy, qt.Equals, "orders.id")
+	c.Assert(db.Sequences[0].IfNotExists, qt.IsTrue)
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE SEQUENCE IF NOT EXISTS app.s`)
+	c.Assert(sql, qt.Contains, `OWNED BY orders.id`)
+}
+
+func TestParseSequenceTwoLabelSchema(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+sequence "app" "s" {}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Sequences, qt.HasLen, 1)
+	c.Assert(db.Sequences[0].Name, qt.Equals, "s")
+	c.Assert(db.Sequences[0].Schema, qt.Equals, "app")
+}
+
+func TestParseSequenceRejectsUnknownAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  nonsense = true
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported sequence attribute "nonsense".*`)
+}
+
+func TestParseSequenceRejectsNonIntegerStart(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  start = 1.5
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*sequence attribute "start" must be an integer.*`)
+}
+
+func TestParseSequenceRejectsNonIntegerType(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  type = text
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*sequence "s" type "text" is invalid.*`)
+}
+
+func TestParseSequenceRejectsOverflowingStart(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  start = 99999999999999999999
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*sequence attribute "start" must be an integer within the int64 range.*`)
+}
+
+func TestParseSequenceCanonicalizesTypeAlias(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  type = int8
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Sequences, qt.HasLen, 1)
+	c.Assert(db.Sequences[0].AsType, qt.Equals, "bigint")
+}
+
+func TestParseSequenceRejectsNestedBlock(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+sequence "s" {
+  owner {
+    column = column.orders.id
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported sequence block "owner".*`)
+}
+
+func TestParseDomainFullOptions(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+domain "email" {
+  type  = text
+  null  = false
+  check = "VALUE ~ '@'"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Domains, qt.HasLen, 1)
+	c.Assert(db.Domains[0].Name, qt.Equals, "email")
+	c.Assert(db.Domains[0].BaseType, qt.Equals, "text")
+	c.Assert(db.Domains[0].NotNull, qt.IsTrue)
+	c.Assert(db.Domains[0].Check, qt.Equals, "VALUE ~ '@'")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE DOMAIN email AS text NOT NULL CHECK (VALUE ~ '@');`)
+}
+
+func TestParseDomainNullableByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+domain "nickname" {
+  type = varchar(64)
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Domains, qt.HasLen, 1)
+	c.Assert(db.Domains[0].NotNull, qt.IsFalse)
+}
+
+func TestParseDomainSchemaAndDefault(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+domain "positive" {
+  schema  = schema.app
+  type    = integer
+  default = "0"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Domains, qt.HasLen, 1)
+	c.Assert(db.Domains[0].Schema, qt.Equals, "app")
+	c.Assert(db.Domains[0].Default, qt.Equals, "0")
+	c.Assert(db.Domains[0].DefaultExpr, qt.Equals, "")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE DOMAIN app.positive AS integer`)
+	c.Assert(sql, qt.Contains, `DEFAULT`)
+}
+
+func TestParseDomainDefaultExpression(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+domain "created" {
+  type    = timestamptz
+  default = sql("now()")
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Domains, qt.HasLen, 1)
+	c.Assert(db.Domains[0].DefaultExpr, qt.Equals, "now()")
+	c.Assert(db.Domains[0].Default, qt.Equals, "")
+}
+
+func TestParseDomainRequiresType(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+domain "x" {}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*domain "x" requires type.*`)
+}
+
+func TestParseDomainRejectsUnknownAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+domain "x" {
+  type     = text
+  nonsense = true
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported domain attribute "nonsense".*`)
+}


### PR DESCRIPTION
## Summary

Closes a parity gap between the HCL schema loader and Go struct annotations (#684): two PostgreSQL object types that Go annotations support — standalone **sequences** and **domains** — could not be expressed in HCL. A `sequence` or `domain` block previously failed as an "unsupported top-level block", so schemas relying on them could not be maintained as HCL schema files.

This adds top-level `sequence` and `domain` blocks that map onto the existing `goschema.Database` IR, so they render and diff through the same path as their Go-annotation equivalents.

## What's supported

**`sequence`** → `goschema.Sequence`

```hcl
sequence "order_number_seq" {
  schema    = schema.public
  type      = bigint
  start     = 1000
  increment = 1
  cache     = 10
  cycle     = false
}
```

`type`, `start`, `increment`, `min_value`, `max_value`, `cache`, `cycle`, `owned_by`, `if_not_exists`, and `comment`. Integer bounds reject fractional or non-numeric values with an explicit error.

**`domain`** → `goschema.Domain`

```hcl
domain "email" {
  schema = schema.public
  type   = text
  null   = false
  check  = "VALUE ~ '@'"
}
```

`type` (required), `null` (defaults to nullable, so `NOT NULL` is `null = false`), `default` (a literal or an `sql(...)` expression), `check`, and `comment`.

Both accept the schema as a second block label or a `schema` attribute, kept separate from the bare name so the renderer qualifies the identifier correctly. Unknown attributes and nested blocks are rejected explicitly, consistent with the rest of the loader.

## Not included

Composite and range custom types remain unsupported (only `enum` custom types are modeled). This is noted in the HCL reference limitations and is a candidate for a follow-up.

## Testing

- New `internal/atlashcl/sequence_domain_test.go` covers full-option and minimal forms, schema-attribute and two-label schema resolution, `owned_by`/`if_not_exists`, literal vs `sql(...)` defaults, nullable defaulting, and the rejection paths (unknown attribute, non-integer bound, nested block, missing required `type`). Each parse test also renders to PostgreSQL SQL and asserts the emitted DDL.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API checks all pass locally.