### PR TITLE
Validate Atlas project migration enums

### DIFF
--- a/cmd/atlas/migrate_apply_project_test.go
+++ b/cmd/atlas/migrate_apply_project_test.go
@@ -1,0 +1,69 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/atlascompat"
+	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestMigrateApplyWithAtlasProjectExecutionOrderIdentifier(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	c.Assert(os.Mkdir("migrations", 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join("migrations", "20260101000000_create_widgets.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	sum, sumErr := atlascompat.ComputeSum(os.DirFS("migrations"), migrator.MigrationDirFormatAtlas)
+	c.Assert(sumErr, qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join("migrations", atlascompat.AtlasSumFileName),
+			sum.Bytes(),
+			0o600,
+		),
+		qt.IsNil,
+	)
+	dbPath := filepath.Join(root, "apply.db")
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir        = "file://migrations"
+    format     = atlas
+    exec_order = LINEAR_SKIP
+    tx_mode    = "file"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewAtlasCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"migrate", "apply", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", output.String()))
+	conn, connectErr := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(connectErr, qt.IsNil)
+	defer conn.Close()
+	var tableCount int
+	queryErr := conn.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'widgets'`,
+	).Scan(&tableCount)
+	c.Assert(queryErr, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 1)
+}

--- a/cmd/atlas/migrate_new_project_test.go
+++ b/cmd/atlas/migrate_new_project_test.go
@@ -18,12 +18,27 @@ func TestMigrateNewWithAtlasProjectEnumIdentifiers(t *testing.T) {
 	root := t.TempDir()
 	t.Chdir(root)
 	c.Assert(os.Mkdir("migrations", 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join("migrations", "20260101000000_existing.sql"),
+		[]byte("CREATE TABLE existing (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	initialSum, sumErr := atlascompat.ComputeSum(os.DirFS("migrations"), migrator.MigrationDirFormatAtlas)
+	c.Assert(sumErr, qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join("migrations", atlascompat.AtlasSumFileName),
+			initialSum.Bytes(),
+			0o600,
+		),
+		qt.IsNil,
+	)
 	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
   migration {
     dir        = "file://migrations"
     format     = atlas
-    exec_order = linear
-    tx_mode    = file
+    exec_order = LINEAR_SKIP
+    tx_mode    = "file"
   }
 }
 `), 0o600), qt.IsNil)

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	pathpkg "path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -386,7 +387,16 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			}
 			migration.Dir = normalizeAtlasMigrationDir(value)
 		case "format":
-			value, err := p.identifierOrStringAttr(attrName, attr)
+			value, err := p.scopedEnumOrStringAttr(
+				attrName,
+				attr,
+				"atlas",
+				"golang-migrate",
+				"goose",
+				"flyway",
+				"liquibase",
+				"dbmate",
+			)
 			if err != nil {
 				return err
 			}
@@ -404,13 +414,13 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			}
 			migration.LockTimeout = value
 		case "exec_order":
-			value, err := p.identifierOrStringAttr(attrName, attr)
+			value, err := p.scopedEnumOrStringAttr(attrName, attr, "LINEAR", "LINEAR_SKIP", "NON_LINEAR")
 			if err != nil {
 				return err
 			}
-			migration.ExecOrder = value
+			migration.ExecOrder = strings.ReplaceAll(strings.ToLower(value), "_", "-")
 		case "tx_mode":
