### PR TITLE
test(schema): add Go-to-HCL process acceptance

### DIFF
--- a/.github/workflows/export-acceptance.yml
+++ b/.github/workflows/export-acceptance.yml
@@ -10,6 +10,11 @@ name: Export Acceptance
 # builds, and must be byte-identical when regenerated. WIRE_JSON checks cover
 # additive changes, reordering, reserved field removals, tombstones, and an
 # intentionally incompatible type change.
+#
+# Go annotation to HCL export acceptance (issue #898) runs through the compiled
+# binary, checks deterministic output, consumes the generated HCL through
+# `schema render`, and verifies preview, destructive, and repeated cleanup
+# behavior.
 on:
   push:
     branches:
@@ -57,3 +62,6 @@ jobs:
 
       - name: Protobuf acceptance
         run: bash scripts/check-protobuf-export-acceptance.sh
+
+      - name: Go annotation to HCL acceptance
+        run: bash scripts/check-hcl-export-acceptance.sh

--- a/core/goschema/embedded_overrides_test.go
+++ b/core/goschema/embedded_overrides_test.go
@@ -13,13 +13,11 @@ func TestParseSource_EmbeddedPlatformOverridesReachConcreteFields(t *testing.T) 
 	source := `
 package models
 
-//ptah:schema:embed
 type Audit struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" platform.mysql.type="DATETIME"
 	CreatedAt string
 }
 
-//ptah:schema:embed
 type AuditEnvelope struct {
 	//ptah:embedded mode="inline" prefix="inner_" platform.mysql.type="DATETIME(3)"
 	Audit

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -1190,7 +1190,6 @@ func TestParseFS_EmbeddedFields(t *testing.T) {
 			files: map[string]string{
 				"models.go": `package models
 
-//ptah:schema:embed
 type BaseModel struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null="true"
 	CreatedAt string

