### PR TITLE
Support index comments in Atlas HCL (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -36,8 +36,8 @@ current schema IR:
 - `primary_key` blocks with `columns`; PostgreSQL primary keys also support
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
-  `on { expr = "..." }`, `desc`, `unique`, `type`, and `where`; PostgreSQL
-  indexes also support `include`, BRIN `page_per_range`, and
+  `on { expr = "..." }`, `desc`, `unique`, `type`, `where`, and `comment`;
+  PostgreSQL indexes also support `include`, BRIN `page_per_range`, and
   `nulls_distinct`
 - `unique` blocks with `columns`; PostgreSQL unique constraints also support
   `include` and `nulls_distinct`

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -47,8 +47,8 @@ directly from Ptah's IR:
 - enums
 - tables and concrete columns, including columns from embedded Go structs
 - primary keys
-- indexes, including uniqueness, predicates, include columns, and supported
-  index part metadata
+- indexes, including uniqueness, predicates, include columns, comments, and
+  supported index part metadata
 - unique constraints
 - foreign keys from both field annotations and table constraints
 - check constraints from both field annotations and table constraints

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -57,7 +57,7 @@ table "users" {
 | `table` | Table blocks with columns, primary keys, indexes, uniques, foreign keys, checks, and row security. |
 | `column` | `type`, `null`, `auto_increment`, `unique`, `unique_expr`, `default`, `check`, `check_name`, `identity` (with `options`), and comments. |
 | `primary_key` | `columns`; PostgreSQL also supports `include`. |
-| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, and PostgreSQL include/storage options. |
+| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, `comment`, and PostgreSQL include/storage options. |
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |
 | `foreign_key` | One local `columns` entry and one table-qualified `ref_columns` entry. |
 | `check` | `expr`. |

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -477,6 +477,7 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		Type:           indexType,
 		Parser:         parserName,
 		Condition:      p.optionalString(block.Body.Attributes["where"]),
+		Comment:        p.optionalString(block.Body.Attributes["comment"]),
 		IncludeColumns: include,
 		StorageParams:  storageParams,
 		TableName:      tableName,
@@ -1018,6 +1019,7 @@ func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 		"unique":          true,
 		"type":            true,
 		"where":           true,
+		"comment":         true,
 	}, "index")
 }
 

