### PR TITLE
refactor(schema): share Go annotation source snapshot

### DIFF
--- a/core/goschema/walker.go
+++ b/core/goschema/walker.go
@@ -3,10 +3,12 @@ package goschema
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
 // ParseDir parses all Go files in the given root directory and its subdirectories
@@ -19,7 +21,8 @@ import (
 //
 // The parsing process includes:
 //   - Recursive directory traversal starting from rootDir
-//   - Filtering to include only .go files (excluding tests and vendor)
+//   - Filtering to include only .go files (excluding tests, hidden directories,
+//     and directories named exactly vendor)
 //   - Extraction of tables, fields, indexes, enums, and embedded fields
 //   - Deduplication of entities found in multiple files
 //   - Dependency analysis based on foreign key relationships
@@ -152,32 +155,35 @@ func bindManagedDataSourceRoot(result *Database, root string) {
 	}
 }
 
-// accumulateGoFiles walks the non-test, non-vendor Go source files under rootDir
-// in fsys and appends each parsed file's schema objects onto result without
+// accumulateGoFiles walks the selected Go annotation sources under rootDir in
+// fsys and appends each parsed file's schema objects onto result without
 // finalizing. It is the shared, pre-finalize body of ParseFS and ParseDirs, so
 // multiple roots can accumulate into one result before a single finalize pass.
 func accumulateGoFiles(result *Database, fsys fs.FS, rootDir string) error {
 	var parseErrors []error
 
-	// Walk through all directories recursively
 	err := fs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-
-		// Skip non-Go files
-		if !strings.HasSuffix(path, ".go") {
+		if d.IsDir() {
+			if path != rootDir && goannotationsource.SkipDirectory(d.Name()) {
+				return fs.SkipDir
+			}
 			return nil
 		}
-
-		// Skip test files
-		if strings.HasSuffix(path, "_test.go") {
+		if !goannotationsource.IsSource(path) {
 			return nil
 		}
-
-		// Skip vendor directories (handle both Unix and Windows path separators)
-		if strings.Contains(path, "vendor/") || strings.Contains(path, "vendor\\") {
-			return nil
+		if d.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("refuse to parse symlinked Go source %s", path)
+		}
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat Go source %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refuse to parse non-regular Go source %s", path)
 		}
 
 		database, err := parseDatabaseFile(fsys, path)
@@ -186,7 +192,6 @@ func accumulateGoFiles(result *Database, fsys fs.FS, rootDir string) error {
 			return nil
 		}
 
-		// Add this file's schema objects to the accumulator.
 		appendDatabase(result, &database)
 
 		return nil

--- a/core/goschema/walker_test.go
+++ b/core/goschema/walker_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
 func TestParseDir_ExtensionMerging(t *testing.T) {
@@ -716,6 +717,48 @@ type TestUser struct {
 			expectedFields: 1,
 		},
 		{
+			name: "excludes hidden directories",
+			files: map[string]string{
+				"user.go": `package models
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}`,
+				".hidden/model.go": `package hidden
+
+//ptah:schema:table name="hidden_table"
+type HiddenModel struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}`,
+			},
+			expectedTables: 1,
+			expectedFields: 1,
+		},
+		{
+			name: "includes directory containing vendor substring",
+			files: map[string]string{
+				"user.go": `package models
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}`,
+				"myvendor/model.go": `package myvendor
+
+//ptah:schema:table name="application_table"
+type ApplicationModel struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}`,
+			},
+			expectedTables: 2,
+			expectedFields: 2,
+		},
+		{
 			name: "excludes vendor directories",
 			files: map[string]string{
 				"user.go": `package models
@@ -771,6 +814,104 @@ type User struct {
 			// Check counts
 			c.Assert(result.Tables, qt.HasLen, tt.expectedTables)
 			c.Assert(result.Fields, qt.HasLen, tt.expectedFields)
+		})
+	}
+}
+
+func TestParseDir_HappyPath_UsesSharedFileFiltering(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	files := []struct {
+		name string
+		data string
+	}{
+		{
+			name: ".generated.go",
+			data: "package models\n\n//ptah:schema:table name=\"generated\"\ntype Generated struct{}\n",
+		},
+		{
+			name: "myvendor/model.go",
+			data: "package myvendor\n\n//ptah:schema:table name=\"included\"\ntype Included struct{}\n",
+		},
+		{
+			name: ".hidden/model.go",
+			data: "package hidden\n\n//ptah:schema:table name=\"hidden\"\ntype Hidden struct{}\n",
+		},
+		{
+			name: "vendor/model.go",
+			data: "package vendor\n\n//ptah:schema:table name=\"vendored\"\ntype Vendored struct{}\n",
+		},
+		{
+			name: "model_test.go",
+			data: "package models_test\n\n//ptah:schema:table name=\"test_table\"\ntype TestModel struct{}\n",
+		},
+	}
+	for _, file := range files {
+		path := filepath.Join(root, file.name)
+		c.Assert(os.MkdirAll(filepath.Dir(path), 0o755), qt.IsNil)
+		c.Assert(os.WriteFile(path, []byte(file.data), 0o600), qt.IsNil)
+	}
+
+	result, err := goschema.ParseDir(root)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Tables, qt.HasLen, 2)
+	c.Assert(result.Tables[0].Name, qt.Equals, "generated")
+	c.Assert(result.Tables[1].Name, qt.Equals, "included")
+}
+
+func TestParseFS_HappyPath_ParsesCapturedSourceBytes(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	c.Assert(os.WriteFile(
+		source,
+		[]byte("package models\n\n//ptah:schema:table name=\"captured\"\ntype Captured struct{}\n"),
+		0o600,
+	), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(
+		source,
+		[]byte("package models\n\n//ptah:schema:table name=\"live\"\ntype Live struct{}\n"),
+		0o600,
+	), qt.IsNil)
+
+	result, err := goschema.ParseFS(snapshot.FS(), ".")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Tables, qt.HasLen, 1)
+	c.Assert(result.Tables[0].Name, qt.Equals, "captured")
+}
+
+func TestParseFS_FailurePath_RejectsSelectedNonRegularSources(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		mode    fs.FileMode
+		wantErr string
+	}{
+		{
+			name:    "symlink",
+			mode:    fs.ModeSymlink,
+			wantErr: "refuse to parse symlinked Go source model.go",
+		},
+		{
+			name:    "named pipe",
+			mode:    fs.ModeNamedPipe,
+			wantErr: "refuse to parse non-regular Go source model.go",
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			fsys := fstest.MapFS{
+				"model.go": &fstest.MapFile{Mode: test.mode},
+			}
+
+			result, err := goschema.ParseFS(fsys, ".")
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(result, qt.IsNil)
 		})
 	}
 }

--- a/docs/site/src/content/docs/schema/go-annotations.md
+++ b/docs/site/src/content/docs/schema/go-annotations.md
@@ -41,6 +41,11 @@ type Account struct {
 }
 ```
 
+Ptah recursively reads regular `*.go` files under each `--root-dir`. It skips
+`*_test.go`, hidden directories, and directories named exactly `vendor`.
+Names that merely contain that word, such as `myvendor`, remain part of the
+source tree.
+
 Render the desired SQL before connecting to a database:
 
 ```bash
@@ -145,6 +150,11 @@ stable before it writes `schema.hcl`. Every valid Go annotation semantic has an
 HCL representation, so the export is expected to have no diagnostics. Review
 any unexpected diagnostic before cleanup.
 
+One export captures the complete selected Go source set and uses that immutable
+view for both HCL parsing and cleanup planning. Ptah rechecks source membership,
+file identity, permissions, and contents before publishing the HCL; a concurrent
+source change aborts the export.
+
 Preview annotation removal only after the export has no diagnostics:
 
 ```bash
@@ -162,10 +172,13 @@ the same command without `--cleanup-diff` to apply the prevalidated cleanup
 plan.
 
 :::caution[Cleanup is a one-time migration]
-Cleanup fails before any write if the export reports diagnostics, the output
-aliases a Go source or referenced managed-data file, or no removable
-annotations remain. Do not repeat the cleanup command after a successful
-migration; use `schema.hcl` as the new source.
+Cleanup fails before HCL publication if the export reports diagnostics, the
+output uses a `.go` path or aliases a protected source, or no removable
+annotations remain. Ptah revalidates the Go source set before HCL publication
+and again before cleanup. If a source changes between those steps, the HCL file
+remains published but cleanup leaves every Go file unchanged and returns an
+error. Do not repeat the cleanup command after a successful migration; use
+`schema.hcl` as the new source.
 :::
 
 ## Next steps

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stokaro/ptah/internal/annotationmeta"
 	"github.com/stokaro/ptah/internal/annotationparse"
+	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
 // Result describes cleanup changes for one file.
@@ -38,14 +39,9 @@ type removedLine struct {
 	annotation Annotation
 }
 
-type sourceFile struct {
-	path string
-	info os.FileInfo
-}
-
 type filePlan struct {
 	result  Result
-	info    os.FileInfo
+	source  goannotationsource.File
 	before  []byte
 	after   []byte
 	removed []removedLine
@@ -60,49 +56,25 @@ type stagedPlan struct {
 
 // Plan is an immutable set of validated annotation removals.
 type Plan struct {
-	sources []sourceFile
-	changes []filePlan
+	snapshot *goannotationsource.Snapshot
+	changes  []filePlan
 }
 
-// PlanDir validates Go sources under root and plans annotation removals without
-// modifying any files.
-func PlanDir(root string) (*Plan, error) {
-	if root == "" {
-		root = "."
+// NewPlan plans annotation removals from one captured source view.
+func NewPlan(snapshot *goannotationsource.Snapshot) (*Plan, error) {
+	if snapshot == nil {
+		return nil, errors.New("Go annotation source snapshot is nil")
 	}
-	root = filepath.Clean(root)
-	cleanupPlan := &Plan{}
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+	cleanupPlan := &Plan{snapshot: snapshot}
+	for _, source := range snapshot.Files() {
+		file, err := planFile(source)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		if entry.IsDir() {
-			if path != root && (entry.Name() == "vendor" || strings.HasPrefix(entry.Name(), ".")) {
-				return filepath.SkipDir
-			}
-			return nil
+		if !file.result.Changed {
+			continue
 		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refuse to clean symlinked Go source %s", path)
-		}
-		file, err := planFile(path)
-		if err != nil {
-			return err
-		}
-		cleanupPlan.sources = append(cleanupPlan.sources, sourceFile{
-			path: file.result.Path,
-			info: file.info,
-		})
-		if file.result.Changed {
-			cleanupPlan.changes = append(cleanupPlan.changes, file)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		cleanupPlan.changes = append(cleanupPlan.changes, file)
 	}
 	return cleanupPlan, nil
 }
@@ -140,74 +112,41 @@ func (p *Plan) Annotations() []Annotation {
 
 // Apply commits the validated annotation-removal plan.
 func (p *Plan) Apply() error {
-	return applyPlans(p.changes)
+	if err := p.snapshot.Revalidate(); err != nil {
+		return fmt.Errorf("revalidate Go annotation sources before cleanup: %w", err)
+	}
+	return applyPlans(p.changes, p.snapshot.Revalidate)
 }
 
-// SourceAlias returns the planned Go source aliased by path, or an empty string
-// when path does not refer to any source in the plan.
-func (p *Plan) SourceAlias(path string) (string, error) {
-	path = filepath.Clean(path)
-	for _, source := range p.sources {
-		if path == source.path {
-			return source.path, nil
-		}
-	}
-
-	info, err := os.Stat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("stat potential Go source alias %s: %w", path, err)
-	}
-	for _, source := range p.sources {
-		if os.SameFile(source.info, info) {
-			return source.path, nil
-		}
-	}
-	return "", nil
-}
-
-func planFile(path string) (filePlan, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return filePlan{}, fmt.Errorf("stat %s: %w", path, err)
-	}
-	if !info.Mode().IsRegular() {
-		return filePlan{}, fmt.Errorf("refuse to clean non-regular Go source %s", path)
-	}
-	before, err := os.ReadFile(path)
-	if err != nil {
-		return filePlan{}, fmt.Errorf("read %s: %w", path, err)
-	}
-	after, removed, err := removeAnnotationLines(path, before)
+func planFile(source goannotationsource.File) (filePlan, error) {
+	after, removed, err := removeAnnotationLines(source.Path, source.Contents)
 	if err != nil {
 		return filePlan{}, err
 	}
 	if len(removed) == 0 {
 		return filePlan{
-			result: Result{Path: path},
-			info:   info,
-			before: before,
+			result: Result{Path: source.Path},
+			source: source,
+			before: source.Contents,
 			after:  after,
 		}, nil
 	}
 	result := Result{
-		Path:         path,
-		Changed:      !bytes.Equal(before, after),
+		Path:         source.Path,
+		Changed:      !bytes.Equal(source.Contents, after),
 		RemovedLines: len(removed),
-		Diff:         unifiedRemovalDiff(path, before, removed),
+		Diff:         unifiedRemovalDiff(source.Path, source.Contents, removed),
 	}
 	return filePlan{
 		result:  result,
-		info:    info,
-		before:  before,
+		source:  source,
+		before:  source.Contents,
 		after:   after,
 		removed: removed,
 	}, nil
 }
 
-func applyPlans(plans []filePlan) error {
+func applyPlans(plans []filePlan, revalidate func() error) error {
 	files := make([]*os.File, 0, len(plans))
 	for _, plan := range plans {
 		file, err := openValidatedPlan(plan)
@@ -228,6 +167,12 @@ func applyPlans(plans []filePlan) error {
 	}
 	if err := closeFiles(files); err != nil {
 		return errors.Join(err, cleanupStagedPlans(staged))
+	}
+	if err := revalidate(); err != nil {
+		return errors.Join(
+			fmt.Errorf("revalidate Go annotation sources before cleanup commit: %w", err),
+			cleanupStagedPlans(staged),
+		)
 	}
 	if err := commitStagedPlans(staged); err != nil {
 		return errors.Join(err, cleanupStagedPlans(staged))
@@ -258,7 +203,7 @@ func validatePlanPath(plan filePlan) error {
 	if info.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
 	}
-	if !info.Mode().IsRegular() || !os.SameFile(plan.info, info) {
+	if !info.Mode().IsRegular() || !plan.source.SameFile(info) {
 		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
 	}
 	current, err := os.ReadFile(plan.result.Path)
@@ -276,7 +221,7 @@ func validateOpenPlan(file *os.File, plan filePlan) error {
 	if err != nil {
 		return fmt.Errorf("stat opened Go source %s: %w", plan.result.Path, err)
 	}
-	if !os.SameFile(plan.info, currentInfo) {
+	if !plan.source.SameFile(currentInfo) {
 		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
 	}
 	return validatePlanContent(file, plan)
@@ -332,7 +277,7 @@ func stageFile(plan filePlan, kind string, data []byte) (string, error) {
 		return "", fmt.Errorf("create staged %s for %s: %w", kind, plan.result.Path, err)
 	}
 	path := file.Name()
-	if err := file.Chmod(plan.info.Mode()); err != nil {
+	if err := file.Chmod(plan.source.Mode()); err != nil {
 		_ = file.Close()
 		return "", errors.Join(
 			fmt.Errorf("set staged %s mode for %s: %w", kind, plan.result.Path, err),

--- a/internal/goannotationcleanup/cleanup_internal_test.go
+++ b/internal/goannotationcleanup/cleanup_internal_test.go
@@ -1,0 +1,94 @@
+package goannotationcleanup
+
+// White-box testing required: this file injects source mutations at the
+// unexported post-staging commit barrier, which public APIs cannot observe
+// deterministically without timing-dependent filesystem polling.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
+)
+
+func TestApplyPlans_FailurePath_RevalidatesCompleteSourceSetAfterStaging(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name           string
+		mutate         func(c *qt.C, root, plainPath string)
+		wantPlain      []byte
+		wantEntryNames []string
+	}{
+		{
+			name: "added source",
+			mutate: func(c *qt.C, root, _ string) {
+				c.Assert(os.WriteFile(
+					filepath.Join(root, "new.go"),
+					[]byte("package models\n"),
+					0o600,
+				), qt.IsNil)
+			},
+			wantPlain:      []byte("package models\n\ntype Plain struct{}\n"),
+			wantEntryNames: []string{"annotated.go", "new.go", "plain.go"},
+		},
+		{
+			name: "edited unannotated source",
+			mutate: func(c *qt.C, _ string, plainPath string) {
+				c.Assert(os.WriteFile(
+					plainPath,
+					[]byte("package models\n\ntype Other struct{}\n"),
+					0o600,
+				), qt.IsNil)
+			},
+			wantPlain:      []byte("package models\n\ntype Other struct{}\n"),
+			wantEntryNames: []string{"annotated.go", "plain.go"},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			annotatedPath := filepath.Join(root, "annotated.go")
+			plainPath := filepath.Join(root, "plain.go")
+			annotated := []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			)
+			plain := []byte("package models\n\ntype Plain struct{}\n")
+			c.Assert(os.WriteFile(annotatedPath, annotated, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(plainPath, plain, 0o600), qt.IsNil)
+			snapshot, err := goannotationsource.Capture(root)
+			c.Assert(err, qt.IsNil)
+			plan, err := NewPlan(snapshot)
+			c.Assert(err, qt.IsNil)
+
+			err = applyPlans(plan.changes, func() error {
+				test.mutate(c, root, plainPath)
+				return snapshot.Revalidate()
+			})
+
+			c.Assert(err, qt.ErrorIs, goannotationsource.ErrChanged)
+			assertInternalFileBytes(c, annotatedPath, annotated)
+			assertInternalFileBytes(c, plainPath, test.wantPlain)
+			entries, err := os.ReadDir(root)
+			c.Assert(err, qt.IsNil)
+			c.Assert(internalEntryNames(entries), qt.DeepEquals, test.wantEntryNames)
+		})
+	}
+}
+
+func assertInternalFileBytes(c *qt.C, path string, want []byte) {
+	c.Helper()
+	got, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, want)
+}
+
+func internalEntryNames(entries []os.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}

--- a/internal/goannotationcleanup/cleanup_symlink_unix_test.go
+++ b/internal/goannotationcleanup/cleanup_symlink_unix_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-
-	"github.com/stokaro/ptah/internal/goannotationcleanup"
 )
 
 func TestCleanDir_FailurePath_RejectsSymlinkedGoSource(t *testing.T) {
@@ -22,10 +20,10 @@ func TestCleanDir_FailurePath_RejectsSymlinkedGoSource(t *testing.T) {
 	c.Assert(os.WriteFile(target, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Symlink(target, link), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(root)
+	plan, err := planDir(root)
 
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "refuse to clean symlinked Go source")
+	c.Assert(err.Error(), qt.Contains, "refuse to capture symlinked Go source")
 	c.Assert(plan, qt.IsNil)
 	content, err := os.ReadFile(target)
 	c.Assert(err, qt.IsNil)
@@ -33,30 +31,6 @@ func TestCleanDir_FailurePath_RejectsSymlinkedGoSource(t *testing.T) {
 	info, err := os.Lstat(link)
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode()&os.ModeSymlink, qt.Equals, os.ModeSymlink)
-}
-
-func TestPlanSourceAlias_HappyPath_ReportsSymlinkAndHardLinkAliases(t *testing.T) {
-	c := qt.New(t)
-	root := t.TempDir()
-	outside := t.TempDir()
-	source := filepath.Join(root, "model.go")
-	symlinkAlias := filepath.Join(outside, "schema-symlink.hcl")
-	hardLinkAlias := filepath.Join(outside, "schema-hardlink.hcl")
-	original := "package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n"
-	c.Assert(os.WriteFile(source, []byte(original), 0o600), qt.IsNil)
-	c.Assert(os.Symlink(source, symlinkAlias), qt.IsNil)
-	c.Assert(os.Link(source, hardLinkAlias), qt.IsNil)
-
-	plan, err := goannotationcleanup.PlanDir(root)
-	c.Assert(err, qt.IsNil)
-
-	alias, err := plan.SourceAlias(symlinkAlias)
-	c.Assert(err, qt.IsNil)
-	c.Assert(alias, qt.Equals, source)
-
-	alias, err = plan.SourceAlias(hardLinkAlias)
-	c.Assert(err, qt.IsNil)
-	c.Assert(alias, qt.Equals, source)
 }
 
 func TestPlanApply_FailurePath_StagingFailureLeavesEverySourceUnchanged(t *testing.T) {
@@ -73,7 +47,7 @@ func TestPlanApply_FailurePath_StagingFailureLeavesEverySourceUnchanged(t *testi
 	c.Assert(os.WriteFile(firstPath, firstData, 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(blockedPath, blockedData, 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(root)
+	plan, err := planDir(root)
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.Chmod(blockedDir, 0o500), qt.IsNil)
 	defer func() {

--- a/internal/goannotationcleanup/cleanup_test.go
+++ b/internal/goannotationcleanup/cleanup_test.go
@@ -9,6 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/internal/goannotationcleanup"
+	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
 func TestCleanDirDryRunDiffAndWrite(t *testing.T) {
@@ -31,7 +32,7 @@ type User struct {
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Chmod(path, 0o644), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results := plan.DiffResults()
@@ -42,7 +43,7 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, original)
 
-	plan, err = goannotationcleanup.PlanDir(dir)
+	plan, err = planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results = plan.Results()
@@ -58,7 +59,7 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o644))
 
-	plan, err = goannotationcleanup.PlanDir(dir)
+	plan, err = planDir(dir)
 	c.Assert(err, qt.IsNil)
 	results = plan.Results()
 	c.Assert(results, qt.HasLen, 0)
@@ -73,7 +74,7 @@ func TestCleanDirPreservesUnrelatedFormattingByteForByte(t *testing.T) {
 	expected := "package models\n\n// User is business documentation.\ntype User struct{ID int64}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results := plan.Results()
@@ -96,7 +97,7 @@ func TestCleanDirDiffReportsDuplicateRemovedLinesByPosition(t *testing.T) {
 		"OtherID int64\n}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results := plan.DiffResults()
@@ -147,7 +148,7 @@ func TestCleanDir_HappyPath_PreservesStringLiteralsAndRemovesStandaloneAnnotatio
 		"}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results := plan.Results()
@@ -183,7 +184,7 @@ func TestCleanDir_HappyPath_SkipsTestVendorAndHiddenSources(t *testing.T) {
 	c.Assert(os.WriteFile(vendorPath, []byte(skippedVendor), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(hiddenPath, []byte(skippedHidden), 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	results := plan.Results()
@@ -216,7 +217,7 @@ func TestCleanDir_FailurePath_InvalidGoSourceIsNotModified(t *testing.T) {
 	c.Assert(os.Chmod(validPath, 0o640), qt.IsNil)
 	c.Assert(os.Chmod(invalidPath, 0o640), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "z_invalid.go")
@@ -246,13 +247,15 @@ func TestPlanApply_FailurePath_PrevalidatesEverySourceBeforeWriting(t *testing.T
 	c.Assert(os.WriteFile(firstPath, firstData, 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(changedPath, changedData, 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.WriteFile(changedPath, replacementData, 0o600), qt.IsNil)
 
 	err = plan.Apply()
 
-	c.Assert(err, qt.ErrorMatches, "go source changed before cleanup: .*z_model.go")
+	c.Assert(err, qt.ErrorIs, goannotationsource.ErrChanged)
+	c.Assert(err.Error(), qt.Contains, "source contents changed")
+	c.Assert(err.Error(), qt.Contains, "z_model.go")
 	firstAfter, err := os.ReadFile(firstPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(firstAfter, qt.DeepEquals, firstData)
@@ -280,7 +283,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 	c.Assert(os.Chmod(path, 0o640), qt.IsNil)
 
-	dryRunPlan, err := goannotationcleanup.PlanDir(dir)
+	dryRunPlan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	dryRunResults := dryRunPlan.Results()
@@ -296,7 +299,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	diffPlan, err := goannotationcleanup.PlanDir(dir)
+	diffPlan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	diffResults := diffPlan.DiffResults()
@@ -313,7 +316,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	writePlan, err := goannotationcleanup.PlanDir(dir)
+	writePlan, err := planDir(dir)
 
 	c.Assert(err, qt.IsNil)
 	writeResults := writePlan.Results()
@@ -330,12 +333,12 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(err, qt.IsNil)
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 
-	idempotentDryRunPlan, err := goannotationcleanup.PlanDir(dir)
+	idempotentDryRunPlan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)
 	idempotentDryRunResults := idempotentDryRunPlan.DiffResults()
 	c.Assert(idempotentDryRunResults, qt.HasLen, 0)
 
-	idempotentWritePlan, err := goannotationcleanup.PlanDir(dir)
+	idempotentWritePlan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)
 	idempotentWriteResults := idempotentWritePlan.Results()
 	c.Assert(idempotentWriteResults, qt.HasLen, 0)
@@ -370,7 +373,7 @@ func TestCleanDir_HappyPath_DiffMarksMissingFinalNewline(t *testing.T) {
 			path := filepath.Join(dir, "model.go")
 			c.Assert(os.WriteFile(path, []byte(tt.original), 0o600), qt.IsNil)
 
-			plan, err := goannotationcleanup.PlanDir(dir)
+			plan, err := planDir(dir)
 
 			c.Assert(err, qt.IsNil)
 			results := plan.DiffResults()
@@ -384,14 +387,14 @@ func TestCleanDir_HappyPath_DiffMarksMissingFinalNewline(t *testing.T) {
 	}
 }
 
-func TestPlanSourceAlias_HappyPath_ReportsExactSourceAndMissingPath(t *testing.T) {
+func TestPlanAnnotations_HappyPath_ReturnsMetadata(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "model.go")
 	original := "package models\n\n//ptah:schema:table name=\"users\" platform.mysql.engine=\"InnoDB\"\ntype User struct{}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
-	plan, err := goannotationcleanup.PlanDir(dir)
+	plan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)
 	c.Assert(plan.Annotations(), qt.DeepEquals, []goannotationcleanup.Annotation{
 		{
@@ -401,12 +404,21 @@ func TestPlanSourceAlias_HappyPath_ReportsExactSourceAndMissingPath(t *testing.T
 			Attributes: []string{"name", "platform.mysql.engine"},
 		},
 	})
+}
 
-	alias, err := plan.SourceAlias(path)
-	c.Assert(err, qt.IsNil)
-	c.Assert(alias, qt.Equals, path)
+func TestNewPlan_FailurePath_RejectsNilSnapshot(t *testing.T) {
+	c := qt.New(t)
 
-	alias, err = plan.SourceAlias(filepath.Join(dir, "schema.hcl"))
-	c.Assert(err, qt.IsNil)
-	c.Assert(alias, qt.Equals, "")
+	plan, err := goannotationcleanup.NewPlan(nil)
+
+	c.Assert(err, qt.ErrorMatches, "Go annotation source snapshot is nil")
+	c.Assert(plan, qt.IsNil)
+}
+
+func planDir(root string) (*goannotationcleanup.Plan, error) {
+	snapshot, err := goannotationsource.Capture(root)
+	if err != nil {
+		return nil, err
+	}
+	return goannotationcleanup.NewPlan(snapshot)
 }

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/internal/atlashcl"
 	"github.com/stokaro/ptah/internal/atlashclrender"
 	"github.com/stokaro/ptah/internal/goannotationcleanup"
+	"github.com/stokaro/ptah/internal/goannotationsource"
 	"github.com/stokaro/ptah/internal/pathguard"
 )
 
@@ -29,6 +30,8 @@ var (
 	ErrInvalidHCL = errors.New("generated HCL failed round-trip validation")
 	// ErrOutputAliasesSource reports that the output aliases an input Go source.
 	ErrOutputAliasesSource = errors.New("HCL output aliases a Go source file")
+	// ErrOutputIsGoSource reports that the HCL destination uses a Go source path.
+	ErrOutputIsGoSource = errors.New("HCL output path must not end in .go")
 	// ErrOutputAliasesManagedData reports that the output aliases a managed-data
 	// source and would overwrite the referenced row data.
 	ErrOutputAliasesManagedData = errors.New("HCL output aliases a managed data file")
@@ -56,8 +59,8 @@ type Result struct {
 
 type exportPlan struct {
 	options        Options
-	rootDir        string
 	outputPath     string
+	snapshot       *goannotationsource.Snapshot
 	cleanup        *goannotationcleanup.Plan
 	cleanupResults []goannotationcleanup.Result
 }
@@ -68,9 +71,18 @@ type renderedExport struct {
 	diagnostics []atlashclrender.Diagnostic
 }
 
+type stagedOutput struct {
+	outputPath string
+	tempPath   string
+}
+
 // Export renders Go annotations to HCL and optionally applies one validated
 // cleanup plan after the output has been committed.
 func Export(opts Options) (Result, error) {
+	return export(opts, func() {})
+}
+
+func export(opts Options, afterOutputStage func()) (Result, error) {
 	plan, err := prepareExport(opts)
 	if err != nil {
 		return Result{}, err
@@ -83,8 +95,16 @@ func Export(opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if err := writeOutput(plan.outputPath, rendered.hcl, mode); err != nil {
+	staged, err := stageOutput(plan.outputPath, rendered.hcl, mode)
+	if err != nil {
 		return Result{}, err
+	}
+	afterOutputStage()
+	if err := plan.validatePublication(rendered.database.ManagedData); err != nil {
+		return Result{}, errors.Join(err, staged.cleanup())
+	}
+	if err := staged.commit(); err != nil {
+		return Result{}, errors.Join(err, staged.cleanup())
 	}
 	if err := plan.applyCleanup(); err != nil {
 		return Result{}, err
@@ -110,14 +130,21 @@ func prepareExport(opts Options) (exportPlan, error) {
 		return exportPlan{}, err
 	}
 
-	cleanupPlan, err := goannotationcleanup.PlanDir(rootDir)
+	snapshot, err := goannotationsource.Capture(rootDir)
+	if err != nil {
+		return exportPlan{}, fmt.Errorf("capture Go annotation sources: %w", err)
+	}
+	cleanupPlan, err := goannotationcleanup.NewPlan(snapshot)
 	if err != nil {
 		return exportPlan{}, fmt.Errorf("plan Go annotation cleanup: %w", err)
 	}
-	if alias, err := cleanupPlan.SourceAlias(outputPath); err != nil {
+	if alias, err := snapshot.SourceAlias(outputPath); err != nil {
 		return exportPlan{}, err
 	} else if alias != "" {
 		return exportPlan{}, fmt.Errorf("%w: output %s refers to %s", ErrOutputAliasesSource, outputPath, alias)
+	}
+	if strings.HasSuffix(outputPath, ".go") {
+		return exportPlan{}, fmt.Errorf("%w: %s", ErrOutputIsGoSource, outputPath)
 	}
 
 	cleanupResults := cleanupPlan.Results()
@@ -130,18 +157,19 @@ func prepareExport(opts Options) (exportPlan, error) {
 
 	return exportPlan{
 		options:        opts,
-		rootDir:        rootDir,
 		outputPath:     outputPath,
+		snapshot:       snapshot,
 		cleanup:        cleanupPlan,
 		cleanupResults: cleanupResults,
 	}, nil
 }
 
 func renderExport(plan exportPlan) (renderedExport, error) {
-	db, err := goschema.ParseDir(plan.rootDir)
+	db, err := goschema.ParseFS(plan.snapshot.FS(), ".")
 	if err != nil {
 		return renderedExport{}, fmt.Errorf("parse Go annotations: %w", err)
 	}
+	bindSnapshotManagedDataSourceRoot(db.ManagedData, plan.snapshot.Root())
 	if alias, err := managedDataSourceAlias(db.ManagedData, plan.outputPath); err != nil {
 		return renderedExport{}, err
 	} else if alias != "" {
@@ -173,6 +201,46 @@ func renderExport(plan exportPlan) (renderedExport, error) {
 		hcl:         canonicalHCL,
 		diagnostics: diagnostics,
 	}, nil
+}
+
+func bindSnapshotManagedDataSourceRoot(values []goschema.ManagedData, root string) {
+	for i := range values {
+		if filepath.IsAbs(values[i].SourceDir) {
+			continue
+		}
+		values[i].SourceDir = filepath.Clean(
+			filepath.Join(root, filepath.FromSlash(values[i].SourceDir)),
+		)
+	}
+}
+
+func (p exportPlan) validatePublication(managedData []goschema.ManagedData) error {
+	if err := p.snapshot.Revalidate(); err != nil {
+		return fmt.Errorf("revalidate Go annotation sources before HCL publication: %w", err)
+	}
+	alias, err := p.snapshot.SourceAlias(p.outputPath)
+	if err != nil {
+		return err
+	}
+	if alias != "" {
+		return fmt.Errorf(
+			"%w: output %s refers to %s",
+			ErrOutputAliasesSource,
+			p.outputPath,
+			alias,
+		)
+	}
+	if alias, err := managedDataSourceAlias(managedData, p.outputPath); err != nil {
+		return err
+	} else if alias != "" {
+		return fmt.Errorf(
+			"%w: output %s refers to %s",
+			ErrOutputAliasesManagedData,
+			p.outputPath,
+			alias,
+		)
+	}
+	return nil
 }
 
 func managedDataSourceAlias(values []goschema.ManagedData, outputPath string) (string, error) {
@@ -320,39 +388,69 @@ func hasRolePasswords(roles []goschema.Role) bool {
 	})
 }
 
-func writeOutput(path string, data []byte, mode os.FileMode) error {
+func stageOutput(path string, data []byte, mode os.FileMode) (stagedOutput, error) {
 	parent := filepath.Dir(path)
 	if err := os.MkdirAll(parent, 0o755); err != nil {
-		return fmt.Errorf("create HCL output directory: %w", err)
+		return stagedOutput{}, fmt.Errorf("create HCL output directory: %w", err)
 	}
 
 	file, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("create temporary HCL output: %w", err)
+		return stagedOutput{}, fmt.Errorf("create temporary HCL output: %w", err)
 	}
 	tempPath := file.Name()
-	defer func() {
-		_ = os.Remove(tempPath)
-	}()
+	staged := stagedOutput{outputPath: path, tempPath: tempPath}
 
 	if err := file.Chmod(mode); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("set temporary HCL output mode: %w", err)
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("set temporary HCL output mode: %w", err),
+			staged.cleanup(),
+		)
 	}
 	if _, err := file.Write(data); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("write temporary HCL output: %w", err)
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("write temporary HCL output: %w", err),
+			staged.cleanup(),
+		)
 	}
 	if err := file.Sync(); err != nil {
 		_ = file.Close()
-		return fmt.Errorf("sync temporary HCL output: %w", err)
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("sync temporary HCL output: %w", err),
+			staged.cleanup(),
+		)
 	}
 	if err := file.Close(); err != nil {
-		return fmt.Errorf("close temporary HCL output: %w", err)
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("close temporary HCL output: %w", err),
+			staged.cleanup(),
+		)
 	}
-	if err := os.Rename(tempPath, path); err != nil {
+	return staged, nil
+}
+
+func (s *stagedOutput) commit() error {
+	if err := os.Rename(s.tempPath, s.outputPath); err != nil {
 		return fmt.Errorf("commit HCL output: %w", err)
 	}
+	s.tempPath = ""
+	return nil
+}
+
+func (s *stagedOutput) cleanup() error {
+	if s.tempPath == "" {
+		return nil
+	}
+	err := os.Remove(s.tempPath)
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	if err != nil {
+		return fmt.Errorf("remove temporary HCL output: %w", err)
+	}
+	s.tempPath = ""
 	return nil
 }
 

--- a/internal/goannotationexport/export_internal_test.go
+++ b/internal/goannotationexport/export_internal_test.go
@@ -39,8 +39,10 @@ func TestExport_FailurePath_RevalidatesSourcesAfterOutputStaging(t *testing.T) {
 		{
 			name: "identity replacement",
 			mutate: func(c *qt.C, _ string, source string, original []byte) {
+				replacement := source + ".replacement"
+				c.Assert(os.WriteFile(replacement, original, 0o600), qt.IsNil)
 				c.Assert(os.Remove(source), qt.IsNil)
-				c.Assert(os.WriteFile(source, original, 0o600), qt.IsNil)
+				c.Assert(os.Rename(replacement, source), qt.IsNil)
 			},
 			wantSource: []byte(
 				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",

--- a/internal/goannotationexport/export_internal_test.go
+++ b/internal/goannotationexport/export_internal_test.go
@@ -1,0 +1,109 @@
+package goannotationexport
+
+// White-box testing required: this file injects source mutations after HCL
+// staging but before the unexported publication barrier, a timing boundary that
+// public APIs cannot exercise deterministically without filesystem polling.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
+)
+
+func TestExport_FailurePath_RevalidatesSourcesAfterOutputStaging(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name           string
+		mutate         func(c *qt.C, root, source string, original []byte)
+		wantSource     []byte
+		wantEntryNames []string
+	}{
+		{
+			name: "same-size edit",
+			mutate: func(c *qt.C, _ string, source string, _ []byte) {
+				c.Assert(os.WriteFile(
+					source,
+					[]byte("package models\n\n//ptah:schema:table name=\"roles\"\ntype User struct{}\n"),
+					0o600,
+				), qt.IsNil)
+			},
+			wantSource: []byte(
+				"package models\n\n//ptah:schema:table name=\"roles\"\ntype User struct{}\n",
+			),
+			wantEntryNames: []string{"model.go", "schema.hcl"},
+		},
+		{
+			name: "identity replacement",
+			mutate: func(c *qt.C, _ string, source string, original []byte) {
+				c.Assert(os.Remove(source), qt.IsNil)
+				c.Assert(os.WriteFile(source, original, 0o600), qt.IsNil)
+			},
+			wantSource: []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			),
+			wantEntryNames: []string{"model.go", "schema.hcl"},
+		},
+		{
+			name: "source addition",
+			mutate: func(c *qt.C, root, _ string, _ []byte) {
+				c.Assert(os.WriteFile(
+					filepath.Join(root, "added.go"),
+					[]byte("package models\n"),
+					0o600,
+				), qt.IsNil)
+			},
+			wantSource: []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			),
+			wantEntryNames: []string{"added.go", "model.go", "schema.hcl"},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			original := []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			)
+			previousOutput := []byte("previous schema\n")
+			c.Assert(os.WriteFile(source, original, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(output, previousOutput, 0o600), qt.IsNil)
+
+			result, err := export(Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			}, func() {
+				test.mutate(c, root, source, original)
+			})
+
+			c.Assert(err, qt.ErrorIs, goannotationsource.ErrChanged)
+			c.Assert(result, qt.DeepEquals, Result{})
+			assertExportInternalFileBytes(c, source, test.wantSource)
+			assertExportInternalFileBytes(c, output, previousOutput)
+			entries, err := os.ReadDir(root)
+			c.Assert(err, qt.IsNil)
+			c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, test.wantEntryNames)
+		})
+	}
+}
+
+func assertExportInternalFileBytes(c *qt.C, path string, want []byte) {
+	c.Helper()
+	got, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, want)
+}
+
+func exportInternalEntryNames(entries []os.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}

--- a/internal/goannotationexport/export_symlink_unix_internal_test.go
+++ b/internal/goannotationexport/export_symlink_unix_internal_test.go
@@ -1,0 +1,58 @@
+//go:build unix
+
+package goannotationexport
+
+// White-box testing required: this file changes output identity after HCL
+// staging to verify the unexported managed-data alias publication barrier
+// without timing-dependent filesystem polling.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestExport_FailurePath_RevalidatesManagedDataAliasAfterOutputStaging(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "model.go")
+	dataPath := filepath.Join(root, "countries.yaml")
+	output := filepath.Join(root, "schema.hcl")
+	sourceData := []byte(`package models
+
+//ptah:schema:table name="countries"
+//ptah:schema:data table="countries" key="code" file="countries.yaml"
+type Country struct {
+	//ptah:schema:field name="code" type="TEXT" primary="true"
+	Code string
+}
+`)
+	data := []byte("- code: CZ\n")
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(dataPath, data, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, []byte("previous schema\n"), 0o600), qt.IsNil)
+
+	result, err := export(Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	}, func() {
+		c.Assert(os.Remove(output), qt.IsNil)
+		c.Assert(os.Link(dataPath, output), qt.IsNil)
+	})
+
+	c.Assert(err, qt.ErrorIs, ErrOutputAliasesManagedData)
+	c.Assert(result, qt.DeepEquals, Result{})
+	assertExportInternalFileBytes(c, source, sourceData)
+	assertExportInternalFileBytes(c, dataPath, data)
+	assertExportInternalFileBytes(c, output, data)
+	entries, err := os.ReadDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, []string{
+		"countries.yaml",
+		"model.go",
+		"schema.hcl",
+	})
+}

--- a/internal/goannotationexport/export_test.go
+++ b/internal/goannotationexport/export_test.go
@@ -50,6 +50,50 @@ func TestExport_HappyPath_WritesValidatedHCLAndCleansAnnotations(t *testing.T) {
 	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
 }
 
+func TestExport_HappyPath_UsesOneSourcePolicyForParsingAndCleanup(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	included := filepath.Join(root, "myvendor", "included.go")
+	hidden := filepath.Join(root, ".hidden", "hidden.go")
+	vendored := filepath.Join(root, "vendor", "vendored.go")
+	testSource := filepath.Join(root, "model_test.go")
+	c.Assert(os.MkdirAll(filepath.Dir(included), 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(hidden), 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(filepath.Dir(vendored), 0o755), qt.IsNil)
+	includedData := []byte("package myvendor\n\n//ptah:schema:table name=\"included\"\ntype Included struct{}\n")
+	hiddenData := []byte("package hidden\n\n//ptah:schema:table name=\"hidden\"\ntype Hidden struct{}\n")
+	vendoredData := []byte("package vendor\n\n//ptah:schema:table name=\"vendored\"\ntype Vendored struct{}\n")
+	testData := []byte("package models_test\n\n//ptah:schema:table name=\"test_table\"\ntype TestModel struct{}\n")
+	c.Assert(os.WriteFile(included, includedData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(hidden, hiddenData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(vendored, vendoredData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(testSource, testData, 0o600), qt.IsNil)
+	output := filepath.Join(root, "schema.hcl")
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Tables, qt.Equals, 1)
+	c.Assert(result.Cleanup, qt.HasLen, 1)
+	resolvedIncluded, err := filepath.EvalSymlinks(included)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Cleanup[0].Path, qt.Equals, resolvedIncluded)
+	assertFileBytes(c, included, []byte("package myvendor\n\ntype Included struct{}\n"))
+	assertFileBytes(c, hidden, hiddenData)
+	assertFileBytes(c, vendored, vendoredData)
+	assertFileBytes(c, testSource, testData)
+	outputData, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(outputData), qt.Contains, `table "included"`)
+	c.Assert(string(outputData), qt.Not(qt.Contains), `table "hidden"`)
+	c.Assert(string(outputData), qt.Not(qt.Contains), `table "vendored"`)
+	c.Assert(string(outputData), qt.Not(qt.Contains), `table "test_table"`)
+}
+
 func TestExport_HappyPath_TightensPermissionsForRolePasswords(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()
@@ -339,6 +383,27 @@ func TestExport_FailurePath_OutputCannotAliasGoSource(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, goannotationexport.ErrOutputAliasesSource)
 	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
 	assertFileBytes(c, source, sourceData)
+}
+
+func TestExport_FailurePath_OutputCannotUseExcludedGoPath(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSimpleModel(c, root)
+	sourceData, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	output := filepath.Join(root, ".hidden", "schema.go")
+
+	result, err := goannotationexport.Export(goannotationexport.Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	})
+
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrOutputIsGoSource)
+	c.Assert(result, qt.DeepEquals, goannotationexport.Result{})
+	assertFileBytes(c, source, sourceData)
+	_, err = os.Stat(output)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func TestExport_FailurePath_OutputCannotAliasManagedData(t *testing.T) {

--- a/internal/goannotationsource/snapshot.go
+++ b/internal/goannotationsource/snapshot.go
@@ -244,7 +244,7 @@ func captureOpenedRoot(root *pathguard.OpenedDirectory) (*Snapshot, error) {
 	slices.SortFunc(files, func(a, b File) int {
 		return strings.Compare(a.RelativePath, b.RelativePath)
 	})
-	filesystem, err := fsnapshot.FromFiles(contents)
+	filesystem, err := fsnapshot.TakeFiles(contents)
 	if err != nil {
 		return nil, fmt.Errorf("build Go annotation source filesystem: %w", err)
 	}

--- a/internal/goannotationsource/snapshot.go
+++ b/internal/goannotationsource/snapshot.go
@@ -1,0 +1,287 @@
+// Package goannotationsource captures the Go files that define one annotation
+// parsing and cleanup operation.
+package goannotationsource
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/fsnapshot"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+var (
+	// ErrChanged reports that the selected Go source set, file identity, mode,
+	// or contents no longer match a captured snapshot.
+	ErrChanged = errors.New("Go annotation sources changed after snapshot")
+)
+
+// File is one regular, non-test Go source selected for annotation processing.
+// Contents returns from Snapshot.Files are independent copies.
+type File struct {
+	Path         string
+	RelativePath string
+	Contents     []byte
+	info         fs.FileInfo
+}
+
+// Mode returns the captured source mode.
+func (f File) Mode() fs.FileMode {
+	return f.info.Mode()
+}
+
+// SameFile reports whether info identifies the captured filesystem object.
+func (f File) SameFile(info fs.FileInfo) bool {
+	return os.SameFile(f.info, info)
+}
+
+// Snapshot is an immutable source-set view backed by a read-only in-memory
+// filesystem and the host metadata needed for safe publication and cleanup.
+type Snapshot struct {
+	root       string
+	rootInfo   fs.FileInfo
+	files      []File
+	filesystem fsnapshot.Snapshot
+}
+
+// Capture selects and reads every Go file eligible for annotation processing
+// under root, including files that currently contain no annotations.
+func Capture(root string) (*Snapshot, error) {
+	if root == "" {
+		root = "."
+	}
+	openedRoot, err := pathguard.OpenDirectory(root)
+	if err != nil {
+		return nil, fmt.Errorf("open Go annotation source root: %w", err)
+	}
+	snapshot, captureErr := captureOpenedRoot(openedRoot)
+	closeErr := openedRoot.Close()
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close Go annotation source root: %w", closeErr)
+	}
+	if err := errors.Join(captureErr, closeErr); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
+// IsSource reports whether path belongs to the Go annotation source set.
+func IsSource(path string) bool {
+	return strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go")
+}
+
+// SkipDirectory reports whether a directory is outside the Go annotation
+// source set.
+func SkipDirectory(name string) bool {
+	return name == "vendor" || strings.HasPrefix(name, ".")
+}
+
+// Root returns the absolute source root captured by the snapshot.
+func (s *Snapshot) Root() string {
+	return s.root
+}
+
+// FS returns an independent immutable filesystem view.
+func (s *Snapshot) FS() fs.FS {
+	return s.filesystem.Clone()
+}
+
+// Files returns the selected files in stable relative-path order.
+func (s *Snapshot) Files() []File {
+	files := make([]File, len(s.files))
+	for i, file := range s.files {
+		files[i] = file
+		files[i].Contents = slices.Clone(file.Contents)
+	}
+	return files
+}
+
+// SourceAlias returns the captured source aliased by path, or an empty string
+// when path does not refer to a selected source.
+func (s *Snapshot) SourceAlias(path string) (string, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve potential Go source alias %s: %w", path, err)
+	}
+	absolutePath = filepath.Clean(absolutePath)
+	for _, file := range s.files {
+		if absolutePath == file.Path {
+			return file.Path, nil
+		}
+	}
+
+	info, err := os.Stat(absolutePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("stat potential Go source alias %s: %w", absolutePath, err)
+	}
+	for _, file := range s.files {
+		if file.SameFile(info) {
+			return file.Path, nil
+		}
+	}
+	return "", nil
+}
+
+// Revalidate verifies that source membership, identity, mode, and contents
+// still match the captured snapshot.
+func (s *Snapshot) Revalidate() error {
+	current, err := Capture(s.root)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrChanged, err)
+	}
+	if !os.SameFile(s.rootInfo, current.rootInfo) {
+		return fmt.Errorf("%w: source root identity changed: %s", ErrChanged, s.root)
+	}
+	if s.rootInfo.Mode() != current.rootInfo.Mode() {
+		return fmt.Errorf("%w: source root mode changed: %s", ErrChanged, s.root)
+	}
+	if len(current.files) != len(s.files) {
+		return fmt.Errorf(
+			"%w: source count changed from %d to %d",
+			ErrChanged,
+			len(s.files),
+			len(current.files),
+		)
+	}
+	for i, expected := range s.files {
+		actual := current.files[i]
+		if actual.RelativePath != expected.RelativePath {
+			return fmt.Errorf(
+				"%w: source path %q changed to %q",
+				ErrChanged,
+				expected.RelativePath,
+				actual.RelativePath,
+			)
+		}
+		if !expected.SameFile(actual.info) {
+			return fmt.Errorf(
+				"%w: source identity changed: %s",
+				ErrChanged,
+				expected.Path,
+			)
+		}
+		if actual.Mode() != expected.Mode() {
+			return fmt.Errorf(
+				"%w: source mode changed: %s",
+				ErrChanged,
+				expected.Path,
+			)
+		}
+		if !bytes.Equal(actual.Contents, expected.Contents) {
+			return fmt.Errorf(
+				"%w: source contents changed: %s",
+				ErrChanged,
+				expected.Path,
+			)
+		}
+	}
+	return nil
+}
+
+func captureOpenedRoot(root *pathguard.OpenedDirectory) (*Snapshot, error) {
+	rootInfo, err := root.Stat(".")
+	if err != nil {
+		return nil, fmt.Errorf("stat Go annotation source root: %w", err)
+	}
+	if !rootInfo.IsDir() {
+		return nil, fmt.Errorf("Go annotation source root is not a directory: %s", root.Path())
+	}
+
+	files := make([]File, 0)
+	contents := make(map[string][]byte)
+	fsys := root.FS()
+	err = fs.WalkDir(fsys, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != "." && SkipDirectory(entry.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !IsSource(path) {
+			return nil
+		}
+
+		if entry.Type()&fs.ModeSymlink != 0 {
+			return fmt.Errorf("refuse to capture symlinked Go source %s", path)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat Go source %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refuse to capture non-regular Go source %s", path)
+		}
+		info, data, err := captureFile(fsys, path, info)
+		if err != nil {
+			return err
+		}
+		relativePath := filepath.ToSlash(path)
+		files = append(files, File{
+			Path:         filepath.Join(root.Path(), filepath.FromSlash(relativePath)),
+			RelativePath: relativePath,
+			Contents:     data,
+			info:         info,
+		})
+		contents[relativePath] = data
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("capture Go annotation sources: %w", err)
+	}
+	slices.SortFunc(files, func(a, b File) int {
+		return strings.Compare(a.RelativePath, b.RelativePath)
+	})
+	filesystem, err := fsnapshot.FromFiles(contents)
+	if err != nil {
+		return nil, fmt.Errorf("build Go annotation source filesystem: %w", err)
+	}
+	return &Snapshot{
+		root:       root.Path(),
+		rootInfo:   rootInfo,
+		files:      files,
+		filesystem: filesystem,
+	}, nil
+}
+
+func captureFile(fsys fs.FS, path string, info fs.FileInfo) (fs.FileInfo, []byte, error) {
+	file, err := fsys.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open Go source %s: %w", path, err)
+	}
+	defer file.Close()
+
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat opened Go source %s: %w", path, err)
+	}
+	if !os.SameFile(info, openedInfo) || !openedInfo.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("%w: source identity changed: %s", ErrChanged, path)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read Go source %s: %w", path, err)
+	}
+	finalInfo, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("restat opened Go source %s: %w", path, err)
+	}
+	if !os.SameFile(openedInfo, finalInfo) ||
+		openedInfo.Mode() != finalInfo.Mode() ||
+		finalInfo.Size() != int64(len(data)) {
+		return nil, nil, fmt.Errorf("%w: source changed while reading: %s", ErrChanged, path)
+	}
+	return finalInfo, data, nil
+}

--- a/internal/goannotationsource/snapshot_symlink_unix_test.go
+++ b/internal/goannotationsource/snapshot_symlink_unix_test.go
@@ -1,0 +1,93 @@
+//go:build unix
+
+package goannotationsource_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"golang.org/x/sys/unix"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
+)
+
+func TestCapture_FailurePath_RejectsSelectedSourceSymlink(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	target := writeSource(c, t.TempDir(), "outside.go", "package outside\n")
+	link := filepath.Join(root, "model.go")
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+
+	snapshot, err := goannotationsource.Capture(root)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "refuse to capture symlinked Go source")
+	c.Assert(snapshot, qt.IsNil)
+}
+
+func TestCapture_FailurePath_RejectsSelectedHiddenFilenameSymlink(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	target := writeSource(c, t.TempDir(), "outside.go", "package outside\n")
+	link := filepath.Join(root, ".model.go")
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+
+	snapshot, err := goannotationsource.Capture(root)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "refuse to capture symlinked Go source")
+	c.Assert(snapshot, qt.IsNil)
+}
+
+func TestCapture_FailurePath_RejectsSelectedNamedPipe(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "events.go")
+	c.Assert(unix.Mkfifo(path, 0o600), qt.IsNil)
+
+	snapshot, err := goannotationsource.Capture(root)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "refuse to capture non-regular Go source")
+	c.Assert(snapshot, qt.IsNil)
+}
+
+func TestCapture_HappyPath_AnchorsSymlinkedRoot(t *testing.T) {
+	c := qt.New(t)
+	target := t.TempDir()
+	writeSource(c, target, "models.go", "package models\n")
+	root := filepath.Join(t.TempDir(), "models")
+	c.Assert(os.Symlink(target, root), qt.IsNil)
+
+	snapshot, err := goannotationsource.Capture(root)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(snapshot.Root(), qt.Equals, root)
+	c.Assert(sourcePaths(snapshot.Files()), qt.DeepEquals, []string{"models.go"})
+	c.Assert(os.Remove(root), qt.IsNil)
+	c.Assert(os.Symlink(t.TempDir(), root), qt.IsNil)
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotSourceAlias_HappyPath_ReportsSymlinkAndHardLink(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := writeSource(c, root, "model.go", "package models\n")
+	aliases := t.TempDir()
+	symlinkAlias := filepath.Join(aliases, "schema-symlink.hcl")
+	hardLinkAlias := filepath.Join(aliases, "schema-hardlink.hcl")
+	c.Assert(os.Symlink(source, symlinkAlias), qt.IsNil)
+	c.Assert(os.Link(source, hardLinkAlias), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	alias, err := snapshot.SourceAlias(symlinkAlias)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, source)
+
+	alias, err = snapshot.SourceAlias(hardLinkAlias)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, source)
+}

--- a/internal/goannotationsource/snapshot_test.go
+++ b/internal/goannotationsource/snapshot_test.go
@@ -1,0 +1,226 @@
+package goannotationsource_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
+)
+
+func TestCapture_HappyPath_UsesStableSharedSourcePolicy(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+	writeSource(c, root, ".generated.go", "package models\n")
+	writeSource(c, root, "models_test.go", "package models_test\n")
+	writeSource(c, root, "myvendor/models.go", "package myvendor\n")
+	writeSource(c, root, "vendor/models.go", "package vendor\n")
+	writeSource(c, root, ".hidden/models.go", "package hidden\n")
+
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourcePaths(snapshot.Files()), qt.DeepEquals, []string{
+		".generated.go",
+		"models.go",
+		"myvendor/models.go",
+	})
+	c.Assert(fstest.TestFS(
+		snapshot.FS(),
+		".generated.go",
+		"models.go",
+		"myvendor/models.go",
+	), qt.IsNil)
+
+	writeSource(c, root, "models.go", "package changed\n")
+	data, err := fs.ReadFile(snapshot.FS(), "models.go")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, "package models\n")
+}
+
+func TestCapture_HappyPath_ReturnsIndependentFileBytes(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	files := snapshot.Files()
+	files[0].Contents[0] = 'X'
+
+	data, err := fs.ReadFile(snapshot.FS(), "models.go")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, "package models\n")
+}
+
+func TestSnapshotRevalidate_HappyPath_AcceptsUnchangedSources(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(snapshot.Revalidate(), qt.IsNil)
+}
+
+func TestSnapshotRevalidate_HappyPath_IgnoresExcludedChanges(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	writeSource(c, root, "models_test.go", "package models_test\n")
+	writeSource(c, root, ".hidden/model.go", "package hidden\n")
+	writeSource(c, root, "vendor/model.go", "package vendor\n")
+	writeSource(c, root, "notes.txt", "not Go source\n")
+
+	c.Assert(snapshot.Revalidate(), qt.IsNil)
+}
+
+func TestCapture_HappyPath_TraversesHiddenSelectedRoot(t *testing.T) {
+	c := qt.New(t)
+	root := filepath.Join(t.TempDir(), ".models")
+	writeSource(c, root, "models.go", "package models\n")
+
+	snapshot, err := goannotationsource.Capture(root)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sourcePaths(snapshot.Files()), qt.DeepEquals, []string{"models.go"})
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsChangedContents(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	writeSource(c, root, "models.go", "package modals\n")
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsAddedSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	writeSource(c, root, "added.go", "package models\n")
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsRemovedSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.Remove(path), qt.IsNil)
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsRenamedSource(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.Rename(path, filepath.Join(root, "renamed.go")), qt.IsNil)
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsReplacedIdentity(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+	replacement := writeSource(c, root, "replacement.tmp", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.Remove(path), qt.IsNil)
+	c.Assert(os.Rename(replacement, path), qt.IsNil)
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsChangedMode(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+	c.Assert(os.Chmod(path, 0o600), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.Chmod(path, 0o400), qt.IsNil)
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotRevalidate_FailurePath_RejectsReplacedEmptyRoot(t *testing.T) {
+	c := qt.New(t)
+	parent := t.TempDir()
+	root := filepath.Join(parent, "models")
+	c.Assert(os.Mkdir(root, 0o755), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(os.Rename(root, filepath.Join(parent, "old-models")), qt.IsNil)
+	c.Assert(os.Mkdir(root, 0o755), qt.IsNil)
+
+	c.Assert(snapshot.Revalidate(), qt.ErrorIs, goannotationsource.ErrChanged)
+}
+
+func TestSnapshotSourceAlias_HappyPath_ReportsExactSourceAndMissingPath(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+
+	alias, err := snapshot.SourceAlias(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, path)
+
+	alias, err = snapshot.SourceAlias(filepath.Join(root, "schema.hcl"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(alias, qt.Equals, "")
+}
+
+func TestCapture_FailurePath_RejectsNonDirectoryRoot(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	path := writeSource(c, root, "models.go", "package models\n")
+
+	snapshot, err := goannotationsource.Capture(path)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "not a directory")
+	c.Assert(snapshot, qt.IsNil)
+}
+
+func sourcePaths(files []goannotationsource.File) []string {
+	paths := make([]string, len(files))
+	for i, file := range files {
+		paths[i] = file.RelativePath
+	}
+	return paths
+}
+
+func writeSource(c *qt.C, root, name, data string) string {
+	c.Helper()
+	path := filepath.Join(root, name)
+	c.Assert(os.MkdirAll(filepath.Dir(path), 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(data), 0o600), qt.IsNil)
+	return path
+}


### PR DESCRIPTION
Closes #899.

## Summary

- capture the complete selected Go annotation source set once and share its immutable filesystem view between parsing and cleanup planning
- define one exact source-selection policy: regular lowercase `*.go`, excluding `*_test.go`, descendant hidden directories, and directories named exactly `vendor`
- anchor source capture to an opened directory and reject selected symlinks and non-regular files
- revalidate source membership, identity, mode, and contents immediately before HCL publication and again before cleanup commit
- reject `.go` output destinations and recheck source and managed-data aliases after output staging
- transfer the captured byte map into the indexed immutable snapshot added by merged PR #910
- document the source policy and the publication/cleanup concurrency contract

## Verification

- `go test -race -count=1 ./...`
- `go test -race -count=1 ./internal/fsnapshot ./internal/goannotationsource ./internal/goannotationcleanup ./internal/goannotationexport ./core/goschema`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- Windows cross-compilation for all affected packages
- docs site checks, version self-test, production build, and `npm audit`
- `git diff --check`

## Self-review

Two independent review passes covered source-set consistency, parser/cleanup drift, output and cleanup commit barriers, symlink and non-regular inputs, alias replacement after staging, platform compilation, documentation, and test-style compliance. The in-scope findings were fixed and regression-tested. The branch was then rebased onto merged prerequisite PR #910 and the combined snapshot/parser/export/cleanup race and lint gates were rerun.

## Dependencies and follow-ups

Prerequisite [PR #910](https://github.com/stokaro/ptah/pull/910) (closes #908) is merged. This branch now consumes its indexed immutable snapshot and ownership-transfer API. Rooted mutation, durable publication, rollback, and the remaining validation-to-rename ancestor race are intentionally tracked by #900 and are not claimed as solved here.

Documentation impact: the canonical Go annotation page changed; `README.md` and the site content inventory were reviewed and need no update because command paths and page topology did not change.