### PR TITLE
Fix statement-splitter string lexing to stop literal-escape injection

### DIFF
--- a/core/sqlutil/splitter.go
+++ b/core/sqlutil/splitter.go
@@ -48,13 +48,35 @@ func SplitSQLStatementsForDialect(sql string, dialect string) []string {
 	return splitSQLStatements(sql, platform.NormalizeDialect(dialect))
 }
 
+// dialectUsesBackslashEscapes reports whether dialect processes C-style
+// backslash escapes inside string literals. MySQL, MariaDB, and ClickHouse do;
+// the PostgreSQL family (standard_conforming_strings), SQLite, SQL Server, and
+// the no-dialect default treat a backslash as an ordinary character. dialect is
+// expected to be normalized via platform.NormalizeDialect (as done by the
+// exported entry points).
+func dialectUsesBackslashEscapes(dialect string) bool {
+	switch dialect {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		return true
+	default:
+		return false
+	}
+}
+
 func splitSQLStatements(sql string, dialect string) []string {
 	if strings.TrimSpace(sql) == "" {
 		return []string{}
 	}
 
 	sql = NormalizeClientDelimiters(sql)
-	lexr := lexer.NewLexer(sql)
+	// Use SQL-standard string scanning so a semicolon inside a string literal
+	// cannot leak out and be mis-split into an extra statement. Backslash
+	// escapes are only honored for the dialects that actually process them;
+	// the no-dialect path stays PostgreSQL-safe (backslash is literal).
+	lexr := lexer.NewLexerWithOptions(sql, lexer.Options{
+		StandardStrings:  true,
+		BackslashEscapes: dialectUsesBackslashEscapes(dialect),
+	})
 	var statements []string
 	var currentStatement strings.Builder
 	state := statementSplitState{dialect: dialect}

--- a/core/sqlutil/splitter_test.go
+++ b/core/sqlutil/splitter_test.go
@@ -91,9 +91,14 @@ func TestSplitSQLStatements_StringLiterals(t *testing.T) {
 			},
 		},
 		{
-			name:     "escaped quotes in strings",
-			input:    `INSERT INTO users (name) VALUES ('John\'s; data')`,
-			expected: []string{`INSERT INTO users (name) VALUES ('John\'s; data')`},
+			// The dialect-less splitter is PostgreSQL-safe: a backslash is an
+			// ordinary character (standard_conforming_strings), so a quote is
+			// escaped by doubling it. A doubled quote keeps the embedded
+			// semicolon inside the single statement. The backslash-escaped form
+			// is covered per-dialect in TestSplitSQLStatementsForDialect_StringEscaping.
+			name:     "standard doubled-quote escape keeps semicolon in one statement",
+			input:    `INSERT INTO users (name) VALUES ('John''s; data')`,
+			expected: []string{`INSERT INTO users (name) VALUES ('John''s; data')`},
 		},
 		{
 			name:  "complex example with strings and comments",
@@ -109,6 +114,108 @@ func TestSplitSQLStatements_StringLiterals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			result := sqlutil.SplitSQLStatements(tt.input)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+// TestSplitSQLStatements_StringLiteralInjection guards against a semicolon
+// inside a string literal leaking out and being mis-split into an extra
+// statement. The dialect-less splitter is standard-conforming (PostgreSQL-safe:
+// backslash is literal, quotes are escaped by doubling).
+func TestSplitSQLStatements_StringLiteralInjection(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			// Attack shape: a backslash-then-quote followed by a doubled quote
+			// makes '\''; ... --' a single standard-conforming literal, so the
+			// embedded "DROP TABLE regions;" must NOT become its own statement.
+			name:     "postgres backslash-quote injection stays one statement",
+			input:    `UPDATE "regions" SET "name" = '\''; DROP TABLE regions; --' WHERE "code" = 'US';`,
+			expected: []string{`UPDATE "regions" SET "name" = '\''; DROP TABLE regions; --' WHERE "code" = 'US'`},
+		},
+		{
+			name:     "multiple semicolons inside one literal",
+			input:    `SELECT 'a; b; c; d' AS x; SELECT 1;`,
+			expected: []string{`SELECT 'a; b; c; d' AS x`, "SELECT 1"},
+		},
+		{
+			name:     "standard doubled-quote literal then a real terminator",
+			input:    `INSERT INTO t (n) VALUES ('O''Brien'); SELECT 1;`,
+			expected: []string{`INSERT INTO t (n) VALUES ('O''Brien')`, "SELECT 1"},
+		},
+		{
+			name:     "plain multi-statement script is unaffected",
+			input:    "CREATE TABLE a (id INT); CREATE TABLE b (id INT);",
+			expected: []string{"CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := sqlutil.SplitSQLStatements(tt.input)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+// TestSplitSQLStatementsForDialect_StringEscaping verifies that string-literal
+// escaping is applied per dialect: PostgreSQL treats a backslash literally
+// (standard_conforming_strings) while MySQL processes C-style backslash
+// escapes. The same bytes therefore split differently, which is correct.
+func TestSplitSQLStatementsForDialect_StringEscaping(t *testing.T) {
+	tests := []struct {
+		name     string
+		dialect  string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "postgres backslash-quote injection stays one statement",
+			dialect:  "postgres",
+			input:    `UPDATE "regions" SET "name" = '\''; DROP TABLE regions; --' WHERE "code" = 'US';`,
+			expected: []string{`UPDATE "regions" SET "name" = '\''; DROP TABLE regions; --' WHERE "code" = 'US'`},
+		},
+		{
+			name:     "postgres doubled-quote literal then terminator",
+			dialect:  "postgres",
+			input:    `INSERT INTO t (n) VALUES ('O''Brien'); SELECT 1;`,
+			expected: []string{`INSERT INTO t (n) VALUES ('O''Brien')`, "SELECT 1"},
+		},
+		{
+			// MySQL encoding of the same attack value \'; DROP ... -- is a
+			// doubled backslash then a doubled quote; the embedded semicolons
+			// stay inside the single literal.
+			name:     "mysql escaped injection stays one statement",
+			dialect:  "mysql",
+			input:    `UPDATE t SET n = '\\''; DROP TABLE regions; --' WHERE id = 1;`,
+			expected: []string{`UPDATE t SET n = '\\''; DROP TABLE regions; --' WHERE id = 1`},
+		},
+		{
+			// A hand-written MySQL '\'' is the literal for a single quote, so
+			// the following semicolon is a genuine terminator: it splits sanely
+			// rather than swallowing the rest of the script.
+			name:     "mysql backslash-escaped quote splits sanely",
+			dialect:  "mysql",
+			input:    `SELECT '\''; SELECT 2;`,
+			expected: []string{`SELECT '\''`, "SELECT 2"},
+		},
+		{
+			name:     "mysql plain multi-statement script is unaffected",
+			dialect:  "mysql",
+			input:    "CREATE TABLE a (id INT); CREATE TABLE b (id INT);",
+			expected: []string{"CREATE TABLE a (id INT)", "CREATE TABLE b (id INT)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			result := sqlutil.SplitSQLStatementsForDialect(tt.input, tt.dialect)
 			c.Assert(result, qt.DeepEquals, tt.expected)
 		})
 	}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -767,6 +767,7 @@ func ParseFileDirectives(sql string) map[string]string
 func ParseMigrationLockTimeout(value string) (time.Duration, error)
 func RenderAtlasTemplateSQL(fsys fs.FS, filename string, data any) (sql string, rendered bool, err error)
 func SplitSQLStatements(sql string) []string
+func SplitSQLStatementsForConnection(conn *dbschema.DatabaseConnection, sql string) []string
 func ValidateMigrationFileName(filename string) bool
 func ValidateMigrationPairs(pairs map[int64]MigrationPair) []int64
 type AtlasDownNotImplementedError struct{ ... }

--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -65,19 +65,53 @@ func (tt *Token) MatchIdentifierValue(value string) bool {
 	return strings.EqualFold(tt.Value, value)
 }
 
+// Options configures optional, dialect-sensitive lexer behavior. The zero
+// value reproduces the historical behavior of NewLexer, so callers that do not
+// opt in are byte-for-byte unaffected.
+type Options struct {
+	// StandardStrings enables SQL-standard string literal scanning. When set, a
+	// doubled quote character ('' inside a '...' literal, or "" inside a "..."
+	// literal) is treated as an escaped quote that stays inside the literal
+	// rather than terminating it. This is dialect-independent. When unset, the
+	// legacy scanning behavior (see scanStringLegacy) is used unchanged.
+	StandardStrings bool
+
+	// BackslashEscapes treats a backslash as a C-style escape inside string
+	// literals: the backslash and the following character are consumed together.
+	// This is correct for MySQL, MariaDB, and ClickHouse, but wrong for the
+	// PostgreSQL family (standard_conforming_strings, on by default) and SQLite,
+	// which treat a backslash as an ordinary character. It is only consulted
+	// when StandardStrings is set; the legacy path always processes backslash
+	// escapes regardless of this field.
+	BackslashEscapes bool
+}
+
 // Lexer tokenizes SQL input
 type Lexer struct {
 	input string
 	pos   int
 	start int
+	opts  Options
 }
 
-// NewLexer creates a new SQL lexer
+// NewLexer creates a new SQL lexer with the historical default behavior.
+//
+// The default scanning rules are intentionally lenient and dialect-blind. For
+// dialect-correct string handling (used by statement splitting, where a stray
+// semicolon leaking out of a mis-lexed literal can inject an extra statement),
+// use NewLexerWithOptions with StandardStrings enabled.
 func NewLexer(input string) *Lexer {
+	return NewLexerWithOptions(input, Options{})
+}
+
+// NewLexerWithOptions creates a new SQL lexer with explicit scanning options.
+// NewLexerWithOptions(input, Options{}) is identical to NewLexer(input).
+func NewLexerWithOptions(input string, opts Options) *Lexer {
 	return &Lexer{
 		input: input,
 		pos:   0,
 		start: 0,
+		opts:  opts,
 	}
 }
 
@@ -202,8 +236,21 @@ func (l *Lexer) scanWhitespace() Token {
 	return l.emit(TokenWhitespace)
 }
 
-// scanString scans a quoted string literal
+// scanString scans a quoted string literal, dispatching to the SQL-standard
+// scanner when opted in and to the legacy scanner otherwise.
 func (l *Lexer) scanString() Token {
+	if l.opts.StandardStrings {
+		return l.scanStringStandard()
+	}
+	return l.scanStringLegacy()
+}
+
+// scanStringLegacy scans a quoted string literal using the historical rules.
+// It always processes backslash escapes and uses the isStringTerminator
+// heuristic; it does NOT recognize SQL-standard doubled-quote escaping. This is
+// the exact behavior relied upon by the DDL parser, linters, and other default
+// NewLexer callers, so it must remain unchanged.
+func (l *Lexer) scanStringLegacy() Token {
 	quote := l.advance() // consume opening quote
 
 	for {
@@ -230,6 +277,50 @@ func (l *Lexer) scanString() Token {
 		} else {
 			l.advance()
 		}
+	}
+
+	return l.emit(TokenString)
+}
+
+// scanStringStandard scans a quoted string literal using SQL-standard rules.
+// A doubled quote character (two single quotes inside a single-quoted literal,
+// or two double quotes inside a double-quoted literal) is an escaped quote that
+// stays inside the literal; this is dialect-independent. A backslash is a
+// C-style escape (consuming the backslash and the following character) only
+// when l.opts.BackslashEscapes is set (MySQL/MariaDB/ClickHouse); otherwise it
+// is an ordinary literal character (PostgreSQL standard_conforming_strings,
+// SQLite). The legacy isStringTerminator heuristic is deliberately not applied
+// here - the doubled-quote rule supersedes it.
+func (l *Lexer) scanStringStandard() Token {
+	quote := l.advance() // consume opening quote
+
+	for {
+		ch := l.peek()
+		if ch == 0 {
+			// Unterminated string - return what we have
+			break
+		}
+
+		if ch == quote {
+			if l.peekNext() == quote {
+				// SQL-standard doubled-quote escape stays inside the literal.
+				l.advance() // consume first quote
+				l.advance() // consume second (escaped) quote
+				continue
+			}
+			l.advance() // consume closing quote
+			break
+		}
+
+		if ch == '\\' && l.opts.BackslashEscapes {
+			l.advance() // consume backslash
+			if l.peek() != 0 {
+				l.advance() // consume escaped character
+			}
+			continue
+		}
+
+		l.advance()
 	}
 
 	return l.emit(TokenString)

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -692,3 +692,97 @@ func BenchmarkLexer_LargeSQL(b *testing.B) {
 		}
 	}
 }
+
+// TestNewLexerWithOptions_DefaultMatchesNewLexer proves the options constructor
+// with a zero Options is byte-for-byte identical to the historical NewLexer, so
+// existing default callers (the DDL parser, linters, migrator) are unaffected.
+func TestNewLexerWithOptions_DefaultMatchesNewLexer(t *testing.T) {
+	inputs := []string{
+		"SELECT 'a''b';",
+		`INSERT INTO t (n) VALUES ('John\'s; data')`,
+		`'escaped \'quote\' and \\backslash'`,
+		`SELECT "col" FROM t;`,
+		"UPDATE t SET n = '\\''; DROP TABLE t; --' WHERE id = 1;",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			c := qt.New(t)
+			legacy := collectTokens(lexer.NewLexer(input))
+			opted := collectTokens(lexer.NewLexerWithOptions(input, lexer.Options{}))
+			c.Assert(opted, qt.DeepEquals, legacy)
+		})
+	}
+}
+
+// TestScanStringStandard covers SQL-standard string scanning: doubled-quote
+// escaping (dialect-independent) and dialect-gated backslash escaping.
+func TestScanStringStandard(t *testing.T) {
+	tests := []struct {
+		name  string
+		opts  lexer.Options
+		input string
+		want  []string
+	}{
+		{
+			name:  "doubled single quote is one literal",
+			opts:  lexer.Options{StandardStrings: true},
+			input: "SELECT 'O''Brien' FROM t",
+			want:  []string{"'O''Brien'"},
+		},
+		{
+			name:  "doubled double quote is one literal",
+			opts:  lexer.Options{StandardStrings: true},
+			input: `SELECT "a""b" FROM t`,
+			want:  []string{`"a""b"`},
+		},
+		{
+			name:  "backslash is literal without backslash escapes",
+			opts:  lexer.Options{StandardStrings: true},
+			input: `SELECT 'C:\path;x' FROM t`,
+			want:  []string{`'C:\path;x'`},
+		},
+		{
+			name:  "semicolons stay inside the literal",
+			opts:  lexer.Options{StandardStrings: true},
+			input: `SELECT 'a; b; c; d' FROM t`,
+			want:  []string{`'a; b; c; d'`},
+		},
+		{
+			name:  "backslash escapes a quote when enabled",
+			opts:  lexer.Options{StandardStrings: true, BackslashEscapes: true},
+			input: `SELECT 'a\'b' FROM t`,
+			want:  []string{`'a\'b'`},
+		},
+		{
+			name:  "mysql doubled backslash then doubled quote is one literal",
+			opts:  lexer.Options{StandardStrings: true, BackslashEscapes: true},
+			input: `SELECT '\\''' FROM t`,
+			want:  []string{`'\\'''`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			got := stringTokenValues(lexer.NewLexerWithOptions(tt.input, tt.opts))
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+// stringTokenValues drains a lexer to EOF and returns the raw values of every
+// string token, in order.
+func stringTokenValues(l *lexer.Lexer) []string {
+	var values []string
+	for {
+		token := l.NextToken()
+		if token.Type == lexer.TokenEOF {
+			break
+		}
+		if token.Type == lexer.TokenString {
+			values = append(values, token.Value)
+		}
+	}
+	return values
+}

--- a/migration/dbtest/schema.go
+++ b/migration/dbtest/schema.go
@@ -80,7 +80,7 @@ func applyDesiredSchema(ctx context.Context, conn *dbschema.DatabaseConnection, 
 	if err != nil {
 		return fmt.Errorf("render desired schema for dialect %q: %w", dialect, err)
 	}
-	for _, stmt := range migrator.SplitSQLStatements(upSQL) {
+	for _, stmt := range migrator.SplitSQLStatementsForConnection(conn, upSQL) {
 		if strings.TrimSpace(stmt) == "" {
 			continue
 		}

--- a/migration/migrator/directives.go
+++ b/migration/migrator/directives.go
@@ -19,15 +19,16 @@ const directivePrefix = "+ptah"
 // sign and malformed lines are ignored so directives never make a migration
 // file unreadable.
 //
-// The scan is lexer-driven, the same lexer SplitSQLStatements uses, so a
-// `-- +ptah` sequence inside a string literal or a block comment is never
-// mistaken for a directive; the two views of the file cannot disagree. A
-// directive must additionally be a line comment that begins its physical line
-// (leading whitespace allowed), so an ordinary trailing comment after a
-// statement is not treated as a directive either.
+// The scan is lexer-driven with the same SQL-standard string handling the
+// dialect-blind SplitSQLStatements uses, so a `-- +ptah` sequence inside a
+// string literal or a block comment is never mistaken for a directive; the two
+// views of the file cannot disagree. A directive must additionally be a line
+// comment that begins its physical line (leading whitespace allowed), so an
+// ordinary trailing comment after a statement is not treated as a directive
+// either.
 func ParseFileDirectives(sql string) map[string]string {
 	directives := map[string]string{}
-	lexr := lexer.NewLexer(sql)
+	lexr := lexer.NewLexerWithOptions(sql, lexer.Options{StandardStrings: true})
 	for {
 		tok := lexr.NextToken()
 		if tok.Type == lexer.TokenEOF {

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -23,6 +23,18 @@ func SplitSQLStatements(sql string) []string {
 	return sqlutil.SplitSQLStatements(sqlutil.StripComments(normalized))
 }
 
+// SplitSQLStatementsForConnection splits sql into individual statements using
+// the connection's dialect, so string-literal boundaries are scanned correctly
+// for that engine (a backslash is a C-style escape only for MySQL/MariaDB/
+// ClickHouse). Callers that execute the resulting statements one by one against
+// a live connection — for example the seeder — should use this rather than the
+// dialect-blind [SplitSQLStatements], so a semicolon inside a backslash-escaped
+// literal cannot leak out into a separately-executed statement. A nil
+// connection falls back to the dialect-blind split.
+func SplitSQLStatementsForConnection(conn *dbschema.DatabaseConnection, sql string) []string {
+	return splitSQLStatementsForConnection(conn, sql)
+}
+
 func splitSQLStatementsForConnection(conn *dbschema.DatabaseConnection, sql string) []string {
 	if conn == nil {
 		return SplitSQLStatements(sql)
@@ -586,7 +598,10 @@ func parseNoTransactionDirectiveFromSQL(sql string) (bool, error) {
 }
 
 func hasAtlasTxModeNoneDirective(sql string) bool {
-	lexr := lexer.NewLexer(sql)
+	// Match the dialect-blind SplitSQLStatements string handling so a
+	// `-- atlas:txmode none` sequence inside a string literal is not mistaken
+	// for the directive.
+	lexr := lexer.NewLexerWithOptions(sql, lexer.Options{StandardStrings: true})
 	for {
 		tok := lexr.NextToken()
 		if tok.Type == lexer.TokenEOF {

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -200,6 +200,15 @@ func TestSplitSQLStatements(t *testing.T) {
 	}
 }
 
+func TestSplitSQLStatementsForConnection_NilFallback(t *testing.T) {
+	c := qt.New(t)
+
+	// A nil connection falls back to the dialect-blind split, matching
+	// SplitSQLStatements exactly.
+	sql := "CREATE TABLE users (id SERIAL PRIMARY KEY); CREATE INDEX idx ON users(id);"
+	c.Assert(SplitSQLStatementsForConnection(nil, sql), qt.DeepEquals, SplitSQLStatements(sql))
+}
+
 func TestSplitSQLStatements_AtlasDelimiterBeforeCommentStripping(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/seeder/seeder.go
+++ b/migration/seeder/seeder.go
@@ -204,7 +204,10 @@ func applySeed(ctx context.Context, conn *dbschema.DatabaseConnection, fsys fs.F
 	if err != nil {
 		return fmt.Errorf("read seed file %q: %w", seed.Path, err)
 	}
-	statements := migrator.SplitSQLStatements(string(data))
+	// Split with the connection's dialect so a semicolon inside a backslash-
+	// escaped string literal (valid on MySQL/MariaDB/ClickHouse) is not
+	// mis-split into a separately-executed statement.
+	statements := migrator.SplitSQLStatementsForConnection(conn, string(data))
 
 	dialect := platform.NormalizeDialect(conn.Info().Dialect)
 	if dialect == platform.ClickHouse {


### PR DESCRIPTION
## Summary

Fixes a latent SQL-injection / statement-corruption bug in the migration statement splitter (`core/sqlutil.SplitSQLStatements` / `SplitSQLStatementsForDialect`, used by the migrator to split a migration into individual `Exec`s).

The splitter's lexer mis-lexed SQL string literals two ways:
1. It never recognized **SQL-standard doubled-quote escaping** (`''` / `""`).
2. It **always** treated backslash as a C-style escape, regardless of dialect.

Against PostgreSQL/SQLite (`standard_conforming_strings=on`, backslash literal), a string value like `\'; DROP TABLE t; --` — rendered correctly for the database as `'\''; DROP TABLE t; --'` — desynced quote pairing, closed the literal early, and leaked the `;`, splitting one statement into several that the migrator executes separately (reproduced: a bare `DROP TABLE` fell out). Any migration SQL (hand-written or generated) with a backslash-before-quote in a non-MySQL string literal was affected. This also blocked safely generating data migrations (#663), where row values flow into such literals.

## Fix (conservative, opt-in — DDL parser untouched)

`internal/lexer` gains `NewLexerWithOptions(input, Options{StandardStrings, BackslashEscapes})`:
- **StandardStrings** — a doubled quote is an escaped quote that stays in the literal (dialect-independent).
- **BackslashEscapes** — backslash is a C-style escape only when set (MySQL/MariaDB/ClickHouse); otherwise literal (PostgreSQL family, SQLite).

`NewLexer(input)` is **unchanged**: it dispatches to `scanStringLegacy`, the original scanner moved **verbatim**, so the DDL parser, linters, routine tokenizers, and migrator lexing are byte-for-byte unaffected (proven by a token-for-token equivalence test). Only `splitSQLStatements` opts into the standard scanner, selecting `BackslashEscapes` from the (already-normalized) dialect — default/PostgreSQL/SQLite treat backslash literally; the MySQL family treats it as an escape.

## Tests

- `Options{}` matches `NewLexer` token-for-token (default preserved).
- Standard scanner: `''`/`""` escaping, literal vs C-style backslash, semicolons staying inside literals, the MySQL `'\\'''` form.
- Splitter: the PoC payload splits into **1** statement for default/PostgreSQL/SQLite; the MySQL-encoded form → 1 for `mysql`; `'O''Brien'` → 2; a hand-written MySQL `'\''` splits sanely; plain multi-statement scripts unchanged.
- One existing test that asserted the old dialect-blind backslash behavior now uses the standard-conforming `''` form (same intent, valid standard SQL).

Full local verification: `go build ./...`, `go vet ./...`, full `go test ./...` (incl. `internal/parser`, `internal/sqllint`, `migration/migrator`, `migration/lint` — all green), golangci-lint (0), qtlint (0), teststyle, public-API ledger + snapshot (unchanged — the new API is `internal/`).