### PR TITLE
Load checkpoint flag in the migration provider (#660)

### DIFF
--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -156,10 +156,11 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 		migrationFile := files[i]
 		if _, exists := migrationsMap[migrationFile.Version]; !exists {
 			migrationsMap[migrationFile.Version] = &Migration{
-				Version:     migrationFile.Version,
-				Description: migrationFile.Name,
-				Up:          NoopMigrationFunc,
-				Down:        NoopMigrationFunc,
+				Version:      migrationFile.Version,
+				Description:  migrationFile.Name,
+				Up:           NoopMigrationFunc,
+				Down:         NoopMigrationFunc,
+				IsCheckpoint: migrationFile.IsCheckpoint,
 			}
 			foundFiles[migrationFile.Version] = make(map[string]bool)
 		}
@@ -167,6 +168,11 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 		foundFiles[migrationFile.Version][migrationFile.Direction] = true
 
 		migration := migrationsMap[migrationFile.Version]
+		// The up and down halves of one version must agree on whether they are
+		// a checkpoint; a mixed pair is a malformed directory.
+		if migration.IsCheckpoint != migrationFile.IsCheckpoint {
+			return fmt.Errorf("migration version %d mixes checkpoint and non-checkpoint files", migrationFile.Version)
+		}
 		switch migrationFile.Direction {
 		case "up":
 			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -187,6 +187,47 @@ func TestRegisteredMigrationProvider_ConcurrentRegisterAndMigrations(t *testing.
 	c.Assert(provider.Migrations(), qt.HasLen, workers*iterations)
 }
 
+func TestNewFSMigrationProvider_LoadsCheckpoint(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_init.up.sql":                  &fstest.MapFile{Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY);")},
+		"0000000001_init.down.sql":                &fstest.MapFile{Data: []byte("DROP TABLE users;")},
+		"0000000002_snapshot.checkpoint.up.sql":   &fstest.MapFile{Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);")},
+		"0000000002_snapshot.checkpoint.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE users;")},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 2)
+	c.Assert(findMigrationByVersion(migrations, 1).IsCheckpoint, qt.IsFalse)
+	c.Assert(findMigrationByVersion(migrations, 2).IsCheckpoint, qt.IsTrue)
+	c.Assert(findMigrationByVersion(migrations, 2).Description, qt.Equals, "Snapshot")
+}
+
+func TestNewFSMigrationProvider_RejectsMixedCheckpointPair(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000002_snapshot.checkpoint.up.sql": &fstest.MapFile{Data: []byte("CREATE TABLE users (id SERIAL PRIMARY KEY);")},
+		"0000000002_snapshot.down.sql":          &fstest.MapFile{Data: []byte("DROP TABLE users;")},
+	}
+
+	_, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.ErrorMatches, `.*mixes checkpoint and non-checkpoint files.*`)
+}
+
+func findMigrationByVersion(migrations []*migrator.Migration, version int64) *migrator.Migration {
+	for _, m := range migrations {
+		if m.Version == version {
+			return m
+		}
+	}
+	return &migrator.Migration{}
+}
+
 func TestNewFSMigrationProvider_Success(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -376,6 +376,12 @@ type Migration struct {
 	// per-migration transaction. Execution uses the direction-specific fields.
 	NoTransaction                bool
 	directionalNoTransactionMode bool
+	// IsCheckpoint marks a checkpoint migration whose up body is the full
+	// cumulative schema at its version. On a fresh database the migrator
+	// bootstraps from the newest checkpoint and records all lower versions as
+	// applied instead of replaying them; an already-migrated database ignores
+	// the checkpoint and applies history normally.
+	IsCheckpoint bool
 }
 
 func (m *Migration) upExecutionMode() migrationExecutionMode {


### PR DESCRIPTION
## Summary

Second step toward `ptah migrations checkpoint` (#660). Phase 1 (#719) taught discovery to *recognize* a checkpoint file; this carries that marker through to the loaded `Migration`.

A checkpoint gets its **own version** (higher than the history it squashes), so it coexists with the ordinary migrations in one directory without a version collision. `loadPtah` now:

- sets `Migration.IsCheckpoint` from the discovered file, and
- rejects a version whose up and down halves disagree on whether they are a checkpoint (`migration version N mixes checkpoint and non-checkpoint files`) — a malformed pair.

Still **no execution behavior change**: the flag is loaded but not yet consulted by the up/down planner. That is Phase 3 (checkpoint-aware selection), which will get a full adversarial review as the risky core.

## Testing

- `TestNewFSMigrationProvider_LoadsCheckpoint`: a checkpoint pair (version 2) coexists with an ordinary migration (version 1); only the checkpoint's `Migration` has `IsCheckpoint` set.
- `TestNewFSMigrationProvider_RejectsMixedCheckpointPair`: a checkpoint up + ordinary down at one version is rejected.
- `go build ./...`, `go vet`, `go test ./migration/...`, golangci-lint v2.12.2, qtlint, teststyle pass locally.