### PR TITLE
Support Atlas migration enum identifiers

### DIFF
--- a/cmd/atlas/migrate_new_project_test.go
+++ b/cmd/atlas/migrate_new_project_test.go
@@ -1,0 +1,53 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/atlascompat"
+	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMigrateNewWithAtlasProjectEnumIdentifiers(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	c.Assert(os.Mkdir("migrations", 0o755), qt.IsNil)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  migration {
+    dir        = "file://migrations"
+    format     = atlas
+    exec_order = linear
+    tx_mode    = file
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewAtlasCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"migrate", "new", "manual_hotfix", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(output.String(), qt.Contains, "Generated empty migration file:")
+	migrations, globErr := filepath.Glob(filepath.Join(root, "migrations", "*_manual_hotfix.sql"))
+	c.Assert(globErr, qt.IsNil)
+	c.Assert(migrations, qt.HasLen, 1)
+	migrationSQL, readErr := os.ReadFile(migrations[0])
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(migrationSQL), qt.Equals, "")
+	migrationDir := filepath.Join(root, "migrations")
+	gotSum, readErr := os.ReadFile(filepath.Join(migrationDir, atlascompat.AtlasSumFileName))
+	c.Assert(readErr, qt.IsNil)
+	wantSum, sumErr := atlascompat.ComputeSum(os.DirFS(migrationDir), migrator.MigrationDirFormatAtlas)
+	c.Assert(sumErr, qt.IsNil)
+	c.Assert(string(gotSum), qt.Equals, string(wantSum.Bytes()))
+}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -386,7 +386,7 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			}
 			migration.Dir = normalizeAtlasMigrationDir(value)
 		case "format":
-			value, err := p.stringAttr(attrName, attr)
+			value, err := p.identifierOrStringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
@@ -404,13 +404,13 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			}
 			migration.LockTimeout = value
 		case "exec_order":
-			value, err := p.stringAttr(attrName, attr)
+			value, err := p.identifierOrStringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
 			migration.ExecOrder = value
 		case "tx_mode":
-			value, err := p.stringAttr(attrName, attr)
+			value, err := p.identifierOrStringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -50,6 +50,41 @@ func TestParseAtlasProjectConfig(t *testing.T) {
 	c.Assert(*cfg.Lint.Latest, qt.Equals, 5)
 }
 
+func TestParseAtlasProjectConfigMigrationEnumIdentifiers(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  migration {
+    dir        = "file://migrations"
+    format     = atlas
+    exec_order = linear
+    tx_mode    = file
+  }
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Migration.Dir, qt.Equals, "migrations")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "linear")
+	c.Assert(cfg.Migration.TxMode, qt.Equals, "file")
+}
+
+func TestParseAtlasProjectConfigRejectsMigrationEnumTraversal(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  migration {
+    format = local.format
+  }
+}
+`)
+
+	_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
+
+	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`)
+}
+
 func TestParseAtlasProjectConfigEnvLintGit(t *testing.T) {
 	c := qt.New(t)
 	raw := []byte(`env "ci" {


### PR DESCRIPTION
## Summary

- accept Atlas's unquoted identifier syntax for `migration.format`, `migration.exec_order`, and `migration.tx_mode`
- preserve the already-supported quoted forms through the shared identifier-or-string parser
- add black-box parser coverage for accepted identifiers and rejected traversals
- add a black-box `ptah atlas migrate new --env` test that verifies the generated migration and exact `atlas.sum`

## Why

Process-executing the imported Atlas `sqlite/cli-migrate-project.txtar` fixture for #651 exposed that Ptah rejected valid Atlas project syntax such as `format = atlas`. The previous conformance simulator synthesized the migration file and hid this parser gap.

## Validation

- `go test -race ./... -timeout 10m` (green outside the macOS sandbox; the sandbox itself blocks existing file-creation and loopback-bind tests)
- `go test -race ./config/projectconfig ./cmd/atlas`
- `go vet ./...`
- `go build ./...`
- `go tool qtlint ./...`
- `golangci-lint run ./...` (`0 issues`)
- two review passes across parser semantics, regressions, security, test style, and command behavior

Closes #737
Related to #651