### PR TITLE
Add INSERT/UPDATE/DELETE to DML query builder (Phase 4 of #98)

### DIFF
--- a/core/ast/write.go
+++ b/core/ast/write.go
@@ -1,0 +1,97 @@
+package ast
+
+// This file defines the write-side DML statement AST: INSERT, UPDATE, and
+// DELETE. Like SelectStatement, these are statements rather than expressions —
+// they do not implement the sealed Expression interface — because rendering a
+// statement returns bound arguments alongside a SQL string. Their value and
+// filter positions reuse the Expression tree from select.go (BoundValue,
+// ColumnRef, Comparison, and the boolean combinators), so every value still
+// reaches SQL as a placeholder and every identifier through dialect quoting.
+// Render them with renderer.RenderInsert, renderer.RenderUpdate, and
+// renderer.RenderDelete; build them fluently with the core/query package.
+//
+// Deliberately out of scope for now, and tracked as follow-ups on issue #98:
+// ON CONFLICT / upsert (the DDL-side UpsertNode in dml.go is a separate,
+// unrelated node), INSERT … SELECT, common table expressions, subqueries in a
+// VALUES row or a SET value, and multi-table UPDATE / DELETE.
+
+// Assignment is a single "column = value" pair in an UPDATE SET clause.
+//
+// Column is rendered as a dialect-quoted identifier; Value is an ordinary
+// expression, so the query builder supplies a BoundValue and the value travels
+// to the database as a placeholder rather than inline SQL.
+type Assignment struct {
+	// Column is the target column name, rendered as a quoted identifier.
+	Column string
+	// Value is the assigned value expression, typically a BoundValue.
+	Value Expression
+}
+
+// InsertStatement is an INSERT INTO … VALUES … over a single table, with one or
+// more value rows and an optional RETURNING projection.
+//
+// Every element of every row is an expression — the query builder supplies a
+// BoundValue — so values are bound positionally at render time, row by row and
+// left to right, and never interpolated. The renderer rejects a statement with
+// no columns, no rows, or a row whose length does not match Columns, rather than
+// emit invalid SQL or panic on ragged input.
+type InsertStatement struct {
+	// Table is the target table, rendered as a quoted identifier. Required.
+	Table string
+	// Columns is the inserted column list, each a quoted identifier. Required and
+	// non-empty; every row must supply exactly one value per column.
+	Columns []string
+	// Rows is the list of value rows. At least one row is required, and each row
+	// must have the same length as Columns. Values are bound row by row, in order.
+	Rows [][]Expression
+	// Returning is the optional RETURNING projection: the columns to return from
+	// the inserted rows. An empty slice emits no RETURNING. RETURNING is supported
+	// only on the PostgreSQL family and SQLite; the renderer rejects it on MySQL
+	// and MariaDB rather than emit SQL those engines cannot run.
+	Returning []ColumnRef
+}
+
+// UpdateStatement is an UPDATE … SET … over a single table, with an optional
+// WHERE clause and RETURNING projection.
+//
+// SET values are bound before WHERE values, matching left-to-right emission
+// order, so placeholder numbering is deterministic. An UPDATE with no WHERE
+// clause rewrites every row; because that is rarely intended, the renderer
+// rejects it unless Unconditional is set, turning an accidental whole-table
+// update into a render-time error rather than silent data loss.
+type UpdateStatement struct {
+	// Table is the target table, rendered as a quoted identifier. Required.
+	Table string
+	// Set is the list of column assignments. Required and non-empty; the renderer
+	// rejects an empty SET.
+	Set []Assignment
+	// Where is the optional filter expression tree; nil means no WHERE clause. A
+	// nil Where is allowed only together with Unconditional.
+	Where Expression
+	// Unconditional opts in to a whole-table UPDATE when Where is nil. It is the
+	// explicit acknowledgment that every row is to be updated; without it, a nil
+	// Where is an error. It has no effect when Where is set.
+	Unconditional bool
+	// Returning is the optional RETURNING projection. See InsertStatement.Returning
+	// for the dialect support rules.
+	Returning []ColumnRef
+}
+
+// DeleteStatement is a DELETE FROM … over a single table, with an optional WHERE
+// clause and RETURNING projection.
+//
+// Like UpdateStatement, a DELETE with no WHERE clause removes every row, so the
+// renderer rejects it unless Unconditional is set.
+type DeleteStatement struct {
+	// Table is the target table, rendered as a quoted identifier. Required.
+	Table string
+	// Where is the optional filter expression tree; nil means no WHERE clause. A
+	// nil Where is allowed only together with Unconditional.
+	Where Expression
+	// Unconditional opts in to a whole-table DELETE when Where is nil, exactly as
+	// on UpdateStatement.
+	Unconditional bool
+	// Returning is the optional RETURNING projection. See InsertStatement.Returning
+	// for the dialect support rules.
+	Returning []ColumnRef
+}

--- a/core/query/doc.go
+++ b/core/query/doc.go
@@ -15,9 +15,16 @@
 // OFFSET. Tables can be aliased (FromAs and the alias argument of the join
 // methods) and columns can be qualified by a table or alias with Col, so a
 // projection, WHERE, join ON, GROUP BY, HAVING, or ORDER BY term can render as
-// "alias"."col". Non-aggregate function calls, arithmetic, LIKE, subqueries,
-// window functions, and the INSERT / UPDATE / DELETE family are intentionally not
-// implemented yet and are tracked as follow-up phases.
+// "alias"."col".
+//
+// The write side of DML is covered too: InsertInto, Update, and DeleteFrom build
+// single-table INSERT / UPDATE / DELETE statements, each rendered by its own
+// renderer entry point (RenderInsert, RenderUpdate, RenderDelete). See the
+// "Writes" section below.
+//
+// Non-aggregate function calls, arithmetic, LIKE, subqueries, window functions,
+// ON CONFLICT / upsert, INSERT … SELECT, and common table expressions are
+// intentionally not implemented yet and are tracked as follow-up phases.
 //
 // # Safety model
 //
@@ -133,4 +140,42 @@
 // follows left-to-right emission order. A function name (COUNT, SUM, …) is a
 // keyword emitted verbatim and never quoted; the renderer rejects a name that is
 // not a simple identifier rather than emit it.
+//
+// # Writes (INSERT, UPDATE, DELETE)
+//
+// InsertInto, Update, and DeleteFrom build the write-side statements. Values
+// passed to Values and Set are bound exactly like WHERE values — the classic
+// "concatenate a value into SQL" injection cannot happen through this API — and
+// column and table names are quoted. Each has its own renderer entry point:
+// RenderInsert, RenderUpdate, RenderDelete, all returning (sql, args, err).
+//
+//	ins := query.InsertInto("users").
+//		Columns("id", "name").
+//		Values(int64(1), "alice").
+//		Values(int64(2), "bob").
+//		Returning("id").
+//		Build()
+//	sql, args, err := renderer.RenderInsert(ins, platform.Postgres)
+//	// sql:  INSERT INTO "users" ("id", "name") VALUES ($1, $2), ($3, $4) RETURNING "id"
+//	// args: []any{int64(1), "alice", int64(2), "bob"}
+//
+//	upd := query.Update("users").
+//		Set("name", "bob").
+//		Where(query.Eq("id", int64(7))).
+//		Build()
+//	sql, args, err = renderer.RenderUpdate(upd, platform.Postgres)
+//	// sql:  UPDATE "users" SET "name" = $1 WHERE "id" = $2
+//	// args: []any{"bob", int64(7)}
+//
+// An UPDATE's SET values are numbered before its WHERE values, matching
+// left-to-right emission order, and an INSERT numbers values row by row, so
+// placeholder order always follows the SQL.
+//
+// Two safety rules apply. First, a whole-table UPDATE or DELETE — one with no
+// WHERE clause — is rejected at render time unless the builder marks it
+// Unconditional, so a missing filter cannot silently rewrite or delete every row.
+// Second, RETURNING renders only on dialects that can execute it: the PostgreSQL
+// family and SQLite (3.35+). MySQL and MariaDB have no portable RETURNING across
+// all three statements, so RenderInsert / RenderUpdate / RenderDelete reject a
+// non-empty RETURNING there rather than emit SQL the engine cannot run.
 package query

--- a/core/query/write.go
+++ b/core/query/write.go
@@ -1,0 +1,181 @@
+package query
+
+import "github.com/stokaro/ptah/core/ast"
+
+// This file adds the write-side builders — INSERT, UPDATE, and DELETE — alongside
+// the SELECT builder. They share the SELECT builder's conventions: each method
+// mutates and returns the same builder for chaining, values passed as any are
+// wrapped as bound parameters (never inlined), identifiers stay identifiers, and
+// Build produces a plain *ast node that renderer.RenderInsert / RenderUpdate /
+// RenderDelete turns into dialect SQL plus its positional arguments. Validation
+// of degenerate input (no rows, ragged rows, empty SET, a WHERE-less whole-table
+// mutation) happens at render time, mirroring the SELECT builder, so Build never
+// fails.
+
+// InsertBuilder builds an *ast.InsertStatement through a fluent, chainable API.
+// Start with InsertInto. A builder is not safe for concurrent use.
+type InsertBuilder struct {
+	table     string
+	columns   []string
+	rows      [][]ast.Expression
+	returning []ast.ColumnRef
+}
+
+// InsertInto starts an INSERT INTO the given table. Follow it with Columns to
+// declare the column list and one or more Values calls to add rows.
+func InsertInto(table string) *InsertBuilder {
+	return &InsertBuilder{table: table}
+}
+
+// Columns declares (or extends) the inserted column list. Each name is rendered
+// as a dialect-quoted identifier. Every row added with Values must supply exactly
+// one value per column; a mismatch is rejected at render time.
+func (b *InsertBuilder) Columns(columns ...string) *InsertBuilder {
+	b.columns = append(b.columns, columns...)
+	return b
+}
+
+// Values appends one row of values, each bound as a parameter. Call Values once
+// per row for a multi-row INSERT; rows render in call order and their values are
+// numbered left to right, row by row. Passing nil as a value binds SQL NULL.
+func (b *InsertBuilder) Values(values ...any) *InsertBuilder {
+	row := make([]ast.Expression, len(values))
+	for i, v := range values {
+		row[i] = &ast.BoundValue{Value: v}
+	}
+	b.rows = append(b.rows, row)
+	return b
+}
+
+// Returning adds columns to the RETURNING clause, projecting them from the
+// inserted rows. RETURNING renders only on the PostgreSQL family and SQLite;
+// RenderInsert rejects it on MySQL and MariaDB.
+func (b *InsertBuilder) Returning(columns ...string) *InsertBuilder {
+	b.returning = appendReturning(b.returning, columns)
+	return b
+}
+
+// Build returns the assembled *ast.InsertStatement. Render it with
+// renderer.RenderInsert.
+func (b *InsertBuilder) Build() *ast.InsertStatement {
+	return &ast.InsertStatement{
+		Table:     b.table,
+		Columns:   b.columns,
+		Rows:      b.rows,
+		Returning: b.returning,
+	}
+}
+
+// UpdateBuilder builds an *ast.UpdateStatement through a fluent, chainable API.
+// Start with Update. A builder is not safe for concurrent use.
+type UpdateBuilder struct {
+	table         string
+	set           []ast.Assignment
+	where         ast.Expression
+	unconditional bool
+	returning     []ast.ColumnRef
+}
+
+// Update starts an UPDATE of the given table. Add assignments with Set and a
+// filter with Where.
+func Update(table string) *UpdateBuilder {
+	return &UpdateBuilder{table: table}
+}
+
+// Set appends a "column = value" assignment, binding value as a parameter.
+// Assignments render in call order, and their values are numbered before any
+// WHERE value. Passing nil sets the column to SQL NULL.
+func (b *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
+	b.set = append(b.set, ast.Assignment{Column: column, Value: &ast.BoundValue{Value: value}})
+	return b
+}
+
+// Where sets the filter expression. Calling Where again replaces the previous
+// expression; compose multiple conditions with And, Or, and Not.
+func (b *UpdateBuilder) Where(expr ast.Expression) *UpdateBuilder {
+	b.where = expr
+	return b
+}
+
+// Unconditional opts in to updating every row. It is required when no Where is
+// set: RenderUpdate rejects a WHERE-less UPDATE unless the statement is marked
+// unconditional, so a whole-table update is always deliberate. It has no effect
+// when a Where is present.
+func (b *UpdateBuilder) Unconditional() *UpdateBuilder {
+	b.unconditional = true
+	return b
+}
+
+// Returning adds columns to the RETURNING clause. See InsertBuilder.Returning for
+// the dialect rules.
+func (b *UpdateBuilder) Returning(columns ...string) *UpdateBuilder {
+	b.returning = appendReturning(b.returning, columns)
+	return b
+}
+
+// Build returns the assembled *ast.UpdateStatement. Render it with
+// renderer.RenderUpdate.
+func (b *UpdateBuilder) Build() *ast.UpdateStatement {
+	return &ast.UpdateStatement{
+		Table:         b.table,
+		Set:           b.set,
+		Where:         b.where,
+		Unconditional: b.unconditional,
+		Returning:     b.returning,
+	}
+}
+
+// DeleteBuilder builds an *ast.DeleteStatement through a fluent, chainable API.
+// Start with DeleteFrom. A builder is not safe for concurrent use.
+type DeleteBuilder struct {
+	table         string
+	where         ast.Expression
+	unconditional bool
+	returning     []ast.ColumnRef
+}
+
+// DeleteFrom starts a DELETE FROM the given table. Add a filter with Where.
+func DeleteFrom(table string) *DeleteBuilder {
+	return &DeleteBuilder{table: table}
+}
+
+// Where sets the filter expression. Calling Where again replaces the previous
+// expression; compose multiple conditions with And, Or, and Not.
+func (b *DeleteBuilder) Where(expr ast.Expression) *DeleteBuilder {
+	b.where = expr
+	return b
+}
+
+// Unconditional opts in to deleting every row. It is required when no Where is
+// set, exactly as on UpdateBuilder.
+func (b *DeleteBuilder) Unconditional() *DeleteBuilder {
+	b.unconditional = true
+	return b
+}
+
+// Returning adds columns to the RETURNING clause. See InsertBuilder.Returning for
+// the dialect rules.
+func (b *DeleteBuilder) Returning(columns ...string) *DeleteBuilder {
+	b.returning = appendReturning(b.returning, columns)
+	return b
+}
+
+// Build returns the assembled *ast.DeleteStatement. Render it with
+// renderer.RenderDelete.
+func (b *DeleteBuilder) Build() *ast.DeleteStatement {
+	return &ast.DeleteStatement{
+		Table:         b.table,
+		Where:         b.where,
+		Unconditional: b.unconditional,
+		Returning:     b.returning,
+	}
+}
+
+// appendReturning appends bare column names as RETURNING projection entries. It
+// backs the Returning method on all three write builders.
+func appendReturning(dst []ast.ColumnRef, columns []string) []ast.ColumnRef {
+	for _, name := range columns {
+		dst = append(dst, ast.ColumnRef{Name: name})
+	}
+	return dst
+}

--- a/core/query/write_test.go
+++ b/core/query/write_test.go
@@ -1,0 +1,142 @@
+package query_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/query"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestInsertBuilder(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("single row", func(c *qt.C) {
+		stmt := query.InsertInto("users").
+			Columns("id", "name").
+			Values(int64(1), "alice").
+			Build()
+		sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `INSERT INTO "users" ("id", "name") VALUES ($1, $2)`)
+		c.Assert(args, qt.DeepEquals, []any{int64(1), "alice"})
+	})
+
+	c.Run("multi row with returning", func(c *qt.C) {
+		stmt := query.InsertInto("users").
+			Columns("id", "name").
+			Values(int64(1), "alice").
+			Values(int64(2), "bob").
+			Returning("id").
+			Build()
+		sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `INSERT INTO "users" ("id", "name") VALUES ($1, $2), ($3, $4) RETURNING "id"`)
+		c.Assert(args, qt.DeepEquals, []any{int64(1), "alice", int64(2), "bob"})
+	})
+
+	c.Run("nil value binds SQL NULL", func(c *qt.C) {
+		stmt := query.InsertInto("users").
+			Columns("name", "deleted_at").
+			Values("alice", nil).
+			Build()
+		sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `INSERT INTO "users" ("name", "deleted_at") VALUES ($1, $2)`)
+		c.Assert(args, qt.DeepEquals, []any{"alice", nil})
+	})
+}
+
+func TestUpdateBuilder(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("set values are numbered before the where value", func(c *qt.C) {
+		stmt := query.Update("users").
+			Set("name", "bob").
+			Set("email", "bob@example.com").
+			Where(query.Eq("id", int64(7))).
+			Returning("updated_at").
+			Build()
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "users" SET "name" = $1, "email" = $2 WHERE "id" = $3 RETURNING "updated_at"`)
+		c.Assert(args, qt.DeepEquals, []any{"bob", "bob@example.com", int64(7)})
+	})
+
+	c.Run("unconditional update renders without a where", func(c *qt.C) {
+		stmt := query.Update("flags").
+			Set("enabled", true).
+			Unconditional().
+			Build()
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "flags" SET "enabled" = $1`)
+		c.Assert(args, qt.DeepEquals, []any{true})
+	})
+
+	c.Run("a where-less update without the opt-in is rejected at render time", func(c *qt.C) {
+		stmt := query.Update("users").Set("active", false).Build()
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.ErrorMatches, "renderer: update without a WHERE clause must be marked unconditional")
+		c.Assert(sql, qt.Equals, "")
+		c.Assert(args, qt.IsNil)
+	})
+}
+
+func TestDeleteBuilder(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("delete with a where", func(c *qt.C) {
+		stmt := query.DeleteFrom("users").
+			Where(query.Eq("id", int64(7))).
+			Build()
+		sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `DELETE FROM "users" WHERE "id" = $1`)
+		c.Assert(args, qt.DeepEquals, []any{int64(7)})
+	})
+
+	c.Run("unconditional delete renders without a where", func(c *qt.C) {
+		stmt := query.DeleteFrom("sessions").Unconditional().Build()
+		sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `DELETE FROM "sessions"`)
+		c.Assert(args, qt.HasLen, 0)
+	})
+
+	c.Run("a where-less delete without the opt-in is rejected at render time", func(c *qt.C) {
+		stmt := query.DeleteFrom("users").Build()
+		sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+		c.Assert(err, qt.ErrorMatches, "renderer: delete without a WHERE clause must be marked unconditional")
+		c.Assert(sql, qt.Equals, "")
+		c.Assert(args, qt.IsNil)
+	})
+}
+
+// TestWriteBuilder_SharedWhereFragment builds one WHERE expression and attaches it
+// to both an UPDATE and a DELETE, mirroring the SELECT builder's shared-fragment
+// story: the expression constructors return plain nodes, so a filter composes
+// across statement kinds.
+func TestWriteBuilder_SharedWhereFragment(t *testing.T) {
+	c := qt.New(t)
+
+	filter := query.And(query.Eq("tenant_id", int64(42)), query.Eq("draft", true))
+
+	c.Run("update reuses the fragment", func(c *qt.C) {
+		stmt := query.Update("commodities").Set("archived", true).Where(filter).Build()
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "commodities" SET "archived" = $1 WHERE ("tenant_id" = $2 AND "draft" = $3)`)
+		c.Assert(args, qt.DeepEquals, []any{true, int64(42), true})
+	})
+
+	c.Run("delete reuses the fragment", func(c *qt.C) {
+		stmt := query.DeleteFrom("commodities").Where(filter).Build()
+		sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `DELETE FROM "commodities" WHERE ("tenant_id" = $1 AND "draft" = $2)`)
+		c.Assert(args, qt.DeepEquals, []any{int64(42), true})
+	})
+}

--- a/core/renderer/dml.go
+++ b/core/renderer/dml.go
@@ -1,0 +1,289 @@
+package renderer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+)
+
+// This file renders the write-side DML statements — INSERT, UPDATE, and DELETE —
+// to parameterized SQL. It reuses the SELECT renderer's parameter machinery
+// (selectRenderer in select.go) so that the whole family shares one placeholder
+// numbering pass, one identifier-quoting path, and one expression renderer. A
+// value can therefore never become an identifier, an identifier can never break
+// out of its quotes, and placeholder numbering is a single left-to-right pass —
+// INSERT binds row by row; UPDATE binds every SET value before any WHERE value;
+// DELETE binds its WHERE values — so callers never manage indices by hand.
+
+// RenderInsert renders an INSERT statement to parameterized SQL for the given
+// dialect, returning the SQL text and its positional arguments.
+//
+// Every value in every row is emitted as a placeholder and returned in args,
+// never interpolated; placeholders are numbered row by row, left to right, in the
+// dialect's style ($1, $2, … for the PostgreSQL family; ? for MySQL, MariaDB, and
+// SQLite). The table and column names are quoted for the dialect. An optional
+// RETURNING clause is emitted only where the dialect supports it (see
+// renderReturning); on MySQL and MariaDB a non-empty RETURNING is an error.
+//
+// It returns an error for a nil statement, an unsupported dialect, a missing
+// table, an empty column list, an empty row list, or a row whose length does not
+// match the column count.
+func RenderInsert(stmt *ast.InsertStatement, dialect string) (string, []any, error) {
+	if stmt == nil {
+		return "", nil, errors.New("renderer: nil insert statement")
+	}
+	r, err := newWriteRenderer(dialect, "INSERT")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := r.renderInsert(stmt); err != nil {
+		return "", nil, err
+	}
+	return r.buf.String(), r.args, nil
+}
+
+// RenderUpdate renders an UPDATE statement to parameterized SQL for the given
+// dialect, returning the SQL text and its positional arguments.
+//
+// SET values are bound before WHERE values, matching emission order, so
+// placeholder numbering is a single left-to-right pass. Table and column names
+// are quoted; every value is bound. An optional RETURNING clause is emitted only
+// where the dialect supports it.
+//
+// A whole-table UPDATE is a footgun, so a statement with no WHERE clause is
+// rejected unless it is explicitly marked Unconditional. It also returns an error
+// for a nil statement, an unsupported dialect, a missing table, an empty SET
+// list, an assignment with an empty column or nil value, or a RETURNING clause on
+// a dialect that cannot execute one.
+func RenderUpdate(stmt *ast.UpdateStatement, dialect string) (string, []any, error) {
+	if stmt == nil {
+		return "", nil, errors.New("renderer: nil update statement")
+	}
+	r, err := newWriteRenderer(dialect, "UPDATE")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := r.renderUpdate(stmt); err != nil {
+		return "", nil, err
+	}
+	return r.buf.String(), r.args, nil
+}
+
+// RenderDelete renders a DELETE statement to parameterized SQL for the given
+// dialect, returning the SQL text and its positional arguments.
+//
+// The table name is quoted and every WHERE value is bound. An optional RETURNING
+// clause is emitted only where the dialect supports it.
+//
+// As with UPDATE, a WHERE-less whole-table DELETE is rejected unless the
+// statement is explicitly marked Unconditional. It also returns an error for a
+// nil statement, an unsupported dialect, a missing table, or a RETURNING clause
+// on a dialect that cannot execute one.
+func RenderDelete(stmt *ast.DeleteStatement, dialect string) (string, []any, error) {
+	if stmt == nil {
+		return "", nil, errors.New("renderer: nil delete statement")
+	}
+	r, err := newWriteRenderer(dialect, "DELETE")
+	if err != nil {
+		return "", nil, err
+	}
+	if err := r.renderDelete(stmt); err != nil {
+		return "", nil, err
+	}
+	return r.buf.String(), r.args, nil
+}
+
+// newWriteRenderer builds a parameter renderer for a write statement, reusing the
+// SELECT renderer's dialect resolution and placeholder numbering (bind),
+// identifier quoting (quote / writeQualifiedIdent / writeTableRef), and
+// expression rendering (renderExpr). kind names the statement in the
+// unsupported-dialect error.
+func newWriteRenderer(dialect, kind string) (*selectRenderer, error) {
+	normalized := platform.NormalizeDialect(dialect)
+	style, ok := selectPlaceholderStyle(normalized)
+	if !ok {
+		return nil, fmt.Errorf("renderer: %s rendering is not supported for dialect %q", kind, dialect)
+	}
+	return &selectRenderer{dialect: normalized, placeholder: style}, nil
+}
+
+func (r *selectRenderer) renderInsert(stmt *ast.InsertStatement) error {
+	if strings.TrimSpace(stmt.Table) == "" {
+		return errors.New("renderer: insert statement requires a table")
+	}
+	if len(stmt.Columns) == 0 {
+		return errors.New("renderer: insert statement requires at least one column")
+	}
+	if len(stmt.Rows) == 0 {
+		return errors.New("renderer: insert statement requires at least one row")
+	}
+
+	r.buf.WriteString("INSERT INTO ")
+	r.writeTableRef(stmt.Table, "")
+	r.buf.WriteString(" (")
+	if err := r.writeInsertColumns(stmt.Columns); err != nil {
+		return err
+	}
+	r.buf.WriteString(") VALUES ")
+	if err := r.writeInsertRows(stmt.Columns, stmt.Rows); err != nil {
+		return err
+	}
+	return r.renderReturning(stmt.Returning)
+}
+
+// writeInsertColumns writes the parenthesized column list. Each name is quoted
+// for the dialect; a blank name is rejected. Names are quoted verbatim, matching
+// how the SELECT projection quotes a column, so the empty check trims but the
+// output does not.
+func (r *selectRenderer) writeInsertColumns(columns []string) error {
+	for i, col := range columns {
+		if strings.TrimSpace(col) == "" {
+			return errors.New("renderer: insert column has an empty name")
+		}
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		r.buf.WriteString(r.quote(col))
+	}
+	return nil
+}
+
+// writeInsertRows writes the comma-separated VALUES rows, binding each value in
+// order so args match placeholder numbering row by row. A row whose length does
+// not match the column count is rejected rather than emitted, so ragged input
+// fails cleanly instead of producing a mismatched INSERT.
+func (r *selectRenderer) writeInsertRows(columns []string, rows [][]ast.Expression) error {
+	for i, row := range rows {
+		if len(row) != len(columns) {
+			return fmt.Errorf("renderer: insert row %d has %d values but there are %d columns", i+1, len(row), len(columns))
+		}
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		r.buf.WriteString("(")
+		for j, value := range row {
+			if j > 0 {
+				r.buf.WriteString(", ")
+			}
+			if err := r.renderExpr(value); err != nil {
+				return err
+			}
+		}
+		r.buf.WriteString(")")
+	}
+	return nil
+}
+
+func (r *selectRenderer) renderUpdate(stmt *ast.UpdateStatement) error {
+	if strings.TrimSpace(stmt.Table) == "" {
+		return errors.New("renderer: update statement requires a table")
+	}
+	if len(stmt.Set) == 0 {
+		return errors.New("renderer: update statement requires at least one assignment")
+	}
+	if stmt.Where == nil && !stmt.Unconditional {
+		return errors.New("renderer: update without a WHERE clause must be marked unconditional")
+	}
+
+	r.buf.WriteString("UPDATE ")
+	r.writeTableRef(stmt.Table, "")
+	r.buf.WriteString(" SET ")
+	if err := r.writeAssignments(stmt.Set); err != nil {
+		return err
+	}
+	if stmt.Where != nil {
+		r.buf.WriteString(" WHERE ")
+		if err := r.renderExpr(stmt.Where); err != nil {
+			return err
+		}
+	}
+	return r.renderReturning(stmt.Returning)
+}
+
+// writeAssignments writes the SET list, binding each value after its quoted
+// column. Because SET renders before WHERE, these values are numbered first.
+func (r *selectRenderer) writeAssignments(assignments []ast.Assignment) error {
+	for i := range assignments {
+		if strings.TrimSpace(assignments[i].Column) == "" {
+			return errors.New("renderer: assignment has an empty column")
+		}
+		if assignments[i].Value == nil {
+			return errors.New("renderer: assignment has a nil value")
+		}
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		r.buf.WriteString(r.quote(assignments[i].Column))
+		r.buf.WriteString(" = ")
+		if err := r.renderExpr(assignments[i].Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *selectRenderer) renderDelete(stmt *ast.DeleteStatement) error {
+	if strings.TrimSpace(stmt.Table) == "" {
+		return errors.New("renderer: delete statement requires a table")
+	}
+	if stmt.Where == nil && !stmt.Unconditional {
+		return errors.New("renderer: delete without a WHERE clause must be marked unconditional")
+	}
+
+	r.buf.WriteString("DELETE FROM ")
+	r.writeTableRef(stmt.Table, "")
+	if stmt.Where != nil {
+		r.buf.WriteString(" WHERE ")
+		if err := r.renderExpr(stmt.Where); err != nil {
+			return err
+		}
+	}
+	return r.renderReturning(stmt.Returning)
+}
+
+// renderReturning appends a RETURNING clause when cols is non-empty, and only for
+// a dialect that can execute one. Each column is quoted like any other
+// identifier; a blank or "*" column is rejected because RETURNING here projects
+// named columns, not a star.
+//
+// RETURNING is supported on the PostgreSQL family (always) and SQLite (since
+// 3.35, 2021). MySQL has no RETURNING at all, and MariaDB supports it only for
+// INSERT and DELETE, not UPDATE — so, to keep one rule across all three write
+// statements, both MySQL and MariaDB are treated as unsupported and a non-empty
+// RETURNING is rejected there rather than emitted as SQL the engine cannot run.
+func (r *selectRenderer) renderReturning(cols []ast.ColumnRef) error {
+	if len(cols) == 0 {
+		return nil
+	}
+	if !r.supportsReturning() {
+		return fmt.Errorf("renderer: %s does not support RETURNING", r.dialect)
+	}
+	r.buf.WriteString(" RETURNING ")
+	for i := range cols {
+		if strings.TrimSpace(cols[i].Name) == "" {
+			return errors.New("renderer: RETURNING column has an empty name")
+		}
+		if strings.TrimSpace(cols[i].Name) == "*" {
+			return errors.New("renderer: RETURNING does not support a star column")
+		}
+		if i > 0 {
+			r.buf.WriteString(", ")
+		}
+		r.writeQualifiedIdent(cols[i].Qualifier, cols[i].Name)
+	}
+	return nil
+}
+
+// supportsReturning reports whether the renderer's dialect can execute a
+// RETURNING clause. See renderReturning for the per-dialect rationale.
+func (r *selectRenderer) supportsReturning() bool {
+	switch r.dialect {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.SQLite:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/renderer/dml_test.go
+++ b/core/renderer/dml_test.go
@@ -1,0 +1,642 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func insertUsers() *ast.InsertStatement {
+	return &ast.InsertStatement{
+		Table:   "users",
+		Columns: []string{"id", "name"},
+		Rows: [][]ast.Expression{
+			{&ast.BoundValue{Value: int64(1)}, &ast.BoundValue{Value: "alice"}},
+		},
+	}
+}
+
+func TestRenderInsert_SingleRow(t *testing.T) {
+	c := qt.New(t)
+
+	wantArgs := []any{int64(1), "alice"}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres uses dollar placeholders and double quotes",
+			dialect: platform.Postgres,
+			wantSQL: `INSERT INTO "users" ("id", "name") VALUES ($1, $2)`,
+		},
+		{
+			name:    "mysql uses question placeholders and backticks",
+			dialect: platform.MySQL,
+			wantSQL: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?)",
+		},
+		{
+			name:    "mariadb matches mysql",
+			dialect: platform.MariaDB,
+			wantSQL: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?)",
+		},
+		{
+			name:    "sqlite uses question placeholders and double quotes",
+			dialect: platform.SQLite,
+			wantSQL: `INSERT INTO "users" ("id", "name") VALUES (?, ?)`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderInsert(insertUsers(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderInsert_MultiRow(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.InsertStatement{
+		Table:   "users",
+		Columns: []string{"id", "name"},
+		Rows: [][]ast.Expression{
+			{&ast.BoundValue{Value: int64(1)}, &ast.BoundValue{Value: "alice"}},
+			{&ast.BoundValue{Value: int64(2)}, &ast.BoundValue{Value: "bob"}},
+			{&ast.BoundValue{Value: int64(3)}, &ast.BoundValue{Value: "carol"}},
+		},
+	}
+	wantArgs := []any{int64(1), "alice", int64(2), "bob", int64(3), "carol"}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres numbers every value across rows",
+			dialect: platform.Postgres,
+			wantSQL: `INSERT INTO "users" ("id", "name") VALUES ($1, $2), ($3, $4), ($5, $6)`,
+		},
+		{
+			name:    "mysql repeats question placeholders",
+			dialect: platform.MySQL,
+			wantSQL: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?), (?, ?), (?, ?)",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderInsert(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderInsert_Returning(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.InsertStatement{
+		Table:     "users",
+		Columns:   []string{"name"},
+		Rows:      [][]ast.Expression{{&ast.BoundValue{Value: "alice"}}},
+		Returning: []ast.ColumnRef{{Name: "id"}, {Name: "created_at"}},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres renders RETURNING",
+			dialect: platform.Postgres,
+			wantSQL: `INSERT INTO "users" ("name") VALUES ($1) RETURNING "id", "created_at"`,
+		},
+		{
+			name:    "sqlite renders RETURNING",
+			dialect: platform.SQLite,
+			wantSQL: `INSERT INTO "users" ("name") VALUES (?) RETURNING "id", "created_at"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderInsert(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{"alice"})
+		})
+	}
+}
+
+func TestRenderInsert_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		stmt        *ast.InsertStatement
+		dialect     string
+		wantErrLike string
+	}{
+		{
+			name:        "nil statement",
+			stmt:        nil,
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil insert statement",
+		},
+		{
+			name:        "unsupported dialect",
+			stmt:        insertUsers(),
+			dialect:     platform.ClickHouse,
+			wantErrLike: `renderer: INSERT rendering is not supported for dialect "clickhouse"`,
+		},
+		{
+			name:        "missing table",
+			stmt:        &ast.InsertStatement{Columns: []string{"a"}, Rows: [][]ast.Expression{{&ast.BoundValue{Value: 1}}}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: insert statement requires a table",
+		},
+		{
+			name:        "no columns",
+			stmt:        &ast.InsertStatement{Table: "t", Rows: [][]ast.Expression{{}}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: insert statement requires at least one column",
+		},
+		{
+			name:        "no rows",
+			stmt:        &ast.InsertStatement{Table: "t", Columns: []string{"a"}},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: insert statement requires at least one row",
+		},
+		{
+			name: "ragged row",
+			stmt: &ast.InsertStatement{
+				Table:   "t",
+				Columns: []string{"a", "b"},
+				Rows:    [][]ast.Expression{{&ast.BoundValue{Value: 1}}},
+			},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: insert row 1 has 1 values but there are 2 columns",
+		},
+		{
+			name: "empty column name",
+			stmt: &ast.InsertStatement{
+				Table:   "t",
+				Columns: []string{"  "},
+				Rows:    [][]ast.Expression{{&ast.BoundValue{Value: 1}}},
+			},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: insert column has an empty name",
+		},
+		{
+			name: "returning on mysql",
+			stmt: &ast.InsertStatement{
+				Table:     "t",
+				Columns:   []string{"a"},
+				Rows:      [][]ast.Expression{{&ast.BoundValue{Value: 1}}},
+				Returning: []ast.ColumnRef{{Name: "id"}},
+			},
+			dialect:     platform.MySQL,
+			wantErrLike: "renderer: mysql does not support RETURNING",
+		},
+		{
+			name: "returning on mariadb",
+			stmt: &ast.InsertStatement{
+				Table:     "t",
+				Columns:   []string{"a"},
+				Rows:      [][]ast.Expression{{&ast.BoundValue{Value: 1}}},
+				Returning: []ast.ColumnRef{{Name: "id"}},
+			},
+			dialect:     platform.MariaDB,
+			wantErrLike: "renderer: mariadb does not support RETURNING",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderInsert(tt.stmt, tt.dialect)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+func updateUser() *ast.UpdateStatement {
+	return &ast.UpdateStatement{
+		Table: "users",
+		Set: []ast.Assignment{
+			{Column: "name", Value: &ast.BoundValue{Value: "bob"}},
+			{Column: "email", Value: &ast.BoundValue{Value: "bob@example.com"}},
+		},
+		Where: &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "id"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: int64(7)},
+		},
+	}
+}
+
+func TestRenderUpdate_SetThenWhere(t *testing.T) {
+	c := qt.New(t)
+
+	wantArgs := []any{"bob", "bob@example.com", int64(7)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres binds SET values before the WHERE value",
+			dialect: platform.Postgres,
+			wantSQL: `UPDATE "users" SET "name" = $1, "email" = $2 WHERE "id" = $3`,
+		},
+		{
+			name:    "mysql binds SET values before the WHERE value",
+			dialect: platform.MySQL,
+			wantSQL: "UPDATE `users` SET `name` = ?, `email` = ? WHERE `id` = ?",
+		},
+		{
+			name:    "sqlite binds SET values before the WHERE value",
+			dialect: platform.SQLite,
+			wantSQL: `UPDATE "users" SET "name" = ?, "email" = ? WHERE "id" = ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderUpdate(updateUser(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderUpdate_Returning(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.UpdateStatement{
+		Table:     "users",
+		Set:       []ast.Assignment{{Column: "name", Value: &ast.BoundValue{Value: "bob"}}},
+		Where:     &ast.Comparison{Left: &ast.ColumnRef{Name: "id"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: int64(7)}},
+		Returning: []ast.ColumnRef{{Name: "updated_at"}},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres renders RETURNING",
+			dialect: platform.Postgres,
+			wantSQL: `UPDATE "users" SET "name" = $1 WHERE "id" = $2 RETURNING "updated_at"`,
+		},
+		{
+			name:    "sqlite renders RETURNING",
+			dialect: platform.SQLite,
+			wantSQL: `UPDATE "users" SET "name" = ? WHERE "id" = ? RETURNING "updated_at"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderUpdate(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{"bob", int64(7)})
+		})
+	}
+}
+
+func TestRenderUpdate_NoWhereGuard(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("without unconditional the whole-table update is rejected", func(c *qt.C) {
+		stmt := &ast.UpdateStatement{
+			Table: "users",
+			Set:   []ast.Assignment{{Column: "active", Value: &ast.BoundValue{Value: false}}},
+		}
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.ErrorMatches, "renderer: update without a WHERE clause must be marked unconditional")
+		c.Assert(sql, qt.Equals, "")
+		c.Assert(args, qt.IsNil)
+	})
+
+	c.Run("with unconditional the whole-table update renders", func(c *qt.C) {
+		stmt := &ast.UpdateStatement{
+			Table:         "users",
+			Set:           []ast.Assignment{{Column: "active", Value: &ast.BoundValue{Value: false}}},
+			Unconditional: true,
+		}
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "users" SET "active" = $1`)
+		c.Assert(args, qt.DeepEquals, []any{false})
+	})
+}
+
+func TestRenderUpdate_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		stmt        *ast.UpdateStatement
+		dialect     string
+		wantErrLike string
+	}{
+		{
+			name:        "nil statement",
+			stmt:        nil,
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil update statement",
+		},
+		{
+			name:        "missing table",
+			stmt:        &ast.UpdateStatement{Set: []ast.Assignment{{Column: "a", Value: &ast.BoundValue{Value: 1}}}, Unconditional: true},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: update statement requires a table",
+		},
+		{
+			name:        "empty set",
+			stmt:        &ast.UpdateStatement{Table: "t", Unconditional: true},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: update statement requires at least one assignment",
+		},
+		{
+			name:        "empty column",
+			stmt:        &ast.UpdateStatement{Table: "t", Set: []ast.Assignment{{Column: " ", Value: &ast.BoundValue{Value: 1}}}, Unconditional: true},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: assignment has an empty column",
+		},
+		{
+			name:        "nil value",
+			stmt:        &ast.UpdateStatement{Table: "t", Set: []ast.Assignment{{Column: "a"}}, Unconditional: true},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: assignment has a nil value",
+		},
+		{
+			name: "returning on mysql",
+			stmt: &ast.UpdateStatement{
+				Table:     "t",
+				Set:       []ast.Assignment{{Column: "a", Value: &ast.BoundValue{Value: 1}}},
+				Where:     &ast.Comparison{Left: &ast.ColumnRef{Name: "id"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: 1}},
+				Returning: []ast.ColumnRef{{Name: "a"}},
+			},
+			dialect:     platform.MySQL,
+			wantErrLike: "renderer: mysql does not support RETURNING",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderUpdate(tt.stmt, tt.dialect)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+func deleteUser() *ast.DeleteStatement {
+	return &ast.DeleteStatement{
+		Table: "users",
+		Where: &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "id"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: int64(7)},
+		},
+	}
+}
+
+func TestRenderDelete_Where(t *testing.T) {
+	c := qt.New(t)
+
+	wantArgs := []any{int64(7)}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres",
+			dialect: platform.Postgres,
+			wantSQL: `DELETE FROM "users" WHERE "id" = $1`,
+		},
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			wantSQL: "DELETE FROM `users` WHERE `id` = ?",
+		},
+		{
+			name:    "sqlite",
+			dialect: platform.SQLite,
+			wantSQL: `DELETE FROM "users" WHERE "id" = ?`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderDelete(deleteUser(), tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, wantArgs)
+		})
+	}
+}
+
+func TestRenderDelete_NoWhereGuard(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("without unconditional the whole-table delete is rejected", func(c *qt.C) {
+		sql, args, err := renderer.RenderDelete(&ast.DeleteStatement{Table: "users"}, platform.Postgres)
+		c.Assert(err, qt.ErrorMatches, "renderer: delete without a WHERE clause must be marked unconditional")
+		c.Assert(sql, qt.Equals, "")
+		c.Assert(args, qt.IsNil)
+	})
+
+	c.Run("with unconditional the whole-table delete renders and binds nothing", func(c *qt.C) {
+		sql, args, err := renderer.RenderDelete(&ast.DeleteStatement{Table: "users", Unconditional: true}, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `DELETE FROM "users"`)
+		c.Assert(args, qt.HasLen, 0)
+	})
+}
+
+func TestRenderDelete_Returning(t *testing.T) {
+	c := qt.New(t)
+
+	stmt := &ast.DeleteStatement{
+		Table:     "users",
+		Where:     &ast.Comparison{Left: &ast.ColumnRef{Name: "id"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: int64(7)}},
+		Returning: []ast.ColumnRef{{Name: "id"}},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+		wantSQL string
+	}{
+		{
+			name:    "postgres renders RETURNING",
+			dialect: platform.Postgres,
+			wantSQL: `DELETE FROM "users" WHERE "id" = $1 RETURNING "id"`,
+		},
+		{
+			name:    "sqlite renders RETURNING",
+			dialect: platform.SQLite,
+			wantSQL: `DELETE FROM "users" WHERE "id" = ? RETURNING "id"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderDelete(stmt, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.wantSQL)
+			c.Assert(args, qt.DeepEquals, []any{int64(7)})
+		})
+	}
+}
+
+func TestRenderDelete_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		stmt        *ast.DeleteStatement
+		dialect     string
+		wantErrLike string
+	}{
+		{
+			name:        "nil statement",
+			stmt:        nil,
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: nil delete statement",
+		},
+		{
+			name:        "unsupported dialect",
+			stmt:        deleteUser(),
+			dialect:     platform.ClickHouse,
+			wantErrLike: `renderer: DELETE rendering is not supported for dialect "clickhouse"`,
+		},
+		{
+			name:        "missing table",
+			stmt:        &ast.DeleteStatement{Unconditional: true},
+			dialect:     platform.Postgres,
+			wantErrLike: "renderer: delete statement requires a table",
+		},
+		{
+			name: "returning on mysql",
+			stmt: &ast.DeleteStatement{
+				Table:     "t",
+				Where:     &ast.Comparison{Left: &ast.ColumnRef{Name: "id"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: 1}},
+				Returning: []ast.ColumnRef{{Name: "id"}},
+			},
+			dialect:     platform.MySQL,
+			wantErrLike: "renderer: mysql does not support RETURNING",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			sql, args, err := renderer.RenderDelete(tt.stmt, tt.dialect)
+			c.Assert(err, qt.ErrorMatches, tt.wantErrLike)
+			c.Assert(sql, qt.Equals, "")
+			c.Assert(args, qt.IsNil)
+		})
+	}
+}
+
+// TestRenderWrite_ValuesStayBound feeds a SQL-injection payload through an INSERT
+// value, an UPDATE SET value, and a DELETE WHERE value, and asserts each ends up
+// as a bound argument — never spliced into the SQL text.
+func TestRenderWrite_ValuesStayBound(t *testing.T) {
+	c := qt.New(t)
+
+	payload := `x'); DROP TABLE users; --`
+
+	c.Run("insert value is bound", func(c *qt.C) {
+		stmt := &ast.InsertStatement{
+			Table:   "users",
+			Columns: []string{"name"},
+			Rows:    [][]ast.Expression{{&ast.BoundValue{Value: payload}}},
+		}
+		sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `INSERT INTO "users" ("name") VALUES ($1)`)
+		c.Assert(sql, qt.Not(qt.Contains), "DROP TABLE")
+		c.Assert(args, qt.DeepEquals, []any{payload})
+	})
+
+	c.Run("update set value is bound", func(c *qt.C) {
+		stmt := &ast.UpdateStatement{
+			Table:         "users",
+			Set:           []ast.Assignment{{Column: "name", Value: &ast.BoundValue{Value: payload}}},
+			Unconditional: true,
+		}
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "users" SET "name" = $1`)
+		c.Assert(sql, qt.Not(qt.Contains), "DROP TABLE")
+		c.Assert(args, qt.DeepEquals, []any{payload})
+	})
+
+	c.Run("delete where value is bound", func(c *qt.C) {
+		stmt := &ast.DeleteStatement{
+			Table: "users",
+			Where: &ast.Comparison{Left: &ast.ColumnRef{Name: "name"}, Operator: ast.OpEqual, Right: &ast.BoundValue{Value: payload}},
+		}
+		sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `DELETE FROM "users" WHERE "name" = $1`)
+		c.Assert(sql, qt.Not(qt.Contains), "DROP TABLE")
+		c.Assert(args, qt.DeepEquals, []any{payload})
+	})
+}
+
+// TestRenderWrite_IdentifiersAreQuoted feeds a quote-bearing identifier through a
+// table name, an INSERT column, and an UPDATE assignment column, and asserts the
+// embedded quote is doubled (escaped) so the identifier can never terminate its
+// quotes — an identifier stays an identifier.
+func TestRenderWrite_IdentifiersAreQuoted(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("insert column and table are quoted", func(c *qt.C) {
+		stmt := &ast.InsertStatement{
+			Table:   `us"ers`,
+			Columns: []string{`na"me`},
+			Rows:    [][]ast.Expression{{&ast.BoundValue{Value: "alice"}}},
+		}
+		sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `INSERT INTO "us""ers" ("na""me") VALUES ($1)`)
+		c.Assert(args, qt.DeepEquals, []any{"alice"})
+	})
+
+	c.Run("update assignment column is quoted", func(c *qt.C) {
+		stmt := &ast.UpdateStatement{
+			Table:         "users",
+			Set:           []ast.Assignment{{Column: `na"me`, Value: &ast.BoundValue{Value: "alice"}}},
+			Unconditional: true,
+		}
+		sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sql, qt.Equals, `UPDATE "users" SET "na""me" = $1`)
+		c.Assert(args, qt.DeepEquals, []any{"alice"})
+	})
+}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -77,6 +77,7 @@ type AlterTableEnableRLSNode struct{ ... }
 type AlterTableNode struct{ ... }
 type AlterTypeNode struct{ ... }
     func NewAlterType(name string) *AlterTypeNode
