### PR TITLE
Add row introspection and the datadiff package (#663)

### DIFF
--- a/dbschema/read_rows.go
+++ b/dbschema/read_rows.go
@@ -1,0 +1,97 @@
+package dbschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+// ReadTableRows reads the current rows of table, projected onto the requested
+// column set, from the database behind conn.
+//
+// The SELECT is built with dialect-aware, safely-quoted identifiers (via
+// internal/sqlident) keyed off conn.Info().Dialect, so callers never hand-quote
+// table or column names. When schema is non-empty the table is
+// schema-qualified. columns is required and drives both the projection and the
+// keys of the returned maps: each returned row is a map[string]any keyed by the
+// requested column names, in the exact spelling passed in. []byte scan results
+// (several drivers return []byte for text and numeric columns) are converted to
+// string so that values compare stably regardless of driver; all other values
+// are returned as scanned.
+//
+// No ORDER BY is applied, so the returned row order is whatever the database
+// yields and must not be relied upon. This suits set-oriented callers such as
+// migration/datadiff.Compute, which key rows by their declared key columns and
+// are order-independent by construction.
+//
+// The context governs query execution and row iteration; canceling it aborts
+// the read with the context error wrapped in the returned error.
+func ReadTableRows(ctx context.Context, conn *DatabaseConnection, schema, table string, columns []string) ([]map[string]any, error) {
+	if conn == nil {
+		return nil, errors.New("dbschema: ReadTableRows requires a non-nil connection")
+	}
+	if strings.TrimSpace(table) == "" {
+		return nil, errors.New("dbschema: ReadTableRows requires a table name")
+	}
+	if len(columns) == 0 {
+		return nil, errors.New("dbschema: ReadTableRows requires at least one column")
+	}
+
+	dialect := conn.Info().Dialect
+
+	quoted := make([]string, len(columns))
+	for i, col := range columns {
+		quoted[i] = sqlident.Quote(dialect, col)
+	}
+	query := "SELECT " + strings.Join(quoted, ", ") + " FROM " + sqlident.Qualified(dialect, schema, table)
+
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("dbschema: read rows of table %q: %w", table, err)
+	}
+	defer rows.Close()
+
+	names, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("dbschema: read columns of table %q: %w", table, err)
+	}
+	if len(names) != len(columns) {
+		return nil, fmt.Errorf("dbschema: table %q returned %d columns, want %d", table, len(names), len(columns))
+	}
+
+	holders := make([]any, len(columns))
+	scanTargets := make([]any, len(columns))
+	for i := range holders {
+		scanTargets[i] = &holders[i]
+	}
+
+	var result []map[string]any
+	for rows.Next() {
+		if err := rows.Scan(scanTargets...); err != nil {
+			return nil, fmt.Errorf("dbschema: scan row of table %q: %w", table, err)
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = normalizeScannedValue(holders[i])
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("dbschema: iterate rows of table %q: %w", table, err)
+	}
+
+	return result, nil
+}
+
+// normalizeScannedValue converts driver []byte results (several drivers return
+// []byte for text and numeric columns) to string, leaving all other values
+// untouched, so scanned values compare stably regardless of driver.
+func normalizeScannedValue(v any) any {
+	if b, ok := v.([]byte); ok {
+		return string(b)
+	}
+	return v
+}

