### PR TITLE
Add `ptah schema test` declarative schema test runner (#659)

### DIFF
--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -71,6 +71,8 @@ under ptah atlas.`,
 	driftCmd.Short = "Check live database drift against desired schema"
 	driftCmd.Long = "Check live database drift against desired schema."
 	cmd.AddCommand(driftCmd)
+
+	cmd.AddCommand(NewSchemaTestCommand())
 	return cmd
 }
 

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -203,6 +203,7 @@ func TestSchemaCommand_RegistersNativePaths(t *testing.T) {
 		{"render"},
 		{"compare"},
 		{"drift"},
+		{"test"},
 	} {
 		found, _, err := cmd.Find(path)
 		c.Assert(err, qt.IsNil)

--- a/cmd/schema/test.go
+++ b/cmd/schema/test.go
@@ -1,0 +1,98 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/migration/dbtest"
+)
+
+const (
+	testDirFlag     = "dir"
+	testRootDirFlag = "root-dir"
+	testDBURLFlag   = "db-url"
+	testReportFlag  = "report"
+
+	testReportFormatText = "text"
+)
+
+type testOptions struct {
+	dir     string
+	rootDir string
+	dbURL   string
+	report  string
+}
+
+// NewSchemaTestCommand returns the "test" command for the schema namespace. It
+// applies a desired schema (from Go annotations) to a throwaway database once
+// and runs declarative YAML test cases against it.
+func NewSchemaTestCommand() *cobra.Command {
+	opts := testOptions{}
+	cmd := &cobra.Command{
+		Use:          "test",
+		Short:        "Run declarative schema tests",
+		SilenceUsage: true,
+		Long: `Run declarative YAML schema test cases against a throwaway database.
+
+The desired schema is parsed from Go annotations under --root-dir, rendered to
+CREATE DDL, and applied to a fresh database before each case's steps run. Each
+test file is a YAML document with a top-level cases: list. A case is a named,
+ordered list of steps; each step performs exactly one action:
+
+  - exec:   run raw SQL.
+  - assert: run a query and check one of row_count, scalar, or error_contains.
+
+A migrate_to step is not valid in a schema test (use "ptah migrations test").
+
+When --db-url is omitted, an ephemeral SQLite database is provisioned in a
+temporary directory and removed afterwards. When --db-url is set it must point
+at a throwaway database, because tests mutate schema and data.
+
+The command exits non-zero if any case fails.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSchemaTest(cmd.Context(), cmd.OutOrStdout(), opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.dir, testDirFlag, "./tests", "Directory containing declarative test-case YAML files")
+	flags.StringVar(&opts.rootDir, testRootDirFlag, "./models", "Root directory to scan for Go schema annotations")
+	flags.StringVar(&opts.dbURL, testDBURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
+	flags.StringVar(&opts.report, testReportFlag, testReportFormatText, "Report format (only \"text\" is supported)")
+
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
+}
+
+func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
+	if opts.report != "" && opts.report != testReportFormatText {
+		return fmt.Errorf("unsupported report format %q: only %q is supported", opts.report, testReportFormatText)
+	}
+
+	cases, err := dbtest.LoadCases(opts.dir)
+	if err != nil {
+		return fmt.Errorf("failed to load test cases: %w", err)
+	}
+	if len(cases) == 0 {
+		return fmt.Errorf("no test cases found in %s", opts.dir)
+	}
+
+	report, err := dbtest.RunSchemaTest(ctx, dbtest.SchemaOptions{
+		Cases:   cases,
+		RootDir: opts.rootDir,
+		DBURL:   opts.dbURL,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprint(out, report.Text())
+	if report.Failed() {
+		return fmt.Errorf("schema tests failed")
+	}
+	return nil
+}

--- a/cmd/schema/test_test.go
+++ b/cmd/schema/test_test.go
@@ -1,0 +1,103 @@
+package schema_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/schema"
+)
+
+func writeUsersModel(c *qt.C, dir string) {
+	c.Helper()
+	content := `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "user.go"), []byte(content), 0o600), qt.IsNil)
+}
+
+// runSchemaTestCommand runs "schema test" through the full command tree so
+// registration in NewSchemaCommand is exercised alongside the command itself.
+func runSchemaTestCommand(args ...string) (string, error) {
+	cmd := schema.NewSchemaCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append([]string{"test"}, args...))
+	err := cmd.ExecuteContext(context.Background())
+	return out.String(), err
+}
+
+func TestSchemaTestCommand_Passes(t *testing.T) {
+	c := qt.New(t)
+	modelsDir := t.TempDir()
+	testsDir := t.TempDir()
+	writeUsersModel(c, modelsDir)
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "users.yaml"), []byte(
+		"cases:\n"+
+			"  - name: users schema works\n"+
+			"    steps:\n"+
+			"      - name: starts empty\n"+
+			"        assert:\n"+
+			"          query: SELECT * FROM users\n"+
+			"          row_count: 0\n"+
+			"      - name: insert\n"+
+			"        exec: INSERT INTO users (id, name) VALUES (1, 'ada')\n"+
+			"      - name: one user\n"+
+			"        assert:\n"+
+			"          query: SELECT COUNT(*) FROM users\n"+
+			"          scalar: \"1\"\n"), 0o600), qt.IsNil)
+
+	out, err := runSchemaTestCommand("--dir", testsDir, "--root-dir", modelsDir)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "PASS  case \"users schema works\"")
+	c.Assert(out, qt.Contains, "1 cases, 1 passed, 0 failed")
+}
+
+func TestSchemaTestCommand_FailsWithNonZeroError(t *testing.T) {
+	c := qt.New(t)
+	modelsDir := t.TempDir()
+	testsDir := t.TempDir()
+	writeUsersModel(c, modelsDir)
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "fail.yaml"), []byte(
+		"cases:\n"+
+			"  - name: bad expectation\n"+
+			"    steps:\n"+
+			"      - name: wrong count\n"+
+			"        assert:\n"+
+			"          query: SELECT * FROM users\n"+
+			"          row_count: 5\n"), 0o600), qt.IsNil)
+
+	out, err := runSchemaTestCommand("--dir", testsDir, "--root-dir", modelsDir)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "schema tests failed")
+	c.Assert(out, qt.Contains, "FAIL  case \"bad expectation\"")
+}
+
+func TestSchemaTestCommand_NoCasesFound(t *testing.T) {
+	c := qt.New(t)
+	modelsDir := t.TempDir()
+	writeUsersModel(c, modelsDir)
+	_, err := runSchemaTestCommand("--dir", t.TempDir(), "--root-dir", modelsDir)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "no test cases found")
+}
+
+func TestSchemaTestCommand_RejectsUnsupportedReport(t *testing.T) {
+	c := qt.New(t)
+	_, err := runSchemaTestCommand("--dir", t.TempDir(), "--report", "html")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "unsupported report format")
+}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -646,6 +646,8 @@ type CaseResult struct{ ... }
 type Options struct{ ... }
 type Report struct{ ... }
     func RunMigrationTest(ctx context.Context, opts Options) (*Report, error)
+    func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error)
+type SchemaOptions struct{ ... }
 type Step struct{ ... }
 type StepResult struct{ ... }
 

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -1,9 +1,18 @@
-// Package dbtest is a Ptah-native, declarative migration test runner.
+// Package dbtest is a Ptah-native, declarative database test runner.
 //
-// It applies a project's migrations to an ephemeral (or explicitly throwaway)
-// database and asserts on the result, so migration behavior can be exercised in
-// CI without a bespoke test harness. Test cases are authored either in Go using
-// the exported [Case]/[Step]/[Assertion] types, or as YAML loaded with
+// It provides two entry points that share the same [Case]/[Step]/[Assertion]
+// model and database isolation:
+//
+//   - [RunMigrationTest] applies a project's migrations to an ephemeral (or
+//     explicitly throwaway) database and asserts on the result, so migration
+//     behavior can be exercised in CI without a bespoke test harness.
+//   - [RunSchemaTest] applies a desired schema (rendered from Go entity
+//     annotations) to a fresh database once per case and then asserts on the
+//     result, so a schema definition can be exercised without authoring
+//     migrations.
+//
+// Test cases are authored either in Go using the exported
+// [Case]/[Step]/[Assertion] types, or as YAML loaded with
 // [ParseCases]/[LoadCases].
 //
 // # YAML format
@@ -40,12 +49,19 @@
 //	          query: SELECT * FROM does_not_exist
 //	          error_contains: does_not_exist
 //
-// # Phase 1 scope
+// # Schema tests
 //
-// Phase 1 supports only the migrate_to, exec, and assert step kinds and the
-// row_count, scalar, and error_contains assertions listed above. Seed steps,
-// desired-schema application, and structured (HTML/JSON) reporting are out of
-// scope. Reporting is text only via [Report.Text].
+// [RunSchemaTest] reuses the same step and assertion vocabulary but applies a
+// desired schema instead of migrations. A migrate_to step is invalid in a
+// schema test — there are no migrations to move between — and fails with an
+// explanatory detail rather than being silently skipped.
+//
+// # Scope
+//
+// The supported step kinds are migrate_to (migration tests only), exec, and
+// assert, with the row_count, scalar, and error_contains assertions listed
+// above. Seed steps and structured (HTML/JSON) reporting are out of scope;
+// reporting is text only via [Report.Text].
 //
 // # Database isolation
 //

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -127,7 +127,9 @@ func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
 		r.migrateTo = r.runMigrateTo
 		return r.runCase(ctx, c), nil
 	}
-	return runCases(ctx, opts.DBURL, "MIGRATION", opts.Cases, run)
+	// Migration tests need no per-database provisioning: each case applies its
+	// own migrations via migrate_to.
+	return runCases(ctx, opts.DBURL, "MIGRATION", opts.Cases, nil, run)
 }
 
 // caseRunner runs a single case against a freshly provisioned connection.
@@ -137,13 +139,24 @@ func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
 // [CaseResult].
 type caseRunner func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error)
 
+// provisionFunc sets up a freshly connected database once, before any case runs
+// against it. It is called once per shared connection or once per ephemeral
+// database.
+type provisionFunc func(ctx context.Context, conn *dbschema.DatabaseConnection) error
+
 // runCases drives every case with the database isolation both public entry
 // points ([RunMigrationTest] and [RunSchemaTest]) share. An explicit database
 // URL is a single throwaway the caller owns, so all cases share one connection
 // and the caller is responsible for isolating them. The default (ephemeral) mode
 // instead gives each case its own fresh SQLite database so cases cannot
 // contaminate one another.
-func runCases(ctx context.Context, dbURL, kind string, cases []Case, run caseRunner) (*Report, error) {
+//
+// provision, when non-nil, sets up a database once after it is connected and
+// before any case runs against it: once per shared connection, or once per fresh
+// ephemeral database. Schema tests use it to create the desired schema exactly
+// once per database; migration tests pass nil because each case applies its own
+// migrations.
+func runCases(ctx context.Context, dbURL, kind string, cases []Case, provision provisionFunc, run caseRunner) (*Report, error) {
 	report := &Report{Cases: make([]CaseResult, 0, len(cases)), kind: kind}
 
 	if dbURL != "" {
@@ -153,6 +166,11 @@ func runCases(ctx context.Context, dbURL, kind string, cases []Case, run caseRun
 		}
 		defer dbschema.CloseAndWarn(conn)
 
+		if provision != nil {
+			if err := provision(ctx, conn); err != nil {
+				return nil, err
+			}
+		}
 		for i := range cases {
 			result, err := run(ctx, conn, cases[i])
 			if err != nil {
@@ -164,7 +182,7 @@ func runCases(ctx context.Context, dbURL, kind string, cases []Case, run caseRun
 	}
 
 	for i := range cases {
-		result, err := runEphemeralCase(ctx, cases[i], run)
+		result, err := runEphemeralCase(ctx, cases[i], provision, run)
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +193,7 @@ func runCases(ctx context.Context, dbURL, kind string, cases []Case, run caseRun
 
 // runEphemeralCase runs one case against a fresh SQLite database that exists
 // only for that case, so state created by one case is never visible to another.
-func runEphemeralCase(ctx context.Context, c Case, run caseRunner) (CaseResult, error) {
+func runEphemeralCase(ctx context.Context, c Case, provision provisionFunc, run caseRunner) (CaseResult, error) {
 	tmpDir, err := os.MkdirTemp("", "ptah-dbtest-*")
 	if err != nil {
 		return CaseResult{}, fmt.Errorf("create ephemeral database directory: %w", err)
@@ -189,6 +207,11 @@ func runEphemeralCase(ctx context.Context, c Case, run caseRunner) (CaseResult, 
 	}
 	defer dbschema.CloseAndWarn(conn)
 
+	if provision != nil {
+		if err := provision(ctx, conn); err != nil {
+			return CaseResult{}, err
+		}
+	}
 	return run(ctx, conn, c)
 }
 

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -32,9 +32,13 @@ type Options struct {
 	DirFormat migrator.MigrationDirFormat
 }
 
-// Report is the outcome of a [RunMigrationTest] run.
+// Report is the outcome of a [RunMigrationTest] or [RunSchemaTest] run.
 type Report struct {
 	Cases []CaseResult
+
+	// kind labels the report header ("MIGRATION" or "SCHEMA"). It defaults to
+	// "MIGRATION" so a zero-value Report still renders sensibly.
+	kind string
 }
 
 // CaseResult is the outcome of a single [Case]. Passed is true only when every
@@ -66,7 +70,11 @@ func (r *Report) Failed() bool {
 // Text renders a human-readable summary of the report.
 func (r *Report) Text() string {
 	var b strings.Builder
-	b.WriteString("=== MIGRATION TEST ===\n")
+	kind := r.kind
+	if kind == "" {
+		kind = "MIGRATION"
+	}
+	fmt.Fprintf(&b, "=== %s TEST ===\n", kind)
 
 	passed := 0
 	for i := range r.Cases {
@@ -114,28 +122,49 @@ func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
 		dirFormat = migrator.MigrationDirFormatPtah
 	}
 
-	report := &Report{Cases: make([]CaseResult, 0, len(opts.Cases))}
+	run := func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error) {
+		r := &runner{conn: conn, migrationsDir: opts.MigrationsDir, dirFormat: dirFormat}
+		r.migrateTo = r.runMigrateTo
+		return r.runCase(ctx, c), nil
+	}
+	return runCases(ctx, opts.DBURL, "MIGRATION", opts.Cases, run)
+}
 
-	// An explicit database URL is a single throwaway the caller owns, so all
-	// cases share one connection and the caller is responsible for isolating
-	// them. The default (ephemeral) mode instead gives each case its own fresh
-	// SQLite database so cases cannot contaminate one another.
-	if opts.DBURL != "" {
-		conn, err := dbschema.ConnectToDatabase(ctx, opts.DBURL)
+// caseRunner runs a single case against a freshly provisioned connection.
+// Returning an error aborts the whole run: it signals the test bed itself could
+// not be set up (for example, a desired schema that fails to render or apply),
+// which is distinct from an ordinary assertion failure captured in the
+// [CaseResult].
+type caseRunner func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error)
+
+// runCases drives every case with the database isolation both public entry
+// points ([RunMigrationTest] and [RunSchemaTest]) share. An explicit database
+// URL is a single throwaway the caller owns, so all cases share one connection
+// and the caller is responsible for isolating them. The default (ephemeral) mode
+// instead gives each case its own fresh SQLite database so cases cannot
+// contaminate one another.
+func runCases(ctx context.Context, dbURL, kind string, cases []Case, run caseRunner) (*Report, error) {
+	report := &Report{Cases: make([]CaseResult, 0, len(cases)), kind: kind}
+
+	if dbURL != "" {
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 		if err != nil {
 			return nil, fmt.Errorf("connect to test database: %w", err)
 		}
 		defer dbschema.CloseAndWarn(conn)
 
-		r := &runner{conn: conn, migrationsDir: opts.MigrationsDir, dirFormat: dirFormat}
-		for i := range opts.Cases {
-			report.Cases = append(report.Cases, r.runCase(ctx, opts.Cases[i]))
+		for i := range cases {
+			result, err := run(ctx, conn, cases[i])
+			if err != nil {
+				return nil, err
+			}
+			report.Cases = append(report.Cases, result)
 		}
 		return report, nil
 	}
 
-	for i := range opts.Cases {
-		result, err := runEphemeralCase(ctx, opts.Cases[i], opts.MigrationsDir, dirFormat)
+	for i := range cases {
+		result, err := runEphemeralCase(ctx, cases[i], run)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +175,7 @@ func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
 
 // runEphemeralCase runs one case against a fresh SQLite database that exists
 // only for that case, so state created by one case is never visible to another.
-func runEphemeralCase(ctx context.Context, c Case, migrationsDir string, dirFormat migrator.MigrationDirFormat) (CaseResult, error) {
+func runEphemeralCase(ctx context.Context, c Case, run caseRunner) (CaseResult, error) {
 	tmpDir, err := os.MkdirTemp("", "ptah-dbtest-*")
 	if err != nil {
 		return CaseResult{}, fmt.Errorf("create ephemeral database directory: %w", err)
@@ -160,8 +189,7 @@ func runEphemeralCase(ctx context.Context, c Case, migrationsDir string, dirForm
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	r := &runner{conn: conn, migrationsDir: migrationsDir, dirFormat: dirFormat}
-	return r.runCase(ctx, c), nil
+	return run(ctx, conn, c)
 }
 
 // runner executes steps against a single shared database connection.
@@ -169,6 +197,11 @@ type runner struct {
 	conn          *dbschema.DatabaseConnection
 	migrationsDir string
 	dirFormat     migrator.MigrationDirFormat
+	// migrateTo handles a migrate_to step. Migration tests wire it to
+	// [runner.runMigrateTo]; schema tests wire it to a rejection because a schema
+	// test applies a desired schema directly and has no migrations to move
+	// between. It must be set before [runner.execStep] is called.
+	migrateTo func(ctx context.Context, target string) (passed bool, detail string)
 }
 
 func (r *runner) runCase(ctx context.Context, c Case) CaseResult {
@@ -192,7 +225,7 @@ func (r *runner) execStep(ctx context.Context, step Step) (passed bool, detail s
 	kind, _ := step.kind()
 	switch kind {
 	case stepKindMigrateTo:
-		return r.runMigrateTo(ctx, step.MigrateTo)
+		return r.migrateTo(ctx, step.MigrateTo)
 	case stepKindExec:
 		return r.runExec(ctx, step.Exec)
 	case stepKindAssert:

--- a/migration/dbtest/schema.go
+++ b/migration/dbtest/schema.go
@@ -17,8 +17,9 @@ type SchemaOptions struct {
 	Cases []Case
 	// RootDir is a directory of Go entity annotations describing the desired
 	// schema. It is parsed with goschema.ParseDir, rendered to dependency-ordered
-	// CREATE DDL for the target dialect, and applied to each case's fresh database
-	// before that case's steps run.
+	// CREATE DDL for the target dialect, and applied once per database before any
+	// case runs against it (once per ephemeral per-case database, or once for a
+	// shared explicit database).
 	RootDir string
 	// DBURL is an optional database URL to run the tests against. It must point at
 	// a throwaway database, because tests mutate schema and data. When empty, an
@@ -52,15 +53,19 @@ func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error) {
 		return nil, fmt.Errorf("parse desired schema from %s: %w", opts.RootDir, err)
 	}
 
+	// Provision the desired schema once per database — once per ephemeral
+	// per-case database, or once for a shared explicit database — rather than
+	// per case, so re-creating already-created objects never collides on the
+	// shared-database path.
+	provision := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		return applyDesiredSchema(ctx, conn, schema)
+	}
 	run := func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error) {
-		if err := applyDesiredSchema(ctx, conn, schema); err != nil {
-			return CaseResult{}, err
-		}
 		r := &runner{conn: conn}
 		r.migrateTo = rejectMigrateToInSchemaTest
 		return r.runCase(ctx, c), nil
 	}
-	return runCases(ctx, opts.DBURL, "SCHEMA", opts.Cases, run)
+	return runCases(ctx, opts.DBURL, "SCHEMA", opts.Cases, provision, run)
 }
 
 // applyDesiredSchema renders schema to CREATE DDL for conn's dialect and applies

--- a/migration/dbtest/schema.go
+++ b/migration/dbtest/schema.go
@@ -1,0 +1,94 @@
+package dbtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// SchemaOptions configures a single [RunSchemaTest] invocation.
+type SchemaOptions struct {
+	// Cases are the test cases to run, in order.
+	Cases []Case
+	// RootDir is a directory of Go entity annotations describing the desired
+	// schema. It is parsed with goschema.ParseDir, rendered to dependency-ordered
+	// CREATE DDL for the target dialect, and applied to each case's fresh database
+	// before that case's steps run.
+	RootDir string
+	// DBURL is an optional database URL to run the tests against. It must point at
+	// a throwaway database, because tests mutate schema and data. When empty, an
+	// ephemeral SQLite database is provisioned per case in a temporary directory
+	// and removed afterwards.
+	DBURL string
+}
+
+// RunSchemaTest applies a desired schema — parsed from the Go annotations in
+// opts.RootDir — to a fresh database and runs each case's exec and assert steps
+// against it. Unlike [RunMigrationTest] there are no migrations: the desired
+// schema is rendered to CREATE DDL and applied once per case before that case's
+// steps run, so a migrate_to step is invalid and fails with an explanatory
+// detail rather than being silently skipped.
+//
+// Isolation mirrors [RunMigrationTest]: with an empty DBURL each case runs
+// against its own fresh ephemeral SQLite database; with an explicit DBURL all
+// cases share that one throwaway database and the caller owns their isolation.
+//
+// A returned error indicates the run itself could not be set up (invalid cases,
+// an unparseable or unrenderable desired schema, an unreachable database, or a
+// desired schema that fails to apply); ordinary assertion failures are captured
+// in the report, so callers should inspect [Report.Failed].
+func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error) {
+	if err := validateCases(opts.Cases); err != nil {
+		return nil, fmt.Errorf("invalid test cases: %w", err)
+	}
+
+	schema, err := goschema.ParseDir(opts.RootDir)
+	if err != nil {
+		return nil, fmt.Errorf("parse desired schema from %s: %w", opts.RootDir, err)
+	}
+
+	run := func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error) {
+		if err := applyDesiredSchema(ctx, conn, schema); err != nil {
+			return CaseResult{}, err
+		}
+		r := &runner{conn: conn}
+		r.migrateTo = rejectMigrateToInSchemaTest
+		return r.runCase(ctx, c), nil
+	}
+	return runCases(ctx, opts.DBURL, "SCHEMA", opts.Cases, run)
+}
+
+// applyDesiredSchema renders schema to CREATE DDL for conn's dialect and applies
+// it, so a case's steps run against the fully created desired schema. The DDL is
+// split into individual statements (mirroring how the migrator applies migration
+// bodies) because some drivers execute only the first statement of a multi-
+// statement string. An empty schema renders to no statements and applies as a
+// no-op.
+func applyDesiredSchema(ctx context.Context, conn *dbschema.DatabaseConnection, schema *goschema.Database) error {
+	dialect := conn.Info().Dialect
+	upSQL, _, err := generator.GenerateCheckpoint(schema, dialect)
+	if err != nil {
+		return fmt.Errorf("render desired schema for dialect %q: %w", dialect, err)
+	}
+	for _, stmt := range migrator.SplitSQLStatements(upSQL) {
+		if strings.TrimSpace(stmt) == "" {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("apply desired schema: %w", err)
+		}
+	}
+	return nil
+}
+
+// rejectMigrateToInSchemaTest is the migrate_to handler for schema tests. A
+// schema test applies a desired schema directly and has no migration history to
+// move between, so a migrate_to step is a mistake rather than a runnable action.
+func rejectMigrateToInSchemaTest(context.Context, string) (passed bool, detail string) {
+	return false, `migrate_to is not valid in a schema test; use "ptah migrations test"`
+}

--- a/migration/dbtest/schema_test.go
+++ b/migration/dbtest/schema_test.go
@@ -1,0 +1,121 @@
+package dbtest_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/dbtest"
+)
+
+// writeUsersEntity writes a minimal Go entity annotation file describing a
+// "users" table into a fresh temporary directory and returns that directory so
+// it can be used as a [dbtest.SchemaOptions] RootDir.
+func writeUsersEntity(c *qt.C) string {
+	c.Helper()
+	dir := c.TempDir()
+	content := `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "user.go"), []byte(content), 0o600), qt.IsNil)
+	return dir
+}
+
+func TestRunSchemaTest_AppliesDesiredSchema(t *testing.T) {
+	c := qt.New(t)
+	rootDir := writeUsersEntity(c)
+
+	cases := []dbtest.Case{{
+		Name: "users schema applies and accepts rows",
+		Steps: []dbtest.Step{
+			{Name: "table exists and is empty", Assert: &dbtest.Assertion{Query: "SELECT * FROM users", RowCount: new(0)}},
+			{Name: "insert a user", Exec: "INSERT INTO users (id, name) VALUES (1, 'ada')"},
+			{Name: "user is retrievable", Assert: &dbtest.Assertion{Query: "SELECT name FROM users WHERE id = 1", Scalar: new("ada")}},
+		},
+	}}
+
+	report, err := dbtest.RunSchemaTest(context.Background(), dbtest.SchemaOptions{Cases: cases, RootDir: rootDir})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report, qt.IsNotNil)
+	c.Assert(report.Failed(), qt.IsFalse, qt.Commentf("%s", report.Text()))
+	c.Assert(report.Cases, qt.HasLen, 1)
+	c.Assert(report.Cases[0].Steps, qt.HasLen, 3)
+	// The report header identifies the schema-test surface, not the migration one.
+	c.Assert(report.Text(), qt.Contains, "=== SCHEMA TEST ===")
+}
+
+func TestRunSchemaTest_RejectsMigrateToStep(t *testing.T) {
+	c := qt.New(t)
+	rootDir := writeUsersEntity(c)
+
+	cases := []dbtest.Case{{
+		Name:  "migrate_to is not allowed",
+		Steps: []dbtest.Step{{Name: "attempt migrate", MigrateTo: "latest"}},
+	}}
+
+	report, err := dbtest.RunSchemaTest(context.Background(), dbtest.SchemaOptions{Cases: cases, RootDir: rootDir})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsTrue)
+	c.Assert(report.Cases, qt.HasLen, 1)
+	c.Assert(report.Cases[0].Passed, qt.IsFalse)
+	c.Assert(report.Cases[0].Steps, qt.HasLen, 1)
+	c.Assert(report.Cases[0].Steps[0].Passed, qt.IsFalse)
+	c.Assert(report.Cases[0].Steps[0].Detail, qt.Contains, `migrate_to is not valid in a schema test; use "ptah migrations test"`)
+}
+
+func TestRunSchemaTest_EphemeralCasesAreIsolated(t *testing.T) {
+	c := qt.New(t)
+	rootDir := writeUsersEntity(c)
+
+	cases := []dbtest.Case{
+		{
+			Name: "first case inserts a row",
+			Steps: []dbtest.Step{
+				{Name: "insert", Exec: "INSERT INTO users (id, name) VALUES (1, 'ada')"},
+				{Name: "one row present", Assert: &dbtest.Assertion{Query: "SELECT * FROM users", RowCount: new(1)}},
+			},
+		},
+		{
+			Name: "second case sees a fresh schema",
+			Steps: []dbtest.Step{
+				// A fresh ephemeral database per case reapplies the desired schema, so
+				// the users table exists but is empty. A shared database would leak the
+				// first case's row and fail this assertion.
+				{Name: "no rows leaked", Assert: &dbtest.Assertion{Query: "SELECT * FROM users", RowCount: new(0)}},
+			},
+		},
+	}
+
+	report, err := dbtest.RunSchemaTest(context.Background(), dbtest.SchemaOptions{Cases: cases, RootDir: rootDir})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsFalse, qt.Commentf("%s", report.Text()))
+	c.Assert(report.Cases, qt.HasLen, 2)
+	c.Assert(report.Cases[0].Passed, qt.IsTrue)
+	c.Assert(report.Cases[1].Passed, qt.IsTrue)
+}
+
+func TestRunSchemaTest_InvalidCasesError(t *testing.T) {
+	c := qt.New(t)
+	rootDir := writeUsersEntity(c)
+
+	cases := []dbtest.Case{{
+		Name:  "no action",
+		Steps: []dbtest.Step{{Name: "empty"}},
+	}}
+
+	report, err := dbtest.RunSchemaTest(context.Background(), dbtest.SchemaOptions{Cases: cases, RootDir: rootDir})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(report, qt.IsNil)
+	c.Assert(err.Error(), qt.Contains, "invalid test cases")
+}

