### PR TITLE
[smoke] testkit-sync end-to-end test — do not merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,5 @@ tool (
 	golang.org/x/exp/cmd/apidiff
 	golang.org/x/vuln/cmd/govulncheck
 )
+
+// testkit-sync smoke test (temporary; PR will be closed)

--- a/testkit/go.sum
+++ b/testkit/go.sum
@@ -262,3 +262,4 @@ modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/testkit/go.sum
+++ b/testkit/go.sum
@@ -262,4 +262,3 @@ modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=


### PR DESCRIPTION
Temporary smoke test of the #865/#875 auto-sync: root go.mod touched + one line removed from testkit/go.sum. Expected: the testkit-sync workflow mints the app token, restores go.sum via tidy, pushes the sync commit, and CI re-runs on the synced head. Will be closed without merging.