### PR TITLE
fix(config): preserve explicit values across merges

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -616,7 +616,10 @@ func atlasMigrateDirFormatFlag(nativeName string) atlasargs.Flag {
 
 func atlasMigrateDirFormatValue(value string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(value))
-	if normalized == "" || normalized == atlasDirFormatDefault {
+	if normalized == "" {
+		return "", fmt.Errorf("migration directory format must not be empty")
+	}
+	if normalized == atlasDirFormatDefault {
 		return atlasDirFormatDefault, nil
 	}
 	if slices.Contains(unsupportedAtlasDirFormats, normalized) {

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
@@ -78,6 +79,7 @@ func atlasMigrateApplyArgs(cmd *cobra.Command, args []string) error {
 
 func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, args []string) error {
 	formatOutput := cmd.Flags().Changed("format")
+	projectDirFormatPresent := false
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
 	if needsAtlasMigrateApplyConfig(cmd) {
 		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
@@ -86,17 +88,50 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 		return err
 	}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.dir = dbcli.EffectiveString(cmd, "dir", opts.dir, projectCfg.Migration.Dir)
-		if projectCfg.Migration.Format != "" {
-			opts.dirFormat = projectCfg.Migration.Format
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		opts.dir = dbcli.EffectiveString(
+			cmd,
+			"dir",
+			opts.dir,
+			projectCfg.StringValue(projectconfig.StringMigrationDir),
+		)
+		dirFormat := projectCfg.StringValue(projectconfig.StringMigrationFormat)
+		projectDirFormatPresent = dirFormat.Present
+		if dirFormat.Present {
+			opts.dirFormat = dirFormat.Value
 		}
-		opts.txMode = dbcli.EffectiveString(cmd, "tx-mode", opts.txMode, projectCfg.Migration.TxMode)
-		opts.execOrder = dbcli.EffectiveString(cmd, "exec-order", opts.execOrder, projectCfg.Migration.ExecOrder)
-		opts.revisionsSchema = dbcli.EffectiveString(cmd, "revisions-schema", opts.revisionsSchema, projectCfg.Migration.RevisionsSchema)
-		opts.lockTimeout = dbcli.EffectiveString(cmd, "lock-timeout", opts.lockTimeout, projectCfg.Migration.LockTimeout)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Migrate.Apply)
-		formatOutput = formatOutput || projectCfg.Format.Migrate.Apply != ""
+		opts.txMode = dbcli.EffectiveString(
+			cmd,
+			"tx-mode",
+			opts.txMode,
+			projectCfg.StringValue(projectconfig.StringMigrationTxMode),
+		)
+		opts.execOrder = dbcli.EffectiveString(
+			cmd,
+			"exec-order",
+			opts.execOrder,
+			projectCfg.StringValue(projectconfig.StringMigrationExecOrder),
+		)
+		opts.revisionsSchema = dbcli.EffectiveString(
+			cmd,
+			"revisions-schema",
+			opts.revisionsSchema,
+			projectCfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+		)
+		opts.lockTimeout = dbcli.EffectiveString(
+			cmd,
+			"lock-timeout",
+			opts.lockTimeout,
+			projectCfg.StringValue(projectconfig.StringMigrationLockTimeout),
+		)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatMigrateApply)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatOutput = formatOutput || formatValue.Present
 	}
 	if formatOutput && strings.TrimSpace(opts.format) == "" {
 		return fmt.Errorf("--format must not be empty")
@@ -114,13 +149,20 @@ func runAtlasMigrateApply(cmd *cobra.Command, opts atlasMigrateApplyOptions, arg
 	}
 
 	var localDir atlasargs.LocalDir
-	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+	if loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		localDir, err = atlasProjectConfigLocalDirWithQuery(cmd, opts.dir)
 	} else {
 		localDir, err = atlasargs.ParseLocalDir(opts.dir)
 	}
 	if err != nil {
 		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+	}
+	if projectDirFormatPresent && opts.dirFormat == "" {
+		if _, queryOverridesProjectFormat := localDir.Query["format"]; !queryOverridesProjectFormat {
+			return fmt.Errorf("atlas migrate apply --dir: migration directory format must not be empty")
+		}
 	}
 	dir := localDir.Path
 	dir, err = pathguard.ResolveCLIPath(dir)

--- a/cmd/atlas/migrate_apply_project_test.go
+++ b/cmd/atlas/migrate_apply_project_test.go
@@ -134,6 +134,21 @@ func TestMigrateApplyProjectDirURLFormatOverridesProjectDefault(t *testing.T) {
 	c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
 }
 
+func TestMigrateApplyProjectDirURLFormatOverridesExplicitEmptyProjectFormat(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	writeAtlasApplyProjectMigration(c, "migrations", "1_create_widgets.sql", "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n")
+	writeAtlasApplyProjectSum(c, "migrations")
+	dbPath := filepath.Join(root, "apply.db")
+	writeAtlasApplyProjectConfigWithDir(c, dbPath, "file://migrations?format=atlas", "", "LINEAR")
+
+	output, err := executeAtlasProjectCommand("migrate", "apply", "--env", "local")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", output))
+	c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
+}
+
 func TestMigrateApplyProjectDirURLFormatSelectsGoose(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/editor"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
@@ -87,6 +88,7 @@ diff policy values.`,
 }
 
 func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name string) error {
+	formatConfigured := cmd.Flags().Changed("format")
 	policy := atlasschema.DiffPolicy{}
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
 	if needsAtlasMigrateDiffConfig(cmd) {
@@ -96,15 +98,29 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
-		opts.dirURL = dbcli.EffectiveString(cmd, "dir", opts.dirURL, projectCfg.Migration.Dir)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Migrate.Diff)
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
+		opts.dirURL = dbcli.EffectiveString(
+			cmd,
+			"dir",
+			opts.dirURL,
+			projectCfg.StringValue(projectconfig.StringMigrationDir),
+		)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatMigrateDiff)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatConfigured = formatConfigured || formatValue.Present
 		policy, err = atlasDiffPolicy(projectCfg)
 		if err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
 	}
-	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+	if loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		opts.dirURL, err = atlasProjectConfigLocalDir(cmd, opts.dirURL)
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
@@ -127,6 +143,9 @@ func runAtlasMigrateDiff(cmd *cobra.Command, opts atlasMigrateDiffOptions, name 
 	qualifier, err := atlasmigrate.ParseQualifier(opts.qualifier)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
+	}
+	if formatConfigured && strings.TrimSpace(opts.format) == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
 	}
 	format := atlasreport.NormalizeMigrateDiffFormat(opts.format)
 	if err := atlasreport.ValidateSchemaDiffTemplate(format); err != nil {

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
@@ -331,33 +332,60 @@ func applyAtlasMigrateDownFormatProjectConfig(opts *atlasMigrateDownFormatOption
 	if err != nil {
 		return err
 	}
-	opts.url = atlasDownEffective(opts.flagSet, "url", opts.url, cfg.DatabaseURL)
-	opts.devURL = atlasDownEffective(opts.flagSet, "dev-url", opts.devURL, cfg.DevURL)
-	opts.revisionsSchema = atlasDownEffective(opts.flagSet, "revisions-schema", opts.revisionsSchema, cfg.Migration.RevisionsSchema)
-	opts.lockTimeout = atlasDownEffective(opts.flagSet, "lock-timeout", opts.lockTimeout, cfg.Migration.LockTimeout)
-	if cfg.Migration.Format != "" {
+	opts.url = atlasDownEffective(
+		opts.flagSet,
+		"url",
+		opts.url,
+		cfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	opts.devURL = atlasDownEffective(
+		opts.flagSet,
+		"dev-url",
+		opts.devURL,
+		cfg.StringValue(projectconfig.StringDevURL),
+	)
+	opts.revisionsSchema = atlasDownEffective(
+		opts.flagSet,
+		"revisions-schema",
+		opts.revisionsSchema,
+		cfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+	)
+	opts.lockTimeout = atlasDownEffective(
+		opts.flagSet,
+		"lock-timeout",
+		opts.lockTimeout,
+		cfg.StringValue(projectconfig.StringMigrationLockTimeout),
+	)
+	dirFormat := cfg.StringValue(projectconfig.StringMigrationFormat)
+	if dirFormat.Present {
 		// The format path executes Atlas-format directories only, matching the
 		// dedicated apply and status commands.
-		if _, err := atlasMigrateDirFormatValue(cfg.Migration.Format); err != nil {
+		if _, err := atlasMigrateDirFormatValue(dirFormat.Value); err != nil {
 			return fmt.Errorf("atlas.hcl migration.format: %w", err)
 		}
 	}
-	if !opts.flagSet.Changed("dir") && cfg.Migration.Dir != "" {
-		dir, err := atlasProjectConfigLocalDirFromFlags(project.flags, cfg.Migration.Dir)
+	migrationDir := cfg.StringValue(projectconfig.StringMigrationDir)
+	if !opts.flagSet.Changed("dir") && migrationDir.Present {
+		dir, err := atlasProjectConfigLocalDirFromFlags(project.flags, migrationDir.Value)
 		if err != nil {
 			return fmt.Errorf("atlas.hcl migration.dir: %w", err)
 		}
-		opts.rawDir = cfg.Migration.Dir
+		opts.rawDir = migrationDir.Value
 		opts.dir = dir
 	}
 	return nil
 }
 
-func atlasDownEffective(flagSet *pflag.FlagSet, name, flagValue, configValue string) string {
-	if flagSet.Changed(name) || configValue == "" {
+func atlasDownEffective(
+	flagSet *pflag.FlagSet,
+	name string,
+	flagValue string,
+	configValue projectconfig.Value[string],
+) string {
+	if flagSet.Changed(name) || !configValue.Present {
 		return flagValue
 	}
-	return configValue
+	return configValue.Value
 }
 
 func parseAtlasMigrateDownTarget(value string) (int64, error) {

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -69,16 +69,51 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
-		opts.dir = dbcli.EffectiveString(cmd, "dir", opts.dir, projectCfg.Migration.Dir)
-		opts.dirFormat = dbcli.EffectiveString(cmd, "dir-format", opts.dirFormat, projectCfg.Migration.Format)
-		opts.atlasEnv = dbcli.EffectiveString(cmd, dbcli.EnvFlagName, opts.atlasEnv, projectCfg.EnvName)
-		opts.gitBase = dbcli.EffectiveString(cmd, "git-base", opts.gitBase, projectCfg.Lint.GitBase)
-		opts.gitDir = dbcli.EffectiveString(cmd, "git-dir", opts.gitDir, projectCfg.Lint.GitDir)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Migrate.Lint)
-		formatOutput = formatOutput || projectCfg.Format.Migrate.Lint != ""
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
+		opts.dir = dbcli.EffectiveString(
+			cmd,
+			"dir",
+			opts.dir,
+			projectCfg.StringValue(projectconfig.StringMigrationDir),
+		)
+		opts.dirFormat = dbcli.EffectiveString(
+			cmd,
+			"dir-format",
+			opts.dirFormat,
+			projectCfg.StringValue(projectconfig.StringMigrationFormat),
+		)
+		opts.atlasEnv = dbcli.EffectiveString(
+			cmd,
+			dbcli.EnvFlagName,
+			opts.atlasEnv,
+			projectCfg.StringValue(projectconfig.StringEnvName),
+		)
+		if !cmd.Flags().Changed("latest") {
+			opts.gitBase = dbcli.EffectiveString(
+				cmd,
+				"git-base",
+				opts.gitBase,
+				projectCfg.StringValue(projectconfig.StringLintGitBase),
+			)
+			opts.gitDir = dbcli.EffectiveString(
+				cmd,
+				"git-dir",
+				opts.gitDir,
+				projectCfg.StringValue(projectconfig.StringLintGitDir),
+			)
+		}
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatMigrateLint)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatOutput = formatOutput || formatValue.Present
 	}
-	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+	if loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		opts.dir, err = atlasProjectConfigLocalDir(cmd, opts.dir)
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate lint --dir: %w", err))
@@ -156,7 +191,7 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 			GitDir:    cmd.Flags().Changed("git-dir"),
 			Latest:    cmd.Flags().Changed("latest"),
 		},
-	}, atlasMigrateLintReportConfig(projectCfg))
+	}, projectCfg)
 	if err != nil {
 		if formatOutput {
 			if err := writeAtlasMigrateLintReplayError(cmd, opts, dir, report, integrity, err); err != nil {
@@ -186,11 +221,6 @@ func runAtlasMigrateLint(cmd *cobra.Command, opts atlasMigrateLintOptions) error
 		return exitcode.New(1, errors.New(atlasMigrateLintFindingError))
 	}
 	return nil
-}
-
-func atlasMigrateLintReportConfig(projectCfg projectconfig.Config) projectconfig.Config {
-	projectCfg.Migration.Dir = ""
-	return projectCfg
 }
 
 func writeAtlasMigrateLintReplayError(

--- a/cmd/atlas/migrate_set.go
+++ b/cmd/atlas/migrate_set.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
@@ -107,15 +108,35 @@ func prepareAtlasMigrateSet(
 		return atlasMigrateSetOptions{}, "", err
 	}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.dir = dbcli.EffectiveString(cmd, "dir", opts.dir, projectCfg.Migration.Dir)
-		opts.dirFormat = dbcli.EffectiveString(cmd, "dir-format", opts.dirFormat, projectCfg.Migration.Format)
-		opts.atlasEnv = dbcli.EffectiveString(cmd, dbcli.EnvFlagName, opts.atlasEnv, projectCfg.EnvName)
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		opts.dir = dbcli.EffectiveString(
+			cmd,
+			"dir",
+			opts.dir,
+			projectCfg.StringValue(projectconfig.StringMigrationDir),
+		)
+		opts.dirFormat = dbcli.EffectiveString(
+			cmd,
+			"dir-format",
+			opts.dirFormat,
+			projectCfg.StringValue(projectconfig.StringMigrationFormat),
+		)
+		opts.atlasEnv = dbcli.EffectiveString(
+			cmd,
+			dbcli.EnvFlagName,
+			opts.atlasEnv,
+			projectCfg.StringValue(projectconfig.StringEnvName),
+		)
 		opts.revisionsSchema = dbcli.EffectiveString(
 			cmd,
 			"revisions-schema",
 			opts.revisionsSchema,
-			projectCfg.Migration.RevisionsSchema,
+			projectCfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
 		)
 	}
 	if opts.dir == "" {
@@ -128,7 +149,9 @@ func prepareAtlasMigrateSet(
 	if format != atlasDirFormatDefault {
 		return atlasMigrateSetOptions{}, "", fmt.Errorf("atlas migrate set --dir-format: expected atlas")
 	}
-	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+	if loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		opts.dir, err = atlasProjectConfigLocalDir(cmd, opts.dir)
 		if err != nil {
 			return atlasMigrateSetOptions{}, "", fmt.Errorf("atlas migrate set --dir: %w", err)

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasargs"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
@@ -61,15 +62,43 @@ func runAtlasMigrateStatus(cmd *cobra.Command, opts atlasMigrateStatusOptions) e
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.dir = dbcli.EffectiveString(cmd, "dir", opts.dir, projectCfg.Migration.Dir)
-		opts.dirFormat = dbcli.EffectiveString(cmd, "dir-format", opts.dirFormat, projectCfg.Migration.Format)
-		opts.atlasEnv = dbcli.EffectiveString(cmd, dbcli.EnvFlagName, opts.atlasEnv, projectCfg.EnvName)
-		opts.revisionsSchema = dbcli.EffectiveString(cmd, "revisions-schema", opts.revisionsSchema, projectCfg.Migration.RevisionsSchema)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Migrate.Status)
-		formatOutput = formatOutput || projectCfg.Format.Migrate.Status != ""
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		opts.dir = dbcli.EffectiveString(
+			cmd,
+			"dir",
+			opts.dir,
+			projectCfg.StringValue(projectconfig.StringMigrationDir),
+		)
+		opts.dirFormat = dbcli.EffectiveString(
+			cmd,
+			"dir-format",
+			opts.dirFormat,
+			projectCfg.StringValue(projectconfig.StringMigrationFormat),
+		)
+		opts.atlasEnv = dbcli.EffectiveString(
+			cmd,
+			dbcli.EnvFlagName,
+			opts.atlasEnv,
+			projectCfg.StringValue(projectconfig.StringEnvName),
+		)
+		opts.revisionsSchema = dbcli.EffectiveString(
+			cmd,
+			"revisions-schema",
+			opts.revisionsSchema,
+			projectCfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+		)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatMigrateStatus)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatOutput = formatOutput || formatValue.Present
 	}
-	if loaded && !cmd.Flags().Changed("dir") && projectCfg.Migration.Dir != "" {
+	if loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		opts.dir, err = atlasProjectConfigLocalDir(cmd, opts.dir)
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -349,21 +349,57 @@ func applyAtlasProjectConfigToArgs(
 	cfg projectconfig.Config,
 	projectFlags atlasProjectFlagValues,
 ) ([]string, error) {
-	args = appendAtlasProjectStringArg(flags, args, "url", cfg.DatabaseURL)
-	args = appendAtlasProjectStringArg(flags, args, "dev-url", cfg.DevURL)
-	if cfg.Migration.Dir != "" && atlasFlagRegistered(flags, "dir") && !atlasFlagPresent(flags, args, "dir") {
-		dir, err := atlasProjectConfigLocalDirFromFlags(projectFlags, cfg.Migration.Dir)
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"url",
+		cfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"dev-url",
+		cfg.StringValue(projectconfig.StringDevURL),
+	)
+	migrationDir := cfg.StringValue(projectconfig.StringMigrationDir)
+	if migrationDir.Present && atlasFlagRegistered(flags, "dir") && !atlasFlagPresent(flags, args, "dir") {
+		dir, err := atlasProjectConfigLocalDirFromFlags(projectFlags, migrationDir.Value)
 		if err != nil {
 			return nil, fmt.Errorf("atlas.hcl migration.dir: %w", err)
 		}
 		args = append(args, "--dir", dir)
 	}
-	args = appendAtlasProjectStringArg(flags, args, "dir-format", cfg.Migration.Format)
-	args = appendAtlasProjectStringArg(flags, args, "revisions-schema", cfg.Migration.RevisionsSchema)
-	args = appendAtlasProjectStringArg(flags, args, "lock-timeout", cfg.Migration.LockTimeout)
-	args = appendAtlasProjectStringArg(flags, args, "latest", atlasProjectLatest(cfg))
-	args = appendAtlasProjectStringArg(flags, args, "git-base", cfg.Lint.GitBase)
-	args = appendAtlasProjectStringArg(flags, args, "git-dir", cfg.Lint.GitDir)
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"dir-format",
+		cfg.StringValue(projectconfig.StringMigrationFormat),
+	)
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"revisions-schema",
+		cfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+	)
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"lock-timeout",
+		cfg.StringValue(projectconfig.StringMigrationLockTimeout),
+	)
+	cliLatest := atlasFlagPresent(flags, args, "latest")
+	cliGitBase := atlasFlagPresent(flags, args, "git-base")
+	if !cliGitBase {
+		args = appendAtlasProjectStringArg(flags, args, "latest", atlasProjectLatest(cfg))
+	}
+	gitBase := cfg.StringValue(projectconfig.StringLintGitBase)
+	if !cliLatest && gitBase.Value != "" {
+		args = appendAtlasProjectStringArg(flags, args, "git-base", gitBase)
+	}
+	gitDir := cfg.StringValue(projectconfig.StringLintGitDir)
+	if !cliLatest && gitDir.Value != "" {
+		args = appendAtlasProjectStringArg(flags, args, "git-dir", gitDir)
+	}
 	return args, nil
 }
 
@@ -379,14 +415,26 @@ func applyAtlasSchemaTestProjectConfig(
 	cfg projectconfig.Config,
 	projectFlags atlasProjectFlagValues,
 ) ([]string, error) {
-	args = appendAtlasProjectStringArg(flags, args, "dev-url", cfg.DevURL)
-	if len(cfg.SchemaSources) == 0 || atlasFlagPresent(flags, args, "url") {
+	args = appendAtlasProjectStringArg(
+		flags,
+		args,
+		"dev-url",
+		cfg.StringValue(projectconfig.StringDevURL),
+	)
+	if atlasFlagPresent(flags, args, "url") {
 		return args, nil
 	}
-	if len(cfg.SchemaSources) > 1 {
-		return nil, fmt.Errorf("atlas schema test supports one atlas.hcl schema source, got %d", len(cfg.SchemaSources))
+	sources := cfg.SchemaSourcesValue()
+	if !sources.Present {
+		return args, nil
 	}
-	urls, err := atlasProjectConfigSchemaURLsFromFlags(projectFlags, cfg.SchemaSources)
+	if len(sources.Value) == 0 {
+		return nil, fmt.Errorf("atlas.hcl schema.src: desired schema source is required")
+	}
+	if len(sources.Value) > 1 {
+		return nil, fmt.Errorf("atlas schema test supports one atlas.hcl schema source, got %d", len(sources.Value))
+	}
+	urls, err := atlasProjectConfigSchemaURLsFromFlags(projectFlags, sources.Value)
 	if err != nil {
 		return nil, fmt.Errorf("atlas.hcl schema.src: %w", err)
 	}
@@ -408,18 +456,24 @@ func applyAtlasProjectConfigToNativeArgs(args []string, flags atlasProjectFlagVa
 	return args, nil
 }
 
-func atlasProjectLatest(cfg projectconfig.Config) string {
-	if cfg.Lint.Latest == nil {
-		return ""
+func atlasProjectLatest(cfg projectconfig.Config) projectconfig.Value[string] {
+	latest := cfg.LintLatestValue()
+	return projectconfig.Value[string]{
+		Value:   fmt.Sprint(latest.Value),
+		Present: latest.Present,
 	}
-	return fmt.Sprint(*cfg.Lint.Latest)
 }
 
-func appendAtlasProjectStringArg(flags []atlasargs.Flag, args []string, name string, value string) []string {
-	if strings.TrimSpace(value) == "" || !atlasFlagRegistered(flags, name) || atlasFlagPresent(flags, args, name) {
+func appendAtlasProjectStringArg(
+	flags []atlasargs.Flag,
+	args []string,
+	name string,
+	value projectconfig.Value[string],
+) []string {
+	if !value.Present || !atlasFlagRegistered(flags, name) || atlasFlagPresent(flags, args, name) {
 		return args
 	}
-	return append(args, "--"+name, value)
+	return append(args, "--"+name, value.Value)
 }
 
 func atlasFlagRegistered(flags []atlasargs.Flag, name string) bool {

--- a/cmd/atlas/project_config_presence_test.go
+++ b/cmd/atlas/project_config_presence_test.go
@@ -1,0 +1,193 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+)
+
+func TestCompatCommand_ProjectConfigExplicitEmptyMigrationDirFails(t *testing.T) {
+	c := qt.New(t)
+	t.Chdir(t.TempDir())
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  migration {
+    dir = ""
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "hash", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl migration\.dir: migration directories URL is required`)
+}
+
+func TestCompatCommand_ProjectConfigExplicitEmptyMigrationFormatFails(t *testing.T) {
+	c := qt.New(t)
+	t.Chdir(t.TempDir())
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  migration {
+    format = ""
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "hash", "--env", "local", "--dir", "file://migrations"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas migrate hash --dir-format: migration directory format must not be empty`)
+}
+
+func TestCompatCommand_ProjectConfigEmptyGitBaseKeepsLatestSelector(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	c.Assert(os.Mkdir("migrations", 0o750), qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join("migrations", "1.sql"),
+			[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`lint {
+  latest = 1
+}
+env "ci" {
+  lint {
+    git {
+      base = ""
+      dir  = ""
+    }
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "lint",
+		"--env", "ci",
+		"--dir", "migrations",
+		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", out.String()))
+}
+
+func TestCompatCommand_ExplicitGitBaseSuppressesProjectLatest(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	c.Assert(os.Mkdir("migrations", 0o750), qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join("migrations", "1.sql"),
+			[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "ci" {
+  lint {
+    latest = 1
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "lint",
+		"--env", "ci",
+		"--dir", "migrations",
+		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
+		"--git-base=-unsafe",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `--git-base "-unsafe" is not a safe Git ref`)
+	c.Assert(out.String(), qt.Not(qt.Contains), "--latest and --git-base are mutually exclusive")
+}
+
+func TestCompatCommand_ExplicitLatestSuppressesProjectGitSelector(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	c.Assert(os.Mkdir("migrations", 0o750), qt.IsNil)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join("migrations", "1.sql"),
+			[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "ci" {
+  lint {
+    git {
+      base = "-unsafe"
+      dir  = "/not/a/repository"
+    }
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "lint",
+		"--env", "ci",
+		"--dir", "migrations",
+		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
+		"--latest", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", out.String()))
+}
+
+func TestCompatCommand_ProjectConfigExplicitEmptySchemaSourcesFail(t *testing.T) {
+	c := qt.New(t)
+	t.Chdir(t.TempDir())
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  src = []
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"schema", "test", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl schema\.src: desired schema source is required`)
+}

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/editor"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlasreport"
@@ -120,12 +121,23 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
 		opts.toURLs = effectiveStringArray(cmd, "to", opts.toURLs, projectCfg.SchemaSources)
 		opts.exclude = effectiveAtlasExclude(cmd, opts.exclude, projectCfg)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Schema.Apply)
-		formatOutput = formatOutput || projectCfg.Format.Schema.Apply != ""
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatSchemaApply)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatOutput = formatOutput || formatValue.Present
 		policy, err = atlasDiffPolicy(projectCfg)
 		if err != nil {
 			return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_clean.go
+++ b/cmd/atlas/schema_clean.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdflags"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/schemaclean"
@@ -57,9 +58,15 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Schema.Clean)
-		formatOutput = formatOutput || projectCfg.Format.Schema.Clean != ""
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatSchemaClean)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatOutput = formatOutput || formatValue.Present
 	}
 	if formatOutput && strings.TrimSpace(opts.format) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -2,11 +2,13 @@ package atlas
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasschema"
@@ -66,6 +68,7 @@ Atlas Cloud web output is an explicit follow-up gap.`,
 }
 
 func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
+	formatConfigured := cmd.Flags().Changed("format")
 	policy := atlasschema.DiffPolicy{}
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
 	if needsAtlasSchemaDiffConfig(cmd) {
@@ -76,9 +79,16 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 	}
 	if loaded {
 		opts.toURLs = effectiveStringArray(cmd, "to", opts.toURLs, projectCfg.SchemaSources)
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
 		opts.exclude = effectiveAtlasExclude(cmd, opts.exclude, projectCfg)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Schema.Diff)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatSchemaDiff)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatConfigured = formatConfigured || formatValue.Present
 		policy, err = atlasDiffPolicy(projectCfg)
 		if err != nil {
 			return cmdutil.Fail(cmd, err)
@@ -89,6 +99,9 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
 		}
+	}
+	if formatConfigured && strings.TrimSpace(opts.format) == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
 	}
 	format := atlasreport.NormalizeSchemaDiffFormat(opts.format)
 	if err := atlasreport.ValidateSchemaDiffTemplate(format); err != nil {

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlassource"
 )
@@ -60,6 +61,7 @@ contacted.`,
 }
 
 func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) error {
+	formatConfigured := cmd.Flags().Changed("format")
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
 	if needsAtlasSchemaInspectConfig(cmd) {
 		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
@@ -69,14 +71,29 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	}
 	projectEnv := atlassource.ProjectEnv{}
 	if loaded {
-		opts.url = dbcli.EffectiveString(cmd, "url", opts.url, projectCfg.DatabaseURL)
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
+		opts.url = dbcli.EffectiveString(
+			cmd,
+			"url",
+			opts.url,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
 		opts.exclude = effectiveAtlasExclude(cmd, opts.exclude, projectCfg)
-		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, projectCfg.Format.Schema.Inspect)
+		formatValue := projectCfg.StringValue(projectconfig.StringFormatSchemaInspect)
+		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
+		formatConfigured = formatConfigured || formatValue.Present
 		projectEnv, err = atlasSourceProjectEnv(cmd, projectCfg)
 		if err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
+	}
+	if formatConfigured && strings.TrimSpace(opts.format) == "" {
+		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
 	}
 	if _, err := atlasschema.NormalizeInspectFormat(opts.format); err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasschema"
 )
@@ -99,11 +100,17 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 	if loaded {
-		if !cmd.Flags().Changed(atlasFromFlagName) && strings.TrimSpace(projectCfg.DatabaseURL) != "" {
-			opts.fromURLs = []string{projectCfg.DatabaseURL}
+		databaseURL := projectCfg.StringValue(projectconfig.StringDatabaseURL)
+		if !cmd.Flags().Changed(atlasFromFlagName) && databaseURL.Present {
+			opts.fromURLs = []string{databaseURL.Value}
 		}
 		opts.toURLs = effectiveStringArray(cmd, "to", opts.toURLs, projectCfg.SchemaSources)
-		opts.devURL = dbcli.EffectiveString(cmd, "dev-url", opts.devURL, projectCfg.DevURL)
+		opts.devURL = dbcli.EffectiveString(
+			cmd,
+			"dev-url",
+			opts.devURL,
+			projectCfg.StringValue(projectconfig.StringDevURL),
+		)
 		opts.exclude = effectiveAtlasExclude(cmd, opts.exclude, projectCfg)
 		policy, err = atlasDiffPolicy(projectCfg)
 		if err != nil {

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/planner"
@@ -97,8 +98,18 @@ func compareCommand(cmd *cobra.Command, opts *options) error {
 	if err != nil {
 		return err
 	}
-	dbURL := dbcli.EffectiveString(cmd, dbURLFlag, opts.dbURL, projectCfg.DatabaseURL)
-	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemas, dbcli.JoinSchemas(projectCfg.Schemas))
+	dbURL := dbcli.EffectiveString(
+		cmd,
+		dbURLFlag,
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	schemasValue := dbcli.EffectiveString(
+		cmd,
+		dbcli.SchemasFlagName,
+		opts.schemas,
+		dbcli.JoinSchemasValue(projectCfg.SchemasValue()),
+	)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/schemaops"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/migration/safety"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -148,8 +149,18 @@ func runDrift(cmd *cobra.Command, opts runOptions) error {
 	if err != nil {
 		return writeError(cmd.ErrOrStderr(), opts.format, err.Error())
 	}
-	dbURL := dbcli.EffectiveString(cmd, "db-url", opts.dbURL, projectCfg.DatabaseURL)
-	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemasRaw, dbcli.JoinSchemas(projectCfg.Schemas))
+	dbURL := dbcli.EffectiveString(
+		cmd,
+		"db-url",
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	schemasValue := dbcli.EffectiveString(
+		cmd,
+		dbcli.SchemasFlagName,
+		opts.schemasRaw,
+		dbcli.JoinSchemasValue(projectCfg.SchemasValue()),
+	)
 
 	if dbURL == "" {
 		return writeError(cmd.ErrOrStderr(), opts.format, "database URL is required")

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -86,13 +86,26 @@ func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig
 	})
 }
 
-// EffectiveString returns flagValue when flagName was explicitly set, otherwise
-// configValue when it is non-empty, otherwise flagValue.
-func EffectiveString(cmd *cobra.Command, flagName, flagValue, configValue string) string {
-	if flagChanged(cmd, flagName) || configValue == "" {
+// EffectiveString returns an explicit CLI value first, then a present project
+// config value (including an empty value), then the flag's built-in default.
+func EffectiveString(
+	cmd *cobra.Command,
+	flagName string,
+	flagValue string,
+	configValue projectconfig.Value[string],
+) string {
+	if flagChanged(cmd, flagName) || !configValue.Present {
 		return flagValue
 	}
-	return configValue
+	return configValue.Value
+}
+
+// JoinSchemasValue converts a presence-aware schema list to its CLI form.
+func JoinSchemasValue(value projectconfig.Value[[]string]) projectconfig.Value[string] {
+	return projectconfig.Value[string]{
+		Value:   JoinSchemas(value.Value),
+		Present: value.Present,
+	}
 }
 
 // ResolveExternalSchemaCommands resolves the external-command schema source for

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -18,7 +18,10 @@ func TestEffectiveStringPrefersExplicitCLIFlag(t *testing.T) {
 	cmd.Flags().String("db-url", "builtin", "")
 	c.Assert(cmd.Flags().Set("db-url", "cli"), qt.IsNil)
 
-	got := dbcli.EffectiveString(cmd, "db-url", "cli", "config")
+	got := dbcli.EffectiveString(cmd, "db-url", "cli", projectconfig.Value[string]{
+		Value:   "config",
+		Present: true,
+	})
 
 	c.Assert(got, qt.Equals, "cli")
 }
@@ -28,9 +31,39 @@ func TestEffectiveStringUsesConfigWhenFlagIsDefault(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("migrations-dir", "./migrations", "")
 
-	got := dbcli.EffectiveString(cmd, "migrations-dir", "./migrations", "atlas-migrations")
+	got := dbcli.EffectiveString(cmd, "migrations-dir", "./migrations", projectconfig.Value[string]{
+		Value:   "atlas-migrations",
+		Present: true,
+	})
 
 	c.Assert(got, qt.Equals, "atlas-migrations")
+}
+
+func TestEffectiveStringUsesExplicitEmptyConfigValue(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("migrations-dir", "./migrations", "")
+
+	got := dbcli.EffectiveString(cmd, "migrations-dir", "./migrations", projectconfig.Value[string]{
+		Present: true,
+	})
+
+	c.Assert(got, qt.Equals, "")
+}
+
+func TestEffectiveStringUsesDefaultWhenConfigValueIsAbsent(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("migrations-dir", "./migrations", "")
+
+	got := dbcli.EffectiveString(
+		cmd,
+		"migrations-dir",
+		"./migrations",
+		projectconfig.Value[string]{},
+	)
+
+	c.Assert(got, qt.Equals, "./migrations")
 }
 
 func TestLoadProjectConfigReadsAtlasEnvAndPtahFallback(t *testing.T) {

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -197,10 +197,12 @@ func prepareReportOptions(
 	projectCfg projectconfig.Config,
 	sourceOpts sourceOptions,
 ) (migrationlintreport.Options, *migrationsource.OCI, error) {
-	effectiveDir := opts.Dir
-	if !opts.Changed.Dir && projectCfg.Migration.Dir != "" {
-		effectiveDir = projectCfg.Migration.Dir
-	}
+	effectiveDir := dbcli.EffectiveString(
+		cmd,
+		"dir",
+		opts.Dir,
+		projectCfg.StringValue(projectconfig.StringMigrationDir),
+	)
 	isOCI := strings.HasPrefix(effectiveDir, ociartifact.Scheme)
 	if sourceOpts.attach && !isOCI {
 		return migrationlintreport.Options{}, nil, errors.New("--attach requires an OCI migration source")
@@ -209,18 +211,22 @@ func prepareReportOptions(
 		return opts, nil, nil
 	}
 
-	effectiveGitBase := opts.GitBase
-	if !opts.Changed.GitBase {
-		effectiveGitBase = projectCfg.Lint.GitBase
-	}
+	effectiveGitBase := dbcli.EffectiveString(
+		cmd,
+		gitBaseFlag,
+		opts.GitBase,
+		projectCfg.StringValue(projectconfig.StringLintGitBase),
+	)
 	if strings.TrimSpace(effectiveGitBase) != "" {
 		return migrationlintreport.Options{}, nil, errors.New("--git-base is not supported with OCI migration sources")
 	}
 
-	effectiveDirFormat := opts.DirFormat
-	if !opts.Changed.DirFormat && projectCfg.Migration.Format != "" {
-		effectiveDirFormat = projectCfg.Migration.Format
-	}
+	effectiveDirFormat := dbcli.EffectiveString(
+		cmd,
+		"dir-format",
+		opts.DirFormat,
+		projectCfg.StringValue(projectconfig.StringMigrationFormat),
+	)
 	source, err := migrationsource.Resolve(cmd.Context(), effectiveDir, migrationsource.Options{
 		DirFormat: migrator.MigrationDirFormat(effectiveDirFormat),
 		PlainHTTP: sourceOpts.plainHTTP,

--- a/cmd/lint/lint_internal_test.go
+++ b/cmd/lint/lint_internal_test.go
@@ -1,0 +1,50 @@
+package lint
+
+// White-box testing required: these tests verify the command's pre-resolution
+// precedence before an OCI migration source is fetched.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+	"github.com/stokaro/ptah/internal/migrationlintreport"
+)
+
+func TestPrepareReportOptions_PresentEmptyDirSuppressesDefault(t *testing.T) {
+	c := qt.New(t)
+	cfg, err := projectconfig.ParsePtah([]byte("migration:\n  dir: \"\"\n"), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+	cmd := NewLintCommand()
+
+	got, provenance, err := prepareReportOptions(
+		cmd,
+		migrationlintreport.Options{Dir: "oci://"},
+		cfg,
+		sourceOptions{attach: true},
+	)
+
+	c.Assert(err, qt.ErrorMatches, "--attach requires an OCI migration source")
+	c.Assert(got, qt.DeepEquals, migrationlintreport.Options{})
+	c.Assert(provenance, qt.IsNil)
+}
+
+func TestPrepareReportOptions_ExplicitDirWinsPresentEmptyConfig(t *testing.T) {
+	c := qt.New(t)
+	cfg, err := projectconfig.ParsePtah([]byte("migration:\n  dir: \"\"\n"), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+	cmd := NewLintCommand()
+	c.Assert(cmd.Flags().Set("dir", "oci://"), qt.IsNil)
+
+	got, provenance, err := prepareReportOptions(
+		cmd,
+		migrationlintreport.Options{Dir: "oci://"},
+		cfg,
+		sourceOptions{attach: true},
+	)
+
+	c.Assert(err, qt.ErrorMatches, "invalid OCI reference: invalid reference: missing registry or repository")
+	c.Assert(got, qt.DeepEquals, migrationlintreport.Options{})
+	c.Assert(provenance, qt.IsNil)
+}

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -270,6 +270,55 @@ func TestRunLint_ProjectConfigLatestRestrictsToLatestMigrationVersions(t *testin
 	c.Assert(report.Findings[0].File, qt.Contains, "0000000002_new.up.sql")
 }
 
+func TestRunLint_ExplicitGitBaseSuppressesProjectLatest(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	migrationsDir := filepath.Join(root, "migrations")
+	c.Assert(os.Mkdir(migrationsDir, 0o750), qt.IsNil)
+	writeLintTestFile(c, migrationsDir, "1.sql", "CREATE TABLE users (id INT);\n")
+	c.Assert(os.WriteFile(filepath.Join(root, "atlas.hcl"), []byte(`env "ci" {
+  migration {
+    dir = "file://migrations"
+  }
+  lint {
+    latest = 1
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Chdir(root)
+
+	_, stderr, err := execute("--env", "ci", "--git-base=-unsafe")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(stderr, qt.Contains, `--git-base "-unsafe" is not a safe Git ref`)
+	c.Assert(stderr, qt.Not(qt.Contains), "--latest and --git-base are mutually exclusive")
+}
+
+func TestRunLint_ExplicitLatestSuppressesProjectGitSelector(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	migrationsDir := filepath.Join(root, "migrations")
+	c.Assert(os.Mkdir(migrationsDir, 0o750), qt.IsNil)
+	writeLintTestFile(c, migrationsDir, "1.sql", "CREATE TABLE users (id INT);\n")
+	c.Assert(os.WriteFile(filepath.Join(root, "atlas.hcl"), []byte(`env "ci" {
+  migration {
+    dir = "file://migrations"
+  }
+  lint {
+    git {
+      base = "-unsafe"
+      dir  = "/not/a/repository"
+    }
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Chdir(root)
+
+	_, _, err := execute("--env", "ci", "--latest", "1", "--format", "json", "--fail-on", "none")
+
+	c.Assert(err, qt.IsNil)
+}
+
 func TestRunLint_GitBaseRestrictsToChangedMigrationVersions(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/internal/atlasurl"
@@ -150,9 +151,9 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	dbURL = dbcli.EffectiveString(cmd, generateDBURLFlag, dbURL, projectCfg.DatabaseURL)
-	migrationsDir = dbcli.EffectiveString(cmd, generateMigrationsDirFlag, migrationsDir, projectCfg.Migration.Dir)
-	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, shadowDB, projectCfg.DevURL)
+	dbURL = dbcli.EffectiveString(cmd, generateDBURLFlag, dbURL, projectCfg.StringValue(projectconfig.StringDatabaseURL))
+	migrationsDir = dbcli.EffectiveString(cmd, generateMigrationsDirFlag, migrationsDir, projectCfg.StringValue(projectconfig.StringMigrationDir))
+	shadowDB = dbcli.EffectiveString(cmd, generateShadowDBFlag, shadowDB, projectCfg.StringValue(projectconfig.StringDevURL))
 	reportFormat, err := cmd.Flags().GetString(generateReportFormatFlag)
 	if err != nil {
 		return err
@@ -192,8 +193,18 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	schemasValue = dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, schemasValue, dbcli.JoinSchemas(projectCfg.Schemas))
-	connectTimeoutValue = dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, connectTimeoutValue, projectCfg.Migration.ConnectTimeout)
+	schemasValue = dbcli.EffectiveString(
+		cmd,
+		dbcli.SchemasFlagName,
+		schemasValue,
+		dbcli.JoinSchemasValue(projectCfg.SchemasValue()),
+	)
+	connectTimeoutValue = dbcli.EffectiveString(
+		cmd,
+		dbcli.ConnectTimeoutFlagName,
+		connectTimeoutValue,
+		projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+	)
 
 	// Early qualifier syntax validation; the generator re-validates the
 	// single-schema scope and dialect support once the dialect is known.

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 )
@@ -50,14 +51,24 @@ func TestMigrateGenerateProjectConfigPrecedence(t *testing.T) {
 	cfg, err := dbcli.LoadProjectConfig(cmd, "")
 	c.Assert(err, qt.IsNil)
 
-	shadowDB := dbcli.EffectiveString(cmd, "shadow-db", flagShadow, cfg.DevURL)
+	shadowDB := dbcli.EffectiveString(
+		cmd,
+		"shadow-db",
+		flagShadow,
+		cfg.StringValue(projectconfig.StringDevURL),
+	)
 
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/flag_shadow")
 
 	cmd = migrate.NewMigrateGenerateCommand()
 	cfg, err = dbcli.LoadProjectConfig(cmd, "")
 	c.Assert(err, qt.IsNil)
-	shadowDB = dbcli.EffectiveString(cmd, "shadow-db", "", cfg.DevURL)
+	shadowDB = dbcli.EffectiveString(
+		cmd,
+		"shadow-db",
+		"",
+		cfg.StringValue(projectconfig.StringDevURL),
+	)
 	c.Assert(shadowDB, qt.Equals, "postgres://localhost/atlas_shadow")
 }
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
@@ -111,8 +112,18 @@ func migrateCommandWithOptions(cmd *cobra.Command, opts *options) error {
 	if err != nil {
 		return err
 	}
-	dbURL := dbcli.EffectiveString(cmd, dbURLFlag, opts.dbURL, projectCfg.DatabaseURL)
-	schemasValue := dbcli.EffectiveString(cmd, dbcli.SchemasFlagName, opts.schemas, dbcli.JoinSchemas(projectCfg.Schemas))
+	dbURL := dbcli.EffectiveString(
+		cmd,
+		dbURLFlag,
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	schemasValue := dbcli.EffectiveString(
+		cmd,
+		dbcli.SchemasFlagName,
+		opts.schemas,
+		dbcli.JoinSchemasValue(projectCfg.SchemasValue()),
+	)
 
 	if dbURL == "" {
 		return fmt.Errorf("database URL is required")

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/migrationsource"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/onlineddl"
 	"github.com/stokaro/ptah/internal/preflight"
@@ -131,44 +132,76 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	dbcli.RegisterRevisionTableFormatFlag(flags, &opts.revisionTableFormat)
 }
 
-func migrateDownCommand(cmd *cobra.Command, opts *options) error {
-	dbURL := opts.dbURL
-	migrationsDir := opts.migrationsDir
-	targetVersionValue := opts.target
-	dirFormatValue := opts.dirFormat
-	atlasEnv := opts.atlasEnv
-	execOrderValue := opts.execOrder
-	migrationLockTimeoutValue := opts.migrationLockTimeout
-	lockTimeout := opts.lockTimeout
-	statementTimeout := opts.statementTimeout
-	preDownHook := opts.preDownHook
-	pgDumpTo := opts.pgDumpTo
-	mySQLDumpTo := opts.mySQLDumpTo
-	webhook := opts.webhook
-	migrationsSchema := opts.migrationsSchema
-	migrationsTable := opts.migrationsTable
-	revisionFormatValue := opts.revisionTableFormat
+func resolveProjectOptions(cmd *cobra.Command, opts options, projectCfg projectconfig.Config) options {
+	effectiveString := func(flagName, flagValue string, field projectconfig.StringField) string {
+		return dbcli.EffectiveString(cmd, flagName, flagValue, projectCfg.StringValue(field))
+	}
+	opts.dbURL = effectiveString(dbURLFlag, opts.dbURL, projectconfig.StringDatabaseURL)
+	opts.migrationsDir = effectiveString(migrationsFlag, opts.migrationsDir, projectconfig.StringMigrationDir)
+	opts.dirFormat = effectiveString(dirFormatFlag, opts.dirFormat, projectconfig.StringMigrationFormat)
+	opts.atlasEnv = effectiveString(atlasEnvFlag, opts.atlasEnv, projectconfig.StringEnvName)
+	opts.execOrder = effectiveString(execOrderFlag, opts.execOrder, projectconfig.StringMigrationExecOrder)
+	opts.migrationLockTimeout = effectiveString(
+		migrationLockTimeoutFlag,
+		opts.migrationLockTimeout,
+		projectconfig.StringMigrationMigrationLockTimeout,
+	)
+	opts.lockTimeout = effectiveString(lockTimeoutFlag, opts.lockTimeout, projectconfig.StringMigrationLockTimeout)
+	opts.statementTimeout = effectiveString(
+		statementTimeoutFlag,
+		opts.statementTimeout,
+		projectconfig.StringMigrationStatementTimeout,
+	)
+	opts.preDownHook = effectiveString(preDownHookFlag, opts.preDownHook, projectconfig.StringMigrationPreDownHook)
+	opts.pgDumpTo = effectiveString(pgDumpToFlag, opts.pgDumpTo, projectconfig.StringMigrationPostgresDumpTo)
+	opts.mySQLDumpTo = effectiveString(mySQLDumpToFlag, opts.mySQLDumpTo, projectconfig.StringMigrationMySQLDumpTo)
+	opts.webhook = effectiveString(webhookFlag, opts.webhook, projectconfig.StringMigrationWebhook)
+	opts.migrationsSchema = effectiveString(
+		dbcli.MigrationsSchemaFlagName,
+		opts.migrationsSchema,
+		projectconfig.StringMigrationRevisionsSchema,
+	)
+	opts.migrationsTable = effectiveString(
+		dbcli.MigrationsTableFlagName,
+		opts.migrationsTable,
+		projectconfig.StringMigrationRevisionsTable,
+	)
+	opts.revisionTableFormat = effectiveString(
+		dbcli.RevisionTableFormatFlagName,
+		opts.revisionTableFormat,
+		projectconfig.StringMigrationRevisionFormat,
+	)
+	opts.connectTimeout = effectiveString(
+		dbcli.ConnectTimeoutFlagName,
+		opts.connectTimeout,
+		projectconfig.StringMigrationConnectTimeout,
+	)
+	return opts
+}
 
+func migrateDownCommand(cmd *cobra.Command, opts *options) error {
 	projectCfg, err := dbcli.LoadProjectConfig(cmd, opts.configPath)
 	if err != nil {
 		return err
 	}
-	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
-	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
-	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
-	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
-	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
-	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
-	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
-	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
-	preDownHook = dbcli.EffectiveString(cmd, preDownHookFlag, preDownHook, projectCfg.Migration.PreDownHook)
-	pgDumpTo = dbcli.EffectiveString(cmd, pgDumpToFlag, pgDumpTo, projectCfg.Migration.PostgresDumpTo)
-	mySQLDumpTo = dbcli.EffectiveString(cmd, mySQLDumpToFlag, mySQLDumpTo, projectCfg.Migration.MySQLDumpTo)
-	webhook = dbcli.EffectiveString(cmd, webhookFlag, webhook, projectCfg.Migration.Webhook)
-	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
-	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
-	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
-	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout)
+	resolvedOpts := resolveProjectOptions(cmd, *opts, projectCfg)
+	dbURL := resolvedOpts.dbURL
+	migrationsDir := resolvedOpts.migrationsDir
+	targetVersionValue := resolvedOpts.target
+	dirFormatValue := resolvedOpts.dirFormat
+	atlasEnv := resolvedOpts.atlasEnv
+	execOrderValue := resolvedOpts.execOrder
+	migrationLockTimeoutValue := resolvedOpts.migrationLockTimeout
+	lockTimeout := resolvedOpts.lockTimeout
+	statementTimeout := resolvedOpts.statementTimeout
+	preDownHook := resolvedOpts.preDownHook
+	pgDumpTo := resolvedOpts.pgDumpTo
+	mySQLDumpTo := resolvedOpts.mySQLDumpTo
+	webhook := resolvedOpts.webhook
+	migrationsSchema := resolvedOpts.migrationsSchema
+	migrationsTable := resolvedOpts.migrationsTable
+	revisionFormatValue := resolvedOpts.revisionTableFormat
+	connectTimeoutValue := resolvedOpts.connectTimeout
 
 	runtime, err := startObservability(cmd, opts)
 	if err != nil {

--- a/cmd/migrateset/migrateset.go
+++ b/cmd/migrateset/migrateset.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasmigrate"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -85,14 +86,54 @@ func runMigrateSet(cmd *cobra.Command, opts options) error {
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	opts.dbURL = dbcli.EffectiveString(cmd, dbURLFlag, opts.dbURL, projectCfg.DatabaseURL)
-	opts.migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, opts.migrationsDir, projectCfg.Migration.Dir)
-	opts.dirFormat = dbcli.EffectiveString(cmd, dirFormatFlag, opts.dirFormat, projectCfg.Migration.Format)
-	opts.atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, opts.atlasEnv, projectCfg.EnvName)
-	opts.migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, opts.migrationsSchema, projectCfg.Migration.RevisionsSchema)
-	opts.migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, opts.migrationsTable, projectCfg.Migration.RevisionsTable)
-	opts.revisionTableFormat = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, opts.revisionTableFormat, projectCfg.Migration.RevisionFormat)
-	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout)
+	opts.dbURL = dbcli.EffectiveString(
+		cmd,
+		dbURLFlag,
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	opts.migrationsDir = dbcli.EffectiveString(
+		cmd,
+		migrationsFlag,
+		opts.migrationsDir,
+		projectCfg.StringValue(projectconfig.StringMigrationDir),
+	)
+	opts.dirFormat = dbcli.EffectiveString(
+		cmd,
+		dirFormatFlag,
+		opts.dirFormat,
+		projectCfg.StringValue(projectconfig.StringMigrationFormat),
+	)
+	opts.atlasEnv = dbcli.EffectiveString(
+		cmd,
+		atlasEnvFlag,
+		opts.atlasEnv,
+		projectCfg.StringValue(projectconfig.StringEnvName),
+	)
+	opts.migrationsSchema = dbcli.EffectiveString(
+		cmd,
+		dbcli.MigrationsSchemaFlagName,
+		opts.migrationsSchema,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+	)
+	opts.migrationsTable = dbcli.EffectiveString(
+		cmd,
+		dbcli.MigrationsTableFlagName,
+		opts.migrationsTable,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionsTable),
+	)
+	opts.revisionTableFormat = dbcli.EffectiveString(
+		cmd,
+		dbcli.RevisionTableFormatFlagName,
+		opts.revisionTableFormat,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionFormat),
+	)
+	connectTimeoutValue := dbcli.EffectiveString(
+		cmd,
+		dbcli.ConnectTimeoutFlagName,
+		opts.connectTimeout,
+		projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+	)
 
 	if strings.TrimSpace(opts.dbURL) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("database URL is required"))

--- a/cmd/migratestatus/migratestatus.go
+++ b/cmd/migratestatus/migratestatus.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/migrationsource"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/migrator"
 )
@@ -112,14 +113,54 @@ func migrateStatusCommand(cmd *cobra.Command, opts *options) error {
 	if err != nil {
 		return err
 	}
-	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
-	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
-	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
-	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
-	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
-	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
-	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
-	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout)
+	dbURL = dbcli.EffectiveString(
+		cmd,
+		dbURLFlag,
+		dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	migrationsDir = dbcli.EffectiveString(
+		cmd,
+		migrationsFlag,
+		migrationsDir,
+		projectCfg.StringValue(projectconfig.StringMigrationDir),
+	)
+	dirFormatValue = dbcli.EffectiveString(
+		cmd,
+		dirFormatFlag,
+		dirFormatValue,
+		projectCfg.StringValue(projectconfig.StringMigrationFormat),
+	)
+	atlasEnv = dbcli.EffectiveString(
+		cmd,
+		atlasEnvFlag,
+		atlasEnv,
+		projectCfg.StringValue(projectconfig.StringEnvName),
+	)
+	migrationsSchema = dbcli.EffectiveString(
+		cmd,
+		dbcli.MigrationsSchemaFlagName,
+		migrationsSchema,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionsSchema),
+	)
+	migrationsTable = dbcli.EffectiveString(
+		cmd,
+		dbcli.MigrationsTableFlagName,
+		migrationsTable,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionsTable),
+	)
+	revisionFormatValue = dbcli.EffectiveString(
+		cmd,
+		dbcli.RevisionTableFormatFlagName,
+		revisionFormatValue,
+		projectCfg.StringValue(projectconfig.StringMigrationRevisionFormat),
+	)
+	connectTimeoutValue := dbcli.EffectiveString(
+		cmd,
+		dbcli.ConnectTimeoutFlagName,
+		opts.connectTimeout,
+		projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+	)
 
 	logWriter := cmd.ErrOrStderr()
 	if opts.logFormat == "json" && !opts.jsonOutput {

--- a/cmd/migratestatus/migratestatus_test.go
+++ b/cmd/migratestatus/migratestatus_test.go
@@ -2,6 +2,7 @@ package migratestatus_test
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -50,4 +51,48 @@ func TestMigrateStatusCommand_UnreachableDatabaseExits2(t *testing.T) {
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
 	c.Assert(errOut.String(), qt.Contains, "error connecting to database")
 	c.Assert(errOut.String(), qt.Not(qt.Contains), "Usage:")
+}
+
+func TestMigrateStatusCommand_ExplicitEmptyAtlasDirBeatsBuiltinDefault(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	ptahConfigPath := filepath.Join(dir, "ptah.yaml")
+	atlasConfigPath := filepath.Join(dir, "atlas.hcl")
+	c.Assert(os.WriteFile(
+		ptahConfigPath,
+		[]byte("migration:\n  dir: ptah-migrations\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		atlasConfigPath,
+		[]byte(`env "local" {
+  migration {
+    dir = ""
+  }
+}
+`),
+		0o600,
+	), qt.IsNil)
+
+	cmd := migratestatus.NewMigrateStatusCommand()
+	migrationsFlag := cmd.Flag("migrations-dir")
+	c.Assert(migrationsFlag, qt.IsNotNil)
+	c.Assert(migrationsFlag.Value.Set("migrations"), qt.IsNil)
+	migrationsFlag.DefValue = "migrations"
+	c.Assert(migrationsFlag.Changed, qt.IsFalse)
+
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"--db-url", "sqlite://" + filepath.Join(dir, "status.db"),
+		"--config", ptahConfigPath,
+		"--atlas-project-config", atlasConfigPath,
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "migrations directory is required")
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(errOut.String(), qt.Equals, "error: migrations directory is required\n")
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/migrationsource"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/deploymentreport"
 	"github.com/stokaro/ptah/internal/migratesum"
@@ -206,45 +207,77 @@ func parseMigrationSettings(
 	}, nil
 }
 
-func migrateUpCommand(cmd *cobra.Command, opts *options) error {
-	dbURL := opts.dbURL
-	migrationsDir := opts.migrationsDir
-	dirFormatValue := opts.dirFormat
-	atlasEnv := opts.atlasEnv
-	execOrderValue := opts.execOrder
-	txModeValue := opts.txMode
-	migrationLockTimeoutValue := opts.migrationLockTimeout
-	lockTimeout := opts.lockTimeout
-	statementTimeout := opts.statementTimeout
-	preUpHook := opts.preUpHook
-	pgDumpTo := opts.pgDumpTo
-	mySQLDumpTo := opts.mySQLDumpTo
-	webhook := opts.webhook
-	migrationsSchema := opts.migrationsSchema
-	migrationsTable := opts.migrationsTable
-	revisionFormatValue := opts.revisionTableFormat
+func resolveProjectOptions(cmd *cobra.Command, opts options, projectCfg projectconfig.Config) options {
+	effectiveString := func(flagName, flagValue string, field projectconfig.StringField) string {
+		return dbcli.EffectiveString(cmd, flagName, flagValue, projectCfg.StringValue(field))
+	}
+	opts.dbURL = effectiveString(dbURLFlag, opts.dbURL, projectconfig.StringDatabaseURL)
+	opts.migrationsDir = effectiveString(migrationsFlag, opts.migrationsDir, projectconfig.StringMigrationDir)
+	opts.dirFormat = effectiveString(dirFormatFlag, opts.dirFormat, projectconfig.StringMigrationFormat)
+	opts.atlasEnv = effectiveString(atlasEnvFlag, opts.atlasEnv, projectconfig.StringEnvName)
+	opts.execOrder = effectiveString(execOrderFlag, opts.execOrder, projectconfig.StringMigrationExecOrder)
+	opts.txMode = effectiveString(txModeFlag, opts.txMode, projectconfig.StringMigrationTxMode)
+	opts.migrationLockTimeout = effectiveString(
+		migrationLockTimeoutFlag,
+		opts.migrationLockTimeout,
+		projectconfig.StringMigrationMigrationLockTimeout,
+	)
+	opts.lockTimeout = effectiveString(lockTimeoutFlag, opts.lockTimeout, projectconfig.StringMigrationLockTimeout)
+	opts.statementTimeout = effectiveString(
+		statementTimeoutFlag,
+		opts.statementTimeout,
+		projectconfig.StringMigrationStatementTimeout,
+	)
+	opts.preUpHook = effectiveString(preUpHookFlag, opts.preUpHook, projectconfig.StringMigrationPreUpHook)
+	opts.pgDumpTo = effectiveString(pgDumpToFlag, opts.pgDumpTo, projectconfig.StringMigrationPostgresDumpTo)
+	opts.mySQLDumpTo = effectiveString(mySQLDumpToFlag, opts.mySQLDumpTo, projectconfig.StringMigrationMySQLDumpTo)
+	opts.webhook = effectiveString(webhookFlag, opts.webhook, projectconfig.StringMigrationWebhook)
+	opts.migrationsSchema = effectiveString(
+		dbcli.MigrationsSchemaFlagName,
+		opts.migrationsSchema,
+		projectconfig.StringMigrationRevisionsSchema,
+	)
+	opts.migrationsTable = effectiveString(
+		dbcli.MigrationsTableFlagName,
+		opts.migrationsTable,
+		projectconfig.StringMigrationRevisionsTable,
+	)
+	opts.revisionTableFormat = effectiveString(
+		dbcli.RevisionTableFormatFlagName,
+		opts.revisionTableFormat,
+		projectconfig.StringMigrationRevisionFormat,
+	)
+	opts.connectTimeout = effectiveString(
+		dbcli.ConnectTimeoutFlagName,
+		opts.connectTimeout,
+		projectconfig.StringMigrationConnectTimeout,
+	)
+	return opts
+}
 
+func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	projectCfg, err := dbcli.LoadProjectConfig(cmd, opts.configPath)
 	if err != nil {
 		return err
 	}
-	dbURL = dbcli.EffectiveString(cmd, dbURLFlag, dbURL, projectCfg.DatabaseURL)
-	migrationsDir = dbcli.EffectiveString(cmd, migrationsFlag, migrationsDir, projectCfg.Migration.Dir)
-	dirFormatValue = dbcli.EffectiveString(cmd, dirFormatFlag, dirFormatValue, projectCfg.Migration.Format)
-	atlasEnv = dbcli.EffectiveString(cmd, atlasEnvFlag, atlasEnv, projectCfg.EnvName)
-	execOrderValue = dbcli.EffectiveString(cmd, execOrderFlag, execOrderValue, projectCfg.Migration.ExecOrder)
-	txModeValue = dbcli.EffectiveString(cmd, txModeFlag, txModeValue, projectCfg.Migration.TxMode)
-	migrationLockTimeoutValue = dbcli.EffectiveString(cmd, migrationLockTimeoutFlag, migrationLockTimeoutValue, projectCfg.Migration.MigrationLockTimeout)
-	lockTimeout = dbcli.EffectiveString(cmd, lockTimeoutFlag, lockTimeout, projectCfg.Migration.LockTimeout)
-	statementTimeout = dbcli.EffectiveString(cmd, statementTimeoutFlag, statementTimeout, projectCfg.Migration.StatementTimeout)
-	preUpHook = dbcli.EffectiveString(cmd, preUpHookFlag, preUpHook, projectCfg.Migration.PreUpHook)
-	pgDumpTo = dbcli.EffectiveString(cmd, pgDumpToFlag, pgDumpTo, projectCfg.Migration.PostgresDumpTo)
-	mySQLDumpTo = dbcli.EffectiveString(cmd, mySQLDumpToFlag, mySQLDumpTo, projectCfg.Migration.MySQLDumpTo)
-	webhook = dbcli.EffectiveString(cmd, webhookFlag, webhook, projectCfg.Migration.Webhook)
-	migrationsSchema = dbcli.EffectiveString(cmd, dbcli.MigrationsSchemaFlagName, migrationsSchema, projectCfg.Migration.RevisionsSchema)
-	migrationsTable = dbcli.EffectiveString(cmd, dbcli.MigrationsTableFlagName, migrationsTable, projectCfg.Migration.RevisionsTable)
-	revisionFormatValue = dbcli.EffectiveString(cmd, dbcli.RevisionTableFormatFlagName, revisionFormatValue, projectCfg.Migration.RevisionFormat)
-	connectTimeoutValue := dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout)
+	resolvedOpts := resolveProjectOptions(cmd, *opts, projectCfg)
+	dbURL := resolvedOpts.dbURL
+	migrationsDir := resolvedOpts.migrationsDir
+	dirFormatValue := resolvedOpts.dirFormat
+	atlasEnv := resolvedOpts.atlasEnv
+	execOrderValue := resolvedOpts.execOrder
+	txModeValue := resolvedOpts.txMode
+	migrationLockTimeoutValue := resolvedOpts.migrationLockTimeout
+	lockTimeout := resolvedOpts.lockTimeout
+	statementTimeout := resolvedOpts.statementTimeout
+	preUpHook := resolvedOpts.preUpHook
+	pgDumpTo := resolvedOpts.pgDumpTo
+	mySQLDumpTo := resolvedOpts.mySQLDumpTo
+	webhook := resolvedOpts.webhook
+	migrationsSchema := resolvedOpts.migrationsSchema
+	migrationsTable := resolvedOpts.migrationsTable
+	revisionFormatValue := resolvedOpts.revisionTableFormat
+	connectTimeoutValue := resolvedOpts.connectTimeout
 
 	logWriter := cmd.ErrOrStderr()
 	if opts.logFormat == "json" {

--- a/cmd/schema/apply.go
+++ b/cmd/schema/apply.go
@@ -133,8 +133,18 @@ func runSchemaApply(cmd *cobra.Command, opts schemaApplyOptions) error {
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	opts.dbURL = dbcli.EffectiveString(cmd, applyDBURLFlag, opts.dbURL, projectCfg.DatabaseURL)
-	opts.devURL = dbcli.EffectiveString(cmd, applyDevURLFlag, opts.devURL, projectCfg.DevURL)
+	opts.dbURL = dbcli.EffectiveString(
+		cmd,
+		applyDBURLFlag,
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	opts.devURL = dbcli.EffectiveString(
+		cmd,
+		applyDevURLFlag,
+		opts.devURL,
+		projectCfg.StringValue(projectconfig.StringDevURL),
+	)
 	policy := nativeDiffPolicy(projectCfg)
 
 	if strings.TrimSpace(opts.dbURL) == "" {
@@ -172,7 +182,12 @@ func runSchemaApply(cmd *cobra.Command, opts schemaApplyOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 	connectTimeout, err := dbcli.ParseConnectTimeout(
-		dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout))
+		dbcli.EffectiveString(
+			cmd,
+			dbcli.ConnectTimeoutFlagName,
+			opts.connectTimeout,
+			projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+		))
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/schema/diff.go
+++ b/cmd/schema/diff.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlasreport"
 	"github.com/stokaro/ptah/internal/atlasschema"
@@ -82,7 +83,12 @@ func runSchemaDiff(cmd *cobra.Command, opts schemaDiffOptions) error {
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	opts.devURL = dbcli.EffectiveString(cmd, diffDevURLFlag, opts.devURL, projectCfg.DevURL)
+	opts.devURL = dbcli.EffectiveString(
+		cmd,
+		diffDevURLFlag,
+		opts.devURL,
+		projectCfg.StringValue(projectconfig.StringDevURL),
+	)
 	policy := nativeDiffPolicy(projectCfg)
 
 	format := strings.ToLower(strings.TrimSpace(opts.format))
@@ -97,7 +103,12 @@ func runSchemaDiff(cmd *cobra.Command, opts schemaDiffOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 	connectTimeout, err := dbcli.ParseConnectTimeout(
-		dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout))
+		dbcli.EffectiveString(
+			cmd,
+			dbcli.ConnectTimeoutFlagName,
+			opts.connectTimeout,
+			projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+		))
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/schema/inspect.go
+++ b/cmd/schema/inspect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasschema"
 	"github.com/stokaro/ptah/internal/atlassource"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -88,9 +89,19 @@ func runSchemaInspect(cmd *cobra.Command, opts schemaInspectOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 	if opts.schemaFile == "" && opts.migrationsDir == "" {
-		opts.dbURL = dbcli.EffectiveString(cmd, inspectDBURLFlag, opts.dbURL, projectCfg.DatabaseURL)
+		opts.dbURL = dbcli.EffectiveString(
+			cmd,
+			inspectDBURLFlag,
+			opts.dbURL,
+			projectCfg.StringValue(projectconfig.StringDatabaseURL),
+		)
 	}
-	opts.devURL = dbcli.EffectiveString(cmd, inspectDevURLFlag, opts.devURL, projectCfg.DevURL)
+	opts.devURL = dbcli.EffectiveString(
+		cmd,
+		inspectDevURLFlag,
+		opts.devURL,
+		projectCfg.StringValue(projectconfig.StringDevURL),
+	)
 
 	sourceURL, err := resolveInspectSource(opts)
 	if err != nil {
@@ -101,7 +112,12 @@ func runSchemaInspect(cmd *cobra.Command, opts schemaInspectOptions) error {
 		return cmdutil.Fail(cmd, err)
 	}
 	connectTimeout, err := dbcli.ParseConnectTimeout(
-		dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout))
+		dbcli.EffectiveString(
+			cmd,
+			dbcli.ConnectTimeoutFlagName,
+			opts.connectTimeout,
+			projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+		))
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/schema/plan.go
+++ b/cmd/schema/plan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasschema"
 )
@@ -86,8 +87,18 @@ func runSchemaPlan(cmd *cobra.Command, opts schemaPlanOptions) error {
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	opts.dbURL = dbcli.EffectiveString(cmd, planDBURLFlag, opts.dbURL, projectCfg.DatabaseURL)
-	opts.devURL = dbcli.EffectiveString(cmd, planDevURLFlag, opts.devURL, projectCfg.DevURL)
+	opts.dbURL = dbcli.EffectiveString(
+		cmd,
+		planDBURLFlag,
+		opts.dbURL,
+		projectCfg.StringValue(projectconfig.StringDatabaseURL),
+	)
+	opts.devURL = dbcli.EffectiveString(
+		cmd,
+		planDevURLFlag,
+		opts.devURL,
+		projectCfg.StringValue(projectconfig.StringDevURL),
+	)
 	policy := nativeDiffPolicy(projectCfg)
 
 	if strings.TrimSpace(opts.dbURL) == "" {
@@ -107,7 +118,12 @@ func runSchemaPlan(cmd *cobra.Command, opts schemaPlanOptions) error {
 		return cmdutil.Fail(cmd, fmt.Errorf("--%s must not contain path separators; use --%s to choose the plan file location", planNameFlag, planOutputFlag))
 	}
 	connectTimeout, err := dbcli.ParseConnectTimeout(
-		dbcli.EffectiveString(cmd, dbcli.ConnectTimeoutFlagName, opts.connectTimeout, projectCfg.Migration.ConnectTimeout))
+		dbcli.EffectiveString(
+			cmd,
+			dbcli.ConnectTimeoutFlagName,
+			opts.connectTimeout,
+			projectCfg.StringValue(projectconfig.StringMigrationConnectTimeout),
+		))
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -267,7 +267,7 @@ func (p atlasParser) parseSchema(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 			cfg.SchemaSources = values
-			cfg.presence.schemaSources = true
+			cfg.presence.mark(fieldSchemaSources)
 		default:
 			return unsupportedAttr(attrName, attr)
 		}
@@ -338,28 +338,28 @@ func (p atlasParser) parseEnvAttr(attrName string, attr *hclsyntax.Attribute, cf
 			return err
 		}
 		cfg.DatabaseURL = value
-		cfg.presence.databaseURL = true
+		cfg.presence.mark(fieldDatabaseURL)
 	case "dev":
 		value, err := p.stringAttr(attrName, attr)
 		if err != nil {
 			return err
 		}
 		cfg.DevURL = value
-		cfg.presence.devURL = true
+		cfg.presence.mark(fieldDevURL)
 	case "src":
 		values, err := p.stringOrStringListAttr(attrName, attr)
 		if err != nil {
 			return err
 		}
 		cfg.SchemaSources = values
-		cfg.presence.schemaSources = true
+		cfg.presence.mark(fieldSchemaSources)
 	case "exclude":
 		values, err := p.stringListAttr(attrName, attr)
 		if err != nil {
 			return err
 		}
 		cfg.Exclude = values
-		cfg.presence.exclude = true
+		cfg.presence.mark(fieldExclude)
 	default:
 		return unsupportedAttr(attrName, attr)
 	}
@@ -374,9 +374,11 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 	if migration.Format == "" {
 		migration.Format = "atlas"
 	}
+	cfg.presence.mark(fieldMigrationFormat)
 	if migration.RevisionFormat == "" {
 		migration.RevisionFormat = "atlas"
 	}
+	cfg.presence.mark(fieldMigrationRevisionFormat)
 
 	for attrName, attr := range block.Body.Attributes {
 		switch attrName {
@@ -386,6 +388,7 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 			migration.Dir = normalizeAtlasMigrationDir(value)
+			cfg.presence.mark(fieldMigrationDir)
 		case "format":
 			value, err := p.scopedEnumOrStringAttr(
 				attrName,
@@ -401,30 +404,35 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 			migration.Format = value
+			cfg.presence.mark(fieldMigrationFormat)
 		case "revisions_schema":
 			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
 			migration.RevisionsSchema = value
+			cfg.presence.mark(fieldMigrationRevisionsSchema)
 		case "lock_timeout":
 			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
 			migration.LockTimeout = value
+			cfg.presence.mark(fieldMigrationLockTimeout)
 		case "exec_order":
 			value, err := p.scopedEnumOrStringAttr(attrName, attr, "LINEAR", "LINEAR_SKIP", "NON_LINEAR")
 			if err != nil {
 				return err
 			}
 			migration.ExecOrder = strings.ReplaceAll(strings.ToLower(value), "_", "-")
+			cfg.presence.mark(fieldMigrationExecOrder)
 		case "tx_mode":
 			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
 			migration.TxMode = value
+			cfg.presence.mark(fieldMigrationTxMode)
 		default:
 			return unsupportedAttr(attrName, attr)
 		}
@@ -456,6 +464,7 @@ func (p atlasParser) parseLintAttr(attrName string, attr *hclsyntax.Attribute, c
 			return err
 		}
 		cfg.Lint.Latest = &value
+		cfg.presence.mark(fieldLintLatest)
 	case "log":
 		// Atlas's lint.log is a Go text/template that renders the migrate lint
 		// output. It shares the format IR with format.migrate.lint, so the CLI
@@ -466,6 +475,7 @@ func (p atlasParser) parseLintAttr(attrName string, attr *hclsyntax.Attribute, c
 			return err
 		}
 		cfg.Format.Migrate.Lint = value
+		cfg.presence.mark(fieldFormatMigrateLint)
 	default:
 		return unsupportedAttr(attrName, attr)
 	}
@@ -579,6 +589,8 @@ func setLintRuleConfig(cfg *Config, code string, config LintRuleConfig) {
 		cfg.Lint.RuleConfigs = map[string]LintRuleConfig{}
 	}
 	cfg.Lint.RuleConfigs[code] = config
+	cfg.presence.mark(fieldLintRuleConfigs)
+	cfg.presence.mark(lintRuleSeverityField(code))
 }
 
 func (p atlasParser) parseLintGit(block *hclsyntax.Block, cfg *Config) error {
@@ -593,12 +605,14 @@ func (p atlasParser) parseLintGit(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 			cfg.Lint.GitBase = value
+			cfg.presence.mark(fieldLintGitBase)
 		case "dir":
 			value, err := p.stringAttr(attrName, attr)
 			if err != nil {
 				return err
 			}
 			cfg.Lint.GitDir = value
+			cfg.presence.mark(fieldLintGitDir)
 		default:
 			return unsupportedAttr(attrName, attr)
 		}
@@ -646,54 +660,47 @@ func (p atlasParser) parseFormat(block *hclsyntax.Block, cfg *Config) error {
 }
 
 func (p atlasParser) parseMigrateFormat(block *hclsyntax.Block, cfg *Config) error {
-	if len(block.Labels) > 0 {
-		return unsupportedBlock(block)
-	}
-	for attrName, attr := range block.Body.Attributes {
-		value, err := p.nonEmptyStringAttr(attrName, attr)
-		if err != nil {
-			return err
-		}
-		switch attrName {
-		case "apply":
-			cfg.Format.Migrate.Apply = value
-		case "diff":
-			cfg.Format.Migrate.Diff = value
-		case "lint":
-			cfg.Format.Migrate.Lint = value
-		case "status":
-			cfg.Format.Migrate.Status = value
-		default:
-			return unsupportedAttr(attrName, attr)
-		}
-	}
-	if len(block.Body.Blocks) > 0 {
-		return unsupportedBlock(block.Body.Blocks[0])
-	}
-	return nil
+	return p.parseFormatAttributes(block, &cfg.presence, map[string]atlasFormatField{
+		"apply":  {destination: &cfg.Format.Migrate.Apply, presence: fieldFormatMigrateApply},
+		"diff":   {destination: &cfg.Format.Migrate.Diff, presence: fieldFormatMigrateDiff},
+		"lint":   {destination: &cfg.Format.Migrate.Lint, presence: fieldFormatMigrateLint},
+		"status": {destination: &cfg.Format.Migrate.Status, presence: fieldFormatMigrateStatus},
+	})
 }
 
 func (p atlasParser) parseSchemaFormat(block *hclsyntax.Block, cfg *Config) error {
+	return p.parseFormatAttributes(block, &cfg.presence, map[string]atlasFormatField{
+		"apply":   {destination: &cfg.Format.Schema.Apply, presence: fieldFormatSchemaApply},
+		"clean":   {destination: &cfg.Format.Schema.Clean, presence: fieldFormatSchemaClean},
+		"diff":    {destination: &cfg.Format.Schema.Diff, presence: fieldFormatSchemaDiff},
+		"inspect": {destination: &cfg.Format.Schema.Inspect, presence: fieldFormatSchemaInspect},
+	})
+}
+
+type atlasFormatField struct {
+	destination *string
+	presence    configField
+}
+
+func (p atlasParser) parseFormatAttributes(
+	block *hclsyntax.Block,
+	presence *configPresence,
+	fields map[string]atlasFormatField,
+) error {
 	if len(block.Labels) > 0 {
 		return unsupportedBlock(block)
 	}
 	for attrName, attr := range block.Body.Attributes {
+		field, ok := fields[attrName]
+		if !ok {
+			return unsupportedAttr(attrName, attr)
+		}
 		value, err := p.nonEmptyStringAttr(attrName, attr)
 		if err != nil {
 			return err
 		}
-		switch attrName {
-		case "apply":
-			cfg.Format.Schema.Apply = value
-		case "clean":
-			cfg.Format.Schema.Clean = value
-		case "diff":
-			cfg.Format.Schema.Diff = value
-		case "inspect":
-			cfg.Format.Schema.Inspect = value
-		default:
-			return unsupportedAttr(attrName, attr)
-		}
+		*field.destination = value
+		presence.mark(field.presence)
 	}
 	if len(block.Body.Blocks) > 0 {
 		return unsupportedBlock(block.Body.Blocks[0])

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -216,6 +216,7 @@ func (p atlasParser) parseEnv(env atlasEnvBlock) (Config, error) {
 	cfg := Config{
 		EnvName: env.name,
 	}
+	cfg.presence.mark(fieldEnvName)
 
 	for attrName, attr := range env.block.Body.Attributes {
 		if err := p.parseEnvAttr(attrName, attr, &cfg); err != nil {
@@ -453,7 +454,19 @@ func (p atlasParser) parseLint(block *hclsyntax.Block, cfg *Config) error {
 			return err
 		}
 	}
-	return p.parseLintPolicyBlocks(block, cfg)
+	if err := p.parseLintPolicyBlocks(block, cfg); err != nil {
+		return err
+	}
+	if cfg.presence.has(fieldLintLatest) &&
+		cfg.presence.has(fieldLintGitBase) &&
+		cfg.Lint.GitBase != "" {
+		return fmt.Errorf(
+			"atlas.hcl lint.latest and lint.git.base are mutually exclusive at %s:%d",
+			block.TypeRange.Filename,
+			block.TypeRange.Start.Line,
+		)
+	}
+	return nil
 }
 
 func (p atlasParser) parseLintAttr(attrName string, attr *hclsyntax.Attribute, cfg *Config) error {

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1186,6 +1186,8 @@ func TestLoadMergesAtlasOverPtah(t *testing.T) {
 exclude: [tmp_*]
 migration:
   dir: ./ptah-migrations
+  revisions_schema: revisions
+  lock_timeout: 1s
   exec_order: non-linear
 `), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(atlasPath, []byte(`env "local" {
@@ -1193,7 +1195,9 @@ migration:
   src = []
   exclude = []
   migration {
-    dir = "file://atlas-migrations"
+    dir              = "file://atlas-migrations"
+    revisions_schema = ""
+    lock_timeout     = ""
   }
 }
 `), 0o600), qt.IsNil)
@@ -1208,6 +1212,8 @@ migration:
 	c.Assert(cfg.SchemaSources, qt.DeepEquals, []string{})
 	c.Assert(cfg.Exclude, qt.DeepEquals, []string{})
 	c.Assert(cfg.Migration.Dir, qt.Equals, "atlas-migrations")
+	c.Assert(cfg.Migration.RevisionsSchema, qt.Equals, "")
+	c.Assert(cfg.Migration.LockTimeout, qt.Equals, "")
 	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "non-linear")
 	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
 	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -5,6 +5,7 @@ package projectconfig
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/stokaro/ptah/migration/diffpolicy"
 )
@@ -69,19 +70,99 @@ type Config struct {
 	presence configPresence
 }
 
-type configPresence struct {
-	databaseURL            bool
-	devURL                 bool
-	schemaSources          bool
-	schemas                bool
-	exclude                bool
-	lintDisabledRules      bool
-	externalSchemaProgram  bool
-	externalSchemaEnv      bool
-	onlineDDLTool          bool
-	onlineDDLThresholdRows bool
-	onlineDDLArgs          bool
-	onlineDDLFallback      bool
+type configField string
+
+const (
+	fieldEnvName                   configField = "env.name"
+	fieldDatabaseURL               configField = "database.url"
+	fieldDevURL                    configField = "database.dev_url"
+	fieldSchemaSources             configField = "schema.sources"
+	fieldSchemas                   configField = "database.schemas"
+	fieldExclude                   configField = "database.exclude"
+	fieldMigrationDir              configField = "migration.dir"
+	fieldMigrationFormat           configField = "migration.format"
+	fieldMigrationRevisionsSchema  configField = "migration.revisions_schema"
+	fieldMigrationRevisionsTable   configField = "migration.revisions_table"
+	fieldMigrationRevisionFormat   configField = "migration.revision_format"
+	fieldMigrationLockTimeout      configField = "migration.lock_timeout"
+	fieldMigrationStatementTimeout configField = "migration.statement_timeout"
+	fieldMigrationConnectTimeout   configField = "migration.connect_timeout"
+	fieldMigrationMigrationLock    configField = "migration.migration_lock_timeout"
+	fieldMigrationExecOrder        configField = "migration.exec_order"
+	fieldMigrationTxMode           configField = "migration.tx_mode"
+	fieldMigrationPreUpHook        configField = "migration.pre_up_hook"
+	fieldMigrationPreDownHook      configField = "migration.pre_down_hook"
+	fieldMigrationPostgresDumpTo   configField = "migration.pg_dump_to"
+	fieldMigrationMySQLDumpTo      configField = "migration.mysqldump_to"
+	fieldMigrationWebhook          configField = "migration.webhook"
+	fieldOnlineDDLTool             configField = "online_ddl.tool"
+	fieldOnlineDDLThresholdRows    configField = "online_ddl.threshold_rows"
+	fieldOnlineDDLArgs             configField = "online_ddl.args"
+	fieldOnlineDDLFallback         configField = "online_ddl.fallback"
+	fieldLintDialect               configField = "lint.dialect"
+	fieldLintDisabledRules         configField = "lint.disabled_rules"
+	fieldLintRuleConfigs           configField = "lint.rules"
+	fieldLintLatest                configField = "lint.latest"
+	fieldLintGitBase               configField = "lint.git.base"
+	fieldLintGitDir                configField = "lint.git.dir"
+	fieldFormatMigrateApply        configField = "format.migrate.apply"
+	fieldFormatMigrateDiff         configField = "format.migrate.diff"
+	fieldFormatMigrateLint         configField = "format.migrate.lint"
+	fieldFormatMigrateStatus       configField = "format.migrate.status"
+	fieldFormatSchemaApply         configField = "format.schema.apply"
+	fieldFormatSchemaClean         configField = "format.schema.clean"
+	fieldFormatSchemaDiff          configField = "format.schema.diff"
+	fieldFormatSchemaInspect       configField = "format.schema.inspect"
+	fieldExternalSchemaProgram     configField = "external_schema.program"
+	fieldExternalSchemaFormat      configField = "external_schema.format"
+	fieldExternalSchemaWorkingDir  configField = "external_schema.working_dir"
+	fieldExternalSchemaEnv         configField = "external_schema.env"
+	lintRuleConfigFieldPrefix                  = "lint.rules."
+)
+
+type configPresence map[configField]struct{}
+
+func (p configPresence) has(field configField) bool {
+	_, ok := p[field]
+	return ok
+}
+
+func (p *configPresence) mark(field configField) {
+	if *p == nil {
+		*p = configPresence{}
+	}
+	(*p)[field] = struct{}{}
+}
+
+func (p *configPresence) unmark(field configField) {
+	delete(*p, field)
+}
+
+func (p *configPresence) removePrefix(prefix string) {
+	for field := range *p {
+		if strings.HasPrefix(string(field), prefix) {
+			delete(*p, field)
+		}
+	}
+}
+
+func (p configPresence) clone() configPresence {
+	if len(p) == 0 {
+		return nil
+	}
+	result := make(configPresence, len(p))
+	for field := range p {
+		result[field] = struct{}{}
+	}
+	return result
+}
+
+func lintRuleSeverityField(code string) configField {
+	return configField(lintRuleConfigFieldPrefix + code + ".severity")
+}
+
+func lintRuleExcludeField(code string) configField {
+	return configField(lintRuleConfigFieldPrefix + code + ".exclude")
 }
 
 // OnlineDDLConfig configures automatic online-DDL routing for ALTER TABLE
@@ -309,109 +390,209 @@ func appendDisabledMode(patterns []string, option ConfigBool, pattern string) []
 	return patterns
 }
 
-// Merge returns base overridden by non-zero values from override.
+// Merge returns base overridden by explicitly present loader values and
+// non-zero programmatic values from override.
 func Merge(base, override Config) Config {
 	result := base
-	if override.EnvName != "" {
-		result.EnvName = override.EnvName
-	}
-	if override.presence.databaseURL || override.DatabaseURL != "" {
-		result.DatabaseURL = override.DatabaseURL
-		result.presence.databaseURL = true
-	}
-	if override.presence.devURL || override.DevURL != "" {
-		result.DevURL = override.DevURL
-		result.presence.devURL = true
-	}
-	if override.presence.schemaSources || len(override.SchemaSources) > 0 {
-		result.SchemaSources = slices.Clone(override.SchemaSources)
-		result.presence.schemaSources = true
-	}
-	if override.presence.schemas || len(override.Schemas) > 0 {
-		result.Schemas = slices.Clone(override.Schemas)
-		result.presence.schemas = true
-	}
-	if override.presence.exclude || len(override.Exclude) > 0 {
-		result.Exclude = slices.Clone(override.Exclude)
-		result.presence.exclude = true
-	}
+	result.presence = base.presence.clone()
+	result.EnvName = mergeStringValue(
+		base.EnvName,
+		override.EnvName,
+		fieldEnvName,
+		override.presence,
+		&result.presence,
+	)
+	result.DatabaseURL = mergeStringValue(
+		base.DatabaseURL,
+		override.DatabaseURL,
+		fieldDatabaseURL,
+		override.presence,
+		&result.presence,
+	)
+	result.DevURL = mergeStringValue(
+		base.DevURL,
+		override.DevURL,
+		fieldDevURL,
+		override.presence,
+		&result.presence,
+	)
+	result.SchemaSources = mergeStringSliceValue(
+		base.SchemaSources,
+		override.SchemaSources,
+		fieldSchemaSources,
+		override.presence,
+		&result.presence,
+	)
+	result.Schemas = mergeStringSliceValue(
+		base.Schemas,
+		override.Schemas,
+		fieldSchemas,
+		override.presence,
+		&result.presence,
+	)
+	result.Exclude = mergeStringSliceValue(
+		base.Exclude,
+		override.Exclude,
+		fieldExclude,
+		override.presence,
+		&result.presence,
+	)
 	result.Schema = mergeSchema(result.Schema, override.Schema)
-	result.Migration = mergeMigration(result.Migration, override.Migration)
-	result.OnlineDDL = mergeOnlineDDL(result.OnlineDDL, override.OnlineDDL, override.presence)
-	result.Lint = mergeLint(result.Lint, override.Lint, override.presence)
-	result.Format = mergeFormat(result.Format, override.Format)
+	result.Migration = mergeMigration(
+		result.Migration,
+		override.Migration,
+		override.presence,
+		&result.presence,
+	)
+	result.OnlineDDL = mergeOnlineDDL(
+		result.OnlineDDL,
+		override.OnlineDDL,
+		override.presence,
+		&result.presence,
+	)
+	result.Lint = mergeLint(
+		result.Lint,
+		override.Lint,
+		override.presence,
+		&result.presence,
+	)
+	result.Format = mergeFormat(
+		result.Format,
+		override.Format,
+		override.presence,
+		&result.presence,
+	)
 	result.Diff = mergeDiff(result.Diff, override.Diff)
-	result.ExternalSchema = mergeExternalSchema(result.ExternalSchema, override.ExternalSchema, override.presence)
-	result.presence = mergeConfigPresence(result.presence, override)
+	result.ExternalSchema = mergeExternalSchema(
+		result.ExternalSchema,
+		override.ExternalSchema,
+		override.presence,
+		&result.presence,
+	)
 	return result
 }
 
-func mergeConfigPresence(result configPresence, override Config) configPresence {
-	if override.presence.lintDisabledRules || len(override.Lint.DisabledRules) > 0 {
-		result.lintDisabledRules = true
+func mergeStringValue(
+	base string,
+	override string,
+	field configField,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) string {
+	if !overridePresence.has(field) && override == "" {
+		return base
 	}
-	if override.presence.externalSchemaProgram || len(override.ExternalSchema.Program) > 0 {
-		result.externalSchemaProgram = true
+	resultPresence.mark(field)
+	return override
+}
+
+func mergeStringSliceValue(
+	base []string,
+	override []string,
+	field configField,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) []string {
+	if !overridePresence.has(field) && len(override) == 0 {
+		return slices.Clone(base)
 	}
-	if override.presence.externalSchemaEnv || len(override.ExternalSchema.Env) > 0 {
-		result.externalSchemaEnv = true
+	resultPresence.mark(field)
+	return slices.Clone(override)
+}
+
+func mergeInt64Value(
+	base int64,
+	override int64,
+	field configField,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) int64 {
+	if !overridePresence.has(field) && override == 0 {
+		return base
 	}
-	if override.presence.onlineDDLTool || override.OnlineDDL.Tool != "" {
-		result.onlineDDLTool = true
-	}
-	if override.presence.onlineDDLThresholdRows || override.OnlineDDL.ThresholdRows != 0 {
-		result.onlineDDLThresholdRows = true
-	}
-	if override.presence.onlineDDLArgs || len(override.OnlineDDL.Args) > 0 {
-		result.onlineDDLArgs = true
-	}
-	if override.presence.onlineDDLFallback || override.OnlineDDL.Fallback != "" {
-		result.onlineDDLFallback = true
-	}
-	return result
+	resultPresence.mark(field)
+	return override
 }
 
 func mergeOnlineDDL(
 	base OnlineDDLConfig,
 	override OnlineDDLConfig,
-	presence configPresence,
+	overridePresence configPresence,
+	resultPresence *configPresence,
 ) OnlineDDLConfig {
 	result := base
 	result.Args = slices.Clone(base.Args)
-	toolSet := presence.onlineDDLTool || override.Tool != ""
-	thresholdSet := presence.onlineDDLThresholdRows || override.ThresholdRows != 0
+	toolSet := overridePresence.has(fieldOnlineDDLTool) || override.Tool != ""
+	thresholdSet := overridePresence.has(fieldOnlineDDLThresholdRows) || override.ThresholdRows != 0
 	if toolSet {
 		result.Tool = override.Tool
+		resultPresence.mark(fieldOnlineDDLTool)
 		if override.Tool == "" && !thresholdSet {
 			result.ThresholdRows = 0
+			resultPresence.mark(fieldOnlineDDLThresholdRows)
 		}
 	}
 	if thresholdSet {
-		result.ThresholdRows = override.ThresholdRows
+		result.ThresholdRows = mergeInt64Value(
+			result.ThresholdRows,
+			override.ThresholdRows,
+			fieldOnlineDDLThresholdRows,
+			overridePresence,
+			resultPresence,
+		)
 	}
-	if presence.onlineDDLArgs || len(override.Args) > 0 {
-		result.Args = slices.Clone(override.Args)
-	}
-	if presence.onlineDDLFallback || override.Fallback != "" {
-		result.Fallback = override.Fallback
-	}
+	result.Args = mergeStringSliceValue(
+		result.Args,
+		override.Args,
+		fieldOnlineDDLArgs,
+		overridePresence,
+		resultPresence,
+	)
+	result.Fallback = mergeStringValue(
+		result.Fallback,
+		override.Fallback,
+		fieldOnlineDDLFallback,
+		overridePresence,
+		resultPresence,
+	)
 	return result
 }
 
-func mergeExternalSchema(base, override ExternalSchemaConfig, presence configPresence) ExternalSchemaConfig {
+func mergeExternalSchema(
+	base ExternalSchemaConfig,
+	override ExternalSchemaConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) ExternalSchemaConfig {
 	result := base
-	if presence.externalSchemaProgram || len(override.Program) > 0 {
-		result.Program = slices.Clone(override.Program)
-	}
-	if override.Format != "" {
-		result.Format = override.Format
-	}
-	if override.WorkingDir != "" {
-		result.WorkingDir = override.WorkingDir
-	}
-	if presence.externalSchemaEnv || len(override.Env) > 0 {
-		result.Env = slices.Clone(override.Env)
-	}
+	result.Program = mergeStringSliceValue(
+		base.Program,
+		override.Program,
+		fieldExternalSchemaProgram,
+		overridePresence,
+		resultPresence,
+	)
+	result.Format = mergeStringValue(
+		base.Format,
+		override.Format,
+		fieldExternalSchemaFormat,
+		overridePresence,
+		resultPresence,
+	)
+	result.WorkingDir = mergeStringValue(
+		base.WorkingDir,
+		override.WorkingDir,
+		fieldExternalSchemaWorkingDir,
+		overridePresence,
+		resultPresence,
+	)
+	result.Env = mergeStringSliceValue(
+		base.Env,
+		override.Env,
+		fieldExternalSchemaEnv,
+		overridePresence,
+		resultPresence,
+	)
 	return result
 }
 
@@ -428,102 +609,208 @@ func mergeSchema(base, override SchemaConfig) SchemaConfig {
 	return result
 }
 
-func mergeMigration(base, override MigrationConfig) MigrationConfig {
+func mergeMigration(
+	base MigrationConfig,
+	override MigrationConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) MigrationConfig {
 	result := base
-	if override.Dir != "" {
-		result.Dir = override.Dir
-	}
-	if override.Format != "" {
-		result.Format = override.Format
-	}
-	if override.RevisionsSchema != "" {
-		result.RevisionsSchema = override.RevisionsSchema
-	}
-	if override.RevisionsTable != "" {
-		result.RevisionsTable = override.RevisionsTable
-	}
-	if override.RevisionFormat != "" {
-		result.RevisionFormat = override.RevisionFormat
-	}
-	if override.LockTimeout != "" {
-		result.LockTimeout = override.LockTimeout
-	}
-	if override.StatementTimeout != "" {
-		result.StatementTimeout = override.StatementTimeout
-	}
-	if override.ConnectTimeout != "" {
-		result.ConnectTimeout = override.ConnectTimeout
-	}
-	if override.MigrationLockTimeout != "" {
-		result.MigrationLockTimeout = override.MigrationLockTimeout
-	}
-	if override.ExecOrder != "" {
-		result.ExecOrder = override.ExecOrder
-	}
-	if override.TxMode != "" {
-		result.TxMode = override.TxMode
-	}
-	if override.PreUpHook != "" {
-		result.PreUpHook = override.PreUpHook
-	}
-	if override.PreDownHook != "" {
-		result.PreDownHook = override.PreDownHook
-	}
-	if override.PostgresDumpTo != "" {
-		result.PostgresDumpTo = override.PostgresDumpTo
-	}
-	if override.MySQLDumpTo != "" {
-		result.MySQLDumpTo = override.MySQLDumpTo
-	}
-	if override.Webhook != "" {
-		result.Webhook = override.Webhook
-	}
+	result.Dir = mergeStringValue(base.Dir, override.Dir, fieldMigrationDir, overridePresence, resultPresence)
+	result.Format = mergeStringValue(
+		base.Format,
+		override.Format,
+		fieldMigrationFormat,
+		overridePresence,
+		resultPresence,
+	)
+	result.RevisionsSchema = mergeStringValue(
+		base.RevisionsSchema,
+		override.RevisionsSchema,
+		fieldMigrationRevisionsSchema,
+		overridePresence,
+		resultPresence,
+	)
+	result.RevisionsTable = mergeStringValue(
+		base.RevisionsTable,
+		override.RevisionsTable,
+		fieldMigrationRevisionsTable,
+		overridePresence,
+		resultPresence,
+	)
+	result.RevisionFormat = mergeStringValue(
+		base.RevisionFormat,
+		override.RevisionFormat,
+		fieldMigrationRevisionFormat,
+		overridePresence,
+		resultPresence,
+	)
+	result.LockTimeout = mergeStringValue(
+		base.LockTimeout,
+		override.LockTimeout,
+		fieldMigrationLockTimeout,
+		overridePresence,
+		resultPresence,
+	)
+	result.StatementTimeout = mergeStringValue(
+		base.StatementTimeout,
+		override.StatementTimeout,
+		fieldMigrationStatementTimeout,
+		overridePresence,
+		resultPresence,
+	)
+	result.ConnectTimeout = mergeStringValue(
+		base.ConnectTimeout,
+		override.ConnectTimeout,
+		fieldMigrationConnectTimeout,
+		overridePresence,
+		resultPresence,
+	)
+	result.MigrationLockTimeout = mergeStringValue(
+		base.MigrationLockTimeout,
+		override.MigrationLockTimeout,
+		fieldMigrationMigrationLock,
+		overridePresence,
+		resultPresence,
+	)
+	result.ExecOrder = mergeStringValue(
+		base.ExecOrder,
+		override.ExecOrder,
+		fieldMigrationExecOrder,
+		overridePresence,
+		resultPresence,
+	)
+	result.TxMode = mergeStringValue(
+		base.TxMode,
+		override.TxMode,
+		fieldMigrationTxMode,
+		overridePresence,
+		resultPresence,
+	)
+	result.PreUpHook = mergeStringValue(
+		base.PreUpHook,
+		override.PreUpHook,
+		fieldMigrationPreUpHook,
+		overridePresence,
+		resultPresence,
+	)
+	result.PreDownHook = mergeStringValue(
+		base.PreDownHook,
+		override.PreDownHook,
+		fieldMigrationPreDownHook,
+		overridePresence,
+		resultPresence,
+	)
+	result.PostgresDumpTo = mergeStringValue(
+		base.PostgresDumpTo,
+		override.PostgresDumpTo,
+		fieldMigrationPostgresDumpTo,
+		overridePresence,
+		resultPresence,
+	)
+	result.MySQLDumpTo = mergeStringValue(
+		base.MySQLDumpTo,
+		override.MySQLDumpTo,
+		fieldMigrationMySQLDumpTo,
+		overridePresence,
+		resultPresence,
+	)
+	result.Webhook = mergeStringValue(
+		base.Webhook,
+		override.Webhook,
+		fieldMigrationWebhook,
+		overridePresence,
+		resultPresence,
+	)
 	return result
 }
 
-func mergeLint(base, override LintConfig, presence configPresence) LintConfig {
+func mergeLint(
+	base LintConfig,
+	override LintConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) LintConfig {
 	result := base
-	if override.Dialect != "" {
-		result.Dialect = override.Dialect
-	}
-	if presence.lintDisabledRules || len(override.DisabledRules) > 0 {
-		result.DisabledRules = slices.Clone(override.DisabledRules)
-	}
-	if len(override.RuleConfigs) > 0 {
-		result.RuleConfigs = mergeLintRuleConfigs(result.RuleConfigs, override.RuleConfigs)
-	}
-	if override.Latest != nil {
-		latest := *override.Latest
-		result.Latest = &latest
+	result.Latest = clonePointer(base.Latest)
+	result.Dialect = mergeStringValue(
+		base.Dialect,
+		override.Dialect,
+		fieldLintDialect,
+		overridePresence,
+		resultPresence,
+	)
+	result.DisabledRules = mergeStringSliceValue(
+		base.DisabledRules,
+		override.DisabledRules,
+		fieldLintDisabledRules,
+		overridePresence,
+		resultPresence,
+	)
+	result.RuleConfigs = mergeLintRuleConfigs(
+		base.RuleConfigs,
+		override.RuleConfigs,
+		overridePresence,
+		resultPresence,
+	)
+	if overridePresence.has(fieldLintLatest) || override.Latest != nil {
+		result.Latest = clonePointer(override.Latest)
 		result.GitBase = ""
 		result.GitDir = ""
+		resultPresence.mark(fieldLintLatest)
+		resultPresence.unmark(fieldLintGitBase)
+		resultPresence.unmark(fieldLintGitDir)
 	}
-	if override.GitBase != "" {
+	if overridePresence.has(fieldLintGitBase) || override.GitBase != "" {
 		result.GitBase = override.GitBase
 		result.Latest = nil
+		resultPresence.mark(fieldLintGitBase)
+		resultPresence.unmark(fieldLintLatest)
 	}
-	if override.GitDir != "" {
-		result.GitDir = override.GitDir
-	}
+	result.GitDir = mergeStringValue(
+		result.GitDir,
+		override.GitDir,
+		fieldLintGitDir,
+		overridePresence,
+		resultPresence,
+	)
 	return result
 }
 
 func mergeLintRuleConfigs(
 	base map[string]LintRuleConfig,
 	override map[string]LintRuleConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
 ) map[string]LintRuleConfig {
 	result := cloneLintRuleConfigs(base)
+	if !overridePresence.has(fieldLintRuleConfigs) && len(override) == 0 {
+		return result
+	}
+	resultPresence.mark(fieldLintRuleConfigs)
+	if len(override) == 0 {
+		resultPresence.removePrefix(lintRuleConfigFieldPrefix)
+		return map[string]LintRuleConfig{}
+	}
 	if result == nil {
 		result = make(map[string]LintRuleConfig, len(override))
 	}
 	for code, config := range override {
 		baseConfig := result[code]
-		if config.Severity != "" {
-			baseConfig.Severity = config.Severity
-		}
-		if len(config.Exclude) > 0 {
-			baseConfig.Exclude = slices.Clone(config.Exclude)
-		}
+		baseConfig.Severity = mergeStringValue(
+			baseConfig.Severity,
+			config.Severity,
+			lintRuleSeverityField(code),
+			overridePresence,
+			resultPresence,
+		)
+		baseConfig.Exclude = mergeStringSliceValue(
+			baseConfig.Exclude,
+			config.Exclude,
+			lintRuleExcludeField(code),
+			overridePresence,
+			resultPresence,
+		)
 		result[code] = baseConfig
 	}
 	return result
@@ -541,33 +828,78 @@ func cloneLintRuleConfigs(values map[string]LintRuleConfig) map[string]LintRuleC
 	return cloned
 }
 
-func mergeFormat(base, override FormatConfig) FormatConfig {
+func mergeFormat(
+	base FormatConfig,
+	override FormatConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) FormatConfig {
 	result := base
-	if override.Migrate.Apply != "" {
-		result.Migrate.Apply = override.Migrate.Apply
-	}
-	if override.Migrate.Diff != "" {
-		result.Migrate.Diff = override.Migrate.Diff
-	}
-	if override.Migrate.Lint != "" {
-		result.Migrate.Lint = override.Migrate.Lint
-	}
-	if override.Migrate.Status != "" {
-		result.Migrate.Status = override.Migrate.Status
-	}
-	if override.Schema.Apply != "" {
-		result.Schema.Apply = override.Schema.Apply
-	}
-	if override.Schema.Clean != "" {
-		result.Schema.Clean = override.Schema.Clean
-	}
-	if override.Schema.Diff != "" {
-		result.Schema.Diff = override.Schema.Diff
-	}
-	if override.Schema.Inspect != "" {
-		result.Schema.Inspect = override.Schema.Inspect
-	}
+	result.Migrate.Apply = mergeStringValue(
+		base.Migrate.Apply,
+		override.Migrate.Apply,
+		fieldFormatMigrateApply,
+		overridePresence,
+		resultPresence,
+	)
+	result.Migrate.Diff = mergeStringValue(
+		base.Migrate.Diff,
+		override.Migrate.Diff,
+		fieldFormatMigrateDiff,
+		overridePresence,
+		resultPresence,
+	)
+	result.Migrate.Lint = mergeStringValue(
+		base.Migrate.Lint,
+		override.Migrate.Lint,
+		fieldFormatMigrateLint,
+		overridePresence,
+		resultPresence,
+	)
+	result.Migrate.Status = mergeStringValue(
+		base.Migrate.Status,
+		override.Migrate.Status,
+		fieldFormatMigrateStatus,
+		overridePresence,
+		resultPresence,
+	)
+	result.Schema.Apply = mergeStringValue(
+		base.Schema.Apply,
+		override.Schema.Apply,
+		fieldFormatSchemaApply,
+		overridePresence,
+		resultPresence,
+	)
+	result.Schema.Clean = mergeStringValue(
+		base.Schema.Clean,
+		override.Schema.Clean,
+		fieldFormatSchemaClean,
+		overridePresence,
+		resultPresence,
+	)
+	result.Schema.Diff = mergeStringValue(
+		base.Schema.Diff,
+		override.Schema.Diff,
+		fieldFormatSchemaDiff,
+		overridePresence,
+		resultPresence,
+	)
+	result.Schema.Inspect = mergeStringValue(
+		base.Schema.Inspect,
+		override.Schema.Inspect,
+		fieldFormatSchemaInspect,
+		overridePresence,
+		resultPresence,
+	)
 	return result
+}
+
+func clonePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func mergeDiff(base, override DiffConfig) DiffConfig {

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -70,6 +70,57 @@ type Config struct {
 	presence configPresence
 }
 
+// Value carries a project-config value together with whether a source or
+// programmatic override supplied it. Command defaults must apply only when
+// Present is false.
+type Value[T any] struct {
+	Value   T
+	Present bool
+}
+
+// StringField identifies one string-valued Config field for presence-aware
+// command-default resolution.
+type StringField uint8
+
+// String-valued project-config fields.
+const (
+	StringEnvName StringField = iota
+	StringDatabaseURL
+	StringDevURL
+	StringMigrationDir
+	StringMigrationFormat
+	StringMigrationRevisionsSchema
+	StringMigrationRevisionsTable
+	StringMigrationRevisionFormat
+	StringMigrationLockTimeout
+	StringMigrationStatementTimeout
+	StringMigrationConnectTimeout
+	StringMigrationMigrationLockTimeout
+	StringMigrationExecOrder
+	StringMigrationTxMode
+	StringMigrationPreUpHook
+	StringMigrationPreDownHook
+	StringMigrationPostgresDumpTo
+	StringMigrationMySQLDumpTo
+	StringMigrationWebhook
+	StringOnlineDDLTool
+	StringOnlineDDLFallback
+	StringLintDialect
+	StringLintGitBase
+	StringLintGitDir
+	StringFormatMigrateApply
+	StringFormatMigrateDiff
+	StringFormatMigrateLint
+	StringFormatMigrateStatus
+	StringFormatSchemaApply
+	StringFormatSchemaClean
+	StringFormatSchemaDiff
+	StringFormatSchemaInspect
+	StringExternalSchemaFormat
+	StringExternalSchemaWorkingDir
+	stringFieldCount
+)
+
 type configField string
 
 const (
@@ -163,6 +214,194 @@ func lintRuleSeverityField(code string) configField {
 
 func lintRuleExcludeField(code string) configField {
 	return configField(lintRuleConfigFieldPrefix + code + ".exclude")
+}
+
+type stringFieldDescriptor struct {
+	presence configField
+	value    func(Config) string
+}
+
+var stringFieldDescriptors = [stringFieldCount]stringFieldDescriptor{
+	StringEnvName: {
+		presence: fieldEnvName,
+		value:    func(c Config) string { return c.EnvName },
+	},
+	StringDatabaseURL: {
+		presence: fieldDatabaseURL,
+		value:    func(c Config) string { return c.DatabaseURL },
+	},
+	StringDevURL: {
+		presence: fieldDevURL,
+		value:    func(c Config) string { return c.DevURL },
+	},
+	StringMigrationDir: {
+		presence: fieldMigrationDir,
+		value:    func(c Config) string { return c.Migration.Dir },
+	},
+	StringMigrationFormat: {
+		presence: fieldMigrationFormat,
+		value:    func(c Config) string { return c.Migration.Format },
+	},
+	StringMigrationRevisionsSchema: {
+		presence: fieldMigrationRevisionsSchema,
+		value:    func(c Config) string { return c.Migration.RevisionsSchema },
+	},
+	StringMigrationRevisionsTable: {
+		presence: fieldMigrationRevisionsTable,
+		value:    func(c Config) string { return c.Migration.RevisionsTable },
+	},
+	StringMigrationRevisionFormat: {
+		presence: fieldMigrationRevisionFormat,
+		value:    func(c Config) string { return c.Migration.RevisionFormat },
+	},
+	StringMigrationLockTimeout: {
+		presence: fieldMigrationLockTimeout,
+		value:    func(c Config) string { return c.Migration.LockTimeout },
+	},
+	StringMigrationStatementTimeout: {
+		presence: fieldMigrationStatementTimeout,
+		value:    func(c Config) string { return c.Migration.StatementTimeout },
+	},
+	StringMigrationConnectTimeout: {
+		presence: fieldMigrationConnectTimeout,
+		value:    func(c Config) string { return c.Migration.ConnectTimeout },
+	},
+	StringMigrationMigrationLockTimeout: {
+		presence: fieldMigrationMigrationLock,
+		value:    func(c Config) string { return c.Migration.MigrationLockTimeout },
+	},
+	StringMigrationExecOrder: {
+		presence: fieldMigrationExecOrder,
+		value:    func(c Config) string { return c.Migration.ExecOrder },
+	},
+	StringMigrationTxMode: {
+		presence: fieldMigrationTxMode,
+		value:    func(c Config) string { return c.Migration.TxMode },
+	},
+	StringMigrationPreUpHook: {
+		presence: fieldMigrationPreUpHook,
+		value:    func(c Config) string { return c.Migration.PreUpHook },
+	},
+	StringMigrationPreDownHook: {
+		presence: fieldMigrationPreDownHook,
+		value:    func(c Config) string { return c.Migration.PreDownHook },
+	},
+	StringMigrationPostgresDumpTo: {
+		presence: fieldMigrationPostgresDumpTo,
+		value:    func(c Config) string { return c.Migration.PostgresDumpTo },
+	},
+	StringMigrationMySQLDumpTo: {
+		presence: fieldMigrationMySQLDumpTo,
+		value:    func(c Config) string { return c.Migration.MySQLDumpTo },
+	},
+	StringMigrationWebhook: {
+		presence: fieldMigrationWebhook,
+		value:    func(c Config) string { return c.Migration.Webhook },
+	},
+	StringOnlineDDLTool: {
+		presence: fieldOnlineDDLTool,
+		value:    func(c Config) string { return c.OnlineDDL.Tool },
+	},
+	StringOnlineDDLFallback: {
+		presence: fieldOnlineDDLFallback,
+		value:    func(c Config) string { return c.OnlineDDL.Fallback },
+	},
+	StringLintDialect: {
+		presence: fieldLintDialect,
+		value:    func(c Config) string { return c.Lint.Dialect },
+	},
+	StringLintGitBase: {
+		presence: fieldLintGitBase,
+		value:    func(c Config) string { return c.Lint.GitBase },
+	},
+	StringLintGitDir: {
+		presence: fieldLintGitDir,
+		value:    func(c Config) string { return c.Lint.GitDir },
+	},
+	StringFormatMigrateApply: {
+		presence: fieldFormatMigrateApply,
+		value:    func(c Config) string { return c.Format.Migrate.Apply },
+	},
+	StringFormatMigrateDiff: {
+		presence: fieldFormatMigrateDiff,
+		value:    func(c Config) string { return c.Format.Migrate.Diff },
+	},
+	StringFormatMigrateLint: {
+		presence: fieldFormatMigrateLint,
+		value:    func(c Config) string { return c.Format.Migrate.Lint },
+	},
+	StringFormatMigrateStatus: {
+		presence: fieldFormatMigrateStatus,
+		value:    func(c Config) string { return c.Format.Migrate.Status },
+	},
+	StringFormatSchemaApply: {
+		presence: fieldFormatSchemaApply,
+		value:    func(c Config) string { return c.Format.Schema.Apply },
+	},
+	StringFormatSchemaClean: {
+		presence: fieldFormatSchemaClean,
+		value:    func(c Config) string { return c.Format.Schema.Clean },
+	},
+	StringFormatSchemaDiff: {
+		presence: fieldFormatSchemaDiff,
+		value:    func(c Config) string { return c.Format.Schema.Diff },
+	},
+	StringFormatSchemaInspect: {
+		presence: fieldFormatSchemaInspect,
+		value:    func(c Config) string { return c.Format.Schema.Inspect },
+	},
+	StringExternalSchemaFormat: {
+		presence: fieldExternalSchemaFormat,
+		value:    func(c Config) string { return c.ExternalSchema.Format },
+	},
+	StringExternalSchemaWorkingDir: {
+		presence: fieldExternalSchemaWorkingDir,
+		value:    func(c Config) string { return c.ExternalSchema.WorkingDir },
+	},
+}
+
+// StringValue returns a string-valued field together with its source presence.
+// Non-empty programmatic values count as present even without loader metadata.
+// Unknown fields return an absent value.
+func (c Config) StringValue(field StringField) Value[string] {
+	if field >= stringFieldCount {
+		return Value[string]{}
+	}
+	descriptor := stringFieldDescriptors[field]
+	value := descriptor.value(c)
+	return Value[string]{
+		Value:   value,
+		Present: c.presence.has(descriptor.presence) || value != "",
+	}
+}
+
+// SchemaSourcesValue returns the desired schema sources with presence.
+func (c Config) SchemaSourcesValue() Value[[]string] {
+	return Value[[]string]{
+		Value:   slices.Clone(c.SchemaSources),
+		Present: c.presence.has(fieldSchemaSources) || len(c.SchemaSources) > 0,
+	}
+}
+
+// SchemasValue returns the configured introspection schemas with presence.
+func (c Config) SchemasValue() Value[[]string] {
+	return Value[[]string]{
+		Value:   slices.Clone(c.Schemas),
+		Present: c.presence.has(fieldSchemas) || len(c.Schemas) > 0,
+	}
+}
+
+// LintLatestValue returns lint.latest with presence. A present nil pointer is
+// retained for completeness even though supported loaders materialize an int.
+func (c Config) LintLatestValue() Value[int] {
+	value := 0
+	if c.Lint.Latest != nil {
+		value = *c.Lint.Latest
+	}
+	return Value[int]{
+		Value:   value,
+		Present: c.presence.has(fieldLintLatest) || c.Lint.Latest != nil,
+	}
 }
 
 // OnlineDDLConfig configures automatic online-DDL routing for ALTER TABLE
@@ -763,9 +1002,11 @@ func mergeLint(
 	}
 	if overridePresence.has(fieldLintGitBase) || override.GitBase != "" {
 		result.GitBase = override.GitBase
-		result.Latest = nil
 		resultPresence.mark(fieldLintGitBase)
-		resultPresence.unmark(fieldLintLatest)
+		if override.GitBase != "" {
+			result.Latest = nil
+			resultPresence.unmark(fieldLintLatest)
+		}
 	}
 	result.GitDir = mergeStringValue(
 		result.GitDir,

--- a/config/projectconfig/presence_test.go
+++ b/config/projectconfig/presence_test.go
@@ -387,3 +387,187 @@ func TestMergeClonesBaseLintLatest(t *testing.T) {
 	c.Assert(merged.Lint.Latest, qt.IsNotNil)
 	c.Assert(*merged.Lint.Latest, qt.Equals, 3)
 }
+
+func TestParseAtlasRejectsConflictingLintSelectors(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParseAtlas([]byte(`
+env "ci" {
+  lint {
+    latest = 1
+    git {
+      base = "main"
+    }
+  }
+}
+`), "atlas.hcl", "ci")
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`atlas\.hcl lint\.latest and lint\.git\.base are mutually exclusive at atlas\.hcl:3`,
+	)
+}
+
+func TestParseAtlasEmptyGitBasePreservesLatest(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := projectconfig.ParseAtlas([]byte(`
+lint {
+  latest = 2
+}
+env "ci" {
+  lint {
+    git {
+      base = ""
+    }
+  }
+}
+`), "atlas.hcl", "ci")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Lint.Latest, qt.IsNotNil)
+	c.Assert(*cfg.Lint.Latest, qt.Equals, 2)
+	c.Assert(cfg.Lint.GitBase, qt.Equals, "")
+}
+
+func TestMergeUnlabeledAtlasEnvClearsPtahEnvName(t *testing.T) {
+	c := qt.New(t)
+	ptah, err := projectconfig.ParsePtah([]byte(`
+env:
+  prod:
+    url: postgres://prod/db
+`), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+	atlas, err := projectconfig.ParseAtlas([]byte(`
+env {
+  url = "postgres://atlas/db"
+}
+`), "atlas.hcl", "")
+	c.Assert(err, qt.IsNil)
+
+	cfg := projectconfig.Merge(ptah, atlas)
+
+	c.Assert(cfg.EnvName, qt.Equals, "")
+	c.Assert(
+		cfg.StringValue(projectconfig.StringEnvName),
+		qt.DeepEquals,
+		projectconfig.Value[string]{Present: true},
+	)
+}
+
+func TestConfigValuePresenceDistinguishesAbsentAndExplicitZeroValues(t *testing.T) {
+	c := qt.New(t)
+	explicit, err := projectconfig.ParsePtah([]byte(`
+migration:
+  dir: ""
+schemas: []
+lint:
+  latest: 0
+`), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(
+		explicit.StringValue(projectconfig.StringMigrationDir),
+		qt.DeepEquals,
+		projectconfig.Value[string]{Present: true},
+	)
+	c.Assert(
+		explicit.SchemasValue(),
+		qt.DeepEquals,
+		projectconfig.Value[[]string]{Value: []string{}, Present: true},
+	)
+	c.Assert(
+		explicit.LintLatestValue(),
+		qt.DeepEquals,
+		projectconfig.Value[int]{Present: true},
+	)
+	c.Assert(
+		(projectconfig.Config{}).StringValue(projectconfig.StringMigrationDir),
+		qt.DeepEquals,
+		projectconfig.Value[string]{},
+	)
+}
+
+func TestConfigValuePresenceTreatsProgrammaticNonZeroAsPresent(t *testing.T) {
+	c := qt.New(t)
+	cfg := projectconfig.Config{
+		Migration: projectconfig.MigrationConfig{Dir: "migrations"},
+	}
+
+	c.Assert(
+		cfg.StringValue(projectconfig.StringMigrationDir),
+		qt.DeepEquals,
+		projectconfig.Value[string]{Value: "migrations", Present: true},
+	)
+}
+
+func TestConfigStringValueUnknownFieldIsAbsent(t *testing.T) {
+	c := qt.New(t)
+
+	got := (projectconfig.Config{}).StringValue(projectconfig.StringField(255))
+
+	c.Assert(got, qt.DeepEquals, projectconfig.Value[string]{})
+}
+
+func TestMergeClonesEveryCollection(t *testing.T) {
+	c := qt.New(t)
+	base := projectconfig.Config{
+		SchemaSources: []string{"file://base.hcl"},
+		Lint: projectconfig.LintConfig{
+			DisabledRules: []string{"MF103"},
+		},
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program: []string{"base-loader"},
+		},
+	}
+	override := projectconfig.Config{
+		Schemas: []string{"tenant"},
+		Exclude: []string{"audit"},
+		OnlineDDL: projectconfig.OnlineDDLConfig{
+			Args: []string{"--assume-rbr"},
+		},
+		Lint: projectconfig.LintConfig{
+			RuleConfigs: map[string]projectconfig.LintRuleConfig{
+				"DS": {
+					Severity: "error",
+					Exclude:  []string{"generated/**"},
+				},
+			},
+		},
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Env: []string{"MODE=override"},
+		},
+	}
+
+	merged := projectconfig.Merge(base, override)
+	base.SchemaSources[0] = "file://mutated.hcl"
+	base.Lint.DisabledRules[0] = "DS102"
+	base.ExternalSchema.Program[0] = "mutated-loader"
+	override.Schemas[0] = "mutated"
+	override.Exclude[0] = "mutated"
+	override.OnlineDDL.Args[0] = "--mutated"
+	rule := override.Lint.RuleConfigs["DS"]
+	rule.Severity = "warning"
+	rule.Exclude[0] = "mutated/**"
+	override.Lint.RuleConfigs["DS"] = rule
+	override.ExternalSchema.Env[0] = "MODE=mutated"
+
+	c.Assert(merged.SchemaSources, qt.DeepEquals, []string{"file://base.hcl"})
+	c.Assert(merged.Schemas, qt.DeepEquals, []string{"tenant"})
+	c.Assert(merged.Exclude, qt.DeepEquals, []string{"audit"})
+	c.Assert(merged.OnlineDDL.Args, qt.DeepEquals, []string{"--assume-rbr"})
+	c.Assert(merged.Lint.DisabledRules, qt.DeepEquals, []string{"MF103"})
+	c.Assert(
+		merged.Lint.RuleConfigs,
+		qt.DeepEquals,
+		map[string]projectconfig.LintRuleConfig{
+			"DS": {
+				Severity: "error",
+				Exclude:  []string{"generated/**"},
+			},
+		},
+	)
+	c.Assert(merged.ExternalSchema.Program, qt.DeepEquals, []string{"base-loader"})
+	c.Assert(merged.ExternalSchema.Env, qt.DeepEquals, []string{"MODE=override"})
+}

--- a/config/projectconfig/presence_test.go
+++ b/config/projectconfig/presence_test.go
@@ -1,0 +1,389 @@
+package projectconfig_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestParsePtahPresence_ExplicitZeroValuesOverrideRoot(t *testing.T) {
+	c := qt.New(t)
+
+	cfg, err := projectconfig.ParsePtah([]byte(`
+url: postgres://root/db
+dev: postgres://root/dev
+schemas: [public]
+exclude: [audit]
+migration:
+  dir: migrations
+  format: ptah
+  revisions_schema: revisions
+  revisions_table: schema_migrations
+  revision_format: ptah
+  lock_timeout: 1s
+  statement_timeout: 2s
+  connect_timeout: 3s
+  migration_lock_timeout: 4s
+  exec_order: linear
+  tx_mode: all
+  pre_up_hook: backup
+  pre_down_hook: verify
+  pg_dump_to: pg.sql
+  mysqldump_to: mysql.sql
+  webhook: https://example.test/hook
+online_ddl:
+  tool: ghost
+  threshold_rows: 100
+  args: [--assume-rbr]
+  fallback: plain
+lint:
+  dialect: postgres
+  disabled-rules: [DS101]
+  latest: 5
+external_schema:
+  program: [schema-loader]
+  format: sql
+  working_dir: ./schema
+  env: [MODE=root]
+diff:
+  skip: [drop_table]
+  concurrent_index: true
+env:
+  prod:
+    url: ""
+    dev: ""
+    schemas: []
+    exclude: []
+    migrate:
+      generate:
+        shadow_db: postgres://ignored/dev
+    migration:
+      dir: ""
+      format: ""
+      revisions_schema: ""
+      revisions_table: ""
+      revision_format: ""
+      lock_timeout: ""
+      statement_timeout: ""
+      connect_timeout: ""
+      migration_lock_timeout: ""
+      exec_order: ""
+      tx_mode: ""
+      pre_up_hook: ""
+      pre_down_hook: ""
+      pg_dump_to: ""
+      mysqldump_to: ""
+      webhook: ""
+    online_ddl:
+      tool: ""
+      threshold_rows: 0
+      args: []
+      fallback: ""
+    lint:
+      dialect: ""
+      disabled-rules: []
+      latest: 0
+    external_schema:
+      program: []
+      format: ""
+      working_dir: ""
+      env: []
+    diff:
+      skip: []
+      concurrent_index: false
+`), "ptah.yaml", "prod")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.EnvName, qt.Equals, "prod")
+	c.Assert(cfg.DatabaseURL, qt.Equals, "")
+	c.Assert(cfg.DevURL, qt.Equals, "")
+	c.Assert(cfg.Schemas, qt.HasLen, 0)
+	c.Assert(cfg.Exclude, qt.HasLen, 0)
+	c.Assert(cfg.Migration, qt.DeepEquals, projectconfig.MigrationConfig{})
+	c.Assert(cfg.OnlineDDL.Tool, qt.Equals, "")
+	c.Assert(cfg.OnlineDDL.ThresholdRows, qt.Equals, int64(0))
+	c.Assert(cfg.OnlineDDL.Args, qt.HasLen, 0)
+	c.Assert(cfg.OnlineDDL.Fallback, qt.Equals, "")
+	c.Assert(cfg.Lint.Dialect, qt.Equals, "")
+	c.Assert(cfg.Lint.DisabledRules, qt.HasLen, 0)
+	c.Assert(cfg.Lint.Latest, qt.IsNotNil)
+	c.Assert(*cfg.Lint.Latest, qt.Equals, 0)
+	c.Assert(cfg.ExternalSchema.Program, qt.HasLen, 0)
+	c.Assert(cfg.ExternalSchema.Format, qt.Equals, "")
+	c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "")
+	c.Assert(cfg.ExternalSchema.Env, qt.HasLen, 0)
+	c.Assert(cfg.Diff.Skip.DropTable, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
+	c.Assert(cfg.Diff.Skip.DropColumn, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
+	c.Assert(cfg.Diff.Skip.DropIndex, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
+	c.Assert(cfg.Diff.Skip.DropEnum, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
+	c.Assert(cfg.Diff.ConcurrentIndex.Create, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
+}
+
+func TestMergePresence_AtlasEmptyMigrationOverridesPtah(t *testing.T) {
+	c := qt.New(t)
+
+	base, err := projectconfig.ParsePtah([]byte(`
+url: postgres://root/db
+dev: postgres://root/dev
+exclude: [audit]
+migration:
+  dir: migrations
+  format: ptah
+  revisions_schema: revisions
+  revisions_table: schema_migrations
+  revision_format: ptah
+  lock_timeout: 1s
+  exec_order: linear
+  tx_mode: all
+`), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+
+	override, err := projectconfig.ParseAtlas([]byte(`
+env "prod" {
+  url     = ""
+  dev     = ""
+  src     = []
+  exclude = []
+
+  migration {
+    dir              = ""
+    revisions_schema = ""
+    lock_timeout     = ""
+    exec_order       = ""
+    tx_mode          = ""
+  }
+}
+`), "atlas.hcl", "prod")
+	c.Assert(err, qt.IsNil)
+
+	cfg := projectconfig.Merge(base, override)
+
+	c.Assert(cfg.DatabaseURL, qt.Equals, "")
+	c.Assert(cfg.DevURL, qt.Equals, "")
+	c.Assert(cfg.SchemaSources, qt.HasLen, 0)
+	c.Assert(cfg.Exclude, qt.HasLen, 0)
+	c.Assert(cfg.Migration.Dir, qt.Equals, "")
+	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.RevisionsSchema, qt.Equals, "")
+	c.Assert(cfg.Migration.RevisionsTable, qt.Equals, "schema_migrations")
+	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+	c.Assert(cfg.Migration.LockTimeout, qt.Equals, "")
+	c.Assert(cfg.Migration.ExecOrder, qt.Equals, "")
+	c.Assert(cfg.Migration.TxMode, qt.Equals, "")
+}
+
+func TestMergePresence_PersistsForFormatAndLintRuleFields(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, err := projectconfig.ParseAtlas([]byte(`
+lint {
+  destructive {
+    error = true
+  }
+}
+
+env "prod" {
+  format {
+    migrate {
+      apply  = "apply"
+      diff   = "diff"
+      lint   = "lint"
+      status = "status"
+    }
+    schema {
+      apply   = "apply"
+      clean   = "clean"
+      diff    = "diff"
+      inspect = "inspect"
+    }
+  }
+}
+`), "atlas.hcl", "prod")
+	c.Assert(err, qt.IsNil)
+
+	fields := projectconfig.Merge(projectconfig.Config{}, parsed)
+	rule := fields.Lint.RuleConfigs["DS"]
+	rule.Severity = ""
+	fields.Lint.RuleConfigs["DS"] = rule
+	fields.Format = projectconfig.FormatConfig{}
+
+	base := projectconfig.Config{
+		Lint: projectconfig.LintConfig{
+			RuleConfigs: map[string]projectconfig.LintRuleConfig{
+				"DS": {
+					Severity: "warning",
+					Exclude:  []string{"legacy/**"},
+				},
+			},
+		},
+		Format: projectconfig.FormatConfig{
+			Migrate: projectconfig.MigrateFormatConfig{
+				Apply:  "base-apply",
+				Diff:   "base-diff",
+				Lint:   "base-lint",
+				Status: "base-status",
+			},
+			Schema: projectconfig.SchemaFormatConfig{
+				Apply:   "base-apply",
+				Clean:   "base-clean",
+				Diff:    "base-diff",
+				Inspect: "base-inspect",
+			},
+		},
+	}
+	cfg := projectconfig.Merge(base, fields)
+
+	c.Assert(cfg.Format, qt.DeepEquals, projectconfig.FormatConfig{})
+	c.Assert(cfg.Lint.RuleConfigs["DS"].Severity, qt.Equals, "")
+	c.Assert(cfg.Lint.RuleConfigs["DS"].Exclude, qt.DeepEquals, []string{"legacy/**"})
+
+	rules := projectconfig.Merge(projectconfig.Config{}, parsed)
+	rules.Lint.RuleConfigs = map[string]projectconfig.LintRuleConfig{}
+	cfg = projectconfig.Merge(base, rules)
+
+	c.Assert(cfg.Lint.RuleConfigs, qt.HasLen, 0)
+}
+
+func TestMergeProgrammaticNonZeroValuesOverrideEverySection(t *testing.T) {
+	c := qt.New(t)
+	baseLatest := 1
+	overrideLatest := 2
+	base := projectconfig.Config{
+		EnvName:       "base",
+		DatabaseURL:   "postgres://base/db",
+		DevURL:        "postgres://base/dev",
+		SchemaSources: []string{"file://base.hcl"},
+		Schemas:       []string{"base"},
+		Exclude:       []string{"base"},
+		Schema: projectconfig.SchemaConfig{
+			Mode: projectconfig.SchemaModeConfig{
+				Tables: projectconfig.ConfigBool{Value: true, Set: true},
+			},
+		},
+		Migration: projectconfig.MigrationConfig{Dir: "base"},
+		OnlineDDL: projectconfig.OnlineDDLConfig{Tool: projectconfig.OnlineDDLToolGhost, ThresholdRows: 1},
+		Lint: projectconfig.LintConfig{
+			Dialect: "postgres",
+			RuleConfigs: map[string]projectconfig.LintRuleConfig{
+				"DS": {Severity: "warning"},
+			},
+			Latest: &baseLatest,
+		},
+		Format: projectconfig.FormatConfig{
+			Migrate: projectconfig.MigrateFormatConfig{Apply: "base"},
+		},
+		Diff: projectconfig.DiffConfig{
+			ConcurrentIndex: projectconfig.DiffConcurrentIndexConfig{
+				Create: projectconfig.ConfigBool{Value: true, Set: true},
+			},
+		},
+		ExternalSchema: projectconfig.ExternalSchemaConfig{Program: []string{"base"}},
+	}
+	override := projectconfig.Config{
+		EnvName:       "override",
+		DatabaseURL:   "postgres://override/db",
+		DevURL:        "postgres://override/dev",
+		SchemaSources: []string{"file://override.hcl"},
+		Schemas:       []string{"override"},
+		Exclude:       []string{"override"},
+		Schema: projectconfig.SchemaConfig{
+			Mode: projectconfig.SchemaModeConfig{
+				Tables: projectconfig.ConfigBool{Set: true},
+			},
+		},
+		Migration: projectconfig.MigrationConfig{
+			Dir:                  "override",
+			Format:               "atlas",
+			RevisionsSchema:      "override",
+			RevisionsTable:       "override",
+			RevisionFormat:       "atlas",
+			LockTimeout:          "1s",
+			StatementTimeout:     "2s",
+			ConnectTimeout:       "3s",
+			MigrationLockTimeout: "4s",
+			ExecOrder:            "non-linear",
+			TxMode:               "none",
+			PreUpHook:            "up",
+			PreDownHook:          "down",
+			PostgresDumpTo:       "pg.sql",
+			MySQLDumpTo:          "mysql.sql",
+			Webhook:              "https://example.test/hook",
+		},
+		OnlineDDL: projectconfig.OnlineDDLConfig{
+			Tool:          projectconfig.OnlineDDLToolPTOSC,
+			ThresholdRows: 2,
+			Args:          []string{"--alter-foreign-keys-method=auto"},
+			Fallback:      projectconfig.OnlineDDLFallbackPlain,
+		},
+		Lint: projectconfig.LintConfig{
+			Dialect:       "mysql",
+			DisabledRules: []string{"DS101"},
+			RuleConfigs: map[string]projectconfig.LintRuleConfig{
+				"DS": {
+					Severity: "error",
+					Exclude:  []string{"generated/**"},
+				},
+			},
+			Latest: &overrideLatest,
+		},
+		Format: projectconfig.FormatConfig{
+			Migrate: projectconfig.MigrateFormatConfig{
+				Apply:  "apply",
+				Diff:   "diff",
+				Lint:   "lint",
+				Status: "status",
+			},
+			Schema: projectconfig.SchemaFormatConfig{
+				Apply:   "apply",
+				Clean:   "clean",
+				Diff:    "diff",
+				Inspect: "inspect",
+			},
+		},
+		Diff: projectconfig.DiffConfig{
+			ConcurrentIndex: projectconfig.DiffConcurrentIndexConfig{
+				Create: projectconfig.ConfigBool{Set: true},
+			},
+		},
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program:    []string{"override"},
+			Format:     "hcl",
+			WorkingDir: "./override",
+			Env:        []string{"MODE=override"},
+		},
+	}
+
+	cfg := projectconfig.Merge(base, override)
+
+	c.Assert(cfg.EnvName, qt.Equals, override.EnvName)
+	c.Assert(cfg.DatabaseURL, qt.Equals, override.DatabaseURL)
+	c.Assert(cfg.DevURL, qt.Equals, override.DevURL)
+	c.Assert(cfg.SchemaSources, qt.DeepEquals, override.SchemaSources)
+	c.Assert(cfg.Schemas, qt.DeepEquals, override.Schemas)
+	c.Assert(cfg.Exclude, qt.DeepEquals, override.Exclude)
+	c.Assert(cfg.Schema, qt.DeepEquals, override.Schema)
+	c.Assert(cfg.Migration, qt.DeepEquals, override.Migration)
+	c.Assert(cfg.OnlineDDL, qt.DeepEquals, override.OnlineDDL)
+	c.Assert(cfg.Lint, qt.DeepEquals, override.Lint)
+	c.Assert(cfg.Format, qt.DeepEquals, override.Format)
+	c.Assert(cfg.Diff, qt.DeepEquals, override.Diff)
+	c.Assert(cfg.ExternalSchema, qt.DeepEquals, override.ExternalSchema)
+}
+
+func TestMergeClonesBaseLintLatest(t *testing.T) {
+	c := qt.New(t)
+	latest := 3
+	base := projectconfig.Config{
+		Lint: projectconfig.LintConfig{
+			Latest: &latest,
+		},
+	}
+
+	merged := projectconfig.Merge(base, projectconfig.Config{})
+	*base.Lint.Latest = 9
+
+	c.Assert(merged.Lint.Latest, qt.IsNotNil)
+	c.Assert(*merged.Lint.Latest, qt.Equals, 3)
+}

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -19,8 +19,8 @@ type yamlDocument struct {
 }
 
 type yamlSettings struct {
-	URL            string             `yaml:"url"`
-	Dev            string             `yaml:"dev"`
+	URL            *string            `yaml:"url"`
+	Dev            *string            `yaml:"dev"`
 	Schemas        *[]string          `yaml:"schemas"`
 	Exclude        *[]string          `yaml:"exclude"`
 	Migration      yamlMigration      `yaml:"migration"`
@@ -38,8 +38,8 @@ type yamlSettings struct {
 // are pointers so an explicit empty list is distinguishable from an unset value.
 type yamlExternalSchema struct {
 	Program    *[]string `yaml:"program"`
-	Format     string    `yaml:"format"`
-	WorkingDir string    `yaml:"working_dir"`
+	Format     *string   `yaml:"format"`
+	WorkingDir *string   `yaml:"working_dir"`
 	Env        *[]string `yaml:"env"`
 }
 
@@ -48,31 +48,31 @@ type yamlExternalSchema struct {
 // CREATE INDEX CONCURRENTLY for newly added indexes. concurrent_index is a
 // pointer so an explicit false is distinguishable from an unset value.
 type yamlDiff struct {
-	Skip            []string `yaml:"skip"`
-	ConcurrentIndex *bool    `yaml:"concurrent_index"`
+	Skip            *[]string `yaml:"skip"`
+	ConcurrentIndex *bool     `yaml:"concurrent_index"`
 }
 
 type yamlMigration struct {
-	Dir                  string `yaml:"dir"`
-	Format               string `yaml:"format"`
-	RevisionsSchema      string `yaml:"revisions_schema"`
-	RevisionsTable       string `yaml:"revisions_table"`
-	RevisionFormat       string `yaml:"revision_format"`
-	LockTimeout          string `yaml:"lock_timeout"`
-	StatementTimeout     string `yaml:"statement_timeout"`
-	ConnectTimeout       string `yaml:"connect_timeout"`
-	MigrationLockTimeout string `yaml:"migration_lock_timeout"`
-	ExecOrder            string `yaml:"exec_order"`
-	TxMode               string `yaml:"tx_mode"`
-	PreUpHook            string `yaml:"pre_up_hook"`
-	PreDownHook          string `yaml:"pre_down_hook"`
-	PostgresDumpTo       string `yaml:"pg_dump_to"`
-	MySQLDumpTo          string `yaml:"mysqldump_to"`
-	Webhook              string `yaml:"webhook"`
+	Dir                  *string `yaml:"dir"`
+	Format               *string `yaml:"format"`
+	RevisionsSchema      *string `yaml:"revisions_schema"`
+	RevisionsTable       *string `yaml:"revisions_table"`
+	RevisionFormat       *string `yaml:"revision_format"`
+	LockTimeout          *string `yaml:"lock_timeout"`
+	StatementTimeout     *string `yaml:"statement_timeout"`
+	ConnectTimeout       *string `yaml:"connect_timeout"`
+	MigrationLockTimeout *string `yaml:"migration_lock_timeout"`
+	ExecOrder            *string `yaml:"exec_order"`
+	TxMode               *string `yaml:"tx_mode"`
+	PreUpHook            *string `yaml:"pre_up_hook"`
+	PreDownHook          *string `yaml:"pre_down_hook"`
+	PostgresDumpTo       *string `yaml:"pg_dump_to"`
+	MySQLDumpTo          *string `yaml:"mysqldump_to"`
+	Webhook              *string `yaml:"webhook"`
 }
 
 type yamlLint struct {
-	Dialect       string    `yaml:"dialect"`
+	Dialect       *string   `yaml:"dialect"`
 	DisabledRules *[]string `yaml:"disabled-rules"`
 	Latest        *int      `yaml:"latest"`
 }
@@ -89,7 +89,7 @@ type yamlMigrateConfig struct {
 }
 
 type yamlMigrateGenerateConfig struct {
-	ShadowDatabaseURL string `yaml:"shadow_db"`
+	ShadowDatabaseURL *string `yaml:"shadow_db"`
 }
 
 // LoadPtahFile loads Ptah's project config file. A missing file returns an
@@ -174,60 +174,137 @@ func selectPtahEnv(doc yamlDocument, envName string) (Config, error) {
 }
 
 func (c yamlSettings) projectConfig() (Config, error) {
-	dev := c.Dev
-	if dev == "" {
-		dev = c.Migrate.Generate.ShadowDatabaseURL
+	cfg := Config{}
+	applyYAMLString(c.URL, &cfg.DatabaseURL, fieldDatabaseURL, &cfg.presence)
+	switch {
+	case c.Dev != nil:
+		applyYAMLString(c.Dev, &cfg.DevURL, fieldDevURL, &cfg.presence)
+	case c.Migrate.Generate.ShadowDatabaseURL != nil:
+		applyYAMLString(
+			c.Migrate.Generate.ShadowDatabaseURL,
+			&cfg.DevURL,
+			fieldDevURL,
+			&cfg.presence,
+		)
 	}
-	cfg := Config{
-		DatabaseURL: c.URL,
-		DevURL:      dev,
-		Migration: MigrationConfig{
-			Dir:                  c.Migration.Dir,
-			Format:               c.Migration.Format,
-			RevisionsSchema:      c.Migration.RevisionsSchema,
-			RevisionsTable:       c.Migration.RevisionsTable,
-			RevisionFormat:       c.Migration.RevisionFormat,
-			LockTimeout:          c.Migration.LockTimeout,
-			StatementTimeout:     c.Migration.StatementTimeout,
-			ConnectTimeout:       c.Migration.ConnectTimeout,
-			MigrationLockTimeout: c.Migration.MigrationLockTimeout,
-			ExecOrder:            c.Migration.ExecOrder,
-			TxMode:               c.Migration.TxMode,
-			PreUpHook:            c.Migration.PreUpHook,
-			PreDownHook:          c.Migration.PreDownHook,
-			PostgresDumpTo:       c.Migration.PostgresDumpTo,
-			MySQLDumpTo:          c.Migration.MySQLDumpTo,
-			Webhook:              c.Migration.Webhook,
-		},
-		Lint: LintConfig{
-			Dialect: c.Lint.Dialect,
-			Latest:  c.Lint.Latest,
-		},
-		ExternalSchema: ExternalSchemaConfig{
-			Format:     c.ExternalSchema.Format,
-			WorkingDir: c.ExternalSchema.WorkingDir,
-		},
+	applyYAMLString(c.Migration.Dir, &cfg.Migration.Dir, fieldMigrationDir, &cfg.presence)
+	applyYAMLString(c.Migration.Format, &cfg.Migration.Format, fieldMigrationFormat, &cfg.presence)
+	applyYAMLString(
+		c.Migration.RevisionsSchema,
+		&cfg.Migration.RevisionsSchema,
+		fieldMigrationRevisionsSchema,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.RevisionsTable,
+		&cfg.Migration.RevisionsTable,
+		fieldMigrationRevisionsTable,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.RevisionFormat,
+		&cfg.Migration.RevisionFormat,
+		fieldMigrationRevisionFormat,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.LockTimeout,
+		&cfg.Migration.LockTimeout,
+		fieldMigrationLockTimeout,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.StatementTimeout,
+		&cfg.Migration.StatementTimeout,
+		fieldMigrationStatementTimeout,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.ConnectTimeout,
+		&cfg.Migration.ConnectTimeout,
+		fieldMigrationConnectTimeout,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.MigrationLockTimeout,
+		&cfg.Migration.MigrationLockTimeout,
+		fieldMigrationMigrationLock,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.ExecOrder,
+		&cfg.Migration.ExecOrder,
+		fieldMigrationExecOrder,
+		&cfg.presence,
+	)
+	applyYAMLString(c.Migration.TxMode, &cfg.Migration.TxMode, fieldMigrationTxMode, &cfg.presence)
+	applyYAMLString(
+		c.Migration.PreUpHook,
+		&cfg.Migration.PreUpHook,
+		fieldMigrationPreUpHook,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.PreDownHook,
+		&cfg.Migration.PreDownHook,
+		fieldMigrationPreDownHook,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.PostgresDumpTo,
+		&cfg.Migration.PostgresDumpTo,
+		fieldMigrationPostgresDumpTo,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.MySQLDumpTo,
+		&cfg.Migration.MySQLDumpTo,
+		fieldMigrationMySQLDumpTo,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.Migration.Webhook,
+		&cfg.Migration.Webhook,
+		fieldMigrationWebhook,
+		&cfg.presence,
+	)
+	applyYAMLString(c.Lint.Dialect, &cfg.Lint.Dialect, fieldLintDialect, &cfg.presence)
+	if c.Lint.Latest != nil {
+		cfg.Lint.Latest = clonePointer(c.Lint.Latest)
+		cfg.presence.mark(fieldLintLatest)
 	}
+	applyYAMLString(
+		c.ExternalSchema.Format,
+		&cfg.ExternalSchema.Format,
+		fieldExternalSchemaFormat,
+		&cfg.presence,
+	)
+	applyYAMLString(
+		c.ExternalSchema.WorkingDir,
+		&cfg.ExternalSchema.WorkingDir,
+		fieldExternalSchemaWorkingDir,
+		&cfg.presence,
+	)
 	c.OnlineDDL.applyTo(&cfg)
 	if c.ExternalSchema.Program != nil {
 		cfg.ExternalSchema.Program = slices.Clone(*c.ExternalSchema.Program)
-		cfg.presence.externalSchemaProgram = true
+		cfg.presence.mark(fieldExternalSchemaProgram)
 	}
 	if c.ExternalSchema.Env != nil {
 		cfg.ExternalSchema.Env = slices.Clone(*c.ExternalSchema.Env)
-		cfg.presence.externalSchemaEnv = true
+		cfg.presence.mark(fieldExternalSchemaEnv)
 	}
 	if c.Schemas != nil {
 		cfg.Schemas = slices.Clone(*c.Schemas)
-		cfg.presence.schemas = true
+		cfg.presence.mark(fieldSchemas)
 	}
 	if c.Exclude != nil {
 		cfg.Exclude = slices.Clone(*c.Exclude)
-		cfg.presence.exclude = true
+		cfg.presence.mark(fieldExclude)
 	}
 	if c.Lint.DisabledRules != nil {
 		cfg.Lint.DisabledRules = slices.Clone(*c.Lint.DisabledRules)
-		cfg.presence.lintDisabledRules = true
+		cfg.presence.mark(fieldLintDisabledRules)
 	}
 	diff, err := c.Diff.diffConfig()
 	if err != nil {
@@ -237,22 +314,35 @@ func (c yamlSettings) projectConfig() (Config, error) {
 	return cfg, nil
 }
 
+func applyYAMLString(
+	value *string,
+	destination *string,
+	field configField,
+	presence *configPresence,
+) {
+	if value == nil {
+		return
+	}
+	*destination = *value
+	presence.mark(field)
+}
+
 func (c yamlOnlineDDL) applyTo(cfg *Config) {
 	if c.Tool != nil {
 		cfg.OnlineDDL.Tool = *c.Tool
-		cfg.presence.onlineDDLTool = true
+		cfg.presence.mark(fieldOnlineDDLTool)
 	}
 	if c.ThresholdRows != nil {
 		cfg.OnlineDDL.ThresholdRows = *c.ThresholdRows
-		cfg.presence.onlineDDLThresholdRows = true
+		cfg.presence.mark(fieldOnlineDDLThresholdRows)
 	}
 	if c.Args != nil {
 		cfg.OnlineDDL.Args = slices.Clone(*c.Args)
-		cfg.presence.onlineDDLArgs = true
+		cfg.presence.mark(fieldOnlineDDLArgs)
 	}
 	if c.Fallback != nil {
 		cfg.OnlineDDL.Fallback = *c.Fallback
-		cfg.presence.onlineDDLFallback = true
+		cfg.presence.mark(fieldOnlineDDLFallback)
 	}
 }
 
@@ -260,12 +350,20 @@ func (c yamlOnlineDDL) applyTo(cfg *Config) {
 // skip kinds against the shared diffpolicy vocabulary.
 func (d yamlDiff) diffConfig() (DiffConfig, error) {
 	var cfg DiffConfig
-	for _, raw := range d.Skip {
-		kind, err := diffpolicy.ParseChangeKind(raw)
-		if err != nil {
-			return DiffConfig{}, fmt.Errorf("ptah.yaml diff.skip: %w", err)
+	if d.Skip != nil {
+		cfg.Skip = DiffSkipConfig{
+			DropTable:  ConfigBool{Set: true},
+			DropColumn: ConfigBool{Set: true},
+			DropIndex:  ConfigBool{Set: true},
+			DropEnum:   ConfigBool{Set: true},
 		}
-		setDiffSkipKind(&cfg.Skip, kind)
+		for _, raw := range *d.Skip {
+			kind, err := diffpolicy.ParseChangeKind(raw)
+			if err != nil {
+				return DiffConfig{}, fmt.Errorf("ptah.yaml diff.skip: %w", err)
+			}
+			setDiffSkipKind(&cfg.Skip, kind)
+		}
 	}
 	if d.ConcurrentIndex != nil {
 		cfg.ConcurrentIndex.Create = ConfigBool{Value: *d.ConcurrentIndex, Set: true}

--- a/config/projectconfig/yaml_test.go
+++ b/config/projectconfig/yaml_test.go
@@ -272,7 +272,6 @@ env:
 	cfg, err := projectconfig.ParsePtah(raw, "ptah.yaml", "prod")
 
 	c.Assert(err, qt.IsNil)
-	// Base drop_table is inherited; prod adds drop_column.
-	c.Assert(cfg.Diff.Skip.DropTable.Value, qt.IsTrue)
+	c.Assert(cfg.Diff.Skip.DropTable, qt.DeepEquals, projectconfig.ConfigBool{Set: true})
 	c.Assert(cfg.Diff.Skip.DropColumn.Value, qt.IsTrue)
 }

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -315,8 +315,10 @@ explicitly present value replaces the lower-precedence value instead of being
 treated as absent. This includes an empty string, zero, `false`, or an empty
 list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
 while `PTAH_*` environment variables and explicit CLI flags still win. After
-project sources are merged, each command applies its defaults and normal
-validation to the effective value.
+project sources are merged, a command applies its built-in default only when a
+field is absent. An explicitly present empty or zero value instead reaches the
+command's normal validation. Fields that do not accept empty values, including
+Atlas format templates, fail during parsing or command validation.
 
 This means a repo can keep an Atlas-shaped migration setup while still letting
 one-off CLI invocations override any value:

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -310,6 +310,14 @@ Ptah merges configuration in this order:
 4. `ptah.yaml`
 5. Built-in command defaults
 
+Project-file merging preserves source presence. For a supported field, an
+explicitly present value replaces the lower-precedence value instead of being
+treated as absent. This includes an empty string, zero, `false`, or an empty
+list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
+while `PTAH_*` environment variables and explicit CLI flags still win. After
+project sources are merged, each command applies its defaults and normal
+validation to the effective value.
+
 This means a repo can keep an Atlas-shaped migration setup while still letting
 one-off CLI invocations override any value:
 

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -244,8 +244,10 @@ explicitly present value replaces the lower-precedence value instead of being
 treated as absent. This includes an empty string, zero, `false`, or an empty
 list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
 while environment variables and explicit CLI flags still win.
-After project sources are merged, each command applies its defaults and normal
-validation to the effective value.
+After project sources are merged, a command applies its built-in default only
+when a field is absent. An explicitly present empty or zero value instead
+reaches the command's normal validation. Fields that do not accept empty values
+fail during parsing or command validation.
 
 `atlas.hcl` is translated into the same project config IR. The `ptah-compat`
 binary's Atlas-compatible `schema ...` and `migrate ...` commands also accept

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -202,9 +202,8 @@ Skipping `drop_table` also omits the dependent removals (indexes, constraints,
 triggers, RLS policies, table-level grants) that a kept table must retain, so the
 plan stays consistent. Skip is currently honored by the PostgreSQL-family planner.
 
-The list form is additive across environments: a named `env` block can add skip
-kinds to those inherited from the top-level `diff.skip`, but it cannot remove an
-inherited kind. Define skips at the level where they should apply.
+The selected environment's `diff.skip` replaces the top-level list when the
+field is present. An explicit empty list therefore clears inherited skip kinds.
 
 This is finer-grained than the coarse `--check-destructive` / `--allow-destructive`
 gate: `--check-destructive` blocks (or allows) the whole migration when it
@@ -239,6 +238,14 @@ Runtime values resolve in this order:
 3. `atlas.hcl`
 4. `ptah.yaml`
 5. Built-in command defaults
+
+Project-file merging preserves source presence. For a supported field, an
+explicitly present value replaces the lower-precedence value instead of being
+treated as absent. This includes an empty string, zero, `false`, or an empty
+list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
+while environment variables and explicit CLI flags still win.
+After project sources are merged, each command applies its defaults and normal
+validation to the effective value.
 
 `atlas.hcl` is translated into the same project config IR. The `ptah-compat`
 binary's Atlas-compatible `schema ...` and `migrate ...` commands also accept

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -170,6 +170,9 @@ type OnlineDDLConfig struct{ ... }
 type SchemaConfig struct{ ... }
 type SchemaFormatConfig struct{ ... }
 type SchemaModeConfig struct{ ... }
+type StringField uint8
+    const StringEnvName StringField = iota ...
+type Value[T any] struct{ ... }
 
 ### github.com/stokaro/ptah/config/projectconfig.AtlasLoadOptions
 
@@ -229,6 +232,10 @@ func Merge(base, override Config) Config
 func ParseAtlas(data []byte, filename, envName string) (Config, error)
 func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error)
 func ParsePtah(data []byte, filename, envName string) (Config, error)
+func (c Config) LintLatestValue() Value[int]
+func (c Config) SchemaSourcesValue() Value[[]string]
+func (c Config) SchemasValue() Value[[]string]
+func (c Config) StringValue(field StringField) Value[string]
 
 ### github.com/stokaro/ptah/config/projectconfig.ConfigBool
 
@@ -457,6 +464,29 @@ type SchemaModeConfig struct {
     SchemaModeConfig holds Atlas env.schema.mode settings.
 
 func (m SchemaModeConfig) ExcludePatterns() []string
+
+### github.com/stokaro/ptah/config/projectconfig.StringField
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type StringField uint8
+    StringField identifies one string-valued Config field for presence-aware
+    command-default resolution.
+
+const StringEnvName StringField = iota ...
+
+### github.com/stokaro/ptah/config/projectconfig.Value
+
+package projectconfig // import "github.com/stokaro/ptah/config/projectconfig"
+
+type Value[T any] struct {
+    Value   T
+    Present bool
+}
+    Value carries a project-config value together with whether a source or
+    programmatic override supplied it. Command defaults must apply only when
+    Present is false.
+
 
 ## github.com/stokaro/ptah/core/ast
 

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -120,8 +120,13 @@ env "local" {
 | `diff.skip.drop_table` | Suppresses table drops in supported local diff/apply plans. |
 | `diff.concurrent_index.create` | Requests PostgreSQL concurrent index creation where transaction mode allows it. |
 
-Explicit CLI flags win over `atlas.hcl`, and `atlas.hcl` wins over built-in
-defaults.
+Project config precedence is explicit CLI flags, environment variables,
+`atlas.hcl`, `ptah.yaml`, then built-in defaults. Project-file merging
+preserves source presence. For a supported field, an explicitly present value
+replaces the lower-precedence value instead of being treated as absent. This
+includes an empty string, zero, `false`, or an empty list when the field accepts
+that type. After project sources are merged, each command applies its defaults
+and normal validation to the effective value.
 
 `env.exclude` and disabled `env.schema.mode` values compose with the
 `schema apply`/`schema diff` positive selection flags in a fixed order:

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -125,8 +125,10 @@ Project config precedence is explicit CLI flags, environment variables,
 preserves source presence. For a supported field, an explicitly present value
 replaces the lower-precedence value instead of being treated as absent. This
 includes an empty string, zero, `false`, or an empty list when the field accepts
-that type. After project sources are merged, each command applies its defaults
-and normal validation to the effective value.
+that type. After project sources are merged, a command applies its built-in
+default only when a field is absent. An explicitly present empty or zero value
+instead reaches normal validation. Fields that do not accept empty values,
+including Atlas format templates, fail during parsing or command validation.
 
 `env.exclude` and disabled `env.schema.mode` values compose with the
 `schema apply`/`schema diff` positive selection flags in a fixed order:

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -13,6 +13,14 @@ Configuration precedence is:
 | 4 | `ptah.yaml` selected environment |
 | 5 | Built-in defaults |
 
+Project-file merging preserves source presence. For a supported field, an
+explicitly present value replaces the lower-precedence value instead of being
+treated as absent. This includes an empty string, zero, `false`, or an empty
+list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
+while environment variables and explicit CLI flags still win.
+After project sources are merged, each command applies its defaults and normal
+validation to the effective value.
+
 Use `ptah.yaml` for Ptah-owned configuration and the supported `atlas.hcl`
 subset for Atlas-compatible project config. The supported Atlas subset includes
 local `variable` defaults and Atlas-style `--var name=value` overrides,
@@ -76,7 +84,9 @@ lists destructive change kinds (`drop_table`, `drop_column`, `drop_index`,
 `drop_enum`) to omit — a `-- SKIP: ...` comment is written in their place — and
 `diff.concurrent_index: true` requests `CREATE INDEX CONCURRENTLY` for new
 indexes (PostgreSQL, capability-gated). A skipped change is never emitted, so it
-never trips the `--check-destructive` gate.
+never trips the `--check-destructive` gate. A selected environment's
+`diff.skip` replaces the top-level list; an explicit empty list clears all
+inherited skip kinds.
 
 The Atlas-compatible command tree lives in the separate `ptah-compat` binary,
 the drop-in replacement for scripts that expect Atlas-style root commands.

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -18,8 +18,10 @@ explicitly present value replaces the lower-precedence value instead of being
 treated as absent. This includes an empty string, zero, `false`, or an empty
 list when the field accepts that type. Thus `atlas.hcl` wins over `ptah.yaml`,
 while environment variables and explicit CLI flags still win.
-After project sources are merged, each command applies its defaults and normal
-validation to the effective value.
+After project sources are merged, a command applies its built-in default only
+when a field is absent. An explicitly present empty or zero value instead
+reaches normal validation. Fields that do not accept empty values, including
+Atlas format templates, fail during parsing or command validation.
 
 Use `ptah.yaml` for Ptah-owned configuration and the supported `atlas.hcl`
 subset for Atlas-compatible project config. The supported Atlas subset includes

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -254,31 +254,41 @@ func normalizeOptions(opts Options, projectCfg projectconfig.Config) (Options, e
 }
 
 func (opts Options) effectiveDir(projectCfg projectconfig.Config) string {
-	if !opts.Changed.Dir && projectCfg.Migration.Dir != "" {
-		return projectCfg.Migration.Dir
-	}
-	return opts.Dir
+	return effectiveProjectString(
+		projectconfig.Value[string]{Value: opts.Dir, Present: opts.Changed.Dir},
+		projectCfg.StringValue(projectconfig.StringMigrationDir),
+	)
 }
 
 func (opts Options) effectiveDirFormat(projectCfg projectconfig.Config) string {
-	if !opts.Changed.DirFormat && projectCfg.Migration.Format != "" {
-		return projectCfg.Migration.Format
-	}
-	return opts.DirFormat
+	return effectiveProjectString(
+		projectconfig.Value[string]{Value: opts.DirFormat, Present: opts.Changed.DirFormat},
+		projectCfg.StringValue(projectconfig.StringMigrationFormat),
+	)
 }
 
 func (opts Options) effectiveAtlasEnv(projectCfg projectconfig.Config) string {
-	if !opts.Changed.AtlasEnv && projectCfg.EnvName != "" {
-		return projectCfg.EnvName
-	}
-	return opts.AtlasEnv
+	return effectiveProjectString(
+		projectconfig.Value[string]{Value: opts.AtlasEnv, Present: opts.Changed.AtlasEnv},
+		projectCfg.StringValue(projectconfig.StringEnvName),
+	)
 }
 
 func (opts Options) effectiveDevURL(projectCfg projectconfig.Config) string {
-	if !opts.Changed.DevURL && projectCfg.DevURL != "" {
-		return projectCfg.DevURL
+	return effectiveProjectString(
+		projectconfig.Value[string]{Value: opts.DevURL, Present: opts.Changed.DevURL},
+		projectCfg.StringValue(projectconfig.StringDevURL),
+	)
+}
+
+func effectiveProjectString(
+	optionValue projectconfig.Value[string],
+	configValue projectconfig.Value[string],
+) string {
+	if optionValue.Present || !configValue.Present {
+		return optionValue.Value
 	}
-	return opts.DevURL
+	return configValue.Value
 }
 
 func loadEffectiveConfig(
@@ -400,12 +410,16 @@ func lintVersions(
 	cfg projectconfig.Config,
 	fsys fs.FS,
 ) ([]int64, bool, error) {
-	latest, latestSet := effectiveLatest(opts, cfg)
-	git, err := effectiveGit(opts, cfg)
+	projectSelectors := projectLintSelectorUse{
+		latest: !opts.Changed.GitBase,
+		git:    !opts.Changed.Latest,
+	}
+	latest, latestSet := effectiveLatest(opts, cfg, projectSelectors)
+	git, err := effectiveGit(opts, cfg, projectSelectors)
 	if err != nil {
 		return nil, false, err
 	}
-	if !git.ok && gitDirConfigured(opts, cfg) {
+	if !git.ok && gitDirConfigured(opts, cfg, projectSelectors) {
 		return nil, false, fmt.Errorf("--git-dir requires --git-base")
 	}
 	if latestSet && git.ok {
@@ -433,12 +447,25 @@ func lintVersions(
 	return nil, false, nil
 }
 
-func effectiveLatest(opts Options, cfg projectconfig.Config) (int, bool) {
+type projectLintSelectorUse struct {
+	latest bool
+	git    bool
+}
+
+func effectiveLatest(
+	opts Options,
+	cfg projectconfig.Config,
+	projectSelectors projectLintSelectorUse,
+) (int, bool) {
 	if opts.Changed.Latest {
 		return int(opts.Latest), true
 	}
-	if cfg.Lint.Latest != nil {
-		return *cfg.Lint.Latest, true
+	if !projectSelectors.latest {
+		return 0, false
+	}
+	value := cfg.LintLatestValue()
+	if value.Present {
+		return value.Value, true
 	}
 	return 0, false
 }
@@ -449,14 +476,20 @@ type effectiveGitOptions struct {
 	ok   bool
 }
 
-func effectiveGit(opts Options, cfg projectconfig.Config) (effectiveGitOptions, error) {
+func effectiveGit(
+	opts Options,
+	cfg projectconfig.Config,
+	projectSelectors projectLintSelectorUse,
+) (effectiveGitOptions, error) {
 	gitBase := opts.GitBase
-	if !opts.Changed.GitBase {
-		gitBase = cfg.Lint.GitBase
+	configGitBase := cfg.StringValue(projectconfig.StringLintGitBase)
+	if !opts.Changed.GitBase && projectSelectors.git && configGitBase.Present {
+		gitBase = configGitBase.Value
 	}
 	gitDir := opts.GitDir
-	if !opts.Changed.GitDir && cfg.Lint.GitDir != "" {
-		gitDir = cfg.Lint.GitDir
+	configGitDir := cfg.StringValue(projectconfig.StringLintGitDir)
+	if !opts.Changed.GitDir && projectSelectors.git && configGitDir.Present {
+		gitDir = configGitDir.Value
 	}
 	if strings.TrimSpace(gitBase) == "" {
 		return effectiveGitOptions{dir: gitDir}, nil
@@ -481,8 +514,19 @@ func validateGitBaseRef(ref string) error {
 	return nil
 }
 
-func gitDirConfigured(opts Options, cfg projectconfig.Config) bool {
-	return opts.Changed.GitDir || cfg.Lint.GitDir != ""
+func gitDirConfigured(
+	opts Options,
+	cfg projectconfig.Config,
+	projectSelectors projectLintSelectorUse,
+) bool {
+	if opts.Changed.GitDir {
+		return true
+	}
+	if !projectSelectors.git {
+		return false
+	}
+	configGitDir := cfg.StringValue(projectconfig.StringLintGitDir)
+	return configGitDir.Present && configGitDir.Value != ""
 }
 
 func gitChangedMigrationVersions(

--- a/internal/migrationlintreport/report_test.go
+++ b/internal/migrationlintreport/report_test.go
@@ -60,6 +60,94 @@ func TestBuild_UsesProjectConfigWithoutCobra(t *testing.T) {
 	c.Assert(report.Findings[0].File, qt.Contains, "0000000002_new.up.sql")
 }
 
+func TestBuild_ExplicitEmptyProjectDirReachesValidation(t *testing.T) {
+	c := qt.New(t)
+	cfg, err := projectconfig.ParsePtah([]byte(`
+migration:
+  dir: ""
+`), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+
+	_, err = migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		Dialect:   "sqlite",
+		FailOn:    migrationlintreport.FailOnNone,
+		Changed:   migrationlintreport.ChangedOptions{Dialect: true},
+	}, cfg)
+
+	c.Assert(err, qt.ErrorMatches, `migrations directory : .*`)
+}
+
+func TestBuild_ExplicitZeroProjectLatestReachesValidation(t *testing.T) {
+	c := qt.New(t)
+	cfg, err := projectconfig.ParsePtah([]byte(`
+lint:
+  latest: 0
+`), "ptah.yaml", "")
+	c.Assert(err, qt.IsNil)
+
+	_, err = migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		FS:        fstest.MapFS{"1_init.sql": {Data: []byte("CREATE TABLE users (id int);")}},
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		Dialect:   "sqlite",
+		FailOn:    migrationlintreport.FailOnNone,
+		Changed:   migrationlintreport.ChangedOptions{Dialect: true},
+	}, cfg)
+
+	c.Assert(err, qt.ErrorMatches, `--latest must be greater than zero`)
+}
+
+func TestBuild_ExplicitGitBaseSuppressesProjectLatest(t *testing.T) {
+	c := qt.New(t)
+	latest := 1
+	cfg := projectconfig.Config{
+		Lint: projectconfig.LintConfig{Latest: &latest},
+	}
+
+	_, err := migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		FS:        fstest.MapFS{"1_init.sql": {Data: []byte("CREATE TABLE users (id int);")}},
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		Dialect:   "sqlite",
+		GitBase:   "-unsafe",
+		FailOn:    migrationlintreport.FailOnNone,
+		Changed: migrationlintreport.ChangedOptions{
+			Dialect: true,
+			GitBase: true,
+		},
+	}, cfg)
+
+	c.Assert(err, qt.ErrorMatches, `--git-base "-unsafe" is not a safe Git ref`)
+}
+
+func TestBuild_ExplicitLatestSuppressesProjectGitSelector(t *testing.T) {
+	c := qt.New(t)
+	cfg := projectconfig.Config{
+		Lint: projectconfig.LintConfig{
+			GitBase: "-unsafe",
+			GitDir:  "/not/a/repository",
+		},
+	}
+
+	report, err := migrationlintreport.Build(context.Background(), migrationlintreport.Options{
+		Dir:       t.TempDir(),
+		FS:        fstest.MapFS{"1_init.sql": {Data: []byte("CREATE TABLE users (id int);")}},
+		DirFormat: string(migrator.MigrationDirFormatAtlas),
+		Dialect:   "sqlite",
+		Latest:    1,
+		FailOn:    migrationlintreport.FailOnNone,
+		Changed: migrationlintreport.ChangedOptions{
+			Dialect: true,
+			Latest:  true,
+		},
+	}, cfg)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(report.Versions, qt.DeepEquals, []int64{1})
+}
+
 func TestBuild_LatestAndAnalysisShareOneSourceSnapshot(t *testing.T) {
 	c := qt.New(t)
 	source := &countingSnapshotSource{


### PR DESCRIPTION
## Summary

- preserve per-field source presence through Ptah root/env, Atlas global/env, and cross-file merges
- carry explicit empty/zero/list presence through native Ptah commands, `ptah atlas`, and `ptah-compat`
- apply command defaults only when project fields are absent while keeping explicit CLI flags highest priority
- resolve `lint.latest` versus Git selection atomically across config and CLI sources
- keep merge results detached from input slices, maps, and pointers
- document exact precedence and native `diff.skip` replacement semantics

## Self-review

- pass 1: audited every project-config field, loader presence, merge propagation, pointer and collection aliasing, and lint selector invariants
- pass 2: audited native Ptah, `ptah atlas`, and `ptah-compat` command boundaries for default resurrection and CLI precedence
- independent review 1: found command-default presence loss, unlabeled Atlas env handling, and same-level lint selector conflicts
- independent review 2: found empty Git selector forwarding, explicit empty `schema.src`, atomic CLI selector precedence, public API safety/snapshot, and deep-copy coverage gaps
- all findings were fixed before the final verification pass

## Verification

- `gopls check` on all changed Go files
- `go test ./... -count=1`
- `go test -race -count=1 ./config/projectconfig ./cmd/internal/dbcli ./internal/migrationlintreport ./cmd/atlas ./cmd/lint`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `scripts/check-public-api-snapshot.sh`
- docs core-link, page-health, link, redirect, exit-code, and versions checks
- `git diff --check`

Fixes #884
Prerequisite for #276
