### PR TITLE
Render reversible data migrations from a DataDiff (#663)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -645,6 +645,7 @@ type SchemaWriter interface {
 
 ## github.com/stokaro/ptah/migration/datadiff
 
+func Render(diff *DataDiff, dialect string) (up string, down string, err error)
 type DataDiff struct{ ... }
     func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error)
 type Row = map[string]any

--- a/migration/datadiff/render.go
+++ b/migration/datadiff/render.go
@@ -1,0 +1,380 @@
+package datadiff
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+// Render renders diff into a pair of SQL scripts: up applies the desired state
+// and down reverses it, so that applying up followed by down returns the table
+// to its original contents.
+//
+// Statement order in up is Inserts, then Updates, then Deletes, preserving the
+// deterministic per-key ordering of the DataDiff slices:
+//
+//   - Insert R  -> INSERT INTO <table> (<all columns, sorted>) VALUES (<literals>);
+//   - Update U  -> UPDATE <table> SET <non-key columns of U.Desired, sorted> WHERE <key columns, sorted, AND-joined>;
+//   - Delete R  -> DELETE FROM <table> WHERE <key columns, sorted, AND-joined>;
+//
+// down emits the exact inverse of every statement in fully reversed order (undo
+// Deletes first, then Updates, then Inserts, each group iterated in reverse) so
+// that up followed by down is a round-trip:
+//
+//   - the inverse of an INSERT is a DELETE keyed on the inserted row;
+//   - the inverse of an UPDATE restores the prior values captured in RowUpdate.Live;
+//   - the inverse of a DELETE re-inserts the captured live row.
+//
+// Both scripts are newline-terminated sequences of ';'-terminated statements,
+// or empty strings when diff carries no changes (a no-op is valid). Identifiers
+// are quoted for dialect via sqlident.Quote; values are rendered as
+// safely-escaped literals (see [renderLiteral]) so a string value can never
+// terminate its literal or inject SQL.
+//
+// Render returns an error for a nil diff, for a non-empty diff with no key
+// columns, for a row that is missing a key column or has no columns at all, and
+// for any value that [renderLiteral] cannot represent safely.
+//
+// # Table name
+//
+// A DataDiff carries no schema, so the table is quoted as a single identifier
+// via sqlident.Qualified(dialect, "", diff.Table). A dotted name such as
+// "app.regions" is therefore quoted whole (for PostgreSQL: "app.regions")
+// rather than as schema.table; schema-qualified managed tables are a known
+// follow-up.
+//
+// # Limitations
+//
+// The inverse of a DELETE re-inserts only the managed columns captured in the
+// live row; columns the database held but that were not read back are not
+// reconstructed. Likewise the inverse of an UPDATE restores exactly the non-key
+// columns present in RowUpdate.Live, so a forward UPDATE that introduces a value
+// for a column absent from the live row cannot be rolled back to that absence.
+// Binary blobs are out of scope for this phase: a []byte value is treated as
+// UTF-8 text (see [renderLiteral]).
+func Render(diff *DataDiff, dialect string) (up string, down string, err error) {
+	if diff == nil {
+		return "", "", errors.New("datadiff: nil diff")
+	}
+
+	if len(diff.Inserts) == 0 && len(diff.Updates) == 0 && len(diff.Deletes) == 0 {
+		return "", "", nil
+	}
+
+	if len(diff.Keys) == 0 {
+		return "", "", errors.New("datadiff: keys must be non-empty to render a non-empty diff")
+	}
+
+	table := sqlident.Qualified(dialect, "", diff.Table)
+
+	upStmts, err := renderUp(dialect, table, diff)
+	if err != nil {
+		return "", "", err
+	}
+	downStmts, err := renderDown(dialect, table, diff)
+	if err != nil {
+		return "", "", err
+	}
+	return joinStatements(upStmts), joinStatements(downStmts), nil
+}
+
+// renderUp builds the forward statements in Inserts, Updates, Deletes order.
+func renderUp(dialect, table string, diff *DataDiff) ([]string, error) {
+	stmts := make([]string, 0, len(diff.Inserts)+len(diff.Updates)+len(diff.Deletes))
+	for _, row := range diff.Inserts {
+		s, err := insertStmt(dialect, table, row)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	for _, u := range diff.Updates {
+		s, err := updateStmt(dialect, table, diff.Keys, u.Desired, u.Key)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	for _, row := range diff.Deletes {
+		s, err := deleteStmt(dialect, table, diff.Keys, row)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	return stmts, nil
+}
+
+// renderDown builds the inverse statements in fully reversed order: the inverse
+// of each Delete (re-insert), then of each Update (restore Live), then of each
+// Insert (delete), with every group iterated back to front.
+func renderDown(dialect, table string, diff *DataDiff) ([]string, error) {
+	stmts := make([]string, 0, len(diff.Inserts)+len(diff.Updates)+len(diff.Deletes))
+	for _, row := range slices.Backward(diff.Deletes) {
+		s, err := insertStmt(dialect, table, row)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	for _, u := range slices.Backward(diff.Updates) {
+		s, err := updateStmt(dialect, table, diff.Keys, u.Live, u.Key)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	for _, row := range slices.Backward(diff.Inserts) {
+		s, err := deleteStmt(dialect, table, diff.Keys, row)
+		if err != nil {
+			return nil, err
+		}
+		stmts = append(stmts, s)
+	}
+	return stmts, nil
+}
+
+// insertStmt renders an INSERT for every column of row, columns sorted so the
+// output is deterministic. A row with no columns is an error.
+func insertStmt(dialect, table string, row Row) (string, error) {
+	cols := sortedColumns(row)
+	if len(cols) == 0 {
+		return "", errors.New("datadiff: cannot render INSERT for a row with no columns")
+	}
+	quotedCols := make([]string, len(cols))
+	literals := make([]string, len(cols))
+	for i, col := range cols {
+		lit, err := renderLiteral(dialect, row[col])
+		if err != nil {
+			return "", fmt.Errorf("datadiff: column %q: %w", col, err)
+		}
+		quotedCols[i] = sqlident.Quote(dialect, col)
+		literals[i] = lit
+	}
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s);",
+		table, strings.Join(quotedCols, ", "), strings.Join(literals, ", "),
+	), nil
+}
+
+// updateStmt renders an UPDATE that sets the non-key columns of setRow (sorted)
+// and matches rows on the key columns, whose values are taken from keyRow. Key
+// columns are skipped in the SET clause. An empty setRow, a setRow with no
+// non-key columns, or a keyRow missing a key column is an error.
+func updateStmt(dialect, table string, keys []string, setRow, keyRow Row) (string, error) {
+	if len(setRow) == 0 {
+		return "", errors.New("datadiff: cannot render UPDATE for a row with no columns")
+	}
+
+	keySet := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		keySet[k] = struct{}{}
+	}
+
+	setCols := make([]string, 0, len(setRow))
+	for col := range setRow {
+		if _, isKey := keySet[col]; !isKey {
+			setCols = append(setCols, col)
+		}
+	}
+	if len(setCols) == 0 {
+		return "", errors.New("datadiff: cannot render UPDATE with no non-key columns to set")
+	}
+	slices.Sort(setCols)
+
+	assignments := make([]string, len(setCols))
+	for i, col := range setCols {
+		lit, err := renderLiteral(dialect, setRow[col])
+		if err != nil {
+			return "", fmt.Errorf("datadiff: column %q: %w", col, err)
+		}
+		assignments[i] = sqlident.Quote(dialect, col) + " = " + lit
+	}
+
+	where, err := keyPredicate(dialect, keys, keyRow)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("UPDATE %s SET %s WHERE %s;", table, strings.Join(assignments, ", "), where), nil
+}
+
+// deleteStmt renders a DELETE that matches rows on the key columns, whose values
+// are taken from row.
+func deleteStmt(dialect, table string, keys []string, row Row) (string, error) {
+	where, err := keyPredicate(dialect, keys, row)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("DELETE FROM %s WHERE %s;", table, where), nil
+}
+
+// keyPredicate builds a "<key> = <literal>" predicate for every key column,
+// sorted and joined with AND. Values are taken from values; a missing key column
+// is an error.
+func keyPredicate(dialect string, keys []string, values Row) (string, error) {
+	sorted := slices.Clone(keys)
+	slices.Sort(sorted)
+	parts := make([]string, len(sorted))
+	for i, k := range sorted {
+		v, ok := values[k]
+		if !ok {
+			return "", fmt.Errorf("datadiff: missing key column %q", k)
+		}
+		lit, err := renderLiteral(dialect, v)
+		if err != nil {
+			return "", fmt.Errorf("datadiff: key column %q: %w", k, err)
+		}
+		parts[i] = sqlident.Quote(dialect, k) + " = " + lit
+	}
+	return strings.Join(parts, " AND "), nil
+}
+
+// sortedColumns returns the column names of row in ascending order.
+func sortedColumns(row Row) []string {
+	cols := make([]string, 0, len(row))
+	for col := range row {
+		cols = append(cols, col)
+	}
+	slices.Sort(cols)
+	return cols
+}
+
+// joinStatements joins statements with newlines and appends a trailing newline,
+// or returns the empty string for no statements.
+func joinStatements(stmts []string) string {
+	if len(stmts) == 0 {
+		return ""
+	}
+	return strings.Join(stmts, "\n") + "\n"
+}
+
+// renderLiteral renders v as a SQL value literal that is safe to embed directly
+// in a statement for dialect. It is the security-sensitive core of the renderer:
+// a string value can never terminate its literal or inject SQL.
+//
+// Mapping:
+//
+//   - nil            -> NULL
+//   - bool           -> TRUE/FALSE, except 1/0 for MySQL, MariaDB, ClickHouse,
+//     and SQL Server (see [usesNumericBool])
+//   - signed ints    -> decimal digits
+//   - unsigned ints  -> decimal digits
+//   - float32/float64 -> strconv.FormatFloat(f, 'g', -1, bitSize); NaN and
+//     infinities are rejected as they have no SQL literal
+//   - string, []byte -> a single-quoted literal (see below)
+//
+// Any other Go type is rejected with an error naming the type rather than being
+// formatted into SQL, which would be an injection risk. A []byte is treated as
+// UTF-8 text and escaped like a string; binary blob encoding is out of scope.
+//
+// # String escaping (per dialect)
+//
+// The single quote is always doubled (” ) per the SQL standard. For MySQL,
+// MariaDB, and ClickHouse the backslash is ALSO escaped (\ -> \\) because those
+// dialects process C-style backslash escapes inside string literals by default;
+// for the PostgreSQL family, SQLite, SQL Server, and any unrecognized dialect
+// the backslash is left untouched, as standard SQL treats it literally. A string
+// containing a NUL byte is rejected because it is not portably representable as a
+// SQL literal.
+func renderLiteral(dialect string, v any) (string, error) {
+	switch val := v.(type) {
+	case nil:
+		return "NULL", nil
+	case bool:
+		if usesNumericBool(dialect) {
+			if val {
+				return "1", nil
+			}
+			return "0", nil
+		}
+		if val {
+			return "TRUE", nil
+		}
+		return "FALSE", nil
+	case string:
+		return stringLiteral(dialect, val)
+	case []byte:
+		return stringLiteral(dialect, string(val))
+	case int:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int8:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int64:
+		return strconv.FormatInt(val, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint64:
+		return strconv.FormatUint(val, 10), nil
+	case float32:
+		return floatLiteral(float64(val), 32)
+	case float64:
+		return floatLiteral(val, 64)
+	default:
+		return "", fmt.Errorf("datadiff: unsupported value type %T for SQL literal", v)
+	}
+}
+
+// floatLiteral renders f using the shortest representation that round-trips at
+// bitSize (32 for float32, 64 for float64). NaN and infinities have no SQL
+// literal and are rejected.
+func floatLiteral(f float64, bitSize int) (string, error) {
+	if math.IsNaN(f) {
+		return "", errors.New("datadiff: NaN has no SQL literal representation")
+	}
+	if math.IsInf(f, 0) {
+		return "", errors.New("datadiff: infinity has no SQL literal representation")
+	}
+	return strconv.FormatFloat(f, 'g', -1, bitSize), nil
+}
+
+// stringLiteral renders s as a single-quoted SQL literal, escaping per the rules
+// documented on [renderLiteral].
+func stringLiteral(dialect, s string) (string, error) {
+	if strings.IndexByte(s, 0) >= 0 {
+		return "", errors.New("datadiff: string value contains a NUL byte, which has no portable SQL literal representation")
+	}
+	if usesBackslashEscapes(dialect) {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+	}
+	s = strings.ReplaceAll(s, "'", "''")
+	return "'" + s + "'", nil
+}
+
+// usesBackslashEscapes reports whether dialect processes C-style backslash
+// escapes inside string literals by default, requiring backslashes to be
+// doubled.
+func usesBackslashEscapes(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		return true
+	default:
+		return false
+	}
+}
+
+// usesNumericBool reports whether dialect spells boolean literals as 1/0 rather
+// than TRUE/FALSE.
+func usesNumericBool(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse, platform.SQLServer:
+		return true
+	default:
+		return false
+	}
+}

--- a/migration/datadiff/render_test.go
+++ b/migration/datadiff/render_test.go
@@ -6,8 +6,47 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/migration/datadiff"
 )
