### PR TITLE
Add JSON and HTML report output to the test runner (#659)

### DIFF
--- a/cmd/migrationstest/migrationstest.go
+++ b/cmd/migrationstest/migrationstest.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,9 @@ const (
 
 	reportFormatText = "text"
 )
+
+// reportFormats are the report formats the command accepts.
+var reportFormats = []string{"text", "json", "html"}
 
 type options struct {
 	dir           string
@@ -66,15 +70,15 @@ The command exits non-zero if any case fails.`,
 	flags.StringVar(&opts.migrationsDir, migrationsDirFlag, "./migrations", "Directory containing migration files")
 	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
 	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format: auto, ptah, or atlas")
-	flags.StringVar(&opts.report, reportFlag, reportFormatText, "Report format (only \"text\" is supported)")
+	flags.StringVar(&opts.report, reportFlag, reportFormatText, "Report format: text, json, or html")
 
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 
 func run(ctx context.Context, out io.Writer, opts options) error {
-	if opts.report != "" && opts.report != reportFormatText {
-		return fmt.Errorf("unsupported report format %q: only %q is supported", opts.report, reportFormatText)
+	if opts.report != "" && !slices.Contains(reportFormats, opts.report) {
+		return fmt.Errorf("unsupported report format %q: want text, json, or html", opts.report)
 	}
 
 	dirFormat, err := migrator.ParseMigrationDirFormat(opts.dirFormat)
@@ -100,7 +104,11 @@ func run(ctx context.Context, out io.Writer, opts options) error {
 		return err
 	}
 
-	fmt.Fprint(out, report.Text())
+	rendered, err := report.Render(opts.report)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(out, rendered)
 	if report.Failed() {
 		return fmt.Errorf("migration tests failed")
 	}

--- a/cmd/migrationstest/migrationstest_test.go
+++ b/cmd/migrationstest/migrationstest_test.go
@@ -82,7 +82,7 @@ func TestMigrationsTestCommand_NoCasesFound(t *testing.T) {
 
 func TestMigrationsTestCommand_RejectsUnsupportedReport(t *testing.T) {
 	c := qt.New(t)
-	_, err := runTestCommand("--dir", t.TempDir(), "--report", "html")
+	_, err := runTestCommand("--dir", t.TempDir(), "--report", "xml")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "unsupported report format")
 }

--- a/cmd/schema/test.go
+++ b/cmd/schema/test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -19,6 +20,9 @@ const (
 
 	testReportFormatText = "text"
 )
+
+// testReportFormats are the report formats the command accepts.
+var testReportFormats = []string{"text", "json", "html"}
 
 type testOptions struct {
 	dir     string
@@ -62,15 +66,15 @@ The command exits non-zero if any case fails.`,
 	flags.StringVar(&opts.dir, testDirFlag, "./tests", "Directory containing declarative test-case YAML files")
 	flags.StringVar(&opts.rootDir, testRootDirFlag, "./models", "Root directory to scan for Go schema annotations")
 	flags.StringVar(&opts.dbURL, testDBURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
-	flags.StringVar(&opts.report, testReportFlag, testReportFormatText, "Report format (only \"text\" is supported)")
+	flags.StringVar(&opts.report, testReportFlag, testReportFormatText, "Report format: text, json, or html")
 
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
 }
 
 func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
-	if opts.report != "" && opts.report != testReportFormatText {
-		return fmt.Errorf("unsupported report format %q: only %q is supported", opts.report, testReportFormatText)
+	if opts.report != "" && !slices.Contains(testReportFormats, opts.report) {
+		return fmt.Errorf("unsupported report format %q: want text, json, or html", opts.report)
 	}
 
 	cases, err := dbtest.LoadCases(opts.dir)
@@ -90,7 +94,11 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 		return err
 	}
 
-	fmt.Fprint(out, report.Text())
+	rendered, err := report.Render(opts.report)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(out, rendered)
 	if report.Failed() {
 		return fmt.Errorf("schema tests failed")
 	}

--- a/cmd/schema/test_test.go
+++ b/cmd/schema/test_test.go
@@ -97,7 +97,7 @@ func TestSchemaTestCommand_NoCasesFound(t *testing.T) {
 
 func TestSchemaTestCommand_RejectsUnsupportedReport(t *testing.T) {
 	c := qt.New(t)
-	_, err := runSchemaTestCommand("--dir", t.TempDir(), "--report", "html")
+	_, err := runSchemaTestCommand("--dir", t.TempDir(), "--report", "xml")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "unsupported report format")
 }

--- a/docs/site/src/content/docs/workflows/testing.md
+++ b/docs/site/src/content/docs/workflows/testing.md
@@ -56,9 +56,10 @@ ptah schema test --dir ./tests --root-dir ./models
 ```
 
 Both commands load every `*.yaml`/`*.yml` file under `--dir`, run the cases, print
-a text report, and exit non-zero if any case fails — so they slot straight into a
-CI gate. A `migrate_to` step is rejected in a schema test (there are no
-migrations), and reported as a failed step rather than silently skipped.
+a report, and exit non-zero if any case fails — so they slot straight into a CI
+gate. `--report` selects the output format: `text` (default), `json` (for CI
+tooling), or `html`. A `migrate_to` step is rejected in a schema test (there are
+no migrations), and reported as a failed step rather than silently skipped.
 
 ## Database isolation
 

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -61,8 +61,8 @@
 //
 // The supported step kinds are migrate_to (migration tests only), exec, seed,
 // and assert, with the row_count, scalar, and error_contains assertions listed
-// above. Structured (HTML/JSON) reporting is out of scope; reporting is text
-// only via [Report.Text].
+// above. Reports render as text ([Report.Text]), JSON ([Report.JSON]), or HTML
+// ([Report.HTML]); [Report.Render] selects by format name.
 //
 // # Database isolation
 //

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -150,6 +150,13 @@ func (r *Report) counts() (total, passed, failed int) {
 // case and step. It is stable enough to consume from CI tooling.
 func (r *Report) JSON() (string, error) {
 	total, passed, failed := r.counts()
+	// Normalize a nil case slice to an empty one so the JSON is always
+	// "cases": [] rather than "cases": null, even for a zero-value Report built
+	// directly by a library caller.
+	cases := r.Cases
+	if cases == nil {
+		cases = []CaseResult{}
+	}
 	doc := struct {
 		Kind   string       `json:"kind"`
 		Total  int          `json:"total"`
@@ -161,7 +168,7 @@ func (r *Report) JSON() (string, error) {
 		Total:  total,
 		Passed: passed,
 		Failed: failed,
-		Cases:  r.Cases,
+		Cases:  cases,
 	}
 	out, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -2,7 +2,9 @@ package dbtest
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"html/template"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -45,17 +47,17 @@ type Report struct {
 // CaseResult is the outcome of a single [Case]. Passed is true only when every
 // executed step passed.
 type CaseResult struct {
-	Name   string
-	Steps  []StepResult
-	Passed bool
+	Name   string       `json:"name"`
+	Steps  []StepResult `json:"steps"`
+	Passed bool         `json:"passed"`
 }
 
 // StepResult is the outcome of a single [Step]. Detail carries a short
 // human-readable explanation of the result, especially on failure.
 type StepResult struct {
-	Name   string
-	Passed bool
-	Detail string
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
 }
 
 // Failed reports whether any case failed.
@@ -107,6 +109,119 @@ func (r *Report) Text() string {
 	fmt.Fprintf(&b, "\n%d cases, %d passed, %d failed\n", len(r.Cases), passed, len(r.Cases)-passed)
 	return b.String()
 }
+
+// Render renders the report in the named format: "" or "text" for the text
+// summary, "json" for indented JSON, or "html" for a self-contained HTML page.
+// An unknown format is an error.
+func (r *Report) Render(format string) (string, error) {
+	switch format {
+	case "", "text":
+		return r.Text(), nil
+	case "json":
+		return r.JSON()
+	case "html":
+		return r.HTML()
+	default:
+		return "", fmt.Errorf("unsupported report format %q: want text, json, or html", format)
+	}
+}
+
+// reportKind returns the report's kind label, defaulting to "MIGRATION" so a
+// zero-value Report still renders sensibly.
+func (r *Report) reportKind() string {
+	if r.kind == "" {
+		return "MIGRATION"
+	}
+	return r.kind
+}
+
+// counts returns the total, passed, and failed case counts.
+func (r *Report) counts() (total, passed, failed int) {
+	total = len(r.Cases)
+	for i := range r.Cases {
+		if r.Cases[i].Passed {
+			passed++
+		}
+	}
+	return total, passed, total - passed
+}
+
+// JSON renders the report as indented JSON: the kind, summary counts, and every
+// case and step. It is stable enough to consume from CI tooling.
+func (r *Report) JSON() (string, error) {
+	total, passed, failed := r.counts()
+	doc := struct {
+		Kind   string       `json:"kind"`
+		Total  int          `json:"total"`
+		Passed int          `json:"passed"`
+		Failed int          `json:"failed"`
+		Cases  []CaseResult `json:"cases"`
+	}{
+		Kind:   r.reportKind(),
+		Total:  total,
+		Passed: passed,
+		Failed: failed,
+		Cases:  r.Cases,
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("render JSON report: %w", err)
+	}
+	return string(out) + "\n", nil
+}
+
+// HTML renders the report as a self-contained HTML document.
+func (r *Report) HTML() (string, error) {
+	total, passed, failed := r.counts()
+	data := struct {
+		Kind   string
+		Total  int
+		Passed int
+		Failed int
+		Cases  []CaseResult
+	}{r.reportKind(), total, passed, failed, r.Cases}
+
+	var b strings.Builder
+	if err := reportHTMLTemplate.Execute(&b, data); err != nil {
+		return "", fmt.Errorf("render HTML report: %w", err)
+	}
+	return b.String(), nil
+}
+
+var reportHTMLTemplate = template.Must(template.New("dbtest-report").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{{.Kind}} test report</title>
+<style>
+body { font-family: system-ui, sans-serif; margin: 2rem; }
+.pass { color: #157f3b; }
+.fail { color: #b3261e; }
+.case { margin: 0.75rem 0; }
+.steps { margin: 0.25rem 0 0 1.5rem; padding: 0; list-style: none; }
+.detail { color: #555; }
+</style>
+</head>
+<body>
+<h1>{{.Kind}} test report</h1>
+<p>{{.Total}} cases, {{.Passed}} passed, {{.Failed}} failed</p>
+{{range .Cases}}
+<div class="case">
+  <strong class="{{if .Passed}}pass{{else}}fail{{end}}">{{if .Passed}}PASS{{else}}FAIL{{end}}</strong>
+  case &ldquo;{{.Name}}&rdquo;
+  <ul class="steps">
+    {{range .Steps}}
+    <li>
+      <span class="{{if .Passed}}pass{{else}}fail{{end}}">{{if .Passed}}PASS{{else}}FAIL{{end}}</span>
+      step &ldquo;{{.Name}}&rdquo;{{if .Detail}} <span class="detail">&mdash; {{.Detail}}</span>{{end}}
+    </li>
+    {{end}}
+  </ul>
+</div>
+{{end}}
+</body>
+</html>
+`))
 
 // RunMigrationTest runs the test cases in opts against a database and returns a
 // report describing every case and step. A returned error indicates the run

