### PR TITLE
Add a seed step to the declarative test runner (#659)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -648,6 +648,7 @@ type Report struct{ ... }
     func RunMigrationTest(ctx context.Context, opts Options) (*Report, error)
     func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error)
 type SchemaOptions struct{ ... }
+type SeedStep struct{ ... }
 type Step struct{ ... }
 type StepResult struct{ ... }
 

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -24,6 +24,7 @@
 //     integer version, the string "latest" (migrate up to the newest
 //     migration), or the string "0" (roll everything back).
 //   - exec: run raw SQL against the database.
+//   - seed: apply environment-scoped SQL seed files from a directory.
 //   - assert: run a query and check exactly one condition (row_count, scalar,
 //     or error_contains).
 //
@@ -94,8 +95,22 @@ type Step struct {
 	MigrateTo string `yaml:"migrate_to"`
 	// Exec runs raw SQL against the database.
 	Exec string `yaml:"exec"`
+	// Seed applies environment-scoped SQL seed files from a directory.
+	Seed *SeedStep `yaml:"seed"`
 	// Assert runs a query and checks a single condition on the result.
 	Assert *Assertion `yaml:"assert"`
+}
+
+// SeedStep applies SQL seed files from Dir using the seeder's
+// NNN_description.env.sql convention: files matching Env plus files ending in
+// .all.sql are applied in version order. Because the target is a throwaway test
+// database, protected-environment and protected-table guards do not apply.
+type SeedStep struct {
+	// Dir is the directory of seed files. It is required.
+	Dir string `yaml:"dir"`
+	// Env is the seed environment to apply (for example dev or test). When empty,
+	// only .all.sql files are applied.
+	Env string `yaml:"env"`
 }
 
 // Assertion runs Query and checks exactly one of RowCount, Scalar, or
@@ -126,6 +141,7 @@ const (
 	stepKindNone stepKind = iota
 	stepKindMigrateTo
 	stepKindExec
+	stepKindSeed
 	stepKindAssert
 )
 
