### PR TITLE
Forward immutable project config snapshots through adapters

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -230,9 +230,14 @@ jobs:
 
       - name: Run database-realm cleanup and replay tests
         env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           COCKROACHDB_URL: "cockroachdb://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
+          MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+          CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
+          PTAH_SQLSERVER_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
           MYSQL_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3306)/mysql"
           MYSQL_ADMIN_TEST_URL: "mysql://root:root_password@tcp(127.0.0.1:3306)/mysql"
           MARIADB_ADMIN_TEST_DSN: "root:root_password@tcp(127.0.0.1:3307)/mysql"
@@ -242,7 +247,8 @@ jobs:
           PTAH_SQLSERVER_REALM_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
         run: |
           go test -v -count=1 ./internal/dblock -run '^TestAdvisoryLock_PostgresFamilyLive$' -timeout 3m
-          go test -v -count=1 ./internal/devlock -run '^TestAcquire_CockroachDBSerializesSameRealmLive$' -timeout 3m
+          go test -v -count=1 ./internal/devlock -run '^Test(Acquire_CockroachDBSerializesSameRealmLive|SameRealm_(PostgresDriverURLOverridesLive|NetworkDatabasesLive))$' -timeout 3m
+          go test -v -count=1 ./migration/generator -run '^TestVerifyRollbackFromShadow_FailurePathRejects(DriverOverrideAliasLive|LiveDialectMismatch)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/mysql -tags=integration -run '^TestWriterDropDatabaseRealm_Live(RejectsProtectedDatabase|RejectsExternalStoredProgram|RejectsMissingTriggerPrivilege)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_(Live|RejectsExternalDependencyLive|RejectsLegacyServerLive)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -118,6 +118,7 @@ func newAtlasCommand(use, short, long string) *cobra.Command {
 	installAtlasUsageTree(cmd)
 	installAtlasProjectFlagResetTree(schemaCommand)
 	installAtlasProjectFlagResetTree(migrateCommand)
+	installAtlasProjectFlagResetRoot(cmd, schemaCommand, migrateCommand)
 	return cmd
 }
 
