### PR TITLE
perf(fs): index immutable snapshot directories

### DIFF
--- a/internal/fsnapshot/snapshot.go
+++ b/internal/fsnapshot/snapshot.go
@@ -17,7 +17,8 @@ import (
 // Snapshot is an immutable in-memory filesystem. Its read methods return
 // independent values, and Clone returns an independent filesystem view.
 type Snapshot struct {
-	files map[string][]byte
+	files       map[string][]byte
+	directories map[string][]fs.DirEntry
 }
 
 // FromFiles returns an immutable snapshot containing files. Every path must be
@@ -26,11 +27,11 @@ func FromFiles(files map[string][]byte) (Snapshot, error) {
 	if err := validateFilePaths(files); err != nil {
 		return Snapshot{}, err
 	}
-	snapshot := Snapshot{files: make(map[string][]byte, len(files))}
+	cloned := make(map[string][]byte, len(files))
 	for name, contents := range files {
-		snapshot.files[name] = slices.Clone(contents)
+		cloned[name] = slices.Clone(contents)
 	}
-	return snapshot, nil
+	return snapshotFromValidatedFiles(cloned), nil
 }
 
 // TakeFiles returns an immutable snapshot by taking exclusive ownership of
@@ -40,7 +41,7 @@ func TakeFiles(files map[string][]byte) (Snapshot, error) {
 	if err := validateFilePaths(files); err != nil {
 		return Snapshot{}, err
 	}
-	return Snapshot{files: files}, nil
+	return snapshotFromValidatedFiles(files), nil
 }
 
 func validateFilePaths(files map[string][]byte) error {
@@ -80,7 +81,7 @@ func CaptureMatching(
 	if snapshot, ok := fsys.(Snapshot); ok {
 		return snapshot.matching(include), nil
 	}
-	snapshot := Snapshot{files: map[string][]byte{}}
+	files := map[string][]byte{}
 	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -92,18 +93,24 @@ func CaptureMatching(
 		if err != nil {
 			return fmt.Errorf("read snapshot file %s: %w", name, err)
 		}
-		snapshot.files[name] = slices.Clone(contents)
+		files[name] = slices.Clone(contents)
 		return nil
 	})
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("capture filesystem snapshot: %w", err)
 	}
-	return snapshot, nil
+	if err := validateFilePaths(files); err != nil {
+		return Snapshot{}, fmt.Errorf("capture filesystem snapshot: %w", err)
+	}
+	return snapshotFromValidatedFiles(files), nil
 }
 
 // Clone returns an independent view of the same captured files.
 func (s Snapshot) Clone() Snapshot {
-	cloned := Snapshot{files: make(map[string][]byte, len(s.files))}
+	cloned := Snapshot{
+		files:       make(map[string][]byte, len(s.files)),
+		directories: s.directories,
+	}
 	maps.Copy(cloned.files, s.files)
 	return cloned
 }
@@ -125,19 +132,19 @@ func (s Snapshot) WithFiles(files map[string][]byte) (Snapshot, error) {
 	if err := validateFilePaths(combined); err != nil {
 		return Snapshot{}, err
 	}
-	return Snapshot{files: combined}, nil
+	return snapshotFromValidatedFiles(combined), nil
 }
 
 func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Snapshot {
-	filtered := Snapshot{files: make(map[string][]byte, len(s.files))}
+	filtered := make(map[string][]byte, len(s.files))
 	for _, name := range slices.Sorted(maps.Keys(s.files)) {
 		contents := s.files[name]
 		entry := snapshotFileInfo{name: path.Base(name), size: int64(len(contents))}
 		if include(name, entry) {
-			filtered.files[name] = contents
+			filtered[name] = contents
 		}
 	}
-	return filtered
+	return snapshotFromValidatedFiles(filtered)
 }
 
 // Open implements fs.FS.
@@ -151,8 +158,8 @@ func (s Snapshot) Open(name string) (fs.File, error) {
 			info:   snapshotFileInfo{name: path.Base(name), size: int64(len(contents))},
 		}, nil
 	}
