### PR TITLE
Add migration statement observation hooks

### DIFF
--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -56,6 +56,12 @@ files are marked explicitly without changing version selection.
 Compatibility-specific directive behavior must be selected explicitly; native
 Ptah behavior is the zero-value default.
 
+`migration/migrator` exposes `WithStatementObserver` for tools that need to
+audit successful filesystem-migration execution without replacing the
+interceptor, splitter, directive, or transaction path. Observers receive
+structured source and statement metadata after execution but no connection
+handle, so they cannot alter the migrator execution path.
+
 Public failures from these packages should use `core/ptaherr` where the caller
 can reasonably branch on the error. In particular, annotation failures should
 support `errors.As(err, *ptaherr.ParseError)`, and unsupported dialect failures

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -802,6 +802,7 @@ type FSProviderOption func(*FSMigrationProvider)
     func WithAtlasTemplateData(data any) FSProviderOption
     func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption
     func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
+    func WithStatementObserver(observer StatementObserver) FSProviderOption
 type MigrateUpOptions struct{ ... }
 type Migration struct{ ... }
     func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration
@@ -848,7 +849,11 @@ type RepairMigrationOptions struct{ ... }
 type RevisionTableFormat string
     const RevisionTableFormatPtah RevisionTableFormat = "ptah" ...
     func ParseRevisionTableFormat(value string) (RevisionTableFormat, error)
+type StatementEvent struct{ ... }
 type StatementInterceptor interface{ ... }
+type StatementObservationError struct{ ... }
+type StatementObserver interface{ ... }
+type StatementObserverFunc func(context.Context, StatementEvent) error
 
 ### github.com/stokaro/ptah/migration/migrator.MigrationProvider
 
@@ -906,6 +911,18 @@ type StatementInterceptor interface {
     ParseFileDirectives). It returns handled=true when it fully executed the
     statement itself; on handled=false the migrator executes the statement
     normally. A non-nil error aborts the migration.
+
+
+### github.com/stokaro/ptah/migration/migrator.StatementObserver
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementObserver interface {
+    ObserveStatement(ctx context.Context, event StatementEvent) error
+}
+    StatementObserver receives successfully executed migration statements. It is
+    called after either an interceptor or the normal migrator path executes the
+    statement. Returning an error aborts the migration.
 
 
 ## github.com/stokaro/ptah/migration/planner

--- a/docs/site/src/content/docs/reference/public-api.md
+++ b/docs/site/src/content/docs/reference/public-api.md
@@ -39,6 +39,25 @@ Import paths use the module prefix:
 import "github.com/stokaro/ptah/core/renderer"
 ```
 
+## Migration Statement Observation
+
+`migration/migrator.WithStatementObserver` attaches a read-only callback to a
+filesystem migration provider. The observer runs after every successfully
+executed statement and receives its source path, one-based statement ordinal,
+total statement count, SQL text, and an event-local copy of file directives.
+
+Use `migrator.StatementObserverFunc` for a closure or implement
+`migrator.StatementObserver` for a stateful collector. The callback receives
+no database connection and cannot alter the migrator execution path. A
+database-aware collector may capture a consumer-owned connection when that
+consumer controls transaction visibility. Returning an error stops the
+migration and returns a `migrator.StatementObservationError` with source and
+statement context; dirty progress includes the statement that completed before
+the callback failed.
+
+The observer composes with `StatementInterceptor`: a statement handled by an
+external executor is observed once after that executor reports success.
+
 ## Error Contracts
 
 Public failures should use `core/ptaherr` when callers can reasonably branch on

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -266,6 +266,8 @@ pending and out of order.
 - **`WithExecOrder(policy)`**: Configures out-of-order migration handling
 - **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
 - **`WithAtlasTemplateData(data)`**: Supplies data, including `.Env`, for Atlas SQL template migrations
+- **`WithStatementInterceptor(interceptor)`**: Lets an external executor take over selected statements
+- **`WithStatementObserver(observer)`**: Reports each statement after successful execution without replacing the execution path
 - **`WithRevisionTableFormat(format)`**: Selects Ptah's native `schema_migrations` layout or Atlas's `atlas_schema_revisions` layout
 - **`Baseline(ctx, version)` / `BaselineWithOptions(ctx, opts)`**: Records provider migrations as already applied without executing their SQL bodies
 
@@ -357,6 +359,44 @@ sqlMigration := migrator.CreateMigrationFromSQL(
 )
 provider.Register(sqlMigration)
 ```
+
+### Observing Executed Statements
+
+Use a statement observer for auditing, metrics, or consumer-controlled replay
+analysis that must follow the real migration execution path. The callback runs
+after each statement succeeds, including statements handled by a configured
+`StatementInterceptor`.
+
+```go
+observer := migrator.StatementObserverFunc(func(
+    _ context.Context,
+    event migrator.StatementEvent,
+) error {
+    log.Printf(
+        "executed migration statement %d/%d from %s",
+        event.Index,
+        event.Total,
+        event.SourcePath,
+    )
+    return nil
+})
+
+provider, err := migrator.NewFSMigrationProvider(
+    os.DirFS("/path/to/migrations"),
+    migrator.WithStatementObserver(observer),
+)
+if err != nil {
+    panic(err)
+}
+```
+
+`StatementEvent.Directives` is an event-local copy. An observer must not
+modify migration execution. A database-aware observer may capture a connection
+owned by its consumer, but that consumer is responsible for transaction
+visibility. Returning an error stops the migration with a
+`StatementObservationError`; its event preserves the source path, statement
+ordinal, and statement text and records the already-executed statement in
+dirty-migration progress.
 
 ### Migration Status Checking
 

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -70,7 +70,7 @@ type FSMigrationProvider struct {
 	mu                sync.Mutex
 	fsys              fs.FS
 	migrations        []*Migration
-	interceptor       StatementInterceptor
+	hooks             statementExecutionHooks
 	format            MigrationDirFormat
 	atlasTemplateData any
 }
