### PR TITLE
Support schema-qualified managed data tables

### DIFF
--- a/core/goschema/managed_data_test.go
+++ b/core/goschema/managed_data_test.go
@@ -49,6 +49,46 @@ type Country struct {
 	}
 }
 
+func TestParseManagedDataAnnotation_Schema(t *testing.T) {
+	c := qt.New(t)
+
+	db := mustParseSource(c, "schema.go", `
+package fixture
+
+//migrator:schema:data table="countries" schema="reference" key="code" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}
+`)
+
+	c.Assert(db.ManagedData, qt.HasLen, 1)
+	c.Assert(db.ManagedData[0].Schema, qt.Equals, "reference")
+}
+
+func TestParseManagedDataAnnotation_SchemaDefaultsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	db := mustParseSource(c, "schema.go", `
+package fixture
+
+//migrator:schema:data table="countries" key="code" file="countries.yaml"
+type Country struct {
+	//migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+}
+`)
+
+	c.Assert(db.ManagedData, qt.HasLen, 1)
+	c.Assert(db.ManagedData[0].Schema, qt.Equals, "")
+}
+
 func TestParseManagedDataAnnotation_MissingRequiredAttributeRejected(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -1345,6 +1345,7 @@ func (s *schemaParseState) parseManagedDataComment(comment *ast.Comment, structN
 	s.managedData = append(s.managedData, ManagedData{
 		StructName: structName,
 		Table:      kv["table"],
+		Schema:     kv["schema"],
 		Keys:       keys,
 		File:       kv["file"],
 		SourceDir:  filepath.Dir(s.filename),

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -1093,6 +1093,7 @@ func (g *Grant) Canonicalize() {
 type ManagedData struct {
 	StructName string   // Name of the Go struct this data annotation is associated with
 	Table      string   // Target table the rows belong to
+	Schema     string   // Database schema the table belongs to; empty targets the connection's default schema
 	Keys       []string // Key column(s) forming each row's logical identity (parsed from the comma-separated "key" attribute)
 	File       string   // Path to the YAML row-data file, verbatim, relative to SourceDir
 	// SourceDir is the parse-root-relative directory of the Go source file that

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -650,7 +650,7 @@ type SchemaWriter interface {
 
 func Render(diff *DataDiff, dialect string) (up string, down string, err error)
 type DataDiff struct{ ... }
-    func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error)
+    func Compute(schema, table string, keys []string, desired, live []Row) (*DataDiff, error)
 type Row = map[string]any
 type RowUpdate struct{ ... }
 

--- a/docs/site/src/content/docs/workflows/reference-data.md
+++ b/docs/site/src/content/docs/workflows/reference-data.md
@@ -81,7 +81,9 @@ generates them:
   Insert-only migrations are additive and are always allowed.
 - Naming a table with `--protected-table` refuses any change to it — insert,
   update, or delete — unless `--allow-prod` is also set, mirroring the
-  protected-target posture of `ptah seed`.
+  protected-target posture of `ptah seed`. An entry matches a managed table by
+  its bare name (`regions`) or its schema-qualified name (`reference.regions`),
+  so either spelling protects a table declared with `schema="..."`.
 
 Both gates run before any SQL is emitted, so they apply to `--dry-run` too:
 combine `--allow-destructive --dry-run` to preview a destructive change without

--- a/docs/site/src/content/docs/workflows/reference-data.md
+++ b/docs/site/src/content/docs/workflows/reference-data.md
@@ -41,6 +41,11 @@ YAML list of column maps:
 
 Use a comma-separated `key` for composite keys (`key="tenant_id,code"`).
 
+Add an optional `schema="..."` to target a table in a non-default schema; both
+the live-row read and the generated DML are then schema-qualified (for
+PostgreSQL, `"reference"."countries"`). Omit it to use the connection's default
+schema.
+
 ## Generating a data migration
 
 ```bash
@@ -93,10 +98,10 @@ containing quotes, backslashes, or semicolons cannot break out of its literal.
 
 Known limits (tracked follow-ups): only the managed columns are reconciled and
 restored, so emptying a populated table's desired set is refused rather than
-generating a rollback that could not restore the non-key columns; tables are
+generating a rollback that could not restore the non-key columns; and tables are
 ordered alphabetically rather than by foreign-key dependency, so FK-related
 tables may need manual reordering (a violation aborts the transactional migration
-cleanly); and schema-qualified managed tables are not yet supported.
+cleanly).
 
 ## Declarative data versus `ptah seed`
 

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -556,6 +556,7 @@ var directives = []Directive{
 		Scopes:      []Scope{ScopeStruct},
 		Attributes: []Attribute{
 			attr("table", "Target table the rows belong to.", valueString, true, false),
+			attr("schema", "Database schema the table belongs to.", valueString, false, false),
 			attr("key", "Comma-separated key column(s) forming each row's identity.", valueList, true, false),
 			attr("file", "Path to the YAML row-data file, relative to the Go source file.", valueString, true, false),
 		},

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -88,9 +88,10 @@ type Options struct {
 // entry is refused. See [Options] for why these live here rather than on the
 // apply path.
 //
-// The table is read with an empty schema argument: a datadiff.DataDiff carries
-// no schema, so both the read and the rendered DML target the connection's
-// default schema. Schema-qualified managed tables are a known follow-up.
+// Each table is read and rendered under the schema declared on its
+// //migrator:schema:data annotation (the "schema" attribute, carried on
+// goschema.ManagedData); an empty schema targets the connection's default
+// schema. The schema qualifies both the live-row read and the generated DML.
 func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Options) (upSQL, downSQL string, err error) {
 	if conn == nil {
 		return "", "", errors.New("datamigrate: a database connection is required")
@@ -129,8 +130,8 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 			// nothing to reverse for this table.
 			continue
 		}
-		ups = append(ups, tableBlock(md.Table, rendered.up))
-		downs = append(downs, tableBlock(md.Table, rendered.down))
+		ups = append(ups, tableBlock(qualifiedName(md.Schema, md.Table), rendered.up))
+		downs = append(downs, tableBlock(qualifiedName(md.Schema, md.Table), rendered.down))
 		changes = append(changes, tableChange{table: md.Table, updates: len(rendered.diff.Updates), deletes: len(rendered.diff.Deletes)})
 	}
 
@@ -192,7 +193,7 @@ func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect
 		return tableRender{}, err
 	}
 
-	live, err := dbschema.ReadTableRows(ctx, conn, "", md.Table, managedColumns(desired, md.Keys))
+	live, err := dbschema.ReadTableRows(ctx, conn, md.Schema, md.Table, managedColumns(desired, md.Keys))
 	if err != nil {
 		return tableRender{}, err
 	}
@@ -210,7 +211,7 @@ func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect
 			md.Table, len(live))
 	}
 
-	diff, err := datadiff.Compute(md.Table, md.Keys, desired, live)
+	diff, err := datadiff.Compute(md.Schema, md.Table, md.Keys, desired, live)
 	if err != nil {
 		return tableRender{}, err
 	}
@@ -336,6 +337,17 @@ func managedColumns(rows []map[string]any, keys []string) []string {
 	}
 	slices.Sort(cols)
 	return cols
+}
+
+// qualifiedName renders a table name for the block comment, prefixing the
+// schema when one is declared (schema.table) and returning just the table
+// otherwise. It is display-only; the actual SQL identifiers are quoted by the
+// renderer.
+func qualifiedName(schema, table string) string {
+	if schema == "" {
+		return table
+	}
+	return schema + "." + table
 }
 
 // tableBlock prefixes a rendered per-table script with a comment naming the

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -132,7 +132,7 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 		}
 		ups = append(ups, tableBlock(qualifiedName(md.Schema, md.Table), rendered.up))
 		downs = append(downs, tableBlock(qualifiedName(md.Schema, md.Table), rendered.down))
-		changes = append(changes, tableChange{table: md.Table, updates: len(rendered.diff.Updates), deletes: len(rendered.diff.Deletes)})
+		changes = append(changes, tableChange{schema: md.Schema, table: md.Table, updates: len(rendered.diff.Updates), deletes: len(rendered.diff.Deletes)})
 	}
 
 	if len(ups) == 0 {
@@ -148,28 +148,38 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 }
 
 // tableChange records how many rows a single managed table's diff would update
-// and delete, the two operations the destructive gate cares about. Inserts are
-// additive and are not tracked here.
+// and delete, the two operations the destructive gate cares about, along with
+// the table's schema so the gates identify and report it as schema.table.
+// Inserts are additive and are not tracked here.
 type tableChange struct {
+	schema  string
 	table   string
 	updates int
 	deletes int
 }
 
-// mergeByTable folds multiple change entries for the same table into one,
-// summing their volumes and preserving first-seen order. More than one
+// qualified returns the schema.table display form for the change (just the
+// table when it has no schema), matching how the renderer qualifies the name.
+func (c tableChange) qualified() string {
+	return qualifiedName(c.schema, c.table)
+}
+
+// mergeByTable folds multiple change entries for the same schema-qualified table
+// into one, summing their volumes and preserving first-seen order. More than one
 // //migrator:schema:data annotation can target the same table, which would
-// otherwise make the gates report and count that table twice.
+// otherwise make the gates report and count that table twice. Tables that share
+// a bare name across different schemas stay distinct.
 func mergeByTable(changes []tableChange) []tableChange {
 	merged := make([]tableChange, 0, len(changes))
 	index := make(map[string]int, len(changes))
 	for _, change := range changes {
-		if i, ok := index[change.table]; ok {
+		key := change.qualified()
+		if i, ok := index[key]; ok {
 			merged[i].updates += change.updates
 			merged[i].deletes += change.deletes
 			continue
 		}
-		index[change.table] = len(merged)
+		index[key] = len(merged)
 		merged = append(merged, change)
 	}
 	return merged
@@ -236,23 +246,28 @@ func checkPolicy(changes []tableChange, opts Options) error {
 
 // checkProtected refuses to change any table named in opts.ProtectedTables
 // unless opts.AllowProd is set. Only tables that the migration would actually
-// change are examined, matched case-insensitively.
+// change are examined. A protected entry matches a change case-insensitively by
+// either its bare table name or its schema-qualified "schema.table" form, so a
+// schema-qualified managed table can be protected by either spelling and a bare
+// entry protects the table in whatever schema it lives.
 func checkProtected(changes []tableChange, opts Options) error {
 	if opts.AllowProd || len(opts.ProtectedTables) == 0 {
 		return nil
 	}
 
-	protected := make(map[string]string, len(opts.ProtectedTables))
+	protected := make(map[string]struct{}, len(opts.ProtectedTables))
 	for _, table := range opts.ProtectedTables {
 		if table = strings.TrimSpace(table); table != "" {
-			protected[strings.ToLower(table)] = table
+			protected[strings.ToLower(table)] = struct{}{}
 		}
 	}
 
 	var matched []string
 	for _, change := range changes {
-		if original, ok := protected[strings.ToLower(change.table)]; ok {
-			matched = append(matched, original)
+		_, bareHit := protected[strings.ToLower(change.table)]
+		_, qualifiedHit := protected[strings.ToLower(change.qualified())]
+		if bareHit || qualifiedHit {
+			matched = append(matched, change.qualified())
 		}
 	}
 	slices.Sort(matched)
@@ -280,7 +295,7 @@ func checkDestructive(changes []tableChange, opts Options) error {
 		}
 		updates += change.updates
 		deletes += change.deletes
-		details = append(details, fmt.Sprintf("%q (%d update(s), %d delete(s))", change.table, change.updates, change.deletes))
+		details = append(details, fmt.Sprintf("%q (%d update(s), %d delete(s))", change.qualified(), change.updates, change.deletes))
 	}
 
 	if !safety.HasDestructive(destructiveFindings(updates, deletes)) {
@@ -344,7 +359,9 @@ func managedColumns(rows []map[string]any, keys []string) []string {
 // otherwise. It is display-only; the actual SQL identifiers are quoted by the
 // renderer.
 func qualifiedName(schema, table string) string {
-	if schema == "" {
+	// Trim so the display and gate keys treat a blank schema the same way
+	// sqlident.Qualified does when rendering the actual SQL identifier.
+	if schema = strings.TrimSpace(schema); schema == "" {
 		return table
 	}
 	return schema + "." + table

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -240,6 +240,75 @@ type Region struct {
 	})
 }
 
+// TestGenerate_ProtectedSchemaQualifiedTable proves the protected gate is
+// schema-aware: a schema-qualified managed table is protected by both its
+// qualified "schema.table" name and its bare table name, and the refusal names
+// the qualified table.
+func TestGenerate_ProtectedSchemaQualifiedTable(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	// setup builds a fresh connection with an insert-only drift on
+	// reference.regions, so only the protected gate (not the destructive gate)
+	// can refuse the run.
+	setup := func() (*dbschema.DatabaseConnection, string) {
+		conn, err := dbschema.ConnectToDatabase(ctx, "sqlite:///:memory:")
+		c.Assert(err, qt.IsNil)
+		t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+		_, err = conn.ExecContext(ctx, `ATTACH DATABASE ':memory:' AS reference`)
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(ctx, `CREATE TABLE reference.regions (code TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(ctx, `INSERT INTO reference.regions (code, name) VALUES ('US', 'United States')`)
+		c.Assert(err, qt.IsNil)
+
+		root := t.TempDir()
+		goSrc := `package fixture
+
+//migrator:schema:data table="regions" schema="reference" key="code" file="regions.yaml"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+		c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+		c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"), []byte(insertOnlyDesiredRows), 0o600), qt.IsNil)
+		return conn, root
+	}
+
+	// A qualified protected entry refuses and reports the qualified name.
+	conn, root := setup()
+	_, _, err := datamigrate.Generate(ctx, conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"reference.regions"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected table(s) reference.regions")
+
+	// A bare protected entry also protects the table in its schema (safe-side),
+	// preserving the pre-schema behavior.
+	conn, root = setup()
+	_, _, err = datamigrate.Generate(ctx, conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"regions"},
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "protected table(s) reference.regions")
+
+	// --allow-prod clears the gate and the insert-only migration is generated.
+	conn, root = setup()
+	up, _, err := datamigrate.Generate(ctx, conn, datamigrate.Options{
+		RootDir:         root,
+		ProtectedTables: []string{"reference.regions"},
+		AllowProd:       true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Contains, `INSERT INTO "reference"."regions"`)
+}
+
 func TestGenerate_EmptyDesiredWithLiveRowsErrors(t *testing.T) {
 	c := qt.New(t)
 
@@ -349,7 +418,9 @@ func TestGenerate_ProtectedTableMatchIsCaseInsensitive(t *testing.T) {
 		ProtectedTables: []string{"REGIONS"},
 	})
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "protected table(s) REGIONS")
+	// The match is case-insensitive, and the message names the actual managed
+	// table (as declared), not the operator's protected-entry casing.
+	c.Assert(err.Error(), qt.Contains, "protected table(s) regions")
 }
 
 func TestGenerate_ProtectedTablePrecedesDestructiveGate(t *testing.T) {

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -164,6 +164,82 @@ func TestGenerate_RoundTripApply(t *testing.T) {
 	})
 }
 
+// TestGenerate_SchemaQualifiedTable proves an annotation's schema="..." flows
+// through the whole pipeline: the live rows are read from the schema-qualified
+// table, the generated DML targets it, and applying up then down round-trips.
+func TestGenerate_SchemaQualifiedTable(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, "sqlite:///:memory:")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	// Attach a second in-memory database as the "reference" schema and create a
+	// schema-qualified regions table in it. Ptah caps in-memory SQLite to a
+	// single connection, so the ATTACH persists for every subsequent query.
+	_, err = conn.ExecContext(ctx, `ATTACH DATABASE ':memory:' AS reference`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `CREATE TABLE reference.regions (code TEXT PRIMARY KEY, name TEXT NOT NULL)`)
+	c.Assert(err, qt.IsNil)
+	for _, r := range [][2]string{{"US", "United States"}, {"CZ", "Czech Republic"}, {"XX", "Old Name"}} {
+		_, execErr := conn.ExecContext(ctx, `INSERT INTO reference.regions (code, name) VALUES (?, ?)`, r[0], r[1])
+		c.Assert(execErr, qt.IsNil)
+	}
+
+	root := t.TempDir()
+	goSrc := `package fixture
+
+//migrator:schema:data table="regions" schema="reference" key="code" file="regions.yaml"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"), []byte(driftDesiredRows), 0o600), qt.IsNil)
+
+	up, down, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: root, AllowDestructive: true})
+	c.Assert(err, qt.IsNil)
+	// The live rows were read from reference.regions (main has no regions table),
+	// and the generated DML targets the schema-qualified table.
+	c.Assert(up, qt.Contains, `"reference"."regions"`)
+	c.Assert(down, qt.Contains, `"reference"."regions"`)
+
+	apply := func(script string) {
+		for _, stmt := range migrator.SplitSQLStatementsForConnection(conn, script) {
+			_, execErr := conn.ExecContext(ctx, stmt)
+			c.Assert(execErr, qt.IsNil, qt.Commentf("stmt: %s", stmt))
+		}
+	}
+	readState := func() map[string]string {
+		rows, queryErr := conn.QueryContext(ctx, `SELECT code, name FROM reference.regions ORDER BY code`)
+		c.Assert(queryErr, qt.IsNil)
+		defer func() { _ = rows.Close() }()
+		out := map[string]string{}
+		for rows.Next() {
+			var code, name string
+			c.Assert(rows.Scan(&code, &name), qt.IsNil)
+			out[code] = name
+		}
+		c.Assert(rows.Err(), qt.IsNil)
+		return out
+	}
+
+	apply(up)
+	c.Assert(readState(), qt.DeepEquals, map[string]string{
+		"US": "United States", "CZ": "Czechia", "DE": "Germany",
+	})
+
+	apply(down)
+	c.Assert(readState(), qt.DeepEquals, map[string]string{
+		"US": "United States", "CZ": "Czech Republic", "XX": "Old Name",
+	})
+}
+
 func TestGenerate_EmptyDesiredWithLiveRowsErrors(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/datadiff/datadiff.go
+++ b/migration/datadiff/datadiff.go
@@ -53,6 +53,11 @@ type RowUpdate struct {
 // in both whose managed columns differ. Inserts, Updates, and Deletes are each
 // sorted by their composite key so the output is deterministic and testable.
 type DataDiff struct {
+	// Schema is the database schema the table belongs to, or empty for the
+	// connection's default schema. It does not affect the diff computation (rows
+	// are matched by key regardless of schema); it identifies the target table so
+	// [Render] can emit a schema-qualified name.
+	Schema  string
 	Table   string
 	Keys    []string
 	Inserts []Row
@@ -60,8 +65,10 @@ type DataDiff struct {
 	Deletes []Row
 }
 
-// Compute computes the row-level diff for table between the desired rows and the
-// live rows, keyed by the key columns in keys.
+// Compute computes the row-level diff for schema.table between the desired rows
+// and the live rows, keyed by the key columns in keys. schema may be empty for
+// the connection's default schema; it is recorded on the returned diff so
+// [Render] can emit a schema-qualified name but does not affect matching.
 //
 // keys must be non-empty and every desired and live row must contain a value
 // for each key column; a missing key column is a validation error. Rows are
@@ -76,7 +83,7 @@ type DataDiff struct {
 //
 // If two rows on the same side share a composite key, the later one in input
 // order wins; keys should be chosen so this does not occur.
-func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error) {
+func Compute(schema, table string, keys []string, desired, live []Row) (*DataDiff, error) {
 	if len(keys) == 0 {
 		return nil, errors.New("datadiff: keys must be non-empty")
 	}
@@ -91,8 +98,9 @@ func Compute(table string, keys []string, desired, live []Row) (*DataDiff, error
 	}
 
 	diff := &DataDiff{
-		Table: table,
-		Keys:  slices.Clone(keys),
+		Schema: schema,
+		Table:  table,
+		Keys:   slices.Clone(keys),
 	}
 
 	for _, k := range sortedKeys(desiredByKey) {

--- a/migration/datadiff/datadiff_test.go
+++ b/migration/datadiff/datadiff_test.go
@@ -183,7 +183,7 @@ func TestCompute(t *testing.T) {
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			got, err := datadiff.Compute(tt.table, tt.keys, tt.desired, tt.live)
+			got, err := datadiff.Compute("", tt.table, tt.keys, tt.desired, tt.live)
 			c.Assert(err, qt.IsNil)
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
@@ -221,7 +221,7 @@ func TestComputeErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			got, err := datadiff.Compute("regions", tt.keys, tt.desired, tt.live)
+			got, err := datadiff.Compute("", "regions", tt.keys, tt.desired, tt.live)
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(got, qt.IsNil)
 		})

--- a/migration/datadiff/render.go
+++ b/migration/datadiff/render.go
@@ -43,11 +43,11 @@ import (
 //
 // # Table name
 //
-// A DataDiff carries no schema, so the table is quoted as a single identifier
-// via sqlident.Qualified(dialect, "", diff.Table). A dotted name such as
-// "app.regions" is therefore quoted whole (for PostgreSQL: "app.regions")
-// rather than as schema.table; schema-qualified managed tables are a known
-// follow-up.
+// The table is quoted via sqlident.Qualified(dialect, diff.Schema, diff.Table).
+// When diff.Schema is set the name is emitted schema-qualified (for PostgreSQL:
+// "app"."regions"); when it is empty only the table is quoted. diff.Table is
+// always treated as a single identifier, so a dotted table name is quoted whole
+// rather than split into schema and table — put the schema in diff.Schema.
 //
 // # Limitations
 //
@@ -71,7 +71,7 @@ func Render(diff *DataDiff, dialect string) (up string, down string, err error) 
 		return "", "", errors.New("datadiff: keys must be non-empty to render a non-empty diff")
 	}
 
-	table := sqlident.Qualified(dialect, "", diff.Table)
+	table := sqlident.Qualified(dialect, diff.Schema, diff.Table)
 
 	upStmts, err := renderUp(dialect, table, diff)
 	if err != nil {

--- a/migration/datadiff/render_test.go
+++ b/migration/datadiff/render_test.go
@@ -48,6 +48,45 @@ func TestRender_SplitterRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRender_SchemaQualifiedTableName proves diff.Schema qualifies the rendered
+// table name per dialect, and that an empty schema stays a bare, unqualified
+// identifier (backward compatible).
+func TestRender_SchemaQualifiedTableName(t *testing.T) {
+	c := qt.New(t)
+
+	qualified := &datadiff.DataDiff{
+		Schema:  "app",
+		Table:   "regions",
+		Keys:    []string{"code"},
+		Inserts: []datadiff.Row{{"code": "US", "name": "United States"}},
+		Deletes: []datadiff.Row{{"code": "XX", "name": "Old"}},
+	}
+
+	// PostgreSQL: double-quoted schema.table in both directions.
+	up, down, err := datadiff.Render(qualified, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(up, qt.Contains, `INSERT INTO "app"."regions" `)
+	c.Assert(up, qt.Contains, `DELETE FROM "app"."regions" `)
+	c.Assert(down, qt.Contains, `INSERT INTO "app"."regions" `)
+
+	// MySQL: backtick-quoted schema.table.
+	upMy, _, err := datadiff.Render(qualified, "mysql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(upMy, qt.Contains, "INSERT INTO `app`.`regions` ")
+
+	// Empty schema renders a bare table name, unchanged from the pre-schema
+	// behavior.
+	unqualified := &datadiff.DataDiff{
+		Table:   "regions",
+		Keys:    []string{"code"},
+		Inserts: []datadiff.Row{{"code": "US", "name": "United States"}},
+	}
+	upBare, _, err := datadiff.Render(unqualified, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(upBare, qt.Contains, `INSERT INTO "regions" `)
+	c.Assert(upBare, qt.Not(qt.Contains), `"."`)
+}
+
 // TestRenderShapesAndRoundTrip renders a diff carrying every kind of change and
 // asserts the exact up script and its exact inverse. down must undo every
 // statement in fully reversed order: re-insert the deleted rows, restore the

--- a/migration/datadiff/render_test.go
+++ b/migration/datadiff/render_test.go
@@ -85,6 +85,18 @@ func TestRender_SchemaQualifiedTableName(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(upBare, qt.Contains, `INSERT INTO "regions" `)
 	c.Assert(upBare, qt.Not(qt.Contains), `"."`)
+
+	// A schema containing the quote character is escaped by the identifier
+	// quoter (doubled), so it cannot break out of the identifier.
+	weird := &datadiff.DataDiff{
+		Schema:  `a"b`,
+		Table:   "regions",
+		Keys:    []string{"code"},
+		Inserts: []datadiff.Row{{"code": "US", "name": "United States"}},
+	}
+	upWeird, _, err := datadiff.Render(weird, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(upWeird, qt.Contains, `INSERT INTO "a""b"."regions" `)
 }
 
 // TestRenderShapesAndRoundTrip renders a diff carrying every kind of change and

--- a/schemas/migrator-annotations.schema.json
+++ b/schemas/migrator-annotations.schema.json
@@ -232,6 +232,10 @@
               "description": "Comma-separated key column(s) forming each row's identity.",
               "type": "string"
             },
+            "schema": {
+              "description": "Database schema the table belongs to.",
+              "type": "string"
+            },
             "table": {
               "description": "Target table the rows belong to.",
               "type": "string"


### PR DESCRIPTION
## Summary

Completes a tracked #663 follow-up: declarative reference data (`ptah migrations data`) could only target a table in the connection's default schema. The `//migrator:schema:data` directive had no schema attribute, `datamigrate` read and rendered every table with an empty schema, and a `datadiff.DataDiff` carried no schema — so the generated DML was never schema-qualified.

## Change

Threads an optional schema through the whole pipeline:

- **Annotation:** optional `schema="..."` on `//migrator:schema:data` (registered in `annotationmeta`, reflected in the regenerated `schemas/migrator-annotations.schema.json`), parsed onto the new `goschema.ManagedData.Schema`.
- **Diff/render:** `datadiff.DataDiff.Schema` (set by `Compute`, which now takes a `schema` argument) qualifies the rendered table via `sqlident.Qualified`, so up/down DML targets `schema.table` with dialect-correct quoting (`"app"."regions"` on PostgreSQL, `` `app`.`regions` `` on MySQL). An empty schema is byte-for-byte unchanged from before — existing annotations behave identically.
- **Orchestration:** `datamigrate` passes `md.Schema` to both `dbschema.ReadTableRows` (already schema-aware) and `datadiff.Compute`, so the live-row read and the generated migration agree on the target table.

## Verification

New tests: annotation parsing (schema present and defaulted-empty), per-dialect render qualification (and that an empty schema stays a bare identifier — backward compatible), and a full **schema-qualified round-trip on SQLite via `ATTACH`** (proves the live read hits `reference.regions`, the DML is qualified, and up→down restores the original). Locally green: `go build`, `gofmt`, `go vet`, full `go test ./...`, `golangci-lint`, `qtlint`, public-API snapshot (regenerated for the `Compute` signature), and the doc-site checks. `datadiff.Compute` gains a leading `schema` parameter — a pre-v1 public-API change with a contained blast radius (only `datamigrate` and datadiff tests call it).

Part of #663.