### PR TITLE
Write checkpoint migration files and refresh ptah.sum (#660)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -651,6 +651,7 @@ type SkippedChange struct{ ... }
 
 func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downSQL string, err error)
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
+func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error)
 type BaselineShadowVerifyOptions struct{ ... }
 type DiffPolicy struct{ ... }
 type EmptyMigrationOptions struct{ ... }
@@ -720,6 +721,7 @@ type Statement struct{ ... }
 
 const DirectiveNoTransaction = "no_transaction"
 func FindMigrationGaps(versions []int64) []int64
+func GenerateCheckpointMigrationFileName(version int64, description, direction string) string
 func GenerateMigrationFileName(version int64, description, direction string) string
 func GetNextMigrationVersion() int64
 func GroupMigrationFiles(files []MigrationFile) map[int64]MigrationPair

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -2,10 +2,14 @@ package generator
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform/capability"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
 
@@ -36,4 +40,35 @@ func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downS
 		return "", "", fmt.Errorf("generate checkpoint: %w", err)
 	}
 	return spec.UpSQL, spec.DownSQL, nil
+}
+
+// WriteCheckpointFiles writes a checkpoint migration pair
+// (NNNNNNNNNN_description.checkpoint.up.sql and .checkpoint.down.sql) into
+// outputDir at the given version and rewrites the directory's ptah.sum so the
+// new files are integrity-protected. It refuses to overwrite existing files —
+// the caller resolves a version above the existing history — and returns the
+// two written paths.
+func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error) {
+	if err := ensureMigrationOutputDir(outputDir); err != nil {
+		return "", "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	upPath = filepath.Join(outputDir, migrator.GenerateCheckpointMigrationFileName(version, description, "up"))
+	downPath = filepath.Join(outputDir, migrator.GenerateCheckpointMigrationFileName(version, description, "down"))
+	if fileExists(upPath) || fileExists(downPath) {
+		return "", "", fmt.Errorf("checkpoint files for version %d already exist", version)
+	}
+
+	if err := writeNewMigrationFile(upPath, upSQL); err != nil {
+		return "", "", fmt.Errorf("failed to write checkpoint up file: %w", err)
+	}
+	if err := writeNewMigrationFile(downPath, downSQL); err != nil {
+		_ = os.Remove(upPath)
+		return "", "", fmt.Errorf("failed to write checkpoint down file: %w", err)
+	}
+
+	if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatPtah); err != nil {
+		return "", "", fmt.Errorf("failed to rewrite ptah.sum: %w", err)
+	}
+	return upPath, downPath, nil
 }

--- a/migration/generator/checkpoint_test.go
+++ b/migration/generator/checkpoint_test.go
@@ -1,6 +1,8 @@
 package generator_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -8,7 +10,41 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
 )
