### PR TITLE
Add declarative managed-data model (#663)

### DIFF
--- a/core/goschema/managed_data.go
+++ b/core/goschema/managed_data.go
@@ -11,11 +11,15 @@ import (
 // LoadManagedRows reads the YAML row-data file referenced by md and returns its
 // rows as an ordered slice of column maps.
 //
-// The file path is resolved as filepath.Join(baseDir, md.File): md.File is the
-// value written verbatim in the //migrator:schema:data annotation and is
-// interpreted relative to baseDir, which callers set to the directory of the Go
-// source file that carried the annotation. The file must be a top-level YAML
-// list of mappings, one mapping per row:
+// The path is resolved as filepath.Join(rootDir, md.SourceDir, md.File): rootDir
+// is the root the schema was parsed from (the argument passed to ParseDir, or ""
+// for ParseFile), md.SourceDir is the parse-root-relative directory of the Go
+// source file that carried the annotation (recorded at parse time), and md.File
+// is the value written verbatim in the annotation. Because ParseDir abstracts the
+// OS root away via os.DirFS, SourceDir alone cannot be resolved — but a caller
+// only needs the single parse root, and SourceDir disambiguates which
+// subdirectory each entry came from. The file must be a top-level YAML list of
+// mappings, one mapping per row:
 //
 //   - code: US
 //     name: United States
@@ -23,13 +27,14 @@ import (
 //     name: Czechia
 //
 // Each mapping becomes one map[string]any whose keys are the column names. This
-// makes the declarative data model self-contained and testable; the later
-// data-diff phase consumes the returned rows to compute row-level changes.
+// makes the declarative data model testable; the later data-diff phase consumes
+// the returned rows to compute row-level changes.
 //
-// A missing or unreadable file, or malformed YAML, is returned as a wrapped
-// error that names the resolved path and target table.
-func LoadManagedRows(baseDir string, md ManagedData) ([]map[string]any, error) {
-	path := filepath.Join(baseDir, md.File)
+// An empty, null, or whitespace-only file yields no rows and no error. A missing
+// or unreadable file, or malformed YAML, is returned as a wrapped error that
+// names the resolved path and target table.
+func LoadManagedRows(rootDir string, md ManagedData) ([]map[string]any, error) {
+	path := filepath.Join(rootDir, md.SourceDir, md.File)
 
 	content, err := os.ReadFile(path)
 	if err != nil {

--- a/core/goschema/managed_data.go
+++ b/core/goschema/managed_data.go
@@ -1,0 +1,45 @@
+package goschema
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// LoadManagedRows reads the YAML row-data file referenced by md and returns its
+// rows as an ordered slice of column maps.
+//
+// The file path is resolved as filepath.Join(baseDir, md.File): md.File is the
+// value written verbatim in the //migrator:schema:data annotation and is
+// interpreted relative to baseDir, which callers set to the directory of the Go
+// source file that carried the annotation. The file must be a top-level YAML
+// list of mappings, one mapping per row:
+//
+//   - code: US
+//     name: United States
+//   - code: CZ
+//     name: Czechia
+//
+// Each mapping becomes one map[string]any whose keys are the column names. This
+// makes the declarative data model self-contained and testable; the later
+// data-diff phase consumes the returned rows to compute row-level changes.
+//
+// A missing or unreadable file, or malformed YAML, is returned as a wrapped
+// error that names the resolved path and target table.
+func LoadManagedRows(baseDir string, md ManagedData) ([]map[string]any, error) {
+	path := filepath.Join(baseDir, md.File)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read managed data file %q for table %q: %w", path, md.Table, err)
+	}
+
+	var rows []map[string]any
+	if err := yaml.Unmarshal(content, &rows); err != nil {
+		return nil, fmt.Errorf("parse managed data file %q for table %q: %w", path, md.Table, err)
+	}
+
+	return rows, nil
+}

--- a/core/goschema/managed_data_test.go
+++ b/core/goschema/managed_data_test.go
@@ -1,0 +1,179 @@
+package goschema_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/ptaherr"
+)
+
+func TestParseManagedDataAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		wantKeys []string
+	}{
+		{name: "single key", key: "code", wantKeys: []string{"code"}},
+		{name: "composite key", key: "tenant_id,code", wantKeys: []string{"tenant_id", "code"}},
+		{name: "composite key with spaces", key: "tenant_id, code", wantKeys: []string{"tenant_id", "code"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			db := mustParseSource(c, "schema.go", `
+package fixture
+
+//migrator:schema:data table="countries" key="`+tt.key+`" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}
+`)
+
+			c.Assert(db.ManagedData, qt.HasLen, 1)
+			md := db.ManagedData[0]
+			c.Assert(md.StructName, qt.Equals, "Country")
+			c.Assert(md.Table, qt.Equals, "countries")
+			c.Assert(md.Keys, qt.DeepEquals, tt.wantKeys)
+			c.Assert(md.File, qt.Equals, "countries.yaml")
+		})
+	}
+}
+
+func TestParseManagedDataAnnotation_MissingRequiredAttributeRejected(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotation    string
+		wantAttribute string
+	}{
+		{
+			name:          "missing file",
+			annotation:    `//migrator:schema:data table="countries" key="code"`,
+			wantAttribute: "file",
+		},
+		{
+			name:          "missing key",
+			annotation:    `//migrator:schema:data table="countries" file="countries.yaml"`,
+			wantAttribute: "key",
+		},
+		{
+			name:          "missing table",
+			annotation:    `//migrator:schema:data key="code" file="countries.yaml"`,
+			wantAttribute: "table",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := goschema.ParseSource("schema.go", `
+package fixture
+
+`+tt.annotation+`
+type Country struct{}
+`)
+
+			var parseErr *ptaherr.ParseError
+			c.Assert(err, qt.ErrorAs, &parseErr)
+			c.Assert(parseErr.Attribute, qt.Equals, tt.wantAttribute)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrMissingRequiredAttribute)
+		})
+	}
+}
+
+func TestParseManagedDataAnnotation_AggregatesAcrossFiles(t *testing.T) {
+	c := qt.New(t)
+
+	root := t.TempDir()
+	writeGoFile(c, root, "countries.go", `
+package fixture
+
+//migrator:schema:data table="countries" key="code" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+	Code string
+}
+`)
+	writeGoFile(c, root, "currencies.go", `
+package fixture
+
+//migrator:schema:data table="currencies" key="tenant_id,code" file="currencies.yaml"
+type Currency struct {
+	//migrator:schema:field name="code" type="VARCHAR(3)" primary="true"
+	Code string
+}
+`)
+
+	db, err := goschema.ParseDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.ManagedData, qt.HasLen, 2)
+
+	byTable := map[string]goschema.ManagedData{}
+	for _, md := range db.ManagedData {
+		byTable[md.Table] = md
+	}
+	c.Assert(byTable["countries"].Keys, qt.DeepEquals, []string{"code"})
+	c.Assert(byTable["countries"].File, qt.Equals, "countries.yaml")
+	c.Assert(byTable["currencies"].Keys, qt.DeepEquals, []string{"tenant_id", "code"})
+	c.Assert(byTable["currencies"].File, qt.Equals, "currencies.yaml")
+}
+
+func TestLoadManagedRows(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "countries.yaml"), []byte(`
+- code: US
+  name: United States
+  rank: 1
+- code: CZ
+  name: Czechia
+  rank: 2
+`), 0o600), qt.IsNil)
+
+	rows, err := goschema.LoadManagedRows(dir, goschema.ManagedData{
+		Table: "countries",
+		Keys:  []string{"code"},
+		File:  "countries.yaml",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rows, qt.DeepEquals, []map[string]any{
+		{"code": "US", "name": "United States", "rank": 1},
+		{"code": "CZ", "name": "Czechia", "rank": 2},
+	})
+}
+
+func TestLoadManagedRows_MissingFileReturnsError(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := goschema.LoadManagedRows(t.TempDir(), goschema.ManagedData{
+		Table: "countries",
+		Keys:  []string{"code"},
+		File:  "does-not-exist.yaml",
+	})
+	c.Assert(err, qt.ErrorMatches, `read managed data file ".*does-not-exist.yaml" for table "countries": .*`)
+}
+
+func TestLoadManagedRows_MalformedYAMLReturnsError(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte("this: is: not a list of rows"), 0o600), qt.IsNil)
+
+	_, err := goschema.LoadManagedRows(dir, goschema.ManagedData{
+		Table: "countries",
+		Keys:  []string{"code"},
+		File:  "bad.yaml",
+	})
+	c.Assert(err, qt.ErrorMatches, `parse managed data file ".*bad.yaml" for table "countries": .*`)
+}

