### PR TITLE
Add `ptah migrations data` to generate reversible data migrations (#663)

### DIFF
--- a/cmd/migratedata/migratedata.go
+++ b/cmd/migratedata/migratedata.go
@@ -1,0 +1,205 @@
+// Package migratedata implements `ptah migrations data`, which generates an
+// ordinary migration from the drift between declarative reference/seed data
+// (//migrator:schema:data annotations) and a live database.
+package migratedata
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/datamigrate"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const (
+	rootDirFlag     = "root-dir"
+	dbURLFlag       = "db-url"
+	migrationsFlag  = "migrations-dir"
+	versionFlag     = "version"
+	descriptionFlag = "description"
+	dryRunFlag      = "dry-run"
+)
+
+type options struct {
+	rootDir        string
+	dbURL          string
+	migrationsDir  string
+	version        string
+	description    string
+	dryRun         bool
+	schemas        string
+	connectTimeout string
+}
+
+// NewMigrateDataCommand returns the `data` command.
+func NewMigrateDataCommand() *cobra.Command {
+	opts := options{}
+	cmd := &cobra.Command{
+		Use:   "data",
+		Short: "Generate a migration from declarative reference/seed data drift",
+		Long: `Generate an ordinary migration from the drift between declarative
+reference/seed data and a live database.
+
+The Go sources under --root-dir are scanned for //migrator:schema:data
+annotations. For every declared table its desired rows are loaded from the
+referenced YAML file and diffed against the live rows in --db-url, and the
+combined difference is written as an ordinary migration pair
+(NNNNNNNNNN_description.up.sql / .down.sql) with ptah.sum refreshed. The up
+body inserts, updates, and deletes rows to reach the desired state; the down
+body reverses it. When nothing has drifted, no files are written.
+
+The generated migration is meant to be reviewed before it is applied, and it is
+applied through the normal migration path, so this command performs no
+safety/risk gating of its own: destructive UPDATE/DELETE volume gating and
+protected-table guards are a deferred follow-up.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return migrateDataCommand(cmd, &opts)
+		},
+	}
+	registerFlags(cmd, &opts)
+	cmdutil.ConfigureCommand(cmd)
+	return cmd
+}
+
+func registerFlags(cmd *cobra.Command, opts *options) {
+	flags := cmd.Flags()
+	flags.StringVar(&opts.rootDir, rootDirFlag, "", "Directory of Go sources carrying //migrator:schema:data annotations (required)")
+	flags.StringVar(&opts.dbURL, dbURLFlag, "", "Live database URL to diff the desired data against (required)")
+	flags.StringVar(&opts.migrationsDir, migrationsFlag, "./migrations", "Directory the generated migration pair is written to")
+	flags.StringVar(&opts.version, versionFlag, "", "Migration version; defaults to one above the newest migration")
+	flags.StringVar(&opts.description, descriptionFlag, "data", "Migration description used in the file name")
+	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the migration SQL instead of writing files")
+	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
+	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
+}
+
+func migrateDataCommand(cmd *cobra.Command, opts *options) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	if opts.rootDir == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("a Go annotations directory is required (--%s)", rootDirFlag))
+	}
+	if opts.dbURL == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("a database URL is required (--%s)", dbURLFlag))
+	}
+	if opts.migrationsDir == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("migrations directory is required (--%s)", migrationsFlag))
+	}
+
+	connectTimeout, err := dbcli.ParseConnectTimeout(opts.connectTimeout)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	version, err := resolveVersion(opts.version, opts.migrationsDir)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
+	connectCtx, cancel := dbcli.ConnectContext(ctx, connectTimeout)
+	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.dbURL)
+	cancel()
+	if err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("connect to database: %w", err))
+	}
+	defer dbschema.CloseAndWarn(conn)
+
+	upSQL, downSQL, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: opts.rootDir})
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
+	if upSQL == "" {
+		fmt.Fprintln(out, "no data changes")
+		return nil
+	}
+
+	if opts.dryRun {
+		upName := migrator.GenerateMigrationFileName(version, opts.description, "up")
+		downName := migrator.GenerateMigrationFileName(version, opts.description, "down")
+		fmt.Fprintf(out, "-- data migration version %d (dry run, no files written)\n\n-- %s\n%s\n\n-- %s\n%s\n",
+			version, upName, upSQL, downName, downSQL)
+		return nil
+	}
+
+	upPath, downPath, err := generator.WriteDataMigrationFiles(opts.migrationsDir, version, opts.description, upSQL, downSQL)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	fmt.Fprintf(out, "Wrote data migration version %d:\n  %s\n  %s\n", version, upPath, downPath)
+	return nil
+}
+
+// maxMigrationVersion is the largest value the 10-digit NNNNNNNNNN file-name
+// prefix can hold. A larger version would produce a file name the migration
+// parser cannot recognize, so the migration would be silently invisible.
+const maxMigrationVersion = 9999999999
+
+// resolveVersion returns the version for the generated migration. Without
+// --version it is one above the newest migration so the data migration sorts
+// after the whole existing history. An explicit --version must be a positive
+// value that fits the file-name width and is above every existing migration —
+// otherwise it would collide with or precede an existing migration — so those
+// are rejected up front. It mirrors the checkpoint command's resolver, but
+// treats a not-yet-created migrations directory as an empty history (version 1)
+// because a data migration may be the first file written to a fresh project.
+func resolveVersion(explicit, migrationsDir string) (int64, error) {
+	latest, err := latestMigrationVersion(migrationsDir)
+	if err != nil {
+		return 0, err
+	}
+
+	if explicit == "" {
+		return latest + 1, nil
+	}
+
+	version, err := strconv.ParseInt(explicit, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --%s value %q: %w", versionFlag, explicit, err)
+	}
+	if version <= 0 {
+		return 0, fmt.Errorf("invalid --%s value %d: must be a positive version", versionFlag, version)
+	}
+	if version > maxMigrationVersion {
+		return 0, fmt.Errorf("invalid --%s value %d: exceeds the maximum migration version %d", versionFlag, version, int64(maxMigrationVersion))
+	}
+	if version <= latest {
+		return 0, fmt.Errorf("invalid --%s value %d: must be above the newest existing migration version %d", versionFlag, version, latest)
+	}
+	return version, nil
+}
+
+// latestMigrationVersion returns the highest version among the ptah-format
+// migrations in migrationsDir, or 0 when the directory does not yet exist.
+func latestMigrationVersion(migrationsDir string) (int64, error) {
+	info, err := os.Stat(migrationsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+	if !info.IsDir() {
+		return 0, fmt.Errorf("%q exists and is not a directory", migrationsDir)
+	}
+
+	files, err := migrator.DiscoverMigrationFiles(os.DirFS(migrationsDir), migrator.MigrationDirFormatPtah)
+	if err != nil {
+		return 0, fmt.Errorf("failed to scan migrations directory: %w", err)
+	}
+	var latest int64
+	for _, file := range files {
+		if file.Version > latest {
+			latest = file.Version
+		}
+	}
+	return latest, nil
+}

--- a/cmd/migratedata/migratedata.go
+++ b/cmd/migratedata/migratedata.go
@@ -35,7 +35,6 @@ type options struct {
 	version        string
 	description    string
 	dryRun         bool
-	schemas        string
 	connectTimeout string
 }
 
@@ -77,7 +76,6 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.version, versionFlag, "", "Migration version; defaults to one above the newest migration")
 	flags.StringVar(&opts.description, descriptionFlag, "data", "Migration description used in the file name")
 	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the migration SQL instead of writing files")
-	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 }
 
@@ -158,6 +156,9 @@ func resolveVersion(explicit, migrationsDir string) (int64, error) {
 	}
 
 	if explicit == "" {
+		if latest >= maxMigrationVersion {
+			return 0, fmt.Errorf("cannot derive a version: the newest migration %d is already at the maximum %d", latest, int64(maxMigrationVersion))
+		}
 		return latest + 1, nil
 	}
 

--- a/cmd/migratedata/migratedata_test.go
+++ b/cmd/migratedata/migratedata_test.go
@@ -1,0 +1,155 @@
+package migratedata_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migratedata"
+	"github.com/stokaro/ptah/dbschema"
+)
+
+// seedLiveDB creates a file-backed SQLite database with a "regions" table
+// seeded with the given rows and returns its connection URL. A file (not
+// :memory:) database is used so the command, which opens its own connection,
+// sees the same data.
+func seedLiveDB(t *testing.T, rows [][2]string) string {
+	t.Helper()
+	c := qt.New(t)
+
+	url := "sqlite://" + filepath.Join(t.TempDir(), "live.db")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), url)
+	c.Assert(err, qt.IsNil)
+
+	_, err = conn.ExecContext(context.Background(),
+		`CREATE TABLE regions (code TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	for _, r := range rows {
+		_, err := conn.ExecContext(context.Background(),
+			`INSERT INTO regions (code, name) VALUES (?, ?)`, r[0], r[1])
+		c.Assert(err, qt.IsNil)
+	}
+	dbschema.CloseAndWarn(conn)
+	return url
+}
+
+// writeRegionsFixture writes the //migrator:schema:data annotation source and
+// its YAML rows file into root.
+func writeRegionsFixture(t *testing.T, root, yamlRows string) {
+	t.Helper()
+	c := qt.New(t)
+
+	goSrc := `package fixture
+
+//migrator:schema:data table="regions" key="code" file="regions.yaml"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"), []byte(yamlRows), 0o600), qt.IsNil)
+}
+
+const desiredRows = `
+- code: US
+  name: United States
+- code: CZ
+  name: Czechia
+`
+
+func runData(args ...string) (string, error) {
+	cmd := migratedata.NewMigrateDataCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return out.String(), err
+}
+
+func TestMigrateDataCommand_WritesPair(t *testing.T) {
+	c := qt.New(t)
+
+	// Live CZ has an old name (update); the desired CZ name and a new US row
+	// drive the migration.
+	dbURL := seedLiveDB(t, [][2]string{{"CZ", "Czech Republic"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+
+	// The migrations directory was empty, so the version is 1.
+	up, err := os.ReadFile(filepath.Join(migrationsDir, "0000000001_data.up.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(up), qt.Contains, `INSERT INTO "regions" ("code", "name") VALUES ('US', 'United States');`)
+	c.Assert(string(up), qt.Contains, `UPDATE "regions" SET "name" = 'Czechia' WHERE "code" = 'CZ';`)
+
+	down, err := os.ReadFile(filepath.Join(migrationsDir, "0000000001_data.down.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(down), qt.Contains, `UPDATE "regions" SET "name" = 'Czech Republic' WHERE "code" = 'CZ';`)
+	c.Assert(string(down), qt.Contains, `DELETE FROM "regions" WHERE "code" = 'US';`)
+
+	sum, err := os.ReadFile(filepath.Join(migrationsDir, "ptah.sum"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, "0000000001_data.up.sql")
+
+	c.Assert(out, qt.Contains, "Wrote data migration version 1")
+}
+
+func TestMigrateDataCommand_DryRunWritesNothing(t *testing.T) {
+	c := qt.New(t)
+
+	dbURL := seedLiveDB(t, [][2]string{{"CZ", "Czech Republic"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--dry-run")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "dry run")
+	c.Assert(out, qt.Contains, `INSERT INTO "regions"`)
+	c.Assert(out, qt.Contains, `UPDATE "regions"`)
+
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateDataCommand_NoChanges(t *testing.T) {
+	c := qt.New(t)
+
+	// Live already equals desired, so nothing is generated.
+	dbURL := seedLiveDB(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czechia"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "no data changes")
+
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateDataCommand_RequiresDBURL(t *testing.T) {
+	c := qt.New(t)
+
+	out, err := runData("--root-dir", t.TempDir())
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "a database URL is required")
+}

--- a/cmd/migrations/migrations.go
+++ b/cmd/migrations/migrations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migrate"
 	"github.com/stokaro/ptah/cmd/migratebaseline"
 	"github.com/stokaro/ptah/cmd/migratecheckpoint"
+	"github.com/stokaro/ptah/cmd/migratedata"
 	"github.com/stokaro/ptah/cmd/migratedown"
 	"github.com/stokaro/ptah/cmd/migrateedit"
 	"github.com/stokaro/ptah/cmd/migratehash"
@@ -42,6 +43,13 @@ ptah atlas.`,
 	cmd.AddCommand(migrationCommand(migrate.NewMigrateCommand(), "Plan migration SQL from schema differences", "Plan migration SQL from schema differences without writing migration files."))
 	cmd.AddCommand(migrationCommand(migrate.NewMigrateGenerateCommand(), "Generate migration files from schema differences", "Generate migration files from schema differences and write them to the migrations directory."))
 	cmd.AddCommand(migrationCommand(migrate.NewMigrateCreateCommand(), "Create empty migration files for manual SQL", "Create empty migration files for manual SQL."))
+	cmd.AddCommand(migrationCommand(
+		migratedata.NewMigrateDataCommand(),
+		"Generate a migration from reference/seed data drift",
+		"Generate an ordinary migration from the drift between declarative reference/seed data "+
+			"(//migrator:schema:data) and a live database. It applies no safety/risk gating of its own "+
+			"(a deferred follow-up); review the generated file before applying.",
+	))
 	cmd.AddCommand(migrationCommand(migrationsimport.NewMigrationsImportCommand(), "Import migrations from another tool", "Convert a golang-migrate, Goose, Flyway, or Liquibase migration directory into Ptah's native format."))
 	cmd.AddCommand(migrationCommand(migrateup.NewMigrateUpCommand(), "Run pending migrations", "Run pending migrations against a live database."))
 	cmd.AddCommand(migrationCommand(migratedown.NewMigrateDownCommand(), "Roll back migrations", "Roll back migrations against a live database."))

--- a/docs/native_cli.md
+++ b/docs/native_cli.md
@@ -30,6 +30,7 @@ root-level command spellings are removed instead of preserved.
 | `ptah migrations plan` | Print migration SQL from desired/live schema differences. |
 | `ptah migrations generate` | Generate migration files from desired/live schema differences. |
 | `ptah migrations create` | Create empty migration files for manual SQL. |
+| `ptah migrations data` | Generate a migration from declarative reference/seed data drift against a live database. |
 | `ptah migrations import` | Convert another tool's migration directory to Ptah format. |
 | `ptah migrations up` | Run pending migrations. |
 | `ptah migrations down` | Roll back migrations. |

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -684,6 +684,7 @@ func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downS
 func GenerateCheckpointFromShadow(ctx context.Context, opts CheckpointFromShadowOptions) (upSQL, downSQL string, err error)
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
 func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error)
+func WriteDataMigrationFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error)
 type BaselineShadowVerifyOptions struct{ ... }
 type CheckpointFromShadowOptions struct{ ... }
 type DiffPolicy struct{ ... }

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -46,9 +46,16 @@ type Options struct {
 // managed column set (the union of the desired rows' columns plus the key
 // columns), computes the row-level diff, and renders it. The per-table up
 // scripts are concatenated in Table order and the down scripts in reverse Table
-// order, so that applying the whole up followed by the whole down is a
-// round-trip even when tables have inter-table foreign keys. Tables whose diff
-// is empty contribute nothing.
+// order, so that applying the whole up followed by the whole down restores the
+// original state (a net-state round-trip). Tables whose diff is empty contribute
+// nothing.
+//
+// Table order is alphabetical, not foreign-key-topological, so a migration that
+// deletes a parent table's rows before a child's, or inserts a child's before a
+// parent's, can hit a foreign-key violation at apply time. Each migration runs
+// in a transaction, so such a violation aborts cleanly with nothing applied;
+// FK-related managed tables may need manual reordering. Dependency-aware
+// ordering is a tracked follow-up.
 //
 // When no managed table has any changes, both returned strings are empty and
 // the caller writes nothing. A missing row-data file, a row missing a key
@@ -118,6 +125,19 @@ func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect
 	live, err := dbschema.ReadTableRows(ctx, conn, "", md.Table, managedColumns(desired, md.Keys))
 	if err != nil {
 		return "", "", err
+	}
+
+	// With no desired rows the managed column set is just the keys, so every
+	// live row becomes a DELETE whose down re-inserts only the key columns —
+	// a rollback that drops (or, under NOT NULL, cannot restore) every other
+	// column. Rather than emit a knowingly-irreversible migration, refuse the
+	// empty-desired-but-populated-table case. Reconstructing the full row on
+	// rollback needs the table's whole column set and is a tracked follow-up;
+	// an empty desired set against an empty table is still a clean no-op.
+	if len(desired) == 0 && len(live) > 0 {
+		return "", "", fmt.Errorf(
+			"datamigrate: managed table %q has an empty desired row set but %d live row(s); a reversible full delete cannot be generated from the key columns alone — provide the desired rows or remove the annotation",
+			md.Table, len(live))
 	}
 
 	diff, err := datadiff.Compute(md.Table, md.Keys, desired, live)

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -1,0 +1,161 @@
+// Package datamigrate composes the declarative reference/seed data pipeline:
+// it parses //migrator:schema:data annotations, reads the corresponding live
+// rows, diffs them, and renders the difference as a single reversible SQL
+// migration body pair.
+//
+// It is the database-facing orchestration layer that sits above the pure
+// migration/datadiff computation and below the ptah migrations data command. It
+// lives under internal/ because it is a composition of existing public building
+// blocks (core/goschema, dbschema, migration/datadiff) rather than a new public
+// contract, and it is kept separate from the command so it can be exercised
+// end to end against an in-memory database without cobra.
+package datamigrate
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/datadiff"
+)
+
+// Options configures [Generate].
+type Options struct {
+	// RootDir is the directory of Go sources carrying //migrator:schema:data
+	// annotations. It is passed verbatim to goschema.ParseDir and reused to
+	// resolve each annotation's YAML row-data file, so it must be the same root
+	// the annotations were authored against.
+	RootDir string
+	// Dialect selects the SQL dialect for literal and identifier rendering. When
+	// empty the dialect reported by the connection is used, matching how the
+	// command infers it from --db-url.
+	Dialect string
+}
+
+// Generate composes the full data-migration pipeline against conn and returns a
+// single reversible SQL body pair covering every managed table.
+//
+// It parses the Go annotations under opts.RootDir and, for each declared
+// //migrator:schema:data table (iterated in Table order for deterministic
+// output), loads the desired rows, reads the live rows projected onto the
+// managed column set (the union of the desired rows' columns plus the key
+// columns), computes the row-level diff, and renders it. The per-table up
+// scripts are concatenated in Table order and the down scripts in reverse Table
+// order, so that applying the whole up followed by the whole down is a
+// round-trip even when tables have inter-table foreign keys. Tables whose diff
+// is empty contribute nothing.
+//
+// When no managed table has any changes, both returned strings are empty and
+// the caller writes nothing. A missing row-data file, a row missing a key
+// column, or an unrenderable value surfaces as an error naming the offending
+// input.
+//
+// The table is read with an empty schema argument: a datadiff.DataDiff carries
+// no schema, so both the read and the rendered DML target the connection's
+// default schema. Schema-qualified managed tables are a known follow-up.
+func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Options) (upSQL, downSQL string, err error) {
+	if conn == nil {
+		return "", "", errors.New("datamigrate: a database connection is required")
+	}
+
+	dialect := opts.Dialect
+	if dialect == "" {
+		dialect = conn.Info().Dialect
+	}
+
+	db, err := goschema.ParseDir(opts.RootDir)
+	if err != nil {
+		return "", "", fmt.Errorf("datamigrate: parse Go annotations in %q: %w", opts.RootDir, err)
+	}
+
+	managed := slices.Clone(db.ManagedData)
+	slices.SortFunc(managed, func(a, b goschema.ManagedData) int {
+		if c := cmp.Compare(a.Table, b.Table); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.StructName, b.StructName); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.File, b.File)
+	})
+
+	var ups, downs []string
+	for _, md := range managed {
+		up, down, err := renderTable(ctx, conn, dialect, opts.RootDir, md)
+		if err != nil {
+			return "", "", err
+		}
+		if up == "" {
+			// An empty diff renders as empty up and down together, so there is
+			// nothing to reverse for this table.
+			continue
+		}
+		ups = append(ups, tableBlock(md.Table, up))
+		downs = append(downs, tableBlock(md.Table, down))
+	}
+
+	if len(ups) == 0 {
+		return "", "", nil
+	}
+
+	slices.Reverse(downs)
+	return strings.Join(ups, "\n"), strings.Join(downs, "\n"), nil
+}
+
+// renderTable runs the pipeline for a single managed table: load desired rows,
+// read the live rows for the managed columns, diff, and render.
+func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect, rootDir string, md goschema.ManagedData) (up, down string, err error) {
+	desired, err := goschema.LoadManagedRows(rootDir, md)
+	if err != nil {
+		return "", "", err
+	}
+
+	live, err := dbschema.ReadTableRows(ctx, conn, "", md.Table, managedColumns(desired, md.Keys))
+	if err != nil {
+		return "", "", err
+	}
+
+	diff, err := datadiff.Compute(md.Table, md.Keys, desired, live)
+	if err != nil {
+		return "", "", err
+	}
+	return datadiff.Render(diff, dialect)
+}
+
+// managedColumns returns the distinct, sorted set of columns Ptah manages for a
+// table: every column that appears in any desired row plus the key columns. The
+// keys are always included so a table with no desired rows still reads its live
+// rows (which then all become deletes) and so a key that never appears as a
+// data column is still projected. The result is deduplicated and sorted because
+// dbschema.ReadTableRows rejects duplicate columns and a stable order keeps the
+// generated SQL deterministic.
+func managedColumns(rows []map[string]any, keys []string) []string {
+	set := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		set[k] = struct{}{}
+	}
+	for _, row := range rows {
+		for col := range row {
+			set[col] = struct{}{}
+		}
+	}
+
+	cols := make([]string, 0, len(set))
+	for col := range set {
+		cols = append(cols, col)
+	}
+	slices.Sort(cols)
+	return cols
+}
+
+// tableBlock prefixes a rendered per-table script with a comment naming the
+// table so a reviewer can tell the concatenated blocks apart. The comment is a
+// no-op at apply time and does not affect the round-trip.
+func tableBlock(table, body string) string {
+	return "-- data: " + table + "\n" + body
+}

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/datamigrate"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // newRegionsConn opens an in-memory SQLite database and creates a "regions"
@@ -106,6 +107,81 @@ func TestGenerate_NoDriftYieldsEmpty(t *testing.T) {
 	})
 	root := t.TempDir()
 	writeRegionsFixture(t, root, driftDesiredRows)
