### PR TITLE
Harden Go annotation cleanup exports

### DIFF
--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -17,8 +17,7 @@ import (
 	"github.com/stokaro/ptah/cmd/schemapush"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/internal/annotationschema"
-	hclrender "github.com/stokaro/ptah/internal/atlashclrender"
-	"github.com/stokaro/ptah/internal/goannotationcleanup"
+	"github.com/stokaro/ptah/internal/goannotationexport"
 	"github.com/stokaro/ptah/internal/graphqlrender"
 	"github.com/stokaro/ptah/internal/openapirender"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -182,7 +181,7 @@ exported.`,
 	flags.StringSliceVar(&includeTables, exportIncludeTablesFlag, nil, "Only export these tables (comma-separated); applies to openapi-v3/graphql")
 	flags.StringSliceVar(&excludeTables, exportExcludeTablesFlag, nil, "Exclude these tables (comma-separated); applies to openapi-v3/graphql")
 	flags.StringVar(&title, exportTitleFlag, "", "OpenAPI info.title (openapi-v3 only)")
-	flags.BoolVar(&cleanupAnnotations, cleanupGoAnnotationsFlag, false, "Remove Ptah schema annotations from Go source after a successful export")
+	flags.BoolVar(&cleanupAnnotations, cleanupGoAnnotationsFlag, false, "Remove Ptah schema annotations after a lossless HCL export")
 	flags.BoolVar(&cleanupDryRun, cleanupDryRunFlag, false, "Show cleanup summary without modifying Go files")
 	flags.BoolVar(&cleanupDiff, cleanupDiffFlag, false, "Print cleanup diff without modifying Go files")
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
@@ -225,16 +224,15 @@ func runExport(cmd *cobra.Command, opts exportOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 
+	if opts.to == exportFormatHCL {
+		return runHCLExport(cmd, opts, rootDir)
+	}
+
 	db, err := goschema.ParseDir(rootDir)
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("parse Go annotations: %w", err))
 	}
-
 	switch opts.to {
-	case exportFormatHCL:
-		if err := runHCLExport(cmd, opts, db); err != nil {
-			return err
-		}
 	case exportFormatOpenAPI:
 		rendered, err := openapirender.Render(db, openapirender.Options{
 			IncludeTables: opts.includeTables,
@@ -264,54 +262,50 @@ func runExport(cmd *cobra.Command, opts exportOptions) error {
 		return cmdutil.Fail(cmd, fmt.Errorf("unsupported --%s %q", exportToFlag, opts.to))
 	}
 
-	out := cmd.OutOrStdout()
-	if opts.cleanupAnnotations {
-		results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-			RootDir: rootDir,
-			DryRun:  opts.cleanupDryRun,
-			Diff:    opts.cleanupDiff,
-		})
-		if err != nil {
-			return cmdutil.Fail(cmd, err)
-		}
-		for _, result := range results {
-			if opts.cleanupDiff && result.Diff != "" {
-				fmt.Fprint(out, result.Diff)
-			}
-		}
-		action := "Cleaned"
-		if opts.cleanupDryRun || opts.cleanupDiff {
-			action = "Would clean"
-		}
-		fmt.Fprintf(out, "%s %d file(s), removed %d annotation line(s)\n", action, len(results), removedAnnotationLines(results))
-	}
 	return nil
 }
 
-// runHCLExport renders the schema to HCL and writes it to the required --out file.
-func runHCLExport(cmd *cobra.Command, opts exportOptions, db *goschema.Database) error {
-	outPath, err := resolveOutputPath(opts.outPath)
+// runHCLExport adapts the reusable Go-to-HCL workflow to Cobra streams.
+func runHCLExport(cmd *cobra.Command, opts exportOptions, rootDir string) error {
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    rootDir,
+		OutputPath: opts.outPath,
+		Cleanup:    opts.cleanupAnnotations,
+		DryRun:     opts.cleanupDryRun,
+		Diff:       opts.cleanupDiff,
+	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
-	}
-	rendered, err := hclrender.Render(db)
-	if err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-	if err := os.WriteFile(outPath, rendered.Data, 0o600); err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("write HCL schema: %w", err))
 	}
 
 	errOut := cmd.ErrOrStderr()
-	for _, diagnostic := range rendered.Diagnostics {
+	for _, diagnostic := range result.Diagnostics {
 		fmt.Fprintf(errOut, "%s: %s: %s\n", diagnostic.Severity, diagnostic.Path, diagnostic.Message)
 	}
 
 	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Exported HCL schema to %s\n", outPath)
-	fmt.Fprintf(out, "Found %d table(s), %d field(s), %d enum(s)\n", len(db.Tables), len(db.Fields), len(db.Enums))
-	if len(rendered.Diagnostics) > 0 {
-		fmt.Fprintf(out, "%d export warning(s) reported\n", len(rendered.Diagnostics))
+	fmt.Fprintf(out, "Exported HCL schema to %s\n", result.OutputPath)
+	fmt.Fprintf(out, "Found %d table(s), %d field(s), %d enum(s)\n", result.Tables, result.Fields, result.Enums)
+	if len(result.Diagnostics) > 0 {
+		fmt.Fprintf(out, "%d export warning(s) reported\n", len(result.Diagnostics))
+	}
+	for _, cleanup := range result.Cleanup {
+		if opts.cleanupDiff && cleanup.Diff != "" {
+			fmt.Fprint(out, cleanup.Diff)
+		}
+	}
+	if opts.cleanupAnnotations {
+		action := "Cleaned"
+		if opts.cleanupDryRun || opts.cleanupDiff {
+			action = "Would clean"
+		}
+		fmt.Fprintf(
+			out,
+			"%s %d file(s), removed %d annotation line(s)\n",
+			action,
+			len(result.Cleanup),
+			result.RemovedLines,
+		)
 	}
 	return nil
 }
@@ -388,12 +382,4 @@ func resolveOutputPath(path string) (string, error) {
 		return "", fmt.Errorf("create output directory: %w", err)
 	}
 	return cleaned, nil
-}
-
-func removedAnnotationLines(results []goannotationcleanup.Result) int {
-	total := 0
-	for _, result := range results {
-		total += result.RemovedLines
-	}
-	return total
 }

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/schema"
 	"github.com/stokaro/ptah/internal/atlashcl"
+	"github.com/stokaro/ptah/internal/goannotationexport"
 )
 
 func TestSchemaExportCommandWritesHCL(t *testing.T) {
@@ -156,7 +157,7 @@ func TestSchemaExportCommandPreservesSchemaObjects(t *testing.T) {
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
-	c.Assert(stdout.String(), qt.Contains, "6 export warning(s) reported")
+	c.Assert(stdout.String(), qt.Contains, "7 export warning(s) reported")
 	c.Assert(stderr.String(), qt.Contains, "domain types are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "composite types are not yet representable")
 	c.Assert(stderr.String(), qt.Contains, "range types are not yet representable")
@@ -300,6 +301,71 @@ func TestSchemaExportCleanupDryRunAndWrite(t *testing.T) {
 	c.Assert(string(content), qt.Not(qt.Contains), "migrator:schema")
 	c.Assert(string(content), qt.Not(qt.Contains), "migrator:embedded")
 	c.Assert(string(content), qt.Contains, "// User is business documentation.")
+}
+
+func TestSchemaExportCommand_FailurePath_LossyCleanupPreservesSourcesAndOutput(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.go")
+	outPath := filepath.Join(dir, "schema.hcl")
+	modelData := []byte(`package models
+
+//migrator:schema:table name="users" custom="WITHOUT OIDS"
+type User struct{}
+`)
+	outData := []byte("previous schema\n")
+	c.Assert(os.WriteFile(modelPath, modelData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(outPath, outData, 0o600), qt.IsNil)
+
+	cmd := schema.NewSchemaCommand()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"export",
+		"--root-dir", dir,
+		"--out", outPath,
+		"--cleanup-go-annotations",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrLossyCleanup)
+	c.Assert(stderr.String(), qt.Contains, "custom SQL")
+	modelAfter, err := os.ReadFile(modelPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(modelAfter, qt.DeepEquals, modelData)
+	outAfter, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(outAfter, qt.DeepEquals, outData)
+}
+
+func TestSchemaExportCommand_FailurePath_RepeatCleanupPreservesExistingOutput(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.go")
+	outPath := filepath.Join(dir, "schema.hcl")
+	modelData := []byte("package models\n\ntype User struct{}\n")
+	outData := []byte("previous useful schema\n")
+	c.Assert(os.WriteFile(modelPath, modelData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(outPath, outData, 0o600), qt.IsNil)
+
+	cmd := schema.NewSchemaCommand()
+	cmd.SetArgs([]string{
+		"export",
+		"--root-dir", dir,
+		"--out", outPath,
+		"--cleanup-go-annotations",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrNoAnnotations)
+	modelAfter, err := os.ReadFile(modelPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(modelAfter, qt.DeepEquals, modelData)
+	outAfter, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(outAfter, qt.DeepEquals, outData)
 }
 
 func writeModel(c *qt.C, dir string) string {

--- a/docs/go_annotations_vs_atlas_hcl.md
+++ b/docs/go_annotations_vs_atlas_hcl.md
@@ -1,4 +1,4 @@
-# Go Annotations vs. HCL Schema
+# Go annotations vs. HCL schema
 
 Ptah can use both Go source annotations and HCL schema files as schema sources.
 It can also export Go annotations to HCL schema:
@@ -18,7 +18,7 @@ state for every Go project. If the Go service owns the schema and the annotation
 model remains expressive enough, keeping Go annotations as the source of truth
 is a supported Ptah workflow.
 
-## When to Use Each Format
+## When to use each format
 
 Use Go annotations when the Go model types remain the primary schema source:
 
@@ -46,7 +46,7 @@ Use export as a one-time migration path when a project wants to move from
 app-schema authoring to declarative schema authoring without manually rewriting
 its existing Ptah metadata.
 
-## Exported Schema Shape
+## Exported schema shape
 
 The exporter writes deterministic HCL for the schema subset that maps
 directly from Ptah's IR:
@@ -83,7 +83,7 @@ function parameter strings that cannot be split into Atlas `arg` blocks without
 losing meaning. These warnings are intentional; the exporter must not silently
 drop schema intent.
 
-## Cleanup Mode
+## Cleanup mode
 
 After a successful export, Ptah can remove Go schema annotations:
 
@@ -96,14 +96,27 @@ ptah schema export \
   --cleanup-go-annotations
 ```
 
-Cleanup removes only Ptah schema annotation comments:
+Cleanup is a one-time source migration. Before Ptah writes the HCL file or
+changes Go source, it verifies all of these conditions:
+
+- the cleanup plan contains at least one real Ptah annotation
+- the output path does not alias a Go source file
+- the HCL renderer reports no lossy or unsupported details
+- the rendered HCL parses and remains byte-stable after canonical re-rendering
+
+Cleanup then removes only Ptah schema annotation comments:
 
 - `//migrator:schema:*`
 - `//migrator:embedded ...`
 
 It preserves regular Go comments, leaves unrelated formatting untouched, and
-keeps original file permissions. Cleanup is idempotent: running it again after
-annotations were removed should report no changed files.
+keeps original file permissions. Ptah writes the validated HCL output before it
+applies the prevalidated source cleanup plan. A failed output write therefore
+leaves every Go source unchanged.
+
+Do not repeat the cleanup command after the annotations are gone. Ptah rejects
+that run with `no Ptah Go annotations found to export and clean` before it can
+replace the previous HCL file with an empty schema.
 
 Use dry-run or diff mode before modifying source files:
 
@@ -115,16 +128,20 @@ ptah schema export --root-dir ./models --out schema.hcl \
   --cleanup-go-annotations --cleanup-diff
 ```
 
-Both dry-run and diff mode require `--cleanup-go-annotations`. Cleanup starts
-only after the HCL file has been rendered and written successfully.
+Both dry-run and diff mode require `--cleanup-go-annotations`. They write the
+validated HCL export but do not modify Go source. Any export diagnostic blocks
+all three cleanup modes with
+`refuse to clean Go annotations after a lossy HCL export`; run without cleanup
+to inspect the partial HCL and its diagnostics.
 
-## Current Limits
+## Current limits
 
 The exporter targets the HCL schema subset documented in
 [HCL Schema Input](atlas_hcl_schema.md). Objects that need their own
 structural model, parser, or renderer are not emitted as best-effort SQL blobs.
-They produce diagnostics instead so the caller can decide whether the exported
-HCL is complete enough to replace the original Go annotations.
+They produce diagnostics instead. A non-destructive export writes that partial
+HCL and reports every diagnostic. Destructive cleanup refuses the same export
+because the HCL cannot safely replace the original Go annotations.
 
 Some PostgreSQL object blocks documented by Atlas are gated by Atlas plans at
 runtime. Ptah's guarantee here is IR preservation through Atlas-compatible HCL

--- a/docs/site/src/content/docs/schema/go-annotations.md
+++ b/docs/site/src/content/docs/schema/go-annotations.md
@@ -128,6 +128,44 @@ such as enum storage, serial columns, constraints, or generated columns.
 Dialect differences are expected; the important check is that each target
 renders valid SQL for the capabilities it supports.
 
+## Move the schema to HCL
+
+Start with a non-destructive export:
+
+```bash
+ptah schema export \
+  --from go \
+  --to hcl \
+  --root-dir ./models \
+  --out schema.hcl
+```
+
+Ptah parses the generated HCL and verifies that its canonical re-render is
+stable before it writes `schema.hcl`. Review any diagnostics on stderr. They
+identify schema intent that HCL did not preserve.
+
+Preview annotation removal only after the export has no diagnostics:
+
+```bash
+ptah schema export \
+  --from go \
+  --to hcl \
+  --root-dir ./models \
+  --out schema.hcl \
+  --cleanup-go-annotations \
+  --cleanup-diff
+```
+
+The diff mode writes the validated HCL file but does not modify Go source. Run
+the same command without `--cleanup-diff` to apply the prevalidated cleanup
+plan.
+
+:::caution[Cleanup is a one-time migration]
+Cleanup fails before any write if the export is lossy, the output aliases a Go
+source file, or no removable annotations remain. Do not repeat the cleanup
+command after a successful migration; use `schema.hcl` as the new source.
+:::
+
 ## Next steps
 
 - Looking up a directive or attribute? [Go annotation reference](../../reference/go-annotations/).

--- a/docs/site/src/content/docs/schema/hcl.md
+++ b/docs/site/src/content/docs/schema/hcl.md
@@ -67,6 +67,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "accounts_email_key" ON "public"."accounts" ("
 `ptah schema render`, `ptah schema compare`, `ptah schema drift`, and the
 migration commands (`ptah migrations plan` / `ptah migrations generate`).
 
+To replace Go annotations with an HCL source, use the lossless one-time export
+workflow in [Go annotations](../go-annotations/#move-the-schema-to-hcl).
+
 ## Plan against a database
 
 ```bash

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -64,6 +64,16 @@ func (r *renderer) renderUserTypes() {
 	}
 }
 
