### PR TITLE
Auto-sync the testkit module on bot dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    # testkit/ is a separate Go module whose go.sum must move together with
+    # the root module, so both manifests are updated in the same PR.
+    directories:
+      - "/"
+      - "/testkit"
     schedule:
       interval: "weekly"
     allow:

--- a/.github/workflows/testkit-sync.yml
+++ b/.github/workflows/testkit-sync.yml
@@ -1,0 +1,70 @@
+# Auto-syncs the separate testkit module after bot dependency bumps.
+#
+# Renovate and Dependabot update only the root go.mod/go.sum; testkit/ is a
+# separate Go module (with `replace github.com/stokaro/ptah => ..`), so its
+# go.sum goes stale on every root Go dependency bump and the testkit CI jobs
+# fail with "go: updates to go.mod needed; to update it: go mod tidy".
+# This workflow runs that tidy on the bot's PR branch and pushes the sync
+# commit automatically.
+#
+# Token note: pushes made with the default GITHUB_TOKEN do not retrigger CI
+# runs. Configure a fine-grained PAT (Contents: read/write on this repository)
+# as the TESTKIT_SYNC_TOKEN secret so the sync commit re-runs the checks; with
+# the fallback token the sync still lands but the checks need a manual re-run.
+#
+# pull_request_target is used because Dependabot-triggered pull_request runs
+# get a read-only GITHUB_TOKEN. The job is restricted to bot-authored branches
+# of this repository and only ever runs `go mod tidy` in testkit/.
+name: testkit-sync
+
+on:
+  pull_request_target:
+    paths:
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync testkit go.sum
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' ||
+       startsWith(github.event.pull_request.head.ref, 'renovate/') ||
+       startsWith(github.event.pull_request.head.ref, 'dependabot/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the pull request branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.TESTKIT_SYNC_TOKEN || github.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            testkit/go.sum
+
+      - name: Tidy the testkit module
+        working-directory: testkit
+        env:
+          GOWORK: "off"
+          GOFLAGS: "-mod=mod"
+        run: go mod tidy
+
+      - name: Commit and push the sync when needed
+        run: |
+          if git diff --quiet -- testkit/go.mod testkit/go.sum; then
+            echo "testkit module already in sync; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add testkit/go.mod testkit/go.sum
+          git commit -m "Sync testkit module go.sum with the root dependency bump"
+          git push


### PR DESCRIPTION
Fixes the recurring CI breakage where every Renovate/Dependabot Go bump fails the `sqlite`/`containers` jobs: the bots update only the root `go.mod`, while `testkit/` is a separate module whose `go.sum` then goes stale (`go: updates to go.mod needed`). Until now the sync was applied by hand on every such PR (#797–#800, #853…).

Two complementary mechanisms:

1. **`testkit-sync` workflow** — on bot PRs touching root `go.mod`/`go.sum` (`pull_request_target`, restricted to same-repo `renovate/`/`dependabot/` branches; Dependabot-triggered `pull_request` runs get a read-only token, hence the target event), runs `go mod tidy` in `testkit/` and pushes the sync commit with the `github-actions[bot]` identity. No-op when already in sync.
2. **Dependabot multi-directory** — the gomod ecosystem now lists `directories: ["/", "/testkit"]`, so Dependabot updates both manifests in the same PR natively (indirect deps are already allowed in this config); the workflow remains the safety net and covers Renovate.

**One manual step to get the full effect:** pushes made with the default `GITHUB_TOKEN` do not retrigger CI, so after an auto-sync the checks would need a manual re-run. Add a fine-grained PAT (this repository only, permission **Contents: Read and write**) as the **`TESTKIT_SYNC_TOKEN`** secret — the workflow prefers it and the sync commit then re-runs CI automatically.