### PR TITLE
Complete Atlas validate and command diagnostic parity

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -54,26 +54,6 @@ var unsupportedAtlasDirFormats = []string{
 	"liquibase",
 }
 
-// atlasUnknownCommandArgs is the positional-args validator for an
-// Atlas-compatible command group. A stray positional argument on a group means
-// an unknown subcommand, so it emits Atlas CE's cobra-style diagnostic
-//
-//	Error: unknown command "<arg>" for "<command path>"
-//	Run '<command path> --help' for usage.
-//
-// on stderr and fails, instead of the native "unexpected positional arguments"
-// message. The unknown token is quoted with %q exactly as cobra (and therefore
-// Atlas) does. The command's error-code policy maps the failure to Atlas's
-// exit code 1; native Ptah commands keep NoPositionalArgs and are unaffected.
-func atlasUnknownCommandArgs(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return nil
-	}
-	path := cmd.CommandPath()
-	fmt.Fprintf(cmd.ErrOrStderr(), "Error: unknown command %q for %q\nRun '%s --help' for usage.\n", args[0], path, path)
-	return exitcode.New(atlasErrorExitCode, fmt.Errorf("unknown command %q for %q", args[0], path))
-}
-
 // NewAtlasCommand returns the Atlas command namespace.
 func NewAtlasCommand() *cobra.Command {
 	cmd := newAtlasCommand("atlas [command]", "Atlas OSS command namespace", `Atlas OSS command namespace.
@@ -106,15 +86,14 @@ func newAtlasCommand(use, short, long string) *cobra.Command {
 		Use:   use,
 		Short: short,
 		Long:  long,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
+		RunE:  runAtlasGroupHelp,
 	}
-	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
+	cmdutil.ConfigureCommandArgs(cmd, atlasRootArgs)
 	cmd.AddCommand(newAtlasVersionCommand())
 	cmd.AddCommand(newAtlasLicenseCommand())
 	cmd.AddCommand(newAtlasSchemaCommand())
 	cmd.AddCommand(newAtlasMigrateCommand())
+	installAtlasCompletionCommand(cmd)
 	installAtlasUsageTree(cmd)
 	return cmd
 }
@@ -123,11 +102,11 @@ func newAtlasSchemaCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema [command]",
 		Short: "Atlas schema commands",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
+		RunE:  runAtlasGroupHelp,
 	}
-	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
+	// Atlas CE treats an extra token on a command group as a request for that
+	// group's help, so the group intentionally accepts positional arguments.
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	registerAtlasProjectFlags(cmd.PersistentFlags(), &atlasProjectFlagValues{})
 	cmd.AddCommand(newAtlasSchemaCleanCommand())
 	cmd.AddCommand(newAtlasSchemaInspectCommand())
@@ -146,11 +125,11 @@ func newAtlasMigrateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "migrate [command]",
 		Short: "Atlas migrate commands",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
+		RunE:  runAtlasGroupHelp,
 	}
-	cmdutil.ConfigureCommandArgs(cmd, atlasUnknownCommandArgs)
+	// Atlas CE treats an extra token on a command group as a request for that
+	// group's help, so the group intentionally accepts positional arguments.
+	cmdutil.ConfigureCommandArgs(cmd, nil)
 	registerAtlasProjectFlags(cmd.PersistentFlags(), &atlasProjectFlagValues{})
 	cmd.AddCommand(newAtlasMigrateApplyCommand())
 	cmd.AddCommand(newAtlasMigrateLintCommand())
@@ -231,6 +210,66 @@ func newAtlasMigrateCommand() *cobra.Command {
 		{use: "test", short: "Test migration files through Atlas Cloud"},
 	})
 	return cmd
+}
+
+func atlasRootArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+
+	unknownErr := fmt.Errorf("unknown command %q for %q", args[0], "atlas")
+	var diagnostic strings.Builder
+	fmt.Fprintf(&diagnostic, "Error: %s\n", unknownErr)
+
+	suggestions := cmd.SuggestionsFor(args[0])
+	if len(suggestions) > 0 {
+		diagnostic.WriteString("\nDid you mean this?\n")
+		for _, suggestion := range suggestions {
+			fmt.Fprintf(&diagnostic, "\t%s\n", suggestion)
+		}
+		diagnostic.WriteString("\n")
+	}
+	diagnostic.WriteString("Run 'atlas --help' for usage.\n")
+
+	if _, err := fmt.Fprint(cmd.ErrOrStderr(), diagnostic.String()); err != nil {
+		return exitcode.New(atlasErrorExitCode, fmt.Errorf("%w: write diagnostic: %w", unknownErr, err))
+	}
+	return exitcode.New(atlasErrorExitCode, unknownErr)
+}
+
+func installAtlasCompletionCommand(cmd *cobra.Command) {
+	cmd.InitDefaultCompletionCmd()
+	for _, child := range cmd.Commands() {
+		if child.Name() != "completion" {
+			continue
+		}
+		child.Use = "completion [command]"
+		child.RunE = runAtlasGroupHelp
+		cmdutil.ConfigureCommandArgs(child, nil)
+		for _, shell := range child.Commands() {
+			shell.Args = atlasCompletionShellArgs
+		}
+		return
+	}
+}
+
+func runAtlasGroupHelp(cmd *cobra.Command, _ []string) error {
+	if err := renderAtlasHelp(cmd); err != nil {
+		return exitcode.New(atlasErrorExitCode, err)
+	}
+	return nil
+}
+
+func atlasCompletionShellArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+
+	unknownErr := fmt.Errorf("unknown command %q for %q", args[0], "atlas completion "+cmd.Name())
+	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", unknownErr); err != nil {
+		return exitcode.New(atlasErrorExitCode, fmt.Errorf("%w: write diagnostic: %w", unknownErr, err))
+	}
+	return exitcode.New(atlasErrorExitCode, unknownErr)
 }
 
 type atlasUnsupportedCommunityVerb struct {

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -16,8 +16,6 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
-	"github.com/stokaro/ptah/cmd/internal/cmdutil"
-	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
@@ -188,94 +186,6 @@ func TestNewCompatCommand_LicenseResolvesAtRoot(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "License: MIT")
 	c.Assert(out.String(), qt.Not(qt.Contains), "not implemented")
-}
-
-func TestNewCompatCommand_UnknownNestedCommandFails(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewCompatCommand("ptah-compat")
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"migrate", "aplly"})
-
-	err := executeAtlasCommandForTest(cmd)
-
-	c.Assert(err, qt.ErrorMatches, `unknown command "aplly" for "ptah-compat migrate"`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `Error: unknown command "aplly" for "ptah-compat migrate"`)
-	c.Assert(out.String(), qt.Contains, `Run 'ptah-compat migrate --help' for usage.`)
-}
-
-func TestNewAtlasCommand_UnknownNestedCommandFails(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewAtlasCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"migrate", "aplly"})
-
-	err := executeAtlasCommandForTest(cmd)
-
-	c.Assert(err, qt.ErrorMatches, `unknown command "aplly" for "atlas migrate"`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `Error: unknown command "aplly" for "atlas migrate"`)
-	c.Assert(out.String(), qt.Contains, `Run 'atlas migrate --help' for usage.`)
-}
-
-// TestNewAtlasCommand_UnknownTopLevelCommandFails guards #687: `ptah atlas
-// <unknown>` must fail (exit non-zero), not silently print help and exit 0, so a
-// script with a typo does not masquerade as success.
-func TestNewAtlasCommand_UnknownTopLevelCommandFails(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewAtlasCommand()
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"definitely-not-a-command"})
-
-	err := executeAtlasCommandForTest(cmd)
-
-	c.Assert(err, qt.ErrorMatches, `unknown command "definitely-not-a-command" for "atlas"`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `Error: unknown command "definitely-not-a-command" for "atlas"`)
-	c.Assert(out.String(), qt.Contains, `Run 'atlas --help' for usage.`)
-}
-
-func TestNewCompatCommand_UnknownTopLevelCommandFails(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewCompatCommand("ptah-compat")
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"definitely-not-a-command"})
-
-	err := executeAtlasCommandForTest(cmd)
-
-	c.Assert(err, qt.ErrorMatches, `unknown command "definitely-not-a-command" for "ptah-compat"`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, `Error: unknown command "definitely-not-a-command" for "ptah-compat"`)
-	c.Assert(out.String(), qt.Contains, `Run 'ptah-compat --help' for usage.`)
-}
-
-func TestAtlasUnknownCommandArgs_ConstructionAndQuoting(t *testing.T) {
-	c := qt.New(t)
-	cmd := NewAtlasCommand() // standalone command path is "atlas"
-	var out bytes.Buffer
-	cmd.SetErr(&out)
-
-	// No positional argument is not an unknown command.
-	c.Assert(atlasUnknownCommandArgs(cmd, nil), qt.IsNil)
-	c.Assert(out.String(), qt.Equals, "")
-
-	// The unknown token is quoted (and escaped) with %q exactly as cobra/Atlas.
-	err := atlasUnknownCommandArgs(cmd, []string{`a"b`, "ignored"})
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Equals, `unknown command "a\"b" for "atlas"`)
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-
-	want := `Error: unknown command "a\"b" for "atlas"` + "\n" +
-		`Run 'atlas --help' for usage.` + "\n"
-	c.Assert(out.String(), qt.Equals, want)
 }
 
 func TestNewAtlasCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
