### PR TITLE
Cover checkpoint files in ptah.sum integrity (#660)

### DIFF
--- a/internal/migratesum/sum.go
+++ b/internal/migratesum/sum.go
@@ -56,8 +56,9 @@ type SumFile struct {
 }
 
 // Compute walks fsys and builds the sum over every migration file the
-// migrator recognizes (NNNNNNNNNN_description.(up|down).sql), so the checksum
-// covers exactly what `ptah migrations up` and `ptah migrations down` execute. The ptah.sum file itself
+// migrator recognizes (NNNNNNNNNN_description.(up|down).sql, including the
+// .checkpoint. variant), so the checksum covers exactly what `ptah migrations
+// up` and `ptah migrations down` execute. The ptah.sum file itself
 // and any non-migration file are excluded.
 func Compute(fsys fs.FS) (*SumFile, error) {
 	return ComputeWithFormat(fsys, migrator.MigrationDirFormatAuto)

--- a/internal/migratesum/sum_test.go
+++ b/internal/migratesum/sum_test.go
@@ -3,6 +3,7 @@ package migratesum_test
 import (
 	"bytes"
 	"encoding/base64"
+	"maps"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -51,6 +52,36 @@ func TestCompute_HashesOnlyMigrationFilesSortedByName(t *testing.T) {
 		"nested/0000000004_x.up.sql",
 	}, qt.Commentf("only recognized migration files, sorted; README/ptah.sum/.txt excluded"))
 	c.Assert(sum.DirHash, qt.Matches, "h1:.+")
+}
+
+func TestCompute_CoversCheckpointFiles(t *testing.T) {
+	c := qt.New(t)
+
+	base := map[string]string{
+		"0000000001_init.up.sql":                  "CREATE TABLE t (id INT);\n",
+		"0000000001_init.down.sql":                "DROP TABLE t;\n",
+		"0000000002_snapshot.checkpoint.up.sql":   "CREATE TABLE t (id INT, name TEXT);\n",
+		"0000000002_snapshot.checkpoint.down.sql": "DROP TABLE t;\n",
+	}
+
+	sum, err := migratesum.Compute(fixture(base))
+	c.Assert(err, qt.IsNil)
+
+	var names []string
+	for _, e := range sum.Entries {
+		names = append(names, e.Name)
+	}
+	// A checkpoint pair is integrity-protected exactly like ordinary
+	// migrations, so a tampered checkpoint fails `ptah migrations validate`.
+	c.Assert(names, qt.Contains, "0000000002_snapshot.checkpoint.up.sql")
+	c.Assert(names, qt.Contains, "0000000002_snapshot.checkpoint.down.sql")
+
+	tampered := make(map[string]string, len(base))
+	maps.Copy(tampered, base)
+	tampered["0000000002_snapshot.checkpoint.up.sql"] = "CREATE TABLE t (id INT, name TEXT, extra INT);\n"
+	tamperedSum, err := migratesum.Compute(fixture(tampered))
+	c.Assert(err, qt.IsNil)
+	c.Assert(tamperedSum.DirHash, qt.Not(qt.Equals), sum.DirHash)
 }
 
 func TestComputeWithFormat_HashesAtlasMigrationFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Pins a `ptah migrations checkpoint` acceptance criterion (#660): a checkpoint migration must be integrity-protected exactly like an ordinary migration, so a tampered checkpoint fails `ptah migrations validate`.

This already holds — `migratesum.Compute` discovers files through `migrator.DiscoverMigrationFiles`, which (since #719) recognizes the `.checkpoint.` variant, so checkpoint files are hashed into `ptah.sum` automatically. This PR locks that in with a regression test and documents it in the `Compute` doc comment, so a future change to file discovery can't silently drop checkpoint coverage.

## Testing

- New `TestCompute_CoversCheckpointFiles`: a checkpoint `.up`/`.down` pair appears in the sum entries alongside ordinary migrations, and tampering with a checkpoint body changes the directory hash (which `validate` would reject).
- `go build ./...`, `go test ./internal/migratesum/...`, golangci-lint v2.12.2, qtlint, teststyle pass locally.