### PR TITLE
Add GROUP BY, HAVING, aggregates, and DISTINCT to DML query builder (Phase 3 of #98)

### DIFF
--- a/core/ast/select.go
+++ b/core/ast/select.go
@@ -9,11 +9,16 @@ package ast
 // Phase 1 modeled SELECT / WHERE / ORDER BY / LIMIT / OFFSET over a single
 // table. Phase 2 adds JOINs: a table alias on the FROM clause, an optional
 // qualifier on ColumnRef / ResultColumn / OrderByClause so a column can render
-// as "alias"."col", and a JoinClause list on SelectStatement. GROUP BY, HAVING,
-// DISTINCT, subqueries, functions, and arithmetic remain follow-up phases. The
-// types are shaped so those extensions slot in without breaking callers (for
-// example, Comparison takes Expression operands on both sides rather than a bare
-// column string, so a JOIN ON can compare two columns directly).
+// as "alias"."col", and a JoinClause list on SelectStatement. Phase 3 adds
+// DISTINCT, GROUP BY, HAVING, and aggregate functions: a Distinct flag, a
+// GroupBy column list, and a Having expression on SelectStatement; a general
+// FuncCall expression node for COUNT / SUM / AVG / MIN / MAX; and an optional
+// Expr (and Alias) on ResultColumn so a projection entry can be an expression
+// rather than a plain column. Non-aggregate functions, arithmetic, LIKE,
+// subqueries, and window functions remain follow-up phases. The types are shaped
+// so those extensions slot in without breaking callers (for example, Comparison
+// takes Expression operands on both sides rather than a bare column string, so a
+// HAVING can compare an aggregate against a bound value directly).
 
 // Expression is a boolean or scalar expression used in DML statements such as
 // the WHERE clause of a SELECT.
@@ -181,6 +186,37 @@ type NotExpr struct {
 
 func (*NotExpr) expressionNode() {}
 
+// FuncCall is a function-call expression, such as an aggregate: COUNT(*),
+// COUNT("col"), COUNT(DISTINCT "col"), or SUM("col"). It is shaped as a general
+// function call so non-aggregate functions can reuse it in a later phase.
+//
+// The function is usable anywhere an Expression is: in a projection (via
+// ResultColumn.Expr) and in a HAVING comparison (as an operand of Comparison).
+// Name is a bare SQL keyword emitted verbatim, never quoted and never bound — the
+// renderer rejects a Name that is not a simple identifier so a caller cannot
+// smuggle SQL through it. Args are ordinary expressions, so a column argument is
+// quoted through the identifier path and a value argument is bound as a
+// placeholder.
+type FuncCall struct {
+	// Name is the function name, emitted verbatim as a keyword. Required. It must
+	// be a simple identifier — a letter or underscore followed by letters, digits,
+	// or underscores — and the renderer rejects anything else rather than quote a
+	// function name.
+	Name string
+	// Args are the function arguments, each an expression. A column argument is
+	// quoted; a value argument is bound. Ignored when Star is true.
+	Args []Expression
+	// Star renders the argument list as a single "*", as in COUNT(*). When Star is
+	// true, Args must be empty and Distinct must be false; the renderer rejects
+	// either combination rather than emit invalid SQL.
+	Star bool
+	// Distinct emits the DISTINCT keyword before the arguments, as in
+	// COUNT(DISTINCT "col").
+	Distinct bool
+}
+
+func (*FuncCall) expressionNode() {}
+
 // SortDirection is the direction of an ORDER BY term.
 type SortDirection int
 
@@ -218,18 +254,28 @@ type OrderByClause struct {
 
 // ResultColumn is one entry in a SELECT projection.
 //
-// When Star is true the entry renders as "*" (select all columns) and Name and
-// Qualifier are ignored; otherwise Name renders as a dialect-quoted identifier,
-// prefixed by "Qualifier". when Qualifier is set.
+// When Expr is set the entry renders that expression (for example an aggregate)
+// and Qualifier, Name, and Star are ignored. Otherwise, when Star is true the
+// entry renders as "*" (select all columns) and Name and Qualifier are ignored;
+// otherwise Name renders as a dialect-quoted identifier, prefixed by
+// "Qualifier". when Qualifier is set. When Alias is set the entry is followed by
+// AS and the quoted alias. A zero ResultColumn leaves Expr nil and Alias empty,
+// so the Phase 1 and Phase 2 rendering is preserved unchanged.
 type ResultColumn struct {
+	// Expr is an optional projected expression, such as a FuncCall aggregate. When
+	// non-nil it is rendered instead of Qualifier, Name, and Star.
+	Expr Expression
 	// Qualifier is the optional table name or alias qualifying the column,
 	// quoted independently. An empty Qualifier renders a bare column name. It is
-	// ignored when Star is true.
+	// ignored when Star is true or Expr is set.
 	Qualifier string
-	// Name is the column name, used when Star is false.
+	// Name is the column name, used when Star is false and Expr is nil.
 	Name string
-	// Star selects all columns (SELECT *).
+	// Star selects all columns (SELECT *). Ignored when Expr is set.
 	Star bool
+	// Alias is an optional output-column alias, rendered as `AS "alias"` with the
+	// alias quoted independently. An empty Alias renders no alias.
+	Alias string
 }
 
 // JoinType enumerates the join kinds supported in Phase 2.
@@ -285,13 +331,16 @@ type JoinClause struct {
 }
 
 // SelectStatement is a SELECT over a source table and zero or more joins, with
-// an optional WHERE clause, ORDER BY terms, and LIMIT/OFFSET bounds.
+// an optional DISTINCT, WHERE clause, GROUP BY / HAVING, ORDER BY terms, and
+// LIMIT/OFFSET bounds.
 //
-// GROUP BY, HAVING, DISTINCT, subqueries, functions, and arithmetic are not
-// modeled yet. Render it with renderer.RenderSelect, which returns the SQL
-// string and its positional arguments. Build one fluently with the core/query
-// package.
+// Subqueries, non-aggregate functions, arithmetic, and window functions are not
+// modeled yet. Render it with renderer.RenderSelect, which returns the SQL string
+// and its positional arguments. Build one fluently with the core/query package.
 type SelectStatement struct {
+	// Distinct renders SELECT DISTINCT, deduplicating result rows. It defaults to
+	// false, so a zero statement renders a plain SELECT unchanged.
+	Distinct bool
 	// Columns is the projection. An empty slice renders as "*".
 	Columns []ResultColumn
 	// From is the source table, rendered as a quoted identifier. Required.
@@ -304,6 +353,14 @@ type SelectStatement struct {
 	Joins []JoinClause
 	// Where is the optional filter expression tree; nil means no WHERE clause.
 	Where Expression
+	// GroupBy is the optional list of GROUP BY columns, rendered after WHERE. Each
+	// column may be qualified. An empty slice renders no GROUP BY. Columns carry no
+	// bound values, so they do not affect placeholder numbering.
+	GroupBy []ColumnRef
+	// Having is the optional filter over grouped rows, rendered after GROUP BY; nil
+	// means no HAVING. Its bound values are numbered after the WHERE clause and
+	// before LIMIT/OFFSET.
+	Having Expression
 	// OrderBy is the optional list of sort terms, applied in order.
 	OrderBy []OrderByClause
 	// Limit is the optional row limit; nil means no LIMIT. The value is bound.

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -10,11 +10,13 @@
 // # Scope
 //
 // This package models a SELECT with a FROM table, INNER / LEFT / RIGHT / FULL
-// OUTER joins, a composable WHERE expression tree, ORDER BY, LIMIT, and OFFSET.
-// Tables can be aliased (FromAs and the alias argument of the join methods) and
-// columns can be qualified by a table or alias with Col, so a projection, WHERE,
-// join ON, or ORDER BY term can render as "alias"."col". GROUP BY, HAVING,
-// DISTINCT, subqueries, functions, arithmetic, and LIKE are intentionally not
+// OUTER joins, a composable WHERE expression tree, DISTINCT, GROUP BY, HAVING,
+// aggregate functions (COUNT / SUM / AVG / MIN / MAX), ORDER BY, LIMIT, and
+// OFFSET. Tables can be aliased (FromAs and the alias argument of the join
+// methods) and columns can be qualified by a table or alias with Col, so a
+// projection, WHERE, join ON, GROUP BY, HAVING, or ORDER BY term can render as
+// "alias"."col". Non-aggregate function calls, arithmetic, LIKE, subqueries,
+// window functions, and the INSERT / UPDATE / DELETE family are intentionally not
 // implemented yet and are tracked as follow-up phases.
 //
 // # Safety model
@@ -100,4 +102,35 @@
 // MySQL and MariaDB have no FULL OUTER JOIN in any version. In short, FULL OUTER
 // renders only on the PostgreSQL family; RIGHT renders everywhere except SQLite;
 // INNER and LEFT render on every supported dialect.
+//
+// # Aggregates, GROUP BY, and HAVING
+//
+// Distinct renders SELECT DISTINCT. GroupBy adds GROUP BY columns (qualified with
+// Col, or bare with Col("", name)). The aggregate constructors — CountStar,
+// Count, CountDistinct, Sum, Avg, Min, and Max, plus the matching methods on Col
+// for qualified columns — return expressions usable in two places: a projection
+// (via Exprs, or ExprAs to attach an AS alias) and a HAVING predicate. Because a
+// HAVING predicate compares an aggregate against a value, wrap the aggregate with
+// Expr to reach the comparison helpers: Expr(CountStar()).Gt(int64(5)).
+//
+//	stmt := query.Select("status").
+//		ExprAs(query.CountStar(), "n").
+//		From("orders").
+//		Where(query.Eq("tenant_id", tenantID)).
+//		GroupBy(query.Col("", "status")).
+//		Having(query.Expr(query.CountStar()).Gt(int64(5))).
+//		OrderBy(query.Asc("status")).
+//		Limit(10).
+//		Build()
+//
+//	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+//	// sql:  SELECT "status", COUNT(*) AS "n" FROM "orders" WHERE "tenant_id" = $1
+//	//       GROUP BY "status" HAVING COUNT(*) > $2 ORDER BY "status" ASC LIMIT $3
+//	// args: []any{tenantID, int64(5), int64(10)}
+//
+// GROUP BY carries only identifiers and binds nothing; a HAVING value is bound
+// after every WHERE value and before LIMIT/OFFSET, so placeholder numbering still
+// follows left-to-right emission order. A function name (COUNT, SUM, …) is a
+// keyword emitted verbatim and never quoted; the renderer rejects a name that is
+// not a simple identifier rather than emit it.
 package query

--- a/core/query/query.go
+++ b/core/query/query.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"strings"
+
 	"github.com/stokaro/ptah/core/ast"
 )
 
@@ -289,8 +291,14 @@ func CountStar() ast.Expression {
 }
 
 // Count builds COUNT("column"), counting the non-null values of a bare column.
-// Use Col(table, name).Count for a qualified column.
+// As a convenience, Count("*") is COUNT(*) — identical to CountStar — rather than
+// the invalid COUNT("*") over a column literally named "*". Use
+// Col(table, name).Count for a qualified column, and CountStar as the primary way
+// to count all rows.
 func Count(column string) ast.Expression {
+	if strings.TrimSpace(column) == "*" {
+		return CountStar()
+	}
 	return aggregate("COUNT", column)
 }
 

--- a/core/query/query.go
+++ b/core/query/query.go
@@ -10,11 +10,14 @@ import (
 // method mutates and returns the same builder for chaining. Build produces the
 // statement. Builders are not safe for concurrent use.
 type SelectBuilder struct {
+	distinct  bool
 	columns   []ast.ResultColumn
 	from      string
 	fromAlias string
 	joins     []ast.JoinClause
 	where     ast.Expression
+	groupBy   []ast.ColumnRef
+	having    ast.Expression
 	orderBy   []ast.OrderByClause
 	limit     *int64
 	offset    *int64
@@ -65,6 +68,30 @@ func (b *SelectBuilder) Columns(columns ...Column) *SelectBuilder {
 	return b
 }
 
+// Distinct renders the query as SELECT DISTINCT, deduplicating result rows.
+func (b *SelectBuilder) Distinct() *SelectBuilder {
+	b.distinct = true
+	return b
+}
+
+// Exprs appends expression projection entries — typically aggregates built with
+// Count, Sum, and friends — to the SELECT list, in the order given across calls.
+// Use ExprAs to attach an output-column alias.
+func (b *SelectBuilder) Exprs(exprs ...ast.Expression) *SelectBuilder {
+	for _, expr := range exprs {
+		b.columns = append(b.columns, ast.ResultColumn{Expr: expr})
+	}
+	return b
+}
+
+// ExprAs appends a single expression projection entry with an output-column
+// alias, rendering as `<expr> AS "alias"`. It is the aliased counterpart to
+// Exprs, for example ExprAs(query.CountStar(), "n") to project COUNT(*) AS "n".
+func (b *SelectBuilder) ExprAs(expr ast.Expression, alias string) *SelectBuilder {
+	b.columns = append(b.columns, ast.ResultColumn{Expr: expr, Alias: alias})
+	return b
+}
+
 // InnerJoin appends an INNER JOIN of table (with an optional alias) on the given
 // condition. Build the condition from qualified columns, for example
 // Col("o", "user_id").EqCol(Col("u", "id")). An empty alias joins the bare table.
@@ -109,6 +136,25 @@ func (b *SelectBuilder) Where(expr ast.Expression) *SelectBuilder {
 	return b
 }
 
+// GroupBy appends GROUP BY columns, in the order given across calls. Build each
+// column with Col: Col(table, name) for a qualified column across joins, or
+// Col("", name) for a bare column. GROUP BY carries no bound values.
+func (b *SelectBuilder) GroupBy(columns ...Column) *SelectBuilder {
+	for _, col := range columns {
+		b.groupBy = append(b.groupBy, *col.columnRef())
+	}
+	return b
+}
+
+// Having sets the HAVING filter over grouped rows. Its bound values are numbered
+// after the WHERE clause. Calling Having again replaces the previous expression;
+// compare an aggregate against a bound value with Expr, for example
+// Expr(query.CountStar()).Gt(int64(5)), and compose with And, Or, and Not.
+func (b *SelectBuilder) Having(expr ast.Expression) *SelectBuilder {
+	b.having = expr
+	return b
+}
+
 // OrderBy appends sort terms, applied in the order given across calls. Use Asc
 // and Desc to build terms.
 func (b *SelectBuilder) OrderBy(terms ...ast.OrderByClause) *SelectBuilder {
@@ -134,11 +180,14 @@ func (b *SelectBuilder) Offset(n int64) *SelectBuilder {
 // renderer.RenderSelect.
 func (b *SelectBuilder) Build() *ast.SelectStatement {
 	return &ast.SelectStatement{
+		Distinct:  b.distinct,
 		Columns:   b.columns,
 		From:      b.from,
 		FromAlias: b.fromAlias,
 		Joins:     b.joins,
 		Where:     b.where,
+		GroupBy:   b.groupBy,
+		Having:    b.having,
 		OrderBy:   b.orderBy,
 		Limit:     b.limit,
 		Offset:    b.offset,
@@ -226,6 +275,81 @@ func Or(exprs ...ast.Expression) ast.Expression {
 func Not(expr ast.Expression) ast.Expression {
 	return &ast.NotExpr{Operand: expr}
 }
+
+// aggregate builds a single-argument aggregate function call over a bare column,
+// as in SUM("column"). It backs the bare-column aggregate constructors.
+func aggregate(name, column string) ast.Expression {
+	return &ast.FuncCall{Name: name, Args: []ast.Expression{&ast.ColumnRef{Name: column}}}
+}
+
+// CountStar builds the COUNT(*) aggregate, counting all rows. It is usable in a
+// projection (via Exprs or ExprAs) and in a HAVING comparison (via Expr).
+func CountStar() ast.Expression {
+	return &ast.FuncCall{Name: "COUNT", Star: true}
+}
+
+// Count builds COUNT("column"), counting the non-null values of a bare column.
+// Use Col(table, name).Count for a qualified column.
+func Count(column string) ast.Expression {
+	return aggregate("COUNT", column)
+}
+
+// CountDistinct builds COUNT(DISTINCT "column") over a bare column. Use
+// Col(table, name).CountDistinct for a qualified column.
+func CountDistinct(column string) ast.Expression {
+	return &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{&ast.ColumnRef{Name: column}}, Distinct: true}
+}
+
+// Sum builds SUM("column") over a bare column.
+func Sum(column string) ast.Expression { return aggregate("SUM", column) }
+
+// Avg builds AVG("column") over a bare column.
+func Avg(column string) ast.Expression { return aggregate("AVG", column) }
+
+// Min builds MIN("column") over a bare column.
+func Min(column string) ast.Expression { return aggregate("MIN", column) }
+
+// Max builds MAX("column") over a bare column.
+func Max(column string) ast.Expression { return aggregate("MAX", column) }
+
+// ExprCompare adapts an expression — typically an aggregate produced by Count,
+// Sum, and friends — so it can be compared against a bound value, the usual shape
+// of a HAVING predicate. Build one with Expr. It mirrors the comparison helpers
+// on Column, but its left operand is any expression rather than a column.
+type ExprCompare struct {
+	left ast.Expression
+}
+
+// Expr wraps an expression so it can be compared against a bound value with the
+// methods on ExprCompare, for example Expr(query.CountStar()).Gt(int64(5)) as a
+// HAVING predicate. The result composes with And, Or, and Not like any other
+// expression.
+func Expr(left ast.Expression) ExprCompare {
+	return ExprCompare{left: left}
+}
+
+// compare builds "expr <op> value" with the value bound as a parameter.
+func (e ExprCompare) compare(op ast.ComparisonOperator, value any) ast.Expression {
+	return &ast.Comparison{Left: e.left, Operator: op, Right: &ast.BoundValue{Value: value}}
+}
+
+// Eq builds "expr = value", binding value as a parameter.
+func (e ExprCompare) Eq(value any) ast.Expression { return e.compare(ast.OpEqual, value) }
+
+// Ne builds "expr <> value", binding value as a parameter.
+func (e ExprCompare) Ne(value any) ast.Expression { return e.compare(ast.OpNotEqual, value) }
+
+// Lt builds "expr < value", binding value as a parameter.
+func (e ExprCompare) Lt(value any) ast.Expression { return e.compare(ast.OpLessThan, value) }
+
+// Le builds "expr <= value", binding value as a parameter.
+func (e ExprCompare) Le(value any) ast.Expression { return e.compare(ast.OpLessThanOrEqual, value) }
+
+// Gt builds "expr > value", binding value as a parameter.
+func (e ExprCompare) Gt(value any) ast.Expression { return e.compare(ast.OpGreaterThan, value) }
+
+// Ge builds "expr >= value", binding value as a parameter.
+func (e ExprCompare) Ge(value any) ast.Expression { return e.compare(ast.OpGreaterThanOrEqual, value) }
 
 // Asc builds an ascending ORDER BY term for column.
 func Asc(column string) ast.OrderByClause {
@@ -324,3 +448,31 @@ func (c Column) Asc() ast.OrderByClause {
 func (c Column) Desc() ast.OrderByClause {
 	return ast.OrderByClause{Qualifier: c.qualifier, Column: c.name, Direction: ast.SortDescending}
 }
+
+// aggregate builds a single-argument aggregate function call over the qualified
+// column, as in SUM("u"."total"). It backs the qualified-column aggregate
+// methods.
+func (c Column) aggregate(name string) ast.Expression {
+	return &ast.FuncCall{Name: name, Args: []ast.Expression{c.columnRef()}}
+}
+
+// Count builds COUNT over the qualified column, as in COUNT("u"."id").
+func (c Column) Count() ast.Expression { return c.aggregate("COUNT") }
+
+// CountDistinct builds COUNT(DISTINCT …) over the qualified column, as in
+// COUNT(DISTINCT "u"."id").
+func (c Column) CountDistinct() ast.Expression {
+	return &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{c.columnRef()}, Distinct: true}
+}
+
+// Sum builds SUM over the qualified column, as in SUM("o"."total").
+func (c Column) Sum() ast.Expression { return c.aggregate("SUM") }
+
+// Avg builds AVG over the qualified column.
+func (c Column) Avg() ast.Expression { return c.aggregate("AVG") }
+
+// Min builds MIN over the qualified column.
+func (c Column) Min() ast.Expression { return c.aggregate("MIN") }
+
+// Max builds MAX over the qualified column.
+func (c Column) Max() ast.Expression { return c.aggregate("MAX") }

--- a/core/query/query_groupby_test.go
+++ b/core/query/query_groupby_test.go
@@ -1,0 +1,215 @@
+package query_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/query"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+// renderProjection renders "SELECT <expr> FROM t" for PostgreSQL and returns the
+// observable SQL and args, so aggregate constructors can be asserted through the
+// public rendering contract rather than the internal node shape.
+func renderProjection(c *qt.C, expr ast.Expression) (string, []any) {
+	c.Helper()
+	stmt := query.Select().Exprs(expr).From("t").Build()
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	return sql, args
+}
+
+func TestAggregateConstructors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		expr    ast.Expression
+		wantSQL string
+	}{
+		{name: "count star", expr: query.CountStar(), wantSQL: `SELECT COUNT(*) FROM "t"`},
+		{name: "count", expr: query.Count("id"), wantSQL: `SELECT COUNT("id") FROM "t"`},
+		{name: "count distinct", expr: query.CountDistinct("status"), wantSQL: `SELECT COUNT(DISTINCT "status") FROM "t"`},
+		{name: "sum", expr: query.Sum("total"), wantSQL: `SELECT SUM("total") FROM "t"`},
+		{name: "avg", expr: query.Avg("total"), wantSQL: `SELECT AVG("total") FROM "t"`},
+		{name: "min", expr: query.Min("total"), wantSQL: `SELECT MIN("total") FROM "t"`},
+		{name: "max", expr: query.Max("total"), wantSQL: `SELECT MAX("total") FROM "t"`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args := renderProjection(c, tt.expr)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestColumnAggregateMethods(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		expr    ast.Expression
+		wantSQL string
+	}{
+		{name: "count", expr: query.Col("u", "id").Count(), wantSQL: `SELECT COUNT("u"."id") FROM "t"`},
+		{name: "count distinct", expr: query.Col("u", "id").CountDistinct(), wantSQL: `SELECT COUNT(DISTINCT "u"."id") FROM "t"`},
+		{name: "sum", expr: query.Col("o", "total").Sum(), wantSQL: `SELECT SUM("o"."total") FROM "t"`},
+		{name: "avg", expr: query.Col("o", "total").Avg(), wantSQL: `SELECT AVG("o"."total") FROM "t"`},
+		{name: "min", expr: query.Col("o", "total").Min(), wantSQL: `SELECT MIN("o"."total") FROM "t"`},
+		{name: "max", expr: query.Col("o", "total").Max(), wantSQL: `SELECT MAX("o"."total") FROM "t"`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args := renderProjection(c, tt.expr)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestExprComparison(t *testing.T) {
+	c := qt.New(t)
+
+	// Expr wraps an aggregate so it can be compared against a bound value, the
+	// shape of a HAVING predicate. The value is always bound, never inlined.
+	tests := []struct {
+		name    string
+		expr    ast.Expression
+		wantSQL string
+	}{
+		{name: "eq", expr: query.Expr(query.CountStar()).Eq(int64(5)), wantSQL: `SELECT * FROM "t" WHERE COUNT(*) = $1`},
+		{name: "ne", expr: query.Expr(query.CountStar()).Ne(int64(5)), wantSQL: `SELECT * FROM "t" WHERE COUNT(*) <> $1`},
+		{name: "lt", expr: query.Expr(query.Sum("total")).Lt(int64(5)), wantSQL: `SELECT * FROM "t" WHERE SUM("total") < $1`},
+		{name: "le", expr: query.Expr(query.Sum("total")).Le(int64(5)), wantSQL: `SELECT * FROM "t" WHERE SUM("total") <= $1`},
+		{name: "gt", expr: query.Expr(query.CountStar()).Gt(int64(5)), wantSQL: `SELECT * FROM "t" WHERE COUNT(*) > $1`},
+		{name: "ge", expr: query.Expr(query.Avg("total")).Ge(int64(5)), wantSQL: `SELECT * FROM "t" WHERE AVG("total") >= $1`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args := renderWhere(c, tt.expr)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{int64(5)})
+		})
+	}
+}
+
+func TestSelectBuilder_Distinct(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := query.Select("status").Distinct().From("orders").Build()
+	c.Assert(stmt.Distinct, qt.IsTrue)
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT DISTINCT "status" FROM "orders"`)
+	c.Assert(args, qt.HasLen, 0)
+}
+
+func TestSelectBuilder_GroupBy(t *testing.T) {
+	c := qt.New(t)
+
+	// GroupBy accepts qualified columns and, via an empty qualifier, bare columns;
+	// both accumulate in order across calls.
+	stmt := query.Select("*").
+		From("orders").
+		GroupBy(query.Col("", "status")).
+		GroupBy(query.Col("o", "kind")).
+		Build()
+
+	c.Assert(stmt.GroupBy, qt.DeepEquals, []ast.ColumnRef{
+		{Name: "status"},
+		{Qualifier: "o", Name: "kind"},
+	})
+}
+
+func TestSelectBuilder_ExprsAndExprAs(t *testing.T) {
+	c := qt.New(t)
+
+	// Exprs projects expressions without an alias; ExprAs attaches one. Both append
+	// after any columns already selected.
+	stmt := query.Select().
+		Columns(query.Col("", "status")).
+		Exprs(query.Sum("total")).
+		ExprAs(query.CountStar(), "n").
+		From("orders").
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "status", SUM("total"), COUNT(*) AS "n" FROM "orders"`)
+	c.Assert(args, qt.HasLen, 0)
+}
+
+func TestSelectBuilder_GroupByHavingEndToEnd(t *testing.T) {
+	c := qt.New(t)
+
+	// A grouped aggregate query with a WHERE filter, a HAVING over COUNT(*), and a
+	// LIMIT, proving the fluent API composes and placeholders order across clauses.
+	stmt := query.Select("status").
+		ExprAs(query.CountStar(), "n").
+		From("orders").
+		Where(query.Eq("tenant_id", "acme")).
+		GroupBy(query.Col("", "status")).
+		Having(query.Expr(query.CountStar()).Gt(int64(5))).
+		OrderBy(query.Asc("status")).
+		Limit(10).
+		Build()
+
+	wantArgs := []any{"acme", int64(5), int64(10)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "status", COUNT(*) AS "n" FROM "orders" WHERE "tenant_id" = $1 GROUP BY "status" HAVING COUNT(*) > $2 ORDER BY "status" ASC LIMIT $3`,
+		},
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `status`, COUNT(*) AS `n` FROM `orders` WHERE `tenant_id` = ? GROUP BY `status` HAVING COUNT(*) > ? ORDER BY `status` ASC LIMIT ?",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestSelectBuilder_HavingComposesWithBooleans(t *testing.T) {
+	c := qt.New(t)
+
+	// A HAVING can combine several aggregate predicates with And, since each
+	// comparison is an ordinary expression.
+	stmt := query.Select().
+		Columns(query.Col("u", "id")).
+		ExprAs(query.Col("o", "id").Count(), "orders").
+		FromAs("users", "u").
+		InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+		GroupBy(query.Col("u", "id")).
+		Having(query.And(
+			query.Expr(query.Col("o", "id").Count()).Gt(int64(1)),
+			query.Expr(query.Col("o", "total").Sum()).Ge(int64(100)),
+		)).
+		Build()
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "u"."id", COUNT("o"."id") AS "orders" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" GROUP BY "u"."id" HAVING (COUNT("o"."id") > $1 AND SUM("o"."total") >= $2)`)
+	c.Assert(args, qt.DeepEquals, []any{int64(1), int64(100)})
+}

--- a/core/query/query_groupby_test.go
+++ b/core/query/query_groupby_test.go
@@ -48,6 +48,50 @@ func TestAggregateConstructors(t *testing.T) {
 	}
 }
 
+func TestCountStarArgumentIsCountStar(t *testing.T) {
+	c := qt.New(t)
+
+	// Count("*") is a convenience for COUNT(*): it renders identically to
+	// CountStar and never the invalid COUNT("*") over a column named "*".
+	starSQL, starArgs := renderProjection(c, query.CountStar())
+	countSQL, countArgs := renderProjection(c, query.Count("*"))
+
+	c.Assert(countSQL, qt.Equals, `SELECT COUNT(*) FROM "t"`)
+	c.Assert(countSQL, qt.Equals, starSQL)
+	c.Assert(countArgs, qt.HasLen, 0)
+	c.Assert(starArgs, qt.HasLen, 0)
+}
+
+func TestAggregateStarArgumentRejected(t *testing.T) {
+	c := qt.New(t)
+
+	// Only Count("*") maps to the star form. Every other "*" aggregate argument —
+	// a non-COUNT aggregate, COUNT(DISTINCT *), or a qualified star — has no valid
+	// SQL form, so it is rejected at render time rather than emitting a quoted "*".
+	tests := []struct {
+		name string
+		expr ast.Expression
+	}{
+		{name: "sum star", expr: query.Sum("*")},
+		{name: "avg star", expr: query.Avg("*")},
+		{name: "min star", expr: query.Min("*")},
+		{name: "max star", expr: query.Max("*")},
+		{name: "count distinct star", expr: query.CountDistinct("*")},
+		{name: "qualified count star", expr: query.Col("u", "*").Count()},
+		{name: "qualified sum star", expr: query.Col("o", "*").Sum()},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stmt := query.Select().Exprs(tt.expr).From("t").Build()
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.ErrorMatches, `.*is not a valid column reference.*`)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
 func TestColumnAggregateMethods(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -15,23 +15,28 @@ import (
 // dialect, returning the SQL text and its positional arguments.
 //
 // Every value in the statement — comparison operands (including those inside a
-// JOIN ON), IN list elements, and the LIMIT/OFFSET bounds — is emitted as a
-// placeholder and returned in args, never interpolated into the SQL. Placeholder
-// style follows the dialect: $1, $2, … for the PostgreSQL family and ? for
-// MySQL, MariaDB, and SQLite. Placeholders are numbered in a single
-// left-to-right pass over FROM, the joins, WHERE, then LIMIT/OFFSET, so args are
-// ordered to match; a JOIN ON value is numbered before any WHERE value.
+// JOIN ON or a HAVING), IN list elements, function-call value arguments, and the
+// LIMIT/OFFSET bounds — is emitted as a placeholder and returned in args, never
+// interpolated into the SQL. Placeholder style follows the dialect: $1, $2, … for
+// the PostgreSQL family and ? for MySQL, MariaDB, and SQLite. Placeholders are
+// numbered in a single left-to-right pass over the projection, FROM, the joins,
+// WHERE, then HAVING, then LIMIT/OFFSET, so args are ordered to match; a JOIN ON
+// value is numbered before any WHERE value, and a HAVING value after every WHERE
+// value. GROUP BY carries only identifiers and never binds a placeholder.
 //
 // Identifiers (table, alias, and column names) are quoted for the dialect via
 // internal/sqlident, so a value can never be rendered as an identifier and an
 // attacker-shaped identifier or alias cannot break out of its quotes. A
 // qualified column renders as "alias"."col" with each part quoted independently.
+// A function name (COUNT, SUM, …) is a keyword emitted verbatim, never quoted;
+// the renderer rejects a name that is not a simple identifier rather than emit it.
 //
 // Supported dialects are PostgreSQL (including CockroachDB and YugabyteDB),
 // MySQL, MariaDB, and SQLite. Any other dialect returns an error, as does a nil
 // statement, a statement without a FROM table, an empty IN list, a malformed
-// operator, a join without a table or ON condition, or a RIGHT/FULL join on
-// SQLite (which cannot express one before version 3.39).
+// operator, a function call with an invalid name or a bad argument shape, a GROUP
+// BY term with an empty column, a join without a table or ON condition, or a
+// RIGHT/FULL join on SQLite (which cannot express one before version 3.39).
 func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error) {
 	if stmt == nil {
 		return "", nil, errors.New("renderer: nil select statement")
@@ -130,6 +135,9 @@ func (r *selectRenderer) render(stmt *ast.SelectStatement) error {
 	}
 
 	r.buf.WriteString("SELECT ")
+	if stmt.Distinct {
+		r.buf.WriteString("DISTINCT ")
+	}
 	if err := r.renderColumns(stmt.Columns); err != nil {
 		return err
 	}
@@ -148,6 +156,17 @@ func (r *selectRenderer) render(stmt *ast.SelectStatement) error {
 		}
 	}
 
+	if err := r.renderGroupBy(stmt.GroupBy); err != nil {
+		return err
+	}
+
+	if stmt.Having != nil {
+		r.buf.WriteString(" HAVING ")
+		if err := r.renderExpr(stmt.Having); err != nil {
+			return err
+		}
+	}
+
 	if err := r.renderOrderBy(stmt.OrderBy); err != nil {
 		return err
 	}
@@ -161,18 +180,38 @@ func (r *selectRenderer) renderColumns(columns []ast.ResultColumn) error {
 		r.buf.WriteString("*")
 		return nil
 	}
-	for i, col := range columns {
+	for i := range columns {
 		if i > 0 {
 			r.buf.WriteString(", ")
 		}
-		if col.Star {
-			r.buf.WriteString("*")
-			continue
+		if err := r.renderResultColumn(columns[i]); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+// renderResultColumn writes one projection entry and its optional alias. An Expr
+// entry renders the expression (for example an aggregate); a Star entry renders
+// "*"; every other entry renders a quoted column. Expr takes precedence over Star
+// and Name, so an expression projection ignores the column fields.
+func (r *selectRenderer) renderResultColumn(col ast.ResultColumn) error {
+	switch {
+	case col.Expr != nil:
+		if err := r.renderExpr(col.Expr); err != nil {
+			return err
+		}
+	case col.Star:
+		r.buf.WriteString("*")
+	default:
 		if strings.TrimSpace(col.Name) == "" {
 			return errors.New("renderer: result column has an empty name")
 		}
 		r.writeResultColumn(col)
+	}
+	if alias := strings.TrimSpace(col.Alias); alias != "" {
+		r.buf.WriteString(" AS ")
+		r.buf.WriteString(r.quote(alias))
 	}
 	return nil
 }
@@ -278,6 +317,8 @@ func (r *selectRenderer) renderExpr(expr ast.Expression) error {
 		return r.renderLogical(e)
 	case *ast.NotExpr:
 		return r.renderNot(e)
+	case *ast.FuncCall:
+		return r.renderFuncCall(e)
 	default:
 		return fmt.Errorf("renderer: unsupported expression type %T", expr)
 	}
@@ -387,6 +428,97 @@ func (r *selectRenderer) renderNot(not *ast.NotExpr) error {
 		return err
 	}
 	r.buf.WriteString(")")
+	return nil
+}
+
+// renderFuncCall writes a function call such as COUNT(*), COUNT("col"),
+// COUNT(DISTINCT "col"), or SUM("u"."total"). The function name is validated and
+// emitted verbatim as a keyword — never quoted and never bound — while each
+// argument routes through renderExpr so a column is quoted and a value is bound.
+func (r *selectRenderer) renderFuncCall(fn *ast.FuncCall) error {
+	if fn == nil {
+		return errors.New("renderer: nil function call")
+	}
+	name := strings.TrimSpace(fn.Name)
+	if name == "" {
+		return errors.New("renderer: function call has an empty name")
+	}
+	if !isSafeFunctionName(name) {
+		return fmt.Errorf("renderer: function name %q is not a valid identifier", fn.Name)
+	}
+	if fn.Star {
+		return r.renderFuncStar(name, fn)
+	}
+	if len(fn.Args) == 0 {
+		return fmt.Errorf("renderer: function %s requires at least one argument", name)
+	}
+	r.buf.WriteString(name)
+	r.buf.WriteString("(")
+	if fn.Distinct {
+		r.buf.WriteString("DISTINCT ")
+	}
+	for i, arg := range fn.Args {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		if err := r.renderExpr(arg); err != nil {
+			return err
+		}
+	}
+	r.buf.WriteString(")")
+	return nil
+}
+
+// renderFuncStar writes the "*" argument form, as in COUNT(*). The star is
+// mutually exclusive with explicit arguments and with DISTINCT, since neither
+// COUNT(*, x) nor COUNT(DISTINCT *) is valid SQL.
+func (r *selectRenderer) renderFuncStar(name string, fn *ast.FuncCall) error {
+	if len(fn.Args) > 0 {
+		return fmt.Errorf("renderer: function %s with a star takes no arguments", name)
+	}
+	if fn.Distinct {
+		return fmt.Errorf("renderer: function %s cannot combine DISTINCT with a star", name)
+	}
+	r.buf.WriteString(name)
+	r.buf.WriteString("(*)")
+	return nil
+}
+
+// isSafeFunctionName reports whether name is a simple SQL identifier — a letter
+// or underscore followed by letters, digits, or underscores. Because a function
+// name is emitted as a keyword rather than a quoted identifier, restricting it to
+// this shape prevents a hand-built FuncCall from smuggling SQL through the name.
+func isSafeFunctionName(name string) bool {
+	for i, r := range name {
+		switch {
+		case r == '_':
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return name != ""
+}
+
+// renderGroupBy appends the GROUP BY clause after WHERE. Each column is rendered
+// as a quoted identifier, qualified when a qualifier is set; GROUP BY carries no
+// values, so it never binds a placeholder. An empty list renders nothing.
+func (r *selectRenderer) renderGroupBy(cols []ast.ColumnRef) error {
+	if len(cols) == 0 {
+		return nil
+	}
+	r.buf.WriteString(" GROUP BY ")
+	for i := range cols {
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		col := cols[i]
+		if strings.TrimSpace(col.Name) == "" {
+			return errors.New("renderer: GROUP BY term has an empty column")
+		}
+		r.writeQualifiedIdent(col.Qualifier, col.Name)
+	}
 	return nil
 }
 

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -331,6 +331,14 @@ func (r *selectRenderer) renderColumnRef(ref *ast.ColumnRef) error {
 	if strings.TrimSpace(ref.Name) == "" {
 		return errors.New("renderer: column reference has an empty name")
 	}
+	// A "*" is not a column: quoting it would yield "*" (or "q"."*"), which the
+	// database reads as a column literally named *. The star belongs to the
+	// projection (ResultColumn.Star / a qualified "q".*) and to the star form of
+	// an aggregate (FuncCall.Star, e.g. COUNT(*)), never to a column reference in
+	// an expression, so it is rejected here rather than mis-rendered.
+	if strings.TrimSpace(ref.Name) == "*" {
+		return errors.New(`renderer: "*" is not a valid column reference; use a star aggregate such as COUNT(*)`)
+	}
 	r.writeQualifiedIdent(ref.Qualifier, ref.Name)
 	return nil
 }

--- a/core/renderer/select_groupby_test.go
+++ b/core/renderer/select_groupby_test.go
@@ -1,0 +1,384 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestRenderSelect_Distinct(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.SelectStatement{
+		Distinct: true,
+		Columns:  []ast.ResultColumn{{Name: "status"}},
+		From:     "orders",
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{name: "postgres", dialect: platform.Postgres, wantSQL: `SELECT DISTINCT "status" FROM "orders"`},
+		{name: "mysql", dialect: platform.MySQL, wantSQL: "SELECT DISTINCT `status` FROM `orders`"},
+		{name: "sqlite", dialect: platform.SQLite, wantSQL: `SELECT DISTINCT "status" FROM "orders"`},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_GroupBy(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		stmt    *ast.SelectStatement
+		wantSQL string
+	}{
+		{
+			name: "bare columns",
+			stmt: &ast.SelectStatement{
+				Columns: []ast.ResultColumn{{Name: "status"}},
+				From:    "orders",
+				GroupBy: []ast.ColumnRef{{Name: "status"}, {Name: "kind"}},
+			},
+			wantSQL: `SELECT "status" FROM "orders" GROUP BY "status", "kind"`,
+		},
+		{
+			name: "qualified columns in a join",
+			stmt: &ast.SelectStatement{
+				Columns:   []ast.ResultColumn{{Qualifier: "u", Name: "id"}},
+				From:      "users",
+				FromAlias: "u",
+				Joins: []ast.JoinClause{
+					{Type: ast.JoinInner, Table: "orders", Alias: "o", On: eqCols("o", "user_id", "u", "id")},
+				},
+				GroupBy: []ast.ColumnRef{{Qualifier: "u", Name: "id"}, {Qualifier: "o", Name: "status"}},
+			},
+			wantSQL: `SELECT "u"."id" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" GROUP BY "u"."id", "o"."status"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(tt.stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+// groupedCountQuery groups by a column, projects COUNT(*), filters rows before
+// grouping (WHERE) and groups after (HAVING), so the placeholder ordering across
+// WHERE, HAVING, and LIMIT can be asserted in one statement.
+func groupedCountQuery() *ast.SelectStatement {
+	limit := int64(10)
+	return &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Name: "status"},
+			{Expr: &ast.FuncCall{Name: "COUNT", Star: true}, Alias: "n"},
+		},
+		From:  "orders",
+		Where: &ast.Comparison{Left: &ast.ColumnRef{Name: "tenant_id"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "acme"}},
+		GroupBy: []ast.ColumnRef{
+			{Name: "status"},
+		},
+		Having: &ast.Comparison{
+			Left:     &ast.FuncCall{Name: "COUNT", Star: true},
+			Operator: ast.OpGreaterThan,
+			Right:    &ast.BoundValue{Value: int64(5)},
+		},
+		OrderBy: []ast.OrderByClause{{Column: "status", Direction: ast.SortAscending}},
+		Limit:   &limit,
+	}
+}
+
+func TestRenderSelect_GroupByHavingPlaceholderOrdering(t *testing.T) {
+	c := qt.New(t)
+
+	// A bound WHERE value takes the first placeholder, the HAVING value the second,
+	// and the LIMIT bound the third, proving HAVING binds after WHERE and before
+	// LIMIT and that GROUP BY (a COUNT(*) with no arguments) binds nothing.
+	wantArgs := []any{"acme", int64(5), int64(10)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres numbers where then having then limit",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "status", COUNT(*) AS "n" FROM "orders" WHERE "tenant_id" = $1 GROUP BY "status" HAVING COUNT(*) > $2 ORDER BY "status" ASC LIMIT $3`,
+		},
+		{
+			name:    "mysql keeps the order with question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `status`, COUNT(*) AS `n` FROM `orders` WHERE `tenant_id` = ? GROUP BY `status` HAVING COUNT(*) > ? ORDER BY `status` ASC LIMIT ?",
+		},
+		{
+			name:    "sqlite keeps the order with question placeholders",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT "status", COUNT(*) AS "n" FROM "orders" WHERE "tenant_id" = ? GROUP BY "status" HAVING COUNT(*) > ? ORDER BY "status" ASC LIMIT ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(groupedCountQuery(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderSelect_AggregateProjection(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		expr    ast.Expression
+		alias   string
+		wantSQL string
+	}{
+		{
+			name:    "count star",
+			expr:    &ast.FuncCall{Name: "COUNT", Star: true},
+			wantSQL: `SELECT COUNT(*) FROM "t"`,
+		},
+		{
+			name:    "count column",
+			expr:    &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{&ast.ColumnRef{Name: "id"}}},
+			wantSQL: `SELECT COUNT("id") FROM "t"`,
+		},
+		{
+			name:    "count distinct column",
+			expr:    &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{&ast.ColumnRef{Name: "status"}}, Distinct: true},
+			wantSQL: `SELECT COUNT(DISTINCT "status") FROM "t"`,
+		},
+		{
+			name:    "sum",
+			expr:    &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			wantSQL: `SELECT SUM("total") FROM "t"`,
+		},
+		{
+			name:    "avg",
+			expr:    &ast.FuncCall{Name: "AVG", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			wantSQL: `SELECT AVG("total") FROM "t"`,
+		},
+		{
+			name:    "min",
+			expr:    &ast.FuncCall{Name: "MIN", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			wantSQL: `SELECT MIN("total") FROM "t"`,
+		},
+		{
+			name:    "max",
+			expr:    &ast.FuncCall{Name: "MAX", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			wantSQL: `SELECT MAX("total") FROM "t"`,
+		},
+		{
+			name:    "aliased aggregate",
+			expr:    &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			alias:   "grand_total",
+			wantSQL: `SELECT SUM("total") AS "grand_total" FROM "t"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			col := ast.ResultColumn{Expr: tt.expr, Alias: tt.alias}
+			stmt := &ast.SelectStatement{Columns: []ast.ResultColumn{col}, From: "t"}
+			sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_AggregateOverQualifiedColumnInJoin(t *testing.T) {
+	c := qt.New(t)
+
+	// COUNT("u"."id") and SUM("o"."total") each quote both qualifier parts, mix
+	// with a grouped column, and render in a join query across dialects.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Qualifier: "u", Name: "name"},
+			{Expr: &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{&ast.ColumnRef{Qualifier: "o", Name: "id"}}}, Alias: "orders"},
+			{Expr: &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Qualifier: "o", Name: "total"}}}, Alias: "spent"},
+		},
+		From:      "users",
+		FromAlias: "u",
+		Joins: []ast.JoinClause{
+			{Type: ast.JoinInner, Table: "orders", Alias: "o", On: eqCols("o", "user_id", "u", "id")},
+		},
+		GroupBy: []ast.ColumnRef{{Qualifier: "u", Name: "name"}},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "u"."name", COUNT("o"."id") AS "orders", SUM("o"."total") AS "spent" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" GROUP BY "u"."name"`,
+		},
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `u`.`name`, COUNT(`o`.`id`) AS `orders`, SUM(`o`.`total`) AS `spent` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id` GROUP BY `u`.`name`",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRenderSelect_AggregateInHavingBindsValue(t *testing.T) {
+	c := qt.New(t)
+
+	// SUM("total") in the projection carries no value, but comparing it against a
+	// bound value in HAVING binds exactly one placeholder.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Name: "status"}, {Expr: &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}}}},
+		From:    "orders",
+		GroupBy: []ast.ColumnRef{{Name: "status"}},
+		Having: &ast.Comparison{
+			Left:     &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			Operator: ast.OpGreaterThanOrEqual,
+			Right:    &ast.BoundValue{Value: int64(1000)},
+		},
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "status", SUM("total") FROM "orders" GROUP BY "status" HAVING SUM("total") >= $1`)
+	c.Assert(args, qt.DeepEquals, []any{int64(1000)})
+}
+
+func TestRenderSelect_FunctionNameNeverQuotedButValidated(t *testing.T) {
+	c := qt.New(t)
+
+	// The function name is a keyword emitted verbatim, so a well-formed name is not
+	// quoted even though its column argument is.
+	c.Run("name is not quoted", func(c *qt.C) {
+		stmt := &ast.SelectStatement{
+			Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "COUNT", Args: []ast.Expression{&ast.ColumnRef{Name: "id"}}}}},
+			From:    "t",
+		}
+		sql, _, err := renderer.RenderSelect(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `SELECT COUNT("id") FROM "t"`)
+	})
+
+	// An unsafe function name cannot be smuggled through as SQL: because the name
+	// is not quoted, the renderer rejects anything that is not a simple identifier.
+	c.Run("injection name is rejected", func(c *qt.C) {
+		stmt := &ast.SelectStatement{
+			Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "COUNT(*) FROM secrets; --", Star: true}}},
+			From:    "t",
+		}
+		sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+		c.Assert(err, qt.ErrorMatches, `renderer: function name "COUNT\(\*\) FROM secrets; --" is not a valid identifier`)
+		c.Assert(sql, qt.Equals, "")
+		c.Assert(args, qt.IsNil)
+	})
+}
+
+func TestRenderSelect_GroupByHavingErrors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		stmt        *ast.SelectStatement
+		wantErrLike string
+	}{
+		{
+			name:        "empty group by column",
+			stmt:        &ast.SelectStatement{From: "t", GroupBy: []ast.ColumnRef{{Name: "  "}}},
+			wantErrLike: "renderer: GROUP BY term has an empty column",
+		},
+		{
+			name:        "function with empty name",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "  ", Star: true}}}, From: "t"},
+			wantErrLike: "renderer: function call has an empty name",
+		},
+		{
+			name:        "function without arguments or star",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "SUM"}}}, From: "t"},
+			wantErrLike: "renderer: function SUM requires at least one argument",
+		},
+		{
+			name:        "star with arguments",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "COUNT", Star: true, Args: []ast.Expression{&ast.ColumnRef{Name: "id"}}}}}, From: "t"},
+			wantErrLike: "renderer: function COUNT with a star takes no arguments",
+		},
+		{
+			name:        "star with distinct",
+			stmt:        &ast.SelectStatement{Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "COUNT", Star: true, Distinct: true}}}, From: "t"},
+			wantErrLike: "renderer: function COUNT cannot combine DISTINCT with a star",
+		},
+		{
+			name:        "typed-nil function call does not panic",
+			stmt:        &ast.SelectStatement{From: "t", Having: (*ast.FuncCall)(nil)},
+			wantErrLike: "renderer: nil function call",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(tt.stmt, platform.Postgres)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+func TestRenderSelect_Phase3ZeroValuesAreBackwardCompatible(t *testing.T) {
+	c := qt.New(t)
+
+	// A statement that sets none of the Phase 3 fields (Distinct, GroupBy, Having,
+	// ResultColumn.Expr/Alias) renders byte-identically to the Phase 1/2 output.
+	limit := int64(24)
+	offset := int64(0)
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Name: "id"}, {Name: "name"}},
+		From:    "commodities",
+		Where: &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "draft"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: false},
+		},
+		OrderBy: []ast.OrderByClause{{Column: "name", Direction: ast.SortAscending}},
+		Limit:   &limit,
+		Offset:  &offset,
+	}
+
+	sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, `SELECT "id", "name" FROM "commodities" WHERE "draft" = $1 ORDER BY "name" ASC LIMIT $2 OFFSET $3`)
+	c.Assert(args, qt.DeepEquals, []any{false, int64(24), int64(0)})
+}

