### PR TITLE
Support ClickHouse index granularity in Atlas HCL (#684)

### DIFF
--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -38,7 +38,7 @@ current schema IR:
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
   `on { expr = "..." }`, `desc`, `unique`, `type`, `where`, and `comment`;
   PostgreSQL indexes also support `include`, BRIN `page_per_range`, and
-  `nulls_distinct`
+  `nulls_distinct`, and ClickHouse data-skipping indexes support `granularity`
 - `unique` blocks with `columns`; PostgreSQL unique constraints also support
   `include` and `nulls_distinct`
 - `foreign_key` blocks with one local `columns` entry and one table-qualified

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -47,8 +47,8 @@ directly from Ptah's IR:
 - enums
 - tables and concrete columns, including columns from embedded Go structs
 - primary keys
-- indexes, including uniqueness, predicates, include columns, comments, and
-  supported index part metadata
+- indexes, including uniqueness, predicates, include columns, comments,
+  ClickHouse data-skipping granularity, and supported index part metadata
 - unique constraints
 - foreign keys from both field annotations and table constraints
 - check constraints from both field annotations and table constraints

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -57,7 +57,7 @@ table "users" {
 | `table` | Table blocks with columns, primary keys, indexes, uniques, foreign keys, checks, and row security. |
 | `column` | `type`, `null`, `auto_increment`, `unique`, `unique_expr`, `default`, `check`, `check_name`, `identity` (with `options`), and comments. |
 | `primary_key` | `columns`; PostgreSQL also supports `include`. |
-| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, `comment`, and PostgreSQL include/storage options. |
+| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, `comment`, ClickHouse `granularity`, and PostgreSQL include/storage options. |
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |
 | `foreign_key` | One local `columns` entry and one table-qualified `ref_columns` entry. |
 | `check` | `expr`. |

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -467,6 +467,10 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if nullsDistinct != nil && !unique {
 		return goschema.Index{}, p.blockError(block, "index nulls_distinct requires unique = true")
 	}
+	granularity, err := p.optionalGranularity(block)
+	if err != nil {
+		return goschema.Index{}, err
+	}
 	return goschema.Index{
 		StructName:     structName,
 		Name:           block.Labels[0],
@@ -480,8 +484,29 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 		Comment:        p.optionalString(block.Body.Attributes["comment"]),
 		IncludeColumns: include,
 		StorageParams:  storageParams,
+		Granularity:    granularity,
 		TableName:      tableName,
 	}, nil
+}
+
+// optionalGranularity reads the optional ClickHouse data-skipping index
+// GRANULARITY value. An absent attribute yields 0, which the ClickHouse
+// renderer treats as "use the dialect default". The value must be a
+// non-negative integer within the int64 range, mirroring the Go-annotation
+// path (parseIndexComment), which parses it with strconv.Atoi and rejects
+// negatives; both frontends therefore accept the same granularity values.
+func (p *parser) optionalGranularity(block *hclsyntax.Block) (int, error) {
+	value, err := p.optionalInt64(block, "granularity", "index")
+	if err != nil {
+		return 0, err
+	}
+	if value == nil {
+		return 0, nil
+	}
+	if *value < 0 {
+		return 0, p.blockError(block, "index attribute %q must be a non-negative integer", "granularity")
+	}
+	return int(*value), nil
 }
 
 func (p *parser) parseUnique(structName, tableName string, block *hclsyntax.Block) (goschema.Constraint, error) {
@@ -1020,6 +1045,7 @@ func (p *parser) rejectUnsupportedIndexAttrs(block *hclsyntax.Block) error {
 		"type":            true,
 		"where":           true,
 		"comment":         true,
+		"granularity":     true,
 	}, "index")
 }
 