+func (r *renderer) renderManagedData() {
+	managedData := append([]goschema.ManagedData(nil), r.db.ManagedData...)
+	slices.SortFunc(managedData, func(a, b goschema.ManagedData) int {
+		return cmp.Compare(a.Table, b.Table)
+	})
+	for _, data := range managedData {
+		r.warn("managed_data."+data.Table, "managed data cannot be represented in HCL schema output")
+	}
+}
+
 func (r *renderer) renderRoles() {
 	roles := append([]goschema.Role(nil), r.db.Roles...)
 	slices.SortFunc(roles, func(a, b goschema.Role) int {

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -2,7 +2,9 @@
 package atlashclrender
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -69,6 +71,7 @@ func (r *renderer) render() {
 	r.renderTriggers()
 	r.renderRLSPolicies()
 	r.renderGrants()
+	r.renderManagedData()
 }
 
 func (r *renderer) renderSchemas() {
@@ -105,8 +108,8 @@ func (r *renderer) renderTables() {
 		return tables[i].QualifiedName() < tables[j].QualifiedName()
 	})
 	fieldsByStruct := groupFieldsByStruct(r.db.Fields)
-	indexesByTable := groupIndexesByTable(r.db.Indexes, tables)
-	constraintsByTable := groupConstraintsByTable(r.db.Constraints, tables)
+	indexesByTable, orphanIndexes := groupIndexesByTable(r.db.Indexes, tables)
+	constraintsByTable, orphanConstraints := groupConstraintsByTable(r.db.Constraints, tables)
 	rlsEnabledByTable, orphanRLSEnabledTables := groupRLSEnabledByTable(r.db.RLSEnabledTables, tables)
 
 	for _, table := range tables {
@@ -117,6 +120,12 @@ func (r *renderer) renderTables() {
 			constraintsByTable[table.QualifiedName()],
 			rlsEnabledByTable[table.QualifiedName()],
 		)
+	}
+	for _, index := range orphanIndexes {
+		r.warn("index "+index.Name, "index cannot be rendered because the target table is absent from the exported schema")
+	}
+	for _, constraint := range orphanConstraints {
+		r.warn("constraint "+constraint.Name, "constraint cannot be rendered because the target table is absent from the exported schema")
 	}
 	for _, rlsEnabled := range orphanRLSEnabledTables {
 		r.warn("rls_enabled_tables."+rlsEnabled.Table, "RLS enablement cannot be rendered because the target table is absent from the exported schema")
@@ -154,6 +163,9 @@ func (r *renderer) renderTable(
 		return fields[i].Name < fields[j].Name
 	})
 	for _, field := range fields {
+		if fieldIsPrimary(table, field) {
+			field.Nullable = false
+		}
 		r.renderColumn(field)
 	}
 	r.renderPrimaryKey(table, fields)
@@ -169,6 +181,9 @@ func (r *renderer) renderTable(
 	}
 	if table.CustomSQL != "" {
 		r.warn("table "+table.QualifiedName(), "custom SQL cannot be represented in HCL schema output")
+	}
+	if len(table.Checks) > 0 {
+		r.warn("table "+table.QualifiedName(), "legacy table checks cannot be represented in HCL schema output")
 	}
 	r.line("}")
 	r.line("")
@@ -216,6 +231,14 @@ func (r *renderer) renderColumn(field goschema.Field) {
 	r.stringAttr(2, "collate", field.Collate)
 	r.stringAttr(2, "comment", field.Comment)
 	r.line("  }")
+}
+
+func fieldIsPrimary(table goschema.Table, field goschema.Field) bool {
+	return field.Primary ||
+		slices.Contains(table.PrimaryKey, field.Name) ||
+		slices.ContainsFunc(table.PrimaryKeyParts, func(part goschema.PrimaryKeyPart) bool {
+			return part.Name == field.Name
+		})
 }
 
 func (r *renderer) renderFieldChecks(table goschema.Table, fields []goschema.Field, constraintNames map[string]struct{}) {
@@ -451,38 +474,60 @@ func groupFieldsByStruct(fields []goschema.Field) map[string][]goschema.Field {
 	return result
 }
 
-func groupIndexesByTable(indexes []goschema.Index, tables []goschema.Table) map[string][]goschema.Index {
-	result := make(map[string][]goschema.Index)
-	for _, index := range indexes {
-		table := resolveTable(tables, index.StructName, index.TableName)
-		if table == nil {
-			continue
-		}
-		result[table.QualifiedName()] = append(result[table.QualifiedName()], index)
-	}
-	for key := range result {
-		sort.Slice(result[key], func(i, j int) bool {
-			return result[key][i].Name < result[key][j].Name
-		})
-	}
-	return result
+func groupIndexesByTable(
+	indexes []goschema.Index,
+	tables []goschema.Table,
+) (map[string][]goschema.Index, []goschema.Index) {
+	return groupTableObjects(
+		indexes,
+		tables,
+		func(index goschema.Index) (string, string) {
+			return index.StructName, index.TableName
+		},
+		func(a, b goschema.Index) int {
+			return cmp.Compare(a.Name, b.Name)
+		},
+	)
 }
 
-func groupConstraintsByTable(constraints []goschema.Constraint, tables []goschema.Table) map[string][]goschema.Constraint {
-	result := make(map[string][]goschema.Constraint)
-	for _, constraint := range constraints {
-		table := resolveTable(tables, constraint.StructName, constraint.Table)
+func groupConstraintsByTable(
+	constraints []goschema.Constraint,
+	tables []goschema.Table,
+) (map[string][]goschema.Constraint, []goschema.Constraint) {
+	return groupTableObjects(
+		constraints,
+		tables,
+		func(constraint goschema.Constraint) (string, string) {
+			return constraint.StructName, constraint.Table
+		},
+		func(a, b goschema.Constraint) int {
+			return cmp.Compare(a.Name, b.Name)
+		},
+	)
+}
+
+func groupTableObjects[T any](
+	objects []T,
+	tables []goschema.Table,
+	tableReference func(T) (string, string),
+	compare func(T, T) int,
+) (map[string][]T, []T) {
+	result := make(map[string][]T)
+	var orphan []T
+	for _, object := range objects {
+		structName, tableName := tableReference(object)
+		table := resolveTable(tables, structName, tableName)
 		if table == nil {
+			orphan = append(orphan, object)
 			continue
 		}
-		result[table.QualifiedName()] = append(result[table.QualifiedName()], constraint)
+		result[table.QualifiedName()] = append(result[table.QualifiedName()], object)
 	}
 	for key := range result {
-		sort.Slice(result[key], func(i, j int) bool {
-			return result[key][i].Name < result[key][j].Name
-		})
+		slices.SortFunc(result[key], compare)
 	}
-	return result
+	slices.SortFunc(orphan, compare)
+	return result, orphan
 }
 
 func constraintNameSet(constraints []goschema.Constraint) map[string]struct{} {

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -44,6 +44,32 @@ func TestRenderColumnUniqueExprAndIdentityOptionsRoundTrip(t *testing.T) {
 	c.Assert(fieldByName(parsed.Fields, "email").UniqueExpr, qt.Equals, "lower(email)")
 }
 
+func TestRenderPrimaryKeyColumnIsNotNullable(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+			PrimaryKey: []string{"id"},
+		}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			Name:       "id",
+			Type:       "BIGINT",
+			Nullable:   true,
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(rendered.Data), qt.Not(qt.Contains), "null = true")
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Fields, qt.HasLen, 1)
+	c.Assert(parsed.Fields[0].Nullable, qt.IsFalse)
+}
+
 func TestRenderTablesIndexesConstraintsAndDiagnostics(t *testing.T) {
 	c := qt.New(t)
 	falseValue := false
@@ -236,7 +262,7 @@ func TestRenderFixture023SchemaObjectsRoundTrip(t *testing.T) {
 	c.Assert(hcl, qt.Contains, `trigger "users_set_updated_at"`)
 	c.Assert(hcl, qt.Contains, `policy "users_tenant_policy"`)
 	c.Assert(hcl, qt.Contains, `permission {`)
-	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{"extensions.pg_trgm", "sequences.fixture_order_seq", "domains.fixture_email", "composite_types.fixture_address", "ranges.fixture_floatrange", "grants.fixture_app_user"})
+	c.Assert(diagnosticPaths(rendered.Diagnostics), qt.DeepEquals, []string{"extensions.pg_trgm", "sequences.fixture_order_seq", "domains.fixture_email", "composite_types.fixture_address", "ranges.fixture_floatrange", "grants.fixture_app_user", "managed_data.users"})
 
 	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
@@ -315,6 +341,60 @@ func TestRenderReportsLossyObjectDetails(t *testing.T) {
 	})
 	_, err = atlashcl.Parse(rendered.Data, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", string(rendered.Data)))
+}
+
+func TestRenderReportsLegacyChecksAndManagedData(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "User",
+			Name:       "users",
+			Checks:     []string{"id > 0"},
+		}},
+		ManagedData: []goschema.ManagedData{{
+			StructName: "User",
+			Table:      "users",
+			Keys:       []string{"id"},
+			File:       "users.yaml",
+		}},
+		Indexes: []goschema.Index{{
+			Name:      "missing_table_idx",
+			TableName: "missing",
+			Fields:    []string{"id"},
+		}},
+		Constraints: []goschema.Constraint{{
+			Name:    "missing_table_check",
+			Table:   "missing",
+			Type:    "CHECK",
+			Columns: []string{"id"},
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered.Diagnostics, qt.DeepEquals, []atlashclrender.Diagnostic{
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "table users",
+			Message:  "legacy table checks cannot be represented in HCL schema output",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "index missing_table_idx",
+			Message:  "index cannot be rendered because the target table is absent from the exported schema",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "constraint missing_table_check",
+			Message:  "constraint cannot be rendered because the target table is absent from the exported schema",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "managed_data.users",
+			Message:  "managed data cannot be represented in HCL schema output",
+		},
+	})
 }
 
 func TestRenderMaterializedViewRefreshStrategyRoundTrip(t *testing.T) {

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -10,9 +10,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/stokaro/ptah/internal/annotationmeta"
+	"github.com/stokaro/ptah/internal/annotationparse"
 )
 
 // Result describes cleanup changes for one file.
@@ -23,32 +25,53 @@ type Result struct {
 	Diff         string
 }
 
-// Options controls cleanup behavior.
-type Options struct {
-	RootDir string
-	DryRun  bool
-	Diff    bool
+// Annotation identifies one planned Ptah annotation removal.
+type Annotation struct {
+	Path       string
+	Line       int
+	Directive  string
+	Attributes []string
 }
 
 type removedLine struct {
-	number int
+	number     int
+	annotation Annotation
+}
+
+type sourceFile struct {
+	path string
+	info os.FileInfo
 }
 
 type filePlan struct {
-	result Result
-	info   os.FileInfo
-	before []byte
-	after  []byte
+	result  Result
+	info    os.FileInfo
+	before  []byte
+	after   []byte
+	removed []removedLine
 }
 
-// CleanDir removes Ptah schema annotations from Go files under RootDir.
-func CleanDir(opts Options) ([]Result, error) {
-	root := opts.RootDir
+type stagedPlan struct {
+	plan           filePlan
+	cleanedPath    string
+	backupPath     string
+	preserveBackup bool
+}
+
+// Plan is an immutable set of validated annotation removals.
+type Plan struct {
+	sources []sourceFile
+	changes []filePlan
+}
+
+// PlanDir validates Go sources under root and plans annotation removals without
+// modifying any files.
+func PlanDir(root string) (*Plan, error) {
 	if root == "" {
 		root = "."
 	}
 	root = filepath.Clean(root)
-	var plans []filePlan
+	cleanupPlan := &Plan{}
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -65,32 +88,84 @@ func CleanDir(opts Options) ([]Result, error) {
 		if entry.Type()&os.ModeSymlink != 0 {
 			return fmt.Errorf("refuse to clean symlinked Go source %s", path)
 		}
-		plan, err := planFile(path)
+		file, err := planFile(path)
 		if err != nil {
 			return err
 		}
-		if plan.result.Changed {
-			plans = append(plans, plan)
+		cleanupPlan.sources = append(cleanupPlan.sources, sourceFile{
+			path: file.result.Path,
+			info: file.info,
+		})
+		if file.result.Changed {
+			cleanupPlan.changes = append(cleanupPlan.changes, file)
 		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	if !opts.DryRun && !opts.Diff {
-		if err := applyPlans(plans); err != nil {
-			return nil, err
+	return cleanupPlan, nil
+}
+
+// Results returns planned changes without unified diffs.
+func (p *Plan) Results() []Result {
+	results := p.DiffResults()
+	for i := range results {
+		results[i].Diff = ""
+	}
+	return results
+}
+
+// DiffResults returns planned changes with unified diffs.
+func (p *Plan) DiffResults() []Result {
+	results := make([]Result, len(p.changes))
+	for i := range p.changes {
+		results[i] = p.changes[i].result
+	}
+	return results
+}
+
+// Annotations returns the validated annotations represented by the plan.
+func (p *Plan) Annotations() []Annotation {
+	var annotations []Annotation
+	for _, change := range p.changes {
+		for _, removed := range change.removed {
+			annotation := removed.annotation
+			annotation.Attributes = append([]string(nil), annotation.Attributes...)
+			annotations = append(annotations, annotation)
 		}
 	}
-	results := make([]Result, len(plans))
-	for i := range plans {
-		result := plans[i].result
-		if !opts.Diff {
-			result.Diff = ""
+	return annotations
+}
+
+// Apply commits the validated annotation-removal plan.
+func (p *Plan) Apply() error {
+	return applyPlans(p.changes)
+}
+
+// SourceAlias returns the planned Go source aliased by path, or an empty string
+// when path does not refer to any source in the plan.
+func (p *Plan) SourceAlias(path string) (string, error) {
+	path = filepath.Clean(path)
+	for _, source := range p.sources {
+		if path == source.path {
+			return source.path, nil
 		}
-		results[i] = result
 	}
-	return results, nil
+
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("stat potential Go source alias %s: %w", path, err)
+	}
+	for _, source := range p.sources {
+		if os.SameFile(source.info, info) {
+			return source.path, nil
+		}
+	}
+	return "", nil
 }
 
 func planFile(path string) (filePlan, error) {
@@ -124,10 +199,11 @@ func planFile(path string) (filePlan, error) {
 		Diff:         unifiedRemovalDiff(path, before, removed),
 	}
 	return filePlan{
-		result: result,
-		info:   info,
-		before: before,
-		after:  after,
+		result:  result,
+		info:    info,
+		before:  before,
+		after:   after,
+		removed: removed,
 	}, nil
 }
 
@@ -141,41 +217,69 @@ func applyPlans(plans []filePlan) error {
 		files = append(files, file)
 	}
 
+	staged, err := stagePlans(plans)
+	if err != nil {
+		return errors.Join(err, closeFiles(files))
+	}
 	for i, file := range files {
-		if err := writePlan(file, plans[i]); err != nil {
-			return errors.Join(err, closeFiles(files))
+		if err := validateOpenPlan(file, plans[i]); err != nil {
+			return errors.Join(err, closeFiles(files), cleanupStagedPlans(staged))
 		}
 	}
-	return closeFiles(files)
+	if err := closeFiles(files); err != nil {
+		return errors.Join(err, cleanupStagedPlans(staged))
+	}
+	if err := commitStagedPlans(staged); err != nil {
+		return errors.Join(err, cleanupStagedPlans(staged))
+	}
+	return cleanupStagedPlans(staged)
 }
 
 func openValidatedPlan(plan filePlan) (*os.File, error) {
-	info, err := os.Lstat(plan.result.Path)
-	if err != nil {
-		return nil, fmt.Errorf("stat Go source before cleanup %s: %w", plan.result.Path, err)
+	if err := validatePlanPath(plan); err != nil {
+		return nil, err
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
-	}
-
-	file, err := os.OpenFile(plan.result.Path, os.O_RDWR, 0)
+	file, err := os.Open(plan.result.Path)
 	if err != nil {
 		return nil, fmt.Errorf("open Go source for cleanup %s: %w", plan.result.Path, err)
 	}
-	currentInfo, err := file.Stat()
-	if err != nil {
-		_ = file.Close()
-		return nil, fmt.Errorf("stat opened Go source %s: %w", plan.result.Path, err)
-	}
-	if !os.SameFile(plan.info, currentInfo) {
-		_ = file.Close()
-		return nil, fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
-	}
-	if err := validatePlanContent(file, plan); err != nil {
+	if err := validateOpenPlan(file, plan); err != nil {
 		_ = file.Close()
 		return nil, err
 	}
 	return file, nil
+}
+
+func validatePlanPath(plan filePlan) error {
+	info, err := os.Lstat(plan.result.Path)
+	if err != nil {
+		return fmt.Errorf("stat Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(plan.info, info) {
+		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
+	}
+	current, err := os.ReadFile(plan.result.Path)
+	if err != nil {
+		return fmt.Errorf("read Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if !bytes.Equal(current, plan.before) {
+		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
+	}
+	return nil
+}
+
+func validateOpenPlan(file *os.File, plan filePlan) error {
+	currentInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat opened Go source %s: %w", plan.result.Path, err)
+	}
+	if !os.SameFile(plan.info, currentInfo) {
+		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
+	}
+	return validatePlanContent(file, plan)
 }
 
 func validatePlanContent(file *os.File, plan filePlan) error {
@@ -192,21 +296,126 @@ func validatePlanContent(file *os.File, plan filePlan) error {
 	return nil
 }
 
-func writePlan(file *os.File, plan filePlan) error {
-	if err := validatePlanContent(file, plan); err != nil {
-		return err
+func stagePlans(plans []filePlan) ([]stagedPlan, error) {
+	staged := make([]stagedPlan, 0, len(plans))
+	for _, plan := range plans {
+		stagedFile, err := stagePlan(plan)
+		if err != nil {
+			return nil, errors.Join(err, cleanupStagedPlans(staged))
+		}
+		staged = append(staged, stagedFile)
 	}
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek Go source for cleanup %s: %w", plan.result.Path, err)
+	return staged, nil
+}
+
+func stagePlan(plan filePlan) (stagedPlan, error) {
+	backupPath, err := stageFile(plan, "backup", plan.before)
+	if err != nil {
+		return stagedPlan{}, err
 	}
-	if err := file.Truncate(0); err != nil {
-		return fmt.Errorf("truncate Go source for cleanup %s: %w", plan.result.Path, err)
+	cleanedPath, err := stageFile(plan, "cleaned", plan.after)
+	if err != nil {
+		return stagedPlan{}, errors.Join(err, removeStagedFile(backupPath))
 	}
-	if _, err := file.Write(plan.after); err != nil {
-		return fmt.Errorf("write cleaned Go source %s: %w", plan.result.Path, err)
+	return stagedPlan{
+		plan:        plan,
+		cleanedPath: cleanedPath,
+		backupPath:  backupPath,
+	}, nil
+}
+
+func stageFile(plan filePlan, kind string, data []byte) (string, error) {
+	dir := filepath.Dir(plan.result.Path)
+	pattern := "." + filepath.Base(plan.result.Path) + ".ptah-" + kind + "-*"
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("create staged %s for %s: %w", kind, plan.result.Path, err)
+	}
+	path := file.Name()
+	if err := file.Chmod(plan.info.Mode()); err != nil {
+		_ = file.Close()
+		return "", errors.Join(
+			fmt.Errorf("set staged %s mode for %s: %w", kind, plan.result.Path, err),
+			removeStagedFile(path),
+		)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return "", errors.Join(
+			fmt.Errorf("write staged %s for %s: %w", kind, plan.result.Path, err),
+			removeStagedFile(path),
+		)
 	}
 	if err := file.Sync(); err != nil {
-		return fmt.Errorf("sync cleaned Go source %s: %w", plan.result.Path, err)
+		_ = file.Close()
+		return "", errors.Join(
+			fmt.Errorf("sync staged %s for %s: %w", kind, plan.result.Path, err),
+			removeStagedFile(path),
+		)
+	}
+	if err := file.Close(); err != nil {
+		return "", errors.Join(
+			fmt.Errorf("close staged %s for %s: %w", kind, plan.result.Path, err),
+			removeStagedFile(path),
+		)
+	}
+	return path, nil
+}
+
+func commitStagedPlans(staged []stagedPlan) error {
+	for i := range staged {
+		if err := validatePlanPath(staged[i].plan); err != nil {
+			return errors.Join(err, rollbackStagedPlans(staged[:i]))
+		}
+		if err := replaceFile(staged[i].cleanedPath, staged[i].plan.result.Path); err != nil {
+			return errors.Join(
+				fmt.Errorf("commit cleaned Go source %s: %w", staged[i].plan.result.Path, err),
+				rollbackStagedPlans(staged[:i]),
+			)
+		}
+		staged[i].cleanedPath = ""
+	}
+	return nil
+}
+
+func rollbackStagedPlans(staged []stagedPlan) error {
+	var rollbackErr error
+	for i := range slices.Backward(staged) {
+		if err := replaceFile(staged[i].backupPath, staged[i].plan.result.Path); err != nil {
+			staged[i].preserveBackup = true
+			rollbackErr = errors.Join(
+				rollbackErr,
+				fmt.Errorf(
+					"restore Go source %s from %s: %w",
+					staged[i].plan.result.Path,
+					staged[i].backupPath,
+					err,
+				),
+			)
+			continue
+		}
+		staged[i].backupPath = ""
+	}
+	return rollbackErr
+}
+
+func cleanupStagedPlans(staged []stagedPlan) error {
+	var cleanupErr error
+	for _, stagedFile := range staged {
+		cleanupErr = errors.Join(cleanupErr, removeStagedFile(stagedFile.cleanedPath))
+		if !stagedFile.preserveBackup {
+			cleanupErr = errors.Join(cleanupErr, removeStagedFile(stagedFile.backupPath))
+		}
+	}
+	return cleanupErr
+}
+
+func removeStagedFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove staged cleanup file %s: %w", path, err)
 	}
 	return nil
 }
@@ -215,7 +424,7 @@ func closeFiles(files []*os.File) error {
 	var closeErr error
 	for _, file := range files {
 		if err := file.Close(); err != nil {
-			closeErr = errors.Join(closeErr, fmt.Errorf("close cleaned Go source %s: %w", file.Name(), err))
+			closeErr = errors.Join(closeErr, fmt.Errorf("close Go source %s: %w", file.Name(), err))
 		}
 	}
 	return closeErr
@@ -231,9 +440,10 @@ func removeAnnotationLines(path string, data []byte) ([]byte, []removedLine, err
 	removed := make([]removedLine, 0)
 	for i, line := range lines {
 		lineNumber := i + 1
-		if _, ok := lineNumbers[lineNumber]; ok {
+		if annotation, ok := lineNumbers[lineNumber]; ok {
 			removed = append(removed, removedLine{
-				number: lineNumber,
+				number:     lineNumber,
+				annotation: annotation,
 			})
 			continue
 		}
@@ -242,32 +452,44 @@ func removeAnnotationLines(path string, data []byte) ([]byte, []removedLine, err
 	return bytes.Join(filtered, nil), removed, nil
 }
 
-func annotationLineNumbers(path string, data []byte, lines [][]byte) (map[int]struct{}, error) {
+func annotationLineNumbers(path string, data []byte, lines [][]byte) (map[int]Annotation, error) {
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, path, data, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		return nil, fmt.Errorf("parse Go source %s: %w", path, err)
 	}
 
-	lineNumbers := make(map[int]struct{})
+	lineNumbers := make(map[int]Annotation)
 	for _, group := range file.Comments {
 		for _, comment := range group.List {
 			lineNumber := fileSet.PositionFor(comment.Pos(), false).Line
-			if !isPtahSchemaAnnotationComment(comment.Text) ||
-				lineNumber < 1 ||
+			directive, ok := annotationmeta.MatchCommentDirective(comment.Text)
+			if !ok || lineNumber < 1 ||
 				lineNumber > len(lines) ||
 				strings.TrimSpace(string(lines[lineNumber-1])) != strings.TrimSpace(comment.Text) {
 				continue
 			}
-			lineNumbers[lineNumber] = struct{}{}
+			lineNumbers[lineNumber] = Annotation{
+				Path:       path,
+				Line:       lineNumber,
+				Directive:  directive.Name,
+				Attributes: annotationAttributes(comment.Text),
+			}
 		}
 	}
 	return lineNumbers, nil
 }
 
-func isPtahSchemaAnnotationComment(comment string) bool {
-	_, ok := annotationmeta.MatchCommentDirective(comment)
-	return ok
+func annotationAttributes(comment string) []string {
+	annotations := annotationparse.Scan(comment)
+	if len(annotations) == 0 {
+		return nil
+	}
+	attributes := make([]string, len(annotations[0].Attributes))
+	for i, attribute := range annotations[0].Attributes {
+		attributes[i] = attribute.Name
+	}
+	return attributes
 }
 
 func unifiedRemovalDiff(path string, before []byte, removed []removedLine) string {

--- a/internal/goannotationcleanup/cleanup_symlink_unix_test.go
+++ b/internal/goannotationcleanup/cleanup_symlink_unix_test.go
@@ -22,15 +22,75 @@ func TestCleanDir_FailurePath_RejectsSymlinkedGoSource(t *testing.T) {
 	c.Assert(os.WriteFile(target, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Symlink(target, link), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: root})
+	plan, err := goannotationcleanup.PlanDir(root)
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "refuse to clean symlinked Go source")
-	c.Assert(results, qt.HasLen, 0)
+	c.Assert(plan, qt.IsNil)
 	content, err := os.ReadFile(target)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, original)
 	info, err := os.Lstat(link)
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode()&os.ModeSymlink, qt.Equals, os.ModeSymlink)
+}
+
+func TestPlanSourceAlias_HappyPath_ReportsSymlinkAndHardLinkAliases(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	symlinkAlias := filepath.Join(outside, "schema-symlink.hcl")
+	hardLinkAlias := filepath.Join(outside, "schema-hardlink.hcl")
+	original := "package models\n\n//migrator:schema:table name=\"users\"\ntype User struct{}\n"
+	c.Assert(os.WriteFile(source, []byte(original), 0o600), qt.IsNil)
+	c.Assert(os.Symlink(source, symlinkAlias), qt.IsNil)
+	c.Assert(os.Link(source, hardLinkAlias), qt.IsNil)
+
+	plan, err := goannotationcleanup.PlanDir(root)
+	c.Assert(err, qt.IsNil)
+
+	alias, err := plan.SourceAlias(symlinkAlias)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, source)
+
+	alias, err = plan.SourceAlias(hardLinkAlias)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, source)
+}
+
+func TestPlanApply_FailurePath_StagingFailureLeavesEverySourceUnchanged(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	firstDir := filepath.Join(root, "first")
+	blockedDir := filepath.Join(root, "blocked")
+	c.Assert(os.MkdirAll(firstDir, 0o700), qt.IsNil)
+	c.Assert(os.MkdirAll(blockedDir, 0o700), qt.IsNil)
+	firstPath := filepath.Join(firstDir, "model.go")
+	blockedPath := filepath.Join(blockedDir, "model.go")
+	firstData := []byte("package first\n\n//migrator:schema:table name=\"first\"\ntype First struct{}\n")
+	blockedData := []byte("package blocked\n\n//migrator:schema:table name=\"blocked\"\ntype Blocked struct{}\n")
+	c.Assert(os.WriteFile(firstPath, firstData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(blockedPath, blockedData, 0o600), qt.IsNil)
+
+	plan, err := goannotationcleanup.PlanDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chmod(blockedDir, 0o500), qt.IsNil)
+	defer func() {
+		c.Check(os.Chmod(blockedDir, 0o700), qt.IsNil)
+	}()
+
+	err = plan.Apply()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "create staged")
+	firstAfter, err := os.ReadFile(firstPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(firstAfter, qt.DeepEquals, firstData)
+	blockedAfter, err := os.ReadFile(blockedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(blockedAfter, qt.DeepEquals, blockedData)
+	firstEntries, err := os.ReadDir(firstDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(firstEntries, qt.HasLen, 1)
 }

--- a/internal/goannotationcleanup/cleanup_test.go
+++ b/internal/goannotationcleanup/cleanup_test.go
@@ -31,13 +31,10 @@ type User struct {
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Chmod(path, 0o644), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-		RootDir: dir,
-		DryRun:  true,
-		Diff:    true,
-	})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results := plan.DiffResults()
 	c.Assert(results, qt.HasLen, 1)
 	c.Assert(results[0].RemovedLines, qt.Equals, 3)
 	c.Assert(results[0].Diff, qt.Contains, `-//migrator:schema:table name="users"`)
@@ -45,10 +42,12 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, original)
 
-	results, err = goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err = goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results = plan.Results()
 	c.Assert(results, qt.HasLen, 1)
+	c.Assert(plan.Apply(), qt.IsNil)
 	content, err = os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Contains, "// User is business documentation.")
@@ -59,9 +58,11 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o644))
 
-	results, err = goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err = goannotationcleanup.PlanDir(dir)
 	c.Assert(err, qt.IsNil)
+	results = plan.Results()
 	c.Assert(results, qt.HasLen, 0)
+	c.Assert(plan.Apply(), qt.IsNil)
 }
 
 func TestCleanDirPreservesUnrelatedFormattingByteForByte(t *testing.T) {
@@ -72,10 +73,12 @@ func TestCleanDirPreservesUnrelatedFormattingByteForByte(t *testing.T) {
 	expected := "package models\n\n// User is business documentation.\ntype User struct{ID int64}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results := plan.Results()
 	c.Assert(results, qt.HasLen, 1)
+	c.Assert(plan.Apply(), qt.IsNil)
 	content, err := os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
@@ -93,13 +96,10 @@ func TestCleanDirDiffReportsDuplicateRemovedLinesByPosition(t *testing.T) {
 		"OtherID int64\n}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-		RootDir: dir,
-		DryRun:  true,
-		Diff:    true,
-	})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results := plan.DiffResults()
 	c.Assert(results, qt.HasLen, 1)
 	c.Assert(results[0].RemovedLines, qt.Equals, 2)
 	c.Assert(strings.Count(results[0].Diff, "-"+annotation), qt.Equals, 2)
@@ -147,14 +147,16 @@ func TestCleanDir_HappyPath_PreservesStringLiteralsAndRemovesStandaloneAnnotatio
 		"}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results := plan.Results()
 	c.Assert(results, qt.HasLen, 1)
 	c.Assert(results[0].Path, qt.Equals, path)
 	c.Assert(results[0].Changed, qt.IsTrue)
 	c.Assert(results[0].RemovedLines, qt.Equals, 3)
 	c.Assert(results[0].Diff, qt.Equals, "")
+	c.Assert(plan.Apply(), qt.IsNil)
 	content, err := os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
@@ -169,7 +171,7 @@ func TestCleanDir_HappyPath_SkipsTestVendorAndHiddenSources(t *testing.T) {
 	vendorPath := filepath.Join(vendorDir, "model.go")
 	hiddenDir := filepath.Join(dir, "models", ".codex", "worktrees")
 	hiddenPath := filepath.Join(hiddenDir, "model.go")
-	original := "package models\n\n//migrator:schema:table name=\"users\"\ntype User struct{}\n"
+	original := "package models\n\n//migrator:schema:table name=\"users\" platform.mysql.engine=\"InnoDB\"\ntype User struct{}\n"
 	expected := "package models\n\ntype User struct{}\n"
 	skippedTest := "package models\n\n//migrator:schema:table name=\"test_only\"\ntype TestOnly struct {\n"
 	skippedVendor := "package example\n\n//migrator:schema:table name=\"vendor_only\"\ntype VendorOnly struct {\n"
@@ -181,11 +183,13 @@ func TestCleanDir_HappyPath_SkipsTestVendorAndHiddenSources(t *testing.T) {
 	c.Assert(os.WriteFile(vendorPath, []byte(skippedVendor), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(hiddenPath, []byte(skippedHidden), 0o600), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	results := plan.Results()
 	c.Assert(results, qt.HasLen, 1)
 	c.Assert(results[0].Path, qt.Equals, path)
+	c.Assert(plan.Apply(), qt.IsNil)
 	content, err := os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
@@ -212,11 +216,11 @@ func TestCleanDir_FailurePath_InvalidGoSourceIsNotModified(t *testing.T) {
 	c.Assert(os.Chmod(validPath, 0o640), qt.IsNil)
 	c.Assert(os.Chmod(invalidPath, 0o640), qt.IsNil)
 
-	results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	plan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "z_invalid.go")
-	c.Assert(results, qt.HasLen, 0)
+	c.Assert(plan, qt.IsNil)
 	validContent, err := os.ReadFile(validPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(validContent), qt.Equals, validOriginal)
@@ -229,6 +233,32 @@ func TestCleanDir_FailurePath_InvalidGoSourceIsNotModified(t *testing.T) {
 	invalidInfo, err := os.Stat(invalidPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(invalidInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+}
+
+func TestPlanApply_FailurePath_PrevalidatesEverySourceBeforeWriting(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "a_model.go")
+	changedPath := filepath.Join(dir, "z_model.go")
+	firstData := []byte("package models\n\n//migrator:schema:table name=\"first\"\ntype First struct{}\n")
+	changedData := []byte("package models\n\n//migrator:schema:table name=\"changed\"\ntype Changed struct{}\n")
+	replacementData := []byte("package models\n\ntype Changed struct{ ID int64 }\n")
+	c.Assert(os.WriteFile(firstPath, firstData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(changedPath, changedData, 0o600), qt.IsNil)
+
+	plan, err := goannotationcleanup.PlanDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(changedPath, replacementData, 0o600), qt.IsNil)
+
+	err = plan.Apply()
+
+	c.Assert(err, qt.ErrorMatches, "go source changed before cleanup: .*z_model.go")
+	firstAfter, err := os.ReadFile(firstPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(firstAfter, qt.DeepEquals, firstData)
+	changedAfter, err := os.ReadFile(changedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(changedAfter, qt.DeepEquals, replacementData)
 }
 
 func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *testing.T) {
@@ -250,12 +280,10 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Chmod(path, 0o640), qt.IsNil)
 
-	dryRunResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-		RootDir: dir,
-		DryRun:  true,
-	})
+	dryRunPlan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	dryRunResults := dryRunPlan.Results()
 	c.Assert(dryRunResults, qt.HasLen, 1)
 	c.Assert(dryRunResults[0].Path, qt.Equals, path)
 	c.Assert(dryRunResults[0].Changed, qt.IsTrue)
@@ -268,12 +296,10 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	diffResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-		RootDir: dir,
-		Diff:    true,
-	})
+	diffPlan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	diffResults := diffPlan.DiffResults()
 	c.Assert(diffResults, qt.HasLen, 1)
 	c.Assert(diffResults[0].Path, qt.Equals, dryRunResults[0].Path)
 	c.Assert(diffResults[0].Changed, qt.Equals, dryRunResults[0].Changed)
@@ -287,14 +313,16 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	writeResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	writePlan, err := goannotationcleanup.PlanDir(dir)
 
 	c.Assert(err, qt.IsNil)
+	writeResults := writePlan.Results()
 	c.Assert(writeResults, qt.HasLen, 1)
 	c.Assert(writeResults[0].Path, qt.Equals, dryRunResults[0].Path)
 	c.Assert(writeResults[0].Changed, qt.Equals, dryRunResults[0].Changed)
 	c.Assert(writeResults[0].RemovedLines, qt.Equals, dryRunResults[0].RemovedLines)
 	c.Assert(writeResults[0].Diff, qt.Equals, "")
+	c.Assert(writePlan.Apply(), qt.IsNil)
 	content, err = os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
@@ -302,17 +330,16 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	idempotentDryRunResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-		RootDir: dir,
-		DryRun:  true,
-		Diff:    true,
-	})
+	idempotentDryRunPlan, err := goannotationcleanup.PlanDir(dir)
 	c.Assert(err, qt.IsNil)
+	idempotentDryRunResults := idempotentDryRunPlan.DiffResults()
 	c.Assert(idempotentDryRunResults, qt.HasLen, 0)
 
-	idempotentWriteResults, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{RootDir: dir})
+	idempotentWritePlan, err := goannotationcleanup.PlanDir(dir)
 	c.Assert(err, qt.IsNil)
+	idempotentWriteResults := idempotentWritePlan.Results()
 	c.Assert(idempotentWriteResults, qt.HasLen, 0)
+	c.Assert(idempotentWritePlan.Apply(), qt.IsNil)
 	content, err = os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
@@ -343,12 +370,10 @@ func TestCleanDir_HappyPath_DiffMarksMissingFinalNewline(t *testing.T) {
 			path := filepath.Join(dir, "model.go")
 			c.Assert(os.WriteFile(path, []byte(tt.original), 0o600), qt.IsNil)
 
-			results, err := goannotationcleanup.CleanDir(goannotationcleanup.Options{
-				RootDir: dir,
-				Diff:    true,
-			})
+			plan, err := goannotationcleanup.PlanDir(dir)
 
 			c.Assert(err, qt.IsNil)
+			results := plan.DiffResults()
 			c.Assert(results, qt.HasLen, 1)
 			c.Assert(results[0].Diff, qt.Contains, tt.wantDiffLine)
 			c.Assert(strings.Count(results[0].Diff, "\\ No newline at end of file\n"), qt.Equals, 1)
@@ -357,4 +382,31 @@ func TestCleanDir_HappyPath_DiffMarksMissingFinalNewline(t *testing.T) {
 			c.Assert(string(content), qt.Equals, tt.original)
 		})
 	}
+}
+
+func TestPlanSourceAlias_HappyPath_ReportsExactSourceAndMissingPath(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := "package models\n\n//migrator:schema:table name=\"users\" platform.mysql.engine=\"InnoDB\"\ntype User struct{}\n"
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+
+	plan, err := goannotationcleanup.PlanDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.Annotations(), qt.DeepEquals, []goannotationcleanup.Annotation{
+		{
+			Path:       path,
+			Line:       3,
+			Directive:  "migrator:schema:table",
+			Attributes: []string{"name", "platform.mysql.engine"},
+		},
+	})
+
+	alias, err := plan.SourceAlias(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, path)
+
+	alias, err = plan.SourceAlias(filepath.Join(dir, "schema.hcl"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, "")
 }

--- a/internal/goannotationcleanup/replacefile_nonwindows.go
+++ b/internal/goannotationcleanup/replacefile_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package goannotationcleanup
+
+import "os"
+
+func replaceFile(source, target string) error {
+	return os.Rename(source, target)
+}

--- a/internal/goannotationcleanup/replacefile_windows.go
+++ b/internal/goannotationcleanup/replacefile_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package goannotationcleanup
+
+import "golang.org/x/sys/windows"
+
+func replaceFile(source, target string) error {
+	return windows.Rename(source, target)
+}

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -1,0 +1,340 @@
+// Package goannotationexport migrates Ptah Go annotations to HCL schema files.
+package goannotationexport
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/annotationmeta"
+	"github.com/stokaro/ptah/internal/atlashcl"
+	"github.com/stokaro/ptah/internal/atlashclrender"
+	"github.com/stokaro/ptah/internal/goannotationcleanup"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+var (
+	// ErrNoAnnotations reports that destructive cleanup has no source annotations
+	// to migrate and would therefore risk replacing a previous export with an
+	// empty schema.
+	ErrNoAnnotations = errors.New("no Ptah Go annotations found to export and clean")
+	// ErrLossyCleanup reports that destructive cleanup would discard schema intent.
+	ErrLossyCleanup = errors.New("refuse to clean Go annotations after a lossy HCL export")
+	// ErrInvalidHCL reports that generated HCL is not parseable and stable.
+	ErrInvalidHCL = errors.New("generated HCL failed round-trip validation")
+	// ErrOutputAliasesSource reports that the output aliases an input Go source.
+	ErrOutputAliasesSource = errors.New("HCL output aliases a Go source file")
+)
+
+// Options controls one Go-annotation-to-HCL export.
+type Options struct {
+	RootDir    string
+	OutputPath string
+	Cleanup    bool
+	DryRun     bool
+	Diff       bool
+}
+
+// Result describes a completed export.
+type Result struct {
+	OutputPath   string
+	Tables       int
+	Fields       int
+	Enums        int
+	Diagnostics  []atlashclrender.Diagnostic
+	Cleanup      []goannotationcleanup.Result
+	RemovedLines int
+}
+
+type exportPlan struct {
+	options        Options
+	rootDir        string
+	outputPath     string
+	cleanup        *goannotationcleanup.Plan
+	cleanupResults []goannotationcleanup.Result
+}
+
+type renderedExport struct {
+	database    *goschema.Database
+	hcl         []byte
+	diagnostics []atlashclrender.Diagnostic
+}
+
+// Export renders Go annotations to HCL and optionally applies one validated
+// cleanup plan after the output has been committed.
+func Export(opts Options) (Result, error) {
+	plan, err := prepareExport(opts)
+	if err != nil {
+		return Result{}, err
+	}
+	rendered, err := renderExport(plan)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := writeOutput(plan.outputPath, rendered.hcl); err != nil {
+		return Result{}, err
+	}
+	if err := plan.applyCleanup(); err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		OutputPath:   plan.outputPath,
+		Tables:       len(rendered.database.Tables),
+		Fields:       len(rendered.database.Fields),
+		Enums:        len(rendered.database.Enums),
+		Diagnostics:  rendered.diagnostics,
+		Cleanup:      plan.cleanupResults,
+		RemovedLines: removedAnnotationLines(plan.cleanupResults),
+	}, nil
+}
+
+func prepareExport(opts Options) (exportPlan, error) {
+	if (opts.DryRun || opts.Diff) && !opts.Cleanup {
+		return exportPlan{}, fmt.Errorf("cleanup dry-run and diff require cleanup")
+	}
+	rootDir, outputPath, err := resolvePaths(opts)
+	if err != nil {
+		return exportPlan{}, err
+	}
+
+	cleanupPlan, err := goannotationcleanup.PlanDir(rootDir)
+	if err != nil {
+		return exportPlan{}, fmt.Errorf("plan Go annotation cleanup: %w", err)
+	}
+	if alias, err := cleanupPlan.SourceAlias(outputPath); err != nil {
+		return exportPlan{}, err
+	} else if alias != "" {
+		return exportPlan{}, fmt.Errorf("%w: output %s refers to %s", ErrOutputAliasesSource, outputPath, alias)
+	}
+
+	cleanupResults := cleanupPlan.Results()
+	if opts.Diff {
+		cleanupResults = cleanupPlan.DiffResults()
+	}
+	if opts.Cleanup && len(cleanupResults) == 0 {
+		return exportPlan{}, ErrNoAnnotations
+	}
+
+	return exportPlan{
+		options:        opts,
+		rootDir:        rootDir,
+		outputPath:     outputPath,
+		cleanup:        cleanupPlan,
+		cleanupResults: cleanupResults,
+	}, nil
+}
+
+func renderExport(plan exportPlan) (renderedExport, error) {
+	db, err := goschema.ParseDir(plan.rootDir)
+	if err != nil {
+		return renderedExport{}, fmt.Errorf("parse Go annotations: %w", err)
+	}
+	rendered, err := atlashclrender.Render(db)
+	if err != nil {
+		return renderedExport{}, fmt.Errorf("render HCL schema: %w", err)
+	}
+	diagnostics := append(
+		append([]atlashclrender.Diagnostic(nil), rendered.Diagnostics...),
+		unretainedPlatformOverrideDiagnostics(plan.rootDir, plan.cleanup)...,
+	)
+	sortDiagnostics(diagnostics)
+	canonicalHCL, err := canonicalRoundTrip(rendered.Data)
+	if err != nil {
+		return renderedExport{}, err
+	}
+	if plan.options.Cleanup && len(diagnostics) > 0 {
+		return renderedExport{}, lossyCleanupError(diagnostics)
+	}
+	return renderedExport{
+		database:    db,
+		hcl:         canonicalHCL,
+		diagnostics: diagnostics,
+	}, nil
+}
+
+func (p exportPlan) applyCleanup() error {
+	if !p.options.Cleanup || p.options.DryRun || p.options.Diff {
+		return nil
+	}
+	if err := p.cleanup.Apply(); err != nil {
+		return fmt.Errorf("apply Go annotation cleanup: %w", err)
+	}
+	return nil
+}
+
+func removedAnnotationLines(results []goannotationcleanup.Result) int {
+	total := 0
+	for _, result := range results {
+		total += result.RemovedLines
+	}
+	return total
+}
+
+func resolvePaths(opts Options) (rootDir string, outputPath string, err error) {
+	root := opts.RootDir
+	if strings.TrimSpace(root) == "" {
+		root = "."
+	}
+	rootDir, err = pathguard.ResolveCLIPath(root)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid root directory: %w", err)
+	}
+	info, err := os.Stat(rootDir)
+	if err != nil {
+		return "", "", fmt.Errorf("stat root directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("root path is not a directory: %s", rootDir)
+	}
+	outputPath, err = pathguard.ResolveCLIPath(opts.OutputPath)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid output path: %w", err)
+	}
+	return rootDir, outputPath, nil
+}
+
+func canonicalRoundTrip(data []byte) ([]byte, error) {
+	parsed, err := atlashcl.Parse(data, "schema.hcl")
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse generated schema: %v", ErrInvalidHCL, err)
+	}
+	canonical, err := atlashclrender.Render(parsed)
+	if err != nil {
+		return nil, fmt.Errorf("%w: render canonical schema: %v", ErrInvalidHCL, err)
+	}
+	if len(canonical.Diagnostics) > 0 {
+		return nil, ErrInvalidHCL
+	}
+	if !bytes.Equal(canonical.Data, data) {
+		return nil, fmt.Errorf("%w: canonical render changed the generated schema", ErrInvalidHCL)
+	}
+	reparsed, err := atlashcl.Parse(canonical.Data, "schema.hcl")
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse canonical schema: %v", ErrInvalidHCL, err)
+	}
+	stable, err := atlashclrender.Render(reparsed)
+	if err != nil {
+		return nil, fmt.Errorf("%w: verify canonical schema: %v", ErrInvalidHCL, err)
+	}
+	if len(stable.Diagnostics) > 0 || !bytes.Equal(stable.Data, canonical.Data) {
+		return nil, ErrInvalidHCL
+	}
+	return canonical.Data, nil
+}
+
+func unretainedPlatformOverrideDiagnostics(
+	root string,
+	plan *goannotationcleanup.Plan,
+) []atlashclrender.Diagnostic {
+	var diagnostics []atlashclrender.Diagnostic
+	for _, annotation := range plan.Annotations() {
+		spec, ok := annotationmeta.Lookup(annotation.Directive)
+		if !ok || !spec.AllowPlatform || platformOverridesRetained(annotation.Directive) {
+			continue
+		}
+		for _, attribute := range annotation.Attributes {
+			if !strings.HasPrefix(attribute, "platform.") {
+				continue
+			}
+			path, err := filepath.Rel(root, annotation.Path)
+			if err != nil {
+				path = annotation.Path
+			}
+			diagnostics = append(diagnostics, atlashclrender.Diagnostic{
+				Severity: atlashclrender.SeverityWarning,
+				Path:     fmt.Sprintf("annotations.%s:%d", filepath.ToSlash(path), annotation.Line),
+				Message: fmt.Sprintf(
+					"%s is accepted by annotation syntax but is not retained in the schema IR",
+					attribute,
+				),
+			})
+		}
+	}
+	return diagnostics
+}
+
+func platformOverridesRetained(directive string) bool {
+	switch directive {
+	case "migrator:schema:field", "migrator:embedded", "migrator:schema:table":
+		return true
+	default:
+		return false
+	}
+}
+
+func sortDiagnostics(diagnostics []atlashclrender.Diagnostic) {
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+		return diagnostics[i].Message < diagnostics[j].Message
+	})
+}
+
+func lossyCleanupError(diagnostics []atlashclrender.Diagnostic) error {
+	var builder strings.Builder
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintf(&builder, "\n- %s: %s", diagnostic.Path, diagnostic.Message)
+	}
+	return fmt.Errorf("%w:%s", ErrLossyCleanup, builder.String())
+}
+
+func writeOutput(path string, data []byte) error {
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create HCL output directory: %w", err)
+	}
+
+	mode, err := outputMode(path)
+	if err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary HCL output: %w", err)
+	}
+	tempPath := file.Name()
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := file.Chmod(mode); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("set temporary HCL output mode: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write temporary HCL output: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync temporary HCL output: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary HCL output: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("commit HCL output: %w", err)
+	}
+	return nil
+}
+
+func outputMode(path string) (os.FileMode, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0o600, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("stat HCL output: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return 0, fmt.Errorf("HCL output is not a regular file: %s", path)
+	}
+	return info.Mode().Perm(), nil
+}

--- a/internal/goannotationexport/export_symlink_unix_test.go
+++ b/internal/goannotationexport/export_symlink_unix_test.go
@@ -1,0 +1,59 @@
+//go:build unix
+
+package goannotationexport_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationexport"
+)
+
+func TestExport_FailurePath_OutputSymlinkAliasCannotOverwriteGoSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	source := writeSimpleModel(c, root)
+	output := filepath.Join(outside, "schema.hcl")
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Symlink(source, output), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrOutputAliasesSource)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	info, err := os.Lstat(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode()&os.ModeSymlink, qt.Equals, os.ModeSymlink)
+}
+
+func TestExport_FailurePath_OutputHardLinkAliasCannotOverwriteGoSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	source := writeSimpleModel(c, root)
+	output := filepath.Join(outside, "schema.hcl")
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Link(source, output), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrOutputAliasesSource)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	assertFileBytes(c, output, sourceData)
+}