@@ -3645,7 +3555,7 @@ func TestNewAtlasCommand_MigrateValidateResolvesProjectRelativeMigrationDir(t *t
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "OK: migrations directory matches atlas.sum")
+	c.Assert(out.String(), qt.Equals, "")
 }
 
 func TestNewAtlasCommand_MigrateHashResolvesProjectRelativeMigrationDir(t *testing.T) {
@@ -4581,11 +4491,6 @@ func TestNewAtlasCommand_HelpAdvertisesGroupedNativeEquivalents(t *testing.T) {
 func writeAtlasTestFile(c *qt.C, dir, name, content string) {
 	c.Helper()
 	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
-}
-
-func executeAtlasCommandForTest(cmd *cobra.Command) error {
-	executed, err := cmd.ExecuteC()
-	return cmdutil.NormalizeCommandError(executed, err, 2)
 }
 
 func readAtlasTestFile(c *qt.C, dir, name string) string {

--- a/cmd/atlas/atlas_usage.go
+++ b/cmd/atlas/atlas_usage.go
@@ -2,6 +2,7 @@ package atlas
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,8 @@ func installAtlasUsageTree(cmd *cobra.Command) {
 }
 
 func renderAtlasUsage(cmd *cobra.Command) error {
-	out := cmd.OutOrStderr()
+	var usage strings.Builder
+	out := &usage
 	useLine := atlasUseLine(cmd)
 	fmt.Fprint(out, "Usage:")
 	if cmd.Runnable() {
@@ -35,11 +37,15 @@ func renderAtlasUsage(cmd *cobra.Command) error {
 		fmt.Fprintf(out, "\n  %s [command]", atlasDisplayPath(cmd))
 	}
 	fmt.Fprintln(out)
+	if _, err := io.WriteString(cmd.ErrOrStderr(), usage.String()); err != nil {
+		return fmt.Errorf("write Atlas usage: %w", err)
+	}
 	return nil
 }
 
 func renderAtlasHelp(cmd *cobra.Command) error {
-	out := cmd.OutOrStdout()
+	var help strings.Builder
+	out := &help
 	description := strings.TrimSpace(cmd.Long)
 	if description == "" {
 		description = strings.TrimSpace(cmd.Short)
@@ -89,6 +95,9 @@ func renderAtlasHelp(cmd *cobra.Command) error {
 		fmt.Fprintf(out, "\n\nUse \"%s [command] --help\" for more information about a command.", atlasDisplayPath(cmd))
 	}
 	fmt.Fprintln(out)
+	if _, err := io.WriteString(cmd.OutOrStdout(), help.String()); err != nil {
+		return fmt.Errorf("write Atlas help: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/atlas/atlas_usage_test.go
+++ b/cmd/atlas/atlas_usage_test.go
@@ -2,6 +2,7 @@ package atlas_test
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -144,6 +145,245 @@ func TestNewAtlasCommand_ForwardedNativeFailureExits1(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "error: migrations directory")
 }
 
+func TestAtlasCompatibilityRoots_UnknownCommandMatchesAtlasCE(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{
+			name: "ptah atlas",
+			cmd: func() *cobra.Command {
+				root := &cobra.Command{Use: "ptah", SilenceUsage: true, SilenceErrors: true}
+				root.AddCommand(atlas.NewAtlasCommand())
+				return root
+			}(),
+			args: []string{"atlas", "definitely-not-a-command", "ignored-extra-token"},
+		},
+		{
+			name: "compatibility binary",
+			cmd:  atlas.NewCompatCommand("ptah-compat"),
+			args: []string{"definitely-not-a-command", "ignored-extra-token"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			var stdout, stderr bytes.Buffer
+			tt.cmd.SetOut(&stdout)
+			tt.cmd.SetErr(&stderr)
+			tt.cmd.SetArgs(tt.args)
+
+			err := executeAtlasTestCommand(tt.cmd)
+
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(err, qt.ErrorMatches, `unknown command "definitely-not-a-command" for "atlas"`)
+			c.Assert(stdout.String(), qt.Equals, "")
+			c.Assert(stderr.String(), qt.Equals,
+				"Error: unknown command \"definitely-not-a-command\" for \"atlas\"\n"+
+					"Run 'atlas --help' for usage.\n")
+		})
+	}
+}
+
+func TestAtlasCompatibilityRoot_UnknownCommandQuotesSafely(t *testing.T) {
+	c := qt.New(t)
+	cmd := atlas.NewCompatCommand("ptah-compat")
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"bad\ncommand"})
+
+	err := executeAtlasTestCommand(cmd)
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stdout.String(), qt.Equals, "")
+	c.Assert(stderr.String(), qt.Equals,
+		"Error: unknown command \"bad\\ncommand\" for \"atlas\"\n"+
+			"Run 'atlas --help' for usage.\n")
+}
+
+func TestAtlasCompatibilityRoot_UnknownCommandSuggestsAtlasVerb(t *testing.T) {
+	c := qt.New(t)
+	cmd := atlas.NewCompatCommand("ptah-compat")
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"migrat"})
+
+	err := executeAtlasTestCommand(cmd)
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(stdout.String(), qt.Equals, "")
+	c.Assert(stderr.String(), qt.Equals,
+		"Error: unknown command \"migrat\" for \"atlas\"\n\n"+
+			"Did you mean this?\n"+
+			"\tmigrate\n\n"+
+			"Run 'atlas --help' for usage.\n")
+}
+
+func TestAtlasCompatibilityDiagnostics_WriterFailure(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "root command",
+			args:    []string{"unknown"},
+			wantErr: `unknown command "unknown" for "atlas": write diagnostic: write failed`,
+		},
+		{
+			name:    "completion shell",
+			args:    []string{"completion", "bash", "extra"},
+			wantErr: `unknown command "extra" for "atlas completion bash": write diagnostic: write failed`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			cmd := atlas.NewCompatCommand("atlas")
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(atlasFailingWriter{})
+			cmd.SetArgs(tt.args)
+
+			err := executeAtlasTestCommand(cmd)
+
+			c.Assert(err, qt.ErrorIs, errAtlasWriteFailed)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(stdout.String(), qt.Equals, "")
+		})
+	}
+}
+
+func TestAtlasCompatibilityGroups_ExtraTokenMatchesAtlasCEHelp(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		args      []string
+		wantUsage string
+	}{
+		{
+			name:      "migrate",
+			args:      []string{"migrate", "aplly"},
+			wantUsage: "Usage:\n  atlas migrate [command]",
+		},
+		{
+			name:      "schema",
+			args:      []string{"schema", "definitely-not-a-command"},
+			wantUsage: "Usage:\n  atlas schema [command]",
+		},
+		{
+			name:      "completion",
+			args:      []string{"completion", "sh"},
+			wantUsage: "Usage:\n  atlas completion [command]",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			cmd := atlas.NewCompatCommand("atlas")
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tt.args)
+
+			err := executeAtlasTestCommand(cmd)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(stdout.String(), qt.Contains, tt.wantUsage)
+			c.Assert(stderr.String(), qt.Equals, "")
+		})
+	}
+}
+
+func TestAtlasCompatibilityGroups_HelpWriterFailure(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "migrate",
+			args: []string{"migrate", "aplly"},
+		},
+		{
+			name: "schema",
+			args: []string{"schema", "unknown"},
+		},
+		{
+			name: "completion",
+			args: []string{"completion", "sh"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			cmd := atlas.NewCompatCommand("atlas")
+			var stderr bytes.Buffer
+			cmd.SetOut(atlasFailingWriter{})
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tt.args)
+
+			err := executeAtlasTestCommand(cmd)
+
+			c.Assert(err, qt.ErrorIs, errAtlasWriteFailed)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(stderr.String(), qt.Equals, "")
+		})
+	}
+}
+
+func TestAtlasCompatibilityCompletion_ExtraTokenMatchesAtlasCE(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		args []string
+	}{
+		{
+			name: "ptah atlas",
+			cmd: func() *cobra.Command {
+				root := &cobra.Command{Use: "ptah", SilenceUsage: true, SilenceErrors: true}
+				root.AddCommand(atlas.NewAtlasCommand())
+				return root
+			}(),
+			args: []string{"atlas", "completion", "bash", "extra"},
+		},
+		{
+			name: "compatibility binary",
+			cmd:  atlas.NewCompatCommand("ptah-compat"),
+			args: []string{"completion", "bash", "extra"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			var stdout, stderr bytes.Buffer
+			tt.cmd.SetOut(&stdout)
+			tt.cmd.SetErr(&stderr)
+			tt.cmd.SetArgs(tt.args)
+
+			err := executeAtlasTestCommand(tt.cmd)
+
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(err, qt.ErrorMatches, `unknown command "extra" for "atlas completion bash"`)
+			c.Assert(stdout.String(), qt.Equals, "")
+			c.Assert(stderr.String(), qt.Equals,
+				"Error: unknown command \"extra\" for \"atlas completion bash\"\n")
+		})
+	}
+}
+
 func executeAtlasUsageTestCommand(cmd *cobra.Command, args []string) (string, error) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
