### PR TITLE
Add composite and range type HCL schema blocks (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -62,6 +62,11 @@ current schema IR:
   `max_value`, `cache`, `cycle`, `owned_by`, `if_not_exists`, and `comment`
 - PostgreSQL `domain` blocks with `type`, `null`, `default`, `check`, and
   `comment`
+- PostgreSQL `composite` blocks with ordered `field` sub-blocks (each a name
+  label and a `type`; quote multi-word types, e.g. `type = "double precision"`)
+  and `comment`
+- PostgreSQL `range` blocks with `subtype`, `subtype_opclass`, `collation`,
+  `canonical`, `subtype_diff`, and `comment`
 
 Unsupported schema semantics are rejected with an explicit parse error instead
 of being silently dropped from the generated Ptah IR.
@@ -280,6 +285,22 @@ domain "email" {
   check  = "VALUE ~ '@'"
 }
 
+composite "address" {
+  schema = schema.public
+  field "street" {
+    type = text
+  }
+  field "zip" {
+    type = integer
+  }
+}
+
+range "floatrange" {
+  schema       = schema.public
+  subtype      = float8
+  subtype_diff = float8mi
+}
+
 role "app_user" {
   login   = true
   inherit = true
@@ -377,8 +398,6 @@ Atlas features that Ptah cannot represent without losing semantics, including:
 - trigger `execute`, `referencing`, `when`, constraint, and deferrable metadata
 - policy `as`
 - permission targets other than schema and table
-- PostgreSQL `composite` and `range` custom types (only `enum` custom types are
-  modeled so far)
 - HCL objects outside direct schema definitions, such as realms and other
   dialect-specific object types
 

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -70,6 +70,8 @@ table "users" {
 | `policy` | PostgreSQL RLS policy fields. |
 | `sequence` | PostgreSQL `type`, `start`, `increment`, `min_value`, `max_value`, `cache`, `cycle`, `owned_by`, and `if_not_exists`. |
 | `domain` | PostgreSQL `type`, `null`, `default`, and `check`. |
+| `composite` | PostgreSQL composite type with ordered `field` sub-blocks. |
+| `range` | PostgreSQL `subtype`, `subtype_opclass`, `collation`, `canonical`, and `subtype_diff`. |
 
 Unsupported semantics fail explicitly. Ptah does not silently drop HCL objects
 that it cannot represent in the schema IR.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -72,6 +72,10 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		return p.parseSequence(block)
 	case "domain":
 		return p.parseDomain(block)
+	case "composite":
+		return p.parseComposite(block)
+	case "range":
+		return p.parseRange(block)
 	case "table":
 		return p.parseTable(block)
 	case "extension":

--- a/internal/atlashcl/composite_range_test.go
+++ b/internal/atlashcl/composite_range_test.go
@@ -1,0 +1,170 @@
+package atlashcl_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseCompositeType(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+composite "address" {
+  field "street" {
+    type = text
+  }
+  field "zip" {
+    type = integer
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CompositeTypes, qt.HasLen, 1)
+	c.Assert(db.CompositeTypes[0].Name, qt.Equals, "address")
+	c.Assert(db.CompositeTypes[0].Fields, qt.HasLen, 2)
+	c.Assert(db.CompositeTypes[0].Fields[0].Name, qt.Equals, "street")
+	c.Assert(db.CompositeTypes[0].Fields[0].Type, qt.Equals, "text")
+	c.Assert(db.CompositeTypes[0].Fields[1].Name, qt.Equals, "zip")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE TYPE address AS (street text, zip integer);`)
+}
+
+func TestParseCompositeTypeWithSchema(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+composite "app" "point" {
+  field "x" {
+    type = float8
+  }
+  field "y" {
+    type = float8
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CompositeTypes, qt.HasLen, 1)
+	c.Assert(db.CompositeTypes[0].Name, qt.Equals, "point")
+	c.Assert(db.CompositeTypes[0].Schema, qt.Equals, "app")
+}
+
+func TestParseCompositeQuotedMultiWordFieldType(t *testing.T) {
+	c := qt.New(t)
+
+	// A multi-word type has no bare HCL spelling, so it must be quoted; the
+	// quotes must be stripped from the stored type or the rendered DDL becomes a
+	// quoted identifier for a nonexistent type.
+	db, err := atlashcl.Parse([]byte(`
+composite "measurement" {
+  field "value" {
+    type = "double precision"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CompositeTypes, qt.HasLen, 1)
+	c.Assert(db.CompositeTypes[0].Fields[0].Type, qt.Equals, "double precision")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE TYPE measurement AS (value double precision);`)
+}
+
+func TestParseCompositeRequiresField(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+composite "empty" {}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*composite "empty" requires at least one field.*`)
+}
+
+func TestParseCompositeFieldRequiresType(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+composite "address" {
+  field "street" {}
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*composite field "street" requires type.*`)
+}
+
+func TestParseCompositeRejectsUnknownBlock(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+composite "address" {
+  column "street" {
+    type = text
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported composite block "column".*`)
+}
+
+func TestParseRangeType(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+range "floatrange" {
+  subtype      = float8
+  subtype_diff = float8mi
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Ranges, qt.HasLen, 1)
+	c.Assert(db.Ranges[0].Name, qt.Equals, "floatrange")
+	c.Assert(db.Ranges[0].Subtype, qt.Equals, "float8")
+	c.Assert(db.Ranges[0].SubtypeDiff, qt.Equals, "float8mi")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE TYPE floatrange AS RANGE (SUBTYPE = float8, SUBTYPE_DIFF = float8mi);`)
+}
+
+func TestParseRangeTypeAllOptions(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+range "app" "textrange" {
+  subtype         = text
+  subtype_opclass = text_ops
+  collation       = "en_US"
+  canonical       = textrange_canonical
+  subtype_diff    = textrange_diff
+  comment         = "text range"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Ranges, qt.HasLen, 1)
+	c.Assert(db.Ranges[0].Schema, qt.Equals, "app")
+	c.Assert(db.Ranges[0].SubtypeOpClass, qt.Equals, "text_ops")
+	c.Assert(db.Ranges[0].Collation, qt.Equals, "en_US")
+	c.Assert(db.Ranges[0].Canonical, qt.Equals, "textrange_canonical")
+	c.Assert(db.Ranges[0].Comment, qt.Equals, "text range")
+}
+
+func TestParseRangeRequiresSubtype(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+range "floatrange" {}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*range "floatrange" requires subtype.*`)
+}
+
+func TestParseRangeRejectsUnknownAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+range "floatrange" {
+  subtype  = float8
+  nonsense = true
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*unsupported range attribute "nonsense".*`)
+}

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -759,6 +759,117 @@ func (p *parser) rejectUnsupportedDomainAttrs(block *hclsyntax.Block) error {
 	}, "domain")
 }
 
+// parseComposite parses a top-level composite block into a
+// goschema.CompositeType. The ordered fields come from nested field blocks,
+// each carrying a name label and a type attribute.
+func (p *parser) parseComposite(block *hclsyntax.Block) error {
+	schema, name, err := p.objectSchemaAndName(block, "composite")
+	if err != nil {
+		return err
+	}
+	if err := p.rejectUnsupportedCompositeAttrs(block); err != nil {
+		return err
+	}
+	fields, err := p.parseCompositeFields(block)
+	if err != nil {
+		return err
+	}
+	if len(fields) == 0 {
+		return p.blockError(block, "composite %q requires at least one field", name)
+	}
+	composite := goschema.CompositeType{
+		Name:    name,
+		Schema:  schema,
+		Fields:  fields,
+		Comment: p.optionalString(block.Body.Attributes["comment"]),
+	}
+	composite.Canonicalize()
+	p.db.CompositeTypes = append(p.db.CompositeTypes, composite)
+	return nil
+}
+
+func (p *parser) parseCompositeFields(block *hclsyntax.Block) ([]goschema.CompositeTypeField, error) {
+	var fields []goschema.CompositeTypeField
+	for _, nested := range block.Body.Blocks {
+		if nested.Type != "field" {
+			return nil, p.blockError(nested, "unsupported composite block %q", nested.Type)
+		}
+		if len(nested.Labels) != 1 {
+			return nil, p.blockError(nested, "composite field requires exactly one name label")
+		}
+		if len(nested.Body.Blocks) > 0 {
+			return nil, p.blockError(nested.Body.Blocks[0], "unsupported composite field block %q", nested.Body.Blocks[0].Type)
+		}
+		if err := p.rejectUnsupportedAttrs(nested, map[string]bool{"type": true}, "composite field"); err != nil {
+			return nil, err
+		}
+		typeAttr := nested.Body.Attributes["type"]
+		if typeAttr == nil {
+			return nil, p.blockError(nested, "composite field %q requires type", nested.Labels[0])
+		}
+		// exprString (not rawExpr) so a quoted string literal is unquoted:
+		// multi-word types like "double precision" have no bare HCL spelling,
+		// so they must be written as a string, while bare references (text) and
+		// function-call shapes (numeric(10,2)) fall back to the raw source.
+		fields = append(fields, goschema.CompositeTypeField{
+			Name: nested.Labels[0],
+			Type: p.exprString(typeAttr),
+		})
+	}
+	return fields, nil
+}
+
+func (p *parser) rejectUnsupportedCompositeAttrs(block *hclsyntax.Block) error {
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"schema":  true,
+		"comment": true,
+	}, "composite")
+}
+
+// parseRange parses a top-level range block into a goschema.Range. The subtype
+// is required; the remaining attributes are optional PostgreSQL range options.
+func (p *parser) parseRange(block *hclsyntax.Block) error {
+	schema, name, err := p.objectSchemaAndName(block, "range")
+	if err != nil {
+		return err
+	}
+	if err := p.rejectUnsupportedRangeAttrs(block); err != nil {
+		return err
+	}
+	subtype := p.optionalString(block.Body.Attributes["subtype"])
+	if subtype == "" {
+		return p.blockError(block, "range %q requires subtype", name)
+	}
+	rng := goschema.Range{
+		Name:           name,
+		Schema:         schema,
+		Subtype:        subtype,
+		SubtypeOpClass: p.optionalString(block.Body.Attributes["subtype_opclass"]),
+		Collation:      p.optionalString(block.Body.Attributes["collation"]),
+		Canonical:      p.optionalString(block.Body.Attributes["canonical"]),
+		SubtypeDiff:    p.optionalString(block.Body.Attributes["subtype_diff"]),
+		Comment:        p.optionalString(block.Body.Attributes["comment"]),
+	}
+	rng.Canonicalize()
+	p.db.Ranges = append(p.db.Ranges, rng)
+	return nil
+}
+
+func (p *parser) rejectUnsupportedRangeAttrs(block *hclsyntax.Block) error {
+	if len(block.Body.Blocks) > 0 {
+		return p.blockError(block.Body.Blocks[0], "unsupported range block %q", block.Body.Blocks[0].Type)
+	}
+	return p.rejectUnsupportedAttrs(block, map[string]bool{
+		"schema":          true,
+		"subtype":         true,
+		"subtype_opclass": true,
+		"collation":       true,
+		"canonical":       true,
+		"subtype_diff":    true,
+		"comment":         true,
+	}, "range")
+}
+
 // objectSchemaAndName resolves an object's bare name and optional schema from
 // the block labels and an optional schema attribute. One label is the name; two
 // labels are schema and name. A schema attribute that disagrees with a


### PR DESCRIPTION
## Summary

Completes the object-type parity between the HCL schema loader and Go annotations (#684). The two remaining custom types that Go annotations support but HCL could not express — PostgreSQL **composite types** and **range types** — now parse into the existing `goschema.Database` IR. Previously a `composite` or `range` block failed as an "unsupported top-level block".

With sequences and domains (#713), the HCL loader now covers **every object type expressible via Go annotations**.

## What's supported

**`composite`** → `goschema.CompositeType` — ordered fields as nested `field` sub-blocks:

```hcl
composite "address" {
  schema = schema.public
  field "street" {
    type = text
  }
  field "zip" {
    type = integer
  }
}
```

At least one `field` is required (matching the Go path). Renders to `CREATE TYPE address AS (street text, zip integer);`.

**`range`** → `goschema.Range`:

```hcl
range "floatrange" {
  schema       = schema.public
  subtype      = float8
  subtype_diff = float8mi
}
```

`subtype` (required), plus `subtype_opclass`, `collation`, `canonical`, `subtype_diff`, and `comment`. Renders to `CREATE TYPE floatrange AS RANGE (SUBTYPE = float8, SUBTYPE_DIFF = float8mi);`.

Both accept the schema as a second block label or a `schema` attribute (kept separate from the bare name), and both canonicalize the parsed struct like the Go path. Unknown attributes and blocks are rejected explicitly.

## Testing

- New `internal/atlashcl/composite_range_test.go`: composite with fields (+ SQL render), two-label schema, required-field and required-type rejections, unknown-block rejection; range full/minimal options (+ SQL render), required-subtype and unknown-attribute rejections.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API checks all pass locally.