--- a/internal/atlashcl/index_comment_test.go
+++ b/internal/atlashcl/index_comment_test.go
@@ -1,0 +1,94 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseIndexComment(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "email" {
+    type = text
+  }
+  index "idx_users_email" {
+    columns = [column.email]
+    comment = "lookup by email"
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Name, qt.Equals, "idx_users_email")
+	c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"email"})
+	c.Assert(db.Indexes[0].Comment, qt.Equals, "lookup by email")
+}
+
+func TestParseIndexCommentAbsentIsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "email" {
+    type = text
+  }
+  index "idx_users_email" {
+    columns = [column.email]
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Comment, qt.Equals, "")
+}
+
+// TestIndexCommentGoAnnotationParity asserts that the Go annotation frontend and
+// the Atlas HCL frontend produce an equivalent index comment for the same
+// schema, closing the #684 parity gap for index comments. Like the Go path
+// (parseIndexComment), neither frontend normalizes or validates the value, so
+// the comment string is carried through verbatim.
+func TestIndexCommentGoAnnotationParity(t *testing.T) {
+	c := qt.New(t)
+
+	goDB, err := goschema.ParseSource("users.go", `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="email" type="TEXT"
+	Email string
+
+	//migrator:schema:index name="idx_users_email" fields="email" comment="lookup by email"
+	_ int
+}
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(goDB.Indexes, qt.HasLen, 1)
+
+	hclDB, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "email" {
+    type = text
+  }
+  index "idx_users_email" {
+    columns = [column.email]
+    comment = "lookup by email"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(hclDB.Indexes, qt.HasLen, 1)
+
+	goIndex := goDB.Indexes[0]
+	hclIndex := hclDB.Indexes[0]
+	c.Assert(hclIndex.Name, qt.Equals, goIndex.Name)
+	c.Assert(hclIndex.Fields, qt.DeepEquals, goIndex.Fields)
+	c.Assert(hclIndex.Comment, qt.Equals, goIndex.Comment)
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -359,6 +359,7 @@ func (r *renderer) renderIndex(index goschema.Index) {
 	r.stringAttr(2, "type", index.Type)
 	r.stringAttr(2, "parser", index.Parser)
 	r.stringAttr(2, "where", index.Condition)
+	r.stringAttr(2, "comment", index.Comment)
 	r.boolPtrAttr(2, "nulls_distinct", index.NullsDistinct)
 	if len(index.IncludeColumns) > 0 {
 		r.rawAttr(2, "include", columnRefs(index.IncludeColumns))
@@ -388,9 +389,6 @@ func (r *renderer) renderIndex(index goschema.Index) {
 	}
 	if index.Granularity != 0 {
 		r.warn("index "+index.Name, "ClickHouse granularity cannot be represented in the supported HCL subset")
-	}
-	if index.Comment != "" {
-		r.warn("index "+index.Name, "index comments cannot be represented in HCL schema output")
 	}
 	r.line("  }")
 }

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -248,6 +248,34 @@ func TestRenderMaterializedViewManualStrategyOmitsAttribute(t *testing.T) {
 	c.Assert(string(rendered.Data), qt.Not(qt.Contains), "refresh_strategy")
 }
 
+func TestRenderIndexCommentRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Fields: []goschema.Field{{StructName: "User", FieldName: "Email", Name: "email", Type: "text"}},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			TableName:  "users",
+			Name:       "idx_users_email",
+			Fields:     []string{"email"},
+			Comment:    "lookup by email",
+		}},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.HasLen, 0)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, `comment = "lookup by email"`)
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.Indexes, qt.HasLen, 1)
+	c.Assert(parsed.Indexes[0].Comment, qt.Equals, "lookup by email")
+}
+
 func TestRenderReportsPlatformOverrideDiagnostics(t *testing.T) {
 	c := qt.New(t)
 	db := &goschema.Database{


### PR DESCRIPTION
## Gap closed

Advances #684 (Ptah HCL must express everything the Go `//migrator:schema:*` annotations can) by closing the **index `comment`** parity gap.

Go `//migrator:schema:index` annotations accept a `comment` attribute, which the Go parser fills into `goschema.Index.Comment`. The Atlas HCL frontend could neither parse nor emit it:

- `internal/atlashcl` `parseIndex` ignored `comment` and its allow-list (`rejectUnsupportedIndexAttrs`) rejected it, so `index { comment = "..." }` was a hard parse error.
- `internal/atlashclrender` `renderIndex` warned and dropped any index comment (`"index comments cannot be represented in HCL schema output"`).

This is the same "parse rejects + exporter warn-and-drops" shape that #780 closed for materialized-view `refresh_strategy`.

## Contention evidence

- Open PRs are only Renovate dependency bumps (#774 astro, #108 mariadb) — neither touches `internal/atlashcl*`.
- Recent `internal/atlashcl` / `internal/atlashclrender` history (#780 matview refresh_strategy, #718 column check/unique_expr/identity, #717 extension if_not_exists, #716 permission sequences, #715 composite/range, #713 sequence/domain) does not touch index comments.
- Deliberately avoided the already-closed matview `refresh_strategy` gap (#780) and the security-sensitive role `password` gap (intentionally deferred — emitting secrets into inspectable HCL).

## Parity approach

- Parse `comment` on `index` blocks into the same `goschema.Index` the Go path produces, via `p.optionalString` (`exprString`, so a quoted literal is unquoted), and add `comment` to the index attribute allow-list.
- The Go-annotation path (`parseIndexComment`) applies no normalization and no validation, and `goschema.Index` has no `Canonicalize`, so the HCL path is a straight passthrough too — both frontends yield an identical comment for the same schema.
- Make the exporter symmetric: emit `comment` for indexes (`stringAttr` omits empty values) instead of warn-and-drop, so an absent comment stays implicit and the render → parse round-trip is lossless.

## HCL syntax added

```hcl
table "users" {
  column "email" {
    type = text
  }
  index "idx_users_email" {
    columns = [column.email]
    comment = "lookup by email"
  }
}
```

## Verification

- `go build ./...`, `gofmt -l` (empty), `go vet` on changed packages — clean.
- `golangci-lint run` on changed packages — 0 issues.
- `go tool qtlint` and `go tool teststyle` — OK.
- Full `go test ./...` — pass.
- Public-API snapshot checks — pass (changes are confined to `internal/` packages; no exported API change).
- New tests: HCL parse (present + absent comment); Go-annotation vs HCL parity for the same schema; renderer round-trip (emit → re-parse) asserting the comment survives.
- Docs updated: `docs/atlas_hcl_schema.md`, `docs/go_annotations_vs_atlas_hcl.md`, and `docs/site/src/content/docs/reference/hcl-schema.md`.

## Adjacent gaps noticed (future PRs)

- **Index `granularity`** (ClickHouse data-skipping GRANULARITY) is still warn-and-dropped by the exporter and unparsed by the frontend — a genuine gap, but ClickHouse-specific and `int`-typed (needs an `optionalInt64`-style reader with overflow rejection), so scoped separately.
- **Table `custom`** (raw CREATE TABLE SQL) is listed among the exporter's intentional lossy diagnostics — worth a design discussion rather than a mechanical parity add.