--- a/core/goschema/managed_data_test.go
+++ b/core/goschema/managed_data_test.go
@@ -91,6 +91,67 @@ type Country struct{}
 	}
 }
 
+func TestParseManagedDataAnnotation_EmptyKeyListRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "single comma", key: ","},
+		{name: "only commas", key: ",,"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := goschema.ParseSource("schema.go", `
+package fixture
+
+//migrator:schema:data table="countries" key="`+tt.key+`" file="countries.yaml"
+type Country struct{}
+`)
+
+			var parseErr *ptaherr.ParseError
+			c.Assert(err, qt.ErrorAs, &parseErr)
+			c.Assert(parseErr.Attribute, qt.Equals, "key")
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidAttributeValue)
+		})
+	}
+}
+
+// TestParseManagedDataAnnotation_LoadRowsAfterParseDir proves the SourceDir
+// recorded at parse time lets rows load from a subdirectory without the caller
+// tracking base directories: ParseDir walks the tree, and LoadManagedRows
+// resolves the row file against the recorded SourceDir alone.
+func TestParseManagedDataAnnotation_LoadRowsAfterParseDir(t *testing.T) {
+	c := qt.New(t)
+
+	root := t.TempDir()
+	sub := filepath.Join(root, "reference")
+	c.Assert(os.MkdirAll(sub, 0o755), qt.IsNil)
+	writeGoFile(c, sub, "countries.go", `
+package reference
+
+//migrator:schema:data table="countries" key="code" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+	Code string
+}
+`)
+	c.Assert(os.WriteFile(filepath.Join(sub, "countries.yaml"), []byte("- code: US\n  name: United States\n"), 0o600), qt.IsNil)
+
+	db, err := goschema.ParseDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.ManagedData, qt.HasLen, 1)
+	// SourceDir is parse-root-relative; resolved against the parse root it points
+	// at the subdirectory the annotation came from.
+	c.Assert(db.ManagedData[0].SourceDir, qt.Equals, "reference")
+
+	rows, err := goschema.LoadManagedRows(root, db.ManagedData[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(rows, qt.DeepEquals, []map[string]any{{"code": "US", "name": "United States"}})
+}
+
 func TestParseManagedDataAnnotation_AggregatesAcrossFiles(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/merge.go
+++ b/core/goschema/merge.go
@@ -24,6 +24,7 @@ func newDatabase() *Database {
 		RLSEnabledTables:           []RLSEnabledTable{},
 		Roles:                      []Role{},
 		Grants:                     []Grant{},
+		ManagedData:                []ManagedData{},
 		Dependencies:               make(map[string][]string),
 		FunctionDependencies:       make(map[string][]string),
 		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
@@ -55,6 +56,7 @@ func appendDatabase(dst, src *Database) {
 	dst.RLSEnabledTables = append(dst.RLSEnabledTables, src.RLSEnabledTables...)
 	dst.Roles = append(dst.Roles, src.Roles...)
 	dst.Grants = append(dst.Grants, src.Grants...)
+	dst.ManagedData = append(dst.ManagedData, src.ManagedData...)
 }
 
 // finalizeDatabase runs the shared post-merge pipeline over an accumulator that

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -1330,11 +1330,24 @@ func (s *schemaParseState) parseManagedDataComment(comment *ast.Comment, structN
 		return err
 	}
 
+	keys := splitCommaList(kv["key"])
+	if len(keys) == 0 {
+		return &ptaherr.ParseError{
+			File:      ctx.file,
+			Line:      ctx.line,
+			Directive: strings.TrimPrefix(ctx.directive, "//"),
+			Attribute: "key",
+			Err:       ptaherr.ErrInvalidAttributeValue,
+			Message:   fmt.Sprintf("empty key list for \"key\" on %s at %s; expected one or more comma-separated key columns", ctx.directive, ctx.location),
+		}
+	}
+
 	s.managedData = append(s.managedData, ManagedData{
 		StructName: structName,
 		Table:      kv["table"],
-		Keys:       splitCommaList(kv["key"]),
+		Keys:       keys,
 		File:       kv["file"],
+		SourceDir:  filepath.Dir(s.filename),
 	})
 	return nil
 }

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -463,6 +463,7 @@ type schemaParseState struct {
 	rlsEnabledTables      []RLSEnabledTable
 	roles                 []Role
 	grants                []Grant
+	managedData           []ManagedData
 	schemas               []Schema
 }
 
@@ -574,6 +575,8 @@ func (s *schemaParseState) parseSharedComment(comment *ast.Comment, target schem
 		return s.parseRoleComment(comment, target.structName)
 	case strings.HasPrefix(comment.Text, "//migrator:schema:grant"):
 		return s.parseGrantComment(comment, target.structName)
+	case strings.HasPrefix(comment.Text, "//migrator:schema:data"):
+		return s.parseManagedDataComment(comment, target.structName)
 	}
 	return nil
 }
@@ -706,6 +709,7 @@ func parseFileAST(filename string, fset *token.FileSet, f *ast.File) (Database, 
 		RLSEnabledTables:  state.rlsEnabledTables,
 		Roles:             state.roles,
 		Grants:            state.grants,
+		ManagedData:       state.managedData,
 		Dependencies:      make(map[string][]string),
 	}
 	normalizeTableScopedNames(&result)
@@ -1313,6 +1317,25 @@ func (s *schemaParseState) parseGrantComment(comment *ast.Comment, structName st
 	}
 	grant.Canonicalize()
 	s.grants = append(s.grants, grant)
+	return nil
+}
+
+func (s *schemaParseState) parseManagedDataComment(comment *ast.Comment, structName string) error {
+	kv := parseutils.ParseKeyValueComment(comment.Text)
+	ctx := s.annotationContext(comment, "//migrator:schema:data", kv["table"])
+	if err := validateAttributes(kv, ctx); err != nil {
+		return err
+	}
+	if err := requireAttributes(kv, ctx); err != nil {
+		return err
+	}
+
+	s.managedData = append(s.managedData, ManagedData{
+		StructName: structName,
+		Table:      kv["table"],
+		Keys:       splitCommaList(kv["key"]),
+		File:       kv["file"],
+	})
 	return nil
 }
 