+
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, "")
+	c.Assert(down, qt.Equals, "")
+}
+
+// TestGenerate_RoundTripApply proves reversibility against a real database:
+// applying up reaches the desired state and applying down restores the original,
+// splitting each script through the same connection-dialect splitter the
+// migrator uses.
+func TestGenerate_RoundTripApply(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	up, down, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNil)
+
+	apply := func(script string) {
+		for _, stmt := range migrator.SplitSQLStatementsForConnection(conn, script) {
+			_, execErr := conn.ExecContext(ctx, stmt)
+			c.Assert(execErr, qt.IsNil, qt.Commentf("stmt: %s", stmt))
+		}
+	}
+	readState := func() map[string]string {
+		rows, queryErr := conn.QueryContext(ctx, `SELECT code, name FROM regions ORDER BY code`)
+		c.Assert(queryErr, qt.IsNil)
+		defer func() { _ = rows.Close() }()
+		out := map[string]string{}
+		for rows.Next() {
+			var code, name string
+			c.Assert(rows.Scan(&code, &name), qt.IsNil)
+			out[code] = name
+		}
+		c.Assert(rows.Err(), qt.IsNil)
+		return out
+	}
+
+	apply(up)
+	c.Assert(readState(), qt.DeepEquals, map[string]string{
+		"US": "United States", "CZ": "Czechia", "DE": "Germany",
+	})
+
+	apply(down)
+	c.Assert(readState(), qt.DeepEquals, map[string]string{
+		"US": "United States", "CZ": "Czech Republic", "XX": "Old Name",
+	})
+}
+
+func TestGenerate_EmptyDesiredWithLiveRowsErrors(t *testing.T) {
+	c := qt.New(t)
+
+	conn := newRegionsConn(t, [][2]string{{"US", "United States"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, "[]\n")
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "empty desired row set")
+}
+
+func TestGenerate_EmptyDesiredEmptyTableIsNoOp(t *testing.T) {
+	c := qt.New(t)
+
+	conn := newRegionsConn(t, nil)
+	root := t.TempDir()
+	writeRegionsFixture(t, root, "[]\n")
 
 	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
 	c.Assert(err, qt.IsNil)

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -1,0 +1,121 @@
+package datamigrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/datamigrate"
+)
+
+// newRegionsConn opens an in-memory SQLite database and creates a "regions"
+// table seeded with the given code/name rows. The connection is closed via
+// t.Cleanup.
+func newRegionsConn(t *testing.T, rows [][2]string) *dbschema.DatabaseConnection {
+	t.Helper()
+	c := qt.New(t)
+
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite:///:memory:")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	_, err = conn.ExecContext(context.Background(),
+		`CREATE TABLE regions (code TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	for _, r := range rows {
+		_, err := conn.ExecContext(context.Background(),
+			`INSERT INTO regions (code, name) VALUES (?, ?)`, r[0], r[1])
+		c.Assert(err, qt.IsNil)
+	}
+	return conn
+}
+
+// writeRegionsFixture writes a Go source carrying a //migrator:schema:data
+// annotation for the "regions" table and the referenced YAML rows file into
+// root, so goschema.ParseDir + LoadManagedRows resolve the desired rows.
+func writeRegionsFixture(t *testing.T, root, yamlRows string) {
+	t.Helper()
+	c := qt.New(t)
+
+	goSrc := `package fixture
+
+//migrator:schema:data table="regions" key="code" file="regions.yaml"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"), []byte(yamlRows), 0o600), qt.IsNil)
+}
+
+const driftDesiredRows = `
+- code: US
+  name: United States
+- code: CZ
+  name: Czechia
+- code: DE
+  name: Germany
+`
+
+func TestGenerate_ComputesReversibleDataMigration(t *testing.T) {
+	c := qt.New(t)
+
+	// Live state: US matches desired (unchanged), CZ has an old name (update),
+	// XX is live-only (delete). Desired adds DE (insert).
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNil)
+
+	// Up reaches the desired state.
+	c.Assert(up, qt.Contains, `INSERT INTO "regions" ("code", "name") VALUES ('DE', 'Germany');`)
+	c.Assert(up, qt.Contains, `UPDATE "regions" SET "name" = 'Czechia' WHERE "code" = 'CZ';`)
+	c.Assert(up, qt.Contains, `DELETE FROM "regions" WHERE "code" = 'XX';`)
+	// The unchanged US row produces no statement in either direction.
+	c.Assert(up, qt.Not(qt.Contains), "'US'")
+	c.Assert(down, qt.Not(qt.Contains), "'US'")
+
+	// Down is the exact inverse of up.
+	c.Assert(down, qt.Contains, `INSERT INTO "regions" ("code", "name") VALUES ('XX', 'Old Name');`)
+	c.Assert(down, qt.Contains, `UPDATE "regions" SET "name" = 'Czech Republic' WHERE "code" = 'CZ';`)
+	c.Assert(down, qt.Contains, `DELETE FROM "regions" WHERE "code" = 'DE';`)
+}
+
+func TestGenerate_NoDriftYieldsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	// Live state already equals the desired state, so there is nothing to do.
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czechia"},
+		{"DE", "Germany"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, "")
+	c.Assert(down, qt.Equals, "")
+}
+
+func TestGenerate_NilConnection(t *testing.T) {
+	c := qt.New(t)
+
+	_, _, err := datamigrate.Generate(context.Background(), nil, datamigrate.Options{RootDir: t.TempDir()})
+	c.Assert(err, qt.ErrorMatches, `datamigrate: a database connection is required`)
+}

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -3,8 +3,6 @@ package generator
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/stokaro/ptah/core/goschema"
@@ -12,7 +10,6 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
-	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
@@ -53,28 +50,7 @@ func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downS
 // the caller resolves a version above the existing history — and returns the
 // two written paths.
 func WriteCheckpointFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return "", "", fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	upPath = filepath.Join(outputDir, migrator.GenerateCheckpointMigrationFileName(version, description, "up"))
