### PR TITLE
test(atlas): complete project config acceptance

### DIFF
--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1,6 +1,7 @@
 package projectconfig_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,30 @@ import (
 
 	"github.com/stokaro/ptah/config/projectconfig"
 )
+
+type atlasProjectConfigGolden struct {
+	EnvName       string                     `json:"env_name"`
+	DatabaseURL   string                     `json:"database_url"`
+	DevURL        string                     `json:"dev_url"`
+	SchemaSources []string                   `json:"schema_sources"`
+	Exclude       []string                   `json:"exclude"`
+	Migration     atlasMigrationConfigGolden `json:"migration"`
+	Lint          atlasLintConfigGolden      `json:"lint"`
+}
+
+type atlasMigrationConfigGolden struct {
+	Dir             string `json:"dir"`
+	Format          string `json:"format"`
+	RevisionFormat  string `json:"revision_format"`
+	RevisionsSchema string `json:"revisions_schema"`
+	LockTimeout     string `json:"lock_timeout"`
+	ExecOrder       string `json:"exec_order"`
+	TxMode          string `json:"tx_mode"`
+}
+
+type atlasLintConfigGolden struct {
+	Latest *int `json:"latest"`
+}
 
 func TestParseAtlasProjectConfig(t *testing.T) {
 	c := qt.New(t)
@@ -49,6 +74,104 @@ func TestParseAtlasProjectConfig(t *testing.T) {
 	c.Assert(cfg.Migration.TxMode, qt.Equals, "none")
 	c.Assert(cfg.Lint.Latest, qt.IsNotNil)
 	c.Assert(*cfg.Lint.Latest, qt.Equals, 5)
+}
+
+func TestParseAtlasProjectConfigGolden_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		input   string
+		golden  string
+		envName string
+	}{
+		{
+			name:    "complete local environment",
+			input:   "complete.hcl",
+			golden:  "complete.golden.json",
+			envName: "",
+		},
+		{
+			name:    "selected production environment",
+			input:   "multiple-envs.hcl",
+			golden:  "production.golden.json",
+			envName: "production",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			raw := readAtlasProjectConfigFixture(c, tt.input)
+
+			cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", tt.envName)
+			c.Assert(err, qt.IsNil)
+
+			got, err := json.MarshalIndent(newAtlasProjectConfigGolden(cfg), "", "  ")
+			c.Assert(err, qt.IsNil)
+			got = append(got, '\n')
+
+			want := readAtlasProjectConfigFixture(c, tt.golden)
+			c.Assert(string(got), qt.Equals, string(want))
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigGolden_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "Atlas Cloud block",
+			input:   "unsupported-cloud.hcl",
+			wantErr: `unsupported atlas\.hcl construct "atlas" at atlas\.hcl:1`,
+		},
+		{
+			name:    "unknown environment attribute",
+			input:   "unsupported-attribute.hcl",
+			wantErr: `unsupported atlas\.hcl construct "project" at atlas\.hcl:2`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			raw := readAtlasProjectConfigFixture(c, tt.input)
+
+			_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+func readAtlasProjectConfigFixture(c *qt.C, name string) []byte {
+	c.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "atlas", name))
+	c.Assert(err, qt.IsNil)
+	return data
+}
+
+func newAtlasProjectConfigGolden(cfg projectconfig.Config) atlasProjectConfigGolden {
+	return atlasProjectConfigGolden{
+		EnvName:       cfg.EnvName,
+		DatabaseURL:   cfg.DatabaseURL,
+		DevURL:        cfg.DevURL,
+		SchemaSources: cfg.SchemaSources,
+		Exclude:       cfg.Exclude,
+		Migration: atlasMigrationConfigGolden{
+			Dir:             cfg.Migration.Dir,
+			Format:          cfg.Migration.Format,
+			RevisionFormat:  cfg.Migration.RevisionFormat,
+			RevisionsSchema: cfg.Migration.RevisionsSchema,
+			LockTimeout:     cfg.Migration.LockTimeout,
+			ExecOrder:       cfg.Migration.ExecOrder,
+			TxMode:          cfg.Migration.TxMode,
+		},
+		Lint: atlasLintConfigGolden{
+			Latest: cfg.Lint.Latest,
+		},
+	}
 }
 
 func TestParseAtlasProjectConfigPreservesMigrationDirURLSemantics(t *testing.T) {

--- a/config/projectconfig/testdata/atlas/complete.golden.json
+++ b/config/projectconfig/testdata/atlas/complete.golden.json
@@ -1,0 +1,24 @@
+{
+  "env_name": "local",
+  "database_url": "postgres://app@localhost:5432/app?sslmode=disable",
+  "dev_url": "docker://postgres/16/dev",
+  "schema_sources": [
+    "file://schema.hcl",
+    "schema.sql"
+  ],
+  "exclude": [
+    "tmp_*"
+  ],
+  "migration": {
+    "dir": "migrations",
+    "format": "atlas",
+    "revision_format": "atlas",
+    "revisions_schema": "atlas",
+    "lock_timeout": "3s",
+    "exec_order": "linear",
+    "tx_mode": "none"
+  },
+  "lint": {
+    "latest": 5
+  }
+}

--- a/config/projectconfig/testdata/atlas/complete.hcl
+++ b/config/projectconfig/testdata/atlas/complete.hcl
@@ -1,0 +1,17 @@
+env "local" {
+  url = "postgres://app@localhost:5432/app?sslmode=disable"
+  dev = "docker://postgres/16/dev"
+  src = ["file://schema.hcl", "schema.sql"]
+  exclude = ["tmp_*"]
+  migration {
+    dir              = "file://migrations"
+    format           = "atlas"
+    revisions_schema = "atlas"
+    lock_timeout     = "3s"
+    exec_order       = "linear"
+    tx_mode          = "none"
+  }
+  lint {
+    latest = 5
+  }
+}

--- a/config/projectconfig/testdata/atlas/multiple-envs.hcl
+++ b/config/projectconfig/testdata/atlas/multiple-envs.hcl
@@ -1,0 +1,26 @@
+env "development" {
+  url = "postgres://app@localhost:5432/development?sslmode=disable"
+  dev = "docker://postgres/16/development"
+  migration {
+    dir = "file://development-migrations"
+  }
+  lint {
+    latest = 2
+  }
+}
+
+env "production" {
+  url = "postgres://app@localhost:5432/production?sslmode=disable"
+  dev = "docker://postgres/16/production"
+  src = ["file://production.hcl"]
+  exclude = ["audit_*"]
+  migration {
+    dir              = "file://production-migrations"
+    revisions_schema = "migration_meta"
+    lock_timeout     = "10s"
+    exec_order       = "linear-skip"
+  }
+  lint {
+    latest = 8
+  }
+}

--- a/config/projectconfig/testdata/atlas/production.golden.json
+++ b/config/projectconfig/testdata/atlas/production.golden.json
@@ -1,0 +1,23 @@
+{
+  "env_name": "production",
+  "database_url": "postgres://app@localhost:5432/production?sslmode=disable",
+  "dev_url": "docker://postgres/16/production",
+  "schema_sources": [
+    "file://production.hcl"
+  ],
+  "exclude": [
+    "audit_*"
+  ],
+  "migration": {
+    "dir": "production-migrations",
+    "format": "atlas",
+    "revision_format": "atlas",
+    "revisions_schema": "migration_meta",
+    "lock_timeout": "10s",
+    "exec_order": "linear-skip",
+    "tx_mode": ""
+  },
+  "lint": {
+    "latest": 8
+  }
+}

--- a/config/projectconfig/testdata/atlas/unsupported-attribute.hcl
+++ b/config/projectconfig/testdata/atlas/unsupported-attribute.hcl
@@ -1,0 +1,3 @@
+env "local" {
+  project = "inventory"
+}

--- a/config/projectconfig/testdata/atlas/unsupported-cloud.hcl
+++ b/config/projectconfig/testdata/atlas/unsupported-cloud.hcl
@@ -1,0 +1,3 @@
+atlas {
+  cloud {}
+}

--- a/integration/atlas_project_config_e2e_test.go
+++ b/integration/atlas_project_config_e2e_test.go
@@ -18,6 +18,26 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
+const (
+	atlasProjectConfigSeedVersion    = "20260719010000"
+	atlasProjectConfigPendingVersion = "20260719010101"
+	atlasProjectConfigSeedHash       = "BH+RgWEaFyoTPktaYRIv/patf+c8tCfnN+p6QfFNmR0="
+	atlasProjectConfigPendingHash    = "EcuB2Y9oYkkrUBgA88MQGlzZAClvWSpHb1LUBOr+yAw="
+)
+
+type atlasProjectConfigRevision struct {
+	Version         string
+	Description     string
+	Type            int
+	Applied         int
+	Total           int
+	Error           sql.NullString
+	ErrorStatement  sql.NullString
+	Hash            string
+	PartialHashes   sql.NullString
+	OperatorVersion string
+}
+
 func TestAtlasProjectConfigMigrateStatusAndUpE2E(t *testing.T) {
 	dbURL := postgresE2EDatabaseURL(t)
 	if dbURL == "" {
@@ -44,14 +64,20 @@ func TestAtlasProjectConfigMigrateStatusAndUpE2E(t *testing.T) {
 	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
 
 	workDir := t.TempDir()
-	writeAtlasProjectConfigFixture(c, workDir, replaceDatabaseName(c, dbURL, testDBName))
+	testDBURL := replaceDatabaseName(c, dbURL, testDBName)
+	t.Setenv("PTAH_ATLAS_PROJECT_CONFIG_E2E_URL", testDBURL)
+	writeAtlasProjectConfigFixture(c, repoRoot, workDir)
+	seedAtlasProjectConfigDatabaseState(c, ctx, testDBURL)
 
 	output, err := runPtahInDir(ctx, workDir, binaryPath, "migrations", "status", "--env", "local", "--json")
 	c.Assert(err, qt.IsNil, qt.Commentf("migrations status output:\n%s", output))
-	c.Assert(readStatusField(c, output, "total_migrations"), qt.Equals, float64(1))
+	c.Assert(readStatusField(c, output, "total_migrations"), qt.Equals, float64(2))
+	c.Assert(readStatusField(c, output, "current_version"), qt.Equals, float64(20260719010000))
+	c.Assert(readStatusField(c, output, "applied_migrations"), qt.DeepEquals, []any{float64(20260719010000)})
+	c.Assert(readStatusField(c, output, "pending_migrations"), qt.DeepEquals, []any{float64(20260719010101)})
 	c.Assert(readStatusField(c, output, "has_pending_changes"), qt.Equals, true)
 
-	output, err = runPtahInDir(ctx, workDir, binaryPath, "migrations", "up", "--env", "local")
+	output, err = runPtahInDir(ctx, workDir, binaryPath, "migrations", "up", "--env", "local", "--verify-sum")
 	c.Assert(err, qt.IsNil, qt.Commentf("migrations up output:\n%s", output))
 	c.Assert(output, qt.Contains, "Migration directory format: atlas")
 	c.Assert(output, qt.Contains, "Database is now at version: 20260719010101")
@@ -59,33 +85,55 @@ func TestAtlasProjectConfigMigrateStatusAndUpE2E(t *testing.T) {
 	output, err = runPtahInDir(ctx, workDir, binaryPath, "migrations", "status", "--env", "local", "--json")
 	c.Assert(err, qt.IsNil, qt.Commentf("final migrations status output:\n%s", output))
 	c.Assert(readStatusField(c, output, "current_version"), qt.Equals, float64(20260719010101))
+	c.Assert(readStatusField(c, output, "applied_migrations"), qt.DeepEquals, []any{
+		float64(20260719010000),
+		float64(20260719010101),
+	})
+	c.Assert(readStatusField(c, output, "pending_migrations"), qt.DeepEquals, []any{})
 	c.Assert(readStatusField(c, output, "has_pending_changes"), qt.Equals, false)
 
-	verifyAtlasProjectConfigDatabaseState(c, ctx, replaceDatabaseName(c, dbURL, testDBName))
+	verifyAtlasProjectConfigDatabaseState(c, ctx, testDBURL)
 }
 
-func writeAtlasProjectConfigFixture(c *qt.C, workDir, dbURL string) {
-	migrationsDir := filepath.Join(workDir, "migrations")
-	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(workDir, "atlas.hcl"), []byte(fmt.Sprintf(`env "local" {
-  url = %q
-  migration {
-    dir              = "file://migrations"
-    revisions_schema = "ptah_issue_276"
-    lock_timeout     = "3s"
-    exec_order       = "linear"
-  }
+func writeAtlasProjectConfigFixture(c *qt.C, repoRoot, workDir string) {
+	fixtureRoot := filepath.Join(repoRoot, "integration", "testdata", "atlas-project-config")
+	c.Assert(os.CopyFS(workDir, os.DirFS(fixtureRoot)), qt.IsNil)
 }
-`, dbURL)), 0600), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "atlas.sum"), []byte(
-		"h1:directory\n"+
-			"20260719010101_create_project_config_widgets.sql h1:ptahissue276\n",
-	), 0600), qt.IsNil)
-	c.Assert(os.WriteFile(
-		filepath.Join(migrationsDir, "20260719010101_create_project_config_widgets.sql"),
-		[]byte("CREATE TABLE ptah_issue_276_widgets (id INT PRIMARY KEY);\n"),
-		0600,
-	), qt.IsNil)
+
+func seedAtlasProjectConfigDatabaseState(c *qt.C, ctx context.Context, dbURL string) {
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE ptah_issue_276_seed (id INT PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, "CREATE SCHEMA ptah_issue_276")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, `CREATE TABLE ptah_issue_276.atlas_schema_revisions (
+    version VARCHAR(255) PRIMARY KEY,
+    description TEXT NOT NULL,
+    type BIGINT NOT NULL DEFAULT 2,
+    applied BIGINT NOT NULL DEFAULT 0,
+    total BIGINT NOT NULL DEFAULT 0,
+    executed_at TIMESTAMP NOT NULL,
+    execution_time BIGINT NOT NULL,
+    error TEXT NULL,
+    error_stmt TEXT NULL,
+    hash VARCHAR(255) NOT NULL,
+    partial_hashes JSONB NULL,
+    operator_version VARCHAR(255) NOT NULL
+)`)
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, `INSERT INTO ptah_issue_276.atlas_schema_revisions
+(version, description, type, applied, total, executed_at, execution_time, hash, operator_version)
+VALUES ($1, $2, 2, 1, 1, $3, 100, $4, $5)`,
+		atlasProjectConfigSeedVersion,
+		"Seed project config",
+		time.Now(),
+		atlasProjectConfigSeedHash,
+		"Atlas",
+	)
+	c.Assert(err, qt.IsNil)
 }
 
 func runPtahInDir(ctx context.Context, dir, binaryPath string, args ...string) (string, error) {
@@ -113,11 +161,80 @@ WHERE table_schema = 'public' AND table_name = 'ptah_issue_276_widgets'`).Scan(&
 	c.Assert(err, qt.IsNil)
 	c.Assert(tableName, qt.Equals, "ptah_issue_276_widgets")
 
-	var version, hash string
-	err = db.QueryRowContext(ctx, `SELECT version, hash
-FROM ptah_issue_276.atlas_schema_revisions
-WHERE version = '20260719010101'`).Scan(&version, &hash)
+	err = db.QueryRowContext(ctx, `SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public' AND table_name = 'ptah_issue_276_seed'`).Scan(&tableName)
 	c.Assert(err, qt.IsNil)
-	c.Assert(version, qt.Equals, "20260719010101")
-	c.Assert(hash, qt.Equals, "ptahissue276")
+	c.Assert(tableName, qt.Equals, "ptah_issue_276_seed")
+
+	var indexName string
+	err = db.QueryRowContext(ctx, `SELECT indexname
+FROM pg_indexes
+WHERE schemaname = 'public' AND indexname = 'idx_ptah_issue_276_seed_id'`).Scan(&indexName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(indexName, qt.Equals, "idx_ptah_issue_276_seed_id")
+
+	seedRevision := readAtlasProjectConfigRevision(c, ctx, db, atlasProjectConfigSeedVersion)
+	c.Assert(seedRevision, qt.DeepEquals, atlasProjectConfigRevision{
+		Version:         atlasProjectConfigSeedVersion,
+		Description:     "Seed project config",
+		Type:            2,
+		Applied:         1,
+		Total:           1,
+		Hash:            atlasProjectConfigSeedHash,
+		OperatorVersion: "Atlas",
+	})
+
+	pendingRevision := readAtlasProjectConfigRevision(c, ctx, db, atlasProjectConfigPendingVersion)
+	c.Assert(pendingRevision, qt.DeepEquals, atlasProjectConfigRevision{
+		Version:         atlasProjectConfigPendingVersion,
+		Description:     "Create Project Config Widgets",
+		Type:            2,
+		Applied:         2,
+		Total:           2,
+		Hash:            atlasProjectConfigPendingHash,
+		OperatorVersion: "Ptah",
+	})
+
+	var revisionCount int
+	err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ptah_issue_276.atlas_schema_revisions`).Scan(&revisionCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisionCount, qt.Equals, 2)
+}
+
+func readAtlasProjectConfigRevision(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	version string,
+) atlasProjectConfigRevision {
+	c.Helper()
+
+	var revision atlasProjectConfigRevision
+	err := db.QueryRowContext(ctx, `SELECT
+    version,
+    description,
+    type,
+    applied,
+    total,
+    error,
+    error_stmt,
+    hash,
+    partial_hashes,
+    operator_version
+FROM ptah_issue_276.atlas_schema_revisions
+WHERE version = $1`, version).Scan(
+		&revision.Version,
+		&revision.Description,
+		&revision.Type,
+		&revision.Applied,
+		&revision.Total,
+		&revision.Error,
+		&revision.ErrorStatement,
+		&revision.Hash,
+		&revision.PartialHashes,
+		&revision.OperatorVersion,
+	)
+	c.Assert(err, qt.IsNil)
+	return revision
 }

--- a/integration/testdata/atlas-project-config/atlas.hcl
+++ b/integration/testdata/atlas-project-config/atlas.hcl
@@ -1,0 +1,8 @@
+env "local" {
+  url = getenv("PTAH_ATLAS_PROJECT_CONFIG_E2E_URL")
+  migration {
+    dir              = "file://migrations"
+    revisions_schema = "ptah_issue_276"
+    exec_order       = "linear"
+  }
+}

--- a/integration/testdata/atlas-project-config/migrations/20260719010000_seed_project_config.sql
+++ b/integration/testdata/atlas-project-config/migrations/20260719010000_seed_project_config.sql
@@ -1,0 +1,1 @@
+CREATE TABLE ptah_issue_276_seed (id INT PRIMARY KEY);

--- a/integration/testdata/atlas-project-config/migrations/20260719010101_create_project_config_widgets.sql
+++ b/integration/testdata/atlas-project-config/migrations/20260719010101_create_project_config_widgets.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+CREATE INDEX CONCURRENTLY idx_ptah_issue_276_seed_id ON ptah_issue_276_seed (id);
+CREATE TABLE ptah_issue_276_widgets (id INT PRIMARY KEY);

--- a/integration/testdata/atlas-project-config/migrations/atlas.sum
+++ b/integration/testdata/atlas-project-config/migrations/atlas.sum
@@ -1,0 +1,3 @@
+h1:hXcTbqFWJj+MpSUHxj2gx+LKG1Iwo57RusuWLa61D2M=
+20260719010000_seed_project_config.sql h1:BH+RgWEaFyoTPktaYRIv/patf+c8tCfnN+p6QfFNmR0=
+20260719010101_create_project_config_widgets.sql h1:EcuB2Y9oYkkrUBgA88MQGlzZAClvWSpHb1LUBOr+yAw=


### PR DESCRIPTION
## Summary

Completes the literal acceptance evidence that remained missing from #276 after its original implementation:

- adds a checked-in `atlas.hcl` golden corpus for complete config loading, environment selection, Atlas Cloud rejection, and unknown-attribute diagnostics;
- replaces the synthetic E2E setup with an Atlas-shaped fixture repository and a canonical, checksum-validated `atlas.sum`;
- pre-seeds an Atlas revision table and one applied migration, then proves Ptah reports only the second migration as pending;
- exercises `-- atlas:txmode none` through `CREATE INDEX CONCURRENTLY`, so directive regressions fail on PostgreSQL;
- verifies final schema state and every relevant field in both Atlas/Ptah revision rows.

Refs #276. The issue remains open until companion conformance adds the independent Atlas-vs-Ptah status oracle.

## Self-review

Two local review passes and two independent agent reviews covered declarative test structure, fixture validity, checksum semantics, Atlas directive execution, brownfield revision preservation, database cleanup, and metadata completeness. Review findings about fake hashes, circular evidence, directive coverage, and shallow revision assertions were addressed before opening this PR.

## Verification

- `gopls check config/projectconfig/atlas_test.go integration/atlas_project_config_e2e_test.go`
- `scripts/check-test-style.sh`
- `go tool qtlint ./...`
- `golangci-lint run --build-tags=integration ./config/projectconfig ./integration`
- `go test ./... -count=1` (green outside the macOS sandbox; the sandboxed run only failed existing bind/write tests)
- `go test -tags=integration ./integration -run '^TestAtlasProjectConfigMigrateStatusAndUpE2E$' -count=1 -v` against PostgreSQL 18
- `ptah-compat migrate validate --dir file://integration/testdata/atlas-project-config/migrations`

All completed successfully. The branch was rebased onto current `origin/master` before the final focused checks.