@@ -156,4 +396,12 @@ func executeAtlasUsageTestCommand(cmd *cobra.Command, args []string) (string, er
 func executeAtlasTestCommand(cmd *cobra.Command) error {
 	executed, err := cmd.ExecuteC()
 	return cmdutil.NormalizeCommandError(executed, err, 2)
+}
+
+type atlasFailingWriter struct{}
+
+var errAtlasWriteFailed = errors.New("write failed")
+
+func (atlasFailingWriter) Write(_ []byte) (int, error) {
+	return 0, errAtlasWriteFailed
 }

--- a/cmd/atlas/atlas_validate_devurl_test.go
+++ b/cmd/atlas/atlas_validate_devurl_test.go
@@ -36,8 +36,7 @@ func TestNewAtlasCommand_MigrateValidateDevURLReplaysAtlasMigration(t *testing.T
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "OK: migrations directory matches atlas.sum")
-	c.Assert(out.String(), qt.Contains, "OK: migration SQL validated on dev database")
+	c.Assert(out.String(), qt.Equals, "")
 	assertSQLiteTableCount(c, devDBPath, "atlas_validate_dev_url", 1)
 }
 
@@ -62,8 +61,7 @@ func TestNewCompatCommand_MigrateValidateDevURLReplaysAtlasMigration(t *testing.
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "OK: migrations directory matches atlas.sum")
-	c.Assert(out.String(), qt.Contains, "OK: migration SQL validated on dev database")
+	c.Assert(out.String(), qt.Equals, "")
 	assertSQLiteTableCount(c, devDBPath, "compat_validate_dev_url", 1)
 }
 

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -24,7 +24,10 @@ const (
 	atlasChecksumFooter = "Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n"
 )
 