-	downPath = filepath.Join(outputDir, migrator.GenerateCheckpointMigrationFileName(version, description, "down"))
-	if fileExists(upPath) || fileExists(downPath) {
-		return "", "", fmt.Errorf("checkpoint files for version %d already exist", version)
-	}
-
-	if err := writeNewMigrationFile(upPath, upSQL); err != nil {
-		return "", "", fmt.Errorf("failed to write checkpoint up file: %w", err)
-	}
-	if err := writeNewMigrationFile(downPath, downSQL); err != nil {
-		_ = os.Remove(upPath)
-		return "", "", fmt.Errorf("failed to write checkpoint down file: %w", err)
-	}
-
-	if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatPtah); err != nil {
-		return "", "", fmt.Errorf("failed to rewrite ptah.sum: %w", err)
-	}
-	return upPath, downPath, nil
+	return writeMigrationPair(outputDir, version, description, upSQL, downSQL, "checkpoint", migrator.GenerateCheckpointMigrationFileName)
 }
 
 // CheckpointFromShadowOptions configures GenerateCheckpointFromShadow.

--- a/migration/generator/datamigration.go
+++ b/migration/generator/datamigration.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// WriteDataMigrationFiles writes an ordinary migration pair
+// (NNNNNNNNNN_description.up.sql and .down.sql) into outputDir at the given
+// version and rewrites the directory's ptah.sum so the new files are
+// integrity-protected. It refuses to overwrite existing files — the caller
+// resolves a version above the existing history — and returns the two written
+// paths.
+//
+// Unlike WriteCheckpointFiles it produces ordinary (non-checkpoint) migration
+// files, so the generated pair is applied and rolled back like any hand-written
+// migration and takes part in normal history. It is the writer for the
+// declarative reference/seed data pipeline (ptah migrations data): the SQL
+// bodies are the concatenated datadiff DML for every managed table.
+func WriteDataMigrationFiles(outputDir string, version int64, description, upSQL, downSQL string) (upPath, downPath string, err error) {
+	return writeMigrationPair(outputDir, version, description, upSQL, downSQL, "migration", migrator.GenerateMigrationFileName)
+}
+
+// writeMigrationPair writes an up/down migration file pair, named by nameFor,
+// into outputDir at version and then rewrites ptah.sum so the pair is
+// integrity-protected. It refuses to overwrite an existing pair. kind labels
+// the pair in error messages (for example "migration" or "checkpoint") so
+// callers surface a wording that matches the file kind they asked for. It is
+// the shared core of WriteDataMigrationFiles and WriteCheckpointFiles, which
+// differ only in the file-name scheme and that label.
+func writeMigrationPair(
+	outputDir string,
+	version int64,
+	description, upSQL, downSQL, kind string,
+	nameFor func(version int64, description, direction string) string,
+) (upPath, downPath string, err error) {
+	if err := ensureMigrationOutputDir(outputDir); err != nil {
+		return "", "", fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	upPath = filepath.Join(outputDir, nameFor(version, description, "up"))
+	downPath = filepath.Join(outputDir, nameFor(version, description, "down"))
+	if fileExists(upPath) || fileExists(downPath) {
+		return "", "", fmt.Errorf("%s files for version %d already exist", kind, version)
+	}
+
+	if err := writeNewMigrationFile(upPath, upSQL); err != nil {
+		return "", "", fmt.Errorf("failed to write %s up file: %w", kind, err)
+	}
+	if err := writeNewMigrationFile(downPath, downSQL); err != nil {
+		_ = os.Remove(upPath)
+		return "", "", fmt.Errorf("failed to write %s down file: %w", kind, err)
+	}
+
+	if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatPtah); err != nil {
+		return "", "", fmt.Errorf("failed to rewrite ptah.sum: %w", err)
+	}
+	return upPath, downPath, nil
+}

