### PR TITLE
Require package-level doc comments and enforce them via ST1000 (#854)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,14 +211,21 @@ linters:
         # STxxxx checks in https://staticcheck.io/docs/checks/#ST
         - all
         - -QF1008
-        - -ST1000
+        # ST1000 (package comment required) is intentionally enabled: every Go
+        # package must carry a package-level doc comment (see AGENTS.md).
         - -ST1003
         - -ST1005
         - -ST1016
+        # Exported-symbol comment checks stay off (previously suppressed by the
+        # "comments" exclusion preset, which had to go to let ST1000 report).
+        - -ST1020
+        - -ST1021
+        - -ST1022
   exclusions:
     generated: lax
     presets:
-      - comments
+      # The "comments" preset is deliberately absent: it swallows staticcheck
+      # "should have a package comment" findings, which would neuter ST1000.
       - common-false-positives
       - legacy
       - std-error-handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,21 @@ golangci-lint run ./...
 
 The fix pass can leave second-pass fallout such as unused imports, removed helper functions, or staticcheck suggestions. Clean those manually before considering the lint run complete.
 
+### Package Documentation
+
+Every Go package must carry a package-level doc comment (`// Package <name>
+...`), either atop a central file of the package or in a dedicated `doc.go`.
+This is CI-enforced through staticcheck's `ST1000` in `.golangci.yml`; a PR
+that introduces a new package must ship the comment in the same PR. The rule
+applies to every module in the repository, including `testkit/`. `main`
+packages describe their binary; test-only packages (`package foo_test`) are
+exempt.
+
+The comment must say in one to three sentences what the package does and where
+it sits in the system, grounded in the package's actual code. Generic filler
+such as "Package x contains x utilities" is not acceptable — the anti-slop
+rules of [`docs/STYLE_GUIDE.md`](docs/STYLE_GUIDE.md) apply in spirit.
+
 ## Testing Standards
 
 ### Declarative Tests Only

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -1,3 +1,6 @@
+// Package compare implements "ptah schema compare", which builds the desired
+// schema from Go entities or schema files and reports how it differs from a
+// live database.
 package compare
 
 import (

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -1,3 +1,6 @@
+// Package drift implements "ptah schema drift", which checks a live database
+// for drift against the desired schema and signals divergence through its exit
+// code.
 package drift
 
 import (

--- a/cmd/dropall/dropall.go
+++ b/cmd/dropall/dropall.go
@@ -1,3 +1,5 @@
+// Package dropall implements "ptah db drop-all", the destructive command that
+// drops all tables and enums from the target database.
 package dropall
 
 import (

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -1,3 +1,6 @@
+// Package generate implements "ptah schema render", which renders the desired
+// schema from Go entity annotations or local schema files as dialect-specific
+// SQL DDL.
 package generate
 
 import (

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -1,3 +1,7 @@
+// Package migrate implements the "ptah migrations" planning commands: "plan"
+// prints migration SQL from schema differences, "generate" writes timestamped
+// migration files, and "create" scaffolds empty migration files for manual
+// SQL.
 package migrate
 
 import (

--- a/cmd/migratebaseline/migratebaseline.go
+++ b/cmd/migratebaseline/migratebaseline.go
@@ -1,3 +1,6 @@
+// Package migratebaseline implements "ptah migrations baseline", which records
+// existing migration files as already applied in the revision table without
+// executing them.
 package migratebaseline
 
 import (

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -1,3 +1,5 @@
+// Package migratedown implements "ptah migrations down", which rolls back
+// applied migrations to a target version against a live database.
 package migratedown
 
 import (

--- a/cmd/migraterepair/migraterepair.go
+++ b/cmd/migraterepair/migraterepair.go
@@ -1,3 +1,5 @@
+// Package migraterepair implements "ptah migrations repair", which fixes dirty
+// or partial migration revision metadata after a failed run.
 package migraterepair
 
 import (

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -1,3 +1,6 @@
+// Package migratestatus implements "ptah migrations status", which reports
+// applied and pending migrations for a live database and migrations
+// directory.
 package migratestatus
 
 import (

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -1,3 +1,6 @@
+// Package migrateup implements "ptah migrations up", which applies pending
+// migrations to a live database with optional lint checks, apply limits, and
+// online-DDL configuration.
 package migrateup
 
 import (

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -1,3 +1,5 @@
+// Package readdb implements "ptah db read", which introspects a live database
+// and displays its tables, columns, indexes, and constraints.
 package readdb
 
 import (

--- a/cmd/seed/seed.go
+++ b/cmd/seed/seed.go
@@ -1,3 +1,5 @@
+// Package seed implements "ptah seed", which applies environment-scoped SQL
+// seed files to a live database.
 package seed
 
 import (

--- a/core/ast/mocks/visitor.go
+++ b/core/ast/mocks/visitor.go
@@ -1,3 +1,6 @@
+// Package mocks provides test doubles for the core/ast package, most notably
+// MockVisitor, an ast.Visitor that records the nodes it visits and can be
+// switched to fail every visit for error-path testing.
 package mocks
 
 import (

--- a/core/goschema/doc.go
+++ b/core/goschema/doc.go
@@ -1,0 +1,9 @@
+// Package goschema parses Ptah annotation comments in Go source files into the
+// database-agnostic schema model used across the Ptah toolchain.
+//
+// The package walks directories or file systems (ParseDir, ParseFS, ParseDirs),
+// extracts tables, fields, indexes, constraints, enums, extensions, roles, and
+// RLS declarations into a Database, merges embedded fields and multi-file
+// declarations, and reports conflicting definitions. The resulting model feeds
+// the renderer, planner, and schema-diff layers.
+package goschema

--- a/core/goschema/internal/parseutils/parseutils.go
+++ b/core/goschema/internal/parseutils/parseutils.go
@@ -1,3 +1,6 @@
+// Package parseutils implements the low-level annotation text parsing shared by
+// goschema: splitting key="value" comment options into maps and extracting
+// platform-specific override groups.
 package parseutils
 
 import (

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -1,6 +1,3 @@
-// Package goschematypes defines the core data structures used throughout the Ptah schema migration system.
-// These types represent the intermediate representation of database schema elements parsed from
-// Go struct annotations and used for generating database-specific migration SQL.
 package goschema
 
 import (

--- a/core/renderer/internal/dialects/internal/bufwriter/bufwriter.go
+++ b/core/renderer/internal/dialects/internal/bufwriter/bufwriter.go
@@ -1,3 +1,5 @@
+// Package bufwriter provides the small line-oriented output buffer the dialect
+// renderers share for accumulating generated SQL.
 package bufwriter
 
 import (

--- a/core/renderer/internal/dialects/mariadb/mariadb.go
+++ b/core/renderer/internal/dialects/mariadb/mariadb.go
@@ -1,3 +1,5 @@
+// Package mariadb provides the MariaDB SQL renderer: a thin wrapper over the
+// shared mysqllike renderer configured with MariaDB capabilities.
 package mariadb
 
 import (

--- a/core/renderer/internal/dialects/mysql/mysql.go
+++ b/core/renderer/internal/dialects/mysql/mysql.go
@@ -1,3 +1,5 @@
+// Package mysql provides the MySQL SQL renderer: a thin wrapper over the
+// shared mysqllike renderer configured with strict MySQL capabilities.
 package mysql
 
 import (

--- a/core/renderer/internal/dialects/mysqllike/mysqllike.go
+++ b/core/renderer/internal/dialects/mysqllike/mysqllike.go
@@ -1,3 +1,7 @@
+// Package mysqllike implements the shared SQL renderer for the MySQL family of
+// dialects. It is the validity layer of the capability model: planners record
+// intent on AST nodes, and this renderer drops modifiers the concrete target
+// (MySQL or MariaDB) would reject.
 package mysqllike
 
 import (

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -1,3 +1,6 @@
+// Package postgres implements the PostgreSQL SQL renderer, turning Ptah AST
+// nodes into PostgreSQL DDL including enums, sequences, roles, row-level
+// security policies, and check constraints.
 package postgres
 
 import (

--- a/core/sqlutil/doc.go
+++ b/core/sqlutil/doc.go
@@ -1,0 +1,5 @@
+// Package sqlutil provides SQL text utilities shared across Ptah: splitting
+// scripts into statements, stripping comments, rewriting bind placeholders per
+// dialect, normalizing client-side delimiter directives, and classifying
+// routine body fragments.
+package sqlutil

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -1,3 +1,6 @@
+// Package types defines the database-agnostic model of an introspected live
+// schema (DBSchema and its tables, columns, indexes, and constraints) shared by
+// the dbschema readers and writers and consumed by schema diffing.
 package types
 
 import (

--- a/examples/annotation_parser/models/doc.go
+++ b/examples/annotation_parser/models/doc.go
@@ -1,0 +1,4 @@
+// Package models contains the annotated example entities parsed by the
+// annotation_parser example to demonstrate Ptah schema annotations, including
+// embedded struct fields.
+package models

--- a/examples/migrator/migrations.go
+++ b/examples/migrator/migrations.go
@@ -1,3 +1,6 @@
+// Package migrator embeds a sample migrations directory demonstrating the
+// Ptah migration file layout; migrator package examples run against this
+// embedded filesystem.
 package migrator
 
 import (

--- a/integration/doc.go
+++ b/integration/doc.go
@@ -1,0 +1,5 @@
+// Package integration implements Ptah's dynamic integration-test framework: it
+// loads versioned entity fixtures from fixtures/entities, runs migration
+// scenarios (up, down, idempotency, round-trip) against live databases, and
+// produces the reports consumed by the integration-test binary.
+package integration

--- a/integration/fixtures/entities/000-initial/doc.go
+++ b/integration/fixtures/entities/000-initial/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 000-initial: the baseline users and
+// products schema that the schema-evolution scenarios start from.
+package entities

--- a/integration/fixtures/entities/001-add-fields/doc.go
+++ b/integration/fixtures/entities/001-add-fields/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 001-add-fields: extends 000-initial
+// by adding new columns to the users and products tables.
+package entities

--- a/integration/fixtures/entities/002-add-posts/doc.go
+++ b/integration/fixtures/entities/002-add-posts/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 002-add-posts: adds a posts table
+// referencing users on top of 001-add-fields.
+package entities

--- a/integration/fixtures/entities/003-add-enums/doc.go
+++ b/integration/fixtures/entities/003-add-enums/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 003-add-enums: introduces enum-typed
+// columns across the users, posts, and products tables.
+package entities

--- a/integration/fixtures/entities/004-field-rename/doc.go
+++ b/integration/fixtures/entities/004-field-rename/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 004-field-rename: renames user
+// columns (age to user_age, bio to description) to exercise field-rename
+// diffs.
+package entities

--- a/integration/fixtures/entities/005-field-type-change/doc.go
+++ b/integration/fixtures/entities/005-field-type-change/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 005-field-type-change: changes an
+// existing column's type to exercise type-change migrations.
+package entities

--- a/integration/fixtures/entities/006-field-drop/doc.go
+++ b/integration/fixtures/entities/006-field-drop/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 006-field-drop: drops a column to
+// exercise column-removal migrations.
+package entities

--- a/integration/fixtures/entities/007-index-add/doc.go
+++ b/integration/fixtures/entities/007-index-add/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 007-index-add: adds an index to
+// exercise index-creation migrations.
+package entities

--- a/integration/fixtures/entities/008-index-remove/doc.go
+++ b/integration/fixtures/entities/008-index-remove/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 008-index-remove: removes the index
+// introduced in 007-index-add.
+package entities

--- a/integration/fixtures/entities/009-add-constraints/doc.go
+++ b/integration/fixtures/entities/009-add-constraints/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 009-add-constraints: adds table
+// constraints to exercise constraint-creation migrations.
+package entities

--- a/integration/fixtures/entities/010-drop-constraints/doc.go
+++ b/integration/fixtures/entities/010-drop-constraints/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 010-drop-constraints: removes the
+// constraints introduced in 009-add-constraints.
+package entities

--- a/integration/fixtures/entities/011-add-entity/doc.go
+++ b/integration/fixtures/entities/011-add-entity/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 011-add-entity: adds a new category
+// entity to exercise table creation within an existing schema.
+package entities

--- a/integration/fixtures/entities/012-drop-entity/doc.go
+++ b/integration/fixtures/entities/012-drop-entity/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 012-drop-entity: removes an entity
+// to exercise table-drop migrations.
+package entities

--- a/integration/fixtures/entities/013-embedded-fields/doc.go
+++ b/integration/fixtures/entities/013-embedded-fields/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 013-embedded-fields: introduces
+// embedded struct fields such as shared timestamps and base IDs across the
+// entities.
+package entities

--- a/integration/fixtures/entities/014-rls-functions/doc.go
+++ b/integration/fixtures/entities/014-rls-functions/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 014-rls-functions: adds PostgreSQL
+// functions and row-level security policies for tenant isolation.
+package entities

--- a/integration/fixtures/entities/015-rls-advanced/doc.go
+++ b/integration/fixtures/entities/015-rls-advanced/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 015-rls-advanced: exercises advanced
+// row-level security policy configurations.
+package entities

--- a/integration/fixtures/entities/016-rls-multiple-files/doc.go
+++ b/integration/fixtures/entities/016-rls-multiple-files/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 016-rls-multiple-files: spreads
+// RLS-enabled entities (locations, areas, commodities, files) across multiple
+// files to verify multi-file annotation parsing.
+package entities

--- a/integration/fixtures/entities/016-roles/doc.go
+++ b/integration/fixtures/entities/016-roles/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 016-roles: declares PostgreSQL roles
+// (application, admin, read-only) alongside the users and products tables.
+package entities

--- a/integration/fixtures/entities/017-rls-inventario-reproduction/doc.go
+++ b/integration/fixtures/entities/017-rls-inventario-reproduction/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 017-rls-inventario-reproduction:
+// reproduces the Inventario multi-tenant RLS schema used to debug
+// tenant-isolation policy generation.
+package entities

--- a/integration/fixtures/entities/017-roles-advanced/doc.go
+++ b/integration/fixtures/entities/017-roles-advanced/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 017-roles-advanced: evolves the role
+// declarations from 016-roles to exercise role alterations.
+package entities

--- a/integration/fixtures/entities/018-rls-functions-modified/doc.go
+++ b/integration/fixtures/entities/018-rls-functions-modified/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 018-rls-functions-modified: modifies
+// the RLS functions from 014-rls-functions to exercise function-change
+// migrations.
+package entities

--- a/integration/fixtures/entities/019-field-check-constraints/doc.go
+++ b/integration/fixtures/entities/019-field-check-constraints/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 019-field-check-constraints: adds
+// column-level check constraints to the users and products tables.
+package entities

--- a/integration/fixtures/entities/020-field-check-constraints-modified/doc.go
+++ b/integration/fixtures/entities/020-field-check-constraints-modified/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture
+// 020-field-check-constraints-modified: modifies the check constraints from
+// 019-field-check-constraints to exercise check-change diffs.
+package entities

--- a/integration/fixtures/entities/021-fk-actions-initial/doc.go
+++ b/integration/fixtures/entities/021-fk-actions-initial/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 021-fk-actions-initial: a
+// users/orders schema with the field-level foreign key fk_orders_user declared
+// without explicit referential actions.
+package entities

--- a/integration/fixtures/entities/022-fk-actions-changed/doc.go
+++ b/integration/fixtures/entities/022-fk-actions-changed/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 022-fk-actions-changed: changes
+// fk_orders_user from 021-fk-actions-initial to carry ON DELETE SET NULL and
+// ON UPDATE CASCADE.
+package entities

--- a/integration/fixtures/entities/023-go-annotations-objects/doc.go
+++ b/integration/fixtures/entities/023-go-annotations-objects/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 023-go-annotations-objects: declares
+// non-table schema objects (such as views) through Go annotations, including a
+// duplicate declaration case.
+package entities

--- a/integration/fixtures/entities/024-roundtrip-empty/doc.go
+++ b/integration/fixtures/entities/024-roundtrip-empty/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 024-roundtrip-empty: an
+// intentionally empty schema serving as the empty endpoint of round-trip
+// scenarios.
+package entities

--- a/integration/fixtures/entities/025-roundtrip-single-table/doc.go
+++ b/integration/fixtures/entities/025-roundtrip-single-table/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 025-roundtrip-single-table: a single
+// users table for the minimal round-trip scenario.
+package entities

--- a/integration/fixtures/entities/026-roundtrip-composite-pk/doc.go
+++ b/integration/fixtures/entities/026-roundtrip-composite-pk/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 026-roundtrip-composite-pk: a
+// memberships table with a composite primary key for round-trip testing.
+package entities

--- a/integration/fixtures/entities/027-roundtrip-self-reference/doc.go
+++ b/integration/fixtures/entities/027-roundtrip-self-reference/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 027-roundtrip-self-reference: a
+// category table with a self-referencing foreign key.
+package entities

--- a/integration/fixtures/entities/028-roundtrip-parent-child/doc.go
+++ b/integration/fixtures/entities/028-roundtrip-parent-child/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 028-roundtrip-parent-child: a
+// customer/order pair linked by a parent-child foreign key.
+package entities

--- a/integration/fixtures/entities/029-roundtrip-mutual-cycle/doc.go
+++ b/integration/fixtures/entities/029-roundtrip-mutual-cycle/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 029-roundtrip-mutual-cycle:
+// left_nodes and right_nodes tables referencing each other to round-trip a
+// mutual foreign-key cycle.
+package entities

--- a/integration/fixtures/entities/030-roundtrip-check-v1/doc.go
+++ b/integration/fixtures/entities/030-roundtrip-check-v1/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 030-roundtrip-check-v1: a product
+// table with a check constraint, the first half of the check-constraint
+// round-trip pair.
+package entities

--- a/integration/fixtures/entities/031-roundtrip-check-v2/doc.go
+++ b/integration/fixtures/entities/031-roundtrip-check-v2/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 031-roundtrip-check-v2: the modified
+// check constraint completing the pair started in 030-roundtrip-check-v1.
+package entities

--- a/integration/fixtures/entities/032-roundtrip-unique-v1/doc.go
+++ b/integration/fixtures/entities/032-roundtrip-unique-v1/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 032-roundtrip-unique-v1: an account
+// table with a unique constraint, the first half of the unique-constraint
+// round-trip pair.
+package entities

--- a/integration/fixtures/entities/033-roundtrip-unique-v2/doc.go
+++ b/integration/fixtures/entities/033-roundtrip-unique-v2/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 033-roundtrip-unique-v2: the
+// modified unique constraint completing the pair started in
+// 032-roundtrip-unique-v1.
+package entities

--- a/integration/fixtures/entities/034-roundtrip-fk-chain/doc.go
+++ b/integration/fixtures/entities/034-roundtrip-fk-chain/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 034-roundtrip-fk-chain: an
+// organization, project, and task chain linked by foreign keys.
+package entities

--- a/integration/fixtures/entities/035-roundtrip-fk-diamond/doc.go
+++ b/integration/fixtures/entities/035-roundtrip-fk-diamond/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 035-roundtrip-fk-diamond: a
+// diamond-shaped foreign-key graph across account, team, project, and
+// assignment tables.
+package entities

--- a/integration/fixtures/entities/036-roundtrip-pk-base/doc.go
+++ b/integration/fixtures/entities/036-roundtrip-pk-base/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 036-roundtrip-pk-base: a memberships
+// table without a primary key, the base for the composite-primary-key round
+// trips.
+package entities

--- a/integration/fixtures/entities/037-roundtrip-pk-composite-added/doc.go
+++ b/integration/fixtures/entities/037-roundtrip-pk-composite-added/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 037-roundtrip-pk-composite-added:
+// adds a composite primary key (org_id, user_id) to the 036-roundtrip-pk-base
+// memberships table.
+package entities

--- a/integration/fixtures/entities/038-roundtrip-pk-composite-removed/doc.go
+++ b/integration/fixtures/entities/038-roundtrip-pk-composite-removed/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 038-roundtrip-pk-composite-removed:
+// removes the composite primary key again, matching 036-roundtrip-pk-base.
+package entities

--- a/integration/fixtures/entities/039-roundtrip-enum-v1/doc.go
+++ b/integration/fixtures/entities/039-roundtrip-enum-v1/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 039-roundtrip-enum-v1: a product
+// table with an enum status column, the first step of the enum round-trip
+// sequence.
+package entities

--- a/integration/fixtures/entities/040-roundtrip-enum-v2-add/doc.go
+++ b/integration/fixtures/entities/040-roundtrip-enum-v2-add/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 040-roundtrip-enum-v2-add: adds an
+// enum value to the 039-roundtrip-enum-v1 schema.
+package entities

--- a/integration/fixtures/entities/041-roundtrip-enum-v3-remove/doc.go
+++ b/integration/fixtures/entities/041-roundtrip-enum-v3-remove/doc.go
@@ -1,0 +1,3 @@
+// Package entities is integration fixture 041-roundtrip-enum-v3-remove:
+// removes an enum value relative to 040-roundtrip-enum-v2-add.
+package entities

--- a/integration/fixtures/entities/042-roundtrip-check-to-unique-v1/doc.go
+++ b/integration/fixtures/entities/042-roundtrip-check-to-unique-v1/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 042-roundtrip-check-to-unique-v1: an
+// account table with a check constraint that 043-roundtrip-check-to-unique-v2
+// replaces with a unique constraint.
+package entities

--- a/integration/fixtures/entities/043-roundtrip-check-to-unique-v2/doc.go
+++ b/integration/fixtures/entities/043-roundtrip-check-to-unique-v2/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 043-roundtrip-check-to-unique-v2:
+// replaces the check constraint from 042-roundtrip-check-to-unique-v1 with a
+// unique constraint.
+package entities

--- a/integration/fixtures/entities/044-roundtrip-unique-to-check-v1/doc.go
+++ b/integration/fixtures/entities/044-roundtrip-unique-to-check-v1/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 044-roundtrip-unique-to-check-v1: a
+// product table with a unique constraint that 045-roundtrip-unique-to-check-v2
+// replaces with a check constraint.
+package entities

--- a/integration/fixtures/entities/045-roundtrip-unique-to-check-v2/doc.go
+++ b/integration/fixtures/entities/045-roundtrip-unique-to-check-v2/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 045-roundtrip-unique-to-check-v2:
+// replaces the unique constraint from 044-roundtrip-unique-to-check-v1 with a
+// check constraint.
+package entities

--- a/integration/fixtures/entities/046-roundtrip-existing-fk-base/doc.go
+++ b/integration/fixtures/entities/046-roundtrip-existing-fk-base/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 046-roundtrip-existing-fk-base:
+// users and accounts tables where account_id and manager_id exist as plain
+// columns without foreign keys.
+package entities

--- a/integration/fixtures/entities/047-roundtrip-existing-fk-added/doc.go
+++ b/integration/fixtures/entities/047-roundtrip-existing-fk-added/doc.go
@@ -1,0 +1,4 @@
+// Package entities is integration fixture 047-roundtrip-existing-fk-added:
+// adds foreign keys onto the pre-existing account_id and manager_id columns
+// from 046-roundtrip-existing-fk-base.
+package entities

--- a/internal/atlashclfmt/fmt.go
+++ b/internal/atlashclfmt/fmt.go
@@ -1,3 +1,7 @@
+// Package atlashclfmt formats Atlas HCL schema files with canonical hclwrite
+// formatting. It backs the "schema fmt" commands of both the ptah and
+// ptah-compat binaries, in rewrite (FormatPaths) and check-only (CheckPaths)
+// modes.
 package atlashclfmt
 
 import (

--- a/internal/atlasmigrate/doc.go
+++ b/internal/atlasmigrate/doc.go
@@ -1,0 +1,4 @@
+// Package atlasmigrate implements the engine behind the ptah-compat binary's
+// Atlas OSS "migrate" commands: applying, diffing, rolling back, and reporting
+// status of versioned migration directories with Atlas-compatible semantics.
+package atlasmigrate

--- a/internal/atlasmigratereport/apply.go
+++ b/internal/atlasmigratereport/apply.go
@@ -1,3 +1,6 @@
+// Package atlasmigratereport renders Atlas-compatible "migrate apply" report
+// output from Ptah runtime results, resolving the applied migration filesystem
+// and connection details the report templates need.
 package atlasmigratereport
 
 import (

--- a/internal/atlasreport/doc.go
+++ b/internal/atlasreport/doc.go
@@ -1,0 +1,4 @@
+// Package atlasreport defines the Atlas CLI-compatible report payloads and
+// template rendering used by the ptah-compat binary for migrate apply, down,
+// lint, and status output in JSON and Go-template formats.
+package atlasreport

--- a/internal/atlasschema/doc.go
+++ b/internal/atlasschema/doc.go
@@ -1,0 +1,5 @@
+// Package atlasschema implements the engine behind the ptah-compat binary's
+// Atlas OSS "schema" commands: inspecting live databases, diffing schema
+// sources, and applying desired state with Atlas-compatible policies and plan
+// locking.
+package atlasschema

--- a/internal/atlasurl/url.go
+++ b/internal/atlasurl/url.go
@@ -1,3 +1,6 @@
+// Package atlasurl interprets Atlas-style database URLs: mapping a URL to a
+// Ptah dialect, validating that a URL matches a target dialect, and deciding
+// whether two URLs address the same database.
 package atlasurl
 
 import (

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -1,3 +1,7 @@
+// Package dbschematogo converts an introspected database schema
+// (dbschema/types.DBSchema) into the goschema entity model, so live databases
+// can flow through the same diff and planning pipeline as annotated Go
+// sources.
 package dbschematogo
 
 import (

--- a/internal/dbschema/dbtest/driver.go
+++ b/internal/dbschema/dbtest/driver.go
@@ -1,3 +1,6 @@
+// Package dbtest provides an in-memory database/sql driver whose query and
+// exec behavior is scripted per test, so dialect readers and writers can be
+// tested without a live database.
 package dbtest
 
 import (

--- a/internal/dbschema/mssql/doc.go
+++ b/internal/dbschema/mssql/doc.go
@@ -1,0 +1,3 @@
+// Package mssql implements SQL Server schema introspection and DDL execution
+// for the dbschema connection layer.
+package mssql

--- a/internal/dbschema/mysql/mysql.go
+++ b/internal/dbschema/mysql/mysql.go
@@ -1,3 +1,5 @@
+// Package mysql implements MySQL schema introspection and DDL execution for
+// the dbschema connection layer.
 package mysql
 
 import (

--- a/internal/dbschema/postgres/postgres.go
+++ b/internal/dbschema/postgres/postgres.go
@@ -1,3 +1,5 @@
+// Package postgres implements schema introspection and DDL execution for
+// PostgreSQL-family databases in the dbschema connection layer.
 package postgres
 
 import (

--- a/internal/dbschema/sqlite/sqlite.go
+++ b/internal/dbschema/sqlite/sqlite.go
@@ -1,3 +1,5 @@
+// Package sqlite implements SQLite schema introspection and DDL execution for
+// the dbschema connection layer.
 package sqlite
 
 import (

--- a/internal/deporder/deporder.go
+++ b/internal/deporder/deporder.go
@@ -1,3 +1,6 @@
+// Package deporder provides deterministic dependency ordering for schema
+// objects: stable topological sorts used to create objects such as views in
+// dependency order and drop them in reverse.
 package deporder
 
 import (

--- a/internal/pathguard/pathguard.go
+++ b/internal/pathguard/pathguard.go
@@ -1,3 +1,6 @@
+// Package pathguard validates user-supplied filesystem paths, resolving them
+// against an allowed root and rejecting escapes so CLI flags cannot traverse
+// outside the intended directory.
 package pathguard
 
 import (

--- a/internal/planner/dialects/mysql/doc.go
+++ b/internal/planner/dialects/mysql/doc.go
@@ -1,0 +1,6 @@
+// Package mysql implements the MySQL migration planner dialect, transforming
+// schema differences into MySQL DDL operations. Modifier intent recorded on
+// the planned AST (such as IF EXISTS) is later validated by the renderer
+// capability layer, which drops what the concrete MySQL target does not
+// accept.
+package mysql

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -1,3 +1,5 @@
+// Package testutils provides canned goschema fixtures and small lookup helpers
+// shared by dbschema-related unit tests.
 package testutils
 
 import (

--- a/migration/schemadiff/internal/normalize/normalize.go
+++ b/migration/schemadiff/internal/normalize/normalize.go
@@ -1,3 +1,6 @@
+// Package normalize canonicalizes type names, default values, and expressions
+// read from live databases so schema comparison is not tripped by cosmetic
+// dialect spellings such as PostgreSQL typecasts.
 package normalize
 
 import (

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -1,3 +1,7 @@
+// Package types defines the schema difference model (SchemaDiff and the
+// per-object diffs for tables, columns, enums, functions, triggers, RLS
+// policies, roles, and grants) produced by schemadiff and consumed by the
+// migration planner.
 package types
 
 import (

--- a/stubs/product.go
+++ b/stubs/product.go
@@ -1,3 +1,6 @@
+// Package stubs contains annotated Go entities exercising the Ptah annotation
+// surface end to end. The files serve as parser input for goschema tests and
+// demos; they are parsed from source rather than imported.
 package stubs
 
 //ptah:schema:table name="products" platform.mysql.engine="InnoDB" platform.mysql.comment="Product catalog" platform.mariadb.engine="InnoDB" platform.mariadb.comment="Product catalog"


### PR DESCRIPTION
Closes #854.

## Summary

- **Lint it — yes, ST1000**: staticcheck's package-comment check is now enforced. Non-obvious fix required: merely deleting the `-ST1000` suppression does nothing — golangci-lint v2's `comments` exclusion preset text-matches and silently swallows every ST1000 finding. The preset is removed, its one real effect preserved by explicitly disabling `ST1020/ST1021/ST1022` (exported-symbol comment checks), with YAML comments explaining both decisions. Revive can't double-report (its rule allowlist never included `package-comments`). Empirically verified: rule enabled + docs absent → 230 findings across 94 packages; final tree → 0; removing any doc.go immediately flags again.
- **Fix missing documentation**: all 94 undocumented packages now carry meaningful `// Package ...` comments (34 atop a central file, 60 in `doc.go` — including the 50 integration fixture packages, each verified against its actual annotations, which caught real traps like the PK-less 036/038 fixtures). One landmine dodged: `stubs/` gets its comment in `product.go` because a `doc.go` breaks `TestGenerateCreateTableFromStubs`'s per-file parsing. A stale wrong-name package comment in `core/goschema/types.go` removed. `testkit/` already compliant.
- **AGENTS.md**: new "Package Documentation" requirement — every package ships a doc comment (CI-enforced, same-PR for new packages, applies to every module incl. testkit), with the quality bar (what/where-it-sits, no filler; STYLE_GUIDE anti-slop applies in spirit).

## Verification

build, gofmt, vet, **golangci-lint 0 issues with the new rule active**, qtlint, teststyle, full `go test ./...` (166 pkgs), public-API checks (snapshot unaffected — it doesn't capture package doc text), testkit module build+test — all green.