### PR TITLE
Make Go annotation cleanup syntax-aware and source-set safe

### DIFF
--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -3,10 +3,16 @@ package goannotationcleanup
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"go/parser"
+	"go/token"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/stokaro/ptah/internal/annotationmeta"
 )
 
 // Result describes cleanup changes for one file.
@@ -24,15 +30,15 @@ type Options struct {
 	Diff    bool
 }
 
-type cleanMode int
-
-const (
-	cleanModeWrite cleanMode = iota
-	cleanModeDryRun
-)
-
 type removedLine struct {
 	number int
+}
+
+type filePlan struct {
+	result Result
+	info   os.FileInfo
+	before []byte
+	after  []byte
 }
 
 // CleanDir removes Ptah schema annotations from Go files under RootDir.
@@ -42,7 +48,7 @@ func CleanDir(opts Options) ([]Result, error) {
 		root = "."
 	}
 	root = filepath.Clean(root)
-	var results []Result
+	var plans []filePlan
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -53,40 +59,63 @@ func CleanDir(opts Options) ([]Result, error) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") {
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
-		mode := cleanModeWrite
-		if opts.DryRun || opts.Diff {
-			mode = cleanModeDryRun
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refuse to clean symlinked Go source %s", path)
 		}
-		result, err := cleanFile(path, mode)
+		plan, err := planFile(path)
 		if err != nil {
 			return err
 		}
-		if result.Changed {
-			if !opts.Diff {
-				result.Diff = ""
-			}
-			results = append(results, result)
+		if plan.result.Changed {
+			plans = append(plans, plan)
 		}
 		return nil
 	})
-	return results, err
+	if err != nil {
+		return nil, err
+	}
+	if !opts.DryRun && !opts.Diff {
+		if err := applyPlans(plans); err != nil {
+			return nil, err
+		}
+	}
+	results := make([]Result, len(plans))
+	for i := range plans {
+		result := plans[i].result
+		if !opts.Diff {
+			result.Diff = ""
+		}
+		results[i] = result
+	}
+	return results, nil
 }
 
