### PR TITLE
Harden dev database cleanup and migration publication

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -294,7 +294,9 @@ jobs:
         env:
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MYSQL_CLEANUP_URL: "mysql://root:root_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+          MARIADB_CLEANUP_URL: "mariadb://root:root_password@tcp(127.0.0.1:3307)/ptah_test"
           CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
           COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -243,10 +243,10 @@ jobs:
         run: |
           go test -v -count=1 ./internal/dblock -run '^TestAdvisoryLock_PostgresFamilyLive$' -timeout 3m
           go test -v -count=1 ./internal/devlock -run '^TestAcquire_CockroachDBSerializesSameRealmLive$' -timeout 3m
-          go test -v -count=1 ./internal/dbschema/mysql -tags=integration -run '^TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase$' -timeout 3m
-          go test -v -count=1 ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_(Live|RejectsLegacyServerLive)$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/mysql -tags=integration -run '^TestWriterDropDatabaseRealm_Live(RejectsProtectedDatabase|RejectsExternalStoredProgram|RejectsMissingTriggerPrivilege)$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_(Live|RejectsExternalDependencyLive|RejectsLegacyServerLive)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m
-          go test -v -count=1 ./internal/dbschema/postgres -tags=integration -run '^TestWriterDropDatabaseRealm_Live(PostgresFamilyCleansCrossSchemaGraph|RejectsProtectedDatabase)$' -timeout 5m
+          go test -v -count=1 ./internal/dbschema/postgres -tags=integration -run '^TestWriterDropDatabaseRealm_Live(PostgresFamilyCleansCrossSchemaGraph|PostgresCleansLargeObjects|PostgresRejectsPublication|RejectsProtectedDatabase)$' -timeout 5m
           go test -v -count=1 ./internal/migrationreplay -tags=integration -run '^TestWithReplayedSnapshot_(ClickHouse|SQLServer)Live$' -timeout 5m
           go test -v -count=1 ./integration -tags=integration -run '^TestAtlasMigrateDiff(MySQLFamilyDatabaseDesiredState|PostgresFamilyDevCleanup)E2E$' -timeout 12m
 

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
           - 3307:3306
 
       clickhouse:
-        image: clickhouse/clickhouse-server:24
+        image: clickhouse/clickhouse-server:24.12
         env:
           CLICKHOUSE_DB: ptah_test
           CLICKHOUSE_USER: ptah_user
@@ -77,6 +77,22 @@ jobs:
         ports:
           - 8123:8123
           - 9000:9000
+
+      clickhouse-legacy:
+        image: clickhouse/clickhouse-server:24.10
+        env:
+          CLICKHOUSE_DB: ptah_test
+          CLICKHOUSE_USER: ptah_user
+          CLICKHOUSE_PASSWORD: ptah_password
+          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+        options: >-
+          --health-cmd "wget --no-verbose --tries=1 --spider http://localhost:8123/ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 8124:8123
+          - 9001:9000
 
       sqlserver:
         image: mcr.microsoft.com/mssql/server:2025-latest
@@ -152,6 +168,13 @@ jobs:
           done
           echo "ClickHouse is ready!"
 
+          echo "Waiting for legacy ClickHouse..."
+          until curl --silent --fail http://127.0.0.1:8124/ping; do
+            echo "Legacy ClickHouse is unavailable - sleeping"
+            sleep 2
+          done
+          echo "Legacy ClickHouse is ready!"
+
           echo "Waiting for CockroachDB..."
           until docker exec ptah-cockroachdb /cockroach/cockroach sql --insecure --host=127.0.0.1:26257 --execute="SELECT 1"; do
             echo "CockroachDB is unavailable - sleeping"
@@ -194,19 +217,37 @@ jobs:
           MARIADB_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3307)/mysql"
           MARIADB_ADMIN_TEST_URL: "mariadb://root:root_password@tcp(127.0.0.1:3307)/mysql"
           PTAH_CLICKHOUSE_REALM_TEST_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL: "clickhouse://ptah_user:ptah_password@localhost:9001/ptah_test"
           PTAH_SQLSERVER_REALM_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
           PTAH_OCI_TEST_REGISTRY: "127.0.0.1:5000"
         run: |
           go test -v ./integration -tags=integration -timeout 15m
           go test -v ./integration/gonative -tags=integration -timeout 15m
-          go test -v ./internal/dblock -run '^TestAdvisoryLock_PostgresFamilyLive$' -timeout 3m
-          go test -v ./internal/devlock -run '^TestAcquire_CockroachDBSerializesSameRealmLive$' -timeout 3m
-          go test -v ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_Live$' -timeout 3m
-          go test -v ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m
-          go test -v ./internal/dbschema/postgres -tags=integration -run '^TestWriterDrop(DatabaseRealm|AllTables)_Live' -timeout 5m
           go test -v ./dbschema -run 'TestSQLServerLive(ReadSchema|DropAllTablesDropsForeignKeys|ComputedColumnZeroDiff|DropAllTablesRejectsExternalForeignKeys|IdentifierSemantics_)' -timeout 3m
           go test -v ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration' -timeout 3m
           go test -v ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m
+
+      - name: Run database-realm cleanup and replay tests
+        env:
+          POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+          MYSQL_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3306)/mysql"
+          MYSQL_ADMIN_TEST_URL: "mysql://root:root_password@tcp(127.0.0.1:3306)/mysql"
+          MARIADB_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3307)/mysql"
+          MARIADB_ADMIN_TEST_URL: "mariadb://root:root_password@tcp(127.0.0.1:3307)/mysql"
+          PTAH_CLICKHOUSE_REALM_TEST_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL: "clickhouse://ptah_user:ptah_password@localhost:9001/ptah_test"
+          PTAH_SQLSERVER_REALM_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
+        run: |
+          go test -v -count=1 ./internal/dblock -run '^TestAdvisoryLock_PostgresFamilyLive$' -timeout 3m
+          go test -v -count=1 ./internal/devlock -run '^TestAcquire_CockroachDBSerializesSameRealmLive$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/mysql -tags=integration -run '^TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_(Live|RejectsLegacyServerLive)$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m
+          go test -v -count=1 ./internal/dbschema/postgres -tags=integration -run '^TestWriterDropDatabaseRealm_Live(PostgresFamilyCleansCrossSchemaGraph|RejectsProtectedDatabase)$' -timeout 5m
+          go test -v -count=1 ./internal/migrationreplay -tags=integration -run '^TestWithReplayedSnapshot_(ClickHouse|SQLServer)Live$' -timeout 5m
+          go test -v -count=1 ./integration -tags=integration -run '^TestAtlasMigrateDiff(MySQLFamilyDatabaseDesiredState|PostgresFamilyDevCleanup)E2E$' -timeout 12m
 
       - name: Build integration test binary
         run: |

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -200,6 +200,7 @@ jobs:
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           MYSQL_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MYSQL_CLEANUP_TEST_DSN: "root:root_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
           COCKROACHDB_TEST_DSN: "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_TEST_DSN: "postgresql://yugabyte@localhost:5433/yugabyte?sslmode=disable"

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -180,6 +180,8 @@ jobs:
           MARIADB_TEST_DSN: "ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
           COCKROACHDB_TEST_DSN: "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_TEST_DSN: "postgresql://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+          COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
+          YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
           SQLSERVER_TEST_DSN: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
           POSTGRES_TEST_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
@@ -191,10 +193,17 @@ jobs:
           MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
           MARIADB_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3307)/mysql"
           MARIADB_ADMIN_TEST_URL: "mariadb://root:root_password@tcp(127.0.0.1:3307)/mysql"
+          PTAH_CLICKHOUSE_REALM_TEST_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          PTAH_SQLSERVER_REALM_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
           PTAH_OCI_TEST_REGISTRY: "127.0.0.1:5000"
         run: |
           go test -v ./integration -tags=integration -timeout 15m
           go test -v ./integration/gonative -tags=integration -timeout 15m
+          go test -v ./internal/dblock -run '^TestAdvisoryLock_PostgresFamilyLive$' -timeout 3m
+          go test -v ./internal/devlock -run '^TestAcquire_CockroachDBSerializesSameRealmLive$' -timeout 3m
+          go test -v ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_Live$' -timeout 3m
+          go test -v ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m
+          go test -v ./internal/dbschema/postgres -tags=integration -run '^TestWriterDrop(DatabaseRealm|AllTables)_Live' -timeout 5m
           go test -v ./dbschema -run 'TestSQLServerLive(ReadSchema|DropAllTablesDropsForeignKeys|ComputedColumnZeroDiff|DropAllTablesRejectsExternalForeignKeys|IdentifierSemantics_)' -timeout 3m
           go test -v ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration' -timeout 3m
           go test -v ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -53,6 +53,6 @@ jobs:
 
       - name: Run Windows filesystem publication tests
         run: |
-          go test -v ./internal/fsdurable ./internal/migratesum ./internal/devlock -timeout 5m
-          go test -v ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
-          go test -v ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m
+          go test -v -count=1 ./internal/fsdurable ./internal/migratesum ./internal/devlock -timeout 5m
+          go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
+          go test -v -count=1 ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -52,4 +52,7 @@ jobs:
         run: go mod download
 
       - name: Run Windows filesystem publication tests
-        run: go test -v ./internal/fsdurable ./internal/migratesum ./internal/atlasmigrate -timeout 5m
+        run: |
+          go test -v ./internal/fsdurable ./internal/migratesum ./internal/devlock -timeout 5m
+          go test -v ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
+          go test -v ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m

--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -33,3 +33,23 @@ jobs:
           # Run unit tests excluding integration tests
           # These tests don't require database connections
           go test -v -race ./... -timeout 10m
+
+  windows-publication:
+    name: windows-publication
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.5'
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run Windows filesystem publication tests
+        run: go test -v ./internal/fsdurable ./internal/migratesum ./internal/atlasmigrate -timeout 5m

--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -476,12 +476,6 @@
     },
     {
       "path": "internal/dbschema/postgres/postgres_test.go",
-      "function": "TestPostgreSQLWriterDropAllTablesRollsBackOnFailure",
-      "kind": "if",
-      "count": 1
-    },
-    {
-      "path": "internal/dbschema/postgres/postgres_test.go",
       "function": "TestPostgresNullsDistinctFromDefinition",
       "kind": "if",
       "count": 1

--- a/cmd/atlas/atlas_lint_devurl_test.go
+++ b/cmd/atlas/atlas_lint_devurl_test.go
@@ -38,7 +38,7 @@ func TestCompatCommand_MigrateLintDevURLReplaysMigration(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "Analyzing changes until version 1 (1 migration in total):")
 	c.Assert(out.String(), qt.Contains, "  -- analyzing version 1\n    -- no diagnostics found\n")
 	c.Assert(out.String(), qt.Contains, "  -- 1 version ok\n")
-	assertAtlasLintDevURLSQLiteTableCount(c, devDBPath, "atlas_lint_dev_url", 1)
+	assertAtlasLintDevURLSQLiteTableCount(c, devDBPath, "atlas_lint_dev_url", 0)
 }
 
 func TestCompatCommand_MigrateLintRejectsDockerDevURL(t *testing.T) {

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/testutils"
 	migrationlint "github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -3192,7 +3193,7 @@ CREATE TABLE users (
 
 	err := cmd.Execute()
 	_, statErr := os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
-	_, lockStatErr := os.Stat(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"))
+	_, lockStatErr := os.Stat(atlasMigrateDiffLockPath(migrationsDir))
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "ALTER TABLE")
@@ -3555,7 +3556,11 @@ func TestCompatCommand_MigrateDiffLockTimeout(t *testing.T) {
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
 	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"), []byte("held\n"), 0o600), qt.IsNil)
+	releaseLock, err := testutils.AcquireExclusiveFileLock(atlasMigrateDiffLockPath(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(releaseLock(), qt.IsNil)
+	})
 	schemaPath := filepath.Join(dir, "schema.sql")
 	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE locked_diff (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
 
@@ -3572,7 +3577,7 @@ func TestCompatCommand_MigrateDiffLockTimeout(t *testing.T) {
 		"locked_diff",
 	})
 
-	err := cmd.Execute()
+	err = cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `migration directory lock timeout after 1ms: .*\.ptah-migrate-diff\.lock`)
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 0)
@@ -4602,4 +4607,12 @@ func readAtlasTestFile(c *qt.C, dir, name string) string {
 	data, err := os.ReadFile(filepath.Join(dir, name))
 	c.Assert(err, qt.IsNil)
 	return string(data)
+}
+
+func atlasMigrateDiffLockPath(migrationsDir string) string {
+	cleanDir := filepath.Clean(migrationsDir)
+	return filepath.Join(
+		filepath.Dir(cleanDir),
+		"."+filepath.Base(cleanDir)+".ptah-migrate-diff.lock",
+	)
 }

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -3193,7 +3193,10 @@ CREATE TABLE users (
 
 	err := cmd.Execute()
 	_, statErr := os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
-	_, lockStatErr := os.Stat(atlasMigrateDiffLockPath(migrationsDir))
+	lockInfo, lockStatErr := os.Stat(atlasMigrateDiffLockPath(migrationsDir))
+	releaseLock, lockErr := testutils.AcquireExclusiveFileLock(
+		atlasMigrateDiffLockPath(migrationsDir),
+	)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "ALTER TABLE")
@@ -3202,7 +3205,10 @@ CREATE TABLE users (
 	c.Assert(out.String(), qt.Not(qt.Contains), "Created migration file:")
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
 	c.Assert(statErr, qt.ErrorIs, os.ErrNotExist)
-	c.Assert(lockStatErr, qt.ErrorIs, os.ErrNotExist)
+	c.Assert(lockStatErr, qt.IsNil)
+	c.Assert(lockInfo.Mode().IsRegular(), qt.IsTrue)
+	c.Assert(lockErr, qt.IsNil)
+	c.Assert(releaseLock(), qt.IsNil)
 }
 
 func TestCompatCommand_MigrateDiffCustomFormatWritesFormattedMigration(t *testing.T) {

--- a/cmd/atlas/atlas_validate_devurl_test.go
+++ b/cmd/atlas/atlas_validate_devurl_test.go
@@ -37,7 +37,7 @@ func TestCompatCommand_MigrateValidateDevURLReplaysAtlasMigration(t *testing.T) 
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "")
-	assertSQLiteTableCount(c, devDBPath, "atlas_validate_dev_url", 1)
+	assertSQLiteTableCount(c, devDBPath, "atlas_validate_dev_url", 0)
 }
 
 func TestNewCompatCommand_MigrateValidateDevURLReplaysAtlasMigration(t *testing.T) {
@@ -62,7 +62,7 @@ func TestNewCompatCommand_MigrateValidateDevURLReplaysAtlasMigration(t *testing.
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "")
-	assertSQLiteTableCount(c, devDBPath, "compat_validate_dev_url", 1)
+	assertSQLiteTableCount(c, devDBPath, "compat_validate_dev_url", 0)
 }
 
 func writeAtlasMigration(c *qt.C, dir, name, sql string) {

--- a/cmd/atlas/editor_flags_test.go
+++ b/cmd/atlas/editor_flags_test.go
@@ -93,8 +93,8 @@ CREATE TABLE users (
 
 	err := cmd.Execute()
 
-	// --edit opens the generated migration in $EDITOR and atlas.sum is
-	// refreshed afterwards, so the edited content still validates.
+	// --edit opens the staged migration in $EDITOR before publication, so
+	// atlas.sum commits the edited content without an inconsistent window.
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
 	c.Assert(out.String(), qt.Contains, "Created migration file:")
 	files, globErr := filepath.Glob(filepath.Join(migrationsDir, "*_add_email.sql"))

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlassource"
-	"github.com/stokaro/ptah/internal/migrateops"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -155,6 +154,12 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	}
 	defer dbschema.CloseAndWarn(conn)
 
+	var preparePublication func([]string) error
+	if opts.edit {
+		preparePublication = func(stagedPaths []string) error {
+			return editor.Open("", stagedPaths...)
+		}
+	}
 	diffResult, err := atlasmigrate.GenerateDiff(cmd.Context(), conn, atlasmigrate.DiffOptions{
 		Dir:                  migrationsDir,
 		Desired:              desired,
@@ -166,6 +171,7 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 		Policy:               policy,
 		Qualifier:            qualifier,
 		DryRun:               opts.dryRun,
+		PreparePublication:   preparePublication,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -177,18 +183,6 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	if opts.dryRun {
 		fmt.Fprint(cmd.OutOrStdout(), diffResult.SQL)
 		return nil
-	}
-	if opts.edit {
-		for _, migrationPath := range diffResult.MigrationPaths {
-			if err := editor.Open("", migrationPath); err != nil {
-				return cmdutil.Fail(cmd, err)
-			}
-		}
-		// Editing changes the just-hashed migration content, so atlas.sum is
-		// refreshed to keep the directory valid.
-		if _, err := migrateops.Rehash(migrationsDir, migrator.MigrationDirFormatAtlas); err != nil {
-			return cmdutil.Fail(cmd, fmt.Errorf("refresh atlas.sum after editing: %w", err))
-		}
 	}
 	for _, migrationPath := range diffResult.MigrationPaths {
 		fmt.Fprintf(cmd.OutOrStdout(), "Created migration file: %s\n", migrationPath)

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -43,6 +43,11 @@ type listOptions struct {
 	showAll     bool
 }
 
+type databaseTarget struct {
+	connectionURL string
+	cleanupURL    string
+}
+
 func newRootCommand() *cobra.Command {
 	opts := rootOptions{}
 	cmd := &cobra.Command{
@@ -147,8 +152,14 @@ func runIntegrationTests(_ *cobra.Command, _ []string, opts *rootOptions) error 
 	if err != nil {
 		return err
 	}
-	for dbName, url := range selectedConnections {
-		runner.AddDatabase(dbName, url)
+	for dbName, target := range selectedConnections {
+		if err := runner.AddDatabaseWithCleanup(
+			dbName,
+			target.connectionURL,
+			target.cleanupURL,
+		); err != nil {
+			return fmt.Errorf("configure %s integration database: %w", dbName, err)
+		}
 		if opts.verbose {
 			fmt.Printf("Added database: %s\n", dbName)
 		}
@@ -244,32 +255,65 @@ func runIntegrationTests(_ *cobra.Command, _ []string, opts *rootOptions) error 
 	return nil
 }
 
-func configuredDatabaseConnections() map[string]string {
-	return map[string]string{
-		"postgres":    os.Getenv("POSTGRES_URL"),
-		"mysql":       os.Getenv("MYSQL_URL"),
-		"mariadb":     os.Getenv("MARIADB_URL"),
-		"clickhouse":  os.Getenv("CLICKHOUSE_URL"),
-		"cockroachdb": os.Getenv("COCKROACHDB_URL"),
-		"yugabytedb":  os.Getenv("YUGABYTEDB_URL"),
-		"sqlserver":   os.Getenv("SQLSERVER_URL"),
+func configuredDatabaseConnections() map[string]databaseTarget {
+	return map[string]databaseTarget{
+		"postgres": databaseTargetFromEnvironment("POSTGRES_URL", "POSTGRES_CLEANUP_URL"),
+		"mysql": databaseTargetFromEnvironment(
+			"MYSQL_URL",
+			"MYSQL_CLEANUP_URL",
+		),
+		"mariadb": databaseTargetFromEnvironment(
+			"MARIADB_URL",
+			"MARIADB_CLEANUP_URL",
+		),
+		"clickhouse": databaseTargetFromEnvironment(
+			"CLICKHOUSE_URL",
+			"CLICKHOUSE_CLEANUP_URL",
+		),
+		"cockroachdb": databaseTargetFromEnvironment(
+			"COCKROACHDB_URL",
+			"COCKROACHDB_CLEANUP_URL",
+		),
+		"yugabytedb": databaseTargetFromEnvironment(
+			"YUGABYTEDB_URL",
+			"YUGABYTEDB_CLEANUP_URL",
+		),
+		"sqlserver": databaseTargetFromEnvironment(
+			"SQLSERVER_URL",
+			"SQLSERVER_CLEANUP_URL",
+		),
 	}
 }
 
-func requestedDatabaseConnections(databases []string, dbConnections map[string]string) (map[string]string, error) {
-	selected := make(map[string]string, len(databases))
+func databaseTargetFromEnvironment(connectionEnv, cleanupEnv string) databaseTarget {
+	connectionURL := os.Getenv(connectionEnv)
+	cleanupURL := os.Getenv(cleanupEnv)
+	if cleanupURL == "" {
+		cleanupURL = connectionURL
+	}
+	return databaseTarget{
+		connectionURL: connectionURL,
+		cleanupURL:    cleanupURL,
+	}
+}
+
+func requestedDatabaseConnections(
+	databases []string,
+	dbConnections map[string]databaseTarget,
+) (map[string]databaseTarget, error) {
+	selected := make(map[string]databaseTarget, len(databases))
 	var missing []string
 	for _, dbName := range databases {
 		canonicalName := platform.NormalizeDialect(dbName)
 		if canonicalName == "" {
 			canonicalName = dbName
 		}
-		url, exists := dbConnections[canonicalName]
-		if !exists || url == "" {
+		target, exists := dbConnections[canonicalName]
+		if !exists || target.connectionURL == "" {
 			missing = append(missing, dbName)
 			continue
 		}
-		selected[canonicalName] = url
+		selected[canonicalName] = target
 	}
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("missing database URL for requested database(s): %s", strings.Join(missing, ", "))

--- a/cmd/integration-test/main_test.go
+++ b/cmd/integration-test/main_test.go
@@ -36,9 +36,11 @@ func TestGetStaticScenarios(t *testing.T) {
 		c.Assert(scenario.Name, qt.Not(qt.Equals), "", qt.Commentf("Static scenario name should not be empty"))
 		c.Assert(scenario.Description, qt.Not(qt.Equals), "", qt.Commentf("Static scenario description should not be empty"))
 
-		// Should have either TestFunc or EnhancedTestFunc
-		hasTestFunc := scenario.TestFunc != nil || scenario.EnhancedTestFunc != nil
-		c.Assert(hasTestFunc, qt.IsTrue, qt.Commentf("Static scenario %s should have a test function", scenario.Name))
+		c.Assert(
+			scenario.IsRunnable(),
+			qt.IsTrue,
+			qt.Commentf("Static scenario %s should have a test function", scenario.Name),
+		)
 	}
 }
 

--- a/cmd/integration-test/main_test.go
+++ b/cmd/integration-test/main_test.go
@@ -74,6 +74,7 @@ func TestConfiguredDatabaseConnectionsIncludesDistributedSQLAndSQLServer(t *test
 
 	t.Setenv("POSTGRES_URL", "postgres://postgres.example/db")
 	t.Setenv("MYSQL_URL", "mysql://mysql.example/db")
+	t.Setenv("MYSQL_CLEANUP_URL", "mysql://root@mysql.example/db")
 	t.Setenv("MARIADB_URL", "mariadb://mariadb.example/db")
 	t.Setenv("CLICKHOUSE_URL", "clickhouse://clickhouse.example/db")
 	t.Setenv("COCKROACHDB_URL", "cockroachdb://cockroach.example/defaultdb")
@@ -82,9 +83,22 @@ func TestConfiguredDatabaseConnectionsIncludesDistributedSQLAndSQLServer(t *test
 
 	connections := configuredDatabaseConnections()
 
-	c.Assert(connections["cockroachdb"], qt.Equals, "cockroachdb://cockroach.example/defaultdb")
-	c.Assert(connections["yugabytedb"], qt.Equals, "yugabytedb://yugabyte.example/yugabyte")
-	c.Assert(connections["sqlserver"], qt.Equals, "sqlserver://sqlserver.example/db")
+	c.Assert(connections["cockroachdb"], qt.Equals, databaseTarget{
+		connectionURL: "cockroachdb://cockroach.example/defaultdb",
+		cleanupURL:    "cockroachdb://cockroach.example/defaultdb",
+	})
+	c.Assert(connections["yugabytedb"], qt.Equals, databaseTarget{
+		connectionURL: "yugabytedb://yugabyte.example/yugabyte",
+		cleanupURL:    "yugabytedb://yugabyte.example/yugabyte",
+	})
+	c.Assert(connections["sqlserver"], qt.Equals, databaseTarget{
+		connectionURL: "sqlserver://sqlserver.example/db",
+		cleanupURL:    "sqlserver://sqlserver.example/db",
+	})
+	c.Assert(connections["mysql"], qt.Equals, databaseTarget{
+		connectionURL: "mysql://mysql.example/db",
+		cleanupURL:    "mysql://root@mysql.example/db",
+	})
 }
 
 func TestRequestedDatabaseConnectionsRejectsMissingRequestedURL(t *testing.T) {
@@ -92,7 +106,12 @@ func TestRequestedDatabaseConnectionsRejectsMissingRequestedURL(t *testing.T) {
 
 	_, err := requestedDatabaseConnections(
 		[]string{"postgres", "mysql"},
-		map[string]string{"postgres": "postgres://postgres.example/db"},
+		map[string]databaseTarget{
+			"postgres": {
+				connectionURL: "postgres://postgres.example/db",
+				cleanupURL:    "postgres://postgres.example/db",
+			},
+		},
 	)
 
 	c.Assert(err, qt.ErrorMatches, `missing database URL for requested database\(s\): mysql`)
@@ -103,16 +122,27 @@ func TestRequestedDatabaseConnectionsKeepsConfiguredURLs(t *testing.T) {
 
 	selected, err := requestedDatabaseConnections(
 		[]string{"postgres", "mysql"},
-		map[string]string{
-			"postgres": "postgres://postgres.example/db",
-			"mysql":    "mysql://mysql.example/db",
+		map[string]databaseTarget{
+			"postgres": {
+				connectionURL: "postgres://postgres.example/db",
+				cleanupURL:    "postgres://postgres.example/db",
+			},
+			"mysql": {
+				connectionURL: "mysql://mysql.example/db",
+				cleanupURL:    "mysql://root@mysql.example/db",
+			},
 		},
 	)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(selected, qt.DeepEquals, map[string]string{
-		"postgres": "postgres://postgres.example/db",
-		"mysql":    "mysql://mysql.example/db",
+	c.Assert(selected, qt.HasLen, 2)
+	c.Assert(selected["postgres"], qt.Equals, databaseTarget{
+		connectionURL: "postgres://postgres.example/db",
+		cleanupURL:    "postgres://postgres.example/db",
+	})
+	c.Assert(selected["mysql"], qt.Equals, databaseTarget{
+		connectionURL: "mysql://mysql.example/db",
+		cleanupURL:    "mysql://root@mysql.example/db",
 	})
 }
 
@@ -121,14 +151,19 @@ func TestRequestedDatabaseConnectionsNormalizesSQLServerAliases(t *testing.T) {
 
 	selected, err := requestedDatabaseConnections(
 		[]string{"mssql"},
-		map[string]string{
-			"sqlserver": "sqlserver://sqlserver.example/db",
+		map[string]databaseTarget{
+			"sqlserver": {
+				connectionURL: "sqlserver://sqlserver.example/db",
+				cleanupURL:    "sqlserver://sqlserver.example/db",
+			},
 		},
 	)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(selected, qt.DeepEquals, map[string]string{
-		"sqlserver": "sqlserver://sqlserver.example/db",
+	c.Assert(selected, qt.HasLen, 1)
+	c.Assert(selected["sqlserver"], qt.Equals, databaseTarget{
+		connectionURL: "sqlserver://sqlserver.example/db",
+		cleanupURL:    "sqlserver://sqlserver.example/db",
 	})
 }
 

--- a/cmd/lint/lint_devurl_test.go
+++ b/cmd/lint/lint_devurl_test.go
@@ -37,7 +37,7 @@ func TestRunLint_DevURLReplaysMigrationAndInfersDialect(t *testing.T) {
 	}
 	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
 	c.Assert(report.Dialect, qt.Equals, "sqlite")
-	assertLintDevURLSQLiteTableCount(c, devDBPath, "lint_dev_url", 1)
+	assertLintDevURLSQLiteTableCount(c, devDBPath, "lint_dev_url", 0)
 }
 
 func TestRunLint_UsesEvaluatedAtlasProjectConfigDevURL(t *testing.T) {
@@ -72,7 +72,7 @@ env "local" {
 	}
 	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
 	c.Assert(report.Dialect, qt.Equals, "sqlite")
-	assertLintDevURLSQLiteTableCount(c, filepath.Join(dir, "config-dev.db"), "lint_config_dev_url", 1)
+	assertLintDevURLSQLiteTableCount(c, filepath.Join(dir, "config-dev.db"), "lint_config_dev_url", 0)
 }
 
 func TestRunLint_DevURLFailureExitsTwo(t *testing.T) {

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -279,20 +279,27 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	var files *generator.MigrationFiles
 	if replay {
 		var plan *generator.MigrationPlan
-		err = migrationreplay.WithReplayedDirectory(
+		err = atlasmigrate.WithMigrationDirectoryLock(
 			cmd.Context(),
-			devConn,
 			migrationsDir,
-			dirFormat,
-			func(replayConn *dbschema.DatabaseConnection) error {
-				replayOpts := generateOpts
-				replayOpts.DBConn = replayConn
-				plan, err = generator.PlanMigration(connectCtx, replayOpts)
-				return err
+			0,
+			func() error {
+				return migrationreplay.WithReplayedDirectory(
+					cmd.Context(),
+					devConn,
+					migrationsDir,
+					dirFormat,
+					func(replayConn *dbschema.DatabaseConnection) error {
+						replayOpts := generateOpts
+						replayOpts.DBConn = replayConn
+						plan, err = generator.PlanMigration(connectCtx, replayOpts)
+						return err
+					},
+				)
 			},
 		)
 		if err == nil && plan != nil {
-			files, err = plan.WriteFiles()
+			files, err = plan.WriteFilesContext(cmd.Context())
 		}
 	} else {
 		files, err = generator.GenerateMigration(connectCtx, generateOpts)

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -283,16 +283,19 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 			cmd.Context(),
 			migrationsDir,
 			0,
-			func() error {
+			func(lockedCtx context.Context) error {
+				if err := atlasmigrate.RecoverPendingPublicationLocked(migrationsDir); err != nil {
+					return fmt.Errorf("recover migration publication before replay: %w", err)
+				}
 				return migrationreplay.WithReplayedDirectory(
-					cmd.Context(),
+					lockedCtx,
 					devConn,
 					migrationsDir,
 					dirFormat,
 					func(replayConn *dbschema.DatabaseConnection) error {
 						replayOpts := generateOpts
 						replayOpts.DBConn = replayConn
-						plan, err = generator.PlanMigration(connectCtx, replayOpts)
+						plan, err = generator.PlanMigration(lockedCtx, replayOpts)
 						return err
 					},
 				)

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -247,8 +247,9 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	defer cancelConnect()
 
 	var devConn *dbschema.DatabaseConnection
+	var dirFormat migrator.MigrationDirFormat
 	if replay {
-		dirFormat, err := migrator.ParseMigrationDirFormat(dirFormatValue)
+		dirFormat, err = migrator.ParseMigrationDirFormat(dirFormatValue)
 		if err != nil {
 			return err
 		}
@@ -257,15 +258,11 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("connect to --%s: %w", generateDevURLFlag, err)
 		}
 		defer dbschema.CloseAndWarn(devConn)
-		if err := migrationreplay.ReplayOnConnection(cmd.Context(), devConn, migrationsDir, dirFormat); err != nil {
-			return err
-		}
 	}
 
-	files, err := generator.GenerateMigration(connectCtx, generator.GenerateMigrationOptions{
+	generateOpts := generator.GenerateMigrationOptions{
 		Generated:         generated,
 		DatabaseURL:       targetURL,
-		DBConn:            devConn,
 		MigrationName:     name,
 		OutputDir:         migrationsDir,
 		Schemas:           dbcli.ParseSchemas(schemasValue),
@@ -278,7 +275,28 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 			SkipChangeKinds: projectCfg.Diff.SkipChangeKinds(),
 			ConcurrentIndex: projectCfg.Diff.ConcurrentIndexCreate(),
 		},
-	})
+	}
+	var files *generator.MigrationFiles
+	if replay {
+		var plan *generator.MigrationPlan
+		err = migrationreplay.WithReplayedDirectory(
+			cmd.Context(),
+			devConn,
+			migrationsDir,
+			dirFormat,
+			func(replayConn *dbschema.DatabaseConnection) error {
+				replayOpts := generateOpts
+				replayOpts.DBConn = replayConn
+				plan, err = generator.PlanMigration(connectCtx, replayOpts)
+				return err
+			},
+		)
+		if err == nil && plan != nil {
+			files, err = plan.WriteFiles()
+		}
+	} else {
+		files, err = generator.GenerateMigration(connectCtx, generateOpts)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/migrate/generate_replay_test.go
+++ b/cmd/migrate/generate_replay_test.go
@@ -9,6 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/dbschema"
 )
 
 func runGenerate(args ...string) (string, error) {
@@ -65,6 +66,22 @@ func TestMigrateGenerateReplayDerivesCurrentStateFromDirectory(t *testing.T) {
 	// The replayed state already contains users, so only orders is created.
 	c.Assert(string(upSQL), qt.Contains, `CREATE TABLE "orders"`)
 	c.Assert(string(upSQL), qt.Not(qt.Contains), `CREATE TABLE "users"`)
+	assertGenerateReplayDevEmpty(c, devPath)
+}
+
+func assertGenerateReplayDevEmpty(c *qt.C, path string) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+path)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+	`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }
 
 func TestMigrateGenerateReplayRequiresDevURL(t *testing.T) {

--- a/cmd/migratevalidate/migratevalidate_devurl_test.go
+++ b/cmd/migratevalidate/migratevalidate_devurl_test.go
@@ -32,7 +32,7 @@ func TestMigrateValidate_DevURLReplaysAtlasMigration(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Contains, "OK: migrations directory matches atlas.sum")
 	c.Assert(stdout, qt.Contains, "OK: migration SQL validated on dev database")
-	assertSQLiteTableCount(c, devDBPath, "native_validate_dev_url", 1)
+	assertSQLiteTableCount(c, devDBPath, "native_validate_dev_url", 0)
 }
 
 func TestMigrateValidate_DevURLFailureExitsTwo(t *testing.T) {

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -3,6 +3,8 @@ package dbschema
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -21,6 +23,7 @@ import (
 	"github.com/stokaro/ptah/internal/dbschema/mysql"
 	"github.com/stokaro/ptah/internal/dbschema/postgres"
 	"github.com/stokaro/ptah/internal/dbschema/sqlite"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 // ConnectToDatabase creates a database connection from a URL.
@@ -94,35 +97,71 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		)
 	}
 
-	// Create appropriate schema reader and writer
-	var reader types.SchemaReader
-	var writer types.SchemaWriter
+	var newReader schemaReaderFactory
+	var newWriter schemaWriterFactory
 	switch dialectProtocol {
 	case "pgx":
-		reader = postgres.NewPostgreSQLReaderWithCapabilities(db, info.Schema, info.Capabilities)
-		writer = postgres.NewPostgreSQLWriter(db, info.Schema)
+		newReader = func(runner sqlrunner.Runner) types.SchemaReader {
+			return postgres.NewPostgreSQLReaderWithCapabilities(runner, info.Schema, info.Capabilities)
+		}
+		newWriter = func(runner sqlrunner.Runner, _ *sql.Conn) types.SchemaWriter {
+			return postgres.NewPostgreSQLWriterForRunner(runner, info.Schema)
+		}
 	case "mysql":
-		reader = mysql.NewMySQLReader(db, info.Schema)
-		writer = mysql.NewMySQLWriter(db, info.Schema, info.Dialect)
+		newReader = func(runner sqlrunner.Runner) types.SchemaReader {
+			return mysql.NewMySQLReader(runner, info.Schema)
+		}
+		newWriter = func(runner sqlrunner.Runner, session *sql.Conn) types.SchemaWriter {
+			if session != nil {
+				return mysql.NewMySQLWriterForPinnedRunner(
+					runner,
+					db,
+					session,
+					info.Schema,
+					info.Dialect,
+					info.Version,
+				)
+			}
+			return mysql.NewMySQLWriterForRunner(runner, db, info.Schema, info.Dialect, info.Version)
+		}
 	case "clickhouse":
-		reader = clickhouse.NewClickHouseReader(db, info.Schema)
-		writer = clickhouse.NewClickHouseWriter(db, info.Schema)
+		newReader = func(runner sqlrunner.Runner) types.SchemaReader {
+			return clickhouse.NewClickHouseReader(runner, info.Schema)
+		}
+		newWriter = func(runner sqlrunner.Runner, _ *sql.Conn) types.SchemaWriter {
+			return clickhouse.NewClickHouseWriterForRunner(runner, info.Schema)
+		}
 	case "sqlite":
-		reader = sqlite.NewSQLiteReader(db, info.Schema)
-		writer = sqlite.NewSQLiteWriter(db, info.Schema)
+		newReader = func(runner sqlrunner.Runner) types.SchemaReader {
+			return sqlite.NewSQLiteReader(runner, info.Schema)
+		}
+		newWriter = func(runner sqlrunner.Runner, session *sql.Conn) types.SchemaWriter {
+			if session != nil {
+				return sqlite.NewSQLiteWriterForPinnedRunner(runner, session, info.Schema)
+			}
+			return sqlite.NewSQLiteWriterForRunner(runner, info.Schema)
+		}
 	case "sqlserver":
-		reader = mssql.NewSQLServerReader(db, info.Schema)
-		writer = mssql.NewSQLServerWriter(db, info.Schema)
+		newReader = func(runner sqlrunner.Runner) types.SchemaReader {
+			return mssql.NewSQLServerReader(runner, info.Schema)
+		}
+		newWriter = func(runner sqlrunner.Runner, _ *sql.Conn) types.SchemaWriter {
+			return mssql.NewSQLServerWriterForRunner(runner, info.Schema)
+		}
 	default:
 		_ = db.Close()
 		return nil, fmt.Errorf("no schema reader available for dialect: %s", dialect)
 	}
 
+	runner := sqlrunner.Runner(db)
 	return &DatabaseConnection{
-		db:     db,
-		info:   info,
-		reader: reader,
-		writer: writer,
+		db:        db,
+		runner:    runner,
+		info:      info,
+		reader:    newReader(runner),
+		writer:    newWriter(runner, nil),
+		newReader: newReader,
+		newWriter: newWriter,
 	}, nil
 }
 
@@ -145,15 +184,26 @@ func databaseDriverConfig(dialect, dbURL string) (driverName, dataSourceName str
 
 // DatabaseConnection represents a database connection with metadata
 type DatabaseConnection struct {
-	db       *sql.DB
-	info     types.DBInfo
-	reader   types.SchemaReader
-	writer   types.SchemaWriter
-	executor types.SchemaExecutor
+	db        *sql.DB
+	runner    sqlrunner.Runner
+	info      types.DBInfo
+	reader    types.SchemaReader
+	writer    types.SchemaWriter
+	executor  types.SchemaExecutor
+	newReader schemaReaderFactory
+	newWriter schemaWriterFactory
+	pinned    bool
 }
+
+type schemaReaderFactory func(sqlrunner.Runner) types.SchemaReader
+type schemaWriterFactory func(sqlrunner.Runner, *sql.Conn) types.SchemaWriter
 
 type schemaScopedReader interface {
 	SetSchemas([]string)
+}
+
+type contextExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
 }
 
 // ReadSchemaWithSchemas reads a database schema, applying a schema allow-list
@@ -191,9 +241,9 @@ func (dc *DatabaseConnection) Writer() types.SchemaExecutor {
 	return dc.writer
 }
 
-// SchemaWriter returns the root schema writer for administrative operations
-// such as starting transactions, toggling dry-run mode, or dropping all tables
-// with a caller-supplied context.
+// SchemaWriter returns the schema writer bound to this connection's SQL
+// session. Transaction-scoped executors do not replace the administrative
+// writer.
 func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter {
 	return dc.writer
 }
@@ -209,48 +259,118 @@ func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *Datab
 	return &cloned
 }
 
+// WithSession pins one physical database session for the callback and rebuilds
+// the dialect reader and writer on that same session. The scoped connection
+// does not own the pool and must not escape the callback. The physical
+// connection is discarded afterward so callback-created session state cannot
+// leak to another pool user.
+func (dc *DatabaseConnection) WithSession(
+	ctx context.Context,
+	use func(*DatabaseConnection) error,
+) (resultErr error) {
+	if dc == nil || dc.db == nil {
+		return fmt.Errorf("database session requires an open database connection")
+	}
+	if use == nil {
+		return fmt.Errorf("database session callback is nil")
+	}
+	if dc.pinned {
+		return fmt.Errorf("database connection is already pinned to a session")
+	}
+	if dc.newReader == nil || dc.newWriter == nil {
+		return fmt.Errorf("database connection does not support session rebinding")
+	}
+
+	session, err := dc.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("pin database session: %w", err)
+	}
+	defer func() {
+		discardErr := session.Raw(func(any) error {
+			return driver.ErrBadConn
+		})
+		if discardErr != nil && !errors.Is(discardErr, driver.ErrBadConn) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("discard pinned database session: %w", discardErr))
+		}
+		if closeErr := session.Close(); closeErr != nil && !errors.Is(closeErr, sql.ErrConnDone) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("close pinned database session: %w", closeErr))
+		}
+	}()
+
+	runner := sqlrunner.NewConn(ctx, session)
+	scoped := *dc
+	scoped.runner = runner
+	scoped.reader = dc.newReader(runner)
+	scoped.writer = dc.newWriter(runner, session)
+	scoped.executor = nil
+	scoped.pinned = true
+	if dc.writer != nil && dc.writer.IsDryRun() {
+		scoped.writer.SetDryRun(true)
+	}
+	return use(&scoped)
+}
+
 // Query executes a query and returns the result rows
 func (dc *DatabaseConnection) Query(query string, args ...any) (*sql.Rows, error) {
-	return dc.db.Query(query, args...)
+	return dc.sqlRunner().Query(query, args...)
 }
 
 // QueryContext executes a query using a context and returns the result rows.
 func (dc *DatabaseConnection) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return dc.db.QueryContext(ctx, query, args...)
+	return dc.sqlRunner().QueryContext(ctx, query, args...)
 }
 
 // QueryRow executes a query that returns a single row
 func (dc *DatabaseConnection) QueryRow(query string, args ...any) *sql.Row {
-	return dc.db.QueryRow(query, args...)
+	return dc.sqlRunner().QueryRow(query, args...)
 }
 
 // QueryRowContext executes a query that returns a single row using a context
 func (dc *DatabaseConnection) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
-	return dc.db.QueryRowContext(ctx, query, args...)
+	return dc.sqlRunner().QueryRowContext(ctx, query, args...)
 }
 
 // Exec executes a query without returning any rows
 func (dc *DatabaseConnection) Exec(query string, args ...any) (sql.Result, error) {
-	return dc.db.Exec(query, args...)
+	if executor, ok := dc.executor.(contextExecutor); ok {
+		return executor.ExecContext(context.Background(), query, args...)
+	}
+	return dc.sqlRunner().Exec(query, args...)
 }
 
 // ExecContext executes a query without returning any rows using a context
 func (dc *DatabaseConnection) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return dc.db.ExecContext(ctx, query, args...)
+	if executor, ok := dc.executor.(contextExecutor); ok {
+		return executor.ExecContext(ctx, query, args...)
+	}
+	return dc.sqlRunner().ExecContext(ctx, query, args...)
 }
 
 // Conn returns a dedicated database session. Callers that use session-scoped
 // database features must close the returned connection when finished.
 func (dc *DatabaseConnection) Conn(ctx context.Context) (*sql.Conn, error) {
+	if dc.pinned {
+		return nil, fmt.Errorf("database connection is already pinned to a session")
+	}
 	return dc.db.Conn(ctx)
 }
 
 // Close closes the database connection
 func (dc *DatabaseConnection) Close() error {
+	if dc.pinned {
+		return nil
+	}
 	if dc.db != nil {
 		return dc.db.Close()
 	}
 	return nil
+}
+
+func (dc *DatabaseConnection) sqlRunner() sqlrunner.Runner {
+	if dc.runner != nil {
+		return dc.runner
+	}
+	return dc.db
 }
 
 // CloseAndWarn closes the connection and logs a warning at slog.LevelWarn if

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -103,7 +103,7 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		writer = postgres.NewPostgreSQLWriter(db, info.Schema)
 	case "mysql":
 		reader = mysql.NewMySQLReader(db, info.Schema)
-		writer = mysql.NewMySQLWriter(db, info.Schema)
+		writer = mysql.NewMySQLWriter(db, info.Schema, info.Dialect)
 	case "clickhouse":
 		reader = clickhouse.NewClickHouseReader(db, info.Schema)
 		writer = clickhouse.NewClickHouseWriter(db, info.Schema)
@@ -418,6 +418,8 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 			return info, fmt.Errorf("failed to get MySQL/MariaDB version: %w", err)
 		}
 		info.Version = version
+		info.Dialect = detectMySQLWireDialect(dialect, version)
+		info.IdentifierSemantics = identifier.ForDialect(info.Dialect)
 
 		// Get database name from URL path
 		if parsedURL.Path != "" && len(parsedURL.Path) > 1 {
@@ -508,6 +510,13 @@ func detectPostgresWireDialect(declaredDialect, version string) string {
 	default:
 		return platform.NormalizeDialect(declaredDialect)
 	}
+}
+
+func detectMySQLWireDialect(declaredDialect, version string) string {
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return platform.MariaDB
+	}
+	return platform.NormalizeDialect(declaredDialect)
 }
 
 // convertMySQLURL converts a MySQL/MariaDB URL from standard format to Go driver format

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -279,6 +279,47 @@ func TestDetectPostgresWireDialect(t *testing.T) {
 	}
 }
 
+func TestDetectMySQLWireDialect(t *testing.T) {
+	tests := []struct {
+		name     string
+		declared string
+		version  string
+		expected string
+	}{
+		{
+			name:     "mysql server",
+			declared: "mysql",
+			version:  "9.7.0",
+			expected: "mysql",
+		},
+		{
+			name:     "mariadb detected from mysql URL",
+			declared: "mysql",
+			version:  "10.11.15-MariaDB-ubu2204",
+			expected: "mariadb",
+		},
+		{
+			name:     "mariadb replication prefix",
+			declared: "mysql",
+			version:  "5.5.5-10.11.15-MariaDB-ubu2204",
+			expected: "mariadb",
+		},
+		{
+			name:     "explicit mariadb survives generic banner",
+			declared: "mariadb",
+			version:  "MySQL-compatible server",
+			expected: "mariadb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(detectMySQLWireDialect(tt.declared, tt.version), qt.Equals, tt.expected)
+		})
+	}
+}
+
 func TestDatabaseConnectionInfoClonesCapabilities(t *testing.T) {
 	c := qt.New(t)
 

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -5,14 +5,165 @@ package dbschema
 // the public connection API alone.
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
+
+type connectionTestWriter struct {
+	executed string
+}
+
+func (w *connectionTestWriter) ExecuteSQL(_ context.Context, statement string, _ ...any) error {
+	w.executed = statement
+	return nil
+}
+
+func (w *connectionTestWriter) ExecContext(
+	_ context.Context,
+	statement string,
+	_ ...any,
+) (sql.Result, error) {
+	w.executed = statement
+	return driver.RowsAffected(1), nil
+}
+
+func (w *connectionTestWriter) DropAllTables(context.Context) error {
+	return nil
+}
+
+func (w *connectionTestWriter) BeginTransaction(context.Context) (types.SchemaTransaction, error) {
+	return nil, nil
+}
+
+func (w *connectionTestWriter) SetDryRun(bool) {}
+
+func (w *connectionTestWriter) IsDryRun() bool {
+	return false
+}
+
+type connectionTestExecutor struct{}
+
+func (*connectionTestExecutor) ExecuteSQL(context.Context, string, ...any) error {
+	return nil
+}
+
+func (*connectionTestExecutor) IsDryRun() bool {
+	return false
+}
+
+func TestDatabaseConnectionWithExecutor_PreservesRootWriterForNarrowExecutor(t *testing.T) {
+	c := qt.New(t)
+	root := new(connectionTestWriter)
+	executor := new(connectionTestExecutor)
+	conn := &DatabaseConnection{writer: root}
+
+	scoped := conn.WithExecutor(executor)
+
+	c.Assert(scoped.SchemaWriter(), qt.Equals, types.SchemaWriter(root))
+	c.Assert(scoped.Writer(), qt.Equals, types.SchemaExecutor(executor))
+}
+
+type connectionSessionReader struct {
+	runner sqlrunner.Runner
+}
+
+func (r *connectionSessionReader) ReadSchema() (*types.DBSchema, error) {
+	var value int
+	err := r.runner.QueryRow("SELECT 1").Scan(&value)
+	return &types.DBSchema{}, err
+}
+
+type connectionSessionWriter struct {
+	runner sqlrunner.Runner
+}
+
+func (w *connectionSessionWriter) ExecuteSQL(
+	ctx context.Context,
+	statement string,
+	args ...any,
+) error {
+	_, err := w.runner.ExecContext(ctx, statement, args...)
+	return err
+}
+
+func (w *connectionSessionWriter) DropAllTables(context.Context) error {
+	return nil
+}
+
+func (w *connectionSessionWriter) BeginTransaction(context.Context) (types.SchemaTransaction, error) {
+	return nil, nil
+}
+
+func (w *connectionSessionWriter) SetDryRun(bool) {}
+
+func (w *connectionSessionWriter) IsDryRun() bool {
+	return false
+}
+
+func TestDatabaseConnectionWithSession_RebindsAllDatabaseOperations(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.OpenWithExec(
+		t,
+		func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+			return dbtest.QueryResult{
+				Columns: []string{"value"},
+				Rows:    [][]driver.Value{{int64(1)}},
+			}, nil
+		},
+		func(string, []driver.NamedValue) (driver.Result, error) {
+			return driver.RowsAffected(1), nil
+		},
+	)
+	db.SQL.SetMaxOpenConns(1)
+	newReader := func(runner sqlrunner.Runner) types.SchemaReader {
+		return &connectionSessionReader{runner: runner}
+	}
+	newWriter := func(runner sqlrunner.Runner, _ *sql.Conn) types.SchemaWriter {
+		return &connectionSessionWriter{runner: runner}
+	}
+	rootRunner := sqlrunner.Runner(db.SQL)
+	conn := &DatabaseConnection{
+		db:        db.SQL,
+		runner:    rootRunner,
+		reader:    newReader(rootRunner),
+		writer:    newWriter(rootRunner, nil),
+		newReader: newReader,
+		newWriter: newWriter,
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+
+	err := conn.WithSession(ctx, func(scoped *DatabaseConnection) error {
+		_, execErr := scoped.ExecContext(ctx, "DIRECT")
+		c.Assert(execErr, qt.IsNil)
+		_, readErr := scoped.Reader().ReadSchema()
+		c.Assert(readErr, qt.IsNil)
+		writerErr := scoped.Writer().ExecuteSQL(ctx, "WRITER")
+		c.Assert(writerErr, qt.IsNil)
+		nested, nestedErr := scoped.Conn(ctx)
+		c.Assert(nestedErr, qt.ErrorMatches, `database connection is already pinned to a session`)
+		c.Assert(nested, qt.IsNil)
+		c.Assert(scoped.Close(), qt.IsNil)
+		return nil
+	})
+
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, "ROOT")
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 1)
+	c.Assert(db.ExecCount(), qt.Equals, 3)
+}
 
 func TestConvertClickHouseURL(t *testing.T) {
 	tests := []struct {

--- a/dbschema/connection_test.go
+++ b/dbschema/connection_test.go
@@ -80,6 +80,34 @@ func TestFormatDatabaseURL(t *testing.T) {
 	}
 }
 
+func TestDatabaseConnectionWithSession_DiscardsSessionState(t *testing.T) {
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "session.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	err = conn.WithSession(t.Context(), func(scoped *dbschema.DatabaseConnection) error {
+		_, execErr := scoped.ExecContext(
+			t.Context(),
+			"CREATE TEMP TABLE replay_session_state (id INTEGER PRIMARY KEY)",
+		)
+		return execErr
+	})
+	c.Assert(err, qt.IsNil)
+
+	var count int
+	err = conn.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM temp.sqlite_schema WHERE name = ?",
+		"replay_session_state",
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}
+
 func TestConnectToDatabase_InvalidURL(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -331,10 +331,12 @@ type SchemaExecutor interface {
 // SchemaWriter writes schemas to databases.
 type SchemaWriter interface {
 	SchemaExecutor
-	// DropAllTables removes all user schema objects. The context governs object
-	// discovery and destructive DDL. Implementations may use a short, bounded
-	// cleanup context after cancellation to restore connection-local settings
-	// before returning.
+	// DropAllTables removes supported user objects from the writer's configured
+	// schema or database. Database-global objects, such as PostgreSQL
+	// extensions, can widen that effect. The context governs object discovery
+	// and destructive DDL. Implementations may use a short, bounded cleanup
+	// context after cancellation to restore connection-local settings before
+	// returning.
 	DropAllTables(ctx context.Context) error
 	BeginTransaction(ctx context.Context) (SchemaTransaction, error)
 	SetDryRun(dryRun bool)

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -332,11 +332,11 @@ type SchemaExecutor interface {
 type SchemaWriter interface {
 	SchemaExecutor
 	// DropAllTables removes supported user objects from the writer's configured
-	// schema or database. Database-global objects, such as PostgreSQL
-	// extensions, can widen that effect. The context governs object discovery
-	// and destructive DDL. Implementations may use a short, bounded cleanup
-	// context after cancellation to restore connection-local settings before
-	// returning.
+	// schema or database. Implementations must refuse cleanup when dependencies
+	// or database-global ownership prevent them from confining the destructive
+	// effect to that scope. The context governs object discovery and DDL.
+	// Implementations may use a short, bounded cleanup context after
+	// cancellation to restore connection-local settings before returning.
 	DropAllTables(ctx context.Context) error
 	BeginTransaction(ctx context.Context) (SchemaTransaction, error)
 	SetDryRun(dryRun bool)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,7 +137,9 @@ services:
     environment:
       POSTGRES_URL: "postgres://ptah_user:ptah_password@postgres:5432/ptah_test?sslmode=disable"
       MYSQL_URL: "mysql://ptah_user:ptah_password@tcp(mysql:3306)/ptah_test"
+      MYSQL_CLEANUP_URL: "mysql://root:root_password@tcp(mysql:3306)/ptah_test"
       MARIADB_URL: "mariadb://ptah_user:ptah_password@tcp(mariadb:3306)/ptah_test"
+      MARIADB_CLEANUP_URL: "mariadb://root:root_password@tcp(mariadb:3306)/ptah_test"
       CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@clickhouse:9000/ptah_test"
       COCKROACHDB_URL: "cockroachdb://root@cockroachdb:26257/defaultdb?sslmode=disable"
       YUGABYTEDB_URL: "yugabytedb://yugabyte@yugabytedb:5433/yugabyte?sslmode=disable"

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -68,6 +68,17 @@ interceptor, splitter, directive, or transaction path. Observers receive
 structured source and statement metadata after execution but no connection
 handle, so they cannot alter the migrator execution path.
 
+`dbschema.DatabaseConnection.WithSession` pins one physical database session
+for a callback and rebinds the dialect reader, writer, and SQL runner to it.
+Use it when session-local state must remain consistent across cleanup, replay,
+introspection, and verification. The scoped connection must not escape the
+callback.
+
+`migration/generator.PlanMigration` performs loading, diff planning, safety
+checks, and optional shadow verification without publishing files. Its
+`MigrationPlan.WriteFiles` method publishes the validated artifacts once.
+`GenerateMigration` remains the convenience composition of those two steps.
+
 Atlas revision metadata is represented explicitly by `AtlasRevisionType` on
 `MigrationRevision`. `SetAtlasRevision` implements Atlas's metadata-only
 history transition: it preserves existing clean rows through the target, adds

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -68,6 +68,13 @@ interceptor, splitter, directive, or transaction path. Observers receive
 structured source and statement metadata after execution but no connection
 handle, so they cannot alter the migrator execution path.
 
+`migration/migrator.WithStatementValidator` installs a pre-execution safety
+gate on a filesystem provider. Ptah splits and validates every statement in one
+migration before executing its first statement, so a rejected later statement
+cannot leave an earlier statement applied. Validators inspect SQL but do not
+replace the migrator's execution path; use `WithStatementInterceptor` only when
+an external executor must take over accepted statements.
+
 `dbschema.DatabaseConnection.WithSession` pins one physical database session
 for a callback and rebinds the dialect reader, writer, and SQL runner to it.
 Use it when session-local state must remain consistent across cleanup, replay,
@@ -76,8 +83,12 @@ callback.
 
 `migration/generator.PlanMigration` performs loading, diff planning, safety
 checks, and optional shadow verification without publishing files. Its
-`MigrationPlan.WriteFiles` method publishes the validated artifacts once.
-`GenerateMigration` remains the convenience composition of those two steps.
+`MigrationPlan.WriteFiles` method publishes the validated artifacts once. The
+plan records the migration-directory snapshot used during planning and refuses
+publication if that history changed. `WriteFilesContext` additionally lets an
+embedder cancel waiting for the cross-process publication lock.
+`GenerateMigration` remains the convenience composition of planning and
+publication.
 
 Atlas revision metadata is represented explicitly by `AtlasRevisionType` on
 `MigrationRevision`. `SetAtlasRevision` implements Atlas's metadata-only

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -85,10 +85,12 @@ callback.
 checks, and optional shadow verification without publishing files. Its
 `MigrationPlan.WriteFiles` method publishes the validated artifacts once. The
 plan records the migration-directory snapshot used during planning and refuses
-publication if that history changed. `WriteFilesContext` additionally lets an
-embedder cancel waiting for the cross-process publication lock.
+publication with `generator.ErrMigrationDirectoryChanged` if that history
+changed. `WriteFilesContext` additionally lets an embedder cancel waiting for
+the cross-process publication lock and rejects concurrent use of one plan with
+`generator.ErrMigrationPlanInUse`.
 `GenerateMigration` remains the convenience composition of planning and
-publication.
+publication and propagates its context through both phases.
 
 Atlas revision metadata is represented explicitly by `AtlasRevisionType` on
 `MigrationRevision`. `SetAtlasRevision` implements Atlas's metadata-only

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5798,6 +5798,7 @@ func (c SkippedChange) Comment() string
 
 ## github.com/stokaro/ptah/migration/generator
 
+var ErrMigrationDirectoryChanged = errors.New("migration directory changed after migration planning") ...
 func GenerateCheckpoint(schema *goschema.Database, dialect string) (upSQL, downSQL string, err error)
 func GenerateCheckpointFromShadow(ctx context.Context, opts CheckpointFromShadowOptions) (upSQL, downSQL string, err error)
 func GenerateCheckpointWithDatabase(ctx context.Context, conn *dbschema.DatabaseConnection, ...) (upSQL, downSQL string, err error)

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5999,6 +5999,7 @@ type MigrationPlan struct {
 
 func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationPlan, error)
 func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error)
+func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles, error)
 
 ### github.com/stokaro/ptah/migration/generator.RollbackFromShadowOptions
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -4957,6 +4957,7 @@ func (dc *DatabaseConnection) Reader() types.SchemaReader
 func (dc *DatabaseConnection) ResolveIdentifierSemantics(ctx context.Context, names []string) (identifier.Semantics, error)
 func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter
 func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *DatabaseConnection
+func (dc *DatabaseConnection) WithSession(ctx context.Context, use func(*DatabaseConnection) error) (resultErr error)
 func (dc *DatabaseConnection) Writer() types.SchemaExecutor
 
 ## github.com/stokaro/ptah/dbschema/types
@@ -5474,10 +5475,12 @@ package types // import "github.com/stokaro/ptah/dbschema/types"
 
 type SchemaWriter interface {
     SchemaExecutor
-    // DropAllTables removes all user schema objects. The context governs object
-    // discovery and destructive DDL. Implementations may use a short, bounded
-    // cleanup context after cancellation to restore connection-local settings
-    // before returning.
+    // DropAllTables removes supported user objects from the writer's configured
+    // schema or database. Implementations must refuse cleanup when dependencies
+    // or database-global ownership prevent them from confining the destructive
+    // effect to that scope. The context governs object discovery and DDL.
+    // Implementations may use a short, bounded cleanup context after
+    // cancellation to restore connection-local settings before returning.
     DropAllTables(ctx context.Context) error
     BeginTransaction(ctx context.Context) (SchemaTransaction, error)
     SetDryRun(dryRun bool)
@@ -5812,6 +5815,8 @@ type MigrationFilePair struct{ ... }
 type MigrationFiles struct{ ... }
     func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
     func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error)
+type MigrationPlan struct{ ... }
+    func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationPlan, error)
 type RollbackFromShadowOptions struct{ ... }
 type ShadowMismatch struct{ ... }
 type ShadowVerificationError struct{ ... }
@@ -5981,6 +5986,19 @@ type MigrationFiles struct {
 
 func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
 func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error)
+
+### github.com/stokaro/ptah/migration/generator.MigrationPlan
+
+package generator // import "github.com/stokaro/ptah/migration/generator"
+
+type MigrationPlan struct {
+    // Has unexported fields.
+}
+    MigrationPlan is a fully validated migration that has not been written to
+    disk yet. WriteFiles publishes the planned migration once.
+
+func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationPlan, error)
+func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error)
 
 ### github.com/stokaro/ptah/migration/generator.RollbackFromShadowOptions
 
@@ -6571,6 +6589,7 @@ type FSProviderOption func(*FSMigrationProvider)
     func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption
     func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
     func WithStatementObserver(observer StatementObserver) FSProviderOption
+    func WithStatementValidator(validator StatementValidator) FSProviderOption
 type MigrateUpOptions struct{ ... }
 type Migration struct{ ... }
     func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration
@@ -6623,6 +6642,7 @@ type StatementInterceptor interface{ ... }
 type StatementObservationError struct{ ... }
 type StatementObserver interface{ ... }
 type StatementObserverFunc func(context.Context, StatementEvent) error
+type StatementValidator interface{ ... }
 
 ### github.com/stokaro/ptah/migration/migrator.AtlasDownNotImplementedError
 
@@ -6806,6 +6826,7 @@ func WithAtlasTemplateData(data any) FSProviderOption
 func WithMigrationDirFormat(format MigrationDirFormat) FSProviderOption
 func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
 func WithStatementObserver(observer StatementObserver) FSProviderOption
+func WithStatementValidator(validator StatementValidator) FSProviderOption
 
 ### github.com/stokaro/ptah/migration/migrator.MigrateUpOptions
 
@@ -7317,6 +7338,18 @@ type StatementObserverFunc func(context.Context, StatementEvent) error
     StatementObserverFunc adapts a function to StatementObserver.
 
 func (f StatementObserverFunc) ObserveStatement(ctx context.Context, event StatementEvent) error
+
+### github.com/stokaro/ptah/migration/migrator.StatementValidator
+
+package migrator // import "github.com/stokaro/ptah/migration/migrator"
+
+type StatementValidator interface {
+    ValidateStatement(stmt string) error
+}
+    StatementValidator rejects unsafe or unsupported migration statements
+    without taking over their execution. Every statement in a migration file is
+    validated before the first statement runs.
+
 
 ## github.com/stokaro/ptah/migration/planner
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -203,20 +203,31 @@ reference into the evaluated `atlas.hcl` environment. With `--env`, Ptah can
 read `env.schema.src`, `env.dev`, `migration.dir`, `format.migrate.diff`, and
 supported `diff` policy from `atlas.hcl`.
 
-Ptah snapshots the desired schema first, drops all tables in the dev database,
-and replays the migration directory into it. It then compares the replayed
-state to the snapshot and writes Atlas-style `.sql` migration files plus
-`atlas.sum` when changes exist. Use a disposable dev database. Ptah only reads
-a database used as `--to`; it never cleans or mutates that database. Ptah
-rejects a desired database that identifies the same host, port, and database
-as `--dev-url`, even when credentials, connection options, scheme aliases, or
-an explicit default port differ.
+Ptah snapshots the desired schema first, cleans the dev database, and replays
+the migration directory into it. It compares the replayed state to the
+snapshot, cleans the dev database again, and only then writes Atlas-style
+`.sql` migration files plus `atlas.sum` when changes exist. The final cleanup
+also runs after replay, introspection, comparison, or context-cancellation
+failures. Use a disposable dev database. Ptah only reads a database used as
+`--to`; it never cleans or mutates that database. Ptah rejects a desired
+database that identifies the same host, port, and database as `--dev-url`,
+even when credentials, connection options, scheme aliases, or an explicit
+default port differ.
 
 If `atlas.sum` already exists, Ptah validates it before replaying migrations
-and fails on checksum drift instead of silently rehashing edited files.
-`atlas.sum` is updated only after every migration file of the run was written;
-a failed write rolls the whole generation back so no partial files or
-checksums remain.
+and fails on checksum drift instead of silently rehashing edited files. Ptah
+holds the migration-directory lock while it captures and verifies one immutable
+directory snapshot, replays that exact snapshot, and publishes the result.
+Generated migration files are staged before publication, and `atlas.sum` is
+atomically replaced last as the batch commit marker. An OS-backed lock prevents
+cooperating processes from planning against the same directory concurrently
+and is released by the operating system if a process exits unexpectedly.
+`atlas.sum` is updated only after every migration file of the run was written.
+A failed write rolls the generation back immediately. If the process exits
+between publishing the SQL files and publishing `atlas.sum`, the durable
+publication journal remains next to the migration directory; the next lock
+holder compares the checksum commit marker and either finalizes the committed
+batch or removes only the hard-linked files owned by the interrupted batch.
 
 ```bash
 ptah-compat migrate diff add_users \
@@ -269,9 +280,11 @@ ptah-compat migrate diff import_history \
   --dev-url "$DEV_DATABASE_URL"
 ```
 
-The desired directory is checksummed and replayed to a disconnected snapshot
-before Ptah evaluates the output directory. A source loading failure therefore
-does not create the output migration directory.
+The desired directory is checksummed and replayed on the dev database to
+capture a schema snapshot. Ptah cleans the dev database before it evaluates
+the output directory. A source loading failure therefore does not create the
+output migration directory, and a successful source replay does not leave its
+objects behind.
 
 Atlas OSS registers `migrate diff --dry-run` as a hidden flag. Ptah accepts the
 same hidden flag and prints the generated SQL instead of writing a migration

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -212,17 +212,30 @@ failures. Use a disposable dev database. Ptah only reads a database used as
 `--to`; it never cleans or mutates that database. Ptah rejects a desired
 database that identifies the same host, port, and database as `--dev-url`,
 even when credentials, connection options, scheme aliases, or an explicit
-default port differ.
+default port differ. Repeated `--schema` values filter both sides of the
+comparison and the generated output. They do not narrow the
+[dev database realm](../../concepts/database-urls-and-dev-databases/) replayed
+and cleaned by Ptah.
 
 If `atlas.sum` already exists, Ptah validates it before replaying migrations
 and fails on checksum drift instead of silently rehashing edited files. Ptah
 holds the migration-directory lock while it captures and verifies one immutable
 directory snapshot, replays that exact snapshot, and publishes the result.
+It also holds an exclusive dev-database lock from desired-schema resolution
+through final cleanup. PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server
+use session advisory locks. SQLite, ClickHouse, and CockroachDB use an
+operating-system lock keyed by normalized database identity. The latter
+coordinates Ptah processes on one host; cross-host ClickHouse and CockroachDB
+replay is unsupported. A dialect without a safe locking mechanism fails before
+Ptah cleans the dev database.
 Generated migration files are staged before publication, and `atlas.sum` is
 atomically replaced last as the batch commit marker. An OS-backed lock prevents
 cooperating processes from planning against the same directory concurrently
 and is released by the operating system if a process exits unexpectedly.
-`atlas.sum` is updated only after every migration file of the run was written.
+The generated versions and checksum are derived from the captured snapshot.
+Ptah rejects a migration added after that capture instead of publishing above
+an unreplayed file. `atlas.sum` is updated only after every migration file of
+the run was written.
 A failed write rolls the generation back immediately. If the process exits
 between publishing the SQL files and publishing `atlas.sum`, the durable
 publication journal remains next to the migration directory; the next lock
@@ -298,11 +311,11 @@ ptah-compat migrate diff add_users \
   --dry-run
 ```
 
-Use `--lock-timeout` to bound waiting for Ptah's local migration-directory lock
-while the command validates checksums and writes the new migration. The default
-migration-file format matches Atlas's two-space SQL indentation template. Use
-`--format` to render the generated migration SQL through Atlas-style Go
-templates with `sql` and `.MarshalSQL`, for example to disable indentation:
+Use `--lock-timeout` to bound waiting for both the migration-directory lock and
+the exclusive dev-database lock. The default migration-file format matches
+Atlas's two-space SQL indentation template. Use `--format` to render the
+generated migration SQL through Atlas-style Go templates with `sql` and
+`.MarshalSQL`, for example to disable indentation:
 
 ```bash
 ptah-compat migrate diff add_users \

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -73,6 +73,11 @@ exercise a real server dialect — see
   ClickHouse cleanup owns the selected database. SQL Server cleanup owns all
   supported user schemas in the selected database. SQLite cleanup owns `main`
   on one pinned session.
+- **MySQL-family cleanup needs global catalog visibility.** MySQL cleanup
+  credentials require global `SELECT`, `DROP`, `ALTER`, `ALTER ROUTINE`,
+  `EVENT`, `LOCK TABLES`, and `PROCESS`; MariaDB also requires global
+  `SHOW VIEW`. Ptah checks these privileges before destructive DDL. Use such
+  credentials only for a disposable dev database.
 - **ClickHouse realm cleanup requires 24.11 or newer.** Ptah uses `CHECK GRANT`
   to prove complete catalog visibility before dropping objects. Older servers
   fail before cleanup because role-aware visibility cannot be proven safely.

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -38,7 +38,10 @@ whose state matters after the command exits.
 **A dev database** (`--dev-url`) is a disposable replay target used for
 validation: `ptah migrations validate` and `ptah migrations lint` clean it and
 replay the migration directory on it to prove the SQL executes, and
-Atlas-compatible verbs use it for planning and linting the same way.
+Atlas-compatible verbs use it for planning and linting the same way. Ptah
+cleans the replay realm before migration execution, after a failed replay, and
+after a successful replay. Commands that inspect the replayed state do so
+between execution and the final cleanup on the same pinned database session.
 
 **A shadow database** (`--shadow-db`) is a disposable verification target for
 commands that write or record migrations: `ptah migrations generate` replays
@@ -59,21 +62,27 @@ exercise a real server dialect — see
   database workflows clean user objects, and test seed steps bypass the
   seeder's protected-environment guards. Point these flags at scratch databases
   only, never at a real environment.
-- **Cleanup ordering depends on the workflow.** `ptah-compat migrate diff`
-  validates its inputs before cleaning the dev database and cleans again after
-  success or a failure once replay starts. Validation, lint, and shadow
-  workflows reset their disposable database before replay but do not promise
-  that it is empty when the command exits.
-- **Cleanup follows the configured scope.** SQLite cleanup affects the selected
-  attached schema, while MySQL and MariaDB cleanup affects the selected
-  database and refuses to proceed when foreign keys or views from another
-  database reference it. PostgreSQL cleanup refuses to proceed when objects
-  outside the selected schema depend on managed objects. It also refuses a
-  schema-owned PostgreSQL extension: `DROP EXTENSION` is database-scoped and
-  can remove extension members outside the selected schema, so schema cleanup
-  cannot make that operation safe. Use a disposable database, not only a
-  disposable schema, and install required extensions outside the replayed
-  migration history until Ptah has an explicit database-wide cleanup mode.
+- **Comparison scope does not reduce the replay realm.** Repeated
+  `--schema` values select which schemas Ptah compares and emits. They do not
+  limit which schemas a migration may create or which user schemas final
+  cleanup removes.
+- **The replay realm follows the database engine.** PostgreSQL, CockroachDB,
+  and YugabyteDB cleanup treats all user schemas and user-installed extensions
+  in the selected database as one dependency graph. MySQL, MariaDB, and
+  ClickHouse cleanup owns the selected database. SQL Server cleanup owns all
+  supported user schemas in the selected database. SQLite cleanup owns `main`
+  on one pinned session.
+- **Cross-realm operations fail before execution.** Ptah rejects direct
+  statements that switch or mutate another database, protected namespace,
+  server, cluster, temporary namespace, external file, or attached SQLite
+  database. It also rejects statement forms whose nested SQL cannot be
+  confined safely during replay.
+- **Replay cleanup is serialized by realm.** PostgreSQL, YugabyteDB, MySQL,
+  MariaDB, and SQL Server use database advisory locks. SQLite, ClickHouse, and
+  CockroachDB use an operating-system file lock keyed by the normalized
+  database identity, which coordinates Ptah processes on the same host.
+  Cross-host ClickHouse and CockroachDB replay is unsupported because neither
+  engine provides the required effective session advisory lock.
 - **Match the target engine.** Replay verification proves the SQL executes on
   the engine it ran against, so a dev or shadow database should run the same
   engine (and ideally the same version) as the target.

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -61,7 +61,8 @@ exercise a real server dialect — see
 - **Disposable means Ptah may drop everything it supports.** Dev and shadow
   database workflows clean user objects, and test seed steps bypass the
   seeder's protected-environment guards. Point these flags at scratch databases
-  only, never at a real environment.
+  only, never at a real environment. Cleanup rejects known system, template,
+  metadata, and administrative database names.
 - **Comparison scope does not reduce the replay realm.** Repeated
   `--schema` values select which schemas Ptah compares and emits. They do not
   limit which schemas a migration may create or which user schemas final
@@ -72,6 +73,9 @@ exercise a real server dialect — see
   ClickHouse cleanup owns the selected database. SQL Server cleanup owns all
   supported user schemas in the selected database. SQLite cleanup owns `main`
   on one pinned session.
+- **ClickHouse realm cleanup requires 24.11 or newer.** Ptah uses `CHECK GRANT`
+  to prove complete catalog visibility before dropping objects. Older servers
+  fail before cleanup because role-aware visibility cannot be proven safely.
 - **Cross-realm operations fail before execution.** Ptah rejects direct
   statements that switch or mutate another database, protected namespace,
   server, cluster, temporary namespace, external file, or attached SQLite
@@ -80,15 +84,44 @@ exercise a real server dialect — see
 - **Replay cleanup is serialized by realm.** PostgreSQL, YugabyteDB, MySQL,
   MariaDB, and SQL Server use database advisory locks. SQLite, ClickHouse, and
   CockroachDB use an operating-system file lock keyed by the normalized
-  database identity, which coordinates Ptah processes on the same host.
-  Cross-host ClickHouse and CockroachDB replay is unsupported because neither
-  engine provides the required effective session advisory lock.
+  database identity. That file lock coordinates only Ptah processes that
+  resolve the same temporary lock path and can access it, normally processes
+  running as the same operating-system user with the same temporary-directory
+  configuration. Different users, different temporary directories, other
+  hosts, and non-Ptah clients are not coordinated. Cross-host ClickHouse and
+  CockroachDB replay is unsupported because neither engine provides the
+  required effective session advisory lock.
 - **Match the target engine.** Replay verification proves the SQL executes on
   the engine it ran against, so a dev or shadow database should run the same
   engine (and ideally the same version) as the target.
 - **Every flag has an environment variable.** `PTAH_DB_URL`, `PTAH_DEV_URL`,
   and `PTAH_SHADOW_DB` set the corresponding flags, which keeps credentials
   out of CI command lines — see [Configuration](../../reference/configuration/).
+
+### Statement forms that fail closed
+
+Replay rejects SQL sublanguages and storage mechanisms whose effects cannot be
+proven to stay inside the disposable realm:
+
+- PostgreSQL-family `DO`, `CALL`, routine creation or alteration, foreign-table
+  creation or alteration, foreign servers, `IMPORT FOREIGN SCHEMA`,
+  `SET search_path`, and `SELECT INTO` protected namespaces.
+- MySQL and MariaDB executable comments, `CALL`, events, triggers, routines,
+  `LOAD DATA`/`LOAD XML`, and externally backed `FEDERATED` or `CONNECT`
+  tables.
+- SQL Server `EXEC`/`EXECUTE`, procedure/function/trigger creation or
+  alteration, synonym/external-table creation, `BULK INSERT`, `BACKUP`,
+  `RESTORE`, and server-level maintenance statements.
+- ClickHouse remote, distributed, replicated, and unknown table engines,
+  external dictionary sources, and `FREEZE`/`UNFREEZE`. Tables and standalone
+  materialized views must select an explicitly allowlisted engine.
+- SQLite `ATTACH`, `DETACH`, temporary objects, and non-restorable pragmas.
+
+The rejection happens while Ptah validates the whole migration, before its
+first statement executes. Realm-local removal forms that Ptah can classify
+without interpreting a routine body, such as `DROP FUNCTION`,
+`DROP FOREIGN TABLE`, `DROP SYNONYM`, and `DROP EXTERNAL TABLE`, remain
+allowed.
 
 ## Where it appears
 

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -75,12 +75,30 @@ exercise a real server dialect — see
   on one pinned session.
 - **MySQL-family cleanup needs global catalog visibility.** MySQL cleanup
   credentials require global `SELECT`, `DROP`, `ALTER`, `ALTER ROUTINE`,
-  `EVENT`, `LOCK TABLES`, and `PROCESS`; MariaDB also requires global
-  `SHOW VIEW`. Ptah checks these privileges before destructive DDL. Use such
-  credentials only for a disposable dev database.
+  `EVENT`, `LOCK TABLES`, and `PROCESS`. MySQL also requires global `TRIGGER`
+  and, on MySQL 8.0.20 and newer, `SHOW_ROUTINE`; MariaDB requires global
+  `SHOW VIEW`. Ptah checks these privileges before destructive DDL. It fails
+  closed when another user database contains a routine, event, or trigger
+  because stored-program bodies can reference the cleanup realm without a
+  catalog dependency. Use dedicated server instances and credentials only for
+  disposable dev databases.
 - **ClickHouse realm cleanup requires 24.11 or newer.** Ptah uses `CHECK GRANT`
-  to prove complete catalog visibility before dropping objects. Older servers
-  fail before cleanup because role-aware visibility cannot be proven safely.
+  with global `SHOW DATABASES` and `SHOW TABLES` to prove complete catalog
+  visibility before dropping objects. ClickHouse does not expose ordinary-view
+  dependencies, so Ptah fails closed when another user database contains a
+  view, materialized view, live/window view, dictionary, or `Buffer`,
+  `Distributed`, or `Merge` table. Older servers fail before cleanup because
+  role-aware visibility cannot be proven safely.
+- **PostgreSQL-family cleanup rejects database-scoped artifacts.** PostgreSQL
+  and YugabyteDB reject publications, subscriptions, logical replication
+  slots, event triggers, and non-extension foreign-data wrappers, servers, or
+  user mappings before DDL. PostgreSQL also removes and verifies database large
+  objects transactionally. YugabyteDB does not run that PostgreSQL-specific
+  large-object operation.
+- **SQL Server cleanup rejects replication state.** A replication-enabled
+  database or replicated table fails before DDL, along with other unsupported
+  database-scoped artifacts. Remove replication configuration or use a
+  dedicated disposable database before replay.
 - **Cross-realm operations fail before execution.** Ptah rejects direct
   statements that switch or mutate another database, protected namespace,
   server, cluster, temporary namespace, external file, or attached SQLite

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -55,9 +55,25 @@ exercise a real server dialect — see
 
 ## Consequences
 
-- **Disposable means dropped.** Dev and shadow databases are cleaned on every
-  run, and test seed steps bypass the seeder's protected-environment guards.
-  Point these flags at scratch databases only, never at a real environment.
+- **Disposable means Ptah may drop everything it supports.** Dev and shadow
+  database workflows clean user objects, and test seed steps bypass the
+  seeder's protected-environment guards. Point these flags at scratch databases
+  only, never at a real environment.
+- **Cleanup ordering depends on the workflow.** `ptah-compat migrate diff`
+  validates its inputs before cleaning the dev database and cleans again after
+  success or a failure once replay starts. Validation, lint, and shadow
+  workflows reset their disposable database before replay but do not promise
+  that it is empty when the command exits.
+- **Cleanup follows the configured scope.** SQLite cleanup affects the selected
+  attached schema, while MySQL and MariaDB cleanup affects the selected
+  database and refuses to proceed when foreign keys or views from another
+  database reference it. PostgreSQL cleanup refuses to proceed when objects
+  outside the selected schema depend on managed objects. It also refuses a
+  schema-owned PostgreSQL extension: `DROP EXTENSION` is database-scoped and
+  can remove extension members outside the selected schema, so schema cleanup
+  cannot make that operation safe. Use a disposable database, not only a
+  disposable schema, and install required extensions outside the replayed
+  migration history until Ptah has an explicit database-wide cleanup mode.
 - **Match the target engine.** Replay verification proves the SQL executes on
   the engine it ran against, so a dev or shadow database should run the same
   engine (and ideally the same version) as the target.

--- a/docs/site/src/content/docs/databases/sqlserver.md
+++ b/docs/site/src/content/docs/databases/sqlserver.md
@@ -43,6 +43,8 @@ ptah db read --db-url "sqlserver://sa:$SA_PASSWORD@localhost:1433?database=app&s
   related catalog views.
 - Transactional migration apply for DDL SQL Server supports in transactions,
   and migration-run serialization through a session application lock.
+- Transactional dev-database cleanup across supported user schemas, with a
+  preflight that rejects replication-enabled databases and replicated tables.
 - One-row upsert rendering to `MERGE` through the Go DML AST (an embedder
   surface, not a CLI command).
 
@@ -108,6 +110,8 @@ rendered SQL always preserves your annotation text verbatim.
 - Index planning preserves key order, direction, and filtered predicates, but
   not included columns.
 - Engine-specific options such as `WITH (ONLINE = ON)` are not planned.
+- Dev-database cleanup rejects database replication, replicated tables, and
+  unsupported database-scoped artifacts before its first DDL statement.
 
 ## Next steps
 

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -53,11 +53,13 @@ SQL:
   rolled back by the surrounding transaction.
 
 Database-realm cleanup requires global `SELECT`, `DROP`, `ALTER`,
-`ALTER ROUTINE`, `EVENT`, `LOCK TABLES`, and `PROCESS`. MariaDB additionally
+`ALTER ROUTINE`, `EVENT`, `LOCK TABLES`, and `PROCESS`. MySQL also requires
+global `TRIGGER` and, on MySQL 8.0.20 and newer, `SHOW_ROUTINE`; MariaDB
 requires global `SHOW VIEW`. Ptah verifies this privilege set before destructive
-DDL so it can inspect cross-database dependencies and fails closed when partial
-revokes make that proof incomplete. Grant these privileges only to credentials
-used with a disposable dev database.
+DDL. Cleanup fails closed when another user database contains a routine, event,
+or trigger because its body can reference the cleanup realm without a catalog
+dependency. Grant these privileges only to credentials used with a dedicated
+disposable dev database.
 
 For large tables, `ptah migrations up` and `down` can route `ALTER TABLE`
 statements through gh-ost or pt-online-schema-change, either per migration
@@ -114,6 +116,11 @@ matching preset automatically.
 CockroachDB and YugabyteDB run in integration coverage against live
 open-source containers; Spanner coverage is offline (capability, planning,
 rendering, URL, and detection), so review generated SQL before relying on it.
+PostgreSQL and YugabyteDB reject unsupported database-scoped publications,
+subscriptions, logical replication slots, event triggers, and non-extension
+foreign-data objects before dev-database cleanup. PostgreSQL additionally
+removes database large objects inside the cleanup transaction; YugabyteDB does
+not support that catalog write path.
 
 ## ClickHouse
 
@@ -122,7 +129,10 @@ ClickHouse support is capability-limited. The preset models enums as inline
 are outside the preset. Review generated SQL and the
 [capability gates](../../reference/capabilities/) before adopting a workflow
 on ClickHouse. Dev-database replay cleanup requires ClickHouse 24.11 or newer
-so Ptah can prove complete catalog visibility with `CHECK GRANT`.
+and global `SHOW DATABASES` plus `SHOW TABLES`. Because ordinary views have no
+complete catalog dependency metadata, cleanup also requires that other user
+databases contain no view-like or dictionary objects and no `Buffer`,
+`Distributed`, or `Merge` tables.
 
 ## Choosing behavior by capability, not by name
 

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -52,6 +52,13 @@ SQL:
 - DDL commits implicitly on both engines, so a failed migration cannot be
   rolled back by the surrounding transaction.
 
+Database-realm cleanup requires global `SELECT`, `DROP`, `ALTER`,
+`ALTER ROUTINE`, `EVENT`, `LOCK TABLES`, and `PROCESS`. MariaDB additionally
+requires global `SHOW VIEW`. Ptah verifies this privilege set before destructive
+DDL so it can inspect cross-database dependencies and fails closed when partial
+revokes make that proof incomplete. Grant these privileges only to credentials
+used with a disposable dev database.
+
 For large tables, `ptah migrations up` and `down` can route `ALTER TABLE`
 statements through gh-ost or pt-online-schema-change, either per migration
 with a `-- +ptah online_ddl_tool=ghost` directive or automatically above a

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -114,7 +114,8 @@ ClickHouse support is capability-limited. The preset models enums as inline
 `Enum8`/`Enum16` column types; foreign keys and enforced `CHECK` constraints
 are outside the preset. Review generated SQL and the
 [capability gates](../../reference/capabilities/) before adopting a workflow
-on ClickHouse.
+on ClickHouse. Dev-database replay cleanup requires ClickHouse 24.11 or newer
+so Ptah can prove complete catalog visibility with `CHECK GRANT`.
 
 ## Choosing behavior by capability, not by name
 

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -71,6 +71,29 @@ the callback failed.
 The observer composes with `StatementInterceptor`: a statement handled by an
 external executor is observed once after that executor reports success.
 
+## Pinned database sessions
+
+`dbschema.DatabaseConnection.WithSession` pins one physical database session
+for the duration of a callback and rebinds the dialect reader, writer, and SQL
+runner to that session. Use it for cleanup, replay, and inspection workflows
+that depend on session-local state or SQLite attached-database visibility.
+
+The scoped connection must not escape the callback. Ptah discards the physical
+connection afterward so session-local state cannot leak to a later pool user.
+
+## Migration statement validation
+
+`migration/migrator.WithStatementValidator` attaches a pre-execution SQL
+safety gate to a filesystem provider. Ptah splits and validates every
+statement in one migration before executing its first statement. Rejecting a
+later statement cannot leave an earlier statement applied.
+
+Implement `migrator.StatementValidator` when an embedder must confine replay to
+a disposable database or reject unsupported statement forms. Validators
+inspect SQL but do not replace execution. Combine a validator with
+`StatementInterceptor` only when an external tool must execute accepted
+statements.
+
 ## Schema diff and planning contracts
 
 `migration/schemadiff/types.SchemaDiff` stores index additions and removals as
@@ -83,6 +106,11 @@ schema whose live catalog semantics must survive checkpoint planning.
 `GenerateCheckpointWithDatabaseInfo` accepts a caller-supplied complete
 identifier snapshot; the dialect-only checkpoint helper uses conservative
 offline rules.
+`migration/generator.PlanMigration` returns an unpublished plan bound to the
+migration-directory snapshot used during planning. `MigrationPlan.WriteFiles`
+rejects changed history under the shared cross-process publication lock.
+Embedders that need cancellation while waiting for that lock use
+`WriteFilesContext`.
 `migration/planner.Planner` exposes only checked planning; malformed references,
 unresolved additions, and target index-namespace conflicts fail before SQL is
 returned.

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -108,9 +108,10 @@ identifier snapshot; the dialect-only checkpoint helper uses conservative
 offline rules.
 `migration/generator.PlanMigration` returns an unpublished plan bound to the
 migration-directory snapshot used during planning. `MigrationPlan.WriteFiles`
-rejects changed history under the shared cross-process publication lock.
-Embedders that need cancellation while waiting for that lock use
-`WriteFilesContext`.
+rejects changed history with `generator.ErrMigrationDirectoryChanged` under
+the shared cross-process publication lock. Embedders that need cancellation
+while waiting for that lock use `WriteFilesContext`; concurrent use of one plan
+fails with `generator.ErrMigrationPlanInUse`.
 `migration/planner.Planner` exposes only checked planning; malformed references,
 unresolved additions, and target index-namespace conflicts fail before SQL is
 returned.

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -120,10 +120,17 @@ files. With `--env`, reads `env.schema.src`, `env.dev`, `migration.dir`,
 `-- atlas:txmode none` directive, splitting mixed plans into a transactional
 file followed by a concurrent-index file (unsplittable mixes are refused).
 Generated SQL uses Atlas-style two-space indentation by default; `--format`
-renders it with `sql` and `.MarshalSQL` templates. `--schema/-s` narrows both
-the replayed dev database state and the desired schema. `--edit` opens the
-generated migrations in `$VISUAL`/`$EDITOR` before `atlas.sum` is finalized.
-`--lock-timeout` bounds waiting for Ptah's local migration-directory lock.
+renders it with `sql` and `.MarshalSQL` templates. `--schema/-s` narrows the
+current and desired schemas used for comparison and output; migration replay
+and cleanup still own the complete [dev database realm](../../concepts/database-urls-and-dev-databases/).
+`--edit` opens the generated migrations in `$VISUAL`/`$EDITOR` before
+`atlas.sum` is finalized.
+`--lock-timeout` bounds waiting for both Ptah's local migration-directory lock
+and the exclusive dev-database lock. PostgreSQL, YugabyteDB, MySQL, MariaDB,
+and SQL Server use session advisory locks; SQLite, ClickHouse, and CockroachDB
+use an operating-system lock keyed by normalized database identity. Cross-host
+ClickHouse and CockroachDB replay is unsupported. Dialects without a safe
+dev-database lock fail before cleanup.
 `--qualifier` prefixes every object in the generated statements with a custom
 schema qualifier on PostgreSQL-family, MySQL, and MariaDB dev databases;
 invalid values, unsupported dialects, multi-schema plans, and statement kinds

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -43,6 +43,9 @@ The current SQL Server implementation covers:
 - Live schema introspection from `sys.tables`, `sys.columns`,
   `sys.foreign_keys`, `sys.indexes`, and related catalog views.
 - Transactional migration apply for DDL supported by SQL Server.
+- Transactional dev-database cleanup across supported user schemas, with a
+  preflight that rejects replication-enabled and subscriber databases,
+  replicated tables, and unsupported database-scoped artifacts.
 
 Enums are represented as `NVARCHAR(255)` plus generated CHECK constraints.
 SQL Server does not have a native enum object equivalent to PostgreSQL
@@ -159,6 +162,9 @@ The SQL Server support is deliberately conservative:
   mutating objects outside the selected schema.
 - SQL Server-specific options such as `WITH (ONLINE = ON)` and
   `NOT FOR REPLICATION` are not planned yet.
+- Database-realm cleanup fails before DDL when replication is configured,
+  subscription state is unavailable or unexpected, a user table is replicated,
+  or another unsupported database-scoped artifact exists.
 
 ## Live Tests
 
@@ -174,6 +180,9 @@ table name, computed columns, CHECK/UNIQUE/FK constraints, and an index, then
 verifies that Ptah can introspect them through the SQL Server reader. The live
 coverage also verifies full database-realm cleanup of cross-schema dependency
 graphs and migration metadata placement through the URL `schema` parameter.
+The cleanup suite executes replication-state catalog checks on a real SQL
+Server and unit coverage verifies fail-closed subscriber and replicated-table
+states.
 Schema-scoped cleanup fails safely when another schema owns a foreign key into
 the selected schema, and computed column
 and default catalog readback are compared as a zero-diff schema. SQL Server

--- a/docs/sqlserver.md
+++ b/docs/sqlserver.md
@@ -172,9 +172,10 @@ PTAH_SQLSERVER_TEST_URL='sqlserver://sa:pass@localhost:1433?database=ptah&encryp
 The test creates a temporary schema, tables with `IDENTITY`, a reserved-word
 table name, computed columns, CHECK/UNIQUE/FK constraints, and an index, then
 verifies that Ptah can introspect them through the SQL Server reader. The live
-coverage also verifies schema-scoped cleanup of FK-linked tables and migration
-metadata placement through the URL `schema` parameter. Cleanup fails safely when
-another schema owns a foreign key into the selected schema, and computed column
+coverage also verifies full database-realm cleanup of cross-schema dependency
+graphs and migration metadata placement through the URL `schema` parameter.
+Schema-scoped cleanup fails safely when another schema owns a foreign key into
+the selected schema, and computed column
 and default catalog readback are compared as a zero-diff schema. SQL Server
 advisory-lock coverage verifies both normal migration progress and timeout
 reporting when another session holds `ptah_migrate`. Identifier-collation

--- a/integration/README.md
+++ b/integration/README.md
@@ -48,7 +48,9 @@ The standalone integration runner reads scenario connections from
 `<DATABASE>_URL`. Set the optional matching `<DATABASE>_CLEANUP_URL` when
 cleanup requires broader privileges. The scenario and cleanup URLs may use
 different credentials, but the runner rejects a cleanup URL that addresses a
-different database.
+different database. Cleanup credentials are exposed only to database reset
+operations; migration generation, application, validation, and permission
+scenarios continue to use the restricted scenario connection.
 
 For MySQL and MariaDB, keep scenario execution restricted while granting the
 cleanup connection the global metadata and destructive privileges listed

--- a/integration/README.md
+++ b/integration/README.md
@@ -272,12 +272,15 @@ Rich, interactive report with:
 
 ### MySQL
 - Version: 8+
-- Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
+- Required cleanup permissions: global SELECT, DROP, ALTER, ALTER ROUTINE,
+  EVENT, LOCK TABLES, and PROCESS. Use these credentials only for a disposable
+  dev database. Restricted credentials remain suitable for non-cleanup tests.
 - Authentication: default MySQL authentication (`caching_sha2_password` on current MySQL images)
 
 ### MariaDB
 - Version: 10.11+
-- Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
+- Required cleanup permissions: the MySQL cleanup privileges plus global
+  SHOW VIEW. Use these credentials only for a disposable dev database.
 - Compatible with MySQL driver
 
 ### ClickHouse

--- a/integration/README.md
+++ b/integration/README.md
@@ -51,7 +51,7 @@ another database. Set the matching URL and run the focused package:
 ```bash
 PTAH_CLICKHOUSE_REALM_TEST_URL="$CLICKHOUSE_ADMIN_URL" \
   go test -v -count=1 ./internal/dbschema/clickhouse \
-  -run '^TestWriterDropDatabaseRealm_Live$'
+  -run '^TestWriterDropDatabaseRealm_(Live|RejectsExternalDependencyLive)$'
 
 PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL="$CLICKHOUSE_24_10_ADMIN_URL" \
   go test -v -count=1 ./internal/dbschema/clickhouse \
@@ -60,7 +60,7 @@ PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL="$CLICKHOUSE_24_10_ADMIN_URL" \
 MYSQL_ADMIN_TEST_DSN="$MYSQL_ADMIN_DSN" \
 MARIADB_ADMIN_TEST_DSN="$MARIADB_ADMIN_DSN" \
   go test -v -count=1 ./internal/dbschema/mysql -tags=integration \
-  -run '^TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase$'
+  -run '^TestWriterDropDatabaseRealm_Live(RejectsProtectedDatabase|RejectsExternalStoredProgram|RejectsMissingTriggerPrivilege)$'
 
 PTAH_SQLSERVER_REALM_TEST_URL="$SQLSERVER_ADMIN_URL" \
   go test -v -count=1 ./internal/dbschema/mssql \
@@ -77,6 +77,13 @@ Each URL must identify an administrative connection intended for tests. The
 success-path tests create a separate temporary database and drop it during
 cleanup. Protected-name tests connect to the named administrative database
 only to prove cleanup fails before mutation.
+
+ClickHouse cleanup requires global `SHOW DATABASES` and `SHOW TABLES`
+visibility. ClickHouse does not expose dependency metadata for ordinary views,
+so Ptah fails closed when another user database contains a view, materialized
+view, live/window view, dictionary, or `Buffer`, `Distributed`, or `Merge`
+table. Use a dedicated ClickHouse development server without unrelated
+dependency-capable objects.
 
 ## Architecture
 
@@ -273,8 +280,9 @@ Rich, interactive report with:
 ### MySQL
 - Version: 8+
 - Required cleanup permissions: global SELECT, DROP, ALTER, ALTER ROUTINE,
-  EVENT, LOCK TABLES, and PROCESS. Use these credentials only for a disposable
-  dev database. Restricted credentials remain suitable for non-cleanup tests.
+  EVENT, LOCK TABLES, PROCESS, and TRIGGER. MySQL 8.0.20 and newer also
+  requires SHOW_ROUTINE. Use these credentials only for a disposable dev
+  database. Restricted credentials remain suitable for non-cleanup tests.
 - Authentication: default MySQL authentication (`caching_sha2_password` on current MySQL images)
 
 ### MariaDB

--- a/integration/README.md
+++ b/integration/README.md
@@ -44,6 +44,40 @@ The integration test suite covers all aspects of the migration system as outline
 - Drop all tables and re-run from empty state on PostgreSQL, MySQL, MariaDB,
   ClickHouse, and opt-in SQL Server
 
+The database-realm cleanup tests use dedicated scratch databases and verify
+that replay cleanup removes database-scoped artifacts without crossing into
+another database. Set the matching URL and run the focused package:
+
+```bash
+PTAH_CLICKHOUSE_REALM_TEST_URL="$CLICKHOUSE_ADMIN_URL" \
+  go test -v -count=1 ./internal/dbschema/clickhouse \
+  -run '^TestWriterDropDatabaseRealm_Live$'
+
+PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL="$CLICKHOUSE_24_10_ADMIN_URL" \
+  go test -v -count=1 ./internal/dbschema/clickhouse \
+  -run '^TestWriterDropDatabaseRealm_RejectsLegacyServerLive$'
+
+MYSQL_ADMIN_TEST_DSN="$MYSQL_ADMIN_DSN" \
+MARIADB_ADMIN_TEST_DSN="$MARIADB_ADMIN_DSN" \
+  go test -v -count=1 ./internal/dbschema/mysql -tags=integration \
+  -run '^TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase$'
+
+PTAH_SQLSERVER_REALM_TEST_URL="$SQLSERVER_ADMIN_URL" \
+  go test -v -count=1 ./internal/dbschema/mssql \
+  -run '^TestWriterDropDatabaseRealm_.*Live$'
+
+POSTGRES_URL="$POSTGRES_ADMIN_URL" \
+COCKROACHDB_URL="$COCKROACHDB_ADMIN_URL" \
+YUGABYTEDB_URL="$YUGABYTEDB_ADMIN_URL" \
+  go test -v -count=1 ./internal/dbschema/postgres -tags=integration \
+  -run '^TestWriterDropDatabaseRealm_Live(PostgresFamilyCleansCrossSchemaGraph|RejectsProtectedDatabase)$'
+```
+
+Each URL must identify an administrative connection intended for tests. The
+success-path tests create a separate temporary database and drop it during
+cleanup. Protected-name tests connect to the named administrative database
+only to prove cleanup fails before mutation.
+
 ## Architecture
 
 ### Components
@@ -245,6 +279,11 @@ Rich, interactive report with:
 - Version: 10.11+
 - Required permissions: CREATE, DROP, SELECT, INSERT, UPDATE, DELETE
 - Compatible with MySQL driver
+
+### ClickHouse
+- Version: 24.11+ for database-realm replay cleanup
+- Required permissions: CHECK GRANT, SHOW DATABASES, SHOW TABLES, CREATE DATABASE, DROP DATABASE, and the required DROP privileges for every supported object type in the scratch database
+- Cleanup fails before mutation on older servers because complete catalog visibility cannot be proven
 
 ### SQL Server
 - Version: SQL Server 2022 / Azure SQL compatible subset

--- a/integration/README.md
+++ b/integration/README.md
@@ -44,6 +44,24 @@ The integration test suite covers all aspects of the migration system as outline
 - Drop all tables and re-run from empty state on PostgreSQL, MySQL, MariaDB,
   ClickHouse, and opt-in SQL Server
 
+The standalone integration runner reads scenario connections from
+`<DATABASE>_URL`. Set the optional matching `<DATABASE>_CLEANUP_URL` when
+cleanup requires broader privileges. The scenario and cleanup URLs may use
+different credentials, but the runner rejects a cleanup URL that addresses a
+different database.
+
+For MySQL and MariaDB, keep scenario execution restricted while granting the
+cleanup connection the global metadata and destructive privileges listed
+below:
+
+```bash
+MYSQL_URL="$MYSQL_RESTRICTED_URL" \
+MYSQL_CLEANUP_URL="$MYSQL_ADMIN_URL" \
+MARIADB_URL="$MARIADB_RESTRICTED_URL" \
+MARIADB_CLEANUP_URL="$MARIADB_ADMIN_URL" \
+  ./integration-test --databases=mysql,mariadb
+```
+
 The database-realm cleanup tests use dedicated scratch databases and verify
 that replay cleanup removes database-scoped artifacts without crossing into
 another database. Set the matching URL and run the focused package:

--- a/integration/atlas_migrate_diff_e2e_test.go
+++ b/integration/atlas_migrate_diff_e2e_test.go
@@ -42,6 +42,84 @@ func TestAtlasMigrateDiffConcurrentIndexAndQualifierE2E(t *testing.T) {
 	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
 
 	testDBURL := replaceDatabaseName(c, dbURL, testDBName)
+	devDB, err := sql.Open("pgx", testDBURL)
+	c.Assert(err, qt.IsNil)
+	defer devDB.Close()
+	_, err = devDB.ExecContext(ctx, `
+CREATE VIEW stale_dev_view AS SELECT 1 AS value;
+CREATE MATERIALIZED VIEW stale_dev_materialized_view AS SELECT 1 AS value;
+CREATE FUNCTION stale_dev_function() RETURNS integer LANGUAGE sql AS 'SELECT 1';
+CREATE PROCEDURE stale_dev_procedure() LANGUAGE sql AS 'SELECT 1';
+CREATE AGGREGATE stale_dev_aggregate(integer) (
+	SFUNC = int4pl,
+	STYPE = integer,
+	INITCOND = '0'
+);
+CREATE SEQUENCE stale_dev_sequence;
+CREATE DOMAIN stale_dev_domain AS text;
+CREATE TYPE stale_dev_composite AS (value integer);
+CREATE TYPE z_stale_dev_range AS RANGE (
+	subtype = integer,
+	multirange_type_name = a_stale_dev_multirange
+);
+`)
+	c.Assert(err, qt.IsNil)
+	t.Run("cleanup rejects dependencies owned by another schema", func(t *testing.T) {
+		c := qt.New(t)
+		_, err := devDB.ExecContext(ctx, `
+CREATE TABLE public.stale_dependency_parent (id integer PRIMARY KEY);
+CREATE SCHEMA audit;
+CREATE VIEW audit.external_parent_view AS
+	SELECT id FROM public.stale_dependency_parent;
+CREATE TABLE audit.external_child (
+	id integer PRIMARY KEY,
+	parent_id integer REFERENCES public.stale_dependency_parent(id)
+);
+`)
+		c.Assert(err, qt.IsNil)
+		defer func() {
+			_, cleanupErr := devDB.ExecContext(
+				context.Background(),
+				"DROP SCHEMA IF EXISTS audit CASCADE; DROP TABLE IF EXISTS public.stale_dependency_parent",
+			)
+			c.Check(cleanupErr, qt.IsNil)
+		}()
+		dir := t.TempDir()
+		migrationsDir := filepath.Join(dir, "migrations")
+		schemaPath := filepath.Join(dir, "schema.sql")
+		c.Assert(os.WriteFile(
+			schemaPath,
+			[]byte("CREATE TABLE desired_items (id BIGSERIAL PRIMARY KEY);\n"),
+			0o600,
+		), qt.IsNil)
+
+		output, err := runPtah(ctx, dir, binaryPath,
+			"migrate", "diff",
+			"--to", "file://"+schemaPath,
+			"--dev-url", testDBURL,
+			"--dir", "file://"+migrationsDir,
+			"must_reject_external_dependencies")
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(output, qt.Contains, `refusing to clean schema "public"`)
+		var externalObjectCount int
+		err = devDB.QueryRowContext(ctx, `
+SELECT
+	(SELECT COUNT(*) FROM pg_class c
+	 JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = 'audit'
+	   AND c.relname IN ('external_parent_view', 'external_child')) +
+	(SELECT COUNT(*) FROM pg_class c
+	 JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = 'public'
+	   AND c.relname = 'stale_dependency_parent')
+`).Scan(&externalObjectCount)
+		c.Assert(err, qt.IsNil)
+		c.Assert(externalObjectCount, qt.Equals, 3)
+		entries, err := os.ReadDir(migrationsDir)
+		c.Assert(err, qt.IsNil)
+		c.Assert(entries, qt.HasLen, 0)
+	})
 	desiredDBName := testDBName + "_desired"
 	createE2EDatabase(c, ctx, adminDB, desiredDBName)
 	defer dropE2EDatabase(c, context.Background(), adminDB, desiredDBName)
@@ -50,7 +128,17 @@ func TestAtlasMigrateDiffConcurrentIndexAndQualifierE2E(t *testing.T) {
 	desiredDB, err := sql.Open("pgx", desiredDBURL)
 	c.Assert(err, qt.IsNil)
 	defer desiredDB.Close()
-	_, err = desiredDB.ExecContext(ctx, "CREATE TABLE desired_database_items (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL)")
+	_, err = desiredDB.ExecContext(ctx, `
+CREATE SEQUENCE shared_ids;
+CREATE TABLE desired_database_items (
+	id BIGSERIAL PRIMARY KEY,
+	name TEXT NOT NULL
+);
+CREATE TABLE desired_shared_sequence_items (
+	id BIGINT PRIMARY KEY DEFAULT nextval('shared_ids'),
+	name TEXT NOT NULL
+);
+`)
 	c.Assert(err, qt.IsNil)
 
 	t.Run("env database desired state generates migration without mutating source", func(t *testing.T) {
@@ -82,12 +170,57 @@ env "dev" {
 		migrationSQL := readFirstMatchingFile(c, migrationsDir, "*_add_database_items.sql")
 		c.Assert(migrationSQL, qt.Contains, "CREATE TABLE")
 		c.Assert(migrationSQL, qt.Contains, "desired_database_items")
+		c.Assert(migrationSQL, qt.Contains, "BIGSERIAL")
+		c.Assert(migrationSQL, qt.Contains, "CREATE SEQUENCE")
+		c.Assert(migrationSQL, qt.Contains, "shared_ids")
+		c.Assert(migrationSQL, qt.Contains, "nextval")
 		var sourceTableCount int
 		queryErr := desiredDB.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'desired_database_items'").
 			Scan(&sourceTableCount)
 		c.Assert(queryErr, qt.IsNil)
 		c.Assert(sourceTableCount, qt.Equals, 1)
+		c.Assert(e2eUserTableCount(c, ctx, testDBURL), qt.Equals, 0)
+		c.Assert(e2eStaleObjectCount(c, ctx, testDBURL), qt.Equals, 0)
+
+		applyDBName := testDBName + "_env_apply"
+		createE2EDatabase(c, ctx, adminDB, applyDBName)
+		defer dropE2EDatabase(c, context.Background(), adminDB, applyDBName)
+		applyDBURL := replaceDatabaseName(c, dbURL, applyDBName)
+		output, err = runPtah(ctx, t.TempDir(), binaryPath,
+			"migrate", "apply",
+			"--url", applyDBURL,
+			"--dir", "file://"+migrationsDir)
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+		c.Assert(e2eTableCount(c, ctx, applyDBURL, "desired_database_items"), qt.Equals, 1)
+		c.Assert(e2eTableCount(c, ctx, applyDBURL, "desired_shared_sequence_items"), qt.Equals, 1)
+
+		applyDB, err := sql.Open("pgx", applyDBURL)
+		c.Assert(err, qt.IsNil)
+		defer applyDB.Close()
+
+		var generatedID int64
+		err = applyDB.QueryRowContext(ctx,
+			"INSERT INTO desired_database_items (name) VALUES ($1) RETURNING id",
+			"generated",
+		).Scan(&generatedID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(generatedID > 0, qt.IsTrue)
+
+		var sharedGeneratedID int64
+		err = applyDB.QueryRowContext(ctx,
+			"INSERT INTO desired_shared_sequence_items (name) VALUES ($1) RETURNING id",
+			"shared",
+		).Scan(&sharedGeneratedID)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sharedGeneratedID > 0, qt.IsTrue)
+
+		var sharedSequenceIsNotSerial bool
+		err = applyDB.QueryRowContext(ctx,
+			"SELECT pg_get_serial_sequence('public.desired_shared_sequence_items', 'id') IS NULL",
+		).Scan(&sharedSequenceIsNotSerial)
+		c.Assert(err, qt.IsNil)
+		c.Assert(sharedSequenceIsNotSerial, qt.IsTrue)
 	})
 
 	t.Run("concurrent index policy splits files and tags txmode none", func(t *testing.T) {
@@ -144,7 +277,18 @@ CREATE INDEX idx_users_email ON users (email);
 
 		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
 		c.Assert(output, qt.Contains, "The migration directory is synced with the desired state")
-		c.Assert(e2eIndexIsValid(c, ctx, testDBURL, "idx_users_email"), qt.IsTrue)
+		c.Assert(e2eUserTableCount(c, ctx, testDBURL), qt.Equals, 0)
+
+		applyDBName := testDBName + "_concurrent_apply"
+		createE2EDatabase(c, ctx, adminDB, applyDBName)
+		defer dropE2EDatabase(c, context.Background(), adminDB, applyDBName)
+		applyDBURL := replaceDatabaseName(c, dbURL, applyDBName)
+		output, err = runPtah(ctx, dir, binaryPath,
+			"migrate", "apply",
+			"--url", applyDBURL,
+			"--dir", "file://"+migrationsDir)
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+		c.Assert(e2eIndexIsValid(c, ctx, applyDBURL, "idx_users_email"), qt.IsTrue)
 	})
 
 	t.Run("qualifier prefixes generated statements and artifacts apply cleanly", func(t *testing.T) {
@@ -202,7 +346,7 @@ CREATE INDEX idx_users_email ON users (email);
 			"--qualifier", "bad.name",
 			"broken")
 
-		c.Assert(err, qt.Not(qt.IsNil))
+		c.Assert(err, qt.IsNotNil)
 		c.Assert(output, qt.Contains, `invalid --qualifier "bad.name"`)
 		entries, readErr := os.ReadDir(migrationsDir)
 		c.Assert(readErr, qt.IsNil)
@@ -210,9 +354,62 @@ CREATE INDEX idx_users_email ON users (email);
 	})
 }
 
-// e2eIndexIsValid reports whether the named index exists, is valid, and is
-// ready on the target database (pg_index.indisvalid/indisready both hold for
-// successfully completed concurrent builds).
+func e2eUserTableCount(c *qt.C, ctx context.Context, dbURL string) int {
+	c.Helper()
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	var count int
+	err = db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func e2eTableCount(c *qt.C, ctx context.Context, dbURL, tableName string) int {
+	c.Helper()
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	var count int
+	err = db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM information_schema.tables
+WHERE table_schema = 'public' AND table_name = $1`, tableName).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func e2eStaleObjectCount(c *qt.C, ctx context.Context, dbURL string) int {
+	c.Helper()
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	var count int
+	err = db.QueryRowContext(ctx, `
+SELECT
+	(SELECT COUNT(*) FROM pg_class WHERE relname IN (
+		'stale_dev_view',
+		'stale_dev_materialized_view',
+		'stale_dev_sequence'
+	)) +
+	(SELECT COUNT(*) FROM pg_proc WHERE proname IN (
+		'stale_dev_function',
+		'stale_dev_procedure',
+		'stale_dev_aggregate'
+	)) +
+	(SELECT COUNT(*) FROM pg_type WHERE typname IN (
+		'stale_dev_domain',
+		'stale_dev_composite',
+		'z_stale_dev_range',
+		'a_stale_dev_multirange'
+	))`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
 func e2eIndexIsValid(c *qt.C, ctx context.Context, dbURL, indexName string) bool {
 	c.Helper()
 	db, err := sql.Open("pgx", dbURL)

--- a/integration/atlas_migrate_diff_e2e_test.go
+++ b/integration/atlas_migrate_diff_e2e_test.go
@@ -64,7 +64,7 @@ CREATE TYPE z_stale_dev_range AS RANGE (
 );
 `)
 	c.Assert(err, qt.IsNil)
-	t.Run("cleanup rejects dependencies owned by another schema", func(t *testing.T) {
+	t.Run("database realm cleans dependencies across schemas", func(t *testing.T) {
 		c := qt.New(t)
 		_, err := devDB.ExecContext(ctx, `
 CREATE TABLE public.stale_dependency_parent (id integer PRIMARY KEY);
@@ -98,10 +98,9 @@ CREATE TABLE audit.external_child (
 			"--to", "file://"+schemaPath,
 			"--dev-url", testDBURL,
 			"--dir", "file://"+migrationsDir,
-			"must_reject_external_dependencies")
+			"database_realm_dependencies")
 
-		c.Assert(err, qt.IsNotNil)
-		c.Assert(output, qt.Contains, `refusing to clean schema "public"`)
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
 		var externalObjectCount int
 		err = devDB.QueryRowContext(ctx, `
 SELECT
@@ -115,10 +114,14 @@ SELECT
 	   AND c.relname = 'stale_dependency_parent')
 `).Scan(&externalObjectCount)
 		c.Assert(err, qt.IsNil)
-		c.Assert(externalObjectCount, qt.Equals, 3)
-		entries, err := os.ReadDir(migrationsDir)
-		c.Assert(err, qt.IsNil)
-		c.Assert(entries, qt.HasLen, 0)
+		c.Assert(externalObjectCount, qt.Equals, 0)
+		migrationSQL := readFirstMatchingFile(
+			c,
+			migrationsDir,
+			"*_database_realm_dependencies.sql",
+		)
+		c.Assert(migrationSQL, qt.Contains, "CREATE TABLE")
+		c.Assert(migrationSQL, qt.Contains, "desired_items")
 	})
 	desiredDBName := testDBName + "_desired"
 	createE2EDatabase(c, ctx, adminDB, desiredDBName)

--- a/integration/atlas_migrate_diff_e2e_test.go
+++ b/integration/atlas_migrate_diff_e2e_test.go
@@ -115,6 +115,14 @@ SELECT
 `).Scan(&externalObjectCount)
 		c.Assert(err, qt.IsNil)
 		c.Assert(externalObjectCount, qt.Equals, 0)
+		var auditSchemaCount int
+		err = devDB.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM pg_namespace
+WHERE nspname = 'audit'
+`).Scan(&auditSchemaCount)
+		c.Assert(err, qt.IsNil)
+		c.Assert(auditSchemaCount, qt.Equals, 0)
 		migrationSQL := readFirstMatchingFile(
 			c,
 			migrationsDir,

--- a/integration/atlas_migrate_diff_mysql_e2e_test.go
+++ b/integration/atlas_migrate_diff_mysql_e2e_test.go
@@ -14,12 +14,18 @@ import (
 
 	qt "github.com/frankban/quicktest"
 	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
 type mySQLMigrateDiffCase struct {
-	name        string
-	adminDSNEnv string
-	adminURLEnv string
+	name            string
+	adminDSNEnv     string
+	adminURLEnv     string
+	expectedDialect string
+	staleDDL        []string
 }
 
 func TestAtlasMigrateDiffMySQLFamilyDatabaseDesiredStateE2E(t *testing.T) {
@@ -33,14 +39,35 @@ func TestAtlasMigrateDiffMySQLFamilyDatabaseDesiredStateE2E(t *testing.T) {
 
 	tests := []mySQLMigrateDiffCase{
 		{
-			name:        "mysql",
-			adminDSNEnv: "MYSQL_ADMIN_TEST_DSN",
-			adminURLEnv: "MYSQL_ADMIN_TEST_URL",
+			name:            "mysql",
+			adminDSNEnv:     "MYSQL_ADMIN_TEST_DSN",
+			adminURLEnv:     "MYSQL_ADMIN_TEST_URL",
+			expectedDialect: platform.MySQL,
+			staleDDL: []string{
+				"CREATE VIEW `%s`.`stale_dev_view` AS SELECT 1 AS id",
+				"CREATE FUNCTION `%s`.`stale_dev_function`() RETURNS INTEGER DETERMINISTIC NO SQL RETURN 1",
+				"CREATE PROCEDURE `%s`.`stale_dev_procedure`() SELECT 1",
+				"CREATE EVENT `%s`.`stale_dev_event` ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR DO SELECT 1",
+			},
 		},
 		{
-			name:        "mariadb",
-			adminDSNEnv: "MARIADB_ADMIN_TEST_DSN",
-			adminURLEnv: "MARIADB_ADMIN_TEST_URL",
+			name:            "mariadb",
+			adminDSNEnv:     "MARIADB_ADMIN_TEST_DSN",
+			adminURLEnv:     "MARIADB_ADMIN_TEST_URL",
+			expectedDialect: platform.MariaDB,
+			staleDDL: []string{
+				"CREATE VIEW `%s`.`stale_dev_view` AS SELECT 1 AS id",
+				"CREATE FUNCTION `%s`.`stale_dev_function`() RETURNS INTEGER DETERMINISTIC NO SQL RETURN 1",
+				"CREATE PROCEDURE `%s`.`stale_dev_procedure`() SELECT 1",
+				"CREATE EVENT `%s`.`stale_dev_event` ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR DO SELECT 1",
+				"CREATE SEQUENCE `%s`.`stale_dev_sequence` START WITH 1",
+				"CREATE TABLE `%s`.`stale_dev_versioned` (" + `
+					id BIGINT PRIMARY KEY,
+					row_start TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
+					row_end TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
+					PERIOD FOR SYSTEM_TIME (row_start, row_end)
+				) WITH SYSTEM VERSIONING`,
+			},
 		},
 	}
 
@@ -68,10 +95,16 @@ func runMySQLMigrateDiffCase(
 	suffix := time.Now().UnixNano()
 	desiredName := fmt.Sprintf("ptah_diff_desired_%d", suffix)
 	devName := fmt.Sprintf("ptah_diff_dev_%d", suffix)
+	applyName := fmt.Sprintf("ptah_diff_apply_%d", suffix)
+	externalName := fmt.Sprintf("ptah_diff_external_%d", suffix)
 	createMySQLDatabase(c, ctx, adminDB, desiredName)
 	defer dropMySQLDatabase(c, context.Background(), adminDB, desiredName)
 	createMySQLDatabase(c, ctx, adminDB, devName)
 	defer dropMySQLDatabase(c, context.Background(), adminDB, devName)
+	createMySQLDatabase(c, ctx, adminDB, applyName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, applyName)
+	createMySQLDatabase(c, ctx, adminDB, externalName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, externalName)
 
 	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
 		"CREATE TABLE `%s`.`desired_database_items` (id BIGINT PRIMARY KEY, name VARCHAR(255) NOT NULL)",
@@ -81,9 +114,73 @@ func runMySQLMigrateDiffCase(
 
 	desiredURL := replaceMySQLDatabaseName(c, adminURL, desiredName)
 	devURL := replaceMySQLDatabaseName(c, adminURL, devName)
+	publicConnection, err := dbschema.ConnectToDatabase(ctx, asMySQLURL(desiredURL))
+	c.Assert(err, qt.IsNil)
+	defer publicConnection.Close()
+	c.Assert(publicConnection.Info().Dialect, qt.Equals, test.expectedDialect)
+
+	for _, ddl := range test.staleDDL {
+		_, err = adminDB.ExecContext(ctx, fmt.Sprintf(ddl, devName))
+		c.Assert(err, qt.IsNil)
+	}
+	_, err = adminDB.ExecContext(
+		ctx,
+		fmt.Sprintf("CREATE TABLE `%s`.`dependency_parent` (id BIGINT PRIMARY KEY)", devName),
+	)
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE VIEW `%s`.`external_parent_view` AS SELECT id FROM `%s`.`dependency_parent`",
+		externalName,
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+	rejectionDir := c.TempDir()
+	rejectionMigrationsDir := filepath.Join(rejectionDir, "migrations")
+	output, err := runPtah(ctx, rejectionDir, binaryPath,
+		"migrate", "diff",
+		"--to", desiredURL,
+		"--dev-url", devURL,
+		"--dir", "file://"+rejectionMigrationsDir,
+		"must_reject_external_view",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(output, qt.Contains, "views from other databases reference it")
+	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "dependency_parent"), qt.Equals, 1)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, externalName, "external_parent_view"), qt.Equals, 1)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("DROP VIEW `%s`.`external_parent_view`", externalName))
+	c.Assert(err, qt.IsNil)
+
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE %[1]s.external_child (
+	id BIGINT PRIMARY KEY,
+	parent_id BIGINT,
+	CONSTRAINT fk_external_parent
+		FOREIGN KEY (parent_id) REFERENCES %[2]s.dependency_parent(id)
+)`, sqlident.Quote(platform.MySQL, externalName), sqlident.Quote(platform.MySQL, devName)))
+	c.Assert(err, qt.IsNil)
+
+	foreignKeyRejectionDir := c.TempDir()
+	foreignKeyRejectionMigrationsDir := filepath.Join(foreignKeyRejectionDir, "migrations")
+	output, err = runPtah(ctx, foreignKeyRejectionDir, binaryPath,
+		"migrate", "diff",
+		"--to", desiredURL,
+		"--dev-url", devURL,
+		"--dir", "file://"+foreignKeyRejectionMigrationsDir,
+		"must_reject_external_foreign_key",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(output, qt.Contains, "foreign key constraints from other databases reference it")
+	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "dependency_parent"), qt.Equals, 1)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, externalName, "external_child"), qt.Equals, 1)
+
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE `%s`", externalName))
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("DROP TABLE `%s`.`dependency_parent`", devName))
+	c.Assert(err, qt.IsNil)
+
 	workDir := c.TempDir()
 	migrationsDir := filepath.Join(workDir, "migrations")
-	output, err := runPtah(ctx, workDir, binaryPath,
+	output, err = runPtah(ctx, workDir, binaryPath,
 		"migrate", "diff",
 		"--to", desiredURL,
 		"--dev-url", devURL,
@@ -94,6 +191,16 @@ func runMySQLMigrateDiffCase(
 	migrationSQL := readFirstMatchingFile(c, migrationsDir, "*_add_database_items.sql")
 	c.Assert(migrationSQL, qt.Contains, "CREATE TABLE")
 	c.Assert(migrationSQL, qt.Contains, "desired_database_items")
+	c.Assert(mySQLUserObjectCount(c, ctx, adminDB, devName), qt.Equals, 0)
+
+	applyURL := replaceMySQLDatabaseName(c, adminURL, applyName)
+	output, err = runPtah(ctx, workDir, binaryPath,
+		"migrate", "apply",
+		"--url", applyURL,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+	c.Assert(mySQLTableCount(c, ctx, adminDB, applyName, "desired_database_items"), qt.Equals, 1)
 
 	output, err = runPtah(ctx, workDir, binaryPath,
 		"migrate", "diff",
@@ -105,7 +212,12 @@ func runMySQLMigrateDiffCase(
 	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
 	c.Assert(output, qt.Contains, "The migration directory is synced with the desired state")
 	c.Assert(mySQLTableCount(c, ctx, adminDB, desiredName, "desired_database_items"), qt.Equals, 1)
-	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "desired_database_items"), qt.Equals, 1)
+	c.Assert(mySQLUserObjectCount(c, ctx, adminDB, devName), qt.Equals, 0)
+}
+
+func asMySQLURL(rawURL string) string {
+	withoutScheme := strings.TrimPrefix(strings.TrimPrefix(rawURL, "mysql://"), "mariadb://")
+	return "mysql://" + withoutScheme
 }
 
 func requireIntegrationEnvironment(c *qt.C, name string) string {
@@ -155,6 +267,36 @@ func mySQLTableCount(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
 		database,
 		table,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func mySQLUserObjectCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	database string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(
+		ctx,
+		`SELECT SUM(object_count)
+		FROM (
+			SELECT COUNT(*) AS object_count
+			FROM information_schema.tables
+			WHERE table_schema = ?
+			UNION ALL
+			SELECT COUNT(*)
+			FROM information_schema.routines
+			WHERE routine_schema = ?
+			UNION ALL
+			SELECT COUNT(*)
+			FROM information_schema.events
+			WHERE event_schema = ?
+		) AS user_objects`,
+		database, database, database,
 	).Scan(&count)
 	c.Assert(err, qt.IsNil)
 	return count

--- a/integration/atlas_migrate_diff_mysql_e2e_test.go
+++ b/integration/atlas_migrate_diff_mysql_e2e_test.go
@@ -5,18 +5,22 @@ package integration_test
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	_ "github.com/go-sql-driver/mysql"
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
+	mysqlschema "github.com/stokaro/ptah/internal/dbschema/mysql"
 	"github.com/stokaro/ptah/internal/sqlident"
 )
 
@@ -26,6 +30,29 @@ type mySQLMigrateDiffCase struct {
 	adminURLEnv     string
 	expectedDialect string
 	staleDDL        []string
+}
+
+type mySQLCleanupRaceCase struct {
+	name               string
+	externalDDL        string
+	externalObjectName string
+}
+
+type mySQLUnlockGate struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+type mySQLUnlockGateConnector struct {
+	driver.Connector
+	gate *mySQLUnlockGate
+}
+
+type mySQLUnlockGateConn struct {
+	driver.Conn
+	gate *mySQLUnlockGate
 }
 
 func TestAtlasMigrateDiffMySQLFamilyDatabaseDesiredStateE2E(t *testing.T) {
@@ -75,6 +102,445 @@ func TestAtlasMigrateDiffMySQLFamilyDatabaseDesiredStateE2E(t *testing.T) {
 		c.Run(test.name, func(c *qt.C) {
 			runMySQLMigrateDiffCase(c, ctx, binaryPath, test)
 		})
+	}
+}
+
+func TestMySQLFamilyLockedDropRejectsConcurrentDependenciesE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	engines := []struct {
+		config mySQLMigrateDiffCase
+		races  []mySQLCleanupRaceCase
+	}{
+		{
+			config: mySQLMigrateDiffCase{
+				name:        "mysql",
+				adminDSNEnv: "MYSQL_ADMIN_TEST_DSN",
+			},
+			races: []mySQLCleanupRaceCase{
+				{
+					name: "external view",
+					externalDDL: "CREATE VIEW `%[1]s`.`racing_view` AS " +
+						"SELECT id FROM `%[2]s`.`dependency_parent`",
+					externalObjectName: "racing_view",
+				},
+				{
+					name: "external foreign key",
+					externalDDL: "CREATE TABLE `%[1]s`.`racing_child` (" +
+						"id BIGINT PRIMARY KEY, parent_id BIGINT, " +
+						"CONSTRAINT `fk_racing_parent` FOREIGN KEY (parent_id) " +
+						"REFERENCES `%[2]s`.`dependency_parent` (id))",
+					externalObjectName: "racing_child",
+				},
+			},
+		},
+		{
+			config: mySQLMigrateDiffCase{
+				name:        "mariadb",
+				adminDSNEnv: "MARIADB_ADMIN_TEST_DSN",
+			},
+			races: []mySQLCleanupRaceCase{
+				{
+					name: "external view",
+					externalDDL: "CREATE VIEW `%[1]s`.`racing_view` AS " +
+						"SELECT id FROM `%[2]s`.`dependency_parent`",
+					externalObjectName: "racing_view",
+				},
+			},
+		},
+	}
+
+	for _, engine := range engines {
+		c.Run(engine.config.name, func(c *qt.C) {
+			for _, race := range engine.races {
+				c.Run(race.name, func(c *qt.C) {
+					runMySQLLockedDropRace(c, ctx, engine.config, race)
+				})
+			}
+		})
+	}
+}
+
+func TestMariaDBLockedDropFailsClosedForConcurrentForeignKeyE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	runMariaDBLockedDropForeignKeyFailClosed(c, ctx)
+}
+
+func TestMySQLFamilyDropViewUnderExplicitLockIsRejectedE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	engines := []mySQLMigrateDiffCase{
+		{
+			name:        "mysql",
+			adminDSNEnv: "MYSQL_ADMIN_TEST_DSN",
+		},
+		{
+			name:        "mariadb",
+			adminDSNEnv: "MARIADB_ADMIN_TEST_DSN",
+		},
+	}
+
+	for _, engine := range engines {
+		c.Run(engine.name, func(c *qt.C) {
+			runMySQLLockedViewDrop(c, ctx, engine)
+		})
+	}
+}
+
+func TestMySQLFamilyProtectedViewDropWinsMetadataLockHandoffE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	engines := []mySQLMigrateDiffCase{
+		{
+			name:            "mysql",
+			adminDSNEnv:     "MYSQL_ADMIN_TEST_DSN",
+			expectedDialect: platform.MySQL,
+		},
+		{
+			name:            "mariadb",
+			adminDSNEnv:     "MARIADB_ADMIN_TEST_DSN",
+			expectedDialect: platform.MariaDB,
+		},
+	}
+
+	for _, engine := range engines {
+		c.Run(engine.name, func(c *qt.C) {
+			runMySQLProtectedViewDropHandoff(c, ctx, engine)
+		})
+	}
+}
+
+func runMySQLLockedDropRace(
+	c *qt.C,
+	ctx context.Context,
+	engine mySQLMigrateDiffCase,
+	race mySQLCleanupRaceCase,
+) {
+	c.Helper()
+	adminDSN := requireIntegrationEnvironment(c, engine.adminDSNEnv)
+	adminDB, err := sql.Open("mysql", adminDSN)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+	c.Assert(adminDB.PingContext(ctx), qt.IsNil)
+
+	suffix := time.Now().UnixNano()
+	devName := fmt.Sprintf("ptah_cleanup_race_dev_%d", suffix)
+	externalName := fmt.Sprintf("ptah_cleanup_race_external_%d", suffix)
+	createMySQLDatabase(c, ctx, adminDB, devName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, devName)
+	createMySQLDatabase(c, ctx, adminDB, externalName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, externalName)
+
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s`.`dependency_parent` (id BIGINT PRIMARY KEY)",
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+
+	lockConn, err := adminDB.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer lockConn.Close()
+	defer func() {
+		_, unlockErr := lockConn.ExecContext(context.Background(), "UNLOCK TABLES")
+		c.Check(unlockErr, qt.IsNil)
+	}()
+
+	lockSQL := fmt.Sprintf("LOCK TABLES `%s`.`dependency_parent` WRITE", devName)
+	_, err = lockConn.ExecContext(ctx, lockSQL)
+	c.Assert(err, qt.IsNil)
+
+	externalSQL := fmt.Sprintf(race.externalDDL, externalName, devName)
+	externalDone := make(chan error, 1)
+	go func() {
+		_, createErr := adminDB.ExecContext(ctx, externalSQL)
+		externalDone <- createErr
+	}()
+	c.Assert(waitForMySQLMetadataWait(ctx, adminDB, externalSQL), qt.IsNil)
+
+	dropSQL := fmt.Sprintf("DROP TABLE `%s`.`dependency_parent`", devName)
+	_, err = lockConn.ExecContext(ctx, dropSQL)
+	c.Assert(err, qt.IsNil)
+	_, err = lockConn.ExecContext(ctx, "UNLOCK TABLES")
+	c.Assert(err, qt.IsNil)
+	c.Assert(<-externalDone, qt.IsNotNil)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "dependency_parent"), qt.Equals, 0)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, externalName, race.externalObjectName), qt.Equals, 0)
+}
+
+func runMySQLLockedViewDrop(
+	c *qt.C,
+	ctx context.Context,
+	engine mySQLMigrateDiffCase,
+) {
+	c.Helper()
+	adminDSN := requireIntegrationEnvironment(c, engine.adminDSNEnv)
+	adminDB, err := sql.Open("mysql", adminDSN)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+	c.Assert(adminDB.PingContext(ctx), qt.IsNil)
+
+	database := fmt.Sprintf("ptah_locked_view_drop_%d", time.Now().UnixNano())
+	createMySQLDatabase(c, ctx, adminDB, database)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, database)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s`.`source_table` (id BIGINT PRIMARY KEY)",
+		database,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE VIEW `%s`.`managed_view` AS SELECT id FROM `%s`.`source_table`",
+		database,
+		database,
+	))
+	c.Assert(err, qt.IsNil)
+
+	lockConn, err := adminDB.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, fmt.Sprintf(
+		"LOCK TABLES `%s`.`managed_view` WRITE",
+		database,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = lockConn.ExecContext(ctx, fmt.Sprintf(
+		"DROP VIEW `%s`.`managed_view`",
+		database,
+	))
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "active locked tables")
+	_, err = lockConn.ExecContext(ctx, "UNLOCK TABLES")
+	c.Assert(err, qt.IsNil)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, database, "managed_view"), qt.Equals, 1)
+}
+
+func runMySQLProtectedViewDropHandoff(
+	c *qt.C,
+	ctx context.Context,
+	engine mySQLMigrateDiffCase,
+) {
+	c.Helper()
+	adminDSN := requireIntegrationEnvironment(c, engine.adminDSNEnv)
+	adminDB, err := sql.Open("mysql", adminDSN)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+	c.Assert(adminDB.PingContext(ctx), qt.IsNil)
+
+	suffix := time.Now().UnixNano()
+	devName := fmt.Sprintf("ptah_view_handoff_dev_%d", suffix)
+	externalName := fmt.Sprintf("ptah_view_handoff_external_%d", suffix)
+	createMySQLDatabase(c, ctx, adminDB, devName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, devName)
+	createMySQLDatabase(c, ctx, adminDB, externalName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, externalName)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s`.`source_table` (id BIGINT PRIMARY KEY)",
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE VIEW `%[1]s`.`managed_view` AS SELECT id FROM `%[1]s`.`source_table`",
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+
+	config, err := mysqldriver.ParseDSN(adminDSN)
+	c.Assert(err, qt.IsNil)
+	config.DBName = devName
+	connector, err := mysqldriver.NewConnector(config)
+	c.Assert(err, qt.IsNil)
+	gate := newMySQLUnlockGate()
+	cleanupDB := sql.OpenDB(&mySQLUnlockGateConnector{
+		Connector: connector,
+		gate:      gate,
+	})
+	defer cleanupDB.Close()
+	defer gate.releaseUnlock()
+
+	writer := mysqlschema.NewMySQLWriter(cleanupDB, devName, engine.expectedDialect)
+	cleanupDone := make(chan error, 1)
+	go func() {
+		cleanupDone <- writer.DropAllTables(ctx)
+	}()
+
+	dropSQL := fmt.Sprintf("DROP VIEW IF EXISTS `%s`.`managed_view`", devName)
+	c.Assert(waitForMySQLUnlockGate(ctx, gate.started), qt.IsNil)
+	c.Assert(waitForMySQLMetadataWait(ctx, adminDB, dropSQL), qt.IsNil)
+
+	//nolint:gosec // G201: generated catalog identifiers are emitted only through identifier quoting.
+	competitorSQL := fmt.Sprintf(
+		"CREATE VIEW %s AS SELECT id FROM %s",
+		sqlident.Qualified(platform.MySQL, externalName, "competing_view"),
+		sqlident.Qualified(platform.MySQL, devName, "managed_view"),
+	)
+	competitorDone := make(chan error, 1)
+	go func() {
+		_, createErr := adminDB.ExecContext(ctx, competitorSQL)
+		competitorDone <- createErr
+	}()
+	c.Assert(waitForMySQLMetadataWait(ctx, adminDB, competitorSQL), qt.IsNil)
+
+	gate.releaseUnlock()
+	c.Assert(<-cleanupDone, qt.IsNil)
+	c.Assert(<-competitorDone, qt.IsNotNil)
+	c.Assert(mySQLUserObjectCount(c, ctx, adminDB, devName), qt.Equals, 0)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, externalName, "competing_view"), qt.Equals, 0)
+}
+
+func runMariaDBLockedDropForeignKeyFailClosed(c *qt.C, ctx context.Context) {
+	c.Helper()
+	adminDSN := requireIntegrationEnvironment(c, "MARIADB_ADMIN_TEST_DSN")
+	adminDB, err := sql.Open("mysql", adminDSN)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+	c.Assert(adminDB.PingContext(ctx), qt.IsNil)
+
+	suffix := time.Now().UnixNano()
+	devName := fmt.Sprintf("ptah_locked_fk_dev_%d", suffix)
+	externalName := fmt.Sprintf("ptah_locked_fk_external_%d", suffix)
+	createMySQLDatabase(c, ctx, adminDB, devName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, devName)
+	createMySQLDatabase(c, ctx, adminDB, externalName)
+	defer dropMySQLDatabase(c, context.Background(), adminDB, externalName)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%s`.`dependency_parent` (id BIGINT PRIMARY KEY)",
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+
+	lockConn, err := adminDB.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, fmt.Sprintf(
+		"LOCK TABLES `%s`.`dependency_parent` WRITE",
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE `%[1]s`.`racing_child` ("+
+			"id BIGINT PRIMARY KEY, parent_id BIGINT, "+
+			"CONSTRAINT `fk_racing_parent` FOREIGN KEY (parent_id) "+
+			"REFERENCES `%[2]s`.`dependency_parent` (id))",
+		externalName,
+		devName,
+	))
+	c.Assert(err, qt.IsNil)
+
+	_, err = lockConn.ExecContext(ctx, fmt.Sprintf(
+		"DROP TABLE IF EXISTS `%s`.`dependency_parent`",
+		devName,
+	))
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "foreign key constraint fails")
+	_, err = lockConn.ExecContext(ctx, "UNLOCK TABLES")
+	c.Assert(err, qt.IsNil)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "dependency_parent"), qt.Equals, 1)
+	c.Assert(mySQLTableCount(c, ctx, adminDB, externalName, "racing_child"), qt.Equals, 1)
+	c.Assert(mySQLForeignKeyCount(c, ctx, adminDB, externalName, "fk_racing_parent"), qt.Equals, 1)
+}
+
+func waitForMySQLMetadataWait(
+	ctx context.Context,
+	db *sql.DB,
+	statement string,
+) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		var count int
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM information_schema.processlist
+			WHERE state = 'Waiting for table metadata lock'
+			  AND info = ?
+		`, statement).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("inspect MySQL metadata wait: %w", err)
+		}
+		if count > 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for MySQL metadata lock on %q: %w", statement, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func newMySQLUnlockGate() *mySQLUnlockGate {
+	return &mySQLUnlockGate{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (gate *mySQLUnlockGate) releaseUnlock() {
+	gate.releaseOnce.Do(func() {
+		close(gate.release)
+	})
+}
+
+func (c *mySQLUnlockGateConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.Connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &mySQLUnlockGateConn{
+		Conn: conn,
+		gate: c.gate,
+	}, nil
+}
+
+func (conn *mySQLUnlockGateConn) ExecContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Result, error) {
+	execer, ok := conn.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	if strings.EqualFold(strings.TrimSpace(query), "UNLOCK TABLES") {
+		conn.gate.startedOnce.Do(func() {
+			close(conn.gate.started)
+		})
+		select {
+		case <-conn.gate.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return execer.ExecContext(ctx, query, args)
+}
+
+func (conn *mySQLUnlockGateConn) QueryContext(
+	ctx context.Context,
+	query string,
+	args []driver.NamedValue,
+) (driver.Rows, error) {
+	queryer, ok := conn.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return queryer.QueryContext(ctx, query, args)
+}
+
+func waitForMySQLUnlockGate(ctx context.Context, started <-chan struct{}) error {
+	select {
+	case <-started:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for protected view-drop unlock: %w", ctx.Err())
 	}
 }
 
@@ -128,6 +594,38 @@ func runMySQLMigrateDiffCase(
 		fmt.Sprintf("CREATE TABLE `%s`.`dependency_parent` (id BIGINT PRIMARY KEY)", devName),
 	)
 	c.Assert(err, qt.IsNil)
+
+	limitedUser := fmt.Sprintf("ptah_limited_%d", suffix)
+	const limitedPassword = "Ptah842!Limited"
+	createMySQLUser(c, ctx, adminDB, limitedUser, limitedPassword)
+	defer dropMySQLUser(c, context.Background(), adminDB, limitedUser)
+	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
+		"GRANT ALL PRIVILEGES ON `%s`.* TO '%s'@'%%'",
+		devName,
+		limitedUser,
+	))
+	c.Assert(err, qt.IsNil)
+
+	limitedRejectionDir := c.TempDir()
+	limitedMigrationsDir := filepath.Join(limitedRejectionDir, "migrations")
+	limitedDevURL := replaceMySQLCredentials(
+		c,
+		devURL,
+		limitedUser,
+		limitedPassword,
+	)
+	output, err := runPtah(ctx, limitedRejectionDir, binaryPath,
+		"migrate", "diff",
+		"--to", desiredURL,
+		"--dev-url", limitedDevURL,
+		"--dir", "file://"+limitedMigrationsDir,
+		"must_reject_limited_metadata",
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(output, qt.Contains, "global SELECT")
+	c.Assert(output, qt.Contains, "complete metadata visibility")
+	c.Assert(mySQLTableCount(c, ctx, adminDB, devName, "dependency_parent"), qt.Equals, 1)
+
 	_, err = adminDB.ExecContext(ctx, fmt.Sprintf(
 		"CREATE VIEW `%s`.`external_parent_view` AS SELECT id FROM `%s`.`dependency_parent`",
 		externalName,
@@ -136,7 +634,7 @@ func runMySQLMigrateDiffCase(
 	c.Assert(err, qt.IsNil)
 	rejectionDir := c.TempDir()
 	rejectionMigrationsDir := filepath.Join(rejectionDir, "migrations")
-	output, err := runPtah(ctx, rejectionDir, binaryPath,
+	output, err = runPtah(ctx, rejectionDir, binaryPath,
 		"migrate", "diff",
 		"--to", desiredURL,
 		"--dev-url", devURL,
@@ -175,8 +673,18 @@ CREATE TABLE %[1]s.external_child (
 
 	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE `%s`", externalName))
 	c.Assert(err, qt.IsNil)
-	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("DROP TABLE `%s`.`dependency_parent`", devName))
-	c.Assert(err, qt.IsNil)
+
+	managedViewCleanupDir := c.TempDir()
+	managedViewMigrationsDir := filepath.Join(managedViewCleanupDir, "migrations")
+	output, err = runPtah(ctx, managedViewCleanupDir, binaryPath,
+		"migrate", "diff",
+		"--to", desiredURL,
+		"--dev-url", devURL,
+		"--dir", "file://"+managedViewMigrationsDir,
+		"clean_managed_view",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+	c.Assert(mySQLUserObjectCount(c, ctx, adminDB, devName), qt.Equals, 0)
 
 	workDir := c.TempDir()
 	migrationsDir := filepath.Join(workDir, "migrations")
@@ -241,6 +749,51 @@ func replaceMySQLDatabaseName(c *qt.C, rawURL, database string) string {
 	return replaced
 }
 
+func replaceMySQLCredentials(
+	c *qt.C,
+	rawURL,
+	username,
+	password string,
+) string {
+	c.Helper()
+	schemeEnd := strings.Index(rawURL, "://")
+	c.Assert(schemeEnd >= 0, qt.IsTrue)
+	authorityStart := schemeEnd + len("://")
+	pathOffset := strings.Index(rawURL[authorityStart:], "/")
+	c.Assert(pathOffset >= 0, qt.IsTrue)
+	pathStart := authorityStart + pathOffset
+	authority := rawURL[authorityStart:pathStart]
+	at := strings.LastIndex(authority, "@")
+	c.Assert(at >= 0, qt.IsTrue)
+	credentials := url.UserPassword(username, password).String()
+	if strings.Contains(rawURL, "@tcp(") {
+		credentials = username + ":" + password
+	}
+	return rawURL[:authorityStart] + credentials + "@" + authority[at+1:] + rawURL[pathStart:]
+}
+
+func createMySQLUser(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	username,
+	password string,
+) {
+	c.Helper()
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE USER '%s'@'%%' IDENTIFIED BY '%s'",
+		username,
+		password,
+	))
+	c.Assert(err, qt.IsNil)
+}
+
+func dropMySQLUser(c *qt.C, ctx context.Context, db *sql.DB, username string) {
+	c.Helper()
+	_, err := db.ExecContext(ctx, fmt.Sprintf("DROP USER IF EXISTS '%s'@'%%'", username))
+	c.Check(err, qt.IsNil)
+}
+
 func createMySQLDatabase(c *qt.C, ctx context.Context, db *sql.DB, name string) {
 	c.Helper()
 	_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", name))
@@ -267,6 +820,28 @@ func mySQLTableCount(
 		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
 		database,
 		table,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func mySQLForeignKeyCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	database,
+	constraint string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*)
+		FROM information_schema.referential_constraints
+		WHERE constraint_schema = ?
+		  AND constraint_name = ?`,
+		database,
+		constraint,
 	).Scan(&count)
 	c.Assert(err, qt.IsNil)
 	return count

--- a/integration/atlas_migrate_diff_postgres_family_e2e_test.go
+++ b/integration/atlas_migrate_diff_postgres_family_e2e_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+type postgresFamilyMigrateDiffCase struct {
+	name   string
+	urlEnv string
+}
+
+func TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 6*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah")
+	buildPtah(c, ctx, repoRoot, binaryPath)
+
+	tests := []postgresFamilyMigrateDiffCase{
+		{name: "cockroachdb", urlEnv: "COCKROACHDB_URL"},
+		{name: "yugabytedb", urlEnv: "YUGABYTEDB_URL"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			runPostgresFamilyMigrateDiffCase(c, ctx, binaryPath, test)
+		})
+	}
+}
+
+func runPostgresFamilyMigrateDiffCase(
+	c *qt.C,
+	ctx context.Context,
+	binaryPath string,
+	test postgresFamilyMigrateDiffCase,
+) {
+	c.Helper()
+	adminURL := requireIntegrationEnvironment(c, test.urlEnv)
+	adminDB, err := sql.Open("pgx", postgresFamilyDriverURL(c, adminURL))
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+	c.Assert(adminDB.PingContext(ctx), qt.IsNil)
+
+	suffix := time.Now().UnixNano()
+	desiredName := fmt.Sprintf("ptah_diff_desired_%d", suffix)
+	devName := fmt.Sprintf("ptah_diff_dev_%d", suffix)
+	applyName := fmt.Sprintf("ptah_diff_apply_%d", suffix)
+	createE2EDatabase(c, ctx, adminDB, desiredName)
+	defer dropPostgresFamilyE2EDatabase(c, adminDB, desiredName)
+	createE2EDatabase(c, ctx, adminDB, devName)
+	defer dropPostgresFamilyE2EDatabase(c, adminDB, devName)
+	createE2EDatabase(c, ctx, adminDB, applyName)
+	defer dropPostgresFamilyE2EDatabase(c, adminDB, applyName)
+
+	desiredURL := replaceDatabaseName(c, adminURL, desiredName)
+	devURL := replaceDatabaseName(c, adminURL, devName)
+	applyURL := replaceDatabaseName(c, adminURL, applyName)
+	execPostgresFamilySQL(c, ctx, desiredURL, `
+		CREATE TABLE desired_items (
+			id BIGINT PRIMARY KEY,
+			name TEXT NOT NULL
+		)`)
+	execPostgresFamilySQL(c, ctx, devURL, `
+		CREATE TABLE stale_parent (id BIGINT PRIMARY KEY);
+		CREATE VIEW stale_parent_view AS SELECT id FROM stale_parent`)
+
+	dir := c.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	output, err := runPtah(ctx, dir, binaryPath,
+		"migrate", "diff",
+		"--to", desiredURL,
+		"--dev-url", devURL,
+		"--dir", "file://"+migrationsDir,
+		"add_items")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+	migrationSQL := readFirstMatchingFile(c, migrationsDir, "*_add_items.sql")
+	c.Assert(migrationSQL, qt.Contains, "CREATE TABLE")
+	c.Assert(migrationSQL, qt.Contains, "desired_items")
+	c.Assert(postgresFamilyObjectCount(c, ctx, desiredURL), qt.Equals, 1)
+	c.Assert(postgresFamilyObjectCount(c, ctx, devURL), qt.Equals, 0)
+
+	output, err = runPtah(ctx, c.TempDir(), binaryPath,
+		"migrate", "apply",
+		"--url", applyURL,
+		"--dir", "file://"+migrationsDir)
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))
+	c.Assert(e2eTableCount(c, ctx, postgresFamilyDriverURL(c, applyURL), "desired_items"), qt.Equals, 1)
+}
+
+func postgresFamilyDriverURL(c *qt.C, rawURL string) string {
+	c.Helper()
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Scheme = "postgres"
+	return parsed.String()
+}
+
+func execPostgresFamilySQL(c *qt.C, ctx context.Context, dbURL, sqlExpr string) {
+	c.Helper()
+	db, err := sql.Open("pgx", postgresFamilyDriverURL(c, dbURL))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	_, err = db.ExecContext(ctx, sqlExpr)
+	c.Assert(err, qt.IsNil)
+}
+
+func postgresFamilyObjectCount(c *qt.C, ctx context.Context, dbURL string) int {
+	c.Helper()
+	db, err := sql.Open("pgx", postgresFamilyDriverURL(c, dbURL))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	var count int
+	err = db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.tables
+		WHERE table_schema = 'public'
+		  AND table_type IN ('BASE TABLE', 'VIEW')
+		  AND table_name <> 'schema_migrations'
+	`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func dropPostgresFamilyE2EDatabase(c *qt.C, adminDB *sql.DB, name string) {
+	c.Helper()
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := adminDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteE2EIdent(name))
+	c.Assert(err, qt.IsNil)
+}

--- a/integration/atlas_migrate_diff_postgres_family_e2e_test.go
+++ b/integration/atlas_migrate_diff_postgres_family_e2e_test.go
@@ -27,8 +27,8 @@ func TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E(t *testing.T) {
 	defer cancel()
 
 	repoRoot := e2eRepoRoot(t)
-	binaryPath := filepath.Join(t.TempDir(), "ptah")
-	buildPtah(c, ctx, repoRoot, binaryPath)
+	binaryPath := filepath.Join(t.TempDir(), "ptah-compat")
+	buildPtahCompat(c, ctx, repoRoot, binaryPath)
 
 	tests := []postgresFamilyMigrateDiffCase{
 		{name: "cockroachdb", urlEnv: "COCKROACHDB_URL"},

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -100,10 +100,13 @@ type TestScenario struct {
 	TestFunc    func(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error
 	// Optional enhanced test function that supports step recording
 	EnhancedTestFunc func(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error
-	// UseCleanupConnection runs the scenario itself with the cleanup URL. Set
-	// this only for scenarios that intentionally exercise destructive reset
-	// operations requiring broader privileges.
-	UseCleanupConnection bool
+	cleanupTestFunc  func(
+		ctx context.Context,
+		conn *dbschema.DatabaseConnection,
+		fixtures fs.FS,
+		recorder *StepRecorder,
+		cleanup databaseCleanupFunc,
+	) error
 	// ClickHouseCompatible opts a scenario in to running against a live
 	// ClickHouse connection. Default false because most existing scenarios
 	// exercise features ClickHouse cannot meaningfully support (functions,
@@ -128,6 +131,13 @@ type TestScenario struct {
 	SQLServerCompatible bool
 }
 
+// IsRunnable reports whether the scenario has an executable test function.
+func (s TestScenario) IsRunnable() bool {
+	return s.TestFunc != nil ||
+		s.EnhancedTestFunc != nil ||
+		s.cleanupTestFunc != nil
+}
+
 // TestRunner manages and executes integration tests
 type TestRunner struct {
 	scenarios []TestScenario
@@ -141,6 +151,8 @@ type databaseTarget struct {
 	connectionURL string
 	cleanupURL    string
 }
+
+type databaseCleanupFunc func(context.Context) error
 
 // NewTestRunner creates a new test runner
 func NewTestRunner(fixtures fs.FS) *TestRunner {
@@ -293,25 +305,8 @@ func (tr *TestRunner) runSingleTest(
 		return result
 	}
 
-	executionConn := conn
-	if scenario.UseCleanupConnection && target.cleanupURL != target.connectionURL {
-		executionConn, err = dbschema.ConnectToDatabase(ctx, target.cleanupURL)
-		if err != nil {
-			result.Success = false
-			result.Error = fmt.Sprintf("Failed to connect to cleanup database: %v", err)
-			result.Duration = time.Since(start)
-			return result
-		}
-		defer func() {
-			if cerr := executionConn.Close(); cerr != nil && result.Success {
-				result.Success = false
-				result.Error = fmt.Sprintf("Failed to close cleanup database connection: %v", cerr)
-			}
-		}()
-	}
-
 	// Clean database before test
-	if err := tr.cleanDatabase(ctx, executionConn, target.cleanupURL); err != nil {
+	if err := tr.cleanDatabase(ctx, conn, target.cleanupURL); err != nil {
 		result.Success = false
 		result.Error = fmt.Sprintf("Failed to clean database: %v", err)
 		result.Duration = time.Since(start)
@@ -321,11 +316,18 @@ func (tr *TestRunner) runSingleTest(
 	// Create step recorder
 	recorder := &StepRecorder{}
 
-	// Run the test scenario - use enhanced function if available, otherwise use regular function
-	if scenario.EnhancedTestFunc != nil {
-		err = scenario.EnhancedTestFunc(ctx, executionConn, tr.fixtures, recorder)
-	} else {
-		err = scenario.TestFunc(ctx, executionConn, tr.fixtures)
+	cleanup := func(cleanupCtx context.Context) error {
+		return tr.cleanDatabase(cleanupCtx, conn, target.cleanupURL)
+	}
+
+	// Run the test scenario - use cleanup-aware or enhanced functions when available.
+	switch {
+	case scenario.cleanupTestFunc != nil:
+		err = scenario.cleanupTestFunc(ctx, conn, tr.fixtures, recorder, cleanup)
+	case scenario.EnhancedTestFunc != nil:
+		err = scenario.EnhancedTestFunc(ctx, conn, tr.fixtures, recorder)
+	default:
+		err = scenario.TestFunc(ctx, conn, tr.fixtures)
 	}
 
 	if err != nil {
@@ -335,8 +337,8 @@ func (tr *TestRunner) runSingleTest(
 		result.Success = true
 	}
 
-	// Capture recorded steps (only if enhanced function was used)
-	if scenario.EnhancedTestFunc != nil {
+	// Capture recorded steps when the selected scenario function supports them.
+	if scenario.cleanupTestFunc != nil || scenario.EnhancedTestFunc != nil {
 		result.Steps = recorder.GetSteps()
 	}
 

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -98,6 +100,10 @@ type TestScenario struct {
 	TestFunc    func(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error
 	// Optional enhanced test function that supports step recording
 	EnhancedTestFunc func(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error
+	// UseCleanupConnection runs the scenario itself with the cleanup URL. Set
+	// this only for scenarios that intentionally exercise destructive reset
+	// operations requiring broader privileges.
+	UseCleanupConnection bool
 	// ClickHouseCompatible opts a scenario in to running against a live
 	// ClickHouse connection. Default false because most existing scenarios
 	// exercise features ClickHouse cannot meaningfully support (functions,
@@ -125,17 +131,22 @@ type TestScenario struct {
 // TestRunner manages and executes integration tests
 type TestRunner struct {
 	scenarios []TestScenario
-	databases map[string]string // name -> connection URL
+	databases map[string]databaseTarget
 	fixtures  fs.FS
 	report    *TestReport
 	mu        sync.Mutex
+}
+
+type databaseTarget struct {
+	connectionURL string
+	cleanupURL    string
 }
 
 // NewTestRunner creates a new test runner
 func NewTestRunner(fixtures fs.FS) *TestRunner {
 	return &TestRunner{
 		scenarios: make([]TestScenario, 0),
-		databases: make(map[string]string),
+		databases: make(map[string]databaseTarget),
 		fixtures:  fixtures,
 		report: &TestReport{
 			Results: make([]TestResult, 0),
@@ -143,9 +154,30 @@ func NewTestRunner(fixtures fs.FS) *TestRunner {
 	}
 }
 
-// AddDatabase adds a database connection for testing
+// AddDatabase adds a database connection used for both scenarios and cleanup.
 func (tr *TestRunner) AddDatabase(name, connectionURL string) {
-	tr.databases[name] = connectionURL
+	tr.databases[name] = databaseTarget{
+		connectionURL: connectionURL,
+		cleanupURL:    connectionURL,
+	}
+}
+
+// AddDatabaseWithCleanup adds separate scenario and cleanup credentials for
+// the same database. The cleanup URL may grant broader destructive privileges,
+// but it must not address a different database realm.
+func (tr *TestRunner) AddDatabaseWithCleanup(name, connectionURL, cleanupURL string) error {
+	sameDatabase, err := atlasurl.SameDatabase(connectionURL, cleanupURL)
+	if err != nil {
+		return fmt.Errorf("validate %s cleanup database URL: %w", name, err)
+	}
+	if !sameDatabase {
+		return fmt.Errorf("%s cleanup URL must address the scenario database", name)
+	}
+	tr.databases[name] = databaseTarget{
+		connectionURL: connectionURL,
+		cleanupURL:    cleanupURL,
+	}
+	return nil
 }
 
 // AddScenario adds a test scenario
@@ -157,9 +189,9 @@ func (tr *TestRunner) AddScenario(scenario TestScenario) {
 func (tr *TestRunner) RunAll(ctx context.Context) error {
 	tr.report.StartTime = time.Now()
 
-	for dbName, dbURL := range tr.databases {
+	for dbName, target := range tr.databases {
 		for _, scenario := range tr.scenarios {
-			result := tr.runSingleTest(ctx, scenario, dbName, dbURL)
+			result := tr.runSingleTest(ctx, scenario, dbName, target)
 			tr.mu.Lock()
 			tr.report.Results = append(tr.report.Results, result)
 			tr.report.TotalTests++
@@ -186,7 +218,12 @@ func (tr *TestRunner) RunAll(ctx context.Context) error {
 // The return value is named so the deferred Close handler can promote a
 // connection-close failure into a test failure when the scenario itself
 // succeeded — otherwise the close error would be silently lost.
-func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, dbName, dbURL string) (result TestResult) {
+func (tr *TestRunner) runSingleTest(
+	ctx context.Context,
+	scenario TestScenario,
+	dbName string,
+	target databaseTarget,
+) (result TestResult) {
 	start := time.Now()
 
 	result = TestResult{
@@ -196,7 +233,7 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 	}
 
 	// Connect to database
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	conn, err := dbschema.ConnectToDatabase(ctx, target.connectionURL)
 	if err != nil {
 		result.Success = false
 		result.Error = fmt.Sprintf("Failed to connect to database: %v", err)
@@ -256,8 +293,25 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 		return result
 	}
 
+	executionConn := conn
+	if scenario.UseCleanupConnection && target.cleanupURL != target.connectionURL {
+		executionConn, err = dbschema.ConnectToDatabase(ctx, target.cleanupURL)
+		if err != nil {
+			result.Success = false
+			result.Error = fmt.Sprintf("Failed to connect to cleanup database: %v", err)
+			result.Duration = time.Since(start)
+			return result
+		}
+		defer func() {
+			if cerr := executionConn.Close(); cerr != nil && result.Success {
+				result.Success = false
+				result.Error = fmt.Sprintf("Failed to close cleanup database connection: %v", cerr)
+			}
+		}()
+	}
+
 	// Clean database before test
-	if err := tr.cleanDatabase(ctx, conn); err != nil {
+	if err := tr.cleanDatabase(ctx, executionConn, target.cleanupURL); err != nil {
 		result.Success = false
 		result.Error = fmt.Sprintf("Failed to clean database: %v", err)
 		result.Duration = time.Since(start)
@@ -269,9 +323,9 @@ func (tr *TestRunner) runSingleTest(ctx context.Context, scenario TestScenario, 
 
 	// Run the test scenario - use enhanced function if available, otherwise use regular function
 	if scenario.EnhancedTestFunc != nil {
-		err = scenario.EnhancedTestFunc(ctx, conn, tr.fixtures, recorder)
+		err = scenario.EnhancedTestFunc(ctx, executionConn, tr.fixtures, recorder)
 	} else {
-		err = scenario.TestFunc(ctx, conn, tr.fixtures)
+		err = scenario.TestFunc(ctx, executionConn, tr.fixtures)
 	}
 
 	if err != nil {
@@ -300,12 +354,27 @@ func isPostgresDistributedSQL(dialect string) bool {
 }
 
 // cleanDatabase drops all scenario-owned objects and resets the database to a clean state.
-func (tr *TestRunner) cleanDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
+func (tr *TestRunner) cleanDatabase(
+	ctx context.Context,
+	scenarioConn *dbschema.DatabaseConnection,
+	cleanupURL string,
+) (resultErr error) {
+	cleanupConn := scenarioConn
+	if cleanupURL != scenarioConn.Info().URL {
+		var err error
+		cleanupConn, err = dbschema.ConnectToDatabase(ctx, cleanupURL)
+		if err != nil {
+			return fmt.Errorf("connect to cleanup database: %w", err)
+		}
+		defer func() {
+			resultErr = errors.Join(resultErr, cleanupConn.Close())
+		}()
+	}
+	if err := cleanupConn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return err
 	}
-	if platform.NormalizeDialect(conn.Info().Dialect) == platform.Postgres {
-		return cleanPostgresFixtureFunctions(ctx, conn)
+	if platform.NormalizeDialect(cleanupConn.Info().Dialect) == platform.Postgres {
+		return cleanPostgresFixtureFunctions(ctx, cleanupConn)
 	}
 	return nil
 }

--- a/integration/framework_database_test.go
+++ b/integration/framework_database_test.go
@@ -33,16 +33,3 @@ func TestTestRunnerAddDatabaseWithCleanup_FailurePath(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, "mysql cleanup URL must address the scenario database")
 }
-
-func TestCleanupScenariosUseCleanupConnection(t *testing.T) {
-	c := qt.New(t)
-	scenarios := make(map[string]integration.TestScenario)
-	for _, scenario := range integration.GetAllScenarios() {
-		scenarios[scenario.Name] = scenario
-	}
-
-	c.Assert(scenarios["migration_generator_validation"].UseCleanupConnection, qt.IsTrue)
-	c.Assert(scenarios["migration_generator_roundtrip_fixtures"].UseCleanupConnection, qt.IsTrue)
-	c.Assert(scenarios["cleanup_support"].UseCleanupConnection, qt.IsTrue)
-	c.Assert(scenarios["permission_restrictions"].UseCleanupConnection, qt.IsFalse)
-}

--- a/integration/framework_database_test.go
+++ b/integration/framework_database_test.go
@@ -1,0 +1,48 @@
+package integration_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/integration"
+)
+
+func TestTestRunnerAddDatabaseWithCleanup_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	runner := integration.NewTestRunner(nil)
+
+	err := runner.AddDatabaseWithCleanup(
+		"mysql",
+		"mysql://app:secret@tcp(localhost:3306)/ptah_test",
+		"mysql://root:secret@tcp(127.0.0.1:3306)/ptah_test",
+	)
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestTestRunnerAddDatabaseWithCleanup_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	runner := integration.NewTestRunner(nil)
+
+	err := runner.AddDatabaseWithCleanup(
+		"mysql",
+		"mysql://app:secret@tcp(localhost:3306)/ptah_test",
+		"mysql://root:secret@tcp(localhost:3306)/other",
+	)
+
+	c.Assert(err, qt.ErrorMatches, "mysql cleanup URL must address the scenario database")
+}
+
+func TestCleanupScenariosUseCleanupConnection(t *testing.T) {
+	c := qt.New(t)
+	scenarios := make(map[string]integration.TestScenario)
+	for _, scenario := range integration.GetAllScenarios() {
+		scenarios[scenario.Name] = scenario
+	}
+
+	c.Assert(scenarios["migration_generator_validation"].UseCleanupConnection, qt.IsTrue)
+	c.Assert(scenarios["migration_generator_roundtrip_fixtures"].UseCleanupConnection, qt.IsTrue)
+	c.Assert(scenarios["cleanup_support"].UseCleanupConnection, qt.IsTrue)
+	c.Assert(scenarios["permission_restrictions"].UseCleanupConnection, qt.IsFalse)
+}

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -139,6 +139,7 @@ func TestMySQLWriter_Integration(t *testing.T) {
 	writer := mysql.NewMySQLWriter(db, "", "mysql")
 
 	t.Run("transaction lifecycle", func(t *testing.T) {
+		c := qt.New(t)
 		// Test successful transaction
 		tx, err := writer.BeginTransaction(t.Context())
 		c.Assert(err, qt.IsNil)
@@ -158,15 +159,27 @@ func TestMySQLWriter_Integration(t *testing.T) {
 	})
 
 	t.Run("DropAllTables", func(t *testing.T) {
+		c := qt.New(t)
+		cleanupDSN := requireReachableTestDSN(
+			t,
+			"MYSQL_CLEANUP_TEST_DSN",
+			"mysql",
+			"MySQL cleanup",
+		)
+		cleanupDB, err := sql.Open("mysql", cleanupDSN)
+		c.Assert(err, qt.IsNil)
+		defer cleanupDB.Close()
+		cleanupWriter := mysql.NewMySQLWriter(cleanupDB, "", "mysql")
+
 		// Create a test table first
-		_, err := db.Exec("CREATE TABLE IF NOT EXISTS temp_test_table (id INT AUTO_INCREMENT PRIMARY KEY)")
+		_, err = cleanupDB.Exec("CREATE TABLE IF NOT EXISTS temp_test_table (id INT AUTO_INCREMENT PRIMARY KEY)")
 		c.Assert(err, qt.IsNil)
 
-		err = writer.DropAllTables(t.Context())
+		err = cleanupWriter.DropAllTables(t.Context())
 		c.Assert(err, qt.IsNil)
 
 		// Verify table was dropped
-		exists := tableExists(db, "temp_test_table", noDryRun)
+		exists := tableExists(cleanupDB, "temp_test_table", noDryRun)
 		c.Assert(exists, qt.IsFalse)
 	})
 }

--- a/integration/gonative/mysql_integration_test.go
+++ b/integration/gonative/mysql_integration_test.go
@@ -136,7 +136,7 @@ func TestMySQLWriter_Integration(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer db.Close()
 
-	writer := mysql.NewMySQLWriter(db, "")
+	writer := mysql.NewMySQLWriter(db, "", "mysql")
 
 	t.Run("transaction lifecycle", func(t *testing.T) {
 		// Test successful transaction

--- a/integration/scenarios.go
+++ b/integration/scenarios.go
@@ -126,24 +126,21 @@ func GetAllScenarios() []TestScenario {
 
 		// Migration Generator Validation
 		{
-			Name:                 "migration_generator_validation",
-			Description:          "Validate migration generator with forward and rollback migrations",
-			EnhancedTestFunc:     testMigrationGeneratorValidation,
-			UseCleanupConnection: true,
+			Name:            "migration_generator_validation",
+			Description:     "Validate migration generator with forward and rollback migrations",
+			cleanupTestFunc: testMigrationGeneratorValidation,
 		},
 		{
-			Name:                 "migration_generator_roundtrip_fixtures",
-			Description:          "Validate generated migrations with fixture-driven apply, down-to-zero, and re-apply round trips",
-			EnhancedTestFunc:     testMigrationGeneratorRoundTripFixtures,
-			UseCleanupConnection: true,
+			Name:            "migration_generator_roundtrip_fixtures",
+			Description:     "Validate generated migrations with fixture-driven apply, down-to-zero, and re-apply round trips",
+			cleanupTestFunc: testMigrationGeneratorRoundTripFixtures,
 		},
 
 		// Cleanup Support
 		{
 			Name:                 "cleanup_support",
 			Description:          "Test drop and re-run from empty state",
-			TestFunc:             testCleanupSupport,
-			UseCleanupConnection: true,
+			cleanupTestFunc:      testCleanupSupport,
 			ClickHouseCompatible: true,
 			SQLServerCompatible:  true,
 		},

--- a/integration/scenarios.go
+++ b/integration/scenarios.go
@@ -126,14 +126,16 @@ func GetAllScenarios() []TestScenario {
 
 		// Migration Generator Validation
 		{
-			Name:             "migration_generator_validation",
-			Description:      "Validate migration generator with forward and rollback migrations",
-			EnhancedTestFunc: testMigrationGeneratorValidation,
+			Name:                 "migration_generator_validation",
+			Description:          "Validate migration generator with forward and rollback migrations",
+			EnhancedTestFunc:     testMigrationGeneratorValidation,
+			UseCleanupConnection: true,
 		},
 		{
-			Name:             "migration_generator_roundtrip_fixtures",
-			Description:      "Validate generated migrations with fixture-driven apply, down-to-zero, and re-apply round trips",
-			EnhancedTestFunc: testMigrationGeneratorRoundTripFixtures,
+			Name:                 "migration_generator_roundtrip_fixtures",
+			Description:          "Validate generated migrations with fixture-driven apply, down-to-zero, and re-apply round trips",
+			EnhancedTestFunc:     testMigrationGeneratorRoundTripFixtures,
+			UseCleanupConnection: true,
 		},
 
 		// Cleanup Support
@@ -141,6 +143,7 @@ func GetAllScenarios() []TestScenario {
 			Name:                 "cleanup_support",
 			Description:          "Test drop and re-run from empty state",
 			TestFunc:             testCleanupSupport,
+			UseCleanupConnection: true,
 			ClickHouseCompatible: true,
 			SQLServerCompatible:  true,
 		},

--- a/integration/scenarios_advanced.go
+++ b/integration/scenarios_advanced.go
@@ -359,7 +359,13 @@ func testPartialFailureRecovery(ctx context.Context, conn *dbschema.DatabaseConn
 // testMigrationGeneratorValidation tests the migration generator with forward and rollback migrations
 // This test validates the correctness of migration generation and application using the ptah/migration/generator module.
 // It ensures that the resulting database schema is consistent with goschema, and that schemadiff reports no differences.
-func testMigrationGeneratorValidation(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
+func testMigrationGeneratorValidation(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	fixtures fs.FS,
+	recorder *StepRecorder,
+	cleanup databaseCleanupFunc,
+) error {
 	// Create versioned entity manager
 	vem, err := NewVersionedEntityManager(fixtures)
 	if err != nil {
@@ -572,7 +578,7 @@ func testMigrationGeneratorValidation(ctx context.Context, conn *dbschema.Databa
 
 	err = recorder.RecordStep("7.3 Drop Schema", "Drop all tables to clean up", func() error {
 		// Step 7.3: Drop the schema to clean up
-		if err := rollbackToEmptyState(ctx, conn); err != nil {
+		if err := cleanup(ctx); err != nil {
 			return fmt.Errorf("failed to drop schema: %w", err)
 		}
 		return nil
@@ -655,16 +661,6 @@ func rollbackToVersion(ctx context.Context, conn *dbschema.DatabaseConnection, v
 	// Apply the rollback migration
 	if err := vem.ApplyMigrationFromEntities(ctx, conn, description); err != nil {
 		return fmt.Errorf("failed to apply rollback migration: %w", err)
-	}
-
-	return nil
-}
-
-// rollbackToEmptyState drops all tables to return to an empty database state
-func rollbackToEmptyState(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	// Drop all tables to return to empty state
-	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
-		return fmt.Errorf("failed to drop all tables: %w", err)
 	}
 
 	return nil

--- a/integration/scenarios_advanced_test.go
+++ b/integration/scenarios_advanced_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -30,7 +31,15 @@ func TestMigrationGeneratorValidation(t *testing.T) {
 
 	// Run the migration generator validation test
 	recorder := &StepRecorder{}
-	err = testMigrationGeneratorValidation(ctx, conn, testFixtures, recorder)
+	err = testMigrationGeneratorValidation(
+		ctx,
+		conn,
+		testFixtures,
+		recorder,
+		func(cleanupCtx context.Context) error {
+			return conn.SchemaWriter().DropAllTables(cleanupCtx)
+		},
+	)
 	c.Assert(err, qt.IsNil)
 }
 

--- a/integration/scenarios_misc.go
+++ b/integration/scenarios_misc.go
@@ -141,7 +141,7 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 		// server-wide privilege table, giving this probe a side-effect-free
 		// distinction between scenario and cleanup credentials.
 		var userCount int
-		err := conn.QueryRow("SELECT COUNT(*) FROM mysql.user").Scan(&userCount)
+		err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM mysql.user").Scan(&userCount)
 		if err == nil {
 			return fmt.Errorf("restricted %s connection unexpectedly read mysql.user", dialect)
 		}

--- a/integration/scenarios_misc.go
+++ b/integration/scenarios_misc.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"strings"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 )
 
@@ -143,6 +145,24 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 	restrictedSQL := "CREATE DATABASE test_restricted_db"
 	err := helper.ExecuteSQL(ctx, restrictedSQL)
 
+	dialect := platform.NormalizeDialect(conn.Info().Dialect)
+	if dialect == platform.MySQL || dialect == platform.MariaDB {
+		if err == nil {
+			_ = helper.ExecuteSQL(ctx, "DROP DATABASE IF EXISTS test_restricted_db")
+			return fmt.Errorf("restricted %s connection unexpectedly created a database", dialect)
+		}
+		if err.Error() == "" {
+			return fmt.Errorf("restricted %s failure message should not be empty", dialect)
+		}
+		errorMessage := strings.ToLower(err.Error())
+		if !strings.Contains(errorMessage, "denied") &&
+			!strings.Contains(errorMessage, "permission") &&
+			!strings.Contains(errorMessage, "privilege") {
+			return fmt.Errorf("restricted %s connection returned a non-permission error: %w", dialect, err)
+		}
+		return nil
+	}
+
 	// We expect this might fail, and that's okay for this test
 	// The important thing is that we handle the error gracefully
 	if err != nil {
@@ -170,7 +190,13 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 }
 
 // testCleanupSupport tests dropping all tables and re-running migrations
-func testCleanupSupport(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error {
+func testCleanupSupport(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	fixtures fs.FS,
+	_ *StepRecorder,
+	cleanup databaseCleanupFunc,
+) error {
 	helper := NewDatabaseHelper(conn)
 
 	migrationsFS, err := GetMigrationsFS(fixtures, conn, "basic")
@@ -193,7 +219,7 @@ func testCleanupSupport(ctx context.Context, conn *dbschema.DatabaseConnection, 
 	}
 
 	// Drop all tables (cleanup)
-	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
+	if err := cleanup(ctx); err != nil {
 		return fmt.Errorf("failed to drop all tables: %w", err)
 	}
 

--- a/integration/scenarios_misc.go
+++ b/integration/scenarios_misc.go
@@ -135,21 +135,15 @@ func testManualPatchDetection(ctx context.Context, conn *dbschema.DatabaseConnec
 
 // testPermissionRestrictions tests behavior with limited database permissions
 func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS) error {
-	// This test is challenging to implement without actually creating a restricted user
-	// For now, we'll simulate the scenario by testing error handling
-
-	helper := NewDatabaseHelper(conn)
-
-	// Try to execute a statement that might fail due to permissions
-	// This is a simplified test - in a real scenario, you'd connect with a restricted user
-	restrictedSQL := "CREATE DATABASE test_restricted_db"
-	err := helper.ExecuteSQL(ctx, restrictedSQL)
-
 	dialect := platform.NormalizeDialect(conn.Info().Dialect)
 	if dialect == platform.MySQL || dialect == platform.MariaDB {
+		// CI provisions these scenario connections without access to the
+		// server-wide privilege table, giving this probe a side-effect-free
+		// distinction between scenario and cleanup credentials.
+		var userCount int
+		err := conn.QueryRow("SELECT COUNT(*) FROM mysql.user").Scan(&userCount)
 		if err == nil {
-			_ = helper.ExecuteSQL(ctx, "DROP DATABASE IF EXISTS test_restricted_db")
-			return fmt.Errorf("restricted %s connection unexpectedly created a database", dialect)
+			return fmt.Errorf("restricted %s connection unexpectedly read mysql.user", dialect)
 		}
 		if err.Error() == "" {
 			return fmt.Errorf("restricted %s failure message should not be empty", dialect)
@@ -162,6 +156,12 @@ func testPermissionRestrictions(ctx context.Context, conn *dbschema.DatabaseConn
 		}
 		return nil
 	}
+
+	// Try to execute a statement that might fail due to permissions
+	// This is a simplified test - in a real scenario, you'd connect with a restricted user
+	helper := NewDatabaseHelper(conn)
+	restrictedSQL := "CREATE DATABASE test_restricted_db"
+	err := helper.ExecuteSQL(ctx, restrictedSQL)
 
 	// We expect this might fail, and that's okay for this test
 	// The important thing is that we handle the error gracefully

--- a/integration/scenarios_roundtrip_fixtures.go
+++ b/integration/scenarios_roundtrip_fixtures.go
@@ -116,6 +116,7 @@ func testMigrationGeneratorRoundTripFixtures(
 	conn *dbschema.DatabaseConnection,
 	fixtures fs.FS,
 	recorder *StepRecorder,
+	cleanup databaseCleanupFunc,
 ) error {
 	for _, fixture := range roundTripFixtures {
 		if issue := fixture.BlockedByDialect[conn.Info().Dialect]; issue != "" {
@@ -129,7 +130,7 @@ func testMigrationGeneratorRoundTripFixtures(
 			"Round-trip fixture "+fixture.Name,
 			fixture.Description,
 			func() error {
-				return runRoundTripFixture(ctx, conn, fixtures, fixture)
+				return runRoundTripFixture(ctx, conn, fixtures, fixture, cleanup)
 			},
 		); err != nil {
 			return err
@@ -151,6 +152,7 @@ func runRoundTripFixture(
 	conn *dbschema.DatabaseConnection,
 	fixtures fs.FS,
 	fixture roundTripFixture,
+	cleanup databaseCleanupFunc,
 ) error {
 	vem, err := NewVersionedEntityManager(fixtures)
 	if err != nil {
@@ -167,7 +169,7 @@ func runRoundTripFixture(
 	migrationsFS := os.DirFS(migrationsDir)
 	dh := NewDatabaseHelper(conn)
 
-	if err := resetRoundTripFixtureDatabase(ctx, conn); err != nil {
+	if err := resetRoundTripFixtureDatabase(ctx, conn, cleanup); err != nil {
 		return err
 	}
 
@@ -201,7 +203,7 @@ func runRoundTripFixture(
 		}
 	}
 
-	return resetRoundTripFixtureDatabase(ctx, conn)
+	return resetRoundTripFixtureDatabase(ctx, conn, cleanup)
 }
 
 func previousRoundTripVersion(versions []string, versionIndex int) string {
@@ -251,9 +253,13 @@ func validateRoundTripRollbackState(
 	return nil
 }
 
-func resetRoundTripFixtureDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	if err := rollbackToEmptyState(ctx, conn); err != nil {
-		return err
+func resetRoundTripFixtureDatabase(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	cleanup databaseCleanupFunc,
+) error {
+	if err := cleanup(ctx); err != nil {
+		return fmt.Errorf("reset round-trip fixture database: %w", err)
 	}
 	return validateEmptySchema(ctx, conn)
 }

--- a/internal/atlasmigrate/devlock.go
+++ b/internal/atlasmigrate/devlock.go
@@ -1,0 +1,33 @@
+package atlasmigrate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devlock"
+)
+
+type devDatabaseLock struct {
+	lock *devlock.Lock
+}
+
+func acquireDevDatabaseLock(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	timeout time.Duration,
+) (*devDatabaseLock, error) {
+	lock, err := devlock.Acquire(ctx, conn, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("acquire migrate diff dev database lock: %w", err)
+	}
+	return &devDatabaseLock{lock: lock}, nil
+}
+
+func (l *devDatabaseLock) release() error {
+	if l == nil {
+		return nil
+	}
+	return l.lock.Release()
+}

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -31,7 +31,6 @@ import (
 const (
 	revisionTableName = "atlas_schema_revisions"
 	lockFileName      = ".ptah-migrate-diff.lock"
-	devCleanupTimeout = 30 * time.Second
 )
 
 type DiffOptions struct {
@@ -63,9 +62,17 @@ type devSchemaReader func(
 	defaultSchema string,
 ) (*dbschematypes.DBSchema, error)
 
+type replaySnapshotConsumer func(
+	context.Context,
+	*dbschema.DatabaseConnection,
+	fs.FS,
+	migrator.MigrationDirFormat,
+	func(*dbschema.DatabaseConnection) error,
+) error
+
 type diffRuntime struct {
-	readDevSchema    devSchemaReader
-	cleanDevDatabase func(context.Context, *dbschema.DatabaseConnection) error
+	readDevSchema        devSchemaReader
+	withReplayedSnapshot replaySnapshotConsumer
 }
 
 type preparedDiff struct {
@@ -80,8 +87,8 @@ func GenerateDiff(
 	opts DiffOptions,
 ) (DiffResult, error) {
 	return generateDiff(ctx, conn, opts, diffRuntime{
-		readDevSchema:    readScopedDevSchema,
-		cleanDevDatabase: cleanDevDatabaseAfterDiff,
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
 	})
 }
 
@@ -109,6 +116,13 @@ func generateDiff(
 	defer func() {
 		err = errors.Join(err, dirLock.release())
 	}()
+	devLock, err := acquireDevDatabaseLock(ctx, conn, opts.LockTimeout)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	defer func() {
+		err = errors.Join(err, devLock.release())
+	}()
 	desiredState, err := resolveDesiredState(ctx, conn, opts)
 	if err != nil {
 		return DiffResult{}, err
@@ -127,39 +141,34 @@ func generateDiff(
 		return DiffResult{}, err
 	}
 
-	if err := migrationreplay.ReplaySnapshotOnConnection(
-		ctx,
-		conn,
-		migrationSnapshot,
-		migrator.MigrationDirFormatAtlas,
-	); err != nil {
-		return DiffResult{}, err
-	}
-	cleanupPending := true
-	defer func() {
-		if cleanupPending {
-			err = errors.Join(err, runtime.cleanDevDatabase(ctx, conn))
-		}
-	}()
-	devDefaultSchema := conn.Info().Schema
-	current, err := runtime.readDevSchema(conn, schemas, devDefaultSchema)
-	if err != nil {
-		return DiffResult{}, err
-	}
-
 	info := conn.Info()
+	devDefaultSchema := info.Schema
 	desiredDefaultSchema := desiredState.DefaultSchema
 	if desiredDefaultSchema == "" {
 		desiredDefaultSchema = devDefaultSchema
 	}
 	desired := schemascope.FilterGeneratedWithDefaultSchema(desiredState.Schema, schemas, desiredDefaultSchema)
-	diff, err := schemadiff.CompareWithDatabase(ctx, conn, desired, current, nil)
-	if err != nil {
-		return DiffResult{}, fmt.Errorf("compare dev database schema: %w", err)
+	var diff *difftypes.SchemaDiff
+	if err := runtime.withReplayedSnapshot(
+		ctx,
+		conn,
+		migrationSnapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(replayConn *dbschema.DatabaseConnection) error {
+			current, err := runtime.readDevSchema(replayConn, schemas, devDefaultSchema)
+			if err != nil {
+				return err
+			}
+			diff, err = schemadiff.CompareWithDatabase(ctx, replayConn, desired, current, nil)
+			if err != nil {
+				return fmt.Errorf("compare dev database schema: %w", err)
+			}
+			return nil
+		},
+	); err != nil {
+		return DiffResult{}, err
 	}
-	cleanupErr := runtime.cleanDevDatabase(ctx, conn)
-	cleanupPending = false
-	if err := errors.Join(ctx.Err(), cleanupErr); err != nil {
+	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
 	}
 	diff = atlasschema.ApplyDiffPolicy(diff, opts.Policy)
@@ -180,7 +189,7 @@ func generateDiff(
 	if opts.DryRun {
 		return DiffResult{SQL: joinFileContentSQL(contents)}, nil
 	}
-	return writeDiffArtifacts(ctx, opts.Dir, opts.Name, contents)
+	return writeDiffArtifacts(ctx, opts.Dir, opts.Name, contents, migrationSnapshot)
 }
 
 func prepareDiff(
@@ -212,15 +221,6 @@ func prepareDiff(
 	return preparedDiff{opts: opts, schemas: schemas, format: format}, nil
 }
 
-func cleanDevDatabaseAfterDiff(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), devCleanupTimeout)
-	defer cancel()
-	if err := conn.SchemaWriter().DropAllTables(cleanupCtx); err != nil {
-		return fmt.Errorf("clean dev database after migrate diff: %w", err)
-	}
-	return nil
-}
-
 func resolveDesiredState(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
@@ -238,6 +238,7 @@ func resolveDesiredState(
 		DialectFlag:    "--dev-url",
 		DevURL:         devURL,
 		ConnectTimeout: opts.SourceConnectTimeout,
+		DevLockHeld:    true,
 	})
 	if err != nil {
 		return atlassource.State{}, fmt.Errorf("load --to schema: %w", err)

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -44,6 +44,10 @@ type DiffOptions struct {
 	Policy               atlasschema.DiffPolicy
 	Qualifier            Qualifier
 	DryRun               bool
+	// PreparePublication may edit the staged migration files before they are
+	// durably published and included in atlas.sum. The callback runs while the
+	// migration-directory lock is held.
+	PreparePublication func([]string) error
 }
 
 type DiffResult struct {
@@ -189,7 +193,14 @@ func generateDiff(
 	if opts.DryRun {
 		return DiffResult{SQL: joinFileContentSQL(contents)}, nil
 	}
-	return writeDiffArtifacts(ctx, opts.Dir, opts.Name, contents, migrationSnapshot)
+	return writeDiffArtifacts(
+		ctx,
+		opts.Dir,
+		opts.Name,
+		contents,
+		migrationSnapshot,
+		opts.PreparePublication,
+	)
 }
 
 func prepareDiff(

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -17,8 +17,10 @@ import (
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlassource"
+	"github.com/stokaro/ptah/internal/fsnapshot"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/migrationreplay"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/internal/schemascope"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
@@ -29,6 +31,7 @@ import (
 const (
 	revisionTableName = "atlas_schema_revisions"
 	lockFileName      = ".ptah-migrate-diff.lock"
+	devCleanupTimeout = 30 * time.Second
 )
 
 type DiffOptions struct {
@@ -54,26 +57,58 @@ type DiffResult struct {
 	SumPath        string
 }
 
-func GenerateDiff(ctx context.Context, conn *dbschema.DatabaseConnection, opts DiffOptions) (result DiffResult, err error) {
-	if conn == nil {
-		return DiffResult{}, errors.New("migrate diff requires dev database connection")
-	}
-	if strings.TrimSpace(opts.Dir) == "" {
-		return DiffResult{}, errors.New("migrate diff requires migration directory")
-	}
-	if len(opts.Desired.Sources) == 0 {
-		return DiffResult{}, errors.New("migrate diff requires desired state")
-	}
-	opts = normalizeDiffOptions(opts)
-	schemas := schemascope.SplitNames(opts.Schemas)
-	format := atlasreport.NormalizeMigrateDiffFormat(opts.Format)
-	if err := atlasreport.ValidateSchemaDiffTemplate(format); err != nil {
-		return DiffResult{}, err
-	}
-	if err := opts.Qualifier.ValidateScope(conn.Info().Dialect, schemas); err != nil {
-		return DiffResult{}, err
-	}
+type devSchemaReader func(
+	conn *dbschema.DatabaseConnection,
+	schemas []string,
+	defaultSchema string,
+) (*dbschematypes.DBSchema, error)
 
+type diffRuntime struct {
+	readDevSchema    devSchemaReader
+	cleanDevDatabase func(context.Context, *dbschema.DatabaseConnection) error
+}
+
+type preparedDiff struct {
+	opts    DiffOptions
+	schemas []string
+	format  string
+}
+
+func GenerateDiff(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	opts DiffOptions,
+) (DiffResult, error) {
+	return generateDiff(ctx, conn, opts, diffRuntime{
+		readDevSchema:    readScopedDevSchema,
+		cleanDevDatabase: cleanDevDatabaseAfterDiff,
+	})
+}
+
+func generateDiff(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	opts DiffOptions,
+	runtime diffRuntime,
+) (result DiffResult, err error) {
+	prepared, err := prepareDiff(ctx, conn, opts)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	opts = prepared.opts
+	schemas := prepared.schemas
+	format := prepared.format
+
+	if err := os.MkdirAll(filepath.Dir(filepath.Clean(opts.Dir)), 0755); err != nil {
+		return DiffResult{}, fmt.Errorf("create migration directory parent: %w", err)
+	}
+	dirLock, err := acquireDirLock(ctx, opts.Dir, opts.LockTimeout)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	defer func() {
+		err = errors.Join(err, dirLock.release())
+	}()
 	desiredState, err := resolveDesiredState(ctx, conn, opts)
 	if err != nil {
 		return DiffResult{}, err
@@ -81,24 +116,33 @@ func GenerateDiff(ctx context.Context, conn *dbschema.DatabaseConnection, opts D
 	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
 		return DiffResult{}, fmt.Errorf("create migration directory: %w", err)
 	}
-	dirLock, err := acquireDirLock(ctx, opts.Dir, opts.LockTimeout)
-	if err != nil {
-		return DiffResult{}, err
+	if err := recoverPendingPublication(opts.Dir); err != nil {
+		return DiffResult{}, fmt.Errorf("recover migration artifact publication: %w", err)
 	}
-	defer func() {
-		if releaseErr := dirLock.release(); releaseErr != nil && err == nil {
-			err = releaseErr
-		}
-	}()
-	if err := verifyDirSum(opts.Dir); err != nil {
+	migrationSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(opts.Dir))
+	if err != nil {
+		return DiffResult{}, fmt.Errorf("capture migration directory: %w", err)
+	}
+	if err := verifyDirSum(migrationSnapshot); err != nil {
 		return DiffResult{}, err
 	}
 
-	if err := migrationreplay.ReplayOnConnection(ctx, conn, opts.Dir, migrator.MigrationDirFormatAtlas); err != nil {
+	if err := migrationreplay.ReplaySnapshotOnConnection(
+		ctx,
+		conn,
+		migrationSnapshot,
+		migrator.MigrationDirFormatAtlas,
+	); err != nil {
 		return DiffResult{}, err
 	}
+	cleanupPending := true
+	defer func() {
+		if cleanupPending {
+			err = errors.Join(err, runtime.cleanDevDatabase(ctx, conn))
+		}
+	}()
 	devDefaultSchema := conn.Info().Schema
-	current, err := readScopedDevSchema(conn, schemas, devDefaultSchema)
+	current, err := runtime.readDevSchema(conn, schemas, devDefaultSchema)
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -113,6 +157,11 @@ func GenerateDiff(ctx context.Context, conn *dbschema.DatabaseConnection, opts D
 	if err != nil {
 		return DiffResult{}, fmt.Errorf("compare dev database schema: %w", err)
 	}
+	cleanupErr := runtime.cleanDevDatabase(ctx, conn)
+	cleanupPending = false
+	if err := errors.Join(ctx.Err(), cleanupErr); err != nil {
+		return DiffResult{}, err
+	}
 	diff = atlasschema.ApplyDiffPolicy(diff, opts.Policy)
 	if !diff.HasChanges() {
 		return DiffResult{Synced: true}, nil
@@ -122,10 +171,54 @@ func GenerateDiff(ctx context.Context, conn *dbschema.DatabaseConnection, opts D
 	if err != nil {
 		return DiffResult{}, err
 	}
+	if err := ctx.Err(); err != nil {
+		return DiffResult{}, err
+	}
+	if err := verifyMigrationDirUnchanged(opts.Dir, migrationSnapshot); err != nil {
+		return DiffResult{}, err
+	}
 	if opts.DryRun {
 		return DiffResult{SQL: joinFileContentSQL(contents)}, nil
 	}
-	return writeDiffArtifacts(opts.Dir, opts.Name, contents)
+	return writeDiffArtifacts(ctx, opts.Dir, opts.Name, contents)
+}
+
+func prepareDiff(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	opts DiffOptions,
+) (preparedDiff, error) {
+	if conn == nil {
+		return preparedDiff{}, errors.New("migrate diff requires dev database connection")
+	}
+	if strings.TrimSpace(opts.Dir) == "" {
+		return preparedDiff{}, errors.New("migrate diff requires migration directory")
+	}
+	if len(opts.Desired.Sources) == 0 {
+		return preparedDiff{}, errors.New("migrate diff requires desired state")
+	}
+	opts = normalizeDiffOptions(opts)
+	schemas := schemascope.SplitNames(opts.Schemas)
+	format := atlasreport.NormalizeMigrateDiffFormat(opts.Format)
+	if err := atlasreport.ValidateSchemaDiffTemplate(format); err != nil {
+		return preparedDiff{}, err
+	}
+	if err := opts.Qualifier.ValidateScope(conn.Info().Dialect, schemas); err != nil {
+		return preparedDiff{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return preparedDiff{}, err
+	}
+	return preparedDiff{opts: opts, schemas: schemas, format: format}, nil
+}
+
+func cleanDevDatabaseAfterDiff(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), devCleanupTimeout)
+	defer cancel()
+	if err := conn.SchemaWriter().DropAllTables(cleanupCtx); err != nil {
+		return fmt.Errorf("clean dev database after migrate diff: %w", err)
+	}
+	return nil
 }
 
 func resolveDesiredState(
@@ -182,54 +275,6 @@ func joinFileContentSQL(contents []MigrationFileContent) string {
 	return strings.Join(sqls, "\n")
 }
 
-// writeDiffArtifacts writes every planned migration file and then atlas.sum,
-// all-or-nothing.
-func writeDiffArtifacts(dir, name string, contents []MigrationFileContent) (DiffResult, error) {
-	paths, err := writeMigrationFiles(dir, name, contents)
-	if err != nil {
-		return DiffResult{}, err
-	}
-	sumPath, err := writeDirSum(dir, paths)
-	if err != nil {
-		return DiffResult{}, err
-	}
-	return DiffResult{MigrationPaths: paths, SumPath: sumPath}, nil
-}
-
-// writeDirSum refreshes atlas.sum after every migration file was written. A
-// failed checksum update rolls the whole generation back: the new migration
-// files are removed and the previous atlas.sum content is restored, so the
-// directory hash only ever changes after a fully successful generation.
-func writeDirSum(dir string, migrationPaths []string) (string, error) {
-	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
-	previousSum, previousErr := os.ReadFile(sumPath)
-	if _, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas); err != nil {
-		removeFiles(migrationPaths)
-		restoreSumFile(sumPath, previousSum, previousErr)
-		return "", fmt.Errorf("write atlas.sum: %w", err)
-	}
-	return sumPath, nil
-}
-
-func removeFiles(paths []string) {
-	for _, path := range paths {
-		_ = os.Remove(path)
-	}
-}
-
-// restoreSumFile best-effort restores atlas.sum's previous bytes after a
-// failed overwrite, or removes it when it did not exist before. When the
-// previous content could not be read for any other reason, the file is left
-// alone rather than destroyed.
-func restoreSumFile(path string, previous []byte, previousErr error) {
-	switch {
-	case previousErr == nil:
-		_ = os.WriteFile(path, previous, 0644) //nolint:gosec // atlas.sum is a shared checked-in file
-	case errors.Is(previousErr, os.ErrNotExist):
-		_ = os.Remove(path)
-	}
-}
-
 func normalizeDiffOptions(opts DiffOptions) DiffOptions {
 	if strings.TrimSpace(opts.Name) == "" {
 		opts.Name = "migration"
@@ -262,86 +307,8 @@ func renderMigrationDiffSQL(statements []string, format string) (string, error) 
 	return out.String(), nil
 }
 
-type dirLock struct {
-	path string
-	file *os.File
-}
-
-func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Duration) (*dirLock, error) {
-	lockPath := filepath.Join(migrationsDir, lockFileName)
-	startedAt := time.Now()
-	for {
-		lock, err := tryAcquireDirLock(lockPath)
-		if err == nil {
-			return lock, nil
-		}
-		if !errors.Is(err, os.ErrExist) {
-			return nil, err
-		}
-		if timeout > 0 && time.Since(startedAt) >= timeout {
-			return nil, fmt.Errorf("migration directory lock timeout after %s: %s", timeout, lockPath)
-		}
-		if err := waitForDirLockRetry(ctx, startedAt, timeout); err != nil {
-			return nil, err
-		}
-	}
-}
-
-func tryAcquireDirLock(lockPath string) (*dirLock, error) {
-	file, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
-	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("create migration directory lock: %w", err)
-	}
-	if _, err := fmt.Fprintf(file, "pid=%d\n", os.Getpid()); err != nil {
-		_ = file.Close()
-		_ = os.Remove(lockPath)
-		return nil, fmt.Errorf("write migration directory lock: %w", err)
-	}
-	return &dirLock{path: lockPath, file: file}, nil
-}
-
-func waitForDirLockRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
-	wait := 25 * time.Millisecond
-	if timeout > 0 {
-		remaining := timeout - time.Since(startedAt)
-		if remaining <= 0 {
-			return nil
-		}
-		wait = min(wait, remaining)
-	}
-	timer := time.NewTimer(wait)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("acquire migration directory lock: %w", ctx.Err())
-	case <-timer.C:
-		return nil
-	}
-}
-
-func (l *dirLock) release() error {
-	if l == nil {
-		return nil
-	}
-	closeErr := l.file.Close()
-	removeErr := os.Remove(l.path)
-	if closeErr != nil && removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("release migration directory lock: %w", errors.Join(closeErr, removeErr))
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close migration directory lock: %w", closeErr)
-	}
-	if removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-		return fmt.Errorf("remove migration directory lock: %w", removeErr)
-	}
-	return nil
-}
-
-func verifyDirSum(migrationsDir string) error {
-	result, err := migratesum.VerifyDirWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+func verifyDirSum(fsys fs.FS) error {
+	result, err := migratesum.VerifyWithFormat(fsys, migrator.MigrationDirFormatAtlas)
 	if errors.Is(err, migratesum.ErrSumFileMissing) {
 		return nil
 	}
@@ -350,6 +317,17 @@ func verifyDirSum(migrationsDir string) error {
 	}
 	if !result.OK() {
 		return fmt.Errorf("migration directory checksum verification failed:\n%s", result.Describe())
+	}
+	return nil
+}
+
+func verifyMigrationDirUnchanged(dir string, expected fsnapshot.Snapshot) error {
+	current, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	if err != nil {
+		return fmt.Errorf("recapture migration directory: %w", err)
+	}
+	if !expected.Equal(current) {
+		return errors.New("migration directory changed during migrate diff planning")
 	}
 	return nil
 }
@@ -379,105 +357,4 @@ func filterByTable[T any](values []T, keep func(T) bool) []T {
 		}
 	}
 	return out
-}
-
-// writeMigrationFiles writes every planned migration file with consecutive
-// versions, all-or-nothing: a failed write removes the files already written
-// in this run before returning, so a partial failure leaves no partial state
-// behind. Versions are allocated together so a split plan stays adjacent and
-// ordered in the directory.
-func writeMigrationFiles(dir, name string, contents []MigrationFileContent) ([]string, error) {
-	if len(contents) == 0 {
-		return nil, fmt.Errorf("migration SQL is empty")
-	}
-	for _, content := range contents {
-		if strings.TrimSpace(content.SQL) == "" {
-			return nil, fmt.Errorf("migration SQL is empty")
-		}
-	}
-	version, err := nextMigrationVersion(dir)
-	if err != nil {
-		return nil, err
-	}
-	for {
-		paths, collidedVersion, err := writeMigrationFilesAt(dir, name, version, contents)
-		if err != nil {
-			return nil, err
-		}
-		if collidedVersion == 0 {
-			return paths, nil
-		}
-		// Another writer claimed a version despite the directory lock; retry
-		// the whole batch above the collision so the files stay adjacent.
-		version = collidedVersion + 1
-	}
-}
-
-// writeMigrationFilesAt attempts one batch write at base version. On a
-// version collision it removes this attempt's files and reports the colliding
-// version; on any other failure it removes this attempt's files and returns
-// the error.
-func writeMigrationFilesAt(dir, name string, version int64, contents []MigrationFileContent) ([]string, int64, error) {
-	paths := make([]string, 0, len(contents))
-	for i, content := range contents {
-		fileVersion := version + int64(i)
-		slug := migrationSlug(name + content.NameSuffix)
-		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", fileVersion, slug))
-		err := writeNewMigrationFile(path, content.SQL)
-		if errors.Is(err, os.ErrExist) {
-			removeFiles(paths)
-			return nil, fileVersion, nil
-		}
-		if err != nil {
-			removeFiles(paths)
-			return nil, 0, fmt.Errorf("write migration file: %w", err)
-		}
-		paths = append(paths, path)
-	}
-	return paths, 0, nil
-}
-
-func writeNewMigrationFile(path, sql string) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if err != nil {
-		return err
-	}
-	if _, err := file.WriteString(sql); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return fmt.Errorf("write migration SQL: %w", err)
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return fmt.Errorf("close migration file: %w", err)
-	}
-	return nil
-}
-
-func nextMigrationVersion(dir string) (int64, error) {
-	files, err := migrator.DiscoverMigrationFiles(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
-	if err != nil {
-		return 0, err
-	}
-	version := migrator.GetNextMigrationVersion()
-	for _, file := range files {
-		if file.Version >= version {
-			version = file.Version + 1
-		}
-	}
-	return version, nil
-}
-
-var migrationSlugInvalidChars = regexp.MustCompile(`[^a-z0-9_]+`)
-
-func migrationSlug(name string) string {
-	slug := strings.ToLower(strings.TrimSpace(name))
-	slug = strings.ReplaceAll(slug, "-", "_")
-	slug = strings.ReplaceAll(slug, " ", "_")
-	slug = migrationSlugInvalidChars.ReplaceAllString(slug, "")
-	slug = strings.Trim(slug, "_")
-	if slug == "" {
-		return "migration"
-	}
-	return slug
 }

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -69,6 +70,174 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
 }
 
+func TestPublishMigrationBatch_ExclusiveCopyMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"copy",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	batch.mode = publicationModeCopy
+
+	published, err := publishMigrationBatch(dir, batch)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	finalInfo, err := os.Stat(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
+	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	finalContents, err := os.ReadFile(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(finalContents, qt.DeepEquals, stagedContents)
+	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+}
+
+func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	journal := publicationJournal{
+		Version:    publicationJournalVersion,
+		CommitMode: publicationCommitModeAtlasSum,
+		Entries: []publicationEntry{{
+			Staged: ".ptah-migrate-diff-staged.tmp",
+			Final:  "1_copy.sql",
+			Mode:   string(publicationModeCopy),
+			Digest: contentDigest([]byte("sum")),
+		}},
+		Sum: []byte("sum"),
+	}
+
+	err := writePublicationJournalWithLink(
+		dir,
+		journal,
+		func(string, string) error {
+			return syscall.ENOTSUP
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	got, err := readPublicationJournal(journalPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, journal)
+	backups, err := filepath.Glob(journalPath + ".*.tmp")
+	c.Assert(err, qt.IsNil)
+	c.Assert(backups, qt.HasLen, 1)
+	c.Assert(os.WriteFile(journalPath, []byte("{"), 0o600), qt.IsNil)
+	got, err = readPublicationJournal(journalPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, journal)
+	c.Assert(removePublicationJournal(journalPath), qt.IsNil)
+}
+
+func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+
+	paths, err := PublishArtifactsLocked(
+		t.Context(),
+		dir,
+		[]PublicationArtifact{
+			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
+			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},
+			{Name: "1_change.safety.json", Contents: []byte("{}\n")},
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(paths, qt.DeepEquals, []string{
+		filepath.Join(dir, "1_change.up.sql"),
+		filepath.Join(dir, "1_change.down.sql"),
+		filepath.Join(dir, "1_change.safety.json"),
+	})
+	up, err := os.ReadFile(paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(up), qt.Equals, "SELECT 1;\n")
+	down, err := os.ReadFile(paths[1])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(down), qt.Equals, "SELECT 2;\n")
+	report, err := os.ReadFile(paths[2])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(report), qt.Equals, "{}\n")
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	existingPath := filepath.Join(dir, "1_change.down.sql")
+	c.Assert(os.WriteFile(existingPath, []byte("existing\n"), 0o600), qt.IsNil)
+
+	paths, err := PublishArtifactsLocked(
+		t.Context(),
+		dir,
+		[]PublicationArtifact{
+			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
+			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},
+		},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migration directory changed during publication: .* already exists`)
+	c.Assert(paths, qt.IsNil)
+	_, err = os.Stat(filepath.Join(dir, "1_change.up.sql"))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	existing, err := os.ReadFile(existingPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(existing), qt.Equals, "existing\n")
+	staged, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(staged, qt.HasLen, 0)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+
+	batch, err := stageMigrationBatchAtWithModeDetector(
+		dir,
+		"copy",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+		func(stagedPath string) (publicationMode, error) {
+			return detectPublicationModeWithLink(
+				stagedPath,
+				func(string, string) error {
+					return syscall.ENOTSUP
+				},
+			)
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(batch.mode, qt.Equals, publicationModeCopy)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	finalInfo, err := os.Stat(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
+	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+}
+
 func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
@@ -82,6 +251,7 @@ func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 		"add_email",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
+		nil,
 	)
 
 	c.Assert(err, qt.ErrorMatches, `write atlas\.sum: .*`)
@@ -130,6 +300,112 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.OK(), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	initialPath := filepath.Join(dir, "1_initial.sql")
+	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"interrupted_copy",
+		2,
+		[]MigrationFileContent{{SQL: "SELECT 2;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	batch.mode = publicationModeCopy
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 2;"}},
+	)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	result, err := migratesum.VerifyWithFormat(
+		os.DirFS(dir),
+		migrator.MigrationDirFormatAtlas,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.OK(), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"interrupted_move",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	batch.mode = publicationModeWriteThroughMove
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageArtifactBatch(
+		dir,
+		[]PublicationArtifact{
+			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
+			{Name: "1_change.safety.json", Contents: []byte("{}\n")},
+		},
+	)
+	c.Assert(err, qt.IsNil)
+	journal, err := beginMarkerPublication(dir, batch)
+	c.Assert(err, qt.IsNil)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 2)
+	c.Assert(writePublicationCommitMarker(dir, journal), qt.IsNil)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	up, err := os.ReadFile(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(up), qt.Equals, "SELECT 1;\n")
+	report, err := os.ReadFile(batch.paths[1])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(report), qt.Equals, "{}\n")
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
@@ -193,7 +469,7 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 
 	err = recoverPendingPublication(dir)
 
-	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* is not the journaled staging file; preserved at .*`)
+	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* content changed; preserved at .*`)
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
@@ -231,7 +507,7 @@ func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 
 	err = abortPendingPublication(dir, batch, published)
 
-	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: .* is not the journaled staging file; preserved at .*`)
+	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: .* content changed; preserved at .*`)
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
@@ -239,6 +515,45 @@ func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 	c.Assert(string(contents), qt.Equals, "foreign")
 	_, err = os.Stat(batch.stagedPaths[0])
 	c.Assert(err, qt.IsNil)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"mutated",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	batch.mode = publicationModeHardLink
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+
+	err = abortPendingPublication(dir, batch, published)
+
+	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: staging file content changed; preserved .*`)
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "foreign")
+	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(stagedContents), qt.Equals, "foreign")
 	journalPath, err := publicationJournalPath(dir)
 	c.Assert(err, qt.IsNil)
 	_, err = os.Stat(journalPath)
@@ -257,6 +572,7 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 		"uncertain",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
+		nil,
 		func(dir string, sum *migratesum.SumFile) (string, error) {
 			path, writeErr := writeDirSum(dir, sum)
 			c.Assert(writeErr, qt.IsNil)
@@ -310,6 +626,7 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 		"planned",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
+		nil,
 	)
 
 	c.Assert(err, qt.ErrorMatches, `migration directory changed during migrate diff planning`)
@@ -500,6 +817,110 @@ func TestGenerateDiff_CancellationDuringCleanupPreventsArtifacts(t *testing.T) {
 	assertDiffDirectoryReleased(c, opts.Dir)
 }
 
+func TestGenerateDiff_PreparePublicationFailurePreservesExistingArtifacts(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	previousSum, err := os.ReadFile(
+		filepath.Join(opts.Dir, migratesum.AtlasFileName),
+	)
+	c.Assert(err, qt.IsNil)
+	prepareErr := errors.New("injected preparation failure")
+	opts.PreparePublication = func(stagedPaths []string) error {
+		writeErr := os.WriteFile(
+			stagedPaths[0],
+			[]byte("SELECT 99;\n"),
+			0o600,
+		)
+		return errors.Join(writeErr, prepareErr)
+	}
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.ErrorIs, prepareErr)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	sqlFiles, err := filepath.Glob(filepath.Join(opts.Dir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlFiles, qt.HasLen, 1)
+	restoredSum, err := os.ReadFile(
+		filepath.Join(opts.Dir, migratesum.AtlasFileName),
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(restoredSum, qt.DeepEquals, previousSum)
+	verification, err := migratesum.VerifyWithFormat(
+		os.DirFS(opts.Dir),
+		migrator.MigrationDirFormatAtlas,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(verification.OK(), qt.IsTrue)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryLockReleased(c, opts.Dir)
+}
+
+func TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	opts.PreparePublication = func(stagedPaths []string) error {
+		return os.WriteFile(
+			stagedPaths[0],
+			[]byte("SELECT 99;\n"),
+			0o600,
+		)
+	}
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.MigrationPaths, qt.HasLen, 1)
+	sqlFiles, err := filepath.Glob(filepath.Join(opts.Dir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlFiles, qt.HasLen, 2)
+	contents, err := os.ReadFile(result.MigrationPaths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "SELECT 99;\n")
+	verification, err := migratesum.VerifyWithFormat(
+		os.DirFS(opts.Dir),
+		migrator.MigrationDirFormatAtlas,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(verification.OK(), qt.IsTrue)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryLockReleased(c, opts.Dir)
+}
+
+func TestGenerateDiff_PreparePublicationRunsUnderDirectoryLock(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	var competingLock *dirLock
+	var competingErr error
+	opts.LockTimeout = time.Millisecond
+	opts.PreparePublication = func([]string) error {
+		competingLock, competingErr = acquireDirLock(
+			t.Context(),
+			opts.Dir,
+			opts.LockTimeout,
+		)
+		return competingErr
+	}
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `.*migration directory lock timeout after 1ms: .*`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(competingLock, qt.IsNil)
+	c.Assert(competingErr, qt.IsNotNil)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryReleased(c, opts.Dir)
+}
+
 func TestCanonicalMigrationDirResolvesSymlinkAlias(t *testing.T) {
 	c := qt.New(t)
 	root := c.TempDir()
@@ -526,8 +947,12 @@ func TestTryAcquireDirLock_ReclaimsStaleFile(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(lock.release(), qt.IsNil)
 
-	_, err = os.Stat(lockPath)
-	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	info, err := os.Stat(lockPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().IsRegular(), qt.IsTrue)
+	lock, err = tryAcquireDirLock(lockPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(lock.release(), qt.IsNil)
 }
 
 func TestGenerateDiff_SerializesSQLiteDevDatabaseAcrossDirectories(t *testing.T) {
@@ -615,6 +1040,12 @@ func assertDiffDirectoryReleased(c *qt.C, dir string) {
 	entries, err := os.ReadDir(dir)
 	c.Assert(err, qt.IsNil)
 	c.Assert(entries, qt.HasLen, 2)
-	_, err = os.Stat(migrationDirLockPath(dir))
-	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	assertDiffDirectoryLockReleased(c, dir)
+}
+
+func assertDiffDirectoryLockReleased(c *qt.C, dir string) {
+	c.Helper()
+	lock, err := tryAcquireDirLock(migrationDirLockPath(dir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(lock.release(), qt.IsNil)
 }

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -1,36 +1,42 @@
 package atlasmigrate
 
-// White-box testing required: writeMigrationFiles' version-collision retry
-// and its all-or-nothing rollback react to filesystem races that cannot be
-// staged deterministically through GenerateDiff, which allocates versions
-// under the directory lock immediately before writing.
+// White-box testing required: filesystem publication races and post-replay
+// fault injection cannot be staged deterministically through the exported
+// GenerateDiff API.
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/atlassource"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
 )
 
-func TestWriteMigrationFilesAt_CollisionRollsBackAttemptAndReportsVersion(t *testing.T) {
+func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
-	// A concurrent writer claimed version 2 after this run allocated 1..2:
-	// the second batch file collides, the attempt rolls back, and the caller
-	// retries the whole batch above the colliding version.
+	// A non-cooperating writer claimed version 2 after this run allocated 1..2.
+	// Publishing the stale plan must fail instead of silently moving it above
+	// a migration that was never replayed.
 	c.Assert(os.WriteFile(filepath.Join(dir, "2_add_email_concurrent_indexes.sql"), []byte("taken"), 0o600), qt.IsNil)
 	contents := []MigrationFileContent{
 		{NameSuffix: "_transactional", SQL: "SELECT 1;"},
 		{NameSuffix: "_concurrent_indexes", SQL: "SELECT 2;", NoTransaction: true},
 	}
 
-	paths, collidedVersion, err := writeMigrationFilesAt(dir, "add_email", 1, contents)
+	paths, err := writeMigrationFilesAt(dir, "add_email", 1, contents)
 
-	c.Assert(err, qt.IsNil)
+	c.Assert(err, qt.ErrorMatches, `migration directory changed during publication: .*2_add_email_concurrent_indexes\.sql already exists`)
 	c.Assert(paths, qt.HasLen, 0)
-	c.Assert(collidedVersion, qt.Equals, int64(2))
 	// The colliding file kept its content and no version-1 leftover remains
 	// from the aborted attempt.
 	taken, readErr := os.ReadFile(filepath.Join(dir, "2_add_email_concurrent_indexes.sql"))
@@ -38,15 +44,6 @@ func TestWriteMigrationFilesAt_CollisionRollsBackAttemptAndReportsVersion(t *tes
 	c.Assert(string(taken), qt.Equals, "taken")
 	_, leftoverErr := os.Stat(filepath.Join(dir, "1_add_email_transactional.sql"))
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
-
-	retryPaths, retryCollided, retryErr := writeMigrationFilesAt(dir, "add_email", collidedVersion+1, contents)
-
-	c.Assert(retryErr, qt.IsNil)
-	c.Assert(retryCollided, qt.Equals, int64(0))
-	c.Assert(retryPaths, qt.DeepEquals, []string{
-		filepath.Join(dir, "3_add_email_transactional.sql"),
-		filepath.Join(dir, "4_add_email_concurrent_indexes.sql"),
-	})
 }
 
 func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
@@ -62,10 +59,148 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 		{NameSuffix: oversizedSuffix, SQL: "SELECT 2;", NoTransaction: true},
 	})
 
-	c.Assert(err, qt.ErrorMatches, `write migration file: .*`)
+	c.Assert(err, qt.ErrorMatches, `publish migration file: .*`)
 	c.Assert(paths, qt.HasLen, 0)
 	_, leftoverErr := os.Stat(filepath.Join(dir, "1_add_email_transactional.sql"))
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.Mkdir(filepath.Join(dir, "atlas.sum"), 0o700), qt.IsNil)
+
+	result, err := writeDiffArtifacts(
+		t.Context(),
+		dir,
+		"add_email",
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `write atlas\.sum: .*`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	entries, readErr := os.ReadDir(dir)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 1)
+	c.Assert(entries[0].Name(), qt.Equals, "atlas.sum")
+	c.Assert(entries[0].IsDir(), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	initialPath := filepath.Join(dir, "1_initial.sql")
+	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"interrupted",
+		2,
+		[]MigrationFileContent{{SQL: "SELECT 2;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.OK(), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"committed",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	_, err = writeDirSum(dir)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	contents, err := os.ReadFile(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "SELECT 1;")
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.OK(), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"collision",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+
+	err = recoverPendingPublication(dir)
+
+	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* is not the journaled staging file`)
+	contents, err := os.ReadFile(batch.paths[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "foreign")
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath, err := stageMigrationFile(dir, "SELECT 1;")
+	c.Assert(err, qt.IsNil)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	journalTemp, err := os.CreateTemp(
+		filepath.Dir(journalPath),
+		filepath.Base(journalPath)+".*.tmp",
+	)
+	c.Assert(err, qt.IsNil)
+	journalTempPath := journalTemp.Name()
+	c.Assert(journalTemp.Close(), qt.IsNil)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+	_, err = os.Stat(stagedPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(journalTempPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func TestWriteMigrationFiles_EmptySQLIsRejected(t *testing.T) {
@@ -76,4 +211,196 @@ func TestWriteMigrationFiles_EmptySQLIsRejected(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `migration SQL is empty`)
 	c.Assert(paths, qt.HasLen, 0)
+}
+
+func TestGenerateDiff_PostReplayReadFailureCleansAndReleasesLock(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	readErr := errors.New("injected schema read failure")
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return nil, readErr
+		},
+		cleanDevDatabase: cleanDevDatabaseAfterDiff,
+	})
+
+	c.Assert(err, qt.ErrorIs, readErr)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryReleased(c, opts.Dir)
+}
+
+func TestGenerateDiff_FinalCleanupFailureIsNotRetried(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	cleanupErr := errors.New("injected final cleanup failure")
+	cleanupCalls := 0
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema: readScopedDevSchema,
+		cleanDevDatabase: func(context.Context, *dbschema.DatabaseConnection) error {
+			cleanupCalls++
+			return cleanupErr
+		},
+	})
+
+	c.Assert(err, qt.ErrorIs, cleanupErr)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(cleanupCalls, qt.Equals, 1)
+	assertSQLiteCleanupObjectCount(c, conn, 2)
+	assertDiffDirectoryReleased(c, opts.Dir)
+}
+
+func TestGenerateDiff_JoinsPostReplayFailureAndCleanupFailure(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	readErr := errors.New("injected schema read failure")
+	cleanupErr := errors.New("injected cleanup failure")
+	cleanupCalls := 0
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema: func(
+			*dbschema.DatabaseConnection,
+			[]string,
+			string,
+		) (*dbschematypes.DBSchema, error) {
+			return nil, readErr
+		},
+		cleanDevDatabase: func(context.Context, *dbschema.DatabaseConnection) error {
+			cleanupCalls++
+			return cleanupErr
+		},
+	})
+
+	c.Assert(err, qt.ErrorIs, readErr)
+	c.Assert(err, qt.ErrorIs, cleanupErr)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(cleanupCalls, qt.Equals, 1)
+	assertSQLiteCleanupObjectCount(c, conn, 2)
+	assertDiffDirectoryReleased(c, opts.Dir)
+}
+
+func TestGenerateDiff_CancellationDuringCleanupPreventsArtifacts(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	ctx, cancel := context.WithCancel(t.Context())
+	cleanupCalls := 0
+
+	result, err := generateDiff(ctx, conn, opts, diffRuntime{
+		readDevSchema: readScopedDevSchema,
+		cleanDevDatabase: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+			cleanupCalls++
+			cleanupErr := cleanDevDatabaseAfterDiff(ctx, conn)
+			cancel()
+			return cleanupErr
+		},
+	})
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(cleanupCalls, qt.Equals, 1)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryReleased(c, opts.Dir)
+}
+
+func TestCanonicalMigrationDirResolvesSymlinkAlias(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	realDir := filepath.Join(root, "real", "migrations")
+	c.Assert(os.MkdirAll(realDir, 0o755), qt.IsNil)
+	aliasDir := filepath.Join(root, "alias")
+	c.Assert(os.Symlink(realDir, aliasDir), qt.IsNil)
+
+	canonicalReal, err := canonicalMigrationDir(realDir)
+	c.Assert(err, qt.IsNil)
+	canonicalAlias, err := canonicalMigrationDir(aliasDir)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(canonicalAlias, qt.Equals, canonicalReal)
+	c.Assert(migrationDirLockPath(canonicalAlias), qt.Equals, migrationDirLockPath(canonicalReal))
+}
+
+func TestTryAcquireDirLock_ReclaimsStaleFile(t *testing.T) {
+	c := qt.New(t)
+	lockPath := filepath.Join(c.TempDir(), ".migrations"+lockFileName)
+	c.Assert(os.WriteFile(lockPath, []byte("stale"), 0o600), qt.IsNil)
+
+	lock, err := tryAcquireDirLock(lockPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(lock.release(), qt.IsNil)
+
+	_, err = os.Stat(lockPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func prepareGenerateDiffFaultTest(c *qt.C) (*dbschema.DatabaseConnection, DiffOptions) {
+	c.Helper()
+	dir := c.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte(`
+CREATE TABLE replayed_users (id INTEGER PRIMARY KEY);
+CREATE VIEW replayed_user_ids AS SELECT id FROM replayed_users;
+`),
+		0o600,
+	), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(
+		schemaPath,
+		[]byte("CREATE TABLE desired_users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	desired, err := atlassource.ClassifySet(
+		"--to",
+		[]string{"file://" + schemaPath},
+		atlassource.ProjectEnv{},
+	)
+	c.Assert(err, qt.IsNil)
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+filepath.Join(dir, "dev.db"))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		dbschema.CloseAndWarn(conn)
+	})
+	return conn, DiffOptions{
+		Dir:     migrationsDir,
+		Desired: desired,
+		Name:    "fault_injection",
+	}
+}
+
+func assertSQLiteCleanupObjectCount(
+	c *qt.C,
+	conn *dbschema.DatabaseConnection,
+	want int,
+) {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM pragma_table_list
+		WHERE schema = ?
+		  AND type IN ('table', 'view', 'virtual')
+		  AND name NOT LIKE 'sqlite_%'
+		  AND name <> 'schema_migrations'
+	`, "main").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, want)
+}
+
+func assertDiffDirectoryReleased(c *qt.C, dir string) {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 2)
+	_, err = os.Stat(migrationDirLockPath(dir))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlassource"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/migrationreplay"
 	"github.com/stokaro/ptah/internal/migrationsnapshot"
@@ -1004,7 +1005,10 @@ CREATE VIEW replayed_user_ids AS SELECT id FROM replayed_users;
 		atlassource.ProjectEnv{},
 	)
 	c.Assert(err, qt.IsNil)
-	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+filepath.Join(dir, "dev.db"))
+	conn, err := dbschema.ConnectToDatabase(
+		c.Context(),
+		atlasurl.SQLiteURLFromPath(filepath.Join(dir, "dev.db")),
+	)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		dbschema.CloseAndWarn(conn)

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -799,15 +799,17 @@ func TestGenerateDiff_CancellationDuringCleanupPreventsArtifacts(t *testing.T) {
 			consume func(*dbschema.DatabaseConnection) error,
 		) error {
 			cleanupCalls++
-			replayErr := migrationreplay.WithReplayedSnapshotLocked(
+			return migrationreplay.WithReplayedSnapshotLocked(
 				replayCtx,
 				replayConn,
 				snapshot,
 				format,
-				consume,
+				func(conn *dbschema.DatabaseConnection) error {
+					consumeErr := consume(conn)
+					cancel()
+					return errors.Join(consumeErr, replayCtx.Err())
+				},
 			)
-			cancel()
-			return replayErr
 		},
 	})
 

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -7,10 +7,12 @@ package atlasmigrate
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -18,6 +20,8 @@ import (
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlassource"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/migrationreplay"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -69,12 +73,15 @@ func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
 	c.Assert(os.Mkdir(filepath.Join(dir, "atlas.sum"), 0o700), qt.IsNil)
+	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	c.Assert(err, qt.IsNil)
 
 	result, err := writeDiffArtifacts(
 		t.Context(),
 		dir,
 		"add_email",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+		baseSnapshot,
 	)
 
 	c.Assert(err, qt.ErrorMatches, `write atlas\.sum: .*`)
@@ -100,7 +107,12 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 2;"}},
+	)
 	published, err := publishMigrationBatch(dir, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
@@ -130,12 +142,20 @@ func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	journal, sum := beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
 	published, err := publishMigrationBatch(dir, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	_, err = writeDirSum(dir)
+	_, err = writeDirSum(dir, sum)
 	c.Assert(err, qt.IsNil)
+	committed, err := publicationCommitted(dir, journal)
+	c.Assert(err, qt.IsNil)
+	c.Assert(committed, qt.IsTrue)
 
 	c.Assert(recoverPendingPublication(dir), qt.IsNil)
 
@@ -163,13 +183,20 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(beginPublication(dir, batch), qt.IsNil)
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
 	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
 
 	err = recoverPendingPublication(dir)
 
-	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* is not the journaled staging file`)
-	contents, err := os.ReadFile(batch.paths[0])
+	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* is not the journaled staging file; preserved at .*`)
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
 	_, err = os.Stat(batch.stagedPaths[0])
@@ -178,6 +205,141 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
+}
+
+func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	batch, err := stageMigrationBatchAt(
+		dir,
+		"collision",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	_, _ = beginTestPublication(
+		c,
+		dir,
+		batch,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	published, err := publishMigrationBatch(dir, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	c.Assert(os.Remove(batch.paths[0]), qt.IsNil)
+	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+
+	err = abortPendingPublication(dir, batch, published)
+
+	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: .* is not the journaled staging file; preserved at .*`)
+	_, err = os.Stat(batch.paths[0])
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "foreign")
+	_, err = os.Stat(batch.stagedPaths[0])
+	c.Assert(err, qt.IsNil)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	c.Assert(err, qt.IsNil)
+
+	result, err := writeDiffArtifactsWithSumWriter(
+		t.Context(),
+		dir,
+		"uncertain",
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+		baseSnapshot,
+		func(dir string, sum *migratesum.SumFile) (string, error) {
+			path, writeErr := writeDirSum(dir, sum)
+			c.Assert(writeErr, qt.IsNil)
+			return path, &migratesum.CommitUncertainError{
+				Err: errors.New("injected directory sync failure"),
+			}
+		},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `write atlas\.sum; migration publication journal retained for recovery: injected directory sync failure`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	sqlFiles, err := filepath.Glob(filepath.Join(dir, "*_uncertain.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlFiles, qt.HasLen, 1)
+	stagedFiles, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(stagedFiles, qt.HasLen, 1)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	sqlFiles, err = filepath.Glob(filepath.Join(dir, "*_uncertain.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlFiles, qt.HasLen, 1)
+	stagedFiles, err = filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(stagedFiles, qt.HasLen, 0)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	verifyResult, err := migratesum.VerifyWithFormat(
+		os.DirFS(dir),
+		migrator.MigrationDirFormatAtlas,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(verifyResult.OK(), qt.IsTrue)
+}
+
+func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	c.Assert(err, qt.IsNil)
+	foreignPath := filepath.Join(dir, "99_foreign.sql")
+	c.Assert(os.WriteFile(foreignPath, []byte("SELECT 99;"), 0o600), qt.IsNil)
+
+	result, err := writeDiffArtifacts(
+		t.Context(),
+		dir,
+		"planned",
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+		baseSnapshot,
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migration directory changed during migrate diff planning`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	contents, err := os.ReadFile(foreignPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "SELECT 99;")
+	plannedFiles, err := filepath.Glob(filepath.Join(dir, "*_planned.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(plannedFiles, qt.HasLen, 0)
+	journalPath, err := publicationJournalPath(dir)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func beginTestPublication(
+	c *qt.C,
+	dir string,
+	batch migrationBatch,
+	contents []MigrationFileContent,
+) (publicationJournal, *migratesum.SumFile) {
+	c.Helper()
+	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	c.Assert(err, qt.IsNil)
+	_, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
+	c.Assert(err, qt.IsNil)
+	journal, err := beginPublication(dir, batch, sum.Bytes())
+	c.Assert(err, qt.IsNil)
+	return journal, sum
 }
 
 func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
@@ -226,7 +388,7 @@ func TestGenerateDiff_PostReplayReadFailureCleansAndReleasesLock(t *testing.T) {
 		) (*dbschematypes.DBSchema, error) {
 			return nil, readErr
 		},
-		cleanDevDatabase: cleanDevDatabaseAfterDiff,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
 	})
 
 	c.Assert(err, qt.ErrorIs, readErr)
@@ -243,16 +405,25 @@ func TestGenerateDiff_FinalCleanupFailureIsNotRetried(t *testing.T) {
 
 	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
 		readDevSchema: readScopedDevSchema,
-		cleanDevDatabase: func(context.Context, *dbschema.DatabaseConnection) error {
+		withReplayedSnapshot: func(
+			ctx context.Context,
+			conn *dbschema.DatabaseConnection,
+			snapshot fs.FS,
+			format migrator.MigrationDirFormat,
+			consume func(*dbschema.DatabaseConnection) error,
+		) error {
 			cleanupCalls++
-			return cleanupErr
+			return errors.Join(
+				migrationreplay.WithReplayedSnapshotLocked(ctx, conn, snapshot, format, consume),
+				cleanupErr,
+			)
 		},
 	})
 
 	c.Assert(err, qt.ErrorIs, cleanupErr)
 	c.Assert(result.MigrationPaths, qt.HasLen, 0)
 	c.Assert(cleanupCalls, qt.Equals, 1)
-	assertSQLiteCleanupObjectCount(c, conn, 2)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
 	assertDiffDirectoryReleased(c, opts.Dir)
 }
 
@@ -271,9 +442,18 @@ func TestGenerateDiff_JoinsPostReplayFailureAndCleanupFailure(t *testing.T) {
 		) (*dbschematypes.DBSchema, error) {
 			return nil, readErr
 		},
-		cleanDevDatabase: func(context.Context, *dbschema.DatabaseConnection) error {
+		withReplayedSnapshot: func(
+			ctx context.Context,
+			conn *dbschema.DatabaseConnection,
+			snapshot fs.FS,
+			format migrator.MigrationDirFormat,
+			consume func(*dbschema.DatabaseConnection) error,
+		) error {
 			cleanupCalls++
-			return cleanupErr
+			return errors.Join(
+				migrationreplay.WithReplayedSnapshotLocked(ctx, conn, snapshot, format, consume),
+				cleanupErr,
+			)
 		},
 	})
 
@@ -281,7 +461,7 @@ func TestGenerateDiff_JoinsPostReplayFailureAndCleanupFailure(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, cleanupErr)
 	c.Assert(result.MigrationPaths, qt.HasLen, 0)
 	c.Assert(cleanupCalls, qt.Equals, 1)
-	assertSQLiteCleanupObjectCount(c, conn, 2)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
 	assertDiffDirectoryReleased(c, opts.Dir)
 }
 
@@ -293,11 +473,23 @@ func TestGenerateDiff_CancellationDuringCleanupPreventsArtifacts(t *testing.T) {
 
 	result, err := generateDiff(ctx, conn, opts, diffRuntime{
 		readDevSchema: readScopedDevSchema,
-		cleanDevDatabase: func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+		withReplayedSnapshot: func(
+			replayCtx context.Context,
+			replayConn *dbschema.DatabaseConnection,
+			snapshot fs.FS,
+			format migrator.MigrationDirFormat,
+			consume func(*dbschema.DatabaseConnection) error,
+		) error {
 			cleanupCalls++
-			cleanupErr := cleanDevDatabaseAfterDiff(ctx, conn)
+			replayErr := migrationreplay.WithReplayedSnapshotLocked(
+				replayCtx,
+				replayConn,
+				snapshot,
+				format,
+				consume,
+			)
 			cancel()
-			return cleanupErr
+			return replayErr
 		},
 	})
 
@@ -335,6 +527,28 @@ func TestTryAcquireDirLock_ReclaimsStaleFile(t *testing.T) {
 	c.Assert(lock.release(), qt.IsNil)
 
 	_, err = os.Stat(lockPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestGenerateDiff_SerializesSQLiteDevDatabaseAcrossDirectories(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	opts.Dir = filepath.Join(c.TempDir(), "other-migrations")
+	opts.LockTimeout = time.Millisecond
+	devLock, err := acquireDevDatabaseLock(t.Context(), conn, 0)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(devLock.release(), qt.IsNil)
+	})
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `acquire migrate diff dev database lock: acquire sqlite dev database realm lock: lock timeout after 1ms`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	_, err = os.Stat(opts.Dir)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -7,6 +7,7 @@ package atlasmigrate
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlassource"
 	"github.com/stokaro/ptah/internal/atlasurl"
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/migrationreplay"
 	"github.com/stokaro/ptah/internal/migrationsnapshot"
@@ -39,10 +41,13 @@ func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 		{NameSuffix: "_concurrent_indexes", SQL: "SELECT 2;", NoTransaction: true},
 	}
 
-	paths, err := writeMigrationFilesAt(dir, "add_email", 1, contents)
+	batch, err := stageMigrationBatchAt(dir, "add_email", 1, contents)
+	c.Assert(err, qt.IsNil)
+	published, err := publishMigrationBatch(dir, batch)
 
 	c.Assert(err, qt.ErrorMatches, `migration directory changed during publication: .*2_add_email_concurrent_indexes\.sql already exists`)
-	c.Assert(paths, qt.HasLen, 0)
+	c.Assert(published, qt.Equals, 1)
+	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
 	// The colliding file kept its content and no version-1 leftover remains
 	// from the aborted attempt.
 	taken, readErr := os.ReadFile(filepath.Join(dir, "2_add_email_concurrent_indexes.sql"))
@@ -60,13 +65,16 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 	// already written; the batch rolls back completely.
 	oversizedSuffix := "_" + strings.Repeat("x", 512)
 
-	paths, err := writeMigrationFiles(dir, "add_email", []MigrationFileContent{
+	batch, err := stageMigrationBatch(dir, "add_email", []MigrationFileContent{
 		{NameSuffix: "_transactional", SQL: "SELECT 1;"},
 		{NameSuffix: oversizedSuffix, SQL: "SELECT 2;", NoTransaction: true},
 	})
+	c.Assert(err, qt.IsNil)
+	published, err := publishMigrationBatch(dir, batch)
 
 	c.Assert(err, qt.ErrorMatches, `publish migration file: .*`)
-	c.Assert(paths, qt.HasLen, 0)
+	c.Assert(published, qt.Equals, 1)
+	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
 	_, leftoverErr := os.Stat(filepath.Join(dir, "1_add_email_transactional.sql"))
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
 }
@@ -375,6 +383,84 @@ func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
+func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name string
+		mode publicationMode
+	}{
+		{name: "hard link", mode: publicationModeHardLink},
+		{name: "copy", mode: publicationModeCopy},
+		{name: "write-through move", mode: publicationModeWriteThroughMove},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := c.TempDir()
+			batch, err := stageMigrationBatchAt(
+				dir,
+				"interrupted",
+				1,
+				[]MigrationFileContent{{SQL: "SELECT 1;"}},
+			)
+			c.Assert(err, qt.IsNil)
+			batch.mode = test.mode
+			_, _ = beginTestPublication(
+				c,
+				dir,
+				batch,
+				[]MigrationFileContent{{SQL: "SELECT 1;"}},
+			)
+			published, err := publishMigrationBatch(dir, batch)
+			c.Assert(err, qt.IsNil)
+			c.Assert(published, qt.Equals, 1)
+			quarantineDir := batch.stagedPaths[0] + ".rollback"
+			quarantinePath := filepath.Join(quarantineDir, "published")
+			c.Assert(os.Mkdir(quarantineDir, 0o700), qt.IsNil)
+			c.Assert(os.Rename(batch.paths[0], quarantinePath), qt.IsNil)
+			c.Assert(removeFiles(batch.stagedPaths), qt.IsNil)
+
+			c.Assert(recoverPendingPublication(dir), qt.IsNil)
+
+			_, err = os.Stat(batch.paths[0])
+			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+			_, err = os.Stat(batch.stagedPaths[0])
+			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+			_, err = os.Stat(quarantinePath)
+			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+			_, err = os.Stat(quarantineDir)
+			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+			journalPath, err := publicationJournalPath(dir)
+			c.Assert(err, qt.IsNil)
+			_, err = os.Stat(journalPath)
+			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+		})
+	}
+}
+
+func TestRemovePublicationJournal_RetireFailurePreservesCommitMarker(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	journalPath := filepath.Join(dir, "publication.pending")
+	markerPath := publicationCommitMarkerPath(journalPath)
+	c.Assert(os.WriteFile(journalPath, []byte("{}"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(markerPath, []byte("committed"), 0o600), qt.IsNil)
+	retireErr := errors.New("injected journal retirement failure")
+
+	err := removePublicationJournalWithRetirer(
+		journalPath,
+		func(string, string) error {
+			return retireErr
+		},
+	)
+
+	c.Assert(err, qt.ErrorIs, retireErr)
+	_, err = os.Stat(journalPath)
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(markerPath)
+	c.Assert(err, qt.IsNil)
+}
+
 func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
@@ -406,6 +492,8 @@ func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	_, err = os.Stat(journalPath + publicationCleanupSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
@@ -687,10 +775,31 @@ func TestWriteMigrationFiles_EmptySQLIsRejected(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
 
-	paths, err := writeMigrationFiles(dir, "noop", []MigrationFileContent{{SQL: "   \n"}})
+	batch, err := stageMigrationBatch(dir, "noop", []MigrationFileContent{{SQL: "   \n"}})
 
 	c.Assert(err, qt.ErrorMatches, `migration SQL is empty`)
-	c.Assert(paths, qt.HasLen, 0)
+	c.Assert(batch.paths, qt.HasLen, 0)
+}
+
+func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
+	return publishMigrationBatchContext(context.Background(), dir, batch)
+}
+
+func rollBackUnjournaledBatch(
+	dir string,
+	batch migrationBatch,
+	published int,
+) error {
+	if err := removeFiles(batch.paths[:published]); err != nil {
+		return fmt.Errorf("roll back published migration files: %w", err)
+	}
+	if err := removeFiles(batch.stagedPaths); err != nil {
+		return fmt.Errorf("remove rolled back migration staging files: %w", err)
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync rolled back migration directory: %w", err)
+	}
+	return nil
 }
 
 func TestGenerateDiff_PostReplayReadFailureCleansAndReleasesLock(t *testing.T) {

--- a/internal/atlasmigrate/diff_prepare_nonwindows_internal_test.go
+++ b/internal/atlasmigrate/diff_prepare_nonwindows_internal_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package atlasmigrate
+
+// White-box testing required: replacing a staged file during the internal
+// preparation callback cannot be exercised through the exported API.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/migrationreplay"
+)
+
+func TestGenerateDiff_PreparePublicationRejectsSymlinkReplacement(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	previousSum, err := os.ReadFile(filepath.Join(opts.Dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	targetPath := filepath.Join(c.TempDir(), "replacement.sql")
+	c.Assert(os.WriteFile(targetPath, []byte("SELECT 99;\n"), 0o600), qt.IsNil)
+	opts.PreparePublication = func(stagedPaths []string) error {
+		return errors.Join(
+			os.Remove(stagedPaths[0]),
+			os.Symlink(targetPath, stagedPaths[0]),
+		)
+	}
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `staged migration file is not a regular file: .*`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	restoredSum, err := os.ReadFile(filepath.Join(opts.Dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(restoredSum, qt.DeepEquals, previousSum)
+	sqlFiles, err := filepath.Glob(filepath.Join(opts.Dir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqlFiles, qt.HasLen, 1)
+	assertSQLiteCleanupObjectCount(c, conn, 0)
+	assertDiffDirectoryLockReleased(c, opts.Dir)
+}

--- a/internal/atlasmigrate/diff_test.go
+++ b/internal/atlasmigrate/diff_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/internal/atlassource"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/testutils"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -62,6 +63,7 @@ CREATE TABLE users (
 	sum, err := os.ReadFile(result.SumPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(sum), qt.Contains, filepath.Base(result.MigrationPaths[0]))
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func TestGenerateDiff_CustomFormatWritesFormattedMigrationSQL(t *testing.T) {
@@ -131,7 +133,7 @@ CREATE TABLE users (
 		DryRun:      true,
 	})
 	_, statErr := os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
-	_, lockStatErr := os.Stat(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"))
+	_, lockStatErr := os.Stat(diffLockPath(migrationsDir))
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.Synced, qt.IsFalse)
@@ -143,6 +145,7 @@ CREATE TABLE users (
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
 	c.Assert(statErr, qt.ErrorIs, os.ErrNotExist)
 	c.Assert(lockStatErr, qt.ErrorIs, os.ErrNotExist)
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func TestGenerateDiff_DryRunPreservesExistingAtlasSum(t *testing.T) {
@@ -188,6 +191,7 @@ CREATE TABLE users (
 	c.Assert(readErr, qt.IsNil)
 	c.Assert(string(afterSum), qt.Equals, string(beforeSum))
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func TestGenerateDiff_SyncedReturnsNoChange(t *testing.T) {
@@ -222,6 +226,7 @@ CREATE TABLE users (
 	c.Assert(result.MigrationPaths, qt.HasLen, 0)
 	c.Assert(result.SumPath, qt.Equals, "")
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func TestGenerateDiff_SchemaFilterIgnoresOutOfScopeDesiredSchema(t *testing.T) {
@@ -290,6 +295,8 @@ CREATE TABLE users (
 
 	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
 	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE protected_users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
 
 	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
 		Dir:         migrationsDir,
@@ -302,6 +309,15 @@ CREATE TABLE users (
 	c.Assert(result.Synced, qt.IsFalse)
 	c.Assert(result.MigrationPaths, qt.HasLen, 0)
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
+	var protectedCount int
+	err = conn.QueryRowContext(
+		t.Context(),
+		`SELECT COUNT(*) FROM pragma_table_list WHERE schema = ? AND name = ?`,
+		"main",
+		"protected_users",
+	).Scan(&protectedCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(protectedCount, qt.Equals, 1)
 }
 
 func TestGenerateDiff_LockTimeout(t *testing.T) {
@@ -309,7 +325,11 @@ func TestGenerateDiff_LockTimeout(t *testing.T) {
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
 	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
-	c.Assert(os.WriteFile(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock"), []byte("held\n"), 0o600), qt.IsNil)
+	releaseLock, err := testutils.AcquireExclusiveFileLock(diffLockPath(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(releaseLock(), qt.IsNil)
+	})
 	schemaPath := filepath.Join(dir, "schema.sql")
 	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE locked_diff (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
 
@@ -327,6 +347,50 @@ func TestGenerateDiff_LockTimeout(t *testing.T) {
 	c.Assert(result.Synced, qt.IsFalse)
 	c.Assert(result.MigrationPaths, qt.HasLen, 0)
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 0)
+}
+
+func TestGenerateDiff_LockCoversMigrationDirectoryDesiredResolution(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	releaseLock, err := testutils.AcquireExclusiveFileLock(diffLockPath(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(releaseLock(), qt.IsNil)
+	})
+	desiredDir := filepath.Join(dir, "desired")
+	c.Assert(os.MkdirAll(desiredDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(desiredDir, "1_desired.sql"),
+		[]byte("CREATE TABLE desired_users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, err = migratesum.WriteWithFormat(desiredDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE protected_users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+
+	result, err := atlasmigrate.GenerateDiff(t.Context(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		Desired:     localDesiredSet(c, "file://"+desiredDir),
+		Name:        "locked_diff",
+		LockTimeout: time.Millisecond,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `migration directory lock timeout after 1ms: .*\.ptah-migrate-diff\.lock`)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	var protectedCount int
+	err = conn.QueryRowContext(
+		t.Context(),
+		`SELECT COUNT(*) FROM pragma_table_list WHERE schema = ? AND name = ?`,
+		"main",
+		"protected_users",
+	).Scan(&protectedCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(protectedCount, qt.Equals, 1)
 }
 
 func TestGenerateDiff_RejectsInvalidFormatBeforeCreatingDirectory(t *testing.T) {
@@ -380,6 +444,7 @@ CREATE TABLE users (
 	c.Assert(result.Synced, qt.IsFalse)
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
 	c.Assert(fileExists(filepath.Join(migrationsDir, "atlas.sum")), qt.IsFalse)
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func TestGenerateDiff_ReleasesLockAfterError(t *testing.T) {
@@ -388,23 +453,65 @@ func TestGenerateDiff_ReleasesLockAfterError(t *testing.T) {
 	migrationsDir := filepath.Join(dir, "migrations")
 	c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
 	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_init.sql"), []byte(`
-CREATE TABLE users (
-  id INTEGER PRIMARY KEY
-);
+THIS IS NOT SQL;
 `), 0o600), qt.IsNil)
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		"CREATE TABLE desired_users (id INTEGER PRIMARY KEY);\n",
+	), 0o600), qt.IsNil)
 	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
 	defer dbschema.CloseAndWarn(conn)
 
 	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
 		Dir:         migrationsDir,
-		Desired:     localDesiredSet(c, "file://"+filepath.Join(dir, "missing.sql")),
-		Name:        "missing_schema",
+		Desired:     localDesiredSet(c, "file://"+schemaPath),
+		Name:        "invalid_replay",
 		LockTimeout: time.Second,
 	})
 
-	c.Assert(err, qt.ErrorMatches, `load --to schema: .*`)
+	c.Assert(err, qt.ErrorMatches, `(?s)replay migration 1 on dev database: .*`)
 	c.Assert(result.Synced, qt.IsFalse)
-	c.Assert(fileExists(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock")), qt.IsFalse)
+	c.Assert(fileExists(diffLockPath(migrationsDir)), qt.IsFalse)
+	assertDevDatabaseEmpty(c, conn)
+}
+
+func TestGenerateDiff_PreCanceledContextPreservesDevAndSkipsDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		"CREATE TABLE desired_users (id INTEGER PRIMARY KEY);\n",
+	), 0o600), qt.IsNil)
+	conn := connectSQLite(c, filepath.Join(dir, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+	_, err := conn.ExecContext(t.Context(),
+		"CREATE TABLE stale_users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := atlasmigrate.GenerateDiff(ctx, conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		Desired:     localDesiredSet(c, "file://"+schemaPath),
+		Name:        "canceled",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(result.Synced, qt.IsFalse)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(fileExists(diffLockPath(migrationsDir)), qt.IsFalse)
+	c.Assert(fileExists(migrationsDir), qt.IsFalse)
+	var count int
+	err = conn.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM pragma_table_list WHERE schema = ? AND name = ?",
+		"main",
+		"stale_users",
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
 }
 
 func TestGenerateDiff_InvalidMigrationSnapshotDoesNotResetDevDatabase(t *testing.T) {
@@ -534,11 +641,9 @@ func TestGenerateDiff_QualifierRejectsMultiSchemaScopeBeforeAnyWrite(t *testing.
 	c.Assert(fileExists(migrationsDir), qt.IsFalse)
 }
 
-// TestGenerateDiff_SumWriteFailureRemovesMigrationFiles injects an atlas.sum
-// write failure (a read-only existing checksum) and verifies the
-// all-or-nothing contract: the newly written migration file is rolled back and
-// no checksum is left behind.
-func TestGenerateDiff_SumWriteFailureRemovesMigrationFiles(t *testing.T) {
+// TestGenerateDiff_AtomicallyReplacesReadOnlySum verifies that checksum
+// publication replaces the old file instead of truncating it in place.
+func TestGenerateDiff_AtomicallyReplacesReadOnlySum(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
@@ -572,17 +677,16 @@ CREATE TABLE users (
 		LockTimeout: time.Second,
 	})
 
-	c.Assert(err, qt.ErrorMatches, `write atlas\.sum: .*`)
+	c.Assert(err, qt.IsNil)
 	c.Assert(result.Synced, qt.IsFalse)
-	c.Assert(result.MigrationPaths, qt.HasLen, 0)
-	c.Assert(result.SumPath, qt.Equals, "")
-	// The generated migration file was rolled back; only the pre-existing
-	// migration remains and no atlas.sum content was written.
-	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
+	c.Assert(result.MigrationPaths, qt.HasLen, 1)
+	c.Assert(result.SumPath, qt.Equals, sumPath)
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 2)
 	afterSum, sumErr := os.ReadFile(sumPath)
 	c.Assert(sumErr, qt.IsNil)
-	c.Assert(afterSum, qt.DeepEquals, previousSum)
-	c.Assert(fileExists(filepath.Join(migrationsDir, ".ptah-migrate-diff.lock")), qt.IsFalse)
+	c.Assert(afterSum, qt.Not(qt.DeepEquals), previousSum)
+	c.Assert(fileExists(diffLockPath(migrationsDir)), qt.IsFalse)
+	assertDevDatabaseEmpty(c, conn)
 }
 
 func connectSQLite(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
@@ -590,6 +694,29 @@ func connectSQLite(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
 	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
 	c.Assert(err, qt.IsNil)
 	return conn
+}
+
+func diffLockPath(migrationsDir string) string {
+	cleanDir := filepath.Clean(migrationsDir)
+	return filepath.Join(
+		filepath.Dir(cleanDir),
+		"."+filepath.Base(cleanDir)+".ptah-migrate-diff.lock",
+	)
+}
+
+func assertDevDatabaseEmpty(c *qt.C, conn *dbschema.DatabaseConnection) {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM pragma_table_list
+		WHERE schema = ?
+		  AND type IN ('table', 'view', 'virtual')
+		  AND name NOT LIKE 'sqlite_%'
+		  AND name <> 'schema_migrations'
+	`, "main").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }
 
 func localDesiredSet(c *qt.C, rawURL string) atlassource.Set {

--- a/internal/atlasmigrate/diff_test.go
+++ b/internal/atlasmigrate/diff_test.go
@@ -133,7 +133,6 @@ CREATE TABLE users (
 		DryRun:      true,
 	})
 	_, statErr := os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
-	_, lockStatErr := os.Stat(diffLockPath(migrationsDir))
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.Synced, qt.IsFalse)
@@ -144,7 +143,7 @@ CREATE TABLE users (
 	c.Assert(result.SumPath, qt.Equals, "")
 	c.Assert(atlasSQLFiles(c, migrationsDir), qt.DeepEquals, []string{filepath.Join(migrationsDir, "1_init.sql")})
 	c.Assert(statErr, qt.ErrorIs, os.ErrNotExist)
-	c.Assert(lockStatErr, qt.ErrorIs, os.ErrNotExist)
+	assertDiffLockReleased(c, migrationsDir)
 	assertDevDatabaseEmpty(c, conn)
 }
 
@@ -471,7 +470,7 @@ THIS IS NOT SQL;
 
 	c.Assert(err, qt.ErrorMatches, `(?s)replay migration 1 on dev database: .*`)
 	c.Assert(result.Synced, qt.IsFalse)
-	c.Assert(fileExists(diffLockPath(migrationsDir)), qt.IsFalse)
+	assertDiffLockReleased(c, migrationsDir)
 	assertDevDatabaseEmpty(c, conn)
 }
 
@@ -685,7 +684,7 @@ CREATE TABLE users (
 	afterSum, sumErr := os.ReadFile(sumPath)
 	c.Assert(sumErr, qt.IsNil)
 	c.Assert(afterSum, qt.Not(qt.DeepEquals), previousSum)
-	c.Assert(fileExists(diffLockPath(migrationsDir)), qt.IsFalse)
+	assertDiffLockReleased(c, migrationsDir)
 	assertDevDatabaseEmpty(c, conn)
 }
 
@@ -702,6 +701,13 @@ func diffLockPath(migrationsDir string) string {
 		filepath.Dir(cleanDir),
 		"."+filepath.Base(cleanDir)+".ptah-migrate-diff.lock",
 	)
+}
+
+func assertDiffLockReleased(c *qt.C, migrationsDir string) {
+	c.Helper()
+	release, err := testutils.AcquireExclusiveFileLock(diffLockPath(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(release(), qt.IsNil)
 }
 
 func assertDevDatabaseEmpty(c *qt.C, conn *dbschema.DatabaseConnection) {

--- a/internal/atlasmigrate/lock.go
+++ b/internal/atlasmigrate/lock.go
@@ -1,0 +1,144 @@
+package atlasmigrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+var errDirLocked = errors.New("migration directory is locked")
+
+type dirLock struct {
+	path string
+	file *os.File
+}
+
+func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Duration) (*dirLock, error) {
+	canonicalDir, err := canonicalMigrationDir(migrationsDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve migration directory lock path: %w", err)
+	}
+	lockPath := migrationDirLockPath(canonicalDir)
+	startedAt := time.Now()
+	for {
+		lock, err := tryAcquireDirLock(lockPath)
+		if err == nil {
+			return lock, nil
+		}
+		if !errors.Is(err, errDirLocked) {
+			return nil, err
+		}
+		if timeout > 0 && time.Since(startedAt) >= timeout {
+			return nil, fmt.Errorf("migration directory lock timeout after %s: %s", timeout, lockPath)
+		}
+		if err := waitForDirLockRetry(ctx, startedAt, timeout); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func canonicalMigrationDir(migrationsDir string) (string, error) {
+	absoluteDir, err := filepath.Abs(migrationsDir)
+	if err != nil {
+		return "", err
+	}
+	resolvedDir, err := filepath.EvalSymlinks(absoluteDir)
+	if err == nil {
+		return resolvedDir, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(absoluteDir))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedParent, filepath.Base(absoluteDir)), nil
+}
+
+func migrationDirLockPath(migrationsDir string) string {
+	cleanDir := filepath.Clean(migrationsDir)
+	return filepath.Join(
+		filepath.Dir(cleanDir),
+		"."+filepath.Base(cleanDir)+lockFileName,
+	)
+}
+
+func tryAcquireDirLock(lockPath string) (*dirLock, error) {
+	file, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("open migration directory lock: %w", err)
+	}
+	locked, err := tryLockFile(file)
+	if err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	if !locked {
+		return nil, errors.Join(errDirLocked, file.Close())
+	}
+	current, err := file.Stat()
+	if err != nil {
+		return nil, errors.Join(err, unlockFile(file), file.Close())
+	}
+	pathInfo, err := os.Stat(lockPath)
+	if err != nil || !os.SameFile(current, pathInfo) {
+		return nil, errors.Join(errDirLocked, unlockFile(file), file.Close())
+	}
+	return &dirLock{path: lockPath, file: file}, nil
+}
+
+func waitForDirLockRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
+	wait := 25 * time.Millisecond
+	if timeout > 0 {
+		remaining := timeout - time.Since(startedAt)
+		if remaining <= 0 {
+			return nil
+		}
+		wait = min(wait, remaining)
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("acquire migration directory lock: %w", ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (l *dirLock) release() error {
+	if l == nil {
+		return nil
+	}
+	removeErr := removeLockPath(l.path, l.file)
+	syncErr := fsdurable.SyncDir(filepath.Dir(l.path))
+	unlockErr := unlockFile(l.file)
+	closeErr := l.file.Close()
+	if err := errors.Join(removeErr, syncErr, unlockErr, closeErr); err != nil {
+		return fmt.Errorf("release migration directory lock: %w", err)
+	}
+	return nil
+}
+
+func removeLockPath(path string, file *os.File) error {
+	current, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	pathInfo, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !os.SameFile(current, pathInfo) {
+		return errors.New("migration directory lock path changed while held")
+	}
+	return os.Remove(path)
+}

--- a/internal/atlasmigrate/lock.go
+++ b/internal/atlasmigrate/lock.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,25 +16,63 @@ type dirLock struct {
 	file *os.File
 }
 
+type heldMigrationDirectoryLock struct {
+	active       atomic.Bool
+	canonicalDir string
+	parent       *heldMigrationDirectoryLock
+}
+
+type heldMigrationDirectoryLockContextKey struct{}
+
 // WithMigrationDirectoryLock invokes consume while holding the cross-process
-// lock shared by migration directory readers and publishers.
+// lock shared by migration directory readers and publishers. The callback must
+// use its scoped context for nested operations that may acquire the same lock.
 func WithMigrationDirectoryLock(
 	ctx context.Context,
 	migrationsDir string,
 	timeout time.Duration,
-	consume func() error,
+	consume func(context.Context) error,
 ) (resultErr error) {
 	if consume == nil {
 		return errors.New("migration directory lock callback is nil")
 	}
-	lock, err := acquireDirLock(ctx, migrationsDir, timeout)
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("acquire migration directory lock: %w", err)
+	}
+	canonicalDir, err := canonicalMigrationDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("resolve migration directory lock path: %w", err)
+	}
+	held, _ := ctx.Value(heldMigrationDirectoryLockContextKey{}).(*heldMigrationDirectoryLock)
+	lock, err := acquireDirLock(ctx, canonicalDir, timeout)
 	if err != nil {
 		return err
 	}
+	current := &heldMigrationDirectoryLock{
+		canonicalDir: canonicalDir,
+		parent:       held,
+	}
+	current.active.Store(true)
+	lockedCtx := context.WithValue(ctx, heldMigrationDirectoryLockContextKey{}, current)
 	defer func() {
+		current.active.Store(false)
 		resultErr = errors.Join(resultErr, lock.release())
 	}()
-	return consume()
+	return consume(lockedCtx)
+}
+
+func migrationDirectoryLockHeld(ctx context.Context, migrationsDir string) (bool, error) {
+	canonicalDir, err := canonicalMigrationDir(migrationsDir)
+	if err != nil {
+		return false, err
+	}
+	held, _ := ctx.Value(heldMigrationDirectoryLockContextKey{}).(*heldMigrationDirectoryLock)
+	for current := held; current != nil; current = current.parent {
+		if current.active.Load() && current.canonicalDir == canonicalDir {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Duration) (*dirLock, error) {

--- a/internal/atlasmigrate/lock.go
+++ b/internal/atlasmigrate/lock.go
@@ -7,18 +7,39 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/stokaro/ptah/internal/fsdurable"
 )
 
 var errDirLocked = errors.New("migration directory is locked")
 
 type dirLock struct {
-	path string
 	file *os.File
 }
 
+// WithMigrationDirectoryLock invokes consume while holding the cross-process
+// lock shared by migration directory readers and publishers.
+func WithMigrationDirectoryLock(
+	ctx context.Context,
+	migrationsDir string,
+	timeout time.Duration,
+	consume func() error,
+) (resultErr error) {
+	if consume == nil {
+		return errors.New("migration directory lock callback is nil")
+	}
+	lock, err := acquireDirLock(ctx, migrationsDir, timeout)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, lock.release())
+	}()
+	return consume()
+}
+
 func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Duration) (*dirLock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("acquire migration directory lock: %w", err)
+	}
 	canonicalDir, err := canonicalMigrationDir(migrationsDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve migration directory lock path: %w", err)
@@ -28,6 +49,12 @@ func acquireDirLock(ctx context.Context, migrationsDir string, timeout time.Dura
 	for {
 		lock, err := tryAcquireDirLock(lockPath)
 		if err == nil {
+			if contextErr := ctx.Err(); contextErr != nil {
+				return nil, errors.Join(
+					fmt.Errorf("acquire migration directory lock: %w", contextErr),
+					lock.release(),
+				)
+			}
 			return lock, nil
 		}
 		if !errors.Is(err, errDirLocked) {
@@ -89,7 +116,7 @@ func tryAcquireDirLock(lockPath string) (*dirLock, error) {
 	if err != nil || !os.SameFile(current, pathInfo) {
 		return nil, errors.Join(errDirLocked, unlockFile(file), file.Close())
 	}
-	return &dirLock{path: lockPath, file: file}, nil
+	return &dirLock{file: file}, nil
 }
 
 func waitForDirLockRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
@@ -115,30 +142,10 @@ func (l *dirLock) release() error {
 	if l == nil {
 		return nil
 	}
-	removeErr := removeLockPath(l.path, l.file)
-	syncErr := fsdurable.SyncDir(filepath.Dir(l.path))
 	unlockErr := unlockFile(l.file)
 	closeErr := l.file.Close()
-	if err := errors.Join(removeErr, syncErr, unlockErr, closeErr); err != nil {
+	if err := errors.Join(unlockErr, closeErr); err != nil {
 		return fmt.Errorf("release migration directory lock: %w", err)
 	}
 	return nil
-}
-
-func removeLockPath(path string, file *os.File) error {
-	current, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	pathInfo, err := os.Stat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if !os.SameFile(current, pathInfo) {
-		return errors.New("migration directory lock path changed while held")
-	}
-	return os.Remove(path)
 }

--- a/internal/atlasmigrate/lock_test.go
+++ b/internal/atlasmigrate/lock_test.go
@@ -1,0 +1,79 @@
+package atlasmigrate_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasmigrate"
+)
+
+func TestRecoverPendingPublication_ReusesHeldDirectoryLock(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	dir := c.TempDir()
+
+	err := atlasmigrate.WithMigrationDirectoryLock(ctx, dir, 0, func(lockedCtx context.Context) error {
+		return atlasmigrate.RecoverPendingPublication(lockedCtx, dir)
+	})
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestRecoverPendingPublication_DoesNotReuseReleasedDirectoryLock(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	var releasedCtx context.Context
+	err := atlasmigrate.WithMigrationDirectoryLock(
+		t.Context(),
+		dir,
+		0,
+		func(lockedCtx context.Context) error {
+			releasedCtx = lockedCtx
+			return nil
+		},
+	)
+	c.Assert(err, qt.IsNil)
+
+	recoveryCtx, cancel := context.WithTimeout(releasedCtx, 50*time.Millisecond)
+	defer cancel()
+	err = atlasmigrate.WithMigrationDirectoryLock(
+		t.Context(),
+		dir,
+		0,
+		func(context.Context) error {
+			return atlasmigrate.RecoverPendingPublication(recoveryCtx, dir)
+		},
+	)
+
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+}
+
+func TestRecoverPendingPublication_DoesNotReuseAnotherDirectoryLock(t *testing.T) {
+	c := qt.New(t)
+	heldDir := c.TempDir()
+	recoveryDir := c.TempDir()
+	recoveryCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := atlasmigrate.WithMigrationDirectoryLock(
+		t.Context(),
+		recoveryDir,
+		0,
+		func(context.Context) error {
+			return atlasmigrate.WithMigrationDirectoryLock(
+				t.Context(),
+				heldDir,
+				0,
+				func(heldCtx context.Context) error {
+					return atlasmigrate.RecoverPendingPublication(recoveryCtx, recoveryDir)
+				},
+			)
+		},
+	)
+
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+}

--- a/internal/atlasmigrate/lock_unix.go
+++ b/internal/atlasmigrate/lock_unix.go
@@ -1,0 +1,29 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package atlasmigrate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockFile(file *os.File) (bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock migration directory: %w", err)
+	}
+	return true, nil
+}
+
+func unlockFile(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock migration directory: %w", err)
+	}
+	return nil
+}

--- a/internal/atlasmigrate/lock_windows.go
+++ b/internal/atlasmigrate/lock_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package atlasmigrate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockFile(file *os.File) (bool, error) {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock migration directory: %w", err)
+	}
+	return true, nil
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(
+		windows.Handle(file.Fd()),
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("unlock migration directory: %w", err)
+	}
+	return nil
+}

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -454,7 +454,6 @@ func abortPendingPublication(dir string, batch migrationBatch, published int) er
 			batch.stagedPaths[i],
 			batch.paths[i],
 			batch.digests[i],
-			batch.mode,
 		); err != nil {
 			return fmt.Errorf("roll back published migration files: %w", err)
 		}
@@ -498,6 +497,22 @@ func recoverPendingPublication(dir string) error {
 // The caller must hold the migration-directory lock for dir.
 func RecoverPendingPublicationLocked(dir string) error {
 	return recoverPendingPublication(dir)
+}
+
+// RecoverPendingPublication resolves an interrupted artifact publication,
+// acquiring the migration-directory lock unless ctx proves that the caller
+// already holds it.
+func RecoverPendingPublication(ctx context.Context, dir string) error {
+	held, err := migrationDirectoryLockHeld(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("resolve migration directory lock path: %w", err)
+	}
+	if held {
+		return recoverPendingPublication(dir)
+	}
+	return WithMigrationDirectoryLock(ctx, dir, 0, func(context.Context) error {
+		return recoverPendingPublication(dir)
+	})
 }
 
 func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
@@ -561,7 +576,6 @@ func rollBackPendingPublication(
 			stagedPath,
 			finalPath,
 			entry.Digest,
-			publicationMode(entry.Mode),
 		); err != nil {
 			return err
 		}
@@ -574,11 +588,29 @@ func rollBackPendingPublication(
 
 func rollBackPublicationEntry(
 	stagedPath, finalPath, expectedDigest string,
-	_ publicationMode,
 ) error {
 	quarantineDir := stagedPath + ".rollback"
 	quarantinePath := filepath.Join(quarantineDir, "published")
 
+	if err := quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath); err != nil {
+		return err
+	}
+	stagedDigest, stagedErr := fileDigest(stagedPath)
+	quarantinedDigest, quarantineErr := fileDigest(quarantinePath)
+	return reconcileRollbackFiles(rollbackFileState{
+		stagedPath:        stagedPath,
+		finalPath:         finalPath,
+		quarantineDir:     quarantineDir,
+		quarantinePath:    quarantinePath,
+		expectedDigest:    expectedDigest,
+		stagedDigest:      stagedDigest,
+		stagedErr:         stagedErr,
+		quarantinedDigest: quarantinedDigest,
+		quarantineErr:     quarantineErr,
+	})
+}
+
+func quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath string) error {
 	if err := os.Mkdir(quarantineDir, 0700); err != nil && !errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("create migration rollback quarantine: %w", err)
 	}
@@ -596,48 +628,61 @@ func rollBackPublicationEntry(
 	} else if err != nil {
 		return fmt.Errorf("inspect quarantined migration file: %w", err)
 	}
+	return nil
+}
 
-	stagedDigest, stagedErr := fileDigest(stagedPath)
-	quarantinedDigest, quarantineErr := fileDigest(quarantinePath)
+type rollbackFileState struct {
+	stagedPath        string
+	finalPath         string
+	quarantineDir     string
+	quarantinePath    string
+	expectedDigest    string
+	stagedDigest      string
+	stagedErr         error
+	quarantinedDigest string
+	quarantineErr     error
+}
+
+func reconcileRollbackFiles(state rollbackFileState) error {
 	switch {
-	case errors.Is(stagedErr, os.ErrNotExist) && errors.Is(quarantineErr, os.ErrNotExist):
-		return removeEmptyQuarantineDir(quarantineDir)
-	case stagedErr == nil && errors.Is(quarantineErr, os.ErrNotExist):
-		if stagedDigest != expectedDigest {
+	case errors.Is(state.stagedErr, os.ErrNotExist) && errors.Is(state.quarantineErr, os.ErrNotExist):
+		return removeEmptyQuarantineDir(state.quarantineDir)
+	case state.stagedErr == nil && errors.Is(state.quarantineErr, os.ErrNotExist):
+		if state.stagedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: staging file content changed; preserved %s",
-				stagedPath,
+				state.stagedPath,
 			)
 		}
-		return removeRollbackFiles(quarantineDir, stagedPath)
-	case errors.Is(stagedErr, os.ErrNotExist) &&
-		quarantineErr == nil:
-		if quarantinedDigest != expectedDigest {
+		return removeRollbackFiles(state.quarantineDir, state.stagedPath)
+	case errors.Is(state.stagedErr, os.ErrNotExist) &&
+		state.quarantineErr == nil:
+		if state.quarantinedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: %s content changed; preserved at %s",
-				finalPath,
-				quarantinePath,
+				state.finalPath,
+				state.quarantinePath,
 			)
 		}
-		return removeRollbackFiles(quarantineDir, quarantinePath)
-	case stagedErr != nil:
-		return fmt.Errorf("inspect staged migration file: %w", stagedErr)
-	case quarantineErr != nil:
-		return fmt.Errorf("inspect quarantined migration file: %w", quarantineErr)
-	case stagedDigest != expectedDigest:
+		return removeRollbackFiles(state.quarantineDir, state.quarantinePath)
+	case state.stagedErr != nil:
+		return fmt.Errorf("inspect staged migration file: %w", state.stagedErr)
+	case state.quarantineErr != nil:
+		return fmt.Errorf("inspect quarantined migration file: %w", state.quarantineErr)
+	case state.stagedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: staging file content changed; preserved %s and %s",
-			stagedPath,
-			quarantinePath,
+			state.stagedPath,
+			state.quarantinePath,
 		)
-	case quarantinedDigest != expectedDigest:
+	case state.quarantinedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: %s content changed; preserved at %s",
-			finalPath,
-			quarantinePath,
+			state.finalPath,
+			state.quarantinePath,
 		)
 	default:
-		return removeRollbackFiles(quarantineDir, quarantinePath, stagedPath)
+		return removeRollbackFiles(state.quarantineDir, state.quarantinePath, state.stagedPath)
 	}
 }
 

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -1,0 +1,537 @@
+package atlasmigrate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const (
+	publicationJournalVersion = 1
+	publicationJournalSuffix  = ".ptah-migrate-diff.pending"
+	stagedMigrationPattern    = ".ptah-migrate-diff-*.tmp"
+)
+
+type publicationEntry struct {
+	Staged string `json:"staged"`
+	Final  string `json:"final"`
+}
+
+type publicationJournal struct {
+	Version int                `json:"version"`
+	Entries []publicationEntry `json:"entries"`
+}
+
+type migrationBatch struct {
+	paths       []string
+	stagedPaths []string
+}
+
+// writeDiffArtifacts durably publishes one batch of migration files and then
+// atlas.sum. A journal next to the migration directory makes an interrupted
+// publication recoverable by the next lock holder.
+func writeDiffArtifacts(
+	ctx context.Context,
+	dir, name string,
+	contents []MigrationFileContent,
+) (DiffResult, error) {
+	if err := ctx.Err(); err != nil {
+		return DiffResult{}, err
+	}
+	if err := recoverPendingPublication(dir); err != nil {
+		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
+	}
+	batch, err := stageMigrationBatch(dir, name, contents)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	if err := beginPublication(dir, batch); err != nil {
+		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	published, err := publishMigrationBatch(dir, batch)
+	if err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	if err := ctx.Err(); err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	sumPath, err := writeDirSum(dir)
+	if err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	result := DiffResult{MigrationPaths: batch.paths, SumPath: sumPath}
+	if err := recoverPendingPublication(dir); err != nil {
+		return result, fmt.Errorf("finalize migration artifact publication: %w", err)
+	}
+	return result, nil
+}
+
+func beginPublication(dir string, batch migrationBatch) error {
+	entries := make([]publicationEntry, len(batch.paths))
+	for i := range batch.paths {
+		entries[i] = publicationEntry{
+			Staged: filepath.Base(batch.stagedPaths[i]),
+			Final:  filepath.Base(batch.paths[i]),
+		}
+	}
+	journal := publicationJournal{
+		Version: publicationJournalVersion,
+		Entries: entries,
+	}
+	if err := writePublicationJournal(dir, journal); err != nil {
+		return fmt.Errorf("write migration publication journal: %w", err)
+	}
+	return nil
+}
+
+func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
+	for i, stagedPath := range batch.stagedPaths {
+		if err := os.Link(stagedPath, batch.paths[i]); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return i, fmt.Errorf(
+					"migration directory changed during publication: %s already exists",
+					batch.paths[i],
+				)
+			}
+			return i, fmt.Errorf("publish migration file: %w", err)
+		}
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return len(batch.paths), fmt.Errorf("sync published migration files: %w", err)
+	}
+	return len(batch.paths), nil
+}
+
+func abortPendingPublication(dir string, batch migrationBatch, published int) error {
+	if err := removeFiles(batch.paths[:published]); err != nil {
+		return fmt.Errorf("roll back published migration files: %w", err)
+	}
+	if err := removeFiles(batch.stagedPaths); err != nil {
+		return fmt.Errorf("remove rolled back migration staging files: %w", err)
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync rolled back migration directory: %w", err)
+	}
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return err
+	}
+	return removePublicationJournal(journalPath)
+}
+
+func recoverPendingPublication(dir string) error {
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return err
+	}
+	journal, err := readPublicationJournal(journalPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return removeOrphanPublicationTemps(dir, journalPath)
+	}
+	if err != nil {
+		return err
+	}
+	committed, err := publicationCommitted(dir)
+	if err != nil {
+		return err
+	}
+	if committed {
+		return finalizeCommittedPublication(dir, journalPath, journal)
+	}
+	return rollBackPendingPublication(dir, journalPath, journal)
+}
+
+func publicationCommitted(dir string) (bool, error) {
+	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	if errors.Is(err, migratesum.ErrSumFileMissing) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("verify migration publication commit marker: %w", err)
+	}
+	return result.OK(), nil
+}
+
+func finalizeCommittedPublication(
+	dir, journalPath string,
+	journal publicationJournal,
+) error {
+	stagedPaths := publicationStagedPaths(dir, journal)
+	if err := removeFiles(stagedPaths); err != nil {
+		return fmt.Errorf("remove committed migration staging files: %w", err)
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync committed migration directory: %w", err)
+	}
+	return removePublicationJournal(journalPath)
+}
+
+func rollBackPendingPublication(
+	dir, journalPath string,
+	journal publicationJournal,
+) error {
+	for _, entry := range journal.Entries {
+		stagedPath := filepath.Join(dir, entry.Staged)
+		finalPath := filepath.Join(dir, entry.Final)
+		if err := rollBackPublicationEntry(stagedPath, finalPath); err != nil {
+			return err
+		}
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync rolled back migration directory: %w", err)
+	}
+	return removePublicationJournal(journalPath)
+}
+
+func rollBackPublicationEntry(stagedPath, finalPath string) error {
+	stagedInfo, stagedErr := os.Stat(stagedPath)
+	finalInfo, finalErr := os.Stat(finalPath)
+	switch {
+	case errors.Is(stagedErr, os.ErrNotExist) && errors.Is(finalErr, os.ErrNotExist):
+		return nil
+	case stagedErr == nil && errors.Is(finalErr, os.ErrNotExist):
+		return removeFiles([]string{stagedPath})
+	case errors.Is(stagedErr, os.ErrNotExist) && finalErr == nil:
+		return fmt.Errorf(
+			"cannot safely recover migration publication: staging file missing for %s",
+			finalPath,
+		)
+	case stagedErr != nil:
+		return fmt.Errorf("inspect staged migration file: %w", stagedErr)
+	case finalErr != nil:
+		return fmt.Errorf("inspect published migration file: %w", finalErr)
+	case !os.SameFile(stagedInfo, finalInfo):
+		return fmt.Errorf(
+			"cannot safely recover migration publication: %s is not the journaled staging file",
+			finalPath,
+		)
+	default:
+		return removeFiles([]string{finalPath, stagedPath})
+	}
+}
+
+func removePublicationJournal(journalPath string) error {
+	if err := removeFiles([]string{journalPath}); err != nil {
+		return fmt.Errorf("remove migration publication journal: %w", err)
+	}
+	if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
+		return fmt.Errorf("sync migration publication journal directory: %w", err)
+	}
+	return nil
+}
+
+func removeOrphanPublicationTemps(dir, journalPath string) error {
+	stagedPaths, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
+	if err != nil {
+		return fmt.Errorf("find orphan migration staging files: %w", err)
+	}
+	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+	if err != nil {
+		return fmt.Errorf("find orphan migration publication journals: %w", err)
+	}
+	if err := removeFiles(append(stagedPaths, journalTemps...)); err != nil {
+		return fmt.Errorf("remove orphan migration publication files: %w", err)
+	}
+	if len(stagedPaths) > 0 {
+		if err := fsdurable.SyncDir(dir); err != nil {
+			return fmt.Errorf("sync migration directory after orphan cleanup: %w", err)
+		}
+	}
+	if len(journalTemps) > 0 {
+		if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
+			return fmt.Errorf("sync publication journal directory after orphan cleanup: %w", err)
+		}
+	}
+	return nil
+}
+
+func writePublicationJournal(dir string, journal publicationJournal) error {
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return err
+	}
+	contents, err := json.Marshal(journal)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(journalPath)
+	file, err := os.CreateTemp(parent, filepath.Base(journalPath)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := file.Name()
+	if err := file.Chmod(0600); err != nil {
+		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
+	}
+	if _, err := file.Write(contents); err != nil {
+		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
+	}
+	if err := file.Sync(); err != nil {
+		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(err, removeFiles([]string{tempPath}))
+	}
+	if err := os.Link(tempPath, journalPath); err != nil {
+		return errors.Join(err, removeFiles([]string{tempPath}))
+	}
+	if err := removeFiles([]string{tempPath}); err != nil {
+		return err
+	}
+	return fsdurable.SyncDir(parent)
+}
+
+func readPublicationJournal(path string) (publicationJournal, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return publicationJournal{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.DisallowUnknownFields()
+	var journal publicationJournal
+	if err := decoder.Decode(&journal); err != nil {
+		return publicationJournal{}, fmt.Errorf("decode migration publication journal: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return publicationJournal{}, err
+	}
+	if err := validatePublicationJournal(journal); err != nil {
+		return publicationJournal{}, err
+	}
+	return journal, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return errors.New("decode migration publication journal: trailing JSON data")
+	}
+	return nil
+}
+
+func validatePublicationJournal(journal publicationJournal) error {
+	if journal.Version != publicationJournalVersion {
+		return fmt.Errorf(
+			"unsupported migration publication journal version: %d",
+			journal.Version,
+		)
+	}
+	if len(journal.Entries) == 0 {
+		return errors.New("migration publication journal has no entries")
+	}
+	stagedNames := make([]string, 0, len(journal.Entries))
+	finalNames := make([]string, 0, len(journal.Entries))
+	for _, entry := range journal.Entries {
+		if filepath.Base(entry.Staged) != entry.Staged ||
+			!strings.HasPrefix(entry.Staged, ".ptah-migrate-diff-") ||
+			!strings.HasSuffix(entry.Staged, ".tmp") {
+			return fmt.Errorf("invalid staged migration publication path: %q", entry.Staged)
+		}
+		if filepath.Base(entry.Final) != entry.Final ||
+			!strings.HasSuffix(entry.Final, ".sql") {
+			return fmt.Errorf("invalid final migration publication path: %q", entry.Final)
+		}
+		if slices.Contains(stagedNames, entry.Staged) ||
+			slices.Contains(finalNames, entry.Final) {
+			return errors.New("migration publication journal contains duplicate paths")
+		}
+		stagedNames = append(stagedNames, entry.Staged)
+		finalNames = append(finalNames, entry.Final)
+	}
+	return nil
+}
+
+func publicationJournalPath(dir string) (string, error) {
+	canonicalDir, err := canonicalMigrationDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve migration publication journal path: %w", err)
+	}
+	return filepath.Join(
+		filepath.Dir(canonicalDir),
+		"."+filepath.Base(canonicalDir)+publicationJournalSuffix,
+	), nil
+}
+
+func publicationStagedPaths(dir string, journal publicationJournal) []string {
+	paths := make([]string, 0, len(journal.Entries))
+	for _, entry := range journal.Entries {
+		paths = append(paths, filepath.Join(dir, entry.Staged))
+	}
+	return paths
+}
+
+// writeDirSum atomically refreshes atlas.sum after every complete migration
+// file has been published. The sum is the commit marker for the batch.
+func writeDirSum(dir string) (string, error) {
+	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
+	if _, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas); err != nil {
+		return "", fmt.Errorf("write atlas.sum: %w", err)
+	}
+	return sumPath, nil
+}
+
+func removeFiles(paths []string) error {
+	var resultErr error
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+	return resultErr
+}
+
+// writeMigrationFiles writes every planned migration file with consecutive
+// versions. It is retained as a focused white-box primitive; production
+// publication uses writeDiffArtifacts so the batch is journaled through the
+// atlas.sum commit.
+func writeMigrationFiles(dir, name string, contents []MigrationFileContent) ([]string, error) {
+	batch, err := stageMigrationBatch(dir, name, contents)
+	if err != nil {
+		return nil, err
+	}
+	published, err := publishMigrationBatch(dir, batch)
+	if err != nil {
+		return nil, errors.Join(err, rollBackUnjournaledBatch(dir, batch, published))
+	}
+	if err := removeFiles(batch.stagedPaths); err != nil {
+		return nil, errors.Join(err, removeFiles(batch.paths))
+	}
+	return batch.paths, nil
+}
+
+func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (migrationBatch, error) {
+	if len(contents) == 0 {
+		return migrationBatch{}, errors.New("migration SQL is empty")
+	}
+	for _, content := range contents {
+		if strings.TrimSpace(content.SQL) == "" {
+			return migrationBatch{}, errors.New("migration SQL is empty")
+		}
+	}
+	version, err := nextMigrationVersion(dir)
+	if err != nil {
+		return migrationBatch{}, err
+	}
+	return stageMigrationBatchAt(dir, name, version, contents)
+}
+
+func stageMigrationBatchAt(
+	dir, name string,
+	version int64,
+	contents []MigrationFileContent,
+) (migrationBatch, error) {
+	batch := migrationBatch{
+		paths:       make([]string, 0, len(contents)),
+		stagedPaths: make([]string, 0, len(contents)),
+	}
+	for i, content := range contents {
+		fileVersion := version + int64(i)
+		slug := migrationSlug(name + content.NameSuffix)
+		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", fileVersion, slug))
+		stagedPath, err := stageMigrationFile(dir, content.SQL)
+		if err != nil {
+			return migrationBatch{}, errors.Join(
+				fmt.Errorf("stage migration file: %w", err),
+				removeFiles(batch.stagedPaths),
+			)
+		}
+		batch.paths = append(batch.paths, path)
+		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+	}
+	return batch, nil
+}
+
+// writeMigrationFilesAt stages and syncs one complete batch before publishing
+// each final path without overwriting an existing migration.
+func writeMigrationFilesAt(
+	dir, name string,
+	version int64,
+	contents []MigrationFileContent,
+) ([]string, error) {
+	batch, err := stageMigrationBatchAt(dir, name, version, contents)
+	if err != nil {
+		return nil, err
+	}
+	published, err := publishMigrationBatch(dir, batch)
+	if err != nil {
+		return nil, errors.Join(err, rollBackUnjournaledBatch(dir, batch, published))
+	}
+	if err := removeFiles(batch.stagedPaths); err != nil {
+		return nil, errors.Join(err, removeFiles(batch.paths))
+	}
+	return batch.paths, nil
+}
+
+func rollBackUnjournaledBatch(dir string, batch migrationBatch, published int) error {
+	if err := removeFiles(batch.paths[:published]); err != nil {
+		return fmt.Errorf("roll back published migration files: %w", err)
+	}
+	if err := removeFiles(batch.stagedPaths); err != nil {
+		return fmt.Errorf("remove rolled back migration staging files: %w", err)
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync rolled back migration directory: %w", err)
+	}
+	return nil
+}
+
+func stageMigrationFile(dir, migrationSQL string) (string, error) {
+	file, err := os.CreateTemp(dir, stagedMigrationPattern)
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Chmod(0644); err != nil {
+		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+	}
+	if _, err := file.WriteString(migrationSQL); err != nil {
+		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+	}
+	if err := file.Sync(); err != nil {
+		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+	}
+	if err := file.Close(); err != nil {
+		return "", errors.Join(err, removeFiles([]string{path}))
+	}
+	return path, nil
+}
+
+func nextMigrationVersion(dir string) (int64, error) {
+	files, err := migrator.DiscoverMigrationFiles(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		return 0, err
+	}
+	version := migrator.GetNextMigrationVersion()
+	for _, file := range files {
+		if file.Version >= version {
+			version = file.Version + 1
+		}
+	}
+	return version, nil
+}
+
+var migrationSlugInvalidChars = regexp.MustCompile(`[^a-z0-9_]+`)
+
+func migrationSlug(name string) string {
+	slug := strings.ToLower(strings.TrimSpace(name))
+	slug = strings.ReplaceAll(slug, "-", "_")
+	slug = strings.ReplaceAll(slug, " ", "_")
+	slug = migrationSlugInvalidChars.ReplaceAllString(slug, "")
+	slug = strings.Trim(slug, "_")
+	if slug == "" {
+		return "migration"
+	}
+	return slug
+}

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -3,6 +3,8 @@ package atlasmigrate
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,25 +23,48 @@ import (
 )
 
 const (
-	publicationJournalVersion = 2
-	publicationJournalSuffix  = ".ptah-migrate-diff.pending"
-	stagedMigrationPattern    = ".ptah-migrate-diff-*.tmp"
+	publicationJournalVersion     = 5
+	publicationJournalSuffix      = ".ptah-migrate-diff.pending"
+	publicationCommitMarkerSuffix = ".committed"
+	stagedMigrationPattern        = ".ptah-migrate-diff-*.tmp"
+
+	publicationCommitModeAtlasSum = "atlas-sum"
+	publicationCommitModeMarker   = "journal-marker"
+)
+
+type publicationMode string
+
+const (
+	publicationModeHardLink         publicationMode = "hard-link"
+	publicationModeCopy             publicationMode = "exclusive-copy"
+	publicationModeWriteThroughMove publicationMode = "write-through-move"
 )
 
 type publicationEntry struct {
 	Staged string `json:"staged"`
 	Final  string `json:"final"`
+	Mode   string `json:"mode"`
+	Digest string `json:"digest"`
 }
 
 type publicationJournal struct {
-	Version int                `json:"version"`
-	Entries []publicationEntry `json:"entries"`
-	Sum     []byte             `json:"sum"`
+	Version    int                `json:"version"`
+	CommitMode string             `json:"commit_mode"`
+	Entries    []publicationEntry `json:"entries"`
+	Sum        []byte             `json:"sum,omitempty"`
+}
+
+// PublicationArtifact is one immutable file in a journaled publication batch.
+type PublicationArtifact struct {
+	Name     string
+	Contents []byte
 }
 
 type migrationBatch struct {
 	paths       []string
 	stagedPaths []string
+	digests     []string
+	mode        publicationMode
 }
 
 // writeDiffArtifacts durably publishes one batch of migration files and then
@@ -50,6 +75,7 @@ func writeDiffArtifacts(
 	dir, name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
+	prepare func([]string) error,
 ) (DiffResult, error) {
 	return writeDiffArtifactsWithSumWriter(
 		ctx,
@@ -57,6 +83,7 @@ func writeDiffArtifacts(
 		name,
 		contents,
 		baseSnapshot,
+		prepare,
 		writeDirSum,
 	)
 }
@@ -66,6 +93,7 @@ func writeDiffArtifactsWithSumWriter(
 	dir, name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
+	prepare func([]string) error,
 	writeSum func(string, *migratesum.SumFile) (string, error),
 ) (DiffResult, error) {
 	if err := ctx.Err(); err != nil {
@@ -82,7 +110,18 @@ func writeDiffArtifactsWithSumWriter(
 	if err != nil {
 		return DiffResult{}, err
 	}
-	publishedSnapshot, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
+	if err := prepareStagedMigrationBatch(ctx, batch, prepare); err != nil {
+		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	stagedContents, err := readStagedMigrationContents(&batch)
+	if err != nil {
+		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	publishedSnapshot, sum, err := preparePublicationSnapshot(
+		baseSnapshot,
+		batch,
+		stagedContents,
+	)
 	if err != nil {
 		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
 	}
@@ -90,7 +129,7 @@ func writeDiffArtifactsWithSumWriter(
 	if err != nil {
 		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
 	}
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatchContext(ctx, dir, batch)
 	if err != nil {
 		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
 	}
@@ -126,6 +165,125 @@ func writeDiffArtifactsWithSumWriter(
 		return result, fmt.Errorf("finalize migration artifact publication: %w", err)
 	}
 	return result, nil
+}
+
+// PublishArtifactsLocked durably publishes all artifacts as one batch. The
+// caller must hold the migration-directory lock for dir.
+func PublishArtifactsLocked(
+	ctx context.Context,
+	dir string,
+	artifacts []PublicationArtifact,
+) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := recoverPendingPublication(dir); err != nil {
+		return nil, fmt.Errorf("recover previous artifact publication: %w", err)
+	}
+	batch, err := stageArtifactBatch(dir, artifacts)
+	if err != nil {
+		return nil, err
+	}
+	journal, err := beginMarkerPublication(dir, batch)
+	if err != nil {
+		return nil, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	published, err := publishMigrationBatchContext(ctx, dir, batch)
+	if err != nil {
+		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	if err := writePublicationCommitMarker(dir, journal); err != nil {
+		committed, commitErr := publicationCommitted(dir, journal)
+		if committed && commitErr == nil {
+			return nil, fmt.Errorf(
+				"write artifact publication commit marker; journal retained for recovery: %w",
+				err,
+			)
+		}
+		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return nil, err
+	}
+	committed, err := publicationCommitted(dir, journal)
+	if err != nil {
+		return nil, fmt.Errorf("verify artifact publication commit marker: %w", err)
+	}
+	if !committed {
+		return nil, errors.New("artifact publication commit marker does not match its journal")
+	}
+	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
+		return slices.Clone(batch.paths), fmt.Errorf("finalize artifact publication: %w", err)
+	}
+	return slices.Clone(batch.paths), nil
+}
+
+func prepareStagedMigrationBatch(
+	ctx context.Context,
+	batch migrationBatch,
+	prepare func([]string) error,
+) error {
+	if prepare != nil {
+		if err := prepare(slices.Clone(batch.stagedPaths)); err != nil {
+			return fmt.Errorf("prepare migration files for publication: %w", err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, path := range batch.stagedPaths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("inspect staged migration file after preparation: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("staged migration file is not a regular file: %s", path)
+		}
+		file, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			return fmt.Errorf("open staged migration file after preparation: %w", err)
+		}
+		openedInfo, err := file.Stat()
+		if err != nil {
+			return errors.Join(
+				fmt.Errorf("inspect opened staged migration file: %w", err),
+				file.Close(),
+			)
+		}
+		if !os.SameFile(info, openedInfo) {
+			return errors.Join(
+				fmt.Errorf("staged migration file changed while being opened: %s", path),
+				file.Close(),
+			)
+		}
+		if err := errors.Join(file.Sync(), file.Close()); err != nil {
+			return fmt.Errorf("sync staged migration file after preparation: %w", err)
+		}
+	}
+	return nil
+}
+
+func readStagedMigrationContents(batch *migrationBatch) ([]MigrationFileContent, error) {
+	contents := make([]MigrationFileContent, len(batch.stagedPaths))
+	batch.digests = make([]string, len(batch.stagedPaths))
+	for i, path := range batch.stagedPaths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read staged migration file after preparation: %w", err)
+		}
+		contents[i] = MigrationFileContent{SQL: string(data)}
+		batch.digests[i] = contentDigest(data)
+	}
+	return contents, nil
+}
+
+func contentDigest(contents []byte) string {
+	sum := sha256.Sum256(contents)
+	return hex.EncodeToString(sum[:])
 }
 
 func preparePublicationSnapshot(
@@ -168,12 +326,15 @@ func beginPublication(
 		entries[i] = publicationEntry{
 			Staged: filepath.Base(batch.stagedPaths[i]),
 			Final:  filepath.Base(batch.paths[i]),
+			Mode:   string(batch.mode),
+			Digest: batch.digests[i],
 		}
 	}
 	journal := publicationJournal{
-		Version: publicationJournalVersion,
-		Entries: entries,
-		Sum:     slices.Clone(sum),
+		Version:    publicationJournalVersion,
+		CommitMode: publicationCommitModeAtlasSum,
+		Entries:    entries,
+		Sum:        slices.Clone(sum),
 	}
 	if err := writePublicationJournal(dir, journal); err != nil {
 		return publicationJournal{}, fmt.Errorf("write migration publication journal: %w", err)
@@ -181,9 +342,48 @@ func beginPublication(
 	return journal, nil
 }
 
+func beginMarkerPublication(
+	dir string,
+	batch migrationBatch,
+) (publicationJournal, error) {
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return publicationJournal{}, fmt.Errorf("sync staged artifact files: %w", err)
+	}
+	entries := make([]publicationEntry, len(batch.paths))
+	for i := range batch.paths {
+		entries[i] = publicationEntry{
+			Staged: filepath.Base(batch.stagedPaths[i]),
+			Final:  filepath.Base(batch.paths[i]),
+			Mode:   string(batch.mode),
+			Digest: batch.digests[i],
+		}
+	}
+	journal := publicationJournal{
+		Version:    publicationJournalVersion,
+		CommitMode: publicationCommitModeMarker,
+		Entries:    entries,
+	}
+	if err := writePublicationJournal(dir, journal); err != nil {
+		return publicationJournal{}, fmt.Errorf("write artifact publication journal: %w", err)
+	}
+	return journal, nil
+}
+
 func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
+	return publishMigrationBatchContext(context.Background(), dir, batch)
+}
+
+func publishMigrationBatchContext(
+	ctx context.Context,
+	dir string,
+	batch migrationBatch,
+) (int, error) {
 	for i, stagedPath := range batch.stagedPaths {
-		if err := os.Link(stagedPath, batch.paths[i]); err != nil {
+		if err := ctx.Err(); err != nil {
+			return i, err
+		}
+		err := publishStagedFile(stagedPath, batch.paths[i], batch.mode)
+		if err != nil {
 			if errors.Is(err, os.ErrExist) {
 				return i, fmt.Errorf(
 					"migration directory changed during publication: %s already exists",
@@ -199,9 +399,66 @@ func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
 	return len(batch.paths), nil
 }
 
+func publishStagedFile(
+	stagedPath, finalPath string,
+	mode publicationMode,
+) error {
+	switch mode {
+	case publicationModeHardLink:
+		return os.Link(stagedPath, finalPath)
+	case publicationModeCopy:
+		return copyFileExclusive(stagedPath, finalPath)
+	case publicationModeWriteThroughMove:
+		return fsdurable.MoveFileNoReplace(stagedPath, finalPath)
+	default:
+		return fmt.Errorf("unsupported migration publication mode %q", mode)
+	}
+}
+
+func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
+	contents, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return err
+	}
+	destination, err := os.OpenFile(
+		destinationPath,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+		0o644,
+	)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			resultErr = errors.Join(
+				resultErr,
+				destination.Close(),
+				removeFiles([]string{destinationPath}),
+			)
+		}
+	}()
+	if _, err := destination.Write(contents); err != nil {
+		return err
+	}
+	if err := destination.Sync(); err != nil {
+		return err
+	}
+	if err := destination.Close(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
 func abortPendingPublication(dir string, batch migrationBatch, published int) error {
 	for i := range published {
-		if err := rollBackPublicationEntry(batch.stagedPaths[i], batch.paths[i]); err != nil {
+		if err := rollBackPublicationEntry(
+			batch.stagedPaths[i],
+			batch.paths[i],
+			batch.digests[i],
+			batch.mode,
+		); err != nil {
 			return fmt.Errorf("roll back published migration files: %w", err)
 		}
 	}
@@ -241,14 +498,39 @@ func recoverPendingPublication(dir string) error {
 }
 
 func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
-	contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
+	switch journal.CommitMode {
+	case publicationCommitModeAtlasSum:
+		contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return bytes.Equal(contents, journal.Sum), nil
+	case publicationCommitModeMarker:
+		journalPath, err := publicationJournalPath(dir)
+		if err != nil {
+			return false, err
+		}
+		contents, err := os.ReadFile(publicationCommitMarkerPath(journalPath))
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		expected, err := publicationJournalDigest(journal)
+		if err != nil {
+			return false, err
+		}
+		return bytes.Equal(contents, expected), nil
+	default:
+		return false, fmt.Errorf(
+			"unsupported publication commit mode %q",
+			journal.CommitMode,
+		)
 	}
-	if err != nil {
-		return false, err
-	}
-	return bytes.Equal(contents, journal.Sum), nil
 }
 
 func finalizeCommittedPublication(
@@ -272,7 +554,12 @@ func rollBackPendingPublication(
 	for _, entry := range journal.Entries {
 		stagedPath := filepath.Join(dir, entry.Staged)
 		finalPath := filepath.Join(dir, entry.Final)
-		if err := rollBackPublicationEntry(stagedPath, finalPath); err != nil {
+		if err := rollBackPublicationEntry(
+			stagedPath,
+			finalPath,
+			entry.Digest,
+			publicationMode(entry.Mode),
+		); err != nil {
 			return err
 		}
 	}
@@ -282,7 +569,10 @@ func rollBackPendingPublication(
 	return removePublicationJournal(journalPath)
 }
 
-func rollBackPublicationEntry(stagedPath, finalPath string) error {
+func rollBackPublicationEntry(
+	stagedPath, finalPath, expectedDigest string,
+	mode publicationMode,
+) error {
 	quarantineDir := stagedPath + ".rollback"
 	quarantinePath := filepath.Join(quarantineDir, "published")
 
@@ -299,25 +589,46 @@ func rollBackPublicationEntry(stagedPath, finalPath string) error {
 		return fmt.Errorf("inspect quarantined migration file: %w", err)
 	}
 
-	stagedInfo, stagedErr := os.Stat(stagedPath)
-	quarantinedInfo, quarantineErr := os.Stat(quarantinePath)
+	stagedDigest, stagedErr := fileDigest(stagedPath)
+	quarantinedDigest, quarantineErr := fileDigest(quarantinePath)
 	switch {
 	case errors.Is(stagedErr, os.ErrNotExist) && errors.Is(quarantineErr, os.ErrNotExist):
 		return removeEmptyQuarantineDir(quarantineDir)
 	case stagedErr == nil && errors.Is(quarantineErr, os.ErrNotExist):
+		if stagedDigest != expectedDigest {
+			return fmt.Errorf(
+				"cannot safely recover migration publication: staging file content changed; preserved %s",
+				stagedPath,
+			)
+		}
 		return errors.Join(removeFiles([]string{stagedPath}), removeEmptyQuarantineDir(quarantineDir))
-	case errors.Is(stagedErr, os.ErrNotExist) && quarantineErr == nil:
-		return fmt.Errorf(
-			"cannot safely recover migration publication: staging file missing; preserved %s",
-			quarantinePath,
+	case errors.Is(stagedErr, os.ErrNotExist) &&
+		quarantineErr == nil &&
+		mode == publicationModeWriteThroughMove:
+		if quarantinedDigest != expectedDigest {
+			return fmt.Errorf(
+				"cannot safely recover migration publication: %s content changed; preserved at %s",
+				finalPath,
+				quarantinePath,
+			)
+		}
+		return errors.Join(
+			removeFiles([]string{quarantinePath}),
+			removeEmptyQuarantineDir(quarantineDir),
 		)
 	case stagedErr != nil:
 		return fmt.Errorf("inspect staged migration file: %w", stagedErr)
 	case quarantineErr != nil:
 		return fmt.Errorf("inspect quarantined migration file: %w", quarantineErr)
-	case !os.SameFile(stagedInfo, quarantinedInfo):
+	case stagedDigest != expectedDigest:
 		return fmt.Errorf(
-			"cannot safely recover migration publication: %s is not the journaled staging file; preserved at %s",
+			"cannot safely recover migration publication: staging file content changed; preserved %s and %s",
+			stagedPath,
+			quarantinePath,
+		)
+	case quarantinedDigest != expectedDigest:
+		return fmt.Errorf(
+			"cannot safely recover migration publication: %s content changed; preserved at %s",
 			finalPath,
 			quarantinePath,
 		)
@@ -329,6 +640,14 @@ func rollBackPublicationEntry(stagedPath, finalPath string) error {
 	}
 }
 
+func fileDigest(path string) (string, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return contentDigest(contents), nil
+}
+
 func removeEmptyQuarantineDir(path string) error {
 	err := os.Remove(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -338,7 +657,15 @@ func removeEmptyQuarantineDir(path string) error {
 }
 
 func removePublicationJournal(journalPath string) error {
-	if err := removeFiles([]string{journalPath}); err != nil {
+	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+	if err != nil {
+		return fmt.Errorf("find migration publication journal backups: %w", err)
+	}
+	paths := append(
+		[]string{journalPath, publicationCommitMarkerPath(journalPath)},
+		journalTemps...,
+	)
+	if err := removeFiles(paths); err != nil {
 		return fmt.Errorf("remove migration publication journal: %w", err)
 	}
 	if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
@@ -356,7 +683,12 @@ func removeOrphanPublicationTemps(dir, journalPath string) error {
 	if err != nil {
 		return fmt.Errorf("find orphan migration publication journals: %w", err)
 	}
-	if err := removeFiles(append(stagedPaths, journalTemps...)); err != nil {
+	orphanPaths := slices.Concat(
+		stagedPaths,
+		journalTemps,
+		[]string{publicationCommitMarkerPath(journalPath)},
+	)
+	if err := removeFiles(orphanPaths); err != nil {
 		return fmt.Errorf("remove orphan migration publication files: %w", err)
 	}
 	if len(stagedPaths) > 0 {
@@ -372,7 +704,103 @@ func removeOrphanPublicationTemps(dir, journalPath string) error {
 	return nil
 }
 
+func writePublicationCommitMarker(
+	dir string,
+	journal publicationJournal,
+) error {
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return err
+	}
+	contents, err := publicationJournalDigest(journal)
+	if err != nil {
+		return err
+	}
+	markerPath := publicationCommitMarkerPath(journalPath)
+	parent := filepath.Dir(markerPath)
+	temp, err := os.CreateTemp(parent, filepath.Base(markerPath)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	if err := temp.Chmod(0600); err != nil {
+		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
+	}
+	if _, err := temp.Write(contents); err != nil {
+		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
+	}
+	if err := temp.Sync(); err != nil {
+		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
+	}
+	if err := temp.Close(); err != nil {
+		return errors.Join(err, removeFiles([]string{tempPath}))
+	}
+	mode, err := detectPublicationMode(tempPath)
+	if err != nil {
+		return errors.Join(err, removeFiles([]string{tempPath}))
+	}
+	if err := publishStagedFile(tempPath, markerPath, mode); err != nil {
+		return errors.Join(err, removeFiles([]string{tempPath}))
+	}
+	if mode != publicationModeWriteThroughMove {
+		if err := removeFiles([]string{tempPath}); err != nil {
+			return err
+		}
+	}
+	return fsdurable.SyncDir(parent)
+}
+
+func publicationJournalDigest(journal publicationJournal) ([]byte, error) {
+	contents, err := json.Marshal(journal)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(contents)
+	return sum[:], nil
+}
+
+func publicationCommitMarkerPath(journalPath string) string {
+	return journalPath + publicationCommitMarkerSuffix
+}
+
 func writePublicationJournal(dir string, journal publicationJournal) error {
+	return writePublicationJournalWithPublisher(
+		dir,
+		journal,
+		func(tempPath, journalPath string) error {
+			mode, err := detectPublicationMode(tempPath)
+			if err != nil {
+				return err
+			}
+			return publishStagedFile(tempPath, journalPath, mode)
+		},
+	)
+}
+
+func writePublicationJournalWithLink(
+	dir string,
+	journal publicationJournal,
+	link func(string, string) error,
+) error {
+	return writePublicationJournalWithPublisher(
+		dir,
+		journal,
+		func(tempPath, journalPath string) error {
+			if err := link(tempPath, journalPath); err != nil {
+				if copyErr := copyFileExclusive(tempPath, journalPath); copyErr != nil {
+					return errors.Join(err, copyErr)
+				}
+			}
+			return nil
+		},
+	)
+}
+
+func writePublicationJournalWithPublisher(
+	dir string,
+	journal publicationJournal,
+	publish func(string, string) error,
+) error {
 	journalPath, err := publicationJournalPath(dir)
 	if err != nil {
 		return err
@@ -399,11 +827,8 @@ func writePublicationJournal(dir string, journal publicationJournal) error {
 	if err := file.Close(); err != nil {
 		return errors.Join(err, removeFiles([]string{tempPath}))
 	}
-	if err := os.Link(tempPath, journalPath); err != nil {
+	if err := publish(tempPath, journalPath); err != nil {
 		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	if err := removeFiles([]string{tempPath}); err != nil {
-		return err
 	}
 	return fsdurable.SyncDir(parent)
 }
@@ -413,6 +838,28 @@ func readPublicationJournal(path string) (publicationJournal, error) {
 	if err != nil {
 		return publicationJournal{}, err
 	}
+	journal, decodeErr := decodePublicationJournal(contents)
+	if decodeErr == nil {
+		return journal, nil
+	}
+	backups, globErr := filepath.Glob(path + ".*.tmp")
+	if globErr != nil {
+		return publicationJournal{}, errors.Join(decodeErr, globErr)
+	}
+	for _, backup := range backups {
+		contents, err := os.ReadFile(backup)
+		if err != nil {
+			continue
+		}
+		journal, err := decodePublicationJournal(contents)
+		if err == nil {
+			return journal, nil
+		}
+	}
+	return publicationJournal{}, decodeErr
+}
+
+func decodePublicationJournal(contents []byte) (publicationJournal, error) {
 	decoder := json.NewDecoder(bytes.NewReader(contents))
 	decoder.DisallowUnknownFields()
 	var journal publicationJournal
@@ -446,20 +893,14 @@ func validatePublicationJournal(journal publicationJournal) error {
 	if len(journal.Entries) == 0 {
 		return errors.New("migration publication journal has no entries")
 	}
-	if len(journal.Sum) == 0 {
-		return errors.New("migration publication journal has no checksum")
+	if err := validatePublicationCommit(journal); err != nil {
+		return err
 	}
 	stagedNames := make([]string, 0, len(journal.Entries))
 	finalNames := make([]string, 0, len(journal.Entries))
 	for _, entry := range journal.Entries {
-		if filepath.Base(entry.Staged) != entry.Staged ||
-			!strings.HasPrefix(entry.Staged, ".ptah-migrate-diff-") ||
-			!strings.HasSuffix(entry.Staged, ".tmp") {
-			return fmt.Errorf("invalid staged migration publication path: %q", entry.Staged)
-		}
-		if filepath.Base(entry.Final) != entry.Final ||
-			!strings.HasSuffix(entry.Final, ".sql") {
-			return fmt.Errorf("invalid final migration publication path: %q", entry.Final)
+		if err := validatePublicationEntry(entry); err != nil {
+			return err
 		}
 		if slices.Contains(stagedNames, entry.Staged) ||
 			slices.Contains(finalNames, entry.Final) {
@@ -467,6 +908,48 @@ func validatePublicationJournal(journal publicationJournal) error {
 		}
 		stagedNames = append(stagedNames, entry.Staged)
 		finalNames = append(finalNames, entry.Final)
+	}
+	return nil
+}
+
+func validatePublicationCommit(journal publicationJournal) error {
+	switch journal.CommitMode {
+	case publicationCommitModeAtlasSum:
+		if len(journal.Sum) == 0 {
+			return errors.New("migration publication journal has no checksum")
+		}
+	case publicationCommitModeMarker:
+		if len(journal.Sum) != 0 {
+			return errors.New("marker-based publication journal contains atlas checksum")
+		}
+	default:
+		return fmt.Errorf(
+			"unsupported migration publication commit mode: %q",
+			journal.CommitMode,
+		)
+	}
+	return nil
+}
+
+func validatePublicationEntry(entry publicationEntry) error {
+	if filepath.Base(entry.Staged) != entry.Staged ||
+		!strings.HasPrefix(entry.Staged, ".ptah-migrate-diff-") ||
+		!strings.HasSuffix(entry.Staged, ".tmp") {
+		return fmt.Errorf("invalid staged migration publication path: %q", entry.Staged)
+	}
+	if filepath.Base(entry.Final) != entry.Final ||
+		entry.Final == "." ||
+		entry.Final == "" {
+		return fmt.Errorf("invalid final migration publication path: %q", entry.Final)
+	}
+	if entry.Mode != string(publicationModeHardLink) &&
+		entry.Mode != string(publicationModeCopy) &&
+		entry.Mode != string(publicationModeWriteThroughMove) {
+		return fmt.Errorf("invalid migration publication mode: %q", entry.Mode)
+	}
+	digest, err := hex.DecodeString(entry.Digest)
+	if err != nil || len(digest) != sha256.Size {
+		return fmt.Errorf("invalid migration publication digest: %q", entry.Digest)
 	}
 	return nil
 }
@@ -533,6 +1016,51 @@ func writeMigrationFiles(dir, name string, contents []MigrationFileContent) ([]s
 	return batch.paths, nil
 }
 
+func stageArtifactBatch(
+	dir string,
+	artifacts []PublicationArtifact,
+) (migrationBatch, error) {
+	if len(artifacts) == 0 {
+		return migrationBatch{}, errors.New("artifact publication batch is empty")
+	}
+	batch := migrationBatch{
+		paths:       make([]string, 0, len(artifacts)),
+		stagedPaths: make([]string, 0, len(artifacts)),
+		digests:     make([]string, 0, len(artifacts)),
+	}
+	names := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if filepath.Base(artifact.Name) != artifact.Name ||
+			artifact.Name == "." ||
+			artifact.Name == "" {
+			return migrationBatch{}, errors.Join(
+				fmt.Errorf("invalid artifact publication name %q", artifact.Name),
+				removeFiles(batch.stagedPaths),
+			)
+		}
+		if slices.Contains(names, artifact.Name) {
+			return migrationBatch{}, errors.Join(
+				fmt.Errorf("duplicate artifact publication name %q", artifact.Name),
+				removeFiles(batch.stagedPaths),
+			)
+		}
+		stagedPath, err := stageArtifactFile(dir, artifact.Contents)
+		if err != nil {
+			return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		}
+		names = append(names, artifact.Name)
+		batch.paths = append(batch.paths, filepath.Join(dir, artifact.Name))
+		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+		batch.digests = append(batch.digests, contentDigest(artifact.Contents))
+	}
+	mode, err := detectPublicationMode(batch.stagedPaths[0])
+	if err != nil {
+		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	batch.mode = mode
+	return batch, nil
+}
+
 func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (migrationBatch, error) {
 	if len(contents) == 0 {
 		return migrationBatch{}, errors.New("migration SQL is empty")
@@ -554,6 +1082,21 @@ func stageMigrationBatchAt(
 	version int64,
 	contents []MigrationFileContent,
 ) (migrationBatch, error) {
+	return stageMigrationBatchAtWithModeDetector(
+		dir,
+		name,
+		version,
+		contents,
+		detectPublicationMode,
+	)
+}
+
+func stageMigrationBatchAtWithModeDetector(
+	dir, name string,
+	version int64,
+	contents []MigrationFileContent,
+	detectMode func(string) (publicationMode, error),
+) (migrationBatch, error) {
 	batch := migrationBatch{
 		paths:       make([]string, 0, len(contents)),
 		stagedPaths: make([]string, 0, len(contents)),
@@ -572,7 +1115,33 @@ func stageMigrationBatchAt(
 		batch.paths = append(batch.paths, path)
 		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
 	}
+	mode, err := detectMode(batch.stagedPaths[0])
+	if err != nil {
+		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	batch.mode = mode
+	if _, err := readStagedMigrationContents(&batch); err != nil {
+		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
 	return batch, nil
+}
+
+func detectPublicationMode(stagedPath string) (publicationMode, error) {
+	return platformPublicationMode(stagedPath)
+}
+
+func detectPublicationModeWithLink(
+	stagedPath string,
+	link func(string, string) error,
+) (publicationMode, error) {
+	probePath := stagedPath + ".link-probe"
+	if err := link(stagedPath, probePath); err != nil {
+		return publicationModeCopy, nil
+	}
+	if err := os.Remove(probePath); err != nil {
+		return "", fmt.Errorf("remove migration publication link probe: %w", err)
+	}
+	return publicationModeHardLink, nil
 }
 
 // writeMigrationFilesAt stages and syncs one complete batch before publishing
@@ -610,6 +1179,10 @@ func rollBackUnjournaledBatch(dir string, batch migrationBatch, published int) e
 }
 
 func stageMigrationFile(dir, migrationSQL string) (string, error) {
+	return stageArtifactFile(dir, []byte(migrationSQL))
+}
+
+func stageArtifactFile(dir string, contents []byte) (string, error) {
 	file, err := os.CreateTemp(dir, stagedMigrationPattern)
 	if err != nil {
 		return "", err
@@ -618,7 +1191,7 @@ func stageMigrationFile(dir, migrationSQL string) (string, error) {
 	if err := file.Chmod(0644); err != nil {
 		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
 	}
-	if _, err := file.WriteString(migrationSQL); err != nil {
+	if _, err := file.Write(contents); err != nil {
 		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
 	}
 	if err := file.Sync(); err != nil {

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,12 +15,13 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/internal/fsdurable"
+	"github.com/stokaro/ptah/internal/fsnapshot"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
 const (
-	publicationJournalVersion = 1
+	publicationJournalVersion = 2
 	publicationJournalSuffix  = ".ptah-migrate-diff.pending"
 	stagedMigrationPattern    = ".ptah-migrate-diff-*.tmp"
 )
@@ -32,6 +34,7 @@ type publicationEntry struct {
 type publicationJournal struct {
 	Version int                `json:"version"`
 	Entries []publicationEntry `json:"entries"`
+	Sum     []byte             `json:"sum"`
 }
 
 type migrationBatch struct {
@@ -46,6 +49,24 @@ func writeDiffArtifacts(
 	ctx context.Context,
 	dir, name string,
 	contents []MigrationFileContent,
+	baseSnapshot fsnapshot.Snapshot,
+) (DiffResult, error) {
+	return writeDiffArtifactsWithSumWriter(
+		ctx,
+		dir,
+		name,
+		contents,
+		baseSnapshot,
+		writeDirSum,
+	)
+}
+
+func writeDiffArtifactsWithSumWriter(
+	ctx context.Context,
+	dir, name string,
+	contents []MigrationFileContent,
+	baseSnapshot fsnapshot.Snapshot,
+	writeSum func(string, *migratesum.SumFile) (string, error),
 ) (DiffResult, error) {
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
@@ -53,32 +74,95 @@ func writeDiffArtifacts(
 	if err := recoverPendingPublication(dir); err != nil {
 		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
 	}
-	batch, err := stageMigrationBatch(dir, name, contents)
+	version, err := nextMigrationVersionFS(baseSnapshot)
 	if err != nil {
 		return DiffResult{}, err
 	}
-	if err := beginPublication(dir, batch); err != nil {
+	batch, err := stageMigrationBatchAt(dir, name, version, contents)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	publishedSnapshot, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
+	if err != nil {
+		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	}
+	journal, err := beginPublication(dir, batch, sum.Bytes())
+	if err != nil {
 		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
 	}
 	published, err := publishMigrationBatch(dir, batch)
 	if err != nil {
 		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
 	}
+	if err := verifyMigrationDirUnchanged(dir, publishedSnapshot); err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	}
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
 	}
-	sumPath, err := writeDirSum(dir)
+	sumPath, err := writeSum(dir, sum)
 	if err != nil {
+		if migratesum.IsCommitUncertain(err) {
+			return DiffResult{}, fmt.Errorf(
+				"write atlas.sum; migration publication journal retained for recovery: %w",
+				err,
+			)
+		}
 		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
 	}
 	result := DiffResult{MigrationPaths: batch.paths, SumPath: sumPath}
-	if err := recoverPendingPublication(dir); err != nil {
+	journalPath, err := publicationJournalPath(dir)
+	if err != nil {
+		return result, err
+	}
+	committed, err := publicationCommitted(dir, journal)
+	if err != nil {
+		return result, fmt.Errorf("verify migration publication commit marker: %w", err)
+	}
+	if !committed {
+		return result, errors.New("atlas.sum does not match the journaled migration publication")
+	}
+	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
 		return result, fmt.Errorf("finalize migration artifact publication: %w", err)
 	}
 	return result, nil
 }
 
-func beginPublication(dir string, batch migrationBatch) error {
+func preparePublicationSnapshot(
+	baseSnapshot fsnapshot.Snapshot,
+	batch migrationBatch,
+	contents []MigrationFileContent,
+) (fsnapshot.Snapshot, *migratesum.SumFile, error) {
+	files := make(map[string][]byte, len(batch.paths))
+	for i, path := range batch.paths {
+		files[filepath.Base(path)] = []byte(contents[i].SQL)
+	}
+	publishedSnapshot, err := baseSnapshot.WithFiles(files)
+	if err != nil {
+		return fsnapshot.Snapshot{}, nil, fmt.Errorf("build published migration snapshot: %w", err)
+	}
+	sum, err := migratesum.ComputeWithFormat(
+		publishedSnapshot,
+		migrator.MigrationDirFormatAtlas,
+	)
+	if err != nil {
+		return fsnapshot.Snapshot{}, nil, fmt.Errorf("compute published migration checksum: %w", err)
+	}
+	return publishedSnapshot, sum, nil
+}
+
+func beginPublication(
+	dir string,
+	batch migrationBatch,
+	sum []byte,
+) (publicationJournal, error) {
+	// Persist the staging directory entries before making the journal durable.
+	// Once the journal exists, recovery relies on the staging links to prove
+	// ownership of any published final paths.
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return publicationJournal{}, fmt.Errorf("sync staged migration files: %w", err)
+	}
+
 	entries := make([]publicationEntry, len(batch.paths))
 	for i := range batch.paths {
 		entries[i] = publicationEntry{
@@ -89,11 +173,12 @@ func beginPublication(dir string, batch migrationBatch) error {
 	journal := publicationJournal{
 		Version: publicationJournalVersion,
 		Entries: entries,
+		Sum:     slices.Clone(sum),
 	}
 	if err := writePublicationJournal(dir, journal); err != nil {
-		return fmt.Errorf("write migration publication journal: %w", err)
+		return publicationJournal{}, fmt.Errorf("write migration publication journal: %w", err)
 	}
-	return nil
+	return journal, nil
 }
 
 func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
@@ -115,10 +200,12 @@ func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
 }
 
 func abortPendingPublication(dir string, batch migrationBatch, published int) error {
-	if err := removeFiles(batch.paths[:published]); err != nil {
-		return fmt.Errorf("roll back published migration files: %w", err)
+	for i := range published {
+		if err := rollBackPublicationEntry(batch.stagedPaths[i], batch.paths[i]); err != nil {
+			return fmt.Errorf("roll back published migration files: %w", err)
+		}
 	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
+	if err := removeFiles(batch.stagedPaths[published:]); err != nil {
 		return fmt.Errorf("remove rolled back migration staging files: %w", err)
 	}
 	if err := fsdurable.SyncDir(dir); err != nil {
@@ -143,7 +230,7 @@ func recoverPendingPublication(dir string) error {
 	if err != nil {
 		return err
 	}
-	committed, err := publicationCommitted(dir)
+	committed, err := publicationCommitted(dir, journal)
 	if err != nil {
 		return err
 	}
@@ -153,15 +240,15 @@ func recoverPendingPublication(dir string) error {
 	return rollBackPendingPublication(dir, journalPath, journal)
 }
 
-func publicationCommitted(dir string) (bool, error) {
-	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
-	if errors.Is(err, migratesum.ErrSumFileMissing) {
+func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
+	contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("verify migration publication commit marker: %w", err)
+		return false, err
 	}
-	return result.OK(), nil
+	return bytes.Equal(contents, journal.Sum), nil
 }
 
 func finalizeCommittedPublication(
@@ -196,30 +283,58 @@ func rollBackPendingPublication(
 }
 
 func rollBackPublicationEntry(stagedPath, finalPath string) error {
+	quarantineDir := stagedPath + ".rollback"
+	quarantinePath := filepath.Join(quarantineDir, "published")
+
+	if err := os.Mkdir(quarantineDir, 0700); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("create migration rollback quarantine: %w", err)
+	}
+	if _, err := os.Stat(quarantinePath); errors.Is(err, os.ErrNotExist) {
+		if renameErr := os.Rename(finalPath, quarantinePath); renameErr != nil {
+			if !errors.Is(renameErr, os.ErrNotExist) {
+				return fmt.Errorf("quarantine published migration file: %w", renameErr)
+			}
+		}
+	} else if err != nil {
+		return fmt.Errorf("inspect quarantined migration file: %w", err)
+	}
+
 	stagedInfo, stagedErr := os.Stat(stagedPath)
-	finalInfo, finalErr := os.Stat(finalPath)
+	quarantinedInfo, quarantineErr := os.Stat(quarantinePath)
 	switch {
-	case errors.Is(stagedErr, os.ErrNotExist) && errors.Is(finalErr, os.ErrNotExist):
-		return nil
-	case stagedErr == nil && errors.Is(finalErr, os.ErrNotExist):
-		return removeFiles([]string{stagedPath})
-	case errors.Is(stagedErr, os.ErrNotExist) && finalErr == nil:
+	case errors.Is(stagedErr, os.ErrNotExist) && errors.Is(quarantineErr, os.ErrNotExist):
+		return removeEmptyQuarantineDir(quarantineDir)
+	case stagedErr == nil && errors.Is(quarantineErr, os.ErrNotExist):
+		return errors.Join(removeFiles([]string{stagedPath}), removeEmptyQuarantineDir(quarantineDir))
+	case errors.Is(stagedErr, os.ErrNotExist) && quarantineErr == nil:
 		return fmt.Errorf(
-			"cannot safely recover migration publication: staging file missing for %s",
-			finalPath,
+			"cannot safely recover migration publication: staging file missing; preserved %s",
+			quarantinePath,
 		)
 	case stagedErr != nil:
 		return fmt.Errorf("inspect staged migration file: %w", stagedErr)
-	case finalErr != nil:
-		return fmt.Errorf("inspect published migration file: %w", finalErr)
-	case !os.SameFile(stagedInfo, finalInfo):
+	case quarantineErr != nil:
+		return fmt.Errorf("inspect quarantined migration file: %w", quarantineErr)
+	case !os.SameFile(stagedInfo, quarantinedInfo):
 		return fmt.Errorf(
-			"cannot safely recover migration publication: %s is not the journaled staging file",
+			"cannot safely recover migration publication: %s is not the journaled staging file; preserved at %s",
 			finalPath,
+			quarantinePath,
 		)
 	default:
-		return removeFiles([]string{finalPath, stagedPath})
+		return errors.Join(
+			removeFiles([]string{quarantinePath, stagedPath}),
+			removeEmptyQuarantineDir(quarantineDir),
+		)
 	}
+}
+
+func removeEmptyQuarantineDir(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 func removePublicationJournal(journalPath string) error {
@@ -331,6 +446,9 @@ func validatePublicationJournal(journal publicationJournal) error {
 	if len(journal.Entries) == 0 {
 		return errors.New("migration publication journal has no entries")
 	}
+	if len(journal.Sum) == 0 {
+		return errors.New("migration publication journal has no checksum")
+	}
 	stagedNames := make([]string, 0, len(journal.Entries))
 	finalNames := make([]string, 0, len(journal.Entries))
 	for _, entry := range journal.Entries {
@@ -374,9 +492,13 @@ func publicationStagedPaths(dir string, journal publicationJournal) []string {
 
 // writeDirSum atomically refreshes atlas.sum after every complete migration
 // file has been published. The sum is the commit marker for the batch.
-func writeDirSum(dir string) (string, error) {
+func writeDirSum(dir string, sum *migratesum.SumFile) (string, error) {
 	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
-	if _, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas); err != nil {
+	if err := migratesum.WritePrecomputedWithFormat(
+		dir,
+		migrator.MigrationDirFormatAtlas,
+		sum,
+	); err != nil {
 		return "", fmt.Errorf("write atlas.sum: %w", err)
 	}
 	return sumPath, nil
@@ -509,7 +631,11 @@ func stageMigrationFile(dir, migrationSQL string) (string, error) {
 }
 
 func nextMigrationVersion(dir string) (int64, error) {
-	files, err := migrator.DiscoverMigrationFiles(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	return nextMigrationVersionFS(os.DirFS(dir))
+}
+
+func nextMigrationVersionFS(fsys fs.FS) (int64, error) {
+	files, err := migrator.DiscoverMigrationFiles(fsys, migrator.MigrationDirFormatAtlas)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -26,6 +26,7 @@ const (
 	publicationJournalVersion     = 5
 	publicationJournalSuffix      = ".ptah-migrate-diff.pending"
 	publicationCommitMarkerSuffix = ".committed"
+	publicationCleanupSuffix      = ".cleanup"
 	stagedMigrationPattern        = ".ptah-migrate-diff-*.tmp"
 
 	publicationCommitModeAtlasSum = "atlas-sum"
@@ -369,10 +370,6 @@ func beginMarkerPublication(
 	return journal, nil
 }
 
-func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
-	return publishMigrationBatchContext(context.Background(), dir, batch)
-}
-
 func publishMigrationBatchContext(
 	ctx context.Context,
 	dir string,
@@ -497,6 +494,12 @@ func recoverPendingPublication(dir string) error {
 	return rollBackPendingPublication(dir, journalPath, journal)
 }
 
+// RecoverPendingPublicationLocked resolves an interrupted artifact publication.
+// The caller must hold the migration-directory lock for dir.
+func RecoverPendingPublicationLocked(dir string) error {
+	return recoverPendingPublication(dir)
+}
+
 func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
 	switch journal.CommitMode {
 	case publicationCommitModeAtlasSum:
@@ -571,7 +574,7 @@ func rollBackPendingPublication(
 
 func rollBackPublicationEntry(
 	stagedPath, finalPath, expectedDigest string,
-	mode publicationMode,
+	_ publicationMode,
 ) error {
 	quarantineDir := stagedPath + ".rollback"
 	quarantinePath := filepath.Join(quarantineDir, "published")
@@ -579,11 +582,16 @@ func rollBackPublicationEntry(
 	if err := os.Mkdir(quarantineDir, 0700); err != nil && !errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("create migration rollback quarantine: %w", err)
 	}
+	if err := fsdurable.SyncDir(filepath.Dir(quarantineDir)); err != nil {
+		return fmt.Errorf("sync migration rollback quarantine directory: %w", err)
+	}
 	if _, err := os.Stat(quarantinePath); errors.Is(err, os.ErrNotExist) {
-		if renameErr := os.Rename(finalPath, quarantinePath); renameErr != nil {
-			if !errors.Is(renameErr, os.ErrNotExist) {
-				return fmt.Errorf("quarantine published migration file: %w", renameErr)
+		if moveErr := fsdurable.MoveFileNoReplace(finalPath, quarantinePath); moveErr != nil {
+			if !errors.Is(moveErr, os.ErrNotExist) {
+				return fmt.Errorf("quarantine published migration file: %w", moveErr)
 			}
+		} else if err := syncQuarantineMove(finalPath, quarantineDir); err != nil {
+			return err
 		}
 	} else if err != nil {
 		return fmt.Errorf("inspect quarantined migration file: %w", err)
@@ -601,10 +609,9 @@ func rollBackPublicationEntry(
 				stagedPath,
 			)
 		}
-		return errors.Join(removeFiles([]string{stagedPath}), removeEmptyQuarantineDir(quarantineDir))
+		return removeRollbackFiles(quarantineDir, stagedPath)
 	case errors.Is(stagedErr, os.ErrNotExist) &&
-		quarantineErr == nil &&
-		mode == publicationModeWriteThroughMove:
+		quarantineErr == nil:
 		if quarantinedDigest != expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: %s content changed; preserved at %s",
@@ -612,10 +619,7 @@ func rollBackPublicationEntry(
 				quarantinePath,
 			)
 		}
-		return errors.Join(
-			removeFiles([]string{quarantinePath}),
-			removeEmptyQuarantineDir(quarantineDir),
-		)
+		return removeRollbackFiles(quarantineDir, quarantinePath)
 	case stagedErr != nil:
 		return fmt.Errorf("inspect staged migration file: %w", stagedErr)
 	case quarantineErr != nil:
@@ -633,11 +637,27 @@ func rollBackPublicationEntry(
 			quarantinePath,
 		)
 	default:
-		return errors.Join(
-			removeFiles([]string{quarantinePath, stagedPath}),
-			removeEmptyQuarantineDir(quarantineDir),
-		)
+		return removeRollbackFiles(quarantineDir, quarantinePath, stagedPath)
 	}
+}
+
+func syncQuarantineMove(finalPath, quarantineDir string) error {
+	if err := fsdurable.SyncDir(filepath.Dir(finalPath)); err != nil {
+		return fmt.Errorf("sync migration directory after quarantine move: %w", err)
+	}
+	if err := fsdurable.SyncDir(quarantineDir); err != nil {
+		return fmt.Errorf("sync migration rollback quarantine: %w", err)
+	}
+	return nil
+}
+
+func removeRollbackFiles(quarantineDir string, paths ...string) error {
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove %s: %w", path, err)
+		}
+	}
+	return removeEmptyQuarantineDir(quarantineDir)
 }
 
 func fileDigest(path string) (string, error) {
@@ -657,21 +677,47 @@ func removeEmptyQuarantineDir(path string) error {
 }
 
 func removePublicationJournal(journalPath string) error {
+	return removePublicationJournalWithRetirer(journalPath, retirePublicationJournal)
+}
+
+func removePublicationJournalWithRetirer(
+	journalPath string,
+	retire func(string, string) error,
+) error {
 	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
 	if err != nil {
 		return fmt.Errorf("find migration publication journal backups: %w", err)
 	}
+	cleanupPath := journalPath + publicationCleanupSuffix
+	if err := retire(journalPath, cleanupPath); err != nil {
+		return fmt.Errorf("retire migration publication journal: %w", err)
+	}
+	parent := filepath.Dir(journalPath)
+	if err := fsdurable.SyncDir(parent); err != nil {
+		return fmt.Errorf("sync retired migration publication journal: %w", err)
+	}
 	paths := append(
-		[]string{journalPath, publicationCommitMarkerPath(journalPath)},
+		[]string{publicationCommitMarkerPath(journalPath), cleanupPath},
 		journalTemps...,
 	)
 	if err := removeFiles(paths); err != nil {
-		return fmt.Errorf("remove migration publication journal: %w", err)
+		return fmt.Errorf("remove retired migration publication metadata: %w", err)
 	}
-	if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
+	if err := fsdurable.SyncDir(parent); err != nil {
 		return fmt.Errorf("sync migration publication journal directory: %w", err)
 	}
 	return nil
+}
+
+func retirePublicationJournal(journalPath, cleanupPath string) error {
+	_, err := os.Stat(journalPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fsdurable.ReplaceFile(journalPath, cleanupPath)
 }
 
 func removeOrphanPublicationTemps(dir, journalPath string) error {
@@ -686,7 +732,10 @@ func removeOrphanPublicationTemps(dir, journalPath string) error {
 	orphanPaths := slices.Concat(
 		stagedPaths,
 		journalTemps,
-		[]string{publicationCommitMarkerPath(journalPath)},
+		[]string{
+			publicationCommitMarkerPath(journalPath),
+			journalPath + publicationCleanupSuffix,
+		},
 	)
 	if err := removeFiles(orphanPaths); err != nil {
 		return fmt.Errorf("remove orphan migration publication files: %w", err)
@@ -997,25 +1046,6 @@ func removeFiles(paths []string) error {
 	return resultErr
 }
 
-// writeMigrationFiles writes every planned migration file with consecutive
-// versions. It is retained as a focused white-box primitive; production
-// publication uses writeDiffArtifacts so the batch is journaled through the
-// atlas.sum commit.
-func writeMigrationFiles(dir, name string, contents []MigrationFileContent) ([]string, error) {
-	batch, err := stageMigrationBatch(dir, name, contents)
-	if err != nil {
-		return nil, err
-	}
-	published, err := publishMigrationBatch(dir, batch)
-	if err != nil {
-		return nil, errors.Join(err, rollBackUnjournaledBatch(dir, batch, published))
-	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
-		return nil, errors.Join(err, removeFiles(batch.paths))
-	}
-	return batch.paths, nil
-}
-
 func stageArtifactBatch(
 	dir string,
 	artifacts []PublicationArtifact,
@@ -1142,40 +1172,6 @@ func detectPublicationModeWithLink(
 		return "", fmt.Errorf("remove migration publication link probe: %w", err)
 	}
 	return publicationModeHardLink, nil
-}
-
-// writeMigrationFilesAt stages and syncs one complete batch before publishing
-// each final path without overwriting an existing migration.
-func writeMigrationFilesAt(
-	dir, name string,
-	version int64,
-	contents []MigrationFileContent,
-) ([]string, error) {
-	batch, err := stageMigrationBatchAt(dir, name, version, contents)
-	if err != nil {
-		return nil, err
-	}
-	published, err := publishMigrationBatch(dir, batch)
-	if err != nil {
-		return nil, errors.Join(err, rollBackUnjournaledBatch(dir, batch, published))
-	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
-		return nil, errors.Join(err, removeFiles(batch.paths))
-	}
-	return batch.paths, nil
-}
-
-func rollBackUnjournaledBatch(dir string, batch migrationBatch, published int) error {
-	if err := removeFiles(batch.paths[:published]); err != nil {
-		return fmt.Errorf("roll back published migration files: %w", err)
-	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
-		return fmt.Errorf("remove rolled back migration staging files: %w", err)
-	}
-	if err := fsdurable.SyncDir(dir); err != nil {
-		return fmt.Errorf("sync rolled back migration directory: %w", err)
-	}
-	return nil
 }
 
 func stageMigrationFile(dir, migrationSQL string) (string, error) {

--- a/internal/atlasmigrate/publication_mode_nonwindows.go
+++ b/internal/atlasmigrate/publication_mode_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package atlasmigrate
+
+import "os"
+
+func platformPublicationMode(stagedPath string) (publicationMode, error) {
+	return detectPublicationModeWithLink(stagedPath, os.Link)
+}

--- a/internal/atlasmigrate/publication_mode_windows.go
+++ b/internal/atlasmigrate/publication_mode_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package atlasmigrate
+
+func platformPublicationMode(string) (publicationMode, error) {
+	return publicationModeWriteThroughMove, nil
+}

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -11,12 +11,16 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlassource"
+	"github.com/stokaro/ptah/internal/devclean"
 	"github.com/stokaro/ptah/internal/migrationreplay"
 	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
 )
+
+const inspectDevCleanupTimeout = 30 * time.Second
 
 // InspectSourceOptions configures URL-driven Atlas schema inspection.
 type InspectSourceOptions struct {
@@ -128,37 +132,89 @@ func inspectOnDev(
 
 	switch set.Kind {
 	case atlassource.KindMigrationDir:
-		// ReplayOnConnection resets the dev database before replaying.
-		if err := migrationreplay.ReplayOnConnection(ctx, devConn, set.Sources[0].Path, migrator.MigrationDirFormatAtlas); err != nil {
+		var rendered string
+		err := migrationreplay.WithReplayedDirectory(
+			ctx,
+			devConn,
+			set.Sources[0].Path,
+			migrator.MigrationDirFormatAtlas,
+			func(replayConn *dbschema.DatabaseConnection) error {
+				schema, err := readInspectDevSchema(replayConn, opts.Schemas)
+				if err != nil {
+					return err
+				}
+				rendered, err = renderInspectSchema(
+					atlassource.WithoutRevisionTable(schema),
+					replayConn.Info(),
+					inspectOpts,
+				)
+				return err
+			},
+		)
+		if err != nil {
 			return "", fmt.Errorf("--url %q: %w", set.Sources[0].Raw, err)
 		}
+		return rendered, nil
 	case atlassource.KindLocalFile:
-		if err := materializeOnDev(ctx, devConn, desired); err != nil {
+		var rendered string
+		err := withMaterializedDevSchema(
+			ctx,
+			devConn,
+			desired,
+			func(materializedConn *dbschema.DatabaseConnection) error {
+				schema, err := readInspectDevSchema(materializedConn, opts.Schemas)
+				if err != nil {
+					return err
+				}
+				rendered, err = renderInspectSchema(schema, materializedConn.Info(), inspectOpts)
+				return err
+			},
+		)
+		if err != nil {
 			return "", err
 		}
+		return rendered, nil
 	}
-
-	schema, err := dbschema.ReadSchemaWithSchemas(devConn, SplitSchemaNames(opts.Schemas))
-	if err != nil {
-		return "", fmt.Errorf("read dev database schema: %w", err)
-	}
-	if set.Kind == atlassource.KindMigrationDir {
-		schema = atlassource.WithoutRevisionTable(schema)
-	}
-	return renderInspectSchema(schema, devConn.Info(), inspectOpts)
+	return "", fmt.Errorf("--url: unresolved %s inspection source", set.Kind)
 }
 
-// materializeOnDev resets the dev database and executes the desired schema's
-// ordered CREATE statements on it, so introspection sees the schema as the
-// dev database normalizes it.
+func withMaterializedDevSchema(
+	ctx context.Context,
+	devConn *dbschema.DatabaseConnection,
+	desired *goschema.Database,
+	consume func(*dbschema.DatabaseConnection) error,
+) error {
+	return devConn.WithSession(ctx, func(materializedConn *dbschema.DatabaseConnection) (resultErr error) {
+		defer func() {
+			cleanupCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx),
+				inspectDevCleanupTimeout,
+			)
+			defer cancel()
+			if cleanupErr := devclean.DatabaseRealm(cleanupCtx, materializedConn); cleanupErr != nil {
+				resultErr = errors.Join(
+					resultErr,
+					fmt.Errorf("clean dev database after schema inspection: %w", cleanupErr),
+				)
+			}
+		}()
+		if err := devclean.DatabaseRealm(ctx, materializedConn); err != nil {
+			return fmt.Errorf("reset dev database: %w", err)
+		}
+		if err := materializeOnDev(ctx, materializedConn, desired); err != nil {
+			return err
+		}
+		return consume(materializedConn)
+	})
+}
+
+// materializeOnDev executes the desired schema's ordered CREATE statements on
+// an already-reset dev database.
 func materializeOnDev(
 	ctx context.Context,
 	devConn *dbschema.DatabaseConnection,
 	desired *goschema.Database,
 ) error {
-	if err := devConn.SchemaWriter().DropAllTables(ctx); err != nil {
-		return fmt.Errorf("reset dev database: %w", err)
-	}
 	info := devConn.Info()
 	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(desired, info.Dialect, info.Capabilities)
 	if err != nil {
@@ -168,6 +224,17 @@ func materializeOnDev(
 		return fmt.Errorf("materialize schema on dev database: %w", err)
 	}
 	return nil
+}
+
+func readInspectDevSchema(
+	devConn *dbschema.DatabaseConnection,
+	schemas []string,
+) (*dbschematypes.DBSchema, error) {
+	schema, err := dbschema.ReadSchemaWithSchemas(devConn, SplitSchemaNames(schemas))
+	if err != nil {
+		return nil, fmt.Errorf("read dev database schema: %w", err)
+	}
+	return schema, nil
 }
 
 func sourceRawURLs(set atlassource.Set) []string {

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlassource"
 	"github.com/stokaro/ptah/internal/devclean"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/internal/migrationreplay"
 	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -183,7 +184,20 @@ func withMaterializedDevSchema(
 	devConn *dbschema.DatabaseConnection,
 	desired *goschema.Database,
 	consume func(*dbschema.DatabaseConnection) error,
-) error {
+) (resultErr error) {
+	lock, err := devlock.Acquire(ctx, devConn, 0)
+	if err != nil {
+		return fmt.Errorf("acquire schema inspection dev database lock: %w", err)
+	}
+	defer func() {
+		if releaseErr := lock.Release(); releaseErr != nil {
+			resultErr = errors.Join(
+				resultErr,
+				fmt.Errorf("release schema inspection dev database lock: %w", releaseErr),
+			)
+		}
+	}()
+
 	return devConn.WithSession(ctx, func(materializedConn *dbschema.DatabaseConnection) (resultErr error) {
 		defer func() {
 			cleanupCtx, cancel := context.WithTimeout(

--- a/internal/atlasschema/inspect_source_test.go
+++ b/internal/atlasschema/inspect_source_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlassource"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
@@ -53,6 +55,46 @@ func TestInspectSource_LocalSQLFileOnDev(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(rendered, qt.Contains, `table "users"`)
 	c.Assert(rendered, qt.Contains, `column "email"`)
+	assertInspectSQLiteDevEmpty(c, devPath)
+}
+
+func TestInspectSource_LocalSQLFileWaitsForDevRealmLock(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "schema.sql")
+	devPath := filepath.Join(dir, "dev.db")
+	c.Assert(
+		os.WriteFile(
+			schemaPath,
+			[]byte("CREATE TABLE locked_inspection (id INTEGER PRIMARY KEY);\n"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+
+	lockConn := connectSQLite(c, devPath)
+	defer dbschema.CloseAndWarn(lockConn)
+	lock, err := devlock.Acquire(t.Context(), lockConn, 0)
+	c.Assert(err, qt.IsNil)
+
+	blockedCtx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	rendered, err := atlasschema.InspectSource(blockedCtx, atlasschema.InspectSourceOptions{
+		URL:    "file://" + schemaPath,
+		DevURL: "sqlite://" + devPath,
+		Format: "hcl",
+	})
+	c.Assert(err, qt.ErrorMatches, `acquire schema inspection dev database lock: .*context deadline exceeded`)
+	c.Assert(rendered, qt.Equals, "")
+	c.Assert(lock.Release(), qt.IsNil)
+
+	rendered, err = atlasschema.InspectSource(t.Context(), atlasschema.InspectSourceOptions{
+		URL:    "file://" + schemaPath,
+		DevURL: "sqlite://" + devPath,
+		Format: "hcl",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, `table "locked_inspection"`)
 	assertInspectSQLiteDevEmpty(c, devPath)
 }
 

--- a/internal/atlasschema/inspect_source_test.go
+++ b/internal/atlasschema/inspect_source_test.go
@@ -41,17 +41,19 @@ func TestInspectSource_LocalSQLFileOnDev(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	schemaPath := filepath.Join(dir, "a.sql")
+	devPath := filepath.Join(dir, "dev.db")
 	c.Assert(os.WriteFile(schemaPath, []byte("CREATE TABLE users (\n  id INTEGER PRIMARY KEY,\n  email TEXT NOT NULL\n);\n"), 0o600), qt.IsNil)
 
 	rendered, err := atlasschema.InspectSource(context.Background(), atlasschema.InspectSourceOptions{
 		URL:    "file://" + schemaPath,
-		DevURL: "sqlite://" + filepath.Join(dir, "dev.db"),
+		DevURL: "sqlite://" + devPath,
 		Format: "hcl",
 	})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(rendered, qt.Contains, `table "users"`)
 	c.Assert(rendered, qt.Contains, `column "email"`)
+	assertInspectSQLiteDevEmpty(c, devPath)
 }
 
 // TestInspectSource_DevDatabaseIsReset proves the dev database is reset
@@ -83,6 +85,7 @@ func TestInspectSource_MigrationDirOnDev(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
+	devPath := filepath.Join(dir, "dev.db")
 	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
 	c.Assert(os.WriteFile(
 		filepath.Join(migrationsDir, "1_init.sql"),
@@ -94,13 +97,28 @@ func TestInspectSource_MigrationDirOnDev(t *testing.T) {
 
 	rendered, err := atlasschema.InspectSource(context.Background(), atlasschema.InspectSourceOptions{
 		URL:    "file://" + migrationsDir,
-		DevURL: "sqlite://" + filepath.Join(dir, "dev.db"),
+		DevURL: "sqlite://" + devPath,
 		Format: "hcl",
 	})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(rendered, qt.Contains, `table "replayed_users"`)
 	c.Assert(rendered, qt.Not(qt.Contains), "atlas_schema_revisions")
+	assertInspectSQLiteDevEmpty(c, devPath)
+}
+
+func assertInspectSQLiteDevEmpty(c *qt.C, path string) {
+	c.Helper()
+	conn := connectSQLite(c, path)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err := conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+	`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }
 
 func TestInspectSource_EnvSchemaSource(t *testing.T) {

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -16,13 +18,18 @@ import (
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 	"github.com/stokaro/ptah/internal/migratesum"
 	"github.com/stokaro/ptah/internal/migrationreplay"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/internal/schemafile"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
-// revisionTableName is the Atlas revision table filtered out of replayed
-// dev-database state, mirroring `atlas migrate diff` behavior.
-const revisionTableName = "atlas_schema_revisions"
+const (
+	// revisionTableName is the Atlas revision table filtered out of replayed
+	// dev-database state, mirroring `atlas migrate diff` behavior.
+	revisionTableName = "atlas_schema_revisions"
+
+	migrationDirCleanupTimeout = 30 * time.Second
+)
 
 // ResolveOptions configures resolution of one classified desired-state set.
 type ResolveOptions struct {
@@ -125,7 +132,7 @@ func (s Set) ensureDialect(opts ResolveOptions) error {
 	return fmt.Errorf("%s database dialect %q does not match %s dialect %q", s.Flag, implied, opts.DialectFlag, pinned)
 }
 
-func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (State, error) {
+func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (state State, resultErr error) {
 	source := s.Sources[0]
 	devURL := strings.TrimSpace(opts.DevURL)
 	if err := s.EnsureDevDatabase(devURL); err != nil {
@@ -137,7 +144,11 @@ func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (Stat
 	if err := s.ensureDevDialect(devURL, opts); err != nil {
 		return State{}, err
 	}
-	if err := VerifyMigrationDir(source.Path); err != nil {
+	snapshot, err := migrationsnapshot.CaptureStable(os.DirFS(source.Path))
+	if err != nil {
+		return State{}, fmt.Errorf("capture migration directory: %w", err)
+	}
+	if err := verifyMigrationFS(snapshot); err != nil {
 		return State{}, err
 	}
 
@@ -147,20 +158,46 @@ func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (Stat
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := migrationreplay.ReplayOnConnection(ctx, conn, source.Path, migrator.MigrationDirFormatAtlas); err != nil {
+	if err := migrationreplay.ReplaySnapshotOnConnection(
+		ctx,
+		conn,
+		snapshot,
+		migrator.MigrationDirFormatAtlas,
+	); err != nil {
 		return State{}, fmt.Errorf("%s %q: %w", s.Flag, source.Raw, err)
 	}
+	cleanupPending := true
+	defer func() {
+		if cleanupPending {
+			resultErr = errors.Join(resultErr, cleanMigrationDirDevDatabase(ctx, conn))
+		}
+	}()
 	schema, err := dbschema.ReadSchemaWithSchemas(conn, nil)
 	if err != nil {
 		return State{}, fmt.Errorf("read dev database schema: %w", err)
 	}
 	schema = WithoutRevisionTable(schema)
-	return State{
+	state = State{
 		Kind:          s.Kind,
 		Schema:        dbschematogo.ConvertDBSchemaToGoSchema(schema),
 		DB:            schema,
 		DefaultSchema: conn.Info().Schema,
-	}, nil
+	}
+	cleanupErr := cleanMigrationDirDevDatabase(ctx, conn)
+	cleanupPending = false
+	if err := errors.Join(ctx.Err(), cleanupErr); err != nil {
+		return State{}, err
+	}
+	return state, nil
+}
+
+func cleanMigrationDirDevDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), migrationDirCleanupTimeout)
+	defer cancel()
+	if err := conn.SchemaWriter().DropAllTables(cleanupCtx); err != nil {
+		return fmt.Errorf("clean dev database after resolving migration directory: %w", err)
+	}
+	return nil
 }
 
 func (s Set) ensureDevDialect(devURL string, opts ResolveOptions) error {
@@ -192,7 +229,11 @@ func connectDatabase(
 // migration directory used as a desired-state or inspection source: a missing
 // atlas.sum is tolerated, an invalid one fails before replay.
 func VerifyMigrationDir(dir string) error {
-	result, err := migratesum.VerifyDirWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	return verifyMigrationFS(os.DirFS(dir))
+}
+
+func verifyMigrationFS(fsys fs.FS) error {
+	result, err := migratesum.VerifyWithFormat(fsys, migrator.MigrationDirFormatAtlas)
 	if errors.Is(err, migratesum.ErrSumFileMissing) {
 		return nil
 	}

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -27,8 +27,6 @@ const (
 	// revisionTableName is the Atlas revision table filtered out of replayed
 	// dev-database state, mirroring `atlas migrate diff` behavior.
 	revisionTableName = "atlas_schema_revisions"
-
-	migrationDirCleanupTimeout = 30 * time.Second
 )
 
 // ResolveOptions configures resolution of one classified desired-state set.
@@ -47,6 +45,9 @@ type ResolveOptions struct {
 	// initial connection metadata. A zero value leaves the caller's context
 	// deadline unchanged.
 	ConnectTimeout time.Duration
+	// DevLockHeld tells migration-directory resolution that the caller already
+	// holds the dev database realm lock across a larger operation.
+	DevLockHeld bool
 }
 
 // State is one resolved desired-state. Resolution closes every connection it
@@ -132,7 +133,7 @@ func (s Set) ensureDialect(opts ResolveOptions) error {
 	return fmt.Errorf("%s database dialect %q does not match %s dialect %q", s.Flag, implied, opts.DialectFlag, pinned)
 }
 
-func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (state State, resultErr error) {
+func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (State, error) {
 	source := s.Sources[0]
 	devURL := strings.TrimSpace(opts.DevURL)
 	if err := s.EnsureDevDatabase(devURL); err != nil {
@@ -158,46 +159,37 @@ func (s Set) resolveMigrationDir(ctx context.Context, opts ResolveOptions) (stat
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	if err := migrationreplay.ReplaySnapshotOnConnection(
+	var state State
+	replay := migrationreplay.WithReplayedSnapshot
+	if opts.DevLockHeld {
+		replay = migrationreplay.WithReplayedSnapshotLocked
+	}
+	if err := replay(
 		ctx,
 		conn,
 		snapshot,
 		migrator.MigrationDirFormatAtlas,
+		func(replayConn *dbschema.DatabaseConnection) error {
+			schema, err := dbschema.ReadSchemaWithSchemas(replayConn, nil)
+			if err != nil {
+				return fmt.Errorf("read dev database schema: %w", err)
+			}
+			schema = WithoutRevisionTable(schema)
+			state = State{
+				Kind:          s.Kind,
+				Schema:        dbschematogo.ConvertDBSchemaToGoSchema(schema),
+				DB:            schema,
+				DefaultSchema: replayConn.Info().Schema,
+			}
+			return nil
+		},
 	); err != nil {
 		return State{}, fmt.Errorf("%s %q: %w", s.Flag, source.Raw, err)
 	}
-	cleanupPending := true
-	defer func() {
-		if cleanupPending {
-			resultErr = errors.Join(resultErr, cleanMigrationDirDevDatabase(ctx, conn))
-		}
-	}()
-	schema, err := dbschema.ReadSchemaWithSchemas(conn, nil)
-	if err != nil {
-		return State{}, fmt.Errorf("read dev database schema: %w", err)
-	}
-	schema = WithoutRevisionTable(schema)
-	state = State{
-		Kind:          s.Kind,
-		Schema:        dbschematogo.ConvertDBSchemaToGoSchema(schema),
-		DB:            schema,
-		DefaultSchema: conn.Info().Schema,
-	}
-	cleanupErr := cleanMigrationDirDevDatabase(ctx, conn)
-	cleanupPending = false
-	if err := errors.Join(ctx.Err(), cleanupErr); err != nil {
+	if err := ctx.Err(); err != nil {
 		return State{}, err
 	}
 	return state, nil
-}
-
-func cleanMigrationDirDevDatabase(ctx context.Context, conn *dbschema.DatabaseConnection) error {
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), migrationDirCleanupTimeout)
-	defer cancel()
-	if err := conn.SchemaWriter().DropAllTables(cleanupCtx); err != nil {
-		return fmt.Errorf("clean dev database after resolving migration directory: %w", err)
-	}
-	return nil
 }
 
 func (s Set) ensureDevDialect(devURL string, opts ResolveOptions) error {

--- a/internal/atlassource/resolve_test.go
+++ b/internal/atlassource/resolve_test.go
@@ -92,6 +92,31 @@ func TestResolve_MigrationDirReplaysOnDevDatabase(t *testing.T) {
 	c.Assert(state.Schema.Tables, qt.HasLen, 1)
 	c.Assert(state.Schema.Tables[0].Name, qt.Equals, "replayed_users")
 	c.Assert(state.DefaultSchema, qt.Equals, "main")
+	assertSQLiteDevEmpty(c, devURL)
+}
+
+func TestResolve_MigrationDirFailureCleansPartialDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_create_users.sql"),
+		[]byte(`
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+CREATE VIEW user_ids AS SELECT id FROM users;
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "2_invalid.sql"),
+		[]byte("THIS IS NOT SQL;\n"), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	set := classifySingle(t, "--to", "file://"+dir)
+
+	_, err = set.Resolve(t.Context(), atlassource.ResolveOptions{
+		Dialect: "sqlite",
+		DevURL:  devURL,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `(?s)--to "file://.*": replay migration 2 on dev database: .*`)
+	assertSQLiteDevEmpty(c, devURL)
 }
 
 func TestResolve_MigrationDirRequiresDevURL(t *testing.T) {
@@ -225,4 +250,22 @@ func TestResolve_LocalDirectoryWithoutSumKeepsLegacyError(t *testing.T) {
 	_, err := set.Resolve(t.Context(), atlassource.ResolveOptions{Dialect: "sqlite"})
 
 	c.Assert(err, qt.ErrorMatches, `schema file is a directory: .*`)
+}
+
+func assertSQLiteDevEmpty(c *qt.C, devURL string) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM pragma_table_list
+		WHERE schema = ?
+		  AND type IN ('table', 'view', 'virtual')
+		  AND name NOT LIKE 'sqlite_%'
+		  AND name <> 'schema_migrations'
+	`, "main").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }

--- a/internal/atlasurl/url.go
+++ b/internal/atlasurl/url.go
@@ -25,6 +25,13 @@ var defaultPorts = map[string]string{
 	platform.ClickHouse:  "9000",
 }
 
+// SQLiteURLFromPath returns a SQLite URL whose path remains unambiguous on the
+// current operating system. Windows drive paths use the URL's opaque form
+// instead of being misparsed as a host and port.
+func SQLiteURLFromPath(path string) string {
+	return "sqlite:" + filepath.ToSlash(filepath.Clean(path))
+}
+
 func DialectFromURL(rawURL string) (string, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {

--- a/internal/atlasurl/url.go
+++ b/internal/atlasurl/url.go
@@ -6,7 +6,9 @@ package atlasurl
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -69,6 +71,20 @@ func ValidateDialectMatch(rawURL, targetDialect string) error {
 // ignored: using different users, TLS settings, or pool settings does not make
 // a destructive dev operation safe against the same database.
 func SameDatabase(left, right string) (bool, error) {
+	leftURL, leftDialect, err := parseDatabaseURL(left)
+	if err != nil {
+		return false, err
+	}
+	rightURL, rightDialect, err := parseDatabaseURL(right)
+	if err != nil {
+		return false, err
+	}
+	if leftDialect != rightDialect {
+		return false, nil
+	}
+	if leftDialect == platform.SQLite {
+		return sameSQLiteDatabase(leftURL, rightURL)
+	}
 	leftIdentity, err := databaseIdentity(left)
 	if err != nil {
 		return false, err
@@ -89,7 +105,7 @@ func databaseIdentity(rawURL string) (string, error) {
 		return sqliteIdentity(parsed)
 	}
 
-	host := strings.ToLower(parsed.Hostname())
+	host := normalizedDatabaseHost(parsed.Hostname())
 	port := parsed.Port()
 	if port == "" {
 		port = defaultPorts[dialect]
@@ -130,6 +146,46 @@ func normalizeMySQLTCPURL(rawURL string) string {
 }
 
 func sqliteIdentity(parsed *url.URL) (string, error) {
+	path, memory := sqliteDatabasePath(parsed)
+	if memory {
+		return "sqlite\x00:memory:", nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", errors.New("resolve SQLite database path")
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err == nil {
+		absolute = resolved
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", errors.New("resolve SQLite database path")
+	}
+	return "sqlite\x00" + filepath.Clean(absolute), nil
+}
+
+func sameSQLiteDatabase(left, right *url.URL) (bool, error) {
+	leftPath, leftMemory := sqliteDatabasePath(left)
+	rightPath, rightMemory := sqliteDatabasePath(right)
+	if leftMemory || rightMemory {
+		return leftMemory && rightMemory, nil
+	}
+	leftInfo, leftErr := os.Stat(leftPath)
+	rightInfo, rightErr := os.Stat(rightPath)
+	if leftErr == nil && rightErr == nil {
+		return os.SameFile(leftInfo, rightInfo), nil
+	}
+	leftIdentity, err := sqliteIdentity(left)
+	if err != nil {
+		return false, err
+	}
+	rightIdentity, err := sqliteIdentity(right)
+	if err != nil {
+		return false, err
+	}
+	return leftIdentity == rightIdentity, nil
+}
+
+func sqliteDatabasePath(parsed *url.URL) (string, bool) {
 	path := parsed.Opaque
 	switch {
 	case path != "":
@@ -141,17 +197,27 @@ func sqliteIdentity(parsed *url.URL) (string, error) {
 	default:
 		path = parsed.Path
 	}
-	if path == "" || path == "/:memory:" || path == ":memory:" {
-		return "sqlite\x00:memory:", nil
+	path = strings.TrimPrefix(path, "file:")
+	if path == "" || path == "/:memory:" || path == ":memory:" ||
+		parsed.Query().Get("mode") == "memory" {
+		return "", true
 	}
-	if strings.HasPrefix(path, "file:") {
-		return "sqlite\x00" + path, nil
+	return filepath.Clean(path), false
+}
+
+func normalizedDatabaseHost(host string) string {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	if host == "localhost" {
+		return "loopback"
 	}
-	absolute, err := filepath.Abs(path)
-	if err != nil {
-		return "", errors.New("resolve SQLite database path")
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host
 	}
-	return "sqlite\x00" + filepath.Clean(absolute), nil
+	if ip.IsLoopback() {
+		return "loopback"
+	}
+	return ip.String()
 }
 
 func dialectFromDockerURL(parsed *url.URL) (string, error) {

--- a/internal/atlasurl/url_symlink_unix_test.go
+++ b/internal/atlasurl/url_symlink_unix_test.go
@@ -1,0 +1,30 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package atlasurl_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasurl"
+)
+
+func TestSameDatabase_SQLiteSymlinkAlias(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	databasePath := filepath.Join(dir, "dev.db")
+	aliasPath := filepath.Join(dir, "dev-alias.db")
+	c.Assert(os.WriteFile(databasePath, nil, 0o600), qt.IsNil)
+	c.Assert(os.Symlink(databasePath, aliasPath), qt.IsNil)
+
+	same, err := atlasurl.SameDatabase(
+		"sqlite://"+databasePath,
+		"sqlite://"+aliasPath,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(same, qt.IsTrue)
+}

--- a/internal/atlasurl/url_test.go
+++ b/internal/atlasurl/url_test.go
@@ -1,6 +1,7 @@
 package atlasurl_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -98,6 +99,9 @@ func TestSameDatabase_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	sqlitePath := filepath.Join(dir, "dev.db")
+	sqliteHardLink := filepath.Join(dir, "dev-hard-link.db")
+	c.Assert(os.WriteFile(sqlitePath, nil, 0o600), qt.IsNil)
+	c.Assert(os.Link(sqlitePath, sqliteHardLink), qt.IsNil)
 
 	tests := []struct {
 		name  string
@@ -121,6 +125,30 @@ func TestSameDatabase_HappyPath(t *testing.T) {
 			name:  "sqlite relative and absolute paths identify the same file",
 			left:  "sqlite://" + sqlitePath,
 			right: "sqlite://" + filepath.Join(dir, ".", "dev.db") + "?mode=rwc",
+			want:  true,
+		},
+		{
+			name:  "sqlite hard links identify the same file",
+			left:  "sqlite://" + sqlitePath,
+			right: "sqlite://" + sqliteHardLink,
+			want:  true,
+		},
+		{
+			name:  "loopback host aliases identify the same server",
+			left:  "postgres://localhost/app",
+			right: "postgres://127.0.0.1:5432/app",
+			want:  true,
+		},
+		{
+			name:  "expanded and compressed ipv6 identify the same server",
+			left:  "postgres://[2001:0db8:0000:0000:0000:ff00:0042:8329]/app",
+			right: "postgres://[2001:db8::ff00:42:8329]:5432/app",
+			want:  true,
+		},
+		{
+			name:  "expanded ipv6 loopback and localhost identify the same server",
+			left:  "postgres://[0:0:0:0:0:0:0:1]/app",
+			right: "postgres://localhost:5432/app",
 			want:  true,
 		},
 		{

--- a/internal/atlasurl/url_test.go
+++ b/internal/atlasurl/url_test.go
@@ -123,14 +123,14 @@ func TestSameDatabase_HappyPath(t *testing.T) {
 		},
 		{
 			name:  "sqlite relative and absolute paths identify the same file",
-			left:  "sqlite://" + sqlitePath,
-			right: "sqlite://" + filepath.Join(dir, ".", "dev.db") + "?mode=rwc",
+			left:  atlasurl.SQLiteURLFromPath(sqlitePath),
+			right: atlasurl.SQLiteURLFromPath(filepath.Join(dir, ".", "dev.db")) + "?mode=rwc",
 			want:  true,
 		},
 		{
 			name:  "sqlite hard links identify the same file",
-			left:  "sqlite://" + sqlitePath,
-			right: "sqlite://" + sqliteHardLink,
+			left:  atlasurl.SQLiteURLFromPath(sqlitePath),
+			right: atlasurl.SQLiteURLFromPath(sqliteHardLink),
 			want:  true,
 		},
 		{
@@ -165,8 +165,8 @@ func TestSameDatabase_HappyPath(t *testing.T) {
 		},
 		{
 			name:  "different sqlite files",
-			left:  "sqlite://" + sqlitePath,
-			right: "sqlite://" + filepath.Join(dir, "other.db"),
+			left:  atlasurl.SQLiteURLFromPath(sqlitePath),
+			right: atlasurl.SQLiteURLFromPath(filepath.Join(dir, "other.db")),
 			want:  false,
 		},
 	}

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -119,23 +119,24 @@ func convertTablesAndFields(
 		// Convert columns to fields
 		for _, dbColumn := range dbTable.Columns {
 			field := goschema.Field{
-				StructName:    structName,
-				FieldName:     generateFieldName(dbColumn.Name),
-				Name:          dbColumn.Name,
-				Type:          goSchemaFieldType(dbColumn),
-				Nullable:      dbColumn.IsNullable == "YES",
-				Primary:       dbColumn.IsPrimaryKey && !compositePKColumns[dbTable.QualifiedName()][dbColumn.Name],
-				AutoInc:       dbColumn.IsAutoIncrement,
-				Unique:        dbColumn.IsUnique,
-				Charset:       dbColumn.Charset,
-				Collate:       dbColumn.Collate,
-				GeneratedKind: dbColumn.GeneratedKind,
+				StructName:         structName,
+				FieldName:          generateFieldName(dbColumn.Name),
+				Name:               dbColumn.Name,
+				Type:               goSchemaFieldType(dbColumn),
+				Nullable:           dbColumn.IsNullable == "YES",
+				Primary:            dbColumn.IsPrimaryKey && !compositePKColumns[dbTable.QualifiedName()][dbColumn.Name],
+				AutoInc:            dbColumn.IsAutoIncrement,
+				Unique:             dbColumn.IsUnique,
+				Charset:            dbColumn.Charset,
+				Collate:            dbColumn.Collate,
+				GeneratedKind:      dbColumn.GeneratedKind,
+				IdentityGeneration: dbColumn.IdentityGeneration,
 			}
 			if dbColumn.GeneratedExpression != nil {
 				field.GeneratedExpression = *dbColumn.GeneratedExpression
 			}
 
-			if dbColumn.ColumnDefault != nil {
+			if dbColumn.ColumnDefault != nil && postgresSerialType(dbColumn) == "" {
 				setFieldDefaultFromDB(&field, *dbColumn.ColumnDefault)
 			}
 
@@ -522,6 +523,9 @@ func firstString(values []string) string {
 }
 
 func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
+	if serialType := postgresSerialType(dbColumn); serialType != "" {
+		return serialType
+	}
 	if strings.EqualFold(dbColumn.DataType, "USER-DEFINED") && dbColumn.UDTName != "" {
 		return dbColumn.UDTName
 	}
@@ -532,6 +536,23 @@ func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
 		return sizedType
 	}
 	return dbColumn.DataType
+}
+
+func postgresSerialType(dbColumn dbschematypes.DBColumn) string {
+	if !dbColumn.IsAutoIncrement || dbColumn.ColumnDefault == nil ||
+		!strings.Contains(strings.ToLower(*dbColumn.ColumnDefault), "nextval(") {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(dbColumn.DataType)) {
+	case "smallint":
+		return "SMALLSERIAL"
+	case "integer":
+		return "SERIAL"
+	case "bigint":
+		return "BIGSERIAL"
+	default:
+		return ""
+	}
 }
 
 func sizedColumnType(dbColumn dbschematypes.DBColumn) string {

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -423,6 +423,49 @@ func TestConvertDBSchemaToGoSchema_DBDefaultExpression(t *testing.T) {
 	c.Assert(result.Fields[1].DefaultExpr, qt.Equals, "")
 }
 
+func TestConvertDBSchemaToGoSchema_PostgresSequenceSemantics(t *testing.T) {
+	c := qt.New(t)
+	serialDefault := "nextval('items_id_seq'::regclass)"
+	standaloneSequenceDefault := "nextval('shared_ids'::regclass)"
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "items",
+				Columns: []types.DBColumn{
+					{
+						Name:            "id",
+						DataType:        "bigint",
+						ColumnDefault:   &serialDefault,
+						IsAutoIncrement: true,
+					},
+					{
+						Name:          "external_id",
+						DataType:      "bigint",
+						ColumnDefault: &standaloneSequenceDefault,
+					},
+					{
+						Name:               "identity_id",
+						DataType:           "bigint",
+						IdentityGeneration: "ALWAYS",
+					},
+				},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Fields, qt.HasLen, 3)
+	c.Assert(result.Fields[0].Type, qt.Equals, "BIGSERIAL")
+	c.Assert(result.Fields[0].AutoInc, qt.IsTrue)
+	c.Assert(result.Fields[0].DefaultExpr, qt.Equals, "")
+	c.Assert(result.Fields[1].Type, qt.Equals, "bigint")
+	c.Assert(result.Fields[1].AutoInc, qt.IsFalse)
+	c.Assert(result.Fields[1].DefaultExpr, qt.Equals, standaloneSequenceDefault)
+	c.Assert(result.Fields[2].Type, qt.Equals, "bigint")
+	c.Assert(result.Fields[2].IdentityGeneration, qt.Equals, "ALWAYS")
+}
+
 func TestConvertDBSchemaToGoSchema_CompositeForeignKeyBecomesTableConstraint(t *testing.T) {
 	c := qt.New(t)
 	dbSchema := &types.DBSchema{

--- a/internal/dblock/dblock.go
+++ b/internal/dblock/dblock.go
@@ -19,9 +19,12 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 )
 
-// mariaDBDefaultTimeoutSeconds stands in for an infinite GET_LOCK wait on
-// MariaDB, which rejects the negative timeout MySQL uses for "wait forever".
-const mariaDBDefaultTimeoutSeconds = 31_536_000
+const (
+	// mariaDBDefaultTimeoutSeconds stands in for an infinite GET_LOCK wait on
+	// MariaDB, which rejects the negative timeout MySQL uses for "wait forever".
+	mariaDBDefaultTimeoutSeconds = 31_536_000
+	postgresLockPollInterval     = 25 * time.Millisecond
+)
 
 // DefaultReleaseTimeout bounds the deferred release of an advisory lock so a
 // canceled command still returns its dedicated session connection promptly.
@@ -49,7 +52,11 @@ func IsTimeout(err error) bool {
 // semantics. [Acquire] returns a no-op lock on unsupported dialects.
 func Supported(dialect string) bool {
 	switch platform.NormalizeDialect(dialect) {
-	case platform.Postgres, platform.MySQL, platform.MariaDB, platform.SQLServer:
+	case platform.Postgres,
+		platform.YugabyteDB,
+		platform.MySQL,
+		platform.MariaDB,
+		platform.SQLServer:
 		return true
 	default:
 		return false
@@ -99,7 +106,7 @@ func Acquire(
 	if name == "" {
 		return nil, errors.New("advisory lock name must not be empty")
 	}
-	dialect := conn.Info().Dialect
+	dialect := platform.NormalizeDialect(conn.Info().Dialect)
 	if !Supported(dialect) {
 		return &Lock{}, nil
 	}
@@ -111,10 +118,10 @@ func Acquire(
 
 	lock := &Lock{conn: session}
 	var acquireErr error
-	switch platform.NormalizeDialect(dialect) {
-	case platform.Postgres:
-		lock.release = releasePostgresLock(session, name)
-		acquireErr = acquirePostgresLock(ctx, session, name, timeout)
+	switch dialect {
+	case platform.Postgres, platform.YugabyteDB:
+		lock.release = releasePostgresLock(session, dialect, name)
+		acquireErr = acquirePostgresLock(ctx, session, dialect, name, timeout)
 	case platform.MySQL, platform.MariaDB:
 		lock.release = releaseMySQLLock(session, name)
 		acquireErr = acquireMySQLLock(ctx, session, dialect, name, timeout)
@@ -136,30 +143,73 @@ func PostgresKey(name string) int64 {
 	return int64(hash.Sum32())
 }
 
-func acquirePostgresLock(ctx context.Context, conn *sql.Conn, name string, timeout time.Duration) error {
+func acquirePostgresLock(
+	ctx context.Context,
+	conn *sql.Conn,
+	dialect, name string,
+	timeout time.Duration,
+) error {
 	lockCtx := ctx
 	var cancel context.CancelFunc
 	if timeout > 0 {
 		lockCtx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	if _, err := conn.ExecContext(lockCtx, "SELECT pg_advisory_lock($1)", PostgresKey(name)); err != nil {
-		if timeout > 0 && errors.Is(lockCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-			return &TimeoutError{Dialect: platform.Postgres, Name: name, Timeout: timeout}
+
+	ticker := time.NewTicker(postgresLockPollInterval)
+	defer ticker.Stop()
+	for {
+		var acquired bool
+		if err := conn.QueryRowContext(
+			lockCtx,
+			"SELECT pg_try_advisory_lock($1)",
+			PostgresKey(name),
+		).Scan(&acquired); err != nil {
+			return postgresLockWaitError(ctx, lockCtx, dialect, name, timeout, err)
 		}
-		return err
+		if acquired {
+			return nil
+		}
+
+		select {
+		case <-lockCtx.Done():
+			return postgresLockWaitError(
+				ctx,
+				lockCtx,
+				dialect,
+				name,
+				timeout,
+				lockCtx.Err(),
+			)
+		case <-ticker.C:
+		}
 	}
-	return nil
 }
 
-func releasePostgresLock(conn *sql.Conn, name string) func(context.Context) error {
+func postgresLockWaitError(
+	ctx,
+	lockCtx context.Context,
+	dialect,
+	name string,
+	timeout time.Duration,
+	fallback error,
+) error {
+	if timeout > 0 &&
+		errors.Is(lockCtx.Err(), context.DeadlineExceeded) &&
+		ctx.Err() == nil {
+		return &TimeoutError{Dialect: dialect, Name: name, Timeout: timeout}
+	}
+	return fallback
+}
+
+func releasePostgresLock(conn *sql.Conn, dialect, name string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		var released bool
 		if err := conn.QueryRowContext(ctx, "SELECT pg_advisory_unlock($1)", PostgresKey(name)).Scan(&released); err != nil {
 			return err
 		}
 		if !released {
-			return fmt.Errorf("postgres advisory lock was not held")
+			return fmt.Errorf("%s advisory lock was not held", dialect)
 		}
 		return nil
 	}

--- a/internal/dblock/dblock.go
+++ b/internal/dblock/dblock.go
@@ -8,6 +8,7 @@ package dblock
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -71,6 +72,18 @@ type Lock struct {
 	release func(context.Context) error
 }
 
+type ambiguousAcquisitionError struct {
+	err error
+}
+
+func (e *ambiguousAcquisitionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *ambiguousAcquisitionError) Unwrap() error {
+	return e.err
+}
+
 // Supported reports whether the lock is backed by a real database lock, as
 // opposed to the no-op lock acquired on dialects without advisory locks.
 func (l *Lock) Supported() bool {
@@ -83,8 +96,13 @@ func (l *Lock) Release(ctx context.Context) error {
 	if l == nil || l.conn == nil {
 		return nil
 	}
-	defer l.conn.Close()
-	return l.release(ctx)
+	conn := l.conn
+	l.conn = nil
+	releaseErr := l.release(ctx)
+	if releaseErr != nil {
+		return errors.Join(releaseErr, discardConnection(conn))
+	}
+	return conn.Close()
 }
 
 // Acquire takes the dialect-specific session advisory lock named name on a
@@ -130,8 +148,7 @@ func Acquire(
 		acquireErr = acquireSQLServerLock(ctx, session, name, timeout)
 	}
 	if acquireErr != nil {
-		_ = session.Close()
-		return nil, acquireErr
+		return nil, closeAfterFailedAcquisition(session, acquireErr)
 	}
 	return lock, nil
 }
@@ -165,7 +182,9 @@ func acquirePostgresLock(
 			"SELECT pg_try_advisory_lock($1)",
 			PostgresKey(name),
 		).Scan(&acquired); err != nil {
-			return postgresLockWaitError(ctx, lockCtx, dialect, name, timeout, err)
+			return &ambiguousAcquisitionError{
+				err: postgresLockWaitError(ctx, lockCtx, dialect, name, timeout, err),
+			}
 		}
 		if acquired {
 			return nil
@@ -220,7 +239,7 @@ func acquireMySQLLock(ctx context.Context, conn *sql.Conn, dialect string, name 
 
 	var acquired sql.NullInt64
 	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", name, timeoutSeconds).Scan(&acquired); err != nil {
-		return err
+		return &ambiguousAcquisitionError{err: err}
 	}
 	if !acquired.Valid {
 		return fmt.Errorf("GET_LOCK(%q) returned NULL", name)
@@ -259,7 +278,7 @@ EXEC @result = sys.sp_getapplock
     @LockOwner = 'Session',
     @LockTimeout = @p2;
 SELECT @result;`, name, timeoutMilliseconds).Scan(&result); err != nil {
-		return err
+		return &ambiguousAcquisitionError{err: err}
 	}
 	if result >= 0 {
 		return nil
@@ -307,4 +326,25 @@ func sqlServerLockTimeoutMilliseconds(timeout time.Duration) int {
 		return math.MaxInt32
 	}
 	return int(milliseconds)
+}
+
+func closeAfterFailedAcquisition(conn *sql.Conn, acquireErr error) error {
+	if _, ok := errors.AsType[*ambiguousAcquisitionError](acquireErr); ok {
+		return errors.Join(acquireErr, discardConnection(conn))
+	}
+	return errors.Join(acquireErr, conn.Close())
+}
+
+func discardConnection(conn *sql.Conn) error {
+	discardErr := conn.Raw(func(any) error {
+		return driver.ErrBadConn
+	})
+	if errors.Is(discardErr, driver.ErrBadConn) {
+		discardErr = nil
+	}
+	closeErr := conn.Close()
+	if errors.Is(closeErr, sql.ErrConnDone) {
+		closeErr = nil
+	}
+	return errors.Join(discardErr, closeErr)
 }

--- a/internal/dblock/dblock_internal_test.go
+++ b/internal/dblock/dblock_internal_test.go
@@ -1,15 +1,19 @@
 package dblock
 
 // White-box testing required: advisory-lock polling and timeout conversions
-// are only observable through SQL sent to live servers. Their retry and
-// numeric edge cases cannot be asserted through the public Acquire API without
-// coupling these unit tests to live PostgreSQL-family, MySQL, MariaDB, and SQL
-// Server instances.
+// and physical-session disposal are only observable through SQL sent to live
+// servers and database/sql internals. Their retry, numeric, and pool-reuse
+// edge cases cannot be asserted through the public Acquire API without
+// coupling these unit tests to live PostgreSQL-family, MySQL, MariaDB, and
+// SQL Server instances.
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"math"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -112,6 +116,119 @@ func TestPostgresLockWaitError_MapsQueryDeadlineToTimeout(t *testing.T) {
 	c.Assert(IsTimeout(err), qt.IsTrue)
 }
 
+func TestCloseAfterFailedAcquisition_DiscardsAmbiguousSession(t *testing.T) {
+	c := qt.New(t)
+	queryErr := errors.New("lock response lost")
+	db, tracker := openTrackingDB(c, queryErr)
+	session, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+
+	acquireErr := acquirePostgresLock(
+		c.Context(),
+		session,
+		platform.Postgres,
+		"ptah_test",
+		time.Second,
+	)
+	c.Assert(acquireErr, qt.ErrorIs, queryErr)
+	c.Assert(closeAfterFailedAcquisition(session, acquireErr), qt.ErrorIs, queryErr)
+	c.Assert(tracker.closeCount.Load(), qt.Equals, int64(1))
+
+	replacement, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(tracker.openCount.Load(), qt.Equals, int64(2))
+	c.Assert(replacement.Close(), qt.IsNil)
+}
+
+func TestAcquireMySQLLock_DiscardsSessionAfterAmbiguousFailure(t *testing.T) {
+	c := qt.New(t)
+	queryErr := errors.New("GET_LOCK response lost")
+	db, tracker := openTrackingDB(c, queryErr)
+	session, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+
+	acquireErr := acquireMySQLLock(
+		c.Context(),
+		session,
+		platform.MySQL,
+		"ptah_test",
+		time.Second,
+	)
+	c.Assert(acquireErr, qt.ErrorIs, queryErr)
+	c.Assert(closeAfterFailedAcquisition(session, acquireErr), qt.ErrorIs, queryErr)
+	c.Assert(tracker.closeCount.Load(), qt.Equals, int64(1))
+
+	replacement, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(tracker.openCount.Load(), qt.Equals, int64(2))
+	c.Assert(replacement.Close(), qt.IsNil)
+}
+
+func TestAcquireSQLServerLock_DiscardsSessionAfterAmbiguousFailure(t *testing.T) {
+	c := qt.New(t)
+	queryErr := errors.New("sp_getapplock response lost")
+	db, tracker := openTrackingDB(c, queryErr)
+	session, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+
+	acquireErr := acquireSQLServerLock(
+		c.Context(),
+		session,
+		"ptah_test",
+		time.Second,
+	)
+	c.Assert(acquireErr, qt.ErrorIs, queryErr)
+	c.Assert(closeAfterFailedAcquisition(session, acquireErr), qt.ErrorIs, queryErr)
+	c.Assert(tracker.closeCount.Load(), qt.Equals, int64(1))
+
+	replacement, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(tracker.openCount.Load(), qt.Equals, int64(2))
+	c.Assert(replacement.Close(), qt.IsNil)
+}
+
+func TestCloseAfterFailedAcquisition_ReturnsDefiniteFailureSessionToPool(t *testing.T) {
+	c := qt.New(t)
+	db, tracker := openTrackingDB(c, nil)
+	session, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	timeoutErr := &TimeoutError{
+		Dialect: platform.Postgres,
+		Name:    "ptah_test",
+		Timeout: time.Second,
+	}
+
+	c.Assert(closeAfterFailedAcquisition(session, timeoutErr), qt.ErrorIs, timeoutErr)
+	c.Assert(tracker.closeCount.Load(), qt.Equals, int64(0))
+
+	replacement, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(tracker.openCount.Load(), qt.Equals, int64(1))
+	c.Assert(replacement.Close(), qt.IsNil)
+}
+
+func TestLockRelease_DiscardsSessionAfterTimeout(t *testing.T) {
+	c := qt.New(t)
+	db, tracker := openTrackingDB(c, nil)
+	session, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	lock := &Lock{
+		conn: session,
+		release: func(context.Context) error {
+			return context.DeadlineExceeded
+		},
+	}
+
+	c.Assert(lock.Release(c.Context()), qt.ErrorIs, context.DeadlineExceeded)
+	c.Assert(tracker.closeCount.Load(), qt.Equals, int64(1))
+	c.Assert(lock.Release(c.Context()), qt.IsNil)
+
+	replacement, err := db.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(tracker.openCount.Load(), qt.Equals, int64(2))
+	c.Assert(replacement.Close(), qt.IsNil)
+}
+
 func TestMySQLLockTimeoutSeconds(t *testing.T) {
 	c := qt.New(t)
 
@@ -133,6 +250,66 @@ func TestMySQLLockTimeoutSeconds(t *testing.T) {
 		})
 	}
 }
+
+type trackingDB struct {
+	openCount  atomic.Int64
+	closeCount atomic.Int64
+	queryErr   error
+}
+
+type trackingDriver struct {
+	tracker *trackingDB
+}
+
+type trackingConn struct {
+	tracker *trackingDB
+}
+
+var trackingDriverID atomic.Int64
+
+func openTrackingDB(c *qt.C, queryErr error) (*sql.DB, *trackingDB) {
+	c.Helper()
+	tracker := &trackingDB{queryErr: queryErr}
+	driverName := "ptah_dblock_tracking_" + strconv.FormatInt(trackingDriverID.Add(1), 10)
+	sql.Register(driverName, &trackingDriver{tracker: tracker})
+	db, err := sql.Open(driverName, "")
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(db.Close(), qt.IsNil)
+	})
+	return db, tracker
+}
+
+func (d *trackingDriver) Open(string) (driver.Conn, error) {
+	d.tracker.openCount.Add(1)
+	return &trackingConn{tracker: d.tracker}, nil
+}
+
+func (c *trackingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not supported")
+}
+
+func (c *trackingConn) Close() error {
+	c.tracker.closeCount.Add(1)
+	return nil
+}
+
+func (c *trackingConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not supported")
+}
+
+func (c *trackingConn) QueryContext(
+	context.Context,
+	string,
+	[]driver.NamedValue,
+) (driver.Rows, error) {
+	return nil, c.tracker.queryErr
+}
+
+var (
+	_ driver.Conn           = (*trackingConn)(nil)
+	_ driver.QueryerContext = (*trackingConn)(nil)
+)
 
 func TestSQLServerLockTimeoutMilliseconds(t *testing.T) {
 	c := qt.New(t)

--- a/internal/dblock/dblock_internal_test.go
+++ b/internal/dblock/dblock_internal_test.go
@@ -1,18 +1,116 @@
 package dblock
 
-// White-box testing required: the GET_LOCK and sp_getapplock timeout
-// conversions are only observable through SQL sent to live MySQL, MariaDB,
-// and SQL Server servers, so their numeric edge cases (rounding up, MariaDB's
-// finite stand-in for an infinite wait, and the SQL Server int cap) cannot be
-// asserted through the public Acquire API without those servers.
+// White-box testing required: advisory-lock polling and timeout conversions
+// are only observable through SQL sent to live servers. Their retry and
+// numeric edge cases cannot be asserted through the public Acquire API without
+// coupling these unit tests to live PostgreSQL-family, MySQL, MariaDB, and SQL
+// Server instances.
 
 import (
+	"context"
+	"database/sql/driver"
 	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
 )
+
+func TestAcquirePostgresLock_RetriesUntilAcquired(t *testing.T) {
+	c := qt.New(t)
+	responses := []bool{false, true}
+	var attempt atomic.Int64
+	db := dbtest.Open(t, func(
+		query string,
+		args []driver.NamedValue,
+	) (dbtest.QueryResult, error) {
+		c.Check(query, qt.Equals, "SELECT pg_try_advisory_lock($1)")
+		c.Check(args, qt.DeepEquals, []driver.NamedValue{{
+			Ordinal: 1,
+			Value:   PostgresKey("ptah_test"),
+		}})
+		index := min(int(attempt.Add(1)-1), len(responses)-1)
+		return dbtest.QueryResult{
+			Columns: []string{"pg_try_advisory_lock"},
+			Rows:    [][]driver.Value{{responses[index]}},
+		}, nil
+	})
+	conn, err := db.SQL.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+
+	err = acquirePostgresLock(
+		t.Context(),
+		conn,
+		platform.YugabyteDB,
+		"ptah_test",
+		time.Second,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+}
+
+func TestAcquirePostgresLock_ReportsDialectOnTimeout(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, func(
+		string,
+		[]driver.NamedValue,
+	) (dbtest.QueryResult, error) {
+		return dbtest.QueryResult{
+			Columns: []string{"pg_try_advisory_lock"},
+			Rows:    [][]driver.Value{{false}},
+		}, nil
+	})
+	conn, err := db.SQL.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+
+	err = acquirePostgresLock(
+		context.Background(),
+		conn,
+		platform.YugabyteDB,
+		"ptah_test",
+		time.Millisecond,
+	)
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`timed out acquiring advisory lock "ptah_test" on yugabytedb after 1ms`,
+	)
+	c.Assert(IsTimeout(err), qt.IsTrue)
+}
+
+func TestPostgresLockWaitError_MapsQueryDeadlineToTimeout(t *testing.T) {
+	c := qt.New(t)
+	lockCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	err := postgresLockWaitError(
+		t.Context(),
+		lockCtx,
+		platform.Postgres,
+		"ptah_test",
+		25*time.Millisecond,
+		context.DeadlineExceeded,
+	)
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`timed out acquiring advisory lock "ptah_test" on postgres after 25ms`,
+	)
+	c.Assert(IsTimeout(err), qt.IsTrue)
+}
 
 func TestMySQLLockTimeoutSeconds(t *testing.T) {
 	c := qt.New(t)

--- a/internal/dblock/dblock_live_test.go
+++ b/internal/dblock/dblock_live_test.go
@@ -1,0 +1,84 @@
+package dblock_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/dblock"
+)
+
+func TestAdvisoryLock_PostgresFamilyLive(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		urlEnv  string
+		dialect string
+	}{
+		{name: "postgres", urlEnv: "POSTGRES_TEST_DSN", dialect: platform.Postgres},
+		{name: "yugabytedb", urlEnv: "YUGABYTEDB_URL", dialect: platform.YugabyteDB},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			databaseURL := requireLiveLockURL(c, test.urlEnv)
+			first, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(first)
+			})
+			second, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(second)
+			})
+
+			firstLock, err := dblock.Acquire(
+				c.Context(),
+				first,
+				"ptah_dblock_postgres_family_live",
+				5*time.Second,
+			)
+			c.Assert(err, qt.IsNil)
+			c.Assert(firstLock.Supported(), qt.IsTrue)
+
+			blockedLock, err := dblock.Acquire(
+				c.Context(),
+				second,
+				"ptah_dblock_postgres_family_live",
+				100*time.Millisecond,
+			)
+			c.Assert(err, qt.ErrorMatches,
+				`timed out acquiring advisory lock "ptah_dblock_postgres_family_live" on `+
+					test.dialect+` after 100ms`)
+			c.Assert(dblock.IsTimeout(err), qt.IsTrue)
+			c.Assert(blockedLock, qt.IsNil)
+
+			c.Assert(firstLock.Release(c.Context()), qt.IsNil)
+
+			secondLock, err := dblock.Acquire(
+				c.Context(),
+				second,
+				"ptah_dblock_postgres_family_live",
+				5*time.Second,
+			)
+			c.Assert(err, qt.IsNil)
+			c.Assert(secondLock.Supported(), qt.IsTrue)
+			c.Assert(secondLock.Release(c.Context()), qt.IsNil)
+		})
+	}
+}
+
+func requireLiveLockURL(c *qt.C, environmentName string) string {
+	c.Helper()
+	databaseURL := os.Getenv(environmentName)
+	if databaseURL == "" {
+		c.Skip(environmentName + " is not set")
+	}
+	return databaseURL
+}

--- a/internal/dblock/dblock_test.go
+++ b/internal/dblock/dblock_test.go
@@ -28,6 +28,7 @@ func TestSupported(t *testing.T) {
 		{name: "sqlite", dialect: "sqlite", want: false},
 		{name: "clickhouse", dialect: "clickhouse", want: false},
 		{name: "cockroachdb", dialect: "cockroachdb", want: false},
+		{name: "yugabytedb", dialect: "yugabytedb", want: true},
 		{name: "spanner", dialect: "spanner", want: false},
 		{name: "unknown", dialect: "not-a-dialect", want: false},
 	}

--- a/internal/dbschema/clickhouse/reader.go
+++ b/internal/dbschema/clickhouse/reader.go
@@ -1,11 +1,11 @@
 package clickhouse
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 // Engines we consider "real data tables" for schema introspection. The
@@ -24,14 +24,14 @@ import (
 // (ClickHouse's read consistency is per-query against the storage engine,
 // and the system tables are MergeTree-backed views).
 type Reader struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 }
 
 // NewClickHouseReader creates a reader for the given database/schema.
 // `schema` corresponds to the ClickHouse database name; if empty it
 // defaults to `currentDatabase()` resolved on each query.
-func NewClickHouseReader(db *sql.DB, schema string) *Reader {
+func NewClickHouseReader(db sqlrunner.Runner, schema string) *Reader {
 	return &Reader{db: db, schema: schema}
 }
 

--- a/internal/dbschema/clickhouse/writer.go
+++ b/internal/dbschema/clickhouse/writer.go
@@ -246,8 +246,7 @@ func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
 	if slices.Contains(protectedClickHouseDatabases, w.schema) {
 		return fmt.Errorf("clickhouse: refusing database-realm cleanup of protected database %q", w.schema)
 	}
-	checkGrants, err := w.validateDatabaseRealmTarget(ctx)
-	if err != nil {
+	if err := w.validateDatabaseRealmTarget(ctx); err != nil {
 		return err
 	}
 
@@ -261,10 +260,8 @@ func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
 		}
 	}
 
-	if checkGrants {
-		if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
-			return fmt.Errorf("clickhouse: verify database %q remains fully visible: %w", w.schema, err)
-		}
+	if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
+		return fmt.Errorf("clickhouse: verify database %q remains fully visible: %w", w.schema, err)
 	}
 	remaining, err := w.listDatabaseRealmObjects(ctx)
 	if err != nil {
@@ -280,30 +277,32 @@ func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
 	return nil
 }
 
-func (w *Writer) validateDatabaseRealmTarget(ctx context.Context) (bool, error) {
+func (w *Writer) validateDatabaseRealmTarget(ctx context.Context) error {
 	var version string
 	if err := w.db.QueryRowContext(ctx, databaseRealmVersionQuery).Scan(&version); err != nil {
-		return false, fmt.Errorf("clickhouse: inspect server version: %w", err)
+		return fmt.Errorf("clickhouse: inspect server version: %w", err)
 	}
 	checkGrants, err := supportsCheckGrant(version)
 	if err != nil {
-		return false, err
+		return err
 	}
-	// CHECK GRANT was added in ClickHouse 24.11. Older supported servers
-	// still get preclassification and residual checks, but cannot prove
-	// effective grants without parsing role-aware SHOW GRANTS output.
-	if checkGrants {
-		if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
-			return false, err
-		}
+	if !checkGrants {
+		return fmt.Errorf(
+			"clickhouse: refusing database-realm cleanup on server version %q: "+
+				"ClickHouse 24.11 or newer is required to prove complete catalog visibility with CHECK GRANT",
+			version,
+		)
+	}
+	if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
+		return err
 	}
 
 	var engine string
 	if err := w.db.QueryRowContext(ctx, databaseRealmEngineQuery, w.schema).Scan(&engine); err != nil {
-		return false, fmt.Errorf("clickhouse: inspect database %q: %w", w.schema, err)
+		return fmt.Errorf("clickhouse: inspect database %q: %w", w.schema, err)
 	}
 	if !slices.Contains(databaseRealmCleanupEngines, engine) {
-		return false, fmt.Errorf(
+		return fmt.Errorf(
 			"clickhouse: refusing to clean database %q with unsupported engine %q",
 			w.schema,
 			engine,
@@ -312,15 +311,15 @@ func (w *Writer) validateDatabaseRealmTarget(ctx context.Context) (bool, error) 
 
 	temporaryObjects, err := w.listTemporaryObjects(ctx)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if len(temporaryObjects) != 0 {
-		return false, fmt.Errorf(
+		return fmt.Errorf(
 			"clickhouse: refusing database-realm cleanup while session-temporary objects exist: %q",
 			temporaryObjects,
 		)
 	}
-	return checkGrants, nil
+	return nil
 }
 
 func supportsCheckGrant(version string) (bool, error) {

--- a/internal/dbschema/clickhouse/writer.go
+++ b/internal/dbschema/clickhouse/writer.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -82,13 +83,43 @@ const databaseRealmTemporaryObjectsQuery = `
 	ORDER BY name
 `
 
+const databaseRealmGlobalPrivilegesQuery = `
+	CHECK GRANT SHOW DATABASES, SHOW TABLES ON *.*
+`
+
+// ClickHouse does not expose dependency metadata for ordinary views. Fail
+// closed when another user database contains an object capable of referencing
+// the cleanup realm, because proving that object independent would require
+// parsing its engine or SELECT sub-language.
+const databaseRealmExternalDependenciesQuery = `
+	SELECT database, name, engine
+	FROM system.tables
+	WHERE database != ?
+	  AND database NOT IN (
+	    'INFORMATION_SCHEMA',
+	    '_temporary_and_external_tables',
+	    'information_schema',
+	    'system'
+	  )
+	  AND engine IN (
+	    'Buffer',
+	    'Dictionary',
+	    'Distributed',
+	    'LiveView',
+	    'MaterializedView',
+	    'Merge',
+	    'View',
+	    'WindowView'
+	  )
+	ORDER BY database, name
+	LIMIT 1
+`
+
 var databaseRealmCleanupEngines = []string{
 	"Atomic",
 	"Lazy",
 	"Memory",
 	"Ordinary",
-	"Replicated",
-	"Shared",
 }
 
 var protectedClickHouseDatabases = []string{
@@ -346,6 +377,15 @@ func (w *Writer) checkDatabaseRealmPrivileges(ctx context.Context) error {
 			quoteIdent(w.schema),
 		)
 	}
+	if err := w.db.QueryRowContext(ctx, databaseRealmGlobalPrivilegesQuery).Scan(&granted); err != nil {
+		return fmt.Errorf("clickhouse: check global catalog visibility: %w", err)
+	}
+	if granted != 1 {
+		return fmt.Errorf(
+			"clickhouse: database-realm cleanup requires SHOW DATABASES and SHOW TABLES on *.* " +
+				"to prove that external dependencies are absent",
+		)
+	}
 	return nil
 }
 
@@ -371,6 +411,9 @@ func (w *Writer) listTemporaryObjects(ctx context.Context) ([]string, error) {
 }
 
 func (w *Writer) listDatabaseRealmObjects(ctx context.Context) ([]databaseRealmObject, error) {
+	if err := w.rejectExternalDatabaseRealmDependencies(ctx); err != nil {
+		return nil, err
+	}
 	rows, err := w.db.QueryContext(ctx, databaseRealmObjectsQuery, w.schema)
 	if err != nil {
 		return nil, fmt.Errorf("clickhouse: list persistent objects in database %q: %w", w.schema, err)
@@ -408,6 +451,34 @@ func (w *Writer) listDatabaseRealmObjects(ctx context.Context) ([]databaseRealmO
 		)
 	}
 	return objects, nil
+}
+
+func (w *Writer) rejectExternalDatabaseRealmDependencies(ctx context.Context) error {
+	var database string
+	var name string
+	var engine string
+	err := w.db.QueryRowContext(
+		ctx,
+		databaseRealmExternalDependenciesQuery,
+		w.schema,
+	).Scan(&database, &name, &engine)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf(
+			"clickhouse: inspect external dependencies on database %q: %w",
+			w.schema,
+			err,
+		)
+	}
+	return fmt.Errorf(
+		"clickhouse: refusing to clean database %q: external object %s with engine %q "+
+			"may depend on the cleanup realm",
+		w.schema,
+		quoteQualifiedIdent(database, name),
+		engine,
+	)
 }
 
 func classifyDatabaseRealmObject(engine, createSQL string) databaseRealmObjectKind {

--- a/internal/dbschema/clickhouse/writer.go
+++ b/internal/dbschema/clickhouse/writer.go
@@ -5,17 +5,21 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
-// quoteIdent returns a safely-backtick-quoted ClickHouse identifier.
-// Embedded backticks are doubled so that values coming from system.tables
-// (or any other untrusted-shaped string) cannot terminate the quoted
-// identifier and inject DDL.
 func quoteIdent(name string) string {
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	return sqlident.Quote(platform.ClickHouse, name)
+}
+
+func quoteQualifiedIdent(database, name string) string {
+	return sqlident.Qualified(platform.ClickHouse, database, name)
 }
 
 // Writer applies schema changes to a ClickHouse server.
@@ -27,7 +31,7 @@ func quoteIdent(name string) string {
 // records dry-run output unchanged, so callers using DRY_RUN see the same
 // shape of trace they get from the other dialects.
 type Writer struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 	dryRun bool
 }
@@ -36,9 +40,73 @@ type transactionWriter struct {
 	writer *Writer
 }
 
+type databaseRealmObjectKind uint8
+
+const (
+	databaseRealmObjectUnknown databaseRealmObjectKind = iota
+	databaseRealmObjectView
+	databaseRealmObjectMaterializedView
+	databaseRealmObjectLiveView
+	databaseRealmObjectWindowView
+	databaseRealmObjectDictionary
+	databaseRealmObjectTable
+)
+
+type databaseRealmObject struct {
+	name      string
+	engine    string
+	createSQL string
+	kind      databaseRealmObjectKind
+}
+
+const databaseRealmObjectsQuery = `
+	SELECT name, engine, create_table_query
+	FROM system.tables
+	WHERE database = ?
+	  AND is_temporary = 0
+	ORDER BY name
+`
+
+const databaseRealmEngineQuery = `
+	SELECT engine
+	FROM system.databases
+	WHERE name = ?
+`
+
+const databaseRealmVersionQuery = `SELECT version()`
+
+const databaseRealmTemporaryObjectsQuery = `
+	SELECT name
+	FROM system.tables
+	WHERE is_temporary = 1
+	ORDER BY name
+`
+
+var databaseRealmCleanupEngines = []string{
+	"Atomic",
+	"Lazy",
+	"Memory",
+	"Ordinary",
+	"Replicated",
+	"Shared",
+}
+
+var protectedClickHouseDatabases = []string{
+	"INFORMATION_SCHEMA",
+	"_temporary_and_external_tables",
+	"information_schema",
+	"system",
+}
+
 // NewClickHouseWriter constructs a Writer.
 func NewClickHouseWriter(db *sql.DB, schema string) *Writer {
-	return &Writer{db: db, schema: schema}
+	return NewClickHouseWriterForRunner(db, schema)
+}
+
+// NewClickHouseWriterForRunner constructs a writer bound to a pool or pinned
+// database session.
+func NewClickHouseWriterForRunner(runner sqlrunner.Runner, schema string) *Writer {
+	return &Writer{db: runner, schema: schema}
 }
 
 // ExecuteSQL executes a SQL statement against the ClickHouse server. Values
@@ -160,6 +228,322 @@ func (w *Writer) DropAllTables(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// DropDatabaseRealm removes every persistent object from the explicitly
+// configured ClickHouse database. Unlike DropAllTables, this stronger cleanup
+// contract does not depend on the connection's current database.
+func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if w.schema == "" {
+		return fmt.Errorf("clickhouse: database-realm cleanup requires a configured database")
+	}
+	if slices.Contains(protectedClickHouseDatabases, w.schema) {
+		return fmt.Errorf("clickhouse: refusing database-realm cleanup of protected database %q", w.schema)
+	}
+	checkGrants, err := w.validateDatabaseRealmTarget(ctx)
+	if err != nil {
+		return err
+	}
+
+	objects, err := w.listDatabaseRealmObjects(ctx)
+	if err != nil {
+		return err
+	}
+	for _, object := range orderDatabaseRealmObjects(objects) {
+		if err := w.ExecuteSQL(ctx, object.dropSQL(w.schema)); err != nil {
+			return err
+		}
+	}
+
+	if checkGrants {
+		if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
+			return fmt.Errorf("clickhouse: verify database %q remains fully visible: %w", w.schema, err)
+		}
+	}
+	remaining, err := w.listDatabaseRealmObjects(ctx)
+	if err != nil {
+		return fmt.Errorf("clickhouse: verify database %q is empty: %w", w.schema, err)
+	}
+	if len(remaining) != 0 {
+		return fmt.Errorf(
+			"clickhouse: database-realm cleanup left persistent objects in %q: %s",
+			w.schema,
+			describeDatabaseRealmObjects(remaining),
+		)
+	}
+	return nil
+}
+
+func (w *Writer) validateDatabaseRealmTarget(ctx context.Context) (bool, error) {
+	var version string
+	if err := w.db.QueryRowContext(ctx, databaseRealmVersionQuery).Scan(&version); err != nil {
+		return false, fmt.Errorf("clickhouse: inspect server version: %w", err)
+	}
+	checkGrants, err := supportsCheckGrant(version)
+	if err != nil {
+		return false, err
+	}
+	// CHECK GRANT was added in ClickHouse 24.11. Older supported servers
+	// still get preclassification and residual checks, but cannot prove
+	// effective grants without parsing role-aware SHOW GRANTS output.
+	if checkGrants {
+		if err := w.checkDatabaseRealmPrivileges(ctx); err != nil {
+			return false, err
+		}
+	}
+
+	var engine string
+	if err := w.db.QueryRowContext(ctx, databaseRealmEngineQuery, w.schema).Scan(&engine); err != nil {
+		return false, fmt.Errorf("clickhouse: inspect database %q: %w", w.schema, err)
+	}
+	if !slices.Contains(databaseRealmCleanupEngines, engine) {
+		return false, fmt.Errorf(
+			"clickhouse: refusing to clean database %q with unsupported engine %q",
+			w.schema,
+			engine,
+		)
+	}
+
+	temporaryObjects, err := w.listTemporaryObjects(ctx)
+	if err != nil {
+		return false, err
+	}
+	if len(temporaryObjects) != 0 {
+		return false, fmt.Errorf(
+			"clickhouse: refusing database-realm cleanup while session-temporary objects exist: %q",
+			temporaryObjects,
+		)
+	}
+	return checkGrants, nil
+}
+
+func supportsCheckGrant(version string) (bool, error) {
+	var major int
+	var minor int
+	count, err := fmt.Sscanf(version, "%d.%d", &major, &minor)
+	if err != nil || count != 2 {
+		return false, fmt.Errorf("clickhouse: cannot parse server version %q", version)
+	}
+	return major > 24 || major == 24 && minor >= 11, nil
+}
+
+func (w *Writer) checkDatabaseRealmPrivileges(ctx context.Context) error {
+	query := "CHECK GRANT SHOW DATABASES, SHOW TABLES, DROP TABLE, DROP VIEW, " +
+		"DROP DICTIONARY ON " + quoteIdent(w.schema) + ".*"
+	var granted uint8
+	if err := w.db.QueryRowContext(ctx, query).Scan(&granted); err != nil {
+		return fmt.Errorf("clickhouse: check database-realm cleanup privileges for %q: %w", w.schema, err)
+	}
+	if granted != 1 {
+		return fmt.Errorf(
+			"clickhouse: database-realm cleanup requires SHOW DATABASES, SHOW TABLES, "+
+				"DROP TABLE, DROP VIEW, and DROP DICTIONARY on %s.*",
+			quoteIdent(w.schema),
+		)
+	}
+	return nil
+}
+
+func (w *Writer) listTemporaryObjects(ctx context.Context) ([]string, error) {
+	rows, err := w.db.QueryContext(ctx, databaseRealmTemporaryObjectsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse: list session-temporary objects: %w", err)
+	}
+	defer rows.Close()
+
+	var objects []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("clickhouse: scan session-temporary object: %w", err)
+		}
+		objects = append(objects, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("clickhouse: iterate session-temporary objects: %w", err)
+	}
+	return objects, nil
+}
+
+func (w *Writer) listDatabaseRealmObjects(ctx context.Context) ([]databaseRealmObject, error) {
+	rows, err := w.db.QueryContext(ctx, databaseRealmObjectsQuery, w.schema)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse: list persistent objects in database %q: %w", w.schema, err)
+	}
+	defer rows.Close()
+
+	var objects []databaseRealmObject
+	for rows.Next() {
+		var object databaseRealmObject
+		if err := rows.Scan(&object.name, &object.engine, &object.createSQL); err != nil {
+			return nil, fmt.Errorf(
+				"clickhouse: scan persistent object in database %q: %w",
+				w.schema,
+				err,
+			)
+		}
+		object.kind = classifyDatabaseRealmObject(object.engine, object.createSQL)
+		if object.kind == databaseRealmObjectUnknown {
+			return nil, fmt.Errorf(
+				"clickhouse: refusing to clean database %q: cannot safely classify "+
+					"persistent object %q with engine %q and creation statement %q",
+				w.schema,
+				object.name,
+				object.engine,
+				object.createSQL,
+			)
+		}
+		objects = append(objects, object)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf(
+			"clickhouse: iterate persistent objects in database %q: %w",
+			w.schema,
+			err,
+		)
+	}
+	return objects, nil
+}
+
+func classifyDatabaseRealmObject(engine, createSQL string) databaseRealmObjectKind {
+	createKind := classifyDatabaseRealmCreateStatement(createSQL)
+	switch createKind {
+	case databaseRealmObjectView:
+		if engine == "View" {
+			return createKind
+		}
+	case databaseRealmObjectMaterializedView:
+		if engine == "MaterializedView" {
+			return createKind
+		}
+	case databaseRealmObjectLiveView:
+		if engine == "LiveView" {
+			return createKind
+		}
+	case databaseRealmObjectWindowView:
+		if engine == "WindowView" {
+			return createKind
+		}
+	case databaseRealmObjectDictionary:
+		if engine == "Dictionary" {
+			return createKind
+		}
+	case databaseRealmObjectTable:
+		if !isDatabaseRealmViewEngine(engine) {
+			return createKind
+		}
+	}
+	return databaseRealmObjectUnknown
+}
+
+func classifyDatabaseRealmCreateStatement(createSQL string) databaseRealmObjectKind {
+	fields := strings.Fields(strings.ToUpper(createSQL))
+	if len(fields) < 2 || fields[0] != "CREATE" {
+		return databaseRealmObjectUnknown
+	}
+
+	objectIndex := 1
+	if len(fields) >= 4 && fields[1] == "OR" && fields[2] == "REPLACE" {
+		objectIndex = 3
+	}
+	if len(fields) <= objectIndex {
+		return databaseRealmObjectUnknown
+	}
+
+	switch fields[objectIndex] {
+	case "LIVE":
+		if len(fields) > objectIndex+1 && fields[objectIndex+1] == "VIEW" {
+			return databaseRealmObjectLiveView
+		}
+	case "MATERIALIZED":
+		if len(fields) > objectIndex+1 && fields[objectIndex+1] == "VIEW" {
+			return databaseRealmObjectMaterializedView
+		}
+	case "WINDOW":
+		if len(fields) > objectIndex+1 && fields[objectIndex+1] == "VIEW" {
+			return databaseRealmObjectWindowView
+		}
+	case "VIEW":
+		return databaseRealmObjectView
+	case "DICTIONARY":
+		return databaseRealmObjectDictionary
+	case "TABLE":
+		return databaseRealmObjectTable
+	}
+	return databaseRealmObjectUnknown
+}
+
+func isDatabaseRealmViewEngine(engine string) bool {
+	return slices.Contains([]string{"LiveView", "MaterializedView", "View", "WindowView"}, engine)
+}
+
+func isDatabaseRealmViewKind(kind databaseRealmObjectKind) bool {
+	switch kind {
+	case databaseRealmObjectView,
+		databaseRealmObjectMaterializedView,
+		databaseRealmObjectLiveView,
+		databaseRealmObjectWindowView:
+		return true
+	case databaseRealmObjectUnknown,
+		databaseRealmObjectDictionary,
+		databaseRealmObjectTable:
+		return false
+	}
+	return false
+}
+
+func orderDatabaseRealmObjects(objects []databaseRealmObject) []databaseRealmObject {
+	ordered := make([]databaseRealmObject, 0, len(objects))
+	for _, object := range objects {
+		if isDatabaseRealmViewKind(object.kind) {
+			ordered = append(ordered, object)
+		}
+	}
+	for _, object := range objects {
+		if object.kind == databaseRealmObjectTable && object.engine == "Dictionary" {
+			ordered = append(ordered, object)
+		}
+	}
+	for _, object := range objects {
+		if object.kind == databaseRealmObjectDictionary {
+			ordered = append(ordered, object)
+		}
+	}
+	for _, object := range objects {
+		if object.kind == databaseRealmObjectTable && object.engine != "Dictionary" {
+			ordered = append(ordered, object)
+		}
+	}
+	return ordered
+}
+
+func (o databaseRealmObject) dropSQL(database string) string {
+	dropKind := "TABLE"
+	switch o.kind {
+	case databaseRealmObjectView,
+		databaseRealmObjectMaterializedView,
+		databaseRealmObjectLiveView,
+		databaseRealmObjectWindowView:
+		dropKind = "VIEW"
+	case databaseRealmObjectDictionary:
+		dropKind = "DICTIONARY"
+	}
+	return "DROP " + dropKind + " IF EXISTS " +
+		quoteQualifiedIdent(database, o.name) + " SYNC"
+}
+
+func describeDatabaseRealmObjects(objects []databaseRealmObject) string {
+	descriptions := make([]string, 0, len(objects))
+	for _, object := range objects {
+		descriptions = append(descriptions, fmt.Sprintf("%s (%s)", object.name, object.engine))
+	}
+	return strings.Join(descriptions, ", ")
 }
 
 // SetDryRun toggles dry-run mode.

--- a/internal/dbschema/clickhouse/writer_cleanup_live_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_live_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestWriterDropDatabaseRealm_Live(t *testing.T) {
 	c := qt.New(t)
-	db, database := openLiveClickHouseRealmDatabase(t)
+	db, database := openLiveClickHouseRealmDatabase(t, "PTAH_CLICKHOUSE_REALM_TEST_URL")
 	writer := clickhouse.NewClickHouseWriter(db, database)
 
 	err := writer.DropDatabaseRealm(t.Context())
@@ -53,11 +53,43 @@ func TestWriterDropDatabaseRealm_Live(t *testing.T) {
 	c.Assert(objectCount, qt.Equals, uint64(0))
 }
 
-func openLiveClickHouseRealmDatabase(t *testing.T) (*sql.DB, string) {
+func TestWriterDropDatabaseRealm_RejectsLegacyServerLive(t *testing.T) {
+	c := qt.New(t)
+	db, database := openLiveClickHouseRealmDatabase(
+		t,
+		"PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL",
+	)
+	writer := clickhouse.NewClickHouseWriter(db, database)
+	table := sqlident.Qualified(platform.ClickHouse, database, "events")
+	_, err := db.ExecContext(
+		t.Context(),
+		"CREATE TABLE "+table+" (id UInt64) ENGINE = MergeTree ORDER BY id",
+	)
+	c.Assert(err, qt.IsNil)
+
+	err = writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Contains,
+		"ClickHouse 24.11 or newer is required to prove complete catalog visibility with CHECK GRANT",
+	)
+	var objectCount uint64
+	err = db.QueryRowContext(
+		t.Context(),
+		"SELECT count() FROM system.tables WHERE database = ? AND is_temporary = 0",
+		database,
+	).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, uint64(1))
+}
+
+func openLiveClickHouseRealmDatabase(t *testing.T, environmentVariable string) (*sql.DB, string) {
 	t.Helper()
-	adminURL, configured := os.LookupEnv("PTAH_CLICKHOUSE_REALM_TEST_URL")
+	adminURL, configured := os.LookupEnv(environmentVariable)
 	if !configured {
-		t.Skip("PTAH_CLICKHOUSE_REALM_TEST_URL is not configured")
+		t.Skip(environmentVariable + " is not configured")
 	}
 
 	admin, err := sql.Open("clickhouse", adminURL)

--- a/internal/dbschema/clickhouse/writer_cleanup_live_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_live_test.go
@@ -1,0 +1,92 @@
+package clickhouse_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/dbschema/clickhouse"
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+func TestWriterDropDatabaseRealm_Live(t *testing.T) {
+	c := qt.New(t)
+	db, database := openLiveClickHouseRealmDatabase(t)
+	writer := clickhouse.NewClickHouseWriter(db, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+
+	table := sqlident.Qualified(platform.ClickHouse, database, "events'raw")
+	view := sqlident.Qualified(platform.ClickHouse, database, "events_view")
+	materializedView := sqlident.Qualified(platform.ClickHouse, database, "events_mv")
+	statements := []string{
+		"CREATE TABLE " + table + " (id UInt64) ENGINE = MergeTree ORDER BY id",
+		"CREATE VIEW " + view + " AS SELECT id FROM " + table,
+		"CREATE MATERIALIZED VIEW " + materializedView +
+			" ENGINE = Memory AS SELECT id FROM " + table,
+	}
+	for _, statement := range statements {
+		_, err = db.ExecContext(t.Context(), statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("execute ClickHouse fixture statement: %s", statement))
+	}
+
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+
+	var objectCount uint64
+	err = db.QueryRowContext(
+		t.Context(),
+		"SELECT count() FROM system.tables WHERE database = ? AND is_temporary = 0",
+		database,
+	).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, uint64(0))
+}
+
+func openLiveClickHouseRealmDatabase(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	adminURL, configured := os.LookupEnv("PTAH_CLICKHOUSE_REALM_TEST_URL")
+	if !configured {
+		t.Skip("PTAH_CLICKHOUSE_REALM_TEST_URL is not configured")
+	}
+
+	admin, err := sql.Open("clickhouse", adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, admin.PingContext(t.Context()), qt.IsNil)
+
+	database := fmt.Sprintf("ptah_realm_%d", time.Now().UnixNano())
+	quotedDatabase := sqlident.Quote(platform.ClickHouse, database)
+	_, err = admin.ExecContext(t.Context(), "CREATE DATABASE "+quotedDatabase)
+	qt.Assert(t, err, qt.IsNil)
+
+	parsedURL, err := url.Parse(adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	parsedURL.Path = "/" + database
+	parsedURL.RawPath = ""
+	db, err := sql.Open("clickhouse", parsedURL.String())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, db.PingContext(t.Context()), qt.IsNil)
+
+	t.Cleanup(func() {
+		qt.Check(t, db.Close(), qt.IsNil)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, cleanupErr := admin.ExecContext(
+			cleanupCtx,
+			"DROP DATABASE IF EXISTS "+quotedDatabase+" SYNC",
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, admin.Close(), qt.IsNil)
+	})
+	return db, database
+}

--- a/internal/dbschema/clickhouse/writer_cleanup_live_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_live_test.go
@@ -53,6 +53,104 @@ func TestWriterDropDatabaseRealm_Live(t *testing.T) {
 	c.Assert(objectCount, qt.Equals, uint64(0))
 }
 
+func TestWriterDropDatabaseRealm_RejectsExternalDependencyLive(t *testing.T) {
+	c := qt.New(t)
+	db, database := openLiveClickHouseRealmDatabase(t, "PTAH_CLICKHOUSE_REALM_TEST_URL")
+	writer := clickhouse.NewClickHouseWriter(db, database)
+	tests := []struct {
+		name            string
+		engine          string
+		objectName      string
+		createStatement func(string, string, string) string
+	}{
+		{
+			name:       "buffer table",
+			engine:     "Buffer",
+			objectName: "events_buffer",
+			createStatement: func(externalObject, _, targetDatabase string) string {
+				return "CREATE TABLE " + externalObject +
+					" (id UInt64) ENGINE = Buffer('" + targetDatabase +
+					"', 'events', 1, 1, 10, 1, 10, 1, 1000000)"
+			},
+		},
+		{
+			name:       "merge table",
+			engine:     "Merge",
+			objectName: "events_merge",
+			createStatement: func(externalObject, _, targetDatabase string) string {
+				return "CREATE TABLE " + externalObject +
+					" (id UInt64) ENGINE = Merge('" + targetDatabase + "', '^events$')"
+			},
+		},
+		{
+			name:       "view",
+			engine:     "View",
+			objectName: "events_view",
+			createStatement: func(externalObject, targetTable, _ string) string {
+				return "CREATE VIEW " + externalObject + " AS SELECT id FROM " + targetTable
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			externalDatabase := fmt.Sprintf(
+				"ptah_realm_external_%s_%d",
+				test.name,
+				time.Now().UnixNano(),
+			)
+			quotedExternalDatabase := sqlident.Quote(platform.ClickHouse, externalDatabase)
+			_, err := db.ExecContext(t.Context(), "CREATE DATABASE "+quotedExternalDatabase)
+			c.Assert(err, qt.IsNil)
+			table := sqlident.Qualified(platform.ClickHouse, database, "events")
+			c.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				_, cleanupErr := db.ExecContext(
+					cleanupCtx,
+					"DROP DATABASE IF EXISTS "+quotedExternalDatabase+" SYNC",
+				)
+				c.Check(cleanupErr, qt.IsNil)
+				_, cleanupErr = db.ExecContext(
+					cleanupCtx,
+					"DROP TABLE IF EXISTS "+table+" SYNC",
+				)
+				c.Check(cleanupErr, qt.IsNil)
+			})
+
+			externalObject := sqlident.Qualified(
+				platform.ClickHouse,
+				externalDatabase,
+				test.objectName,
+			)
+			_, err = db.ExecContext(
+				t.Context(),
+				"CREATE TABLE "+table+" (id UInt64) ENGINE = MergeTree ORDER BY id",
+			)
+			c.Assert(err, qt.IsNil)
+			_, err = db.ExecContext(
+				t.Context(),
+				test.createStatement(externalObject, table, database),
+			)
+			c.Assert(err, qt.IsNil)
+
+			err = writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, "external object "+externalObject)
+			c.Assert(err.Error(), qt.Contains, `engine "`+test.engine+`"`)
+			var objectCount uint64
+			err = db.QueryRowContext(
+				t.Context(),
+				"SELECT count() FROM system.tables WHERE database = ? AND is_temporary = 0",
+				database,
+			).Scan(&objectCount)
+			c.Assert(err, qt.IsNil)
+			c.Assert(objectCount, qt.Equals, uint64(1))
+		})
+	}
+}
+
 func TestWriterDropDatabaseRealm_RejectsLegacyServerLive(t *testing.T) {
 	c := qt.New(t)
 	db, database := openLiveClickHouseRealmDatabase(

--- a/internal/dbschema/clickhouse/writer_cleanup_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_test.go
@@ -37,6 +37,34 @@ const databaseRealmTemporaryObjectsQuery = `
 	ORDER BY name
 `
 
+const databaseRealmGlobalPrivilegesQuery = `
+	CHECK GRANT SHOW DATABASES, SHOW TABLES ON *.*
+`
+
+const databaseRealmExternalDependenciesQuery = `
+	SELECT database, name, engine
+	FROM system.tables
+	WHERE database != ?
+	  AND database NOT IN (
+	    'INFORMATION_SCHEMA',
+	    '_temporary_and_external_tables',
+	    'information_schema',
+	    'system'
+	  )
+	  AND engine IN (
+	    'Buffer',
+	    'Dictionary',
+	    'Distributed',
+	    'LiveView',
+	    'MaterializedView',
+	    'Merge',
+	    'View',
+	    'WindowView'
+	  )
+	ORDER BY database, name
+	LIMIT 1
+`
+
 type sqlMockQuery struct {
 	sql    string
 	args   []driver.NamedValue
@@ -77,6 +105,8 @@ func TestWriterDropDatabaseRealm_DropsPersistentObjectsInDependencyOrder(t *test
 			},
 		},
 		databaseRealmGrantedQuery(privilegesQuery),
+		databaseRealmGlobalGrantedQuery(),
+		databaseRealmNoExternalDependencyQuery(database),
 		sqlMockQuery{
 			sql:    databaseRealmObjectsQuery,
 			args:   queryArgs,
@@ -146,6 +176,8 @@ func TestWriterDropDatabaseRealm_VerifiesPersistentObjectsAreGone(t *testing.T) 
 		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
 		sqlMockQuery{sql: databaseRealmObjectsQuery, args: queryArgs, result: objectRows},
 		databaseRealmGrantedQuery(privilegesQuery),
+		databaseRealmGlobalGrantedQuery(),
+		databaseRealmNoExternalDependencyQuery(database),
 		sqlMockQuery{sql: databaseRealmObjectsQuery, args: queryArgs, result: objectRows},
 	)
 	execs := []sqlMockExec{
@@ -212,7 +244,9 @@ func TestWriterDropDatabaseRealm_MissingPrivilegesFailBeforeCatalogRead(t *testi
 	assertClickHouseSQLMockComplete(c, db, queries, nil)
 }
 
-func TestWriterDropDatabaseRealm_UnsupportedDatabaseEngineFailsBeforeMutation(t *testing.T) {
+func TestWriterDropDatabaseRealm_MissingGlobalVisibilityFailsBeforeCatalogRead(
+	t *testing.T,
+) {
 	c := qt.New(t)
 	database := "analytics"
 	privilegesQuery := databaseRealmPrivilegesQuery(database)
@@ -220,11 +254,10 @@ func TestWriterDropDatabaseRealm_UnsupportedDatabaseEngineFailsBeforeMutation(t 
 		databaseRealmVersionResult("26.2.0.0"),
 		databaseRealmGrantedQuery(privilegesQuery),
 		{
-			sql:  databaseRealmEngineQuery,
-			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			sql: databaseRealmGlobalPrivilegesQuery,
 			result: dbtest.QueryResult{
-				Columns: []string{"engine"},
-				Rows:    [][]driver.Value{{"DataLakeCatalog"}},
+				Columns: []string{"result"},
+				Rows:    [][]driver.Value{{int64(0)}},
 			},
 		},
 	}
@@ -236,9 +269,106 @@ func TestWriterDropDatabaseRealm_UnsupportedDatabaseEngineFailsBeforeMutation(t 
 	c.Assert(
 		err,
 		qt.ErrorMatches,
-		`clickhouse: refusing to clean database "analytics" with unsupported engine "DataLakeCatalog"`,
+		`clickhouse: database-realm cleanup requires SHOW DATABASES and SHOW TABLES on \*\.\* `+
+			`to prove that external dependencies are absent`,
 	)
 	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_UnsupportedDatabaseEngineFailsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	engines := []string{"DataLakeCatalog", "Replicated", "Shared"}
+
+	for _, engine := range engines {
+		c.Run(engine, func(c *qt.C) {
+			database := "analytics"
+			privilegesQuery := databaseRealmPrivilegesQuery(database)
+			queries := []sqlMockQuery{
+				databaseRealmVersionResult("26.2.0.0"),
+				databaseRealmGrantedQuery(privilegesQuery),
+				databaseRealmGlobalGrantedQuery(),
+				{
+					sql:  databaseRealmEngineQuery,
+					args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+					result: dbtest.QueryResult{
+						Columns: []string{"engine"},
+						Rows:    [][]driver.Value{{engine}},
+					},
+				},
+			}
+			db := openClickHouseSQLMock(t, c, queries, nil)
+			writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`clickhouse: refusing to clean database "analytics" with unsupported engine "`+
+					engine+`"`,
+			)
+			assertClickHouseSQLMockComplete(c, db, queries, nil)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_ExternalDependencyFailsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name       string
+		objectName string
+		engine     string
+	}{
+		{
+			name:       "buffer table",
+			objectName: "events_buffer",
+			engine:     "Buffer",
+		},
+		{
+			name:       "materialized view",
+			objectName: "events_mv",
+			engine:     "MaterializedView",
+		},
+		{
+			name:       "merge table",
+			objectName: "events_merge",
+			engine:     "Merge",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := "analytics"
+			privilegesQuery := databaseRealmPrivilegesQuery(database)
+			externalArgs := []driver.NamedValue{
+				{Ordinal: 1, Value: database},
+			}
+			queries := append(
+				databaseRealmTargetPreflightQueries(database, privilegesQuery, "Atomic"),
+				sqlMockQuery{
+					sql:  databaseRealmExternalDependenciesQuery,
+					args: externalArgs,
+					result: dbtest.QueryResult{
+						Columns: []string{"database", "name", "engine"},
+						Rows:    [][]driver.Value{{"reporting", test.objectName, test.engine}},
+					},
+				},
+			)
+			db := openClickHouseSQLMock(t, c, queries, nil)
+			writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`clickhouse: refusing to clean database "analytics": external object `+
+					"`reporting`.`"+test.objectName+"`"+` with engine "`+test.engine+
+					`" may depend on the cleanup realm`,
+			)
+			assertClickHouseSQLMockComplete(c, db, queries, nil)
+		})
+	}
 }
 
 func TestWriterDropDatabaseRealm_ProtectedDatabasesFailWithoutIO(t *testing.T) {
@@ -270,6 +400,7 @@ func TestWriterDropDatabaseRealm_TemporaryObjectsFailBeforePersistentCatalogRead
 	queries := []sqlMockQuery{
 		databaseRealmVersionResult("26.2.0.0"),
 		databaseRealmGrantedQuery(privilegesQuery),
+		databaseRealmGlobalGrantedQuery(),
 		{
 			sql:  databaseRealmEngineQuery,
 			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
@@ -380,6 +511,8 @@ func TestWriterDropDatabaseRealm_IsIdempotentWhenDatabaseIsEmpty(t *testing.T) {
 		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
 		emptyObjectsQuery,
 		databaseRealmGrantedQuery(privilegesQuery),
+		databaseRealmGlobalGrantedQuery(),
+		databaseRealmNoExternalDependencyQuery(database),
 		emptyObjectsQuery,
 	)
 	queries := append(append([]sqlMockQuery{}, oneRun...), oneRun...)
@@ -465,6 +598,27 @@ func databaseRealmGrantedQuery(privilegesQuery string) sqlMockQuery {
 	}
 }
 
+func databaseRealmGlobalGrantedQuery() sqlMockQuery {
+	return sqlMockQuery{
+		sql: databaseRealmGlobalPrivilegesQuery,
+		result: dbtest.QueryResult{
+			Columns: []string{"result"},
+			Rows:    [][]driver.Value{{int64(1)}},
+		},
+	}
+}
+
+func databaseRealmNoExternalDependencyQuery(database string) sqlMockQuery {
+	args := []driver.NamedValue{
+		{Ordinal: 1, Value: database},
+	}
+	return sqlMockQuery{
+		sql:    databaseRealmExternalDependenciesQuery,
+		args:   args,
+		result: dbtest.QueryResult{Columns: []string{"database", "name", "engine"}},
+	}
+}
+
 func databaseRealmVersionResult(version string) sqlMockQuery {
 	return sqlMockQuery{
 		sql: databaseRealmVersionQuery,
@@ -480,9 +634,21 @@ func databaseRealmPreflightQueries(
 	privilegesQuery string,
 	engine string,
 ) []sqlMockQuery {
+	return append(
+		databaseRealmTargetPreflightQueries(database, privilegesQuery, engine),
+		databaseRealmNoExternalDependencyQuery(database),
+	)
+}
+
+func databaseRealmTargetPreflightQueries(
+	database string,
+	privilegesQuery string,
+	engine string,
+) []sqlMockQuery {
 	return []sqlMockQuery{
 		databaseRealmVersionResult("26.2.0.0"),
 		databaseRealmGrantedQuery(privilegesQuery),
+		databaseRealmGlobalGrantedQuery(),
 		{
 			sql:  databaseRealmEngineQuery,
 			args: []driver.NamedValue{{Ordinal: 1, Value: database}},

--- a/internal/dbschema/clickhouse/writer_cleanup_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_test.go
@@ -1,0 +1,558 @@
+package clickhouse_test
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/dbschema/clickhouse"
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+)
+
+const databaseRealmObjectsQuery = `
+	SELECT name, engine, create_table_query
+	FROM system.tables
+	WHERE database = ?
+	  AND is_temporary = 0
+	ORDER BY name
+`
+
+const databaseRealmEngineQuery = `
+	SELECT engine
+	FROM system.databases
+	WHERE name = ?
+`
+
+const databaseRealmVersionQuery = `SELECT version()`
+
+const databaseRealmTemporaryObjectsQuery = `
+	SELECT name
+	FROM system.tables
+	WHERE is_temporary = 1
+	ORDER BY name
+`
+
+type sqlMockQuery struct {
+	sql    string
+	args   []driver.NamedValue
+	result dbtest.QueryResult
+	err    error
+}
+
+type sqlMockExec struct {
+	sql  string
+	args []driver.NamedValue
+	err  error
+}
+
+func TestWriterDropDatabaseRealm_DropsPersistentObjectsInDependencyOrder(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics`realm"
+	privilegesQuery := "CHECK GRANT SHOW DATABASES, SHOW TABLES, DROP TABLE, DROP VIEW, " +
+		"DROP DICTIONARY ON `analytics``realm`.*"
+	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
+	queries := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		sqlMockQuery{
+			sql:  databaseRealmObjectsQuery,
+			args: queryArgs,
+			result: dbtest.QueryResult{
+				Columns: []string{"name", "engine", "create_table_query"},
+				Rows: [][]driver.Value{
+					{".inner_id.mv", "MergeTree", "CREATE TABLE `analytics``realm`.`.inner_id.mv` (id UInt64) ENGINE = MergeTree ORDER BY id"},
+					{"dictionary_table", "Dictionary", "CREATE TABLE `analytics``realm`.dictionary_table (id UInt64) ENGINE = Dictionary(lookup)"},
+					{"events`daily", "MergeTree", "CREATE OR REPLACE TABLE `analytics``realm`.`events``daily` (id UInt64) ENGINE = MergeTree ORDER BY id"},
+					{"events_mv", "MaterializedView", "CREATE OR REPLACE MATERIALIZED VIEW `analytics``realm`.events_mv TO `analytics``realm`.events_rollup AS SELECT 1"},
+					{"events_view", "View", "CREATE OR REPLACE VIEW `analytics``realm`.events_view AS SELECT 1"},
+					{"legacy_live", "LiveView", "CREATE LIVE VIEW `analytics``realm`.legacy_live AS SELECT 1"},
+					{"lookup", "Dictionary", "CREATE OR REPLACE DICTIONARY `analytics``realm`.lookup (id UInt64) PRIMARY KEY id SOURCE(NULL()) LAYOUT(FLAT())"},
+					{"queue", "Kafka", "CREATE TABLE `analytics``realm`.queue (payload String) ENGINE = Kafka"},
+					{"windowed", "WindowView", "CREATE WINDOW VIEW `analytics``realm`.windowed AS SELECT 1"},
+				},
+			},
+		},
+		databaseRealmGrantedQuery(privilegesQuery),
+		sqlMockQuery{
+			sql:    databaseRealmObjectsQuery,
+			args:   queryArgs,
+			result: dbtest.QueryResult{Columns: []string{"name", "engine", "create_table_query"}},
+		},
+	)
+	execs := []sqlMockExec{
+		{sql: "DROP VIEW IF EXISTS `analytics``realm`.`events_mv` SYNC"},
+		{sql: "DROP VIEW IF EXISTS `analytics``realm`.`events_view` SYNC"},
+		{sql: "DROP VIEW IF EXISTS `analytics``realm`.`legacy_live` SYNC"},
+		{sql: "DROP VIEW IF EXISTS `analytics``realm`.`windowed` SYNC"},
+		{sql: "DROP TABLE IF EXISTS `analytics``realm`.`dictionary_table` SYNC"},
+		{sql: "DROP DICTIONARY IF EXISTS `analytics``realm`.`lookup` SYNC"},
+		{sql: "DROP TABLE IF EXISTS `analytics``realm`.`.inner_id.mv` SYNC"},
+		{sql: "DROP TABLE IF EXISTS `analytics``realm`.`events``daily` SYNC"},
+		{sql: "DROP TABLE IF EXISTS `analytics``realm`.`queue` SYNC"},
+	}
+	db := openClickHouseSQLMock(t, c, queries, execs)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	assertClickHouseSQLMockComplete(c, db, queries, execs)
+}
+
+func TestWriterDropDatabaseRealm_UnknownObjectFailsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queries := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		sqlMockQuery{
+			sql:  databaseRealmObjectsQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			result: dbtest.QueryResult{
+				Columns: []string{"name", "engine", "create_table_query"},
+				Rows: [][]driver.Value{
+					{"events", "MergeTree", "CREATE TABLE analytics.events (id UInt64) ENGINE = MergeTree ORDER BY id"},
+					{"future_view", "FutureView", "CREATE FUTURE VIEW analytics.future_view AS SELECT 1"},
+				},
+			},
+		},
+	)
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `clickhouse: refusing to clean database "analytics": .*`)
+	c.Assert(err.Error(), qt.Contains, `persistent object "future_view" with engine "FutureView"`)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_VerifiesPersistentObjectsAreGone(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
+	objectRows := dbtest.QueryResult{
+		Columns: []string{"name", "engine", "create_table_query"},
+		Rows: [][]driver.Value{
+			{"events", "MergeTree", "CREATE TABLE analytics.events (id UInt64) ENGINE = MergeTree ORDER BY id"},
+		},
+	}
+	queries := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		sqlMockQuery{sql: databaseRealmObjectsQuery, args: queryArgs, result: objectRows},
+		databaseRealmGrantedQuery(privilegesQuery),
+		sqlMockQuery{sql: databaseRealmObjectsQuery, args: queryArgs, result: objectRows},
+	)
+	execs := []sqlMockExec{
+		{sql: "DROP TABLE IF EXISTS `analytics`.`events` SYNC"},
+	}
+	db := openClickHouseSQLMock(t, c, queries, execs)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`clickhouse: database-realm cleanup left persistent objects in "analytics": events \(MergeTree\)`,
+	)
+	assertClickHouseSQLMockComplete(c, db, queries, execs)
+}
+
+func TestWriterDropDatabaseRealm_CatalogErrorDoesNotMutate(t *testing.T) {
+	c := qt.New(t)
+	catalogErr := errors.New("catalog unavailable")
+	database := "analytics"
+	queries := append(
+		databaseRealmPreflightQueries(
+			database,
+			databaseRealmPrivilegesQuery(database),
+			"Atomic",
+		),
+		sqlMockQuery{
+			sql:  databaseRealmObjectsQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			err:  catalogErr,
+		},
+	)
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorIs, catalogErr)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_MissingPrivilegesFailBeforeCatalogRead(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queries := []sqlMockQuery{
+		databaseRealmVersionResult("26.2.0.0"),
+		{
+			sql: privilegesQuery,
+			result: dbtest.QueryResult{
+				Columns: []string{"result"},
+				Rows:    [][]driver.Value{{int64(0)}},
+			},
+		},
+	}
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `clickhouse: database-realm cleanup requires SHOW DATABASES, .*`)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_UnsupportedDatabaseEngineFailsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queries := []sqlMockQuery{
+		databaseRealmVersionResult("26.2.0.0"),
+		databaseRealmGrantedQuery(privilegesQuery),
+		{
+			sql:  databaseRealmEngineQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			result: dbtest.QueryResult{
+				Columns: []string{"engine"},
+				Rows:    [][]driver.Value{{"DataLakeCatalog"}},
+			},
+		},
+	}
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`clickhouse: refusing to clean database "analytics" with unsupported engine "DataLakeCatalog"`,
+	)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_ProtectedDatabasesFailWithoutIO(t *testing.T) {
+	c := qt.New(t)
+	databases := []string{
+		"INFORMATION_SCHEMA",
+		"_temporary_and_external_tables",
+		"information_schema",
+		"system",
+	}
+
+	for _, database := range databases {
+		c.Run(database, func(c *qt.C) {
+			db := openClickHouseSQLMock(t, c, nil, nil)
+			writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(err, qt.ErrorMatches, `clickhouse: refusing database-realm cleanup of protected database .*`)
+			assertClickHouseSQLMockComplete(c, db, nil, nil)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_TemporaryObjectsFailBeforePersistentCatalogRead(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queries := []sqlMockQuery{
+		databaseRealmVersionResult("26.2.0.0"),
+		databaseRealmGrantedQuery(privilegesQuery),
+		{
+			sql:  databaseRealmEngineQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			result: dbtest.QueryResult{
+				Columns: []string{"engine"},
+				Rows:    [][]driver.Value{{"Atomic"}},
+			},
+		},
+		{
+			sql: databaseRealmTemporaryObjectsQuery,
+			result: dbtest.QueryResult{
+				Columns: []string{"name"},
+				Rows:    [][]driver.Value{{"shadow_events"}},
+			},
+		},
+	}
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`clickhouse: refusing database-realm cleanup while session-temporary objects exist: \["shadow_events"\]`,
+	)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_PostCleanupVisibilityLossFailsClosed(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
+	queries := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		sqlMockQuery{
+			sql:  databaseRealmObjectsQuery,
+			args: queryArgs,
+			result: dbtest.QueryResult{
+				Columns: []string{"name", "engine", "create_table_query"},
+				Rows: [][]driver.Value{
+					{"events", "MergeTree", "CREATE TABLE analytics.events (id UInt64) ENGINE = MergeTree ORDER BY id"},
+				},
+			},
+		},
+		sqlMockQuery{
+			sql: privilegesQuery,
+			result: dbtest.QueryResult{
+				Columns: []string{"result"},
+				Rows:    [][]driver.Value{{int64(0)}},
+			},
+		},
+	)
+	execs := []sqlMockExec{
+		{sql: "DROP TABLE IF EXISTS `analytics`.`events` SYNC"},
+	}
+	db := openClickHouseSQLMock(t, c, queries, execs)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `clickhouse: verify database "analytics" remains fully visible: .*`)
+	assertClickHouseSQLMockComplete(c, db, queries, execs)
+}
+
+func TestWriterDropDatabaseRealm_DropFailureStopsBeforeResidualVerification(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	dropErr := errors.New("drop failed")
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queries := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		sqlMockQuery{
+			sql:  databaseRealmObjectsQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			result: dbtest.QueryResult{
+				Columns: []string{"name", "engine", "create_table_query"},
+				Rows: [][]driver.Value{
+					{"events", "MergeTree", "CREATE TABLE analytics.events (id UInt64) ENGINE = MergeTree ORDER BY id"},
+				},
+			},
+		},
+	)
+	execs := []sqlMockExec{
+		{sql: "DROP TABLE IF EXISTS `analytics`.`events` SYNC", err: dropErr},
+	}
+	db := openClickHouseSQLMock(t, c, queries, execs)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorIs, dropErr)
+	assertClickHouseSQLMockComplete(c, db, queries, execs)
+}
+
+func TestWriterDropDatabaseRealm_IsIdempotentWhenDatabaseIsEmpty(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	privilegesQuery := databaseRealmPrivilegesQuery(database)
+	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
+	emptyObjectsQuery := sqlMockQuery{
+		sql:    databaseRealmObjectsQuery,
+		args:   queryArgs,
+		result: dbtest.QueryResult{Columns: []string{"name", "engine", "create_table_query"}},
+	}
+	oneRun := append(
+		databaseRealmPreflightQueries(database, privilegesQuery, "Atomic"),
+		emptyObjectsQuery,
+		databaseRealmGrantedQuery(privilegesQuery),
+		emptyObjectsQuery,
+	)
+	queries := append(append([]sqlMockQuery{}, oneRun...), oneRun...)
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	firstErr := writer.DropDatabaseRealm(t.Context())
+	secondErr := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(firstErr, qt.IsNil)
+	c.Assert(secondErr, qt.IsNil)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_ClickHouse2410UsesCompatibleCatalogPath(t *testing.T) {
+	c := qt.New(t)
+	database := "analytics"
+	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
+	emptyObjectsQuery := sqlMockQuery{
+		sql:    databaseRealmObjectsQuery,
+		args:   queryArgs,
+		result: dbtest.QueryResult{Columns: []string{"name", "engine", "create_table_query"}},
+	}
+	queries := []sqlMockQuery{
+		databaseRealmVersionResult("24.10.2.80"),
+		{
+			sql:  databaseRealmEngineQuery,
+			args: queryArgs,
+			result: dbtest.QueryResult{
+				Columns: []string{"engine"},
+				Rows:    [][]driver.Value{{"Atomic"}},
+			},
+		},
+		{
+			sql:    databaseRealmTemporaryObjectsQuery,
+			result: dbtest.QueryResult{Columns: []string{"name"}},
+		},
+		emptyObjectsQuery,
+		emptyObjectsQuery,
+	}
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_UnparseableServerVersionFailsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	queries := []sqlMockQuery{
+		databaseRealmVersionResult("development"),
+	}
+	db := openClickHouseSQLMock(t, c, queries, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, "analytics")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `clickhouse: cannot parse server version "development"`)
+	assertClickHouseSQLMockComplete(c, db, queries, nil)
+}
+
+func TestWriterDropDatabaseRealm_CanceledContext(t *testing.T) {
+	c := qt.New(t)
+	db := openClickHouseSQLMock(t, c, nil, nil)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, "analytics")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	assertClickHouseSQLMockComplete(c, db, nil, nil)
+}
+
+func TestWriterDropDatabaseRealm_DryRunNeedsNoDatabase(t *testing.T) {
+	c := qt.New(t)
+	writer := clickhouse.NewClickHouseWriter(nil, "")
+	writer.SetDryRun(true)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+}
+
+func databaseRealmPrivilegesQuery(database string) string {
+	return "CHECK GRANT SHOW DATABASES, SHOW TABLES, DROP TABLE, DROP VIEW, " +
+		"DROP DICTIONARY ON `" + database + "`.*"
+}
+
+func databaseRealmGrantedQuery(privilegesQuery string) sqlMockQuery {
+	return sqlMockQuery{
+		sql: privilegesQuery,
+		result: dbtest.QueryResult{
+			Columns: []string{"result"},
+			Rows:    [][]driver.Value{{int64(1)}},
+		},
+	}
+}
+
+func databaseRealmVersionResult(version string) sqlMockQuery {
+	return sqlMockQuery{
+		sql: databaseRealmVersionQuery,
+		result: dbtest.QueryResult{
+			Columns: []string{"version()"},
+			Rows:    [][]driver.Value{{version}},
+		},
+	}
+}
+
+func databaseRealmPreflightQueries(
+	database string,
+	privilegesQuery string,
+	engine string,
+) []sqlMockQuery {
+	return []sqlMockQuery{
+		databaseRealmVersionResult("26.2.0.0"),
+		databaseRealmGrantedQuery(privilegesQuery),
+		{
+			sql:  databaseRealmEngineQuery,
+			args: []driver.NamedValue{{Ordinal: 1, Value: database}},
+			result: dbtest.QueryResult{
+				Columns: []string{"engine"},
+				Rows:    [][]driver.Value{{engine}},
+			},
+		},
+		{
+			sql:    databaseRealmTemporaryObjectsQuery,
+			result: dbtest.QueryResult{Columns: []string{"name"}},
+		},
+	}
+}
+
+func openClickHouseSQLMock(
+	t *testing.T,
+	c *qt.C,
+	queries []sqlMockQuery,
+	execs []sqlMockExec,
+) *dbtest.DB {
+	var queryIndex atomic.Int64
+	var execIndex atomic.Int64
+	return dbtest.OpenWithExec(
+		t,
+		func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+			expected := queries[queryIndex.Add(1)-1]
+			c.Check(normalizeSQL(query), qt.Equals, normalizeSQL(expected.sql))
+			c.Check(normalizeSQLArgs(args), qt.DeepEquals, normalizeSQLArgs(expected.args))
+			return expected.result, expected.err
+		},
+		func(query string, args []driver.NamedValue) (driver.Result, error) {
+			expected := execs[execIndex.Add(1)-1]
+			c.Check(normalizeSQL(query), qt.Equals, normalizeSQL(expected.sql))
+			c.Check(normalizeSQLArgs(args), qt.DeepEquals, normalizeSQLArgs(expected.args))
+			return driver.RowsAffected(0), expected.err
+		},
+	)
+}
+
+func assertClickHouseSQLMockComplete(
+	c *qt.C,
+	db *dbtest.DB,
+	queries []sqlMockQuery,
+	execs []sqlMockExec,
+) {
+	c.Check(db.QueryCount(), qt.Equals, len(queries))
+	c.Check(db.ExecCount(), qt.Equals, len(execs))
+}
+
+func normalizeSQL(query string) string {
+	return strings.Join(strings.Fields(query), " ")
+}
+
+func normalizeSQLArgs(args []driver.NamedValue) []driver.NamedValue {
+	return append([]driver.NamedValue{}, args...)
+}

--- a/internal/dbschema/clickhouse/writer_cleanup_test.go
+++ b/internal/dbschema/clickhouse/writer_cleanup_test.go
@@ -394,38 +394,22 @@ func TestWriterDropDatabaseRealm_IsIdempotentWhenDatabaseIsEmpty(t *testing.T) {
 	assertClickHouseSQLMockComplete(c, db, queries, nil)
 }
 
-func TestWriterDropDatabaseRealm_ClickHouse2410UsesCompatibleCatalogPath(t *testing.T) {
+func TestWriterDropDatabaseRealm_ClickHouse2410FailsClosedBeforeCatalogRead(t *testing.T) {
 	c := qt.New(t)
-	database := "analytics"
-	queryArgs := []driver.NamedValue{{Ordinal: 1, Value: database}}
-	emptyObjectsQuery := sqlMockQuery{
-		sql:    databaseRealmObjectsQuery,
-		args:   queryArgs,
-		result: dbtest.QueryResult{Columns: []string{"name", "engine", "create_table_query"}},
-	}
 	queries := []sqlMockQuery{
 		databaseRealmVersionResult("24.10.2.80"),
-		{
-			sql:  databaseRealmEngineQuery,
-			args: queryArgs,
-			result: dbtest.QueryResult{
-				Columns: []string{"engine"},
-				Rows:    [][]driver.Value{{"Atomic"}},
-			},
-		},
-		{
-			sql:    databaseRealmTemporaryObjectsQuery,
-			result: dbtest.QueryResult{Columns: []string{"name"}},
-		},
-		emptyObjectsQuery,
-		emptyObjectsQuery,
 	}
 	db := openClickHouseSQLMock(t, c, queries, nil)
-	writer := clickhouse.NewClickHouseWriter(db.SQL, database)
+	writer := clickhouse.NewClickHouseWriter(db.SQL, "analytics")
 
 	err := writer.DropDatabaseRealm(t.Context())
 
-	c.Assert(err, qt.IsNil)
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`clickhouse: refusing database-realm cleanup on server version "24\.10\.2\.80": `+
+			`ClickHouse 24\.11 or newer is required to prove complete catalog visibility with CHECK GRANT`,
+	)
 	assertClickHouseSQLMockComplete(c, db, queries, nil)
 }
 

--- a/internal/dbschema/mssql/reader.go
+++ b/internal/dbschema/mssql/reader.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 const schemaPredicatePlaceholder = "/* ptah:schema-predicate */"
@@ -22,13 +23,13 @@ type catalogObjectKey struct {
 
 // Reader reads schema information from Microsoft SQL Server databases.
 type Reader struct {
-	db      *sql.DB
+	db      sqlrunner.Runner
 	schema  string
 	schemas []string
 	scoped  bool
 }
 
-func NewSQLServerReader(db *sql.DB, schema string) *Reader {
+func NewSQLServerReader(db sqlrunner.Runner, schema string) *Reader {
 	if schema == "" {
 		schema = "dbo"
 	}

--- a/internal/dbschema/mssql/writer.go
+++ b/internal/dbschema/mssql/writer.go
@@ -1,31 +1,33 @@
 package mssql
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 func quoteIdent(name string) string {
-	return "[" + strings.ReplaceAll(name, "]", "]]") + "]"
+	return sqlident.Quote(platform.SQLServer, name)
 }
 
 func quoteQualified(schema, name string) string {
-	if schema == "" {
-		return quoteIdent(name)
-	}
-	return quoteIdent(schema) + "." + quoteIdent(name)
+	return sqlident.Qualified(platform.SQLServer, schema, name)
 }
 
 // Writer applies schema changes to SQL Server.
 type Writer struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 	dryRun bool
 }
@@ -38,6 +40,49 @@ type foreignKey struct {
 	ReferencedTable  string
 }
 
+type realmObject struct {
+	ID              int64
+	ParentID        int64
+	HistoryTableID  int64
+	Schema          string
+	Name            string
+	Type            string
+	TypeDescription string
+	TemporalType    int64
+	LedgerType      int64
+}
+
+type realmDependency struct {
+	ReferencingID int64
+	ReferencedID  int64
+}
+
+type realmType struct {
+	Schema string
+	Name   string
+}
+
+type realmXMLSchema struct {
+	Schema string
+	Name   string
+}
+
+type realmResidual struct {
+	Category string
+	Schema   string
+	Name     string
+	Detail   string
+}
+
+type realmCleanupPlan struct {
+	foreignKeys  []foreignKey
+	objects      []realmObject
+	dependencies []realmDependency
+	types        []realmType
+	xmlSchemas   []realmXMLSchema
+	schemas      []string
+}
+
 type transactionWriter struct {
 	mu     sync.Mutex
 	tx     *sql.Tx
@@ -45,10 +90,16 @@ type transactionWriter struct {
 }
 
 func NewSQLServerWriter(db *sql.DB, schema string) *Writer {
+	return NewSQLServerWriterForRunner(db, schema)
+}
+
+// NewSQLServerWriterForRunner creates a writer bound to a pool or pinned
+// database session.
+func NewSQLServerWriterForRunner(runner sqlrunner.Runner, schema string) *Writer {
 	if schema == "" {
 		schema = "dbo"
 	}
-	return &Writer{db: db, schema: schema}
+	return &Writer{db: runner, schema: schema}
 }
 
 func (w *Writer) ExecuteSQL(ctx context.Context, sqlExpr string, args ...any) error {
@@ -180,6 +231,1030 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	}
 	committed = true
 	return nil
+}
+
+// DropDatabaseRealm removes supported user objects from every user schema in
+// the current database as one transaction. The configured schema and dbo are
+// preserved, while other user-defined schemas are removed after their contents.
+func (w *Writer) DropDatabaseRealm(ctx context.Context) (resultErr error) {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("sqlserver: database realm cleanup canceled before start: %w", err)
+	}
+
+	tx, err := w.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("sqlserver: begin database realm cleanup transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				resultErr = errors.Join(
+					resultErr,
+					fmt.Errorf("sqlserver: roll back database realm cleanup transaction: %w", rollbackErr),
+				)
+			}
+		}
+	}()
+
+	if err := requireRealmMetadataVisibility(ctx, tx); err != nil {
+		return err
+	}
+	unsupported, err := findUnsupportedRealmArtifact(ctx, tx, w.schema)
+	if err != nil {
+		return err
+	}
+	if unsupported != nil {
+		return fmt.Errorf(
+			"sqlserver: refusing to clean database realm with unsupported database-scoped %s %s (%s)",
+			unsupported.Category,
+			quoteResidual(*unsupported),
+			unsupported.Detail,
+		)
+	}
+	plan, err := buildRealmCleanupPlan(ctx, tx, w.schema)
+	if err != nil {
+		return err
+	}
+	if err := executeRealmCleanupPlan(ctx, tx, plan); err != nil {
+		return err
+	}
+	residual, err := findRealmResidual(ctx, tx, w.schema)
+	if err != nil {
+		return err
+	}
+	if residual != nil {
+		return fmt.Errorf(
+			"sqlserver: refusing to commit database realm cleanup: residual %s %s (%s)",
+			residual.Category,
+			quoteResidual(*residual),
+			residual.Detail,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlserver: commit database realm cleanup transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func requireRealmMetadataVisibility(ctx context.Context, tx *sql.Tx) error {
+	var databaseName string
+	var hasControl bool
+	var hasViewDefinition bool
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT
+			DB_NAME(),
+			HAS_PERMS_BY_NAME(DB_NAME(), N'DATABASE', N'CONTROL'),
+			HAS_PERMS_BY_NAME(DB_NAME(), N'DATABASE', N'VIEW DEFINITION')`,
+	).Scan(&databaseName, &hasControl, &hasViewDefinition)
+	if err != nil {
+		return fmt.Errorf("sqlserver: verify database realm metadata visibility: %w", err)
+	}
+	switch databaseName {
+	case "master", "model", "msdb", "tempdb":
+		return fmt.Errorf(
+			"sqlserver: refusing to clean system database %s",
+			quoteIdent(databaseName),
+		)
+	}
+	if !hasControl {
+		return fmt.Errorf(
+			"sqlserver: refusing to clean database realm without CONTROL permission on the current database",
+		)
+	}
+	if !hasViewDefinition {
+		return fmt.Errorf(
+			"sqlserver: refusing to clean database realm without VIEW DEFINITION permission on the current database",
+		)
+	}
+	return nil
+}
+
+func buildRealmCleanupPlan(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchema string,
+) (realmCleanupPlan, error) {
+	objects, err := listRealmObjects(ctx, tx)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	if err := rejectUnsupportedRealmObjects(objects); err != nil {
+		return realmCleanupPlan{}, err
+	}
+	foreignKeys, err := listRealmForeignKeys(ctx, tx)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	dependencies, err := listRealmDependencies(ctx, tx)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	dependencies = append(dependencies, temporalRealmDependencies(objects)...)
+	userTypes, err := listRealmTypes(ctx, tx)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	xmlSchemas, err := listRealmXMLSchemas(ctx, tx)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	schemas, err := listDroppableRealmSchemas(ctx, tx, preservedSchema)
+	if err != nil {
+		return realmCleanupPlan{}, err
+	}
+	return realmCleanupPlan{
+		foreignKeys:  foreignKeys,
+		objects:      objects,
+		dependencies: dependencies,
+		types:        userTypes,
+		xmlSchemas:   xmlSchemas,
+		schemas:      schemas,
+	}, nil
+}
+
+func executeRealmCleanupPlan(ctx context.Context, tx *sql.Tx, plan realmCleanupPlan) error {
+	for _, fk := range plan.foreignKeys {
+		qualifiedTable := quoteQualified(fk.Schema, fk.Table)
+		constraint := quoteIdent(fk.Name)
+		//nolint:gosec // G202: catalog identifiers are emitted only through SQL Server identifier quoting.
+		dropSQL := "ALTER TABLE " + qualifiedTable + " DROP CONSTRAINT " + constraint
+		if _, err := tx.ExecContext(ctx, dropSQL); err != nil {
+			return fmt.Errorf(
+				"sqlserver: drop foreign key %s on %s: %w",
+				constraint,
+				qualifiedTable,
+				err,
+			)
+		}
+	}
+
+	if err := dropRealmSecurityPolicies(ctx, tx, plan.objects); err != nil {
+		return err
+	}
+	if err := dropRealmObjects(ctx, tx, plan.objects, plan.dependencies); err != nil {
+		return err
+	}
+	for _, userType := range plan.types {
+		qualified := quoteQualified(userType.Schema, userType.Name)
+		if _, err := tx.ExecContext(ctx, "DROP TYPE IF EXISTS "+qualified); err != nil {
+			return fmt.Errorf("sqlserver: drop type %s: %w", qualified, err)
+		}
+	}
+	for _, xmlSchema := range plan.xmlSchemas {
+		qualified := quoteQualified(xmlSchema.Schema, xmlSchema.Name)
+		if _, err := tx.ExecContext(ctx, "DROP XML SCHEMA COLLECTION "+qualified); err != nil {
+			return fmt.Errorf("sqlserver: drop XML schema collection %s: %w", qualified, err)
+		}
+	}
+	for _, schema := range plan.schemas {
+		quoted := quoteIdent(schema)
+		if _, err := tx.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+quoted); err != nil {
+			return fmt.Errorf("sqlserver: drop schema %s: %w", quoted, err)
+		}
+	}
+	return nil
+}
+
+func dropRealmSecurityPolicies(ctx context.Context, tx *sql.Tx, objects []realmObject) error {
+	for _, object := range objects {
+		if object.Type != "SP" {
+			continue
+		}
+		if err := dropRealmObject(ctx, tx, object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dropRealmObjects(
+	ctx context.Context,
+	tx *sql.Tx,
+	objects []realmObject,
+	dependencies []realmDependency,
+) error {
+	var droppable []realmObject
+	for _, object := range objects {
+		_, canDrop := realmDropPrefix(object)
+		if canDrop && object.Type != "SP" {
+			droppable = append(droppable, object)
+		}
+	}
+	for _, object := range orderRealmObjects(droppable, dependencies) {
+		if err := dropRealmObject(ctx, tx, object); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dropRealmObject(ctx context.Context, tx *sql.Tx, object realmObject) error {
+	prefix, canDrop := realmDropPrefix(object)
+	if !canDrop {
+		return fmt.Errorf(
+			"sqlserver: internal cleanup error: unsupported drop for %s %s",
+			object.TypeDescription,
+			quoteQualified(object.Schema, object.Name),
+		)
+	}
+	qualified := quoteQualified(object.Schema, object.Name)
+	if object.TemporalType == 2 {
+		//nolint:gosec // G202: catalog identifiers are emitted only through SQL Server identifier quoting.
+		disableSQL := "ALTER TABLE " + qualified + " SET (SYSTEM_VERSIONING = OFF)"
+		if _, err := tx.ExecContext(ctx, disableSQL); err != nil {
+			return fmt.Errorf(
+				"sqlserver: disable system versioning on temporal table %s: %w",
+				qualified,
+				err,
+			)
+		}
+	}
+	//nolint:gosec // G202: the fixed drop prefix is selected by type and catalog identifiers are safely quoted.
+	dropSQL := prefix + qualified
+	if _, err := tx.ExecContext(ctx, dropSQL); err != nil {
+		return fmt.Errorf(
+			"sqlserver: drop %s %s: %w",
+			strings.ToLower(object.TypeDescription),
+			qualified,
+			err,
+		)
+	}
+	return nil
+}
+
+func realmDropPrefix(object realmObject) (string, bool) {
+	switch object.Type {
+	case "AF":
+		return "DROP AGGREGATE IF EXISTS ", true
+	case "D":
+		return "DROP DEFAULT IF EXISTS ", object.ParentID == 0
+	case "ET":
+		return "DROP EXTERNAL TABLE IF EXISTS ", true
+	case "FN", "FS", "FT", "IF", "TF":
+		return "DROP FUNCTION IF EXISTS ", true
+	case "P", "PC":
+		return "DROP PROCEDURE IF EXISTS ", true
+	case "R":
+		return "DROP RULE IF EXISTS ", true
+	case "SN":
+		return "DROP SYNONYM IF EXISTS ", true
+	case "SO":
+		return "DROP SEQUENCE IF EXISTS ", true
+	case "SP":
+		return "DROP SECURITY POLICY IF EXISTS ", true
+	case "TA", "TR":
+		return "DROP TRIGGER IF EXISTS ", true
+	case "U":
+		return "DROP TABLE IF EXISTS ", true
+	case "V":
+		return "DROP VIEW IF EXISTS ", true
+	default:
+		return "", false
+	}
+}
+
+func rejectUnsupportedRealmObjects(objects []realmObject) error {
+	var unsupported []string
+	for _, object := range objects {
+		if object.LedgerType != 0 {
+			unsupported = append(
+				unsupported,
+				fmt.Sprintf(
+					"%s (%s)",
+					quoteQualified(object.Schema, object.Name),
+					"LEDGER_TABLE",
+				),
+			)
+			continue
+		}
+		_, canDrop := realmDropPrefix(object)
+		if canDrop || realmObjectOwnedBySupportedObject(object) {
+			continue
+		}
+		unsupported = append(
+			unsupported,
+			fmt.Sprintf(
+				"%s (%s)",
+				quoteQualified(object.Schema, object.Name),
+				object.TypeDescription,
+			),
+		)
+	}
+	if len(unsupported) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"sqlserver: refusing to clean database realm with unsupported user objects: %s",
+		strings.Join(unsupported, "; "),
+	)
+}
+
+func temporalRealmDependencies(objects []realmObject) []realmDependency {
+	var dependencies []realmDependency
+	for _, object := range objects {
+		if object.TemporalType != 2 || object.HistoryTableID == 0 {
+			continue
+		}
+		dependencies = append(dependencies, realmDependency{
+			ReferencingID: object.ID,
+			ReferencedID:  object.HistoryTableID,
+		})
+	}
+	return dependencies
+}
+
+func realmObjectOwnedBySupportedObject(object realmObject) bool {
+	switch object.Type {
+	case "C", "EC", "F", "IT", "PK", "ST", "TT", "UQ":
+		return true
+	case "D":
+		return object.ParentID != 0
+	default:
+		return false
+	}
+}
+
+func orderRealmObjects(objects []realmObject, dependencies []realmDependency) []realmObject {
+	objectsByID := make(map[int64]realmObject, len(objects))
+	inDegree := make(map[int64]int, len(objects))
+	outgoing := make(map[int64][]int64, len(objects))
+	for _, object := range objects {
+		objectsByID[object.ID] = object
+		inDegree[object.ID] = 0
+	}
+
+	edges := make(map[[2]int64]struct{}, len(dependencies))
+	for _, dependency := range dependencies {
+		_, hasReferencing := objectsByID[dependency.ReferencingID]
+		_, hasReferenced := objectsByID[dependency.ReferencedID]
+		edge := [2]int64{dependency.ReferencingID, dependency.ReferencedID}
+		if !hasReferencing || !hasReferenced || dependency.ReferencingID == dependency.ReferencedID {
+			continue
+		}
+		if _, duplicate := edges[edge]; duplicate {
+			continue
+		}
+		edges[edge] = struct{}{}
+		outgoing[dependency.ReferencingID] = append(
+			outgoing[dependency.ReferencingID],
+			dependency.ReferencedID,
+		)
+		inDegree[dependency.ReferencedID]++
+	}
+
+	var ready []realmObject
+	for _, object := range objects {
+		if inDegree[object.ID] == 0 {
+			ready = append(ready, object)
+		}
+	}
+	sortRealmObjects(ready)
+
+	ordered := make([]realmObject, 0, len(objects))
+	for len(ready) > 0 {
+		object := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, object)
+		for _, referencedID := range outgoing[object.ID] {
+			inDegree[referencedID]--
+			if inDegree[referencedID] == 0 {
+				ready = append(ready, objectsByID[referencedID])
+				sortRealmObjects(ready)
+			}
+		}
+	}
+
+	if len(ordered) == len(objects) {
+		return ordered
+	}
+	var cyclic []realmObject
+	for _, object := range objects {
+		if inDegree[object.ID] > 0 {
+			cyclic = append(cyclic, object)
+		}
+	}
+	sortRealmObjects(cyclic)
+	return append(ordered, cyclic...)
+}
+
+func sortRealmObjects(objects []realmObject) {
+	slices.SortFunc(objects, func(left, right realmObject) int {
+		if result := cmp.Compare(left.Schema, right.Schema); result != 0 {
+			return result
+		}
+		if result := cmp.Compare(left.Name, right.Name); result != 0 {
+			return result
+		}
+		if result := cmp.Compare(left.Type, right.Type); result != 0 {
+			return result
+		}
+		return cmp.Compare(left.ID, right.ID)
+	})
+}
+
+func listRealmObjects(ctx context.Context, tx *sql.Tx) ([]realmObject, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			o.object_id,
+			o.parent_object_id,
+			s.name,
+			o.name,
+			o.type,
+			o.type_desc,
+			COALESCE(t.temporal_type, 0),
+			COALESCE(t.history_table_id, 0),
+			COALESCE(t.ledger_type, 0)
+		FROM sys.objects AS o
+		JOIN sys.schemas AS s ON s.schema_id = o.schema_id
+		LEFT JOIN sys.tables AS t ON t.object_id = o.object_id
+		WHERE o.is_ms_shipped = 0
+		  AND s.name NOT IN (
+			  N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+		ORDER BY s.name, o.name, o.type
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list database realm objects: %w", err)
+	}
+	defer rows.Close()
+
+	var objects []realmObject
+	for rows.Next() {
+		var object realmObject
+		if err := rows.Scan(
+			&object.ID,
+			&object.ParentID,
+			&object.Schema,
+			&object.Name,
+			&object.Type,
+			&object.TypeDescription,
+			&object.TemporalType,
+			&object.HistoryTableID,
+			&object.LedgerType,
+		); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan database realm object: %w", err)
+		}
+		object.Type = strings.TrimSpace(object.Type)
+		objects = append(objects, object)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate database realm objects: %w", err)
+	}
+	return objects, nil
+}
+
+func listRealmForeignKeys(ctx context.Context, tx *sql.Tx) ([]foreignKey, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT ps.name, pt.name, fk.name, rs.name, rt.name
+		FROM sys.foreign_keys AS fk
+		JOIN sys.tables AS pt ON pt.object_id = fk.parent_object_id
+		JOIN sys.schemas AS ps ON ps.schema_id = pt.schema_id
+		JOIN sys.tables AS rt ON rt.object_id = fk.referenced_object_id
+		JOIN sys.schemas AS rs ON rs.schema_id = rt.schema_id
+		WHERE pt.is_ms_shipped = 0
+		  AND ps.name NOT IN (
+			  N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+		ORDER BY ps.name, pt.name, fk.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list database realm foreign keys: %w", err)
+	}
+	defer rows.Close()
+
+	var foreignKeys []foreignKey
+	for rows.Next() {
+		var fk foreignKey
+		if err := rows.Scan(&fk.Schema, &fk.Table, &fk.Name, &fk.ReferencedSchema, &fk.ReferencedTable); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan database realm foreign key: %w", err)
+		}
+		foreignKeys = append(foreignKeys, fk)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate database realm foreign keys: %w", err)
+	}
+	return foreignKeys, nil
+}
+
+func listRealmDependencies(ctx context.Context, tx *sql.Tx) ([]realmDependency, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT DISTINCT
+			CASE
+				WHEN referencing_object.type IN (N'C', N'D')
+					AND referencing_object.parent_object_id <> 0
+					THEN referencing_object.parent_object_id
+				ELSE dependency.referencing_id
+			END,
+			dependency.referenced_id
+		FROM sys.sql_expression_dependencies AS dependency
+		JOIN sys.objects AS referencing_object
+			ON referencing_object.object_id = dependency.referencing_id
+		WHERE dependency.referencing_class = 1
+		  AND dependency.referenced_class = 1
+		  AND dependency.referenced_id IS NOT NULL
+		ORDER BY 1, 2
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list database realm dependencies: %w", err)
+	}
+	defer rows.Close()
+
+	var dependencies []realmDependency
+	for rows.Next() {
+		var dependency realmDependency
+		if err := rows.Scan(&dependency.ReferencingID, &dependency.ReferencedID); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan database realm dependency: %w", err)
+		}
+		dependencies = append(dependencies, dependency)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate database realm dependencies: %w", err)
+	}
+	return dependencies, nil
+}
+
+func listRealmTypes(ctx context.Context, tx *sql.Tx) ([]realmType, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT s.name, t.name
+		FROM sys.types AS t
+		JOIN sys.schemas AS s ON s.schema_id = t.schema_id
+		WHERE t.is_user_defined = 1
+		  AND s.name NOT IN (
+			  N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+		ORDER BY t.is_table_type DESC, s.name, t.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list database realm types: %w", err)
+	}
+	defer rows.Close()
+
+	var userTypes []realmType
+	for rows.Next() {
+		var userType realmType
+		if err := rows.Scan(&userType.Schema, &userType.Name); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan database realm type: %w", err)
+		}
+		userTypes = append(userTypes, userType)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate database realm types: %w", err)
+	}
+	return userTypes, nil
+}
+
+func listRealmXMLSchemas(ctx context.Context, tx *sql.Tx) ([]realmXMLSchema, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT s.name, x.name
+		FROM sys.xml_schema_collections AS x
+		JOIN sys.schemas AS s ON s.schema_id = x.schema_id
+		WHERE x.xml_collection_id > 1
+		  AND s.name NOT IN (
+			  N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+		ORDER BY s.name, x.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list database realm XML schema collections: %w", err)
+	}
+	defer rows.Close()
+
+	var xmlSchemas []realmXMLSchema
+	for rows.Next() {
+		var xmlSchema realmXMLSchema
+		if err := rows.Scan(&xmlSchema.Schema, &xmlSchema.Name); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan database realm XML schema collection: %w", err)
+		}
+		xmlSchemas = append(xmlSchemas, xmlSchema)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate database realm XML schema collections: %w", err)
+	}
+	return xmlSchemas, nil
+}
+
+func listDroppableRealmSchemas(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchema string,
+) ([]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT s.name
+		FROM sys.schemas AS s
+		WHERE s.name NOT IN (
+			  N'dbo', N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+		  AND s.name <> @p1
+		ORDER BY s.name
+	`, preservedSchema)
+	if err != nil {
+		return nil, fmt.Errorf("sqlserver: list droppable database realm schemas: %w", err)
+	}
+	defer rows.Close()
+
+	var schemas []string
+	for rows.Next() {
+		var schema string
+		if err := rows.Scan(&schema); err != nil {
+			return nil, fmt.Errorf("sqlserver: scan droppable database realm schema: %w", err)
+		}
+		schemas = append(schemas, schema)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlserver: iterate droppable database realm schemas: %w", err)
+	}
+	return schemas, nil
+}
+
+func findRealmResidual(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchema string,
+) (*realmResidual, error) {
+	row := tx.QueryRowContext(ctx, `
+		SELECT TOP (1) residual.category, residual.schema_name, residual.object_name, residual.detail
+		FROM (
+			SELECT
+				N'object' AS category,
+				s.name AS schema_name,
+				o.name AS object_name,
+				o.type_desc AS detail
+			FROM sys.objects AS o
+			JOIN sys.schemas AS s ON s.schema_id = o.schema_id
+			WHERE o.is_ms_shipped = 0
+			  AND s.name NOT IN (
+				  N'sys', N'INFORMATION_SCHEMA', N'guest',
+				  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+				  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+				  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+			  )
+
+			UNION ALL
+
+			SELECT N'type', s.name, t.name, N'USER_DEFINED_TYPE'
+			FROM sys.types AS t
+			JOIN sys.schemas AS s ON s.schema_id = t.schema_id
+			WHERE t.is_user_defined = 1
+			  AND s.name NOT IN (
+				  N'sys', N'INFORMATION_SCHEMA', N'guest',
+				  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+				  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+				  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+			  )
+
+			UNION ALL
+
+			SELECT N'XML schema collection', s.name, x.name, N'XML_SCHEMA_COLLECTION'
+			FROM sys.xml_schema_collections AS x
+			JOIN sys.schemas AS s ON s.schema_id = x.schema_id
+			WHERE x.xml_collection_id > 1
+			  AND s.name NOT IN (
+				  N'sys', N'INFORMATION_SCHEMA', N'guest',
+				  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+				  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+				  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+			  )
+
+			UNION ALL
+
+			SELECT N'schema', N'', s.name, N'USER_SCHEMA'
+			FROM sys.schemas AS s
+			WHERE s.name NOT IN (
+				  N'dbo', N'sys', N'INFORMATION_SCHEMA', N'guest',
+				  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+				  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+				  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+			  )
+			  AND s.name <> @p1
+		) AS residual
+		ORDER BY residual.category, residual.schema_name, residual.object_name
+	`, preservedSchema)
+
+	var residual realmResidual
+	if err := row.Scan(&residual.Category, &residual.Schema, &residual.Name, &residual.Detail); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("sqlserver: verify database realm cleanup: %w", err)
+		}
+		return findUnsupportedRealmArtifact(ctx, tx, preservedSchema)
+	}
+	return &residual, nil
+}
+
+const unsupportedRealmArtifactQuery = `
+		SELECT TOP (1)
+			artifact.category,
+			N'' AS schema_name,
+			artifact.object_name,
+			artifact.detail
+		FROM (
+			SELECT
+				N'database DDL trigger' AS category,
+				t.name AS object_name,
+				t.type_desc AS detail
+			FROM sys.triggers AS t
+			WHERE t.parent_class = 0
+			  AND t.is_ms_shipped = 0
+
+			UNION ALL
+
+			SELECT N'database principal', p.name, p.type_desc
+			FROM sys.database_principals AS p
+			WHERE p.principal_id > 4
+			  AND p.is_fixed_role = 0
+			  AND p.principal_id <> DATABASE_PRINCIPAL_ID()
+
+			UNION ALL
+
+			SELECT
+				N'database role membership',
+				CONCAT(role_principal.name, N': ', member_principal.name),
+				N'DATABASE_ROLE_MEMBERSHIP'
+			FROM sys.database_role_members AS membership
+			JOIN sys.database_principals AS role_principal
+				ON role_principal.principal_id = membership.role_principal_id
+			JOIN sys.database_principals AS member_principal
+				ON member_principal.principal_id = membership.member_principal_id
+			WHERE NOT (
+				role_principal.name = N'db_owner'
+				AND member_principal.principal_id = DATABASE_PRINCIPAL_ID()
+			)
+
+			UNION ALL
+
+			SELECT
+				N'schema authorization',
+				CONCAT(s.name, N': ', principal.name),
+				N'SCHEMA_AUTHORIZATION'
+			FROM sys.schemas AS s
+			JOIN sys.database_principals AS principal
+				ON principal.principal_id = s.principal_id
+			WHERE s.name IN (N'dbo', @p1)
+			  AND s.principal_id <> DATABASE_PRINCIPAL_ID(N'dbo')
+
+			UNION ALL
+
+			SELECT N'assembly', a.name, N'USER_ASSEMBLY'
+			FROM sys.assemblies AS a
+			WHERE a.is_user_defined = 1
+
+			UNION ALL
+
+			SELECT N'filegroup', f.name, N'FILEGROUP'
+			FROM sys.filegroups AS f
+			WHERE f.data_space_id > 1
+
+			UNION ALL
+
+			SELECT N'database file', f.name, f.type_desc
+			FROM sys.database_files AS f
+			WHERE f.file_id > 2
+
+			UNION ALL
+
+			SELECT N'partition function', f.name, N'PARTITION_FUNCTION'
+			FROM sys.partition_functions AS f
+			WHERE f.is_system = 0
+
+			UNION ALL
+
+			SELECT N'full-text catalog', c.name, N'FULLTEXT_CATALOG'
+			FROM sys.fulltext_catalogs AS c
+
+			UNION ALL
+
+			SELECT N'full-text stoplist', s.name, N'FULLTEXT_STOPLIST'
+			FROM sys.fulltext_stoplists AS s
+
+			UNION ALL
+
+			SELECT N'search property list', p.name, N'SEARCH_PROPERTY_LIST'
+			FROM sys.registered_search_property_lists AS p
+
+			UNION ALL
+
+			SELECT N'database-scoped credential', c.name, N'DATABASE_SCOPED_CREDENTIAL'
+			FROM sys.database_scoped_credentials AS c
+
+			UNION ALL
+
+			SELECT N'external data source', s.name, N'EXTERNAL_DATA_SOURCE'
+			FROM sys.external_data_sources AS s
+
+			UNION ALL
+
+			SELECT N'external file format', f.name, N'EXTERNAL_FILE_FORMAT'
+			FROM sys.external_file_formats AS f
+
+			UNION ALL
+
+			SELECT N'external library', l.name, N'EXTERNAL_LIBRARY'
+			FROM sys.external_libraries AS l
+
+			UNION ALL
+
+			SELECT N'external language', l.language, N'EXTERNAL_LANGUAGE'
+			FROM sys.external_languages AS l
+			WHERE l.principal_id <> DATABASE_PRINCIPAL_ID(N'sys')
+
+			UNION ALL
+
+			SELECT N'certificate', c.name, N'CERTIFICATE'
+			FROM sys.certificates AS c
+
+			UNION ALL
+
+			SELECT N'asymmetric key', k.name, N'ASYMMETRIC_KEY'
+			FROM sys.asymmetric_keys AS k
+
+			UNION ALL
+
+			SELECT N'symmetric key', k.name, N'SYMMETRIC_KEY'
+			FROM sys.symmetric_keys AS k
+
+			UNION ALL
+
+			SELECT N'column master key', k.name, N'COLUMN_MASTER_KEY'
+			FROM sys.column_master_keys AS k
+
+			UNION ALL
+
+			SELECT N'column encryption key', k.name, N'COLUMN_ENCRYPTION_KEY'
+			FROM sys.column_encryption_keys AS k
+
+			UNION ALL
+
+			SELECT N'database audit specification', s.name, N'DATABASE_AUDIT_SPECIFICATION'
+			FROM sys.database_audit_specifications AS s
+
+			UNION ALL
+
+			SELECT N'database event notification', n.name, N'EVENT_NOTIFICATION'
+			FROM sys.event_notifications AS n
+			WHERE n.parent_class = 0
+
+			UNION ALL
+
+			SELECT
+				N'Service Broker message type',
+				m.name COLLATE DATABASE_DEFAULT,
+				N'SERVICE_MESSAGE_TYPE'
+			FROM sys.service_message_types AS m
+			WHERE m.message_type_id >= 65536
+
+			UNION ALL
+
+			SELECT
+				N'Service Broker contract',
+				c.name COLLATE DATABASE_DEFAULT,
+				N'SERVICE_CONTRACT'
+			FROM sys.service_contracts AS c
+			WHERE c.service_contract_id >= 65536
+
+			UNION ALL
+
+			SELECT
+				N'Service Broker service',
+				s.name COLLATE DATABASE_DEFAULT,
+				N'SERVICE'
+			FROM sys.services AS s
+			WHERE s.service_id >= 65536
+
+			UNION ALL
+
+			SELECT
+				N'Service Broker route',
+				r.name COLLATE DATABASE_DEFAULT,
+				N'ROUTE'
+			FROM sys.routes AS r
+			WHERE r.name <> N'AutoCreatedLocal'
+
+			UNION ALL
+
+			SELECT
+				N'remote service binding',
+				b.name COLLATE DATABASE_DEFAULT,
+				N'REMOTE_SERVICE_BINDING'
+			FROM sys.remote_service_bindings AS b
+
+			UNION ALL
+
+			SELECT
+				N'conversation priority',
+				p.name COLLATE DATABASE_DEFAULT,
+				N'CONVERSATION_PRIORITY'
+			FROM sys.conversation_priorities AS p
+
+			UNION ALL
+
+			SELECT
+				N'database-scoped configuration',
+				c.name,
+				CONCAT(N'VALUE=', CONVERT(nvarchar(128), c.value))
+			FROM sys.database_scoped_configurations AS c
+			WHERE c.is_value_default = 0
+
+			UNION ALL
+
+			SELECT
+				N'database permission',
+				CONCAT(p.state_desc, N' ', p.permission_name, N' TO ', principal.name),
+				N'DATABASE_PERMISSION'
+			FROM sys.database_permissions AS p
+			JOIN sys.database_principals AS principal
+				ON principal.principal_id = p.grantee_principal_id
+			WHERE p.class = 0
+			  AND NOT (
+				  p.grantee_principal_id = 0
+				  AND p.permission_name IN (
+					  N'VIEW ANY COLUMN ENCRYPTION KEY DEFINITION',
+					  N'VIEW ANY COLUMN MASTER KEY DEFINITION'
+				  )
+			  )
+			  AND NOT (
+				  p.grantee_principal_id IN (1, DATABASE_PRINCIPAL_ID())
+				  AND p.permission_name = N'CONNECT'
+			  )
+
+			UNION ALL
+
+			SELECT
+				N'schema permission',
+				CONCAT(
+					s.name,
+					N': ',
+					p.state_desc,
+					N' ',
+					p.permission_name,
+					N' TO ',
+					principal.name
+				),
+				N'SCHEMA_PERMISSION'
+			FROM sys.database_permissions AS p
+			JOIN sys.schemas AS s ON s.schema_id = p.major_id
+			JOIN sys.database_principals AS principal
+				ON principal.principal_id = p.grantee_principal_id
+			WHERE p.class = 3
+			  AND s.name IN (N'dbo', @p1)
+
+			UNION ALL
+
+			SELECT N'database extended property', p.name, N'EXTENDED_PROPERTY'
+			FROM sys.extended_properties AS p
+			WHERE p.class = 0
+			   OR (
+				   p.class = 3
+				   AND p.major_id IN (SCHEMA_ID(N'dbo'), SCHEMA_ID(@p1))
+			   )
+		) AS artifact
+		ORDER BY artifact.category, artifact.object_name
+	`
+
+func findUnsupportedRealmArtifact(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchema string,
+) (*realmResidual, error) {
+	row := tx.QueryRowContext(ctx, unsupportedRealmArtifactQuery, preservedSchema)
+	var artifact realmResidual
+	if err := row.Scan(&artifact.Category, &artifact.Schema, &artifact.Name, &artifact.Detail); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("sqlserver: inspect unsupported database-scoped artifacts: %w", err)
+	}
+	return &artifact, nil
+}
+
+func quoteResidual(residual realmResidual) string {
+	if residual.Schema == "" {
+		return quoteIdent(residual.Name)
+	}
+	return quoteQualified(residual.Schema, residual.Name)
 }
 
 func (w *Writer) rejectExternalForeignKeys(foreignKeys []foreignKey) error {

--- a/internal/dbschema/mssql/writer.go
+++ b/internal/dbschema/mssql/writer.go
@@ -982,6 +982,61 @@ const unsupportedRealmArtifactQuery = `
 
 			UNION ALL
 
+			SELECT
+				N'replication-enabled database',
+				d.name,
+				CONCAT(
+					N'is_distributor=', d.is_distributor,
+					N', is_published=', d.is_published,
+					N', is_merge_published=', d.is_merge_published
+				)
+			FROM sys.databases AS d
+			WHERE d.name = DB_NAME()
+			  AND (
+				  d.is_distributor = 1
+				  OR d.is_published = 1
+				  OR d.is_merge_published = 1
+			  )
+
+			UNION ALL
+
+			SELECT
+				CASE
+					WHEN TRY_CONVERT(int, subscription.raw_value) = 1
+						THEN N'subscriber database'
+					ELSE N'unknown database subscription state'
+				END,
+				DB_NAME(),
+				CONCAT(
+					N'IsSubscribed=',
+					COALESCE(TRY_CONVERT(nvarchar(128), subscription.raw_value), N'<unavailable>')
+				)
+			FROM (
+				SELECT DATABASEPROPERTYEX(DB_NAME(), N'IsSubscribed') AS raw_value
+			) AS subscription
+			WHERE COALESCE(TRY_CONVERT(int, subscription.raw_value), -1) <> 0
+
+			UNION ALL
+
+			SELECT
+				N'replicated table',
+				CONCAT(s.name, N'.', t.name),
+				CONCAT(
+					N'is_replicated=', t.is_replicated,
+					N', is_merge_published=', t.is_merge_published,
+					N', is_sync_tran_subscribed=', t.is_sync_tran_subscribed
+				)
+			FROM sys.tables AS t
+			JOIN sys.schemas AS s ON s.schema_id = t.schema_id
+			WHERE t.is_ms_shipped = 0
+			  AND (
+				  t.is_replicated = 1
+				  OR t.is_merge_published = 1
+				  OR t.is_sync_tran_subscribed = 1
+			  )
+
+			UNION ALL
+
 			SELECT N'database principal', p.name, p.type_desc
 			FROM sys.database_principals AS p
 			WHERE p.principal_id > 4

--- a/internal/dbschema/mssql/writer_realm_test.go
+++ b/internal/dbschema/mssql/writer_realm_test.go
@@ -1,0 +1,1055 @@
+package mssql_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/microsoft/go-mssqldb"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/dbschema/dbtest"
+	"github.com/stokaro/ptah/internal/dbschema/mssql"
+	"github.com/stokaro/ptah/internal/sqlident"
+)
+
+func TestWriterDropDatabaseRealm_CleansCrossSchemaGraph(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+				[]driver.Value{int64(1), int64(0), "a]pp", "row_filter", "SP", "SECURITY_POLICY", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(2), int64(0), "a]pp", "order]view", "V ", "VIEW", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(3), int64(0), "z_data", "child", "U ", "USER_TABLE", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(4), int64(0), "a]pp", "normalize_id", "FN", "SQL_SCALAR_FUNCTION", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(5), int64(0), "m_util", "order_seq", "SO", "SEQUENCE_OBJECT", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(6), int64(0), "dbo", "orders_alias", "SN", "SYNONYM", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(7), int64(3), "z_data", "df_child_id", "D ", "DEFAULT_CONSTRAINT", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(8), int64(0), "types", "id_list", "TT", "TYPE_TABLE", int64(0), int64(0), int64(0)},
+				[]driver.Value{int64(9), int64(0), "external", "event]feed", "ET", "EXTERNAL_TABLE", int64(0), int64(0), int64(0)},
+			),
+			queryExpectation(
+				"FROM sys.foreign_keys AS fk",
+				nil,
+				[]string{"parent_schema", "parent_table", "name", "referenced_schema", "referenced_table"},
+				[]driver.Value{"z_data", "child", "fk]child_parent", "m_util", "parent"},
+			),
+			queryExpectation(
+				"FROM sys.sql_expression_dependencies AS dependency",
+				nil,
+				[]string{"referencing_id", "referenced_id"},
+				[]driver.Value{int64(2), int64(3)},
+				[]driver.Value{int64(3), int64(4)},
+			),
+			queryExpectation(
+				"FROM sys.types AS t",
+				nil,
+				[]string{"schema", "name"},
+				[]driver.Value{"types", "id_list"},
+			),
+			queryExpectation(
+				"FROM sys.xml_schema_collections AS x",
+				nil,
+				[]string{"schema", "name"},
+				[]driver.Value{"types", "payload]xml"},
+			),
+			queryExpectation(
+				"SELECT s.name\n\t\tFROM sys.schemas AS s",
+				[]any{"dbo"},
+				[]string{"schema"},
+				[]driver.Value{"a]pp"},
+				[]driver.Value{"external"},
+				[]driver.Value{"m_util"},
+				[]driver.Value{"types"},
+				[]driver.Value{"z_data"},
+			),
+			queryExpectation(
+				"SELECT TOP (1) residual.category",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+		},
+		[]writerExecExpectation{
+			execExpectation("ALTER TABLE [z_data].[child] DROP CONSTRAINT [fk]]child_parent]", nil),
+			execExpectation("DROP SECURITY POLICY IF EXISTS [a]]pp].[row_filter]", nil),
+			execExpectation("DROP VIEW IF EXISTS [a]]pp].[order]]view]", nil),
+			execExpectation("DROP SYNONYM IF EXISTS [dbo].[orders_alias]", nil),
+			execExpectation("DROP EXTERNAL TABLE IF EXISTS [external].[event]]feed]", nil),
+			execExpectation("DROP SEQUENCE IF EXISTS [m_util].[order_seq]", nil),
+			execExpectation("DROP TABLE IF EXISTS [z_data].[child]", nil),
+			execExpectation("DROP FUNCTION IF EXISTS [a]]pp].[normalize_id]", nil),
+			execExpectation("DROP TYPE IF EXISTS [types].[id_list]", nil),
+			execExpectation("DROP XML SCHEMA COLLECTION [types].[payload]]xml]", nil),
+			execExpectation("DROP SCHEMA IF EXISTS [a]]pp]", nil),
+			execExpectation("DROP SCHEMA IF EXISTS [external]", nil),
+			execExpectation("DROP SCHEMA IF EXISTS [m_util]", nil),
+			execExpectation("DROP SCHEMA IF EXISTS [types]", nil),
+			execExpectation("DROP SCHEMA IF EXISTS [z_data]", nil),
+		},
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RequiresCompleteMetadataVisibility(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", false, true},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm without CONTROL permission on the current database`,
+	)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RequiresViewDefinitionMetadataVisibility(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, false},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm without VIEW DEFINITION permission on the current database`,
+	)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsUnknownObjectAndRollsBack(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+				[]driver.Value{
+					int64(1), int64(0), "jobs", "work_queue", "SQ", "SERVICE_QUEUE",
+					int64(0), int64(0), int64(0),
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported user objects: `+
+			`\[jobs\]\.\[work_queue\] \(SERVICE_QUEUE\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsResidualObjectAndRollsBack(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+			),
+			queryExpectation(
+				"FROM sys.foreign_keys AS fk",
+				nil,
+				[]string{"parent_schema", "parent_table", "name", "referenced_schema", "referenced_table"},
+			),
+			queryExpectation(
+				"FROM sys.sql_expression_dependencies AS dependency",
+				nil,
+				[]string{"referencing_id", "referenced_id"},
+			),
+			queryExpectation(
+				"FROM sys.types AS t",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"FROM sys.xml_schema_collections AS x",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"SELECT s.name\n\t\tFROM sys.schemas AS s",
+				[]any{"dbo"},
+				[]string{"schema"},
+			),
+			queryExpectation(
+				"SELECT TOP (1) residual.category",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{"object", "rogue]", "queue]", "SERVICE_QUEUE"},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Contains,
+		"refusing to commit database realm cleanup: residual object [rogue]]].[queue]]] (SERVICE_QUEUE)",
+	)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_DDLFailureRollsBack(t *testing.T) {
+	c := qt.New(t)
+	dropErr := errors.New("table is still referenced")
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+				[]driver.Value{
+					int64(1), int64(0), "dbo", "users", "U", "USER_TABLE",
+					int64(0), int64(0), int64(0),
+				},
+			),
+			queryExpectation(
+				"FROM sys.foreign_keys AS fk",
+				nil,
+				[]string{"parent_schema", "parent_table", "name", "referenced_schema", "referenced_table"},
+			),
+			queryExpectation(
+				"FROM sys.sql_expression_dependencies AS dependency",
+				nil,
+				[]string{"referencing_id", "referenced_id"},
+			),
+			queryExpectation(
+				"FROM sys.types AS t",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"FROM sys.xml_schema_collections AS x",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"SELECT s.name\n\t\tFROM sys.schemas AS s",
+				[]any{"dbo"},
+				[]string{"schema"},
+			),
+		},
+		[]writerExecExpectation{
+			execExpectation("DROP TABLE IF EXISTS [dbo].[users]", dropErr),
+		},
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorIs, dropErr)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_DisablesTemporalTableBeforeDroppingHistory(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+				[]driver.Value{
+					int64(2), int64(0), "audit", "a_history", "U ", "USER_TABLE",
+					int64(1), int64(0), int64(0),
+				},
+				[]driver.Value{
+					int64(1), int64(0), "app", "z_current", "U ", "USER_TABLE",
+					int64(2), int64(2), int64(0),
+				},
+			),
+			queryExpectation(
+				"FROM sys.foreign_keys AS fk",
+				nil,
+				[]string{"parent_schema", "parent_table", "name", "referenced_schema", "referenced_table"},
+			),
+			queryExpectation(
+				"FROM sys.sql_expression_dependencies AS dependency",
+				nil,
+				[]string{"referencing_id", "referenced_id"},
+			),
+			queryExpectation(
+				"FROM sys.types AS t",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"FROM sys.xml_schema_collections AS x",
+				nil,
+				[]string{"schema", "name"},
+			),
+			queryExpectation(
+				"SELECT s.name\n\t\tFROM sys.schemas AS s",
+				[]any{"dbo"},
+				[]string{"schema"},
+			),
+			queryExpectation(
+				"SELECT TOP (1) residual.category",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+		},
+		[]writerExecExpectation{
+			execExpectation(
+				"ALTER TABLE [app].[z_current] SET (SYSTEM_VERSIONING = OFF)",
+				nil,
+			),
+			execExpectation("DROP TABLE IF EXISTS [app].[z_current]", nil),
+			execExpectation("DROP TABLE IF EXISTS [audit].[a_history]", nil),
+		},
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RejectsLedgerTableBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"COALESCE(t.temporal_type, 0)",
+				nil,
+				realmObjectColumns(),
+				[]driver.Value{
+					int64(1), int64(0), "dbo", "ledger_events", "U ", "USER_TABLE",
+					int64(0), int64(0), int64(1),
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported user objects: `+
+			`\[dbo\]\.\[ledger_events\] \(LEDGER_TABLE\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsSystemDatabase(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"master", true, true},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `sqlserver: refusing to clean system database \[master\]`)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsUnsupportedDatabaseArtifactBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{"database DDL trigger", "", "deny]drop", "SQL_TRIGGER"},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`database DDL trigger \[deny\]\]drop\] \(SQL_TRIGGER\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsPreservedSchemaPermissionBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"schema permission",
+					"",
+					"dbo: GRANT SELECT TO public",
+					"SCHEMA_PERMISSION",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`schema permission \[dbo: GRANT SELECT TO public\] \(SCHEMA_PERMISSION\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsLateDatabaseArtifactAndRollsBack(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		append(
+			emptyRealmPlanQueryExpectations(),
+			queryExpectation(
+				"SELECT TOP (1) residual.category",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{"database-scoped credential", "", "late]credential", "DATABASE_SCOPED_CREDENTIAL"},
+			),
+		),
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to commit database realm cleanup: residual database-scoped credential `+
+			`\[late\]\]credential\] \(DATABASE_SCOPED_CREDENTIAL\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_IsIdempotentWhenRealmIsEmpty(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		append(
+			emptyRealmPlanQueryExpectations(),
+			queryExpectation(
+				"SELECT TOP (1) residual.category",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+			),
+		),
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_Live(t *testing.T) {
+	c := qt.New(t)
+	db := openLiveSQLServerRealmDatabase(t)
+	writer := mssql.NewSQLServerWriter(db, "dbo")
+	t.Cleanup(func() {
+		qt.Check(t, writer.DropDatabaseRealm(context.Background()), qt.IsNil)
+	})
+	err := writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+
+	statements := []string{
+		"CREATE SCHEMA [app]",
+		"CREATE SCHEMA [audit]",
+		"CREATE TABLE [app].[parent] ([id] bigint NOT NULL PRIMARY KEY)",
+		"CREATE TABLE [audit].[child] (" +
+			"[id] bigint NOT NULL PRIMARY KEY, " +
+			"[parent_id] bigint NOT NULL, " +
+			"CONSTRAINT [fk_child_parent] FOREIGN KEY ([parent_id]) REFERENCES [app].[parent] ([id]))",
+		"CREATE TABLE [app].[z_temporal] (" +
+			"[id] bigint NOT NULL PRIMARY KEY, " +
+			"[valid_from] datetime2 GENERATED ALWAYS AS ROW START NOT NULL, " +
+			"[valid_to] datetime2 GENERATED ALWAYS AS ROW END NOT NULL, " +
+			"PERIOD FOR SYSTEM_TIME ([valid_from], [valid_to])) " +
+			"WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [audit].[a_temporal_history]))",
+		"CREATE FUNCTION [app].[normalize_id] (@value bigint) RETURNS bigint AS BEGIN RETURN @value END",
+		"CREATE VIEW [audit].[child_view] AS SELECT [id], [parent_id] FROM [audit].[child]",
+		"CREATE VIEW [audit].[temporal_view] AS " +
+			"SELECT [id] FROM [app].[z_temporal] FOR SYSTEM_TIME ALL",
+		"CREATE SEQUENCE [app].[order_seq] AS bigint START WITH 1 INCREMENT BY 1",
+		"CREATE SYNONYM [dbo].[parent_alias] FOR [app].[parent]",
+		"CREATE TYPE [app].[identifier] FROM bigint NOT NULL",
+		"EXEC sys.sp_addextendedproperty " +
+			"@name = N'realm_note', @value = N'test', " +
+			"@level0type = N'SCHEMA', @level0name = N'app'",
+	}
+	for _, statement := range statements {
+		_, err := db.ExecContext(t.Context(), statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("execute SQL Server fixture statement: %s", statement))
+	}
+
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+
+	var objectCount int
+	err = db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM sys.objects AS o
+		JOIN sys.schemas AS s ON s.schema_id = o.schema_id
+		WHERE o.is_ms_shipped = 0
+		  AND s.name NOT IN (
+			  N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+	`).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, 0)
+
+	var typeCount int
+	err = db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM sys.types AS t
+		JOIN sys.schemas AS s ON s.schema_id = t.schema_id
+		WHERE t.is_user_defined = 1
+		  AND s.name NOT IN (N'sys', N'INFORMATION_SCHEMA')
+	`).Scan(&typeCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(typeCount, qt.Equals, 0)
+
+	var schemaCount int
+	err = db.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM sys.schemas AS s
+		WHERE s.name NOT IN (
+			  N'dbo', N'sys', N'INFORMATION_SCHEMA', N'guest',
+			  N'db_owner', N'db_accessadmin', N'db_securityadmin',
+			  N'db_ddladmin', N'db_backupoperator', N'db_datareader',
+			  N'db_datawriter', N'db_denydatareader', N'db_denydatawriter'
+		  )
+	`).Scan(&schemaCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemaCount, qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RejectsDatabaseScopedArtifactLive(t *testing.T) {
+	c := qt.New(t)
+	db := openLiveSQLServerRealmDatabase(t)
+	writer := mssql.NewSQLServerWriter(db, "dbo")
+	err := writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		_, cleanupErr := db.ExecContext(
+			context.Background(),
+			"DROP TRIGGER IF EXISTS [realm]]guard] ON DATABASE",
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, writer.DropDatabaseRealm(context.Background()), qt.IsNil)
+	})
+
+	_, err = db.ExecContext(t.Context(), "CREATE TABLE [dbo].[kept_until_safe] ([id] bigint NOT NULL)")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(
+		t.Context(),
+		"CREATE TRIGGER [realm]]guard] ON DATABASE FOR CREATE_TABLE AS RETURN",
+	)
+	c.Assert(err, qt.IsNil)
+
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`database DDL trigger \[realm\]\]guard\] \(SQL_TRIGGER\)`,
+	)
+
+	var tableCount int
+	err = db.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM sys.tables WHERE object_id = OBJECT_ID(N'dbo.kept_until_safe')",
+	).Scan(&tableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 1)
+
+	_, err = db.ExecContext(t.Context(), "DROP TRIGGER IF EXISTS [realm]]guard] ON DATABASE")
+	c.Assert(err, qt.IsNil)
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+}
+
+func TestWriterDropDatabaseRealm_RejectsPreservedSchemaPermissionLive(t *testing.T) {
+	c := qt.New(t)
+	db := openLiveSQLServerRealmDatabase(t)
+	writer := mssql.NewSQLServerWriter(db, "dbo")
+	err := writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		_, cleanupErr := db.ExecContext(
+			context.Background(),
+			"REVOKE SELECT ON SCHEMA::[dbo] FROM [public]",
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, writer.DropDatabaseRealm(context.Background()), qt.IsNil)
+	})
+
+	_, err = db.ExecContext(t.Context(), "GRANT SELECT ON SCHEMA::[dbo] TO [public]")
+	c.Assert(err, qt.IsNil)
+
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`schema permission \[dbo: GRANT SELECT TO public\] \(SCHEMA_PERMISSION\)`,
+	)
+
+	_, err = db.ExecContext(t.Context(), "REVOKE SELECT ON SCHEMA::[dbo] FROM [public]")
+	c.Assert(err, qt.IsNil)
+	err = writer.DropDatabaseRealm(t.Context())
+	c.Assert(err, qt.IsNil)
+}
+
+func TestWriterDropDatabaseRealm_CancellationAfterBeginRollsBack(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			{
+				queryContains: "FROM sys.triggers AS t",
+				args:          []any{"dbo"},
+				err:           context.Canceled,
+			},
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_PreCanceledContextDoesNotBeginTransaction(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	db := dbtest.OpenWithExec(t, nil, nil)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.BeginCount(), qt.Equals, 0)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+}
+
+func openLiveSQLServerRealmDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	adminURL, configured := os.LookupEnv("PTAH_SQLSERVER_REALM_TEST_URL")
+	if !configured {
+		t.Skip("PTAH_SQLSERVER_REALM_TEST_URL is not configured")
+	}
+	admin, err := sql.Open("sqlserver", adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, admin.PingContext(t.Context()), qt.IsNil)
+
+	databaseName := fmt.Sprintf("ptah_realm_%d", time.Now().UnixNano())
+	quotedDatabase := sqlident.Quote(platform.SQLServer, databaseName)
+	_, err = admin.ExecContext(t.Context(), "CREATE DATABASE "+quotedDatabase)
+	qt.Assert(t, err, qt.IsNil)
+
+	parsedURL, err := url.Parse(adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	query := parsedURL.Query()
+	query.Set("database", databaseName)
+	parsedURL.RawQuery = query.Encode()
+	db, err := sql.Open("sqlserver", parsedURL.String())
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, db.PingContext(t.Context()), qt.IsNil)
+
+	t.Cleanup(func() {
+		qt.Check(t, db.Close(), qt.IsNil)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, cleanupErr := admin.ExecContext(
+			cleanupCtx,
+			"ALTER DATABASE "+quotedDatabase+
+				" SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE "+quotedDatabase,
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, admin.Close(), qt.IsNil)
+	})
+	return db
+}
+
+func emptyRealmPlanQueryExpectations() []writerQueryExpectation {
+	return []writerQueryExpectation{
+		queryExpectation(
+			"HAS_PERMS_BY_NAME",
+			nil,
+			realmAccessColumns(),
+			[]driver.Value{"ptah_dev", true, true},
+		),
+		queryExpectation(
+			"FROM sys.triggers AS t",
+			[]any{"dbo"},
+			[]string{"category", "schema", "name", "detail"},
+		),
+		queryExpectation(
+			"COALESCE(t.temporal_type, 0)",
+			nil,
+			realmObjectColumns(),
+		),
+		queryExpectation(
+			"FROM sys.foreign_keys AS fk",
+			nil,
+			[]string{"parent_schema", "parent_table", "name", "referenced_schema", "referenced_table"},
+		),
+		queryExpectation(
+			"FROM sys.sql_expression_dependencies AS dependency",
+			nil,
+			[]string{"referencing_id", "referenced_id"},
+		),
+		queryExpectation(
+			"FROM sys.types AS t",
+			nil,
+			[]string{"schema", "name"},
+		),
+		queryExpectation(
+			"FROM sys.xml_schema_collections AS x",
+			nil,
+			[]string{"schema", "name"},
+		),
+		queryExpectation(
+			"SELECT s.name\n\t\tFROM sys.schemas AS s",
+			[]any{"dbo"},
+			[]string{"schema"},
+		),
+	}
+}
+
+func realmAccessColumns() []string {
+	return []string{"database_name", "has_control", "has_view_definition"}
+}
+
+func realmObjectColumns() []string {
+	return []string{
+		"object_id",
+		"parent_object_id",
+		"schema",
+		"name",
+		"type",
+		"type_desc",
+		"temporal_type",
+		"history_table_id",
+		"ledger_type",
+	}
+}
+
+type writerQueryExpectation struct {
+	queryContains string
+	args          []any
+	result        dbtest.QueryResult
+	err           error
+}
+
+type writerExecExpectation struct {
+	sql string
+	err error
+}
+
+type writerSQLMock struct {
+	c                  *qt.C
+	queryExpectations  []writerQueryExpectation
+	execExpectations   []writerExecExpectation
+	queryExpectationID int
+	execExpectationID  int
+}
+
+func newWriterSQLMock(
+	t *testing.T,
+	queryExpectations []writerQueryExpectation,
+	execExpectations []writerExecExpectation,
+) *writerSQLMock {
+	mock := &writerSQLMock{
+		c:                 qt.New(t),
+		queryExpectations: queryExpectations,
+		execExpectations:  execExpectations,
+	}
+	t.Cleanup(mock.checkExpectations)
+	return mock
+}
+
+func queryExpectation(
+	queryContains string,
+	args []any,
+	columns []string,
+	rows ...[]driver.Value,
+) writerQueryExpectation {
+	return writerQueryExpectation{
+		queryContains: queryContains,
+		args:          args,
+		result: dbtest.QueryResult{
+			Columns: columns,
+			Rows:    rows,
+		},
+	}
+}
+
+func execExpectation(statement string, err error) writerExecExpectation {
+	return writerExecExpectation{sql: statement, err: err}
+}
+
+func (m *writerSQLMock) query(
+	query string,
+	args []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if m.queryExpectationID >= len(m.queryExpectations) {
+		return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+	}
+	expectation := m.queryExpectations[m.queryExpectationID]
+	m.queryExpectationID++
+	m.c.Check(query, qt.Contains, expectation.queryContains)
+	m.c.Check(namedValues(args), qt.DeepEquals, expectation.args)
+	return expectation.result, expectation.err
+}
+
+func (m *writerSQLMock) exec(
+	statement string,
+	args []driver.NamedValue,
+) (driver.Result, error) {
+	if m.execExpectationID >= len(m.execExpectations) {
+		return nil, fmt.Errorf("unexpected SQL execution: %s", statement)
+	}
+	expectation := m.execExpectations[m.execExpectationID]
+	m.execExpectationID++
+	m.c.Check(statement, qt.Equals, expectation.sql)
+	m.c.Check(namedValues(args), qt.DeepEquals, []any(nil))
+	return driver.RowsAffected(0), expectation.err
+}
+
+func (m *writerSQLMock) checkExpectations() {
+	m.c.Check(m.queryExpectationID, qt.Equals, len(m.queryExpectations))
+	m.c.Check(m.execExpectationID, qt.Equals, len(m.execExpectations))
+}
+
+func namedValues(values []driver.NamedValue) []any {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]any, 0, len(values))
+	for _, value := range values {
+		result = append(result, value.Value)
+	}
+	return result
+}

--- a/internal/dbschema/mssql/writer_realm_test.go
+++ b/internal/dbschema/mssql/writer_realm_test.go
@@ -540,6 +540,209 @@ func TestWriterDropDatabaseRealm_RejectsUnsupportedDatabaseArtifactBeforeDDL(t *
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
 }
 
+func TestWriterDropDatabaseRealm_RejectsReplicationEnabledDatabaseBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"replication-enabled database",
+					"",
+					"ptah_dev",
+					"is_distributor=1, is_published=0, is_merge_published=0",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`replication-enabled database \[ptah_dev\] `+
+			`\(is_distributor=1, is_published=0, is_merge_published=0\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsSubscriberDatabaseBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"DATABASEPROPERTYEX(DB_NAME(), N'IsSubscribed')",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"subscriber database",
+					"",
+					"ptah_dev",
+					"IsSubscribed=1",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`subscriber database \[ptah_dev\] \(IsSubscribed=1\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsUnknownSubscriptionStateBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"COALESCE(TRY_CONVERT(int, subscription.raw_value), -1) <> 0",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"unknown database subscription state",
+					"",
+					"ptah_dev",
+					"IsSubscribed=<unavailable>",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`unknown database subscription state \[ptah_dev\] `+
+			`\(IsSubscribed=<unavailable>\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsUnexpectedSubscriptionStateBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"COALESCE(TRY_CONVERT(int, subscription.raw_value), -1) <> 0",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"unknown database subscription state",
+					"",
+					"ptah_dev",
+					"IsSubscribed=2",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`unknown database subscription state \[ptah_dev\] \(IsSubscribed=2\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsReplicatedTableBeforeDDL(t *testing.T) {
+	c := qt.New(t)
+	sqlMock := newWriterSQLMock(t,
+		[]writerQueryExpectation{
+			queryExpectation(
+				"HAS_PERMS_BY_NAME",
+				nil,
+				realmAccessColumns(),
+				[]driver.Value{"ptah_dev", true, true},
+			),
+			queryExpectation(
+				"FROM sys.triggers AS t",
+				[]any{"dbo"},
+				[]string{"category", "schema", "name", "detail"},
+				[]driver.Value{
+					"replicated table",
+					"",
+					"app.orders",
+					"is_replicated=1, is_merge_published=0, is_sync_tran_subscribed=0",
+				},
+			),
+		},
+		nil,
+	)
+	db := dbtest.OpenWithExec(t, sqlMock.query, sqlMock.exec)
+	writer := mssql.NewSQLServerWriter(db.SQL, "dbo")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlserver: refusing to clean database realm with unsupported database-scoped `+
+			`replicated table \[app\.orders\] `+
+			`\(is_replicated=1, is_merge_published=0, is_sync_tran_subscribed=0\)`,
+	)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
 func TestWriterDropDatabaseRealm_RejectsPreservedSchemaPermissionBeforeDDL(t *testing.T) {
 	c := qt.New(t)
 	sqlMock := newWriterSQLMock(t,

--- a/internal/dbschema/mysql/mysql_test.go
+++ b/internal/dbschema/mysql/mysql_test.go
@@ -12,6 +12,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	mysqldriver "github.com/go-sql-driver/mysql"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/dbschema/dbtest"
@@ -366,16 +367,17 @@ func TestNormalizeMySQLColumnDefaultQuotesCatalogStringLiterals(t *testing.T) {
 func TestNewMySQLWriter(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		c := qt.New(t)
-		writer := NewMySQLWriter(nil, "test_schema")
+		writer := NewMySQLWriter(nil, "test_schema", platform.MySQL)
 		c.Assert(writer, qt.IsNotNil)
 		c.Assert(writer.schema, qt.Equals, "test_schema")
+		c.Assert(writer.dialect, qt.Equals, platform.MySQL)
 		c.Assert(writer.db, qt.IsNil) // We passed nil for testing
 	})
 }
 
 func TestMySQLWriter_TransactionMethods_NoConnection(t *testing.T) {
 	c := qt.New(t)
-	writer := NewMySQLWriter(nil, "test")
+	writer := NewMySQLWriter(nil, "test", platform.MySQL)
 
 	t.Run("ExecuteSQL with no connection", func(t *testing.T) {
 		err := writer.ExecuteSQL(context.Background(), "SELECT 1")
@@ -403,7 +405,7 @@ func TestMySQLWriter_TransactionMethods_NoConnection(t *testing.T) {
 func TestMySQLWriterConcurrentTransactions(t *testing.T) {
 	c := qt.New(t)
 	db := dbtest.OpenWithExec(t, nil, nil)
-	writer := NewMySQLWriter(db.SQL, "test")
+	writer := NewMySQLWriter(db.SQL, "test", platform.MySQL)
 
 	const goroutines = 64
 	var wg sync.WaitGroup
@@ -443,41 +445,9 @@ func TestMySQLWriterConcurrentTransactions(t *testing.T) {
 	c.Assert(db.CommitCount()+db.RollbackCount(), qt.Equals, goroutines)
 }
 
-func TestMySQLWriterDropAllTablesSucceeds(t *testing.T) {
-	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, mysqlDropAllQueryHandler, nil)
-	writer := NewMySQLWriter(db.SQL, "test")
-
-	c.Assert(writer.DropAllTables(t.Context()), qt.IsNil)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
-}
-
-func TestMySQLWriterDropAllTablesReturnsExecutionFailure(t *testing.T) {
-	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, mysqlDropAllQueryHandler, mysqlDropAllExecutionFailureHandler)
-	writer := NewMySQLWriter(db.SQL, "test")
-
-	err := writer.DropAllTables(t.Context())
-	c.Assert(err, qt.ErrorMatches, "failed to drop table users: SQL execution failed: boom\nSQL: DROP TABLE IF EXISTS `users`")
-}
-
-func mysqlDropAllExecutionFailureHandler(query string, _ []driver.NamedValue) (driver.Result, error) {
-	if strings.Contains(query, "DROP TABLE") {
-		return nil, fmt.Errorf("boom")
-	}
-	return driver.RowsAffected(0), nil
-}
-
-func mysqlDropAllQueryHandler(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
-	if !strings.Contains(query, "information_schema.tables") {
-		return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
-	}
-	return dbtest.QueryResult{Columns: []string{"table_name"}, Rows: [][]driver.Value{{"users"}}}, nil
-}
-
 func TestMySQLWriter_UtilityMethods(t *testing.T) {
 	c := qt.New(t)
-	writer := NewMySQLWriter(nil, "test")
+	writer := NewMySQLWriter(nil, "test", platform.MySQL)
 
 	t.Run("splitSQLStatements", func(t *testing.T) {
 		tests := []struct {
@@ -652,7 +622,7 @@ func TestMySQLWriter_UtilityMethods(t *testing.T) {
 
 func TestMySQLWriter_SchemaWriterInterface(t *testing.T) {
 	c := qt.New(t)
-	writer := NewMySQLWriter(nil, "test")
+	writer := NewMySQLWriter(nil, "test", platform.MySQL)
 	var _ types.SchemaWriter = writer
 	c.Assert(writer, qt.IsNotNil)
 }

--- a/internal/dbschema/mysql/reader.go
+++ b/internal/dbschema/mysql/reader.go
@@ -9,11 +9,12 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 // Reader reads schema information from MySQL/MariaDB databases
 type Reader struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 }
 
@@ -33,7 +34,7 @@ type tableColumnKey struct {
 }
 
 // NewMySQLReader creates a new MySQL schema reader
-func NewMySQLReader(db *sql.DB, schema string) *Reader {
+func NewMySQLReader(db sqlrunner.Runner, schema string) *Reader {
 	if schema == "" {
 		schema = "information_schema"
 	}

--- a/internal/dbschema/mysql/writer.go
+++ b/internal/dbschema/mysql/writer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -14,9 +15,13 @@ import (
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
-const sessionRestoreTimeout = 5 * time.Second
+const (
+	sessionRestoreTimeout = 5 * time.Second
+	metadataLockPollDelay = 10 * time.Millisecond
+)
 
 func quoteIdent(name string) string {
 	return sqlident.Quote(platform.MySQL, name)
@@ -28,10 +33,13 @@ func quoteQualifiedIdent(schema, name string) string {
 
 // Writer writes schemas to MySQL/MariaDB databases
 type Writer struct {
-	db      *sql.DB
-	schema  string
-	dialect string
-	dryRun  bool
+	db            sqlrunner.Runner
+	connector     sqlrunner.Connector
+	cleanupConn   *sql.Conn
+	schema        string
+	dialect       string
+	serverVersion string
+	dryRun        bool
 }
 
 type transactionWriter struct {
@@ -43,10 +51,59 @@ type transactionWriter struct {
 
 // NewMySQLWriter creates a new MySQL-family schema writer.
 func NewMySQLWriter(db *sql.DB, schema, dialect string) *Writer {
+	return NewMySQLWriterWithServerVersion(db, schema, dialect, "")
+}
+
+// NewMySQLWriterWithServerVersion creates a MySQL-family schema writer using
+// server metadata already resolved by the connection layer.
+func NewMySQLWriterWithServerVersion(db *sql.DB, schema, dialect, serverVersion string) *Writer {
+	if db == nil {
+		return newMySQLWriter(nil, nil, nil, schema, dialect, serverVersion)
+	}
+	return newMySQLWriter(db, db, nil, schema, dialect, serverVersion)
+}
+
+// NewMySQLWriterForRunner creates a writer whose ordinary SQL runs on runner
+// while multi-session cleanup acquires auxiliary connections from connector.
+func NewMySQLWriterForRunner(
+	runner sqlrunner.Runner,
+	connector sqlrunner.Connector,
+	schema,
+	dialect,
+	serverVersion string,
+) *Writer {
+	return newMySQLWriter(runner, connector, nil, schema, dialect, serverVersion)
+}
+
+// NewMySQLWriterForPinnedRunner creates a writer whose ordinary SQL and
+// primary cleanup operations use the pinned session. connector supplies the
+// auxiliary sessions needed for the protected view-drop handoff.
+func NewMySQLWriterForPinnedRunner(
+	runner sqlrunner.Runner,
+	connector sqlrunner.Connector,
+	cleanupConn *sql.Conn,
+	schema,
+	dialect,
+	serverVersion string,
+) *Writer {
+	return newMySQLWriter(runner, connector, cleanupConn, schema, dialect, serverVersion)
+}
+
+func newMySQLWriter(
+	runner sqlrunner.Runner,
+	connector sqlrunner.Connector,
+	cleanupConn *sql.Conn,
+	schema,
+	dialect,
+	serverVersion string,
+) *Writer {
 	return &Writer{
-		db:      db,
-		schema:  schema,
-		dialect: platform.NormalizeDialect(dialect),
+		db:            runner,
+		connector:     connector,
+		cleanupConn:   cleanupConn,
+		schema:        schema,
+		dialect:       platform.NormalizeDialect(dialect),
+		serverVersion: serverVersion,
 	}
 }
 
@@ -153,47 +210,71 @@ type cleanupForeignKey struct {
 }
 
 // DropAllTables drops all user schema objects in the configured database.
-func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
+func (w *Writer) DropAllTables(ctx context.Context) error {
+	return w.withCleanupConnection(ctx, "cleanup", func(conn *sql.Conn) error {
+		return w.dropAllTablesOnConnection(ctx, conn)
+	})
+}
+
+func (w *Writer) withCleanupConnection(
+	ctx context.Context,
+	label string,
+	use func(*sql.Conn) error,
+) (resultErr error) {
 	if w.dryRun {
 		return nil
 	}
 	if w.db == nil {
 		return fmt.Errorf("no database connection")
 	}
+	if w.connector == nil {
+		return fmt.Errorf("mysql: cleanup requires a database connection pool")
+	}
 
-	conn, err := w.db.Conn(ctx)
+	conn := w.cleanupConn
+	if conn != nil {
+		return use(conn)
+	}
+
+	conn, err := acquireAuxiliaryConnection(ctx, w.connector, label)
 	if err != nil {
-		return fmt.Errorf("mysql: acquire cleanup connection: %w", err)
+		return err
 	}
 	defer func() {
-		closeErr := conn.Close()
-		if closeErr != nil && !errors.Is(closeErr, sql.ErrConnDone) {
-			resultErr = errors.Join(resultErr, fmt.Errorf("mysql: close cleanup connection: %w", closeErr))
-		}
+		resultErr = errors.Join(resultErr, closeCleanupConnection(conn, label))
 	}()
+	return use(conn)
+}
 
+func (w *Writer) dropAllTablesOnConnection(
+	ctx context.Context,
+	conn *sql.Conn,
+) error {
 	schema, err := w.cleanupSchema(ctx, conn)
 	if err != nil {
 		return err
 	}
-	foreignKeyChecks, err := readForeignKeyChecks(ctx, conn)
+	serverVersion, err := w.cleanupServerVersion(ctx, conn)
 	if err != nil {
 		return err
 	}
-	if !foreignKeyChecks {
-		defer func() {
-			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
-			defer cancel()
-			if _, restoreErr := conn.ExecContext(cleanupCtx, "SET FOREIGN_KEY_CHECKS = 0"); restoreErr != nil {
-				discardConn(conn)
-				resultErr = errors.Join(resultErr, fmt.Errorf("mysql: restore foreign key checks: %w", restoreErr))
-			}
-		}()
-		if _, err := conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
-			return fmt.Errorf("mysql: enable foreign key checks for cleanup: %w", err)
-		}
+	if w.dialect == platform.MySQL && !supportsMySQLViewTableUsage(serverVersion) {
+		return fmt.Errorf(
+			"mysql: refusing to clean database %q: server version %q lacks "+
+				"information_schema.VIEW_TABLE_USAGE required for complete external-view dependency checks",
+			schema,
+			serverVersion,
+		)
 	}
+	if err := requireGlobalMetadataVisibility(ctx, conn, schema, w.dialect); err != nil {
+		return err
+	}
+	return withForeignKeyChecksEnabled(ctx, conn, func() error {
+		return w.dropDatabaseObjects(ctx, conn, schema)
+	})
+}
 
+func (w *Writer) dropDatabaseObjects(ctx context.Context, conn *sql.Conn, schema string) error {
 	foreignKeys, err := listInternalForeignKeys(ctx, conn, schema)
 	if err != nil {
 		return err
@@ -202,6 +283,8 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if err != nil {
 		return err
 	}
+	groups := groupCleanupObjects(objects)
+
 	// Run dependency checks immediately before the first destructive statement.
 	// FOREIGN_KEY_CHECKS remains enabled, so a cross-database foreign key
 	// created after this preflight still makes DROP TABLE fail.
@@ -211,7 +294,71 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if err := rejectExternalViews(ctx, conn, schema, w.dialect); err != nil {
 		return err
 	}
+	if err := w.dropProtectedViews(ctx, conn, schema, groups.views, groups.tables); err != nil {
+		return err
+	}
+	if err := dropCleanupForeignKeys(ctx, conn, schema, foreignKeys); err != nil {
+		return err
+	}
+	if err := w.dropProtectedObjects(ctx, conn, schema, groups.tables); err != nil {
+		return err
+	}
+	return dropRemainingCleanupObjects(ctx, conn, schema, groups.remaining)
+}
 
+func withForeignKeyChecksEnabled(
+	ctx context.Context,
+	conn *sql.Conn,
+	use func() error,
+) (resultErr error) {
+	foreignKeyChecks, err := readForeignKeyChecks(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if foreignKeyChecks {
+		return use()
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
+		defer cancel()
+		if _, restoreErr := conn.ExecContext(cleanupCtx, "SET FOREIGN_KEY_CHECKS = 0"); restoreErr != nil {
+			discardConn(conn)
+			resultErr = errors.Join(resultErr, fmt.Errorf("mysql: restore foreign key checks: %w", restoreErr))
+		}
+	}()
+	if _, err := conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		return fmt.Errorf("mysql: enable foreign key checks for cleanup: %w", err)
+	}
+	return use()
+}
+
+type cleanupObjectGroups struct {
+	views     []string
+	tables    []string
+	remaining []cleanupObject
+}
+
+func groupCleanupObjects(objects []cleanupObject) cleanupObjectGroups {
+	var groups cleanupObjectGroups
+	for _, object := range objects {
+		switch object.Kind {
+		case "VIEW":
+			groups.views = append(groups.views, object.Name)
+		case "TABLE":
+			groups.tables = append(groups.tables, object.Name)
+		default:
+			groups.remaining = append(groups.remaining, object)
+		}
+	}
+	return groups
+}
+
+func dropCleanupForeignKeys(
+	ctx context.Context,
+	conn *sql.Conn,
+	schema string,
+	foreignKeys []cleanupForeignKey,
+) error {
 	for _, foreignKey := range foreignKeys {
 		//nolint:gosec // G202: schema and catalog identifiers are emitted only through identifier quoting.
 		dropSQL := "ALTER TABLE " + quoteQualifiedIdent(schema, foreignKey.Table) +
@@ -226,11 +373,17 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 			)
 		}
 	}
+	return nil
+}
 
+func dropRemainingCleanupObjects(
+	ctx context.Context,
+	conn *sql.Conn,
+	schema string,
+	objects []cleanupObject,
+) error {
 	// MySQL DDL implicitly commits, so cleanup deliberately avoids a transaction.
 	for _, object := range objects {
-		// Identifiers cannot be bound as parameters; quoteIdent escapes every
-		// backtick in the schema and name returned by information_schema.
 		//nolint:gosec // G202: schema and object.Name are emitted only through identifier quoting.
 		dropSQL := "DROP " + object.Kind + " IF EXISTS " + quoteQualifiedIdent(schema, object.Name)
 		if _, err := conn.ExecContext(ctx, dropSQL); err != nil {
@@ -238,8 +391,394 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 				strings.ToLower(object.Kind), object.Name, err, dropSQL)
 		}
 	}
-
 	return nil
+}
+
+// DropDatabaseRealm drops the selected MySQL/MariaDB database realm and
+// verifies that no supported user object remains.
+func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
+	if w.dryRun {
+		return nil
+	}
+	return w.withCleanupConnection(ctx, "realm-cleanup", func(conn *sql.Conn) error {
+		if err := w.dropAllTablesOnConnection(ctx, conn); err != nil {
+			return err
+		}
+		return w.verifyDatabaseRealm(ctx, conn)
+	})
+}
+
+func (w *Writer) verifyDatabaseRealm(ctx context.Context, conn *sql.Conn) error {
+	schema, err := w.cleanupSchema(ctx, conn)
+	if err != nil {
+		return err
+	}
+	objects, err := listCleanupObjects(ctx, conn, schema)
+	if err != nil {
+		return err
+	}
+	if len(objects) > 0 {
+		return fmt.Errorf(
+			"mysql: database-realm cleanup left %d user objects; first residual object is %s %s",
+			len(objects),
+			strings.ToLower(objects[0].Kind),
+			objects[0].Name,
+		)
+	}
+	return nil
+}
+
+func (w *Writer) cleanupServerVersion(ctx context.Context, conn *sql.Conn) (string, error) {
+	if strings.TrimSpace(w.serverVersion) != "" {
+		return w.serverVersion, nil
+	}
+	var version string
+	if err := conn.QueryRowContext(ctx, "SELECT VERSION()").Scan(&version); err != nil {
+		return "", fmt.Errorf("mysql: read server version for cleanup: %w", err)
+	}
+	return version, nil
+}
+
+func requireGlobalMetadataVisibility(
+	ctx context.Context,
+	conn *sql.Conn,
+	schema,
+	dialect string,
+) error {
+	privilegeNames := "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, and PROCESS"
+	if platform.NormalizeDialect(dialect) == platform.MariaDB {
+		privilegeNames = "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and SHOW VIEW"
+	}
+
+	var hasSelect bool
+	var hasDrop bool
+	var hasAlter bool
+	var hasAlterRoutine bool
+	var hasEvent bool
+	var hasLockTables bool
+	var hasProcess bool
+	var hasShowView bool
+	if err := conn.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(MAX(privilege_type = 'SELECT'), 0),
+			COALESCE(MAX(privilege_type = 'DROP'), 0),
+			COALESCE(MAX(privilege_type = 'ALTER'), 0),
+			COALESCE(MAX(privilege_type = 'ALTER ROUTINE'), 0),
+			COALESCE(MAX(privilege_type = 'EVENT'), 0),
+			COALESCE(MAX(privilege_type = 'LOCK TABLES'), 0),
+			COALESCE(MAX(privilege_type = 'PROCESS'), 0),
+			COALESCE(MAX(privilege_type = 'SHOW VIEW'), 0)
+		FROM information_schema.user_privileges
+		WHERE grantee = CONCAT(
+			QUOTE(SUBSTRING_INDEX(CURRENT_USER(), '@', 1)),
+			'@',
+			QUOTE(SUBSTRING_INDEX(CURRENT_USER(), '@', -1))
+		)
+		  AND privilege_type IN (
+		    'SELECT',
+		    'DROP',
+		    'ALTER',
+		    'ALTER ROUTINE',
+		    'EVENT',
+		    'LOCK TABLES',
+		    'PROCESS',
+		    'SHOW VIEW'
+		  )
+	`).Scan(
+		&hasSelect,
+		&hasDrop,
+		&hasAlter,
+		&hasAlterRoutine,
+		&hasEvent,
+		&hasLockTables,
+		&hasProcess,
+		&hasShowView,
+	); err != nil {
+		return fmt.Errorf("mysql: prove global metadata visibility: %w", err)
+	}
+	hasRequiredPrivileges := hasSelect &&
+		hasDrop &&
+		hasAlter &&
+		hasAlterRoutine &&
+		hasEvent &&
+		hasLockTables &&
+		hasProcess
+	if platform.NormalizeDialect(dialect) == platform.MariaDB {
+		hasRequiredPrivileges = hasRequiredPrivileges && hasShowView
+	}
+	if !hasRequiredPrivileges {
+		return fmt.Errorf(
+			"mysql: refusing to clean database %q: global %s privileges are required "+
+				"to prove complete metadata visibility and protect destructive DDL",
+			schema,
+			privilegeNames,
+		)
+	}
+
+	rows, err := conn.QueryContext(ctx, "SHOW GRANTS")
+	if err != nil {
+		return fmt.Errorf("mysql: inspect metadata visibility restrictions: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var grant string
+		if err := rows.Scan(&grant); err != nil {
+			return fmt.Errorf("mysql: scan metadata visibility grant: %w", err)
+		}
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(grant)), "REVOKE ") {
+			return fmt.Errorf(
+				"mysql: refusing to clean database %q: partial privilege revokes "+
+					"prevent proving complete metadata visibility",
+				schema,
+			)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("mysql: iterate metadata visibility grants: %w", err)
+	}
+	return nil
+}
+
+func (w *Writer) dropProtectedViews(
+	ctx context.Context,
+	lockConn *sql.Conn,
+	schema string,
+	views,
+	tables []string,
+) (resultErr error) {
+	if len(views) == 0 {
+		return nil
+	}
+
+	dropConn, err := acquireAuxiliaryConnection(ctx, w.connector, "view-drop")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, closeCleanupConnection(dropConn, "view-drop"))
+	}()
+	monitorConn, err := acquireAuxiliaryConnection(ctx, w.connector, "metadata-lock monitor")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, closeCleanupConnection(monitorConn, "metadata-lock monitor"))
+	}()
+
+	lockTargets := make([]string, 0, len(views)+len(tables))
+	lockTargets = append(lockTargets, views...)
+	lockTargets = append(lockTargets, tables...)
+	if _, err := lockConn.ExecContext(ctx, buildLockTablesSQL(schema, lockTargets)); err != nil {
+		return fmt.Errorf("mysql: lock cleanup views and tables: %w", err)
+	}
+	locked := true
+	defer func() {
+		if locked {
+			resultErr = errors.Join(resultErr, releaseTableLocks(ctx, lockConn))
+		}
+	}()
+
+	if err := rejectExternalForeignKeys(ctx, lockConn, schema); err != nil {
+		return err
+	}
+	if err := rejectExternalViews(ctx, lockConn, schema, w.dialect); err != nil {
+		return err
+	}
+
+	var dropConnectionID int64
+	if err := dropConn.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&dropConnectionID); err != nil {
+		return fmt.Errorf("mysql: read view-drop connection ID: %w", err)
+	}
+	dropSQL := buildDropObjectsSQL(schema, "VIEW", views)
+	dropCtx, cancelDrop := context.WithCancel(ctx)
+	defer cancelDrop()
+	dropDone := make(chan error, 1)
+	go func() {
+		_, dropErr := dropConn.ExecContext(dropCtx, dropSQL)
+		dropDone <- formatDropObjectsError("VIEW", views, dropSQL, dropErr)
+	}()
+
+	dropErr, finished, waitErr := waitForOwnedMetadataLock(
+		ctx,
+		monitorConn,
+		dropConnectionID,
+		dropDone,
+	)
+	if waitErr != nil {
+		cancelDrop()
+		return errors.Join(waitErr, waitForCanceledViewDrop(dropDone))
+	}
+	if finished {
+		unlockErr := releaseTableLocks(ctx, lockConn)
+		locked = false
+		return errors.Join(dropErr, unlockErr)
+	}
+	unlockErr := releaseTableLocks(ctx, lockConn)
+	locked = false
+	if unlockErr != nil {
+		cancelDrop()
+		return errors.Join(unlockErr, waitForCanceledViewDrop(dropDone))
+	}
+	return <-dropDone
+}
+
+func waitForOwnedMetadataLock(
+	ctx context.Context,
+	conn *sql.Conn,
+	dropConnectionID int64,
+	dropDone <-chan error,
+) (dropErr error, finished bool, resultErr error) {
+	ticker := time.NewTicker(metadataLockPollDelay)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case dropErr := <-dropDone:
+			return dropErr, true, nil
+		default:
+		}
+
+		var ownedWaiters int
+		var otherWaiters int
+		if err := conn.QueryRowContext(ctx, `
+			SELECT
+				COALESCE(SUM(id = ?), 0),
+				COALESCE(SUM(id <> ?), 0)
+			FROM information_schema.processlist
+			WHERE LOWER(COALESCE(state, '')) LIKE '%metadata lock%'
+		`, dropConnectionID, dropConnectionID).Scan(&ownedWaiters, &otherWaiters); err != nil {
+			return nil, false, fmt.Errorf("mysql: inspect metadata-lock waiters: %w", err)
+		}
+		if otherWaiters > 0 {
+			return nil, false, fmt.Errorf(
+				"mysql: refusing view cleanup: %d competing metadata-lock waiters appeared before the protected DROP VIEW handoff",
+				otherWaiters,
+			)
+		}
+		if ownedWaiters == 1 {
+			return nil, false, nil
+		}
+
+		select {
+		case dropErr := <-dropDone:
+			return dropErr, true, nil
+		case <-ctx.Done():
+			return nil, false, fmt.Errorf(
+				"mysql: wait for protected DROP VIEW metadata lock: %w",
+				ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func acquireAuxiliaryConnection(
+	ctx context.Context,
+	connector sqlrunner.Connector,
+	label string,
+) (*sql.Conn, error) {
+	acquireCtx, cancel := context.WithTimeout(ctx, sessionRestoreTimeout)
+	defer cancel()
+	conn, err := connector.Conn(acquireCtx)
+	if err != nil {
+		return nil, fmt.Errorf("mysql: acquire %s connection: %w", label, err)
+	}
+	return conn, nil
+}
+
+func waitForCanceledViewDrop(dropDone <-chan error) error {
+	timer := time.NewTimer(sessionRestoreTimeout)
+	defer timer.Stop()
+	select {
+	case err := <-dropDone:
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	case <-timer.C:
+		return fmt.Errorf("mysql: canceled DROP VIEW did not stop within %s", sessionRestoreTimeout)
+	}
+}
+
+func closeCleanupConnection(conn *sql.Conn, label string) error {
+	if err := conn.Close(); err != nil && !errors.Is(err, sql.ErrConnDone) {
+		return fmt.Errorf("mysql: close %s connection: %w", label, err)
+	}
+	return nil
+}
+
+func (w *Writer) dropProtectedObjects(
+	ctx context.Context,
+	conn *sql.Conn,
+	schema string,
+	names []string,
+) (resultErr error) {
+	if len(names) == 0 {
+		return nil
+	}
+
+	lockSQL := buildLockTablesSQL(schema, names)
+	if _, err := conn.ExecContext(ctx, lockSQL); err != nil {
+		return fmt.Errorf("mysql: lock cleanup tables: %w", err)
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, releaseTableLocks(ctx, conn))
+	}()
+
+	if err := rejectExternalForeignKeys(ctx, conn, schema); err != nil {
+		return err
+	}
+	if err := rejectExternalViews(ctx, conn, schema, w.dialect); err != nil {
+		return err
+	}
+
+	dropSQL := buildDropObjectsSQL(schema, "TABLE", names)
+	_, err := conn.ExecContext(ctx, dropSQL)
+	return formatDropObjectsError("TABLE", names, dropSQL, err)
+}
+
+func buildLockTablesSQL(schema string, names []string) string {
+	locks := make([]string, 0, len(names))
+	for _, name := range names {
+		locks = append(locks, quoteQualifiedIdent(schema, name)+" WRITE")
+	}
+	return "LOCK TABLES " + strings.Join(locks, ", ")
+}
+
+func buildDropObjectsSQL(schema, kind string, names []string) string {
+	qualifiedNames := make([]string, 0, len(names))
+	for _, name := range names {
+		qualifiedNames = append(qualifiedNames, quoteQualifiedIdent(schema, name))
+	}
+	return "DROP " + kind + " IF EXISTS " + strings.Join(qualifiedNames, ", ")
+}
+
+func releaseTableLocks(ctx context.Context, conn *sql.Conn) error {
+	unlockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
+	defer cancel()
+	if _, err := conn.ExecContext(unlockCtx, "UNLOCK TABLES"); err != nil {
+		discardConn(conn)
+		return fmt.Errorf("mysql: release cleanup table locks: %w", err)
+	}
+	return nil
+}
+
+func formatDropObjectsError(kind string, names []string, dropSQL string, err error) error {
+	if err == nil {
+		return nil
+	}
+	objectLabel := strings.ToLower(kind)
+	if len(names) > 1 {
+		objectLabel += "s"
+	}
+	return fmt.Errorf(
+		"failed to drop %s %s: SQL execution failed: %w\nSQL: %s",
+		objectLabel,
+		strings.Join(names, ", "),
+		err,
+		dropSQL,
+	)
 }
 
 func (w *Writer) cleanupSchema(ctx context.Context, conn *sql.Conn) (string, error) {
@@ -338,6 +877,24 @@ func externalViewCount(ctx context.Context, conn *sql.Conn, schema, dialect stri
 		return mariaDBExternalViewCount(ctx, conn, schema)
 	}
 	return mySQLExternalViewCount(ctx, conn, schema)
+}
+
+func supportsMySQLViewTableUsage(version string) bool {
+	numericVersion, _, _ := strings.Cut(version, "-")
+	parts := strings.Split(numericVersion, ".")
+	if len(parts) < 3 {
+		return false
+	}
+	major, majorErr := strconv.Atoi(parts[0])
+	minor, minorErr := strconv.Atoi(parts[1])
+	patch, patchErr := strconv.Atoi(parts[2])
+	if majorErr != nil || minorErr != nil || patchErr != nil {
+		return false
+	}
+	if major != 8 {
+		return major > 8
+	}
+	return minor > 0 || patch >= 13
 }
 
 func mySQLExternalViewCount(ctx context.Context, conn *sql.Conn, schema string) (int, error) {

--- a/internal/dbschema/mysql/writer.go
+++ b/internal/dbschema/mysql/writer.go
@@ -11,24 +11,27 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
 const sessionRestoreTimeout = 5 * time.Second
 
-// quoteIdent returns a safely-backtick-quoted MySQL/MariaDB identifier.
-// Embedded backticks are doubled so that values coming from
-// information_schema (or any other untrusted-shaped string) cannot terminate
-// the quoted identifier and inject DDL.
 func quoteIdent(name string) string {
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	return sqlident.Quote(platform.MySQL, name)
+}
+
+func quoteQualifiedIdent(schema, name string) string {
+	return sqlident.Qualified(platform.MySQL, schema, name)
 }
 
 // Writer writes schemas to MySQL/MariaDB databases
 type Writer struct {
-	db     *sql.DB
-	schema string
-	dryRun bool
+	db      *sql.DB
+	schema  string
+	dialect string
+	dryRun  bool
 }
 
 type transactionWriter struct {
@@ -38,11 +41,12 @@ type transactionWriter struct {
 	dryRun bool
 }
 
-// NewMySQLWriter creates a new MySQL schema writer
-func NewMySQLWriter(db *sql.DB, schema string) *Writer {
+// NewMySQLWriter creates a new MySQL-family schema writer.
+func NewMySQLWriter(db *sql.DB, schema, dialect string) *Writer {
 	return &Writer{
-		db:     db,
-		schema: schema,
+		db:      db,
+		schema:  schema,
+		dialect: platform.NormalizeDialect(dialect),
 	}
 }
 
@@ -138,7 +142,17 @@ func (w *transactionWriter) Rollback() error {
 // IsDryRun returns whether dry-run mode is enabled.
 func (w *transactionWriter) IsDryRun() bool { return w.dryRun }
 
-// DropAllTables drops ALL tables in the database (COMPLETE CLEANUP!)
+type cleanupObject struct {
+	Name string
+	Kind string
+}
+
+type cleanupForeignKey struct {
+	Table string
+	Name  string
+}
+
+// DropAllTables drops all user schema objects in the configured database.
 func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if w.dryRun {
 		return nil
@@ -158,62 +172,260 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 		}
 	}()
 
-	if _, err := conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
-		return fmt.Errorf("failed to disable foreign key checks: %w", err)
-	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
-		defer cancel()
-		if _, restoreErr := conn.ExecContext(cleanupCtx, "SET FOREIGN_KEY_CHECKS = 1"); restoreErr != nil {
-			discardConn(conn)
-			resultErr = errors.Join(resultErr, fmt.Errorf("mysql: restore foreign key checks: %w", restoreErr))
-		}
-	}()
-
-	tables, err := listTables(ctx, conn)
+	schema, err := w.cleanupSchema(ctx, conn)
 	if err != nil {
 		return err
 	}
+	foreignKeyChecks, err := readForeignKeyChecks(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if !foreignKeyChecks {
+		defer func() {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
+			defer cancel()
+			if _, restoreErr := conn.ExecContext(cleanupCtx, "SET FOREIGN_KEY_CHECKS = 0"); restoreErr != nil {
+				discardConn(conn)
+				resultErr = errors.Join(resultErr, fmt.Errorf("mysql: restore foreign key checks: %w", restoreErr))
+			}
+		}()
+		if _, err := conn.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+			return fmt.Errorf("mysql: enable foreign key checks for cleanup: %w", err)
+		}
+	}
+
+	foreignKeys, err := listInternalForeignKeys(ctx, conn, schema)
+	if err != nil {
+		return err
+	}
+	objects, err := listCleanupObjects(ctx, conn, schema)
+	if err != nil {
+		return err
+	}
+	// Run dependency checks immediately before the first destructive statement.
+	// FOREIGN_KEY_CHECKS remains enabled, so a cross-database foreign key
+	// created after this preflight still makes DROP TABLE fail.
+	if err := rejectExternalForeignKeys(ctx, conn, schema); err != nil {
+		return err
+	}
+	if err := rejectExternalViews(ctx, conn, schema, w.dialect); err != nil {
+		return err
+	}
+
+	for _, foreignKey := range foreignKeys {
+		//nolint:gosec // G202: schema and catalog identifiers are emitted only through identifier quoting.
+		dropSQL := "ALTER TABLE " + quoteQualifiedIdent(schema, foreignKey.Table) +
+			" DROP FOREIGN KEY " + quoteIdent(foreignKey.Name)
+		if _, err := conn.ExecContext(ctx, dropSQL); err != nil {
+			return fmt.Errorf(
+				"failed to drop foreign key %s on table %s: SQL execution failed: %w\nSQL: %s",
+				foreignKey.Name,
+				foreignKey.Table,
+				err,
+				dropSQL,
+			)
+		}
+	}
 
 	// MySQL DDL implicitly commits, so cleanup deliberately avoids a transaction.
-	for _, tableName := range tables {
+	for _, object := range objects {
 		// Identifiers cannot be bound as parameters; quoteIdent escapes every
-		// backtick in the name returned by information_schema.
-		//nolint:gosec // G202: tableName is emitted only through identifier quoting.
-		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName)
+		// backtick in the schema and name returned by information_schema.
+		//nolint:gosec // G202: schema and object.Name are emitted only through identifier quoting.
+		dropSQL := "DROP " + object.Kind + " IF EXISTS " + quoteQualifiedIdent(schema, object.Name)
 		if _, err := conn.ExecContext(ctx, dropSQL); err != nil {
-			return fmt.Errorf("failed to drop table %s: SQL execution failed: %w\nSQL: %s", tableName, err, dropSQL)
+			return fmt.Errorf("failed to drop %s %s: SQL execution failed: %w\nSQL: %s",
+				strings.ToLower(object.Kind), object.Name, err, dropSQL)
 		}
 	}
 
 	return nil
 }
 
-func listTables(ctx context.Context, conn *sql.Conn) ([]string, error) {
+func (w *Writer) cleanupSchema(ctx context.Context, conn *sql.Conn) (string, error) {
+	if strings.TrimSpace(w.schema) != "" {
+		return w.schema, nil
+	}
+	var schema sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&schema); err != nil {
+		return "", fmt.Errorf("mysql: read current database: %w", err)
+	}
+	if !schema.Valid || strings.TrimSpace(schema.String) == "" {
+		return "", fmt.Errorf("mysql: cleanup requires a selected database")
+	}
+	return schema.String, nil
+}
+
+func readForeignKeyChecks(ctx context.Context, conn *sql.Conn) (bool, error) {
+	var value bool
+	if err := conn.QueryRowContext(ctx, "SELECT @@SESSION.FOREIGN_KEY_CHECKS").Scan(&value); err != nil {
+		return false, fmt.Errorf("mysql: read foreign key checks: %w", err)
+	}
+	return value, nil
+}
+
+func rejectExternalForeignKeys(ctx context.Context, conn *sql.Conn, schema string) error {
+	var count int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT DISTINCT constraint_schema, constraint_name
+			FROM information_schema.key_column_usage
+			WHERE referenced_table_schema = ?
+			  AND constraint_schema <> ?
+		) AS external_foreign_keys
+	`, schema, schema).Scan(&count); err != nil {
+		return fmt.Errorf("mysql: inspect cross-database foreign keys: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf("mysql: refusing to clean database %q: %d foreign key constraints from other databases reference it", schema, count)
+	}
+	return nil
+}
+
+func listInternalForeignKeys(
+	ctx context.Context,
+	conn *sql.Conn,
+	schema string,
+) ([]cleanupForeignKey, error) {
 	rows, err := conn.QueryContext(ctx, `
-		SELECT table_name
-		FROM information_schema.tables
-		WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'
-		ORDER BY table_name
-	`)
+		SELECT table_name, constraint_name
+		FROM (
+			SELECT DISTINCT table_name, constraint_name
+			FROM information_schema.key_column_usage
+			WHERE constraint_schema = ?
+			  AND referenced_table_name IS NOT NULL
+		) AS internal_foreign_keys
+		ORDER BY table_name, constraint_name
+	`, schema)
 	if err != nil {
-		return nil, fmt.Errorf("mysql: query tables: %w", err)
+		return nil, fmt.Errorf("mysql: query internal foreign keys: %w", err)
 	}
 	defer rows.Close()
 
-	var tables []string
+	var foreignKeys []cleanupForeignKey
 	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			return nil, fmt.Errorf("mysql: scan table name: %w", err)
+		var foreignKey cleanupForeignKey
+		if err := rows.Scan(&foreignKey.Table, &foreignKey.Name); err != nil {
+			return nil, fmt.Errorf("mysql: scan internal foreign key: %w", err)
 		}
-		tables = append(tables, tableName)
+		foreignKeys = append(foreignKeys, foreignKey)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("mysql: iterate tables: %w", err)
+		return nil, fmt.Errorf("mysql: iterate internal foreign keys: %w", err)
 	}
 
-	return tables, nil
+	return foreignKeys, nil
+}
+
+func rejectExternalViews(ctx context.Context, conn *sql.Conn, schema, dialect string) error {
+	count, err := externalViewCount(ctx, conn, schema, dialect)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf(
+			"mysql: refusing to clean database %q: %d views from other databases reference it",
+			schema,
+			count,
+		)
+	}
+	return nil
+}
+
+func externalViewCount(ctx context.Context, conn *sql.Conn, schema, dialect string) (int, error) {
+	if platform.NormalizeDialect(dialect) == platform.MariaDB {
+		return mariaDBExternalViewCount(ctx, conn, schema)
+	}
+	return mySQLExternalViewCount(ctx, conn, schema)
+}
+
+func mySQLExternalViewCount(ctx context.Context, conn *sql.Conn, schema string) (int, error) {
+	var count int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT DISTINCT view_schema, view_name
+			FROM information_schema.view_table_usage
+			WHERE table_schema = ?
+			  AND view_schema <> ?
+		) AS external_views
+	`, schema, schema).Scan(&count); err != nil {
+		return 0, fmt.Errorf("mysql: inspect cross-database views: %w", err)
+	}
+	return count, nil
+}
+
+func mariaDBExternalViewCount(ctx context.Context, conn *sql.Conn, schema string) (int, error) {
+	// MariaDB has no information_schema.view_table_usage relation. It
+	// normalizes table references in VIEW_DEFINITION to fully qualified,
+	// backtick-quoted names, so the exact database qualifier is a conservative
+	// dependency signal. Keeping the qualifier as a bound value avoids mixing
+	// metadata values into the query text.
+	var count int
+	if err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM information_schema.views
+		WHERE table_schema <> ?
+		  AND INSTR(view_definition, ?) > 0
+	`, schema, quoteIdent(schema)+".").Scan(&count); err != nil {
+		return 0, fmt.Errorf("mariadb: inspect cross-database views: %w", err)
+	}
+	return count, nil
+}
+
+func listCleanupObjects(ctx context.Context, conn *sql.Conn, schema string) ([]cleanupObject, error) {
+	rows, err := conn.QueryContext(ctx, `
+		SELECT object_name, object_kind
+		FROM (
+			SELECT
+				table_name AS object_name,
+				CASE table_type
+					WHEN 'VIEW' THEN 'VIEW'
+					WHEN 'SEQUENCE' THEN 'SEQUENCE'
+					ELSE 'TABLE'
+				END AS object_kind,
+				CASE table_type
+					WHEN 'VIEW' THEN 10
+					WHEN 'SEQUENCE' THEN 40
+					ELSE 30
+				END AS priority
+			FROM information_schema.tables
+			WHERE table_schema = ?
+			  AND table_type IN ('BASE TABLE', 'VIEW', 'SEQUENCE', 'SYSTEM VERSIONED')
+
+			UNION ALL
+
+			SELECT routine_name, routine_type, 20
+			FROM information_schema.routines
+			WHERE routine_schema = ?
+
+			UNION ALL
+
+			SELECT event_name, 'EVENT', 0
+			FROM information_schema.events
+			WHERE event_schema = ?
+		) AS cleanup_objects
+		ORDER BY priority, object_kind, object_name
+	`, schema, schema, schema)
+	if err != nil {
+		return nil, fmt.Errorf("mysql: query schema objects: %w", err)
+	}
+	defer rows.Close()
+
+	var objects []cleanupObject
+	for rows.Next() {
+		var object cleanupObject
+		if err := rows.Scan(&object.Name, &object.Kind); err != nil {
+			return nil, fmt.Errorf("mysql: scan schema object: %w", err)
+		}
+		objects = append(objects, object)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("mysql: iterate schema objects: %w", err)
+	}
+
+	return objects, nil
 }
 
 func discardConn(conn *sql.Conn) {

--- a/internal/dbschema/mysql/writer.go
+++ b/internal/dbschema/mysql/writer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +23,19 @@ const (
 	sessionRestoreTimeout = 5 * time.Second
 	metadataLockPollDelay = 10 * time.Millisecond
 )
+
+var protectedMySQLDatabases = []string{
+	"information_schema",
+	"metrics_schema",
+	"mysql",
+	"mysql_innodb_cluster_metadata",
+	"mysql_innodb_cluster_metadata_backup",
+	"mysql_innodb_cluster_metadata_bkp",
+	"mysql_innodb_cluster_metadata_previous",
+	"ndbinfo",
+	"performance_schema",
+	"sys",
+}
 
 func quoteIdent(name string) string {
 	return sqlident.Quote(platform.MySQL, name)
@@ -401,11 +415,25 @@ func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
 		return nil
 	}
 	return w.withCleanupConnection(ctx, "realm-cleanup", func(conn *sql.Conn) error {
+		schema, err := w.cleanupSchema(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if err := rejectProtectedMySQLDatabase(schema); err != nil {
+			return err
+		}
 		if err := w.dropAllTablesOnConnection(ctx, conn); err != nil {
 			return err
 		}
 		return w.verifyDatabaseRealm(ctx, conn)
 	})
+}
+
+func rejectProtectedMySQLDatabase(database string) error {
+	if slices.Contains(protectedMySQLDatabases, strings.ToLower(database)) {
+		return fmt.Errorf("mysql: refusing to clean protected database %q", database)
+	}
+	return nil
 }
 
 func (w *Writer) verifyDatabaseRealm(ctx context.Context, conn *sql.Conn) error {

--- a/internal/dbschema/mysql/writer.go
+++ b/internal/dbschema/mysql/writer.go
@@ -280,7 +280,13 @@ func (w *Writer) dropAllTablesOnConnection(
 			serverVersion,
 		)
 	}
-	if err := requireGlobalMetadataVisibility(ctx, conn, schema, w.dialect); err != nil {
+	if err := requireGlobalMetadataVisibility(
+		ctx,
+		conn,
+		schema,
+		w.dialect,
+		serverVersion,
+	); err != nil {
 		return err
 	}
 	return withForeignKeyChecksEnabled(ctx, conn, func() error {
@@ -308,6 +314,9 @@ func (w *Writer) dropDatabaseObjects(ctx context.Context, conn *sql.Conn, schema
 	if err := rejectExternalViews(ctx, conn, schema, w.dialect); err != nil {
 		return err
 	}
+	if err := rejectExternalStoredPrograms(ctx, conn, schema); err != nil {
+		return err
+	}
 	if err := w.dropProtectedViews(ctx, conn, schema, groups.views, groups.tables); err != nil {
 		return err
 	}
@@ -315,6 +324,9 @@ func (w *Writer) dropDatabaseObjects(ctx context.Context, conn *sql.Conn, schema
 		return err
 	}
 	if err := w.dropProtectedObjects(ctx, conn, schema, groups.tables); err != nil {
+		return err
+	}
+	if err := rejectExternalStoredPrograms(ctx, conn, schema); err != nil {
 		return err
 	}
 	return dropRemainingCleanupObjects(ctx, conn, schema, groups.remaining)
@@ -467,25 +479,93 @@ func (w *Writer) cleanupServerVersion(ctx context.Context, conn *sql.Conn) (stri
 	return version, nil
 }
 
+type globalMetadataPrivileges struct {
+	selectPrivilege       bool
+	dropPrivilege         bool
+	alterPrivilege        bool
+	alterRoutinePrivilege bool
+	eventPrivilege        bool
+	lockTablesPrivilege   bool
+	processPrivilege      bool
+	showViewPrivilege     bool
+	showRoutinePrivilege  bool
+	triggerPrivilege      bool
+}
+
+type globalMetadataRequirements struct {
+	names       string
+	showView    bool
+	showRoutine bool
+	trigger     bool
+}
+
+func (r globalMetadataRequirements) satisfiedBy(privileges globalMetadataPrivileges) bool {
+	return privileges.selectPrivilege &&
+		privileges.dropPrivilege &&
+		privileges.alterPrivilege &&
+		privileges.alterRoutinePrivilege &&
+		privileges.eventPrivilege &&
+		privileges.lockTablesPrivilege &&
+		privileges.processPrivilege &&
+		(!r.showView || privileges.showViewPrivilege) &&
+		(!r.showRoutine || privileges.showRoutinePrivilege) &&
+		(!r.trigger || privileges.triggerPrivilege)
+}
+
 func requireGlobalMetadataVisibility(
 	ctx context.Context,
 	conn *sql.Conn,
 	schema,
-	dialect string,
+	dialect,
+	serverVersion string,
 ) error {
-	privilegeNames := "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, and PROCESS"
-	if platform.NormalizeDialect(dialect) == platform.MariaDB {
-		privilegeNames = "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and SHOW VIEW"
+	requirements := metadataVisibilityRequirements(dialect, serverVersion)
+	privileges, err := readGlobalMetadataPrivileges(ctx, conn)
+	if err != nil {
+		return err
 	}
+	if !requirements.satisfiedBy(privileges) {
+		return fmt.Errorf(
+			"mysql: refusing to clean database %q: global %s privileges are required "+
+				"to prove complete metadata visibility and protect destructive DDL",
+			schema,
+			requirements.names,
+		)
+	}
+	return rejectPartialPrivilegeRevokes(ctx, conn, schema)
+}
 
-	var hasSelect bool
-	var hasDrop bool
-	var hasAlter bool
-	var hasAlterRoutine bool
-	var hasEvent bool
-	var hasLockTables bool
-	var hasProcess bool
-	var hasShowView bool
+func metadataVisibilityRequirements(dialect, serverVersion string) globalMetadataRequirements {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MariaDB:
+		return globalMetadataRequirements{
+			names:    "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and SHOW VIEW",
+			showView: true,
+		}
+	case platform.MySQL:
+		requiresShowRoutine := supportsMySQLShowRoutinePrivilege(serverVersion)
+		if requiresShowRoutine {
+			return globalMetadataRequirements{
+				names:       "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, SHOW_ROUTINE, and TRIGGER",
+				showRoutine: true,
+				trigger:     true,
+			}
+		}
+		return globalMetadataRequirements{
+			names:   "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and TRIGGER",
+			trigger: true,
+		}
+	}
+	return globalMetadataRequirements{
+		names: "SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, and PROCESS",
+	}
+}
+
+func readGlobalMetadataPrivileges(
+	ctx context.Context,
+	conn *sql.Conn,
+) (globalMetadataPrivileges, error) {
+	var privileges globalMetadataPrivileges
 	if err := conn.QueryRowContext(ctx, `
 		SELECT
 			COALESCE(MAX(privilege_type = 'SELECT'), 0),
@@ -495,7 +575,9 @@ func requireGlobalMetadataVisibility(
 			COALESCE(MAX(privilege_type = 'EVENT'), 0),
 			COALESCE(MAX(privilege_type = 'LOCK TABLES'), 0),
 			COALESCE(MAX(privilege_type = 'PROCESS'), 0),
-			COALESCE(MAX(privilege_type = 'SHOW VIEW'), 0)
+			COALESCE(MAX(privilege_type = 'SHOW VIEW'), 0),
+			COALESCE(MAX(privilege_type = 'SHOW_ROUTINE'), 0),
+			COALESCE(MAX(privilege_type = 'TRIGGER'), 0)
 		FROM information_schema.user_privileges
 		WHERE grantee = CONCAT(
 			QUOTE(SUBSTRING_INDEX(CURRENT_USER(), '@', 1)),
@@ -510,39 +592,28 @@ func requireGlobalMetadataVisibility(
 		    'EVENT',
 		    'LOCK TABLES',
 		    'PROCESS',
-		    'SHOW VIEW'
+		    'SHOW VIEW',
+		    'SHOW_ROUTINE',
+		    'TRIGGER'
 		  )
 	`).Scan(
-		&hasSelect,
-		&hasDrop,
-		&hasAlter,
-		&hasAlterRoutine,
-		&hasEvent,
-		&hasLockTables,
-		&hasProcess,
-		&hasShowView,
+		&privileges.selectPrivilege,
+		&privileges.dropPrivilege,
+		&privileges.alterPrivilege,
+		&privileges.alterRoutinePrivilege,
+		&privileges.eventPrivilege,
+		&privileges.lockTablesPrivilege,
+		&privileges.processPrivilege,
+		&privileges.showViewPrivilege,
+		&privileges.showRoutinePrivilege,
+		&privileges.triggerPrivilege,
 	); err != nil {
-		return fmt.Errorf("mysql: prove global metadata visibility: %w", err)
+		return globalMetadataPrivileges{}, fmt.Errorf("mysql: prove global metadata visibility: %w", err)
 	}
-	hasRequiredPrivileges := hasSelect &&
-		hasDrop &&
-		hasAlter &&
-		hasAlterRoutine &&
-		hasEvent &&
-		hasLockTables &&
-		hasProcess
-	if platform.NormalizeDialect(dialect) == platform.MariaDB {
-		hasRequiredPrivileges = hasRequiredPrivileges && hasShowView
-	}
-	if !hasRequiredPrivileges {
-		return fmt.Errorf(
-			"mysql: refusing to clean database %q: global %s privileges are required "+
-				"to prove complete metadata visibility and protect destructive DDL",
-			schema,
-			privilegeNames,
-		)
-	}
+	return privileges, nil
+}
 
+func rejectPartialPrivilegeRevokes(ctx context.Context, conn *sql.Conn, schema string) error {
 	rows, err := conn.QueryContext(ctx, "SHOW GRANTS")
 	if err != nil {
 		return fmt.Errorf("mysql: inspect metadata visibility restrictions: %w", err)
@@ -611,6 +682,9 @@ func (w *Writer) dropProtectedViews(
 		return err
 	}
 	if err := rejectExternalViews(ctx, lockConn, schema, w.dialect); err != nil {
+		return err
+	}
+	if err := rejectExternalStoredPrograms(ctx, lockConn, schema); err != nil {
 		return err
 	}
 
@@ -758,6 +832,9 @@ func (w *Writer) dropProtectedObjects(
 		return err
 	}
 	if err := rejectExternalViews(ctx, conn, schema, w.dialect); err != nil {
+		return err
+	}
+	if err := rejectExternalStoredPrograms(ctx, conn, schema); err != nil {
 		return err
 	}
 
@@ -908,21 +985,86 @@ func externalViewCount(ctx context.Context, conn *sql.Conn, schema, dialect stri
 }
 
 func supportsMySQLViewTableUsage(version string) bool {
+	parts, valid := parseMySQLVersion(version)
+	if !valid {
+		return false
+	}
+	if parts[0] != 8 {
+		return parts[0] > 8
+	}
+	return parts[1] > 0 || parts[2] >= 13
+}
+
+func supportsMySQLShowRoutinePrivilege(version string) bool {
+	parts, valid := parseMySQLVersion(version)
+	if !valid {
+		return false
+	}
+	if parts[0] != 8 {
+		return parts[0] > 8
+	}
+	return parts[1] > 0 || parts[2] >= 20
+}
+
+func parseMySQLVersion(version string) ([3]int, bool) {
 	numericVersion, _, _ := strings.Cut(version, "-")
 	parts := strings.Split(numericVersion, ".")
 	if len(parts) < 3 {
-		return false
+		return [3]int{}, false
 	}
 	major, majorErr := strconv.Atoi(parts[0])
 	minor, minorErr := strconv.Atoi(parts[1])
 	patch, patchErr := strconv.Atoi(parts[2])
 	if majorErr != nil || minorErr != nil || patchErr != nil {
-		return false
+		return [3]int{}, false
 	}
-	if major != 8 {
-		return major > 8
+	return [3]int{major, minor, patch}, true
+}
+
+func rejectExternalStoredPrograms(ctx context.Context, conn *sql.Conn, schema string) error {
+	var externalSchema string
+	var name string
+	var kind string
+	err := conn.QueryRowContext(ctx, `
+		SELECT object_schema, object_name, object_kind
+		FROM (
+			SELECT
+				routine_schema AS object_schema,
+				routine_name AS object_name,
+				routine_type AS object_kind
+			FROM information_schema.routines
+			WHERE routine_schema <> ?
+			  AND routine_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+
+			UNION ALL
+
+			SELECT event_schema, event_name, 'EVENT'
+			FROM information_schema.events
+			WHERE event_schema <> ?
+			  AND event_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+
+			UNION ALL
+
+			SELECT trigger_schema, trigger_name, 'TRIGGER'
+			FROM information_schema.triggers
+			WHERE trigger_schema <> ?
+			  AND trigger_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+		) AS external_stored_programs
+		ORDER BY object_schema, object_kind, object_name
+		LIMIT 1
+	`, schema, schema, schema).Scan(&externalSchema, &name, &kind)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
 	}
-	return minor > 0 || patch >= 13
+	if err != nil {
+		return fmt.Errorf("mysql: inspect external stored programs: %w", err)
+	}
+	return fmt.Errorf(
+		"mysql: refusing to clean database %q: external %s %s may reference the cleanup realm",
+		schema,
+		strings.ToLower(kind),
+		quoteQualifiedIdent(externalSchema, name),
+	)
 }
 
 func mySQLExternalViewCount(ctx context.Context, conn *sql.Conn, schema string) (int, error) {

--- a/internal/dbschema/mysql/writer_context_test.go
+++ b/internal/dbschema/mysql/writer_context_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/internal/dbschema/dbtest"
 	"github.com/stokaro/ptah/internal/dbschema/mysql"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 func TestWriterDropAllTables_RestoresForeignKeyChecksAfterCancellation(t *testing.T) {
@@ -26,14 +28,16 @@ func TestWriterDropAllTables_RestoresForeignKeyChecksAfterCancellation(t *testin
 		dropErr:      context.Canceled,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(ctx)
 
 	c.Assert(err, qt.ErrorIs, context.Canceled)
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
 		"SET FOREIGN_KEY_CHECKS = 1",
+		"LOCK TABLES `test`.`users` WRITE",
 		"DROP TABLE IF EXISTS `test`.`users`",
+		"UNLOCK TABLES",
 		"SET FOREIGN_KEY_CHECKS = 0",
 	})
 }
@@ -47,7 +51,7 @@ func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
 		restoreErr: restoreErr,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -55,7 +59,9 @@ func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, restoreErr)
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
 		"SET FOREIGN_KEY_CHECKS = 1",
+		"LOCK TABLES `test`.`users` WRITE",
 		"DROP TABLE IF EXISTS `test`.`users`",
+		"UNLOCK TABLES",
 		"SET FOREIGN_KEY_CHECKS = 0",
 	})
 }
@@ -64,16 +70,49 @@ func TestWriterDropAllTables_TemporarilyEnablesForeignKeyChecks(t *testing.T) {
 	c := qt.New(t)
 	recorder := &mysqlCleanupRecorder{}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
 		"SET FOREIGN_KEY_CHECKS = 1",
+		"LOCK TABLES `test`.`users` WRITE",
 		"DROP TABLE IF EXISTS `test`.`users`",
+		"UNLOCK TABLES",
 		"SET FOREIGN_KEY_CHECKS = 0",
 	})
+}
+
+func TestWriterDropDatabaseRealm_UsesPinnedConnectionForVerification(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		objects:          [][]driver.Value{},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	db.SQL.SetMaxOpenConns(1)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+	conn, err := db.SQL.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	writer := mysql.NewMySQLWriterForPinnedRunner(
+		sqlrunner.NewConn(ctx, conn),
+		db.SQL,
+		conn,
+		"test",
+		platform.MySQL,
+		"8.0.13",
+	)
+
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(recorder.catalogCount(), qt.Equals, 2)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
 }
 
 func TestWriterDropAllTables_RestoresAfterEnableFailure(t *testing.T) {
@@ -83,7 +122,7 @@ func TestWriterDropAllTables_RestoresAfterEnableFailure(t *testing.T) {
 		enableErr: enableErr,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -101,7 +140,7 @@ func TestWriterDropAllTables_RejectsCrossDatabaseForeignKeys(t *testing.T) {
 		externalForeignKeys: 2,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -116,7 +155,7 @@ func TestWriterDropAllTables_RejectsCrossDatabaseViews(t *testing.T) {
 		externalViews:    2,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -137,7 +176,7 @@ func TestWriterDropAllTables_RejectsMariaDBCrossDatabaseViews(t *testing.T) {
 		externalViews:    2,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MariaDB)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MariaDB, "10.11.15-MariaDB")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -152,6 +191,291 @@ func TestWriterDropAllTables_RejectsMariaDBCrossDatabaseViews(t *testing.T) {
 	})
 }
 
+func TestWriterDropAllTables_FailsClosedWithoutGlobalMetadataVisibility(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:        1,
+		missingGlobalPrivileges: true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, and PROCESS privileges are required `+
+			`to prove complete metadata visibility and protect destructive DDL`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_FailsClosedForPartialPrivilegeRevokes(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:        1,
+		partialPrivilegeRevokes: true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": partial privilege revokes `+
+			`prevent proving complete metadata visibility`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RequiresMariaDBViewVisibility(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:        1,
+		missingGlobalPrivileges: true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MariaDB, "10.11.15-MariaDB")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and SHOW VIEW privileges are required `+
+			`to prove complete metadata visibility and protect destructive DDL`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RefusesLegacyMySQLViewMetadata(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{foreignKeyChecks: 1}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.12")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": server version "8.0.12" lacks `+
+			`information_schema.VIEW_TABLE_USAGE required for complete external-view dependency checks`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_FailsClosedWhenViewInspectionFails(t *testing.T) {
+	c := qt.New(t)
+	inspectionErr := errors.New("view metadata unavailable")
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		viewQueryErr:     inspectionErr,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, inspectionErr)
+	c.Assert(err, qt.ErrorMatches, "mysql: inspect cross-database views: view metadata unavailable")
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RejectsForeignKeyCreatedBeforeLockedRecheck(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:         1,
+		externalForeignKeyCounts: []int{0, 1},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": 1 foreign key constraints from other databases reference it`,
+	)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"LOCK TABLES `test`.`users` WRITE",
+		"UNLOCK TABLES",
+	})
+}
+
+func TestWriterDropAllTables_RejectsViewCreatedBeforeLockedRecheck(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:   1,
+		externalViewCounts: []int{0, 1},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing to clean database "test": 1 views from other databases reference it`,
+	)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"LOCK TABLES `test`.`users` WRITE",
+		"UNLOCK TABLES",
+	})
+}
+
+func TestWriterDropAllTables_DropsManagedViewsThroughProtectedHandoff(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		version string
+	}{
+		{
+			name:    "mysql",
+			dialect: platform.MySQL,
+			version: "8.0.13",
+		},
+		{
+			name:    "mariadb",
+			dialect: platform.MariaDB,
+			version: "10.11.15-MariaDB",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			recorder := &mysqlCleanupRecorder{
+				foreignKeyChecks: 1,
+				viewDropStarted:  make(chan struct{}),
+				viewDropRelease:  make(chan struct{}),
+				internalForeignKeys: [][]driver.Value{
+					{"users", "fk_users_account"},
+				},
+				objects: [][]driver.Value{
+					{"active_users", "VIEW"},
+					{"users", "TABLE"},
+				},
+			}
+			db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+			writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", test.dialect, test.version)
+
+			err := writer.DropAllTables(t.Context())
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(recorder.statements(), qt.DeepEquals, []string{
+				"LOCK TABLES `test`.`active_users` WRITE, `test`.`users` WRITE",
+				"DROP VIEW IF EXISTS `test`.`active_users`",
+				"UNLOCK TABLES",
+				"ALTER TABLE `test`.`users` DROP FOREIGN KEY `fk_users_account`",
+				"LOCK TABLES `test`.`users` WRITE",
+				"DROP TABLE IF EXISTS `test`.`users`",
+				"UNLOCK TABLES",
+			})
+		})
+	}
+}
+
+func TestWriterDropAllTables_RejectsCompetingMetadataLockWaiter(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:         1,
+		otherMetadataLockWaiters: 1,
+		viewDropStarted:          make(chan struct{}),
+		viewDropRelease:          make(chan struct{}),
+		objects: [][]driver.Value{
+			{"active_users", "VIEW"},
+			{"users", "TABLE"},
+		},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: refusing view cleanup: 1 competing metadata-lock waiters appeared before the protected DROP VIEW handoff`,
+	)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"LOCK TABLES `test`.`active_users` WRITE, `test`.`users` WRITE",
+		"DROP VIEW IF EXISTS `test`.`active_users`",
+		"UNLOCK TABLES",
+	})
+}
+
+func TestWriterDropAllTables_ReturnsImmediateViewDropFailure(t *testing.T) {
+	c := qt.New(t)
+	viewDropErr := errors.New("view drop failed before waiting")
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		viewDropStarted:  make(chan struct{}),
+		viewDropErr:      viewDropErr,
+		objects: [][]driver.Value{
+			{"active_users", "VIEW"},
+			{"users", "TABLE"},
+		},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, viewDropErr)
+	c.Assert(err, qt.ErrorMatches,
+		"failed to drop view active_users: SQL execution failed: view drop failed before waiting\n"+
+			"SQL: DROP VIEW IF EXISTS `test`.`active_users`",
+	)
+	statements := recorder.statements()
+	c.Assert(statements, qt.ContentEquals, []string{
+		"LOCK TABLES `test`.`active_users` WRITE, `test`.`users` WRITE",
+		"DROP VIEW IF EXISTS `test`.`active_users`",
+		"UNLOCK TABLES",
+	})
+}
+
+func TestWriterDropAllTables_AcceptsImmediateViewDropCompletion(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		viewDropStarted:  make(chan struct{}),
+		objects: [][]driver.Value{
+			{"active_users", "VIEW"},
+			{"users", "TABLE"},
+		},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	statements := recorder.statements()
+	c.Assert(statements, qt.ContentEquals, []string{
+		"LOCK TABLES `test`.`active_users` WRITE, `test`.`users` WRITE",
+		"DROP VIEW IF EXISTS `test`.`active_users`",
+		"UNLOCK TABLES",
+		"LOCK TABLES `test`.`users` WRITE",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"UNLOCK TABLES",
+	})
+}
+
+func TestWriterDropAllTables_ReservesAuxiliaryConnectionsBeforeLocking(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		objects: [][]driver.Value{
+			{"active_users", "VIEW"},
+			{"users", "TABLE"},
+		},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	db.SQL.SetMaxOpenConns(2)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+
+	err := writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.ErrorMatches,
+		`mysql: acquire metadata-lock monitor connection: context deadline exceeded`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
 func TestWriterDropAllTables_DropsAllSupportedObjects(t *testing.T) {
 	c := qt.New(t)
 	recorder := &mysqlCleanupRecorder{
@@ -162,7 +486,6 @@ func TestWriterDropAllTables_DropsAllSupportedObjects(t *testing.T) {
 		},
 		objects: [][]driver.Value{
 			{"nightly_cleanup", "EVENT"},
-			{"active_users", "VIEW"},
 			{"normalize_email", "FUNCTION"},
 			{"refresh_users", "PROCEDURE"},
 			{"users", "TABLE"},
@@ -170,7 +493,7 @@ func TestWriterDropAllTables_DropsAllSupportedObjects(t *testing.T) {
 		},
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -178,11 +501,12 @@ func TestWriterDropAllTables_DropsAllSupportedObjects(t *testing.T) {
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
 		"ALTER TABLE `test`.`child``records` DROP FOREIGN KEY `fk``parent`",
 		"ALTER TABLE `test`.`users` DROP FOREIGN KEY `fk_users_account`",
+		"LOCK TABLES `test`.`users` WRITE",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"UNLOCK TABLES",
 		"DROP EVENT IF EXISTS `test`.`nightly_cleanup`",
-		"DROP VIEW IF EXISTS `test`.`active_users`",
 		"DROP FUNCTION IF EXISTS `test`.`normalize_email`",
 		"DROP PROCEDURE IF EXISTS `test`.`refresh_users`",
-		"DROP TABLE IF EXISTS `test`.`users`",
 		"DROP SEQUENCE IF EXISTS `test`.`order_numbers`",
 	})
 	catalogQuery, catalogArgs := recorder.catalog()
@@ -205,7 +529,7 @@ func TestWriterDropAllTables_FailsClosedWhenForeignKeyInspectionFails(t *testing
 		externalForeignKeyQueryErr: inspectionErr,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -225,7 +549,7 @@ func TestWriterDropAllTables_StopsWhenInternalForeignKeyDropFails(t *testing.T) 
 		foreignKeyDropErr: dropErr,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -247,7 +571,7 @@ func TestWriterDropAllTables_ReturnsQualifiedExecutionFailure(t *testing.T) {
 		dropErr:          errors.New("boom"),
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
 
 	err := writer.DropAllTables(t.Context())
 
@@ -259,15 +583,27 @@ type mysqlCleanupRecorder struct {
 	statementsSeen             []string
 	foreignKeyChecks           int
 	externalForeignKeys        int
+	externalForeignKeyCounts   []int
 	externalViews              int
+	externalViewCounts         []int
 	internalForeignKeys        [][]driver.Value
 	objects                    [][]driver.Value
 	catalogQuery               string
 	catalogArgs                []driver.NamedValue
+	catalogQueries             int
 	viewCatalogQuery           string
 	viewCatalogArgs            []driver.NamedValue
 	cancelOnDrop               context.CancelFunc
 	externalForeignKeyQueryErr error
+	viewQueryErr               error
+	missingGlobalPrivileges    bool
+	partialPrivilegeRevokes    bool
+	viewDropStarted            chan struct{}
+	viewDropStartedOnce        sync.Once
+	viewDropRelease            chan struct{}
+	viewDropReleaseOnce        sync.Once
+	viewDropErr                error
+	otherMetadataLockWaiters   int
 	enableErr                  error
 	foreignKeyDropErr          error
 	dropErr                    error
@@ -279,6 +615,70 @@ func (rec *mysqlCleanupRecorder) query(
 	args []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
 	switch {
+	case strings.Contains(query, "information_schema.user_privileges"):
+		hasSelect := int64(1)
+		hasDrop := int64(1)
+		hasAlter := int64(1)
+		hasAlterRoutine := int64(1)
+		hasEvent := int64(1)
+		hasLockTables := int64(1)
+		hasProcess := int64(1)
+		hasShowView := int64(1)
+		if rec.missingGlobalPrivileges {
+			hasDrop = 0
+			hasAlter = 0
+			hasAlterRoutine = 0
+			hasEvent = 0
+			hasLockTables = 0
+			hasProcess = 0
+			hasShowView = 0
+		}
+		return dbtest.QueryResult{
+			Columns: []string{
+				"has_select",
+				"has_drop",
+				"has_alter",
+				"has_alter_routine",
+				"has_event",
+				"has_lock_tables",
+				"has_process",
+				"has_show_view",
+			},
+			Rows: [][]driver.Value{{
+				hasSelect,
+				hasDrop,
+				hasAlter,
+				hasAlterRoutine,
+				hasEvent,
+				hasLockTables,
+				hasProcess,
+				hasShowView,
+			}},
+		}, nil
+	case strings.Contains(query, "SHOW GRANTS"):
+		grant := "GRANT SELECT, LOCK TABLES, PROCESS, SHOW VIEW ON *.* TO `ptah`@`%`"
+		if rec.partialPrivilegeRevokes {
+			grant = "REVOKE SELECT ON `hidden`.* FROM `ptah`@`%`"
+		}
+		return dbtest.QueryResult{
+			Columns: []string{"grants"},
+			Rows:    [][]driver.Value{{grant}},
+		}, nil
+	case strings.Contains(query, "SELECT CONNECTION_ID()"):
+		return dbtest.QueryResult{
+			Columns: []string{"connection_id"},
+			Rows:    [][]driver.Value{{int64(42)}},
+		}, nil
+	case strings.Contains(query, "information_schema.processlist"):
+		rec.waitForViewDropStart()
+		rec.releaseViewDropForCompetingWaiter()
+		return dbtest.QueryResult{
+			Columns: []string{"owned_waiters", "other_waiters"},
+			Rows: [][]driver.Value{{
+				int64(1),
+				int64(rec.otherMetadataLockWaiters),
+			}},
+		}, nil
 	case strings.Contains(query, "@@SESSION.FOREIGN_KEY_CHECKS"):
 		return dbtest.QueryResult{
 			Columns: []string{"foreign_key_checks"},
@@ -293,26 +693,36 @@ func (rec *mysqlCleanupRecorder) query(
 		if rec.externalForeignKeyQueryErr != nil {
 			return dbtest.QueryResult{}, rec.externalForeignKeyQueryErr
 		}
+		count := rec.nextExternalForeignKeyCount()
 		return dbtest.QueryResult{
 			Columns: []string{"count"},
-			Rows:    [][]driver.Value{{int64(rec.externalForeignKeys)}},
+			Rows:    [][]driver.Value{{int64(count)}},
 		}, nil
 	case strings.Contains(query, "information_schema.view_table_usage"):
 		rec.recordViewCatalog(query, args)
+		if rec.viewQueryErr != nil {
+			return dbtest.QueryResult{}, rec.viewQueryErr
+		}
+		count := rec.nextExternalViewCount()
 		return dbtest.QueryResult{
 			Columns: []string{"count"},
-			Rows:    [][]driver.Value{{int64(rec.externalViews)}},
+			Rows:    [][]driver.Value{{int64(count)}},
 		}, nil
 	case strings.Contains(query, "information_schema.views"):
 		rec.recordViewCatalog(query, args)
+		if rec.viewQueryErr != nil {
+			return dbtest.QueryResult{}, rec.viewQueryErr
+		}
+		count := rec.nextExternalViewCount()
 		return dbtest.QueryResult{
 			Columns: []string{"count"},
-			Rows:    [][]driver.Value{{int64(rec.externalViews)}},
+			Rows:    [][]driver.Value{{int64(count)}},
 		}, nil
 	case strings.Contains(query, "cleanup_objects"):
 		rec.mu.Lock()
 		rec.catalogQuery = query
 		rec.catalogArgs = append([]driver.NamedValue(nil), args...)
+		rec.catalogQueries++
 		rec.mu.Unlock()
 		objects := rec.objects
 		if objects == nil {
@@ -339,12 +749,17 @@ func (rec *mysqlCleanupRecorder) exec(
 	enableErr := rec.enableErr
 	foreignKeyDropErr := rec.foreignKeyDropErr
 	dropErr := rec.dropErr
+	viewDropErr := rec.viewDropErr
 	restoreErr := rec.restoreErr
 	rec.mu.Unlock()
+	rec.recordViewDropStart(statement)
 
 	switch {
 	case statement == "SET FOREIGN_KEY_CHECKS = 1" && enableErr != nil:
 		return nil, enableErr
+	case strings.HasPrefix(statement, "DROP VIEW"):
+		rec.waitForViewDropRelease()
+		return driver.RowsAffected(0), viewDropErr
 	case strings.HasPrefix(statement, "ALTER TABLE") && foreignKeyDropErr != nil:
 		return nil, foreignKeyDropErr
 	case strings.HasPrefix(statement, "DROP TABLE") && dropErr != nil:
@@ -352,11 +767,71 @@ func (rec *mysqlCleanupRecorder) exec(
 			cancelOnDrop()
 		}
 		return nil, dropErr
+	case statement == "UNLOCK TABLES":
+		rec.releaseViewDrop()
+		return driver.RowsAffected(0), nil
 	case statement == "SET FOREIGN_KEY_CHECKS = 0" && restoreErr != nil:
 		return nil, restoreErr
 	default:
 		return driver.RowsAffected(0), nil
 	}
+}
+
+func (rec *mysqlCleanupRecorder) recordViewDropStart(statement string) {
+	if rec.viewDropStarted == nil || !strings.HasPrefix(statement, "DROP VIEW") {
+		return
+	}
+	rec.viewDropStartedOnce.Do(func() {
+		close(rec.viewDropStarted)
+	})
+}
+
+func (rec *mysqlCleanupRecorder) waitForViewDropStart() {
+	if rec.viewDropStarted != nil {
+		<-rec.viewDropStarted
+	}
+}
+
+func (rec *mysqlCleanupRecorder) waitForViewDropRelease() {
+	if rec.viewDropRelease != nil {
+		<-rec.viewDropRelease
+	}
+}
+
+func (rec *mysqlCleanupRecorder) releaseViewDrop() {
+	if rec.viewDropRelease != nil {
+		rec.viewDropReleaseOnce.Do(func() {
+			close(rec.viewDropRelease)
+		})
+	}
+}
+
+func (rec *mysqlCleanupRecorder) releaseViewDropForCompetingWaiter() {
+	if rec.otherMetadataLockWaiters > 0 {
+		rec.releaseViewDrop()
+	}
+}
+
+func (rec *mysqlCleanupRecorder) nextExternalForeignKeyCount() int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.externalForeignKeyCounts) == 0 {
+		return rec.externalForeignKeys
+	}
+	count := rec.externalForeignKeyCounts[0]
+	rec.externalForeignKeyCounts = rec.externalForeignKeyCounts[1:]
+	return count
+}
+
+func (rec *mysqlCleanupRecorder) nextExternalViewCount() int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.externalViewCounts) == 0 {
+		return rec.externalViews
+	}
+	count := rec.externalViewCounts[0]
+	rec.externalViewCounts = rec.externalViewCounts[1:]
+	return count
 }
 
 func (rec *mysqlCleanupRecorder) statements() []string {
@@ -369,6 +844,12 @@ func (rec *mysqlCleanupRecorder) catalog() (string, []driver.NamedValue) {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	return rec.catalogQuery, append([]driver.NamedValue(nil), rec.catalogArgs...)
+}
+
+func (rec *mysqlCleanupRecorder) catalogCount() int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return rec.catalogQueries
 }
 
 func (rec *mysqlCleanupRecorder) recordViewCatalog(query string, args []driver.NamedValue) {

--- a/internal/dbschema/mysql/writer_context_test.go
+++ b/internal/dbschema/mysql/writer_context_test.go
@@ -115,6 +115,72 @@ func TestWriterDropDatabaseRealm_UsesPinnedConnectionForVerification(t *testing.
 	c.Assert(recorder.statements(), qt.HasLen, 0)
 }
 
+func TestWriterDropDatabaseRealm_RejectsProtectedDatabasesBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	tests := []string{
+		"information_schema",
+		"METRICS_SCHEMA",
+		"mysql",
+		"mysql_innodb_cluster_metadata",
+		"mysql_innodb_cluster_metadata_backup",
+		"mysql_innodb_cluster_metadata_bkp",
+		"mysql_innodb_cluster_metadata_previous",
+		"ndbinfo",
+		"performance_schema",
+		"sys",
+	}
+
+	for _, database := range tests {
+		c.Run(database, func(c *qt.C) {
+			recorder := &mysqlCleanupRecorder{}
+			db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+			writer := mysql.NewMySQLWriterWithServerVersion(
+				db.SQL,
+				database,
+				platform.MySQL,
+				"8.0.13",
+			)
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`mysql: refusing to clean protected database ".*"`,
+			)
+			c.Assert(db.QueryCount(), qt.Equals, 0)
+			c.Assert(recorder.statements(), qt.HasLen, 0)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_RejectsProtectedSelectedDatabaseBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{}
+	db := dbtest.OpenWithExec(t, func(
+		query string,
+		_ []driver.NamedValue,
+	) (dbtest.QueryResult, error) {
+		c.Assert(query, qt.Equals, "SELECT DATABASE()")
+		return dbtest.QueryResult{
+			Columns: []string{"database"},
+			Rows:    [][]driver.Value{{"mysql"}},
+		}, nil
+	}, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(
+		db.SQL,
+		"",
+		platform.MySQL,
+		"8.0.13",
+	)
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `mysql: refusing to clean protected database "mysql"`)
+	c.Assert(db.QueryCount(), qt.Equals, 1)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
 func TestWriterDropAllTables_RestoresAfterEnableFailure(t *testing.T) {
 	c := qt.New(t)
 	enableErr := errors.New("enable outcome unknown")

--- a/internal/dbschema/mysql/writer_context_test.go
+++ b/internal/dbschema/mysql/writer_context_test.go
@@ -257,6 +257,52 @@ func TestWriterDropAllTables_RejectsMariaDBCrossDatabaseViews(t *testing.T) {
 	})
 }
 
+func TestWriterDropAllTables_RejectsExternalStoredProgramsBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name   string
+		schema string
+		object string
+		kind   string
+	}{
+		{name: "function", schema: "reporting", object: "load_events", kind: "FUNCTION"},
+		{name: "procedure", schema: "reporting", object: "refresh_events", kind: "PROCEDURE"},
+		{name: "event", schema: "scheduler", object: "nightly_rollup", kind: "EVENT"},
+		{name: "trigger", schema: "audit", object: "capture_event", kind: "TRIGGER"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			recorder := &mysqlCleanupRecorder{
+				foreignKeyChecks: 1,
+				externalStoredPrograms: [][]driver.Value{{
+					test.schema,
+					test.object,
+					test.kind,
+				}},
+			}
+			db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+			writer := mysql.NewMySQLWriterWithServerVersion(
+				db.SQL,
+				"test",
+				platform.MySQL,
+				"8.0.13",
+			)
+
+			err := writer.DropAllTables(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`mysql: refusing to clean database "test": external `+
+					strings.ToLower(test.kind)+
+					" `"+test.schema+"`.`"+test.object+"` may reference the cleanup realm",
+			)
+			c.Assert(recorder.statements(), qt.HasLen, 0)
+		})
+	}
+}
+
 func TestWriterDropAllTables_FailsClosedWithoutGlobalMetadataVisibility(t *testing.T) {
 	c := qt.New(t)
 	recorder := &mysqlCleanupRecorder{
@@ -269,10 +315,71 @@ func TestWriterDropAllTables_FailsClosedWithoutGlobalMetadataVisibility(t *testi
 	err := writer.DropAllTables(t.Context())
 
 	c.Assert(err, qt.ErrorMatches,
-		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, and PROCESS privileges are required `+
+		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, and TRIGGER privileges are required `+
 			`to prove complete metadata visibility and protect destructive DDL`,
 	)
 	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RequiresShowRoutineOnModernMySQL(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:   1,
+		missingShowRoutine: true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "9.7.1")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, `+
+			`EVENT, LOCK TABLES, PROCESS, SHOW_ROUTINE, and TRIGGER privileges are required `+
+			`to prove complete metadata visibility and protect destructive DDL`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RequiresTriggerVisibilityOnMySQL(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		missingTrigger:   true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(db.SQL, "test", platform.MySQL, "8.0.13")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`mysql: refusing to clean database "test": global SELECT, DROP, ALTER, ALTER ROUTINE, `+
+			`EVENT, LOCK TABLES, PROCESS, and TRIGGER privileges are required `+
+			`to prove complete metadata visibility and protect destructive DDL`,
+	)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_DoesNotRequireTriggerVisibilityOnMariaDB(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		missingTrigger:   true,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriterWithServerVersion(
+		db.SQL,
+		"test",
+		platform.MariaDB,
+		"10.11.15-MariaDB",
+	)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
 }
 
 func TestWriterDropAllTables_FailsClosedForPartialPrivilegeRevokes(t *testing.T) {
@@ -662,8 +769,12 @@ type mysqlCleanupRecorder struct {
 	cancelOnDrop               context.CancelFunc
 	externalForeignKeyQueryErr error
 	viewQueryErr               error
+	storedProgramQueryErr      error
 	missingGlobalPrivileges    bool
+	missingShowRoutine         bool
+	missingTrigger             bool
 	partialPrivilegeRevokes    bool
+	externalStoredPrograms     [][]driver.Value
 	viewDropStarted            chan struct{}
 	viewDropStartedOnce        sync.Once
 	viewDropRelease            chan struct{}
@@ -690,6 +801,8 @@ func (rec *mysqlCleanupRecorder) query(
 		hasLockTables := int64(1)
 		hasProcess := int64(1)
 		hasShowView := int64(1)
+		hasShowRoutine := int64(1)
+		hasTrigger := int64(1)
 		if rec.missingGlobalPrivileges {
 			hasDrop = 0
 			hasAlter = 0
@@ -698,6 +811,14 @@ func (rec *mysqlCleanupRecorder) query(
 			hasLockTables = 0
 			hasProcess = 0
 			hasShowView = 0
+			hasShowRoutine = 0
+			hasTrigger = 0
+		}
+		if rec.missingShowRoutine {
+			hasShowRoutine = 0
+		}
+		if rec.missingTrigger {
+			hasTrigger = 0
 		}
 		return dbtest.QueryResult{
 			Columns: []string{
@@ -709,6 +830,8 @@ func (rec *mysqlCleanupRecorder) query(
 				"has_lock_tables",
 				"has_process",
 				"has_show_view",
+				"has_show_routine",
+				"has_trigger",
 			},
 			Rows: [][]driver.Value{{
 				hasSelect,
@@ -719,6 +842,8 @@ func (rec *mysqlCleanupRecorder) query(
 				hasLockTables,
 				hasProcess,
 				hasShowView,
+				hasShowRoutine,
+				hasTrigger,
 			}},
 		}, nil
 	case strings.Contains(query, "SHOW GRANTS"):
@@ -783,6 +908,14 @@ func (rec *mysqlCleanupRecorder) query(
 		return dbtest.QueryResult{
 			Columns: []string{"count"},
 			Rows:    [][]driver.Value{{int64(count)}},
+		}, nil
+	case strings.Contains(query, "external_stored_programs"):
+		if rec.storedProgramQueryErr != nil {
+			return dbtest.QueryResult{}, rec.storedProgramQueryErr
+		}
+		return dbtest.QueryResult{
+			Columns: []string{"object_schema", "object_name", "object_kind"},
+			Rows:    rec.externalStoredPrograms,
 		}, nil
 	case strings.Contains(query, "cleanup_objects"):
 		rec.mu.Lock()

--- a/internal/dbschema/mysql/writer_context_test.go
+++ b/internal/dbschema/mysql/writer_context_test.go
@@ -11,6 +11,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/internal/dbschema/dbtest"
 	"github.com/stokaro/ptah/internal/dbschema/mysql"
 )
@@ -25,15 +26,15 @@ func TestWriterDropAllTables_RestoresForeignKeyChecksAfterCancellation(t *testin
 		dropErr:      context.Canceled,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test")
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
 
 	err := writer.DropAllTables(ctx)
 
 	c.Assert(err, qt.ErrorIs, context.Canceled)
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
-		"SET FOREIGN_KEY_CHECKS = 0",
-		"DROP TABLE IF EXISTS `users`",
 		"SET FOREIGN_KEY_CHECKS = 1",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"SET FOREIGN_KEY_CHECKS = 0",
 	})
 }
 
@@ -46,38 +47,284 @@ func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
 		restoreErr: restoreErr,
 	}
 	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
-	writer := mysql.NewMySQLWriter(db.SQL, "test")
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
 
 	err := writer.DropAllTables(t.Context())
 
 	c.Assert(err, qt.ErrorIs, dropErr)
 	c.Assert(err, qt.ErrorIs, restoreErr)
 	c.Assert(recorder.statements(), qt.DeepEquals, []string{
-		"SET FOREIGN_KEY_CHECKS = 0",
-		"DROP TABLE IF EXISTS `users`",
 		"SET FOREIGN_KEY_CHECKS = 1",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"SET FOREIGN_KEY_CHECKS = 0",
 	})
 }
 
+func TestWriterDropAllTables_TemporarilyEnablesForeignKeyChecks(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"SET FOREIGN_KEY_CHECKS = 1",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"SET FOREIGN_KEY_CHECKS = 0",
+	})
+}
+
+func TestWriterDropAllTables_RestoresAfterEnableFailure(t *testing.T) {
+	c := qt.New(t)
+	enableErr := errors.New("enable outcome unknown")
+	recorder := &mysqlCleanupRecorder{
+		enableErr: enableErr,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, enableErr)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"SET FOREIGN_KEY_CHECKS = 1",
+		"SET FOREIGN_KEY_CHECKS = 0",
+	})
+}
+
+func TestWriterDropAllTables_RejectsCrossDatabaseForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:    1,
+		externalForeignKeys: 2,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `mysql: refusing to clean database "test": 2 foreign key constraints from other databases reference it`)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_RejectsCrossDatabaseViews(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		externalViews:    2,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `mysql: refusing to clean database "test": 2 views from other databases reference it`)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+	viewQuery, viewArgs := recorder.viewCatalog()
+	c.Assert(viewQuery, qt.Contains, "information_schema.view_table_usage")
+	c.Assert(viewArgs, qt.DeepEquals, []driver.NamedValue{
+		{Ordinal: 1, Value: "test"},
+		{Ordinal: 2, Value: "test"},
+	})
+}
+
+func TestWriterDropAllTables_RejectsMariaDBCrossDatabaseViews(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		externalViews:    2,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MariaDB)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `mysql: refusing to clean database "test": 2 views from other databases reference it`)
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+	viewQuery, viewArgs := recorder.viewCatalog()
+	c.Assert(viewQuery, qt.Contains, "information_schema.views")
+	c.Assert(viewQuery, qt.Contains, "INSTR(view_definition, ?)")
+	c.Assert(viewArgs, qt.DeepEquals, []driver.NamedValue{
+		{Ordinal: 1, Value: "test"},
+		{Ordinal: 2, Value: "`test`."},
+	})
+}
+
+func TestWriterDropAllTables_DropsAllSupportedObjects(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		internalForeignKeys: [][]driver.Value{
+			{"child`records", "fk`parent"},
+			{"users", "fk_users_account"},
+		},
+		objects: [][]driver.Value{
+			{"nightly_cleanup", "EVENT"},
+			{"active_users", "VIEW"},
+			{"normalize_email", "FUNCTION"},
+			{"refresh_users", "PROCEDURE"},
+			{"users", "TABLE"},
+			{"order_numbers", "SEQUENCE"},
+		},
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"ALTER TABLE `test`.`child``records` DROP FOREIGN KEY `fk``parent`",
+		"ALTER TABLE `test`.`users` DROP FOREIGN KEY `fk_users_account`",
+		"DROP EVENT IF EXISTS `test`.`nightly_cleanup`",
+		"DROP VIEW IF EXISTS `test`.`active_users`",
+		"DROP FUNCTION IF EXISTS `test`.`normalize_email`",
+		"DROP PROCEDURE IF EXISTS `test`.`refresh_users`",
+		"DROP TABLE IF EXISTS `test`.`users`",
+		"DROP SEQUENCE IF EXISTS `test`.`order_numbers`",
+	})
+	catalogQuery, catalogArgs := recorder.catalog()
+	c.Assert(catalogQuery, qt.Contains, "information_schema.tables")
+	c.Assert(catalogQuery, qt.Contains, "information_schema.routines")
+	c.Assert(catalogQuery, qt.Contains, "information_schema.events")
+	c.Assert(catalogQuery, qt.Contains, "'SYSTEM VERSIONED'")
+	c.Assert(catalogArgs, qt.DeepEquals, []driver.NamedValue{
+		{Ordinal: 1, Value: "test"},
+		{Ordinal: 2, Value: "test"},
+		{Ordinal: 3, Value: "test"},
+	})
+}
+
+func TestWriterDropAllTables_FailsClosedWhenForeignKeyInspectionFails(t *testing.T) {
+	c := qt.New(t)
+	inspectionErr := errors.New("access denied")
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks:           1,
+		externalForeignKeyQueryErr: inspectionErr,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, inspectionErr)
+	c.Assert(err, qt.ErrorMatches, "mysql: inspect cross-database foreign keys: access denied")
+	c.Assert(recorder.statements(), qt.HasLen, 0)
+}
+
+func TestWriterDropAllTables_StopsWhenInternalForeignKeyDropFails(t *testing.T) {
+	c := qt.New(t)
+	dropErr := errors.New("cannot drop constraint")
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		internalForeignKeys: [][]driver.Value{
+			{"users", "fk_users_account"},
+		},
+		foreignKeyDropErr: dropErr,
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, dropErr)
+	c.Assert(err, qt.ErrorMatches,
+		"failed to drop foreign key fk_users_account on table users: "+
+			"SQL execution failed: cannot drop constraint\n"+
+			"SQL: ALTER TABLE `test`.`users` DROP FOREIGN KEY `fk_users_account`",
+	)
+	c.Assert(recorder.statements(), qt.DeepEquals, []string{
+		"ALTER TABLE `test`.`users` DROP FOREIGN KEY `fk_users_account`",
+	})
+}
+
+func TestWriterDropAllTables_ReturnsQualifiedExecutionFailure(t *testing.T) {
+	c := qt.New(t)
+	recorder := &mysqlCleanupRecorder{
+		foreignKeyChecks: 1,
+		dropErr:          errors.New("boom"),
+	}
+	db := dbtest.OpenWithExec(t, recorder.query, recorder.exec)
+	writer := mysql.NewMySQLWriter(db.SQL, "test", platform.MySQL)
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, "failed to drop table users: SQL execution failed: boom\nSQL: DROP TABLE IF EXISTS `test`.`users`")
+}
+
 type mysqlCleanupRecorder struct {
-	mu             sync.Mutex
-	statementsSeen []string
-	cancelOnDrop   context.CancelFunc
-	dropErr        error
-	restoreErr     error
+	mu                         sync.Mutex
+	statementsSeen             []string
+	foreignKeyChecks           int
+	externalForeignKeys        int
+	externalViews              int
+	internalForeignKeys        [][]driver.Value
+	objects                    [][]driver.Value
+	catalogQuery               string
+	catalogArgs                []driver.NamedValue
+	viewCatalogQuery           string
+	viewCatalogArgs            []driver.NamedValue
+	cancelOnDrop               context.CancelFunc
+	externalForeignKeyQueryErr error
+	enableErr                  error
+	foreignKeyDropErr          error
+	dropErr                    error
+	restoreErr                 error
 }
 
 func (rec *mysqlCleanupRecorder) query(
 	query string,
-	_ []driver.NamedValue,
+	args []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
-	if !strings.Contains(query, "information_schema.tables") {
+	switch {
+	case strings.Contains(query, "@@SESSION.FOREIGN_KEY_CHECKS"):
+		return dbtest.QueryResult{
+			Columns: []string{"foreign_key_checks"},
+			Rows:    [][]driver.Value{{int64(rec.foreignKeyChecks)}},
+		}, nil
+	case strings.Contains(query, "internal_foreign_keys"):
+		return dbtest.QueryResult{
+			Columns: []string{"table_name", "constraint_name"},
+			Rows:    rec.internalForeignKeys,
+		}, nil
+	case strings.Contains(query, "external_foreign_keys"):
+		if rec.externalForeignKeyQueryErr != nil {
+			return dbtest.QueryResult{}, rec.externalForeignKeyQueryErr
+		}
+		return dbtest.QueryResult{
+			Columns: []string{"count"},
+			Rows:    [][]driver.Value{{int64(rec.externalForeignKeys)}},
+		}, nil
+	case strings.Contains(query, "information_schema.view_table_usage"):
+		rec.recordViewCatalog(query, args)
+		return dbtest.QueryResult{
+			Columns: []string{"count"},
+			Rows:    [][]driver.Value{{int64(rec.externalViews)}},
+		}, nil
+	case strings.Contains(query, "information_schema.views"):
+		rec.recordViewCatalog(query, args)
+		return dbtest.QueryResult{
+			Columns: []string{"count"},
+			Rows:    [][]driver.Value{{int64(rec.externalViews)}},
+		}, nil
+	case strings.Contains(query, "cleanup_objects"):
+		rec.mu.Lock()
+		rec.catalogQuery = query
+		rec.catalogArgs = append([]driver.NamedValue(nil), args...)
+		rec.mu.Unlock()
+		objects := rec.objects
+		if objects == nil {
+			objects = [][]driver.Value{{"users", "TABLE"}}
+		}
+		return dbtest.QueryResult{
+			Columns: []string{"object_name", "object_kind"},
+			Rows:    objects,
+		}, nil
+	default:
 		return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
 	}
-	return dbtest.QueryResult{
-		Columns: []string{"table_name"},
-		Rows:    [][]driver.Value{{"users"}},
-	}, nil
 }
 
 func (rec *mysqlCleanupRecorder) exec(
@@ -89,17 +336,23 @@ func (rec *mysqlCleanupRecorder) exec(
 	rec.mu.Lock()
 	rec.statementsSeen = append(rec.statementsSeen, statement)
 	cancelOnDrop := rec.cancelOnDrop
+	enableErr := rec.enableErr
+	foreignKeyDropErr := rec.foreignKeyDropErr
 	dropErr := rec.dropErr
 	restoreErr := rec.restoreErr
 	rec.mu.Unlock()
 
 	switch {
+	case statement == "SET FOREIGN_KEY_CHECKS = 1" && enableErr != nil:
+		return nil, enableErr
+	case strings.HasPrefix(statement, "ALTER TABLE") && foreignKeyDropErr != nil:
+		return nil, foreignKeyDropErr
 	case strings.HasPrefix(statement, "DROP TABLE") && dropErr != nil:
 		if cancelOnDrop != nil {
 			cancelOnDrop()
 		}
 		return nil, dropErr
-	case statement == "SET FOREIGN_KEY_CHECKS = 1" && restoreErr != nil:
+	case statement == "SET FOREIGN_KEY_CHECKS = 0" && restoreErr != nil:
 		return nil, restoreErr
 	default:
 		return driver.RowsAffected(0), nil
@@ -110,4 +363,23 @@ func (rec *mysqlCleanupRecorder) statements() []string {
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	return append([]string(nil), rec.statementsSeen...)
+}
+
+func (rec *mysqlCleanupRecorder) catalog() (string, []driver.NamedValue) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return rec.catalogQuery, append([]driver.NamedValue(nil), rec.catalogArgs...)
+}
+
+func (rec *mysqlCleanupRecorder) recordViewCatalog(query string, args []driver.NamedValue) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	rec.viewCatalogQuery = query
+	rec.viewCatalogArgs = append([]driver.NamedValue(nil), args...)
+}
+
+func (rec *mysqlCleanupRecorder) viewCatalog() (string, []driver.NamedValue) {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return rec.viewCatalogQuery, append([]driver.NamedValue(nil), rec.viewCatalogArgs...)
 }

--- a/internal/dbschema/mysql/writer_live_test.go
+++ b/internal/dbschema/mysql/writer_live_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package mysql_test
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/dbschema/mysql"
+)
+
+func TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dsnEnv  string
+		dialect string
+	}{
+		{
+			name:    "mysql",
+			dsnEnv:  "MYSQL_ADMIN_TEST_DSN",
+			dialect: platform.MySQL,
+		},
+		{
+			name:    "mariadb",
+			dsnEnv:  "MARIADB_ADMIN_TEST_DSN",
+			dialect: platform.MariaDB,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db := openMySQLWriterLiveDatabase(c, test.dsnEnv)
+			c.Cleanup(func() {
+				c.Check(db.Close(), qt.IsNil)
+			})
+			writer := mysql.NewMySQLWriter(db, "mysql", test.dialect)
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(err, qt.ErrorMatches, `mysql: refusing to clean protected database "mysql"`)
+		})
+	}
+}
+
+func openMySQLWriterLiveDatabase(c *qt.C, dsnEnv string) *sql.DB {
+	c.Helper()
+	dsn := os.Getenv(dsnEnv)
+	if dsn == "" {
+		c.Skipf("%s is not set", dsnEnv)
+	}
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.PingContext(c.Context()), qt.IsNil)
+	return db
+}

--- a/internal/dbschema/mysql/writer_live_test.go
+++ b/internal/dbschema/mysql/writer_live_test.go
@@ -3,14 +3,19 @@
 package mysql_test
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/internal/dbschema/mysql"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
 func TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase(t *testing.T) {
@@ -47,6 +52,167 @@ func TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase(t *testing.T) {
 	}
 }
 
+func TestWriterDropDatabaseRealm_LiveRejectsExternalStoredProgram(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dsnEnv  string
+		dialect string
+	}{
+		{
+			name:    "mysql",
+			dsnEnv:  "MYSQL_ADMIN_TEST_DSN",
+			dialect: platform.MySQL,
+		},
+		{
+			name:    "mariadb",
+			dsnEnv:  "MARIADB_ADMIN_TEST_DSN",
+			dialect: platform.MariaDB,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db := openMySQLWriterLiveDatabase(c, test.dsnEnv)
+			c.Cleanup(func() {
+				c.Check(db.Close(), qt.IsNil)
+			})
+			suffix := time.Now().UnixNano()
+			target := fmt.Sprintf("ptah_realm_%d", suffix)
+			external := fmt.Sprintf("ptah_external_%d", suffix)
+			quotedTarget := sqlident.Quote(test.dialect, target)
+			quotedExternal := sqlident.Quote(test.dialect, external)
+			events := sqlident.Qualified(test.dialect, target, "events")
+			externalFunction := sqlident.Qualified(test.dialect, external, "event_count")
+			_, err := db.ExecContext(
+				t.Context(),
+				"CREATE DATABASE "+quotedTarget,
+			)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				_, cleanupErr := db.ExecContext(
+					cleanupCtx,
+					"DROP DATABASE IF EXISTS "+quotedTarget,
+				)
+				c.Check(cleanupErr, qt.IsNil)
+			})
+			_, err = db.ExecContext(t.Context(), "CREATE DATABASE "+quotedExternal)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				_, cleanupErr := db.ExecContext(
+					cleanupCtx,
+					"DROP DATABASE IF EXISTS "+quotedExternal,
+				)
+				c.Check(cleanupErr, qt.IsNil)
+			})
+			_, err = db.ExecContext(
+				t.Context(),
+				"CREATE TABLE "+events+" (id BIGINT PRIMARY KEY)",
+			)
+			c.Assert(err, qt.IsNil)
+			_, err = db.ExecContext(
+				t.Context(),
+				"CREATE FUNCTION "+externalFunction+
+					"() RETURNS BIGINT READS SQL DATA RETURN (SELECT COUNT(*) FROM "+events+")",
+			)
+			c.Assert(err, qt.IsNil)
+			writer := mysql.NewMySQLWriter(db, target, test.dialect)
+
+			err = writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, "external function "+externalFunction)
+			var tableCount int
+			err = db.QueryRowContext(
+				t.Context(),
+				"SELECT COUNT(*) FROM information_schema.tables "+
+					"WHERE table_schema = ? AND table_name = 'events'",
+				target,
+			).Scan(&tableCount)
+			c.Assert(err, qt.IsNil)
+			c.Assert(tableCount, qt.Equals, 1)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_LiveRejectsMissingTriggerPrivilege(t *testing.T) {
+	c := qt.New(t)
+	adminDB := openMySQLWriterLiveDatabase(c, "MYSQL_ADMIN_TEST_DSN")
+	c.Cleanup(func() {
+		c.Check(adminDB.Close(), qt.IsNil)
+	})
+
+	suffix := time.Now().UnixMilli()
+	target := fmt.Sprintf("ptah_trigger_target_%d", suffix)
+	external := fmt.Sprintf("ptah_trigger_external_%d", suffix)
+	username := fmt.Sprintf("ptah_no_trigger_%d", suffix)
+	password := "Ptah-test-2026!"
+	createMySQLWriterLiveDatabase(c, adminDB, target)
+	c.Cleanup(func() {
+		dropMySQLWriterLiveDatabase(c, adminDB, target)
+	})
+	createMySQLWriterLiveDatabase(c, adminDB, external)
+	c.Cleanup(func() {
+		dropMySQLWriterLiveDatabase(c, adminDB, external)
+	})
+	_, err := adminDB.ExecContext(
+		c.Context(),
+		"CREATE TABLE "+sqlident.Qualified(platform.MySQL, target, "events")+
+			" (id BIGINT PRIMARY KEY)",
+	)
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(
+		c.Context(),
+		"CREATE TABLE "+sqlident.Qualified(platform.MySQL, external, "source_events")+
+			" (id BIGINT PRIMARY KEY)",
+	)
+	c.Assert(err, qt.IsNil)
+	_, err = adminDB.ExecContext(
+		c.Context(),
+		"CREATE TRIGGER "+sqlident.Qualified(platform.MySQL, external, "capture_event")+
+			" BEFORE INSERT ON "+sqlident.Qualified(platform.MySQL, external, "source_events")+
+			" FOR EACH ROW INSERT INTO "+sqlident.Qualified(platform.MySQL, target, "events")+
+			" (id) VALUES (NEW.id)",
+	)
+	c.Assert(err, qt.IsNil)
+	createMySQLWriterLiveUser(c, adminDB, username, password)
+	c.Cleanup(func() {
+		dropMySQLWriterLiveUser(c, adminDB, username)
+	})
+	grantMySQLWriterLivePrivilegesWithoutTrigger(c, adminDB, username)
+
+	config, err := mysqldriver.ParseDSN(os.Getenv("MYSQL_ADMIN_TEST_DSN"))
+	c.Assert(err, qt.IsNil)
+	config.User = username
+	config.Passwd = password
+	config.DBName = target
+	restrictedDB, err := sql.Open("mysql", config.FormatDSN())
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(restrictedDB.Close(), qt.IsNil)
+	})
+	c.Assert(restrictedDB.PingContext(c.Context()), qt.IsNil)
+	writer := mysql.NewMySQLWriter(restrictedDB, target, platform.MySQL)
+
+	err = writer.DropDatabaseRealm(c.Context())
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "TRIGGER privileges are required")
+	var tableCount int
+	err = adminDB.QueryRowContext(
+		c.Context(),
+		"SELECT COUNT(*) FROM information_schema.tables "+
+			"WHERE table_schema = ? AND table_name = 'events'",
+		target,
+	).Scan(&tableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 1)
+}
+
 func openMySQLWriterLiveDatabase(c *qt.C, dsnEnv string) *sql.DB {
 	c.Helper()
 	dsn := os.Getenv(dsnEnv)
@@ -57,4 +223,54 @@ func openMySQLWriterLiveDatabase(c *qt.C, dsnEnv string) *sql.DB {
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.PingContext(c.Context()), qt.IsNil)
 	return db
+}
+
+func createMySQLWriterLiveDatabase(c *qt.C, db *sql.DB, name string) {
+	c.Helper()
+	_, err := db.ExecContext(
+		c.Context(),
+		"CREATE DATABASE "+sqlident.Quote(platform.MySQL, name),
+	)
+	c.Assert(err, qt.IsNil)
+}
+
+func dropMySQLWriterLiveDatabase(c *qt.C, db *sql.DB, name string) {
+	c.Helper()
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(
+		cleanupCtx,
+		"DROP DATABASE IF EXISTS "+sqlident.Quote(platform.MySQL, name),
+	)
+	c.Check(err, qt.IsNil)
+}
+
+func createMySQLWriterLiveUser(c *qt.C, db *sql.DB, username, password string) {
+	c.Helper()
+	//nolint:gosec // The generated username and fixed test password contain no SQL metacharacters.
+	query := fmt.Sprintf("CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", username, password)
+	_, err := db.ExecContext(c.Context(), query)
+	c.Assert(err, qt.IsNil)
+}
+
+func dropMySQLWriterLiveUser(c *qt.C, db *sql.DB, username string) {
+	c.Helper()
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	//nolint:gosec // The generated username contains no SQL metacharacters.
+	query := fmt.Sprintf("DROP USER IF EXISTS '%s'@'%%'", username)
+	_, err := db.ExecContext(cleanupCtx, query)
+	c.Check(err, qt.IsNil)
+}
+
+func grantMySQLWriterLivePrivilegesWithoutTrigger(c *qt.C, db *sql.DB, username string) {
+	c.Helper()
+	//nolint:gosec // The generated username contains no SQL metacharacters.
+	query := fmt.Sprintf(
+		"GRANT SELECT, DROP, ALTER, ALTER ROUTINE, EVENT, LOCK TABLES, PROCESS, SHOW_ROUTINE "+
+			"ON *.* TO '%s'@'%%'",
+		username,
+	)
+	_, err := db.ExecContext(c.Context(), query)
+	c.Assert(err, qt.IsNil)
 }

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -202,8 +202,8 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 		tableName := fmt.Sprintf("table_%02d", i)
 		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
 		columnRows = append(columnRows,
-			[]driver.Value{tableName, "id", "integer", "int4", "NO", nil, nil, nil, nil, int64(1), "", "", ""},
-			[]driver.Value{tableName, "name", "character varying", "varchar", "NO", nil, int64(255), nil, nil, int64(2), "", "", ""},
+			[]driver.Value{tableName, "id", "integer", "int4", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
+			[]driver.Value{tableName, "name", "character varying", "varchar", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
 		)
 	}
 
@@ -225,6 +225,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 					"generated_kind",
 					"generated_expression",
 					"identity_kind",
+					"owned_sequence_name",
 				},
 				Rows: columnRows,
 			}, nil
@@ -457,48 +458,6 @@ func TestPostgreSQLWriterConcurrentTransactions(t *testing.T) {
 	c.Assert(db.BeginCount(), qt.Equals, goroutines)
 	c.Assert(db.ExecCount(), qt.Equals, goroutines)
 	c.Assert(db.CommitCount()+db.RollbackCount(), qt.Equals, goroutines)
-}
-
-func TestPostgreSQLWriterDropAllTablesCommitsOnSuccess(t *testing.T) {
-	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, postgresDropAllQueryHandler, nil)
-	writer := NewPostgreSQLWriter(db.SQL, "public")
-
-	c.Assert(writer.DropAllTables(t.Context()), qt.IsNil)
-	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
-	c.Assert(db.CommitCount(), qt.Equals, 1)
-	c.Assert(db.RollbackCount(), qt.Equals, 0)
-}
-
-func TestPostgreSQLWriterDropAllTablesRollsBackOnFailure(t *testing.T) {
-	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, postgresDropAllQueryHandler, func(query string, _ []driver.NamedValue) (driver.Result, error) {
-		if strings.Contains(query, "DROP TYPE") {
-			return nil, fmt.Errorf("boom")
-		}
-		return driver.RowsAffected(0), nil
-	})
-	writer := NewPostgreSQLWriter(db.SQL, "public")
-
-	err := writer.DropAllTables(t.Context())
-	c.Assert(err, qt.ErrorMatches, `failed to drop enum status: SQL execution failed: boom\nSQL: DROP TYPE IF EXISTS "status" CASCADE`)
-	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.CommitCount(), qt.Equals, 0)
-	c.Assert(db.RollbackCount(), qt.Equals, 1)
-}
-
-func postgresDropAllQueryHandler(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
-	switch {
-	case strings.Contains(query, "information_schema.tables"):
-		return dbtest.QueryResult{Columns: []string{"table_name"}, Rows: [][]driver.Value{{"users"}}}, nil
-	case strings.Contains(query, "pg_type"):
-		return dbtest.QueryResult{Columns: []string{"typname"}, Rows: [][]driver.Value{{"status"}}}, nil
-	case strings.Contains(query, "information_schema.sequences"):
-		return dbtest.QueryResult{Columns: []string{"sequence_name"}, Rows: [][]driver.Value{{"users_id_seq"}}}, nil
-	default:
-		return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
-	}
 }
 
 func TestQuoteIdent(t *testing.T) {

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 // Reader reads schema from PostgreSQL databases
 type Reader struct {
-	db      *sql.DB
+	db      sqlrunner.Runner
 	schema  string
 	schemas []string
 	scoped  bool
@@ -21,13 +22,17 @@ type Reader struct {
 }
 
 // NewPostgreSQLReader creates a new PostgreSQL schema reader
-func NewPostgreSQLReader(db *sql.DB, schema string) *Reader {
+func NewPostgreSQLReader(db sqlrunner.Runner, schema string) *Reader {
 	return NewPostgreSQLReaderWithCapabilities(db, schema, capability.Postgres16())
 }
 
 // NewPostgreSQLReaderWithCapabilities creates a PostgreSQL-family schema reader
 // whose PostgreSQL-specific catalog reads are gated by target capabilities.
-func NewPostgreSQLReaderWithCapabilities(db *sql.DB, schema string, caps capability.Capabilities) *Reader {
+func NewPostgreSQLReaderWithCapabilities(
+	db sqlrunner.Runner,
+	schema string,
+	caps capability.Capabilities,
+) *Reader {
 	if schema == "" {
 		schema = "public"
 	}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -303,7 +303,14 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			ordinal_position,
 			COALESCE(a.attgenerated, '') AS generated_kind,
 			COALESCE(CASE WHEN a.attgenerated <> '' THEN pg_get_expr(ad.adbin, ad.adrelid) ELSE '' END, '') AS generated_expression,
-			COALESCE(a.attidentity, '') AS identity_kind
+			COALESCE(a.attidentity, '') AS identity_kind,
+			COALESCE(
+				pg_get_serial_sequence(
+					format('%I.%I', col.table_schema, col.table_name),
+					col.column_name
+				),
+				''
+			) AS owned_sequence_name
 		FROM information_schema.columns col
 		JOIN pg_namespace n ON n.nspname = col.table_schema
 		JOIN pg_class cls ON cls.relname = col.table_name AND cls.relnamespace = n.oid
@@ -327,6 +334,7 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 		var generatedKind string
 		var generatedExpression string
 		var identityKind string
+		var ownedSequenceName string
 		var tableName string
 		err := rows.Scan(
 			&tableName,
@@ -342,6 +350,7 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			&generatedKind,
 			&generatedExpression,
 			&identityKind,
+			&ownedSequenceName,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan column: %w", err)
@@ -352,11 +361,10 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 		}
 		col.IdentityGeneration = postgresIdentityGeneration(identityKind)
 
-		// Detect auto increment (SERIAL types)
 		if col.ColumnDefault != nil {
 			defaultVal := *col.ColumnDefault
-			col.IsAutoIncrement = strings.Contains(defaultVal, "nextval(") &&
-				strings.Contains(defaultVal, "_seq")
+			col.IsAutoIncrement = ownedSequenceName != "" &&
+				strings.Contains(strings.ToLower(defaultVal), "nextval(")
 		}
 
 		columnsByTable[tableName] = append(columnsByTable[tableName], col)

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -222,12 +222,14 @@ type postgresCleanupObject struct {
 }
 
 type postgresCleanupCapabilities struct {
-	retryFailedDDL        bool
-	lockManagedRelations  bool
-	inspectPartitionEdges bool
-	preservePublicSchema  bool
-	protectedDatabases    []string
-	systemExtensions      []string
+	retryFailedDDL           bool
+	lockManagedRelations     bool
+	inspectPartitionEdges    bool
+	inspectDatabaseArtifacts bool
+	cleanupLargeObjects      bool
+	preservePublicSchema     bool
+	protectedDatabases       []string
+	systemExtensions         []string
 }
 
 type postgresCleanupScope struct {
@@ -259,18 +261,22 @@ func inspectCleanupCapabilities(
 		strings.Contains(version, "yugabyte"),
 		strings.Contains(version, "-yb-"):
 		return postgresCleanupCapabilities{
-			retryFailedDDL:        true,
-			inspectPartitionEdges: true,
-			protectedDatabases:    protectedYugabyteDatabases,
-			systemExtensions:      []string{"pg_stat_statements", "plpgsql"},
+			retryFailedDDL:           true,
+			inspectPartitionEdges:    true,
+			inspectDatabaseArtifacts: true,
+			protectedDatabases:       protectedYugabyteDatabases,
+			systemExtensions:         []string{"pg_stat_statements", "plpgsql"},
 		}, nil
 	default:
+		isPostgreSQL := strings.Contains(version, "postgresql")
 		return postgresCleanupCapabilities{
-			retryFailedDDL:        true,
-			lockManagedRelations:  strings.Contains(version, "postgresql"),
-			inspectPartitionEdges: true,
-			protectedDatabases:    protectedPostgresDatabases,
-			systemExtensions:      []string{"plpgsql"},
+			retryFailedDDL:           true,
+			lockManagedRelations:     isPostgreSQL,
+			inspectPartitionEdges:    true,
+			inspectDatabaseArtifacts: isPostgreSQL,
+			cleanupLargeObjects:      isPostgreSQL,
+			protectedDatabases:       protectedPostgresDatabases,
+			systemExtensions:         []string{"plpgsql"},
 		}, nil
 	}
 }
@@ -316,6 +322,13 @@ type postgresSchemaMetadata struct {
 	aclIsDefault     bool
 	commentStatement string
 	privileges       []postgresSchemaPrivilege
+}
+
+type postgresDatabaseCleanupPlan struct {
+	capabilities postgresCleanupCapabilities
+	rootMetadata postgresSchemaMetadata
+	schemas      []string
+	objects      []postgresCleanupObject
 }
 
 func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx *sql.Tx) error {
@@ -830,6 +843,143 @@ func rejectProtectedPostgresDatabase(
 	return nil
 }
 
+func rejectPostgresDatabaseScopedArtifacts(ctx context.Context, tx *sql.Tx) error {
+	var kind string
+	var name string
+	err := tx.QueryRowContext(ctx, `
+		WITH database_scoped_artifacts AS (
+			SELECT
+				'publication'::text AS object_kind,
+				publication.pubname AS object_name
+			FROM pg_publication publication
+
+			UNION ALL
+			SELECT
+				'subscription',
+				subscription.subname
+			FROM pg_subscription subscription
+			WHERE subscription.subdbid = (
+				SELECT database.oid
+				FROM pg_database database
+				WHERE database.datname = current_database()
+			)
+
+			UNION ALL
+			SELECT
+				'logical replication slot',
+				slot.slot_name
+			FROM pg_replication_slots slot
+			WHERE slot.slot_type = 'logical'
+			  AND slot.datoid = (
+				SELECT database.oid
+				FROM pg_database database
+				WHERE database.datname = current_database()
+			  )
+
+			UNION ALL
+			SELECT
+				'event trigger',
+				event_trigger.evtname
+			FROM pg_event_trigger event_trigger
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM pg_depend dependency
+				WHERE dependency.classid = 'pg_event_trigger'::regclass
+				  AND dependency.objid = event_trigger.oid
+				  AND dependency.deptype = 'e'
+			)
+
+			UNION ALL
+			SELECT
+				'foreign-data wrapper',
+				wrapper.fdwname
+			FROM pg_foreign_data_wrapper wrapper
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM pg_depend dependency
+				WHERE dependency.classid = 'pg_foreign_data_wrapper'::regclass
+				  AND dependency.objid = wrapper.oid
+				  AND dependency.deptype = 'e'
+			)
+
+			UNION ALL
+			SELECT
+				'foreign server',
+				server.srvname
+			FROM pg_foreign_server server
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM pg_depend dependency
+				WHERE dependency.classid = 'pg_foreign_server'::regclass
+				  AND dependency.objid = server.oid
+				  AND dependency.deptype = 'e'
+			)
+
+			UNION ALL
+			SELECT
+				'user mapping',
+				format(
+					'%s@%s',
+					COALESCE(role.rolname, 'PUBLIC'),
+					server.srvname
+				)
+			FROM pg_user_mapping mapping
+			LEFT JOIN pg_roles role ON role.oid = mapping.umuser
+			JOIN pg_foreign_server server ON server.oid = mapping.umserver
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM pg_depend dependency
+				WHERE dependency.classid = 'pg_user_mapping'::regclass
+				  AND dependency.objid = mapping.oid
+				  AND dependency.deptype = 'e'
+			)
+		)
+		SELECT object_kind, object_name
+		FROM database_scoped_artifacts
+		ORDER BY object_kind, object_name
+		LIMIT 1
+	`).Scan(&kind, &name)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect PostgreSQL database-scoped artifacts: %w", err)
+	}
+	return fmt.Errorf(
+		"refusing to clean PostgreSQL database realm with unsupported database-scoped %s %q",
+		kind,
+		name,
+	)
+}
+
+func cleanupPostgresLargeObjects(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+		SELECT lo_unlink(oid)
+		FROM pg_largeobject_metadata
+		ORDER BY oid
+	`); err != nil {
+		return fmt.Errorf("failed to remove PostgreSQL large objects: %w", err)
+	}
+	return nil
+}
+
+func verifyPostgresLargeObjects(ctx context.Context, tx *sql.Tx) error {
+	var oid uint32
+	err := tx.QueryRowContext(ctx, `
+		SELECT oid
+		FROM pg_largeobject_metadata
+		ORDER BY oid
+		LIMIT 1
+	`).Scan(&oid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to verify PostgreSQL large object cleanup: %w", err)
+	}
+	return fmt.Errorf("PostgreSQL database realm cleanup left residual large object %d", oid)
+}
+
 func (w *PostgreSQLWriter) dropSchemaObjects(ctx context.Context) (resultErr error) {
 	if w.dryRun {
 		return nil
@@ -896,81 +1046,130 @@ func (w *PostgreSQLWriter) dropDatabaseRealm(ctx context.Context) (resultErr err
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	committed := false
 	defer func() {
-		if !committed {
-			rollbackErr := sqlTx.Rollback()
-			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-				resultErr = errors.Join(resultErr, fmt.Errorf("failed to roll back transaction: %w", rollbackErr))
-			}
-		}
+		finishPostgresCleanupTransaction(sqlTx, &resultErr)
 	}()
 
-	capabilities, err := inspectCleanupCapabilities(ctx, sqlTx)
+	plan, err := w.planDatabaseRealmCleanup(ctx, sqlTx)
 	if err != nil {
 		return err
 	}
-	if err := rejectProtectedPostgresDatabase(
-		ctx,
-		sqlTx,
-		capabilities.protectedDatabases,
-	); err != nil {
-		return err
-	}
-	rootMetadata, err := capturePostgresSchemaMetadata(ctx, sqlTx, w.schema)
+	preservedSchemas, err := w.executeDatabaseRealmCleanup(ctx, sqlTx, plan)
 	if err != nil {
 		return err
 	}
-	schemas, err := collectUserSchemas(ctx, sqlTx)
-	if err != nil {
-		return err
-	}
-	objects, err := w.collectAllObjects(
-		ctx,
-		sqlTx,
-		postgresDatabaseCleanupScope(schemas, capabilities.systemExtensions),
-	)
-	if err != nil {
-		return err
-	}
-	if capabilities.lockManagedRelations {
-		if err := w.lockManagedRelations(ctx, sqlTx, objects); err != nil {
-			return err
-		}
-	}
-
-	dropErr := capabilities.dropObjects(ctx, sqlTx, objects)
-	if dropErr != nil {
-		return fmt.Errorf("refusing to clean PostgreSQL database realm: %w", dropErr)
-	}
-
-	preservedSchemas := []string{w.schema}
-	droppableSchemas := schemas
-	if capabilities.preservePublicSchema {
-		preservedSchemas = appendUniqueString(preservedSchemas, "public")
-		droppableSchemas = excludeString(droppableSchemas, "public")
-	}
-	if err := dropPostgresUserSchemas(ctx, sqlTx, droppableSchemas); err != nil {
-		return err
-	}
-	if !capabilities.preservePublicSchema || w.schema != "public" {
-		if err := restorePostgresRootSchema(ctx, sqlTx, w.schema, rootMetadata); err != nil {
-			return err
-		}
-	}
-
-	if err := verifyPostgresDatabaseRealm(
-		ctx,
-		sqlTx,
-		preservedSchemas,
-		capabilities.systemExtensions,
-	); err != nil {
+	if err := verifyCompletedPostgresDatabaseCleanup(ctx, sqlTx, preservedSchemas, plan.capabilities); err != nil {
 		return err
 	}
 	if err := sqlTx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
-	committed = true
+	return nil
+}
+
+func finishPostgresCleanupTransaction(tx *sql.Tx, resultErr *error) {
+	rollbackErr := tx.Rollback()
+	if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+		*resultErr = errors.Join(*resultErr, fmt.Errorf("failed to roll back transaction: %w", rollbackErr))
+	}
+}
+
+func (w *PostgreSQLWriter) planDatabaseRealmCleanup(
+	ctx context.Context,
+	tx *sql.Tx,
+) (postgresDatabaseCleanupPlan, error) {
+	capabilities, err := inspectCleanupCapabilities(ctx, tx)
+	if err != nil {
+		return postgresDatabaseCleanupPlan{}, err
+	}
+	if err := rejectProtectedPostgresDatabase(ctx, tx, capabilities.protectedDatabases); err != nil {
+		return postgresDatabaseCleanupPlan{}, err
+	}
+	if capabilities.inspectDatabaseArtifacts {
+		if err := rejectPostgresDatabaseScopedArtifacts(ctx, tx); err != nil {
+			return postgresDatabaseCleanupPlan{}, err
+		}
+	}
+	rootMetadata, err := capturePostgresSchemaMetadata(ctx, tx, w.schema)
+	if err != nil {
+		return postgresDatabaseCleanupPlan{}, err
+	}
+	schemas, err := collectUserSchemas(ctx, tx)
+	if err != nil {
+		return postgresDatabaseCleanupPlan{}, err
+	}
+	objects, err := w.collectAllObjects(
+		ctx,
+		tx,
+		postgresDatabaseCleanupScope(schemas, capabilities.systemExtensions),
+	)
+	if err != nil {
+		return postgresDatabaseCleanupPlan{}, err
+	}
+	if capabilities.lockManagedRelations {
+		if err := w.lockManagedRelations(ctx, tx, objects); err != nil {
+			return postgresDatabaseCleanupPlan{}, err
+		}
+	}
+	return postgresDatabaseCleanupPlan{
+		capabilities: capabilities,
+		rootMetadata: rootMetadata,
+		schemas:      schemas,
+		objects:      objects,
+	}, nil
+}
+
+func (w *PostgreSQLWriter) executeDatabaseRealmCleanup(
+	ctx context.Context,
+	tx *sql.Tx,
+	plan postgresDatabaseCleanupPlan,
+) ([]string, error) {
+	dropErr := plan.capabilities.dropObjects(ctx, tx, plan.objects)
+	if dropErr != nil {
+		return nil, fmt.Errorf("refusing to clean PostgreSQL database realm: %w", dropErr)
+	}
+	if plan.capabilities.cleanupLargeObjects {
+		if err := cleanupPostgresLargeObjects(ctx, tx); err != nil {
+			return nil, err
+		}
+	}
+
+	preservedSchemas := []string{w.schema}
+	droppableSchemas := plan.schemas
+	if plan.capabilities.preservePublicSchema {
+		preservedSchemas = appendUniqueString(preservedSchemas, "public")
+		droppableSchemas = excludeString(droppableSchemas, "public")
+	}
+	if err := dropPostgresUserSchemas(ctx, tx, droppableSchemas); err != nil {
+		return nil, err
+	}
+	if !plan.capabilities.preservePublicSchema || w.schema != "public" {
+		if err := restorePostgresRootSchema(ctx, tx, w.schema, plan.rootMetadata); err != nil {
+			return nil, err
+		}
+	}
+	return preservedSchemas, nil
+}
+
+func verifyCompletedPostgresDatabaseCleanup(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchemas []string,
+	capabilities postgresCleanupCapabilities,
+) error {
+	if err := verifyPostgresDatabaseRealm(
+		ctx,
+		tx,
+		preservedSchemas,
+		capabilities.systemExtensions,
+	); err != nil {
+		return err
+	}
+	if capabilities.cleanupLargeObjects {
+		if err := verifyPostgresLargeObjects(ctx, tx); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 func quoteIdent(name string) string {
@@ -21,7 +23,7 @@ func quoteIdent(name string) string {
 
 // PostgreSQLWriter writes schemas to PostgreSQL databases
 type PostgreSQLWriter struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 	dryRun bool
 }
@@ -35,11 +37,23 @@ type postgresTransactionWriter struct {
 
 // NewPostgreSQLWriter creates a new PostgreSQL schema writer
 func NewPostgreSQLWriter(db *sql.DB, schema string) *PostgreSQLWriter {
+	if db == nil {
+		return NewPostgreSQLWriterForRunner(nil, schema)
+	}
+	return NewPostgreSQLWriterForRunner(db, schema)
+}
+
+// NewPostgreSQLWriterForRunner creates a writer bound to a pool or pinned
+// database session.
+func NewPostgreSQLWriterForRunner(
+	runner sqlrunner.Runner,
+	schema string,
+) *PostgreSQLWriter {
 	if schema == "" {
 		schema = "public"
 	}
 	return &PostgreSQLWriter{
-		db:     db,
+		db:     runner,
 		schema: schema,
 	}
 }
@@ -182,8 +196,72 @@ func (w *postgresTransactionWriter) IsDryRun() bool { return w.dryRun }
 
 type postgresCleanupObject struct {
 	Kind      string
+	Schema    string
 	Name      string
 	Statement string
+}
+
+type postgresCleanupCapabilities struct {
+	retryFailedDDL        bool
+	lockManagedRelations  bool
+	inspectPartitionEdges bool
+	preservePublicSchema  bool
+	systemExtensions      []string
+}
+
+func inspectCleanupCapabilities(
+	ctx context.Context,
+	tx *sql.Tx,
+) (postgresCleanupCapabilities, error) {
+	var version string
+	if err := tx.QueryRowContext(ctx, "SELECT version()").Scan(&version); err != nil {
+		return postgresCleanupCapabilities{}, fmt.Errorf(
+			"failed to inspect PostgreSQL-family cleanup capabilities: %w",
+			err,
+		)
+	}
+
+	version = strings.ToLower(version)
+	switch {
+	case strings.Contains(version, "cockroachdb"):
+		return postgresCleanupCapabilities{
+			preservePublicSchema: true,
+		}, nil
+	case strings.Contains(version, "yugabytedb"),
+		strings.Contains(version, "yugabyte"),
+		strings.Contains(version, "-yb-"):
+		return postgresCleanupCapabilities{
+			retryFailedDDL:        true,
+			inspectPartitionEdges: true,
+			systemExtensions:      []string{"pg_stat_statements", "plpgsql"},
+		}, nil
+	default:
+		return postgresCleanupCapabilities{
+			retryFailedDDL:        true,
+			lockManagedRelations:  strings.Contains(version, "postgresql"),
+			inspectPartitionEdges: true,
+			systemExtensions:      []string{"plpgsql"},
+		}, nil
+	}
+}
+
+type postgresSchemaPrivilege struct {
+	grantee     string
+	privilege   string
+	grantOption bool
+}
+
+type postgresSchemaMetadata struct {
+	exists           bool
+	owner            string
+	aclIsDefault     bool
+	commentStatement string
+	privileges       []postgresSchemaPrivilege
+}
+
+type postgresExtensionCleanup struct {
+	name      string
+	statement string
 }
 
 func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx *sql.Tx) error {
@@ -215,12 +293,83 @@ func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx 
 func (w *PostgreSQLWriter) collectAllObjects(
 	ctx context.Context,
 	tx *sql.Tx,
+	schemas []string,
 ) ([]postgresCleanupObject, error) {
-	rows, err := tx.QueryContext(ctx, `
-		WITH cleanup_objects AS (
+	if len(schemas) == 0 {
+		return nil, nil
+	}
+
+	query := strings.ReplaceAll(`
+		WITH RECURSIVE
+		managed_namespaces AS (
+			SELECT n.oid, n.nspname
+			FROM pg_namespace n
+			WHERE n.nspname IN ({{SCHEMA_PLACEHOLDERS}})
+		),
+		managed_views AS (
+			SELECT c.oid
+			FROM pg_class c
+			JOIN managed_namespaces n ON n.oid = c.relnamespace
+			AND c.relkind IN ('v', 'm')
+		),
+		view_dependencies AS (
+			SELECT
+				dependent.oid AS dependent_oid,
+				referenced.oid AS referenced_oid
+			FROM pg_rewrite rewrite
+			JOIN pg_class dependent ON dependent.oid = rewrite.ev_class
+			JOIN managed_namespaces dependent_namespace
+				ON dependent_namespace.oid = dependent.relnamespace
+			JOIN pg_depend dependency
+				ON dependency.classid = 'pg_rewrite'::regclass
+			   AND dependency.objid = rewrite.oid
+			   AND dependency.refclassid = 'pg_class'::regclass
+			JOIN pg_class referenced ON referenced.oid = dependency.refobjid
+			JOIN managed_namespaces referenced_namespace
+				ON referenced_namespace.oid = referenced.relnamespace
+			WHERE dependent.relkind IN ('v', 'm')
+			  AND referenced.relkind IN ('v', 'm')
+			  AND dependent.oid <> referenced.oid
+		),
+		view_depths AS (
+			SELECT view.oid, 0 AS depth
+			FROM managed_views view
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM view_dependencies dependency
+				WHERE dependency.dependent_oid = view.oid
+			)
+
+			UNION ALL
+
+			SELECT dependency.dependent_oid, depth.depth + 1
+			FROM view_depths depth
+			JOIN view_dependencies dependency
+				ON dependency.referenced_oid = depth.oid
+		),
+		view_order AS (
+			SELECT oid, MAX(depth) AS depth
+			FROM view_depths
+			GROUP BY oid
+		),
+		cleanup_objects AS (
+			SELECT
+				-10 AS priority,
+				0 AS dependency_depth,
+				'extension'::text AS object_kind,
+				n.nspname AS object_schema,
+				e.extname AS object_name,
+				format('DROP EXTENSION IF EXISTS %I RESTRICT', e.extname) AS drop_statement
+			FROM pg_extension e
+			JOIN managed_namespaces n ON n.oid = e.extnamespace
+
+			UNION ALL
+
 			SELECT
 				0 AS priority,
+				0 AS dependency_depth,
 				'constraint'::text AS object_kind,
+				n.nspname AS object_schema,
 				con.conname AS object_name,
 				format(
 					'ALTER TABLE %I.%I DROP CONSTRAINT IF EXISTS %I RESTRICT',
@@ -230,9 +379,8 @@ func (w *PostgreSQLWriter) collectAllObjects(
 				) AS drop_statement
 			FROM pg_constraint con
 			JOIN pg_class c ON c.oid = con.conrelid
-			JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE n.nspname = $1
-			  AND con.contype = 'f'
+			JOIN managed_namespaces n ON n.oid = c.relnamespace
+			WHERE con.contype = 'f'
 
 			UNION ALL
 
@@ -243,6 +391,7 @@ func (w *PostgreSQLWriter) collectAllObjects(
 					WHEN 'S' THEN 30
 					ELSE 20
 				END,
+				COALESCE(view_order.depth, 0),
 				CASE c.relkind
 					WHEN 'v' THEN 'view'
 					WHEN 'm' THEN 'materialized view'
@@ -250,6 +399,7 @@ func (w *PostgreSQLWriter) collectAllObjects(
 					WHEN 'S' THEN 'sequence'
 					ELSE 'table'
 				END,
+				n.nspname,
 				c.relname,
 				format(
 					CASE c.relkind
@@ -263,19 +413,21 @@ func (w *PostgreSQLWriter) collectAllObjects(
 					c.relname
 				)
 			FROM pg_class c
-			JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE n.nspname = $1
-			  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+			JOIN managed_namespaces n ON n.oid = c.relnamespace
+			LEFT JOIN view_order ON view_order.oid = c.oid
+			WHERE c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
 
 			UNION ALL
 
 			SELECT
 				40,
+				0,
 				CASE p.prokind
 					WHEN 'p' THEN 'procedure'
 					WHEN 'a' THEN 'aggregate'
 					ELSE 'function'
 				END,
+				n.nspname,
 				p.proname,
 				format(
 					'DROP %s IF EXISTS %I.%I(%s) RESTRICT',
@@ -289,9 +441,8 @@ func (w *PostgreSQLWriter) collectAllObjects(
 					pg_get_function_identity_arguments(p.oid)
 				)
 			FROM pg_proc p
-			JOIN pg_namespace n ON n.oid = p.pronamespace
-			WHERE n.nspname = $1
-			  AND p.prokind IN ('f', 'p', 'a', 'w')
+			JOIN managed_namespaces n ON n.oid = p.pronamespace
+			WHERE p.prokind IN ('f', 'p', 'a', 'w')
 			  AND NOT EXISTS (
 				SELECT 1
 				FROM pg_depend d
@@ -304,22 +455,24 @@ func (w *PostgreSQLWriter) collectAllObjects(
 
 			SELECT
 				50,
+				0,
 				'type',
+				n.nspname,
 				t.typname,
 				format('DROP TYPE IF EXISTS %I.%I RESTRICT', n.nspname, t.typname)
 			FROM pg_type t
-			JOIN pg_namespace n ON n.oid = t.typnamespace
+			JOIN managed_namespaces n ON n.oid = t.typnamespace
 			LEFT JOIN pg_class c ON c.oid = t.typrelid
-			WHERE n.nspname = $1
-				  AND (
+			WHERE (
 				t.typtype IN ('e', 'd', 'r')
 				OR (t.typtype = 'c' AND c.relkind = 'c')
 			  )
 		)
-		SELECT object_kind, object_name, drop_statement
+		SELECT object_kind, object_schema, object_name, drop_statement
 		FROM cleanup_objects
-		ORDER BY priority, object_kind, object_name
-	`, w.schema)
+		ORDER BY priority, dependency_depth DESC, object_schema, object_kind, object_name
+	`, "{{SCHEMA_PLACEHOLDERS}}", postgresPlaceholders(len(schemas)))
+	rows, err := tx.QueryContext(ctx, query, stringsToAny(schemas)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query schema objects: %w", err)
 	}
@@ -328,7 +481,7 @@ func (w *PostgreSQLWriter) collectAllObjects(
 	var objects []postgresCleanupObject
 	for rows.Next() {
 		var object postgresCleanupObject
-		if err := rows.Scan(&object.Kind, &object.Name, &object.Statement); err != nil {
+		if err := rows.Scan(&object.Kind, &object.Schema, &object.Name, &object.Statement); err != nil {
 			return nil, fmt.Errorf("failed to scan schema object: %w", err)
 		}
 		objects = append(objects, object)
@@ -337,6 +490,90 @@ func (w *PostgreSQLWriter) collectAllObjects(
 		return nil, fmt.Errorf("failed to iterate schema objects: %w", err)
 	}
 	return objects, nil
+}
+
+func postgresPlaceholders(count int) string {
+	placeholders := make([]string, count)
+	for i := range count {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	return strings.Join(placeholders, ", ")
+}
+
+func stringsToAny(values []string) []any {
+	args := make([]any, len(values))
+	for i := range values {
+		args[i] = values[i]
+	}
+	return args
+}
+
+func (w *PostgreSQLWriter) lockManagedRelations(
+	ctx context.Context,
+	tx *sql.Tx,
+	objects []postgresCleanupObject,
+) error {
+	relations := make([]string, 0, len(objects))
+	for _, object := range objects {
+		switch object.Kind {
+		case "table", "foreign table":
+			relations = append(relations, quoteIdent(object.Schema)+"."+quoteIdent(object.Name))
+		}
+	}
+	if len(relations) == 0 {
+		return nil
+	}
+
+	// Identifiers come from the catalog snapshot and are quoted individually;
+	// LOCK TABLE does not support identifier bind parameters.
+	//nolint:gosec // LOCK TABLE cannot bind the individually quoted catalog identifiers.
+	statement := "LOCK TABLE " + strings.Join(relations, ", ") + " IN ACCESS EXCLUSIVE MODE"
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("failed to lock managed relations before cleanup: %w", err)
+	}
+	return nil
+}
+
+func (w *PostgreSQLWriter) rejectCrossSchemaPartitionEdges(ctx context.Context, tx *sql.Tx) error {
+	var parentSchema string
+	var parentName string
+	var childSchema string
+	var childName string
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			parent_namespace.nspname,
+			parent.relname,
+			child_namespace.nspname,
+			child.relname
+		FROM pg_inherits inheritance
+		JOIN pg_class parent ON parent.oid = inheritance.inhparent
+		JOIN pg_namespace parent_namespace ON parent_namespace.oid = parent.relnamespace
+		JOIN pg_class child ON child.oid = inheritance.inhrelid
+		JOIN pg_namespace child_namespace ON child_namespace.oid = child.relnamespace
+		WHERE child.relispartition
+		  AND (
+			(parent_namespace.nspname = $1 AND child_namespace.nspname <> $1)
+			OR (child_namespace.nspname = $1 AND parent_namespace.nspname <> $1)
+		  )
+		ORDER BY parent_namespace.nspname, parent.relname, child_namespace.nspname, child.relname
+		LIMIT 1
+	`, w.schema).Scan(&parentSchema, &parentName, &childSchema, &childName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect partition relationships: %w", err)
+	}
+
+	return fmt.Errorf(
+		"refusing to clean schema %q: partition %q.%q is attached to "+
+			"partitioned table %q.%q across the schema boundary",
+		w.schema,
+		childSchema,
+		childName,
+		parentSchema,
+		parentName,
+	)
 }
 
 func tryDropCleanupObject(
@@ -365,6 +602,25 @@ func tryDropCleanupObject(
 		return nil, fmt.Errorf("failed to release cleanup savepoint: %w", err)
 	}
 	return nil, nil
+}
+
+func dropCleanupObjectsOnce(
+	ctx context.Context,
+	tx *sql.Tx,
+	objects []postgresCleanupObject,
+) error {
+	for _, object := range objects {
+		if _, err := tx.ExecContext(ctx, object.Statement); err != nil {
+			return fmt.Errorf(
+				"failed to drop %s %s: SQL execution failed: %w\nSQL: %s",
+				object.Kind,
+				object.Name,
+				err,
+				object.Statement,
+			)
+		}
+	}
+	return nil
 }
 
 func dropCleanupObjects(
@@ -411,7 +667,31 @@ func dropCleanupObjects(
 }
 
 // DropAllTables drops all user objects in the configured database schema.
-func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) {
+func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) error {
+	return w.dropSchemaObjects(ctx)
+}
+
+// DropDatabaseRealm removes every user schema and recreates the configured
+// root schema. CockroachDB's immutable public schema is preserved in place,
+// but its user objects are removed and verified like every other realm object.
+func (w *PostgreSQLWriter) DropDatabaseRealm(ctx context.Context) error {
+	if w.dryRun {
+		return nil
+	}
+	if w.db == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if isPostgresSystemSchema(w.schema) {
+		return fmt.Errorf(
+			"refusing to clean PostgreSQL database realm with system root schema %q",
+			w.schema,
+		)
+	}
+
+	return w.dropDatabaseRealm(ctx)
+}
+
+func (w *PostgreSQLWriter) dropSchemaObjects(ctx context.Context) (resultErr error) {
 	if w.dryRun {
 		return nil
 	}
@@ -433,16 +713,36 @@ func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) 
 		}
 	}()
 
-	if err := w.rejectSchemaScopedExtensions(ctx, sqlTx); err != nil {
-		return err
-	}
-	objects, err := w.collectAllObjects(ctx, sqlTx)
+	capabilities, err := inspectCleanupCapabilities(ctx, sqlTx)
 	if err != nil {
 		return err
 	}
+	if err := w.rejectSchemaScopedExtensions(ctx, sqlTx); err != nil {
+		return err
+	}
+	objects, err := w.collectAllObjects(ctx, sqlTx, []string{w.schema})
+	if err != nil {
+		return err
+	}
+	if capabilities.lockManagedRelations {
+		if err := w.lockManagedRelations(ctx, sqlTx, objects); err != nil {
+			return err
+		}
+	}
+	if capabilities.inspectPartitionEdges {
+		if err := w.rejectCrossSchemaPartitionEdges(ctx, sqlTx); err != nil {
+			return err
+		}
+	}
 
-	if err := dropCleanupObjects(ctx, sqlTx, objects); err != nil {
-		return fmt.Errorf("refusing to clean schema %q: %w", w.schema, err)
+	var dropErr error
+	if capabilities.retryFailedDDL {
+		dropErr = dropCleanupObjects(ctx, sqlTx, objects)
+	} else {
+		dropErr = dropCleanupObjectsOnce(ctx, sqlTx, objects)
+	}
+	if dropErr != nil {
+		return fmt.Errorf("refusing to clean schema %q: %w", w.schema, dropErr)
 	}
 
 	if err := sqlTx.Commit(); err != nil {
@@ -451,6 +751,562 @@ func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) 
 	committed = true
 
 	return nil
+}
+
+func (w *PostgreSQLWriter) dropDatabaseRealm(ctx context.Context) (resultErr error) {
+	sqlTx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			rollbackErr := sqlTx.Rollback()
+			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				resultErr = errors.Join(resultErr, fmt.Errorf("failed to roll back transaction: %w", rollbackErr))
+			}
+		}
+	}()
+
+	capabilities, err := inspectCleanupCapabilities(ctx, sqlTx)
+	if err != nil {
+		return err
+	}
+	rootMetadata, err := capturePostgresSchemaMetadata(ctx, sqlTx, w.schema)
+	if err != nil {
+		return err
+	}
+	schemas, err := collectUserSchemas(ctx, sqlTx)
+	if err != nil {
+		return err
+	}
+	extensions, err := collectPostgresUserExtensions(
+		ctx,
+		sqlTx,
+		capabilities.systemExtensions,
+	)
+	if err != nil {
+		return err
+	}
+	if err := dropPostgresUserExtensions(ctx, sqlTx, extensions); err != nil {
+		return err
+	}
+
+	preservedSchemas := []string{w.schema}
+	if capabilities.preservePublicSchema {
+		preservedSchemas = appendUniqueString(preservedSchemas, "public")
+		if err := w.dropCockroachDatabaseRealm(ctx, sqlTx, schemas, rootMetadata); err != nil {
+			return err
+		}
+	} else {
+		if err := dropPostgresUserSchemas(ctx, sqlTx, schemas); err != nil {
+			return err
+		}
+		if err := restorePostgresRootSchema(ctx, sqlTx, w.schema, rootMetadata); err != nil {
+			return err
+		}
+	}
+
+	if err := verifyPostgresDatabaseRealm(
+		ctx,
+		sqlTx,
+		preservedSchemas,
+		capabilities.systemExtensions,
+	); err != nil {
+		return err
+	}
+	if err := sqlTx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func (w *PostgreSQLWriter) dropCockroachDatabaseRealm(
+	ctx context.Context,
+	tx *sql.Tx,
+	schemas []string,
+	rootMetadata postgresSchemaMetadata,
+) error {
+	droppableSchemas := excludeString(schemas, "public")
+	if err := dropPostgresUserSchemas(ctx, tx, droppableSchemas); err != nil {
+		return err
+	}
+
+	publicObjects, err := w.collectAllObjects(ctx, tx, []string{"public"})
+	if err != nil {
+		return err
+	}
+	if err := dropCleanupObjectsOnce(ctx, tx, publicObjects); err != nil {
+		return fmt.Errorf("refusing to clean PostgreSQL database realm: %w", err)
+	}
+
+	if w.schema != "public" {
+		if err := restorePostgresRootSchema(ctx, tx, w.schema, rootMetadata); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectUserSchemas(ctx context.Context, tx *sql.Tx) ([]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT n.nspname
+		FROM pg_namespace n
+		WHERE n.nspname <> 'information_schema'
+		  AND n.nspname <> 'crdb_internal'
+		  AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'
+		ORDER BY n.nspname
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query PostgreSQL user schemas: %w", err)
+	}
+	defer rows.Close()
+
+	var schemas []string
+	for rows.Next() {
+		var schema string
+		if err := rows.Scan(&schema); err != nil {
+			return nil, fmt.Errorf("failed to scan PostgreSQL user schema: %w", err)
+		}
+		schemas = append(schemas, schema)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate PostgreSQL user schemas: %w", err)
+	}
+	return schemas, nil
+}
+
+func capturePostgresSchemaMetadata(
+	ctx context.Context,
+	tx *sql.Tx,
+	schema string,
+) (postgresSchemaMetadata, error) {
+	var metadata postgresSchemaMetadata
+	err := tx.QueryRowContext(ctx, `
+		SELECT
+			pg_get_userbyid(n.nspowner),
+			n.nspacl IS NULL,
+			format(
+				'COMMENT ON SCHEMA %I IS %L',
+				n.nspname,
+				obj_description(n.oid, 'pg_namespace')
+			)
+		FROM pg_namespace n
+		WHERE n.nspname = $1
+	`, schema).Scan(
+		&metadata.owner,
+		&metadata.aclIsDefault,
+		&metadata.commentStatement,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return postgresSchemaMetadata{}, nil
+	}
+	if err != nil {
+		return postgresSchemaMetadata{}, fmt.Errorf(
+			"failed to capture root schema %q metadata: %w",
+			schema,
+			err,
+		)
+	}
+	metadata.exists = true
+	if metadata.aclIsDefault {
+		return metadata, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT
+			CASE acl.grantee
+				WHEN 0 THEN 'PUBLIC'
+				ELSE pg_get_userbyid(acl.grantee)
+			END,
+			acl.privilege_type,
+			acl.is_grantable
+		FROM pg_namespace n
+		CROSS JOIN LATERAL aclexplode(n.nspacl) acl
+		WHERE n.nspname = $1
+		ORDER BY 1, 2, 3
+	`, schema)
+	if err != nil {
+		return postgresSchemaMetadata{}, fmt.Errorf(
+			"failed to capture root schema %q privileges: %w",
+			schema,
+			err,
+		)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var privilege postgresSchemaPrivilege
+		if err := rows.Scan(&privilege.grantee, &privilege.privilege, &privilege.grantOption); err != nil {
+			return postgresSchemaMetadata{}, fmt.Errorf(
+				"failed to scan root schema %q privilege: %w",
+				schema,
+				err,
+			)
+		}
+		metadata.privileges = append(metadata.privileges, privilege)
+	}
+	if err := rows.Err(); err != nil {
+		return postgresSchemaMetadata{}, fmt.Errorf(
+			"failed to iterate root schema %q privileges: %w",
+			schema,
+			err,
+		)
+	}
+	if err := validatePostgresSchemaPrivileges(metadata.privileges); err != nil {
+		return postgresSchemaMetadata{}, err
+	}
+	return metadata, nil
+}
+
+func dropPostgresUserSchemas(ctx context.Context, tx *sql.Tx, schemas []string) error {
+	for _, schema := range schemas {
+		// Schema names come from pg_namespace and are quoted as identifiers;
+		// PostgreSQL-family DDL does not support identifier bind parameters.
+		//nolint:gosec // The catalog identifier is quoted through sqlident.
+		statement := "DROP SCHEMA IF EXISTS " + quoteIdent(schema) + " CASCADE"
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf(
+				"failed to drop user schema %q from PostgreSQL database realm: %w",
+				schema,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func collectPostgresUserExtensions(
+	ctx context.Context,
+	tx *sql.Tx,
+	systemExtensions []string,
+) ([]postgresExtensionCleanup, error) {
+	query := `
+		SELECT
+			e.extname,
+			format('DROP EXTENSION IF EXISTS %I CASCADE', e.extname)
+		FROM pg_extension e
+	`
+	var args []any
+	if len(systemExtensions) > 0 {
+		//nolint:gosec // Only internally generated positional placeholders are interpolated.
+		query += " WHERE e.extname NOT IN (" + postgresPlaceholders(len(systemExtensions)) + ")"
+		args = stringsToAny(systemExtensions)
+	}
+	query += " ORDER BY e.extname"
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query PostgreSQL user extensions: %w", err)
+	}
+	defer rows.Close()
+
+	var extensions []postgresExtensionCleanup
+	for rows.Next() {
+		var extension postgresExtensionCleanup
+		if err := rows.Scan(&extension.name, &extension.statement); err != nil {
+			return nil, fmt.Errorf("failed to scan PostgreSQL user extension: %w", err)
+		}
+		extensions = append(extensions, extension)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate PostgreSQL user extensions: %w", err)
+	}
+	return extensions, nil
+}
+
+func dropPostgresUserExtensions(
+	ctx context.Context,
+	tx *sql.Tx,
+	extensions []postgresExtensionCleanup,
+) error {
+	for _, extension := range extensions {
+		if _, err := tx.ExecContext(ctx, extension.statement); err != nil {
+			return fmt.Errorf(
+				"failed to drop user extension %q from PostgreSQL database realm: %w",
+				extension.name,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func restorePostgresRootSchema(
+	ctx context.Context,
+	tx *sql.Tx,
+	schema string,
+	metadata postgresSchemaMetadata,
+) error {
+	//nolint:gosec // Schema and owner identifiers are quoted through sqlident.
+	statement := "CREATE SCHEMA " + quoteIdent(schema)
+	if metadata.exists {
+		statement += " AUTHORIZATION " + quoteIdent(metadata.owner)
+	}
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("failed to recreate root schema %q: %w", schema, err)
+	}
+	if !metadata.exists {
+		return nil
+	}
+	if !metadata.aclIsDefault {
+		if err := restorePostgresSchemaPrivileges(ctx, tx, schema, metadata); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, metadata.commentStatement); err != nil {
+		return fmt.Errorf("failed to restore root schema %q comment: %w", schema, err)
+	}
+	return nil
+}
+
+func restorePostgresSchemaPrivileges(
+	ctx context.Context,
+	tx *sql.Tx,
+	schema string,
+	metadata postgresSchemaMetadata,
+) error {
+	grantees := []string{"PUBLIC", metadata.owner}
+	for _, privilege := range metadata.privileges {
+		grantees = appendUniqueString(grantees, privilege.grantee)
+	}
+	for _, grantee := range grantees {
+		//nolint:gosec // Schema and role identifiers are quoted through sqlident.
+		statement := "REVOKE ALL PRIVILEGES ON SCHEMA " + quoteIdent(schema) +
+			" FROM " + quotePostgresRole(grantee)
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf(
+				"failed to reset root schema %q privileges for %q: %w",
+				schema,
+				grantee,
+				err,
+			)
+		}
+	}
+	for _, privilege := range metadata.privileges {
+		//nolint:gosec // Privilege is allow-listed; identifiers are quoted through sqlident.
+		statement := "GRANT " + privilege.privilege + " ON SCHEMA " +
+			quoteIdent(schema) + " TO " + quotePostgresRole(privilege.grantee)
+		if privilege.grantOption {
+			statement += " WITH GRANT OPTION"
+		}
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf(
+				"failed to restore root schema %q privilege for %q: %w",
+				schema,
+				privilege.grantee,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+func validatePostgresSchemaPrivileges(privileges []postgresSchemaPrivilege) error {
+	for _, privilege := range privileges {
+		if privilege.privilege != "CREATE" && privilege.privilege != "USAGE" {
+			return fmt.Errorf(
+				"refusing to restore unsupported PostgreSQL schema privilege %q",
+				privilege.privilege,
+			)
+		}
+	}
+	return nil
+}
+
+func verifyPostgresDatabaseRealm(
+	ctx context.Context,
+	tx *sql.Tx,
+	preservedSchemas []string,
+	systemExtensions []string,
+) error {
+	schemas, err := collectUserSchemas(ctx, tx)
+	if err != nil {
+		return err
+	}
+	expected := make(map[string]struct{}, len(preservedSchemas))
+	for _, schema := range preservedSchemas {
+		expected[schema] = struct{}{}
+	}
+	for _, schema := range schemas {
+		if _, ok := expected[schema]; !ok {
+			return fmt.Errorf(
+				"PostgreSQL database realm cleanup left residual user schema %q",
+				schema,
+			)
+		}
+		delete(expected, schema)
+	}
+	for schema := range expected {
+		return fmt.Errorf(
+			"PostgreSQL database realm cleanup did not recreate root schema %q",
+			schema,
+		)
+	}
+	if err := verifyPostgresUserExtensions(ctx, tx, systemExtensions); err != nil {
+		return err
+	}
+
+	query := strings.ReplaceAll(`
+		WITH managed_namespaces AS (
+			SELECT n.oid, n.nspname
+			FROM pg_namespace n
+			WHERE n.nspname IN ({{SCHEMA_PLACEHOLDERS}})
+		),
+		residual_objects AS (
+			SELECT 'relation'::text AS object_kind, n.nspname, c.relname
+			FROM pg_class c
+			JOIN managed_namespaces n ON n.oid = c.relnamespace
+
+			UNION ALL
+			SELECT 'routine', n.nspname, p.proname
+			FROM pg_proc p
+			JOIN managed_namespaces n ON n.oid = p.pronamespace
+
+			UNION ALL
+			SELECT 'type', n.nspname, t.typname
+			FROM pg_type t
+			JOIN managed_namespaces n ON n.oid = t.typnamespace
+
+			UNION ALL
+			SELECT 'collation', n.nspname, c.collname
+			FROM pg_collation c
+			JOIN managed_namespaces n ON n.oid = c.collnamespace
+
+			UNION ALL
+			SELECT 'conversion', n.nspname, c.conname
+			FROM pg_conversion c
+			JOIN managed_namespaces n ON n.oid = c.connamespace
+
+			UNION ALL
+			SELECT 'operator', n.nspname, o.oprname
+			FROM pg_operator o
+			JOIN managed_namespaces n ON n.oid = o.oprnamespace
+
+			UNION ALL
+			SELECT 'operator class', n.nspname, o.opcname
+			FROM pg_opclass o
+			JOIN managed_namespaces n ON n.oid = o.opcnamespace
+
+			UNION ALL
+			SELECT 'operator family', n.nspname, o.opfname
+			FROM pg_opfamily o
+			JOIN managed_namespaces n ON n.oid = o.opfnamespace
+
+			UNION ALL
+			SELECT 'text search configuration', n.nspname, c.cfgname
+			FROM pg_ts_config c
+			JOIN managed_namespaces n ON n.oid = c.cfgnamespace
+
+			UNION ALL
+			SELECT 'text search dictionary', n.nspname, d.dictname
+			FROM pg_ts_dict d
+			JOIN managed_namespaces n ON n.oid = d.dictnamespace
+
+			UNION ALL
+			SELECT 'text search parser', n.nspname, p.prsname
+			FROM pg_ts_parser p
+			JOIN managed_namespaces n ON n.oid = p.prsnamespace
+
+			UNION ALL
+			SELECT 'text search template', n.nspname, t.tmplname
+			FROM pg_ts_template t
+			JOIN managed_namespaces n ON n.oid = t.tmplnamespace
+
+			UNION ALL
+			SELECT 'extension', n.nspname, e.extname
+			FROM pg_extension e
+			JOIN managed_namespaces n ON n.oid = e.extnamespace
+
+			UNION ALL
+			SELECT 'default privilege', n.nspname, d.oid::text
+			FROM pg_default_acl d
+			JOIN managed_namespaces n ON n.oid = d.defaclnamespace
+		)
+		SELECT object_kind, nspname, relname
+		FROM residual_objects
+		ORDER BY object_kind, nspname, relname
+		LIMIT 1
+	`, "{{SCHEMA_PLACEHOLDERS}}", postgresPlaceholders(len(preservedSchemas)))
+
+	var kind string
+	var schema string
+	var name string
+	err = tx.QueryRowContext(ctx, query, stringsToAny(preservedSchemas)...).Scan(
+		&kind,
+		&schema,
+		&name,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to verify PostgreSQL database realm cleanup: %w", err)
+	}
+	return fmt.Errorf(
+		"PostgreSQL database realm cleanup left residual %s %q.%q",
+		kind,
+		schema,
+		name,
+	)
+}
+
+func verifyPostgresUserExtensions(
+	ctx context.Context,
+	tx *sql.Tx,
+	systemExtensions []string,
+) error {
+	query := "SELECT e.extname FROM pg_extension e"
+	var args []any
+	if len(systemExtensions) > 0 {
+		query += " WHERE e.extname NOT IN (" + postgresPlaceholders(len(systemExtensions)) + ")"
+		args = stringsToAny(systemExtensions)
+	}
+	query += " ORDER BY e.extname LIMIT 1"
+
+	var extension string
+	err := tx.QueryRowContext(ctx, query, args...).Scan(&extension)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to verify PostgreSQL user extension cleanup: %w", err)
+	}
+	return fmt.Errorf(
+		"PostgreSQL database realm cleanup left residual user extension %q",
+		extension,
+	)
+}
+
+func isPostgresSystemSchema(schema string) bool {
+	return schema == "information_schema" ||
+		schema == "crdb_internal" ||
+		strings.HasPrefix(schema, "pg_")
+}
+
+func quotePostgresRole(role string) string {
+	if role == "PUBLIC" {
+		return role
+	}
+	return quoteIdent(role)
+}
+
+func appendUniqueString(values []string, value string) []string {
+	if slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
+}
+
+func excludeString(values []string, excluded string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != excluded {
+			result = append(result, value)
+		}
+	}
+	return result
 }
 
 // SetDryRun enables or disables dry run mode

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -17,6 +17,26 @@ import (
 	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
+var protectedPostgresDatabases = []string{
+	"postgres",
+	"template0",
+	"template1",
+}
+
+var protectedCockroachDatabases = []string{
+	"defaultdb",
+	"postgres",
+	"system",
+}
+
+var protectedYugabyteDatabases = []string{
+	"postgres",
+	"system_platform",
+	"template0",
+	"template1",
+	"yugabyte",
+}
+
 func quoteIdent(name string) string {
 	return sqlident.Quote(platform.Postgres, name)
 }
@@ -206,7 +226,14 @@ type postgresCleanupCapabilities struct {
 	lockManagedRelations  bool
 	inspectPartitionEdges bool
 	preservePublicSchema  bool
+	protectedDatabases    []string
 	systemExtensions      []string
+}
+
+type postgresCleanupScope struct {
+	schemas                []string
+	extensionNamespaceJoin string
+	systemExtensions       []string
 }
 
 func inspectCleanupCapabilities(
@@ -226,6 +253,7 @@ func inspectCleanupCapabilities(
 	case strings.Contains(version, "cockroachdb"):
 		return postgresCleanupCapabilities{
 			preservePublicSchema: true,
+			protectedDatabases:   protectedCockroachDatabases,
 		}, nil
 	case strings.Contains(version, "yugabytedb"),
 		strings.Contains(version, "yugabyte"),
@@ -233,6 +261,7 @@ func inspectCleanupCapabilities(
 		return postgresCleanupCapabilities{
 			retryFailedDDL:        true,
 			inspectPartitionEdges: true,
+			protectedDatabases:    protectedYugabyteDatabases,
 			systemExtensions:      []string{"pg_stat_statements", "plpgsql"},
 		}, nil
 	default:
@@ -240,8 +269,38 @@ func inspectCleanupCapabilities(
 			retryFailedDDL:        true,
 			lockManagedRelations:  strings.Contains(version, "postgresql"),
 			inspectPartitionEdges: true,
+			protectedDatabases:    protectedPostgresDatabases,
 			systemExtensions:      []string{"plpgsql"},
 		}, nil
+	}
+}
+
+func (c postgresCleanupCapabilities) dropObjects(
+	ctx context.Context,
+	tx *sql.Tx,
+	objects []postgresCleanupObject,
+) error {
+	if c.retryFailedDDL {
+		return dropCleanupObjects(ctx, tx, objects)
+	}
+	return dropCleanupObjectsOnce(ctx, tx, objects)
+}
+
+func postgresSchemaCleanupScope(schemas []string) postgresCleanupScope {
+	return postgresCleanupScope{
+		schemas:                schemas,
+		extensionNamespaceJoin: "JOIN managed_namespaces n ON n.oid = e.extnamespace",
+	}
+}
+
+func postgresDatabaseCleanupScope(
+	schemas []string,
+	systemExtensions []string,
+) postgresCleanupScope {
+	return postgresCleanupScope{
+		schemas:                schemas,
+		extensionNamespaceJoin: "JOIN pg_namespace n ON n.oid = e.extnamespace",
+		systemExtensions:       systemExtensions,
 	}
 }
 
@@ -257,11 +316,6 @@ type postgresSchemaMetadata struct {
 	aclIsDefault     bool
 	commentStatement string
 	privileges       []postgresSchemaPrivilege
-}
-
-type postgresExtensionCleanup struct {
-	name      string
-	statement string
 }
 
 func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx *sql.Tx) error {
@@ -290,15 +344,23 @@ func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx 
 	return nil
 }
 
+//nolint:funlen // The dependency-ordered catalog query is kept in one auditable unit.
 func (w *PostgreSQLWriter) collectAllObjects(
 	ctx context.Context,
 	tx *sql.Tx,
-	schemas []string,
+	scope postgresCleanupScope,
 ) ([]postgresCleanupObject, error) {
-	if len(schemas) == 0 {
+	if len(scope.schemas) == 0 {
 		return nil, nil
 	}
 
+	extensionFilter := ""
+	args := stringsToAny(scope.schemas)
+	if len(scope.systemExtensions) > 0 {
+		extensionFilter = "WHERE e.extname NOT IN (" +
+			postgresPlaceholdersFrom(len(args)+1, len(scope.systemExtensions)) + ")"
+		args = append(args, stringsToAny(scope.systemExtensions)...)
+	}
 	query := strings.ReplaceAll(`
 		WITH RECURSIVE
 		managed_namespaces AS (
@@ -361,7 +423,8 @@ func (w *PostgreSQLWriter) collectAllObjects(
 				e.extname AS object_name,
 				format('DROP EXTENSION IF EXISTS %I RESTRICT', e.extname) AS drop_statement
 			FROM pg_extension e
-			JOIN managed_namespaces n ON n.oid = e.extnamespace
+			{{EXTENSION_NAMESPACE_JOIN}}
+			{{SYSTEM_EXTENSION_FILTER}}
 
 			UNION ALL
 
@@ -467,12 +530,67 @@ func (w *PostgreSQLWriter) collectAllObjects(
 				t.typtype IN ('e', 'd', 'r')
 				OR (t.typtype = 'c' AND c.relkind = 'c')
 			  )
+
+			UNION ALL
+
+			SELECT
+				60,
+				0,
+				'collation',
+				n.nspname,
+				c.collname,
+				format(
+					'DROP COLLATION IF EXISTS %I.%I RESTRICT',
+					n.nspname,
+					c.collname
+				)
+			FROM pg_collation c
+			JOIN managed_namespaces n ON n.oid = c.collnamespace
+
+			UNION ALL
+
+			SELECT DISTINCT
+				70,
+				0,
+				'default privilege',
+				n.nspname,
+				format(
+					'%s/%s/%s',
+					pg_get_userbyid(d.defaclrole),
+					d.defaclobjtype,
+					CASE acl.grantee
+						WHEN 0 THEN 'PUBLIC'
+						ELSE pg_get_userbyid(acl.grantee)
+					END
+				),
+				format(
+					'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I ' ||
+					'REVOKE ALL PRIVILEGES ON %s FROM %s',
+					pg_get_userbyid(d.defaclrole),
+					n.nspname,
+					CASE d.defaclobjtype
+						WHEN 'r' THEN 'TABLES'
+						WHEN 'S' THEN 'SEQUENCES'
+						WHEN 'f' THEN 'FUNCTIONS'
+						WHEN 'T' THEN 'TYPES'
+					END,
+					CASE acl.grantee
+						WHEN 0 THEN 'PUBLIC'
+						ELSE format('%I', pg_get_userbyid(acl.grantee))
+					END
+				)
+			FROM pg_default_acl d
+			JOIN managed_namespaces n ON n.oid = d.defaclnamespace
+			CROSS JOIN LATERAL aclexplode(d.defaclacl) acl
+			WHERE d.defaclobjtype IN ('r', 'S', 'f', 'T')
 		)
 		SELECT object_kind, object_schema, object_name, drop_statement
 		FROM cleanup_objects
 		ORDER BY priority, dependency_depth DESC, object_schema, object_kind, object_name
-	`, "{{SCHEMA_PLACEHOLDERS}}", postgresPlaceholders(len(schemas)))
-	rows, err := tx.QueryContext(ctx, query, stringsToAny(schemas)...)
+	`, "{{SCHEMA_PLACEHOLDERS}}", postgresPlaceholders(len(scope.schemas)))
+	query = strings.ReplaceAll(query, "{{EXTENSION_NAMESPACE_JOIN}}", scope.extensionNamespaceJoin)
+	query = strings.ReplaceAll(query, "{{SYSTEM_EXTENSION_FILTER}}", extensionFilter)
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query schema objects: %w", err)
 	}
@@ -493,9 +611,13 @@ func (w *PostgreSQLWriter) collectAllObjects(
 }
 
 func postgresPlaceholders(count int) string {
+	return postgresPlaceholdersFrom(1, count)
+}
+
+func postgresPlaceholdersFrom(start, count int) string {
 	placeholders := make([]string, count)
 	for i := range count {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		placeholders[i] = fmt.Sprintf("$%d", start+i)
 	}
 	return strings.Join(placeholders, ", ")
 }
@@ -687,8 +809,25 @@ func (w *PostgreSQLWriter) DropDatabaseRealm(ctx context.Context) error {
 			w.schema,
 		)
 	}
-
 	return w.dropDatabaseRealm(ctx)
+}
+
+func rejectProtectedPostgresDatabase(
+	ctx context.Context,
+	tx *sql.Tx,
+	protectedDatabases []string,
+) error {
+	var database string
+	if err := tx.QueryRowContext(ctx, "SELECT current_database()").Scan(&database); err != nil {
+		return fmt.Errorf("failed to inspect current PostgreSQL database for cleanup: %w", err)
+	}
+	if slices.Contains(protectedDatabases, strings.ToLower(database)) {
+		return fmt.Errorf(
+			"refusing to clean protected PostgreSQL-family database %q",
+			database,
+		)
+	}
+	return nil
 }
 
 func (w *PostgreSQLWriter) dropSchemaObjects(ctx context.Context) (resultErr error) {
@@ -720,7 +859,11 @@ func (w *PostgreSQLWriter) dropSchemaObjects(ctx context.Context) (resultErr err
 	if err := w.rejectSchemaScopedExtensions(ctx, sqlTx); err != nil {
 		return err
 	}
-	objects, err := w.collectAllObjects(ctx, sqlTx, []string{w.schema})
+	objects, err := w.collectAllObjects(
+		ctx,
+		sqlTx,
+		postgresSchemaCleanupScope([]string{w.schema}),
+	)
 	if err != nil {
 		return err
 	}
@@ -735,12 +878,7 @@ func (w *PostgreSQLWriter) dropSchemaObjects(ctx context.Context) (resultErr err
 		}
 	}
 
-	var dropErr error
-	if capabilities.retryFailedDDL {
-		dropErr = dropCleanupObjects(ctx, sqlTx, objects)
-	} else {
-		dropErr = dropCleanupObjectsOnce(ctx, sqlTx, objects)
-	}
+	dropErr := capabilities.dropObjects(ctx, sqlTx, objects)
 	if dropErr != nil {
 		return fmt.Errorf("refusing to clean schema %q: %w", w.schema, dropErr)
 	}
@@ -772,6 +910,13 @@ func (w *PostgreSQLWriter) dropDatabaseRealm(ctx context.Context) (resultErr err
 	if err != nil {
 		return err
 	}
+	if err := rejectProtectedPostgresDatabase(
+		ctx,
+		sqlTx,
+		capabilities.protectedDatabases,
+	); err != nil {
+		return err
+	}
 	rootMetadata, err := capturePostgresSchemaMetadata(ctx, sqlTx, w.schema)
 	if err != nil {
 		return err
@@ -780,28 +925,35 @@ func (w *PostgreSQLWriter) dropDatabaseRealm(ctx context.Context) (resultErr err
 	if err != nil {
 		return err
 	}
-	extensions, err := collectPostgresUserExtensions(
+	objects, err := w.collectAllObjects(
 		ctx,
 		sqlTx,
-		capabilities.systemExtensions,
+		postgresDatabaseCleanupScope(schemas, capabilities.systemExtensions),
 	)
 	if err != nil {
 		return err
 	}
-	if err := dropPostgresUserExtensions(ctx, sqlTx, extensions); err != nil {
-		return err
+	if capabilities.lockManagedRelations {
+		if err := w.lockManagedRelations(ctx, sqlTx, objects); err != nil {
+			return err
+		}
+	}
+
+	dropErr := capabilities.dropObjects(ctx, sqlTx, objects)
+	if dropErr != nil {
+		return fmt.Errorf("refusing to clean PostgreSQL database realm: %w", dropErr)
 	}
 
 	preservedSchemas := []string{w.schema}
+	droppableSchemas := schemas
 	if capabilities.preservePublicSchema {
 		preservedSchemas = appendUniqueString(preservedSchemas, "public")
-		if err := w.dropCockroachDatabaseRealm(ctx, sqlTx, schemas, rootMetadata); err != nil {
-			return err
-		}
-	} else {
-		if err := dropPostgresUserSchemas(ctx, sqlTx, schemas); err != nil {
-			return err
-		}
+		droppableSchemas = excludeString(droppableSchemas, "public")
+	}
+	if err := dropPostgresUserSchemas(ctx, sqlTx, droppableSchemas); err != nil {
+		return err
+	}
+	if !capabilities.preservePublicSchema || w.schema != "public" {
 		if err := restorePostgresRootSchema(ctx, sqlTx, w.schema, rootMetadata); err != nil {
 			return err
 		}
@@ -819,33 +971,6 @@ func (w *PostgreSQLWriter) dropDatabaseRealm(ctx context.Context) (resultErr err
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 	committed = true
-	return nil
-}
-
-func (w *PostgreSQLWriter) dropCockroachDatabaseRealm(
-	ctx context.Context,
-	tx *sql.Tx,
-	schemas []string,
-	rootMetadata postgresSchemaMetadata,
-) error {
-	droppableSchemas := excludeString(schemas, "public")
-	if err := dropPostgresUserSchemas(ctx, tx, droppableSchemas); err != nil {
-		return err
-	}
-
-	publicObjects, err := w.collectAllObjects(ctx, tx, []string{"public"})
-	if err != nil {
-		return err
-	}
-	if err := dropCleanupObjectsOnce(ctx, tx, publicObjects); err != nil {
-		return fmt.Errorf("refusing to clean PostgreSQL database realm: %w", err)
-	}
-
-	if w.schema != "public" {
-		if err := restorePostgresRootSchema(ctx, tx, w.schema, rootMetadata); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -965,67 +1090,11 @@ func dropPostgresUserSchemas(ctx context.Context, tx *sql.Tx, schemas []string) 
 		// Schema names come from pg_namespace and are quoted as identifiers;
 		// PostgreSQL-family DDL does not support identifier bind parameters.
 		//nolint:gosec // The catalog identifier is quoted through sqlident.
-		statement := "DROP SCHEMA IF EXISTS " + quoteIdent(schema) + " CASCADE"
+		statement := "DROP SCHEMA IF EXISTS " + quoteIdent(schema) + " RESTRICT"
 		if _, err := tx.ExecContext(ctx, statement); err != nil {
 			return fmt.Errorf(
 				"failed to drop user schema %q from PostgreSQL database realm: %w",
 				schema,
-				err,
-			)
-		}
-	}
-	return nil
-}
-
-func collectPostgresUserExtensions(
-	ctx context.Context,
-	tx *sql.Tx,
-	systemExtensions []string,
-) ([]postgresExtensionCleanup, error) {
-	query := `
-		SELECT
-			e.extname,
-			format('DROP EXTENSION IF EXISTS %I CASCADE', e.extname)
-		FROM pg_extension e
-	`
-	var args []any
-	if len(systemExtensions) > 0 {
-		//nolint:gosec // Only internally generated positional placeholders are interpolated.
-		query += " WHERE e.extname NOT IN (" + postgresPlaceholders(len(systemExtensions)) + ")"
-		args = stringsToAny(systemExtensions)
-	}
-	query += " ORDER BY e.extname"
-
-	rows, err := tx.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query PostgreSQL user extensions: %w", err)
-	}
-	defer rows.Close()
-
-	var extensions []postgresExtensionCleanup
-	for rows.Next() {
-		var extension postgresExtensionCleanup
-		if err := rows.Scan(&extension.name, &extension.statement); err != nil {
-			return nil, fmt.Errorf("failed to scan PostgreSQL user extension: %w", err)
-		}
-		extensions = append(extensions, extension)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate PostgreSQL user extensions: %w", err)
-	}
-	return extensions, nil
-}
-
-func dropPostgresUserExtensions(
-	ctx context.Context,
-	tx *sql.Tx,
-	extensions []postgresExtensionCleanup,
-) error {
-	for _, extension := range extensions {
-		if _, err := tx.ExecContext(ctx, extension.statement); err != nil {
-			return fmt.Errorf(
-				"failed to drop user extension %q from PostgreSQL database realm: %w",
-				extension.name,
 				err,
 			)
 		}

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -10,15 +10,13 @@ import (
 	"sync"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
-// quoteIdent returns a safely-quoted PostgreSQL identifier. Embedded double
-// quotes are doubled per the SQL standard so that values coming from
-// information_schema (or any other untrusted-shaped string) cannot terminate
-// the quoted identifier and inject DDL.
 func quoteIdent(name string) string {
-	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	return sqlident.Quote(platform.Postgres, name)
 }
 
 // PostgreSQLWriter writes schemas to PostgreSQL databases
@@ -182,84 +180,237 @@ func (w *postgresTransactionWriter) Rollback() error {
 // IsDryRun returns whether dry-run mode is enabled.
 func (w *postgresTransactionWriter) IsDryRun() bool { return w.dryRun }
 
-func (w *PostgreSQLWriter) collectAllObjects(ctx context.Context) (tables []string, enums []string, sequences []string, err error) { //revive:disable-line:function-result-limit // It's acceptable here
-	// Get all tables in the schema
-	tablesQuery := `
-			SELECT table_name
-			FROM information_schema.tables
-			WHERE table_schema = $1 AND table_type = 'BASE TABLE'
-			ORDER BY table_name`
+type postgresCleanupObject struct {
+	Kind      string
+	Name      string
+	Statement string
+}
 
-	rows, err := w.db.QueryContext(ctx, tablesQuery, w.schema)
+func (w *PostgreSQLWriter) rejectSchemaScopedExtensions(ctx context.Context, tx *sql.Tx) error {
+	// DROP EXTENSION removes every member regardless of the member's schema.
+	// Refuse it here because a schema-scoped cleanup cannot safely own that
+	// database-wide operation, even when DROP EXTENSION uses RESTRICT.
+	var count int
+	var first string
+	err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(MIN(e.extname), '')
+		FROM pg_extension e
+		JOIN pg_namespace n ON n.oid = e.extnamespace
+		WHERE n.nspname = $1
+	`, w.schema).Scan(&count, &first)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to query tables: %w", err)
+		return fmt.Errorf("failed to inspect schema-owned extensions: %w", err)
+	}
+	if count > 0 {
+		return fmt.Errorf(
+			"refusing to clean schema %q: extension %q is owned by it; "+
+				"schema-scoped cleanup cannot prove that every extension member is confined to the schema",
+			w.schema,
+			first,
+		)
+	}
+	return nil
+}
+
+func (w *PostgreSQLWriter) collectAllObjects(
+	ctx context.Context,
+	tx *sql.Tx,
+) ([]postgresCleanupObject, error) {
+	rows, err := tx.QueryContext(ctx, `
+		WITH cleanup_objects AS (
+			SELECT
+				0 AS priority,
+				'constraint'::text AS object_kind,
+				con.conname AS object_name,
+				format(
+					'ALTER TABLE %I.%I DROP CONSTRAINT IF EXISTS %I RESTRICT',
+					n.nspname,
+					c.relname,
+					con.conname
+				) AS drop_statement
+			FROM pg_constraint con
+			JOIN pg_class c ON c.oid = con.conrelid
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = $1
+			  AND con.contype = 'f'
+
+			UNION ALL
+
+			SELECT
+				CASE c.relkind
+					WHEN 'v' THEN 10
+					WHEN 'm' THEN 10
+					WHEN 'S' THEN 30
+					ELSE 20
+				END,
+				CASE c.relkind
+					WHEN 'v' THEN 'view'
+					WHEN 'm' THEN 'materialized view'
+					WHEN 'f' THEN 'foreign table'
+					WHEN 'S' THEN 'sequence'
+					ELSE 'table'
+				END,
+				c.relname,
+				format(
+					CASE c.relkind
+						WHEN 'v' THEN 'DROP VIEW IF EXISTS %I.%I RESTRICT'
+						WHEN 'm' THEN 'DROP MATERIALIZED VIEW IF EXISTS %I.%I RESTRICT'
+						WHEN 'f' THEN 'DROP FOREIGN TABLE IF EXISTS %I.%I RESTRICT'
+						WHEN 'S' THEN 'DROP SEQUENCE IF EXISTS %I.%I RESTRICT'
+						ELSE 'DROP TABLE IF EXISTS %I.%I RESTRICT'
+					END,
+					n.nspname,
+					c.relname
+				)
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = $1
+			  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+
+			UNION ALL
+
+			SELECT
+				40,
+				CASE p.prokind
+					WHEN 'p' THEN 'procedure'
+					WHEN 'a' THEN 'aggregate'
+					ELSE 'function'
+				END,
+				p.proname,
+				format(
+					'DROP %s IF EXISTS %I.%I(%s) RESTRICT',
+					CASE p.prokind
+						WHEN 'p' THEN 'PROCEDURE'
+						WHEN 'a' THEN 'AGGREGATE'
+						ELSE 'FUNCTION'
+					END,
+					n.nspname,
+					p.proname,
+					pg_get_function_identity_arguments(p.oid)
+				)
+			FROM pg_proc p
+			JOIN pg_namespace n ON n.oid = p.pronamespace
+			WHERE n.nspname = $1
+			  AND p.prokind IN ('f', 'p', 'a', 'w')
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM pg_depend d
+				WHERE d.classid = 'pg_proc'::regclass
+				  AND d.objid = p.oid
+				  AND d.deptype = 'i'
+			  )
+
+			UNION ALL
+
+			SELECT
+				50,
+				'type',
+				t.typname,
+				format('DROP TYPE IF EXISTS %I.%I RESTRICT', n.nspname, t.typname)
+			FROM pg_type t
+			JOIN pg_namespace n ON n.oid = t.typnamespace
+			LEFT JOIN pg_class c ON c.oid = t.typrelid
+			WHERE n.nspname = $1
+				  AND (
+				t.typtype IN ('e', 'd', 'r')
+				OR (t.typtype = 'c' AND c.relkind = 'c')
+			  )
+		)
+		SELECT object_kind, object_name, drop_statement
+		FROM cleanup_objects
+		ORDER BY priority, object_kind, object_name
+	`, w.schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query schema objects: %w", err)
 	}
 	defer rows.Close()
 
+	var objects []postgresCleanupObject
 	for rows.Next() {
-		var tableName string
-		if err := rows.Scan(&tableName); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to scan table name: %w", err)
+		var object postgresCleanupObject
+		if err := rows.Scan(&object.Kind, &object.Name, &object.Statement); err != nil {
+			return nil, fmt.Errorf("failed to scan schema object: %w", err)
 		}
-		tables = append(tables, tableName)
+		objects = append(objects, object)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to iterate tables: %w", err)
+		return nil, fmt.Errorf("failed to iterate schema objects: %w", err)
 	}
-
-	// Get all custom types (enums) in the schema
-	enumsQuery := `
-			SELECT typname
-			FROM pg_type t
-			JOIN pg_namespace n ON t.typnamespace = n.oid
-			WHERE n.nspname = $1 AND t.typtype = 'e'
-			ORDER BY typname`
-
-	enumRows, err := w.db.QueryContext(ctx, enumsQuery, w.schema)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to query enums: %w", err)
-	}
-	defer enumRows.Close()
-
-	for enumRows.Next() {
-		var enumName string
-		if err := enumRows.Scan(&enumName); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to scan enum name: %w", err)
-		}
-		enums = append(enums, enumName)
-	}
-	if err := enumRows.Err(); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to iterate enums: %w", err)
-	}
-
-	// Get all sequences in the schema
-	sequencesQuery := `
-			SELECT sequence_name
-			FROM information_schema.sequences
-			WHERE sequence_schema = $1
-			ORDER BY sequence_name`
-
-	seqRows, err := w.db.QueryContext(ctx, sequencesQuery, w.schema)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to query sequences: %w", err)
-	}
-	defer seqRows.Close()
-
-	for seqRows.Next() {
-		var sequenceName string
-		if err := seqRows.Scan(&sequenceName); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to scan sequence name: %w", err)
-		}
-		sequences = append(sequences, sequenceName)
-	}
-	if err := seqRows.Err(); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to iterate sequences: %w", err)
-	}
-
-	return tables, enums, sequences, nil
+	return objects, nil
 }
 
-// DropAllTables drops ALL tables and enums in the database schema (COMPLETE CLEANUP!)
+func tryDropCleanupObject(
+	ctx context.Context,
+	tx *sql.Tx,
+	object postgresCleanupObject,
+) (dropErr error, controlErr error) {
+	const savepoint = "ptah_cleanup_object"
+
+	if _, err := tx.ExecContext(ctx, "SAVEPOINT "+savepoint); err != nil {
+		return nil, fmt.Errorf("failed to create cleanup savepoint: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, object.Statement); err != nil {
+		dropErr = fmt.Errorf("SQL execution failed: %w\nSQL: %s", err, object.Statement)
+		if _, rollbackErr := tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+savepoint); rollbackErr != nil {
+			controlErr = fmt.Errorf("failed to roll back cleanup savepoint: %w", rollbackErr)
+		}
+		if _, releaseErr := tx.ExecContext(ctx, "RELEASE SAVEPOINT "+savepoint); releaseErr != nil {
+			controlErr = errors.Join(controlErr, fmt.Errorf("failed to release cleanup savepoint: %w", releaseErr))
+		}
+		return dropErr, controlErr
+	}
+
+	if _, err := tx.ExecContext(ctx, "RELEASE SAVEPOINT "+savepoint); err != nil {
+		return nil, fmt.Errorf("failed to release cleanup savepoint: %w", err)
+	}
+	return nil, nil
+}
+
+func dropCleanupObjects(
+	ctx context.Context,
+	tx *sql.Tx,
+	objects []postgresCleanupObject,
+) error {
+	// RESTRICT remains the final authority for every drop. Savepoints let a
+	// later internal dependent disappear before its dependency is retried,
+	// while an external or unknown dependency eventually stops all progress
+	// and causes the outer transaction to roll back.
+	pending := objects
+	for len(pending) > 0 {
+		remaining := make([]postgresCleanupObject, 0, len(pending))
+		var firstDropErr error
+
+		for _, object := range pending {
+			dropErr, controlErr := tryDropCleanupObject(ctx, tx, object)
+			if controlErr != nil {
+				return fmt.Errorf(
+					"failed to drop %s %s: %w",
+					object.Kind,
+					object.Name,
+					errors.Join(dropErr, controlErr),
+				)
+			}
+			if dropErr != nil {
+				if firstDropErr == nil {
+					firstDropErr = fmt.Errorf("failed to drop %s %s: %w", object.Kind, object.Name, dropErr)
+				}
+				remaining = append(remaining, object)
+			}
+		}
+
+		if len(remaining) == 0 {
+			return nil
+		}
+		if len(remaining) == len(pending) {
+			return firstDropErr
+		}
+		pending = remaining
+	}
+	return nil
+}
+
+// DropAllTables drops all user objects in the configured database schema.
 func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) {
 	if w.dryRun {
 		return nil
@@ -268,53 +419,33 @@ func (w *PostgreSQLWriter) DropAllTables(ctx context.Context) (resultErr error) 
 		return fmt.Errorf("no database connection")
 	}
 
-	tables, enums, sequences, err := w.collectAllObjects(ctx)
-	if err != nil {
-		return err
-	}
-
-	tx, err := w.BeginTransaction(ctx)
+	sqlTx, err := w.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	committed := false
 	defer func() {
 		if !committed {
-			rollbackErr := tx.Rollback()
+			rollbackErr := sqlTx.Rollback()
 			if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
 				resultErr = errors.Join(resultErr, fmt.Errorf("failed to roll back transaction: %w", rollbackErr))
 			}
 		}
 	}()
 
-	// Drop all tables with CASCADE to handle dependencies. Identifiers cannot
-	// be bound as parameters; quoteIdent doubles any embedded `"` so a hostile
-	// name coming back from information_schema cannot break out of the quoted
-	// identifier.
-	for _, tableName := range tables {
-		dropSQL := "DROP TABLE IF EXISTS " + quoteIdent(tableName) + " CASCADE"
-		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
-			return fmt.Errorf("failed to drop table %s: %w", tableName, err)
-		}
+	if err := w.rejectSchemaScopedExtensions(ctx, sqlTx); err != nil {
+		return err
+	}
+	objects, err := w.collectAllObjects(ctx, sqlTx)
+	if err != nil {
+		return err
 	}
 
-	// Drop all enums
-	for _, enumName := range enums {
-		dropSQL := "DROP TYPE IF EXISTS " + quoteIdent(enumName) + " CASCADE"
-		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
-			return fmt.Errorf("failed to drop enum %s: %w", enumName, err)
-		}
+	if err := dropCleanupObjects(ctx, sqlTx, objects); err != nil {
+		return fmt.Errorf("refusing to clean schema %q: %w", w.schema, err)
 	}
 
-	// Drop all sequences
-	for _, sequenceName := range sequences {
-		dropSQL := "DROP SEQUENCE IF EXISTS " + quoteIdent(sequenceName) + " CASCADE"
-		if err := tx.ExecuteSQL(ctx, dropSQL); err != nil {
-			return fmt.Errorf("failed to drop sequence %s: %w", sequenceName, err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
+	if err := sqlTx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 	committed = true

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -3,6 +3,8 @@ package postgres_test
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -25,9 +27,244 @@ func TestWriterDropAllTables_CanceledContext(t *testing.T) {
 	c.Assert(db.BeginCount(), qt.Equals, 0)
 }
 
+func TestWriterDropAllTables_CommitsAllCatalogObjects(t *testing.T) {
+	c := qt.New(t)
+	var catalogQueries []string
+	var catalogArgs [][]driver.NamedValue
+	db := dbtest.OpenWithExec(t, func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+		catalogQueries = append(catalogQueries, query)
+		catalogArgs = append(catalogArgs, args)
+		return postgresCleanupQuery(query, args)
+	}, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(catalogQueries, qt.HasLen, 2)
+	c.Assert(catalogQueries[0], qt.Contains, "SELECT COUNT(*)")
+	c.Assert(catalogQueries[0], qt.Contains, "FROM pg_extension")
+	c.Assert(catalogQueries[1], qt.Contains, "cleanup_objects")
+	c.Assert(catalogQueries[1], qt.Contains, "FROM pg_constraint")
+	c.Assert(catalogQueries[1], qt.Contains, "con.contype = 'f'")
+	c.Assert(catalogQueries[1], qt.Contains, "p.prokind IN ('f', 'p', 'a', 'w')")
+	c.Assert(catalogQueries[1], qt.Contains, "d.deptype = 'i'")
+	c.Assert(catalogQueries[1], qt.Contains, "t.typtype IN ('e', 'd', 'r')")
+	c.Assert(catalogQueries[1], qt.Contains, "RESTRICT")
+	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "CASCADE")
+	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "dependent_objects")
+	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "d.deptype = 'e'")
+	c.Assert(catalogArgs, qt.DeepEquals, [][]driver.NamedValue{
+		{{Ordinal: 1, Value: "public"}},
+		{{Ordinal: 1, Value: "public"}},
+	})
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(db.ExecCount(), qt.Equals, 30)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropAllTables_RollsBackOnFailure(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.OpenWithExec(t, postgresCleanupQuery, failPostgresTypeDrop)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`refusing to clean schema "public": failed to drop type status: SQL execution failed: boom\nSQL: DROP TYPE IF EXISTS "public"."status" RESTRICT`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.ExecCount(), qt.Equals, 35)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_RejectsSchemaScopedExtensions(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.OpenWithExec(t, func(
+		query string,
+		_ []driver.NamedValue,
+	) (dbtest.QueryResult, error) {
+		return dbtest.QueryResult{
+			Columns: []string{"count", "first"},
+			Rows: [][]driver.Value{{
+				int64(1),
+				"hstore",
+			}},
+		}, nil
+	}, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`refusing to clean schema "public": extension "hstore" is owned by it; schema-scoped cleanup cannot prove that every extension member is confined to the schema`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 1)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_RejectsExternalPolicyDependency(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.OpenWithExec(t, postgresPolicyCleanupQuery, failPostgresPolicyDependency)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`refusing to clean schema "public": failed to drop function is_allowed: SQL execution failed: cannot drop function public\.is_allowed\(\) because policy audit_policy depends on it\nSQL: DROP FUNCTION IF EXISTS "public"."is_allowed"\(\) RESTRICT`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_ResolvesInternalDependencies(t *testing.T) {
+	c := qt.New(t)
+	execHandler := new(postgresInternalDependencyExec)
+	db := dbtest.OpenWithExec(t, postgresInternalDependencyQuery, execHandler.execute)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(db.ExecCount(), qt.Equals, 10)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropAllTables_PreservesDropErrorWhenSavepointRecoveryFails(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.OpenWithExec(t, postgresPolicyCleanupQuery, failPostgresDropAndSavepointRollback)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(err.Error(), qt.Contains, "failed to roll back cleanup savepoint: rollback failed")
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
 func emptyPostgresCleanupQuery(
-	_ string,
+	query string,
 	_ []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
+	if strings.Contains(query, "FROM pg_extension") {
+		return noPostgresSchemaOwnedExtensions(), nil
+	}
 	return dbtest.QueryResult{}, nil
+}
+
+func postgresCleanupQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if strings.Contains(query, "FROM pg_extension") {
+		return noPostgresSchemaOwnedExtensions(), nil
+	}
+	return dbtest.QueryResult{
+		Columns: []string{"object_kind", "object_name", "drop_statement"},
+		Rows: [][]driver.Value{
+			{"constraint", "users_parent_fkey", `ALTER TABLE "public"."users" DROP CONSTRAINT IF EXISTS "users_parent_fkey" RESTRICT`},
+			{"view", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
+			{"materialized view", "user_stats", `DROP MATERIALIZED VIEW IF EXISTS "public"."user_stats" RESTRICT`},
+			{"foreign table", "remote_users", `DROP FOREIGN TABLE IF EXISTS "public"."remote_users" RESTRICT`},
+			{"table", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
+			{"sequence", "users_id_seq", `DROP SEQUENCE IF EXISTS "public"."users_id_seq" RESTRICT`},
+			{"procedure", "refresh_users", `DROP PROCEDURE IF EXISTS "public"."refresh_users"() RESTRICT`},
+			{"aggregate", "sum_text", `DROP AGGREGATE IF EXISTS "public"."sum_text"(text) RESTRICT`},
+			{"function", "normalize_email", `DROP FUNCTION IF EXISTS "public"."normalize_email"(text) RESTRICT`},
+			{"type", "status", `DROP TYPE IF EXISTS "public"."status" RESTRICT`},
+		},
+	}, nil
+}
+
+func noPostgresSchemaOwnedExtensions() dbtest.QueryResult {
+	return dbtest.QueryResult{
+		Columns: []string{"count", "first"},
+		Rows:    [][]driver.Value{{int64(0), ""}},
+	}
+}
+
+func postgresPolicyCleanupQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if strings.Contains(query, "FROM pg_extension") {
+		return noPostgresSchemaOwnedExtensions(), nil
+	}
+	return dbtest.QueryResult{
+		Columns: []string{"object_kind", "object_name", "drop_statement"},
+		Rows: [][]driver.Value{{
+			"function",
+			"is_allowed",
+			`DROP FUNCTION IF EXISTS "public"."is_allowed"() RESTRICT`,
+		}},
+	}, nil
+}
+
+func postgresInternalDependencyQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if strings.Contains(query, "FROM pg_extension") {
+		return noPostgresSchemaOwnedExtensions(), nil
+	}
+	return dbtest.QueryResult{
+		Columns: []string{"object_kind", "object_name", "drop_statement"},
+		Rows: [][]driver.Value{
+			{"table", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
+			{"view", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
+		},
+	}, nil
+}
+
+func failPostgresTypeDrop(query string, _ []driver.NamedValue) (driver.Result, error) {
+	if strings.Contains(query, "DROP TYPE") {
+		return nil, errors.New("boom")
+	}
+	return driver.RowsAffected(0), nil
+}
+
+func failPostgresPolicyDependency(query string, _ []driver.NamedValue) (driver.Result, error) {
+	if strings.Contains(query, "DROP FUNCTION") {
+		return nil, errors.New("cannot drop function public.is_allowed() because policy audit_policy depends on it")
+	}
+	return driver.RowsAffected(0), nil
+}
+
+func failPostgresDropAndSavepointRollback(query string, _ []driver.NamedValue) (driver.Result, error) {
+	if strings.Contains(query, "DROP FUNCTION") {
+		return nil, context.Canceled
+	}
+	if strings.Contains(query, "ROLLBACK TO SAVEPOINT") {
+		return nil, errors.New("rollback failed")
+	}
+	return driver.RowsAffected(0), nil
+}
+
+type postgresInternalDependencyExec struct {
+	viewDropped bool
+}
+
+func (e *postgresInternalDependencyExec) execute(
+	query string,
+	_ []driver.NamedValue,
+) (driver.Result, error) {
+	if strings.Contains(query, "DROP VIEW") {
+		e.viewDropped = true
+	}
+	if strings.Contains(query, "DROP TABLE") && !e.viewDropped {
+		return nil, errors.New("cannot drop table because view depends on it")
+	}
+	return driver.RowsAffected(0), nil
 }

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -31,36 +31,55 @@ func TestWriterDropAllTables_CommitsAllCatalogObjects(t *testing.T) {
 	c := qt.New(t)
 	var catalogQueries []string
 	var catalogArgs [][]driver.NamedValue
+	var execQueries []string
+	var events []string
 	db := dbtest.OpenWithExec(t, func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
 		catalogQueries = append(catalogQueries, query)
 		catalogArgs = append(catalogArgs, args)
+		events = append(events, "query: "+query)
 		return postgresCleanupQuery(query, args)
-	}, nil)
+	}, func(query string, _ []driver.NamedValue) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		events = append(events, "exec: "+query)
+		return driver.RowsAffected(0), nil
+	})
 	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
 
 	err := writer.DropAllTables(t.Context())
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(catalogQueries, qt.HasLen, 2)
-	c.Assert(catalogQueries[0], qt.Contains, "SELECT COUNT(*)")
-	c.Assert(catalogQueries[0], qt.Contains, "FROM pg_extension")
-	c.Assert(catalogQueries[1], qt.Contains, "cleanup_objects")
-	c.Assert(catalogQueries[1], qt.Contains, "FROM pg_constraint")
-	c.Assert(catalogQueries[1], qt.Contains, "con.contype = 'f'")
-	c.Assert(catalogQueries[1], qt.Contains, "p.prokind IN ('f', 'p', 'a', 'w')")
-	c.Assert(catalogQueries[1], qt.Contains, "d.deptype = 'i'")
-	c.Assert(catalogQueries[1], qt.Contains, "t.typtype IN ('e', 'd', 'r')")
-	c.Assert(catalogQueries[1], qt.Contains, "RESTRICT")
-	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "CASCADE")
-	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "dependent_objects")
-	c.Assert(catalogQueries[1], qt.Not(qt.Contains), "d.deptype = 'e'")
-	c.Assert(catalogArgs, qt.DeepEquals, [][]driver.NamedValue{
-		{{Ordinal: 1, Value: "public"}},
-		{{Ordinal: 1, Value: "public"}},
-	})
+	c.Assert(catalogQueries, qt.HasLen, 4)
+	c.Assert(catalogQueries[0], qt.Equals, "SELECT version()")
+	c.Assert(catalogQueries[1], qt.Contains, "SELECT COUNT(*)")
+	c.Assert(catalogQueries[1], qt.Contains, "FROM pg_extension")
+	c.Assert(catalogQueries[2], qt.Contains, "cleanup_objects")
+	c.Assert(catalogQueries[2], qt.Contains, "view_dependencies")
+	c.Assert(catalogQueries[2], qt.Contains, "ORDER BY priority, dependency_depth DESC")
+	c.Assert(catalogQueries[2], qt.Contains, "FROM pg_constraint")
+	c.Assert(catalogQueries[2], qt.Contains, "con.contype = 'f'")
+	c.Assert(catalogQueries[2], qt.Contains, "p.prokind IN ('f', 'p', 'a', 'w')")
+	c.Assert(catalogQueries[2], qt.Contains, "d.deptype = 'i'")
+	c.Assert(catalogQueries[2], qt.Contains, "t.typtype IN ('e', 'd', 'r')")
+	c.Assert(catalogQueries[2], qt.Contains, "RESTRICT")
+	c.Assert(catalogQueries[2], qt.Not(qt.Contains), "CASCADE")
+	c.Assert(catalogQueries[2], qt.Not(qt.Contains), "dependent_objects")
+	c.Assert(catalogQueries[2], qt.Not(qt.Contains), "d.deptype = 'e'")
+	c.Assert(catalogQueries[3], qt.Contains, "FROM pg_inherits")
+	c.Assert(catalogQueries[3], qt.Contains, "child.relispartition")
+	c.Assert(catalogArgs[0], qt.HasLen, 0)
+	c.Assert(catalogArgs[1], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[2], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[3], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(execQueries[0], qt.Equals,
+		`LOCK TABLE "public"."remote_users", "public"."users" IN ACCESS EXCLUSIVE MODE`)
+	c.Assert(events[0], qt.Contains, "query: SELECT version()")
+	c.Assert(events[1], qt.Contains, "FROM pg_extension")
+	c.Assert(events[2], qt.Contains, "cleanup_objects")
+	c.Assert(events[3], qt.Contains, "exec: LOCK TABLE")
+	c.Assert(events[4], qt.Contains, "FROM pg_inherits")
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 2)
-	c.Assert(db.ExecCount(), qt.Equals, 30)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
+	c.Assert(db.ExecCount(), qt.Equals, 31)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
@@ -75,25 +94,15 @@ func TestWriterDropAllTables_RollsBackOnFailure(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`refusing to clean schema "public": failed to drop type status: SQL execution failed: boom\nSQL: DROP TYPE IF EXISTS "public"."status" RESTRICT`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.ExecCount(), qt.Equals, 35)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
+	c.Assert(db.ExecCount(), qt.Equals, 36)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
 }
 
 func TestWriterDropAllTables_RejectsSchemaScopedExtensions(t *testing.T) {
 	c := qt.New(t)
-	db := dbtest.OpenWithExec(t, func(
-		query string,
-		_ []driver.NamedValue,
-	) (dbtest.QueryResult, error) {
-		return dbtest.QueryResult{
-			Columns: []string{"count", "first"},
-			Rows: [][]driver.Value{{
-				int64(1),
-				"hstore",
-			}},
-		}, nil
-	}, nil)
+	db := dbtest.OpenWithExec(t, postgresSchemaScopedExtensionQuery, nil)
 	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
 
 	err := writer.DropAllTables(t.Context())
@@ -101,7 +110,7 @@ func TestWriterDropAllTables_RejectsSchemaScopedExtensions(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`refusing to clean schema "public": extension "hstore" is owned by it; schema-scoped cleanup cannot prove that every extension member is confined to the schema`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 2)
 	c.Assert(db.ExecCount(), qt.Equals, 0)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -117,7 +126,7 @@ func TestWriterDropAllTables_RejectsExternalPolicyDependency(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`refusing to clean schema "public": failed to drop function is_allowed: SQL execution failed: cannot drop function public\.is_allowed\(\) because policy audit_policy depends on it\nSQL: DROP FUNCTION IF EXISTS "public"."is_allowed"\(\) RESTRICT`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
 	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -133,10 +142,285 @@ func TestWriterDropAllTables_ResolvesInternalDependencies(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 2)
-	c.Assert(db.ExecCount(), qt.Equals, 10)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
+	c.Assert(db.ExecCount(), qt.Equals, 11)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropAllTables_CockroachUsesCatalogOrderWithoutSavepoints(t *testing.T) {
+	c := qt.New(t)
+	var execQueries []string
+	db := dbtest.OpenWithExec(t, cockroachOrderedDependencyQuery, func(
+		query string,
+		_ []driver.NamedValue,
+	) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		return driver.RowsAffected(0), nil
+	})
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(execQueries, qt.DeepEquals, []string{
+		`DROP VIEW IF EXISTS "public"."z_dependent_view" RESTRICT`,
+		`DROP VIEW IF EXISTS "public"."a_base_view" RESTRICT`,
+		`DROP TABLE IF EXISTS "public"."users" RESTRICT`,
+	})
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 3)
+	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
+	c := qt.New(t)
+	var catalogQueries []string
+	var catalogArgs [][]driver.NamedValue
+	var execQueries []string
+	queryHandler := newPostgresRealmMetadataQuery()
+	db := dbtest.OpenWithExec(t, func(
+		query string,
+		args []driver.NamedValue,
+	) (dbtest.QueryResult, error) {
+		catalogQueries = append(catalogQueries, query)
+		catalogArgs = append(catalogArgs, args)
+		return queryHandler.query(query, args)
+	}, func(query string, _ []driver.NamedValue) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		return driver.RowsAffected(0), nil
+	})
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(catalogQueries, qt.HasLen, 8)
+	c.Assert(catalogQueries[0], qt.Equals, "SELECT version()")
+	c.Assert(catalogQueries[1], qt.Contains, "obj_description")
+	c.Assert(catalogQueries[1], qt.Contains, "COMMENT ON SCHEMA %I IS %L")
+	c.Assert(catalogQueries[2], qt.Contains, "aclexplode")
+	c.Assert(catalogQueries[3], qt.Contains, "n.nspname NOT LIKE 'pg\\_%'")
+	c.Assert(catalogQueries[3], qt.Not(qt.Contains), "n.nspname NOT LIKE 'yb\\_%'")
+	c.Assert(catalogQueries[4], qt.Contains, "DROP EXTENSION IF EXISTS %I CASCADE")
+	c.Assert(catalogQueries[6], qt.Contains, "SELECT e.extname FROM pg_extension")
+	c.Assert(catalogQueries[7], qt.Contains, "residual_objects")
+	c.Assert(catalogQueries[7], qt.Contains, "FROM pg_collation")
+	c.Assert(catalogQueries[7], qt.Contains, "FROM pg_default_acl")
+	c.Assert(catalogArgs[0], qt.HasLen, 0)
+	c.Assert(catalogArgs[1], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[2], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[3], qt.HasLen, 0)
+	c.Assert(catalogArgs[4], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
+	c.Assert(catalogArgs[5], qt.HasLen, 0)
+	c.Assert(catalogArgs[6], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
+	c.Assert(catalogArgs[7], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(execQueries, qt.DeepEquals, []string{
+		`DROP EXTENSION IF EXISTS "hstore" CASCADE`,
+		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
+		`DROP SCHEMA IF EXISTS "public" CASCADE`,
+		`CREATE SCHEMA "public" AUTHORIZATION "app_owner"`,
+		`REVOKE ALL PRIVILEGES ON SCHEMA "public" FROM PUBLIC`,
+		`REVOKE ALL PRIVILEGES ON SCHEMA "public" FROM "app_owner"`,
+		`REVOKE ALL PRIVILEGES ON SCHEMA "public" FROM "app_reader"`,
+		`GRANT CREATE ON SCHEMA "public" TO "app_owner"`,
+		`GRANT USAGE ON SCHEMA "public" TO "app_owner"`,
+		`GRANT USAGE ON SCHEMA "public" TO "app_reader" WITH GRANT OPTION`,
+		`GRANT USAGE ON SCHEMA "public" TO PUBLIC`,
+		`COMMENT ON SCHEMA "public" IS 'application root'`,
+	})
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 8)
+	c.Assert(db.ExecCount(), qt.Equals, 12)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_CreatesAbsentRootSchema(t *testing.T) {
+	c := qt.New(t)
+	var execQueries []string
+	queryHandler := newPostgresRealmAbsentRootQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, func(
+		query string,
+		_ []driver.NamedValue,
+	) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		return driver.RowsAffected(0), nil
+	})
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "shadow")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(execQueries, qt.DeepEquals, []string{
+		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
+		`DROP SCHEMA IF EXISTS "public" CASCADE`,
+		`CREATE SCHEMA "shadow"`,
+	})
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 7)
+	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_CockroachPreservesPublicSchemaContainer(t *testing.T) {
+	c := qt.New(t)
+	var execQueries []string
+	queryHandler := newPostgresRealmCockroachQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, func(
+		query string,
+		_ []driver.NamedValue,
+	) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		return driver.RowsAffected(0), nil
+	})
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(execQueries, qt.DeepEquals, []string{
+		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
+		`DROP TABLE IF EXISTS "public"."stale_items" RESTRICT`,
+	})
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 8)
+	c.Assert(db.ExecCount(), qt.Equals, 2)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RollsBackOnResidualObject(t *testing.T) {
+	c := qt.New(t)
+	queryHandler := newPostgresRealmResidualQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`PostgreSQL database realm cleanup left residual collation "public"\."stale_collation"`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 7)
+	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsSystemRootSchema(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, emptyPostgresCleanupQuery)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "pg_catalog")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`refusing to clean PostgreSQL database realm with system root schema "pg_catalog"`)
+	c.Assert(db.BeginCount(), qt.Equals, 0)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RollsBackOnResidualExtension(t *testing.T) {
+	c := qt.New(t)
+	queryHandler := newPostgresRealmResidualExtensionQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`PostgreSQL database realm cleanup left residual user extension "hstore"`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 6)
+	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_CanceledContext(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, emptyPostgresCleanupQuery)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(db.BeginCount(), qt.Equals, 0)
+	c.Assert(db.QueryCount(), qt.Equals, 0)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RejectsUnsupportedPrivilegeBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	queryHandler := newPostgresRealmUnsupportedPrivilegeQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches,
+		`refusing to restore unsupported PostgreSQL schema privilege "TEMPORARY"`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 3)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_RejectsCrossSchemaPartitionEdges(t *testing.T) {
+	c := qt.New(t)
+	tests := []postgresPartitionEdgeTest{
+		{
+			name:          "external child",
+			managedName:   "events",
+			parentSchema:  "public",
+			parentName:    "events",
+			childSchema:   "archive",
+			childName:     "events_2025",
+			wantErrorExpr: `refusing to clean schema "public": partition "archive"\."events_2025" is attached to partitioned table "public"\."events" across the schema boundary`,
+		},
+		{
+			name:          "external parent",
+			managedName:   "events_2025",
+			parentSchema:  "archive",
+			parentName:    "events",
+			childSchema:   "public",
+			childName:     "events_2025",
+			wantErrorExpr: `refusing to clean schema "public": partition "public"\."events_2025" is attached to partitioned table "archive"\."events" across the schema boundary`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			var execQueries []string
+			db := dbtest.OpenWithExec(t, postgresPartitionEdgeQuery(test), func(
+				query string,
+				_ []driver.NamedValue,
+			) (driver.Result, error) {
+				execQueries = append(execQueries, query)
+				return driver.RowsAffected(0), nil
+			})
+			writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+			err := writer.DropAllTables(t.Context())
+
+			c.Assert(err, qt.ErrorMatches, test.wantErrorExpr)
+			c.Assert(execQueries, qt.DeepEquals, []string{
+				`LOCK TABLE "public"."` + test.managedName + `" IN ACCESS EXCLUSIVE MODE`,
+			})
+			c.Assert(db.BeginCount(), qt.Equals, 1)
+			c.Assert(db.QueryCount(), qt.Equals, 4)
+			c.Assert(db.ExecCount(), qt.Equals, 1)
+			c.Assert(db.CommitCount(), qt.Equals, 0)
+			c.Assert(db.RollbackCount(), qt.Equals, 1)
+		})
+	}
 }
 
 func TestWriterDropAllTables_PreservesDropErrorWhenSavepointRecoveryFails(t *testing.T) {
@@ -149,43 +433,288 @@ func TestWriterDropAllTables_PreservesDropErrorWhenSavepointRecoveryFails(t *tes
 	c.Assert(err, qt.ErrorIs, context.Canceled)
 	c.Assert(err.Error(), qt.Contains, "failed to roll back cleanup savepoint: rollback failed")
 	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
 	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
+type postgresPartitionEdgeTest struct {
+	name          string
+	managedName   string
+	parentSchema  string
+	parentName    string
+	childSchema   string
+	childName     string
+	wantErrorExpr string
 }
 
 func emptyPostgresCleanupQuery(
 	query string,
 	_ []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
-	if strings.Contains(query, "FROM pg_extension") {
-		return noPostgresSchemaOwnedExtensions(), nil
-	}
-	return dbtest.QueryResult{}, nil
+	return postgresCleanupCatalogQuery(query, "PostgreSQL 18.0", nil)
 }
 
 func postgresCleanupQuery(
 	query string,
 	_ []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
-	if strings.Contains(query, "FROM pg_extension") {
-		return noPostgresSchemaOwnedExtensions(), nil
+	return postgresCleanupCatalogQuery(query, "PostgreSQL 18.0", [][]driver.Value{
+		{"constraint", "public", "users_parent_fkey", `ALTER TABLE "public"."users" DROP CONSTRAINT IF EXISTS "users_parent_fkey" RESTRICT`},
+		{"view", "public", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
+		{"materialized view", "public", "user_stats", `DROP MATERIALIZED VIEW IF EXISTS "public"."user_stats" RESTRICT`},
+		{"foreign table", "public", "remote_users", `DROP FOREIGN TABLE IF EXISTS "public"."remote_users" RESTRICT`},
+		{"table", "public", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
+		{"sequence", "public", "users_id_seq", `DROP SEQUENCE IF EXISTS "public"."users_id_seq" RESTRICT`},
+		{"procedure", "public", "refresh_users", `DROP PROCEDURE IF EXISTS "public"."refresh_users"() RESTRICT`},
+		{"aggregate", "public", "sum_text", `DROP AGGREGATE IF EXISTS "public"."sum_text"(text) RESTRICT`},
+		{"function", "public", "normalize_email", `DROP FUNCTION IF EXISTS "public"."normalize_email"(text) RESTRICT`},
+		{"type", "public", "status", `DROP TYPE IF EXISTS "public"."status" RESTRICT`},
+	})
+}
+
+func postgresPolicyCleanupQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return postgresCleanupCatalogQuery(query, "PostgreSQL 18.0", [][]driver.Value{{
+		"function",
+		"public",
+		"is_allowed",
+		`DROP FUNCTION IF EXISTS "public"."is_allowed"() RESTRICT`,
+	}})
+}
+
+func postgresInternalDependencyQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return postgresCleanupCatalogQuery(query, "PostgreSQL 18.0", [][]driver.Value{
+		{"table", "public", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
+		{"view", "public", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
+	})
+}
+
+func cockroachOrderedDependencyQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return postgresCleanupCatalogQuery(
+		query,
+		"CockroachDB CCL v26.2.4",
+		[][]driver.Value{
+			{"view", "public", "z_dependent_view", `DROP VIEW IF EXISTS "public"."z_dependent_view" RESTRICT`},
+			{"view", "public", "a_base_view", `DROP VIEW IF EXISTS "public"."a_base_view" RESTRICT`},
+			{"table", "public", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
+		},
+	)
+}
+
+type postgresRealmQuery struct {
+	version           string
+	metadata          [][]driver.Value
+	privileges        [][]driver.Value
+	initialSchemas    [][]driver.Value
+	finalSchemas      [][]driver.Value
+	publicObjects     [][]driver.Value
+	userExtensions    [][]driver.Value
+	residualExtension [][]driver.Value
+	residualObjects   [][]driver.Value
+	schemaQueryCount  int
+}
+
+func newPostgresRealmMetadataQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version: "PostgreSQL 18.0",
+		metadata: [][]driver.Value{{
+			"app_owner",
+			false,
+			`COMMENT ON SCHEMA "public" IS 'application root'`,
+		}},
+		privileges: [][]driver.Value{
+			{"app_owner", "CREATE", false},
+			{"app_owner", "USAGE", false},
+			{"app_reader", "USAGE", true},
+			{"PUBLIC", "USAGE", false},
+		},
+		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
+		finalSchemas:   [][]driver.Value{{"public"}},
+		userExtensions: [][]driver.Value{{
+			"hstore",
+			`DROP EXTENSION IF EXISTS "hstore" CASCADE`,
+		}},
+	}
+}
+
+func newPostgresRealmAbsentRootQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:        "PostgreSQL 18.0",
+		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
+		finalSchemas:   [][]driver.Value{{"shadow"}},
+	}
+}
+
+func newPostgresRealmCockroachQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:        "CockroachDB CCL v26.2.4",
+		metadata:       [][]driver.Value{{"root", true, `COMMENT ON SCHEMA "public" IS NULL`}},
+		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
+		finalSchemas:   [][]driver.Value{{"public"}},
+		publicObjects: [][]driver.Value{{
+			"table",
+			"public",
+			"stale_items",
+			`DROP TABLE IF EXISTS "public"."stale_items" RESTRICT`,
+		}},
+	}
+}
+
+func newPostgresRealmResidualQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:         "PostgreSQL 18.0",
+		metadata:        [][]driver.Value{{"app_owner", true, `COMMENT ON SCHEMA "public" IS NULL`}},
+		initialSchemas:  [][]driver.Value{{"public"}},
+		finalSchemas:    [][]driver.Value{{"public"}},
+		residualObjects: [][]driver.Value{{"collation", "public", "stale_collation"}},
+	}
+}
+
+func newPostgresRealmResidualExtensionQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:           "PostgreSQL 18.0",
+		metadata:          [][]driver.Value{{"app_owner", true, `COMMENT ON SCHEMA "public" IS NULL`}},
+		initialSchemas:    [][]driver.Value{{"public"}},
+		finalSchemas:      [][]driver.Value{{"public"}},
+		residualExtension: [][]driver.Value{{"hstore"}},
+	}
+}
+
+func newPostgresRealmUnsupportedPrivilegeQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:    "YugabyteDB 2026.1",
+		metadata:   [][]driver.Value{{"yugabyte", false, `COMMENT ON SCHEMA "public" IS NULL`}},
+		privileges: [][]driver.Value{{"yugabyte", "TEMPORARY", false}},
+	}
+}
+
+func (q *postgresRealmQuery) query(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	switch {
+	case strings.Contains(query, "SELECT version()"):
+		return postgresVersionResult(q.version), nil
+	case strings.Contains(query, "obj_description"):
+		return dbtest.QueryResult{
+			Columns: []string{"owner", "acl_is_default", "comment_statement"},
+			Rows:    q.metadata,
+		}, nil
+	case strings.Contains(query, "aclexplode"):
+		return dbtest.QueryResult{
+			Columns: []string{"grantee", "privilege_type", "is_grantable"},
+			Rows:    q.privileges,
+		}, nil
+	case strings.Contains(query, "cleanup_objects"):
+		return dbtest.QueryResult{
+			Columns: []string{"object_kind", "object_schema", "object_name", "drop_statement"},
+			Rows:    q.publicObjects,
+		}, nil
+	case strings.Contains(query, "DROP EXTENSION IF EXISTS %I CASCADE"):
+		return dbtest.QueryResult{
+			Columns: []string{"extname", "drop_statement"},
+			Rows:    q.userExtensions,
+		}, nil
+	case strings.Contains(query, "SELECT e.extname FROM pg_extension"):
+		return dbtest.QueryResult{
+			Columns: []string{"extname"},
+			Rows:    q.residualExtension,
+		}, nil
+	case strings.Contains(query, "residual_objects"):
+		return dbtest.QueryResult{
+			Columns: []string{"object_kind", "nspname", "relname"},
+			Rows:    q.residualObjects,
+		}, nil
+	case strings.Contains(query, "n.nspname NOT LIKE"):
+		q.schemaQueryCount++
+		if q.schemaQueryCount > 1 {
+			return dbtest.QueryResult{
+				Columns: []string{"nspname"},
+				Rows:    q.finalSchemas,
+			}, nil
+		}
+		return dbtest.QueryResult{
+			Columns: []string{"nspname"},
+			Rows:    q.initialSchemas,
+		}, nil
+	default:
+		return dbtest.QueryResult{}, nil
+	}
+}
+
+func postgresPartitionEdgeQuery(test postgresPartitionEdgeTest) func(
+	string,
+	[]driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	return func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		if strings.Contains(query, "FROM pg_inherits") {
+			return dbtest.QueryResult{
+				Columns: []string{"parent_schema", "parent_name", "child_schema", "child_name"},
+				Rows: [][]driver.Value{{
+					test.parentSchema,
+					test.parentName,
+					test.childSchema,
+					test.childName,
+				}},
+			}, nil
+		}
+		return postgresCleanupCatalogQuery(query, "PostgreSQL 18.0", [][]driver.Value{{
+			"table",
+			"public",
+			test.managedName,
+			`DROP TABLE IF EXISTS "public".` + quotePostgresTestIdent(test.managedName) + ` RESTRICT`,
+		}})
+	}
+}
+
+func postgresSchemaScopedExtensionQuery(
+	query string,
+	_ []driver.NamedValue,
+) (dbtest.QueryResult, error) {
+	if strings.Contains(query, "SELECT version()") {
+		return postgresVersionResult("PostgreSQL 18.0"), nil
 	}
 	return dbtest.QueryResult{
-		Columns: []string{"object_kind", "object_name", "drop_statement"},
-		Rows: [][]driver.Value{
-			{"constraint", "users_parent_fkey", `ALTER TABLE "public"."users" DROP CONSTRAINT IF EXISTS "users_parent_fkey" RESTRICT`},
-			{"view", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
-			{"materialized view", "user_stats", `DROP MATERIALIZED VIEW IF EXISTS "public"."user_stats" RESTRICT`},
-			{"foreign table", "remote_users", `DROP FOREIGN TABLE IF EXISTS "public"."remote_users" RESTRICT`},
-			{"table", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
-			{"sequence", "users_id_seq", `DROP SEQUENCE IF EXISTS "public"."users_id_seq" RESTRICT`},
-			{"procedure", "refresh_users", `DROP PROCEDURE IF EXISTS "public"."refresh_users"() RESTRICT`},
-			{"aggregate", "sum_text", `DROP AGGREGATE IF EXISTS "public"."sum_text"(text) RESTRICT`},
-			{"function", "normalize_email", `DROP FUNCTION IF EXISTS "public"."normalize_email"(text) RESTRICT`},
-			{"type", "status", `DROP TYPE IF EXISTS "public"."status" RESTRICT`},
-		},
+		Columns: []string{"count", "first"},
+		Rows:    [][]driver.Value{{int64(1), "hstore"}},
 	}, nil
+}
+
+func postgresCleanupCatalogQuery(
+	query string,
+	version string,
+	objects [][]driver.Value,
+) (dbtest.QueryResult, error) {
+	switch {
+	case strings.Contains(query, "SELECT version()"):
+		return postgresVersionResult(version), nil
+	case strings.Contains(query, "SELECT COUNT(*)") && strings.Contains(query, "FROM pg_extension"):
+		return noPostgresSchemaOwnedExtensions(), nil
+	case strings.Contains(query, "FROM pg_inherits"):
+		return noPostgresCrossSchemaPartitionEdges(), nil
+	default:
+		return dbtest.QueryResult{
+			Columns: []string{"object_kind", "object_schema", "object_name", "drop_statement"},
+			Rows:    objects,
+		}, nil
+	}
+}
+
+func postgresVersionResult(version string) dbtest.QueryResult {
+	return dbtest.QueryResult{
+		Columns: []string{"version"},
+		Rows:    [][]driver.Value{{version}},
+	}
 }
 
 func noPostgresSchemaOwnedExtensions() dbtest.QueryResult {
@@ -195,37 +724,14 @@ func noPostgresSchemaOwnedExtensions() dbtest.QueryResult {
 	}
 }
 
-func postgresPolicyCleanupQuery(
-	query string,
-	_ []driver.NamedValue,
-) (dbtest.QueryResult, error) {
-	if strings.Contains(query, "FROM pg_extension") {
-		return noPostgresSchemaOwnedExtensions(), nil
-	}
+func noPostgresCrossSchemaPartitionEdges() dbtest.QueryResult {
 	return dbtest.QueryResult{
-		Columns: []string{"object_kind", "object_name", "drop_statement"},
-		Rows: [][]driver.Value{{
-			"function",
-			"is_allowed",
-			`DROP FUNCTION IF EXISTS "public"."is_allowed"() RESTRICT`,
-		}},
-	}, nil
+		Columns: []string{"parent_schema", "parent_name", "child_schema", "child_name"},
+	}
 }
 
-func postgresInternalDependencyQuery(
-	query string,
-	_ []driver.NamedValue,
-) (dbtest.QueryResult, error) {
-	if strings.Contains(query, "FROM pg_extension") {
-		return noPostgresSchemaOwnedExtensions(), nil
-	}
-	return dbtest.QueryResult{
-		Columns: []string{"object_kind", "object_name", "drop_statement"},
-		Rows: [][]driver.Value{
-			{"table", "users", `DROP TABLE IF EXISTS "public"."users" RESTRICT`},
-			{"view", "active_users", `DROP VIEW IF EXISTS "public"."active_users" RESTRICT`},
-		},
-	}, nil
+func quotePostgresTestIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func failPostgresTypeDrop(query string, _ []driver.NamedValue) (driver.Result, error) {

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -197,30 +197,47 @@ func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
 	err := writer.DropDatabaseRealm(t.Context())
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(catalogQueries, qt.HasLen, 8)
+	c.Assert(catalogQueries, qt.HasLen, 9)
 	c.Assert(catalogQueries[0], qt.Equals, "SELECT version()")
-	c.Assert(catalogQueries[1], qt.Contains, "obj_description")
-	c.Assert(catalogQueries[1], qt.Contains, "COMMENT ON SCHEMA %I IS %L")
-	c.Assert(catalogQueries[2], qt.Contains, "aclexplode")
-	c.Assert(catalogQueries[3], qt.Contains, "n.nspname NOT LIKE 'pg\\_%'")
-	c.Assert(catalogQueries[3], qt.Not(qt.Contains), "n.nspname NOT LIKE 'yb\\_%'")
-	c.Assert(catalogQueries[4], qt.Contains, "DROP EXTENSION IF EXISTS %I CASCADE")
-	c.Assert(catalogQueries[6], qt.Contains, "SELECT e.extname FROM pg_extension")
-	c.Assert(catalogQueries[7], qt.Contains, "residual_objects")
-	c.Assert(catalogQueries[7], qt.Contains, "FROM pg_collation")
-	c.Assert(catalogQueries[7], qt.Contains, "FROM pg_default_acl")
+	c.Assert(catalogQueries[1], qt.Equals, "SELECT current_database()")
+	c.Assert(catalogQueries[2], qt.Contains, "obj_description")
+	c.Assert(catalogQueries[2], qt.Contains, "COMMENT ON SCHEMA %I IS %L")
+	c.Assert(catalogQueries[3], qt.Contains, "aclexplode")
+	c.Assert(catalogQueries[4], qt.Contains, "n.nspname NOT LIKE 'pg\\_%'")
+	c.Assert(catalogQueries[4], qt.Not(qt.Contains), "n.nspname NOT LIKE 'yb\\_%'")
+	c.Assert(catalogQueries[5], qt.Contains, "cleanup_objects")
+	c.Assert(catalogQueries[5], qt.Contains, "DROP EXTENSION IF EXISTS %I RESTRICT")
+	c.Assert(catalogQueries[5], qt.Contains, "DROP COLLATION IF EXISTS %I.%I RESTRICT")
+	c.Assert(catalogQueries[5], qt.Contains, "ALTER DEFAULT PRIVILEGES FOR ROLE %I")
+	c.Assert(catalogQueries[7], qt.Contains, "SELECT e.extname FROM pg_extension")
+	c.Assert(catalogQueries[8], qt.Contains, "residual_objects")
+	c.Assert(catalogQueries[8], qt.Contains, "FROM pg_collation")
+	c.Assert(catalogQueries[8], qt.Contains, "FROM pg_default_acl")
 	c.Assert(catalogArgs[0], qt.HasLen, 0)
-	c.Assert(catalogArgs[1], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[1], qt.HasLen, 0)
 	c.Assert(catalogArgs[2], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
-	c.Assert(catalogArgs[3], qt.HasLen, 0)
-	c.Assert(catalogArgs[4], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
-	c.Assert(catalogArgs[5], qt.HasLen, 0)
-	c.Assert(catalogArgs[6], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
-	c.Assert(catalogArgs[7], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[3], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[4], qt.HasLen, 0)
+	c.Assert(catalogArgs[5], qt.DeepEquals, []driver.NamedValue{
+		{Ordinal: 1, Value: "audit"},
+		{Ordinal: 2, Value: "public"},
+		{Ordinal: 3, Value: "plpgsql"},
+	})
+	c.Assert(catalogArgs[6], qt.HasLen, 0)
+	c.Assert(catalogArgs[7], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
+	c.Assert(catalogArgs[8], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
 	c.Assert(execQueries, qt.DeepEquals, []string{
-		`DROP EXTENSION IF EXISTS "hstore" CASCADE`,
-		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
-		`DROP SCHEMA IF EXISTS "public" CASCADE`,
+		`SAVEPOINT ptah_cleanup_object`,
+		`DROP EXTENSION IF EXISTS "hstore" RESTRICT`,
+		`RELEASE SAVEPOINT ptah_cleanup_object`,
+		`SAVEPOINT ptah_cleanup_object`,
+		`DROP COLLATION IF EXISTS "public"."ptah_case_sensitive" RESTRICT`,
+		`RELEASE SAVEPOINT ptah_cleanup_object`,
+		`SAVEPOINT ptah_cleanup_object`,
+		`ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner" IN SCHEMA "public" REVOKE ALL PRIVILEGES ON TABLES FROM PUBLIC`,
+		`RELEASE SAVEPOINT ptah_cleanup_object`,
+		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
+		`DROP SCHEMA IF EXISTS "public" RESTRICT`,
 		`CREATE SCHEMA "public" AUTHORIZATION "app_owner"`,
 		`REVOKE ALL PRIVILEGES ON SCHEMA "public" FROM PUBLIC`,
 		`REVOKE ALL PRIVILEGES ON SCHEMA "public" FROM "app_owner"`,
@@ -232,8 +249,8 @@ func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
 		`COMMENT ON SCHEMA "public" IS 'application root'`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 8)
-	c.Assert(db.ExecCount(), qt.Equals, 12)
+	c.Assert(db.QueryCount(), qt.Equals, 9)
+	c.Assert(db.ExecCount(), qt.Equals, 20)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
@@ -255,12 +272,12 @@ func TestWriterDropDatabaseRealm_CreatesAbsentRootSchema(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(execQueries, qt.DeepEquals, []string{
-		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
-		`DROP SCHEMA IF EXISTS "public" CASCADE`,
+		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
+		`DROP SCHEMA IF EXISTS "public" RESTRICT`,
 		`CREATE SCHEMA "shadow"`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 7)
+	c.Assert(db.QueryCount(), qt.Equals, 8)
 	c.Assert(db.ExecCount(), qt.Equals, 3)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
@@ -283,8 +300,8 @@ func TestWriterDropDatabaseRealm_CockroachPreservesPublicSchemaContainer(t *test
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(execQueries, qt.DeepEquals, []string{
-		`DROP SCHEMA IF EXISTS "audit" CASCADE`,
 		`DROP TABLE IF EXISTS "public"."stale_items" RESTRICT`,
+		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
 	c.Assert(db.QueryCount(), qt.Equals, 8)
@@ -304,7 +321,7 @@ func TestWriterDropDatabaseRealm_RollsBackOnResidualObject(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`PostgreSQL database realm cleanup left residual collation "public"\."stale_collation"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 7)
+	c.Assert(db.QueryCount(), qt.Equals, 8)
 	c.Assert(db.ExecCount(), qt.Equals, 3)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -324,6 +341,94 @@ func TestWriterDropDatabaseRealm_RejectsSystemRootSchema(t *testing.T) {
 	c.Assert(db.ExecCount(), qt.Equals, 0)
 }
 
+func TestWriterDropDatabaseRealm_RejectsProtectedDatabasesBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		version  string
+		database string
+	}{
+		{name: "postgres database", version: "PostgreSQL 18.0", database: "POSTGRES"},
+		{name: "postgres template0", version: "PostgreSQL 18.0", database: "template0"},
+		{name: "postgres template1", version: "PostgreSQL 18.0", database: "template1"},
+		{name: "cockroach defaultdb", version: "CockroachDB CCL v26.2.4", database: "defaultdb"},
+		{name: "cockroach postgres", version: "CockroachDB CCL v26.2.4", database: "postgres"},
+		{name: "cockroach system", version: "CockroachDB CCL v26.2.4", database: "system"},
+		{name: "yugabyte database", version: "YugabyteDB 2026.1", database: "yugabyte"},
+		{name: "yugabyte postgres", version: "YugabyteDB 2026.1", database: "postgres"},
+		{name: "yugabyte template0", version: "YugabyteDB 2026.1", database: "template0"},
+		{name: "yugabyte template1", version: "YugabyteDB 2026.1", database: "template1"},
+		{name: "yugabyte system platform", version: "YugabyteDB 2026.1", database: "system_platform"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			queryHandler := &postgresRealmQuery{
+				version:  test.version,
+				database: test.database,
+			}
+			db := dbtest.Open(t, queryHandler.query)
+			writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`refusing to clean protected PostgreSQL-family database ".*"`,
+			)
+			c.Assert(db.QueryCount(), qt.Equals, 2)
+			c.Assert(db.BeginCount(), qt.Equals, 1)
+			c.Assert(db.ExecCount(), qt.Equals, 0)
+			c.Assert(db.CommitCount(), qt.Equals, 0)
+			c.Assert(db.RollbackCount(), qt.Equals, 1)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_PostgresAllowsOtherFamilyProtectedNames(t *testing.T) {
+	c := qt.New(t)
+	tests := []string{"defaultdb", "system", "system_platform", "yugabyte"}
+
+	for _, database := range tests {
+		c.Run(database, func(c *qt.C) {
+			queryHandler := newPostgresRealmMetadataQuery()
+			queryHandler.database = database
+			queryHandler.publicObjects = nil
+			db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+			writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.CommitCount(), qt.Equals, 1)
+			c.Assert(db.RollbackCount(), qt.Equals, 0)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_RollsBackOnPreservedDependency(t *testing.T) {
+	c := qt.New(t)
+	queryHandler := newPostgresRealmMetadataQuery()
+	queryHandler.publicObjects = [][]driver.Value{{
+		"function",
+		"public",
+		"is_allowed",
+		`DROP FUNCTION IF EXISTS "public"."is_allowed"() RESTRICT`,
+	}}
+	db := dbtest.OpenWithExec(t, queryHandler.query, failPostgresPreservedFunctionDrop)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `(?s)refusing to clean PostgreSQL database realm: failed to drop function is_allowed: SQL execution failed: cannot drop function because other objects depend on it.*`)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 6)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
 func TestWriterDropDatabaseRealm_RollsBackOnResidualExtension(t *testing.T) {
 	c := qt.New(t)
 	queryHandler := newPostgresRealmResidualExtensionQuery()
@@ -335,7 +440,7 @@ func TestWriterDropDatabaseRealm_RollsBackOnResidualExtension(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`PostgreSQL database realm cleanup left residual user extension "hstore"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 6)
+	c.Assert(db.QueryCount(), qt.Equals, 7)
 	c.Assert(db.ExecCount(), qt.Equals, 3)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -367,7 +472,7 @@ func TestWriterDropDatabaseRealm_RejectsUnsupportedPrivilegeBeforeMutation(t *te
 	c.Assert(err, qt.ErrorMatches,
 		`refusing to restore unsupported PostgreSQL schema privilege "TEMPORARY"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 3)
+	c.Assert(db.QueryCount(), qt.Equals, 4)
 	c.Assert(db.ExecCount(), qt.Equals, 0)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -513,12 +618,12 @@ func cockroachOrderedDependencyQuery(
 
 type postgresRealmQuery struct {
 	version           string
+	database          string
 	metadata          [][]driver.Value
 	privileges        [][]driver.Value
 	initialSchemas    [][]driver.Value
 	finalSchemas      [][]driver.Value
 	publicObjects     [][]driver.Value
-	userExtensions    [][]driver.Value
 	residualExtension [][]driver.Value
 	residualObjects   [][]driver.Value
 	schemaQueryCount  int
@@ -526,7 +631,8 @@ type postgresRealmQuery struct {
 
 func newPostgresRealmMetadataQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
-		version: "PostgreSQL 18.0",
+		version:  "PostgreSQL 18.0",
+		database: "ptah_test",
 		metadata: [][]driver.Value{{
 			"app_owner",
 			false,
@@ -540,16 +646,33 @@ func newPostgresRealmMetadataQuery() *postgresRealmQuery {
 		},
 		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
 		finalSchemas:   [][]driver.Value{{"public"}},
-		userExtensions: [][]driver.Value{{
-			"hstore",
-			`DROP EXTENSION IF EXISTS "hstore" CASCADE`,
-		}},
+		publicObjects: [][]driver.Value{
+			{
+				"extension",
+				"public",
+				"hstore",
+				`DROP EXTENSION IF EXISTS "hstore" RESTRICT`,
+			},
+			{
+				"collation",
+				"public",
+				"ptah_case_sensitive",
+				`DROP COLLATION IF EXISTS "public"."ptah_case_sensitive" RESTRICT`,
+			},
+			{
+				"default privilege",
+				"public",
+				"app_owner/r/PUBLIC",
+				`ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner" IN SCHEMA "public" REVOKE ALL PRIVILEGES ON TABLES FROM PUBLIC`,
+			},
+		},
 	}
 }
 
 func newPostgresRealmAbsentRootQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
 		version:        "PostgreSQL 18.0",
+		database:       "ptah_test",
 		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
 		finalSchemas:   [][]driver.Value{{"shadow"}},
 	}
@@ -558,6 +681,7 @@ func newPostgresRealmAbsentRootQuery() *postgresRealmQuery {
 func newPostgresRealmCockroachQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
 		version:        "CockroachDB CCL v26.2.4",
+		database:       "ptah_test",
 		metadata:       [][]driver.Value{{"root", true, `COMMENT ON SCHEMA "public" IS NULL`}},
 		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
 		finalSchemas:   [][]driver.Value{{"public"}},
@@ -573,6 +697,7 @@ func newPostgresRealmCockroachQuery() *postgresRealmQuery {
 func newPostgresRealmResidualQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
 		version:         "PostgreSQL 18.0",
+		database:        "ptah_test",
 		metadata:        [][]driver.Value{{"app_owner", true, `COMMENT ON SCHEMA "public" IS NULL`}},
 		initialSchemas:  [][]driver.Value{{"public"}},
 		finalSchemas:    [][]driver.Value{{"public"}},
@@ -583,6 +708,7 @@ func newPostgresRealmResidualQuery() *postgresRealmQuery {
 func newPostgresRealmResidualExtensionQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
 		version:           "PostgreSQL 18.0",
+		database:          "ptah_test",
 		metadata:          [][]driver.Value{{"app_owner", true, `COMMENT ON SCHEMA "public" IS NULL`}},
 		initialSchemas:    [][]driver.Value{{"public"}},
 		finalSchemas:      [][]driver.Value{{"public"}},
@@ -593,6 +719,7 @@ func newPostgresRealmResidualExtensionQuery() *postgresRealmQuery {
 func newPostgresRealmUnsupportedPrivilegeQuery() *postgresRealmQuery {
 	return &postgresRealmQuery{
 		version:    "YugabyteDB 2026.1",
+		database:   "ptah_test",
 		metadata:   [][]driver.Value{{"yugabyte", false, `COMMENT ON SCHEMA "public" IS NULL`}},
 		privileges: [][]driver.Value{{"yugabyte", "TEMPORARY", false}},
 	}
@@ -603,6 +730,8 @@ func (q *postgresRealmQuery) query(
 	_ []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
 	switch {
+	case strings.Contains(query, "current_database()"):
+		return postgresCurrentDatabaseResult(q.database), nil
 	case strings.Contains(query, "SELECT version()"):
 		return postgresVersionResult(q.version), nil
 	case strings.Contains(query, "obj_description"):
@@ -610,20 +739,15 @@ func (q *postgresRealmQuery) query(
 			Columns: []string{"owner", "acl_is_default", "comment_statement"},
 			Rows:    q.metadata,
 		}, nil
-	case strings.Contains(query, "aclexplode"):
-		return dbtest.QueryResult{
-			Columns: []string{"grantee", "privilege_type", "is_grantable"},
-			Rows:    q.privileges,
-		}, nil
 	case strings.Contains(query, "cleanup_objects"):
 		return dbtest.QueryResult{
 			Columns: []string{"object_kind", "object_schema", "object_name", "drop_statement"},
 			Rows:    q.publicObjects,
 		}, nil
-	case strings.Contains(query, "DROP EXTENSION IF EXISTS %I CASCADE"):
+	case strings.Contains(query, "aclexplode"):
 		return dbtest.QueryResult{
-			Columns: []string{"extname", "drop_statement"},
-			Rows:    q.userExtensions,
+			Columns: []string{"grantee", "privilege_type", "is_grantable"},
+			Rows:    q.privileges,
 		}, nil
 	case strings.Contains(query, "SELECT e.extname FROM pg_extension"):
 		return dbtest.QueryResult{
@@ -650,6 +774,23 @@ func (q *postgresRealmQuery) query(
 	default:
 		return dbtest.QueryResult{}, nil
 	}
+}
+
+func postgresCurrentDatabaseResult(database string) dbtest.QueryResult {
+	return dbtest.QueryResult{
+		Columns: []string{"current_database"},
+		Rows:    [][]driver.Value{{database}},
+	}
+}
+
+func failPostgresPreservedFunctionDrop(
+	query string,
+	_ []driver.NamedValue,
+) (driver.Result, error) {
+	if strings.HasPrefix(query, "DROP FUNCTION") {
+		return nil, errors.New("cannot drop function because other objects depend on it")
+	}
+	return driver.RowsAffected(0), nil
 }
 
 func postgresPartitionEdgeQuery(test postgresPartitionEdgeTest) func(

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -197,35 +197,46 @@ func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
 	err := writer.DropDatabaseRealm(t.Context())
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(catalogQueries, qt.HasLen, 9)
+	c.Assert(catalogQueries, qt.HasLen, 11)
 	c.Assert(catalogQueries[0], qt.Equals, "SELECT version()")
 	c.Assert(catalogQueries[1], qt.Equals, "SELECT current_database()")
-	c.Assert(catalogQueries[2], qt.Contains, "obj_description")
-	c.Assert(catalogQueries[2], qt.Contains, "COMMENT ON SCHEMA %I IS %L")
-	c.Assert(catalogQueries[3], qt.Contains, "aclexplode")
-	c.Assert(catalogQueries[4], qt.Contains, "n.nspname NOT LIKE 'pg\\_%'")
-	c.Assert(catalogQueries[4], qt.Not(qt.Contains), "n.nspname NOT LIKE 'yb\\_%'")
-	c.Assert(catalogQueries[5], qt.Contains, "cleanup_objects")
-	c.Assert(catalogQueries[5], qt.Contains, "DROP EXTENSION IF EXISTS %I RESTRICT")
-	c.Assert(catalogQueries[5], qt.Contains, "DROP COLLATION IF EXISTS %I.%I RESTRICT")
-	c.Assert(catalogQueries[5], qt.Contains, "ALTER DEFAULT PRIVILEGES FOR ROLE %I")
-	c.Assert(catalogQueries[7], qt.Contains, "SELECT e.extname FROM pg_extension")
-	c.Assert(catalogQueries[8], qt.Contains, "residual_objects")
-	c.Assert(catalogQueries[8], qt.Contains, "FROM pg_collation")
-	c.Assert(catalogQueries[8], qt.Contains, "FROM pg_default_acl")
+	c.Assert(catalogQueries[2], qt.Contains, "database_scoped_artifacts")
+	c.Assert(catalogQueries[2], qt.Contains, "FROM pg_publication")
+	c.Assert(catalogQueries[2], qt.Contains, "FROM pg_subscription")
+	c.Assert(catalogQueries[2], qt.Contains, "subscription.subdbid =")
+	c.Assert(catalogQueries[2], qt.Contains, "FROM pg_replication_slots")
+	c.Assert(catalogQueries[2], qt.Contains, "slot.slot_type = 'logical'")
+	c.Assert(catalogQueries[2], qt.Contains, "slot.datoid =")
+	c.Assert(catalogQueries[2], qt.Contains, "FROM pg_event_trigger")
+	c.Assert(catalogQueries[3], qt.Contains, "obj_description")
+	c.Assert(catalogQueries[3], qt.Contains, "COMMENT ON SCHEMA %I IS %L")
+	c.Assert(catalogQueries[4], qt.Contains, "aclexplode")
+	c.Assert(catalogQueries[5], qt.Contains, "n.nspname NOT LIKE 'pg\\_%'")
+	c.Assert(catalogQueries[5], qt.Not(qt.Contains), "n.nspname NOT LIKE 'yb\\_%'")
+	c.Assert(catalogQueries[6], qt.Contains, "cleanup_objects")
+	c.Assert(catalogQueries[6], qt.Contains, "DROP EXTENSION IF EXISTS %I RESTRICT")
+	c.Assert(catalogQueries[6], qt.Contains, "DROP COLLATION IF EXISTS %I.%I RESTRICT")
+	c.Assert(catalogQueries[6], qt.Contains, "ALTER DEFAULT PRIVILEGES FOR ROLE %I")
+	c.Assert(catalogQueries[8], qt.Contains, "SELECT e.extname FROM pg_extension")
+	c.Assert(catalogQueries[9], qt.Contains, "residual_objects")
+	c.Assert(catalogQueries[9], qt.Contains, "FROM pg_collation")
+	c.Assert(catalogQueries[9], qt.Contains, "FROM pg_default_acl")
+	c.Assert(catalogQueries[10], qt.Contains, "FROM pg_largeobject_metadata")
 	c.Assert(catalogArgs[0], qt.HasLen, 0)
 	c.Assert(catalogArgs[1], qt.HasLen, 0)
-	c.Assert(catalogArgs[2], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[2], qt.HasLen, 0)
 	c.Assert(catalogArgs[3], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
-	c.Assert(catalogArgs[4], qt.HasLen, 0)
-	c.Assert(catalogArgs[5], qt.DeepEquals, []driver.NamedValue{
+	c.Assert(catalogArgs[4], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[5], qt.HasLen, 0)
+	c.Assert(catalogArgs[6], qt.DeepEquals, []driver.NamedValue{
 		{Ordinal: 1, Value: "audit"},
 		{Ordinal: 2, Value: "public"},
 		{Ordinal: 3, Value: "plpgsql"},
 	})
-	c.Assert(catalogArgs[6], qt.HasLen, 0)
-	c.Assert(catalogArgs[7], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
-	c.Assert(catalogArgs[8], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[7], qt.HasLen, 0)
+	c.Assert(catalogArgs[8], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "plpgsql"}})
+	c.Assert(catalogArgs[9], qt.DeepEquals, []driver.NamedValue{{Ordinal: 1, Value: "public"}})
+	c.Assert(catalogArgs[10], qt.HasLen, 0)
 	c.Assert(execQueries, qt.DeepEquals, []string{
 		`SAVEPOINT ptah_cleanup_object`,
 		`DROP EXTENSION IF EXISTS "hstore" RESTRICT`,
@@ -236,6 +247,7 @@ func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
 		`SAVEPOINT ptah_cleanup_object`,
 		`ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner" IN SCHEMA "public" REVOKE ALL PRIVILEGES ON TABLES FROM PUBLIC`,
 		`RELEASE SAVEPOINT ptah_cleanup_object`,
+		"\n\t\tSELECT lo_unlink(oid)\n\t\tFROM pg_largeobject_metadata\n\t\tORDER BY oid\n\t",
 		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
 		`DROP SCHEMA IF EXISTS "public" RESTRICT`,
 		`CREATE SCHEMA "public" AUTHORIZATION "app_owner"`,
@@ -249,8 +261,8 @@ func TestWriterDropDatabaseRealm_RecreatesRootSchemaWithMetadata(t *testing.T) {
 		`COMMENT ON SCHEMA "public" IS 'application root'`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 9)
-	c.Assert(db.ExecCount(), qt.Equals, 20)
+	c.Assert(db.QueryCount(), qt.Equals, 11)
+	c.Assert(db.ExecCount(), qt.Equals, 21)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
@@ -272,13 +284,14 @@ func TestWriterDropDatabaseRealm_CreatesAbsentRootSchema(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(execQueries, qt.DeepEquals, []string{
+		"\n\t\tSELECT lo_unlink(oid)\n\t\tFROM pg_largeobject_metadata\n\t\tORDER BY oid\n\t",
 		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
 		`DROP SCHEMA IF EXISTS "public" RESTRICT`,
 		`CREATE SCHEMA "shadow"`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 8)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.QueryCount(), qt.Equals, 10)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
@@ -321,8 +334,8 @@ func TestWriterDropDatabaseRealm_RollsBackOnResidualObject(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`PostgreSQL database realm cleanup left residual collation "public"\."stale_collation"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 8)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.QueryCount(), qt.Equals, 9)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
 }
@@ -407,6 +420,67 @@ func TestWriterDropDatabaseRealm_PostgresAllowsOtherFamilyProtectedNames(t *test
 	}
 }
 
+func TestWriterDropDatabaseRealm_RejectsDatabaseScopedArtifactBeforeMutation(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name string
+		kind string
+		item string
+	}{
+		{name: "publication", kind: "publication", item: "events_publication"},
+		{name: "subscription", kind: "subscription", item: "events_subscription"},
+		{name: "logical replication slot", kind: "logical replication slot", item: "events_slot"},
+		{name: "event trigger", kind: "event trigger", item: "audit_ddl"},
+		{name: "foreign-data wrapper", kind: "foreign-data wrapper", item: "custom_fdw"},
+		{name: "foreign server", kind: "foreign server", item: "warehouse"},
+		{name: "user mapping", kind: "user mapping", item: "app@warehouse"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			queryHandler := newPostgresRealmMetadataQuery()
+			queryHandler.databaseArtifacts = [][]driver.Value{{test.kind, test.item}}
+			db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+			writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+			err := writer.DropDatabaseRealm(t.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`refusing to clean PostgreSQL database realm with unsupported database-scoped `+
+					test.kind+` "`+test.item+`"`,
+			)
+			c.Assert(db.BeginCount(), qt.Equals, 1)
+			c.Assert(db.QueryCount(), qt.Equals, 3)
+			c.Assert(db.ExecCount(), qt.Equals, 0)
+			c.Assert(db.CommitCount(), qt.Equals, 0)
+			c.Assert(db.RollbackCount(), qt.Equals, 1)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_FailsClosedWithoutDatabaseArtifactVisibility(t *testing.T) {
+	c := qt.New(t)
+	queryHandler := newPostgresRealmMetadataQuery()
+	queryHandler.databaseArtifactErr = errors.New("permission denied for view pg_replication_slots")
+	db := dbtest.OpenWithExec(t, queryHandler.query, nil)
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "public")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`failed to inspect PostgreSQL database-scoped artifacts: permission denied for view pg_replication_slots`,
+	)
+	c.Assert(db.BeginCount(), qt.Equals, 1)
+	c.Assert(db.QueryCount(), qt.Equals, 3)
+	c.Assert(db.ExecCount(), qt.Equals, 0)
+	c.Assert(db.CommitCount(), qt.Equals, 0)
+	c.Assert(db.RollbackCount(), qt.Equals, 1)
+}
+
 func TestWriterDropDatabaseRealm_RollsBackOnPreservedDependency(t *testing.T) {
 	c := qt.New(t)
 	queryHandler := newPostgresRealmMetadataQuery()
@@ -423,7 +497,7 @@ func TestWriterDropDatabaseRealm_RollsBackOnPreservedDependency(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `(?s)refusing to clean PostgreSQL database realm: failed to drop function is_allowed: SQL execution failed: cannot drop function because other objects depend on it.*`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 6)
+	c.Assert(db.QueryCount(), qt.Equals, 7)
 	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -440,8 +514,8 @@ func TestWriterDropDatabaseRealm_RollsBackOnResidualExtension(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches,
 		`PostgreSQL database realm cleanup left residual user extension "hstore"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 7)
-	c.Assert(db.ExecCount(), qt.Equals, 3)
+	c.Assert(db.QueryCount(), qt.Equals, 8)
+	c.Assert(db.ExecCount(), qt.Equals, 4)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
 }
@@ -472,7 +546,7 @@ func TestWriterDropDatabaseRealm_RejectsUnsupportedPrivilegeBeforeMutation(t *te
 	c.Assert(err, qt.ErrorMatches,
 		`refusing to restore unsupported PostgreSQL schema privilege "TEMPORARY"`)
 	c.Assert(db.BeginCount(), qt.Equals, 1)
-	c.Assert(db.QueryCount(), qt.Equals, 4)
+	c.Assert(db.QueryCount(), qt.Equals, 5)
 	c.Assert(db.ExecCount(), qt.Equals, 0)
 	c.Assert(db.CommitCount(), qt.Equals, 0)
 	c.Assert(db.RollbackCount(), qt.Equals, 1)
@@ -617,16 +691,18 @@ func cockroachOrderedDependencyQuery(
 }
 
 type postgresRealmQuery struct {
-	version           string
-	database          string
-	metadata          [][]driver.Value
-	privileges        [][]driver.Value
-	initialSchemas    [][]driver.Value
-	finalSchemas      [][]driver.Value
-	publicObjects     [][]driver.Value
-	residualExtension [][]driver.Value
-	residualObjects   [][]driver.Value
-	schemaQueryCount  int
+	version             string
+	database            string
+	databaseArtifacts   [][]driver.Value
+	databaseArtifactErr error
+	metadata            [][]driver.Value
+	privileges          [][]driver.Value
+	initialSchemas      [][]driver.Value
+	finalSchemas        [][]driver.Value
+	publicObjects       [][]driver.Value
+	residualExtension   [][]driver.Value
+	residualObjects     [][]driver.Value
+	schemaQueryCount    int
 }
 
 func newPostgresRealmMetadataQuery() *postgresRealmQuery {
@@ -730,6 +806,11 @@ func (q *postgresRealmQuery) query(
 	_ []driver.NamedValue,
 ) (dbtest.QueryResult, error) {
 	switch {
+	case strings.Contains(query, "database_scoped_artifacts"):
+		return dbtest.QueryResult{
+			Columns: []string{"object_kind", "object_name"},
+			Rows:    q.databaseArtifacts,
+		}, q.databaseArtifactErr
 	case strings.Contains(query, "current_database()"):
 		return postgresCurrentDatabaseResult(q.database), nil
 	case strings.Contains(query, "SELECT version()"):

--- a/internal/dbschema/postgres/writer_live_test.go
+++ b/internal/dbschema/postgres/writer_live_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -16,6 +17,23 @@ import (
 
 	"github.com/stokaro/ptah/internal/dbschema/postgres"
 )
+
+type postgresWriterFamilyLiveCase struct {
+	name   string
+	urlEnv string
+}
+
+type postgresWriterLiveDatabase struct {
+	db      *sql.DB
+	name    string
+	cleanup func()
+}
+
+type postgresWriterLiveSchemaMetadata struct {
+	Owner      string
+	Comment    sql.NullString
+	Privileges []string
+}
 
 func TestWriterDropAllTables_LiveRejectsExternalPolicyDependency(t *testing.T) {
 	c := qt.New(t)
@@ -113,6 +131,328 @@ func TestWriterDropAllTables_LiveResolvesInternalDependencies(t *testing.T) {
 	c.Assert(postgresWriterLiveRelationCount(c, ctx, db, schema), qt.Equals, 0)
 }
 
+func TestWriterDropAllTables_LivePostgresFamilyResolvesReverseViewChain(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	tests := []postgresWriterFamilyLiveCase{
+		{name: "cockroachdb", urlEnv: "COCKROACHDB_URL"},
+		{name: "yugabytedb", urlEnv: "YUGABYTEDB_URL"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db, err := sql.Open("pgx", requirePostgresWriterFamilyLiveURL(c, test.urlEnv))
+			c.Assert(err, qt.IsNil)
+			defer db.Close()
+			c.Assert(db.PingContext(ctx), qt.IsNil)
+
+			schema := fmt.Sprintf("ptah_cleanup_chain_%d", time.Now().UnixNano())
+			schemaIdent := pgx.Identifier{schema}.Sanitize()
+			_, err = db.ExecContext(ctx, fmt.Sprintf(`
+				CREATE SCHEMA %[1]s;
+				CREATE TABLE %[1]s.stale_parent (id bigint PRIMARY KEY);
+				CREATE VIEW %[1]s.a_base_view AS
+					SELECT id FROM %[1]s.stale_parent;
+				CREATE VIEW %[1]s.z_dependent_view AS
+					SELECT id FROM %[1]s.a_base_view;
+			`, schemaIdent))
+			c.Assert(err, qt.IsNil)
+			defer func() {
+				_, cleanupErr := db.ExecContext(
+					context.Background(),
+					fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaIdent),
+				)
+				c.Check(cleanupErr, qt.IsNil)
+			}()
+			c.Assert(postgresWriterLiveRelationCount(c, ctx, db, schema), qt.Equals, 3)
+
+			writer := postgres.NewPostgreSQLWriter(db, schema)
+			err = writer.DropAllTables(ctx)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(postgresWriterLiveRelationCount(c, ctx, db, schema), qt.Equals, 0)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresFamilyCleansCrossSchemaGraph(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	tests := []postgresWriterFamilyLiveCase{
+		{name: "postgres", urlEnv: "POSTGRES_URL"},
+		{name: "cockroachdb", urlEnv: "COCKROACHDB_URL"},
+		{name: "yugabytedb", urlEnv: "YUGABYTEDB_URL"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			liveDatabase := newPostgresWriterLiveDatabase(
+				c,
+				ctx,
+				requirePostgresWriterFamilyLiveURL(c, test.urlEnv),
+			)
+			defer liveDatabase.cleanup()
+			db := liveDatabase.db
+			rootMetadata := loadPostgresWriterLiveSchemaMetadata(c, ctx, db, "public")
+			systemExtensions := postgresWriterLiveExtensionNames(c, ctx, db)
+
+			suffix := time.Now().UnixNano()
+			parentSchema := fmt.Sprintf("ptah_realm_parent_%d", suffix)
+			childSchema := fmt.Sprintf("ptah_realm_child_%d", suffix)
+			ybPrefixedSchema := fmt.Sprintf("yb_ptah_realm_%d", suffix)
+			parentIdent := pgx.Identifier{parentSchema}.Sanitize()
+			childIdent := pgx.Identifier{childSchema}.Sanitize()
+			ybPrefixedIdent := pgx.Identifier{ybPrefixedSchema}.Sanitize()
+			_, err := db.ExecContext(ctx, fmt.Sprintf(`
+				CREATE SCHEMA %[1]s;
+				CREATE SCHEMA %[2]s;
+				CREATE SCHEMA %[3]s;
+				CREATE TYPE public.ptah_root_status AS ENUM ('ready');
+				CREATE SEQUENCE public.ptah_root_sequence;
+				CREATE FUNCTION public.ptah_root_answer()
+					RETURNS integer
+					LANGUAGE sql
+					AS 'SELECT 42';
+				CREATE TABLE public.ptah_root_items (id bigint PRIMARY KEY);
+				CREATE TABLE %[1]s.parents (id bigint PRIMARY KEY);
+				CREATE TABLE %[2]s.children (
+					id bigint PRIMARY KEY,
+					parent_id bigint REFERENCES %[1]s.parents(id)
+				);
+				CREATE VIEW %[2]s.parent_ids AS
+					SELECT id FROM %[1]s.parents;
+				CREATE TABLE %[3]s.prefixed_items (id bigint PRIMARY KEY);
+			`, parentIdent, childIdent, ybPrefixedIdent))
+			c.Assert(err, qt.IsNil)
+
+			writer := postgres.NewPostgreSQLWriter(db, "public")
+			err = writer.DropDatabaseRealm(ctx)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(writer.DropDatabaseRealm(ctx), qt.IsNil)
+			c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, parentSchema), qt.Equals, 0)
+			c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, childSchema), qt.Equals, 0)
+			c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, ybPrefixedSchema), qt.Equals, 0)
+			c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, "public"), qt.Equals, 1)
+			c.Assert(postgresWriterLiveRelationCount(c, ctx, db, "public"), qt.Equals, 0)
+			c.Assert(
+				loadPostgresWriterLiveSchemaMetadata(c, ctx, db, "public"),
+				qt.DeepEquals,
+				rootMetadata,
+			)
+			c.Assert(postgresWriterLiveExtensionNames(c, ctx, db), qt.DeepEquals, systemExtensions)
+			c.Assert(postgresWriterLiveCurrentDatabase(c, ctx, db), qt.Equals, liveDatabase.name)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresRestoresRootMetadata(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+	db := liveDatabase.db
+
+	_, err := db.ExecContext(ctx, `
+		COMMENT ON SCHEMA public IS 'Ptah cleanup root metadata';
+		REVOKE ALL PRIVILEGES ON SCHEMA public FROM PUBLIC;
+		GRANT USAGE ON SCHEMA public TO PUBLIC;
+		CREATE COLLATION public.ptah_case_sensitive FROM "C";
+		CREATE EXTENSION hstore WITH SCHEMA public;
+		ALTER DEFAULT PRIVILEGES IN SCHEMA public
+			GRANT SELECT ON TABLES TO PUBLIC;
+		CREATE TABLE public.stale_items (id bigint PRIMARY KEY);
+	`)
+	c.Assert(err, qt.IsNil)
+	beforeOID := postgresWriterLiveSchemaOID(c, ctx, db, "public")
+	beforeMetadata := loadPostgresWriterLiveSchemaMetadata(c, ctx, db, "public")
+
+	writer := postgres.NewPostgreSQLWriter(db, "public")
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(postgresWriterLiveSchemaOID(c, ctx, db, "public"), qt.Not(qt.Equals), beforeOID)
+	c.Assert(loadPostgresWriterLiveSchemaMetadata(c, ctx, db, "public"), qt.DeepEquals, beforeMetadata)
+	c.Assert(postgresWriterLiveCollationCount(c, ctx, db, "public"), qt.Equals, 0)
+	c.Assert(postgresWriterLiveExtensionCount(c, ctx, db, "hstore"), qt.Equals, 0)
+	c.Assert(postgresWriterLiveRelationCount(c, ctx, db, "public"), qt.Equals, 0)
+	c.Assert(postgresWriterLiveCurrentDatabase(c, ctx, db), qt.Equals, liveDatabase.name)
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresCreatesAbsentRoot(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+
+	writer := postgres.NewPostgreSQLWriter(liveDatabase.db, "shadow")
+	err := writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(writer.DropDatabaseRealm(ctx), qt.IsNil)
+	c.Assert(postgresWriterLiveSchemaCount(c, ctx, liveDatabase.db, "public"), qt.Equals, 0)
+	c.Assert(postgresWriterLiveSchemaCount(c, ctx, liveDatabase.db, "shadow"), qt.Equals, 1)
+	c.Assert(
+		postgresWriterLiveCurrentDatabase(c, ctx, liveDatabase.db),
+		qt.Equals,
+		liveDatabase.name,
+	)
+}
+
+func TestWriterDropAllTables_LiveRejectsCrossSchemaPartitionEdges(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	db, err := sql.Open("pgx", requirePostgresWriterLiveURL(t))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	c.Assert(db.PingContext(ctx), qt.IsNil)
+
+	tests := []struct {
+		name                string
+		setup               string
+		managedRelationName string
+		externalRelation    string
+	}{
+		{
+			name: "external child",
+			setup: `
+				CREATE TABLE %[1]s.events (
+					id bigint,
+					occurred_at date
+				) PARTITION BY RANGE (occurred_at);
+				CREATE TABLE %[2]s.events_2025
+					PARTITION OF %[1]s.events
+					FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+			`,
+			managedRelationName: "events",
+			externalRelation:    "events_2025",
+		},
+		{
+			name: "external parent",
+			setup: `
+				CREATE TABLE %[2]s.events (
+					id bigint,
+					occurred_at date
+				) PARTITION BY RANGE (occurred_at);
+				CREATE TABLE %[1]s.events_2025
+					PARTITION OF %[2]s.events
+					FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+			`,
+			managedRelationName: "events_2025",
+			externalRelation:    "events",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			suffix := time.Now().UnixNano()
+			managedSchema := fmt.Sprintf("ptah_partition_managed_%d", suffix)
+			externalSchema := fmt.Sprintf("ptah_partition_external_%d", suffix)
+			managedIdent := pgx.Identifier{managedSchema}.Sanitize()
+			externalIdent := pgx.Identifier{externalSchema}.Sanitize()
+
+			_, err := db.ExecContext(ctx, fmt.Sprintf(`
+				CREATE SCHEMA %[1]s;
+				CREATE SCHEMA %[2]s;
+				%[3]s
+			`, managedIdent, externalIdent, fmt.Sprintf(test.setup, managedIdent, externalIdent)))
+			c.Assert(err, qt.IsNil)
+			defer func() {
+				_, cleanupErr := db.ExecContext(
+					context.Background(),
+					fmt.Sprintf("DROP SCHEMA %s CASCADE; DROP SCHEMA %s CASCADE", externalIdent, managedIdent),
+				)
+				c.Check(cleanupErr, qt.IsNil)
+			}()
+
+			writer := postgres.NewPostgreSQLWriter(db, managedSchema)
+			err = writer.DropAllTables(ctx)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, fmt.Sprintf(`refusing to clean schema %q`, managedSchema))
+			c.Assert(err.Error(), qt.Contains, "across the schema boundary")
+			c.Assert(
+				postgresWriterLiveObjectCount(c, ctx, db, managedSchema, test.managedRelationName),
+				qt.Equals,
+				1,
+			)
+			c.Assert(
+				postgresWriterLiveObjectCount(c, ctx, db, externalSchema, test.externalRelation),
+				qt.Equals,
+				1,
+			)
+		})
+	}
+}
+
+func newPostgresWriterLiveDatabase(
+	c *qt.C,
+	ctx context.Context,
+	rawURL string,
+) postgresWriterLiveDatabase {
+	c.Helper()
+	admin, err := sql.Open("pgx", rawURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(admin.PingContext(ctx), qt.IsNil)
+
+	name := fmt.Sprintf("ptah_writer_%d", time.Now().UnixNano())
+	nameIdent := pgx.Identifier{name}.Sanitize()
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+nameIdent)
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	parsed.RawPath = ""
+	db, err := sql.Open("pgx", parsed.String())
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.PingContext(ctx), qt.IsNil)
+
+	return postgresWriterLiveDatabase{
+		db:   db,
+		name: name,
+		cleanup: func() {
+			c.Check(db.Close(), qt.IsNil)
+			_, dropErr := admin.ExecContext(
+				context.Background(),
+				"DROP DATABASE IF EXISTS "+nameIdent,
+			)
+			c.Check(dropErr, qt.IsNil)
+			c.Check(admin.Close(), qt.IsNil)
+		},
+	}
+}
+
+func requirePostgresWriterFamilyLiveURL(c *qt.C, name string) string {
+	c.Helper()
+	rawURL := os.Getenv(name)
+	if rawURL == "" {
+		c.Skipf("%s is not set", name)
+	}
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Scheme = "postgres"
+	return parsed.String()
+}
+
 func requirePostgresWriterLiveURL(t *testing.T) string {
 	t.Helper()
 	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
@@ -122,6 +462,135 @@ func requirePostgresWriterLiveURL(t *testing.T) string {
 	}
 	t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
 	return ""
+}
+
+func postgresWriterLiveCurrentDatabase(c *qt.C, ctx context.Context, db *sql.DB) string {
+	c.Helper()
+	var name string
+	err := db.QueryRowContext(ctx, "SELECT current_database()").Scan(&name)
+	c.Assert(err, qt.IsNil)
+	return name
+}
+
+func postgresWriterLiveSchemaOID(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) int64 {
+	c.Helper()
+	var oid int64
+	err := db.QueryRowContext(
+		ctx,
+		"SELECT oid FROM pg_namespace WHERE nspname = $1",
+		schema,
+	).Scan(&oid)
+	c.Assert(err, qt.IsNil)
+	return oid
+}
+
+func loadPostgresWriterLiveSchemaMetadata(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) postgresWriterLiveSchemaMetadata {
+	c.Helper()
+	var metadata postgresWriterLiveSchemaMetadata
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			pg_get_userbyid(n.nspowner),
+			obj_description(n.oid, 'pg_namespace')
+		FROM pg_namespace n
+		WHERE n.nspname = $1
+	`, schema).Scan(&metadata.Owner, &metadata.Comment)
+	c.Assert(err, qt.IsNil)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			CASE acl.grantee
+				WHEN 0 THEN 'PUBLIC'
+				ELSE pg_get_userbyid(acl.grantee)
+			END,
+			acl.privilege_type,
+			acl.is_grantable
+		FROM pg_namespace n
+		CROSS JOIN LATERAL aclexplode(
+			COALESCE(n.nspacl, acldefault('n', n.nspowner))
+		) acl
+		WHERE n.nspname = $1
+		ORDER BY 1, 2, 3
+	`, schema)
+	c.Assert(err, qt.IsNil)
+	defer rows.Close()
+
+	for rows.Next() {
+		var grantee string
+		var privilege string
+		var grantOption bool
+		c.Assert(rows.Scan(&grantee, &privilege, &grantOption), qt.IsNil)
+		metadata.Privileges = append(
+			metadata.Privileges,
+			fmt.Sprintf("%s:%s:%t", grantee, privilege, grantOption),
+		)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return metadata
+}
+
+func postgresWriterLiveCollationCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_collation c
+		JOIN pg_namespace n ON n.oid = c.collnamespace
+		WHERE n.nspname = $1
+	`, schema).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveExtensionCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	name string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(
+		ctx,
+		"SELECT COUNT(*) FROM pg_extension WHERE extname = $1",
+		name,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveExtensionNames(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+) []string {
+	c.Helper()
+	rows, err := db.QueryContext(ctx, "SELECT extname FROM pg_extension ORDER BY extname")
+	c.Assert(err, qt.IsNil)
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		c.Assert(rows.Scan(&name), qt.IsNil)
+		names = append(names, name)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return names
 }
 
 func postgresWriterLiveObjectCount(
@@ -180,6 +649,23 @@ func postgresWriterLiveRelationCount(
 		WHERE n.nspname = $1
 		  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
 	`, schema).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveSchemaCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(
+		ctx,
+		"SELECT COUNT(*) FROM pg_namespace WHERE nspname = $1",
+		schema,
+	).Scan(&count)
 	c.Assert(err, qt.IsNil)
 	return count
 }

--- a/internal/dbschema/postgres/writer_live_test.go
+++ b/internal/dbschema/postgres/writer_live_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/stokaro/ptah/internal/dbschema/postgres"
+)
+
+func TestWriterDropAllTables_LiveRejectsExternalPolicyDependency(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	db, err := sql.Open("pgx", requirePostgresWriterLiveURL(t))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	c.Assert(db.PingContext(ctx), qt.IsNil)
+
+	suffix := time.Now().UnixNano()
+	managedSchema := fmt.Sprintf("ptah_cleanup_managed_%d", suffix)
+	externalSchema := fmt.Sprintf("ptah_cleanup_external_%d", suffix)
+	managedIdent := pgx.Identifier{managedSchema}.Sanitize()
+	externalIdent := pgx.Identifier{externalSchema}.Sanitize()
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE SCHEMA %[1]s;
+		CREATE SCHEMA %[2]s;
+		CREATE FUNCTION %[1]s.is_allowed()
+			RETURNS boolean
+			LANGUAGE sql
+			IMMUTABLE
+			AS 'SELECT true';
+		CREATE TABLE %[1]s.stale_items (id bigint PRIMARY KEY);
+		CREATE TABLE %[2]s.audit_items (id bigint PRIMARY KEY);
+		ALTER TABLE %[2]s.audit_items ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY audit_items_policy
+			ON %[2]s.audit_items
+			USING (%[1]s.is_allowed());
+	`, managedIdent, externalIdent))
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, cleanupErr := db.ExecContext(
+			context.Background(),
+			fmt.Sprintf("DROP SCHEMA %s CASCADE; DROP SCHEMA %s CASCADE", externalIdent, managedIdent),
+		)
+		c.Check(cleanupErr, qt.IsNil)
+	}()
+
+	writer := postgres.NewPostgreSQLWriter(db, managedSchema)
+	err = writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, fmt.Sprintf(`refusing to clean schema %q`, managedSchema))
+	c.Assert(err.Error(), qt.Contains, "because other objects depend on it")
+	c.Assert(postgresWriterLiveObjectCount(c, ctx, db, managedSchema, "stale_items"), qt.Equals, 1)
+	c.Assert(postgresWriterLivePolicyCount(c, ctx, db, externalSchema, "audit_items_policy"), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_LiveResolvesInternalDependencies(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	db, err := sql.Open("pgx", requirePostgresWriterLiveURL(t))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	c.Assert(db.PingContext(ctx), qt.IsNil)
+
+	schema := fmt.Sprintf("ptah_cleanup_internal_%d", time.Now().UnixNano())
+	schemaIdent := pgx.Identifier{schema}.Sanitize()
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE SCHEMA %[1]s;
+		CREATE TABLE %[1]s.parents (
+			id bigint PRIMARY KEY,
+			child_id bigint
+		);
+		CREATE TABLE %[1]s.children (
+			id bigint PRIMARY KEY,
+			parent_id bigint REFERENCES %[1]s.parents(id)
+		);
+		ALTER TABLE %[1]s.parents
+			ADD CONSTRAINT parents_child_fkey
+			FOREIGN KEY (child_id) REFERENCES %[1]s.children(id);
+		CREATE VIEW %[1]s.a_base_view AS
+			SELECT id FROM %[1]s.parents;
+		CREATE VIEW %[1]s.z_dependent_view AS
+			SELECT id FROM %[1]s.a_base_view;
+	`, schemaIdent))
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, cleanupErr := db.ExecContext(
+			context.Background(),
+			fmt.Sprintf("DROP SCHEMA %s CASCADE", schemaIdent),
+		)
+		c.Check(cleanupErr, qt.IsNil)
+	}()
+
+	writer := postgres.NewPostgreSQLWriter(db, schema)
+	err = writer.DropAllTables(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(postgresWriterLiveRelationCount(c, ctx, db, schema), qt.Equals, 0)
+}
+
+func requirePostgresWriterLiveURL(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	return ""
+}
+
+func postgresWriterLiveObjectCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+	name string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1
+		  AND c.relname = $2
+	`, schema, name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLivePolicyCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+	name string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_policy p
+		JOIN pg_class c ON c.oid = p.polrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1
+		  AND p.polname = $2
+	`, schema, name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveRelationCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1
+		  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+	`, schema).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}

--- a/internal/dbschema/postgres/writer_live_test.go
+++ b/internal/dbschema/postgres/writer_live_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/stokaro/ptah/internal/dbschema/postgres"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 type postgresWriterFamilyLiveCase struct {
@@ -240,12 +241,147 @@ func TestWriterDropDatabaseRealm_LivePostgresFamilyCleansCrossSchemaGraph(t *tes
 			c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, "public"), qt.Equals, 1)
 			c.Assert(postgresWriterLiveRelationCount(c, ctx, db, "public"), qt.Equals, 0)
 			c.Assert(
+				postgresWriterLiveNamedTypeCount(c, ctx, db, "public", "ptah_root_status"),
+				qt.Equals,
+				0,
+			)
+			c.Assert(
+				postgresWriterLiveRoutineCount(c, ctx, db, "public", "ptah_root_answer"),
+				qt.Equals,
+				0,
+			)
+			c.Assert(
 				loadPostgresWriterLiveSchemaMetadata(c, ctx, db, "public"),
 				qt.DeepEquals,
 				rootMetadata,
 			)
 			c.Assert(postgresWriterLiveExtensionNames(c, ctx, db), qt.DeepEquals, systemExtensions)
 			c.Assert(postgresWriterLiveCurrentDatabase(c, ctx, db), qt.Equals, liveDatabase.name)
+		})
+	}
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresCleansToastTable(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+	db := liveDatabase.db
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE public.ptah_toast_items (
+			id bigint PRIMARY KEY,
+			payload text NOT NULL
+		);
+		INSERT INTO public.ptah_toast_items (id, payload)
+		SELECT 1, string_agg(md5(value::text), '')
+		FROM generate_series(1, 20000) AS value;
+	`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(postgresWriterLiveToastOID(c, ctx, db, "public", "ptah_toast_items"), qt.Not(qt.Equals), 0)
+	c.Assert(postgresWriterLiveStoredColumnSize(c, ctx, db), qt.Not(qt.Equals), 0)
+
+	writer := postgres.NewPostgreSQLWriter(db, "public")
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(postgresWriterLiveRelationCount(c, ctx, db, "public"), qt.Equals, 0)
+	c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, "public"), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresRollsBackOnTemporaryPolicyDependency(
+	t *testing.T,
+) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+	db := liveDatabase.db
+	conn, err := db.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, `
+		CREATE FUNCTION public.ptah_policy_guard()
+			RETURNS boolean
+			LANGUAGE sql
+			IMMUTABLE
+			AS 'SELECT true';
+		CREATE TABLE public.ptah_realm_items (id bigint PRIMARY KEY);
+		CREATE TEMP TABLE ptah_preserved_items (id bigint PRIMARY KEY);
+		ALTER TABLE pg_temp.ptah_preserved_items ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY ptah_preserved_policy
+			ON pg_temp.ptah_preserved_items
+			USING (public.ptah_policy_guard());
+	`)
+	c.Assert(err, qt.IsNil)
+
+	writer := postgres.NewPostgreSQLWriterForRunner(sqlrunner.NewConn(ctx, conn), "public")
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "because other objects depend on it")
+	c.Assert(postgresWriterLiveObjectCount(c, ctx, db, "public", "ptah_realm_items"), qt.Equals, 1)
+	c.Assert(
+		postgresWriterLiveRoutineCount(c, ctx, db, "public", "ptah_policy_guard"),
+		qt.Equals,
+		1,
+	)
+	c.Assert(postgresWriterLiveTemporaryPolicyCount(c, ctx, conn), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_LiveRejectsProtectedDatabase(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		urlEnv   string
+		database string
+	}{
+		{
+			name:     "postgres",
+			urlEnv:   "POSTGRES_URL",
+			database: "postgres",
+		},
+		{
+			name:     "cockroachdb",
+			urlEnv:   "COCKROACHDB_URL",
+			database: "defaultdb",
+		},
+		{
+			name:     "yugabytedb",
+			urlEnv:   "YUGABYTEDB_URL",
+			database: "yugabyte",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db := openPostgresWriterProtectedLiveDatabase(
+				c,
+				requirePostgresWriterFamilyLiveURL(c, test.urlEnv),
+				test.database,
+			)
+			writer := postgres.NewPostgreSQLWriter(db, "public")
+
+			err := writer.DropDatabaseRealm(c.Context())
+
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`refusing to clean protected PostgreSQL-family database "`+test.database+`"`,
+			)
 		})
 	}
 }
@@ -453,6 +589,21 @@ func requirePostgresWriterFamilyLiveURL(c *qt.C, name string) string {
 	return parsed.String()
 }
 
+func openPostgresWriterProtectedLiveDatabase(c *qt.C, rawURL, database string) *sql.DB {
+	c.Helper()
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + database
+	parsed.RawPath = ""
+	db, err := sql.Open("pgx", parsed.String())
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.PingContext(c.Context()), qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(db.Close(), qt.IsNil)
+	})
+	return db
+}
+
 func requirePostgresWriterLiveURL(t *testing.T) string {
 	t.Helper()
 	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
@@ -649,6 +800,95 @@ func postgresWriterLiveRelationCount(
 		WHERE n.nspname = $1
 		  AND c.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
 	`, schema).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveNamedTypeCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+	name string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_type t
+		JOIN pg_namespace n ON n.oid = t.typnamespace
+		WHERE n.nspname = $1
+		  AND t.typname = $2
+	`, schema, name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveRoutineCount(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+	name string,
+) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = $1
+		  AND p.proname = $2
+	`, schema, name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+func postgresWriterLiveToastOID(
+	c *qt.C,
+	ctx context.Context,
+	db *sql.DB,
+	schema string,
+	table string,
+) int64 {
+	c.Helper()
+	var oid int64
+	err := db.QueryRowContext(ctx, `
+		SELECT c.reltoastrelid
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE n.nspname = $1
+		  AND c.relname = $2
+	`, schema, table).Scan(&oid)
+	c.Assert(err, qt.IsNil)
+	return oid
+}
+
+func postgresWriterLiveStoredColumnSize(c *qt.C, ctx context.Context, db *sql.DB) int {
+	c.Helper()
+	var size int
+	err := db.QueryRowContext(
+		ctx,
+		"SELECT pg_column_size(payload) FROM public.ptah_toast_items WHERE id = 1",
+	).Scan(&size)
+	c.Assert(err, qt.IsNil)
+	return size
+}
+
+func postgresWriterLiveTemporaryPolicyCount(
+	c *qt.C,
+	ctx context.Context,
+	conn *sql.Conn,
+) int {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM pg_policy p
+		JOIN pg_class c ON c.oid = p.polrelid
+		WHERE c.relnamespace = pg_my_temp_schema()
+		  AND p.polname = 'ptah_preserved_policy'
+	`).Scan(&count)
 	c.Assert(err, qt.IsNil)
 	return count
 }

--- a/internal/dbschema/postgres/writer_live_test.go
+++ b/internal/dbschema/postgres/writer_live_test.go
@@ -295,6 +295,77 @@ func TestWriterDropDatabaseRealm_LivePostgresCleansToastTable(t *testing.T) {
 	c.Assert(postgresWriterLiveSchemaCount(c, ctx, db, "public"), qt.Equals, 1)
 }
 
+func TestWriterDropDatabaseRealm_LivePostgresCleansLargeObjects(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+	db := liveDatabase.db
+
+	var oid uint32
+	err := db.QueryRowContext(ctx, "SELECT lo_create(0)").Scan(&oid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(oid, qt.Not(qt.Equals), uint32(0))
+
+	writer := postgres.NewPostgreSQLWriter(db, "public")
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(err, qt.IsNil)
+	var objectCount int
+	err = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pg_largeobject_metadata").Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_LivePostgresRejectsPublication(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	defer cancel()
+
+	liveDatabase := newPostgresWriterLiveDatabase(
+		c,
+		ctx,
+		requirePostgresWriterFamilyLiveURL(c, "POSTGRES_URL"),
+	)
+	defer liveDatabase.cleanup()
+	db := liveDatabase.db
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE public.ptah_published_events (id bigint PRIMARY KEY);
+		CREATE PUBLICATION ptah_events_publication
+			FOR TABLE public.ptah_published_events;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	writer := postgres.NewPostgreSQLWriter(db, "public")
+	err = writer.DropDatabaseRealm(ctx)
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`refusing to clean PostgreSQL database realm with unsupported database-scoped `+
+			`publication "ptah_events_publication"`,
+	)
+	c.Assert(
+		postgresWriterLiveObjectCount(c, ctx, db, "public", "ptah_published_events"),
+		qt.Equals,
+		1,
+	)
+	var publicationCount int
+	err = db.QueryRowContext(
+		ctx,
+		"SELECT COUNT(*) FROM pg_publication WHERE pubname = 'ptah_events_publication'",
+	).Scan(&publicationCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(publicationCount, qt.Equals, 1)
+}
+
 func TestWriterDropDatabaseRealm_LivePostgresRollsBackOnTemporaryPolicyDependency(
 	t *testing.T,
 ) {

--- a/internal/dbschema/sqlite/reader.go
+++ b/internal/dbschema/sqlite/reader.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/convert/fromschema"
+	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 var triggerHeaderPattern = regexp.MustCompile(
@@ -20,7 +22,7 @@ var triggerHeaderPattern = regexp.MustCompile(
 
 // Reader reads schema information from SQLite databases.
 type Reader struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	schema string
 }
 
@@ -30,7 +32,7 @@ type tableColumnKey struct {
 }
 
 // NewSQLiteReader creates a SQLite schema reader.
-func NewSQLiteReader(db *sql.DB, schema string) *Reader {
+func NewSQLiteReader(db sqlrunner.Runner, schema string) *Reader {
 	if schema == "" {
 		schema = "main"
 	}
@@ -116,7 +118,7 @@ func (c sqliteSchemaCatalog) triggers(schema string) []types.DBTrigger {
 }
 
 func (r *Reader) readSchemaCatalog() (sqliteSchemaCatalog, error) {
-	query := formatSQLiteCatalogQuery(`
+	query := fmt.Sprintf(`
 		SELECT type, name, tbl_name, sql
 		FROM %s
 		WHERE type IN ('table', 'index', 'view', 'trigger')
@@ -209,19 +211,11 @@ func (r *Reader) schemaObject(name string) string {
 	if schema == "" {
 		schema = "main"
 	}
-	return quoteSQLiteIdentifier(schema) + "." + name
-}
-
-func quoteSQLiteIdentifier(value string) string {
-	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
-}
-
-func formatSQLiteCatalogQuery(format string, objects ...any) string {
-	return fmt.Sprintf(format, objects...)
+	return sqlident.Qualified("sqlite", schema, name)
 }
 
 func (r *Reader) readColumnsByTable() (map[string][]types.DBColumn, error) {
-	query := formatSQLiteCatalogQuery(`
+	query := fmt.Sprintf(`
 		SELECT m.name, x.cid, x.name, x.type, x."notnull", x.dflt_value, x.pk, x.hidden, m.sql
 		FROM %s AS m
 		JOIN pragma_table_xinfo(m.name, ?) AS x
@@ -363,7 +357,7 @@ func (r *Reader) readIndexesByTable(
 }
 
 func (r *Reader) readIndexEntriesByTable() (map[string][]sqliteIndexEntry, error) {
-	query := formatSQLiteCatalogQuery(`
+	query := fmt.Sprintf(`
 		SELECT m.name, il.seq, il.name, il."unique", il.origin, il.partial
 		FROM %s AS m
 		JOIN pragma_index_list(m.name, ?) AS il
@@ -468,7 +462,7 @@ type sqliteIndexColumns struct {
 }
 
 func (r *Reader) readIndexColumnsByIndex() (map[string]sqliteIndexColumns, error) {
-	query := formatSQLiteCatalogQuery(`
+	query := fmt.Sprintf(`
 		SELECT il.name, ix.seqno, ix.cid, ix.name, ix.key
 		FROM %s AS m
 		JOIN pragma_index_list(m.name, ?) AS il
@@ -658,7 +652,7 @@ func primaryKeyConstraint(tableName, schema string, columns []types.DBColumn, dd
 }
 
 func (r *Reader) readForeignKeysByTable(tableDDLByName map[string]string) (map[string][]types.DBConstraint, error) {
-	query := formatSQLiteCatalogQuery(`
+	query := fmt.Sprintf(`
 		SELECT m.name, fk.id, fk.seq, fk."table", fk."from", fk."to", fk.on_update, fk.on_delete, fk.match
 		FROM %s AS m
 		JOIN pragma_foreign_key_list(m.name, ?) AS fk

--- a/internal/dbschema/sqlite/sqlite_test.go
+++ b/internal/dbschema/sqlite/sqlite_test.go
@@ -33,9 +33,9 @@ func openMemoryDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func execSQL(t *testing.T, db *sql.DB, statement string) {
+func execSQL(t *testing.T, db *sql.DB, statement string, args ...any) {
 	t.Helper()
-	if _, err := db.ExecContext(context.Background(), statement); err != nil {
+	if _, err := db.ExecContext(context.Background(), statement, args...); err != nil {
 		t.Fatalf("exec %q: %v", statement, err)
 	}
 }
@@ -142,6 +142,7 @@ func TestWriterDropAllTables(t *testing.T) {
 		id INTEGER PRIMARY KEY,
 		parent_id INTEGER NOT NULL REFERENCES parents(id)
 	)`)
+	execSQL(t, db, `CREATE VIEW parent_ids AS SELECT id FROM parents`)
 
 	writer := sqlite.NewSQLiteWriter(db, "main")
 	err := writer.DropAllTables(t.Context())
@@ -150,6 +151,7 @@ func TestWriterDropAllTables(t *testing.T) {
 	schema, err := sqlite.NewSQLiteReader(db, "main").ReadSchema()
 	c.Assert(err, qt.IsNil)
 	c.Assert(schema.Tables, qt.HasLen, 0)
+	c.Assert(schema.Views, qt.HasLen, 0)
 
 	var foreignKeys int
 	err = db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys)

--- a/internal/dbschema/sqlite/writer.go
+++ b/internal/dbschema/sqlite/writer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/internal/sqlrunner"
 )
 
 const sessionRestoreTimeout = 5 * time.Second
@@ -24,7 +25,7 @@ func quoteQualifiedIdent(schema, name string) string {
 
 // Writer applies schema changes to a SQLite database.
 type Writer struct {
-	db     *sql.DB
+	db     sqlrunner.Runner
 	conn   *sql.Conn
 	schema string
 	dryRun bool
@@ -39,29 +40,63 @@ type transactionWriter struct {
 
 // NewSQLiteWriter creates a SQLite schema writer.
 func NewSQLiteWriter(db *sql.DB, schema string) *Writer {
-	return &Writer{db: db, schema: normalizeSchema(schema)}
+	if db == nil {
+		return NewSQLiteWriterForRunner(nil, schema)
+	}
+	return NewSQLiteWriterForRunner(db, schema)
+}
+
+// NewSQLiteWriterForRunner creates a writer bound to a pool-backed runner.
+func NewSQLiteWriterForRunner(runner sqlrunner.Runner, schema string) *Writer {
+	return &Writer{db: runner, schema: normalizeSchema(schema)}
 }
 
 // NewSQLiteWriterForConnection creates a writer pinned to an existing SQLite
 // connection. Use it for connection-local state such as attached databases.
 // The caller retains ownership of conn.
 func NewSQLiteWriterForConnection(conn *sql.Conn, schema string) *Writer {
-	return &Writer{conn: conn, schema: normalizeSchema(schema)}
+	return NewSQLiteWriterForPinnedRunner(
+		sqlrunner.NewConn(context.Background(), conn),
+		conn,
+		schema,
+	)
+}
+
+// NewSQLiteWriterForPinnedRunner creates a writer bound to runner while
+// retaining the underlying session for SQLite connection-local cleanup.
+func NewSQLiteWriterForPinnedRunner(
+	runner sqlrunner.Runner,
+	conn *sql.Conn,
+	schema string,
+) *Writer {
+	return &Writer{
+		db:     runner,
+		conn:   conn,
+		schema: normalizeSchema(schema),
+	}
 }
 
 // ExecuteSQL executes a standalone SQL statement.
 func (w *Writer) ExecuteSQL(ctx context.Context, sqlExpr string, args ...any) error {
-	if w.dryRun {
-		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
-		return nil
-	}
-	if w.db == nil && w.conn == nil {
-		return fmt.Errorf("no database connection")
-	}
-	if _, err := w.execContext(ctx, sqlExpr, args...); err != nil {
+	_, err := w.ExecContext(ctx, sqlExpr, args...)
+	if err != nil {
 		return fmt.Errorf("sqlite: SQL execution failed: %w\nSQL: %s", err, sqlExpr)
 	}
 	return nil
+}
+
+// ExecContext executes a standalone SQL statement and returns its driver
+// result. DatabaseConnection uses this method when a connection-bound writer
+// is installed as its active executor.
+func (w *Writer) ExecContext(ctx context.Context, sqlExpr string, args ...any) (sql.Result, error) {
+	if w.dryRun {
+		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
+		return nil, nil
+	}
+	if w.db == nil && w.conn == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	return w.execContext(ctx, sqlExpr, args...)
 }
 
 // BeginTransaction starts a transaction and returns a transaction-scoped writer.
@@ -139,6 +174,33 @@ type cleanupObject struct {
 
 // DropAllTables drops all user tables and views from the configured SQLite schema.
 func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
+	return w.dropAllTables(ctx, false)
+}
+
+// DropDatabaseRealm removes every user object from a pinned SQLite main
+// database. Replay callers use this stronger contract so revision state cannot
+// leak between runs.
+func (w *Writer) DropDatabaseRealm(ctx context.Context) error {
+	if w.conn == nil {
+		return fmt.Errorf("sqlite: database-realm cleanup requires a pinned connection")
+	}
+	if !strings.EqualFold(w.cleanupSchema(), "main") {
+		return fmt.Errorf(
+			"sqlite: database-realm cleanup requires schema %q, got %q",
+			"main",
+			w.cleanupSchema(),
+		)
+	}
+	if err := inspectDatabaseRealm(ctx, w.conn); err != nil {
+		return err
+	}
+	if err := w.dropAllTables(ctx, true); err != nil {
+		return err
+	}
+	return verifyDatabaseRealmEmpty(ctx, w.conn)
+}
+
+func (w *Writer) dropAllTables(ctx context.Context, includeRevisionTable bool) (resultErr error) {
 	if w.dryRun {
 		return nil
 	}
@@ -152,6 +214,10 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 			resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: close cleanup connection: %w", closeErr))
 		}
 	}()
+
+	if err := refuseCleanupWithTempViews(ctx, conn, w.cleanupSchema()); err != nil {
+		return err
+	}
 
 	var tx *sql.Tx
 	committed := false
@@ -187,7 +253,7 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if err != nil {
 		return fmt.Errorf("sqlite: begin drop transaction: %w", err)
 	}
-	objects, err := w.listCleanupObjects(ctx, tx)
+	objects, err := w.listCleanupObjects(ctx, tx, includeRevisionTable)
 	if err != nil {
 		return err
 	}
@@ -206,6 +272,112 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	}
 	committed = true
 
+	return nil
+}
+
+func inspectDatabaseRealm(ctx context.Context, conn *sql.Conn) error {
+	attachments, err := listAuxiliaryDatabases(ctx, conn)
+	if err != nil {
+		return err
+	}
+	if len(attachments) > 0 {
+		return fmt.Errorf(
+			"sqlite: refusing database-realm cleanup with attached databases: %s",
+			strings.Join(attachments, ", "),
+		)
+	}
+	tempObjects, err := listSchemaObjects(ctx, conn, "temp")
+	if err != nil {
+		return err
+	}
+	if len(tempObjects) > 0 {
+		return fmt.Errorf(
+			"sqlite: refusing database-realm cleanup with TEMP objects: %s",
+			strings.Join(tempObjects, ", "),
+		)
+	}
+	return nil
+}
+
+func verifyDatabaseRealmEmpty(ctx context.Context, conn *sql.Conn) error {
+	if err := inspectDatabaseRealm(ctx, conn); err != nil {
+		return err
+	}
+	objects, err := listSchemaObjects(ctx, conn, "main")
+	if err != nil {
+		return err
+	}
+	if len(objects) > 0 {
+		return fmt.Errorf(
+			"sqlite: database-realm cleanup left user objects: %s",
+			strings.Join(objects, ", "),
+		)
+	}
+	return nil
+}
+
+func listAuxiliaryDatabases(ctx context.Context, conn *sql.Conn) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, "PRAGMA database_list")
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: inspect attached databases: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var sequence int
+		var name, filename string
+		if err := rows.Scan(&sequence, &name, &filename); err != nil {
+			return nil, fmt.Errorf("sqlite: scan attached database: %w", err)
+		}
+		if !strings.EqualFold(name, "main") && !strings.EqualFold(name, "temp") {
+			names = append(names, name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate attached databases: %w", err)
+	}
+	return names, nil
+}
+
+func listSchemaObjects(ctx context.Context, conn *sql.Conn, schema string) ([]string, error) {
+	//nolint:gosec // G202: schema is an identifier quoted by sqlident, not an SQL value.
+	query := "SELECT type || ':' || name FROM " + quoteQualifiedIdent(schema, "sqlite_schema") + `
+		WHERE name NOT LIKE 'sqlite_%'
+		ORDER BY type, name
+	`
+	rows, err := conn.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: inspect %s schema objects: %w", schema, err)
+	}
+	defer rows.Close()
+
+	var objects []string
+	for rows.Next() {
+		var object string
+		if err := rows.Scan(&object); err != nil {
+			return nil, fmt.Errorf("sqlite: scan %s schema object: %w", schema, err)
+		}
+		objects = append(objects, object)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate %s schema objects: %w", schema, err)
+	}
+	return objects, nil
+}
+
+func refuseCleanupWithTempViews(ctx context.Context, conn *sql.Conn, schema string) error {
+	var exists bool
+	const query = `SELECT EXISTS (SELECT 1 FROM temp.sqlite_schema WHERE type = 'view')`
+	if err := conn.QueryRowContext(ctx, query).Scan(&exists); err != nil {
+		return fmt.Errorf("sqlite: inspect TEMP views: %w", err)
+	}
+	if exists {
+		return fmt.Errorf(
+			"sqlite: refusing to clean schema %q: TEMP views exist on the cleanup connection and may depend on it",
+			schema,
+		)
+	}
 	return nil
 }
 
@@ -245,7 +417,11 @@ func (w *Writer) acquireCleanupConnection(ctx context.Context) (*sql.Conn, func(
 	if w.db == nil {
 		return nil, nil, fmt.Errorf("no database connection")
 	}
-	conn, err := w.db.Conn(ctx)
+	connector, ok := w.db.(sqlrunner.Connector)
+	if !ok {
+		return nil, nil, fmt.Errorf("database runner cannot acquire a cleanup connection")
+	}
+	conn, err := connector.Conn(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -259,17 +435,21 @@ func (w *Writer) cleanupSchema() string {
 	return w.schema
 }
 
-func (w *Writer) listCleanupObjects(ctx context.Context, tx *sql.Tx) ([]cleanupObject, error) {
+func (w *Writer) listCleanupObjects(
+	ctx context.Context,
+	tx *sql.Tx,
+	includeRevisionTable bool,
+) ([]cleanupObject, error) {
 	const query = `
 		SELECT name, CASE type WHEN 'view' THEN 'view' ELSE 'table' END
 		FROM pragma_table_list
 		WHERE schema = ?
 		  AND type IN ('table', 'view', 'virtual')
 		  AND name NOT LIKE 'sqlite_%'
-		  AND name <> 'schema_migrations'
+		  AND (? OR name <> 'schema_migrations')
 		ORDER BY CASE type WHEN 'view' THEN 0 ELSE 1 END, name
 	`
-	rows, err := tx.QueryContext(ctx, query, w.cleanupSchema())
+	rows, err := tx.QueryContext(ctx, query, w.cleanupSchema(), includeRevisionTable)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: list schema objects: %w", err)
 	}

--- a/internal/dbschema/sqlite/writer.go
+++ b/internal/dbschema/sqlite/writer.go
@@ -11,18 +11,21 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/sqlident"
 )
 
 const sessionRestoreTimeout = 5 * time.Second
 
-func quoteIdent(name string) string {
-	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+func quoteQualifiedIdent(schema, name string) string {
+	return sqlident.Qualified(platform.SQLite, schema, name)
 }
 
 // Writer applies schema changes to a SQLite database.
 type Writer struct {
 	db     *sql.DB
+	conn   *sql.Conn
 	schema string
 	dryRun bool
 }
@@ -36,10 +39,14 @@ type transactionWriter struct {
 
 // NewSQLiteWriter creates a SQLite schema writer.
 func NewSQLiteWriter(db *sql.DB, schema string) *Writer {
-	if schema == "" {
-		schema = "main"
-	}
-	return &Writer{db: db, schema: schema}
+	return &Writer{db: db, schema: normalizeSchema(schema)}
+}
+
+// NewSQLiteWriterForConnection creates a writer pinned to an existing SQLite
+// connection. Use it for connection-local state such as attached databases.
+// The caller retains ownership of conn.
+func NewSQLiteWriterForConnection(conn *sql.Conn, schema string) *Writer {
+	return &Writer{conn: conn, schema: normalizeSchema(schema)}
 }
 
 // ExecuteSQL executes a standalone SQL statement.
@@ -48,10 +55,10 @@ func (w *Writer) ExecuteSQL(ctx context.Context, sqlExpr string, args ...any) er
 		slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
 		return nil
 	}
-	if w.db == nil {
+	if w.db == nil && w.conn == nil {
 		return fmt.Errorf("no database connection")
 	}
-	if _, err := w.db.ExecContext(ctx, sqlExpr, args...); err != nil {
+	if _, err := w.execContext(ctx, sqlExpr, args...); err != nil {
 		return fmt.Errorf("sqlite: SQL execution failed: %w\nSQL: %s", err, sqlExpr)
 	}
 	return nil
@@ -63,10 +70,10 @@ func (w *Writer) BeginTransaction(ctx context.Context) (types.SchemaTransaction,
 		slog.Info("[DRY RUN] Would begin transaction")
 		return &transactionWriter{schema: w.schema, dryRun: true}, nil
 	}
-	if w.db == nil {
+	if w.db == nil && w.conn == nil {
 		return nil, fmt.Errorf("no database connection")
 	}
-	tx, err := w.db.BeginTx(ctx, nil)
+	tx, err := w.beginTx(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -125,21 +132,22 @@ func (w *transactionWriter) Rollback() error {
 // IsDryRun reports whether dry-run mode is active.
 func (w *transactionWriter) IsDryRun() bool { return w.dryRun }
 
-// DropAllTables drops all user tables from the configured SQLite schema.
+type cleanupObject struct {
+	Name string
+	Type string
+}
+
+// DropAllTables drops all user tables and views from the configured SQLite schema.
 func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	if w.dryRun {
 		return nil
 	}
-	if w.db == nil {
-		return fmt.Errorf("no database connection")
-	}
-
-	conn, err := w.db.Conn(ctx)
+	conn, release, err := w.acquireCleanupConnection(ctx)
 	if err != nil {
 		return fmt.Errorf("sqlite: acquire cleanup connection: %w", err)
 	}
 	defer func() {
-		closeErr := conn.Close()
+		closeErr := release()
 		if closeErr != nil && !errors.Is(closeErr, sql.ErrConnDone) {
 			resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: close cleanup connection: %w", closeErr))
 		}
@@ -148,8 +156,9 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	var tx *sql.Tx
 	committed := false
 
-	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
-		return fmt.Errorf("sqlite: disable foreign keys: %w", err)
+	foreignKeys, err := readForeignKeys(ctx, conn)
+	if err != nil {
+		return err
 	}
 	defer func() {
 		if tx != nil && !committed {
@@ -161,26 +170,35 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionRestoreTimeout)
 		defer cancel()
-		if _, restoreErr := conn.ExecContext(cleanupCtx, "PRAGMA foreign_keys = ON"); restoreErr != nil {
+		restoreSQL := "PRAGMA foreign_keys = 0"
+		if foreignKeys {
+			restoreSQL = "PRAGMA foreign_keys = 1"
+		}
+		if _, restoreErr := conn.ExecContext(cleanupCtx, restoreSQL); restoreErr != nil {
 			discardConn(conn)
 			resultErr = errors.Join(resultErr, fmt.Errorf("sqlite: restore foreign keys: %w", restoreErr))
 		}
 	}()
-
-	tables, err := w.listTables(ctx, conn)
-	if err != nil {
-		return err
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("sqlite: disable foreign keys: %w", err)
 	}
 
 	tx, err = conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("sqlite: begin drop transaction: %w", err)
 	}
+	objects, err := w.listCleanupObjects(ctx, tx)
+	if err != nil {
+		return err
+	}
 	txWriter := &transactionWriter{tx: tx, schema: w.schema}
 
-	for _, table := range tables {
-		if err := txWriter.ExecuteSQL(ctx, "DROP TABLE IF EXISTS "+quoteIdent(table)); err != nil {
-			return fmt.Errorf("sqlite: drop table %s: %w", table, err)
+	schema := w.cleanupSchema()
+	for _, object := range objects {
+		statement := "DROP " + strings.ToUpper(object.Type) + " IF EXISTS " +
+			quoteQualifiedIdent(schema, object.Name)
+		if err := txWriter.ExecuteSQL(ctx, statement); err != nil {
+			return fmt.Errorf("sqlite: drop %s %s: %w", object.Type, object.Name, err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -191,32 +209,84 @@ func (w *Writer) DropAllTables(ctx context.Context) (resultErr error) {
 	return nil
 }
 
-func (w *Writer) listTables(ctx context.Context, conn *sql.Conn) ([]string, error) {
-	rows, err := conn.QueryContext(ctx, `
-		SELECT name
-		FROM sqlite_schema
-		WHERE type = 'table'
+func readForeignKeys(ctx context.Context, conn *sql.Conn) (bool, error) {
+	var value bool
+	if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&value); err != nil {
+		return false, fmt.Errorf("sqlite: read foreign keys setting: %w", err)
+	}
+	return value, nil
+}
+
+func normalizeSchema(schema string) string {
+	if schema == "" {
+		return "main"
+	}
+	return schema
+}
+
+func (w *Writer) execContext(ctx context.Context, sqlExpr string, args ...any) (sql.Result, error) {
+	if w.conn != nil {
+		return w.conn.ExecContext(ctx, sqlExpr, args...)
+	}
+	return w.db.ExecContext(ctx, sqlExpr, args...)
+}
+
+func (w *Writer) beginTx(ctx context.Context) (*sql.Tx, error) {
+	if w.conn != nil {
+		return w.conn.BeginTx(ctx, nil)
+	}
+	return w.db.BeginTx(ctx, nil)
+}
+
+func (w *Writer) acquireCleanupConnection(ctx context.Context) (*sql.Conn, func() error, error) {
+	if w.conn != nil {
+		return w.conn, func() error { return nil }, nil
+	}
+	if w.db == nil {
+		return nil, nil, fmt.Errorf("no database connection")
+	}
+	conn, err := w.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, conn.Close, nil
+}
+
+func (w *Writer) cleanupSchema() string {
+	if strings.TrimSpace(w.schema) == "" {
+		return "main"
+	}
+	return w.schema
+}
+
+func (w *Writer) listCleanupObjects(ctx context.Context, tx *sql.Tx) ([]cleanupObject, error) {
+	const query = `
+		SELECT name, CASE type WHEN 'view' THEN 'view' ELSE 'table' END
+		FROM pragma_table_list
+		WHERE schema = ?
+		  AND type IN ('table', 'view', 'virtual')
 		  AND name NOT LIKE 'sqlite_%'
 		  AND name <> 'schema_migrations'
-		ORDER BY name
-	`)
+		ORDER BY CASE type WHEN 'view' THEN 0 ELSE 1 END, name
+	`
+	rows, err := tx.QueryContext(ctx, query, w.cleanupSchema())
 	if err != nil {
-		return nil, fmt.Errorf("sqlite: list tables: %w", err)
+		return nil, fmt.Errorf("sqlite: list schema objects: %w", err)
 	}
 	defer rows.Close()
 
-	var tables []string
+	var objects []cleanupObject
 	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("sqlite: scan table name: %w", err)
+		var object cleanupObject
+		if err := rows.Scan(&object.Name, &object.Type); err != nil {
+			return nil, fmt.Errorf("sqlite: scan schema object: %w", err)
 		}
-		tables = append(tables, name)
+		objects = append(objects, object)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("sqlite: iterate tables: %w", err)
+		return nil, fmt.Errorf("sqlite: iterate schema objects: %w", err)
 	}
-	return tables, nil
+	return objects, nil
 }
 
 func discardConn(conn *sql.Conn) {

--- a/internal/dbschema/sqlite/writer_context_test.go
+++ b/internal/dbschema/sqlite/writer_context_test.go
@@ -57,9 +57,9 @@ func TestWriterDropAllTables_PinsCleanupToOneConnection(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(trace.connectionIDs(), qt.HasLen, 1)
 	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = OFF")
-	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "children"`)
-	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "parents"`)
-	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "main"."children"`)
+	c.Assert(trace.statements(), qt.Contains, `DROP TABLE IF EXISTS "main"."parents"`)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = 1")
 }
 
 func TestWriterDropAllTables_RestoresForeignKeysAfterCancellation(t *testing.T) {
@@ -79,7 +79,7 @@ func TestWriterDropAllTables_RestoresForeignKeysAfterCancellation(t *testing.T) 
 
 	c.Assert(err, qt.ErrorIs, context.Canceled)
 	c.Assert(trace.connectionIDs(), qt.HasLen, 1)
-	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = 1")
 }
 
 func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
@@ -99,7 +99,68 @@ func TestWriterDropAllTables_JoinsPrimaryAndRestoreErrors(t *testing.T) {
 
 	c.Assert(err, qt.ErrorIs, dropErr)
 	c.Assert(err, qt.ErrorIs, restoreErr)
-	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = ON")
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = 1")
+}
+
+func TestWriterDropAllTables_RestoresDisabledForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDBWithDSN(t, trace, filepath.Join(t.TempDir(), "cleanup.sqlite"))
+	execSQL(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	trace.reset()
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = 0")
+}
+
+func TestWriterDropAllTables_RestoresAfterDisableFailure(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDB(t, trace)
+	execSQL(t, db, `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	trace.reset()
+	disableErr := errors.New("disable outcome unknown")
+	trace.disableErr = disableErr
+
+	writer := sqlite.NewSQLiteWriter(db, "main")
+	err := writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.ErrorIs, disableErr)
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = OFF")
+	c.Assert(trace.statements(), qt.Contains, "PRAGMA foreign_keys = 1")
+}
+
+func TestWriterDropAllTables_CleansOnlyConfiguredAttachedSchema(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	auxPath := filepath.Join(t.TempDir(), "aux.sqlite")
+	_, err = conn.ExecContext(t.Context(), `ATTACH DATABASE ? AS aux`, auxPath)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE main.users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE aux.users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE VIRTUAL TABLE aux.search USING fts5(body)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TEMP TABLE users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, "aux")
+	err = writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "main", "users"), qt.Equals, 1)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "aux", "users"), qt.Equals, 0)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "aux", "search"), qt.Equals, 0)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "temp", "users"), qt.Equals, 1)
 }
 
 func openFileSQLiteDB(t *testing.T) *sql.DB {
@@ -119,11 +180,16 @@ func openFileSQLiteDB(t *testing.T) *sql.DB {
 func openTrackedSQLiteDB(t *testing.T, trace *sqliteCleanupTrace) *sql.DB {
 	t.Helper()
 
+	return openTrackedSQLiteDBWithDSN(t, trace, filepath.Join(t.TempDir(), "cleanup.sqlite")+"?_pragma=foreign_keys(1)")
+}
+
+func openTrackedSQLiteDBWithDSN(t *testing.T, trace *sqliteCleanupTrace, dsn string) *sql.DB {
+	t.Helper()
+
 	driverName := "ptah_sqlite_cleanup_" + strconv.FormatInt(sqliteCleanupDriverID.Add(1), 10)
 	sql.Register(driverName, &sqliteCleanupDriver{trace: trace})
 
-	path := filepath.Join(t.TempDir(), "cleanup.sqlite")
-	db, err := sql.Open(driverName, path+"?_pragma=foreign_keys(1)")
+	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		t.Fatalf("open tracked sqlite: %v", err)
 	}
@@ -133,6 +199,15 @@ func openTrackedSQLiteDB(t *testing.T, trace *sqliteCleanupTrace) *sql.DB {
 		_ = db.Close()
 	})
 	return db
+}
+
+func sqliteConnSchemaObjectCount(c *qt.C, conn *sql.Conn, schema, name string) int {
+	c.Helper()
+	var count int
+	const query = `SELECT COUNT(*) FROM pragma_table_list WHERE schema = ? AND name = ?`
+	err := conn.QueryRowContext(c.Context(), query, schema, name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
 }
 
 var sqliteCleanupDriverID atomic.Int64
@@ -147,6 +222,7 @@ type sqliteCleanupTrace struct {
 	nextConnection atomic.Int64
 	events         []sqliteCleanupEvent
 	cancelOnDrop   context.CancelFunc
+	disableErr     error
 	dropErr        error
 	restoreErr     error
 }
@@ -165,17 +241,22 @@ func (tr *sqliteCleanupTrace) executionError(query string) error {
 
 	tr.mu.Lock()
 	cancelOnDrop := tr.cancelOnDrop
+	disableErr := tr.disableErr
 	dropErr := tr.dropErr
 	restoreErr := tr.restoreErr
 	tr.mu.Unlock()
 
 	switch {
+	case statement == "PRAGMA foreign_keys = OFF" && disableErr != nil:
+		return disableErr
 	case strings.HasPrefix(statement, "DROP TABLE") && dropErr != nil:
 		if cancelOnDrop != nil {
 			cancelOnDrop()
 		}
 		return dropErr
-	case statement == "PRAGMA foreign_keys = ON" && restoreErr != nil:
+	case strings.HasPrefix(statement, "PRAGMA foreign_keys = ") &&
+		statement != "PRAGMA foreign_keys = OFF" &&
+		restoreErr != nil:
 		return restoreErr
 	default:
 		return nil

--- a/internal/dbschema/sqlite/writer_context_test.go
+++ b/internal/dbschema/sqlite/writer_context_test.go
@@ -141,7 +141,7 @@ func TestWriterDropAllTables_CleansOnlyConfiguredAttachedSchema(t *testing.T) {
 	t.Cleanup(func() {
 		c.Check(conn.Close(), qt.IsNil)
 	})
-	auxPath := filepath.Join(t.TempDir(), "aux.sqlite")
+	auxPath := filepath.Join(t.TempDir(), "aux'quoted.sqlite")
 	_, err = conn.ExecContext(t.Context(), `ATTACH DATABASE ? AS aux`, auxPath)
 	c.Assert(err, qt.IsNil)
 	_, err = conn.ExecContext(t.Context(), `CREATE TABLE main.users (id INTEGER PRIMARY KEY)`)
@@ -161,6 +161,152 @@ func TestWriterDropAllTables_CleansOnlyConfiguredAttachedSchema(t *testing.T) {
 	c.Assert(sqliteConnSchemaObjectCount(c, conn, "aux", "users"), qt.Equals, 0)
 	c.Assert(sqliteConnSchemaObjectCount(c, conn, "aux", "search"), qt.Equals, 0)
 	c.Assert(sqliteConnSchemaObjectCount(c, conn, "temp", "users"), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_PreservesPaddedCatalogIdentifierBytes(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	paddedPath := filepath.Join(t.TempDir(), "padded.sqlite")
+	unpaddedPath := filepath.Join(t.TempDir(), "unpadded.sqlite")
+	_, err = conn.ExecContext(t.Context(), `ATTACH DATABASE ? AS " aux "`, paddedPath)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `ATTACH DATABASE ? AS aux`, unpaddedPath)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE " aux ".users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE aux.users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, " aux ")
+	err = writer.DropAllTables(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, " aux ", "users"), qt.Equals, 0)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "aux", "users"), qt.Equals, 1)
+}
+
+func TestWriterDropAllTables_RefusesCleanupWhenTempViewExists(t *testing.T) {
+	c := qt.New(t)
+	trace := new(sqliteCleanupTrace)
+	db := openTrackedSQLiteDB(t, trace)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE main.users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `INSERT INTO main.users (id) VALUES (7)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TEMP VIEW temp_users AS SELECT id FROM main.users`)
+	c.Assert(err, qt.IsNil)
+	trace.reset()
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, "main")
+	err = writer.DropAllTables(t.Context())
+	statements := trace.statements()
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`sqlite: refusing to clean schema "main": TEMP views exist on the cleanup connection and may depend on it`,
+	)
+	c.Assert(statements, qt.Not(qt.Contains), "PRAGMA foreign_keys = OFF")
+	c.Assert(strings.Join(statements, "\n"), qt.Not(qt.Contains), "DROP ")
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "main", "users"), qt.Equals, 1)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "temp", "temp_users"), qt.Equals, 1)
+
+	var id int
+	err = conn.QueryRowContext(t.Context(), `SELECT id FROM temp_users`).Scan(&id)
+	c.Assert(err, qt.IsNil)
+	c.Assert(id, qt.Equals, 7)
+}
+
+func TestWriterDropDatabaseRealm_CleansRevisionAndUserObjects(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE INDEX users_id_idx ON users (id)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE VIEW user_ids AS SELECT id FROM users`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE VIRTUAL TABLE search USING fts5(body)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, "main")
+	err = writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	var count int
+	err = conn.QueryRowContext(t.Context(), `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+	`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}
+
+func TestWriterDropDatabaseRealm_RequiresPinnedConnection(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	writer := sqlite.NewSQLiteWriter(db, "main")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `sqlite: database-realm cleanup requires a pinned connection`)
+}
+
+func TestWriterDropDatabaseRealm_RejectsAttachedDatabase(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	auxPath := filepath.Join(t.TempDir(), "aux.sqlite")
+	_, err = conn.ExecContext(t.Context(), `ATTACH DATABASE ? AS aux`, auxPath)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(t.Context(), `CREATE TABLE main.users (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, "main")
+	err = writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `sqlite: refusing database-realm cleanup with attached databases: aux`)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "main", "users"), qt.Equals, 1)
+}
+
+func TestWriterDropDatabaseRealm_RejectsTempObject(t *testing.T) {
+	c := qt.New(t)
+	db := openFileSQLiteDB(t)
+	conn, err := db.Conn(t.Context())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	_, err = conn.ExecContext(t.Context(), `CREATE TEMP TABLE scratch (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+
+	writer := sqlite.NewSQLiteWriterForConnection(conn, "main")
+	err = writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `sqlite: refusing database-realm cleanup with TEMP objects: table:scratch`)
+	c.Assert(sqliteConnSchemaObjectCount(c, conn, "temp", "scratch"), qt.Equals, 1)
 }
 
 func openFileSQLiteDB(t *testing.T) *sql.DB {

--- a/internal/devclean/clean.go
+++ b/internal/devclean/clean.go
@@ -1,0 +1,28 @@
+// Package devclean resets disposable development databases between migration
+// replay operations.
+package devclean
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stokaro/ptah/dbschema"
+)
+
+type databaseRealmCleaner interface {
+	DropDatabaseRealm(context.Context) error
+}
+
+// DatabaseRealm removes every user object in the mutation realm represented by
+// conn. Dialect writers with a broader realm than their configured schema
+// implement DropDatabaseRealm; single-realm writers use DropAllTables.
+func DatabaseRealm(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	if conn == nil {
+		return fmt.Errorf("clean dev database realm: nil database connection")
+	}
+	writer := conn.SchemaWriter()
+	if cleaner, ok := writer.(databaseRealmCleaner); ok {
+		return cleaner.DropDatabaseRealm(ctx)
+	}
+	return writer.DropAllTables(ctx)
+}

--- a/internal/devclean/guard.go
+++ b/internal/devclean/guard.go
@@ -24,6 +24,11 @@ func NewReplayGuard(info types.DBInfo) *ReplayGuard {
 // the replay database realm.
 func (g *ReplayGuard) ValidateStatement(stmt string) error {
 	dialect := platform.NormalizeDialect(g.info.Dialect)
+	if dialect == platform.MySQL || dialect == platform.MariaDB {
+		if err := rejectMySQLExecutableComments(dialect, stmt); err != nil {
+			return err
+		}
+	}
 	tokens := significantTokens(stmt, replayLexerOptions(dialect))
 	switch dialect {
 	case platform.SQLite:
@@ -42,6 +47,23 @@ func (g *ReplayGuard) ValidateStatement(stmt string) error {
 			unsupportedDialect = "unknown"
 		}
 		return unsafeReplayStatement(unsupportedDialect, "unsupported dialect")
+	}
+}
+
+func rejectMySQLExecutableComments(dialect, stmt string) error {
+	lex := lexer.NewLexerWithOptions(stmt, replayLexerOptions(dialect))
+	for {
+		token := lex.NextToken()
+		if token.Type == lexer.TokenEOF {
+			return nil
+		}
+		if token.Type != lexer.TokenComment {
+			continue
+		}
+		comment := strings.ToUpper(token.Value)
+		if strings.HasPrefix(comment, "/*!") || strings.HasPrefix(comment, "/*M!") {
+			return unsafeReplayStatement(dialect, "executable comment")
+		}
 	}
 }
 

--- a/internal/devclean/guard.go
+++ b/internal/devclean/guard.go
@@ -1,0 +1,169 @@
+package devclean
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+// ReplayGuard rejects migration statements whose effects cannot be confined to
+// the disposable database realm cleaned after migration replay.
+type ReplayGuard struct {
+	info types.DBInfo
+}
+
+// NewReplayGuard creates a dialect-aware migration replay guard.
+func NewReplayGuard(info types.DBInfo) *ReplayGuard {
+	return &ReplayGuard{info: info}
+}
+
+// ValidateStatement rejects statements whose effects cannot be confined to
+// the replay database realm.
+func (g *ReplayGuard) ValidateStatement(stmt string) error {
+	dialect := platform.NormalizeDialect(g.info.Dialect)
+	tokens := significantTokens(stmt, replayLexerOptions(dialect))
+	switch dialect {
+	case platform.SQLite:
+		return validateSQLiteReplayStatement(tokens)
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return validatePostgresReplayStatement(dialect, tokens)
+	case platform.MySQL, platform.MariaDB:
+		return validateMySQLReplayStatement(dialect, g.info.Schema, tokens)
+	case platform.SQLServer:
+		return validateSQLServerReplayStatement(tokens)
+	case platform.ClickHouse:
+		return validateClickHouseReplayStatement(g.info.Schema, tokens)
+	default:
+		unsupportedDialect := strings.TrimSpace(g.info.Dialect)
+		if unsupportedDialect == "" {
+			unsupportedDialect = "unknown"
+		}
+		return unsafeReplayStatement(unsupportedDialect, "unsupported dialect")
+	}
+}
+
+func validateSQLiteReplayStatement(tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "ATTACH", "DETACH":
+		return unsafeReplayStatement(platform.SQLite, first)
+	case "CREATE":
+		if createsSQLiteTemporaryObject(tokens) {
+			return unsafeReplayStatement(platform.SQLite, "TEMP object")
+		}
+	case "PRAGMA":
+		if !isRestorableSQLitePragma(tokens) {
+			return unsafeReplayStatement(platform.SQLite, "state-changing or unsupported PRAGMA")
+		}
+	case "VACUUM":
+		if containsIdentifier(tokens[1:], "INTO") {
+			return unsafeReplayStatement(platform.SQLite, "VACUUM INTO")
+		}
+	}
+
+	if containsIdentifier(tokens, "LOAD_EXTENSION") {
+		return unsafeReplayStatement(platform.SQLite, "load_extension")
+	}
+	if mutatesSQLiteRealm(first) && containsQualifiedIdentifier(tokens, "temp") {
+		return unsafeReplayStatement(platform.SQLite, "TEMP schema target")
+	}
+	return nil
+}
+
+func createsSQLiteTemporaryObject(tokens []lexer.Token) bool {
+	if len(tokens) < 2 {
+		return false
+	}
+	modifier := normalizedIdentifier(tokens[1])
+	return modifier == "TEMP" || modifier == "TEMPORARY"
+}
+
+func isRestorableSQLitePragma(tokens []lexer.Token) bool {
+	if len(tokens) < 2 {
+		return true
+	}
+	return normalizedIdentifier(tokens[1]) == "FOREIGN_KEYS"
+}
+
+func significantTokens(stmt string, opts lexer.Options) []lexer.Token {
+	lex := lexer.NewLexerWithOptions(stmt, opts)
+	var tokens []lexer.Token
+	for {
+		token := lex.NextToken()
+		switch token.Type {
+		case lexer.TokenWhitespace, lexer.TokenComment, lexer.TokenSemicolon:
+			continue
+		case lexer.TokenEOF:
+			return tokens
+		default:
+			tokens = append(tokens, token)
+		}
+	}
+}
+
+func containsIdentifier(tokens []lexer.Token, value string) bool {
+	for _, token := range tokens {
+		if normalizedIdentifier(token) == value {
+			return true
+		}
+	}
+	return false
+}
+
+func containsQualifiedIdentifier(tokens []lexer.Token, value string) bool {
+	for index := range len(tokens) - 1 {
+		if normalizedIdentifier(tokens[index]) == strings.ToUpper(value) &&
+			tokens[index+1].MatchOperatorValue(".") {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedIdentifier(token lexer.Token) string {
+	value := token.Value
+	switch token.Type {
+	case lexer.TokenIdentifier:
+	case lexer.TokenString:
+	default:
+		return ""
+	}
+	value = strings.TrimPrefix(value, "`")
+	value = strings.TrimSuffix(value, "`")
+	value = strings.TrimPrefix(value, `"`)
+	value = strings.TrimSuffix(value, `"`)
+	value = strings.TrimPrefix(value, "'")
+	value = strings.TrimSuffix(value, "'")
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	value = strings.ReplaceAll(value, "``", "`")
+	value = strings.ReplaceAll(value, `""`, `"`)
+	value = strings.ReplaceAll(value, "''", "'")
+	value = strings.ReplaceAll(value, "]]", "]")
+	return strings.ToUpper(value)
+}
+
+func mutatesSQLiteRealm(first string) bool {
+	switch first {
+	case "ALTER", "CREATE", "DELETE", "DROP", "INSERT", "PRAGMA", "REINDEX",
+		"REPLACE", "UPDATE", "VACUUM":
+		return true
+	default:
+		return false
+	}
+}
+
+func unsafeReplayStatement(dialect, operation string) error {
+	return fmt.Errorf(
+		"%s migration replay rejects %s because its effects cannot be confined to the disposable database realm",
+		dialect,
+		operation,
+	)
+}

--- a/internal/devclean/guard_clickhouse.go
+++ b/internal/devclean/guard_clickhouse.go
@@ -1,0 +1,261 @@
+package devclean
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+func validateClickHouseReplayStatement(database string, tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	if containsClickHouseKeywordSequence(tokens, "PARALLEL", "WITH") {
+		return unsafeReplayStatement(platform.ClickHouse, "PARALLEL WITH")
+	}
+	if err := rejectClickHouseGlobalMutation(tokens); err != nil {
+		return err
+	}
+	if err := validateClickHouseReplayStatementBase(database, tokens); err != nil {
+		return err
+	}
+	if err := validateClickHouseInsertTarget(database, tokens); err != nil {
+		return err
+	}
+	return validateClickHouseSecondaryTargets(database, tokens)
+}
+
+func rejectClickHouseGlobalMutation(tokens []lexer.Token) error {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "GRANT", "REVOKE":
+		return unsafeReplayStatement(platform.ClickHouse, first+" RBAC change")
+	case "ATTACH", "DETACH", "UNDROP", "BACKUP", "RESTORE":
+		return unsafeReplayStatement(platform.ClickHouse, first)
+	case "SET":
+		if clickHouseKeywordSequenceAt(tokens, 1, "ROLE") ||
+			clickHouseKeywordSequenceAt(tokens, 1, "DEFAULT", "ROLE") {
+			return unsafeReplayStatement(platform.ClickHouse, "role change")
+		}
+	case "TRUNCATE":
+		if clickHouseKeywordSequenceAt(tokens, 1, "DATABASE") ||
+			clickHouseKeywordSequenceAt(tokens, 1, "ALL") ||
+			clickHouseKeywordSequenceAt(tokens, 1, "TABLES") {
+			return unsafeReplayStatement(platform.ClickHouse, "database-wide TRUNCATE")
+		}
+	}
+	return nil
+}
+
+func validateClickHouseInsertTarget(database string, tokens []lexer.Token) error {
+	insertIndex := clickHouseInsertIndex(tokens)
+	if insertIndex == mutationTargetNotFound {
+		return nil
+	}
+	intoIndex := findClickHouseKeyword(tokens, "INTO", insertIndex+1)
+	if intoIndex == mutationTargetNotFound {
+		return nil
+	}
+
+	targetIndex := intoIndex + 1
+	if clickHouseKeywordSequenceAt(tokens, targetIndex, "TABLE") {
+		targetIndex++
+	}
+	if clickHouseKeywordSequenceAt(tokens, targetIndex, "FUNCTION") {
+		return unsafeReplayStatement(platform.ClickHouse, "table-function write")
+	}
+	target, _ := qualifiedIdentifierAt(tokens, targetIndex)
+	return rejectClickHouseCrossDatabaseTarget(database, target)
+}
+
+func clickHouseInsertIndex(tokens []lexer.Token) int {
+	if clickHouseKeywordSequenceAt(tokens, 0, "INSERT") {
+		return 0
+	}
+	if !clickHouseKeywordSequenceAt(tokens, 0, "WITH") {
+		return mutationTargetNotFound
+	}
+	return findTopLevelClickHouseKeyword(tokens, "INSERT", 1)
+}
+
+func validateClickHouseSecondaryTargets(database string, tokens []lexer.Token) error {
+	switch normalizedIdentifier(tokens[0]) {
+	case "RENAME":
+		return validateClickHouseRenameTargets(database, tokens)
+	case "EXCHANGE":
+		return validateClickHouseExchangeTargets(database, tokens)
+	case "ALTER":
+		return validateClickHouseMovePartitionTarget(database, tokens)
+	case "CREATE":
+		return validateClickHouseViewTarget(database, tokens)
+	default:
+		return nil
+	}
+}
+
+func validateClickHouseRenameTargets(database string, tokens []lexer.Token) error {
+	index := 1
+	if clickHouseKeywordSequenceAt(tokens, index, "TABLE") ||
+		clickHouseKeywordSequenceAt(tokens, index, "DICTIONARY") {
+		index++
+	}
+	for index < len(tokens) {
+		source, next := qualifiedIdentifierAt(tokens, index)
+		if err := rejectClickHouseCrossDatabaseTarget(database, source); err != nil {
+			return err
+		}
+		if !clickHouseKeywordSequenceAt(tokens, next, "TO") {
+			return nil
+		}
+		destination, next := qualifiedIdentifierAt(tokens, next+1)
+		if err := rejectClickHouseCrossDatabaseTarget(database, destination); err != nil {
+			return err
+		}
+		index = next
+		if index >= len(tokens) || !tokens[index].MatchOperatorValue(",") {
+			return nil
+		}
+		index++
+	}
+	return nil
+}
+
+func validateClickHouseExchangeTargets(database string, tokens []lexer.Token) error {
+	index := 1
+	if clickHouseKeywordSequenceAt(tokens, index, "TABLES") ||
+		clickHouseKeywordSequenceAt(tokens, index, "DICTIONARIES") {
+		index++
+	}
+	for index < len(tokens) {
+		left, next := qualifiedIdentifierAt(tokens, index)
+		if err := rejectClickHouseCrossDatabaseTarget(database, left); err != nil {
+			return err
+		}
+		if !clickHouseKeywordSequenceAt(tokens, next, "AND") {
+			return nil
+		}
+		right, next := qualifiedIdentifierAt(tokens, next+1)
+		if err := rejectClickHouseCrossDatabaseTarget(database, right); err != nil {
+			return err
+		}
+		index = next
+		if index >= len(tokens) || !tokens[index].MatchOperatorValue(",") {
+			return nil
+		}
+		index++
+	}
+	return nil
+}
+
+func validateClickHouseMovePartitionTarget(database string, tokens []lexer.Token) error {
+	for index := 1; index+2 < len(tokens); index++ {
+		if !clickHouseKeywordSequenceAt(tokens, index, "TO", "TABLE") {
+			continue
+		}
+		target, _ := qualifiedIdentifierAt(tokens, index+2)
+		if err := rejectClickHouseCrossDatabaseTarget(database, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateClickHouseViewTarget(database string, tokens []lexer.Token) error {
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound ||
+		!isClickHouseTargetViewKind(normalizedIdentifier(tokens[kindIndex])) {
+		return nil
+	}
+
+	nameIndex := objectNameIndex(tokens, kindIndex)
+	_, searchStart := qualifiedIdentifierAt(tokens, nameIndex)
+	asIndex := findClickHouseKeyword(tokens, "AS", searchStart)
+	searchEnd := len(tokens)
+	if asIndex != mutationTargetNotFound {
+		searchEnd = asIndex
+	}
+	for index := searchStart; index < searchEnd; index++ {
+		if !clickHouseKeywordSequenceAt(tokens, index, "TO") {
+			continue
+		}
+		target, _ := qualifiedIdentifierAt(tokens, index+1)
+		return rejectClickHouseCrossDatabaseTarget(database, target)
+	}
+	return nil
+}
+
+func isClickHouseTargetViewKind(kind string) bool {
+	switch kind {
+	case "LIVE", "MATERIALIZED", "WINDOW":
+		return true
+	default:
+		return false
+	}
+}
+
+func rejectClickHouseCrossDatabaseTarget(database string, target []string) error {
+	if len(target) < 2 {
+		return nil
+	}
+	if strings.TrimSpace(database) == "" {
+		return unsafeReplayStatement(platform.ClickHouse, "qualified target without a configured database")
+	}
+	if target[0] == database {
+		return nil
+	}
+	return unsafeReplayStatement(
+		platform.ClickHouse,
+		fmt.Sprintf("cross-database target %q", strings.Join(target, ".")),
+	)
+}
+
+func containsClickHouseKeywordSequence(tokens []lexer.Token, values ...string) bool {
+	for index := range tokens {
+		if clickHouseKeywordSequenceAt(tokens, index, values...) {
+			return true
+		}
+	}
+	return false
+}
+
+func clickHouseKeywordSequenceAt(tokens []lexer.Token, index int, values ...string) bool {
+	if index < 0 || index+len(values) > len(tokens) {
+		return false
+	}
+	for offset, value := range values {
+		token := tokens[index+offset]
+		if token.Type != lexer.TokenIdentifier || normalizedIdentifier(token) != value {
+			return false
+		}
+	}
+	return true
+}
+
+func findClickHouseKeyword(tokens []lexer.Token, value string, start int) int {
+	for index := max(start, 0); index < len(tokens); index++ {
+		if clickHouseKeywordSequenceAt(tokens, index, value) {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}
+
+func findTopLevelClickHouseKeyword(tokens []lexer.Token, value string, start int) int {
+	depth := 0
+	for index := max(start, 0); index < len(tokens); index++ {
+		if tokens[index].MatchOperatorValue("(") {
+			depth++
+			continue
+		}
+		if tokens[index].MatchOperatorValue(")") {
+			depth = max(depth-1, 0)
+			continue
+		}
+		if depth == 0 && clickHouseKeywordSequenceAt(tokens, index, value) {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}

--- a/internal/devclean/guard_clickhouse.go
+++ b/internal/devclean/guard_clickhouse.go
@@ -18,6 +18,12 @@ func validateClickHouseReplayStatement(database string, tokens []lexer.Token) er
 	if err := rejectClickHouseGlobalMutation(tokens); err != nil {
 		return err
 	}
+	if source := unsafeClickHouseDictionarySource(tokens); source != "" {
+		return unsafeReplayStatement(platform.ClickHouse, source+" dictionary source")
+	}
+	if engine := unconfinedClickHouseEngine(tokens); engine != "" {
+		return unsafeReplayStatement(platform.ClickHouse, engine+" table engine")
+	}
 	if err := validateClickHouseReplayStatementBase(database, tokens); err != nil {
 		return err
 	}
@@ -27,6 +33,97 @@ func validateClickHouseReplayStatement(database string, tokens []lexer.Token) er
 	return validateClickHouseSecondaryTargets(database, tokens)
 }
 
+func unconfinedClickHouseEngine(tokens []lexer.Token) string {
+	if normalizedIdentifier(tokens[0]) != "CREATE" || usesTemporaryObject(tokens) {
+		return ""
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound ||
+		!isClickHouseTableLikeKind(normalizedIdentifier(tokens[kindIndex])) {
+		return ""
+	}
+	engine, assigned := topLevelValueAfterKeyword(
+		tokens,
+		"ENGINE",
+		objectNameIndex(tokens, kindIndex)+1,
+	)
+	if !assigned || engine == "" {
+		if normalizedIdentifier(tokens[kindIndex]) == "TABLE" ||
+			normalizedIdentifier(tokens[kindIndex]) == "MATERIALIZED" &&
+				!containsIdentifier(tokens, "TO") {
+			return "implicit/default"
+		}
+		return ""
+	}
+	if isConfinedClickHouseEngine(engine) {
+		return ""
+	}
+	return engine
+}
+
+func unsafeClickHouseDictionarySource(tokens []lexer.Token) string {
+	if !isDDLAction(tokens) {
+		return ""
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound ||
+		normalizedIdentifier(tokens[kindIndex]) != "DICTIONARY" {
+		return ""
+	}
+	source := clickHouseDictionarySource(tokens, objectNameIndex(tokens, kindIndex)+1)
+	if source == "" || source == "NULL" {
+		return ""
+	}
+	return source
+}
+
+func clickHouseDictionarySource(tokens []lexer.Token, start int) string {
+	depth := 0
+	for index := max(start, 0); index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+		case depth == 0 && normalizedIdentifier(tokens[index]) == "SOURCE":
+			index++
+			if index < len(tokens) && tokens[index].MatchOperatorValue("(") {
+				index++
+			}
+			if index < len(tokens) {
+				return normalizedIdentifier(tokens[index])
+			}
+			return ""
+		}
+	}
+	return ""
+}
+
+func isClickHouseTableLikeKind(kind string) bool {
+	switch kind {
+	case "LIVE", "MATERIALIZED", "TABLE", "WINDOW":
+		return true
+	default:
+		return false
+	}
+}
+
+// Only engines whose data is owned by the disposable local table are allowed.
+// Unknown engines fail closed because their storage and replication scope is
+// not structurally provable from the statement.
+func isConfinedClickHouseEngine(engine string) bool {
+	switch engine {
+	case "AGGREGATINGMERGETREE", "COLLAPSINGMERGETREE", "EMBEDDEDROCKSDB",
+		"GENERATERANDOM", "GRAPHITEMERGETREE", "JOIN", "LOG", "MEMORY", "MERGE",
+		"MERGETREE", "NULL", "REPLACINGMERGETREE", "SET", "STRIPELOG",
+		"SUMMINGMERGETREE", "TINYLOG",
+		"VERSIONEDCOLLAPSINGMERGETREE":
+		return true
+	default:
+		return false
+	}
+}
+
 func rejectClickHouseGlobalMutation(tokens []lexer.Token) error {
 	first := normalizedIdentifier(tokens[0])
 	switch first {
@@ -34,6 +131,10 @@ func rejectClickHouseGlobalMutation(tokens []lexer.Token) error {
 		return unsafeReplayStatement(platform.ClickHouse, first+" RBAC change")
 	case "ATTACH", "DETACH", "UNDROP", "BACKUP", "RESTORE":
 		return unsafeReplayStatement(platform.ClickHouse, first)
+	case "ALTER":
+		if clickHouseHasPersistentSnapshotAction(tokens) {
+			return unsafeReplayStatement(platform.ClickHouse, "persistent table snapshot")
+		}
 	case "SET":
 		if clickHouseKeywordSequenceAt(tokens, 1, "ROLE") ||
 			clickHouseKeywordSequenceAt(tokens, 1, "DEFAULT", "ROLE") {
@@ -47,6 +148,35 @@ func rejectClickHouseGlobalMutation(tokens []lexer.Token) error {
 		}
 	}
 	return nil
+}
+
+func clickHouseHasPersistentSnapshotAction(tokens []lexer.Token) bool {
+	if !clickHouseKeywordSequenceAt(tokens, 0, "ALTER", "TABLE") {
+		return false
+	}
+	_, index := qualifiedIdentifierAt(tokens, 2)
+	if clickHouseKeywordSequenceAt(tokens, index, "ON", "CLUSTER") {
+		_, index = qualifiedIdentifierAt(tokens, index+2)
+	}
+	expectAction := true
+	depth := 0
+	for ; index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+		case depth == 0 && tokens[index].MatchOperatorValue(","):
+			expectAction = true
+		case depth == 0 && expectAction:
+			if clickHouseKeywordSequenceAt(tokens, index, "FREEZE") ||
+				clickHouseKeywordSequenceAt(tokens, index, "UNFREEZE") {
+				return true
+			}
+			expectAction = false
+		}
+	}
+	return false
 }
 
 func validateClickHouseInsertTarget(database string, tokens []lexer.Token) error {

--- a/internal/devclean/guard_clickhouse_internal_test.go
+++ b/internal/devclean/guard_clickhouse_internal_test.go
@@ -1,0 +1,376 @@
+package devclean
+
+// White-box testing required: the ClickHouse validator is an internal replay
+// boundary whose token-level decisions are not exposed through the public API.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+func TestValidateClickHouseReplayStatement_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "empty statement",
+			statement: "",
+		},
+		{
+			name:      "local table",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = MergeTree ORDER BY id",
+		},
+		{
+			name:      "unqualified local insert",
+			statement: "INSERT INTO events VALUES (1)",
+		},
+		{
+			name:      "local insert",
+			statement: "INSERT INTO ptah_dev.events VALUES (1)",
+		},
+		{
+			name:      "local insert with table keyword",
+			statement: "INSERT INTO TABLE ptah_dev.events VALUES (1)",
+		},
+		{
+			name:      "local insert with cte",
+			statement: "WITH 1 AS id INSERT INTO ptah_dev.events SELECT id",
+		},
+		{
+			name: "local insert with nested cte",
+			statement: "WITH (SELECT number FROM numbers(1)) AS ids " +
+				"INSERT INTO TABLE ptah_dev.events SELECT * FROM ids",
+		},
+		{
+			name:      "quoted table named function",
+			statement: "INSERT INTO TABLE ptah_dev.`FUNCTION` VALUES (1)",
+		},
+		{
+			name:      "local update",
+			statement: "UPDATE ptah_dev.events SET id = 2 WHERE id = 1",
+		},
+		{
+			name:      "local delete",
+			statement: "DELETE FROM ptah_dev.events WHERE id = 1",
+		},
+		{
+			name:      "local truncate table",
+			statement: "TRUNCATE TABLE ptah_dev.events",
+		},
+		{
+			name:      "local rename table",
+			statement: "RENAME TABLE ptah_dev.events TO ptah_dev.events_archive",
+		},
+		{
+			name:      "local rename shorthand",
+			statement: "RENAME ptah_dev.events TO ptah_dev.events_archive",
+		},
+		{
+			name:      "local rename dictionary",
+			statement: "RENAME DICTIONARY ptah_dev.geo TO ptah_dev.geo_archive",
+		},
+		{
+			name:      "local exchange",
+			statement: "EXCHANGE TABLES ptah_dev.events AND ptah_dev.events_archive",
+		},
+		{
+			name:      "local dictionary exchange",
+			statement: "EXCHANGE DICTIONARIES ptah_dev.geo AND ptah_dev.geo_archive",
+		},
+		{
+			name:      "local partition move",
+			statement: "ALTER TABLE ptah_dev.events MOVE PARTITION 202607 TO TABLE ptah_dev.events_archive",
+		},
+		{
+			name: "local materialized view target",
+			statement: "CREATE MATERIALIZED VIEW ptah_dev.events_mv TO ptah_dev.events_archive " +
+				"AS SELECT * FROM ptah_dev.events",
+		},
+		{
+			name: "local materialized view without target",
+			statement: "CREATE MATERIALIZED VIEW ptah_dev.events_mv ENGINE = Memory " +
+				"AS SELECT * FROM ptah_dev.events",
+		},
+		{
+			name:      "ordinary session setting",
+			statement: "SET max_threads = 4",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestValidateClickHouseReplayStatement_GlobalFailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name: "parallel statement",
+			statement: "SELECT 1 PARALLEL WITH " +
+				"CREATE FUNCTION leaked AS x -> x",
+			wantErr: `clickhouse migration replay rejects PARALLEL WITH .*`,
+		},
+		{
+			name:      "grant",
+			statement: "GRANT ALL ON *.* TO migration_user WITH GRANT OPTION",
+			wantErr:   `clickhouse migration replay rejects GRANT RBAC change .*`,
+		},
+		{
+			name:      "revoke",
+			statement: "REVOKE ALL ON *.* FROM migration_user",
+			wantErr:   `clickhouse migration replay rejects REVOKE RBAC change .*`,
+		},
+		{
+			name:      "set default role",
+			statement: "SET DEFAULT ROLE ALL TO migration_user",
+			wantErr:   `clickhouse migration replay rejects role change .*`,
+		},
+		{
+			name:      "set active role",
+			statement: "SET ROLE ALL",
+			wantErr:   `clickhouse migration replay rejects role change .*`,
+		},
+		{
+			name:      "function",
+			statement: "CREATE FUNCTION normalize AS x -> lower(x)",
+			wantErr:   `clickhouse migration replay rejects CREATE FUNCTION .*`,
+		},
+		{
+			name:      "user",
+			statement: "CREATE USER migration_user",
+			wantErr:   `clickhouse migration replay rejects CREATE USER .*`,
+		},
+		{
+			name:      "named collection",
+			statement: "ALTER NAMED COLLECTION remote SET url = 'https://example.test'",
+			wantErr:   `clickhouse migration replay rejects ALTER NAMED .*`,
+		},
+		{
+			name:      "workload",
+			statement: "DROP WORKLOAD analytics",
+			wantErr:   `clickhouse migration replay rejects DROP WORKLOAD .*`,
+		},
+		{
+			name:      "resource",
+			statement: "CREATE RESOURCE io_read (READ DISK disk1 FOR INTERVAL 1 SECOND MAX 10M)",
+			wantErr:   `clickhouse migration replay rejects CREATE RESOURCE .*`,
+		},
+		{
+			name:      "on cluster",
+			statement: "CREATE TABLE ptah_dev.events ON CLUSTER production (id UInt64) ENGINE = Memory",
+			wantErr:   `clickhouse migration replay rejects ON CLUSTER .*`,
+		},
+		{
+			name:      "temporary view",
+			statement: "CREATE TEMPORARY VIEW events_view AS SELECT 1",
+			wantErr:   `clickhouse migration replay rejects TEMP object .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestValidateClickHouseReplayStatement_LifecycleFailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "attach table",
+			statement: "ATTACH TABLE ptah_dev.events",
+			wantErr:   `clickhouse migration replay rejects ATTACH .*`,
+		},
+		{
+			name:      "detach table",
+			statement: "DETACH TABLE ptah_dev.events PERMANENTLY",
+			wantErr:   `clickhouse migration replay rejects DETACH .*`,
+		},
+		{
+			name:      "undrop table",
+			statement: "UNDROP TABLE ptah_dev.events",
+			wantErr:   `clickhouse migration replay rejects UNDROP .*`,
+		},
+		{
+			name:      "backup",
+			statement: "BACKUP DATABASE ptah_dev TO Disk('backups', 'ptah.zip')",
+			wantErr:   `clickhouse migration replay rejects BACKUP .*`,
+		},
+		{
+			name:      "restore",
+			statement: "RESTORE DATABASE production FROM Disk('backups', 'production.zip')",
+			wantErr:   `clickhouse migration replay rejects RESTORE .*`,
+		},
+		{
+			name:      "truncate database",
+			statement: "TRUNCATE DATABASE production",
+			wantErr:   `clickhouse migration replay rejects database-wide TRUNCATE .*`,
+		},
+		{
+			name:      "truncate all tables",
+			statement: "TRUNCATE ALL TABLES FROM production",
+			wantErr:   `clickhouse migration replay rejects database-wide TRUNCATE .*`,
+		},
+		{
+			name:      "truncate tables",
+			statement: "TRUNCATE TABLES FROM production",
+			wantErr:   `clickhouse migration replay rejects database-wide TRUNCATE .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestValidateClickHouseReplayStatement_CrossDatabaseFailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "rename destination",
+			statement: "RENAME TABLE ptah_dev.events TO production.events",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name:      "rename shorthand destination",
+			statement: "RENAME ptah_dev.events TO production.events",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name:      "rename dictionary destination",
+			statement: "RENAME DICTIONARY ptah_dev.geo TO production.geo",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.geo" .*`,
+		},
+		{
+			name: "rename second source",
+			statement: "RENAME TABLE ptah_dev.events TO ptah_dev.events_archive, " +
+				"production.audit TO ptah_dev.audit",
+			wantErr: `clickhouse migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name:      "exchange right target",
+			statement: "EXCHANGE TABLES ptah_dev.events AND production.events",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name: "exchange second pair",
+			statement: "EXCHANGE TABLES ptah_dev.events AND ptah_dev.events_archive, " +
+				"production.audit AND ptah_dev.audit",
+			wantErr: `clickhouse migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name: "move partition destination",
+			statement: "ALTER TABLE ptah_dev.events MOVE PARTITION 202607 " +
+				"TO TABLE production.events",
+			wantErr: `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name: "materialized view destination",
+			statement: "CREATE MATERIALIZED VIEW ptah_dev.events_mv TO production.events " +
+				"AS SELECT * FROM ptah_dev.events",
+			wantErr: `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name: "window view destination",
+			statement: "CREATE WINDOW VIEW ptah_dev.events_window TO `production`.`events` " +
+				"AS SELECT * FROM ptah_dev.events GROUP BY tumble(now(), INTERVAL 1 MINUTE)",
+			wantErr: `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestValidateClickHouseReplayStatement_InsertFailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "insert with table keyword",
+			statement: "INSERT INTO TABLE production.audit VALUES (1)",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name:      "insert with cte",
+			statement: "WITH 1 AS id INSERT INTO production.audit SELECT id",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name:      "table function",
+			statement: "INSERT INTO FUNCTION remote('prod:9000', production.audit) VALUES (1)",
+			wantErr:   `clickhouse migration replay rejects table-function write .*`,
+		},
+		{
+			name:      "table function with table keyword",
+			statement: "INSERT INTO TABLE FUNCTION file('audit.tsv', TSV, 'id UInt64') VALUES (1)",
+			wantErr:   `clickhouse migration replay rejects table-function write .*`,
+		},
+		{
+			name: "table function with cte",
+			statement: "WITH 1 AS id INSERT INTO TABLE FUNCTION " +
+				"remote('prod:9000', production.audit) SELECT id",
+			wantErr: `clickhouse migration replay rejects table-function write .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func clickHouseReplayTokens(statement string) []lexer.Token {
+	return significantTokens(statement, replayLexerOptions(platform.ClickHouse))
+}

--- a/internal/devclean/guard_clickhouse_internal_test.go
+++ b/internal/devclean/guard_clickhouse_internal_test.go
@@ -27,6 +27,10 @@ func TestValidateClickHouseReplayStatement_HappyPath(t *testing.T) {
 			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = MergeTree ORDER BY id",
 		},
 		{
+			name:      "embedded local engine",
+			statement: "CREATE TABLE ptah_dev.kv (id UInt64, value String) ENGINE = EmbeddedRocksDB PRIMARY KEY id",
+		},
+		{
 			name:      "unqualified local insert",
 			statement: "INSERT INTO events VALUES (1)",
 		},
@@ -100,6 +104,26 @@ func TestValidateClickHouseReplayStatement_HappyPath(t *testing.T) {
 		{
 			name:      "ordinary session setting",
 			statement: "SET max_threads = 4",
+		},
+		{
+			name:      "column named freeze",
+			statement: "ALTER TABLE ptah_dev.events ADD COLUMN freeze String",
+		},
+		{
+			name:      "quoted column named freeze",
+			statement: "ALTER TABLE ptah_dev.events ADD COLUMN `FREEZE` String",
+		},
+		{
+			name:      "freeze in string literal",
+			statement: "ALTER TABLE ptah_dev.events ADD COLUMN note String DEFAULT 'FREEZE'",
+		},
+		{
+			name:      "rename column to unfreeze",
+			statement: "ALTER TABLE ptah_dev.events RENAME COLUMN id TO unfreeze",
+		},
+		{
+			name:      "nested freeze column",
+			statement: "ALTER TABLE ptah_dev.events ADD COLUMN metadata Tuple(freeze String)",
 		},
 	}
 
@@ -181,6 +205,81 @@ func TestValidateClickHouseReplayStatement_GlobalFailurePath(t *testing.T) {
 			name:      "temporary view",
 			statement: "CREATE TEMPORARY VIEW events_view AS SELECT 1",
 			wantErr:   `clickhouse migration replay rejects TEMP object .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateClickHouseReplayStatement(
+				"ptah_dev",
+				clickHouseReplayTokens(test.statement),
+			)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestValidateClickHouseReplayStatement_EngineFailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "distributed engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = Distributed(cluster, production, events)",
+			wantErr:   `clickhouse migration replay rejects DISTRIBUTED table engine .*`,
+		},
+		{
+			name:      "implicit default table engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64)",
+			wantErr:   `clickhouse migration replay rejects implicit/default table engine .*`,
+		},
+		{
+			name:      "table as select with implicit default engine",
+			statement: "CREATE TABLE ptah_dev.copied AS SELECT engine FROM ptah_dev.source",
+			wantErr:   `clickhouse migration replay rejects implicit/default table engine .*`,
+		},
+		{
+			name:      "external dictionary source",
+			statement: "CREATE DICTIONARY ptah_dev.remote (id UInt64) PRIMARY KEY id SOURCE(HTTP(URL 'https://example.test/data')) LAYOUT(FLAT())",
+			wantErr:   `clickhouse migration replay rejects HTTP dictionary source .*`,
+		},
+		{
+			name:      "executable dictionary source",
+			statement: "CREATE DICTIONARY ptah_dev.remote (id UInt64) PRIMARY KEY id SOURCE(EXECUTABLE(COMMAND 'touch /tmp/escaped')) LAYOUT(FLAT())",
+			wantErr:   `clickhouse migration replay rejects EXECUTABLE dictionary source .*`,
+		},
+		{
+			name:      "persistent table snapshot",
+			statement: "ALTER TABLE ptah_dev.events FREEZE",
+			wantErr:   `clickhouse migration replay rejects persistent table snapshot .*`,
+		},
+		{
+			name:      "persistent table unfreeze",
+			statement: "ALTER TABLE ptah_dev.events UNFREEZE WITH NAME 'snapshot'",
+			wantErr:   `clickhouse migration replay rejects persistent table snapshot .*`,
+		},
+		{
+			name:      "persistent snapshot as second alter action",
+			statement: "ALTER TABLE ptah_dev.events ADD COLUMN note String, FREEZE",
+			wantErr:   `clickhouse migration replay rejects persistent table snapshot .*`,
+		},
+		{
+			name:      "remote PostgreSQL engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = PostgreSQL('host:5432', 'db', 'events', 'user', 'pass')",
+			wantErr:   `clickhouse migration replay rejects POSTGRESQL table engine .*`,
+		},
+		{
+			name:      "replicated engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = ReplicatedMergeTree('/tables/events', '{replica}') ORDER BY id",
+			wantErr:   `clickhouse migration replay rejects REPLICATEDMERGETREE table engine .*`,
+		},
+		{
+			name:      "unknown engine fails closed",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = FutureRemoteEngine('endpoint')",
+			wantErr:   `clickhouse migration replay rejects FUTUREREMOTEENGINE table engine .*`,
 		},
 	}
 

--- a/internal/devclean/guard_dialects.go
+++ b/internal/devclean/guard_dialects.go
@@ -55,28 +55,13 @@ func validateMySQLReplayStatement(dialect, database string, tokens []lexer.Token
 	if len(tokens) == 0 {
 		return nil
 	}
+	tokens = leadingCTEExecutableTokens(tokens)
 	first := normalizedIdentifier(tokens[0])
-	switch first {
-	case "USE", "INSTALL", "UNINSTALL", "FLUSH", "RESET":
-		return unsafeReplayStatement(dialect, first)
-	case "SET":
-		if tokenSequenceAt(tokens, 1, "GLOBAL") ||
-			tokenSequenceAt(tokens, 1, "PERSIST") ||
-			tokenSequenceAt(tokens, 1, "PERSIST_ONLY") {
-			return unsafeReplayStatement(dialect, "global or persistent SET")
-		}
-	case "GRANT", "REVOKE":
-		return unsafeReplayStatement(dialect, "privilege or role mutation")
-	case "PREPARE", "EXECUTE", "DEALLOCATE":
-		return unsafeReplayStatement(dialect, "prepared statement")
-	case "LOCK":
-		if tokenSequenceAt(tokens, 1, "TABLES") {
-			return unsafeReplayStatement(dialect, "LOCK TABLES")
-		}
-	case "ALTER":
-		if tokenSequenceAt(tokens, 1, "INSTANCE") {
-			return unsafeReplayStatement(dialect, "ALTER INSTANCE")
-		}
+	if err := rejectMySQLExecutableObjects(dialect, first, tokens); err != nil {
+		return err
+	}
+	if operation := unsafeMySQLReplayOperation(tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
 	}
 	if isGlobalMySQLDDL(tokens) {
 		return unsafeReplayStatement(dialect, describeStatementObject(tokens))
@@ -92,15 +77,168 @@ func validateMySQLReplayStatement(dialect, database string, tokens []lexer.Token
 	if err := rejectMySQLRenameDestinations(dialect, database, tokens); err != nil {
 		return err
 	}
-	return rejectCrossDatabaseTargets(dialect, database, tokens)
+	return rejectMySQLCrossDatabaseTargets(dialect, database, tokens)
+}
+
+func unsafeMySQLReplayOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "USE", "INSTALL", "UNINSTALL", "FLUSH", "RESET":
+		return first
+	case "CALL":
+		return "CALL sublanguage"
+	case "LOAD":
+		if tokenSequenceAt(tokens, 1, "DATA") || tokenSequenceAt(tokens, 1, "XML") {
+			return first + " external data operation"
+		}
+	case "SET":
+		if tokenSequenceAt(tokens, 1, "GLOBAL") ||
+			tokenSequenceAt(tokens, 1, "PERSIST") ||
+			tokenSequenceAt(tokens, 1, "PERSIST_ONLY") {
+			return "global or persistent SET"
+		}
+	case "GRANT", "REVOKE":
+		return "privilege or role mutation"
+	case "PREPARE", "EXECUTE", "DEALLOCATE":
+		return "prepared statement"
+	case "LOCK":
+		if tokenSequenceAt(tokens, 1, "TABLES") {
+			return "LOCK TABLES"
+		}
+	case "ALTER":
+		if tokenSequenceAt(tokens, 1, "INSTANCE") {
+			return "ALTER INSTANCE"
+		}
+	}
+	return ""
+}
+
+func rejectMySQLExecutableObjects(dialect, first string, tokens []lexer.Token) error {
+	if definesMySQLExecutableBody(tokens) {
+		return unsafeReplayStatement(dialect, first+" executable stored body")
+	}
+	if engine := unconfinedMySQLStorageEngine(tokens); engine != "" {
+		return unsafeReplayStatement(dialect, engine+" storage engine")
+	}
+	return nil
 }
 
 func rejectMySQLRenameDestinations(dialect, database string, tokens []lexer.Token) error {
-	if tokenSequenceAt(tokens, 0, "RENAME", "TABLE") ||
-		tokenSequenceAt(tokens, 0, "ALTER", "TABLE") && containsIdentifier(tokens, "RENAME") {
+	if tokenSequenceAt(tokens, 0, "ALTER", "TABLE") && containsIdentifier(tokens, "RENAME") {
 		return rejectTargetsAfterKeyword(dialect, database, tokens, "TO")
 	}
 	return nil
+}
+
+func rejectMySQLCrossDatabaseTargets(dialect, database string, tokens []lexer.Token) error {
+	if strings.TrimSpace(database) == "" {
+		return unsafeReplayStatement(dialect, "qualified target without a configured database")
+	}
+	for _, target := range mysqlMutationTargets(tokens) {
+		if len(target) < 2 || target[0] == database {
+			continue
+		}
+		return unsafeReplayStatement(
+			dialect,
+			fmt.Sprintf("cross-database target %q", strings.Join(target, ".")),
+		)
+	}
+	return nil
+}
+
+func mysqlMutationTargets(tokens []lexer.Token) [][]string {
+	switch normalizedIdentifier(tokens[0]) {
+	case "RENAME":
+		return mysqlRenameTargets(tokens)
+	case "DROP":
+		kindIndex := statementObjectKindIndex(tokens)
+		if kindIndex != mutationTargetNotFound &&
+			(normalizedIdentifier(tokens[kindIndex]) == "TABLE" ||
+				normalizedIdentifier(tokens[kindIndex]) == "VIEW") {
+			return commaSeparatedQualifiedTargets(
+				tokens,
+				objectNameIndex(tokens, kindIndex),
+				"",
+			)
+		}
+	case "UPDATE":
+		return mysqlUpdateTargets(tokens)
+	}
+	return mutationTargets(tokens)
+}
+
+func mysqlUpdateTargets(tokens []lexer.Token) [][]string {
+	index := 1
+	for index < len(tokens) {
+		switch normalizedIdentifier(tokens[index]) {
+		case "LOW_PRIORITY", "IGNORE", "ONLY":
+			index++
+		default:
+			return mysqlTableReferenceTargets(tokens, index)
+		}
+	}
+	return nil
+}
+
+func mysqlTableReferenceTargets(tokens []lexer.Token, start int) [][]string {
+	var targets [][]string
+	expectTarget := true
+	depth := 0
+	for index := start; index < len(tokens); index++ {
+		if depth == 0 && tokens[index].MatchIdentifierValue("SET") {
+			return targets
+		}
+		if expectTarget {
+			target, next := qualifiedIdentifierAt(tokens, index)
+			if len(target) == 0 {
+				continue
+			}
+			targets = append(targets, target)
+			expectTarget = false
+			index = next - 1
+			continue
+		}
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+		case depth == 0 && tokens[index].MatchOperatorValue(","):
+			expectTarget = true
+		case depth == 0 && (tokens[index].MatchIdentifierValue("JOIN") ||
+			tokens[index].MatchIdentifierValue("STRAIGHT_JOIN")):
+			expectTarget = true
+		}
+	}
+	return targets
+}
+
+func mysqlRenameTargets(tokens []lexer.Token) [][]string {
+	index := 1
+	if index < len(tokens) && tokens[index].MatchIdentifierValue("TABLE") {
+		index++
+	}
+	var targets [][]string
+	for index < len(tokens) {
+		source, next := qualifiedIdentifierAt(tokens, index)
+		if len(source) == 0 {
+			return targets
+		}
+		targets = append(targets, source)
+		if next >= len(tokens) || !tokens[next].MatchIdentifierValue("TO") {
+			return targets
+		}
+		destination, next := qualifiedIdentifierAt(tokens, next+1)
+		if len(destination) == 0 {
+			return targets
+		}
+		targets = append(targets, destination)
+		if next >= len(tokens) || !tokens[next].MatchOperatorValue(",") {
+			return targets
+		}
+		index = next + 1
+	}
+	return targets
 }
 
 func validateSQLServerReplayStatementBase(tokens []lexer.Token) error {
@@ -122,7 +260,7 @@ func validateSQLServerReplayStatementBase(tokens []lexer.Token) error {
 	if usesTemporaryObject(tokens) || containsTemporaryTarget(tokens) {
 		return unsafeReplayStatement(platform.SQLServer, "temporary object")
 	}
-	for _, target := range mutationTargets(tokens) {
+	for _, target := range sqlServerMutationTargets(tokens) {
 		if len(target) >= 3 {
 			return unsafeReplayStatement(
 				platform.SQLServer,
@@ -177,7 +315,8 @@ func isGlobalPostgresDDL(tokens []lexer.Token) bool {
 	case "EVENT":
 		return tokenSequenceAt(tokens, kindIndex, "EVENT", "TRIGGER")
 	case "FOREIGN":
-		return !tokenSequenceAt(tokens, kindIndex, "FOREIGN", "TABLE")
+		return normalizedIdentifier(tokens[0]) != "DROP" ||
+			!tokenSequenceAt(tokens, kindIndex, "FOREIGN", "TABLE")
 	case "SERVER":
 		return true
 	case "TEXT":
@@ -221,6 +360,8 @@ func isGlobalSQLServerDDL(tokens []lexer.Token) bool {
 		return true
 	case "SERVER":
 		return true
+	case "SYNONYM":
+		return normalizedIdentifier(tokens[0]) != "DROP"
 	case "EXTERNAL":
 		return !tokenSequenceAt(tokens, kindIndex, "EXTERNAL", "TABLE")
 	default:
@@ -286,6 +427,106 @@ func usesTemporaryObject(tokens []lexer.Token) bool {
 		containsIdentifier(tokens[1:kindIndex], "TEMPORARY")
 }
 
+func definesMySQLExecutableBody(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	first := normalizedIdentifier(tokens[0])
+	if first != "CREATE" && first != "ALTER" {
+		return false
+	}
+	index := 1
+	if first == "CREATE" && tokenSequenceAt(tokens, index, "OR", "REPLACE") {
+		index += 2
+	}
+	if first == "CREATE" && tokenSequenceAt(tokens, index, "DEFINER") {
+		index = skipMySQLDefiner(tokens, index+1)
+	}
+	if tokenSequenceAt(tokens, index, "AGGREGATE", "FUNCTION") {
+		return true
+	}
+	return tokenSequenceAt(tokens, index, "EVENT") ||
+		tokenSequenceAt(tokens, index, "FUNCTION") ||
+		tokenSequenceAt(tokens, index, "PROCEDURE") ||
+		tokenSequenceAt(tokens, index, "TRIGGER")
+}
+
+func skipMySQLDefiner(tokens []lexer.Token, index int) int {
+	if index < len(tokens) && tokens[index].MatchOperatorValue("=") {
+		index++
+	}
+	if index >= len(tokens) {
+		return index
+	}
+	index++
+	if index < len(tokens) && tokens[index].MatchOperatorValue("(") {
+		index = skipBalancedParentheses(tokens, index)
+	}
+	if index < len(tokens) && tokens[index].MatchOperatorValue("@") {
+		index += min(2, len(tokens)-index)
+	}
+	return index
+}
+
+func skipBalancedParentheses(tokens []lexer.Token, index int) int {
+	depth := 0
+	for index < len(tokens) {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return index + 1
+			}
+		}
+		index++
+	}
+	return index
+}
+
+func unconfinedMySQLStorageEngine(tokens []lexer.Token) string {
+	if !isDDLAction(tokens) {
+		return ""
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound ||
+		normalizedIdentifier(tokens[kindIndex]) != "TABLE" {
+		return ""
+	}
+	engine, _ := topLevelValueAfterKeyword(tokens, "ENGINE", objectNameIndex(tokens, kindIndex)+1)
+	if engine == "FEDERATED" || engine == "CONNECT" {
+		return engine
+	}
+	return ""
+}
+
+func topLevelValueAfterKeyword(tokens []lexer.Token, keyword string, start int) (string, bool) {
+	depth := 0
+	for index := max(start, 0); index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+		case depth == 0 && normalizedIdentifier(tokens[index]) == "SELECT":
+			return "", false
+		case depth == 0 && normalizedIdentifier(tokens[index]) == keyword:
+			index++
+			assigned := false
+			if index < len(tokens) && tokens[index].MatchOperatorValue("=") {
+				index++
+				assigned = true
+			}
+			if index < len(tokens) {
+				return normalizedIdentifier(tokens[index]), assigned
+			}
+			return "", assigned
+		}
+	}
+	return "", false
+}
+
 func containsTemporaryTarget(tokens []lexer.Token) bool {
 	for _, target := range mutationTargets(tokens) {
 		for _, part := range target {
@@ -311,6 +552,107 @@ func rejectCrossDatabaseTargets(dialect, database string, tokens []lexer.Token) 
 		)
 	}
 	return nil
+}
+
+func sqlServerMutationTargets(tokens []lexer.Token) [][]string {
+	if normalizedIdentifier(tokens[0]) != "DROP" {
+		return mutationTargets(tokens)
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return mutationTargets(tokens)
+	}
+	if normalizedIdentifier(tokens[kindIndex]) == "INDEX" {
+		return sqlServerDropIndexTargets(tokens, kindIndex+1)
+	}
+	return commaSeparatedQualifiedTargets(
+		tokens,
+		objectNameIndex(tokens, kindIndex),
+		"",
+	)
+}
+
+func sqlServerDropIndexTargets(tokens []lexer.Token, start int) [][]string {
+	var targets [][]string
+	for index := start; index < len(tokens); index++ {
+		if !tokens[index].MatchIdentifierValue("ON") {
+			continue
+		}
+		target, next := qualifiedIdentifierAt(tokens, index+1)
+		if len(target) != 0 {
+			targets = append(targets, target)
+		}
+		index = next - 1
+	}
+	return targets
+}
+
+func commaSeparatedQualifiedTargets(
+	tokens []lexer.Token,
+	start int,
+	stopKeyword string,
+) [][]string {
+	var targets [][]string
+	expectTarget := true
+	depth := 0
+	for index := start; index < len(tokens); index++ {
+		if depth == 0 && stopKeyword != "" &&
+			tokens[index].MatchIdentifierValue(stopKeyword) {
+			return targets
+		}
+		if expectTarget {
+			target, next := qualifiedIdentifierAt(tokens, index)
+			if len(target) == 0 {
+				continue
+			}
+			targets = append(targets, target)
+			expectTarget = false
+			index = next - 1
+			continue
+		}
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+		case depth == 0 && tokens[index].MatchOperatorValue(","):
+			expectTarget = true
+		}
+	}
+	return targets
+}
+
+func leadingCTEExecutableTokens(tokens []lexer.Token) []lexer.Token {
+	if len(tokens) == 0 || !tokens[0].MatchIdentifierValue("WITH") {
+		return tokens
+	}
+	depth := 0
+	closedDefinition := false
+	for index := 1; index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth = max(depth-1, 0)
+			closedDefinition = depth == 0
+		case depth == 0 && closedDefinition && isDMLStatementToken(tokens[index]):
+			return tokens[index:]
+		}
+	}
+	return tokens
+}
+
+func isDMLStatementToken(token lexer.Token) bool {
+	switch {
+	case token.MatchIdentifierValue("SELECT"),
+		token.MatchIdentifierValue("INSERT"),
+		token.MatchIdentifierValue("UPDATE"),
+		token.MatchIdentifierValue("DELETE"),
+		token.MatchIdentifierValue("MERGE"):
+		return true
+	default:
+		return false
+	}
 }
 
 func rejectTargetsAfterKeyword(
@@ -415,7 +757,7 @@ func isStatementObjectKind(value string) bool {
 		"LOGIN", "LOGFILE", "MATERIALIZED", "NAMED", "NONCLUSTERED",
 		"PROCEDURE", "PUBLICATION", "QUOTA", "RESOURCE", "ROLE", "ROW",
 		"SCHEMA", "SEQUENCE", "SERVER", "SETTINGS", "SPATIAL", "SUBSCRIPTION",
-		"TABLE", "TABLESPACE", "TEXT", "TRANSFORM", "TRIGGER", "TYPE",
+		"SYNONYM", "TABLE", "TABLESPACE", "TEXT", "TRANSFORM", "TRIGGER", "TYPE",
 		"UNDO", "UNIQUE", "USER", "VIEW", "WINDOW", "WORKLOAD":
 		return true
 	default:

--- a/internal/devclean/guard_dialects.go
+++ b/internal/devclean/guard_dialects.go
@@ -1,0 +1,590 @@
+package devclean
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+const mutationTargetNotFound = -1
+
+func replayLexerOptions(dialect string) lexer.Options {
+	options := lexer.Options{StandardStrings: true}
+	switch dialect {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		options.BackslashEscapes = true
+	case platform.SQLServer:
+		options.BracketIdentifiers = true
+		options.DisableHashComments = true
+	case platform.SQLite:
+		options.BracketIdentifiers = true
+	}
+	return options
+}
+
+func validatePostgresReplayStatementBase(dialect string, tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	first := normalizedIdentifier(tokens[0])
+	if first == "COPY" && isExternalPostgresCopy(tokens) {
+		return unsafeReplayStatement(dialect, "external COPY")
+	}
+	if first == "ALTER" && tokenSequenceAt(tokens, 1, "SYSTEM") {
+		return unsafeReplayStatement(dialect, "ALTER SYSTEM")
+	}
+	if first == "SET" && tokenSequenceAt(tokens, 1, "ROLE") {
+		return unsafeReplayStatement(dialect, "SET ROLE")
+	}
+	if first == "SET" && tokenSequenceAt(tokens, 1, "SESSION", "AUTHORIZATION") {
+		return unsafeReplayStatement(dialect, "SET SESSION AUTHORIZATION")
+	}
+	if isGlobalPostgresDDL(tokens) {
+		return unsafeReplayStatement(dialect, describeStatementObject(tokens))
+	}
+	if usesTemporaryObject(tokens) {
+		return unsafeReplayStatement(dialect, "TEMP object")
+	}
+	return nil
+}
+
+func validateMySQLReplayStatement(dialect, database string, tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "USE", "INSTALL", "UNINSTALL", "FLUSH", "RESET":
+		return unsafeReplayStatement(dialect, first)
+	case "SET":
+		if tokenSequenceAt(tokens, 1, "GLOBAL") ||
+			tokenSequenceAt(tokens, 1, "PERSIST") ||
+			tokenSequenceAt(tokens, 1, "PERSIST_ONLY") {
+			return unsafeReplayStatement(dialect, "global or persistent SET")
+		}
+	case "GRANT", "REVOKE":
+		return unsafeReplayStatement(dialect, "privilege or role mutation")
+	case "PREPARE", "EXECUTE", "DEALLOCATE":
+		return unsafeReplayStatement(dialect, "prepared statement")
+	case "LOCK":
+		if tokenSequenceAt(tokens, 1, "TABLES") {
+			return unsafeReplayStatement(dialect, "LOCK TABLES")
+		}
+	case "ALTER":
+		if tokenSequenceAt(tokens, 1, "INSTANCE") {
+			return unsafeReplayStatement(dialect, "ALTER INSTANCE")
+		}
+	}
+	if isGlobalMySQLDDL(tokens) {
+		return unsafeReplayStatement(dialect, describeStatementObject(tokens))
+	}
+	if usesTemporaryObject(tokens) {
+		return unsafeReplayStatement(dialect, "TEMP object")
+	}
+	if containsIdentifier(tokens, "OUTFILE") ||
+		containsIdentifier(tokens, "DUMPFILE") ||
+		containsIdentifier(tokens, "SONAME") {
+		return unsafeReplayStatement(dialect, "external file operation")
+	}
+	if err := rejectMySQLRenameDestinations(dialect, database, tokens); err != nil {
+		return err
+	}
+	return rejectCrossDatabaseTargets(dialect, database, tokens)
+}
+
+func rejectMySQLRenameDestinations(dialect, database string, tokens []lexer.Token) error {
+	if tokenSequenceAt(tokens, 0, "RENAME", "TABLE") ||
+		tokenSequenceAt(tokens, 0, "ALTER", "TABLE") && containsIdentifier(tokens, "RENAME") {
+		return rejectTargetsAfterKeyword(dialect, database, tokens, "TO")
+	}
+	return nil
+}
+
+func validateSQLServerReplayStatementBase(tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	first := normalizedIdentifier(tokens[0])
+	if first == "USE" {
+		return unsafeReplayStatement(platform.SQLServer, first)
+	}
+	if first == "EXEC" || first == "EXECUTE" {
+		if containsIdentifier(tokens, "AT") {
+			return unsafeReplayStatement(platform.SQLServer, "remote EXECUTE")
+		}
+	}
+	if isGlobalSQLServerDDL(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, describeStatementObject(tokens))
+	}
+	if usesTemporaryObject(tokens) || containsTemporaryTarget(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, "temporary object")
+	}
+	for _, target := range mutationTargets(tokens) {
+		if len(target) >= 3 {
+			return unsafeReplayStatement(
+				platform.SQLServer,
+				fmt.Sprintf("cross-database target %q", strings.Join(target, ".")),
+			)
+		}
+	}
+	return nil
+}
+
+func validateClickHouseReplayStatementBase(database string, tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "USE", "SYSTEM":
+		return unsafeReplayStatement(platform.ClickHouse, first)
+	case "SET":
+		if tokenSequenceAt(tokens, 1, "GLOBAL") {
+			return unsafeReplayStatement(platform.ClickHouse, "global SET")
+		}
+	}
+	if containsTokenSequence(tokens, "ON", "CLUSTER") {
+		return unsafeReplayStatement(platform.ClickHouse, "ON CLUSTER")
+	}
+	if isGlobalClickHouseDDL(tokens) {
+		return unsafeReplayStatement(platform.ClickHouse, describeStatementObject(tokens))
+	}
+	if usesTemporaryObject(tokens) {
+		return unsafeReplayStatement(platform.ClickHouse, "TEMP object")
+	}
+	if containsIdentifier(tokens, "INTO") &&
+		(containsIdentifier(tokens, "OUTFILE") || containsIdentifier(tokens, "DUMPFILE")) {
+		return unsafeReplayStatement(platform.ClickHouse, "external file operation")
+	}
+	return rejectCrossDatabaseTargets(platform.ClickHouse, database, tokens)
+}
+
+func isGlobalPostgresDDL(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	switch normalizedIdentifier(tokens[kindIndex]) {
+	case "DATABASE", "ROLE", "USER", "TABLESPACE", "SUBSCRIPTION",
+		"PUBLICATION", "CAST", "LANGUAGE", "TRANSFORM":
+		return true
+	case "EVENT":
+		return tokenSequenceAt(tokens, kindIndex, "EVENT", "TRIGGER")
+	case "FOREIGN":
+		return !tokenSequenceAt(tokens, kindIndex, "FOREIGN", "TABLE")
+	case "SERVER":
+		return true
+	case "TEXT":
+		return tokenSequenceAt(tokens, kindIndex, "TEXT", "SEARCH")
+	case "ACCESS":
+		return tokenSequenceAt(tokens, kindIndex, "ACCESS", "METHOD")
+	default:
+		return false
+	}
+}
+
+func isGlobalMySQLDDL(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	switch normalizedIdentifier(tokens[kindIndex]) {
+	case "DATABASE", "SCHEMA", "USER", "ROLE", "SERVER", "TABLESPACE",
+		"UNDO", "LOGFILE", "RESOURCE":
+		return true
+	case "SPATIAL":
+		return tokenSequenceAt(tokens, kindIndex, "SPATIAL", "REFERENCE", "SYSTEM")
+	default:
+		return false
+	}
+}
+
+func isGlobalSQLServerDDL(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	switch normalizedIdentifier(tokens[kindIndex]) {
+	case "DATABASE", "LOGIN", "CREDENTIAL", "ENDPOINT", "AVAILABILITY":
+		return true
+	case "SERVER":
+		return true
+	case "EXTERNAL":
+		return !tokenSequenceAt(tokens, kindIndex, "EXTERNAL", "TABLE")
+	default:
+		return false
+	}
+}
+
+func isGlobalClickHouseDDL(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	switch normalizedIdentifier(tokens[kindIndex]) {
+	case "DATABASE", "USER", "ROLE", "QUOTA", "FUNCTION", "WORKLOAD", "RESOURCE":
+		return true
+	case "ROW":
+		return tokenSequenceAt(tokens, kindIndex, "ROW", "POLICY")
+	case "SETTINGS":
+		return tokenSequenceAt(tokens, kindIndex, "SETTINGS", "PROFILE")
+	case "NAMED":
+		return tokenSequenceAt(tokens, kindIndex, "NAMED", "COLLECTION")
+	default:
+		return false
+	}
+}
+
+func isExternalPostgresCopy(tokens []lexer.Token) bool {
+	if containsIdentifier(tokens, "PROGRAM") {
+		return true
+	}
+	toIndex := findIdentifier(tokens, "TO", 1)
+	if toIndex == mutationTargetNotFound || toIndex+1 >= len(tokens) {
+		return false
+	}
+	return tokens[toIndex+1].Type == lexer.TokenString &&
+		normalizedIdentifier(tokens[toIndex+1]) != "STDOUT"
+}
+
+func isDDLAction(tokens []lexer.Token) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	switch normalizedIdentifier(tokens[0]) {
+	case "CREATE", "ALTER", "DROP", "RENAME":
+		return true
+	default:
+		return false
+	}
+}
+
+func usesTemporaryObject(tokens []lexer.Token) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	return containsIdentifier(tokens[1:kindIndex], "TEMP") ||
+		containsIdentifier(tokens[1:kindIndex], "TEMPORARY")
+}
+
+func containsTemporaryTarget(tokens []lexer.Token) bool {
+	for _, target := range mutationTargets(tokens) {
+		for _, part := range target {
+			if strings.HasPrefix(part, "#") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rejectCrossDatabaseTargets(dialect, database string, tokens []lexer.Token) error {
+	if strings.TrimSpace(database) == "" {
+		return unsafeReplayStatement(dialect, "qualified target without a configured database")
+	}
+	for _, target := range mutationTargets(tokens) {
+		if len(target) < 2 || target[0] == database {
+			continue
+		}
+		return unsafeReplayStatement(
+			dialect,
+			fmt.Sprintf("cross-database target %q", strings.Join(target, ".")),
+		)
+	}
+	return nil
+}
+
+func rejectTargetsAfterKeyword(
+	dialect,
+	database string,
+	tokens []lexer.Token,
+	keyword string,
+) error {
+	for index := 1; index < len(tokens); index++ {
+		if normalizedIdentifier(tokens[index]) != keyword {
+			continue
+		}
+		target, _ := qualifiedIdentifierAt(tokens, skipNameModifiers(tokens, index+1))
+		if len(target) < 2 || target[0] == database {
+			continue
+		}
+		return unsafeReplayStatement(
+			dialect,
+			fmt.Sprintf("cross-database target %q", strings.Join(target, ".")),
+		)
+	}
+	return nil
+}
+
+func mutationTargets(tokens []lexer.Token) [][]string {
+	if len(tokens) == 0 {
+		return nil
+	}
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "INSERT", "REPLACE", "MERGE":
+		return targetAfterKeywordWithModifiers(tokens, "INTO", 1, "TABLE")
+	case "UPDATE":
+		return targetAfterModifiers(tokens, 1, "LOW_PRIORITY", "IGNORE", "ONLY")
+	case "DELETE":
+		return targetAfterKeyword(tokens, "FROM", 1)
+	case "TRUNCATE":
+		return targetAfterModifiers(tokens, 1, "TABLE", "ONLY")
+	case "OPTIMIZE", "ANALYZE", "REPAIR":
+		return targetAfterKeyword(tokens, "TABLE", 1)
+	case "CREATE", "ALTER", "DROP":
+		return ddlMutationTargets(tokens)
+	case "RENAME":
+		return targetAfterKeyword(tokens, "TABLE", 1)
+	case "COMMENT":
+		return targetAfterKeyword(tokens, "ON", 1)
+	default:
+		return nil
+	}
+}
+
+func targetAfterKeywordWithModifiers(
+	tokens []lexer.Token,
+	keyword string,
+	start int,
+	modifiers ...string,
+) [][]string {
+	index := findIdentifier(tokens, keyword, start)
+	if index == mutationTargetNotFound {
+		return nil
+	}
+	return targetAfterModifiers(tokens, skipNameModifiers(tokens, index+1), modifiers...)
+}
+
+func ddlMutationTargets(tokens []lexer.Token) [][]string {
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return nil
+	}
+	kind := normalizedIdentifier(tokens[kindIndex])
+	if kind == "INDEX" || tokenSequenceAt(tokens, kindIndex, "UNIQUE", "INDEX") ||
+		tokenSequenceAt(tokens, kindIndex, "FULLTEXT", "INDEX") ||
+		tokenSequenceAt(tokens, kindIndex, "SPATIAL", "INDEX") ||
+		tokenSequenceAt(tokens, kindIndex, "CLUSTERED", "INDEX") ||
+		tokenSequenceAt(tokens, kindIndex, "NONCLUSTERED", "INDEX") {
+		return targetAfterKeyword(tokens, "ON", kindIndex+1)
+	}
+
+	nameIndex := objectNameIndex(tokens, kindIndex)
+	targets := qualifiedTargetAt(tokens, nameIndex)
+	if kind == "TRIGGER" {
+		targets = append(targets, targetAfterKeyword(tokens, "ON", nameIndex)...)
+	}
+	return targets
+}
+
+func statementObjectKindIndex(tokens []lexer.Token) int {
+	limit := min(len(tokens), 16)
+	for index := 1; index < limit; index++ {
+		if isStatementObjectKind(normalizedIdentifier(tokens[index])) {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}
+
+func isStatementObjectKind(value string) bool {
+	switch value {
+	case "ACCESS", "AVAILABILITY", "CAST", "CREDENTIAL", "DATABASE",
+		"DICTIONARY", "DOMAIN", "ENDPOINT", "EVENT", "EXTERNAL", "EXTENSION",
+		"FOREIGN", "FUNCTION", "FULLTEXT", "INDEX", "LANGUAGE", "LIVE",
+		"LOGIN", "LOGFILE", "MATERIALIZED", "NAMED", "NONCLUSTERED",
+		"PROCEDURE", "PUBLICATION", "QUOTA", "RESOURCE", "ROLE", "ROW",
+		"SCHEMA", "SEQUENCE", "SERVER", "SETTINGS", "SPATIAL", "SUBSCRIPTION",
+		"TABLE", "TABLESPACE", "TEXT", "TRANSFORM", "TRIGGER", "TYPE",
+		"UNDO", "UNIQUE", "USER", "VIEW", "WINDOW", "WORKLOAD":
+		return true
+	default:
+		return false
+	}
+}
+
+func objectNameIndex(tokens []lexer.Token, kindIndex int) int {
+	index := kindIndex + 1
+	switch normalizedIdentifier(tokens[kindIndex]) {
+	case "ACCESS":
+		index = skipSequence(tokens, index, "METHOD")
+	case "AVAILABILITY":
+		index = skipSequence(tokens, index, "GROUP")
+	case "EVENT":
+		index = skipSequence(tokens, index, "TRIGGER")
+	case "EXTERNAL":
+		index = skipSequence(tokens, index, "TABLE")
+	case "FOREIGN":
+		index = skipSequence(tokens, index, "TABLE", "DATA", "WRAPPER")
+	case "FULLTEXT", "UNIQUE", "CLUSTERED", "NONCLUSTERED":
+		index = skipSequence(tokens, index, "INDEX")
+	case "LIVE", "MATERIALIZED", "WINDOW":
+		index = skipSequence(tokens, index, "VIEW")
+	case "LOGFILE":
+		index = skipSequence(tokens, index, "GROUP")
+	case "NAMED":
+		index = skipSequence(tokens, index, "COLLECTION")
+	case "RESOURCE":
+		index = skipSequence(tokens, index, "GROUP")
+	case "ROW":
+		index = skipSequence(tokens, index, "POLICY")
+	case "SERVER":
+		index = skipSequence(tokens, index, "ROLE", "AUDIT")
+	case "SETTINGS":
+		index = skipSequence(tokens, index, "PROFILE")
+	case "SPATIAL":
+		if tokenSequenceAt(tokens, index, "INDEX") {
+			index++
+		} else {
+			index = skipSequence(tokens, index, "REFERENCE", "SYSTEM")
+		}
+	case "TEXT":
+		index = skipSequence(tokens, index, "SEARCH")
+	case "UNDO":
+		index = skipSequence(tokens, index, "TABLESPACE")
+	}
+	return skipNameModifiers(tokens, index)
+}
+
+func skipSequence(tokens []lexer.Token, index int, alternatives ...string) int {
+	for index < len(tokens) && containsString(alternatives, normalizedIdentifier(tokens[index])) {
+		index++
+	}
+	return index
+}
+
+func skipNameModifiers(tokens []lexer.Token, index int) int {
+	for index < len(tokens) {
+		switch normalizedIdentifier(tokens[index]) {
+		case "IF", "NOT", "EXISTS", "ONLY", "CONCURRENTLY":
+			index++
+		default:
+			return index
+		}
+	}
+	return index
+}
+
+func targetAfterKeyword(tokens []lexer.Token, keyword string, start int) [][]string {
+	index := findIdentifier(tokens, keyword, start)
+	if index == mutationTargetNotFound {
+		return nil
+	}
+	return qualifiedTargetAt(tokens, skipNameModifiers(tokens, index+1))
+}
+
+func targetAfterModifiers(tokens []lexer.Token, index int, modifiers ...string) [][]string {
+	for index < len(tokens) && containsString(modifiers, normalizedIdentifier(tokens[index])) {
+		index++
+	}
+	return qualifiedTargetAt(tokens, index)
+}
+
+func qualifiedTargetAt(tokens []lexer.Token, index int) [][]string {
+	parts, _ := qualifiedIdentifierAt(tokens, index)
+	if len(parts) == 0 {
+		return nil
+	}
+	return [][]string{parts}
+}
+
+func qualifiedIdentifierAt(tokens []lexer.Token, index int) ([]string, int) {
+	if index < 0 || index >= len(tokens) || normalizedIdentifier(tokens[index]) == "" {
+		return nil, index
+	}
+	parts := []string{identifierValue(tokens[index])}
+	index++
+	for index+1 < len(tokens) && tokens[index].MatchOperatorValue(".") {
+		value := identifierValue(tokens[index+1])
+		if value == "" {
+			break
+		}
+		parts = append(parts, value)
+		index += 2
+	}
+	return parts, index
+}
+
+func identifierValue(token lexer.Token) string {
+	value := token.Value
+	switch token.Type {
+	case lexer.TokenIdentifier, lexer.TokenString:
+	default:
+		return ""
+	}
+	value = strings.TrimPrefix(value, "`")
+	value = strings.TrimSuffix(value, "`")
+	value = strings.TrimPrefix(value, `"`)
+	value = strings.TrimSuffix(value, `"`)
+	value = strings.TrimPrefix(value, "'")
+	value = strings.TrimSuffix(value, "'")
+	value = strings.TrimPrefix(value, "[")
+	value = strings.TrimSuffix(value, "]")
+	value = strings.ReplaceAll(value, "``", "`")
+	value = strings.ReplaceAll(value, `""`, `"`)
+	value = strings.ReplaceAll(value, "''", "'")
+	value = strings.ReplaceAll(value, "]]", "]")
+	return value
+}
+
+func tokenSequenceAt(tokens []lexer.Token, index int, values ...string) bool {
+	if index < 0 || index+len(values) > len(tokens) {
+		return false
+	}
+	for offset, value := range values {
+		if normalizedIdentifier(tokens[index+offset]) != value {
+			return false
+		}
+	}
+	return true
+}
+
+func containsTokenSequence(tokens []lexer.Token, values ...string) bool {
+	for index := range len(tokens) {
+		if tokenSequenceAt(tokens, index, values...) {
+			return true
+		}
+	}
+	return false
+}
+
+func findIdentifier(tokens []lexer.Token, value string, start int) int {
+	for index := max(start, 0); index < len(tokens); index++ {
+		if normalizedIdentifier(tokens[index]) == value {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}
+
+func containsString(values []string, target string) bool {
+	return slices.Contains(values, target)
+}
+
+func describeStatementObject(tokens []lexer.Token) string {
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return normalizedIdentifier(tokens[0])
+	}
+	return normalizedIdentifier(tokens[0]) + " " + normalizedIdentifier(tokens[kindIndex])
+}

--- a/internal/devclean/guard_dialects_test.go
+++ b/internal/devclean/guard_dialects_test.go
@@ -29,20 +29,12 @@ func TestReplayGuardPostgresFamily_HappyPath(t *testing.T) {
 			statement: `CREATE EXTENSION IF NOT EXISTS citext`,
 		},
 		{
-			name:      "ordinary function",
-			statement: `CREATE FUNCTION public.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
-		},
-		{
-			name:      "session search path",
-			statement: `SET search_path TO archive, public`,
-		},
-		{
-			name:      "anonymous data migration",
-			statement: `DO $$ BEGIN UPDATE public.users SET active = true; END $$`,
-		},
-		{
 			name:      "copy into managed table",
 			statement: `COPY public.users FROM STDIN`,
+		},
+		{
+			name:      "drop local foreign table",
+			statement: `DROP FOREIGN TABLE app.remote_users`,
 		},
 	}
 
@@ -105,6 +97,126 @@ func TestReplayGuardPostgresFamily_FailurePath(t *testing.T) {
 			statement: `SET SESSION AUTHORIZATION admin`,
 			wantErr:   `postgres migration replay rejects SET SESSION AUTHORIZATION .*`,
 		},
+		{
+			name:      "function definition",
+			statement: `CREATE FUNCTION public.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
+			wantErr:   `postgres migration replay rejects CREATE routine definition .*`,
+		},
+		{
+			name:      "anonymous block",
+			statement: `DO $$ BEGIN UPDATE public.users SET active = true; END $$`,
+			wantErr:   `postgres migration replay rejects DO sublanguage .*`,
+		},
+		{
+			name:      "procedure call",
+			statement: `CALL public.refresh_materialized_data()`,
+			wantErr:   `postgres migration replay rejects CALL sublanguage .*`,
+		},
+		{
+			name:      "search path mutation",
+			statement: `SET search_path TO pg_catalog`,
+			wantErr:   `postgres migration replay rejects SET search_path .*`,
+		},
+		{
+			name:      "foreign table",
+			statement: `CREATE FOREIGN TABLE public.remote_users (id bigint) SERVER upstream`,
+			wantErr:   `postgres migration replay rejects CREATE FOREIGN .*`,
+		},
+		{
+			name:      "foreign schema import",
+			statement: `IMPORT FOREIGN SCHEMA remote FROM SERVER upstream INTO public`,
+			wantErr:   `postgres migration replay rejects IMPORT FOREIGN SCHEMA .*`,
+		},
+		{
+			name:      "alter foreign table",
+			statement: `ALTER FOREIGN TABLE app.remote_users ADD COLUMN label text`,
+			wantErr:   `postgres migration replay rejects ALTER FOREIGN .*`,
+		},
+		{
+			name:      "cte select into protected namespace",
+			statement: `WITH source AS (SELECT 1 AS id) SELECT id INTO pg_catalog.ptah_leak FROM source`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second aggregate in protected namespace",
+			statement: `DROP AGGREGATE app.keep(integer), pg_catalog.ptah_leak(integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second collation in protected namespace",
+			statement: `DROP COLLATION app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second conversion in protected namespace",
+			statement: `DROP CONVERSION app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second domain in protected namespace",
+			statement: `DROP DOMAIN app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second foreign table in protected namespace",
+			statement: `DROP FOREIGN TABLE app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second function in protected namespace",
+			statement: `DROP FUNCTION app.keep(integer), pg_catalog.ptah_leak(integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second index in protected namespace",
+			statement: `DROP INDEX app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second materialized view in protected namespace",
+			statement: `DROP MATERIALIZED VIEW app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second operator in protected namespace",
+			statement: `DROP OPERATOR app.=== (integer, integer), pg_catalog.=== (integer, integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second procedure in protected namespace",
+			statement: `DROP PROCEDURE app.keep(integer), pg_catalog.ptah_leak(integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second routine in protected namespace",
+			statement: `DROP ROUTINE app.keep(integer), pg_catalog.ptah_leak(integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second schema in protected namespace",
+			statement: `DROP SCHEMA app, pg_catalog`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second sequence in protected namespace",
+			statement: `DROP SEQUENCE app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second statistics in protected namespace",
+			statement: `DROP STATISTICS app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second type in protected namespace",
+			statement: `DROP TYPE app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second view in protected namespace",
+			statement: `DROP VIEW app.keep, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
 	}
 
 	for _, test := range tests {
@@ -138,16 +250,45 @@ func TestReplayGuardMySQLFamily_HappyPath(t *testing.T) {
 			statement: "UPDATE `ptah_dev`.`users` SET `active` = 1",
 		},
 		{
-			name:      "database event",
-			statement: "CREATE EVENT `ptah_dev`.`prune_users` ON SCHEDULE EVERY 1 DAY DO DELETE FROM users",
-		},
-		{
 			name:      "insert with table modifier",
 			statement: "INSERT INTO TABLE `ptah_dev`.`users` VALUES (1)",
 		},
 		{
 			name:      "table named temp",
 			statement: "CREATE TABLE `ptah_dev`.`temp` (id bigint)",
+		},
+		{
+			name:      "ordinary block comment",
+			statement: "/* migration metadata */ CREATE TABLE comments (id bigint)",
+		},
+		{
+			name:      "executable marker in string",
+			statement: "INSERT INTO comments VALUES ('/*! CREATE USER escaped */')",
+		},
+		{
+			name:      "definer view without stored body",
+			statement: "CREATE DEFINER = CURRENT_USER VIEW active_users AS SELECT id FROM users WHERE active = 1",
+		},
+		{
+			name:      "table as select with engine column",
+			statement: "CREATE TABLE copied_users AS SELECT engine FROM users",
+		},
+		{
+			name:      "local update with leading cte",
+			statement: "WITH source AS (SELECT 1 AS id) UPDATE ptah_dev.users SET active = 1",
+		},
+		{
+			name:      "local multi-table update",
+			statement: "UPDATE ptah_dev.users AS users, ptah_dev.audit AS audit SET users.active = 1",
+		},
+		{
+			name:      "local multi-table drop",
+			statement: "DROP TABLE ptah_dev.users, ptah_dev.audit",
+		},
+		{
+			name: "local multi-table rename",
+			statement: "RENAME TABLE ptah_dev.users TO ptah_dev.users_old, " +
+				"ptah_dev.audit TO ptah_dev.audit_old",
 		},
 	}
 
@@ -226,6 +367,21 @@ func TestReplayGuardMySQLFamily_FailurePath(t *testing.T) {
 			wantErr:   `mysql migration replay rejects prepared statement .*`,
 		},
 		{
+			name:      "stored procedure call",
+			statement: "CALL production.rotate_users()",
+			wantErr:   `mysql migration replay rejects CALL sublanguage .*`,
+		},
+		{
+			name:      "load data",
+			statement: "LOAD DATA INFILE '/tmp/users.csv' INTO TABLE production.users",
+			wantErr:   `mysql migration replay rejects LOAD external data operation .*`,
+		},
+		{
+			name:      "load XML",
+			statement: "LOAD XML INFILE '/tmp/users.xml' INTO TABLE production.users",
+			wantErr:   `mysql migration replay rejects LOAD external data operation .*`,
+		},
+		{
 			name:      "lock tables",
 			statement: "LOCK TABLES users WRITE",
 			wantErr:   `mysql migration replay rejects LOCK TABLES .*`,
@@ -263,7 +419,117 @@ func TestReplayGuardMySQLFamily_FailurePath(t *testing.T) {
 		{
 			name:      "native function",
 			statement: "CREATE FUNCTION sys_exec RETURNS integer SONAME 'lib_mysqludf_sys.so'",
-			wantErr:   `mysql migration replay rejects external file operation .*`,
+			wantErr:   `mysql migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "event body",
+			statement: "CREATE EVENT `ptah_dev`.`prune_users` ON SCHEDULE EVERY 1 DAY DO DELETE FROM users",
+			wantErr:   `mysql migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "trigger body",
+			statement: "CREATE TRIGGER users_audit AFTER INSERT ON users FOR EACH ROW INSERT INTO audit VALUES (NEW.id)",
+			wantErr:   `mysql migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "procedure body",
+			statement: "CREATE PROCEDURE rebuild_users() BEGIN DELETE FROM users; END",
+			wantErr:   `mysql migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "definer trigger body",
+			statement: "CREATE DEFINER = 'migration'@'localhost' TRIGGER users_audit AFTER INSERT ON users FOR EACH ROW INSERT INTO audit VALUES (NEW.id)",
+			wantErr:   `mysql migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "alter event body",
+			statement: "ALTER EVENT prune_users DO DELETE FROM users",
+			wantErr:   `mysql migration replay rejects ALTER executable stored body .*`,
+		},
+		{
+			name:      "version executable comment",
+			statement: "/*!50000 CREATE USER escaped */",
+			wantErr:   `mysql migration replay rejects executable comment .*`,
+		},
+		{
+			name:      "federated engine",
+			statement: "CREATE TABLE remote_users (id bigint) ENGINE = FEDERATED CONNECTION = 'mysql://remote/users'",
+			wantErr:   `mysql migration replay rejects FEDERATED storage engine .*`,
+		},
+		{
+			name:      "cross database update with leading cte",
+			statement: "WITH source AS (SELECT 1 AS id) UPDATE production.users SET active = 1",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "second multi-table update target",
+			statement: "UPDATE ptah_dev.users AS users, production.audit AS audit SET users.active = 1",
+			wantErr:   `mysql migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name: "joined multi-table update target",
+			statement: "UPDATE LOW_PRIORITY ptah_dev.users AS users " +
+				"JOIN production.audit AS audit ON audit.id = users.id " +
+				"SET users.active = 1",
+			wantErr: `mysql migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name:      "second drop target",
+			statement: "DROP TABLE ptah_dev.users, production.audit",
+			wantErr:   `mysql migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name: "second rename source",
+			statement: "RENAME TABLE ptah_dev.users TO ptah_dev.users_old, " +
+				"production.audit TO ptah_dev.audit",
+			wantErr: `mysql migration replay rejects cross-database target "production.audit" .*`,
+		},
+		{
+			name: "second rename destination",
+			statement: "RENAME TABLE ptah_dev.users TO ptah_dev.users_old, " +
+				"ptah_dev.audit TO production.audit",
+			wantErr: `mysql migration replay rejects cross-database target "production.audit" .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestReplayGuardMariaDB_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.MariaDB,
+		Schema:  "ptah_dev",
+	})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "MariaDB executable comment",
+			statement: "/*M!100100 CREATE USER escaped */",
+			wantErr:   `mariadb migration replay rejects executable comment .*`,
+		},
+		{
+			name:      "connect engine",
+			statement: "CREATE TABLE remote_users (id bigint) ENGINE CONNECT TABLE_TYPE MYSQL",
+			wantErr:   `mariadb migration replay rejects CONNECT storage engine .*`,
+		},
+		{
+			name:      "cross database update with leading cte",
+			statement: "WITH source AS (SELECT 1 AS id) UPDATE production.users SET active = 1",
+			wantErr:   `mariadb migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "second drop target",
+			statement: "DROP TABLE ptah_dev.users, production.audit",
+			wantErr:   `mariadb migration replay rejects cross-database target "production.audit" .*`,
 		},
 	}
 
@@ -294,8 +560,28 @@ func TestReplayGuardSQLServer_HappyPath(t *testing.T) {
 			statement: "CREATE INDEX [users_email] ON [tenant].[users] ([email])",
 		},
 		{
-			name:      "external table in current database",
-			statement: "CREATE EXTERNAL TABLE [tenant].[events] ([id] bigint) WITH (LOCATION = '/events')",
+			name:      "drop local function",
+			statement: "DROP FUNCTION IF EXISTS [tenant].[answer]",
+		},
+		{
+			name:      "drop local synonym",
+			statement: "DROP SYNONYM IF EXISTS [tenant].[users]",
+		},
+		{
+			name:      "drop local external table",
+			statement: "DROP EXTERNAL TABLE IF EXISTS [tenant].[events]",
+		},
+		{
+			name:      "check identity",
+			statement: "DBCC CHECKIDENT ('tenant.users', RESEED, 0)",
+		},
+		{
+			name:      "check table",
+			statement: "DBCC CHECKTABLE ('tenant.users')",
+		},
+		{
+			name:      "check constraints",
+			statement: "DBCC CHECKCONSTRAINTS ('tenant.users')",
 		},
 	}
 
@@ -348,6 +634,47 @@ func TestReplayGuardSQLServer_FailurePath(t *testing.T) {
 			statement: "EXECUTE ('DROP TABLE users') AT production_server",
 			wantErr:   `sqlserver migration replay rejects remote EXECUTE .*`,
 		},
+		{
+			name:      "external table",
+			statement: "CREATE EXTERNAL TABLE [tenant].[events] ([id] bigint) WITH (LOCATION = '/events')",
+			wantErr:   `sqlserver migration replay rejects CREATE EXTERNAL TABLE .*`,
+		},
+		{
+			name:      "synonym",
+			statement: "CREATE SYNONYM [tenant].[users] FOR [production].[dbo].[users]",
+			wantErr:   `sqlserver migration replay rejects CREATE SYNONYM .*`,
+		},
+		{
+			name:      "trigger body",
+			statement: "CREATE TRIGGER [tenant].[audit] ON [tenant].[users] AFTER INSERT AS SELECT 1",
+			wantErr:   `sqlserver migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "procedure body",
+			statement: "CREATE PROCEDURE [tenant].[rebuild] AS DELETE FROM [tenant].[users]",
+			wantErr:   `sqlserver migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "function body",
+			statement: "CREATE FUNCTION [tenant].[answer]() RETURNS int AS BEGIN RETURN 42 END",
+			wantErr:   `sqlserver migration replay rejects CREATE executable stored body .*`,
+		},
+		{
+			name:      "second multi-object drop target",
+			statement: "DROP TABLE dbo.local_copy, otherdb.dbo.remote_copy",
+			wantErr:   `sqlserver migration replay rejects cross-database target "otherdb.dbo.remote_copy" .*`,
+		},
+		{
+			name: "second drop index target",
+			statement: "DROP INDEX ix_local ON dbo.local_copy, " +
+				"ix_remote ON otherdb.dbo.remote_copy",
+			wantErr: `sqlserver migration replay rejects cross-database target "otherdb.dbo.remote_copy" .*`,
+		},
+		{
+			name:      "other DBCC command",
+			statement: "DBCC CHECKDB",
+			wantErr:   `sqlserver migration replay rejects DBCC server operation .*`,
+		},
 	}
 
 	for _, test := range tests {
@@ -383,6 +710,10 @@ func TestReplayGuardClickHouse_HappyPath(t *testing.T) {
 		{
 			name:      "table named temp",
 			statement: "CREATE TABLE `ptah_dev`.`temp` (id UInt64) ENGINE = Memory",
+		},
+		{
+			name:      "embedded local engine",
+			statement: "CREATE TABLE `ptah_dev`.`kv` (id UInt64, value String) ENGINE = EmbeddedRocksDB PRIMARY KEY id",
 		},
 	}
 
@@ -454,6 +785,46 @@ func TestReplayGuardClickHouse_FailurePath(t *testing.T) {
 			name:      "cross database table",
 			statement: "CREATE TABLE production.events (id UInt64) ENGINE = Memory",
 			wantErr:   `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+		{
+			name:      "implicit default table engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64)",
+			wantErr:   `clickhouse migration replay rejects implicit/default table engine .*`,
+		},
+		{
+			name:      "table as select with implicit default engine",
+			statement: "CREATE TABLE ptah_dev.copied AS SELECT engine FROM ptah_dev.source",
+			wantErr:   `clickhouse migration replay rejects implicit/default table engine .*`,
+		},
+		{
+			name:      "external dictionary source",
+			statement: "CREATE DICTIONARY ptah_dev.remote (id UInt64) PRIMARY KEY id SOURCE(HTTP(URL 'https://example.test/data')) LAYOUT(FLAT())",
+			wantErr:   `clickhouse migration replay rejects HTTP dictionary source .*`,
+		},
+		{
+			name:      "executable dictionary source",
+			statement: "CREATE DICTIONARY ptah_dev.remote (id UInt64) PRIMARY KEY id SOURCE(EXECUTABLE(COMMAND 'touch /tmp/escaped')) LAYOUT(FLAT())",
+			wantErr:   `clickhouse migration replay rejects EXECUTABLE dictionary source .*`,
+		},
+		{
+			name:      "persistent table snapshot",
+			statement: "ALTER TABLE ptah_dev.events FREEZE",
+			wantErr:   `clickhouse migration replay rejects persistent table snapshot .*`,
+		},
+		{
+			name:      "distributed engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = Distributed(cluster, production, events)",
+			wantErr:   `clickhouse migration replay rejects DISTRIBUTED table engine .*`,
+		},
+		{
+			name:      "remote database engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = PostgreSQL('host:5432', 'db', 'events', 'user', 'pass')",
+			wantErr:   `clickhouse migration replay rejects POSTGRESQL table engine .*`,
+		},
+		{
+			name:      "replicated engine",
+			statement: "CREATE TABLE ptah_dev.events (id UInt64) ENGINE = ReplicatedMergeTree('/tables/events', '{replica}') ORDER BY id",
+			wantErr:   `clickhouse migration replay rejects REPLICATEDMERGETREE table engine .*`,
 		},
 	}
 

--- a/internal/devclean/guard_dialects_test.go
+++ b/internal/devclean/guard_dialects_test.go
@@ -1,0 +1,475 @@
+package devclean_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/devclean"
+)
+
+func TestReplayGuardPostgresFamily_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.Postgres,
+		Schema:  "public",
+	})
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "schema qualified table",
+			statement: `CREATE TABLE archive.users (id bigint PRIMARY KEY)`,
+		},
+		{
+			name:      "database extension",
+			statement: `CREATE EXTENSION IF NOT EXISTS citext`,
+		},
+		{
+			name:      "ordinary function",
+			statement: `CREATE FUNCTION public.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
+		},
+		{
+			name:      "session search path",
+			statement: `SET search_path TO archive, public`,
+		},
+		{
+			name:      "anonymous data migration",
+			statement: `DO $$ BEGIN UPDATE public.users SET active = true; END $$`,
+		},
+		{
+			name:      "copy into managed table",
+			statement: `COPY public.users FROM STDIN`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestReplayGuardPostgresFamily_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.Postgres,
+		Schema:  "public",
+	})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "role",
+			statement: `CREATE ROLE app_user`,
+			wantErr:   `postgres migration replay rejects CREATE ROLE .*`,
+		},
+		{
+			name:      "alter system",
+			statement: `ALTER SYSTEM SET work_mem = '64MB'`,
+			wantErr:   `postgres migration replay rejects ALTER SYSTEM .*`,
+		},
+		{
+			name:      "copy program",
+			statement: `COPY public.users TO PROGRAM 'cat > /tmp/users'`,
+			wantErr:   `postgres migration replay rejects external COPY .*`,
+		},
+		{
+			name:      "copy file",
+			statement: `COPY public.users TO '/tmp/users'`,
+			wantErr:   `postgres migration replay rejects external COPY .*`,
+		},
+		{
+			name:      "event trigger",
+			statement: `CREATE EVENT TRIGGER ddl_watch ON ddl_command_end EXECUTE FUNCTION watch_ddl()`,
+			wantErr:   `postgres migration replay rejects CREATE EVENT .*`,
+		},
+		{
+			name:      "foreign data wrapper",
+			statement: `CREATE FOREIGN DATA WRAPPER remote_db`,
+			wantErr:   `postgres migration replay rejects CREATE FOREIGN .*`,
+		},
+		{
+			name:      "temporary table",
+			statement: `CREATE TEMP TABLE users (id bigint)`,
+			wantErr:   `postgres migration replay rejects TEMP object .*`,
+		},
+		{
+			name:      "session authorization",
+			statement: `SET SESSION AUTHORIZATION admin`,
+			wantErr:   `postgres migration replay rejects SET SESSION AUTHORIZATION .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestReplayGuardMySQLFamily_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.MySQL,
+		Schema:  "ptah_dev",
+	})
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "qualified table",
+			statement: "CREATE TABLE `ptah_dev`.`users` (id bigint PRIMARY KEY)",
+		},
+		{
+			name:      "qualified index target",
+			statement: "CREATE UNIQUE INDEX `users_email` ON `ptah_dev`.`users` (`email`)",
+		},
+		{
+			name:      "qualified update target",
+			statement: "UPDATE `ptah_dev`.`users` SET `active` = 1",
+		},
+		{
+			name:      "database event",
+			statement: "CREATE EVENT `ptah_dev`.`prune_users` ON SCHEDULE EVERY 1 DAY DO DELETE FROM users",
+		},
+		{
+			name:      "insert with table modifier",
+			statement: "INSERT INTO TABLE `ptah_dev`.`users` VALUES (1)",
+		},
+		{
+			name:      "table named temp",
+			statement: "CREATE TABLE `ptah_dev`.`temp` (id bigint)",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestReplayGuardMySQLFamily_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.MySQL,
+		Schema:  "ptah_dev",
+	})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "switch database",
+			statement: "USE production",
+			wantErr:   `mysql migration replay rejects USE .*`,
+		},
+		{
+			name:      "database",
+			statement: "CREATE DATABASE production",
+			wantErr:   `mysql migration replay rejects CREATE DATABASE .*`,
+		},
+		{
+			name:      "temporary table",
+			statement: "CREATE TEMPORARY TABLE users (id bigint)",
+			wantErr:   `mysql migration replay rejects TEMP object .*`,
+		},
+		{
+			name:      "cross database table",
+			statement: "CREATE TABLE production.users (id bigint)",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "cross database index target",
+			statement: "CREATE INDEX users_email ON production.users (email)",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "cross database update",
+			statement: "UPDATE production.users SET active = 1",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "global set",
+			statement: "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES'",
+			wantErr:   `mysql migration replay rejects global or persistent SET .*`,
+		},
+		{
+			name:      "role grant",
+			statement: "GRANT app_role TO app_user",
+			wantErr:   `mysql migration replay rejects privilege or role mutation .*`,
+		},
+		{
+			name:      "object grant",
+			statement: "GRANT SELECT ON `ptah_dev`.`users` TO `reader`@`%`",
+			wantErr:   `mysql migration replay rejects privilege or role mutation .*`,
+		},
+		{
+			name:      "object revoke",
+			statement: "REVOKE SELECT ON `ptah_dev`.`users` FROM `reader`@`%`",
+			wantErr:   `mysql migration replay rejects privilege or role mutation .*`,
+		},
+		{
+			name:      "prepared statement",
+			statement: "PREPARE replay_stmt FROM 'DROP DATABASE production'",
+			wantErr:   `mysql migration replay rejects prepared statement .*`,
+		},
+		{
+			name:      "lock tables",
+			statement: "LOCK TABLES users WRITE",
+			wantErr:   `mysql migration replay rejects LOCK TABLES .*`,
+		},
+		{
+			name:      "alter instance",
+			statement: "ALTER INSTANCE ROTATE INNODB MASTER KEY",
+			wantErr:   `mysql migration replay rejects ALTER INSTANCE .*`,
+		},
+		{
+			name:      "flush",
+			statement: "FLUSH PRIVILEGES",
+			wantErr:   `mysql migration replay rejects FLUSH .*`,
+		},
+		{
+			name:      "rename destination",
+			statement: "RENAME TABLE ptah_dev.users TO production.users",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "alter table rename destination",
+			statement: "ALTER TABLE ptah_dev.users RENAME TO production.users",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "insert table modifier into another database",
+			statement: "INSERT INTO TABLE production.users VALUES (1)",
+			wantErr:   `mysql migration replay rejects cross-database target "production.users" .*`,
+		},
+		{
+			name:      "outfile",
+			statement: "SELECT * FROM users INTO OUTFILE '/tmp/users'",
+			wantErr:   `mysql migration replay rejects external file operation .*`,
+		},
+		{
+			name:      "native function",
+			statement: "CREATE FUNCTION sys_exec RETURNS integer SONAME 'lib_mysqludf_sys.so'",
+			wantErr:   `mysql migration replay rejects external file operation .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestReplayGuardSQLServer_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.SQLServer,
+		Schema:  "dbo",
+	})
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "schema qualified table",
+			statement: "CREATE TABLE [tenant].[users] ([id] bigint PRIMARY KEY)",
+		},
+		{
+			name:      "schema qualified index target",
+			statement: "CREATE INDEX [users_email] ON [tenant].[users] ([email])",
+		},
+		{
+			name:      "external table in current database",
+			statement: "CREATE EXTERNAL TABLE [tenant].[events] ([id] bigint) WITH (LOCATION = '/events')",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestReplayGuardSQLServer_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.SQLServer,
+		Schema:  "dbo",
+	})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "switch database",
+			statement: "USE production",
+			wantErr:   `sqlserver migration replay rejects USE .*`,
+		},
+		{
+			name:      "login",
+			statement: "CREATE LOGIN app_user WITH PASSWORD = 'secret'",
+			wantErr:   `sqlserver migration replay rejects CREATE LOGIN .*`,
+		},
+		{
+			name:      "server role",
+			statement: "CREATE SERVER ROLE operators",
+			wantErr:   `sqlserver migration replay rejects CREATE SERVER .*`,
+		},
+		{
+			name:      "temporary table",
+			statement: "CREATE TABLE #users (id bigint)",
+			wantErr:   `sqlserver migration replay rejects temporary object .*`,
+		},
+		{
+			name:      "cross database table",
+			statement: "CREATE TABLE [production].[dbo].[users] ([id] bigint)",
+			wantErr:   `sqlserver migration replay rejects cross-database target "production.dbo.users" .*`,
+		},
+		{
+			name:      "remote execute",
+			statement: "EXECUTE ('DROP TABLE users') AT production_server",
+			wantErr:   `sqlserver migration replay rejects remote EXECUTE .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestReplayGuardClickHouse_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.ClickHouse,
+		Schema:  "ptah_dev",
+	})
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "qualified table",
+			statement: "CREATE TABLE `ptah_dev`.`events` (id UInt64) ENGINE = MergeTree ORDER BY id",
+		},
+		{
+			name:      "qualified dictionary",
+			statement: "CREATE DICTIONARY `ptah_dev`.`countries` (id UInt64, name String) PRIMARY KEY id SOURCE(NULL()) LAYOUT(FLAT())",
+		},
+		{
+			name:      "qualified materialized view",
+			statement: "CREATE MATERIALIZED VIEW `ptah_dev`.`events_daily` ENGINE = SummingMergeTree ORDER BY day AS SELECT toDate(ts) AS day FROM events",
+		},
+		{
+			name:      "table named temp",
+			statement: "CREATE TABLE `ptah_dev`.`temp` (id UInt64) ENGINE = Memory",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestReplayGuardClickHouse_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{
+		Dialect: platform.ClickHouse,
+		Schema:  "ptah_dev",
+	})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "switch database",
+			statement: "USE production",
+			wantErr:   `clickhouse migration replay rejects USE .*`,
+		},
+		{
+			name:      "database",
+			statement: "CREATE DATABASE production",
+			wantErr:   `clickhouse migration replay rejects CREATE DATABASE .*`,
+		},
+		{
+			name:      "function",
+			statement: "CREATE FUNCTION normalize AS x -> lower(x)",
+			wantErr:   `clickhouse migration replay rejects CREATE FUNCTION .*`,
+		},
+		{
+			name:      "named collection",
+			statement: "CREATE NAMED COLLECTION remote AS url = 'https://example.test'",
+			wantErr:   `clickhouse migration replay rejects CREATE NAMED .*`,
+		},
+		{
+			name:      "system command",
+			statement: "SYSTEM DROP DNS CACHE",
+			wantErr:   `clickhouse migration replay rejects SYSTEM .*`,
+		},
+		{
+			name:      "cluster ddl",
+			statement: "CREATE TABLE ptah_dev.events ON CLUSTER production (id UInt64) ENGINE = Memory",
+			wantErr:   `clickhouse migration replay rejects ON CLUSTER .*`,
+		},
+		{
+			name:      "workload",
+			statement: "CREATE WORKLOAD analytics",
+			wantErr:   `clickhouse migration replay rejects CREATE WORKLOAD .*`,
+		},
+		{
+			name:      "resource",
+			statement: "CREATE RESOURCE io_read (READ DISK disk1 FOR INTERVAL 1 SECOND MAX 10M)",
+			wantErr:   `clickhouse migration replay rejects CREATE RESOURCE .*`,
+		},
+		{
+			name:      "temporary table",
+			statement: "CREATE TEMPORARY TABLE events (id UInt64)",
+			wantErr:   `clickhouse migration replay rejects TEMP object .*`,
+		},
+		{
+			name:      "cross database table",
+			statement: "CREATE TABLE production.events (id UInt64) ENGINE = Memory",
+			wantErr:   `clickhouse migration replay rejects cross-database target "production.events" .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestReplayGuardUnknownDialect_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{Dialect: "oracle"})
+
+	err := guard.ValidateStatement("CREATE TABLE users (id integer)")
+
+	c.Assert(err, qt.ErrorMatches, `oracle migration replay rejects unsupported dialect .*`)
+}

--- a/internal/devclean/guard_postgres.go
+++ b/internal/devclean/guard_postgres.go
@@ -15,13 +15,22 @@ func validatePostgresReplayStatement(dialect string, tokens []lexer.Token) error
 
 	first := normalizedIdentifier(tokens[0])
 	if first == "DO" {
-		return nil
+		return unsafeReplayStatement(dialect, "DO sublanguage")
+	}
+	if first == "CALL" {
+		return unsafeReplayStatement(dialect, "CALL sublanguage")
+	}
+	if definesPostgresRoutine(tokens) {
+		return unsafeReplayStatement(dialect, first+" routine definition")
 	}
 	if namespace := protectedPostgresMutationNamespace(tokens); namespace != "" {
 		return unsafeReplayStatement(
 			dialect,
 			fmt.Sprintf("protected namespace %q mutation", namespace),
 		)
+	}
+	if first == "IMPORT" && containsTokenSequence(tokens, "FOREIGN", "SCHEMA") {
+		return unsafeReplayStatement(dialect, "IMPORT FOREIGN SCHEMA")
 	}
 	if operation := postgresGlobalDCLOrMetadata(tokens); operation != "" {
 		return unsafeReplayStatement(dialect, operation)
@@ -46,6 +55,9 @@ func validatePostgresReplayStatement(dialect string, tokens []lexer.Token) error
 }
 
 func protectedPostgresMutationNamespace(tokens []lexer.Token) string {
+	if namespace := protectedPostgresSelectIntoNamespace(tokens); namespace != "" {
+		return namespace
+	}
 	for _, target := range postgresMutationTargets(tokens) {
 		if namespace := protectedNamespaceFromMutationTarget(tokens, target); namespace != "" {
 			return namespace
@@ -70,6 +82,29 @@ func protectedPostgresMutationNamespace(tokens []lexer.Token) string {
 			return namespace
 		}
 		return protectedPostgresObjectTarget(tokens)
+	}
+	return ""
+}
+
+func protectedPostgresSelectIntoNamespace(tokens []lexer.Token) string {
+	tokens = leadingCTEExecutableTokens(tokens)
+	if normalizedIdentifier(tokens[0]) != "SELECT" {
+		return ""
+	}
+	for index := 1; index < len(tokens); index++ {
+		if normalizedIdentifier(tokens[index]) != "INTO" {
+			continue
+		}
+		targetIndex := index + 1
+		for targetIndex < len(tokens) {
+			switch normalizedIdentifier(tokens[targetIndex]) {
+			case "GLOBAL", "LOCAL", "TEMP", "TEMPORARY", "UNLOGGED", "TABLE":
+				targetIndex++
+			default:
+				return protectedPostgresQualifiedNamespaceAt(tokens, targetIndex)
+			}
+		}
+		return ""
 	}
 	return ""
 }
@@ -129,14 +164,12 @@ func protectedPostgresMutationListNamespace(tokens []lexer.Token) string {
 	first := normalizedIdentifier(tokens[0])
 	switch first {
 	case "DROP":
-		kindIndex := statementObjectKindIndex(tokens)
-		if kindIndex == mutationTargetNotFound {
+		const kindIndex = 1
+		if kindIndex >= len(tokens) {
 			return ""
 		}
 		kind := normalizedIdentifier(tokens[kindIndex])
-		if kind != "FOREIGN" && kind != "INDEX" && kind != "MATERIALIZED" &&
-			kind != "SCHEMA" && kind != "SEQUENCE" && kind != "TABLE" &&
-			kind != "TYPE" && kind != "VIEW" {
+		if !postgresDropSupportsObjectList(tokens, kindIndex, kind) {
 			return ""
 		}
 		targetAt := protectedPostgresQualifiedNamespaceAt
@@ -165,6 +198,21 @@ func protectedPostgresMutationListNamespace(tokens []lexer.Token) string {
 		)
 	default:
 		return ""
+	}
+}
+
+func postgresDropSupportsObjectList(tokens []lexer.Token, kindIndex int, kind string) bool {
+	switch kind {
+	case "AGGREGATE", "COLLATION", "CONVERSION", "DOMAIN", "FUNCTION", "INDEX",
+		"OPERATOR", "PROCEDURE", "ROUTINE", "SCHEMA", "SEQUENCE", "STATISTICS",
+		"TABLE", "TYPE", "VIEW":
+		return true
+	case "FOREIGN":
+		return tokenSequenceAt(tokens, kindIndex, "FOREIGN", "TABLE")
+	case "MATERIALIZED":
+		return tokenSequenceAt(tokens, kindIndex, "MATERIALIZED", "VIEW")
+	default:
+		return false
 	}
 }
 
@@ -617,7 +665,7 @@ func postgresSessionOrControlOperation(tokens []lexer.Token) string {
 		return "REINDEX database or system"
 	}
 	if first == "SET" && setsPostgresSearchPath(tokens) {
-		return ""
+		return "SET search_path"
 	}
 	switch first {
 	case "ABORT", "BEGIN", "CHECKPOINT", "COMMIT", "DEALLOCATE", "DECLARE",
@@ -693,16 +741,20 @@ func dangerousPostgresFunctionCall(tokens []lexer.Token) string {
 }
 
 func definesPostgresRoutine(tokens []lexer.Token) bool {
-	if normalizedIdentifier(tokens[0]) != "CREATE" &&
-		normalizedIdentifier(tokens[0]) != "ALTER" {
+	if len(tokens) == 0 {
 		return false
 	}
-	kindIndex := statementObjectKindIndex(tokens)
-	if kindIndex == mutationTargetNotFound {
+	first := normalizedIdentifier(tokens[0])
+	if first != "CREATE" && first != "ALTER" {
 		return false
 	}
-	kind := normalizedIdentifier(tokens[kindIndex])
-	return kind == "FUNCTION" || kind == "PROCEDURE"
+	index := 1
+	if first == "CREATE" && tokenSequenceAt(tokens, index, "OR", "REPLACE") {
+		index += 2
+	}
+	return tokenSequenceAt(tokens, index, "FUNCTION") ||
+		tokenSequenceAt(tokens, index, "PROCEDURE") ||
+		first == "ALTER" && tokenSequenceAt(tokens, index, "ROUTINE")
 }
 
 func postgresObjectClassWidth(tokens []lexer.Token, index int) int {

--- a/internal/devclean/guard_postgres.go
+++ b/internal/devclean/guard_postgres.go
@@ -1,0 +1,757 @@
+package devclean
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+func validatePostgresReplayStatement(dialect string, tokens []lexer.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	first := normalizedIdentifier(tokens[0])
+	if first == "DO" {
+		return nil
+	}
+	if namespace := protectedPostgresMutationNamespace(tokens); namespace != "" {
+		return unsafeReplayStatement(
+			dialect,
+			fmt.Sprintf("protected namespace %q mutation", namespace),
+		)
+	}
+	if operation := postgresGlobalDCLOrMetadata(tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
+	}
+	if operation := postgresRoleOrAuthorizationChange(tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
+	}
+	if operation := postgresDialectGlobalOperation(dialect, tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
+	}
+	if operation := postgresSessionOrControlOperation(tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
+	}
+	if selectsIntoPostgresTemporaryObject(tokens) {
+		return unsafeReplayStatement(dialect, "TEMP object")
+	}
+	if operation := dangerousPostgresFunctionCall(tokens); operation != "" {
+		return unsafeReplayStatement(dialect, operation)
+	}
+
+	return validatePostgresReplayStatementBase(dialect, tokens)
+}
+
+func protectedPostgresMutationNamespace(tokens []lexer.Token) string {
+	for _, target := range postgresMutationTargets(tokens) {
+		if namespace := protectedNamespaceFromMutationTarget(tokens, target); namespace != "" {
+			return namespace
+		}
+	}
+	if namespace := protectedPostgresMutationListNamespace(tokens); namespace != "" {
+		return namespace
+	}
+	if namespace := protectedPostgresSpecialMutationNamespace(tokens); namespace != "" {
+		return namespace
+	}
+
+	switch normalizedIdentifier(tokens[0]) {
+	case "ALTER":
+		if tokenSequenceAt(tokens, 1, "DEFAULT", "PRIVILEGES") {
+			return protectedPostgresSchemaClause(tokens)
+		}
+	case "COMMENT", "SECURITY":
+		return protectedPostgresObjectTarget(tokens)
+	case "GRANT", "REVOKE":
+		if namespace := protectedPostgresSchemaClause(tokens); namespace != "" {
+			return namespace
+		}
+		return protectedPostgresObjectTarget(tokens)
+	}
+	return ""
+}
+
+func postgresMutationTargets(tokens []lexer.Token) [][]string {
+	targets := mutationTargets(tokens)
+	for index := 1; index < len(tokens); index++ {
+		switch normalizedIdentifier(tokens[index]) {
+		case "DELETE", "INSERT", "MERGE", "TRUNCATE", "UPDATE":
+			targets = append(targets, mutationTargets(tokens[index:])...)
+		}
+	}
+	return targets
+}
+
+func protectedNamespaceFromMutationTarget(tokens []lexer.Token, target []string) string {
+	if len(target) >= 2 && isProtectedPostgresNamespace(target[0]) {
+		return target[0]
+	}
+	if len(target) == 0 {
+		return ""
+	}
+
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex != mutationTargetNotFound &&
+		normalizedIdentifier(tokens[kindIndex]) == "SCHEMA" &&
+		isProtectedPostgresNamespace(target[0]) {
+		return target[0]
+	}
+	return ""
+}
+
+func protectedPostgresSchemaClause(tokens []lexer.Token) string {
+	for index := 0; index+1 < len(tokens); index++ {
+		if normalizedIdentifier(tokens[index]) != "SCHEMA" {
+			continue
+		}
+		if index > 0 {
+			previous := normalizedIdentifier(tokens[index-1])
+			if previous != "IN" && previous != "ON" {
+				continue
+			}
+		}
+		if namespace := protectedPostgresObjectListNamespace(
+			tokens,
+			index+1,
+			postgresPrivilegeRecipientKeyword(tokens),
+			protectedPostgresNamespaceObjectAt,
+		); namespace != "" {
+			return namespace
+		}
+	}
+	return ""
+}
+
+func protectedPostgresMutationListNamespace(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "DROP":
+		kindIndex := statementObjectKindIndex(tokens)
+		if kindIndex == mutationTargetNotFound {
+			return ""
+		}
+		kind := normalizedIdentifier(tokens[kindIndex])
+		if kind != "FOREIGN" && kind != "INDEX" && kind != "MATERIALIZED" &&
+			kind != "SCHEMA" && kind != "SEQUENCE" && kind != "TABLE" &&
+			kind != "TYPE" && kind != "VIEW" {
+			return ""
+		}
+		targetAt := protectedPostgresQualifiedNamespaceAt
+		if kind == "SCHEMA" {
+			targetAt = protectedPostgresNamespaceObjectAt
+		}
+		return protectedPostgresObjectListNamespace(
+			tokens,
+			objectNameIndex(tokens, kindIndex),
+			"",
+			targetAt,
+		)
+	case "TRUNCATE":
+		index := 1
+		if tokenSequenceAt(tokens, index, "TABLE") {
+			index++
+		}
+		if tokenSequenceAt(tokens, index, "ONLY") {
+			index++
+		}
+		return protectedPostgresObjectListNamespace(
+			tokens,
+			index,
+			"",
+			protectedPostgresQualifiedNamespaceAt,
+		)
+	default:
+		return ""
+	}
+}
+
+func protectedPostgresSpecialMutationNamespace(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "ALTER", "CREATE", "DROP":
+		return protectedPostgresSpecialDDLNamespace(tokens)
+	case "IMPORT":
+		if containsTokenSequence(tokens, "FOREIGN", "SCHEMA") {
+			return protectedPostgresNamespaceAfterKeyword(
+				tokens,
+				"INTO",
+				1,
+				protectedPostgresNamespaceObjectAt,
+			)
+		}
+	case "REFRESH":
+		if tokenSequenceAt(tokens, 1, "MATERIALIZED", "VIEW") {
+			index := 3
+			if tokenSequenceAt(tokens, index, "CONCURRENTLY") {
+				index++
+			}
+			return protectedPostgresQualifiedNamespaceAt(tokens, index)
+		}
+	case "REINDEX":
+		return protectedPostgresReindexNamespace(tokens)
+	}
+	return ""
+}
+
+func protectedPostgresSpecialDDLNamespace(tokens []lexer.Token) string {
+	kindIndex := postgresSpecialDDLKindIndex(tokens)
+	if kindIndex >= len(tokens) {
+		return ""
+	}
+	kind := normalizedIdentifier(tokens[kindIndex])
+	switch kind {
+	case "AGGREGATE", "COLLATION", "CONVERSION", "OPERATOR", "STATISTICS":
+		return protectedPostgresNamedSpecialDDLNamespace(tokens, kindIndex, kind)
+	case "EXTENSION":
+		return protectedPostgresNamespaceAfterKeyword(
+			tokens,
+			"SCHEMA",
+			kindIndex+1,
+			protectedPostgresNamespaceObjectAt,
+		)
+	case "POLICY":
+		return protectedPostgresNamespaceAfterKeyword(
+			tokens,
+			"ON",
+			kindIndex+1,
+			protectedPostgresQualifiedNamespaceAt,
+		)
+	case "RULE":
+		keyword := "ON"
+		if normalizedIdentifier(tokens[0]) == "CREATE" {
+			keyword = "TO"
+		}
+		return protectedPostgresNamespaceAfterKeyword(
+			tokens,
+			keyword,
+			kindIndex+1,
+			protectedPostgresQualifiedNamespaceAt,
+		)
+	default:
+		return ""
+	}
+}
+
+func postgresSpecialDDLKindIndex(tokens []lexer.Token) int {
+	index := 1
+	if normalizedIdentifier(tokens[0]) == "CREATE" &&
+		tokenSequenceAt(tokens, index, "OR", "REPLACE") {
+		index += 2
+	}
+	return index
+}
+
+func protectedPostgresNamedSpecialDDLNamespace(
+	tokens []lexer.Token,
+	kindIndex int,
+	kind string,
+) string {
+	nameIndex := kindIndex + 1
+	if kind == "OPERATOR" &&
+		(tokenSequenceAt(tokens, nameIndex, "CLASS") ||
+			tokenSequenceAt(tokens, nameIndex, "FAMILY")) {
+		nameIndex++
+	}
+	nameIndex = skipNameModifiers(tokens, nameIndex)
+	if namespace := protectedPostgresObjectListNamespace(
+		tokens,
+		nameIndex,
+		"",
+		protectedPostgresQualifiedNamespaceAt,
+	); namespace != "" {
+		return namespace
+	}
+	if kind == "STATISTICS" {
+		return protectedPostgresNamespaceAfterKeyword(
+			tokens,
+			"FROM",
+			nameIndex,
+			protectedPostgresQualifiedNamespaceAt,
+		)
+	}
+	return ""
+}
+
+func protectedPostgresReindexNamespace(tokens []lexer.Token) string {
+	for index := 1; index < len(tokens); index++ {
+		switch normalizedIdentifier(tokens[index]) {
+		case "DATABASE", "SYSTEM":
+			return ""
+		case "INDEX", "TABLE":
+			targetIndex := skipNameModifiers(tokens, index+1)
+			return protectedPostgresQualifiedNamespaceAt(tokens, targetIndex)
+		case "SCHEMA":
+			targetIndex := skipNameModifiers(tokens, index+1)
+			return protectedPostgresNamespaceObjectAt(tokens, targetIndex)
+		}
+	}
+	return ""
+}
+
+func protectedPostgresNamespaceAfterKeyword(
+	tokens []lexer.Token,
+	keyword string,
+	start int,
+	targetAt func([]lexer.Token, int) string,
+) string {
+	index := findPostgresKeyword(tokens, keyword, start)
+	if index == mutationTargetNotFound {
+		return ""
+	}
+	return targetAt(tokens, index+1)
+}
+
+func protectedPostgresObjectTarget(tokens []lexer.Token) string {
+	onIndex := findPostgresKeyword(tokens, "ON", 1)
+	if onIndex == mutationTargetNotFound || onIndex+1 >= len(tokens) {
+		return ""
+	}
+
+	targetIndex := onIndex + 1
+	classWidth := postgresObjectClassWidth(tokens, targetIndex)
+	targetIndex += classWidth
+	targetAt := protectedPostgresQualifiedNamespaceAt
+	if classWidth == 1 && normalizedIdentifier(tokens[onIndex+1]) == "SCHEMA" {
+		targetAt = protectedPostgresNamespaceObjectAt
+	}
+	if namespace := protectedPostgresObjectListNamespace(
+		tokens,
+		targetIndex,
+		postgresPrivilegeRecipientKeyword(tokens),
+		targetAt,
+	); namespace != "" {
+		return namespace
+	}
+
+	kind := normalizedIdentifier(tokens[onIndex+1])
+	if kind != "CONSTRAINT" && kind != "POLICY" && kind != "RULE" && kind != "TRIGGER" {
+		return ""
+	}
+	relationOnIndex := findPostgresKeyword(tokens, "ON", targetIndex+1)
+	if relationOnIndex == mutationTargetNotFound {
+		return ""
+	}
+	return protectedPostgresQualifiedNamespaceAt(tokens, relationOnIndex+1)
+}
+
+func protectedPostgresObjectListNamespace(
+	tokens []lexer.Token,
+	start int,
+	stopKeyword string,
+	targetAt func([]lexer.Token, int) string,
+) string {
+	expectTarget := true
+	depth := 0
+	for index := start; index < len(tokens); index++ {
+		if depth == 0 && stopKeyword != "" && postgresKeywordAt(tokens[index], stopKeyword) {
+			return ""
+		}
+		if tokens[index].MatchOperatorValue("(") {
+			depth++
+			continue
+		}
+		if tokens[index].MatchOperatorValue(")") {
+			depth = max(depth-1, 0)
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if tokens[index].MatchOperatorValue(",") {
+			expectTarget = true
+			continue
+		}
+		if !expectTarget {
+			continue
+		}
+		if namespace := targetAt(tokens, index); namespace != "" {
+			return namespace
+		}
+		parts, next := qualifiedIdentifierAt(tokens, index)
+		if len(parts) == 0 {
+			continue
+		}
+		expectTarget = false
+		index = next - 1
+	}
+	return ""
+}
+
+func protectedPostgresNamespaceObjectAt(tokens []lexer.Token, index int) string {
+	if index < 0 || index >= len(tokens) {
+		return ""
+	}
+	name := identifierValue(tokens[index])
+	if !isProtectedPostgresNamespace(name) {
+		return ""
+	}
+	return name
+}
+
+func protectedPostgresQualifiedNamespaceAt(tokens []lexer.Token, index int) string {
+	name := protectedPostgresNamespaceObjectAt(tokens, index)
+	if name == "" {
+		return ""
+	}
+	if index+1 < len(tokens) && tokens[index+1].MatchOperatorValue(".") {
+		return name
+	}
+	return ""
+}
+
+func isProtectedPostgresNamespace(namespace string) bool {
+	namespace = strings.ToLower(strings.TrimSpace(namespace))
+	return namespace == "information_schema" ||
+		namespace == "crdb_internal" ||
+		strings.HasPrefix(namespace, "pg_")
+}
+
+func postgresGlobalDCLOrMetadata(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "ALTER":
+		return postgresGlobalAlterOperation(tokens)
+	case "COMMENT", "SECURITY":
+		return postgresGlobalMetadataOperation(tokens)
+	case "CREATE":
+		if tokenSequenceAt(tokens, 1, "GROUP") {
+			return "CREATE GROUP"
+		}
+	case "DROP":
+		if tokenSequenceAt(tokens, 1, "GROUP") {
+			return "DROP GROUP"
+		}
+		if tokenSequenceAt(tokens, 1, "OWNED") {
+			return "DROP OWNED"
+		}
+	case "GRANT", "REVOKE":
+		return postgresGlobalPrivilegeOperation(tokens)
+	case "REASSIGN":
+		if tokenSequenceAt(tokens, 1, "OWNED") {
+			return "REASSIGN OWNED"
+		}
+	}
+	return ""
+}
+
+func postgresGlobalAlterOperation(tokens []lexer.Token) string {
+	switch {
+	case tokenSequenceAt(tokens, 1, "DEFAULT", "PRIVILEGES") &&
+		!containsTokenSequence(tokens, "IN", "SCHEMA"):
+		return "ALTER DEFAULT PRIVILEGES without IN SCHEMA"
+	case tokenSequenceAt(tokens, 1, "GROUP"):
+		return "ALTER GROUP"
+	case tokenSequenceAt(tokens, 1, "LARGE", "OBJECT"):
+		return "ALTER LARGE OBJECT"
+	case tokenSequenceAt(tokens, 1, "EXTENSION"):
+		return "ALTER EXTENSION"
+	case tokenSequenceAt(tokens, 1, "SCHEMA"):
+		return "ALTER SCHEMA metadata"
+	default:
+		return ""
+	}
+}
+
+func postgresGlobalPrivilegeOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	recipientKeyword := postgresPrivilegeRecipientKeyword(tokens)
+	onIndex := findPostgresKeyword(tokens, "ON", 1)
+	recipientIndex := findPostgresKeyword(tokens, recipientKeyword, 1)
+	if onIndex == mutationTargetNotFound ||
+		(recipientIndex != mutationTargetNotFound && onIndex > recipientIndex) {
+		return first + " role membership"
+	}
+	if onIndex+1 >= len(tokens) {
+		return first + " global privilege"
+	}
+
+	classIndex := onIndex + 1
+	if normalizedIdentifier(tokens[classIndex]) == "ALL" {
+		classIndex++
+	}
+	if classIndex >= len(tokens) {
+		return first + " global privilege"
+	}
+	switch normalizedIdentifier(tokens[classIndex]) {
+	case "DATABASE", "LANGUAGE", "PARAMETER", "ROLE", "SCHEMA", "TABLEGROUP", "TABLESPACE":
+		return first + " database or global privilege"
+	case "FOREIGN":
+		return first + " foreign server privilege"
+	case "LARGE":
+		if tokenSequenceAt(tokens, classIndex, "LARGE", "OBJECT") ||
+			tokenSequenceAt(tokens, classIndex, "LARGE", "OBJECTS") {
+			return first + " large object privilege"
+		}
+	case "SERVER":
+		return first + " server privilege"
+	}
+	return ""
+}
+
+func postgresGlobalMetadataOperation(tokens []lexer.Token) string {
+	onIndex := findPostgresKeyword(tokens, "ON", 1)
+	if onIndex == mutationTargetNotFound || onIndex+1 >= len(tokens) {
+		return ""
+	}
+	switch normalizedIdentifier(tokens[onIndex+1]) {
+	case "ACCESS", "CAST", "DATABASE", "EVENT", "EXTENSION", "LANGUAGE", "PUBLICATION",
+		"ROLE", "SCHEMA", "SERVER", "SUBSCRIPTION", "TABLEGROUP", "TABLESPACE", "TRANSFORM":
+		return normalizedIdentifier(tokens[0]) + " ON global metadata"
+	case "FOREIGN":
+		return normalizedIdentifier(tokens[0]) + " ON foreign server metadata"
+	case "LARGE":
+		if tokenSequenceAt(tokens, onIndex+1, "LARGE", "OBJECT") {
+			return normalizedIdentifier(tokens[0]) + " ON large object metadata"
+		}
+	}
+	return ""
+}
+
+func postgresRoleOrAuthorizationChange(tokens []lexer.Token) string {
+	if normalizedIdentifier(tokens[0]) != "SET" {
+		return ""
+	}
+
+	if tokenSequenceAt(tokens, 1, "ROLE") ||
+		tokenSequenceAt(tokens, 1, "LOCAL", "ROLE") ||
+		tokenSequenceAt(tokens, 1, "SESSION", "ROLE") {
+		return "SET ROLE"
+	}
+	if tokenSequenceAt(tokens, 1, "SESSION", "AUTHORIZATION") ||
+		tokenSequenceAt(tokens, 1, "LOCAL", "SESSION", "AUTHORIZATION") ||
+		tokenSequenceAt(tokens, 1, "SESSION", "SESSION", "AUTHORIZATION") {
+		return "SET SESSION AUTHORIZATION"
+	}
+	return ""
+}
+
+func postgresDialectGlobalOperation(dialect string, tokens []lexer.Token) string {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.CockroachDB:
+		return cockroachGlobalOperation(tokens)
+	case platform.YugabyteDB:
+		return yugabyteGlobalOperation(tokens)
+	default:
+		return ""
+	}
+}
+
+func cockroachGlobalOperation(tokens []lexer.Token) string {
+	if operation := cockroachClusterSettingOperation(tokens); operation != "" {
+		return operation
+	}
+	if operation := cockroachGlobalDDLOperation(tokens); operation != "" {
+		return operation
+	}
+	return cockroachJobOrIOOperation(tokens)
+}
+
+func cockroachClusterSettingOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch {
+	case first == "SET" && tokenSequenceAt(tokens, 1, "CLUSTER", "SETTING"):
+		return "SET CLUSTER SETTING"
+	case first == "RESET" && tokenSequenceAt(tokens, 1, "CLUSTER", "SETTING"):
+		return "RESET CLUSTER SETTING"
+	default:
+		return ""
+	}
+}
+
+func cockroachGlobalDDLOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch {
+	case (first == "CREATE" || first == "ALTER" || first == "DROP") &&
+		tokenSequenceAt(tokens, 1, "CHANGEFEED"):
+		return first + " CHANGEFEED"
+	case (first == "CREATE" || first == "ALTER" || first == "DROP") &&
+		tokenSequenceAt(tokens, 1, "EXTERNAL", "CONNECTION"):
+		return first + " EXTERNAL CONNECTION"
+	case (first == "CREATE" || first == "ALTER" || first == "DROP") &&
+		tokenSequenceAt(tokens, 1, "TENANT"):
+		return first + " TENANT"
+	case (first == "CREATE" || first == "ALTER" || first == "DROP") &&
+		tokenSequenceAt(tokens, 1, "SCHEDULE"):
+		return first + " SCHEDULE"
+	case first == "ALTER" && tokenSequenceAt(tokens, 1, "RANGE"):
+		return "ALTER RANGE"
+	default:
+		return ""
+	}
+}
+
+func cockroachJobOrIOOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "BACKUP", "EXPORT", "IMPORT", "RESTORE":
+		return first
+	case "CANCEL", "PAUSE", "RESUME":
+		if tokenSequenceAt(tokens, 1, "JOB") ||
+			tokenSequenceAt(tokens, 1, "JOBS") ||
+			tokenSequenceAt(tokens, 1, "SCHEDULE") ||
+			tokenSequenceAt(tokens, 1, "SCHEDULES") {
+			return first + " cluster job"
+		}
+	default:
+		return ""
+	}
+	return ""
+}
+
+func yugabyteGlobalOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	if (first == "CREATE" || first == "ALTER" || first == "DROP") &&
+		tokenSequenceAt(tokens, 1, "TABLEGROUP") {
+		return first + " TABLEGROUP"
+	}
+	return ""
+}
+
+func postgresSessionOrControlOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	if first == "REINDEX" &&
+		(containsIdentifier(tokens, "DATABASE") || containsIdentifier(tokens, "SYSTEM")) {
+		return "REINDEX database or system"
+	}
+	if first == "SET" && setsPostgresSearchPath(tokens) {
+		return ""
+	}
+	switch first {
+	case "ABORT", "BEGIN", "CHECKPOINT", "COMMIT", "DEALLOCATE", "DECLARE",
+		"DISCARD", "END", "EXECUTE", "FETCH", "LISTEN", "LOAD", "LOCK", "MOVE",
+		"NOTIFY", "PREPARE", "RELEASE", "RESET", "ROLLBACK", "SAVEPOINT", "SET",
+		"START", "UNLISTEN":
+		return first + " session or transaction state"
+	default:
+		return ""
+	}
+}
+
+func setsPostgresSearchPath(tokens []lexer.Token) bool {
+	index := 1
+	if tokenSequenceAt(tokens, index, "LOCAL") || tokenSequenceAt(tokens, index, "SESSION") {
+		index++
+	}
+	return tokenSequenceAt(tokens, index, "SEARCH_PATH")
+}
+
+func selectsIntoPostgresTemporaryObject(tokens []lexer.Token) bool {
+	for index := 0; index+1 < len(tokens); index++ {
+		if normalizedIdentifier(tokens[index]) != "INTO" {
+			continue
+		}
+		targetIndex := index + 1
+		if tokenSequenceAt(tokens, targetIndex, "GLOBAL") ||
+			tokenSequenceAt(tokens, targetIndex, "LOCAL") {
+			targetIndex++
+		}
+		if tokenSequenceAt(tokens, targetIndex, "TEMP") ||
+			tokenSequenceAt(tokens, targetIndex, "TEMPORARY") {
+			return true
+		}
+	}
+	return false
+}
+
+func dangerousPostgresFunctionCall(tokens []lexer.Token) string {
+	if definesPostgresRoutine(tokens) || normalizedIdentifier(tokens[0]) == "CALL" {
+		return ""
+	}
+	for index := 0; index+1 < len(tokens); index++ {
+		if !tokens[index+1].MatchOperatorValue("(") {
+			continue
+		}
+		switch normalizedIdentifier(tokens[index]) {
+		case "DBLINK", "DBLINK_CANCEL_QUERY", "DBLINK_CLOSE", "DBLINK_CONNECT",
+			"DBLINK_CONNECT_U", "DBLINK_DISCONNECT", "DBLINK_EXEC", "DBLINK_FETCH",
+			"DBLINK_GET_RESULT", "DBLINK_OPEN", "DBLINK_SEND_QUERY":
+			return "external dblink operation"
+		case "LO_CLOSE", "LO_CREATE", "LO_EXPORT", "LO_FROM_BYTEA", "LO_IMPORT",
+			"LO_LSEEK", "LO_LSEEK64", "LO_OPEN", "LO_PUT", "LO_TRUNCATE",
+			"LO_TRUNCATE64", "LO_UNLINK", "LOWRITE":
+			return "large object operation"
+		case "PG_ADVISORY_LOCK", "PG_ADVISORY_LOCK_SHARED", "PG_TRY_ADVISORY_LOCK",
+			"PG_TRY_ADVISORY_LOCK_SHARED":
+			return "session advisory lock"
+		case "PG_CANCEL_BACKEND", "PG_CREATE_RESTORE_POINT", "PG_NOTIFY", "PG_PROMOTE",
+			"PG_RELOAD_CONF", "PG_ROTATE_LOGFILE", "PG_SWITCH_WAL", "PG_TERMINATE_BACKEND",
+			"PG_WAL_REPLAY_PAUSE", "PG_WAL_REPLAY_RESUME", "SET_CONFIG":
+			return "cluster control function"
+		case "PG_COPY_LOGICAL_REPLICATION_SLOT", "PG_COPY_PHYSICAL_REPLICATION_SLOT",
+			"PG_CREATE_LOGICAL_REPLICATION_SLOT", "PG_CREATE_PHYSICAL_REPLICATION_SLOT",
+			"PG_DROP_REPLICATION_SLOT", "PG_REPLICATION_ORIGIN_ADVANCE",
+			"PG_REPLICATION_ORIGIN_CREATE", "PG_REPLICATION_ORIGIN_DROP",
+			"PG_REPLICATION_ORIGIN_SESSION_RESET", "PG_REPLICATION_ORIGIN_SESSION_SETUP",
+			"PG_REPLICATION_ORIGIN_XACT_RESET", "PG_REPLICATION_ORIGIN_XACT_SETUP":
+			return "replication state operation"
+		}
+	}
+	return ""
+}
+
+func definesPostgresRoutine(tokens []lexer.Token) bool {
+	if normalizedIdentifier(tokens[0]) != "CREATE" &&
+		normalizedIdentifier(tokens[0]) != "ALTER" {
+		return false
+	}
+	kindIndex := statementObjectKindIndex(tokens)
+	if kindIndex == mutationTargetNotFound {
+		return false
+	}
+	kind := normalizedIdentifier(tokens[kindIndex])
+	return kind == "FUNCTION" || kind == "PROCEDURE"
+}
+
+func postgresObjectClassWidth(tokens []lexer.Token, index int) int {
+	switch normalizedIdentifier(tokens[index]) {
+	case "ACCESS", "EVENT", "LARGE", "MATERIALIZED":
+		return 2
+	case "FOREIGN":
+		if tokenSequenceAt(tokens, index, "FOREIGN", "DATA", "WRAPPER") {
+			return 3
+		}
+		return 2
+	case "OPERATOR":
+		if tokenSequenceAt(tokens, index, "OPERATOR", "CLASS") ||
+			tokenSequenceAt(tokens, index, "OPERATOR", "FAMILY") {
+			return 2
+		}
+		return 1
+	case "TEXT":
+		if tokenSequenceAt(tokens, index, "TEXT", "SEARCH") {
+			return min(3, len(tokens)-index)
+		}
+		return 1
+	case "AGGREGATE", "CAST", "COLLATION", "COLUMN", "CONSTRAINT", "CONVERSION",
+		"DATABASE", "DOMAIN", "EXTENSION", "FUNCTION", "INDEX", "LANGUAGE",
+		"PARAMETER", "POLICY", "PROCEDURE", "PUBLICATION", "ROLE", "ROUTINE",
+		"RULE", "SCHEMA", "SEQUENCE", "SERVER", "STATISTICS", "SUBSCRIPTION",
+		"TABLE", "TABLEGROUP", "TABLESPACE", "TRANSFORM", "TRIGGER", "TYPE", "VIEW":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func postgresPrivilegeRecipientKeyword(tokens []lexer.Token) string {
+	if len(tokens) > 0 && normalizedIdentifier(tokens[0]) == "REVOKE" {
+		return "FROM"
+	}
+	return "TO"
+}
+
+func findPostgresKeyword(tokens []lexer.Token, value string, start int) int {
+	for index := max(start, 0); index < len(tokens); index++ {
+		if postgresKeywordAt(tokens[index], value) {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}
+
+func postgresKeywordAt(token lexer.Token, value string) bool {
+	return token.Type == lexer.TokenIdentifier && strings.EqualFold(token.Value, value)
+}

--- a/internal/devclean/guard_postgres_internal_test.go
+++ b/internal/devclean/guard_postgres_internal_test.go
@@ -58,31 +58,6 @@ func TestValidatePostgresReplayStatement_HappyPath(t *testing.T) {
 			dialect:   platform.Postgres,
 			statement: `COMMENT ON TABLE app.users IS 'application users'`,
 		},
-		{
-			name:      "ordinary function definition",
-			dialect:   platform.Postgres,
-			statement: `CREATE FUNCTION app.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
-		},
-		{
-			name:      "ordinary anonymous block",
-			dialect:   platform.Postgres,
-			statement: `DO $$ BEGIN RAISE NOTICE 'replay'; END $$`,
-		},
-		{
-			name:      "ordinary procedure call",
-			dialect:   platform.Postgres,
-			statement: `CALL app.refresh_materialized_data()`,
-		},
-		{
-			name:      "session search path",
-			dialect:   platform.Postgres,
-			statement: `SET search_path TO app, public`,
-		},
-		{
-			name:      "explicit session search path",
-			dialect:   platform.Postgres,
-			statement: `SET SESSION search_path TO app, public`,
-		},
 	}
 
 	for _, test := range tests {
@@ -271,6 +246,12 @@ func TestValidatePostgresReplayStatement_FailurePath(t *testing.T) {
 			wantErr:   `postgres migration replay rejects TEMP object .*`,
 		},
 		{
+			name:      "select into protected namespace",
+			dialect:   platform.Postgres,
+			statement: `SELECT 1 INTO pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
 			name:      "begin transaction",
 			dialect:   platform.Postgres,
 			statement: `BEGIN`,
@@ -359,6 +340,60 @@ func TestValidatePostgresReplayStatement_FailurePath(t *testing.T) {
 			dialect:   platform.Postgres,
 			statement: `COPY app.users TO PROGRAM 'cat > /tmp/users'`,
 			wantErr:   `postgres migration replay rejects external COPY .*`,
+		},
+		{
+			name:      "function definition",
+			dialect:   platform.Postgres,
+			statement: `CREATE OR REPLACE FUNCTION app.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
+			wantErr:   `postgres migration replay rejects CREATE routine definition .*`,
+		},
+		{
+			name:      "procedure definition",
+			dialect:   platform.Postgres,
+			statement: `CREATE PROCEDURE app.refresh() LANGUAGE SQL AS $$ DELETE FROM app.cache $$`,
+			wantErr:   `postgres migration replay rejects CREATE routine definition .*`,
+		},
+		{
+			name:      "alter routine",
+			dialect:   platform.Postgres,
+			statement: `ALTER ROUTINE app.answer() SECURITY DEFINER`,
+			wantErr:   `postgres migration replay rejects ALTER routine definition .*`,
+		},
+		{
+			name:      "anonymous block",
+			dialect:   platform.Postgres,
+			statement: `DO $$ BEGIN RAISE NOTICE 'replay'; END $$`,
+			wantErr:   `postgres migration replay rejects DO sublanguage .*`,
+		},
+		{
+			name:      "procedure call",
+			dialect:   platform.Postgres,
+			statement: `CALL app.refresh_materialized_data()`,
+			wantErr:   `postgres migration replay rejects CALL sublanguage .*`,
+		},
+		{
+			name:      "session search path",
+			dialect:   platform.Postgres,
+			statement: `SET search_path TO app, public`,
+			wantErr:   `postgres migration replay rejects SET search_path .*`,
+		},
+		{
+			name:      "explicit session search path",
+			dialect:   platform.Postgres,
+			statement: `SET SESSION search_path TO app, public`,
+			wantErr:   `postgres migration replay rejects SET search_path .*`,
+		},
+		{
+			name:      "foreign table",
+			dialect:   platform.Postgres,
+			statement: `CREATE FOREIGN TABLE app.remote_users (id bigint) SERVER upstream`,
+			wantErr:   `postgres migration replay rejects CREATE FOREIGN .*`,
+		},
+		{
+			name:      "foreign schema import",
+			dialect:   platform.Postgres,
+			statement: `IMPORT FOREIGN SCHEMA remote FROM SERVER upstream INTO app`,
+			wantErr:   `postgres migration replay rejects IMPORT FOREIGN SCHEMA .*`,
 		},
 	}
 

--- a/internal/devclean/guard_postgres_internal_test.go
+++ b/internal/devclean/guard_postgres_internal_test.go
@@ -1,0 +1,372 @@
+package devclean
+
+// White-box testing required: this file verifies the unexported PostgreSQL-
+// family replay policy without expanding the package API.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+func TestValidatePostgresReplayStatement_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		dialect   string
+		statement string
+	}{
+		{
+			name:      "schema qualified table",
+			dialect:   platform.Postgres,
+			statement: `CREATE TABLE app.users (id bigint PRIMARY KEY)`,
+		},
+		{
+			name:      "ordinary insert",
+			dialect:   platform.Postgres,
+			statement: `INSERT INTO app.users (id) VALUES (1)`,
+		},
+		{
+			name:      "ordinary update in cte",
+			dialect:   platform.Postgres,
+			statement: `WITH changed AS (UPDATE app.users SET id = 2 RETURNING id) SELECT id FROM changed`,
+		},
+		{
+			name:      "system catalog read",
+			dialect:   platform.Postgres,
+			statement: `SELECT relname FROM pg_catalog.pg_class`,
+		},
+		{
+			name:      "table from system catalog read",
+			dialect:   platform.Postgres,
+			statement: `CREATE TABLE app.relations AS SELECT relname FROM pg_catalog.pg_class`,
+		},
+		{
+			name:      "schema scoped default privileges",
+			dialect:   platform.Postgres,
+			statement: `ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO app_reader`,
+		},
+		{
+			name:      "table grant",
+			dialect:   platform.Postgres,
+			statement: `GRANT SELECT ON TABLE app.users TO app_reader`,
+		},
+		{
+			name:      "table comment",
+			dialect:   platform.Postgres,
+			statement: `COMMENT ON TABLE app.users IS 'application users'`,
+		},
+		{
+			name:      "ordinary function definition",
+			dialect:   platform.Postgres,
+			statement: `CREATE FUNCTION app.answer() RETURNS integer LANGUAGE SQL AS $$ SELECT 42 $$`,
+		},
+		{
+			name:      "ordinary anonymous block",
+			dialect:   platform.Postgres,
+			statement: `DO $$ BEGIN RAISE NOTICE 'replay'; END $$`,
+		},
+		{
+			name:      "ordinary procedure call",
+			dialect:   platform.Postgres,
+			statement: `CALL app.refresh_materialized_data()`,
+		},
+		{
+			name:      "session search path",
+			dialect:   platform.Postgres,
+			statement: `SET search_path TO app, public`,
+		},
+		{
+			name:      "explicit session search path",
+			dialect:   platform.Postgres,
+			statement: `SET SESSION search_path TO app, public`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			tokens := significantTokens(test.statement, replayLexerOptions(test.dialect))
+			err := validatePostgresReplayStatement(test.dialect, tokens)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestValidatePostgresReplayStatement_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		dialect   string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "create in pg catalog",
+			dialect:   platform.Postgres,
+			statement: `CREATE TABLE pg_catalog.ptah_leak (id integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "nested update in information schema",
+			dialect:   platform.Postgres,
+			statement: `WITH changed AS (UPDATE information_schema.tables SET table_name = 'x' RETURNING table_name) SELECT table_name FROM changed`,
+			wantErr:   `postgres migration replay rejects protected namespace "information_schema" mutation .*`,
+		},
+		{
+			name:      "drop crdb internal schema",
+			dialect:   platform.CockroachDB,
+			statement: `DROP SCHEMA crdb_internal CASCADE`,
+			wantErr:   `cockroachdb migration replay rejects protected namespace "crdb_internal" mutation .*`,
+		},
+		{
+			name:      "comment on pg catalog table",
+			dialect:   platform.Postgres,
+			statement: `COMMENT ON TABLE pg_catalog.pg_class IS 'changed'`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "grant on protected schema",
+			dialect:   platform.Postgres,
+			statement: `GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO app_reader`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "grant on second protected schema",
+			dialect:   platform.Postgres,
+			statement: `GRANT SELECT ON ALL TABLES IN SCHEMA app, pg_catalog TO app_reader`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "drop second protected table",
+			dialect:   platform.Postgres,
+			statement: `DROP TABLE app.users, pg_catalog.ptah_leak`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "explicit pg temp target",
+			dialect:   platform.Postgres,
+			statement: `CREATE TABLE pg_temp.ptah_leak (id integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_temp" mutation .*`,
+		},
+		{
+			name:      "collation in pg catalog",
+			dialect:   platform.Postgres,
+			statement: `CREATE COLLATION pg_catalog.ptah_collation FROM "C"`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "operator in pg catalog",
+			dialect:   platform.Postgres,
+			statement: `CREATE OPERATOR pg_catalog.=== (FUNCTION = app.equals, LEFTARG = integer, RIGHTARG = integer)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "policy on pg catalog",
+			dialect:   platform.Postgres,
+			statement: `CREATE POLICY ptah_policy ON pg_catalog.pg_class USING (true)`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "foreign schema import into pg catalog",
+			dialect:   platform.Postgres,
+			statement: `IMPORT FOREIGN SCHEMA remote FROM SERVER upstream INTO pg_catalog`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "extension schema pg catalog",
+			dialect:   platform.Postgres,
+			statement: `CREATE EXTENSION hstore WITH SCHEMA pg_catalog`,
+			wantErr:   `postgres migration replay rejects protected namespace "pg_catalog" mutation .*`,
+		},
+		{
+			name:      "database grant",
+			dialect:   platform.Postgres,
+			statement: `GRANT CONNECT ON DATABASE ptah_dev TO PUBLIC`,
+			wantErr:   `postgres migration replay rejects GRANT database or global privilege .*`,
+		},
+		{
+			name:      "role membership",
+			dialect:   platform.Postgres,
+			statement: `GRANT app_owner TO app_user`,
+			wantErr:   `postgres migration replay rejects GRANT role membership .*`,
+		},
+		{
+			name:      "quoted role named on",
+			dialect:   platform.Postgres,
+			statement: `GRANT "on" TO app_user`,
+			wantErr:   `postgres migration replay rejects GRANT role membership .*`,
+		},
+		{
+			name:      "global default privileges",
+			dialect:   platform.Postgres,
+			statement: `ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC`,
+			wantErr:   `postgres migration replay rejects ALTER DEFAULT PRIVILEGES without IN SCHEMA .*`,
+		},
+		{
+			name:      "database comment",
+			dialect:   platform.Postgres,
+			statement: `COMMENT ON DATABASE ptah_dev IS 'persistent'`,
+			wantErr:   `postgres migration replay rejects COMMENT ON global metadata .*`,
+		},
+		{
+			name:      "root schema comment",
+			dialect:   platform.Postgres,
+			statement: `COMMENT ON SCHEMA public IS 'persistent'`,
+			wantErr:   `postgres migration replay rejects COMMENT ON global metadata .*`,
+		},
+		{
+			name:      "alter schema owner",
+			dialect:   platform.Postgres,
+			statement: `ALTER SCHEMA public OWNER TO app_owner`,
+			wantErr:   `postgres migration replay rejects ALTER SCHEMA metadata .*`,
+		},
+		{
+			name:      "drop owned",
+			dialect:   platform.Postgres,
+			statement: `DROP OWNED BY app_owner`,
+			wantErr:   `postgres migration replay rejects DROP OWNED .*`,
+		},
+		{
+			name:      "reassign owned",
+			dialect:   platform.Postgres,
+			statement: `REASSIGN OWNED BY app_owner TO replacement_owner`,
+			wantErr:   `postgres migration replay rejects REASSIGN OWNED .*`,
+		},
+		{
+			name:      "set session role",
+			dialect:   platform.Postgres,
+			statement: `SET SESSION ROLE app_owner`,
+			wantErr:   `postgres migration replay rejects SET ROLE .*`,
+		},
+		{
+			name:      "set local role",
+			dialect:   platform.Postgres,
+			statement: `SET LOCAL ROLE app_owner`,
+			wantErr:   `postgres migration replay rejects SET ROLE .*`,
+		},
+		{
+			name:      "set local session authorization",
+			dialect:   platform.Postgres,
+			statement: `SET LOCAL SESSION AUTHORIZATION app_owner`,
+			wantErr:   `postgres migration replay rejects SET SESSION AUTHORIZATION .*`,
+		},
+		{
+			name:      "reset session",
+			dialect:   platform.Postgres,
+			statement: `RESET ALL`,
+			wantErr:   `postgres migration replay rejects RESET session or transaction state .*`,
+		},
+		{
+			name:      "set config function",
+			dialect:   platform.Postgres,
+			statement: `SELECT set_config('session_replication_role', 'replica', false)`,
+			wantErr:   `postgres migration replay rejects cluster control function .*`,
+		},
+		{
+			name:      "select into temp",
+			dialect:   platform.Postgres,
+			statement: `SELECT 1 INTO TEMP TABLE ptah_leak`,
+			wantErr:   `postgres migration replay rejects TEMP object .*`,
+		},
+		{
+			name:      "begin transaction",
+			dialect:   platform.Postgres,
+			statement: `BEGIN`,
+			wantErr:   `postgres migration replay rejects BEGIN session or transaction state .*`,
+		},
+		{
+			name:      "prepare transaction",
+			dialect:   platform.Postgres,
+			statement: `PREPARE TRANSACTION 'ptah_leak'`,
+			wantErr:   `postgres migration replay rejects PREPARE session or transaction state .*`,
+		},
+		{
+			name:      "listen",
+			dialect:   platform.Postgres,
+			statement: `LISTEN ptah_channel`,
+			wantErr:   `postgres migration replay rejects LISTEN session or transaction state .*`,
+		},
+		{
+			name:      "advisory lock",
+			dialect:   platform.Postgres,
+			statement: `SELECT pg_catalog.pg_advisory_lock(42)`,
+			wantErr:   `postgres migration replay rejects session advisory lock .*`,
+		},
+		{
+			name:      "large object",
+			dialect:   platform.Postgres,
+			statement: `SELECT lo_create(900001)`,
+			wantErr:   `postgres migration replay rejects large object operation .*`,
+		},
+		{
+			name:      "replication slot",
+			dialect:   platform.Postgres,
+			statement: `SELECT * FROM pg_create_logical_replication_slot('ptah_leak', 'test_decoding')`,
+			wantErr:   `postgres migration replay rejects replication state operation .*`,
+		},
+		{
+			name:      "dblink external mutation",
+			dialect:   platform.Postgres,
+			statement: `SELECT dblink_exec('host=remote', 'DELETE FROM accounts')`,
+			wantErr:   `postgres migration replay rejects external dblink operation .*`,
+		},
+		{
+			name:      "cockroach cluster setting",
+			dialect:   platform.CockroachDB,
+			statement: `SET CLUSTER SETTING diagnostics.reporting.enabled = false`,
+			wantErr:   `cockroachdb migration replay rejects SET CLUSTER SETTING .*`,
+		},
+		{
+			name:      "cockroach changefeed",
+			dialect:   platform.CockroachDB,
+			statement: `CREATE CHANGEFEED FOR TABLE public.events INTO 's3://bucket/path'`,
+			wantErr:   `cockroachdb migration replay rejects CREATE CHANGEFEED .*`,
+		},
+		{
+			name:      "cockroach external connection",
+			dialect:   platform.CockroachDB,
+			statement: `CREATE EXTERNAL CONNECTION sink AS 's3://bucket/path'`,
+			wantErr:   `cockroachdb migration replay rejects CREATE EXTERNAL CONNECTION .*`,
+		},
+		{
+			name:      "cockroach cluster job",
+			dialect:   platform.CockroachDB,
+			statement: `PAUSE JOB 123`,
+			wantErr:   `cockroachdb migration replay rejects PAUSE cluster job .*`,
+		},
+		{
+			name:      "yugabyte tablegroup",
+			dialect:   platform.YugabyteDB,
+			statement: `CREATE TABLEGROUP ptah_leak`,
+			wantErr:   `yugabytedb migration replay rejects CREATE TABLEGROUP .*`,
+		},
+		{
+			name:      "yugabyte tablegroup grant",
+			dialect:   platform.YugabyteDB,
+			statement: `GRANT ALL ON TABLEGROUP ptah_leak TO app_user`,
+			wantErr:   `yugabytedb migration replay rejects GRANT database or global privilege .*`,
+		},
+		{
+			name:      "existing create role rejection",
+			dialect:   platform.Postgres,
+			statement: `CREATE ROLE app_user`,
+			wantErr:   `postgres migration replay rejects CREATE ROLE .*`,
+		},
+		{
+			name:      "existing external copy rejection",
+			dialect:   platform.Postgres,
+			statement: `COPY app.users TO PROGRAM 'cat > /tmp/users'`,
+			wantErr:   `postgres migration replay rejects external COPY .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			tokens := significantTokens(test.statement, replayLexerOptions(test.dialect))
+			err := validatePostgresReplayStatement(test.dialect, tokens)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}

--- a/internal/devclean/guard_sqlserver.go
+++ b/internal/devclean/guard_sqlserver.go
@@ -1,0 +1,460 @@
+package devclean
+
+import (
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+// validateSQLServerReplayStatement rejects SQL Server mutations whose
+// effects cannot be removed by the database-realm cleanup.
+func validateSQLServerReplayStatement(tokens []lexer.Token) error {
+	if err := validateSQLServerReplayStatementBase(tokens); err != nil {
+		return err
+	}
+	if len(tokens) == 0 {
+		return nil
+	}
+	replayTokens := tokens
+	tokens = sqlServerExecutableTokens(tokens)
+
+	first := normalizedIdentifier(tokens[0])
+	if first == "EXEC" || first == "EXECUTE" {
+		return unsafeReplayStatement(platform.SQLServer, "EXEC/EXECUTE sublanguage")
+	}
+	if first == "GRANT" || first == "DENY" || first == "REVOKE" {
+		return unsafeReplayStatement(platform.SQLServer, "permission mutation")
+	}
+	if sqlServerHasGlobalScope(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, "ON SERVER or ON ALL SERVER")
+	}
+	if sqlServerHasDatabaseTriggerScope(tokens) {
+		return unsafeReplayStatement(
+			platform.SQLServer,
+			first+" DATABASE DDL TRIGGER",
+		)
+	}
+	if sqlServerSelectIntoEscapesRealm(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, "cross-database SELECT INTO")
+	}
+	if sqlServerSelectIntoTemporaryObject(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, "temporary SELECT INTO target")
+	}
+	destination := sqlServerMutationRowsetDestination(tokens)
+	if destination == "" {
+		destination = sqlServerMutationRowsetCTEDestination(replayTokens, tokens)
+	}
+	if destination != "" {
+		return unsafeReplayStatement(
+			platform.SQLServer,
+			destination+" mutation destination",
+		)
+	}
+	if sqlServerExternalTableWritesData(tokens) {
+		return unsafeReplayStatement(
+			platform.SQLServer,
+			"CREATE EXTERNAL TABLE AS SELECT",
+		)
+	}
+	if sqlServerEnablesLedger(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, "LEDGER table")
+	}
+	if operation := sqlServerUnsupportedRealmOperation(tokens); operation != "" {
+		return unsafeReplayStatement(platform.SQLServer, operation)
+	}
+	return nil
+}
+
+func sqlServerHasGlobalScope(tokens []lexer.Token) bool {
+	if !sqlServerTriggerStatement(tokens) &&
+		!sqlServerDDLStartsWith(tokens, "EVENT", "SESSION") &&
+		!sqlServerDDLStartsWith(tokens, "EVENT", "NOTIFICATION") {
+		return false
+	}
+	return sqlServerContainsKeywordSequence(tokens, "ON", "SERVER") ||
+		sqlServerContainsKeywordSequence(tokens, "ON", "ALL", "SERVER")
+}
+
+func sqlServerHasDatabaseTriggerScope(tokens []lexer.Token) bool {
+	return sqlServerTriggerStatement(tokens) &&
+		sqlServerContainsKeywordSequence(tokens, "ON", "DATABASE")
+}
+
+func sqlServerTriggerStatement(tokens []lexer.Token) bool {
+	if sqlServerDDLStartsWith(tokens, "TRIGGER") {
+		return true
+	}
+	if len(tokens) < 2 {
+		return false
+	}
+	first := normalizedIdentifier(tokens[0])
+	return (first == "ENABLE" || first == "DISABLE") &&
+		sqlServerKeywordSequenceAt(tokens, 1, "TRIGGER")
+}
+
+func sqlServerExecutableTokens(tokens []lexer.Token) []lexer.Token {
+	if len(tokens) == 0 || !tokens[0].MatchIdentifierValue("WITH") {
+		return tokens
+	}
+	depth := 0
+	closedDefinition := false
+	for index := 1; index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth--
+			closedDefinition = depth == 0
+		case depth == 0 && closedDefinition &&
+			sqlServerDMLStatementAt(tokens, index):
+			return tokens[index:]
+		}
+	}
+	return tokens
+}
+
+func sqlServerDMLStatementAt(tokens []lexer.Token, index int) bool {
+	return sqlServerKeywordSequenceAt(tokens, index, "SELECT") ||
+		sqlServerKeywordSequenceAt(tokens, index, "INSERT") ||
+		sqlServerKeywordSequenceAt(tokens, index, "UPDATE") ||
+		sqlServerKeywordSequenceAt(tokens, index, "DELETE") ||
+		sqlServerKeywordSequenceAt(tokens, index, "MERGE")
+}
+
+func sqlServerSelectIntoEscapesRealm(tokens []lexer.Token) bool {
+	targetIndex := sqlServerSelectIntoTargetIndex(tokens)
+	return sqlServerQualifiedNameArityAt(tokens, targetIndex) >= 3
+}
+
+func sqlServerSelectIntoTemporaryObject(tokens []lexer.Token) bool {
+	targetIndex := sqlServerSelectIntoTargetIndex(tokens)
+	if targetIndex < 0 || targetIndex >= len(tokens) {
+		return false
+	}
+	target := normalizedIdentifier(tokens[targetIndex])
+	return len(target) > 0 && target[0] == '#'
+}
+
+func sqlServerSelectIntoTargetIndex(tokens []lexer.Token) int {
+	if len(tokens) == 0 {
+		return mutationTargetNotFound
+	}
+	first := normalizedIdentifier(tokens[0])
+	if first != "SELECT" && first != "WITH" {
+		return mutationTargetNotFound
+	}
+	intoIndex := sqlServerFindKeyword(tokens, "INTO", 1)
+	if intoIndex == mutationTargetNotFound {
+		return mutationTargetNotFound
+	}
+	return intoIndex + 1
+}
+
+func sqlServerQualifiedNameArityAt(tokens []lexer.Token, index int) int {
+	if index < 0 || index >= len(tokens) || identifierValue(tokens[index]) == "" {
+		return 0
+	}
+	arity := 1
+	index++
+	for index < len(tokens) && tokens[index].MatchOperatorValue(".") {
+		arity++
+		index++
+		if index < len(tokens) && identifierValue(tokens[index]) != "" {
+			index++
+		}
+	}
+	return arity
+}
+
+func sqlServerMutationRowsetDestination(tokens []lexer.Token) string {
+	index := sqlServerMutationDestinationIndex(tokens)
+	if index == mutationTargetNotFound {
+		return ""
+	}
+	if destination := sqlServerRowsetFunctionAt(tokens, index); destination != "" {
+		return destination
+	}
+	return sqlServerMutationRowsetAliasDestination(tokens, index)
+}
+
+func sqlServerRowsetFunctionAt(tokens []lexer.Token, index int) string {
+	if index < 0 ||
+		index+1 >= len(tokens) ||
+		!tokens[index+1].MatchOperatorValue("(") {
+		return ""
+	}
+	switch {
+	case tokens[index].MatchIdentifierValue("OPENQUERY"):
+		return "OPENQUERY"
+	case tokens[index].MatchIdentifierValue("OPENROWSET"):
+		return "OPENROWSET"
+	default:
+		return ""
+	}
+}
+
+func sqlServerMutationRowsetAliasDestination(tokens []lexer.Token, targetIndex int) string {
+	first := normalizedIdentifier(tokens[0])
+	if first != "UPDATE" && first != "DELETE" {
+		return ""
+	}
+	if targetIndex+1 < len(tokens) && tokens[targetIndex+1].MatchOperatorValue(".") {
+		return ""
+	}
+	target := normalizedIdentifier(tokens[targetIndex])
+	fromIndex := sqlServerFindKeyword(tokens, "FROM", targetIndex+1)
+	if target == "" || fromIndex == mutationTargetNotFound {
+		return ""
+	}
+	for index := fromIndex + 1; index < len(tokens); index++ {
+		destination := sqlServerRowsetFunctionAt(tokens, index)
+		if destination == "" {
+			continue
+		}
+		aliasIndex := skipSQLServerParenthesized(tokens, index+1)
+		if sqlServerKeywordSequenceAt(tokens, aliasIndex, "AS") {
+			aliasIndex++
+		}
+		if aliasIndex < len(tokens) &&
+			normalizedIdentifier(tokens[aliasIndex]) == target {
+			return destination
+		}
+	}
+	return ""
+}
+
+func sqlServerMutationRowsetCTEDestination(
+	replayTokens,
+	executableTokens []lexer.Token,
+) string {
+	if len(replayTokens) == 0 ||
+		!replayTokens[0].MatchIdentifierValue("WITH") ||
+		len(executableTokens) >= len(replayTokens) {
+		return ""
+	}
+	targetIndex := sqlServerMutationDestinationIndex(executableTokens)
+	if targetIndex == mutationTargetNotFound ||
+		targetIndex+1 < len(executableTokens) &&
+			executableTokens[targetIndex+1].MatchOperatorValue(".") {
+		return ""
+	}
+	target := normalizedIdentifier(executableTokens[targetIndex])
+	definitionTokens := replayTokens[:len(replayTokens)-len(executableTokens)]
+	return sqlServerCTERowsetDefinition(definitionTokens, target)
+}
+
+func sqlServerCTERowsetDefinition(tokens []lexer.Token, target string) string {
+	for index := 1; index < len(tokens); {
+		name := normalizedIdentifier(tokens[index])
+		index++
+		if index < len(tokens) && tokens[index].MatchOperatorValue("(") {
+			index = skipSQLServerParenthesized(tokens, index)
+		}
+		if !sqlServerKeywordSequenceAt(tokens, index, "AS") {
+			return ""
+		}
+		index++
+		if index >= len(tokens) || !tokens[index].MatchOperatorValue("(") {
+			return ""
+		}
+		bodyEnd := skipSQLServerParenthesized(tokens, index)
+		if name == target {
+			return sqlServerRowsetFunctionInRange(tokens, index+1, bodyEnd-1)
+		}
+		index = bodyEnd
+		if index >= len(tokens) || !tokens[index].MatchOperatorValue(",") {
+			return ""
+		}
+		index++
+	}
+	return ""
+}
+
+func sqlServerRowsetFunctionInRange(tokens []lexer.Token, start, end int) string {
+	for index := max(start, 0); index < min(end, len(tokens)); index++ {
+		if destination := sqlServerRowsetFunctionAt(tokens, index); destination != "" {
+			return destination
+		}
+	}
+	return ""
+}
+
+func sqlServerFindKeyword(tokens []lexer.Token, value string, start int) int {
+	for index := max(start, 0); index < len(tokens); index++ {
+		if tokens[index].MatchIdentifierValue(value) {
+			return index
+		}
+	}
+	return mutationTargetNotFound
+}
+
+func sqlServerContainsKeywordSequence(tokens []lexer.Token, values ...string) bool {
+	for index := range len(tokens) {
+		if sqlServerKeywordSequenceAt(tokens, index, values...) {
+			return true
+		}
+	}
+	return false
+}
+
+func sqlServerKeywordSequenceAt(tokens []lexer.Token, index int, values ...string) bool {
+	if index < 0 || index+len(values) > len(tokens) {
+		return false
+	}
+	for offset, value := range values {
+		if !tokens[index+offset].MatchIdentifierValue(value) {
+			return false
+		}
+	}
+	return true
+}
+
+func sqlServerDDLStartsWith(tokens []lexer.Token, values ...string) bool {
+	if !isDDLAction(tokens) {
+		return false
+	}
+	index := 1
+	if sqlServerKeywordSequenceAt(tokens, index, "OR", "ALTER") {
+		index += 2
+	}
+	return sqlServerKeywordSequenceAt(tokens, index, values...)
+}
+
+func sqlServerMutationDestinationIndex(tokens []lexer.Token) int {
+	if len(tokens) == 0 {
+		return mutationTargetNotFound
+	}
+	index := skipSQLServerTopClause(tokens, 1)
+	switch normalizedIdentifier(tokens[0]) {
+	case "INSERT", "MERGE":
+		if sqlServerKeywordSequenceAt(tokens, index, "INTO") {
+			index++
+		}
+	case "UPDATE":
+	case "DELETE":
+		if sqlServerKeywordSequenceAt(tokens, index, "FROM") {
+			index++
+		}
+	default:
+		return mutationTargetNotFound
+	}
+	if index >= len(tokens) {
+		return mutationTargetNotFound
+	}
+	return index
+}
+
+func skipSQLServerTopClause(tokens []lexer.Token, index int) int {
+	if !sqlServerKeywordSequenceAt(tokens, index, "TOP") {
+		return index
+	}
+	index++
+	if index < len(tokens) && tokens[index].MatchOperatorValue("(") {
+		index = skipSQLServerParenthesized(tokens, index)
+	} else if index < len(tokens) {
+		index++
+	}
+	if sqlServerKeywordSequenceAt(tokens, index, "PERCENT") {
+		index++
+	}
+	return index
+}
+
+func skipSQLServerParenthesized(tokens []lexer.Token, index int) int {
+	depth := 0
+	for index < len(tokens) {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth--
+			if depth == 0 {
+				return index + 1
+			}
+		}
+		index++
+	}
+	return index
+}
+
+func sqlServerExternalTableWritesData(tokens []lexer.Token) bool {
+	if !tokens[0].MatchIdentifierValue("CREATE") ||
+		!sqlServerDDLStartsWith(tokens, "EXTERNAL", "TABLE") {
+		return false
+	}
+	depth := 0
+	for index := 3; index < len(tokens); index++ {
+		switch {
+		case tokens[index].MatchOperatorValue("("):
+			depth++
+		case tokens[index].MatchOperatorValue(")"):
+			depth--
+		case depth == 0 && tokens[index].MatchIdentifierValue("AS"):
+			return true
+		}
+	}
+	return false
+}
+
+func sqlServerEnablesLedger(tokens []lexer.Token) bool {
+	if !sqlServerDDLStartsWith(tokens, "TABLE") {
+		return false
+	}
+	for index := 0; index+2 < len(tokens); index++ {
+		if tokens[index].MatchIdentifierValue("LEDGER") &&
+			tokens[index+1].MatchOperatorValue("=") &&
+			tokens[index+2].MatchIdentifierValue("ON") {
+			return true
+		}
+	}
+	return false
+}
+
+func sqlServerUnsupportedRealmOperation(tokens []lexer.Token) string {
+	if !isDDLAction(tokens) {
+		return ""
+	}
+	first := normalizedIdentifier(tokens[0])
+	if sqlServerDDLStartsWith(tokens, "USER") ||
+		sqlServerDDLStartsWith(tokens, "ROLE") ||
+		sqlServerDDLStartsWith(tokens, "APPLICATION", "ROLE") {
+		return first + " DATABASE PRINCIPAL"
+	}
+
+	patterns := [...]struct {
+		sequence  []string
+		operation string
+	}{
+		{sequence: []string{"AUTHORIZATION"}, operation: first + " AUTHORIZATION"},
+		{sequence: []string{"ASSEMBLY"}, operation: first + " ASSEMBLY"},
+		{sequence: []string{"PARTITION", "FUNCTION"}, operation: first + " PARTITION FUNCTION"},
+		{sequence: []string{"PARTITION", "SCHEME"}, operation: first + " PARTITION SCHEME"},
+		{sequence: []string{"FULLTEXT", "CATALOG"}, operation: first + " FULLTEXT CATALOG"},
+		{sequence: []string{"FULLTEXT", "STOPLIST"}, operation: first + " FULLTEXT STOPLIST"},
+		{sequence: []string{"SEARCH", "PROPERTY", "LIST"}, operation: first + " SEARCH PROPERTY LIST"},
+		{sequence: []string{"CERTIFICATE"}, operation: first + " CERTIFICATE"},
+		{sequence: []string{"COLUMN", "MASTER", "KEY"}, operation: first + " COLUMN MASTER KEY"},
+		{sequence: []string{"COLUMN", "ENCRYPTION", "KEY"}, operation: first + " COLUMN ENCRYPTION KEY"},
+		{sequence: []string{"MASTER", "KEY"}, operation: first + " MASTER KEY"},
+		{sequence: []string{"SYMMETRIC", "KEY"}, operation: first + " SYMMETRIC KEY"},
+		{sequence: []string{"ASYMMETRIC", "KEY"}, operation: first + " ASYMMETRIC KEY"},
+		{sequence: []string{"EVENT", "NOTIFICATION"}, operation: first + " EVENT NOTIFICATION"},
+		{sequence: []string{"EVENT", "SESSION"}, operation: first + " EVENT SESSION"},
+		{sequence: []string{"MESSAGE", "TYPE"}, operation: first + " MESSAGE TYPE"},
+		{sequence: []string{"REMOTE", "SERVICE", "BINDING"}, operation: first + " REMOTE SERVICE BINDING"},
+		{sequence: []string{"BROKER", "PRIORITY"}, operation: first + " BROKER PRIORITY"},
+		{sequence: []string{"CONTRACT"}, operation: first + " CONTRACT"},
+		{sequence: []string{"QUEUE"}, operation: first + " QUEUE"},
+		{sequence: []string{"SERVICE"}, operation: first + " SERVICE"},
+		{sequence: []string{"ROUTE"}, operation: first + " ROUTE"},
+		{sequence: []string{"RESOURCE", "POOL"}, operation: first + " RESOURCE POOL"},
+		{sequence: []string{"RESOURCE", "GOVERNOR"}, operation: first + " RESOURCE GOVERNOR"},
+		{sequence: []string{"WORKLOAD", "GROUP"}, operation: first + " WORKLOAD GROUP"},
+		{sequence: []string{"CRYPTOGRAPHIC", "PROVIDER"}, operation: first + " CRYPTOGRAPHIC PROVIDER"},
+	}
+	for _, pattern := range patterns {
+		if sqlServerDDLStartsWith(tokens, pattern.sequence...) {
+			return pattern.operation
+		}
+	}
+	return ""
+}

--- a/internal/devclean/guard_sqlserver.go
+++ b/internal/devclean/guard_sqlserver.go
@@ -21,6 +21,9 @@ func validateSQLServerReplayStatement(tokens []lexer.Token) error {
 	if first == "EXEC" || first == "EXECUTE" {
 		return unsafeReplayStatement(platform.SQLServer, "EXEC/EXECUTE sublanguage")
 	}
+	if operation := sqlServerExternalOrServerOperation(tokens); operation != "" {
+		return unsafeReplayStatement(platform.SQLServer, operation)
+	}
 	if first == "GRANT" || first == "DENY" || first == "REVOKE" {
 		return unsafeReplayStatement(platform.SQLServer, "permission mutation")
 	}
@@ -32,6 +35,9 @@ func validateSQLServerReplayStatement(tokens []lexer.Token) error {
 			platform.SQLServer,
 			first+" DATABASE DDL TRIGGER",
 		)
+	}
+	if sqlServerDefinesExecutableBody(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, first+" executable stored body")
 	}
 	if sqlServerSelectIntoEscapesRealm(tokens) {
 		return unsafeReplayStatement(platform.SQLServer, "cross-database SELECT INTO")
@@ -55,6 +61,9 @@ func validateSQLServerReplayStatement(tokens []lexer.Token) error {
 			"CREATE EXTERNAL TABLE AS SELECT",
 		)
 	}
+	if sqlServerRejectsExternalTableDDL(tokens) {
+		return unsafeReplayStatement(platform.SQLServer, first+" EXTERNAL TABLE")
+	}
 	if sqlServerEnablesLedger(tokens) {
 		return unsafeReplayStatement(platform.SQLServer, "LEDGER table")
 	}
@@ -62,6 +71,47 @@ func validateSQLServerReplayStatement(tokens []lexer.Token) error {
 		return unsafeReplayStatement(platform.SQLServer, operation)
 	}
 	return nil
+}
+
+func sqlServerRejectsExternalTableDDL(tokens []lexer.Token) bool {
+	return normalizedIdentifier(tokens[0]) != "DROP" &&
+		sqlServerDDLStartsWith(tokens, "EXTERNAL", "TABLE")
+}
+
+func sqlServerExternalOrServerOperation(tokens []lexer.Token) string {
+	first := normalizedIdentifier(tokens[0])
+	switch first {
+	case "BACKUP", "RESTORE":
+		return first + " external storage operation"
+	case "BULK":
+		if sqlServerKeywordSequenceAt(tokens, 1, "INSERT") {
+			return "BULK INSERT external data operation"
+		}
+	case "DBCC":
+		if !sqlServerDatabaseLocalDBCC(tokens) {
+			return first + " server operation"
+		}
+	case "KILL", "RECONFIGURE", "SHUTDOWN":
+		return first + " server operation"
+	}
+	return ""
+}
+
+func sqlServerDefinesExecutableBody(tokens []lexer.Token) bool {
+	if normalizedIdentifier(tokens[0]) == "DROP" &&
+		sqlServerDDLStartsWith(tokens, "FUNCTION") {
+		return false
+	}
+	return sqlServerDDLStartsWith(tokens, "FUNCTION") ||
+		sqlServerDDLStartsWith(tokens, "PROCEDURE") ||
+		sqlServerDDLStartsWith(tokens, "PROC") ||
+		sqlServerDDLStartsWith(tokens, "TRIGGER")
+}
+
+func sqlServerDatabaseLocalDBCC(tokens []lexer.Token) bool {
+	return sqlServerKeywordSequenceAt(tokens, 1, "CHECKIDENT") ||
+		sqlServerKeywordSequenceAt(tokens, 1, "CHECKTABLE") ||
+		sqlServerKeywordSequenceAt(tokens, 1, "CHECKCONSTRAINTS")
 }
 
 func sqlServerHasGlobalScope(tokens []lexer.Token) bool {

--- a/internal/devclean/guard_sqlserver_internal_test.go
+++ b/internal/devclean/guard_sqlserver_internal_test.go
@@ -30,16 +30,6 @@ func TestValidateSQLServerReplayStatement_HappyPath(t *testing.T) {
 			statement: "CREATE TABLE dbo.accounts (id bigint PRIMARY KEY, balance decimal(18,2));",
 		},
 		{
-			name: "ordinary external table metadata",
-			statement: "CREATE EXTERNAL TABLE dbo.remote_data (" +
-				"id int, [as] nvarchar(32)) WITH (" +
-				"LOCATION = '/data', DATA_SOURCE = remote_source);",
-		},
-		{
-			name:      "drop external table metadata",
-			statement: "DROP EXTERNAL TABLE IF EXISTS dbo.remote_data;",
-		},
-		{
 			name: "unsupported kind words used as local column names",
 			statement: "CREATE TABLE dbo.words (" +
 				"service int, queue int, route int, contract int, " +
@@ -64,6 +54,10 @@ func TestValidateSQLServerReplayStatement_HappyPath(t *testing.T) {
 		{
 			name:      "local select into quoted keyword",
 			statement: "SELECT id INTO [IF] FROM dbo.source;",
+		},
+		{
+			name:      "drop external table metadata",
+			statement: "DROP EXTERNAL TABLE IF EXISTS dbo.remote_data;",
 		},
 		{
 			name:      "string literal resembling into keyword",
@@ -107,10 +101,6 @@ func TestValidateSQLServerReplayStatement_HappyPath(t *testing.T) {
 				"CHECK ([ledger] = 'ON'));",
 		},
 		{
-			name:      "local dml trigger",
-			statement: "CREATE TRIGGER dbo.audit_insert ON dbo.accounts AFTER INSERT AS SELECT 1;",
-		},
-		{
 			name: "local security policy",
 			statement: "CREATE SECURITY POLICY dbo.tenant_policy " +
 				"ADD FILTER PREDICATE dbo.tenant_filter(tenant_id) ON dbo.accounts;",
@@ -126,10 +116,6 @@ func TestValidateSQLServerReplayStatement_HappyPath(t *testing.T) {
 		{
 			name:      "local xml schema collection",
 			statement: "CREATE XML SCHEMA COLLECTION dbo.documents AS N'<schema />';",
-		},
-		{
-			name:      "local synonym",
-			statement: "CREATE SYNONYM dbo.current_accounts FOR dbo.accounts;",
 		},
 		{
 			name:      "local schema with authorization",
@@ -303,6 +289,26 @@ func TestValidateSQLServerReplayStatement_FailurePath(t *testing.T) {
 			wantOperation: "CREATE EXTERNAL TABLE AS SELECT",
 		},
 		{
+			name:          "bulk insert",
+			statement:     `BULK INSERT otherdb.dbo.users FROM '\\host\share\users.csv';`,
+			wantOperation: "BULK INSERT external data operation",
+		},
+		{
+			name:          "backup database",
+			statement:     `BACKUP DATABASE ptah_dev TO DISK = '\\host\share\ptah.bak';`,
+			wantOperation: "BACKUP external storage operation",
+		},
+		{
+			name:          "restore database",
+			statement:     `RESTORE DATABASE ptah_dev FROM DISK = '\\host\share\ptah.bak';`,
+			wantOperation: "RESTORE external storage operation",
+		},
+		{
+			name:          "DBCC server operation",
+			statement:     "DBCC FREEPROCCACHE;",
+			wantOperation: "DBCC server operation",
+		},
+		{
 			name: "create external table as cte select",
 			statement: "CREATE EXTERNAL TABLE dbo.remote_export " +
 				"WITH (LOCATION = '/export', DATA_SOURCE = remote_source, " +
@@ -310,6 +316,33 @@ func TestValidateSQLServerReplayStatement_FailurePath(t *testing.T) {
 				"WITH source_rows AS (SELECT id FROM dbo.source) " +
 				"SELECT id FROM source_rows;",
 			wantOperation: "CREATE EXTERNAL TABLE AS SELECT",
+		},
+		{
+			name: "create external table metadata",
+			statement: "CREATE EXTERNAL TABLE dbo.remote_data (" +
+				"id int, [as] nvarchar(32)) WITH (" +
+				"LOCATION = '/data', DATA_SOURCE = remote_source);",
+			wantOperation: "CREATE EXTERNAL TABLE",
+		},
+		{
+			name:          "local dml trigger body",
+			statement:     "CREATE TRIGGER dbo.audit_insert ON dbo.accounts AFTER INSERT AS SELECT 1;",
+			wantOperation: "CREATE executable stored body",
+		},
+		{
+			name:          "local procedure body",
+			statement:     "CREATE OR ALTER PROCEDURE dbo.rebuild AS DELETE FROM dbo.accounts;",
+			wantOperation: "CREATE executable stored body",
+		},
+		{
+			name:          "local function body",
+			statement:     "ALTER FUNCTION dbo.answer() RETURNS int AS BEGIN RETURN 42 END;",
+			wantOperation: "ALTER executable stored body",
+		},
+		{
+			name:          "local synonym",
+			statement:     "CREATE SYNONYM dbo.current_accounts FOR dbo.accounts;",
+			wantOperation: "CREATE SYNONYM",
 		},
 		{
 			name:          "create ledger table",

--- a/internal/devclean/guard_sqlserver_internal_test.go
+++ b/internal/devclean/guard_sqlserver_internal_test.go
@@ -1,0 +1,527 @@
+package devclean
+
+// White-box testing required: the SQL Server replay policy is an internal
+// safety boundary whose token-level decisions are not observable through an
+// exported API.
+
+import (
+	"regexp"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+func TestValidateSQLServerReplayStatement_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "empty statement",
+			statement: "-- comment only",
+		},
+		{
+			name:      "ordinary local table",
+			statement: "CREATE TABLE dbo.accounts (id bigint PRIMARY KEY, balance decimal(18,2));",
+		},
+		{
+			name: "ordinary external table metadata",
+			statement: "CREATE EXTERNAL TABLE dbo.remote_data (" +
+				"id int, [as] nvarchar(32)) WITH (" +
+				"LOCATION = '/data', DATA_SOURCE = remote_source);",
+		},
+		{
+			name:      "drop external table metadata",
+			statement: "DROP EXTERNAL TABLE IF EXISTS dbo.remote_data;",
+		},
+		{
+			name: "unsupported kind words used as local column names",
+			statement: "CREATE TABLE dbo.words (" +
+				"service int, queue int, route int, contract int, " +
+				"certificate int, assembly int, authorization int);",
+		},
+		{
+			name:      "local table named openquery",
+			statement: "INSERT INTO [OPENQUERY] (id) VALUES (1);",
+		},
+		{
+			name:      "local index on identifiers named server and event",
+			statement: "CREATE INDEX ix_event ON server.event (id);",
+		},
+		{
+			name:      "local select into unqualified table",
+			statement: "SELECT id INTO snapshot FROM dbo.source;",
+		},
+		{
+			name:      "local select into schema table",
+			statement: "SELECT id INTO dbo.snapshot FROM dbo.source;",
+		},
+		{
+			name:      "local select into quoted keyword",
+			statement: "SELECT id INTO [IF] FROM dbo.source;",
+		},
+		{
+			name:      "string literal resembling into keyword",
+			statement: "SELECT 'INTO', 'otherdb.dbo.snapshot';",
+		},
+		{
+			name:      "incomplete select into remains panic safe",
+			statement: "SELECT id INTO;",
+		},
+		{
+			name: "openquery used only as source",
+			statement: "INSERT INTO dbo.local_copy (id) " +
+				"SELECT id FROM OPENQUERY(remote_link, 'SELECT id FROM remote_table');",
+		},
+		{
+			name: "openrowset used only as source",
+			statement: "UPDATE dbo.local_copy SET value = source.value " +
+				"FROM OPENROWSET('MSOLEDBSQL', 'Server=remote;', " +
+				"'SELECT id, value FROM remote_table') AS source " +
+				"WHERE dbo.local_copy.id = source.id;",
+		},
+		{
+			name: "cte openquery used only as source",
+			statement: "WITH remote_rows AS (" +
+				"SELECT id, value FROM OPENQUERY(remote_link, 'SELECT id, value FROM remote_table')) " +
+				"UPDATE dbo.local_copy SET value = remote_rows.value " +
+				"FROM remote_rows WHERE dbo.local_copy.id = remote_rows.id;",
+		},
+		{
+			name: "temporal table",
+			statement: "CREATE TABLE dbo.temporal_data (" +
+				"id int PRIMARY KEY, valid_from datetime2 GENERATED ALWAYS AS ROW START, " +
+				"valid_to datetime2 GENERATED ALWAYS AS ROW END, " +
+				"PERIOD FOR SYSTEM_TIME (valid_from, valid_to)) " +
+				"WITH (SYSTEM_VERSIONING = ON);",
+		},
+		{
+			name: "ordinary table with ledger column",
+			statement: "CREATE TABLE dbo.ledger_entries (" +
+				"id bigint PRIMARY KEY, [ledger] nvarchar(64), " +
+				"CHECK ([ledger] = 'ON'));",
+		},
+		{
+			name:      "local dml trigger",
+			statement: "CREATE TRIGGER dbo.audit_insert ON dbo.accounts AFTER INSERT AS SELECT 1;",
+		},
+		{
+			name: "local security policy",
+			statement: "CREATE SECURITY POLICY dbo.tenant_policy " +
+				"ADD FILTER PREDICATE dbo.tenant_filter(tenant_id) ON dbo.accounts;",
+		},
+		{
+			name:      "local aggregate",
+			statement: "CREATE AGGREGATE dbo.concat_values (@value nvarchar(max)) RETURNS nvarchar(max);",
+		},
+		{
+			name:      "local type",
+			statement: "CREATE TYPE dbo.account_id FROM bigint NOT NULL;",
+		},
+		{
+			name:      "local xml schema collection",
+			statement: "CREATE XML SCHEMA COLLECTION dbo.documents AS N'<schema />';",
+		},
+		{
+			name:      "local synonym",
+			statement: "CREATE SYNONYM dbo.current_accounts FOR dbo.accounts;",
+		},
+		{
+			name:      "local schema with authorization",
+			statement: "CREATE SCHEMA app AUTHORIZATION dbo;",
+		},
+		{
+			name:      "ordinary insert",
+			statement: "INSERT INTO dbo.accounts (id, balance) VALUES (1, 10);",
+		},
+		{
+			name:      "ordinary update",
+			statement: "UPDATE dbo.accounts SET balance = 20 WHERE id = 1;",
+		},
+		{
+			name:      "ordinary delete",
+			statement: "DELETE FROM dbo.accounts WHERE id = 1;",
+		},
+		{
+			name: "ordinary merge",
+			statement: "MERGE INTO dbo.accounts AS target " +
+				"USING dbo.incoming AS source ON target.id = source.id " +
+				"WHEN MATCHED THEN UPDATE SET balance = source.balance;",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateSQLServerReplayStatement(sqlServerReplayTokens(test.statement))
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestValidateSQLServerReplayStatement_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name          string
+		statement     string
+		wantOperation string
+	}{
+		{
+			name:          "dynamic exec",
+			statement:     "EXEC(N'CREATE LOGIN escaped WITH PASSWORD = ''secret''');",
+			wantOperation: "EXEC/EXECUTE sublanguage",
+		},
+		{
+			name:          "stored procedure execute",
+			statement:     "EXECUTE sys.sp_addextendedproperty @name = N'outside', @value = 1;",
+			wantOperation: "EXEC/EXECUTE sublanguage",
+		},
+		{
+			name:          "server trigger",
+			statement:     "CREATE TRIGGER reject_login ON ALL SERVER FOR LOGON AS ROLLBACK;",
+			wantOperation: "ON SERVER or ON ALL SERVER",
+		},
+		{
+			name:          "server event session",
+			statement:     "CREATE EVENT SESSION replay_escape ON SERVER ADD EVENT sqlserver.error_reported;",
+			wantOperation: "ON SERVER or ON ALL SERVER",
+		},
+		{
+			name:          "disable server trigger",
+			statement:     "DISABLE TRIGGER reject_login ON ALL SERVER;",
+			wantOperation: "ON SERVER or ON ALL SERVER",
+		},
+		{
+			name:          "database ddl trigger",
+			statement:     "CREATE TRIGGER reject_table ON DATABASE FOR CREATE_TABLE AS ROLLBACK;",
+			wantOperation: "CREATE DATABASE DDL TRIGGER",
+		},
+		{
+			name:          "enable database ddl trigger",
+			statement:     "ENABLE TRIGGER reject_table ON DATABASE;",
+			wantOperation: "ENABLE DATABASE DDL TRIGGER",
+		},
+		{
+			name:          "database event notification",
+			statement:     "CREATE EVENT NOTIFICATION notify_ddl ON DATABASE FOR CREATE_TABLE TO SERVICE 'svc', 'current database';",
+			wantOperation: "CREATE EVENT NOTIFICATION",
+		},
+		{
+			name:          "cross database select into three part name",
+			statement:     "SELECT id INTO otherdb.dbo.snapshot FROM dbo.source;",
+			wantOperation: "cross-database SELECT INTO",
+		},
+		{
+			name:          "cross database select into omitted schema",
+			statement:     "SELECT id INTO otherdb..snapshot FROM dbo.source;",
+			wantOperation: "cross-database SELECT INTO",
+		},
+		{
+			name:          "cross server select into",
+			statement:     "SELECT id INTO remote_server.otherdb.dbo.snapshot FROM dbo.source;",
+			wantOperation: "cross-database SELECT INTO",
+		},
+		{
+			name:          "cte cross database select into",
+			statement:     "WITH source_rows AS (SELECT id FROM dbo.source) SELECT id INTO otherdb.dbo.snapshot FROM source_rows;",
+			wantOperation: "cross-database SELECT INTO",
+		},
+		{
+			name:          "temporary select into",
+			statement:     "SELECT id INTO #snapshot FROM dbo.source;",
+			wantOperation: "temporary SELECT INTO target",
+		},
+		{
+			name:          "insert openquery destination",
+			statement:     "INSERT OPENQUERY(remote_link, 'SELECT id FROM remote_table') VALUES (1);",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name:          "insert top openrowset destination",
+			statement:     "INSERT TOP (10) INTO OPENROWSET('MSOLEDBSQL', 'Server=remote;', 'SELECT id FROM remote_table') VALUES (1);",
+			wantOperation: "OPENROWSET mutation destination",
+		},
+		{
+			name:          "update openquery destination",
+			statement:     "UPDATE TOP (5) OPENQUERY(remote_link, 'SELECT value FROM remote_table') SET value = 1;",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name:          "update openrowset alias destination",
+			statement:     "UPDATE RemoteRows SET value = 1 FROM OPENROWSET('MSOLEDBSQL', 'Server=remote;', 'SELECT value FROM remote_table') AS remoteRows;",
+			wantOperation: "OPENROWSET mutation destination",
+		},
+		{
+			name:          "delete openrowset destination",
+			statement:     "DELETE TOP (25) PERCENT FROM OPENROWSET('MSOLEDBSQL', 'Server=remote;', 'SELECT id FROM remote_table');",
+			wantOperation: "OPENROWSET mutation destination",
+		},
+		{
+			name:          "delete openquery alias destination",
+			statement:     "DELETE remote_rows FROM OPENQUERY(remote_link, 'SELECT id FROM remote_table') remote_rows;",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name:          "merge openquery destination",
+			statement:     "MERGE INTO OPENQUERY(remote_link, 'SELECT id FROM remote_table') AS target USING dbo.source ON target.id = source.id;",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name: "cte insert openquery destination",
+			statement: "WITH rows_to_send AS (SELECT id FROM dbo.source) " +
+				"INSERT OPENQUERY(remote_link, 'SELECT id FROM remote_table') " +
+				"SELECT id FROM rows_to_send;",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name: "openrowset cte update destination",
+			statement: "WITH remote_rows (id, value) AS (" +
+				"SELECT id, value FROM OPENROWSET('MSOLEDBSQL', 'Server=remote;', " +
+				"'SELECT id, value FROM remote_table')) " +
+				"UPDATE remote_rows SET value = 1;",
+			wantOperation: "OPENROWSET mutation destination",
+		},
+		{
+			name: "openquery second cte delete destination",
+			statement: "WITH local_rows AS (SELECT id FROM dbo.source), " +
+				"remote_rows AS (SELECT id FROM OPENQUERY(remote_link, " +
+				"'SELECT id FROM remote_table')) " +
+				"DELETE remote_rows;",
+			wantOperation: "OPENQUERY mutation destination",
+		},
+		{
+			name: "create external table as select",
+			statement: "CREATE EXTERNAL TABLE dbo.remote_export " +
+				"WITH (LOCATION = '/export', DATA_SOURCE = remote_source, " +
+				"FILE_FORMAT = parquet_format) AS " +
+				"SELECT id FROM dbo.source;",
+			wantOperation: "CREATE EXTERNAL TABLE AS SELECT",
+		},
+		{
+			name: "create external table as cte select",
+			statement: "CREATE EXTERNAL TABLE dbo.remote_export " +
+				"WITH (LOCATION = '/export', DATA_SOURCE = remote_source, " +
+				"FILE_FORMAT = parquet_format) AS " +
+				"WITH source_rows AS (SELECT id FROM dbo.source) " +
+				"SELECT id FROM source_rows;",
+			wantOperation: "CREATE EXTERNAL TABLE AS SELECT",
+		},
+		{
+			name:          "create ledger table",
+			statement:     "CREATE TABLE dbo.ledger_data (id int PRIMARY KEY) WITH (LEDGER = ON);",
+			wantOperation: "LEDGER table",
+		},
+		{
+			name:          "alter table to enable ledger",
+			statement:     "ALTER TABLE dbo.ledger_data SET (LEDGER = ON);",
+			wantOperation: "LEDGER table",
+		},
+		{
+			name:          "create user",
+			statement:     "CREATE USER replay_user WITHOUT LOGIN;",
+			wantOperation: "CREATE DATABASE PRINCIPAL",
+		},
+		{
+			name:          "create application role",
+			statement:     "CREATE APPLICATION ROLE replay_role WITH PASSWORD = 'secret';",
+			wantOperation: "CREATE DATABASE PRINCIPAL",
+		},
+		{
+			name:          "alter role membership",
+			statement:     "ALTER ROLE replay_role ADD MEMBER replay_user;",
+			wantOperation: "ALTER DATABASE PRINCIPAL",
+		},
+		{
+			name:          "drop user",
+			statement:     "DROP USER replay_user;",
+			wantOperation: "DROP DATABASE PRINCIPAL",
+		},
+		{
+			name:          "grant permission",
+			statement:     "GRANT CONTROL ON SCHEMA::dbo TO replay_user;",
+			wantOperation: "permission mutation",
+		},
+		{
+			name:          "deny permission",
+			statement:     "DENY SELECT TO replay_user;",
+			wantOperation: "permission mutation",
+		},
+		{
+			name:          "revoke permission",
+			statement:     "REVOKE CONNECT FROM replay_user;",
+			wantOperation: "permission mutation",
+		},
+		{
+			name:          "alter authorization",
+			statement:     "ALTER AUTHORIZATION ON SCHEMA::dbo TO replay_user;",
+			wantOperation: "ALTER AUTHORIZATION",
+		},
+		{
+			name:          "create assembly",
+			statement:     "CREATE ASSEMBLY replay_assembly FROM 0x00;",
+			wantOperation: "CREATE ASSEMBLY",
+		},
+		{
+			name:          "create partition function",
+			statement:     "CREATE PARTITION FUNCTION replay_partition(int) AS RANGE LEFT FOR VALUES (10);",
+			wantOperation: "CREATE PARTITION FUNCTION",
+		},
+		{
+			name:          "create partition scheme",
+			statement:     "CREATE PARTITION SCHEME replay_scheme AS PARTITION replay_partition ALL TO ([PRIMARY]);",
+			wantOperation: "CREATE PARTITION SCHEME",
+		},
+		{
+			name:          "create fulltext catalog",
+			statement:     "CREATE FULLTEXT CATALOG replay_catalog;",
+			wantOperation: "CREATE FULLTEXT CATALOG",
+		},
+		{
+			name:          "create fulltext stoplist",
+			statement:     "CREATE FULLTEXT STOPLIST replay_stoplist;",
+			wantOperation: "CREATE FULLTEXT STOPLIST",
+		},
+		{
+			name:          "create search property list",
+			statement:     "CREATE SEARCH PROPERTY LIST replay_properties;",
+			wantOperation: "CREATE SEARCH PROPERTY LIST",
+		},
+		{
+			name:          "create certificate",
+			statement:     "CREATE CERTIFICATE replay_certificate WITH SUBJECT = 'replay';",
+			wantOperation: "CREATE CERTIFICATE",
+		},
+		{
+			name:          "create database master key",
+			statement:     "CREATE MASTER KEY ENCRYPTION BY PASSWORD = 'secret';",
+			wantOperation: "CREATE MASTER KEY",
+		},
+		{
+			name:          "create symmetric key",
+			statement:     "CREATE SYMMETRIC KEY replay_symmetric WITH ALGORITHM = AES_256 ENCRYPTION BY PASSWORD = 'secret';",
+			wantOperation: "CREATE SYMMETRIC KEY",
+		},
+		{
+			name:          "create asymmetric key",
+			statement:     "CREATE ASYMMETRIC KEY replay_asymmetric WITH ALGORITHM = RSA_2048;",
+			wantOperation: "CREATE ASYMMETRIC KEY",
+		},
+		{
+			name:          "create column master key",
+			statement:     "CREATE COLUMN MASTER KEY replay_column_master WITH (KEY_STORE_PROVIDER_NAME = 'provider', KEY_PATH = 'path');",
+			wantOperation: "CREATE COLUMN MASTER KEY",
+		},
+		{
+			name:          "create column encryption key",
+			statement:     "CREATE COLUMN ENCRYPTION KEY replay_column_encryption WITH VALUES (COLUMN_MASTER_KEY = replay_column_master, ALGORITHM = 'RSA_OAEP', ENCRYPTED_VALUE = 0x00);",
+			wantOperation: "CREATE COLUMN ENCRYPTION KEY",
+		},
+		{
+			name:          "create event session",
+			statement:     "CREATE EVENT SESSION replay_session ON DATABASE ADD EVENT sqlserver.error_reported;",
+			wantOperation: "CREATE EVENT SESSION",
+		},
+		{
+			name:          "create broker message type",
+			statement:     "CREATE MESSAGE TYPE [replay_message] VALIDATION = NONE;",
+			wantOperation: "CREATE MESSAGE TYPE",
+		},
+		{
+			name:          "create broker contract",
+			statement:     "CREATE CONTRACT replay_contract ([replay_message] SENT BY INITIATOR);",
+			wantOperation: "CREATE CONTRACT",
+		},
+		{
+			name:          "create broker queue",
+			statement:     "CREATE QUEUE dbo.replay_queue;",
+			wantOperation: "CREATE QUEUE",
+		},
+		{
+			name:          "create broker service",
+			statement:     "CREATE SERVICE replay_service ON QUEUE dbo.replay_queue (replay_contract);",
+			wantOperation: "CREATE SERVICE",
+		},
+		{
+			name:          "create broker route",
+			statement:     "CREATE ROUTE replay_route WITH SERVICE_NAME = 'replay_service', ADDRESS = 'LOCAL';",
+			wantOperation: "CREATE ROUTE",
+		},
+		{
+			name:          "create remote service binding",
+			statement:     "CREATE REMOTE SERVICE BINDING replay_binding TO SERVICE 'replay_service' WITH USER = replay_user;",
+			wantOperation: "CREATE REMOTE SERVICE BINDING",
+		},
+		{
+			name:          "create broker priority",
+			statement:     "CREATE BROKER PRIORITY replay_priority FOR CONVERSATION SET (CONTRACT_NAME = ANY);",
+			wantOperation: "CREATE BROKER PRIORITY",
+		},
+		{
+			name:          "create resource pool",
+			statement:     "CREATE RESOURCE POOL replay_pool;",
+			wantOperation: "CREATE RESOURCE POOL",
+		},
+		{
+			name:          "alter resource governor",
+			statement:     "ALTER RESOURCE GOVERNOR RECONFIGURE;",
+			wantOperation: "ALTER RESOURCE GOVERNOR",
+		},
+		{
+			name:          "create workload group",
+			statement:     "CREATE WORKLOAD GROUP replay_group USING replay_pool;",
+			wantOperation: "CREATE WORKLOAD GROUP",
+		},
+		{
+			name:          "create cryptographic provider",
+			statement:     "CREATE CRYPTOGRAPHIC PROVIDER replay_provider FROM FILE = 'provider.dll';",
+			wantOperation: "CREATE CRYPTOGRAPHIC PROVIDER",
+		},
+		{
+			name:          "database scoped credential inherited rejection",
+			statement:     "CREATE DATABASE SCOPED CREDENTIAL replay_credential WITH IDENTITY = 'identity';",
+			wantOperation: "CREATE DATABASE",
+		},
+		{
+			name:          "external data source inherited rejection",
+			statement:     "CREATE EXTERNAL DATA SOURCE replay_source WITH (LOCATION = 'https://example.invalid');",
+			wantOperation: "CREATE EXTERNAL",
+		},
+		{
+			name:          "database audit specification inherited rejection",
+			statement:     "CREATE DATABASE AUDIT SPECIFICATION replay_audit FOR SERVER AUDIT audit_target;",
+			wantOperation: "CREATE DATABASE",
+		},
+		{
+			name:          "database scoped configuration inherited rejection",
+			statement:     "ALTER DATABASE SCOPED CONFIGURATION SET MAXDOP = 1;",
+			wantOperation: "ALTER DATABASE",
+		},
+		{
+			name:          "database file inherited rejection",
+			statement:     "ALTER DATABASE current_database ADD FILE (NAME = replay_file, FILENAME = 'replay.ndf');",
+			wantOperation: "ALTER DATABASE",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := validateSQLServerReplayStatement(sqlServerReplayTokens(test.statement))
+			c.Assert(
+				err,
+				qt.ErrorMatches,
+				`sqlserver migration replay rejects `+
+					regexp.QuoteMeta(test.wantOperation)+
+					` because its effects cannot be confined to the disposable database realm`,
+			)
+		})
+	}
+}
+
+func sqlServerReplayTokens(statement string) []lexer.Token {
+	return significantTokens(statement, replayLexerOptions(platform.SQLServer))
+}

--- a/internal/devclean/guard_test.go
+++ b/internal/devclean/guard_test.go
@@ -1,0 +1,106 @@
+package devclean_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/devclean"
+)
+
+func TestReplayGuardSQLite_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{Dialect: platform.SQLite})
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "main table",
+			statement: `CREATE TABLE main.users (id INTEGER PRIMARY KEY)`,
+		},
+		{
+			name:      "ordinary data migration",
+			statement: `INSERT INTO users (id) VALUES (1)`,
+		},
+		{
+			name:      "temp word in value",
+			statement: `UPDATE users SET label = 'temp.object'`,
+		},
+		{
+			name:      "table named temp",
+			statement: `CREATE TABLE temp (id INTEGER PRIMARY KEY)`,
+		},
+		{
+			name:      "foreign keys pragma",
+			statement: `PRAGMA foreign_keys = ON`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestReplayGuardSQLite_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	guard := devclean.NewReplayGuard(types.DBInfo{Dialect: platform.SQLite})
+	tests := []struct {
+		name      string
+		statement string
+		wantErr   string
+	}{
+		{
+			name:      "attach database",
+			statement: `ATTACH DATABASE 'other.db' AS aux`,
+			wantErr:   `sqlite migration replay rejects ATTACH .*`,
+		},
+		{
+			name:      "detach database",
+			statement: `DETACH DATABASE aux`,
+			wantErr:   `sqlite migration replay rejects DETACH .*`,
+		},
+		{
+			name:      "temporary object",
+			statement: `CREATE TEMPORARY TABLE users (id INTEGER)`,
+			wantErr:   `sqlite migration replay rejects TEMP object .*`,
+		},
+		{
+			name:      "qualified temp target",
+			statement: `INSERT INTO "temp".users (id) VALUES (1)`,
+			wantErr:   `sqlite migration replay rejects TEMP schema target .*`,
+		},
+		{
+			name:      "bracketed temp target",
+			statement: `DROP TABLE [temp].users`,
+			wantErr:   `sqlite migration replay rejects TEMP schema target .*`,
+		},
+		{
+			name:      "vacuum into",
+			statement: `VACUUM main INTO 'backup.db'`,
+			wantErr:   `sqlite migration replay rejects VACUUM INTO .*`,
+		},
+		{
+			name:      "load extension",
+			statement: `SELECT load_extension('unsafe')`,
+			wantErr:   `sqlite migration replay rejects load_extension .*`,
+		},
+		{
+			name:      "persistent pragma",
+			statement: `PRAGMA user_version = 42`,
+			wantErr:   `sqlite migration replay rejects state-changing or unsupported PRAGMA .*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := guard.ValidateStatement(test.statement)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}

--- a/internal/devlock/identity_unix.go
+++ b/internal/devlock/identity_unix.go
@@ -1,0 +1,21 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package devlock
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func filesystemIdentity(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("unsupported file metadata for %q", path)
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino), nil
+}

--- a/internal/devlock/identity_windows.go
+++ b/internal/devlock/identity_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package devlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func filesystemIdentity(path string) (identity string, resultErr error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, file.Close())
+	}()
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"%d:%d:%d",
+		info.VolumeSerialNumber,
+		info.FileIndexHigh,
+		info.FileIndexLow,
+	), nil
+}

--- a/internal/devlock/lock.go
+++ b/internal/devlock/lock.go
@@ -1,0 +1,201 @@
+// Package devlock serializes destructive replay work by disposable database
+// realm.
+package devlock
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/dblock"
+)
+
+const (
+	lockRetryInterval     = 25 * time.Millisecond
+	defaultReleaseTimeout = 10 * time.Second
+)
+
+var errLocked = errors.New("dev database realm is locked")
+
+// Lock is an exclusive lock for one disposable database realm.
+type Lock struct {
+	advisory *dblock.Lock
+	file     *os.File
+}
+
+// Acquire locks the selected disposable database realm. A zero timeout waits
+// until ctx is canceled.
+func Acquire(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	timeout time.Duration,
+) (*Lock, error) {
+	if conn == nil {
+		return nil, errors.New("dev database locking requires a database connection")
+	}
+	dialect := platform.NormalizeDialect(conn.Info().Dialect)
+	identity, err := realmIdentity(ctx, conn, dialect)
+	if err != nil {
+		return nil, err
+	}
+	lockName := fmt.Sprintf("ptah-dev-replay:%s:%s", dialect, identity)
+	if dblock.Supported(dialect) {
+		advisory, err := dblock.Acquire(ctx, conn, lockName, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("acquire dev database realm lock: %w", err)
+		}
+		return &Lock{advisory: advisory}, nil
+	}
+	switch dialect {
+	case platform.SQLite, platform.ClickHouse, platform.CockroachDB:
+		file, err := acquireFile(ctx, localLockPath(lockName), timeout)
+		if err != nil {
+			return nil, fmt.Errorf("acquire %s dev database realm lock: %w", dialect, err)
+		}
+		return &Lock{file: file}, nil
+	default:
+		return nil, fmt.Errorf(
+			"%s replay cannot safely serialize destructive dev database use",
+			dialect,
+		)
+	}
+}
+
+// Release releases the realm lock. It uses a bounded background context so a
+// canceled replay does not leak a server advisory lock.
+func (l *Lock) Release() error {
+	if l == nil {
+		return nil
+	}
+	var advisoryErr error
+	if l.advisory != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), defaultReleaseTimeout)
+		advisoryErr = l.advisory.Release(ctx)
+		cancel()
+	}
+	var fileErr error
+	if l.file != nil {
+		fileErr = errors.Join(unlockFile(l.file), l.file.Close())
+	}
+	return errors.Join(advisoryErr, fileErr)
+}
+
+func realmIdentity(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	dialect string,
+) (string, error) {
+	switch dialect {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		var database string
+		if err := conn.QueryRowContext(ctx, "SELECT current_database()").Scan(&database); err != nil {
+			return "", fmt.Errorf("resolve %s dev database realm: %w", dialect, err)
+		}
+		return database, nil
+	case platform.SQLServer:
+		var database string
+		if err := conn.QueryRowContext(ctx, "SELECT DB_NAME()").Scan(&database); err != nil {
+			return "", fmt.Errorf("resolve sqlserver dev database realm: %w", err)
+		}
+		return database, nil
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		database := strings.TrimSpace(conn.Info().Schema)
+		if database == "" {
+			return "", fmt.Errorf("%s dev database realm has no selected database", dialect)
+		}
+		return database, nil
+	case platform.SQLite:
+		return sqliteIdentity(conn.Info().URL)
+	default:
+		return "", fmt.Errorf("unsupported dev database lock dialect %q", dialect)
+	}
+}
+
+func sqliteIdentity(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	path := parsed.Path
+	if parsed.Opaque != "" {
+		path = parsed.Opaque
+	}
+	if parsed.Host != "" {
+		path = parsed.Host + path
+	}
+	if strings.Contains(path, ":memory:") || strings.HasPrefix(path, "file:") {
+		return path, nil
+	}
+	return filepath.Abs(filepath.Clean(path))
+}
+
+func localLockPath(identity string) string {
+	hash := sha256.Sum256([]byte(identity))
+	return filepath.Join(os.TempDir(), "ptah-dev-replay-locks", fmt.Sprintf("%x.lock", hash))
+}
+
+func acquireFile(ctx context.Context, path string, timeout time.Duration) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	startedAt := time.Now()
+	for {
+		file, err := tryAcquireFile(path)
+		if err == nil {
+			return file, nil
+		}
+		if !errors.Is(err, errLocked) {
+			return nil, err
+		}
+		if timeout > 0 && time.Since(startedAt) >= timeout {
+			return nil, fmt.Errorf("lock timeout after %s", timeout)
+		}
+		if err := waitForRetry(ctx, startedAt, timeout); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func tryAcquireFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	locked, err := tryLockFile(file)
+	if err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	if !locked {
+		return nil, errors.Join(errLocked, file.Close())
+	}
+	return file, nil
+}
+
+func waitForRetry(ctx context.Context, startedAt time.Time, timeout time.Duration) error {
+	wait := lockRetryInterval
+	if timeout > 0 {
+		remaining := timeout - time.Since(startedAt)
+		if remaining <= 0 {
+			return nil
+		}
+		wait = min(wait, remaining)
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/devlock/lock.go
+++ b/internal/devlock/lock.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -42,6 +43,12 @@ func Acquire(
 		return nil, errors.New("dev database locking requires a database connection")
 	}
 	dialect := platform.NormalizeDialect(conn.Info().Dialect)
+	switch dialect {
+	case platform.ClickHouse, platform.CockroachDB:
+		if err := validateLocalFileLockURL(dialect, conn.Info().URL); err != nil {
+			return nil, err
+		}
+	}
 	identity, err := realmIdentity(ctx, conn, dialect)
 	if err != nil {
 		return nil, err
@@ -52,7 +59,11 @@ func Acquire(
 		if err != nil {
 			return nil, fmt.Errorf("acquire dev database realm lock: %w", err)
 		}
-		return &Lock{advisory: advisory}, nil
+		lock, err := finishAcquire(ctx, &Lock{advisory: advisory})
+		if err != nil {
+			return nil, fmt.Errorf("acquire dev database realm lock: %w", err)
+		}
+		return lock, nil
 	}
 	switch dialect {
 	case platform.SQLite, platform.ClickHouse, platform.CockroachDB:
@@ -60,7 +71,11 @@ func Acquire(
 		if err != nil {
 			return nil, fmt.Errorf("acquire %s dev database realm lock: %w", dialect, err)
 		}
-		return &Lock{file: file}, nil
+		lock, err := finishAcquire(ctx, &Lock{file: file})
+		if err != nil {
+			return nil, fmt.Errorf("acquire %s dev database realm lock: %w", dialect, err)
+		}
+		return lock, nil
 	default:
 		return nil, fmt.Errorf(
 			"%s replay cannot safely serialize destructive dev database use",
@@ -88,6 +103,14 @@ func (l *Lock) Release() error {
 	return errors.Join(advisoryErr, fileErr)
 }
 
+func finishAcquire(ctx context.Context, lock *Lock) (*Lock, error) {
+	if err := ctx.Err(); err != nil {
+		releaseErr := lock.Release()
+		return nil, errors.Join(err, releaseErr)
+	}
+	return lock, nil
+}
+
 func realmIdentity(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
@@ -113,30 +136,51 @@ func realmIdentity(
 		}
 		return database, nil
 	case platform.SQLite:
-		return sqliteIdentity(conn.Info().URL)
+		return sqliteIdentity(ctx, conn)
 	default:
 		return "", fmt.Errorf("unsupported dev database lock dialect %q", dialect)
 	}
 }
 
-func sqliteIdentity(rawURL string) (string, error) {
+func sqliteIdentity(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) (string, error) {
+	var path string
+	if err := conn.QueryRowContext(
+		ctx,
+		"SELECT file FROM pragma_database_list WHERE name = 'main'",
+	).Scan(&path); err != nil {
+		return "", fmt.Errorf("resolve sqlite dev database realm: %w", err)
+	}
+	if strings.TrimSpace(path) == "" {
+		return ":memory:", nil
+	}
+	identity, err := filesystemIdentity(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve sqlite dev database file identity: %w", err)
+	}
+	return identity, nil
+}
+
+func validateLocalFileLockURL(dialect, rawURL string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return "", err
+		return fmt.Errorf("parse %s dev database URL for local locking: %w", dialect, err)
 	}
-	parsed.RawQuery = ""
-	parsed.Fragment = ""
-	path := parsed.Path
-	if parsed.Opaque != "" {
-		path = parsed.Opaque
+	hostname := strings.TrimSuffix(strings.ToLower(parsed.Hostname()), ".")
+	if hostname == "" || hostname == "localhost" {
+		return nil
 	}
-	if parsed.Host != "" {
-		path = parsed.Host + path
+	ip := net.ParseIP(hostname)
+	if ip != nil && ip.IsLoopback() {
+		return nil
 	}
-	if strings.Contains(path, ":memory:") || strings.HasPrefix(path, "file:") {
-		return path, nil
-	}
-	return filepath.Abs(filepath.Clean(path))
+	return fmt.Errorf(
+		"%s replay cannot safely serialize non-local dev database host %q with a local file lock",
+		dialect,
+		parsed.Hostname(),
+	)
 }
 
 func localLockPath(identity string) string {

--- a/internal/devlock/lock_internal_test.go
+++ b/internal/devlock/lock_internal_test.go
@@ -1,0 +1,119 @@
+package devlock
+
+// White-box testing required: local-file-lock URL eligibility and the
+// post-acquisition cancellation handoff are safety boundaries that cannot be
+// exercised deterministically through exported API without live databases.
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+func TestFinishAcquire_CanceledContextReleasesFileLock(t *testing.T) {
+	c := qt.New(t)
+	path := filepath.Join(t.TempDir(), "realm.lock")
+	file, err := tryAcquireFile(path)
+	c.Assert(err, qt.IsNil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	lock, err := finishAcquire(ctx, &Lock{file: file})
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(lock, qt.IsNil)
+	reacquired, err := tryAcquireFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(errors.Join(unlockFile(reacquired), reacquired.Close()), qt.IsNil)
+}
+
+func TestValidateLocalFileLockURL_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		rawURL  string
+	}{
+		{
+			name:    "clickhouse localhost",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse://user:password@localhost:9000/dev",
+		},
+		{
+			name:    "clickhouse localhost absolute",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse://user:password@localhost.:9000/dev",
+		},
+		{
+			name:    "clickhouse local socket",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse:///dev?address=%2Ftmp%2Fclickhouse.sock",
+		},
+		{
+			name:    "cockroachdb ipv4 loopback",
+			dialect: platform.CockroachDB,
+			rawURL:  "cockroachdb://root@127.0.0.2:26257/defaultdb",
+		},
+		{
+			name:    "cockroachdb ipv6 loopback",
+			dialect: platform.CockroachDB,
+			rawURL:  "cockroachdb://root@[::1]:26257/defaultdb",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(validateLocalFileLockURL(test.dialect, test.rawURL), qt.IsNil)
+		})
+	}
+}
+
+func TestValidateLocalFileLockURL_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		rawURL  string
+		wantErr string
+	}{
+		{
+			name:    "clickhouse remote DNS name",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse://user:password@clickhouse.example.com:9000/dev",
+			wantErr: `clickhouse replay cannot safely serialize non-local dev database host "clickhouse.example.com" with a local file lock`,
+		},
+		{
+			name:    "clickhouse container DNS name",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse://user:password@clickhouse:9000/dev",
+			wantErr: `clickhouse replay cannot safely serialize non-local dev database host "clickhouse" with a local file lock`,
+		},
+		{
+			name:    "cockroachdb private address",
+			dialect: platform.CockroachDB,
+			rawURL:  "cockroachdb://root@10.0.0.12:26257/defaultdb",
+			wantErr: `cockroachdb replay cannot safely serialize non-local dev database host "10.0.0.12" with a local file lock`,
+		},
+		{
+			name:    "malformed URL",
+			dialect: platform.ClickHouse,
+			rawURL:  "clickhouse://local%zzhost/dev",
+			wantErr: `parse clickhouse dev database URL for local locking: .*invalid URL escape.*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(
+				validateLocalFileLockURL(test.dialect, test.rawURL),
+				qt.ErrorMatches,
+				test.wantErr,
+			)
+		})
+	}
+}

--- a/internal/devlock/lock_live_test.go
+++ b/internal/devlock/lock_live_test.go
@@ -1,0 +1,47 @@
+package devlock_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devlock"
+)
+
+func TestAcquire_CockroachDBSerializesSameRealmLive(t *testing.T) {
+	c := qt.New(t)
+	databaseURL := requireCockroachDBURL(c)
+	firstConn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	secondConn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+
+	firstLock, err := devlock.Acquire(c.Context(), firstConn, 0)
+	c.Assert(err, qt.IsNil)
+
+	waitCtx, cancel := context.WithTimeout(c.Context(), 50*time.Millisecond)
+	defer cancel()
+	blockedLock, err := devlock.Acquire(waitCtx, secondConn, 0)
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+	c.Assert(blockedLock, qt.IsNil)
+
+	c.Assert(firstLock.Release(), qt.IsNil)
+	secondLock, err := devlock.Acquire(c.Context(), secondConn, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(secondLock.Release(), qt.IsNil)
+}
+
+func requireCockroachDBURL(c *qt.C) string {
+	c.Helper()
+	databaseURL := os.Getenv("COCKROACHDB_URL")
+	if databaseURL == "" {
+		c.Skip("COCKROACHDB_URL is not set")
+	}
+	return databaseURL
+}

--- a/internal/devlock/lock_symlink_unix_test.go
+++ b/internal/devlock/lock_symlink_unix_test.go
@@ -1,0 +1,48 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package devlock_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devlock"
+)
+
+func TestAcquire_SQLiteSerializesSymlinkAliases(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	databasePath := filepath.Join(dir, "dev.db")
+	aliasPath := filepath.Join(dir, "dev-alias.db")
+	firstConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+databasePath,
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	_, err = firstConn.ExecContext(t.Context(), "CREATE TABLE identity_probe (id INTEGER)")
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Symlink(databasePath, aliasPath), qt.IsNil)
+	secondConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+aliasPath,
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+
+	firstLock, err := devlock.Acquire(t.Context(), firstConn, 0)
+	c.Assert(err, qt.IsNil)
+	waitCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	blockedLock, err := devlock.Acquire(waitCtx, secondConn, 0)
+
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+	c.Assert(blockedLock, qt.IsNil)
+	c.Assert(firstLock.Release(), qt.IsNil)
+}

--- a/internal/devlock/lock_test.go
+++ b/internal/devlock/lock_test.go
@@ -1,0 +1,62 @@
+package devlock_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devlock"
+)
+
+func TestAcquire_SQLiteSerializesSameRealm(t *testing.T) {
+	c := qt.New(t)
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	firstConn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	secondConn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+
+	firstLock, err := devlock.Acquire(t.Context(), firstConn, 0)
+	c.Assert(err, qt.IsNil)
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	blockedLock, err := devlock.Acquire(waitCtx, secondConn, 0)
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+	c.Assert(blockedLock, qt.IsNil)
+
+	c.Assert(firstLock.Release(), qt.IsNil)
+	secondLock, err := devlock.Acquire(t.Context(), secondConn, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(secondLock.Release(), qt.IsNil)
+}
+
+func TestAcquire_SQLiteSeparatesDifferentRealms(t *testing.T) {
+	c := qt.New(t)
+	firstConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "first.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	secondConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "second.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+
+	firstLock, err := devlock.Acquire(t.Context(), firstConn, 0)
+	c.Assert(err, qt.IsNil)
+	secondLock, err := devlock.Acquire(t.Context(), secondConn, 0)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(secondLock.Release(), qt.IsNil)
+	c.Assert(firstLock.Release(), qt.IsNil)
+}

--- a/internal/devlock/lock_test.go
+++ b/internal/devlock/lock_test.go
@@ -2,6 +2,7 @@ package devlock_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -58,5 +59,37 @@ func TestAcquire_SQLiteSeparatesDifferentRealms(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(secondLock.Release(), qt.IsNil)
+	c.Assert(firstLock.Release(), qt.IsNil)
+}
+
+func TestAcquire_SQLiteSerializesHardLinkAliases(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	databasePath := filepath.Join(dir, "dev.db")
+	aliasPath := filepath.Join(dir, "dev-alias.db")
+	firstConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+databasePath,
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	_, err = firstConn.ExecContext(t.Context(), "CREATE TABLE identity_probe (id INTEGER)")
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Link(databasePath, aliasPath), qt.IsNil)
+	secondConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+aliasPath,
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+
+	firstLock, err := devlock.Acquire(t.Context(), firstConn, 0)
+	c.Assert(err, qt.IsNil)
+	waitCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	blockedLock, err := devlock.Acquire(waitCtx, secondConn, 0)
+
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+	c.Assert(blockedLock, qt.IsNil)
 	c.Assert(firstLock.Release(), qt.IsNil)
 }

--- a/internal/devlock/lock_test.go
+++ b/internal/devlock/lock_test.go
@@ -10,12 +10,13 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/devlock"
 )
 
 func TestAcquire_SQLiteSerializesSameRealm(t *testing.T) {
 	c := qt.New(t)
-	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	devURL := atlasurl.SQLiteURLFromPath(filepath.Join(t.TempDir(), "dev.db"))
 	firstConn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(firstConn)
@@ -42,13 +43,13 @@ func TestAcquire_SQLiteSeparatesDifferentRealms(t *testing.T) {
 	c := qt.New(t)
 	firstConn, err := dbschema.ConnectToDatabase(
 		t.Context(),
-		"sqlite://"+filepath.Join(t.TempDir(), "first.db"),
+		atlasurl.SQLiteURLFromPath(filepath.Join(t.TempDir(), "first.db")),
 	)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(firstConn)
 	secondConn, err := dbschema.ConnectToDatabase(
 		t.Context(),
-		"sqlite://"+filepath.Join(t.TempDir(), "second.db"),
+		atlasurl.SQLiteURLFromPath(filepath.Join(t.TempDir(), "second.db")),
 	)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(secondConn)
@@ -69,7 +70,7 @@ func TestAcquire_SQLiteSerializesHardLinkAliases(t *testing.T) {
 	aliasPath := filepath.Join(dir, "dev-alias.db")
 	firstConn, err := dbschema.ConnectToDatabase(
 		t.Context(),
-		"sqlite://"+databasePath,
+		atlasurl.SQLiteURLFromPath(databasePath),
 	)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(firstConn)
@@ -78,7 +79,7 @@ func TestAcquire_SQLiteSerializesHardLinkAliases(t *testing.T) {
 	c.Assert(os.Link(databasePath, aliasPath), qt.IsNil)
 	secondConn, err := dbschema.ConnectToDatabase(
 		t.Context(),
-		"sqlite://"+aliasPath,
+		atlasurl.SQLiteURLFromPath(aliasPath),
 	)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(secondConn)

--- a/internal/devlock/lock_unix.go
+++ b/internal/devlock/lock_unix.go
@@ -1,0 +1,29 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package devlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockFile(file *os.File) (bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock dev database realm: %w", err)
+	}
+	return true, nil
+}
+
+func unlockFile(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock dev database realm: %w", err)
+	}
+	return nil
+}

--- a/internal/devlock/lock_windows.go
+++ b/internal/devlock/lock_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package devlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockFile(file *os.File) (bool, error) {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock dev database realm: %w", err)
+	}
+	return true, nil
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(
+		windows.Handle(file.Fd()),
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("unlock dev database realm: %w", err)
+	}
+	return nil
+}

--- a/internal/fsdurable/doc.go
+++ b/internal/fsdurable/doc.go
@@ -1,0 +1,3 @@
+// Package fsdurable provides filesystem operations for durable artifact
+// publication across supported operating systems.
+package fsdurable

--- a/internal/fsdurable/move_nonwindows.go
+++ b/internal/fsdurable/move_nonwindows.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package fsdurable
+
+import (
+	"errors"
+	"os"
+)
+
+// MoveFileNoReplace publishes oldPath at newPath without replacing an
+// existing entry. Callers must sync the containing directory afterwards.
+func MoveFileNoReplace(oldPath, newPath string) error {
+	if err := os.Link(oldPath, newPath); err != nil {
+		return err
+	}
+	if err := os.Remove(oldPath); err != nil {
+		return errors.Join(err, os.Remove(newPath))
+	}
+	return nil
+}

--- a/internal/fsdurable/move_test.go
+++ b/internal/fsdurable/move_test.go
@@ -1,0 +1,47 @@
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestMoveFileNoReplace_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	oldPath := filepath.Join(dir, "staged")
+	newPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(oldPath, []byte("contents"), 0o600), qt.IsNil)
+
+	err := fsdurable.MoveFileNoReplace(oldPath, newPath)
+
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(oldPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(newPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "contents")
+}
+
+func TestMoveFileNoReplace_RefusesExistingDestination(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	oldPath := filepath.Join(dir, "staged")
+	newPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(oldPath, []byte("new"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(newPath, []byte("existing"), 0o600), qt.IsNil)
+
+	err := fsdurable.MoveFileNoReplace(oldPath, newPath)
+
+	c.Assert(err, qt.IsNotNil)
+	oldContents, readErr := os.ReadFile(oldPath)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(oldContents), qt.Equals, "new")
+	newContents, readErr := os.ReadFile(newPath)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(newContents), qt.Equals, "existing")
+}

--- a/internal/fsdurable/move_windows.go
+++ b/internal/fsdurable/move_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package fsdurable
+
+import "golang.org/x/sys/windows"
+
+// MoveFileNoReplace atomically publishes oldPath at newPath without replacing
+// an existing entry and asks Windows to flush the move before returning.
+func MoveFileNoReplace(oldPath, newPath string) error {
+	oldPathPtr, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPathPtr, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		oldPathPtr,
+		newPathPtr,
+		windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/internal/fsdurable/replace_nonwindows.go
+++ b/internal/fsdurable/replace_nonwindows.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package fsdurable
+
+import "os"
+
+// ReplaceFile atomically replaces newPath with oldPath.
+func ReplaceFile(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}

--- a/internal/fsdurable/replace_windows.go
+++ b/internal/fsdurable/replace_windows.go
@@ -1,0 +1,21 @@
+package fsdurable
+
+import "golang.org/x/sys/windows"
+
+// ReplaceFile atomically replaces newPath with oldPath and asks Windows to
+// flush the move to stable storage before returning.
+func ReplaceFile(oldPath, newPath string) error {
+	oldPathPtr, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPathPtr, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		oldPathPtr,
+		newPathPtr,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/internal/fsdurable/sync.go
+++ b/internal/fsdurable/sync.go
@@ -1,0 +1,16 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// SyncDir flushes directory-entry changes for dir to stable storage.
+func SyncDir(dir string) error {
+	handle, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open directory for sync: %w", err)
+	}
+	return errors.Join(handle.Sync(), handle.Close())
+}

--- a/internal/fsdurable/sync_nonwindows.go
+++ b/internal/fsdurable/sync_nonwindows.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package fsdurable
 
 import (

--- a/internal/fsdurable/sync_nonwindows_test.go
+++ b/internal/fsdurable/sync_nonwindows_test.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestSyncDir_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	err := fsdurable.SyncDir(filepath.Join(c.TempDir(), "missing"))
+
+	c.Assert(err, qt.ErrorMatches, `open directory for sync: .*`)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}

--- a/internal/fsdurable/sync_test.go
+++ b/internal/fsdurable/sync_test.go
@@ -1,0 +1,28 @@
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestSyncDir_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "entry"), []byte("value"), 0o600), qt.IsNil)
+
+	c.Assert(fsdurable.SyncDir(dir), qt.IsNil)
+}
+
+func TestSyncDir_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	err := fsdurable.SyncDir(filepath.Join(c.TempDir(), "missing"))
+
+	c.Assert(err, qt.ErrorMatches, `open directory for sync: .*`)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}

--- a/internal/fsdurable/sync_test.go
+++ b/internal/fsdurable/sync_test.go
@@ -17,12 +17,3 @@ func TestSyncDir_HappyPath(t *testing.T) {
 
 	c.Assert(fsdurable.SyncDir(dir), qt.IsNil)
 }
-
-func TestSyncDir_FailurePath(t *testing.T) {
-	c := qt.New(t)
-
-	err := fsdurable.SyncDir(filepath.Join(c.TempDir(), "missing"))
-
-	c.Assert(err, qt.ErrorMatches, `open directory for sync: .*`)
-	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-}

--- a/internal/fsdurable/sync_windows.go
+++ b/internal/fsdurable/sync_windows.go
@@ -1,0 +1,8 @@
+package fsdurable
+
+// SyncDir is a no-op on Windows because FlushFileBuffers does not support
+// directory handles. Callers sync file contents before publication and use
+// write-through replacement for commit-marker renames.
+func SyncDir(string) error {
+	return nil
+}

--- a/internal/fsnapshot/snapshot.go
+++ b/internal/fsnapshot/snapshot.go
@@ -108,6 +108,12 @@ func (s Snapshot) Clone() Snapshot {
 	return cloned
 }
 
+// Equal reports whether both snapshots contain exactly the same paths and
+// bytes.
+func (s Snapshot) Equal(other Snapshot) bool {
+	return maps.EqualFunc(s.files, other.files, bytes.Equal)
+}
+
 func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Snapshot {
 	filtered := Snapshot{files: make(map[string][]byte, len(s.files))}
 	for _, name := range slices.Sorted(maps.Keys(s.files)) {

--- a/internal/fsnapshot/snapshot.go
+++ b/internal/fsnapshot/snapshot.go
@@ -114,6 +114,20 @@ func (s Snapshot) Equal(other Snapshot) bool {
 	return maps.EqualFunc(s.files, other.files, bytes.Equal)
 }
 
+// WithFiles returns a new immutable snapshot with files added or replaced.
+// Paths and contents are validated and cloned; the receiver is unchanged.
+func (s Snapshot) WithFiles(files map[string][]byte) (Snapshot, error) {
+	combined := make(map[string][]byte, len(s.files)+len(files))
+	maps.Copy(combined, s.files)
+	for name, contents := range files {
+		combined[name] = slices.Clone(contents)
+	}
+	if err := validateFilePaths(combined); err != nil {
+		return Snapshot{}, err
+	}
+	return Snapshot{files: combined}, nil
+}
+
 func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Snapshot {
 	filtered := Snapshot{files: make(map[string][]byte, len(s.files))}
 	for _, name := range slices.Sorted(maps.Keys(s.files)) {

--- a/internal/fsnapshot/snapshot_test.go
+++ b/internal/fsnapshot/snapshot_test.go
@@ -58,6 +58,30 @@ func TestCapture_ClonesExistingSnapshotWithoutReadingSourceAgain(t *testing.T) {
 	c.Assert(secondContents, qt.DeepEquals, firstContents)
 }
 
+func TestSnapshotEqualComparesPathsAndContents(t *testing.T) {
+	c := qt.New(t)
+	left, err := fsnapshot.FromFiles(map[string][]byte{
+		"1.sql": []byte("SELECT 1;\n"),
+	})
+	c.Assert(err, qt.IsNil)
+	equal, err := fsnapshot.FromFiles(map[string][]byte{
+		"1.sql": []byte("SELECT 1;\n"),
+	})
+	c.Assert(err, qt.IsNil)
+	differentContents, err := fsnapshot.FromFiles(map[string][]byte{
+		"1.sql": []byte("SELECT 2;\n"),
+	})
+	c.Assert(err, qt.IsNil)
+	differentPaths, err := fsnapshot.FromFiles(map[string][]byte{
+		"2.sql": []byte("SELECT 1;\n"),
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(left.Equal(equal), qt.IsTrue)
+	c.Assert(left.Equal(differentContents), qt.IsFalse)
+	c.Assert(left.Equal(differentPaths), qt.IsFalse)
+}
+
 func TestFromFiles_ClonesInput(t *testing.T) {
 	c := qt.New(t)
 	files := map[string][]byte{

--- a/internal/fsnapshot/snapshot_test.go
+++ b/internal/fsnapshot/snapshot_test.go
@@ -82,6 +82,26 @@ func TestSnapshotEqualComparesPathsAndContents(t *testing.T) {
 	c.Assert(left.Equal(differentPaths), qt.IsFalse)
 }
 
+func TestSnapshotWithFilesReturnsIndependentOverlay(t *testing.T) {
+	c := qt.New(t)
+	original, err := fsnapshot.FromFiles(map[string][]byte{
+		"1_initial.sql": []byte("SELECT 1;"),
+	})
+	c.Assert(err, qt.IsNil)
+	added := []byte("SELECT 2;")
+
+	overlay, err := original.WithFiles(map[string][]byte{"2_next.sql": added})
+	c.Assert(err, qt.IsNil)
+	added[0] = 'X'
+
+	originalEntries, err := fs.ReadDir(original, ".")
+	c.Assert(err, qt.IsNil)
+	c.Assert(originalEntries, qt.HasLen, 1)
+	contents, err := fs.ReadFile(overlay, "2_next.sql")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "SELECT 2;")
+}
+
 func TestFromFiles_ClonesInput(t *testing.T) {
 	c := qt.New(t)
 	files := map[string][]byte{

--- a/internal/migratesum/io.go
+++ b/internal/migratesum/io.go
@@ -34,6 +34,48 @@ func WriteWithFormat(dir string, format migrator.MigrationDirFormat) (*SumFile, 
 	return sum, nil
 }
 
+// WritePrecomputedWithFormat writes sum to the integrity file selected by
+// format without reading the live migration directory again.
+func WritePrecomputedWithFormat(
+	dir string,
+	format migrator.MigrationDirFormat,
+	sum *SumFile,
+) error {
+	if sum == nil {
+		return errors.New("migration checksum must not be nil")
+	}
+	name, err := FileNameForFormat(format)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomicSumFile(filepath.Join(dir, name), sum.Bytes()); err != nil {
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+	return nil
+}
+
+// CommitUncertainError reports that the checksum file was atomically replaced
+// but syncing the containing directory failed. The visible checksum may be the
+// old or new commit marker after a crash, so callers must retain recovery state.
+type CommitUncertainError struct {
+	Err error
+}
+
+func (e *CommitUncertainError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *CommitUncertainError) Unwrap() error {
+	return e.Err
+}
+
+// IsCommitUncertain reports whether err means the checksum rename succeeded
+// but its directory durability could not be confirmed.
+func IsCommitUncertain(err error) bool {
+	var target *CommitUncertainError
+	return errors.As(err, &target)
+}
+
 func writeAtomicSumFile(path string, contents []byte) error {
 	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
 	if err != nil {
@@ -55,10 +97,13 @@ func writeAtomicSumFile(path string, contents []byte) error {
 	if err := file.Close(); err != nil {
 		return errors.Join(err, removeFile(tempPath))
 	}
-	if err := os.Rename(tempPath, path); err != nil {
+	if err := fsdurable.ReplaceFile(tempPath, path); err != nil {
 		return errors.Join(err, removeFile(tempPath))
 	}
-	return fsdurable.SyncDir(filepath.Dir(path))
+	if err := fsdurable.SyncDir(filepath.Dir(path)); err != nil {
+		return &CommitUncertainError{Err: err}
+	}
+	return nil
 }
 
 func removeFile(path string) error {

--- a/internal/migratesum/io.go
+++ b/internal/migratesum/io.go
@@ -1,10 +1,12 @@
 package migratesum
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -26,13 +28,45 @@ func WriteWithFormat(dir string, format migrator.MigrationDirFormat) (*SumFile, 
 	if err != nil {
 		return nil, err
 	}
-	// The sum file is committed alongside the migrations and read by everyone
-	// who checks out the repo, so it uses the same 0644 as generated migration
-	// files rather than a private 0600.
-	if err := os.WriteFile(filepath.Join(dir, name), sum.Bytes(), 0644); err != nil { //nolint:gosec // 0644 is fine
+	if err := writeAtomicSumFile(filepath.Join(dir, name), sum.Bytes()); err != nil {
 		return nil, fmt.Errorf("failed to write %s: %w", name, err)
 	}
 	return sum, nil
+}
+
+func writeAtomicSumFile(path string, contents []byte) error {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := file.Name()
+
+	// The sum file is committed alongside migrations and checked in, so it
+	// uses the same 0644 permissions as generated migration files.
+	if err := file.Chmod(0644); err != nil {
+		return errors.Join(err, file.Close(), removeFile(tempPath))
+	}
+	if _, err := file.Write(contents); err != nil {
+		return errors.Join(err, file.Close(), removeFile(tempPath))
+	}
+	if err := file.Sync(); err != nil {
+		return errors.Join(err, file.Close(), removeFile(tempPath))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(err, removeFile(tempPath))
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return errors.Join(err, removeFile(tempPath))
+	}
+	return fsdurable.SyncDir(filepath.Dir(path))
+}
+
+func removeFile(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // VerifyDir verifies the migrations directory at dir against its ptah.sum.

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -4,16 +4,20 @@ package migrationreplay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/migration/migrator"
 )
+
+const failedReplayCleanupTimeout = 30 * time.Second
 
 // Options configures a migration replay run.
 type Options struct {
@@ -65,6 +69,21 @@ func ReplayOnConnection(
 	if err != nil {
 		return fmt.Errorf("capture migration directory: %w", err)
 	}
+	return ReplaySnapshotOnConnection(ctx, conn, snapshot, dirFormat)
+}
+
+// ReplaySnapshotOnConnection replays one immutable migration filesystem on an
+// already-open dev database connection.
+func ReplaySnapshotOnConnection(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	snapshot fs.FS,
+	dirFormat migrator.MigrationDirFormat,
+) error {
+	snapshot, err := migrationsnapshot.Capture(snapshot)
+	if err != nil {
+		return fmt.Errorf("capture migration snapshot: %w", err)
+	}
 	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil)
 }
 
@@ -74,7 +93,7 @@ func replayOnConnection(
 	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
 	atlasTemplateData any,
-) error {
+) (resultErr error) {
 	provider, err := migrator.NewFSMigrationProvider(
 		fsys,
 		migrator.WithMigrationDirFormat(dirFormat),
@@ -84,6 +103,20 @@ func replayOnConnection(
 		return fmt.Errorf("load migration directory: %w", err)
 	}
 	migrations := provider.Migrations()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	replaySucceeded := false
+	defer func() {
+		if replaySucceeded {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failedReplayCleanupTimeout)
+		defer cancel()
+		if cleanupErr := conn.SchemaWriter().DropAllTables(cleanupCtx); cleanupErr != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("clean dev database after failed replay: %w", cleanupErr))
+		}
+	}()
 	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return fmt.Errorf("clean dev database: %w", err)
 	}
@@ -92,6 +125,7 @@ func replayOnConnection(
 			return fmt.Errorf("replay migration %d on dev database: %w", migration.Version, err)
 		}
 	}
+	replaySucceeded = true
 	return nil
 }
 

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -12,7 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devclean"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -54,7 +57,7 @@ func Replay(ctx context.Context, opts Options) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	return replayOnConnection(ctx, conn, snapshot, opts.DirFormat, opts.AtlasTemplateData)
+	return replayOnConnection(ctx, conn, snapshot, opts.DirFormat, opts.AtlasTemplateData, nil)
 }
 
 // ReplayOnConnection replays the migration directory on an already-open dev
@@ -72,6 +75,23 @@ func ReplayOnConnection(
 	return ReplaySnapshotOnConnection(ctx, conn, snapshot, dirFormat)
 }
 
+// WithReplayedDirectory replays one migration directory, invokes consume while
+// the replayed database is bound to the same physical session, and cleans the
+// database realm before returning.
+func WithReplayedDirectory(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	dir string,
+	dirFormat migrator.MigrationDirFormat,
+	consume func(*dbschema.DatabaseConnection) error,
+) error {
+	snapshot, err := migrationsnapshot.Capture(os.DirFS(dir))
+	if err != nil {
+		return fmt.Errorf("capture migration directory: %w", err)
+	}
+	return WithReplayedSnapshot(ctx, conn, snapshot, dirFormat, consume)
+}
+
 // ReplaySnapshotOnConnection replays one immutable migration filesystem on an
 // already-open dev database connection.
 func ReplaySnapshotOnConnection(
@@ -84,7 +104,47 @@ func ReplaySnapshotOnConnection(
 	if err != nil {
 		return fmt.Errorf("capture migration snapshot: %w", err)
 	}
-	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil)
+	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, nil)
+}
+
+// WithReplayedSnapshot replays one immutable migration filesystem, invokes
+// consume while the replayed database is bound to the same physical session,
+// and cleans the database realm before returning.
+func WithReplayedSnapshot(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	snapshot fs.FS,
+	dirFormat migrator.MigrationDirFormat,
+	consume func(*dbschema.DatabaseConnection) error,
+) error {
+	if consume == nil {
+		return fmt.Errorf("consume replayed database callback is nil")
+	}
+	snapshot, err := migrationsnapshot.Capture(snapshot)
+	if err != nil {
+		return fmt.Errorf("capture migration snapshot: %w", err)
+	}
+	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, consume)
+}
+
+// WithReplayedSnapshotLocked performs the same replay as
+// [WithReplayedSnapshot] while relying on the caller to hold the dev database
+// realm lock across a larger operation.
+func WithReplayedSnapshotLocked(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	snapshot fs.FS,
+	dirFormat migrator.MigrationDirFormat,
+	consume func(*dbschema.DatabaseConnection) error,
+) error {
+	if consume == nil {
+		return fmt.Errorf("consume replayed database callback is nil")
+	}
+	snapshot, err := migrationsnapshot.Capture(snapshot)
+	if err != nil {
+		return fmt.Errorf("capture migration snapshot: %w", err)
+	}
+	return replayOnLockedConnection(ctx, conn, snapshot, dirFormat, nil, consume)
 }
 
 func replayOnConnection(
@@ -93,31 +153,83 @@ func replayOnConnection(
 	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
 	atlasTemplateData any,
+	consume func(*dbschema.DatabaseConnection) error,
 ) (resultErr error) {
+	if conn == nil {
+		return fmt.Errorf("replay migrations: nil database connection")
+	}
+	lock, err := devlock.Acquire(ctx, conn, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, lock.Release())
+	}()
+	return replayOnLockedConnection(ctx, conn, fsys, dirFormat, atlasTemplateData, consume)
+}
+
+func replayOnLockedConnection(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	fsys fs.FS,
+	dirFormat migrator.MigrationDirFormat,
+	atlasTemplateData any,
+	consume func(*dbschema.DatabaseConnection) error,
+) error {
+	if conn == nil {
+		return fmt.Errorf("replay migrations: nil database connection")
+	}
 	provider, err := migrator.NewFSMigrationProvider(
 		fsys,
 		migrator.WithMigrationDirFormat(dirFormat),
 		migrator.WithAtlasTemplateData(atlasTemplateData),
+		migrator.WithStatementValidator(devclean.NewReplayGuard(conn.Info())),
 	)
 	if err != nil {
 		return fmt.Errorf("load migration directory: %w", err)
 	}
 	migrations := provider.Migrations()
+	return conn.WithSession(ctx, func(replayConn *dbschema.DatabaseConnection) (resultErr error) {
+		restoreSession, err := captureReplaySessionState(ctx, replayConn)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failedReplayCleanupTimeout)
+			defer cancel()
+			resultErr = errors.Join(resultErr, restoreSession(restoreCtx))
+		}()
+		return replayMigrations(
+			ctx,
+			replayConn,
+			migrations,
+			consume,
+		)
+	})
+}
+
+func replayMigrations(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migrations []*migrator.Migration,
+	consume func(*dbschema.DatabaseConnection) error,
+) (resultErr error) {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	replaySucceeded := false
 	defer func() {
-		if replaySucceeded {
-			return
-		}
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), failedReplayCleanupTimeout)
 		defer cancel()
-		if cleanupErr := conn.SchemaWriter().DropAllTables(cleanupCtx); cleanupErr != nil {
-			resultErr = errors.Join(resultErr, fmt.Errorf("clean dev database after failed replay: %w", cleanupErr))
+		if cleanupErr := devclean.DatabaseRealm(cleanupCtx, conn); cleanupErr != nil {
+			label := "clean dev database after replay"
+			if !replaySucceeded {
+				label = "clean dev database after failed replay"
+			}
+			resultErr = errors.Join(resultErr, fmt.Errorf("%s: %w", label, cleanupErr))
 		}
 	}()
-	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
+	if err := devclean.DatabaseRealm(ctx, conn); err != nil {
 		return fmt.Errorf("clean dev database: %w", err)
 	}
 	for _, migration := range migrations {
@@ -125,8 +237,37 @@ func replayOnConnection(
 			return fmt.Errorf("replay migration %d on dev database: %w", migration.Version, err)
 		}
 	}
+	if consume != nil {
+		if err := consume(conn); err != nil {
+			return err
+		}
+	}
 	replaySucceeded = true
 	return nil
+}
+
+func captureReplaySessionState(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) (func(context.Context) error, error) {
+	if platform.NormalizeDialect(conn.Info().Dialect) != platform.SQLite {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	var foreignKeysEnabled bool
+	if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeysEnabled); err != nil {
+		return nil, fmt.Errorf("capture SQLite foreign key state before migration replay: %w", err)
+	}
+	return func(restoreCtx context.Context) error {
+		statement := "PRAGMA foreign_keys = OFF"
+		if foreignKeysEnabled {
+			statement = "PRAGMA foreign_keys = ON"
+		}
+		if _, err := conn.ExecContext(restoreCtx, statement); err != nil {
+			return fmt.Errorf("restore SQLite foreign key state after migration replay: %w", err)
+		}
+		return nil
+	}, nil
 }
 
 func isDockerURL(rawURL string) bool {

--- a/internal/migrationreplay/replay_realm_live_test.go
+++ b/internal/migrationreplay/replay_realm_live_test.go
@@ -1,0 +1,270 @@
+//go:build integration
+
+package migrationreplay_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/migrationreplay"
+	"github.com/stokaro/ptah/internal/sqlident"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestWithReplayedSnapshot_ClickHouseLive(t *testing.T) {
+	c := qt.New(t)
+	admin, realm, database := openClickHouseReplayRealm(t)
+	snapshot := fstest.MapFS{
+		"1_realm.sql": {
+			Data: []byte(`
+CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id;
+CREATE VIEW event_ids AS SELECT id FROM events;
+CREATE MATERIALIZED VIEW event_rollup ENGINE = MergeTree ORDER BY id AS SELECT id FROM events;
+`),
+		},
+	}
+
+	err := migrationreplay.WithReplayedSnapshot(
+		t.Context(),
+		realm,
+		snapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(conn *dbschema.DatabaseConnection) error {
+			var objectCount uint64
+			queryErr := conn.QueryRowContext(
+				t.Context(),
+				`SELECT count()
+				 FROM system.tables
+				 WHERE database = ?
+				   AND name IN ('events', 'event_ids', 'event_rollup')`,
+				database,
+			).Scan(&objectCount)
+			c.Assert(queryErr, qt.IsNil)
+			c.Assert(objectCount, qt.Equals, uint64(3))
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	var objectCount uint64
+	err = realm.QueryRowContext(
+		t.Context(),
+		"SELECT count() FROM system.tables WHERE database = ? AND is_temporary = 0",
+		database,
+	).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, uint64(0))
+
+	escapedDatabase := fmt.Sprintf("ptah_replay_escape_%d", time.Now().UnixNano())
+	unsafeSnapshot := fstest.MapFS{
+		"2_unsafe.sql": {
+			Data: []byte(
+				"CREATE TABLE local_first (id UInt64) ENGINE = MergeTree ORDER BY id;\n" +
+					"CREATE DATABASE " + sqlident.Quote(platform.ClickHouse, escapedDatabase) + ";\n",
+			),
+		},
+	}
+
+	err = migrationreplay.WithReplayedSnapshot(
+		t.Context(),
+		realm,
+		unsafeSnapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(*dbschema.DatabaseConnection) error {
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Contains,
+		"clickhouse migration replay rejects CREATE DATABASE because its effects cannot be confined to the disposable database realm",
+	)
+	err = realm.QueryRowContext(
+		t.Context(),
+		"SELECT count() FROM system.tables WHERE database = ? AND is_temporary = 0",
+		database,
+	).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, uint64(0))
+	var escapedCount uint64
+	err = admin.QueryRowContext(
+		t.Context(),
+		"SELECT count() FROM system.databases WHERE name = ?",
+		escapedDatabase,
+	).Scan(&escapedCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(escapedCount, qt.Equals, uint64(0))
+}
+
+func TestWithReplayedSnapshot_SQLServerLive(t *testing.T) {
+	c := qt.New(t)
+	admin, realm := openSQLServerReplayRealm(t)
+	snapshot := fstest.MapFS{
+		"1_realm.sql": {
+			Data: []byte(`
+CREATE SCHEMA app;
+CREATE TABLE app.events (id BIGINT PRIMARY KEY);
+CREATE VIEW app.event_ids AS SELECT id FROM app.events;
+CREATE SEQUENCE app.event_sequence AS BIGINT START WITH 1;
+`),
+		},
+	}
+
+	err := migrationreplay.WithReplayedSnapshot(
+		t.Context(),
+		realm,
+		snapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(conn *dbschema.DatabaseConnection) error {
+			var objectCount int
+			queryErr := conn.QueryRowContext(t.Context(), `
+SELECT COUNT(*)
+FROM sys.objects
+WHERE is_ms_shipped = 0
+  AND type IN ('U', 'V', 'SO')
+`).Scan(&objectCount)
+			c.Assert(queryErr, qt.IsNil)
+			c.Assert(objectCount, qt.Equals, 3)
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	var objectCount int
+	err = realm.QueryRowContext(t.Context(), `
+SELECT COUNT(*)
+FROM sys.objects
+WHERE is_ms_shipped = 0
+  AND type IN ('U', 'V', 'SO')
+`).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, 0)
+
+	escapedDatabase := fmt.Sprintf("ptah_replay_escape_%d", time.Now().UnixNano())
+	unsafeSnapshot := fstest.MapFS{
+		"2_unsafe.sql": {
+			Data: []byte(
+				"CREATE TABLE dbo.local_first (id BIGINT PRIMARY KEY);\n" +
+					"CREATE DATABASE " + sqlident.Quote(platform.SQLServer, escapedDatabase) + ";\n",
+			),
+		},
+	}
+
+	err = migrationreplay.WithReplayedSnapshot(
+		t.Context(),
+		realm,
+		unsafeSnapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(*dbschema.DatabaseConnection) error {
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Contains,
+		"sqlserver migration replay rejects CREATE DATABASE because its effects cannot be confined to the disposable database realm",
+	)
+	err = realm.QueryRowContext(t.Context(), `
+SELECT COUNT(*)
+FROM sys.objects
+WHERE is_ms_shipped = 0
+  AND type IN ('U', 'V', 'SO')
+`).Scan(&objectCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(objectCount, qt.Equals, 0)
+	var escapedCount int
+	err = admin.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM sys.databases WHERE name = @p1",
+		escapedDatabase,
+	).Scan(&escapedCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(escapedCount, qt.Equals, 0)
+}
+
+func openClickHouseReplayRealm(
+	t *testing.T,
+) (*dbschema.DatabaseConnection, *dbschema.DatabaseConnection, string) {
+	t.Helper()
+	adminURL, configured := os.LookupEnv("PTAH_CLICKHOUSE_REALM_TEST_URL")
+	if !configured {
+		t.Skip("PTAH_CLICKHOUSE_REALM_TEST_URL is not configured")
+	}
+	admin, err := dbschema.ConnectToDatabase(t.Context(), adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	database := fmt.Sprintf("ptah_replay_%d", time.Now().UnixNano())
+	quotedDatabase := sqlident.Quote(platform.ClickHouse, database)
+	_, err = admin.ExecContext(t.Context(), "CREATE DATABASE "+quotedDatabase)
+	qt.Assert(t, err, qt.IsNil)
+
+	parsedURL, err := url.Parse(adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	parsedURL.Path = "/" + database
+	parsedURL.RawPath = ""
+	realm, err := dbschema.ConnectToDatabase(t.Context(), parsedURL.String())
+	qt.Assert(t, err, qt.IsNil)
+
+	t.Cleanup(func() {
+		qt.Check(t, realm.Close(), qt.IsNil)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, cleanupErr := admin.ExecContext(
+			cleanupCtx,
+			"DROP DATABASE IF EXISTS "+quotedDatabase+" SYNC",
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, admin.Close(), qt.IsNil)
+	})
+	return admin, realm, database
+}
+
+func openSQLServerReplayRealm(
+	t *testing.T,
+) (*dbschema.DatabaseConnection, *dbschema.DatabaseConnection) {
+	t.Helper()
+	adminURL, configured := os.LookupEnv("PTAH_SQLSERVER_REALM_TEST_URL")
+	if !configured {
+		t.Skip("PTAH_SQLSERVER_REALM_TEST_URL is not configured")
+	}
+	admin, err := dbschema.ConnectToDatabase(t.Context(), adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	database := fmt.Sprintf("ptah_replay_%d", time.Now().UnixNano())
+	quotedDatabase := sqlident.Quote(platform.SQLServer, database)
+	_, err = admin.ExecContext(t.Context(), "CREATE DATABASE "+quotedDatabase)
+	qt.Assert(t, err, qt.IsNil)
+
+	parsedURL, err := url.Parse(adminURL)
+	qt.Assert(t, err, qt.IsNil)
+	query := parsedURL.Query()
+	query.Set("database", database)
+	parsedURL.RawQuery = query.Encode()
+	realm, err := dbschema.ConnectToDatabase(t.Context(), parsedURL.String())
+	qt.Assert(t, err, qt.IsNil)
+
+	t.Cleanup(func() {
+		qt.Check(t, realm.Close(), qt.IsNil)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, cleanupErr := admin.ExecContext(
+			cleanupCtx,
+			"ALTER DATABASE "+quotedDatabase+" SET SINGLE_USER WITH ROLLBACK IMMEDIATE; "+
+				"DROP DATABASE "+quotedDatabase,
+		)
+		qt.Check(t, cleanupErr, qt.IsNil)
+		qt.Check(t, admin.Close(), qt.IsNil)
+	})
+	return admin, realm
+}

--- a/internal/migrationreplay/replay_test.go
+++ b/internal/migrationreplay/replay_test.go
@@ -2,10 +2,12 @@ package migrationreplay_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -31,30 +33,26 @@ func TestReplayCleansDevDatabaseAndIgnoresExistingRevisionRows(t *testing.T) {
 	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "1_create_replay_runs.sql"),
 		[]byte("CREATE TABLE replay_runs (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
 
-	err := migrationreplay.Replay(context.Background(), migrationreplay.Options{
-		Dir:       migrationsDir,
-		DirFormat: migrator.MigrationDirFormatAtlas,
-		DevURL:    "sqlite://" + devDBPath,
-	})
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "sqlite://"+devDBPath)
 	c.Assert(err, qt.IsNil)
-
-	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+devDBPath)
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE stale_replay_runs (id INTEGER PRIMARY KEY)")
 	c.Assert(err, qt.IsNil)
-	_, err = conn.ExecContext(context.Background(), "INSERT INTO replay_runs (id) VALUES (1)")
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE schema_migrations (version BIGINT NOT NULL PRIMARY KEY)")
 	c.Assert(err, qt.IsNil)
-	_, err = conn.ExecContext(context.Background(), "CREATE TABLE schema_migrations (version BIGINT NOT NULL PRIMARY KEY)")
-	c.Assert(err, qt.IsNil)
-	_, err = conn.ExecContext(context.Background(), "INSERT INTO schema_migrations (version) VALUES (1)")
+	_, err = conn.ExecContext(t.Context(), "INSERT INTO schema_migrations (version) VALUES (1)")
 	c.Assert(err, qt.IsNil)
 	dbschema.CloseAndWarn(conn)
 
-	err = migrationreplay.Replay(context.Background(), migrationreplay.Options{
+	err = migrationreplay.Replay(t.Context(), migrationreplay.Options{
 		Dir:       migrationsDir,
 		DirFormat: migrator.MigrationDirFormatAtlas,
 		DevURL:    "sqlite://" + devDBPath,
 	})
 	c.Assert(err, qt.IsNil)
-	assertReplayRunsRows(c, devDBPath, 0)
+	conn, err = dbschema.ConnectToDatabase(t.Context(), "sqlite://"+devDBPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	assertSQLiteRealmObjectCount(c, conn, 0)
 }
 
 func TestReplayUsesProvidedFilesystemSnapshot(t *testing.T) {
@@ -86,7 +84,10 @@ CREATE TABLE wrong_template_branch (id INTEGER PRIMARY KEY);
 	})
 
 	c.Assert(err, qt.IsNil)
-	assertReplayRunsRows(c, devDBPath, 0)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "sqlite://"+devDBPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	assertSQLiteRealmObjectCount(c, conn, 0)
 }
 
 func TestReplayProviderFailurePreservesDevDatabase(t *testing.T) {
@@ -115,9 +116,14 @@ func TestReplayProviderFailurePreservesDevDatabase(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(conn)
 	var count int
-	err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM sentinel").Scan(&count)
+	err = conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE type = 'table'
+		  AND name = 'sentinel'
+	`).Scan(&count)
 	c.Assert(err, qt.IsNil)
-	c.Assert(count, qt.Equals, 0)
+	c.Assert(count, qt.Equals, 1)
 }
 
 func TestReplayPreCanceledContextPreservesDevDatabase(t *testing.T) {
@@ -193,14 +199,205 @@ CREATE VIEW user_ids AS SELECT id FROM users;
 	c.Assert(count, qt.Equals, 0)
 }
 
-func assertReplayRunsRows(c *qt.C, dbPath string, want int) {
-	c.Helper()
-	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+func TestReplaySQLiteRejectsAttachedDatabaseEscape(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+
+	err := migrationreplay.Replay(ctx, migrationreplay.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		DevURL:    devURL,
+		FS: fstest.MapFS{
+			"1_attach.sql": {
+				Data: []byte(`
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+ATTACH DATABASE ':memory:' AS aux;
+CREATE TABLE aux.outside_realm (id INTEGER PRIMARY KEY);
+`),
+			},
+		},
+	})
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`(?s)replay migration 1 on dev database: .*sqlite migration replay rejects ATTACH .*`,
+	)
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(conn)
-
 	var count int
-	err = conn.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM replay_runs").Scan(&count)
+	err = conn.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+	`).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}
+
+func TestWithReplayedSnapshot_UsesPinnedSQLiteSessionAndRestoresState(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	callbackForeignKeys := -1
+	callbackObjects := -1
+
+	err = migrationreplay.WithReplayedSnapshot(
+		ctx,
+		conn,
+		fstest.MapFS{
+			"1_create_users.sql": {
+				Data: []byte(`
+PRAGMA foreign_keys = OFF;
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+`),
+			},
+		},
+		migrator.MigrationDirFormatAtlas,
+		func(replayConn *dbschema.DatabaseConnection) error {
+			err := replayConn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&callbackForeignKeys)
+			c.Assert(err, qt.IsNil)
+			err = replayConn.QueryRowContext(ctx, `
+				SELECT COUNT(*)
+				FROM main.sqlite_schema
+				WHERE type = 'table'
+				  AND name = 'users'
+			`).Scan(&callbackObjects)
+			c.Assert(err, qt.IsNil)
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(callbackForeignKeys, qt.Equals, 0)
+	c.Assert(callbackObjects, qt.Equals, 1)
+	var restoredForeignKeys int
+	err = conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&restoredForeignKeys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(restoredForeignKeys, qt.Equals, 1)
+	assertSQLiteRealmObjectCount(c, conn, 0)
+}
+
+func TestWithReplayedSnapshot_CallbackFailureCleansDatabaseRealm(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	consumeErr := errors.New("injected consumer failure")
+
+	err = migrationreplay.WithReplayedSnapshot(
+		ctx,
+		conn,
+		fstest.MapFS{
+			"1_create_users.sql": {
+				Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			},
+		},
+		migrator.MigrationDirFormatAtlas,
+		func(*dbschema.DatabaseConnection) error {
+			return consumeErr
+		},
+	)
+
+	c.Assert(err, qt.ErrorIs, consumeErr)
+	assertSQLiteRealmObjectCount(c, conn, 0)
+}
+
+func TestWithReplayedSnapshot_NilCallbackPreservesDatabaseRealm(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(ctx, "CREATE TABLE sentinel (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+
+	err = migrationreplay.WithReplayedSnapshot(
+		ctx,
+		conn,
+		fstest.MapFS{
+			"1_create_users.sql": {
+				Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			},
+		},
+		migrator.MigrationDirFormatAtlas,
+		nil,
+	)
+
+	c.Assert(err, qt.ErrorMatches, `consume replayed database callback is nil`)
+	assertSQLiteRealmObjectCount(c, conn, 1)
+}
+
+func TestWithReplayedSnapshot_SerializesConcurrentRealmReplay(t *testing.T) {
+	c := qt.New(t)
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	firstConn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	secondConn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+	snapshot := fstest.MapFS{
+		"1_create_users.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		},
+	}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+
+	go func() {
+		firstDone <- migrationreplay.WithReplayedSnapshot(
+			t.Context(),
+			firstConn,
+			snapshot,
+			migrator.MigrationDirFormatAtlas,
+			func(*dbschema.DatabaseConnection) error {
+				close(firstEntered)
+				<-releaseFirst
+				return nil
+			},
+		)
+	}()
+	<-firstEntered
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	err = migrationreplay.WithReplayedSnapshot(
+		waitCtx,
+		secondConn,
+		snapshot,
+		migrator.MigrationDirFormatAtlas,
+		func(*dbschema.DatabaseConnection) error {
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+	close(releaseFirst)
+	c.Assert(<-firstDone, qt.IsNil)
+	assertSQLiteRealmObjectCount(c, firstConn, 0)
+}
+
+func assertSQLiteRealmObjectCount(
+	c *qt.C,
+	conn *dbschema.DatabaseConnection,
+	want int,
+) {
+	c.Helper()
+	var count int
+	err := conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM main.sqlite_schema
+		WHERE name NOT LIKE 'sqlite_%'
+	`).Scan(&count)
 	c.Assert(err, qt.IsNil)
 	c.Assert(count, qt.Equals, want)
 }

--- a/internal/migrationreplay/replay_test.go
+++ b/internal/migrationreplay/replay_test.go
@@ -120,6 +120,79 @@ func TestReplayProviderFailurePreservesDevDatabase(t *testing.T) {
 	c.Assert(count, qt.Equals, 0)
 }
 
+func TestReplayPreCanceledContextPreservesDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	devURL := "sqlite://" + filepath.Join(t.TempDir(), "dev.db")
+	conn, err := dbschema.ConnectToDatabase(t.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE sentinel (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = migrationreplay.ReplaySnapshotOnConnection(
+		ctx,
+		conn,
+		fstest.MapFS{
+			"1_create_users.sql": {
+				Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			},
+		},
+		migrator.MigrationDirFormatAtlas,
+	)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	var count int
+	err = conn.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM pragma_table_list WHERE schema = ? AND name = ?",
+		"main",
+		"sentinel",
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+}
+
+func TestReplayExecutionFailureCleansPartialDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	devDBPath := filepath.Join(t.TempDir(), "dev.db")
+	devURL := "sqlite://" + devDBPath
+
+	err := migrationreplay.Replay(ctx, migrationreplay.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		DevURL:    devURL,
+		FS: fstest.MapFS{
+			"1_create_users.sql": {
+				Data: []byte(`
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+CREATE VIEW user_ids AS SELECT id FROM users;
+`),
+			},
+			"2_invalid.sql": {
+				Data: []byte("THIS IS NOT SQL;\n"),
+			},
+		},
+	})
+	c.Assert(err, qt.ErrorMatches, `(?s)replay migration 2 on dev database: .*`)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRowContext(c.Context(), `
+		SELECT COUNT(*)
+		FROM pragma_table_list
+		WHERE schema = ?
+		  AND type IN ('table', 'view', 'virtual')
+		  AND name NOT LIKE 'sqlite_%'
+		  AND name <> 'schema_migrations'
+	`, "main").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
+}
+
 func assertReplayRunsRows(c *qt.C, dbPath string, want int) {
 	c.Helper()
 	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)

--- a/internal/migrationsnapshot/snapshot.go
+++ b/internal/migrationsnapshot/snapshot.go
@@ -2,12 +2,15 @@
 package migrationsnapshot
 
 import (
+	"errors"
 	"io/fs"
 	"path"
 	"strings"
 
 	"github.com/stokaro/ptah/internal/fsnapshot"
 )
+
+var ErrChangedDuringCapture = errors.New("migration directory changed during snapshot capture")
 
 var metadataFiles = map[string]struct{}{
 	".ptah-lint.yaml": {},
@@ -25,4 +28,21 @@ func Capture(fsys fs.FS) (fsnapshot.Snapshot, error) {
 		_, ok := metadataFiles[path.Base(name)]
 		return ok
 	})
+}
+
+// CaptureStable requires two consecutive snapshots to match. This rejects a
+// directory that changed while its files were being read.
+func CaptureStable(fsys fs.FS) (fsnapshot.Snapshot, error) {
+	first, err := Capture(fsys)
+	if err != nil {
+		return fsnapshot.Snapshot{}, err
+	}
+	second, err := Capture(fsys)
+	if err != nil {
+		return fsnapshot.Snapshot{}, err
+	}
+	if !first.Equal(second) {
+		return fsnapshot.Snapshot{}, ErrChangedDuringCapture
+	}
+	return second, nil
 }

--- a/internal/migrationsnapshot/snapshot_test.go
+++ b/internal/migrationsnapshot/snapshot_test.go
@@ -2,6 +2,7 @@ package migrationsnapshot_test
 
 import (
 	"io/fs"
+	"slices"
 	"testing"
 	"testing/fstest"
 
@@ -34,4 +35,34 @@ func TestCapture_IncludesOnlyMigrationInputs(t *testing.T) {
 	), qt.IsNil)
 	_, err = fs.Stat(snapshot, "README.md")
 	c.Assert(err, qt.ErrorIs, fs.ErrNotExist)
+}
+
+func TestCaptureStable_RejectsChangingDirectory(t *testing.T) {
+	c := qt.New(t)
+	source := &changingFS{
+		FS: fstest.MapFS{
+			"1.sql": {Data: []byte("SELECT 1;\n")},
+		},
+		first:  []byte("SELECT 1;\n"),
+		second: []byte("SELECT 2;\n"),
+	}
+
+	_, err := migrationsnapshot.CaptureStable(source)
+
+	c.Assert(err, qt.ErrorIs, migrationsnapshot.ErrChangedDuringCapture)
+}
+
+type changingFS struct {
+	fs.FS
+	first  []byte
+	second []byte
+	reads  int
+}
+
+func (f *changingFS) ReadFile(string) ([]byte, error) {
+	f.reads++
+	if f.reads == 1 {
+		return slices.Clone(f.first), nil
+	}
+	return slices.Clone(f.second), nil
 }

--- a/internal/migrationvalidate/validate_test.go
+++ b/internal/migrationvalidate/validate_test.go
@@ -32,7 +32,7 @@ func TestValidate_WithDevURLReplaysAtlasMigration(t *testing.T) {
 	c.Assert(result.Integrity.OK(), qt.IsTrue)
 	c.Assert(result.Integrity.SumFileName, qt.Equals, migratesum.AtlasFileName)
 	c.Assert(result.DevSQLValidated, qt.IsTrue)
-	assertSQLiteTableCount(c, devDBPath, "validate_dev_url_runtime", 1)
+	assertSQLiteTableCount(c, devDBPath, "validate_dev_url_runtime", 0)
 }
 
 func TestValidate_WithDevURLReportsSQLExecutionFailure(t *testing.T) {

--- a/internal/sqlident/sqlident.go
+++ b/internal/sqlident/sqlident.go
@@ -26,13 +26,10 @@ func Quote(dialect, name string) string {
 }
 
 // Qualified returns a dialect-quoted identifier optionally qualified by schema,
-// as in "schema"."name". Leading and trailing whitespace is trimmed from schema
-// and name before quoting; an empty (or whitespace-only) schema yields just the
-// quoted name.
+// as in "schema"."name". A whitespace-only schema yields just the quoted name.
+// Otherwise, schema and name are quoted verbatim.
 func Qualified(dialect, schema, name string) string {
-	schema = strings.TrimSpace(schema)
-	name = strings.TrimSpace(name)
-	if schema == "" {
+	if strings.TrimSpace(schema) == "" {
 		return Quote(dialect, name)
 	}
 	return Quote(dialect, schema) + "." + Quote(dialect, name)

--- a/internal/sqlident/sqlident_test.go
+++ b/internal/sqlident/sqlident_test.go
@@ -52,8 +52,8 @@ func TestQualified(t *testing.T) {
 	}{
 		{name: "postgres schema qualified", dialect: "postgres", schema: "public", ident: "users", want: `"public"."users"`},
 		{name: "empty schema yields bare name", dialect: "postgres", schema: "", ident: "users", want: `"users"`},
-		{name: "whitespace schema treated as empty", dialect: "postgres", schema: "  ", ident: "users", want: `"users"`},
-		{name: "schema and name are trimmed", dialect: "mysql", schema: " app ", ident: " users ", want: "`app`.`users`"},
+		{name: "whitespace schema treated as empty", dialect: "postgres", schema: "  ", ident: " users ", want: `" users "`},
+		{name: "schema and name bytes are preserved", dialect: "mysql", schema: " app ", ident: " users ", want: "` app `.` users `"},
 		{name: "sqlserver schema qualified", dialect: "sqlserver", schema: "dbo", ident: "users", want: "[dbo].[users]"},
 	}
 

--- a/internal/sqlrunner/sqlrunner.go
+++ b/internal/sqlrunner/sqlrunner.go
@@ -1,0 +1,80 @@
+// Package sqlrunner defines the SQL operations shared by pooled and pinned
+// database sessions.
+package sqlrunner
+
+import (
+	"context"
+	"database/sql"
+)
+
+// Runner is the database/sql surface used by schema readers and writers.
+// Both *sql.DB and Conn satisfy it.
+type Runner interface {
+	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
+	Exec(string, ...any) (sql.Result, error)
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	Query(string, ...any) (*sql.Rows, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRow(string, ...any) *sql.Row
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+// Connector acquires a dedicated physical database session.
+type Connector interface {
+	Conn(context.Context) (*sql.Conn, error)
+}
+
+// Conn adapts *sql.Conn to Runner. Context-free calls use the context that was
+// active when the session was pinned.
+type Conn struct {
+	ctx  context.Context
+	conn *sql.Conn
+}
+
+// NewConn binds conn to ctx without taking ownership of conn.
+func NewConn(ctx context.Context, conn *sql.Conn) *Conn {
+	return &Conn{ctx: ctx, conn: conn}
+}
+
+// BeginTx starts a transaction on the pinned session.
+func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return c.conn.BeginTx(ctx, opts)
+}
+
+// Exec executes a statement on the pinned session.
+func (c *Conn) Exec(query string, args ...any) (sql.Result, error) {
+	return c.conn.ExecContext(c.ctx, query, args...)
+}
+
+// ExecContext executes a statement on the pinned session.
+func (c *Conn) ExecContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (sql.Result, error) {
+	return c.conn.ExecContext(ctx, query, args...)
+}
+
+// Query executes a query on the pinned session.
+func (c *Conn) Query(query string, args ...any) (*sql.Rows, error) {
+	return c.conn.QueryContext(c.ctx, query, args...)
+}
+
+// QueryContext executes a query on the pinned session.
+func (c *Conn) QueryContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (*sql.Rows, error) {
+	return c.conn.QueryContext(ctx, query, args...)
+}
+
+// QueryRow executes a single-row query on the pinned session.
+func (c *Conn) QueryRow(query string, args ...any) *sql.Row {
+	return c.conn.QueryRowContext(c.ctx, query, args...)
+}
+
+// QueryRowContext executes a single-row query on the pinned session.
+func (c *Conn) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return c.conn.QueryRowContext(ctx, query, args...)
+}

--- a/internal/testutils/filelock.go
+++ b/internal/testutils/filelock.go
@@ -1,0 +1,31 @@
+package testutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// AcquireExclusiveFileLock acquires an OS-backed lock for cross-process lock
+// behavior tests. The returned function unlocks and closes the file.
+func AcquireExclusiveFileLock(path string) (func() error, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockFile(file); err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	return func() error {
+		if err := unlockFile(file); err != nil {
+			return errors.Join(err, file.Close())
+		}
+		if err := file.Close(); err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove test lock file: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/internal/testutils/filelock_unix.go
+++ b/internal/testutils/filelock_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("lock test file: %w", err)
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock test file: %w", err)
+	}
+	return nil
+}

--- a/internal/testutils/filelock_windows.go
+++ b/internal/testutils/filelock_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package testutils
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("lock test file: %w", err)
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(
+		windows.Handle(file.Fd()),
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("unlock test file: %w", err)
+	}
+	return nil
+}

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -90,7 +90,10 @@ never renumbers and publishes a plan derived from stale history.
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.
 Use `WriteFilesContext` when lock acquisition must honor cancellation or an
-operation deadline.
+operation deadline. Callers can branch on
+`generator.ErrMigrationDirectoryChanged` when another process changed the
+migration history after planning, and on `generator.ErrMigrationPlanInUse`
+when the same plan is already being published.
 
 ### Migration Process
 

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -83,6 +83,14 @@ fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
 
 Planning does not write migration artifacts. A successful `WriteFiles` call
 consumes the plan; call it once after all surrounding work has succeeded.
+The plan records the migration-directory snapshot used for planning.
+`WriteFiles` acquires the shared cross-process directory lock and rejects the
+plan if migration SQL or integrity metadata changed before publication. It
+never renumbers and publishes a plan derived from stale history.
+It renders every up/down file and requested safety report before publishing
+the artifacts as one batch. A filename collision leaves no partial new files.
+Use `WriteFilesContext` when lock acquisition must honor cancellation or an
+operation deadline.
 
 ### Migration Process
 

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -59,6 +59,31 @@ func main() {
 }
 ```
 
+### Planning before publication
+
+`GenerateMigration` plans and writes in one call. Use `PlanMigration` when a
+caller must finish database cleanup or another pre-publication step before any
+migration file appears:
+
+```go
+plan, err := generator.PlanMigration(ctx, opts)
+if err != nil {
+    return err
+}
+if plan == nil {
+    return nil
+}
+
+files, err := plan.WriteFiles()
+if err != nil {
+    return err
+}
+fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
+```
+
+Planning does not write migration artifacts. A successful `WriteFiles` call
+consumes the plan; call it once after all surrounding work has succeeded.
+
 ### Migration Process
 
 The generator follows this process:

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -194,9 +194,14 @@ func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
-	files, err := createMigrationFilesFromSpecs(dir, "", []generatedMigrationSpec{
-		{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
-		{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},
+	var files *MigrationFiles
+	var publishErr error
+	err := atlasmigrate.WithMigrationDirectoryLock(t.Context(), dir, 0, func() error {
+		files, publishErr = createMigrationFilesFromSpecs(t.Context(), dir, "", []generatedMigrationSpec{
+			{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
+			{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},
+		})
+		return publishErr
 	})
 
 	c.Assert(err, qt.IsNil)

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -196,7 +197,7 @@ func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
 
 	var files *MigrationFiles
 	var publishErr error
-	err := atlasmigrate.WithMigrationDirectoryLock(t.Context(), dir, 0, func() error {
+	err := atlasmigrate.WithMigrationDirectoryLock(t.Context(), dir, 0, func(context.Context) error {
 		files, publishErr = createMigrationFilesFromSpecs(t.Context(), dir, "", []generatedMigrationSpec{
 			{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
 			{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},

--- a/migration/generator/example/main.go
+++ b/migration/generator/example/main.go
@@ -50,9 +50,7 @@ func main() {
 	fmt.Printf("  Migration name: %s\n", migrationName)
 	fmt.Println()
 
-	// Bound the initial database connection so a stuck host fails fast.
-	// The schema-reading work inside GenerateMigration is not yet
-	// context-aware — see its docstring.
+	// Bound database access, planning, lock acquisition, and publication.
 	//
 	// We cancel synchronously rather than via `defer` because the failure
 	// path below uses log.Fatalf, which calls os.Exit and skips deferreds.

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -28,7 +29,9 @@ import (
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 	"github.com/stokaro/ptah/internal/convert/fromschema"
 	"github.com/stokaro/ptah/internal/deporder"
+	"github.com/stokaro/ptah/internal/fsnapshot"
 	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/internal/migrationsnapshot"
 	"github.com/stokaro/ptah/internal/pathguard"
 	"github.com/stokaro/ptah/internal/tableref"
 	"github.com/stokaro/ptah/migration/diffpolicy"
@@ -126,9 +129,15 @@ type MigrationFiles struct {
 type MigrationPlan struct {
 	mu           sync.Mutex
 	outputDir    string
+	outputState  migrationDirectoryState
 	reportFormat string
 	specs        []generatedMigrationSpec
 	written      bool
+}
+
+type migrationDirectoryState struct {
+	exists   bool
+	snapshot fsnapshot.Snapshot
 }
 
 // EmptyMigrationOptions contains options for skeleton migration creation.
@@ -319,6 +328,10 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err != nil {
 		return nil, err
 	}
+	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("capture migration directory before planning: %w", err)
+	}
 
 	// 1. Determine the desired schema: use a pre-merged one when provided (for a
 	// composite desired-state assembled from several sources), otherwise parse the
@@ -433,6 +446,7 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 
 	return &MigrationPlan{
 		outputDir:    opts.OutputDir,
+		outputState:  outputState,
 		reportFormat: opts.ReportFormat,
 		specs:        specs,
 	}, nil
@@ -441,6 +455,12 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 // WriteFiles publishes the migration artifacts represented by the plan. A plan
 // is single-use after a successful publication.
 func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
+	return p.WriteFilesContext(context.Background())
+}
+
+// WriteFilesContext publishes the migration artifacts represented by the plan.
+// The context bounds waiting for the migration-directory publication lock.
+func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles, error) {
 	if p == nil {
 		return nil, fmt.Errorf("migration plan is nil")
 	}
@@ -449,12 +469,60 @@ func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
 	if p.written {
 		return nil, fmt.Errorf("migration plan has already been written")
 	}
-	files, err := createMigrationFilesFromSpecs(p.outputDir, p.reportFormat, p.specs)
-	if err != nil {
-		return nil, fmt.Errorf("error creating migration files: %w", err)
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
-	p.written = true
+	if err := os.MkdirAll(filepath.Dir(filepath.Clean(p.outputDir)), 0755); err != nil {
+		return nil, fmt.Errorf("create migration directory parent: %w", err)
+	}
+	var files *MigrationFiles
+	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func() error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		currentState, err := captureMigrationDirectoryState(p.outputDir)
+		if err != nil {
+			return fmt.Errorf("capture migration directory before publication: %w", err)
+		}
+		if !p.outputState.equal(currentState) {
+			return fmt.Errorf("migration directory changed after migration planning")
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		files, err = createMigrationFilesFromSpecs(ctx, p.outputDir, p.reportFormat, p.specs)
+		if err != nil {
+			return fmt.Errorf("error creating migration files: %w", err)
+		}
+		p.written = true
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return files, nil
+}
+
+func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, error) {
+	info, err := os.Stat(outputDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return migrationDirectoryState{}, nil
+	}
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	if !info.IsDir() {
+		return migrationDirectoryState{}, fmt.Errorf("%q exists and is not a directory", outputDir)
+	}
+	snapshot, err := migrationsnapshot.CaptureStable(os.DirFS(outputDir))
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	return migrationDirectoryState{exists: true, snapshot: snapshot}, nil
+}
+
+func (s migrationDirectoryState) equal(other migrationDirectoryState) bool {
+	return s.exists == other.exists && s.snapshot.Equal(other.snapshot)
 }
 
 func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {
@@ -900,37 +968,27 @@ func cloneIdentifierSemanticsValue(
 	return semantics.Clone()
 }
 
-func createSafetyReportFile(upFile, format string, assessments []safety.StatementAssessment) (string, error) {
+func renderSafetyReport(
+	upFile, format string,
+	assessments []safety.StatementAssessment,
+) (string, []byte, error) {
+	var contents bytes.Buffer
+	var reportFile string
 	switch strings.ToLower(strings.TrimSpace(format)) {
 	case "html":
-		reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.html"
-		return writeSafetyReportFile(reportFile, func(file *os.File) error {
-			return safety.RenderHTML(file, assessments)
-		})
-	case "json":
-		reportFile := strings.TrimSuffix(upFile, ".up.sql") + ".safety.json"
-		return writeSafetyReportFile(reportFile, func(file *os.File) error {
-			return safety.RenderJSON(file, assessments)
-		})
-	default:
-		return "", fmt.Errorf("unsupported safety report format %q", format)
-	}
-}
-
-func writeSafetyReportFile(reportFile string, render func(*os.File) error) (string, error) {
-	file, err := os.Create(reportFile)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			slog.Warn("failed to close safety report", "path", reportFile, "error", closeErr)
+		reportFile = strings.TrimSuffix(upFile, ".up.sql") + ".safety.html"
+		if err := safety.RenderHTML(&contents, assessments); err != nil {
+			return "", nil, err
 		}
-	}()
-	if err := render(file); err != nil {
-		return "", err
+	case "json":
+		reportFile = strings.TrimSuffix(upFile, ".up.sql") + ".safety.json"
+		if err := safety.RenderJSON(&contents, assessments); err != nil {
+			return "", nil, err
+		}
+	default:
+		return "", nil, fmt.Errorf("unsupported safety report format %q", format)
 	}
-	return reportFile, nil
+	return reportFile, contents.Bytes(), nil
 }
 
 // hasActualSQLStatements checks if the statements contain actual SQL operations (not just comments)
@@ -1940,37 +1998,65 @@ func createMigrationFiles(outputDir string, version int64, migrationName, upSQL,
 	}
 }
 
-func createMigrationFilesFromSpecs(outputDir, reportFormat string, specs []generatedMigrationSpec) (*MigrationFiles, error) {
-	pairs := make([]MigrationFilePair, 0, len(specs))
-	cleanup := func() {
-		for _, pair := range pairs {
-			_ = os.Remove(pair.UpFile)
-			_ = os.Remove(pair.DownFile)
-			if pair.ReportFile != "" {
-				_ = os.Remove(pair.ReportFile)
-			}
-		}
+func createMigrationFilesFromSpecs(
+	ctx context.Context,
+	outputDir, reportFormat string,
+	specs []generatedMigrationSpec,
+) (*MigrationFiles, error) {
+	if len(specs) == 0 {
+		return nil, nil
 	}
+	artifacts, pairs, err := renderMigrationArtifacts(outputDir, reportFormat, specs)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureMigrationOutputDir(outputDir); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	if _, err := atlasmigrate.PublishArtifactsLocked(ctx, outputDir, artifacts); err != nil {
+		return nil, err
+	}
+	return migrationFilesFromPairs(pairs), nil
+}
+
+func renderMigrationArtifacts(
+	outputDir, reportFormat string,
+	specs []generatedMigrationSpec,
+) ([]atlasmigrate.PublicationArtifact, []MigrationFilePair, error) {
+	artifacts := make([]atlasmigrate.PublicationArtifact, 0, len(specs)*3)
+	pairs := make([]MigrationFilePair, 0, len(specs))
 	for _, spec := range specs {
-		files, err := createMigrationFiles(outputDir, spec.Version, spec.Name, spec.UpSQL, spec.DownSQL)
-		if err != nil {
-			cleanup()
-			return nil, err
+		upName := migrator.GenerateMigrationFileName(spec.Version, spec.Name, "up")
+		downName := migrator.GenerateMigrationFileName(spec.Version, spec.Name, "down")
+		pair := MigrationFilePair{
+			UpFile:        filepath.Join(outputDir, upName),
+			DownFile:      filepath.Join(outputDir, downName),
+			Version:       spec.Version,
+			NoTransaction: spec.NoTransaction,
 		}
-		pair := files.Files[0]
-		pair.NoTransaction = spec.NoTransaction
+		artifacts = append(
+			artifacts,
+			atlasmigrate.PublicationArtifact{Name: upName, Contents: []byte(spec.UpSQL)},
+			atlasmigrate.PublicationArtifact{Name: downName, Contents: []byte(spec.DownSQL)},
+		)
 		if reportFormat != "" {
-			reportFile, err := createSafetyReportFile(pair.UpFile, reportFormat, spec.Assessments)
+			reportName, reportContents, err := renderSafetyReport(
+				upName,
+				reportFormat,
+				spec.Assessments,
+			)
 			if err != nil {
-				pairs = append(pairs, pair)
-				cleanup()
-				return nil, fmt.Errorf("error creating safety report: %w", err)
+				return nil, nil, fmt.Errorf("error creating safety report: %w", err)
 			}
-			pair.ReportFile = reportFile
+			pair.ReportFile = filepath.Join(outputDir, reportName)
+			artifacts = append(artifacts, atlasmigrate.PublicationArtifact{
+				Name:     reportName,
+				Contents: reportContents,
+			})
 		}
 		pairs = append(pairs, pair)
 	}
-	return migrationFilesFromPairs(pairs), nil
+	return artifacts, pairs, nil
 }
 
 func shadowCandidatesFromSpecs(specs []generatedMigrationSpec) []shadowCandidate {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -42,6 +42,16 @@ import (
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
+var (
+	// ErrMigrationDirectoryChanged reports that migration artifacts changed
+	// between planning and publication.
+	ErrMigrationDirectoryChanged = errors.New(
+		"migration directory changed after migration planning",
+	)
+	// ErrMigrationPlanInUse reports concurrent publication through one plan.
+	ErrMigrationPlanInUse = errors.New("migration plan is already being written")
+)
+
 // GenerateMigrationOptions contains options for migration generation
 type GenerateMigrationOptions struct {
 	// GoEntitiesDir is the directory to scan for Go entities
@@ -306,17 +316,13 @@ func emptyMigrationSQL(name, generatedAt, direction string) string {
 // GenerateMigration generates both up and down migration files by comparing
 // the desired schema (from Go entities) with the current database state.
 //
-// The context bounds only the initial database connection attempt performed
-// when opts.DBConn is nil (so a stuck host cannot block the call
-// indefinitely). The schema-reading and migration-writing work below does not
-// yet propagate the context; future work may thread it through there too.
-// When opts.DBConn is supplied the context is currently unused.
+// The context bounds connection, planning, lock acquisition, and publication.
 func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error) {
 	plan, err := PlanMigration(ctx, opts)
 	if err != nil || plan == nil {
 		return nil, err
 	}
-	return plan.WriteFiles()
+	return plan.WriteFilesContext(ctx)
 }
 
 // PlanMigration performs schema loading, live introspection, diff planning,
@@ -464,7 +470,9 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if p == nil {
 		return nil, fmt.Errorf("migration plan is nil")
 	}
-	p.mu.Lock()
+	if !p.mu.TryLock() {
+		return nil, ErrMigrationPlanInUse
+	}
 	defer p.mu.Unlock()
 	if p.written {
 		return nil, fmt.Errorf("migration plan has already been written")
@@ -485,7 +493,7 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 			return fmt.Errorf("capture migration directory before publication: %w", err)
 		}
 		if !p.outputState.equal(currentState) {
-			return fmt.Errorf("migration directory changed after migration planning")
+			return ErrMigrationDirectoryChanged
 		}
 		if err := ctx.Err(); err != nil {
 			return err

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stokaro/ptah/config"
@@ -118,6 +119,16 @@ type MigrationFiles struct {
 	ReportFile string              // Path to the first safety report file, when requested
 	Version    int64               // First migration version (timestamp)
 	Files      []MigrationFilePair // All generated migration file pairs, in apply order
+}
+
+// MigrationPlan is a fully validated migration that has not been written to
+// disk yet. WriteFiles publishes the planned migration once.
+type MigrationPlan struct {
+	mu           sync.Mutex
+	outputDir    string
+	reportFormat string
+	specs        []generatedMigrationSpec
+	written      bool
 }
 
 // EmptyMigrationOptions contains options for skeleton migration creation.
@@ -292,6 +303,18 @@ func emptyMigrationSQL(name, generatedAt, direction string) string {
 // yet propagate the context; future work may thread it through there too.
 // When opts.DBConn is supplied the context is currently unused.
 func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationFiles, error) {
+	plan, err := PlanMigration(ctx, opts)
+	if err != nil || plan == nil {
+		return nil, err
+	}
+	return plan.WriteFiles()
+}
+
+// PlanMigration performs schema loading, live introspection, diff planning,
+// safety checks, and optional shadow verification without writing migration
+// artifacts. Call WriteFiles only after any surrounding database cleanup or
+// other pre-publication work succeeds.
+func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*MigrationPlan, error) {
 	opts, err := normalizeGenerateMigrationOptions(opts)
 	if err != nil {
 		return nil, err
@@ -408,12 +431,29 @@ func GenerateMigration(ctx context.Context, opts GenerateMigrationOptions) (*Mig
 		}
 	}
 
-	// 7. Create migration files
-	files, err := createMigrationFilesFromSpecs(opts.OutputDir, opts.ReportFormat, specs)
+	return &MigrationPlan{
+		outputDir:    opts.OutputDir,
+		reportFormat: opts.ReportFormat,
+		specs:        specs,
+	}, nil
+}
+
+// WriteFiles publishes the migration artifacts represented by the plan. A plan
+// is single-use after a successful publication.
+func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
+	if p == nil {
+		return nil, fmt.Errorf("migration plan is nil")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.written {
+		return nil, fmt.Errorf("migration plan has already been written")
+	}
+	files, err := createMigrationFilesFromSpecs(p.outputDir, p.reportFormat, p.specs)
 	if err != nil {
 		return nil, fmt.Errorf("error creating migration files: %w", err)
 	}
-
+	p.written = true
 	return files, nil
 }
 

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -334,13 +334,6 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err != nil {
 		return nil, err
 	}
-	if err := recoverMigrationPublication(ctx, opts.OutputDir); err != nil {
-		return nil, err
-	}
-	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
-	if err != nil {
-		return nil, fmt.Errorf("capture migration directory before planning: %w", err)
-	}
 
 	// 1. Determine the desired schema: use a pre-merged one when provided (for a
 	// composite desired-state assembled from several sources), otherwise parse the
@@ -388,6 +381,13 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	dbSchema, err := dbschema.ReadSchemaWithSchemas(conn, opts.Schemas)
 	if err != nil {
 		return nil, fmt.Errorf("error reading database schema: %w", err)
+	}
+	if err := recoverMigrationPublication(ctx, opts.OutputDir); err != nil {
+		return nil, err
+	}
+	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
+	if err != nil {
+		return nil, fmt.Errorf("capture migration directory before planning: %w", err)
 	}
 
 	// 3. Calculate the diff between desired and current schema using live
@@ -465,10 +465,7 @@ func recoverMigrationPublication(ctx context.Context, outputDir string) error {
 	if err := os.MkdirAll(filepath.Dir(filepath.Clean(outputDir)), 0755); err != nil {
 		return fmt.Errorf("create migration directory parent: %w", err)
 	}
-	err := atlasmigrate.WithMigrationDirectoryLock(ctx, outputDir, 0, func() error {
-		return atlasmigrate.RecoverPendingPublicationLocked(outputDir)
-	})
-	if err != nil {
+	if err := atlasmigrate.RecoverPendingPublication(ctx, outputDir); err != nil {
 		return fmt.Errorf("recover migration publication before planning: %w", err)
 	}
 	return nil
@@ -500,7 +497,7 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 		return nil, fmt.Errorf("create migration directory parent: %w", err)
 	}
 	var files *MigrationFiles
-	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func() error {
+	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -334,6 +334,9 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err != nil {
 		return nil, err
 	}
+	if err := recoverMigrationPublication(ctx, opts.OutputDir); err != nil {
+		return nil, err
+	}
 	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
 	if err != nil {
 		return nil, fmt.Errorf("capture migration directory before planning: %w", err)
@@ -456,6 +459,19 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 		reportFormat: opts.ReportFormat,
 		specs:        specs,
 	}, nil
+}
+
+func recoverMigrationPublication(ctx context.Context, outputDir string) error {
+	if err := os.MkdirAll(filepath.Dir(filepath.Clean(outputDir)), 0755); err != nil {
+		return fmt.Errorf("create migration directory parent: %w", err)
+	}
+	err := atlasmigrate.WithMigrationDirectoryLock(ctx, outputDir, 0, func() error {
+		return atlasmigrate.RecoverPendingPublicationLocked(outputDir)
+	})
+	if err != nil {
+		return fmt.Errorf("recover migration publication before planning: %w", err)
+	}
+	return nil
 }
 
 // WriteFiles publishes the migration artifacts represented by the plan. A plan

--- a/migration/generator/plan_export_internal_test.go
+++ b/migration/generator/plan_export_internal_test.go
@@ -1,0 +1,48 @@
+package generator
+
+// White-box testing required: this file exposes planned specifications only to
+// the external-package transactional publication tests.
+
+import (
+	"slices"
+
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+// MigrationPlanSpecForTest exposes one planned artifact pair to black-box tests.
+type MigrationPlanSpecForTest struct {
+	Version       int64
+	Name          string
+	UpSQL         string
+	DownSQL       string
+	Assessments   []safety.StatementAssessment
+	NoTransaction bool
+}
+
+// NewMigrationPlanForTest creates a plan without database-dependent planning.
+func NewMigrationPlanForTest(
+	outputDir, reportFormat string,
+	specs []MigrationPlanSpecForTest,
+) (*MigrationPlan, error) {
+	outputState, err := captureMigrationDirectoryState(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	generatedSpecs := make([]generatedMigrationSpec, len(specs))
+	for index, spec := range specs {
+		generatedSpecs[index] = generatedMigrationSpec{
+			Version:       spec.Version,
+			Name:          spec.Name,
+			UpSQL:         spec.UpSQL,
+			DownSQL:       spec.DownSQL,
+			Assessments:   slices.Clone(spec.Assessments),
+			NoTransaction: spec.NoTransaction,
+		}
+	}
+	return &MigrationPlan{
+		outputDir:    outputDir,
+		outputState:  outputState,
+		reportFormat: reportFormat,
+		specs:        generatedSpecs,
+	}, nil
+}

--- a/migration/generator/plan_export_internal_test.go
+++ b/migration/generator/plan_export_internal_test.go
@@ -1,13 +1,31 @@
 package generator
 
-// White-box testing required: this file exposes planned specifications only to
-// the external-package transactional publication tests.
+// White-box testing required: this file exposes planned specifications and an
+// interrupted-publication fixture to external-package publication tests.
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/stokaro/ptah/migration/safety"
 )
+
+type pendingPublicationJournalForTest struct {
+	Version    int                              `json:"version"`
+	CommitMode string                           `json:"commit_mode"`
+	Entries    []pendingPublicationEntryForTest `json:"entries"`
+}
+
+type pendingPublicationEntryForTest struct {
+	Staged string `json:"staged"`
+	Final  string `json:"final"`
+	Mode   string `json:"mode"`
+	Digest string `json:"digest"`
+}
 
 // MigrationPlanSpecForTest exposes one planned artifact pair to black-box tests.
 type MigrationPlanSpecForTest struct {
@@ -45,4 +63,45 @@ func NewMigrationPlanForTest(
 		reportFormat: reportFormat,
 		specs:        generatedSpecs,
 	}, nil
+}
+
+// WritePendingPublicationForTest creates an interrupted, uncommitted batch.
+func WritePendingPublicationForTest(outputDir string) ([]string, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return nil, err
+	}
+	contents := []byte("CREATE TABLE interrupted_items (id INTEGER);\n")
+	finalName := "9999999999_interrupted.up.sql"
+	stagedName := ".ptah-migrate-diff-recovery-test.tmp"
+	finalPath := filepath.Join(outputDir, finalName)
+	stagedPath := filepath.Join(outputDir, stagedName)
+	if err := os.WriteFile(finalPath, contents, 0o600); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(stagedPath, contents, 0o600); err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(contents)
+	journal := pendingPublicationJournalForTest{
+		Version:    5,
+		CommitMode: "journal-marker",
+		Entries: []pendingPublicationEntryForTest{{
+			Staged: stagedName,
+			Final:  finalName,
+			Mode:   "exclusive-copy",
+			Digest: hex.EncodeToString(digest[:]),
+		}},
+	}
+	journalContents, err := json.Marshal(journal)
+	if err != nil {
+		return nil, err
+	}
+	journalPath := filepath.Join(
+		filepath.Dir(outputDir),
+		"."+filepath.Base(outputDir)+".ptah-migrate-diff.pending",
+	)
+	if err := os.WriteFile(journalPath, journalContents, 0o600); err != nil {
+		return nil, err
+	}
+	return []string{finalPath, stagedPath, journalPath}, nil
 }

--- a/migration/generator/plan_publication_test.go
+++ b/migration/generator/plan_publication_test.go
@@ -1,0 +1,195 @@
+package generator_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+func TestMigrationPlanWriteFiles_PublishesMultiplePairsAndReports(t *testing.T) {
+	c := qt.New(t)
+	outputDir := c.TempDir()
+	firstAssessment := safety.StatementAssessment{
+		Index:     1,
+		NodeType:  "create_table",
+		Subject:   "users",
+		Statement: "CREATE TABLE users (id INTEGER);",
+		Severity:  safety.Safe,
+		Reason:    "creates a new table",
+	}
+	secondAssessment := safety.StatementAssessment{
+		Index:     1,
+		NodeType:  "create_index",
+		Subject:   "users",
+		Statement: "CREATE INDEX CONCURRENTLY users_name_idx ON users (name);",
+		Severity:  safety.Warning,
+		Reason:    "builds an index on an existing table",
+	}
+	specs := []generator.MigrationPlanSpecForTest{
+		{
+			Version:     1700000000,
+			Name:        "transactional",
+			UpSQL:       "CREATE TABLE users (id INTEGER);\n",
+			DownSQL:     "DROP TABLE users;\n",
+			Assessments: []safety.StatementAssessment{firstAssessment},
+		},
+		{
+			Version:       1700000001,
+			Name:          "concurrent_indexes",
+			UpSQL:         "-- +ptah no_transaction\nCREATE INDEX CONCURRENTLY users_name_idx ON users (name);\n",
+			DownSQL:       "-- +ptah no_transaction\nDROP INDEX CONCURRENTLY users_name_idx;\n",
+			Assessments:   []safety.StatementAssessment{secondAssessment},
+			NoTransaction: true,
+		},
+	}
+	plan, err := generator.NewMigrationPlanForTest(outputDir, "json", specs)
+	c.Assert(err, qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	firstUp := filepath.Join(outputDir, "1700000000_transactional.up.sql")
+	firstDown := filepath.Join(outputDir, "1700000000_transactional.down.sql")
+	firstReport := filepath.Join(outputDir, "1700000000_transactional.safety.json")
+	secondUp := filepath.Join(outputDir, "1700000001_concurrent_indexes.up.sql")
+	secondDown := filepath.Join(outputDir, "1700000001_concurrent_indexes.down.sql")
+	secondReport := filepath.Join(outputDir, "1700000001_concurrent_indexes.safety.json")
+	expectedPairs := []generator.MigrationFilePair{
+		{
+			UpFile:     firstUp,
+			DownFile:   firstDown,
+			ReportFile: firstReport,
+			Version:    1700000000,
+		},
+		{
+			UpFile:        secondUp,
+			DownFile:      secondDown,
+			ReportFile:    secondReport,
+			Version:       1700000001,
+			NoTransaction: true,
+		},
+	}
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.DeepEquals, &generator.MigrationFiles{
+		UpFile:     firstUp,
+		DownFile:   firstDown,
+		ReportFile: firstReport,
+		Version:    1700000000,
+		Files:      expectedPairs,
+	})
+
+	firstUpContents, err := os.ReadFile(firstUp)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(firstUpContents), qt.Equals, specs[0].UpSQL)
+	firstDownContents, err := os.ReadFile(firstDown)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(firstDownContents), qt.Equals, specs[0].DownSQL)
+	secondUpContents, err := os.ReadFile(secondUp)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(secondUpContents), qt.Equals, specs[1].UpSQL)
+	secondDownContents, err := os.ReadFile(secondDown)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(secondDownContents), qt.Equals, specs[1].DownSQL)
+
+	firstReportContents, err := os.ReadFile(firstReport)
+	c.Assert(err, qt.IsNil)
+	var firstSafetyReport safety.Report
+	c.Assert(json.Unmarshal(firstReportContents, &firstSafetyReport), qt.IsNil)
+	c.Assert(firstSafetyReport.Assessments, qt.DeepEquals, specs[0].Assessments)
+	secondReportContents, err := os.ReadFile(secondReport)
+	c.Assert(err, qt.IsNil)
+	var secondSafetyReport safety.Report
+	c.Assert(json.Unmarshal(secondReportContents, &secondSafetyReport), qt.IsNil)
+	c.Assert(secondSafetyReport.Assessments, qt.DeepEquals, specs[1].Assessments)
+
+	names, err := migrationArtifactNames(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(names, qt.DeepEquals, []string{
+		"1700000000_transactional.down.sql",
+		"1700000000_transactional.safety.json",
+		"1700000000_transactional.up.sql",
+		"1700000001_concurrent_indexes.down.sql",
+		"1700000001_concurrent_indexes.safety.json",
+		"1700000001_concurrent_indexes.up.sql",
+	})
+}
+
+func TestMigrationPlanWriteFiles_CollisionLeavesNoPartialArtifacts(t *testing.T) {
+	c := qt.New(t)
+	outputDir := c.TempDir()
+	reportName := "1700000000_transactional.safety.json"
+	reportPath := filepath.Join(outputDir, reportName)
+	originalReport := []byte("existing report\n")
+	c.Assert(os.WriteFile(reportPath, originalReport, 0600), qt.IsNil)
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"json",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "transactional",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+			Assessments: []safety.StatementAssessment{{
+				Index:    1,
+				Severity: safety.Safe,
+				Reason:   "creates a new table",
+			}},
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.ErrorMatches, `error creating migration files: migration directory changed during publication: .* already exists`)
+	c.Assert(files, qt.IsNil)
+	names, err := migrationArtifactNames(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(names, qt.DeepEquals, []string{reportName})
+	reportContents, err := os.ReadFile(reportPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(reportContents, qt.DeepEquals, originalReport)
+}
+
+func TestMigrationPlanWriteFiles_CreatesMissingOutputParents(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(c.TempDir(), "nested", "migrations")
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	upContents, err := os.ReadFile(files.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upContents), qt.Equals, "CREATE TABLE users (id INTEGER);\n")
+	downContents, err := os.ReadFile(files.Files[0].DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downContents), qt.Equals, "DROP TABLE users;\n")
+}
+
+func migrationArtifactNames(outputDir string) ([]string, error) {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(entries))
+	for index, entry := range entries {
+		names[index] = entry.Name()
+	}
+	return names, nil
+}

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -99,7 +99,7 @@ func TestMigrationPlanWriteFilesContext_RejectsConcurrentUse(t *testing.T) {
 			t.Context(),
 			outputDir,
 			0,
-			func() error {
+			func(context.Context) error {
 				close(lockHeld)
 				<-releaseLock
 				return nil
@@ -156,7 +156,7 @@ func TestMigrationPlanWriteFilesContext_CancelsWhileWaitingForLock(t *testing.T)
 			t.Context(),
 			outputDir,
 			0,
-			func() error {
+			func(context.Context) error {
 				close(lockHeld)
 				<-releaseLock
 				return nil
@@ -200,7 +200,7 @@ func TestGenerateMigration_CancelsWhileWaitingForRecoveryLock(t *testing.T) {
 			t.Context(),
 			outputDir,
 			0,
-			func() error {
+			func(context.Context) error {
 				close(lockHeld)
 				<-releaseLock
 				return nil

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -1,13 +1,17 @@
 package generator_test
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/migration/generator"
 )
 
@@ -47,6 +51,79 @@ func TestMigrationPlanWriteFiles_FailurePath(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `migration plan has already been written`)
 	c.Assert(files, qt.IsNil)
+}
+
+func TestMigrationPlanWriteFiles_RejectsChangedDirectory(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+	concurrentMigration := filepath.Join(outputDir, "20000101000000_concurrent.up.sql")
+	c.Assert(os.WriteFile(concurrentMigration, []byte("SELECT 1;\n"), 0o600), qt.IsNil)
+
+	files, err := plan.WriteFiles()
+
+	c.Assert(err, qt.ErrorMatches, `migration directory changed after migration planning`)
+	c.Assert(files, qt.IsNil)
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.DeepEquals, []string{concurrentMigration})
+}
+
+func TestMigrationPlanWriteFilesContext_RejectsCanceledContext(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	files, err := plan.WriteFilesContext(ctx)
+
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	c.Assert(files, qt.IsNil)
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 0)
+}
+
+func TestMigrationPlanWriteFilesContext_CancelsWhileWaitingForLock(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- atlasmigrate.WithMigrationDirectoryLock(
+			t.Context(),
+			outputDir,
+			0,
+			func() error {
+				close(lockHeld)
+				<-releaseLock
+				return nil
+			},
+		)
+	}()
+	<-lockHeld
+
+	ctx, cancel := context.WithCancel(t.Context())
+	type writeResult struct {
+		files *generator.MigrationFiles
+		err   error
+	}
+	writeDone := make(chan writeResult, 1)
+	go func() {
+		files, err := plan.WriteFilesContext(ctx)
+		writeDone <- writeResult{files: files, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	result := <-writeDone
+	close(releaseLock)
+
+	c.Assert(result.err, qt.ErrorIs, context.Canceled)
+	c.Assert(result.files, qt.IsNil)
+	c.Assert(<-lockDone, qt.IsNil)
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 0)
 }
 
 func newSQLiteMigrationPlan(c *qt.C) (*generator.MigrationPlan, string) {

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -27,6 +27,25 @@ func TestPlanMigration_DoesNotWriteArtifacts(t *testing.T) {
 	c.Assert(matches, qt.HasLen, 0)
 }
 
+func TestPlanMigration_RecoversPendingPublicationBeforePlanning(t *testing.T) {
+	c := qt.New(t)
+	outputDir := c.TempDir()
+	pendingPaths, err := generator.WritePendingPublicationForTest(outputDir)
+	c.Assert(err, qt.IsNil)
+
+	plan := newSQLiteMigrationPlanAt(c, outputDir)
+
+	c.Assert(plan, qt.IsNotNil)
+	for _, path := range pendingPaths {
+		_, err = os.Stat(path)
+		c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	}
+	files, err := plan.WriteFilesContext(t.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Version < 9_999_999_999, qt.IsTrue)
+}
+
 func TestMigrationPlanWriteFiles_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	plan, outputDir := newSQLiteMigrationPlan(c)
@@ -169,16 +188,73 @@ func TestMigrationPlanWriteFilesContext_CancelsWhileWaitingForLock(t *testing.T)
 	c.Assert(matches, qt.HasLen, 0)
 }
 
+func TestGenerateMigration_CancelsWhileWaitingForRecoveryLock(t *testing.T) {
+	c := qt.New(t)
+	outputDir := c.TempDir()
+	opts := newSQLiteMigrationOptions(c, outputDir)
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- atlasmigrate.WithMigrationDirectoryLock(
+			t.Context(),
+			outputDir,
+			0,
+			func() error {
+				close(lockHeld)
+				<-releaseLock
+				return nil
+			},
+		)
+	}()
+	<-lockHeld
+	ctx, cancel := context.WithCancel(t.Context())
+	type generateResult struct {
+		files *generator.MigrationFiles
+		err   error
+	}
+	generateDone := make(chan generateResult, 1)
+	go func() {
+		files, err := generator.GenerateMigration(ctx, opts)
+		generateDone <- generateResult{files: files, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	result := <-generateDone
+	close(releaseLock)
+
+	c.Assert(result.err, qt.ErrorIs, context.Canceled)
+	c.Assert(result.files, qt.IsNil)
+	c.Assert(<-lockDone, qt.IsNil)
+}
+
 func newSQLiteMigrationPlan(c *qt.C) (*generator.MigrationPlan, string) {
 	c.Helper()
 	outputDir := c.TempDir()
+	return newSQLiteMigrationPlanAt(c, outputDir), outputDir
+}
+
+func newSQLiteMigrationPlanAt(c *qt.C, outputDir string) *generator.MigrationPlan {
+	c.Helper()
+	opts := newSQLiteMigrationOptions(c, outputDir)
+	plan, err := generator.PlanMigration(c.Context(), opts)
+	c.Assert(err, qt.IsNil)
+	return plan
+}
+
+func newSQLiteMigrationOptions(
+	c *qt.C,
+	outputDir string,
+) generator.GenerateMigrationOptions {
+	c.Helper()
 	devURL := atlasurl.SQLiteURLFromPath(filepath.Join(c.TempDir(), "dev.db"))
 	conn, err := dbschema.ConnectToDatabase(c.Context(), devURL)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(conn.Close(), qt.IsNil)
 	})
-	plan, err := generator.PlanMigration(c.Context(), generator.GenerateMigrationOptions{
+	return generator.GenerateMigrationOptions{
 		Generated: &goschema.Database{
 			Tables: []goschema.Table{
 				{StructName: "User", Name: "users"},
@@ -196,7 +272,5 @@ func newSQLiteMigrationPlan(c *qt.C) (*generator.MigrationPlan, string) {
 		DBConn:        conn,
 		MigrationName: "create_users",
 		OutputDir:     outputDir,
-	})
-	c.Assert(err, qt.IsNil)
-	return plan, outputDir
+	}
 }

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -62,11 +62,53 @@ func TestMigrationPlanWriteFiles_RejectsChangedDirectory(t *testing.T) {
 
 	files, err := plan.WriteFiles()
 
-	c.Assert(err, qt.ErrorMatches, `migration directory changed after migration planning`)
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
 	c.Assert(files, qt.IsNil)
 	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(matches, qt.DeepEquals, []string{concurrentMigration})
+}
+
+func TestMigrationPlanWriteFilesContext_RejectsConcurrentUse(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- atlasmigrate.WithMigrationDirectoryLock(
+			t.Context(),
+			outputDir,
+			0,
+			func() error {
+				close(lockHeld)
+				<-releaseLock
+				return nil
+			},
+		)
+	}()
+	<-lockHeld
+
+	type writeResult struct {
+		files *generator.MigrationFiles
+		err   error
+	}
+	writeDone := make(chan writeResult, 1)
+	go func() {
+		files, err := plan.WriteFilesContext(t.Context())
+		writeDone <- writeResult{files: files, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationPlanInUse)
+	c.Assert(files, qt.IsNil)
+	close(releaseLock)
+	firstResult := <-writeDone
+	c.Assert(firstResult.err, qt.IsNil)
+	c.Assert(firstResult.files, qt.IsNotNil)
+	c.Assert(<-lockDone, qt.IsNil)
 }
 
 func TestMigrationPlanWriteFilesContext_RejectsCanceledContext(t *testing.T) {

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/generator"
 )
 
@@ -129,7 +130,7 @@ func TestMigrationPlanWriteFilesContext_CancelsWhileWaitingForLock(t *testing.T)
 func newSQLiteMigrationPlan(c *qt.C) (*generator.MigrationPlan, string) {
 	c.Helper()
 	outputDir := c.TempDir()
-	devURL := "sqlite://" + filepath.Join(c.TempDir(), "dev.db")
+	devURL := atlasurl.SQLiteURLFromPath(filepath.Join(c.TempDir(), "dev.db"))
 	conn, err := dbschema.ConnectToDatabase(c.Context(), devURL)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -1,0 +1,82 @@
+package generator_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+func TestPlanMigration_DoesNotWriteArtifacts(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan, qt.IsNotNil)
+	c.Assert(matches, qt.HasLen, 0)
+}
+
+func TestMigrationPlanWriteFiles_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+
+	files, err := plan.WriteFiles()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 2)
+}
+
+func TestMigrationPlanWriteFiles_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	plan, _ := newSQLiteMigrationPlan(c)
+	files, err := plan.WriteFiles()
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+
+	files, err = plan.WriteFiles()
+
+	c.Assert(err, qt.ErrorMatches, `migration plan has already been written`)
+	c.Assert(files, qt.IsNil)
+}
+
+func newSQLiteMigrationPlan(c *qt.C) (*generator.MigrationPlan, string) {
+	c.Helper()
+	outputDir := c.TempDir()
+	devURL := "sqlite://" + filepath.Join(c.TempDir(), "dev.db")
+	conn, err := dbschema.ConnectToDatabase(c.Context(), devURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(conn.Close(), qt.IsNil)
+	})
+	plan, err := generator.PlanMigration(c.Context(), generator.GenerateMigrationOptions{
+		Generated: &goschema.Database{
+			Tables: []goschema.Table{
+				{StructName: "User", Name: "users"},
+			},
+			Fields: []goschema.Field{
+				{
+					StructName: "User",
+					FieldName:  "ID",
+					Name:       "id",
+					Type:       "INTEGER",
+					Primary:    true,
+				},
+			},
+		},
+		DBConn:        conn,
+		MigrationName: "create_users",
+		OutputDir:     outputDir,
+	})
+	c.Assert(err, qt.IsNil)
+	return plan, outputDir
+}

--- a/migration/generator/safety_test.go
+++ b/migration/generator/safety_test.go
@@ -2,8 +2,6 @@ package generator
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -34,42 +32,40 @@ func TestCheckDestructiveAllowed(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 }
 
-func TestCreateSafetyReportFile(t *testing.T) {
+func TestRenderSafetyReport(t *testing.T) {
 	c := qt.New(t)
 
-	dir := t.TempDir()
-	upFile := filepath.Join(dir, "1234567890_drop_legacy.up.sql")
-	err := os.WriteFile(upFile, []byte("DROP TABLE legacy;\n"), 0o600)
-	c.Assert(err, qt.IsNil)
-
-	reportFile, err := createSafetyReportFile(upFile, "html", []safety.StatementAssessment{
-		{
-			Index:     1,
-			NodeType:  "sql",
-			Subject:   "legacy",
-			Statement: "DROP TABLE legacy;",
-			Severity:  safety.Destructive,
-			Reason:    "DROP TABLE removes the table and all rows",
+	reportFile, content, err := renderSafetyReport(
+		"1234567890_drop_legacy.up.sql",
+		"html",
+		[]safety.StatementAssessment{
+			{
+				Index:     1,
+				NodeType:  "sql",
+				Subject:   "legacy",
+				Statement: "DROP TABLE legacy;",
+				Severity:  safety.Destructive,
+				Reason:    "DROP TABLE removes the table and all rows",
+			},
 		},
-	})
+	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(reportFile, qt.Equals, filepath.Join(dir, "1234567890_drop_legacy.safety.html"))
-
-	content, err := os.ReadFile(reportFile)
-	c.Assert(err, qt.IsNil)
+	c.Assert(reportFile, qt.Equals, "1234567890_drop_legacy.safety.html")
 	c.Assert(string(content), qt.Contains, "Ptah migration safety report")
 	c.Assert(string(content), qt.Contains, "DROP TABLE legacy;")
 	c.Assert(string(content), qt.Contains, "destructive")
 
-	jsonReportFile, err := createSafetyReportFile(upFile, "json", []safety.StatementAssessment{{
-		Index:    1,
-		Severity: safety.Destructive,
-		Reason:   "DROP TABLE removes the table and all rows",
-	}})
+	jsonReportFile, rawJSON, err := renderSafetyReport(
+		"1234567890_drop_legacy.up.sql",
+		"json",
+		[]safety.StatementAssessment{{
+			Index:    1,
+			Severity: safety.Destructive,
+			Reason:   "DROP TABLE removes the table and all rows",
+		}},
+	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(jsonReportFile, qt.Equals, filepath.Join(dir, "1234567890_drop_legacy.safety.json"))
-	rawJSON, err := os.ReadFile(jsonReportFile)
-	c.Assert(err, qt.IsNil)
+	c.Assert(jsonReportFile, qt.Equals, "1234567890_drop_legacy.safety.json")
 	var report safety.Report
 	c.Assert(json.Unmarshal(rawJSON, &report), qt.IsNil)
 	c.Assert(report.Highest, qt.Equals, safety.Destructive)

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -267,6 +267,7 @@ pending and out of order.
 - **`WithMigrationDirFormat(format)`**: Selects `auto`, `ptah`, or `atlas` filesystem discovery
 - **`WithAtlasTemplateData(data)`**: Supplies data, including `.Env`, for Atlas SQL template migrations
 - **`WithStatementInterceptor(interceptor)`**: Lets an external executor take over selected statements
+- **`WithStatementValidator(validator)`**: Validates every statement before the migration executes its first statement
 - **`WithStatementObserver(observer)`**: Reports each statement after successful execution without replacing the execution path
 - **`WithRevisionTableFormat(format)`**: Selects Ptah's native `schema_migrations` layout or Atlas's `atlas_schema_revisions` layout
 - **`Baseline(ctx, version)` / `BaselineWithOptions(ctx, opts)`**: Records provider migrations without executing their SQL bodies; Atlas metadata records only the exact baseline revision
@@ -391,6 +392,28 @@ if err != nil {
     panic(err)
 }
 ```
+
+### Validating statements before execution
+
+Use a statement validator when an embedder must reject SQL that can escape a
+disposable database or is unsupported by its execution policy. The provider
+splits and validates every statement in a migration before executing the first
+statement. A rejected later statement therefore leaves the migration
+untouched.
+
+```go
+provider, err := migrator.NewFSMigrationProvider(
+    os.DirFS("/path/to/migrations"),
+    migrator.WithStatementValidator(replayGuard),
+)
+if err != nil {
+    panic(err)
+}
+```
+
+`replayGuard` implements `migrator.StatementValidator`. The validator observes
+SQL only; combine it with `WithStatementInterceptor` when accepted statements
+may be executed by an external tool.
 
 `StatementEvent.Directives` is an event-local copy. An observer must not
 modify migration execution. A database-aware observer may capture a connection

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -93,6 +93,14 @@ func WithStatementInterceptor(interceptor StatementInterceptor) FSProviderOption
 	}
 }
 
+// WithStatementValidator makes every loaded migration validate all statements
+// before executing the first one.
+func WithStatementValidator(validator StatementValidator) FSProviderOption {
+	return func(p *FSMigrationProvider) {
+		p.hooks.validator = validator
+	}
+}
+
 // WithStatementObserver makes every loaded migration report successfully
 // executed statements to the given observer (see StatementObserver).
 func WithStatementObserver(observer StatementObserver) FSProviderOption {

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -77,6 +77,13 @@ type StatementInterceptor interface {
 	ExecuteStatement(ctx context.Context, conn *dbschema.DatabaseConnection, stmt string, directives map[string]string) (handled bool, err error)
 }
 
+// StatementValidator rejects unsafe or unsupported migration statements
+// without taking over their execution. Every statement in a migration file is
+// validated before the first statement runs.
+type StatementValidator interface {
+	ValidateStatement(stmt string) error
+}
+
 // StatementEvent describes one successfully executed migration statement.
 // Directives is an event-local copy; observers may modify it without affecting
 // migration execution or later events.
@@ -108,6 +115,7 @@ func (f StatementObserverFunc) ObserveStatement(
 
 type statementExecutionHooks struct {
 	interceptor StatementInterceptor
+	validator   StatementValidator
 	observer    StatementObserver
 }
 
@@ -555,6 +563,9 @@ func executeMigrationFileSQL(
 	}
 
 	statements := splitSQLStatementsForConnection(conn, sql)
+	if err := validateMigrationStatements(filename, statements, hooks.validator); err != nil {
+		return err
+	}
 	for i, stmt := range statements {
 		stmt = strings.TrimSpace(stmt)
 		if stmt == "" {
@@ -598,6 +609,31 @@ func executeMigrationFileSQL(
 					Err:   err,
 					Event: event,
 				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateMigrationStatements(
+	filename string,
+	statements []string,
+	validator StatementValidator,
+) error {
+	if validator == nil {
+		return nil
+	}
+	for i, statement := range statements {
+		statement = strings.TrimSpace(statement)
+		if statement == "" {
+			continue
+		}
+		if err := validator.ValidateStatement(statement); err != nil {
+			return &MigrationExecutionError{
+				Err:            fmt.Errorf("failed to validate migration SQL in %s: %w", filename, err),
+				Statement:      statement,
+				StatementIndex: i + 1,
+				Total:          len(statements),
 			}
 		}
 	}

--- a/migration/migrator/validator_test.go
+++ b/migration/migrator/validator_test.go
@@ -1,0 +1,87 @@
+package migrator_test
+
+import (
+	"errors"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+type statementValidatorRecorder struct {
+	statements []string
+	reject     string
+	err        error
+}
+
+func (r *statementValidatorRecorder) ValidateStatement(statement string) error {
+	r.statements = append(r.statements, statement)
+	if statement == r.reject {
+		return r.err
+	}
+	return nil
+}
+
+func TestFSMigrationProvider_StatementValidatorRejectsBeforeExecution(t *testing.T) {
+	c := qt.New(t)
+	validationErr := errors.New("unsafe second statement")
+	validator := &statementValidatorRecorder{
+		reject: "ATTACH DATABASE 'other.db' AS aux",
+		err:    validationErr,
+	}
+	interceptor := &recordingInterceptor{}
+	fsys := fstest.MapFS{
+		"1_validate.sql": {
+			Data: []byte(
+				"CREATE TABLE users (id INTEGER PRIMARY KEY);\n" +
+					"ATTACH DATABASE 'other.db' AS aux;\n",
+			),
+		},
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementValidator(validator),
+		migrator.WithStatementInterceptor(interceptor),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	err = migrations[0].Up(t.Context(), nil)
+
+	c.Assert(err, qt.ErrorIs, validationErr)
+	c.Assert(validator.statements, qt.DeepEquals, []string{
+		"CREATE TABLE users (id INTEGER PRIMARY KEY)",
+		"ATTACH DATABASE 'other.db' AS aux",
+	})
+	c.Assert(interceptor.statements, qt.HasLen, 0)
+}
+
+func TestFSMigrationProvider_StatementValidatorComposesWithInterceptor(t *testing.T) {
+	c := qt.New(t)
+	validator := &statementValidatorRecorder{}
+	interceptor := &recordingInterceptor{}
+	fsys := fstest.MapFS{
+		"1_validate.sql": {
+			Data: []byte("SELECT 1;\nSELECT 2;\n"),
+		},
+	}
+	provider, err := migrator.NewFSMigrationProvider(
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+		migrator.WithStatementValidator(validator),
+		migrator.WithStatementInterceptor(interceptor),
+	)
+	c.Assert(err, qt.IsNil)
+	migrations := provider.Migrations()
+	c.Assert(migrations, qt.HasLen, 1)
+
+	err = migrations[0].Up(t.Context(), nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(validator.statements, qt.DeepEquals, []string{"SELECT 1", "SELECT 2"})
+	c.Assert(interceptor.statements, qt.DeepEquals, []string{"SELECT 1", "SELECT 2"})
+}


### PR DESCRIPTION
## Summary

This PR implements the database-realm cleanup and migration-publication hardening tracked by #856. The branch provides replay confinement, canonical realm locks, safe cross-engine cleanup, crash-recoverable transactional migration publication, and explicit live-database/Windows CI coverage.

The work is split into linked subissues and remains traceable as separately validated commits:

- [x] #859 replay guards against cross-realm side effects (`ac71bb2`)
- [x] #860 canonical realm identity and locking (`81714fd`)
- [x] #861 transactional migration artifact publication (`80788c6`)
- [x] #862 PostgreSQL cleanup without unsafe `CASCADE` behavior (`79637d2`)
- [x] #863 explicit live database and CI coverage (`7d5c1f3`)

Final review hardening adds cancellation-safe planning, crash-safe rollback quarantine, scoped migration-directory lock reuse, MySQL stored-program visibility, PostgreSQL database-scoped artifact and large-object handling, ClickHouse external dependency checks, and SQL Server replication-state checks (`20290b3`..`39ebc7d`).

The standalone integration runner supports separate `<DATABASE>_CLEANUP_URL` credentials while enforcing that scenario and cleanup URLs identify the same database (`854889c`..`8cb73ef`). The restricted scenario connection is retained for migration generation, application, validation, and permission checks; broader cleanup credentials are reachable only through the runner-owned destructive-reset callback. The side-effect-free MySQL/MariaDB permission probe requires a real access-denied error and honors scenario cancellation, so accidental privilege escalation fails the suite.

## Validation

- Full uncached repository suite: `GOWORK=off GOCACHE=/tmp/ptah-go-cache go test -count=1 ./...`
- Focused race suites for generator, CLI, publication, and all affected database writers
- `golangci-lint run --fix ./...` followed by a clean `golangci-lint run ./...`
- `go tool qtlint ./...`, `scripts/check-test-style.sh`, and `git diff --check`
- Public API boundary, snapshot, and released-API checks
- Windows cross-compilation for publication/generator/CLI packages; dedicated Windows publication CI remains enabled
- Live PostgreSQL 18, CockroachDB 26.2.4, YugabyteDB 2026.1, MySQL 9.7, MariaDB 10.11, ClickHouse 24.12/24.10, and SQL Server 2025 cleanup checks
- Live ClickHouse and SQL Server replay/end-state checks
- Exact MySQL/MariaDB/CockroachDB/YugabyteDB migrate-diff E2E contour
- MySQL restricted-user test proving missing global `TRIGGER` visibility fails before DDL
- Live MySQL/MariaDB standalone-runner regression: all cleanup-aware scenarios pass while generation/application/validation retain restricted credentials; context-aware, side-effect-free access-denied checks pass (8/8 focused cases, 2/2 permission-only recheck)
- Documentation link, redirect, page-health, exit-code, version, build, and `npm audit` checks

The branch is ready for review. Merge remains blocked until the refreshed GitHub pipelines are green and every review thread is addressed.

Refs #856