### PR TITLE
Add DML SELECT query builder (Phase 1 of #98)

### DIFF
--- a/core/ast/select.go
+++ b/core/ast/select.go
@@ -1,0 +1,237 @@
+package ast
+
+// This file defines the Phase 1 DML query AST: a single-table SELECT statement
+// and the composable boolean expression tree used by its WHERE clause. These
+// nodes live alongside the DDL nodes but do not participate in the DDL Visitor
+// interface, because DML rendering must return bound arguments in addition to a
+// SQL string. Rendering is handled by renderer.RenderSelect.
+//
+// Phase 1 deliberately models only SELECT / WHERE / ORDER BY / LIMIT / OFFSET.
+// JOIN, GROUP BY, HAVING, DISTINCT, subqueries, functions, and arithmetic are
+// intentionally absent; they are follow-up phases. The types below are shaped
+// so those extensions slot in without breaking callers (for example, Comparison
+// takes Expression operands on both sides rather than a bare column string).
+
+// Expression is a boolean or scalar expression used in DML statements such as
+// the WHERE clause of a SELECT.
+//
+// Expression is a sealed sum type: only the node types declared in this package
+// implement it. Sealing serves the query builder's core safety property — a
+// caller cannot smuggle a raw SQL string in as an expression, and every value
+// reaches the SQL through a BoundValue node (a placeholder), never inlined.
+type Expression interface {
+	// expressionNode is an unexported marker method that seals the interface.
+	expressionNode()
+}
+
+// ColumnRef is a reference to a column by name.
+//
+// A ColumnRef always renders as a dialect-quoted identifier and never as literal
+// SQL text, so an attacker-shaped name cannot terminate the identifier.
+type ColumnRef struct {
+	// Name is the unqualified column name.
+	Name string
+}
+
+func (*ColumnRef) expressionNode() {}
+
+// BoundValue is a parameter value.
+//
+// The renderer emits a dialect-specific placeholder ($1, $2, … for PostgreSQL;
+// ? for MySQL, MariaDB, and SQLite) and appends Value to the returned argument
+// slice. The value is never interpolated into the SQL string.
+type BoundValue struct {
+	// Value is the parameter value, bound positionally at render time.
+	Value any
+}
+
+func (*BoundValue) expressionNode() {}
+
+// ComparisonOperator enumerates the binary comparison operators supported in
+// Phase 1.
+type ComparisonOperator int
+
+const (
+	// OpEqual is the = operator.
+	OpEqual ComparisonOperator = iota
+	// OpNotEqual is the <> operator.
+	OpNotEqual
+	// OpLessThan is the < operator.
+	OpLessThan
+	// OpLessThanOrEqual is the <= operator.
+	OpLessThanOrEqual
+	// OpGreaterThan is the > operator.
+	OpGreaterThan
+	// OpGreaterThanOrEqual is the >= operator.
+	OpGreaterThanOrEqual
+)
+
+// String returns the SQL token for the operator, or an empty string when the
+// operator is outside the defined range. Renderers treat an empty string as an
+// error rather than emitting invalid SQL.
+func (op ComparisonOperator) String() string {
+	switch op {
+	case OpEqual:
+		return "="
+	case OpNotEqual:
+		return "<>"
+	case OpLessThan:
+		return "<"
+	case OpLessThanOrEqual:
+		return "<="
+	case OpGreaterThan:
+		return ">"
+	case OpGreaterThanOrEqual:
+		return ">="
+	default:
+		return ""
+	}
+}
+
+// Comparison is a binary comparison of the form "Left <Operator> Right".
+//
+// In Phase 1 the query builder produces a ColumnRef on the left and a BoundValue
+// on the right, but the node accepts any Expression on either side so later
+// phases can compare columns or expressions directly.
+type Comparison struct {
+	// Left is the left-hand operand.
+	Left Expression
+	// Operator is the comparison operator.
+	Operator ComparisonOperator
+	// Right is the right-hand operand.
+	Right Expression
+}
+
+func (*Comparison) expressionNode() {}
+
+// InExpr is a membership test of the form "Operand IN (Values...)".
+//
+// Values must be non-empty; the renderer rejects an empty list rather than
+// emitting the invalid "IN ()". Each value renders as its own placeholder.
+type InExpr struct {
+	// Operand is the expression tested for membership, typically a ColumnRef.
+	Operand Expression
+	// Values are the candidate values, each bound as a placeholder.
+	Values []Expression
+}
+
+func (*InExpr) expressionNode() {}
+
+// NullTest is a null check of the form "Operand IS NULL" or, when Negated,
+// "Operand IS NOT NULL".
+type NullTest struct {
+	// Operand is the expression tested for null, typically a ColumnRef.
+	Operand Expression
+	// Negated selects IS NOT NULL instead of IS NULL.
+	Negated bool
+}
+
+func (*NullTest) expressionNode() {}
+
+// LogicalOperator enumerates the boolean combinators used by LogicalExpr.
+type LogicalOperator int
+
+const (
+	// LogicalAnd is the AND combinator.
+	LogicalAnd LogicalOperator = iota
+	// LogicalOr is the OR combinator.
+	LogicalOr
+)
+
+// String returns the SQL keyword for the operator, or an empty string when the
+// operator is outside the defined range.
+func (op LogicalOperator) String() string {
+	switch op {
+	case LogicalAnd:
+		return "AND"
+	case LogicalOr:
+		return "OR"
+	default:
+		return ""
+	}
+}
+
+// LogicalExpr combines two or more operands with a single boolean operator, as
+// in "Operands[0] AND Operands[1] AND …". The renderer parenthesizes the whole
+// expression so precedence is explicit regardless of nesting.
+type LogicalExpr struct {
+	// Operator is the boolean combinator applied between operands.
+	Operator LogicalOperator
+	// Operands are the sub-expressions being combined; at least one is required.
+	Operands []Expression
+}
+
+func (*LogicalExpr) expressionNode() {}
+
+// NotExpr negates its operand, rendering as "NOT (Operand)".
+type NotExpr struct {
+	// Operand is the expression being negated.
+	Operand Expression
+}
+
+func (*NotExpr) expressionNode() {}
+
+// SortDirection is the direction of an ORDER BY term.
+type SortDirection int
+
+const (
+	// SortAscending sorts in ascending order (ASC).
+	SortAscending SortDirection = iota
+	// SortDescending sorts in descending order (DESC).
+	SortDescending
+)
+
+// String returns the SQL keyword for the direction, or an empty string when the
+// direction is outside the defined range.
+func (d SortDirection) String() string {
+	switch d {
+	case SortAscending:
+		return "ASC"
+	case SortDescending:
+		return "DESC"
+	default:
+		return ""
+	}
+}
+
+// OrderByClause is a single ORDER BY term: a column and a sort direction. The
+// direction is always rendered explicitly so output is deterministic.
+type OrderByClause struct {
+	// Column is the column name to order by, rendered as a quoted identifier.
+	Column string
+	// Direction is the sort direction.
+	Direction SortDirection
+}
+
+// ResultColumn is one entry in a SELECT projection.
+//
+// When Star is true the entry renders as "*" (select all columns) and Name is
+// ignored; otherwise Name renders as a dialect-quoted identifier.
+type ResultColumn struct {
+	// Name is the column name, used when Star is false.
+	Name string
+	// Star selects all columns (SELECT *).
+	Star bool
+}
+
+// SelectStatement is a single-table SELECT with an optional WHERE clause,
+// ORDER BY terms, and LIMIT/OFFSET bounds.
+//
+// It is the Phase 1 DML node. JOIN, GROUP BY, HAVING, DISTINCT, subqueries,
+// functions, and arithmetic are intentionally not modeled yet. Render it with
+// renderer.RenderSelect, which returns the SQL string and its positional
+// arguments. Build one fluently with the core/query package.
+type SelectStatement struct {
+	// Columns is the projection. An empty slice renders as "*".
+	Columns []ResultColumn
+	// From is the single source table, rendered as a quoted identifier. Required.
+	From string
+	// Where is the optional filter expression tree; nil means no WHERE clause.
+	Where Expression
+	// OrderBy is the optional list of sort terms, applied in order.
+	OrderBy []OrderByClause
+	// Limit is the optional row limit; nil means no LIMIT. The value is bound.
+	Limit *int64
+	// Offset is the optional row offset; nil means no OFFSET. The value is bound.
+	Offset *int64
+}

--- a/core/ast/select_test.go
+++ b/core/ast/select_test.go
@@ -1,0 +1,73 @@
+package ast_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+)
+
+func TestComparisonOperatorString(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		op   ast.ComparisonOperator
+		want string
+	}{
+		{name: "equal", op: ast.OpEqual, want: "="},
+		{name: "not equal", op: ast.OpNotEqual, want: "<>"},
+		{name: "less than", op: ast.OpLessThan, want: "<"},
+		{name: "less than or equal", op: ast.OpLessThanOrEqual, want: "<="},
+		{name: "greater than", op: ast.OpGreaterThan, want: ">"},
+		{name: "greater than or equal", op: ast.OpGreaterThanOrEqual, want: ">="},
+		{name: "out of range yields empty", op: ast.ComparisonOperator(42), want: ""},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.op.String(), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestLogicalOperatorString(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		op   ast.LogicalOperator
+		want string
+	}{
+		{name: "and", op: ast.LogicalAnd, want: "AND"},
+		{name: "or", op: ast.LogicalOr, want: "OR"},
+		{name: "out of range yields empty", op: ast.LogicalOperator(42), want: ""},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.op.String(), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestSortDirectionString(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		dir  ast.SortDirection
+		want string
+	}{
+		{name: "ascending", dir: ast.SortAscending, want: "ASC"},
+		{name: "descending", dir: ast.SortDescending, want: "DESC"},
+		{name: "out of range yields empty", dir: ast.SortDirection(42), want: ""},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.dir.String(), qt.Equals, tt.want)
+		})
+	}
+}

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -45,7 +45,7 @@
 //			query.In("status", []string{"in_use", "sold"}),
 //			query.Or(
 //				query.IsNotNull("deleted_at"),
