### PR TITLE
Recognize checkpoint migration files (#660)

### DIFF
--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -67,12 +67,24 @@ type MigrationFile struct {
 	// They are visible to discovery and linting, but they are not part of
 	// Ptah's ordered versioned execution model.
 	Repeatable bool
+	// IsCheckpoint marks a checkpoint migration whose up body is the full
+	// cumulative schema at its version. A fresh database bootstraps from the
+	// newest checkpoint instead of replaying pre-checkpoint history; an
+	// already-migrated database ignores it. The marker is spelled
+	// NNNNNNNNNN_description.checkpoint.(up|down).sql.
+	IsCheckpoint bool
 }
 
 // ParseMigrationFileName parses a migration filename into its components
 // Expected format: NNNNNNNNNN_description.up.sql or NNNNNNNNNN_description.down.sql
 // where NNNNNNNNNN is a 10-digit version number
 func ParseMigrationFileName(filename string) (*MigrationFile, error) {
+	// A checkpoint file carries a ".checkpoint" marker between the description
+	// and the direction (NNNN_desc.checkpoint.up.sql). Strip it before applying
+	// the ordinary name regex so existing up/down parsing is untouched, and
+	// remember it on the parsed file.
+	isCheckpoint, filename := stripCheckpointMarker(filename)
+
 	matches := fileNameRe.FindStringSubmatch(filename)
 
 	if matches == nil || len(matches) != 5 {
@@ -97,12 +109,28 @@ func ParseMigrationFileName(filename string) (*MigrationFile, error) {
 	extension := matches[4]
 
 	return &MigrationFile{
-		Version:   version,
-		Name:      name,
-		Direction: direction,
-		Extension: extension,
-		Format:    MigrationDirFormatPtah,
+		Version:      version,
+		Name:         name,
+		Direction:    direction,
+		Extension:    extension,
+		Format:       MigrationDirFormatPtah,
+		IsCheckpoint: isCheckpoint,
 	}, nil
+}
+
+// stripCheckpointMarker removes the ".checkpoint" marker that a checkpoint
+// migration carries immediately before its direction, returning whether the
+// marker was present and the filename with the marker removed so the ordinary
+// migration name regex can parse it. NNNN_desc.checkpoint.up.sql becomes
+// NNNN_desc.up.sql; a filename without the marker is returned unchanged.
+func stripCheckpointMarker(filename string) (bool, string) {
+	for _, direction := range []string{"up", "down"} {
+		marker := ".checkpoint." + direction + ".sql"
+		if stem, ok := strings.CutSuffix(filename, marker); ok {
+			return true, stem + "." + direction + ".sql"
+		}
+	}
+	return false, filename
 }
 
 // ParseAtlasMigrationFileName parses an Atlas versioned migration file name.

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -113,6 +113,45 @@ func TestParseMigrationFileName(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:     "checkpoint up migration",
+			filename: "0000000005_baseline.checkpoint.up.sql",
+			expected: &MigrationFile{
+				Version:      5,
+				Name:         "Baseline",
+				Direction:    "up",
+				Extension:    ".sql",
+				IsCheckpoint: true,
+			},
+			expectError: false,
+		},
+		{
+			name:     "checkpoint down migration",
+			filename: "0000000005_baseline.checkpoint.down.sql",
+			expected: &MigrationFile{
+				Version:      5,
+				Name:         "Baseline",
+				Direction:    "down",
+				Extension:    ".sql",
+				IsCheckpoint: true,
+			},
+			expectError: false,
+		},
+		{
+			// The checkpoint marker only counts immediately before the
+			// direction; a description that merely contains "checkpoint" is an
+			// ordinary migration.
+			name:     "description containing checkpoint is not a checkpoint",
+			filename: "0000000006_add_checkpoint_column.up.sql",
+			expected: &MigrationFile{
+				Version:      6,
+				Name:         "Add Checkpoint Column",
+				Direction:    "up",
+				Extension:    ".sql",
+				IsCheckpoint: false,
+			},
+			expectError: false,
+		},
+		{
 			// Only a literal dot separates description from direction: a
 			// lenient-separator pattern ([._]) must not sneak back in.
 			name:        "underscore before direction is not a separator",
@@ -162,6 +201,7 @@ func TestParseMigrationFileName(t *testing.T) {
 				c.Assert(result.Name, qt.Equals, tt.expected.Name)
 				c.Assert(result.Direction, qt.Equals, tt.expected.Direction)
 				c.Assert(result.Extension, qt.Equals, tt.expected.Extension)
+				c.Assert(result.IsCheckpoint, qt.Equals, tt.expected.IsCheckpoint)
 			}
 		})
 	}
@@ -340,6 +380,43 @@ func TestDiscoverMigrationFilesRecognizesAtlasImportedFlywayRepeatables(t *testi
 	c.Assert(files[1].Version, qt.Equals, int64(2))
 	c.Assert(files[2].Path, qt.Equals, "3_third_migration.sql")
 	c.Assert(files[2].Version, qt.Equals, int64(3))
+}
+
+func TestDiscoverMigrationFilesRecognizesCheckpoints(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_init.up.sql":                  &fstest.MapFile{Data: []byte("CREATE TABLE post (id INT);\n")},
+		"0000000001_init.down.sql":                &fstest.MapFile{Data: []byte("DROP TABLE post;\n")},
+		"0000000002_snapshot.checkpoint.up.sql":   &fstest.MapFile{Data: []byte("CREATE TABLE post (id INT, title TEXT);\n")},
+		"0000000002_snapshot.checkpoint.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE post;\n")},
+	}
+
+	files, err := DiscoverMigrationFiles(fsys, MigrationDirFormatPtah)
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.HasLen, 4)
+
+	initUp := migrationFileByPath(files, "0000000001_init.up.sql")
+	c.Assert(initUp.IsCheckpoint, qt.IsFalse)
+
+	checkpointUp := migrationFileByPath(files, "0000000002_snapshot.checkpoint.up.sql")
+	c.Assert(checkpointUp.IsCheckpoint, qt.IsTrue)
+	c.Assert(checkpointUp.Version, qt.Equals, int64(2))
+	c.Assert(checkpointUp.Direction, qt.Equals, "up")
+	c.Assert(checkpointUp.Name, qt.Equals, "Snapshot")
+
+	checkpointDown := migrationFileByPath(files, "0000000002_snapshot.checkpoint.down.sql")
+	c.Assert(checkpointDown.IsCheckpoint, qt.IsTrue)
+	c.Assert(checkpointDown.Direction, qt.Equals, "down")
+}
+
+func migrationFileByPath(files []MigrationFile, wantPath string) MigrationFile {
+	for _, f := range files {
+		if f.Path == wantPath {
+			return f
+		}
+	}
+	return MigrationFile{}
 }
 
 func TestDiscoverMigrationFilesAutoDetectsAtlasImportedNames(t *testing.T) {


### PR DESCRIPTION
## Summary

First step toward `ptah migrations checkpoint` (#660, advancing epic #654 — offering as open/local/no-account what Atlas keeps Pro-only). This teaches the migration-file discovery layer to **recognize** a checkpoint migration; it is recognition only, with no execution behavior change yet.

A checkpoint migration's up body is the full cumulative schema at its version. A fresh database will (in a later phase) bootstrap from the newest checkpoint instead of replaying pre-checkpoint history; an already-migrated database ignores it.

## File format

A checkpoint file carries a `.checkpoint` marker immediately before the direction:

```
0000000005_baseline.checkpoint.up.sql
0000000005_baseline.checkpoint.down.sql
```

`ParseMigrationFileName` strips this marker **before** applying the ordinary name regex, so existing `up`/`down` parsing (including edge cases like descriptions containing dots) is untouched, and records the result on the new `MigrationFile.IsCheckpoint` field. `DiscoverMigrationFiles` threads the flag through automatically because it delegates to `ParseMigrationFileName`.

The marker only counts immediately before the direction — a description that merely *contains* `checkpoint` (e.g. `0000000006_add_checkpoint_column.up.sql`) is an ordinary migration.

## Testing

- Extended `TestParseMigrationFileName` with checkpoint up/down cases, a "description containing checkpoint is not a checkpoint" case, and an `IsCheckpoint` assertion.
- New `TestDiscoverMigrationFilesRecognizesCheckpoints`: a directory with a checkpoint pair alongside an ordinary migration discovers all four files with the flag set correctly.
- `go build ./...`, `go vet`, `go test ./migration/...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API snapshot all pass locally.

## Next phases (tracked on #660)

Provider loading (`Migration.IsCheckpoint`), checkpoint-aware selection in the migrator (fresh-vs-existing DB), checkpoint generation via the shadow database, `ptah.sum` coverage, the `Checkpoint` migrator API, and the `ptah migrations checkpoint` CLI command.