### PR TITLE
Support column check, unique_expr, and identity options in HCL (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -30,8 +30,9 @@ current schema IR:
 - `schema` labels and `comment`, for table namespace references such as
   `schema = schema.main`
 - `table` blocks
-- `column` blocks with `type`, `null`, `auto_increment`, `unique`, `default`,
-  `identity`, and `comment`
+- `column` blocks with `type`, `null`, `auto_increment`, `unique`,
+  `unique_expr`, `default`, `check`, `check_name`, `identity` (including its
+  `options`), and `comment`
 - `primary_key` blocks with `columns`; PostgreSQL primary keys also support
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
@@ -251,9 +252,10 @@ table "users" {
 ```
 
 `generated` accepts `ALWAYS` or `BY_DEFAULT`. When omitted, Ptah follows
-PostgreSQL and Atlas defaults and renders `BY DEFAULT`. Ptah currently supports
-the Atlas `start` and `increment` identity options in HCL input. Other identity
-block attributes are rejected instead of being silently dropped.
+PostgreSQL and Atlas defaults and renders `BY DEFAULT`. The identity block
+supports `start`, `increment`, and an `options` string for raw sequence options
+(rendered inside `GENERATED ... AS IDENTITY (...)`). Other identity block
+attributes are rejected instead of being silently dropped.
 
 ## PostgreSQL Schema Objects
 

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -55,7 +55,7 @@ table "users" {
 | --- | --- |
 | `schema` | Labels and comments for table namespace references. |
 | `table` | Table blocks with columns, primary keys, indexes, uniques, foreign keys, checks, and row security. |
-| `column` | `type`, `null`, `auto_increment`, `unique`, `default`, `identity`, and comments. |
+| `column` | `type`, `null`, `auto_increment`, `unique`, `unique_expr`, `default`, `check`, `check_name`, `identity` (with `options`), and comments. |
 | `primary_key` | `columns`; PostgreSQL also supports `include`. |
 | `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, and PostgreSQL include/storage options. |
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -317,6 +317,10 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		GeneratedExpression: generated.expression,
 		GeneratedKind:       generated.kind,
 		UpdateExpression:    p.optionalSQLExpression(block.Body.Attributes["on_update"]),
+		UniqueExpr:          p.optionalSQLExpression(block.Body.Attributes["unique_expr"]),
+		Check:               p.optionalSQLExpression(block.Body.Attributes["check"]),
+		CheckName:           p.optionalString(block.Body.Attributes["check_name"]),
+		IdentityOptions:     identity.options,
 		Charset:             p.optionalString(block.Body.Attributes["charset"]),
 		Collate:             p.optionalString(block.Body.Attributes["collate"]),
 		Comment:             p.optionalString(block.Body.Attributes["comment"]),
@@ -376,6 +380,7 @@ type identityColumnSpec struct {
 	generation string
 	start      string
 	increment  string
+	options    string
 }
 
 func (p *parser) parseIdentityColumn(block *hclsyntax.Block) (identityColumnSpec, error) {
@@ -413,6 +418,7 @@ func (p *parser) parseIdentityColumn(block *hclsyntax.Block) (identityColumnSpec
 		generation: generation,
 		start:      p.optionalString(identityBlock.Body.Attributes["start"]),
 		increment:  p.optionalString(identityBlock.Body.Attributes["increment"]),
+		options:    p.optionalString(identityBlock.Body.Attributes["options"]),
 	}, nil
 }
 
@@ -966,8 +972,11 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 		"null":           true,
 		"auto_increment": true,
 		"unique":         true,
+		"unique_expr":    true,
 		"default":        true,
 		"on_update":      true,
+		"check":          true,
+		"check_name":     true,
 		"as":             true,
 		"charset":        true,
 		"collate":        true,
@@ -994,6 +1003,7 @@ func (p *parser) rejectUnsupportedIdentityColumnAttrs(block *hclsyntax.Block) er
 		"generated": true,
 		"start":     true,
 		"increment": true,
+		"options":   true,
 	}, "column identity")
 }
 