--- a/dbschema/read_rows.go
+++ b/dbschema/read_rows.go
@@ -39,6 +39,16 @@ func ReadTableRows(ctx context.Context, conn *DatabaseConnection, schema, table 
 	if len(columns) == 0 {
 		return nil, errors.New("dbschema: ReadTableRows requires at least one column")
 	}
+	// Duplicate column names would collapse into a single map key while the
+	// column-count guard below still passed, silently dropping a column, so
+	// reject them up front.
+	seen := make(map[string]struct{}, len(columns))
+	for _, col := range columns {
+		if _, dup := seen[col]; dup {
+			return nil, fmt.Errorf("dbschema: ReadTableRows got duplicate column %q", col)
+		}
+		seen[col] = struct{}{}
+	}
 
 	dialect := conn.Info().Dialect
 

--- a/dbschema/read_rows_test.go
+++ b/dbschema/read_rows_test.go
@@ -1,0 +1,122 @@
+package dbschema_test
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+)
+
+// newRegionsConn opens an in-memory SQLite database, creates a "regions" table
+// with three columns, and seeds it with two rows. The connection is closed via
+// t.Cleanup. It is the shared fixture for the ReadTableRows tests.
+func newRegionsConn(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+	c := qt.New(t)
+
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite:///:memory:")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	_, err = conn.ExecContext(context.Background(),
+		"CREATE TABLE regions (code TEXT PRIMARY KEY, name TEXT NOT NULL, population INTEGER NOT NULL)")
+	c.Assert(err, qt.IsNil)
+
+	_, err = conn.ExecContext(context.Background(),
+		"INSERT INTO regions (code, name, population) VALUES ('US', 'United States', 331), ('CZ', 'Czechia', 10)")
+	c.Assert(err, qt.IsNil)
+
+	return conn
+}
+
+// sortByCode orders rows by their "code" column so an unordered read result can
+// be compared against a fixed expectation (ReadTableRows does not guarantee
+// order).
+func sortByCode(rows []map[string]any) {
+	slices.SortFunc(rows, func(a, b map[string]any) int {
+		return cmp.Compare(a["code"].(string), b["code"].(string))
+	})
+}
+
+func TestReadTableRows_ColumnSubset(t *testing.T) {
+	c := qt.New(t)
+	conn := newRegionsConn(t)
+
+	rows, err := dbschema.ReadTableRows(context.Background(), conn, "", "regions", []string{"code", "name"})
+	c.Assert(err, qt.IsNil)
+	sortByCode(rows)
+	// Only the requested columns are present; the live-only "population" column
+	// is not projected into the returned maps.
+	c.Assert(rows, qt.DeepEquals, []map[string]any{
+		{"code": "CZ", "name": "Czechia"},
+		{"code": "US", "name": "United States"},
+	})
+}
+
+func TestReadTableRows_SchemaQualified(t *testing.T) {
+	c := qt.New(t)
+	conn := newRegionsConn(t)
+
+	// SQLite's default schema is "main"; qualifying with it must resolve the
+	// same table and exercises the schema-qualified identifier path.
+	rows, err := dbschema.ReadTableRows(context.Background(), conn, "main", "regions", []string{"code"})
+	c.Assert(err, qt.IsNil)
+	sortByCode(rows)
+	c.Assert(rows, qt.DeepEquals, []map[string]any{
+		{"code": "CZ"},
+		{"code": "US"},
+	})
+}
+
+func TestReadTableRows_IntegerColumnScannedAsInt64(t *testing.T) {
+	c := qt.New(t)
+	conn := newRegionsConn(t)
+
+	rows, err := dbschema.ReadTableRows(context.Background(), conn, "", "regions", []string{"code", "population"})
+	c.Assert(err, qt.IsNil)
+	sortByCode(rows)
+	c.Assert(rows, qt.DeepEquals, []map[string]any{
+		{"code": "CZ", "population": int64(10)},
+		{"code": "US", "population": int64(331)},
+	})
+}
+
+func TestReadTableRows_EmptyTable(t *testing.T) {
+	c := qt.New(t)
+	conn := newRegionsConn(t)
+
+	_, err := conn.ExecContext(context.Background(), "DELETE FROM regions")
+	c.Assert(err, qt.IsNil)
+
+	rows, err := dbschema.ReadTableRows(context.Background(), conn, "", "regions", []string{"code", "name"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rows, qt.HasLen, 0)
+}
+
+func TestReadTableRows_ValidationErrors(t *testing.T) {
+	c := qt.New(t)
+	conn := newRegionsConn(t)
+
+	tests := []struct {
+		name    string
+		conn    *dbschema.DatabaseConnection
+		table   string
+		columns []string
+	}{
+		{name: "nil connection", conn: nil, table: "regions", columns: []string{"code"}},
+		{name: "empty table name", conn: conn, table: "  ", columns: []string{"code"}},
+		{name: "no columns", conn: conn, table: "regions", columns: nil},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			rows, err := dbschema.ReadTableRows(context.Background(), tt.conn, "", tt.table, tt.columns)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(rows, qt.IsNil)
+		})
+	}
+}

