### PR TITLE
Converge SQL Server filtered-index predicates end to end (#781)

### DIFF
--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -277,7 +277,7 @@ func (s *schemaParseState) parseIndexComment(comment *ast.Comment, structName st
 		Unique:        kv["unique"] == "true",
 		Comment:       kv["comment"],
 		Type:          kv["type"],                                  // PG: GIN/GIST/BTREE/HASH; CH: minmax/set(N)/bloom_filter/...
-		Condition:     firstNonEmpty(kv["where"], kv["condition"]), // PG/SQLite: WHERE clause for partial indexes
+		Condition:     firstNonEmpty(kv["where"], kv["condition"]), // PG/SQLite partial and SQL Server filtered indexes: WHERE clause
 		Operator:      kv["ops"],                                   // PG only: operator class (gin_trgm_ops, etc.)
 		NullsDistinct: parseBoolPtr(kv["nulls_distinct"]),
 		TableName:     tableName,   // Target table name

--- a/core/renderer/internal/dialects/mssql/filtered_index_test.go
+++ b/core/renderer/internal/dialects/mssql/filtered_index_test.go
@@ -1,0 +1,80 @@
+package mssql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/renderer/internal/dialects/mssql"
+)
+
+func TestRenderer_FilteredIndexRendersWherePredicate(t *testing.T) {
+	c := qt.New(t)
+	index := ast.NewIndex("idx_active_users", "dbo.users", "status")
+	index.Condition = "[status] = (1)"
+
+	sql, err := mssql.New().Render(index)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		sql,
+		qt.Equals,
+		"CREATE INDEX [idx_active_users] ON [dbo].[users] ([status]) WHERE [status] = (1);\n",
+	)
+}
+
+func TestRenderer_UniqueFilteredIndexRendersWherePredicate(t *testing.T) {
+	c := qt.New(t)
+	index := ast.NewIndex("uq_users_email_live", "dbo.users", "email").SetUnique()
+	index.Condition = "[deleted_at] IS NULL"
+
+	sql, err := mssql.New().Render(index)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		sql,
+		qt.Equals,
+		"CREATE UNIQUE INDEX [uq_users_email_live] ON [dbo].[users] ([email]) WHERE [deleted_at] IS NULL;\n",
+	)
+}
+
+func TestRenderer_FilteredIndexKeepsGuardAndWherePredicate(t *testing.T) {
+	c := qt.New(t)
+	index := ast.NewIndex("idx_active_users", "dbo.users", "status").SetIfNotExists()
+	index.Condition = "[status] = (1)"
+
+	sql, err := mssql.New().Render(index)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Equals, ""+
+		"IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'idx_active_users' AND object_id = OBJECT_ID('dbo.users'))\n"+
+		"CREATE INDEX [idx_active_users] ON [dbo].[users] ([status]) WHERE [status] = (1);\n")
+}
+
+func TestRenderer_UnfilteredIndexStaysWithoutWhere(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition string
+	}{
+		{name: "empty condition", condition: ""},
+		{name: "whitespace-only condition", condition: "   "},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			index := ast.NewIndex("idx_users_status", "dbo.users", "status")
+			index.Condition = test.condition
+
+			sql, err := mssql.New().Render(index)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(
+				sql,
+				qt.Equals,
+				"CREATE INDEX [idx_users_status] ON [dbo].[users] ([status]);\n",
+			)
+		})
+	}
+}

--- a/dbschema/sqlserver_identifier_live_test.go
+++ b/dbschema/sqlserver_identifier_live_test.go
@@ -346,6 +346,76 @@ CREATE TABLE [dbo].[users] (
 	c.Assert(finalDiff.HasChanges(), qt.IsFalse)
 }
 