-func cleanFile(path string, mode cleanMode) (Result, error) {
-	info, err := os.Stat(path)
+func planFile(path string) (filePlan, error) {
+	info, err := os.Lstat(path)
 	if err != nil {
-		return Result{}, fmt.Errorf("stat %s: %w", path, err)
+		return filePlan{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return filePlan{}, fmt.Errorf("refuse to clean non-regular Go source %s", path)
 	}
 	before, err := os.ReadFile(path)
 	if err != nil {
-		return Result{}, fmt.Errorf("read %s: %w", path, err)
+		return filePlan{}, fmt.Errorf("read %s: %w", path, err)
 	}
-	after, removed := removeAnnotationLines(before)
+	after, removed, err := removeAnnotationLines(path, before)
+	if err != nil {
+		return filePlan{}, err
+	}
 	if len(removed) == 0 {
-		return Result{Path: path}, nil
+		return filePlan{
+			result: Result{Path: path},
+			info:   info,
+			before: before,
+			after:  after,
+		}, nil
 	}
 	result := Result{
 		Path:         path,
@@ -94,34 +123,151 @@ func cleanFile(path string, mode cleanMode) (Result, error) {
 		RemovedLines: len(removed),
 		Diff:         unifiedRemovalDiff(path, before, removed),
 	}
-	if result.Changed && mode == cleanModeWrite {
-		if err := os.WriteFile(path, after, info.Mode().Perm()); err != nil {
-			return Result{}, fmt.Errorf("write cleaned Go file %s: %w", path, err)
-		}
-	}
-	return result, nil
+	return filePlan{
+		result: result,
+		info:   info,
+		before: before,
+		after:  after,
+	}, nil
 }
 
-func removeAnnotationLines(data []byte) ([]byte, []removedLine) {
+func applyPlans(plans []filePlan) error {
+	files := make([]*os.File, 0, len(plans))
+	for _, plan := range plans {
+		file, err := openValidatedPlan(plan)
+		if err != nil {
+			return errors.Join(err, closeFiles(files))
+		}
+		files = append(files, file)
+	}
+
+	for i, file := range files {
+		if err := writePlan(file, plans[i]); err != nil {
+			return errors.Join(err, closeFiles(files))
+		}
+	}
+	return closeFiles(files)
+}
+
+func openValidatedPlan(plan filePlan) (*os.File, error) {
+	info, err := os.Lstat(plan.result.Path)
+	if err != nil {
+		return nil, fmt.Errorf("stat Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
+	}
+
+	file, err := os.OpenFile(plan.result.Path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open Go source for cleanup %s: %w", plan.result.Path, err)
+	}
+	currentInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("stat opened Go source %s: %w", plan.result.Path, err)
+	}
+	if !os.SameFile(plan.info, currentInfo) {
+		_ = file.Close()
+		return nil, fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
+	}
+	if err := validatePlanContent(file, plan); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func validatePlanContent(file *os.File, plan filePlan) error {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	current, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("read Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if !bytes.Equal(current, plan.before) {
+		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
+	}
+	return nil
+}
+
+func writePlan(file *os.File, plan filePlan) error {
+	if err := validatePlanContent(file, plan); err != nil {
+		return err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek Go source for cleanup %s: %w", plan.result.Path, err)
+	}
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncate Go source for cleanup %s: %w", plan.result.Path, err)
+	}
+	if _, err := file.Write(plan.after); err != nil {
+		return fmt.Errorf("write cleaned Go source %s: %w", plan.result.Path, err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync cleaned Go source %s: %w", plan.result.Path, err)
+	}
+	return nil
+}
+
+func closeFiles(files []*os.File) error {
+	var closeErr error
+	for _, file := range files {
+		if err := file.Close(); err != nil {
+			closeErr = errors.Join(closeErr, fmt.Errorf("close cleaned Go source %s: %w", file.Name(), err))
+		}
+	}
+	return closeErr
+}
+
+func removeAnnotationLines(path string, data []byte) ([]byte, []removedLine, error) {
 	lines := bytes.SplitAfter(data, []byte("\n"))
+	lineNumbers, err := annotationLineNumbers(path, data, lines)
+	if err != nil {
+		return nil, nil, err
+	}
 	filtered := make([][]byte, 0, len(lines))
 	removed := make([]removedLine, 0)
 	for i, line := range lines {
-		if isPtahSchemaAnnotationLine(line) {
+		lineNumber := i + 1
+		if _, ok := lineNumbers[lineNumber]; ok {
 			removed = append(removed, removedLine{
-				number: i + 1,
+				number: lineNumber,
 			})
 			continue
 		}
 		filtered = append(filtered, line)
 	}
-	return bytes.Join(filtered, nil), removed
+	return bytes.Join(filtered, nil), removed, nil
 }
 
-func isPtahSchemaAnnotationLine(line []byte) bool {
-	trimmed := strings.TrimSpace(string(line))
-	return strings.HasPrefix(trimmed, "//migrator:schema:") ||
-		strings.HasPrefix(trimmed, "//migrator:embedded")
+func annotationLineNumbers(path string, data []byte, lines [][]byte) (map[int]struct{}, error) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, data, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parse Go source %s: %w", path, err)
+	}
+
+	lineNumbers := make(map[int]struct{})
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			lineNumber := fileSet.PositionFor(comment.Pos(), false).Line
+			if !isPtahSchemaAnnotationComment(comment.Text) ||
+				lineNumber < 1 ||
+				lineNumber > len(lines) ||
+				strings.TrimSpace(string(lines[lineNumber-1])) != strings.TrimSpace(comment.Text) {
+				continue
+			}
+			lineNumbers[lineNumber] = struct{}{}
+		}
+	}
+	return lineNumbers, nil
+}
+
+func isPtahSchemaAnnotationComment(comment string) bool {
+	_, ok := annotationmeta.MatchCommentDirective(comment)
+	return ok
 }
 
 func unifiedRemovalDiff(path string, before []byte, removed []removedLine) string {
@@ -199,5 +345,6 @@ func writeDiffLine(builder *strings.Builder, prefix byte, line string) {
 	builder.WriteString(line)
 	if !strings.HasSuffix(line, "\n") {
 		builder.WriteByte('\n')
+		builder.WriteString("\\ No newline at end of file\n")
 	}
 }

--- a/internal/goannotationcleanup/cleanup_symlink_unix_test.go
+++ b/internal/goannotationcleanup/cleanup_symlink_unix_test.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package goannotationcleanup_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationcleanup"
+)
+
+func TestCleanDir_FailurePath_RejectsSymlinkedGoSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "outside.go")
+	link := filepath.Join(root, "model.go")
+	original := "package outside\n\n//migrator:schema:table name=\"outside\"\ntype Outside struct{}\n"
+	c.Assert(os.WriteFile(target, []byte(original), 0o600), qt.IsNil)
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: root})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "refuse to clean symlinked Go source")
+	c.Assert(results, qt.HasLen, 0)
+	content, err := os.ReadFile(target)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, original)
+	info, err := os.Lstat(link)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode()&os.ModeSymlink, qt.Equals, os.ModeSymlink)
+}