--- a/core/goschema/parser_test.go
+++ b/core/goschema/parser_test.go
@@ -205,6 +205,7 @@ func TestParseSource_RejectsUnknownAttributesOnAllDirectives(t *testing.T) {
 		{name: "rls_enable", annotation: `//migrator:schema:rls:enable table="users" bogus="x"`},
 		{name: "role", annotation: `//migrator:schema:role name="app" bogus="x"`},
 		{name: "grant", annotation: `//migrator:schema:grant role="app" privilege="SELECT" bogus="x"`},
+		{name: "data", annotation: `//migrator:schema:data table="countries" key="code" file="countries.yaml" bogus="x"`},
 	}
 
 	for _, tt := range tests {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -1094,7 +1094,13 @@ type ManagedData struct {
 	StructName string   // Name of the Go struct this data annotation is associated with
 	Table      string   // Target table the rows belong to
 	Keys       []string // Key column(s) forming each row's logical identity (parsed from the comma-separated "key" attribute)
-	File       string   // Path to the YAML row-data file, verbatim, relative to the Go source file's directory
+	File       string   // Path to the YAML row-data file, verbatim, relative to SourceDir
+	// SourceDir is the parse-root-relative directory of the Go source file that
+	// carried the annotation, recorded at parse time. Combined with the parse
+	// root, it lets LoadManagedRows resolve File even after a ParseDir tree walk
+	// spanning subdirectories, where a caller holding the merged Database could
+	// not otherwise know which subdirectory each entry came from.
+	SourceDir string
 }
 
 // SelfReferencingFK represents a self-referencing foreign key that needs to be

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -49,6 +49,7 @@ type Database struct {
 	RLSEnabledTables           []RLSEnabledTable              // Tables with RLS enabled
 	Roles                      []Role                         // PostgreSQL roles
 	Grants                     []Grant                        // PostgreSQL privilege grants
+	ManagedData                []ManagedData                  // Declarative reference/seed row data for tables
 	Dependencies               map[string][]string            // table -> list of tables it depends on
 	FunctionDependencies       map[string][]string            // function -> list of functions it depends on
 	SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
@@ -1053,6 +1054,47 @@ func (g *Grant) Canonicalize() {
 	g.OnTable = strings.TrimSpace(g.OnTable)
 	g.OnSchema = strings.TrimSpace(g.OnSchema)
 	g.OnSequence = strings.TrimSpace(g.OnSequence)
+}
+
+// ManagedData declares a set of reference/seed rows that Ptah manages as
+// desired-state data for a target table. It is parsed from
+// //migrator:schema:data annotations.
+//
+// Unlike other schema objects, the row values are not embedded in the Go source:
+// the annotation points to an external YAML row-data file. The Go annotation
+// parser reads comment text and cannot evaluate Go value expressions, and
+// reference data naturally lives in a data file rather than in code, so the file
+// reference is the source of truth for the rows themselves.
+//
+// ManagedData is created by parsing //migrator:schema:data annotations:
+//
+//	//migrator:schema:data table="countries" key="code" file="countries.yaml"
+//	type Country struct {
+//	    //migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+//	    Code string
+//
+//	    //migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+//	    Name string
+//	}
+//
+// Composite keys are declared as a comma-separated list, e.g. key="tenant_id,code".
+//
+// The referenced file is a top-level YAML list of row maps, resolved relative to
+// the directory of the Go source file that carries the annotation. Use
+// LoadManagedRows to read it:
+//
+//   - code: US
+//     name: United States
+//   - code: CZ
+//     name: Czechia
+//
+// The key column(s) form each row's logical identity and are consumed by the
+// (later) data-diff phase to match a desired row against an existing one.
+type ManagedData struct {
+	StructName string   // Name of the Go struct this data annotation is associated with
+	Table      string   // Target table the rows belong to
+	Keys       []string // Key column(s) forming each row's logical identity (parsed from the comma-separated "key" attribute)
+	File       string   // Path to the YAML row-data file, verbatim, relative to the Go source file's directory
 }
 
 // SelfReferencingFK represents a self-referencing foreign key that needs to be

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -407,7 +407,7 @@ func Deduplicate(r *Database)
 func Finalize(r *Database)
 func GetDependencyInfo(r *Database) string
 func IsValidSequenceType(asType string) bool
-func LoadManagedRows(baseDir string, md ManagedData) ([]map[string]any, error)
+func LoadManagedRows(rootDir string, md ManagedData) ([]map[string]any, error)
 func QualifyTableName(schema, table string) string
 func UniqueStructNames(embeddedFields []EmbeddedField) []string
 type CompositeType struct{ ... }

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -407,6 +407,7 @@ func Deduplicate(r *Database)
 func Finalize(r *Database)
 func GetDependencyInfo(r *Database) string
 func IsValidSequenceType(asType string) bool
+func LoadManagedRows(baseDir string, md ManagedData) ([]map[string]any, error)
 func QualifyTableName(schema, table string) string
 func UniqueStructNames(embeddedFields []EmbeddedField) []string
 type CompositeType struct{ ... }
@@ -430,6 +431,7 @@ type Function struct{ ... }
 type Grant struct{ ... }
 type Index struct{ ... }
 type IndexPart struct{ ... }
+type ManagedData struct{ ... }
 type MaterializedView struct{ ... }
 type PartitionPart struct{ ... }
 type PartitionSpec struct{ ... }

--- a/integration/fixtures/entities/023-go-annotations-objects/users.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/users.go
@@ -69,6 +69,9 @@ type UserTrigger struct{}
 //migrator:schema:grant role="fixture_app_user" privilege="USAGE,SELECT" on_sequence="fixture_order_seq" comment="Sequence usage for fixture_app_user"
 type AccessControlMarker struct{}
 
+//migrator:schema:data table="users" key="id" file="users.yaml"
+type UserSeedDataMarker struct{}
+
 type UserMetadata struct {
 	TraceID string
 }

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -550,6 +550,16 @@ var directives = []Directive{
 			attr("comment", "Grant comment.", valueString, false, false),
 		},
 	},
+	{
+		Name:        "migrator:schema:data",
+		Description: "Declares external reference/seed row data for a table.",
+		Scopes:      []Scope{ScopeStruct},
+		Attributes: []Attribute{
+			attr("table", "Target table the rows belong to.", valueString, true, false),
+			attr("key", "Comma-separated key column(s) forming each row's identity.", valueList, true, false),
+			attr("file", "Path to the YAML row-data file, relative to the Go source file.", valueString, true, false),
+		},
+	},
 }
 
 func attr(name, description, value string, required, boolean bool) Attribute {

--- a/schemas/migrator-annotations.schema.json
+++ b/schemas/migrator-annotations.schema.json
@@ -217,6 +217,43 @@
       ],
       "type": "object"
     },