--- a/internal/atlashcl/column_attrs_test.go
+++ b/internal/atlashcl/column_attrs_test.go
@@ -1,0 +1,88 @@
+package atlashcl_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseColumnCheck(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "age" {
+    type  = int
+    check = "age > 0"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].Check, qt.Equals, "age > 0")
+	c.Assert(db.Fields[0].CheckName, qt.Equals, "")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CHECK (age > 0)`)
+}
+
+func TestParseColumnCheckWithName(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "age" {
+    type       = int
+    check      = "age > 0"
+    check_name = "age_positive"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].CheckName, qt.Equals, "age_positive")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `CONSTRAINT age_positive CHECK (age > 0)`)
+}
+
+func TestParseColumnUniqueExpr(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "email" {
+    type        = text
+    unique_expr = "lower(email)"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].UniqueExpr, qt.Equals, "lower(email)")
+}
+
+func TestParseColumnIdentityOptions(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "id" {
+    type = bigint
+    identity {
+      generated = "ALWAYS"
+      options   = "START WITH 100 INCREMENT BY 5"
+    }
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].IdentityOptions, qt.Equals, "START WITH 100 INCREMENT BY 5")
+
+	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
+	c.Assert(sql, qt.Contains, `AS IDENTITY (START WITH 100 INCREMENT BY 5)`)
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -200,22 +200,20 @@ func (r *renderer) renderColumn(field goschema.Field) {
 		r.stringAttr(3, "type", field.GeneratedKind)
 		r.line("    }")
 	}
-	if field.IdentityGeneration != "" || field.IdentityStart != "" || field.IdentityIncrement != "" {
+	if field.IdentityGeneration != "" || field.IdentityStart != "" || field.IdentityIncrement != "" || field.IdentityOptions != "" {
 		r.line("    identity {")
 		r.stringAttr(3, "generated", field.IdentityGeneration)
 		r.stringAttr(3, "start", field.IdentityStart)
 		r.stringAttr(3, "increment", field.IdentityIncrement)
-		if field.IdentityOptions != "" {
-			r.warn("column "+field.StructName+"."+field.Name, "identity_options cannot be represented in HCL schema output")
-		}
+		r.stringAttr(3, "options", field.IdentityOptions)
 		r.line("    }")
+	}
+	if field.UniqueExpr != "" {
+		r.stringAttr(2, "unique_expr", field.UniqueExpr)
 	}
 	r.stringAttr(2, "charset", field.Charset)
 	r.stringAttr(2, "collate", field.Collate)
 	r.stringAttr(2, "comment", field.Comment)
-	if field.UniqueExpr != "" {
-		r.warn("column "+field.StructName+"."+field.Name, "unique expression cannot be represented as a column unique attribute")
-	}
 	r.line("  }")
 }
 

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/stokaro/ptah/internal/atlashclrender"
 )
 
+func TestRenderColumnUniqueExprAndIdentityOptionsRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{
+				StructName:         "T",
+				Name:               "id",
+				Type:               "bigint",
+				IdentityGeneration: "ALWAYS",
+				IdentityOptions:    "START WITH 100 INCREMENT BY 5",
+			},
+			{
+				StructName: "T",
+				Name:       "email",
+				Type:       "text",
+				UniqueExpr: "lower(email)",
+			},
+		},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, `options = "START WITH 100 INCREMENT BY 5"`)
+	c.Assert(hcl, qt.Contains, `unique_expr = "lower(email)"`)
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(fieldByName(parsed.Fields, "id").IdentityOptions, qt.Equals, "START WITH 100 INCREMENT BY 5")
+	c.Assert(fieldByName(parsed.Fields, "email").UniqueExpr, qt.Equals, "lower(email)")
+}
+
 func TestRenderTablesIndexesConstraintsAndDiagnostics(t *testing.T) {
 	c := qt.New(t)
 	falseValue := false


### PR DESCRIPTION
## Summary

Closes the remaining column-level parity gaps between Go annotations and the HCL loader (#684). Go field annotations can set a column CHECK (`check`/`check_name`), a custom unique expression (`unique_expr`), and raw identity sequence options (`identity_options`), none of which the HCL `column` block could express.

```hcl
column "age" {
  type       = int
  check      = "age > 0"
  check_name = "age_positive"
}

column "email" {
  type        = text
  unique_expr = "lower(email)"
}

column "id" {
  type = bigint
  identity {
    generated = "ALWAYS"
    options   = "START WITH 100 INCREMENT BY 5"
  }
}
```

## Parse

- column `check` / `check_name` → the field's inline CHECK (renders `CONSTRAINT <name> CHECK (...)` or a bare `CHECK (...)`).
- column `unique_expr` → the field's custom unique expression.
- the `identity` block gains an `options` attribute → `GENERATED ... AS IDENTITY (<options>)`.

## Export

The HCL exporter previously warned that `unique_expr` and `identity_options` "cannot be represented" — but this change makes both representable, so the exporter now emits them instead, and both round-trip through parse. Column checks already export as `check` blocks (unchanged); the column `check` attribute is an additional input form for the inline field CHECK.

## Testing

- New `internal/atlashcl/column_attrs_test.go`: `check` (+ render), `check` with `check_name` (+ render), `unique_expr` (IR), and identity `options` (+ render).
- New `internal/atlashclrender` round-trip test: a field with `unique_expr` and identity `options` renders to HCL and parses back to the same values.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API checks pass locally.