### PR TITLE
Order generated data migrations by foreign-key dependency

### DIFF
--- a/docs/site/src/content/docs/workflows/reference-data.md
+++ b/docs/site/src/content/docs/workflows/reference-data.md
@@ -101,8 +101,10 @@ containing quotes, backslashes, or semicolons cannot break out of its literal.
 Managed tables are ordered by the schema's foreign-key dependency graph:
 `INSERT`s run parents-first and `DELETE`s children-first, so a migration
 spanning FK-related reference tables applies (and rolls back) without violating
-a foreign key. Tables without a schema-object definition fall back to
-alphabetical order.
+a foreign key. A managed table is matched to its `//migrator:schema:table`
+definition by qualified name, falling back to the bare table name when the
+`schema` attributes are not both set; tables with no matching definition fall
+back to alphabetical order.
 
 Known limit (tracked follow-up): only the managed columns are reconciled and
 restored, so emptying a populated table's desired set is refused rather than

--- a/docs/site/src/content/docs/workflows/reference-data.md
+++ b/docs/site/src/content/docs/workflows/reference-data.md
@@ -98,12 +98,15 @@ down re-inserts it. Applying up then down restores the original table contents.
 Values are rendered as dialect-correct, safely-escaped SQL literals, so a value
 containing quotes, backslashes, or semicolons cannot break out of its literal.
 
-Known limits (tracked follow-ups): only the managed columns are reconciled and
+Managed tables are ordered by the schema's foreign-key dependency graph:
+`INSERT`s run parents-first and `DELETE`s children-first, so a migration
+spanning FK-related reference tables applies (and rolls back) without violating
+a foreign key. Tables without a schema-object definition fall back to
+alphabetical order.
+
+Known limit (tracked follow-up): only the managed columns are reconciled and
 restored, so emptying a populated table's desired set is refused rather than
-generating a rollback that could not restore the non-key columns; and tables are
-ordered alphabetically rather than by foreign-key dependency, so FK-related
-tables may need manual reordering (a violation aborts the transactional migration
-cleanly).
+generating a rollback that could not restore the non-key columns.
 
 ## Declarative data versus `ptah seed`
 

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 
@@ -59,21 +60,21 @@ type Options struct {
 // single reversible SQL body pair covering every managed table.
 //
 // It parses the Go annotations under opts.RootDir and, for each declared
-// //migrator:schema:data table (iterated in Table order for deterministic
-// output), loads the desired rows, reads the live rows projected onto the
-// managed column set (the union of the desired rows' columns plus the key
-// columns), computes the row-level diff, and renders it. The per-table up
-// scripts are concatenated in Table order and the down scripts in reverse Table
-// order, so that applying the whole up followed by the whole down restores the
-// original state (a net-state round-trip). Tables whose diff is empty contribute
-// nothing.
+// //migrator:schema:data table, loads the desired rows, reads the live rows
+// projected onto the managed column set (the union of the desired rows' columns
+// plus the key columns), and computes the row-level diff. Tables whose diff is
+// empty contribute nothing.
 //
-// Table order is alphabetical, not foreign-key-topological, so a migration that
-// deletes a parent table's rows before a child's, or inserts a child's before a
-// parent's, can hit a foreign-key violation at apply time. Each migration runs
-// in a transaction, so such a violation aborts cleanly with nothing applied;
-// FK-related managed tables may need manual reordering. Dependency-aware
-// ordering is a tracked follow-up.
+// The generated migration is phase-separated and ordered by the schema's
+// foreign-key dependency graph so that foreign keys hold at apply time: up runs
+// every INSERT first with parent tables before the child tables that reference
+// them, then every UPDATE, then every DELETE with child tables before their
+// parents (the reverse). down is the exact reverse-inverse — it undoes the
+// DELETEs (re-inserting parents first), then the UPDATEs, then the INSERTs — so
+// applying the whole up followed by the whole down restores the original state.
+// The dependency order comes from the parsed schema (goschema orders tables
+// parents-first); managed tables without a schema-object definition, and any
+// left after a circular dependency, fall back to a stable alphabetical order.
 //
 // When no managed table has any changes, both returned strings are empty and
 // the caller writes nothing. A missing row-data file, a row missing a key
@@ -118,24 +119,22 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 		return cmp.Compare(a.File, b.File)
 	})
 