-			value, err := p.identifierOrStringAttr(attrName, attr)
+			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
@@ -1064,6 +1074,26 @@ func (p atlasParser) identifierOrStringAttr(name string, attr *hclsyntax.Attribu
 	}
 	root, ok := traversal.Traversal[0].(hcl.TraverseRoot)
 	if !ok {
+		return "", unsupportedAttr(name, attr)
+	}
+	return root.Name, nil
+}
+
+func (p atlasParser) scopedEnumOrStringAttr(
+	name string,
+	attr *hclsyntax.Attribute,
+	allowed ...string,
+) (string, error) {
+	value, diags := attr.Expr.Value(p.ctx)
+	if !diags.HasErrors() && value.Type() == cty.String {
+		return value.AsString(), nil
+	}
+	traversal, ok := attr.Expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok || len(traversal.Traversal) != 1 {
+		return "", unsupportedAttr(name, attr)
+	}
+	root, ok := traversal.Traversal[0].(hcl.TraverseRoot)
+	if !ok || !slices.Contains(allowed, root.Name) {
 		return "", unsupportedAttr(name, attr)
 	}
 	return root.Name, nil

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1,6 +1,7 @@
 package projectconfig_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,37 +53,123 @@ func TestParseAtlasProjectConfig(t *testing.T) {
 
 func TestParseAtlasProjectConfigMigrationEnumIdentifiers(t *testing.T) {
 	c := qt.New(t)
-	raw := []byte(`env "local" {
+	tests := []struct {
+		name          string
+		format        string
+		execOrder     string
+		wantFormat    string
+		wantExecOrder string
+	}{
+		{
+			name:          "atlas linear",
+			format:        "atlas",
+			execOrder:     "LINEAR",
+			wantFormat:    "atlas",
+			wantExecOrder: "linear",
+		},
+		{
+			name:          "golang migrate linear skip",
+			format:        "golang-migrate",
+			execOrder:     "LINEAR_SKIP",
+			wantFormat:    "golang-migrate",
+			wantExecOrder: "linear-skip",
+		},
+		{
+			name:          "goose non linear",
+			format:        "goose",
+			execOrder:     "NON_LINEAR",
+			wantFormat:    "goose",
+			wantExecOrder: "non-linear",
+		},
+		{
+			name:          "flyway",
+			format:        "flyway",
+			execOrder:     "LINEAR",
+			wantFormat:    "flyway",
+			wantExecOrder: "linear",
+		},
+		{
+			name:          "liquibase",
+			format:        "liquibase",
+			execOrder:     "LINEAR",
+			wantFormat:    "liquibase",
+			wantExecOrder: "linear",
+		},
+		{
+			name:          "dbmate",
+			format:        "dbmate",
+			execOrder:     "LINEAR",
+			wantFormat:    "dbmate",
+			wantExecOrder: "linear",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			raw := fmt.Appendf(nil, `env "local" {
   migration {
     dir        = "file://migrations"
-    format     = atlas
-    exec_order = linear
-    tx_mode    = file
+    format     = %s
+    exec_order = %s
+    tx_mode    = "file"
   }
 }
-`)
+`, tt.format, tt.execOrder)
 
-	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
+			cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
 
-	c.Assert(err, qt.IsNil)
-	c.Assert(cfg.Migration.Dir, qt.Equals, "migrations")
-	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
-	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "linear")
-	c.Assert(cfg.Migration.TxMode, qt.Equals, "file")
+			c.Assert(err, qt.IsNil)
+			c.Assert(cfg.Migration.Dir, qt.Equals, "migrations")
+			c.Assert(cfg.Migration.Format, qt.Equals, tt.wantFormat)
+			c.Assert(cfg.Migration.ExecOrder, qt.Equals, tt.wantExecOrder)
+			c.Assert(cfg.Migration.TxMode, qt.Equals, "file")
+		})
+	}
 }
 
-func TestParseAtlasProjectConfigRejectsMigrationEnumTraversal(t *testing.T) {
+func TestParseAtlasProjectConfigMigrationEnumIdentifiersFailurePath(t *testing.T) {
 	c := qt.New(t)
-	raw := []byte(`env "local" {
+	tests := []struct {
+		name    string
+		attr    string
+		wantErr string
+	}{
+		{
+			name:    "unknown format",
+			attr:    "format = atals",
+			wantErr: `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`,
+		},
+		{
+			name:    "unknown execution order",
+			attr:    "exec_order = LINER",
+			wantErr: `unsupported atlas\.hcl construct "exec_order" at atlas\.hcl:3`,
+		},
+		{
+			name:    "bare transaction mode",
+			attr:    "tx_mode = file",
+			wantErr: `unsupported atlas\.hcl construct "tx_mode" at atlas\.hcl:3`,
+		},
+		{
+			name:    "enum traversal",
+			attr:    "format = local.format",
+			wantErr: `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			raw := fmt.Appendf(nil, `env "local" {
   migration {
-    format = local.format
+    %s
   }
 }
-`)
+`, tt.attr)
 
-	_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
+			_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
 
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
 }
 
 func TestParseAtlasProjectConfigEnvLintGit(t *testing.T) {


### PR DESCRIPTION
## Summary

- validate bare `migration.format` and `migration.exec_order` identifiers against the exact Atlas OSS scoped enum sets
- normalize Atlas `LINEAR_SKIP` and `NON_LINEAR` identifiers to Ptah CLI execution-order values
- keep `tx_mode` string-only because Atlas OSS does not register it as a scoped project-config enum
- prove `migrate apply` consumes `LINEAR_SKIP` against a real SQLite database
- strengthen `migrate new` coverage so an existing `atlas.sum` must be refreshed

## Validation

- `go test -race ./... -timeout 10m`
- `go test -race ./config/projectconfig ./cmd/atlas -count=1`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run ./...`
- `go vet ./...`
- `go build ./...`

Closes #737
Follow-up to #739.
Related to #651.