### PR TITLE
Support RLS enablement comments in Atlas HCL (#684)

### DIFF
--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -156,12 +156,11 @@ func TestSchemaExportCommandPreservesSchemaObjects(t *testing.T) {
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
-	c.Assert(stdout.String(), qt.Contains, "7 export warning(s) reported")
+	c.Assert(stdout.String(), qt.Contains, "6 export warning(s) reported")
 	c.Assert(stderr.String(), qt.Contains, "domain types are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "composite types are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "range types are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "extension if_not_exists")
-	c.Assert(stderr.String(), qt.Contains, "RLS enablement comments cannot be represented")
 	c.Assert(stderr.String(), qt.Contains, "standalone sequence objects are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "sequence grants are not yet representable")
 	for _, oldObjectWarning := range []string{
@@ -172,6 +171,7 @@ func TestSchemaExportCommandPreservesSchemaObjects(t *testing.T) {
 		"triggers contain raw SQL bodies",
 		"RLS policies cannot be represented",
 		"RLS enablement cannot be represented",
+		"RLS enablement comments cannot be represented",
 		"roles cannot be represented",
 		"grants cannot be represented",
 	} {
@@ -189,6 +189,7 @@ func TestSchemaExportCommandPreservesSchemaObjects(t *testing.T) {
 	c.Assert(parsed.Triggers, qt.HasLen, 1)
 	c.Assert(parsed.RLSPolicies, qt.HasLen, 1)
 	c.Assert(parsed.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(parsed.RLSEnabledTables[0].Comment, qt.Equals, "Enable RLS for fixture users")
 	c.Assert(parsed.Roles, qt.HasLen, 1)
 	c.Assert(parsed.Grants, qt.HasLen, 3)
 }

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -45,7 +45,8 @@ current schema IR:
   `ref_columns` entry
 - `check` blocks with `expr`
 - `default = sql("...")` as a default expression
-- `row_security` blocks inside `table` with `enabled = true`
+- `row_security` blocks inside `table` with `enabled = true` and an optional
+  `comment`
 - PostgreSQL `extension` blocks with `if_not_exists`, `version`, and `comment`
 - PostgreSQL `role` blocks with `login`, `superuser`, `create_db`,
   `create_role`, `inherit`, `replication`, and `comment`
@@ -320,6 +321,7 @@ table "users" {
 
   row_security {
     enabled = true
+    comment = "tenant isolation"
   }
 }
 

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -62,12 +62,13 @@ directly from Ptah's IR:
 - PostgreSQL views and materialized views with query bodies, comments, and
   materialized-view refresh strategies (`refresh_strategy`)
 - PostgreSQL triggers with timing/event blocks, `for`, body, and comments
-- PostgreSQL row-level security enablement as `table.row_security`
+- PostgreSQL row-level security enablement as `table.row_security`, including its
+  optional comment
 - PostgreSQL row-level security policies
 
 Unsupported or lossy details are reported as export diagnostics on stderr.
 Examples include platform-specific overrides, table custom SQL, extension
-`if_not_exists`, role passwords, grantor metadata, RLS enablement comments,
+`if_not_exists`, role passwords, grantor metadata,
 standalone sequence objects (`//migrator:schema:sequence`) and their grants,
 user-defined types (`//migrator:schema:domain` / `:composite` / `:range`), and
 function parameter strings that cannot be split into Atlas `arg` blocks without

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -242,6 +242,7 @@ func (p *parser) parseRowSecurity(table *goschema.Table, block *hclsyntax.Block)
 	return goschema.RLSEnabledTable{
 		StructName: table.StructName,
 		Table:      table.QualifiedName(),
+		Comment:    p.optionalString(block.Body.Attributes["comment"]),
 	}, nil
 }
 
@@ -496,6 +497,7 @@ func (p *parser) rejectUnsupportedRowSecurityAttrs(block *hclsyntax.Block) error
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"enabled": true,
+		"comment": true,
 	}, "row_security")
 }
 

--- a/internal/atlashcl/rls_comment_test.go
+++ b/internal/atlashcl/rls_comment_test.go
@@ -1,0 +1,93 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/atlashcl"
+)
+
+func TestParseRowSecurityComment(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "id" {
+    type = int
+  }
+  row_security {
+    enabled = true
+    comment = "tenant isolation"
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(db.RLSEnabledTables[0].Table, qt.Equals, "users")
+	c.Assert(db.RLSEnabledTables[0].Comment, qt.Equals, "tenant isolation")
+}
+
+func TestParseRowSecurityCommentAbsentIsEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "id" {
+    type = int
+  }
+  row_security {
+    enabled = true
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(db.RLSEnabledTables[0].Comment, qt.Equals, "")
+}
+
+// TestRowSecurityCommentGoAnnotationParity asserts that the Go annotation
+// frontend and the Atlas HCL frontend produce an equivalent RLS enablement
+// comment for the same schema, closing the #684 parity gap for row_security
+// comments. Like the Go path (parseFileScopedRLSEnableComment), neither frontend
+// normalizes or validates the value, so the comment string is carried through
+// verbatim.
+func TestRowSecurityCommentGoAnnotationParity(t *testing.T) {
+	c := qt.New(t)
+
+	goDB, err := goschema.ParseSource("users.go", `package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="INTEGER" primary="true"
+	ID int
+}
+
+//migrator:schema:rls:enable table="users" comment="tenant isolation"
+type SecurityMarker struct{}
+`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(goDB.RLSEnabledTables, qt.HasLen, 1)
+
+	hclDB, err := atlashcl.Parse([]byte(`
+table "users" {
+  column "id" {
+    type = int
+  }
+  row_security {
+    enabled = true
+    comment = "tenant isolation"
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(hclDB.RLSEnabledTables, qt.HasLen, 1)
+
+	goRLS := goDB.RLSEnabledTables[0]
+	hclRLS := hclDB.RLSEnabledTables[0]
+	c.Assert(hclRLS.Table, qt.Equals, goRLS.Table)
+	c.Assert(hclRLS.Comment, qt.Equals, goRLS.Comment)
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -105,10 +105,8 @@ func (r *renderer) renderRowSecurity(rlsEnabled *goschema.RLSEnabledTable) {
 	}
 	r.line("  row_security {")
 	r.rawAttr(2, "enabled", "true")
+	r.stringAttr(2, "comment", rlsEnabled.Comment)
 	r.line("  }")
-	if rlsEnabled.Comment != "" {
-		r.warn("rls_enabled_tables."+rlsEnabled.Table, "RLS enablement comments cannot be represented in HCL schema row_security")
-	}
 }
 
 func (r *renderer) renderFunctions() {

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -129,7 +129,7 @@ func TestRenderFixture023SchemaObjectsRoundTrip(t *testing.T) {
 	c.Assert(hcl, qt.Contains, `trigger "users_set_updated_at"`)
 	c.Assert(hcl, qt.Contains, `policy "users_tenant_policy"`)
 	c.Assert(hcl, qt.Contains, `permission {`)
-	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{"extensions.pg_trgm", "sequences.fixture_order_seq", "domains.fixture_email", "composite_types.fixture_address", "ranges.fixture_floatrange", "rls_enabled_tables.users", "grants.fixture_app_user"})
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{"extensions.pg_trgm", "sequences.fixture_order_seq", "domains.fixture_email", "composite_types.fixture_address", "ranges.fixture_floatrange", "grants.fixture_app_user"})
 
 	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
@@ -163,6 +163,7 @@ func TestRenderFixture023SchemaObjectsRoundTrip(t *testing.T) {
 	c.Assert(parsed.RLSPolicies[0].UsingExpression, qt.Equals, "get_fixture_tenant_id() IS NOT NULL")
 	c.Assert(parsed.RLSEnabledTables, qt.HasLen, 1)
 	c.Assert(parsed.RLSEnabledTables[0].Table, qt.Equals, "users")
+	c.Assert(parsed.RLSEnabledTables[0].Comment, qt.Equals, "Enable RLS for fixture users")
 	c.Assert(parsed.Roles, qt.HasLen, 1)
 	c.Assert(parsed.Roles[0].Name, qt.Equals, "fixture_app_user")
 	c.Assert(parsed.Roles[0].Inherit, qt.IsTrue)


### PR DESCRIPTION
## Summary

Closes an HCL-vs-Go-annotation parity gap (#684) for PostgreSQL row-level-security enablement comments.

The Go annotation frontend already carries an optional comment on `//migrator:schema:rls:enable` (`RLSEnabledTable.Comment`), but the Atlas HCL frontend neither parsed a `row_security` comment nor emitted one — it warned that the comment could not be represented and dropped it. Now both frontends round-trip the comment.

## Changes

- **Parse**: accept an optional `comment` attribute inside `row_security` blocks and add it to the allow-list of supported attributes (`internal/atlashcl/objects.go`).
- **Render**: emit the comment on export (via the empty-skipping `stringAttr` helper) and drop the lossy export diagnostic (`internal/atlashclrender/objects.go`).
- **Tests**: add parse, absent-is-empty, Go-vs-HCL parity, and render round-trip coverage; update the fixture-023 export/render expectations (one fewer export warning, comment now asserted to round-trip).
- **Docs**: note the optional `row_security` comment in the HCL schema reference and remove RLS enablement comments from the lossy-export list.

## Testing

- `go build ./...`, `gofmt`, `go vet`, `golangci-lint run`, `go tool qtlint`, `go tool teststyle`, and the public-API snapshot checks all pass.
- `go test ./...` — full suite green (139 packages).