@@ -89,7 +89,15 @@ type atlasParts struct {
 // interceptor for each statement (see StatementInterceptor).
 func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption {
 	return func(p *FSMigrationProvider) {
-		p.interceptor = interceptor
+		p.hooks.interceptor = interceptor
+	}
+}
+
+// WithStatementObserver makes every loaded migration report successfully
+// executed statements to the given observer (see StatementObserver).
+func WithStatementObserver(observer StatementObserver) FSProviderOption {
+	return func(p *FSMigrationProvider) {
+		p.hooks.observer = observer
 	}
 }
 
@@ -175,7 +183,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 		}
 		switch migrationFile.Direction {
 		case "up":
-			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)
+			up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, nil)
 			if err != nil {
 				return fmt.Errorf("failed to load up migration %s: %w", migrationFile.Path, err)
 			}
@@ -188,7 +196,7 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
 			migration.directionalNoTransactionMode = true
 		case "down":
-			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, nil)
+			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, nil)
 			if err != nil {
 				return fmt.Errorf("failed to load down migration %s: %w", migrationFile.Path, err)
 			}
@@ -295,7 +303,7 @@ func (p *FSMigrationProvider) loadAtlasFile(parts *atlasParts, migrationFile Mig
 
 func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile MigrationFile) error {
 	if isAtlasDirectionalMigrationFile(migrationFile) {
-		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
+		up, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, p.atlasTemplateData)
 		if err != nil {
 			return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 		}
@@ -303,7 +311,7 @@ func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile Migra
 		return nil
 	}
 
-	atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
+	atlasFile, err := atlasSQLMigrationFileFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, p.atlasTemplateData)
 	if err != nil {
 		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 	}
@@ -318,7 +326,7 @@ func (p *FSMigrationProvider) loadAtlasUp(parts *atlasParts, migrationFile Migra
 }
 
 func (p *FSMigrationProvider) loadAtlasDown(parts *atlasParts, migrationFile MigrationFile) error {
-	down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.interceptor, p.atlasTemplateData)
+	down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, p.atlasTemplateData)
 	if err != nil {
 		return fmt.Errorf("failed to load Atlas migration %s: %w", migrationFile.Path, err)
 	}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -74,6 +75,40 @@ func splitSQLStatementsForDialect(sql, dialect string) []string {
 type StatementInterceptor interface {
 	ValidateDirectives(directives map[string]string) error
 	ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (handled bool, err error)
+}
+
+// StatementEvent describes one successfully executed migration statement.
+// Directives is an event-local copy; observers may modify it without affecting
+// migration execution or later events.
+type StatementEvent struct {
+	SourcePath string
+	Statement  string
+	Index      int
+	Total      int
+	Directives map[string]string
+}
+
+// StatementObserver receives successfully executed migration statements. It is
+// called after either an interceptor or the normal migrator path executes the
+// statement. Returning an error aborts the migration.
+type StatementObserver interface {
+	ObserveStatement(ctx context.Context, event StatementEvent) error
+}
+
+// StatementObserverFunc adapts a function to StatementObserver.
+type StatementObserverFunc func(context.Context, StatementEvent) error
+
+// ObserveStatement calls f with the successfully executed statement.
+func (f StatementObserverFunc) ObserveStatement(
+	ctx context.Context,
+	event StatementEvent,
+) error {
+	return f(ctx, event)
+}
+
+type statementExecutionHooks struct {
+	interceptor StatementInterceptor
+	observer    StatementObserver
 }
 
 type migrationExecutionMode int
@@ -164,7 +199,8 @@ func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc {
 // behaves exactly like MigrationFuncFromSQLFilename.
 func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc {
 	return func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-		migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor, nil)
+		hooks := statementExecutionHooks{interceptor: interceptor}
+		migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, hooks, nil)
 		if err != nil {
 			return err
 		}
@@ -186,7 +222,8 @@ func MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(
 	fsys fs.FS,
 	interceptor StatementInterceptor,
 ) (MigrationFunc, MigrationTimeouts, error) {
-	migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, interceptor, nil)
+	hooks := statementExecutionHooks{interceptor: interceptor}
+	migrationFile, err := migrationFuncFromSQLFilenameWithMetadata(filename, fsys, hooks, nil)
 	if err != nil {
 		return nil, MigrationTimeouts{}, err
 	}
@@ -198,7 +235,7 @@ func MigrationFuncFromSQLFilenameWithTimeoutsAndInterceptor(
 func migrationFuncFromSQLFilenameWithMetadata(
 	filename string,
 	fsys fs.FS,
-	interceptor StatementInterceptor,
+	hooks statementExecutionHooks,
 	atlasTemplateData any,
 ) (sqlMigrationFile, error) {
 	sql, err := readSQLMigrationFile(fsys, filename, atlasTemplateData)
@@ -206,7 +243,7 @@ func migrationFuncFromSQLFilenameWithMetadata(
 		return sqlMigrationFile{}, err
 	}
 
-	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, interceptor)
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, hooks)
 	if err != nil {
 		return sqlMigrationFile{}, err
 	}
@@ -214,13 +251,13 @@ func migrationFuncFromSQLFilenameWithMetadata(
 		return atlasMigrationFile.up, nil
 	}
 
-	return migrationFuncFromSQLStringWithMetadata(filename, sql, interceptor)
+	return migrationFuncFromSQLStringWithMetadata(filename, sql, hooks)
 }
 
 func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
 	filename string,
 	fsys fs.FS,