+
+// TestRender_SplitterRoundTrip proves the renderer and ptah's own dialect-aware
+// statement splitter agree: a rendered statement whose value embeds quotes,
+// backslashes, and semicolons stays exactly one statement when re-split, so a
+// hostile value cannot leak an extra executed statement into a migration.
+func TestRender_SplitterRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		value   string
+	}{
+		{name: "postgres backslash-quote payload", dialect: "postgres", value: `\'; DROP TABLE regions; --`},
+		{name: "postgres quote payload", dialect: "postgres", value: `'); DROP TABLE regions; --`},
+		{name: "sqlite backslash-quote payload", dialect: "sqlite", value: `\'; DROP TABLE regions; --`},
+		{name: "mysql backslash-quote payload", dialect: "mysql", value: `\'; DROP TABLE regions; --`},
+	}
+
+	c := qt.New(t)
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			diff := &datadiff.DataDiff{
+				Table: "regions",
+				Keys:  []string{"code"},
+				Updates: []datadiff.RowUpdate{{
+					Key:     map[string]any{"code": "US"},
+					Desired: datadiff.Row{"code": "US", "name": tt.value},
+					Live:    datadiff.Row{"code": "US", "name": "United States"},
+				}},
+			}
+			up, down, err := datadiff.Render(diff, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			// Each script is a single UPDATE; re-splitting must not free the
+			// embedded "; DROP TABLE ..." into its own statement.
+			c.Assert(sqlutil.SplitSQLStatementsForDialect(up, tt.dialect), qt.HasLen, 1)
+			c.Assert(sqlutil.SplitSQLStatementsForDialect(down, tt.dialect), qt.HasLen, 1)
+		})
+	}
+}
 
 // TestRenderShapesAndRoundTrip renders a diff carrying every kind of change and
 // asserts the exact up script and its exact inverse. down must undo every

