### PR TITLE
Make migration lint analysis immutable and compatibility-scoped

### DIFF
--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -806,12 +806,6 @@
     },
     {
       "path": "migration/lint/lint_test.go",
-      "function": "TestLintFS_CustomRuleAndPrepareFSUsePublicScanner",
-      "kind": "if",
-      "count": 2
-    },
-    {
-      "path": "migration/lint/lint_test.go",
       "function": "TestLintFS_DialectAwareScanning",
       "kind": "if",
       "count": 1

--- a/cmd/atlas/atlas_lint_devurl_test.go
+++ b/cmd/atlas/atlas_lint_devurl_test.go
@@ -98,7 +98,7 @@ func TestNewAtlasCommand_MigrateLintUsesAtlasProjectEnvPolicy(t *testing.T) {
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, `"rule":"DS102"`)
+	c.Assert(out.String(), qt.Contains, `"rule":"DS103"`)
 	c.Assert(out.String(), qt.Contains, `"severity":"warning"`)
 }
 

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -884,7 +884,7 @@ env "ci" {
 	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil)
 	c.Assert(report.Files, qt.HasLen, 1)
 	c.Assert(report.Files[0].Findings, qt.HasLen, 1)
-	c.Assert(report.Files[0].Findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(report.Files[0].Findings[0].Rule, qt.Equals, "DS103")
 	c.Assert(report.Files[0].Findings[0].Severity, qt.Equals, migrationlint.SeverityWarning)
 }
 

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"strings"
 
@@ -18,7 +17,9 @@ import (
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/migrationlintreport"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/internal/pathguard"
+	migrationlint "github.com/stokaro/ptah/migration/lint"
 )
 
 const atlasMigrateLintFindingError = "lint findings exceed the failure threshold"
@@ -107,8 +108,11 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("resolve migration directory: %w", err))
 	}
-	fsys := os.DirFS(dir)
-	integrity, err := atlasreport.InspectMigrateLintIntegrity(fsys)
+	snapshot, err := migrationsnapshot.Capture(os.DirFS(dir))
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	integrity, err := atlasreport.InspectMigrateLintIntegrity(snapshot)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -122,7 +126,6 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 				Driver:    driver,
 				URL:       opts.devURL,
 				Dir:       dir,
-				FS:        fsys,
 				Integrity: integrity,
 			}); err != nil {
 				return cmdutil.Fail(cmd, err)
@@ -135,14 +138,16 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 	}
 
 	report, err := migrationlintreport.Build(cmd.Context(), migrationlintreport.Options{
-		Dir:       dir,
-		DirFormat: dirFormat,
-		AtlasEnv:  opts.atlasEnv,
-		DevURL:    opts.devURL,
-		GitBase:   opts.gitBase,
-		GitDir:    opts.gitDir,
-		FailOn:    migrationlintreport.FailOnError,
-		Latest:    opts.latest,
+		Dir:           dir,
+		FS:            snapshot,
+		DirFormat:     dirFormat,
+		AtlasEnv:      opts.atlasEnv,
+		DevURL:        opts.devURL,
+		GitBase:       opts.gitBase,
+		GitDir:        opts.gitDir,
+		FailOn:        migrationlintreport.FailOnError,
+		Latest:        opts.latest,
+		Compatibility: migrationlint.CompatibilityProfileAtlas,
 		Changed: migrationlintreport.ChangedOptions{
 			Dir:       true,
 			DirFormat: true,
@@ -155,7 +160,7 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 	}, atlasMigrateLintReportConfig(projectCfg))
 	if err != nil {
 		if formatOutput {
-			if err := writeAtlasMigrateLintReplayError(cmd, opts, dir, fsys, integrity, err); err != nil {
+			if err := writeAtlasMigrateLintReplayError(cmd, opts, dir, report, integrity, err); err != nil {
 				return cmdutil.Fail(cmd, err)
 			}
 			return exitcode.New(1, err)
@@ -167,9 +172,7 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 			Driver:    report.Dialect,
 			URL:       opts.devURL,
 			Dir:       dir,
-			FS:        fsys,
-			Findings:  report.Findings,
-			Versions:  report.Versions,
+			Analysis:  &report.Analysis,
 			Integrity: integrity,
 			Error:     report.Error,
 		}); err != nil {
@@ -193,7 +196,7 @@ func writeAtlasMigrateLintReplayError(
 	cmd *cobra.Command,
 	opts atlasMigrateLintOptions,
 	dir string,
-	fsys fs.FS,
+	report migrationlintreport.Report,
 	integrity atlasreport.MigrateLintIntegrity,
 	replayErr error,
 ) error {
@@ -205,7 +208,7 @@ func writeAtlasMigrateLintReplayError(
 		Driver:    driver,
 		URL:       opts.devURL,
 		Dir:       dir,
-		FS:        fsys,
+		Analysis:  &report.Analysis,
 		Integrity: integrity,
 		Error:     replayErr.Error(),
 	})

--- a/cmd/internal/dbcli/preflight.go
+++ b/cmd/internal/dbcli/preflight.go
@@ -5,10 +5,30 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 
 	"github.com/stokaro/ptah/internal/preflight"
 	"github.com/stokaro/ptah/migration/migrator"
 )
+
+// CombineMigrationHooks returns one hook that runs each non-nil hook in order
+// and stops at the first error. It returns nil when no hooks are configured.
+func CombineMigrationHooks(hooks ...migrator.PreMigrationHook) migrator.PreMigrationHook {
+	hooks = slices.DeleteFunc(slices.Clone(hooks), func(hook migrator.PreMigrationHook) bool {
+		return hook == nil
+	})
+	if len(hooks) == 0 {
+		return nil
+	}
+	return func(ctx context.Context, plan migrator.MigrationPlan) error {
+		for _, hook := range hooks {
+			if err := hook(ctx, plan); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
 // MigrationPreflightReporter writes pre-flight progress messages.
 type MigrationPreflightReporter interface {

--- a/cmd/internal/dbcli/preflight_test.go
+++ b/cmd/internal/dbcli/preflight_test.go
@@ -1,0 +1,60 @@
+package dbcli_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestCombineMigrationHooks_NoHooks(t *testing.T) {
+	c := qt.New(t)
+
+	hook := dbcli.CombineMigrationHooks(nil)
+
+	c.Assert(hook, qt.IsNil)
+}
+
+func TestCombineMigrationHooks_RunsNonNilHooksInOrder(t *testing.T) {
+	c := qt.New(t)
+	var calls []string
+	plan := migrator.MigrationPlan{Versions: []int64{1, 2}}
+	first := func(context.Context, migrator.MigrationPlan) error {
+		calls = append(calls, "first")
+		return nil
+	}
+	second := func(context.Context, migrator.MigrationPlan) error {
+		calls = append(calls, "second")
+		return nil
+	}
+
+	hook := dbcli.CombineMigrationHooks(first, nil, second)
+	err := hook(context.Background(), plan)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(calls, qt.DeepEquals, []string{"first", "second"})
+}
+
+func TestCombineMigrationHooks_StopsAtFirstError(t *testing.T) {
+	c := qt.New(t)
+	var calls []string
+	wantErr := errors.New("stop")
+	first := func(context.Context, migrator.MigrationPlan) error {
+		calls = append(calls, "first")
+		return wantErr
+	}
+	second := func(context.Context, migrator.MigrationPlan) error {
+		calls = append(calls, "second")
+		return nil
+	}
+
+	hook := dbcli.CombineMigrationHooks(first, second)
+	err := hook(context.Background(), migrator.MigrationPlan{})
+
+	c.Assert(err, qt.ErrorIs, wantErr)
+	c.Assert(calls, qt.DeepEquals, []string{"first"})
+}

--- a/cmd/migrateup/lint_internal_test.go
+++ b/cmd/migrateup/lint_internal_test.go
@@ -1,0 +1,137 @@
+package migrateup
+
+// White-box testing required: lintPendingDestructive is the native command's
+// final safety-gate adapter and its compatibility profile is not observable
+// through an exported API without opening a real database connection.
+
+import (
+	"context"
+	"io/fs"
+	"slices"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_drop.up.sql": {
+			Data: []byte("-- atlas:nolint destructive\n\nDROP TABLE users;\n"),
+		},
+		"0000000001_drop.down.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+	}
+
+	findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+}
+
+func TestCapturedMigrationsFeedProviderAndDestructiveGateFromSameBytes(t *testing.T) {
+	c := qt.New(t)
+	source := &changingMigrationFS{
+		files: fstest.MapFS{
+			"0000000001_drop.up.sql": {
+				Data: []byte("DROP TABLE users;\n"),
+			},
+			"0000000001_drop.down.sql": {
+				Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+			},
+		},
+		reads: map[string]int{},
+	}
+
+	snapshot, err := migrationsnapshot.Capture(source)
+	c.Assert(err, qt.IsNil)
+	provider, err := migrator.NewFSMigrationProvider(
+		snapshot,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatPtah),
+	)
+	c.Assert(err, qt.IsNil)
+	findings, err := lintPendingDestructive(snapshot, []int64{1}, "sqlite")
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].UpSQL, qt.Equals, "DROP TABLE users;\n")
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+	c.Assert(source.reads, qt.DeepEquals, map[string]int{
+		"0000000001_drop.down.sql": 1,
+		"0000000001_drop.up.sql":   1,
+	})
+}
+
+func TestLockedDestructiveLintHookUsesLockedPlanVersions(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_create.up.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+		"0000000001_create.down.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"0000000002_drop.up.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"0000000002_drop.down.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+	}
+	hook := lockedDestructiveLintHook(fsys, "sqlite")
+
+	err := hook(context.Background(), migrator.MigrationPlan{
+		Versions: []int64{2},
+	})
+
+	c.Assert(err, qt.ErrorMatches, "(?s)pending migrations contain destructive statements.*0000000002_drop.up.sql.*DS101.*")
+}
+
+func TestLockedDestructiveLintHookAllowsSafeLockedPlan(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_create.up.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+		"0000000001_create.down.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"0000000002_drop.up.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"0000000002_drop.down.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+	}
+	hook := lockedDestructiveLintHook(fsys, "sqlite")
+
+	err := hook(context.Background(), migrator.MigrationPlan{
+		Versions: []int64{1},
+	})
+
+	c.Assert(err, qt.IsNil)
+}
+
+type changingMigrationFS struct {
+	files fstest.MapFS
+	reads map[string]int
+}
+
+func (f *changingMigrationFS) Open(name string) (fs.File, error) {
+	return f.files.Open(name)
+}
+
+func (f *changingMigrationFS) ReadFile(name string) ([]byte, error) {
+	f.reads[name]++
+	contents, err := fs.ReadFile(f.files, name)
+	responses := [][]byte{contents, []byte("SELECT 1;\n")}
+	return slices.Clone(responses[min(f.reads[name]-1, 1)]), err
+}

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/internal/onlineddl"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/internal/preflight"
@@ -260,11 +261,15 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	if err != nil {
 		return err
 	}
+	migrationsFS, err := migrationsnapshot.Capture(os.DirFS(migrationsDir))
+	if err != nil {
+		return fmt.Errorf("capture migrations directory: %w", err)
+	}
 
 	// Integrity gate: refuse to apply if a committed migration was edited
 	// out of band. Runs before connecting so a tampered directory fails fast.
 	if opts.verifySum {
-		result, err := migratesum.VerifyDirWithFormat(migrationsDir, settings.dirFormat)
+		result, err := migratesum.VerifyWithFormat(migrationsFS, settings.dirFormat)
 		if err != nil {
 			return fmt.Errorf("migration sum verification failed: %w", err)
 		}
@@ -308,9 +313,6 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	emit.Printf("Migration directory format: %s\n", settings.dirFormat)
 	emit.Printf("Transaction mode: %s\n", settings.txMode)
 	emit.Println()
-
-	// Create filesystem from migrations directory
-	migrationsFS := os.DirFS(migrationsDir)
 
 	// Online-DDL routing: `-- +ptah online_ddl_tool=...` directives always
 	// work; the ptah.yaml online_ddl section adds automatic routing of
@@ -376,16 +378,6 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 		return migrator.NewOutOfOrderError(status.CurrentVersion, status.OutOfOrderMigrations)
 	}
 
-	if !opts.allowDestructive {
-		findings, err := lintPendingDestructive(migrationsFS, pendingMigrationsForRun(status, settings.execOrder), conn.Info().Dialect)
-		if err != nil {
-			return fmt.Errorf("error checking pending migration safety: %w", err)
-		}
-		if len(findings) > 0 {
-			return fmt.Errorf("pending migrations contain destructive statements; rerun with --allow-destructive after review:\n%s", formatDestructiveFindings(findings))
-		}
-	}
-
 	emit.Println()
 	preflightHook := dbcli.LockedMigrationPreflightHook(opts.dryRun, preflight.Options{
 		Direction:          preflight.DirectionUp,
@@ -397,6 +389,12 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 		MySQLDumpDir:       mySQLDumpTo,
 		WebhookURL:         webhook,
 	}, emit, cliobs.NewOutputWriter(cmd.OutOrStdout(), runtime, "pre-flight output"))
+	if !opts.allowDestructive {
+		preflightHook = dbcli.CombineMigrationHooks(
+			lockedDestructiveLintHook(migrationsFS, conn.Info().Dialect),
+			preflightHook,
+		)
+	}
 
 	// Run migrations
 	err = mig.MigrateUpWithPreflight(context.Background(), preflightHook)
@@ -434,35 +432,18 @@ func shutdownObservability(runtime *cliobs.Runtime) {
 	}
 }
 
-func pendingMigrationsForRun(status *migrator.MigrationStatus, execOrder migrator.ExecOrder) []int64 {
-	if execOrder != migrator.ExecOrderLinearSkip {
-		return status.PendingMigrations
-	}
-
-	outOfOrder := make(map[int64]struct{}, len(status.OutOfOrderMigrations))
-	for _, version := range status.OutOfOrderMigrations {
-		outOfOrder[version] = struct{}{}
-	}
-
-	pending := make([]int64, 0, len(status.PendingMigrations))
-	for _, version := range status.PendingMigrations {
-		if _, ok := outOfOrder[version]; ok {
-			continue
-		}
-		pending = append(pending, version)
-	}
-	return pending
-}
-
 func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint.Finding, error) {
 	cfg, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
 	if err != nil {
 		return nil, err
 	}
 	findings, err := lint.LintFS(fsys, lint.Options{
-		Dialect:     dialect,
-		Disabled:    append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
-		Versions:    pending,
+		Dialect:  dialect,
+		Disabled: append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
+		Selection: lint.VersionSelection{
+			Versions:   pending,
+			Restricted: true,
+		},
 		RuleConfigs: cfg.Rules,
 	})
 	if err != nil {
@@ -475,6 +456,22 @@ func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint
 		}
 	}
 	return destructive, nil
