### PR TITLE
Approve the v0.1.2 public API baseline for migration/generator

### DIFF
--- a/docs/public_api_approvals.txt
+++ b/docs/public_api_approvals.txt
@@ -8,3 +8,4 @@
 # compatibility rationale and update docs/public_api.md when the stable package
 # set changes.
 v0.1.1 github.com/stokaro/ptah/migration/generator
+v0.1.2 github.com/stokaro/ptah/migration/generator


### PR DESCRIPTION
Fixes the `Go Lint` failure on `master` ([run 30527083466](https://github.com/stokaro/ptah/actions/runs/30527083466/job/90820417547)):

```
- RollbackFromShadowOptions.Dialect: removed

Public API incompatibilities detected against baseline v0.1.2.
If the change is intentional before v1, add a reviewed approval in docs/public_api_approvals.txt and explain the rationale in the PR.
```

## Cause

#890 replaced `RollbackFromShadowOptions.Dialect string` with
`TargetConnection *dbschema.DatabaseConnection`, so `VerifyRollbackFromShadow` checks the target
and shadow's **live** dialects and selected database realms rather than trusting a caller-supplied
dialect or a URL-derived database name. That is a deliberate safety improvement and
`docs/public_api.md` already documents it:

> `migration/generator.VerifyRollbackFromShadow` requires the caller's open target
> `dbschema.DatabaseConnection`. It checks the target and shadow's live dialects and selected
> database realms before resetting the shadow, rather than trusting a caller-supplied dialect or
> URL-derived database name.

What #890 missed is that `docs/public_api_approvals.txt` is keyed by baseline tag. The package
already carries an approval against `v0.1.1`, but `scripts/check-public-api-released.sh` resolves
its baseline to the newest `v0.*` tag — now `v0.1.2` — so the older entry no longer matches and the
break is reported as unapproved.

## Fix

Restate the existing approval against the current baseline. No code change; the public API is
intentionally what #890 made it.

## Verification

Run locally against `origin/master` + this change:

- `scripts/check-public-api-released.sh` → exit 0
  (`approved pre-v1 public API incompatibility: github.com/stokaro/ptah/migration/generator against v0.1.2`)
- `scripts/check-public-api.sh` → exit 0
- `scripts/check-public-api-snapshot.sh` → exit 0
- annotation JSON Schema freshness → no diff
- `go tool qtlint ./...` → exit 0
- `scripts/check-test-style.sh` → `teststyle: OK (180 conditional groups, 47 white-box files)`
- `go test ./cmd/lint -run TestRunLint_SARIF -count=1` → ok
- `golangci-lint run --timeout=30m` (v2.12.2, the pinned version) → `0 issues.`

The job aborted at the released-baseline step, so every later step was unrun on master; all of them
are checked above.

## Follow-up worth considering

The `v0.1.1` entry is now inert — the script only ever matches the newest `v0.*` tag — so this file
grows one dead line per release for as long as the API stays divergent from its baseline. Either
pruning stale entries on release or noting the per-baseline requirement in the file header would
stop the same failure from recurring on the next `v0.x` tag.