### PR TITLE
Gate destructive `ptah migrations data` behind explicit flags

### DIFF
--- a/cmd/migratedata/migratedata.go
+++ b/cmd/migratedata/migratedata.go
@@ -20,22 +20,28 @@ import (
 )
 
 const (
-	rootDirFlag     = "root-dir"
-	dbURLFlag       = "db-url"
-	migrationsFlag  = "migrations-dir"
-	versionFlag     = "version"
-	descriptionFlag = "description"
-	dryRunFlag      = "dry-run"
+	rootDirFlag          = "root-dir"
+	dbURLFlag            = "db-url"
+	migrationsFlag       = "migrations-dir"
+	versionFlag          = "version"
+	descriptionFlag      = "description"
+	dryRunFlag           = "dry-run"
+	allowDestructiveFlag = "allow-destructive"
+	protectedTableFlag   = "protected-table"
+	allowProdFlag        = "allow-prod"
 )
 
 type options struct {
-	rootDir        string
-	dbURL          string
-	migrationsDir  string
-	version        string
-	description    string
-	dryRun         bool
-	connectTimeout string
+	rootDir          string
+	dbURL            string
+	migrationsDir    string
+	version          string
+	description      string
+	dryRun           bool
+	allowDestructive bool
+	protectedTables  []string
+	allowProd        bool
+	connectTimeout   string
 }
 
 // NewMigrateDataCommand returns the `data` command.
@@ -55,10 +61,15 @@ combined difference is written as an ordinary migration pair
 body inserts, updates, and deletes rows to reach the desired state; the down
 body reverses it. When nothing has drifted, no files are written.
 
