### PR TITLE
Bootstrap from checkpoints in the up planner (#660)

### DIFF
--- a/migration/migrator/checkpoint_selection_internal_test.go
+++ b/migration/migrator/checkpoint_selection_internal_test.go
@@ -1,0 +1,126 @@
+package migrator
+
+// White-box testing required: this file exercises the unexported checkpoint
+// selection helpers (checkpointBootstrap, checkpointFloor, checkpointRunnable,
+// and the checkpoint-aware pending computation) that determine which migrations
+// run, which are not observable through the public migrator API alone.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func checkpointMig(version int64, isCheckpoint bool) *Migration {
+	return &Migration{Version: version, IsCheckpoint: isCheckpoint}
+}
+
+// A representative directory: ordinary history at 1,2,3, a checkpoint at 5, and
+// post-checkpoint history at 7,9.
+func checkpointSampleMigrations() []*Migration {
+	return []*Migration{
+		checkpointMig(1, false),
+		checkpointMig(2, false),
+		checkpointMig(3, false),
+		checkpointMig(5, true),
+		checkpointMig(7, false),
+		checkpointMig(9, false),
+	}
+}
+
+func TestCheckpointBootstrap_FreshDatabasePicksNewestCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	migrations := []*Migration{
+		checkpointMig(1, false),
+		checkpointMig(5, true),
+		checkpointMig(8, true),
+		checkpointMig(9, false),
+	}
+	bootstrap := checkpointBootstrap(migrations, nil, 0)
+	c.Assert(bootstrap, qt.IsNotNil)
+	c.Assert(bootstrap.Version, qt.Equals, int64(8))
+}
+
+func TestCheckpointBootstrap_ExistingDatabaseNeverBootstraps(t *testing.T) {
+	c := qt.New(t)
+	bootstrap := checkpointBootstrap(checkpointSampleMigrations(), []int64{1}, 0)
+	c.Assert(bootstrap, qt.IsNil)
+}
+
+func TestCheckpointBootstrap_TargetExcludesNewerCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	migrations := []*Migration{
+		checkpointMig(5, true),
+		checkpointMig(8, true),
+	}
+	bootstrap := checkpointBootstrap(migrations, nil, 6)
+	c.Assert(bootstrap, qt.IsNotNil)
+	c.Assert(bootstrap.Version, qt.Equals, int64(5))
+}
+
+func TestCheckpointBootstrap_NoCheckpointReturnsNil(t *testing.T) {
+	c := qt.New(t)
+	migrations := []*Migration{checkpointMig(1, false), checkpointMig(2, false)}
+	c.Assert(checkpointBootstrap(migrations, nil, 0), qt.IsNil)
+}
+
+func TestCheckpointFloor_BootstrapVersion(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	bootstrap := checkpointBootstrap(migrations, nil, 0)
+	c.Assert(checkpointFloor(migrations, nil, bootstrap), qt.Equals, int64(5))
+}
+
+func TestCheckpointFloor_HighestAppliedCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	// Existing database with the checkpoint applied: no bootstrap, floor is the
+	// applied checkpoint version.
+	floor := checkpointFloor(migrations, []int64{5, 7}, nil)
+	c.Assert(floor, qt.Equals, int64(5))
+}
+
+func TestCheckpointFloor_NoAppliedCheckpointIsZero(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	// History applied normally, checkpoint file present but never run.
+	c.Assert(checkpointFloor(migrations, []int64{1, 2}, nil), qt.Equals, int64(0))
+}
+
+func TestPendingMigrationVersions_FreshDatabaseBootstrapsAndSkipsSquashed(t *testing.T) {
+	c := qt.New(t)
+	pending := pendingMigrationVersions(checkpointSampleMigrations(), nil)
+	// The checkpoint (5) plus post-checkpoint history (7, 9); squashed 1,2,3 are
+	// not pending.
+	c.Assert(pending, qt.DeepEquals, []int64{5, 7, 9})
+}
+
+func TestPendingMigrationVersions_ExistingDatabaseIgnoresCheckpointAndSquashed(t *testing.T) {
+	c := qt.New(t)
+	// Bootstrapped earlier: checkpoint 5 is applied. Only genuinely new
+	// post-checkpoint migrations are pending; the checkpoint and squashed
+	// history are not.
+	pending := pendingMigrationVersions(checkpointSampleMigrations(), []int64{5})
+	c.Assert(pending, qt.DeepEquals, []int64{7, 9})
+}
+
+func TestPendingMigrationVersions_NormalHistoryIgnoresUnrunCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	// Database migrated through ordinary history (1,2,3 applied) with a
+	// checkpoint file present but never run. The checkpoint is not pending and
+	// nothing below it is squashed.
+	pending := pendingMigrationVersions(checkpointSampleMigrations(), []int64{1, 2, 3})
+	c.Assert(pending, qt.DeepEquals, []int64{7, 9})
+}
+
+func TestCheckpointRunnable(t *testing.T) {
+	c := qt.New(t)
+	bootstrap := checkpointMig(5, true)
+	otherCheckpoint := checkpointMig(8, true)
+	// Only the bootstrap checkpoint runs.
+	c.Assert(checkpointRunnable(bootstrap, bootstrap, 5), qt.IsTrue)
+	c.Assert(checkpointRunnable(otherCheckpoint, bootstrap, 5), qt.IsFalse)
+	// Ordinary migration below the floor is squashed; at or above runs.
+	c.Assert(checkpointRunnable(checkpointMig(3, false), bootstrap, 5), qt.IsFalse)
+	c.Assert(checkpointRunnable(checkpointMig(7, false), bootstrap, 5), qt.IsTrue)
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1747,7 +1747,9 @@ func ensureNoTransactionHasNoTimeouts(version int64, timeouts MigrationTimeouts)
 
 func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, targetVersion int64) ([]*Migration, error) {
 	currentVersion := maxAppliedVersion(applied)
-	pendingVersions := pendingMigrationVersions(migrations, applied)
+	bootstrap := checkpointBootstrap(migrations, applied, targetVersion)
+	floor := checkpointFloor(migrations, applied, bootstrap)
+	pendingVersions := pendingMigrationVersionsFloored(migrations, applied, bootstrap, floor)
 	outOfOrderVersions := outOfOrderMigrationVersions(pendingVersions, currentVersion)
 	execOrder := normalizeExecOrder(m.execOrder)
 
@@ -1758,6 +1760,9 @@ func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, t
 	appliedSet := versionSet(applied)
 	migrationsToApply := make([]*Migration, 0, len(pendingVersions))
 	for _, migration := range migrations {
+		if !checkpointRunnable(migration, bootstrap, floor) {
+			continue
+		}
 		if _, ok := appliedSet[migration.Version]; ok {
 			continue
 		}
@@ -1774,10 +1779,78 @@ func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, t
 	return migrationsToApply, nil
 }
 
+// checkpointBootstrap returns the newest checkpoint the migrator runs to
+// bootstrap a fresh database, or nil. A checkpoint only bootstraps a database
+// with no applied migrations; an already-migrated database never runs one.
+func checkpointBootstrap(migrations []*Migration, applied []int64, targetVersion int64) *Migration {
+	if len(applied) != 0 {
+		return nil
+	}
+	var best *Migration
+	for _, migration := range migrations {
+		if !migration.IsCheckpoint {
+			continue
+		}
+		if targetVersion > 0 && migration.Version > targetVersion {
+			continue
+		}
+		if best == nil || migration.Version > best.Version {
+			best = migration
+		}
+	}
+	return best
+}
+
+// checkpointFloor returns the version below which migrations are squashed by a
+// checkpoint and must not be applied individually: the bootstrap checkpoint's
+// version on a fresh database, otherwise the highest applied checkpoint's
+// version (0 when no checkpoint applies).
+func checkpointFloor(migrations []*Migration, applied []int64, bootstrap *Migration) int64 {
+	if bootstrap != nil {
+		return bootstrap.Version
+	}
+	appliedSet := versionSet(applied)
+	var floor int64
+	for _, migration := range migrations {
+		if !migration.IsCheckpoint {
+			continue
+		}
+		if _, ok := appliedSet[migration.Version]; ok && migration.Version > floor {
+			floor = migration.Version
+		}
+	}
+	return floor
+}
+
+// checkpointRunnable reports whether a migration is eligible to run given the
+// checkpoint bootstrap decision. Only the bootstrap checkpoint runs; other
+// checkpoints never do, and ordinary migrations below the squash floor are
+// covered by the checkpoint and skipped.
+func checkpointRunnable(migration *Migration, bootstrap *Migration, floor int64) bool {
+	if migration.IsCheckpoint {
+		return migration == bootstrap
+	}
+	return migration.Version >= floor
+}
+
 func pendingMigrationVersions(migrations []*Migration, applied []int64) []int64 {
+	bootstrap := checkpointBootstrap(migrations, applied, 0)
+	floor := checkpointFloor(migrations, applied, bootstrap)
+	return pendingMigrationVersionsFloored(migrations, applied, bootstrap, floor)
+}
+
+// pendingMigrationVersionsFloored computes the versions that would be applied
+// next given a checkpoint bootstrap decision: the bootstrap checkpoint (on a
+// fresh database) plus any ordinary migration at or above the squash floor that
+// is not yet applied. Squashed history and non-bootstrap checkpoints are not
+// pending.
+func pendingMigrationVersionsFloored(migrations []*Migration, applied []int64, bootstrap *Migration, floor int64) []int64 {
 	appliedSet := versionSet(applied)
 	pending := make([]int64, 0, len(migrations))
 	for _, migration := range migrations {
+		if !checkpointRunnable(migration, bootstrap, floor) {
+			continue
+		}
 		if _, ok := appliedSet[migration.Version]; ok {
 			continue
 		}


### PR DESCRIPTION
## Summary

Third step toward `ptah migrations checkpoint` (#660) and the behavior-changing core: the up planner now bootstraps a **fresh** database from the newest checkpoint and skips the history the checkpoint squashes, while an **already-migrated** database ignores checkpoints entirely.

## Design: crash-safe, no separate baseline rows

Rather than executing the checkpoint and then atomically writing baseline revision rows for every squashed version (which risks a broken state if the process dies between the two), the "squashed" status is **derived** from the checkpoint's own applied state:

- The checkpoint executes through the existing per-migration transaction machinery, recording only its own revision row atomically.
- Selection/status treat any version below the bootstrap (or highest applied) checkpoint as covered, so squashed history is never attempted.

This is fully crash-safe and requires no new transaction/recording code.

## Behavior

| State | Result |
| --- | --- |
| Fresh DB, checkpoint present | run newest checkpoint + post-checkpoint history; squashed history skipped |
| DB bootstrapped from a checkpoint | checkpoint already applied → only genuinely new post-checkpoint migrations pending |
| DB migrated through ordinary history, checkpoint file never run | checkpoint ignored, nothing squashed |
| No checkpoints | floor is 0 — behavior unchanged |

Three pure helpers — `checkpointBootstrap`, `checkpointFloor`, `checkpointRunnable` — encode this, and both `migrationsToApply` and the shared `pendingMigrationVersions` use them so `up`, `status`, and pending stay consistent.

## Scope

Up-path selection only. Down/rollback-below-checkpoint guard, checkpoint generation (shadow snapshot), `ptah.sum` coverage, the `Checkpoint` migrator API, and the CLI command are later phases on #660.

## Testing

- New `checkpoint_selection_internal_test.go` (11 tests): bootstrap picks the newest checkpoint / never on an existing DB / respects a target; floor from bootstrap vs highest-applied-checkpoint vs none; pending on a fresh DB (checkpoint + post, squashed skipped), on a bootstrapped DB, and on ordinary history with an unrun checkpoint; `checkpointRunnable` truth table.
- Existing migrator/provider/discovery tests still pass (no regression with no checkpoints present).
- `go build ./...`, `go vet`, `go test ./migration/...`, golangci-lint v2.12.2, qtlint, teststyle pass locally.