--- a/migration/generator/datamigration_test.go
+++ b/migration/generator/datamigration_test.go
@@ -1,0 +1,52 @@
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestWriteDataMigrationFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	// Seed an ordinary migration so ptah.sum starts with prior content that must
+	// be preserved and extended, not clobbered.
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"), []byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.down.sql"), []byte("DROP TABLE t;\n"), 0o600), qt.IsNil)
+
+	upPath, downPath, err := generator.WriteDataMigrationFiles(dir, 2, "seed data",
+		"INSERT INTO t (id) VALUES (1);\n", "DELETE FROM t WHERE id = 1;\n")
+	c.Assert(err, qt.IsNil)
+
+	// The pair uses ordinary migration file names, not checkpoint names.
+	c.Assert(filepath.Base(upPath), qt.Equals, "0000000002_seed_data.up.sql")
+	c.Assert(filepath.Base(downPath), qt.Equals, "0000000002_seed_data.down.sql")
+
+	parsed, err := migrator.ParseMigrationFileName(filepath.Base(upPath))
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.IsCheckpoint, qt.IsFalse)
+
+	upContent, err := os.ReadFile(upPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upContent), qt.Contains, "INSERT INTO t")
+	downContent, err := os.ReadFile(downPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downContent), qt.Contains, "DELETE FROM t")
+
+	// ptah.sum was rewritten and now covers both the prior and the new pair.
+	sum, err := os.ReadFile(filepath.Join(dir, "ptah.sum"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, "0000000001_init.up.sql")
+	c.Assert(string(sum), qt.Contains, "0000000002_seed_data.up.sql")
+	c.Assert(string(sum), qt.Contains, "0000000002_seed_data.down.sql")
+
+	// Writing the same version again refuses rather than overwriting.
+	_, _, err = generator.WriteDataMigrationFiles(dir, 2, "seed data", "x", "y")
+	c.Assert(err, qt.ErrorMatches, `migration files for version 2 already exist`)
+}