--- a/core/renderer/select_groupby_test.go
+++ b/core/renderer/select_groupby_test.go
@@ -244,6 +244,11 @@ func TestRenderSelect_AggregateOverQualifiedColumnInJoin(t *testing.T) {
 			dialect: platform.MySQL,
 			wantSQL: "SELECT `u`.`name`, COUNT(`o`.`id`) AS `orders`, SUM(`o`.`total`) AS `spent` FROM `users` `u` INNER JOIN `orders` `o` ON `o`.`user_id` = `u`.`id` GROUP BY `u`.`name`",
 		},
+		{
+			name:    "sqlite",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT "u"."name", COUNT("o"."id") AS "orders", SUM("o"."total") AS "spent" FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id" GROUP BY "u"."name"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -381,4 +386,170 @@ func TestRenderSelect_Phase3ZeroValuesAreBackwardCompatible(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(sql, qt.Equals, `SELECT "id", "name" FROM "commodities" WHERE "draft" = $1 ORDER BY "name" ASC LIMIT $2 OFFSET $3`)
 	c.Assert(args, qt.DeepEquals, []any{false, int64(24), int64(0)})
+}
+
+// onWhereHavingLimitOffset carries a bound value in the JOIN ON, the WHERE, the
+// HAVING, and both the LIMIT and OFFSET, so a single statement pins the full
+// placeholder order across every binding clause.
+func onWhereHavingLimitOffset() *ast.SelectStatement {
+	limit := int64(10)
+	offset := int64(20)
+	return &ast.SelectStatement{
+		Columns: []ast.ResultColumn{
+			{Qualifier: "o", Name: "status"},
+			{Expr: &ast.FuncCall{Name: "COUNT", Star: true}, Alias: "n"},
+		},
+		From:      "orders",
+		FromAlias: "o",
+		Joins: []ast.JoinClause{
+			{
+				Type:  ast.JoinInner,
+				Table: "users",
+				Alias: "u",
+				On: &ast.LogicalExpr{
+					Operator: ast.LogicalAnd,
+					Operands: []ast.Expression{
+						eqCols("u", "id", "o", "user_id"),
+						&ast.Comparison{Left: &ast.ColumnRef{Qualifier: "u", Name: "status"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: "active"}},
+					},
+				},
+			},
+		},
+		Where:   &ast.Comparison{Left: &ast.ColumnRef{Qualifier: "o", Name: "total"}, Operator: ast.OpGreaterThan, Right: &ast.BoundValue{Value: int64(100)}},
+		GroupBy: []ast.ColumnRef{{Qualifier: "o", Name: "status"}},
+		Having: &ast.Comparison{
+			Left:     &ast.FuncCall{Name: "COUNT", Star: true},
+			Operator: ast.OpGreaterThan,
+			Right:    &ast.BoundValue{Value: int64(5)},
+		},
+		Limit:  &limit,
+		Offset: &offset,
+	}
+}
+
+func TestRenderSelect_OnWhereHavingLimitOffsetPlaceholderOrdering(t *testing.T) {
+	c := qt.New(t)
+
+	// The bound values are numbered strictly by render order: JOIN ON first, then
+	// WHERE, then HAVING, then LIMIT, then OFFSET — regardless of placeholder style.
+	wantArgs := []any{"active", int64(100), int64(5), int64(10), int64(20)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres dollar placeholders",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT "o"."status", COUNT(*) AS "n" FROM "orders" "o" INNER JOIN "users" "u" ON ("u"."id" = "o"."user_id" AND "u"."status" = $1) WHERE "o"."total" > $2 GROUP BY "o"."status" HAVING COUNT(*) > $3 LIMIT $4 OFFSET $5`,
+		},
+		{
+			name:    "mysql question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT `o`.`status`, COUNT(*) AS `n` FROM `orders` `o` INNER JOIN `users` `u` ON (`u`.`id` = `o`.`user_id` AND `u`.`status` = ?) WHERE `o`.`total` > ? GROUP BY `o`.`status` HAVING COUNT(*) > ? LIMIT ? OFFSET ?",
+		},
+		{
+			name:    "sqlite question placeholders",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT "o"."status", COUNT(*) AS "n" FROM "orders" "o" INNER JOIN "users" "u" ON ("u"."id" = "o"."user_id" AND "u"."status" = ?) WHERE "o"."total" > ? GROUP BY "o"."status" HAVING COUNT(*) > ? LIMIT ? OFFSET ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(onWhereHavingLimitOffset(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderSelect_HavingWithoutGroupBy(t *testing.T) {
+	c := qt.New(t)
+
+	// A HAVING is valid without GROUP BY: the aggregate spans the whole table. No
+	// GROUP BY clause is emitted, and the HAVING value takes the first placeholder.
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "COUNT", Star: true}, Alias: "n"}},
+		From:    "orders",
+		Having: &ast.Comparison{
+			Left:     &ast.FuncCall{Name: "COUNT", Star: true},
+			Operator: ast.OpGreaterThan,
+			Right:    &ast.BoundValue{Value: int64(5)},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{name: "postgres", dialect: platform.Postgres, wantSQL: `SELECT COUNT(*) AS "n" FROM "orders" HAVING COUNT(*) > $1`},
+		{name: "mysql", dialect: platform.MySQL, wantSQL: "SELECT COUNT(*) AS `n` FROM `orders` HAVING COUNT(*) > ?"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{int64(5)})
+		})
+	}
+}
+
+func TestRenderSelect_HavingWithOffsetOnly(t *testing.T) {
+	c := qt.New(t)
+
+	// A HAVING value binds before the OFFSET value even when there is no LIMIT: the
+	// HAVING takes the first placeholder and the OFFSET the second. On MySQL,
+	// MariaDB, and SQLite the offset-only "no limit" sentinel is a literal between
+	// HAVING and OFFSET, so it consumes no placeholder and does not shift the order.
+	offset := int64(5)
+	stmt := &ast.SelectStatement{
+		Columns: []ast.ResultColumn{{Expr: &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}}, Alias: "s"}},
+		From:    "orders",
+		GroupBy: []ast.ColumnRef{{Name: "status"}},
+		Having: &ast.Comparison{
+			Left:     &ast.FuncCall{Name: "SUM", Args: []ast.Expression{&ast.ColumnRef{Name: "total"}}},
+			Operator: ast.OpGreaterThan,
+			Right:    &ast.BoundValue{Value: int64(1000)},
+		},
+		Offset: &offset,
+	}
+
+	wantArgs := []any{int64(1000), int64(5)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres emits a bare offset",
+			dialect: platform.Postgres,
+			wantSQL: `SELECT SUM("total") AS "s" FROM "orders" GROUP BY "status" HAVING SUM("total") > $1 OFFSET $2`,
+		},
+		{
+			name:    "mysql synthesizes a max-bigint limit before offset",
+			dialect: platform.MySQL,
+			wantSQL: "SELECT SUM(`total`) AS `s` FROM `orders` GROUP BY `status` HAVING SUM(`total`) > ? LIMIT 18446744073709551615 OFFSET ?",
+		},
+		{
+			name:    "sqlite synthesizes a negative-one limit before offset",
+			dialect: platform.SQLite,
+			wantSQL: `SELECT SUM("total") AS "s" FROM "orders" GROUP BY "status" HAVING SUM("total") > ? LIMIT -1 OFFSET ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderSelect(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
 }

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -154,6 +154,7 @@ type Expression interface{ ... }
 type ExtensionNode struct{ ... }
     func NewExtension(name string) *ExtensionNode
 type ForeignKeyRef struct{ ... }
+type FuncCall struct{ ... }
 type FunctionBodyKind string
     const FunctionBodyQuoted FunctionBodyKind = "quoted" ...
 type GrantPrivilegeNode struct{ ... }
@@ -530,6 +531,10 @@ type RenderError struct{ ... }
 
 func And(exprs ...ast.Expression) ast.Expression
 func Asc(column string) ast.OrderByClause
+func Avg(column string) ast.Expression
+func Count(column string) ast.Expression
+func CountDistinct(column string) ast.Expression
+func CountStar() ast.Expression
 func Desc(column string) ast.OrderByClause
 func Eq(column string, value any) ast.Expression
 func Ge(column string, value any) ast.Expression
@@ -539,11 +544,16 @@ func IsNotNull(column string) ast.Expression
 func IsNull(column string) ast.Expression
 func Le(column string, value any) ast.Expression
 func Lt(column string, value any) ast.Expression
+func Max(column string) ast.Expression
+func Min(column string) ast.Expression
 func Ne(column string, value any) ast.Expression
 func Not(expr ast.Expression) ast.Expression
 func Or(exprs ...ast.Expression) ast.Expression
+func Sum(column string) ast.Expression
 type Column struct{ ... }
     func Col(qualifier, name string) Column
+type ExprCompare struct{ ... }
+    func Expr(left ast.Expression) ExprCompare
 type SelectBuilder struct{ ... }
     func Select(columns ...string) *SelectBuilder
 

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -17,18 +17,21 @@ placeholder counters.
 
 Implemented so far:
 
-- `SELECT` with an explicit column list or `*`;
+- `SELECT` with an explicit column list or `*`, and `SELECT DISTINCT`;
 - `INNER`, `LEFT`, `RIGHT`, and `FULL OUTER` joins, with table aliases and
   columns qualified by a table or alias (see [Joins](#joins));
 - a composable `WHERE` (and join `ON`) expression tree: `=`, `<>`, `<`, `<=`,
   `>`, `>=`, `IN`, `IS NULL`, `IS NOT NULL`, and the boolean combinators `AND`,
   `OR`, `NOT`;
+- aggregate functions — `COUNT(*)`, `COUNT`, `COUNT(DISTINCT …)`, `SUM`, `AVG`,
+  `MIN`, `MAX` — in the projection and in `HAVING` (see
+  [Aggregates, GROUP BY, and HAVING](#aggregates-group-by-and-having));
+- `GROUP BY` (bare or qualified columns) and `HAVING`;
 - `ORDER BY` with per-column `ASC`/`DESC`;
 - `LIMIT` and `OFFSET`.
 
-Not yet implemented (follow-up phases): `GROUP BY`, `HAVING`, `DISTINCT`,
-subqueries, function calls, arithmetic, `LIKE`, and the `INSERT`/`UPDATE`/
-`DELETE` family.
+Not yet implemented (follow-up phases): non-aggregate function calls, arithmetic,
+`LIKE`, subqueries, window functions, and the `INSERT`/`UPDATE`/`DELETE` family.
 
 ## Safety model
 
@@ -180,24 +183,101 @@ that fails at execution time against the database.
 - The **PostgreSQL family** (including CockroachDB and YugabyteDB) supports all
   four.
 
+## Aggregates, GROUP BY, and HAVING
+
+`Distinct()` renders `SELECT DISTINCT`. `GroupBy` adds `GROUP BY` columns — pass
+`Col(table, name)` for a qualified column across joins, or `Col("", name)` for a
+bare column. GROUP BY carries only identifiers, so it never binds a placeholder.
+
+Aggregates are built with `CountStar`, `Count`, `CountDistinct`, `Sum`, `Avg`,
+`Min`, and `Max` (bare-column free functions), or the matching methods on a
+qualified column: `Col("o", "total").Sum()`, `Col("u", "id").Count()`, and so on.
+Each returns an expression usable in two places:
+
+- **the projection**, via `Exprs` (no alias) or `ExprAs` (with an `AS` alias);
+- **a `HAVING` predicate**, by wrapping it with `Expr` to reach the comparison
+  helpers — `Expr(query.CountStar()).Gt(int64(5))` — which compose with `And`,
+  `Or`, and `Not` like any other expression.
+
+A function name (`COUNT`, `SUM`, …) is a keyword emitted verbatim and never
+quoted; its column arguments are quoted, and any value it is compared against is
+bound. The renderer rejects a function name that is not a simple identifier
+rather than emit it.
+
+```go
+stmt := query.Select("status").
+	ExprAs(query.CountStar(), "n").
+	From("orders").
+	Where(query.Eq("tenant_id", tenantID)).
+	GroupBy(query.Col("", "status")).
+	Having(query.Expr(query.CountStar()).Gt(int64(5))).
+	OrderBy(query.Asc("status")).
+	Limit(10).
+	Build()
+
+sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
+```
+
+The PostgreSQL output is:
+
+```sql
+SELECT "status", COUNT(*) AS "n"
+FROM "orders"
+WHERE "tenant_id" = $1
+GROUP BY "status"
+HAVING COUNT(*) > $2
+ORDER BY "status" ASC
+LIMIT $3
+```
+
+with `args` equal to `[]any{tenantID, int64(5), int64(10)}`. A `HAVING` value is
+bound **after** every `WHERE` value and **before** `LIMIT`/`OFFSET`, so
+placeholder numbering still follows left-to-right emission order across `WHERE`,
+`HAVING`, and `LIMIT`/`OFFSET`.
+
+Aggregates work over qualified columns in join queries too:
+
+```go
+stmt := query.Select().
+	Columns(query.Col("u", "name")).
+	ExprAs(query.Col("o", "id").Count(), "orders").
+	ExprAs(query.Col("o", "total").Sum(), "spent").
+	FromAs("users", "u").
+	InnerJoin("orders", "o", query.Col("o", "user_id").EqCol(query.Col("u", "id"))).
+	GroupBy(query.Col("u", "name")).
+	Build()
+
+// SELECT "u"."name", COUNT("o"."id") AS "orders", SUM("o"."total") AS "spent"
+// FROM "users" "u" INNER JOIN "orders" "o" ON "o"."user_id" = "u"."id"
+// GROUP BY "u"."name"
+```
+
 ## Builder reference
 
 | Function | Result |
 | --- | --- |
 | `Select(cols ...string)` | Start a builder; `"*"` or no columns selects all. |
+| `.Distinct()` | Render `SELECT DISTINCT`. |
 | `.Columns(cols ...Column)` | Append qualified columns (from `Col`) to the projection. |
+| `.Exprs(exprs ...ast.Expression)` | Append expression projections (for example aggregates). |
+| `.ExprAs(expr, alias)` | Append one expression projection with an `AS` alias. |
 | `.From(table)` | Set the source table (required); clears any alias. |
 | `.FromAs(table, alias)` | Set the source table with an alias. |
 | `.InnerJoin` / `.LeftJoin` / `.RightJoin` / `.FullJoin` `(table, alias, on)` | Append a join with an `ON` condition. |
 | `.Where(expr)` | Set the filter expression; a later call replaces the earlier one. |
+| `.GroupBy(cols ...Column)` | Append `GROUP BY` columns across calls. |
+| `.Having(expr)` | Set the `HAVING` predicate; a later call replaces the earlier one. |
 | `.OrderBy(terms ...)` | Append sort terms across calls. |
 | `.Limit(n)` / `.Offset(n)` | Set bound row limit/offset. |
 | `.Build()` | Produce the `*ast.SelectStatement`. |
 
 Expression helpers: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `In`, `IsNull`,
-`IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`. Qualified
-columns: `Col(table, name)`, with `.Eq`/`.Ne`/`.Lt`/`.Le`/`.Gt`/`.Ge`,
-`.EqCol` (column-to-column, for `ON`), `.IsNull`/`.IsNotNull`, and `.Asc`/`.Desc`.
+`IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`. Aggregate
+helpers: `CountStar`, `Count`, `CountDistinct`, `Sum`, `Avg`, `Min`, `Max`, and
+`Expr(expr)` with `.Eq`/`.Ne`/`.Lt`/`.Le`/`.Gt`/`.Ge` for `HAVING` comparisons.
+Qualified columns: `Col(table, name)`, with `.Eq`/`.Ne`/`.Lt`/`.Le`/`.Gt`/`.Ge`,
+`.EqCol` (column-to-column, for `ON`), `.IsNull`/`.IsNotNull`, `.Asc`/`.Desc`, and
+the aggregate methods `.Count`/`.CountDistinct`/`.Sum`/`.Avg`/`.Min`/`.Max`.
 
 `renderer.RenderSelect(stmt, dialect)` returns `(sql string, args []any, err error)`.
 It returns an error for an unsupported dialect, a missing `FROM` table, an empty

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -199,6 +199,12 @@ Each returns an expression usable in two places:
   helpers — `Expr(query.CountStar()).Gt(int64(5))` — which compose with `And`,
   `Or`, and `Not` like any other expression.
 
+`CountStar()` is the primary way to count all rows; `Count("*")` is an equivalent
+convenience for `COUNT(*)`. Every other `"*"` aggregate argument — a non-`COUNT`
+aggregate, `COUNT(DISTINCT *)`, or a qualified star such as `Col("u", "*").Count()`
+— has no portable star form and is rejected at render time rather than emitting an
+invalid quoted `"*"`.
+
 A function name (`COUNT`, `SUM`, …) is a keyword emitted verbatim and never
 quoted; its column arguments are quoted, and any value it is compared against is
 bound. The renderer rejects a function name that is not a simple identifier


### PR DESCRIPTION
## Summary

Phase 3 of #98 extends the DML SELECT query builder with **DISTINCT**, **GROUP BY**, **HAVING**, and **aggregate functions** (`COUNT` / `SUM` / `AVG` / `MIN` / `MAX`). It builds directly on the merged Phase 1 (SELECT / WHERE / ORDER BY / LIMIT) and Phase 2 (JOINs) and is **strictly additive** — no Phase 1/2 public signature or rendered output changes.

## AST additions (`core/ast/select.go`)

- `SelectStatement` gains `Distinct bool`, `GroupBy []ColumnRef`, and `Having Expression`.
- `ResultColumn` gains an optional `Expr Expression` and `Alias string`. When `Expr` is set it renders instead of `Qualifier`/`Name`/`Star`; a zero `ResultColumn` renders exactly as before.
- New sealed-`Expression` node `FuncCall{Name string, Args []Expression, Star bool, Distinct bool}` — a general function-call shape so non-aggregate functions can reuse it later. It covers `COUNT(*)`, `COUNT("col")`, `COUNT(DISTINCT "col")`, and `SUM/AVG/MIN/MAX("col")`, over bare or qualified columns.

## Renderer (`core/renderer/select.go`)

- `render()` now emits, in SQL clause order: `SELECT [DISTINCT] … FROM … <joins> WHERE … GROUP BY … HAVING … ORDER BY … LIMIT/OFFSET`.
- `FuncCall` renders the name as a **keyword emitted verbatim, never quoted**; its column arguments are quoted through `internal/sqlident` and any compared value is bound. `DISTINCT` and the `*` form are handled; `COUNT(*)` cannot combine with args or `DISTINCT`.
- The function name is validated to be a simple identifier — a hand-built `FuncCall` cannot smuggle SQL through the (unquoted) name; anything else is a clean render error.
- Degenerate cases return clean errors (no panics): empty/invalid function name, function with neither args nor star, star-with-args, star-with-distinct, empty GROUP BY column, typed-nil `FuncCall`.

## Builder (`core/query`)

- Builder methods: `.Distinct()`, `.GroupBy(cols ...Column)`, `.Having(expr)`, `.Exprs(exprs ...ast.Expression)`, `.ExprAs(expr, alias)`.
- Aggregate constructors returning `ast.Expression`: `CountStar`, `Count`, `CountDistinct`, `Sum`, `Avg`, `Min`, `Max` (bare-column free functions), plus matching methods on the qualified-column type — `Col("o","total").Sum()`, `Col("u","id").Count()`, `.CountDistinct()`, `.Avg()`, `.Min()`, `.Max()`.
- `Expr(left ast.Expression) ExprCompare` wraps an aggregate so it reaches comparison helpers (`.Eq/.Ne/.Lt/.Le/.Gt/.Ge`) for HAVING, e.g. `query.Expr(query.CountStar()).Gt(int64(5))`.

## How aggregates work in projection + HAVING

An aggregate constructor returns a plain `ast.Expression`, so the same value drops into both places:

```go
stmt := query.Select("status").
    ExprAs(query.CountStar(), "n").                       // projection, aliased
    From("orders").
    Where(query.Eq("tenant_id", tenantID)).
    GroupBy(query.Col("", "status")).                     // bare column via Col("", name)
    Having(query.Expr(query.CountStar()).Gt(int64(5))).   // HAVING via the Expr wrapper
    OrderBy(query.Asc("status")).
    Limit(10).
    Build()

sql, args, err := renderer.RenderSelect(stmt, platform.Postgres)
// SELECT "status", COUNT(*) AS "n" FROM "orders" WHERE "tenant_id" = $1
//   GROUP BY "status" HAVING COUNT(*) > $2 ORDER BY "status" ASC LIMIT $3
// args: []any{tenantID, int64(5), int64(10)}
```

Since `ast.Expression` is a sealed interface (its marker method is unexported in `core/ast`), a `core/query` type cannot itself implement it; aggregates therefore return the concrete `*ast.FuncCall` as `ast.Expression`, and the small exported `Expr(...)` wrapper — which the issue explicitly suggested — supplies the HAVING comparison ergonomics without changing Phase 1's string-based `Eq`/`Gt`/… helpers.

## Parameter ordering

Placeholders are still assigned in the single left-to-right bind pass, now **ON → WHERE → HAVING → LIMIT/OFFSET**. A HAVING bound value is numbered after every WHERE value and before LIMIT/OFFSET. GROUP BY carries only identifiers and binds nothing. Verified per dialect for both `$N` (PostgreSQL family) and `?` (MySQL / MariaDB / SQLite).

## Backward compatibility

- The public-API snapshot diff is **additive only**: one new `ast.FuncCall` type and, in `core/query`, the seven aggregate functions plus the `ExprCompare` type and its `Expr` constructor. No existing line changed or was removed (struct-field and method additions do not alter the `go doc -short` snapshot).
- New `ResultColumn`/`SelectStatement` fields are zero-valued by default, so a plain query with no DISTINCT/GROUP BY/HAVING renders byte-identical to Phase 1/2 — covered by an explicit backward-compat test, and all Phase 1/2 tests pass unmodified.

## Per-dialect notes

- Function name and `DISTINCT`/`*` handling are dialect-independent; only identifier quoting and placeholder style differ (`"…"`/`$N` for PostgreSQL, `` `…` ``/`?` for MySQL & MariaDB, `"…"`/`?` for SQLite).
- Column aliases render as `AS "alias"` with the alias quoted per dialect.
- No new dialect gating was needed for GROUP BY / HAVING / aggregates (all supported dialects accept them).

## Verification

- `go build ./...`, `go vet ./core/...`, `gofmt -l` clean.
- `golangci-lint run` on the changed packages: 0 issues.
- `go tool qtlint` and `go tool teststyle` OK.
- Full `go test ./...` green, including unmodified Phase 1/2 tests.
- New table-driven, per-dialect tests: `SELECT DISTINCT`; GROUP BY (bare + qualified, incl. in a join); HAVING `COUNT(*) > n` with placeholder ordering vs WHERE and LIMIT; `COUNT(*)`/`COUNT(DISTINCT x)`/`SUM`/`AVG`/`MIN`/`MAX` in projection; aggregates over qualified columns in a join query; the injection-name rejection; degenerate-case errors; and a byte-identical backward-compat render.
- Docs updated: `core/query/doc.go` and `docs/site/.../reference/query-builder.md`; the `docs/site` `check:*` scripts pass. Public-API snapshot regenerated.

## Deferred (follow-ups)

Non-aggregate function calls, arithmetic, `LIKE`, subqueries, window functions, and the `INSERT`/`UPDATE`/`DELETE` family.