--- a/examples/annotation_parser/models/embedded_example.go
+++ b/examples/annotation_parser/models/embedded_example.go
@@ -8,7 +8,6 @@ import (
 // Example demonstrating embedded field functionality
 
 // Embedded types
-//
 type Timestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`

--- a/examples/annotation_parser/models/embedded_example.go
+++ b/examples/annotation_parser/models/embedded_example.go
@@ -9,7 +9,6 @@ import (
 
 // Embedded types
 //
-//ptah:schema:embed
 type Timestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null="true" default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`
@@ -18,7 +17,6 @@ type Timestamps struct {
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-//ptah:schema:embed
 type AuditInfo struct {
 	//ptah:schema:field name="by" type="TEXT"
 	By string `db:"by"`
@@ -27,7 +25,6 @@ type AuditInfo struct {
 	Reason string `db:"reason"`
 }
 
-//ptah:schema:embed
 type Meta struct {
 	Author string
 	Source string

--- a/internal/goannotationexport/testdata/parity/models.go
+++ b/internal/goannotationexport/testdata/parity/models.go
@@ -18,7 +18,6 @@ type PostalAddress struct{}
 //ptah:schema:range name="price_range" schema="app" subtype="NUMERIC" subtype_opclass="numeric_ops" collation="C" canonical="canonical_price" subtype_diff="numeric_subdiff" comment="Price interval"
 type PriceRange struct{}
 
-//ptah:schema:embed
 type Audit struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMPTZ" not_null="true" platform.mysql.type="DATETIME"
 	CreatedAt string

--- a/scripts/check-hcl-export-acceptance.sh
+++ b/scripts/check-hcl-export-acceptance.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ptah_bin="${PTAH_BIN:-$repo_root/bin/ptah}"
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/ptah-hcl-export-acceptance.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+if [[ ! -x "$ptah_bin" ]]; then
+	printf 'ptah binary is not executable: %s\n' "$ptah_bin" >&2
+	exit 1
+fi
+
+fixture_root="$repo_root/internal/goannotationexport/testdata/parity"
+export_root="$workspace/export-models"
+cleanup_root="$workspace/cleanup-models"
+schema_file="$workspace/schema.hcl"
+
+cp -R "$fixture_root" "$export_root"
+"$ptah_bin" schema export \
+	--from go \
+	--to hcl \
+	--root-dir "$export_root" \
+	--out "$schema_file"
+
+cp "$schema_file" "$workspace/schema.first.hcl"
+"$ptah_bin" schema export \
+	--from go \
+	--to hcl \
+	--root-dir "$export_root" \
+	--out "$schema_file"
+cmp "$workspace/schema.first.hcl" "$schema_file"
+
+"$ptah_bin" schema render \
+	--schema-file "$schema_file" \
+	--dialect postgres \
+	>"$workspace/schema.sql"
+
+required_sql=(
+	'CREATE TABLE "app"."users"'
+	'CREATE SEQUENCE IF NOT EXISTS "app"."order_seq"'
+	'CREATE DOMAIN "app"."email_address"'
+	'CREATE TYPE "app"."postal_address"'
+	'CREATE OR REPLACE FUNCTION "app"."lookup_user"'
+	'CREATE MATERIALIZED VIEW "app"."user_stats"'
+	'CREATE POLICY "users_policy"'
+	'GRANT SELECT, INSERT ON TABLE "app"."users"'
+	'CREATE TRIGGER "users_touch"'
+)
+for statement in "${required_sql[@]}"; do
+	if ! grep -Fq "$statement" "$workspace/schema.sql"; then
+		printf 'rendered HCL is missing expected SQL: %s\n' "$statement" >&2
+		exit 1
+	fi
+done
+
+cp -R "$fixture_root" "$cleanup_root"
+cp "$cleanup_root/models.go" "$workspace/models.before.go"
+"$ptah_bin" schema export \
+	--from go \
+	--to hcl \
+	--root-dir "$cleanup_root" \
+	--out "$workspace/cleanup.hcl" \
+	--cleanup-go-annotations \
+	--cleanup-diff \
+	>"$workspace/cleanup.diff"
+cmp "$workspace/models.before.go" "$cleanup_root/models.go"
+grep -Fq -- '-//ptah:schema:table' "$workspace/cleanup.diff"
+grep -Fq -- '-	//ptah:embedded' "$workspace/cleanup.diff"
+
+"$ptah_bin" schema export \
+	--from go \
+	--to hcl \
+	--root-dir "$cleanup_root" \
+	--out "$workspace/cleanup.hcl" \
+	--cleanup-go-annotations \
+	>"$workspace/cleanup.out"
+
+if grep -Rq --include='*.go' '//ptah:' "$cleanup_root"; then
+	printf 'destructive cleanup left Ptah annotations in Go source\n' >&2
+	exit 1
+fi
+grep -Fq 'package parity' "$cleanup_root/models.go"
+grep -Fq 'type User struct {' "$cleanup_root/models.go"
+grep -Fq 'Email string' "$cleanup_root/models.go"
+grep -Fq 'type UserData struct{}' "$cleanup_root/models.go"
+
+cp "$workspace/cleanup.hcl" "$workspace/cleanup.before-repeat.hcl"
+cp "$cleanup_root/models.go" "$workspace/models.before-repeat.go"
+if "$ptah_bin" schema export \
+	--from go \
+	--to hcl \
+	--root-dir "$cleanup_root" \
+	--out "$workspace/cleanup.hcl" \
+	--cleanup-go-annotations \
+	>"$workspace/repeat.out" \
+	2>"$workspace/repeat.err"; then
+	printf 'repeated destructive cleanup unexpectedly succeeded\n' >&2
+	exit 1
+fi
+grep -Fq 'no Ptah Go annotations found to export and clean' "$workspace/repeat.err"
+cmp "$workspace/cleanup.before-repeat.hcl" "$workspace/cleanup.hcl"
+cmp "$workspace/models.before-repeat.go" "$cleanup_root/models.go"
+
+printf 'Go annotation to HCL export acceptance: OK\n'

--- a/stubs/embedded.go
+++ b/stubs/embedded.go
@@ -17,7 +17,6 @@ type EmbeddedExample struct {
 
 // Embedded type definitions
 //
-//ptah:schema:embed
 type Timestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`
@@ -26,7 +25,6 @@ type Timestamps struct {
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-//ptah:schema:embed
 type AuditInfo struct {
 	//ptah:schema:field name="by" type="TEXT"
 	By string `db:"by"`
@@ -35,7 +33,6 @@ type AuditInfo struct {
 	Reason string `db:"reason"`
 }
 
-//ptah:schema:embed
 type Meta struct {
 	Author string
 	Source string

--- a/stubs/embedded.go
+++ b/stubs/embedded.go
@@ -16,7 +16,6 @@ type EmbeddedExample struct {
 }
 
 // Embedded type definitions
-//
 type Timestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`

--- a/stubs/simplified_syntax.go
+++ b/stubs/simplified_syntax.go
@@ -59,7 +59,6 @@ type SimplifiedPost struct {
 var _ = SimplifiedPost{}
 
 // Embedded types with simplified syntax
-//
 type SimpleTimestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`

--- a/stubs/simplified_syntax.go
+++ b/stubs/simplified_syntax.go
@@ -60,7 +60,6 @@ var _ = SimplifiedPost{}
 
 // Embedded types with simplified syntax
 //
-//ptah:schema:embed
 type SimpleTimestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt time.Time `db:"created_at"`
@@ -69,7 +68,6 @@ type SimpleTimestamps struct {
 	UpdatedAt *time.Time `db:"updated_at"`
 }
 
-//ptah:schema:embed
 type SimpleAudit struct {
 	//ptah:schema:field name="created_by" type="VARCHAR(100)"
 	CreatedBy *string `db:"created_by"`

--- a/stubs/syntax_comparison.go
+++ b/stubs/syntax_comparison.go
@@ -60,7 +60,6 @@ type MixedSyntaxPost struct {
 }
 
 // EMBEDDED FIELDS WITH SIMPLIFIED SYNTAX
-//
 type ModernTimestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt string `db:"created_at"`

--- a/stubs/syntax_comparison.go
+++ b/stubs/syntax_comparison.go
@@ -61,7 +61,6 @@ type MixedSyntaxPost struct {
 
 // EMBEDDED FIELDS WITH SIMPLIFIED SYNTAX
 //
-//ptah:schema:embed
 type ModernTimestamps struct {
 	//ptah:schema:field name="created_at" type="TIMESTAMP" not_null default_expr="CURRENT_TIMESTAMP"
 	CreatedAt string `db:"created_at"`


### PR DESCRIPTION
## Summary

- run Go annotation to HCL export through the compiled `ptah` binary in Export Acceptance
- require byte-identical repeated exports and consume generated HCL through `schema render`
- cover cleanup preview, destructive cleanup, and safe repeated-cleanup failure
- remove the undocumented `//ptah:schema:embed` no-op marker from fixtures and examples instead of promoting obsolete syntax into the supported annotation API

## Current status

This is intentionally a draft while the independent #381 hardening review findings are addressed in prerequisite PRs:

- [x] #899 shared immutable source snapshot for parser and cleanup ([PR #909](https://github.com/stokaro/ptah/pull/909): merged as `530bef58`)
- [x] #908 indexed immutable filesystem snapshots for large source trees ([PR #910](https://github.com/stokaro/ptah/pull/910): merged as `1ad1a188`)
- [ ] #900 conflict-safe, durable, ancestor-symlink-safe cleanup and publication
  - [x] #912 reusable rooted durable publication primitives ([PR #913](https://github.com/stokaro/ptah/pull/913): merged as `107d96aa`)
- [ ] #901 role-password redaction in cleanup diffs
- [ ] #902 non-NFC Unicode loss diagnostics before destructive cleanup

The acceptance branch is rebased through #899/#908 and all checks on head `94387e2` are green. It will be rebased and the process gate rerun after #900 merges; #901 and #902 will follow the same sequence.

## Verification

- `bash scripts/check-hcl-export-acceptance.sh`
- `go test -race -count=1 ./core/goschema ./internal/goannotationexport ./internal/goannotationcleanup ./internal/atlashclrender ./cmd/schema ./examples/annotation_parser ./stubs`
- `go tool qtlint ./core/goschema ./internal/goannotationexport ./internal/goannotationcleanup ./internal/atlashclrender ./cmd/schema`
- `scripts/check-test-style.sh`
- `gopls check` on every edited Go file
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `git diff --check`

## Documentation

No reader-facing behavior is introduced by this PR. Existing Go-to-HCL and cleanup documentation remains canonical. Removing `//ptah:schema:embed` corrects an undocumented no-op in test/example sources; embedded-field behavior continues to use the documented `//ptah:embedded` field annotation.

Closes #898.
Related to #381.