### PR TITLE
Report semantic schema-change counts in Atlas migrate lint output (#750)

### DIFF
--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -52,7 +52,10 @@ execution without a second configuration-file read.
 integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
 prepared files and findings together with a read-only source snapshot. Finding
 contexts identify the exact statement and affected tables or columns; column
-subjects can also carry the parent table and declared data type. Atlas-ignored
+subjects can also carry the parent table and declared data type. Each prepared
+up-migration file also carries the semantic schema changes it expresses
+(`File.Changes`, typed `SchemaChange`), recovered from Ptah's dialect-aware SQL
+parser so one statement can map to zero, one, or several changes. Atlas-ignored
 files are marked explicitly without changing version selection.
 Compatibility-specific directive behavior must be selected explicitly; native
 Ptah behavior is the zero-value default.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5979,6 +5979,9 @@ type Options struct{ ... }
 type Rule struct{ ... }
     func Rules() []Rule
 type RuleConfig struct{ ... }
+type SchemaChange struct{ ... }
+type SchemaChangeKind string
+    const SchemaChangeAdd SchemaChangeKind = "add" ...
 type Severity = risk.Severity
     const SeverityWarning Severity = risk.Warning ...
 type SourceSpan struct{ ... }
@@ -6097,6 +6100,13 @@ type File struct {
     // Statements holds the parsed statements of up migrations. Empty for
     // down migrations (statement rules do not run there).
     Statements []Statement
+    // Changes holds the semantic schema changes this up migration expresses,
+    // recovered from Ptah's dialect-aware SQL parser. Empty for down migrations
+    // and for files whose statements express no structural change. One statement
+    // can contribute zero, one, or several changes, so len(Changes) is not the
+    // statement count. Ordered by statement, then by the order changes appear
+    // within each statement.
+    Changes []SchemaChange
     // Has unexported fields.
 }
     File is one migration file prepared for linting.
@@ -6211,6 +6221,49 @@ type RuleConfig struct {
 }
     RuleConfig customizes one rule for a lint run.
 
+
+### github.com/stokaro/ptah/migration/lint.SchemaChange
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type SchemaChange struct {
+    // Version is the migration version that produced the change; zero when the
+    // file name carries no recognizable version.
+    Version int64 `json:"version"`
+    // File is the migration file path exactly as findings report it (reporting
+    // prefix included).
+    File string `json:"file"`
+    // StatementIndex is the zero-based index of the producing statement in the
+    // owning file's Statements slice.
+    StatementIndex int `json:"statement_index"`
+    // Line is the 1-based line number of the producing statement's first token.
+    Line int `json:"line,omitempty"`
+    // Kind classifies the DDL effect.
+    Kind SchemaChangeKind `json:"kind"`
+    // Object is the primary schema object the change affects (the table, index,
+    // type, column, … name). Best-effort: empty when the parser does not expose
+    // a name for the construct.
+    Object string `json:"object,omitempty"`
+}
+    SchemaChange is one semantic schema change an up migration expresses.
+    Changes are recovered from Ptah's dialect-aware SQL parser — the same
+    parser the planner and dev-database replay rely on — rather than by counting
+    statements or files. Parsing one statement can yield zero changes (a
+    comment-only or operational statement such as INSERT/SELECT, or a statement
+    outside Ptah's DDL grammar), exactly one (a single CREATE or DROP), or
+    several (a multi-action ALTER TABLE, or a DROP TABLE naming several tables).
+    A schema change count is therefore not interchangeable with a statement or
+    file count.
+
+
+### github.com/stokaro/ptah/migration/lint.SchemaChangeKind
+
+package lint // import "github.com/stokaro/ptah/migration/lint"
+
+type SchemaChangeKind string
+    SchemaChangeKind classifies the DDL effect of one semantic schema change.
+
+const SchemaChangeAdd SchemaChangeKind = "add" ...
 
 ### github.com/stokaro/ptah/migration/lint.Severity
 

--- a/docs/site/src/content/docs/workflows/atlas-cli.md
+++ b/docs/site/src/content/docs/workflows/atlas-cli.md
@@ -416,6 +416,15 @@ selecting `--latest` versions, replaying migrations, and rendering reports.
 Checksum status, findings, statement metadata, and formatted output therefore
 describe the same immutable inputs.
 
+The `Replay Migration Files` step reports the number of semantic schema changes
+the selected migrations express, recovered from Ptah's dialect-aware parse of
+their DDL — the same parser the replay and planner use — not a count of
+statements or files. One statement can contribute zero changes (an operational
+`INSERT`/`SELECT` or a construct outside the DDL grammar), exactly one (a single
+`CREATE`), or several (a multi-action `ALTER TABLE`, or a `DROP TABLE` naming
+several tables), so this change count and the new-migration-file count differ in
+general.
+
 Ptah also validates and fully loads the migration provider, including Atlas
 templates, before dropping any objects from the dev database. A malformed
 migration directory therefore leaves the existing dev database state intact;

--- a/internal/atlasreport/migrate_lint.go
+++ b/internal/atlasreport/migrate_lint.go
@@ -73,7 +73,7 @@ func NewMigrateLint(opts MigrateLintOptions) (MigrateLint, error) {
 		},
 	}
 	if opts.Integrity.Failed() {
-		result.Steps = migrateLintSteps(nil, 0, opts.Integrity, "")
+		result.Steps = migrateLintSteps(nil, 0, 0, opts.Integrity, "")
 		result.Files = []MigrateLintFile{
 			{
 				Name:  migratesum.AtlasFileName,
@@ -86,9 +86,9 @@ func NewMigrateLint(opts MigrateLintOptions) (MigrateLint, error) {
 	if opts.Analysis == nil {
 		return MigrateLint{}, fmt.Errorf("migration lint analysis is required")
 	}
-	files, total := migrateLintFiles(*opts.Analysis)
+	files, total, changes := migrateLintFiles(*opts.Analysis)
 	files = attachMigrateLintFindings(files, opts.Analysis.Findings())
-	result.Steps = migrateLintSteps(files, total, opts.Integrity, opts.Error)
+	result.Steps = migrateLintSteps(files, total, changes, opts.Integrity, opts.Error)
 	result.Files = files
 	return result, nil
 }
@@ -115,13 +115,18 @@ func (i MigrateLintIntegrity) Failed() bool {
 	return i.Checked && i.Error != ""
 }
 
-func migrateLintFiles(analysis migrationlint.Analysis) ([]MigrateLintFile, int) {
+// migrateLintFiles returns the selected up-migration files, the count of new
+// up-migration files considered, and the total number of semantic schema
+// changes those selected files express. The change count is sourced from the
+// dialect-aware replay/planning pipeline (see migrationlint.SchemaChange), not
+// from re-parsing SQL here, so one statement can contribute zero, one, or
+// several changes.
+func migrateLintFiles(analysis migrationlint.Analysis) (files []MigrateLintFile, total, changes int) {
 	prepared := analysis.Files()
 	slices.SortStableFunc(prepared, func(a, b migrationlint.File) int {
 		return cmp.Or(cmp.Compare(a.Version, b.Version), strings.Compare(a.Name, b.Name))
 	})
-	files := make([]MigrateLintFile, 0, len(prepared))
-	total := 0
+	files = make([]MigrateLintFile, 0, len(prepared))
 	for _, file := range prepared {
 		if file.Repeatable || file.Direction != "up" || file.Ignored {
 			continue
@@ -130,13 +135,14 @@ func migrateLintFiles(analysis migrationlint.Analysis) ([]MigrateLintFile, int) 
 		if !file.Selected {
 			continue
 		}
+		changes += len(file.Changes)
 		files = append(files, MigrateLintFile{
 			Name:       file.Name,
 			Text:       file.Source,
 			sourcePath: file.Path,
 		})
 	}
-	return files, total
+	return files, total, changes
 }
 
 func attachMigrateLintFindings(
@@ -169,6 +175,7 @@ func atlasMigrateLintFinding(finding migrationlint.Finding) migrationlint.Findin
 func migrateLintSteps(
 	files []MigrateLintFile,
 	total int,
+	changes int,
 	integrity MigrateLintIntegrity,
 	errText string,
 ) []MigrateLintStep {
@@ -198,7 +205,7 @@ func migrateLintSteps(
 	}
 	steps = append(steps, MigrateLintStep{
 		Name: "Replay Migration Files",
-		Text: fmt.Sprintf("Loaded %d changes on dev database", len(files)),
+		Text: fmt.Sprintf("Loaded %d changes on dev database", changes),
 	})
 	for _, file := range files {
 		steps = append(steps, MigrateLintStep{

--- a/internal/atlasreport/migrate_lint_test.go
+++ b/internal/atlasreport/migrate_lint_test.go
@@ -191,6 +191,84 @@ func TestNewMigrateLint_PathPrefixCannotCrossAttachFindings(t *testing.T) {
 	c.Assert(report.Files[1].Findings, qt.HasLen, 0)
 }
 
+func TestNewMigrateLint_LoadsSemanticChangeCountForMultiActionAlter(t *testing.T) {
+	c := qt.New(t)
+	analysis, err := migrationlint.AnalyzeFS(fstest.MapFS{
+		"1_alter.sql": {Data: []byte("ALTER TABLE users ADD COLUMN a INTEGER, ADD COLUMN b INTEGER;\n")},
+	}, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{Analysis: &analysis})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Steps, qt.HasLen, 3)
+	c.Assert(report.Steps[1].Name, qt.Equals, "Replay Migration Files")
+	// One ALTER statement expresses two schema changes: counting the file or
+	// statement would report 1.
+	c.Assert(report.Steps[1].Text, qt.Equals, "Loaded 2 changes on dev database")
+}
+
+func TestNewMigrateLint_LoadsZeroChangesForNonDDLFile(t *testing.T) {
+	c := qt.New(t)
+	analysis, err := migrationlint.AnalyzeFS(fstest.MapFS{
+		"1_seed.sql": {Data: []byte("INSERT INTO users (id) VALUES (1);\n")},
+	}, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{Analysis: &analysis})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Steps[0].Text, qt.Equals, "Found 1 new migration files (from 1 total)")
+	// The file has a statement but no structural change.
+	c.Assert(report.Steps[1].Text, qt.Equals, "Loaded 0 changes on dev database")
+}
+
+func TestNewMigrateLint_LoadsSemanticChangeCountForMixedFile(t *testing.T) {
+	c := qt.New(t)
+	analysis, err := migrationlint.AnalyzeFS(fstest.MapFS{
+		"1_mixed.sql": {Data: []byte(
+			"CREATE TABLE t (id INTEGER);\n" +
+				"INSERT INTO t (id) VALUES (1);\n" +
+				"ALTER TABLE t ADD COLUMN a INTEGER, ADD COLUMN b INTEGER;\n")},
+	}, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{Analysis: &analysis})
+
+	c.Assert(err, qt.IsNil)
+	// Three statements, one operational: 1 (CREATE) + 0 (INSERT) + 2 (ALTER).
+	c.Assert(report.Steps[1].Text, qt.Equals, "Loaded 3 changes on dev database")
+}
+
+func TestNewMigrateLint_LoadsOneChangePerSingleStatementFixtureFile(t *testing.T) {
+	c := qt.New(t)
+	analysis, err := migrationlint.AnalyzeFS(fstest.MapFS{
+		"1_create_users.sql":    {Data: []byte("CREATE TABLE users (id INTEGER);\n")},
+		"2_create_accounts.sql": {Data: []byte("CREATE TABLE accounts (id INTEGER);\n")},
+	}, migrationlint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+
+	report, err := atlasreport.NewMigrateLint(atlasreport.MigrateLintOptions{Analysis: &analysis})
+
+	c.Assert(err, qt.IsNil)
+	// Imported one-statement-per-change fixtures keep parity: two files, each a
+	// single CREATE, is two changes.
+	c.Assert(report.Steps[0].Text, qt.Equals, "Found 2 new migration files (from 2 total)")
+	c.Assert(report.Steps[1].Text, qt.Equals, "Loaded 2 changes on dev database")
+}
+
 func TestWriteMigrateLintFormat_RedactsSensitiveURL(t *testing.T) {
 	c := qt.New(t)
 	redactionURL := "postgres://app:" + "secret" + "@db.local/app?token=" + "secret" +

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -144,7 +144,14 @@ type File struct {
 	NoTransaction bool
 	// Statements holds the parsed statements of up migrations. Empty for
 	// down migrations (statement rules do not run there).
-	Statements      []Statement
+	Statements []Statement
+	// Changes holds the semantic schema changes this up migration expresses,
+	// recovered from Ptah's dialect-aware SQL parser. Empty for down migrations
+	// and for files whose statements express no structural change. One statement
+	// can contribute zero, one, or several changes, so len(Changes) is not the
+	// statement count. Ordered by statement, then by the order changes appear
+	// within each statement.
+	Changes         []SchemaChange
 	suppressedRules []string
 }
 
@@ -205,6 +212,7 @@ func cloneFiles(files []File) []File {
 
 func cloneFile(file File) File {
 	file.suppressedRules = slices.Clone(file.suppressedRules)
+	file.Changes = slices.Clone(file.Changes)
 	statements := file.Statements
 	file.Statements = make([]Statement, len(statements))
 	for i := range statements {
@@ -290,6 +298,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			versionDirs,
 			opts.PathPrefix,
 			mode,
+			opts.Dialect,
 			opts.AtlasTemplateData,
 			dirFormat,
 			opts.Selection,
@@ -429,6 +438,7 @@ func prepareFile(
 	versionDirs map[int64]map[string]bool,
 	pathPrefix string,
 	mode scanMode,
+	dialect string,
 	atlasTemplateData any,
 	dirFormat migrator.MigrationDirFormat,
 	selection VersionSelection,
@@ -507,6 +517,7 @@ func prepareFile(
 				suppressedRules: rawStmt.suppressedRules,
 			})
 		}
+		file.Changes = extractSchemaChanges(&file, dialect)
 	}
 	return file, nil
 }

--- a/migration/lint/changes.go
+++ b/migration/lint/changes.go
@@ -1,0 +1,275 @@
+package lint
+
+import (
+	"strings"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/internal/parser"
+)
+
+// SchemaChangeKind classifies the DDL effect of one semantic schema change.
+type SchemaChangeKind string
+
+const (
+	// SchemaChangeAdd creates a schema object or adds an element to an existing
+	// table (CREATE TABLE/INDEX/TYPE/…, ALTER TABLE … ADD COLUMN/CONSTRAINT).
+	SchemaChangeAdd SchemaChangeKind = "add"
+	// SchemaChangeModify alters an existing schema object in place (ALTER TABLE
+	// … ALTER COLUMN, ALTER TYPE/SEQUENCE/ROLE, ENABLE/DISABLE ROW LEVEL
+	// SECURITY, REFRESH MATERIALIZED VIEW, COMMENT ON …).
+	SchemaChangeModify SchemaChangeKind = "modify"
+	// SchemaChangeDrop removes a schema object or an element of a table (DROP
+	// TABLE/INDEX/TYPE/…, ALTER TABLE … DROP COLUMN/CONSTRAINT).
+	SchemaChangeDrop SchemaChangeKind = "drop"
+	// SchemaChangeRename renames a table or a column (ALTER TABLE … RENAME …).
+	SchemaChangeRename SchemaChangeKind = "rename"
+)
+
+// SchemaChange is one semantic schema change an up migration expresses. Changes
+// are recovered from Ptah's dialect-aware SQL parser — the same parser the
+// planner and dev-database replay rely on — rather than by counting statements
+// or files. Parsing one statement can yield zero changes (a comment-only or
+// operational statement such as INSERT/SELECT, or a statement outside Ptah's
+// DDL grammar), exactly one (a single CREATE or DROP), or several (a
+// multi-action ALTER TABLE, or a DROP TABLE naming several tables). A schema
+// change count is therefore not interchangeable with a statement or file count.
+type SchemaChange struct {
+	// Version is the migration version that produced the change; zero when the
+	// file name carries no recognizable version.
+	Version int64 `json:"version"`
+	// File is the migration file path exactly as findings report it (reporting
+	// prefix included).
+	File string `json:"file"`
+	// StatementIndex is the zero-based index of the producing statement in the
+	// owning file's Statements slice.
+	StatementIndex int `json:"statement_index"`
+	// Line is the 1-based line number of the producing statement's first token.
+	Line int `json:"line,omitempty"`
+	// Kind classifies the DDL effect.
+	Kind SchemaChangeKind `json:"kind"`
+	// Object is the primary schema object the change affects (the table, index,
+	// type, column, … name). Best-effort: empty when the parser does not expose
+	// a name for the construct.
+	Object string `json:"object,omitempty"`
+}
+
+// extractSchemaChanges recovers the semantic schema changes an up migration
+// expresses by parsing each of its statements with Ptah's dialect-aware SQL
+// parser and classifying the resulting AST. Statements are parsed individually
+// so a single construct the parser does not model (for example GRANT) cannot
+// suppress the changes of its neighbors. Down migrations and files without
+// parsed statements yield no changes.
+func extractSchemaChanges(file *File, dialect string) []SchemaChange {
+	if !file.IsUp || len(file.Statements) == 0 {
+		return nil
+	}
+	var changes []SchemaChange
+	for i := range file.Statements {
+		changes = append(changes, statementSchemaChanges(file, file.Statements[i], dialect)...)
+	}
+	return changes
+}
+
+func statementSchemaChanges(file *File, stmt Statement, dialect string) []SchemaChange {
+	var opts []parser.Option
+	if strings.TrimSpace(dialect) != "" {
+		opts = []parser.Option{parser.WithDialect(dialect)}
+	}
+	list, err := parser.NewParser(stmt.SQL, opts...).Parse()
+	if err != nil || list == nil {
+		// A statement Ptah's parser cannot model contributes no structural
+		// change here. The dev-database replay independently validates that the
+		// statement executes, so nothing is silently accepted; it is only
+		// excluded from the semantic change count.
+		return nil
+	}
+	var changes []SchemaChange
+	for _, node := range list.Statements {
+		changes = append(changes, nodeSchemaChanges(file, stmt, node)...)
+	}
+	return changes
+}
+
+func nodeSchemaChanges(file *File, stmt Statement, node ast.Node) []SchemaChange {
+	change := func(kind SchemaChangeKind, object string) SchemaChange {
+		return SchemaChange{
+			Version:        file.Version,
+			File:           file.Path,
+			StatementIndex: stmt.Index,
+			Line:           stmt.Line,
+			Kind:           kind,
+			Object:         object,
+		}
+	}
+	// DROP TABLE and ALTER TABLE are the two constructs where one statement can
+	// carry several changes; every other modeled node maps to exactly one.
+	switch n := node.(type) {
+	case *ast.DropTableNode:
+		names := n.TableNames()
+		out := make([]SchemaChange, 0, len(names))
+		for _, name := range names {
+			out = append(out, change(SchemaChangeDrop, name))
+		}
+		return out
+	case *ast.AlterTableNode:
+		out := make([]SchemaChange, 0, len(n.Operations))
+		for _, op := range n.Operations {
+			kind, object := alterOperationChange(n, op)
+			out = append(out, change(kind, object))
+		}
+		return out
+	}
+	if object, ok := addNodeObject(node); ok {
+		return []SchemaChange{change(SchemaChangeAdd, object)}
+	}
+	if object, ok := dropNodeObject(node); ok {
+		return []SchemaChange{change(SchemaChangeDrop, object)}
+	}
+	if object, ok := modifyNodeObject(node); ok {
+		return []SchemaChange{change(SchemaChangeModify, object)}
+	}
+	// Operational nodes (INSERT/SELECT wrappers, DO blocks, raw SQL) and any
+	// construct Ptah does not model as a schema object contribute nothing.
+	return nil
+}
+
+// addNodeObject reports the object a CREATE (or GRANT) node adds.
+func addNodeObject(node ast.Node) (object string, ok bool) {
+	switch n := node.(type) {
+	case *ast.CreateTableNode:
+		return n.Name, true
+	case *ast.EnumNode:
+		return n.Name, true
+	case *ast.CreateTypeNode:
+		return n.Name, true
+	case *ast.IndexNode:
+		return n.Name, true
+	case *ast.ExtensionNode:
+		return n.Name, true
+	case *ast.CreateSequenceNode:
+		return n.Name, true
+	case *ast.CreateSchemaNode:
+		return n.Name, true
+	case *ast.CreateDatabaseNode:
+		return n.Name, true
+	case *ast.CreateViewNode:
+		return n.Name, true
+	case *ast.CreateMaterializedViewNode:
+		return n.Name, true
+	case *ast.CreateTriggerNode:
+		return n.Name, true
+	case *ast.CreateFunctionNode:
+		return n.Name, true
+	case *ast.CreatePolicyNode:
+		return n.Name, true
+	case *ast.CreateRoleNode:
+		return n.Name, true
+	case *ast.GrantPrivilegeNode:
+		return n.ObjectName, true
+	case *ast.OpaqueRoutineNode, *ast.MySQLRoutineNode,
+		*ast.PostgresRoutineNode, *ast.SQLServerRoutineNode:
+		// Dialect routine bodies (CREATE FUNCTION/PROCEDURE the parser preserves
+		// verbatim) are opaque but are still object creations.
+		return "", true
+	default:
+		return "", false
+	}
+}
+
+// dropNodeObject reports the object a DROP (or REVOKE) node removes. DROP TABLE
+// is handled by the caller because it can name several tables at once.
+func dropNodeObject(node ast.Node) (object string, ok bool) {
+	switch n := node.(type) {
+	case *ast.DropTypeNode:
+		return n.Name, true
+	case *ast.DropIndexNode:
+		return n.Name, true
+	case *ast.DropExtensionNode:
+		return n.Name, true
+	case *ast.DropSequenceNode:
+		return n.Name, true
+	case *ast.DropViewNode:
+		return n.Name, true
+	case *ast.DropMaterializedViewNode:
+		return n.Name, true
+	case *ast.DropTriggerNode:
+		return n.Name, true
+	case *ast.DropFunctionNode:
+		return n.Name, true
+	case *ast.DropPolicyNode:
+		return n.Name, true
+	case *ast.DropRoleNode:
+		return n.Name, true
+	case *ast.RevokePrivilegeNode:
+		return n.ObjectName, true
+	default:
+		return "", false
+	}
+}
+
+// modifyNodeObject reports the object an in-place ALTER (or COMMENT ON) node
+// mutates.
+func modifyNodeObject(node ast.Node) (object string, ok bool) {
+	switch n := node.(type) {
+	case *ast.AlterTypeNode:
+		return n.Name, true
+	case *ast.AlterSequenceNode:
+		return n.Name, true
+	case *ast.RefreshMaterializedViewNode:
+		return n.Name, true
+	case *ast.AlterRoleNode:
+		return n.Name, true
+	case *ast.AlterTableEnableRLSNode:
+		return n.Table, true
+	case *ast.AlterTableDisableRLSNode:
+		return n.Table, true
+	case *ast.CommentNode:
+		// A COMMENT ON … statement modifies an object's comment. Bare SQL
+		// comments never reach here; the scanner drops them before parsing.
+		return "", true
+	default:
+		return "", false
+	}
+}
+
+func alterOperationChange(alter *ast.AlterTableNode, op ast.AlterOperation) (SchemaChangeKind, string) {
+	switch o := op.(type) {
+	case *ast.AddColumnOperation:
+		return SchemaChangeAdd, columnName(o.Column)
+	case *ast.DropColumnOperation:
+		return SchemaChangeDrop, o.ColumnName
+	case *ast.ModifyColumnOperation:
+		return SchemaChangeModify, columnName(o.Column)
+	case *ast.AlterGeneratedColumnExpressionOperation:
+		return SchemaChangeModify, o.ColumnName
+	case *ast.AddConstraintOperation:
+		return SchemaChangeAdd, constraintName(o.Constraint)
+	case *ast.DropConstraintOperation:
+		return SchemaChangeDrop, o.ConstraintName
+	case *ast.RenameColumnOperation:
+		return SchemaChangeRename, o.OldName
+	case *ast.RenameTableOperation:
+		return SchemaChangeRename, alter.Name
+	case *ast.AddSkippingIndexOperation:
+		return SchemaChangeAdd, o.Name
+	case *ast.ModifyTTLOperation:
+		return SchemaChangeModify, alter.Name
+	default:
+		// Any other ALTER TABLE action still mutates the table.
+		return SchemaChangeModify, alter.Name
+	}
+}
+
+func columnName(column *ast.ColumnNode) string {
+	if column == nil {
+		return ""
+	}
+	return column.Name
+}
+
+func constraintName(constraint *ast.ConstraintNode) string {
+	if constraint == nil {
+		return ""
+	}
+	return constraint.Name
+}

--- a/migration/lint/changes_test.go
+++ b/migration/lint/changes_test.go
@@ -1,0 +1,202 @@
+package lint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/lint"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+type changeProjection struct {
+	Kind   lint.SchemaChangeKind
+	Object string
+}
+
+func projectChanges(changes []lint.SchemaChange) []changeProjection {
+	out := make([]changeProjection, 0, len(changes))
+	for _, ch := range changes {
+		out = append(out, changeProjection{Kind: ch.Kind, Object: ch.Object})
+	}
+	return out
+}
+
+func fileByName(c *qt.C, analysis lint.Analysis, name string) lint.File {
+	c.Helper()
+	for _, f := range analysis.Files() {
+		if f.Name == name {
+			return f
+		}
+	}
+	c.Fatalf("file %q not present in analysis", name)
+	return lint.File{}
+}
+
+func analyzeSQLite(c *qt.C, files map[string]string) lint.Analysis {
+	c.Helper()
+	analysis, err := lint.AnalyzeFS(fixture(files), lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "sqlite",
+	})
+	c.Assert(err, qt.IsNil)
+	return analysis
+}
+
+// TestAnalyzeFS_SchemaChangeCardinality proves the change count is decoupled
+// from the statement and file count: a statement can yield zero, one, or many
+// semantic schema changes.
+func TestAnalyzeFS_SchemaChangeCardinality(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []changeProjection
+	}{
+		{
+			name: "single create is one change",
+			sql:  "CREATE TABLE users (id INTEGER);",
+			want: []changeProjection{{lint.SchemaChangeAdd, "users"}},
+		},
+		{
+			name: "single drop is one change",
+			sql:  "DROP TABLE users;",
+			want: []changeProjection{{lint.SchemaChangeDrop, "users"}},
+		},
+		{
+			name: "one statement dropping several tables is several changes",
+			sql:  "DROP TABLE a, b, c;",
+			want: []changeProjection{
+				{lint.SchemaChangeDrop, "a"},
+				{lint.SchemaChangeDrop, "b"},
+				{lint.SchemaChangeDrop, "c"},
+			},
+		},
+		{
+			name: "one multi-action alter is several changes",
+			sql:  "ALTER TABLE t ADD COLUMN a INTEGER, ADD COLUMN b INTEGER;",
+			want: []changeProjection{
+				{lint.SchemaChangeAdd, "a"},
+				{lint.SchemaChangeAdd, "b"},
+			},
+		},
+		{
+			name: "drop column is one change",
+			sql:  "ALTER TABLE users DROP COLUMN legacy;",
+			want: []changeProjection{{lint.SchemaChangeDrop, "legacy"}},
+		},
+		{
+			name: "create index is one change",
+			sql:  "CREATE INDEX idx_users_id ON users (id);",
+			want: []changeProjection{{lint.SchemaChangeAdd, "idx_users_id"}},
+		},
+		{
+			name: "operational insert is zero changes",
+			sql:  "INSERT INTO users (id) VALUES (1);",
+			want: []changeProjection{},
+		},
+		{
+			name: "select is zero changes",
+			sql:  "SELECT 1;",
+			want: []changeProjection{},
+		},
+		{
+			name: "comment-only file is zero changes",
+			sql:  "-- nothing structural here\n",
+			want: []changeProjection{},
+		},
+		{
+			name: "statement outside the DDL grammar is zero changes",
+			sql:  "GRANT SELECT ON users TO app;",
+			want: []changeProjection{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			analysis := analyzeSQLite(c, map[string]string{"1_change.sql": tc.sql})
+			file := fileByName(c, analysis, "1_change.sql")
+			c.Assert(projectChanges(file.Changes), qt.DeepEquals, tc.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_MixedDDLAndNonDDLFile shows a single file mixing DDL and
+// operational statements: the change count reflects only the structural
+// statements, and each change points back at its producing statement.
+func TestAnalyzeFS_MixedDDLAndNonDDLFile(t *testing.T) {
+	c := qt.New(t)
+	analysis := analyzeSQLite(c, map[string]string{
+		"7_mixed.sql": "CREATE TABLE t (id INTEGER);\n" +
+			"INSERT INTO t (id) VALUES (1);\n" +
+			"ALTER TABLE t ADD COLUMN a INTEGER, ADD COLUMN b INTEGER;\n",
+	})
+
+	file := fileByName(c, analysis, "7_mixed.sql")
+
+	c.Assert(file.Statements, qt.HasLen, 3)
+	c.Assert(file.Changes, qt.HasLen, 3)
+	c.Assert(projectChanges(file.Changes), qt.DeepEquals, []changeProjection{
+		{lint.SchemaChangeAdd, "t"},
+		{lint.SchemaChangeAdd, "a"},
+		{lint.SchemaChangeAdd, "b"},
+	})
+	// The CREATE came from statement 0; the two ADD COLUMN changes both came
+	// from statement 2 — the INSERT (statement 1) produced nothing.
+	c.Assert(file.Changes[0].StatementIndex, qt.Equals, 0)
+	c.Assert(file.Changes[1].StatementIndex, qt.Equals, 2)
+	c.Assert(file.Changes[2].StatementIndex, qt.Equals, 2)
+	c.Assert(file.Changes[0].Version, qt.Equals, int64(7))
+	c.Assert(file.Changes[0].File, qt.Equals, "7_mixed.sql")
+	c.Assert(file.Changes[0].Line, qt.Equals, 1)
+	c.Assert(file.Changes[1].Line, qt.Equals, 3)
+}
+
+func TestAnalyzeFS_DownMigrationHasNoChanges(t *testing.T) {
+	c := qt.New(t)
+	analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE users (id INTEGER);",
+		"0000000001_init.down.sql": "DROP TABLE users;",
+	}), lint.Options{DirFormat: migrator.MigrationDirFormatPtah})
+	c.Assert(err, qt.IsNil)
+
+	up := fileByName(c, analysis, "0000000001_init.up.sql")
+	down := fileByName(c, analysis, "0000000001_init.down.sql")
+
+	c.Assert(projectChanges(up.Changes), qt.DeepEquals, []changeProjection{
+		{lint.SchemaChangeAdd, "users"},
+	})
+	c.Assert(down.Changes, qt.HasLen, 0)
+}
+
+func TestAnalyzeFS_SchemaChangesAreDeterministic(t *testing.T) {
+	c := qt.New(t)
+	files := map[string]string{
+		"1_a.sql": "CREATE TABLE a (id INTEGER);\nALTER TABLE a ADD COLUMN x INTEGER, ADD COLUMN y INTEGER;\n",
+		"2_b.sql": "DROP TABLE a, b;",
+	}
+
+	first := fileByName(c, analyzeSQLite(c, files), "1_a.sql")
+	second := fileByName(c, analyzeSQLite(c, files), "1_a.sql")
+
+	c.Assert(second.Changes, qt.DeepEquals, first.Changes)
+}
+
+// TestAnalyzeFS_SchemaChangesRespectDialect confirms changes flow through the
+// dialect-aware parser rather than a dialect-blind heuristic.
+func TestAnalyzeFS_SchemaChangesRespectDialect(t *testing.T) {
+	c := qt.New(t)
+	sql := "CREATE TABLE t (id INTEGER);\nALTER TABLE t ADD COLUMN a INTEGER, ADD COLUMN b INTEGER;\n"
+
+	postgres, err := lint.AnalyzeFS(fixture(map[string]string{"1_change.sql": sql}), lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+	c.Assert(err, qt.IsNil)
+
+	file := fileByName(c, postgres, "1_change.sql")
+	c.Assert(projectChanges(file.Changes), qt.DeepEquals, []changeProjection{
+		{lint.SchemaChangeAdd, "t"},
+		{lint.SchemaChangeAdd, "a"},
+		{lint.SchemaChangeAdd, "b"},
+	})
+}


### PR DESCRIPTION
Closes #750. Follow-up to #747.

## Problem

The Atlas-compatible default `migrate lint` renderer reported `Loaded N changes on dev database` using `len(files)` as the count — a crude proxy. One SQL statement can produce multiple schema changes, a statement can be operational (non-structural), and dialect-specific statements differ in effect, so a statement/file count is not a schema-change count.

## Approach

- New `migration/lint.SchemaChange` (version, file, statement index, line, kind, object) and a `File.Changes []SchemaChange` field on the existing `lint.File`, so the data rides along on `Analysis.Files()` for both native and Atlas renderers with no Cobra/text coupling.
- Changes are recovered in `migration/lint` by parsing each already-split statement with Ptah's **canonical dialect-aware SQL parser** (`internal/parser`, the same one the planner/replay use) and classifying the resulting `core/ast` nodes — not a second SQL classifier. Parsing is per-statement so a construct the parser does not model (e.g. `GRANT`) is isolated to zero changes rather than aborting the file; the dev-database replay still validates such statements execute.
- `internal/atlasreport/migrate_lint.go` does zero SQL parsing — it only sums `len(file.Changes)` over the selected up-migration files.

## Cardinality handled

- **0**: `INSERT`/`SELECT`/comment-only → no schema nodes.
- **1**: single `CREATE`/`DROP`/`CREATE INDEX`.
- **many**: `ALTER TABLE … ADD COLUMN a, ADD COLUMN b` → N; `DROP TABLE a, b, c` → 3.
- **mixed DDL/non-DDL** file: `CREATE; INSERT; multi-ALTER` → 1 + 0 + 2 = 3, each change carrying its producing statement index.

## Tests

- `migration/lint/changes_test.go`: table-driven cardinality, mixed-file source locations, determinism, dialect-awareness, down-migration-has-no-changes.
- `internal/atlasreport/migrate_lint_test.go`: asserts the exact `Loaded N changes` line for multi-action ALTER (2), non-DDL (0), mixed (3), and one-statement-per-file parity (2).

## Notes

- `migration/lint` is in the public-API allowlist; `docs/public_api.snapshot` regenerated (adds `SchemaChange`, `SchemaChangeKind`, and `File.Changes`). `docs/public_api.md` and the atlas-cli docs page updated.
- Honest limitation: statements the parser does not model as DDL (currently top-level `GRANT`/`REVOKE`) contribute zero to the count; the classifier already maps those node types, so counts pick them up automatically if the parser gains top-level `GRANT` support. Native report behavior is unchanged.

## Testing

`go build ./...`, `gofmt -l`, `go vet ./...`, `golangci-lint run ./...`, `go tool qtlint ./...`, `go tool teststyle`, `go test ./...` (+ `-race` on migration/… and internal/atlasreport), and both public-API checks all pass.