+    "migrator.schema.data": {
+      "additionalProperties": false,
+      "description": "Declares external reference/seed row data for a table.",
+      "properties": {
+        "attributes": {
+          "additionalProperties": false,
+          "properties": {
+            "file": {
+              "description": "Path to the YAML row-data file, relative to the Go source file.",
+              "type": "string"
+            },
+            "key": {
+              "description": "Comma-separated key column(s) forming each row's identity.",
+              "type": "string"
+            },
+            "table": {
+              "description": "Target table the rows belong to.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "file",
+            "key",
+            "table"
+          ],
+          "type": "object"
+        },
+        "directive": {
+          "const": "migrator:schema:data"
+        }
+      },
+      "required": [
+        "directive",
+        "attributes"
+      ],
+      "type": "object"
+    },
     "migrator.schema.domain": {
       "additionalProperties": false,
       "description": "Declares a PostgreSQL domain type.",
@@ -1347,6 +1384,9 @@
     },
     {
       "$ref": "#/$defs/migrator.schema.grant"
+    },
+    {
+      "$ref": "#/$defs/migrator.schema.data"
     }
   ],
   "title": "Ptah Go Annotation Directives"


### PR DESCRIPTION
## Summary

First phase of declarative reference/seed data management (#663, epic #654) — the desired-data model. Atlas keeps declarative data / data-migration generation in its Pro build; this begins Ptah's free, local, embeddable equivalent.

A new `//migrator:schema:data` annotation declares that a table's rows are managed as desired-state data:

```go
//migrator:schema:data table="countries" key="code" file="countries.yaml"
type Country struct { /* fields... */ }
```

- `table` (required) — target table.
- `key` (required) — comma-separated key column(s) forming each row's identity (`key="tenant_id,code"` for composite keys).
- `file` (required) — a YAML row-data file, resolved relative to the Go source directory.

### Design decision

The annotation references an **external YAML file** rather than extracting Go value literals from the AST: the comment parser reads text and cannot evaluate Go values, and reference data naturally lives in a data file. This fits the existing comment-kv parser and avoids fragile AST literal extraction.

## Implementation

- `core/goschema/types.go`: `ManagedData{StructName, Table, Keys, File}` + `Database.ManagedData`.
- `core/goschema/parser.go`: `//migrator:schema:data` dispatch + `parseManagedDataComment`, mirroring the sibling parsers (`parseutils.ParseKeyValueComment`, `validateAttributes`/`requireAttributes`, `splitCommaList`).
- `core/goschema/merge.go`: aggregate `ManagedData` across files/roots.
- `core/goschema/managed_data.go`: `LoadManagedRows(baseDir, md)` reads the YAML row file into ordered `[]map[string]any`, with wrapped errors.
- `internal/annotationmeta/meta.go`: register the directive (required `table`/`key`/`file`) so unknown/missing attributes are rejected through the standard diagnostics; regenerated the committed annotation JSON schema golden.
- A fixture marker exercises the new `Database.ManagedData` field for the reflection completeness guard.

## Scope

Data diff, dbschema row introspection, reversible data-migration generation, and the CLI are deferred to later phases. `LoadManagedRows` is the model's only consumer today.

## Tests

Black-box: single/composite/space-trimmed key parsing, missing-required-attribute rejection, cross-file aggregation via `ParseDir`, and `LoadManagedRows` happy/missing-file/malformed cases.

Full local verification: `go build ./...`, `go vet`, `go test -race ./core/goschema/...`, full `go test ./...` (130 pkgs), golangci-lint (0), qtlint (0), teststyle, and the public-API ledger + snapshot (regenerated — adds `ManagedData` and `LoadManagedRows`).