@@ -138,6 +154,10 @@ func (s Step) kind() (kind stepKind, setCount int) {
 	}
 	if strings.TrimSpace(s.Exec) != "" {
 		kind = stepKindExec
+		setCount++
+	}
+	if s.Seed != nil {
+		kind = stepKindSeed
 		setCount++
 	}
 	if s.Assert != nil {
@@ -175,13 +195,23 @@ func (c Case) validate() error {
 func (s Step) validate() error {
 	_, setCount := s.kind()
 	if setCount == 0 {
-		return fmt.Errorf("step must set exactly one of migrate_to, exec, or assert, but none is set")
+		return fmt.Errorf("step must set exactly one of migrate_to, exec, seed, or assert, but none is set")
 	}
 	if setCount > 1 {
-		return fmt.Errorf("step must set exactly one of migrate_to, exec, or assert, but %d are set", setCount)
+		return fmt.Errorf("step must set exactly one of migrate_to, exec, seed, or assert, but %d are set", setCount)
+	}
+	if s.Seed != nil {
+		return s.Seed.validate()
 	}
 	if s.Assert != nil {
 		return s.Assert.validate()
+	}
+	return nil
+}
+
+func (s *SeedStep) validate() error {
+	if strings.TrimSpace(s.Dir) == "" {
+		return fmt.Errorf("seed requires a dir")
 	}
 	return nil
 }

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -59,10 +59,10 @@
 //
 // # Scope
 //
-// The supported step kinds are migrate_to (migration tests only), exec, and
-// assert, with the row_count, scalar, and error_contains assertions listed
-// above. Seed steps and structured (HTML/JSON) reporting are out of scope;
-// reporting is text only via [Report.Text].
+// The supported step kinds are migrate_to (migration tests only), exec, seed,
+// and assert, with the row_count, scalar, and error_contains assertions listed
+// above. Structured (HTML/JSON) reporting is out of scope; reporting is text
+// only via [Report.Text].
 //
 // # Database isolation
 //
@@ -108,8 +108,8 @@ type Step struct {
 type SeedStep struct {
 	// Dir is the directory of seed files. It is required.
 	Dir string `yaml:"dir"`
-	// Env is the seed environment to apply (for example dev or test). When empty,
-	// only .all.sql files are applied.
+	// Env is the seed environment to apply (for example dev or test). It is
+	// required; files matching Env plus files ending in .all.sql are applied.
 	Env string `yaml:"env"`
 }
 
@@ -212,6 +212,9 @@ func (s Step) validate() error {
 func (s *SeedStep) validate() error {
 	if strings.TrimSpace(s.Dir) == "" {
 		return fmt.Errorf("seed requires a dir")
+	}
+	if strings.TrimSpace(s.Env) == "" {
+		return fmt.Errorf("seed requires an env")
 	}
 	return nil
 }

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
+	"github.com/stokaro/ptah/migration/seeder"
 )
 
 // Options configures a single [RunMigrationTest] invocation.
@@ -251,6 +252,8 @@ func (r *runner) execStep(ctx context.Context, step Step) (passed bool, detail s
 		return r.migrateTo(ctx, step.MigrateTo)
 	case stepKindExec:
 		return r.runExec(ctx, step.Exec)
+	case stepKindSeed:
+		return r.runSeed(ctx, step.Seed)
 	case stepKindAssert:
 		return r.runAssert(ctx, step.Assert)
 	default:
@@ -304,6 +307,20 @@ func (r *runner) runExec(ctx context.Context, sql string) (passed bool, detail s
 		return false, fmt.Sprintf("exec failed: %v", err)
 	}
 	return true, "exec ok"
+}
+
+func (r *runner) runSeed(ctx context.Context, seed *SeedStep) (passed bool, detail string) {
+	// The test database is a throwaway, so AllowProd bypasses the seeder's
+	// protected-environment and protected-table guards, which exist to stop
+	// accidental seeding of real environments.
+	result, err := seeder.Apply(ctx, r.conn, os.DirFS(seed.Dir), seeder.Options{
+		Env:       seed.Env,
+		AllowProd: true,
+	})
+	if err != nil {
+		return false, fmt.Sprintf("seed failed: %v", err)
+	}
+	return true, fmt.Sprintf("seeded %d file(s)", len(result.Applied))
 }
 
 func (r *runner) runAssert(ctx context.Context, a *Assertion) (passed bool, detail string) {

--- a/migration/dbtest/engine_test.go
+++ b/migration/dbtest/engine_test.go
@@ -220,6 +220,21 @@ func TestRunMigrationTest_SeedStep(t *testing.T) {
 	c.Assert(report.Cases[0].Steps[1].Detail, qt.Contains, "seeded 2 file(s)")
 }
 
+func TestRunMigrationTest_SeedRequiresEnv(t *testing.T) {
+	c := qt.New(t)
+	// A seed step without an env must be rejected at validation, not accepted and
+	// then failed at run time by the seeder's "environment is required" guard.
+	cases := []dbtest.Case{{
+		Name:  "seed without env",
+		Steps: []dbtest.Step{{Name: "seed", Seed: &dbtest.SeedStep{Dir: t.TempDir()}}},
+	}}
+
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(report, qt.IsNil)
+	c.Assert(err.Error(), qt.Contains, "seed requires an env")
+}
+
 func TestRunMigrationTest_MigrateToWithoutDir(t *testing.T) {
 	c := qt.New(t)
 	cases := []dbtest.Case{{

--- a/migration/dbtest/engine_test.go
+++ b/migration/dbtest/engine_test.go
@@ -187,6 +187,39 @@ func TestRunMigrationTest_EphemeralCasesAreIsolated(t *testing.T) {
 	c.Assert(report.Cases[1].Passed, qt.IsTrue)
 }
 
+func TestRunMigrationTest_SeedStep(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := t.TempDir()
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_create_widgets.up.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_create_widgets.down.sql"),
+		[]byte("DROP TABLE widgets;"), 0o600), qt.IsNil)
+
+	seedsDir := t.TempDir()
+	// .all.sql applies for any env; the .dev.sql file only applies when env=dev.
+	c.Assert(os.WriteFile(filepath.Join(seedsDir, "010_widgets.all.sql"),
+		[]byte("INSERT INTO widgets (name) VALUES ('gear');"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(seedsDir, "020_widgets.dev.sql"),
+		[]byte("INSERT INTO widgets (name) VALUES ('cog');"), 0o600), qt.IsNil)
+
+	cases := []dbtest.Case{{
+		Name: "seed applies matching environment files",
+		Steps: []dbtest.Step{
+			{Name: "migrate", MigrateTo: "latest"},
+			{Name: "seed dev", Seed: &dbtest.SeedStep{Dir: seedsDir, Env: "dev"}},
+			{Name: "both seed rows present", Assert: &dbtest.Assertion{Query: "SELECT id FROM widgets", RowCount: new(2)}},
+		},
+	}}
+
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases, MigrationsDir: migrationsDir})
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Failed(), qt.IsFalse, qt.Commentf("%s", report.Text()))
+	c.Assert(report.Cases[0].Steps, qt.HasLen, 3)
+	c.Assert(report.Cases[0].Steps[1].Detail, qt.Contains, "seeded 2 file(s)")
+}
+
 func TestRunMigrationTest_MigrateToWithoutDir(t *testing.T) {
 	c := qt.New(t)
 	cases := []dbtest.Case{{


### PR DESCRIPTION
## Summary

Adds the `seed` step kind to the declarative testing framework (#659, epic #654), usable by both `ptah migrations test` and `ptah schema test`. A seed step applies environment-scoped SQL seed files via `migration/seeder`, so a test can migrate/apply a schema, load fixtures, and then assert against seeded data.

```yaml
cases:
  - name: seeded widgets
    steps:
      - migrate_to: latest
      - seed: { dir: ./seeds, env: dev }
      - assert: { query: SELECT id FROM widgets, row_count: 2 }
```

## Behavior

- A step now sets exactly one of `migrate_to` / `exec` / `seed` / `assert`; a seed step requires `dir` and takes an optional `env`.
- Seeding follows the seeder's `NNN_description.env.sql` convention — files matching `env` plus `.all.sql` files, applied in version order.
- Because the test database is a throwaway, the seeder's protected-environment and protected-table guards are bypassed (they exist to protect real environments, not disposable test databases).

## Tests

A black-box migration-test over SQLite: migrate creates a table, a `dev` seed applies the `.all.sql` + `.dev.sql` fixtures, and an assertion confirms both rows landed.

Full local verification: `go build ./...`, `go vet`, `go test -race`, golangci-lint (0), qtlint (0), teststyle, and the public-API ledger + snapshot (regenerated — adds `SeedStep`).

## Scope

Docs (native CLI table rows, capabilities/comparison entries, a feature page, the conformance workflow-parity row) are the remaining #659 item and land in a follow-up.