### PR TITLE
Re-sync testkit module after the go.yaml.in/yaml/v3 bump

### DIFF
--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     paths:
       - "testkit/**"
+      # The testkit module depends on the root module via `replace => ..`, so a
+      # root dependency change (e.g. a Renovate bump of go.mod/go.sum) can leave
+      # testkit/go.mod out of sync. Re-run testkit on those PRs so the module
+      # inconsistency is caught before it reaches master.
+      - "go.mod"
+      - "go.sum"
       - ".github/workflows/testkit.yml"
 
 env:

--- a/testkit/go.mod
+++ b/testkit/go.mod
@@ -84,7 +84,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/testkit/go.sum
+++ b/testkit/go.sum
@@ -203,8 +203,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
-go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=


### PR DESCRIPTION
## Problem

The **testkit** workflow has been failing on **every push to master for ~22 commits** (since `1bd7efb`, "Update module go.yaml.in/yaml/v3 to v3.0.5 (#731)"). Every other check is green, so it was easy to miss: testkit runs on `push: master` but, on pull requests, only when `testkit/**` or the workflow file changes — so the root-only dependency bump never re-ran it, and the failure only surfaced after the PR merged to master.

Both testkit jobs (`sqlite`, `containers`) fail identically before any test runs:

```
go: updates to go.mod needed; to update it:
	go mod tidy
```

## Root cause

`testkit` is a **separate module** (`replace github.com/stokaro/ptah => ..`) that tracks the root module's dependency graph. #731 bumped `go.yaml.in/yaml/v3` to `v3.0.5` in the root `go.mod` but left `testkit/go.mod` pinning the `v3.0.4` indirect requirement. `go test` in `testkit/` then fails the module-consistency check.

## Fix

- `go mod tidy` in `testkit`: bump the indirect `go.yaml.in/yaml/v3` to `v3.0.5` and refresh `go.sum`, matching the root module. Minimal diff (one require line + two go.sum lines).
- **Prevent recurrence:** broaden the testkit workflow's `pull_request` `paths` to include the root `go.mod`/`go.sum`, so a future root dependency change (e.g. a Renovate bump) re-runs testkit on the PR and this module drift is caught before it lands on master.

## Verification

Locally (`GOWORK=off`, as the workflow sets): `go test ./...` in `testkit` passes; `go build`/`go vet -tags=testkitcontainers ./...` pass the module check (container tests themselves need Docker, available on CI); and re-running `go mod tidy` produces no further changes. Because this PR touches `testkit/**` and the workflow file, the **testkit** workflow runs on this PR and will confirm both jobs green.