### PR TITLE
Support sequence targets in HCL permission blocks (#684)

### DIFF
--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1060,11 +1060,11 @@ func constraintDedupKey(c Constraint) string {
 	return scope + "." + c.Name
 }
 
-// deduplicateGrants dedups by role + privileges + target (table or schema).
-// The grant option is part of identity: a plain grant and a grant WITH GRANT
-// OPTION must both survive. Privilege order is normalized only for the key, so
-// logically identical grants deduplicate even when annotations list privileges
-// in a different order.
+// deduplicateGrants dedups by role + privileges + target (table, schema, or
+// sequence). The grant option is part of identity: a plain grant and a grant
+// WITH GRANT OPTION must both survive. Privilege order is normalized only for
+// the key, so logically identical grants deduplicate even when annotations list
+// privileges in a different order.
 func deduplicateGrants(grants []Grant) []Grant {
 	seen := make(map[string]bool)
 	deduplicated := make([]Grant, 0, len(grants))
@@ -1073,7 +1073,7 @@ func deduplicateGrants(grants []Grant) []Grant {
 		privileges := append([]string(nil), g.Privileges...)
 		sort.Strings(privileges)
 		privs := strings.Join(privileges, ",")
-		key := g.Role + "|" + privs + "|t:" + g.OnTable + "|s:" + g.OnSchema + "|o:" + strconv.FormatBool(g.WithOption)
+		key := g.Role + "|" + privs + "|t:" + g.OnTable + "|s:" + g.OnSchema + "|q:" + g.OnSequence + "|o:" + strconv.FormatBool(g.WithOption)
 		if !seen[key] {
 			seen[key] = true
 			deduplicated = append(deduplicated, g)

--- a/core/goschema/utils_test.go
+++ b/core/goschema/utils_test.go
@@ -236,6 +236,27 @@ func TestDeduplicate_GrantsKeepGrantOptionAndIgnorePrivilegeOrder(t *testing.T) 
 	c.Assert(db.Grants[1].Privileges, qt.DeepEquals, []string{"SELECT", "INSERT"})
 }
 
+func TestDeduplicate_GrantsDistinguishSequenceTargets(t *testing.T) {
+	c := qt.New(t)
+
+	// Grants that differ only by their sequence target must both survive; the
+	// sequence name is part of the grant's identity. A duplicate sequence grant
+	// still deduplicates.
+	db := &goschema.Database{
+		Grants: []goschema.Grant{
+			{Role: "app", Privileges: []string{"USAGE"}, OnSequence: "seq_a"},
+			{Role: "app", Privileges: []string{"USAGE"}, OnSequence: "seq_b"},
+			{Role: "app", Privileges: []string{"USAGE"}, OnSequence: "seq_a"},
+		},
+	}
+
+	goschema.Deduplicate(db)
+
+	c.Assert(db.Grants, qt.HasLen, 2)
+	c.Assert(db.Grants[0].OnSequence, qt.Equals, "seq_a")
+	c.Assert(db.Grants[1].OnSequence, qt.Equals, "seq_b")
+}
+
 func TestDeduplicate_ConstraintsUseExplicitTableScope(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -48,8 +48,8 @@ current schema IR:
 - PostgreSQL `extension` blocks with `version` and `comment`
 - PostgreSQL `role` blocks with `login`, `superuser`, `create_db`,
   `create_role`, `inherit`, `replication`, and `comment`
-- PostgreSQL `permission` blocks for table and schema targets with `to`,
-  `for`, `privileges`, `grantable`, and `comment`
+- PostgreSQL `permission` blocks for table, schema, and sequence targets with
+  `to`, `for`, `privileges`, `grantable`, and `comment`
 - PostgreSQL `function` blocks with `schema`, `lang`, `arg`, `return`,
   `security`, `volatility`, `as`, and `comment`
 - PostgreSQL `view` blocks with `schema`, `as`, `check_option`, and `comment`
@@ -372,7 +372,8 @@ permission {
 Ptah intentionally supports the subset it can round-trip through its IR. For
 example, `extension.schema`, `row_security.enforced`, materialized-view column
 blocks, trigger `execute` blocks, policy `as`, and permission targets other
-than `table` or `schema` are rejected instead of being accepted and dropped.
+than `table`, `schema`, or `sequence` are rejected instead of being accepted and
+dropped.
 Function arguments are accepted as Atlas `arg` blocks; export diagnostics are
 reported when a Go annotation `params` string cannot be represented this way.
 
@@ -397,7 +398,7 @@ Atlas features that Ptah cannot represent without losing semantics, including:
 - view/materialized-view column metadata
 - trigger `execute`, `referencing`, `when`, constraint, and deferrable metadata
 - policy `as`
-- permission targets other than schema and table
+- permission targets other than schema, table, and sequence
 - HCL objects outside direct schema definitions, such as realms and other
   dialect-specific object types
 

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -63,7 +63,7 @@ table "users" {
 | `check` | `expr`. |
 | `extension` | PostgreSQL `version` and comments. |
 | `role` | PostgreSQL role attributes such as `login`, `superuser`, `create_db`, and `inherit`. |
-| `permission` | PostgreSQL table and schema permissions. |
+| `permission` | PostgreSQL table, schema, and sequence permissions. |
 | `function` | PostgreSQL function metadata and raw body. |
 | `view` / `materialized` | SQL body plus schema and comments. |
 | `trigger` | Trigger timing, target, execution mode, function body, and comments. |

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -1438,7 +1438,7 @@ permission {
   for        = function.get_tenant
   privileges = [EXECUTE]
 }`,
-			match: `.*permission requires table or schema target.*`,
+			match: `.*permission requires table, schema, or sequence target.*`,
 		},
 		{
 			name: "permission missing privileges",

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -330,8 +330,10 @@ func (p *parser) parsePermission(block *hclsyntax.Block) error {
 		grant.OnTable = table
 	} else if schema := objectRefName(target, "schema"); schema != "" {
 		grant.OnSchema = schema
+	} else if sequence := objectRefName(target, "sequence"); sequence != "" {
+		grant.OnSequence = sequence
 	} else {
-		return p.blockError(block, "permission requires table or schema target")
+		return p.blockError(block, "permission requires table, schema, or sequence target")
 	}
 	if grant.Role == "" {
 		return p.blockError(block, "permission requires to")

--- a/internal/atlashcl/permission_sequence_test.go
+++ b/internal/atlashcl/permission_sequence_test.go
@@ -1,0 +1,58 @@
+package atlashcl_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParsePermissionSequenceTarget(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+permission {
+  to         = role.app_user
+  for        = sequence.order_seq
+  privileges = [USAGE, SELECT]
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Grants, qt.HasLen, 1)
+	c.Assert(db.Grants[0].OnSequence, qt.Equals, "order_seq")
+	c.Assert(db.Grants[0].OnTable, qt.Equals, "")
+	c.Assert(db.Grants[0].OnSchema, qt.Equals, "")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `GRANT USAGE, SELECT ON SEQUENCE order_seq TO app_user;`)
+}
+
+func TestParsePermissionSchemaQualifiedSequenceTarget(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+permission {
+  to         = role.app_user
+  for        = sequence.app.order_seq
+  privileges = [USAGE]
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Grants, qt.HasLen, 1)
+	c.Assert(db.Grants[0].OnSequence, qt.Equals, "app.order_seq")
+}
+
+func TestParsePermissionRejectsUnknownTargetKind(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+permission {
+  to         = role.app_user
+  for        = view.reporting
+  privileges = [SELECT]
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*permission requires table, schema, or sequence target.*`)
+}


### PR DESCRIPTION
## Summary

Closes the last GRANT-target parity gap between Go annotations and the HCL loader (#684). Go grant annotations can target a sequence (`on_sequence="..."`), but a `permission` block only resolved table and schema targets, so `for = sequence.<name>` failed as an unsupported target.

```hcl
permission {
  to         = role.app_user
  for        = sequence.order_seq
  privileges = [USAGE, SELECT]
}
```

now parses to `Grant.OnSequence` and renders `GRANT USAGE, SELECT ON SEQUENCE order_seq TO app_user;`.

The grant IR, SQL rendering, and schema diff already handle `OnSequence` — this was purely a loader gap. The fix mirrors the existing table/schema branches using the same `objectRefName` reference decoder, and extends the target error message to mention sequences.

## Latent dedup fix

While wiring this up, I found and fixed a latent grant-deduplication bug this newly exercises: the dedup key in `deduplicateGrants` omitted `OnSequence`, so two grants differing only by their sequence target collided and the second was silently dropped during `Finalize`. Authoring `USAGE` on two sequences for one role would lose one grant with no error. The key now includes the sequence (this also affected grants authored via Go `on_sequence` annotations).

## Scope

Loader (parse) only. Exporting a sequence grant back to HCL stays gated (sequence **objects** themselves are not yet rendered to HCL, so emitting a grant that references one would produce a dangling reference), so the `atlashclrender` path is unchanged.

## Testing

- New `internal/atlashcl/permission_sequence_test.go`: bare and schema-qualified sequence targets (with SQL render assertion) and the unknown-target-kind rejection with the updated message.
- New `TestDeduplicate_GrantsDistinguishSequenceTargets` in `core/goschema`: two distinct sequence grants both survive; a duplicate still dedups.
- Updated the existing "permission unsupported target" case to the new error wording.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API checks pass locally.