### PR TITLE
Support materialized-view refresh strategies in Atlas HCL (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -54,7 +54,8 @@ current schema IR:
 - PostgreSQL `function` blocks with `schema`, `lang`, `arg`, `return`,
   `security`, `volatility`, `as`, and `comment`
 - PostgreSQL `view` blocks with `schema`, `as`, `check_option`, and `comment`
-- PostgreSQL `materialized` blocks with `schema`, `as`, and `comment`
+- PostgreSQL `materialized` blocks with `schema`, `as`, `refresh_strategy`, and
+  `comment`
 - PostgreSQL `trigger` blocks with `on`, one of `before`/`after`/`instead_of`,
   `for` or `foreach`, `as`, and `comment`
 - PostgreSQL `policy` blocks with `on`, `for`, `to`, `using`, `check`, and
@@ -338,8 +339,9 @@ view "active_users" {
 }
 
 materialized "user_stats" {
-  schema = schema.public
-  as     = "SELECT count(*) FROM users"
+  schema           = schema.public
+  as               = "SELECT count(*) FROM users"
+  refresh_strategy = "concurrently"
 }
 
 trigger "users_set_updated_at" {
@@ -395,7 +397,6 @@ Atlas features that Ptah cannot represent without losing semantics, including:
 - role passwords
 - forced row-level security (`row_security.enforced`)
 - grantor metadata
-- materialized-view refresh strategies beyond Ptah's default manual behavior
 - function options outside Ptah's current IR, such as `leakproof`, `parallel`,
   `return_set`, `return_table`, `config_params`, and argument defaults
 - view/materialized-view column metadata

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -59,20 +59,20 @@ directly from Ptah's IR:
 - PostgreSQL grants as Atlas `permission` blocks for table and schema targets
 - PostgreSQL functions with body, language, return type, simple argument
   blocks, security, volatility, and comments
-- PostgreSQL views and materialized views with query bodies and comments
+- PostgreSQL views and materialized views with query bodies, comments, and
+  materialized-view refresh strategies (`refresh_strategy`)
 - PostgreSQL triggers with timing/event blocks, `for`, body, and comments
 - PostgreSQL row-level security enablement as `table.row_security`
 - PostgreSQL row-level security policies
 
 Unsupported or lossy details are reported as export diagnostics on stderr.
 Examples include platform-specific overrides, table custom SQL, extension
-`if_not_exists`, role passwords, grantor metadata, non-manual
-materialized-view refresh strategies, RLS enablement comments, standalone
-sequence objects (`//migrator:schema:sequence`) and their grants, user-defined
-types (`//migrator:schema:domain` / `:composite` / `:range`), and function
-parameter strings that cannot be split into Atlas `arg` blocks without losing
-meaning. These warnings are intentional; the exporter must not silently drop
-schema intent.
+`if_not_exists`, role passwords, grantor metadata, RLS enablement comments,
+standalone sequence objects (`//migrator:schema:sequence`) and their grants,
+user-defined types (`//migrator:schema:domain` / `:composite` / `:range`), and
+function parameter strings that cannot be split into Atlas `arg` blocks without
+losing meaning. These warnings are intentional; the exporter must not silently
+drop schema intent.
 
 ## Cleanup Mode
 

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -65,7 +65,7 @@ table "users" {
 | `role` | PostgreSQL role attributes such as `login`, `superuser`, `create_db`, and `inherit`. |
 | `permission` | PostgreSQL table, schema, and sequence permissions. |
 | `function` | PostgreSQL function metadata and raw body. |
-| `view` / `materialized` | SQL body plus schema and comments. |
+| `view` / `materialized` | SQL body plus schema and comments; `materialized` also supports `refresh_strategy`. |
 | `trigger` | Trigger timing, target, execution mode, function body, and comments. |
 | `policy` | PostgreSQL RLS policy fields. |
 | `sequence` | PostgreSQL `type`, `start`, `increment`, `min_value`, `max_value`, `cache`, `cycle`, `owned_by`, and `if_not_exists`. |

--- a/internal/atlashcl/materialized_test.go
+++ b/internal/atlashcl/materialized_test.go
@@ -1,0 +1,110 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseMaterializedViewRefreshStrategy(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+materialized "user_stats" {
+  schema           = schema.public
+  as               = "SELECT count(*) FROM users"
+  refresh_strategy = "concurrently"
+  comment          = "user stats"
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.MaterializedViews, qt.HasLen, 1)
+	c.Assert(db.MaterializedViews[0].Name, qt.Equals, "public.user_stats")
+	c.Assert(db.MaterializedViews[0].Body, qt.Equals, "SELECT count(*) FROM users")
+	c.Assert(db.MaterializedViews[0].RefreshStrategy, qt.Equals, "concurrently")
+	c.Assert(db.MaterializedViews[0].Comment, qt.Equals, "user stats")
+}
+
+func TestParseMaterializedViewRefreshStrategyDefaultsToManual(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+materialized "user_stats" {
+  as = "SELECT count(*) FROM users"
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.MaterializedViews, qt.HasLen, 1)
+	c.Assert(db.MaterializedViews[0].RefreshStrategy, qt.Equals, "manual")
+}
+
+// TestParseMaterializedViewRefreshStrategyCanonicalized verifies the HCL path
+// lowercases and trims the value through MaterializedView.Canonicalize, matching
+// the Go-annotation path (which lowercases before canonicalizing). Neither path
+// validates the value against an allow-list, so an arbitrary strategy string is
+// accepted rather than rejected.
+func TestParseMaterializedViewRefreshStrategyCanonicalized(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+materialized "user_stats" {
+  as               = "SELECT count(*) FROM users"
+  refresh_strategy = "  CONCURRENTLY  "
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.MaterializedViews, qt.HasLen, 1)
+	c.Assert(db.MaterializedViews[0].RefreshStrategy, qt.Equals, "concurrently")
+}
+
+func TestParseMaterializedViewRejectsUnknownAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+materialized "user_stats" {
+  as       = "SELECT count(*) FROM users"
+  populate = true
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*unsupported materialized attribute "populate".*`)
+}
+
+// TestMaterializedViewRefreshStrategyGoAnnotationParity asserts that the Go
+// annotation frontend and the Atlas HCL frontend produce an equivalent
+// MaterializedView for the same schema, closing the #684 parity gap for
+// refresh_strategy.
+func TestMaterializedViewRefreshStrategyGoAnnotationParity(t *testing.T) {
+	c := qt.New(t)
+
+	goDB, err := goschema.ParseSource("user_stats.go", `package models
+
+//migrator:schema:matview name="user_stats" body="SELECT count(*) FROM users" refresh_strategy="concurrently" comment="user stats"
+type UserStatsMatView struct{}
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(goDB.MaterializedViews, qt.HasLen, 1)
+
+	hclDB, err := atlashcl.Parse([]byte(`
+materialized "user_stats" {
+  as               = "SELECT count(*) FROM users"
+  refresh_strategy = "concurrently"
+  comment          = "user stats"
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(hclDB.MaterializedViews, qt.HasLen, 1)
+
+	goView := goDB.MaterializedViews[0]
+	hclView := hclDB.MaterializedViews[0]
+	c.Assert(hclView.Name, qt.Equals, goView.Name)
+	c.Assert(hclView.Body, qt.Equals, goView.Body)
+	c.Assert(hclView.RefreshStrategy, qt.Equals, goView.RefreshStrategy)
+	c.Assert(hclView.Comment, qt.Equals, goView.Comment)
+}

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -117,11 +117,19 @@ func (p *parser) parseMaterializedView(block *hclsyntax.Block) error {
 	if body == "" {
 		return p.blockError(block, "materialized %q requires as", name)
 	}
-	p.db.MaterializedViews = append(p.db.MaterializedViews, goschema.MaterializedView{
-		Name:    qualifyObjectName(p.optionalRefName(block.Body.Attributes["schema"]), name),
-		Body:    body,
-		Comment: p.optionalString(block.Body.Attributes["comment"]),
-	})
+	view := goschema.MaterializedView{
+		Name:            qualifyObjectName(p.optionalRefName(block.Body.Attributes["schema"]), name),
+		Body:            body,
+		RefreshStrategy: p.optionalString(block.Body.Attributes["refresh_strategy"]),
+		Comment:         p.optionalString(block.Body.Attributes["comment"]),
+	}
+	// Canonicalize lowercases refresh_strategy and defaults it to "manual",
+	// mirroring the Go-annotation path (parseMatViewComment). The Go path applies
+	// no further validation, so neither does this one: any strategy string is
+	// accepted, keeping both frontends' MaterializedView identical for the same
+	// schema.
+	view.Canonicalize()
+	p.db.MaterializedViews = append(p.db.MaterializedViews, view)
 	return nil
 }
 
@@ -439,9 +447,10 @@ func (p *parser) rejectUnsupportedMaterializedAttrs(block *hclsyntax.Block) erro
 		return p.blockError(block.Body.Blocks[0], "unsupported materialized block %q", block.Body.Blocks[0].Type)
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"schema":  true,
-		"as":      true,
-		"comment": true,
+		"schema":           true,
+		"as":               true,
+		"refresh_strategy": true,
+		"comment":          true,
 	}, "materialized")
 }
 

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -205,10 +205,13 @@ func (r *renderer) renderMaterializedView(view goschema.MaterializedView) {
 		r.rawAttr(1, "schema", "schema."+schema)
 	}
 	r.stringAttr(1, "as", view.Body)
-	r.stringAttr(1, "comment", view.Comment)
+	// Emit refresh_strategy only when it differs from the canonical default so
+	// output stays minimal; the Ptah HCL parser defaults an absent attribute back
+	// to "manual", keeping this render/parse pair symmetric.
 	if view.RefreshStrategy != "" && view.RefreshStrategy != "manual" {
-		r.warn("materialized_views."+view.Name, "materialized view refresh strategy cannot be represented in PostgreSQL HCL schema output")
+		r.stringAttr(1, "refresh_strategy", view.RefreshStrategy)
 	}
+	r.stringAttr(1, "comment", view.Comment)
 	r.line("}")
 	r.line("")
 }

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -202,12 +202,50 @@ func TestRenderReportsLossyObjectDetails(t *testing.T) {
 	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{
 		"role app_user",
 		"function filter_user",
-		"materialized_views.user_stats",
 		"triggers.bad_event",
 		"grants.app_user",
 	})
 	_, err = atlashcl.Parse(rendered.Data, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", string(rendered.Data)))
+}
+
+func TestRenderMaterializedViewRefreshStrategyRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name:            "user_stats",
+			Body:            "SELECT count(*) FROM users",
+			RefreshStrategy: "CONCURRENTLY",
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.HasLen, 0)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, `refresh_strategy = "concurrently"`)
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.MaterializedViews, qt.HasLen, 1)
+	c.Assert(parsed.MaterializedViews[0].RefreshStrategy, qt.Equals, "concurrently")
+}
+
+func TestRenderMaterializedViewManualStrategyOmitsAttribute(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		MaterializedViews: []goschema.MaterializedView{{
+			Name: "user_stats",
+			Body: "SELECT count(*) FROM users",
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.HasLen, 0)
+	c.Assert(string(rendered.Data), qt.Not(qt.Contains), "refresh_strategy")
 }
 
 func TestRenderReportsPlatformOverrideDiagnostics(t *testing.T) {


### PR DESCRIPTION
## The parity gap (#684)

Issue #684 requires that everything expressible via Go `//migrator:schema:*` annotations also be expressible in Ptah's Atlas-style HCL. Go's `//migrator:schema:matview` accepts a `refresh_strategy` attribute (`manual`, `concurrently`, …), but the HCL frontend supported neither side of it:

- `atlashcl.parseMaterializedView` ignored `refresh_strategy`, and `rejectUnsupportedMaterializedAttrs` actively **rejected** it as an unknown attribute.
- The exporter (`atlashclrender`) **warned and dropped** any non-manual strategy, so it was inexpressible on output too.

That made a Go-annotation-expressible feature impossible to represent in HCL — precisely the gap #684 targets.

## Why this gap is uncontested

- No open PR touches HCL/atlashcl: `gh pr list --state open --search "atlashcl OR hcl OR 684"` returns nothing, and the only open PRs are Renovate/Docker bumps.
- `git log core/atlashcl` (now `internal/atlashcl` after the #455 internalization) shows the area's last change was #455; every recent merge (#728–#779) is DML/migrations/data work that does not touch the HCL frontend.

## Approach (Canonicalize + mirrored validation)

- **Parse into the same IR:** `refresh_strategy` is read on `materialized` blocks into the same `goschema.MaterializedView` the Go path produces, using the `exprString`-backed `optionalString` helper.
- **Canonicalize where the Go path does:** `MaterializedView.Canonicalize()` is called after populating the struct, lowercasing the value and defaulting it to `manual`, matching `parseMatViewComment`.
- **Mirrored validation:** the Go path applies no value allow-list (any strategy string is accepted and lowercased), so HCL does the same — both frontends yield an identical `MaterializedView` for the same schema. The block's attribute allow-list now includes `refresh_strategy`; unknown attributes are still rejected.
- **Symmetric emit:** the exporter now writes `refresh_strategy` for non-default strategies instead of dropping it with a diagnostic. `manual` stays implicit and an absent attribute parses back to `manual`, so the render/parse round-trip is lossless.

## Tests

- HCL parses `refresh_strategy` (explicit value, `manual` default, whitespace/case canonicalization, and unknown-attribute rejection).
- Go-annotation vs HCL parity: `goschema.ParseSource` of a `//migrator:schema:matview` annotation and `atlashcl.Parse` of the equivalent HCL produce an equivalent `MaterializedView`.
- Renderer round-trips a non-default strategy (`concurrently`) with no diagnostic and omits the attribute for the `manual` default. The existing lossy-details test no longer lists the materialized view as lossy.

## Verification

- `go build ./...` (and `-tags integration`), `gofmt -l` clean, `go vet` clean.
- `golangci-lint run` on the changed packages: 0 issues.
- `go tool qtlint` and `go tool teststyle` (183 conditional groups, 49 white-box files): OK.
- Full `go test ./...`: pass.
- Public API snapshot check: no drift (no exported surface changed).
- `docs/site` `check:core-doc-links`, `check:page-health`, `check:links`, `check:exit-codes`: OK.

## Files changed

- `internal/atlashcl/objects.go` — parse `refresh_strategy`, canonicalize, allow-list it.
- `internal/atlashclrender/objects.go` — emit `refresh_strategy` for non-default strategies.
- `internal/atlashcl/materialized_test.go` — parse, canonicalization, rejection, and Go/HCL parity tests.
- `internal/atlashclrender/render_test.go` — round-trip tests; drop the matview from the lossy-details expectation.
- `docs/atlas_hcl_schema.md`, `docs/go_annotations_vs_atlas_hcl.md`, `docs/site/src/content/docs/reference/hcl-schema.md` — reflect the new attribute and remove the stale limitation.