### PR TITLE
Generate cumulative checkpoint SQL from a schema (#660)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -649,6 +649,7 @@ type SkippedChange struct{ ... }
 
 ## github.com/stokaro/ptah/migration/generator
 
+func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downSQL string, err error)
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
 type BaselineShadowVerifyOptions struct{ ... }
 type DiffPolicy struct{ ... }

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -1,0 +1,39 @@
+package generator
+
+import (
+	"fmt"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+// GenerateCheckpoint renders a full cumulative schema as a checkpoint migration
+// body pair. The up body creates every object in dependency order; the down
+// body drops them in reverse.
+//
+// It diffs the schema against an empty database, so it is deterministic and
+// needs no live database connection. Callers obtain the schema either by
+// introspecting a database that has the whole migration directory applied (and
+// converting the result with internal/convert/dbschematogo) or from Go
+// entities / schema files. An empty schema yields empty up and down bodies.
+func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downSQL string, err error) {
+	if schema == nil {
+		return "", "", fmt.Errorf("checkpoint schema is required")
+	}
+
+	empty := &dbschematypes.DBSchema{}
+	diff := schemadiff.CompareWithDialect(schema, empty, dialect)
+	spec, _, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
+		Diff:         diff,
+		Generated:    schema,
+		DBSchema:     empty,
+		Dialect:      dialect,
+		Capabilities: capability.ForDialect(dialect),
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("generate checkpoint: %w", err)
+	}
+	return spec.UpSQL, spec.DownSQL, nil
+}

--- a/migration/generator/checkpoint_test.go
+++ b/migration/generator/checkpoint_test.go
@@ -1,0 +1,82 @@
+package generator_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+func checkpointSampleSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Post", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "Post", Name: "user_id", Type: "INTEGER", Foreign: "users(id)"},
+		},
+	}
+}
+
+func TestGenerateCheckpoint_UpCreatesAndDownDropsInDependencyOrder(t *testing.T) {
+	c := qt.New(t)
+
+	up, down, err := generator.GenerateCheckpoint(checkpointSampleSchema(), "postgres")
+	c.Assert(err, qt.IsNil)
+
+	// Up creates every table; the referenced table (users) comes before the
+	// referencing one (posts), and the foreign key is added afterward.
+	c.Assert(up, qt.Contains, `CREATE TABLE "users"`)
+	c.Assert(up, qt.Contains, `CREATE TABLE "posts"`)
+	c.Assert(strings.Index(up, `CREATE TABLE "users"`) < strings.Index(up, `CREATE TABLE "posts"`), qt.IsTrue)
+	c.Assert(up, qt.Contains, `FOREIGN KEY ("user_id") REFERENCES "users"`)
+
+	// Down drops in reverse dependency order: posts before users.
+	c.Assert(down, qt.Contains, `DROP TABLE IF EXISTS "posts"`)
+	c.Assert(down, qt.Contains, `DROP TABLE IF EXISTS "users"`)
+	c.Assert(strings.Index(down, `DROP TABLE IF EXISTS "posts"`) < strings.Index(down, `DROP TABLE IF EXISTS "users"`), qt.IsTrue)
+}
+
+func TestGenerateCheckpoint_DeterministicSchemaContent(t *testing.T) {
+	c := qt.New(t)
+
+	up1, down1, err := generator.GenerateCheckpoint(checkpointSampleSchema(), "postgres")
+	c.Assert(err, qt.IsNil)
+	up2, down2, err := generator.GenerateCheckpoint(checkpointSampleSchema(), "postgres")
+	c.Assert(err, qt.IsNil)
+
+	// The generated DDL is deterministic; only the generated-on timestamp
+	// comment varies, so compare with that line stripped.
+	c.Assert(stripGeneratedOn(up1), qt.Equals, stripGeneratedOn(up2))
+	c.Assert(stripGeneratedOn(down1), qt.Equals, stripGeneratedOn(down2))
+}
+
+func TestGenerateCheckpoint_NilAndEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	_, _, err := generator.GenerateCheckpoint(nil, "postgres")
+	c.Assert(err, qt.ErrorMatches, `checkpoint schema is required`)
+
+	up, down, err := generator.GenerateCheckpoint(&goschema.Database{}, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, "")
+	c.Assert(down, qt.Equals, "")
+}
+
+func stripGeneratedOn(sql string) string {
+	var b strings.Builder
+	for line := range strings.SplitSeq(sql, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "-- Generated on:") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Adds `generator.GenerateCheckpoint`, the deterministic content core of `ptah migrations checkpoint` (#660). Given the full cumulative schema it renders the checkpoint's two bodies:

- **up** — creates every object in dependency order (tables, then their foreign keys as deferred `ALTER`s)
- **down** — drops them in reverse (foreign keys first, then tables)

```go
up, down, err := generator.GenerateCheckpoint(schema, "postgres")
```

## Design

It diffs the schema against an **empty** database (`schemadiff.CompareWithDialect` + the existing `buildGeneratedMigrationSpec`), so it reuses the same diff planner and renderer that ordinary `migrations generate` uses — the FK ordering, drop-safety comments, and dialect handling all come for free. Because the "current" side is a literal empty schema, it is **deterministic and needs no live database**: callers obtain the schema either by introspecting a database that has the whole directory applied (converting with `internal/convert/dbschematogo`) or from Go entities / schema files. An empty schema yields empty up and down bodies.

## Scope

This is the pure content step only. The shadow-replay orchestration that produces the cumulative schema, and the `ptah migrations checkpoint` command that writes the `.checkpoint.up.sql`/`.checkpoint.down.sql` pair and rewrites `ptah.sum`, are the next steps on #660 (which already has file-format recognition, provider loading, the up-planner bootstrap, the rollback-below-checkpoint guard, and ptah.sum coverage merged).

## Testing

- `TestGenerateCheckpoint_UpCreatesAndDownDropsInDependencyOrder`: two tables with a foreign key — up creates the referenced table before the referencing one and adds the FK; down drops in reverse.
- `TestGenerateCheckpoint_DeterministicSchemaContent`: two runs produce identical DDL (only the generated-on timestamp comment differs).
- `TestGenerateCheckpoint_NilAndEmpty`: nil schema errors; empty schema yields empty bodies.
- `go build ./...`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API snapshot (new exported symbol recorded) pass locally.