### PR TITLE
Restore reader-facing lint extensibility documentation (#270)

### DIFF
--- a/docs/site/src/content/docs/extend/components.md
+++ b/docs/site/src/content/docs/extend/components.md
@@ -414,6 +414,33 @@ and `DataType`. In Atlas compatibility mode, a bare file-header
 findings. Report adapters should omit ignored files while retaining them in the
 captured snapshot.
 
+A host tool can add its own analyzers to the same run without reimplementing
+the dialect-aware scanner. `Options.ExtraRules` appends per-run rules — the
+preferred shape, with no global state — and `lint.Register` installs a rule
+process-wide. Either way, the rule receives statements Ptah has already
+prepared: `Statement.Words` is the comment-free token-word sequence the
+built-in rules scan, and `Statement.Canonical` is the uppercased display
+form. This example is compile-checked in `examples/reusable_components`:
+
+```go
+findings, err = lint.LintFS(fsys, lint.Options{
+	Dialect: "postgres",
+	ExtraRules: []lint.Rule{{
+		Code:     "ORG101",
+		Title:    "TEXT column without explicit limit",
+		Severity: lint.SeverityWarning,
+		CheckStatement: func(stmt *lint.Statement) (bool, string) {
+			return slices.Contains(stmt.Words, "TEXT"), "use VARCHAR(n) so limits stay reviewable"
+		},
+	}},
+})
+```
+
+Custom codes flow through reporting, `--disable`, inline `-- ptah:nolint`
+directives, and `.ptah-lint.yaml` per-rule severity and path excludes
+exactly like built-in codes; the configuration surface is documented in
+[Integrity and safety](../../versioned/integrity-and-safety/).
+
 ### Use capabilities
 
 Use capabilities when syntax depends on a dialect version rather than only a

--- a/docs/site/src/content/docs/testing/ci.md
+++ b/docs/site/src/content/docs/testing/ci.md
@@ -106,6 +106,30 @@ ptah schema render --root-dir ./models --dialect postgres >/tmp/ptah-schema.sql
 Use a disposable database for `migrations plan`, `migrations generate`, and
 `migrations up` in pull requests.
 
+## Upload lint findings to code scanning
+
+`ptah migrations lint --format sarif` emits a SARIF 2.1.0 document that
+GitHub code scanning ingests, turning findings into pull-request annotations
+with stable rule identifiers:
+
+```yaml
+      - name: Lint migrations
+        run: >
+          ptah migrations lint --dir ./migrations --dialect postgres
+          --fail-on none --format sarif > ptah-lint.sarif
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ptah-lint.sarif
+          category: ptah-lint
+```
+
+The upload step needs the `security-events: write` permission. Use
+`--fail-on none` when code scanning owns the failure policy — above the
+threshold the report goes to stderr and the command exits `1`, so a plain
+stdout redirect would capture an empty file. Prefer
+`--format github-actions` when inline annotations are wanted without the
+code-scanning permission model.
+
 ## Recommended pull-request contour
 
 | Check | Why it exists |

--- a/docs/site/src/content/docs/versioned/generate.md
+++ b/docs/site/src/content/docs/versioned/generate.md
@@ -213,8 +213,11 @@ exit `2`:
 error: destructive migration statements require AllowDestructive
 ```
 
-Review the plan, then rerun with `--allow-destructive` to accept it. The
-apply-time gate on `ptah migrations up` is separate — see
+Review the plan, then rerun with `--allow-destructive` to accept it. Use
+`--report json` when CI needs the safety classification as structured data
+instead of text — the GitHub Action's destructive-change check run is driven
+by exactly that report ([CI](../../testing/ci/)). The apply-time gate on
+`ptah migrations up` is separate — see
 [Integrity and safety](../integrity-and-safety/).
 
 **Conflicting sources stop generation.** When two schema sources disagree

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -128,16 +128,79 @@ Useful controls, all designed for CI:
 - `--fail-on error` (default) fails only on error-severity findings;
   `--fail-on any` fails on warnings too; `--fail-on none` always exits `0`.
 - `--format json`, `--format sarif`, and `--format github-actions` feed code
-  scanners and PR annotations.
+  scanners and PR annotations. The SARIF output is a SARIF 2.1.0 document
+  that GitHub code scanning ingests — [CI](../../testing/ci/) shows the
+  upload step.
 - `--dialect` gates dialect-specific rules; `--dev-url` infers the dialect
   and additionally replays the directory on the dev database.
-- A `.ptah-lint.yaml` in the migration directory pins rule severities and
-  disabled rules; `--disable DS101` (or a family such as `MY`) does it ad
-  hoc.
+- `--disable DS101` (or a family such as `MY`) skips rules ad hoc; a
+  committed `.ptah-lint.yaml` does it persistently and adds per-rule
+  severity and path scoping — see below.
 
 For OCI-distributed directories, `lint --dir oci://...` lints the published
 artifact, and `--attach` stores the canonical report next to it — see
 [OCI registry artifacts](../../operate/oci-registry/).
+
+### Configure rules with `.ptah-lint.yaml`
+
+Commit a `.ptah-lint.yaml` next to the migration files to make lint policy
+part of the reviewed migration directory. Without an explicit `--config`
+path, Ptah loads `<dir>/.ptah-lint.yaml` when present:
+
+```yaml
+dialect: postgres
+disabled-rules:
+  - MF103
+  - MY
+rules:
+  DS103:
+    severity: warning
+  DS102:
+    severity: error
+    exclude:
+      - legacy/**
+```
+
+- `dialect` sets the default lint dialect; `--dialect` overrides it.
+- `disabled-rules` lists rule codes (`DS101`) or family prefixes (`MY`) to
+  skip entirely; entries merge with `--disable` flags.
+- `rules` keys name an exact code or a family prefix; the most specific key
+  wins, so a `DS102` entry beats a `DS` entry.
+- `severity` accepts `warning` or `error` and replaces the rule's default
+  severity on its findings — the level that `--fail-on` and the apply-time
+  destructive gate below evaluate. Any other value fails config parsing
+  (exit `2`).
+- `exclude` lists slash-separated path globs (`**` crosses directory
+  levels) where the rule is skipped, matched against each migration file's
+  path — "DS102 is acceptable under `legacy/`" without disabling the rule
+  everywhere.
+
+Precedence: a rule listed in `disabled-rules` never runs, regardless of its
+`rules` entry; then `exclude` skips the matching files; then `severity`
+relabels the findings that remain. Per-rule entries apply to custom
+analyzer codes the same way as to built-in ones — see
+[Reusable components](../../extend/components/) for registering custom
+rules from Go.
+
+### Suppress a single statement inline
+
+When one reviewed statement is acceptable but the rule should stay active
+everywhere else, put a `ptah:nolint` comment directly above it:
+
+```sql
+-- ptah:nolint DS102
+ALTER TABLE users DROP COLUMN archived_note;
+```
+
+The directive suppresses only the named rules, and only for the next
+statement. List several codes separated by spaces or commas, name a family
+(`DS`), or write a bare `-- ptah:nolint` to silence every rule for that one
+statement. `-- atlas:nolint DS102` is accepted as an alias with the same
+statement-scoped behavior, so a directory shared with Atlas tooling keeps
+one set of directives. Atlas analyzer-name selectors (such as
+`destructive`) and whole-file `atlas:nolint` headers take effect only on
+the Atlas-compatible surface — see
+[Atlas migrate commands](../../atlas/migrate-commands/).
 
 ## The destructive-change gate
 
@@ -156,6 +219,29 @@ error: error running migrations: pending migrations contain destructive statemen
 
 Use `--allow-destructive` only after the plan has been reviewed and the
 rollback path is understood.
+
+The apply-time gate loads the same `.ptah-lint.yaml` as
+`ptah migrations lint` and blocks on error-severity `DS` data-safety
+findings. That makes the escape hatch proportional: a rule downgraded with
+`severity: warning`, listed under `disabled-rules`, or excluded for a path
+stops blocking exactly that reviewed pattern — a widening
+`ALTER COLUMN ... TYPE` under `rules: {DS103: {severity: warning}}` applies
+without `--allow-destructive` — while a `DROP TABLE` in another pending
+file of the same batch still aborts the apply. `--allow-destructive`
+remains the all-or-nothing per-run override rather than the only way past
+a single warning-grade finding.
+
+Know the limits of this gate: the policy file is not tamper-evident.
+`ptah.sum` hashes only the migration `*.sql` files, so
+`ptah migrations validate` and `up --verify-sum` still pass when
+`.ptah-lint.yaml` is added or edited out-of-band, and the apply prints no
+notice when the config suppresses a destructive finding — a one-line
+`disabled-rules: [DS]` dropped next to the migrations at deploy time
+disables this gate silently. Loosening the gate is a visible committed
+change only if your process makes it one: commit `.ptah-lint.yaml`, treat
+any edit to it as an edit to the gate in review, and restrict writes to
+the deployed migration directory, because the integrity file does not
+protect the policy the way it protects the SQL.
 
 `ptah migrations up` captures the migration directory before checksum
 verification, provider registration, and destructive linting. The safety gate

--- a/examples/reusable_components/reusable_components_test.go
+++ b/examples/reusable_components/reusable_components_test.go
@@ -1,6 +1,7 @@
 package reusable_components_test
 
 import (
+	"slices"
 	"testing"
 	"testing/fstest"
 
@@ -123,6 +124,35 @@ func TestMigrationIntegrityAndLint(t *testing.T) {
 	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "sqlite"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 0)
+}
+
+func TestCustomLintRule(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		"0000000001_create_notes.up.sql": {
+			Data: []byte("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);\n"),
+		},
+		"0000000001_create_notes.down.sql": {
+			Data: []byte("DROP TABLE notes;\n"),
+		},
+	}
+
+	findings, err := lint.LintFS(fsys, lint.Options{
+		Dialect: "postgres",
+		ExtraRules: []lint.Rule{{
+			Code:     "ORG101",
+			Title:    "TEXT column without explicit limit",
+			Severity: lint.SeverityWarning,
+			CheckStatement: func(stmt *lint.Statement) (bool, string) {
+				return slices.Contains(stmt.Words, "TEXT"), "use VARCHAR(n) so limits stay reviewable"
+			},
+		}},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 1)
+	c.Assert(findings[0].Rule, qt.Equals, "ORG101")
+	c.Assert(findings[0].Severity, qt.Equals, lint.SeverityWarning)
 }
 
 func TestCapabilitiesRender(t *testing.T) {


### PR DESCRIPTION
Closes #270.

## Summary

Audit-first result: all four of the issue's code asks are **already implemented on master** — pluggable analyzers (`lint.Register`, `Options.ExtraRules`, `AnalyzeFS` with exported `Statement`), per-rule severity overrides in `.ptah-lint.yaml` (validated, exact-code-beats-family precedence), statement-scoped `-- ptah:nolint` (with the `atlas:nolint` alias) plus path-scoped `exclude` globs, and a migrate-up gate that loads the directory's `.ptah-lint.yaml`. The issue was reopened solely because the docs restructuring removed the reader-facing guidance.

This change restores that documentation and adds a compile-checked custom-rule example:

- `versioned/integrity-and-safety.md`: full `.ptah-lint.yaml` reference (severity map, `disabled-rules`, path `exclude` globs, precedence), inline-suppression section, and the apply-gate composition semantics — including a loud, honest note that the policy file can suppress the destructive gate and how to mitigate (the file lives in the hashed, reviewed migration directory; `--allow-destructive` remains the explicit per-run override).
- `extend/components.md`: custom-analyzer section whose snippet is byte-for-byte the new `TestCustomLintRule` in `examples/reusable_components` (exercises `Options.ExtraRules` via public API only).
- `testing/ci.md` + `versioned/generate.md`: SARIF and JSON safety-report guidance restored.

Zero Go behavior changes (`migration/lint`, `cmd/migrateup`, `migration/migrator` diffs are empty); adversarial review empirically re-verified the gate semantics (blocked without config, severity/exclude/nolint unblock exactly as documented) and confirmed the snapshot is unchanged.

Follow-up candidate noted by review (outside this issue's reopened scope): a runtime notice when config suppresses a DS finding at apply time.

## Verification

build, gofmt, vet, golangci-lint (0 issues), qtlint, teststyle, `go test ./...` (165 pkgs), both public-API checks, docs-site `check:*` (58 pages / 30 redirects) — all green.