+type Assignment struct{ ... }
 type BoundValue struct{ ... }
 type ColumnNode struct{ ... }
     func NewColumn(name, dataType string) *ColumnNode
@@ -120,6 +121,7 @@ type CreateTypeNode struct{ ... }
 type CreateViewNode struct{ ... }
     func NewCreateView(name string) *CreateViewNode
 type DefaultValue struct{ ... }
+type DeleteStatement struct{ ... }
 type DomainTypeDef struct{ ... }
     func NewDomainTypeDef(baseType string) *DomainTypeDef
 type DropColumnOperation struct{ ... }
@@ -163,6 +165,7 @@ type InExpr struct{ ... }
 type IndexNode struct{ ... }
     func NewIndex(name, table string, columns ...string) *IndexNode
 type IndexPart struct{ ... }
+type InsertStatement struct{ ... }
 type JoinClause struct{ ... }
 type JoinType int
     const JoinInner JoinType = iota ...
@@ -244,6 +247,7 @@ type SortDirection int
 type StatementList struct{ ... }
 type TypeDefinition interface{ ... }
 type TypeOperation interface{ ... }
+type UpdateStatement struct{ ... }
 type UpsertAssignment struct{ ... }
 type UpsertNode struct{ ... }
     func NewUpsert(table string) *UpsertNode
