### PR TITLE
Support if_not_exists on HCL extension blocks (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -45,7 +45,7 @@ current schema IR:
 - `check` blocks with `expr`
 - `default = sql("...")` as a default expression
 - `row_security` blocks inside `table` with `enabled = true`
-- PostgreSQL `extension` blocks with `version` and `comment`
+- PostgreSQL `extension` blocks with `if_not_exists`, `version`, and `comment`
 - PostgreSQL `role` blocks with `login`, `superuser`, `create_db`,
   `create_role`, `inherit`, `replication`, and `comment`
 - PostgreSQL `permission` blocks for table, schema, and sequence targets with
@@ -265,8 +265,9 @@ rendering.
 schema "public" {}
 
 extension "pg_trgm" {
-  version = "1.6"
-  comment = "trigram search"
+  if_not_exists = true
+  version       = "1.6"
+  comment       = "trigram search"
 }
 
 sequence "order_number_seq" {

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -61,7 +61,7 @@ table "users" {
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |
 | `foreign_key` | One local `columns` entry and one table-qualified `ref_columns` entry. |
 | `check` | `expr`. |
-| `extension` | PostgreSQL `version` and comments. |
+| `extension` | PostgreSQL `if_not_exists`, `version`, and comments. |
 | `role` | PostgreSQL role attributes such as `login`, `superuser`, `create_db`, and `inherit`. |
 | `permission` | PostgreSQL table, schema, and sequence permissions. |
 | `function` | PostgreSQL function metadata and raw body. |

--- a/internal/atlashcl/extension_test.go
+++ b/internal/atlashcl/extension_test.go
@@ -1,0 +1,53 @@
+package atlashcl_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseExtensionIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+extension "pg_trgm" {
+  if_not_exists = true
+  version       = "1.6"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Extensions, qt.HasLen, 1)
+	c.Assert(db.Extensions[0].IfNotExists, qt.IsTrue)
+	c.Assert(db.Extensions[0].Version, qt.Equals, "1.6")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE EXTENSION IF NOT EXISTS pg_trgm VERSION '1.6';`)
+}
+
+func TestParseExtensionDefaultsWithoutIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+extension "pg_trgm" {}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Extensions, qt.HasLen, 1)
+	c.Assert(db.Extensions[0].IfNotExists, qt.IsFalse)
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CREATE EXTENSION pg_trgm;`)
+}
+
+func TestParseExtensionRejectsNonBoolIfNotExists(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+extension "pg_trgm" {
+  if_not_exists = "yes"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.ErrorMatches, `.*extension attribute "if_not_exists" must be a bool.*`)
+}

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -19,10 +19,15 @@ func (p *parser) parseExtension(block *hclsyntax.Block) error {
 	if err := p.rejectUnsupportedExtensionAttrs(block); err != nil {
 		return err
 	}
+	ifNotExists, err := p.boolAttr(block, "if_not_exists", "extension", false)
+	if err != nil {
+		return err
+	}
 	p.db.Extensions = append(p.db.Extensions, goschema.Extension{
-		Name:    name,
-		Version: p.optionalString(block.Body.Attributes["version"]),
-		Comment: p.optionalString(block.Body.Attributes["comment"]),
+		Name:        name,
+		IfNotExists: ifNotExists,
+		Version:     p.optionalString(block.Body.Attributes["version"]),
+		Comment:     p.optionalString(block.Body.Attributes["comment"]),
 	})
 	return nil
 }
@@ -390,8 +395,9 @@ func (p *parser) rejectUnsupportedExtensionAttrs(block *hclsyntax.Block) error {
 		return p.blockError(block.Body.Blocks[0], "unsupported extension block %q", block.Body.Blocks[0].Type)
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"version": true,
-		"comment": true,
+		"if_not_exists": true,
+		"version":       true,
+		"comment":       true,
 	}, "extension")
 }
 


### PR DESCRIPTION
## Summary

Closes another small HCL-loader parity gap (#684). Go extension annotations can request `IF NOT EXISTS` (`if_not_exists="true"`), but the HCL `extension` block only read `version` and `comment`, so the clause could not be expressed in HCL.

```hcl
extension "pg_trgm" {
  if_not_exists = true
  version       = "1.6"
}
```

now parses and renders `CREATE EXTENSION IF NOT EXISTS pg_trgm VERSION '1.6';`.

The extension IR (`goschema.Extension.IfNotExists`) and the renderer already emit `CREATE EXTENSION IF NOT EXISTS` — this was purely a loader gap. The bool is read with the same `boolAttr` helper the `sequence` block uses for its `if_not_exists`.

## Testing

- New `internal/atlashcl/extension_test.go`: `if_not_exists = true` (with render assertion), the default (absent) form, and a non-bool rejection.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API checks pass locally.