### PR TITLE
Add JOIN support to DML query builder (Phase 2 of #98)

### DIFF
--- a/core/ast/select.go
+++ b/core/ast/select.go
@@ -1,16 +1,19 @@
 package ast
 
-// This file defines the Phase 1 DML query AST: a single-table SELECT statement
-// and the composable boolean expression tree used by its WHERE clause. These
-// nodes live alongside the DDL nodes but do not participate in the DDL Visitor
+// This file defines the DML query AST: a SELECT statement and the composable
+// boolean expression tree used by its WHERE and JOIN ON clauses. These nodes
+// live alongside the DDL nodes but do not participate in the DDL Visitor
 // interface, because DML rendering must return bound arguments in addition to a
 // SQL string. Rendering is handled by renderer.RenderSelect.
 //
-// Phase 1 deliberately models only SELECT / WHERE / ORDER BY / LIMIT / OFFSET.
-// JOIN, GROUP BY, HAVING, DISTINCT, subqueries, functions, and arithmetic are
-// intentionally absent; they are follow-up phases. The types below are shaped
-// so those extensions slot in without breaking callers (for example, Comparison
-// takes Expression operands on both sides rather than a bare column string).
+// Phase 1 modeled SELECT / WHERE / ORDER BY / LIMIT / OFFSET over a single
+// table. Phase 2 adds JOINs: a table alias on the FROM clause, an optional
+// qualifier on ColumnRef / ResultColumn / OrderByClause so a column can render
+// as "alias"."col", and a JoinClause list on SelectStatement. GROUP BY, HAVING,
+// DISTINCT, subqueries, functions, and arithmetic remain follow-up phases. The
+// types are shaped so those extensions slot in without breaking callers (for
+// example, Comparison takes Expression operands on both sides rather than a bare
+// column string, so a JOIN ON can compare two columns directly).
 
 // Expression is a boolean or scalar expression used in DML statements such as
 // the WHERE clause of a SELECT.
@@ -24,12 +27,19 @@ type Expression interface {
 	expressionNode()
 }
 
-// ColumnRef is a reference to a column by name.
+// ColumnRef is a reference to a column, optionally qualified by a table name or
+// alias.
 //
 // A ColumnRef always renders as a dialect-quoted identifier and never as literal
-// SQL text, so an attacker-shaped name cannot terminate the identifier.
+// SQL text, so an attacker-shaped name cannot terminate the identifier. When
+// Qualifier is set the column renders as "Qualifier"."Name", each part quoted
+// independently.
 type ColumnRef struct {
-	// Name is the unqualified column name.
+	// Qualifier is the optional table name or alias qualifying the column. An
+	// empty Qualifier renders a bare column name. It is quoted independently of
+	// Name so neither part can break out of its quotes.
+	Qualifier string
+	// Name is the column name.
 	Name string
 }
 
@@ -197,6 +207,9 @@ func (d SortDirection) String() string {
 // OrderByClause is a single ORDER BY term: a column and a sort direction. The
 // direction is always rendered explicitly so output is deterministic.
 type OrderByClause struct {
+	// Qualifier is the optional table name or alias qualifying the column,
+	// quoted independently. An empty Qualifier renders a bare column name.
+	Qualifier string
 	// Column is the column name to order by, rendered as a quoted identifier.
 	Column string
 	// Direction is the sort direction.
@@ -205,27 +218,90 @@ type OrderByClause struct {
 
 // ResultColumn is one entry in a SELECT projection.
 //
-// When Star is true the entry renders as "*" (select all columns) and Name is
-// ignored; otherwise Name renders as a dialect-quoted identifier.
+// When Star is true the entry renders as "*" (select all columns) and Name and
+// Qualifier are ignored; otherwise Name renders as a dialect-quoted identifier,
+// prefixed by "Qualifier". when Qualifier is set.
 type ResultColumn struct {
+	// Qualifier is the optional table name or alias qualifying the column,
+	// quoted independently. An empty Qualifier renders a bare column name. It is
+	// ignored when Star is true.
+	Qualifier string
 	// Name is the column name, used when Star is false.
 	Name string
 	// Star selects all columns (SELECT *).
 	Star bool
 }
 
-// SelectStatement is a single-table SELECT with an optional WHERE clause,
-// ORDER BY terms, and LIMIT/OFFSET bounds.
+// JoinType enumerates the join kinds supported in Phase 2.
+type JoinType int
+
+const (
+	// JoinInner is an INNER JOIN: only rows matching the ON condition.
+	JoinInner JoinType = iota
+	// JoinLeft is a LEFT [OUTER] JOIN: all left rows, right columns NULL when
+	// unmatched.
+	JoinLeft
+	// JoinRight is a RIGHT [OUTER] JOIN: all right rows, left columns NULL when
+	// unmatched.
+	JoinRight
+	// JoinFull is a FULL OUTER JOIN: all rows from both sides.
+	JoinFull
+)
+
+// String returns the SQL keyword for the join type, or an empty string when the
+// type is outside the defined range. Renderers treat an empty string as an error
+// rather than emitting invalid SQL.
+func (t JoinType) String() string {
+	switch t {
+	case JoinInner:
+		return "INNER JOIN"
+	case JoinLeft:
+		return "LEFT JOIN"
+	case JoinRight:
+		return "RIGHT JOIN"
+	case JoinFull:
+		return "FULL OUTER JOIN"
+	default:
+		return ""
+	}
+}
+
+// JoinClause is a single join applied to the SELECT's FROM clause: a join type,
+// a target table with an optional alias, and an ON condition.
 //
-// It is the Phase 1 DML node. JOIN, GROUP BY, HAVING, DISTINCT, subqueries,
-// functions, and arithmetic are intentionally not modeled yet. Render it with
-// renderer.RenderSelect, which returns the SQL string and its positional
-// arguments. Build one fluently with the core/query package.
+// The ON condition reuses the Expression tree, so an equi-join is a Comparison
+// of two ColumnRef operands and richer predicates compose with LogicalExpr. The
+// ON expression is rendered through the same bound-parameter and identifier
+// quoting path as WHERE.
+type JoinClause struct {
+	// Type is the join type (INNER, LEFT, RIGHT, or FULL OUTER).
+	Type JoinType
+	// Table is the joined table name, rendered as a quoted identifier. Required.
+	Table string
+	// Alias is the optional alias for the joined table; empty means no alias.
+	Alias string
+	// On is the join condition; nil is rejected by the renderer.
+	On Expression
+}
+
+// SelectStatement is a SELECT over a source table and zero or more joins, with
+// an optional WHERE clause, ORDER BY terms, and LIMIT/OFFSET bounds.
+//
+// GROUP BY, HAVING, DISTINCT, subqueries, functions, and arithmetic are not
+// modeled yet. Render it with renderer.RenderSelect, which returns the SQL
+// string and its positional arguments. Build one fluently with the core/query
+// package.
 type SelectStatement struct {
 	// Columns is the projection. An empty slice renders as "*".
 	Columns []ResultColumn
-	// From is the single source table, rendered as a quoted identifier. Required.
+	// From is the source table, rendered as a quoted identifier. Required.
 	From string
+	// FromAlias is the optional alias for the source table; empty means no alias.
+	// When set, the FROM clause renders as "From" "FromAlias".
+	FromAlias string
+	// Joins is the optional list of joins, rendered after FROM in order. Their ON
+	// conditions are bound before the WHERE clause.
+	Joins []JoinClause
 	// Where is the optional filter expression tree; nil means no WHERE clause.
 	Where Expression
 	// OrderBy is the optional list of sort terms, applied in order.

--- a/core/ast/select_test.go
+++ b/core/ast/select_test.go
@@ -52,6 +52,28 @@ func TestLogicalOperatorString(t *testing.T) {
 	}
 }
 
+func TestJoinTypeString(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		jt   ast.JoinType
+		want string
+	}{
+		{name: "inner", jt: ast.JoinInner, want: "INNER JOIN"},
+		{name: "left", jt: ast.JoinLeft, want: "LEFT JOIN"},
+		{name: "right", jt: ast.JoinRight, want: "RIGHT JOIN"},
+		{name: "full", jt: ast.JoinFull, want: "FULL OUTER JOIN"},
+		{name: "out of range yields empty", jt: ast.JoinType(42), want: ""},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.jt.String(), qt.Equals, tt.want)
+		})
+	}
+}
+
 func TestSortDirectionString(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -92,7 +92,12 @@
 //
 // A join ON value is bound before any WHERE value, because joins render before
 // WHERE. Aliases and qualifiers are quoted through the same dialect-aware path
-// as every other identifier. Because SQLite could not express a RIGHT or FULL
-// OUTER join before version 3.39, RenderSelect returns an error for those on
-// SQLite rather than emit SQL an older engine would reject.
+// as every other identifier.
+//
+// Not every dialect can express every join type, and RenderSelect rejects an
+// unsupported one at render time rather than emit SQL the database would reject:
+// SQLite could not express RIGHT or FULL OUTER joins before version 3.39, and
+// MySQL and MariaDB have no FULL OUTER JOIN in any version. In short, FULL OUTER
+// renders only on the PostgreSQL family; RIGHT renders everywhere except SQLite;
+// INNER and LEFT render on every supported dialect.
 package query

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -7,10 +7,13 @@
 // renderer.RenderSelect turns into a SQL string plus its positional arguments
 // for PostgreSQL, MySQL, MariaDB, and SQLite.
 //
-// # Scope (Phase 1)
+// # Scope
 //
-// This package models exactly SELECT with a single FROM table, a composable
-// WHERE expression tree, ORDER BY, LIMIT, and OFFSET. JOIN, GROUP BY, HAVING,
+// This package models a SELECT with a FROM table, INNER / LEFT / RIGHT / FULL
+// OUTER joins, a composable WHERE expression tree, ORDER BY, LIMIT, and OFFSET.
+// Tables can be aliased (FromAs and the alias argument of the join methods) and
+// columns can be qualified by a table or alias with Col, so a projection, WHERE,
+// join ON, or ORDER BY term can render as "alias"."col". GROUP BY, HAVING,
 // DISTINCT, subqueries, functions, arithmetic, and LIKE are intentionally not
 // implemented yet and are tracked as follow-up phases.
 //
@@ -60,4 +63,36 @@
 // A WHERE expression can be built once and shared between statements (for
 // example, a COUNT(*) and the paged SELECT that share the same filter), because
 // the expression constructors return plain *ast expression nodes.
+//
+// # Joins
+//
+// Alias the source table with FromAs, join with InnerJoin, LeftJoin, RightJoin,
+// or FullJoin, and qualify columns with Col so they render as "alias"."col". A
+// join ON condition is an ordinary expression, so an equi-join is Col(…).EqCol
+// and richer predicates compose with And, Or, and Not:
+//
+//	stmt := query.Select().
+//		Columns(query.Col("u", "id"), query.Col("u", "name"), query.Col("o", "total")).
+//		FromAs("users", "u").
+//		InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+//		Where(query.And(
+//			query.Col("o", "status").Eq("paid"),
+//			query.Col("u", "active").Eq(true),
+//		)).
+//		OrderBy(query.Col("u", "name").Asc()).
+//		Limit(20).
+//		Build()
+//
+//	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+//	// sql:  SELECT "u"."id", "u"."name", "o"."total" FROM "users" "u"
+//	//       INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"
+//	//       WHERE ("o"."status" = $1 AND "u"."active" = $2)
+//	//       ORDER BY "u"."name" ASC LIMIT $3
+//	// args: []any{"paid", true, int64(20)}
+//
+// A join ON value is bound before any WHERE value, because joins render before
+// WHERE. Aliases and qualifiers are quoted through the same dialect-aware path
+// as every other identifier. Because SQLite could not express a RIGHT or FULL
+// OUTER join before version 3.39, RenderSelect returns an error for those on
+// SQLite rather than emit SQL an older engine would reject.
 package query

--- a/core/query/query.go
+++ b/core/query/query.go
@@ -10,12 +10,14 @@ import (
 // method mutates and returns the same builder for chaining. Build produces the
 // statement. Builders are not safe for concurrent use.
 type SelectBuilder struct {
-	columns []ast.ResultColumn
-	from    string
-	where   ast.Expression
-	orderBy []ast.OrderByClause
-	limit   *int64
-	offset  *int64
+	columns   []ast.ResultColumn
+	from      string
+	fromAlias string
+	joins     []ast.JoinClause
+	where     ast.Expression
+	orderBy   []ast.OrderByClause
+	limit     *int64
+	offset    *int64
 }
 
 // Select starts a SELECT with the given projection columns.
@@ -35,10 +37,68 @@ func Select(columns ...string) *SelectBuilder {
 	return b
 }
 
-// From sets the single source table for the query. It is required; rendering a
-// statement without a table returns an error.
+// From sets the source table for the query. It is required; rendering a
+// statement without a table returns an error. Calling From clears any alias set
+// by a previous FromAs.
 func (b *SelectBuilder) From(table string) *SelectBuilder {
 	b.from = table
+	b.fromAlias = ""
+	return b
+}
+
+// FromAs sets the source table together with an alias, rendered as
+// "table" "alias". Use the alias to qualify columns across joins with Col. An
+// empty alias behaves like From.
+func (b *SelectBuilder) FromAs(table, alias string) *SelectBuilder {
+	b.from = table
+	b.fromAlias = alias
+	return b
+}
+
+// Columns appends result columns to the projection, allowing qualified columns
+// built with Col to be mixed with any columns already selected. Appending to an
+// otherwise empty projection replaces the implicit "*".
+func (b *SelectBuilder) Columns(columns ...Column) *SelectBuilder {
+	for _, col := range columns {
+		b.columns = append(b.columns, col.resultColumn())
+	}
+	return b
+}
+
+// InnerJoin appends an INNER JOIN of table (with an optional alias) on the given
+// condition. Build the condition from qualified columns, for example
+// Col("o", "user_id").EqCol(Col("u", "id")). An empty alias joins the bare table.
+func (b *SelectBuilder) InnerJoin(table, alias string, on ast.Expression) *SelectBuilder {
+	return b.join(ast.JoinInner, table, alias, on)
+}
+
+// LeftJoin appends a LEFT OUTER JOIN of table (with an optional alias) on the
+// given condition.
+func (b *SelectBuilder) LeftJoin(table, alias string, on ast.Expression) *SelectBuilder {
+	return b.join(ast.JoinLeft, table, alias, on)
+}
+
+// RightJoin appends a RIGHT OUTER JOIN of table (with an optional alias) on the
+// given condition. RenderSelect rejects a RIGHT JOIN on SQLite.
+func (b *SelectBuilder) RightJoin(table, alias string, on ast.Expression) *SelectBuilder {
+	return b.join(ast.JoinRight, table, alias, on)
+}
+
+// FullJoin appends a FULL OUTER JOIN of table (with an optional alias) on the
+// given condition. RenderSelect rejects a FULL OUTER JOIN on SQLite.
+func (b *SelectBuilder) FullJoin(table, alias string, on ast.Expression) *SelectBuilder {
+	return b.join(ast.JoinFull, table, alias, on)
+}
+
+// join appends a join clause of the given type. It is shared by the exported
+// per-type join methods.
+func (b *SelectBuilder) join(joinType ast.JoinType, table, alias string, on ast.Expression) *SelectBuilder {
+	b.joins = append(b.joins, ast.JoinClause{
+		Type:  joinType,
+		Table: table,
+		Alias: alias,
+		On:    on,
+	})
 	return b
 }
 
@@ -74,12 +134,14 @@ func (b *SelectBuilder) Offset(n int64) *SelectBuilder {
 // renderer.RenderSelect.
 func (b *SelectBuilder) Build() *ast.SelectStatement {
 	return &ast.SelectStatement{
-		Columns: b.columns,
-		From:    b.from,
-		Where:   b.where,
-		OrderBy: b.orderBy,
-		Limit:   b.limit,
-		Offset:  b.offset,
+		Columns:   b.columns,
+		From:      b.from,
+		FromAlias: b.fromAlias,
+		Joins:     b.joins,
+		Where:     b.where,
+		OrderBy:   b.orderBy,
+		Limit:     b.limit,
+		Offset:    b.offset,
 	}
 }
 
@@ -173,4 +235,92 @@ func Asc(column string) ast.OrderByClause {
 // Desc builds a descending ORDER BY term for column.
 func Desc(column string) ast.OrderByClause {
 	return ast.OrderByClause{Column: column, Direction: ast.SortDescending}
+}
+
+// Column is a reference to a column, optionally qualified by a table name or
+// alias. It is the entry point for the qualified-column API used with joins:
+// build one with Col, then turn it into a projection entry (via the builder's
+// Columns method), a comparison, a null test, or an ORDER BY term.
+//
+// The value-oriented Phase 1 helpers (Eq, In, Asc, and so on) that take a bare
+// column name still work unchanged for unqualified columns; Column adds
+// qualified-column support alongside them, it does not replace them. A qualifier
+// and name are always emitted as separately quoted identifiers, never inlined.
+type Column struct {
+	qualifier string
+	name      string
+}
+
+// Col returns a column qualified by a table name or alias, rendering as
+// "qualifier"."name". Use it to disambiguate columns across joined tables. An
+// empty qualifier yields a bare, unqualified column.
+func Col(qualifier, name string) Column {
+	return Column{qualifier: qualifier, name: name}
+}
+
+// columnRef returns the AST node for the column, used as a comparison operand.
+func (c Column) columnRef() *ast.ColumnRef {
+	return &ast.ColumnRef{Qualifier: c.qualifier, Name: c.name}
+}
+
+// resultColumn returns the projection entry for the column.
+func (c Column) resultColumn() ast.ResultColumn {
+	return ast.ResultColumn{Qualifier: c.qualifier, Name: c.name}
+}
+
+// compareValue builds "column <op> value" with the value bound as a parameter.
+func (c Column) compareValue(op ast.ComparisonOperator, value any) ast.Expression {
+	return &ast.Comparison{
+		Left:     c.columnRef(),
+		Operator: op,
+		Right:    &ast.BoundValue{Value: value},
+	}
+}
+
+// Eq builds "column = value", binding value as a parameter.
+func (c Column) Eq(value any) ast.Expression { return c.compareValue(ast.OpEqual, value) }
+
+// Ne builds "column <> value", binding value as a parameter.
+func (c Column) Ne(value any) ast.Expression { return c.compareValue(ast.OpNotEqual, value) }
+
+// Lt builds "column < value", binding value as a parameter.
+func (c Column) Lt(value any) ast.Expression { return c.compareValue(ast.OpLessThan, value) }
+
+// Le builds "column <= value", binding value as a parameter.
+func (c Column) Le(value any) ast.Expression { return c.compareValue(ast.OpLessThanOrEqual, value) }
+
+// Gt builds "column > value", binding value as a parameter.
+func (c Column) Gt(value any) ast.Expression { return c.compareValue(ast.OpGreaterThan, value) }
+
+// Ge builds "column >= value", binding value as a parameter.
+func (c Column) Ge(value any) ast.Expression { return c.compareValue(ast.OpGreaterThanOrEqual, value) }
+
+// EqCol builds "column = other", comparing two columns rather than a column and
+// a bound value. It is the common equi-join predicate for a join ON condition.
+func (c Column) EqCol(other Column) ast.Expression {
+	return &ast.Comparison{
+		Left:     c.columnRef(),
+		Operator: ast.OpEqual,
+		Right:    other.columnRef(),
+	}
+}
+
+// IsNull builds "column IS NULL".
+func (c Column) IsNull() ast.Expression {
+	return &ast.NullTest{Operand: c.columnRef()}
+}
+
+// IsNotNull builds "column IS NOT NULL".
+func (c Column) IsNotNull() ast.Expression {
+	return &ast.NullTest{Operand: c.columnRef(), Negated: true}
+}
+
+// Asc builds an ascending ORDER BY term for the column.
+func (c Column) Asc() ast.OrderByClause {
+	return ast.OrderByClause{Qualifier: c.qualifier, Column: c.name, Direction: ast.SortAscending}
+}
+
+// Desc builds a descending ORDER BY term for the column.
+func (c Column) Desc() ast.OrderByClause {
+	return ast.OrderByClause{Qualifier: c.qualifier, Column: c.name, Direction: ast.SortDescending}
 }

--- a/core/query/query_join_test.go
+++ b/core/query/query_join_test.go
@@ -1,0 +1,235 @@
+package query_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/query"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestColumnExpressionConstructors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		expr     ast.Expression
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "eq binds the value and qualifies the column",
+			expr:     query.Col("u", "id").Eq(1),
+			wantSQL:  `SELECT * FROM "t" WHERE "u"."id" = $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "ne",
+			expr:     query.Col("u", "id").Ne(1),
+			wantSQL:  `SELECT * FROM "t" WHERE "u"."id" <> $1`,
+			wantArgs: []any{1},
+		},
+		{
+			name:     "lt",
+			expr:     query.Col("o", "total").Lt(int64(10)),
+			wantSQL:  `SELECT * FROM "t" WHERE "o"."total" < $1`,
+			wantArgs: []any{int64(10)},
+		},
+		{
+			name:     "le",
+			expr:     query.Col("o", "total").Le(int64(10)),
+			wantSQL:  `SELECT * FROM "t" WHERE "o"."total" <= $1`,
+			wantArgs: []any{int64(10)},
+		},
+		{
+			name:     "gt",
+			expr:     query.Col("o", "total").Gt(int64(10)),
+			wantSQL:  `SELECT * FROM "t" WHERE "o"."total" > $1`,
+			wantArgs: []any{int64(10)},
+		},
+		{
+			name:     "ge",
+			expr:     query.Col("o", "total").Ge(int64(10)),
+			wantSQL:  `SELECT * FROM "t" WHERE "o"."total" >= $1`,
+			wantArgs: []any{int64(10)},
+		},
+		{
+			name:     "eqcol compares two columns without binding a value",
+			expr:     query.Col("o", "user_id").EqCol(query.Col("u", "id")),
+			wantSQL:  `SELECT * FROM "t" WHERE "o"."user_id" = "u"."id"`,
+			wantArgs: nil,
+		},
+		{
+			name:     "is null",
+			expr:     query.Col("u", "deleted_at").IsNull(),
+			wantSQL:  `SELECT * FROM "t" WHERE "u"."deleted_at" IS NULL`,
+			wantArgs: nil,
+		},
+		{
+			name:     "is not null",
+			expr:     query.Col("u", "deleted_at").IsNotNull(),
+			wantSQL:  `SELECT * FROM "t" WHERE "u"."deleted_at" IS NOT NULL`,
+			wantArgs: nil,
+		},
+		{
+			name:     "empty qualifier renders a bare column",
+			expr:     query.Col("", "id").Eq(1),
+			wantSQL:  `SELECT * FROM "t" WHERE "id" = $1`,
+			wantArgs: []any{1},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args := renderWhere(c, tt.expr)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, tt.wantArgs)
+		})
+	}
+}
+
+func TestColumnOrderByTerms(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("*").
+		From("t").
+		OrderBy(query.Col("u", "name").Asc(), query.Col("o", "total").Desc()).
+		Build()
+
+	c.Assert(stmt.OrderBy, qt.DeepEquals, []ast.OrderByClause{
+		{Qualifier: "u", Column: "name", Direction: ast.SortAscending},
+		{Qualifier: "o", Column: "total", Direction: ast.SortDescending},
+	})
+}
+
+func TestSelectBuilder_FromAs(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("*").FromAs("users", "u").Build()
+	c.Assert(stmt.From, qt.Equals, "users")
+	c.Assert(stmt.FromAlias, qt.Equals, "u")
+
+	sql, _, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT * FROM "users" "u"`)
+}
+
+func TestSelectBuilder_FromClearsPreviousAlias(t *testing.T) {
+	c := qt.New(t)
+
+	// From after FromAs drops the alias, so a later From wins cleanly.
+	stmt := query.Select("*").FromAs("users", "u").From("people").Build()
+	c.Assert(stmt.From, qt.Equals, "people")
+	c.Assert(stmt.FromAlias, qt.Equals, "")
+}
+
+func TestSelectBuilder_Columns(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		stmt *ast.SelectStatement
+		want []ast.ResultColumn
+	}{
+		{
+			name: "qualified columns replace the implicit star",
+			stmt: query.Select().Columns(query.Col("u", "id"), query.Col("o", "total")).From("t").Build(),
+			want: []ast.ResultColumn{{Qualifier: "u", Name: "id"}, {Qualifier: "o", Name: "total"}},
+		},
+		{
+			name: "qualified columns append after bare columns",
+			stmt: query.Select("id").Columns(query.Col("o", "total")).From("t").Build(),
+			want: []ast.ResultColumn{{Name: "id"}, {Qualifier: "o", Name: "total"}},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.stmt.Columns, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestSelectBuilder_JoinMethodsSetType(t *testing.T) {
+	c := qt.New(t)
+
+	on := query.Col("b", "a_id").EqCol(query.Col("a", "id"))
+
+	tests := []struct {
+		name     string
+		build    func() *ast.SelectStatement
+		wantType ast.JoinType
+	}{
+		{
+			name:     "inner",
+			build:    func() *ast.SelectStatement { return query.Select("*").From("a").InnerJoin("b", "x", on).Build() },
+			wantType: ast.JoinInner,
+		},
+		{
+			name:     "left",
+			build:    func() *ast.SelectStatement { return query.Select("*").From("a").LeftJoin("b", "x", on).Build() },
+			wantType: ast.JoinLeft,
+		},
+		{
+			name:     "right",
+			build:    func() *ast.SelectStatement { return query.Select("*").From("a").RightJoin("b", "x", on).Build() },
+			wantType: ast.JoinRight,
+		},
+		{
+			name:     "full",
+			build:    func() *ast.SelectStatement { return query.Select("*").From("a").FullJoin("b", "x", on).Build() },
+			wantType: ast.JoinFull,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := tt.build()
+			c.Assert(stmt.Joins, qt.HasLen, 1)
+			c.Assert(stmt.Joins[0].Type, qt.Equals, tt.wantType)
+			c.Assert(stmt.Joins[0].Table, qt.Equals, "b")
+			c.Assert(stmt.Joins[0].Alias, qt.Equals, "x")
+			c.Assert(stmt.Joins[0].On, qt.Equals, on)
+		})
+	}
+}
+
+func TestSelectBuilder_JoinsAccumulateInOrder(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("*").
+		FromAs("users", "u").
+		InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+		LeftJoin("payments", "p", query.Col("p", "order_id").EqCol(query.Col("o", "id"))).
+		Build()
+
+	c.Assert(stmt.Joins, qt.HasLen, 2)
+	c.Assert(stmt.Joins[0].Type, qt.Equals, ast.JoinInner)
+	c.Assert(stmt.Joins[0].Table, qt.Equals, "orders")
+	c.Assert(stmt.Joins[1].Type, qt.Equals, ast.JoinLeft)
+	c.Assert(stmt.Joins[1].Table, qt.Equals, "payments")
+}
+
+func TestSelectBuilder_JoinFluentEndToEnd(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select().
+		Columns(query.Col("u", "id"), query.Col("u", "name"), query.Col("o", "total")).
+		FromAs("users", "u").
+		InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+		Where(query.And(
+			query.Col("o", "status").Eq("paid"),
+			query.Col("u", "active").Eq(true),
+		)).
+		OrderBy(query.Col("u", "name").Asc(), query.Col("o", "total").Desc()).
+		Limit(5).
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "u"."id", "u"."name", "o"."total" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" WHERE ("o"."status" = $1 AND "u"."active" = $2) ORDER BY "u"."name" ASC, "o"."total" DESC LIMIT $3`)
+	c.Assert(args, qt.DeepEquals, []any{"paid", true, int64(5)})
+}

--- a/core/query/query_join_test.go
+++ b/core/query/query_join_test.go
@@ -153,6 +153,23 @@ func TestSelectBuilder_Columns(t *testing.T) {
 	}
 }
 
+func TestSelectBuilder_QualifiedStarProjection(t *testing.T) {
+	c := qt.New(t)
+
+	// Col(alias, "*") projects a qualified star, rendering "u".* rather than the
+	// invalid "u"."*".
+	stmt := query.Select().
+		Columns(query.Col("u", "*"), query.Col("o", "total")).
+		FromAs("users", "u").
+		InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "u".*, "o"."total" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"`)
+	c.Assert(args, qt.HasLen, 0)
+}
+
 func TestSelectBuilder_JoinMethodsSetType(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -14,20 +14,24 @@ import (
 // RenderSelect renders a SELECT statement to parameterized SQL for the given
 // dialect, returning the SQL text and its positional arguments.
 //
-// Every value in the statement — comparison operands, IN list elements, and the
-// LIMIT/OFFSET bounds — is emitted as a placeholder and returned in args, never
-// interpolated into the SQL. Placeholder style follows the dialect: $1, $2, …
-// for the PostgreSQL family and ? for MySQL, MariaDB, and SQLite. Placeholders
-// are numbered in a single left-to-right pass, so args are ordered to match.
+// Every value in the statement — comparison operands (including those inside a
+// JOIN ON), IN list elements, and the LIMIT/OFFSET bounds — is emitted as a
+// placeholder and returned in args, never interpolated into the SQL. Placeholder
+// style follows the dialect: $1, $2, … for the PostgreSQL family and ? for
+// MySQL, MariaDB, and SQLite. Placeholders are numbered in a single
+// left-to-right pass over FROM, the joins, WHERE, then LIMIT/OFFSET, so args are
+// ordered to match; a JOIN ON value is numbered before any WHERE value.
 //
-// Identifiers (the table and column names) are quoted for the dialect via
+// Identifiers (table, alias, and column names) are quoted for the dialect via
 // internal/sqlident, so a value can never be rendered as an identifier and an
-// attacker-shaped identifier cannot break out of its quotes.
+// attacker-shaped identifier or alias cannot break out of its quotes. A
+// qualified column renders as "alias"."col" with each part quoted independently.
 //
 // Supported dialects are PostgreSQL (including CockroachDB and YugabyteDB),
 // MySQL, MariaDB, and SQLite. Any other dialect returns an error, as does a nil
-// statement, a statement without a FROM table, an empty IN list, or a malformed
-// operator.
+// statement, a statement without a FROM table, an empty IN list, a malformed
+// operator, a join without a table or ON condition, or a RIGHT/FULL join on
+// SQLite (which cannot express one before version 3.39).
 func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error) {
 	if stmt == nil {
 		return "", nil, errors.New("renderer: nil select statement")
@@ -95,6 +99,28 @@ func (r *selectRenderer) quote(identifier string) string {
 	return sqlident.Quote(r.dialect, identifier)
 }
 
+// writeQualifiedIdent writes name quoted for the dialect, prefixed by a quoted
+// qualifier and a dot when qualifier is non-empty, as in "alias"."col". Each
+// part is quoted independently so neither can break out of its quotes.
+func (r *selectRenderer) writeQualifiedIdent(qualifier, name string) {
+	if strings.TrimSpace(qualifier) != "" {
+		r.buf.WriteString(r.quote(qualifier))
+		r.buf.WriteString(".")
+	}
+	r.buf.WriteString(r.quote(name))
+}
+
+// writeTableRef writes a quoted table name followed by an optional quoted alias,
+// as in "t" or "t" "a". The bare "table alias" form is used rather than "table
+// AS alias" because every supported dialect accepts it.
+func (r *selectRenderer) writeTableRef(table, alias string) {
+	r.buf.WriteString(r.quote(table))
+	if strings.TrimSpace(alias) != "" {
+		r.buf.WriteString(" ")
+		r.buf.WriteString(r.quote(alias))
+	}
+}
+
 func (r *selectRenderer) render(stmt *ast.SelectStatement) error {
 	if strings.TrimSpace(stmt.From) == "" {
 		return errors.New("renderer: select statement requires a FROM table")
@@ -106,7 +132,11 @@ func (r *selectRenderer) render(stmt *ast.SelectStatement) error {
 	}
 
 	r.buf.WriteString(" FROM ")
-	r.buf.WriteString(r.quote(stmt.From))
+	r.writeTableRef(stmt.From, stmt.FromAlias)
+
+	if err := r.renderJoins(stmt.Joins); err != nil {
+		return err
+	}
 
 	if stmt.Where != nil {
 		r.buf.WriteString(" WHERE ")
@@ -139,9 +169,61 @@ func (r *selectRenderer) renderColumns(columns []ast.ResultColumn) error {
 		if strings.TrimSpace(col.Name) == "" {
 			return errors.New("renderer: result column has an empty name")
 		}
-		r.buf.WriteString(r.quote(col.Name))
+		r.writeQualifiedIdent(col.Qualifier, col.Name)
 	}
 	return nil
+}
+
+// renderJoins appends each join after the FROM clause in declared order. Their
+// ON conditions bind their placeholders before the WHERE clause, because they
+// render first.
+func (r *selectRenderer) renderJoins(joins []ast.JoinClause) error {
+	for i := range joins {
+		if err := r.renderJoin(&joins[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderJoin appends a single join: " <TYPE> JOIN <table> [alias] ON <cond>".
+func (r *selectRenderer) renderJoin(join *ast.JoinClause) error {
+	keyword := join.Type.String()
+	if keyword == "" {
+		return fmt.Errorf("renderer: unknown join type %d", join.Type)
+	}
+	if err := r.checkJoinDialect(join.Type); err != nil {
+		return err
+	}
+	if strings.TrimSpace(join.Table) == "" {
+		return errors.New("renderer: join requires a table")
+	}
+	if join.On == nil {
+		return errors.New("renderer: join requires an ON condition")
+	}
+	r.buf.WriteString(" ")
+	r.buf.WriteString(keyword)
+	r.buf.WriteString(" ")
+	r.writeTableRef(join.Table, join.Alias)
+	r.buf.WriteString(" ON ")
+	return r.renderExpr(join.On)
+}
+
+// checkJoinDialect rejects join types a dialect cannot express. SQLite gained
+// RIGHT and FULL [OUTER] JOIN only in version 3.39 (2022); because Ptah targets
+// a range of SQLite versions and cannot assume 3.39+, it rejects those at render
+// time rather than emit SQL that fails at execution time on an older engine.
+// INNER and LEFT joins are accepted by every supported dialect.
+func (r *selectRenderer) checkJoinDialect(t ast.JoinType) error {
+	if r.dialect != platform.SQLite {
+		return nil
+	}
+	switch t {
+	case ast.JoinRight, ast.JoinFull:
+		return fmt.Errorf("renderer: SQLite does not support %s", t)
+	default:
+		return nil
+	}
 }
 
 // renderExpr dispatches over the sealed ast.Expression sum type. Each case
@@ -178,7 +260,7 @@ func (r *selectRenderer) renderColumnRef(ref *ast.ColumnRef) error {
 	if strings.TrimSpace(ref.Name) == "" {
 		return errors.New("renderer: column reference has an empty name")
 	}
-	r.buf.WriteString(r.quote(ref.Name))
+	r.writeQualifiedIdent(ref.Qualifier, ref.Name)
 	return nil
 }
 
@@ -294,7 +376,7 @@ func (r *selectRenderer) renderOrderBy(terms []ast.OrderByClause) error {
 		if direction == "" {
 			return fmt.Errorf("renderer: unknown sort direction %d", term.Direction)
 		}
-		r.buf.WriteString(r.quote(term.Column))
+		r.writeQualifiedIdent(term.Qualifier, term.Column)
 		r.buf.WriteString(" ")
 		r.buf.WriteString(direction)
 	}

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -101,10 +101,12 @@ func (r *selectRenderer) quote(identifier string) string {
 
 // writeQualifiedIdent writes name quoted for the dialect, prefixed by a quoted
 // qualifier and a dot when qualifier is non-empty, as in "alias"."col". Each
-// part is quoted independently so neither can break out of its quotes.
+// part is quoted independently so neither can break out of its quotes. The
+// qualifier is trimmed before it is quoted, matching sqlident.Qualified, so
+// surrounding whitespace never lands inside the quotes.
 func (r *selectRenderer) writeQualifiedIdent(qualifier, name string) {
-	if strings.TrimSpace(qualifier) != "" {
-		r.buf.WriteString(r.quote(qualifier))
+	if q := strings.TrimSpace(qualifier); q != "" {
+		r.buf.WriteString(r.quote(q))
 		r.buf.WriteString(".")
 	}
 	r.buf.WriteString(r.quote(name))
@@ -112,12 +114,13 @@ func (r *selectRenderer) writeQualifiedIdent(qualifier, name string) {
 
 // writeTableRef writes a quoted table name followed by an optional quoted alias,
 // as in "t" or "t" "a". The bare "table alias" form is used rather than "table
-// AS alias" because every supported dialect accepts it.
+// AS alias" because every supported dialect accepts it. Both the table and the
+// alias are trimmed before quoting, matching sqlident.Qualified.
 func (r *selectRenderer) writeTableRef(table, alias string) {
-	r.buf.WriteString(r.quote(table))
-	if strings.TrimSpace(alias) != "" {
+	r.buf.WriteString(r.quote(strings.TrimSpace(table)))
+	if a := strings.TrimSpace(alias); a != "" {
 		r.buf.WriteString(" ")
-		r.buf.WriteString(r.quote(alias))
+		r.buf.WriteString(r.quote(a))
 	}
 }
 
@@ -169,9 +172,26 @@ func (r *selectRenderer) renderColumns(columns []ast.ResultColumn) error {
 		if strings.TrimSpace(col.Name) == "" {
 			return errors.New("renderer: result column has an empty name")
 		}
-		r.writeQualifiedIdent(col.Qualifier, col.Name)
+		r.writeResultColumn(col)
 	}
 	return nil
+}
+
+// writeResultColumn writes one projection entry. A qualified star ("u".*) is
+// rendered with the qualifier quoted and a bare, unquoted "*" — quoting the star
+// would produce the invalid "u"."*" — so a qualified SELECT u.* renders as
+// standard SQL. Every other column routes through writeQualifiedIdent.
+func (r *selectRenderer) writeResultColumn(col ast.ResultColumn) {
+	if strings.TrimSpace(col.Name) != "*" {
+		r.writeQualifiedIdent(col.Qualifier, col.Name)
+		return
+	}
+	if q := strings.TrimSpace(col.Qualifier); q != "" {
+		r.buf.WriteString(r.quote(q))
+		r.buf.WriteString(".*")
+		return
+	}
+	r.buf.WriteString("*")
 }
 
 // renderJoins appends each join after the FROM clause in declared order. Their
@@ -209,21 +229,31 @@ func (r *selectRenderer) renderJoin(join *ast.JoinClause) error {
 	return r.renderExpr(join.On)
 }
 
-// checkJoinDialect rejects join types a dialect cannot express. SQLite gained
-// RIGHT and FULL [OUTER] JOIN only in version 3.39 (2022); because Ptah targets
-// a range of SQLite versions and cannot assume 3.39+, it rejects those at render
-// time rather than emit SQL that fails at execution time on an older engine.
-// INNER and LEFT joins are accepted by every supported dialect.
+// checkJoinDialect rejects join types a dialect cannot express, so an
+// unsupported join fails at render time rather than at execution time against
+// the database.
+//
+//   - SQLite gained RIGHT and FULL [OUTER] JOIN only in version 3.39 (2022);
+//     because Ptah targets a range of SQLite versions and cannot assume 3.39+,
+//     both are rejected.
+//   - MySQL and MariaDB have no FULL [OUTER] JOIN in any version (it must be
+//     emulated with a UNION of a LEFT and a RIGHT join), so it is rejected.
+//
+// INNER and LEFT joins are accepted by every supported dialect; RIGHT is
+// accepted everywhere except SQLite; FULL OUTER is accepted only by the
+// PostgreSQL family.
 func (r *selectRenderer) checkJoinDialect(t ast.JoinType) error {
-	if r.dialect != platform.SQLite {
-		return nil
+	switch r.dialect {
+	case platform.SQLite:
+		if t == ast.JoinRight || t == ast.JoinFull {
+			return fmt.Errorf("renderer: SQLite does not support %s", t)
+		}
+	case platform.MySQL, platform.MariaDB:
+		if t == ast.JoinFull {
+			return fmt.Errorf("renderer: %s does not support %s", r.dialect, t)
+		}
 	}
-	switch t {
-	case ast.JoinRight, ast.JoinFull:
-		return fmt.Errorf("renderer: SQLite does not support %s", t)
-	default:
-		return nil
-	}
+	return nil
 }
 
 // renderExpr dispatches over the sealed ast.Expression sum type. Each case

--- a/core/renderer/select_join_test.go
+++ b/core/renderer/select_join_test.go
@@ -359,6 +359,197 @@ func TestRenderSelect_SQLiteRejectsRightAndFullJoin(t *testing.T) {
 	}
 }
 
+func TestRenderSelect_MySQLLikeRejectsFullJoin(t *testing.T) {
+	c := qt.New(t)
+
+	// MySQL and MariaDB have no FULL [OUTER] JOIN in any version; the renderer
+	// rejects it rather than emit SQL the database would fail on. The error names
+	// the normalized dialect.
+	tests := []struct {
+		name        string
+		dialect     string
+		wantErrLike string
+	}{
+		{name: "mysql", dialect: platform.MySQL, wantErrLike: "renderer: mysql does not support FULL OUTER JOIN"},
+		{name: "mariadb", dialect: platform.MariaDB, wantErrLike: "renderer: mariadb does not support FULL OUTER JOIN"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From:  "a",
+				Joins: []ast.JoinClause{{Type: ast.JoinFull, Table: "b", On: eqCols("b", "a_id", "a", "id")}},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+func TestRenderSelect_MySQLLikeAcceptsRightJoin(t *testing.T) {
+	c := qt.New(t)
+
+	// RIGHT JOIN is valid on MySQL and MariaDB; only FULL is blocked there.
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: platform.MySQL},
+		{name: "mariadb", dialect: platform.MariaDB},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From:  "a",
+				Joins: []ast.JoinClause{{Type: ast.JoinRight, Table: "b", On: eqCols("b", "a_id", "a", "id")}},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, "SELECT * FROM `a` RIGHT JOIN `b` ON `b`.`a_id` = `a`.`id`")
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_QualifiedStar(t *testing.T) {
+	c := qt.New(t)
+
+	// A qualified star renders "u".* (not the invalid "u"."*"), and mixes with
+	// ordinary qualified columns.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Qualifier: "u", Name: "*"},
+			{Qualifier: "o", Name: "total"},
+		},
+		From:      "users",
+		FromAlias: "u",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: "orders", Alias: "o", On: eqCols("o", "user_id", "u", "id")},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "u".*, "o"."total" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"`,
+		},
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `u`.*, `o`.`total` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id`",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_IdentifiersAreTrimmedBeforeQuoting(t *testing.T) {
+	c := qt.New(t)
+
+	// Surrounding whitespace on a table, alias, or qualifier is trimmed before
+	// quoting, matching sqlident.Qualified, so it never lands inside the quotes.
+	limit := int64(1)
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Qualifier: " u ", Name: "id"}},
+		From:    " users ",
+		// FromAlias carries surrounding whitespace too.
+		FromAlias: " u ",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: " orders ", Alias: " o ", On: eqCols(" o ", "user_id", " u ", "id")},
+		},
+		OrderBy: []ast.OrderByClause{{Qualifier: " u ", Column: "id", Direction: ast.SortAscending}},
+		Limit:   &limit,
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "u"."id" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" ORDER BY "u"."id" ASC LIMIT $1`)
+	c.Assert(args, qt.DeepEquals, []any{int64(1)})
+}
+
+func TestRenderSelect_TwoBoundJoinOnsPlaceholderOrdering(t *testing.T) {
+	c := qt.New(t)
+
+	// Two joins, each carrying a bound value in its ON, prove the exact ordering:
+	// join1 ON -> $1, join2 ON -> $2, WHERE -> $3, LIMIT -> $4.
+	limit := int64(10)
+	stmt := &ast.SelectStatement{
+		From:      "a",
+		FromAlias: "a0",
+		Joins: []ast.JoinClause{
+			{
+				Type:  ast.JoinInner,
+				Table: "b",
+				Alias: "b0",
+				On: &ast.LogicalExpr{
+					Operator: ast.LogicalAnd,
+					Operands: []ast.Expression{
+						eqCols("b0", "a_id", "a0", "id"),
+						&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "b0", Name: "status"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "active"}},
+					},
+				},
+			},
+			{
+				Type:  ast.JoinLeft,
+				Table: "c",
+				Alias: "c0",
+				On: &ast.LogicalExpr{
+					Operator: ast.LogicalAnd,
+					Operands: []ast.Expression{
+						eqCols("c0", "b_id", "b0", "id"),
+						&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "c0", Name: "kind"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "primary"}},
+					},
+				},
+			},
+		},
+		Where: &ast.Comparison{Left: &ast.ColumnRef{Qualifier: "a0", Name: "active"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: true}},
+		Limit: &limit,
+	}
+
+	wantArgs := []any{"active", "primary", true, int64(10)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres numbers each on then where then limit",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT * FROM "a" "a0" INNER JOIN "b" "b0" ON ("b0"."a_id" = "a0"."id" AND "b0"."status" = $1) LEFT JOIN "c" "c0" ON ("c0"."b_id" = "b0"."id" AND "c0"."kind" = $2) WHERE "a0"."active" = $3 LIMIT $4`,
+		},
+		{
+			name:    "mysql keeps the order with question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT * FROM `a` `a0` INNER JOIN `b` `b0` ON (`b0`.`a_id` = `a0`.`id` AND `b0`.`status` = ?) LEFT JOIN `c` `c0` ON (`c0`.`b_id` = `b0`.`id` AND `c0`.`kind` = ?) WHERE `a0`.`active` = ? LIMIT ?",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
 func TestRenderSelect_JoinErrors(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/select_join_test.go
+++ b/core/renderer/select_join_test.go
@@ -1,0 +1,396 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+// eqCols builds a "left = right" comparison of two qualified columns, the shape
+// of an equi-join ON condition.
+func eqCols(lq, ln, rq, rn string) *ast.Comparison {
+	return &ast.Comparison{
+		Left:     &ast.ColumnRef{Qualifier: lq, Name: ln},
+		Operator: ast.OpEqual,
+		Right:    &ast.ColumnRef{Qualifier: rq, Name: rn},
+	}
+}
+
+// twoTableJoin exercises an aliased FROM, one INNER JOIN, and qualified columns
+// in the projection, ON, WHERE, and ORDER BY clauses at once.
+func twoTableJoin() *ast.SelectStatement {
+	limit := int64(5)
+	return &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Qualifier: "u", Name: "id"},
+			{Qualifier: "u", Name: "name"},
+			{Qualifier: "o", Name: "total"},
+		},
+		From:      "users",
+		FromAlias: "u",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: "orders", Alias: "o", On: eqCols("o", "user_id", "u", "id")},
+		},
+		Where: &ast.LogicalExpr{
+			Operator: ast.LogicalAnd,
+			Operands: []ast.Expression{
+				&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "o", Name: "status"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "paid"}},
+				&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "u", Name: "active"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: true}},
+			},
+		},
+		OrderBy: []ast.OrderByClause{
+			{Qualifier: "u", Column: "name", Direction: ast.SortAscending},
+			{Qualifier: "o", Column: "total", Direction: ast.SortDescending},
+		},
+		Limit: &limit,
+	}
+}
+
+func TestRenderSelect_TwoTableJoin(t *testing.T) {
+	c := qt.New(t)
+
+	wantArgs := []any{"paid", true, int64(5)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres qualifies with double quotes and dollar placeholders",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "u"."id", "u"."name", "o"."total" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" WHERE ("o"."status" = $1 AND "u"."active" = $2) ORDER BY "u"."name" ASC, "o"."total" DESC LIMIT $3`,
+		},
+		{
+			name:    "mysql qualifies with backticks and question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `u`.`id`, `u`.`name`, `o`.`total` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id` WHERE (`o`.`status` = ? AND `u`.`active` = ?) ORDER BY `u`.`name` ASC, `o`.`total` DESC LIMIT ?",
+		},
+		{
+			name:    "mariadb matches mysql",
+			dialect: platform.MariaDB,
+			wantSQL: "SELECT `u`.`id`, `u`.`name`, `o`.`total` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id` WHERE (`o`.`status` = ? AND `u`.`active` = ?) ORDER BY `u`.`name` ASC, `o`.`total` DESC LIMIT ?",
+		},
+		{
+			name:    "sqlite qualifies with double quotes and question placeholders",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT "u"."id", "u"."name", "o"."total" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" WHERE ("o"."status" = ? AND "u"."active" = ?) ORDER BY "u"."name" ASC, "o"."total" DESC LIMIT ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(twoTableJoin(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+// threeTableJoin chains an INNER JOIN and a LEFT JOIN so the joins render in
+// declared order.
+func threeTableJoin() *ast.SelectStatement {
+	return &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Qualifier: "u", Name: "name"},
+			{Qualifier: "o", Name: "id"},
+			{Qualifier: "p", Name: "amount"},
+		},
+		From:      "users",
+		FromAlias: "u",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: "orders", Alias: "o", On: eqCols("o", "user_id", "u", "id")},
+			{Type: ast.JoinLeft, Table: "payments", Alias: "p", On: eqCols("p", "order_id", "o", "id")},
+		},
+		Where:   &ast.Comparison{Left: &ast.ColumnRef{Qualifier: "o", Name: "status"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "paid"}},
+		OrderBy: []ast.OrderByClause{{Qualifier: "o", Column: "id", Direction: ast.SortAscending}},
+	}
+}
+
+func TestRenderSelect_ThreeTableJoin(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "u"."name", "o"."id", "p"."amount" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" LEFT JOIN "payments" "p" ON "p"."order_id" = "o"."id" WHERE "o"."status" = $1 ORDER BY "o"."id" ASC`,
+		},
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `u`.`name`, `o`.`id`, `p`.`amount` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id` LEFT JOIN `payments` `p` ON `p`.`order_id` = `o`.`id` WHERE `o`.`status` = ? ORDER BY `o`.`id` ASC",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(threeTableJoin(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{"paid"})
+		})
+	}
+}
+
+func TestRenderSelect_JoinTypeKeywords(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		joinType ast.JoinType
+		wantSQL  string
+	}{
+		{name: "inner", joinType: ast.JoinInner, wantSQL: `SELECT * FROM "a" INNER JOIN "b" ON "b"."a_id" = "a"."id"`},
+		{name: "left", joinType: ast.JoinLeft, wantSQL: `SELECT * FROM "a" LEFT JOIN "b" ON "b"."a_id" = "a"."id"`},
+		{name: "right", joinType: ast.JoinRight, wantSQL: `SELECT * FROM "a" RIGHT JOIN "b" ON "b"."a_id" = "a"."id"`},
+		{name: "full", joinType: ast.JoinFull, wantSQL: `SELECT * FROM "a" FULL OUTER JOIN "b" ON "b"."a_id" = "a"."id"`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From: "a",
+				Joins: []ast.JoinClause{
+					{Type: tt.joinType, Table: "b", On: eqCols("b", "a_id", "a", "id")},
+				},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_JoinWithoutAliasUsesTableNameQualifier(t *testing.T) {
+	c := qt.New(t)
+
+	// An unaliased join renders the bare table name and callers qualify columns
+	// by the table name itself.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Qualifier: "orders", Name: "total"}},
+		From:    "users",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: "orders", On: eqCols("orders", "user_id", "users", "id")},
+		},
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "orders"."total" FROM "users" INNER JOIN "orders" ON "orders"."user_id" = "users"."id"`)
+	c.Assert(args, qt.HasLen, 0)
+}
+
+func TestRenderSelect_JoinAliasAndQualifierQuoteEscaping(t *testing.T) {
+	c := qt.New(t)
+
+	// A quote-bearing FROM alias, join alias, and column qualifier are all
+	// escaped by doubling the dialect quote character, so none can break out.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Qualifier: `a"x`, Name: `c"d`}},
+		From:    "t",
+		// FromAlias intentionally omitted here; the join alias carries the payload.
+		Joins: []ast.JoinClause{
+			{
+				Type:  ast.JoinInner,
+				Table: "u",
+				Alias: `b"y`,
+				On:    eqCols(`b"y`, "id", `a"x`, "uid"),
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres doubles embedded double quotes",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "a""x"."c""d" FROM "t" INNER JOIN "u" "b""y" ON "b""y"."id" = "a""x"."uid"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_FromAliasQuoteEscaping(t *testing.T) {
+	c := qt.New(t)
+
+	// A backtick-bearing FROM alias is escaped for MySQL by doubling the backtick.
+	stmt := &ast.SelectStatement{
+		From:      "t",
+		FromAlias: "a`x",
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.MySQL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, "SELECT * FROM `t` `a``x`")
+	c.Assert(args, qt.HasLen, 0)
+}
+
+func TestRenderSelect_JoinPlaceholderOrderingAcrossOnWhereLimit(t *testing.T) {
+	c := qt.New(t)
+
+	// A bound value inside the JOIN ON is numbered before the WHERE value, which
+	// is numbered before the LIMIT bound, proving placeholders follow render
+	// order across ON, WHERE, and LIMIT.
+	limit := int64(10)
+	stmt := &ast.SelectStatement{
+		From:      "orders",
+		FromAlias: "o",
+		Joins: []ast.JoinClause{
+			{
+				Type:  ast.JoinInner,
+				Table: "users",
+				Alias: "u",
+				On: &ast.LogicalExpr{
+					Operator: ast.LogicalAnd,
+					Operands: []ast.Expression{
+						eqCols("u", "id", "o", "user_id"),
+						&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "u", Name: "status"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "active"}},
+					},
+				},
+			},
+		},
+		Where: &ast.Comparison{Left: &ast.ColumnRef{Qualifier: "o", Name: "total"}, Operator: ast.OpGreaterThan, Right: &ast.BoundValue{Value: int64(100)}},
+		Limit: &limit,
+	}
+
+	wantArgs := []any{"active", int64(100), int64(10)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres numbers on then where then limit",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT * FROM "orders" "o" INNER JOIN "users" "u" ON ("u"."id" = "o"."user_id" AND "u"."status" = $1) WHERE "o"."total" > $2 LIMIT $3`,
+		},
+		{
+			name:    "mysql keeps the same order with question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT * FROM `orders` `o` INNER JOIN `users` `u` ON (`u`.`id` = `o`.`user_id` AND `u`.`status` = ?) WHERE `o`.`total` > ? LIMIT ?",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderSelect_SQLiteAcceptsInnerAndLeftJoin(t *testing.T) {
+	c := qt.New(t)
+
+	// INNER and LEFT joins are supported by every SQLite version.
+	tests := []struct {
+		name     string
+		joinType ast.JoinType
+		wantSQL  string
+	}{
+		{name: "inner", joinType: ast.JoinInner, wantSQL: `SELECT * FROM "a" INNER JOIN "b" ON "b"."a_id" = "a"."id"`},
+		{name: "left", joinType: ast.JoinLeft, wantSQL: `SELECT * FROM "a" LEFT JOIN "b" ON "b"."a_id" = "a"."id"`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From:  "a",
+				Joins: []ast.JoinClause{{Type: tt.joinType, Table: "b", On: eqCols("b", "a_id", "a", "id")}},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, platform.SQLite)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_SQLiteRejectsRightAndFullJoin(t *testing.T) {
+	c := qt.New(t)
+
+	// SQLite gained RIGHT and FULL joins only in 3.39; the renderer rejects them
+	// rather than emit SQL that fails at execution time on an older engine.
+	tests := []struct {
+		name        string
+		joinType    ast.JoinType
+		wantErrLike string
+	}{
+		{name: "right", joinType: ast.JoinRight, wantErrLike: "renderer: SQLite does not support RIGHT JOIN"},
+		{name: "full", joinType: ast.JoinFull, wantErrLike: "renderer: SQLite does not support FULL OUTER JOIN"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{
+				From:  "a",
+				Joins: []ast.JoinClause{{Type: tt.joinType, Table: "b", On: eqCols("b", "a_id", "a", "id")}},
+			}
+			sql, args, err := renderer.RenderSelect(stmt, platform.SQLite)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+func TestRenderSelect_JoinErrors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		join        ast.JoinClause
+		wantErrLike string
+	}{
+		{
+			name:        "missing table",
+			join:        ast.JoinClause{Type: ast.JoinInner, On: eqCols("b", "a_id", "a", "id")},
+			wantErrLike: "renderer: join requires a table",
+		},
+		{
+			name:        "nil on condition",
+			join:        ast.JoinClause{Type: ast.JoinInner, Table: "b"},
+			wantErrLike: "renderer: join requires an ON condition",
+		},
+		{
+			name:        "unknown join type",
+			join:        ast.JoinClause{Type: ast.JoinType(42), Table: "b", On: eqCols("b", "a_id", "a", "id")},
+			wantErrLike: "renderer: unknown join type 42",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := &ast.SelectStatement{From: "a", Joins: []ast.JoinClause{tt.join}}
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -162,6 +162,9 @@ type InExpr struct{ ... }
 type IndexNode struct{ ... }
     func NewIndex(name, table string, columns ...string) *IndexNode
 type IndexPart struct{ ... }
+type JoinClause struct{ ... }
+type JoinType int
+    const JoinInner JoinType = iota ...
 type LogicalExpr struct{ ... }
 type LogicalOperator int
     const LogicalAnd LogicalOperator = iota ...
@@ -539,6 +542,8 @@ func Lt(column string, value any) ast.Expression
 func Ne(column string, value any) ast.Expression
 func Not(expr ast.Expression) ast.Expression
 func Or(exprs ...ast.Expression) ast.Expression
+type Column struct{ ... }
+    func Col(qualifier, name string) Column
 type SelectBuilder struct{ ... }
     func Select(columns ...string) *SelectBuilder
 

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -8,22 +8,25 @@ statements. It is the DML counterpart to the DDL AST: a builder produces an
 `*ast.SelectStatement`, and `renderer.RenderSelect` turns that into a SQL string
 plus its positional arguments for PostgreSQL, MySQL, MariaDB, and SQLite.
 
-This is the first, bounded slice of the DML work in issue
+This is a bounded slice of the DML work in issue
 [`#98`](https://github.com/stokaro/ptah/issues/98). It exists so callers can stop
 hand-rolling dynamic `WHERE` / `ORDER BY` / `IN (…)` clauses with manual
 placeholder counters.
 
 ## Scope
 
-Implemented in this phase:
+Implemented so far:
 
-- single-table `SELECT` with an explicit column list or `*`;
-- a composable `WHERE` expression tree: `=`, `<>`, `<`, `<=`, `>`, `>=`, `IN`,
-  `IS NULL`, `IS NOT NULL`, and the boolean combinators `AND`, `OR`, `NOT`;
+- `SELECT` with an explicit column list or `*`;
+- `INNER`, `LEFT`, `RIGHT`, and `FULL OUTER` joins, with table aliases and
+  columns qualified by a table or alias (see [Joins](#joins));
+- a composable `WHERE` (and join `ON`) expression tree: `=`, `<>`, `<`, `<=`,
+  `>`, `>=`, `IN`, `IS NULL`, `IS NOT NULL`, and the boolean combinators `AND`,
+  `OR`, `NOT`;
 - `ORDER BY` with per-column `ASC`/`DESC`;
 - `LIMIT` and `OFFSET`.
 
-Not yet implemented (follow-up phases): `JOIN`, `GROUP BY`, `HAVING`, `DISTINCT`,
+Not yet implemented (follow-up phases): `GROUP BY`, `HAVING`, `DISTINCT`,
 subqueries, function calls, arithmetic, `LIKE`, and the `INSERT`/`UPDATE`/
 `DELETE` family.
 
@@ -109,19 +112,78 @@ total := query.Select("id").From("commodities").
 	Where(filter).Build()
 ```
 
+## Joins
+
+Alias the source table with `FromAs`, add joins with `InnerJoin`, `LeftJoin`,
+`RightJoin`, or `FullJoin`, and qualify columns with `Col` so they render as
+`"alias"."col"`. A qualified column works everywhere a column is accepted: the
+projection (via `.Columns`), the join `ON` condition, `WHERE`, and `ORDER BY`.
+
+A join `ON` is an ordinary expression, so an equi-join is
+`Col(left).EqCol(Col(right))` and richer predicates compose with `And`, `Or`, and
+`Not`. `Col(table, name)` also carries the comparison helpers (`Eq`, `Ne`, `Lt`,
+`Le`, `Gt`, `Ge`, `IsNull`, `IsNotNull`) and the ordering helpers (`Asc`, `Desc`)
+for the qualified column.
+
+```go
+stmt := query.Select().
+	Columns(query.Col("u", "id"), query.Col("u", "name"), query.Col("o", "total")).
+	FromAs("users", "u").
+	InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+	Where(query.And(
+		query.Col("o", "status").Eq("paid"),
+		query.Col("u", "active").Eq(true),
+	)).
+	OrderBy(query.Col("u", "name").Asc()).
+	Limit(20).
+	Build()
+
+sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+```
+
+The PostgreSQL output is:
+
+```sql
+SELECT "u"."id", "u"."name", "o"."total"
+FROM "users" "u"
+INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"
+WHERE ("o"."status" = $1 AND "u"."active" = $2)
+ORDER BY "u"."name" ASC
+LIMIT $3
+```
+
+with `args` equal to `[]any{"paid", true, int64(20)}`. Tables render as
+`table alias` (no `AS`), which every supported dialect accepts. A value inside a
+join `ON` is bound **before** any `WHERE` value, because joins render first — so
+placeholder numbering still follows left-to-right emission order across `ON`,
+`WHERE`, and `LIMIT`/`OFFSET`.
+
+### SQLite and RIGHT / FULL joins
+
+SQLite gained `RIGHT` and `FULL OUTER JOIN` only in version 3.39 (2022). Because
+Ptah targets a range of SQLite versions and cannot assume 3.39+, `RenderSelect`
+returns an error for a `RIGHT` or `FULL` join on SQLite rather than emit SQL that
+fails at execution time on an older engine. `INNER` and `LEFT` joins are accepted
+on every dialect. On PostgreSQL, MySQL, and MariaDB all four join types render.
+
 ## Builder reference
 
 | Function | Result |
 | --- | --- |
 | `Select(cols ...string)` | Start a builder; `"*"` or no columns selects all. |
-| `.From(table)` | Set the single source table (required). |
+| `.Columns(cols ...Column)` | Append qualified columns (from `Col`) to the projection. |
+| `.From(table)` | Set the source table (required); clears any alias. |
+| `.FromAs(table, alias)` | Set the source table with an alias. |
+| `.InnerJoin` / `.LeftJoin` / `.RightJoin` / `.FullJoin` `(table, alias, on)` | Append a join with an `ON` condition. |
 | `.Where(expr)` | Set the filter expression; a later call replaces the earlier one. |
 | `.OrderBy(terms ...)` | Append sort terms across calls. |
 | `.Limit(n)` / `.Offset(n)` | Set bound row limit/offset. |
 | `.Build()` | Produce the `*ast.SelectStatement`. |
 
 Expression helpers: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `In`, `IsNull`,
-`IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`.
+`IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`. Qualified
+columns: `Col(table, name)`, with `.Eq`/`.Ne`/`.Lt`/`.Le`/`.Gt`/`.Ge`,
+`.EqCol` (column-to-column, for `ON`), `.IsNull`/`.IsNotNull`, and `.Asc`/`.Desc`.
 
 `renderer.RenderSelect(stmt, dialect)` returns `(sql string, args []any, err error)`.
 It returns an error for an unsupported dialect, a missing `FROM` table, an empty

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -158,13 +158,27 @@ join `ON` is bound **before** any `WHERE` value, because joins render first — 
 placeholder numbering still follows left-to-right emission order across `ON`,
 `WHERE`, and `LIMIT`/`OFFSET`.
 
-### SQLite and RIGHT / FULL joins
+### Join-type support by dialect
 
-SQLite gained `RIGHT` and `FULL OUTER JOIN` only in version 3.39 (2022). Because
-Ptah targets a range of SQLite versions and cannot assume 3.39+, `RenderSelect`
-returns an error for a `RIGHT` or `FULL` join on SQLite rather than emit SQL that
-fails at execution time on an older engine. `INNER` and `LEFT` joins are accepted
-on every dialect. On PostgreSQL, MySQL, and MariaDB all four join types render.
+Not every dialect can express every join type. `RenderSelect` rejects an
+unsupported join at render time — returning a clear error — rather than emit SQL
+that fails at execution time against the database.
+
+| Join type | PostgreSQL family | MySQL / MariaDB | SQLite |
+| --- | --- | --- | --- |
+| `INNER` | yes | yes | yes |
+| `LEFT` | yes | yes | yes |
+| `RIGHT` | yes | yes | no (added in 3.39) |
+| `FULL OUTER` | yes | no (never supported) | no (added in 3.39) |
+
+- **SQLite** gained `RIGHT` and `FULL OUTER JOIN` only in version 3.39 (2022).
+  Because Ptah targets a range of SQLite versions and cannot assume 3.39+, both
+  are rejected (`renderer: SQLite does not support RIGHT JOIN`).
+- **MySQL and MariaDB** have no `FULL [OUTER] JOIN` in any version — it must be
+  emulated with a `UNION` of a `LEFT` and a `RIGHT` join — so `FULL` is rejected
+  (`renderer: mysql does not support FULL OUTER JOIN`). `RIGHT` renders normally.
+- The **PostgreSQL family** (including CockroachDB and YugabyteDB) supports all
+  four.
 
 ## Builder reference
 

--- a/docs/site/src/content/docs/reference/reusable-components.md
+++ b/docs/site/src/content/docs/reference/reusable-components.md
@@ -70,11 +70,12 @@ triggers, row-level security policies, roles, grants, and routine placeholders
 where supported. It is not a full SQL parser for every dialect-specific
 sub-language.
 
-DML query building has a first, bounded slice: `core/query` builds
-parameterized single-table `SELECT` statements with a composable `WHERE`
-expression tree, `ORDER BY`, and `LIMIT`/`OFFSET`, rendered through
-`renderer.RenderSelect`. `JOIN`, `GROUP BY`, `HAVING`, subqueries, and the
-`INSERT`/`UPDATE`/`DELETE` family are follow-up phases of issue
+DML query building has a bounded slice: `core/query` builds parameterized
+`SELECT` statements with `INNER`/`LEFT`/`RIGHT`/`FULL OUTER` joins, table aliases
+and qualified columns, a composable `WHERE` (and join `ON`) expression tree,
+`ORDER BY`, and `LIMIT`/`OFFSET`, rendered through `renderer.RenderSelect`.
+`GROUP BY`, `HAVING`, subqueries, and the `INSERT`/`UPDATE`/`DELETE` family are
+follow-up phases of issue
 [`#98`](https://github.com/stokaro/ptah/issues/98). See the
 [Query Builder](../query-builder/) reference for the full API.
 


### PR DESCRIPTION
## Summary

Phase 2 of the DML query builder (#98): adds JOINs to the Phase 1 `SELECT`
builder, which required table aliases and qualified column references to be
useful. Builds directly on the merged Phase 1 (`core/ast/select.go`,
`core/query`, `core/renderer/select.go`) and extends the same packages.

Phase 1 remains fully intact. GROUP BY, HAVING, subqueries, and
INSERT/UPDATE/DELETE are still deferred to later phases.

## Backward compatibility

All changes are **additive** — no Phase 1 signature changed and the rendered
output for join-less queries is byte-for-byte identical. `apidiff` against the
Phase 1 baseline reports only *Compatible changes* for `core/ast`, `core/query`,
and `core/renderer`; the existing Phase 1 tests pass unmodified.

- The FROM alias is a new `SelectStatement.FromAlias string` field (not a change
  to `From string`), so `From: "t"` callers are untouched.
- Column qualifiers are new optional `Qualifier string` fields on `ColumnRef`,
  `ResultColumn`, and `OrderByClause`; a zero qualifier renders exactly as before.

## AST (`core/ast/select.go`)

- `ColumnRef`, `ResultColumn`, `OrderByClause` gain an optional `Qualifier`, so a
  column renders as `"alias"."col"` with each part quoted independently.
- `SelectStatement` gains `FromAlias` and `Joins []JoinClause`.
- New `JoinType` (`JoinInner`, `JoinLeft`, `JoinRight`, `JoinFull`) with a
  `String()` that yields `INNER JOIN` / `LEFT JOIN` / `RIGHT JOIN` /
  `FULL OUTER JOIN`, and `JoinClause{Type, Table, Alias, On}`. The `On` condition
  reuses the existing `Expression` tree, so an equi-join is just a `Comparison`
  of two `ColumnRef` operands.

## Builder (`core/query`)

- `FromAs(table, alias)` aliases the source table; `From` still works and now
  clears any prior alias.
- `InnerJoin` / `LeftJoin` / `RightJoin` / `FullJoin(table, alias, on)` append
  joins.
- `Columns(cols ...Column)` projects qualified columns (mixable with bare ones),
  including a qualified star via `Col("u", "*")`.
- New `Column` type via `Col(table, name)`, with `.Eq/.Ne/.Lt/.Le/.Gt/.Ge`
  (column vs bound value), `.EqCol` (column vs column, for `ON`),
  `.IsNull/.IsNotNull`, and `.Asc/.Desc`. Phase 1's bare-string API
  (`Select("id")`, `Eq("col", v)`, `Asc("col")`) is unchanged.

```go
stmt := query.Select().
    Columns(query.Col("u", "id"), query.Col("u", "name"), query.Col("o", "total")).
    FromAs("users", "u").
    InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
    Where(query.And(
        query.Col("o", "status").Eq("paid"),
        query.Col("u", "active").Eq(true),
    )).
    OrderBy(query.Col("u", "name").Asc()).
    Limit(20).
    Build()

sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
// SELECT "u"."id", "u"."name", "o"."total" FROM "users" "u"
//   INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"
//   WHERE ("o"."status" = $1 AND "u"."active" = $2)
//   ORDER BY "u"."name" ASC LIMIT $3
// args: []any{"paid", true, int64(20)}
```

## Renderer (`core/renderer/select.go`)

- Joins render after FROM in declared order. Tables render as `"table" "alias"`
  (bare form, no `AS`) because every supported dialect accepts it. Qualified
  columns render `"alias"."col"`, each part quoted via `internal/sqlident` after
  trimming surrounding whitespace (matching `sqlident.Qualified`). A qualified
  star renders `"u".*`, never the invalid `"u"."*"`.
- **Per dialect:** identifiers use `"…"` for PostgreSQL/SQLite and backticks for
  MySQL/MariaDB; placeholders are `$N` for the PostgreSQL family and `?` for
  MySQL/MariaDB/SQLite.
- **Parameterization across ON + WHERE:** the `ON` condition goes through the
  same bound-parameter and quoting path as `WHERE`. Because joins render before
  `WHERE`, a value inside a JOIN `ON` is numbered before any `WHERE` value, which
  is numbered before `LIMIT`/`OFFSET` — a single left-to-right pass, correct for
  both `$N` and `?`. A two-joins-each-with-a-bound-ON test pins the exact order.

### Join-type support by dialect

Not every dialect can express every join type. `RenderSelect` rejects an
unsupported join **at render time** with a clear error, rather than emit SQL that
fails at execution time against the database.

| Join type | PostgreSQL family | MySQL / MariaDB | SQLite |
| --- | --- | --- | --- |
| `INNER` | yes | yes | yes |
| `LEFT` | yes | yes | yes |
| `RIGHT` | yes | yes | no (added in 3.39) |
| `FULL OUTER` | yes | **no** (never supported) | no (added in 3.39) |

- **SQLite** gained `RIGHT`/`FULL OUTER JOIN` only in 3.39 (2022); since Ptah
  targets a range of versions and cannot assume 3.39+, both are rejected.
- **MySQL / MariaDB** have no `FULL [OUTER] JOIN` in any version (it must be
  emulated with a `UNION` of a `LEFT` and a `RIGHT` join), so `FULL` is rejected;
  `RIGHT` renders normally.

## Tests

Table-driven, per-dialect black-box tests (quicktest): 2- and 3-table joins with
qualified columns in projection/ON/WHERE/ORDER BY; every join type; alias and
qualifier quote-escaping (double-quote and backtick payloads); the SQLite
RIGHT/FULL and MySQL/MariaDB FULL rejections (with RIGHT acceptance on
MySQL/MariaDB); qualified-star rendering; whitespace trimming of table/alias/
qualifier; placeholder ordering across two bound ONs + WHERE + LIMIT on both
`$N` and `?`; join error paths (missing table, nil ON, unknown type); and a
builder end-to-end test producing the same SQL as the hand-built AST.

## Verification

- `go build ./...`, `gofmt -l` clean, `go vet`, `go test ./...` (all 138
  packages) and `-race` on the changed packages — green.
- `golangci-lint run` on the changed packages — 0 issues.
- `qtlint ./...`, `teststyle` — OK.
- Public API: `check-public-api.sh` and `check-public-api-snapshot.sh` pass;
  snapshot is additive-only and unchanged by the review fixes (no signature
  changed); `apidiff` reports no incompatible changes.
- Docs: `query-builder.md` gains a Joins section and the per-dialect matrix;
  `reusable-components.md` and `doc.go` updated; docs-site `check:*` scripts pass.

## Follow-ups (deferred, purely additive)

- A fluent **qualified `IN`** — e.g. a package-level generic `ColIn[T any](c Column, values []T)`
  (a method can't carry its own type parameter, so it must be a free function).
  Phase 1's `In("col", []T)` still covers the unqualified case today.
- `GROUP BY`, `HAVING`, `DISTINCT`, subqueries, `LIKE`, and the
  `INSERT`/`UPDATE`/`DELETE` family remain later phases of #98.
