### PR TITLE
Skip Homebrew upload when no tap token is configured

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -176,6 +176,12 @@ brews:
       owner: stokaro
       name: homebrew-ptah
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    # The formula is always generated, but publishing it needs the tap
+    # repository and a token that can push to it. Without HOMEBREW_TAP_TOKEN
+    # the upload is skipped instead of failing the whole release.
+    # index, not .Env.X: the snapshot job does not define the variable at all,
+    # and .Env.X errors on a missing key while index yields an empty string.
+    skip_upload: '{{ if index .Env "HOMEBREW_TAP_TOKEN" }}false{{ else }}true{{ end }}'
     directory: Formula
     homepage: "https://github.com/stokaro/ptah"
     description: "Schema management and migration tooling for Go projects"

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -4,8 +4,10 @@ Ptah releases are produced by GoReleaser from annotated version tags.
 
 ## Prerequisites
 
-- `HOMEBREW_TAP_TOKEN` repository secret with permission to push to
-  `stokaro/homebrew-ptah`.
+- Optional, for Homebrew publishing: the `stokaro/homebrew-ptah` tap repository
+  and a `HOMEBREW_TAP_TOKEN` repository secret that can push to it. Neither
+  exists yet, so the formula is generated and its upload is skipped; the rest of
+  the release publishes normally. Create both to start shipping the tap.
 - GitHub Actions package permissions enabled for publishing
   `ghcr.io/stokaro/ptah`.
 - GoReleaser `v2.15.4`. The GitHub Actions workflow pins this version because
@@ -26,24 +28,35 @@ Ptah releases are produced by GoReleaser from annotated version tags.
    goreleaser release --snapshot --clean --skip=sign,docker
    ```
 
-3. Create and push an annotated semver tag:
+3. Create and push an annotated semver tag. Never move or delete a pushed tag;
+   if a release run fails, fix the cause and cut the next patch version:
 
    ```bash
-   git tag -a v0.1.0 -m "Release v0.1.0"
-   git push origin v0.1.0
+   git tag -a v0.1.2 -m "Release v0.1.2"
+   git push origin v0.1.2
    ```
 
 4. Wait for the `Release` workflow to finish.
 5. Verify the GitHub Release contains archives for Linux, macOS, and Windows,
-   `checksums.txt`, SBOM artifacts, and cosign signature/certificate files.
+   the source archive, `checksums.txt`, SBOM artifacts, and one
+   `<artifact>.sigstore.json` cosign bundle per checksum and SBOM file. Verify a
+   bundle:
+
+   ```bash
+   cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt \
+     --certificate-identity-regexp 'github.com/stokaro/ptah' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+   ```
+
 6. Verify the container images exist:
 
    ```bash
-   docker pull ghcr.io/stokaro/ptah:v0.1.0
+   docker pull ghcr.io/stokaro/ptah:0.1.2
    docker pull ghcr.io/stokaro/ptah:latest
    ```
 
-7. Verify Homebrew install:
+7. Verify the Homebrew install, once the tap repository and
+   `HOMEBREW_TAP_TOKEN` exist (until then the formula upload is skipped):
 
    ```bash
    brew update


### PR DESCRIPTION
The **v0.1.1 release published successfully** — 6 platform archives (each carrying `ptah`, `ptah-ls`, `ptah-compat`), the source archive, `checksums.txt`, SBOMs, one `.sigstore.json` cosign bundle per checksum/SBOM (23 assets), plus `ghcr.io/stokaro/ptah:0.1.1-amd64/-arm64` with the `0.1.1` and `latest` manifests. The run then went red on the very last step: `homebrew formula: could not get default branch: GET .../stokaro/homebrew-ptah: 401 Bad credentials` — neither the tap repository nor the `HOMEBREW_TAP_TOKEN` secret exists.

Changes:
- `.goreleaser.yaml`: the formula is still generated, but its upload is skipped unless `HOMEBREW_TAP_TOKEN` is set, so a missing tap cannot fail an otherwise complete release. Creating the tap plus the secret turns publishing back on with no further config change.
- `docs/release_process.md`: the tap is documented as an **optional** prerequisite with its current state; the verification step now describes the cosign v3 `.sigstore.json` bundles (with a `cosign verify-blob --bundle` command) instead of the old signature/certificate pair; example tag and `docker pull` versions refreshed; added the rule that a pushed tag is never moved or deleted — a failed run is followed by the next patch version.

`goreleaser check` validates with an empty token; `go build ./...` and the docs-site link check pass.