### PR DESCRIPTION
## Summary

Capstone of declarative reference/seed data (#663, epic #654): a command that composes the full pipeline (model → live-row read → diff → reversible render) into a migration file. Atlas keeps declarative data / data-migration generation in its Pro build; `ptah migrations data` is Ptah's free, local, embeddable equivalent.

For each `//migrator:schema:data` table under `--root-dir`, it loads the desired rows from the annotation's YAML file, reads the live rows for the managed columns from `--db-url`, diffs them, and renders a reversible migration pair — `INSERT`/`UPDATE`/`DELETE` up, exact inverse down — writing an ordinary `NNNNNNNNNN_data.up.sql` / `.down.sql` pair and refreshing `ptah.sum`.

```bash
ptah migrations data --root-dir ./models --db-url postgres://… --migrations-dir ./migrations
ptah migrations data --root-dir ./models --db-url … --dry-run   # print SQL, write nothing
```

- Per-table blocks concatenate in table order; down blocks in reverse table order, so a whole-migration up/down round-trips even under inter-table FKs.
- A run with no drift writes nothing (`no data changes`).

## Structure

- `generator.WriteDataMigrationFiles` writes an ordinary (non-checkpoint) pair + `ptah.sum`; `WriteCheckpointFiles` now shares the same `writeMigrationPair` helper (behavior byte-for-byte unchanged — checkpoint error strings identical).
- `internal/datamigrate.Generate(ctx, conn, opts)` is the DB-facing orchestration over the pure `core/goschema` + `dbschema` + `migration/datadiff` building blocks — kept off the public surface and testable against an in-memory database without cobra.
- `cmd/migratedata` is the thin CLI, registered under `ptah migrations`, mirroring `ptah migrations checkpoint` (flags, version resolution + guard, dry-run, `cmdutil.Fail`).

## Scope

Destructive `UPDATE`/`DELETE` volume gating + protected-table guards, schema-qualified managed tables, and the feature/comparison docs are deferred follow-ups (noted in the command help). The generated file is reviewed before apply and applied through the migrator's existing safety gates (and, thanks to #756, split correctly).

## Tests

- Writer: writes the ordinary pair + `ptah.sum`; refuses overwrite.
- End-to-end (`internal/datamigrate`, SQLite): a live table diffed against desired managed data produces the expected INSERT/UPDATE/DELETE up with the inverse down; no-drift → empty.
- CLI: dry-run prints and writes nothing; a real run writes the pair; `--db-url`/`--root-dir` required; no-changes prints `no data changes`.

Full local verification: `go build ./...`, `go vet`, `go test -race`, full `go test ./...` (134 pkgs), golangci-lint (0), qtlint (0), teststyle, public-API ledger + snapshot (adds `WriteDataMigrationFiles`).