### PR TITLE
Generate checkpoint schema from a shadow replay (#660)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -650,9 +650,11 @@ type SkippedChange struct{ ... }
 ## github.com/stokaro/ptah/migration/generator
 
 func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downSQL string, err error)
+func GenerateCheckpointFromShadow(ctx context.Context, opts CheckpointFromShadowOptions) (upSQL, downSQL string, err error)
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
 func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error)
 type BaselineShadowVerifyOptions struct{ ... }
+type CheckpointFromShadowOptions struct{ ... }
 type DiffPolicy struct{ ... }
 type EmptyMigrationOptions struct{ ... }
 type GenerateMigrationOptions struct{ ... }

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -1,13 +1,17 @@
 package generator
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -71,4 +75,84 @@ func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, d
 		return "", "", fmt.Errorf("failed to rewrite ptah.sum: %w", err)
 	}
 	return upPath, downPath, nil
+}
+
+// CheckpointFromShadowOptions configures GenerateCheckpointFromShadow.
+type CheckpointFromShadowOptions struct {
+	// ShadowDatabaseURL is an ephemeral database the generator drops clean and
+	// replays the migration directory into. Its contents are discarded.
+	ShadowDatabaseURL string
+	// MigrationsDir is the directory whose entire history is replayed.
+	MigrationsDir string
+	// Dialect, when set, must match the shadow database dialect. When empty the
+	// shadow database's dialect is used.
+	Dialect string
+	// Schemas restricts introspection to the listed schemas where supported.
+	Schemas []string
+	// ProviderOptions are passed to the migration provider (e.g. dir format).
+	ProviderOptions []migrator.FSProviderOption
+	// ConnectTimeout bounds the shadow database connection attempt.
+	ConnectTimeout time.Duration
+}
+
+// GenerateCheckpointFromShadow replays the entire migration directory on a fresh
+// shadow database, introspects the resulting cumulative schema, and renders it
+// as a checkpoint migration body pair (up creates everything, down drops it).
+// The migration directory is the source of truth, so no target database is
+// needed. The shadow database is dropped clean before the replay and its
+// migration metadata is removed before introspection.
+func GenerateCheckpointFromShadow(ctx context.Context, opts CheckpointFromShadowOptions) (upSQL, downSQL string, err error) {
+	connectCtx, cancelConnect := baselineShadowConnectContext(ctx, opts.ConnectTimeout)
+	shadowConn, err := dbschema.ConnectToDatabase(connectCtx, opts.ShadowDatabaseURL)
+	cancelConnect()
+	if err != nil {
+		return "", "", fmt.Errorf("checkpoint generation failed: connect to shadow database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(shadowConn)
+
+	return generateCheckpointFromConn(ctx, shadowConn, opts)
+}
+
+// generateCheckpointFromConn holds the database-facing core of checkpoint
+// generation so it can be exercised against any connection, including an
+// in-memory one, without a live server.
+func generateCheckpointFromConn(ctx context.Context, shadowConn *dbschema.DatabaseConnection, opts CheckpointFromShadowOptions) (upSQL, downSQL string, err error) {
+	dialect := opts.Dialect
+	if dialect == "" {
+		dialect = shadowConn.Info().Dialect
+	} else if !sameDialect(dialect, shadowConn.Info().Dialect) {
+		return "", "", fmt.Errorf("checkpoint generation failed: shadow database dialect %q does not match target dialect %q", shadowConn.Info().Dialect, dialect)
+	}
+
+	if err := shadowConn.SchemaWriter().DropAllTables(); err != nil {
+		return "", "", fmt.Errorf("checkpoint generation failed: drop all objects: %w", err)
+	}
+	if err := resetBaselineShadowSchemas(ctx, shadowConn, opts.Schemas); err != nil {
+		return "", "", err
+	}
+
+	migrations, err := loadPriorMigrations(opts.MigrationsDir, opts.ProviderOptions...)
+	if err != nil {
+		return "", "", fmt.Errorf("checkpoint generation failed: load migrations: %w", err)
+	}
+	if len(migrations) == 0 {
+		return "", "", fmt.Errorf("checkpoint generation failed: no migrations found in %s", opts.MigrationsDir)
+	}
+
+	mig := migrator.NewMigrator(shadowConn, migrator.NewRegisteredMigrationProvider(migrations...))
+	if err := mig.MigrateUp(ctx); err != nil {
+		if description := describeReplayError(err); description != "" {
+			return "", "", fmt.Errorf("checkpoint generation failed: %s", description)
+		}
+		return "", "", fmt.Errorf("checkpoint generation failed: replay migrations: %w", err)
+	}
+	if err := dropBaselineShadowMetadata(ctx, shadowConn, mig.MigrationsTableIdentifier()); err != nil {
+		return "", "", err
+	}
+
+	shadowSchema, err := dbschema.ReadSchemaWithSchemas(shadowConn, opts.Schemas)
+	if err != nil {
+		return "", "", fmt.Errorf("checkpoint generation failed: read shadow schema: %w", err)
+	}
+	return GenerateCheckpoint(dbschematogo.ConvertDBSchemaToGoSchema(shadowSchema), dialect)
 }

--- a/migration/generator/checkpoint_test.go
+++ b/migration/generator/checkpoint_test.go
@@ -1,6 +1,7 @@
 package generator_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,49 @@ import (
 	"github.com/stokaro/ptah/migration/generator"
 	"github.com/stokaro/ptah/migration/migrator"
 )
+
+func TestGenerateCheckpointFromShadow_ReplaysHistoryIntoCumulativeSnapshot(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	writeMigration := func(name, up, down string) {
+		c.Assert(os.WriteFile(filepath.Join(dir, name+".up.sql"), []byte(up), 0o600), qt.IsNil)
+		c.Assert(os.WriteFile(filepath.Join(dir, name+".down.sql"), []byte(down), 0o600), qt.IsNil)
+	}
+	writeMigration("0000000001_init",
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\n", "DROP TABLE users;\n")
+	writeMigration("0000000002_add_email",
+		"ALTER TABLE users ADD COLUMN email TEXT;\n", "ALTER TABLE users DROP COLUMN email;\n")
+
+	shadowURL := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+
+	up, down, err := generator.GenerateCheckpointFromShadow(context.Background(), generator.CheckpointFromShadowOptions{
+		ShadowDatabaseURL: shadowURL,
+		MigrationsDir:     dir,
+		Dialect:           "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	// The checkpoint is the cumulative schema: one CREATE TABLE users carrying
+	// both the original id column and the column added by the second migration.
+	c.Assert(up, qt.Contains, "CREATE TABLE")
+	c.Assert(up, qt.Contains, "users")
+	c.Assert(up, qt.Contains, "email")
+	c.Assert(down, qt.Contains, "DROP TABLE")
+	c.Assert(down, qt.Contains, "users")
+}
+
+func TestGenerateCheckpointFromShadow_EmptyDirectoryErrors(t *testing.T) {
+	c := qt.New(t)
+
+	shadowURL := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+	_, _, err := generator.GenerateCheckpointFromShadow(context.Background(), generator.CheckpointFromShadowOptions{
+		ShadowDatabaseURL: shadowURL,
+		MigrationsDir:     t.TempDir(),
+		Dialect:           "sqlite",
+	})
+	c.Assert(err, qt.ErrorMatches, `.*no migrations found.*`)
+}
 
 func TestWriteCheckpointFiles(t *testing.T) {
 	c := qt.New(t)


### PR DESCRIPTION
## Summary

Adds `generator.GenerateCheckpointFromShadow`, the schema-production core of `ptah migrations checkpoint` (#660): it replays the **entire** migration directory on a fresh shadow database, introspects the resulting cumulative schema, and renders it as a checkpoint body pair via the merged `GenerateCheckpoint` (#729).

Because the migration directory is the source of truth, no target database is needed. This reuses the vetted baseline-shadow machinery — drop all objects, replay the history, strip the migration-metadata table, introspect — and the `dbschematogo` converter, then feeds the schema to the deterministic `GenerateCheckpoint`.

## Locally verifiable

The database-facing core is factored behind a `*dbschema.DatabaseConnection`, so it is exercised **end to end against an in-memory SQLite shadow** — no server, no Docker. The test replays a real two-migration history (`CREATE TABLE users` then `ALTER TABLE users ADD COLUMN email`) and asserts the generated checkpoint's up body carries the cumulative `users(id, email)` and the down body drops it.

## Scope

Schema production only. The `ptah migrations checkpoint` CLI command that resolves the checkpoint version (above the existing history) and writes the pair with the merged `WriteCheckpointFiles` (#730) — plus the Atlas passthrough verb and docs — is the last remaining #660 step.

## Testing

- `TestGenerateCheckpointFromShadow_ReplaysHistoryIntoCumulativeSnapshot`: SQLite shadow, two-migration replay → cumulative checkpoint.
- `TestGenerateCheckpointFromShadow_EmptyDirectoryErrors`: an empty directory is a clear error.
- `go build ./...`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle, and the public-API snapshot (two new exported symbols) pass locally.