@@ -552,18 +556,27 @@ func Or(exprs ...ast.Expression) ast.Expression
 func Sum(column string) ast.Expression
 type Column struct{ ... }
     func Col(qualifier, name string) Column
+type DeleteBuilder struct{ ... }
+    func DeleteFrom(table string) *DeleteBuilder
 type ExprCompare struct{ ... }
     func Expr(left ast.Expression) ExprCompare
+type InsertBuilder struct{ ... }
+    func InsertInto(table string) *InsertBuilder
 type SelectBuilder struct{ ... }
     func Select(columns ...string) *SelectBuilder
+type UpdateBuilder struct{ ... }
+    func Update(table string) *UpdateBuilder
 
 ## github.com/stokaro/ptah/core/renderer
 
 func GetOrderedCreateStatements(r *goschema.Database, dialect string) ([]string, error)
 func GetOrderedCreateStatementsWithCapabilities(r *goschema.Database, dialect string, caps capability.Capabilities) ([]string, error)
+func RenderDelete(stmt *ast.DeleteStatement, dialect string) (string, []any, error)
+func RenderInsert(stmt *ast.InsertStatement, dialect string) (string, []any, error)
 func RenderSQL(dialect string, nodes ...ast.Node) (string, error)
 func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nodes ...ast.Node) (string, error)
 func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error)