--- a/migration/dbtest/engine_test.go
+++ b/migration/dbtest/engine_test.go
@@ -2,6 +2,7 @@ package dbtest_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -233,6 +234,46 @@ func TestRunMigrationTest_SeedRequiresEnv(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(report, qt.IsNil)
 	c.Assert(err.Error(), qt.Contains, "seed requires an env")
+}
+
+func TestReport_RenderFormats(t *testing.T) {
+	c := qt.New(t)
+	cases := []dbtest.Case{{
+		Name: "one exec and assert",
+		Steps: []dbtest.Step{
+			{Name: "create", Exec: "CREATE TABLE t (id INTEGER PRIMARY KEY)"},
+			{Name: "empty", Assert: &dbtest.Assertion{Query: "SELECT id FROM t", RowCount: new(0)}},
+		},
+	}}
+	report, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: cases})
+	c.Assert(err, qt.IsNil)
+
+	// JSON carries the kind, summary counts, and cases, and round-trips.
+	jsonOut, err := report.JSON()
+	c.Assert(err, qt.IsNil)
+	var parsed map[string]any
+	c.Assert(json.Unmarshal([]byte(jsonOut), &parsed), qt.IsNil)
+	c.Assert(parsed["kind"], qt.Equals, "MIGRATION")
+	c.Assert(parsed["total"], qt.Equals, float64(1))
+	c.Assert(parsed["passed"], qt.Equals, float64(1))
+	c.Assert(parsed["failed"], qt.Equals, float64(0))
+
+	// HTML is a self-contained document naming the case.
+	htmlOut, err := report.HTML()
+	c.Assert(err, qt.IsNil)
+	c.Assert(htmlOut, qt.Contains, "<!doctype html>")
+	c.Assert(htmlOut, qt.Contains, "one exec and assert")
+
+	// Render dispatches by format name and rejects unknown formats.
+	text, err := report.Render("text")
+	c.Assert(err, qt.IsNil)
+	c.Assert(text, qt.Contains, "=== MIGRATION TEST ===")
+	rjson, err := report.Render("json")
+	c.Assert(err, qt.IsNil)
+	c.Assert(rjson, qt.Equals, jsonOut)
+	_, err = report.Render("xml")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "unsupported report format")
 }
 
 func TestRunMigrationTest_MigrateToWithoutDir(t *testing.T) {

--- a/migration/dbtest/engine_test.go
+++ b/migration/dbtest/engine_test.go
@@ -264,6 +264,18 @@ func TestReport_RenderFormats(t *testing.T) {
 	c.Assert(htmlOut, qt.Contains, "<!doctype html>")
 	c.Assert(htmlOut, qt.Contains, "one exec and assert")
 
+	// A case name with HTML metacharacters is escaped, never emitted raw, so the
+	// report cannot inject markup regardless of the test-case contents.
+	xssReport, err := dbtest.RunMigrationTest(context.Background(), dbtest.Options{Cases: []dbtest.Case{{
+		Name:  "<script>alert(1)</script>",
+		Steps: []dbtest.Step{{Name: "noop", Exec: "SELECT 1"}},
+	}}})
+	c.Assert(err, qt.IsNil)
+	xssHTML, err := xssReport.HTML()
+	c.Assert(err, qt.IsNil)
+	c.Assert(xssHTML, qt.Not(qt.Contains), "<script>alert(1)</script>")
+	c.Assert(xssHTML, qt.Contains, "&lt;script&gt;")
+
 	// Render dispatches by format name and rejects unknown formats.
 	text, err := report.Render("text")
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
## Summary

Completes the reporting aspect of #659's testing framework. The runner reported results as text only; this adds JSON and HTML output.

- `Report.JSON()` — indented JSON with the kind, summary counts (`total`/`passed`/`failed`), and every case/step, for CI tooling.
- `Report.HTML()` — a self-contained HTML page; case and step names are auto-escaped by `html/template`.
- `Report.Render(format)` — one entry point that dispatches by `text`/`json`/`html` and errors on unknown formats.

`--report {text,json,html}` is wired into both `ptah migrations test` and `ptah schema test` (default `text`, unchanged). The feature page and package docs are updated — they previously described structured reporting as out of scope.

## Tests

A black-box test asserts the JSON round-trips with correct summary counts, the HTML is a self-contained document naming the case, and `Render` dispatches by format and rejects unknown ones. The two CLIs' unsupported-format tests now use a genuinely-unsupported format.

Full local verification: `go build ./...`, `go vet`, `go test -race`, golangci-lint (0), qtlint (0), teststyle, public-API ledger + snapshot (unchanged — the additions are methods on an existing exported type), and the doc-site link/health checks.