-The generated migration is meant to be reviewed before it is applied, and it is
-applied through the normal migration path, so this command performs no
-safety/risk gating of its own: destructive UPDATE/DELETE volume gating and
-protected-table guards are a deferred follow-up.`,
+The generated migration is applied through the normal migration path, where
+neither the lint nor the safety gate classifies row INSERT/UPDATE/DELETE as
+destructive, so this command gates destructive changes at generation time.
+Unless --allow-destructive is set, a migration that would update or delete
+existing rows is refused with a per-table summary; insert-only migrations are
+always allowed. Naming a table with --protected-table refuses any change to it
+unless --allow-prod is also set. Both gates apply to --dry-run as well, so
+combine --allow-destructive --dry-run to preview a destructive change without
+writing files.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return migrateDataCommand(cmd, &opts)
 		},
@@ -76,6 +87,9 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.version, versionFlag, "", "Migration version; defaults to one above the newest migration")
 	flags.StringVar(&opts.description, descriptionFlag, "data", "Migration description used in the file name")
 	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the migration SQL instead of writing files")
+	flags.BoolVar(&opts.allowDestructive, allowDestructiveFlag, false, "Allow generating a data migration that updates or deletes existing rows")
+	flags.StringArrayVar(&opts.protectedTables, protectedTableFlag, nil, "Managed table that requires --allow-prod to modify; repeat to add more")
+	flags.BoolVar(&opts.allowProd, allowProdFlag, false, "Allow generating a data migration that modifies a protected table")
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 }
 
@@ -110,7 +124,12 @@ func migrateDataCommand(cmd *cobra.Command, opts *options) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	upSQL, downSQL, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: opts.rootDir})
+	upSQL, downSQL, err := datamigrate.Generate(ctx, conn, datamigrate.Options{
+		RootDir:          opts.rootDir,
+		AllowDestructive: opts.allowDestructive,
+		ProtectedTables:  opts.protectedTables,
+		AllowProd:        opts.allowProd,
+	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/migratedata/migratedata_test.go
+++ b/cmd/migratedata/migratedata_test.go
@@ -166,6 +166,27 @@ func TestMigrateDataCommand_DestructiveRefusedByDefault(t *testing.T) {
 	c.Assert(written, qt.HasLen, 0)
 }
 
+func TestMigrateDataCommand_DryRunAlsoGatesDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	// The gates run before any SQL is emitted, so --dry-run is refused too and
+	// prints no SQL — the documented "combine --allow-destructive --dry-run to
+	// preview" behavior depends on this.
+	dbURL := seedLiveDB(t, [][2]string{{"CZ", "Czech Republic"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--dry-run")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "destructive")
+	c.Assert(out, qt.Not(qt.Contains), "INSERT INTO")
+
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
 func TestMigrateDataCommand_ProtectedTableRefused(t *testing.T) {
 	c := qt.New(t)
 

--- a/cmd/migratedata/migratedata_test.go
+++ b/cmd/migratedata/migratedata_test.go
@@ -85,7 +85,7 @@ func TestMigrateDataCommand_WritesPair(t *testing.T) {
 	writeRegionsFixture(t, root, desiredRows)
 	migrationsDir := t.TempDir()
 
-	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir)
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--allow-destructive")
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 
 	// The migrations directory was empty, so the version is 1.
@@ -114,7 +114,7 @@ func TestMigrateDataCommand_DryRunWritesNothing(t *testing.T) {
 	writeRegionsFixture(t, root, desiredRows)
 	migrationsDir := t.TempDir()
 
-	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--dry-run")
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--dry-run", "--allow-destructive")
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 	c.Assert(out, qt.Contains, "dry run")
 	c.Assert(out, qt.Contains, `INSERT INTO "regions"`)
@@ -140,6 +140,46 @@ func TestMigrateDataCommand_NoChanges(t *testing.T) {
 	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir)
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 	c.Assert(out, qt.Contains, "no data changes")
+
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateDataCommand_DestructiveRefusedByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	// The CZ name change is an UPDATE, so without --allow-destructive the command
+	// refuses and writes nothing.
+	dbURL := seedLiveDB(t, [][2]string{{"CZ", "Czech Republic"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "destructive")
+	c.Assert(out, qt.Contains, "--allow-destructive")
+
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 0)
+}
+
+func TestMigrateDataCommand_ProtectedTableRefused(t *testing.T) {
+	c := qt.New(t)
+
+	// The US insert is additive (not destructive), so --protected-table is the
+	// only gate that can refuse this run.
+	dbURL := seedLiveDB(t, [][2]string{{"CZ", "Czechia"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, desiredRows)
+	migrationsDir := t.TempDir()
+
+	out, err := runData("--root-dir", root, "--db-url", dbURL, "--migrations-dir", migrationsDir, "--protected-table", "regions")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "protected table(s) regions")
+	c.Assert(out, qt.Contains, "--allow-prod")
 
 	written, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
 	c.Assert(err, qt.IsNil)

--- a/docs/site/src/content/docs/workflows/reference-data.md
+++ b/docs/site/src/content/docs/workflows/reference-data.md
@@ -64,6 +64,24 @@ refreshes `ptah.sum`, so the data migration applies and rolls back like any othe
 `--dry-run` prints the SQL instead of writing files; a run with no drift writes
 nothing.
 
+## Safety gates
+
+A data migration is applied through the ordinary migration path, where neither
+the lint nor the safety gate classifies row `INSERT`/`UPDATE`/`DELETE` as
+destructive. So `ptah migrations data` gates destructive changes when it
+generates them:
+
+- Unless `--allow-destructive` is set, a migration that would `UPDATE` or
+  `DELETE` existing rows is refused with a per-table summary of the volume.
+  Insert-only migrations are additive and are always allowed.
+- Naming a table with `--protected-table` refuses any change to it — insert,
+  update, or delete — unless `--allow-prod` is also set, mirroring the
+  protected-target posture of `ptah seed`.
+
+Both gates run before any SQL is emitted, so they apply to `--dry-run` too:
+combine `--allow-destructive --dry-run` to preview a destructive change without
+writing files.
+
 ## Reversibility
 
 The generated `down` is the exact inverse of `up`: an inserted row's down is a

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/datadiff"
+	"github.com/stokaro/ptah/migration/safety"
 )
 
 // Options configures [Generate].
@@ -35,6 +36,23 @@ type Options struct {
 	// empty the dialect reported by the connection is used, matching how the
 	// command infers it from --db-url.
 	Dialect string
+	// AllowDestructive permits generating a migration whose up body updates or
+	// deletes existing rows. When false (the default) any update or delete makes
+	// Generate refuse with a summary of the destructive volume. A data migration
+	// is applied through the ordinary migration path, where neither the lint nor
+	// the safety gate classifies row INSERT/UPDATE/DELETE as destructive, so this
+	// generate-time gate is the only guard standing between a stray diff and a
+	// mass row deletion or overwrite at apply time. Insert-only migrations are
+	// additive and are never gated.
+	AllowDestructive bool
+	// ProtectedTables lists managed tables that require AllowProd before a
+	// generated migration may change them at all (insert, update, or delete),
+	// mirroring the protected-target posture of migration/seeder. Matching is
+	// case-insensitive. Only tables the migration would actually change are
+	// considered, so protecting a table with no drift is a no-op.
+	ProtectedTables []string
+	// AllowProd permits changing a protected table.
+	AllowProd bool
 }
 
 // Generate composes the full data-migration pipeline against conn and returns a
@@ -61,6 +79,14 @@ type Options struct {
 // the caller writes nothing. A missing row-data file, a row missing a key
 // column, or an unrenderable value surfaces as an error naming the offending
 // input.
+//
+// Two generate-time safety gates guard the change set once it is computed but
+// before any SQL is returned, so they apply equally to a dry run and to a
+// written migration. Unless opts.AllowDestructive is set, a change set that
+// updates or deletes any existing row is refused with a per-table summary;
+// unless opts.AllowProd is set, a change set that touches any opts.ProtectedTables
+// entry is refused. See [Options] for why these live here rather than on the
+// apply path.
 //
 // The table is read with an empty schema argument: a datadiff.DataDiff carries
 // no schema, so both the read and the rendered DML target the connection's
@@ -92,39 +118,64 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 	})
 
 	var ups, downs []string
+	var changes []tableChange
 	for _, md := range managed {
-		up, down, err := renderTable(ctx, conn, dialect, opts.RootDir, md)
+		rendered, err := renderTable(ctx, conn, dialect, opts.RootDir, md)
 		if err != nil {
 			return "", "", err
 		}
-		if up == "" {
+		if rendered.up == "" {
 			// An empty diff renders as empty up and down together, so there is
 			// nothing to reverse for this table.
 			continue
 		}
-		ups = append(ups, tableBlock(md.Table, up))
-		downs = append(downs, tableBlock(md.Table, down))
+		ups = append(ups, tableBlock(md.Table, rendered.up))
+		downs = append(downs, tableBlock(md.Table, rendered.down))
+		changes = append(changes, tableChange{table: md.Table, updates: len(rendered.diff.Updates), deletes: len(rendered.diff.Deletes)})
 	}
 
 	if len(ups) == 0 {
 		return "", "", nil
 	}
 
+	if err := checkPolicy(changes, opts); err != nil {
+		return "", "", err
+	}
+
 	slices.Reverse(downs)
 	return strings.Join(ups, "\n"), strings.Join(downs, "\n"), nil
 }
 
+// tableChange records how many rows a single managed table's diff would update
+// and delete, the two operations the destructive gate cares about. Inserts are
+// additive and are not tracked here.
+type tableChange struct {
+	table   string
+	updates int
+	deletes int
+}
+
+// tableRender is a single managed table's rendered migration together with the
+// diff it came from, so the caller can both concatenate the scripts and assess
+// the change volume. An empty up means the table had no drift.
+type tableRender struct {
+	up   string
+	down string
+	diff *datadiff.DataDiff
+}
+
 // renderTable runs the pipeline for a single managed table: load desired rows,
-// read the live rows for the managed columns, diff, and render.
-func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect, rootDir string, md goschema.ManagedData) (up, down string, err error) {
+// read the live rows for the managed columns, diff, and render. On error it
+// returns the zero tableRender.
+func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect, rootDir string, md goschema.ManagedData) (tableRender, error) {
 	desired, err := goschema.LoadManagedRows(rootDir, md)
 	if err != nil {
-		return "", "", err
+		return tableRender{}, err
 	}
 
 	live, err := dbschema.ReadTableRows(ctx, conn, "", md.Table, managedColumns(desired, md.Keys))
 	if err != nil {
-		return "", "", err
+		return tableRender{}, err
 	}
 
 	// With no desired rows the managed column set is just the keys, so every
@@ -135,16 +186,106 @@ func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect
 	// rollback needs the table's whole column set and is a tracked follow-up;
 	// an empty desired set against an empty table is still a clean no-op.
 	if len(desired) == 0 && len(live) > 0 {
-		return "", "", fmt.Errorf(
+		return tableRender{}, fmt.Errorf(
 			"datamigrate: managed table %q has an empty desired row set but %d live row(s); a reversible full delete cannot be generated from the key columns alone — provide the desired rows or remove the annotation",
 			md.Table, len(live))
 	}
 
 	diff, err := datadiff.Compute(md.Table, md.Keys, desired, live)
 	if err != nil {
-		return "", "", err
+		return tableRender{}, err
 	}
-	return datadiff.Render(diff, dialect)
+	up, down, err := datadiff.Render(diff, dialect)
+	if err != nil {
+		return tableRender{}, err
+	}
+	return tableRender{up: up, down: down, diff: diff}, nil
+}
+
+// checkPolicy enforces the generate-time safety gates over the tables the
+// migration would change. Protected-table refusal takes precedence over the
+// destructive gate so that a run against a protected target reports the
+// protection first, regardless of whether the change also happens to be
+// destructive.
+func checkPolicy(changes []tableChange, opts Options) error {
+	if err := checkProtected(changes, opts); err != nil {
+		return err
+	}
+	return checkDestructive(changes, opts)
+}
+
+// checkProtected refuses to change any table named in opts.ProtectedTables
+// unless opts.AllowProd is set. Only tables that the migration would actually
+// change are examined, matched case-insensitively.
+func checkProtected(changes []tableChange, opts Options) error {
+	if opts.AllowProd || len(opts.ProtectedTables) == 0 {
+		return nil
+	}
+
+	protected := make(map[string]string, len(opts.ProtectedTables))
+	for _, table := range opts.ProtectedTables {
+		if table = strings.TrimSpace(table); table != "" {
+			protected[strings.ToLower(table)] = table
+		}
+	}
+
+	var matched []string
+	for _, change := range changes {
+		if original, ok := protected[strings.ToLower(change.table)]; ok {
+			matched = append(matched, original)
+		}
+	}
+	slices.Sort(matched)
+	if len(matched) > 0 {
+		return fmt.Errorf("datamigrate: refusing to modify protected table(s) %s; pass --allow-prod to override", strings.Join(matched, ", "))
+	}
+	return nil
+}
+
+// checkDestructive refuses a change set that updates or deletes existing rows
+// unless opts.AllowDestructive is set. The destructive volume is expressed in
+// the shared migration/safety vocabulary so the gate reuses the same
+// destructive-severity definition as the DDL safety report.
+func checkDestructive(changes []tableChange, opts Options) error {
+	if opts.AllowDestructive {
+		return nil
+	}
+
+	var updates, deletes int
+	var details []string
+	for _, change := range changes {
+		if change.updates == 0 && change.deletes == 0 {
+			continue
+		}
+		updates += change.updates
+		deletes += change.deletes
+		details = append(details, fmt.Sprintf("%q (%d update(s), %d delete(s))", change.table, change.updates, change.deletes))
+	}
+
+	if !safety.HasDestructive(destructiveFindings(updates, deletes)) {
+		return nil
+	}
+	return fmt.Errorf(
+		"datamigrate: refusing to generate a destructive data migration that would change existing rows in %s; pass --allow-destructive after reviewing the change",
+		strings.Join(details, ", "))
+}
+
+// destructiveFindings expresses the destructive row-change volume in the shared
+// migration/safety vocabulary, mirroring safety.ClassifySchemaDiff for DDL: an
+// UPDATE overwrites existing row data and a DELETE removes rows, so both are
+// destructive; INSERTs are additive and contribute no finding.
+func destructiveFindings(updates, deletes int) []safety.Finding {
+	var findings []safety.Finding
+	addFinding(&findings, "data_rows_updated", updates)
+	addFinding(&findings, "data_rows_deleted", deletes)
+	return findings
+}
+
+func addFinding(findings *[]safety.Finding, category string, count int) {
+	if count == 0 {
+		return
+	}
+	*findings = append(*findings, safety.Finding{Category: category, Count: count, Severity: safety.Destructive})
 }
 
 // managedColumns returns the distinct, sorted set of columns Ptah manages for a

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -138,7 +138,7 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 		return "", "", nil
 	}
 
-	if err := checkPolicy(changes, opts); err != nil {
+	if err := checkPolicy(mergeByTable(changes), opts); err != nil {
 		return "", "", err
 	}
 
@@ -153,6 +153,25 @@ type tableChange struct {
 	table   string
 	updates int
 	deletes int
+}
+
+// mergeByTable folds multiple change entries for the same table into one,
+// summing their volumes and preserving first-seen order. More than one
+// //migrator:schema:data annotation can target the same table, which would
+// otherwise make the gates report and count that table twice.
+func mergeByTable(changes []tableChange) []tableChange {
+	merged := make([]tableChange, 0, len(changes))
+	index := make(map[string]int, len(changes))
+	for _, change := range changes {
+		if i, ok := index[change.table]; ok {
+			merged[i].updates += change.updates
+			merged[i].deletes += change.deletes
+			continue
+		}
+		index[change.table] = len(merged)
+		merged = append(merged, change)
+	}
+	return merged
 }
 
 // tableRender is a single managed table's rendered migration together with the
@@ -243,9 +262,10 @@ func checkProtected(changes []tableChange, opts Options) error {
 }
 
 // checkDestructive refuses a change set that updates or deletes existing rows
-// unless opts.AllowDestructive is set. The destructive volume is expressed in
-// the shared migration/safety vocabulary so the gate reuses the same
-// destructive-severity definition as the DDL safety report.
+// unless opts.AllowDestructive is set. The row-change volume is expressed as
+// migration/safety findings so the gate speaks the same severity vocabulary as
+// the DDL safety report and defers the destructive verdict to
+// safety.HasDestructive.
 func checkDestructive(changes []tableChange, opts Options) error {
 	if opts.AllowDestructive {
 		return nil
@@ -270,10 +290,14 @@ func checkDestructive(changes []tableChange, opts Options) error {
 		strings.Join(details, ", "))
 }
 
-// destructiveFindings expresses the destructive row-change volume in the shared
-// migration/safety vocabulary, mirroring safety.ClassifySchemaDiff for DDL: an
-// UPDATE overwrites existing row data and a DELETE removes rows, so both are
-// destructive; INSERTs are additive and contribute no finding.
+// destructiveFindings expresses the row-change volume as migration/safety
+// findings, the same shape safety.ClassifySchemaDiff produces for DDL. A DELETE
+// removes rows and an UPDATE overwrites existing row values, so both are marked
+// Destructive here. This is deliberately stricter than the DDL classifier,
+// which treats in-place value rewrites (for example SET EXPRESSION) as a
+// Warning: row data a data migration overwrites in a live database cannot be
+// recovered from the migration alone, so the stricter default is intentional.
+// INSERTs are additive and contribute no finding.
 func destructiveFindings(updates, deletes int) []safety.Finding {
 	var findings []safety.Finding
 	addFinding(&findings, "data_rows_updated", updates)

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -79,7 +79,7 @@ func TestGenerate_ComputesReversibleDataMigration(t *testing.T) {
 	root := t.TempDir()
 	writeRegionsFixture(t, root, driftDesiredRows)
 
-	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root, AllowDestructive: true})
 	c.Assert(err, qt.IsNil)
 
 	// Up reaches the desired state.
@@ -130,7 +130,7 @@ func TestGenerate_RoundTripApply(t *testing.T) {
 	root := t.TempDir()
 	writeRegionsFixture(t, root, driftDesiredRows)
 
-	up, down, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: root})
+	up, down, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: root, AllowDestructive: true})
 	c.Assert(err, qt.IsNil)
 
 	apply := func(script string) {
@@ -194,4 +194,148 @@ func TestGenerate_NilConnection(t *testing.T) {
 
 	_, _, err := datamigrate.Generate(context.Background(), nil, datamigrate.Options{RootDir: t.TempDir()})
 	c.Assert(err, qt.ErrorMatches, `datamigrate: a database connection is required`)
+}
+
+// insertOnlyDesiredRows keeps the live US row unchanged and adds DE, so the
+// diff is a single additive INSERT with no update or delete.
+const insertOnlyDesiredRows = `
+- code: US
+  name: United States
+- code: DE
+  name: Germany
+`
+
+func TestGenerate_DestructiveRefusedByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	// driftDesiredRows updates CZ and deletes XX against this live state.
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "destructive")
+	c.Assert(err.Error(), qt.Contains, "--allow-destructive")
+	// The summary names the affected table and its update/delete volume.
+	c.Assert(err.Error(), qt.Contains, `"regions" (1 update(s), 1 delete(s))`)
+}
+
+func TestGenerate_InsertOnlyAllowedWithoutFlag(t *testing.T) {
+	c := qt.New(t)
+
+	// Only US exists live; the desired set keeps US and adds DE, so the diff is
+	// insert-only and the destructive gate must not fire.
+	conn := newRegionsConn(t, [][2]string{{"US", "United States"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, insertOnlyDesiredRows)
+
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Contains, `INSERT INTO "regions" ("code", "name") VALUES ('DE', 'Germany');`)
+	c.Assert(down, qt.Contains, `DELETE FROM "regions" WHERE "code" = 'DE';`)
+	// An insert-only up contains no destructive statement.
+	c.Assert(up, qt.Not(qt.Contains), "DELETE")
+	c.Assert(up, qt.Not(qt.Contains), "UPDATE")
+}
+
+func TestGenerate_ProtectedTableRefused(t *testing.T) {
+	c := qt.New(t)
+
+	// Insert-only drift, so it is the protected-table gate — not the destructive
+	// gate — that refuses the run.
+	conn := newRegionsConn(t, [][2]string{{"US", "United States"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, insertOnlyDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"regions"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected table(s) regions")
+	c.Assert(err.Error(), qt.Contains, "--allow-prod")
+}
+
+func TestGenerate_ProtectedTableMatchIsCaseInsensitive(t *testing.T) {
+	c := qt.New(t)
+
+	conn := newRegionsConn(t, [][2]string{{"US", "United States"}})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, insertOnlyDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"REGIONS"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected table(s) REGIONS")
+}
+
+func TestGenerate_ProtectedTablePrecedesDestructiveGate(t *testing.T) {
+	c := qt.New(t)
+
+	// The drift is destructive AND touches a protected table; the protected-table
+	// refusal must win so the operator sees the protection first.
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"regions"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "destructive")
+}
+
+func TestGenerate_ProtectedAndDestructiveAllowed(t *testing.T) {
+	c := qt.New(t)
+
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	up, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:          root,
+		ProtectedTables:  []string{"regions"},
+		AllowProd:        true,
+		AllowDestructive: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Contains, `DELETE FROM "regions" WHERE "code" = 'XX';`)
+}
+
+func TestGenerate_ProtectedTableWithNoDriftIsNoOp(t *testing.T) {
+	c := qt.New(t)
+
+	// The protected table has no drift, so there is no change to refuse and the
+	// run is a clean no-op even without --allow-prod.
+	conn := newRegionsConn(t, [][2]string{
+		{"US", "United States"},
+		{"DE", "Germany"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, insertOnlyDesiredRows)
+
+	up, down, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"regions"},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Equals, "")
+	c.Assert(down, qt.Equals, "")
 }

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -339,3 +339,160 @@ func TestGenerate_ProtectedTableWithNoDriftIsNoOp(t *testing.T) {
 	c.Assert(up, qt.Equals, "")
 	c.Assert(down, qt.Equals, "")
 }
+
+func TestGenerate_AllowProdAloneStillRefusesDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	// The drift is destructive and touches the protected table. --allow-prod
+	// clears the protected gate, but the destructive gate must still refuse,
+	// proving --allow-prod cannot mask a destructive change.
+	conn := newRegionsConn(t, [][2]string{
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"regions"},
+		AllowProd:       true,
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "destructive")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "protected")
+}
+
+func TestGenerate_AllowDestructiveAloneStillRefusesProtected(t *testing.T) {
+	c := qt.New(t)
+
+	// Symmetric to the above: --allow-destructive clears the destructive gate,
+	// but the protected gate must still refuse (and take precedence).
+	conn := newRegionsConn(t, [][2]string{
+		{"CZ", "Czech Republic"},
+		{"XX", "Old Name"},
+	})
+	root := t.TempDir()
+	writeRegionsFixture(t, root, driftDesiredRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:          root,
+		ProtectedTables:  []string{"regions"},
+		AllowDestructive: true,
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "destructive")
+}
+
+// newMultiTableConn opens an in-memory SQLite database with "regions" and
+// "countries" tables seeded with the given code/name rows.
+func newMultiTableConn(t *testing.T, regions, countries [][2]string) *dbschema.DatabaseConnection {
+	t.Helper()
+	c := qt.New(t)
+
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite:///:memory:")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	for _, ddl := range []string{
+		`CREATE TABLE regions (code TEXT PRIMARY KEY, name TEXT NOT NULL)`,
+		`CREATE TABLE countries (code TEXT PRIMARY KEY, name TEXT NOT NULL)`,
+	} {
+		_, err := conn.ExecContext(context.Background(), ddl)
+		c.Assert(err, qt.IsNil)
+	}
+	seed := func(table string, rows [][2]string) {
+		for _, r := range rows {
+			_, err := conn.ExecContext(context.Background(),
+				`INSERT INTO `+table+` (code, name) VALUES (?, ?)`, r[0], r[1])
+			c.Assert(err, qt.IsNil)
+		}
+	}
+	seed("regions", regions)
+	seed("countries", countries)
+	return conn
+}
+
+// writeMultiTableFixture writes //migrator:schema:data annotations for both
+// "regions" and "countries" and their YAML rows files into root.
+func writeMultiTableFixture(t *testing.T, root, regionsYAML, countriesYAML string) {
+	t.Helper()
+	c := qt.New(t)
+
+	goSrc := `package fixture
+
+//migrator:schema:data table="regions" key="code" file="regions.yaml"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+
+//migrator:schema:data table="countries" key="code" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"), []byte(regionsYAML), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "countries.yaml"), []byte(countriesYAML), 0o600), qt.IsNil)
+}
+
+const countriesUpdateRows = `
+- code: CZ
+  name: Czechia
+`
+
+func TestGenerate_MultiTableDestructiveSummaryNamesOnlyChangedTable(t *testing.T) {
+	c := qt.New(t)
+
+	// regions: keeps US and adds DE — insert-only. countries: CZ live name
+	// differs from desired — a destructive UPDATE. Only countries must appear in
+	// the destructive summary.
+	conn := newMultiTableConn(t,
+		[][2]string{{"US", "United States"}},
+		[][2]string{{"CZ", "Old Name"}},
+	)
+	root := t.TempDir()
+	writeMultiTableFixture(t, root, insertOnlyDesiredRows, countriesUpdateRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `"countries" (1 update(s), 0 delete(s))`)
+	// regions is insert-only, so it must not be named as destructive.
+	c.Assert(err.Error(), qt.Not(qt.Contains), "regions")
+
+	// With the flag, both tables' changes are generated.
+	up, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{RootDir: root, AllowDestructive: true})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Contains, `INSERT INTO "regions" ("code", "name") VALUES ('DE', 'Germany');`)
+	c.Assert(up, qt.Contains, `UPDATE "countries" SET "name" = 'Czechia' WHERE "code" = 'CZ';`)
+}
+
+func TestGenerate_MultiTableProtectedNamesOnlyProtectedTable(t *testing.T) {
+	c := qt.New(t)
+
+	// Both tables have only insert drift; protecting countries must refuse and
+	// name countries alone, leaving the insert-only regions change unmentioned.
+	conn := newMultiTableConn(t,
+		[][2]string{{"US", "United States"}},
+		nil,
+	)
+	root := t.TempDir()
+	writeMultiTableFixture(t, root, insertOnlyDesiredRows, countriesUpdateRows)
+
+	_, _, err := datamigrate.Generate(context.Background(), conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"countries"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected table(s) countries")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "regions")
+}


### PR DESCRIPTION
## Summary

Closes the safety-gating acceptance-criterion gap from #663. A generated data migration is applied through the ordinary migration path, where **neither the lint nor the safety gate classifies row `INSERT`/`UPDATE`/`DELETE` as destructive** (verified: `safety.assessRawSQL` and `migration/lint` only flag DROP*/TRUNCATE/enum-value removal). So a stray reference-data diff could delete or overwrite live rows at apply time with zero friction. This gates destructive changes at generation time.

## Gates

- **`--allow-destructive`** (default off): `datamigrate.Generate` assesses the change set it computed and refuses a migration that would `UPDATE` or `DELETE` existing rows, reporting the per-table volume. Insert-only migrations are additive and are never gated. This is a deliberately safer default than `ptah migrate generate`'s opt-in `--check-destructive`, justified because there is no downstream DML gate on the apply path.
- **`--protected-table` + `--allow-prod`**: mirrors the protected-target posture of `migration/seeder` — naming a managed table refuses any change to it (insert/update/delete) unless `--allow-prod` is set. Only tables the migration would actually change are considered; matching is case-insensitive. Protected-table refusal takes precedence over the destructive gate.

The destructive volume is expressed in the shared `migration/safety` vocabulary (mirroring `safety.ClassifySchemaDiff`), reusing the same destructive-severity definition as the DDL safety report. Both gates run before any SQL is emitted, so they apply to `--dry-run` too — combine `--allow-destructive --dry-run` to preview a destructive change without writing files.

## Behavior change

`ptah migrations data` (and `datamigrate.Generate`) now refuse destructive diffs by default. The command is brand-new/unreleased (merged in #663 this cycle), so no released behavior changes. The two existing tests that produced destructive diffs now pass `AllowDestructive`.

## Verification

New tests at both layers cover default refusal, insert-only pass-through, the protected-table gate, case-insensitive matching, gate precedence (protected before destructive), and the allow overrides. Locally green: `go build ./...`, `gofmt`, `go vet`, full `go test ./...`, `golangci-lint`, `qtlint`, public-API snapshot (unchanged — the new fields are on an `internal/` type), and the doc-site checks.

Part of #663.