+
+func TestWriteCheckpointFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	// Seed an ordinary migration so ptah.sum starts with prior content.
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte("DROP TABLE t;\n"), 0o600), qt.IsNil)
+
+	upPath, downPath, err := generator.WriteCheckpointFiles(dir, 2, "snapshot",
+		"CREATE TABLE t (id INT, name TEXT);\n", "DROP TABLE t;\n")
+	c.Assert(err, qt.IsNil)
+	c.Assert(filepath.Base(upPath), qt.Equals, "0000000002_snapshot.checkpoint.up.sql")
+	c.Assert(filepath.Base(downPath), qt.Equals, "0000000002_snapshot.checkpoint.down.sql")
+
+	upContent, err := os.ReadFile(upPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upContent), qt.Contains, "name TEXT")
+
+	parsed, err := migrator.ParseMigrationFileName(filepath.Base(upPath))
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.IsCheckpoint, qt.IsTrue)
+
+	// ptah.sum was rewritten and now covers the checkpoint pair.
+	sum, err := os.ReadFile(filepath.Join(dir, "ptah.sum"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, "0000000002_snapshot.checkpoint.up.sql")
+	c.Assert(string(sum), qt.Contains, "0000000002_snapshot.checkpoint.down.sql")
+
+	// Writing the same version again refuses rather than overwriting.
+	_, _, err = generator.WriteCheckpointFiles(dir, 2, "snapshot", "x", "y")
+	c.Assert(err, qt.ErrorMatches, `checkpoint files for version 2 already exist`)
+}
 
 func checkpointSampleSchema() *goschema.Database {
 	return &goschema.Database{

--- a/migration/migrator/util.go
+++ b/migration/migrator/util.go
@@ -275,12 +275,24 @@ func ValidateMigrationFileName(filename string) bool {
 
 // GenerateMigrationFileName generates a migration filename from components
 func GenerateMigrationFileName(version int64, description, direction string) string {
-	// Convert description to snake_case
+	return fmt.Sprintf("%010d_%s.%s.sql", version, normalizeMigrationDescription(description), direction)
+}
+
+// GenerateCheckpointMigrationFileName returns the file name for one direction of
+// a checkpoint migration: NNNNNNNNNN_description.checkpoint.(up|down).sql. It
+// mirrors GenerateMigrationFileName but carries the checkpoint marker that
+// ParseMigrationFileName recognizes, so a written checkpoint file round-trips.
+func GenerateCheckpointMigrationFileName(version int64, description, direction string) string {
+	return fmt.Sprintf("%010d_%s.checkpoint.%s.sql", version, normalizeMigrationDescription(description), direction)
+}
+
+// normalizeMigrationDescription lower-cases the description, replaces spaces
+// with underscores, and strips any remaining non [a-z0-9_] characters, matching
+// the snake_case stem the file name regex accepts.
+func normalizeMigrationDescription(description string) string {
 	desc := strings.ToLower(description)
 	desc = strings.ReplaceAll(desc, " ", "_")
-	desc = regexp.MustCompile(`[^a-z0-9_]`).ReplaceAllString(desc, "")
-
-	return fmt.Sprintf("%010d_%s.%s.sql", version, desc, direction)
+	return regexp.MustCompile(`[^a-z0-9_]`).ReplaceAllString(desc, "")
 }
 
 // GetNextMigrationVersion generates the next migration version number

--- a/migration/migrator/util_test.go
+++ b/migration/migrator/util_test.go
@@ -207,6 +207,23 @@ func TestParseMigrationFileName(t *testing.T) {
 	}
 }
 
+func TestGenerateCheckpointMigrationFileName(t *testing.T) {
+	c := qt.New(t)
+
+	up := GenerateCheckpointMigrationFileName(5, "Cumulative Snapshot", "up")
+	c.Assert(up, qt.Equals, "0000000005_cumulative_snapshot.checkpoint.up.sql")
+	down := GenerateCheckpointMigrationFileName(5, "Cumulative Snapshot", "down")
+	c.Assert(down, qt.Equals, "0000000005_cumulative_snapshot.checkpoint.down.sql")
+
+	// A generated checkpoint name round-trips through the parser as a checkpoint.
+	parsed, err := ParseMigrationFileName(up)
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Version, qt.Equals, int64(5))
+	c.Assert(parsed.Direction, qt.Equals, "up")
+	c.Assert(parsed.Name, qt.Equals, "Cumulative Snapshot")
+	c.Assert(parsed.IsCheckpoint, qt.IsTrue)
+}
+
 func TestParseAtlasMigrationFileName(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

Adds the file-writing half of `ptah migrations checkpoint` (#660), building on the merged `GenerateCheckpoint` content core (#729):

- **`migrator.GenerateCheckpointMigrationFileName(version, description, direction)`** — builds `NNNNNNNNNN_description.checkpoint.(up|down).sql`, which round-trips through `ParseMigrationFileName` as a checkpoint (the marker recognized since #719). It shares the snake_case description normalization with `GenerateMigrationFileName` via a small extracted helper.
- **`generator.WriteCheckpointFiles(outputDir, version, description, upSQL, downSQL)`** — writes the up and down checkpoint files at a caller-resolved version and rewrites the directory's `ptah.sum` so the new files are integrity-protected (covered by #726). It refuses to overwrite existing files and cleans up the up file if the down write fails.

Both take an **explicit version**, so they are deterministic and unit-tested without a database.

## Scope

File writing only. The shadow-replay orchestration that produces the cumulative schema (feeding `GenerateCheckpoint`) and the `ptah migrations checkpoint` CLI command that resolves the version and ties everything together are the remaining #660 steps.

## Testing

- `TestGenerateCheckpointMigrationFileName`: the generated name is exactly `0000000005_cumulative_snapshot.checkpoint.up.sql` and parses back to version 5 / direction up / `IsCheckpoint`.
- `TestWriteCheckpointFiles`: writes the pair into a temp dir alongside an ordinary migration, verifies the file names and content, that the up file re-parses as a checkpoint, that `ptah.sum` was rewritten to cover both checkpoint files, and that a second write at the same version is refused.
- `go build ./...`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API snapshot (two new exported symbols) pass locally.