### PR TITLE
Fix migration file loading rejecting the documented check directive

### DIFF
--- a/cmd/migrateup/checks_file_load_internal_test.go
+++ b/cmd/migrateup/checks_file_load_internal_test.go
@@ -1,0 +1,101 @@
+package migrateup
+
+// White-box testing required: these tests reuse resetMigrateUpCommandForTest,
+// which manages the command's package-global flag state and is not accessible
+// from an external test package.
+//
+// The tests give end-to-end coverage for `-- +ptah check` directives loaded
+// from real migration files (docs/pre-migration-checks.md syntax). This
+// regressed once: the timeout directive scanner rejected the `check` token, so
+// any file carrying the documented directive failed to load with
+// `invalid +ptah directive "check"` before the check could ever run. The
+// check-execution tests in migration/migrator bypass file loading via
+// CreateMigrationFromSQL, so the CLI file path must be exercised here.
+
+import (
+	"bytes"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migratehash"
+)
+
+// checkDirectiveDropUsersSQL is the exact documented directive syntax from
+// docs/pre-migration-checks.md guarding a destructive statement.
+const checkDirectiveDropUsersSQL = `-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort` + "\nDROP TABLE users;\n"
+
+// hashMigrationsDirForTest hashes dir through the real `migrations hash`
+// command so --verify-sum exercises the full hash-then-load CLI flow.
+func hashMigrationsDirForTest(c *qt.C, dir string) {
+	c.Helper()
+	cmd := migratehash.NewMigrateHashCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--dir", dir})
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("hash output:\n%s", out.String()))
+}
+
+func writeCheckDirectiveMigrationsDir(c *qt.C, initUpSQL string) string {
+	c.Helper()
+	dir := c.TempDir()
+	writeMigrateUpFile(c, dir, "0000000001_init.up.sql", initUpSQL)
+	writeMigrateUpFile(c, dir, "0000000001_init.down.sql", "DROP TABLE users;\n")
+	writeMigrateUpFile(c, dir, "0000000002_drop_users.up.sql", checkDirectiveDropUsersSQL)
+	writeMigrateUpFile(c, dir, "0000000002_drop_users.down.sql", "CREATE TABLE users (id INTEGER PRIMARY KEY);\n")
+	hashMigrationsDirForTest(c, dir)
+	return dir
+}
+
+func executeCheckDirectiveMigrateUp(c *qt.C, dir, dbURL string) error {
+	c.Helper()
+	cmd := NewMigrateUpCommand()
+	resetMigrateUpCommandForTest(c, cmd)
+	c.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
+	var out, errOut bytes.Buffer // swallow command output to keep test logs quiet
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--verify-sum",
+		"--allow-destructive",
+	})
+	return cmd.Execute()
+}
+
+func TestMigrateUpCommand_CheckDirectiveFilePassingCheckApplies(t *testing.T) {
+	c := qt.New(t)
+
+	// users is created empty, so migration 2's check passes and the guarded
+	// DROP TABLE applies.
+	dir := writeCheckDirectiveMigrationsDir(c, "CREATE TABLE users (id INTEGER PRIMARY KEY);\n")
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+
+	err := executeCheckDirectiveMigrateUp(c, dir, dbURL)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqliteMigrateUpTableExists(c, dbURL, "users"), qt.IsFalse)
+}
+
+func TestMigrateUpCommand_CheckDirectiveFileFailingCheckAborts(t *testing.T) {
+	c := qt.New(t)
+
+	// users is seeded with a row, so migration 2's check must execute, fail,
+	// and abort with the guarded DROP TABLE never applied.
+	dir := writeCheckDirectiveMigrationsDir(c,
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\nINSERT INTO users (id) VALUES (1);\n")
+	dbURL := (&url.URL{Scheme: "sqlite", Path: filepath.Join(t.TempDir(), "ptah.db")}).String()
+
+	err := executeCheckDirectiveMigrateUp(c, dir, dbURL)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "invalid +ptah directive",
+		qt.Commentf("the documented check directive must not fail file loading"))
+	c.Assert(err.Error(), qt.Contains, "pre-migration check users_empty for migration 2 was not satisfied")
+	c.Assert(err.Error(), qt.Contains, "rerun with --skip-checks")
+	c.Assert(sqliteMigrateUpTableExists(c, dbURL, "users"), qt.IsTrue)
+}

--- a/cmd/migratevalidate/migratevalidate_devurl_test.go
+++ b/cmd/migratevalidate/migratevalidate_devurl_test.go
@@ -52,6 +52,37 @@ func TestMigrateValidate_DevURLFailureExitsTwo(t *testing.T) {
 	c.Assert(stderr, qt.Contains, "error validating migration SQL on dev database")
 }
 