-	var ups, downs []string
+	diffs := make([]*datadiff.DataDiff, 0, len(managed))
 	var changes []tableChange
 	for _, md := range managed {
-		rendered, err := renderTable(ctx, conn, dialect, opts.RootDir, md)
+		diff, err := computeTable(ctx, conn, opts.RootDir, md)
 		if err != nil {
 			return "", "", err
 		}
-		if rendered.up == "" {
-			// An empty diff renders as empty up and down together, so there is
-			// nothing to reverse for this table.
+		if len(diff.Inserts) == 0 && len(diff.Updates) == 0 && len(diff.Deletes) == 0 {
+			// No drift for this table; it contributes nothing in either direction.
 			continue
 		}
-		ups = append(ups, tableBlock(qualifiedName(md.Schema, md.Table), rendered.up))
-		downs = append(downs, tableBlock(qualifiedName(md.Schema, md.Table), rendered.down))
-		changes = append(changes, tableChange{schema: md.Schema, table: md.Table, updates: len(rendered.diff.Updates), deletes: len(rendered.diff.Deletes)})
+		diffs = append(diffs, diff)
+		changes = append(changes, tableChange{schema: md.Schema, table: md.Table, updates: len(diff.Updates), deletes: len(diff.Deletes)})
 	}
 
-	if len(ups) == 0 {
+	if len(diffs) == 0 {
 		return "", "", nil
 	}
 
@@ -143,8 +142,8 @@ func Generate(ctx context.Context, conn *dbschema.DatabaseConnection, opts Optio
 		return "", "", err
 	}
 
-	slices.Reverse(downs)
-	return strings.Join(ups, "\n"), strings.Join(downs, "\n"), nil
+	orderByDependency(db, diffs)
+	return composeByPhase(diffs, dialect)
 }
 
 // tableChange records how many rows a single managed table's diff would update
@@ -185,27 +184,19 @@ func mergeByTable(changes []tableChange) []tableChange {
 	return merged
 }
 
-// tableRender is a single managed table's rendered migration together with the
-// diff it came from, so the caller can both concatenate the scripts and assess
-// the change volume. An empty up means the table had no drift.
-type tableRender struct {
-	up   string
-	down string
-	diff *datadiff.DataDiff
-}
-
-// renderTable runs the pipeline for a single managed table: load desired rows,
-// read the live rows for the managed columns, diff, and render. On error it
-// returns the zero tableRender.
-func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect, rootDir string, md goschema.ManagedData) (tableRender, error) {
+// computeTable runs the read-and-diff half of the pipeline for a single managed
+// table: load desired rows, read the live rows for the managed columns, and
+// compute the row-level diff. Rendering happens later, in composeByPhase, once
+// every table's diff is known and can be ordered by dependency.
+func computeTable(ctx context.Context, conn *dbschema.DatabaseConnection, rootDir string, md goschema.ManagedData) (*datadiff.DataDiff, error) {
 	desired, err := goschema.LoadManagedRows(rootDir, md)
 	if err != nil {
-		return tableRender{}, err
+		return nil, err
 	}
 
 	live, err := dbschema.ReadTableRows(ctx, conn, md.Schema, md.Table, managedColumns(desired, md.Keys))
 	if err != nil {
-		return tableRender{}, err
+		return nil, err
 	}
 
 	// With no desired rows the managed column set is just the keys, so every
@@ -216,20 +207,114 @@ func renderTable(ctx context.Context, conn *dbschema.DatabaseConnection, dialect
 	// rollback needs the table's whole column set and is a tracked follow-up;
 	// an empty desired set against an empty table is still a clean no-op.
 	if len(desired) == 0 && len(live) > 0 {
-		return tableRender{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"datamigrate: managed table %q has an empty desired row set but %d live row(s); a reversible full delete cannot be generated from the key columns alone — provide the desired rows or remove the annotation",
 			md.Table, len(live))
 	}
 
-	diff, err := datadiff.Compute(md.Schema, md.Table, md.Keys, desired, live)
-	if err != nil {
-		return tableRender{}, err
+	return datadiff.Compute(md.Schema, md.Table, md.Keys, desired, live)
+}
+
+// orderByDependency reorders diffs in place so a table appears before every
+// table that declares a foreign key to it, matching the schema's dependency
+// graph. db.Tables is already topologically sorted parents-first, so its index
+// gives the insert order (the reverse gives the delete order). Managed tables
+// with no schema-object definition — and any left after a circular dependency —
+// keep a stable alphabetical order after the known ones, so output stays
+// deterministic.
+func orderByDependency(db *goschema.Database, diffs []*datadiff.DataDiff) {
+	pos := make(map[string]int, len(db.Tables))
+	for i, t := range db.Tables {
+		pos[t.QualifiedName()] = i
 	}
-	up, down, err := datadiff.Render(diff, dialect)
-	if err != nil {
-		return tableRender{}, err
+	rank := func(d *datadiff.DataDiff) int {
+		if i, ok := pos[qualifiedName(d.Schema, d.Table)]; ok {
+			return i
+		}
+		return math.MaxInt
 	}
-	return tableRender{up: up, down: down, diff: diff}, nil
+	slices.SortStableFunc(diffs, func(a, b *datadiff.DataDiff) int {
+		if c := cmp.Compare(rank(a), rank(b)); c != 0 {
+			return c
+		}
+		return cmp.Compare(qualifiedName(a.Schema, a.Table), qualifiedName(b.Schema, b.Table))
+	})
+}
+
+// composeByPhase renders the dependency-ordered diffs into one reversible up/down
+// pair, separating the work into phases so foreign keys hold at apply time. up
+// runs all INSERTs parents-first, then all UPDATEs, then all DELETEs
+// children-first; down is the exact reverse-inverse (undo DELETEs parents-first,
+// then UPDATEs and INSERTs children-first). Each phase is rendered from a
+// single-operation sub-diff via datadiff.Render, so the proven per-table
+// inverse contract composes into a global reversible migration.
+func composeByPhase(ordered []*datadiff.DataDiff, dialect string) (upSQL, downSQL string, err error) {
+	type phased struct {
+		insUp, insDown string
+		updUp, updDown string
+		delUp, delDown string
+	}
+	rendered := make([]phased, len(ordered))
+	for i, d := range ordered {
+		var p phased
+		if p.insUp, p.insDown, err = datadiff.Render(subDiff(d, d.Inserts, nil, nil), dialect); err != nil {
+			return "", "", err
+		}
+		if p.updUp, p.updDown, err = datadiff.Render(subDiff(d, nil, d.Updates, nil), dialect); err != nil {
+			return "", "", err
+		}
+		if p.delUp, p.delDown, err = datadiff.Render(subDiff(d, nil, nil, d.Deletes), dialect); err != nil {
+			return "", "", err
+		}
+		rendered[i] = p
+	}
+
+	var up []string
+	for i, d := range ordered { // INSERTs: parents before children.
+		up = appendBlock(up, d, "insert", rendered[i].insUp)
+	}
+	for i, d := range ordered { // UPDATEs.
+		up = appendBlock(up, d, "update", rendered[i].updUp)
+	}
+	for i, d := range slices.Backward(ordered) { // DELETEs: children before parents.
+		up = appendBlock(up, d, "delete", rendered[i].delUp)
+	}
+
+	var down []string
+	for i, d := range ordered { // Undo DELETEs (re-insert): parents before children.
+		down = appendBlock(down, d, "delete", rendered[i].delDown)
+	}
+	for i, d := range slices.Backward(ordered) { // Undo UPDATEs: children before parents.
+		down = appendBlock(down, d, "update", rendered[i].updDown)
+	}
+	for i, d := range slices.Backward(ordered) { // Undo INSERTs (delete): children before parents.
+		down = appendBlock(down, d, "insert", rendered[i].insDown)
+	}
+
+	return strings.Join(up, "\n"), strings.Join(down, "\n"), nil
+}
+
+// subDiff builds a single-operation view of d carrying only the given rows, so
+// each phase can be rendered independently while keeping d's schema, table, and
+// key columns.
+func subDiff(d *datadiff.DataDiff, inserts []datadiff.Row, updates []datadiff.RowUpdate, deletes []datadiff.Row) *datadiff.DataDiff {
+	return &datadiff.DataDiff{
+		Schema:  d.Schema,
+		Table:   d.Table,
+		Keys:    d.Keys,
+		Inserts: inserts,
+		Updates: updates,
+		Deletes: deletes,
+	}
+}
+
+// appendBlock appends a phase's rendered statements for a table, prefixed with a
+// comment naming the phase and table, skipping empty phases.
+func appendBlock(blocks []string, d *datadiff.DataDiff, phase, rendered string) []string {
+	if rendered == "" {
+		return blocks
+	}
+	return append(blocks, tableBlock(phase+" "+qualifiedName(d.Schema, d.Table), rendered))
 }
 
 // checkPolicy enforces the generate-time safety gates over the tables the
@@ -367,9 +452,10 @@ func qualifiedName(schema, table string) string {
 	return schema + "." + table
 }
 
-// tableBlock prefixes a rendered per-table script with a comment naming the
-// table so a reviewer can tell the concatenated blocks apart. The comment is a
-// no-op at apply time and does not affect the round-trip.
-func tableBlock(table, body string) string {
-	return "-- data: " + table + "\n" + body
+// tableBlock prefixes a rendered script with a "-- data: <label>" comment (the
+// label names the phase and table, e.g. "insert public.regions") so a reviewer
+// can tell the concatenated phase blocks apart. The comment is a no-op at apply
+// time and does not affect the round-trip.
+func tableBlock(label, body string) string {
+	return "-- data: " + label + "\n" + body
 }

--- a/internal/datamigrate/datamigrate.go
+++ b/internal/datamigrate/datamigrate.go
@@ -223,13 +223,30 @@ func computeTable(ctx context.Context, conn *dbschema.DatabaseConnection, rootDi
 // keep a stable alphabetical order after the known ones, so output stays
 // deterministic.
 func orderByDependency(db *goschema.Database, diffs []*datadiff.DataDiff) {
+	// Index the dependency-sorted tables by their fully-qualified name, and also
+	// by bare name where that name is unambiguous across the schema. The bare
+	// index is a fallback for when a //migrator:schema:data annotation omits the
+	// schema attribute while its //migrator:schema:table definition sets one (or
+	// vice versa); without it the qualified lookup would miss and FK ordering
+	// would silently degrade to alphabetical for that table. A bare name shared
+	// by tables in different schemas is left out of the fallback so it can never
+	// resolve to the wrong table.
 	pos := make(map[string]int, len(db.Tables))
+	barePos := make(map[string]int, len(db.Tables))
+	bareCount := make(map[string]int, len(db.Tables))
 	for i, t := range db.Tables {
 		pos[t.QualifiedName()] = i
+		barePos[t.Name] = i
+		bareCount[t.Name]++
 	}
 	rank := func(d *datadiff.DataDiff) int {
 		if i, ok := pos[qualifiedName(d.Schema, d.Table)]; ok {
 			return i
+		}
+		if bareCount[d.Table] == 1 {
+			if i, ok := barePos[d.Table]; ok {
+				return i
+			}
 		}
 		return math.MaxInt
 	}

--- a/internal/datamigrate/datamigrate_test.go
+++ b/internal/datamigrate/datamigrate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -307,6 +308,117 @@ type Region struct {
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(up, qt.Contains, `INSERT INTO "reference"."regions"`)
+}
+
+// TestGenerate_ForeignKeyOrdering proves the migration is ordered by the
+// schema's foreign-key dependency graph: INSERTs run parents-first and DELETEs
+// children-first, so applying up and then down never violates a foreign key.
+// The test enforces foreign keys (PRAGMA foreign_keys=ON) so a wrong order would
+// actually fail rather than pass silently.
+func TestGenerate_ForeignKeyOrdering(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, "sqlite:///:memory:")
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	_, err = conn.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	c.Assert(err, qt.IsNil)
+	for _, ddl := range []string{
+		`CREATE TABLE countries (code TEXT PRIMARY KEY, name TEXT NOT NULL)`,
+		`CREATE TABLE regions (code TEXT PRIMARY KEY, country_code TEXT NOT NULL REFERENCES countries(code), name TEXT NOT NULL)`,
+		// Live: US + XX countries; CA(->US) + ZZ(->XX) regions.
+		`INSERT INTO countries (code, name) VALUES ('US', 'United States'), ('XX', 'Old Country')`,
+		`INSERT INTO regions (code, country_code, name) VALUES ('CA', 'US', 'California'), ('ZZ', 'XX', 'Old Region')`,
+	} {
+		_, execErr := conn.ExecContext(ctx, ddl)
+		c.Assert(execErr, qt.IsNil)
+	}
+
+	root := t.TempDir()
+	goSrc := `package fixture
+
+//migrator:schema:table name="countries"
+type Country struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+
+//migrator:schema:table name="regions"
+type Region struct {
+	//migrator:schema:field name="code" type="TEXT" primary="true"
+	Code string
+	//migrator:schema:field name="country_code" type="TEXT" not_null="true" foreign="countries(code)"
+	CountryCode string
+	//migrator:schema:field name="name" type="TEXT" not_null="true"
+	Name string
+}
+
+//migrator:schema:data table="countries" key="code" file="countries.yaml"
+type countryData struct{ _ int }
+
+//migrator:schema:data table="regions" key="code" file="regions.yaml"
+type regionData struct{ _ int }
+`
+	c.Assert(os.WriteFile(filepath.Join(root, "schema.go"), []byte(goSrc), 0o600), qt.IsNil)
+	// Desired: drop the XX country and ZZ region, add the DE country and the BY
+	// region that references DE.
+	c.Assert(os.WriteFile(filepath.Join(root, "countries.yaml"),
+		[]byte("- code: US\n  name: United States\n- code: DE\n  name: Germany\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(root, "regions.yaml"),
+		[]byte("- code: CA\n  country_code: US\n  name: California\n- code: BY\n  country_code: DE\n  name: Bavaria\n"), 0o600), qt.IsNil)
+
+	up, down, err := datamigrate.Generate(ctx, conn, datamigrate.Options{RootDir: root, AllowDestructive: true})
+	c.Assert(err, qt.IsNil)
+
+	// Parent INSERT before child INSERT; child DELETE before parent DELETE.
+	c.Assert(strings.Index(up, `INSERT INTO "countries"`) < strings.Index(up, `INSERT INTO "regions"`), qt.IsTrue,
+		qt.Commentf("up:\n%s", up))
+	c.Assert(strings.Index(up, `DELETE FROM "regions"`) < strings.Index(up, `DELETE FROM "countries"`), qt.IsTrue,
+		qt.Commentf("up:\n%s", up))
+
+	apply := func(script string) {
+		for _, stmt := range migrator.SplitSQLStatementsForConnection(conn, script) {
+			_, execErr := conn.ExecContext(ctx, stmt)
+			c.Assert(execErr, qt.IsNil, qt.Commentf("stmt: %s", stmt))
+		}
+	}
+	readState := func() (map[string]string, map[string]string) {
+		countries := map[string]string{}
+		rows, qErr := conn.QueryContext(ctx, `SELECT code, name FROM countries ORDER BY code`)
+		c.Assert(qErr, qt.IsNil)
+		for rows.Next() {
+			var k, v string
+			c.Assert(rows.Scan(&k, &v), qt.IsNil)
+			countries[k] = v
+		}
+		c.Assert(rows.Err(), qt.IsNil)
+		_ = rows.Close()
+		regions := map[string]string{}
+		rows2, qErr := conn.QueryContext(ctx, `SELECT code, country_code FROM regions ORDER BY code`)
+		c.Assert(qErr, qt.IsNil)
+		for rows2.Next() {
+			var k, v string
+			c.Assert(rows2.Scan(&k, &v), qt.IsNil)
+			regions[k] = v
+		}
+		c.Assert(rows2.Err(), qt.IsNil)
+		_ = rows2.Close()
+		return countries, regions
+	}
+
+	apply(up)
+	countries, regions := readState()
+	c.Assert(countries, qt.DeepEquals, map[string]string{"US": "United States", "DE": "Germany"})
+	c.Assert(regions, qt.DeepEquals, map[string]string{"CA": "US", "BY": "DE"})
+
+	apply(down)
+	countries, regions = readState()
+	c.Assert(countries, qt.DeepEquals, map[string]string{"US": "United States", "XX": "Old Country"})
+	c.Assert(regions, qt.DeepEquals, map[string]string{"CA": "US", "ZZ": "XX"})
 }
 
 func TestGenerate_EmptyDesiredWithLiveRowsErrors(t *testing.T) {

--- a/internal/datamigrate/order_internal_test.go
+++ b/internal/datamigrate/order_internal_test.go
@@ -1,5 +1,10 @@
 package datamigrate
 
+// White-box testing required: exercises orderByDependency, the package-local
+// helper that maps managed-data diffs to the schema's dependency-sorted tables.
+// It has no exported entry point, and the mapping edge cases (bare-name fallback,
+// ambiguity guard) are not observable from the black-box Generate output.
+
 import (
 	"testing"
 

--- a/internal/datamigrate/order_test.go
+++ b/internal/datamigrate/order_test.go
@@ -1,0 +1,70 @@
+package datamigrate
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/migration/datadiff"
+)
+
+// TestOrderByDependency covers how managed-data diffs are matched to the
+// schema's dependency-sorted tables: by qualified name, by a bare-name fallback
+// when the data annotation omits the schema, and the ambiguity guard that
+// refuses to guess when a bare name is shared across schemas.
+func TestOrderByDependency(t *testing.T) {
+	c := qt.New(t)
+
+	names := func(diffs []*datadiff.DataDiff) []string {
+		out := make([]string, len(diffs))
+		for i, d := range diffs {
+			out[i] = qualifiedName(d.Schema, d.Table)
+		}
+		return out
+	}
+
+	// db.Tables is already dependency-sorted parents-first (authors before
+	// articles); note "articles" < "authors" alphabetically, so any path that
+	// falls back to alphabetical order would wrongly put the child first.
+	depSorted := func() *goschema.Database {
+		return &goschema.Database{Tables: []goschema.Table{
+			{Name: "authors", Schema: "app"},
+			{Name: "articles", Schema: "app"},
+		}}
+	}
+
+	c.Run("qualified match follows dependency order", func(c *qt.C) {
+		diffs := []*datadiff.DataDiff{
+			{Schema: "app", Table: "articles"},
+			{Schema: "app", Table: "authors"},
+		}
+		orderByDependency(depSorted(), diffs)
+		c.Assert(names(diffs), qt.DeepEquals, []string{"app.authors", "app.articles"})
+	})
+
+	c.Run("bare-name fallback when the data annotation omits the schema", func(c *qt.C) {
+		diffs := []*datadiff.DataDiff{
+			{Table: "articles"},
+			{Table: "authors"},
+		}
+		orderByDependency(depSorted(), diffs)
+		c.Assert(names(diffs), qt.DeepEquals, []string{"authors", "articles"})
+	})
+
+	c.Run("ambiguous bare name is not guessed", func(c *qt.C) {
+		// The same bare name in two schemas must not resolve via the fallback;
+		// with no qualified match either, both rank last and sort alphabetically
+		// by qualified name ("t" < "z.t").
+		db := &goschema.Database{Tables: []goschema.Table{
+			{Name: "t", Schema: "b"},
+			{Name: "t", Schema: "a"},
+		}}
+		diffs := []*datadiff.DataDiff{
+			{Schema: "z", Table: "t"},
+			{Table: "t"},
+		}
+		orderByDependency(db, diffs)
+		c.Assert(names(diffs), qt.DeepEquals, []string{"t", "z.t"})
+	})
+}


### PR DESCRIPTION
## Summary

Completes a tracked #663 follow-up. `ptah migrations data` concatenated each managed table's statements in **alphabetical** order, so a migration spanning foreign-key-related reference tables could hit an FK violation at apply time (a child row inserted before its parent, or a parent deleted before its child). The transaction aborted cleanly, but the tables needed manual reordering.

## Change

Order the work by the schema's foreign-key dependency graph and phase-separate it so foreign keys hold:

- **up** runs every `INSERT` parents-first (goschema already topologically sorts tables parents-first via its FK dependency graph), then every `UPDATE`, then every `DELETE` children-first (the reverse).
- **down** is the exact reverse-inverse — undo the `DELETE`s (re-inserting parents first), then the `UPDATE`s, then the `INSERT`s — so applying up then down still restores the original contents.
- Each phase is rendered from a single-operation sub-diff via the existing `datadiff.Render`, so its proven per-table inverse contract composes into a globally reversible migration with **no change to `datadiff`**. A single managed table's statements are unchanged. Managed tables without a `//migrator:schema:table` definition (or any left after a circular dependency) keep a stable alphabetical order, so output stays deterministic.

## Verification

A new test builds a parent/child reference-data migration (countries ← regions FK) and applies **and rolls back** under `PRAGMA foreign_keys=ON`, so a wrong INSERT/DELETE order would fail rather than pass silently; it also asserts parent-INSERT-before-child and child-DELETE-before-parent. All existing datamigrate round-trip/gate tests still pass unchanged. Locally green: build, gofmt, `go vet`, full `go test ./...`, `golangci-lint`, `qtlint`, public-API snapshot (unchanged — internal package), and doc-site checks. Docs updated.

Part of #663.