### PR TITLE
Cover concrete type APIs in the public API snapshot guard (#784)

### DIFF
--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -92,10 +92,14 @@ CI runs three public API checks:
   non-command, non-example, non-fixture package that is importable from outside
   this module but not listed here.
 - `scripts/check-public-api-snapshot.sh` regenerates the `go doc -short`
-  exported-symbol snapshot for every package listed here, expands public
-  interface method sets, and compares it with `docs/public_api.snapshot`.
+  exported-symbol snapshot for every package listed here, then appends the full
+  `go doc` output for every exported named type (struct, interface, alias, map,
+  func type), and compares the result with `docs/public_api.snapshot`. Because
+  the full per-type output is recorded, changes to exported struct fields and to
+  methods on concrete named types are caught, not only interface method sets.
   Any exported surface change must update the snapshot in the same reviewed
-  change.
+  change. The guard is itself covered by a self-test in
+  `internal/apiguard` that fails if this per-type coverage regresses.
 - `scripts/check-public-api-released.sh` compares each stable package against
   the latest `v0.x` release tag with `apidiff -incompatible`. Until the first
   `v0.x` tag exists, the script reports that no released baseline is available
@@ -109,8 +113,9 @@ to the stable embedder API. Intentional approval must be explicit in the same
 reviewed change:
 
 - update this document if packages move between stable and non-public surfaces;
-- update `docs/public_api.snapshot` when exported symbols or public interface
-  method sets change;
+- update `docs/public_api.snapshot` when any exported surface changes —
+  symbols, struct fields, interface method sets, or methods on concrete named
+  types;
 - add one package-level approval line to `docs/public_api_approvals.txt` when
   `scripts/check-public-api-released.sh` reports an incompatibility against the
   latest `v0.x` baseline;

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -19,12 +19,121 @@ type SumResult struct{ ... }
     func VerifySum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumResult, error)
     func VerifySumDir(dir string, format migrator.MigrationDirFormat) (*SumResult, error)
 
+### github.com/stokaro/ptah/atlascompat.ParseSQLOptions
+
+package atlascompat // import "github.com/stokaro/ptah/atlascompat"
+
+type ParseSQLOptions struct {
+    // Dialect selects dialect-specific parsing behavior. Empty means
+    // compatibility-oriented best effort.
+    Dialect string
+    // Capabilities selects dialect capabilities for syntax where the same
+    // dialect has version-dependent behavior.
+    Capabilities capability.Capabilities
+    // Timeout caps parser work. Zero keeps Ptah's parser default.
+    Timeout time.Duration
+}
+    ParseSQLOptions configures ParseSQL.
+
+
+### github.com/stokaro/ptah/atlascompat.SumEntry
+
+package atlascompat // import "github.com/stokaro/ptah/atlascompat"
+
+type SumEntry struct {
+    // Name is the slash-separated path of the file relative to the migrations
+    // directory.
+    Name string
+    // Hash is the h1: content hash of the file.
+    Hash string
+}
+    SumEntry is one migration file and its content hash.
+
+
+### github.com/stokaro/ptah/atlascompat.SumFile
+
+package atlascompat // import "github.com/stokaro/ptah/atlascompat"
+
+type SumFile struct {
+    // DirHash is the directory-level hash.
+    DirHash string
+    // Entries are per-file hashes sorted by name.
+    Entries []SumEntry
+}
+    SumFile is a migration-directory integrity file.
+
+func ComputeSum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumFile, error)
+func ParseSum(data []byte) (*SumFile, error)
+func WriteSum(dir string, format migrator.MigrationDirFormat) (*SumFile, error)
+func (s *SumFile) Bytes() []byte
+
+### github.com/stokaro/ptah/atlascompat.SumResult
+
+package atlascompat // import "github.com/stokaro/ptah/atlascompat"
+
+type SumResult struct {
+    // Added are migration files present on disk but absent from the sum file.
+    Added []string
+    // Removed are files recorded in the sum file but missing on disk.
+    Removed []string
+    // Changed are files whose content hash no longer matches the sum file.
+    Changed []string
+    // DirHashMismatch is set when the directory hash differs while per-file
+    // entries match.
+    DirHashMismatch bool
+    // SumFileName is the integrity file this result was compared against.
+    SumFileName string
+}
+    SumResult is the outcome of a migration-directory integrity verification.
+
+func VerifySum(fsys fs.FS, format migrator.MigrationDirFormat) (*SumResult, error)
+func VerifySumDir(dir string, format migrator.MigrationDirFormat) (*SumResult, error)
+func (r *SumResult) Describe() string
+func (r *SumResult) OK() bool
+
 ## github.com/stokaro/ptah/config
 
 type CompareOptions struct{ ... }
     func DefaultCompareOptions() *CompareOptions
     func WithAdditionalIgnoredExtensions(extensions ...string) *CompareOptions
     func WithIgnoredExtensions(extensions ...string) *CompareOptions
+
+### github.com/stokaro/ptah/config.CompareOptions
+
+package config // import "github.com/stokaro/ptah/config"
+
+type CompareOptions struct {
+    // IgnoredExtensions is a list of PostgreSQL extension names that should be
+    // ignored during schema migrations. These extensions will:
+    // - Never be deleted, even if missing from the target schema
+    // - Be excluded from schema diff calculations
+    // - Be treated as if they don't exist for comparison purposes
+    //
+    // Common extensions to ignore include:
+    // - plpgsql: Default procedural language, usually pre-installed
+    // - adminpack: Administrative functions, often pre-installed
+    IgnoredExtensions []string
+
+    // Dialect is the target database dialect ("postgres", "mysql", "mariadb",
+    // "clickhouse"). It is optional; when empty the comparison uses
+    // dialect-neutral rules. It is currently consulted only to fold
+    // referential-action reporting quirks: MariaDB reports an unspecified
+    // ON DELETE/ON UPDATE as RESTRICT (MySQL and PostgreSQL report NO ACTION),
+    // and InnoDB treats RESTRICT and NO ACTION identically, so for MySQL/MariaDB
+    // RESTRICT is folded to NO ACTION to avoid a perpetual drop+add loop on an
+    // unchanged foreign key. PostgreSQL distinguishes the two at DDL, so the
+    // fold is deliberately NOT applied there.
+    Dialect string
+}
+    CompareOptions contains configuration options for schema comparison
+    operations. These options control how schema differences are calculated and
+    what elements should be ignored during comparison.
+
+func DefaultCompareOptions() *CompareOptions
+func WithAdditionalIgnoredExtensions(extensions ...string) *CompareOptions
+func WithIgnoredExtensions(extensions ...string) *CompareOptions
+func (c *CompareOptions) FilterIgnoredExtensions(extensions []string) []string
+func (c *CompareOptions) IsExtensionIgnored(extensionName string) bool
 
 ## github.com/stokaro/ptah/config/projectconfig
 
@@ -56,6 +165,293 @@ type OnlineDDLConfig struct{ ... }
 type SchemaConfig struct{ ... }
 type SchemaFormatConfig struct{ ... }
 type SchemaModeConfig struct{ ... }
+
+### github.com/stokaro/ptah/config/projectconfig.AtlasLoadOptions
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type AtlasLoadOptions struct {
+    EnvName string
+    Vars    []string
+}
+    AtlasLoadOptions selects Atlas project config evaluation settings.
+
+
+### github.com/stokaro/ptah/config/projectconfig.Config
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type Config struct {
+    // EnvName is the selected project env name, when the source had one.
+    EnvName string
+    // DatabaseURL is the target database URL used by migration commands.
+    DatabaseURL string
+    // DevURL is the disposable dev/shadow database URL.
+    DevURL string
+    // SchemaSources are desired schema source URLs.
+    SchemaSources []string
+    // Schemas restricts database introspection to selected schemas.
+    Schemas []string
+    // Exclude lists schema patterns excluded by project config.
+    Exclude []string
+    // Schema holds Atlas declarative schema settings.
+    Schema SchemaConfig
+    // Migration holds migration-directory and runtime settings.
+    Migration MigrationConfig
+    // OnlineDDL configures automatic online-DDL routing.
+    OnlineDDL OnlineDDLConfig
+    // Lint holds migration-lint settings.
+    Lint LintConfig
+    // Format holds Atlas-compatible output templates.
+    Format FormatConfig
+    // Diff holds Atlas-compatible schema diff policy.
+    Diff DiffConfig
+    // ExternalSchema configures an external program that emits the desired
+    // schema to stdout.
+    ExternalSchema ExternalSchemaConfig
+
+    // Has unexported fields.
+}
+    Config is Ptah's project-level configuration IR. Loaders translate supported
+    file formats into this shape; command code should consume this type instead
+    of branching on the original file format.
+
+func Load(opts LoadOptions) (Config, error)
+func LoadAtlasFile(path, envName string) (Config, error)
+func LoadAtlasFileWithOptions(path string, opts AtlasLoadOptions) (Config, error)
+func LoadPtahFile(path, envName string) (Config, error)
+func Merge(base, override Config) Config
+func ParseAtlas(data []byte, filename, envName string) (Config, error)
+func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error)
+func ParsePtah(data []byte, filename, envName string) (Config, error)
+
+### github.com/stokaro/ptah/config/projectconfig.ConfigBool
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type ConfigBool struct {
+    Value bool
+    Set   bool
+}
+    ConfigBool preserves whether a boolean project config value was set
+    explicitly, which is needed for Atlas global/env inheritance.
+
+
+### github.com/stokaro/ptah/config/projectconfig.DiffConcurrentIndexConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type DiffConcurrentIndexConfig struct {
+    Create ConfigBool
+    Drop   ConfigBool
+}
+    DiffConcurrentIndexConfig holds Atlas diff.concurrent_index policy.
+
+
+### github.com/stokaro/ptah/config/projectconfig.DiffConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type DiffConfig struct {
+    Skip            DiffSkipConfig
+    ConcurrentIndex DiffConcurrentIndexConfig
+}
+    DiffConfig holds Atlas diff policy blocks.
+
+func (c DiffConfig) ConcurrentIndexCreate() bool
+func (c DiffConfig) SkipChangeKinds() []diffpolicy.ChangeKind
+
+### github.com/stokaro/ptah/config/projectconfig.DiffSkipConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type DiffSkipConfig struct {
+    DropTable  ConfigBool
+    DropColumn ConfigBool
+    DropIndex  ConfigBool
+    DropEnum   ConfigBool
+}
+    DiffSkipConfig holds the diff.skip policy: the destructive change kinds a
+    project omits from generated migrations. Each field is a tri-state so an
+    explicit false can override an inherited true.
+
+
+### github.com/stokaro/ptah/config/projectconfig.ExternalSchemaConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type ExternalSchemaConfig struct {
+    // Program is the executable and its arguments as an explicit argv list.
+    // Program[0] is the command; it is run without a shell.
+    Program []string
+    // Format is the stdout format (default "sql").
+    Format string
+    // WorkingDir is the directory the program runs in; empty uses the current
+    // working directory.
+    WorkingDir string
+    // Env holds extra "KEY=VALUE" entries passed to the program.
+    Env []string
+}
+    ExternalSchemaConfig configures an external program whose standard output is
+    the desired schema. It is Ptah's open equivalent of Atlas's external_schema
+    data source: Program is run directly (no shell) and must print the complete
+    desired schema — currently SQL DDL — to stdout.
+
+
+### github.com/stokaro/ptah/config/projectconfig.FormatConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type FormatConfig struct {
+    Migrate MigrateFormatConfig
+    Schema  SchemaFormatConfig
+}
+    FormatConfig holds Atlas env.format command templates.
+
+
+### github.com/stokaro/ptah/config/projectconfig.LintConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type LintConfig struct {
+    Dialect       string
+    DisabledRules []string
+    RuleConfigs   map[string]LintRuleConfig
+    Latest        *int
+    GitBase       string
+    GitDir        string
+}
+    LintConfig is the lint section of the project config IR.
+
+
+### github.com/stokaro/ptah/config/projectconfig.LintRuleConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type LintRuleConfig struct {
+    Severity string
+    Exclude  []string
+}
+    LintRuleConfig holds project-level overrides for one lint rule code or
+    rule-family prefix.
+
+
+### github.com/stokaro/ptah/config/projectconfig.LoadOptions
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type LoadOptions struct {
+    PtahPath  string
+    AtlasPath string
+    EnvName   string
+    AtlasVars []string
+}
+    LoadOptions selects project config files and the Atlas env.
+
+
+### github.com/stokaro/ptah/config/projectconfig.MigrateFormatConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type MigrateFormatConfig struct {
+    Apply  string
+    Diff   string
+    Lint   string
+    Status string
+}
+    MigrateFormatConfig holds Atlas env.format.migrate templates.
+
+
+### github.com/stokaro/ptah/config/projectconfig.MigrationConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type MigrationConfig struct {
+    Dir                  string
+    Format               string
+    RevisionsSchema      string
+    RevisionsTable       string
+    RevisionFormat       string
+    LockTimeout          string
+    StatementTimeout     string
+    ConnectTimeout       string
+    MigrationLockTimeout string
+    ExecOrder            string
+    TxMode               string
+    PreUpHook            string
+    PreDownHook          string
+    PostgresDumpTo       string
+    MySQLDumpTo          string
+    Webhook              string
+}
+    MigrationConfig is the migration section of the project config IR.
+
+
+### github.com/stokaro/ptah/config/projectconfig.OnlineDDLConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type OnlineDDLConfig struct {
+    // Tool selects the online-DDL tool: "ghost" or "pt-osc". Empty disables
+    // automatic routing; per-migration directives keep working.
+    Tool string
+    // ThresholdRows routes ALTER TABLE statements when the target table's
+    // estimated row count is at or above this value. Zero disables automatic
+    // routing.
+    ThresholdRows int64
+    // Args are extra arguments appended to every online-DDL tool invocation.
+    Args []string
+    // Fallback controls what happens when a selected online-DDL path cannot be
+    // used: "error" aborts and "plain" executes the plain ALTER TABLE. Empty
+    // uses the source default.
+    Fallback string
+}
+    OnlineDDLConfig configures automatic online-DDL routing for ALTER TABLE
+    statements.
+
+func (c OnlineDDLConfig) Enabled() bool
+func (c OnlineDDLConfig) Validate() error
+
+### github.com/stokaro/ptah/config/projectconfig.SchemaConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type SchemaConfig struct {
+    Mode SchemaModeConfig
+}
+    SchemaConfig holds Atlas env.schema settings.
+
+
+### github.com/stokaro/ptah/config/projectconfig.SchemaFormatConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type SchemaFormatConfig struct {
+    Apply   string
+    Clean   string
+    Diff    string
+    Inspect string
+}
+    SchemaFormatConfig holds Atlas env.format.schema templates.
+
+
+### github.com/stokaro/ptah/config/projectconfig.SchemaModeConfig
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type SchemaModeConfig struct {
+    Funcs       ConfigBool
+    Objects     ConfigBool
+    Permissions ConfigBool
+    Roles       ConfigBool
+    Tables      ConfigBool
+    Triggers    ConfigBool
+    Types       ConfigBool
+    Views       ConfigBool
+}
+    SchemaModeConfig holds Atlas env.schema.mode settings.
+
+func (m SchemaModeConfig) ExcludePatterns() []string
 
 ## github.com/stokaro/ptah/core/ast
 
@@ -253,6 +649,104 @@ type UpsertNode struct{ ... }
     func NewUpsert(table string) *UpsertNode
 type Visitor interface{ ... }
 