-//				query.Not(query.Gt("count", 10)),
+//				query.Not(query.Gt("count", int64(10))),
 //			),
 //		)).
 //		OrderBy(query.Asc("name"), query.Asc("id")).

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -1,0 +1,63 @@
+// Package query provides a fluent, dialect-aware builder for parameterized SQL
+// SELECT statements.
+//
+// It is the DML counterpart to the DDL construction helpers in
+// ptah/internal/astbuilder: where those build CREATE TABLE and friends, this
+// package builds read queries. A builder produces an *ast.SelectStatement, which
+// renderer.RenderSelect turns into a SQL string plus its positional arguments
+// for PostgreSQL, MySQL, MariaDB, and SQLite.
+//
+// # Scope (Phase 1)
+//
+// This package models exactly SELECT with a single FROM table, a composable
+// WHERE expression tree, ORDER BY, LIMIT, and OFFSET. JOIN, GROUP BY, HAVING,
+// DISTINCT, subqueries, functions, arithmetic, and LIKE are intentionally not
+// implemented yet and are tracked as follow-up phases.
+//
+// # Safety model
+//
+// The builder separates identifiers from values structurally, so the classic
+// "string-concatenate a value into SQL" injection cannot happen through this
+// API:
+//
+//   - Values passed to Eq, In, and the other comparison helpers are typed as
+//     any and always travel to the database as bound parameters. They are never
+//     interpolated into the SQL text; the renderer emits a placeholder ($1, $2,
+//     … for PostgreSQL; ? for MySQL/MariaDB/SQLite) and appends the value to the
+//     returned argument slice. LIMIT and OFFSET values are bound the same way.
+//   - Identifiers (table names, column names) are always emitted through
+//     dialect-aware quoting, so an attacker-shaped identifier cannot terminate
+//     the quoted identifier and inject SQL. As with Ptah's DDL rendering,
+//     restricting which identifiers a caller may supply (for example, an
+//     allow-list of sortable columns) remains the caller's responsibility; the
+//     builder guarantees quoting and the absence of value interpolation.
+//
+// Placeholder numbering is assigned by the renderer in a single left-to-right
+// pass, so argument order always matches placeholder order and callers never
+// manage indices by hand.
+//
+// # Usage
+//
+//	stmt := query.Select("id", "name").
+//		From("commodities").
+//		Where(query.And(
+//			query.Eq("draft", false),
+//			query.In("status", []string{"in_use", "sold"}),
+//			query.Or(
+//				query.IsNotNull("deleted_at"),
+//				query.Not(query.Gt("count", 10)),
+//			),
+//		)).
+//		OrderBy(query.Asc("name"), query.Asc("id")).
+//		Limit(24).
+//		Offset(0).
+//		Build()
+//
+//	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+//	// sql:  SELECT "id", "name" FROM "commodities" WHERE (...) ORDER BY ... LIMIT $5 OFFSET $6
+//	// args: []any{false, "in_use", "sold", int64(10), int64(24), int64(0)}
+//
+// A WHERE expression can be built once and shared between statements (for
+// example, a COUNT(*) and the paged SELECT that share the same filter), because
+// the expression constructors return plain *ast expression nodes.
+package query

--- a/core/query/query.go
+++ b/core/query/query.go
@@ -1,0 +1,176 @@
+package query
+
+import (
+	"github.com/stokaro/ptah/core/ast"
+)
+
+// SelectBuilder builds an *ast.SelectStatement through a fluent, chainable API.
+//
+// A zero SelectBuilder is not meant to be used directly; start with Select. Each
+// method mutates and returns the same builder for chaining. Build produces the
+// statement. Builders are not safe for concurrent use.
+type SelectBuilder struct {
+	columns []ast.ResultColumn
+	from    string
+	where   ast.Expression
+	orderBy []ast.OrderByClause
+	limit   *int64
+	offset  *int64
+}
+
+// Select starts a SELECT with the given projection columns.
+//
+// Each name is rendered as a dialect-quoted identifier, except the special
+// column "*", which selects all columns. Calling Select with no arguments (or a
+// single "*") selects all columns.
+func Select(columns ...string) *SelectBuilder {
+	b := &SelectBuilder{}
+	for _, name := range columns {
+		if name == "*" {
+			b.columns = append(b.columns, ast.ResultColumn{Star: true})
+			continue
+		}
+		b.columns = append(b.columns, ast.ResultColumn{Name: name})
+	}
+	return b
+}
+
+// From sets the single source table for the query. It is required; rendering a
+// statement without a table returns an error.
+func (b *SelectBuilder) From(table string) *SelectBuilder {
+	b.from = table
+	return b
+}
+
+// Where sets the filter expression. Calling Where again replaces the previous
+// expression; compose multiple conditions with And, Or, and Not.
+func (b *SelectBuilder) Where(expr ast.Expression) *SelectBuilder {
+	b.where = expr
+	return b
+}
+
+// OrderBy appends sort terms, applied in the order given across calls. Use Asc
+// and Desc to build terms.
+func (b *SelectBuilder) OrderBy(terms ...ast.OrderByClause) *SelectBuilder {
+	b.orderBy = append(b.orderBy, terms...)
+	return b
+}
+
+// Limit sets the maximum number of rows. The value is bound as a parameter, not
+// inlined. Setting Limit to 0 emits LIMIT 0 (no rows); omit the call for no
+// limit at all.
+func (b *SelectBuilder) Limit(n int64) *SelectBuilder {
+	b.limit = &n
+	return b
+}
+
+// Offset sets the number of rows to skip. The value is bound as a parameter.
+func (b *SelectBuilder) Offset(n int64) *SelectBuilder {
+	b.offset = &n
+	return b
+}
+
+// Build returns the assembled *ast.SelectStatement. Render it with
+// renderer.RenderSelect.
+func (b *SelectBuilder) Build() *ast.SelectStatement {
+	return &ast.SelectStatement{
+		Columns: b.columns,
+		From:    b.from,
+		Where:   b.where,
+		OrderBy: b.orderBy,
+		Limit:   b.limit,
+		Offset:  b.offset,
+	}
+}
+
+// comparison builds a "column <op> value" expression with the column as a quoted
+// identifier and the value bound as a parameter.
+func comparison(column string, op ast.ComparisonOperator, value any) ast.Expression {
+	return &ast.Comparison{
+		Left:     &ast.ColumnRef{Name: column},
+		Operator: op,
+		Right:    &ast.BoundValue{Value: value},
+	}
+}
+
+// Eq builds "column = value".
+func Eq(column string, value any) ast.Expression {
+	return comparison(column, ast.OpEqual, value)
+}
+
+// Ne builds "column <> value".
+func Ne(column string, value any) ast.Expression {
+	return comparison(column, ast.OpNotEqual, value)
+}
+
+// Lt builds "column < value".
+func Lt(column string, value any) ast.Expression {
+	return comparison(column, ast.OpLessThan, value)
+}
+
+// Le builds "column <= value".
+func Le(column string, value any) ast.Expression {
+	return comparison(column, ast.OpLessThanOrEqual, value)
+}
+
+// Gt builds "column > value".
+func Gt(column string, value any) ast.Expression {
+	return comparison(column, ast.OpGreaterThan, value)
+}
+
+// Ge builds "column >= value".
+func Ge(column string, value any) ast.Expression {
+	return comparison(column, ast.OpGreaterThanOrEqual, value)
+}
+
+// In builds "column IN (values...)", binding each value as a parameter. The
+// values slice must be non-empty; rendering an empty IN returns an error. The
+// generic element type lets callers pass, for example, []string or []int64
+// without converting to []any.
+func In[T any](column string, values []T) ast.Expression {
+	bound := make([]ast.Expression, len(values))
+	for i, v := range values {
+		bound[i] = &ast.BoundValue{Value: v}
+	}
+	return &ast.InExpr{
+		Operand: &ast.ColumnRef{Name: column},
+		Values:  bound,
+	}
+}
+
+// IsNull builds "column IS NULL".
+func IsNull(column string) ast.Expression {
+	return &ast.NullTest{Operand: &ast.ColumnRef{Name: column}}
+}
+
+// IsNotNull builds "column IS NOT NULL".
+func IsNotNull(column string) ast.Expression {
+	return &ast.NullTest{Operand: &ast.ColumnRef{Name: column}, Negated: true}
+}
+
+// And combines expressions with AND. The renderer parenthesizes the result, so
+// it composes safely inside Or and Not.
+func And(exprs ...ast.Expression) ast.Expression {
+	return &ast.LogicalExpr{Operator: ast.LogicalAnd, Operands: exprs}
+}
+
+// Or combines expressions with OR. The renderer parenthesizes the result, so it
+// composes safely inside And and Not.
+func Or(exprs ...ast.Expression) ast.Expression {
+	return &ast.LogicalExpr{Operator: ast.LogicalOr, Operands: exprs}
+}
+
+// Not negates an expression, rendering as "NOT (expr)".
+func Not(expr ast.Expression) ast.Expression {
+	return &ast.NotExpr{Operand: expr}
+}
+
+// Asc builds an ascending ORDER BY term for column.
+func Asc(column string) ast.OrderByClause {
+	return ast.OrderByClause{Column: column, Direction: ast.SortAscending}
+}
+
+// Desc builds a descending ORDER BY term for column.
+func Desc(column string) ast.OrderByClause {
+	return ast.OrderByClause{Column: column, Direction: ast.SortDescending}
+}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -251,3 +251,46 @@ func TestSelectBuilder_SharedWhereFragment(t *testing.T) {
 	c.Assert(totalSQL, qt.Equals, `SELECT "id" FROM "commodities" WHERE ("draft" = $1 AND "tenant_id" = $2)`)
 	c.Assert(totalArgs, qt.DeepEquals, []any{false, "acme"})
 }