@@ -728,7 +729,7 @@ func registerAtlasFlags(cmd *cobra.Command, flags []atlasargs.Flag) {
 
 func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 	return func(cmd *cobra.Command, args []string) ([]string, context.Context, error) {
-		forwardContext := cmd.Root().Context()
+		forwardContext := cmd.Context()
 		parentProjectFlags, parentChanged, err := atlasProjectFlagsFromCommand(cmd)
 		if err != nil {
 			return nil, nil, err

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -2,6 +2,7 @@
 package atlas
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cmdadapter"
 	"github.com/stokaro/ptah/cmd/internal/cmdflags"
 	"github.com/stokaro/ptah/cmd/internal/cmdutil"
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/exitcode"
 	"github.com/stokaro/ptah/cmd/internal/licensetext"
 	"github.com/stokaro/ptah/cmd/migrate"
@@ -26,6 +28,7 @@ import (
 	"github.com/stokaro/ptah/cmd/migratevalidate"
 	"github.com/stokaro/ptah/cmd/migrationstest"
 	"github.com/stokaro/ptah/cmd/schema"
+	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasargs"
 )
 
@@ -720,10 +723,11 @@ func registerAtlasFlags(cmd *cobra.Command, flags []atlasargs.Flag) {
 }
 
 func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
-	return func(cmd *cobra.Command, args []string) ([]string, error) {
+	return func(cmd *cobra.Command, args []string) ([]string, context.Context, error) {
+		forwardContext := cmd.Root().Context()
 		parentProjectFlags, parentChanged, err := atlasProjectFlagsFromCommand(cmd)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		parentProject := atlasProjectArgValues{
 			flags:   parentProjectFlags,
@@ -731,14 +735,14 @@ func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 		}
 		project, remaining, err := extractAtlasProjectArgs(args)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		project = mergeAtlasProjectArgs(parentProject, project)
 		args = remaining
 		if project.changed {
-			cfg, err := loadRequiredAtlasProjectConfig(project.flags)
+			cfg, targetCfg, err := loadAtlasAdapterProjectConfig(verb, project.flags)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			applyProjectConfig := verb.projectConfig
 			if applyProjectConfig == nil {
@@ -746,28 +750,36 @@ func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 			}
 			args, err = applyProjectConfig(verb.flags, args, cfg, project.flags)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if verb.nativeProjectConfig {
-				args, err = applyAtlasProjectConfigToNativeArgs(args, project.flags)
-				if err != nil {
-					return nil, err
-				}
+				forwardContext = dbcli.WithProjectConfig(forwardContext, targetCfg)
 			}
 		}
 		if err := rejectNativeOnlyAtlasFlags(group, verb, args); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		args, nativeTail, err := mapAtlasPositionalArgs(group, verb, args)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		mapped, err := atlasargs.Map(group, verb.use, verb.flags, args)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return append(mapped, nativeTail...), nil
+		return append(mapped, nativeTail...), forwardContext, nil
 	}
+}
+
+func loadAtlasAdapterProjectConfig(
+	verb atlasVerb,
+	flags atlasProjectFlagValues,
+) (atlasConfig, targetConfig projectconfig.Config, err error) {
+	if !verb.nativeProjectConfig {
+		cfg, err := loadRequiredAtlasProjectConfig(flags)
+		return cfg, projectconfig.Config{}, err
+	}
+	return loadRequiredMergedProjectConfig(flags)
 }
 
 func rejectNativeOnlyAtlasFlags(group string, verb atlasVerb, args []string) error {

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -108,12 +108,16 @@ func newAtlasCommand(use, short, long string) *cobra.Command {
 		RunE:  runAtlasGroupHelp,
 	}
 	cmdutil.ConfigureCommandArgs(cmd, atlasRootArgs)
+	schemaCommand := newAtlasSchemaCommand()
+	migrateCommand := newAtlasMigrateCommand()
 	cmd.AddCommand(newAtlasVersionCommand())
 	cmd.AddCommand(newAtlasLicenseCommand())
-	cmd.AddCommand(newAtlasSchemaCommand())
-	cmd.AddCommand(newAtlasMigrateCommand())
+	cmd.AddCommand(schemaCommand)
+	cmd.AddCommand(migrateCommand)
 	installAtlasCompletionCommand(cmd)
 	installAtlasUsageTree(cmd)
+	installAtlasProjectFlagResetTree(schemaCommand)
+	installAtlasProjectFlagResetTree(migrateCommand)
 	return cmd
 }
 

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -168,6 +168,7 @@ func runAtlasMigrateDownFormat(cmd *cobra.Command, verb atlasVerb, args []string
 	// missing down migration aborts before the target is touched.
 	if opts.devURL != "" && !plan.Noop() {
 		err := generator.VerifyRollbackFromShadow(cmd.Context(), generator.RollbackFromShadowOptions{
+			TargetDatabaseURL: opts.url,
 			ShadowDatabaseURL: opts.devURL,
 			FS:                os.DirFS(dir),
 			Dialect:           conn.Info().Dialect,

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -168,10 +168,9 @@ func runAtlasMigrateDownFormat(cmd *cobra.Command, verb atlasVerb, args []string
 	// missing down migration aborts before the target is touched.
 	if opts.devURL != "" && !plan.Noop() {
 		err := generator.VerifyRollbackFromShadow(cmd.Context(), generator.RollbackFromShadowOptions{
-			TargetDatabaseURL: opts.url,
+			TargetConnection:  conn,
 			ShadowDatabaseURL: opts.devURL,
 			FS:                os.DirFS(dir),
-			Dialect:           conn.Info().Dialect,
 			CurrentVersion:    plan.CurrentVersion,
 			TargetVersion:     targetVersion,
 			ProviderOptions: []migrator.FSProviderOption{

--- a/cmd/atlas/migrate_test_forward_test.go
+++ b/cmd/atlas/migrate_test_forward_test.go
@@ -62,6 +62,28 @@ func TestCompatCommand_MigrateTestForwardsToNative(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "1 cases, 1 passed, 0 failed")
 }
 
+func TestCompatCommand_MigrateTestNativeDirectoryEnvironmentOverridesAtlasDefault(t *testing.T) {
+	c := qt.New(t)
+	t.Chdir(t.TempDir())
+	migrationsDir, testsDir := t.TempDir(), t.TempDir()
+	writeMigrateTestFixture(c, migrationsDir, testsDir)
+	t.Setenv("PTAH_MIGRATIONS_DIR", migrationsDir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "test", testsDir,
+		"--dev-url", "sqlite://" + filepath.Join(t.TempDir(), "dev.db"),
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, `PASS  case "users table accepts rows"`)
+}
+
 func TestCompatCommand_MigrateTestFailingCaseExits1(t *testing.T) {
 	c := qt.New(t)
 	migrationsDir, testsDir := t.TempDir(), t.TempDir()

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/stokaro/ptah/cmd/internal/cmdflags"
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/internal/atlasargs"
@@ -64,10 +65,55 @@ func loadRequiredAtlasProjectConfig(flags atlasProjectFlagValues) (projectconfig
 	if err != nil {
 		return projectconfig.Config{}, err
 	}
-	if _, err := os.Stat(path); err != nil {
+	raw, err := os.ReadFile(path)
+	if err != nil {
 		return projectconfig.Config{}, fmt.Errorf("failed to read atlas config %s: %w", path, err)
 	}
-	return loadAtlasProjectConfig(flags)
+	return projectconfig.ParseAtlasWithOptions(raw, path, projectconfig.AtlasLoadOptions{
+		EnvName: flags.envName,
+		Vars:    flags.vars,
+	})
+}
+
+func loadRequiredMergedProjectConfig(
+	flags atlasProjectFlagValues,
+) (atlasConfig, mergedConfig projectconfig.Config, err error) {
+	atlas, err := loadRequiredAtlasProjectConfig(flags)
+	if err != nil {
+		return projectconfig.Config{}, projectconfig.Config{}, err
+	}
+	resolvedAtlas, err := resolveAtlasProjectConfigPaths(flags, atlas)
+	if err != nil {
+		return projectconfig.Config{}, projectconfig.Config{}, err
+	}
+	ptah, err := projectconfig.LoadPtahFile(projectconfig.PtahFileName, flags.envName)
+	if err != nil {
+		return projectconfig.Config{}, projectconfig.Config{}, err
+	}
+	return atlas, projectconfig.Merge(ptah, resolvedAtlas), nil
+}
+
+func resolveAtlasProjectConfigPaths(
+	flags atlasProjectFlagValues,
+	config projectconfig.Config,
+) (projectconfig.Config, error) {
+	migrationDir := config.StringValue(projectconfig.StringMigrationDir)
+	if migrationDir.Present {
+		resolved, err := atlasProjectConfigLocalDirFromFlags(flags, migrationDir.Value)
+		if err != nil {
+			return projectconfig.Config{}, fmt.Errorf("atlas.hcl migration.dir: %w", err)
+		}
+		config.Migration.Dir = resolved
+	}
+	sources := config.SchemaSourcesValue()
+	if sources.Present {
+		resolved, err := atlasProjectConfigSchemaURLsFromFlags(flags, sources.Value)
+		if err != nil {
+			return projectconfig.Config{}, fmt.Errorf("atlas.hcl schema.src: %w", err)
+		}
+		config.SchemaSources = resolved
+	}
+	return config, nil
 }
 
 func atlasConfigPathValue(value string) (string, error) {
@@ -362,7 +408,9 @@ func applyAtlasProjectConfigToArgs(
 		cfg.StringValue(projectconfig.StringDevURL),
 	)
 	migrationDir := cfg.StringValue(projectconfig.StringMigrationDir)
-	if migrationDir.Present && atlasFlagRegistered(flags, "dir") && !atlasFlagPresent(flags, args, "dir") {
+	if migrationDir.Present &&
+		atlasFlagRegistered(flags, "dir") &&
+		!atlasFlagValueSet(flags, args, "dir") {
 		dir, err := atlasProjectConfigLocalDirFromFlags(projectFlags, migrationDir.Value)
 		if err != nil {
 			return nil, fmt.Errorf("atlas.hcl migration.dir: %w", err)
@@ -387,8 +435,8 @@ func applyAtlasProjectConfigToArgs(
 		"lock-timeout",
 		cfg.StringValue(projectconfig.StringMigrationLockTimeout),
 	)
-	cliLatest := atlasFlagPresent(flags, args, "latest")
-	cliGitBase := atlasFlagPresent(flags, args, "git-base")
+	cliLatest := atlasFlagValueSet(flags, args, "latest")
+	cliGitBase := atlasFlagValueSet(flags, args, "git-base")
 	if !cliGitBase {
 		args = appendAtlasProjectStringArg(flags, args, "latest", atlasProjectLatest(cfg))
 	}
@@ -421,7 +469,7 @@ func applyAtlasSchemaTestProjectConfig(
 		"dev-url",
 		cfg.StringValue(projectconfig.StringDevURL),
 	)
-	if atlasFlagPresent(flags, args, "url") {
+	if atlasFlagValueSet(flags, args, "url") {
 		return args, nil
 	}
 	sources := cfg.SchemaSourcesValue()
@@ -441,21 +489,6 @@ func applyAtlasSchemaTestProjectConfig(
 	return append(args, "--url", urls[0]), nil
 }
 
-func applyAtlasProjectConfigToNativeArgs(args []string, flags atlasProjectFlagValues) ([]string, error) {
-	path, err := atlasConfigPathValue(flags.configPath)
-	if err != nil {
-		return nil, err
-	}
-	args = append(args, "--"+dbcli.AtlasProjectConfigFlagName, path)
-	if strings.TrimSpace(flags.envName) != "" && !atlasFlagPresentByName(args, dbcli.EnvFlagName, "") {
-		args = append(args, "--"+dbcli.EnvFlagName, flags.envName)
-	}
-	for _, value := range flags.vars {
-		args = append(args, "--"+dbcli.AtlasProjectVarFlagName, value)
-	}
-	return args, nil
-}
-
 func atlasProjectLatest(cfg projectconfig.Config) projectconfig.Value[string] {
 	latest := cfg.LintLatestValue()
 	return projectconfig.Value[string]{
@@ -470,7 +503,7 @@ func appendAtlasProjectStringArg(
 	name string,
 	value projectconfig.Value[string],
 ) []string {
-	if !value.Present || !atlasFlagRegistered(flags, name) || atlasFlagPresent(flags, args, name) {
+	if !value.Present || !atlasFlagRegistered(flags, name) || atlasFlagValueSet(flags, args, name) {
 		return args
 	}
 	return append(args, "--"+name, value.Value)
@@ -487,6 +520,31 @@ func atlasFlagRegistered(flags []atlasargs.Flag, name string) bool {
 
 func atlasFlagPresent(flags []atlasargs.Flag, args []string, name string) bool {
 	return atlasFlagPresentByName(args, name, atlasFlagShorthand(flags, name))
+}
+
+func atlasFlagValueSet(flags []atlasargs.Flag, args []string, name string) bool {
+	return atlasFlagPresent(flags, args, name) || atlasFlagEnvironmentPresent(flags, name)
+}
+
+func atlasFlagEnvironmentPresent(flags []atlasargs.Flag, name string) bool {
+	for _, flag := range flags {
+		if flag.Name != name || flag.EnvDisabled {
+			continue
+		}
+		if nonEmptyEnvironmentVariable(cmdflags.EnvName("PTAH", flag.Name)) {
+			return true
+		}
+		if flag.NativeName != "" &&
+			nonEmptyEnvironmentVariable(cmdflags.EnvName("PTAH", flag.NativeName)) {
+			return true
+		}
+	}
+	return false
+}
+
+func nonEmptyEnvironmentVariable(name string) bool {
+	value, ok := os.LookupEnv(name)
+	return ok && value != ""
 }
 
 func atlasFlagPresentByName(args []string, name string, short string) bool {

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -277,14 +277,20 @@ func installAtlasProjectFlagResetSubtree(cmd, group *cobra.Command) {
 }
 
 func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
-	if validateArgs := cmd.Args; validateArgs != nil {
-		cmd.Args = func(cmd *cobra.Command, args []string) error {
-			err := validateArgs(cmd, args)
-			if err != nil {
-				resetAtlasProjectFlags(group)
-			}
-			return err
+	validateArgs := cmd.Args
+	cmd.Args = func(cmd *cobra.Command, args []string) error {
+		// Cobra retains a child command's first context when a root command is
+		// reused. Refresh it before validation so each ExecuteContext call
+		// reaches direct commands as well as adapter-backed commands.
+		cmd.SetContext(cmd.Root().Context())
+		if validateArgs == nil {
+			return nil
 		}
+		err := validateArgs(cmd, args)
+		if err != nil {
+			resetAtlasProjectFlags(group)
+		}
+		return err
 	}
 	if persistentPreRunE := cmd.PersistentPreRunE; persistentPreRunE != nil {
 		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -342,17 +348,48 @@ func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
 }
 
 func installAtlasProjectFlagResetRoot(root *cobra.Command, groups ...*cobra.Command) {
+	resetGroups := func() {
+		for _, group := range groups {
+			resetAtlasProjectFlags(group)
+		}
+	}
+	rootArgs := root.Args
+	root.Args = func(cmd *cobra.Command, args []string) error {
+		err := rootArgs(cmd, args)
+		if err != nil {
+			resetGroups()
+		}
+		return err
+	}
+	rootHelp := root.HelpFunc()
+	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		defer resetGroups()
+		rootHelp(cmd, args)
+	})
+	rootFlagError := root.FlagErrorFunc()
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		defer resetGroups()
+		return rootFlagError(cmd, err)
+	})
+	if runE := root.RunE; runE != nil {
+		root.RunE = func(cmd *cobra.Command, args []string) error {
+			defer resetGroups()
+			return runE(cmd, args)
+		}
+	}
+	if run := root.Run; run != nil {
+		root.Run = func(cmd *cobra.Command, args []string) {
+			defer resetGroups()
+			run(cmd, args)
+		}
+	}
 	// Generated commands such as __complete do not pass through the wrapped
-	// static tree, so successful root-level execution needs the same cleanup.
+	// static tree, so successful child execution needs the same cleanup.
 	persistentPostRunE := root.PersistentPostRunE
 	persistentPostRun := root.PersistentPostRun
 	root.PersistentPostRun = nil
 	root.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
-		defer func() {
-			for _, group := range groups {
-				resetAtlasProjectFlags(group)
-			}
-		}()
+		defer resetGroups()
 		if persistentPostRunE != nil {
 			return persistentPostRunE(cmd, args)
 		}

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -286,6 +286,37 @@ func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
 			return err
 		}
 	}
+	if persistentPreRunE := cmd.PersistentPreRunE; persistentPreRunE != nil {
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			err := persistentPreRunE(cmd, args)
+			if err != nil {
+				resetAtlasProjectFlags(group)
+			}
+			return err
+		}
+	}
+	preRunE := cmd.PreRunE
+	preRun := cmd.PreRun
+	cmd.PreRun = nil
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if preRunE != nil {
+			if err := preRunE(cmd, args); err != nil {
+				resetAtlasProjectFlags(group)
+				return err
+			}
+		} else if preRun != nil {
+			preRun(cmd, args)
+		}
+		if err := cmd.ValidateRequiredFlags(); err != nil {
+			resetAtlasProjectFlags(group)
+			return err
+		}
+		if err := cmd.ValidateFlagGroups(); err != nil {
+			resetAtlasProjectFlags(group)
+			return err
+		}
+		return nil
+	}
 	if runE := cmd.RunE; runE != nil {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			defer resetAtlasProjectFlags(group)
@@ -308,6 +339,28 @@ func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
 		defer resetAtlasProjectFlags(group)
 		return flagError(cmd, err)
 	})
+}
+
+func installAtlasProjectFlagResetRoot(root *cobra.Command, groups ...*cobra.Command) {
+	// Generated commands such as __complete do not pass through the wrapped
+	// static tree, so successful root-level execution needs the same cleanup.
+	persistentPostRunE := root.PersistentPostRunE
+	persistentPostRun := root.PersistentPostRun
+	root.PersistentPostRun = nil
+	root.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+		defer func() {
+			for _, group := range groups {
+				resetAtlasProjectFlags(group)
+			}
+		}()
+		if persistentPostRunE != nil {
+			return persistentPostRunE(cmd, args)
+		}
+		if persistentPostRun != nil {
+			persistentPostRun(cmd, args)
+		}
+		return nil
+	}
 }
 
 func resetAtlasProjectFlags(group *cobra.Command) {

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -82,38 +82,11 @@ func loadRequiredMergedProjectConfig(
 	if err != nil {
 		return projectconfig.Config{}, projectconfig.Config{}, err
 	}
-	resolvedAtlas, err := resolveAtlasProjectConfigPaths(flags, atlas)
-	if err != nil {
-		return projectconfig.Config{}, projectconfig.Config{}, err
-	}
 	ptah, err := projectconfig.LoadPtahFile(projectconfig.PtahFileName, flags.envName)
 	if err != nil {
 		return projectconfig.Config{}, projectconfig.Config{}, err
 	}
-	return atlas, projectconfig.Merge(ptah, resolvedAtlas), nil
-}
-
-func resolveAtlasProjectConfigPaths(
-	flags atlasProjectFlagValues,
-	config projectconfig.Config,
-) (projectconfig.Config, error) {
-	migrationDir := config.StringValue(projectconfig.StringMigrationDir)
-	if migrationDir.Present {
-		resolved, err := atlasProjectConfigLocalDirFromFlags(flags, migrationDir.Value)
-		if err != nil {
-			return projectconfig.Config{}, fmt.Errorf("atlas.hcl migration.dir: %w", err)
-		}
-		config.Migration.Dir = resolved
-	}
-	sources := config.SchemaSourcesValue()
-	if sources.Present {
-		resolved, err := atlasProjectConfigSchemaURLsFromFlags(flags, sources.Value)
-		if err != nil {
-			return projectconfig.Config{}, fmt.Errorf("atlas.hcl schema.src: %w", err)
-		}
-		config.SchemaSources = resolved
-	}
-	return config, nil
+	return atlas, projectconfig.Merge(ptah, atlas), nil
 }
 
 func atlasConfigPathValue(value string) (string, error) {
@@ -248,6 +221,9 @@ func loadAtlasProjectConfigForCommand(
 }
 
 func atlasProjectFlagsFromCommand(cmd *cobra.Command) (atlasProjectFlagValues, bool, error) {
+	if err := refreshAtlasProjectFlagEnvironment(cmd); err != nil {
+		return atlasProjectFlagValues{}, false, err
+	}
 	flags := atlasProjectFlagValues{configPath: "file://" + projectconfig.AtlasFileName}
 	changed := false
 	if flag := cmd.Flags().Lookup(atlasConfigFlagName); flag != nil {
@@ -267,6 +243,77 @@ func atlasProjectFlagsFromCommand(cmd *cobra.Command) (atlasProjectFlagValues, b
 		changed = changed || flag.Changed
 	}
 	return flags, changed, nil
+}
+
+func refreshAtlasProjectFlagEnvironment(cmd *cobra.Command) error {
+	for _, name := range []string{atlasConfigFlagName, dbcli.EnvFlagName, atlasVarFlagName} {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil || flag.Changed {
+			continue
+		}
+		value, ok := os.LookupEnv(cmdflags.EnvName("PTAH", name))
+		if !ok || value == "" {
+			continue
+		}
+		if err := cmd.Flags().Set(name, value); err != nil {
+			return fmt.Errorf("apply %s: %w", cmdflags.EnvName("PTAH", name), err)
+		}
+	}
+	return nil
+}
+
+func installAtlasProjectFlagResetTree(group *cobra.Command) {
+	wrapAtlasProjectFlagReset(group, group)
+	for _, child := range group.Commands() {
+		installAtlasProjectFlagResetSubtree(child, group)
+	}
+}
+
+func installAtlasProjectFlagResetSubtree(cmd, group *cobra.Command) {
+	wrapAtlasProjectFlagReset(cmd, group)
+	for _, child := range cmd.Commands() {
+		installAtlasProjectFlagResetSubtree(child, group)
+	}
+}
+
+func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
+	if runE := cmd.RunE; runE != nil {
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			defer resetAtlasProjectFlags(group)
+			return runE(cmd, args)
+		}
+	}
+	if run := cmd.Run; run != nil {
+		cmd.Run = func(cmd *cobra.Command, args []string) {
+			defer resetAtlasProjectFlags(group)
+			run(cmd, args)
+		}
+	}
+	help := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		defer resetAtlasProjectFlags(group)
+		help(cmd, args)
+	})
+	flagError := cmd.FlagErrorFunc()
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		defer resetAtlasProjectFlags(group)
+		return flagError(cmd, err)
+	})
+}
+
+func resetAtlasProjectFlags(group *cobra.Command) {
+	for _, name := range []string{atlasConfigFlagName, dbcli.EnvFlagName, atlasVarFlagName} {
+		flag := group.PersistentFlags().Lookup(name)
+		if flag == nil {
+			continue
+		}
+		if value, ok := flag.Value.(pflag.SliceValue); ok {
+			_ = value.Replace(nil)
+		} else {
+			_ = flag.Value.Set(flag.DefValue)
+		}
+		flag.Changed = false
+	}
 }
 
 func atlasProjectConfigExists(path string) bool {

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -277,6 +277,15 @@ func installAtlasProjectFlagResetSubtree(cmd, group *cobra.Command) {
 }
 
 func wrapAtlasProjectFlagReset(cmd, group *cobra.Command) {
+	if validateArgs := cmd.Args; validateArgs != nil {
+		cmd.Args = func(cmd *cobra.Command, args []string) error {
+			err := validateArgs(cmd, args)
+			if err != nil {
+				resetAtlasProjectFlags(group)
+			}
+			return err
+		}
+	}
 	if runE := cmd.RunE; runE != nil {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			defer resetAtlasProjectFlags(group)

--- a/cmd/atlas/project_config_snapshot_internal_test.go
+++ b/cmd/atlas/project_config_snapshot_internal_test.go
@@ -1,0 +1,62 @@
+package atlas
+
+// White-box testing required: this test verifies the unexported Atlas argument
+// mapper's snapshot boundary between project evaluation and native consumption;
+// no exported API exposes a deterministic hook at that point.
+
+import (
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+)
+
+func TestAtlasArgMapperPreservesProjectFilesSnapshot(t *testing.T) {
+	c := qt.New(t)
+	t.Chdir(t.TempDir())
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      pre_down_hook: "generation-one-hook"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  url = "sqlite://generation-one.db"
+  migration {
+    dir = "file://generation-one-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	mapperCommand := &cobra.Command{Use: "down"}
+	mapperCommand.SetContext(t.Context())
+	mapper := atlasArgMapper("migrate", atlasMigrateDownVerb())
+	_, snapshotContext, err := mapper(mapperCommand, []string{
+		"--config", "file://atlas.hcl",
+		"--env", "local",
+	})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      pre_down_hook: "generation-two-hook"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  url = "sqlite://generation-two.db"
+  migration {
+    dir = "file://generation-two-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	nativeCommand := &cobra.Command{Use: "down"}
+	nativeCommand.SetContext(snapshotContext)
+	loaded, err := dbcli.LoadProjectConfig(nativeCommand, "ptah.yaml")
+	c.Assert(err, qt.IsNil)
+	c.Assert(loaded.DatabaseURL, qt.Equals, "sqlite://generation-one.db")
+	c.Assert(loaded.Migration.Dir, qt.Equals, "generation-one-migrations")
+	c.Assert(loaded.Migration.PreDownHook, qt.Equals, "generation-one-hook")
+}

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -140,6 +140,84 @@ func TestCompatCommandMigrateDownEnvironmentOverridesSafetySnapshot(t *testing.T
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
 }
 
+func TestCompatCommandMigrateDownUsesProjectDevURLForShadowVerification(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	dbPath := filepath.Join(dir, "project-dev.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "2_add_audit.down.sql"),
+		[]byte("DROP TABLE no_such_table;\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    dev: "sqlite://`+filepath.Join(dir, "shadow.db")+`"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", "project.hcl",
+		"--env", "local",
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s)rollback verification failed: .*no_such_table.*`)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+}
+
+func TestCompatCommandMigrateDownExplicitDirectoryOverridesUnsupportedProjectPaths(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "explicit-migrations")
+	dbPath := filepath.Join(dir, "explicit-directory.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  schema {
+    src = ["postgres://unused/schema"]
+  }
+  migration {
+    dir = "atlas://remote/migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", "project.hcl",
+		"--env", "local",
+		"--dir", "file://" + migrationsDir,
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 0)
+}
+
 func TestCompatCommandMigrateDownNativeDirectoryEnvironmentOverridesProjectConfig(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -154,8 +232,11 @@ func TestCompatCommandMigrateDownNativeDirectoryEnvironmentOverridesProjectConfi
 `), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
   url = "sqlite://`+dbPath+`"
+  schema {
+    src = ["postgres://unused/schema"]
+  }
   migration {
-    dir = "file://missing-config-migrations"
+    dir = "atlas://remote/migrations"
   }
 }
 `), 0o600), qt.IsNil)
@@ -228,4 +309,82 @@ func TestCompatCommandProjectConfigDefersToDirectoryEnvironment(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "2 migration file(s) hashed")
+}
+
+func TestCompatCommandProjectSelectionDoesNotLeakAcrossRootReuse(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate",
+		"--config", "file://missing-first.hcl",
+		"--env", "first",
+		"--var", "name=first",
+		"--help",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	out.Reset()
+	cmd.SetArgs([]string{
+		"migrate", "hash",
+		"--dir", "file://" + migrationsDir,
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+}
+
+func TestCompatCommandProjectEnvironmentRemainsEffectiveAcrossRootReuse(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "environment-migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  migration {
+    dir = "file://environment-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_CONFIG", "file://project.hcl")
+	t.Setenv("PTAH_ENV", "local")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "hash"})
+
+	firstErr := cmd.Execute()
+
+	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	out.Reset()
+	cmd.SetArgs([]string{"migrate", "hash"})
+
+	secondErr := cmd.Execute()
+
+	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
 }

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -389,6 +389,70 @@ func TestCompatCommandProjectSelectionDoesNotLeakAfterArgumentValidationFailure(
 	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
 }
 
+func TestCompatCommandProjectSelectionDoesNotLeakAfterFlagGroupValidationFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--config", "file://missing-first.hcl",
+		"--env", "first",
+		"--var", "name=first",
+		"--file", "schema.hcl",
+		"--to", "schema.sql",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `if any flags in the group \[file to\] are set none of the others can be; \[file to\] were all set`)
+	out.Reset()
+	cmd.SetArgs([]string{
+		"schema", "inspect",
+		"--url", "sqlite://" + filepath.Join(dir, "target.db"),
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+}
+
+func TestCompatCommandProjectSelectionDoesNotLeakAfterCompletion(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"__complete",
+		"schema", "inspect",
+		"--config", "file://missing-first.hcl",
+		"--env", "first",
+		"--var", "name=first",
+		"",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	out.Reset()
+	cmd.SetArgs([]string{
+		"schema", "inspect",
+		"--url", "sqlite://" + filepath.Join(dir, "target.db"),
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+}
+
 func TestCompatCommandProjectEnvironmentRemainsEffectiveAcrossRootReuse(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -350,6 +350,45 @@ func TestCompatCommandProjectSelectionDoesNotLeakAcrossRootReuse(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
 }
 
+func TestCompatCommandProjectSelectionDoesNotLeakAfterArgumentValidationFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate",
+		"--config", "file://missing-first.hcl",
+		"--env", "first",
+		"--var", "name=first",
+		"status", "unexpected",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["unexpected"\]`)
+	out.Reset()
+	cmd.SetArgs([]string{
+		"migrate", "hash",
+		"--dir", "file://" + migrationsDir,
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+}
+
 func TestCompatCommandProjectEnvironmentRemainsEffectiveAcrossRootReuse(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -2,6 +2,7 @@ package atlas_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -490,4 +491,110 @@ func TestCompatCommandProjectEnvironmentRemainsEffectiveAcrossRootReuse(t *testi
 
 	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", out.String()))
 	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+}
+
+func TestCompatCommandProjectSelectionDoesNotLeakAfterRootHelp(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile("second.hcl", []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_CONFIG", "file://second.hcl")
+	t.Setenv("PTAH_ENV", "local")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	migrate, _, err := cmd.Find([]string{"migrate"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrate.PersistentFlags().Set("config", "file://missing-first.hcl"), qt.IsNil)
+	c.Assert(migrate.PersistentFlags().Set("env", "first"), qt.IsNil)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	out.Reset()
+	cmd.SetArgs([]string{"migrate", "hash"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+}
+
+func TestCompatCommandProjectSelectionDoesNotLeakAfterRootArgumentFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile("second.hcl", []byte(`env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_CONFIG", "file://second.hcl")
+	t.Setenv("PTAH_ENV", "local")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	migrate, _, err := cmd.Find([]string{"migrate"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrate.PersistentFlags().Set("config", "file://missing-first.hcl"), qt.IsNil)
+	c.Assert(migrate.PersistentFlags().Set("env", "first"), qt.IsNil)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"unexpected"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `unknown command "unexpected" for "atlas"`)
+	out.Reset()
+	cmd.SetArgs([]string{"migrate", "hash"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+}
+
+func TestCompatCommandDirectExecutionRefreshesContextAcrossRootReuse(t *testing.T) {
+	c := qt.New(t)
+	dbURL := "sqlite://" + filepath.Join(t.TempDir(), "target.db")
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"schema", "inspect", "--url", dbURL})
+
+	err := cmd.ExecuteContext(context.Background())
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	out.Reset()
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetArgs([]string{"schema", "inspect", "--url", dbURL})
+
+	err = cmd.ExecuteContext(canceledContext)
+
+	c.Assert(err, qt.ErrorMatches, `connect to --url: failed to ping database: context canceled`)
 }

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -1,0 +1,231 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+)
+
+func TestCompatCommandMigrateDownUsesPtahSafetySnapshot(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	projectDir := filepath.Join(dir, "project")
+	migrationsDir := filepath.Join(projectDir, "migrations")
+	dbPath := filepath.Join(dir, "snapshot.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      pre_down_hook: "echo snapshot-hook; exit 8"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "project.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", filepath.Join(projectDir, "project.hcl"),
+		"--env", "local",
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		"(?s).*down pre-flight custom command hook failed: exit status 8.*snapshot-hook.*",
+	)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+}
+
+func TestCompatCommandMigrateDownPreservesPtahPathBase(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	projectDir := filepath.Join(dir, "project")
+	migrationsDir := filepath.Join(dir, "migrations")
+	dbPath := filepath.Join(dir, "ptah-path.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.MkdirAll(projectDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      dir: ./migrations
+      pre_down_hook: "echo ptah-path-hook; exit 8"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(projectDir, "project.hcl"), []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", filepath.Join(projectDir, "project.hcl"),
+		"--env", "local",
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		"(?s).*down pre-flight custom command hook failed: exit status 8.*ptah-path-hook.*",
+	)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+}
+
+func TestCompatCommandMigrateDownEnvironmentOverridesSafetySnapshot(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	dbPath := filepath.Join(dir, "environment.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      pre_down_hook: "echo snapshot-hook; exit 8"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_PRE_DOWN_HOOK", "echo environment-hook; exit 9")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", "project.hcl",
+		"--env", "local",
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		"(?s).*down pre-flight custom command hook failed: exit status 9.*environment-hook.*",
+	)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+}
+
+func TestCompatCommandMigrateDownNativeDirectoryEnvironmentOverridesProjectConfig(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "environment-migrations")
+	dbPath := filepath.Join(dir, "native-directory-environment.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(os.WriteFile("ptah.yaml", []byte(`env:
+  local:
+    migration:
+      pre_down_hook: "echo native-directory-hook; exit 8"
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  url = "sqlite://`+dbPath+`"
+  migration {
+    dir = "file://missing-config-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_MIGRATIONS_DIR", migrationsDir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--config", "project.hcl",
+		"--env", "local",
+		"--to-version", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		"(?s).*down pre-flight custom command hook failed: exit status 8.*native-directory-hook.*",
+	)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+}
+
+func TestCompatCommandProjectConfigDefersToDirectoryEnvironment(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configDir := filepath.Join(dir, "config-migrations")
+	environmentDir := filepath.Join(dir, "environment-migrations")
+	c.Assert(os.MkdirAll(configDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(environmentDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(configDir, "1_config.sql"),
+		[]byte("CREATE TABLE config_table (id int);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(environmentDir, "1_environment.sql"),
+		[]byte("CREATE TABLE environment_one (id int);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(environmentDir, "2_environment.sql"),
+		[]byte("CREATE TABLE environment_two (id int);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile("project.hcl", []byte(`env "local" {
+  migration {
+    dir = "file://config-migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+	t.Setenv("PTAH_DIR", "file://"+environmentDir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "hash",
+		"--config", "project.hcl",
+		"--env", "local",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "2 migration file(s) hashed")
+}

--- a/cmd/internal/cmdadapter/cmdadapter.go
+++ b/cmd/internal/cmdadapter/cmdadapter.go
@@ -90,11 +90,17 @@ func newForwardCommandWithArgsMapper(
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		SilenceErrors:      true,
+		Args: func(cmd *cobra.Command, _ []string) error {
+			// ExecuteContext replaces only the root context. Refresh this child
+			// before inherited pre-runs derive command-scoped values from it.
+			cmd.SetContext(cmd.Root().Context())
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if help == adapterHelp && hasHelpArg(args) {
 				return cmd.Help()
 			}
-			forwardContext := cmd.Root().Context()
+			forwardContext := cmd.Context()
 			if mapper != nil {
 				var err error
 				args, forwardContext, err = mapper(cmd, args)

--- a/cmd/internal/cmdadapter/cmdadapter.go
+++ b/cmd/internal/cmdadapter/cmdadapter.go
@@ -3,6 +3,7 @@
 package cmdadapter
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"strings"
@@ -17,9 +18,9 @@ const envPrefix = "PTAH"
 
 const defaultSliceAnnotation = "ptah.cmdadapter.default-slice"
 
-// ArgMapper rewrites command arguments before they are forwarded to the target
-// command implementation.
-type ArgMapper func(*cobra.Command, []string) ([]string, error)
+// ArgMapper rewrites command arguments and returns the context for one
+// forwarded target execution.
+type ArgMapper func(*cobra.Command, []string) ([]string, context.Context, error)
 
 type helpBehavior int
 
@@ -93,14 +94,21 @@ func newForwardCommandWithArgsMapper(
 			if help == adapterHelp && hasHelpArg(args) {
 				return cmd.Help()
 			}
+			forwardContext := cmd.Root().Context()
 			if mapper != nil {
 				var err error
-				args, err = mapper(cmd, args)
+				args, forwardContext, err = mapper(cmd, args)
 				if err != nil {
 					return err
 				}
 			}
 			target := factory()
+			targetContexts := captureCommandContexts(target)
+			if forwardContext == nil {
+				forwardContext = context.Background()
+			}
+			setCommandContext(target, forwardContext)
+			defer restoreCommandContexts(target, targetContexts)
 			resetCommandFlags(target)
 			initializeForwardedTarget(target)
 			defer resetCommandFlags(target)
@@ -127,6 +135,33 @@ func newForwardCommandWithArgsMapper(
 			defer resetCommandIO(target)
 			return target.Execute()
 		},
+	}
+}
+
+func captureCommandContexts(root *cobra.Command) map[*cobra.Command]context.Context {
+	contexts := make(map[*cobra.Command]context.Context)
+	walkCommands(root, func(cmd *cobra.Command) {
+		contexts[cmd] = cmd.Context()
+	})
+	return contexts
+}
+
+func setCommandContext(root *cobra.Command, ctx context.Context) {
+	walkCommands(root, func(cmd *cobra.Command) {
+		cmd.SetContext(ctx)
+	})
+}
+
+func restoreCommandContexts(root *cobra.Command, contexts map[*cobra.Command]context.Context) {
+	walkCommands(root, func(cmd *cobra.Command) {
+		cmd.SetContext(contexts[cmd])
+	})
+}
+
+func walkCommands(root *cobra.Command, visit func(*cobra.Command)) {
+	visit(root)
+	for _, child := range root.Commands() {
+		walkCommands(child, visit)
 	}
 }
 

--- a/cmd/internal/cmdadapter/cmdadapter_test.go
+++ b/cmd/internal/cmdadapter/cmdadapter_test.go
@@ -2,13 +2,23 @@ package cmdadapter_test
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
 	"github.com/stokaro/ptah/cmd/internal/cmdadapter"
+	"github.com/stokaro/ptah/cmd/internal/dbcli"
+	"github.com/stokaro/ptah/config/projectconfig"
 )
+
+type testContextKey struct{}
+
+var errAdapterCanceled = errors.New("adapter canceled")
 
 func TestForwardCommandWithTargetHelpShowsTargetFlags(t *testing.T) {
 	c := qt.New(t)
@@ -90,6 +100,7 @@ func TestForwardCommandResetsTargetFlagsAndIO(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(adapterOut.String(), qt.Equals, "changed\n")
 	c.Assert(values, qt.DeepEquals, []string{"changed"})
+	c.Assert(target.Context(), qt.IsNil)
 
 	var directOut bytes.Buffer
 	target.SetOut(&directOut)
@@ -100,6 +111,141 @@ func TestForwardCommandResetsTargetFlagsAndIO(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(directOut.String(), qt.Equals, "default\n")
 	c.Assert(values, qt.DeepEquals, []string{"changed", "default"})
+}
+
+func TestForwardCommandCarriesAndRestoresContext(t *testing.T) {
+	c := qt.New(t)
+	targetContext := context.WithValue(t.Context(), testContextKey{}, "target")
+	var receivedValue string
+	var receivedCause error
+	var receivedDeadline time.Time
+	var receivedDeadlineSet bool
+	target := &cobra.Command{
+		Use: "target",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			receivedValue, _ = cmd.Context().Value(testContextKey{}).(string)
+			receivedCause = context.Cause(cmd.Context())
+			receivedDeadline, receivedDeadlineSet = cmd.Context().Deadline()
+			return nil
+		},
+	}
+	target.SetContext(targetContext)
+	cmd := cmdadapter.NewForwardCommand("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	deadline := time.Now().Add(time.Hour)
+	deadlineContext, cancelDeadline := context.WithDeadline(t.Context(), deadline)
+	defer cancelDeadline()
+	adapterContext, cancel := context.WithCancelCause(
+		context.WithValue(deadlineContext, testContextKey{}, "adapter"),
+	)
+	cancel(errAdapterCanceled)
+	cmd.SetContext(adapterContext)
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(receivedValue, qt.Equals, "adapter")
+	c.Assert(receivedCause, qt.ErrorIs, errAdapterCanceled)
+	c.Assert(receivedDeadlineSet, qt.IsTrue)
+	c.Assert(receivedDeadline, qt.Equals, deadline)
+	c.Assert(target.Context().Value(testContextKey{}), qt.Equals, "target")
+	c.Assert(context.Cause(target.Context()), qt.IsNil)
+}
+
+func TestForwardCommandReplacesContextAcrossReusedTargetTree(t *testing.T) {
+	c := qt.New(t)
+	var receivedValues []string
+	var receivedCauses []error
+	target := &cobra.Command{Use: "target"}
+	target.AddCommand(&cobra.Command{
+		Use: "child",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			receivedValues = append(
+				receivedValues,
+				cmd.Context().Value(testContextKey{}).(string),
+			)
+			receivedCauses = append(receivedCauses, context.Cause(cmd.Context()))
+			return nil
+		},
+	})
+	cmd := cmdadapter.NewForwardCommandWithArgs(
+		"atlas",
+		"Atlas adapter command",
+		"target child",
+		func() *cobra.Command {
+			return target
+		},
+		"child",
+	)
+	cmd.SetArgs([]string{})
+	firstContext, cancelFirst := context.WithCancelCause(
+		context.WithValue(t.Context(), testContextKey{}, "first"),
+	)
+	cancelFirst(errAdapterCanceled)
+
+	err := cmd.ExecuteContext(firstContext)
+
+	c.Assert(err, qt.IsNil)
+	secondContext := context.WithValue(t.Context(), testContextKey{}, "second")
+	err = cmd.ExecuteContext(secondContext)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(receivedValues, qt.DeepEquals, []string{"first", "second"})
+	c.Assert(receivedCauses[0], qt.ErrorIs, errAdapterCanceled)
+	c.Assert(receivedCauses[1], qt.IsNil)
+	c.Assert(target.Context(), qt.IsNil)
+	c.Assert(target.Commands()[0].Context(), qt.IsNil)
+}
+
+func TestForwardCommandPassesProjectConfigSnapshotWithoutReloading(t *testing.T) {
+	c := qt.New(t)
+	snapshot := projectconfig.Config{
+		Migration: projectconfig.MigrationConfig{
+			PreDownHook: "echo snapshot-hook; exit 8",
+		},
+	}
+	var loaded projectconfig.Config
+	target := &cobra.Command{
+		Use: "target",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var err error
+			loaded, err = dbcli.LoadProjectConfig(
+				cmd,
+				filepath.Join(t.TempDir(), "missing.yaml"),
+			)
+			return err
+		},
+	}
+	mapper := func(
+		cmd *cobra.Command,
+		args []string,
+	) ([]string, context.Context, error) {
+		ctx := dbcli.WithProjectConfig(cmd.Root().Context(), snapshot)
+		return args, ctx, nil
+	}
+	cmd := cmdadapter.NewForwardCommandWithArgsMapper(
+		"atlas",
+		"Atlas adapter command",
+		"target",
+		func() *cobra.Command {
+			return target
+		},
+		mapper,
+	)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(loaded.Migration.PreDownHook, qt.Equals, "echo snapshot-hook; exit 8")
+	snapshot.Migration.PreDownHook = "echo second-snapshot-hook; exit 9"
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(loaded.Migration.PreDownHook, qt.Equals, "echo second-snapshot-hook; exit 9")
+	c.Assert(target.Context(), qt.IsNil)
 }
 
 func TestForwardCommandResetsStringArrayEmptyDefault(t *testing.T) {

--- a/cmd/internal/cmdadapter/cmdadapter_test.go
+++ b/cmd/internal/cmdadapter/cmdadapter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -17,6 +18,8 @@ import (
 )
 
 type testContextKey struct{}
+
+type middlewareContextKey struct{}
 
 var errAdapterCanceled = errors.New("adapter canceled")
 
@@ -196,6 +199,51 @@ func TestForwardCommandReplacesContextAcrossReusedTargetTree(t *testing.T) {
 	c.Assert(receivedCauses[1], qt.IsNil)
 	c.Assert(target.Context(), qt.IsNil)
 	c.Assert(target.Commands()[0].Context(), qt.IsNil)
+}
+
+func TestForwardCommandCarriesFreshExecutingContextAcrossRootReuse(t *testing.T) {
+	c := qt.New(t)
+	var receivedValues []string
+	target := &cobra.Command{
+		Use: "target",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			receivedValues = append(
+				receivedValues,
+				fmt.Sprint(cmd.Context().Value(middlewareContextKey{})),
+			)
+			return nil
+		},
+	}
+	adapter := cmdadapter.NewForwardCommand(
+		"adapter",
+		"Adapter command",
+		"target",
+		func() *cobra.Command {
+			return target
+		},
+	)
+	root := &cobra.Command{
+		Use: "root",
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			cmd.SetContext(context.WithValue(
+				cmd.Context(),
+				middlewareContextKey{},
+				cmd.Context().Value(testContextKey{}),
+			))
+		},
+	}
+	root.AddCommand(adapter)
+	root.SetArgs([]string{"adapter"})
+
+	err := root.ExecuteContext(context.WithValue(t.Context(), testContextKey{}, "first"))
+
+	c.Assert(err, qt.IsNil)
+	root.SetArgs([]string{"adapter"})
+	err = root.ExecuteContext(context.WithValue(t.Context(), testContextKey{}, "second"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(receivedValues, qt.DeepEquals, []string{"first", "second"})
+	c.Assert(target.Context(), qt.IsNil)
 }
 
 func TestForwardCommandPassesProjectConfigSnapshotWithoutReloading(t *testing.T) {

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -1,6 +1,7 @@
 package dbcli
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -27,6 +28,23 @@ const (
 	AtlasProjectVarFlagName = "atlas-project-var"
 	schemaCommandFlagName   = "schema-cmd"
 )
+
+type projectConfigContextKey struct{}
+
+type projectConfigContextValue struct {
+	config projectconfig.Config
+}
+
+// WithProjectConfig returns a context carrying an immutable project-config
+// snapshot for a forwarded native command.
+func WithProjectConfig(ctx context.Context, config projectconfig.Config) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, projectConfigContextKey{}, projectConfigContextValue{
+		config: cloneProjectConfig(config),
+	})
+}
 
 // RegisterEnvFlag registers the shared project env selection flag.
 func RegisterEnvFlag(flags *pflag.FlagSet, target *string) {
@@ -64,8 +82,12 @@ func RegisterAtlasProjectInternalFlags(flags *pflag.FlagSet) {
 // LoadProjectConfig loads project-level configuration for a command. The
 // explicit Ptah config path controls ptah.yaml only; Atlas-compatible adapters
 // can pass an internal atlas.hcl path and variable overrides through hidden
-// flags.
+// flags. A project-config snapshot supplied by an adapter takes precedence and
+// avoids reopening project files during the forwarded execution.
 func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig.Config, error) {
+	if config, ok := projectConfigFromContext(cmd.Context()); ok {
+		return cloneProjectConfig(config), nil
+	}
 	envName, err := stringFlag(cmd, EnvFlagName)
 	if err != nil {
 		return projectconfig.Config{}, err
@@ -84,6 +106,18 @@ func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig
 		EnvName:   envName,
 		AtlasVars: atlasVars,
 	})
+}
+
+func projectConfigFromContext(ctx context.Context) (projectconfig.Config, bool) {
+	if ctx == nil {
+		return projectconfig.Config{}, false
+	}
+	value, ok := ctx.Value(projectConfigContextKey{}).(projectConfigContextValue)
+	return value.config, ok
+}
+
+func cloneProjectConfig(config projectconfig.Config) projectconfig.Config {
+	return projectconfig.Merge(projectconfig.Config{}, config)
 }
 
 // EffectiveString returns an explicit CLI value first, then a present project

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -199,6 +199,57 @@ func TestLoadProjectConfigReadsNamedPtahEnvRuntimeDefaults(t *testing.T) {
 	c.Assert(cfg.Lint.DisabledRules, qt.DeepEquals, []string{"MF103"})
 }
 
+func TestLoadProjectConfigUsesImmutableContextSnapshot(t *testing.T) {
+	c := qt.New(t)
+	snapshot, err := projectconfig.ParsePtah([]byte(`url: postgres://snapshot/db
+schemas: [public]
+`), "snapshot.yaml", "")
+	c.Assert(err, qt.IsNil)
+	latest := 3
+	snapshot.Lint.Latest = &latest
+	snapshot.Lint.RuleConfigs = map[string]projectconfig.LintRuleConfig{
+		"DS": {
+			Severity: "warning",
+			Exclude:  []string{"migrations/legacy/*"},
+		},
+	}
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(dbcli.WithProjectConfig(cmd.Context(), snapshot))
+	snapshot.DatabaseURL = "postgres://mutated/db"
+	snapshot.Schemas[0] = "mutated"
+	latest = 9
+	snapshot.Lint.RuleConfigs["DS"] = projectconfig.LintRuleConfig{
+		Severity: "error",
+		Exclude:  []string{"mutated/*"},
+	}
+
+	first, err := dbcli.LoadProjectConfig(cmd, filepath.Join(t.TempDir(), "missing.yaml"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(first.DatabaseURL, qt.Equals, "postgres://snapshot/db")
+	c.Assert(first.Schemas, qt.DeepEquals, []string{"public"})
+	c.Assert(*first.Lint.Latest, qt.Equals, 3)
+	c.Assert(first.Lint.RuleConfigs["DS"], qt.DeepEquals, projectconfig.LintRuleConfig{
+		Severity: "warning",
+		Exclude:  []string{"migrations/legacy/*"},
+	})
+	first.DatabaseURL = "postgres://consumer-mutation/db"
+	first.Schemas[0] = "consumer-mutation"
+	*first.Lint.Latest = 12
+	first.Lint.RuleConfigs["DS"] = projectconfig.LintRuleConfig{Severity: "off"}
+
+	second, err := dbcli.LoadProjectConfig(cmd, filepath.Join(t.TempDir(), "missing.yaml"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.DatabaseURL, qt.Equals, "postgres://snapshot/db")
+	c.Assert(second.Schemas, qt.DeepEquals, []string{"public"})
+	c.Assert(*second.Lint.Latest, qt.Equals, 3)
+	c.Assert(second.Lint.RuleConfigs["DS"], qt.DeepEquals, projectconfig.LintRuleConfig{
+		Severity: "warning",
+		Exclude:  []string{"migrations/legacy/*"},
+	})
+}
+
 func TestExternalSchemaCommandsPrefersFlag(t *testing.T) {
 	c := qt.New(t)
 	cmd := &cobra.Command{Use: "test"}

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -355,6 +355,7 @@ func migrateDownCommand(cmd *cobra.Command, opts *options) error {
 	emit.Println()
 
 	if err := verifyRollbackOnShadow(shadowVerification{
+		targetDB:       dbURL,
 		shadowDB:       resolvedOpts.shadowDB,
 		migrationsFS:   migrationsFS,
 		dialect:        conn.Info().Dialect,
@@ -436,6 +437,7 @@ func observeNoopDown(runtime *cliobs.Runtime, dialect string, currentVersion, ta
 }
 
 type shadowVerification struct {
+	targetDB       string
 	shadowDB       string
 	migrationsFS   fs.FS
 	dialect        string
@@ -455,6 +457,7 @@ func verifyRollbackOnShadow(v shadowVerification, emit cliobs.Emitter) error {
 		return nil
 	}
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: v.targetDB,
 		ShadowDatabaseURL: v.shadowDB,
 		FS:                v.migrationsFS,
 		Dialect:           v.dialect,

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -138,6 +138,7 @@ func resolveProjectOptions(cmd *cobra.Command, opts options, projectCfg projectc
 	}
 	opts.dbURL = effectiveString(dbURLFlag, opts.dbURL, projectconfig.StringDatabaseURL)
 	opts.migrationsDir = effectiveString(migrationsFlag, opts.migrationsDir, projectconfig.StringMigrationDir)
+	opts.shadowDB = effectiveString(shadowDBFlag, opts.shadowDB, projectconfig.StringDevURL)
 	opts.dirFormat = effectiveString(dirFormatFlag, opts.dirFormat, projectconfig.StringMigrationFormat)
 	opts.atlasEnv = effectiveString(atlasEnvFlag, opts.atlasEnv, projectconfig.StringEnvName)
 	opts.execOrder = effectiveString(execOrderFlag, opts.execOrder, projectconfig.StringMigrationExecOrder)

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -354,16 +354,15 @@ func migrateDownCommand(cmd *cobra.Command, opts *options) error {
 
 	emit.Println()
 
-	if err := verifyRollbackOnShadow(shadowVerification{
-		targetDB:       dbURL,
-		shadowDB:       resolvedOpts.shadowDB,
-		migrationsFS:   migrationsFS,
-		dialect:        conn.Info().Dialect,
-		currentVersion: status.CurrentVersion,
-		targetVersion:  targetVersion,
-		dirFormat:      dirFormat,
-		atlasEnv:       atlasEnv,
-		connectTimeout: connectTimeout,
+	if err := verifyRollbackOnShadow(cmd.Context(), shadowVerification{
+		targetConnection: conn,
+		shadowDB:         resolvedOpts.shadowDB,
+		migrationsFS:     migrationsFS,
+		currentVersion:   status.CurrentVersion,
+		targetVersion:    targetVersion,
+		dirFormat:        dirFormat,
+		atlasEnv:         atlasEnv,
+		connectTimeout:   connectTimeout,
 	}, emit); err != nil {
 		return err
 	}
@@ -437,30 +436,32 @@ func observeNoopDown(runtime *cliobs.Runtime, dialect string, currentVersion, ta
 }
 
 type shadowVerification struct {
-	targetDB       string
-	shadowDB       string
-	migrationsFS   fs.FS
-	dialect        string
-	currentVersion int64
-	targetVersion  int64
-	dirFormat      migrator.MigrationDirFormat
-	atlasEnv       string
-	connectTimeout time.Duration
+	targetConnection *dbschema.DatabaseConnection
+	shadowDB         string
+	migrationsFS     fs.FS
+	currentVersion   int64
+	targetVersion    int64
+	dirFormat        migrator.MigrationDirFormat
+	atlasEnv         string
+	connectTimeout   time.Duration
 }
 
 // verifyRollbackOnShadow replays the rollback plan on a disposable shadow
 // database first, so a down file that fails or a missing down migration aborts
 // before the target is touched (and before the operator is asked to confirm).
 // Without --shadow-db it is a no-op, keeping the default output unchanged.
-func verifyRollbackOnShadow(v shadowVerification, emit cliobs.Emitter) error {
+func verifyRollbackOnShadow(
+	ctx context.Context,
+	v shadowVerification,
+	emit cliobs.Emitter,
+) error {
 	if v.shadowDB == "" {
 		return nil
 	}
-	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: v.targetDB,
+	err := generator.VerifyRollbackFromShadow(ctx, generator.RollbackFromShadowOptions{
+		TargetConnection:  v.targetConnection,
 		ShadowDatabaseURL: v.shadowDB,
 		FS:                v.migrationsFS,
-		Dialect:           v.dialect,
 		CurrentVersion:    v.currentVersion,
 		TargetVersion:     v.targetVersion,
 		ProviderOptions: []migrator.FSProviderOption{

--- a/cmd/migratedown/migratedown.go
+++ b/cmd/migratedown/migratedown.go
@@ -355,7 +355,7 @@ func migrateDownCommand(cmd *cobra.Command, opts *options) error {
 	emit.Println()
 
 	if err := verifyRollbackOnShadow(shadowVerification{
-		shadowDB:       opts.shadowDB,
+		shadowDB:       resolvedOpts.shadowDB,
 		migrationsFS:   migrationsFS,
 		dialect:        conn.Info().Dialect,
 		currentVersion: status.CurrentVersion,

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -1,4 +1,4 @@
-# Atlas Project Config
+# Atlas project config
 
 Ptah can read a limited Atlas project config subset from `atlas.hcl` and
 translate it into Ptah's project config IR. This is project configuration for
@@ -6,7 +6,7 @@ commands, not schema HCL input. Schema HCL input is documented separately in
 [HCL Schema Input](atlas_hcl_schema.md). `ptah-compat <command> ...`
 invocations in this document run the separate `ptah-compat` drop-in binary.
 
-## Supported Subset
+## Supported subset
 
 Ptah accepts top-level `variable`, `locals`, `data "hcl_schema"`, `env`,
 `lint`, and `diff` blocks. `env` blocks may have either one label or no label:
@@ -82,7 +82,7 @@ The supported attributes map to Ptah settings as follows:
 | Atlas setting | Ptah setting |
 | --- | --- |
 | `env.url` | `--db-url`, `ptah-compat schema inspect --url`, `ptah-compat schema apply --url`, `ptah-compat migrate apply --url`, or `ptah-compat migrate status --url` default |
-| `env.dev` | `migrations generate --shadow-db`, `migrations down --shadow-db`, `ptah-compat schema inspect --dev-url`, `ptah-compat schema apply --dev-url`, `ptah-compat schema diff --dev-url`, `ptah-compat migrate down --dev-url`, `ptah-compat migrate diff --dev-url`, or `ptah-compat migrate lint --dev-url` default |
+| `env.dev` | Disposable replay database default for `migrations generate --shadow-db`, `migrations down --shadow-db`, and compatible `--dev-url` workflows; rollback verification resets it and requires it to identify a different database from `env.url` |
 | `env.src` | `ptah-compat schema apply --to` default |
 | `env.schema.src` | `ptah-compat schema apply --to`, `ptah-compat schema diff --to`, or `ptah-compat migrate diff --to` default |
 | `env.schema.mode.<object>` | Atlas-style exclusion defaults for supported object kinds |
@@ -235,7 +235,7 @@ that `atlas.hcl` file, not the process working directory. Explicit CLI `--dir`
 values keep CLI semantics and resolve relative to the process working directory
 unless they are absolute. Other URI schemes are rejected.
 
-## Expression Evaluation
+## Expression evaluation
 
 Ptah evaluates a scoped Atlas-compatible expression subset for local project
 config workflows:
@@ -290,7 +290,7 @@ when the invocation provides a matching `--var name=value`. Variable `type` and
 Unsupported dynamic data sources such as external schemas, SQL data sources,
 registry-backed sources, and Cloud-specific sources still fail explicitly.
 
-## Env Selection
+## Env selection
 
 Use `--env <name>` when an `atlas.hcl` file contains multiple `env` blocks.
 When the file contains exactly one `env` block, Ptah selects it automatically.
@@ -374,7 +374,7 @@ supported `diff` policy.
 `ptah-compat migrate diff` reads `env.schema.src`, `env.dev`, `migration.dir`,
 `format.migrate.diff`, and supported `diff` policy.
 
-## Unsupported Constructs
+## Unsupported constructs
 
 Ptah intentionally rejects everything outside the documented subset. Unsupported
 attributes, unsupported data sources, unsupported lint policy blocks or attributes,

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -82,7 +82,7 @@ The supported attributes map to Ptah settings as follows:
 | Atlas setting | Ptah setting |
 | --- | --- |
 | `env.url` | `--db-url`, `ptah-compat schema inspect --url`, `ptah-compat schema apply --url`, `ptah-compat migrate apply --url`, or `ptah-compat migrate status --url` default |
-| `env.dev` | `migrations generate --shadow-db`, `ptah-compat schema inspect --dev-url`, `ptah-compat schema apply --dev-url`, `ptah-compat schema diff --dev-url`, `ptah-compat migrate diff --dev-url`, or `ptah-compat migrate lint --dev-url` default |
+| `env.dev` | `migrations generate --shadow-db`, `migrations down --shadow-db`, `ptah-compat schema inspect --dev-url`, `ptah-compat schema apply --dev-url`, `ptah-compat schema diff --dev-url`, `ptah-compat migrate down --dev-url`, `ptah-compat migrate diff --dev-url`, or `ptah-compat migrate lint --dev-url` default |
 | `env.src` | `ptah-compat schema apply --to` default |
 | `env.schema.src` | `ptah-compat schema apply --to`, `ptah-compat schema diff --to`, or `ptah-compat migrate diff --to` default |
 | `env.schema.mode.<object>` | Atlas-style exclusion defaults for supported object kinds |

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -319,6 +319,8 @@ project sources are merged, a command applies its built-in default only when a
 field is absent. An explicitly present empty or zero value instead reaches the
 command's normal validation. Fields that do not accept empty values, including
 Atlas format templates, fail during parsing or command validation.
+Forwarded Atlas-compatible commands pass this merged configuration snapshot to
+the native implementation instead of reopening either project file.
 
 This means a repo can keep an Atlas-shaped migration setup while still letting
 one-off CLI invocations override any value:

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -319,8 +319,10 @@ project sources are merged, a command applies its built-in default only when a
 field is absent. An explicitly present empty or zero value instead reaches the
 command's normal validation. Fields that do not accept empty values, including
 Atlas format templates, fail during parsing or command validation.
-Forwarded Atlas-compatible commands pass this merged configuration snapshot to
-the native implementation instead of reopening either project file.
+When a forwarded native implementation also consumes project configuration,
+the adapter passes this merged snapshot instead of reopening either project
+file. This currently applies to `migrate down`; other adapters map evaluated
+Atlas project values to explicit native command arguments.
 
 This means a repo can keep an Atlas-shaped migration setup while still letting
 one-off CLI invocations override any value:

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -12,10 +12,13 @@ the operator expected.
 
 Each command reads `ptah.yaml` once into the typed project configuration IR.
 Database settings, migration settings, and online-DDL execution policy
-therefore come from the same file generation. Atlas-compatible command adapters
-pass the merged IR to the native command implementation instead of reopening
-`ptah.yaml` or `atlas.hcl`. An explicit `--config` path must exist; the
-conventional `./ptah.yaml` remains optional.
+therefore come from the same file generation. When an Atlas-compatible adapter
+delegates to a native command that also consumes project configuration, the
+adapter passes the merged IR instead of letting that command reopen
+`ptah.yaml` or `atlas.hcl`. This snapshot path currently applies to
+`migrate down`; other adapters evaluate Atlas project configuration once and
+map supported values to explicit native command arguments. An explicit
+`--config` path must exist; the conventional `./ptah.yaml` remains optional.
 
 ## Named Environments
 

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -12,8 +12,10 @@ the operator expected.
 
 Each command reads `ptah.yaml` once into the typed project configuration IR.
 Database settings, migration settings, and online-DDL execution policy
-therefore come from the same file generation. An explicit `--config` path must
-exist; the conventional `./ptah.yaml` remains optional.
+therefore come from the same file generation. Atlas-compatible command adapters
+pass the merged IR to the native command implementation instead of reopening
+`ptah.yaml` or `atlas.hcl`. An explicit `--config` path must exist; the
+conventional `./ptah.yaml` remains optional.
 
 ## Named Environments
 

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -81,7 +81,7 @@ env:
 | Key | Meaning |
 | --- | --- |
 | `url` | Default target database URL for migration commands |
-| `dev` | Disposable dev/shadow database URL for `migrations generate` |
+| `dev` | Disposable dev/shadow database URL for `migrations generate` and rollback verification in `migrations down` |
 | `schemas` | Default schemas to introspect when the command supports schema scoping |
 | `exclude` | Project-level exclude patterns for config consumers |
 | `external_schema.program` | External schema command as an explicit argument list; the first item is the executable |

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -84,7 +84,7 @@ env:
 | Key | Meaning |
 | --- | --- |
 | `url` | Default target database URL for migration commands |
-| `dev` | Disposable dev/shadow database URL for `migrations generate` and rollback verification in `migrations down`; replay resets this database, and rollback verification requires it to identify a different database from `url` |
+| `dev` | Disposable dev/shadow database URL for `migrations generate` and rollback verification in `migrations down`; replay resets this database, and rollback verification requires a different live database/catalog realm from `url` |
 | `schemas` | Default schemas to introspect when the command supports schema scoping |
 | `exclude` | Project-level exclude patterns for config consumers |
 | `external_schema.program` | External schema command as an explicit argument list; the first item is the executable |

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -1,4 +1,4 @@
-# Ptah Project Config
+# Ptah project config
 
 `ptah.yaml` is Ptah's project-level configuration file. It selects command
 defaults and can select an external desired-schema program; the program's
@@ -20,7 +20,7 @@ adapter passes the merged IR instead of letting that command reopen
 map supported values to explicit native command arguments. An explicit
 `--config` path must exist; the conventional `./ptah.yaml` remains optional.
 
-## Named Environments
+## Named environments
 
 Use `env` blocks to name reusable database targets:
 
@@ -79,12 +79,12 @@ env:
       exec_order: non-linear
 ```
 
-## Supported Keys
+## Supported keys
 
 | Key | Meaning |
 | --- | --- |
 | `url` | Default target database URL for migration commands |
-| `dev` | Disposable dev/shadow database URL for `migrations generate` and rollback verification in `migrations down` |
+| `dev` | Disposable dev/shadow database URL for `migrations generate` and rollback verification in `migrations down`; replay resets this database, and rollback verification requires it to identify a different database from `url` |
 | `schemas` | Default schemas to introspect when the command supports schema scoping |
 | `exclude` | Project-level exclude patterns for config consumers |
 | `external_schema.program` | External schema command as an explicit argument list; the first item is the executable |
@@ -128,7 +128,7 @@ high-precision UTC timestamp. Webhooks have a 30-second timeout and redirects
 are not followed. Dry-run migration commands do not execute hooks because
 backups and webhooks are side effects.
 
-## External Desired Schema
+## External desired schema
 
 Use `external_schema` when an ORM, framework, or generator owns the desired
 schema:
@@ -181,7 +181,7 @@ descendants left behind after a successful parent exit.
 See the canonical [ORM and external loaders](site/src/content/docs/schema/orm-and-external.md)
 page and [composite desired schema](site/src/content/docs/schema/composite.md) rules.
 
-## Diff Policy
+## Diff policy
 
 The `diff` block declaratively controls which changes `migrations generate`
 emits, so a project can shape generated migrations without editing Go code or

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -92,6 +92,11 @@ the cross-process publication lock and rejects concurrent use of one plan with
 `GenerateMigration` remains the convenience composition of planning and
 publication and propagates its context through both phases.
 
+`migration/generator.VerifyRollbackFromShadow` requires the caller's open
+target `dbschema.DatabaseConnection`. It checks the target and shadow's live
+dialects and selected database realms before resetting the shadow, rather than
+trusting a caller-supplied dialect or URL-derived database name.
+
 Atlas revision metadata is represented explicitly by `AtlasRevisionType` on
 `MigrationRevision`. `SetAtlasRevision` implements Atlas's metadata-only
 history transition: it preserves existing clean rows through the target, adds

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6037,6 +6037,9 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 package generator // import "github.com/stokaro/ptah/migration/generator"
 
 type RollbackFromShadowOptions struct {
+    // TargetDatabaseURL identifies the database the verified rollback would
+    // eventually modify. It must be distinct from ShadowDatabaseURL.
+    TargetDatabaseURL string
     // ShadowDatabaseURL is an ephemeral database the verification drops clean
     // and replays the migration directory into. Its contents are discarded.
     ShadowDatabaseURL string

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6037,17 +6037,15 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 package generator // import "github.com/stokaro/ptah/migration/generator"
 
 type RollbackFromShadowOptions struct {
-    // TargetDatabaseURL identifies the database the verified rollback would
-    // eventually modify. It must be distinct from ShadowDatabaseURL.
-    TargetDatabaseURL string
+    // TargetConnection is the already-open database the verified rollback
+    // would eventually modify. Its live realm must be distinct from the shadow
+    // database.
+    TargetConnection *dbschema.DatabaseConnection
     // ShadowDatabaseURL is an ephemeral database the verification drops clean
     // and replays the migration directory into. Its contents are discarded.
     ShadowDatabaseURL string
     // FS is the migration filesystem whose rollback plan is verified.
     FS fs.FS
-    // Dialect, when set, must match the shadow database dialect so the verified
-    // SQL is the SQL the target would execute.
-    Dialect string
     // CurrentVersion is the target database's current migration version. The
     // shadow database is migrated up to it before the rollback is replayed.
     CurrentVersion int64

--- a/docs/public_api_approvals.txt
+++ b/docs/public_api_approvals.txt
@@ -7,3 +7,4 @@
 # an incompatible public API change before v1. The PR must explain the
 # compatibility rationale and update docs/public_api.md when the stable package
 # set changes.
+v0.1.1 github.com/stokaro/ptah/migration/generator

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -136,8 +136,10 @@ ptah-compat migrate down \
   --to-version 0
 ```
 
-The dev database must identify a different database from `--url`. Ptah rejects
-equivalent URL aliases before connecting to or resetting the dev database.
+The dev database must select a different live database or catalog from
+`--url`. Ptah rejects equivalent URL aliases first, then connects and verifies
+the actual dialects and selected database/catalog names before resetting the
+dev database. Equal live names fail closed across different endpoints.
 
 Native `ptah migrations` commands read the same directory when `--dir-format
 atlas` is passed; the native lifecycle is documented under

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -124,6 +124,21 @@ Expected output ends with:
 Database is now at version: 0
 ```
 
+Add `--dev-url` to reset a disposable dev database, replay the migration
+directory to the target's current version, and verify the rollback there before
+the target is touched:
+
+```bash
+ptah-compat migrate down \
+  --url "$DATABASE_URL" \
+  --dev-url "$DEV_DATABASE_URL" \
+  --dir file://migrations \
+  --to-version 0
+```
+
+The dev database must identify a different database from `--url`. Ptah rejects
+equivalent URL aliases before connecting to or resetting the dev database.
+
 Native `ptah migrations` commands read the same directory when `--dir-format
 atlas` is passed; the native lifecycle is documented under
 [Versioned migrations](../../versioned/overview/). If parsing fails, force

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -94,7 +94,7 @@ env "local" {
 | Atlas setting | Ptah behavior |
 | --- | --- |
 | `env.url` | Default database URL for compatible schema and migration commands. |
-| `env.dev` | Default shadow/dev database URL where the command supports one. |
+| `env.dev` | Default shadow/dev database URL, including rollback verification for `ptah-compat migrate down`. |
 | `env.src` | Default desired schema source for `schema apply`. |
 | `env.schema.src` | Default desired schema source for `schema apply`, `schema diff`, and `migrate diff`. |
 | `env.schema.mode.<object>` | Default object-kind exclusions for supported schema object kinds. |

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -129,6 +129,8 @@ that type. After project sources are merged, a command applies its built-in
 default only when a field is absent. An explicitly present empty or zero value
 instead reaches normal validation. Fields that do not accept empty values,
 including Atlas format templates, fail during parsing or command validation.
+Forwarded commands pass this merged configuration snapshot to the native
+implementation instead of reopening either project file.
 
 `env.exclude` and disabled `env.schema.mode` values compose with the
 `schema apply`/`schema diff` positive selection flags in a fixed order:

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -94,7 +94,7 @@ env "local" {
 | Atlas setting | Ptah behavior |
 | --- | --- |
 | `env.url` | Default database URL for compatible schema and migration commands. |
-| `env.dev` | Default shadow/dev database URL, including rollback verification for `ptah-compat migrate down`. |
+| `env.dev` | Default disposable replay database URL. Rollback verification resets it and requires it to identify a different database from `env.url`. |
 | `env.src` | Default desired schema source for `schema apply`. |
 | `env.schema.src` | Default desired schema source for `schema apply`, `schema diff`, and `migrate diff`. |
 | `env.schema.mode.<object>` | Default object-kind exclusions for supported schema object kinds. |

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -129,8 +129,10 @@ that type. After project sources are merged, a command applies its built-in
 default only when a field is absent. An explicitly present empty or zero value
 instead reaches normal validation. Fields that do not accept empty values,
 including Atlas format templates, fail during parsing or command validation.
-Forwarded commands pass this merged configuration snapshot to the native
-implementation instead of reopening either project file.
+When a forwarded native implementation also consumes project configuration,
+the adapter passes this merged snapshot instead of reopening either project
+file. This currently applies to `migrate down`; other adapters map evaluated
+Atlas project values to explicit native command arguments.
 
 `env.exclude` and disabled `env.schema.mode` values compose with the
 `schema apply`/`schema diff` positive selection flags in a fixed order:

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -64,8 +64,11 @@ exercise a real server dialect — see
   seeder's protected-environment guards. Point these flags at scratch databases
   only, never at a real environment. Rollback verification rejects a dev or
   shadow URL that identifies the target database, including equivalent URL
-  aliases, before it connects to or resets the replay database. Cleanup rejects
-  known system, template, metadata, and administrative database names.
+  aliases. Before reset it also compares the live dialect and selected
+  database/catalog realm from both connections. Equal network database names
+  fail closed across different endpoints because DNS aliases and replicated
+  members cannot be proven independent before destructive cleanup. Cleanup
+  rejects known system, template, metadata, and administrative database names.
 - **Comparison scope does not reduce the replay realm.** Repeated
   `--schema` values select which schemas Ptah compares and emits. They do not
   limit which schemas a migration may create or which user schemas final

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -38,9 +38,9 @@ whose state matters after the command exits.
 **A dev database** (`--dev-url`) is a disposable replay target used for
 validation: `ptah migrations validate` and `ptah migrations lint` clean it and
 replay the migration directory on it to prove the SQL executes, and
-Atlas-compatible verbs use it for planning and linting the same way. Ptah
-cleans the replay realm before migration execution, after a failed replay, and
-after a successful replay. Commands that inspect the replayed state do so
+Atlas-compatible verbs use it for planning, linting, and rollback verification.
+Ptah cleans the replay realm before migration execution, after a failed replay,
+and after a successful replay. Commands that inspect the replayed state do so
 between execution and the final cleanup on the same pinned database session.
 
 **A shadow database** (`--shadow-db`) is a disposable verification target for
@@ -48,7 +48,8 @@ commands that write or record migrations: `ptah migrations generate` replays
 the directory — including the new migration, up, down, and up again — before
 keeping any files, and `ptah migrations checkpoint` and
 `ptah migrations baseline` use it to verify that migrations reproduce the
-expected schema before anything is recorded.
+expected schema before anything is recorded. `ptah migrations down` uses it to
+verify the rollback plan before changing the target.
 
 **A throwaway test database** is what `ptah migrations test` and
 `ptah schema test` run cases against: by default a fresh ephemeral SQLite
@@ -61,8 +62,10 @@ exercise a real server dialect — see
 - **Disposable means Ptah may drop everything it supports.** Dev and shadow
   database workflows clean user objects, and test seed steps bypass the
   seeder's protected-environment guards. Point these flags at scratch databases
-  only, never at a real environment. Cleanup rejects known system, template,
-  metadata, and administrative database names.
+  only, never at a real environment. Rollback verification rejects a dev or
+  shadow URL that identifies the target database, including equivalent URL
+  aliases, before it connects to or resets the replay database. Cleanup rejects
+  known system, template, metadata, and administrative database names.
 - **Comparison scope does not reduce the replay realm.** Repeated
   `--schema` values select which schemas Ptah compares and emits. They do not
   limit which schemas a migration may create or which user schemas final

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -70,6 +70,9 @@ Project config can also define timeouts, revision table layout, migration
 directory format, transaction mode, backup destinations, pre-flight hooks,
 webhooks, lint defaults, and online-DDL policy.
 
+The `dev` value supplies the disposable database for migration generation and
+the shadow rehearsal that `migrations down` performs before touching its target.
+
 | Setting area | Example keys |
 | --- | --- |
 | Database target | `url`, `src`, `schema.src`, `dev`, `schemas` |

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -34,8 +34,9 @@ and local `diff` policy defaults for the `ptah-compat` binary's commands.
 Ptah reads each selected project config once per command and converts it to a
 typed configuration value. Migration database settings and online-DDL policy
 therefore cannot come from different generations of a concurrently replaced
-`ptah.yaml`. An explicit `--config` path must exist; the conventional
-`./ptah.yaml` is optional.
+`ptah.yaml`. Atlas-compatible command adapters pass that same typed snapshot to
+the native command implementation instead of reopening either project file. An
+explicit `--config` path must exist; the conventional `./ptah.yaml` is optional.
 
 For Atlas-compatible commands, plain local schema paths, relative `file://`
 schema URLs, and relative `migration.dir` values declared in `atlas.hcl` resolve

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -34,9 +34,13 @@ and local `diff` policy defaults for the `ptah-compat` binary's commands.
 Ptah reads each selected project config once per command and converts it to a
 typed configuration value. Migration database settings and online-DDL policy
 therefore cannot come from different generations of a concurrently replaced
-`ptah.yaml`. Atlas-compatible command adapters pass that same typed snapshot to
-the native command implementation instead of reopening either project file. An
-explicit `--config` path must exist; the conventional `./ptah.yaml` is optional.
+`ptah.yaml`. When an Atlas-compatible adapter delegates to a native command
+that also consumes project configuration, the adapter passes the merged typed
+snapshot instead of letting that command reopen either project file. This
+currently applies to `migrate down`; other adapters evaluate Atlas project
+configuration once and map supported values to explicit native command
+arguments. An explicit `--config` path must exist; the conventional
+`./ptah.yaml` is optional.
 
 For Atlas-compatible commands, plain local schema paths, relative `file://`
 schema URLs, and relative `migration.dir` values declared in `atlas.hcl` resolve

--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -83,8 +83,14 @@ Expected output includes the verification pass before the real rollback:
 Database is now at version: 1785255952
 ```
 
-The shadow database must match the target dialect — an empty scratch database
-of the same engine, never a real environment.
+The shadow database must match the target dialect and identify a different
+database from `--db-url` — use an empty scratch database of the same engine,
+never a real environment. Ptah rejects equivalent URL aliases before connecting
+to or resetting the shadow database:
+
+```text
+rollback verification failed: shadow database must be distinct from target database
+```
 
 ## Choosing a target
 

--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -83,10 +83,12 @@ Expected output includes the verification pass before the real rollback:
 Database is now at version: 1785255952
 ```
 
-The shadow database must match the target dialect and identify a different
-database from `--db-url` — use an empty scratch database of the same engine,
-never a real environment. Ptah rejects equivalent URL aliases before connecting
-to or resetting the shadow database:
+The shadow database must match the target dialect and select a different live
+database or catalog from `--db-url` — use an empty scratch database of the same
+engine, never a real environment. Ptah first rejects equivalent URL aliases,
+then connects to the shadow and checks both live dialects and selected
+database/catalog names before resetting it. Equal live names fail closed even
+when the URLs use different hosts, driver overrides, or scheme spellings:
 
 ```text
 rollback verification failed: shadow database must be distinct from target database

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -273,7 +273,7 @@ func appendDefaultArgs(flags []Flag, args []string) []string {
 	out := args
 	cloned := false
 	for _, flag := range flags {
-		if flag.Default == "" || flagPresent(args, flag) {
+		if flag.Default == "" || flagPresent(args, flag) || nativeEnvironmentPresent(flag) {
 			continue
 		}
 		if !cloned {
@@ -283,6 +283,14 @@ func appendDefaultArgs(flags []Flag, args []string) []string {
 		out = append(out, "--"+flag.Name+"="+flag.Default)
 	}
 	return out
+}
+
+func nativeEnvironmentPresent(flag Flag) bool {
+	if flag.EnvDisabled || flag.NativeName == "" || flag.NativeName == flag.Name {
+		return false
+	}
+	value, ok := os.LookupEnv(envName("PTAH", flag.NativeName))
+	return ok && value != ""
 }
 
 func appendEnvArgs(flags []Flag, args []string) []string {

--- a/internal/atlasargs/args_test.go
+++ b/internal/atlasargs/args_test.go
@@ -192,6 +192,24 @@ func TestMap_HappyPathEnvFlagWinsOverStringDefault(t *testing.T) {
 	c.Assert(got, qt.DeepEquals, []string{"--dir-format=ptah"})
 }
 
+func TestMap_HappyPathNativeEnvFlagWinsOverAtlasStringDefault(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_MIGRATIONS_DIR", "/env/migrations")
+	flag := atlasargs.NativeStringDefault(
+		"dir",
+		"",
+		"Migration directory",
+		"migrations-dir",
+		"file://migrations",
+	)
+	flag.MapValue = atlasargs.LocalDirValue
+
+	got, err := atlasargs.Map("migrate", "test", []atlasargs.Flag{flag}, nil)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 0)
+}
+
 func TestMap_HappyPathSchemaCleanAutoApproveMapsToNativeFlag(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/devlock/lock.go
+++ b/internal/devlock/lock.go
@@ -5,6 +5,7 @@ package devlock
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net"
@@ -30,6 +31,33 @@ var errLocked = errors.New("dev database realm is locked")
 type Lock struct {
 	advisory *dblock.Lock
 	file     *os.File
+}
+
+// SameRealm reports whether two live connections select the same destructive
+// database realm. Network endpoints are intentionally excluded from the
+// identity: aliases and replicated members cannot be proven independent before
+// cleanup, so equal live database/catalog names fail closed across hosts.
+func SameRealm(
+	ctx context.Context,
+	left, right *dbschema.DatabaseConnection,
+) (bool, error) {
+	if left == nil || right == nil {
+		return false, errors.New("compare dev database realms requires two database connections")
+	}
+	leftDialect := platform.NormalizeDialect(left.Info().Dialect)
+	rightDialect := platform.NormalizeDialect(right.Info().Dialect)
+	if leftDialect != rightDialect {
+		return false, nil
+	}
+	leftIdentity, err := realmIdentity(ctx, left, leftDialect)
+	if err != nil {
+		return false, err
+	}
+	rightIdentity, err := realmIdentity(ctx, right, rightDialect)
+	if err != nil {
+		return false, err
+	}
+	return leftIdentity == rightIdentity, nil
 }
 
 // Acquire locks the selected disposable database realm. A zero timeout waits
@@ -117,29 +145,34 @@ func realmIdentity(
 	dialect string,
 ) (string, error) {
 	switch dialect {
-	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
-		var database string
-		if err := conn.QueryRowContext(ctx, "SELECT current_database()").Scan(&database); err != nil {
-			return "", fmt.Errorf("resolve %s dev database realm: %w", dialect, err)
-		}
-		return database, nil
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return selectedDatabase(ctx, conn, dialect, "SELECT current_database()")
 	case platform.SQLServer:
-		var database string
-		if err := conn.QueryRowContext(ctx, "SELECT DB_NAME()").Scan(&database); err != nil {
-			return "", fmt.Errorf("resolve sqlserver dev database realm: %w", err)
-		}
-		return database, nil
-	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
-		database := strings.TrimSpace(conn.Info().Schema)
-		if database == "" {
-			return "", fmt.Errorf("%s dev database realm has no selected database", dialect)
-		}
-		return database, nil
+		return selectedDatabase(ctx, conn, dialect, "SELECT DB_NAME()")
+	case platform.MySQL, platform.MariaDB:
+		return selectedDatabase(ctx, conn, dialect, "SELECT DATABASE()")
+	case platform.ClickHouse:
+		return selectedDatabase(ctx, conn, dialect, "SELECT currentDatabase()")
 	case platform.SQLite:
 		return sqliteIdentity(ctx, conn)
 	default:
 		return "", fmt.Errorf("unsupported dev database lock dialect %q", dialect)
 	}
+}
+
+func selectedDatabase(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	dialect, query string,
+) (string, error) {
+	var database sql.NullString
+	if err := conn.QueryRowContext(ctx, query).Scan(&database); err != nil {
+		return "", fmt.Errorf("resolve %s dev database realm: %w", dialect, err)
+	}
+	if !database.Valid || strings.TrimSpace(database.String) == "" {
+		return "", fmt.Errorf("%s dev database realm has no selected database", dialect)
+	}
+	return database.String, nil
 }
 
 func sqliteIdentity(

--- a/internal/devlock/lock_live_test.go
+++ b/internal/devlock/lock_live_test.go
@@ -2,15 +2,73 @@ package devlock_test
 
 import (
 	"context"
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/devlock"
 )
+
+func TestSameRealm_PostgresDriverURLOverridesLive(t *testing.T) {
+	c := qt.New(t)
+	targetURL := requireLiveRealmURL(c, "POSTGRES_TEST_DSN")
+	overrideURL := postgresDriverOverrideURL(c, targetURL)
+	targetConn, err := dbschema.ConnectToDatabase(c.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(targetConn)
+	overrideConn, err := dbschema.ConnectToDatabase(c.Context(), overrideURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(overrideConn)
+
+	same, err := devlock.SameRealm(c.Context(), targetConn, overrideConn)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(same, qt.IsTrue)
+}
+
+func TestSameRealm_NetworkDatabasesLive(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name           string
+		environmentKey string
+	}{
+		{name: "postgres", environmentKey: "POSTGRES_TEST_DSN"},
+		{name: "cockroachdb", environmentKey: "COCKROACHDB_URL"},
+		{name: "yugabytedb", environmentKey: "YUGABYTEDB_URL"},
+		{name: "mysql", environmentKey: "MYSQL_TEST_URL"},
+		{name: "mariadb", environmentKey: "MARIADB_TEST_URL"},
+		{name: "clickhouse", environmentKey: "CLICKHOUSE_URL"},
+		{name: "sqlserver", environmentKey: "PTAH_SQLSERVER_TEST_URL"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			databaseURL := requireLiveRealmURL(c, test.environmentKey)
+			firstConn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(firstConn)
+			})
+			secondConn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(secondConn)
+			})
+
+			same, err := devlock.SameRealm(c.Context(), firstConn, secondConn)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(same, qt.IsTrue)
+		})
+	}
+}
 
 func TestAcquire_CockroachDBSerializesSameRealmLive(t *testing.T) {
 	c := qt.New(t)
@@ -38,10 +96,33 @@ func TestAcquire_CockroachDBSerializesSameRealmLive(t *testing.T) {
 }
 
 func requireCockroachDBURL(c *qt.C) string {
+	return requireLiveRealmURL(c, "COCKROACHDB_URL")
+}
+
+func requireLiveRealmURL(c *qt.C, environmentKey string) string {
 	c.Helper()
-	databaseURL := os.Getenv("COCKROACHDB_URL")
+	databaseURL := os.Getenv(environmentKey)
 	if databaseURL == "" {
-		c.Skip("COCKROACHDB_URL is not set")
+		c.Skip(environmentKey + " is not set")
 	}
 	return databaseURL
+}
+
+func postgresDriverOverrideURL(c *qt.C, rawURL string) string {
+	c.Helper()
+	config, err := pgx.ParseConfig(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	if parsed.Scheme == "" {
+		c.Skip("POSTGRES_TEST_DSN is not a URL")
+	}
+	parsed.Host = "guard.invalid:1"
+	parsed.Path = "/ignored"
+	query := parsed.Query()
+	query.Set("host", config.Host)
+	query.Set("port", strconv.Itoa(int(config.Port)))
+	query.Set("database", config.Database)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
 }

--- a/internal/devlock/lock_test.go
+++ b/internal/devlock/lock_test.go
@@ -63,6 +63,40 @@ func TestAcquire_SQLiteSeparatesDifferentRealms(t *testing.T) {
 	c.Assert(firstLock.Release(), qt.IsNil)
 }
 
+func TestSameRealm_SQLite(t *testing.T) {
+	c := qt.New(t)
+	sharedURL := atlasurl.SQLiteURLFromPath(filepath.Join(t.TempDir(), "shared.db"))
+	firstConn, err := dbschema.ConnectToDatabase(t.Context(), sharedURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(firstConn)
+	secondConn, err := dbschema.ConnectToDatabase(t.Context(), sharedURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(secondConn)
+	distinctConn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		atlasurl.SQLiteURLFromPath(filepath.Join(t.TempDir(), "distinct.db")),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(distinctConn)
+
+	same, err := devlock.SameRealm(t.Context(), firstConn, secondConn)
+	c.Assert(err, qt.IsNil)
+	c.Assert(same, qt.IsTrue)
+
+	same, err = devlock.SameRealm(t.Context(), firstConn, distinctConn)
+	c.Assert(err, qt.IsNil)
+	c.Assert(same, qt.IsFalse)
+}
+
+func TestSameRealm_FailurePathRequiresConnections(t *testing.T) {
+	c := qt.New(t)
+
+	same, err := devlock.SameRealm(t.Context(), nil, nil)
+
+	c.Assert(err, qt.ErrorMatches, `compare dev database realms requires two database connections`)
+	c.Assert(same, qt.IsFalse)
+}
+
 func TestAcquire_SQLiteSerializesHardLinkAliases(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/migration/generator/rollback_shadow.go
+++ b/migration/generator/rollback_shadow.go
@@ -7,11 +7,15 @@ import (
 	"time"
 
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // RollbackFromShadowOptions configures VerifyRollbackFromShadow.
 type RollbackFromShadowOptions struct {
+	// TargetDatabaseURL identifies the database the verified rollback would
+	// eventually modify. It must be distinct from ShadowDatabaseURL.
+	TargetDatabaseURL string
 	// ShadowDatabaseURL is an ephemeral database the verification drops clean
 	// and replays the migration directory into. Its contents are discarded.
 	ShadowDatabaseURL string
@@ -44,8 +48,18 @@ func VerifyRollbackFromShadow(ctx context.Context, opts RollbackFromShadowOption
 	if opts.ShadowDatabaseURL == "" {
 		return fmt.Errorf("rollback verification failed: a shadow database URL is required")
 	}
+	if opts.TargetDatabaseURL == "" {
+		return fmt.Errorf("rollback verification failed: a target database URL is required")
+	}
 	if opts.FS == nil {
 		return fmt.Errorf("rollback verification failed: a migration filesystem is required")
+	}
+	sameDatabase, err := atlasurl.SameDatabase(opts.TargetDatabaseURL, opts.ShadowDatabaseURL)
+	if err != nil {
+		return fmt.Errorf("rollback verification failed: compare target and shadow databases: %w", err)
+	}
+	if sameDatabase {
+		return fmt.Errorf("rollback verification failed: shadow database must be distinct from target database")
 	}
 
 	connectCtx, cancelConnect := baselineShadowConnectContext(ctx, opts.ConnectTimeout)

--- a/migration/generator/rollback_shadow.go
+++ b/migration/generator/rollback_shadow.go
@@ -8,22 +8,21 @@ import (
 
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasurl"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
 // RollbackFromShadowOptions configures VerifyRollbackFromShadow.
 type RollbackFromShadowOptions struct {
-	// TargetDatabaseURL identifies the database the verified rollback would
-	// eventually modify. It must be distinct from ShadowDatabaseURL.
-	TargetDatabaseURL string
+	// TargetConnection is the already-open database the verified rollback
+	// would eventually modify. Its live realm must be distinct from the shadow
+	// database.
+	TargetConnection *dbschema.DatabaseConnection
 	// ShadowDatabaseURL is an ephemeral database the verification drops clean
 	// and replays the migration directory into. Its contents are discarded.
 	ShadowDatabaseURL string
 	// FS is the migration filesystem whose rollback plan is verified.
 	FS fs.FS
-	// Dialect, when set, must match the shadow database dialect so the verified
-	// SQL is the SQL the target would execute.
-	Dialect string
 	// CurrentVersion is the target database's current migration version. The
 	// shadow database is migrated up to it before the rollback is replayed.
 	CurrentVersion int64
@@ -48,13 +47,16 @@ func VerifyRollbackFromShadow(ctx context.Context, opts RollbackFromShadowOption
 	if opts.ShadowDatabaseURL == "" {
 		return fmt.Errorf("rollback verification failed: a shadow database URL is required")
 	}
-	if opts.TargetDatabaseURL == "" {
-		return fmt.Errorf("rollback verification failed: a target database URL is required")
+	if opts.TargetConnection == nil {
+		return fmt.Errorf("rollback verification failed: a target database connection is required")
 	}
 	if opts.FS == nil {
 		return fmt.Errorf("rollback verification failed: a migration filesystem is required")
 	}
-	sameDatabase, err := atlasurl.SameDatabase(opts.TargetDatabaseURL, opts.ShadowDatabaseURL)
+	sameDatabase, err := atlasurl.SameDatabase(
+		opts.TargetConnection.Info().URL,
+		opts.ShadowDatabaseURL,
+	)
 	if err != nil {
 		return fmt.Errorf("rollback verification failed: compare target and shadow databases: %w", err)
 	}
@@ -70,12 +72,19 @@ func VerifyRollbackFromShadow(ctx context.Context, opts RollbackFromShadowOption
 	}
 	defer dbschema.CloseAndWarn(shadowConn)
 
-	if opts.Dialect != "" && !sameDialect(opts.Dialect, shadowConn.Info().Dialect) {
+	if !sameDialect(opts.TargetConnection.Info().Dialect, shadowConn.Info().Dialect) {
 		return fmt.Errorf(
 			"rollback verification failed: shadow database dialect %q does not match target dialect %q",
 			shadowConn.Info().Dialect,
-			opts.Dialect,
+			opts.TargetConnection.Info().Dialect,
 		)
+	}
+	sameDatabase, err = devlock.SameRealm(ctx, opts.TargetConnection, shadowConn)
+	if err != nil {
+		return fmt.Errorf("rollback verification failed: compare live target and shadow database realms: %w", err)
+	}
+	if sameDatabase {
+		return fmt.Errorf("rollback verification failed: shadow database must be distinct from target database")
 	}
 
 	if err := shadowConn.SchemaWriter().DropAllTables(ctx); err != nil {

--- a/migration/generator/rollback_shadow_test.go
+++ b/migration/generator/rollback_shadow_test.go
@@ -8,6 +8,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/migration/generator"
 )
 
@@ -28,6 +29,7 @@ func TestVerifyRollbackFromShadow_HappyPathReplaysUpThenDown(t *testing.T) {
 	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN email;\n")
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
 		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
 		FS:                os.DirFS(dir),
 		Dialect:           "sqlite",
@@ -44,6 +46,7 @@ func TestVerifyRollbackFromShadow_FailurePathBrokenDownMigrationReported(t *test
 	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN no_such_column;\n")
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
 		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
 		FS:                os.DirFS(dir),
 		Dialect:           "sqlite",
@@ -62,6 +65,7 @@ func TestVerifyRollbackFromShadow_FailurePathDialectMismatch(t *testing.T) {
 	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN email;\n")
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
 		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
 		FS:                os.DirFS(dir),
 		Dialect:           "postgres",
@@ -76,12 +80,53 @@ func TestVerifyRollbackFromShadow_FailurePathValidatesInputs(t *testing.T) {
 	c := qt.New(t)
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		FS: os.DirFS(t.TempDir()),
+		TargetDatabaseURL: "sqlite://target.db",
+		FS:                os.DirFS(t.TempDir()),
 	})
 	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a shadow database URL is required`)
 
 	err = generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		ShadowDatabaseURL: "sqlite://shadow.db",
+		FS:                os.DirFS(t.TempDir()),
+	})
+	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a target database URL is required`)
+
+	err = generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: "sqlite://target.db",
 		ShadowDatabaseURL: "sqlite://ignored.db",
 	})
 	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a migration filesystem is required`)
+}
+
+func TestVerifyRollbackFromShadow_FailurePathRejectsTargetAliasBeforeReset(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	databasePath := filepath.Join(dir, "target.db")
+	targetURL := "sqlite://" + databasePath
+	shadowAliasURL := "sqlite://" + filepath.Join(dir, ".", "target.db") + "?mode=rwc"
+
+	targetConn, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	_, err = targetConn.Exec("CREATE TABLE protected_target (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	c.Assert(targetConn.Close(), qt.IsNil)
+
+	err = generator.VerifyRollbackFromShadow(ctx, generator.RollbackFromShadowOptions{
+		TargetDatabaseURL: targetURL,
+		ShadowDatabaseURL: shadowAliasURL,
+		FS:                os.DirFS(t.TempDir()),
+		Dialect:           "sqlite",
+	})
+
+	c.Check(err, qt.ErrorMatches, `rollback verification failed: shadow database must be distinct from target database`)
+	targetConn, err = dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	var protectedTableCount int
+	err = targetConn.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'protected_target'",
+	).Scan(&protectedTableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(protectedTableCount, qt.Equals, 1)
+	c.Assert(targetConn.Close(), qt.IsNil)
 }

--- a/migration/generator/rollback_shadow_test.go
+++ b/migration/generator/rollback_shadow_test.go
@@ -2,13 +2,17 @@ package generator_test
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/migration/generator"
 )
 
@@ -23,16 +27,29 @@ func writeRollbackShadowMigrations(c *qt.C, dir string, downSQL string) {
 	write("0000000002_add_email.down.sql", downSQL)
 }
 
+func openRollbackTarget(c *qt.C, rawURL string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(c.Context(), rawURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		dbschema.CloseAndWarn(conn)
+	})
+	return conn
+}
+
 func TestVerifyRollbackFromShadow_HappyPathReplaysUpThenDown(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN email;\n")
+	targetConn := openRollbackTarget(
+		c,
+		"sqlite://"+filepath.Join(t.TempDir(), "target.db"),
+	)
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
+		TargetConnection:  targetConn,
 		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
 		FS:                os.DirFS(dir),
-		Dialect:           "sqlite",
 		CurrentVersion:    2,
 		TargetVersion:     1,
 	})
@@ -44,12 +61,15 @@ func TestVerifyRollbackFromShadow_FailurePathBrokenDownMigrationReported(t *test
 	c := qt.New(t)
 	dir := t.TempDir()
 	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN no_such_column;\n")
+	targetConn := openRollbackTarget(
+		c,
+		"sqlite://"+filepath.Join(t.TempDir(), "target.db"),
+	)
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
+		TargetConnection:  targetConn,
 		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
 		FS:                os.DirFS(dir),
-		Dialect:           "sqlite",
 		CurrentVersion:    2,
 		TargetVersion:     1,
 	})
@@ -59,29 +79,13 @@ func TestVerifyRollbackFromShadow_FailurePathBrokenDownMigrationReported(t *test
 	c.Assert(err, qt.ErrorMatches, `(?s)rollback verification failed: roll back to version 1 on shadow database: failed to revert migration 2: .*no_such_column.*`)
 }
 
-func TestVerifyRollbackFromShadow_FailurePathDialectMismatch(t *testing.T) {
-	c := qt.New(t)
-	dir := t.TempDir()
-	writeRollbackShadowMigrations(c, dir, "ALTER TABLE users DROP COLUMN email;\n")
-
-	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "target.db"),
-		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
-		FS:                os.DirFS(dir),
-		Dialect:           "postgres",
-		CurrentVersion:    2,
-		TargetVersion:     1,
-	})
-
-	c.Assert(err, qt.ErrorMatches, `rollback verification failed: shadow database dialect "sqlite" does not match target dialect "postgres"`)
-}
-
 func TestVerifyRollbackFromShadow_FailurePathValidatesInputs(t *testing.T) {
 	c := qt.New(t)
+	targetConn := openRollbackTarget(c, "sqlite://"+filepath.Join(t.TempDir(), "target.db"))
 
 	err := generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: "sqlite://target.db",
-		FS:                os.DirFS(t.TempDir()),
+		TargetConnection: targetConn,
+		FS:               os.DirFS(t.TempDir()),
 	})
 	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a shadow database URL is required`)
 
@@ -89,10 +93,10 @@ func TestVerifyRollbackFromShadow_FailurePathValidatesInputs(t *testing.T) {
 		ShadowDatabaseURL: "sqlite://shadow.db",
 		FS:                os.DirFS(t.TempDir()),
 	})
-	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a target database URL is required`)
+	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a target database connection is required`)
 
 	err = generator.VerifyRollbackFromShadow(context.Background(), generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: "sqlite://target.db",
+		TargetConnection:  targetConn,
 		ShadowDatabaseURL: "sqlite://ignored.db",
 	})
 	c.Assert(err, qt.ErrorMatches, `rollback verification failed: a migration filesystem is required`)
@@ -108,25 +112,103 @@ func TestVerifyRollbackFromShadow_FailurePathRejectsTargetAliasBeforeReset(t *te
 
 	targetConn, err := dbschema.ConnectToDatabase(ctx, targetURL)
 	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(targetConn)
 	_, err = targetConn.Exec("CREATE TABLE protected_target (id INTEGER PRIMARY KEY)")
 	c.Assert(err, qt.IsNil)
-	c.Assert(targetConn.Close(), qt.IsNil)
 
 	err = generator.VerifyRollbackFromShadow(ctx, generator.RollbackFromShadowOptions{
-		TargetDatabaseURL: targetURL,
+		TargetConnection:  targetConn,
 		ShadowDatabaseURL: shadowAliasURL,
 		FS:                os.DirFS(t.TempDir()),
-		Dialect:           "sqlite",
 	})
 
 	c.Check(err, qt.ErrorMatches, `rollback verification failed: shadow database must be distinct from target database`)
-	targetConn, err = dbschema.ConnectToDatabase(ctx, targetURL)
-	c.Assert(err, qt.IsNil)
 	var protectedTableCount int
 	err = targetConn.QueryRow(
 		"SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'protected_target'",
 	).Scan(&protectedTableCount)
 	c.Assert(err, qt.IsNil)
 	c.Assert(protectedTableCount, qt.Equals, 1)
-	c.Assert(targetConn.Close(), qt.IsNil)
+}
+
+func TestVerifyRollbackFromShadow_FailurePathRejectsLiveDialectMismatch(t *testing.T) {
+	c := qt.New(t)
+	targetConn := openRollbackTarget(c, requireRollbackPostgresURL(c))
+
+	err := generator.VerifyRollbackFromShadow(c.Context(), generator.RollbackFromShadowOptions{
+		TargetConnection:  targetConn,
+		ShadowDatabaseURL: "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
+		FS:                os.DirFS(t.TempDir()),
+	})
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`rollback verification failed: shadow database dialect "sqlite" does not match target dialect "postgres"`,
+	)
+}
+
+func TestVerifyRollbackFromShadow_FailurePathRejectsDriverOverrideAliasLive(t *testing.T) {
+	c := qt.New(t)
+	targetURL := rollbackPostgresDatabaseURL(
+		c,
+		requireRollbackPostgresURL(c),
+		"postgres",
+	)
+	shadowURL := rollbackPostgresDriverOverrideURL(c, targetURL)
+	targetConn := openRollbackTarget(c, targetURL)
+	fastPathSame, err := atlasurl.SameDatabase(targetURL, shadowURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fastPathSame, qt.IsFalse)
+
+	err = generator.VerifyRollbackFromShadow(c.Context(), generator.RollbackFromShadowOptions{
+		TargetConnection:  targetConn,
+		ShadowDatabaseURL: shadowURL,
+		FS:                os.DirFS(t.TempDir()),
+	})
+
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`rollback verification failed: shadow database must be distinct from target database`,
+	)
+}
+
+func requireRollbackPostgresURL(c *qt.C) string {
+	c.Helper()
+	rawURL := os.Getenv("POSTGRES_TEST_DSN")
+	if rawURL == "" {
+		c.Skip("POSTGRES_TEST_DSN is not set")
+	}
+	return rawURL
+}
+
+func rollbackPostgresDatabaseURL(c *qt.C, rawURL, database string) string {
+	c.Helper()
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	if parsed.Scheme == "" {
+		c.Skip("POSTGRES_TEST_DSN is not a URL")
+	}
+	parsed.Path = "/" + database
+	query := parsed.Query()
+	query.Set("database", database)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+func rollbackPostgresDriverOverrideURL(c *qt.C, rawURL string) string {
+	c.Helper()
+	config, err := pgx.ParseConfig(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Host = "guard.invalid:1"
+	parsed.Path = "/ignored"
+	query := parsed.Query()
+	query.Set("host", config.Host)
+	query.Set("port", strconv.Itoa(int(config.Port)))
+	query.Set("database", config.Database)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
 }


### PR DESCRIPTION
## Summary

- evaluate Atlas and Ptah project configuration once before forwarding to the native command
- carry a deep-cloned immutable snapshot with the executing child context and restore reused command trees after every run
- preserve CLI/environment precedence and distinct Atlas-relative versus Ptah working-directory path semantics
- reset project-selection flags across execution, root/group help, completion, flag parsing, positional validation, required-flag validation, and flag-group validation
- refresh direct Atlas child contexts on every reused `ExecuteContext` call
- wire configured dev URLs into native rollback verification
- reject lexical target/dev aliases before connection and reject equal live dialect/database realms before destructive reset

## Review findings addressed

- added a real mapper-boundary test that replaces both `ptah.yaml` and `atlas.hcl` after mapping and proves native code consumes the original snapshot
- added root-reuse regressions for root/group help, root/child argument failures, Cobra flag-group failures, generated `__complete`, and changed environment values
- added repeated `ExecuteContext` regressions for forwarded and direct Atlas commands
- made rollback verification require the already-open target connection instead of trusting an optional caller-supplied dialect
- added fail-closed live realm comparison across PostgreSQL, CockroachDB, YugabyteDB, MySQL, MariaDB, ClickHouse, SQL Server, and SQLite
- changed MySQL, MariaDB, and ClickHouse realm locking to query the selected database live instead of trusting URL-derived metadata
- added a protected-PostgreSQL pgx `host`/`port`/`database` override regression that reaches the live guard without risking destructive cleanup
- wired every new live test explicitly into the database-realm integration job
- documented destructive reset behavior, live identity checks, and the distinct-database requirement

## Verification completed

- `go test ./...` outside the macOS sandbox
- `go test -race ./migration/generator ./internal/devlock ./cmd/atlas ./cmd/migratedown`
- local live realm matrix: PostgreSQL, CockroachDB, YugabyteDB, MySQL, MariaDB, ClickHouse, and SQL Server
- local live generator guards: pgx driver override alias and target/shadow dialect mismatch
- `gopls check` on every edited Go file
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- `scripts/check-public-api-released.sh`
- docs link, redirect, core-link, page-health, exit-code, and versions checks
- `npm run build`
- `npm audit --audit-level=low` (0 vulnerabilities)
- built `ptah-compat`; applied two SQLite migrations, verified and rolled them back through a distinct dev database, then proved a target URL alias is rejected with the target still at version 2
- two fresh independent final diff reviews: CLEAN / CLEAN

## Remaining draft gates

- wait for every GitHub Actions check on `a3aef4e` and address every failure
- inspect and address every review thread on the current head

## Public API rationale

`RollbackFromShadowOptions.Dialect` is intentionally removed relative to v0.1.1 and recorded in `docs/public_api_approvals.txt`. Ptah is pre-v1, and retaining an optional caller-supplied dialect would preserve the unsafe gap: an empty value skipped the only target/shadow dialect check. The replacement requires the existing open target `dbschema.DatabaseConnection`, derives the live dialect from it, and compares both live database realms before reset. `TargetDatabaseURL`, introduced only on this branch, is replaced by the same connection rather than released as a second source of truth.

## Documentation impact

Updated the canonical project-config and public-API references, the dev/shadow database concept page, the native rollback how-to, and the Atlas-compatible migration workflow. The docs now distinguish the lexical URL precheck from the mandatory live dialect/database-realm check before reset. No reader-facing page was added, moved, split, or retired, so the content inventory does not change.

## Security note

The workspace vulnerability scan still reports the pre-existing `GO-2026-5932` OpenPGP finding. This PR changes no dependencies and introduces no new vulnerability finding.

Closes #889