-var errAtlasChecksumMismatch = errors.New("checksum mismatch")
+var (
+	errAtlasChecksumMismatch     = errors.New("checksum mismatch")
+	errAtlasChecksumFileNotFound = errors.New("checksum file not found")
+)
 
 // NewMigrateValidateCommand returns the migration validation command.
 func NewMigrateValidateCommand() *cobra.Command {
@@ -82,23 +85,25 @@ func runNativeValidate(cmd *cobra.Command, dir, dirFormatValue, devURL string) e
 		return exitcode.New(1, errors.New("migration directory integrity check failed"))
 	}
 
-	return writeValidationSuccess(cmd, result)
+	return writeNativeValidationSuccess(cmd, result)
 }
 
 func runAtlasValidate(cmd *cobra.Command, dir, dirFormatValue, devURL string) error {
 	result, err := validate(cmd.Context(), dir, dirFormatValue, devURL)
-	if errors.Is(err, migratesum.ErrSumFileMalformed) {
-		return failAtlasChecksum(cmd, nil)
-	}
-	if err != nil {
+	switch {
+	case errors.Is(err, migratesum.ErrSumFileMissing):
+		return failAtlasChecksum(cmd, nil, errAtlasChecksumFileNotFound)
+	case errors.Is(err, migratesum.ErrSumFileMalformed):
+		return failAtlasChecksum(cmd, nil, errAtlasChecksumMismatch)
+	case err != nil:
 		return cmdutil.Fail(cmd, err)
 	}
 
 	if !result.Integrity.OK() {
-		return failAtlasChecksum(cmd, result.Integrity.FirstMismatch())
+		return failAtlasChecksum(cmd, result.Integrity.FirstMismatch(), errAtlasChecksumMismatch)
 	}
 
-	return writeValidationSuccess(cmd, result)
+	return nil
 }
 
 func validate(
@@ -121,24 +126,31 @@ func validate(
 	})
 }
 
-func writeValidationSuccess(cmd *cobra.Command, result migrationvalidate.Result) error {
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "OK: migrations directory matches %s\n", result.Integrity.SumFileName)
+func writeNativeValidationSuccess(cmd *cobra.Command, result migrationvalidate.Result) error {
+	var message strings.Builder
+	fmt.Fprintf(&message, "OK: migrations directory matches %s\n", result.Integrity.SumFileName)
 	if result.DevSQLValidated {
-		fmt.Fprintln(out, "OK: migration SQL validated on dev database")
+		message.WriteString("OK: migration SQL validated on dev database\n")
+	}
+	if _, err := io.WriteString(cmd.OutOrStdout(), message.String()); err != nil {
+		return fmt.Errorf("write validation success: %w", err)
 	}
 	return nil
 }
 