--- a/dbschema/read_rows_test.go
+++ b/dbschema/read_rows_test.go
@@ -110,6 +110,7 @@ func TestReadTableRows_ValidationErrors(t *testing.T) {
 		{name: "nil connection", conn: nil, table: "regions", columns: []string{"code"}},
 		{name: "empty table name", conn: conn, table: "  ", columns: []string{"code"}},
 		{name: "no columns", conn: conn, table: "regions", columns: nil},
+		{name: "duplicate columns", conn: conn, table: "regions", columns: []string{"code", "code"}},
 	}
 
 	for _, tt := range tests {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -23,6 +23,7 @@ These packages are intended for application and tool embedders:
 - `github.com/stokaro/ptah/core/sqlutil`
 - `github.com/stokaro/ptah/dbschema`
 - `github.com/stokaro/ptah/dbschema/types`
+- `github.com/stokaro/ptah/migration/datadiff`
 - `github.com/stokaro/ptah/migration/dbtest`
 - `github.com/stokaro/ptah/migration/diffpolicy`
 - `github.com/stokaro/ptah/migration/generator`

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -547,6 +547,7 @@ func StripComments(sql string) string
 func CloseAndWarn(conn *DatabaseConnection)
 func FormatDatabaseURL(dbURL string) string
 func ReadSchemaWithSchemas(conn *DatabaseConnection, schemas []string) (*types.DBSchema, error)
+func ReadTableRows(ctx context.Context, conn *DatabaseConnection, schema, table string, ...) ([]map[string]any, error)
 type DatabaseConnection struct{ ... }
     func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, error)
 
@@ -637,6 +638,13 @@ type SchemaWriter interface {
 }
     SchemaWriter interface for writing schemas to databases.
 
+
+## github.com/stokaro/ptah/migration/datadiff
+
+type DataDiff struct{ ... }
+    func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error)
+type Row = map[string]any
+type RowUpdate struct{ ... }
 
 ## github.com/stokaro/ptah/migration/dbtest
 

