### PR TITLE
Match Atlas unknown-subcommand diagnostics on compatibility CLIs (#725)

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -54,6 +54,26 @@ var unsupportedAtlasDirFormats = []string{
 	"liquibase",
 }
 
+// atlasUnknownCommandArgs is the positional-args validator for an
+// Atlas-compatible command group. A stray positional argument on a group means
+// an unknown subcommand, so it emits Atlas CE's cobra-style diagnostic
+//
+//	Error: unknown command "<arg>" for "<command path>"
+//	Run '<command path> --help' for usage.
+//
+// on stderr and fails, instead of the native "unexpected positional arguments"
+// message. The unknown token is quoted with %q exactly as cobra (and therefore
+// Atlas) does. The command's error-code policy maps the failure to Atlas's
+// exit code 1; native Ptah commands keep NoPositionalArgs and are unaffected.
+func atlasUnknownCommandArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	path := cmd.CommandPath()
+	fmt.Fprintf(cmd.ErrOrStderr(), "Error: unknown command %q for %q\nRun '%s --help' for usage.\n", args[0], path, path)
+	return exitcode.New(atlasErrorExitCode, fmt.Errorf("unknown command %q for %q", args[0], path))
+}
+
 // NewAtlasCommand returns the Atlas command namespace.
 func NewAtlasCommand() *cobra.Command {
 	cmd := newAtlasCommand("atlas [command]", "Atlas OSS command namespace", `Atlas OSS command namespace.
@@ -90,7 +110,7 @@ func newAtlasCommand(use, short, long string) *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
 	cmd.AddCommand(newAtlasVersionCommand())
 	cmd.AddCommand(newAtlasLicenseCommand())
 	cmd.AddCommand(newAtlasSchemaCommand())
@@ -107,7 +127,7 @@ func newAtlasSchemaCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
 	registerAtlasProjectFlags(cmd.PersistentFlags(), &atlasProjectFlagValues{})
 	cmd.AddCommand(newAtlasSchemaCleanCommand())
 	cmd.AddCommand(newAtlasSchemaInspectCommand())
@@ -130,7 +150,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
+	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
 	registerAtlasProjectFlags(cmd.PersistentFlags(), &atlasProjectFlagValues{})
 	cmd.AddCommand(newAtlasMigrateApplyCommand())
 	cmd.AddCommand(newAtlasMigrateLintCommand())

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -200,9 +200,10 @@ func TestNewCompatCommand_UnknownNestedCommandFails(t *testing.T) {
 
 	err := executeAtlasCommandForTest(cmd)
 
-	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["aplly"\]`)
+	c.Assert(err, qt.ErrorMatches, `unknown command "aplly" for "ptah-compat migrate"`)
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `error: unexpected positional arguments ["aplly"]`)
+	c.Assert(out.String(), qt.Contains, `Error: unknown command "aplly" for "ptah-compat migrate"`)
+	c.Assert(out.String(), qt.Contains, `Run 'ptah-compat migrate --help' for usage.`)
 }
 
 func TestNewAtlasCommand_UnknownNestedCommandFails(t *testing.T) {
@@ -215,9 +216,10 @@ func TestNewAtlasCommand_UnknownNestedCommandFails(t *testing.T) {
 
 	err := executeAtlasCommandForTest(cmd)
 
-	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["aplly"\]`)
+	c.Assert(err, qt.ErrorMatches, `unknown command "aplly" for "atlas migrate"`)
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `error: unexpected positional arguments ["aplly"]`)
+	c.Assert(out.String(), qt.Contains, `Error: unknown command "aplly" for "atlas migrate"`)
+	c.Assert(out.String(), qt.Contains, `Run 'atlas migrate --help' for usage.`)
 }
 
 // TestNewAtlasCommand_UnknownTopLevelCommandFails guards #687: `ptah atlas
@@ -233,8 +235,10 @@ func TestNewAtlasCommand_UnknownTopLevelCommandFails(t *testing.T) {
 
 	err := executeAtlasCommandForTest(cmd)
 
-	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["definitely-not-a-command"\]`)
+	c.Assert(err, qt.ErrorMatches, `unknown command "definitely-not-a-command" for "atlas"`)
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(out.String(), qt.Contains, `Error: unknown command "definitely-not-a-command" for "atlas"`)
+	c.Assert(out.String(), qt.Contains, `Run 'atlas --help' for usage.`)
 }
 
 func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
@@ -247,8 +251,31 @@ func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
 
 	err := executeAtlasCommandForTest(cmd)
 
-	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, `unknown command "definitely-not-a-command" for "ptah-compat"`)
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(out.String(), qt.Contains, `Error: unknown command "definitely-not-a-command" for "ptah-compat"`)
+	c.Assert(out.String(), qt.Contains, `Run 'ptah-compat --help' for usage.`)
+}
+
+func TestAtlasUnknownCommandArgs_ConstructionAndQuoting(t *testing.T) {
+	c := qt.New(t)
+	cmd := NewAtlasCommand() // standalone command path is "atlas"
+	var out bytes.Buffer
+	cmd.SetErr(&out)
+
+	// No positional argument is not an unknown command.
+	c.Assert(atlasUnknownCommandArgs(cmd, nil), qt.IsNil)
+	c.Assert(out.String(), qt.Equals, "")
+
+	// The unknown token is quoted (and escaped) with %q exactly as cobra/Atlas.
+	err := atlasUnknownCommandArgs(cmd, []string{`a"b`, "ignored"})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, `unknown command "a\"b" for "atlas"`)
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+
+	want := `Error: unknown command "a\"b" for "atlas"` + "\n" +
+		`Run 'atlas --help' for usage.` + "\n"
+	c.Assert(out.String(), qt.Equals, want)
 }
 
 func TestNewAtlasCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -61,6 +61,14 @@ func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 			},
 			wantStderr: "error: unknown command \"extra\" for \"atlas completion bash\"\n",
 		},
+		{
+			name: "unknown root command",
+			command: func(binPath string) *exec.Cmd {
+				return exec.Command(binPath, "definitely-not-a-command")
+			},
+			wantStderr: "Error: unknown command \"definitely-not-a-command\" for \"atlas\"\n" +
+				"Run 'atlas --help' for usage.\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/ptah/main_test.go
+++ b/cmd/ptah/main_test.go
@@ -29,6 +29,25 @@ func TestPtahAtlasChecksumMismatchMatchesAtlasStreams(t *testing.T) {
 	c.Assert(stderr.String(), qt.Equals, "Error: checksum mismatch\n")
 }
 
+func TestPtahAtlasUnknownCommandMatchesAtlasDiagnostic(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildPtahBinary(c)
+
+	run := exec.Command(binPath, "atlas", "definitely-not-a-command")
+	var stdout, stderr bytes.Buffer
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+	err := run.Run()
+	var exitErr *exec.ExitError
+
+	c.Assert(err, qt.ErrorAs, &exitErr)
+	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+	c.Assert(stdout.String(), qt.Equals, "")
+	c.Assert(stderr.String(), qt.Equals,
+		"Error: unknown command \"definitely-not-a-command\" for \"ptah atlas\"\n"+
+			"Run 'ptah atlas --help' for usage.\n")
+}
+
 func buildPtahBinary(c *qt.C) string {
 	c.Helper()
 	binPath := filepath.Join(c.TempDir(), "ptah")

--- a/cmd/root/root_internal_test.go
+++ b/cmd/root/root_internal_test.go
@@ -195,7 +195,7 @@ func TestZZZAtlasUsageErrorsExit1WithoutUsage(t *testing.T) {
 		{
 			name:       "lazy completion command",
 			args:       []string{"atlas", "completion", "bash", "extra"},
-			wantStderr: "error: unexpected positional arguments [\"completion\" \"bash\" \"extra\"]\n",
+			wantStderr: "Error: unknown command \"completion\" for \"ptah atlas\"\nRun 'ptah atlas --help' for usage.\n",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes the diagnostic-text gap in #725. `ptah atlas` and `ptah-compat` already exit `1` for an unknown root subcommand, but printed Ptah's generic `error: unexpected positional arguments [...]` instead of Atlas CE's cobra-style unknown-command diagnostic:

```text
Error: unknown command "definitely-not-a-command" for "atlas"
Run 'atlas --help' for usage.
```

## Change

A new `atlasUnknownCommandArgs` positional-args validator emits the Atlas message — quoting the unknown token with `%q` exactly as cobra (and therefore Atlas) does — and is wired into the three Atlas command **groups** (root, `schema`, `migrate`) in place of `NoPositionalArgs`. So unknown commands at any Atlas level (`ptah atlas foo`, `ptah atlas migrate foo`) match Atlas.

- exit stays `1` (existing error-code policy), stdout stays empty, message on stderr
- the command path comes from `cmd.CommandPath()`, so the `ptah-compat` binary (named `atlas`) prints `for "atlas"` / `Run 'atlas --help'`, matching pinned Atlas CE, while `ptah atlas` prints `for "ptah atlas"`
- **native Ptah commands are unchanged** — they keep `NoPositionalArgs`; the unsupported-community leaf keeps its own handling

## Testing

- **Unit**: `TestAtlasUnknownCommandArgs_ConstructionAndQuoting` covers the no-arg (not an error) path and `%q` escaping of a tricky token (`a"b` → `"a\"b"`).
- **Command-level**: root and nested unknown-command assertions updated on both `NewAtlasCommand` and `NewCompatCommand`.
- **Process-level**: new tests build and run the `ptah` and `ptah-compat` binaries against an unknown root command, asserting exit 1, empty stdout, and the exact Atlas stderr.
- **Native regression**: `cmd/root` native rejection tests still assert the unchanged `unexpected positional arguments` / native `unknown command` behavior.
- `go build ./...`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle pass locally.

The strict conformance rows in the companion repo (validated against pinned Atlas CE) are satisfied by the `ptah-compat` binary now emitting `for "atlas"` / `Run 'atlas --help' for usage.`.