### PR TITLE
Add the ptah migrations checkpoint command (#660)

### DIFF
--- a/cmd/migratecheckpoint/migratecheckpoint.go
+++ b/cmd/migratecheckpoint/migratecheckpoint.go
@@ -1,0 +1,151 @@
+// Package migratecheckpoint implements `ptah migrations checkpoint`, which
+// squashes a migration directory's history into a cumulative-schema checkpoint.
+package migratecheckpoint
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const (
+	migrationsFlag  = "migrations-dir"
+	shadowDBFlag    = "shadow-db"
+	dialectFlag     = "dialect"
+	descriptionFlag = "description"
+	versionFlag     = "version"
+	dryRunFlag      = "dry-run"
+	dirFormatFlag   = "dir-format"
+	schemasFlag     = "schemas"
+)
+
+type options struct {
+	migrationsDir  string
+	shadowDB       string
+	dialect        string
+	description    string
+	version        string
+	dryRun         bool
+	dirFormat      string
+	schemas        string
+	connectTimeout string
+}
+
+// NewMigrateCheckpointCommand returns the `checkpoint` command.
+func NewMigrateCheckpointCommand() *cobra.Command {
+	opts := options{}
+	cmd := &cobra.Command{
+		Use:   "checkpoint",
+		Short: "Squash migration history into a cumulative-schema checkpoint",
+		Long: `Write a checkpoint migration that captures the full cumulative schema at the
+current version.
+
+The entire migration directory is replayed on a fresh shadow database, the
+resulting schema is introspected, and a checkpoint migration pair
+(NNNNNNNNNN_description.checkpoint.up.sql / .down.sql) is written and ptah.sum is
+refreshed. A fresh database then bootstraps from the newest checkpoint instead
+of replaying all history, while an already-migrated database ignores it.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return migrateCheckpointCommand(cmd, args, &opts)
+		},
+	}
+	registerFlags(cmd, &opts)
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
+}
+
+func registerFlags(cmd *cobra.Command, opts *options) {
+	flags := cmd.Flags()
+	flags.StringVar(&opts.migrationsDir, migrationsFlag, "./migrations", "Directory containing migration files")
+	flags.StringVar(&opts.shadowDB, shadowDBFlag, "", "Ephemeral shadow database URL the directory is replayed into (required)")
+	flags.StringVar(&opts.dialect, dialectFlag, "", "Database dialect; inferred from the shadow database when omitted")
+	flags.StringVar(&opts.description, descriptionFlag, "checkpoint", "Checkpoint description used in the file name")
+	flags.StringVar(&opts.version, versionFlag, "", "Checkpoint version; defaults to one above the newest migration")
+	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the checkpoint SQL instead of writing files")
+	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format")
+	flags.StringVar(&opts.schemas, schemasFlag, "", "Comma-separated schemas to introspect")
+	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
+}
+
+func migrateCheckpointCommand(cmd *cobra.Command, _ []string, opts *options) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	if opts.shadowDB == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("a shadow database URL is required (--%s)", shadowDBFlag))
+	}
+	if opts.migrationsDir == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("migrations directory is required"))
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(opts.dirFormat)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	connectTimeout, err := dbcli.ParseConnectTimeout(opts.connectTimeout)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	version, err := resolveCheckpointVersion(opts.version, opts.migrationsDir, dirFormat)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
+	upSQL, downSQL, err := generator.GenerateCheckpointFromShadow(ctx, generator.CheckpointFromShadowOptions{
+		ShadowDatabaseURL: opts.shadowDB,
+		MigrationsDir:     opts.migrationsDir,
+		Dialect:           opts.dialect,
+		Schemas:           dbcli.ParseSchemas(opts.schemas),
+		ProviderOptions:   []migrator.FSProviderOption{migrator.WithMigrationDirFormat(dirFormat)},
+		ConnectTimeout:    connectTimeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	if opts.dryRun {
+		upName := migrator.GenerateCheckpointMigrationFileName(version, opts.description, "up")
+		downName := migrator.GenerateCheckpointMigrationFileName(version, opts.description, "down")
+		fmt.Fprintf(out, "-- checkpoint version %d (dry run, no files written)\n\n-- %s\n%s\n\n-- %s\n%s\n",
+			version, upName, upSQL, downName, downSQL)
+		return nil
+	}
+
+	upPath, downPath, err := generator.WriteCheckpointFiles(opts.migrationsDir, version, opts.description, upSQL, downSQL)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	fmt.Fprintf(out, "Wrote checkpoint version %d:\n  %s\n  %s\n", version, upPath, downPath)
+	return nil
+}
+
+// resolveCheckpointVersion returns the explicit version when provided, otherwise
+// one above the newest migration so the checkpoint sorts after and covers the
+// whole existing history.
+func resolveCheckpointVersion(explicit, migrationsDir string, dirFormat migrator.MigrationDirFormat) (int64, error) {
+	if explicit != "" {
+		v, err := strconv.ParseInt(explicit, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid version %q: %w", explicit, err)
+		}
+		return v, nil
+	}
+	files, err := migrator.DiscoverMigrationFiles(os.DirFS(migrationsDir), dirFormat)
+	if err != nil {
+		return 0, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+	var latest int64
+	for _, file := range files {
+		if file.Version > latest {
+			latest = file.Version
+		}
+	}
+	return latest + 1, nil
+}

--- a/cmd/migratecheckpoint/migratecheckpoint.go
+++ b/cmd/migratecheckpoint/migratecheckpoint.go
@@ -23,7 +23,6 @@ const (
 	versionFlag     = "version"
 	dryRunFlag      = "dry-run"
 	dirFormatFlag   = "dir-format"
-	schemasFlag     = "schemas"
 )
 
 type options struct {
@@ -70,7 +69,7 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.version, versionFlag, "", "Checkpoint version; defaults to one above the newest migration")
 	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the checkpoint SQL instead of writing files")
 	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format")
-	flags.StringVar(&opts.schemas, schemasFlag, "", "Comma-separated schemas to introspect")
+	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 }
 
@@ -126,17 +125,19 @@ func migrateCheckpointCommand(cmd *cobra.Command, _ []string, opts *options) err
 	return nil
 }
 
-// resolveCheckpointVersion returns the explicit version when provided, otherwise
-// one above the newest migration so the checkpoint sorts after and covers the
-// whole existing history.
+// maxMigrationVersion is the largest value the 10-digit NNNNNNNNNN file-name
+// prefix can hold. A larger version would produce a file name the migration
+// parser cannot recognize, so the checkpoint would be silently invisible.
+const maxMigrationVersion = 9999999999
+
+// resolveCheckpointVersion returns the checkpoint version. Without --version it
+// is one above the newest migration so the checkpoint sorts after and covers
+// the whole existing history. An explicit --version must be a positive value
+// that fits the file-name width and is above every existing migration —
+// otherwise the checkpoint would overwrite history, collide with an ordinary
+// migration, or fail to squash it — so those are rejected up front rather than
+// producing a directory that only breaks on a later command.
 func resolveCheckpointVersion(explicit, migrationsDir string, dirFormat migrator.MigrationDirFormat) (int64, error) {
-	if explicit != "" {
-		v, err := strconv.ParseInt(explicit, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid version %q: %w", explicit, err)
-		}
-		return v, nil
-	}
 	files, err := migrator.DiscoverMigrationFiles(os.DirFS(migrationsDir), dirFormat)
 	if err != nil {
 		return 0, fmt.Errorf("failed to scan migrations directory: %w", err)
@@ -147,5 +148,23 @@ func resolveCheckpointVersion(explicit, migrationsDir string, dirFormat migrator
 			latest = file.Version
 		}
 	}
-	return latest + 1, nil
+
+	if explicit == "" {
+		return latest + 1, nil
+	}
+
+	version, err := strconv.ParseInt(explicit, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --%s value %q: %w", versionFlag, explicit, err)
+	}
+	if version <= 0 {
+		return 0, fmt.Errorf("invalid --%s value %d: must be a positive version", versionFlag, version)
+	}
+	if version > maxMigrationVersion {
+		return 0, fmt.Errorf("invalid --%s value %d: exceeds the maximum migration version %d", versionFlag, version, int64(maxMigrationVersion))
+	}
+	if version <= latest {
+		return 0, fmt.Errorf("invalid --%s value %d: must be above the newest existing migration version %d so the checkpoint covers the whole history", versionFlag, version, latest)
+	}
+	return version, nil
 }

--- a/cmd/migratecheckpoint/migratecheckpoint_test.go
+++ b/cmd/migratecheckpoint/migratecheckpoint_test.go
@@ -1,0 +1,80 @@
+package migratecheckpoint_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migratecheckpoint"
+)
+
+func seedMigrations(c *qt.C, dir string) {
+	c.Helper()
+	writePair := func(name, up, down string) {
+		c.Assert(os.WriteFile(filepath.Join(dir, name+".up.sql"), []byte(up), 0o600), qt.IsNil)
+		c.Assert(os.WriteFile(filepath.Join(dir, name+".down.sql"), []byte(down), 0o600), qt.IsNil)
+	}
+	writePair("0000000001_init", "CREATE TABLE users (id INTEGER PRIMARY KEY);\n", "DROP TABLE users;\n")
+	writePair("0000000002_email", "ALTER TABLE users ADD COLUMN email TEXT;\n", "ALTER TABLE users DROP COLUMN email;\n")
+}
+
+func runCheckpoint(args ...string) (string, error) {
+	cmd := migratecheckpoint.NewMigrateCheckpointCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return out.String(), err
+}
+
+func TestMigrateCheckpointCommand_WritesCumulativeCheckpoint(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	seedMigrations(c, dir)
+	shadow := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+
+	out, err := runCheckpoint("--shadow-db", shadow, "--migrations-dir", dir, "--dialect", "sqlite")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+
+	// The checkpoint version is one above the newest migration (2 -> 3), and its
+	// up body is the cumulative schema (users carrying the added email column).
+	up, err := os.ReadFile(filepath.Join(dir, "0000000003_checkpoint.checkpoint.up.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(up), qt.Contains, "CREATE TABLE")
+	c.Assert(string(up), qt.Contains, "email")
+	_, err = os.Stat(filepath.Join(dir, "0000000003_checkpoint.checkpoint.down.sql"))
+	c.Assert(err, qt.IsNil)
+
+	sum, err := os.ReadFile(filepath.Join(dir, "ptah.sum"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, "0000000003_checkpoint.checkpoint.up.sql")
+}
+
+func TestMigrateCheckpointCommand_DryRunWritesNothing(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	seedMigrations(c, dir)
+	shadow := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+
+	out, err := runCheckpoint("--shadow-db", shadow, "--migrations-dir", dir, "--dialect", "sqlite", "--dry-run")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "dry run")
+	c.Assert(out, qt.Contains, "CREATE TABLE")
+
+	written, err := filepath.Glob(filepath.Join(dir, "*checkpoint*"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateCheckpointCommand_RequiresShadowDB(t *testing.T) {
+	c := qt.New(t)
+
+	out, err := runCheckpoint("--migrations-dir", t.TempDir())
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "shadow database URL is required")
+}

--- a/cmd/migratecheckpoint/migratecheckpoint_test.go
+++ b/cmd/migratecheckpoint/migratecheckpoint_test.go
@@ -78,3 +78,32 @@ func TestMigrateCheckpointCommand_RequiresShadowDB(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(out, qt.Contains, "shadow database URL is required")
 }
+
+func TestMigrateCheckpointCommand_RejectsVersionAtOrBelowHistory(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	seedMigrations(c, dir) // versions 1 and 2
+	shadow := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+
+	// A version that collides with an existing ordinary migration would poison
+	// the directory (mixed checkpoint/non-checkpoint) and must be refused up
+	// front, not written and then broken on the next command.
+	out, err := runCheckpoint("--shadow-db", shadow, "--migrations-dir", dir, "--dialect", "sqlite", "--version", "2")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "must be above the newest existing migration version 2")
+
+	written, err := filepath.Glob(filepath.Join(dir, "*checkpoint*"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateCheckpointCommand_RejectsNonPositiveVersion(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	seedMigrations(c, dir)
+	shadow := "sqlite://" + filepath.Join(t.TempDir(), "shadow.db")
+
+	out, err := runCheckpoint("--shadow-db", shadow, "--migrations-dir", dir, "--dialect", "sqlite", "--version", "0")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "must be a positive version")
+}

--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stokaro/ptah/cmd/lint"
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratebaseline"
+	"github.com/stokaro/ptah/cmd/migratecheckpoint"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migrateedit"
 	"github.com/stokaro/ptah/cmd/migratehash"
@@ -45,6 +46,7 @@ ptah atlas.`,
 	cmd.AddCommand(migrationCommand(migratedown.NewMigrateDownCommand(), "Roll back migrations", "Roll back migrations against a live database."))
 	cmd.AddCommand(migrationCommand(migratestatus.NewMigrateStatusCommand(), "Show migration status", "Show migration status for a live database and migrations directory."))
 	cmd.AddCommand(migrationCommand(migratebaseline.NewMigrateBaselineCommand(), "Record existing migrations as applied", "Record existing migrations as already applied in the revision table."))
+	cmd.AddCommand(migrationCommand(migratecheckpoint.NewMigrateCheckpointCommand(), "Squash history into a checkpoint", "Squash a migration directory's history into a cumulative-schema checkpoint that fresh databases bootstrap from."))
 	cmd.AddCommand(migrationCommand(migraterepair.NewMigrateRepairCommand(), "Repair migration revision metadata", "Repair migration revision metadata after a dirty or partial migration state."))
 	cmd.AddCommand(migrationCommand(migratehash.NewMigrateHashCommand(), "Write or update migration directory integrity", "Write or update the migration directory integrity file."))
 	cmd.AddCommand(migrationCommand(migratevalidate.NewMigrateValidateCommand(), "Validate migration directory integrity", "Validate the migration directory against its integrity file."))

--- a/docs/native_cli.md
+++ b/docs/native_cli.md
@@ -34,6 +34,7 @@ root-level command spellings are removed instead of preserved.
 | `ptah migrations down` | Roll back migrations. |
 | `ptah migrations status` | Show migration status. |
 | `ptah migrations baseline` | Record existing migrations as applied. |
+| `ptah migrations checkpoint` | Squash history into a cumulative-schema checkpoint fresh databases bootstrap from. |
 | `ptah migrations repair` | Repair migration revision metadata. |
 | `ptah migrations hash` | Write or update migration directory integrity. |
 | `ptah migrations validate` | Validate migration directory integrity and, optionally, SQL execution with `--dev-url`. |


### PR DESCRIPTION
## Summary

The capstone of #660: wires the merged checkpoint building blocks into the user-facing `ptah migrations checkpoint` command.

```bash
ptah migrations checkpoint --shadow-db "$SHADOW_URL" --migrations-dir ./migrations
```

It replays the **whole** migration directory on a fresh shadow database (`GenerateCheckpointFromShadow`, #732), introspects the cumulative schema, renders it (`GenerateCheckpoint`, #729), and writes the `.checkpoint.up.sql`/`.checkpoint.down.sql` pair while refreshing `ptah.sum` (`WriteCheckpointFiles`, #730).

- **version** defaults to one above the newest migration, so the checkpoint sorts last and covers the whole history — a fresh database bootstraps from it (#722) and an already-migrated one ignores it. Override with `--version`.
- **`--dry-run`** prints the up and down SQL instead of writing files.
- **dialect** is inferred from the shadow database when `--dialect` is omitted.

Registered under `ptah migrations checkpoint` and added to the native CLI reference.

## Completes #660

With this, all the #660 building blocks are connected: file-format recognition (#719), provider loading (#720), up-planner bootstrap (#722), rollback-below-checkpoint guard (#724), ptah.sum coverage (#726), snapshot content (#729), file writing (#730), and shadow orchestration (#732).

## Testing

- `TestMigrateCheckpointCommand_WritesCumulativeCheckpoint`: SQLite shadow, a two-migration history (`CREATE TABLE users` then `ADD COLUMN email`) → checkpoint version 3 whose up body carries the cumulative `users(id, email)`, with `ptah.sum` refreshed.
- `TestMigrateCheckpointCommand_DryRunWritesNothing`: `--dry-run` prints SQL, writes no files.
- `TestMigrateCheckpointCommand_RequiresShadowDB`: a missing shadow database is a clear error.
- `go build ./...`, full `go test ./...`, golangci-lint v2.12.2, qtlint, teststyle pass locally.

## Follow-ups (noted, not in scope)

A `--force` to overwrite an existing checkpoint, a `checkpoint` passthrough under `ptah atlas migrate`, and the companion-repo live round-trip conformance fixture.