+// TestSQLServerLiveIdentifierSemantics_FilteredIndexCreateRoundTrip proves the
+// #781 acceptance criteria for a fresh filtered index authored in natural
+// spelling: comparison plans a single CREATE INDEX ... WHERE, the predicate
+// survives execution, and re-introspection against the canonical
+// sys.indexes.filter_definition spelling reports zero diff.
+func TestSQLServerLiveIdentifierSemantics_FilteredIndexCreateRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	dbURL := provisionSQLServerCollationDatabase(t, sqlServerCICollation)
+	conn := connectSQLServerCollationDatabase(t, dbURL)
+	ctx := t.Context()
+	info := conn.Info()
+
+	_, err := conn.ExecContext(ctx, `
+CREATE TABLE [dbo].[users] (
+    [id] int NOT NULL,
+    [status] int NOT NULL
+)`)
+	c.Assert(err, qt.IsNil)
+
+	target := &goschema.Database{Indexes: []goschema.Index{
+		{
+			Name:      "idx_active_users",
+			TableName: "dbo.users",
+			Fields:    []string{"status"},
+			Condition: "status = 1",
+		},
+	}}
+	current, err := dbschema.ReadSchemaWithSchemas(conn, []string{"dbo"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(current.Indexes, qt.HasLen, 0)
+	createDiff, err := schemadiff.CompareWithDatabase(
+		ctx,
+		conn,
+		target,
+		indexOnlySchema(current),
+		nil,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(createDiff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{
+		{Name: "idx_active_users", TableName: "dbo.users"},
+	})
+	c.Assert(createDiff.IndexRemovals(), qt.HasLen, 0)
+
+	statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(
+		createDiff,
+		target,
+		info.Dialect,
+		info.Capabilities,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 1)
+	c.Assert(statements[0], qt.Contains, "WHERE status = 1")
+	_, err = conn.ExecContext(ctx, statements[0])
+	c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", statements[0]))
+
+	actual, err := dbschema.ReadSchemaWithSchemas(conn, []string{"dbo"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(actual.Indexes, qt.HasLen, 1)
+	c.Assert(actual.Indexes[0].Condition, qt.Equals, "([status]=(1))")
+	finalDiff, err := schemadiff.CompareWithDatabase(
+		ctx,
+		conn,
+		target,
+		indexOnlySchema(actual),
+		nil,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(finalDiff.HasChanges(), qt.IsFalse)
+}
+
 func TestSQLServerLiveIdentifierSemantics_CaseSensitiveVariantsCoexist(t *testing.T) {
 	c := qt.New(t)
 	dbURL := provisionSQLServerCollationDatabase(t, sqlServerCSCollation)

--- a/docs/site/src/content/docs/reference/dialect-notes.md
+++ b/docs/site/src/content/docs/reference/dialect-notes.md
@@ -64,6 +64,13 @@ dialect-only comparisons confirm only exact identity. Distinct unresolved
 names in one catalog namespace remain potentially equivalent, so planning
 rejects the ambiguity instead of approximating SQL Server collation behavior.
 
+Filtered indexes are supported: an index annotation `condition` renders as
+`CREATE INDEX ... WHERE ...`, and a changed predicate is planned as
+`DROP INDEX` plus `CREATE INDEX ... WHERE`. Predicate comparison normalizes
+the canonical `sys.indexes.filter_definition` spelling (bracket quoting and
+parenthesized numeric literals); predicates SQL Server rewrites further keep
+comparing as changed, so prefer the catalog's stored spelling for those.
+
 ## PostgreSQL-Compatible Targets
 
 CockroachDB, YugabyteDB, Spanner PostgreSQL interface, and similar targets can

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -36,6 +36,9 @@ The current SQL Server implementation covers:
 - `NVARCHAR`/`NVARCHAR(MAX)` string mapping.
 - Core table DDL, primary keys, unique constraints, foreign keys, CHECK
   constraints, and indexes with ordered ascending or descending key columns.
+- Filtered indexes: the index annotation's `condition` predicate survives
+  introspection, comparison, planning, and rendering as
+  `CREATE INDEX ... WHERE ...`. See [Filtered Indexes](#filtered-indexes).
 - Rendering for views and triggers when definitions are supplied as raw SQL.
 - Live schema introspection from `sys.tables`, `sys.columns`,
   `sys.foreign_keys`, `sys.indexes`, and related catalog views.
@@ -96,6 +99,38 @@ than live planning.
 Ptah does not reproduce SQL Server collation rules locally. The live catalog is
 the source of truth.
 
+## Filtered Indexes
+
+Declare a SQL Server filtered index with the index annotation's `condition`
+(or `where`) attribute:
+
+```go
+//migrator:schema:index name="idx_active_users" fields="status" condition="status = 1"
+```
+
+Ptah renders the predicate verbatim:
+
+```sql
+CREATE INDEX [idx_active_users] ON [dbo].[users] ([status]) WHERE status = 1;
+```
+
+SQL Server cannot alter an index predicate in place, so a changed predicate is
+planned as a replacement: `DROP INDEX ... ON ...` followed by
+`CREATE INDEX ... WHERE ...` carrying the target predicate.
+
+SQL Server persists `sys.indexes.filter_definition` in a canonical spelling —
+identifiers come back bracket-quoted and numeric literals parenthesized, so
+`status = 1` is stored as `([status]=(1))`. Predicate comparison therefore
+normalizes case, whitespace, wrapping parentheses, bracket identifier quoting,
+and parentheses around bare numeric literals before deciding whether an index
+changed. Rewrites SQL Server applies beyond that spelling — for example the
+`N'...'` prefix it adds to Unicode string literals or implicit `CAST`
+insertions — are not reconstructed: such predicates compare as changed and are
+re-planned as a replacement on every run. If a predicate keeps reporting drift
+after it was applied, spell the annotation the way the catalog stores it
+(compare with `ptah db read`); the rendered SQL always preserves the annotation
+text verbatim, so no predicate is ever silently dropped.
+
 ## Limitations
 
 The SQL Server support is deliberately conservative:
@@ -147,6 +182,10 @@ coverage creates separate CI and CS databases, verifies discovered semantics,
 executes case-only, changed-column, and ASC-to-DESC replacements safely, proves
 case variants coexist only on the CS database, and covers Turkish dotless-I,
 accent-insensitive Latin, Greek sigma, Japanese kana, and width equivalence.
+Filtered-index coverage creates a filtered index from a natural-spelling
+`condition` annotation, replaces a changed predicate through
+`DROP INDEX` + `CREATE INDEX ... WHERE`, and re-introspects to a zero diff
+against the canonical `filter_definition` spelling.
 The generator contour replays the prior schema on a separate SQL Server shadow
 database, then applies the generated ASC-to-DESC migration up, down, and up
 again while re-introspecting the index direction after every transition.

--- a/migration/planner/mssql_test.go
+++ b/migration/planner/mssql_test.go
@@ -167,3 +167,85 @@ func TestGenerateSchemaDiffSQL_SQLServerRejectsColumnRemoval(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `.*SQL Server planner does not support automatic DROP COLUMN for users; write an explicit migration that drops dependent constraints and indexes first.*`)
 }
+
+// TestGenerateSchemaDiffSQL_SQLServerFilteredIndexPredicateChange proves that
+// a changed filtered-index predicate plans as DROP INDEX ... ON ... followed
+// by CREATE INDEX ... WHERE ... carrying the target predicate (#781).
+func TestGenerateSchemaDiffSQL_SQLServerFilteredIndexPredicateChange(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		IndexesAdded: []types.IndexRef{
+			{Name: "idx_active_users", TableName: "dbo.users"},
+		},
+		IndexesRemoved: []types.IndexRef{
+			{Name: "idx_active_users", TableName: "dbo.users"},
+		},
+	}
+	semantics := identifier.ForSQLServerCatalog("SQL_Latin1_General_CP1_CI_AS").
+		WithResolvedNames([]identifier.ResolvedName{
+			{Name: "dbo", Key: "dbo"},
+			{Name: "id", Key: "id"},
+			{Name: "idx_active_users", Key: "idx_active_users"},
+			{Name: "status", Key: "status"},
+			{Name: "users", Key: "users"},
+		})
+	diff.IdentifierSemantics = &semantics
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Schema: "dbo", Name: "users"}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INT", Primary: true},
+			{StructName: "User", Name: "status", Type: "INT", Nullable: false},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			Name:       "idx_active_users",
+			Fields:     []string{"status"},
+			Condition:  "[status] = (2)",
+		}},
+	}
+
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, platform.SQLServer)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 2)
+	c.Assert(statements[0], qt.Equals, "DROP INDEX [idx_active_users] ON [dbo].[users]")
+	c.Assert(statements[1], qt.Equals, "CREATE INDEX [idx_active_users] ON [dbo].[users] ([status]) WHERE [status] = (2)")
+}
+
+// TestGenerateSchemaDiffSQL_SQLServerUnfilteredIndexStaysWithoutWhere guards
+// that ordinary index additions keep rendering without a WHERE clause.
+func TestGenerateSchemaDiffSQL_SQLServerUnfilteredIndexStaysWithoutWhere(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		IndexesAdded: []types.IndexRef{
+			{Name: "idx_users_status", TableName: "dbo.users"},
+		},
+	}
+	semantics := identifier.ForSQLServerCatalog("SQL_Latin1_General_CP1_CI_AS").
+		WithResolvedNames([]identifier.ResolvedName{
+			{Name: "dbo", Key: "dbo"},
+			{Name: "idx_users_status", Key: "idx_users_status"},
+			{Name: "status", Key: "status"},
+			{Name: "users", Key: "users"},
+		})
+	diff.IdentifierSemantics = &semantics
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Schema: "dbo", Name: "users"}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "status", Type: "INT", Nullable: false},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			Name:       "idx_users_status",
+			Fields:     []string{"status"},
+		}},
+	}
+
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, platform.SQLServer)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 1)
+	c.Assert(statements[0], qt.Equals, "CREATE INDEX [idx_users_status] ON [dbo].[users] ([status])")
+}

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -405,7 +405,7 @@ func indexDefinitionsChanged(
 	semantics identifier.Semantics,
 ) bool {
 	if !boolPtrEqual(generated.NullsDistinct, database.NullsDistinct) ||
-		indexPredicateChanged(generated.Condition, database.Condition) {
+		indexPredicateChanged(generated.Condition, database.Condition, dialect) {
 		return true
 	}
 	if platform.NormalizeDialect(dialect) != platform.SQLServer {
@@ -458,16 +458,24 @@ func effectiveDatabaseIndexParts(index types.DBIndex) []types.DBIndexPart {
 	return parts
 }
 
-func indexPredicateChanged(generated, database string) bool {
+func indexPredicateChanged(generated, database, dialect string) bool {
 	if strings.TrimSpace(generated) == "" || strings.TrimSpace(database) == "" {
 		return strings.TrimSpace(generated) != strings.TrimSpace(database)
 	}
 	if checkExpressionHasUnsupportedRewrite(generated, database) {
 		return false
 	}
-	return normalizePredicate(generated) != normalizePredicate(database)
+	return normalizePredicate(generated, dialect) != normalizePredicate(database, dialect)
 }
 
-func normalizePredicate(value string) string {
+// normalizePredicate reduces an index predicate to a spelling-insensitive
+// comparison key. SQL Server additionally strips the catalog's canonical
+// filter_definition decorations (bracket quoting, parenthesized numeric
+// literals) so user-authored predicates converge with introspected ones
+// instead of planning a replacement on every run.
+func normalizePredicate(value, dialect string) string {
+	if platform.NormalizeDialect(dialect) == platform.SQLServer {
+		value = normalizeSQLServerPredicateSpelling(value)
+	}
 	return normalizeCheckExpression(value)
 }

--- a/migration/schemadiff/internal/compare/sqlserver_predicate.go
+++ b/migration/schemadiff/internal/compare/sqlserver_predicate.go
@@ -1,0 +1,106 @@
+package compare
+
+import "strings"
+
+// normalizeSQLServerPredicateSpelling reduces SQL Server filtered-index
+// predicate spelling differences that carry no semantic weight before the
+// generic check-expression normalization runs.
+//
+// SQL Server persists sys.indexes.filter_definition in a canonical spelling:
+// identifiers come back bracket-quoted and numeric literals parenthesized, so
+// a user-authored predicate such as "status = 1" is stored as
+// "([status]=(1))". Comparing raw spellings verbatim would classify every
+// such filtered index as a perpetual drop/create replacement. This pass:
+//
+//   - drops square-bracket identifier quoting outside string literals, and
+//   - unwraps parentheses that wrap a bare numeric literal.
+//
+// String literal content, including doubled single-quote escapes, is
+// preserved verbatim. Spellings SQL Server rewrites more aggressively (for example
+// implicit N'...' prefixes or CAST insertions) are intentionally not
+// reconstructed here; they compare as changed and are documented as requiring
+// the catalog's canonical spelling in the annotation.
+func normalizeSQLServerPredicateSpelling(expr string) string {
+	previous := expr
+	for {
+		next := stripSQLServerPredicateSpelling(previous)
+		if next == previous {
+			return next
+		}
+		previous = next
+	}
+}
+
+func stripSQLServerPredicateSpelling(expr string) string {
+	var builder strings.Builder
+	builder.Grow(len(expr))
+	inString := false
+	for pos := 0; pos < len(expr); pos++ {
+		ch := expr[pos]
+		if ch == '\'' {
+			if inString && pos+1 < len(expr) && expr[pos+1] == '\'' {
+				builder.WriteString("''")
+				pos++
+				continue
+			}
+			inString = !inString
+			builder.WriteByte(ch)
+			continue
+		}
+		if inString {
+			builder.WriteByte(ch)
+			continue
+		}
+		if ch == '[' || ch == ']' {
+			continue
+		}
+		if ch == '(' {
+			if literal, closing, ok := parenthesizedNumericLiteral(expr, pos); ok {
+				builder.WriteString(literal)
+				pos = closing
+				continue
+			}
+		}
+		builder.WriteByte(ch)
+	}
+	return builder.String()
+}
+
+// parenthesizedNumericLiteral reports whether the parenthesis opening at
+// expr[open] wraps nothing but a bare numeric literal. It returns the literal
+// text and the position of the closing parenthesis.
+func parenthesizedNumericLiteral(expr string, open int) (literal string, closing int, ok bool) {
+	pos := skipPredicateSpaces(expr, open+1)
+	literalStart := pos
+	if pos < len(expr) && (expr[pos] == '-' || expr[pos] == '+') {
+		pos++
+	}
+	digits, dots := 0, 0
+	for pos < len(expr) {
+		ch := expr[pos]
+		if ch >= '0' && ch <= '9' {
+			digits++
+			pos++
+			continue
+		}
+		if ch == '.' {
+			dots++
+			pos++
+			continue
+		}
+		break
+	}
+	literalEnd := pos
+	pos = skipPredicateSpaces(expr, pos)
+	if digits == 0 || dots > 1 || pos >= len(expr) || expr[pos] != ')' {
+		return "", 0, false
+	}
+	return expr[literalStart:literalEnd], pos, true
+}
+
+func skipPredicateSpaces(expr string, pos int) int {
+	for pos < len(expr) && (expr[pos] == ' ' || expr[pos] == '\t' || expr[pos] == '\n' || expr[pos] == '\r') {
+		pos++
+	}
+	return pos
+}

--- a/migration/schemadiff/internal/compare/sqlserver_predicate_test.go
+++ b/migration/schemadiff/internal/compare/sqlserver_predicate_test.go
@@ -1,0 +1,149 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
+	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+// TestIndexes_SQLServerFilteredPredicateSpelling proves that filtered-index
+// predicate comparison for SQL Server tolerates the catalog's canonical
+// filter_definition spelling (bracket-quoted identifiers, parenthesized
+// numeric literals, wrapping parentheses) while still detecting real
+// predicate changes as a drop/create replacement.
+func TestIndexes_SQLServerFilteredPredicateSpelling(t *testing.T) {
+	replacementRefs := []difftypes.IndexRef{
+		{Name: "idx_users_filtered", TableName: "dbo.users"},
+	}
+	tests := []struct {
+		name          string
+		generated     string
+		database      string
+		wantAdditions []difftypes.IndexRef
+		wantRemovals  []difftypes.IndexRef
+	}{
+		{
+			name:      "natural spelling matches canonical numeric filter",
+			generated: "status = 1",
+			database:  "([status]=(1))",
+		},
+		{
+			name:      "IS NULL matches bracket-quoted catalog spelling",
+			generated: "deleted_at IS NULL",
+			database:  "([deleted_at] IS NULL)",
+		},
+		{
+			name:      "canonical spelling matches itself",
+			generated: "([status]=(2))",
+			database:  "([status]=(2))",
+		},
+		{
+			name:      "negative literal matches canonical parenthesized form",
+			generated: "balance > -1.5",
+			database:  "([balance]>(-1.5))",
+		},
+		{
+			name:      "string literal comparison keeps quote escapes",
+			generated: "note = 'it''s [a] (1)'",
+			database:  "([note]='it''s [a] (1)')",
+		},
+		{
+			name:      "compound predicate matches canonical spelling",
+			generated: "status = 1 AND deleted_at IS NULL",
+			database:  "([status]=(1) AND [deleted_at] IS NULL)",
+		},
+		{
+			name:          "changed literal still replaces",
+			generated:     "status = 2",
+			database:      "([status]=(1))",
+			wantAdditions: replacementRefs,
+			wantRemovals:  replacementRefs,
+		},
+		{
+			name:          "predicate added to unfiltered index replaces",
+			generated:     "status = 1",
+			database:      "",
+			wantAdditions: replacementRefs,
+			wantRemovals:  replacementRefs,
+		},
+		{
+			name:          "predicate removed from filtered index replaces",
+			generated:     "",
+			database:      "([status]=(1))",
+			wantAdditions: replacementRefs,
+			wantRemovals:  replacementRefs,
+		},
+		{
+			name:          "string literal content stays significant",
+			generated:     "note = 'active'",
+			database:      "([note]='archived')",
+			wantAdditions: replacementRefs,
+			wantRemovals:  replacementRefs,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				Indexes: []goschema.Index{{
+					Name:      "idx_users_filtered",
+					TableName: "dbo.users",
+					Fields:    []string{"status"},
+					Condition: test.generated,
+				}},
+			}
+			database := &types.DBSchema{
+				Indexes: []types.DBIndex{{
+					Name:      "idx_users_filtered",
+					TableName: "users",
+					Schema:    "dbo",
+					Columns:   []string{"status"},
+					Condition: test.database,
+				}},
+			}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, "sqlserver")
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, test.wantAdditions)
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, test.wantRemovals)
+		})
+	}
+}
+
+// TestIndexes_PredicateBracketSpellingStaysSignificantOutsideSQLServer guards
+// that the SQL Server spelling normalization is dialect-scoped: for
+// PostgreSQL, square brackets are meaningful (array subscripts) and must keep
+// participating in predicate comparison.
+func TestIndexes_PredicateBracketSpellingStaysSignificantOutsideSQLServer(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Indexes: []goschema.Index{{
+			Name:      "idx_users_filtered",
+			TableName: "users",
+			Fields:    []string{"tags"},
+			Condition: "tags[1] = 'admin'",
+		}},
+	}
+	database := &types.DBSchema{
+		Indexes: []types.DBIndex{{
+			Name:      "idx_users_filtered",
+			TableName: "users",
+			Columns:   []string{"tags"},
+			Condition: "tags1 = 'admin'",
+		}},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.IndexesWithDialect(generated, database, diff, "postgres")
+
+	ref := []difftypes.IndexRef{{Name: "idx_users_filtered", TableName: "users"}}
+	c.Assert(diff.IndexAdditions(), qt.DeepEquals, ref)
+	c.Assert(diff.IndexRemovals(), qt.DeepEquals, ref)
+}