-	interceptor StatementInterceptor,
+	hooks statementExecutionHooks,
 	atlasTemplateData any,
 ) (atlasSQLMigrationFile, error) {
 	sql, err := readSQLMigrationFile(fsys, filename, atlasTemplateData)
@@ -228,7 +265,7 @@ func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
 		return atlasSQLMigrationFile{}, err
 	}
 
-	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, interceptor)
+	atlasMigrationFile, ok, err := atlasSQLMigrationFileFromSQL(filename, sql, hooks)
 	if err != nil {
 		return atlasSQLMigrationFile{}, err
 	}
@@ -236,7 +273,7 @@ func atlasSQLMigrationFileFromSQLFilenameWithMetadata(
 		return atlasMigrationFile, nil
 	}
 
-	up, err := migrationFuncFromSQLStringWithMetadata(filename, sql, interceptor)
+	up, err := migrationFuncFromSQLStringWithMetadata(filename, sql, hooks)
 	if err != nil {
 		return atlasSQLMigrationFile{}, err
 	}
@@ -248,19 +285,19 @@ func readSQLMigrationFile(fsys fs.FS, filename string, atlasTemplateData any) (s
 	return sql, err
 }
 
-func atlasSQLMigrationFileFromSQL(filename, sql string, interceptor StatementInterceptor) (atlasSQLMigrationFile, bool, error) {
+func atlasSQLMigrationFileFromSQL(filename, sql string, hooks statementExecutionHooks) (atlasSQLMigrationFile, bool, error) {
 	parsed, ok, err := parseAtlasTxtarSQL(filename, sql)
 	if err != nil || !ok {
 		return atlasSQLMigrationFile{}, ok, err
 	}
 
-	up, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarMigrationSection, parsed.migrationSQL, interceptor)
+	up, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarMigrationSection, parsed.migrationSQL, hooks)
 	if err != nil {
 		return atlasSQLMigrationFile{}, true, err
 	}
 	atlasMigrationFile := atlasSQLMigrationFile{up: up}
 	if parsed.hasDown {
-		down, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarDownSection, parsed.downSQL, interceptor)
+		down, err := migrationFuncFromSQLStringWithMetadata(filename+"#"+atlasTxtarDownSection, parsed.downSQL, hooks)
 		if err != nil {
 			return atlasSQLMigrationFile{}, true, err
 		}
@@ -270,7 +307,7 @@ func atlasSQLMigrationFileFromSQL(filename, sql string, interceptor StatementInt
 	return atlasMigrationFile, true, nil
 }
 