--- a/internal/atlashcl/index_granularity_test.go
+++ b/internal/atlashcl/index_granularity_test.go
@@ -1,0 +1,151 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseIndexGranularity(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = text
+  }
+  index "idx_events_payload" {
+    columns     = [column.payload]
+    type        = bloom_filter
+    granularity = 64
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Name, qt.Equals, "idx_events_payload")
+	c.Assert(db.Indexes[0].Type, qt.Equals, "bloom_filter")
+	c.Assert(db.Indexes[0].Granularity, qt.Equals, 64)
+}
+
+func TestParseIndexGranularityAbsentIsZero(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = text
+  }
+  index "idx_events_payload" {
+    columns = [column.payload]
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Granularity, qt.Equals, 0)
+}
+
+func TestParseIndexGranularityRejectsNegative(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = text
+  }
+  index "idx_events_payload" {
+    columns     = [column.payload]
+    granularity = -1
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*index attribute "granularity" must be a non-negative integer.*`)
+}
+
+func TestParseIndexGranularityRejectsNonInteger(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = text
+  }
+  index "idx_events_payload" {
+    columns     = [column.payload]
+    granularity = 1.5
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*index attribute "granularity" must be an integer.*`)
+}
+
+func TestParseIndexGranularityRejectsOverflow(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = text
+  }
+  index "idx_events_payload" {
+    columns     = [column.payload]
+    granularity = 99999999999999999999
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*index attribute "granularity" must be an integer within the int64 range.*`)
+}
+
+// TestIndexGranularityGoAnnotationParity asserts that the Go annotation frontend
+// and the Atlas HCL frontend produce an equivalent ClickHouse data-skipping
+// index granularity for the same schema, closing the #684 parity gap. Like the
+// Go path (parseIndexComment), both frontends reject negative or non-integer
+// values and default an absent granularity to 0.
+func TestIndexGranularityGoAnnotationParity(t *testing.T) {
+	c := qt.New(t)
+
+	goDB, err := goschema.ParseSource("events.go", `package models
+
+//migrator:schema:table name="events"
+type Event struct {
+	//migrator:schema:field name="payload" type="String"
+	Payload string
+
+	//migrator:schema:index name="idx_events_payload" fields="payload" type="bloom_filter" granularity="64"
+	_ int
+}
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(goDB.Indexes, qt.HasLen, 1)
+
+	hclDB, err := atlashcl.Parse([]byte(`
+table "events" {
+  column "payload" {
+    type = String
+  }
+  index "idx_events_payload" {
+    columns     = [column.payload]
+    type        = bloom_filter
+    granularity = 64
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(hclDB.Indexes, qt.HasLen, 1)
+
+	goIndex := goDB.Indexes[0]
+	hclIndex := hclDB.Indexes[0]
+	c.Assert(hclIndex.Name, qt.Equals, goIndex.Name)
+	c.Assert(hclIndex.Fields, qt.DeepEquals, goIndex.Fields)
+	c.Assert(hclIndex.Type, qt.Equals, goIndex.Type)
+	c.Assert(hclIndex.Granularity, qt.Equals, goIndex.Granularity)
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -361,6 +361,13 @@ func (r *renderer) renderIndex(index goschema.Index) {
 	r.stringAttr(2, "where", index.Condition)
 	r.stringAttr(2, "comment", index.Comment)
 	r.boolPtrAttr(2, "nulls_distinct", index.NullsDistinct)
+	// Granularity is always non-negative (the parser rejects negatives) and 0 is
+	// the implicit dialect default, so emit only a positive value; the parser
+	// defaults an absent attribute back to 0, keeping the render/parse pair
+	// symmetric.
+	if index.Granularity != 0 {
+		r.rawAttr(2, "granularity", strconv.Itoa(index.Granularity))
+	}
 	if len(index.IncludeColumns) > 0 {
 		r.rawAttr(2, "include", columnRefs(index.IncludeColumns))
 	}
@@ -386,9 +393,6 @@ func (r *renderer) renderIndex(index goschema.Index) {
 	}
 	if index.Operator != "" {
 		r.warn("index "+index.Name, "legacy index operator field was not exported; use structured index parts")
-	}
-	if index.Granularity != 0 {
-		r.warn("index "+index.Name, "ClickHouse granularity cannot be represented in the supported HCL subset")
 	}
 	r.line("  }")
 }

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -276,6 +276,56 @@ func TestRenderIndexCommentRoundTrip(t *testing.T) {
 	c.Assert(parsed.Indexes[0].Comment, qt.Equals, "lookup by email")
 }
 
+func TestRenderIndexGranularityRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Event", Name: "events"}},
+		Fields: []goschema.Field{{StructName: "Event", FieldName: "Payload", Name: "payload", Type: "String"}},
+		Indexes: []goschema.Index{{
+			StructName:  "Event",
+			TableName:   "events",
+			Name:        "idx_events_payload",
+			Fields:      []string{"payload"},
+			Type:        "bloom_filter",
+			Granularity: 64,
+		}},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.HasLen, 0)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, `granularity = 64`)
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.Indexes, qt.HasLen, 1)
+	c.Assert(parsed.Indexes[0].Granularity, qt.Equals, 64)
+}
+
+func TestRenderIndexZeroGranularityOmitsAttribute(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Event", Name: "events"}},
+		Fields: []goschema.Field{{StructName: "Event", FieldName: "Payload", Name: "payload", Type: "String"}},
+		Indexes: []goschema.Index{{
+			StructName: "Event",
+			TableName:  "events",
+			Name:       "idx_events_payload",
+			Fields:     []string{"payload"},
+		}},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.HasLen, 0)
+	c.Assert(string(rendered.Data), qt.Not(qt.Contains), "granularity")
+}
+
 func TestRenderReportsPlatformOverrideDiagnostics(t *testing.T) {
 	c := qt.New(t)
 	db := &goschema.Database{


### PR DESCRIPTION
## Summary

Closes another Go-annotation-vs-HCL parity gap tracked by #684: ClickHouse
data-skipping index **`granularity`**.

Go `//migrator:schema:index` annotations accept a `granularity` attribute
(`goschema.Index.Granularity`), but the Atlas HCL frontend could neither parse
nor emit it:

- `parseIndex` rejected the attribute — `granularity` was not in the index
  allow-list, so `index { granularity = 64 }` failed with
  `unsupported index attribute "granularity"`.
- The exporter warned and dropped any non-zero granularity
  (`ClickHouse granularity cannot be represented in the supported HCL subset`).

Both directions are now supported symmetrically.

## Changes

- **Parse** (`internal/atlashcl`): read `granularity` on `index` blocks into the
  same `goschema.Index` the Go path produces. The value is read as an integer
  and must be a non-negative whole number within the int64 range, mirroring the
  Go-annotation path (`parseIndexComment`), which parses it with `strconv.Atoi`
  and rejects negatives. An absent attribute defaults to `0` (the ClickHouse
  dialect default), matching the Go path.
- **Emit** (`internal/atlashclrender`): render `granularity` for a positive
  value instead of dropping it with a diagnostic. A zero granularity stays
  implicit, so the render/parse round-trip is lossless.
- **Docs**: updated `atlas_hcl_schema.md`, `go_annotations_vs_atlas_hcl.md`, and
  the site HCL reference.

## HCL syntax added

```hcl
table "events" {
  column "payload" {
    type = String
  }
  index "idx_events_payload" {
    columns     = [column.payload]
    type        = bloom_filter
    granularity = 64
  }
}
```

## Tests

- Parse: present (`64`), absent (defaults to `0`), and rejection of negative,
  fractional, and int64-overflowing values.
- Go-annotation vs HCL parity: equivalent index granularity for the same schema.
- Render round-trip: a positive value round-trips through parse; a zero default
  omits the attribute.

## Verification

`go build ./...`, `gofmt -l` (clean), `go vet`, `golangci-lint run` (0 issues),
`go tool qtlint`, `go tool teststyle` (OK), full `go test ./...` (pass),
public-API snapshot check (no exported API change), and the `docs/site`
`check:*` scripts (all OK).