--- a/migration/datadiff/render_test.go
+++ b/migration/datadiff/render_test.go
@@ -1,0 +1,371 @@
+package datadiff_test
+
+import (
+	"math"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/datadiff"
+)
+
+// TestRenderShapesAndRoundTrip renders a diff carrying every kind of change and
+// asserts the exact up script and its exact inverse. down must undo every
+// statement in fully reversed order: re-insert the deleted rows, restore the
+// updated rows from their Live values, then delete the inserted rows.
+func TestRenderShapesAndRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &datadiff.DataDiff{
+		Table: "regions",
+		Keys:  []string{"code"},
+		Inserts: []datadiff.Row{
+			{"code": "AT", "name": "Austria"},
+			{"code": "CZ", "name": "Czechia"},
+		},
+		Updates: []datadiff.RowUpdate{
+			{
+				Key:     map[string]any{"code": "US"},
+				Desired: datadiff.Row{"code": "US", "name": "USA"},
+				Live:    datadiff.Row{"code": "US", "name": "United States"},
+			},
+		},
+		Deletes: []datadiff.Row{
+			{"code": "DE", "name": "Germany"},
+			{"code": "ZZ", "name": "Zeta"},
+		},
+	}
+
+	wantUp := `INSERT INTO "regions" ("code", "name") VALUES ('AT', 'Austria');
+INSERT INTO "regions" ("code", "name") VALUES ('CZ', 'Czechia');
+UPDATE "regions" SET "name" = 'USA' WHERE "code" = 'US';
+DELETE FROM "regions" WHERE "code" = 'DE';
+DELETE FROM "regions" WHERE "code" = 'ZZ';
+`
+
+	wantDown := `INSERT INTO "regions" ("code", "name") VALUES ('ZZ', 'Zeta');
+INSERT INTO "regions" ("code", "name") VALUES ('DE', 'Germany');
+UPDATE "regions" SET "name" = 'United States' WHERE "code" = 'US';
+DELETE FROM "regions" WHERE "code" = 'CZ';
+DELETE FROM "regions" WHERE "code" = 'AT';
+`
+
+	up, down, err := datadiff.Render(diff, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, wantUp)
+	c.Assert(down, qt.Equals, wantDown)
+}
+
+// TestRenderCompositeKeys checks that a composite key produces an AND-joined,
+// key-sorted WHERE clause in both DELETE and UPDATE, and that the UPDATE SET
+// clause omits the key columns.
+func TestRenderCompositeKeys(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &datadiff.DataDiff{
+		Table: "prices",
+		Keys:  []string{"tenant", "code"},
+		Updates: []datadiff.RowUpdate{
+			{
+				Key:     map[string]any{"tenant": 1, "code": "A"},
+				Desired: datadiff.Row{"tenant": 1, "code": "A", "val": "x"},
+				Live:    datadiff.Row{"tenant": 1, "code": "A", "val": "old"},
+			},
+		},
+		Deletes: []datadiff.Row{
+			{"tenant": 2, "code": "B", "val": "z"},
+		},
+	}
+
+	wantUp := `UPDATE "prices" SET "val" = 'x' WHERE "code" = 'A' AND "tenant" = 1;
+DELETE FROM "prices" WHERE "code" = 'B' AND "tenant" = 2;
+`
+	wantDown := `INSERT INTO "prices" ("code", "tenant", "val") VALUES ('B', 2, 'z');
+UPDATE "prices" SET "val" = 'old' WHERE "code" = 'A' AND "tenant" = 1;
+`
+
+	up, down, err := datadiff.Render(diff, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, wantUp)
+	c.Assert(down, qt.Equals, wantDown)
+}
+
+// TestRenderEmptyDiff confirms a no-op diff renders to two empty scripts rather
+// than an error.
+func TestRenderEmptyDiff(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		diff *datadiff.DataDiff
+	}{
+		{
+			name: "no changes with keys",
+			diff: &datadiff.DataDiff{Table: "regions", Keys: []string{"code"}},
+		},
+		{
+			name: "no changes and no keys",
+			diff: &datadiff.DataDiff{Table: "regions"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			up, down, err := datadiff.Render(tt.diff, "postgres")
+			c.Assert(err, qt.IsNil)
+			c.Assert(up, qt.Equals, "")
+			c.Assert(down, qt.Equals, "")
+		})
+	}
+}
+
+// TestRenderLiterals exercises renderLiteral through a single-row INSERT. Each
+// row has a clean string key ("id") plus one value column ("v") under test, so
+// the asserted up script pins down the exact literal produced for each value
+// kind and dialect.
+func TestRenderLiterals(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		value   any
+		wantUp  string
+	}{
+		{
+			name:    "string",
+			dialect: "postgres",
+			value:   "United States",
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 'United States');\n",
+		},
+		{
+			name:    "string with single quote is doubled",
+			dialect: "postgres",
+			value:   "O'Brien",
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 'O''Brien');\n",
+		},
+		{
+			name:    "nil renders NULL",
+			dialect: "postgres",
+			value:   nil,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', NULL);\n",
+		},
+		{
+			name:    "bool true postgres is TRUE",
+			dialect: "postgres",
+			value:   true,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', TRUE);\n",
+		},
+		{
+			name:    "bool false postgres is FALSE",
+			dialect: "postgres",
+			value:   false,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', FALSE);\n",
+		},
+		{
+			name:    "bool true mysql is 1",
+			dialect: "mysql",
+			value:   true,
+			wantUp:  "INSERT INTO `t` (`id`, `v`) VALUES ('r1', 1);\n",
+		},
+		{
+			name:    "bool false mariadb is 0",
+			dialect: "mariadb",
+			value:   false,
+			wantUp:  "INSERT INTO `t` (`id`, `v`) VALUES ('r1', 0);\n",
+		},
+		{
+			name:    "int",
+			dialect: "postgres",
+			value:   42,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 42);\n",
+		},
+		{
+			name:    "negative int64",
+			dialect: "postgres",
+			value:   int64(-7),
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', -7);\n",
+		},
+		{
+			name:    "uint64 max",
+			dialect: "postgres",
+			value:   uint64(18446744073709551615),
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 18446744073709551615);\n",
+		},
+		{
+			name:    "float64",
+			dialect: "postgres",
+			value:   1.5,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 1.5);\n",
+		},
+		{
+			name:    "float32 uses shortest 32-bit form",
+			dialect: "postgres",
+			value:   float32(0.1),
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 0.1);\n",
+		},
+		{
+			name:    "byte slice treated as text",
+			dialect: "postgres",
+			value:   []byte("hi"),
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 'hi');\n",
+		},
+		{
+			name:    "backslash not escaped for postgres",
+			dialect: "postgres",
+			value:   `a\b`,
+			wantUp:  "INSERT INTO \"t\" (\"id\", \"v\") VALUES ('r1', 'a\\b');\n",
+		},
+		{
+			name:    "backslash escaped for mysql",
+			dialect: "mysql",
+			value:   `a\b`,
+			wantUp:  "INSERT INTO `t` (`id`, `v`) VALUES ('r1', 'a\\\\b');\n",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			diff := &datadiff.DataDiff{
+				Table:   "t",
+				Keys:    []string{"id"},
+				Inserts: []datadiff.Row{{"id": "r1", "v": tt.value}},
+			}
+			up, _, err := datadiff.Render(diff, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(up, qt.Equals, tt.wantUp)
+		})
+	}
+}
+
+// TestRenderStringInjectionIsEscaped is the core security assertion: a value
+// crafted to break out of its literal is emitted as one safely-quoted literal.
+// Note that a naive "must not contain '); " check is wrong — the byte sequence
+// '); legitimately appears when an escaped quote precedes a paren. The real
+// breakout marker is an opening paren immediately followed by a quote and paren,
+// i.e. ('); which must be absent.
+func TestRenderStringInjectionIsEscaped(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &datadiff.DataDiff{
+		Table:   "users",
+		Keys:    []string{"id"},
+		Inserts: []datadiff.Row{{"id": "r1", "v": `'); DROP TABLE users;--`}},
+	}
+
+	up, _, err := datadiff.Render(diff, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals,
+		"INSERT INTO \"users\" (\"id\", \"v\") VALUES ('r1', '''); DROP TABLE users;--');\n")
+	c.Assert(up, qt.Contains, "''")
+	c.Assert(up, qt.Not(qt.Contains), "('); ")
+}
+
+// TestRenderLiteralErrors verifies that values with no safe SQL literal cause
+// Render to fail rather than emit anything, and that no partial output leaks.
+func TestRenderLiteralErrors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "nul byte in string", value: "a\x00b"},
+		{name: "nan float", value: math.NaN()},
+		{name: "positive infinity", value: math.Inf(1)},
+		{name: "negative infinity", value: math.Inf(-1)},
+		{name: "unsupported struct type", value: struct{ X int }{X: 1}},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			diff := &datadiff.DataDiff{
+				Table:   "t",
+				Keys:    []string{"id"},
+				Inserts: []datadiff.Row{{"id": "r1", "v": tt.value}},
+			}
+			up, down, err := datadiff.Render(diff, "postgres")
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(up, qt.Equals, "")
+			c.Assert(down, qt.Equals, "")
+		})
+	}
+}
+
+// TestRenderErrors covers the structural validation failures: a nil diff, a
+// non-empty diff without key columns, rows missing a key column (including an
+// insert whose down statement cannot target it), and updates with nothing to
+// set.
+func TestRenderErrors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		diff *datadiff.DataDiff
+	}{
+		{
+			name: "nil diff",
+			diff: nil,
+		},
+		{
+			name: "non-empty diff without keys",
+			diff: &datadiff.DataDiff{
+				Table:   "t",
+				Inserts: []datadiff.Row{{"code": "US"}},
+			},
+		},
+		{
+			name: "insert row with no columns",
+			diff: &datadiff.DataDiff{
+				Table:   "t",
+				Keys:    []string{"code"},
+				Inserts: []datadiff.Row{{}},
+			},
+		},
+		{
+			name: "insert row missing key column cannot be reversed",
+			diff: &datadiff.DataDiff{
+				Table:   "t",
+				Keys:    []string{"code"},
+				Inserts: []datadiff.Row{{"name": "United States"}},
+			},
+		},
+		{
+			name: "delete row missing key column",
+			diff: &datadiff.DataDiff{
+				Table:   "t",
+				Keys:    []string{"code"},
+				Deletes: []datadiff.Row{{"name": "Germany"}},
+			},
+		},
+		{
+			name: "update with empty desired row",
+			diff: &datadiff.DataDiff{
+				Table: "t",
+				Keys:  []string{"code"},
+				Updates: []datadiff.RowUpdate{
+					{Key: map[string]any{"code": "US"}, Desired: datadiff.Row{}, Live: datadiff.Row{"code": "US", "name": "x"}},
+				},
+			},
+		},
+		{
+			name: "update with only key columns has nothing to set",
+			diff: &datadiff.DataDiff{
+				Table: "t",
+				Keys:  []string{"code"},
+				Updates: []datadiff.RowUpdate{
+					{Key: map[string]any{"code": "US"}, Desired: datadiff.Row{"code": "US"}, Live: datadiff.Row{"code": "US", "name": "x"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			up, down, err := datadiff.Render(tt.diff, "postgres")
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(up, qt.Equals, "")
+			c.Assert(down, qt.Equals, "")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 (renderer) of declarative reference/seed data (#663, epic #654). Turns a `datadiff.DataDiff` into a reversible pair of SQL scripts — the data-migration generation core that a later phase writes to migration files and wires into apply.

`datadiff.Render(diff, dialect) (up, down string, err error)`:

- **up** (apply desired state): `INSERT` new rows, `UPDATE` changed non-key columns, `DELETE` removed rows — in that order, preserving the diff's deterministic per-key sort.
- **down** (exact inverse, fully reversed order): re-insert deleted rows, restore prior values from `RowUpdate.Live`, delete inserted rows — so up-then-down round-trips the table.

## Security: value-literal escaping

Data migrations are static SQL text, so row values are inlined — an injection surface. `renderLiteral` handles it carefully:

- `nil` → `NULL`; dialect-correct booleans (`TRUE`/`FALSE`, or `1`/`0` for MySQL/MariaDB/ClickHouse/SQL Server); integer and shortest-round-trip float literals (NaN/±Inf rejected).
- Strings: single-quoted with the quote doubled, **plus backslash doubling for MySQL/MariaDB/ClickHouse** (which process C-style backslash escapes by default, where a lone `\'` is an alternate quote-escape → a breakout vector); PostgreSQL/SQLite leave backslashes literal (standard SQL). NUL bytes are rejected.
- Unsupported Go types are **rejected with an error**, never `%v`-formatted into SQL.

Identifiers are quoted per dialect via `internal/sqlident`.

## Scope

Pure renderer only. Writing data-migration artifacts, `ptah.sum` integration, safety/risk gating, and the CLI are later phases. Documented limitations (follow-ups): schema-qualified table names; `[]byte` binary blobs (treated as text); temporal/decimal types (currently error rather than risk unsafe output — the "cross-dialect value rendering is substantial" caveat).

## Tests

Black-box, thorough: statement shapes + exact-inverse down in reversed order; composite-key AND-joined sorted WHERE; escaping (`O'Brien` → `'O''Brien'`; a `'); DROP TABLE users;--` payload renders as one safe literal; MySQL vs PostgreSQL backslash handling; nil→NULL; per-dialect bool); error cases (NUL, NaN, ±Inf, unsupported struct); and structural errors (nil diff, no keys, zero-column/missing-key rows, keys-only update). Empty diff → `("", "")`.

Full local verification: `go build ./...`, `go vet`, `go test -race`, full `go test ./...` (132 pkgs), golangci-lint (0), qtlint (0), teststyle, and the public-API ledger + snapshot (adds `Render`).