+}
+
+func lockedDestructiveLintHook(fsys fs.FS, dialect string) migrator.PreMigrationHook {
+	return func(_ context.Context, plan migrator.MigrationPlan) error {
+		findings, err := lintPendingDestructive(fsys, plan.Versions, dialect)
+		if err != nil {
+			return fmt.Errorf("error checking pending migration safety: %w", err)
+		}
+		if len(findings) > 0 {
+			return fmt.Errorf(
+				"pending migrations contain destructive statements; rerun with --allow-destructive after review:\n%s",
+				formatDestructiveFindings(findings),
+			)
+		}
+		return nil
+	}
 }
 
 func formatDestructiveFindings(findings []lint.Finding) string {

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -424,31 +424,6 @@ func TestMigrateUpCommandDryRunSkipsPreflightSideEffects(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
-func TestPendingMigrationsForRunSkipsOutOfOrderWhenLinearSkip(t *testing.T) {
-	c := qt.New(t)
-
-	status := &migrator.MigrationStatus{
-		PendingMigrations:    []int64{3, 6},
-		OutOfOrderMigrations: []int64{3},
-	}
-
-	c.Assert(
-		pendingMigrationsForRun(status, migrator.ExecOrderLinear),
-		qt.DeepEquals,
-		[]int64{3, 6},
-	)
-	c.Assert(
-		pendingMigrationsForRun(status, migrator.ExecOrderNonLinear),
-		qt.DeepEquals,
-		[]int64{3, 6},
-	)
-	c.Assert(
-		pendingMigrationsForRun(status, migrator.ExecOrderLinearSkip),
-		qt.DeepEquals,
-		[]int64{6},
-	)
-}
-
 func TestDatabaseURLPasswordsForTest(t *testing.T) {
 	c := qt.New(t)
 

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -46,6 +46,16 @@ packages importable directly.
 online-DDL policy is parsed, merged, validated, and then passed to migration
 execution without a second configuration-file read.
 
+`migration/lint` provides the compact `LintFS` findings API and the richer
+`AnalyzeFS` API. `AnalyzeFS` captures each migration input once: SQL files,
+integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
+prepared files and findings together with a read-only source snapshot. Finding
+contexts identify the exact statement and affected tables or columns; column
+subjects can also carry the parent table and declared data type. Atlas-ignored
+files are marked explicitly without changing version selection.
+Compatibility-specific directive behavior must be selected explicitly; native
+Ptah behavior is the zero-value default.
+
 Public failures from these packages should use `core/ptaherr` where the caller
 can reasonably branch on the error. In particular, annotation failures should
 support `errors.As(err, *ptaherr.ParseError)`, and unsupported dialect failures

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -739,20 +739,29 @@ func Parsers() []Parser
 const ConfigFileName = ".ptah-lint.yaml"
 func Describe(f Finding) string
 func Register(rule Rule) error
+type Analysis struct{ ... }
+    func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error)
+type CompatibilityProfile string
+    const CompatibilityProfileNative CompatibilityProfile = "" ...
 type Config struct{ ... }
     func LoadConfig(path string) (*Config, error)
     func LoadConfigFS(fsys fs.FS, name string) (*Config, error)
 type File struct{ ... }
-    func PrepareFS(fsys fs.FS, opts Options) ([]*File, error)
 type Finding struct{ ... }
     func LintFS(fsys fs.FS, opts Options) ([]Finding, error)
+type FindingContext struct{ ... }
 type Options struct{ ... }
 type Rule struct{ ... }
     func Rules() []Rule
 type RuleConfig struct{ ... }
 type Severity = risk.Severity
     const SeverityWarning Severity = risk.Warning ...
+type SourceSpan struct{ ... }
 type Statement struct{ ... }
+type Subject struct{ ... }
+type SubjectKind string
+    const SubjectTable SubjectKind = "table" ...
+type VersionSelection struct{ ... }
 
 ## github.com/stokaro/ptah/migration/migrator
 

--- a/docs/site/src/content/docs/reference/public-api.md
+++ b/docs/site/src/content/docs/reference/public-api.md
@@ -24,7 +24,7 @@ packages, examples, fixtures, tests, or implementation details.
 | `dbschema` | Live database schema introspection connection layer. |
 | `dbschema/types` | Shared database schema types. |
 | `migration/generator` | Migration file generation. |
-| `migration/lint` | Migration SQL linting rules and findings. |
+| `migration/lint` | Migration SQL linting rules, immutable analysis snapshots, and findings. |
 | `migration/migrator` | Migration providers, revision metadata, dry-run plans, and execution. |
 | `migration/planner` | Schema change planning. |
 | `migration/risk` | Migration risk classification. |

--- a/docs/site/src/content/docs/reference/reusable-components.md
+++ b/docs/site/src/content/docs/reference/reusable-components.md
@@ -291,6 +291,53 @@ if len(findings) > 0 {
 }
 ```
 
+Use `lint.AnalyzeFS` when more than findings are needed. It captures every SQL
+file plus migration metadata (`atlas.sum`, `ptah.sum`, and
+`.ptah-lint.yaml`) once and excludes unrelated files. The immutable result
+contains prepared files, exact statement spans, finding-to-statement contexts,
+and a read-only filesystem snapshot. Replay, checksum, report, and
+migration-provider code can consume that snapshot without reopening a changing
+migration directory:
+
+```go
+analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+	Dialect: "postgres",
+	Selection: lint.VersionSelection{
+		Versions:   []int64{42, 43},
+		Restricted: true,
+	},
+})
+if err != nil {
+	return err
+}
+
+selected := analysis.SelectedFiles()
+findings := analysis.Findings()
+snapshot := analysis.SnapshotFS()
+fmt.Printf("linted %d of %d files and found %d issues\n",
+	len(selected), len(analysis.Files()), len(findings))
+
+m, err := migrator.NewFSMigrator(conn, snapshot)
+if err != nil {
+	return err
+}
+_ = m
+```
+
+`VersionSelection.Restricted` distinguishes no selector from an explicitly
+empty changeset. Native Ptah callers should keep the zero-value
+`CompatibilityProfileNative`; `CompatibilityProfileAtlas` exists for
+Atlas-compatible command adapters and enables Atlas-specific `nolint` aliases
+and file-header semantics without changing native safety behavior.
+
+Each finding context identifies its zero-based statement index. Structured
+subjects preserve the executable identifier spelling: table subjects use
+`SubjectTable`; column subjects use `SubjectColumn` and can include `Parent`
+and `DataType`. In Atlas compatibility mode, a bare file-header
+`-- atlas:nolint` marks `File.Ignored`; it does not merely clear the file's
+findings. Report adapters should omit ignored files while retaining them in the
+captured snapshot.
+
 ### Use Capabilities
 
 Use capabilities when syntax depends on a dialect version rather than only a

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -393,6 +393,27 @@ tables, replays the migration directory, and then runs static lint
 reporting. Docker `--dev-url` values remain an explicit gap; use a directly
 connectable database URL.
 
+The command captures the migration directory once before checking `atlas.sum`,
+selecting `--latest` versions, replaying migrations, and rendering reports.
+Checksum status, findings, statement metadata, and formatted output therefore
+describe the same immutable inputs.
+
+Ptah also validates and fully loads the migration provider, including Atlas
+templates, before dropping any objects from the dev database. A malformed
+migration directory therefore leaves the existing dev database state intact;
+cleanup starts only after the replay plan is valid.
+
+Atlas-compatible lint directives are enabled only under the
+`ptah atlas migrate lint` compatibility profile. A statement-local
+`-- atlas:nolint <selector>` suppresses the following statement. A first
+nonempty `-- atlas:nolint <selector>` header followed by a blank line applies
+to the whole file. A bare file header ignores the file completely, so it is
+absent from `.Files` and per-file analysis steps. Supported analyzer selectors
+are `destructive`, `data_depend`, `concurrent_index`, `incompatible`, and
+`nestedtx`; supported Atlas diagnostic aliases are `DS102`, `DS103`, and
+`MF103`. Native lint and migrate-up safety keep their native directive
+semantics unless the Atlas compatibility profile is selected explicitly.
+
 Atlas-compatible migration metadata commands default to Atlas directory format.
 `ptah atlas migrate hash`, `lint`, `new`, `set`, `status`, and `validate`
 register `--dir-format` with Atlas's default value `atlas`. The supported value

--- a/docs/site/src/content/docs/workflows/migrations.md
+++ b/docs/site/src/content/docs/workflows/migrations.md
@@ -126,6 +126,10 @@ ptah migrations up \
 
 Destructive statements require explicit policy. Use `--allow-destructive` only
 after the plan has been reviewed and the rollback path is understood.
+`ptah migrations up` captures the migration directory before checksum
+verification, provider registration, and destructive linting. The safety gate
+therefore checks the same immutable SQL bytes that the migrator will execute,
+even if files on disk change while the command is running.
 
 ### Pre-migration checks
 

--- a/internal/atlaslint/rules.go
+++ b/internal/atlaslint/rules.go
@@ -1,0 +1,63 @@
+// Package atlaslint maps Ptah migration lint rules to Atlas-compatible
+// analyzer names, diagnostic codes, and suppression selectors.
+package atlaslint
+
+import "strings"
+
+const (
+	AnalyzerConcurrentIndex = "concurrent_index"
+	AnalyzerDataDependent   = "data_depend"
+	AnalyzerDestructive     = "destructive"
+	AnalyzerIncompatible    = "incompatible"
+	AnalyzerNestedTX        = "nestedtx"
+	AnalyzerPtah            = "ptah"
+)
+
+// Rule identifies one Atlas-compatible analyzer diagnostic.
+type Rule struct {
+	Analyzer string
+	Code     string
+}
+
+// RuleForNativeCode returns the Atlas-compatible identity for a native Ptah
+// rule. Rules without a proven Atlas identity remain Ptah diagnostics so
+// overlapping code spaces cannot silently change their meaning.
+func RuleForNativeCode(code string) Rule {
+	switch code {
+	case "DS101":
+		return Rule{Analyzer: AnalyzerDestructive, Code: "DS102"}
+	case "DS102":
+		return Rule{Analyzer: AnalyzerDestructive, Code: "DS103"}
+	case "DD101":
+		return Rule{Analyzer: AnalyzerDataDependent, Code: "MF103"}
+	default:
+		return Rule{Analyzer: AnalyzerPtah, Code: code}
+	}
+}
+
+// NativeSuppressionTargets translates one Atlas nolint selector into native
+// Ptah rule codes or families. Unknown Atlas diagnostic codes intentionally do
+// not fall through to same-named Ptah rules because the two code spaces overlap
+// with different meanings.
+func NativeSuppressionTargets(selector string) []string {
+	switch strings.ToLower(strings.TrimSpace(selector)) {
+	case AnalyzerDestructive:
+		return []string{"DS", "CD"}
+	case AnalyzerDataDependent:
+		return []string{"DD"}
+	case AnalyzerConcurrentIndex:
+		return []string{"PG101", "PG103"}
+	case AnalyzerIncompatible:
+		return []string{"BC"}
+	case AnalyzerNestedTX:
+		return []string{"TX201"}
+	case "ds102":
+		return []string{"DS101"}
+	case "ds103":
+		return []string{"DS102"}
+	case "mf103":
+		return []string{"DD101"}
+	default:
+		return nil
+	}
+}

--- a/internal/atlaslint/rules_test.go
+++ b/internal/atlaslint/rules_test.go
@@ -1,0 +1,110 @@
+package atlaslint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlaslint"
+)
+
+func TestRuleForNativeCode(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		code string
+		want atlaslint.Rule
+	}{
+		{
+			name: "table drop",
+			code: "DS101",
+			want: atlaslint.Rule{Analyzer: atlaslint.AnalyzerDestructive, Code: "DS102"},
+		},
+		{
+			name: "column drop",
+			code: "DS102",
+			want: atlaslint.Rule{Analyzer: atlaslint.AnalyzerDestructive, Code: "DS103"},
+		},
+		{
+			name: "data dependent",
+			code: "DD101",
+			want: atlaslint.Rule{Analyzer: atlaslint.AnalyzerDataDependent, Code: "MF103"},
+		},
+		{
+			name: "overlapping native fallback",
+			code: "DS103",
+			want: atlaslint.Rule{Analyzer: atlaslint.AnalyzerPtah, Code: "DS103"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got := atlaslint.RuleForNativeCode(tt.code)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestNativeSuppressionTargets(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		selector string
+		want     []string
+	}{
+		{
+			name:     "destructive analyzer",
+			selector: "destructive",
+			want:     []string{"DS", "CD"},
+		},
+		{
+			name:     "data dependent analyzer",
+			selector: "data_depend",
+			want:     []string{"DD"},
+		},
+		{
+			name:     "concurrent index analyzer",
+			selector: "concurrent_index",
+			want:     []string{"PG101", "PG103"},
+		},
+		{
+			name:     "incompatible analyzer",
+			selector: "incompatible",
+			want:     []string{"BC"},
+		},
+		{
+			name:     "nested transaction analyzer",
+			selector: "nestedtx",
+			want:     []string{"TX201"},
+		},
+		{
+			name:     "Atlas table drop",
+			selector: "DS102",
+			want:     []string{"DS101"},
+		},
+		{
+			name:     "Atlas column drop",
+			selector: "DS103",
+			want:     []string{"DS102"},
+		},
+		{
+			name:     "Atlas data dependent",
+			selector: "MF103",
+			want:     []string{"DD101"},
+		},
+		{
+			name:     "overlapping unknown code",
+			selector: "DS101",
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got := atlaslint.NativeSuppressionTargets(tt.selector)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}

--- a/internal/atlasreport/migrate_lint.go
+++ b/internal/atlasreport/migrate_lint.go
@@ -1,6 +1,7 @@
 package atlasreport
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stokaro/ptah/internal/atlaslint"
 	"github.com/stokaro/ptah/internal/migratesum"
 	migrationlint "github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -19,9 +21,7 @@ type MigrateLintOptions struct {
 	Driver    string
 	URL       string
 	Dir       string
-	FS        fs.FS
-	Findings  []migrationlint.Finding
-	Versions  []int64
+	Analysis  *migrationlint.Analysis
 	Integrity MigrateLintIntegrity
 	Error     string
 }
@@ -45,10 +45,11 @@ type MigrateLintStep struct {
 }
 
 type MigrateLintFile struct {
-	Name     string                  `json:"Name,omitempty"`
-	Text     string                  `json:"Text,omitempty"`
-	Error    string                  `json:"Error,omitempty"`
-	Findings []migrationlint.Finding `json:"Findings,omitempty"`
+	Name       string                  `json:"Name,omitempty"`
+	Text       string                  `json:"Text,omitempty"`
+	Error      string                  `json:"Error,omitempty"`
+	Findings   []migrationlint.Finding `json:"Findings,omitempty"`
+	sourcePath string
 }
 
 func WriteMigrateLintFormat(w io.Writer, format string, opts MigrateLintOptions) error {
@@ -72,7 +73,7 @@ func NewMigrateLint(opts MigrateLintOptions) (MigrateLint, error) {
 		},
 	}
 	if opts.Integrity.Failed() {
-		result.Steps = migrateLintSteps(nil, opts.Integrity, "")
+		result.Steps = migrateLintSteps(nil, 0, opts.Integrity, "")
 		result.Files = []MigrateLintFile{
 			{
 				Name:  migratesum.AtlasFileName,
@@ -82,13 +83,12 @@ func NewMigrateLint(opts MigrateLintOptions) (MigrateLint, error) {
 		return result, nil
 	}
 
-	files, err := migrateLintFiles(opts.FS)
-	if err != nil {
-		return MigrateLint{}, err
+	if opts.Analysis == nil {
+		return MigrateLint{}, fmt.Errorf("migration lint analysis is required")
 	}
-	files = migrateLintSelectedFiles(files, opts.Versions)
-	files = attachMigrateLintFindings(files, opts.Findings)
-	result.Steps = migrateLintSteps(files, opts.Integrity, opts.Error)
+	files, total := migrateLintFiles(*opts.Analysis)
+	files = attachMigrateLintFindings(files, opts.Analysis.Findings())
+	result.Steps = migrateLintSteps(files, total, opts.Integrity, opts.Error)
 	result.Files = files
 	return result, nil
 }
@@ -115,52 +115,63 @@ func (i MigrateLintIntegrity) Failed() bool {
 	return i.Checked && i.Error != ""
 }
 
-func migrateLintFiles(fsys fs.FS) ([]MigrateLintFile, error) {
-	discovered, err := migrator.DiscoverMigrationFiles(fsys, migrator.MigrationDirFormatAtlas)
-	if err != nil {
-		return nil, fmt.Errorf("discover Atlas migration files: %w", err)
-	}
-	files := make([]MigrateLintFile, 0, len(discovered))
-	for _, file := range discovered {
-		if file.Repeatable || file.Direction == "down" {
+func migrateLintFiles(analysis migrationlint.Analysis) ([]MigrateLintFile, int) {
+	prepared := analysis.Files()
+	slices.SortStableFunc(prepared, func(a, b migrationlint.File) int {
+		return cmp.Or(cmp.Compare(a.Version, b.Version), strings.Compare(a.Name, b.Name))
+	})
+	files := make([]MigrateLintFile, 0, len(prepared))
+	total := 0
+	for _, file := range prepared {
+		if file.Repeatable || file.Direction != "up" || file.Ignored {
 			continue
 		}
-		raw, err := fs.ReadFile(fsys, file.Path)
-		if err != nil {
-			return nil, fmt.Errorf("read migration file %s: %w", file.Path, err)
+		total++
+		if !file.Selected {
+			continue
 		}
 		files = append(files, MigrateLintFile{
-			Name: file.Path,
-			Text: string(raw),
+			Name:       file.Name,
+			Text:       file.Source,
+			sourcePath: file.Path,
 		})
 	}
-	return files, nil
+	return files, total
 }
 
 func attachMigrateLintFindings(
 	files []MigrateLintFile,
 	findings []migrationlint.Finding,
 ) []MigrateLintFile {
-	for i := range files {
-		name := files[i].Name
-		for _, finding := range findings {
-			if sameMigrateLintFile(name, finding.File) {
-				files[i].Findings = append(files[i].Findings, finding)
+	for _, finding := range findings {
+		for i := range files {
+			if sameMigrateLintFile(files[i].sourcePath, finding.File) {
+				files[i].Findings = append(files[i].Findings, atlasMigrateLintFinding(finding))
 			}
 		}
 	}
 	return files
 }
 
-func sameMigrateLintFile(name, findingPath string) bool {
+func sameMigrateLintFile(sourcePath, findingPath string) bool {
 	if findingPath == "" {
 		return false
 	}
-	return path.Base(findingPath) == path.Base(name) ||
-		strings.TrimPrefix(path.Clean(findingPath), "./") == strings.TrimPrefix(path.Clean(name), "./")
+	cleanFinding := strings.TrimPrefix(path.Clean(findingPath), "./")
+	return cleanFinding == strings.TrimPrefix(path.Clean(sourcePath), "./")
 }
 
-func migrateLintSteps(files []MigrateLintFile, integrity MigrateLintIntegrity, errText string) []MigrateLintStep {
+func atlasMigrateLintFinding(finding migrationlint.Finding) migrationlint.Finding {
+	finding.Rule = atlaslint.RuleForNativeCode(finding.Rule).Code
+	return finding
+}
+
+func migrateLintSteps(
+	files []MigrateLintFile,
+	total int,
+	integrity MigrateLintIntegrity,
+	errText string,
+) []MigrateLintStep {
 	steps := make([]MigrateLintStep, 0, len(files)+3)
 	if integrity.Checked {
 		step := MigrateLintStep{
@@ -176,7 +187,7 @@ func migrateLintSteps(files []MigrateLintFile, integrity MigrateLintIntegrity, e
 	}
 	steps = append(steps, MigrateLintStep{
 		Name: "Detect New Migration Files",
-		Text: fmt.Sprintf("Found %d new migration files (from %d total)", len(files), len(files)),
+		Text: fmt.Sprintf("Found %d new migration files (from %d total)", len(files), total),
 	})
 	if errText != "" {
 		return append(steps, MigrateLintStep{
@@ -197,26 +208,4 @@ func migrateLintSteps(files []MigrateLintFile, integrity MigrateLintIntegrity, e
 		})
 	}
 	return steps
-}
-
-func migrateLintSelectedFiles(files []MigrateLintFile, versions []int64) []MigrateLintFile {
-	if len(versions) == 0 {
-		return files
-	}
-	out := make([]MigrateLintFile, 0, len(files))
-	for _, file := range files {
-		version := migrateLintVersion(file.Name)
-		if slices.Contains(versions, version) {
-			out = append(out, file)
-		}
-	}
-	return out
-}
-
-func migrateLintVersion(name string) int64 {
-	parsed, err := migrator.ParseAtlasMigrationFileName(path.Base(name))
-	if err != nil {
-		return 0
-	}
-	return parsed.Version
 }

--- a/internal/atlasreport/migrate_lint_test.go
+++ b/internal/atlasreport/migrate_lint_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	migrationlint "github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -19,29 +20,28 @@ func TestWriteMigrateLintFormat_CustomTemplate(t *testing.T) {
 		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id integer);")},
 		"2_drop_users.sql":   {Data: []byte("DROP TABLE users;")},
 	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Selection: migrationlint.VersionSelection{
+			Versions:   []int64{2},
+			Restricted: true,
+		},
+	})
+	c.Assert(err, qt.IsNil)
 	redactionURL := "postgres://app:" + "secret" + "@db.local/app?token=" + "secret" + "&sslmode=disable"
 	var out bytes.Buffer
 
-	err := atlasreport.WriteMigrateLintFormat(&out,
-		`{{ .Env.Driver }}|{{ len .Files }}|{{ (index .Files 0).Name }}|{{ len (index .Files 0).Findings }}|{{ len .Steps }}`,
+	err = atlasreport.WriteMigrateLintFormat(&out,
+		`{{ .Env.Driver }}|{{ len .Files }}|{{ (index .Files 0).Name }}|{{ len (index .Files 0).Findings }}|{{ len .Steps }}|{{ (index .Steps 0).Text }}`,
 		atlasreport.MigrateLintOptions{
 			Driver:   "sqlite",
 			URL:      redactionURL,
 			Dir:      "/migrations",
-			FS:       fsys,
-			Versions: []int64{2},
-			Findings: []migrationlint.Finding{
-				{
-					Rule:     "DS101",
-					Severity: migrationlint.SeverityError,
-					File:     "2_drop_users.sql",
-					Message:  "DROP TABLE permanently deletes table data",
-				},
-			},
+			Analysis: &analysis,
 		})
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Equals, "sqlite|1|2_drop_users.sql|1|3")
+	c.Assert(out.String(), qt.Equals, "sqlite|1|2_drop_users.sql|1|3|Found 1 new migration files (from 2 total)")
 }
 
 func TestWriteMigrateLintFormat_JSONFiles(t *testing.T) {
@@ -49,15 +49,146 @@ func TestWriteMigrateLintFormat_JSONFiles(t *testing.T) {
 	fsys := fstest.MapFS{
 		"1_create_users.sql": {Data: []byte("CREATE TABLE users (id integer);")},
 	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
 	var out bytes.Buffer
 
-	err := atlasreport.WriteMigrateLintFormat(&out, `{{ json .Files }}`, atlasreport.MigrateLintOptions{
-		FS: fsys,
+	err = atlasreport.WriteMigrateLintFormat(&out, `{{ json .Files }}`, atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
 	})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, `"Name":"1_create_users.sql"`)
 	c.Assert(out.String(), qt.Contains, `"Text":"CREATE TABLE users`)