--- a/internal/goannotationcleanup/cleanup_test.go
+++ b/internal/goannotationcleanup/cleanup_test.go
@@ -107,3 +107,254 @@ func TestCleanDirDiffReportsDuplicateRemovedLinesByPosition(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, original)
 }
+
+func TestCleanDir_HappyPath_PreservesStringLiteralsAndRemovesStandaloneAnnotations(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := "package models\n\n" +
+		"const raw = `header\n" +
+		"//migrator:schema:table name=\"raw_literal\"\n" +
+		"//migrator:embedded mode=\"raw_literal\"\n" +
+		"footer`\n\n" +
+		"const interpreted = \"//migrator:schema:field name=\\\"interpreted_literal\\\" type=\\\"TEXT\\\"\"\n" +
+		"const multiline = \"header\\n//migrator:embedded mode=\\\"interpreted_literal\\\"\\nfooter\"\n" +
+		"const inline = 1 //migrator:schema:table name=\"inline_comment\"\n\n" +
+		"//migrator:embeddedness is ordinary documentation.\n" +
+		"//migrator:schema:not-a-known-directive is ordinary documentation.\n" +
+		"// User is business documentation.\n" +
+		"//migrator:schema:table name=\"users\"\n" +
+		"type User struct {\n" +
+		"\t//migrator:schema:field name=\"id\" type=\"BIGINT\"\n" +
+		"\tID int64\n" +
+		"\t//migrator:embedded mode=\"inline\"\n" +
+		"\tTimestamps\n" +
+		"}\n"
+	expected := "package models\n\n" +
+		"const raw = `header\n" +
+		"//migrator:schema:table name=\"raw_literal\"\n" +
+		"//migrator:embedded mode=\"raw_literal\"\n" +
+		"footer`\n\n" +
+		"const interpreted = \"//migrator:schema:field name=\\\"interpreted_literal\\\" type=\\\"TEXT\\\"\"\n" +
+		"const multiline = \"header\\n//migrator:embedded mode=\\\"interpreted_literal\\\"\\nfooter\"\n" +
+		"const inline = 1 //migrator:schema:table name=\"inline_comment\"\n\n" +
+		"//migrator:embeddedness is ordinary documentation.\n" +
+		"//migrator:schema:not-a-known-directive is ordinary documentation.\n" +
+		"// User is business documentation.\n" +
+		"type User struct {\n" +
+		"\tID int64\n" +
+		"\tTimestamps\n" +
+		"}\n"
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Path, qt.Equals, path)
+	c.Assert(results[0].Changed, qt.IsTrue)
+	c.Assert(results[0].RemovedLines, qt.Equals, 3)
+	c.Assert(results[0].Diff, qt.Equals, "")
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, expected)
+}
+
+func TestCleanDir_HappyPath_SkipsTestVendorAndHiddenSources(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	testPath := filepath.Join(dir, "model_test.go")
+	vendorDir := filepath.Join(dir, "vendor", "example")
+	vendorPath := filepath.Join(vendorDir, "model.go")
+	hiddenDir := filepath.Join(dir, "models", ".codex", "worktrees")
+	hiddenPath := filepath.Join(hiddenDir, "model.go")
+	original := "package models\n\n//migrator:schema:table name=\"users\"\ntype User struct{}\n"
+	expected := "package models\n\ntype User struct{}\n"
+	skippedTest := "package models\n\n//migrator:schema:table name=\"test_only\"\ntype TestOnly struct {\n"
+	skippedVendor := "package example\n\n//migrator:schema:table name=\"vendor_only\"\ntype VendorOnly struct {\n"
+	skippedHidden := "package worktrees\n\n//migrator:schema:table name=\"hidden_only\"\ntype HiddenOnly struct {\n"
+	c.Assert(os.MkdirAll(vendorDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(hiddenDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(testPath, []byte(skippedTest), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(vendorPath, []byte(skippedVendor), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(hiddenPath, []byte(skippedHidden), 0o600), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(results, qt.HasLen, 1)
+	c.Assert(results[0].Path, qt.Equals, path)
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, expected)
+	testContent, err := os.ReadFile(testPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(testContent), qt.Equals, skippedTest)
+	vendorContent, err := os.ReadFile(vendorPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(vendorContent), qt.Equals, skippedVendor)
+	hiddenContent, err := os.ReadFile(hiddenPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(hiddenContent), qt.Equals, skippedHidden)
+}
+
+func TestCleanDir_FailurePath_InvalidGoSourceIsNotModified(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	validPath := filepath.Join(dir, "a_valid.go")
+	invalidPath := filepath.Join(dir, "z_invalid.go")
+	validOriginal := "package models\n\n//migrator:schema:table name=\"users\"\ntype User struct{}\n"
+	invalidOriginal := "package models\n\n//migrator:schema:table name=\"broken\"\ntype Broken struct {\n"
+	c.Assert(os.WriteFile(validPath, []byte(validOriginal), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(invalidPath, []byte(invalidOriginal), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(validPath, 0o640), qt.IsNil)
+	c.Assert(os.Chmod(invalidPath, 0o640), qt.IsNil)
+
+	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "z_invalid.go")
+	c.Assert(results, qt.HasLen, 0)
+	validContent, err := os.ReadFile(validPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(validContent), qt.Equals, validOriginal)
+	invalidContent, err := os.ReadFile(invalidPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(invalidContent), qt.Equals, invalidOriginal)
+	validInfo, err := os.Stat(validPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(validInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	invalidInfo, err := os.Stat(invalidPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invalidInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+}
+
+func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := "package models\r\n" +
+		"\r\n" +
+		"// User keeps business documentation.  \r\n" +
+		"//migrator:schema:table name=\"users\"\r\n" +
+		"type User struct{ID int64}\r\n" +
+		"\t//migrator:embedded mode=\"inline\"\r\n" +
+		"type Audit struct{CreatedAt int64}\r\n"
+	expected := "package models\r\n" +
+		"\r\n" +
+		"// User keeps business documentation.  \r\n" +
+		"type User struct{ID int64}\r\n" +
+		"type Audit struct{CreatedAt int64}\r\n"
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(path, 0o640), qt.IsNil)
+
+	dryRunResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
+		RootDir: dir,
+		DryRun:  true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dryRunResults, qt.HasLen, 1)
+	c.Assert(dryRunResults[0].Path, qt.Equals, path)
+	c.Assert(dryRunResults[0].Changed, qt.IsTrue)
+	c.Assert(dryRunResults[0].RemovedLines, qt.Equals, 2)
+	c.Assert(dryRunResults[0].Diff, qt.Equals, "")
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, original)
+	info, err := os.Stat(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+
+	diffResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
+		RootDir: dir,
+		Diff:    true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diffResults, qt.HasLen, 1)
+	c.Assert(diffResults[0].Path, qt.Equals, dryRunResults[0].Path)
+	c.Assert(diffResults[0].Changed, qt.Equals, dryRunResults[0].Changed)
+	c.Assert(diffResults[0].RemovedLines, qt.Equals, dryRunResults[0].RemovedLines)
+	c.Assert(diffResults[0].Diff, qt.Contains, "-//migrator:schema:table name=\"users\"\r\n")
+	c.Assert(diffResults[0].Diff, qt.Contains, "-\t//migrator:embedded mode=\"inline\"\r\n")
+	content, err = os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, original)
+	info, err = os.Stat(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+
+	writeResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(writeResults, qt.HasLen, 1)
+	c.Assert(writeResults[0].Path, qt.Equals, dryRunResults[0].Path)
+	c.Assert(writeResults[0].Changed, qt.Equals, dryRunResults[0].Changed)
+	c.Assert(writeResults[0].RemovedLines, qt.Equals, dryRunResults[0].RemovedLines)
+	c.Assert(writeResults[0].Diff, qt.Equals, "")
+	content, err = os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, expected)
+	info, err = os.Stat(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+
+	idempotentDryRunResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
+		RootDir: dir,
+		DryRun:  true,
+		Diff:    true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(idempotentDryRunResults, qt.HasLen, 0)
+
+	idempotentWriteResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	c.Assert(err, qt.IsNil)
+	c.Assert(idempotentWriteResults, qt.HasLen, 0)
+	content, err = os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(content), qt.Equals, expected)
+}
+
+func TestCleanDir_HappyPath_DiffMarksMissingFinalNewline(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name         string
+		original     string
+		wantDiffLine string
+	}{
+		{
+			name:         "removed final annotation",
+			original:     "package models\n//migrator:schema:table name=\"users\"",
+			wantDiffLine: "-//migrator:schema:table name=\"users\"\n",
+		},
+		{
+			name:         "final context line",
+			original:     "package models\n//migrator:schema:table name=\"users\"\ntype User struct{}",
+			wantDiffLine: " type User struct{}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dir := c.TempDir()
+			path := filepath.Join(dir, "model.go")
+			c.Assert(os.WriteFile(path, []byte(tt.original), 0o600), qt.IsNil)
+
+			results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
+				RootDir: dir,
+				Diff:    true,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(results, qt.HasLen, 1)
+			c.Assert(results[0].Diff, qt.Contains, tt.wantDiffLine)
+			c.Assert(strings.Count(results[0].Diff, "\\ No newline at end of file\n"), qt.Equals, 1)
+			content, err := os.ReadFile(path)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(content), qt.Equals, tt.original)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- parse Go source and remove only standalone Ptah annotation comments recognized by the shared annotation metadata parser
- prevalidate the complete cleanup source set before writing and reject symlink/non-regular sources
- preserve unrelated bytes, file modes, CRLF, and missing-final-newline diff semantics
- keep dry-run, diff, and write behavior derived from one immutable edit plan

This is the safety prerequisite found while auditing #381. The previous line-prefix implementation could delete annotation-looking content from strings and files that were not part of the exported schema source set.

## Safety properties

- invalid source anywhere in the cleanup source set aborts before the first write
- `_test.go` and vendor sources stay outside the cleanup source set, matching the Go annotation frontend
- the existing hidden-directory boundary remains in place to avoid traversing VCS and tool state
- each writable file is opened without truncation, then identity and original bytes are revalidated before mutation
- Unix symlink sources are rejected without touching their targets
- repeated cleanup is idempotent

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/goannotationcleanup -count=1`
- `go vet ./internal/goannotationcleanup`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/goannotationcleanup`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `gopls check` for all changed Go files
- `git diff --check origin/master...HEAD`

Fixes #832
Related to #381