### PR TITLE
docs: clarify API schema export trust boundaries

### DIFF
--- a/docs/api_schema_export.md
+++ b/docs/api_schema_export.md
@@ -1,15 +1,23 @@
-# API Schema Export (OpenAPI / GraphQL)
+# API schema export (OpenAPI / GraphQL)
 
 Ptah exports the schema it parses from Go annotations to API-facing formats:
 OpenAPI 3.0 component schemas, GraphQL SDL, and Protobuf definitions. The parsed
 `goschema.Database` already carries types, nullability, enums and foreign keys,
 so each format is a direct projection of that intermediate representation.
+This is contract generation, not database publication: Ptah emits no runtime
+server, data access, authentication, or authorization.
 
 - Generated OpenAPI passes [`redocly lint`](https://redocly.com/docs/cli/commands/lint/).
 - Generated GraphQL passes [`graphql-js`](https://github.com/graphql/graphql-js)
   `parse` and `buildSchema`.
 
 Both are exercised in CI (`.github/workflows/export-acceptance.yml`).
+
+The generated artifact is not automatically a safe public API. Database models
+can contain internal, tenant, audit, credential, and personally identifiable
+fields. Use direct projection only where the selected persistence entities
+intentionally match the transport model, and review every generated field
+before publishing it.
 
 This file covers the two stateless targets. The Protobuf target (`--to protobuf`,
 rendered by `internal/protobufrender`) is stateful — field numbers are persistent
@@ -101,11 +109,41 @@ visible rather than silently wrong.
 
 ## Scope and limitations
 
-The export describes what an API component schema or GraphQL type needs: table
-columns, primary keys, foreign keys and enums. Non-column database objects
-(views, materialized views, triggers, functions, RLS policies, standalone
-indexes) are not part of an API schema and are not emitted. Use `--include-tables`
-/ `--exclude-tables` to scope the output to the entities you actually expose.
+The export describes selected table columns, primary keys, foreign keys, and
+enums. Non-column database objects such as views, materialized views, triggers,
+functions, row-level security (RLS) policies, and standalone indexes are not
+emitted.
+
+`--include-tables` and `--exclude-tables` select whole tables. Once a table is
+selected, every exportable column enters the generated shape. Ptah does not
+currently provide field allowlists, separate read/write projections,
+sensitive-field markers, or stable API aliases independent of database names.
+An additive database column can therefore become an unintended API change.
+Generated descriptions also expose table and field comments.
+
+OpenAPI output contains components but no paths. Protobuf output contains
+messages and enums but no services. GraphQL output includes a `Query` root and
+create-shaped inputs, but Ptah does not generate resolvers or define their
+authorization, tenant isolation, assignment, filtering, or transaction
+behavior.
+
+The projection is lossy. It does not carry database defaults, unique or check
+constraints, generated expressions, or transaction behavior. GraphQL `Int`
+cannot represent the full `BIGINT` range, decimal values mapped to GraphQL
+`Float` can lose precision, and custom `DateTime`/`JSON` scalars have no runtime
+implementation. A GraphQL create input recognizes serial and auto-increment
+columns as server-generated, but it does not infer every server-managed or
+database-defaulted field.
+
+Treat these outputs as reviewed contract inputs:
+
+1. Select the smallest set of tables needed.
+2. Inspect every generated field, relation, and exported source comment.
+3. Keep field and row authorization in the implementing service.
+4. Do not pass generated GraphQL inputs directly to persistence code without an
+   assignment allowlist.
+5. Review generated diffs and run consumer compatibility tests before
+   publication.
 
 The HCL schema target (`--to hcl`) is documented in
 [HCL Schema](atlas_hcl_schema.md). The old `--to atlas-hcl` spelling remains an

--- a/docs/site/src/content/docs/schema/export.md
+++ b/docs/site/src/content/docs/schema/export.md
@@ -1,13 +1,17 @@
 ---
 title: API schema export
-description: Export Go entities to OpenAPI 3.0 component schemas or GraphQL SDL.
+description: Project selected Go entities into OpenAPI or GraphQL contract candidates and review their trust-boundary limitations.
 ---
 
 Ptah projects the schema it parses from Go annotations into API-facing formats:
-OpenAPI 3.0 component schemas, GraphQL SDL, and Protobuf definitions. The parsed
-schema already carries types, nullability, enums and foreign keys, so each format
-is a direct projection of it — handy for teams that hand-author API specs from a
-database schema.
+OpenAPI 3.0 component schemas, GraphQL SDL, and Protobuf definitions. Use these
+artifacts when the selected database entities intentionally match your transport
+model, or as input to a separately designed contract.
+
+The export does not expose database rows or create a working API. It does not
+generate handlers, resolvers, Protobuf services, authentication, authorization,
+or database access. The generated schema is a contract candidate that you must
+review before publishing.
 
 The generated OpenAPI passes `redocly lint`; the generated GraphQL parses and
 builds with `graphql-js`.
@@ -147,10 +151,103 @@ The lookup is dialect-agnostic: Postgres and MySQL spellings (`SERIAL`,
 An unrecognized column type maps to `string`/`String` and emits a warning, so an
 unresolved custom type is visible rather than silently wrong.
 
-## Scope
+## What the projection does not preserve
 
-The export describes table columns, primary keys, foreign keys and enums —
-everything an API component schema or GraphQL type needs. Non-column objects
-(views, triggers, functions, RLS, indexes) are not part of an API schema and are
-not emitted. Use `--include-tables` / `--exclude-tables` to scope the output to
-the entities you expose.
+The generated contract is not a complete translation of database behavior:
+
+- OpenAPI and GraphQL do not carry database defaults, unique constraints, check
+  constraints, generated expressions, or transaction behavior. Enforce the API
+  rules in the implementing service even when the database also enforces them.
+- GraphQL `Int` is a signed 32-bit value. A non-primary-key `BIGINT` maps to
+  `Int`, so values outside that range need a separately designed scalar or
+  contract.
+- `DECIMAL` and `NUMERIC` map to OpenAPI `number` and GraphQL `Float`. Those
+  representations can lose decimal precision.
+- GraphQL declares `DateTime` and `JSON` scalar names but does not provide their
+  parsing, serialization, or validation behavior.
+- A GraphQL create input omits serial and auto-increment columns. Other
+  server-managed or database-defaulted columns are not recognized
+  automatically and can still appear in the input.
+- Foreign-key relation fields describe a possible object shape. They do not
+  define loading, batching, tenant checks, or authorization.
+
+## Scope and limitations
+
+The export describes selected table columns, primary keys, foreign keys, and
+enums. Non-column objects such as views, triggers, functions, row-level security
+(RLS) policies, and indexes are not emitted.
+
+Database and API models solve different problems. A database model can contain
+tenant identifiers, audit fields, internal states, credential material, and
+operational columns that no external caller should see. It can also change on a
+different schedule from a public API.
+
+Use direct projection for an internal contract or a deliberately isomorphic
+domain model. Use a curated API model when the contract crosses a trust boundary,
+must remain stable across storage refactors, or exposes only part of a row.
+
+:::caution[Table selection is not field-level access control]
+`--include-tables` and `--exclude-tables` select whole tables. Once a table is
+selected, every exportable column enters the generated shape. Ptah does not
+currently provide field allowlists, read/write visibility, API aliases, or
+sensitive-field classification.
+:::
+
+The generated surface differs by target:
+
+| Target | Ptah emits | Ptah does not emit |
+| --- | --- | --- |
+| OpenAPI | Component schemas under `components.schemas` | Paths, operations, handlers, or authorization |
+| GraphQL | Object and input types, connections, and a `Query` root | Resolvers, a server, data access, or authorization |
+| Protobuf | Messages and enums | Services, remote procedure calls (RPCs), handlers, or authorization |
+
+Publishing any generated schema reveals the selected entity and field names,
+translated types, enum values, relations, and exported source comments. Schema
+metadata is not an authorization boundary, but you should not disclose internal
+metadata that consumers do not need.
+
+RLS omission is important: the generated schema cannot describe who may read or
+write a field or row. Keep authorization in the service that implements the
+contract. Do not infer API permissions from database constraints or from the
+presence or absence of a generated field.
+
+Database identifiers also become API identifiers after target-specific name
+normalization. Ptah does not currently provide a stable alias between a table or
+column name and its exported API name. A storage rename can therefore become a
+contract rename.
+
+GraphQL operation-shaped definitions do not grant access by themselves, but
+they can be wired unsafely. In particular, do not pass generated input objects
+directly to persistence code without an explicit assignment allowlist.
+
+## Review before publishing
+
+Before publishing or generating runtime code from an export:
+
+1. Use `--include-tables` rather than exporting the entire model by default.
+2. Inspect every generated field, including identifiers, audit columns, and
+   server-managed values. Review exported table and field comments too.
+3. If a selected table contains a field that must not cross the trust boundary,
+   use a curated source model or a separately authored contract. Table filters
+   cannot remove individual fields.
+4. Define authentication, authorization, tenant isolation, validation, and
+   assignment rules in the implementing service.
+5. Review the generated diff when the database model changes. An additive
+   database column can be an additive but unintended API change.
+6. Run the target linter or compiler and the consumer compatibility tests before
+   publishing the artifact.
+
+For OpenAPI, merge selected components into a hand-authored specification when
+the public contract differs from storage. For GraphQL, treat the generated
+`Query` and input types as syntax, not as an authorization or resolver design.
+For Protobuf, use generated messages behind separately designed services or
+wrapper messages when the public model must differ.
+
+## Next steps
+
+- Need a stateful wire contract? Use
+  [Protobuf schema export](../protobuf/).
+- Need to verify what the source model declares? Review
+  [Go annotations](../go-annotations/).
+- Publishing the artifact from a pull request? Add it to
+  [Continuous integration](../../testing/ci/).

--- a/docs/site/src/content/docs/schema/protobuf.md
+++ b/docs/site/src/content/docs/schema/protobuf.md
@@ -10,9 +10,21 @@ keys. Unlike the OpenAPI and GraphQL targets on
 are permanent wire identifiers, so the file Ptah wrote last time is read back
 and used as the source of every number it already pins.
 
+Ptah emits messages and enums, not Protobuf services or remote procedure calls
+(RPCs). It does not create a server, access database rows, or implement
+authorization. Publishing the generated file still reveals the selected table
+and column names, translated types, enum values, and exported source comments.
+
 Prerequisites: a built `ptah` binary and a directory of annotated Go models.
 `buf` and `protoc` are needed only if you want to lint or compatibility-check
 the result yourself.
+
+:::caution[Wire compatibility is not API safety]
+Compatibility checks prevent accidental field-number reuse and detect selected
+wire or JSON contract breaks. They do not decide whether a field is appropriate
+for an API. Once a table is selected, every exportable column enters its
+generated message.
+:::
 
 ## Generate the first file
 
@@ -452,6 +464,22 @@ Every check below runs before anything is written, and each exits with code
 - The source is Go annotations only. There is no `--schema-file` or database
   URL for this target; run [`ptah introspect`](../../start/adopt-an-existing-database/)
   first to generate annotated models from an existing database.
+- Table selection is the narrowest available projection. There are no
+  field-level allowlists, read/write visibility rules, sensitive-field markers,
+  or API-specific aliases. Use a curated annotation source or wrapper messages
+  when a public contract must expose only part of a table.
+- Database identifiers determine generated API identifiers after Protobuf name
+  normalization. Renaming a table or column can therefore rename a public
+  symbol even when its wire number remains stable.
+- Additive compatibility is not the same as intentional exposure. Adding a
+  column to a selected table adds a field on the next export unless the whole
+  table is excluded.
+- The generated definition contains no authorization or tenant-isolation
+  semantics. RLS policies are not emitted, and their presence in the database
+  does not define who may use a message field.
+- Table and field comments are copied into the generated definition. Review them
+  for internal implementation details or sensitive operational information
+  before publishing the file.
 - One file per run. Ptah writes a single compilation unit, so splitting a
   schema across `.proto` files means several exports with disjoint
   `--include-tables` sets and separate packages.


### PR DESCRIPTION
## Summary

- frame API schema export as an offline contract projection rather than a
  generated data API
- document the exact OpenAPI, GraphQL, and Protobuf surfaces and the runtime,
  authorization, and data-access behavior Ptah does not provide
- warn that table filters expose every exportable column and that generated
  names, types, enum values, relations, and comments disclose schema metadata
- document lossy OpenAPI/GraphQL mappings, GraphQL input and operation risks,
  row-level security boundaries, storage-name coupling, and the publication
  review checklist
- distinguish Protobuf wire compatibility from field-level API safety

## Follow-up issues

- #904 adds explicit field-level and read/write projections
- #905 decouples API identities and type overrides from database names
- #906 makes GraphQL operations explicit and types-only by default

## Documentation impact map

- Updated `docs/site/src/content/docs/schema/export.md`, the reader workflow for
  OpenAPI and GraphQL export.
- Updated `docs/site/src/content/docs/schema/protobuf.md`, the stateful Protobuf
  contract workflow.
- Updated `docs/api_schema_export.md`, the repository-level backing reference.
- Checked `README.md`, `docs/README.md`, native command reference, Go annotation
  workflow, and desired-schema concepts; they do not duplicate the security or
  projection contract.
- `docs/site/CONTENT_INVENTORY.md` is unchanged because no page was added,
  moved, merged, split, or retired.

## Validation

- `npm run check:links:selftest`
- `npm run check:links`
- `npm run check:redirects`
- `npm run check:core-doc-links`
- `npm run check:page-health`
- `npm run check:exit-codes`
- `npm run versions:selftest`
- `npm run build` (60 pages)
- `npm audit --audit-level=low` (0 vulnerabilities)
- `git diff --check`
- stale-marker and American English sweep over all changed pages

The local browser connection rejected the preview URL, so a screenshot-based
visual pass was not available. No CSS or layout templates changed; the built
HTML was checked for the new headings, target comparison table, and Starlight
caution components.