### PR DESCRIPTION
Closes #781.

## Summary

Investigating the reported gap showed the historical predicate drop site was already fixed on master: #790 routes SQL Server index planning through `fromschema.FromIndex` (which carries `Condition`), and the mssql renderer has emitted `WHERE` since #458. Schemadiff does detect predicate changes and classifies them as replacement.

The **remaining real defect** was comparison-level: SQL Server canonicalizes `sys.indexes.filter_definition` — `status = 1` is stored as `([status]=(1))` — and the predicate comparator only stripped whitespace/case/outer parens, so every natural-spelling annotation compared as *changed* on every run → a perpetual `DROP INDEX` + `CREATE INDEX` replacement and drift that never cleared (the exact symptom in the issue).

## Fix

Dialect-scoped predicate-spelling normalization for SQL Server only (`migration/schemadiff/internal/compare/sqlserver_predicate.go`):
- strip square-bracket identifier quoting **outside string literals** (quote-escape aware — `''` doubling preserved verbatim);
- unwrap parentheses around bare numeric literals (sign/decimal aware), to a fixpoint.

`indexPredicateChanged`/`normalizePredicate` now take the dialect; PostgreSQL semantics are untouched (`arr[1]` subscripts stay significant — guarded by test). Spellings SQL Server rewrites more aggressively (implicit `N'…'`, `CAST` insertions) intentionally still compare as changed and are documented as requiring the catalog spelling — never silently mangled.

## Proof

- **Unit**: planner test asserts exactly `DROP INDEX [idx_active_users] ON [dbo].[users]` → `CREATE INDEX … WHERE [status] = (2)` on predicate change, and byte-identical output for unfiltered indexes; renderer tests prove `WHERE` emission (plain/unique/guarded) and no-`WHERE` regression; compare-level table tests cover the normalizer.
- **Live** (executed against a real SQL Server 2025 container during development): a `condition="status = 1"` index plans one `CREATE INDEX … WHERE status = 1`, applies, re-introspects `([status]=(1))`, and reaches **zero diff**; the existing #790 replacement test covers changed-predicate DROP+CREATE. The new live test name matches the existing `TestSQLServerLive…` selector in the sqlserver CI lane, so it runs in CI.

## Docs

`docs/sqlserver.md` (Filtered Indexes section) and the docs-site dialect notes.

## Testing

build, gofmt, vet, golangci-lint (0 issues), qtlint, teststyle, full `go test ./...` (157 packages), both public-API checks — all green; no exported API change.