--- a/migration/dbtest/schema_test.go
+++ b/migration/dbtest/schema_test.go
@@ -105,6 +105,41 @@ func TestRunSchemaTest_EphemeralCasesAreIsolated(t *testing.T) {
 	c.Assert(report.Cases[1].Passed, qt.IsTrue)
 }
 
+func TestRunSchemaTest_SharedDBURLAppliesSchemaOnce(t *testing.T) {
+	c := qt.New(t)
+	rootDir := writeUsersEntity(c)
+	shared := "sqlite://" + filepath.Join(c.TempDir(), "shared.db")
+
+	// With an explicit shared database, the desired schema must be applied once
+	// for the connection, not per case; a per-case re-apply would fail the second
+	// case with a "table already exists" error and abort the whole run. On a
+	// shared database cases accumulate state, so the second case sees the first
+	// case's row.
+	cases := []dbtest.Case{
+		{
+			Name: "first case inserts a row",
+			Steps: []dbtest.Step{
+				{Name: "insert", Exec: "INSERT INTO users (id, name) VALUES (1, 'ada')"},
+				{Name: "one row present", Assert: &dbtest.Assertion{Query: "SELECT * FROM users", RowCount: new(1)}},
+			},
+		},
+		{
+			Name: "second case shares the same database",
+			Steps: []dbtest.Step{
+				{Name: "row still present", Assert: &dbtest.Assertion{Query: "SELECT name FROM users WHERE id = 1", Scalar: new("ada")}},
+			},
+		},
+	}
+
+	report, err := dbtest.RunSchemaTest(context.Background(), dbtest.SchemaOptions{Cases: cases, RootDir: rootDir, DBURL: shared})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report, qt.IsNotNil)
+	c.Assert(report.Failed(), qt.IsFalse, qt.Commentf("%s", report.Text()))
+	c.Assert(report.Cases, qt.HasLen, 2)
+	c.Assert(report.Cases[0].Passed, qt.IsTrue)
+	c.Assert(report.Cases[1].Passed, qt.IsTrue)
+}
+
 func TestRunSchemaTest_InvalidCasesError(t *testing.T) {
 	c := qt.New(t)
 	rootDir := writeUsersEntity(c)


### PR DESCRIPTION
## Summary

Phase 2 of the declarative testing framework (#659, epic #654). Adds `ptah schema test`, a second surface alongside the Phase 1 `ptah migrations test`. Atlas keeps `schema test` in its Pro build; Ptah provides it free, local, and embeddable.

`ptah schema test` parses a desired schema from Go annotations under `--root-dir`, renders it to CREATE DDL for the target dialect, and applies it to a throwaway database **once per case**, then runs the case's `exec` and `assert` steps against the created schema.

```yaml
cases:
  - name: users schema accepts rows
    steps:
      - assert: { query: SELECT * FROM users, row_count: 0 }
      - exec: INSERT INTO users (id, name) VALUES (1, 'ada')
      - assert: { query: SELECT name FROM users WHERE id = 1, scalar: ada }
```

## Behavior

- **Isolation** mirrors `ptah migrations test`: with no `--db-url`, each case runs against its own fresh ephemeral SQLite database; with an explicit `--db-url`, all cases share one caller-owned throwaway.
- A `migrate_to` step is **not valid** in a schema test (there are no migrations) — it fails with `migrate_to is not valid in a schema test; use "ptah migrations test"` rather than being silently skipped.
- Report headers now name the surface (`SCHEMA` vs `MIGRATION`).

## Implementation

- `migration/dbtest/schema.go`: `RunSchemaTest` + `SchemaOptions`; renders the desired schema via `generator.GenerateCheckpoint` (dependency-ordered CREATE DDL) and applies it statement-by-statement (`migrator.SplitSQLStatements`), inferring the dialect from the connection.
- `migration/dbtest/engine.go`: refactored the connect/provision logic into a shared `runCases` helper so both entry points share identical isolation; `migrate_to` handling is supplied per surface via a strategy field. `RunMigrationTest` behavior is unchanged (its tests still pass).
- `cmd/schema/test.go`: the thin `ptah schema test` command, registered in the schema namespace.

## Scope

Seed steps and HTML/JSON reporting remain deferred to later phases.

## Tests

Black-box unit tests over SQLite: desired-schema apply end-to-end, `migrate_to` rejection, ephemeral case isolation, invalid-cases error, the `SCHEMA TEST` report header, and CLI pass/fail(nonzero)/no-cases paths.

Full local verification: `go build ./...`, `go vet`, `go test -race`, golangci-lint (0), qtlint (0), teststyle, and the public-API ledger + snapshot (regenerated — adds `RunSchemaTest`/`SchemaOptions`).