### PR TITLE
Sign release artifacts as cosign v3 Sigstore bundles

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,30 +100,30 @@ sboms:
   - id: source
     artifacts: source
 
+# cosign v3 writes a single Sigstore bundle per artifact (the v2-era
+# --output-signature/--output-certificate pair is no longer the default
+# contract). Verify with:
+#   cosign verify-blob --bundle <artifact>.sigstore.json <artifact> \
+#     --certificate-identity-regexp 'github.com/stokaro/ptah' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com
 signs:
   - id: checksums
     cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - "--yes"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: checksum
     output: true
   - id: sboms
     cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - "--yes"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: sbom
     output: true


### PR DESCRIPTION
The first tag push (v0.1.0) failed in the release pipeline: cosign v3 (installed by `sigstore/cosign-installer`) made the Sigstore **bundle** format the `sign-blob` default, and the v2-era `--output-signature`/`--output-certificate` invocation now dies with `create bundle file: open : no such file or directory` (empty bundle path).

Fix: the checksum and SBOM sign steps emit a single `<artifact>.sigstore.json` bundle each (`--bundle=${signature}`), with the verification command documented in the config:

```
cosign verify-blob --bundle <artifact>.sigstore.json <artifact> \
  --certificate-identity-regexp "github.com/stokaro/ptah" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

`goreleaser check` validates the config; the `goreleaser-check` CI job covers it too. After merge the v0.1.0 tag will be re-cut on the fixed master.