+}
+
+func TestNewMigrateLint_OmitsAtlasIgnoredFilesAndCounts(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"1_ignored.sql": {
+			Data: []byte("-- atlas:nolint\n\nDROP TABLE users;\n"),
+		},
+		"2_selected.sql": {
+			Data: []byte("CREATE TABLE accounts (id integer);\n"),
+		},
+	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		Compatibility: migrationlint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Files, qt.HasLen, 1)
+	c.Assert(report.Files[0].Name, qt.Equals, "2_selected.sql")
+	c.Assert(report.Steps, qt.HasLen, 3)
+	c.Assert(report.Steps[0].Text, qt.Equals, "Found 1 new migration files (from 1 total)")
+}
+
+func TestNewMigrateLint_DuplicateBasenamesKeepFindingsScoped(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"a/1_change.sql": {Data: []byte("DROP TABLE users;")},
+		"b/1_change.sql": {Data: []byte("SELECT 1;")},
+	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Files, qt.HasLen, 2)
+	c.Assert(report.Files[0].Name, qt.Equals, "a/1_change.sql")
+	c.Assert(report.Files[0].Findings, qt.HasLen, 1)
+	c.Assert(report.Files[1].Name, qt.Equals, "b/1_change.sql")
+	c.Assert(report.Files[1].Findings, qt.HasLen, 0)
+}
+
+func TestNewMigrateLint_MapsAtlasDiagnosticCodes(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"1_change.sql": {
+			Data: []byte(`
+DROP TABLE users;
+ALTER TABLE accounts DROP COLUMN legacy;
+ALTER TABLE accounts ADD COLUMN tenant_id INTEGER NOT NULL;
+`),
+		},
+	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		Compatibility: migrationlint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Dialect:       "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Files, qt.HasLen, 1)
+	c.Assert(report.Files[0].Findings, qt.HasLen, 3)
+	c.Assert(report.Files[0].Findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(report.Files[0].Findings[1].Rule, qt.Equals, "DS103")
+	c.Assert(report.Files[0].Findings[2].Rule, qt.Equals, "MF103")
+}
+
+func TestNewMigrateLint_OrdersMigrationsByVersion(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"10_later.sql":  {Data: []byte("SELECT 10;")},
+		"2_earlier.sql": {Data: []byte("SELECT 2;")},
+	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Files, qt.HasLen, 2)
+	c.Assert(report.Files[0].Name, qt.Equals, "2_earlier.sql")
+	c.Assert(report.Files[1].Name, qt.Equals, "10_later.sql")
+}
+
+func TestNewMigrateLint_PathPrefixCannotCrossAttachFindings(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"1_change.sql":            {Data: []byte("DROP TABLE users;")},
+		"migrations/1_change.sql": {Data: []byte("SELECT 1;")},
+	}
+	analysis, err := migrationlint.AnalyzeFS(fsys, migrationlint.Options{
+		Compatibility: migrationlint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		PathPrefix:    "migrations",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{
+		Analysis: &analysis,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Files, qt.HasLen, 2)
+	c.Assert(report.Files[0].Name, qt.Equals, "1_change.sql")
+	c.Assert(report.Files[0].Findings, qt.HasLen, 1)
+	c.Assert(report.Files[0].Findings[0].Rule, qt.Equals, "DS102")
+	c.Assert(report.Files[1].Name, qt.Equals, "migrations/1_change.sql")
+	c.Assert(report.Files[1].Findings, qt.HasLen, 0)
 }
 
 func TestWriteMigrateLintFormat_RedactsSensitiveURL(t *testing.T) {
@@ -68,11 +199,15 @@ func TestWriteMigrateLintFormat_RedactsSensitiveURL(t *testing.T) {
 		"&api_key=" + "secret" +
 		"&client_secret=" + "secret" +
 		"&sslmode=disable"
+	analysis, err := migrationlint.AnalyzeFS(fstest.MapFS{
+		"1_empty.sql": {Data: []byte("-- no changes\n")},
+	}, migrationlint.Options{DirFormat: migrator.MigrationDirFormatAtlas})
+	c.Assert(err, qt.IsNil)
 	var out bytes.Buffer
 
-	err := atlasreport.WriteMigrateLintFormat(&out, `{{ .Env.URL }}`, atlasreport.MigrateLintOptions{
-		URL: redactionURL,
-		FS:  fstest.MapFS{},
+	err = atlasreport.WriteMigrateLintFormat(&out, `{{ .Env.URL }}`, atlasreport.MigrateLintOptions{
+		URL:      redactionURL,
+		Analysis: &analysis,
 	})
 
 	c.Assert(err, qt.IsNil)
@@ -87,12 +222,20 @@ func TestWriteMigrateLintFormat_ValidAtlasSumAddsIntegrityStep(t *testing.T) {
 	sum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
 	fsys[migratesum.AtlasFileName] = &fstest.MapFile{Data: sum.Bytes()}
-	integrity, err := atlasreport.InspectMigrateLintIntegrity(fsys)
+	snapshot, err := migrationsnapshot.Capture(fsys)
+	c.Assert(err, qt.IsNil)
+	fsys["1_create_users.sql"].Data = []byte("DROP TABLE users;\n")
+
+	integrity, err := atlasreport.InspectMigrateLintIntegrity(snapshot)
+	c.Assert(err, qt.IsNil)
+	analysis, err := migrationlint.AnalyzeFS(snapshot, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
 	c.Assert(err, qt.IsNil)
 	var out bytes.Buffer
 
 	err = atlasreport.WriteMigrateLintFormat(&out, `{{ len .Steps }}|{{ (index .Steps 0).Text }}`, atlasreport.MigrateLintOptions{
-		FS:        fsys,
+		Analysis:  &analysis,
 		Integrity: integrity,
 	})
 
@@ -113,7 +256,6 @@ func TestWriteMigrateLintFormat_InvalidAtlasSumRendersIntegrityFailure(t *testin
 	err = atlasreport.WriteMigrateLintFormat(&out,
 		`{{ len .Steps }}|{{ (index .Steps 0).Text }}|{{ (index .Files 0).Name }}|{{ (index .Files 0).Error }}`,
 		atlasreport.MigrateLintOptions{
-			FS:        fsys,
 			Integrity: integrity,
 		})
 

--- a/internal/fsnapshot/snapshot.go
+++ b/internal/fsnapshot/snapshot.go
@@ -1,0 +1,252 @@
+// Package fsnapshot captures a read-only, in-memory view of an fs.FS.
+package fsnapshot
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	"path"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Snapshot is an immutable in-memory filesystem. Its read methods return
+// independent values, and Clone returns an independent filesystem view.
+type Snapshot struct {
+	files map[string][]byte
+}
+
+// Capture reads every file in fsys exactly once and returns an immutable
+// snapshot. Capturing an existing Snapshot only clones its in-memory contents.
+func Capture(fsys fs.FS) (Snapshot, error) {
+	if snapshot, ok := fsys.(Snapshot); ok {
+		return snapshot.Clone(), nil
+	}
+	return CaptureMatching(fsys, func(string, fs.DirEntry) bool {
+		return true
+	})
+}
+
+// CaptureMatching reads each file accepted by include exactly once.
+func CaptureMatching(
+	fsys fs.FS,
+	include func(name string, entry fs.DirEntry) bool,
+) (Snapshot, error) {
+	if snapshot, ok := fsys.(Snapshot); ok {
+		return snapshot.matching(include), nil
+	}
+	snapshot := Snapshot{files: map[string][]byte{}}
+	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !include(name, entry) {
+			return nil
+		}
+		contents, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return fmt.Errorf("read snapshot file %s: %w", name, err)
+		}
+		snapshot.files[name] = slices.Clone(contents)
+		return nil
+	})
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("capture filesystem snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+// Clone returns an independent view of the same captured files.
+func (s Snapshot) Clone() Snapshot {
+	cloned := Snapshot{files: make(map[string][]byte, len(s.files))}
+	maps.Copy(cloned.files, s.files)
+	return cloned
+}
+
+func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Snapshot {
+	filtered := Snapshot{files: make(map[string][]byte, len(s.files))}
+	for _, name := range slices.Sorted(maps.Keys(s.files)) {
+		contents := s.files[name]
+		entry := snapshotFileInfo{name: path.Base(name), size: int64(len(contents))}
+		if include(name, entry) {
+			filtered.files[name] = contents
+		}
+	}
+	return filtered
+}
+
+// Open implements fs.FS.
+func (s Snapshot) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	if contents, ok := s.files[name]; ok {
+		return &snapshotFile{
+			Reader: bytes.NewReader(contents),
+			info:   snapshotFileInfo{name: path.Base(name), size: int64(len(contents))},
+		}, nil
+	}
+	entries := s.directoryEntries(name)
+	if len(entries) == 0 && name != "." {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return &snapshotDirectory{
+		info:    snapshotFileInfo{name: path.Base(name), directory: true},
+		entries: entries,
+	}, nil
+}
+
+// ReadFile implements fs.ReadFileFS.
+func (s Snapshot) ReadFile(name string) ([]byte, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrInvalid}
+	}
+	contents, ok := s.files[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrNotExist}
+	}
+	return slices.Clone(contents), nil
+}
+
+// ReadDir implements fs.ReadDirFS.
+func (s Snapshot) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+	entries := s.directoryEntries(name)
+	if len(entries) == 0 && name != "." {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
+	}
+	return entries, nil
+}
+
+// Stat implements fs.StatFS.
+func (s Snapshot) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+	if contents, ok := s.files[name]; ok {
+		return snapshotFileInfo{name: path.Base(name), size: int64(len(contents))}, nil
+	}
+	if entries := s.directoryEntries(name); len(entries) > 0 || name == "." {
+		return snapshotFileInfo{name: path.Base(name), directory: true}, nil
+	}
+	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
+}
+
+func (s Snapshot) directoryEntries(name string) []fs.DirEntry {
+	prefix := ""
+	if name != "." {
+		prefix = name + "/"
+	}
+	seen := make(map[string]snapshotFileInfo)
+	for filename, contents := range s.files {
+		relative, ok := strings.CutPrefix(filename, prefix)
+		if !ok || relative == "" {
+			continue
+		}
+		entryName, remainder, _ := strings.Cut(relative, "/")
+		info := snapshotFileInfo{name: entryName, directory: remainder != ""}
+		if !info.directory {
+			info.size = int64(len(contents))
+		}
+		seen[entryName] = info
+	}
+	entries := make([]fs.DirEntry, 0, len(seen))
+	for _, info := range seen {
+		entries = append(entries, info)
+	}
+	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
+	return entries
+}
+
+type snapshotFile struct {
+	*bytes.Reader
+	info snapshotFileInfo
+}
+
+func (f *snapshotFile) Stat() (fs.FileInfo, error) {
+	return f.info, nil
+}
+
+func (f *snapshotFile) Close() error {
+	return nil
+}
+
+type snapshotDirectory struct {
+	info    snapshotFileInfo
+	entries []fs.DirEntry
+	offset  int
+}
+
+func (d *snapshotDirectory) Stat() (fs.FileInfo, error) {
+	return d.info, nil
+}
+
+func (d *snapshotDirectory) Read([]byte) (int, error) {
+	return 0, &fs.PathError{Op: "read", Path: d.info.name, Err: errors.New("is a directory")}
+}
+
+func (d *snapshotDirectory) Close() error {
+	return nil
+}
+
+func (d *snapshotDirectory) ReadDir(count int) ([]fs.DirEntry, error) {
+	if d.offset >= len(d.entries) && count > 0 {
+		return nil, io.EOF
+	}
+	end := len(d.entries)
+	if count > 0 {
+		end = min(d.offset+count, end)
+	}
+	entries := slices.Clone(d.entries[d.offset:end])
+	d.offset = end
+	return entries, nil
+}
+
+type snapshotFileInfo struct {
+	name      string
+	size      int64
+	directory bool
+}
+
+func (i snapshotFileInfo) Name() string {
+	return i.name
+}
+
+func (i snapshotFileInfo) Size() int64 {
+	return i.size
+}
+
+func (i snapshotFileInfo) Mode() fs.FileMode {
+	if i.directory {
+		return fs.ModeDir | 0o555
+	}
+	return 0o444
+}
+
+func (i snapshotFileInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (i snapshotFileInfo) IsDir() bool {
+	return i.directory
+}
+
+func (i snapshotFileInfo) Sys() any {
+	return nil
+}
+
+func (i snapshotFileInfo) Type() fs.FileMode {
+	return i.Mode().Type()
+}
+
+func (i snapshotFileInfo) Info() (fs.FileInfo, error) {
+	return i, nil
+}

--- a/internal/fsnapshot/snapshot_test.go
+++ b/internal/fsnapshot/snapshot_test.go
@@ -1,0 +1,69 @@
+package fsnapshot_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsnapshot"
+)
+
+func TestCapture_ProducesIndependentCompleteSnapshot(t *testing.T) {
+	c := qt.New(t)
+	source := &countingFS{
+		FS: fstest.MapFS{
+			"atlas.sum":        {Data: []byte("sum")},
+			"migrations/1.sql": {Data: []byte("SELECT 1;")},
+		},
+		reads: map[string]int{},
+	}
+
+	snapshot, err := fsnapshot.Capture(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(source.reads, qt.DeepEquals, map[string]int{
+		"atlas.sum":        1,
+		"migrations/1.sql": 1,
+	})
+	c.Assert(fstest.TestFS(snapshot, "atlas.sum", "migrations/1.sql"), qt.IsNil)
+
+	contents, err := fs.ReadFile(snapshot, "migrations/1.sql")
+	c.Assert(err, qt.IsNil)
+	contents[0] = 'X'
+	fresh, err := fs.ReadFile(snapshot, "migrations/1.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(fresh), qt.Equals, "SELECT 1;")
+}
+
+func TestCapture_ClonesExistingSnapshotWithoutReadingSourceAgain(t *testing.T) {
+	c := qt.New(t)
+	source := &countingFS{
+		FS: fstest.MapFS{
+			"1.sql": {Data: []byte("SELECT 1;")},
+		},
+		reads: map[string]int{},
+	}
+
+	first, err := fsnapshot.Capture(source)
+	c.Assert(err, qt.IsNil)
+	second, err := fsnapshot.Capture(first)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(source.reads, qt.DeepEquals, map[string]int{"1.sql": 1})
+	firstContents, err := fs.ReadFile(first, "1.sql")
+	c.Assert(err, qt.IsNil)
+	secondContents, err := fs.ReadFile(second, "1.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(secondContents, qt.DeepEquals, firstContents)
+}
+
+type countingFS struct {
+	fs.FS
+	reads map[string]int
+}
+
+func (f *countingFS) ReadFile(name string) ([]byte, error) {
+	f.reads[name]++
+	return fs.ReadFile(f.FS, name)
+}

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/migrationreplay"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/risk"
@@ -55,12 +56,14 @@ type Report struct {
 	Findings         []lint.Finding `json:"findings"`
 	Error            string         `json:"error,omitempty"`
 	Versions         []int64        `json:"-"`
+	Analysis         lint.Analysis  `json:"-"`
 }
 
 // Options are the migration lint inputs shared by native and Atlas-compatible
 // commands.
 type Options struct {
 	Dir        string
+	FS         fs.FS
 	DirFormat  string
 	Dialect    string
 	ConfigPath string
@@ -73,6 +76,8 @@ type Options struct {
 	Latest     uint
 	Positional []string
 	Changed    ChangedOptions
+	// Compatibility selects native or command-surface-specific lint semantics.
+	Compatibility lint.CompatibilityProfile
 }
 
 // ChangedOptions records which CLI values were explicitly provided. This lets
@@ -170,11 +175,19 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 	if err != nil {
 		return Report{}, err
 	}
-	versions, restrictVersions, err := lintVersions(ctx, opts, projectCfg)
+	sourceFS := opts.FS
+	if sourceFS == nil {
+		sourceFS = os.DirFS(opts.Dir)
+	}
+	snapshot, err := migrationsnapshot.Capture(sourceFS)
 	if err != nil {
 		return Report{}, err
 	}
-	cfg, err := loadEffectiveConfig(opts, projectCfg)
+	versions, restrictVersions, err := lintVersions(ctx, opts, projectCfg, snapshot)
+	if err != nil {
+		return Report{}, err
+	}
+	cfg, err := loadEffectiveConfig(opts, projectCfg, snapshot)
 	if err != nil {
 		return Report{}, err
 	}
@@ -183,23 +196,21 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		return Report{}, err
 	}
 	disabled := append(append([]string{}, cfg.DisabledRules...), opts.Disabled...)
-	findings, err := lintDirectory(ctx, opts, dirFormat, lintSelection{
-		Options: lint.Options{
-			Dialect:           dialect,
-			Disabled:          disabled,
-			PathPrefix:        filepath.ToSlash(opts.Dir),
-			Versions:          versions,
-			DirFormat:         dirFormat,
-			AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
-			RuleConfigs:       cfg.Rules,
+	analysis, err := lintDirectory(ctx, opts, snapshot, dirFormat, lint.Options{
+		Compatibility: opts.Compatibility,
+		Dialect:       dialect,
+		Disabled:      disabled,
+		PathPrefix:    filepath.ToSlash(opts.Dir),
+		Selection: lint.VersionSelection{
+			Versions:   versions,
+			Restricted: restrictVersions,
 		},
-		RestrictVersions: restrictVersions,
+		DirFormat:         dirFormat,
+		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
+		RuleConfigs:       cfg.Rules,
 	})
-	if err != nil {
-		return Report{}, err
-	}
-
-	return Report{
+	findings := analysis.Findings()
+	report := Report{
 		Failed:           shouldFail(findings, opts.FailOn),
 		FailureThreshold: opts.FailOn,
 		Dialect:          dialect,
@@ -207,7 +218,13 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		DisabledRules:    disabled,
 		Findings:         findings,
 		Versions:         versions,
-	}, nil
+		Analysis:         analysis,
+	}
+	if err != nil {
+		report.Error = err.Error()
+		return report, err
+	}
+	return report, nil
 }
 
 func normalizeOptions(opts Options, projectCfg projectconfig.Config) (Options, error) {
@@ -228,8 +245,10 @@ func normalizeOptions(opts Options, projectCfg projectconfig.Config) (Options, e
 	opts.DirFormat = opts.effectiveDirFormat(projectCfg)
 	opts.AtlasEnv = opts.effectiveAtlasEnv(projectCfg)
 	opts.DevURL = opts.effectiveDevURL(projectCfg)
-	if err := validateDir(opts.Dir); err != nil {
-		return Options{}, err
+	if opts.FS == nil {
+		if err := validateDir(opts.Dir); err != nil {
+			return Options{}, err
+		}
 	}
 	return opts, nil
 }
@@ -262,8 +281,12 @@ func (opts Options) effectiveDevURL(projectCfg projectconfig.Config) string {
 	return opts.DevURL
 }
 
-func loadEffectiveConfig(opts Options, projectCfg projectconfig.Config) (*lint.Config, error) {
-	cfg, err := loadConfig(opts)
+func loadEffectiveConfig(
+	opts Options,
+	projectCfg projectconfig.Config,
+	fsys fs.FS,
+) (*lint.Config, error) {
+	cfg, err := loadConfig(opts, fsys)
 	if err != nil {
 		return nil, err
 	}
@@ -295,35 +318,27 @@ func effectiveDialect(opts Options, configDialect, devDialect string) (string, e
 	return dialect, nil
 }
 
-type lintSelection struct {
-	lint.Options
-	RestrictVersions bool
-}
-
 func lintDirectory(
 	ctx context.Context,
 	opts Options,
+	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
-	selection lintSelection,
-) ([]lint.Finding, error) {
-	if err := migrationreplay.Replay(ctx, migrationreplay.Options{
-		Dir:       opts.Dir,
-		DirFormat: dirFormat,
-		DevURL:    opts.DevURL,
-	}); err != nil {
-		return nil, fmt.Errorf("error validating migration SQL on dev database: %v", err)
-	}
-	if selection.RestrictVersions && len(selection.Versions) == 0 {
-		return []lint.Finding{}, nil
-	}
-	findings, err := lint.LintFS(os.DirFS(opts.Dir), selection.Options)
+	lintOptions lint.Options,
+) (lint.Analysis, error) {
+	analysis, err := lint.AnalyzeFS(fsys, lintOptions)
 	if err != nil {
-		return nil, err
+		return lint.Analysis{}, err
 	}
-	if findings == nil {
-		return []lint.Finding{}, nil
+	if err := migrationreplay.Replay(ctx, migrationreplay.Options{
+		Dir:               opts.Dir,
+		DirFormat:         dirFormat,
+		DevURL:            opts.DevURL,
+		FS:                analysis.SnapshotFS(),
+		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
+	}); err != nil {
+		return analysis, fmt.Errorf("error validating migration SQL on dev database: %w", err)
 	}
-	return findings, nil
+	return analysis, nil
 }
 
 func validateDevURLDialect(dialect, devDialect string) error {
@@ -338,14 +353,11 @@ func validateDevURLDialect(dialect, devDialect string) error {
 
 // loadConfig reads the explicit --config file, or the conventional
 // .ptah-lint.yaml inside the linted directory when present.
-func loadConfig(opts Options) (*lint.Config, error) {
+func loadConfig(opts Options, fsys fs.FS) (*lint.Config, error) {
 	if opts.ConfigPath != "" {
-		if _, err := os.Stat(opts.ConfigPath); err != nil {
-			return nil, fmt.Errorf("lint config %s: %w", opts.ConfigPath, err)
-		}
 		return lint.LoadConfig(opts.ConfigPath)
 	}
-	return lint.LoadConfig(filepath.Join(opts.Dir, lint.ConfigFileName))
+	return lint.LoadConfigFS(fsys, lint.ConfigFileName)
 }
 
 func effectiveLintRuleConfigs(
@@ -382,7 +394,12 @@ func cloneLintRuleConfigs(values map[string]lint.RuleConfig) map[string]lint.Rul
 	return cloned
 }
 
-func lintVersions(ctx context.Context, opts Options, cfg projectconfig.Config) ([]int64, bool, error) {
+func lintVersions(
+	ctx context.Context,
+	opts Options,
+	cfg projectconfig.Config,
+	fsys fs.FS,
+) ([]int64, bool, error) {
 	latest, latestSet := effectiveLatest(opts, cfg)
 	git, err := effectiveGit(opts, cfg)
 	if err != nil {
@@ -402,7 +419,7 @@ func lintVersions(ctx context.Context, opts Options, cfg projectconfig.Config) (
 		if err != nil {
 			return nil, false, err
 		}
-		versions, err := latestMigrationVersions(os.DirFS(opts.Dir), uint(latest), dirFormat)
+		versions, err := latestMigrationVersions(fsys, uint(latest), dirFormat)
 		return versions, true, err
 	}
 	if git.ok {

--- a/internal/migrationlintreport/report_test.go
+++ b/internal/migrationlintreport/report_test.go
@@ -3,14 +3,17 @@ package migrationlintreport_test
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/migrationlintreport"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	migrationlint "github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -55,6 +58,81 @@ func TestBuild_UsesProjectConfigWithoutCobra(t *testing.T) {
 	c.Assert(report.Findings, qt.HasLen, 1)
 	c.Assert(report.Findings[0].Rule, qt.Equals, "DS102")
 	c.Assert(report.Findings[0].File, qt.Contains, "0000000002_new.up.sql")
+}
+
+func TestBuild_LatestAndAnalysisShareOneSourceSnapshot(t *testing.T) {
+	c := qt.New(t)
+	source := &countingSnapshotSource{
+		FS: fstest.MapFS{
+			"1_old.sql": {Data: []byte("DROP TABLE old_data;\n")},
+			"2_new.sql": {Data: []byte("DROP TABLE new_data;\n")},
+		},
+		reads: map[string]int{},
+	}
+
+	report, err := migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		FS:        source,
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		FailOn:    migrationlintreport.FailOnNone,
+		Latest:    1,
+		Changed:   migrationlintreport.ChangedOptions{Latest: true},
+	}, projectconfig.Config{})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Versions, qt.DeepEquals, []int64{2})
+	c.Assert(report.Findings, qt.HasLen, 1)
+	c.Assert(report.Findings[0].File, qt.Contains, "2_new.sql")
+	c.Assert(source.reads, qt.DeepEquals, map[string]int{
+		"1_old.sql": 1,
+		"2_new.sql": 1,
+	})
+}
+
+func TestBuild_ProvidedSnapshotDoesNotRequireSourceDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeLintTestFile(c, dir, "1_drop.sql", "DROP TABLE users;\n")
+	snapshot, err := migrationsnapshot.Capture(os.DirFS(dir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.RemoveAll(dir), qt.IsNil)
+
+	report, err := migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       dir,
+		FS:        snapshot,
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		FailOn:    migrationlintreport.FailOnNone,
+	}, projectconfig.Config{})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Findings, qt.HasLen, 1)
+	c.Assert(report.Findings[0].Rule, qt.Equals, "DS101")
+}
+
+func TestBuild_LoadsConventionalLintConfigFromSnapshot(t *testing.T) {
+	c := qt.New(t)
+	source := &countingSnapshotSource{
+		FS: fstest.MapFS{
+			".ptah-lint.yaml": {Data: []byte("disabled-rules: [DS101]\n")},
+			"1_drop.sql":      {Data: []byte("DROP TABLE users;\n")},
+		},
+		reads: map[string]int{},
+	}
+
+	report, err := migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		FS:        source,
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		FailOn:    migrationlintreport.FailOnNone,
+	}, projectconfig.Config{})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.DisabledRules, qt.DeepEquals, []string{"DS101"})
+	c.Assert(report.Findings, qt.HasLen, 0)
+	c.Assert(source.reads, qt.DeepEquals, map[string]int{
+		".ptah-lint.yaml": 1,
+		"1_drop.sql":      1,
+	})
 }
 
 func TestBuild_FailOnErrorDoesNotFailWarnings(t *testing.T) {
@@ -113,6 +191,16 @@ func TestWrite_GitHubActionsEscapesWorkflowCommandCharacters(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, "::error file=dir/evil%2Cfile%3A%3Aname.sql,line=3::")
 	c.Assert(buf.String(), qt.Contains, "DS101: 50%25 data loss%0D%0Asecond line")
 	c.Assert(buf.String(), qt.Not(qt.Contains), "evil,file::name")
+}
+
+type countingSnapshotSource struct {
+	fs.FS
+	reads map[string]int
+}
+
+func (f *countingSnapshotSource) ReadFile(name string) ([]byte, error) {
+	f.reads[name]++
+	return fs.ReadFile(f.FS, name)
 }
 
 func TestWrite_GitHubActionsEscapesErrorReport(t *testing.T) {

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -5,11 +5,13 @@ package migrationreplay
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"strings"
 
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -18,6 +20,9 @@ type Options struct {
 	Dir       string
 	DirFormat migrator.MigrationDirFormat
 	DevURL    string
+	// FS supplies an immutable migration snapshot. When nil, Replay opens Dir.
+	FS                fs.FS
+	AtlasTemplateData any
 }
 
 // Replay connects to the configured dev database and replays the migration
@@ -31,13 +36,21 @@ func Replay(ctx context.Context, opts Options) error {
 		return fmt.Errorf("docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for migration SQL replay")
 	}
 
+	sourceFS := opts.FS
+	if sourceFS == nil {
+		sourceFS = os.DirFS(opts.Dir)
+	}
+	snapshot, err := migrationsnapshot.Capture(sourceFS)
+	if err != nil {
+		return fmt.Errorf("capture migration directory: %w", err)
+	}
 	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
 	if err != nil {
 		return fmt.Errorf("error connecting to dev database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	return ReplayOnConnection(ctx, conn, opts.Dir, opts.DirFormat)
+	return replayOnConnection(ctx, conn, snapshot, opts.DirFormat, opts.AtlasTemplateData)
 }
 
 // ReplayOnConnection replays the migration directory on an already-open dev
@@ -48,17 +61,33 @@ func ReplayOnConnection(
 	dir string,
 	dirFormat migrator.MigrationDirFormat,
 ) error {
-	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
-		return fmt.Errorf("clean dev database: %w", err)
+	snapshot, err := migrationsnapshot.Capture(os.DirFS(dir))
+	if err != nil {
+		return fmt.Errorf("capture migration directory: %w", err)
 	}
+	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil)
+}
+
+func replayOnConnection(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	fsys fs.FS,
+	dirFormat migrator.MigrationDirFormat,
+	atlasTemplateData any,
+) error {
 	provider, err := migrator.NewFSMigrationProvider(
-		os.DirFS(dir),
+		fsys,
 		migrator.WithMigrationDirFormat(dirFormat),
+		migrator.WithAtlasTemplateData(atlasTemplateData),
 	)
 	if err != nil {
 		return fmt.Errorf("load migration directory: %w", err)
 	}
-	for _, migration := range provider.Migrations() {
+	migrations := provider.Migrations()
+	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
+		return fmt.Errorf("clean dev database: %w", err)
+	}
+	for _, migration := range migrations {
 		if err := migration.Up(ctx, conn); err != nil {
 			return fmt.Errorf("replay migration %d on dev database: %w", migration.Version, err)
 		}

--- a/internal/migrationreplay/replay_test.go
+++ b/internal/migrationreplay/replay_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	qt "github.com/frankban/quicktest"
 
@@ -54,6 +55,69 @@ func TestReplayCleansDevDatabaseAndIgnoresExistingRevisionRows(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 	assertReplayRunsRows(c, devDBPath, 0)
+}
+
+func TestReplayUsesProvidedFilesystemSnapshot(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := t.TempDir()
+	devDBPath := filepath.Join(t.TempDir(), "dev.db")
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_invalid.sql"),
+		[]byte("THIS IS NOT SQL;\n"),
+		0o600,
+	), qt.IsNil)
+	snapshot := fstest.MapFS{
+		"1_create_replay_runs.sql": {
+			Data: []byte(`{{- if eq .Env "dev" }}
+CREATE TABLE replay_runs (id INTEGER PRIMARY KEY);
+{{- else }}
+CREATE TABLE wrong_template_branch (id INTEGER PRIMARY KEY);
+{{- end }}
+`),
+		},
+	}
+
+	err := migrationreplay.Replay(context.Background(), migrationreplay.Options{
+		Dir:               migrationsDir,
+		DirFormat:         migrator.MigrationDirFormatAtlas,
+		DevURL:            "sqlite://" + devDBPath,
+		FS:                snapshot,
+		AtlasTemplateData: migrator.AtlasTemplateData{Env: "dev"},
+	})
+
+	c.Assert(err, qt.IsNil)
+	assertReplayRunsRows(c, devDBPath, 0)
+}
+
+func TestReplayProviderFailurePreservesDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	devDBPath := filepath.Join(t.TempDir(), "dev.db")
+	devURL := "sqlite://" + devDBPath
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, "CREATE TABLE sentinel (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	dbschema.CloseAndWarn(conn)
+
+	err = migrationreplay.Replay(ctx, migrationreplay.Options{
+		DirFormat: migrator.MigrationDirFormatPtah,
+		DevURL:    devURL,
+		FS: fstest.MapFS{
+			"0000000001_incomplete.up.sql": {
+				Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			},
+		},
+	})
+	c.Assert(err, qt.ErrorMatches, "load migration directory: incomplete migrations found .*")
+
+	conn, err = dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM sentinel").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }
 
 func assertReplayRunsRows(c *qt.C, dbPath string, want int) {

--- a/internal/migrationsnapshot/snapshot.go
+++ b/internal/migrationsnapshot/snapshot.go
@@ -1,0 +1,28 @@
+// Package migrationsnapshot captures the files that define one migration run.
+package migrationsnapshot
+
+import (
+	"io/fs"
+	"path"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/fsnapshot"
+)
+
+var metadataFiles = map[string]struct{}{
+	".ptah-lint.yaml": {},
+	"atlas.sum":       {},
+	"ptah.sum":        {},
+}
+
+// Capture reads SQL migrations and their lint or integrity metadata exactly
+// once, excluding unrelated files from the immutable snapshot.
+func Capture(fsys fs.FS) (fsnapshot.Snapshot, error) {
+	return fsnapshot.CaptureMatching(fsys, func(name string, _ fs.DirEntry) bool {
+		if strings.EqualFold(path.Ext(name), ".sql") {
+			return true
+		}
+		_, ok := metadataFiles[path.Base(name)]
+		return ok
+	})
+}

--- a/internal/migrationsnapshot/snapshot_test.go
+++ b/internal/migrationsnapshot/snapshot_test.go
@@ -1,0 +1,37 @@
+package migrationsnapshot_test
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
+)
+
+func TestCapture_IncludesOnlyMigrationInputs(t *testing.T) {
+	c := qt.New(t)
+	source := fstest.MapFS{
+		".ptah-lint.yaml": {Data: []byte("rules: {}\n")},
+		"1.sql":           {Data: []byte("SELECT 1;\n")},
+		"README.md":       {Data: []byte("large unrelated file\n")},
+		"atlas.sum":       {Data: []byte("h1:test\n")},
+		"nested/2.SQL":    {Data: []byte("SELECT 2;\n")},
+		"ptah.sum":        {Data: []byte("h1:test\n")},
+	}
+
+	snapshot, err := migrationsnapshot.Capture(source)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(fstest.TestFS(
+		snapshot,
+		".ptah-lint.yaml",
+		"1.sql",
+		"atlas.sum",
+		"nested/2.SQL",
+		"ptah.sum",
+	), qt.IsNil)
+	_, err = fs.Stat(snapshot, "README.md")
+	c.Assert(err, qt.ErrorIs, fs.ErrNotExist)
+}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -1,0 +1,519 @@
+package lint
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/fsnapshot"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// CompatibilityProfile selects command-surface-specific lint semantics.
+type CompatibilityProfile string
+
+const (
+	// CompatibilityProfileNative preserves Ptah rule codes, directives, and
+	// safety behavior. It is the zero value and the default for every native
+	// API and command.
+	CompatibilityProfileNative CompatibilityProfile = ""
+	// CompatibilityProfileAtlas enables Atlas directive aliases and file-header
+	// suppression semantics without changing native Ptah behavior.
+	CompatibilityProfileAtlas CompatibilityProfile = "atlas"
+)
+
+// SourceSpan identifies a half-open byte range in [File.SQL].
+type SourceSpan struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+// SubjectKind identifies the kind of schema object affected by a finding.
+type SubjectKind string
+
+const (
+	// SubjectTable identifies a database table.
+	SubjectTable SubjectKind = "table"
+	// SubjectColumn identifies a database column.
+	SubjectColumn SubjectKind = "column"
+)
+
+// Subject identifies one schema object affected by a finding.
+type Subject struct {
+	Kind     SubjectKind `json:"kind"`
+	Name     string      `json:"name"`
+	Parent   string      `json:"parent,omitempty"`
+	DataType string      `json:"data_type,omitempty"`
+}
+
+// FindingContext ties a finding to one exact statement and its affected
+// schema objects. File-level findings have a nil context.
+type FindingContext struct {
+	StatementIndex int       `json:"statement_index"`
+	Subjects       []Subject `json:"subjects,omitempty"`
+}
+
+// Finding is one rule hit in one migration file.
+type Finding struct {
+	Rule     string   `json:"rule"`
+	Title    string   `json:"title"`
+	Severity Severity `json:"severity"`
+	File     string   `json:"file"`
+	// Line is the 1-based line of the offending statement's first token;
+	// zero for file-level findings (naming, pairing).
+	Line    int    `json:"line,omitempty"`
+	Message string `json:"message"`
+	// Context identifies the exact analyzed statement. Renderers should use it
+	// instead of trying to match findings back to statements by line number.
+	Context *FindingContext `json:"context,omitempty"`
+}
+
+// Statement is one SQL statement of a migration file, in the forms rules
+// consume.
+type Statement struct {
+	// Index is this statement's stable zero-based position in [File.Statements].
+	Index int
+	// Span is the statement's byte range in [File.SQL].
+	Span SourceSpan
+	// SQL is the raw statement text as written (comments included).
+	SQL string
+	// Canonical is the comment-stripped, whitespace-collapsed, uppercased
+	// display form. String literals keep their original case.
+	Canonical string
+	// Words is the token-word sequence the built-in rules scan: comments and
+	// whitespace dropped, bare keywords/identifiers uppercased, punctuation
+	// as its own entry, string literals and quoted identifiers kept verbatim
+	// as single opaque words (so a literal containing "DROP COLUMN" or a
+	// column named "type" can never impersonate a keyword).
+	Words []string
+	// Line is the 1-based line number of the statement's first token.
+	Line            int
+	sourceWords     []string
+	suppressedRules []string
+}
+
+// File is one migration file prepared for linting.
+type File struct {
+	// Path is the file path as it should appear in findings (reporting
+	// prefix included).
+	Path string
+	// Name is the slash-separated path of the file relative to the linted
+	// directory (bare file name for root-level files).
+	Name string
+	// Source is the migration file exactly as captured from the input
+	// filesystem.
+	Source string
+	// SQL is the executable SQL analyzed by the linter. It differs from Source
+	// only when an Atlas SQL template is rendered.
+	SQL string
+	// Version is the parsed migration version, or zero when the name is not
+	// recognized.
+	Version int64
+	// Repeatable reports whether the migrator classifies this as an imported
+	// repeatable migration rather than an ordered version.
+	Repeatable bool
+	// Selected reports whether this file belongs to the requested version
+	// selection. Analysis keeps unselected files so reports can distinguish a
+	// changeset from the complete migration directory.
+	Selected bool
+	// Ignored reports whether the Atlas compatibility profile classified this
+	// file as wholly ignored through a file-header nolint directive. Native
+	// analysis never sets this field.
+	Ignored bool
+	// Direction is the migration direction ("up"/"down") exactly as the
+	// migrator's name parser classifies this file; empty when the migrator
+	// cannot parse the name at all.
+	Direction string
+	// IsUp reports whether statement rules treat this as an up migration:
+	// the migrator parses it as up, or its name carries the .up.sql suffix.
+	IsUp bool
+	// HasPair reports whether the matching counterpart file (down for up,
+	// up for down) exists in the same directory.
+	HasPair bool
+	// WellFormedName reports whether the name matches the documented
+	// NNNNNNNNNN_description.(up|down).sql convention, checked
+	// independently of the migrator's parser as defense in depth (see the
+	// strictNameRe comment).
+	WellFormedName bool
+	// NoTransaction reports whether file-scoped directives opt this migration
+	// out of the migrator's transaction wrapper.
+	NoTransaction bool
+	// Statements holds the parsed statements of up migrations. Empty for
+	// down migrations (statement rules do not run there).
+	Statements      []Statement
+	suppressedRules []string
+}
+
+// VersionSelection selects migration versions while preserving the difference
+// between no selector and an explicitly empty changeset.
+type VersionSelection struct {
+	// Versions lists selected migration versions.
+	Versions []int64
+	// Restricted reports whether Versions is an explicit selection. When true,
+	// an empty Versions slice selects no migrations.
+	Restricted bool
+}
+
+// Analysis is an immutable migration lint result. Its accessors return deep
+// copies, so callers cannot modify the captured files, findings, or source
+// snapshot.
+type Analysis struct {
+	files    []File
+	findings []Finding
+	snapshot fsnapshot.Snapshot
+}
+
+// Files returns every prepared migration file in the captured directory.
+func (a Analysis) Files() []File {
+	return cloneFiles(a.files)
+}
+
+// SelectedFiles returns the prepared files selected for linting.
+func (a Analysis) SelectedFiles() []File {
+	files := make([]File, 0, len(a.files))
+	for i := range a.files {
+		if a.files[i].Selected {
+			files = append(files, cloneFile(a.files[i]))
+		}
+	}
+	return files
+}
+
+// Findings returns the ordered lint findings.
+func (a Analysis) Findings() []Finding {
+	return cloneFindings(a.findings)
+}
+
+// SnapshotFS returns a read-only filesystem containing the SQL sources,
+// integrity files, and lint configuration captured for this analysis. Each call
+// returns an independent snapshot view.
+func (a Analysis) SnapshotFS() fs.FS {
+	return a.snapshot.Clone()
+}
+
+func cloneFiles(files []File) []File {
+	cloned := make([]File, len(files))
+	for i := range files {
+		cloned[i] = cloneFile(files[i])
+	}
+	return cloned
+}
+
+func cloneFile(file File) File {
+	file.suppressedRules = slices.Clone(file.suppressedRules)
+	statements := file.Statements
+	file.Statements = make([]Statement, len(statements))
+	for i := range statements {
+		file.Statements[i] = cloneStatement(statements[i])
+	}
+	return file
+}
+
+func cloneStatement(statement Statement) Statement {
+	statement.Words = slices.Clone(statement.Words)
+	statement.sourceWords = slices.Clone(statement.sourceWords)
+	statement.suppressedRules = slices.Clone(statement.suppressedRules)
+	return statement
+}
+
+func cloneFindings(findings []Finding) []Finding {
+	cloned := make([]Finding, len(findings))
+	copy(cloned, findings)
+	for i := range cloned {
+		if cloned[i].Context == nil {
+			continue
+		}
+		context := *cloned[i].Context
+		context.Subjects = slices.Clone(context.Subjects)
+		cloned[i].Context = &context
+	}
+	return cloned
+}
+
+// AnalyzeFS captures and analyzes every *.sql file under fsys recursively.
+// Input file contents are read exactly once; template rendering, linting,
+// replay, and reporting can all consume the returned immutable snapshot.
+func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
+	if err := validateCompatibilityProfile(opts.Compatibility); err != nil {
+		return Analysis{}, err
+	}
+	if err := validateRules(rulesForOptions(opts)); err != nil {
+		return Analysis{}, err
+	}
+	dirFormat, err := migrator.ParseMigrationDirFormat(string(opts.DirFormat))
+	if err != nil {
+		return Analysis{}, err
+	}
+	snapshot, err := migrationsnapshot.Capture(fsys)
+	if err != nil {
+		return Analysis{}, err
+	}
+	sources, names, err := loadSQLSources(snapshot)
+	if err != nil {
+		return Analysis{}, err
+	}
+	names, err = filterAtlasTemplateSupportNames(sources, names, dirFormat)
+	if err != nil {
+		return Analysis{}, err
+	}
+
+	present := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		present[name] = struct{}{}
+	}
+
+	// Directions present per version, so pairing matches the migrator, which
+	// pairs an up and a down by their shared version prefix regardless of
+	// description, not by an identical file-name stem.
+	versionDirs := map[int64]map[string]bool{}
+	for _, name := range names {
+		if parsed, parseErr := parseKnownMigrationName(path.Base(name), dirFormat); parseErr == nil {
+			if versionDirs[parsed.Version] == nil {
+				versionDirs[parsed.Version] = map[string]bool{}
+			}
+			versionDirs[parsed.Version][parsed.Direction] = true
+		}
+	}
+
+	mode := modeForDialect(opts.Dialect)
+	files := make([]File, 0, len(names))
+	for _, name := range names {
+		file, err := prepareFile(
+			snapshot,
+			sources,
+			name,
+			present,
+			versionDirs,
+			opts.PathPrefix,
+			mode,
+			opts.AtlasTemplateData,
+			dirFormat,
+			opts.Selection,
+			opts.Compatibility,
+		)
+		if err != nil {
+			return Analysis{}, err
+		}
+		files = append(files, file)
+	}
+
+	var findings []Finding
+	for i := range files {
+		if !files[i].Selected {
+			continue
+		}
+		file := cloneFile(files[i])
+		findings = append(findings, runRules(&file, opts)...)
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].File != findings[j].File {
+			return findings[i].File < findings[j].File
+		}
+		if findings[i].Line != findings[j].Line {
+			return findings[i].Line < findings[j].Line
+		}
+		return findings[i].Rule < findings[j].Rule
+	})
+
+	return Analysis{
+		files:    files,
+		findings: cloneFindings(findings),
+		snapshot: snapshot,
+	}, nil
+}
+
+// LintFS lints every *.sql file under fsys and returns findings ordered by
+// file, line, and rule code. Call [AnalyzeFS] when prepared files or the source
+// snapshot are also needed.
+func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
+	analysis, err := AnalyzeFS(fsys, opts)
+	if err != nil {
+		return nil, err
+	}
+	return analysis.Findings(), nil
+}
+
+type sqlSources map[string]string
+
+func loadSQLSources(fsys fs.FS) (sqlSources, []string, error) {
+	var names []string
+	err := fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !d.IsDir() && strings.EqualFold(path.Ext(p), ".sql") {
+			names = append(names, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list migration files: %w", err)
+	}
+	if len(names) == 0 {
+		return nil, nil, fmt.Errorf("no *.sql migration files found")
+	}
+	sort.Strings(names)
+	sources := make(sqlSources, len(names))
+	for _, name := range names {
+		raw, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read %s: %w", name, err)
+		}
+		sources[name] = string(raw)
+	}
+	return sources, names, nil
+}
+
+func validateCompatibilityProfile(profile CompatibilityProfile) error {
+	switch profile {
+	case CompatibilityProfileNative, CompatibilityProfileAtlas:
+		return nil
+	default:
+		return fmt.Errorf("unsupported lint compatibility profile %q", profile)
+	}
+}
+
+func filterAtlasTemplateSupportNames(
+	sources sqlSources,
+	names []string,
+	dirFormat migrator.MigrationDirFormat,
+) ([]string, error) {
+	if !hasAtlasTemplateMigration(sources, names, dirFormat) {
+		return names, nil
+	}
+
+	filtered := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, err := parseKnownMigrationName(path.Base(name), dirFormat); err == nil {
+			filtered = append(filtered, name)
+			continue
+		}
+		if !isAtlasTemplateSupportFile(sources[name]) {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered, nil
+}
+
+func hasAtlasTemplateMigration(
+	sources sqlSources,
+	names []string,
+	dirFormat migrator.MigrationDirFormat,
+) bool {
+	for _, name := range names {
+		parsed, err := parseKnownMigrationName(path.Base(name), dirFormat)
+		if err != nil || parsed.Format != migrator.MigrationDirFormatAtlas {
+			continue
+		}
+		if migrator.LooksAtlasTemplateSQL(sources[name]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAtlasTemplateSupportFile(sql string) bool {
+	return migrator.LooksAtlasTemplateSQL(sql) && strings.Contains(sql, "define ")
+}
+
+// prepareFile loads one migration file into the forms rules consume.
+func prepareFile(
+	snapshot fsnapshot.Snapshot,
+	sources sqlSources,
+	name string,
+	present map[string]struct{},
+	versionDirs map[int64]map[string]bool,
+	pathPrefix string,
+	mode scanMode,
+	atlasTemplateData any,
+	dirFormat migrator.MigrationDirFormat,
+	selection VersionSelection,
+	compatibility CompatibilityProfile,
+) (File, error) {
+	raw := sources[name]
+	base := path.Base(name)
+	direction := ""
+	var version int64
+	hasVersion := false
+	atlasFormat := false
+	repeatable := false
+	if parsed, parseErr := parseKnownMigrationName(base, dirFormat); parseErr == nil {
+		direction = parsed.Direction
+		version = parsed.Version
+		hasVersion = true
+		atlasFormat = parsed.Format == migrator.MigrationDirFormatAtlas
+		repeatable = parsed.Repeatable
+	}
+	file := File{
+		Path:       path.Join(pathPrefix, name),
+		Name:       name,
+		Source:     raw,
+		SQL:        raw,
+		Version:    version,
+		Repeatable: repeatable,
+		Selected:   selectionIncludes(selection, version, hasVersion),
+		Direction:  direction,
+		// The migrator executes whatever its parser classifies as up, so
+		// lint must follow it; the suffix check keeps hazard scanning for
+		// .up.sql files whose version prefix is malformed.
+		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
+		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
+		NoTransaction:  fileNoTransactionDirective(raw),
+	}
+	if compatibility == CompatibilityProfileAtlas {
+		file.suppressedRules, file.Ignored = parseAtlasFileNoLint(raw)
+	}
+	switch {
+	case atlasFormat:
+		file.HasPair = true
+	case hasVersion:
+		// Pair by version, matching the migrator: the counterpart is any
+		// file of the same version in the opposite direction.
+		counterpart := "down"
+		if direction == "down" {
+			counterpart = "up"
+		}
+		file.HasPair = versionDirs[version][counterpart]
+	case file.IsUp:
+		_, file.HasPair = present[strings.TrimSuffix(name, ".up.sql")+".down.sql"]
+	case strings.HasSuffix(name, ".down.sql"):
+		_, file.HasPair = present[strings.TrimSuffix(name, ".down.sql")+".up.sql"]
+	}
+
+	// Statement rules apply to up migrations only.
+	if file.IsUp {
+		sql := raw
+		if atlasFormat && migrator.LooksAtlasTemplateSQL(sql) {
+			rendered, _, err := migrator.RenderAtlasTemplateSQL(snapshot, name, atlasTemplateData)
+			if err != nil {
+				return File{}, err
+			}
+			sql = rendered
+		}
+		file.SQL = sql
+		for index, rawStmt := range splitStatementsWithLines(sql, mode, compatibility) {
+			file.Statements = append(file.Statements, Statement{
+				Index:           index,
+				Span:            SourceSpan{Start: rawStmt.start, End: rawStmt.end},
+				SQL:             rawStmt.text,
+				Canonical:       canonicalize(rawStmt.text, mode),
+				Words:           tokenizeWords(rawStmt.text, mode),
+				Line:            rawStmt.line,
+				sourceWords:     tokenizeSourceWords(rawStmt.text, mode),
+				suppressedRules: rawStmt.suppressedRules,
+			})
+		}
+	}
+	return file, nil
+}
+
+func selectionIncludes(selection VersionSelection, version int64, hasVersion bool) bool {
+	if !selection.Restricted {
+		return true
+	}
+	return hasVersion && slices.Contains(selection.Versions, version)
+}

--- a/migration/lint/analysis_test.go
+++ b/migration/lint/analysis_test.go
@@ -1,0 +1,469 @@
+package lint_test
+
+import (
+	"io/fs"
+	"slices"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/lint"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestAnalyzeFS_VersionSelectionPreservesCompleteSnapshot(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_create.sql": "CREATE TABLE users (id INTEGER);",
+		"2_drop.sql":   "DROP TABLE users;",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Selection: lint.VersionSelection{
+			Versions:   []int64{2},
+			Restricted: true,
+		},
+	})
+
+	c.Assert(err, qt.IsNil)
+	files := analysis.Files()
+	c.Assert(files, qt.HasLen, 2)
+	c.Assert(files[0].Name, qt.Equals, "1_create.sql")
+	c.Assert(files[0].Selected, qt.IsFalse)
+	c.Assert(files[1].Name, qt.Equals, "2_drop.sql")
+	c.Assert(files[1].Selected, qt.IsTrue)
+	selected := analysis.SelectedFiles()
+	c.Assert(selected, qt.HasLen, 1)
+	c.Assert(selected[0].Name, qt.Equals, "2_drop.sql")
+	c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, []string{"DS101"})
+	c.Assert(fstest.TestFS(analysis.SnapshotFS(), "1_create.sql", "2_drop.sql"), qt.IsNil)
+}
+
+func TestAnalyzeFS_ExplicitEmptyVersionSelectionSelectsNothing(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_create.sql": "CREATE TABLE users (id INTEGER);",
+		"2_drop.sql":   "DROP TABLE users;",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Selection: lint.VersionSelection{Restricted: true},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(analysis.Files(), qt.HasLen, 2)
+	c.Assert(analysis.SelectedFiles(), qt.HasLen, 0)
+	c.Assert(analysis.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_NativeSameFileCreateThenNotNullAlterRetainsDD101(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_users.sql": `
+CREATE TABLE users (id INTEGER);
+ALTER TABLE users ADD COLUMN tenant_id INTEGER NOT NULL;
+`,
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, []string{"DD101"})
+}
+
+func TestAnalyzeFS_RejectsUnknownCompatibilityProfile(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_select.sql": "SELECT 1;",
+	})
+
+	_, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfile("unknown"),
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `unsupported lint compatibility profile "unknown"`)
+}
+
+func TestAnalyzeFS_ReturnedDataCannotMutateSnapshot(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_drop.sql": "DROP TABLE users;",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	files := analysis.Files()
+	files[0].Statements[0].Words[0] = "MUTATED"
+	files[0].Statements[0].SQL = "MUTATED"
+	findings := analysis.Findings()
+	findings[0].Context.Subjects[0].Name = "MUTATED"
+	source, err := fs.ReadFile(analysis.SnapshotFS(), "1_drop.sql")
+	c.Assert(err, qt.IsNil)
+	source[0] = 'X'
+
+	freshFiles := analysis.Files()
+	c.Assert(freshFiles[0].Statements[0].Words[0], qt.Equals, "DROP")
+	c.Assert(freshFiles[0].Statements[0].SQL, qt.Equals, "DROP TABLE users")
+	freshFindings := analysis.Findings()
+	c.Assert(freshFindings[0].Context.Subjects[0].Name, qt.Equals, "users")
+	freshSource, err := fs.ReadFile(analysis.SnapshotFS(), "1_drop.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(freshSource), qt.Equals, "DROP TABLE users;")
+}
+
+func TestAnalyzeFS_SameLineStatementsHaveStableContexts(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_hazards.sql": "DROP TABLE users; ALTER TABLE accounts DROP COLUMN legacy;\n",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	files := analysis.Files()
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(files[0].Statements, qt.HasLen, 2)
+	first := files[0].Statements[0]
+	second := files[0].Statements[1]
+	c.Assert(files[0].SQL[first.Span.Start:first.Span.End], qt.Equals, first.SQL)
+	c.Assert(files[0].SQL[second.Span.Start:second.Span.End], qt.Equals, second.SQL)
+	findings := analysis.Findings()
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101", "DS102"})
+	c.Assert(findings[0].Context.StatementIndex, qt.Equals, 0)
+	c.Assert(findings[1].Context.StatementIndex, qt.Equals, 1)
+}
+
+func TestAnalyzeFS_MultiTargetDropReportsOnlyUnsafeTables(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_cleanup.sql": "CREATE TABLE staging (id INTEGER); DROP TABLE staging, users, audit_log;",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+
+	findings := analysis.Findings()
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+	c.Assert(findings[0].Context.StatementIndex, qt.Equals, 1)
+	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
+		{Kind: lint.SubjectTable, Name: "users"},
+		{Kind: lint.SubjectTable, Name: "audit_log"},
+	})
+}
+
+func TestAnalyzeFS_DropTableSubjectsPreserveIdentifierSpelling(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_cleanup.sql": `DROP TABLE ONLY "Users", ONLY public."users" *;`,
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+
+	c.Assert(err, qt.IsNil)
+	findings := analysis.Findings()
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
+		{Kind: lint.SubjectTable, Name: `"Users"`},
+		{Kind: lint.SubjectTable, Name: `public."users"`},
+	})
+}
+
+func TestAnalyzeFS_SQLiteBracketedDropTableRetainsFindingContext(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_cleanup.sql": "DROP TABLE [Users];",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+
+	c.Assert(err, qt.IsNil)
+	findings := analysis.Findings()
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
+		{Kind: lint.SubjectTable, Name: "[Users]"},
+	})
+}
+
+func TestAnalyzeFS_ColumnFindingsExposeStructuredSubjects(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_change.sql": `ALTER TABLE public."Users" DROP COLUMN "Legacy", ADD COLUMN "TenantID" UUID NOT NULL;`,
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+
+	c.Assert(err, qt.IsNil)
+	findings := analysis.Findings()
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DD101", "DS102"})
+	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
+		{
+			Kind:     lint.SubjectColumn,
+			Name:     `"TenantID"`,
+			Parent:   `public."Users"`,
+			DataType: "UUID",
+		},
+	})
+	c.Assert(findings[1].Context.Subjects, qt.DeepEquals, []lint.Subject{
+		{
+			Kind:   lint.SubjectColumn,
+			Name:   `"Legacy"`,
+			Parent: `public."Users"`,
+		},
+	})
+}
+
+func TestAnalyzeFS_AtlasCompatibilityMapsStatementSuppressions(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_suppressed.sql": `-- atlas:nolint DS102
+DROP TABLE users;
+-- atlas:nolint DS103
+ALTER TABLE accounts DROP COLUMN legacy;
+-- atlas:nolint MF103
+ALTER TABLE accounts ADD COLUMN tenant_id INTEGER NOT NULL;
+`,
+	})
+
+	native, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"DS101", "DS102", "DD101"})
+
+	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Dialect:       "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(atlas.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_AtlasFileSuppressionIsCompatibilityScoped(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_suppressed.sql": `-- atlas:nolint destructive
+
+DROP TABLE users;
+ALTER TABLE accounts DROP COLUMN legacy;
+`,
+	})
+
+	native, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"DS101", "DS102"})
+
+	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(atlas.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_AtlasAnalyzerSuppressionsAreCompatibilityScoped(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_index.sql": `-- atlas:nolint concurrent_index
+CREATE INDEX idx_users_id ON users (id);
+`,
+		"2_rename.sql": `-- atlas:nolint incompatible
+ALTER TABLE users RENAME COLUMN old_name TO new_name;
+`,
+		"3_transaction.sql": `-- atlas:nolint nestedtx
+BEGIN;
+`,
+	})
+
+	native, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"PG101", "BC101", "TX201"})
+
+	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Dialect:       "postgres",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(atlas.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_AtlasAnalyzerFileHeaderSuppressesMappedFamilies(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_suppressed.sql": `-- atlas:nolint concurrent_index,incompatible,nestedtx
+
+CREATE INDEX idx_users_id ON users (id);
+ALTER TABLE users RENAME COLUMN old_name TO new_name;
+BEGIN;
+`,
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Dialect:       "postgres",
+	})
+
+	c.Assert(err, qt.IsNil)
+	files := analysis.Files()
+	c.Assert(files, qt.HasLen, 1)
+	c.Assert(files[0].Ignored, qt.IsFalse)
+	c.Assert(analysis.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_BareAtlasHeaderMarksOnlyCompatibilityFileIgnored(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_ignored.sql": `-- atlas:nolint
+
+DROP TABLE users;
+`,
+	})
+
+	native, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+	nativeFiles := native.Files()
+	c.Assert(nativeFiles, qt.HasLen, 1)
+	c.Assert(nativeFiles[0].Ignored, qt.IsFalse)
+	c.Assert(native.Findings(), qt.HasLen, 0)
+
+	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.IsNil)
+	atlasFiles := atlas.Files()
+	c.Assert(atlasFiles, qt.HasLen, 1)
+	c.Assert(atlasFiles[0].Ignored, qt.IsTrue)
+	c.Assert(atlas.Findings(), qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_CustomRuleCannotMutateCompletedAnalysis(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_select.sql": "SELECT 1;",
+	})
+	retainedContext := &lint.FindingContext{
+		StatementIndex: 0,
+		Subjects: []lint.Subject{
+			{Kind: lint.SubjectTable, Name: "users"},
+		},
+	}
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		ExtraRules: []lint.Rule{
+			{
+				Code:     "ZZ101",
+				Title:    "custom finding",
+				Severity: lint.SeverityWarning,
+				CheckFile: func(file *lint.File) []lint.Finding {
+					return []lint.Finding{
+						{
+							Rule:     "ZZ101",
+							Title:    "custom finding",
+							Severity: lint.SeverityWarning,
+							File:     file.Path,
+							Line:     file.Statements[0].Line,
+							Message:  "custom finding",
+							Context:  retainedContext,
+						},
+					}
+				},
+			},
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	retainedContext.Subjects[0].Name = "mutated"
+	findings := analysis.Findings()
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Context.Subjects[0].Name, qt.Equals, "users")
+}
+
+func TestAnalyzeFS_CapturesAtlasTemplateInputsOnce(t *testing.T) {
+	c := qt.New(t)
+	fsys := &changingSQLFS{
+		files: fstest.MapFS{
+			"atlas.sum": {
+				Data: []byte("h1:test\n"),
+			},
+			"1_template.sql": {
+				Data: []byte(`{{ template "shared/drop" . }}`),
+			},
+			"shared/drop.sql": {
+				Data: []byte(`{{ define "shared/drop" }}DROP TABLE users;{{ end }}`),
+			},
+		},
+		reads: map[string]int{},
+	}
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, []string{"DS101"})
+	c.Assert(fsys.reads, qt.DeepEquals, map[string]int{
+		"1_template.sql":  1,
+		"atlas.sum":       1,
+		"shared/drop.sql": 1,
+	})
+	c.Assert(analysis.Files(), qt.HasLen, 1)
+	c.Assert(fstest.TestFS(
+		analysis.SnapshotFS(),
+		"1_template.sql",
+		"atlas.sum",
+		"shared/drop.sql",
+	), qt.IsNil)
+}
+
+type changingSQLFS struct {
+	files fstest.MapFS
+	reads map[string]int
+}
+
+func (f *changingSQLFS) Open(name string) (fs.File, error) {
+	return f.files.Open(name)
+}
+
+func (f *changingSQLFS) ReadFile(name string) ([]byte, error) {
+	f.reads[name]++
+	contents, err := fs.ReadFile(f.files, name)
+	responses := [][]byte{contents, []byte("SELECT 1;")}
+	return slices.Clone(responses[min(f.reads[name]-1, 1)]), err
+}

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -38,14 +38,10 @@ type Config struct {
 	Rules map[string]RuleConfig `yaml:"rules"`
 }
 
-// LoadConfig reads a lint configuration file. A missing file at the
-// conventional location is not an error — callers get an empty config — but
-// an unreadable or malformed file is.
+// LoadConfig reads an explicit lint configuration file. Missing, unreadable,
+// and malformed files are errors.
 func LoadConfig(path string) (*Config, error) {
 	raw, err := os.ReadFile(path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return &Config{}, nil
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read lint config %s: %w", path, err)
 	}
@@ -56,8 +52,8 @@ func LoadConfig(path string) (*Config, error) {
 	return cfg, nil
 }
 
-// LoadConfigFS reads a lint configuration from fsys. A missing file is not an
-// error, matching LoadConfig's conventional-file behavior.
+// LoadConfigFS reads a conventional lint configuration from fsys. A missing
+// file is not an error.
 func LoadConfigFS(fsys fs.FS, name string) (*Config, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if errors.Is(err, fs.ErrNotExist) {

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -30,14 +30,12 @@
 package lint
 
 import (
-	"fmt"
-	"io/fs"
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 
+	"github.com/stokaro/ptah/internal/atlaslint"
 	"github.com/stokaro/ptah/internal/lexer"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/risk"
@@ -53,70 +51,6 @@ const (
 	// SeverityError marks patterns that destroy data or database objects.
 	SeverityError Severity = risk.Error
 )
-
-// Finding is one rule hit in one migration file.
-type Finding struct {
-	Rule     string   `json:"rule"`
-	Title    string   `json:"title"`
-	Severity Severity `json:"severity"`
-	File     string   `json:"file"`
-	// Line is the 1-based line of the offending statement's first token;
-	// zero for file-level findings (naming, pairing).
-	Line    int    `json:"line,omitempty"`
-	Message string `json:"message"`
-}
-
-// Statement is one SQL statement of a migration file, in the forms rules
-// consume.
-type Statement struct {
-	// SQL is the raw statement text as written (comments included).
-	SQL string
-	// Canonical is the comment-stripped, whitespace-collapsed, uppercased
-	// display form. String literals keep their original case.
-	Canonical string
-	// Words is the token-word sequence the built-in rules scan: comments and
-	// whitespace dropped, bare keywords/identifiers uppercased, punctuation
-	// as its own entry, string literals and quoted identifiers kept verbatim
-	// as single opaque words (so a literal containing "DROP COLUMN" or a
-	// column named "type" can never impersonate a keyword).
-	Words []string
-	// Line is the 1-based line number of the statement's first token.
-	Line int
-	// SuppressedRules lists rule codes or families suppressed by a leading
-	// ptah:nolint or atlas:nolint directive.
-	SuppressedRules []string
-}
-
-// File is one migration file prepared for linting.
-type File struct {
-	// Path is the file path as it should appear in findings (reporting
-	// prefix included).
-	Path string
-	// Name is the slash-separated path of the file relative to the linted
-	// directory (bare file name for root-level files).
-	Name string
-	// Direction is the migration direction ("up"/"down") exactly as the
-	// migrator's name parser classifies this file; empty when the migrator
-	// cannot parse the name at all.
-	Direction string
-	// IsUp reports whether statement rules treat this as an up migration:
-	// the migrator parses it as up, or its name carries the .up.sql suffix.
-	IsUp bool
-	// HasPair reports whether the matching counterpart file (down for up,
-	// up for down) exists in the same directory.
-	HasPair bool
-	// WellFormedName reports whether the name matches the documented
-	// NNNNNNNNNN_description.(up|down).sql convention, checked
-	// independently of the migrator's parser as defense in depth (see the
-	// strictNameRe comment).
-	WellFormedName bool
-	// NoTransaction reports whether file-scoped directives opt this migration
-	// out of the migrator's transaction wrapper.
-	NoTransaction bool
-	// Statements holds the parsed statements of up migrations. Empty for
-	// down migrations (statement rules do not run there).
-	Statements []Statement
-}
 
 // Rule is one lint check. Exactly one of CheckStatement / CheckFile is set.
 type Rule struct {
@@ -146,6 +80,9 @@ type RuleConfig struct {
 
 // Options configures a lint run.
 type Options struct {
+	// Compatibility selects command-surface-specific semantics. The zero value
+	// is native Ptah behavior.
+	Compatibility CompatibilityProfile
 	// Dialect gates dialect-specific rules — "postgres" enables PG rules,
 	// "mysql"/"mariadb" enable MY rules — and selects the dialect's lexing
 	// behavior (comment forms, string escape rules, dollar quotes). Empty
@@ -158,9 +95,9 @@ type Options struct {
 	// PathPrefix is prepended (with /) to file names in findings so they
 	// point at real repository paths in CI annotations.
 	PathPrefix string
-	// Versions restricts linting to parsed migration versions. Empty means
-	// every migration file is linted.
-	Versions []int64
+	// Selection restricts linting to parsed migration versions while retaining
+	// the full captured directory for reporting.
+	Selection VersionSelection
 	// DirFormat selects the migration filename/parser rules used by file-form
 	// linting. Empty uses auto detection.
 	DirFormat migrator.MigrationDirFormat
@@ -174,262 +111,6 @@ type Options struct {
 	// RuleConfigs carries per-rule severity and path-scoping overrides,
 	// normally loaded from .ptah-lint.yaml.
 	RuleConfigs map[string]RuleConfig
-}
-
-// LintFS lints every *.sql file under fsys — recursively, because the
-// migrator's FSMigrationProvider discovers migrations in subdirectories too —
-// and returns the findings ordered by file, line and rule code. The .sql
-// suffix is matched case-insensitively so that stray case variants (x.UP.SQL)
-// at least earn a naming warning instead of vanishing.
-func LintFS(fsys fs.FS, opts Options) ([]Finding, error) {
-	if err := validateRules(rulesForOptions(opts)); err != nil {
-		return nil, err
-	}
-	files, err := PrepareFS(fsys, opts)
-	if err != nil {
-		return nil, err
-	}
-	var findings []Finding
-	for _, file := range files {
-		findings = append(findings, runRules(file, opts)...)
-	}
-
-	sort.SliceStable(findings, func(i, j int) bool {
-		if findings[i].File != findings[j].File {
-			return findings[i].File < findings[j].File
-		}
-		if findings[i].Line != findings[j].Line {
-			return findings[i].Line < findings[j].Line
-		}
-		return findings[i].Rule < findings[j].Rule
-	})
-	return findings, nil
-}
-
-// PrepareFS loads and tokenizes every migration file under fsys using the
-// same dialect-aware scanner and naming rules as LintFS. Custom analyzer
-// packages can call this when they need Ptah-prepared File and Statement
-// values without reimplementing the scanner.
-func PrepareFS(fsys fs.FS, opts Options) ([]*File, error) {
-	dirFormat, err := migrator.ParseMigrationDirFormat(string(opts.DirFormat))
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	err = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if !d.IsDir() && strings.EqualFold(path.Ext(p), ".sql") {
-			names = append(names, p)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list migration files: %w", err)
-	}
-	if len(names) == 0 {
-		return nil, fmt.Errorf("no *.sql migration files found")
-	}
-	sort.Strings(names)
-	names = filterNamesByVersion(names, opts.Versions, dirFormat)
-	names, err = filterAtlasTemplateSupportNames(fsys, names, dirFormat)
-	if err != nil {
-		return nil, err
-	}
-	if len(names) == 0 {
-		return nil, nil
-	}
-
-	present := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		present[name] = struct{}{}
-	}
-
-	// Directions present per version, so pairing matches the migrator, which
-	// pairs an up and a down by their shared version prefix regardless of
-	// description — not by an identical file-name stem.
-	versionDirs := map[int64]map[string]bool{}
-	for _, name := range names {
-		if parsed, err := parseKnownMigrationName(path.Base(name), dirFormat); err == nil {
-			if versionDirs[parsed.Version] == nil {
-				versionDirs[parsed.Version] = map[string]bool{}
-			}
-			versionDirs[parsed.Version][parsed.Direction] = true
-		}
-	}
-
-	mode := modeForDialect(opts.Dialect)
-	files := make([]*File, 0, len(names))
-	for _, name := range names {
-		file, err := prepareFile(
-			fsys,
-			name,
-			present,
-			versionDirs,
-			opts.PathPrefix,
-			mode,
-			opts.AtlasTemplateData,
-			dirFormat,
-		)
-		if err != nil {
-			return nil, err
-		}
-		files = append(files, file)
-	}
-	return files, nil
-}
-
-func filterNamesByVersion(names []string, versions []int64, dirFormat migrator.MigrationDirFormat) []string {
-	if len(versions) == 0 {
-		return names
-	}
-	allowed := make(map[int64]struct{}, len(versions))
-	for _, version := range versions {
-		allowed[version] = struct{}{}
-	}
-	var filtered []string
-	for _, name := range names {
-		parsed, err := parseKnownMigrationName(path.Base(name), dirFormat)
-		if err != nil {
-			continue
-		}
-		if _, ok := allowed[parsed.Version]; ok {
-			filtered = append(filtered, name)
-		}
-	}
-	return filtered
-}
-
-func filterAtlasTemplateSupportNames(
-	fsys fs.FS,
-	names []string,
-	dirFormat migrator.MigrationDirFormat,
-) ([]string, error) {
-	hasAtlasTemplate, err := hasAtlasTemplateMigration(fsys, names, dirFormat)
-	if err != nil || !hasAtlasTemplate {
-		return names, err
-	}
-
-	filtered := make([]string, 0, len(names))
-	for _, name := range names {
-		if _, err := parseKnownMigrationName(path.Base(name), dirFormat); err == nil {
-			filtered = append(filtered, name)
-			continue
-		}
-		support, err := isAtlasTemplateSupportFile(fsys, name)
-		if err != nil {
-			return nil, err
-		}
-		if !support {
-			filtered = append(filtered, name)
-		}
-	}
-	return filtered, nil
-}
-
-func hasAtlasTemplateMigration(fsys fs.FS, names []string, dirFormat migrator.MigrationDirFormat) (bool, error) {
-	for _, name := range names {
-		parsed, err := parseKnownMigrationName(path.Base(name), dirFormat)
-		if err != nil || parsed.Format != migrator.MigrationDirFormatAtlas {
-			continue
-		}
-		raw, err := fs.ReadFile(fsys, name)
-		if err != nil {
-			return false, fmt.Errorf("failed to read %s: %w", name, err)
-		}
-		if migrator.LooksAtlasTemplateSQL(string(raw)) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-func isAtlasTemplateSupportFile(fsys fs.FS, name string) (bool, error) {
-	raw, err := fs.ReadFile(fsys, name)
-	if err != nil {
-		return false, fmt.Errorf("failed to read %s: %w", name, err)
-	}
-	sql := string(raw)
-	return migrator.LooksAtlasTemplateSQL(sql) && strings.Contains(sql, "define "), nil
-}
-
-// prepareFile loads one migration file into the forms rules consume.
-func prepareFile(
-	fsys fs.FS,
-	name string,
-	present map[string]struct{},
-	versionDirs map[int64]map[string]bool,
-	pathPrefix string,
-	mode scanMode,
-	atlasTemplateData any,
-	dirFormat migrator.MigrationDirFormat,
-) (*File, error) {
-	raw, err := fs.ReadFile(fsys, name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read %s: %w", name, err)
-	}
-
-	base := path.Base(name)
-	direction := ""
-	var version int64
-	hasVersion := false
-	atlasFormat := false
-	if parsed, parseErr := parseKnownMigrationName(base, dirFormat); parseErr == nil {
-		direction = parsed.Direction
-		version = parsed.Version
-		hasVersion = true
-		atlasFormat = parsed.Format == migrator.MigrationDirFormatAtlas
-	}
-	file := &File{
-		Path:      path.Join(pathPrefix, name),
-		Name:      name,
-		Direction: direction,
-		// The migrator executes whatever its parser classifies as up, so
-		// lint must follow it; the suffix check keeps hazard scanning for
-		// .up.sql files whose version prefix is malformed.
-		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
-		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
-		NoTransaction:  fileNoTransactionDirective(string(raw)),
-	}
-	switch {
-	case atlasFormat:
-		file.HasPair = true
-	case hasVersion:
-		// Pair by version, matching the migrator: the counterpart is any
-		// file of the same version in the opposite direction.
-		counterpart := "down"
-		if direction == "down" {
-			counterpart = "up"
-		}
-		file.HasPair = versionDirs[version][counterpart]
-	case file.IsUp:
-		_, file.HasPair = present[strings.TrimSuffix(name, ".up.sql")+".down.sql"]
-	case strings.HasSuffix(name, ".down.sql"):
-		_, file.HasPair = present[strings.TrimSuffix(name, ".down.sql")+".up.sql"]
-	}
-
-	// Statement rules apply to up migrations only.
-	if file.IsUp {
-		sql := string(raw)
-		if atlasFormat && migrator.LooksAtlasTemplateSQL(sql) {
-			rendered, _, err := migrator.RenderAtlasTemplateSQL(fsys, name, atlasTemplateData)
-			if err != nil {
-				return nil, err
-			}
-			sql = rendered
-		}
-		for _, rawStmt := range splitStatementsWithLines(sql, mode) {
-			file.Statements = append(file.Statements, Statement{
-				SQL:             rawStmt.text,
-				Canonical:       canonicalize(rawStmt.text, mode),
-				Words:           tokenizeWords(rawStmt.text, mode),
-				Line:            rawStmt.line,
-				SuppressedRules: rawStmt.suppressedRules,
-			})
-		}
-	}
-	return file, nil
 }
 
 func parseKnownMigrationName(name string, dirFormat migrator.MigrationDirFormat) (*migrator.MigrationFile, error) {
@@ -495,6 +176,7 @@ func runRules(file *File, opts Options) []Finding {
 	var findings []Finding
 	for _, rule := range rulesForOptions(opts) {
 		if ruleDisabled(rule.Code, opts.Disabled) ||
+			fileSuppressesRule(file, rule.Code) ||
 			!ruleAppliesToDialect(rule, opts.Dialect) ||
 			ruleExcludedForFile(rule.Code, file, opts.RuleConfigs) {
 			continue
@@ -506,6 +188,7 @@ func runRules(file *File, opts Options) []Finding {
 					continue
 				}
 				finding.Severity = severity
+				attachUniqueStatementContext(file, &finding)
 				findings = append(findings, finding)
 			}
 			continue
@@ -522,6 +205,14 @@ func runRules(file *File, opts Options) []Finding {
 					File:     file.Path,
 					Line:     file.Statements[i].Line,
 					Message:  message,
+					Context: statementFindingContext(
+						i,
+						statementSubjects(
+							rule.Code,
+							file.Statements[i].Words,
+							file.Statements[i].sourceWords,
+						)...,
+					),
 				})
 			}
 		}
@@ -574,7 +265,15 @@ func ruleConfigForCode(code string, configs map[string]RuleConfig) (RuleConfig, 
 }
 
 func statementSuppressesRule(stmt *Statement, code string) bool {
-	for _, entry := range stmt.SuppressedRules {
+	return suppressesRule(stmt.suppressedRules, code)
+}
+
+func fileSuppressesRule(file *File, code string) bool {
+	return suppressesRule(file.suppressedRules, code)
+}
+
+func suppressesRule(entries []string, code string) bool {
+	for _, entry := range entries {
 		if entry == "*" || strings.HasPrefix(code, entry) {
 			return true
 		}
@@ -582,17 +281,53 @@ func statementSuppressesRule(stmt *Statement, code string) bool {
 	return false
 }
 
+func statementFindingContext(index int, subjects ...Subject) *FindingContext {
+	return &FindingContext{
+		StatementIndex: index,
+		Subjects:       slices.Clone(subjects),
+	}
+}
+
+func attachUniqueStatementContext(file *File, finding *Finding) {
+	if finding.Context != nil || finding.Line == 0 {
+		return
+	}
+	index := -1
+	for i := range file.Statements {
+		if file.Statements[i].Line != finding.Line {
+			continue
+		}
+		if index >= 0 {
+			return
+		}
+		index = i
+	}
+	if index >= 0 {
+		finding.Context = statementFindingContext(index)
+	}
+}
+
 func fileFindingSuppressed(file *File, finding Finding) bool {
+	if finding.Context != nil {
+		index := finding.Context.StatementIndex
+		return index >= 0 &&
+			index < len(file.Statements) &&
+			statementSuppressesRule(&file.Statements[index], finding.Rule)
+	}
 	if finding.Line == 0 {
 		return false
 	}
+	index := -1
 	for i := range file.Statements {
-		stmt := &file.Statements[i]
-		if stmt.Line == finding.Line && statementSuppressesRule(stmt, finding.Rule) {
-			return true
+		if file.Statements[i].Line != finding.Line {
+			continue
 		}
+		if index >= 0 {
+			return false
+		}
+		index = i
 	}
-	return false
+	return index >= 0 && statementSuppressesRule(&file.Statements[index], finding.Rule)
 }
 
 func pathGlobMatches(pattern, value string) bool {
@@ -662,6 +397,8 @@ var strictNameRe = regexp.MustCompile(`^\d{10}_.+\.(up|down)\.sql$`)
 type rawStatement struct {
 	text            string
 	line            int
+	start           int
+	end             int
 	suppressedRules []string
 }
 
@@ -669,7 +406,11 @@ type rawStatement struct {
 // scanner (so semicolons inside strings, comments, executable comments and
 // dollar-quoted bodies do not terminate statements) while tracking each
 // statement's starting line.
-func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
+func splitStatementsWithLines(
+	raw string,
+	mode scanMode,
+	compatibility CompatibilityProfile,
+) []rawStatement {
 	var statements []rawStatement
 	start := -1
 	end := 0
@@ -681,7 +422,13 @@ func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
 		switch tok.kind {
 		case tokSemicolon:
 			if start >= 0 {
-				statements = append(statements, rawStatement{text: raw[start:end], line: startLine, suppressedRules: activeSuppressions})
+				statements = append(statements, rawStatement{
+					text:            raw[start:end],
+					line:            startLine,
+					start:           start,
+					end:             end,
+					suppressedRules: activeSuppressions,
+				})
 				start = -1
 				activeSuppressions = nil
 				lastStatementEndLine = tok.line
@@ -691,7 +438,10 @@ func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
 			// comments/whitespace are not included in the statement text.
 		case tokComment:
 			if start < 0 && tok.line != lastStatementEndLine {
-				pendingSuppressions = append(pendingSuppressions, parseNoLintDirective(tok.text)...)
+				pendingSuppressions = append(
+					pendingSuppressions,
+					parseNoLintDirective(tok.text, compatibility)...,
+				)
 			}
 		default:
 			if start < 0 {
@@ -704,27 +454,97 @@ func splitStatementsWithLines(raw string, mode scanMode) []rawStatement {
 		}
 	}
 	if start >= 0 {
-		statements = append(statements, rawStatement{text: raw[start:end], line: startLine, suppressedRules: activeSuppressions})
+		statements = append(statements, rawStatement{
+			text:            raw[start:end],
+			line:            startLine,
+			start:           start,
+			end:             end,
+			suppressedRules: activeSuppressions,
+		})
 	}
 	return statements
 }
 
-func parseNoLintDirective(comment string) []string {
+func parseNoLintDirective(
+	comment string,
+	compatibility CompatibilityProfile,
+) []string {
 	trimmed := strings.TrimSpace(comment)
 	if !strings.HasPrefix(trimmed, "--") && !strings.HasPrefix(trimmed, "#") {
 		return nil
 	}
-	lower := strings.ToLower(comment)
-	idx := strings.Index(lower, "ptah:nolint")
-	markerLen := len("ptah:nolint")
-	if idx < 0 {
-		idx = strings.Index(lower, "atlas:nolint")
-		markerLen = len("atlas:nolint")
+	if rules, ok := parseNoLintMarker(comment, "ptah:nolint", nativeNoLintTargets); ok {
+		return rules
 	}
-	if idx < 0 {
-		return nil
+	targets := nativeNoLintTargets
+	if compatibility == CompatibilityProfileAtlas {
+		targets = atlaslint.NativeSuppressionTargets
 	}
-	rest := strings.TrimSpace(comment[idx+markerLen:])
+	rules, _ := parseNoLintMarker(comment, "atlas:nolint", targets)
+	return rules
+}
+
+func parseAtlasFileNoLint(sql string) ([]string, bool) {
+	lines := strings.Split(sql, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimPrefix(line, "\uFEFF"))
+		if trimmed == "" {
+			continue
+		}
+		rules, ok := parseAtlasNoLintLine(trimmed)
+		if !ok {
+			return nil, false
+		}
+		for _, following := range lines[i+1:] {
+			trimmedFollowing := strings.TrimSpace(following)
+			if trimmedFollowing == "" {
+				return rules, suppressesRule(rules, "*")
+			}
+			if strings.HasPrefix(trimmedFollowing, "--") {
+				continue
+			}
+			return nil, false
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
+func parseAtlasNoLintLine(line string) ([]string, bool) {
+	comment, ok := strings.CutPrefix(strings.TrimSpace(line), "--")
+	if !ok {
+		return nil, false
+	}
+	body := strings.TrimSpace(comment)
+	const marker = "atlas:nolint"
+	if len(body) < len(marker) || !strings.EqualFold(body[:len(marker)], marker) {
+		return nil, false
+	}
+	rest := body[len(marker):]
+	if rest != "" && !isNoLintSeparator(rune(rest[0])) {
+		return nil, false
+	}
+	return parseNoLintRules(rest, atlaslint.NativeSuppressionTargets), true
+}
+
+func parseNoLintMarker(
+	comment string,
+	marker string,
+	targets func(string) []string,
+) ([]string, bool) {
+	idx := strings.Index(strings.ToLower(comment), marker)
+	if idx < 0 {
+		return nil, false
+	}
+	rest := comment[idx+len(marker):]
+	if rest != "" && !isNoLintSeparator(rune(rest[0])) {
+		return nil, false
+	}
+	return parseNoLintRules(rest, targets), true
+}
+
+func parseNoLintRules(rest string, targets func(string) []string) []string {
+	rest = strings.TrimSpace(rest)
 	if rest == "" {
 		return []string{"*"}
 	}
@@ -732,11 +552,16 @@ func parseNoLintDirective(comment string) []string {
 	rules := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.ToUpper(strings.TrimSpace(part))
-		if part != "" {
-			rules = append(rules, part)
+		if part == "" {
+			continue
 		}
+		rules = append(rules, targets(part)...)
 	}
 	return rules
+}
+
+func nativeNoLintTargets(entry string) []string {
+	return []string{entry}
 }
 
 func isNoLintSeparator(r rune) bool {
@@ -785,6 +610,19 @@ func tokenizeWords(sql string, mode scanMode) []string {
 			words = append(words, tok.text)
 		default:
 			words = append(words, strings.ToUpper(tok.text))
+		}
+	}
+	return words
+}
+
+func tokenizeSourceWords(sql string, mode scanMode) []string {
+	var words []string
+	for _, tok := range scanSQL(sql, mode) {
+		switch tok.kind {
+		case tokComment, tokWhitespace:
+			continue
+		default:
+			words = append(words, tok.text)
 		}
 	}
 	return words

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -83,7 +83,10 @@ func TestLintFS_VersionsRestrictsFindings(t *testing.T) {
 
 	findings, err := lint.LintFS(fsys, lint.Options{
 		Disabled: []string{"MF", "BC", "PG", "MY"},
-		Versions: []int64{2},
+		Selection: lint.VersionSelection{
+			Versions:   []int64{2},
+			Restricted: true,
+		},
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS102"})
@@ -743,7 +746,7 @@ ALTER TABLE users MODIFY COLUMN email VARCHAR(64);
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"PG101", "DS103", "MY101"})
 }
 
-func TestLintFS_CustomRuleAndPrepareFSUsePublicScanner(t *testing.T) {
+func TestAnalyzeFS_CustomRuleUsesPublicScanner(t *testing.T) {
 	c := qt.New(t)
 
 	fsys := fixture(map[string]string{
@@ -751,33 +754,30 @@ func TestLintFS_CustomRuleAndPrepareFSUsePublicScanner(t *testing.T) {
 		"0000000001_create_users.down.sql": "DROP TABLE users;\n",
 	})
 
-	files, err := lint.PrepareFS(fsys, lint.Options{})
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{})
 	c.Assert(err, qt.IsNil)
+	files := analysis.Files()
 	c.Assert(files, qt.HasLen, 2)
-	var upFile *lint.File
-	for _, file := range files {
-		if file.IsUp {
-			upFile = file
-		}
-	}
-	c.Assert(upFile, qt.IsNotNil)
-	c.Assert(upFile.Statements[0].Words, qt.DeepEquals, []string{"CREATE", "TABLE", "USERS", "(", "ID", "INT", ")"})
+	c.Assert(files[1].Name, qt.Equals, "0000000001_create_users.up.sql")
+	c.Assert(files[1].Statements[0].Words, qt.DeepEquals, []string{"CREATE", "TABLE", "USERS", "(", "ID", "INT", ")"})
 
 	customRule := lint.Rule{
-		Code:     "XX001",
-		Title:    "custom create table analyzer",
-		Severity: lint.SeverityWarning,
-		CheckStatement: func(stmt *lint.Statement) (bool, string) {
-			if len(stmt.Words) >= 3 && stmt.Words[0] == "CREATE" && stmt.Words[1] == "TABLE" {
-				return true, "custom analyzer saw a create table statement through Ptah's scanner"
-			}
-			return false, ""
-		},
+		Code:           "XX001",
+		Title:          "custom create table analyzer",
+		Severity:       lint.SeverityWarning,
+		CheckStatement: checkCustomCreateTable,
 	}
 	findings, err := lint.LintFS(fsys, lint.Options{ExtraRules: []lint.Rule{customRule}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"XX001"})
 	c.Assert(findings[0].Message, qt.Contains, "Ptah's scanner")
+}
+
+func checkCustomCreateTable(stmt *lint.Statement) (bool, string) {
+	if len(stmt.Words) >= 3 && stmt.Words[0] == "CREATE" && stmt.Words[1] == "TABLE" {
+		return true, "custom analyzer saw a create table statement through Ptah's scanner"
+	}
+	return false, ""
 }
 
 func TestLintFS_InvalidCustomRuleFailsFast(t *testing.T) {
@@ -962,7 +962,7 @@ func TestLintFS_NoMigrationFilesIsAnError(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, "no \\*\\.sql migration files found")
 }
 
-func TestLoadConfig(t *testing.T) {
+func TestLoadConfig_HappyPath(t *testing.T) {
 	c := qt.New(t)
 
 	dir := t.TempDir()
@@ -983,21 +983,37 @@ rules:
 	c.Assert(cfg.DisabledRules, qt.DeepEquals, []string{"MF", "BC101"})
 	c.Assert(cfg.Rules["DS103"].Severity, qt.Equals, lint.SeverityWarning)
 	c.Assert(cfg.Rules["DS103"].Exclude, qt.DeepEquals, []string{"legacy/**"})
+}
 
-	// A missing file at the conventional location is not an error.
-	cfg, err = lint.LoadConfig(dir + "/nope.yaml")
-	c.Assert(err, qt.IsNil)
-	c.Assert(cfg.Dialect, qt.Equals, "")
-	c.Assert(cfg.DisabledRules, qt.HasLen, 0)
+func TestLoadConfig_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
 
-	// A malformed file is.
+	c.Run("missing explicit file", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/nope.yaml")
+		c.Assert(err, qt.ErrorMatches, "failed to read lint config .*nope.yaml.*")
+	})
+
 	c.Assert(writeFile(dir+"/broken.yaml", "dialect: [not, a, string"), qt.IsNil)
-	_, err = lint.LoadConfig(dir + "/broken.yaml")
-	c.Assert(err, qt.ErrorMatches, "failed to parse lint config .*")
+	c.Run("malformed YAML", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/broken.yaml")
+		c.Assert(err, qt.ErrorMatches, "failed to parse lint config .*")
+	})
 
 	c.Assert(writeFile(dir+"/bad-severity.yaml", "rules:\n  DS102:\n    severity: fatal\n"), qt.IsNil)
-	_, err = lint.LoadConfig(dir + "/bad-severity.yaml")
-	c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported severity "fatal".*`)
+	c.Run("invalid rule severity", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/bad-severity.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported severity "fatal".*`)
+	})
+}
+
+func TestLoadConfigFS_MissingConventionalFileReturnsEmptyConfig(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := lint.LoadConfigFS(fstest.MapFS{}, lint.ConfigFileName)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg, qt.DeepEquals, &lint.Config{})
 }
 
 func TestRules_EveryRuleHasCodeTitleAndOneChecker(t *testing.T) {

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -134,8 +134,16 @@ func tableDroppedRule() Rule {
 					created[ref] = true
 					continue
 				}
-				if !hasWordPrefix(stmt.Words, "DROP", "TABLE") || dropsOnlyCreatedTables(stmt.Words, created) {
+				if !hasWordPrefix(stmt.Words, "DROP", "TABLE") {
 					continue
+				}
+				unsafeTables, complete := droppedTablesNotCreated(stmt.Words, stmt.sourceWords, created)
+				if complete && len(unsafeTables) == 0 {
+					continue
+				}
+				subjects := make([]Subject, len(unsafeTables))
+				for j, table := range unsafeTables {
+					subjects[j] = Subject{Kind: SubjectTable, Name: table.name}
 				}
 				findings = append(findings, Finding{
 					Rule:     "DS101",
@@ -144,6 +152,7 @@ func tableDroppedRule() Rule {
 					File:     file.Path,
 					Line:     stmt.Line,
 					Message:  "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead",
+					Context:  statementFindingContext(i, subjects...),
 				})
 			}
 			return findings
@@ -458,6 +467,7 @@ func postgresCreateIndexRule() Rule {
 					File:     file.Path,
 					Line:     stmt.Line,
 					Message:  "CREATE INDEX without CONCURRENTLY blocks writes to the table for the whole build; on a populated table use CREATE INDEX CONCURRENTLY outside a transaction",
+					Context:  statementFindingContext(i),
 				})
 			}
 			return findings
@@ -497,6 +507,7 @@ func postgresConcurrentIndexRule() Rule {
 					File:     file.Path,
 					Line:     stmt.Line,
 					Message:  "CONCURRENTLY cannot run inside PostgreSQL's normal migration transaction; mark the migration non-transactional before applying",
+					Context:  statementFindingContext(i),
 				})
 			}
 			return findings
@@ -736,6 +747,7 @@ func transactionRules() []Rule {
 					File:     file.Path,
 					Line:     nonTransactional.Line,
 					Message:  "this migration mixes PostgreSQL statements that require autocommit with transactional DDL; split them into separate migrations",
+					Context:  statementFindingContext(nonTransactional.Index),
 				}}
 			},
 		},
@@ -860,11 +872,8 @@ func clauseStarts(w []string) []int {
 		}
 		break
 	}
-	if j < len(w) && identLike(w[j]) {
-		j++
-		for j+1 < len(w) && w[j] == "." && identLike(w[j+1]) {
-			j += 2 // schema-qualified reference: schema.tbl
-		}
+	if ref, next := tableRefAt(w, w, j); ref.normalized != "" {
+		j = next
 		if j < len(w) && w[j] == "*" {
 			j++ // postgres: name * (include descendant tables)
 		}
@@ -893,6 +902,12 @@ func clauseStarts(w []string) []int {
 // clause-head DROP followed by an identifier counts unless the identifier is
 // a known non-column DROP target (DROP CONSTRAINT, DROP PRIMARY KEY, ...).
 func scanDropColumn(w []string) bool {
+	return len(droppedColumnSubjects(w, w)) > 0
+}
+
+func droppedColumnSubjects(w, sourceWords []string) []Subject {
+	table := alterTableReference(w, sourceWords)
+	var subjects []Subject
 	for _, i := range clauseStarts(w) {
 		if i >= len(w) || w[i] != "DROP" {
 			continue
@@ -911,10 +926,14 @@ func scanDropColumn(w []string) bool {
 			continue
 		}
 		if identLike(w[j]) {
-			return true
+			subjects = append(subjects, Subject{
+				Kind:   SubjectColumn,
+				Name:   sourceWordAt(w, sourceWords, j),
+				Parent: table.name,
+			})
 		}
 	}
-	return false
+	return subjects
 }
 
 // scanModifyChange reports whether an ALTER TABLE statement rewrites a column
@@ -1048,6 +1067,12 @@ func scanConvertCharset(w []string) bool {
 }
 
 func scanAddColumnNotNullWithoutDefault(w []string) bool {
+	return len(nonNullableAddedColumnSubjects(w, w)) > 0
+}
+
+func nonNullableAddedColumnSubjects(w, sourceWords []string) []Subject {
+	table := alterTableReference(w, sourceWords)
+	var subjects []Subject
 	for _, i := range clauseStarts(w) {
 		start, end, ok := addColumnClause(w, i)
 		if !ok {
@@ -1055,10 +1080,44 @@ func scanAddColumnNotNullWithoutDefault(w []string) bool {
 		}
 		clause := w[start:end]
 		if hasWordSeq(clause, "NOT", "NULL") && !slices.Contains(clause, "DEFAULT") {
-			return true
+			subjects = append(subjects, Subject{
+				Kind:     SubjectColumn,
+				Name:     sourceWordAt(w, sourceWords, start-1),
+				Parent:   table.name,
+				DataType: columnDataType(clause, sourceWords[start:end]),
+			})
 		}
 	}
-	return false
+	return subjects
+}
+
+func columnDataType(definition, sourceDefinition []string) string {
+	end := len(definition)
+	depth := 0
+	for i, word := range definition {
+		switch word {
+		case "(", "[":
+			depth++
+		case ")", "]":
+			depth = max(0, depth-1)
+		default:
+			if depth == 0 && columnConstraintWord(word) {
+				end = i
+				return strings.Join(sourceDefinition[:end], " ")
+			}
+		}
+	}
+	return strings.Join(sourceDefinition[:end], " ")
+}
+
+func columnConstraintWord(word string) bool {
+	switch word {
+	case "CHECK", "COLLATE", "COMMENT", "CONSTRAINT", "DEFAULT", "GENERATED",
+		"IDENTITY", "NOT", "NULL", "PRIMARY", "REFERENCES", "UNIQUE":
+		return true
+	default:
+		return false
+	}
 }
 
 func scanAddColumnWithVolatileDefault(w []string) bool {
@@ -1345,24 +1404,102 @@ func createdTableRef(w []string) string {
 	if j+2 < len(w) && w[j] == "IF" && w[j+1] == "NOT" && w[j+2] == "EXISTS" {
 		j += 3
 	}
-	ref, _ := tableRefAt(w, j)
-	return ref
+	ref, _ := tableRefAt(w, w, j)
+	return ref.normalized
 }
 
 // tableRefAt reads a possibly schema-qualified table reference at w[j] and
-// returns it normalized plus the index past its end; "" when w[j] does not
-// start a reference.
-func tableRefAt(w []string, j int) (string, int) {
-	if j >= len(w) || !identLike(w[j]) {
-		return "", j
+// returns separate display and comparison forms plus the index past its end.
+func tableRefAt(w, sourceWords []string, j int) (tableReference, int) {
+	identifier, next, ok := identifierAt(w, sourceWords, j)
+	if !ok {
+		return tableReference{}, j
 	}
-	parts := []string{normalizeIdent(w[j])}
-	j++
-	for j+1 < len(w) && w[j] == "." && identLike(w[j+1]) {
-		parts = append(parts, normalizeIdent(w[j+1]))
-		j += 2
+	displayParts := []string{identifier.name}
+	normalizedParts := []string{identifier.normalized}
+	j = next
+	for j < len(w) && w[j] == "." {
+		identifier, next, ok = identifierAt(w, sourceWords, j+1)
+		if !ok {
+			break
+		}
+		displayParts = append(displayParts, identifier.name)
+		normalizedParts = append(normalizedParts, identifier.normalized)
+		j = next
 	}
-	return strings.Join(parts, "."), j
+	return tableReference{
+		name:       strings.Join(displayParts, "."),
+		normalized: strings.Join(normalizedParts, "."),
+	}, j
+}
+
+func identifierAt(w, sourceWords []string, index int) (tableReference, int, bool) {
+	if index >= len(w) {
+		return tableReference{}, index, false
+	}
+	if identLike(w[index]) {
+		return tableReference{
+			name:       sourceWordAt(w, sourceWords, index),
+			normalized: normalizeIdent(w[index]),
+		}, index + 1, true
+	}
+	if w[index] != "[" {
+		return tableReference{}, index, false
+	}
+	end := index + 1
+	for end < len(w) && w[end] != "]" {
+		end++
+	}
+	if end == index+1 || end >= len(w) {
+		return tableReference{}, index, false
+	}
+	return tableReference{
+		name:       "[" + strings.Join(sourceWords[index+1:end], " ") + "]",
+		normalized: strings.ToUpper(strings.Join(w[index+1:end], " ")),
+	}, end + 1, true
+}
+
+type tableReference struct {
+	name       string
+	normalized string
+}
+
+func alterTableReference(w, sourceWords []string) tableReference {
+	if !hasWordPrefix(w, "ALTER", "TABLE") {
+		return tableReference{}
+	}
+	j := 2
+	for j < len(w) {
+		if w[j] == "ONLY" {
+			j++
+			continue
+		}
+		if next := skipIfExists(w, j); next != j {
+			j = next
+			continue
+		}
+		break
+	}
+	ref, _ := tableRefAt(w, sourceWords, j)
+	return ref
+}
+
+func statementSubjects(code string, words, sourceWords []string) []Subject {
+	switch code {
+	case "DS102":
+		return droppedColumnSubjects(words, sourceWords)
+	case "DD101":
+		return nonNullableAddedColumnSubjects(words, sourceWords)
+	default:
+		return nil
+	}
+}
+
+func sourceWordAt(words, sourceWords []string, index int) string {
+	if index < len(sourceWords) {
+		return sourceWords[index]
+	}
+	return words[index]
 }
 
 // normalizeIdent strips identifier quoting and uppercases for comparison.
@@ -1392,20 +1529,35 @@ func refersToCreated(created map[string]bool, ref string) bool {
 	return false
 }
 
-// dropsOnlyCreatedTables reports whether every table named by a DROP TABLE
-// statement was created earlier in the same file.
-func dropsOnlyCreatedTables(w []string, created map[string]bool) bool {
+// droppedTablesNotCreated returns tables that were not created earlier in the
+// same file and whether every target was parsed. An incomplete parse must remain
+// destructive because treating an unknown target as safe would be fail-open.
+func droppedTablesNotCreated(
+	w []string,
+	sourceWords []string,
+	created map[string]bool,
+) ([]tableReference, bool) {
+	var unsafe []tableReference
 	j := skipIfExists(w, 2)
 	for {
-		ref, next := tableRefAt(w, j)
-		if ref == "" || !refersToCreated(created, ref) {
-			return false
+		if j < len(w) && w[j] == "ONLY" {
+			j++
+		}
+		ref, next := tableRefAt(w, sourceWords, j)
+		if ref.normalized == "" {
+			return unsafe, false
+		}
+		if !refersToCreated(created, ref.normalized) {
+			unsafe = append(unsafe, ref)
+		}
+		if next < len(w) && w[next] == "*" {
+			next++
 		}
 		if next < len(w) && w[next] == "," {
 			j = next + 1
 			continue
 		}
-		return true
+		return unsafe, true
 	}
 }
 
@@ -1414,8 +1566,8 @@ func dropsOnlyCreatedTables(w []string, created map[string]bool) bool {
 func indexTargetRef(w []string) string {
 	for k := range w {
 		if w[k] == "ON" {
-			ref, _ := tableRefAt(w, k+1)
-			return ref
+			ref, _ := tableRefAt(w, w, k+1)
+			return ref.normalized
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary

- add an immutable migration-analysis snapshot that reads and prepares each migration file once
- make native and Atlas lint semantics explicit through typed compatibility profiles, keeping Atlas aliases and file-wide suppressions out of native Ptah behavior
- attach stable statement identities, source spans, and affected-object metadata to findings so report renderers do not reread or reparsed mutable SQL
- make native, Atlas-compatible, safety-gate, and replay paths consume the same snapshot
- run destructive migration safety under the migrator advisory lock and validate replay providers before cleaning a dev database
- document the public API, reusable analysis workflow, compatibility semantics, and immutable migration execution contract

## Regression coverage

- native DD101 behavior and native destructive blocking with Atlas-only aliases
- Atlas file-wide and statement-local suppressions
- same-line statement association and multi-target destructive DDL subjects
- changing-filesystem and deleted-source-directory snapshots
- exact version selection, report ordering, provider wiring, and dev-database preservation on provider failure
- command and migration-up integration paths

## Validation

- `go test ./...`
- `go test -race ./migration/lint ./internal/atlaslint ./internal/fsnapshot ./internal/migrationsnapshot ./internal/atlasreport ./internal/migrationlintreport ./internal/migrationreplay ./cmd/internal/dbcli ./cmd/migrateup ./cmd/atlas`
- `go vet ./...`
- `go tool qtlint ./...`
- `go tool teststyle -root . -baseline .teststyle-baseline.json`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- both `ptah` and `ptah-compat` builds
- documentation build, versions/exit-code/core-link/page-health/link checks, link self-test, and `npm audit --audit-level=low`

Closes #754