+func TestMigrateValidate_DevURLReplaysCheckDirectiveMigration(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := t.TempDir()
+	devDBPath := filepath.Join(t.TempDir(), "dev.db")
+	write := func(name, content string) {
+		c.Assert(os.WriteFile(filepath.Join(migrationsDir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	write("0000000001_init.up.sql", "CREATE TABLE users (id INTEGER PRIMARY KEY);\n")
+	write("0000000001_init.down.sql", "DROP TABLE users;\n")
+	// The documented pre-migration check syntax (docs/pre-migration-checks.md)
+	// must load and replay from a real file; the directive once failed loading
+	// with `invalid +ptah directive "check"`.
+	write("0000000002_drop_users.up.sql",
+		`-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort`+"\nDROP TABLE users;\n")
+	write("0000000002_drop_users.down.sql", "CREATE TABLE users (id INTEGER PRIMARY KEY);\n")
+	_, err := migratesum.Write(migrationsDir)
+	c.Assert(err, qt.IsNil)
+
+	stdout, stderr, err := executeValidate(
+		"--dir", migrationsDir,
+		"--dev-url", "sqlite://"+devDBPath,
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr))
+	c.Assert(stdout, qt.Contains, "OK: migrations directory matches ptah.sum")
+	c.Assert(stdout, qt.Contains, "OK: migration SQL validated on dev database")
+	// The replay ran both migrations: users was created empty, migration 2's
+	// check passed, and the guarded DROP TABLE applied.
+	assertSQLiteTableCount(c, devDBPath, "users", 0)
+}
+
 func TestMigrateValidate_DriftSkipsDevURL(t *testing.T) {
 	c := qt.New(t)
 	migrationsDir := t.TempDir()

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -661,6 +661,83 @@ func TestNewFSMigrationProvider_InvalidFiles(t *testing.T) {
 	c.Assert(migrations[0].Version, qt.Equals, int64(1))
 }
 
+// checkDirectiveLine is the documented pre-migration check syntax from
+// docs/pre-migration-checks.md. A file carrying it must load through the
+// provider; this regressed once when the timeout directive scanner rejected
+// the `check` token.
+const checkDirectiveLine = `-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort`
+
+func TestNewFSMigrationProvider_CheckDirectiveMigrationLoads(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_drop_users.up.sql": &fstest.MapFile{
+			Data: []byte(checkDirectiveLine + "\nDROP TABLE users;\n"),
+		},
+		"0000000001_drop_users.down.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	// The check survives loading verbatim so it executes on apply.
+	c.Assert(migrations[0].UpSQL, qt.Contains, checkDirectiveLine)
+	checks, err := migrator.ParseChecks(migrations[0].UpSQL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(checks, qt.HasLen, 1)
+	c.Assert(checks[0].Name, qt.Equals, "users_empty")
+}
+
+func TestNewFSMigrationProvider_CheckAndTimeoutDirectivesInOneFile(t *testing.T) {
+	c := qt.New(t)
+
+	fsys := fstest.MapFS{
+		"0000000001_drop_users.up.sql": &fstest.MapFile{
+			Data: []byte(checkDirectiveLine + "\n-- +ptah lock_timeout=3s statement_timeout=30s\nDROP TABLE users;\n"),
+		},
+		"0000000001_drop_users.down.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil)
+
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+	c.Assert(migrations[0].UpTimeouts.HasLockTimeout, qt.IsTrue)
+	c.Assert(migrations[0].UpTimeouts.LockTimeout, qt.Equals, 3*time.Second)
+	c.Assert(migrations[0].UpTimeouts.HasStatementTimeout, qt.IsTrue)
+	c.Assert(migrations[0].UpTimeouts.StatementTimeout, qt.Equals, 30*time.Second)
+	checks, err := migrator.ParseChecks(migrations[0].UpSQL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(checks, qt.HasLen, 1)
+}
+
+func TestNewFSMigrationProvider_BareUnknownDirectiveStillRejected(t *testing.T) {
+	c := qt.New(t)
+
+	// A bare token that no directive family owns (e.g. a typo'd timeout
+	// directive that lost its value) must keep failing the load with the
+	// established error message.
+	fsys := fstest.MapFS{
+		"0000000001_init.up.sql": &fstest.MapFile{
+			Data: []byte("-- +ptah lock_timeuot\nCREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		},
+		"0000000001_init.down.sql": &fstest.MapFile{
+			Data: []byte("DROP TABLE users;\n"),
+		},
+	}
+
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.ErrorMatches, `failed to load up migration 0000000001_init\.up\.sql: invalid \+ptah directive "lock_timeuot"`)
+	c.Assert(provider, qt.IsNil)
+}
+
 func TestFSMigrationProvider_FilesystemError(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -466,6 +466,25 @@ ALTER TABLE users ADD COLUMN email TEXT;`,
 			sql:  "-- +ptah no_transaction\nALTER TABLE users ADD COLUMN email TEXT;",
 		},
 		{
+			name: "check directive is ignored by timeout parser",
+			sql:  `-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort` + "\nDROP TABLE users;",
+		},
+		{
+			name: "check directive alongside timeout directives",
+			sql: `-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort
+-- +ptah lock_timeout=3s statement_timeout=30s
+DROP TABLE users;`,
+			wantLockTimeout:         3 * time.Second,
+			wantStatementTimeout:    30 * time.Second,
+			wantHasLockTimeout:      true,
+			wantHasStatementTimeout: true,
+		},
+		{
+			name:    "bare unknown directive fails",
+			sql:     "-- +ptah unknown_directive\nALTER TABLE users ADD COLUMN email TEXT;",
+			wantErr: `invalid +ptah directive "unknown_directive"`,
+		},
+		{
 			name:    "invalid duration fails",
 			sql:     "-- +ptah lock_timeout=soon\nALTER TABLE users ADD COLUMN email TEXT;",
 			wantErr: "invalid +ptah lock_timeout value",

--- a/migration/migrator/timeouts.go
+++ b/migration/migrator/timeouts.go
@@ -75,38 +75,53 @@ func parseMigrationTimeoutDirectives(sql string) (MigrationTimeouts, error) {
 		if directive == "" {
 			return MigrationTimeouts{}, fmt.Errorf("empty +ptah directive")
 		}
+		if isCheckDirectiveBody(directive) {
+			// `-- +ptah check ...` is an ordered pre-migration check owned by
+			// ParseChecks. Its quoted assert value may contain spaces and '=',
+			// so it must be skipped as a whole line rather than field-split.
+			continue
+		}
 
-		for field := range strings.FieldsSeq(directive) {
-			key, value, ok := strings.Cut(field, "=")
-			if !ok {
-				if field == DirectiveNoTransaction {
-					continue
-				}
-				return MigrationTimeouts{}, fmt.Errorf("invalid +ptah directive %q", field)
-			}
-
-			switch key {
-			case "lock_timeout", "lock-timeout":
-				duration, err := parsePositiveDuration(value)
-				if err != nil {
-					return MigrationTimeouts{}, fmt.Errorf("invalid +ptah %s value: %w", key, err)
-				}
-				timeouts.LockTimeout = duration
-				timeouts.HasLockTimeout = true
-			case "statement_timeout", "statement-timeout":
-				duration, err := parsePositiveDuration(value)
-				if err != nil {
-					return MigrationTimeouts{}, fmt.Errorf("invalid +ptah %s value: %w", key, err)
-				}
-				timeouts.StatementTimeout = duration
-				timeouts.HasStatementTimeout = true
-			default:
-				continue
-			}
+		if err := parseTimeoutDirectiveFields(directive, &timeouts); err != nil {
+			return MigrationTimeouts{}, err
 		}
 	}
 
 	return timeouts, nil
+}
+
+// parseTimeoutDirectiveFields field-splits a single `-- +ptah` directive body
+// and folds any timeout key=value pairs into timeouts. Unknown key=value fields
+// belong to other directive families and are skipped; a bare field that is not
+// no_transaction is a typo'd directive and rejected.
+func parseTimeoutDirectiveFields(directive string, timeouts *MigrationTimeouts) error {
+	for field := range strings.FieldsSeq(directive) {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			if field == DirectiveNoTransaction {
+				continue
+			}
+			return fmt.Errorf("invalid +ptah directive %q", field)
+		}
+
+		switch key {
+		case "lock_timeout", "lock-timeout":
+			duration, err := parsePositiveDuration(value)
+			if err != nil {
+				return fmt.Errorf("invalid +ptah %s value: %w", key, err)
+			}
+			timeouts.LockTimeout = duration
+			timeouts.HasLockTimeout = true
+		case "statement_timeout", "statement-timeout":
+			duration, err := parsePositiveDuration(value)
+			if err != nil {
+				return fmt.Errorf("invalid +ptah %s value: %w", key, err)
+			}
+			timeouts.StatementTimeout = duration
+			timeouts.HasStatementTimeout = true
+		}
+	}
+	return nil
 }
 
 func parsePositiveDuration(value string) (time.Duration, error) {

--- a/migration/migrator/timeouts_test.go
+++ b/migration/migrator/timeouts_test.go
@@ -146,6 +146,75 @@ func TestTimeoutStatements(t *testing.T) {
 	}
 }
 
+// TestParseMigrationTimeoutDirectives_ToleratesEveryDirectiveFamily pins the
+// timeout scanner against the full `-- +ptah` directive vocabulary. The scanner
+// runs on every migration file load, so any directive family owned by another
+// parser must pass through it without error — otherwise files carrying that
+// directive fail to load entirely (this regressed once for `check`). When
+// adding a new directive family, add a row here.
+//
+// This is a white-box test because parseMigrationTimeoutDirectives is the
+// unexported scanner on the file-load path; the cross-check must target it
+// directly to guard the two parsers against drifting.
+func TestParseMigrationTimeoutDirectives_ToleratesEveryDirectiveFamily(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		// recognize proves the directive family is real: its owning parser
+		// accepts the exact line the timeout scanner is asked to tolerate.
+		recognize func(c *qt.C, sql string)
+	}{
+		{
+			name: "no_transaction",
+			line: "-- +ptah " + DirectiveNoTransaction,
+			recognize: func(c *qt.C, sql string) {
+				c.Assert(ParseFileDirectives(sql)[DirectiveNoTransaction], qt.Equals, "true")
+			},
+		},
+		{
+			name: "timeouts",
+			line: "-- +ptah lock_timeout=3s statement_timeout=30s",
+			recognize: func(c *qt.C, sql string) {
+				directives := ParseFileDirectives(sql)
+				c.Assert(directives["lock_timeout"], qt.Equals, "3s")
+				c.Assert(directives["statement_timeout"], qt.Equals, "30s")
+			},
+		},
+		{
+			name: "online DDL routing",
+			line: "-- +ptah online_ddl_tool=ghost online_ddl_fallback=error",
+			recognize: func(c *qt.C, sql string) {
+				directives := ParseFileDirectives(sql)
+				c.Assert(directives["online_ddl_tool"], qt.Equals, "ghost")
+				c.Assert(directives["online_ddl_fallback"], qt.Equals, "error")
+			},
+		},
+		{
+			name: "pre-migration check",
+			line: `-- +ptah check name="users_empty" assert="SELECT count(*) = 0 FROM users" on_fail=abort`,
+			recognize: func(c *qt.C, sql string) {
+				checks, err := ParseChecks(sql)
+				c.Assert(err, qt.IsNil)
+				c.Assert(checks, qt.HasLen, 1)
+				c.Assert(checks[0].Name, qt.Equals, "users_empty")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql := tt.line + "\nALTER TABLE users ADD COLUMN email TEXT;"
+			tt.recognize(c, sql)
+
+			_, err := parseMigrationTimeoutDirectives(sql)
+			c.Assert(err, qt.IsNil,
+				qt.Commentf("timeout scanner must tolerate the %s directive family or files carrying it cannot load", tt.name))
+		})
+	}
+}
+
 func TestDurationUnitCeilUsesIntegerMath(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Fixes a regression surfaced while verifying docs examples for #804: any migration file carrying the documented pre-migration-check directive (`-- +ptah check ...`, feature #661) failed to LOAD through the CLI with `invalid +ptah directive "check"` (exit 2).

## Root cause

`parseMigrationTimeoutDirectives` (`migration/migrator/timeouts.go`) field-splits every leading `-- +ptah` line with a strict timeout-token allowlist and errored on the `check` token (and would also choke on the quoted assert body). The newer `ParseFileDirectives` already understands check bodies via `isCheckDirectiveBody` — the two parsers had drifted. Existing check tests bypassed file loading (`CreateMigrationFromSQL`), so CI never caught it.

## Fix

The timeouts scanner now skips whole lines recognized by the **same** `isCheckDirectiveBody` predicate `ParseFileDirectives` uses (one shared definition, no duplicate vocabulary). **Typo detection preserved**: bare tokens other than the timeout family still fail with the unchanged `invalid +ptah directive %q` message — now pinned by tests at parser, provider, and message-text level. A cross-family drift guard (`TestParseMigrationTimeoutDirectives_ToleratesEveryDirectiveFamily`) pins the scanner against every `-- +ptah` directive family, cross-verified against each owning parser.

## Proof

End-to-end on ephemeral SQLite through the real file-load path: `hash` → `up --verify-sum` → `status` all pass with a check-guarded migration; with seeded rows the check **gates**: `up` exits 2 with `pre-migration check users_empty ... was not satisfied` and the data survives. Plus dev-url replay coverage, check+timeout-in-one-file, and typo-rejection regression tests.

## Testing

build, gofmt, vet, golangci-lint (0 issues), qtlint, teststyle, full `go test ./...`, public-API checks — all green.