### PR TITLE
Add `ptah migrations test` declarative migration test runner (#659)

### DIFF
--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migrateup"
 	"github.com/stokaro/ptah/cmd/migratevalidate"
 	"github.com/stokaro/ptah/cmd/migrationsimport"
+	"github.com/stokaro/ptah/cmd/migrationstest"
 )
 
 // NewMigrationsCommand returns the native migration command namespace.
@@ -54,6 +55,7 @@ ptah atlas.`,
 	cmd.AddCommand(migrationCommand(migrateedit.NewMigrateEditCommand(), "Edit a migration and re-hash", "Edit a migration's SQL and rewrite the integrity file, refusing already-applied migrations."))
 	cmd.AddCommand(migrationCommand(migraterebase.NewMigrateRebaseCommand(), "Move a migration to the end of history", "Re-timestamp a migration to the end of history and rewrite the integrity file, refusing already-applied migrations."))
 	cmd.AddCommand(migrationCommand(migraterm.NewMigrateRmCommand(), "Delete a migration and re-hash", "Delete a migration's up/down pair and rewrite the integrity file, refusing already-applied migrations."))
+	cmd.AddCommand(migrationCommand(migrationstest.NewMigrationsTestCommand(), "Run declarative migration tests", "Run declarative YAML migration test cases against an ephemeral or throwaway database."))
 
 	return cmd
 }

--- a/cmd/migrationstest/migrationstest.go
+++ b/cmd/migrationstest/migrationstest.go
@@ -1,0 +1,108 @@
+// Package migrationstest implements the "ptah migrations test" command, which
+// runs declarative YAML migration test cases against an ephemeral or throwaway
+// database.
+package migrationstest
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/migration/dbtest"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const (
+	dirFlag           = "dir"
+	migrationsDirFlag = "migrations-dir"
+	dbURLFlag         = "db-url"
+	dirFormatFlag     = "dir-format"
+	reportFlag        = "report"
+
+	reportFormatText = "text"
+)
+
+type options struct {
+	dir           string
+	migrationsDir string
+	dbURL         string
+	dirFormat     string
+	report        string
+}
+
+// NewMigrationsTestCommand returns the "test" command for the migrations
+// namespace.
+func NewMigrationsTestCommand() *cobra.Command {
+	opts := options{}
+	cmd := &cobra.Command{
+		Use:          "test",
+		Short:        "Run declarative migration tests",
+		SilenceUsage: true,
+		Long: `Run declarative YAML migration test cases against a throwaway database.
+
+Each test file is a YAML document with a top-level cases: list. A case is a
+named, ordered list of steps; each step performs exactly one action:
+
+  - migrate_to: migrate to a target version (an integer, "latest", or "0").
+  - exec:       run raw SQL.
+  - assert:     run a query and check one of row_count, scalar, or
+                error_contains.
+
+When --db-url is omitted, an ephemeral SQLite database is provisioned in a
+temporary directory and removed afterwards. When --db-url is set it must point
+at a throwaway database, because tests mutate schema and data.
+
+The command exits non-zero if any case fails.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return run(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.dir, dirFlag, "./tests", "Directory containing declarative test-case YAML files")
+	flags.StringVar(&opts.migrationsDir, migrationsDirFlag, "./migrations", "Directory containing migration files")
+	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
+	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format: auto, ptah, or atlas")
+	flags.StringVar(&opts.report, reportFlag, reportFormatText, "Report format (only \"text\" is supported)")
+
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
+}
+
+func run(ctx context.Context, out io.Writer, opts options) error {
+	if opts.report != "" && opts.report != reportFormatText {
+		return fmt.Errorf("unsupported report format %q: only %q is supported", opts.report, reportFormatText)
+	}
+
+	dirFormat, err := migrator.ParseMigrationDirFormat(opts.dirFormat)
+	if err != nil {
+		return err
+	}
+
+	cases, err := dbtest.LoadCases(opts.dir)
+	if err != nil {
+		return fmt.Errorf("failed to load test cases: %w", err)
+	}
+	if len(cases) == 0 {
+		return fmt.Errorf("no test cases found in %s", opts.dir)
+	}
+
+	report, err := dbtest.RunMigrationTest(ctx, dbtest.Options{
+		Cases:         cases,
+		MigrationsDir: opts.migrationsDir,
+		DBURL:         opts.dbURL,
+		DirFormat:     dirFormat,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(out, report.Text())
+	if report.Failed() {
+		return fmt.Errorf("migration tests failed")
+	}
+	return nil
+}

--- a/cmd/migrationstest/migrationstest_test.go
+++ b/cmd/migrationstest/migrationstest_test.go
@@ -1,0 +1,88 @@
+package migrationstest_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migrationstest"
+)
+
+func writeMigrationPair(c *qt.C, dir, name, up, down string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(dir, name+".up.sql"), []byte(up), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, name+".down.sql"), []byte(down), 0o600), qt.IsNil)
+}
+
+func runTestCommand(args ...string) (string, error) {
+	cmd := migrationstest.NewMigrationsTestCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return out.String(), err
+}
+
+func TestMigrationsTestCommand_Passes(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := t.TempDir()
+	testsDir := t.TempDir()
+	writeMigrationPair(c, migrationsDir, "0000000001_create_users",
+		"CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);", "DROP TABLE users;")
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "users.yaml"), []byte(
+		"cases:\n"+
+			"  - name: users table works\n"+
+			"    steps:\n"+
+			"      - name: migrate\n"+
+			"        migrate_to: latest\n"+
+			"      - name: insert\n"+
+			"        exec: INSERT INTO users (name) VALUES ('ada')\n"+
+			"      - name: one user\n"+
+			"        assert:\n"+
+			"          query: SELECT COUNT(*) FROM users\n"+
+			"          scalar: \"1\"\n"), 0o600), qt.IsNil)
+
+	out, err := runTestCommand("--dir", testsDir, "--migrations-dir", migrationsDir, "--dir-format", "ptah")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "PASS  case \"users table works\"")
+	c.Assert(out, qt.Contains, "1 cases, 1 passed, 0 failed")
+}
+
+func TestMigrationsTestCommand_FailsWithNonZeroError(t *testing.T) {
+	c := qt.New(t)
+	testsDir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "fail.yaml"), []byte(
+		"cases:\n"+
+			"  - name: bad expectation\n"+
+			"    steps:\n"+
+			"      - name: create\n"+
+			"        exec: CREATE TABLE t (id INTEGER PRIMARY KEY)\n"+
+			"      - name: wrong count\n"+
+			"        assert:\n"+
+			"          query: SELECT id FROM t\n"+
+			"          row_count: 5\n"), 0o600), qt.IsNil)
+
+	out, err := runTestCommand("--dir", testsDir)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "migration tests failed")
+	c.Assert(out, qt.Contains, "FAIL  case \"bad expectation\"")
+}
+
+func TestMigrationsTestCommand_NoCasesFound(t *testing.T) {
+	c := qt.New(t)
+	_, err := runTestCommand("--dir", t.TempDir())
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "no test cases found")
+}
+
+func TestMigrationsTestCommand_RejectsUnsupportedReport(t *testing.T) {
+	c := qt.New(t)
+	_, err := runTestCommand("--dir", t.TempDir(), "--report", "html")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "unsupported report format")
+}

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -23,6 +23,7 @@ These packages are intended for application and tool embedders:
 - `github.com/stokaro/ptah/core/sqlutil`
 - `github.com/stokaro/ptah/dbschema`
 - `github.com/stokaro/ptah/dbschema/types`
