### PR TITLE
Block rollback below a checkpoint boundary (#660)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -740,6 +740,7 @@ type BaselineOptions struct{ ... }
 type Check struct{ ... }
     func ParseChecks(sql string) ([]Check, error)
 type CheckFailedError struct{ ... }
+type CheckpointRollbackError struct{ ... }
 type ChecksumMismatchError struct{ ... }
 type DirtyMigrationError struct{ ... }
 type ExecOrder string

--- a/migration/migrator/checkpoint_selection_internal_test.go
+++ b/migration/migrator/checkpoint_selection_internal_test.go
@@ -113,6 +113,33 @@ func TestPendingMigrationVersions_NormalHistoryIgnoresUnrunCheckpoint(t *testing
 	c.Assert(pending, qt.DeepEquals, []int64{7, 9})
 }
 
+func TestCheckpointRollbackBoundary_BlocksBelowAppliedCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	// Bootstrapped DB (checkpoint 5 applied). Rolling back to a squashed
+	// version is blocked and reports the checkpoint boundary.
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{5, 7}, 3), qt.Equals, int64(5))
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{5, 7}, 4), qt.Equals, int64(5))
+}
+
+func TestCheckpointRollbackBoundary_AllowsCheckpointAndTeardown(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	// Rolling back to the checkpoint version itself is allowed.
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{5, 7}, 5), qt.Equals, int64(0))
+	// A full teardown (target 0) is allowed.
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{5, 7}, 0), qt.Equals, int64(0))
+	// A target above the checkpoint is allowed.
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{5, 7, 9}, 7), qt.Equals, int64(0))
+}
+
+func TestCheckpointRollbackBoundary_NoCheckpointAllows(t *testing.T) {
+	c := qt.New(t)
+	migrations := checkpointSampleMigrations()
+	// Ordinary history with no applied checkpoint: rollback is never blocked.
+	c.Assert(checkpointRollbackBoundary(migrations, []int64{1, 2, 3}, 1), qt.Equals, int64(0))
+}
+
 func TestCheckpointRunnable(t *testing.T) {
 	c := qt.New(t)
 	bootstrap := checkpointMig(5, true)

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -126,6 +126,21 @@ func (e *AtlasDownNotImplementedError) Error() string {
 	)
 }
 
+// CheckpointRollbackError reports a rollback that targets a version below an
+// applied checkpoint. The checkpoint squashed the intermediate history into a
+// single snapshot, so that state cannot be reconstructed by rolling back.
+type CheckpointRollbackError struct {
+	TargetVersion     int64
+	CheckpointVersion int64
+}
+
+func (e *CheckpointRollbackError) Error() string {
+	return fmt.Sprintf(
+		"cannot roll back to version %d: it is below checkpoint %d, whose squashed history cannot be reconstructed; roll back to version %d (the checkpoint) or to 0 (drop everything) instead",
+		e.TargetVersion, e.CheckpointVersion, e.CheckpointVersion,
+	)
+}
+
 // MigrationFuncFromSQLFilename returns a migration function that reads SQL from a file
 // in the provided filesystem and executes it using the database connection
 func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1032,6 +1032,10 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64,
 		return nil
 	}
 
+	if boundary := checkpointRollbackBoundary(m.migrationProvider.Migrations(), appliedMigrations, targetVersion); boundary > 0 {
+		return &CheckpointRollbackError{TargetVersion: targetVersion, CheckpointVersion: boundary}
+	}
+
 	migrationMap := migrationsByVersion(m.migrationProvider.Migrations())
 	if err := m.verifyAppliedMigrationChecksums(ctx, m.migrationProvider.Migrations()); err != nil {
 		return err
@@ -1831,6 +1835,23 @@ func checkpointRunnable(migration *Migration, bootstrap *Migration, floor int64)
 		return migration == bootstrap
 	}
 	return migration.Version >= floor
+}
+
+// checkpointRollbackBoundary returns the applied checkpoint version that blocks
+// a rollback to targetVersion, or 0 when the rollback is allowed. A checkpoint
+// squashes the history below its version into a single snapshot, so rolling
+// back to a version between 1 and that boundary cannot reconstruct the
+// intermediate pre-checkpoint state. Rolling back to the checkpoint version
+// itself, or all the way to 0 (drop everything), stays allowed.
+func checkpointRollbackBoundary(migrations []*Migration, applied []int64, targetVersion int64) int64 {
+	if targetVersion <= 0 {
+		return 0
+	}
+	boundary := checkpointFloor(migrations, applied, nil)
+	if boundary > 0 && targetVersion < boundary {
+		return boundary
+	}
+	return 0
 }
 
 func pendingMigrationVersions(migrations []*Migration, applied []int64) []int64 {


### PR DESCRIPTION
## Summary

Adds the rollback safety guard for `ptah migrations checkpoint` (#660). A checkpoint squashes the history below its version into a single snapshot, so an intermediate pre-checkpoint state cannot be reconstructed by rolling back. Rolling `migrations down` to a version between 1 and an applied checkpoint's version now fails with a clear `CheckpointRollbackError` instead of silently dropping the whole schema via the checkpoint's down.

| `down --target` | Result |
| --- | --- |
| below an applied checkpoint (1 ≤ target < checkpoint) | **error** — squashed state cannot be reconstructed |
| the checkpoint version itself | allowed — rolls back post-checkpoint history, keeps the snapshot |
| 0 (drop everything) | allowed |
| any target when no checkpoint is applied | unaffected |

The boundary is derived by the pure `checkpointRollbackBoundary` helper (reusing the already-reviewed `checkpointFloor`), so the guard is unit-testable without a database.

## Testing

- New unit tests: blocked below an applied checkpoint (reports the boundary), allowed at the checkpoint / teardown / above-checkpoint, and never blocked with no applied checkpoint.
- Exported `CheckpointRollbackError` (consistent with the existing `AtlasDownNotImplementedError`); `docs/public_api.snapshot` updated.
- `go build ./...`, `go vet`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and both public-API checks pass locally.

## Remaining #660 phases

Checkpoint generation (shadow-DB snapshot), `ptah.sum` coverage, the `Checkpoint` migrator API, and the `ptah migrations checkpoint` CLI command.