--- a/internal/schemaclean/clean.go
+++ b/internal/schemaclean/clean.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
 const (
@@ -196,13 +197,13 @@ func sortObjects(objects []Object) {
 }
 
 func dropCommand(dialect string, object Object) string {
-	name := qualifiedName(dialect, object.Schema, object.Name)
+	name := sqlident.Qualified(dialect, object.Schema, object.Name)
 	switch object.Type {
 	case ObjectTypeEnum:
 		return "DROP TYPE IF EXISTS " + name + " CASCADE"
 	case ObjectTypeForeignKey:
-		return "ALTER TABLE " + qualifiedName(dialect, object.Schema, object.Table) +
-			" DROP CONSTRAINT " + quoteIdent(dialect, object.Name)
+		return "ALTER TABLE " + sqlident.Qualified(dialect, object.Schema, object.Table) +
+			" DROP CONSTRAINT " + sqlident.Quote(dialect, object.Name)
 	case ObjectTypeSequence:
 		return "DROP SEQUENCE IF EXISTS " + name + " CASCADE"
 	case ObjectTypeTable:
@@ -260,25 +261,5 @@ func supportsStandaloneSequences(dialect string) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-func qualifiedName(dialect, schema, name string) string {
-	schema = strings.TrimSpace(schema)
-	name = strings.TrimSpace(name)
-	if schema == "" {
-		return quoteIdent(dialect, name)
-	}
-	return quoteIdent(dialect, schema) + "." + quoteIdent(dialect, name)
-}
-
-func quoteIdent(dialect, name string) string {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "mysql", "mariadb", "clickhouse":
-		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
-	case "sqlserver", "mssql":
-		return "[" + strings.ReplaceAll(name, "]", "]]") + "]"
-	default:
-		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 	}
 }

--- a/internal/sqlident/sqlident.go
+++ b/internal/sqlident/sqlident.go
@@ -1,0 +1,39 @@
+// Package sqlident quotes SQL identifiers (schema, table, and column names) for
+// a given SQL dialect. It centralizes the per-dialect quote style and the
+// standard "double the quote character" escaping so that identifiers taken from
+// catalog metadata, annotations, or any other untrusted-shaped string cannot
+// terminate the quoted identifier and inject SQL.
+package sqlident
+
+import "strings"
+
+// Quote returns name as a safely-quoted identifier for dialect. The dialect
+// selects the quote style: backticks for MySQL, MariaDB, and ClickHouse; square
+// brackets for SQL Server; and double quotes for the PostgreSQL family, SQLite,
+// and any unrecognized dialect. Embedded quote characters are doubled per the
+// SQL standard so the value cannot terminate the quoted identifier. The dialect
+// is matched case-insensitively and surrounding whitespace is ignored; name
+// itself is quoted verbatim (it is not trimmed).
+func Quote(dialect, name string) string {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "mysql", "mariadb", "clickhouse":
+		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	case "sqlserver", "mssql":
+		return "[" + strings.ReplaceAll(name, "]", "]]") + "]"
+	default:
+		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	}
+}
+
+// Qualified returns a dialect-quoted identifier optionally qualified by schema,
+// as in "schema"."name". Leading and trailing whitespace is trimmed from schema
+// and name before quoting; an empty (or whitespace-only) schema yields just the
+// quoted name.
+func Qualified(dialect, schema, name string) string {
+	schema = strings.TrimSpace(schema)
+	name = strings.TrimSpace(name)
+	if schema == "" {
+		return Quote(dialect, name)
+	}
+	return Quote(dialect, schema) + "." + Quote(dialect, name)
+}

--- a/internal/sqlident/sqlident_test.go
+++ b/internal/sqlident/sqlident_test.go
@@ -1,0 +1,65 @@
+package sqlident_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+func TestQuote(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		ident   string
+		want    string
+	}{
+		{name: "postgres double quotes", dialect: "postgres", ident: "users", want: `"users"`},
+		{name: "sqlite double quotes", dialect: "sqlite", ident: "users", want: `"users"`},
+		{name: "cockroachdb falls back to double quotes", dialect: "cockroachdb", ident: "users", want: `"users"`},
+		{name: "yugabytedb falls back to double quotes", dialect: "yugabytedb", ident: "users", want: `"users"`},
+		{name: "unknown dialect falls back to double quotes", dialect: "duckdb", ident: "users", want: `"users"`},
+		{name: "mysql backticks", dialect: "mysql", ident: "users", want: "`users`"},
+		{name: "mariadb backticks", dialect: "mariadb", ident: "users", want: "`users`"},
+		{name: "clickhouse backticks", dialect: "clickhouse", ident: "users", want: "`users`"},
+		{name: "sqlserver brackets", dialect: "sqlserver", ident: "users", want: "[users]"},
+		{name: "mssql alias brackets", dialect: "mssql", ident: "users", want: "[users]"},
+		{name: "dialect is case and space insensitive", dialect: "  MySQL ", ident: "users", want: "`users`"},
+		{name: "postgres escapes embedded double quote", dialect: "postgres", ident: `a"b`, want: `"a""b"`},
+		{name: "mysql escapes embedded backtick", dialect: "mysql", ident: "a`b", want: "`a``b`"},
+		{name: "sqlserver escapes embedded bracket", dialect: "sqlserver", ident: "a]b", want: "[a]]b]"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(sqlident.Quote(tt.dialect, tt.ident), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestQualified(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		schema  string
+		ident   string
+		want    string
+	}{
+		{name: "postgres schema qualified", dialect: "postgres", schema: "public", ident: "users", want: `"public"."users"`},
+		{name: "empty schema yields bare name", dialect: "postgres", schema: "", ident: "users", want: `"users"`},
+		{name: "whitespace schema treated as empty", dialect: "postgres", schema: "  ", ident: "users", want: `"users"`},
+		{name: "schema and name are trimmed", dialect: "mysql", schema: " app ", ident: " users ", want: "`app`.`users`"},
+		{name: "sqlserver schema qualified", dialect: "sqlserver", schema: "dbo", ident: "users", want: "[dbo].[users]"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(sqlident.Qualified(tt.dialect, tt.schema, tt.ident), qt.Equals, tt.want)
+		})
+	}
+}

--- a/migration/datadiff/datadiff.go
+++ b/migration/datadiff/datadiff.go
@@ -1,0 +1,200 @@
+// Package datadiff computes row-level differences between the desired managed
+// (reference/seed) data declared in Go sources and the rows currently stored in
+// a database table.
+//
+// It is a pure computation layer with no database or filesystem dependencies. A
+// caller in a later phase composes the full pipeline: load desired rows with
+// goschema.LoadManagedRows, read the live rows with dbschema.ReadTableRows, and
+// hand both to [Compute]. Rendering the resulting diff into DML and wiring it
+// into the migrate/apply commands are separate, later phases; this package only
+// reports what changed.
+//
+// # Value comparison
+//
+// Compute compares values by a normalized string form (see [Compute]): nil
+// becomes the empty string, []byte becomes string, and every other value is
+// formatted with fmt's default verb. This makes comparison driver-agnostic
+// (for example a desired int 1 and a live int64 1 compare equal) but only
+// approximate across dialects: numeric scale, boolean encoding, and decimal
+// precision differences between PostgreSQL, MySQL, and others are not modeled.
+// Type-exact, dialect-aware value comparison is a known follow-up, matching the
+// issue's "cross-dialect value rendering is substantial" caveat.
+package datadiff
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Row is a single table row keyed by column name. It matches the shape returned
+// by goschema.LoadManagedRows and dbschema.ReadTableRows.
+type Row = map[string]any
+
+// RowUpdate describes a row present in both the desired and live data whose
+// managed columns differ. Both Desired and Live are carried so a later phase can
+// render a reversible UPDATE (Desired drives the forward statement, Live the
+// rollback). Key holds only the key-column values that identify the row.
+type RowUpdate struct {
+	Key     map[string]any
+	Desired Row
+	Live    Row
+}
+
+// DataDiff is the set of row-level changes needed to bring a table's live rows
+// in line with the desired managed data.
+//
+// Inserts are rows present in the desired data but absent live. Deletes are
+// rows present live but absent from the desired data. Updates are rows present
+// in both whose managed columns differ. Inserts, Updates, and Deletes are each
+// sorted by their composite key so the output is deterministic and testable.
+type DataDiff struct {
+	Table   string
+	Keys    []string
+	Inserts []Row
+	Updates []RowUpdate
+	Deletes []Row
+}
+
+// Compute computes the row-level diff for table between the desired rows and the
+// live rows, keyed by the key columns in keys.
+//
+// keys must be non-empty and every desired and live row must contain a value
+// for each key column; a missing key column is a validation error. Rows are
+// matched by the tuple of their key-column values, compared by their normalized
+// string form (see the package documentation). A row is:
+//
+//   - an Insert if its key appears in desired but not live;
+//   - a Delete if its key appears in live but not desired;
+//   - an Update if its key appears in both and any managed column differs. Only
+//     the columns present in the desired row (the managed columns) are compared,
+//     so columns that exist only in the live row never trigger an update.
+//
+// If two rows on the same side share a composite key, the later one in input
+// order wins; keys should be chosen so this does not occur.
+func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("datadiff: keys must be non-empty")
+	}
+
+	desiredByKey, err := indexByKey(keys, desired, "desired")
+	if err != nil {
+		return nil, err
+	}
+	liveByKey, err := indexByKey(keys, live, "live")
+	if err != nil {
+		return nil, err
+	}
+
+	diff := &DataDiff{
+		Table: table,
+		Keys:  slices.Clone(keys),
+	}
+
+	for _, k := range sortedKeys(desiredByKey) {
+		desiredRow := desiredByKey[k]
+		liveRow, ok := liveByKey[k]
+		if !ok {
+			diff.Inserts = append(diff.Inserts, desiredRow)
+			continue
+		}
+		if managedColumnsDiffer(desiredRow, liveRow) {
+			diff.Updates = append(diff.Updates, RowUpdate{
+				Key:     keyValues(keys, desiredRow),
+				Desired: desiredRow,
+				Live:    liveRow,
+			})
+		}
+	}
+
+	for _, k := range sortedKeys(liveByKey) {
+		if _, ok := desiredByKey[k]; !ok {
+			diff.Deletes = append(diff.Deletes, liveByKey[k])
+		}
+	}
+
+	return diff, nil
+}
+
+// indexByKey builds a map from composite-key string to row. side ("desired" or
+// "live") is used only to make missing-key errors point at the offending input.
+func indexByKey(keys []string, rows []Row, side string) (map[string]Row, error) {
+	out := make(map[string]Row, len(rows))
+	for i, row := range rows {
+		k, err := keyString(keys, row)
+		if err != nil {
+			return nil, fmt.Errorf("datadiff: %s row %d: %w", side, i, err)
+		}
+		out[k] = row
+	}
+	return out, nil
+}
+
+// keyString builds a collision-free composite key from the key columns of row.
+// Each normalized key value is length-prefixed and NUL-terminated so that no
+// combination of values can produce the same string as a different tuple.
+func keyString(keys []string, row Row) (string, error) {
+	var b strings.Builder
+	for _, k := range keys {
+		v, ok := row[k]
+		if !ok {
+			return "", fmt.Errorf("missing key column %q", k)
+		}
+		n := normalizeValue(v)
+		b.WriteString(strconv.Itoa(len(n)))
+		b.WriteByte(':')
+		b.WriteString(n)
+		b.WriteByte(0)
+	}
+	return b.String(), nil
+}
+
+// keyValues returns a copy of just the key-column values of row.
+func keyValues(keys []string, row Row) map[string]any {
+	out := make(map[string]any, len(keys))
+	for _, k := range keys {
+		out[k] = row[k]
+	}
+	return out
+}
+
+// managedColumnsDiffer reports whether any column present in desired has a
+// different normalized value than the same column in live. Columns present only
+// in live are ignored, so a live row that is a superset of the managed columns
+// does not spuriously register as an update.
+func managedColumnsDiffer(desired, live Row) bool {
+	for col, desiredValue := range desired {
+		if normalizeValue(desiredValue) != normalizeValue(live[col]) {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedKeys returns the map keys in ascending order.
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// normalizeValue reduces a value to a comparable string form: nil to the empty
+// string, []byte to string, and any other value via fmt's default verb. See the
+// package documentation for the cross-dialect limitations of this approach.
+func normalizeValue(v any) string {
+	switch value := v.(type) {
+	case nil:
+		return ""
+	case []byte:
+		return string(value)
+	case string:
+		return value
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}

--- a/migration/datadiff/datadiff.go
+++ b/migration/datadiff/datadiff.go
@@ -11,14 +11,16 @@
 //
 // # Value comparison
 //
-// Compute compares values by a normalized string form (see [Compute]): nil
-// becomes the empty string, []byte becomes string, and every other value is
-// formatted with fmt's default verb. This makes comparison driver-agnostic
-// (for example a desired int 1 and a live int64 1 compare equal) but only
-// approximate across dialects: numeric scale, boolean encoding, and decimal
-// precision differences between PostgreSQL, MySQL, and others are not modeled.
-// Type-exact, dialect-aware value comparison is a known follow-up, matching the
-// issue's "cross-dialect value rendering is substantial" caveat.
+// Compute compares values by a normalized string form (see [Compute]): a
+// one-byte type tag ("N" nil, "S" string, "B" []byte, "V" everything else via
+// fmt's default verb) followed by the value. The tag keeps distinct kinds from
+// colliding — notably a SQL NULL stays distinct from an empty string — while
+// still making the "V" form driver-agnostic (a desired int 1 and a live int64 1
+// compare equal). It remains only approximate across dialects for the "V" form:
+// numeric scale, boolean encoding, and decimal precision differences between
+// PostgreSQL, MySQL, and others are not modeled. Type-exact, dialect-aware value
+// comparison is a known follow-up, matching the issue's "cross-dialect value
+// rendering is substantial" caveat.
 package datadiff
 
 import (
@@ -183,18 +185,22 @@ func sortedKeys[V any](m map[string]V) []string {
 	return out
 }
 
-// normalizeValue reduces a value to a comparable string form: nil to the empty
-// string, []byte to string, and any other value via fmt's default verb. See the
-// package documentation for the cross-dialect limitations of this approach.
+// normalizeValue reduces a value to a comparable string form, prefixed with a
+// one-byte type tag so distinct kinds can never collide: "N" for nil (a SQL
+// NULL), "S" for a string, "B" for []byte, and "V" for any other value via fmt's
+// default verb. The tag keeps a NULL distinct from an empty string, so a live
+// NULL versus a desired "" is correctly reported as a change rather than
+// silently matching. See the package documentation for the remaining
+// cross-dialect limitations (numeric scale, boolean encoding) of the "V" form.
 func normalizeValue(v any) string {
 	switch value := v.(type) {
 	case nil:
-		return ""
+		return "N"
 	case []byte:
-		return string(value)
+		return "B" + string(value)
 	case string:
-		return value
+		return "S" + value
 	default:
-		return fmt.Sprintf("%v", value)
+		return "V" + fmt.Sprintf("%v", value)
 	}
 }

--- a/migration/datadiff/datadiff_test.go
+++ b/migration/datadiff/datadiff_test.go
@@ -142,6 +142,30 @@ func TestCompute(t *testing.T) {
 			want: &datadiff.DataDiff{Table: "regions", Keys: []string{"code"}},
 		},
 		{
+			name:  "live NULL versus desired empty string is an update",
+			table: "regions",
+			keys:  []string{"code"},
+			// A live SQL NULL (nil) must stay distinct from a desired empty
+			// string, so the desired "" is reported as a change to apply.
+			desired: []datadiff.Row{
+				{"code": "US", "note": ""},
+			},
+			live: []datadiff.Row{
+				{"code": "US", "note": nil},
+			},
+			want: &datadiff.DataDiff{
+				Table: "regions",
+				Keys:  []string{"code"},
+				Updates: []datadiff.RowUpdate{
+					{
+						Key:     map[string]any{"code": "US"},
+						Desired: datadiff.Row{"code": "US", "note": ""},
+						Live:    datadiff.Row{"code": "US", "note": nil},
+					},
+				},
+			},
+		},
+		{
 			name:  "normalized values compare equal across numeric types",
 			table: "regions",
 			keys:  []string{"id"},

--- a/migration/datadiff/datadiff_test.go
+++ b/migration/datadiff/datadiff_test.go
@@ -1,0 +1,205 @@
+package datadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/datadiff"
+)
+
+func TestCompute(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		table   string
+		keys    []string
+		desired []datadiff.Row
+		live    []datadiff.Row
+		want    *datadiff.DataDiff
+	}{
+		{
+			name:  "all inserts when live is empty",
+			table: "regions",
+			keys:  []string{"code"},
+			desired: []datadiff.Row{
+				{"code": "US", "name": "United States"},
+				{"code": "CZ", "name": "Czechia"},
+			},
+			live: nil,
+			want: &datadiff.DataDiff{
+				Table: "regions",
+				Keys:  []string{"code"},
+				Inserts: []datadiff.Row{
+					{"code": "CZ", "name": "Czechia"},
+					{"code": "US", "name": "United States"},
+				},
+			},
+		},
+		{
+			name:    "all deletes when desired is empty",
+			table:   "regions",
+			keys:    []string{"code"},
+			desired: nil,
+			live: []datadiff.Row{
+				{"code": "US", "name": "United States"},
+				{"code": "CZ", "name": "Czechia"},
+			},
+			want: &datadiff.DataDiff{
+				Table: "regions",
+				Keys:  []string{"code"},
+				Deletes: []datadiff.Row{
+					{"code": "CZ", "name": "Czechia"},
+					{"code": "US", "name": "United States"},
+				},
+			},
+		},
+		{
+			name:  "mixed insert update delete with deterministic ordering",
+			table: "regions",
+			keys:  []string{"code"},
+			// Deliberately unsorted input to prove the output is sorted by key.
+			desired: []datadiff.Row{
+				{"code": "FR", "name": "France"},
+				{"code": "US", "name": "USA"},
+				{"code": "AT", "name": "Austria"},
+				{"code": "CZ", "name": "Czechia"},
+			},
+			live: []datadiff.Row{
+				{"code": "ZZ", "name": "Zeta"},
+				{"code": "US", "name": "United States"},
+				{"code": "FR", "name": "France"},
+				{"code": "DE", "name": "Germany"},
+			},
+			want: &datadiff.DataDiff{
+				Table: "regions",
+				Keys:  []string{"code"},
+				Inserts: []datadiff.Row{
+					{"code": "AT", "name": "Austria"},
+					{"code": "CZ", "name": "Czechia"},
+				},
+				Updates: []datadiff.RowUpdate{
+					{
+						Key:     map[string]any{"code": "US"},
+						Desired: datadiff.Row{"code": "US", "name": "USA"},
+						Live:    datadiff.Row{"code": "US", "name": "United States"},
+					},
+				},
+				Deletes: []datadiff.Row{
+					{"code": "DE", "name": "Germany"},
+					{"code": "ZZ", "name": "Zeta"},
+				},
+			},
+		},
+		{
+			name:  "no change yields empty diff",
+			table: "regions",
+			keys:  []string{"code"},
+			desired: []datadiff.Row{
+				{"code": "US", "name": "United States"},
+			},
+			live: []datadiff.Row{
+				{"code": "US", "name": "United States"},
+			},
+			want: &datadiff.DataDiff{Table: "regions", Keys: []string{"code"}},
+		},
+		{
+			name: "composite keys",
+			// composite (tenant, code); one insert, one delete, one unchanged.
+			table: "prices",
+			keys:  []string{"tenant", "code"},
+			desired: []datadiff.Row{
+				{"tenant": 1, "code": "A", "val": "x"},
+				{"tenant": 2, "code": "A", "val": "y"},
+			},
+			live: []datadiff.Row{
+				{"tenant": 1, "code": "A", "val": "x"},
+				{"tenant": 1, "code": "B", "val": "z"},
+			},
+			want: &datadiff.DataDiff{
+				Table: "prices",
+				Keys:  []string{"tenant", "code"},
+				Inserts: []datadiff.Row{
+					{"tenant": 2, "code": "A", "val": "y"},
+				},
+				Deletes: []datadiff.Row{
+					{"tenant": 1, "code": "B", "val": "z"},
+				},
+			},
+		},
+		{
+			name:  "live-only column does not trigger update",
+			table: "regions",
+			keys:  []string{"code"},
+			desired: []datadiff.Row{
+				{"code": "US", "name": "United States"},
+			},
+			// live carries an extra managed-unaware column; it must be ignored.
+			live: []datadiff.Row{
+				{"code": "US", "name": "United States", "population": int64(331)},
+			},
+			want: &datadiff.DataDiff{Table: "regions", Keys: []string{"code"}},
+		},
+		{
+			name:  "normalized values compare equal across numeric types",
+			table: "regions",
+			keys:  []string{"id"},
+			// desired id is int, live id is int64; both key match and column
+			// comparison must treat them as equal, yielding no diff.
+			desired: []datadiff.Row{
+				{"id": 1, "name": "x"},
+			},
+			live: []datadiff.Row{
+				{"id": int64(1), "name": "x"},
+			},
+			want: &datadiff.DataDiff{Table: "regions", Keys: []string{"id"}},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got, err := datadiff.Compute(tt.table, tt.keys, tt.desired, tt.live)
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestComputeErrors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		keys    []string
+		desired []datadiff.Row
+		live    []datadiff.Row
+	}{
+		{
+			name:    "empty keys",
+			keys:    nil,
+			desired: []datadiff.Row{{"code": "US"}},
+			live:    nil,
+		},
+		{
+			name:    "desired row missing key column",
+			keys:    []string{"code"},
+			desired: []datadiff.Row{{"name": "United States"}},
+			live:    nil,
+		},
+		{
+			name:    "live row missing key column",
+			keys:    []string{"code"},
+			desired: []datadiff.Row{{"code": "US"}},
+			live:    []datadiff.Row{{"name": "Germany"}},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got, err := datadiff.Compute("regions", tt.keys, tt.desired, tt.live)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(got, qt.IsNil)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of declarative reference/seed data (#663, epic #654), building on the Phase 1 managed-data model. Adds the row-level diff engine — the pure computation plus live-row introspection — that a later phase renders into reversible data migrations. Atlas keeps declarative data/data-migration generation in its Pro build; this is Ptah's free, local, embeddable path.

## What's added

- **`dbschema.ReadTableRows(ctx, conn, schema, table, columns)`** — reads a table's current rows projected onto a requested column set, with dialect-aware quoted identifiers, returning `[]map[string]any` keyed by the requested column names. Driver `[]byte` results are normalized to string; no `ORDER BY` (callers are set-oriented).
- **`migration/datadiff`** (new package, separate from `schemadiff` which stays DDL-only) — a pure, DB-free `Compute(table, keys, desired, live)` that produces `DataDiff{Inserts, Updates, Deletes}`:
  - rows matched on a collision-free composite key (length-prefixed + NUL-terminated);
  - INSERT = desired-only, DELETE = live-only, UPDATE = key in both with a differing **managed** column (columns present only in the live row never trigger an update);
  - `RowUpdate` carries both `Desired` and `Live` so a later phase can render a reversible UPDATE;
  - output sorted by key for determinism.
  - Values compare by a normalized string form (`int 1` == `int64 1`); documented as approximate across dialects (numeric scale/bool/decimal), a known follow-up.

## Refactor

The per-dialect identifier quoter is consolidated into a new leaf package `internal/sqlident` (`dbschema` cannot import `schemaclean`, which imports `dbschema`). `schemaclean` now delegates to it — a byte-for-byte behavior-preserving change that removes a duplicate.

## Scope

DML generation, `ptah.sum` integration, safety/risk gating, and the CLI are later phases. The intended composition is `goschema.LoadManagedRows` → `dbschema.ReadTableRows` → `datadiff.Compute`.

## Tests

- `datadiff.Compute` (pure, black-box): all-insert/all-delete/mixed, no-change, composite keys, live-only-column subset, int/int64 normalization, missing-key error, deterministic ordering.
- `dbschema.ReadTableRows` (black-box, SQLite): column subset, schema-qualified, int64 scan, empty table, validation errors.
- `internal/sqlident`: per-dialect quoting.

Full local verification: `go build ./...`, `go vet`, `go test -race` (targeted), full `go test ./...` (132 pkgs), golangci-lint (0), qtlint (0), teststyle, and the public-API ledger + snapshot (adds `migration/datadiff`, `ReadTableRows`).