### PR TITLE
Make schema cleanup context-aware

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -457,12 +457,6 @@
       "count": 3
     },
     {
-      "path": "internal/dbschema/mysql/mysql_test.go",
-      "function": "TestMySQLWriterDropAllTablesRollsBackOnFailure",
-      "kind": "if",
-      "count": 1
-    },
-    {
       "path": "internal/dbschema/postgres/exclude_constraints_test.go",
       "function": "TestParseExcludeConstraintDefinition",
       "kind": "if",

--- a/cmd/atlas/schema_clean.go
+++ b/cmd/atlas/schema_clean.go
@@ -128,7 +128,7 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 		return nil
 	}
 
-	if err := schemaclean.Apply(conn); err != nil {
+	if err := schemaclean.Apply(cmd.Context(), conn); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	if formatOutput {

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -143,7 +143,7 @@ func dropAllCommand(cmd *cobra.Command, opts *options) error {
 	} else {
 		fmt.Fprintf(out, "Dropping %d supported schema objects from database...\n", len(plan.Changes))
 	}
-	_, err = schemaclean.Execute(conn, schemaclean.Options{DryRun: opts.dryRun})
+	_, err = schemaclean.Execute(cmd.Context(), conn, schemaclean.Options{DryRun: opts.dryRun})
 	if err != nil {
 		return fmt.Errorf("error dropping all tables: %w", err)
 	}

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -77,14 +77,14 @@ func TestMigratePlanCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 
 func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	dbURL, conn := requireMigrateGeneratePostgresTestConnection(t, ctx)
 	defer dbschema.CloseAndWarn(conn)
 	releaseLock := acquireMigrateGenerateTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
-		c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+		c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	}()
 
 	c.Run("broken prior migration aborts before writing candidate files", func(c *qt.C) {
@@ -213,7 +213,7 @@ func writeMigrateGeneratePriorMigration(c *qt.C, dir, upSQL string) {
 }
 
 func prepareMigrateGenerateTargetDB(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) {
-	c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+	c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	_, err := conn.ExecContext(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)")
 	c.Assert(err, qt.IsNil)
 }

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -190,7 +190,8 @@ func (dc *DatabaseConnection) Writer() types.SchemaExecutor {
 }
 
 // SchemaWriter returns the root schema writer for administrative operations
-// such as starting transactions, toggling dry-run mode, or dropping all tables.
+// such as starting transactions, toggling dry-run mode, or dropping all tables
+// with a caller-supplied context.
 func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter {
 	return dc.writer
 }

--- a/dbschema/doc.go
+++ b/dbschema/doc.go
@@ -103,6 +103,11 @@
 //		log.Fatal(err)
 //	}
 //
+// Destructive administrative operations are context-aware as well. Call
+// writer.DropAllTables(ctx) with a context whose cancellation and deadline
+// should govern object discovery and destructive DDL. A dialect may briefly
+// outlive cancellation to restore connection-local safety settings.
+//
 // # Database Information
 //
 // Connection metadata is available through the Info() method:

--- a/dbschema/sqlserver_live_test.go
+++ b/dbschema/sqlserver_live_test.go
@@ -1,7 +1,6 @@
 package dbschema_test
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -25,7 +24,7 @@ func TestSQLServerLiveReadSchema(t *testing.T) {
 		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
 	}
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
@@ -131,7 +130,7 @@ func TestSQLServerLiveDropAllTablesDropsForeignKeys(t *testing.T) {
 		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
 	}
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	adminConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
@@ -165,7 +164,7 @@ func TestSQLServerLiveDropAllTablesDropsForeignKeys(t *testing.T) {
 		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", stmt))
 	}
 
-	c.Assert(scopedConn.SchemaWriter().DropAllTables(), qt.IsNil)
+	c.Assert(scopedConn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 
 	schema, err := dbschema.ReadSchemaWithSchemas(scopedConn, []string{schemaName})
 	c.Assert(err, qt.IsNil)
@@ -179,7 +178,7 @@ func TestSQLServerLiveRenderedUpsertMerge(t *testing.T) {
 		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
 	}
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
@@ -229,7 +228,7 @@ func TestSQLServerLiveComputedColumnZeroDiff(t *testing.T) {
 		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
 	}
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
@@ -281,7 +280,7 @@ func TestSQLServerLiveDropAllTablesRejectsExternalForeignKeys(t *testing.T) {
 		t.Skip("set PTAH_SQLSERVER_TEST_URL to run SQL Server live schema tests")
 	}
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	adminConn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
@@ -318,7 +317,7 @@ func TestSQLServerLiveDropAllTablesRejectsExternalForeignKeys(t *testing.T) {
 		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", stmt))
 	}
 
-	err = scopedConn.SchemaWriter().DropAllTables()
+	err = scopedConn.SchemaWriter().DropAllTables(ctx)
 	c.Assert(err, qt.ErrorMatches, `sqlserver: cannot drop schema .* tables because external foreign keys reference them: .*fk_external_child_parent.*`)
 
 	schema, err := dbschema.ReadSchemaWithSchemas(scopedConn, []string{schemaName})
@@ -354,7 +353,7 @@ func sqlServerLiveTableExists(t *testing.T, conn *dbschema.DatabaseConnection, s
 	t.Helper()
 
 	var count int
-	err := conn.QueryRowContext(context.Background(), `
+	err := conn.QueryRowContext(t.Context(), `
 SELECT COUNT(*)
 FROM sys.tables AS t
 JOIN sys.schemas AS s ON s.schema_id = t.schema_id

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -311,10 +311,14 @@ type SchemaExecutor interface {
 	IsDryRun() bool
 }
 
-// SchemaWriter interface for writing schemas to databases.
+// SchemaWriter writes schemas to databases.
 type SchemaWriter interface {
 	SchemaExecutor
-	DropAllTables() error
+	// DropAllTables removes all user schema objects. The context governs object
+	// discovery and destructive DDL. Implementations may use a short, bounded
+	// cleanup context after cancellation to restore connection-local settings
+	// before returning.
+	DropAllTables(ctx context.Context) error
 	BeginTransaction(ctx context.Context) (SchemaTransaction, error)
 	SetDryRun(dryRun bool)
 }

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -631,11 +631,15 @@ package types // import "github.com/stokaro/ptah/dbschema/types"
 
 type SchemaWriter interface {
     SchemaExecutor
-    DropAllTables() error
+    // DropAllTables removes all user schema objects. The context governs object
+    // discovery and destructive DDL. Implementations may use a short, bounded
+    // cleanup context after cancellation to restore connection-local settings
+    // before returning.
+    DropAllTables(ctx context.Context) error
     BeginTransaction(ctx context.Context) (SchemaTransaction, error)
     SetDryRun(dryRun bool)
 }
-    SchemaWriter interface for writing schemas to databases.
+    SchemaWriter writes schemas to databases.
 
 
 ## github.com/stokaro/ptah/migration/dbtest

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -66,7 +66,7 @@ The SQL Server support is deliberately conservative:
   columns or descending key order for drift-safe round trips.
 - `DROP INDEX IF EXISTS` and `DROP CONSTRAINT IF EXISTS` are not used in the
   portable preset; Ptah relies on scoped, deterministic object ownership.
-- Schema-scoped `DropAllTables` removes tables and foreign keys owned by the
+- Schema-scoped `DropAllTables(ctx)` removes tables and foreign keys owned by the
   selected schema only. If another schema has a foreign key referencing a
   selected table, cleanup fails with a blocking-constraint error instead of
   mutating objects outside the selected schema.

--- a/integration/README.md
+++ b/integration/README.md
@@ -41,7 +41,8 @@ The integration test suite covers all aspects of the migration system as outline
 - Test behavior with limited database privileges
 
 ### 🧹 Cleanup Support
-- Drop all tables and re-run from empty state
+- Drop all tables and re-run from empty state on PostgreSQL, MySQL, MariaDB,
+  ClickHouse, and opt-in SQL Server
 
 ## Architecture
 
@@ -55,11 +56,15 @@ The integration test suite covers all aspects of the migration system as outline
 
 ### Test Fixtures
 
-- **`fixtures/migrations/basic/`** - Standard migration set for testing
+- **`fixtures/migrations/basic/`** - PostgreSQL-family standard migration set
+- **`fixtures/migrations/basic_mysql/`** - MySQL and MariaDB standard migration set
+- **`fixtures/migrations/basic_clickhouse/`** - ClickHouse standard migration set
 - **`fixtures/migrations/basic_sqlserver/`** - SQL Server variant of the standard migration set
 - **`fixtures/migrations/failing/`** - Migrations with intentional failures
+- **`fixtures/migrations/failing_mysql/`** - MySQL and MariaDB intentional failure set
 - **`fixtures/migrations/failing_sqlserver/`** - SQL Server variant of the intentional failure set
 - **`fixtures/migrations/partial_failure/`** - Multi-step migrations with failures
+- **`fixtures/migrations/partial_failure_mysql/`** - MySQL and MariaDB partial failure set
 - **`fixtures/migrations/partial_failure_sqlserver/`** - SQL Server variant of the partial failure set
 - **`fixtures/entities/`** - Go entity definitions for schema generation tests
 

--- a/integration/dynamic_test.go
+++ b/integration/dynamic_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"embed"
 	"os"
 	"testing"
@@ -86,7 +85,7 @@ func TestDynamicScenariosBasic(t *testing.T) {
 	}
 
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Connect to database
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
@@ -94,14 +93,14 @@ func TestDynamicScenariosBasic(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	// Clean database
-	err = conn.SchemaWriter().DropAllTables()
+	err = conn.SchemaWriter().DropAllTables(ctx)
 	c.Assert(err, qt.IsNil)
 
 	t.Run("DynamicBasicEvolution", func(t *testing.T) {
 		c := qt.New(t)
 
 		// Clean database before test
-		err := conn.SchemaWriter().DropAllTables()
+		err := conn.SchemaWriter().DropAllTables(ctx)
 		c.Assert(err, qt.IsNil)
 
 		// Run the dynamic basic evolution test
@@ -119,7 +118,7 @@ func TestDynamicScenariosBasic(t *testing.T) {
 		c := qt.New(t)
 
 		// Clean database before test
-		err := conn.SchemaWriter().DropAllTables()
+		err := conn.SchemaWriter().DropAllTables(ctx)
 		c.Assert(err, qt.IsNil)
 
 		// Run the dynamic idempotency test

--- a/integration/fixtures/migrations/basic_clickhouse/0000000001_create_users_table.down.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000001_create_users_table.down.sql
@@ -1,0 +1,2 @@
+-- Drop users table
+DROP TABLE IF EXISTS users SYNC;

--- a/integration/fixtures/migrations/basic_clickhouse/0000000001_create_users_table.up.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000001_create_users_table.up.sql
@@ -1,0 +1,10 @@
+-- Create users table
+CREATE TABLE users (
+    id UInt64,
+    email String,
+    name String,
+    created_at DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY id;

--- a/integration/fixtures/migrations/basic_clickhouse/0000000002_create_posts_table.down.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000002_create_posts_table.down.sql
@@ -1,0 +1,2 @@
+-- Drop posts table
+DROP TABLE IF EXISTS posts SYNC;

--- a/integration/fixtures/migrations/basic_clickhouse/0000000002_create_posts_table.up.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000002_create_posts_table.up.sql
@@ -1,0 +1,12 @@
+-- Create posts table
+CREATE TABLE posts (
+    id UInt64,
+    user_id UInt64,
+    title String,
+    content String,
+    published Bool DEFAULT false,
+    created_at DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY id;

--- a/integration/fixtures/migrations/basic_clickhouse/0000000003_create_comments_table.down.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000003_create_comments_table.down.sql
@@ -1,0 +1,2 @@
+-- Drop comments table
+DROP TABLE IF EXISTS comments SYNC;

--- a/integration/fixtures/migrations/basic_clickhouse/0000000003_create_comments_table.up.sql
+++ b/integration/fixtures/migrations/basic_clickhouse/0000000003_create_comments_table.up.sql
@@ -1,0 +1,11 @@
+-- Create comments table
+CREATE TABLE comments (
+    id UInt64,
+    post_id UInt64,
+    user_id UInt64,
+    content String,
+    created_at DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY id;

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -312,7 +312,7 @@ func isPostgresDistributedSQL(dialect string) bool {
 
 // cleanDatabase drops all scenario-owned objects and resets the database to a clean state.
 func (tr *TestRunner) cleanDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return err
 	}
 	if platform.NormalizeDialect(conn.Info().Dialect) == platform.Postgres {
@@ -659,6 +659,8 @@ func migrationPathForDialect(dialect, migrationType string) string {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.MySQL, platform.MariaDB:
 		return fmt.Sprintf("migrations/%s_mysql", migrationType)
+	case platform.ClickHouse:
+		return fmt.Sprintf("migrations/%s_clickhouse", migrationType)
 	case platform.SQLServer:
 		return fmt.Sprintf("migrations/%s_sqlserver", migrationType)
 	default:

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -3,7 +3,6 @@
 package gonative_test
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -141,17 +140,17 @@ func TestMySQLWriter_Integration(t *testing.T) {
 
 	t.Run("transaction lifecycle", func(t *testing.T) {
 		// Test successful transaction
-		tx, err := writer.BeginTransaction(context.Background())
+		tx, err := writer.BeginTransaction(t.Context())
 		c.Assert(err, qt.IsNil)
 
-		err = tx.ExecuteSQL(context.Background(), "SELECT 1")
+		err = tx.ExecuteSQL(t.Context(), "SELECT 1")
 		c.Assert(err, qt.IsNil)
 
 		err = tx.Commit()
 		c.Assert(err, qt.IsNil)
 
 		// Test rollback transaction
-		tx, err = writer.BeginTransaction(context.Background())
+		tx, err = writer.BeginTransaction(t.Context())
 		c.Assert(err, qt.IsNil)
 
 		err = tx.Rollback()
@@ -163,7 +162,7 @@ func TestMySQLWriter_Integration(t *testing.T) {
 		_, err := db.Exec("CREATE TABLE IF NOT EXISTS temp_test_table (id INT AUTO_INCREMENT PRIMARY KEY)")
 		c.Assert(err, qt.IsNil)
 
-		err = writer.DropAllTables()
+		err = writer.DropAllTables(t.Context())
 		c.Assert(err, qt.IsNil)
 
 		// Verify table was dropped

--- a/integration/gonative/postgres_integration_test.go
+++ b/integration/gonative/postgres_integration_test.go
@@ -3,7 +3,6 @@
 package gonative_test
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 
@@ -120,17 +119,17 @@ func TestPostgreSQLWriter_Integration(t *testing.T) {
 
 	t.Run("transaction lifecycle", func(t *testing.T) {
 		// Test successful transaction
-		tx, err := writer.BeginTransaction(context.Background())
+		tx, err := writer.BeginTransaction(t.Context())
 		c.Assert(err, qt.IsNil)
 
-		err = tx.ExecuteSQL(context.Background(), "SELECT 1")
+		err = tx.ExecuteSQL(t.Context(), "SELECT 1")
 		c.Assert(err, qt.IsNil)
 
 		err = tx.Commit()
 		c.Assert(err, qt.IsNil)
 
 		// Test rollback transaction
-		tx, err = writer.BeginTransaction(context.Background())
+		tx, err = writer.BeginTransaction(t.Context())
 		c.Assert(err, qt.IsNil)
 
 		err = tx.Rollback()
@@ -142,7 +141,7 @@ func TestPostgreSQLWriter_Integration(t *testing.T) {
 		_, err := db.Exec("CREATE TABLE IF NOT EXISTS temp_test_table (id SERIAL PRIMARY KEY)")
 		c.Assert(err, qt.IsNil)
 
-		err = writer.DropAllTables()
+		err = writer.DropAllTables(t.Context())
 		c.Assert(err, qt.IsNil)
 
 		// Verify table was dropped

--- a/integration/scenarios.go
+++ b/integration/scenarios.go
@@ -138,10 +138,11 @@ func GetAllScenarios() []TestScenario {
 
 		// Cleanup Support
 		{
-			Name:                "cleanup_support",
-			Description:         "Test drop and re-run from empty state",
-			TestFunc:            testCleanupSupport,
-			SQLServerCompatible: true,
+			Name:                 "cleanup_support",
+			Description:          "Test drop and re-run from empty state",
+			TestFunc:             testCleanupSupport,
+			ClickHouseCompatible: true,
+			SQLServerCompatible:  true,
 		},
 	}
 

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -658,7 +658,7 @@ func rollbackToVersion(ctx context.Context, conn *dbschema.DatabaseConnection, v
 // rollbackToEmptyState drops all tables to return to an empty database state
 func rollbackToEmptyState(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 	// Drop all tables to return to empty state
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("failed to drop all tables: %w", err)
 	}
 

--- a/integration/scenarios_advanced_test.go
+++ b/integration/scenarios_advanced_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -20,13 +19,13 @@ func TestMigrationGeneratorValidation(t *testing.T) {
 	}
 
 	// Connect to database
-	ctx := context.Background()
+	ctx := t.Context()
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
 	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
-	err = conn.SchemaWriter().DropAllTables()
+	err = conn.SchemaWriter().DropAllTables(ctx)
 	c.Assert(err, qt.IsNil)
 
 	// Run the migration generator validation test
@@ -46,13 +45,13 @@ func TestValidateSchemaConsistency(t *testing.T) {
 	}
 
 	// Connect to database
-	ctx := context.Background()
+	ctx := t.Context()
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
 	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
-	err = conn.SchemaWriter().DropAllTables()
+	err = conn.SchemaWriter().DropAllTables(ctx)
 	c.Assert(err, qt.IsNil)
 
 	// Create versioned entity manager
@@ -80,13 +79,13 @@ func TestValidateEmptySchema(t *testing.T) {
 	}
 
 	// Connect to database
-	ctx := context.Background()
+	ctx := t.Context()
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	c.Assert(err, qt.IsNil)
 	defer func() { _ = conn.Close() }()
 
 	// Clean database before test
-	err = conn.SchemaWriter().DropAllTables()
+	err = conn.SchemaWriter().DropAllTables(ctx)
 	c.Assert(err, qt.IsNil)
 
 	// Validate empty schema - should pass

--- a/integration/scenarios_misc.go
+++ b/integration/scenarios_misc.go
@@ -193,7 +193,7 @@ func testCleanupSupport(ctx context.Context, conn *dbschema.DatabaseConnection, 
 	}
 
 	// Drop all tables (cleanup)
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("failed to drop all tables: %w", err)
 	}
 

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -239,6 +239,7 @@ func TestMigrationPathForDialect(t *testing.T) {
 		{dialect: "cockroachdb", migrationType: "basic", expected: "migrations/basic"},
 		{dialect: "mysql", migrationType: "basic", expected: "migrations/basic_mysql"},
 		{dialect: "mariadb", migrationType: "failing", expected: "migrations/failing_mysql"},
+		{dialect: "clickhouse", migrationType: "basic", expected: "migrations/basic_clickhouse"},
 		{dialect: "sqlserver", migrationType: "basic", expected: "migrations/basic_sqlserver"},
 		{dialect: "mssql", migrationType: "failing", expected: "migrations/failing_sqlserver"},
 	}

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -229,7 +229,7 @@ func verifyDirSum(migrationsDir string) error {
 }
 
 func replayDir(ctx context.Context, conn *dbschema.DatabaseConnection, migrationsDir string) error {
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("clean dev database: %w", err)
 	}
 	provider, err := migrator.NewFSMigrationProvider(

--- a/internal/dbschema/clickhouse/clickhouse_test.go
+++ b/internal/dbschema/clickhouse/clickhouse_test.go
@@ -69,9 +69,9 @@ func TestWriter_DryRun_NoDBRequired(t *testing.T) {
 	c.Assert(tx.Commit(), qt.IsNil)
 	c.Assert(tx.Rollback(), qt.IsNil)
 
-	// DropAllTables dry-run prints a stub table list and emits no DDL,
-	// so it must succeed without a live DB.
-	c.Assert(w.DropAllTables(), qt.IsNil)
+	// DropAllTables dry-run performs no I/O, so it must succeed without a
+	// live DB.
+	c.Assert(w.DropAllTables(t.Context()), qt.IsNil)
 }
 
 func TestClickHouseWriterConcurrentTransactionNoops(t *testing.T) {

--- a/internal/dbschema/clickhouse/writer.go
+++ b/internal/dbschema/clickhouse/writer.go
@@ -111,64 +111,54 @@ func (w *transactionWriter) IsDryRun() bool { return w.writer.IsDryRun() }
 // below is defense-in-depth — in a real ClickHouse deployment system.tables
 // will not contain such names, but rejecting them outright keeps parity
 // with the postgres/mysql writers and makes the safety property obvious.
-func (w *Writer) DropAllTables() error {
-	slog.Info("WARNING: This will drop ALL tables in the ClickHouse database")
+func (w *Writer) DropAllTables(ctx context.Context) error {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
 
-	// DropAllTables matches the dialect-agnostic SchemaWriter signature
-	// (func() error), so we use a background context for the listing query
-	// and per-table drops — same pattern mysql uses internally.
-	ctx := context.Background()
+	rows, err := w.db.QueryContext(ctx, `
+		SELECT name FROM system.tables
+		WHERE database = currentDatabase()
+		  AND is_temporary = 0
+		  AND (
+		    engine LIKE '%MergeTree'
+		    OR engine = 'Memory'
+		    OR engine = 'Log'
+		    OR engine = 'TinyLog'
+		    OR engine = 'StripeLog'
+		  )
+		  AND engine NOT LIKE '%View'
+		ORDER BY name
+	`)
+	if err != nil {
+		return fmt.Errorf("clickhouse: list tables: %w", err)
+	}
+	defer rows.Close()
 
 	var tables []string
-	if w.dryRun {
-		tables = []string{"<dry-run stub>"}
-		slog.Info("[DRY RUN] DropAllTables using stub table list", "tables", tables)
-	} else {
-		rows, err := w.db.QueryContext(ctx, `
-			SELECT name FROM system.tables
-			WHERE database = currentDatabase()
-			  AND is_temporary = 0
-			  AND (
-			    engine LIKE '%MergeTree'
-			    OR engine = 'Memory'
-			    OR engine = 'Log'
-			    OR engine = 'TinyLog'
-			    OR engine = 'StripeLog'
-			  )
-			  AND engine NOT LIKE '%View'
-			ORDER BY name
-		`)
-		if err != nil {
-			return fmt.Errorf("clickhouse: list tables: %w", err)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("clickhouse: scan table name: %w", err)
 		}
-		defer rows.Close()
-		for rows.Next() {
-			var name string
-			if err := rows.Scan(&name); err != nil {
-				return fmt.Errorf("clickhouse: scan table name: %w", err)
-			}
-			tables = append(tables, name)
-		}
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf("clickhouse: iterate tables: %w", err)
-		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("clickhouse: iterate tables: %w", err)
 	}
 
 	for _, name := range tables {
-		if w.dryRun {
-			slog.Info("[DRY RUN] Would drop table", "tableName", name)
-			continue
-		}
 		if strings.Contains(name, "`") {
 			return fmt.Errorf("clickhouse: refusing to drop table %q: name contains a backtick", name)
 		}
-		slog.Info("Dropping table", "tableName", name)
 		if err := w.ExecuteSQL(ctx, "DROP TABLE IF EXISTS "+quoteIdent(name)+" SYNC"); err != nil {
 			return err
 		}
 	}
 
-	slog.Info("Successfully dropped tables", "count", len(tables))
 	return nil
 }
 

--- a/internal/dbschema/clickhouse/writer_context_test.go
+++ b/internal/dbschema/clickhouse/writer_context_test.go
@@ -1,0 +1,32 @@
+package clickhouse_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/clickhouse"
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+)
+
+func TestWriterDropAllTables_CanceledContext(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, emptyClickHouseCleanupQuery)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, "default")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+}
+
+func emptyClickHouseCleanupQuery(
+	_ string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return dbtest.QueryResult{}, nil
+}

--- a/internal/dbschema/mssql/writer.go
+++ b/internal/dbschema/mssql/writer.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -127,15 +128,14 @@ func (w *transactionWriter) Rollback() error {
 
 func (w *transactionWriter) IsDryRun() bool { return w.dryRun }
 
-func (w *Writer) DropAllTables() error {
-	slog.Info("WARNING: This will drop ALL tables in the SQL Server database")
-
+func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if w.dryRun {
-		slog.Info("[DRY RUN] Would drop SQL Server user tables", "schema", w.schema)
 		return nil
 	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
 
-	ctx := context.Background()
 	tables, err := w.listTables(ctx)
 	if err != nil {
 		return err
@@ -155,7 +155,10 @@ func (w *Writer) DropAllTables() error {
 	committed := false
 	defer func() {
 		if !committed {
-			_ = tx.Rollback()
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("sqlserver: roll back drop transaction: %w", rollbackErr))
+			}
 		}
 	}()
 
@@ -168,7 +171,6 @@ func (w *Writer) DropAllTables() error {
 	}
 	for _, table := range tables {
 		qualified := quoteQualified(table.Schema, table.Name)
-		slog.Info("Dropping table", "tableName", qualified)
 		if err := tx.ExecuteSQL(ctx, "DROP TABLE IF EXISTS "+qualified); err != nil {
 			return fmt.Errorf("sqlserver: drop table %s: %w", qualified, err)
 		}

--- a/internal/dbschema/mssql/writer_context_test.go
+++ b/internal/dbschema/mssql/writer_context_test.go
@@ -1,0 +1,33 @@
+package mssql_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+	"github.com/stokaro/ptah/internal/dbschema/mssql"
+)
+
+func TestWriterDropAllTables_CanceledContext(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, emptySQLServerCleanupQuery)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+	c.Assert(db.BeginCount(), qt.Equals, 0)
+}
+
+func emptySQLServerCleanupQuery(
+	_ string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return dbtest.QueryResult{}, nil
+}

--- a/internal/dbschema/mysql/mysql_test.go
+++ b/internal/dbschema/mysql/mysql_test.go
@@ -443,33 +443,29 @@ func TestMySQLWriterConcurrentTransactions(t *testing.T) {
 	c.Assert(db.CommitCount()+db.RollbackCount(), qt.Equals, goroutines)
 }
 
-func TestMySQLWriterDropAllTablesCommitsOnSuccess(t *testing.T) {
+func TestMySQLWriterDropAllTablesSucceeds(t *testing.T) {
 	c := qt.New(t)
 	db := dbtest.OpenWithExec(t, mysqlDropAllQueryHandler, nil)
 	writer := NewMySQLWriter(db.SQL, "test")
 
-	c.Assert(writer.DropAllTables(), qt.IsNil)
-	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(writer.DropAllTables(t.Context()), qt.IsNil)
 	c.Assert(db.ExecCount(), qt.Equals, 3)
-	c.Assert(db.CommitCount(), qt.Equals, 1)
-	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
 
-func TestMySQLWriterDropAllTablesRollsBackOnFailure(t *testing.T) {
+func TestMySQLWriterDropAllTablesReturnsExecutionFailure(t *testing.T) {
 	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, mysqlDropAllQueryHandler, func(query string, _ []driver.NamedValue) (driver.Result, error) {
-		if strings.Contains(query, "DROP TABLE") {
-			return nil, fmt.Errorf("boom")
-		}
-		return driver.RowsAffected(0), nil
-	})
+	db := dbtest.OpenWithExec(t, mysqlDropAllQueryHandler, mysqlDropAllExecutionFailureHandler)
 	writer := NewMySQLWriter(db.SQL, "test")
 
-	err := writer.DropAllTables()
+	err := writer.DropAllTables(t.Context())
 	c.Assert(err, qt.ErrorMatches, "failed to drop table users: SQL execution failed: boom\nSQL: DROP TABLE IF EXISTS `users`")
-	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.CommitCount(), qt.Equals, 0)
-	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func mysqlDropAllExecutionFailureHandler(query string, _ []driver.NamedValue) (driver.Result, error) {
+	if strings.Contains(query, "DROP TABLE") {
+		return nil, fmt.Errorf("boom")
+	}
+	return driver.RowsAffected(0), nil
 }
 
 func mysqlDropAllQueryHandler(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {

--- a/internal/dbschema/mysql/writer.go
+++ b/internal/dbschema/mysql/writer.go
@@ -3,13 +3,18 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stokaro/ptah/dbschema/types"
 )
+
+const sessionRestoreTimeout = 5 * time.Second
 
 // quoteIdent returns a safely-backtick-quoted MySQL/MariaDB identifier.
 // Embedded backticks are doubled so that values coming from
@@ -134,79 +139,88 @@ func (w *transactionWriter) Rollback() error {
 func (w *transactionWriter) IsDryRun() bool { return w.dryRun }
 
 // DropAllTables drops ALL tables in the database (COMPLETE CLEANUP!)
-func (w *Writer) DropAllTables() error {
-	slog.Info("WARNING: This will drop ALL tables in the database!")
-
-	tx, err := w.BeginTransaction(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
 	}
 
-	committed := false
+	conn, err := w.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("mysql: acquire cleanup connection: %w", err)
+	}
 	defer func() {
-		if !committed {
-			_ = tx.Rollback()
+		closeErr := conn.Close()
+		if closeErr != nil && !errors.Is(closeErr, sql.ErrConnDone) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("mysql: close cleanup connection: %w", closeErr))
 		}
 	}()
 
-	ctx := context.Background()
-
-	// Disable foreign key checks to avoid dependency issues
-	if err := tx.ExecuteSQL(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+	if _, err := conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
 		return fmt.Errorf("failed to disable foreign key checks: %w", err)
 	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
+		defer cancel()
+		if _, restoreErr := conn.ExecContext(cleanupCtx, "SET FOREIGN_KEY_CHECKS = 1"); restoreErr != nil {
+			discardConn(conn)
+			resultErr = errors.Join(resultErr, fmt.Errorf("mysql: restore foreign key checks: %w", restoreErr))
+		}
+	}()
+
+	tables, err := listTables(ctx, conn)
+	if err != nil {
+		return err
+	}
+
+	// MySQL DDL implicitly commits, so cleanup deliberately avoids a transaction.
+	for _, tableName := range tables {
+		// Identifiers cannot be bound as parameters; quoteIdent escapes every
+		// backtick in the name returned by information_schema.
+		//nolint:gosec // G202: tableName is emitted only through identifier quoting.
+		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName)
+		if _, err := conn.ExecContext(ctx, dropSQL); err != nil {
+			return fmt.Errorf("failed to drop table %s: SQL execution failed: %w\nSQL: %s", tableName, err, dropSQL)
+		}
+	}
+
+	return nil
+}
+
+func listTables(ctx context.Context, conn *sql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
+		ORDER BY table_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql: query tables: %w", err)
+	}
+	defer rows.Close()
 
 	var tables []string
-
-	if w.dryRun {
-		// In dry run mode, simulate some tables for demonstration
-		tables = []string{"example_table1", "example_table2", "example_table3"}
-	} else {
-		// Get all tables in the current database
-		tablesQuery := `
-			SELECT table_name
-			FROM information_schema.tables
-			WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
-			ORDER BY table_name`
-
-		rows, err := w.db.Query(tablesQuery)
-		if err != nil {
-			return fmt.Errorf("failed to query tables: %w", err)
+	for rows.Next() {
+		var tableName string
+		if err := rows.Scan(&tableName); err != nil {
+			return nil, fmt.Errorf("mysql: scan table name: %w", err)
 		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var tableName string
-			if err := rows.Scan(&tableName); err != nil {
-				return fmt.Errorf("failed to scan table name: %w", err)
-			}
-			tables = append(tables, tableName)
-		}
+		tables = append(tables, tableName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("mysql: iterate tables: %w", err)
 	}
 
-	// Drop all tables. Identifiers cannot be bound as parameters; quoteIdent
-	// doubles any embedded backtick so that a name harvested from
-	// information_schema cannot break out of the quoted identifier.
-	for _, tableName := range tables {
-		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName)
-		slog.Info("Dropping table", "tableName", tableName)
-		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
-			return fmt.Errorf("failed to drop table %s: %w", tableName, err)
-		}
-	}
+	return tables, nil
+}
 
-	// Re-enable foreign key checks
-	if err := tx.ExecuteSQL(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
-		return fmt.Errorf("failed to re-enable foreign key checks: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-	committed = true
-
-	slog.Info("Successfully dropped tables", "count", len(tables))
-	return nil
+func discardConn(conn *sql.Conn) {
+	// Never return a connection with unknown session state to the pool.
+	_ = conn.Raw(func(any) error {
+		return driver.ErrBadConn
+	})
 }
 
 // isCreateTableStatement checks if a SQL statement is a CREATE TABLE statement

--- a/internal/dbschema/mysql/writer_context_test.go
+++ b/internal/dbschema/mysql/writer_context_test.go
@@ -1,0 +1,113 @@
+package mysql_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+	"github.com/stokaro/ptah/internal/dbschema/mysql"
+)
+
+func TestWriterDropAllTables_RestoresForeignKeyChecksAfterCancellation(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	recorder := &mysqlCleanupRecorder{
+		cancelOnDrop: cancel,
+		dropErr:      context.Canceled,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test")
+
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"DROP TABLE IF EXISTS `users`",
+		"SET FOREIGN_KEY_CHECKS = 1",
+	})
+}
+
+func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
+	c := qt.New(t)
+	dropErr := errors.New("drop failed")
+	restoreErr := errors.New("restore failed")
+	recorder := &mysqlCleanupRecorder{
+		dropErr:    dropErr,
+		restoreErr: restoreErr,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, dropErr)
+	c.Assert(err, qt.ErrorIs, restoreErr)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"DROP TABLE IF EXISTS `users`",
+		"SET FOREIGN_KEY_CHECKS = 1",
+	})
+}
+
+type mysqlCleanupRecorder struct {
+	mu             sync.Mutex
+	statementsSeen []string
+	cancelOnDrop   context.CancelFunc
+	dropErr        error
+	restoreErr     error
+}
+
+func (rec *mysqlCleanupRecorder) query(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if !strings.Contains(query, "information_schema.tables") {
+		return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+	}
+	return dbtest.QueryResult{
+		Columns: []string{"table_name"},
+		Rows:    [][]driver.Value{{"users"}},
+	}, nil
+}
+
+func (rec *mysqlCleanupRecorder) exec(
+	query string,
+	_ []driver.NamedValue,
+) (driver.Result, error) {
+	statement := strings.Join(strings.Fields(query), " ")
+
+	rec.mu.Lock()
+	rec.statementsSeen = append(rec.statementsSeen, statement)
+	cancelOnDrop := rec.cancelOnDrop
+	dropErr := rec.dropErr
+	restoreErr := rec.restoreErr
+	rec.mu.Unlock()
+
+	switch {
+	case strings.HasPrefix(statement, "DROP TABLE") && dropErr != nil:
+		if cancelOnDrop != nil {
+			cancelOnDrop()
+		}
+		return nil, dropErr
+	case statement == "SET FOREIGN_KEY_CHECKS = 1" && restoreErr != nil:
+		return nil, restoreErr
+	default:
+		return driver.RowsAffected(0), nil
+	}
+}
+
+func (rec *mysqlCleanupRecorder) statements() []string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return append([]string(nil), rec.statementsSeen...)
+}

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -463,7 +463,7 @@ func TestPostgreSQLWriterDropAllTablesCommitsOnSuccess(t *testing.T) {
 	db := dbtest.OpenWithExec(t, postgresDropAllQueryHandler, nil)
 	writer := NewPostgreSQLWriter(db.SQL, "public")
 
-	c.Assert(writer.DropAllTables(), qt.IsNil)
+	c.Assert(writer.DropAllTables(t.Context()), qt.IsNil)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
 	c.Assert(db.ExecCount(), qt.Equals, 3)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
@@ -480,7 +480,7 @@ func TestPostgreSQLWriterDropAllTablesRollsBackOnFailure(t *testing.T) {
 	})
 	writer := NewPostgreSQLWriter(db.SQL, "public")
 
-	err := writer.DropAllTables()
+	err := writer.DropAllTables(t.Context())
 	c.Assert(err, qt.ErrorMatches, `failed to drop enum status: SQL execution failed: boom\nSQL: DROP TYPE IF EXISTS "status" CASCADE`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
 	c.Assert(db.CommitCount(), qt.Equals, 0)

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -181,15 +182,7 @@ func (w *postgresTransactionWriter) Rollback() error {
 // IsDryRun returns whether dry-run mode is enabled.
 func (w *postgresTransactionWriter) IsDryRun() bool { return w.dryRun }
 
-func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string, sequences []string, err error) { //revive:disable-line:function-result-limit // It's acceptable here
-	if w.dryRun {
-		// In dry run mode, simulate some tables/enums/sequences for demonstration
-		tables = []string{"example_table1", "example_table2"}
-		enums = []string{"example_enum1", "example_enum2"}
-		sequences = []string{"example_table1_id_seq", "example_table2_id_seq"}
-		return tables, enums, sequences, nil
-	}
-
+func (w *PostgreSQLWriter) collectAllObjects(ctx context.Context) (tables []string, enums []string, sequences []string, err error) { //revive:disable-line:function-result-limit // It's acceptable here
 	// Get all tables in the schema
 	tablesQuery := `
 			SELECT table_name
@@ -197,7 +190,7 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 			WHERE table_schema = $1 AND table_type = 'BASE TABLE'
 			ORDER BY table_name`
 
-	rows, err := w.db.Query(tablesQuery, w.schema)
+	rows, err := w.db.QueryContext(ctx, tablesQuery, w.schema)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to query tables: %w", err)
 	}
@@ -210,6 +203,9 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 		}
 		tables = append(tables, tableName)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to iterate tables: %w", err)
+	}
 
 	// Get all custom types (enums) in the schema
 	enumsQuery := `
@@ -219,7 +215,7 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 			WHERE n.nspname = $1 AND t.typtype = 'e'
 			ORDER BY typname`
 
-	enumRows, err := w.db.Query(enumsQuery, w.schema)
+	enumRows, err := w.db.QueryContext(ctx, enumsQuery, w.schema)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to query enums: %w", err)
 	}
@@ -232,6 +228,9 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 		}
 		enums = append(enums, enumName)
 	}
+	if err := enumRows.Err(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to iterate enums: %w", err)
+	}
 
 	// Get all sequences in the schema
 	sequencesQuery := `
@@ -240,7 +239,7 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 			WHERE sequence_schema = $1
 			ORDER BY sequence_name`
 
-	seqRows, err := w.db.Query(sequencesQuery, w.schema)
+	seqRows, err := w.db.QueryContext(ctx, sequencesQuery, w.schema)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to query sequences: %w", err)
 	}
@@ -253,32 +252,40 @@ func (w *PostgreSQLWriter) collectAllObjects() (tables []string, enums []string,
 		}
 		sequences = append(sequences, sequenceName)
 	}
+	if err := seqRows.Err(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to iterate sequences: %w", err)
+	}
 
 	return tables, enums, sequences, nil
 }
 
 // DropAllTables drops ALL tables and enums in the database schema (COMPLETE CLEANUP!)
-func (w *PostgreSQLWriter) DropAllTables() error {
-	slog.Warn("WARNING: This will drop ALL tables and enums in the database!")
-
-	tx, err := w.BeginTransaction(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
 	}
 
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
-
-	tables, enums, sequences, err := w.collectAllObjects()
+	tables, enums, sequences, err := w.collectAllObjects(ctx)
 	if err != nil {
 		return err
 	}
 
-	ctx := context.Background()
+	tx, err := w.BeginTransaction(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("failed to roll back transaction: %w", rollbackErr))
+			}
+		}
+	}()
 
 	// Drop all tables with CASCADE to handle dependencies. Identifiers cannot
 	// be bound as parameters; quoteIdent doubles any embedded `"` so a hostile
@@ -286,7 +293,6 @@ func (w *PostgreSQLWriter) DropAllTables() error {
 	// identifier.
 	for _, tableName := range tables {
 		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName) + " CASCADE"
-		slog.Info("Dropping table...", "tableName", tableName)
 		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop table %s: %w", tableName, err)
 		}
@@ -295,7 +301,6 @@ func (w *PostgreSQLWriter) DropAllTables() error {
 	// Drop all enums
 	for _, enumName := range enums {
 		dropSQL := "DROP TYPE IF EXISTS " + quoteIdent(enumName) + " CASCADE"
-		slog.Info("Dropping enum...", "enumName", enumName)
 		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop enum %s: %w", enumName, err)
 		}
@@ -304,7 +309,6 @@ func (w *PostgreSQLWriter) DropAllTables() error {
 	// Drop all sequences
 	for _, sequenceName := range sequences {
 		dropSQL := "DROP SEQUENCE IF EXISTS " + quoteIdent(sequenceName) + " CASCADE"
-		slog.Info("Dropping sequence...", "sequenceName", sequenceName)
 		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
 			return fmt.Errorf("failed to drop sequence %s: %w", sequenceName, err)
 		}
@@ -315,7 +319,6 @@ func (w *PostgreSQLWriter) DropAllTables() error {
 	}
 	committed = true
 
-	slog.Info("All tables and enums dropped successfully!", "tables", len(tables), "enums", len(enums), "sequences", len(sequences))
 	return nil
 }
 

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -1,0 +1,33 @@
+package postgres_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+	"github.com/stokaro/ptah/internal/dbschema/postgres"
+)
+
+func TestWriterDropAllTables_CanceledContext(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, emptyPostgresCleanupQuery)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+	c.Assert(db.BeginCount(), qt.Equals, 0)
+}
+
+func emptyPostgresCleanupQuery(
+	_ string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return dbtest.QueryResult{}, nil
+}

--- a/internal/dbschema/sqlite/sqlite_test.go
+++ b/internal/dbschema/sqlite/sqlite_test.go
@@ -144,7 +144,7 @@ func TestWriterDropAllTables(t *testing.T) {
 	)`)
 
 	writer := sqlite.NewSQLiteWriter(db, "main")
-	err := writer.DropAllTables()
+	err := writer.DropAllTables(t.Context())
 	c.Assert(err, qt.IsNil)
 
 	schema, err := sqlite.NewSQLiteReader(db, "main").ReadSchema()

--- a/internal/dbschema/sqlite/writer.go
+++ b/internal/dbschema/sqlite/writer.go
@@ -3,13 +3,18 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stokaro/ptah/dbschema/types"
 )
+
+const sessionRestoreTimeout = 5 * time.Second
 
 func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
@@ -121,45 +126,60 @@ func (w *transactionWriter) Rollback() error {
 func (w *transactionWriter) IsDryRun() bool { return w.dryRun }
 
 // DropAllTables drops all user tables from the configured SQLite schema.
-func (w *Writer) DropAllTables() error {
-	slog.Info("WARNING: This will drop ALL tables in the SQLite database")
-
+func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if w.dryRun {
-		for _, table := range []string{"<dry-run stub>"} {
-			slog.Info("[DRY RUN] Would drop table", "tableName", table)
-		}
 		return nil
 	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
 
-	ctx := context.Background()
-	tables, err := w.listTables(ctx)
+	conn, err := w.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("sqlite: acquire cleanup connection: %w", err)
+	}
+	defer func() {
+		closeErr := conn.Close()
+		if closeErr != nil && !errors.Is(closeErr, sql.ErrConnDone) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: close cleanup connection: %w", closeErr))
+		}
+	}()
+
+	var tx *sql.Tx
+	committed := false
+
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("sqlite: disable foreign keys: %w", err)
+	}
+	defer func() {
+		if tx != nil && !committed {
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: roll back drop transaction: %w", rollbackErr))
+			}
+		}
+
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
+		defer cancel()
+		if _, restoreErr := conn.ExecContext(cleanupCtx, "PRAGMA foreign_keys = ON"); restoreErr != nil {
+			discardConn(conn)
+			resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: restore foreign keys: %w", restoreErr))
+		}
+	}()
+
+	tables, err := w.listTables(ctx, conn)
 	if err != nil {
 		return err
 	}
 
-	if _, err := w.db.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
-		return fmt.Errorf("sqlite: disable foreign keys: %w", err)
-	}
-	defer func() {
-		if _, err := w.db.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
-			slog.Warn("failed to restore SQLite foreign_keys pragma", "error", err)
-		}
-	}()
-
-	tx, err := w.BeginTransaction(ctx)
+	tx, err = conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("sqlite: begin drop transaction: %w", err)
 	}
-	committed := false
-	defer func() {
-		if !committed {
-			_ = tx.Rollback()
-		}
-	}()
+	txWriter := &transactionWriter{tx: tx, schema: w.schema}
 
 	for _, table := range tables {
-		slog.Info("Dropping table", "tableName", table)
-		if err := tx.ExecuteSQL(ctx, "DROP TABLE IF EXISTS "+quoteIdent(table)); err != nil {
+		if err := txWriter.ExecuteSQL(ctx, "DROP TABLE IF EXISTS "+quoteIdent(table)); err != nil {
 			return fmt.Errorf("sqlite: drop table %s: %w", table, err)
 		}
 	}
@@ -168,12 +188,11 @@ func (w *Writer) DropAllTables() error {
 	}
 	committed = true
 
-	slog.Info("Successfully dropped tables", "count", len(tables))
 	return nil
 }
 
-func (w *Writer) listTables(ctx context.Context) ([]string, error) {
-	rows, err := w.db.QueryContext(ctx, `
+func (w *Writer) listTables(ctx context.Context, conn *sql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, `
 		SELECT name
 		FROM sqlite_schema
 		WHERE type = 'table'
@@ -198,6 +217,13 @@ func (w *Writer) listTables(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("sqlite: iterate tables: %w", err)
 	}
 	return tables, nil
+}
+
+func discardConn(conn *sql.Conn) {
+	// Never return a connection with unknown session state to the pool.
+	_ = conn.Raw(func(any) error {
+		return driver.ErrBadConn
+	})
 }
 
 // SetDryRun toggles dry-run mode.

--- a/internal/dbschema/sqlite/writer_context_test.go
+++ b/internal/dbschema/sqlite/writer_context_test.go
@@ -1,0 +1,300 @@
+package sqlite_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	moderncsqlite "modernc.org/sqlite"
+
+	"github.com/stokaro/ptah/internal/dbschema/sqlite"
+)
+
+func TestWriterDropAllTables_DoesNotLog(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	execSQL(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(output.String(), qt.Equals, "")
+}
+
+func TestWriterDropAllTables_PinsCleanupToOneConnection(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDB(t, trace)
+	execSQL(t, db, `CREATE TABLE parents (id INTEGER PRIMARY KEY)`)
+	execSQL(t, db, `CREATE TABLE children (
+		id INTEGER PRIMARY KEY,
+		parent_id INTEGER NOT NULL REFERENCES parents(id)
+	)`)
+	trace.reset()
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(trace.connectionIDs(), qt.HasLen, 1)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = OFF")
+	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "children"`)
+	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "parents"`)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+}
+
+func TestWriterDropAllTables_RestoresForeignKeysAfterCancellation(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDB(t, trace)
+	execSQL(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	trace.reset()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	trace.cancelOnDrop = cancel
+	trace.dropErr = context.Canceled
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(trace.connectionIDs(), qt.HasLen, 1)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+}
+
+func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDB(t, trace)
+	execSQL(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	trace.reset()
+
+	dropErr := errors.New("drop failed")
+	restoreErr := errors.New("restore failed")
+	trace.dropErr = dropErr
+	trace.restoreErr = restoreErr
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, dropErr)
+	c.Assert(err, qt.ErrorIs, restoreErr)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+}
+
+func openFileSQLiteDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "cleanup.sqlite")
+	db, err := sql.Open("sqlite", path+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
+
+func openTrackedSQLiteDB(t *testing.T, trace *sqliteCleanupTrace) *sql.DB {
+	t.Helper()
+
+	driverName := "ptah_sqlite_cleanup_" + strconv.FormatInt(sqliteCleanupDriverID.Add(1), 10)
+	sql.Register(driverName, &sqliteCleanupDriver{trace: trace})
+
+	path := filepath.Join(t.TempDir(), "cleanup.sqlite")
+	db, err := sql.Open(driverName, path+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open tracked sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
+
+var sqliteCleanupDriverID atomic.Int64
+
+type sqliteCleanupEvent struct {
+	connectionID int
+	statement    string
+}
+
+type sqliteCleanupTrace struct {
+	mu             sync.Mutex
+	nextConnection atomic.Int64
+	events         []sqliteCleanupEvent
+	cancelOnDrop   context.CancelFunc
+	dropErr        error
+	restoreErr     error
+}
+
+func (tr *sqliteCleanupTrace) record(connectionID int, query string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.events = append(tr.events, sqliteCleanupEvent{
+		connectionID: connectionID,
+		statement:    normalizeSQL(query),
+	})
+}
+
+func (tr *sqliteCleanupTrace) executionError(query string) error {
+	statement := normalizeSQL(query)
+
+	tr.mu.Lock()
+	cancelOnDrop := tr.cancelOnDrop
+	dropErr := tr.dropErr
+	restoreErr := tr.restoreErr
+	tr.mu.Unlock()
+
+	switch {
+	case strings.HasPrefix(statement, "DROP TABLE") && dropErr != nil:
+		if cancelOnDrop != nil {
+			cancelOnDrop()
+		}
+		return dropErr
+	case statement == "PRAGMA foreign_keys = ON" && restoreErr != nil:
+		return restoreErr
+	default:
+		return nil
+	}
+}
+
+func (tr *sqliteCleanupTrace) reset() {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.events = nil
+}
+
+func (tr *sqliteCleanupTrace) statements() []string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	statements := make([]string, len(tr.events))
+	for index, event := range tr.events {
+		statements[index] = event.statement
+	}
+	return statements
+}
+
+func (tr *sqliteCleanupTrace) connectionIDs() []int {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+
+	unique := make(map[int]struct{})
+	for _, event := range tr.events {
+		unique[event.connectionID] = struct{}{}
+	}
+	ids := make([]int, 0, len(unique))
+	for id := range unique {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+type sqliteCleanupDriver struct {
+	trace *sqliteCleanupTrace
+}
+
+func (drv *sqliteCleanupDriver) Open(name string) (driver.Conn, error) {
+	conn, err := new(moderncsqlite.Driver).Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &sqliteCleanupConn{
+		Conn:         conn,
+		connectionID: int(drv.trace.nextConnection.Add(1)),
+		trace:        drv.trace,
+	}, nil
+}
+
+type sqliteCleanupConn struct {
+	driver.Conn
+	connectionID int
+	trace        *sqliteCleanupTrace
+}
+
+func (conn *sqliteCleanupConn) QueryContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Rows, error) {
+	conn.trace.record(conn.connectionID, query)
+	queryer, ok := conn.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return queryer.QueryContext(ctx, query, args)
+}
+
+func (conn *sqliteCleanupConn) ExecContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Result, error) {
+	conn.trace.record(conn.connectionID, query)
+	if err := conn.trace.executionError(query); err != nil {
+		return nil, err
+	}
+	execer, ok := conn.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return execer.ExecContext(ctx, query, args)
+}
+
+func (conn *sqliteCleanupConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	beginner, ok := conn.Conn.(driver.ConnBeginTx)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return beginner.BeginTx(ctx, opts)
+}
+
+func (conn *sqliteCleanupConn) ResetSession(ctx context.Context) error {
+	resetter, ok := conn.Conn.(driver.SessionResetter)
+	if !ok {
+		return nil
+	}
+	return resetter.ResetSession(ctx)
+}
+
+func (conn *sqliteCleanupConn) IsValid() bool {
+	validator, ok := conn.Conn.(driver.Validator)
+	return !ok || validator.IsValid()
+}
+
+func normalizeSQL(query string) string {
+	return strings.Join(strings.Fields(query), " ")
+}
+
+var (
+	_ driver.ConnBeginTx     = (*sqliteCleanupConn)(nil)
+	_ driver.ExecerContext   = (*sqliteCleanupConn)(nil)
+	_ driver.QueryerContext  = (*sqliteCleanupConn)(nil)
+	_ driver.SessionResetter = (*sqliteCleanupConn)(nil)
+	_ driver.Validator       = (*sqliteCleanupConn)(nil)
+)

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -48,7 +48,7 @@ func ReplayOnConnection(
 	dir string,
 	dirFormat migrator.MigrationDirFormat,
 ) error {
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("clean dev database: %w", err)
 	}
 	provider, err := migrator.NewFSMigrationProvider(

--- a/internal/schemaclean/clean.go
+++ b/internal/schemaclean/clean.go
@@ -2,6 +2,7 @@
 package schemaclean
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -56,7 +57,7 @@ func Inspect(conn *dbschema.DatabaseConnection) (Plan, error) {
 	return PlanFromObjects(objects, dialect), nil
 }
 
-func Execute(conn *dbschema.DatabaseConnection, opts Options) (Plan, error) {
+func Execute(ctx context.Context, conn *dbschema.DatabaseConnection, opts Options) (Plan, error) {
 	plan, err := Inspect(conn)
 	if err != nil {
 		return Plan{}, err
@@ -64,15 +65,15 @@ func Execute(conn *dbschema.DatabaseConnection, opts Options) (Plan, error) {
 	if opts.DryRun {
 		return plan, nil
 	}
-	if err := Apply(conn); err != nil {
+	if err := Apply(ctx, conn); err != nil {
 		return Plan{}, err
 	}
 	return plan, nil
 }
 
-func Apply(conn *dbschema.DatabaseConnection) error {
+func Apply(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 	conn.SchemaWriter().SetDryRun(false)
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("drop schema objects: %w", err)
 	}
 	return nil

--- a/migration/generator/baseline_shadow.go
+++ b/migration/generator/baseline_shadow.go
@@ -54,7 +54,7 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, shadowConn.Info().Capabilities) {
 		return fmt.Errorf("baseline shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
 	}
-	if err := shadowConn.SchemaWriter().DropAllTables(); err != nil {
+	if err := shadowConn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("baseline shadow check failed: drop all objects: %w", err)
 	}
 	if err := resetBaselineShadowSchemas(ctx, shadowConn, opts.Schemas); err != nil {

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -124,7 +124,7 @@ func generateCheckpointFromConn(ctx context.Context, shadowConn *dbschema.Databa
 		return "", "", fmt.Errorf("checkpoint generation failed: shadow database dialect %q does not match target dialect %q", shadowConn.Info().Dialect, dialect)
 	}
 
-	if err := shadowConn.SchemaWriter().DropAllTables(); err != nil {
+	if err := shadowConn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return "", "", fmt.Errorf("checkpoint generation failed: drop all objects: %w", err)
 	}
 	if err := resetBaselineShadowSchemas(ctx, shadowConn, opts.Schemas); err != nil {

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -120,7 +120,7 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 		)
 	}
 
-	if err := conn.SchemaWriter().DropAllTables(); err != nil {
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return newShadowVerificationError("drop-all", "drop_all_error", "drop all objects", err)
 	}
 	replayCtx := context.Background()

--- a/migration/generator/shadow_test.go
+++ b/migration/generator/shadow_test.go
@@ -74,7 +74,7 @@ func TestLoadPriorMigrationsMissingDir(t *testing.T) {
 func TestVerifyShadowMigrationConnectErrorIsStructured(t *testing.T) {
 	c := qt.New(t)
 
-	err := verifyShadowMigration(context.Background(), shadowMigrationOptions{
+	err := verifyShadowMigration(t.Context(), shadowMigrationOptions{
 		DatabaseURL: "not-a-dsn",
 		Dialect:     "postgres",
 	})
@@ -96,7 +96,7 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 	}
 
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 	releaseLock := acquireShadowTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
-		c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+		c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	}()
 
 	c.Run("broken prior migration aborts with missing column", func(c *qt.C) {
@@ -176,7 +176,7 @@ func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *t
 	}
 
 	c := qt.New(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 	if err != nil {
@@ -189,10 +189,10 @@ func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *t
 	releaseLock := acquireShadowTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
-		c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+		c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	}()
 
-	c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+	c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	_, err = conn.ExecContext(ctx, `
 		CREATE TABLE users (
 			id SERIAL PRIMARY KEY,
@@ -302,7 +302,7 @@ func writePriorMigration(c *qt.C, dir, upSQL string) {
 }
 
 func prepareShadowTargetDB(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) {
-	c.Assert(conn.SchemaWriter().DropAllTables(), qt.IsNil)
+	c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
 	_, err := conn.ExecContext(ctx, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL)")
 	c.Assert(err, qt.IsNil)
 }


### PR DESCRIPTION
## Summary

- change `SchemaWriter.DropAllTables` to accept caller context across every dialect and caller
- remove global logger output from library cleanup while preserving CLI-owned reporting
- pin SQLite/MySQL cleanup to one connection, restore session settings after cancellation, and return joined cleanup errors
- add declarative black-box cancellation/session-state tests and live ClickHouse cleanup fixtures
- update public API, SQL Server, and integration fixture documentation

## Validation

- `go test ./...`
- `go test -race ./internal/dbschema/... ./internal/migrationreplay ./internal/schemaclean ./internal/atlasmigrate ./migration/generator`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `go tool teststyle ./...`
- `go vet ./...`
- `go build ./cmd/ptah ./cmd/ptah-compat`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- `scripts/check-public-api-released.sh` (expected pre-release baseline skip)
- live `cleanup_support` matrix: PostgreSQL, MySQL, MariaDB, ClickHouse; 4 passed, 0 skipped
- SQL Server live schema/cleanup suite; 4 passed
- direct `ptah-compat migrate lint` smoke; successful stderr was 0 bytes

## Self-review

Two independent review passes covered cancellation, session restoration, transaction semantics, SQL safety, public API/docs, test style, and cross-dialect behavior. Findings were addressed: the public API snapshot was regenerated, context cleanup semantics were clarified, and the integration fixture inventory now documents every dialect variant.

## Documentation impact

Checked root/public API, dialect, integration, and Starlight documentation surfaces. Updated package docs, `docs/public_api.snapshot`, `docs/sqlserver.md`, and `integration/README.md`; no Starlight page describes this low-level API signature or required a behavior change.

Closes #749