-func failAtlasChecksum(cmd *cobra.Command, mismatch *migratesum.Mismatch) error {
+func failAtlasChecksum(
+	cmd *cobra.Command,
+	mismatch *migratesum.Mismatch,
+	atlasErr error,
+) error {
 	writeErr := errors.Join(
 		writeAtlasChecksumGuidance(cmd.OutOrStdout(), mismatch),
-		writeAtlasChecksumError(cmd.ErrOrStderr()),
+		writeAtlasChecksumError(cmd.ErrOrStderr(), atlasErr),
 	)
 	if writeErr != nil {
-		return exitcode.New(1, fmt.Errorf("%w: failed to write checksum output: %w", errAtlasChecksumMismatch, writeErr))
+		return exitcode.New(1, fmt.Errorf("%w: failed to write checksum output: %w", atlasErr, writeErr))
 	}
-	return exitcode.New(1, errAtlasChecksumMismatch)
+	return exitcode.New(1, atlasErr)
 }
 
 func writeAtlasChecksumGuidance(w io.Writer, mismatch *migratesum.Mismatch) error {
@@ -154,8 +166,8 @@ func writeAtlasChecksumGuidance(w io.Writer, mismatch *migratesum.Mismatch) erro
 	return nil
 }
 
-func writeAtlasChecksumError(w io.Writer) error {
-	if _, err := fmt.Fprintln(w, "Error: checksum mismatch"); err != nil {
+func writeAtlasChecksumError(w io.Writer, atlasErr error) error {
+	if _, err := fmt.Fprintf(w, "Error: %s\n", atlasErr); err != nil {
 		return fmt.Errorf("write checksum error: %w", err)
 	}
 	return nil

--- a/cmd/migratevalidate/migratevalidate_test.go
+++ b/cmd/migratevalidate/migratevalidate_test.go
@@ -52,9 +52,10 @@ func migrationsDir(c *qt.C) string {
 func TestValidate_CleanDirectoryExitsZero(t *testing.T) {
 	c := qt.New(t)
 
-	stdout, _, err := execute("--dir", migrationsDir(c))
+	stdout, stderr, err := execute("--dir", migrationsDir(c))
 	c.Assert(err, qt.IsNil)
-	c.Assert(stdout, qt.Contains, "OK: migrations directory matches ptah.sum")
+	c.Assert(stdout, qt.Equals, "OK: migrations directory matches ptah.sum\n")
+	c.Assert(stderr, qt.Equals, "")
 }
 
 func TestValidate_AutoReadsAtlasSum(t *testing.T) {
@@ -151,6 +152,46 @@ func TestValidate_AtlasMalformedSumMatchesAtlasStreams(t *testing.T) {
 	c.Assert(stderr, qt.Equals, "Error: checksum mismatch\n")
 }
 
+func TestValidate_AtlasCleanDirectoryIsSilent(t *testing.T) {
+	c := qt.New(t)
+	dir := cleanAtlasDirectory(c)
+
+	stdout, stderr, err := executeAtlas("--dir", dir, "--dir-format", "atlas")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Equals, "")
+}
+
+func TestValidate_AtlasDevReplayIsSilent(t *testing.T) {
+	c := qt.New(t)
+	dir := cleanAtlasDirectory(c)
+	devDBPath := filepath.Join(t.TempDir(), "dev.db")
+
+	stdout, stderr, err := executeAtlas(
+		"--dir", dir,
+		"--dir-format", "atlas",
+		"--dev-url", "sqlite://"+devDBPath,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Equals, "")
+}
+
+func TestValidate_AtlasMissingSumMatchesAtlasStreams(t *testing.T) {
+	c := qt.New(t)
+	dir := atlasDirectoryWithoutSum(c)
+
+	stdout, stderr, err := executeAtlas("--dir", dir, "--dir-format", "atlas")
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err, qt.ErrorMatches, "checksum file not found")
+	c.Assert(stdout, qt.Equals, "You have a checksum error in your migration directory.\n"+
+		"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+	c.Assert(stderr, qt.Equals, "Error: checksum file not found\n")
+}
+
 func TestValidate_AtlasIntegrityDriftMatchesAtlasStreams(t *testing.T) {
 	c := qt.New(t)
 
@@ -234,6 +275,20 @@ func TestValidate_NativeDuplicateSumEntryExitsTwo(t *testing.T) {
 	c.Assert(stderr, qt.Contains, `duplicate entry for "1_initial.sql"`)
 }
 
+func TestValidate_NativeSuccessStdoutWriteFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := migrationsDir(c)
+	cmd := migratevalidate.NewMigrateValidateCommand()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"--dir", dir})
+
+	err := cmd.Execute()
+
+	c.Assert(exitcode.Code(err, 2), qt.Equals, 2)
+	c.Assert(err, qt.ErrorIs, errWriteFailed)
+	c.Assert(err, qt.ErrorMatches, "write validation success: write failed")
+}
+
 func TestValidate_AtlasChecksumStdoutWriteFailure(t *testing.T) {
 	c := qt.New(t)
 	dir := malformedAtlasDirectory(c)
@@ -267,13 +322,62 @@ func TestValidate_AtlasChecksumStderrWriteFailure(t *testing.T) {
 		"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
 }
 
+func TestValidate_AtlasMissingSumStdoutWriteFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := atlasDirectoryWithoutSum(c)
+	cmd := migratevalidate.NewAtlasMigrateValidateCommand()
+	var stderr bytes.Buffer
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--dir", dir, "--dir-format", "atlas"})
+
+	err := cmd.Execute()
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err, qt.ErrorIs, errWriteFailed)
+	c.Assert(err, qt.ErrorMatches, "checksum file not found: failed to write checksum output: write checksum guidance: write failed")
+	c.Assert(stderr.String(), qt.Equals, "Error: checksum file not found\n")
+}
+
+func TestValidate_AtlasMissingSumStderrWriteFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := atlasDirectoryWithoutSum(c)
+	cmd := migratevalidate.NewAtlasMigrateValidateCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(failingWriter{})
+	cmd.SetArgs([]string{"--dir", dir, "--dir-format", "atlas"})
+
+	err := cmd.Execute()
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+	c.Assert(err, qt.ErrorIs, errWriteFailed)
+	c.Assert(err, qt.ErrorMatches, "checksum file not found: failed to write checksum output: write checksum error: write failed")
+	c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
+		"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+}
+
 func malformedAtlasDirectory(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirectoryWithoutSum(c)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
+		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
+	return dir
+}
+
+func cleanAtlasDirectory(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirectoryWithoutSum(c)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+func atlasDirectoryWithoutSum(c *qt.C) string {
 	c.Helper()
 	dir := c.TempDir()
 	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"),
 		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
-		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
 	return dir
 }
 

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -8,13 +8,16 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 func TestCompatBinaryNamedAtlasResolvesRootCommands(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
 
-	run := exec.Command(binPath, "migrate", "down", "--help")
+	run := newCompatProcess(binPath, "migrate", "down", "--help")
 	runOut, err := run.CombinedOutput()
 
 	output := string(runOut)
@@ -36,14 +39,14 @@ func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 		{
 			name: "unknown flag",
 			command: func(binPath string) *exec.Cmd {
-				return exec.Command(binPath, "version", "--bogus-flag")
+				return newCompatProcess(binPath, "version", "--bogus-flag")
 			},
 			wantStderr: "error: unknown flag: --bogus-flag\n",
 		},
 		{
 			name: "mutually exclusive flags",
 			command: func(binPath string) *exec.Cmd {
-				return exec.Command(
+				return newCompatProcess(
 					binPath,
 					"schema", "apply",
 					"--url", "sqlite://schema.db",
@@ -57,9 +60,9 @@ func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 		{
 			name: "lazy completion command",
 			command: func(binPath string) *exec.Cmd {
-				return exec.Command(binPath, "completion", "bash", "extra")
+				return newCompatProcess(binPath, "completion", "bash", "extra")
 			},
-			wantStderr: "error: unknown command \"extra\" for \"atlas completion bash\"\n",
+			wantStderr: "Error: unknown command \"extra\" for \"atlas completion bash\"\n",
 		},
 		{
 			name: "unknown root command",
@@ -84,23 +87,116 @@ func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 	}
 }
 
-func TestCompatBinaryChecksumMismatchMatchesAtlasStreams(t *testing.T) {
+func TestCompatBinaryAtlasSuccessPaths(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
-	dir := malformedAtlasDir(c)
 
-	run := exec.Command(binPath, "migrate", "validate", "--dir", dir)
-	var stdout, stderr bytes.Buffer
-	run.Stdout = &stdout
-	run.Stderr = &stderr
-	err := run.Run()
-	var exitErr *exec.ExitError
+	c.Run("clean validation is silent", func(c *qt.C) {
+		dir := cleanAtlasDir(c)
+		run := newCompatProcess(binPath, "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
 
-	c.Assert(err, qt.ErrorAs, &exitErr)
-	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
-	c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
-		"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
-	c.Assert(stderr.String(), qt.Equals, "Error: checksum mismatch\n")
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Equals, "")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("nested extra token prints help", func(c *qt.C) {
+		run := newCompatProcess(binPath, "migrate", "aplly")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "Usage:\n  atlas migrate [command]")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("completion group extra token prints help", func(c *qt.C) {
+		run := newCompatProcess(binPath, "completion", "sh")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "Usage:\n  atlas completion [command]")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("completion script is generated for the Atlas executable", func(c *qt.C) {
+		run := newCompatProcess(binPath, "completion", "bash")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "# bash completion V2 for atlas")
+		c.Assert(stdout.String(), qt.Contains, "__start_atlas")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+}
+
+func TestCompatBinaryAtlasFailurePaths(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+
+	c.Run("checksum mismatch", func(c *qt.C) {
+		dir := malformedAtlasDir(c)
+		run := newCompatProcess(binPath, "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
+			"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+		c.Assert(stderr.String(), qt.Equals, "Error: checksum mismatch\n")
+	})
+
+	c.Run("missing checksum file", func(c *qt.C) {
+		dir := atlasDirWithoutSum(c)
+		run := newCompatProcess(binPath, "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
+			"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+		c.Assert(stderr.String(), qt.Equals, "Error: checksum file not found\n")
+	})
+
+	c.Run("unknown root command", func(c *qt.C) {
+		run := newCompatProcess(binPath, "definitely-not-a-command")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "")
+		c.Assert(stderr.String(), qt.Equals,
+			"Error: unknown command \"definitely-not-a-command\" for \"atlas\"\n"+
+				"Run 'atlas --help' for usage.\n")
+	})
 }
 
 func buildCompatBinary(c *qt.C) string {
@@ -113,12 +209,30 @@ func buildCompatBinary(c *qt.C) string {
 	return binPath
 }
 
+func newCompatProcess(binPath string, args ...string) *exec.Cmd {
+	return exec.Command(binPath, args...)
+}
+
 func malformedAtlasDir(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirWithoutSum(c)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
+		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
+	return dir
+}
+
+func cleanAtlasDir(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirWithoutSum(c)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+func atlasDirWithoutSum(c *qt.C) string {
 	c.Helper()
 	dir := c.TempDir()
 	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"),
 		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
-		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
 	return dir
 }

--- a/cmd/ptah/main_test.go
+++ b/cmd/ptah/main_test.go
@@ -8,44 +8,136 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
-func TestPtahAtlasChecksumMismatchMatchesAtlasStreams(t *testing.T) {
+func TestPtahAtlasCompatibilitySuccessPaths(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildPtahBinary(c)
-	dir := malformedAtlasDir(c)
 
-	run := exec.Command(binPath, "atlas", "migrate", "validate", "--dir", dir)
-	var stdout, stderr bytes.Buffer
-	run.Stdout = &stdout
-	run.Stderr = &stderr
-	err := run.Run()
-	var exitErr *exec.ExitError
+	c.Run("clean validation is silent", func(c *qt.C) {
+		dir := cleanAtlasDir(c)
+		run := newPtahProcess(binPath, "atlas", "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
 
-	c.Assert(err, qt.ErrorAs, &exitErr)
-	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
-	c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
-		"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
-	c.Assert(stderr.String(), qt.Equals, "Error: checksum mismatch\n")
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Equals, "")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("nested extra token prints help", func(c *qt.C) {
+		run := newPtahProcess(binPath, "atlas", "migrate", "aplly")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "Usage:\n  ptah atlas migrate [command]")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("completion group extra token prints help", func(c *qt.C) {
+		run := newPtahProcess(binPath, "atlas", "completion", "sh")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "Usage:\n  ptah atlas completion [command]")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
+
+	c.Run("completion script is generated for the full Ptah CLI", func(c *qt.C) {
+		run := newPtahProcess(binPath, "atlas", "completion", "bash")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+
+		err := run.Run()
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(stdout.String(), qt.Contains, "# bash completion V2 for ptah")
+		c.Assert(stdout.String(), qt.Contains, "__start_ptah")
+		c.Assert(stderr.String(), qt.Equals, "")
+	})
 }
 
-func TestPtahAtlasUnknownCommandMatchesAtlasDiagnostic(t *testing.T) {
+func TestPtahAtlasCompatibilityFailurePaths(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildPtahBinary(c)
 
-	run := exec.Command(binPath, "atlas", "definitely-not-a-command")
-	var stdout, stderr bytes.Buffer
-	run.Stdout = &stdout
-	run.Stderr = &stderr
-	err := run.Run()
-	var exitErr *exec.ExitError
+	c.Run("checksum mismatch", func(c *qt.C) {
+		dir := malformedAtlasDir(c)
+		run := newPtahProcess(binPath, "atlas", "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
 
-	c.Assert(err, qt.ErrorAs, &exitErr)
-	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
-	c.Assert(stdout.String(), qt.Equals, "")
-	c.Assert(stderr.String(), qt.Equals,
-		"Error: unknown command \"definitely-not-a-command\" for \"ptah atlas\"\n"+
-			"Run 'ptah atlas --help' for usage.\n")
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
+			"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+		c.Assert(stderr.String(), qt.Equals, "Error: checksum mismatch\n")
+	})
+
+	c.Run("missing checksum file", func(c *qt.C) {
+		dir := atlasDirWithoutSum(c)
+		run := newPtahProcess(binPath, "atlas", "migrate", "validate", "--dir", "file://"+dir)
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "You have a checksum error in your migration directory.\n"+
+			"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n")
+		c.Assert(stderr.String(), qt.Equals, "Error: checksum file not found\n")
+	})
+
+	c.Run("unknown root command", func(c *qt.C) {
+		run := newPtahProcess(binPath, "atlas", "definitely-not-a-command")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "")
+		c.Assert(stderr.String(), qt.Equals,
+			"Error: unknown command \"definitely-not-a-command\" for \"atlas\"\n"+
+				"Run 'atlas --help' for usage.\n")
+	})
+
+	c.Run("completion shell extra token", func(c *qt.C) {
+		run := newPtahProcess(binPath, "atlas", "completion", "bash", "extra")
+		var stdout, stderr bytes.Buffer
+		run.Stdout = &stdout
+		run.Stderr = &stderr
+		err := run.Run()
+		var exitErr *exec.ExitError
+
+		c.Assert(err, qt.ErrorAs, &exitErr)
+		c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+		c.Assert(stdout.String(), qt.Equals, "")
+		c.Assert(stderr.String(), qt.Equals,
+			"Error: unknown command \"extra\" for \"atlas completion bash\"\n")
+	})
 }
 
 func buildPtahBinary(c *qt.C) string {
@@ -58,12 +150,30 @@ func buildPtahBinary(c *qt.C) string {
 	return binPath
 }
 
+func newPtahProcess(binPath string, args ...string) *exec.Cmd {
+	return exec.Command(binPath, args...)
+}
+
 func malformedAtlasDir(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirWithoutSum(c)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
+		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
+	return dir
+}
+
+func cleanAtlasDir(c *qt.C) string {
+	c.Helper()
+	dir := atlasDirWithoutSum(c)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+func atlasDirWithoutSum(c *qt.C) string {
 	c.Helper()
 	dir := c.TempDir()
 	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"),
 		[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.sum"),
-		[]byte("h1:tampered\n"), 0o600), qt.IsNil)
 	return dir
 }

--- a/cmd/root/root_internal_test.go
+++ b/cmd/root/root_internal_test.go
@@ -195,7 +195,7 @@ func TestZZZAtlasUsageErrorsExit1WithoutUsage(t *testing.T) {
 		{
 			name:       "lazy completion command",
 			args:       []string{"atlas", "completion", "bash", "extra"},
-			wantStderr: "Error: unknown command \"completion\" for \"ptah atlas\"\nRun 'ptah atlas --help' for usage.\n",
+			wantStderr: "Error: unknown command \"extra\" for \"atlas completion bash\"\n",
 		},
 	}
 

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -83,9 +83,19 @@ input, missing files, configuration errors, and database failures, also exit
 `1`. This normalization applies only to the compatibility trees; equivalent
 native Ptah command failures keep exit code `2`.
 
-For `migrate validate`, checksum mismatches exit `1`, write Atlas's guidance to
-stdout, and write `Error: checksum mismatch` to stderr. Entry-level drift also
-identifies the first mismatched `atlas.sum` line, file, and reason. The native
-`ptah migrations validate` command keeps its own diagnostics: malformed sum
-files are usage failures with exit `2`, while valid integrity drift exits `1`
-with Ptah's native drift report.
+An unknown root command exits `1` and writes Atlas's `unknown command`
+diagnostic plus `atlas --help` guidance to stderr. Atlas CE treats an extra
+token under the `migrate` or `schema` command group differently: it prints that
+group's help to stdout and exits `0`. Both compatibility surfaces preserve this
+distinction. The same group behavior applies to `completion`; an extra token
+after a concrete shell command exits `1` with Atlas's leaf-command diagnostic.
+
+Successful `migrate validate` runs are silent, including successful
+`--dev-url` SQL replay. Checksum mismatches exit `1`, write Atlas's recovery
+guidance to stdout, and write `Error: checksum mismatch` to stderr. A missing
+`atlas.sum` uses the same stdout guidance and writes
+`Error: checksum file not found` to stderr. Entry-level drift also identifies
+the first mismatched `atlas.sum` line, file, and reason. The native
+`ptah migrations validate` command keeps its own success and error diagnostics:
+malformed or missing sum files are usage failures with exit `2`, while valid
+integrity drift exits `1` with Ptah's native drift report.

--- a/docs/site/src/content/docs/reference/commands.md
+++ b/docs/site/src/content/docs/reference/commands.md
@@ -65,10 +65,11 @@ executable name.
 | --- | --- |
 | `ptah atlas version` | Prints Ptah build information. |
 | `ptah atlas license` | Prints Ptah MIT license and license-clean Atlas compatibility notice. |
+| `ptah atlas completion <shell>` | Generates shell completion output for the full `ptah` command tree, including the Atlas-compatible namespace. |
 | `ptah atlas migrate apply` | Applies Atlas-format migration directories with Atlas-compatible apply flags. With `--env`, reads `env.url`, `migration`, and `format.migrate.apply` from `atlas.hcl`. |
 | `ptah atlas migrate status` | Reports Atlas-format migration status with Atlas revision-table metadata and Atlas-format migration directories by default; supports `--dir-format atlas`, `--revisions-schema`, and Atlas Go-template `--format` output over `.Env`, `.Available`, `.Applied`, `.Pending`, `.Current`, `.Next`, and `.Status`. |
 | `ptah atlas migrate hash` | Forwards to `ptah migrations hash` with Atlas `--dir-format` defaulting to `atlas`, so the compatibility path writes `atlas.sum` by default. |
-| `ptah atlas migrate validate` | Verifies `atlas.sum`; checksum mismatches use Atlas-compatible exit-1 stdout/stderr diagnostics, and `--dev-url` cleans the dev database and replays the migration directory to validate SQL execution. |
+| `ptah atlas migrate validate` | Silently verifies `atlas.sum` on success; missing or mismatched checksum files use Atlas-compatible exit-1 stdout/stderr diagnostics, and `--dev-url` cleans the dev database and replays the migration directory to validate SQL execution. |
 | `ptah atlas migrate lint` | Runs Ptah migration linting with Atlas `--dir-format` defaulting to `atlas`; maps `--latest N` and `--git-base/--git-dir` to native changeset linting, infers lint dialect from `--dev-url`, cleans and replays migrations on directly connectable dev databases, and supports Atlas Go-template `--format` output over `.Env`, `.Steps`, and `.Files`. Docker dev databases and web reports remain explicit gaps. |
 | `ptah atlas migrate new` | Creates an Atlas single-file skeleton migration and updates `atlas.sum` by default; supports `--dir-format atlas`. |
 | `ptah atlas migrate set [version]` | Sets or rewrites the Atlas-format revision row for the positional version by forwarding to `ptah migrations repair` with Atlas revision-table metadata and Atlas-format migration directories by default. With `--env`, reads `env.url`, `migration.dir`, and `migration.revisions_schema` from `atlas.hcl`; explicit `--dir`, `--url`, and `--revisions-schema` flags keep CLI precedence. |

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -99,11 +99,21 @@ input, missing files, configuration errors, and database failures, also exit
 `1`. This normalization applies only to the compatibility trees; equivalent
 native Ptah command failures keep exit code `2`.
 
-For `migrate validate`, checksum mismatches exit `1`, write Atlas's guidance to
-stdout, and write `Error: checksum mismatch` to stderr. Entry-level drift also
-identifies the first mismatched `atlas.sum` line, file, and reason. The native
-`ptah migrations validate` command keeps its own diagnostics: malformed sum
-files are usage failures with exit `2`, while valid integrity drift exits `1`
-with Ptah's native drift report.
+An unknown root command exits `1` and writes Atlas's `unknown command`
+diagnostic plus `atlas --help` guidance to stderr. Atlas CE treats an extra
+token under the `migrate` or `schema` command group differently: it prints that
+group's help to stdout and exits `0`. Both compatibility surfaces preserve this
+distinction. The same group behavior applies to `completion`; an extra token
+after a concrete shell command exits `1` with Atlas's leaf-command diagnostic.
+
+Successful `migrate validate` runs are silent, including successful
+`--dev-url` SQL replay. Checksum mismatches exit `1`, write Atlas's recovery
+guidance to stdout, and write `Error: checksum mismatch` to stderr. A missing
+`atlas.sum` uses the same stdout guidance and writes
+`Error: checksum file not found` to stderr. Entry-level drift also identifies
+the first mismatched `atlas.sum` line, file, and reason. The native
+`ptah migrations validate` command keeps its own success and error diagnostics:
+malformed or missing sum files are usage failures with exit `2`, while valid
+integrity drift exits `1` with Ptah's native drift report.
 
 This page is checked against the repository exit-code contract during docs CI.

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -53,7 +53,7 @@ SQL paths; prefer `--to` in new Ptah-authored scripts.
 | `ptah atlas migrate down` | Forwards to `ptah migrations down`; maps compatible Atlas flags and fails explicitly for dynamic down-planning and output-format flags that native Ptah does not implement yet. |
 | `ptah atlas migrate status` | Atlas-format migration status with Atlas revision-table metadata |
 | `ptah atlas migrate hash` | `ptah migrations hash` |
-| `ptah atlas migrate validate` | Verifies `atlas.sum` with Atlas-compatible checksum diagnostics; with `--dev-url`, cleans and replays migrations on the dev database to validate SQL execution. |
+| `ptah atlas migrate validate` | Silently verifies `atlas.sum` on success; checksum failures use Atlas-compatible stdout/stderr diagnostics, and `--dev-url` cleans and replays migrations on the dev database to validate SQL execution. |
 | `ptah atlas migrate lint` | `ptah migrations lint`; supports Atlas-style `--latest N`, infers lint dialect from `--dev-url`, and cleans and replays migrations on directly connectable dev databases to validate SQL execution. |
 | `ptah atlas migrate new` | `ptah migrations create` |
 | `ptah atlas migrate set [version]` | `ptah migrations repair` with Atlas revision metadata |
@@ -67,6 +67,7 @@ SQL paths; prefer `--to` in new Ptah-authored scripts.
 | --- | --- |
 | `ptah atlas version` | Prints Ptah build information. |
 | `ptah atlas license` | Prints Ptah MIT license and license-clean Atlas compatibility notice. |
+| `ptah atlas completion <shell>` | Generates Cobra completion output for the full `ptah` command tree, including the Atlas-compatible namespace. |
 
 ## Schema commands
 
@@ -318,13 +319,17 @@ replays the migration directory to validate SQL execution semantics. If
 integrity drift is found, Ptah reports the drift and does not connect to the dev
 database.
 
+A successful validation is silent, including a successful `--dev-url` replay.
 Checksum mismatches exit `1`, print Atlas-compatible recovery guidance to
-stdout, and print `Error: checksum mismatch` to stderr. For added, edited, or
-removed migration files, the stdout guidance includes the first mismatched
-`atlas.sum` line, file name, and reason. This compatibility behavior is scoped
-to `ptah atlas` and `ptah-compat`; native `ptah migrations validate` keeps
-Ptah's native output and treats a malformed sum file as an exit-`2` usage
-failure.
+stdout, and print `Error: checksum mismatch` to stderr. If `atlas.sum` is
+missing, the command prints the same recovery guidance and writes
+`Error: checksum file not found` to stderr. For added, edited, or removed
+migration files, the stdout guidance includes the first mismatched `atlas.sum`
+line, file name, and reason.
+
+This compatibility behavior is scoped to `ptah atlas` and `ptah-compat`.
+Native `ptah migrations validate` keeps Ptah's success banner and native error
+output; missing or malformed sum files remain exit-`2` usage failures.
 
 ```bash
 ptah atlas migrate validate \


### PR DESCRIPTION
## Summary

- keep successful Atlas-compatible `migrate validate` silent while preserving native Ptah success output
- match Atlas CE missing-checksum guidance, root diagnostics, typo suggestions, command-group help, and completion leaf errors
- expose completion generation on both compatibility surfaces and preserve the full `ptah` completion tree under `ptah atlas`
- propagate help, diagnostic, checksum, and native validation writer failures instead of reporting false success
- document the exact exit-code and stdout/stderr contracts

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go tool qtlint ./...`
- `./scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `npm run build` in `docs/site`
- `npm run versions:selftest` in `docs/site`
- pinned Atlas CE v1.2.0 direct exit/output oracle
- companion conformance against fresh `ptah` and `atlas` binaries: 744/744 offline observations and 122/122 CLI-surface observations green

Closes #723
Closes #725
Closes #727