+- `github.com/stokaro/ptah/migration/dbtest`
 - `github.com/stokaro/ptah/migration/diffpolicy`
 - `github.com/stokaro/ptah/migration/generator`
 - `github.com/stokaro/ptah/migration/importer`

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -636,6 +636,19 @@ type SchemaWriter interface {
     SchemaWriter interface for writing schemas to databases.
 
 
+## github.com/stokaro/ptah/migration/dbtest
+
+type Assertion struct{ ... }
+type Case struct{ ... }
+    func LoadCases(dir string) ([]Case, error)
+    func ParseCases(data []byte) ([]Case, error)
+type CaseResult struct{ ... }
+type Options struct{ ... }
+type Report struct{ ... }
+    func RunMigrationTest(ctx context.Context, opts Options) (*Report, error)
+type Step struct{ ... }
+type StepResult struct{ ... }
+
 ## github.com/stokaro/ptah/migration/diffpolicy
 
 type ChangeKind string

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -1,0 +1,188 @@
+// Package dbtest is a Ptah-native, declarative migration test runner.
+//
+// It applies a project's migrations to an ephemeral (or explicitly throwaway)
+// database and asserts on the result, so migration behavior can be exercised in
+// CI without a bespoke test harness. Test cases are authored either in Go using
+// the exported [Case]/[Step]/[Assertion] types, or as YAML loaded with
+// [ParseCases]/[LoadCases].
+//
+// # YAML format
+//
+// A test file is a YAML document with a top-level cases: list. Each case has a
+// name and an ordered list of steps. A step performs exactly one action:
+//
+//   - migrate_to: migrate the database to a target version. The value is an
+//     integer version, the string "latest" (migrate up to the newest
+//     migration), or the string "0" (roll everything back).
+//   - exec: run raw SQL against the database.
+//   - assert: run a query and check exactly one condition (row_count, scalar,
+//     or error_contains).
+//
+// Example:
+//
+//	cases:
+//	  - name: products table accepts rows
+//	    steps:
+//	      - name: migrate to latest
+//	        migrate_to: latest
+//	      - name: insert a product
+//	        exec: INSERT INTO products (name) VALUES ('widget')
+//	      - name: exactly one product exists
+//	        assert:
+//	          query: SELECT id FROM products
+//	          row_count: 1
+//	      - name: the product is named widget
+//	        assert:
+//	          query: SELECT name FROM products LIMIT 1
+//	          scalar: widget
+//	      - name: unknown table errors
+//	        assert:
+//	          query: SELECT * FROM does_not_exist
+//	          error_contains: does_not_exist
+//
+// # Phase 1 scope
+//
+// Phase 1 supports only the migrate_to, exec, and assert step kinds and the
+// row_count, scalar, and error_contains assertions listed above. Seed steps,
+// desired-schema application, and structured (HTML/JSON) reporting are out of
+// scope. Reporting is text only via [Report.Text].
+//
+// # Database isolation
+//
+// In the default (ephemeral) mode — no database URL supplied — each case runs
+// against its own fresh SQLite database, so state created by one case is never
+// visible to another. When an explicit throwaway database URL is supplied, all
+// cases share that one database and the caller is responsible for keeping them
+// independent.
+package dbtest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Case is a single declarative migration test: a named, ordered list of steps
+// executed against the test database.
+type Case struct {
+	Name  string `yaml:"name"`
+	Steps []Step `yaml:"steps"`
+}
+
+// Step performs exactly one action against the test database. Exactly one of
+// MigrateTo, Exec, or Assert must be set.
+type Step struct {
+	// Name is a human-readable label used in reporting. It is optional.
+	Name string `yaml:"name"`
+	// MigrateTo migrates the database to a target version. It accepts an integer
+	// version, "latest", or "0".
+	MigrateTo string `yaml:"migrate_to"`
+	// Exec runs raw SQL against the database.
+	Exec string `yaml:"exec"`
+	// Assert runs a query and checks a single condition on the result.
+	Assert *Assertion `yaml:"assert"`
+}
+
+// Assertion runs Query and checks exactly one of RowCount, Scalar, or
+// ErrorContains.
+type Assertion struct {
+	// Query is the SQL executed by the assertion. It is always required.
+	Query string `yaml:"query"`
+	// RowCount asserts that Query returns exactly this many rows.
+	RowCount *int `yaml:"row_count"`
+	// Scalar asserts that the first column of the first row of Query, formatted
+	// as a string, equals this value.
+	Scalar *string `yaml:"scalar"`
+	// ErrorContains asserts that running Query fails with an error message that
+	// contains this substring.
+	ErrorContains string `yaml:"error_contains"`
+}
+
+// stepKind classifies which action a [Step] performs.
+type stepKind int
+
+const (
+	stepKindNone stepKind = iota
+	stepKindMigrateTo
+	stepKindExec
+	stepKindAssert
+)
+
+// kind reports which single action the step performs and how many actions are
+// set. A well-formed step has exactly one action set.
+func (s Step) kind() (kind stepKind, setCount int) {
+	if s.MigrateTo != "" {
+		kind = stepKindMigrateTo
+		setCount++
+	}
+	if s.Exec != "" {
+		kind = stepKindExec
+		setCount++
+	}
+	if s.Assert != nil {
+		kind = stepKindAssert
+		setCount++
+	}
+	return kind, setCount
+}
+
+// validateCases validates a full set of cases, returning the first error found.
+func validateCases(cases []Case) error {
+	for i := range cases {
+		if err := cases[i].validate(); err != nil {
+			return fmt.Errorf("case %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+func (c Case) validate() error {
+	if strings.TrimSpace(c.Name) == "" {
+		return fmt.Errorf("test case has no name")
+	}
+	if len(c.Steps) == 0 {
+		return fmt.Errorf("test case %q has no steps", c.Name)
+	}
+	for i := range c.Steps {
+		if err := c.Steps[i].validate(); err != nil {
+			return fmt.Errorf("test case %q, step %d: %w", c.Name, i+1, err)
+		}
+	}
+	return nil
+}
+
+func (s Step) validate() error {
+	_, setCount := s.kind()
+	if setCount == 0 {
+		return fmt.Errorf("step must set exactly one of migrate_to, exec, or assert, but none is set")
+	}
+	if setCount > 1 {
+		return fmt.Errorf("step must set exactly one of migrate_to, exec, or assert, but %d are set", setCount)
+	}
+	if s.Assert != nil {
+		return s.Assert.validate()
+	}
+	return nil
+}
+
+func (a *Assertion) validate() error {
+	if strings.TrimSpace(a.Query) == "" {
+		return fmt.Errorf("assert requires a query")
+	}
+	setCount := 0
+	if a.RowCount != nil {
+		setCount++
+	}
+	if a.Scalar != nil {
+		setCount++
+	}
+	if a.ErrorContains != "" {
+		setCount++
+	}
+	if setCount == 0 {
+		return fmt.Errorf("assert must set exactly one of row_count, scalar, or error_contains, but none is set")
+	}
+	if setCount > 1 {
+		return fmt.Errorf("assert must set exactly one of row_count, scalar, or error_contains, but %d are set", setCount)
+	}
+	return nil
+}

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -85,12 +85,18 @@ type Step struct {
 // Assertion runs Query and checks exactly one of RowCount, Scalar, or
 // ErrorContains.
 type Assertion struct {
-	// Query is the SQL executed by the assertion. It is always required.
+	// Query is the SQL executed by the assertion. It is always required and
+	// should be a SELECT: with row_count and scalar it is run as a query, and
+	// with error_contains it is run and expected to fail, so a non-SELECT
+	// statement would execute its side effects.
 	Query string `yaml:"query"`
 	// RowCount asserts that Query returns exactly this many rows.
 	RowCount *int `yaml:"row_count"`
 	// Scalar asserts that the first column of the first row of Query, formatted
-	// as a string, equals this value.
+	// as a string, equals this value. Values are formatted deterministically:
+	// []byte and text as their string, time.Time as RFC3339, SQL NULL as
+	// "<nil>", and other types via fmt's default. Select a column as text (for
+	// example CAST(col AS TEXT)) to compare its raw stored form.
 	Scalar *string `yaml:"scalar"`
 	// ErrorContains asserts that running Query fails with an error message that
 	// contains this substring.
@@ -110,11 +116,11 @@ const (
 // kind reports which single action the step performs and how many actions are
 // set. A well-formed step has exactly one action set.
 func (s Step) kind() (kind stepKind, setCount int) {
-	if s.MigrateTo != "" {
+	if strings.TrimSpace(s.MigrateTo) != "" {
 		kind = stepKindMigrateTo
 		setCount++
 	}
-	if s.Exec != "" {
+	if strings.TrimSpace(s.Exec) != "" {
 		kind = stepKindExec
 		setCount++
 	}

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -1,0 +1,350 @@
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// Options configures a single [RunMigrationTest] invocation.
+type Options struct {
+	// Cases are the test cases to run, in order.
+	Cases []Case
+	// MigrationsDir is the directory containing migration files. It is required
+	// only when a case has a migrate_to step.
+	MigrationsDir string
+	// DBURL is an optional database URL to run the tests against. It must point
+	// at a throwaway database, because tests mutate schema and data. When empty,
+	// an ephemeral SQLite database is provisioned in a temporary directory and
+	// removed afterwards.
+	DBURL string
+	// DirFormat selects how MigrationsDir is parsed. The zero value defaults to
+	// the Ptah directory format.
+	DirFormat migrator.MigrationDirFormat
+}
+
+// Report is the outcome of a [RunMigrationTest] run.
+type Report struct {
+	Cases []CaseResult
+}
+
+// CaseResult is the outcome of a single [Case]. Passed is true only when every
+// executed step passed.
+type CaseResult struct {
+	Name   string
+	Steps  []StepResult
+	Passed bool
+}
+
+// StepResult is the outcome of a single [Step]. Detail carries a short
+// human-readable explanation of the result, especially on failure.
+type StepResult struct {
+	Name   string
+	Passed bool
+	Detail string
+}
+
+// Failed reports whether any case failed.
+func (r *Report) Failed() bool {
+	for i := range r.Cases {
+		if !r.Cases[i].Passed {
+			return true
+		}
+	}
+	return false
+}
+
+// Text renders a human-readable summary of the report.
+func (r *Report) Text() string {
+	var b strings.Builder
+	b.WriteString("=== MIGRATION TEST ===\n")
+
+	passed := 0
+	for i := range r.Cases {
+		c := r.Cases[i]
+		caseStatus := "FAIL"
+		if c.Passed {
+			caseStatus = "PASS"
+			passed++
+		}
+		fmt.Fprintf(&b, "%s  case %q\n", caseStatus, c.Name)
+		for j := range c.Steps {
+			s := c.Steps[j]
+			stepStatus := "FAIL"
+			if s.Passed {
+				stepStatus = "PASS"
+			}
+			label := s.Name
+			if label == "" {
+				label = "(unnamed step)"
+			}
+			if s.Detail != "" {
+				fmt.Fprintf(&b, "    %s  step %q — %s\n", stepStatus, label, s.Detail)
+				continue
+			}
+			fmt.Fprintf(&b, "    %s  step %q\n", stepStatus, label)
+		}
+	}
+
+	fmt.Fprintf(&b, "\n%d cases, %d passed, %d failed\n", len(r.Cases), passed, len(r.Cases)-passed)
+	return b.String()
+}
+
+// RunMigrationTest runs the test cases in opts against a database and returns a
+// report describing every case and step. A returned error indicates the run
+// itself could not be set up (for example, the test cases are invalid or the
+// database is unreachable); ordinary assertion failures are captured in the
+// report, not returned as an error, so callers should inspect [Report.Failed].
+func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
+	if err := validateCases(opts.Cases); err != nil {
+		return nil, fmt.Errorf("invalid test cases: %w", err)
+	}
+
+	dirFormat := opts.DirFormat
+	if dirFormat == "" {
+		dirFormat = migrator.MigrationDirFormatPtah
+	}
+
+	report := &Report{Cases: make([]CaseResult, 0, len(opts.Cases))}
+
+	// An explicit database URL is a single throwaway the caller owns, so all
+	// cases share one connection and the caller is responsible for isolating
+	// them. The default (ephemeral) mode instead gives each case its own fresh
+	// SQLite database so cases cannot contaminate one another.
+	if opts.DBURL != "" {
+		conn, err := dbschema.ConnectToDatabase(ctx, opts.DBURL)
+		if err != nil {
+			return nil, fmt.Errorf("connect to test database: %w", err)
+		}
+		defer dbschema.CloseAndWarn(conn)
+
+		r := &runner{conn: conn, migrationsDir: opts.MigrationsDir, dirFormat: dirFormat}
+		for i := range opts.Cases {
+			report.Cases = append(report.Cases, r.runCase(ctx, opts.Cases[i]))
+		}
+		return report, nil
+	}
+
+	for i := range opts.Cases {
+		result, err := runEphemeralCase(ctx, opts.Cases[i], opts.MigrationsDir, dirFormat)
+		if err != nil {
+			return nil, err
+		}
+		report.Cases = append(report.Cases, result)
+	}
+	return report, nil
+}
+
+// runEphemeralCase runs one case against a fresh SQLite database that exists
+// only for that case, so state created by one case is never visible to another.
+func runEphemeralCase(ctx context.Context, c Case, migrationsDir string, dirFormat migrator.MigrationDirFormat) (CaseResult, error) {
+	tmpDir, err := os.MkdirTemp("", "ptah-dbtest-*")
+	if err != nil {
+		return CaseResult{}, fmt.Errorf("create ephemeral database directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	dbURL := "sqlite://" + filepath.Join(tmpDir, "dbtest.db")
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	if err != nil {
+		return CaseResult{}, fmt.Errorf("connect to ephemeral test database: %w", err)
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	r := &runner{conn: conn, migrationsDir: migrationsDir, dirFormat: dirFormat}
+	return r.runCase(ctx, c), nil
+}
+
+// runner executes steps against a single shared database connection.
+type runner struct {
+	conn          *dbschema.DatabaseConnection
+	migrationsDir string
+	dirFormat     migrator.MigrationDirFormat
+}
+
+func (r *runner) runCase(ctx context.Context, c Case) CaseResult {
+	result := CaseResult{Name: c.Name, Passed: true, Steps: make([]StepResult, 0, len(c.Steps))}
+	for i := range c.Steps {
+		step := c.Steps[i]
+		passed, detail := r.execStep(ctx, step)
+		result.Steps = append(result.Steps, StepResult{Name: step.Name, Passed: passed, Detail: detail})
+		if !passed {
+			// Stop at the first failure: later steps almost always depend on the
+			// state the failed step was supposed to establish, so running them
+			// would produce noise rather than signal.
+			result.Passed = false
+			break
+		}
+	}
+	return result
+}
+
+func (r *runner) execStep(ctx context.Context, step Step) (passed bool, detail string) {
+	kind, _ := step.kind()
+	switch kind {
+	case stepKindMigrateTo:
+		return r.runMigrateTo(ctx, step.MigrateTo)
+	case stepKindExec:
+		return r.runExec(ctx, step.Exec)
+	case stepKindAssert:
+		return r.runAssert(ctx, step.Assert)
+	default:
+		return false, "step performs no action"
+	}
+}
+
+func (r *runner) runMigrateTo(ctx context.Context, target string) (passed bool, detail string) {
+	if r.migrationsDir == "" {
+		return false, "migrate_to requires a migrations directory"
+	}
+	m, err := r.newMigrator()
+	if err != nil {
+		return false, fmt.Sprintf("build migrator: %v", err)
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(target))
+	switch normalized {
+	case "latest":
+		if err := m.MigrateUp(ctx); err != nil {
+			return false, fmt.Sprintf("migrate to latest failed: %v", err)
+		}
+		return true, "migrated to latest"
+	case "0":
+		if err := m.MigrateDownTo(ctx, 0); err != nil {
+			return false, fmt.Sprintf("migrate to 0 failed: %v", err)
+		}
+		return true, "migrated to 0"
+	default:
+		version, err := strconv.ParseInt(normalized, 10, 64)
+		if err != nil {
+			return false, fmt.Sprintf("invalid migrate_to target %q: expected an integer, \"latest\", or \"0\"", target)
+		}
+		if err := m.MigrateTo(ctx, version); err != nil {
+			return false, fmt.Sprintf("migrate to %d failed: %v", version, err)
+		}
+		return true, fmt.Sprintf("migrated to %d", version)
+	}
+}
+
+func (r *runner) newMigrator() (*migrator.Migrator, error) {
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(r.migrationsDir), migrator.WithMigrationDirFormat(r.dirFormat))
+	if err != nil {
+		return nil, err
+	}
+	return migrator.NewMigrator(r.conn, provider).WithLogger(slog.New(slog.DiscardHandler)), nil
+}
+
+func (r *runner) runExec(ctx context.Context, sql string) (passed bool, detail string) {
+	if _, err := r.conn.ExecContext(ctx, sql); err != nil {
+		return false, fmt.Sprintf("exec failed: %v", err)
+	}
+	return true, "exec ok"
+}
+
+func (r *runner) runAssert(ctx context.Context, a *Assertion) (passed bool, detail string) {
+	switch {
+	case a.RowCount != nil:
+		return r.assertRowCount(ctx, a.Query, *a.RowCount)
+	case a.Scalar != nil:
+		return r.assertScalar(ctx, a.Query, *a.Scalar)
+	default:
+		return r.assertErrorContains(ctx, a.Query, a.ErrorContains)
+	}
+}
+
+func (r *runner) assertRowCount(ctx context.Context, query string, want int) (passed bool, detail string) {
+	rows, err := r.conn.QueryContext(ctx, query)
+	if err != nil {
+		return false, fmt.Sprintf("row_count query failed: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	got := 0
+	for rows.Next() {
+		got++
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Sprintf("row_count query failed while reading rows: %v", err)
+	}
+	if got != want {
+		return false, fmt.Sprintf("expected row_count %d, got %d", want, got)
+	}
+	return true, fmt.Sprintf("row_count %d", got)
+}
+
+func (r *runner) assertScalar(ctx context.Context, query, want string) (passed bool, detail string) {
+	rows, err := r.conn.QueryContext(ctx, query)
+	if err != nil {
+		return false, fmt.Sprintf("scalar query failed: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return false, fmt.Sprintf("scalar query failed to report columns: %v", err)
+	}
+	if len(cols) == 0 {
+		return false, "scalar query returned no columns"
+	}
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return false, fmt.Sprintf("scalar query failed while reading rows: %v", err)
+		}
+		return false, "scalar query returned no rows"
+	}
+
+	dests := make([]any, len(cols))
+	for i := range dests {
+		dests[i] = new(any)
+	}
+	if err := rows.Scan(dests...); err != nil {
+		return false, fmt.Sprintf("scalar query failed to scan row: %v", err)
+	}
+
+	got := normalizeScalar(*(dests[0].(*any)))
+	if got != want {
+		return false, fmt.Sprintf("expected scalar %q, got %q", want, got)
+	}
+	return true, fmt.Sprintf("scalar %q", got)
+}
+
+func (r *runner) assertErrorContains(ctx context.Context, query, want string) (passed bool, detail string) {
+	err := r.runExpectingError(ctx, query)
+	if err == nil {
+		return false, fmt.Sprintf("expected an error containing %q, but the query succeeded", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		return false, fmt.Sprintf("expected error to contain %q, got %q", want, err.Error())
+	}
+	return true, fmt.Sprintf("error contained %q", want)
+}
+
+// runExpectingError runs query and returns any error it produces, draining the
+// result set so errors that only surface during row iteration are observed.
+func (r *runner) runExpectingError(ctx context.Context, query string) error {
+	rows, err := r.conn.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		// Drain the result set so errors that only surface during row iteration
+		// are observed.
+	}
+	return rows.Err()
+}
+
+func normalizeScalar(v any) string {
+	if b, ok := v.([]byte); ok {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -26,7 +27,8 @@ type Options struct {
 	// removed afterwards.
 	DBURL string
 	// DirFormat selects how MigrationsDir is parsed. The zero value defaults to
-	// the Ptah directory format.
+	// the Ptah directory format (not the migrator's own "auto" default), so a
+	// direct caller that wants format auto-detection must set it explicitly.
 	DirFormat migrator.MigrationDirFormat
 }
 
@@ -342,9 +344,19 @@ func (r *runner) runExpectingError(ctx context.Context, query string) error {
 	return rows.Err()
 }
 
+// normalizeScalar renders a scanned value as the string an assertion compares
+// against. time.Time is formatted with a fixed layout so date/time columns —
+// which some drivers surface as time.Time rather than the stored text — compare
+// deterministically instead of via time.Time's default String form (which
+// appends " +0000 UTC"). To compare the raw stored text of a date/time column,
+// select it as text (for example `CAST(col AS TEXT)`).
 func normalizeScalar(v any) string {
-	if b, ok := v.([]byte); ok {
-		return string(b)
+	switch val := v.(type) {
+	case []byte:
+		return string(val)
+	case time.Time:
+		return val.Format(time.RFC3339Nano)
+	default:
+		return fmt.Sprintf("%v", v)
 	}
-	return fmt.Sprintf("%v", v)
 }

--- a/migration/dbtest/engine_test.go
+++ b/migration/dbtest/engine_test.go
@@ -1,0 +1,200 @@
+package dbtest_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/dbtest"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestRunMigrationTest_Assertions(t *testing.T) {
+	tests := []struct {
+		name       string
+		cases      []dbtest.Case
+		wantFailed bool
+	}{
+		{
+			name: "row_count and scalar pass",
+			cases: []dbtest.Case{{
+				Name: "products",
+				Steps: []dbtest.Step{
+					{Name: "create", Exec: "CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"},
+					{Name: "seed", Exec: "INSERT INTO products (name) VALUES ('a'), ('b')"},
+					{Name: "count", Assert: &dbtest.Assertion{Query: "SELECT id FROM products", RowCount: new(2)}},
+					{Name: "first", Assert: &dbtest.Assertion{Query: "SELECT name FROM products ORDER BY id LIMIT 1", Scalar: new("a")}},
+				},
+			}},
+			wantFailed: false,
+		},
+		{
+			name: "row_count mismatch fails",
+			cases: []dbtest.Case{{
+				Name: "empty table",
+				Steps: []dbtest.Step{
+					{Name: "create", Exec: "CREATE TABLE t (id INTEGER PRIMARY KEY)"},
+					{Name: "count", Assert: &dbtest.Assertion{Query: "SELECT id FROM t", RowCount: new(3)}},
+				},
+			}},
+			wantFailed: true,
+		},
+		{
+			name: "error_contains passes on failing query",
+			cases: []dbtest.Case{{
+				Name: "missing table errors",
+				Steps: []dbtest.Step{
+					{Name: "query missing", Assert: &dbtest.Assertion{Query: "SELECT * FROM missing_table", ErrorContains: "missing_table"}},
+				},
+			}},
+			wantFailed: false,
+		},
+		{
+			name: "error_contains fails when query succeeds",
+			cases: []dbtest.Case{{
+				Name: "query unexpectedly succeeds",
+				Steps: []dbtest.Step{
+					{Name: "create", Exec: "CREATE TABLE ok (id INTEGER PRIMARY KEY)"},
+					{Name: "expect error", Assert: &dbtest.Assertion{Query: "SELECT id FROM ok", ErrorContains: "boom"}},
+				},
+			}},
+			wantFailed: true,
+		},
+		{
+			name: "exec failure fails the case",
+			cases: []dbtest.Case{{
+				Name: "bad sql",
+				Steps: []dbtest.Step{
+					{Name: "broken", Exec: "THIS IS NOT SQL"},
+				},
+			}},
+			wantFailed: true,
+		},
+	}
+
+	c := qt.New(t)
+	for _, tc := range tests {
+		c.Run(tc.name, func(c *qt.C) {
+			report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: tc.cases})
+			c.Assert(err, qt.IsNil)
+			c.Assert(report, qt.IsNotNil)
+			c.Assert(report.Failed(), qt.Equals, tc.wantFailed)
+		})
+	}
+}
+
+func TestRunMigrationTest_FailureDetailAndShortCircuit(t *testing.T) {
+	c := qt.New(t)
+	cases := []dbtest.Case{{
+		Name: "stops after first failure",
+		Steps: []dbtest.Step{
+			{Name: "create", Exec: "CREATE TABLE t (id INTEGER PRIMARY KEY)"},
+			{Name: "bad count", Assert: &dbtest.Assertion{Query: "SELECT id FROM t", RowCount: new(3)}},
+			{Name: "never runs", Exec: "INSERT INTO t (id) VALUES (1)"},
+		},
+	}}
+
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsTrue)
+	c.Assert(report.Cases, qt.HasLen, 1)
+	c.Assert(report.Cases[0].Passed, qt.IsFalse)
+	// The third step must be skipped once the second fails.
+	c.Assert(report.Cases[0].Steps, qt.HasLen, 2)
+	c.Assert(report.Cases[0].Steps[0].Passed, qt.IsTrue)
+	c.Assert(report.Cases[0].Steps[1].Passed, qt.IsFalse)
+	c.Assert(report.Cases[0].Steps[1].Detail, qt.Contains, "expected row_count 3, got 0")
+
+	text := report.Text()
+	c.Assert(text, qt.Contains, "=== MIGRATION TEST ===")
+	c.Assert(text, qt.Contains, "FAIL  case \"stops after first failure\"")
+	c.Assert(text, qt.Contains, "1 cases, 0 passed, 1 failed")
+}
+
+func TestRunMigrationTest_InvalidCasesError(t *testing.T) {
+	c := qt.New(t)
+	cases := []dbtest.Case{{
+		Name:  "no action",
+		Steps: []dbtest.Step{{Name: "empty"}},
+	}}
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(report, qt.IsNil)
+	c.Assert(err.Error(), qt.Contains, "invalid test cases")
+}
+
+func TestRunMigrationTest_MigrateToLatest(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := t.TempDir()
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_create_widgets.up.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_create_widgets.down.sql"),
+		[]byte("DROP TABLE widgets;"), 0o600), qt.IsNil)
+
+	cases := []dbtest.Case{{
+		Name: "widgets migrate and accept rows",
+		Steps: []dbtest.Step{
+			{Name: "migrate to latest", MigrateTo: "latest"},
+			{Name: "widgets starts empty", Assert: &dbtest.Assertion{Query: "SELECT * FROM widgets", RowCount: new(0)}},
+			{Name: "insert widget", Exec: "INSERT INTO widgets (name) VALUES ('gear')"},
+			{Name: "one widget exists", Assert: &dbtest.Assertion{Query: "SELECT COUNT(*) FROM widgets", Scalar: new("1")}},
+		},
+	}}
+
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{
+		Cases:         cases,
+		MigrationsDir: migrationsDir,
+		DirFormat:     migrator.MigrationDirFormatPtah,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsFalse)
+	c.Assert(report.Cases, qt.HasLen, 1)
+	c.Assert(report.Cases[0].Passed, qt.IsTrue)
+	c.Assert(report.Cases[0].Steps, qt.HasLen, 4)
+}
+
+func TestRunMigrationTest_EphemeralCasesAreIsolated(t *testing.T) {
+	c := qt.New(t)
+	cases := []dbtest.Case{
+		{
+			Name: "creates a table",
+			Steps: []dbtest.Step{
+				{Name: "create", Exec: "CREATE TABLE leak (id INTEGER PRIMARY KEY)"},
+				{Name: "insert", Exec: "INSERT INTO leak (id) VALUES (1)"},
+			},
+		},
+		{
+			Name: "does not see the other case's table",
+			Steps: []dbtest.Step{
+				// A fresh ephemeral database per case means this table is absent, so
+				// the query errors and error_contains passes. A shared database would
+				// make the query succeed and fail this assertion.
+				{Name: "table is absent", Assert: &dbtest.Assertion{Query: "SELECT id FROM leak", ErrorContains: "leak"}},
+			},
+		},
+	}
+
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsFalse)
+	c.Assert(report.Cases, qt.HasLen, 2)
+	c.Assert(report.Cases[0].Passed, qt.IsTrue)
+	c.Assert(report.Cases[1].Passed, qt.IsTrue)
+}
+
+func TestRunMigrationTest_MigrateToWithoutDir(t *testing.T) {
+	c := qt.New(t)
+	cases := []dbtest.Case{{
+		Name:  "migrate without dir",
+		Steps: []dbtest.Step{{Name: "migrate", MigrateTo: "latest"}},
+	}}
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsTrue)
+	c.Assert(report.Cases[0].Steps[0].Detail, qt.Contains, "migrate_to requires a migrations directory")
+}

--- a/migration/dbtest/normalize_internal_test.go
+++ b/migration/dbtest/normalize_internal_test.go
@@ -1,0 +1,35 @@
+package dbtest
+
+// White-box testing required: normalizeScalar is an unexported helper whose
+// formatting contract — deterministic rendering of time.Time (RFC3339, not the
+// default " +0000 UTC" form) and SQL NULL — cannot be asserted through the
+// exported API without depending on driver-specific value typing, so it is
+// exercised directly here.
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestNormalizeScalar(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{name: "bytes", in: []byte("hello"), want: "hello"},
+		{name: "string", in: "hello", want: "hello"},
+		{name: "int64", in: int64(1), want: "1"},
+		{name: "null", in: nil, want: "<nil>"},
+		{name: "time", in: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC), want: "2025-01-15T10:30:00Z"},
+	}
+
+	c := qt.New(t)
+	for _, tc := range tests {
+		c.Run(tc.name, func(c *qt.C) {
+			c.Assert(normalizeScalar(tc.in), qt.Equals, tc.want)
+		})
+	}
+}

--- a/migration/dbtest/parse.go
+++ b/migration/dbtest/parse.go
@@ -18,25 +18,32 @@ type caseFile struct {
 	Cases []Case `yaml:"cases"`
 }
 
-// ParseCases parses a YAML document containing a top-level cases: list and
-// validates the result. Unknown fields are rejected so typos in step or
-// assertion keys surface as errors rather than being silently ignored. An empty
-// document yields no cases and no error.
+// ParseCases parses YAML containing a top-level cases: list and validates the
+// result. Every ---separated document in the input is decoded and its cases are
+// concatenated, so a multi-document file contributes all of its cases rather
+// than silently only the first. Unknown fields are rejected so typos in step or
+// assertion keys surface as errors rather than being silently ignored. Empty
+// input yields no cases and no error.
 func ParseCases(data []byte) ([]Case, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 
-	var file caseFile
-	if err := dec.Decode(&file); err != nil {
+	var cases []Case
+	for {
+		var file caseFile
+		err := dec.Decode(&file)
 		if errors.Is(err, io.EOF) {
-			return nil, nil
+			break
 		}
-		return nil, fmt.Errorf("parse test cases: %w", err)
+		if err != nil {
+			return nil, fmt.Errorf("parse test cases: %w", err)
+		}
+		cases = append(cases, file.Cases...)
 	}
-	if err := validateCases(file.Cases); err != nil {
+	if err := validateCases(cases); err != nil {
 		return nil, err
 	}
-	return file.Cases, nil
+	return cases, nil
 }
 
 // LoadCases reads every *.yaml and *.yml file in dir (non-recursively), parses

--- a/migration/dbtest/parse.go
+++ b/migration/dbtest/parse.go
@@ -1,0 +1,86 @@
+package dbtest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// caseFile is the top-level YAML document shape: a single cases: list.
+type caseFile struct {
+	Cases []Case `yaml:"cases"`
+}
+
+// ParseCases parses a YAML document containing a top-level cases: list and
+// validates the result. Unknown fields are rejected so typos in step or
+// assertion keys surface as errors rather than being silently ignored. An empty
+// document yields no cases and no error.
+func ParseCases(data []byte) ([]Case, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var file caseFile
+	if err := dec.Decode(&file); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("parse test cases: %w", err)
+	}
+	if err := validateCases(file.Cases); err != nil {
+		return nil, err
+	}
+	return file.Cases, nil
+}
+
+// LoadCases reads every *.yaml and *.yml file in dir (non-recursively), parses
+// each as a [ParseCases] document, and returns the concatenated cases. Files are
+// processed in lexical order by name so runs are deterministic.
+func LoadCases(dir string) ([]Case, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read test-case directory %s: %w", dir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !isCaseFile(entry.Name()) {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	var cases []Case
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read test-case file %s: %w", path, err)
+		}
+		parsed, err := ParseCases(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		cases = append(cases, parsed...)
+	}
+	return cases, nil
+}
+
+func isCaseFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}

--- a/migration/dbtest/parse_test.go
+++ b/migration/dbtest/parse_test.go
@@ -1,0 +1,171 @@
+package dbtest_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/dbtest"
+)
+
+func TestParseCases_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []dbtest.Case
+	}{
+		{
+			name: "empty document",
+			yaml: "",
+			want: nil,
+		},
+		{
+			name: "single exec step",
+			yaml: "cases:\n" +
+				"  - name: create table\n" +
+				"    steps:\n" +
+				"      - name: create\n" +
+				"        exec: CREATE TABLE t (id INTEGER)\n",
+			want: []dbtest.Case{{
+				Name:  "create table",
+				Steps: []dbtest.Step{{Name: "create", Exec: "CREATE TABLE t (id INTEGER)"}},
+			}},
+		},
+		{
+			name: "migrate, assert row_count, scalar and error_contains",
+			yaml: "cases:\n" +
+				"  - name: full flow\n" +
+				"    steps:\n" +
+				"      - name: migrate\n" +
+				"        migrate_to: latest\n" +
+				"      - name: count\n" +
+				"        assert:\n" +
+				"          query: SELECT id FROM t\n" +
+				"          row_count: 2\n" +
+				"      - name: scalar\n" +
+				"        assert:\n" +
+				"          query: SELECT name FROM t LIMIT 1\n" +
+				"          scalar: widget\n" +
+				"      - name: error\n" +
+				"        assert:\n" +
+				"          query: SELECT * FROM missing\n" +
+				"          error_contains: missing\n",
+			want: []dbtest.Case{{
+				Name: "full flow",
+				Steps: []dbtest.Step{
+					{Name: "migrate", MigrateTo: "latest"},
+					{Name: "count", Assert: &dbtest.Assertion{Query: "SELECT id FROM t", RowCount: new(2)}},
+					{Name: "scalar", Assert: &dbtest.Assertion{Query: "SELECT name FROM t LIMIT 1", Scalar: new("widget")}},
+					{Name: "error", Assert: &dbtest.Assertion{Query: "SELECT * FROM missing", ErrorContains: "missing"}},
+				},
+			}},
+		},
+		{
+			name: "integer migrate_to target coerces to string",
+			yaml: "cases:\n" +
+				"  - name: migrate to version\n" +
+				"    steps:\n" +
+				"      - migrate_to: 5\n",
+			want: []dbtest.Case{{
+				Name:  "migrate to version",
+				Steps: []dbtest.Step{{MigrateTo: "5"}},
+			}},
+		},
+	}
+
+	c := qt.New(t)
+	for _, tc := range tests {
+		c.Run(tc.name, func(c *qt.C) {
+			got, err := dbtest.ParseCases([]byte(tc.yaml))
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.DeepEquals, tc.want)
+		})
+	}
+}
+
+func TestParseCases_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		wantErrText string
+	}{
+		{
+			name:        "case without name",
+			yaml:        "cases:\n  - steps:\n      - exec: SELECT 1\n",
+			wantErrText: "has no name",
+		},
+		{
+			name:        "case without steps",
+			yaml:        "cases:\n  - name: empty\n",
+			wantErrText: "has no steps",
+		},
+		{
+			name:        "step with no action",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - name: nothing\n",
+			wantErrText: "none is set",
+		},
+		{
+			name:        "step with two actions",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - exec: SELECT 1\n        migrate_to: latest\n",
+			wantErrText: "2 are set",
+		},
+		{
+			name:        "assert without query",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - assert:\n          row_count: 1\n",
+			wantErrText: "assert requires a query",
+		},
+		{
+			name:        "assert with two conditions",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - assert:\n          query: SELECT 1\n          row_count: 1\n          scalar: x\n",
+			wantErrText: "2 are set",
+		},
+		{
+			name:        "assert with no condition",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - assert:\n          query: SELECT 1\n",
+			wantErrText: "none is set",
+		},
+		{
+			name:        "unknown field",
+			yaml:        "cases:\n  - name: c\n    steps:\n      - exec: SELECT 1\n        bogus: value\n",
+			wantErrText: "field bogus not found",
+		},
+	}
+
+	c := qt.New(t)
+	for _, tc := range tests {
+		c.Run(tc.name, func(c *qt.C) {
+			got, err := dbtest.ParseCases([]byte(tc.yaml))
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(got, qt.IsNil)
+			c.Assert(err.Error(), qt.Contains, tc.wantErrText)
+		})
+	}
+}
+
+func TestLoadCases(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "20_second.yaml"),
+		[]byte("cases:\n  - name: second\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "10_first.yml"),
+		[]byte("cases:\n  - name: first\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	// Non-YAML files and subdirectories are ignored.
+	c.Assert(os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore me"), 0o600), qt.IsNil)
+	c.Assert(os.Mkdir(filepath.Join(dir, "nested.yaml"), 0o750), qt.IsNil)
+
+	cases, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 2)
+	// Files are read in lexical order: 10_first.yml before 20_second.yaml.
+	c.Assert(cases[0].Name, qt.Equals, "first")
+	c.Assert(cases[1].Name, qt.Equals, "second")
+}
+
+func TestLoadCases_MissingDir(t *testing.T) {
+	c := qt.New(t)
+	_, err := dbtest.LoadCases(filepath.Join(t.TempDir(), "does-not-exist"))
+	c.Assert(err, qt.IsNotNil)
+}

--- a/migration/dbtest/parse_test.go
+++ b/migration/dbtest/parse_test.go
@@ -10,6 +10,27 @@ import (
 	"github.com/stokaro/ptah/migration/dbtest"
 )
 
+func TestParseCases_MultiDocument(t *testing.T) {
+	c := qt.New(t)
+	// Two ---separated documents must both contribute their cases; the second
+	// one must not be silently dropped.
+	doc := "cases:\n" +
+		"  - name: first\n" +
+		"    steps:\n" +
+		"      - exec: SELECT 1\n" +
+		"---\n" +
+		"cases:\n" +
+		"  - name: second\n" +
+		"    steps:\n" +
+		"      - exec: SELECT 1\n"
+
+	cases, err := dbtest.ParseCases([]byte(doc))
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 2)
+	c.Assert(cases[0].Name, qt.Equals, "first")
+	c.Assert(cases[1].Name, qt.Equals, "second")
+}
+
 func TestParseCases_Valid(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

First phase of the declarative testing framework (#659, epic #654). Atlas keeps `migrate test` in its proprietary Pro build (account + closed-source binary); Ptah provides an equivalent free, local, embeddable runner.

Adds a `migration/dbtest` package and a thin `ptah migrations test` command. Users author declarative YAML test cases that apply a project's migrations to a database and assert on the result.

## What it does

A test file is a YAML document with a top-level `cases:` list; each case is a named, ordered list of steps, and each step performs exactly one action:

- `migrate_to` — migrate to a target version (`latest`, `0`, or an integer)
- `exec` — run raw SQL
- `assert` — run a query and check one of `row_count`, `scalar`, or `error_contains`

```yaml
cases:
  - name: products table accepts rows
    steps:
      - migrate_to: latest
      - exec: INSERT INTO products (name) VALUES ('widget')
      - assert: { query: SELECT id FROM products, row_count: 1 }
      - assert: { query: SELECT name FROM products LIMIT 1, scalar: widget }
      - assert: { query: SELECT * FROM does_not_exist, error_contains: does_not_exist }
```

### Isolation

By default (no `--db-url`), **each case runs against its own fresh ephemeral SQLite database**, so state created by one case is never visible to another — essential for a test runner. An explicit `--db-url` runs all cases against one caller-owned throwaway database (documented; caller manages isolation).

The command reports results as text and exits non-zero on any failure.

## Scope

This is Phase 1. Deferred to later phases (tracked): seed steps (via `migration/seeder`), desired-schema application, `ptah schema test`, HTML/JSON reporting, docs, and the conformance workflow-parity row.

## Tests

Black-box unit tests over SQLite cover the parser/validation, each assertion outcome, first-failure short-circuit, a `migrate_to latest` end-to-end run, and a regression test proving ephemeral cases are isolated from one another.

Full local verification: `go build ./...`, `go vet`, `go test -race`, golangci-lint (0 issues), teststyle, qtlint (0), and the public-API snapshot (unchanged — the new package is not yet in the committed API surface).