-	entries := s.directoryEntries(name)
-	if len(entries) == 0 && name != "." {
+	entries, ok := s.lookupDirectory(name)
+	if !ok {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 	}
 	return &snapshotDirectory{
@@ -178,11 +185,11 @@ func (s Snapshot) ReadDir(name string) ([]fs.DirEntry, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
 	}
-	entries := s.directoryEntries(name)
-	if len(entries) == 0 && name != "." {
+	entries, ok := s.lookupDirectory(name)
+	if !ok {
 		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrNotExist}
 	}
-	return entries, nil
+	return slices.Clone(entries), nil
 }
 
 // Stat implements fs.StatFS.
@@ -193,38 +200,78 @@ func (s Snapshot) Stat(name string) (fs.FileInfo, error) {
 	if contents, ok := s.files[name]; ok {
 		return snapshotFileInfo{name: path.Base(name), size: int64(len(contents))}, nil
 	}
-	if entries := s.directoryEntries(name); len(entries) > 0 || name == "." {
+	if s.hasDirectory(name) {
 		return snapshotFileInfo{name: path.Base(name), directory: true}, nil
 	}
 	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
 }
 
-func (s Snapshot) directoryEntries(name string) []fs.DirEntry {
-	prefix := ""
-	if name != "." {
-		prefix = name + "/"
+func snapshotFromValidatedFiles(files map[string][]byte) Snapshot {
+	return Snapshot{
+		files:       files,
+		directories: buildDirectoryIndex(files),
 	}
-	seen := make(map[string]snapshotFileInfo)
-	for filename, contents := range s.files {
-		relative, ok := strings.CutPrefix(filename, prefix)
-		if !ok || relative == "" {
-			continue
+}
+
+func buildDirectoryIndex(files map[string][]byte) map[string][]fs.DirEntry {
+	infos := map[string]map[string]snapshotFileInfo{
+		".": {},
+	}
+	for filename, contents := range files {
+		parent := path.Dir(filename)
+		addDirectoryInfo(infos, parent, snapshotFileInfo{
+			name: path.Base(filename),
+			size: int64(len(contents)),
+		})
+		for directory := parent; directory != "."; directory = path.Dir(directory) {
+			addDirectoryInfo(infos, path.Dir(directory), snapshotFileInfo{
+				name:      path.Base(directory),
+				directory: true,
+			})
 		}
-		entryName, remainder, _ := strings.Cut(relative, "/")
-		info := snapshotFileInfo{name: entryName, directory: remainder != ""}
-		if !info.directory {
-			info.size = int64(len(contents))
+	}
+
+	index := make(map[string][]fs.DirEntry, len(infos))
+	for directory, directoryInfos := range infos {
+		entries := make([]fs.DirEntry, 0, len(directoryInfos))
+		for _, info := range directoryInfos {
+			entries = append(entries, info)
 		}
-		seen[entryName] = info
+		slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+			return strings.Compare(a.Name(), b.Name())
+		})
+		index[directory] = entries
 	}
-	entries := make([]fs.DirEntry, 0, len(seen))
-	for _, info := range seen {
-		entries = append(entries, info)
+	return index
+}
+
+func addDirectoryInfo(
+	directories map[string]map[string]snapshotFileInfo,
+	directory string,
+	info snapshotFileInfo,
+) {
+	entries, ok := directories[directory]
+	if !ok {
+		entries = make(map[string]snapshotFileInfo)
+		directories[directory] = entries
 	}
-	slices.SortFunc(entries, func(a, b fs.DirEntry) int {
-		return strings.Compare(a.Name(), b.Name())
-	})
-	return entries
+	entries[info.name] = info
+}
+
+func (s Snapshot) lookupDirectory(name string) ([]fs.DirEntry, bool) {
+	entries, ok := s.directories[name]
+	if name == "." {
+		return entries, true
+	}
+	return entries, ok
+}
+
+func (s Snapshot) hasDirectory(name string) bool {
+	if name == "." {
+		return true
+	}
+	_, ok := s.directories[name]
+	return ok
 }
 
 type snapshotFile struct {

--- a/internal/fsnapshot/snapshot_internal_test.go
+++ b/internal/fsnapshot/snapshot_internal_test.go
@@ -1,0 +1,20 @@
+package fsnapshot
+
+// White-box testing required: ownership transfer cannot be observed through
+// the immutable public API without mutating data the caller promised to
+// relinquish. This test verifies that TakeFiles retains the owned bytes.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestTakeFiles_RetainsOwnedBytes(t *testing.T) {
+	c := qt.New(t)
+	contents := []byte("SELECT 1;\n")
+
+	snapshot, err := TakeFiles(map[string][]byte{"migration.sql": contents})
+	c.Assert(err, qt.IsNil)
+	c.Assert(&snapshot.files["migration.sql"][0], qt.Equals, &contents[0])
+}

--- a/internal/fsnapshot/snapshot_test.go
+++ b/internal/fsnapshot/snapshot_test.go
@@ -1,7 +1,9 @@
 package fsnapshot_test
 
 import (
+	"fmt"
 	"io/fs"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -100,6 +102,102 @@ func TestSnapshotWithFilesReturnsIndependentOverlay(t *testing.T) {
 	contents, err := fs.ReadFile(overlay, "2_next.sql")
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "SELECT 2;")
+	c.Assert(fstest.TestFS(overlay, "1_initial.sql", "2_next.sql"), qt.IsNil)
+}
+
+func TestSnapshotDirectoryIndexPreservesFSSemantics(t *testing.T) {
+	c := qt.New(t)
+	files := map[string][]byte{
+		"alpha/a.go":          []byte("package alpha"),
+		"alpha/nested/b.go":   []byte("package nested"),
+		"bravo/c.go":          []byte("package bravo"),
+		"charlie/nested/d.go": []byte("package nested"),
+		"root.go":             []byte("package root"),
+	}
+	paths := []string{
+		"alpha/a.go",
+		"alpha/nested/b.go",
+		"bravo/c.go",
+		"charlie/nested/d.go",
+		"root.go",
+	}
+
+	snapshot, err := fsnapshot.FromFiles(files)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fstest.TestFS(snapshot, paths...), qt.IsNil)
+
+	rootEntries, err := fs.ReadDir(snapshot, ".")
+	c.Assert(err, qt.IsNil)
+	c.Assert(directoryEntryNames(rootEntries), qt.DeepEquals, []string{
+		"alpha",
+		"bravo",
+		"charlie",
+		"root.go",
+	})
+	rootEntries[0] = nil
+	freshRootEntries, err := fs.ReadDir(snapshot, ".")
+	c.Assert(err, qt.IsNil)
+	c.Assert(directoryEntryNames(freshRootEntries), qt.DeepEquals, []string{
+		"alpha",
+		"bravo",
+		"charlie",
+		"root.go",
+	})
+
+	cloned := snapshot.Clone()
+	c.Assert(fstest.TestFS(cloned, paths...), qt.IsNil)
+}
+
+func TestCaptureMatchingBuildsIndependentDirectoryIndex(t *testing.T) {
+	c := qt.New(t)
+	source := fstest.MapFS{
+		"alpha/a.go":        {Data: []byte("package alpha")},
+		"alpha/ignored.txt": {Data: []byte("ignored")},
+		"bravo/b.go":        {Data: []byte("package bravo")},
+	}
+
+	captured, err := fsnapshot.CaptureMatching(
+		source,
+		func(name string, _ fs.DirEntry) bool {
+			return strings.HasSuffix(name, ".go")
+		},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fstest.TestFS(captured, "alpha/a.go", "bravo/b.go"), qt.IsNil)
+
+	filtered, err := fsnapshot.CaptureMatching(
+		captured,
+		func(name string, _ fs.DirEntry) bool {
+			return strings.HasPrefix(name, "alpha/")
+		},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(fstest.TestFS(filtered, "alpha/a.go"), qt.IsNil)
+
+	rootEntries, err := fs.ReadDir(filtered, ".")
+	c.Assert(err, qt.IsNil)
+	c.Assert(directoryEntryNames(rootEntries), qt.DeepEquals, []string{"alpha"})
+}
+
+func TestSnapshotZeroValueAndCloneImplementEmptyFS(t *testing.T) {
+	c := qt.New(t)
+	snapshot := fsnapshot.Snapshot{}
+	tests := []struct {
+		name string
+		fsys fs.FS
+	}{
+		{name: "zero value", fsys: snapshot},
+		{name: "cloned zero value", fsys: snapshot.Clone()},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(fstest.TestFS(test.fsys), qt.IsNil)
+			entries, err := fs.ReadDir(test.fsys, ".")
+			c.Assert(err, qt.IsNil)
+			c.Assert(entries, qt.HasLen, 0)
+		})
+	}
 }
 
 func TestFromFiles_ClonesInput(t *testing.T) {
@@ -149,7 +247,7 @@ func TestFromFiles_RejectsFileDirectoryConflict(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `invalid snapshot file paths "schema" and "schema/main.sql": a file cannot contain another file`)
 }
 
-func TestTakeFiles_DoesNotCloneOwnedContents(t *testing.T) {
+func TestTakeFiles_ProducesValidSnapshotFromOwnedContents(t *testing.T) {
 	c := qt.New(t)
 	files := map[string][]byte{
 		"migration.sql": []byte("SELECT 1;\n"),
@@ -158,12 +256,66 @@ func TestTakeFiles_DoesNotCloneOwnedContents(t *testing.T) {
 	snapshot, err := fsnapshot.TakeFiles(files)
 	c.Assert(err, qt.IsNil)
 	c.Assert(fstest.TestFS(snapshot, "migration.sql"), qt.IsNil)
+}
 
-	allocations := testing.AllocsPerRun(100, func() {
-		snapshot, _ = fsnapshot.TakeFiles(files)
-	})
-	c.Assert(allocations, qt.Equals, float64(0))
-	c.Assert(fstest.TestFS(snapshot, "migration.sql"), qt.IsNil)
+func BenchmarkSnapshotWalkDirectories(b *testing.B) {
+	tests := []struct {
+		name         string
+		packageCount int
+		filesPerDir  int
+	}{
+		{name: "50_packages", packageCount: 50, filesPerDir: 8},
+		{name: "500_packages", packageCount: 500, filesPerDir: 8},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			c := qt.New(b)
+			snapshot, err := fsnapshot.TakeFiles(
+				benchmarkPackageFiles(test.packageCount, test.filesPerDir),
+			)
+			c.Assert(err, qt.IsNil)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				benchmarkWalkErr = fs.WalkDir(
+					snapshot,
+					".",
+					func(_ string, _ fs.DirEntry, err error) error {
+						return err
+					},
+				)
+			}
+			b.StopTimer()
+			c.Assert(benchmarkWalkErr, qt.IsNil)
+		})
+	}
+}
+
+var benchmarkWalkErr error
+
+func directoryEntryNames(entries []fs.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}
+
+func benchmarkPackageFiles(packageCount, filesPerDir int) map[string][]byte {
+	files := make(map[string][]byte, packageCount*filesPerDir)
+	for packageIndex := range packageCount {
+		for fileIndex := range filesPerDir {
+			name := fmt.Sprintf(
+				"package%04d/file%04d.go",
+				packageIndex,
+				fileIndex,
+			)
+			files[name] = []byte("package benchmark\n")
+		}
+	}
+	return files
 }
 
 type countingFS struct {


### PR DESCRIPTION
Closes #908.
Prerequisite for #899 and draft PR #909.

## Summary

- build a stable lexical directory index once for every immutable `fsnapshot.Snapshot`
- make directory `Open`, `ReadDir`, and `Stat` use indexed lookups instead of scanning every captured file
- preserve immutable reads, zero-value filesystem behavior, filtered snapshots, overlays, and clone semantics
- share the internal immutable index across clones and directory handles while cloning only values returned through public read APIs
- retain ownership-transfer behavior in `TakeFiles` without cloning caller-owned file bytes

## Performance

`BenchmarkSnapshotWalkDirectories` walks snapshots containing eight files per package and reports allocations:

```text
50 packages:   25,817 ns/op    19,360 B/op    604 allocs/op
500 packages: 261,105 ns/op   192,258 B/op  6,004 allocs/op
```

A 10x directory/file increase produces approximately 10x time and allocations. The benchmark preserves the old implementation comparison point, where each visited directory rescanned the complete file map.

## Verification

- `go test -race -count=1 ./...`
- race tests for `fsnapshot` and all direct consumers
- `go test -run ^'$' -bench BenchmarkSnapshotWalkDirectories -benchmem ./internal/fsnapshot`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `gopls check` for every changed Go file
- Windows amd64 test cross-compilation
- `git diff --check`

## Self-review

Two independent review passes covered filesystem semantics, immutability, aliasing, zero-value behavior, constructor coverage, races, complexity, allocations, benchmark validity, test style, Go idioms, and Windows portability. The correctness pass found no issues. The performance pass found two redundant copies: directory `Open` copied the index before the handle copied returned entries, and `Clone` copied the immutable index. Both copies were removed and all gates were rerun.

## Documentation

No public behavior, command, configuration, artifact, or reader workflow changes. `internal/fsnapshot` preserves its existing API and filesystem semantics, so no reader-facing documentation or content inventory update is required.