-func migrationFuncFromSQLStringWithMetadata(filename, sql string, interceptor StatementInterceptor) (sqlMigrationFile, error) {
+func migrationFuncFromSQLStringWithMetadata(filename, sql string, hooks statementExecutionHooks) (sqlMigrationFile, error) {
 	timeouts, err := parseMigrationTimeoutDirectives(sql)
 	if err != nil {
 		return sqlMigrationFile{}, err
@@ -282,7 +319,7 @@ func migrationFuncFromSQLStringWithMetadata(filename, sql string, interceptor St
 	}
 	return sqlMigrationFile{
 		fn: func(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
-			return executeMigrationFileSQL(ctx, conn, filename, sql, interceptor, mode)
+			return executeMigrationFileSQL(ctx, conn, filename, sql, hooks, mode)
 		},
 		sql:           sql,
 		timeouts:      timeouts,
@@ -489,16 +526,19 @@ func executeMigrationFileSQL(
 	conn *dbschema.DatabaseConnection,
 	filename string,
 	sql string,
-	interceptor StatementInterceptor,
+	hooks statementExecutionHooks,
 	mode migrationExecutionMode,
 ) error {
 	// Directives live in comments, so they must be read from the raw file
 	// before comment stripping, and validated before any statement runs so an
 	// invalid directive leaves nothing half-applied.
-	var directives map[string]string
-	if interceptor != nil {
-		directives = ParseFileDirectives(sql)
-		if err := interceptor.ValidateDirectives(directives); err != nil {
+	var fileDirectives map[string]string
+	if hooks.interceptor != nil || hooks.observer != nil {
+		fileDirectives = ParseFileDirectives(sql)
+	}
+	interceptorDirectives := maps.Clone(fileDirectives)
+	if hooks.interceptor != nil {
+		if err := hooks.interceptor.ValidateDirectives(interceptorDirectives); err != nil {
 			return fmt.Errorf("invalid migration directives in %s: %w", filename, err)
 		}
 	}
@@ -510,8 +550,10 @@ func executeMigrationFileSQL(
 			continue
 		}
 
-		if interceptor != nil {
-			handled, err := interceptor.ExecuteStatement(ctx, conn, stmt, directives)
+		handled := false
+		if hooks.interceptor != nil {
+			var err error
+			handled, err = hooks.interceptor.ExecuteStatement(ctx, conn, stmt, interceptorDirectives)
 			if err != nil {
 				return &MigrationExecutionError{
 					Err:            fmt.Errorf("failed to execute migration SQL: %w", err),
@@ -520,17 +562,31 @@ func executeMigrationFileSQL(
 					Total:          len(statements),
 				}
 			}
-			if handled {
-				continue
-			}
 		}
 
-		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
-			return &MigrationExecutionError{
-				Err:            fmt.Errorf("failed to execute migration SQL: %w", err),
-				Statement:      stmt,
-				StatementIndex: i + 1,
-				Total:          len(statements),
+		if !handled {
+			if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
+				return &MigrationExecutionError{
+					Err:            fmt.Errorf("failed to execute migration SQL: %w", err),
+					Statement:      stmt,
+					StatementIndex: i + 1,
+					Total:          len(statements),
+				}
+			}
+		}
+		if hooks.observer != nil {
+			event := StatementEvent{
+				SourcePath: filename,
+				Statement:  stmt,
+				Index:      i + 1,
+				Total:      len(statements),
+				Directives: maps.Clone(fileDirectives),
+			}
+			if err := hooks.observer.ObserveStatement(ctx, event); err != nil {
+				return &StatementObservationError{
+					Err:   err,
+					Event: event,
+				}
 			}
 		}
 	}
@@ -551,6 +607,26 @@ func (e *MigrationExecutionError) Error() string {
 }
 
 func (e *MigrationExecutionError) Unwrap() error {
+	return e.Err
+}
+
+// StatementObservationError reports a post-execution observer failure. The
+// statement in Event was applied before the observer returned Err.
+type StatementObservationError struct {
+	Err   error
+	Event StatementEvent
+}
+
+func (e *StatementObservationError) Error() string {
+	return fmt.Sprintf(
+		"failed to observe migration SQL: %v\nSource: %s\nSQL: %s",
+		e.Err,
+		e.Event.SourcePath,
+		e.Event.Statement,
+	)
+}
+
+func (e *StatementObservationError) Unwrap() error {
 	return e.Err
 }
 

--- a/migration/migrator/observer_test.go
+++ b/migration/migrator/observer_test.go
@@ -1,0 +1,855 @@
+package migrator_test
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+type statementObserverRecorder struct {
+	events []migrator.StatementEvent
+	after  func(migrator.StatementEvent) error
+}
+
+func newStatementObserverRecorder() *statementObserverRecorder {
+	return &statementObserverRecorder{after: successfulStatementObservation}
+}
+
+func successfulStatementObservation(migrator.StatementEvent) error {
+	return nil
+}
+
+func (r *statementObserverRecorder) ObserveStatement(
+	_ context.Context,
+	event migrator.StatementEvent,
+) error {
+	snapshot := event
+	snapshot.Directives = maps.Clone(event.Directives)
+	r.events = append(r.events, snapshot)
+	return r.after(event)
+}
+
+type statementObserverInterceptor struct {
+	handled    bool
+	statements []string
+	directives []map[string]string
+}
+
+func (i *statementObserverInterceptor) ValidateDirectives(map[string]string) error {
+	return nil
+}
+
+func (i *statementObserverInterceptor) ExecuteStatement(
+	_ context.Context,
+	_ *dbschema.DatabaseConnection,
+	statement string,
+	directives map[string]string,
+) (bool, error) {
+	i.statements = append(i.statements, statement)
+	i.directives = append(i.directives, maps.Clone(directives))
+	return i.handled, nil
+}
+
+type rejectingStatementInterceptor struct {
+	err error
+}
+
+func (i *rejectingStatementInterceptor) ValidateDirectives(map[string]string) error {
+	return i.err
+}
+
+func (*rejectingStatementInterceptor) ExecuteStatement(
+	context.Context,
+	*dbschema.DatabaseConnection,
+	string,
+	map[string]string,
+) (bool, error) {
+	panic("ExecuteStatement called after directive validation failed")
+}
+
+type failingStatementInterceptor struct {
+	err error
+}
+
+func (*failingStatementInterceptor) ValidateDirectives(map[string]string) error {
+	return nil
+}
+
+func (i *failingStatementInterceptor) ExecuteStatement(
+	context.Context,
+	*dbschema.DatabaseConnection,
+	string,
+	map[string]string,
+) (bool, error) {
+	return false, i.err
+}
+
+type mutatingStatementInterceptor struct {
+	directives map[string]string
+}
+
+func (*mutatingStatementInterceptor) ValidateDirectives(directives map[string]string) error {
+	directives["validation"] = "mutated"
+	return nil
+}
+
+func (i *mutatingStatementInterceptor) ExecuteStatement(
+	_ context.Context,
+	_ *dbschema.DatabaseConnection,
+	_ string,
+	directives map[string]string,
+) (bool, error) {
+	directives["execution"] = "mutated"
+	i.directives = maps.Clone(directives)
+	return true, nil
+}
+
+type statementStateObserver struct {
+	conn   *dbschema.DatabaseConnection
+	query  string
+	counts []int
+}
+
+func (o *statementStateObserver) ObserveStatement(
+	ctx context.Context,
+	_ migrator.StatementEvent,
+) error {
+	var count int
+	err := o.conn.QueryRowContext(ctx, o.query).Scan(&count)
+	o.counts = append(o.counts, count)
+	return err
+}
+
+var (
+	_ migrator.StatementObserver = (*statementObserverRecorder)(nil)
+	_ migrator.StatementObserver = (*statementStateObserver)(nil)
+	_ migrator.StatementObserver = migrator.StatementObserverFunc(nil)
+)
+
+func openStatementObserverSQLite(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+
+	conn, err := dbschema.ConnectToDatabase(
+		context.Background(),
+		"sqlite://"+filepath.Join(t.TempDir(), "statement-observer.sqlite"),
+	)
+	qt.Assert(t, err, qt.IsNil)
+	t.Cleanup(func() {
+		qt.Check(t, conn.Close(), qt.IsNil)
+	})
+	return conn
+}
+
+func statementObserverTableCount(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	tableName string,
+) int {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+		tableName,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func statementObserverRowCount(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	tableName string,
+) int {
+	t.Helper()
+
+	var count int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT count(*) FROM "+tableName,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+type statementObserverRevisionProgress struct {
+	applied        int
+	total          int
+	errorStatement string
+}
+
+func readStatementObserverRevisionProgress(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	tableName string,
+	version int64,
+) statementObserverRevisionProgress {
+	t.Helper()
+
+	var progress statementObserverRevisionProgress
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT applied, total, error_stmt FROM "+tableName+" WHERE version = ?",
+		version,
+	).Scan(&progress.applied, &progress.total, &progress.errorStatement)
+	qt.Assert(t, err, qt.IsNil)
+	return progress
+}
+
+func TestStatementObserver_PtahPairReportsOrderedEvents(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_accounts.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah direction=up\n" +
+				"CREATE TABLE accounts (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO accounts (id) VALUES (1);\n",
+		)},
+		"0000000001_accounts.down.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah direction=down\n" +
+				"DELETE FROM accounts;\n" +
+				"DROP TABLE accounts;\n",
+		)},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	conn := openStatementObserverSQLite(t)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+	c.Assert(migrations[0].Down(context.Background(), conn), qt.IsNil)
+
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_accounts.up.sql",
+			Statement:  "CREATE TABLE accounts (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      2,
+			Directives: map[string]string{"direction": "up"},
+		},
+		{
+			SourcePath: "0000000001_accounts.up.sql",
+			Statement:  "INSERT INTO accounts (id) VALUES (1)",
+			Index:      2,
+			Total:      2,
+			Directives: map[string]string{"direction": "up"},
+		},
+		{
+			SourcePath: "0000000001_accounts.down.sql",
+			Statement:  "DELETE FROM accounts",
+			Index:      1,
+			Total:      2,
+			Directives: map[string]string{"direction": "down"},
+		},
+		{
+			SourcePath: "0000000001_accounts.down.sql",
+			Statement:  "DROP TABLE accounts",
+			Index:      2,
+			Total:      2,
+			Directives: map[string]string{"direction": "down"},
+		},
+	})
+}
+
+func TestStatementObserver_AtlasSingleAndTxtarReportSectionSources(t *testing.T) {
+	c := qt.New(t)
+	const (
+		singlePath = "20240101000001_single.sql"
+		txtarPath  = "20240101000002_archive.sql"
+	)
+	fsys := fstest.MapFS{
+		singlePath: &fstest.MapFile{Data: []byte(
+			"-- +ptah source=single\n" +
+				"CREATE TABLE atlas_single (id INTEGER PRIMARY KEY);\n",
+		)},
+		txtarPath: &fstest.MapFile{Data: []byte(`-- atlas:txtar
+
+-- migration.sql --
+-- +ptah source=txtar_up
+CREATE TABLE atlas_archive (id INTEGER PRIMARY KEY);
+INSERT INTO atlas_archive (id) VALUES (1);
+
+-- schema.sql --
+THIS SECTION MUST NOT EXECUTE;
+
+-- down.sql --
+-- +ptah source=txtar_down
+DROP TABLE atlas_archive;
+`)},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 2)
+	conn := openStatementObserverSQLite(t)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+	c.Assert(migrations[1].Up(context.Background(), conn), qt.IsNil)
+	c.Assert(migrations[1].Down(context.Background(), conn), qt.IsNil)
+
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: singlePath,
+			Statement:  "CREATE TABLE atlas_single (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{"source": "single"},
+		},
+		{
+			SourcePath: txtarPath + "#migration.sql",
+			Statement:  "CREATE TABLE atlas_archive (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      2,
+			Directives: map[string]string{"source": "txtar_up"},
+		},
+		{
+			SourcePath: txtarPath + "#migration.sql",
+			Statement:  "INSERT INTO atlas_archive (id) VALUES (1)",
+			Index:      2,
+			Total:      2,
+			Directives: map[string]string{"source": "txtar_up"},
+		},
+		{
+			SourcePath: txtarPath + "#down.sql",
+			Statement:  "DROP TABLE atlas_archive",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{"source": "txtar_down"},
+		},
+	})
+}
+
+func TestStatementObserver_NormalWriterExecutionIsObservedOnce(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_writer.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE writer_observed (id INTEGER PRIMARY KEY);\n"),
+		},
+		"0000000001_writer.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE writer_observed;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	conn := openStatementObserverSQLite(t)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+
+	c.Assert(statementObserverTableCount(t, conn, "writer_observed"), qt.Equals, 1)
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_writer.up.sql",
+			Statement:  "CREATE TABLE writer_observed (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{},
+		},
+	})
+}
+
+func TestStatementObserver_InterceptorHandledStatementIsObservedOnce(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_handled.up.sql": &fstest.MapFile{
+			Data: []byte("EXECUTE THROUGH INTERCEPTOR;\n"),
+		},
+		"0000000001_handled.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	interceptor := &statementObserverInterceptor{handled: true}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	c.Assert(migrations[0].Up(context.Background(), nil), qt.IsNil)
+
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"EXECUTE THROUGH INTERCEPTOR"})
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_handled.up.sql",
+			Statement:  "EXECUTE THROUGH INTERCEPTOR",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{},
+		},
+	})
+}
+
+func TestStatementObserverFunc_AdaptsFunction(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_adapter.up.sql": &fstest.MapFile{
+			Data: []byte("EXECUTE THROUGH INTERCEPTOR;\n"),
+		},
+		"0000000001_adapter.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	var events []migrator.StatementEvent
+	observer := migrator.StatementObserverFunc(func(
+		_ context.Context,
+		event migrator.StatementEvent,
+	) error {
+		events = append(events, event)
+		return nil
+	})
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(&statementObserverInterceptor{handled: true}),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	c.Assert(migrations[0].Up(context.Background(), nil), qt.IsNil)
+
+	c.Assert(events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_adapter.up.sql",
+			Statement:  "EXECUTE THROUGH INTERCEPTOR",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{},
+		},
+	})
+}
+
+func TestStatementObserver_DirectiveValidationFailureIsNotObserved(t *testing.T) {
+	c := qt.New(t)
+	validationErr := errors.New("invalid observer test directive")
+	fsys := fstest.MapFS{
+		"0000000001_validation.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah mode=invalid\nSELECT 1;\n"),
+		},
+		"0000000001_validation.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(&rejectingStatementInterceptor{err: validationErr}),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	err = migrations[0].Up(context.Background(), nil)
+
+	c.Assert(err, qt.ErrorIs, validationErr)
+	c.Assert(observer.events, qt.HasLen, 0)
+}
+
+func TestStatementObserver_InterceptorExecutionFailureIsNotObserved(t *testing.T) {
+	c := qt.New(t)
+	interceptorErr := errors.New("interceptor execution failed")
+	fsys := fstest.MapFS{
+		"0000000001_interceptor_failure.up.sql": &fstest.MapFile{
+			Data: []byte("EXECUTE THROUGH INTERCEPTOR;\n"),
+		},
+		"0000000001_interceptor_failure.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(&failingStatementInterceptor{err: interceptorErr}),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	err = migrations[0].Up(context.Background(), nil)
+
+	var executionErr *migrator.MigrationExecutionError
+	c.Assert(err, qt.ErrorAs, &executionErr)
+	c.Assert(err, qt.ErrorIs, interceptorErr)
+	c.Assert(executionErr.Statement, qt.Equals, "EXECUTE THROUGH INTERCEPTOR")
+	c.Assert(executionErr.StatementIndex, qt.Equals, 1)
+	c.Assert(executionErr.Total, qt.Equals, 1)
+	c.Assert(observer.events, qt.HasLen, 0)
+}
+
+func TestStatementObserver_InterceptorDeclinedStatementIsObservedOnce(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_declined.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE interceptor_declined (id INTEGER PRIMARY KEY);\n"),
+		},
+		"0000000001_declined.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE interceptor_declined;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	interceptor := &statementObserverInterceptor{handled: false}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	conn := openStatementObserverSQLite(t)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+
+	c.Assert(statementObserverTableCount(t, conn, "interceptor_declined"), qt.Equals, 1)
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{
+		"CREATE TABLE interceptor_declined (id INTEGER PRIMARY KEY)",
+	})
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_declined.up.sql",
+			Statement:  "CREATE TABLE interceptor_declined (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{},
+		},
+	})
+}
+
+func TestStatementObserver_RunsAfterSuccessfulExecution(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_order.up.sql": &fstest.MapFile{Data: []byte(
+			"CREATE TABLE observation_order (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO observation_order (id) VALUES (1);\n",
+		)},
+		"0000000001_order.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE observation_order;\n"),
+		},
+	}
+	conn := openStatementObserverSQLite(t)
+	observer := &statementStateObserver{
+		conn:  conn,
+		query: "SELECT count(*) FROM observation_order",
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+
+	c.Assert(observer.counts, qt.DeepEquals, []int{0, 1})
+}
+
+func TestStatementObserver_ExecutionFailureIsNotObserved(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_failure.up.sql": &fstest.MapFile{
+			Data: []byte("INSERT INTO missing_table (id) VALUES (1);\n"),
+		},
+		"0000000001_failure.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	conn := openStatementObserverSQLite(t)
+
+	err = migrations[0].Up(context.Background(), conn)
+
+	var executionErr *migrator.MigrationExecutionError
+	c.Assert(err, qt.ErrorAs, &executionErr)
+	c.Assert(executionErr.Statement, qt.Equals, "INSERT INTO missing_table (id) VALUES (1)")
+	c.Assert(executionErr.StatementIndex, qt.Equals, 1)
+	c.Assert(executionErr.Total, qt.Equals, 1)
+	c.Assert(observer.events, qt.HasLen, 0)
+}
+
+func TestStatementObserver_FailureStopsMigrationWithStatementContext(t *testing.T) {
+	c := qt.New(t)
+	const sourcePath = "0000000001_observer_failure.up.sql"
+	observerFailure := errors.New("statement observation failed")
+	observationResults := []error{nil, observerFailure}
+	fsys := fstest.MapFS{
+		sourcePath: &fstest.MapFile{Data: []byte(
+			"CREATE TABLE observer_failure (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO observer_failure (id) VALUES (1);\n" +
+				"INSERT INTO observer_failure (id) VALUES (2);\n",
+		)},
+		"0000000001_observer_failure.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE observer_failure;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	observer.after = func(migrator.StatementEvent) error {
+		return observationResults[len(observer.events)-1]
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	conn := openStatementObserverSQLite(t)
+
+	err = migrations[0].Up(context.Background(), conn)
+
+	var observationErr *migrator.StatementObservationError
+	c.Assert(err, qt.ErrorAs, &observationErr)
+	c.Assert(err, qt.ErrorIs, observerFailure)
+	c.Assert(err.Error(), qt.Contains, sourcePath)
+	c.Assert(observationErr.Event.SourcePath, qt.Equals, sourcePath)
+	c.Assert(observationErr.Event.Statement, qt.Equals, "INSERT INTO observer_failure (id) VALUES (1)")
+	c.Assert(observationErr.Event.Index, qt.Equals, 2)
+	c.Assert(observationErr.Event.Total, qt.Equals, 3)
+	c.Assert(observer.events, qt.HasLen, 2)
+	c.Assert(statementObserverRowCount(t, conn, "observer_failure"), qt.Equals, 1)
+}
+
+func TestStatementObserver_DirectivesAreIsolatedCopies(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_directives.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah scope=migration\n" +
+				"FIRST OBSERVED STATEMENT;\n" +
+				"SECOND OBSERVED STATEMENT;\n",
+		)},
+		"0000000001_directives.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	observer.after = func(event migrator.StatementEvent) error {
+		event.Directives["scope"] = "observer-mutated"
+		event.Directives["observer"] = "added"
+		return nil
+	}
+	interceptor := &statementObserverInterceptor{handled: true}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	c.Assert(migrations[0].Up(context.Background(), nil), qt.IsNil)
+
+	c.Assert(observer.events, qt.HasLen, 2)
+	c.Assert(observer.events[0].Directives, qt.DeepEquals, map[string]string{"scope": "migration"})
+	c.Assert(observer.events[1].Directives, qt.DeepEquals, map[string]string{"scope": "migration"})
+	c.Assert(interceptor.directives, qt.DeepEquals, []map[string]string{
+		{"scope": "migration"},
+		{"scope": "migration"},
+	})
+}
+
+func TestStatementObserver_InterceptorMutationsDoNotChangeFileDirectives(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_interceptor_directives.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah scope=migration\n" +
+				"EXECUTE THROUGH INTERCEPTOR;\n",
+		)},
+		"0000000001_interceptor_directives.down.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	interceptor := &mutatingStatementInterceptor{}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementInterceptor(interceptor),
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	c.Assert(migrations[0].Up(context.Background(), nil), qt.IsNil)
+
+	c.Assert(interceptor.directives, qt.DeepEquals, map[string]string{
+		"scope":      "migration",
+		"validation": "mutated",
+		"execution":  "mutated",
+	})
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_interceptor_directives.up.sql",
+			Statement:  "EXECUTE THROUGH INTERCEPTOR",
+			Index:      1,
+			Total:      1,
+			Directives: map[string]string{"scope": "migration"},
+		},
+	})
+}
+
+func TestStatementObserver_TransactionalFailureRollsBackAndRecordsZeroProgress(t *testing.T) {
+	c := qt.New(t)
+	const (
+		migrationsTable = "schema_migrations_observer_transaction"
+		sourcePath      = "0000000001_transaction.up.sql"
+	)
+	observerFailure := errors.New("transaction observation failed")
+	observationResults := []error{nil, observerFailure}
+	fsys := fstest.MapFS{
+		sourcePath: &fstest.MapFile{Data: []byte(
+			"CREATE TABLE observer_transaction (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO observer_transaction (id) VALUES (1);\n",
+		)},
+		"0000000001_transaction.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE observer_transaction;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	observer.after = func(migrator.StatementEvent) error {
+		return observationResults[len(observer.events)-1]
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	conn := openStatementObserverSQLite(t)
+	migrationRunner := migrator.NewMigrator(conn, provider).
+		WithMigrationsTable("", migrationsTable)
+
+	err = migrationRunner.MigrateUp(context.Background())
+
+	var observationErr *migrator.StatementObservationError
+	c.Assert(err, qt.ErrorAs, &observationErr)
+	c.Assert(err, qt.ErrorIs, observerFailure)
+	c.Assert(statementObserverTableCount(t, conn, "observer_transaction"), qt.Equals, 0)
+	progress := readStatementObserverRevisionProgress(t, conn, migrationsTable, 1)
+	c.Assert(progress.applied, qt.Equals, 0)
+	c.Assert(progress.total, qt.Equals, 2)
+	c.Assert(progress.errorStatement, qt.Equals, "INSERT INTO observer_transaction (id) VALUES (1)")
+}
+
+func TestStatementObserver_NoTransactionFailureRecordsAppliedStatement(t *testing.T) {
+	c := qt.New(t)
+	const (
+		migrationsTable = "schema_migrations_observer_no_transaction"
+		sourcePath      = "0000000001_observer_no_transaction.up.sql"
+	)
+	observerFailure := errors.New("no-transaction observation failed")
+	observationResults := []error{nil, observerFailure}
+	fsys := fstest.MapFS{
+		sourcePath: &fstest.MapFile{Data: []byte(
+			"-- +ptah no_transaction\n" +
+				"CREATE TABLE observer_no_transaction (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO observer_no_transaction (id) VALUES (1);\n" +
+				"INSERT INTO observer_no_transaction (id) VALUES (2);\n",
+		)},
+		"0000000001_observer_no_transaction.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE observer_no_transaction;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	observer.after = func(migrator.StatementEvent) error {
+		return observationResults[len(observer.events)-1]
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	conn := openStatementObserverSQLite(t)
+	migrationRunner := migrator.NewMigrator(conn, provider).
+		WithMigrationsTable("", migrationsTable)
+
+	err = migrationRunner.MigrateUp(context.Background())
+
+	var observationErr *migrator.StatementObservationError
+	c.Assert(err, qt.ErrorAs, &observationErr)
+	c.Assert(err, qt.ErrorIs, observerFailure)
+	c.Assert(statementObserverRowCount(t, conn, "observer_no_transaction"), qt.Equals, 1)
+	progress := readStatementObserverRevisionProgress(t, conn, migrationsTable, 1)
+	c.Assert(progress.applied, qt.Equals, 2)
+	c.Assert(progress.total, qt.Equals, 3)
+	c.Assert(progress.errorStatement, qt.Equals, "INSERT INTO observer_no_transaction (id) VALUES (1)")
+}
+
+func TestStatementObserver_NoTransactionExecutionIsObserved(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_no_transaction.up.sql": &fstest.MapFile{Data: []byte(
+			"-- +ptah no_transaction\n" +
+				"CREATE TABLE no_transaction_observed (id INTEGER PRIMARY KEY);\n" +
+				"INSERT INTO no_transaction_observed (id) VALUES (1);\n",
+		)},
+		"0000000001_no_transaction.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE no_transaction_observed;\n"),
+		},
+	}
+	observer := newStatementObserverRecorder()
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].UpNoTransaction, qt.IsTrue)
+	conn := openStatementObserverSQLite(t)
+
+	c.Assert(migrations[0].Up(context.Background(), conn), qt.IsNil)
+
+	c.Assert(statementObserverRowCount(t, conn, "no_transaction_observed"), qt.Equals, 1)
+	c.Assert(observer.events, qt.DeepEquals, []migrator.StatementEvent{
+		{
+			SourcePath: "0000000001_no_transaction.up.sql",
+			Statement:  "CREATE TABLE no_transaction_observed (id INTEGER PRIMARY KEY)",
+			Index:      1,
+			Total:      2,
+			Directives: map[string]string{"no_transaction": "true"},
+		},
+		{
+			SourcePath: "0000000001_no_transaction.up.sql",
+			Statement:  "INSERT INTO no_transaction_observed (id) VALUES (1)",
+			Index:      2,
+			Total:      2,
+			Directives: map[string]string{"no_transaction": "true"},
+		},
+	})
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -119,6 +120,18 @@ func (m *Migrator) migrationStatementCount(sqlText string) int {
 }
 
 func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMode) (applied int, total int, stmt string) {
+	var observationErr *StatementObservationError
+	if errors.As(err, &observationErr) {
+		event := observationErr.Event
+		applied = event.Index
+		total = event.Total
+		stmt = event.Statement
+		if migrationProgressRolledBack(dialect, txMode) {
+			applied = 0
+		}
+		return applied, total, stmt
+	}
+
 	var execErr *MigrationExecutionError
 	if !errors.As(err, &execErr) {
 		return 0, 0, ""
@@ -134,6 +147,21 @@ func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMod
 		applied = 0
 	}
 	return applied, total, execErr.Statement
+}
+
+func migrationProgressRolledBack(dialect string, txMode MigrationTxMode) bool {
+	if txMode == MigrationTxModeAll {
+		return true
+	}
+	if txMode != MigrationTxModeFile {
+		return false
+	}
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.SQLite, platform.SQLServer:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Migrator) getDirtyRevisionSQL() string {


### PR DESCRIPTION
Closes #765

## Why

Atlas-compatible semantic migration reporting must observe successful statement boundaries. Version-boundary catalog diffs lose intermediate operations and cannot reproduce Atlas change counts reliably.

## What changed

- add StatementObserver, StatementObserverFunc, StatementEvent, and WithStatementObserver to filesystem migration providers
- emit one synchronous post-success event for normally executed and interceptor-handled statements
- isolate event directives from provider and interceptor mutation
- distinguish observer failures with StatementObservationError
- preserve correct revision progress for transactional rollback and no-transaction partial application
- document the public API and its connection/transaction visibility boundary

## Self-review

Two independent review passes covered API boundaries, transaction semantics, retry/progress correctness, interceptor interaction, mutation isolation, error compatibility, security, and test gaps. The resulting fixes introduced the dedicated observer error, removed the misleading connection parameter, restored the existing MigrationExecutionError contract, and added full Migrator-level rollback/partial-progress coverage.

## Validation

- go test ./...
- go test -race ./migration/migrator
- go vet ./...
- go tool qtlint ./...
- scripts/check-test-style.sh
- golangci-lint run --fix ./...
- golangci-lint run ./...
- go mod tidy -diff
- scripts/check-public-api.sh
- scripts/check-public-api-snapshot.sh
- scripts/check-public-api-released.sh
- docs site build plus versions, exit-code, core-link, page-health, and link checks
- npm audit --audit-level=low
- built and smoke-tested ptah, ptah atlas, and ptah-compat command trees