+func RenderUpdate(stmt *ast.UpdateStatement, dialect string) (string, []any, error)
 func SupportedDialects() []string
 func VisitorRenderSQL(r RenderVisitor, nodes ...ast.Node) (string, error)
 type RenderVisitor interface{ ... }

--- a/docs/site/src/content/docs/reference/query-builder.md
+++ b/docs/site/src/content/docs/reference/query-builder.md
@@ -28,10 +28,13 @@ Implemented so far:
   [Aggregates, GROUP BY, and HAVING](#aggregates-group-by-and-having));
 - `GROUP BY` (bare or qualified columns) and `HAVING`;
 - `ORDER BY` with per-column `ASC`/`DESC`;
-- `LIMIT` and `OFFSET`.
+- `LIMIT` and `OFFSET`;
+- single-table `INSERT` (one or more `VALUES` rows), `UPDATE`, and `DELETE`,
+  each with an optional `RETURNING` clause (see [Writes](#writes)).
 
 Not yet implemented (follow-up phases): non-aggregate function calls, arithmetic,
-`LIKE`, subqueries, window functions, and the `INSERT`/`UPDATE`/`DELETE` family.
+`LIKE`, subqueries, window functions, `ON CONFLICT` / upsert, `INSERT … SELECT`,
+and common table expressions.
 
 ## Safety model
 
@@ -258,7 +261,125 @@ stmt := query.Select().
 // GROUP BY "u"."name"
 ```
 
+## Writes
+
+`InsertInto`, `Update`, and `DeleteFrom` build the write-side statements. Values
+passed to `Values` and `Set` are bound exactly like `WHERE` values — never
+concatenated into SQL — and table and column names are quoted. Each statement has
+its own renderer entry point, all returning `(sql string, args []any, err error)`:
+
+- `renderer.RenderInsert(stmt, dialect)`
+- `renderer.RenderUpdate(stmt, dialect)`
+- `renderer.RenderDelete(stmt, dialect)`
+
+Validation of degenerate input happens at render time (as with `SELECT`), so a
+builder call never fails and `Build` never returns an error.
+
+### INSERT
+
+Declare the column list with `Columns` and add one row per `Values` call. A
+multi-row insert numbers its values row by row, left to right. Passing `nil` as a
+value binds SQL `NULL`.
+
+```go
+stmt := query.InsertInto("users").
+	Columns("id", "name").
+	Values(int64(1), "alice").
+	Values(int64(2), "bob").
+	Returning("id").
+	Build()
+
+sql, args, err := renderer.RenderInsert(stmt, platform.Postgres)
+```
+
+The PostgreSQL output is:
+
+```sql
+INSERT INTO "users" ("id", "name") VALUES ($1, $2), ($3, $4) RETURNING "id"
+```
+
+with `args` equal to `[]any{int64(1), "alice", int64(2), "bob"}`. `RenderInsert`
+rejects a statement with no columns, no rows, or a row whose length does not match
+the column count — ragged input fails cleanly instead of producing mismatched SQL.
+
+### UPDATE
+
+Add assignments with `Set` (each value bound) and a filter with `Where`. An
+`UPDATE`'s `SET` values are numbered **before** its `WHERE` values, matching
+emission order, so placeholder numbering follows the SQL left to right.
+
+```go
+stmt := query.Update("users").
+	Set("name", "bob").
+	Set("email", "bob@example.com").
+	Where(query.Eq("id", int64(7))).
+	Build()
+
+sql, args, err := renderer.RenderUpdate(stmt, platform.Postgres)
+```
+
+The PostgreSQL output is:
+
+```sql
+UPDATE "users" SET "name" = $1, "email" = $2 WHERE "id" = $3
+```
+
+with `args` equal to `[]any{"bob", "bob@example.com", int64(7)}`. An empty `SET`
+list is rejected.
+
+### DELETE
+
+```go
+stmt := query.DeleteFrom("users").Where(query.Eq("id", int64(7))).Build()
+
+sql, args, err := renderer.RenderDelete(stmt, platform.Postgres)
+// DELETE FROM "users" WHERE "id" = $1   args: []any{int64(7)}
+```
+
+A `WHERE` expression can be built once and shared across statement kinds, exactly
+as with `SELECT` — the expression constructors return plain nodes.
+
+### Whole-table UPDATE / DELETE guard
+
+An `UPDATE` or `DELETE` with no `WHERE` clause mutates every row, which is rarely
+intended. Rather than make that the accidental default, the builder requires an
+explicit opt-in: call `.Unconditional()`. Without it, the renderer rejects a
+`WHERE`-less statement rather than run a whole-table mutation.
+
+```go
+// Rejected: "renderer: delete without a WHERE clause must be marked unconditional"
+query.DeleteFrom("sessions").Build()
+
+// Deliberate whole-table delete — renders as DELETE FROM "sessions"
+query.DeleteFrom("sessions").Unconditional().Build()
+```
+
+### RETURNING support by dialect
+
+`Returning` adds a `RETURNING` projection to any of the three statements.
+`RETURNING` is not portable across every dialect, so `RenderInsert` /
+`RenderUpdate` / `RenderDelete` reject it — returning a clear error — on a dialect
+that cannot execute it, rather than emit SQL that fails at execution time.
+
+| Dialect | `RETURNING` |
+| --- | --- |
+| PostgreSQL family (incl. CockroachDB, YugabyteDB) | yes |
+| SQLite | yes (since 3.35, 2021) |
+| MySQL | no |
+| MariaDB | no (see note) |
+
+- **MySQL** has no `RETURNING` at all.
+- **MariaDB** supports `RETURNING` for `INSERT` and `DELETE` but not `UPDATE`. To
+  keep one rule across all three write statements, Ptah treats MariaDB as
+  unsupported and rejects a non-empty `RETURNING`
+  (`renderer: mariadb does not support RETURNING`).
+- **SQLite** gained `RETURNING` in 3.35 (2021). Ptah emits it; if you must target
+  an older SQLite, avoid `Returning`.
+
 ## Builder reference
+
+`Select` starts a read query; `InsertInto`, `Update`, and `DeleteFrom` start the
+write statements.
 
 | Function | Result |
 | --- | --- |
@@ -276,6 +397,21 @@ stmt := query.Select().
 | `.OrderBy(terms ...)` | Append sort terms across calls. |
 | `.Limit(n)` / `.Offset(n)` | Set bound row limit/offset. |
 | `.Build()` | Produce the `*ast.SelectStatement`. |
+
+Write builders:
+
+| Function | Result |
+| --- | --- |
+| `InsertInto(table)` | Start an `INSERT`. |
+| `.Columns(cols ...string)` | Declare the inserted column list. |
+| `.Values(vals ...any)` | Append one row of bound values; call once per row. |
+| `Update(table)` | Start an `UPDATE`. |
+| `.Set(col, value)` | Append a bound `column = value` assignment. |
+| `DeleteFrom(table)` | Start a `DELETE`. |
+| `.Where(expr)` | Set the filter (shared by `Update` and `DeleteFrom`). |
+| `.Unconditional()` | Opt in to a whole-table `UPDATE`/`DELETE` (required when no `Where`). |
+| `.Returning(cols ...string)` | Add a `RETURNING` projection (PostgreSQL family and SQLite only). |
+| `.Build()` | Produce the `*ast.InsertStatement` / `*ast.UpdateStatement` / `*ast.DeleteStatement`. |
 
 Expression helpers: `Eq`, `Ne`, `Lt`, `Le`, `Gt`, `Ge`, `In`, `IsNull`,
 `IsNotNull`, `And`, `Or`, `Not`. Ordering helpers: `Asc`, `Desc`. Aggregate


### PR DESCRIPTION
## Summary

Phase 4 (the final phase) of #98 adds the **write-side DML** to the query
builder: `INSERT`, `UPDATE`, and `DELETE`. It builds additively on the merged
SELECT builder (Phases 1-3, PRs #773 / #775 / #776) and reuses their
infrastructure rather than duplicating it — the same `Expression` tree for
`WHERE`, the same bind/quote machinery, and the same `$N` / `?` dialect
placeholder logic. **No Phase 1-3 signature or output changed** (their tests pass
unmodified; `select.go` is untouched).

With this, the query builder covers the full read + write DML surface.

## What's added

**AST — `core/ast/write.go`**
- `InsertStatement{Table, Columns, Rows [][]Expression, Returning []ColumnRef}` — multi-row `VALUES`.
- `UpdateStatement{Table, Set []Assignment, Where, Unconditional, Returning}`.
- `DeleteStatement{Table, Where, Unconditional, Returning}`.
- `Assignment{Column string, Value Expression}`.

These are **statements**, like `SelectStatement` — they are not part of the
sealed `Expression` interface. Their value and filter positions reuse the
existing expression nodes (`BoundValue`, `ColumnRef`, `Comparison`, `LogicalExpr`, …).

**Builder — `core/query/write.go`**

```go
ins := query.InsertInto("users").
    Columns("id", "name").
    Values(int64(1), "alice").
    Values(int64(2), "bob").   // call once per row for multi-row INSERT
    Returning("id").
    Build()

upd := query.Update("users").
    Set("name", "bob").
    Set("email", "bob@example.com").
    Where(query.Eq("id", int64(7))).
    Build()

del := query.DeleteFrom("users").Where(query.Eq("id", int64(7))).Build()
```

Values passed to `Values`/`Set` accept `any` and are wrapped as bound parameters;
table/column/`RETURNING` identifiers are quoted via `internal/sqlident`. Build
never fails; degenerate input is caught at render time, mirroring the SELECT
builder.

**Renderer — `core/renderer/dml.go`**
- `RenderInsert(stmt, dialect) (sql string, args []any, err error)`
- `RenderUpdate(...)`, `RenderDelete(...)`

These reuse the existing `selectRenderer` (its `bind` / `quote` /
`writeQualifiedIdent` / `writeTableRef` / `renderExpr`) via a small shared
`newWriteRenderer` constructor, so the whole DML family shares **one**
left-to-right parameter-numbering pass.

## Parameter ordering

Numbering is a single left-to-right pass over emission order, so `args` always
match the placeholders:

- **INSERT** — row by row: `VALUES ($1, $2), ($3, $4)`.
- **UPDATE** — every `SET` value **before** any `WHERE` value:
  `SET "name" = $1, "email" = $2 WHERE "id" = $3`.
- **DELETE** — `WHERE` values.

Verified per dialect for `$N` (PostgreSQL family) and `?` (MySQL / MariaDB /
SQLite).

## RETURNING dialect matrix

`RETURNING` is not portable. A non-empty `RETURNING` on an unsupported dialect
returns a clear error (same fail-fast posture as the SELECT builder's dialect
guards) rather than emitting SQL that fails at execution time.

| Dialect | `RETURNING` |
| --- | --- |
| PostgreSQL family (incl. CockroachDB, YugabyteDB) | yes |
| SQLite | yes (since 3.35, 2021) |
| MySQL | no |
| MariaDB | no |

MySQL has no `RETURNING` at all. MariaDB supports it for `INSERT`/`DELETE` but
**not** `UPDATE`, so — to keep one rule across all three statements — it is
treated as unsupported and rejected (`renderer: mariadb does not support RETURNING`).

## Whole-table UPDATE/DELETE safety guard

A `WHERE`-less `UPDATE`/`DELETE` mutates every row — a classic footgun. Rather
than make it the accidental default, it is rejected at render time unless the
builder opts in explicitly with `.Unconditional()`:

```go
query.DeleteFrom("sessions").Build()               // error: must be marked unconditional
query.DeleteFrom("sessions").Unconditional().Build() // DELETE FROM "sessions"
```

Other degenerate inputs also error cleanly (never panic): INSERT with zero
columns / zero rows / a ragged row (row length != column count), and an empty
`SET`.

## Backward compatibility

Additive only. `select.go` is unchanged; the public-API snapshot diff is purely
additions (4 AST types, 3 builders + 3 constructors, 3 renderer functions); the
released-baseline `apidiff` reports no incompatibilities. Phase 1-3 tests are
untouched and pass.

## Deferred (follow-ups, out of scope)

`ON CONFLICT` / upsert, `INSERT ... SELECT`, CTEs, subqueries in values, and
multi-table `UPDATE`/`DELETE`.

## Verification

- `go build ./...`, `go vet ./core/...`, `gofmt -l` (empty) — clean.
- `golangci-lint run ./core/ast/... ./core/query/... ./core/renderer/...` — 0 issues.
- `go tool qtlint ./...` — 0 issues. `go tool teststyle` — OK.
- Full `go test ./...` — 138 packages ok, 0 failures (incl. unchanged Phase 1-3 tests).
- New table-driven, per-dialect tests: single + multi-row INSERT, UPDATE SET+WHERE
  ordering, DELETE, RETURNING on PG/SQLite and the MySQL/MariaDB error, the
  no-WHERE guard, ragged/empty INSERT and empty SET errors, injection-value-stays-bound,
  and identifier quoting (embedded quote is doubled).
- Public-API snapshot regenerated; `check-public-api.sh` + `check-public-api-snapshot.sh` pass.
- Docs: `reference/query-builder.md` gains a **Writes** section (INSERT/UPDATE/DELETE,
  the RETURNING matrix, the no-WHERE guard, a write-builder reference); all
  `docs/site` `check:*` scripts pass.