+
+func TestSelectBuilder_DegenerateExpressionsErrorCleanly(t *testing.T) {
+	c := qt.New(t)
+
+	// Degenerate constructor inputs must surface a clean RenderSelect error, not
+	// a panic, when the statement is rendered.
+	tests := []struct {
+		name        string
+		expr        ast.Expression
+		wantErrLike string
+	}{
+		{
+			name:        "empty in list",
+			expr:        query.In("status", []string{}),
+			wantErrLike: "renderer: IN requires at least one value",
+		},
+		{
+			name:        "and without operands",
+			expr:        query.And(),
+			wantErrLike: "renderer: logical expression requires at least one operand",
+		},
+		{
+			name:        "or without operands",
+			expr:        query.Or(),
+			wantErrLike: "renderer: logical expression requires at least one operand",
+		},
+		{
+			name:        "not without operand",
+			expr:        query.Not(nil),
+			wantErrLike: "renderer: NOT requires an operand",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := query.Select("*").From("t").Where(tt.expr).Build()
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -1,0 +1,253 @@
+package query_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/query"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+// renderWhere renders "SELECT * FROM t WHERE <expr>" for PostgreSQL and returns
+// the WHERE-clause behavior, so constructor tests can assert the observable SQL
+// contract rather than the internal node shape.
+func renderWhere(c *qt.C, expr ast.Expression) (string, []any) {
+	c.Helper()
+	sql, args, err := renderer.RenderSelect(&ast.SelectStatement{From: "t", Where: expr}, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	return sql, args
+}
+
+func TestExpressionConstructors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		expr     ast.Expression
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "eq",
+			expr:     query.Eq("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" = $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "ne",
+			expr:     query.Ne("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" <> $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "lt",
+			expr:     query.Lt("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" < $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "le",
+			expr:     query.Le("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" <= $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "gt",
+			expr:     query.Gt("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" > $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "ge",
+			expr:     query.Ge("a", 1),
+			wantSQL:  `SELECT * FROM "t" WHERE "a" >= $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "in string slice",
+			expr:     query.In("status", []string{"in_use", "sold"}),
+			wantSQL:  `SELECT * FROM "t" WHERE "status" IN ($1, $2)`,
+			wantArgs: []any{"in_use", "sold"},
+		},
+		{
+			name:     "in int64 slice",
+			expr:     query.In("id", []int64{1, 2, 3}),
+			wantSQL:  `SELECT * FROM "t" WHERE "id" IN ($1, $2, $3)`,
+			wantArgs: []any{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:     "is null",
+			expr:     query.IsNull("deleted_at"),
+			wantSQL:  `SELECT * FROM "t" WHERE "deleted_at" IS NULL`,
+			wantArgs: nil,
+		},
+		{
+			name:     "is not null",
+			expr:     query.IsNotNull("deleted_at"),
+			wantSQL:  `SELECT * FROM "t" WHERE "deleted_at" IS NOT NULL`,
+			wantArgs: nil,
+		},
+		{
+			name:     "and",
+			expr:     query.And(query.Eq("a", 1), query.Eq("b", 2)),
+			wantSQL:  `SELECT * FROM "t" WHERE ("a" = $1 AND "b" = $2)`,
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:     "or",
+			expr:     query.Or(query.Eq("a", 1), query.Eq("b", 2)),
+			wantSQL:  `SELECT * FROM "t" WHERE ("a" = $1 OR "b" = $2)`,
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:     "not",
+			expr:     query.Not(query.Eq("a", 1)),
+			wantSQL:  `SELECT * FROM "t" WHERE NOT ("a" = $1)`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "nested and or not",
+			expr:     query.And(query.Eq("a", 1), query.Or(query.Eq("b", 2), query.Not(query.Eq("c", 3)))),
+			wantSQL:  `SELECT * FROM "t" WHERE ("a" = $1 AND ("b" = $2 OR NOT ("c" = $3)))`,
+			wantArgs: []any{1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args := renderWhere(c, tt.expr)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, tt.wantArgs)
+		})
+	}
+}
+
+func TestSelectBuilder_Projection(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		stmt *ast.SelectStatement
+		want []ast.ResultColumn
+	}{
+		{
+			name: "named columns",
+			stmt: query.Select("id", "name").From("t").Build(),
+			want: []ast.ResultColumn{{Name: "id"}, {Name: "name"}},
+		},
+		{
+			name: "explicit star",
+			stmt: query.Select("*").From("t").Build(),
+			want: []ast.ResultColumn{{Star: true}},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.stmt.Columns, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestSelectBuilder_NoColumnsIsSelectStar(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select().From("t").Build()
+	c.Assert(stmt.Columns, qt.HasLen, 0)
+
+	sql, _, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT * FROM "t"`)
+}
+
+func TestSelectBuilder_LimitOffset(t *testing.T) {
+	c := qt.New(t)
+
+	unbounded := query.Select("*").From("t").Build()
+	c.Assert(unbounded.Limit, qt.IsNil)
+	c.Assert(unbounded.Offset, qt.IsNil)
+
+	bounded := query.Select("*").From("t").Limit(24).Offset(48).Build()
+	c.Assert(bounded.Limit, qt.IsNotNil)
+	c.Assert(*bounded.Limit, qt.Equals, int64(24))
+	c.Assert(bounded.Offset, qt.IsNotNil)
+	c.Assert(*bounded.Offset, qt.Equals, int64(48))
+}
+
+func TestSelectBuilder_OrderByAccumulates(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("*").
+		From("t").
+		OrderBy(query.Asc("name")).
+		OrderBy(query.Desc("id")).
+		Build()
+
+	c.Assert(stmt.OrderBy, qt.DeepEquals, []ast.OrderByClause{
+		{Column: "name", Direction: ast.SortAscending},
+		{Column: "id", Direction: ast.SortDescending},
+	})
+}
+
+func TestSelectBuilder_WhereReplaces(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("*").
+		From("t").
+		Where(query.Eq("a", 1)).
+		Where(query.Eq("b", 2)).
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT * FROM "t" WHERE "b" = $1`)
+	c.Assert(args, qt.DeepEquals, []any{2})
+}
+
+func TestSelectBuilder_FluentEndToEnd(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("id", "name").
+		From("commodities").
+		Where(query.And(
+			query.Eq("draft", false),
+			query.In("status", []string{"in_use", "sold"}),
+			query.Or(
+				query.IsNotNull("deleted_at"),
+				query.Not(query.Gt("count", int64(10))),
+			),
+		)).
+		OrderBy(query.Asc("name"), query.Asc("id")).
+		Limit(24).
+		Offset(0).
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "id", "name" FROM "commodities" WHERE ("draft" = $1 AND "status" IN ($2, $3) AND ("deleted_at" IS NOT NULL OR NOT ("count" > $4))) ORDER BY "name" ASC, "id" ASC LIMIT $5 OFFSET $6`)
+	c.Assert(args, qt.DeepEquals, []any{false, "in_use", "sold", int64(10), int64(24), int64(0)})
+}
+
+func TestSelectBuilder_SharedWhereFragment(t *testing.T) {
+	c := qt.New(t)
+
+	// A WHERE fragment can be built once and attached to multiple statements,
+	// which is the pattern a paged list shares with its COUNT(*).
+	filter := query.And(query.Eq("draft", false), query.Eq("tenant_id", "acme"))
+
+	page := query.Select("id").From("commodities").Where(filter).Limit(20).Build()
+	total := query.Select("id").From("commodities").Where(filter).Build()
+
+	pageSQL, pageArgs, err := renderer.RenderSelect(page, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(pageSQL, qt.Equals, `SELECT "id" FROM "commodities" WHERE ("draft" = $1 AND "tenant_id" = $2) LIMIT $3`)
+	c.Assert(pageArgs, qt.DeepEquals, []any{false, "acme", int64(20)})
+
+	totalSQL, totalArgs, err := renderer.RenderSelect(total, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(totalSQL, qt.Equals, `SELECT "id" FROM "commodities" WHERE ("draft" = $1 AND "tenant_id" = $2)`)
+	c.Assert(totalArgs, qt.DeepEquals, []any{false, "acme"})
+}

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -151,6 +151,9 @@ func (r *selectRenderer) renderExpr(expr ast.Expression) error {
 	case *ast.ColumnRef:
 		return r.renderColumnRef(e)
 	case *ast.BoundValue:
+		if e == nil {
+			return errors.New("renderer: nil bound value")
+		}
 		r.buf.WriteString(r.bind(e.Value))
 		return nil
 	case *ast.Comparison:
@@ -169,6 +172,9 @@ func (r *selectRenderer) renderExpr(expr ast.Expression) error {
 }
 
 func (r *selectRenderer) renderColumnRef(ref *ast.ColumnRef) error {
+	if ref == nil {
+		return errors.New("renderer: nil column reference")
+	}
 	if strings.TrimSpace(ref.Name) == "" {
 		return errors.New("renderer: column reference has an empty name")
 	}
@@ -177,6 +183,9 @@ func (r *selectRenderer) renderColumnRef(ref *ast.ColumnRef) error {
 }
 
 func (r *selectRenderer) renderComparison(cmp *ast.Comparison) error {
+	if cmp == nil {
+		return errors.New("renderer: nil comparison")
+	}
 	symbol := cmp.Operator.String()
 	if symbol == "" {
 		return fmt.Errorf("renderer: unknown comparison operator %d", cmp.Operator)
@@ -191,6 +200,9 @@ func (r *selectRenderer) renderComparison(cmp *ast.Comparison) error {
 }
 
 func (r *selectRenderer) renderIn(in *ast.InExpr) error {
+	if in == nil {
+		return errors.New("renderer: nil IN expression")
+	}
 	if len(in.Values) == 0 {
 		return errors.New("renderer: IN requires at least one value")
 	}
@@ -211,6 +223,9 @@ func (r *selectRenderer) renderIn(in *ast.InExpr) error {
 }
 
 func (r *selectRenderer) renderNullTest(test *ast.NullTest) error {
+	if test == nil {
+		return errors.New("renderer: nil null test")
+	}
 	if err := r.renderExpr(test.Operand); err != nil {
 		return err
 	}
@@ -223,6 +238,9 @@ func (r *selectRenderer) renderNullTest(test *ast.NullTest) error {
 }
 
 func (r *selectRenderer) renderLogical(logical *ast.LogicalExpr) error {
+	if logical == nil {
+		return errors.New("renderer: nil logical expression")
+	}
 	if len(logical.Operands) == 0 {
 		return errors.New("renderer: logical expression requires at least one operand")
 	}
@@ -246,6 +264,9 @@ func (r *selectRenderer) renderLogical(logical *ast.LogicalExpr) error {
 }
 
 func (r *selectRenderer) renderNot(not *ast.NotExpr) error {
+	if not == nil {
+		return errors.New("renderer: nil NOT expression")
+	}
 	if not.Operand == nil {
 		return errors.New("renderer: NOT requires an operand")
 	}
@@ -280,15 +301,50 @@ func (r *selectRenderer) renderOrderBy(terms []ast.OrderByClause) error {
 	return nil
 }
 
+// When a caller sets OFFSET but not LIMIT, MySQL, MariaDB, and SQLite reject a
+// bare OFFSET: it is only valid as a suffix of LIMIT. These sentinels express
+// "no upper bound" so the OFFSET can still be emitted. PostgreSQL accepts a bare
+// OFFSET and needs no sentinel.
+const (
+	// sqliteNoLimit is SQLite's documented "no limit" value.
+	sqliteNoLimit = "-1"
+	// mysqlNoLimit is the maximum BIGINT UNSIGNED, MySQL and MariaDB's documented
+	// idiom for "all rows from the offset onward".
+	mysqlNoLimit = "18446744073709551615"
+)
+
 // renderLimitOffset appends the LIMIT and OFFSET clauses, binding each present
 // bound as a parameter so it is numbered after the WHERE-clause placeholders.
+//
+// When OFFSET is set without LIMIT, a dialect that cannot express a bare OFFSET
+// gets a synthesized "no limit" sentinel in front of it. The sentinel is a
+// structural constant, not caller data, so it is emitted as a literal and does
+// not consume a placeholder; the OFFSET value remains bound.
 func (r *selectRenderer) renderLimitOffset(limit, offset *int64) {
 	if limit != nil {
 		r.buf.WriteString(" LIMIT ")
 		r.buf.WriteString(r.bind(*limit))
+	} else if offset != nil {
+		if sentinel, ok := r.offsetOnlyLimit(); ok {
+			r.buf.WriteString(" LIMIT ")
+			r.buf.WriteString(sentinel)
+		}
 	}
 	if offset != nil {
 		r.buf.WriteString(" OFFSET ")
 		r.buf.WriteString(r.bind(*offset))
+	}
+}
+
+// offsetOnlyLimit returns the sentinel LIMIT literal a dialect requires in front
+// of a bare OFFSET, and whether one is needed. The PostgreSQL family needs none.
+func (r *selectRenderer) offsetOnlyLimit() (string, bool) {
+	switch r.dialect {
+	case platform.SQLite:
+		return sqliteNoLimit, true
+	case platform.MySQL, platform.MariaDB:
+		return mysqlNoLimit, true
+	default:
+		return "", false
 	}
 }

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -1,0 +1,294 @@
+package renderer
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+// RenderSelect renders a SELECT statement to parameterized SQL for the given
+// dialect, returning the SQL text and its positional arguments.
+//
+// Every value in the statement — comparison operands, IN list elements, and the
+// LIMIT/OFFSET bounds — is emitted as a placeholder and returned in args, never
+// interpolated into the SQL. Placeholder style follows the dialect: $1, $2, …
+// for the PostgreSQL family and ? for MySQL, MariaDB, and SQLite. Placeholders
+// are numbered in a single left-to-right pass, so args are ordered to match.
+//
+// Identifiers (the table and column names) are quoted for the dialect via
+// internal/sqlident, so a value can never be rendered as an identifier and an
+// attacker-shaped identifier cannot break out of its quotes.
+//
+// Supported dialects are PostgreSQL (including CockroachDB and YugabyteDB),
+// MySQL, MariaDB, and SQLite. Any other dialect returns an error, as does a nil
+// statement, a statement without a FROM table, an empty IN list, or a malformed
+// operator.
+func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error) {
+	if stmt == nil {
+		return "", nil, errors.New("renderer: nil select statement")
+	}
+	r, err := newSelectRenderer(dialect)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := r.render(stmt); err != nil {
+		return "", nil, err
+	}
+	return r.buf.String(), r.args, nil
+}
+
+// placeholderStyle selects how bound parameters are numbered in the output.
+type placeholderStyle int
+
+const (
+	// placeholderDollar numbers parameters $1, $2, … (PostgreSQL family).
+	placeholderDollar placeholderStyle = iota
+	// placeholderQuestion emits ? for every parameter (MySQL, MariaDB, SQLite).
+	placeholderQuestion
+)
+
+// selectRenderer holds the mutable state for one RenderSelect call: the target
+// dialect, the placeholder style, the accumulated arguments, and the SQL buffer.
+type selectRenderer struct {
+	dialect     string
+	placeholder placeholderStyle
+	args        []any
+	buf         strings.Builder
+}
+
+func newSelectRenderer(dialect string) (*selectRenderer, error) {
+	normalized := platform.NormalizeDialect(dialect)
+	style, ok := selectPlaceholderStyle(normalized)
+	if !ok {
+		return nil, fmt.Errorf("renderer: SELECT rendering is not supported for dialect %q", dialect)
+	}
+	return &selectRenderer{dialect: normalized, placeholder: style}, nil
+}
+
+func selectPlaceholderStyle(normalized string) (placeholderStyle, bool) {
+	switch normalized {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		return placeholderDollar, true
+	case platform.MySQL, platform.MariaDB, platform.SQLite:
+		return placeholderQuestion, true
+	default:
+		return 0, false
+	}
+}
+
+// bind records value as a positional argument and returns its placeholder.
+func (r *selectRenderer) bind(value any) string {
+	r.args = append(r.args, value)
+	if r.placeholder == placeholderDollar {
+		return "$" + strconv.Itoa(len(r.args))
+	}
+	return "?"
+}
+
+// quote returns identifier quoted for the renderer's dialect.
+func (r *selectRenderer) quote(identifier string) string {
+	return sqlident.Quote(r.dialect, identifier)
+}
+
+func (r *selectRenderer) render(stmt *ast.SelectStatement) error {
+	if strings.TrimSpace(stmt.From) == "" {
+		return errors.New("renderer: select statement requires a FROM table")
+	}
+
+	r.buf.WriteString("SELECT ")
+	if err := r.renderColumns(stmt.Columns); err != nil {
+		return err
+	}
+
+	r.buf.WriteString(" FROM ")
+	r.buf.WriteString(r.quote(stmt.From))
+
+	if stmt.Where != nil {
+		r.buf.WriteString(" WHERE ")
+		if err := r.renderExpr(stmt.Where); err != nil {
+			return err
+		}
+	}
+
+	if err := r.renderOrderBy(stmt.OrderBy); err != nil {
+		return err
+	}
+
+	r.renderLimitOffset(stmt.Limit, stmt.Offset)
+	return nil
+}
+
+func (r *selectRenderer) renderColumns(columns []ast.ResultColumn) error {
+	if len(columns) == 0 {
+		r.buf.WriteString("*")
+		return nil
+	}
+	for i, col := range columns {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		if col.Star {
+			r.buf.WriteString("*")
+			continue
+		}
+		if strings.TrimSpace(col.Name) == "" {
+			return errors.New("renderer: result column has an empty name")
+		}
+		r.buf.WriteString(r.quote(col.Name))
+	}
+	return nil
+}
+
+// renderExpr dispatches over the sealed ast.Expression sum type. Each case
+// delegates to a small helper so the dispatch stays flat.
+func (r *selectRenderer) renderExpr(expr ast.Expression) error {
+	switch e := expr.(type) {
+	case *ast.ColumnRef:
+		return r.renderColumnRef(e)
+	case *ast.BoundValue:
+		r.buf.WriteString(r.bind(e.Value))
+		return nil
+	case *ast.Comparison:
+		return r.renderComparison(e)
+	case *ast.InExpr:
+		return r.renderIn(e)
+	case *ast.NullTest:
+		return r.renderNullTest(e)
+	case *ast.LogicalExpr:
+		return r.renderLogical(e)
+	case *ast.NotExpr:
+		return r.renderNot(e)
+	default:
+		return fmt.Errorf("renderer: unsupported expression type %T", expr)
+	}
+}
+
+func (r *selectRenderer) renderColumnRef(ref *ast.ColumnRef) error {
+	if strings.TrimSpace(ref.Name) == "" {
+		return errors.New("renderer: column reference has an empty name")
+	}
+	r.buf.WriteString(r.quote(ref.Name))
+	return nil
+}
+
+func (r *selectRenderer) renderComparison(cmp *ast.Comparison) error {
+	symbol := cmp.Operator.String()
+	if symbol == "" {
+		return fmt.Errorf("renderer: unknown comparison operator %d", cmp.Operator)
+	}
+	if err := r.renderExpr(cmp.Left); err != nil {
+		return err
+	}
+	r.buf.WriteString(" ")
+	r.buf.WriteString(symbol)
+	r.buf.WriteString(" ")
+	return r.renderExpr(cmp.Right)
+}
+
+func (r *selectRenderer) renderIn(in *ast.InExpr) error {
+	if len(in.Values) == 0 {
+		return errors.New("renderer: IN requires at least one value")
+	}
+	if err := r.renderExpr(in.Operand); err != nil {
+		return err
+	}
+	r.buf.WriteString(" IN (")
+	for i, value := range in.Values {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		if err := r.renderExpr(value); err != nil {
+			return err
+		}
+	}
+	r.buf.WriteString(")")
+	return nil
+}
+
+func (r *selectRenderer) renderNullTest(test *ast.NullTest) error {
+	if err := r.renderExpr(test.Operand); err != nil {
+		return err
+	}
+	if test.Negated {
+		r.buf.WriteString(" IS NOT NULL")
+		return nil
+	}
+	r.buf.WriteString(" IS NULL")
+	return nil
+}
+
+func (r *selectRenderer) renderLogical(logical *ast.LogicalExpr) error {
+	if len(logical.Operands) == 0 {
+		return errors.New("renderer: logical expression requires at least one operand")
+	}
+	keyword := logical.Operator.String()
+	if keyword == "" {
+		return fmt.Errorf("renderer: unknown logical operator %d", logical.Operator)
+	}
+	r.buf.WriteString("(")
+	for i, operand := range logical.Operands {
+		if i > 0 {
+			r.buf.WriteString(" ")
+			r.buf.WriteString(keyword)
+			r.buf.WriteString(" ")
+		}
+		if err := r.renderExpr(operand); err != nil {
+			return err
+		}
+	}
+	r.buf.WriteString(")")
+	return nil
+}
+
+func (r *selectRenderer) renderNot(not *ast.NotExpr) error {
+	if not.Operand == nil {
+		return errors.New("renderer: NOT requires an operand")
+	}
+	r.buf.WriteString("NOT (")
+	if err := r.renderExpr(not.Operand); err != nil {
+		return err
+	}
+	r.buf.WriteString(")")
+	return nil
+}
+
+func (r *selectRenderer) renderOrderBy(terms []ast.OrderByClause) error {
+	if len(terms) == 0 {
+		return nil
+	}
+	r.buf.WriteString(" ORDER BY ")
+	for i, term := range terms {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		if strings.TrimSpace(term.Column) == "" {
+			return errors.New("renderer: ORDER BY term has an empty column")
+		}
+		direction := term.Direction.String()
+		if direction == "" {
+			return fmt.Errorf("renderer: unknown sort direction %d", term.Direction)
+		}
+		r.buf.WriteString(r.quote(term.Column))
+		r.buf.WriteString(" ")
+		r.buf.WriteString(direction)
+	}
+	return nil
+}
+
+// renderLimitOffset appends the LIMIT and OFFSET clauses, binding each present
+// bound as a parameter so it is numbered after the WHERE-clause placeholders.
+func (r *selectRenderer) renderLimitOffset(limit, offset *int64) {
+	if limit != nil {
+		r.buf.WriteString(" LIMIT ")
+		r.buf.WriteString(r.bind(*limit))
+	}
+	if offset != nil {
+		r.buf.WriteString(" OFFSET ")
+		r.buf.WriteString(r.bind(*offset))
+	}
+}

--- a/core/renderer/select_test.go
+++ b/core/renderer/select_test.go
@@ -185,6 +185,80 @@ func TestRenderSelect_LimitOffsetPlaceholderOrdering(t *testing.T) {
 	c.Assert(args, qt.DeepEquals, []any{int64(5), int64(10)})
 }
 
+func TestRenderSelect_OffsetWithoutLimit(t *testing.T) {
+	c := qt.New(t)
+
+	// A bare OFFSET is valid on PostgreSQL, but MySQL/MariaDB/SQLite only accept
+	// OFFSET as a suffix of LIMIT, so a "no limit" sentinel is synthesized. The
+	// OFFSET stays bound; the sentinel is a literal and takes no placeholder.
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{name: "postgres emits bare offset", dialect: platform.Postgres, wantSQL: `SELECT * FROM "t" OFFSET $1`},
+		{name: "mysql synthesizes max-bigint limit", dialect: platform.MySQL, wantSQL: "SELECT * FROM `t` LIMIT 18446744073709551615 OFFSET ?"},
+		{name: "mariadb synthesizes max-bigint limit", dialect: platform.MariaDB, wantSQL: "SELECT * FROM `t` LIMIT 18446744073709551615 OFFSET ?"},
+		{name: "sqlite synthesizes negative-one limit", dialect: platform.SQLite, wantSQL: `SELECT * FROM "t" LIMIT -1 OFFSET ?`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			offset := int64(10)
+			stmt := &ast.SelectStatement{From: "t", Offset: &offset}
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{int64(10)})
+		})
+	}
+}
+
+func TestRenderSelect_IdentifierQuotingAcrossClauses(t *testing.T) {
+	c := qt.New(t)
+
+	// The projection, WHERE, and ORDER BY identifiers all route through the same
+	// dialect quoting, so a quote-bearing name is escaped in every clause.
+	tests := []struct {
+		name    string
+		stmt    *ast.SelectStatement
+		wantSQL string
+	}{
+		{
+			name: "projection column is escaped",
+			stmt: &ast.SelectStatement{
+				Columns: []ast.ResultColumn{{Name: `weird" col`}},
+				From:    "t",
+			},
+			wantSQL: `SELECT "weird"" col" FROM "t"`,
+		},
+		{
+			name: "order by column is escaped",
+			stmt: &ast.SelectStatement{
+				From:    "t",
+				OrderBy: []ast.OrderByClause{{Column: `weird" col`, Direction: ast.SortDescending}},
+			},
+			wantSQL: `SELECT * FROM "t" ORDER BY "weird"" col" DESC`,
+		},
+		{
+			name: "from table is escaped",
+			stmt: &ast.SelectStatement{
+				From: `weird" table`,
+			},
+			wantSQL: `SELECT * FROM "weird"" table"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(tt.stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
 func TestRenderSelect_NullTests(t *testing.T) {
 	c := qt.New(t)
 
@@ -330,6 +404,26 @@ func TestRenderSelect_Errors(t *testing.T) {
 			}},
 			dialect:     platform.Postgres,
 			wantErrLike: "renderer: unknown sort direction 99",
+		},
+		{
+			name: "typed-nil column reference leaf does not panic",
+			stmt: &ast.SelectStatement{From: "t", Where: &ast.Comparison{
+				Left:     (*ast.ColumnRef)(nil),
+				Operator: ast.OpEqual,
+				Right:    &ast.BoundValue{Value: 1},
+			}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil column reference",
+		},
+		{
+			name: "typed-nil bound value leaf does not panic",
+			stmt: &ast.SelectStatement{From: "t", Where: &ast.Comparison{
+				Left:     &ast.ColumnRef{Name: "a"},
+				Operator: ast.OpEqual,
+				Right:    (*ast.BoundValue)(nil),
+			}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil bound value",
 		},
 	}
 

--- a/core/renderer/select_test.go
+++ b/core/renderer/select_test.go
@@ -1,0 +1,344 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+// representativeSelect exercises columns, WHERE with AND/OR/NOT/IN/comparison/
+// IS NOT NULL, ORDER BY with a tie-breaker, and LIMIT/OFFSET in a single tree.
+func representativeSelect() *ast.SelectStatement {
+	limit := int64(24)
+	offset := int64(0)
+	return &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Name: "id"}, {Name: "name"}},
+		From:    "commodities",
+		Where: &ast.LogicalExpr{
+			Operator: ast.LogicalAnd,
+			Operands: []ast.Expression{
+				&ast.Comparison{
+					Left:     &ast.ColumnRef{Name: "draft"},
+					Operator: ast.OpEqual,
+					Right:    &ast.BoundValue{Value: false},
+				},
+				&ast.InExpr{
+					Operand: &ast.ColumnRef{Name: "status"},
+					Values: []ast.Expression{
+						&ast.BoundValue{Value: "in_use"},
+						&ast.BoundValue{Value: "sold"},
+					},
+				},
+				&ast.LogicalExpr{
+					Operator: ast.LogicalOr,
+					Operands: []ast.Expression{
+						&ast.NullTest{Operand: &ast.ColumnRef{Name: "deleted_at"}, Negated: true},
+						&ast.NotExpr{Operand: &ast.Comparison{
+							Left:     &ast.ColumnRef{Name: "count"},
+							Operator: ast.OpGreaterThan,
+							Right:    &ast.BoundValue{Value: int64(10)},
+						}},
+					},
+				},
+			},
+		},
+		OrderBy: []ast.OrderByClause{
+			{Column: "name", Direction: ast.SortAscending},
+			{Column: "id", Direction: ast.SortDescending},
+		},
+		Limit:  &limit,
+		Offset: &offset,
+	}
+}
+
+func TestRenderSelect_Representative(t *testing.T) {
+	c := qt.New(t)
+
+	wantArgs := []any{false, "in_use", "sold", int64(10), int64(24), int64(0)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres uses dollar placeholders and double quotes",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "id", "name" FROM "commodities" WHERE ("draft" = $1 AND "status" IN ($2, $3) AND ("deleted_at" IS NOT NULL OR NOT ("count" > $4))) ORDER BY "name" ASC, "id" DESC LIMIT $5 OFFSET $6`,
+		},
+		{
+			name:    "mysql uses question placeholders and backticks",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `id`, `name` FROM `commodities` WHERE (`draft` = ? AND `status` IN (?, ?) AND (`deleted_at` IS NOT NULL OR NOT (`count` > ?))) ORDER BY `name` ASC, `id` DESC LIMIT ? OFFSET ?",
+		},
+		{
+			name:    "mariadb matches mysql",
+			dialect: platform.MariaDB,
+			wantSQL: "SELECT `id`, `name` FROM `commodities` WHERE (`draft` = ? AND `status` IN (?, ?) AND (`deleted_at` IS NOT NULL OR NOT (`count` > ?))) ORDER BY `name` ASC, `id` DESC LIMIT ? OFFSET ?",
+		},
+		{
+			name:    "sqlite uses question placeholders and double quotes",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT "id", "name" FROM "commodities" WHERE ("draft" = ? AND "status" IN (?, ?) AND ("deleted_at" IS NOT NULL OR NOT ("count" > ?))) ORDER BY "name" ASC, "id" DESC LIMIT ? OFFSET ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(representativeSelect(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderSelect_DialectAliasesNormalize(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Star: true}},
+		From:    "users",
+		Where: &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "id"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: int64(7)},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{name: "postgresql alias", dialect: "postgresql", wantSQL: `SELECT * FROM "users" WHERE "id" = $1`},
+		{name: "pgx alias", dialect: "pgx", wantSQL: `SELECT * FROM "users" WHERE "id" = $1`},
+		{name: "cockroachdb dollar placeholders", dialect: platform.CockroachDB, wantSQL: `SELECT * FROM "users" WHERE "id" = $1`},
+		{name: "sqlite3 alias", dialect: "sqlite3", wantSQL: `SELECT * FROM "users" WHERE "id" = ?`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{int64(7)})
+		})
+	}
+}
+
+func TestRenderSelect_ProjectionVariants(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		stmt    *ast.SelectStatement
+		wantSQL string
+	}{
+		{
+			name:    "no columns renders star",
+			stmt:    &ast.SelectStatement{From: "t"},
+			wantSQL: `SELECT * FROM "t"`,
+		},
+		{
+			name:    "explicit star",
+			stmt:    &ast.SelectStatement{Columns: []ast.ResultColumn{{Star: true}}, From: "t"},
+			wantSQL: `SELECT * FROM "t"`,
+		},
+		{
+			name:    "named columns are quoted",
+			stmt:    &ast.SelectStatement{Columns: []ast.ResultColumn{{Name: "a"}, {Name: "b"}}, From: "t"},
+			wantSQL: `SELECT "a", "b" FROM "t"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(tt.stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_LimitOffsetPlaceholderOrdering(t *testing.T) {
+	c := qt.New(t)
+
+	// With no WHERE clause, the LIMIT/OFFSET bounds take the first placeholders,
+	// proving the bounds are numbered by emission order, not treated specially.
+	limit := int64(5)
+	offset := int64(10)
+	stmt := &ast.SelectStatement{
+		From:   "t",
+		Limit:  &limit,
+		Offset: &offset,
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT * FROM "t" LIMIT $1 OFFSET $2`)
+	c.Assert(args, qt.DeepEquals, []any{int64(5), int64(10)})
+}
+
+func TestRenderSelect_NullTests(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		negated bool
+		wantSQL string
+	}{
+		{name: "is null", negated: false, wantSQL: `SELECT * FROM "t" WHERE "deleted_at" IS NULL`},
+		{name: "is not null", negated: true, wantSQL: `SELECT * FROM "t" WHERE "deleted_at" IS NOT NULL`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From:  "t",
+				Where: &ast.NullTest{Operand: &ast.ColumnRef{Name: "deleted_at"}, Negated: tt.negated},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_ValueNeverBecomesSQL(t *testing.T) {
+	c := qt.New(t)
+
+	payload := "x'; DROP TABLE users; --"
+	stmt := &ast.SelectStatement{
+		From: "users",
+		Where: &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "name"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: payload},
+		},
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	// The injection payload appears only as a bound argument, never in the SQL.
+	c.Assert(sql, qt.Equals, `SELECT * FROM "users" WHERE "name" = $1`)
+	c.Assert(sql, qt.Not(qt.Contains), "DROP TABLE")
+	c.Assert(args, qt.DeepEquals, []any{payload})
+}
+
+func TestRenderSelect_IdentifierQuotingNeutralizesInjection(t *testing.T) {
+	c := qt.New(t)
+
+	// An attacker-shaped identifier cannot terminate the quoted identifier: the
+	// dialect quote character is doubled per the SQL standard.
+	tests := []struct {
+		name    string
+		dialect string
+		column  string
+		wantSQL string
+	}{
+		{
+			name:    "postgres doubles embedded double quote",
+			dialect: platform.Postgres,
+			column:  `name" FROM secrets; --`,
+			wantSQL: `SELECT * FROM "t" WHERE "name"" FROM secrets; --" = $1`,
+		},
+		{
+			name:    "mysql doubles embedded backtick",
+			dialect: platform.MySQL,
+			column:  "name` FROM secrets; --",
+			wantSQL: "SELECT * FROM `t` WHERE `name`` FROM secrets; --` = ?",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From: "t",
+				Where: &ast.Comparison{
+					Left:     &ast.ColumnRef{Name: tt.column},
+					Operator: ast.OpEqual,
+					Right:    &ast.BoundValue{Value: 1},
+				},
+			}
+			sql, _, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+		})
+	}
+}
+
+func TestRenderSelect_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		stmt        *ast.SelectStatement
+		dialect     string
+		wantErrLike string
+	}{
+		{
+			name:        "nil statement",
+			stmt:        nil,
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil select statement",
+		},
+		{
+			name:        "unsupported dialect",
+			stmt:        &ast.SelectStatement{From: "t"},
+			dialect:     platform.ClickHouse,
+			wantErrLike: `renderer: SELECT rendering is not supported for dialect "clickhouse"`,
+		},
+		{
+			name:        "missing from",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Name: "a"}}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: select statement requires a FROM table",
+		},
+		{
+			name:        "empty in list",
+			stmt:        &ast.SelectStatement{From: "t", Where: &ast.InExpr{Operand: &ast.ColumnRef{Name: "a"}}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: IN requires at least one value",
+		},
+		{
+			name:        "empty column name",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Name: "  "}}, From: "t"},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: result column has an empty name",
+		},
+		{
+			name: "unknown comparison operator",
+			stmt: &ast.SelectStatement{From: "t", Where: &ast.Comparison{
+				Left:     &ast.ColumnRef{Name: "a"},
+				Operator: ast.ComparisonOperator(99),
+				Right:    &ast.BoundValue{Value: 1},
+			}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: unknown comparison operator 99",
+		},
+		{
+			name: "unknown sort direction",
+			stmt: &ast.SelectStatement{From: "t", OrderBy: []ast.OrderByClause{
+				{Column: "a", Direction: ast.SortDirection(99)},
+			}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: unknown sort direction 99",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(tt.stmt, tt.dialect)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -19,6 +19,7 @@ These packages are intended for application and tool embedders:
 - `github.com/stokaro/ptah/core/platform`
 - `github.com/stokaro/ptah/core/platform/capability`
 - `github.com/stokaro/ptah/core/ptaherr`
+- `github.com/stokaro/ptah/core/query`
 - `github.com/stokaro/ptah/core/renderer`
 - `github.com/stokaro/ptah/core/sqlutil`
 - `github.com/stokaro/ptah/dbschema`

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -77,10 +77,15 @@ type AlterTableEnableRLSNode struct{ ... }
 type AlterTableNode struct{ ... }
 type AlterTypeNode struct{ ... }
     func NewAlterType(name string) *AlterTypeNode
+type BoundValue struct{ ... }
 type ColumnNode struct{ ... }
     func NewColumn(name, dataType string) *ColumnNode
+type ColumnRef struct{ ... }
 type CommentNode struct{ ... }
     func NewComment(text string) *CommentNode
+type Comparison struct{ ... }
+type ComparisonOperator int
+    const OpEqual ComparisonOperator = iota ...
 type CompositeField struct{ ... }
 type CompositeTypeDef struct{ ... }
     func NewCompositeTypeDef(fields ...*CompositeField) *CompositeTypeDef
@@ -145,6 +150,7 @@ type EnumNode struct{ ... }
     func NewEnum(name string, values ...string) *EnumNode
 type EnumTypeDef struct{ ... }
     func NewEnumTypeDef(values ...string) *EnumTypeDef
+type Expression interface{ ... }
 type ExtensionNode struct{ ... }
     func NewExtension(name string) *ExtensionNode
 type ForeignKeyRef struct{ ... }
@@ -152,9 +158,13 @@ type FunctionBodyKind string
     const FunctionBodyQuoted FunctionBodyKind = "quoted" ...
 type GrantPrivilegeNode struct{ ... }
     func NewGrantPrivilege(role, objectType, objectName string, privileges []string) *GrantPrivilegeNode
+type InExpr struct{ ... }
 type IndexNode struct{ ... }
     func NewIndex(name, table string, columns ...string) *IndexNode
 type IndexPart struct{ ... }
+type LogicalExpr struct{ ... }
+type LogicalOperator int
+    const LogicalAnd LogicalOperator = iota ...
 type ModifyColumnOperation struct{ ... }
 type ModifyTTLOperation struct{ ... }
 type MySQLRoutineBody struct{ ... }
@@ -169,8 +179,11 @@ type MySQLRoutineStatement struct{ ... }
 type MySQLRoutineStatementKind string
     const MySQLRoutineStatementRaw MySQLRoutineStatementKind = "raw" ...
 type Node interface{ ... }
+type NotExpr struct{ ... }
+type NullTest struct{ ... }
 type OpaqueRoutineNode struct{ ... }
     func NewOpaqueRoutine(sql, dialect string, kind RoutineKind) *OpaqueRoutineNode
+type OrderByClause struct{ ... }
 type PartitionPart struct{ ... }
 type PartitionSpec struct{ ... }
 type PostgresDoBlockNode struct{ ... }
@@ -193,6 +206,7 @@ type RenameEnumValueOperation struct{ ... }
 type RenameTableOperation struct{ ... }
 type RenameTypeOperation struct{ ... }
     func NewRenameTypeOperation(newName string) *RenameTypeOperation
+type ResultColumn struct{ ... }
 type RevokePrivilegeNode struct{ ... }
     func NewRevokePrivilege(role, objectType, objectName string, privileges []string) *RevokePrivilegeNode
 type RoleOperation interface{ ... }
@@ -206,6 +220,7 @@ type SQLServerRoutineNode struct{ ... }
 type SQLServerRoutineStatement struct{ ... }
 type SQLServerRoutineStatementKind string
     const SQLServerRoutineStatementRaw SQLServerRoutineStatementKind = "raw" ...
+type SelectStatement struct{ ... }
 type SetCreateDBOperation struct{ ... }
     func NewSetCreateDBOperation(createDB bool) *SetCreateDBOperation
 type SetCreateRoleOperation struct{ ... }
@@ -220,6 +235,8 @@ type SetReplicationOperation struct{ ... }
     func NewSetReplicationOperation(replication bool) *SetReplicationOperation
 type SetSuperuserOperation struct{ ... }
     func NewSetSuperuserOperation(superuser bool) *SetSuperuserOperation
+type SortDirection int
+    const SortAscending SortDirection = iota ...
 type StatementList struct{ ... }
 type TypeDefinition interface{ ... }
 type TypeOperation interface{ ... }
@@ -242,6 +259,23 @@ type AlterOperation interface {
     This interface extends the Node interface and includes a marker method to
     ensure type safety. All ALTER operations must implement both the visitor
     pattern and the marker method.
+
+
+### github.com/stokaro/ptah/core/ast.Expression
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type Expression interface {
+    // Has unexported methods.
+}
+    Expression is a boolean or scalar expression used in DML statements such as
+    the WHERE clause of a SELECT.
+
+    Expression is a sealed sum type: only the node types declared in this
+    package implement it. Sealing serves the query builder's core safety
+    property — a caller cannot smuggle a raw SQL string in as an expression,
+    and every value reaches the SQL through a BoundValue node (a placeholder),
+    never inlined.
 
 
 ### github.com/stokaro/ptah/core/ast.Node
@@ -489,12 +523,32 @@ type ParseError struct{ ... }
 type PlanError struct{ ... }
 type RenderError struct{ ... }
 
+## github.com/stokaro/ptah/core/query
+
+func And(exprs ...ast.Expression) ast.Expression
+func Asc(column string) ast.OrderByClause
+func Desc(column string) ast.OrderByClause
+func Eq(column string, value any) ast.Expression
+func Ge(column string, value any) ast.Expression
+func Gt(column string, value any) ast.Expression
+func In[T any](column string, values []T) ast.Expression
+func IsNotNull(column string) ast.Expression
+func IsNull(column string) ast.Expression
+func Le(column string, value any) ast.Expression
+func Lt(column string, value any) ast.Expression
+func Ne(column string, value any) ast.Expression
+func Not(expr ast.Expression) ast.Expression
+func Or(exprs ...ast.Expression) ast.Expression
+type SelectBuilder struct{ ... }
+    func Select(columns ...string) *SelectBuilder
+
 ## github.com/stokaro/ptah/core/renderer
 
 func GetOrderedCreateStatements(r *goschema.Database, dialect string) ([]string, error)
 func GetOrderedCreateStatementsWithCapabilities(r *goschema.Database, dialect string, caps capability.Capabilities) ([]string, error)
 func RenderSQL(dialect string, nodes ...ast.Node) (string, error)
 func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nodes ...ast.Node) (string, error)
+func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error)
 func SupportedDialects() []string
 func VisitorRenderSQL(r RenderVisitor, nodes ...ast.Node) (string, error)
 type RenderVisitor interface{ ... }

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -67,6 +67,7 @@ export default defineConfig({
             { slug: 'reference/atlas-project-config' },
             { slug: 'reference/public-api' },
             { slug: 'reference/reusable-components' },
+            { slug: 'reference/query-builder' },
             { slug: 'reference/capabilities' },
             { slug: 'reference/dialect-notes' },
             { slug: 'reference/comparison' },

--- a/docs/site/src/content/docs/reference/public-api.md
+++ b/docs/site/src/content/docs/reference/public-api.md
@@ -19,6 +19,7 @@ packages, examples, fixtures, tests, or implementation details.
 | `core/platform` | Dialect and platform constants. |
 | `core/platform/capability` | Capability flags for dialect/version behavior. |
 | `core/ptaherr` | Typed public errors and sentinel errors. |
+| `core/query` | Fluent builder for parameterized, dialect-aware SELECT statements. |
 | `core/renderer` | Dialect-aware SQL rendering from AST/schema IR. |
 | `core/sqlutil` | SQL utility helpers used by public paths. |
 | `dbschema` | Live database schema introspection connection layer. |

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -126,3 +126,12 @@ Expression helpers: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `In`, `IsNull`,
 `renderer.RenderSelect(stmt, dialect)` returns `(sql string, args []any, err error)`.
 It returns an error for an unsupported dialect, a missing `FROM` table, an empty
 `IN` list, or a malformed statement.
+
+### OFFSET without LIMIT
+
+MySQL, MariaDB, and SQLite only accept `OFFSET` as a suffix of `LIMIT`, so
+setting `Offset` without `Limit` renders a dialect-specific "no limit" sentinel
+in front of the bound `OFFSET`: `LIMIT -1` for SQLite and
+`LIMIT 18446744073709551615` for MySQL and MariaDB. PostgreSQL accepts a bare
+`OFFSET` and emits one. The sentinel is a structural constant, not caller data,
+so it is emitted as a literal and the `OFFSET` value stays a bound parameter.

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -1,0 +1,128 @@
+---
+title: Query Builder
+description: Build parameterized, dialect-aware SELECT statements with the core/query package.
+---
+
+Ptah's `core/query` package is a fluent builder for parameterized `SELECT`
+statements. It is the DML counterpart to the DDL AST: a builder produces an
+`*ast.SelectStatement`, and `renderer.RenderSelect` turns that into a SQL string
+plus its positional arguments for PostgreSQL, MySQL, MariaDB, and SQLite.
+
+This is the first, bounded slice of the DML work in issue
+[`#98`](https://github.com/stokaro/ptah/issues/98). It exists so callers can stop
+hand-rolling dynamic `WHERE` / `ORDER BY` / `IN (…)` clauses with manual
+placeholder counters.
+
+## Scope
+
+Implemented in this phase:
+
+- single-table `SELECT` with an explicit column list or `*`;
+- a composable `WHERE` expression tree: `=`, `<>`, `<`, `<=`, `>`, `>=`, `IN`,
+  `IS NULL`, `IS NOT NULL`, and the boolean combinators `AND`, `OR`, `NOT`;
+- `ORDER BY` with per-column `ASC`/`DESC`;
+- `LIMIT` and `OFFSET`.
+
+Not yet implemented (follow-up phases): `JOIN`, `GROUP BY`, `HAVING`, `DISTINCT`,
+subqueries, function calls, arithmetic, `LIKE`, and the `INSERT`/`UPDATE`/
+`DELETE` family.
+
+## Safety model
+
+The builder keeps identifiers and values in separate lanes, so the classic
+"concatenate a value into SQL" injection cannot happen through this API:
+
+- **Values are always bound.** Arguments to `Eq`, `In`, and the other
+  comparison helpers are typed as `any` and travel to the database as bound
+  parameters. They are never interpolated into the SQL text. `LIMIT` and
+  `OFFSET` values are bound the same way. The renderer emits the dialect's
+  placeholder (`$1`, `$2`, … for PostgreSQL; `?` for MySQL, MariaDB, and SQLite)
+  and returns the values in a matching `[]any`.
+- **Identifiers are always quoted.** Table and column names are emitted through
+  dialect-aware identifier quoting, so an attacker-shaped identifier cannot
+  terminate the quoted identifier and inject SQL. As with Ptah's DDL rendering,
+  deciding *which* identifiers a caller may supply — for example, an allow-list
+  of sortable columns — remains the caller's responsibility. The builder
+  guarantees quoting and the absence of value interpolation.
+
+Placeholder numbering is assigned by the renderer in a single left-to-right
+pass, so argument order always matches placeholder order and callers never
+manage indices by hand.
+
+## Usage
+
+```go
+import (
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/query"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+stmt := query.Select("id", "name").
+	From("commodities").
+	Where(query.And(
+		query.Eq("draft", false),
+		query.In("status", []string{"in_use", "sold"}),
+		query.Or(
+			query.IsNotNull("deleted_at"),
+			query.Not(query.Gt("count", int64(10))),
+		),
+	)).
+	OrderBy(query.Asc("name"), query.Asc("id")).
+	Limit(24).
+	Offset(0).
+	Build()
+
+sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+```
+
+The PostgreSQL output is:
+
+```sql
+SELECT "id", "name" FROM "commodities"
+WHERE ("draft" = $1 AND "status" IN ($2, $3)
+       AND ("deleted_at" IS NOT NULL OR NOT ("count" > $4)))
+ORDER BY "name" ASC, "id" ASC
+LIMIT $5 OFFSET $6
+```
+
+with `args` equal to `[]any{false, "in_use", "sold", int64(10), int64(24), int64(0)}`.
+
+The same statement rendered with `platform.MySQL` uses backtick-quoted
+identifiers and `?` placeholders; `platform.SQLite` uses double-quoted
+identifiers and `?` placeholders. The argument slice is identical across
+dialects.
+
+## Shared WHERE fragments
+
+Expression constructors return plain expression nodes, so a filter can be built
+once and attached to more than one statement — for example, the paged list and
+the `COUNT(*)` that share the same filter:
+
+```go
+filter := query.And(query.Eq("draft", false), query.Eq("tenant_id", tenantID))
+
+page := query.Select("id", "name").From("commodities").
+	Where(filter).OrderBy(query.Asc("name")).Limit(20).Offset(0).Build()
+
+total := query.Select("id").From("commodities").
+	Where(filter).Build()
+```
+
+## Builder reference
+
+| Function | Result |
+| --- | --- |
+| `Select(cols ...string)` | Start a builder; `"*"` or no columns selects all. |
+| `.From(table)` | Set the single source table (required). |
+| `.Where(expr)` | Set the filter expression; a later call replaces the earlier one. |
+| `.OrderBy(terms ...)` | Append sort terms across calls. |
+| `.Limit(n)` / `.Offset(n)` | Set bound row limit/offset. |
+| `.Build()` | Produce the `*ast.SelectStatement`. |
+
+Expression helpers: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `In`, `IsNull`,
+`IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`.
+
+`renderer.RenderSelect(stmt, dialect)` returns `(sql string, args []any, err error)`.
+It returns an error for an unsupported dialect, a missing `FROM` table, an empty
+`IN` list, or a malformed statement.

--- a/docs/site/src/content/docs/reference/reusable-components.md
+++ b/docs/site/src/content/docs/reference/reusable-components.md
@@ -27,6 +27,7 @@ uses them internally.
 | Need | Stable package(s) | What it gives you |
 | --- | --- | --- |
 | Build SQL DDL programmatically | `core/ast`, `core/renderer` | Dialect-aware SQL from structured AST nodes. |
+| Build parameterized SELECT queries | `core/query`, `core/renderer` | Fluent, dialect-aware SELECT/WHERE/ORDER BY/LIMIT with bound parameters. See [Query Builder](../query-builder/). |
 | Parse Go schema annotations | `core/goschema` | Go source comments to Ptah's schema IR. |
 | Parse Atlas HCL schema files | `atlascompat` | Atlas-style HCL schema files to Ptah's schema IR through a stable compatibility wrapper. |
 | Parse YAML schema files | Native CLI and schema-file workflows | YAML schema parsing is currently an implementation detail, not a stable public package. Use the CLI or create a follow-up API proposal before embedding it. |
@@ -67,9 +68,15 @@ The AST is mature for DDL objects that Ptah currently renders and plans: tables,
 columns, constraints, indexes, enums, extensions, views, materialized views,
 triggers, row-level security policies, roles, grants, and routine placeholders
 where supported. It is not a full SQL parser for every dialect-specific
-sub-language. It is also not a DML query builder; SELECT/WHERE/JOIN style query
-builder work belongs to issue
-[`#98`](https://github.com/stokaro/ptah/issues/98) or follow-up design.
+sub-language.
+
+DML query building has a first, bounded slice: `core/query` builds
+parameterized single-table `SELECT` statements with a composable `WHERE`
+expression tree, `ORDER BY`, and `LIMIT`/`OFFSET`, rendered through
+`renderer.RenderSelect`. `JOIN`, `GROUP BY`, `HAVING`, subqueries, and the
+`INSERT`/`UPDATE`/`DELETE` family are follow-up phases of issue
+[`#98`](https://github.com/stokaro/ptah/issues/98). See the
+[Query Builder](../query-builder/) reference for the full API.
 
 This complete example uses only public packages. The same AST/rendering path is
 validated by


### PR DESCRIPTION
## Summary

Phase 1 of #98: a parameterized, dialect-aware `SELECT` builder. It is a clean, bounded slice that unblocks the downstream consumer's migration away from hand-rolled `fmt.Sprintf("$%d", idx)` `WHERE`/`ORDER BY`/`IN (…)` clauses. The builder mirrors Ptah's existing DDL split (typed AST in `core/ast`, a fluent builder, a dialect-aware renderer) and reuses `internal/sqlident` for identifier quoting and `core/platform` for dialect normalization.

Nothing on the DDL path changes.

## API design

Three pieces, one per existing convention:

- **AST — `core/ast/select.go`** (extends the already-public `core/ast`):
  - `SelectStatement{Columns, From, Where, OrderBy, Limit, Offset}` — single source table; `Limit`/`Offset` are `*int64` so "no limit" is distinct from `LIMIT 0`.
  - `Expression` — a **sealed** sum type (unexported marker method) with `ColumnRef`, `BoundValue`, `Comparison`, `InExpr`, `NullTest`, `LogicalExpr` (n-ary AND/OR), and `NotExpr`. Sealing is what stops a caller from smuggling a raw SQL string in as an expression.
  - `Comparison` takes an `Expression` on both sides (not a bare column string), so column-to-column comparisons and function operands slot in later without a breaking change.
  - `OrderByClause`, `ResultColumn`, and `String()` helpers on the operator/direction enums.
  - These nodes intentionally **do not** join the DDL `Visitor` — DML rendering must also return bound args, which the string-only DDL visitor cannot carry. Keeping them separate is what lets Phase 1 avoid touching all seven DDL dialect renderers.

- **Builder — new public package `core/query`**: fluent `Select(cols...).From(table).Where(expr).OrderBy(...).Limit(n).Offset(m).Build()` returning `*ast.SelectStatement`, plus free-function expression constructors `Eq/Ne/Lt/Le/Gt/Ge`, `In` (generic over element type), `IsNull/IsNotNull`, `And/Or/Not`, and `Asc/Desc`. (The existing `astbuilder` is under `internal/`; a user-facing builder needs a public home, so this is a new sibling package under `core/`.)

- **Renderer — `core/renderer/select.go`** (extends the already-public `core/renderer`): `RenderSelect(stmt, dialect) (sql string, args []any, err error)`.

### Usage

```go
stmt := query.Select("id", "name").
    From("commodities").
    Where(query.And(
        query.Eq("draft", false),
        query.In("status", []string{"in_use", "sold"}),
        query.Or(
            query.IsNotNull("deleted_at"),
            query.Not(query.Gt("count", int64(10))),
        ),
    )).
    OrderBy(query.Asc("name"), query.Asc("id")).
    Limit(24).Offset(0).
    Build()

sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
// SELECT "id", "name" FROM "commodities"
// WHERE ("draft" = $1 AND "status" IN ($2, $3) AND ("deleted_at" IS NOT NULL OR NOT ("count" > $4)))
// ORDER BY "name" ASC, "id" ASC LIMIT $5 OFFSET $6
// args = []any{false, "in_use", "sold", int64(10), int64(24), int64(0)}
```

A `WHERE` fragment is just an expression node, so it can be built once and attached to both a paged `SELECT` and its `COUNT(*)` — the reusable-fragment ergonomics called out in the issue.

## Parameterization & identifier safety

- **Every value is bound, never inlined.** Comparison operands, `IN` list elements, and the `LIMIT`/`OFFSET` bounds all become placeholders; the renderer appends them to `args`. There is no API surface through which a value reaches the SQL string.
- **Placeholder numbering is invisible to the caller.** A single left-to-right render pass allocates the placeholder and appends the arg together, so numbering and arg order always agree by construction — no `idx++` discipline.
- **Identifiers are always quoted** via `internal/sqlident` (dialect-aware, doubles the quote char per the SQL standard), so a value can never become an identifier and an attacker-shaped identifier cannot terminate its quotes. As in Ptah's DDL path, *which* identifiers a caller supplies (e.g. an allow-list of sortable columns) stays a caller responsibility; the library guarantees quoting + no value interpolation.

## Per-dialect rendering

| Dialect | Placeholders | Identifier quoting |
| --- | --- | --- |
| PostgreSQL (+ CockroachDB, YugabyteDB) | `$1, $2, …` | `"double quotes"` |
| MySQL / MariaDB | `?` | `` `backticks` `` |
| SQLite | `?` | `"double quotes"` |

The SELECT grammar is identical across these dialects in Phase 1, so a single renderer is parameterized by a placeholder style plus `sqlident` quoting rather than duplicated three ways. Unsupported dialects (e.g. ClickHouse, SQL Server) return an error instead of mis-rendering.

## In Phase 1 vs. deferred

**In:** single-table `SELECT`; `WHERE` tree with `=`, `<>`, `<`, `<=`, `>`, `>=`, `IN`, `IS [NOT] NULL`, and `AND`/`OR`/`NOT`; `ORDER BY` with `ASC`/`DESC`; `LIMIT`/`OFFSET`; PG/MySQL/MariaDB/SQLite.

**Deferred (follow-up phases, extension points left in place):** `JOIN`, `GROUP BY`, `HAVING`, `DISTINCT`, subqueries, function calls, arithmetic, `LIKE`, and the `INSERT`/`UPDATE`/`DELETE` family.

## Docs

- New `reference/query-builder` page, wired into the Starlight sidebar.
- `reference/public-api` table and the `core/query` entry in `docs/public_api.md` + regenerated `docs/public_api.snapshot`.
- Updated `reusable-components` (the stale "not a DML query builder" note now points at this first slice) and added a component-map row.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `golangci-lint run` on the changed packages: 0 issues.
- `go tool qtlint ./...` clean; `go tool teststyle ./...` OK.
- `go test ./...` green.
- Both public-API checks pass (`check-public-api.sh`, `check-public-api-snapshot.sh`).
- Docs site `check:page-health`, `check:core-doc-links`, `check:links`, `check:exit-codes` all OK.

Tests are black-box, table-driven, quicktest-based: per-dialect golden SQL+args for a representative query, placeholder-ordering across `WHERE`+`IN`+`LIMIT`/`OFFSET`, identifier quoting that neutralizes an injection attempt, an injection payload that stays a bound argument, and the error paths (nil statement, unsupported dialect, missing `FROM`, empty `IN`, malformed operator/direction).

## Notes for reviewers

- **New public package `core/query`.** The existing fluent builder lives in `internal/astbuilder`, which can't back a user-facing API; this adds a public sibling under `core/` rather than promoting the internal one.
- **DML nodes stay off the DDL `Visitor`.** This is the main deliberate divergence: `RenderSelect` walks the sealed `Expression` tree directly so it can return `args`, instead of forcing an args channel into the string-only DDL visitor and touching every dialect renderer. Happy to fold DML into the visitor family in a later phase if you'd prefer.
- **Parenthesization is explicit and conservative** (`LogicalExpr` and `NOT` always wrap), which yields deterministic output and unambiguous precedence at the cost of a redundant outer pair on a top-level `WHERE`.
- **Empty `IN` is an error** rather than silently emitting a `FALSE`-equivalent. Easy to switch to a false-predicate if you prefer that semantic.

Refs #98. Please review and merge — I have not merged this.