+### github.com/stokaro/ptah/core/ast.AddColumnOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AddColumnOperation struct {
+    // Column contains the complete column definition to add
+    Column *ColumnNode
+}
+    AddColumnOperation represents an ADD COLUMN operation in ALTER TABLE
+    statements.
+
+    This operation adds a new column to an existing table with all the specified
+    column attributes (type, constraints, defaults, etc.).
+
+func (op *AddColumnOperation) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.AddConstraintOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AddConstraintOperation struct {
+    // Constraint contains the complete constraint definition to add
+    Constraint *ConstraintNode
+}
+    AddConstraintOperation represents an ADD CONSTRAINT operation in ALTER TABLE
+    statements.
+
+    This operation adds a new constraint to an existing table. The constraint
+    can be a primary key, unique, foreign key, or check constraint.
+
+func (op *AddConstraintOperation) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.AddEnumValueOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AddEnumValueOperation struct {
+    // Value is the new enum value to add
+    Value string
+    // Before specifies the existing value before which to insert (optional)
+    Before string
+    // After specifies the existing value after which to insert (optional)
+    After string
+}
+    AddEnumValueOperation represents an ADD VALUE operation for ALTER TYPE
+    statements.
+
+    This operation adds a new value to an existing enum type. The position can
+    be specified using BEFORE or AFTER clauses.
+
+func NewAddEnumValueOperation(value string) *AddEnumValueOperation
+func (op *AddEnumValueOperation) Accept(visitor Visitor) error
+func (op *AddEnumValueOperation) SetAfter(value string) *AddEnumValueOperation
+func (op *AddEnumValueOperation) SetBefore(value string) *AddEnumValueOperation
+
+### github.com/stokaro/ptah/core/ast.AddSkippingIndexOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AddSkippingIndexOperation struct {
+    // Name is the index name.
+    Name string
+    // Expression is the indexed expression (column name, function call, tuple,
+    // etc.). Empty Expression is rejected by the ClickHouse renderer.
+    Expression string
+    // IndexType is the ClickHouse skipping-index type. Examples:
+    // "minmax", "set(N)", "bloom_filter(0.01)", "tokenbf_v1(...)". The empty
+    // string defaults to "minmax" at render time.
+    IndexType string
+    // Granularity is the GRANULARITY value. Zero defaults to 8192 at render
+    // time, matching ClickHouse's documented default for skipping indexes.
+    Granularity int
+}
+    AddSkippingIndexOperation represents ClickHouse's `ALTER TABLE x ADD INDEX
+    name expression TYPE indexType GRANULARITY n`.
+
+    Skipping indexes are a ClickHouse-only concept; other dialects emit a `--
+    <DIALECT>: data-skipping indexes are ClickHouse-specific; ignored.` comment
+    and otherwise treat the operation as a no-op.
+
+func (op *AddSkippingIndexOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.AlterGeneratedColumnExpressionOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterGeneratedColumnExpressionOperation struct {
+    // ColumnName is the generated column to alter.
+    ColumnName string
+    // Expression is the target generated-column expression without wrapping
+    // parentheses.
+    Expression string
+}
+    AlterGeneratedColumnExpressionOperation changes the expression of an
+    existing generated column without dropping the column and its dependents.
+
+func (op *AlterGeneratedColumnExpressionOperation) Accept(_visitor Visitor) error
+
 ### github.com/stokaro/ptah/core/ast.AlterOperation
 
 package ast // import "github.com/stokaro/ptah/core/ast"
@@ -268,6 +762,1224 @@ type AlterOperation interface {
     ensure type safety. All ALTER operations must implement both the visitor
     pattern and the marker method.
 
+
+### github.com/stokaro/ptah/core/ast.AlterRoleNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterRoleNode struct {
+    // Name is the name of the role to alter
+    Name string
+    // Operations contains the list of operations to perform on the role
+    Operations []RoleOperation
+    // Comment is an optional comment for the alter operation
+    Comment string
+}
+    AlterRoleNode represents an ALTER ROLE statement for PostgreSQL role
+    management.
+
+    This node is used to modify existing PostgreSQL roles, changing their
+    attributes such as login capabilities, password, privileges, and other role
+    properties. Role modifications are applied incrementally to existing roles.
+
+func NewAlterRole(name string) *AlterRoleNode
+func (n *AlterRoleNode) Accept(visitor Visitor) error
+func (n *AlterRoleNode) AddOperation(operation RoleOperation) *AlterRoleNode
+func (n *AlterRoleNode) SetComment(comment string) *AlterRoleNode
+
+### github.com/stokaro/ptah/core/ast.AlterSequenceNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterSequenceNode struct {
+    // Name is the sequence name.
+    Name string
+    // Schema is an optional schema/namespace qualifier.
+    Schema string
+    // AsType changes the underlying integer type when non-empty.
+    AsType string
+    // Start changes the START WITH value when non-nil.
+    Start *int64
+    // Increment changes the INCREMENT BY value when non-nil.
+    Increment *int64
+    // MinValue changes the MINVALUE bound when non-nil.
+    MinValue *int64
+    // MaxValue changes the MAXVALUE bound when non-nil.
+    MaxValue *int64
+    // Cache changes the CACHE size when non-nil.
+    Cache *int64
+    // Cycle sets CYCLE / NO CYCLE when non-nil.
+    Cycle *bool
+    // OwnedBy sets the OWNED BY association when non-empty (use "NONE" to detach).
+    OwnedBy string
+    // Comment is an optional comment for the operation.
+    Comment string
+}
+    AlterSequenceNode represents an ALTER SEQUENCE statement (PostgreSQL).
+    Only the set (non-nil / non-empty) options are emitted, so it can express
+    either a targeted change from a diff or a post-table OWNED BY association.
+
+func NewAlterSequence(name string) *AlterSequenceNode
+func (n *AlterSequenceNode) Accept(visitor Visitor) error
+func (n *AlterSequenceNode) SetAs(asType string) *AlterSequenceNode
+func (n *AlterSequenceNode) SetCache(cache int64) *AlterSequenceNode
+func (n *AlterSequenceNode) SetComment(comment string) *AlterSequenceNode
+func (n *AlterSequenceNode) SetCycle(cycle bool) *AlterSequenceNode
+func (n *AlterSequenceNode) SetIncrement(increment int64) *AlterSequenceNode
+func (n *AlterSequenceNode) SetMaxValue(maxValue int64) *AlterSequenceNode
+func (n *AlterSequenceNode) SetMinValue(minValue int64) *AlterSequenceNode
+func (n *AlterSequenceNode) SetOwnedBy(ownedBy string) *AlterSequenceNode
+func (n *AlterSequenceNode) SetSchema(schema string) *AlterSequenceNode
+func (n *AlterSequenceNode) SetStart(start int64) *AlterSequenceNode
+
+### github.com/stokaro/ptah/core/ast.AlterTableDisableRLSNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterTableDisableRLSNode struct {
+    // Table is the name of the table to disable RLS on
+    Table string
+    // Comment is an optional comment for the operation
+    Comment string
+}
+    AlterTableDisableRLSNode represents an ALTER TABLE ... DISABLE ROW LEVEL
+    SECURITY statement.
+
+    This node is used to disable Row-Level Security on a specific table. RLS
+    should only be disabled after all policies have been removed from the table.
+
+func NewAlterTableDisableRLS(table string) *AlterTableDisableRLSNode
+func (n *AlterTableDisableRLSNode) Accept(visitor Visitor) error
+func (n *AlterTableDisableRLSNode) SetComment(comment string) *AlterTableDisableRLSNode
+
+### github.com/stokaro/ptah/core/ast.AlterTableEnableRLSNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterTableEnableRLSNode struct {
+    // Table is the name of the table to enable RLS on
+    Table string
+    // Comment is an optional comment for the operation
+    Comment string
+}
+    AlterTableEnableRLSNode represents an ALTER TABLE ... ENABLE ROW LEVEL
+    SECURITY statement.
+
+    This node is used to enable Row-Level Security on a specific table. RLS must
+    be enabled before policies can be applied to a table.
+
+func NewAlterTableEnableRLS(table string) *AlterTableEnableRLSNode
+func (n *AlterTableEnableRLSNode) Accept(visitor Visitor) error
+func (n *AlterTableEnableRLSNode) SetComment(comment string) *AlterTableEnableRLSNode
+
+### github.com/stokaro/ptah/core/ast.AlterTableNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterTableNode struct {
+    // Name is the name of the table to alter
+    Name string
+    // Operations contains the list of operations to perform on the table
+    Operations []AlterOperation
+}
+    AlterTableNode represents ALTER TABLE statements with one or more
+    operations.
+
+    This node can contain multiple operations like adding columns, dropping
+    columns, or modifying existing columns. Each operation is represented by a
+    specific AlterOperation implementation.
+
+func (n *AlterTableNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.AlterTypeNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type AlterTypeNode struct {
+    // Name is the name of the type to alter
+    Name string
+    // Operations contains the list of operations to perform on the type
+    Operations []TypeOperation
+}
+    AlterTypeNode represents an ALTER TYPE statement with one or more
+    operations.
+
+    This node can contain multiple operations like adding enum values, renaming
+    values, or modifying type properties. Each operation is represented by a
+    specific TypeOperation implementation.
+
+func NewAlterType(name string) *AlterTypeNode
+func (n *AlterTypeNode) Accept(visitor Visitor) error
+func (n *AlterTypeNode) AddOperation(operation TypeOperation) *AlterTypeNode
+
+### github.com/stokaro/ptah/core/ast.Assignment
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type Assignment struct {
+    // Column is the target column name, rendered as a quoted identifier.
+    Column string
+    // Value is the assigned value expression, typically a BoundValue.
+    Value Expression
+}
+    Assignment is a single "column = value" pair in an UPDATE SET clause.
+
+    Column is rendered as a dialect-quoted identifier; Value is an ordinary
+    expression, so the query builder supplies a BoundValue and the value travels
+    to the database as a placeholder rather than inline SQL.
+
+
+### github.com/stokaro/ptah/core/ast.BoundValue
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type BoundValue struct {
+    // Value is the parameter value, bound positionally at render time.
+    Value any
+}
+    BoundValue is a parameter value.
+
+    The renderer emits a dialect-specific placeholder ($1, $2, … for PostgreSQL;
+    ? for MySQL, MariaDB, and SQLite) and appends Value to the returned argument
+    slice. The value is never interpolated into the SQL string.
+
+
+### github.com/stokaro/ptah/core/ast.ColumnNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ColumnNode struct {
+    // Name is the column name
+    Name string
+    // Type is the column data type (e.g., "INTEGER", "VARCHAR(255)", "TIMESTAMP")
+    Type string
+    // Nullable indicates whether the column allows NULL values (default: true)
+    Nullable bool
+    // Primary indicates whether this column is part of the primary key
+    Primary bool
+    // Unique indicates whether this column has a unique constraint
+    Unique bool
+    // AutoInc indicates whether this column is auto-incrementing
+    AutoInc bool
+    // IdentityGeneration stores PostgreSQL identity generation mode: ALWAYS or BY_DEFAULT.
+    IdentityGeneration string
+    // IdentityStart stores the optional PostgreSQL identity START WITH value.
+    IdentityStart string
+    // IdentityIncrement stores the optional PostgreSQL identity INCREMENT BY value.
+    IdentityIncrement string
+    // IdentityOptions stores raw PostgreSQL identity sequence options for SQL round-trips.
+    IdentityOptions string
+    // Default contains the default value specification (literal or function)
+    Default *DefaultValue
+    // Check contains a check constraint expression for this column
+    Check string
+    // CheckName is an optional explicit constraint name for the column-level
+    // CHECK. When empty, dialect renderers either emit an unnamed `CHECK (...)`
+    // (relying on the engine's auto-generated name) or, in the planner path
+    // when matching against introspected constraints, a deterministic
+    // "<table>_<column>_check" identifier.
+    CheckName string
+    // GeneratedExpression stores the raw SQL expression for generated columns.
+    GeneratedExpression string
+    // GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
+    GeneratedKind string
+    // UpdateExpression stores MySQL/MariaDB ON UPDATE expressions such as CURRENT_TIMESTAMP(6).
+    UpdateExpression string
+    // Charset is an optional column character set for MySQL-compatible dialects.
+    Charset string
+    // Collate is an optional column collation for MySQL-compatible dialects.
+    Collate string
+    // Comment is an optional column comment
+    Comment string
+    // ForeignKey contains foreign key reference information if this column references another table
+    ForeignKey *ForeignKeyRef
+}
+    ColumnNode represents a table column definition with all its attributes.
+
+    This node contains the complete specification of a table column including
+    its data type, constraints, default values, and other properties.
+    It supports a fluent API for easy configuration.
+
+func NewColumn(name, dataType string) *ColumnNode
+func (n *ColumnNode) Accept(visitor Visitor) error
+func (n *ColumnNode) SetAutoIncrement() *ColumnNode
+func (n *ColumnNode) SetCharset(charset string) *ColumnNode
+func (n *ColumnNode) SetCheck(expression string) *ColumnNode
+func (n *ColumnNode) SetCheckName(name string) *ColumnNode
+func (n *ColumnNode) SetCollate(collate string) *ColumnNode
+func (n *ColumnNode) SetComment(comment string) *ColumnNode
+func (n *ColumnNode) SetDefault(value string) *ColumnNode
+func (n *ColumnNode) SetDefaultExpression(fn string) *ColumnNode
+func (n *ColumnNode) SetForeignKey(table, column, name string) *ColumnNode
+func (n *ColumnNode) SetGenerated(expression, kind string) *ColumnNode
+func (n *ColumnNode) SetIdentity(generation, start, increment string) *ColumnNode
+func (n *ColumnNode) SetIdentityOptions(options string) *ColumnNode
+func (n *ColumnNode) SetNotNull() *ColumnNode
+func (n *ColumnNode) SetPrimary() *ColumnNode
+func (n *ColumnNode) SetUnique() *ColumnNode
+func (n *ColumnNode) SetUpdateExpression(expression string) *ColumnNode
+
+### github.com/stokaro/ptah/core/ast.ColumnRef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ColumnRef struct {
+    // Qualifier is the optional table name or alias qualifying the column. An
+    // empty Qualifier renders a bare column name. It is quoted independently of
+    // Name so neither part can break out of its quotes.
+    Qualifier string
+    // Name is the column name.
+    Name string
+}
+    ColumnRef is a reference to a column, optionally qualified by a table name
+    or alias.
+
+    A ColumnRef always renders as a dialect-quoted identifier and never
+    as literal SQL text, so an attacker-shaped name cannot terminate the
+    identifier. When Qualifier is set the column renders as "Qualifier"."Name",
+    each part quoted independently.
+
+
+### github.com/stokaro/ptah/core/ast.CommentNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CommentNode struct {
+    // Text is the comment content
+    Text string
+}
+    CommentNode represents SQL comments that can be included in generated
+    scripts.
+
+    Comments are useful for documenting generated SQL and providing context
+    about the schema structure.
+
+func NewComment(text string) *CommentNode
+func (n *CommentNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.Comparison
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type Comparison struct {
+    // Left is the left-hand operand.
+    Left Expression
+    // Operator is the comparison operator.
+    Operator ComparisonOperator
+    // Right is the right-hand operand.
+    Right Expression
+}
+    Comparison is a binary comparison of the form "Left <Operator> Right".
+
+    In Phase 1 the query builder produces a ColumnRef on the left and a
+    BoundValue on the right, but the node accepts any Expression on either side
+    so later phases can compare columns or expressions directly.
+
+
+### github.com/stokaro/ptah/core/ast.ComparisonOperator
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ComparisonOperator int
+    ComparisonOperator enumerates the binary comparison operators supported in
+    Phase 1.
+
+const OpEqual ComparisonOperator = iota ...
+func (op ComparisonOperator) String() string
+
+### github.com/stokaro/ptah/core/ast.CompositeField
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CompositeField struct {
+    // Name is the field name
+    Name string
+    // Type is the field data type
+    Type string
+    // Comment is an optional field comment
+    Comment string
+}
+    CompositeField represents a field in a composite type definition.
+
+
+### github.com/stokaro/ptah/core/ast.CompositeTypeDef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CompositeTypeDef struct {
+    // Fields contains the list of fields in the composite type
+    Fields []*CompositeField
+}
+    CompositeTypeDef represents a composite type definition for CREATE TYPE
+    statements.
+
+    Composite types define a structure with multiple fields, similar to a table
+    but used as a data type. This is primarily supported by PostgreSQL.
+
+func NewCompositeTypeDef(fields ...*CompositeField) *CompositeTypeDef
+func (td *CompositeTypeDef) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.ConstraintColumn
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ConstraintColumn struct {
+    // Name is the referenced column name.
+    Name string
+    // Prefix stores MySQL index prefix length, as in PRIMARY KEY (`name` (7)).
+    Prefix string
+    // Desc is true when the constraint column is declared with DESC ordering.
+    Desc bool
+}
+    ConstraintColumn represents a column reference inside a table-level
+    constraint.
+
+
+### github.com/stokaro/ptah/core/ast.ConstraintNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ConstraintNode struct {
+    // Type specifies the constraint type (PRIMARY KEY, UNIQUE, etc.)
+    Type ConstraintType
+    // Name is the constraint name (optional for some constraint types)
+    Name string
+    // Columns contains the list of column names involved in the constraint
+    Columns []string
+    // ColumnParts contains structured column references for dialect-specific
+    // attributes such as MySQL prefix lengths and DESC ordering.
+    ColumnParts []ConstraintColumn
+    // IncludeColumns contains PostgreSQL INCLUDE columns for primary key and
+    // unique constraints.
+    IncludeColumns []string
+    // NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+    // Nil means the clause was not specified.
+    NullsDistinct *bool
+    // Reference contains foreign key reference information (only for FOREIGN KEY constraints)
+    Reference *ForeignKeyRef
+    // Expression contains the check expression (only for CHECK constraints)
+    Expression string
+    // UsingMethod specifies the index method for EXCLUDE constraints (e.g., "gist", "btree")
+    UsingMethod string
+    // ExcludeElements contains the exclude elements specification (e.g., "user_id WITH =", "during WITH &&")
+    ExcludeElements string
+    // WhereCondition contains the optional WHERE clause for EXCLUDE constraints
+    WhereCondition string
+}
+    ConstraintNode represents table-level constraints (PRIMARY KEY, UNIQUE,
+    FOREIGN KEY, CHECK, EXCLUDE).
+
+    Table-level constraints can span multiple columns and are defined separately
+    from column definitions. This is different from column-level constraints
+    which are defined as part of the column specification.
+
+func NewExcludeConstraint(name, usingMethod, elements string) *ConstraintNode
+func NewForeignKeyConstraint(name string, columns []string, ref *ForeignKeyRef) *ConstraintNode
+func NewPrimaryKeyConstraint(columns ...string) *ConstraintNode
+func NewUniqueConstraint(name string, columns ...string) *ConstraintNode
+func (n *ConstraintNode) Accept(visitor Visitor) error
+func (c *ConstraintNode) SetWhereCondition(condition string) *ConstraintNode
+
+### github.com/stokaro/ptah/core/ast.ConstraintType
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ConstraintType int
+    ConstraintType represents the different types of table constraints.
+
+    This enumeration covers the standard SQL constraint types that can be
+    applied at the table level, including primary keys, unique constraints,
+    foreign keys, and check constraints.
+
+const PrimaryKeyConstraint ConstraintType = iota ...
+func (ct ConstraintType) String() string
+
+### github.com/stokaro/ptah/core/ast.CreateDatabaseNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateDatabaseNode struct {
+    // Name is the database name.
+    Name string
+    // IfNotExists preserves an IF NOT EXISTS guard when the dialect supports it.
+    IfNotExists bool
+}
+    CreateDatabaseNode represents a CREATE DATABASE statement.
+
+func NewCreateDatabase(name string) *CreateDatabaseNode
+func (n *CreateDatabaseNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.CreateFunctionNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateFunctionNode struct {
+    // Name is the name of the function to create
+    Name string
+    // Parameters contains the function parameter definitions (e.g., "tenant_id_param TEXT")
+    Parameters string
+    // Returns specifies the return type (e.g., "VOID", "TEXT", "INTEGER")
+    Returns string
+    // Language specifies the function language (e.g., "plpgsql", "sql")
+    Language string
+    // Body contains the function implementation code
+    Body string
+    // BodyKind specifies how Body should be rendered.
+    BodyKind FunctionBodyKind
+    // RoutineBody contains dialect-specific parser metadata for the function
+    // body. Rendering still uses Body and BodyKind.
+    RoutineBody *PostgresRoutineBody
+    // Security specifies security attributes (e.g., "DEFINER", "INVOKER")
+    Security string
+    // Volatility specifies function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
+    Volatility string
+    // Comment is an optional comment for the function
+    Comment string
+}
+    CreateFunctionNode represents a CREATE FUNCTION statement for PostgreSQL
+    custom functions.
+
+    This node contains the complete definition of a PostgreSQL function
+    including parameters, return type, language, security attributes,
+    and function body. It supports various PostgreSQL function attributes like
+    SECURITY DEFINER, STABLE, IMMUTABLE, etc.
+
+func NewCreateFunction(name string) *CreateFunctionNode
+func (n *CreateFunctionNode) Accept(visitor Visitor) error
+func (n *CreateFunctionNode) SetAtomicBody(body string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetBody(body string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetComment(comment string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetLanguage(language string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetParameters(parameters string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetReturnBody(body string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetReturns(returns string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetSecurity(security string) *CreateFunctionNode
+func (n *CreateFunctionNode) SetVolatility(volatility string) *CreateFunctionNode
+
+### github.com/stokaro/ptah/core/ast.CreateMaterializedViewNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateMaterializedViewNode struct {
+    Name            string
+    Body            string
+    RefreshStrategy string
+    Comment         string
+}
+    CreateMaterializedViewNode represents a CREATE MATERIALIZED VIEW statement.
+
+func NewCreateMaterializedView(name string) *CreateMaterializedViewNode
+func (n *CreateMaterializedViewNode) Accept(visitor Visitor) error
+func (n *CreateMaterializedViewNode) SetBody(body string) *CreateMaterializedViewNode
+func (n *CreateMaterializedViewNode) SetComment(comment string) *CreateMaterializedViewNode
+func (n *CreateMaterializedViewNode) SetRefreshStrategy(refreshStrategy string) *CreateMaterializedViewNode
+
+### github.com/stokaro/ptah/core/ast.CreatePolicyNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreatePolicyNode struct {
+    // Name is the name of the policy to create
+    Name string
+    // Table is the name of the table this policy applies to
+    Table string
+    // PolicyFor specifies what operations the policy applies to (e.g., "ALL", "SELECT", "INSERT", "UPDATE", "DELETE")
+    PolicyFor string
+    // ToRoles specifies which roles the policy applies to (e.g., "inventario_app", "PUBLIC")
+    ToRoles string
+    // UsingExpression contains the USING clause expression for the policy
+    UsingExpression string
+    // WithCheckExpression contains the WITH CHECK clause expression (for INSERT/UPDATE policies)
+    WithCheckExpression string
+    // Replace indicates whether to drop the policy first if it exists (for conflict resolution)
+    Replace bool
+    // Comment is an optional comment for the policy
+    Comment string
+}
+    CreatePolicyNode represents a CREATE POLICY statement for PostgreSQL
+    Row-Level Security.
+
+    This node contains the complete definition of an RLS policy including the
+    target table, policy type (FOR clause), target roles (TO clause), and the
+    policy expression (USING clause).
+
+func NewCreatePolicy(name, table string) *CreatePolicyNode
+func (n *CreatePolicyNode) Accept(visitor Visitor) error
+func (n *CreatePolicyNode) SetComment(comment string) *CreatePolicyNode
+func (n *CreatePolicyNode) SetPolicyFor(policyFor string) *CreatePolicyNode
+func (n *CreatePolicyNode) SetReplace() *CreatePolicyNode
+func (n *CreatePolicyNode) SetToRoles(toRoles string) *CreatePolicyNode
+func (n *CreatePolicyNode) SetUsingExpression(expression string) *CreatePolicyNode
+func (n *CreatePolicyNode) SetWithCheckExpression(expression string) *CreatePolicyNode
+
+### github.com/stokaro/ptah/core/ast.CreateRoleNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateRoleNode struct {
+    // Name is the name of the role to create
+    Name string
+    // Login indicates whether the role can login (default: false)
+    Login bool
+    // Password contains the role password (optional, should be encrypted)
+    Password string
+    // Superuser indicates whether the role is a superuser (default: false)
+    Superuser bool
+    // CreateDB indicates whether the role can create databases (default: false)
+    CreateDB bool
+    // CreateRole indicates whether the role can create other roles (default: false)
+    CreateRole bool
+    // Inherit indicates whether the role inherits privileges (default: true)
+    Inherit bool
+    // Replication indicates whether the role can initiate replication (default: false)
+    Replication bool
+    // Comment is an optional comment for the role
+    Comment string
+}
+    CreateRoleNode represents a CREATE ROLE statement for PostgreSQL role
+    management.
+
+    This node contains the complete definition of a PostgreSQL role including
+    login capabilities, password, privileges, and other role attributes.
+    It supports various PostgreSQL role attributes for comprehensive role
+    management.
+
+func NewCreateRole(name string) *CreateRoleNode
+func (n *CreateRoleNode) Accept(visitor Visitor) error
+func (n *CreateRoleNode) SetComment(comment string) *CreateRoleNode
+func (n *CreateRoleNode) SetCreateDB(createDB bool) *CreateRoleNode
+func (n *CreateRoleNode) SetCreateRole(createRole bool) *CreateRoleNode
+func (n *CreateRoleNode) SetInherit(inherit bool) *CreateRoleNode
+func (n *CreateRoleNode) SetLogin(login bool) *CreateRoleNode
+func (n *CreateRoleNode) SetPassword(password string) *CreateRoleNode
+func (n *CreateRoleNode) SetReplication(replication bool) *CreateRoleNode
+func (n *CreateRoleNode) SetSuperuser(superuser bool) *CreateRoleNode
+
+### github.com/stokaro/ptah/core/ast.CreateSchemaNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateSchemaNode struct {
+    // Name is the schema name.
+    Name string
+    // IfNotExists preserves an IF NOT EXISTS guard when the dialect supports it.
+    IfNotExists bool
+    // Comment is an optional schema comment.
+    Comment string
+    // Charset is an optional default character set for MySQL-compatible dialects.
+    Charset string
+    // Collate is an optional default collation for MySQL-compatible dialects.
+    Collate string
+}
+    CreateSchemaNode represents a CREATE SCHEMA statement.
+
+func NewCreateSchema(name string) *CreateSchemaNode
+func (n *CreateSchemaNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.CreateSequenceNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateSequenceNode struct {
+    // Name is the sequence name.
+    Name string
+    // Schema is an optional schema/namespace qualifier.
+    Schema string
+    // IfNotExists indicates whether to use IF NOT EXISTS.
+    IfNotExists bool
+    // AsType is the optional underlying integer type (e.g. "bigint").
+    AsType string
+    // Start is the optional START WITH value.
+    Start *int64
+    // Increment is the optional INCREMENT BY value (must be non-zero).
+    Increment *int64
+    // MinValue is the optional MINVALUE bound.
+    MinValue *int64
+    // MaxValue is the optional MAXVALUE bound.
+    MaxValue *int64
+    // Cache is the optional CACHE size.
+    Cache *int64
+    // Cycle indicates whether the sequence uses CYCLE (default NO CYCLE).
+    Cycle bool
+    // OwnedBy is an optional "table.column" association (OWNED BY). Because a
+    // sequence referenced by a column DEFAULT must be created before its table
+    // while OWNED BY requires the table to already exist, planners typically
+    // emit OWNED BY as a separate ALTER SEQUENCE after table creation rather
+    // than inline here.
+    OwnedBy string
+    // Comment is an optional comment for the sequence.
+    Comment string
+}
+    CreateSequenceNode represents a CREATE SEQUENCE statement (PostgreSQL).
+
+    A sequence is a standalone schema object, distinct from the implicit,
+    table-owned sequences that back SERIAL / BIGSERIAL columns. Optional
+    numeric options use pointers so an unset option is distinguishable from an
+    explicit zero (which callers must never rely on for INCREMENT, since zero is
+    invalid).
+
+func NewCreateSequence(name string) *CreateSequenceNode
+func (n *CreateSequenceNode) Accept(visitor Visitor) error
+func (n *CreateSequenceNode) SetAs(asType string) *CreateSequenceNode
+func (n *CreateSequenceNode) SetCache(cache int64) *CreateSequenceNode
+func (n *CreateSequenceNode) SetComment(comment string) *CreateSequenceNode
+func (n *CreateSequenceNode) SetCycle(cycle bool) *CreateSequenceNode
+func (n *CreateSequenceNode) SetIfNotExists() *CreateSequenceNode
+func (n *CreateSequenceNode) SetIncrement(increment int64) *CreateSequenceNode
+func (n *CreateSequenceNode) SetMaxValue(maxValue int64) *CreateSequenceNode
+func (n *CreateSequenceNode) SetMinValue(minValue int64) *CreateSequenceNode
+func (n *CreateSequenceNode) SetOwnedBy(ownedBy string) *CreateSequenceNode
+func (n *CreateSequenceNode) SetSchema(schema string) *CreateSequenceNode
+func (n *CreateSequenceNode) SetStart(start int64) *CreateSequenceNode
+
+### github.com/stokaro/ptah/core/ast.CreateTableNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateTableNode struct {
+    // Name is the name of the table to create
+    Name string
+    // IfNotExists preserves an IF NOT EXISTS guard when present.
+    IfNotExists bool
+    // Columns contains all column definitions for the table
+    Columns []*ColumnNode
+    // Constraints contains table-level constraints (PRIMARY KEY, UNIQUE, FOREIGN KEY, CHECK)
+    Constraints []*ConstraintNode
+    // Options contains dialect-specific table options like ENGINE for MySQL
+    Options map[string]string
+    // Partition stores PostgreSQL PARTITION BY metadata.
+    Partition *PartitionSpec
+    // SelectBody stores the SELECT tail for CREATE TABLE ... SELECT statements.
+    SelectBody string
+    // Comment is an optional table comment
+    Comment string
+}
+    CreateTableNode represents a CREATE TABLE statement with all its components.
+
+    This node contains the complete definition of a table including columns,
+    constraints, dialect-specific options, and optional comments. It supports a
+    fluent API for easy construction.
+
+func NewCreateTable(name string) *CreateTableNode
+func (n *CreateTableNode) Accept(visitor Visitor) error
+func (n *CreateTableNode) AddColumn(column *ColumnNode) *CreateTableNode
+func (n *CreateTableNode) AddConstraint(constraint *ConstraintNode) *CreateTableNode
+func (n *CreateTableNode) SetIfNotExists() *CreateTableNode
+func (n *CreateTableNode) SetOption(key, value string) *CreateTableNode
+func (n *CreateTableNode) SetSelectBody(body string) *CreateTableNode
+
+### github.com/stokaro/ptah/core/ast.CreateTriggerNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateTriggerNode struct {
+    Name         string
+    Table        string
+    Timing       string
+    Event        string
+    ForEach      string
+    Body         string
+    FunctionName string
+    Replace      bool
+    Comment      string
+}
+    CreateTriggerNode represents a CREATE TRIGGER statement.
+
+func NewCreateTrigger(name, table string) *CreateTriggerNode
+func (n *CreateTriggerNode) Accept(visitor Visitor) error
+func (n *CreateTriggerNode) SetBody(body string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetComment(comment string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetEvent(event string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetForEach(forEach string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetFunctionName(functionName string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetReplace() *CreateTriggerNode
+func (n *CreateTriggerNode) SetTiming(timing string) *CreateTriggerNode
+
+### github.com/stokaro/ptah/core/ast.CreateTypeNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateTypeNode struct {
+    // Name is the name of the type to create
+    Name string
+    // TypeDef contains the type definition (enum, composite, domain, etc.)
+    TypeDef TypeDefinition
+    // Comment is an optional comment for the type creation
+    Comment string
+}
+    CreateTypeNode represents a CREATE TYPE statement with various type
+    definitions.
+
+    This node supports different type definitions including enums, composite
+    types, domains, and ranges. The specific type definition is determined by
+    the TypeDef field.
+
+func NewCreateType(name string, typeDef TypeDefinition) *CreateTypeNode
+func (n *CreateTypeNode) Accept(visitor Visitor) error
+func (n *CreateTypeNode) SetComment(comment string) *CreateTypeNode
+
+### github.com/stokaro/ptah/core/ast.CreateViewNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type CreateViewNode struct {
+    Name      string
+    Body      string
+    Replace   bool
+    WithCheck bool
+    Comment   string
+}
+    CreateViewNode represents a CREATE VIEW statement.
+
+func NewCreateView(name string) *CreateViewNode
+func (n *CreateViewNode) Accept(visitor Visitor) error
+func (n *CreateViewNode) SetBody(body string) *CreateViewNode
+func (n *CreateViewNode) SetComment(comment string) *CreateViewNode
+func (n *CreateViewNode) SetReplace() *CreateViewNode
+func (n *CreateViewNode) SetWithCheck(withCheck bool) *CreateViewNode
+
+### github.com/stokaro/ptah/core/ast.DefaultValue
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DefaultValue struct {
+    // Value contains literal default values like 'default_value', '42', 'true'
+    Value string
+    // ValueSet distinguishes an explicitly empty literal from no literal.
+    ValueSet bool
+    // Function contains function calls like NOW(), UUID()
+    Expression string
+}
+    DefaultValue represents different types of default values for table columns.
+
+    A default value can be either a literal value (like 'active', 42, true) or a
+    function call (like NOW(), CURRENT_TIMESTAMP, UUID()). Only one of Value or
+    Function should be set.
+
+func (d *DefaultValue) HasLiteral() bool
+
+### github.com/stokaro/ptah/core/ast.DeleteStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DeleteStatement struct {
+    // Table is the target table, rendered as a quoted identifier. Required.
+    Table string
+    // Where is the optional filter expression tree; nil means no WHERE clause. A
+    // nil Where is allowed only together with Unconditional.
+    Where Expression
+    // Unconditional opts in to a whole-table DELETE when Where is nil, exactly as
+    // on UpdateStatement.
+    Unconditional bool
+    // Returning is the optional RETURNING projection. See InsertStatement.Returning
+    // for the dialect support rules.
+    Returning []ColumnRef
+}
+    DeleteStatement is a DELETE FROM … over a single table, with an optional
+    WHERE clause and RETURNING projection.
+
+    Like UpdateStatement, a DELETE with no WHERE clause removes every row,
+    so the renderer rejects it unless Unconditional is set.
+
+
+### github.com/stokaro/ptah/core/ast.DomainTypeDef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DomainTypeDef struct {
+    // BaseType is the underlying data type
+    BaseType string
+    // Nullable indicates whether the domain allows NULL values
+    Nullable bool
+    // Default contains the default value for the domain
+    Default *DefaultValue
+    // Check contains a check constraint expression
+    Check string
+}
+    DomainTypeDef represents a domain type definition for CREATE DOMAIN
+    statements.
+
+    Domains are essentially aliases for existing data types with optional
+    constraints. This is primarily supported by PostgreSQL.
+
+func NewDomainTypeDef(baseType string) *DomainTypeDef
+func (td *DomainTypeDef) Accept(visitor Visitor) error
+func (td *DomainTypeDef) SetCheck(expression string) *DomainTypeDef
+func (td *DomainTypeDef) SetDefault(value string) *DomainTypeDef
+func (td *DomainTypeDef) SetDefaultExpression(fn string) *DomainTypeDef
+func (td *DomainTypeDef) SetNotNull() *DomainTypeDef
+
+### github.com/stokaro/ptah/core/ast.DropColumnOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropColumnOperation struct {
+    // ColumnName is the name of the column to drop
+    ColumnName string
+    // Cascade indicates whether to automatically drop dependent objects
+    Cascade bool
+}
+    DropColumnOperation represents a DROP COLUMN operation in ALTER TABLE
+    statements.
+
+    This operation removes an existing column from a table. Note that dropping
+    columns may have cascading effects on indexes, constraints, and foreign
+    keys.
+
+func (op *DropColumnOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.DropConstraintOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropConstraintOperation struct {
+    // ConstraintName is the name of the constraint to drop
+    ConstraintName string
+    // IfExists indicates whether to use IF EXISTS clause to avoid errors if constraint doesn't exist
+    IfExists bool
+    // ForeignKey marks the constraint as a FOREIGN KEY. MySQL/MariaDB require
+    // the dedicated `DROP FOREIGN KEY <name>` syntax for foreign keys rather
+    // than the generic `DROP CONSTRAINT <name>`; renderers that distinguish the
+    // two read this flag. Renderers where DROP CONSTRAINT already covers foreign
+    // keys (PostgreSQL) may ignore it.
+    ForeignKey bool
+    // Check requests the dedicated `DROP CHECK <name>` spelling instead of the
+    // generic `DROP CONSTRAINT <name>`. MySQL 8.0.16–8.0.18 accept only the
+    // former (the generic clause arrived in 8.0.19), so planners targeting a
+    // capability set without drop_constraint_generic set this for CHECK
+    // constraints. Ignored when ForeignKey is set; renderers where the generic
+    // clause always exists (PostgreSQL) may ignore it entirely.
+    Check bool
+    // Unique requests the `DROP INDEX <name>` spelling for a UNIQUE
+    // constraint (dropping its backing index), which is valid across the
+    // entire MySQL/MariaDB family — unlike the generic DROP CONSTRAINT
+    // clause, which only exists from MySQL 8.0.19. The MySQL-family planner
+    // sets it for every UNIQUE removal (issue #195). Ignored when ForeignKey
+    // or Check is set; PostgreSQL-style renderers may ignore it.
+    Unique bool
+    // PrimaryKey requests the MySQL-family `DROP PRIMARY KEY` spelling. MySQL
+    // and MariaDB do not accept a generic DROP CONSTRAINT form for primary keys,
+    // and the primary key name is always implicit in that syntax.
+    PrimaryKey bool
+}
+    DropConstraintOperation represents a DROP CONSTRAINT operation in ALTER
+    TABLE statements.
+
+    This operation removes an existing constraint from a table. The constraint
+    can be a primary key, unique, foreign key, check, or exclude constraint.
+
+func (op *DropConstraintOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.DropExtensionNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropExtensionNode struct {
+    // Name is the extension name to drop (pg_trgm, postgis, etc.)
+    Name string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Cascade indicates whether to use CASCADE option (removes dependent objects)
+    Cascade bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropExtensionNode represents a DROP EXTENSION statement for PostgreSQL.
+
+    This node is used to remove PostgreSQL extensions from the database.
+    Extension removal can be dangerous as it may break existing functionality
+    that depends on the extension's features.
+
+func NewDropExtension(name string) *DropExtensionNode
+func (n *DropExtensionNode) Accept(visitor Visitor) error
+func (n *DropExtensionNode) SetCascade() *DropExtensionNode
+func (n *DropExtensionNode) SetComment(comment string) *DropExtensionNode
+func (n *DropExtensionNode) SetIfExists() *DropExtensionNode
+
+### github.com/stokaro/ptah/core/ast.DropFunctionNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropFunctionNode struct {
+    // Name is the name of the function to drop
+    Name string
+    // Parameters contains the function parameter definitions for function signature matching
+    // This is needed because PostgreSQL allows function overloading
+    Parameters string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Cascade indicates whether to use CASCADE option (removes dependent objects)
+    Cascade bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropFunctionNode represents a DROP FUNCTION statement for PostgreSQL custom
+    functions.
+
+    This node is used to remove PostgreSQL custom functions from the database.
+    Function removal should be done carefully as other database objects may
+    depend on the function.
+
+func NewDropFunction(name string) *DropFunctionNode
+func (n *DropFunctionNode) Accept(visitor Visitor) error
+func (n *DropFunctionNode) SetCascade() *DropFunctionNode
+func (n *DropFunctionNode) SetComment(comment string) *DropFunctionNode
+func (n *DropFunctionNode) SetIfExists() *DropFunctionNode
+func (n *DropFunctionNode) SetParameters(parameters string) *DropFunctionNode
+
+### github.com/stokaro/ptah/core/ast.DropIndexNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropIndexNode struct {
+    // Name is the raw, unqualified index identifier. Dialect renderers derive
+    // its namespace from Table.
+    Name string
+    // Table is the qualified owning table. It is required for every planned
+    // index drop even when the target SQL names the index by schema.
+    Table string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropIndexNode represents a DROP INDEX statement.
+
+    This node supports various DROP INDEX options including IF EXISTS,
+    and dialect-specific features. Different databases have different syntax for
+    dropping indexes (some require table name, others don't).
+
+func NewDropIndex(name string) *DropIndexNode
+func (n *DropIndexNode) Accept(visitor Visitor) error
+func (n *DropIndexNode) SetComment(comment string) *DropIndexNode
+func (n *DropIndexNode) SetIfExists() *DropIndexNode
+func (n *DropIndexNode) SetTable(table string) *DropIndexNode
+
+### github.com/stokaro/ptah/core/ast.DropMaterializedViewNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropMaterializedViewNode struct {
+    Name     string
+    IfExists bool
+    Cascade  bool
+    Comment  string
+}
+    DropMaterializedViewNode represents a DROP MATERIALIZED VIEW statement.
+
+func NewDropMaterializedView(name string) *DropMaterializedViewNode
+func (n *DropMaterializedViewNode) Accept(visitor Visitor) error
+func (n *DropMaterializedViewNode) SetCascade() *DropMaterializedViewNode
+func (n *DropMaterializedViewNode) SetComment(comment string) *DropMaterializedViewNode
+func (n *DropMaterializedViewNode) SetIfExists() *DropMaterializedViewNode
+
+### github.com/stokaro/ptah/core/ast.DropPolicyNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropPolicyNode struct {
+    // Name is the name of the policy to drop
+    Name string
+    // Table is the name of the table this policy applies to
+    Table string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropPolicyNode represents a DROP POLICY statement for PostgreSQL Row-Level
+    Security.
+
+    This node is used to remove RLS policies from tables. Policy removal should
+    be done carefully as it changes the security model of the table.
+
+func NewDropPolicy(name, table string) *DropPolicyNode
+func (n *DropPolicyNode) Accept(visitor Visitor) error
+func (n *DropPolicyNode) SetComment(comment string) *DropPolicyNode
+func (n *DropPolicyNode) SetIfExists() *DropPolicyNode
+
+### github.com/stokaro/ptah/core/ast.DropRoleNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropRoleNode struct {
+    // Name is the name of the role to drop
+    Name string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropRoleNode represents a DROP ROLE statement for PostgreSQL role
+    management.
+
+    This node is used to remove PostgreSQL roles from the database. Role removal
+    should be done carefully as other database objects may depend on the role.
+
+func NewDropRole(name string) *DropRoleNode
+func (n *DropRoleNode) Accept(visitor Visitor) error
+func (n *DropRoleNode) SetComment(comment string) *DropRoleNode
+func (n *DropRoleNode) SetIfExists() *DropRoleNode
+
+### github.com/stokaro/ptah/core/ast.DropSequenceNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropSequenceNode struct {
+    // Name is the sequence name to drop.
+    Name string
+    // Schema is an optional schema/namespace qualifier.
+    Schema string
+    // IfExists indicates whether to use IF EXISTS.
+    IfExists bool
+    // Cascade indicates whether to use CASCADE (removes dependent objects).
+    Cascade bool
+    // Comment is an optional comment for the drop operation.
+    Comment string
+}
+    DropSequenceNode represents a DROP SEQUENCE statement (PostgreSQL).
+
+func NewDropSequence(name string) *DropSequenceNode
+func (n *DropSequenceNode) Accept(visitor Visitor) error
+func (n *DropSequenceNode) SetCascade() *DropSequenceNode
+func (n *DropSequenceNode) SetComment(comment string) *DropSequenceNode
+func (n *DropSequenceNode) SetIfExists() *DropSequenceNode
+func (n *DropSequenceNode) SetSchema(schema string) *DropSequenceNode
+
+### github.com/stokaro/ptah/core/ast.DropTableNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropTableNode struct {
+    // Name is the name of the table to drop
+    Name string
+    // Names contains all tables to drop. Name is kept as the first table for compatibility.
+    Names []string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Cascade indicates whether to use CASCADE option (PostgreSQL)
+    Cascade bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropTableNode represents a DROP TABLE statement.
+
+    This node supports various DROP TABLE options including IF EXISTS,
+    CASCADE/RESTRICT, and dialect-specific features.
+
+func NewDropTable(name string) *DropTableNode
+func (n *DropTableNode) Accept(visitor Visitor) error
+func (n *DropTableNode) SetCascade() *DropTableNode
+func (n *DropTableNode) SetComment(comment string) *DropTableNode
+func (n *DropTableNode) SetIfExists() *DropTableNode
+func (n *DropTableNode) SetNames(names []string) *DropTableNode
+func (n *DropTableNode) TableNames() []string
+
+### github.com/stokaro/ptah/core/ast.DropTriggerNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropTriggerNode struct {
+    Name         string
+    Table        string
+    FunctionName string
+    IfExists     bool
+    Cascade      bool
+    Comment      string
+}
+    DropTriggerNode represents a DROP TRIGGER statement.
+
+func NewDropTrigger(name, table string) *DropTriggerNode
+func (n *DropTriggerNode) Accept(visitor Visitor) error
+func (n *DropTriggerNode) SetCascade() *DropTriggerNode
+func (n *DropTriggerNode) SetComment(comment string) *DropTriggerNode
+func (n *DropTriggerNode) SetFunctionName(functionName string) *DropTriggerNode
+func (n *DropTriggerNode) SetIfExists() *DropTriggerNode
+
+### github.com/stokaro/ptah/core/ast.DropTypeNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropTypeNode struct {
+    // Name is the name of the type to drop
+    Name string
+    // IfExists indicates whether to use IF EXISTS clause
+    IfExists bool
+    // Cascade indicates whether to use CASCADE option
+    Cascade bool
+    // Domain indicates the object is a domain, so DROP DOMAIN is emitted instead
+    // of DROP TYPE (PostgreSQL requires the domain-specific spelling).
+    Domain bool
+    // Comment is an optional comment for the drop operation
+    Comment string
+}
+    DropTypeNode represents a DROP TYPE statement (PostgreSQL-specific).
+
+    This node is used to drop custom types, particularly enum types in
+    PostgreSQL. Other databases may not support this operation or handle it
+    differently.
+
+func NewDropType(name string) *DropTypeNode
+func (n *DropTypeNode) Accept(visitor Visitor) error
+func (n *DropTypeNode) SetCascade() *DropTypeNode
+func (n *DropTypeNode) SetComment(comment string) *DropTypeNode
+func (n *DropTypeNode) SetDomain() *DropTypeNode
+func (n *DropTypeNode) SetIfExists() *DropTypeNode
+
+### github.com/stokaro/ptah/core/ast.DropViewNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type DropViewNode struct {
+    Name     string
+    IfExists bool
+    Cascade  bool
+    Comment  string
+}
+    DropViewNode represents a DROP VIEW statement.
+
+func NewDropView(name string) *DropViewNode
+func (n *DropViewNode) Accept(visitor Visitor) error
+func (n *DropViewNode) SetCascade() *DropViewNode
+func (n *DropViewNode) SetComment(comment string) *DropViewNode
+func (n *DropViewNode) SetIfExists() *DropViewNode
+
+### github.com/stokaro/ptah/core/ast.EnumNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type EnumNode struct {
+    // Name is the name of the enum type
+    Name string
+    // Values contains the list of allowed enum values
+    Values []string
+}
+    EnumNode represents a CREATE TYPE ... AS ENUM statement
+    (PostgreSQL-specific).
+
+    Enums are primarily supported by PostgreSQL. Other databases may handle
+    enum-like functionality differently (e.g., CHECK constraints with IN
+    clauses).
+
+func NewEnum(name string, values ...string) *EnumNode
+func (n *EnumNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.EnumTypeDef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type EnumTypeDef struct {
+    // Values contains the list of allowed enum values
+    Values []string
+}
+    EnumTypeDef represents an enum type definition for CREATE TYPE ... AS ENUM
+    statements.
+
+    This is used within CreateTypeNode to define enum types with a list of
+    values.
+
+func NewEnumTypeDef(values ...string) *EnumTypeDef
+func (td *EnumTypeDef) Accept(visitor Visitor) error
 
 ### github.com/stokaro/ptah/core/ast.Expression
 
@@ -286,6 +1998,489 @@ type Expression interface {
     never inlined.
 
 
+### github.com/stokaro/ptah/core/ast.ExtensionNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ExtensionNode struct {
+    // Name is the extension name (pg_trgm, postgis, etc.)
+    Name string
+    // IfNotExists indicates whether to use IF NOT EXISTS clause
+    IfNotExists bool
+    // Version specifies a specific version requirement (optional)
+    Version string
+    // Comment is an optional extension comment
+    Comment string
+}
+    ExtensionNode represents a CREATE EXTENSION statement for PostgreSQL.
+
+    Extensions enable additional functionality in PostgreSQL databases, such as
+    trigram similarity search (pg_trgm) or geographic data support (PostGIS).
+
+func NewExtension(name string) *ExtensionNode
+func (n *ExtensionNode) Accept(visitor Visitor) error
+func (n *ExtensionNode) SetComment(comment string) *ExtensionNode
+func (n *ExtensionNode) SetIfNotExists() *ExtensionNode
+func (n *ExtensionNode) SetVersion(version string) *ExtensionNode
+
+### github.com/stokaro/ptah/core/ast.ForeignKeyRef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ForeignKeyRef struct {
+    // Table is the name of the referenced table
+    Table string
+    // Column is the name of the referenced column. It is kept for single-column
+    // foreign keys and compatibility with existing struct literals.
+    Column string
+    // Columns contains the referenced columns for composite foreign keys. When
+    // empty, Column remains the source of truth.
+    Columns []string
+    // OnDelete specifies the action when the referenced row is deleted (CASCADE, SET NULL, etc.)
+    OnDelete string
+    // OnUpdate specifies the action when the referenced row is updated (CASCADE, SET NULL, etc.)
+    OnUpdate string
+    // Name is the constraint name for the foreign key
+    Name string
+}
+    ForeignKeyRef represents a foreign key reference with optional referential
+    actions.
+
+    This structure defines the target table and columns for a foreign key
+    constraint, along with optional ON DELETE and ON UPDATE actions that specify
+    what should happen when the referenced row is deleted or updated.
+
+func (f *ForeignKeyRef) ReferencedColumns() []string
+
+### github.com/stokaro/ptah/core/ast.FuncCall
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type FuncCall struct {
+    // Name is the function name, emitted verbatim as a keyword. Required. It must
+    // be a simple identifier — a letter or underscore followed by letters, digits,
+    // or underscores — and the renderer rejects anything else rather than quote a
+    // function name.
+    Name string
+    // Args are the function arguments, each an expression. A column argument is
+    // quoted; a value argument is bound. Ignored when Star is true.
+    Args []Expression
+    // Star renders the argument list as a single "*", as in COUNT(*). When Star is
+    // true, Args must be empty and Distinct must be false; the renderer rejects
+    // either combination rather than emit invalid SQL.
+    Star bool
+    // Distinct emits the DISTINCT keyword before the arguments, as in
+    // COUNT(DISTINCT "col").
+    Distinct bool
+}
+    FuncCall is a function-call expression, such as an aggregate: COUNT(*),
+    COUNT("col"), COUNT(DISTINCT "col"), or SUM("col"). It is shaped as a
+    general function call so non-aggregate functions can reuse it in a later
+    phase.
+
+    The function is usable anywhere an Expression is: in a projection (via
+    ResultColumn.Expr) and in a HAVING comparison (as an operand of Comparison).
+    Name is a bare SQL keyword emitted verbatim, never quoted and never bound
+    — the renderer rejects a Name that is not a simple identifier so a caller
+    cannot smuggle SQL through it. Args are ordinary expressions, so a column
+    argument is quoted through the identifier path and a value argument is bound
+    as a placeholder.
+
+
+### github.com/stokaro/ptah/core/ast.FunctionBodyKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type FunctionBodyKind string
+    FunctionBodyKind specifies the PostgreSQL CREATE FUNCTION body syntax.
+
+const FunctionBodyQuoted FunctionBodyKind = "quoted" ...
+
+### github.com/stokaro/ptah/core/ast.GrantPrivilegeNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type GrantPrivilegeNode struct {
+    // Role is the role receiving the privilege.
+    Role string
+    // Privileges contains one or more privileges, e.g. SELECT, INSERT, USAGE.
+    Privileges []string
+    // ObjectType is the target kind, such as TABLE, SCHEMA, or SEQUENCE.
+    ObjectType string
+    // ObjectName is the target table or schema name.
+    ObjectName string
+    // WithOption controls WITH GRANT OPTION.
+    WithOption bool
+    // Comment is an optional comment for the grant operation.
+    Comment string
+}
+    GrantPrivilegeNode represents a PostgreSQL GRANT statement.
+
+func NewGrantPrivilege(role, objectType, objectName string, privileges []string) *GrantPrivilegeNode
+func (n *GrantPrivilegeNode) Accept(visitor Visitor) error
+func (n *GrantPrivilegeNode) SetComment(comment string) *GrantPrivilegeNode
+func (n *GrantPrivilegeNode) SetWithOption(withOption bool) *GrantPrivilegeNode
+
+### github.com/stokaro/ptah/core/ast.InExpr
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type InExpr struct {
+    // Operand is the expression tested for membership, typically a ColumnRef.
+    Operand Expression
+    // Values are the candidate values, each bound as a placeholder.
+    Values []Expression
+}
+    InExpr is a membership test of the form "Operand IN (Values...)".
+
+    Values must be non-empty; the renderer rejects an empty list rather than
+    emitting the invalid "IN ()". Each value renders as its own placeholder.
+
+
+### github.com/stokaro/ptah/core/ast.IndexNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type IndexNode struct {
+    // Name is the raw, unqualified index identifier. Dialect renderers derive
+    // its namespace from Table.
+    Name string
+    // Table is the qualified name of the table to index.
+    Table string
+    // Columns contains the list of column names to include in the index
+    Columns []string
+    // Parts contains structured index elements. When empty, Columns remains
+    // the source of truth for legacy callers.
+    Parts []IndexPart
+    // Unique indicates whether this is a unique index
+    Unique bool
+    // NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT state.
+    // Nil means the clause was not specified.
+    NullsDistinct *bool
+    // Type specifies the index type (BTREE, HASH, GIN, GIST, etc. for
+    // PostgreSQL; "minmax", "set(N)", "bloom_filter(p)", "tokenbf_v1(...)"
+    // etc. for ClickHouse data-skipping indexes) - database-specific.
+    Type string
+    // Parser specifies the MySQL FULLTEXT parser name, for example ngram.
+    Parser string
+    // Comment is an optional index comment
+    Comment string
+    // IfNotExists indicates whether to use IF NOT EXISTS clause for idempotent migrations
+    IfNotExists bool
+
+    // PostgreSQL-specific features
+    // Condition specifies a WHERE clause for partial indexes
+    Condition string
+    // Operator specifies the operator class (gin_trgm_ops, etc.)
+    Operator string
+    // IncludeColumns contains PostgreSQL INCLUDE columns for covering indexes.
+    IncludeColumns []string
+    // StorageParams contains PostgreSQL index storage parameters rendered as
+    // WITH (key='value'), for example pages_per_range for BRIN indexes.
+    StorageParams map[string]string
+    // Concurrently requests CREATE INDEX CONCURRENTLY, PostgreSQL's
+    // non-locking index build. Set by planners only when the target
+    // capability set includes capability.CreateIndexConcurrently and the
+    // caller opted into concurrent builds (they cannot run inside a
+    // transaction block). Ignored by non-PostgreSQL renderers.
+    Concurrently bool
+
+    // ClickHouse-specific features
+    // Granularity is the GRANULARITY value for data-skipping indexes. Zero
+    // instructs the ClickHouse renderer to fall back to its documented
+    // default (8192). Ignored by non-ClickHouse renderers.
+    Granularity int
+}
+    IndexNode represents a CREATE INDEX statement.
+
+    Indexes can be unique or non-unique and may specify an index type depending
+    on the database system capabilities. PostgreSQL-specific features like
+    partial indexes and operator classes are also supported.
+
+func NewIndex(name, table string, columns ...string) *IndexNode
+func (n *IndexNode) Accept(visitor Visitor) error
+func (n *IndexNode) EffectiveParts() []IndexPart
+func (n *IndexNode) SetIfNotExists() *IndexNode
+func (n *IndexNode) SetParts(parts []IndexPart) *IndexNode
+func (n *IndexNode) SetUnique() *IndexNode
+
+### github.com/stokaro/ptah/core/ast.IndexPart
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type IndexPart struct {
+    // Name is the indexed column name.
+    Name string
+    // Expr is a raw indexed expression. It is mutually exclusive with Name.
+    Expr string
+    // Operator is the PostgreSQL operator class for this index part.
+    Operator string
+    // Prefix stores the MySQL index prefix length for column parts.
+    Prefix string
+    // Desc indicates DESC ordering for this index part.
+    Desc bool
+}
+    IndexPart represents one column or expression inside a CREATE INDEX column
+    list.
+
+func (p IndexPart) Reference() string
+
+### github.com/stokaro/ptah/core/ast.InsertStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type InsertStatement struct {
+    // Table is the target table, rendered as a quoted identifier. Required.
+    Table string
+    // Columns is the inserted column list, each a quoted identifier. Required and
+    // non-empty; every row must supply exactly one value per column.
+    Columns []string
+    // Rows is the list of value rows. At least one row is required, and each row
+    // must have the same length as Columns. Values are bound row by row, in order.
+    Rows [][]Expression
+    // Returning is the optional RETURNING projection: the columns to return from
+    // the inserted rows. An empty slice emits no RETURNING. RETURNING is supported
+    // only on the PostgreSQL family and SQLite; the renderer rejects it on MySQL
+    // and MariaDB rather than emit SQL those engines cannot run.
+    Returning []ColumnRef
+}
+    InsertStatement is an INSERT INTO … VALUES … over a single table, with one
+    or more value rows and an optional RETURNING projection.
+
+    Every element of every row is an expression — the query builder supplies a
+    BoundValue — so values are bound positionally at render time, row by row
+    and left to right, and never interpolated. The renderer rejects a statement
+    with no columns, no rows, or a row whose length does not match Columns,
+    rather than emit invalid SQL or panic on ragged input.
+
+
+### github.com/stokaro/ptah/core/ast.JoinClause
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type JoinClause struct {
+    // Type is the join type (INNER, LEFT, RIGHT, or FULL OUTER).
+    Type JoinType
+    // Table is the joined table name, rendered as a quoted identifier. Required.
+    Table string
+    // Alias is the optional alias for the joined table; empty means no alias.
+    Alias string
+    // On is the join condition; nil is rejected by the renderer.
+    On Expression
+}
+    JoinClause is a single join applied to the SELECT's FROM clause: a join
+    type, a target table with an optional alias, and an ON condition.
+
+    The ON condition reuses the Expression tree, so an equi-join is a Comparison
+    of two ColumnRef operands and richer predicates compose with LogicalExpr.
+    The ON expression is rendered through the same bound-parameter and
+    identifier quoting path as WHERE.
+
+
+### github.com/stokaro/ptah/core/ast.JoinType
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type JoinType int
+    JoinType enumerates the join kinds supported in Phase 2.
+
+const JoinInner JoinType = iota ...
+func (t JoinType) String() string
+
+### github.com/stokaro/ptah/core/ast.LogicalExpr
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type LogicalExpr struct {
+    // Operator is the boolean combinator applied between operands.
+    Operator LogicalOperator
+    // Operands are the sub-expressions being combined; at least one is required.
+    Operands []Expression
+}
+    LogicalExpr combines two or more operands with a single boolean operator,
+    as in "Operands[0] AND Operands[1] AND …". The renderer parenthesizes the
+    whole expression so precedence is explicit regardless of nesting.
+
+
+### github.com/stokaro/ptah/core/ast.LogicalOperator
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type LogicalOperator int
+    LogicalOperator enumerates the boolean combinators used by LogicalExpr.
+
+const LogicalAnd LogicalOperator = iota ...
+func (op LogicalOperator) String() string
+
+### github.com/stokaro/ptah/core/ast.ModifyColumnOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ModifyColumnOperation struct {
+    // Column contains the new column definition
+    Column *ColumnNode
+    // PreviousType is the best-known existing database type before the
+    // modification. Renderers ignore this metadata; safety analysis uses it to
+    // distinguish narrowing changes from other column modifications.
+    PreviousType string
+    // PreviousNullable is the best-known existing database nullability before
+    // the modification. Renderers ignore this metadata; safety analysis uses it
+    // to distinguish DROP NOT NULL from SET NOT NULL.
+    PreviousNullable bool
+    // HasPreviousNullable reports whether PreviousNullable was populated.
+    HasPreviousNullable bool
+}
+    ModifyColumnOperation represents an ALTER COLUMN/MODIFY COLUMN operation in
+    ALTER TABLE statements.
+
+    This operation changes the definition of an existing column. The exact
+    syntax varies between database systems (ALTER COLUMN vs MODIFY COLUMN).
+
+func (op *ModifyColumnOperation) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.ModifyTTLOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ModifyTTLOperation struct {
+    // Expression is the new TTL clause. Empty clears the TTL.
+    Expression string
+}
+    ModifyTTLOperation represents ClickHouse's `ALTER TABLE x MODIFY TTL ...`
+    and `ALTER TABLE x REMOVE TTL`.
+
+    Empty Expression instructs the ClickHouse renderer to emit `REMOVE TTL`;
+    any non-empty value is emitted verbatim as `MODIFY TTL <expression>`.
+
+    Table TTL is a ClickHouse-only concept; other dialects emit a `-- <DIALECT>:
+    table TTL is ClickHouse-specific; ignored.` comment and otherwise treat the
+    operation as a no-op.
+
+func (op *ModifyTTLOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineBody
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineBody struct {
+    // SQL is the full body fragment, usually BEGIN ... END or RETURN ...
+    SQL string
+    // Statements are the top-level routine-body statements.
+    Statements []MySQLRoutineStatement
+}
+    MySQLRoutineBody contains a parsed MySQL routine body.
+
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineCursor
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineCursor struct {
+    Name      string
+    SelectSQL string
+}
+    MySQLRoutineCursor models DECLARE ... CURSOR statements.
+
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineDeclaration
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineDeclaration struct {
+    Kind         MySQLRoutineDeclarationKind
+    Names        []string
+    TypeSQL      string
+    DefaultSQL   string
+    ConditionSQL string
+}
+    MySQLRoutineDeclaration models DECLARE variable and condition statements.
+    TypeSQL, DefaultSQL, and ConditionSQL remain raw MySQL fragments; expression
+    parsing is intentionally outside the routine statement-boundary layer.
+
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineDeclarationKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineDeclarationKind string
+    MySQLRoutineDeclarationKind identifies the DECLARE subform.
+
+const MySQLRoutineDeclarationVariable MySQLRoutineDeclarationKind = "variable" ...
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineHandler
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineHandler struct {
+    Action       string
+    Conditions   []string
+    StatementSQL string
+}
+    MySQLRoutineHandler models DECLARE ... HANDLER statements.
+
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineNode struct {
+    // SQL is the complete executable routine statement without client
+    // delimiter commands.
+    SQL string
+    // Dialect is the normalized SQL dialect that selected this parser path.
+    Dialect string
+    // Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+    Kind RoutineKind
+    // Definer stores an optional MySQL DEFINER clause such as
+    // DEFINER=`user`@`host`.
+    Definer string
+    // Name is the routine name, including any schema qualifier or identifier
+    // quoting used by the source statement.
+    Name string
+    // Parameters contains the raw parameter list without surrounding
+    // parentheses.
+    Parameters string
+    // Returns contains the raw MySQL function return type. It is empty for
+    // procedures.
+    Returns string
+    // Characteristics stores raw routine characteristics before the body, such
+    // as DETERMINISTIC, SQL SECURITY INVOKER, or MODIFIES SQL DATA.
+    Characteristics []string
+    // Body is the parsed routine body. Expressions remain raw SQL fragments;
+    // statement boundaries and procedural statement kinds are modeled.
+    Body MySQLRoutineBody
+}
+    MySQLRoutineNode represents a MySQL-family CREATE FUNCTION or CREATE
+    PROCEDURE statement parsed through the dialect-specific routine layer.
+
+func NewMySQLRoutine(sql, dialect string, kind RoutineKind) *MySQLRoutineNode
+func (n *MySQLRoutineNode) Accept(visitor Visitor) error
+func (n *MySQLRoutineNode) SetCharacteristics(characteristics []string) *MySQLRoutineNode
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineStatement struct {
+    Kind        MySQLRoutineStatementKind
+    SQL         string
+    Declaration *MySQLRoutineDeclaration
+    Cursor      *MySQLRoutineCursor
+    Handler     *MySQLRoutineHandler
+}
+    MySQLRoutineStatement is one top-level statement inside a MySQL routine
+    body. SQL expression internals are preserved as raw fragments.
+
+
+### github.com/stokaro/ptah/core/ast.MySQLRoutineStatementKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type MySQLRoutineStatementKind string
+    MySQLRoutineStatementKind identifies a MySQL routine-body statement class.
+
+const MySQLRoutineStatementRaw MySQLRoutineStatementKind = "raw" ...
+
 ### github.com/stokaro/ptah/core/ast.Node
 
 package ast // import "github.com/stokaro/ptah/core/ast"
@@ -300,6 +2495,378 @@ type Node interface {
     pattern. The Accept method allows visitors to traverse the AST and generate
     dialect-specific SQL output.
 
+
+### github.com/stokaro/ptah/core/ast.NotExpr
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type NotExpr struct {
+    // Operand is the expression being negated.
+    Operand Expression
+}
+    NotExpr negates its operand, rendering as "NOT (Operand)".
+
+
+### github.com/stokaro/ptah/core/ast.NullTest
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type NullTest struct {
+    // Operand is the expression tested for null, typically a ColumnRef.
+    Operand Expression
+    // Negated selects IS NOT NULL instead of IS NULL.
+    Negated bool
+}
+    NullTest is a null check of the form "Operand IS NULL" or, when Negated,
+    "Operand IS NOT NULL".
+
+
+### github.com/stokaro/ptah/core/ast.OpaqueRoutineNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type OpaqueRoutineNode struct {
+    // SQL is the complete executable routine statement without client batch
+    // separators such as GO or DELIMITER markers.
+    SQL string
+    // Dialect is the normalized SQL dialect that selected this opaque routine
+    // path, for example mysql, mariadb, or sqlserver.
+    Dialect string
+    // Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+    Kind RoutineKind
+}
+    OpaqueRoutineNode wraps a dialect-specific routine whose outer boundary
+    is understood but whose body is intentionally preserved verbatim until a
+    dialect-specific routine-body AST exists.
+
+func NewOpaqueRoutine(sql, dialect string, kind RoutineKind) *OpaqueRoutineNode
+func (n *OpaqueRoutineNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.OrderByClause
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type OrderByClause struct {
+    // Qualifier is the optional table name or alias qualifying the column,
+    // quoted independently. An empty Qualifier renders a bare column name.
+    Qualifier string
+    // Column is the column name to order by, rendered as a quoted identifier.
+    Column string
+    // Direction is the sort direction.
+    Direction SortDirection
+}
+    OrderByClause is a single ORDER BY term: a column and a sort direction.
+    The direction is always rendered explicitly so output is deterministic.
+
+
+### github.com/stokaro/ptah/core/ast.PartitionPart
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PartitionPart struct {
+    // Name is the partition key column name.
+    Name string
+    // Expr is the raw partition key expression.
+    Expr string
+}
+    PartitionPart represents one partition key column or expression.
+
+
+### github.com/stokaro/ptah/core/ast.PartitionSpec
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PartitionSpec struct {
+    // Type is the partitioning method, such as RANGE, LIST, or HASH.
+    Type string
+    // Parts contains column references or expressions used as partition keys.
+    Parts []PartitionPart
+}
+    PartitionSpec represents a table PARTITION BY clause.
+
+
+### github.com/stokaro/ptah/core/ast.PostgresDoBlockNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PostgresDoBlockNode struct {
+    // SQL is the complete executable DO statement.
+    SQL string
+    // Language stores the optional LANGUAGE clause. Empty means PostgreSQL's
+    // default plpgsql language.
+    Language string
+    // Body is the parsed anonymous routine body.
+    Body PostgresRoutineBody
+}
+    PostgresDoBlockNode represents a PostgreSQL DO statement parsed through the
+    dialect-specific routine layer.
+
+func NewPostgresDoBlock(sql string) *PostgresDoBlockNode
+func (n *PostgresDoBlockNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.PostgresRoutineBody
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PostgresRoutineBody struct {
+    // SQL is the raw body text without string or dollar-quote delimiters.
+    SQL string
+    // Delimiter is the dollar-quote delimiter such as $$ or $tag$. It is empty
+    // for single-quoted and SQL-standard bodies.
+    Delimiter string
+    // Language is the normalized body language known at parse time.
+    Language string
+    // Statements are top-level PL/pgSQL-ish statements when the body is a
+    // block; SQL-language bodies usually remain a single raw statement.
+    Statements []PostgresRoutineStatement
+}
+    PostgresRoutineBody contains parser metadata for a PostgreSQL function,
+    procedure, or DO body. Expressions remain raw PostgreSQL fragments.
+
+
+### github.com/stokaro/ptah/core/ast.PostgresRoutineNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PostgresRoutineNode struct {
+    // SQL is the complete executable routine statement.
+    SQL string
+    // Dialect is the normalized SQL dialect that selected this parser path.
+    Dialect string
+    // Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+    Kind RoutineKind
+    // Name is the routine name, including schema qualifiers or quoting.
+    Name string
+    // Parameters contains the raw parameter list without surrounding
+    // parentheses.
+    Parameters string
+    // Language stores the normalized LANGUAGE clause when present.
+    Language string
+    // Body is the parsed routine body metadata.
+    Body PostgresRoutineBody
+}
+    PostgresRoutineNode represents a PostgreSQL CREATE PROCEDURE statement
+    parsed through the dialect-specific routine layer.
+
+func NewPostgresRoutine(sql, dialect string, kind RoutineKind) *PostgresRoutineNode
+func (n *PostgresRoutineNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.PostgresRoutineStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PostgresRoutineStatement struct {
+    Kind PostgresRoutineStatementKind
+    SQL  string
+}
+    PostgresRoutineStatement is one top-level statement inside a PostgreSQL
+    routine body.
+
+
+### github.com/stokaro/ptah/core/ast.PostgresRoutineStatementKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type PostgresRoutineStatementKind string
+    PostgresRoutineStatementKind identifies a PostgreSQL routine-body statement
+    class.
+
+const PostgresRoutineStatementRaw PostgresRoutineStatementKind = "raw" ...
+
+### github.com/stokaro/ptah/core/ast.RangeTypeDef
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RangeTypeDef struct {
+    // Subtype is the required element type the range is built over (e.g. "integer").
+    Subtype string
+    // SubtypeOpClass is an optional operator class for the subtype ordering.
+    SubtypeOpClass string
+    // Collation is an optional collation for the subtype.
+    Collation string
+    // Canonical is an optional canonicalization function.
+    Canonical string
+    // SubtypeDiff is an optional subtype difference function.
+    SubtypeDiff string
+}
+    RangeTypeDef represents a range type definition for CREATE TYPE ... AS RANGE
+    statements.
+
+    Range types describe a range of values of an ordered subtype (for example an
+    int4range over integer). This is PostgreSQL-specific.
+
+func NewRangeTypeDef(subtype string) *RangeTypeDef
+func (td *RangeTypeDef) Accept(visitor Visitor) error
+func (td *RangeTypeDef) SetCanonical(canonical string) *RangeTypeDef
+func (td *RangeTypeDef) SetCollation(collation string) *RangeTypeDef
+func (td *RangeTypeDef) SetSubtypeDiff(subtypeDiff string) *RangeTypeDef
+func (td *RangeTypeDef) SetSubtypeOpClass(opClass string) *RangeTypeDef
+
+### github.com/stokaro/ptah/core/ast.RawSQLNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RawSQLNode struct {
+    // SQL is the literal SQL text to emit. The renderer writes it as a single
+    // line; if multi-line output is needed include the newlines yourself.
+    SQL string
+}
+    RawSQLNode wraps a literal SQL fragment that should be emitted verbatim
+    during rendering, including its trailing semicolon if any. It exists for the
+    rare case where the renderer's structured nodes can't express what we need —
+    currently the postgres planner uses it to wrap a DO block that dynamically
+    resolves and drops a constraint by name.
+
+    Use sparingly: dialect-agnostic structured nodes are still preferred when
+    they exist.
+
+func NewRawSQL(sql string) *RawSQLNode
+func (n *RawSQLNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.RefreshMaterializedViewNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RefreshMaterializedViewNode struct {
+    Name         string
+    Concurrently bool
+    Comment      string
+}
+    RefreshMaterializedViewNode represents a REFRESH MATERIALIZED VIEW
+    statement.
+
+func NewRefreshMaterializedView(name string) *RefreshMaterializedViewNode
+func (n *RefreshMaterializedViewNode) Accept(visitor Visitor) error
+func (n *RefreshMaterializedViewNode) SetComment(comment string) *RefreshMaterializedViewNode
+func (n *RefreshMaterializedViewNode) SetConcurrently() *RefreshMaterializedViewNode
+
+### github.com/stokaro/ptah/core/ast.RenameColumnOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RenameColumnOperation struct {
+    // OldName is the current column name.
+    OldName string
+    // NewName is the new column name.
+    NewName string
+}
+    RenameColumnOperation represents a RENAME COLUMN operation in ALTER TABLE
+    statements.
+
+    Both PostgreSQL and MySQL 8.0+/MariaDB 10.5.2+ natively support `ALTER
+    TABLE x RENAME COLUMN old TO new`. ClickHouse 22.6+ also supports the same
+    syntax on MergeTree-family engines. The runtime DB version is the caller's
+    responsibility; the renderer always emits the canonical spelling.
+
+func (op *RenameColumnOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.RenameEnumValueOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RenameEnumValueOperation struct {
+    // OldValue is the current enum value name
+    OldValue string
+    // NewValue is the new enum value name
+    NewValue string
+}
+    RenameEnumValueOperation represents a RENAME VALUE operation for ALTER TYPE
+    statements.
+
+    This operation renames an existing enum value to a new name.
+
+func NewRenameEnumValueOperation(oldValue, newValue string) *RenameEnumValueOperation
+func (op *RenameEnumValueOperation) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.RenameTableOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RenameTableOperation struct {
+    // NewName is the new table name.
+    NewName string
+}
+    RenameTableOperation represents a RENAME TO operation in ALTER TABLE
+    statements.
+
+    It is modeled separately from RenameColumnOperation because it changes the
+    relation name itself rather than a column inside the relation. Dialects may
+    render this as `ALTER TABLE old_name RENAME TO new_name` or as an equivalent
+    standalone table-rename statement.
+
+func (op *RenameTableOperation) Accept(_visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.RenameTypeOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RenameTypeOperation struct {
+    // NewName is the new type name
+    NewName string
+}
+    RenameTypeOperation represents a RENAME TO operation for ALTER TYPE
+    statements.
+
+    This operation renames the type itself to a new name.
+
+func NewRenameTypeOperation(newName string) *RenameTypeOperation
+func (op *RenameTypeOperation) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.ResultColumn
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type ResultColumn struct {
+    // Expr is an optional projected expression, such as a FuncCall aggregate. When
+    // non-nil it is rendered instead of Qualifier, Name, and Star.
+    Expr Expression
+    // Qualifier is the optional table name or alias qualifying the column,
+    // quoted independently. An empty Qualifier renders a bare column name. It is
+    // ignored when Star is true or Expr is set.
+    Qualifier string
+    // Name is the column name, used when Star is false and Expr is nil.
+    Name string
+    // Star selects all columns (SELECT *). Ignored when Expr is set.
+    Star bool
+    // Alias is an optional output-column alias, rendered as `AS "alias"` with the
+    // alias quoted independently. An empty Alias renders no alias.
+    Alias string
+}
+    ResultColumn is one entry in a SELECT projection.
+
+    When Expr is set the entry renders that expression (for example an
+    aggregate) and Qualifier, Name, and Star are ignored. Otherwise, when Star
+    is true the entry renders as "*" (select all columns) and Name and Qualifier
+    are ignored; otherwise Name renders as a dialect-quoted identifier, prefixed
+    by "Qualifier". when Qualifier is set. When Alias is set the entry is
+    followed by AS and the quoted alias. A zero ResultColumn leaves Expr nil and
+    Alias empty, so the Phase 1 and Phase 2 rendering is preserved unchanged.
+
+
+### github.com/stokaro/ptah/core/ast.RevokePrivilegeNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RevokePrivilegeNode struct {
+    // Role is the role losing the privilege.
+    Role string
+    // Privileges contains one or more privileges, e.g. SELECT, INSERT, USAGE.
+    Privileges []string
+    // ObjectType is the target kind, such as TABLE, SCHEMA, or SEQUENCE.
+    ObjectType string
+    // ObjectName is the target table or schema name.
+    ObjectName string
+    // GrantOptionFor controls REVOKE GRANT OPTION FOR.
+    GrantOptionFor bool
+    // Comment is an optional comment for the revoke operation.
+    Comment string
+}
+    RevokePrivilegeNode represents a PostgreSQL REVOKE statement.
+
+func NewRevokePrivilege(role, objectType, objectName string, privileges []string) *RevokePrivilegeNode
+func (n *RevokePrivilegeNode) Accept(visitor Visitor) error
+func (n *RevokePrivilegeNode) SetComment(comment string) *RevokePrivilegeNode
+func (n *RevokePrivilegeNode) SetGrantOptionFor(grantOptionFor bool) *RevokePrivilegeNode
 
 ### github.com/stokaro/ptah/core/ast.RoleOperation
 
@@ -316,6 +2883,247 @@ type RoleOperation interface {
     represented in a type-safe manner. Each operation type implements this
     interface to provide specific role modification behavior.
 
+
+### github.com/stokaro/ptah/core/ast.RoutineKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type RoutineKind string
+    RoutineKind identifies which CREATE routine form an opaque routine wraps.
+
+const RoutineKindFunction RoutineKind = "function" ...
+
+### github.com/stokaro/ptah/core/ast.SQLServerRoutineBody
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SQLServerRoutineBody struct {
+    // SQL is the raw body text after AS.
+    SQL string
+    // Statements are top-level T-SQL routine-body statements when boundaries
+    // are recoverable without parsing scalar expressions.
+    Statements []SQLServerRoutineStatement
+}
+    SQLServerRoutineBody contains parser metadata for a T-SQL routine body.
+
+
+### github.com/stokaro/ptah/core/ast.SQLServerRoutineForm
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SQLServerRoutineForm string
+    SQLServerRoutineForm identifies SQL Server function and procedure shapes.
+
+const SQLServerRoutineFormProcedure SQLServerRoutineForm = "procedure" ...
+
+### github.com/stokaro/ptah/core/ast.SQLServerRoutineNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SQLServerRoutineNode struct {
+    // SQL is the complete executable routine statement without GO separators.
+    SQL string
+    // Dialect is the normalized SQL dialect that selected this parser path.
+    Dialect string
+    // Kind identifies whether this is a CREATE FUNCTION or CREATE PROCEDURE.
+    Kind RoutineKind
+    // Name is the routine name, including bracketed schema qualifiers.
+    Name string
+    // Parameters contains the raw parameter list without surrounding
+    // parentheses.
+    Parameters string
+    // Returns contains the raw T-SQL RETURNS clause for functions.
+    Returns string
+    // Form classifies the SQL Server routine shape.
+    Form SQLServerRoutineForm
+    // Body is parsed routine-body metadata. Expressions remain raw T-SQL.
+    Body SQLServerRoutineBody
+}
+    SQLServerRoutineNode represents a SQL Server CREATE FUNCTION or CREATE
+    PROCEDURE statement parsed through the dialect-specific routine layer.
+
+func NewSQLServerRoutine(sql, dialect string, kind RoutineKind) *SQLServerRoutineNode
+func (n *SQLServerRoutineNode) Accept(visitor Visitor) error
+
+### github.com/stokaro/ptah/core/ast.SQLServerRoutineStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SQLServerRoutineStatement struct {
+    Kind SQLServerRoutineStatementKind
+    SQL  string
+}
+    SQLServerRoutineStatement is one top-level statement inside a T-SQL routine
+    body.
+
+
+### github.com/stokaro/ptah/core/ast.SQLServerRoutineStatementKind
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SQLServerRoutineStatementKind string
+    SQLServerRoutineStatementKind identifies a T-SQL routine-body statement
+    class.
+
+const SQLServerRoutineStatementRaw SQLServerRoutineStatementKind = "raw" ...
+
+### github.com/stokaro/ptah/core/ast.SelectStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SelectStatement struct {
+    // Distinct renders SELECT DISTINCT, deduplicating result rows. It defaults to
+    // false, so a zero statement renders a plain SELECT unchanged.
+    Distinct bool
+    // Columns is the projection. An empty slice renders as "*".
+    Columns []ResultColumn
+    // From is the source table, rendered as a quoted identifier. Required.
+    From string
+    // FromAlias is the optional alias for the source table; empty means no alias.
+    // When set, the FROM clause renders as "From" "FromAlias".
+    FromAlias string
+    // Joins is the optional list of joins, rendered after FROM in order. Their ON
+    // conditions are bound before the WHERE clause.
+    Joins []JoinClause
+    // Where is the optional filter expression tree; nil means no WHERE clause.
+    Where Expression
+    // GroupBy is the optional list of GROUP BY columns, rendered after WHERE. Each
+    // column may be qualified. An empty slice renders no GROUP BY. Columns carry no
+    // bound values, so they do not affect placeholder numbering.
+    GroupBy []ColumnRef
+    // Having is the optional filter over grouped rows, rendered after GROUP BY; nil
+    // means no HAVING. Its bound values are numbered after the WHERE clause and
+    // before LIMIT/OFFSET.
+    Having Expression
+    // OrderBy is the optional list of sort terms, applied in order.
+    OrderBy []OrderByClause
+    // Limit is the optional row limit; nil means no LIMIT. The value is bound.
+    Limit *int64
+    // Offset is the optional row offset; nil means no OFFSET. The value is bound.
+    Offset *int64
+}
+    SelectStatement is a SELECT over a source table and zero or more joins,
+    with an optional DISTINCT, WHERE clause, GROUP BY / HAVING, ORDER BY terms,
+    and LIMIT/OFFSET bounds.
+
+    Subqueries, non-aggregate functions, arithmetic, and window functions are
+    not modeled yet. Render it with renderer.RenderSelect, which returns the SQL
+    string and its positional arguments. Build one fluently with the core/query
+    package.
+
+
+### github.com/stokaro/ptah/core/ast.SetCreateDBOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetCreateDBOperation struct {
+    CreateDB bool
+}
+    SetCreateDBOperation represents changing the createdb capability of a role.
+
+func NewSetCreateDBOperation(createDB bool) *SetCreateDBOperation
+func (op *SetCreateDBOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetCreateRoleOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetCreateRoleOperation struct {
+    CreateRole bool
+}
+    SetCreateRoleOperation represents changing the createrole capability of a
+    role.
+
+func NewSetCreateRoleOperation(createRole bool) *SetCreateRoleOperation
+func (op *SetCreateRoleOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetInheritOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetInheritOperation struct {
+    Inherit bool
+}
+    SetInheritOperation represents changing the inherit capability of a role.
+
+func NewSetInheritOperation(inherit bool) *SetInheritOperation
+func (op *SetInheritOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetLoginOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetLoginOperation struct {
+    Login bool
+}
+    SetLoginOperation represents changing the login capability of a role.
+
+func NewSetLoginOperation(login bool) *SetLoginOperation
+func (op *SetLoginOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetPasswordOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetPasswordOperation struct {
+    Password string
+}
+    SetPasswordOperation represents setting a new password for a role.
+
+func NewSetPasswordOperation(password string) *SetPasswordOperation
+func (op *SetPasswordOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetReplicationOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetReplicationOperation struct {
+    Replication bool
+}
+    SetReplicationOperation represents changing the replication capability of a
+    role.
+
+func NewSetReplicationOperation(replication bool) *SetReplicationOperation
+func (op *SetReplicationOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SetSuperuserOperation
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SetSuperuserOperation struct {
+    Superuser bool
+}
+    SetSuperuserOperation represents changing the superuser status of a role.
+
+func NewSetSuperuserOperation(superuser bool) *SetSuperuserOperation
+func (op *SetSuperuserOperation) GetOperationType() string
+
+### github.com/stokaro/ptah/core/ast.SortDirection
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type SortDirection int
+    SortDirection is the direction of an ORDER BY term.
+
+const SortAscending SortDirection = iota ...
+func (d SortDirection) String() string
+
+### github.com/stokaro/ptah/core/ast.StatementList
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type StatementList struct {
+    // Statements contains the ordered list of SQL statements
+    Statements []Node
+}
+    StatementList represents a collection of SQL statements that should be
+    executed together.
+
+    This is typically used to represent a complete schema or migration script
+    that contains multiple DDL statements. The visitor will process each
+    statement in order.
+
+func (sl *StatementList) Accept(visitor Visitor) error
 
 ### github.com/stokaro/ptah/core/ast.TypeDefinition
 
@@ -348,6 +3156,82 @@ type TypeOperation interface {
     to ensure type safety. All ALTER TYPE operations must implement both the
     visitor pattern and the marker method.
 
+
+### github.com/stokaro/ptah/core/ast.UpdateStatement
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type UpdateStatement struct {
+    // Table is the target table, rendered as a quoted identifier. Required.
+    Table string
+    // Set is the list of column assignments. Required and non-empty; the renderer
+    // rejects an empty SET.
+    Set []Assignment
+    // Where is the optional filter expression tree; nil means no WHERE clause. A
+    // nil Where is allowed only together with Unconditional.
+    Where Expression
+    // Unconditional opts in to a whole-table UPDATE when Where is nil. It is the
+    // explicit acknowledgment that every row is to be updated; without it, a nil
+    // Where is an error. It has no effect when Where is set.
+    Unconditional bool
+    // Returning is the optional RETURNING projection. See InsertStatement.Returning
+    // for the dialect support rules.
+    Returning []ColumnRef
+}
+    UpdateStatement is an UPDATE … SET … over a single table, with an optional
+    WHERE clause and RETURNING projection.
+
+    SET values are bound before WHERE values, matching left-to-right emission
+    order, so placeholder numbering is deterministic. An UPDATE with no WHERE
+    clause rewrites every row; because that is rarely intended, the renderer
+    rejects it unless Unconditional is set, turning an accidental whole-table
+    update into a render-time error rather than silent data loss.
+
+
+### github.com/stokaro/ptah/core/ast.UpsertAssignment
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type UpsertAssignment struct {
+    Column     string
+    Expression string
+}
+    UpsertAssignment describes one column assignment in the UPDATE arm of an
+    upsert statement. Expression is a SQL expression fragment, typically a bind
+    placeholder or a reference to the source row.
+
+
+### github.com/stokaro/ptah/core/ast.UpsertNode
+
+package ast // import "github.com/stokaro/ptah/core/ast"
+
+type UpsertNode struct {
+    Table             string
+    InsertColumns     []string
+    Values            []string
+    MatchColumns      []string
+    UpdateAssignments []UpsertAssignment
+    UpdatePredicate   string
+    InsertPredicate   string
+    Comment           string
+}
+    UpsertNode represents a dialect-independent row upsert operation.
+
+    InsertColumns and Values must have the same length. MatchColumns
+    identifies the key columns used to decide whether the source row matches
+    an existing target row. UpdateAssignments controls the update arm.
+    The optional predicate fields are SQL expression fragments appended to the
+    dialect-specific update and insert conditions.
+
+func NewUpsert(table string) *UpsertNode
+func (n *UpsertNode) Accept(visitor Visitor) error
+func (n *UpsertNode) AddInsertValue(column, value string) *UpsertNode
+func (n *UpsertNode) AddUpdateAssignment(column, expression string) *UpsertNode
+func (n *UpsertNode) SetComment(comment string) *UpsertNode
+func (n *UpsertNode) SetInsert(columns, values []string) *UpsertNode
+func (n *UpsertNode) SetInsertPredicate(predicate string) *UpsertNode
+func (n *UpsertNode) SetMatchColumns(columns ...string) *UpsertNode
+func (n *UpsertNode) SetUpdatePredicate(predicate string) *UpsertNode
 
 ### github.com/stokaro/ptah/core/ast.Visitor
 
@@ -493,6 +3377,1063 @@ type Table struct{ ... }
 type Trigger struct{ ... }
 type View struct{ ... }
 
+### github.com/stokaro/ptah/core/goschema.CompositeType
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type CompositeType struct {
+    StructName string               // Name of the Go struct this type is associated with
+    Name       string               // Composite type name (e.g., "address")
+    Schema     string               // Optional schema/namespace (PostgreSQL-style)
+    Fields     []CompositeTypeField // Ordered fields of the composite type
+    Comment    string               // Optional comment for documentation
+}
+    CompositeType represents a PostgreSQL composite type parsed from Go
+    annotations.
+
+    Composite types are defined using //migrator:schema:composite annotations
+    with a comma-separated fields list of "name:type" pairs:
+
+        //migrator:schema:composite name="address" fields="street:TEXT,city:TEXT,zip:VARCHAR(10)"
+        type AddressType struct{}
+
+func (c *CompositeType) Canonicalize()
+func (c CompositeType) QualifiedName() string
+
+### github.com/stokaro/ptah/core/goschema.CompositeTypeField
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type CompositeTypeField struct {
+    Name string // Field name
+    Type string // Field data type
+}
+    CompositeTypeField is a single named field of a composite type.
+
+
+### github.com/stokaro/ptah/core/goschema.Constraint
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Constraint struct {
+    StructName string // Name of the Go struct this constraint belongs to
+    Name       string // Constraint name (e.g., "no_overlapping_bookings")
+    Type       string // Constraint type: EXCLUDE, CHECK, UNIQUE, PRIMARY KEY, FOREIGN KEY
+    Table      string // Table name (if different from struct name)
+
+    // EXCLUDE constraint specific fields
+    UsingMethod     string // Index method for EXCLUDE constraints (e.g., "gist", "btree")
+    ExcludeElements string // Elements specification (e.g., "room_id WITH =, during WITH &&")
+    WhereCondition  string // Optional WHERE clause for EXCLUDE constraints
+
+    // CHECK constraint specific fields
+    CheckExpression string // Check expression for CHECK constraints
+
+    // UNIQUE/PRIMARY KEY constraint specific fields
+    Columns []string // Column names for UNIQUE/PRIMARY KEY constraints
+    // IncludeColumns carries PostgreSQL INCLUDE columns for covering UNIQUE
+    // constraints.
+    IncludeColumns []string
+    // NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+    // Nil means the clause was not specified.
+    NullsDistinct *bool
+
+    // FOREIGN KEY constraint specific fields
+    ForeignTable   string   // Referenced table name
+    ForeignColumn  string   // Referenced column name for single-column foreign keys
+    ForeignColumns []string // Referenced column names for composite foreign keys
+    OnDelete       string   // ON DELETE action
+    OnUpdate       string   // ON UPDATE action
+
+    Comment string // Constraint comment/description
+}
+    Constraint represents a table-level constraint definition parsed from Go
+    struct annotations. Constraints are used to enforce data integrity rules
+    at the table level, such as EXCLUDE constraints for preventing overlapping
+    data, CHECK constraints for data validation, etc.
+
+    Constraint is created by parsing //migrator:schema:constraint annotations:
+
+        type Booking struct {
+            //migrator:schema:constraint name="no_overlapping_bookings" type="EXCLUDE" using="gist" elements="room_id WITH =, during WITH &&"
+            RoomID int64
+            During string // TSRANGE type
+
+            //migrator:schema:constraint name="one_active_session_per_user" type="EXCLUDE" using="gist" elements="user_id WITH =" condition="is_active = true"
+            UserID   int64
+            IsActive bool
+        }
+
+    The Constraint supports different constraint types:
+      - EXCLUDE: PostgreSQL EXCLUDE constraints for preventing conflicts
+      - CHECK: Table-level CHECK constraints for data validation
+      - UNIQUE: Table-level UNIQUE constraints spanning multiple columns
+      - PRIMARY KEY: Composite primary key constraints
+      - FOREIGN KEY: Table-level foreign key constraints
+
+func (c Constraint) ForeignColumnsOrDefault() []string
+
+### github.com/stokaro/ptah/core/goschema.Database
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Database struct {
+    Schemas                    []Schema
+    Tables                     []Table
+    Fields                     []Field
+    Indexes                    []Index
+    Constraints                []Constraint // Table-level constraints (EXCLUDE, CHECK, etc.)
+    Enums                      []Enum
+    EmbeddedFields             []EmbeddedField
+    Extensions                 []Extension                    // PostgreSQL extensions (pg_trgm, postgis, etc.)
+    Functions                  []Function                     // PostgreSQL custom functions
+    Sequences                  []Sequence                     // PostgreSQL standalone sequences (CREATE SEQUENCE)
+    Domains                    []Domain                       // PostgreSQL domain types (CREATE DOMAIN)
+    CompositeTypes             []CompositeType                // PostgreSQL composite types (CREATE TYPE ... AS (...))
+    Ranges                     []Range                        // PostgreSQL range types (CREATE TYPE ... AS RANGE (...))
+    Views                      []View                         // Database views
+    MaterializedViews          []MaterializedView             // Database materialized views
+    Triggers                   []Trigger                      // Database triggers
+    RLSPolicies                []RLSPolicy                    // PostgreSQL Row-Level Security policies
+    RLSEnabledTables           []RLSEnabledTable              // Tables with RLS enabled
+    Roles                      []Role                         // PostgreSQL roles
+    Grants                     []Grant                        // PostgreSQL privilege grants
+    ManagedData                []ManagedData                  // Declarative reference/seed row data for tables
+    Dependencies               map[string][]string            // table -> list of tables it depends on
+    FunctionDependencies       map[string][]string            // function -> list of functions it depends on
+    SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
+}
+    Database represents the complete database schema derived from Go struct
+    annotations.
+
+    This struct aggregates all database schema information discovered
+    during the recursive parsing process. It includes all entity types,
+    their relationships, and dependency information needed for proper migration
+    generation.
+
+    The result is processed to:
+      - Remove duplicates that may occur when entities are defined in multiple
+        files
+      - Build dependency graphs based on foreign key relationships
+      - Sort tables in topological order to ensure proper creation sequence
+
+    Fields:
+      - Schemas: All explicit database schema/namespace directives
+      - Tables: All table directives found in the project
+      - Fields: All field definitions with their database mappings
+      - Indexes: All index definitions for database optimization
+      - Enums: Global enum definitions that can be referenced by fields
+      - EmbeddedFields: Fields from embedded structs with their relation modes
+      - Dependencies: Dependency graph mapping table names to their dependencies
+
+func Merge(dbs ...*Database) (*Database, error)
+func ParseDir(rootDir string) (*Database, error)
+func ParseDirRaw(roots ...string) (*Database, error)
+func ParseDirs(roots ...string) (*Database, error)
+func ParseFS(fsys fs.FS, rootDir string) (*Database, error)
+func ParseFile(filename string) (Database, error)
+func ParseFileWithDependencies(filename string) (Database, error)
+func ParseSource(filename string, source any) (Database, error)
+
+### github.com/stokaro/ptah/core/goschema.Domain
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Domain struct {
+    StructName  string // Name of the Go struct this domain is associated with
+    Name        string // Domain name (e.g., "email")
+    Schema      string // Optional schema/namespace (PostgreSQL-style)
+    BaseType    string // Underlying base data type (e.g., "TEXT", "VARCHAR(255)")
+    NotNull     bool   // Whether the domain is NOT NULL
+    Default     string // Optional literal DEFAULT value
+    DefaultExpr string // Optional DEFAULT expression (function call)
+    Check       string // Optional CHECK constraint expression (uses VALUE)
+    Comment     string // Optional comment for documentation
+}
+    Domain represents a PostgreSQL domain type parsed from Go annotations.
+
+    A domain is a base type constrained with optional NOT NULL, DEFAULT,
+    and CHECK clauses. Domains are defined using //migrator:schema:domain
+    annotations:
+
+        //migrator:schema:domain name="email" type="TEXT" check="VALUE ~ '^[^@]+@[^@]+$'"
+        type EmailDomain struct{}
+
+func (d *Domain) Canonicalize()
+func (d Domain) QualifiedName() string
+
+### github.com/stokaro/ptah/core/goschema.EmbeddedField
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type EmbeddedField struct {
+    StructName       string                       // The struct that contains this embedded field
+    Mode             string                       // inline, json, relation, skip
+    Prefix           string                       // For inline mode - prefix for field names
+    Name             string                       // For json mode - column name
+    Type             string                       // For json mode - column type (JSON/JSONB)
+    Nullable         bool                         // Whether the field can be null
+    Index            bool                         // Whether to create an index
+    Field            string                       // For relation mode - foreign key field name
+    Ref              string                       // For relation mode - reference table(column)
+    OnDelete         string                       // For relation mode - ON DELETE action
+    OnUpdate         string                       // For relation mode - ON UPDATE action
+    Comment          string                       // Comment for the field/column
+    EmbeddedTypeName string                       // The name of the embedded type (e.g., "Timestamps")
+    Overrides        map[string]map[string]string // Platform-specific overrides
+}
+    EmbeddedField represents an embedded field in a Go struct that should
+    be handled specially during schema generation. Embedded fields allow for
+    composition and reuse of common field patterns across multiple tables.
+
+    The EmbeddedField supports four different modes of handling:
+      - "inline": Injects the embedded struct's fields directly as separate
+        columns
+      - "json": Serializes the entire embedded struct into a single JSON/JSONB
+        column
+      - "relation": Creates a foreign key relationship to another table
+      - "skip": Completely ignores the embedded field during schema generation
+
+    Usage in Go structs:
+
+        type User struct {
+            ID int64
+            //migrator:embedded mode="inline"
+            Timestamps  // Results in: created_at, updated_at columns
+
+            //migrator:embedded mode="json" name="metadata" type="JSONB"
+            Meta UserMeta  // Results in: metadata JSONB column
+
+            //migrator:embedded mode="relation" field="company_id" ref="companies(id)"
+            Company Company  // Results in: company_id INTEGER + FK constraint
+        }
+
+
+### github.com/stokaro/ptah/core/goschema.Enum
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Enum struct {
+    Name   string   // The generated enum type name (e.g., "enum_user_status")
+    Values []string // The allowed enum values (e.g., ["active", "inactive", "suspended"])
+}
+    Enum represents a global enumeration type definition that can be shared
+    across multiple tables and fields. Global enums are automatically generated
+    when ENUM type fields are defined in struct annotations.
+
+    What makes an enum "global": Global enums are database-level type
+    definitions (particularly in PostgreSQL) that can be referenced by multiple
+    tables and columns. Unlike inline enum constraints, global enums:
+      - Are created once as a database type (CREATE TYPE ... AS ENUM in
+        PostgreSQL)
+      - Can be reused across multiple tables and columns
+      - Provide better type safety and consistency
+      - Allow for easier maintenance when enum values need to be modified
+
+    How global enums are created: When you define a field with type="ENUM" and
+    enum values, Ptah automatically generates a global enum with a standardized
+    name pattern: "enum_{struct_name}_{field_name}":
+
+        type User struct {
+            //migrator:schema:field name="status" type="ENUM" enum="active,inactive,suspended" default="active"
+            Status string  // Creates global enum: "enum_user_status"
+        }
+
+        type Post struct {
+            //migrator:schema:field name="status" type="ENUM" enum="draft,published,archived" default="draft"
+            Status string  // Creates global enum: "enum_post_status"
+        }
+
+    Database platform differences:
+      - PostgreSQL: Creates actual ENUM types (CREATE TYPE enum_user_status AS
+        ENUM ('active', 'inactive'))
+      - MySQL/MariaDB: Uses ENUM column type with values (status ENUM('active',
+        'inactive'))
+      - SQLite: Uses CHECK constraints with IN clauses (status TEXT CHECK
+        (status IN ('active', 'inactive')))
+
+    Example of generated SQL:
+
+        PostgreSQL:
+          CREATE TYPE enum_user_status AS ENUM ('active', 'inactive', 'suspended');
+          CREATE TABLE users (status enum_user_status DEFAULT 'active');
+
+        MySQL:
+          CREATE TABLE users (status ENUM('active', 'inactive', 'suspended') DEFAULT 'active');
+
+
+### github.com/stokaro/ptah/core/goschema.Extension
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Extension struct {
+    Name        string // Extension name (pg_trgm, postgis, etc.)
+    IfNotExists bool   // Whether to use IF NOT EXISTS clause
+    Version     string // Specific version requirement (optional)
+    Comment     string // Extension comment/description
+}
+    Extension represents a PostgreSQL extension definition parsed from Go struct
+    annotations. Extensions enable additional functionality in PostgreSQL
+    databases.
+
+    Extension is created by parsing //migrator:schema:extension annotations:
+
+        // Enable trigram similarity search
+        //migrator:schema:extension name="pg_trgm" if_not_exists="true"
+        type DatabaseExtensions struct{}
+
+        // Enable PostGIS for geographic data
+        //migrator:schema:extension name="postgis" version="3.0" if_not_exists="true"
+        type GeoExtensions struct{}
+
+
+### github.com/stokaro/ptah/core/goschema.Field
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Field struct {
+    StructName string // Name of the Go struct this field belongs to
+    FieldName  string // Name of the Go struct field
+    Name       string // Database column name
+    Type       string // Database column type (e.g., "VARCHAR(255)", "INTEGER")
+    Nullable   bool   // Whether the column allows NULL values
+    Primary    bool   // Whether this is a primary key column
+    AutoInc    bool   // Whether this column auto-increments
+    // IdentityGeneration stores PostgreSQL identity generation mode: ALWAYS or BY_DEFAULT.
+    IdentityGeneration string
+    // IdentityStart stores the optional PostgreSQL identity START WITH value.
+    IdentityStart string
+    // IdentityIncrement stores the optional PostgreSQL identity INCREMENT BY value.
+    IdentityIncrement string
+    // IdentityOptions stores raw PostgreSQL identity sequence options for SQL round-trips.
+    IdentityOptions string
+    Unique          bool     // Whether this column has a unique constraint
+    UniqueExpr      string   // Custom unique constraint expression
+    Default         string   // Default value for the column
+    DefaultSet      bool     // Whether Default is set, including an empty string literal
+    DefaultExpr     string   // Default expression (e.g., "NOW()", "UUID()", "CURRENT_TIMESTAMP", "1", "true")
+    Foreign         string   // Foreign key reference (e.g., "users(id)")
+    ForeignKeyName  string   // Custom foreign key constraint name
+    OnDelete        string   // Foreign key ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+    OnUpdate        string   // Foreign key ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+    Enum            []string // Enum values for ENUM type fields
+    Check           string   // Check constraint expression
+    CheckName       string   // Optional constraint name for the column-level CHECK; defaults to "<table>_<column>_check"
+    // GeneratedExpression stores the raw SQL expression for generated columns.
+    GeneratedExpression string
+    // GeneratedKind stores the generated column kind, such as VIRTUAL or STORED.
+    GeneratedKind string
+    // UpdateExpression stores MySQL/MariaDB ON UPDATE expressions such as CURRENT_TIMESTAMP(6).
+    UpdateExpression string
+    // Charset stores the column character set for MySQL-compatible dialects.
+    Charset string
+    // Collate stores the column collation for MySQL-compatible dialects.
+    Collate   string
+    Comment   string                       // Column comment
+    Overrides map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
+}
+    Field represents a database column/field definition parsed from Go struct
+    field annotations. This is the core building block for table schema
+    generation, containing all the metadata needed to generate appropriate
+    CREATE TABLE column definitions for different database platforms.
+
+    Field is created by parsing //migrator:schema:field annotations from Go
+    struct fields:
+
+        type Product struct {
+            //migrator:schema:field name="id" type="SERIAL" primary="true"
+            ID int64
+
+            //migrator:schema:field name="name" type="VARCHAR(255)" not_null="true" unique="true"
+            Name string
+
+            //migrator:schema:field name="price" type="DECIMAL(10,2)" check="price > 0" default="0.00"
+            Price float64
+
+            //migrator:schema:field name="status" type="ENUM" enum="active,inactive" default="active"
+            Status string
+
+            //migrator:schema:field name="category_id" type="INTEGER" foreign="categories(id)"
+            CategoryID int64
+        }
+
+    The Field supports platform-specific overrides through the Overrides field:
+
+        //migrator:schema:field name="id" type="SERIAL" platform.mysql.type="INT AUTO_INCREMENT"
+        ID int64
+
+
+### github.com/stokaro/ptah/core/goschema.Function
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Function struct {
+    StructName string // Name of the Go struct this function is associated with
+    Name       string // Function name (e.g., "set_tenant_context")
+    Parameters string // Function parameters (e.g., "tenant_id_param TEXT")
+    Returns    string // Return type (e.g., "VOID", "TEXT")
+    Language   string // Function language (e.g., "plpgsql", "sql")
+    Security   string // Security context (e.g., "DEFINER", "INVOKER")
+    Volatility string // Function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
+    Body       string // Function body/implementation
+    Comment    string // Optional comment for documentation
+}
+    Function represents a PostgreSQL custom function definition parsed from Go
+    struct annotations.
+
+    Functions are defined using //migrator:schema:function annotations and are
+    used to create custom PostgreSQL functions that can be referenced by RLS
+    policies, triggers, or application code.
+
+    Function is created by parsing //migrator:schema:function annotations:
+
+        //migrator:schema:function name="set_tenant_context" params="tenant_id_param TEXT" returns="VOID" language="plpgsql" security="DEFINER" body="BEGIN PERFORM set_config('app.current_tenant_id', tenant_id_param, false); END;"
+        type User struct {
+            // ... fields
+        }
+
+    The function definition supports various PostgreSQL function attributes:
+      - Parameters: Function parameter definitions (e.g., "tenant_id_param TEXT,
+        user_id INTEGER")
+      - Returns: Return type specification (e.g., "VOID", "TEXT", "INTEGER")
+      - Language: Function language (e.g., "plpgsql", "sql")
+      - Security: Security context (e.g., "DEFINER", "INVOKER")
+      - Volatility: Function volatility (e.g., "STABLE", "IMMUTABLE",
+        "VOLATILE")
+      - Body: Function implementation code
+
+    Example generated SQL:
+
+        CREATE OR REPLACE FUNCTION set_tenant_context(tenant_id_param TEXT)
+        RETURNS VOID AS $$
+        BEGIN
+            PERFORM set_config('app.current_tenant_id', tenant_id_param, false);
+        END;
+        $$ LANGUAGE plpgsql SECURITY DEFINER;
+
+func (f *Function) Canonicalize()
+
+### github.com/stokaro/ptah/core/goschema.Grant
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Grant struct {
+    StructName string   // Name of the Go struct this grant is associated with
+    Role       string   // Role receiving the privilege
+    Privileges []string // Privileges to grant, e.g. SELECT, INSERT, USAGE
+    OnTable    string   // Target table, mutually exclusive with OnSchema/OnSequence
+    OnSchema   string   // Target schema, mutually exclusive with OnTable/OnSequence
+    OnSequence string   // Target sequence, mutually exclusive with OnTable/OnSchema
+    WithOption bool     // Whether the grant includes WITH GRANT OPTION
+    GrantedBy  string   // Grantor reported by database introspection, if available
+    Comment    string   // Optional comment for documentation
+}
+    Grant represents a PostgreSQL privilege grant parsed from Go annotations.
+
+    Grants are defined using //migrator:schema:grant annotations and are used to
+    manage access-control privileges for roles that Ptah manages as first-class
+    schema objects.
+
+    Example:
+
+        //migrator:schema:grant role="app_user" privilege="USAGE" on_schema="public"
+        //migrator:schema:grant role="app_user" privilege="SELECT,INSERT" on_table="users"
+        type AccessControl struct{}
+
+func (g *Grant) Canonicalize()
+
+### github.com/stokaro/ptah/core/goschema.Index
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Index struct {
+    StructName string   // Name of the Go struct this index belongs to
+    Name       string   // Index name (e.g., "idx_users_email")
+    Fields     []string // Column names included in the index
+    // Parts carries structured index elements for dialect-specific metadata,
+    // such as DESC ordering and expression indexes. Fields remains the legacy
+    // column/expression list for compatibility.
+    Parts   []IndexPart
+    Unique  bool   // Whether this is a unique index
+    Comment string // Index comment/description
+    // NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
+    // state. Nil means the clause was not specified.
+    NullsDistinct *bool
+
+    // Type carries the dialect-specific index type. For PostgreSQL this is
+    // GIN/GIST/BTREE/HASH; for ClickHouse data-skipping indexes it is
+    // "minmax"/"set(N)"/"bloom_filter(p)"/"tokenbf_v1(...)"/etc.
+    Type string
+    // Parser carries a MySQL FULLTEXT parser name, for example ngram.
+    Parser string
+    // Condition is the WHERE clause for partial indexes (PostgreSQL only).
+    Condition string
+    // Operator is the operator class (PostgreSQL only, e.g. "gin_trgm_ops").
+    Operator string
+    // IncludeColumns carries PostgreSQL INCLUDE columns for covering indexes.
+    IncludeColumns []string
+    // StorageParams carries PostgreSQL index storage parameters rendered as
+    // WITH (key='value'), for example pages_per_range for BRIN indexes.
+    StorageParams map[string]string
+    // TableName is the cross-table association (overrides StructName-based
+    // resolution when set).
+    TableName string
+
+    // Granularity is the ClickHouse data-skipping-index GRANULARITY value.
+    // Zero means "use the dialect default" (8192 for ClickHouse, which is
+    // what the renderer falls back to when this field is unset). Ignored by
+    // all non-ClickHouse renderers.
+    Granularity int
+}
+    Index represents a database index definition parsed from Go struct
+    annotations. Indexes are used to improve query performance and enforce
+    uniqueness constraints on one or more columns.
+
+    Index is created by parsing //migrator:schema:index annotations:
+
+        type User struct {
+            //migrator:schema:field name="id" type="SERIAL" primary="true"
+            ID int64
+
+            //migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+            Email string
+
+            //migrator:schema:field name="status" type="VARCHAR(50)"
+            Status string
+
+            // Single column index
+            //migrator:schema:index name="idx_users_email" fields="email" unique="true"
+            _ int
+
+            // Multi-column index
+            //migrator:schema:index name="idx_users_email_status" fields="email,status"
+            _ int
+
+            // PostgreSQL GIN index for JSONB fields
+            //migrator:schema:index name="idx_users_tags" fields="tags" type="GIN"
+            _ int
+
+            // Partial index with WHERE condition
+            //migrator:schema:index name="idx_active_users" fields="status" condition="deleted_at IS NULL"
+            _ int
+
+            // Trigram similarity index
+            //migrator:schema:index name="idx_users_name_trgm" fields="name" type="GIN" ops="gin_trgm_ops"
+            _ int
+
+            // Cross-table index targeting specific table
+            //migrator:schema:index name="idx_products_name" fields="name" table="products"
+            _ int
+        }
+
+    # ClickHouse data-skipping indexes
+
+    On ClickHouse, the `type=` and `granularity=` keys configure a data-skipping
+    index. `type=` accepts any spelling ClickHouse understands — `minmax`,
+    `set(N)`, `bloom_filter`, `bloom_filter(p)`, `tokenbf_v1(...)`,
+    `ngrambf_v1(...)`, etc. `granularity=` is the number of marks per index
+    block; omitting it falls back to ClickHouse's documented default (8192).
+    Both keys are silently ignored by non-ClickHouse renderers.
+
+        type Event struct {
+            //migrator:schema:field name="payload" type="String"
+            Payload string
+
+            //migrator:schema:index name="idx_e_payload" fields="payload" type="bloom_filter(0.01)" granularity="64"
+            _ int
+        }
+
+
+### github.com/stokaro/ptah/core/goschema.IndexPart
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type IndexPart struct {
+    Name     string // Column name
+    Expr     string // Raw index expression
+    Operator string // PostgreSQL operator class for this part
+    Prefix   string // MySQL index prefix length
+    Desc     bool   // Whether this part is ordered DESC
+}
+    IndexPart represents one column or expression inside an index definition.
+
+
+### github.com/stokaro/ptah/core/goschema.ManagedData
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type ManagedData struct {
+    StructName string   // Name of the Go struct this data annotation is associated with
+    Table      string   // Target table the rows belong to
+    Schema     string   // Database schema the table belongs to; empty targets the connection's default schema
+    Keys       []string // Key column(s) forming each row's logical identity (parsed from the comma-separated "key" attribute)
+    File       string   // Path to the YAML row-data file, verbatim, relative to SourceDir
+    // SourceDir is the parse-root-relative directory of the Go source file that
+    // carried the annotation, recorded at parse time. Combined with the parse
+    // root, it lets LoadManagedRows resolve File even after a ParseDir tree walk
+    // spanning subdirectories, where a caller holding the merged Database could
+    // not otherwise know which subdirectory each entry came from.
+    SourceDir string
+}
+    ManagedData declares a set of reference/seed rows that Ptah
+    manages as desired-state data for a target table. It is parsed from
+    //migrator:schema:data annotations.
+
+    Unlike other schema objects, the row values are not embedded in the
+    Go source: the annotation points to an external YAML row-data file.
+    The Go annotation parser reads comment text and cannot evaluate Go value
+    expressions, and reference data naturally lives in a data file rather
+    than in code, so the file reference is the source of truth for the rows
+    themselves.
+
+    ManagedData is created by parsing //migrator:schema:data annotations:
+
+        //migrator:schema:data table="countries" key="code" file="countries.yaml"
+        type Country struct {
+            //migrator:schema:field name="code" type="VARCHAR(2)" primary="true"
+            Code string
+
+            //migrator:schema:field name="name" type="VARCHAR(255)" not_null="true"
+            Name string
+        }
+
+    Composite keys are declared as a comma-separated list, e.g.
+    key="tenant_id,code".
+
+    The referenced file is a top-level YAML list of row maps, resolved relative
+    to the directory of the Go source file that carries the annotation.
+    Use LoadManagedRows to read it:
+
+      - code: US name: United States
+      - code: CZ name: Czechia
+
+    The key column(s) form each row's logical identity and are consumed by the
+    (later) data-diff phase to match a desired row against an existing one.
+
+
+### github.com/stokaro/ptah/core/goschema.MaterializedView
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type MaterializedView struct {
+    StructName      string // Name of the Go struct this materialized view is associated with
+    Name            string // Materialized view name
+    Body            string // SELECT query used as the materialized view body
+    RefreshStrategy string // manual, concurrently, or future scheduled variants
+    Comment         string // Optional comment for documentation
+}
+    MaterializedView represents a database materialized view definition parsed
+    from Go annotations.
+
+    MaterializedView is created by parsing //migrator:schema:matview
+    annotations:
+
+        //migrator:schema:matview name="user_stats" body="SELECT user_id, COUNT(*) FROM users GROUP BY user_id" refresh_strategy="manual"
+        type UserStats struct{}
+
+func (v *MaterializedView) Canonicalize()
+
+### github.com/stokaro/ptah/core/goschema.PartitionPart
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type PartitionPart struct {
+    Name string // Column name
+    Expr string // Raw partition expression
+}
+    PartitionPart represents one partition key column or expression.
+
+
+### github.com/stokaro/ptah/core/goschema.PartitionSpec
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type PartitionSpec struct {
+    Type  string          // Partitioning method, such as RANGE, LIST, or HASH
+    Parts []PartitionPart // Partition key columns or expressions
+}
+    PartitionSpec represents PostgreSQL table partitioning metadata.
+
+
+### github.com/stokaro/ptah/core/goschema.PrimaryKeyPart
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type PrimaryKeyPart struct {
+    Name   string // Column name
+    Prefix string // MySQL index prefix length
+    Desc   bool   // Whether the column is ordered DESC
+}
+    PrimaryKeyPart represents one column reference inside a table primary key.
+
+
+### github.com/stokaro/ptah/core/goschema.RLSEnabledTable
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type RLSEnabledTable struct {
+    StructName string // Name of the Go struct this RLS enablement is associated with
+    Table      string // Table name to enable RLS on (e.g., "users")
+    Comment    string // Optional comment for documentation
+}
+    RLSEnabledTable represents a table that has Row-Level Security enabled.
+
+    RLS must be enabled on a table before policies can be applied to it. This is
+    done using //migrator:schema:rls:enable annotations.
+
+    RLSEnabledTable is created by parsing //migrator:schema:rls:enable
+    annotations:
+
+        //migrator:schema:rls:enable table="users"
+        type User struct {
+            // ... fields
+        }
+
+    Example generated SQL:
+
+        ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+
+### github.com/stokaro/ptah/core/goschema.RLSPolicy
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type RLSPolicy struct {
+    StructName          string // Name of the Go struct this policy is associated with
+    Name                string // Policy name (e.g., "user_tenant_isolation")
+    Table               string // Target table name (e.g., "users")
+    PolicyFor           string // Operations policy applies to (e.g., "ALL", "SELECT")
+    ToRoles             string // Target roles (e.g., "inventario_app", "PUBLIC")
+    UsingExpression     string // USING clause expression for row filtering
+    WithCheckExpression string // WITH CHECK clause expression (optional)
+    Comment             string // Optional comment for documentation
+}
+    RLSPolicy represents a PostgreSQL Row-Level Security policy definition
+    parsed from Go struct annotations.
+
+    RLS policies are defined using //migrator:schema:rls:policy annotations
+    and provide database-level tenant isolation by automatically filtering rows
+    based on specified conditions.
+
+    RLSPolicy is created by parsing //migrator:schema:rls:policy annotations:
+
+        //migrator:schema:rls:policy name="user_tenant_isolation" table="users" for="ALL" to="inventario_app" using="tenant_id = get_current_tenant_id()"
+        type User struct {
+            //migrator:schema:field name="tenant_id" type="TEXT" not_null="true"
+            TenantID string
+            // ... other fields
+        }
+
+    The policy definition supports various PostgreSQL RLS policy attributes:
+      - Name: Policy name for identification
+      - Table: Target table name the policy applies to
+      - PolicyFor: Operations the policy applies to (e.g., "ALL", "SELECT",
+        "INSERT", "UPDATE", "DELETE")
+      - ToRoles: Database roles the policy applies to (e.g., "app_user",
+        "PUBLIC")
+      - UsingExpression: USING clause expression for row filtering
+      - WithCheckExpression: WITH CHECK clause expression for INSERT/UPDATE
+        validation
+
+    Example generated SQL:
+
+        CREATE POLICY user_tenant_isolation ON users
+            FOR ALL
+            TO inventario_app
+            USING (tenant_id = get_current_tenant_id());
+
+
+### github.com/stokaro/ptah/core/goschema.Range
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Range struct {
+    StructName     string // Name of the Go struct this type is associated with
+    Name           string // Range type name (e.g., "floatrange")
+    Schema         string // Optional schema/namespace (PostgreSQL-style)
+    Subtype        string // Required element subtype (e.g., "float8")
+    SubtypeOpClass string // Optional operator class for the subtype
+    Collation      string // Optional collation for the subtype
+    Canonical      string // Optional canonicalization function
+    SubtypeDiff    string // Optional subtype difference function
+    Comment        string // Optional comment for documentation
+}
+    Range represents a PostgreSQL range type parsed from Go annotations.
+
+    Range types are defined using //migrator:schema:range annotations:
+
+        //migrator:schema:range name="floatrange" subtype="float8" subtype_diff="float8mi"
+        type FloatRange struct{}
+
+func (r *Range) Canonicalize()
+func (r Range) QualifiedName() string
+
+### github.com/stokaro/ptah/core/goschema.Role
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Role struct {
+    StructName  string // Name of the Go struct this role is associated with
+    Name        string // Role name (e.g., "app_user")
+    Login       bool   // Whether role can login (default: false)
+    Password    string // Encrypted password (optional)
+    Superuser   bool   // Whether role is superuser (default: false)
+    CreateDB    bool   // Whether role can create databases (default: false)
+    CreateRole  bool   // Whether role can create other roles (default: false)
+    Inherit     bool   // Whether role inherits privileges (default: true)
+    Replication bool   // Whether role can initiate replication (default: false)
+    Comment     string // Optional comment for documentation
+}
+    Role represents a PostgreSQL role definition parsed from Go struct
+    annotations.
+
+    Roles are defined using //migrator:schema:role annotations and are used to
+    create PostgreSQL database roles that can be referenced by RLS policies,
+    granted permissions, or used for authentication and authorization.
+
+    Role is created by parsing //migrator:schema:role annotations:
+
+        //migrator:schema:role name="app_user" login="true" password="encrypted_password" comment="Application user role"
+        //migrator:schema:role name="admin_user" login="true" superuser="true" comment="Administrator role"
+        //migrator:schema:role name="readonly_user" login="true" comment="Read-only user role"
+        type UserRoles struct {
+            // Dummy struct to hold role annotations
+        }
+
+    The role definition supports various PostgreSQL role attributes:
+      - Name: Role name (e.g., "app_user")
+      - Login: Whether role can login (default: false)
+      - Password: Encrypted password (optional)
+      - Superuser: Whether role is superuser (default: false)
+      - CreateDB: Whether role can create databases (default: false)
+      - CreateRole: Whether role can create other roles (default: false)
+      - Inherit: Whether role inherits privileges (default: true)
+      - Replication: Whether role can initiate replication (default: false)
+      - Comment: Optional comment for documentation
+
+    Example generated SQL:
+
+        -- Application user role
+        CREATE ROLE app_user WITH LOGIN PASSWORD 'encrypted_password';
+
+        -- Administrator role
+        CREATE ROLE admin_user WITH LOGIN SUPERUSER;
+
+        -- Read-only user role
+        CREATE ROLE readonly_user WITH LOGIN;
+
+
+### github.com/stokaro/ptah/core/goschema.Schema
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Schema struct {
+    Name    string // Schema name, e.g. "public"
+    Comment string // Optional schema comment/description
+    Charset string // Optional default character set (MySQL/MariaDB)
+    Collate string // Optional default collation (MySQL/MariaDB)
+}
+    Schema represents a database schema/namespace.
+
+
+### github.com/stokaro/ptah/core/goschema.SelfReferencingFK
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type SelfReferencingFK struct {
+    FieldName      string // Name of the field (e.g., "parent_id")
+    Foreign        string // Foreign key reference (e.g., "users(id)")
+    ForeignKeyName string // Name of the foreign key constraint (e.g., "fk_users_parent")
+    OnDelete       string // ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+    OnUpdate       string // ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
+}
+    SelfReferencingFK represents a self-referencing foreign key that needs to be
+    handled separately from regular foreign keys to avoid circular dependencies.
+
+    Self-referencing foreign keys occur when a table has a foreign key
+    that references its own primary key, such as a "parent_id" field in a
+    hierarchical structure. These cannot be created as part of the initial
+    CREATE TABLE statement because the table doesn't exist yet when the
+    constraint is being defined.
+
+    Instead, these foreign keys are tracked separately and added as ALTER TABLE
+    ADD CONSTRAINT statements after the table has been created.
+
+    Example:
+
+        type User struct {
+            ID       int64  `db:"id"`
+            ParentID *int64 `db:"parent_id" foreign:"users(id)"`
+            Name     string `db:"name"`
+        }
+
+    This would generate:
+
+        CREATE TABLE users (
+            id SERIAL PRIMARY KEY,
+            parent_id INTEGER,
+            name VARCHAR(255)
+        );
+
+        ALTER TABLE users ADD CONSTRAINT fk_users_parent
+            FOREIGN KEY (parent_id) REFERENCES users(id);
+
+
+### github.com/stokaro/ptah/core/goschema.Sequence
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Sequence struct {
+    StructName  string // Name of the Go struct this sequence is associated with
+    Name        string // Sequence name (e.g., "order_number_seq")
+    Schema      string // Optional schema/namespace (PostgreSQL-style)
+    AsType      string // Optional underlying integer type (e.g., "bigint")
+    Start       *int64 // Optional START WITH value
+    Increment   *int64 // Optional INCREMENT BY value (must be non-zero)
+    MinValue    *int64 // Optional MINVALUE bound
+    MaxValue    *int64 // Optional MAXVALUE bound
+    Cache       *int64 // Optional CACHE size
+    Cycle       bool   // Whether the sequence uses CYCLE (default NO CYCLE)
+    OwnedBy     string // Optional "table.column" association (OWNED BY)
+    IfNotExists bool   // Whether to use IF NOT EXISTS clause
+    Comment     string // Optional comment for documentation
+}
+    Sequence represents a standalone PostgreSQL sequence object parsed from Go
+    annotations.
+
+    A sequence is a distinct schema object created with CREATE SEQUENCE and
+    controlled with ALTER SEQUENCE / DROP SEQUENCE. It is separate from the
+    implicit, table-owned sequences that back SERIAL / BIGSERIAL / SMALLSERIAL
+    columns: those are created and dropped automatically with their owning
+    column and are never emitted as standalone objects.
+
+    Sequence is created by parsing //migrator:schema:sequence annotations:
+
+        //migrator:schema:sequence name="order_number_seq" start="1000" increment="1" cache="20"
+        type OrderNumberSeq struct{}
+
+    Supported attributes mirror the PostgreSQL CREATE SEQUENCE options:
+      - AsType: the underlying integer type (e.g. "bigint", "integer",
+        "smallint")
+      - Start: the START WITH value
+      - Increment: the INCREMENT BY value (must be non-zero)
+      - MinValue / MaxValue: the MINVALUE / MAXVALUE bounds
+      - Cache: the CACHE size
+      - Cycle: whether the sequence wraps around (CYCLE vs NO CYCLE)
+      - OwnedBy: an optional "table.column" association (OWNED BY)
+
+    Example generated SQL:
+
+        CREATE SEQUENCE order_number_seq AS bigint START WITH 1000 INCREMENT BY 1 CACHE 20;
+
+func (s *Sequence) Canonicalize()
+func (s Sequence) QualifiedName() string
+
+### github.com/stokaro/ptah/core/goschema.Table
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Table struct {
+    StructName    string   // Name of the Go struct this table represents
+    Name          string   // Database table name
+    Schema        string   // Optional database schema/namespace (PostgreSQL-style)
+    Engine        string   // Storage engine (MySQL/MariaDB specific, e.g., "InnoDB")
+    AutoIncrement string   // Initial AUTO_INCREMENT value (MySQL/MariaDB specific)
+    Charset       string   // Table default character set (MySQL/MariaDB specific)
+    Collate       string   // Table default collation (MySQL/MariaDB specific)
+    Strict        bool     // SQLite STRICT table option
+    WithoutRowID  bool     // SQLite WITHOUT ROWID table option
+    Comment       string   // Table comment/description
+    PrimaryKey    []string // Composite primary key column names
+    // PrimaryKeyParts carries dialect-specific metadata for composite primary
+    // key elements, such as MySQL prefix lengths and DESC ordering.
+    PrimaryKeyParts []PrimaryKeyPart
+    // PrimaryKeyInclude carries PostgreSQL INCLUDE columns for table-level
+    // primary keys.
+    PrimaryKeyInclude []string
+    Checks            []string                     // Table-level check constraints
+    Partition         *PartitionSpec               // PostgreSQL table partitioning metadata
+    CustomSQL         string                       // Custom SQL to append to CREATE TABLE
+    Overrides         map[string]map[string]string // Platform-specific overrides
+}
+    Table represents a database table configuration parsed from Go struct
+    annotations. This defines the overall table properties and metadata that
+    will be used to generate CREATE TABLE statements.
+
+    Table is created by parsing //migrator:schema:table annotations:
+
+        //migrator:schema:table name="users" comment="User accounts table"
+        type User struct {
+            //migrator:schema:field name="id" type="SERIAL" primary="true"
+            ID int64
+
+            //migrator:schema:field name="email" type="VARCHAR(255)" not_null="true"
+            Email string
+        }
+
+    Platform-specific configurations can be specified using overrides:
+
+        //migrator:schema:table name="products" platform.mysql.engine="InnoDB" platform.mysql.comment="Product catalog"
+        type Product struct {
+            // ... fields
+        }
+
+    Composite primary keys can be defined using the primary_key attribute:
+
+        //migrator:schema:table name="user_roles" primary_key="user_id,role_id"
+        type UserRole struct {
+            //migrator:schema:field name="user_id" type="INTEGER" foreign="users(id)"
+            UserID int64
+
+            //migrator:schema:field name="role_id" type="INTEGER" foreign="roles(id)"
+            RoleID int64
+        }
+
+func (t Table) QualifiedName() string
+
+### github.com/stokaro/ptah/core/goschema.Trigger
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type Trigger struct {
+    StructName string // Name of the Go struct this trigger is associated with
+    Name       string // Trigger name
+    Table      string // Target table
+    Timing     string // BEFORE, AFTER, or INSTEAD OF
+    Event      string // INSERT, UPDATE, DELETE, or TRUNCATE
+    ForEach    string // ROW or STATEMENT
+    Body       string // Trigger body
+    Comment    string // Optional comment for documentation
+}
+    Trigger represents a database trigger definition parsed from Go annotations.
+
+    Trigger is created by parsing //migrator:schema:trigger annotations:
+
+        //migrator:schema:trigger name="set_updated_at" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;"
+        type User struct{}
+
+func (t *Trigger) Canonicalize()
+func (t Trigger) FunctionName() string
+
+### github.com/stokaro/ptah/core/goschema.View
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type View struct {
+    StructName string // Name of the Go struct this view is associated with
+    Name       string // View name
+    Body       string // SELECT query used as the view body
+    WithCheck  bool   // Whether to add WITH CHECK OPTION where supported
+    Comment    string // Optional comment for documentation
+}
+    View represents a database view definition parsed from Go annotations.
+
+    View is created by parsing //migrator:schema:view annotations:
+
+        //migrator:schema:view name="active_users" body="SELECT * FROM users WHERE deleted_at IS NULL" with_check="false"
+        type User struct{}
+
+
 ## github.com/stokaro/ptah/core/platform
 
 const Postgres = "postgres" ...
@@ -524,6 +4465,48 @@ type Capability string
     const DropConstraintGeneric Capability = "drop_constraint_generic" ...
     func All() []Capability
 
+### github.com/stokaro/ptah/core/platform/capability.Capabilities
+
+package capability // import "github.com/stokaro/ptah/core/platform/capability"
+
+type Capabilities map[Capability]bool
+    Capabilities is a set of feature flags describing one concrete target,
+    as map[Capability]bool. The nil set is valid and conservative (Has always
+    reports false). Presets in this package enumerate every registry key
+    explicitly; hand-built sets should be checked with Validate.
+
+func ClickHouse24() Capabilities
+func CockroachDB23() Capabilities
+func ForDialect(dialect string) Capabilities
+func ForServerVersion(dialect, version string) Capabilities
+func ForServerVersionResult(dialect, version string) (Capabilities, bool)
+func MariaDB1011() Capabilities
+func MariaDBLegacy() Capabilities
+func MySQL80() Capabilities
+func MySQL8016() Capabilities
+func MySQLLegacy() Capabilities
+func Postgres13() Capabilities
+func Postgres16() Capabilities
+func Postgres17() Capabilities
+func SQLServer2022() Capabilities
+func SQLite3() Capabilities
+func SpannerPostgres() Capabilities
+func YugabyteDB25() Capabilities
+func (c Capabilities) Clone() Capabilities
+func (c Capabilities) Has(key Capability) bool
+func (c Capabilities) Validate() error
+func (c Capabilities) With(key Capability, enabled bool) Capabilities
+
+### github.com/stokaro/ptah/core/platform/capability.Capability
+
+package capability // import "github.com/stokaro/ptah/core/platform/capability"
+
+type Capability string
+    Capability is a single named feature flag from the curated registry below.
+
+const DropConstraintGeneric Capability = "drop_constraint_generic" ...
+func All() []Capability
+
 ## github.com/stokaro/ptah/core/ptaherr
 
 var ErrUnsupportedDialect = errors.New("unsupported database dialect") ...
@@ -531,6 +4514,68 @@ type CapabilityError struct{ ... }
 type ParseError struct{ ... }
 type PlanError struct{ ... }
 type RenderError struct{ ... }
+
+### github.com/stokaro/ptah/core/ptaherr.CapabilityError
+
+package ptaherr // import "github.com/stokaro/ptah/core/ptaherr"
+
+type CapabilityError struct {
+    Dialect string
+    Feature string
+    Err     error
+    Message string
+}
+    CapabilityError reports a requested feature that is not available for the
+    selected dialect or concrete server capability set.
+
+func (e *CapabilityError) Error() string
+func (e *CapabilityError) Unwrap() error
+
+### github.com/stokaro/ptah/core/ptaherr.ParseError
+
+package ptaherr // import "github.com/stokaro/ptah/core/ptaherr"
+
+type ParseError struct {
+    File      string
+    Line      int
+    Directive string
+    Attribute string
+    Err       error
+    Message   string
+}
+    ParseError reports a Go annotation or source parsing failure.
+
+func (e *ParseError) Error() string
+func (e *ParseError) Unwrap() error
+
+### github.com/stokaro/ptah/core/ptaherr.PlanError
+
+package ptaherr // import "github.com/stokaro/ptah/core/ptaherr"
+
+type PlanError struct {
+    Dialect string
+    Err     error
+    Message string
+}
+    PlanError reports migration planning failures.
+
+func (e *PlanError) Error() string
+func (e *PlanError) Unwrap() error
+
+### github.com/stokaro/ptah/core/ptaherr.RenderError
+
+package ptaherr // import "github.com/stokaro/ptah/core/ptaherr"
+
+type RenderError struct {
+    Dialect string
+    Node    ast.Node
+    Err     error
+    Message string
+}
+    RenderError reports SQL rendering failures.
+
+func (e *RenderError) Error() string
+func (e *RenderError) Unwrap() error
 
 ## github.com/stokaro/ptah/core/query
 
@@ -567,6 +4612,146 @@ type SelectBuilder struct{ ... }
     func Select(columns ...string) *SelectBuilder
 type UpdateBuilder struct{ ... }
     func Update(table string) *UpdateBuilder
+
+### github.com/stokaro/ptah/core/query.Column
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type Column struct {
+    // Has unexported fields.
+}
+    Column is a reference to a column, optionally qualified by a table name or
+    alias. It is the entry point for the qualified-column API used with joins:
+    build one with Col, then turn it into a projection entry (via the builder's
+    Columns method), a comparison, a null test, or an ORDER BY term.
+
+    The value-oriented Phase 1 helpers (Eq, In, Asc, and so on) that take a
+    bare column name still work unchanged for unqualified columns; Column
+    adds qualified-column support alongside them, it does not replace them.
+    A qualifier and name are always emitted as separately quoted identifiers,
+    never inlined.
+
+func Col(qualifier, name string) Column
+func (c Column) Asc() ast.OrderByClause
+func (c Column) Avg() ast.Expression
+func (c Column) Count() ast.Expression
+func (c Column) CountDistinct() ast.Expression
+func (c Column) Desc() ast.OrderByClause
+func (c Column) Eq(value any) ast.Expression
+func (c Column) EqCol(other Column) ast.Expression
+func (c Column) Ge(value any) ast.Expression
+func (c Column) Gt(value any) ast.Expression
+func (c Column) IsNotNull() ast.Expression
+func (c Column) IsNull() ast.Expression
+func (c Column) Le(value any) ast.Expression
+func (c Column) Lt(value any) ast.Expression
+func (c Column) Max() ast.Expression
+func (c Column) Min() ast.Expression
+func (c Column) Ne(value any) ast.Expression
+func (c Column) Sum() ast.Expression
+
+### github.com/stokaro/ptah/core/query.DeleteBuilder
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type DeleteBuilder struct {
+    // Has unexported fields.
+}
+    DeleteBuilder builds an *ast.DeleteStatement through a fluent, chainable
+    API. Start with DeleteFrom. A builder is not safe for concurrent use.
+
+func DeleteFrom(table string) *DeleteBuilder
+func (b *DeleteBuilder) Build() *ast.DeleteStatement
+func (b *DeleteBuilder) Returning(columns ...string) *DeleteBuilder
+func (b *DeleteBuilder) Unconditional() *DeleteBuilder
+func (b *DeleteBuilder) Where(expr ast.Expression) *DeleteBuilder
+
+### github.com/stokaro/ptah/core/query.ExprCompare
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type ExprCompare struct {
+    // Has unexported fields.
+}
+    ExprCompare adapts an expression — typically an aggregate produced by Count,
+    Sum, and friends — so it can be compared against a bound value, the usual
+    shape of a HAVING predicate. Build one with Expr. It mirrors the comparison
+    helpers on Column, but its left operand is any expression rather than a
+    column.
+
+func Expr(left ast.Expression) ExprCompare
+func (e ExprCompare) Eq(value any) ast.Expression
+func (e ExprCompare) Ge(value any) ast.Expression
+func (e ExprCompare) Gt(value any) ast.Expression
+func (e ExprCompare) Le(value any) ast.Expression
+func (e ExprCompare) Lt(value any) ast.Expression
+func (e ExprCompare) Ne(value any) ast.Expression
+
+### github.com/stokaro/ptah/core/query.InsertBuilder
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type InsertBuilder struct {
+    // Has unexported fields.
+}
+    InsertBuilder builds an *ast.InsertStatement through a fluent, chainable
+    API. Start with InsertInto. A builder is not safe for concurrent use.
+
+func InsertInto(table string) *InsertBuilder
+func (b *InsertBuilder) Build() *ast.InsertStatement
+func (b *InsertBuilder) Columns(columns ...string) *InsertBuilder
+func (b *InsertBuilder) Returning(columns ...string) *InsertBuilder
+func (b *InsertBuilder) Values(values ...any) *InsertBuilder
+
+### github.com/stokaro/ptah/core/query.SelectBuilder
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type SelectBuilder struct {
+    // Has unexported fields.
+}
+    SelectBuilder builds an *ast.SelectStatement through a fluent, chainable
+    API.
+
+    A zero SelectBuilder is not meant to be used directly; start with Select.
+    Each method mutates and returns the same builder for chaining. Build
+    produces the statement. Builders are not safe for concurrent use.
+
+func Select(columns ...string) *SelectBuilder
+func (b *SelectBuilder) Build() *ast.SelectStatement
+func (b *SelectBuilder) Columns(columns ...Column) *SelectBuilder
+func (b *SelectBuilder) Distinct() *SelectBuilder
+func (b *SelectBuilder) ExprAs(expr ast.Expression, alias string) *SelectBuilder
+func (b *SelectBuilder) Exprs(exprs ...ast.Expression) *SelectBuilder
+func (b *SelectBuilder) From(table string) *SelectBuilder
+func (b *SelectBuilder) FromAs(table, alias string) *SelectBuilder
+func (b *SelectBuilder) FullJoin(table, alias string, on ast.Expression) *SelectBuilder
+func (b *SelectBuilder) GroupBy(columns ...Column) *SelectBuilder
+func (b *SelectBuilder) Having(expr ast.Expression) *SelectBuilder
+func (b *SelectBuilder) InnerJoin(table, alias string, on ast.Expression) *SelectBuilder
+func (b *SelectBuilder) LeftJoin(table, alias string, on ast.Expression) *SelectBuilder
+func (b *SelectBuilder) Limit(n int64) *SelectBuilder
+func (b *SelectBuilder) Offset(n int64) *SelectBuilder
+func (b *SelectBuilder) OrderBy(terms ...ast.OrderByClause) *SelectBuilder
+func (b *SelectBuilder) RightJoin(table, alias string, on ast.Expression) *SelectBuilder
+func (b *SelectBuilder) Where(expr ast.Expression) *SelectBuilder
+
+### github.com/stokaro/ptah/core/query.UpdateBuilder
+
+package query // import "github.com/stokaro/ptah/core/query"
+
+type UpdateBuilder struct {
+    // Has unexported fields.
+}
+    UpdateBuilder builds an *ast.UpdateStatement through a fluent, chainable
+    API. Start with Update. A builder is not safe for concurrent use.
+
+func Update(table string) *UpdateBuilder
+func (b *UpdateBuilder) Build() *ast.UpdateStatement
+func (b *UpdateBuilder) Returning(columns ...string) *UpdateBuilder
+func (b *UpdateBuilder) Set(column string, value any) *UpdateBuilder
+func (b *UpdateBuilder) Unconditional() *UpdateBuilder
+func (b *UpdateBuilder) Where(expr ast.Expression) *UpdateBuilder
 
 ## github.com/stokaro/ptah/core/renderer
 
@@ -637,6 +4822,30 @@ func ReadTableRows(ctx context.Context, conn *DatabaseConnection, schema, table 
 type DatabaseConnection struct{ ... }
     func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, error)
 
+### github.com/stokaro/ptah/dbschema.DatabaseConnection
+
+package dbschema // import "github.com/stokaro/ptah/dbschema"
+
+type DatabaseConnection struct {
+    // Has unexported fields.
+}
+    DatabaseConnection represents a database connection with metadata
+
+func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, error)
+func (dc *DatabaseConnection) Close() error
+func (dc *DatabaseConnection) Conn(ctx context.Context) (*sql.Conn, error)
+func (dc *DatabaseConnection) Exec(query string, args ...any) (sql.Result, error)
+func (dc *DatabaseConnection) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+func (dc *DatabaseConnection) Info() types.DBInfo
+func (dc *DatabaseConnection) Query(query string, args ...any) (*sql.Rows, error)
+func (dc *DatabaseConnection) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+func (dc *DatabaseConnection) QueryRow(query string, args ...any) *sql.Row
+func (dc *DatabaseConnection) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+func (dc *DatabaseConnection) Reader() types.SchemaReader
+func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter
+func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *DatabaseConnection
+func (dc *DatabaseConnection) Writer() types.SchemaExecutor
+
 ## github.com/stokaro/ptah/dbschema/types
 
 func QualifyTableName(schema, table string) string
@@ -665,6 +4874,424 @@ type SchemaExecutor interface{ ... }
 type SchemaReader interface{ ... }
 type SchemaTransaction interface{ ... }
 type SchemaWriter interface{ ... }
+
+### github.com/stokaro/ptah/dbschema/types.DBColumn
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBColumn struct {
+    Name               string  `json:"name"`
+    DataType           string  `json:"data_type"`
+    UDTName            string  `json:"udt_name"`             // For PostgreSQL enum types
+    ColumnType         string  `json:"column_type"`          // For MySQL ENUM syntax
+    IsNullable         string  `json:"is_nullable"`          // YES/NO
+    ColumnDefault      *string `json:"column_default"`       // Can be NULL
+    CharacterMaxLength *int    `json:"character_max_length"` // For VARCHAR, etc.
+    Charset            string  `json:"charset,omitempty"`    // MySQL/MariaDB column character set
+    Collate            string  `json:"collate,omitempty"`    // MySQL/MariaDB column collation
+    NumericPrecision   *int    `json:"numeric_precision"`    // For DECIMAL, etc.
+    NumericScale       *int    `json:"numeric_scale"`        // For DECIMAL, etc.
+    OrdinalPosition    int     `json:"ordinal_position"`
+    IsAutoIncrement    bool    `json:"is_auto_increment"` // Derived field
+    IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field
+    IsUnique           bool    `json:"is_unique"`         // Derived field
+
+    // GeneratedExpression holds the generated-column expression. Nil for plain
+    // columns.
+    GeneratedExpression *string `json:"generated_expression,omitempty"`
+    // GeneratedKind names the generated-column kind, for example STORED,
+    // VIRTUAL, MATERIALIZED, ALIAS, or EPHEMERAL. Empty for plain columns.
+    GeneratedKind string `json:"generated_kind,omitempty"`
+
+    // IdentityGeneration records an identity column's generation mode, mirroring
+    // the goschema-side field: "ALWAYS" (GENERATED ALWAYS AS IDENTITY, which
+    // rejects explicit inserts), "BY_DEFAULT" (GENERATED BY DEFAULT AS IDENTITY,
+    // which accepts them), or "" for non-identity columns. Populated by readers
+    // for dialects that expose identity metadata (currently PostgreSQL via
+    // pg_attribute.attidentity).
+    IdentityGeneration string `json:"identity_generation,omitempty"`
+}
+    DBColumn represents a database column.
+
+    GeneratedKind / GeneratedExpression are populated by readers for dialects
+    that expose generated column metadata. Schema comparison matches these
+    fields when the goschema-side model also carries generated column metadata.
+
+
+### github.com/stokaro/ptah/dbschema/types.DBComposite
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBComposite struct {
+    Name   string             `json:"name"`
+    Schema string             `json:"schema,omitempty"`
+    Fields []DBCompositeField `json:"fields"`
+}
+    DBComposite represents a PostgreSQL composite type read from the database.
+
+func (c DBComposite) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBCompositeField
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBCompositeField struct {
+    Name string `json:"name"`
+    Type string `json:"type"`
+}
+    DBCompositeField is a single field of a composite type read from the
+    database.
+
+
+### github.com/stokaro/ptah/dbschema/types.DBConstraint
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBConstraint struct {
+    Name           string   `json:"name"`
+    TableName      string   `json:"table_name"`
+    Schema         string   `json:"schema,omitempty"`
+    Type           string   `json:"type"` // PRIMARY KEY, FOREIGN KEY, UNIQUE, CHECK, EXCLUDE
+    ColumnName     string   `json:"column_name"`
+    ColumnNames    []string `json:"column_names,omitempty"`
+    ForeignTable   *string  `json:"foreign_table"` // For foreign keys
+    ForeignSchema  string   `json:"foreign_schema,omitempty"`
+    ForeignColumn  *string  `json:"foreign_column"` // For foreign keys
+    ForeignColumns []string `json:"foreign_columns,omitempty"`
+    DeleteRule     *string  `json:"delete_rule"`  // CASCADE, RESTRICT, etc.
+    UpdateRule     *string  `json:"update_rule"`  // CASCADE, RESTRICT, etc.
+    CheckClause    *string  `json:"check_clause"` // For CHECK constraints
+    // NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+    // Nil means the clause was not present in the definition.
+    NullsDistinct *bool `json:"nulls_distinct,omitempty"`
+    // IncludeColumns carries PostgreSQL INCLUDE columns for covering UNIQUE
+    // and PRIMARY KEY constraints.
+    IncludeColumns []string `json:"include_columns,omitempty"`
+    // EXCLUDE constraint specific fields (PostgreSQL only)
+    UsingMethod     *string `json:"using_method"`     // Index method: gist, btree, etc.
+    ExcludeElements *string `json:"exclude_elements"` // Elements with operators: "room_id WITH =, during WITH &&"
+    WhereCondition  *string `json:"where_condition"`  // Optional WHERE clause for EXCLUDE constraints
+}
+    DBConstraint represents a database constraint
+
+func (c DBConstraint) ColumnNamesOrDefault() []string
+func (c DBConstraint) ForeignColumnsOrDefault() []string
+func (c DBConstraint) QualifiedForeignTableName() string
+func (c DBConstraint) QualifiedTableName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBDomain
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBDomain struct {
+    Name     string `json:"name"`
+    Schema   string `json:"schema,omitempty"`
+    BaseType string `json:"base_type"`
+    NotNull  bool   `json:"not_null"`
+    Default  string `json:"default,omitempty"`
+    Check    string `json:"check,omitempty"`
+}
+    DBDomain represents a PostgreSQL domain type read from the database.
+
+func (d DBDomain) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBEnum
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBEnum struct {
+    Name   string   `json:"name"`
+    Values []string `json:"values"`
+}
+    DBEnum represents a database enum type (PostgreSQL)
+
+
+### github.com/stokaro/ptah/dbschema/types.DBExtension
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBExtension struct {
+    Name             string  `json:"name"`              // Extension name (pg_trgm, postgis, etc.)
+    Version          string  `json:"version"`           // Installed version
+    Schema           string  `json:"schema"`            // Schema where extension is installed
+    Relocatable      bool    `json:"relocatable"`       // Whether extension can be moved between schemas
+    Comment          *string `json:"comment"`           // Extension comment/description
+    DefaultVersion   *string `json:"default_version"`   // Default version available
+    InstalledVersion *string `json:"installed_version"` // Currently installed version (may differ from default)
+}
+    DBExtension represents a PostgreSQL extension installed in the database
+
+
+### github.com/stokaro/ptah/dbschema/types.DBFunction
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBFunction struct {
+    Name       string `json:"name"`       // Function name
+    Parameters string `json:"parameters"` // Function parameters (e.g., "tenant_id_param TEXT")
+    Returns    string `json:"returns"`    // Return type (e.g., "VOID", "TEXT")
+    Language   string `json:"language"`   // Function language (e.g., "plpgsql", "sql")
+    Security   string `json:"security"`   // Security context (e.g., "DEFINER", "INVOKER")
+    Volatility string `json:"volatility"` // Function volatility (e.g., "STABLE", "IMMUTABLE", "VOLATILE")
+    Body       string `json:"body"`       // Function body/implementation
+    Comment    string `json:"comment"`    // Function comment/description
+}
+    DBFunction represents a PostgreSQL custom function read from the database
+
+
+### github.com/stokaro/ptah/dbschema/types.DBGrant
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBGrant struct {
+    Role       string `json:"role"`                 // Role receiving the privilege
+    Privilege  string `json:"privilege"`            // Granted privilege, e.g. SELECT or USAGE
+    ObjectType string `json:"object_type"`          // TABLE, SCHEMA, or SEQUENCE
+    Schema     string `json:"schema,omitempty"`     // Schema containing the target object
+    ObjectName string `json:"object_name"`          // Target table or schema name
+    WithOption bool   `json:"with_option"`          // Whether the grant has WITH GRANT OPTION
+    GrantedBy  string `json:"granted_by,omitempty"` // Grantor role
+}
+    DBGrant represents a PostgreSQL privilege grant read from the database.
+
+func (g DBGrant) QualifiedTarget() string
+
+### github.com/stokaro/ptah/dbschema/types.DBIndex
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBIndex struct {
+    Name       string   `json:"name"`
+    TableName  string   `json:"table_name"`
+    Schema     string   `json:"schema,omitempty"`
+    Columns    []string `json:"columns"`
+    IsUnique   bool     `json:"is_unique"`
+    IsPrimary  bool     `json:"is_primary"`
+    Definition string   `json:"definition"` // Full index definition
+    // Condition is the WHERE clause for partial indexes when the dialect
+    // exposes one structurally.
+    Condition string `json:"condition,omitempty"`
+    // NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
+    // state. Nil means the clause was not present in the definition.
+    NullsDistinct *bool `json:"nulls_distinct,omitempty"`
+
+    // Type is the ClickHouse data-skipping-index type. One of
+    // "minmax" / "set(N)" / "bloom_filter" / "bloom_filter(p)" /
+    // "tokenbf_v1(...)" / "ngrambf_v1(...)" etc. Empty on non-ClickHouse
+    // readers.
+    Type string `json:"type,omitempty"`
+    // Expression is the full ClickHouse skipping-index expression
+    // (column reference, function call, tuple, etc.). The reader also writes
+    // the expression into Columns[0] for back-compat with the existing diff
+    // layer; Expression is the canonical field for richer diffing once
+    // that's wired up. Empty on non-ClickHouse readers.
+    Expression string `json:"expression,omitempty"`
+    // Granularity is the GRANULARITY value the index was declared with.
+    // Non-zero only on ClickHouse skipping indexes.
+    Granularity int `json:"granularity,omitempty"`
+}
+    DBIndex represents a database index.
+
+    Most fields are dialect-neutral. The Type/Expression/Granularity trio is
+    populated only by the ClickHouse reader for data-skipping indexes; other
+    readers leave them at their zero values so the diff layer does not start
+    emitting spurious type/granularity changes for PostgreSQL or MySQL indexes.
+
+func (i DBIndex) QualifiedTableName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBInfo
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBInfo struct {
+    Dialect      string                  `json:"dialect"` // postgres, mysql, mariadb
+    Version      string                  `json:"version"`
+    Schema       string                  `json:"schema"`       // public, database name, etc.
+    URL          string                  `json:"url"`          // database connection URL (for reference)
+    Capabilities capability.Capabilities `json:"capabilities"` // resolved from Dialect + Version for live connections
+}
+    DBInfo contains connection and metadata information
+
+
+### github.com/stokaro/ptah/dbschema/types.DBMatView
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBMatView struct {
+    Name            string `json:"name"`             // Materialized view name
+    Schema          string `json:"schema"`           // Schema where the materialized view is defined
+    Body            string `json:"body"`             // SELECT query used as the materialized view definition
+    RefreshStrategy string `json:"refresh_strategy"` // Ptah-managed refresh policy; database introspection defaults to manual
+    Comment         string `json:"comment"`          // Materialized view comment/description
+}
+    DBMatView represents a PostgreSQL materialized view read from the database.
+
+func (v DBMatView) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBRLSPolicy
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBRLSPolicy struct {
+    Name                string `json:"name"`                  // Policy name
+    Table               string `json:"table"`                 // Target table name
+    PolicyFor           string `json:"policy_for"`            // Operations policy applies to (e.g., "ALL", "SELECT")
+    ToRoles             string `json:"to_roles"`              // Target roles (e.g., "app_user", "PUBLIC")
+    UsingExpression     string `json:"using_expression"`      // USING clause expression
+    WithCheckExpression string `json:"with_check_expression"` // WITH CHECK clause expression
+    Comment             string `json:"comment"`               // Policy comment/description
+}
+    DBRLSPolicy represents a PostgreSQL RLS policy read from the database
+
+
+### github.com/stokaro/ptah/dbschema/types.DBRange
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBRange struct {
+    Name    string `json:"name"`
+    Schema  string `json:"schema,omitempty"`
+    Subtype string `json:"subtype"`
+}
+    DBRange represents a PostgreSQL range type read from the database.
+
+func (r DBRange) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBRole
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBRole struct {
+    Name        string `json:"name"`         // Role name
+    Login       bool   `json:"login"`        // Whether role can login
+    Superuser   bool   `json:"superuser"`    // Whether role is superuser
+    CreateDB    bool   `json:"create_db"`    // Whether role can create databases
+    CreateRole  bool   `json:"create_role"`  // Whether role can create other roles
+    Inherit     bool   `json:"inherit"`      // Whether role inherits privileges
+    Replication bool   `json:"replication"`  // Whether role can initiate replication
+    HasPassword bool   `json:"has_password"` // Whether role has a password set
+    Comment     string `json:"comment"`      // Role comment/description
+}
+    DBRole represents a PostgreSQL role read from the database
+
+
+### github.com/stokaro/ptah/dbschema/types.DBSchema
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBSchema struct {
+    Schemas     []DBSchemaInfo `json:"schemas"`
+    Tables      []DBTable      `json:"tables"`
+    Enums       []DBEnum       `json:"enums"`
+    Indexes     []DBIndex      `json:"indexes"`
+    Constraints []DBConstraint `json:"constraints"`
+    Extensions  []DBExtension  `json:"extensions"`   // PostgreSQL extensions
+    Functions   []DBFunction   `json:"functions"`    // PostgreSQL custom functions
+    Sequences   []DBSequence   `json:"sequences"`    // PostgreSQL standalone sequences
+    Domains     []DBDomain     `json:"domains"`      // PostgreSQL domain types
+    Composites  []DBComposite  `json:"composites"`   // PostgreSQL composite types
+    Ranges      []DBRange      `json:"ranges"`       // PostgreSQL range types
+    Views       []DBView       `json:"views"`        // Database views
+    MatViews    []DBMatView    `json:"matviews"`     // Database materialized views
+    Triggers    []DBTrigger    `json:"triggers"`     // Database triggers
+    RLSPolicies []DBRLSPolicy  `json:"rls_policies"` // PostgreSQL RLS policies
+    Roles       []DBRole       `json:"roles"`        // PostgreSQL roles
+    Grants      []DBGrant      `json:"grants"`       // PostgreSQL privilege grants
+}
+    DBSchema represents the complete schema read from a database
+
+
+### github.com/stokaro/ptah/dbschema/types.DBSchemaInfo
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBSchemaInfo struct {
+    Name    string `json:"name"`
+    Comment string `json:"comment,omitempty"`
+    Charset string `json:"charset,omitempty"`
+    Collate string `json:"collate,omitempty"`
+}
+    DBSchemaInfo represents a database schema/namespace.
+
+
+### github.com/stokaro/ptah/dbschema/types.DBSequence
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBSequence struct {
+    Name      string `json:"name"`                // Sequence name
+    Schema    string `json:"schema,omitempty"`    // Schema containing the sequence
+    DataType  string `json:"data_type,omitempty"` // Underlying integer type (e.g. "bigint")
+    Start     *int64 `json:"start,omitempty"`     // START WITH value
+    Increment *int64 `json:"increment,omitempty"` // INCREMENT BY value
+    MinValue  *int64 `json:"min_value,omitempty"` // MINVALUE bound
+    MaxValue  *int64 `json:"max_value,omitempty"` // MAXVALUE bound
+    Cache     *int64 `json:"cache,omitempty"`     // CACHE size
+    Cycle     bool   `json:"cycle"`               // Whether the sequence uses CYCLE
+    OwnedBy   string `json:"owned_by,omitempty"`  // Owning table.column, if any
+    Comment   string `json:"comment,omitempty"`   // Sequence comment/description
+}
+    DBSequence represents a standalone PostgreSQL sequence read from the
+    database.
+
+    Only user-declared, standalone sequences appear here. Implicit sequences
+    that back SERIAL / BIGSERIAL / identity columns (those OWNED BY a column via
+    an internal/auto dependency) are deliberately excluded so that declaring a
+    plain SERIAL column does not surface as a spurious standalone sequence.
+
+func (s DBSequence) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBTable
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBTable struct {
+    Name          string     `json:"name"`
+    Schema        string     `json:"schema,omitempty"`
+    Type          string     `json:"type"` // TABLE, VIEW, etc.
+    Comment       string     `json:"comment"`
+    Columns       []DBColumn `json:"columns"`
+    EstimatedRows int64      `json:"estimated_rows,omitempty"` // Best-effort planner estimate from database statistics
+    RLSEnabled    bool       `json:"rls_enabled"`              // Whether RLS is enabled on this table (PostgreSQL)
+    Strict        bool       `json:"strict,omitempty"`         // SQLite STRICT table option
+    WithoutRowID  bool       `json:"without_rowid,omitempty"`  // SQLite WITHOUT ROWID table option
+}
+    DBTable represents a database table
+
+func (t DBTable) QualifiedName() string
+
+### github.com/stokaro/ptah/dbschema/types.DBTrigger
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBTrigger struct {
+    Name    string `json:"name"`    // Trigger name
+    Schema  string `json:"schema"`  // Schema where the trigger is defined
+    Table   string `json:"table"`   // Target table
+    Timing  string `json:"timing"`  // BEFORE, AFTER, or INSTEAD OF
+    Event   string `json:"event"`   // INSERT, UPDATE, DELETE, or TRUNCATE
+    ForEach string `json:"for"`     // ROW or STATEMENT
+    Body    string `json:"body"`    // Trigger body
+    Comment string `json:"comment"` // Trigger comment/description
+}
+    DBTrigger represents a database trigger read from the database.
+
+func (t DBTrigger) QualifiedTable() string
+
+### github.com/stokaro/ptah/dbschema/types.DBView
+
+package types // import "github.com/stokaro/ptah/dbschema/types"
+
+type DBView struct {
+    Name        string `json:"name"`         // View name
+    Schema      string `json:"schema"`       // Schema where the view is defined
+    Body        string `json:"body"`         // SELECT query used as the view definition
+    CheckOption string `json:"check_option"` // NONE, LOCAL, CASCADED, or dialect equivalent
+    Comment     string `json:"comment"`      // View comment/description
+}
+    DBView represents a database view read from the database.
+
+func (v DBView) QualifiedName() string
 
 ### github.com/stokaro/ptah/dbschema/types.SchemaExecutor
 
@@ -737,6 +5364,56 @@ type DataDiff struct{ ... }
 type Row = map[string]any
 type RowUpdate struct{ ... }
 
+### github.com/stokaro/ptah/migration/datadiff.DataDiff
+
+package datadiff // import "github.com/stokaro/ptah/migration/datadiff"
+
+type DataDiff struct {
+    // Schema is the database schema the table belongs to, or empty for the
+    // connection's default schema. It does not affect the diff computation (rows
+    // are matched by key regardless of schema); it identifies the target table so
+    // [Render] can emit a schema-qualified name.
+    Schema  string
+    Table   string
+    Keys    []string
+    Inserts []Row
+    Updates []RowUpdate
+    Deletes []Row
+}
+    DataDiff is the set of row-level changes needed to bring a table's live rows
+    in line with the desired managed data.
+
+    Inserts are rows present in the desired data but absent live. Deletes are
+    rows present live but absent from the desired data. Updates are rows present
+    in both whose managed columns differ. Inserts, Updates, and Deletes are each
+    sorted by their composite key so the output is deterministic and testable.
+
+func Compute(schema, table string, keys []string, desired, live []Row) (*DataDiff, error)
+
+### github.com/stokaro/ptah/migration/datadiff.Row
+
+package datadiff // import "github.com/stokaro/ptah/migration/datadiff"
+
+type Row = map[string]any
+    Row is a single table row keyed by column name. It matches the shape
+    returned by goschema.LoadManagedRows and dbschema.ReadTableRows.
+
+
+### github.com/stokaro/ptah/migration/datadiff.RowUpdate
+
+package datadiff // import "github.com/stokaro/ptah/migration/datadiff"
+
+type RowUpdate struct {
+    Key     map[string]any
+    Desired Row
+    Live    Row
+}
+    RowUpdate describes a row present in both the desired and live data whose
+    managed columns differ. Both Desired and Live are carried so a later phase
+    can render a reversible UPDATE (Desired drives the forward statement, Live
+    the rollback). Key holds only the key-column values that identify the row.
+
+
 ## github.com/stokaro/ptah/migration/dbtest
 
 type Assertion struct{ ... }
@@ -753,6 +5430,175 @@ type SeedStep struct{ ... }
 type Step struct{ ... }
 type StepResult struct{ ... }
 
+### github.com/stokaro/ptah/migration/dbtest.Assertion
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type Assertion struct {
+    // Query is the SQL executed by the assertion. It is always required and
+    // should be a SELECT: with row_count and scalar it is run as a query, and
+    // with error_contains it is run and expected to fail, so a non-SELECT
+    // statement would execute its side effects.
+    Query string `yaml:"query"`
+    // RowCount asserts that Query returns exactly this many rows.
+    RowCount *int `yaml:"row_count"`
+    // Scalar asserts that the first column of the first row of Query, formatted
+    // as a string, equals this value. Values are formatted deterministically:
+    // []byte and text as their string, time.Time as RFC3339, SQL NULL as
+    // "<nil>", and other types via fmt's default. Select a column as text (for
+    // example CAST(col AS TEXT)) to compare its raw stored form.
+    Scalar *string `yaml:"scalar"`
+    // ErrorContains asserts that running Query fails with an error message that
+    // contains this substring.
+    ErrorContains string `yaml:"error_contains"`
+}
+    Assertion runs Query and checks exactly one of RowCount, Scalar,
+    or ErrorContains.
+
+
+### github.com/stokaro/ptah/migration/dbtest.Case
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type Case struct {
+    Name  string `yaml:"name"`
+    Steps []Step `yaml:"steps"`
+}
+    Case is a single declarative migration test: a named, ordered list of steps
+    executed against the test database.
+
+func LoadCases(dir string) ([]Case, error)
+func ParseCases(data []byte) ([]Case, error)
+
+### github.com/stokaro/ptah/migration/dbtest.CaseResult
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type CaseResult struct {
+    Name   string       `json:"name"`
+    Steps  []StepResult `json:"steps"`
+    Passed bool         `json:"passed"`
+}
+    CaseResult is the outcome of a single Case. Passed is true only when every
+    executed step passed.
+
+
+### github.com/stokaro/ptah/migration/dbtest.Options
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type Options struct {
+    // Cases are the test cases to run, in order.
+    Cases []Case
+    // MigrationsDir is the directory containing migration files. It is required
+    // only when a case has a migrate_to step.
+    MigrationsDir string
+    // DBURL is an optional database URL to run the tests against. It must point
+    // at a throwaway database, because tests mutate schema and data. When empty,
+    // an ephemeral SQLite database is provisioned in a temporary directory and
+    // removed afterwards.
+    DBURL string
+    // DirFormat selects how MigrationsDir is parsed. The zero value defaults to
+    // the Ptah directory format (not the migrator's own "auto" default), so a
+    // direct caller that wants format auto-detection must set it explicitly.
+    DirFormat migrator.MigrationDirFormat
+}
+    Options configures a single RunMigrationTest invocation.
+
+
+### github.com/stokaro/ptah/migration/dbtest.Report
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type Report struct {
+    Cases []CaseResult
+
+    // Has unexported fields.
+}
+    Report is the outcome of a RunMigrationTest or RunSchemaTest run.
+
+func RunMigrationTest(ctx context.Context, opts Options) (*Report, error)
+func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error)
+func (r *Report) Failed() bool
+func (r *Report) HTML() (string, error)
+func (r *Report) JSON() (string, error)
+func (r *Report) Render(format string) (string, error)
+func (r *Report) Text() string
+
+### github.com/stokaro/ptah/migration/dbtest.SchemaOptions
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type SchemaOptions struct {
+    // Cases are the test cases to run, in order.
+    Cases []Case
+    // RootDir is a directory of Go entity annotations describing the desired
+    // schema. It is parsed with goschema.ParseDir, rendered to dependency-ordered
+    // CREATE DDL for the target dialect, and applied once per database before any
+    // case runs against it (once per ephemeral per-case database, or once for a
+    // shared explicit database).
+    RootDir string
+    // DBURL is an optional database URL to run the tests against. It must point at
+    // a throwaway database, because tests mutate schema and data. When empty, an
+    // ephemeral SQLite database is provisioned per case in a temporary directory
+    // and removed afterwards.
+    DBURL string
+}
+    SchemaOptions configures a single RunSchemaTest invocation.
+
+
+### github.com/stokaro/ptah/migration/dbtest.SeedStep
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type SeedStep struct {
+    // Dir is the directory of seed files. It is required.
+    Dir string `yaml:"dir"`
+    // Env is the seed environment to apply (for example dev or test). It is
+    // required; files matching Env plus files ending in .all.sql are applied.
+    Env string `yaml:"env"`
+}
+    SeedStep applies SQL seed files from Dir using the seeder's
+    NNN_description.env.sql convention: files matching Env plus files ending in
+    .all.sql are applied in version order. Because the target is a throwaway
+    test database, protected-environment and protected-table guards do not
+    apply.
+
+
+### github.com/stokaro/ptah/migration/dbtest.Step
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type Step struct {
+    // Name is a human-readable label used in reporting. It is optional.
+    Name string `yaml:"name"`
+    // MigrateTo migrates the database to a target version. It accepts an integer
+    // version, "latest", or "0".
+    MigrateTo string `yaml:"migrate_to"`
+    // Exec runs raw SQL against the database.
+    Exec string `yaml:"exec"`
+    // Seed applies environment-scoped SQL seed files from a directory.
+    Seed *SeedStep `yaml:"seed"`
+    // Assert runs a query and checks a single condition on the result.
+    Assert *Assertion `yaml:"assert"`
+}
+    Step performs exactly one action against the test database. Exactly one of
+    MigrateTo, Exec, or Assert must be set.
+
+
+### github.com/stokaro/ptah/migration/dbtest.StepResult
+
+package dbtest // import "github.com/stokaro/ptah/migration/dbtest"
+
+type StepResult struct {
+    Name   string `json:"name"`
+    Passed bool   `json:"passed"`
+    Detail string `json:"detail,omitempty"`
+}
+    StepResult is the outcome of a single Step. Detail carries a short
+    human-readable explanation of the result, especially on failure.
+
+
 ## github.com/stokaro/ptah/migration/diffpolicy
 
 type ChangeKind string
@@ -764,6 +5610,48 @@ type SkipSet map[ChangeKind]struct{}
 type SkippedChange struct{ ... }
     func Apply(diff *types.SchemaDiff, skip SkipSet) (*types.SchemaDiff, []SkippedChange)
     func ApplyForDialect(diff *types.SchemaDiff, skip SkipSet, dialect string) (*types.SchemaDiff, []SkippedChange)
+
+### github.com/stokaro/ptah/migration/diffpolicy.ChangeKind
+
+package diffpolicy // import "github.com/stokaro/ptah/migration/diffpolicy"
+
+type ChangeKind string
+    ChangeKind identifies a destructive schema change kind that a diff policy
+    can skip. The string values are the stable identifiers accepted in project
+    config (ptah.yaml diff.skip) and are safe to render in migration comments.
+
+const DropTable ChangeKind = "drop_table" ...
+func AllChangeKinds() []ChangeKind
+func ParseChangeKind(raw string) (ChangeKind, error)
+
+### github.com/stokaro/ptah/migration/diffpolicy.SkipSet
+
+package diffpolicy // import "github.com/stokaro/ptah/migration/diffpolicy"
+
+type SkipSet map[ChangeKind]struct{}
+    SkipSet is a set of change kinds a policy skips.
+
+func NewSkipSet(kinds ...ChangeKind) SkipSet
+func (s SkipSet) Empty() bool
+func (s SkipSet) Has(kind ChangeKind) bool
+
+### github.com/stokaro/ptah/migration/diffpolicy.SkippedChange
+
+package diffpolicy // import "github.com/stokaro/ptah/migration/diffpolicy"
+
+type SkippedChange struct {
+    // Kind is the change kind that caused the omission.
+    Kind ChangeKind
+    // Object is a human-readable identity of the omitted object, e.g. a table,
+    // column, index, or enum name.
+    Object string
+}
+    SkippedChange records one change omitted by the policy so a caller can emit
+    a clearly-marked comment in its place.
+
+func Apply(diff *types.SchemaDiff, skip SkipSet) (*types.SchemaDiff, []SkippedChange)
+func ApplyForDialect(diff *types.SchemaDiff, skip SkipSet, dialect string) (*types.SchemaDiff, []SkippedChange)
+func (c SkippedChange) Comment() string
 
 ## github.com/stokaro/ptah/migration/generator
 
@@ -785,6 +5673,210 @@ type ShadowMismatch struct{ ... }
 type ShadowVerificationError struct{ ... }
 type ShadowVerificationResult struct{ ... }
 
+### github.com/stokaro/ptah/migration/generator.BaselineShadowVerifyOptions
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type BaselineShadowVerifyOptions struct {
+    ShadowDatabaseURL string
+    TargetConn        *dbschema.DatabaseConnection
+    MigrationsDir     string
+    Version           int64
+    Dialect           string
+    Capabilities      capability.Capabilities
+    CompareOptions    *config.CompareOptions
+    Schemas           []string
+    ProviderOptions   []migrator.FSProviderOption
+    ConnectTimeout    time.Duration
+}
+    BaselineShadowVerifyOptions configures shadow verification before metadata
+    baselining.
+
+
+### github.com/stokaro/ptah/migration/generator.CheckpointFromShadowOptions
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type CheckpointFromShadowOptions struct {
+    // ShadowDatabaseURL is an ephemeral database the generator drops clean and
+    // replays the migration directory into. Its contents are discarded.
+    ShadowDatabaseURL string
+    // MigrationsDir is the directory whose entire history is replayed.
+    MigrationsDir string
+    // Dialect, when set, must match the shadow database dialect. When empty the
+    // shadow database's dialect is used.
+    Dialect string
+    // Schemas restricts introspection to the listed schemas where supported.
+    Schemas []string
+    // ProviderOptions are passed to the migration provider (e.g. dir format).
+    ProviderOptions []migrator.FSProviderOption
+    // ConnectTimeout bounds the shadow database connection attempt.
+    ConnectTimeout time.Duration
+}
+    CheckpointFromShadowOptions configures GenerateCheckpointFromShadow.
+
+
+### github.com/stokaro/ptah/migration/generator.DiffPolicy
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type DiffPolicy struct {
+    // SkipChangeKinds lists destructive change kinds to omit from generated
+    // migrations. Currently honored by the PostgreSQL-family planner.
+    SkipChangeKinds []diffpolicy.ChangeKind
+    // ConcurrentIndex requests CREATE INDEX CONCURRENTLY for every newly added
+    // index, superseding the populated-table heuristic. It remains gated on the
+    // target's CreateIndexConcurrently capability.
+    ConcurrentIndex bool
+}
+    DiffPolicy is the generator-level view of the project diff policy.
+
+
+### github.com/stokaro/ptah/migration/generator.EmptyMigrationOptions
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type EmptyMigrationOptions struct {
+    // MigrationName is the descriptive migration name used in filenames and headers.
+    MigrationName string
+    // OutputDir is the directory where migration files will be saved.
+    OutputDir string
+    // AllowedOutputRoot constrains OutputDir when set.
+    AllowedOutputRoot string
+    // DirFormat selects the generated migration file layout. Empty generates
+    // Ptah paired up/down files.
+    DirFormat migrator.MigrationDirFormat
+}
+    EmptyMigrationOptions contains options for skeleton migration creation.
+
+
+### github.com/stokaro/ptah/migration/generator.GenerateMigrationOptions
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type GenerateMigrationOptions struct {
+    // GoEntitiesDir is the directory to scan for Go entities
+    GoEntitiesDir string
+    // GoEntitiesFS is the filesystem to use for reading entities (optional, defaults to os.DirFS)
+    GoEntitiesFS fs.FS
+    // Generated is a pre-parsed desired schema (optional). When set, it is used
+    // directly and GoEntitiesDir/GoEntitiesFS are ignored, letting a caller supply
+    // a composite schema merged from several sources.
+    Generated *goschema.Database
+    // DatabaseURL is the connection string for the database
+    DatabaseURL string
+    // DBConn is the database connection (optional, if not provided, a new connection will be created)
+    DBConn *dbschema.DatabaseConnection
+    // MigrationName is the name for the migration (optional, defaults to "migration")
+    MigrationName string
+    // OutputDir is the directory where migration files will be saved (always real filesystem)
+    OutputDir string
+    // AllowedOutputRoot constrains OutputDir when set. Embedders that accept
+    // user-supplied output paths should set this to the project/workspace root.
+    AllowedOutputRoot string
+    // CompareOptions are the options to use when comparing schemas
+    CompareOptions *config.CompareOptions
+    // Schemas restricts database introspection to the listed schemas when the
+    // connected dialect supports schema scoping.
+    Schemas []string
+    // CheckDestructive refuses to generate destructive up migrations unless
+    // AllowDestructive is set.
+    CheckDestructive bool
+    // AllowDestructive permits destructive up migrations when CheckDestructive is set.
+    AllowDestructive bool
+    // ReportFormat optionally writes a safety report next to generated files.
+    // Supported values: "", "html", "json".
+    ReportFormat string
+    // ShadowDatabaseURL enables pre-write verification on an ephemeral database.
+    // The generator drops all objects in this database, replays existing
+    // migrations from OutputDir, applies the candidate migration, re-introspects
+    // the result, and aborts if it differs from the Go schema.
+    ShadowDatabaseURL string
+    // DiffPolicy controls which changes the planner emits: destructive change
+    // kinds to skip and whether to create new indexes concurrently. The zero
+    // value applies no policy. Skipping a destructive change omits it from the
+    // plan (with a comment in its place), so it never trips the CheckDestructive
+    // gate.
+    DiffPolicy DiffPolicy
+}
+    GenerateMigrationOptions contains options for migration generation
+
+
+### github.com/stokaro/ptah/migration/generator.MigrationFilePair
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type MigrationFilePair struct {
+    UpFile        string // Path to the up migration file
+    DownFile      string // Path to the down migration file
+    ReportFile    string // Path to the safety report file, when requested
+    Version       int64  // Migration version (timestamp)
+    NoTransaction bool   // Whether the pair is marked with +ptah no_transaction
+}
+    MigrationFilePair represents one generated up/down migration file pair.
+
+
+### github.com/stokaro/ptah/migration/generator.MigrationFiles
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type MigrationFiles struct {
+    UpFile     string              // Path to the first up migration file
+    DownFile   string              // Path to the first down migration file
+    ReportFile string              // Path to the first safety report file, when requested
+    Version    int64               // First migration version (timestamp)
+    Files      []MigrationFilePair // All generated migration file pairs, in apply order
+}
+    MigrationFiles represents the generated migration files.
+
+func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
+func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error)
+
+### github.com/stokaro/ptah/migration/generator.ShadowMismatch
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type ShadowMismatch struct {
+    Kind       string            `json:"kind"`
+    Object     string            `json:"object,omitempty"`
+    Table      string            `json:"table,omitempty"`
+    Column     string            `json:"column,omitempty"`
+    Constraint string            `json:"constraint,omitempty"`
+    Changes    map[string]string `json:"changes,omitempty"`
+    Message    string            `json:"message"`
+}
+    ShadowMismatch describes one schema mismatch found during shadow
+    verification.
+
+
+### github.com/stokaro/ptah/migration/generator.ShadowVerificationError
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type ShadowVerificationError struct {
+    Result ShadowVerificationResult `json:"result"`
+    Err    error                    `json:"-"`
+}
+    ShadowVerificationError wraps a structured shadow verification result.
+
+func (e *ShadowVerificationError) Error() string
+func (e *ShadowVerificationError) Unwrap() error
+
+### github.com/stokaro/ptah/migration/generator.ShadowVerificationResult
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type ShadowVerificationResult struct {
+    Stage      string           `json:"stage"`
+    Success    bool             `json:"success"`
+    Mismatches []ShadowMismatch `json:"mismatches,omitempty"`
+}
+    ShadowVerificationResult is a structured shadow-database verification
+    outcome. Errors preserve the historical text form through
+    ShadowVerificationError.Error while exposing mismatches to callers that need
+    machine-readable diagnostics.
+
+
 ## github.com/stokaro/ptah/migration/importer
 
 func SupportedTools() []string
@@ -798,6 +5890,37 @@ type Parser interface{ ... }
     func Parsers() []Parser
 type SourceMigration struct{ ... }
     func Normalize(migrations []SourceMigration) ([]SourceMigration, error)
+
+### github.com/stokaro/ptah/migration/importer.EmitResult
+
+package importer // import "github.com/stokaro/ptah/migration/importer"
+
+type EmitResult struct {
+    // Files are the migration file names written into the output directory, in
+    // apply order (each migration contributes an up and a down file).
+    Files []string
+    // SumFile is the integrity file name refreshed after writing (empty in
+    // dry-run).
+    SumFile string
+    // Remapped reports whether source versions were reassigned to sequential
+    // Ptah versions because at least one did not fit the 10-digit format.
+    Remapped bool
+}
+    EmitResult reports the files an import wrote (or, in dry-run, would write).
+
+func Emit(outDir string, migrations []SourceMigration, opts Options) (*EmitResult, error)
+func Import(sourceFS fs.FS, parser Parser, outDir string, opts Options) (*EmitResult, error)
+
+### github.com/stokaro/ptah/migration/importer.Options
+
+package importer // import "github.com/stokaro/ptah/migration/importer"
+
+type Options struct {
+    // DryRun reports the planned files without writing anything.
+    DryRun bool
+}
+    Options configures an import run.
+
 
 ### github.com/stokaro/ptah/migration/importer.Parser
 
@@ -817,6 +5940,24 @@ type Parser interface {
 func DetectParser(fsys fs.FS) (Parser, error)
 func ParserByName(tool string) (Parser, error)
 func Parsers() []Parser
+
+### github.com/stokaro/ptah/migration/importer.SourceMigration
+
+package importer // import "github.com/stokaro/ptah/migration/importer"
+
+type SourceMigration struct {
+    Version    int64
+    Name       string
+    UpSQL      string
+    DownSQL    string
+    Repeatable bool
+}
+    SourceMigration is one migration read from a source tool's directory,
+    normalized to Ptah's up/down model. Version is the source tool's numeric
+    version (integer counter or timestamp); it is preserved so ordering and
+    collisions are detectable. DownSQL is empty when the source has no rollback.
+
+func Normalize(migrations []SourceMigration) ([]SourceMigration, error)
 
 ## github.com/stokaro/ptah/migration/lint
 
@@ -846,6 +5987,316 @@ type Subject struct{ ... }
 type SubjectKind string
     const SubjectTable SubjectKind = "table" ...
 type VersionSelection struct{ ... }
+
+### github.com/stokaro/ptah/migration/lint.Analysis
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Analysis struct {
+    // Has unexported fields.
+}
+    Analysis is an immutable migration lint result. Its accessors return deep
+    copies, so callers cannot modify the captured files, findings, or source
+    snapshot.
+
+func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error)
+func (a Analysis) Files() []File
+func (a Analysis) Findings() []Finding
+func (a Analysis) SelectedFiles() []File
+func (a Analysis) SnapshotFS() fs.FS
+
+### github.com/stokaro/ptah/migration/lint.CompatibilityProfile
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type CompatibilityProfile string
+    CompatibilityProfile selects command-surface-specific lint semantics.
+
+const CompatibilityProfileNative CompatibilityProfile = "" ...
+
+### github.com/stokaro/ptah/migration/lint.Config
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Config struct {
+    // Dialect is the target dialect used to gate dialect-specific rules;
+    // the --dialect flag overrides it.
+    Dialect string `yaml:"dialect"`
+    // DisabledRules lists rule codes or family prefixes to skip; merged
+    // with --disable flags.
+    DisabledRules []string `yaml:"disabled-rules"`
+    // Rules carries per-rule severity and path-scope overrides.
+    Rules map[string]RuleConfig `yaml:"rules"`
+}
+    Config is the on-disk lint configuration.
+
+    Example .ptah-lint.yaml:
+
+        dialect: postgres
+        disabled-rules:
+          - MF103
+          - MY
+        rules:
+          DS103:
+            severity: warning
+            exclude:
+              - legacy/**
+
+func LoadConfig(path string) (*Config, error)
+func LoadConfigFS(fsys fs.FS, name string) (*Config, error)
+
+### github.com/stokaro/ptah/migration/lint.File
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type File struct {
+    // Path is the file path as it should appear in findings (reporting
+    // prefix included).
+    Path string
+    // Name is the slash-separated path of the file relative to the linted
+    // directory (bare file name for root-level files).
+    Name string
+    // Source is the migration file exactly as captured from the input
+    // filesystem.
+    Source string
+    // SQL is the executable SQL analyzed by the linter. It differs from Source
+    // only when an Atlas SQL template is rendered.
+    SQL string
+    // Version is the parsed migration version, or zero when the name is not
+    // recognized.
+    Version int64
+    // Repeatable reports whether the migrator classifies this as an imported
+    // repeatable migration rather than an ordered version.
+    Repeatable bool
+    // Selected reports whether this file belongs to the requested version
+    // selection. Analysis keeps unselected files so reports can distinguish a
+    // changeset from the complete migration directory.
+    Selected bool
+    // Ignored reports whether the Atlas compatibility profile classified this
+    // file as wholly ignored through a file-header nolint directive. Native
+    // analysis never sets this field.
+    Ignored bool
+    // Direction is the migration direction ("up"/"down") exactly as the
+    // migrator's name parser classifies this file; empty when the migrator
+    // cannot parse the name at all.
+    Direction string
+    // IsUp reports whether statement rules treat this as an up migration:
+    // the migrator parses it as up, or its name carries the .up.sql suffix.
+    IsUp bool
+    // HasPair reports whether the matching counterpart file (down for up,
+    // up for down) exists in the same directory.
+    HasPair bool
+    // WellFormedName reports whether the name matches the documented
+    // NNNNNNNNNN_description.(up|down).sql convention, checked
+    // independently of the migrator's parser as defense in depth (see the
+    // strictNameRe comment).
+    WellFormedName bool
+    // NoTransaction reports whether file-scoped directives opt this migration
+    // out of the migrator's transaction wrapper.
+    NoTransaction bool
+    // Statements holds the parsed statements of up migrations. Empty for
+    // down migrations (statement rules do not run there).
+    Statements []Statement
+    // Has unexported fields.
+}
+    File is one migration file prepared for linting.
+
+
+### github.com/stokaro/ptah/migration/lint.Finding
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Finding struct {
+    Rule     string   `json:"rule"`
+    Title    string   `json:"title"`
+    Severity Severity `json:"severity"`
+    File     string   `json:"file"`
+    // Line is the 1-based line of the offending statement's first token;
+    // zero for file-level findings (naming, pairing).
+    Line    int    `json:"line,omitempty"`
+    Message string `json:"message"`
+    // Context identifies the exact analyzed statement. Renderers should use it
+    // instead of trying to match findings back to statements by line number.
+    Context *FindingContext `json:"context,omitempty"`
+}
+    Finding is one rule hit in one migration file.
+
+func LintFS(fsys fs.FS, opts Options) ([]Finding, error)
+
+### github.com/stokaro/ptah/migration/lint.FindingContext
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type FindingContext struct {
+    StatementIndex int       `json:"statement_index"`
+    Subjects       []Subject `json:"subjects,omitempty"`
+}
+    FindingContext ties a finding to one exact statement and its affected schema
+    objects. File-level findings have a nil context.
+
+
+### github.com/stokaro/ptah/migration/lint.Options
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Options struct {
+    // Compatibility selects command-surface-specific semantics. The zero value
+    // is native Ptah behavior.
+    Compatibility CompatibilityProfile
+    // Dialect gates dialect-specific rules — "postgres" enables PG rules,
+    // "mysql"/"mariadb" enable MY rules — and selects the dialect's lexing
+    // behavior (comment forms, string escape rules, dollar quotes). Empty
+    // runs every rule under a hybrid lexer — maximum visibility when the
+    // target is unknown.
+    Dialect string
+    // Disabled lists rule codes or code prefixes to skip: "DS101" disables
+    // one rule, "DS" the whole data-safety family.
+    Disabled []string
+    // PathPrefix is prepended (with /) to file names in findings so they
+    // point at real repository paths in CI annotations.
+    PathPrefix string
+    // Selection restricts linting to parsed migration versions while retaining
+    // the full captured directory for reporting.
+    Selection VersionSelection
+    // DirFormat selects the migration filename/parser rules used by file-form
+    // linting. Empty uses auto detection.
+    DirFormat migrator.MigrationDirFormat
+    // AtlasTemplateData supplies data for Atlas SQL template migrations.
+    // When nil, templates render with migrator.AtlasTemplateData{}.
+    AtlasTemplateData any
+    // ExtraRules appends caller-provided rules to the built-in registry for
+    // this run. It is the preferred API for out-of-tree analyzers that should
+    // not mutate global process state.
+    ExtraRules []Rule
+    // RuleConfigs carries per-rule severity and path-scoping overrides,
+    // normally loaded from .ptah-lint.yaml.
+    RuleConfigs map[string]RuleConfig
+}
+    Options configures a lint run.
+
+
+### github.com/stokaro/ptah/migration/lint.Rule
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Rule struct {
+    // Code is the stable identifier (DS101, PG101, ...).
+    Code string
+    // Title is the short human-readable name of the hazard.
+    Title string
+    // Severity is the default severity of findings from this rule.
+    Severity Severity
+    // Dialects restricts the rule to specific target dialects; empty means
+    // every dialect.
+    Dialects []string
+    // CheckStatement inspects one statement of an up migration and reports
+    // whether the rule fires, with a specific message.
+    CheckStatement func(stmt *Statement) (bool, string)
+    // CheckFile inspects file-level form and returns full findings.
+    CheckFile func(file *File) []Finding
+}
+    Rule is one lint check. Exactly one of CheckStatement / CheckFile is set.
+
+func Rules() []Rule
+
+### github.com/stokaro/ptah/migration/lint.RuleConfig
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type RuleConfig struct {
+    // Severity overrides the rule's default severity when set.
+    Severity Severity `yaml:"severity,omitempty"`
+    // Exclude lists slash-separated path globs where this rule is skipped.
+    Exclude []string `yaml:"exclude,omitempty"`
+}
+    RuleConfig customizes one rule for a lint run.
+
+
+### github.com/stokaro/ptah/migration/lint.Severity
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Severity = risk.Severity
+    Severity is the urgency of a finding.
+
+const SeverityWarning Severity = risk.Warning ...
+
+### github.com/stokaro/ptah/migration/lint.SourceSpan
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type SourceSpan struct {
+    Start int `json:"start"`
+    End   int `json:"end"`
+}
+    SourceSpan identifies a half-open byte range in File.SQL.
+
+
+### github.com/stokaro/ptah/migration/lint.Statement
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Statement struct {
+    // Index is this statement's stable zero-based position in [File.Statements].
+    Index int
+    // Span is the statement's byte range in [File.SQL].
+    Span SourceSpan
+    // SQL is the raw statement text as written (comments included).
+    SQL string
+    // Canonical is the comment-stripped, whitespace-collapsed, uppercased
+    // display form. String literals keep their original case.
+    Canonical string
+    // Words is the token-word sequence the built-in rules scan: comments and
+    // whitespace dropped, bare keywords/identifiers uppercased, punctuation
+    // as its own entry, string literals and quoted identifiers kept verbatim
+    // as single opaque words (so a literal containing "DROP COLUMN" or a
+    // column named "type" can never impersonate a keyword).
+    Words []string
+    // Line is the 1-based line number of the statement's first token.
+    Line int
+
+    // Has unexported fields.
+}
+    Statement is one SQL statement of a migration file, in the forms rules
+    consume.
+
+
+### github.com/stokaro/ptah/migration/lint.Subject
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type Subject struct {
+    Kind     SubjectKind `json:"kind"`
+    Name     string      `json:"name"`
+    Parent   string      `json:"parent,omitempty"`
+    DataType string      `json:"data_type,omitempty"`
+}
+    Subject identifies one schema object affected by a finding.
+
+
+### github.com/stokaro/ptah/migration/lint.SubjectKind
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type SubjectKind string
+    SubjectKind identifies the kind of schema object affected by a finding.
+
+const SubjectTable SubjectKind = "table" ...
+
+### github.com/stokaro/ptah/migration/lint.VersionSelection
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type VersionSelection struct {
+    // Versions lists selected migration versions.
+    Versions []int64
+    // Restricted reports whether Versions is an explicit selection. When true,
+    // an empty Versions slice selects no migrations.
+    Restricted bool
+}
+    VersionSelection selects migration versions while preserving the difference
+    between no selector and an explicitly empty changeset.
+
 
 ## github.com/stokaro/ptah/migration/migrator
 
@@ -939,6 +6390,335 @@ type StatementObservationError struct{ ... }
 type StatementObserver interface{ ... }
 type StatementObserverFunc func(context.Context, StatementEvent) error
 
+### github.com/stokaro/ptah/migration/migrator.AtlasDownNotImplementedError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type AtlasDownNotImplementedError struct {
+    Version     int64
+    Description string
+}
+    AtlasDownNotImplementedError reports an Atlas migration that lacks an
+    embedded down.sql section. Ptah does not yet synthesize Atlas dynamic down
+    plans from the current database state and a dev database.
+
+func (e *AtlasDownNotImplementedError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.AtlasTemplateData
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type AtlasTemplateData struct {
+    Env string
+}
+    AtlasTemplateData is the default data object used for Atlas SQL templates.
+
+
+### github.com/stokaro/ptah/migration/migrator.BaselineOptions
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type BaselineOptions struct {
+    Version int64
+    Force   bool
+}
+    BaselineOptions configures migration metadata baselining.
+
+
+### github.com/stokaro/ptah/migration/migrator.Check
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type Check struct {
+    Name   string
+    Assert string
+    OnFail OnFail
+}
+    Check is a pre-migration assertion parsed from a `-- +ptah check` directive.
+    Assert is a SQL predicate that must evaluate to a single truthy scalar
+    before the migration body runs; Name labels the check in error output;
+    OnFail selects the failure behavior.
+
+func ParseChecks(sql string) ([]Check, error)
+
+### github.com/stokaro/ptah/migration/migrator.CheckFailedError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type CheckFailedError struct {
+    Version int64
+    Name    string
+    Assert  string
+    // Err is set when the assertion query itself failed to execute (as opposed
+    // to running and returning a falsy result).
+    Err error
+}
+    CheckFailedError reports a pre-migration assertion check that was not
+    satisfied, or whose assertion query could not run. It names the migration
+    version and the check so the operator can see exactly which precondition
+    blocked the migration.
+
+func (e *CheckFailedError) Error() string
+func (e *CheckFailedError) Unwrap() error
+
+### github.com/stokaro/ptah/migration/migrator.CheckpointRollbackError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type CheckpointRollbackError struct {
+    TargetVersion     int64
+    CheckpointVersion int64
+}
+    CheckpointRollbackError reports a rollback that targets a version below an
+    applied checkpoint. The checkpoint squashed the intermediate history into a
+    single snapshot, so that state cannot be reconstructed by rolling back.
+
+func (e *CheckpointRollbackError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.ChecksumMismatchError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type ChecksumMismatchError struct {
+    Version  int64
+    Stored   string
+    Computed string
+}
+    ChecksumMismatchError reports that an already-applied migration file
+    changed.
+
+func (e *ChecksumMismatchError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.DirtyMigrationError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type DirtyMigrationError struct {
+    Revision MigrationRevision
+}
+    DirtyMigrationError reports that a previous migration run left a dirty row.
+
+func (e *DirtyMigrationError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.ExecOrder
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type ExecOrder string
+    ExecOrder controls how the migrator handles unapplied migrations whose
+    version is below the current high-water mark.
+
+const ExecOrderLinear ExecOrder = "linear" ...
+func ParseExecOrder(value string) (ExecOrder, error)
+
+### github.com/stokaro/ptah/migration/migrator.FSMigrationProvider
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type FSMigrationProvider struct {
+    // Has unexported fields.
+}
+    FSMigrationProvider is a migration provider that loads migrations from a
+    filesystem. It scans the filesystem for migration files following the naming
+    convention and automatically creates Migration instances from the SQL files.
+
+func NewFSMigrationProvider(fsys fs.FS, opts ...FSProviderOption) (*FSMigrationProvider, error)
+func (p *FSMigrationProvider) Migrations() []*Migration
+
+### github.com/stokaro/ptah/migration/migrator.FSProviderOption
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type FSProviderOption func(*FSMigrationProvider)
+    FSProviderOption configures a FSMigrationProvider before it loads
+    migrations.
+
+func WithAtlasTemplateData(data any) FSProviderOption
+func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption
+func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
+func WithStatementObserver(observer StatementObserver) FSProviderOption
+
+### github.com/stokaro/ptah/migration/migrator.MigrateUpOptions
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrateUpOptions struct {
+    // TargetVersion limits the run to pending migrations at or below this
+    // version. Zero means latest.
+    TargetVersion int64
+    // Amount limits the run to the first N pending migrations after exec-order
+    // and target-version filtering. Zero means all selected migrations.
+    Amount uint64
+    // AllowDirty skips the default dirty revision guard. Callers should expose
+    // this only as an explicit recovery escape hatch.
+    AllowDirty bool
+    // AssumedAppliedVersions are treated as applied for plan selection without
+    // reading or writing revision metadata. This is intended for dry-run paths
+    // that need to model metadata-only operations such as baseline.
+    AssumedAppliedVersions []int64
+    // Preflight runs after the migration lock is acquired and the final plan is
+    // selected, but before any schema or revision changes.
+    Preflight PreMigrationHook
+}
+    MigrateUpOptions selects the pending up migration plan.
+
+
+### github.com/stokaro/ptah/migration/migrator.Migration
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type Migration struct {
+    Version      int64
+    Description  string
+    Checksum     string
+    Up           MigrationFunc
+    Down         MigrationFunc
+    UpSQL        string
+    DownSQL      string
+    UpTimeouts   MigrationTimeouts
+    DownTimeouts MigrationTimeouts
+
+    // UpNoTransaction runs the up body and metadata update outside the normal
+    // per-migration transaction. Use this only for statements that cannot run
+    // transactionally.
+    UpNoTransaction bool
+    // DownNoTransaction is the down-direction counterpart to UpNoTransaction.
+    DownNoTransaction bool
+    // NoTransaction reports whether either direction opts out of the normal
+    // per-migration transaction. Execution uses the direction-specific fields.
+    NoTransaction bool
+
+    // IsCheckpoint marks a checkpoint migration whose up body is the full
+    // cumulative schema at its version. On a fresh database the migrator
+    // bootstraps from the newest checkpoint and records all lower versions as
+    // applied instead of replaying them; an already-migrated database ignores
+    // the checkpoint and applies history normally.
+    IsCheckpoint bool
+    // Has unexported fields.
+}
+    Migration represents a database migration
+
+func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration
+
+### github.com/stokaro/ptah/migration/migrator.MigrationDirFormat
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationDirFormat string
+    MigrationDirFormat selects how a filesystem migration directory is parsed.
+
+const MigrationDirFormatAuto MigrationDirFormat = "auto" ...
+func ParseMigrationDirFormat(value string) (MigrationDirFormat, error)
+
+### github.com/stokaro/ptah/migration/migrator.MigrationDirection
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationDirection string
+    MigrationDirection identifies the migration direction in a selected plan.
+
+const MigrationDirectionUp MigrationDirection = "up" ...
+
+### github.com/stokaro/ptah/migration/migrator.MigrationExecutionError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationExecutionError struct {
+    Err            error
+    Statement      string
+    StatementIndex int
+    Total          int
+}
+    MigrationExecutionError reports the statement that failed while applying a
+    SQL migration.
+
+func (e *MigrationExecutionError) Error() string
+func (e *MigrationExecutionError) Unwrap() error
+
+### github.com/stokaro/ptah/migration/migrator.MigrationFile
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationFile struct {
+    Path      string
+    Version   int64
+    Name      string
+    Direction string
+    Extension string
+    Format    MigrationDirFormat
+    // Repeatable marks Flyway-style repeatable migrations imported by Atlas.
+    // They are visible to discovery and linting, but they are not part of
+    // Ptah's ordered versioned execution model.
+    Repeatable bool
+    // IsCheckpoint marks a checkpoint migration whose up body is the full
+    // cumulative schema at its version. A fresh database bootstraps from the
+    // newest checkpoint instead of replaying pre-checkpoint history; an
+    // already-migrated database ignores it. The marker is spelled
+    // NNNNNNNNNN_description.checkpoint.(up|down).sql.
+    IsCheckpoint bool
+}
+    MigrationFile represents the parsed components of a migration file name
+
+func DiscoverMigrationFiles(fsys fs.FS, format MigrationDirFormat) ([]MigrationFile, error)
+func ParseAtlasMigrationFileName(filename string) (*MigrationFile, error)
+func ParseAtlasMigrationFileNameForAutoDetection(filename string) (*MigrationFile, error)
+func ParseMigrationFileName(filename string) (*MigrationFile, error)
+
+### github.com/stokaro/ptah/migration/migrator.MigrationFunc
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationFunc func(context.Context, *dbschema.DatabaseConnection) error
+    MigrationFunc represents a migration function that operates on a database
+    connection
+
+func MigrationFuncFromSQLFilename(filename string, fsys fs.FS) MigrationFunc
+func MigrationFuncFromSQLFilenameWithInterceptor(filename string, fsys fs.FS, interceptor StatementInterceptor) MigrationFunc
+
+### github.com/stokaro/ptah/migration/migrator.MigrationLockTimeoutError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationLockTimeoutError struct {
+    Dialect string
+    Name    string
+    Timeout time.Duration
+}
+    MigrationLockTimeoutError reports that another runner held the migration
+    advisory lock longer than this migrator was configured to wait.
+
+func (e *MigrationLockTimeoutError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.MigrationPair
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationPair struct {
+    Up   *MigrationFile
+    Down *MigrationFile
+}
+    MigrationPair represents a pair of up and down migration files for a version
+
+func (mp MigrationPair) GetDescription() string
+func (mp MigrationPair) GetVersion() int64
+func (mp MigrationPair) HasDown() bool
+func (mp MigrationPair) HasUp() bool
+func (mp MigrationPair) IsComplete() bool
+
+### github.com/stokaro/ptah/migration/migrator.MigrationPlan
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationPlan struct {
+    Direction      MigrationDirection
+    CurrentVersion int64
+    TargetVersion  int64
+    Versions       []int64
+}
+    MigrationPlan describes the migration work selected while holding the
+    migration lock.
+
+
 ### github.com/stokaro/ptah/migration/migrator.MigrationProvider
 
 package migrator // import "github.com/stokaro/ptah/migration/migrator"
@@ -948,6 +6728,135 @@ type MigrationProvider interface {
     Migrations() []*Migration
 }
     MigrationProvider provides a list of migrations
+
+
+### github.com/stokaro/ptah/migration/migrator.MigrationRevision
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationRevision struct {
+    Version         int64         `json:"version"`
+    Description     string        `json:"description"`
+    State           string        `json:"state"`
+    Applied         int           `json:"applied"`
+    Total           int           `json:"total"`
+    Error           string        `json:"error,omitempty"`
+    ErrorStatement  string        `json:"error_stmt,omitempty"`
+    ExecutionTime   time.Duration `json:"execution_time"`
+    Checksum        string        `json:"checksum,omitempty"`
+    AppliedAt       time.Time     `json:"applied_at"`
+    OperatorVersion string        `json:"operator_version,omitempty"`
+    Dirty           bool          `json:"dirty"`
+    ChecksumCurrent string        `json:"checksum_current,omitempty"`
+}
+    MigrationRevision records one row from the migration metadata table.
+
+
+### github.com/stokaro/ptah/migration/migrator.MigrationStatus
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationStatus struct {
+    CurrentVersion       int64              `json:"current_version"`
+    AppliedMigrations    []int64            `json:"applied_migrations"`
+    PendingMigrations    []int64            `json:"pending_migrations"`
+    OutOfOrderMigrations []int64            `json:"out_of_order_migrations"`
+    TotalMigrations      int                `json:"total_migrations"`
+    HasPendingChanges    bool               `json:"has_pending_changes"`
+    DirtyRevision        *MigrationRevision `json:"dirty_revision,omitempty"`
+}
+    MigrationStatus represents the current state of migrations
+
+
+### github.com/stokaro/ptah/migration/migrator.MigrationTimeouts
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationTimeouts struct {
+    LockTimeout         time.Duration
+    StatementTimeout    time.Duration
+    HasLockTimeout      bool
+    HasStatementTimeout bool
+}
+    MigrationTimeouts configures per-migration database safety timeouts.
+    Empty values mean no timeout is configured.
+
+func ParseMigrationTimeouts(lockTimeout, statementTimeout string) (MigrationTimeouts, error)
+func (t MigrationTimeouts) IsZero() bool
+
+### github.com/stokaro/ptah/migration/migrator.MigrationTxMode
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type MigrationTxMode string
+    MigrationTxMode controls how pending up migrations are wrapped in
+    transactions.
+
+const MigrationTxModeFile MigrationTxMode = "file" ...
+func ParseMigrationTxMode(value string) (MigrationTxMode, error)
+
+### github.com/stokaro/ptah/migration/migrator.Migrator
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type Migrator struct {
+    // Has unexported fields.
+}
+    Migrator handles database migrations for ptah
+
+func NewFSMigrator(conn *dbschema.DatabaseConnection, fsys fs.FS, opts ...FSProviderOption) (*Migrator, error)
+func NewMigrator(conn *dbschema.DatabaseConnection, provider MigrationProvider) *Migrator
+func (m *Migrator) Baseline(ctx context.Context, version int64) error
+func (m *Migrator) BaselineWithOptions(ctx context.Context, opts BaselineOptions) error
+func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error)
+func (m *Migrator) GetAppliedRevisions(ctx context.Context) ([]MigrationRevision, error)
+func (m *Migrator) GetCurrentVersion(ctx context.Context) (int64, error)
+func (m *Migrator) GetMigrationStatus(ctx context.Context) (status *MigrationStatus, err error)
+func (m *Migrator) GetPendingMigrations(ctx context.Context) ([]int64, error)
+func (m *Migrator) GetPreviousMigrationVersion(ctx context.Context) (int64, error)
+func (m *Migrator) Initialize(ctx context.Context) error
+func (m *Migrator) MigrateDown(ctx context.Context) (err error)
+func (m *Migrator) MigrateDownTo(ctx context.Context, targetVersion int64) error
+func (m *Migrator) MigrateDownToWithPreflight(ctx context.Context, targetVersion int64, hook PreMigrationHook) (err error)
+func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int64) (err error)
+func (m *Migrator) MigrateUp(ctx context.Context) error
+func (m *Migrator) MigrateUpWithOptions(ctx context.Context, opts MigrateUpOptions) (err error)
+func (m *Migrator) MigrateUpWithPreflight(ctx context.Context, hook PreMigrationHook) (err error)
+func (m *Migrator) MigrationProvider() MigrationProvider
+func (m *Migrator) MigrationsTableIdentifier() string
+func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOptions) error
+func (m *Migrator) WithDefaultTimeouts(timeouts MigrationTimeouts) *Migrator
+func (m *Migrator) WithExecOrder(execOrder ExecOrder) *Migrator
+func (m *Migrator) WithLogger(l *slog.Logger) *Migrator
+func (m *Migrator) WithMigrationLockName(name string) *Migrator
+func (m *Migrator) WithMigrationLockTimeout(timeout time.Duration) *Migrator
+func (m *Migrator) WithMigrationsTable(schema, table string) *Migrator
+func (m *Migrator) WithObserver(observer Observer) *Migrator
+func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator
+func (m *Migrator) WithSkipChecks(skip bool) *Migrator
+func (m *Migrator) WithTransactionMode(mode MigrationTxMode) *Migrator
+
+### github.com/stokaro/ptah/migration/migrator.NoopObserver
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type NoopObserver struct{}
+    NoopObserver discards all migration observability events.
+
+func (NoopObserver) AddCounter(context.Context, string, int64, ...ObservationAttribute)
+func (NoopObserver) RecordDuration(context.Context, string, time.Duration, ...ObservationAttribute)
+func (NoopObserver) StartSpan(ctx context.Context, _ string, _ ...ObservationAttribute) (context.Context, ObservationSpan)
+
+### github.com/stokaro/ptah/migration/migrator.ObservationAttribute
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type ObservationAttribute struct {
+    Key   string
+    Value any
+}
+    ObservationAttribute is a structured attribute attached to migration
+    observability events.
 
 
 ### github.com/stokaro/ptah/migration/migrator.ObservationSpan
@@ -971,6 +6880,94 @@ type Observer interface {
     RecordDuration(ctx context.Context, name string, duration time.Duration, attrs ...ObservationAttribute)
 }
     Observer receives migration tracing and metrics events.
+
+
+### github.com/stokaro/ptah/migration/migrator.OnFail
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type OnFail string
+    OnFail selects what a failing check does. Only abort is supported today:
+    the migration is aborted before any body statement runs, leaving nothing
+    applied on the transactional path.
+
+const OnFailAbort OnFail = "abort"
+
+### github.com/stokaro/ptah/migration/migrator.OutOfOrderError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type OutOfOrderError struct {
+    CurrentVersion int64
+    Versions       []int64
+}
+    OutOfOrderError reports pending migrations that are below the current
+    high-water mark while linear execution is required.
+
+func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
+func (e *OutOfOrderError) Error() string
+
+### github.com/stokaro/ptah/migration/migrator.PreMigrationHook
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type PreMigrationHook func(ctx context.Context, plan MigrationPlan) error
+    PreMigrationHook runs after the migrator has acquired its migration lock and
+    selected the final migration plan, but before it changes schema or revision
+    state.
+
+
+### github.com/stokaro/ptah/migration/migrator.RegisteredMigrationProvider
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type RegisteredMigrationProvider struct {
+    // Has unexported fields.
+}
+    RegisteredMigrationProvider is a simple in-memory implementation of
+    MigrationProvider
+
+func NewRegisteredMigrationProvider(migrations ...*Migration) *RegisteredMigrationProvider
+func (p *RegisteredMigrationProvider) Migrations() []*Migration
+func (p *RegisteredMigrationProvider) Register(migration *Migration)
+
+### github.com/stokaro/ptah/migration/migrator.RepairMigrationOptions
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type RepairMigrationOptions struct {
+    Version    int64
+    Force      bool
+    ResumeFrom int
+}
+    RepairMigrationOptions configures migration metadata repair.
+
+
+### github.com/stokaro/ptah/migration/migrator.RevisionTableFormat
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type RevisionTableFormat string
+    RevisionTableFormat selects the database table layout used for migration
+    revision metadata.
+
+const RevisionTableFormatPtah RevisionTableFormat = "ptah" ...
+func ParseRevisionTableFormat(value string) (RevisionTableFormat, error)
+
+### github.com/stokaro/ptah/migration/migrator.StatementEvent
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementEvent struct {
+    SourcePath string
+    Statement  string
+    Index      int
+    Total      int
+    Directives map[string]string
+}
+    StatementEvent describes one successfully executed migration statement.
+    Directives is an event-local copy; observers may modify it without affecting
+    migration execution or later events.
 
 
 ### github.com/stokaro/ptah/migration/migrator.StatementInterceptor
@@ -997,6 +6994,20 @@ type StatementInterceptor interface {
     normally. A non-nil error aborts the migration.
 
 
+### github.com/stokaro/ptah/migration/migrator.StatementObservationError
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementObservationError struct {
+    Err   error
+    Event StatementEvent
+}
+    StatementObservationError reports a post-execution observer failure.
+    The statement in Event was applied before the observer returned Err.
+
+func (e *StatementObservationError) Error() string
+func (e *StatementObservationError) Unwrap() error
+
 ### github.com/stokaro/ptah/migration/migrator.StatementObserver
 
 package migrator // import "github.com/stokaro/ptah/migration/migrator"
@@ -1008,6 +7019,15 @@ type StatementObserver interface {
     called after either an interceptor or the normal migrator path executes the
     statement. Returning an error aborts the migration.
 
+
+### github.com/stokaro/ptah/migration/migrator.StatementObserverFunc
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementObserverFunc func(context.Context, StatementEvent) error
+    StatementObserverFunc adapts a function to StatementObserver.
+
+func (f StatementObserverFunc) ObserveStatement(ctx context.Context, event StatementEvent) error
 
 ## github.com/stokaro/ptah/migration/planner
 
@@ -1030,6 +7050,39 @@ type Planner interface{ ... }
     func GetPlanner(dialect string) (Planner, error)
     func GetPlannerWithCapabilities(dialect string, caps capability.Capabilities) (Planner, error)
     func GetPlannerWithOptions(dialect string, opts Options) (Planner, error)
+
+### github.com/stokaro/ptah/migration/planner.Factory
+
+package planner // import "github.com/stokaro/ptah/migration/planner"
+
+type Factory func(Options) Planner
+    Factory creates a planner for a dialect from construction options.
+
+
+### github.com/stokaro/ptah/migration/planner.Options
+
+package planner // import "github.com/stokaro/ptah/migration/planner"
+
+type Options struct {
+    // Capabilities describes the concrete target server. Nil means the
+    // dialect's default capability preset.
+    Capabilities capability.Capabilities
+    // ConcurrentIndexes requests PostgreSQL CREATE INDEX CONCURRENTLY for all
+    // newly added indexes when the target supports it.
+    ConcurrentIndexes bool
+    // ConcurrentIndexRefs requests PostgreSQL CREATE INDEX CONCURRENTLY for
+    // exactly these table-qualified newly added indexes when the target
+    // supports it.
+    ConcurrentIndexRefs []types.IndexRef
+    // SkipChangeKinds lists destructive change kinds the planner must omit from
+    // the plan (emitting a clearly-marked comment in their place) instead of
+    // deferring to the coarse destructive gate. Currently honored by the
+    // PostgreSQL-family planner.
+    SkipChangeKinds []diffpolicy.ChangeKind
+}
+    Options configures high-level planner helpers.
+
+func (o Options) CapabilitiesFor(dialect string) capability.Capabilities
 
 ### github.com/stokaro/ptah/migration/planner.Planner
 
@@ -1101,6 +7154,15 @@ func SARIFLevel(severity Severity) string
 type Severity string
     const Safe Severity = "safe" ...
 
+### github.com/stokaro/ptah/migration/risk.Severity
+
+package risk // import "github.com/stokaro/ptah/migration/risk"
+
+type Severity string
+    Severity is the shared risk level type used by lint and safety reports.
+
+const Safe Severity = "safe" ...
+
 ## github.com/stokaro/ptah/migration/safety
 
 func HasDestructive(findings []Finding) bool
@@ -1123,6 +7185,63 @@ type StatementAssessment struct{ ... }
     func AssessRendered(nodes []ast.Node, dialect string) ([]StatementAssessment, error)
     func AssessRenderedWithCapabilities(nodes []ast.Node, dialect string, caps capability.Capabilities) ([]StatementAssessment, error)
     func AssessSQL(statement string) StatementAssessment
+
+### github.com/stokaro/ptah/migration/safety.Finding
+
+package safety // import "github.com/stokaro/ptah/migration/safety"
+
+type Finding struct {
+    Category string   `json:"category"`
+    Count    int      `json:"count"`
+    Severity Severity `json:"severity"`
+}
+    Finding summarizes one non-empty schema-diff category.
+
+func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding
+
+### github.com/stokaro/ptah/migration/safety.Report
+
+package safety // import "github.com/stokaro/ptah/migration/safety"
+
+type Report struct {
+    Highest     Severity              `json:"highest"`
+    Destructive bool                  `json:"destructive"`
+    Assessments []StatementAssessment `json:"assessments"`
+}
+    Report is the machine-readable safety report envelope.
+
+func NewReport(assessments []StatementAssessment) Report
+
+### github.com/stokaro/ptah/migration/safety.Severity
+
+package safety // import "github.com/stokaro/ptah/migration/safety"
+
+type Severity = risk.Severity
+    Severity is the operational risk level for a schema change.
+
+const Safe Severity = risk.Safe ...
+func Classify(node ast.Node) Severity
+func Highest(findings []Finding) Severity
+func HighestAssessment(assessments []StatementAssessment) Severity
+
+### github.com/stokaro/ptah/migration/safety.StatementAssessment
+
+package safety // import "github.com/stokaro/ptah/migration/safety"
+
+type StatementAssessment struct {
+    Index     int      `json:"index"`
+    NodeType  string   `json:"node_type"`
+    Subject   string   `json:"subject,omitempty"`
+    Statement string   `json:"statement,omitempty"`
+    Severity  Severity `json:"severity"`
+    Reason    string   `json:"reason"`
+}
+    StatementAssessment classifies one generated migration statement.
+
+func Assess(nodes []ast.Node) []StatementAssessment
+func AssessRendered(nodes []ast.Node, dialect string) ([]StatementAssessment, error)
+func AssessRenderedWithCapabilities(nodes []ast.Node, dialect string, caps capability.Capabilities) ([]StatementAssessment, error)
+func AssessSQL(statement string) StatementAssessment
 
 ## github.com/stokaro/ptah/migration/schemadiff
 
@@ -1152,6 +7271,717 @@ type TriggerDiff struct{ ... }
 type TriggerRef struct{ ... }
 type ViewDiff struct{ ... }
 
+### github.com/stokaro/ptah/migration/schemadiff/types.ColumnDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type ColumnDiff struct {
+    // ColumnName is the name of the column being modified
+    ColumnName string `json:"column_name"`
+
+    // Changes maps change types to their old->new value transitions
+    // Format: "change_type" -> "old_value -> new_value"
+    Changes map[string]string `json:"changes"`
+}
+    ColumnDiff represents specific property changes within a database column.
+
+    This structure captures the detailed differences between the current column
+    definition and the target column definition. Each change is represented as a
+    key-value pair showing the transition from old value to new value.
+
+    # Change Types
+
+    Common change types include:
+      - "type": Data type changes (e.g., "VARCHAR(100) -> VARCHAR(255)")
+      - "nullable": Nullability changes (e.g., "true -> false")
+      - "primary_key": Primary key constraint changes (e.g., "false -> true")
+      - "unique": Unique constraint changes (e.g., "false -> true")
+      - "default": Default value changes (e.g., "'old' -> 'new'")
+
+    # Example Usage
+
+        columnDiff := ColumnDiff{
+            ColumnName: "email",
+            Changes: map[string]string{
+                "type": "VARCHAR(100) -> VARCHAR(255)",
+                "nullable": "true -> false",
+                "unique": "false -> true",
+            },
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.CompositeTypeDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type CompositeTypeDiff struct {
+    TypeName string            `json:"type_name"`
+    Changes  map[string]string `json:"changes"`
+}
+    CompositeTypeDiff represents changes to a PostgreSQL composite type.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.ConstraintAdditionInfo
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type ConstraintAdditionInfo struct {
+    // Name is the name of the constraint to be added.
+    Name string `json:"name"`
+
+    // TableName is the concrete database table the constraint is added to.
+    TableName string `json:"table_name"`
+
+    // Type is the constraint type (FOREIGN KEY, CHECK, UNIQUE, ...).
+    Type string `json:"type"`
+
+    // Columns are the local columns the constraint covers (UNIQUE columns or FK
+    // source columns).
+    Columns []string `json:"columns,omitempty"`
+    // IncludeColumns carries PostgreSQL INCLUDE columns for covering UNIQUE and
+    // PRIMARY KEY constraints.
+    IncludeColumns []string `json:"include_columns,omitempty"`
+    // NullsDistinct carries PostgreSQL UNIQUE NULLS [NOT] DISTINCT state.
+    // Nil means the clause was not specified.
+    NullsDistinct *bool `json:"nulls_distinct,omitempty"`
+    // CheckExpression is the CHECK predicate body (CHECK only).
+    CheckExpression string `json:"check_expression,omitempty"`
+
+    // ForeignTable / ForeignColumn / ForeignColumns describe the FK target
+    // (FOREIGN KEY only). ForeignColumn is kept for compatibility with older
+    // single-column callers; ForeignColumns carries the full referenced column
+    // list for composite keys.
+    ForeignTable   string   `json:"foreign_table,omitempty"`
+    ForeignColumn  string   `json:"foreign_column,omitempty"`
+    ForeignColumns []string `json:"foreign_columns,omitempty"`
+
+    // OnDelete / OnUpdate are the referential actions (FOREIGN KEY only).
+    OnDelete string `json:"on_delete,omitempty"`
+    OnUpdate string `json:"on_update,omitempty"`
+}
+    ConstraintAdditionInfo contains the table-qualified definition of a
+    constraint that needs to be added, in parallel to the bare ConstraintsAdded
+    name list (mirroring ConstraintsRemovedWithTables).
+
+    This exists because a field-level FOREIGN KEY whose constraint name repeats
+    across several tables cannot be resolved from the name alone. The canonical
+    case is an embedded inline-relation mixin: a shared base struct that carries
+    `foreign=` fields (e.g. tenant_id with foreign_key_name="fk_entity_tenant")
+    and is embedded into many concrete tables, so the same FK name legitimately
+    lands on every host table. The mixin's Go struct name is not a table,
+    so a planner that re-derives the table from the field's StructName emits
+    `ALTER TABLE <MixinStruct> ...` once per host, all collapsed onto the bogus
+    name (issue #197). Carrying the concrete table (and the full FK definition)
+    here lets the planner emit one correct ALTER TABLE per real host table.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.ConstraintRemovalInfo
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type ConstraintRemovalInfo struct {
+    // Name is the name of the constraint to be removed
+    Name string `json:"name"`
+
+    // TableName is the name of the table that the constraint belongs to
+    TableName string `json:"table_name"`
+
+    // Type is the constraint type (FOREIGN KEY, CHECK, UNIQUE, PRIMARY KEY, ...)
+    Type string `json:"type"`
+}
+    ConstraintRemovalInfo contains information about a constraint that needs
+    to be removed, including the constraint name, the table it belongs to,
+    and its type.
+
+    This is needed for databases like MySQL/MariaDB that require both the table
+    name and a type-specific drop syntax — e.g. FOREIGN KEY constraints are
+    dropped with `ALTER TABLE <table> DROP FOREIGN KEY <name>` rather than `DROP
+    CONSTRAINT`. The plain ConstraintsRemoved name list discards the table name,
+    which the comparator does know at diff time, so it is preserved here in
+    parallel.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.DomainDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type DomainDiff struct {
+    DomainName string            `json:"domain_name"`
+    Changes    map[string]string `json:"changes"`
+}
+    DomainDiff represents changes to a PostgreSQL domain type.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.EnumDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type EnumDiff struct {
+    // EnumName is the name of the enum type being modified
+    EnumName string `json:"enum_name"`
+
+    // ValuesAdded contains enum values that need to be added to the enum type
+    ValuesAdded []string `json:"values_added"`
+
+    // ValuesRemoved contains enum values that need to be removed from the enum type
+    // (may not be supported by all databases - see database limitations above)
+    ValuesRemoved []string `json:"values_removed"`
+}
+    EnumDiff represents changes to enum type values.
+
+    This structure captures modifications to enum types, specifically the
+    addition and removal of enum values. It's important to note that not all
+    databases support enum value removal without recreating the entire enum
+    type.
+
+    # Database Limitations
+
+      - **PostgreSQL**: Supports adding enum values but not removing them
+        without recreating the enum
+      - **MySQL/MariaDB**: Supports both adding and removing enum values with
+        ALTER TABLE
+      - **SQLite**: No native enum support - uses CHECK constraints
+
+    # Example Usage
+
+        enumDiff := EnumDiff{
+            EnumName: "status_type",
+            ValuesAdded: []string{"pending", "archived"},
+            ValuesRemoved: []string{"deprecated"},
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.FunctionDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type FunctionDiff struct {
+    // FunctionName is the name of the function being modified
+    FunctionName string `json:"function_name"`
+
+    // Changes maps change types to their old->new value transitions
+    // Format: "change_type" -> "old_value -> new_value"
+    Changes map[string]string `json:"changes"`
+}
+    FunctionDiff represents changes to PostgreSQL function definitions.
+
+    This structure captures modifications to function definitions, including
+    changes to parameters, return types, function body, and function attributes
+    like security and volatility. Function modifications typically require
+    dropping and recreating the function in PostgreSQL.
+
+    # Function Change Types
+
+    Common function changes include:
+      - **Parameters**: Changes to function parameter list
+      - **Returns**: Changes to return type
+      - **Body**: Changes to function implementation
+      - **Language**: Changes to function language (rare)
+      - **Security**: Changes between DEFINER and INVOKER
+      - **Volatility**: Changes between STABLE, IMMUTABLE, and VOLATILE
+
+    # Example Usage
+
+        functionDiff := FunctionDiff{
+            FunctionName: "get_user_count",
+            Changes: map[string]string{
+                "parameters": "() -> (tenant_id TEXT)",
+                "body": "SELECT COUNT(*) FROM users -> SELECT COUNT(*) FROM users WHERE tenant_id = tenant_id_param",
+                "volatility": "VOLATILE -> STABLE",
+            },
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.GrantRef
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type GrantRef struct {
+    // Role is the role receiving or losing the privilege.
+    Role string `json:"role"`
+
+    // Privilege is the individual privilege, e.g. SELECT, INSERT, or USAGE.
+    Privilege string `json:"privilege"`
+
+    // ObjectType is the target kind: TABLE, SCHEMA, or SEQUENCE.
+    ObjectType string `json:"object_type"`
+
+    // ObjectName is the target table or schema name.
+    ObjectName string `json:"object_name"`
+
+    // WithOption records whether the grant has WITH GRANT OPTION.
+    WithOption bool `json:"with_option"`
+}
+    GrantRef identifies one PostgreSQL privilege grant.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.IndexRef
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type IndexRef struct {
+    // Name is the raw, unqualified index identifier. TableName carries the
+    // namespace used by schema-scoped dialects.
+    Name string `json:"name"`
+
+    // TableName is the qualified name of the table that owns the index.
+    TableName string `json:"table_name"`
+}
+    IndexRef identifies an index together with its owning table. Table-qualified
+    identity is required for dialects such as MySQL and MariaDB, where index
+    names are scoped to a table rather than the database.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.MaterializedViewDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type MaterializedViewDiff struct {
+    ViewName string            `json:"view_name"`
+    Changes  map[string]string `json:"changes"`
+}
+    MaterializedViewDiff represents changes to a materialized view definition.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.RLSPolicyDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type RLSPolicyDiff struct {
+    // PolicyName is the name of the RLS policy being modified
+    PolicyName string `json:"policy_name"`
+
+    // TableName is the name of the table the policy applies to
+    TableName string `json:"table_name"`
+
+    // Changes maps change types to their old->new value transitions
+    // Format: "change_type" -> "old_value -> new_value"
+    Changes map[string]string `json:"changes"`
+}
+    RLSPolicyDiff represents changes to Row-Level Security policy definitions.
+
+    This structure captures modifications to RLS policies, including changes to
+    policy expressions, target roles, and policy types. RLS policy modifications
+    typically require dropping and recreating the policy in PostgreSQL.
+
+    # Policy Change Types
+
+    Common policy changes include:
+      - **PolicyFor**: Changes to policy type (SELECT, INSERT, UPDATE, DELETE,
+        ALL)
+      - **ToRoles**: Changes to target database roles
+      - **UsingExpression**: Changes to USING clause expression
+      - **WithCheckExpression**: Changes to WITH CHECK clause expression
+
+    # Example Usage
+
+        policyDiff := RLSPolicyDiff{
+            PolicyName: "user_tenant_isolation",
+            TableName: "users",
+            Changes: map[string]string{
+                "using_expression": "tenant_id = current_user_id() -> tenant_id = get_current_tenant_id()",
+                "to_roles": "app_user -> app_user,admin_user",
+            },
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.RLSPolicyRef
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type RLSPolicyRef struct {
+    // PolicyName is the name of the RLS policy
+    PolicyName string `json:"policy_name"`
+
+    // TableName is the name of the table the policy applies to
+    TableName string `json:"table_name"`
+}
+    RLSPolicyRef represents a reference to an RLS policy with its table
+    information.
+
+    This structure is used to identify RLS policies that need to be dropped,
+    providing both the policy name and the table it belongs to. This is
+    necessary because PostgreSQL requires both pieces of information for DROP
+    POLICY statements.
+
+    # Example Usage
+
+        policyRef := RLSPolicyRef{
+            PolicyName: "user_tenant_isolation",
+            TableName: "users",
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.RoleDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type RoleDiff struct {
+    // RoleName is the name of the role being modified
+    RoleName string `json:"role_name"`
+
+    // Changes maps change types to their old->new value transitions
+    // Format: "change_type" -> "old_value -> new_value"
+    Changes map[string]string `json:"changes"`
+}
+    RoleDiff represents changes to PostgreSQL role definitions.
+
+    This structure captures modifications to role definitions, including changes
+    to role attributes such as login capabilities, passwords, privileges,
+    and other role properties. Role modifications typically require ALTER ROLE
+    statements in PostgreSQL.
+
+    # Role Change Types
+
+    Common role changes include:
+      - **Login**: Changes to login capability (true -> false or false -> true)
+      - **Password**: Changes to role password (encrypted)
+      - **Superuser**: Changes to superuser status (true -> false or false ->
+        true)
+      - **CreateDB**: Changes to database creation capability
+      - **CreateRole**: Changes to role creation capability
+      - **Inherit**: Changes to privilege inheritance
+      - **Replication**: Changes to replication capability
+
+    # Example Usage
+
+        roleDiff := RoleDiff{
+            RoleName: "app_user",
+            Changes: map[string]string{
+                "login": "false -> true",
+                "password": "old_encrypted_password -> new_encrypted_password",
+                "createdb": "false -> true",
+            },
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.SchemaDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type SchemaDiff struct {
+    // TablesAdded contains names of tables that exist in the target schema
+    // but not in the current database schema
+    TablesAdded []string `json:"tables_added"`
+
+    // TablesRemoved contains names of tables that exist in the current database
+    // but not in the target schema (potentially dangerous - data loss)
+    TablesRemoved []string `json:"tables_removed"`
+
+    // TablesModified contains detailed information about tables that exist in both
+    // schemas but have structural differences (columns, constraints, etc.)
+    TablesModified []TableDiff `json:"tables_modified"`
+
+    // EnumsAdded contains names of enum types that exist in the target schema
+    // but not in the current database schema
+    EnumsAdded []string `json:"enums_added"`
+
+    // EnumsRemoved contains names of enum types that exist in the current database
+    // but not in the target schema (potentially dangerous - may break existing data)
+    EnumsRemoved []string `json:"enums_removed"`
+
+    // EnumsModified contains detailed information about enum types that exist in both
+    // schemas but have different values (additions/removals)
+    EnumsModified []EnumDiff `json:"enums_modified"`
+
+    // IndexesAdded contains table-qualified indexes that exist in the target
+    // schema but not in the current database schema.
+    IndexesAdded []IndexRef `json:"indexes_added"`
+
+    // IndexesRemoved contains table-qualified indexes that exist in the current
+    // database but not in the target schema. Removing them may affect query
+    // plans or uniqueness protections.
+    IndexesRemoved []IndexRef `json:"indexes_removed"`
+
+    // ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
+    // but not in the current database schema
+    ExtensionsAdded []string `json:"extensions_added"`
+
+    // ExtensionsRemoved contains names of PostgreSQL extensions that exist in the current database
+    // but not in the target schema (potentially dangerous - may break existing functionality)
+    ExtensionsRemoved []string `json:"extensions_removed"`
+
+    // FunctionsAdded contains names of PostgreSQL functions that exist in the target schema
+    // but not in the current database schema
+    FunctionsAdded []string `json:"functions_added"`
+
+    // FunctionsRemoved contains names of PostgreSQL functions that exist in the current database
+    // but not in the target schema (potentially dangerous - may break existing functionality)
+    FunctionsRemoved []string `json:"functions_removed"`
+
+    // FunctionsModified contains detailed information about functions that exist in both
+    // schemas but have different definitions (parameters, body, attributes, etc.)
+    FunctionsModified []FunctionDiff `json:"functions_modified"`
+
+    // SequencesAdded contains names of standalone sequences that exist in the target
+    // schema but not in the current database schema.
+    SequencesAdded []string `json:"sequences_added"`
+
+    // SequencesRemoved contains names of standalone sequences that exist in the current
+    // database but not in the target schema (potentially dangerous - may break defaults).
+    SequencesRemoved []string `json:"sequences_removed"`
+
+    // SequencesModified contains detailed information about sequences that exist in both
+    // schemas but have different options (increment, cache, cycle, ownership, etc.).
+    SequencesModified []SequenceDiff `json:"sequences_modified"`
+
+    // DomainsAdded/Removed/Modified track PostgreSQL domain types.
+    DomainsAdded    []string     `json:"domains_added"`
+    DomainsRemoved  []string     `json:"domains_removed"`
+    DomainsModified []DomainDiff `json:"domains_modified"`
+
+    // CompositeTypesAdded/Removed/Modified track PostgreSQL composite types.
+    CompositeTypesAdded    []string            `json:"composite_types_added"`
+    CompositeTypesRemoved  []string            `json:"composite_types_removed"`
+    CompositeTypesModified []CompositeTypeDiff `json:"composite_types_modified"`
+
+    // RangesAdded/Removed track PostgreSQL range types. Ranges have no in-place
+    // alter, so there is no Modified category (a change is drop + recreate).
+    RangesAdded   []string `json:"ranges_added"`
+    RangesRemoved []string `json:"ranges_removed"`
+
+    // ViewsAdded contains names of views that exist in the target schema
+    // but not in the current database schema.
+    ViewsAdded []string `json:"views_added"`
+
+    // ViewsRemoved contains names of views that exist in the current database
+    // but not in the target schema.
+    ViewsRemoved []string `json:"views_removed"`
+
+    // ViewsModified contains detailed information about views with changed definitions.
+    ViewsModified []ViewDiff `json:"views_modified"`
+
+    // MaterializedViewsAdded contains names of materialized views that exist in the target schema
+    // but not in the current database schema.
+    MaterializedViewsAdded []string `json:"materialized_views_added"`
+
+    // MaterializedViewsRemoved contains names of materialized views that exist in the current database
+    // but not in the target schema.
+    MaterializedViewsRemoved []string `json:"materialized_views_removed"`
+
+    // MaterializedViewsModified contains detailed information about changed materialized views.
+    MaterializedViewsModified []MaterializedViewDiff `json:"materialized_views_modified"`
+
+    // TriggersAdded contains table-qualified trigger refs that exist in the target schema
+    // but not in the current database schema.
+    TriggersAdded []TriggerRef `json:"triggers_added"`
+
+    // TriggersRemoved contains table-qualified trigger refs that exist in the current database
+    // but not in the target schema.
+    TriggersRemoved []TriggerRef `json:"triggers_removed"`
+
+    // TriggersModified contains detailed information about changed triggers.
+    TriggersModified []TriggerDiff `json:"triggers_modified"`
+
+    // RLSPoliciesAdded contains names of RLS policies that exist in the target schema
+    // but not in the current database schema
+    RLSPoliciesAdded []string `json:"rls_policies_added"`
+
+    // RLSPoliciesRemoved contains RLS policies that exist in the current database
+    // but not in the target schema (may remove an access-control protection)
+    RLSPoliciesRemoved []RLSPolicyRef `json:"rls_policies_removed"`
+
+    // RLSPoliciesModified contains detailed information about RLS policies that exist in both
+    // schemas but have different definitions (expressions, roles, etc.)
+    RLSPoliciesModified []RLSPolicyDiff `json:"rls_policies_modified"`
+
+    // RLSEnabledTablesAdded contains names of tables that need RLS enabled
+    RLSEnabledTablesAdded []string `json:"rls_enabled_tables_added"`
+
+    // RLSEnabledTablesRemoved contains names of tables that need RLS disabled
+    // (potentially dangerous - removes row-level security)
+    RLSEnabledTablesRemoved []string `json:"rls_enabled_tables_removed"`
+
+    // RolesAdded contains names of PostgreSQL roles that exist in the target schema
+    // but not in the current database schema
+    RolesAdded []string `json:"roles_added"`
+
+    // RolesRemoved contains names of PostgreSQL roles that exist in the current database
+    // but not in the target schema (potentially dangerous - may break existing functionality)
+    RolesRemoved []string `json:"roles_removed"`
+
+    // RolesModified contains detailed information about roles that exist in both
+    // schemas but have different definitions (attributes, passwords, etc.)
+    RolesModified []RoleDiff `json:"roles_modified"`
+
+    // GrantsAdded contains PostgreSQL privilege grants that exist in the target
+    // schema but not in the current database schema.
+    GrantsAdded []GrantRef `json:"grants_added"`
+
+    // GrantsRemoved contains PostgreSQL privilege grants that exist in the current
+    // database schema for managed roles but not in the target schema.
+    GrantsRemoved []GrantRef `json:"grants_removed"`
+
+    // GrantOptionsAdded contains PostgreSQL privileges whose WITH GRANT OPTION
+    // flag exists in the target schema but not in the current database schema.
+    GrantOptionsAdded []GrantRef `json:"grant_options_added"`
+
+    // GrantOptionsRevoked contains PostgreSQL privileges whose WITH GRANT OPTION
+    // flag exists in the database but not in the target schema.
+    GrantOptionsRevoked []GrantRef `json:"grant_options_revoked"`
+
+    // ConstraintsAdded contains names of constraints that exist in the target schema
+    // but not in the current database schema
+    ConstraintsAdded []string `json:"constraints_added"`
+
+    // ConstraintsAddedWithTables contains the table-qualified definitions of the
+    // constraints in ConstraintsAdded. It is NOT index-aligned with
+    // ConstraintsAdded — each list is sorted independently (ConstraintsAdded by
+    // name, this one by table then name), so consumers must correlate entries
+    // by constraint name, never by position. Planners read this to add a
+    // field-level FK to its concrete host table rather than re-deriving the
+    // table from a Go struct name — which breaks for FK names shared across
+    // the many tables that embed an inline-relation mixin (issue #197).
+    ConstraintsAddedWithTables []ConstraintAdditionInfo `json:"constraints_added_with_tables"`
+
+    // ConstraintsRemoved contains names of constraints that exist in the current database
+    // but not in the target schema (potentially dangerous - may affect data integrity)
+    ConstraintsRemoved []string `json:"constraints_removed"`
+
+    // ConstraintsRemovedWithTables contains detailed information about constraints that
+    // need to be removed, including the constraint name, owning table, and type. This is
+    // used by database dialects that require the table name and a type-specific drop
+    // syntax (e.g. MySQL/MariaDB FOREIGN KEY constraints use DROP FOREIGN KEY). It is
+    // NOT index-aligned with ConstraintsRemoved — each list is sorted independently
+    // (ConstraintsRemoved by name, this one by table then name), so consumers must
+    // correlate entries by constraint name, never by position.
+    ConstraintsRemovedWithTables []ConstraintRemovalInfo `json:"constraints_removed_with_tables"`
+}
+    SchemaDiff represents comprehensive differences between two database
+    schemas.
+
+    This structure captures all types of schema changes that can occur between
+    a target schema (generated from Go struct annotations) and an existing
+    database schema. It provides a complete picture of what needs to be modified
+    to bring the database schema in line with the application's expected schema.
+
+    # Structure Organization
+
+    The diff is organized by database object type for clear categorization:
+      - Tables: New, removed, and modified table structures
+      - Enums: New, removed, and modified enum types
+      - Indexes: New and removed database indexes
+
+    # JSON Serialization
+
+    All fields are JSON-serializable for integration with external tools,
+    CI/CD pipelines, and migration management systems.
+
+    # Example Usage
+
+        diff := &SchemaDiff{
+            TablesAdded: []string{"users", "posts"},
+            TablesModified: []TableDiff{
+                {TableName: "products", ColumnsAdded: []string{"price", "category"}},
+            },
+            EnumsAdded: []string{"status_type"},
+        }
+
+        if diff.HasChanges() {
+            fmt.Printf("Found %d new tables\n", len(diff.TablesAdded))
+        }
+
+func (d *SchemaDiff) HasChanges() bool
+func (d *SchemaDiff) IndexAdditions() []IndexRef
+func (d *SchemaDiff) IndexRemovals() []IndexRef
+func (d *SchemaDiff) SetIndexAdditions(refs []IndexRef)
+func (d *SchemaDiff) SetIndexRemovals(refs []IndexRef)
+
+### github.com/stokaro/ptah/migration/schemadiff/types.SequenceDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type SequenceDiff struct {
+    // SequenceName is the (optionally schema-qualified) name of the sequence.
+    SequenceName string `json:"sequence_name"`
+
+    // Changes maps change types to their old->new value transitions
+    // Format: "change_type" -> "old_value -> new_value"
+    Changes map[string]string `json:"changes"`
+}
+    SequenceDiff represents changes to a standalone sequence definition.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.TableDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type TableDiff struct {
+    // TableName is the name of the table being modified
+    TableName string `json:"table_name"`
+
+    // ColumnsAdded contains names of columns that need to be added to the table
+    ColumnsAdded []string `json:"columns_added"`
+
+    // ColumnsRemoved contains names of columns that need to be removed from the table
+    // (potentially dangerous - may cause data loss)
+    ColumnsRemoved []string `json:"columns_removed"`
+
+    // ColumnsModified contains detailed information about columns that exist in both
+    // schemas but have different properties (type, constraints, defaults, etc.)
+    ColumnsModified []ColumnDiff `json:"columns_modified"`
+
+    // ConstraintsAdded contains names of constraints that need to be added to the table
+    ConstraintsAdded []string `json:"constraints_added"`
+
+    // ConstraintsRemoved contains names of constraints that need to be removed from the table
+    // (potentially dangerous - may affect data integrity)
+    ConstraintsRemoved []string `json:"constraints_removed"`
+}
+    TableDiff represents structural differences within a specific database
+    table.
+
+    This structure captures all types of changes that can occur to a table's
+    structure, including column additions, removals, and modifications.
+    It provides detailed information needed to generate appropriate ALTER TABLE
+    statements.
+
+    # Example Usage
+
+        tableDiff := TableDiff{
+            TableName: "users",
+            ColumnsAdded: []string{"email", "created_at"},
+            ColumnsRemoved: []string{"legacy_field"},
+            ColumnsModified: []ColumnDiff{
+                {ColumnName: "name", Changes: map[string]string{"type": "VARCHAR(100) -> VARCHAR(255)"}},
+            },
+        }
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.TriggerDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type TriggerDiff struct {
+    TriggerName string            `json:"trigger_name"`
+    TableName   string            `json:"table_name"`
+    Changes     map[string]string `json:"changes"`
+}
+    TriggerDiff represents changes to a trigger definition.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.TriggerRef
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type TriggerRef struct {
+    TriggerName string `json:"trigger_name"`
+    TableName   string `json:"table_name"`
+}
+    TriggerRef identifies a trigger by table and trigger name.
+
+
+### github.com/stokaro/ptah/migration/schemadiff/types.ViewDiff
+
+package types // import "github.com/stokaro/ptah/migration/schemadiff/types"
+
+type ViewDiff struct {
+    ViewName string            `json:"view_name"`
+    Changes  map[string]string `json:"changes"`
+}
+    ViewDiff represents changes to a view definition.
+
+
 ## github.com/stokaro/ptah/migration/seeder
 
 func DefaultProtectedEnvs() []string
@@ -1163,4 +7993,50 @@ type Result struct{ ... }
 type SeedFile struct{ ... }
     func Discover(fsys fs.FS) ([]SeedFile, error)
     func Select(seeds []SeedFile, env string) []SeedFile
+
+### github.com/stokaro/ptah/migration/seeder.Options
+
+package seeder // import "github.com/stokaro/ptah/migration/seeder"
+
+type Options struct {
+    Env             string
+    ProtectedEnvs   []string
+    ProtectedTables []string
+    Force           bool
+    Idempotent      bool
+    AllowProd       bool
+}
+    Options controls seed execution.
+
+
+### github.com/stokaro/ptah/migration/seeder.Result
+
+package seeder // import "github.com/stokaro/ptah/migration/seeder"
+
+type Result struct {
+    Env     string
+    Total   int
+    Applied []SeedFile
+    Skipped []SeedFile
+}
+    Result summarizes one seed command run.
+
+func Apply(ctx context.Context, conn *dbschema.DatabaseConnection, fsys fs.FS, ...) (*Result, error)
+
+### github.com/stokaro/ptah/migration/seeder.SeedFile
+
+package seeder // import "github.com/stokaro/ptah/migration/seeder"
+
+type SeedFile struct {
+    Path        string
+    Filename    string
+    Version     int
+    Description string
+    Env         string
+    Checksum    string
+}
+    SeedFile is one discovered seed SQL file.
+
+func Discover(fsys fs.FS) ([]SeedFile, error)
+func Select(seeds []SeedFile, env string) []SeedFile
 

--- a/internal/apiguard/doc.go
+++ b/internal/apiguard/doc.go
@@ -1,0 +1,16 @@
+// Package apiguard hosts the self-test for the public API snapshot guard
+// (scripts/check-public-api-snapshot.sh).
+//
+// The test execs the guard's own per-package generation logic
+// (`--emit-package`) against small fixture packages it writes into throwaway
+// temporary modules at run time, and asserts that the generated snapshot reacts
+// to changes in exported struct fields and in methods on concrete named types.
+// That surface is what the pre-#784, interface-only guard silently ignored, so
+// this test is what stops the guard from regressing back to it.
+//
+// The fixtures are generated into temp modules rather than committed as
+// packages so they are resolvable by `go doc` on every Go toolchain (a package
+// under a testdata/ directory is excluded from the module graph and cannot be
+// documented by import path) without being built, vetted, or linted as part of
+// this module. The package carries no runtime code of its own.
+package apiguard

--- a/internal/apiguard/snapshot_test.go
+++ b/internal/apiguard/snapshot_test.go
@@ -1,0 +1,165 @@
+package apiguard_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// baselineFixture is a package with an exported concrete type (with an exported
+// field and two exported methods) and an exported interface. It is the input
+// the guard's per-package generation runs against.
+const baselineFixture = `// Package fixture is the baseline input for the public API snapshot guard self-test.
+package fixture
+
+// Widget is a concrete named type whose exported fields and methods must be
+// recorded by the snapshot guard.
+type Widget struct {
+	// Name identifies the widget.
+	Name string
+
+	// Weight is an exported field.
+	Weight int
+}
+
+// Describe is a concrete method retained by every fixture.
+func (w Widget) Describe() string { return w.Name }
+
+// Rank is a concrete method.
+func (w Widget) Rank() int { return w.Weight }
+
+// Sink is an interface, kept to confirm interface coverage did not regress.
+type Sink interface {
+	// Drain consumes a widget.
+	Drain(w Widget) error
+}
+`
+
+// fieldRemovedFixture is baselineFixture with the exported Weight field dropped.
+const fieldRemovedFixture = `// Package fixture is the baseline input for the public API snapshot guard self-test.
+package fixture
+
+// Widget is a concrete named type whose exported fields and methods must be
+// recorded by the snapshot guard.
+type Widget struct {
+	// Name identifies the widget.
+	Name string
+}
+
+// Describe is a concrete method retained by every fixture.
+func (w Widget) Describe() string { return w.Name }
+
+// Rank is a concrete method.
+func (w Widget) Rank() int { return 0 }
+
+// Sink is an interface, kept to confirm interface coverage did not regress.
+type Sink interface {
+	// Drain consumes a widget.
+	Drain(w Widget) error
+}
+`
+
+// methodRemovedFixture is baselineFixture with the exported Rank method dropped.
+const methodRemovedFixture = `// Package fixture is the baseline input for the public API snapshot guard self-test.
+package fixture
+
+// Widget is a concrete named type whose exported fields and methods must be
+// recorded by the snapshot guard.
+type Widget struct {
+	// Name identifies the widget.
+	Name string
+
+	// Weight is an exported field.
+	Weight int
+}
+
+// Describe is a concrete method retained by every fixture.
+func (w Widget) Describe() string { return w.Name }
+
+// Sink is an interface, kept to confirm interface coverage did not regress.
+type Sink interface {
+	// Drain consumes a widget.
+	Drain(w Widget) error
+}
+`
+
+// TestSnapshotCapturesStructFields proves that removing an exported struct field
+// changes the generated snapshot fragment.
+func TestSnapshotCapturesStructFields(t *testing.T) {
+	c := qt.New(t)
+
+	base := emitFragment(t, baselineFixture)
+	noField := emitFragment(t, fieldRemovedFixture)
+
+	c.Assert(base, qt.Contains, "Weight int")
+	c.Assert(noField, qt.Not(qt.Contains), "Weight int")
+	c.Assert(base, qt.Not(qt.Equals), noField)
+}
+
+// TestSnapshotCapturesConcreteMethods proves that removing an exported method on
+// a concrete named type changes the generated snapshot fragment. This is the
+// coverage the pre-#784 interface-only guard lacked.
+func TestSnapshotCapturesConcreteMethods(t *testing.T) {
+	c := qt.New(t)
+
+	base := emitFragment(t, baselineFixture)
+	noMethod := emitFragment(t, methodRemovedFixture)
+
+	c.Assert(base, qt.Contains, "func (w Widget) Rank() int")
+	c.Assert(noMethod, qt.Not(qt.Contains), "func (w Widget) Rank() int")
+	c.Assert(base, qt.Not(qt.Equals), noMethod)
+}
+
+// TestSnapshotRetainsInterfaceAndMethodCoverage guards against regressing the
+// interface coverage that predates #784 while proving concrete-method coverage
+// is present in the same fragment.
+func TestSnapshotRetainsInterfaceAndMethodCoverage(t *testing.T) {
+	c := qt.New(t)
+
+	base := emitFragment(t, baselineFixture)
+
+	c.Assert(base, qt.Contains, "Drain(w Widget) error")
+	c.Assert(base, qt.Contains, "func (w Widget) Describe() string")
+}
+
+// emitFragment writes source as the sole file of a throwaway temp module and
+// runs the guard's per-package generation (`--emit-package .`) against it,
+// returning the emitted snapshot fragment. The tests therefore exercise exactly
+// the logic the real snapshot is built from rather than a Go reimplementation.
+func emitFragment(t *testing.T, source string) string {
+	t.Helper()
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module apiguardfixture\n\ngo 1.21\n"), 0o600)
+	c.Assert(err, qt.IsNil)
+	err = os.WriteFile(filepath.Join(dir, "fixture.go"), []byte(source), 0o600)
+	c.Assert(err, qt.IsNil)
+
+	script := filepath.Join(moduleRoot(t), "scripts", "check-public-api-snapshot.sh")
+	cmd := exec.Command("bash", script, "--emit-package", ".")
+	cmd.Dir = dir
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	c.Assert(err, qt.IsNil, qt.Commentf("emit failed: %v\nstderr:\n%s", err, stderr.String()))
+
+	return string(out)
+}
+
+// moduleRoot returns the repository root. This package lives at a fixed depth
+// (internal/apiguard) and go test runs with the working directory set to the
+// package source directory, so the root is two directories up.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	qt.New(t).Assert(err, qt.IsNil)
+
+	return filepath.Dir(filepath.Dir(wd))
+}

--- a/scripts/check-public-api-snapshot.sh
+++ b/scripts/check-public-api-snapshot.sh
@@ -3,6 +3,53 @@ set -euo pipefail
 
 export GOWORK=off
 
+# emit_package_snapshot writes the snapshot fragment for a single package to
+# stdout. The fragment has two parts:
+#
+#   1. A "## <package>" header followed by the raw `go doc -short` listing, which
+#      records the package-level API surface (consts, funcs, and the one-line
+#      form of every type).
+#   2. A "### <package>.<Type>" section for EVERY exported named type — struct,
+#      interface, alias, map, func type, any `type X ...` where X is exported —
+#      followed by the full `go doc <package>.<Type>` output. This is what makes
+#      the guard sensitive to changes in exported struct fields and in methods on
+#      concrete named types, not just interface method sets.
+#
+# The exported type names are sorted (LC_ALL=C, byte order) before their blocks
+# are emitted so the fragment is reproducible regardless of the order `go doc`
+# happens to list types across a package's source files.
+emit_package_snapshot() {
+	local package_path="$1"
+	local doc
+	doc="$(go doc -short "$package_path")"
+
+	printf '## %s\n\n' "$package_path"
+	printf '%s\n' "$doc" | expand -t 4 | sed 's/[[:space:]]*$//'
+	printf '\n'
+
+	printf '%s\n' "$doc" |
+		sed -n -E 's/^type ([[:upper:]][[:alnum:]_]*).*/\1/p' |
+		LC_ALL=C sort -u |
+		while IFS= read -r type_name; do
+			printf '### %s.%s\n\n' "$package_path" "$type_name"
+			go doc "$package_path" "$type_name" | expand -t 4 | sed 's/[[:space:]]*$//'
+			printf '\n'
+		done
+}
+
+# Internal mode used by the guard self-test (internal/apiguard): emit the
+# fragment for a single package to stdout without touching the snapshot file or
+# reading docs/public_api.md. This keeps the per-package generation logic in one
+# place so the test exercises exactly what the snapshot is built from.
+if [[ "${1:-}" == "--emit-package" ]]; then
+	if [[ "$#" -ne 2 ]]; then
+		printf 'usage: %s --emit-package <package-import-path>\n' "$0" >&2
+		exit 2
+	fi
+	emit_package_snapshot "$2"
+	exit 0
+fi
+
 snapshot="docs/public_api.snapshot"
 update=0
 if [[ "${1:-}" == "--update" ]]; then
@@ -18,18 +65,7 @@ grep -Eo '`github\.com/stokaro/ptah[^`]+`' docs/public_api.md |
 	sort -u >"$packages"
 
 while IFS= read -r package_path; do
-	doc="$(go doc -short "$package_path")"
-	printf '## %s\n\n' "$package_path" >>"$tmp"
-	printf '%s\n' "$doc" | expand -t 4 | sed 's/[[:space:]]*$//' >>"$tmp"
-	printf '\n' >>"$tmp"
-
-	printf '%s\n' "$doc" |
-		sed -n -E 's/^type ([[:upper:]][[:alnum:]_]*) interface.*/\1/p' |
-		while IFS= read -r type_name; do
-			printf '### %s.%s\n\n' "$package_path" "$type_name" >>"$tmp"
-			go doc "$package_path.$type_name" | expand -t 4 | sed 's/[[:space:]]*$//' >>"$tmp"
-			printf '\n' >>"$tmp"
-		done
+	emit_package_snapshot "$package_path" >>"$tmp"
 done <"$packages"
 
 if [[ "$update" -eq 1 ]]; then


### PR DESCRIPTION
Closes #784.

## Problem

`scripts/check-public-api-snapshot.sh` snapshotted package-level `go doc -short` output and then expanded **only exported interfaces**. Exported struct fields, methods on concrete named types, and other per-type API details could therefore change without failing the guard or updating `docs/public_api.snapshot`. This was exposed while reviewing #777, whose new identifier-semantics package adds exported struct fields and concrete methods the abbreviated snapshot never recorded.

## Changes

- **Guard** (`scripts/check-public-api-snapshot.sh`): enumerate **every** exported named type in each documented package (struct, interface, alias, map, func type — any `type X …` where `X` is exported), not just interfaces, and append its full `go doc <pkg>.<Type>` output. Type names are sorted with `LC_ALL=C` before their blocks are emitted so the snapshot is reproducible regardless of `go doc` ordering. The per-package logic is factored into `emit_package_snapshot`, also reachable via an internal `--emit-package <import-path>` mode. Top-level `--update` / diff-on-mismatch behavior, the package allowlist, and the released-baseline check are unchanged.
- **Self-test** (`internal/apiguard`): a black-box Go test that execs the real generation logic (`--emit-package`) against three `testdata/` fixture packages — `baseline`, `fieldremoved`, `methodremoved` — and proves that removing an exported struct field or an exported concrete method changes the generated fragment, while interface coverage is retained. It runs in the normal `go test ./...` and sits behind an `internal/` boundary so the allowlist check ignores it. Because it execs the actual script, the guard cannot silently regress without the test noticing.
- **Snapshot**: regenerated (`docs/public_api.snapshot`, now records full per-type output; grows from ~1.2k to ~8k lines — expected).
- **Docs** (`docs/public_api.md`): describe the strengthened guard accurately (was stale: claimed interface-only expansion).

## Acceptance criteria

- Changing an exported struct field → guard fails ✓ (self-test `TestSnapshotCapturesStructFields`)
- Changing an exported concrete method → guard fails ✓ (`TestSnapshotCapturesConcreteMethods`)
- Interface coverage retained ✓ (`TestSnapshotRetainsInterfaceAndMethodCoverage`)
- Deterministic: two `--update` runs produce a byte-identical snapshot ✓
- Package allowlist + released-baseline checks intact ✓

## Note for in-flight branches

Because the guard now records full per-type output, any branch that added an exported package/type against the old abbreviated snapshot will need to rebase and re-run `bash scripts/check-public-api-snapshot.sh --update` to capture its per-type API. That is the intended effect of this issue.

## Testing

`go build ./...`, `gofmt -l`, `go vet ./...`, `golangci-lint run ./...`, `go tool qtlint ./...`, `go tool teststyle`, `go test ./...` (full suite), and both `check-public-api-snapshot.sh` / `check-public-api.sh` all pass; determinism re-verified independently.