--- a/internal/goannotationexport/export_test.go
+++ b/internal/goannotationexport/export_test.go
@@ -1,0 +1,360 @@
+package goannotationexport_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlashcl"
+	"github.com/stokaro/ptah/internal/goannotationexport"
+)
+
+func TestExport_HappyPath_WritesValidatedHCLAndCleansAnnotations(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+	c.Assert(os.WriteFile(output, []byte("old schema\n"), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(output, 0o640), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	resolvedOutput, err := filepath.EvalSymlinks(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.OutputPath, qt.Equals, resolvedOutput)
+	c.Assert(result.Tables, qt.Equals, 1)
+	c.Assert(result.Fields, qt.Equals, 1)
+	c.Assert(result.Enums, qt.Equals, 0)
+	c.Assert(result.Diagnostics, qt.HasLen, 0)
+	c.Assert(result.Cleanup, qt.HasLen, 1)
+	c.Assert(result.Cleanup[0].RemovedLines, qt.Equals, 2)
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(sourceData), qt.Equals, "package models\n\ntype User struct {\n\tID int64\n}\n")
+	outputData, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+	parsed, err := atlashcl.Parse(outputData, output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Tables, qt.HasLen, 1)
+	c.Assert(parsed.Fields, qt.HasLen, 1)
+	info, err := os.Stat(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+}
+
+func TestExport_HappyPath_DiffWritesOutputWithoutChangingSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+	original, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+		Diff:       true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Cleanup, qt.HasLen, 1)
+	c.Assert(result.Cleanup[0].Diff, qt.Contains, "-//migrator:schema:table")
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourceData, qt.DeepEquals, original)
+	outputData, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(outputData), qt.Contains, `table "users"`)
+}
+
+func TestExport_HappyPath_CleanupModesReportTheSamePlan(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+	original, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+
+	dryRun, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+		DryRun:     true,
+	})
+	c.Assert(err, qt.IsNil)
+	assertFileBytes(c, source, original)
+
+	diff, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+		Diff:       true,
+	})
+	c.Assert(err, qt.IsNil)
+	assertFileBytes(c, source, original)
+
+	write, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(dryRun.Cleanup, qt.HasLen, 1)
+	c.Assert(diff.Cleanup, qt.HasLen, 1)
+	c.Assert(write.Cleanup, qt.HasLen, 1)
+	c.Assert(dryRun.Cleanup[0].Path, qt.Equals, diff.Cleanup[0].Path)
+	c.Assert(dryRun.Cleanup[0].Path, qt.Equals, write.Cleanup[0].Path)
+	c.Assert(dryRun.Cleanup[0].RemovedLines, qt.Equals, diff.Cleanup[0].RemovedLines)
+	c.Assert(dryRun.Cleanup[0].RemovedLines, qt.Equals, write.Cleanup[0].RemovedLines)
+	c.Assert(dryRun.Cleanup[0].Diff, qt.Equals, "")
+	c.Assert(diff.Cleanup[0].Diff, qt.Contains, "-//migrator:schema:table")
+	c.Assert(write.Cleanup[0].Diff, qt.Equals, "")
+}
+
+func TestExport_HappyPath_IsDeterministicAcrossRepeatedExports(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSimpleModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+
+	_, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+	})
+	c.Assert(err, qt.IsNil)
+	first, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+
+	_, err = goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+	})
+	c.Assert(err, qt.IsNil)
+	second, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(second, qt.DeepEquals, first)
+}
+
+func TestExport_HappyPath_NonDestructiveExportReportsLoss(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeLossyModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+	original, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.HasLen, 1)
+	c.Assert(result.Diagnostics[0].Message, qt.Contains, "custom SQL")
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourceData, qt.DeepEquals, original)
+	outputData, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(outputData), qt.Contains, `table "users"`)
+}
+
+func TestExport_FailurePath_RepeatCleanupPreservesExistingOutput(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	output := filepath.Join(root, "schema.hcl")
+	sourceData := []byte("package models\n\ntype User struct{}\n")
+	outputData := []byte("previous useful schema\n")
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrNoAnnotations)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	assertFileBytes(c, output, outputData)
+}
+
+func TestExport_FailurePath_LossyCleanupPreservesOutputAndSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeLossyModel(c, root)
+	output := filepath.Join(root, "schema.hcl")
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	outputData := []byte("previous schema\n")
+	c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrLossyCleanup)
+	c.Assert(err.Error(), qt.Contains, "custom SQL")
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	assertFileBytes(c, output, outputData)
+}
+
+func TestExport_FailurePath_UnstableHCLPreservesOutputAndSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	output := filepath.Join(root, "schema.hcl")
+	sourceData := []byte(`package models
+
+//migrator:schema:table name="measurements"
+type Measurement struct {
+	//migrator:schema:field name="value" type="DOUBLE PRECISION"
+	Value float64
+}
+`)
+	outputData := []byte("previous schema\n")
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrInvalidHCL)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	assertFileBytes(c, output, outputData)
+}
+
+func TestExport_FailurePath_OutputCannotAliasGoSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: source,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrOutputAliasesSource)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+}
+
+func TestExport_FailurePath_OutputWriteFailurePreservesSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	parentFile := filepath.Join(root, "not-a-directory")
+	c.Assert(os.WriteFile(parentFile, []byte("block directory creation"), 0o600), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: filepath.Join(parentFile, "schema.hcl"),
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "output")
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+}
+
+func TestExport_FailurePath_UnretainedPlatformOverrideBlocksCleanup(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	output := filepath.Join(root, "schema.hcl")
+	sourceData := []byte(`package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="BIGINT"
+	ID int64
+
+	//migrator:schema:index name="idx_users_id" fields="id" platform.mysql.type="HASH"
+	_ int
+}
+`)
+	outputData := []byte("previous schema\n")
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, outputData, 0o600), qt.IsNil)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrLossyCleanup)
+	c.Assert(err.Error(), qt.Contains, "platform.mysql.type")
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	assertFileBytes(c, output, outputData)
+}
+
+func TestExport_FailurePath_RejectsCleanupModesWithoutCleanup(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := goannotationexport.Export(goannotationexport.Options{DryRun: true})
+
+	c.Assert(err, qt.ErrorMatches, "cleanup dry-run and diff require cleanup")
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+}
+
+func writeSimpleModel(c *qt.C, root string) string {
+	path := filepath.Join(root, "model.go")
+	data := []byte(`package models
+
+//migrator:schema:table name="users"
+type User struct {
+	//migrator:schema:field name="id" type="BIGINT"
+	ID int64
+}
+`)
+	c.Assert(os.WriteFile(path, data, 0o600), qt.IsNil)
+	return path
+}
+
+func writeLossyModel(c *qt.C, root string) string {
+	path := filepath.Join(root, "model.go")
+	data := []byte(`package models
+
+//migrator:schema:table name="users" custom="WITHOUT OIDS"
+type User struct {
+	//migrator:schema:field name="id" type="BIGINT"
+	ID int64
+}
+`)
+	c.Assert(os.WriteFile(path, data, 0o600), qt.IsNil)
+	return path
+}
+
+func assertFileBytes(c *qt.C, path string, want []byte) {
+	c.Helper()
+	got, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, want)
+}


### PR DESCRIPTION
## Summary

- move Go-annotation-to-HCL migration orchestration from Cobra into a reusable internal workflow
- require a non-empty, diagnostic-free, byte-stable HCL round trip before destructive cleanup and reject source aliases/repeated cleanup
- stage, sync, atomically replace, and roll back Go source cleanup across Unix and Windows
- report previously silent losses, including managed data, legacy table checks, orphan indexes/constraints, and unretained platform overrides
- document the one-time lossless cleanup workflow in core and site documentation

## Validation

- `go test ./... -count=1`
- `go test -race ./cmd/schema ./internal/goannotationexport ./internal/goannotationcleanup ./internal/atlashclrender -count=1`
- Windows cross-compile tests for affected packages
- `go vet` and `gopls check` for affected packages
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- all docs link, redirect, page-health, exit-code, and version checks
- `npm run build` and `npm audit --audit-level=low` in `docs/site`

Fixes #835